### PR TITLE
feat(frontend-team): support contract-first React + Angular execution in frontend coding agent

### DIFF
--- a/agents/software_engineering_team/frontend_team/README.md
+++ b/agents/software_engineering_team/frontend_team/README.md
@@ -1,25 +1,48 @@
 # Frontend Team
 
-Frontend sub-orchestration for the software engineering team. Runs the full pipeline from design through implementation, quality gates, and build/release for each frontend task.
+Frontend sub-orchestration for the software engineering team. Runs a contract-first pipeline from clarification through implementation, quality gates, and handoff for frontend tasks.
+
+## Objective
+
+Operate like an expert front-end squad that can take implementation-ready tasks from planning/design agents and deliver merge-ready React or Angular code with strong UX, accessibility, performance, API/state integration, and testing discipline.
+
+## Design Principles
+
+1. **Contract-first execution**: every task should include user goal, scoped UI behavior, interaction states, ACs, framework target, styling constraints, and accessibility requirements.
+2. **Design/code collaboration**: micro UI decisions are allowed only within design-system guardrails and must be documented as assumptions.
+3. **Framework-native implementation**: React and Angular paths share concepts but must follow native framework idioms.
+4. **State/API are first-class**: a feature is incomplete without loading/error/empty states, robust data flow, and safe API handling.
+5. **Hard quality gates**: AC coverage, tests, accessibility review, code review, and design-system compliance are required before merge.
 
 ## Agent Roster
 
 | Agent | Role |
 |-------|------|
+| **Frontend Team Lead (Orchestrator)** | Task intake, framework path selection, sequencing, and gate enforcement |
+| **Frontend Task Clarifier** | Validates task completeness and kicks back unclear requests |
+| **Micro UI Design Agent** | Small, bounded UI layout/composition decisions within design system |
+| **UX Interaction Agent** | Defines interaction flows, transitions, and keyboard/focus behavior |
 | **UX Designer** | User flows, interaction patterns, and experience design from task and spec |
 | **UI Designer** | Visual design and component specs; consumes UX output |
 | **Design System** | Component library alignment and consistency |
 | **Frontend Architect** | Technical architecture decisions (structure, patterns, state management) |
-| **Feature Agent** | Implementation (FrontendExpertAgent); generates Angular/TypeScript code |
+| **React Implementation Agent** | Production-grade React implementation (hooks/state/forms/tests) |
+| **Angular Implementation Agent** | Production-grade Angular implementation (RxJS/reactive forms/tests) |
+| **Feature Agent** | Primary coding agent (FrontendExpertAgent) using framework target from task input |
+| **State Management Agent** | Local/shared/server state design and invariants |
+| **API Integration Agent** | Typed DTO mapping, API client integration, error mapping |
+| **Front-End Test Engineer** | AC-to-test trace, unit/component/integration coverage |
+| **Front-End Code Review Agent** | Senior framework-fit and maintainability review |
 | **UX Engineer** | Polish pass: micro-interactions, consistency, UX refinement |
 | **Performance Engineer** | Bundle size, rendering optimization, performance review |
 | **Build/Release** | CI/CD and release planning; writes `plan/frontend_build_release.md` |
 | **Accessibility Agent** | WCAG 2.2 compliance; reviews frontend per task |
+| **Documentation & Handoff Agent** | Completion package, QA notes, and git provenance metadata |
 
 ## Pipeline Order
 
 ```
-UX Designer → UI Designer → Design System → Frontend Architect → Feature Implementation → UX Engineer → Performance Engineer → Build/Release
+Team Lead → Task Clarifier → Micro UI Design → UX Interaction → Design System/State/API planning → Framework Implementation (React or Angular) → UX Engineer → Performance → Quality Gates → Build/Release → Handoff
 ```
 
 Design phase (UX → UI → Design System) is **skipped for lightweight tasks** (fix, patch, refactor, etc.) to speed up implementation-only work.
@@ -38,6 +61,34 @@ The frontend workflow invokes cross-cutting agents from [quality_gates/](../qual
 ## Lightweight Task Path
 
 Tasks with keywords like `fix`, `resolve`, `update`, `patch`, `refactor` and short descriptions skip the design phase. The orchestrator goes directly to Frontend Architect → Feature Implementation → quality gates.
+
+## Required Task Input
+
+Frontend tasks are expected to carry the normalized contract fields below:
+
+- `task_id`, `title`, `priority`, `framework_target` (`react` | `angular` | `either`)
+- `repo_context` (app + module paths)
+- `goal.summary`
+- `scope.included` and `scope.excluded`
+- `constraints` (framework versions, styling system, form handling, API contract ref)
+- `acceptance_criteria`
+- `non_functional_requirements` (performance, accessibility, analytics)
+- `dependencies`
+- `test_requirements`
+- `risk_flags`
+
+If these are missing or vague, the Task Clarifier should return specific clarification requests before coding begins.
+
+## Completion Package Output
+
+Each completed task should include:
+
+- `task_id`, `status`, `framework_used`
+- `files_changed`
+- `acceptance_criteria_trace` (criterion -> implementation refs + tests)
+- `quality_gates` status (lint/types/tests/a11y/ux/review)
+- `notes`, `risks_remaining`
+- `git_operations` (branch, commits, merge metadata)
 
 ## See Also
 

--- a/agents/software_engineering_team/frontend_team/feature_agent/agent.py
+++ b/agents/software_engineering_team/frontend_team/feature_agent/agent.py
@@ -1,4 +1,4 @@
-"""Frontend Expert agent: Angular implementation."""
+"""Frontend Expert agent: framework-native frontend implementation (React/Angular)."""
 
 from __future__ import annotations
 
@@ -186,7 +186,7 @@ _ANGULAR_PROBLEM_SOLVING_INSTRUCTIONS = (
 
 class FrontendExpertAgent:
     """
-    Frontend expert that implements solutions using Angular.
+    Frontend expert that implements framework-native solutions for React or Angular.
     Validates output to ensure proper naming conventions and project structure.
     """
 
@@ -246,7 +246,7 @@ class FrontendExpertAgent:
             return ""
 
     def run(self, input_data: FrontendInput) -> FrontendOutput:
-        """Implement frontend functionality in Angular."""
+        """Implement frontend functionality in the requested framework target."""
         logger.info(
             "Frontend: received task - description=%s | requirements=%s | user_story=%s | "
             "has_architecture=%s | has_existing_code=%s | has_api_endpoints=%s | has_spec=%s | "
@@ -269,7 +269,10 @@ class FrontendExpertAgent:
         code_review_count = len(input_data.code_review_issues) if input_data.code_review_issues else 0
         has_issues = qa_count > 0 or security_count > 0 or accessibility_count > 0 or code_review_count > 0
 
-        context_parts: List[str] = []
+        framework_target = (input_data.framework_target or "angular").lower().strip()
+        framework_label = "Frontend / React" if framework_target == "react" else "Frontend / Angular"
+
+        context_parts: List[str] = [f"**Framework target:** {framework_target}"]
         if has_issues:
             issue_summaries: Dict[str, int] = {}
             if qa_count:
@@ -298,7 +301,7 @@ class FrontendExpertAgent:
                 )
             header = build_problem_solving_header(
                 issue_summaries,
-                "Frontend / Angular",
+                framework_label,
                 instructions=_ANGULAR_PROBLEM_SOLVING_INSTRUCTIONS,
                 issue_descriptions=issue_descriptions,
             )
@@ -516,6 +519,7 @@ class FrontendExpertAgent:
         npm_packages = [str(p).strip() for p in npm_packages if str(p).strip()]
 
         return FrontendOutput(
+            framework_used=(data.get("framework_used") or framework_target),
             code=code,
             summary=summary,
             files=validated_files,
@@ -654,6 +658,7 @@ class FrontendExpertAgent:
                             logger.warning("[%s] Failed to persist plan (non-blocking): %s", task_id, e)
 
             result = self.run(FrontendInput(
+                framework_target=str((current_task.metadata or {}).get("framework_target", "angular")),
                 task_description=current_task.description,
                 requirements=_task_requirements_with_route_expectations(current_task, repo_path),
                 user_story=getattr(current_task, "user_story", "") or "",

--- a/agents/software_engineering_team/frontend_team/feature_agent/models.py
+++ b/agents/software_engineering_team/frontend_team/feature_agent/models.py
@@ -10,6 +10,10 @@ from shared.models import SystemArchitecture
 class FrontendInput(BaseModel):
     """Input for the Frontend Expert agent."""
 
+    framework_target: str = Field(
+        default="angular",
+        description="Target frontend framework for implementation: react | angular | either",
+    )
     task_description: str
     requirements: str = ""
     user_story: str = Field(
@@ -49,6 +53,10 @@ class FrontendInput(BaseModel):
         description="Implementation plan from _plan_task(). When present, the model must implement "
         "the task according to this plan (realize what_changes and tests_needed).",
     )
+    task_contract: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Normalized contract-first frontend task payload (goal/scope/constraints/ACs/NFRs).",
+    )
     convergence_hint: Optional[str] = Field(
         default=None,
         description="Optional hint when code review issue count has not decreased over several rounds. "
@@ -59,6 +67,7 @@ class FrontendInput(BaseModel):
 class FrontendOutput(BaseModel):
     """Output from the Frontend Expert agent."""
 
+    framework_used: str = Field(default="", description="Framework path used for implementation")
     code: str = ""
     summary: str = ""
     files: Dict[str, str] = Field(default_factory=dict)

--- a/agents/software_engineering_team/frontend_team/feature_agent/prompts.py
+++ b/agents/software_engineering_team/frontend_team/feature_agent/prompts.py
@@ -2,7 +2,7 @@
 
 from shared.coding_standards import CODING_STANDARDS
 
-FRONTEND_PLANNING_PROMPT = """You are a Senior Frontend Software Engineer expert in Angular. Before implementing a task, you produce a concise implementation plan.
+FRONTEND_PLANNING_PROMPT = """You are a Senior Frontend Software Engineer operating in a contract-first frontend team for React and Angular. Before implementing a task, you produce a concise implementation plan.
 
 **Your task:** Review the task, requirements, existing codebase, spec, and API endpoints (if provided). Produce a structured plan that will guide the implementation step.
 
@@ -16,25 +16,29 @@ For trivial tasks (e.g. fix a single binding), a minimal plan is fine.
 
 **CRITICAL:** Respond with valid JSON only. No markdown fences, no text before or after. Escape newlines in strings as \\n."""
 
-FRONTEND_PROMPT = """You are a Senior Frontend Software Engineer expert in Angular. You implement production-quality Angular applications with proper project structure and naming conventions.
+FRONTEND_PROMPT = """You are a Senior Frontend Software Engineer expert in React and Angular. You implement production-quality frontend applications with framework-native structure and naming conventions.
 
 """ + CODING_STANDARDS + """
 
 **Your expertise:**
-- Angular (standalone components, signals, reactive forms)
-- TypeScript, RxJS, Observables
-- REST API integration, state management
-- Accessibility (a11y), responsive design
-- Testing (Jasmine, Karma, Cypress)
-- Angular CLI project structure and conventions
+- React 18+ (hooks, composition, React Query, react-hook-form/zod)
+- Angular 17+ (standalone components, RxJS, reactive forms)
+- TypeScript, state management, REST API integration
+- Accessibility (a11y), responsive design, UX interaction quality
+- Testing (RTL/Jest/Vitest and Jasmine/Karma/Cypress as applicable)
+
+**Contract-first execution:**
+- Treat every task as a contract: user goal, exact scope, behavior states, acceptance criteria, framework target, styling constraints, and accessibility requirements.
+- If required fields are missing or vague, request clarification instead of guessing.
+- Micro UI design decisions are allowed only within design-system constraints and must be documented as assumptions.
 
 **CRITICAL CONSTRAINTS -- FRONTEND ONLY:**
 - You are a FRONTEND-ONLY agent. Everything you produce MUST run in a web browser.
 - NEVER write Python, Java, or any server-side/backend code. You do NOT write APIs, routes, database models, or server middleware.
-- ONLY produce files with these extensions: .ts, .html, .scss, .css, .json, .spec.ts
-- ALL file paths MUST start with "src/" (Angular project root). Any file outside src/ is WRONG.
-- For data, ALWAYS connect to REST API endpoints provided by the Backend Engineer. Use Angular's HttpClient to call the API. NEVER implement your own backend, database, or server logic.
-- If API endpoint details are not provided, define an Angular service with placeholder endpoint URLs and document them with TODO comments for later integration.
+- ONLY produce frontend assets/code (.ts/.tsx/.js/.jsx/.html/.scss/.css/.json/.spec.ts/.test.tsx).
+- Use repository-native frontend paths (commonly `src/`); do not write backend/server files.
+- For data, ALWAYS connect to existing API endpoints via the project's API client pattern (React Query/SWR/fetch wrapper or Angular HttpClient service). NEVER implement backend logic.
+- If API contract details are missing, add TODO contract assumptions and request clarification when ambiguity affects behavior.
 
 **PROJECT SCAFFOLDING (already provided):**
 The base Angular project is automatically initialized before your first task runs. You can rely on the following being already set up:
@@ -49,6 +53,7 @@ The base Angular project is automatically initialized before your first task run
 Do NOT recreate these files unless you need to modify them (e.g. adding new routes to `app.routes.ts`). Build on top of the existing scaffolding. When calling APIs, use `environment.apiUrl` (or `environment.production`) instead of hardcoding URLs.
 
 **Input:**
+- framework_target: react | angular | either (use framework-native implementation and tests)
 - Task description and requirements
 - Project specification (the full spec for the application being built)
 - Optional: Implementation plan – when present, you MUST implement the task according to that plan. Your "files" output must realize every item under "What changes" and "Tests needed", and use the algorithms/data structures described. The plan is the authoritative guide; do not deviate unless the task description explicitly contradicts it.
@@ -152,15 +157,16 @@ If a task covers more than 2-3 components or multiple pages/features, it is TOO 
 If a task is for a single component, page, or service, implement it fully.
 
 **Your task:**
-Implement the requested frontend functionality using Angular. When qa_issues, security_issues, or accessibility_issues are provided, implement the fixes described in each issue's "recommendation" field. Modify the existing code accordingly. When code_review_issues are provided, resolve each issue. Follow the architecture when provided. Produce production-quality code that STRICTLY adheres to the coding standards above:
+Implement the requested frontend functionality using the provided framework_target (React or Angular). When qa_issues, security_issues, or accessibility_issues are provided, implement the fixes described in each issue's "recommendation" field. Modify the existing code accordingly. When code_review_issues are provided, resolve each issue. Follow the architecture when provided. Produce production-quality code that STRICTLY adheres to the coding standards above:
 - Design by Contract on all public methods and services
 - SOLID principles (especially SRP, DIP in component/service design)
 - JSDoc on every class, component, and method (how used, why it exists, constraints)
 - Unit/component tests achieving at least 85% coverage
-- Code must compile with `ng build` without errors (requires Node v20.19+ or v22.12+; use NVM and `.nvmrc` in the project). If you add or generate any `.spec.ts` file, include `"@types/jasmine"` in `npm_packages_to_install` so Jasmine globals (describe, it, expect, spyOn) are typed and the build does not fail with "Cannot find name 'describe'", "'it'", or "'expect'".
+- Code must pass the project's framework-native type/lint/build checks (React or Angular). If you add Jasmine-based `.spec.ts` files, include `"@types/jasmine"` in `npm_packages_to_install` so globals are typed.
 
 **Output format:**
 Return a single JSON object with:
+- "framework_used": string (`react` or `angular`)
 - "code": string (can be empty if "files" is fully populated)
 - "summary": string (what you implemented and how it integrates with the existing app)
 - "files": object with FULL file paths as keys (e.g. "src/app/components/task-list/task-list.component.ts") and complete file content as values. REQUIRED - must not be empty.
@@ -182,7 +188,7 @@ Return a single JSON object with:
 - Conflicting requirements
 Do NOT guess—request clarification. If the task is clear and focused enough to implement, set needs_clarification=false and provide full implementation.
 
-Ensure code follows Angular best practices. Use standalone components. All code must be complete and compilable.
+Ensure code follows framework-native best practices for the selected target (React or Angular). All code must be complete and compilable.
 
 **Output (CRITICAL):** Respond with valid JSON only. You MUST respond with exactly one JSON object; no markdown fences, no text before or after. The object MUST include a "files" key mapping file paths (e.g. "src/app/components/task-list/task-list.component.ts") to full file contents. Without a valid "files" object the task will fail (no files to write). Escape newlines in code as \\n.
 


### PR DESCRIPTION
### Motivation

- Align the frontend team implementation with a contract-first, framework-aware operating model so tasks explicitly carry `framework_target` and full UI contracts before coding begins.
- Enable the feature agent to implement React or Angular natively and to surface the chosen framework in its outputs for clearer provenance and downstream tooling.

### Description

- Updated the frontend team documentation to a contract-first React+Angular operating model with expanded role roster, required task input fields, and completion package expectations (`agents/software_engineering_team/frontend_team/README.md`).
- Extended the feature-agent prompt set to accept and require `framework_target` (``react``|``angular``|``either``), to emphasize contract-first guidance, and to permit framework-native frontend assets in instruction text (`agents/.../feature_agent/prompts.py`).
- Added `framework_target` and optional `task_contract` to `FrontendInput`, and added `framework_used` to `FrontendOutput` so the agent can record which framework path it used (`agents/.../feature_agent/models.py`).
- Updated runtime logic to inject the framework target into the LLM prompt/problem-solving header, to use a framework-aware label in problem-solving mode, to propagate `framework_target` from task metadata into `run()`, and to default `framework_used` from the LLM response (`agents/.../feature_agent/agent.py`).

### Testing

- Ran `pytest -q agents/software_engineering_team/tests/test_frontend_agent.py` and all tests passed (30 passed).
- Ran `pytest -q agents/software_engineering_team/tests/test_frontend_team.py` and all tests passed (8 passed).
- Executed the focused test `pytest -q agents/software_engineering_team/tests/test_frontend_agent.py::test_frontend_agent_includes_problem_solving_header_when_issues_present` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a29a07654832e801bb5451d4f0a2c)