### PR TITLE
Add IPS-first multi-asset investment_team scaffold

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This repository provides **multiple Strands-style agent systems** in a monorepo:
 - **Software engineering team** – Full dev team simulation from spec: architecture, Tech Lead, backend/frontend workers, DevOps, security, QA, code review, accessibility, and more. Reads `initial_spec.md` from a git repo and produces working code.
 - **Social media marketing team** – Campaign planning with collaboration agents, human approval gate, and platform specialists (LinkedIn, Facebook, Instagram, X). Produces execution-ready content plans.
 - **SOC2 compliance team** – Multi-agent SOC2 audit for a code repository: Security, Availability, Processing Integrity, Confidentiality, and Privacy TSC agents review the repo and produce a compliance report or a next-steps-for-certification document.
+- **Investment team** – Multi-asset investment organization with IPS hard constraints, strategy validation, promotion gates (`reject/revise/paper/live`), separation-of-duties, risk veto, and monitor-only safety degradation.
 
 ## Project structure
 
@@ -16,6 +17,7 @@ strands-agents/
 ├── software_engineering_team/   # Full software dev team simulation
 ├── social_media_marketing_team/ # Campaign planning with platform specialists
 ├── soc2_compliance_team/        # SOC2 compliance audit and certification team
+├── investment_team/              # Multi-asset investment organization (IPS-first)
 └── requirements.txt        # Shared dependencies
 ```
 
@@ -25,6 +27,7 @@ strands-agents/
 | [software_engineering_team/](software_engineering_team/README.md) | Multi-agent dev team: architecture, Tech Lead, backend/frontend, DevOps, security, QA, code review, accessibility, documentation. |
 | [social_media_marketing_team/](social_media_marketing_team/README.md) | Cross-platform campaign planning with human approval, collaboration agents, and LinkedIn/Facebook/Instagram/X specialists. |
 | [soc2_compliance_team/](soc2_compliance_team/README.md) | SOC2 compliance audit: Security, Availability, Processing Integrity, Confidentiality, Privacy TSC agents; produces compliance report or next-steps document. |
+| [investment_team/](investment_team/README.md) | Multi-asset investment organization with IPS constraints, validation/promotion gates, and safety-first orchestration. |
 
 ```mermaid
 flowchart LR

--- a/investment_team/README.md
+++ b/investment_team/README.md
@@ -1,0 +1,64 @@
+# Investment Team
+
+A multi-agent investment organization covering equities, bonds/Treasuries, options, real estate, FX, crypto, and optional commodities with IPS-first constraints.
+
+## What this package implements
+
+- **Core data model** for portfolio, strategy, validation, promotion, execution, and private-deal workflows.
+- **Agent roles** with separation-of-duties and risk-veto mechanics.
+- **Universal promotion checklist** that decides `reject | revise | paper | live`.
+- **Orchestration state machine** with queueing, escalation, and safe degradation to `monitor_only` when data integrity fails.
+
+## Agent roles and interfaces
+
+- **PolicyGuardianAgent**
+  - Input: `IPS`, `PortfolioProposal`
+  - Output: list of IPS violations
+  - Invariant: IPS caps and exclusions are hard constraints.
+
+- **ValidationAgent**
+  - Input: `ValidationReport`
+  - Output: missing/failed checklist items
+  - Invariant: required checks include backtest quality, walk-forward, stress, costs, and liquidity impact.
+
+- **PromotionGateAgent**
+  - Input: `StrategySpec`, `ValidationReport`, `IPS`, proposer/approver identities, risk veto flag
+  - Output: `PromotionDecision`
+  - Invariants:
+    - proposer cannot self-approve,
+    - risk veto always rejects,
+    - missing validation forces revise,
+    - live promotion requires explicit IPS live enablement.
+
+- **InvestmentCommitteeAgent**
+  - Input: recommendation context and dissenting views
+  - Output: `InvestmentCommitteeMemo`
+
+## Universal promotion checklist
+
+The gate runs these checks in order:
+1. Separation of duties (reject on violation)
+2. Risk veto (reject)
+3. Required validation completeness and pass criteria (revise if incomplete/failing)
+4. IPS live-trading permission (paper if not enabled)
+5. Promote to live only if all gates pass
+
+## Orchestration and safety
+
+`InvestmentTeamOrchestrator` manages queues:
+- `research`
+- `portfolio_design`
+- `validation`
+- `promotion`
+- `execution`
+- `escalation`
+
+Safety defaults:
+- Default workflow mode is `monitor_only` until integrity checks pass.
+- If data integrity fails, orchestrator degrades to `monitor_only` and logs the event.
+- Reject/revise decisions auto-enqueue escalation.
+
+## JSON schemas
+
+- `schemas/investment_profile.schema.json` contains the implementation-ready schema for the user profile object.
+- Remaining contract objects are represented as typed Pydantic models in `models.py`.

--- a/investment_team/__init__.py
+++ b/investment_team/__init__.py
@@ -1,0 +1,40 @@
+"""Multi-asset investment organization agents package."""
+
+from .agents import AgentIdentity, InvestmentCommitteeAgent, PolicyGuardianAgent, PromotionGateAgent
+from .models import (
+    IPS,
+    AssetUniverse,
+    DiligenceFindings,
+    ExecutionReport,
+    InvestmentCommitteeMemo,
+    InvestmentProfile,
+    OrderIntent,
+    PortfolioProposal,
+    PromotionDecision,
+    StrategySpec,
+    UnderwritingSummary,
+    ValidationReport,
+)
+from .orchestrator import InvestmentTeamOrchestrator, QueueItem, WorkflowState
+
+__all__ = [
+    "AgentIdentity",
+    "AssetUniverse",
+    "DiligenceFindings",
+    "ExecutionReport",
+    "IPS",
+    "InvestmentCommitteeAgent",
+    "InvestmentCommitteeMemo",
+    "InvestmentProfile",
+    "InvestmentTeamOrchestrator",
+    "OrderIntent",
+    "PolicyGuardianAgent",
+    "PortfolioProposal",
+    "PromotionDecision",
+    "PromotionGateAgent",
+    "QueueItem",
+    "StrategySpec",
+    "UnderwritingSummary",
+    "ValidationReport",
+    "WorkflowState",
+]

--- a/investment_team/agents.py
+++ b/investment_team/agents.py
@@ -1,0 +1,161 @@
+"""Agent roles and decision logic for the investment organization."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from .models import (
+    IPS,
+    InvestmentCommitteeMemo,
+    PortfolioProposal,
+    PromotionDecision,
+    PromotionStage,
+    StrategySpec,
+    ValidationReport,
+    ValidationStatus,
+)
+
+
+@dataclass(frozen=True)
+class AgentIdentity:
+    agent_id: str
+    role: str
+    version: str
+
+
+class PolicyGuardianAgent:
+    """Enforces IPS hard constraints before any recommendation advances."""
+
+    def check_portfolio(self, ips: IPS, proposal: PortfolioProposal) -> List[str]:
+        violations: List[str] = []
+        constraints = ips.profile.constraints
+
+        if not proposal.positions:
+            return ["Portfolio has no positions."]
+
+        for pos in proposal.positions:
+            if pos.weight_pct > constraints.max_single_position_pct:
+                violations.append(
+                    f"{pos.symbol} exceeds single-position cap "
+                    f"({pos.weight_pct}% > {constraints.max_single_position_pct}%)."
+                )
+
+            class_cap = constraints.max_asset_class_pct.get(pos.asset_class)
+            if class_cap is not None and pos.weight_pct > class_cap:
+                violations.append(
+                    f"{pos.symbol} breaches asset class cap for {pos.asset_class} "
+                    f"({pos.weight_pct}% > {class_cap}%)."
+                )
+
+        if not ips.profile.preferences.crypto_allowed:
+            for pos in proposal.positions:
+                if pos.asset_class == "crypto":
+                    violations.append("Crypto position present despite IPS disallowing crypto.")
+
+        return violations
+
+
+class ValidationAgent:
+    """Checks if a strategy passed required testing and scenario standards."""
+
+    REQUIRED_CHECKS = {
+        "backtest_quality",
+        "walk_forward",
+        "stress_test",
+        "transaction_cost_model",
+        "liquidity_impact",
+    }
+
+    def checklist_failures(self, report: ValidationReport) -> List[str]:
+        failures: List[str] = []
+        present = {c.name for c in report.checks}
+
+        for required in sorted(self.REQUIRED_CHECKS - present):
+            failures.append(f"Missing required validation check: {required}.")
+
+        for check in report.checks:
+            if check.status == ValidationStatus.FAIL:
+                failures.append(f"Failed validation check: {check.name} ({check.details}).")
+
+        return failures
+
+
+class PromotionGateAgent:
+    """Applies universal promotion checklist and enforces separation-of-duties gates."""
+
+    def decide(
+        self,
+        strategy: StrategySpec,
+        validation: ValidationReport,
+        ips: IPS,
+        proposer_agent_id: str,
+        approver: AgentIdentity,
+        risk_veto: bool,
+    ) -> PromotionDecision:
+        if proposer_agent_id == approver.agent_id:
+            return PromotionDecision(
+                strategy_id=strategy.strategy_id,
+                decided_by=approver.agent_id,
+                outcome=PromotionStage.REJECT,
+                rationale="Separation-of-duties violation: proposer cannot self-approve.",
+                required_actions=["Assign independent approval agent."],
+            )
+
+        validator = ValidationAgent()
+        failures = validator.checklist_failures(validation)
+
+        if risk_veto:
+            return PromotionDecision(
+                strategy_id=strategy.strategy_id,
+                decided_by=approver.agent_id,
+                outcome=PromotionStage.REJECT,
+                rationale="Risk management veto invoked.",
+                required_actions=["Address risk concerns and rerun validation."],
+            )
+
+        if failures:
+            return PromotionDecision(
+                strategy_id=strategy.strategy_id,
+                decided_by=approver.agent_id,
+                outcome=PromotionStage.REVISE,
+                rationale="Validation checklist not satisfied.",
+                required_actions=failures,
+            )
+
+        if not ips.live_trading_enabled:
+            return PromotionDecision(
+                strategy_id=strategy.strategy_id,
+                decided_by=approver.agent_id,
+                outcome=PromotionStage.PAPER,
+                rationale="IPS does not permit live trading; defaulting to paper mode.",
+                required_actions=["Obtain explicit human approval + IPS update for live promotion."],
+            )
+
+        return PromotionDecision(
+            strategy_id=strategy.strategy_id,
+            decided_by=approver.agent_id,
+            outcome=PromotionStage.LIVE,
+            rationale="All checklist gates passed, no veto, and IPS allows live trading.",
+            required_actions=["Enable tight risk limits and monitor-first rollout window."],
+        )
+
+
+class InvestmentCommitteeAgent:
+    """Produces a user-facing recommendation memo with rationale and dissent."""
+
+    def draft_memo(
+        self,
+        user_id: str,
+        recommendation: str,
+        rationale: str,
+        dissenting_views: List[str] | None = None,
+    ) -> InvestmentCommitteeMemo:
+        return InvestmentCommitteeMemo(
+            memo_id=f"icm-{user_id}",
+            prepared_for_user_id=user_id,
+            recommendation=recommendation,
+            rationale=rationale,
+            dissenting_views=dissenting_views or [],
+            attachments=[],
+        )

--- a/investment_team/models.py
+++ b/investment_team/models.py
@@ -1,0 +1,219 @@
+"""Data models for the multi-asset investment organization."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class RiskTolerance(str, Enum):
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+    VERY_HIGH = "very_high"
+
+
+class PromotionStage(str, Enum):
+    REJECT = "reject"
+    REVISE = "revise"
+    PAPER = "paper"
+    LIVE = "live"
+
+
+class ValidationStatus(str, Enum):
+    PASS = "pass"
+    WARN = "warn"
+    FAIL = "fail"
+
+
+class PlannedLargeExpense(BaseModel):
+    name: str
+    amount: float
+    date: str
+
+
+class LiquidityNeeds(BaseModel):
+    emergency_fund_months: int = 6
+    planned_large_expenses: List[PlannedLargeExpense] = Field(default_factory=list)
+
+
+class IncomeProfile(BaseModel):
+    annual_gross: float
+    stability: str
+
+
+class NetWorth(BaseModel):
+    total: float
+    investable_assets: float
+
+
+class SavingsRate(BaseModel):
+    monthly: float
+    annual: float
+
+
+class TaxProfile(BaseModel):
+    country: str
+    state: str = ""
+    account_types: List[str] = Field(default_factory=list)
+
+
+class UserPreferences(BaseModel):
+    excluded_asset_classes: List[str] = Field(default_factory=list)
+    excluded_industries: List[str] = Field(default_factory=list)
+    esg_preference: str = "none"
+    crypto_allowed: bool = True
+    options_allowed: bool = True
+    leverage_allowed: bool = False
+
+
+class UserGoal(BaseModel):
+    name: str
+    target_amount: float
+    target_date: str
+    priority: str
+
+
+class PortfolioConstraints(BaseModel):
+    max_single_position_pct: float = 10
+    max_asset_class_pct: Dict[str, float] = Field(default_factory=dict)
+
+
+class InvestmentProfile(BaseModel):
+    schema_version: str = "1.0"
+    user_id: str
+    created_at: str
+    risk_tolerance: RiskTolerance
+    max_drawdown_tolerance_pct: float
+    time_horizon_years: int
+    liquidity_needs: LiquidityNeeds
+    income: IncomeProfile
+    net_worth: NetWorth
+    savings_rate: SavingsRate
+    tax_profile: TaxProfile
+    preferences: UserPreferences
+    goals: List[UserGoal] = Field(default_factory=list)
+    constraints: PortfolioConstraints
+
+
+class IPS(BaseModel):
+    profile: InvestmentProfile
+    live_trading_enabled: bool = False
+    speculative_sleeve_cap_pct: float = 10
+    rebalance_frequency: str = "quarterly"
+    notes: List[str] = Field(default_factory=list)
+
+
+class AssetUniverse(BaseModel):
+    as_of: str
+    allowed_assets: List[str] = Field(default_factory=list)
+    banned_assets: List[str] = Field(default_factory=list)
+    data_snapshot_id: str
+
+
+class PortfolioPosition(BaseModel):
+    symbol: str
+    asset_class: str
+    weight_pct: float
+    rationale: str
+
+
+class PortfolioProposal(BaseModel):
+    proposal_id: str
+    prepared_by: str
+    ips_version: str
+    data_snapshot_id: str
+    objective: str
+    positions: List[PortfolioPosition]
+    expected_return_pct: Optional[float] = None
+    expected_volatility_pct: Optional[float] = None
+    expected_max_drawdown_pct: Optional[float] = None
+    assumptions: List[str] = Field(default_factory=list)
+
+
+class StrategySpec(BaseModel):
+    strategy_id: str
+    authored_by: str
+    asset_class: str
+    hypothesis: str
+    signal_definition: str
+    entry_rules: List[str] = Field(default_factory=list)
+    exit_rules: List[str] = Field(default_factory=list)
+    sizing_rules: List[str] = Field(default_factory=list)
+    risk_limits: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ValidationCheck(BaseModel):
+    name: str
+    status: ValidationStatus
+    details: str
+
+
+class ValidationReport(BaseModel):
+    strategy_id: str
+    generated_by: str
+    data_snapshot_id: str
+    backtest_period: str
+    scenario_set: List[str] = Field(default_factory=list)
+    checks: List[ValidationCheck] = Field(default_factory=list)
+    summary: str = ""
+
+
+class PromotionDecision(BaseModel):
+    strategy_id: str
+    decided_by: str
+    outcome: PromotionStage
+    rationale: str
+    required_actions: List[str] = Field(default_factory=list)
+
+
+class OrderIntent(BaseModel):
+    strategy_id: str
+    symbol: str
+    side: str
+    qty: float
+    order_type: str
+    risk_context: Dict[str, Any] = Field(default_factory=dict)
+
+
+class ExecutionReport(BaseModel):
+    strategy_id: str
+    broker_order_id: str
+    status: str
+    avg_fill_price: Optional[float] = None
+    slippage_bps: Optional[float] = None
+    reconciled: bool = False
+
+
+class DealCard(BaseModel):
+    deal_id: str
+    source: str
+    sector: str
+    asking_price: float
+    revenue: Optional[float] = None
+    ebitda: Optional[float] = None
+
+
+class UnderwritingSummary(BaseModel):
+    deal_id: str
+    model_version: str
+    base_case_irr_pct: float
+    downside_case_irr_pct: float
+    key_risks: List[str] = Field(default_factory=list)
+
+
+class DiligenceFindings(BaseModel):
+    deal_id: str
+    findings: List[str] = Field(default_factory=list)
+    blockers: List[str] = Field(default_factory=list)
+
+
+class InvestmentCommitteeMemo(BaseModel):
+    memo_id: str
+    prepared_for_user_id: str
+    recommendation: str
+    rationale: str
+    dissenting_views: List[str] = Field(default_factory=list)
+    attachments: List[str] = Field(default_factory=list)

--- a/investment_team/orchestrator.py
+++ b/investment_team/orchestrator.py
@@ -1,0 +1,87 @@
+"""Orchestration plan for the investment team workflow."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from .agents import AgentIdentity, PolicyGuardianAgent, PromotionGateAgent
+from .models import IPS, PortfolioProposal, PromotionDecision, StrategySpec, ValidationReport
+
+
+@dataclass
+class QueueItem:
+    queue: str
+    payload_id: str
+    priority: str = "normal"
+
+
+@dataclass
+class WorkflowState:
+    queues: Dict[str, List[QueueItem]] = field(
+        default_factory=lambda: {
+            "research": [],
+            "portfolio_design": [],
+            "validation": [],
+            "promotion": [],
+            "execution": [],
+            "escalation": [],
+        }
+    )
+    mode: str = "monitor_only"
+    audit_log: List[str] = field(default_factory=list)
+
+
+class InvestmentTeamOrchestrator:
+    """
+    Coordinates research -> proposal -> validation -> promotion with safety gates.
+
+    Safety behavior:
+    - If integrity_ok is false, workflow degrades to monitor_only.
+    - Risk has veto power at promotion stage.
+    - Live promotion requires IPS permission and independent approver.
+    """
+
+    def __init__(self) -> None:
+        self.policy_guardian = PolicyGuardianAgent()
+        self.promotion_gate = PromotionGateAgent()
+
+    def enqueue(self, state: WorkflowState, item: QueueItem) -> None:
+        state.queues[item.queue].append(item)
+        state.audit_log.append(f"enqueued:{item.queue}:{item.payload_id}:{item.priority}")
+
+    def handle_data_integrity(self, state: WorkflowState, integrity_ok: bool) -> None:
+        if not integrity_ok:
+            state.mode = "monitor_only"
+            state.audit_log.append("data_integrity_failed:degrade_to_monitor_only")
+
+    def check_proposal(self, state: WorkflowState, ips: IPS, proposal: PortfolioProposal) -> List[str]:
+        violations = self.policy_guardian.check_portfolio(ips, proposal)
+        if violations:
+            state.audit_log.append(f"proposal_rejected:{proposal.proposal_id}")
+        else:
+            state.audit_log.append(f"proposal_passed:{proposal.proposal_id}")
+        return violations
+
+    def promotion_decision(
+        self,
+        state: WorkflowState,
+        strategy: StrategySpec,
+        validation: ValidationReport,
+        ips: IPS,
+        proposer_agent_id: str,
+        approver: AgentIdentity,
+        risk_veto: bool,
+    ) -> PromotionDecision:
+        decision = self.promotion_gate.decide(
+            strategy=strategy,
+            validation=validation,
+            ips=ips,
+            proposer_agent_id=proposer_agent_id,
+            approver=approver,
+            risk_veto=risk_veto,
+        )
+        state.audit_log.append(f"promotion:{strategy.strategy_id}:{decision.outcome.value}")
+        if decision.outcome.value in {"reject", "revise"}:
+            self.enqueue(state, QueueItem(queue="escalation", payload_id=strategy.strategy_id, priority="high"))
+        return decision

--- a/investment_team/schemas/investment_profile.schema.json
+++ b/investment_team/schemas/investment_profile.schema.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/schemas/investment_profile.schema.json",
+  "title": "InvestmentProfile",
+  "type": "object",
+  "required": [
+    "schema_version",
+    "user_id",
+    "created_at",
+    "risk_tolerance",
+    "max_drawdown_tolerance_pct",
+    "time_horizon_years",
+    "liquidity_needs",
+    "income",
+    "net_worth",
+    "savings_rate",
+    "tax_profile",
+    "preferences",
+    "goals",
+    "constraints"
+  ],
+  "properties": {
+    "schema_version": { "type": "string", "const": "1.0" },
+    "user_id": { "type": "string" },
+    "created_at": { "type": "string", "format": "date-time" },
+    "risk_tolerance": {
+      "type": "string",
+      "enum": ["low", "medium", "high", "very_high"]
+    },
+    "max_drawdown_tolerance_pct": { "type": "number", "minimum": 0, "maximum": 100 },
+    "time_horizon_years": { "type": "integer", "minimum": 1 },
+    "liquidity_needs": {
+      "type": "object",
+      "required": ["emergency_fund_months", "planned_large_expenses"],
+      "properties": {
+        "emergency_fund_months": { "type": "integer", "minimum": 0 },
+        "planned_large_expenses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["name", "amount", "date"],
+            "properties": {
+              "name": { "type": "string" },
+              "amount": { "type": "number", "minimum": 0 },
+              "date": { "type": "string", "format": "date-time" }
+            }
+          }
+        }
+      }
+    },
+    "income": {
+      "type": "object",
+      "required": ["annual_gross", "stability"],
+      "properties": {
+        "annual_gross": { "type": "number", "minimum": 0 },
+        "stability": { "type": "string", "enum": ["stable", "variable", "uncertain"] }
+      }
+    },
+    "net_worth": {
+      "type": "object",
+      "required": ["total", "investable_assets"],
+      "properties": {
+        "total": { "type": "number" },
+        "investable_assets": { "type": "number" }
+      }
+    },
+    "savings_rate": {
+      "type": "object",
+      "required": ["monthly", "annual"],
+      "properties": {
+        "monthly": { "type": "number" },
+        "annual": { "type": "number" }
+      }
+    },
+    "tax_profile": {
+      "type": "object",
+      "required": ["country", "state", "account_types"],
+      "properties": {
+        "country": { "type": "string" },
+        "state": { "type": "string" },
+        "account_types": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "enum": ["taxable", "ira", "roth", "401k", "other"]
+          }
+        }
+      }
+    },
+    "preferences": {
+      "type": "object",
+      "required": [
+        "excluded_asset_classes",
+        "excluded_industries",
+        "esg_preference",
+        "crypto_allowed",
+        "options_allowed",
+        "leverage_allowed"
+      ],
+      "properties": {
+        "excluded_asset_classes": { "type": "array", "items": { "type": "string" } },
+        "excluded_industries": { "type": "array", "items": { "type": "string" } },
+        "esg_preference": { "type": "string", "enum": ["none", "light", "strict"] },
+        "crypto_allowed": { "type": "boolean" },
+        "options_allowed": { "type": "boolean" },
+        "leverage_allowed": { "type": "boolean" }
+      }
+    },
+    "goals": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["name", "target_amount", "target_date", "priority"],
+        "properties": {
+          "name": { "type": "string" },
+          "target_amount": { "type": "number", "minimum": 0 },
+          "target_date": { "type": "string", "format": "date-time" },
+          "priority": { "type": "string", "enum": ["high", "medium", "low"] }
+        }
+      }
+    },
+    "constraints": {
+      "type": "object",
+      "required": ["max_single_position_pct", "max_asset_class_pct"],
+      "properties": {
+        "max_single_position_pct": { "type": "number", "minimum": 0, "maximum": 100 },
+        "max_asset_class_pct": {
+          "type": "object",
+          "properties": {
+            "equities": { "type": "number", "minimum": 0, "maximum": 100 },
+            "bonds": { "type": "number", "minimum": 0, "maximum": 100 },
+            "options": { "type": "number", "minimum": 0, "maximum": 100 },
+            "crypto": { "type": "number", "minimum": 0, "maximum": 100 },
+            "fx": { "type": "number", "minimum": 0, "maximum": 100 },
+            "real_estate": { "type": "number", "minimum": 0, "maximum": 100 },
+            "commodities": { "type": "number", "minimum": 0, "maximum": 100 }
+          },
+          "additionalProperties": false
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide an implementation-ready, IPS-first multi-agent scaffold for multi-asset investing that enforces the Investment Policy Statement (IPS) as hard constraints and includes promotion gating from research → paper → live with separation-of-duties and risk veto semantics.

### Description
- Added a new root-level `investment_team` package with Pydantic domain models for the spec (`InvestmentProfile`, `IPS`, `AssetUniverse`, `PortfolioProposal`, `StrategySpec`, `ValidationReport`, `PromotionDecision`, `OrderIntent`, `ExecutionReport`, `DealCard`, `UnderwritingSummary`, `DiligenceFindings`, `InvestmentCommitteeMemo`).
- Implemented agent role logic in `agents.py` including `PolicyGuardianAgent` (IPS enforcement), `ValidationAgent` (required checklist), `PromotionGateAgent` (universal promotion checklist with separation-of-duties and risk veto), and `InvestmentCommitteeAgent` (memo drafting).
- Implemented orchestration in `orchestrator.py` with queue-based `WorkflowState`, audit logging, `monitor_only` safe-degradation on data integrity failures, and auto-escalation on `reject`/`revise` outcomes.
- Added `investment_team/schemas/investment_profile.schema.json`, `investment_team/README.md`, and package exports in `investment_team/__init__.py`, and updated the repo README to list the new package.

### Testing
- Ran `python -m compileall investment_team` which completed successfully and compiled the package modules without syntax errors. 
- Executed a small smoke test by importing the orchestrator and models and running a promotion flow snippet which returned the expected `paper` outcome when `IPS.live_trading_enabled=False`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997ff7f47cc832e90b590953b3ee843)