### PR TITLE
Refactor Deepthought atomic node persistence to follow SOLID principles

### DIFF
--- a/api/main.py
+++ b/api/main.py
@@ -5,7 +5,12 @@ FastAPI application exposing the research-and-review pipeline as an HTTP endpoin
 from __future__ import annotations
 
 import logging
-from typing import List, Optional, Union
+import os
+import base64
+import binascii
+import io
+import uuid
+from typing import Any, List, Optional, Union
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
@@ -99,6 +104,21 @@ class ResearchAndReviewResponse(BaseModel):
     )
 
 
+class DeepthoughtImageProcessRequest(BaseModel):
+    """Request body for processing an image into atomic feature nodes."""
+
+    image_base64: str = Field(..., description="Base64-encoded image bytes.")
+    image_id: Optional[str] = Field(None, description="Optional external image identifier.")
+
+
+class DeepthoughtImageProcessResponse(BaseModel):
+    """Response body for image processing."""
+
+    success: bool
+    image_node_id: Optional[str] = None
+    errors: List[str] = Field(default_factory=list)
+
+
 def _format_audience(audience: Optional[Union[AudienceDetails, str]]) -> str:
     """Convert audience input to a string for the agents."""
     if audience is None:
@@ -115,6 +135,285 @@ def _format_audience(audience: Optional[Union[AudienceDetails, str]]) -> str:
     if audience.other:
         parts.append(audience.other)
     return "; ".join(parts) if parts else ""
+
+
+def _decode_image(image_base64: str) -> bytes:
+    """Decode a base64 image string into raw bytes."""
+    try:
+        return base64.b64decode(image_base64, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise ValueError("image_base64 is not valid base64 data") from exc
+
+
+
+
+def _require_image_processing_dependencies() -> tuple[Any, Any]:
+    """Load image processing dependencies."""
+    try:
+        import numpy as np
+        from PIL import Image
+    except Exception as exc:  # pragma: no cover - runtime dependency guard
+        raise RuntimeError(
+            "Image processing dependencies are missing. Install numpy and pillow."
+        ) from exc
+    return np, Image
+
+
+def _load_rgb_matrix(image_bytes: bytes, np: Any, Image: Any) -> Any:
+    """Load and normalize image bytes into an RGB numpy matrix."""
+    with Image.open(io.BytesIO(image_bytes)) as img:
+        rgb_img = img.convert("RGB")
+        return np.array(rgb_img, dtype=np.uint8)
+
+
+def _compute_edge_detection_rgb(rgb_matrix: Any, np: Any) -> tuple[Any, Any]:
+    """Compute Sobel edge magnitude and its RGB representation."""
+    gray = (
+        0.299 * rgb_matrix[:, :, 0]
+        + 0.587 * rgb_matrix[:, :, 1]
+        + 0.114 * rgb_matrix[:, :, 2]
+    ).astype(np.float32)
+    padded = np.pad(gray, ((1, 1), (1, 1)), mode="edge")
+    gx = (
+        padded[:-2, 2:]
+        + 2 * padded[1:-1, 2:]
+        + padded[2:, 2:]
+        - padded[:-2, :-2]
+        - 2 * padded[1:-1, :-2]
+        - padded[2:, :-2]
+    )
+    gy = (
+        padded[2:, :-2]
+        + 2 * padded[2:, 1:-1]
+        + padded[2:, 2:]
+        - padded[:-2, :-2]
+        - 2 * padded[:-2, 1:-1]
+        - padded[:-2, 2:]
+    )
+    edge = np.clip(np.sqrt(gx**2 + gy**2), 0, 255).astype(np.uint8)
+    edge_rgb = np.stack([edge, edge, edge], axis=-1)
+    return edge, edge_rgb
+
+
+def _compute_pca_reduction_rgb(rgb_matrix: Any, np: Any) -> Any:
+    """Reduce color channels via PCA and reconstruct RGB matrix."""
+    flat = rgb_matrix.reshape(-1, 3).astype(np.float32)
+    mean = flat.mean(axis=0)
+    centered = flat - mean
+    cov = np.cov(centered, rowvar=False)
+    eigvals, eigvecs = np.linalg.eigh(cov)
+    principal = eigvecs[:, np.argsort(eigvals)[::-1][:2]]
+    reduced = centered @ principal
+    reconstructed = (reduced @ principal.T) + mean
+    return np.clip(reconstructed, 0, 255).astype(np.uint8).reshape(rgb_matrix.shape)
+
+def _detect_object_crops(rgb_matrix: Any, edge_matrix: Any) -> list[dict[str, Any]]:
+    """Detect object-like connected components and return cropped RGB matrices."""
+    import numpy as np
+
+    threshold = max(20.0, float(edge_matrix.mean()) * 1.25)
+    mask = edge_matrix > threshold
+
+    visited = np.zeros(mask.shape, dtype=bool)
+    height, width = mask.shape
+    min_area = max(16, (height * width) // 400)
+    crops: list[dict[str, Any]] = []
+
+    for y in range(height):
+        for x in range(width):
+            if not mask[y, x] or visited[y, x]:
+                continue
+
+            stack = [(y, x)]
+            visited[y, x] = True
+            min_y = max_y = y
+            min_x = max_x = x
+            area = 0
+
+            while stack:
+                cy, cx = stack.pop()
+                area += 1
+                min_y = min(min_y, cy)
+                max_y = max(max_y, cy)
+                min_x = min(min_x, cx)
+                max_x = max(max_x, cx)
+
+                for ny, nx in ((cy - 1, cx), (cy + 1, cx), (cy, cx - 1), (cy, cx + 1)):
+                    if 0 <= ny < height and 0 <= nx < width and mask[ny, nx] and not visited[ny, nx]:
+                        visited[ny, nx] = True
+                        stack.append((ny, nx))
+
+            if area < min_area:
+                continue
+
+            # add 1px padding where possible
+            y0 = max(min_y - 1, 0)
+            y1 = min(max_y + 2, height)
+            x0 = max(min_x - 1, 0)
+            x1 = min(max_x + 2, width)
+
+            crop_rgb = rgb_matrix[y0:y1, x0:x1]
+            crops.append(
+                {
+                    "transformation": "object_crop_detection",
+                    "rgb_matrix": crop_rgb.tolist(),
+                    "bbox": {"x": int(x0), "y": int(y0), "width": int(x1 - x0), "height": int(y1 - y0)},
+                }
+            )
+
+    return crops
+
+
+def _build_atomic_matrices(image_bytes: bytes) -> dict:
+    """Build RGB matrices for original image and required atomic transformations."""
+    np, Image = _require_image_processing_dependencies()
+    rgb_matrix = _load_rgb_matrix(image_bytes, np, Image)
+    edge, edge_rgb = _compute_edge_detection_rgb(rgb_matrix, np)
+    pca_rgb = _compute_pca_reduction_rgb(rgb_matrix, np)
+    object_crops = _detect_object_crops(rgb_matrix, edge)
+
+    return {
+        "width": int(rgb_matrix.shape[1]),
+        "height": int(rgb_matrix.shape[0]),
+        "original": rgb_matrix.tolist(),
+        "edge_detection": edge_rgb.tolist(),
+        "pca_color_reduction": pca_rgb.tolist(),
+        "object_crops": object_crops,
+    }
+
+
+
+
+def _require_neo4j_driver() -> Any:
+    """Load Neo4j driver dependency."""
+    try:
+        from neo4j import GraphDatabase
+    except Exception as exc:  # pragma: no cover - runtime dependency guard
+        raise RuntimeError("Neo4j dependency is missing. Install neo4j driver.") from exc
+    return GraphDatabase
+
+
+def _get_neo4j_connection_settings() -> tuple[str, str, str]:
+    """Return validated Neo4j connection settings from environment."""
+    uri = os.getenv("NEO4J_URI")
+    user = os.getenv("NEO4J_USER")
+    password = os.getenv("NEO4J_PASSWORD")
+    if not uri or not user or not password:
+        raise RuntimeError("NEO4J_URI, NEO4J_USER, and NEO4J_PASSWORD must be configured")
+    return uri, user, password
+
+
+def _build_atomic_feature_nodes(
+    edge_matrix: list,
+    pca_matrix: list,
+    object_crops: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Build atomic feature node payloads for graph persistence."""
+    atomic_nodes = [
+        {
+            "id": str(uuid.uuid4()),
+            "transformation": "edge_detection_filter",
+            "rgb_matrix": edge_matrix,
+            "bbox": None,
+        },
+        {
+            "id": str(uuid.uuid4()),
+            "transformation": "pca_color_space_reduction",
+            "rgb_matrix": pca_matrix,
+            "bbox": None,
+        },
+    ]
+
+    for crop in object_crops:
+        atomic_nodes.append(
+            {
+                "id": str(uuid.uuid4()),
+                "transformation": crop["transformation"],
+                "rgb_matrix": crop["rgb_matrix"],
+                "bbox": crop["bbox"],
+            }
+        )
+
+    return atomic_nodes
+
+
+def _write_atomic_nodes_to_neo4j(
+    *,
+    GraphDatabase: Any,
+    uri: str,
+    user: str,
+    password: str,
+    parent_id: str,
+    original_b64: str,
+    width: int,
+    height: int,
+    original_matrix: list,
+    atomic_nodes: list[dict[str, Any]],
+) -> None:
+    """Write image and atomic feature nodes to Neo4j."""
+    driver = GraphDatabase.driver(uri, auth=(user, password))
+    try:
+        with driver.session() as session:
+            session.run(
+                """
+                CREATE (img:Image {
+                    id: $parent_id,
+                    content_base64: $original_b64,
+                    width: $width,
+                    height: $height,
+                    rgb_matrix: $original_matrix
+                })
+                WITH img
+                UNWIND $atomic_nodes AS atomic
+                CREATE (feature:AtomicImageFeature {
+                    id: atomic.id,
+                    transformation: atomic.transformation,
+                    rgb_matrix: atomic.rgb_matrix,
+                    bbox: atomic.bbox
+                })
+                CREATE (feature)-[:PART_OF]->(img)
+                """,
+                parent_id=parent_id,
+                original_b64=original_b64,
+                width=width,
+                height=height,
+                original_matrix=original_matrix,
+                atomic_nodes=atomic_nodes,
+            )
+    finally:
+        driver.close()
+
+def _persist_atomic_nodes(
+    *,
+    original_b64: str,
+    image_id: Optional[str],
+    width: int,
+    height: int,
+    original_matrix: list,
+    edge_matrix: list,
+    pca_matrix: list,
+    object_crops: list[dict[str, Any]],
+) -> str:
+    """Persist original image and atomic feature nodes to Neo4j."""
+    GraphDatabase = _require_neo4j_driver()
+    uri, user, password = _get_neo4j_connection_settings()
+    parent_id = image_id or str(uuid.uuid4())
+    atomic_nodes = _build_atomic_feature_nodes(edge_matrix, pca_matrix, object_crops)
+
+    _write_atomic_nodes_to_neo4j(
+        GraphDatabase=GraphDatabase,
+        uri=uri,
+        user=user,
+        password=password,
+        parent_id=parent_id,
+        original_b64=original_b64,
+        width=width,
+        height=height,
+        original_matrix=original_matrix,
+        atomic_nodes=atomic_nodes,
+    )
+
+    return parent_id
 
 
 # Shared LLM client and agents (initialized on first request or at startup)
@@ -205,3 +504,48 @@ def research_and_review(request: ResearchAndReviewRequest) -> ResearchAndReviewR
 def health() -> dict:
     """Health check endpoint."""
     return {"status": "ok"}
+
+
+@app.post(
+    "/deepthought/images/process",
+    response_model=DeepthoughtImageProcessResponse,
+    summary="Process image into atomic feature nodes",
+    description=(
+        "Decodes an input image, generates atomic RGB matrices for edge detection, "
+        "PCA color-space reduction, and object-crop detection, stores the original image node "
+        "and atomic nodes in Neo4j, and links atomic nodes to the original image via "
+        "PART_OF relationships."
+    ),
+)
+def process_image(request: DeepthoughtImageProcessRequest) -> DeepthoughtImageProcessResponse:
+    """Process an image and persist atomic feature nodes in Neo4j."""
+    errors: list[str] = []
+
+    try:
+        image_bytes = _decode_image(request.image_base64)
+    except Exception as exc:
+        errors.append(str(exc))
+        return DeepthoughtImageProcessResponse(success=False, errors=errors)
+
+    try:
+        matrices = _build_atomic_matrices(image_bytes)
+    except Exception as exc:
+        errors.append(str(exc))
+        return DeepthoughtImageProcessResponse(success=False, errors=errors)
+
+    try:
+        image_node_id = _persist_atomic_nodes(
+            original_b64=request.image_base64,
+            image_id=request.image_id,
+            width=matrices["width"],
+            height=matrices["height"],
+            original_matrix=matrices["original"],
+            edge_matrix=matrices["edge_detection"],
+            pca_matrix=matrices["pca_color_reduction"],
+            object_crops=matrices["object_crops"],
+        )
+    except Exception as exc:
+        errors.append(str(exc))
+        return DeepthoughtImageProcessResponse(success=False, errors=errors)
+
+    return DeepthoughtImageProcessResponse(success=True, image_node_id=image_node_id, errors=[])

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ httpx>=0.27,<0.28
 beautifulsoup4>=4.12,<5.0
 fastapi>=0.115,<1.0
 uvicorn[standard]>=0.32,<1.0
+numpy>=1.26,<3.0
+pillow>=10.0,<12.0
+neo4j>=5.24,<6.0

--- a/tests/test_deepthought_api.py
+++ b/tests/test_deepthought_api.py
@@ -1,0 +1,135 @@
+import pytest
+import base64
+import importlib.util
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT / "blogging"))
+
+spec = importlib.util.spec_from_file_location("root_api_main", ROOT / "api" / "main.py")
+api_main = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+sys.modules["root_api_main"] = api_main
+spec.loader.exec_module(api_main)
+api_main.DeepthoughtImageProcessRequest.model_rebuild()
+
+
+def test_decode_image_rejects_invalid_base64() -> None:
+    try:
+        api_main._decode_image("***not-valid***")
+        assert False, "Expected ValueError"
+    except ValueError as exc:
+        assert "not valid base64" in str(exc)
+
+
+def test_process_image_success_path(monkeypatch) -> None:
+    def fake_build_atomic_matrices(_: bytes) -> dict:
+        return {
+            "width": 1,
+            "height": 1,
+            "original": [[[1, 2, 3]]],
+            "edge_detection": [[[4, 5, 6]]],
+            "pca_color_reduction": [[[7, 8, 9]]],
+            "object_crops": [
+                {
+                    "transformation": "object_crop_detection",
+                    "rgb_matrix": [[[11, 12, 13]]],
+                    "bbox": {"x": 0, "y": 0, "width": 1, "height": 1},
+                }
+            ],
+        }
+
+    def fake_persist_atomic_nodes(**kwargs) -> str:
+        assert kwargs["width"] == 1
+        assert kwargs["height"] == 1
+        assert len(kwargs["object_crops"]) == 1
+        assert kwargs["object_crops"][0]["transformation"] == "object_crop_detection"
+        return "img-123"
+
+    monkeypatch.setattr(api_main, "_build_atomic_matrices", fake_build_atomic_matrices)
+    monkeypatch.setattr(api_main, "_persist_atomic_nodes", fake_persist_atomic_nodes)
+
+    request = api_main.DeepthoughtImageProcessRequest(
+        image_base64=base64.b64encode(b"dummy-bytes").decode("utf-8")
+    )
+    response = api_main.process_image(request)
+
+    assert response.success is True
+    assert response.image_node_id == "img-123"
+    assert response.errors == []
+
+
+def test_detect_object_crops_finds_component() -> None:
+    np = pytest.importorskip("numpy")
+
+    rgb = np.zeros((8, 8, 3), dtype=np.uint8)
+    rgb[2:5, 2:5] = [255, 255, 255]
+
+    edge = np.zeros((8, 8), dtype=np.uint8)
+    edge[2:5, 2:5] = 200
+
+    crops = api_main._detect_object_crops(rgb, edge)
+
+    assert len(crops) >= 1
+    first = crops[0]
+    assert first["transformation"] == "object_crop_detection"
+    assert first["bbox"]["width"] >= 3
+    assert first["bbox"]["height"] >= 3
+
+
+def test_build_atomic_matrices_orchestrates_steps(monkeypatch) -> None:
+    class FakeArray:
+        shape = (2, 3, 3)
+
+        def tolist(self):
+            return [[[1, 2, 3]]]
+
+    fake_rgb = FakeArray()
+    fake_edge_rgb = FakeArray()
+    fake_pca = FakeArray()
+
+    monkeypatch.setattr(api_main, "_require_image_processing_dependencies", lambda: ("np", "Image"))
+    monkeypatch.setattr(api_main, "_load_rgb_matrix", lambda image_bytes, np, Image: fake_rgb)
+    monkeypatch.setattr(api_main, "_compute_edge_detection_rgb", lambda rgb_matrix, np: ("edge", fake_edge_rgb))
+    monkeypatch.setattr(api_main, "_compute_pca_reduction_rgb", lambda rgb_matrix, np: fake_pca)
+    monkeypatch.setattr(
+        api_main,
+        "_detect_object_crops",
+        lambda rgb_matrix, edge: [{"transformation": "object_crop_detection", "rgb_matrix": [[[9, 9, 9]]], "bbox": {"x": 0, "y": 0, "width": 1, "height": 1}}],
+    )
+
+    result = api_main._build_atomic_matrices(b"img-bytes")
+
+    assert result["width"] == 3
+    assert result["height"] == 2
+    assert result["object_crops"][0]["transformation"] == "object_crop_detection"
+
+
+def test_persist_atomic_nodes_orchestrates_helpers(monkeypatch) -> None:
+    monkeypatch.setattr(api_main, "_require_neo4j_driver", lambda: "GraphDatabase")
+    monkeypatch.setattr(api_main, "_get_neo4j_connection_settings", lambda: ("bolt://localhost", "neo4j", "password"))
+    monkeypatch.setattr(api_main, "_build_atomic_feature_nodes", lambda edge, pca, crops: [{"id": "atomic-1"}])
+
+    captured = {}
+
+    def fake_write_atomic_nodes_to_neo4j(**kwargs) -> None:
+        captured.update(kwargs)
+
+    monkeypatch.setattr(api_main, "_write_atomic_nodes_to_neo4j", fake_write_atomic_nodes_to_neo4j)
+
+    result = api_main._persist_atomic_nodes(
+        original_b64="base64",
+        image_id="img-1",
+        width=10,
+        height=5,
+        original_matrix=[[[1, 2, 3]]],
+        edge_matrix=[[[4, 5, 6]]],
+        pca_matrix=[[[7, 8, 9]]],
+        object_crops=[],
+    )
+
+    assert result == "img-1"
+    assert captured["GraphDatabase"] == "GraphDatabase"
+    assert captured["uri"] == "bolt://localhost"
+    assert captured["atomic_nodes"] == [{"id": "atomic-1"}]


### PR DESCRIPTION
### Motivation
- Separate concerns in the Neo4j persistence path to make the image->graph write flow easier to reason about, extend, and test.
- Reduce the responsibility of `_persist_atomic_nodes` so dependency loading, configuration, payload construction, and DB execution are isolated.

### Description
- Extracted Neo4j dependency loading into `_require_neo4j_driver()` and environment validation into `_get_neo4j_connection_settings()` in `api/main.py` to isolate runtime concerns.
- Introduced `_build_atomic_feature_nodes()` to construct atomic node payloads (edge, PCA, and object-crop features) and `_write_atomic_nodes_to_neo4j()` to encapsulate the database write logic.
- Converted `_persist_atomic_nodes()` into a thin orchestrator that composes the new helpers and returns the same parent image ID contract.
- Added an orchestration unit test `test_persist_atomic_nodes_orchestrates_helpers` in `tests/test_deepthought_api.py` that monkeypatches the helpers and asserts the delegation and arguments passed to the writer.

### Testing
- Ran `python -m py_compile api/main.py` which succeeded.
- Ran `pytest -q tests/test_deepthought_api.py` which succeeded with `4 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990bbbab430832eb6b3d8f32c58bb8b)