### PR TITLE
Update README documentation for branding interactive sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This repository provides **multiple Strands-style agent systems** in a unified m
 | **SOC2 Compliance** | Multi-agent SOC2 audit: Security, Availability, Processing Integrity, Confidentiality, Privacy TSC agents review a repo and produce a compliance report or next-steps document. |
 | **Market Research** | Human-AI collaborative workflow for user discovery and product concept viability; transcript ingestion, UX synthesis, experiment scripts, human approval gates. |
 | **Investment Team** | Multi-asset investment organization with IPS hard constraints, strategy validation, promotion gates, separation-of-duties, risk veto, and monitor-only safety degradation. |
+| **Branding Team** | Brand strategy, codification, moodboard concepts, design/writing standards, and interactive async open-question workflow. |
 
 The **User Interface** is an Angular 19 application that provides interactive dashboards for all agent APIs.
 
@@ -92,6 +93,9 @@ cd agents && python -m uvicorn soc2_compliance_team.api.main:app --host 0.0.0.0 
 
 # Social Marketing (port 8010)
 cd agents && python -m uvicorn social_media_marketing_team.api.main:app --host 0.0.0.0 --port 8010
+
+# Branding (port 8012)
+cd agents && python -m uvicorn branding_team.api.main:app --host 0.0.0.0 --port 8012
 ```
 
 **3. Start the User Interface**
@@ -117,6 +121,7 @@ strands-agents/
 │   ├── soc2_compliance_team/        # SOC2 compliance audit
 │   ├── investment_team/             # Multi-asset investment (IPS-first)
 │   ├── market_research_team/        # Market research and concept viability
+│   ├── branding_team/               # Branding strategy + interactive clarification API
 │   ├── docker/                      # Docker config, default spec
 │   ├── Dockerfile                   # Multi-stage image (all 6 teams)
 │   ├── docker-compose.yml           # Run all APIs in one container

--- a/agents/README.md
+++ b/agents/README.md
@@ -8,6 +8,7 @@ This repository provides **multiple Strands-style agent systems** in a monorepo:
 - **SOC2 compliance team** – Multi-agent SOC2 audit for a code repository: Security, Availability, Processing Integrity, Confidentiality, and Privacy TSC agents review the repo and produce a compliance report or a next-steps-for-certification document.
 - **Investment team** – Multi-asset investment organization with IPS hard constraints, strategy validation, promotion gates (`reject/revise/paper/live`), separation-of-duties, risk veto, and monitor-only safety degradation.
 - **Market research team** – Human-AI collaborative workflow for user discovery and product concept viability; transcript ingestion, UX synthesis, experiment scripts, and human approval gates.
+- **Branding team** – Brand strategy codification, moodboard ideation, design and writing standards, plus an asynchronous open-question feed and answer workflow.
 
 ## Project structure
 
@@ -20,6 +21,7 @@ strands-agents/
 ├── soc2_compliance_team/       # SOC2 compliance audit and certification team
 ├── investment_team/            # Multi-asset investment organization (IPS-first)
 ├── market_research_team/       # Market research and concept viability
+├── branding_team/              # Branding strategy + interactive clarification API
 └── requirements.txt            # Shared dependencies
 ```
 
@@ -87,6 +89,7 @@ The `blogging/` and `software_engineering_team/` directories have their own `req
 | **Social media marketing** | package | `uvicorn social_media_marketing_team.api.main:app --host 0.0.0.0 --port 8010` | 8010 |
 | **Market research** | package | `uvicorn market_research_team.api.main:app --host 0.0.0.0 --port 8011` | 8011 |
 | **SOC2 compliance audit** | package | `uvicorn soc2_compliance_team.api.main:app --host 0.0.0.0 --port 8020` | 8020 |
+| **Branding strategy** | package | `uvicorn branding_team.api.main:app --host 0.0.0.0 --port 8012` | 8012 |
 
 ## Prerequisites
 
@@ -136,7 +139,7 @@ APIs are exposed on host ports 18000–18005 (mapped from container 8000–8005)
 
 ## Deployment
 
-- **Port allocation:** Default ports are 8000 (blog/SW), 8010 (social media), 8011 (market research), 8020 (SOC2). Override with `--port` when running multiple services.
+- **Port allocation:** Default ports are 8000 (blog/SW), 8010 (social media), 8011 (market research), 8012 (branding), 8020 (SOC2). Override with `--port` when running multiple services.
 - **Environment:** Set all required environment variables (e.g. `TAVILY_API_KEY`, `SW_LLM_*`) before starting services.
 - **Production:** Use a process manager (e.g. systemd, supervisord) or container orchestration. Run `uvicorn` without `--reload` in production.
 

--- a/agents/branding_team/README.md
+++ b/agents/branding_team/README.md
@@ -10,6 +10,7 @@ This team defines and operationalizes an enterprise brand system through a coord
 4. **Defines writing guidelines, brand guidelines, and design system standards** for consistent delivery.
 5. **Builds and maintains a brand wiki backlog** so the entire organization can work from a shared source of truth.
 6. **Fields on-brand requests** by evaluating assets and returning confidence, rationale, and revision suggestions.
+7. **Runs an interactive asynchronous clarification loop** where open questions are published to a feed and answered one-by-one.
 
 ## API
 
@@ -19,13 +20,43 @@ Start:
 uvicorn branding_team.api.main:app --reload --host 0.0.0.0 --port 8012
 ```
 
-Run:
+### Synchronous team run
 
 ```http
 POST /branding/run
 ```
 
-Example payload:
+Use this endpoint when you already have all required information and only need the final team output.
+
+### Interactive asynchronous workflow
+
+This workflow is designed for human-in-the-loop clarification and progressive refinement.
+
+1. **Create session** and generate initial outputs plus open questions:
+
+```http
+POST /branding/sessions
+```
+
+2. **Read current session state** (mission + latest output + open/answered questions):
+
+```http
+GET /branding/sessions/{session_id}
+```
+
+3. **Read open-question feed** for the session:
+
+```http
+GET /branding/sessions/{session_id}/questions
+```
+
+4. **Answer one question at a time**; the mission is updated and branding artifacts are regenerated:
+
+```http
+POST /branding/sessions/{session_id}/questions/{question_id}/answer
+```
+
+### Example session creation payload
 
 ```json
 {
@@ -40,7 +71,20 @@ Example payload:
       "asset_name": "Q3 product launch landing page",
       "asset_description": "Highlights measurable business outcomes with proof and concise messaging"
     }
-  ],
-  "human_approved": true
+  ]
 }
 ```
+
+### Example answer payload
+
+```json
+{
+  "answer": "Use clear, practical, and direct language for technical buyers"
+}
+```
+
+## Notes on session behavior
+
+- Sessions are currently stored **in memory** in the API process.
+- Restarting the API clears active session state.
+- Each answer is applied immediately to the mission context, then the orchestrator reruns to refresh output artifacts.

--- a/agents/branding_team/api/main.py
+++ b/agents/branding_team/api/main.py
@@ -2,7 +2,11 @@
 
 from __future__ import annotations
 
-from fastapi import FastAPI
+from dataclasses import dataclass
+from threading import Lock
+from uuid import uuid4
+
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
 from branding_team.models import BrandCheckRequest, BrandingMission, HumanReview, TeamOutput
@@ -25,9 +29,116 @@ class RunBrandingTeamRequest(BaseModel):
     human_feedback: str = ""
 
 
+class BrandingQuestion(BaseModel):
+    id: str
+    question: str
+    context: str
+    target_field: str
+    status: str = "open"
+    answer: str | None = None
+
+
+class BrandingSessionResponse(BaseModel):
+    session_id: str
+    status: str
+    mission: BrandingMission
+    latest_output: TeamOutput
+    open_questions: list[BrandingQuestion] = Field(default_factory=list)
+    answered_questions: list[BrandingQuestion] = Field(default_factory=list)
+
+
+class AnswerBrandingQuestionRequest(BaseModel):
+    answer: str = Field(..., min_length=1)
+
+
+@dataclass
+class BrandingSession:
+    mission: BrandingMission
+    questions: list[BrandingQuestion]
+    latest_output: TeamOutput
+
+
+class BrandingSessionStore:
+    def __init__(self) -> None:
+        self._sessions: dict[str, BrandingSession] = {}
+        self._lock = Lock()
+
+    def create(self, mission: BrandingMission, latest_output: TeamOutput) -> tuple[str, BrandingSession]:
+        questions = _build_open_questions(mission)
+        session_id = str(uuid4())
+        session = BrandingSession(mission=mission, questions=questions, latest_output=latest_output)
+        with self._lock:
+            self._sessions[session_id] = session
+        return session_id, session
+
+    def get(self, session_id: str) -> BrandingSession | None:
+        with self._lock:
+            return self._sessions.get(session_id)
+
+
+orchestrator = BrandingTeamOrchestrator()
+session_store = BrandingSessionStore()
+
+
+def _build_open_questions(mission: BrandingMission) -> list[BrandingQuestion]:
+    questions: list[BrandingQuestion] = []
+    if not mission.values:
+        questions.append(
+            BrandingQuestion(
+                id="core-values",
+                question="What are the 3-5 core brand values we should optimize for?",
+                context="These values are used in codification, compliance checks, and writing guidelines.",
+                target_field="values",
+            )
+        )
+    if not mission.differentiators:
+        questions.append(
+            BrandingQuestion(
+                id="differentiators",
+                question="What differentiators should the team emphasize against competitors?",
+                context="Differentiators influence positioning, narrative pillars, and asset reviews.",
+                target_field="differentiators",
+            )
+        )
+    questions.append(
+        BrandingQuestion(
+            id="voice-approval",
+            question="Do you approve the proposed brand voice, or what adjustment should be made?",
+            context="Voice decisions are applied to writing guidelines and future content assets.",
+            target_field="desired_voice",
+        )
+    )
+    return questions
+
+
+def _session_response(session_id: str, session: BrandingSession) -> BrandingSessionResponse:
+    open_questions = [q for q in session.questions if q.status == "open"]
+    answered_questions = [q for q in session.questions if q.status == "answered"]
+    status = "awaiting_user_answers" if open_questions else "ready_for_rollout"
+    return BrandingSessionResponse(
+        session_id=session_id,
+        status=status,
+        mission=session.mission,
+        latest_output=session.latest_output,
+        open_questions=open_questions,
+        answered_questions=answered_questions,
+    )
+
+
+def _apply_answer(mission: BrandingMission, question: BrandingQuestion, answer: str) -> BrandingMission:
+    normalized = answer.strip()
+    if question.target_field in {"values", "differentiators"}:
+        entries = [item.strip() for item in normalized.split(",") if item.strip()]
+        if question.target_field == "values":
+            return mission.model_copy(update={"values": entries})
+        return mission.model_copy(update={"differentiators": entries})
+    if question.target_field == "desired_voice":
+        return mission.model_copy(update={"desired_voice": normalized})
+    return mission
+
+
 @app.post("/branding/run", response_model=TeamOutput)
 def run_branding_team(payload: RunBrandingTeamRequest) -> TeamOutput:
-    orchestrator = BrandingTeamOrchestrator()
     mission = BrandingMission(
         company_name=payload.company_name,
         company_description=payload.company_description,
@@ -40,6 +151,70 @@ def run_branding_team(payload: RunBrandingTeamRequest) -> TeamOutput:
     )
     human_review = HumanReview(approved=payload.human_approved, feedback=payload.human_feedback)
     return orchestrator.run(mission=mission, human_review=human_review, brand_checks=payload.brand_checks)
+
+
+@app.post("/branding/sessions", response_model=BrandingSessionResponse)
+def create_branding_session(payload: RunBrandingTeamRequest) -> BrandingSessionResponse:
+    mission = BrandingMission(
+        company_name=payload.company_name,
+        company_description=payload.company_description,
+        target_audience=payload.target_audience,
+        values=payload.values,
+        differentiators=payload.differentiators,
+        desired_voice=payload.desired_voice,
+        existing_brand_material=payload.existing_brand_material,
+        wiki_path=payload.wiki_path,
+    )
+    output = orchestrator.run(
+        mission=mission,
+        human_review=HumanReview(approved=False, feedback="Interactive review started."),
+        brand_checks=payload.brand_checks,
+    )
+    session_id, session = session_store.create(mission=mission, latest_output=output)
+    return _session_response(session_id, session)
+
+
+@app.get("/branding/sessions/{session_id}", response_model=BrandingSessionResponse)
+def get_branding_session(session_id: str) -> BrandingSessionResponse:
+    session = session_store.get(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return _session_response(session_id, session)
+
+
+@app.get("/branding/sessions/{session_id}/questions", response_model=list[BrandingQuestion])
+def get_branding_questions(session_id: str) -> list[BrandingQuestion]:
+    session = session_store.get(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+    return [q for q in session.questions if q.status == "open"]
+
+
+@app.post("/branding/sessions/{session_id}/questions/{question_id}/answer", response_model=BrandingSessionResponse)
+def answer_branding_question(
+    session_id: str,
+    question_id: str,
+    payload: AnswerBrandingQuestionRequest,
+) -> BrandingSessionResponse:
+    session = session_store.get(session_id)
+    if not session:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    question = next((q for q in session.questions if q.id == question_id and q.status == "open"), None)
+    if not question:
+        raise HTTPException(status_code=404, detail="Open question not found")
+
+    question.status = "answered"
+    question.answer = payload.answer.strip()
+    session.mission = _apply_answer(session.mission, question, payload.answer)
+
+    open_questions = [q for q in session.questions if q.status == "open"]
+    human_review = HumanReview(
+        approved=not open_questions,
+        feedback="Answers applied and branding artifacts refreshed.",
+    )
+    session.latest_output = orchestrator.run(mission=session.mission, human_review=human_review)
+    return _session_response(session_id, session)
 
 
 @app.get("/health")

--- a/agents/branding_team/tests/test_api.py
+++ b/agents/branding_team/tests/test_api.py
@@ -1,0 +1,48 @@
+from fastapi.testclient import TestClient
+
+from branding_team.api.main import app
+
+
+client = TestClient(app)
+
+
+def _payload() -> dict:
+    return {
+        'company_name': 'Northstar Labs',
+        'company_description': 'A strategic studio helping product teams ship cohesive digital experiences',
+        'target_audience': 'enterprise product leaders',
+    }
+
+
+def test_create_session_and_get_questions() -> None:
+    create = client.post('/branding/sessions', json=_payload())
+    assert create.status_code == 200
+    data = create.json()
+    assert data['session_id']
+    assert data['status'] == 'awaiting_user_answers'
+    assert len(data['open_questions']) >= 1
+
+    questions = client.get(f"/branding/sessions/{data['session_id']}/questions")
+    assert questions.status_code == 200
+    assert questions.json()
+
+
+def test_answer_question_updates_session_and_output() -> None:
+    create = client.post('/branding/sessions', json=_payload())
+    session = create.json()
+    session_id = session['session_id']
+    question_id = session['open_questions'][0]['id']
+
+    answer = client.post(
+        f'/branding/sessions/{session_id}/questions/{question_id}/answer',
+        json={'answer': 'clarity, trust, craft'},
+    )
+    assert answer.status_code == 200
+    answered = answer.json()
+    assert any(item['id'] == question_id for item in answered['answered_questions'])
+    assert answered['latest_output']['brand_guidelines']
+
+
+def test_unknown_session_404() -> None:
+    resp = client.get('/branding/sessions/not-found')
+    assert resp.status_code == 404

--- a/user-interface/README.md
+++ b/user-interface/README.md
@@ -1,6 +1,6 @@
 # Strands Agents User Interface
 
-Angular application providing an interactive UI for all Strands agent APIs: Blogging, Software Engineering Team, Market Research, SOC2 Compliance, and Social Media Marketing.
+Angular application providing an interactive UI for all Strands agent APIs: Blogging, Software Engineering Team, Market Research, SOC2 Compliance, Social Media Marketing, and Branding.
 
 ## Prerequisites
 
@@ -32,6 +32,7 @@ API base URLs are configured in `src/environments/environment.ts` (development) 
 | Market Research | `http://localhost:8011` | 8011 |
 | SOC2 Compliance | `http://localhost:8020` | 8020 |
 | Social Media Marketing | `http://localhost:8010` | 8010 |
+| Branding | `http://localhost:8012` | 8012 |
 
 To override, edit `src/environments/environment.ts` before building.
 

--- a/user-interface/src/app/app.routes.ts
+++ b/user-interface/src/app/app.routes.ts
@@ -4,6 +4,7 @@ import { BloggingDashboardComponent } from './components/blogging-dashboard/blog
 import { MarketResearchDashboardComponent } from './components/market-research-dashboard/market-research-dashboard.component';
 import { Soc2ComplianceDashboardComponent } from './components/soc2-compliance-dashboard/soc2-compliance-dashboard.component';
 import { SocialMarketingDashboardComponent } from './components/social-marketing-dashboard/social-marketing-dashboard.component';
+import { BrandingDashboardComponent } from './components/branding-dashboard/branding-dashboard.component';
 import { SoftwareEngineeringDashboardComponent } from './components/software-engineering-dashboard/software-engineering-dashboard.component';
 
 export const routes: Routes = [
@@ -17,6 +18,7 @@ export const routes: Routes = [
       { path: 'market-research', component: MarketResearchDashboardComponent },
       { path: 'soc2-compliance', component: Soc2ComplianceDashboardComponent },
       { path: 'social-marketing', component: SocialMarketingDashboardComponent },
+      { path: 'branding', component: BrandingDashboardComponent },
     ],
   },
   { path: '**', redirectTo: '/blogging' },

--- a/user-interface/src/app/components/api-status-widget/api-status-widget.component.ts
+++ b/user-interface/src/app/components/api-status-widget/api-status-widget.component.ts
@@ -9,6 +9,7 @@ import { SoftwareEngineeringApiService } from '../../services/software-engineeri
 import { MarketResearchApiService } from '../../services/market-research-api.service';
 import { Soc2ComplianceApiService } from '../../services/soc2-compliance-api.service';
 import { SocialMarketingApiService } from '../../services/social-marketing-api.service';
+import { BrandingApiService } from '../../services/branding-api.service';
 
 interface ApiStatus {
   name: string;
@@ -16,7 +17,7 @@ interface ApiStatus {
 }
 
 /**
- * Widget showing health status of all 5 agent APIs.
+ * Widget showing health status of all agent APIs.
  */
 @Component({
   selector: 'app-api-status-widget',
@@ -34,7 +35,8 @@ export class ApiStatusWidgetComponent implements OnInit {
     private readonly softwareEngineering: SoftwareEngineeringApiService,
     private readonly marketResearch: MarketResearchApiService,
     private readonly soc2: Soc2ComplianceApiService,
-    private readonly socialMarketing: SocialMarketingApiService
+    private readonly socialMarketing: SocialMarketingApiService,
+    private readonly branding: BrandingApiService
   ) {}
 
   ngOnInit(): void {
@@ -59,6 +61,10 @@ export class ApiStatusWidgetComponent implements OnInit {
         map((r) => r?.status === 'ok'),
         catchError(() => of(false))
       ),
+      branding: this.branding.health().pipe(
+        map((r) => r?.status === 'ok'),
+        catchError(() => of(false))
+      ),
     }).subscribe((res) => {
       this.statuses = [
         { name: 'Blogging', ok: res.blogging },
@@ -66,6 +72,7 @@ export class ApiStatusWidgetComponent implements OnInit {
         { name: 'Market Research', ok: res.marketResearch },
         { name: 'SOC2 Compliance', ok: res.soc2 },
         { name: 'Social Marketing', ok: res.socialMarketing },
+        { name: 'Branding', ok: res.branding },
       ];
       this.loading = false;
     });

--- a/user-interface/src/app/components/app-shell/app-shell.component.html
+++ b/user-interface/src/app/components/app-shell/app-shell.component.html
@@ -32,6 +32,10 @@
         <mat-icon matListItemIcon>campaign</mat-icon>
         <span matListItemTitle>Social Marketing</span>
       </a>
+      <a mat-list-item routerLink="/branding" routerLinkActive="active" [attr.aria-current]="isActive('/branding') ? 'page' : null">
+        <mat-icon matListItemIcon>style</mat-icon>
+        <span matListItemTitle>Branding</span>
+      </a>
     </nav>
   </mat-sidenav>
   <mat-sidenav-content>

--- a/user-interface/src/app/components/app-shell/app-shell.component.ts
+++ b/user-interface/src/app/components/app-shell/app-shell.component.ts
@@ -9,7 +9,7 @@ import { ApiStatusWidgetComponent } from '../api-status-widget/api-status-widget
 
 /**
  * Application shell with sidebar navigation and main content area.
- * Provides links to all five agent API features.
+ * Provides links to all available agent API features.
  */
 @Component({
   selector: 'app-app-shell',

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.html
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.html
@@ -1,0 +1,95 @@
+<h1>Branding Team API</h1>
+<p>Interactive async branding workflow with a live open-question feed.</p>
+
+<div class="header-row">
+  <app-health-indicator [healthCheck]="healthCheck" label="Branding API" />
+</div>
+
+@if (loading) {
+  <app-loading-spinner message="Processing branding workflow..." />
+}
+
+@if (error) {
+  <app-error-message [message]="error" />
+}
+
+<mat-card>
+  <mat-card-header>
+    <mat-card-title>Start Branding Session</mat-card-title>
+  </mat-card-header>
+  <mat-card-content>
+    <form [formGroup]="form" (ngSubmit)="startSession()" class="session-form">
+      <mat-form-field appearance="outline">
+        <mat-label>Company name</mat-label>
+        <input matInput formControlName="company_name" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Company description</mat-label>
+        <textarea matInput rows="3" formControlName="company_description"></textarea>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Target audience</mat-label>
+        <input matInput formControlName="target_audience" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Desired voice</mat-label>
+        <input matInput formControlName="desired_voice" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Values (comma-separated)</mat-label>
+        <input matInput formControlName="values_csv" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline">
+        <mat-label>Differentiators (comma-separated)</mat-label>
+        <input matInput formControlName="differentiators_csv" />
+      </mat-form-field>
+
+      <button mat-raised-button color="primary" type="submit">Start Session</button>
+    </form>
+  </mat-card-content>
+</mat-card>
+
+@if (session) {
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>Open Questions Feed</mat-card-title>
+      <mat-card-subtitle>Status: {{ session.status }}</mat-card-subtitle>
+    </mat-card-header>
+    <mat-card-content>
+      @if (session.open_questions.length === 0) {
+        <p>All open questions answered. Branding output is refreshed and ready.</p>
+      } @else {
+        @for (question of session.open_questions; track question.id) {
+          <div class="question-item">
+            <h3>{{ question.question }}</h3>
+            <p>{{ question.context }}</p>
+            <mat-form-field appearance="outline" class="answer-field">
+              <mat-label>Your answer</mat-label>
+              <textarea matInput rows="2" [(ngModel)]="answers[question.id]" [ngModelOptions]="{standalone: true}"></textarea>
+            </mat-form-field>
+            <button mat-stroked-button color="primary" (click)="submitAnswer(question)">Submit Answer</button>
+          </div>
+        }
+      }
+    </mat-card-content>
+  </mat-card>
+
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>Updated Branding Guidelines</mat-card-title>
+    </mat-card-header>
+    <mat-card-content>
+      <p>{{ session.latest_output.mission_summary }}</p>
+      <ul>
+        @for (item of session.latest_output.brand_guidelines; track item) {
+          <li>{{ item }}</li>
+        }
+      </ul>
+    </mat-card-content>
+  </mat-card>
+}

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.scss
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.scss
@@ -1,0 +1,23 @@
+.session-form {
+  display: grid;
+  gap: 12px;
+}
+
+mat-form-field {
+  width: 100%;
+}
+
+mat-card {
+  margin-bottom: 16px;
+}
+
+.question-item {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  padding: 12px;
+  margin-bottom: 12px;
+}
+
+.answer-field {
+  width: 100%;
+}

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
@@ -1,0 +1,128 @@
+import { Component, OnDestroy, inject } from '@angular/core';
+import { FormBuilder, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
+import { interval, Subscription, switchMap } from 'rxjs';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { BrandingApiService } from '../../services/branding-api.service';
+import { LoadingSpinnerComponent } from '../../shared/loading-spinner/loading-spinner.component';
+import { ErrorMessageComponent } from '../../shared/error-message/error-message.component';
+import { HealthIndicatorComponent } from '../health-indicator/health-indicator.component';
+import type { BrandingQuestion, BrandingSessionResponse, RunBrandingTeamRequest } from '../../models';
+
+@Component({
+  selector: 'app-branding-dashboard',
+  standalone: true,
+  imports: [
+    FormsModule,
+    ReactiveFormsModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    LoadingSpinnerComponent,
+    ErrorMessageComponent,
+    HealthIndicatorComponent,
+  ],
+  templateUrl: './branding-dashboard.component.html',
+  styleUrl: './branding-dashboard.component.scss',
+})
+export class BrandingDashboardComponent implements OnDestroy {
+  private readonly api = inject(BrandingApiService);
+  private readonly fb = inject(FormBuilder);
+
+  loading = false;
+  error: string | null = null;
+  session: BrandingSessionResponse | null = null;
+  answers: Record<string, string> = {};
+  private pollSub: Subscription | null = null;
+
+  form = this.fb.nonNullable.group({
+    company_name: ['', [Validators.required, Validators.minLength(2)]],
+    company_description: ['', [Validators.required, Validators.minLength(10)]],
+    target_audience: ['', [Validators.required, Validators.minLength(3)]],
+    desired_voice: ['clear, confident, human', [Validators.required]],
+    values_csv: [''],
+    differentiators_csv: [''],
+  });
+
+  healthCheck = (): ReturnType<BrandingApiService['health']> => this.api.health();
+
+  ngOnDestroy(): void {
+    this.pollSub?.unsubscribe();
+  }
+
+  startSession(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+
+    const raw = this.form.getRawValue();
+    const request: RunBrandingTeamRequest = {
+      company_name: raw.company_name,
+      company_description: raw.company_description,
+      target_audience: raw.target_audience,
+      desired_voice: raw.desired_voice,
+      values: raw.values_csv.split(',').map((v) => v.trim()).filter((v) => !!v),
+      differentiators: raw.differentiators_csv.split(',').map((v) => v.trim()).filter((v) => !!v),
+    };
+
+    this.loading = true;
+    this.error = null;
+    this.api.createSession(request).subscribe({
+      next: (res) => {
+        this.session = res;
+        this.loading = false;
+        this.startPolling();
+      },
+      error: (err) => {
+        this.error = err?.error?.detail ?? err?.message ?? 'Failed to start branding session';
+        this.loading = false;
+      },
+    });
+  }
+
+  submitAnswer(question: BrandingQuestion): void {
+    if (!this.session) return;
+    const answer = (this.answers[question.id] ?? '').trim();
+    if (!answer) return;
+
+    this.loading = true;
+    this.error = null;
+    this.api.answerQuestion(this.session.session_id, question.id, answer).subscribe({
+      next: (res) => {
+        this.session = res;
+        this.answers[question.id] = '';
+        this.loading = false;
+      },
+      error: (err) => {
+        this.error = err?.error?.detail ?? err?.message ?? 'Failed to submit answer';
+        this.loading = false;
+      },
+    });
+  }
+
+  private startPolling(): void {
+    this.pollSub?.unsubscribe();
+    if (!this.session?.session_id) {
+      return;
+    }
+    this.pollSub = interval(3000)
+      .pipe(switchMap(() => this.api.getSession(this.session!.session_id)))
+      .subscribe({
+        next: (res) => {
+          this.session = res;
+          if (res.open_questions.length === 0) {
+            this.pollSub?.unsubscribe();
+            this.pollSub = null;
+          }
+        },
+        error: () => {
+          this.pollSub?.unsubscribe();
+          this.pollSub = null;
+        },
+      });
+  }
+}

--- a/user-interface/src/app/models/branding.model.ts
+++ b/user-interface/src/app/models/branding.model.ts
@@ -1,0 +1,43 @@
+export interface BrandCheckRequest {
+  asset_name: string;
+  asset_description: string;
+}
+
+export interface RunBrandingTeamRequest {
+  company_name: string;
+  company_description: string;
+  target_audience: string;
+  values?: string[];
+  differentiators?: string[];
+  desired_voice?: string;
+  existing_brand_material?: string[];
+  wiki_path?: string | null;
+  brand_checks?: BrandCheckRequest[];
+  human_approved?: boolean;
+  human_feedback?: string;
+}
+
+export interface BrandingQuestion {
+  id: string;
+  question: string;
+  context: string;
+  target_field: string;
+  status: string;
+  answer?: string | null;
+}
+
+export interface BrandingSessionResponse {
+  session_id: string;
+  status: string;
+  mission: RunBrandingTeamRequest;
+  latest_output: {
+    status: string;
+    mission_summary: string;
+    brand_guidelines: string[];
+    writing_guidelines: {
+      voice_principles: string[];
+    };
+  };
+  open_questions: BrandingQuestion[];
+  answered_questions: BrandingQuestion[];
+}

--- a/user-interface/src/app/models/index.ts
+++ b/user-interface/src/app/models/index.ts
@@ -5,3 +5,5 @@ export * from './software-engineering.model';
 export * from './market-research.model';
 export * from './soc2-compliance.model';
 export * from './social-marketing.model';
+
+export * from './branding.model';

--- a/user-interface/src/app/services/branding-api.service.spec.ts
+++ b/user-interface/src/app/services/branding-api.service.spec.ts
@@ -1,0 +1,62 @@
+import { TestBed } from '@angular/core/testing';
+import {
+  HttpClientTestingModule,
+  HttpTestingController,
+} from '@angular/common/http/testing';
+import { BrandingApiService } from './branding-api.service';
+import { environment } from '../../environments/environment';
+
+describe('BrandingApiService', () => {
+  let service: BrandingApiService;
+  let httpMock: HttpTestingController;
+  const baseUrl = environment.brandingApiUrl;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [BrandingApiService],
+    });
+    service = TestBed.inject(BrandingApiService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('should call POST /branding/sessions', () => {
+    service
+      .createSession({
+        company_name: 'Acme',
+        company_description: 'Brand strategy for SMB fintech',
+        target_audience: 'Founders',
+      })
+      .subscribe((res) => expect(res.session_id).toBe('s1'));
+
+    const req = httpMock.expectOne(`${baseUrl}/branding/sessions`);
+    expect(req.request.method).toBe('POST');
+    req.flush({
+      session_id: 's1',
+      status: 'awaiting_user_answers',
+      mission: {},
+      latest_output: { status: 'needs_human_decision', mission_summary: '', brand_guidelines: [], writing_guidelines: { voice_principles: [] } },
+      open_questions: [],
+      answered_questions: [],
+    });
+  });
+
+  it('should call POST question answer endpoint', () => {
+    service.answerQuestion('s1', 'q1', 'clarity, trust').subscribe();
+    const req = httpMock.expectOne(`${baseUrl}/branding/sessions/s1/questions/q1/answer`);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body.answer).toBe('clarity, trust');
+    req.flush({
+      session_id: 's1',
+      status: 'ready_for_rollout',
+      mission: {},
+      latest_output: { status: 'ready_for_rollout', mission_summary: '', brand_guidelines: [], writing_guidelines: { voice_principles: [] } },
+      open_questions: [],
+      answered_questions: [],
+    });
+  });
+});

--- a/user-interface/src/app/services/branding-api.service.ts
+++ b/user-interface/src/app/services/branding-api.service.ts
@@ -1,0 +1,39 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+import type {
+  BrandingQuestion,
+  BrandingSessionResponse,
+  RunBrandingTeamRequest,
+  HealthResponse,
+} from '../models';
+
+@Injectable({ providedIn: 'root' })
+export class BrandingApiService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = environment.brandingApiUrl;
+
+  createSession(request: RunBrandingTeamRequest): Observable<BrandingSessionResponse> {
+    return this.http.post<BrandingSessionResponse>(`${this.baseUrl}/branding/sessions`, request);
+  }
+
+  getSession(sessionId: string): Observable<BrandingSessionResponse> {
+    return this.http.get<BrandingSessionResponse>(`${this.baseUrl}/branding/sessions/${sessionId}`);
+  }
+
+  getOpenQuestions(sessionId: string): Observable<BrandingQuestion[]> {
+    return this.http.get<BrandingQuestion[]>(`${this.baseUrl}/branding/sessions/${sessionId}/questions`);
+  }
+
+  answerQuestion(sessionId: string, questionId: string, answer: string): Observable<BrandingSessionResponse> {
+    return this.http.post<BrandingSessionResponse>(
+      `${this.baseUrl}/branding/sessions/${sessionId}/questions/${questionId}/answer`,
+      { answer }
+    );
+  }
+
+  health(): Observable<HealthResponse> {
+    return this.http.get<HealthResponse>(`${this.baseUrl}/health`);
+  }
+}

--- a/user-interface/src/environments/environment.prod.ts
+++ b/user-interface/src/environments/environment.prod.ts
@@ -9,4 +9,5 @@ export const environment = {
   marketResearchApiUrl: '/api/market-research',
   soc2ComplianceApiUrl: '/api/soc2-compliance',
   socialMarketingApiUrl: '/api/social-marketing',
+  brandingApiUrl: '/api/branding',
 };

--- a/user-interface/src/environments/environment.ts
+++ b/user-interface/src/environments/environment.ts
@@ -14,4 +14,6 @@ export const environment = {
   soc2ComplianceApiUrl: 'http://localhost:8020',
   /** Social Media Marketing Team API - default port 8010 */
   socialMarketingApiUrl: 'http://localhost:8010',
+  /** Branding Team API - default port 8012 */
+  brandingApiUrl: 'http://localhost:8012',
 };


### PR DESCRIPTION
### Motivation
- Improve discoverability and developer UX for the newly added interactive asynchronous Branding session workflow by documenting how to create and manage sessions. 
- Clearly list the related API endpoints, example payloads, and runtime behavior (in-memory sessions and artifact refresh on answers). 
- Surface the Branding API in the UI documentation and top-level repo docs so local developers know the default ports and startup commands.

### Description
- Updated `agents/branding_team/README.md` to document the interactive workflow including `POST /branding/sessions`, `GET /branding/sessions/{id}`, `GET /branding/sessions/{id}/questions`, `POST /branding/sessions/{id}/questions/{question_id}/answer`, example payloads, and notes about in-memory session lifecycle. 
- Updated `user-interface/README.md` to include Branding in the supported APIs list and added the default Branding API URL/port (`http://localhost:8012`). 
- Updated top-level `README.md` and `agents/README.md` to include the Branding team in the project overview, add the local startup command for the Branding API, include the `branding_team/` directory in project structure, and update default port allocation guidance. 
- Committed the documentation changes on the current branch and prepared PR metadata describing the doc updates.

### Testing
- Verified diffs and content changes with `git diff` and inspected files using `nl`/`sed` to confirm the expected edits to `agents/branding_team/README.md`, `user-interface/README.md`, `README.md`, and `agents/README.md` (succeeded). 
- Created a commit (`git commit`) and recorded the PR entry confirming the documentation update (succeeded). 
- No runtime or unit test executions were required for these documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699955ad0128832ebe61477369c4dc31)