### PR TITLE
Track and log blog agent LLM request counts

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -155,6 +155,8 @@ def research_and_review(request: ResearchAndReviewRequest) -> ResearchAndReviewR
         logger.exception("Failed to initialize agents")
         raise HTTPException(status_code=500, detail=f"Agent initialization failed: {e}") from e
 
+    llm_requests_before = _llm_client.request_count if _llm_client is not None else 0
+
     # Build brief text (include title concept if provided)
     brief_text = request.brief.strip()
     if request.title_concept:
@@ -186,6 +188,12 @@ def research_and_review(request: ResearchAndReviewRequest) -> ResearchAndReviewR
     except Exception as e:
         logger.exception("Review agent failed")
         raise HTTPException(status_code=500, detail=f"Review failed: {e}") from e
+
+    llm_requests_after = _llm_client.request_count if _llm_client is not None else llm_requests_before
+    logger.info(
+        "Completed research-and-review pipeline with %s LLM requests",
+        llm_requests_after - llm_requests_before,
+    )
 
     return ResearchAndReviewResponse(
         title_choices=[

--- a/blogging/agent_implementations/blog_writing_process.py
+++ b/blogging/agent_implementations/blog_writing_process.py
@@ -116,6 +116,7 @@ for iteration in range(1, DRAFT_EDITOR_ITERATIONS + 1):
         logger.info("Draft iteration %s: revised, length=%s", iteration, len(draft_result.draft))
 
 logger.info("DRAFT DOCUMENT: \n ---------------------------------------- \n %s", draft_result.draft[:2000] + ("..." if len(draft_result.draft) > 2000 else ""))
+logger.info("Total LLM requests across blog agents: %s", llm_client.request_count)
 
 # 4. Output
 print("\n--- Top 10 title choices (with probability of success) ---")

--- a/blogging/api/main.py
+++ b/blogging/api/main.py
@@ -155,6 +155,8 @@ def research_and_review(request: ResearchAndReviewRequest) -> ResearchAndReviewR
         logger.exception("Failed to initialize agents")
         raise HTTPException(status_code=500, detail=f"Agent initialization failed: {e}") from e
 
+    llm_requests_before = _llm_client.request_count if _llm_client is not None else 0
+
     # Build brief text (include title concept if provided)
     brief_text = request.brief.strip()
     if request.title_concept:
@@ -186,6 +188,12 @@ def research_and_review(request: ResearchAndReviewRequest) -> ResearchAndReviewR
     except Exception as e:
         logger.exception("Review agent failed")
         raise HTTPException(status_code=500, detail=f"Review failed: {e}") from e
+
+    llm_requests_after = _llm_client.request_count if _llm_client is not None else llm_requests_before
+    logger.info(
+        "Completed research-and-review pipeline with %s LLM requests",
+        llm_requests_after - llm_requests_before,
+    )
 
     return ResearchAndReviewResponse(
         title_choices=[

--- a/blogging/blog_research_agent/llm.py
+++ b/blogging/blog_research_agent/llm.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 import json
 import re
+from threading import Lock
 from typing import Any, Dict
 
 import httpx
@@ -15,6 +16,19 @@ class LLMClient(ABC):
     The concrete implementation should adapt your Strands runtime's
     LLM interface to this method.
     """
+
+    def __init__(self) -> None:
+        self._request_count = 0
+        self._request_count_lock = Lock()
+
+    @property
+    def request_count(self) -> int:
+        """Total number of LLM requests made through this client instance."""
+        return self._request_count
+
+    def _increment_request_count(self) -> None:
+        with self._request_count_lock:
+            self._request_count += 1
 
     @abstractmethod
     def complete_json(self, prompt: str, *, temperature: float = 0.0) -> Dict[str, Any]:
@@ -42,11 +56,16 @@ class DummyLLMClient(LLMClient):
     This is NOT meant for production use but is handy to keep the agent runnable.
     """
 
+    def __init__(self) -> None:
+        super().__init__()
+
     def complete_json(self, prompt: str, *, temperature: float = 0.0) -> Dict[str, Any]:
         """
         Preconditions: prompt non-empty; 0.0 <= temperature <= 2.0.
         Postconditions: Returns dict; never None. Heuristic outputs for testing only.
         """
+        self._increment_request_count()
+
         # This is intentionally simplistic and only for demonstration/testing.
         lowered = prompt.lower()
         if "core_topics" in lowered and "angle" in lowered and "constraints" in lowered:
@@ -173,6 +192,8 @@ class OllamaLLMClient(LLMClient):
             - timeout > 0.
             - base_url is a non-empty string.
         """
+        super().__init__()
+
         assert model, "model name is required"
         assert timeout > 0, "timeout must be positive"
         assert base_url, "base_url is required"
@@ -240,6 +261,8 @@ class OllamaLLMClient(LLMClient):
         Preconditions: prompt non-empty; 0.0 <= temperature <= 2.0.
         Postconditions: Returns dict; never None. Raises on API or parse failure.
         """
+        self._increment_request_count()
+
         system_message = (
             "You are a strict JSON generator used by an automated research agent. "
             "You MUST respond with a single valid JSON object only, with no "

--- a/blogging/tests/test_llm_request_count.py
+++ b/blogging/tests/test_llm_request_count.py
@@ -1,0 +1,15 @@
+"""Tests for LLM request counting in blog agents."""
+
+from blog_research_agent.llm import DummyLLMClient
+
+
+def test_dummy_llm_tracks_request_count() -> None:
+    llm = DummyLLMClient()
+
+    assert llm.request_count == 0
+
+    llm.complete_json('{"core_topics": true, "angle": true, "constraints": true}')
+    llm.complete_json('{"queries": [], "query_text": "x"}')
+    llm.complete_json('{"summary": "", "key_points": []}')
+
+    assert llm.request_count == 3


### PR DESCRIPTION
### Motivation
- Add observability for LLM usage in the blog research/review/draft workflow by counting and logging LLM requests. 
- Keep the PR focused by removing an unrelated README wording change.

### Description
- Add a thread-safe `request_count` counter to `LLMClient` with `_increment_request_count()` and a `request_count` property, and initialize it in implementations. 
- Increment the counter in `DummyLLMClient.complete_json()` and `OllamaLLMClient.complete_json()` so every API call is tracked. 
- Log per-run LLM request totals in the `research-and-review` API endpoints (`api/main.py` and `blogging/api/main.py`) by capturing the counter before/after the run and logging the delta. 
- Log total LLM requests at the end of the interactive blog writing flow in `blogging/agent_implementations/blog_writing_process.py`. 
- Add unit test `blogging/tests/test_llm_request_count.py` to validate the dummy client increments the counter, and revert an unrelated `software_engineering_team/README.md` edit so the PR scope is limited to LLM tracking changes.

### Testing
- Ran the new unit test with `PYTHONPATH=blogging pytest -q blogging/tests/test_llm_request_count.py`, which passed (`1 passed`).
- No other automated tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990144d7fe0832e98bc09d51b094594)