### PR TITLE
Add branding strategy team with codification, mood boards, and brand governance

### DIFF
--- a/branding_team/README.md
+++ b/branding_team/README.md
@@ -1,0 +1,46 @@
+# Branding Strategy Team
+
+This team defines and operationalizes an enterprise brand system through a coordinated group of specialist agents.
+
+## What this team does
+
+1. **Codifies brand identity** with positioning, promise, and narrative pillars.
+2. **Ideates brand images** through multiple mood-board concepts.
+3. **Guides refinement** with a structured creative workshop and decision framework.
+4. **Defines writing guidelines, brand guidelines, and design system standards** for consistent delivery.
+5. **Builds and maintains a brand wiki backlog** so the entire organization can work from a shared source of truth.
+6. **Fields on-brand requests** by evaluating assets and returning confidence, rationale, and revision suggestions.
+
+## API
+
+Start:
+
+```bash
+uvicorn branding_team.api.main:app --reload --host 0.0.0.0 --port 8012
+```
+
+Run:
+
+```http
+POST /branding/run
+```
+
+Example payload:
+
+```json
+{
+  "company_name": "Northstar Labs",
+  "company_description": "A product and AI enablement consultancy for B2B software teams",
+  "target_audience": "VP Product and Design leaders",
+  "values": ["clarity", "craft", "trust"],
+  "differentiators": ["hands-on operators", "speed to value"],
+  "desired_voice": "clear, practical, confident",
+  "brand_checks": [
+    {
+      "asset_name": "Q3 product launch landing page",
+      "asset_description": "Highlights measurable business outcomes with proof and concise messaging"
+    }
+  ],
+  "human_approved": true
+}
+```

--- a/branding_team/__init__.py
+++ b/branding_team/__init__.py
@@ -1,0 +1,12 @@
+"""Branding strategy team package."""
+
+from .models import BrandingMission, HumanReview, TeamOutput, WorkflowStatus
+from .orchestrator import BrandingTeamOrchestrator
+
+__all__ = [
+    "BrandingMission",
+    "BrandingTeamOrchestrator",
+    "HumanReview",
+    "TeamOutput",
+    "WorkflowStatus",
+]

--- a/branding_team/agents.py
+++ b/branding_team/agents.py
@@ -1,0 +1,238 @@
+"""Agent implementations for branding strategy workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+from .models import (
+    BrandCheckRequest,
+    BrandCheckResult,
+    BrandCodification,
+    BrandingMission,
+    CreativeRefinementPlan,
+    DesignSystemDefinition,
+    MoodBoardConcept,
+    WikiEntry,
+    WritingGuidelines,
+)
+
+
+@dataclass
+class BrandCodificationAgent:
+    """Works with the user to codify a unified brand direction."""
+
+    role: str = "Brand Strategist"
+
+    def codify(self, mission: BrandingMission) -> BrandCodification:
+        values = mission.values or ["trust", "clarity", "momentum"]
+        differentiators = mission.differentiators or ["domain expertise", "execution speed"]
+        return BrandCodification(
+            positioning_statement=(
+                f"{mission.company_name} helps {mission.target_audience} by turning "
+                f"{mission.company_description.lower()} into consistent, recognizable experiences."
+            ),
+            brand_promise=(
+                "Every customer touchpoint should feel cohesive, useful, and unmistakably aligned "
+                "to one unified brand system."
+            ),
+            brand_personality_traits=values[:4],
+            narrative_pillars=[
+                f"Differentiate through {differentiators[0]}",
+                "Build trust with transparent communication",
+                "Show proof through concrete outcomes",
+            ],
+        )
+
+
+@dataclass
+class MoodBoardIdeationAgent:
+    """Creates candidate brand-image mood boards."""
+
+    role: str = "Brand Visual Ideation Lead"
+
+    def ideate(self, mission: BrandingMission) -> List[MoodBoardConcept]:
+        return [
+            MoodBoardConcept(
+                title="Modern Confidence",
+                visual_direction="Clean grids, product-in-context photography, generous whitespace",
+                color_story=["midnight blue", "electric cyan", "neutral stone"],
+                typography_direction="Geometric sans-serif with high readability",
+                image_style=["documentary-style people", "interface closeups", "subtle gradients"],
+            ),
+            MoodBoardConcept(
+                title="Human Craft",
+                visual_direction="Editorial layouts with warm contrast and tactile textures",
+                color_story=["charcoal", "terracotta", "cream"],
+                typography_direction="Humanist sans-serif paired with a restrained serif",
+                image_style=["team collaboration scenes", "sketch-to-product narratives", "macro textures"],
+            ),
+        ]
+
+
+@dataclass
+class CreativeRefinementAgent:
+    """Facilitates iterative creative refinement and decision making."""
+
+    role: str = "Creative Director"
+
+    def build_plan(self) -> CreativeRefinementPlan:
+        return CreativeRefinementPlan(
+            phases=[
+                "Diverge: review 2-3 mood boards and map them to audience perception goals",
+                "Converge: pick one primary direction and one fallback",
+                "Stress-test: apply direction to landing page, sales deck, and social post",
+                "Finalize: lock visual and narrative system in v1.0 brand standards",
+            ],
+            workshop_prompts=[
+                "What should prospects feel in the first 5 seconds?",
+                "Which direction best communicates credibility and momentum?",
+                "What elements are unique enough to own long-term?",
+            ],
+            decision_criteria=[
+                "Audience resonance",
+                "Distinctiveness vs competitors",
+                "Cross-channel consistency",
+                "Execution feasibility in 90 days",
+            ],
+        )
+
+
+@dataclass
+class BrandGuidelinesAgent:
+    """Defines writing, brand, and design-system guidelines."""
+
+    role: str = "Brand Systems Architect"
+
+    def writing_guidelines(self, mission: BrandingMission) -> WritingGuidelines:
+        return WritingGuidelines(
+            voice_principles=[
+                f"Use a {mission.desired_voice} voice across channels",
+                "Lead with customer outcomes before product features",
+                "Prefer plain language over jargon",
+            ],
+            style_dos=[
+                "Use active voice and direct calls to action",
+                "Ground claims in proof points and examples",
+                "Keep paragraphs short and scannable",
+            ],
+            style_donts=[
+                "Do not overpromise or use unverifiable superlatives",
+                "Avoid inconsistent terminology for core offerings",
+                "Do not bury the key value proposition",
+            ],
+            editorial_quality_bar=[
+                "Every artifact must map to one narrative pillar",
+                "Every external asset receives tone and terminology QA",
+                "Every major launch includes a message hierarchy",
+            ],
+        )
+
+    def brand_guidelines(self, codification: BrandCodification) -> List[str]:
+        return [
+            f"Positioning: {codification.positioning_statement}",
+            f"Promise: {codification.brand_promise}",
+            "Identity system: logo spacing, color usage, and typography rules are mandatory.",
+            "Messaging hierarchy: promise -> pillar -> proof -> CTA.",
+            "Governance: route major campaign concepts through brand review before launch.",
+        ]
+
+    def design_system(self) -> DesignSystemDefinition:
+        return DesignSystemDefinition(
+            design_principles=[
+                "Clarity over decoration",
+                "Consistency at scale",
+                "Accessible by default",
+            ],
+            foundation_tokens=[
+                "Color tokens: primary/secondary/surface/critical",
+                "Type tokens: display/body/caption scales",
+                "Spacing tokens: 4-point base scale",
+                "Motion tokens: subtle and meaningful",
+            ],
+            component_standards=[
+                "Buttons: size variants, icon rules, and disabled states",
+                "Cards: elevation, border, and content density options",
+                "Navigation: desktop and mobile behavior patterns",
+            ],
+        )
+
+
+@dataclass
+class BrandWikiAgent:
+    """Builds and maintains an enterprise-ready brand wiki backlog."""
+
+    role: str = "Knowledge Systems Manager"
+
+    def build_wiki_backlog(self, mission: BrandingMission) -> List[WikiEntry]:
+        return [
+            WikiEntry(
+                title="Brand North Star",
+                summary="Single source of truth for positioning, promise, and narrative pillars.",
+                owners=["Brand Strategy", "Executive Sponsor"],
+                update_cadence="quarterly",
+            ),
+            WikiEntry(
+                title="Voice & Writing Playbook",
+                summary="Examples, approved terminology, and do/don't patterns for all writers.",
+                owners=["Content Design", "Comms"],
+                update_cadence="monthly",
+            ),
+            WikiEntry(
+                title="Design System & UI Guidance",
+                summary="Token catalog, component rules, and accessibility requirements.",
+                owners=["Design Systems", "Frontend Platform"],
+                update_cadence="monthly",
+            ),
+            WikiEntry(
+                title="Brand Review Intake",
+                summary=(
+                    "Request template and SLA for checking whether campaigns, pages, and artifacts "
+                    "are on brand."
+                ),
+                owners=["Brand Operations"],
+                update_cadence="bi-weekly",
+            ),
+        ]
+
+
+@dataclass
+class BrandComplianceAgent:
+    """Fields requests to determine whether assets are on brand."""
+
+    role: str = "Brand Compliance Reviewer"
+
+    def evaluate(self, checks: List[BrandCheckRequest], mission: BrandingMission) -> List[BrandCheckResult]:
+        keywords = [*mission.values, *mission.differentiators, mission.company_name, mission.target_audience]
+        lowered_keywords = [k.lower() for k in keywords if k]
+        results: List[BrandCheckResult] = []
+
+        for check in checks:
+            text = f"{check.asset_name} {check.asset_description}".lower()
+            matched = [k for k in lowered_keywords if k in text]
+            is_on_brand = len(matched) >= 2
+            confidence = min(0.95, 0.45 + (0.1 * len(matched)))
+
+            rationale = [
+                "Asset aligns with declared audience and brand language." if is_on_brand else "Asset is missing core brand signals.",
+                f"Detected brand cues: {', '.join(matched[:4]) or 'none'}.",
+            ]
+            revision_suggestions = []
+            if not is_on_brand:
+                revision_suggestions = [
+                    "Add clearer reference to target audience and expected outcome.",
+                    "Use approved voice-and-tone language from the writing playbook.",
+                    "Map copy to one narrative pillar and include proof.",
+                ]
+
+            results.append(
+                BrandCheckResult(
+                    asset_name=check.asset_name,
+                    is_on_brand=is_on_brand,
+                    confidence=round(confidence, 2),
+                    rationale=rationale,
+                    revision_suggestions=revision_suggestions,
+                )
+            )
+
+        return results

--- a/branding_team/api/main.py
+++ b/branding_team/api/main.py
@@ -1,0 +1,47 @@
+"""FastAPI endpoints for running the branding strategy team."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from pydantic import BaseModel, Field
+
+from branding_team.models import BrandCheckRequest, BrandingMission, HumanReview, TeamOutput
+from branding_team.orchestrator import BrandingTeamOrchestrator
+
+app = FastAPI(title="Branding Team API", version="1.0.0")
+
+
+class RunBrandingTeamRequest(BaseModel):
+    company_name: str = Field(..., min_length=2)
+    company_description: str = Field(..., min_length=10)
+    target_audience: str = Field(..., min_length=3)
+    values: list[str] = Field(default_factory=list)
+    differentiators: list[str] = Field(default_factory=list)
+    desired_voice: str = Field(default="clear, confident, human")
+    existing_brand_material: list[str] = Field(default_factory=list)
+    wiki_path: str | None = None
+    brand_checks: list[BrandCheckRequest] = Field(default_factory=list)
+    human_approved: bool = False
+    human_feedback: str = ""
+
+
+@app.post("/branding/run", response_model=TeamOutput)
+def run_branding_team(payload: RunBrandingTeamRequest) -> TeamOutput:
+    orchestrator = BrandingTeamOrchestrator()
+    mission = BrandingMission(
+        company_name=payload.company_name,
+        company_description=payload.company_description,
+        target_audience=payload.target_audience,
+        values=payload.values,
+        differentiators=payload.differentiators,
+        desired_voice=payload.desired_voice,
+        existing_brand_material=payload.existing_brand_material,
+        wiki_path=payload.wiki_path,
+    )
+    human_review = HumanReview(approved=payload.human_approved, feedback=payload.human_feedback)
+    return orchestrator.run(mission=mission, human_review=human_review, brand_checks=payload.brand_checks)
+
+
+@app.get("/health")
+def health() -> dict:
+    return {"status": "ok"}

--- a/branding_team/models.py
+++ b/branding_team/models.py
@@ -1,0 +1,97 @@
+"""Models for the branding strategy multi-agent team."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class WorkflowStatus(str, Enum):
+    NEEDS_HUMAN_DECISION = "needs_human_decision"
+    READY_FOR_ROLLOUT = "ready_for_rollout"
+
+
+class BrandingMission(BaseModel):
+    company_name: str = Field(..., min_length=2)
+    company_description: str = Field(..., min_length=10)
+    target_audience: str = Field(..., min_length=3)
+    values: List[str] = Field(default_factory=list)
+    differentiators: List[str] = Field(default_factory=list)
+    desired_voice: str = "clear, confident, human"
+    existing_brand_material: List[str] = Field(default_factory=list)
+    wiki_path: Optional[str] = None
+
+
+class HumanReview(BaseModel):
+    approved: bool = False
+    feedback: str = ""
+
+
+class BrandCodification(BaseModel):
+    positioning_statement: str
+    brand_promise: str
+    brand_personality_traits: List[str] = Field(default_factory=list)
+    narrative_pillars: List[str] = Field(default_factory=list)
+
+
+class MoodBoardConcept(BaseModel):
+    title: str
+    visual_direction: str
+    color_story: List[str] = Field(default_factory=list)
+    typography_direction: str
+    image_style: List[str] = Field(default_factory=list)
+
+
+class CreativeRefinementPlan(BaseModel):
+    phases: List[str] = Field(default_factory=list)
+    workshop_prompts: List[str] = Field(default_factory=list)
+    decision_criteria: List[str] = Field(default_factory=list)
+
+
+class WritingGuidelines(BaseModel):
+    voice_principles: List[str] = Field(default_factory=list)
+    style_dos: List[str] = Field(default_factory=list)
+    style_donts: List[str] = Field(default_factory=list)
+    editorial_quality_bar: List[str] = Field(default_factory=list)
+
+
+class DesignSystemDefinition(BaseModel):
+    design_principles: List[str] = Field(default_factory=list)
+    foundation_tokens: List[str] = Field(default_factory=list)
+    component_standards: List[str] = Field(default_factory=list)
+
+
+class WikiEntry(BaseModel):
+    title: str
+    summary: str
+    owners: List[str] = Field(default_factory=list)
+    update_cadence: str = "monthly"
+
+
+class BrandCheckRequest(BaseModel):
+    asset_name: str
+    asset_description: str
+
+
+class BrandCheckResult(BaseModel):
+    asset_name: str
+    is_on_brand: bool
+    confidence: float = Field(ge=0, le=1)
+    rationale: List[str] = Field(default_factory=list)
+    revision_suggestions: List[str] = Field(default_factory=list)
+
+
+class TeamOutput(BaseModel):
+    status: WorkflowStatus
+    mission_summary: str
+    codification: BrandCodification
+    mood_boards: List[MoodBoardConcept] = Field(default_factory=list)
+    creative_refinement: CreativeRefinementPlan
+    writing_guidelines: WritingGuidelines
+    brand_guidelines: List[str] = Field(default_factory=list)
+    design_system: DesignSystemDefinition
+    wiki_backlog: List[WikiEntry] = Field(default_factory=list)
+    brand_checks: List[BrandCheckResult] = Field(default_factory=list)
+    human_feedback: Optional[str] = None

--- a/branding_team/orchestrator.py
+++ b/branding_team/orchestrator.py
@@ -1,0 +1,77 @@
+"""Orchestrator for the branding strategy team."""
+
+from __future__ import annotations
+
+from typing import List
+
+from .agents import (
+    BrandCodificationAgent,
+    BrandComplianceAgent,
+    BrandGuidelinesAgent,
+    BrandWikiAgent,
+    CreativeRefinementAgent,
+    MoodBoardIdeationAgent,
+)
+from .models import BrandCheckRequest, BrandingMission, HumanReview, TeamOutput, WorkflowStatus
+
+
+class BrandingTeamOrchestrator:
+    """Coordinates codification, ideation, systems, and brand compliance workflows."""
+
+    def __init__(self) -> None:
+        self.codifier = BrandCodificationAgent()
+        self.moodboard = MoodBoardIdeationAgent()
+        self.refinement = CreativeRefinementAgent()
+        self.guidelines = BrandGuidelinesAgent()
+        self.wiki = BrandWikiAgent()
+        self.compliance = BrandComplianceAgent()
+
+    def run(
+        self,
+        mission: BrandingMission,
+        human_review: HumanReview,
+        brand_checks: List[BrandCheckRequest] | None = None,
+    ) -> TeamOutput:
+        codification = self.codifier.codify(mission)
+        mood_boards = self.moodboard.ideate(mission)
+        refinement_plan = self.refinement.build_plan()
+        writing_guidelines = self.guidelines.writing_guidelines(mission)
+        brand_guidelines = self.guidelines.brand_guidelines(codification)
+        design_system = self.guidelines.design_system()
+        wiki_backlog = self.wiki.build_wiki_backlog(mission)
+        checks = self.compliance.evaluate(brand_checks or [], mission)
+
+        if not human_review.approved:
+            return TeamOutput(
+                status=WorkflowStatus.NEEDS_HUMAN_DECISION,
+                mission_summary=(
+                    "Brand codification, mood boards, and governance artifacts are ready for stakeholder "
+                    "review before enterprise rollout."
+                ),
+                codification=codification,
+                mood_boards=mood_boards,
+                creative_refinement=refinement_plan,
+                writing_guidelines=writing_guidelines,
+                brand_guidelines=brand_guidelines,
+                design_system=design_system,
+                wiki_backlog=wiki_backlog,
+                brand_checks=checks,
+                human_feedback=human_review.feedback or "Awaiting approval from brand leadership.",
+            )
+
+        return TeamOutput(
+            status=WorkflowStatus.READY_FOR_ROLLOUT,
+            mission_summary=(
+                "Branding team finalized codification, systems, and wiki operations and is ready to support "
+                "enterprise-wide on-brand delivery."
+            ),
+            codification=codification,
+            mood_boards=mood_boards,
+            creative_refinement=refinement_plan,
+            writing_guidelines=writing_guidelines,
+            brand_guidelines=brand_guidelines,
+            design_system=design_system,
+            wiki_backlog=wiki_backlog,
+            brand_checks=checks,
+            human_feedback=human_review.feedback or "Approved for rollout.",
+        )

--- a/branding_team/tests/test_orchestrator.py
+++ b/branding_team/tests/test_orchestrator.py
@@ -1,0 +1,44 @@
+from branding_team import BrandingMission, BrandingTeamOrchestrator, HumanReview, WorkflowStatus
+from branding_team.models import BrandCheckRequest
+
+
+def _mission() -> BrandingMission:
+    return BrandingMission(
+        company_name="Northstar Labs",
+        company_description="A strategic studio helping product teams ship cohesive digital experiences",
+        target_audience="enterprise product leaders",
+        values=["clarity", "trust", "momentum"],
+        differentiators=["hands-on partnership", "execution speed"],
+    )
+
+
+def test_requires_human_approval() -> None:
+    orchestrator = BrandingTeamOrchestrator()
+    result = orchestrator.run(mission=_mission(), human_review=HumanReview(approved=False, feedback="Need legal review."))
+
+    assert result.status == WorkflowStatus.NEEDS_HUMAN_DECISION
+    assert result.human_feedback == "Need legal review."
+    assert result.mood_boards
+    assert result.wiki_backlog
+
+
+def test_ready_for_rollout_with_brand_checks() -> None:
+    orchestrator = BrandingTeamOrchestrator()
+    checks = [
+        BrandCheckRequest(
+            asset_name="Homepage refresh",
+            asset_description="Clear messaging for enterprise product leaders with trust-building proof points",
+        ),
+        BrandCheckRequest(
+            asset_name="Flashy ad",
+            asset_description="Guaranteed viral growth for everyone overnight",
+        ),
+    ]
+
+    result = orchestrator.run(mission=_mission(), human_review=HumanReview(approved=True), brand_checks=checks)
+
+    assert result.status == WorkflowStatus.READY_FOR_ROLLOUT
+    assert len(result.brand_guidelines) >= 4
+    assert result.design_system.foundation_tokens
+    assert len(result.brand_checks) == 2
+    assert any(not item.is_on_brand for item in result.brand_checks)


### PR DESCRIPTION
### Motivation
- Provide a dedicated multi-agent team to define, operationalize, and enforce a unified brand across content and design. 
- Enable collaborative brand codification with concrete artifacts (positioning, promise, narrative pillars) and visual ideation (mood boards) to speed decision-making. 
- Produce writing guidelines, brand guidelines, and a design system to ensure consistent delivery across the enterprise. 
- Offer an on-brand evaluation path and wiki backlog so teams can query whether assets are aligned and maintain a single source of truth. 

### Description
- Added a new `branding_team` package containing `models.py`, `agents.py`, `orchestrator.py`, `api/main.py`, `__init__.py`, `README.md`, and `tests/test_orchestrator.py` to implement the branding workflow. 
- Implemented specialist agents: `BrandCodificationAgent`, `MoodBoardIdeationAgent`, `CreativeRefinementAgent`, `BrandGuidelinesAgent`, `BrandWikiAgent`, and `BrandComplianceAgent` to produce codification, mood boards, guidelines, wiki backlog, and brand-check evaluations. 
- Added `BrandingTeamOrchestrator` to coordinate agents, synthesize outputs, and gate enterprise rollout behind `HumanReview` approval. 
- Exposed a FastAPI surface with `POST /branding/run` (accepts `RunBrandingTeamRequest`) and `GET /health`, plus a README with example `uvicorn` startup and payload. 

### Testing
- Running `pytest branding_team/tests/test_orchestrator.py` without `PYTHONPATH` initially reported an import error due to module path resolution. 
- Running `PYTHONPATH=. pytest branding_team/tests/test_orchestrator.py` completed successfully with `2 passed` (the orchestrator approval-gated and rollout-ready brand-check tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699905d59ef8832eb7733ec5826479f8)