### PR TITLE
Add frontend_agent_v2 team with API and UI integration (v2)

### DIFF
--- a/agents/software_engineering_team/api/main.py
+++ b/agents/software_engineering_team/api/main.py
@@ -579,6 +579,49 @@ class BackendCodeV2StatusResponse(BaseModel):
     summary: Optional[str] = None
 
 
+class FrontendAgentV2TaskInput(BaseModel):
+    """Task input for frontend-agent-v2."""
+
+    id: str = Field(default="", description="Task ID (auto-generated if empty)")
+    title: str = Field(default="", description="Short task title")
+    description: str = Field(default="", description="Detailed description")
+    requirements: str = Field(default="", description="Technical requirements")
+    acceptance_criteria: List[str] = Field(default_factory=list, description="Acceptance criteria list")
+
+
+class FrontendAgentV2RunRequest(BaseModel):
+    """Request body for POST /frontend-agent-v2/run."""
+
+    task: FrontendAgentV2TaskInput = Field(..., description="Task to implement")
+    repo_path: str = Field(..., description="Local path to the repository")
+    spec_content: Optional[str] = Field(None, description="Optional project spec context")
+    architecture: Optional[str] = Field(None, description="Optional architecture overview")
+
+
+class FrontendAgentV2RunResponse(BaseModel):
+    """Response from POST /frontend-agent-v2/run."""
+
+    job_id: str = Field(..., description="Job ID for polling status")
+    status: str = Field(default="running")
+    message: str = Field(default="")
+
+
+class FrontendAgentV2StatusResponse(BaseModel):
+    """Response from GET /frontend-agent-v2/status/{job_id}."""
+
+    job_id: str = Field(...)
+    status: str = Field(default="pending", description="pending, running, completed, failed")
+    repo_path: Optional[str] = None
+    current_phase: Optional[str] = None
+    current_microtask: Optional[str] = None
+    progress: int = Field(default=0, description="0-100 completion percentage")
+    microtasks_completed: int = Field(default=0)
+    microtasks_total: int = Field(default=0)
+    completed_phases: List[str] = Field(default_factory=list)
+    error: Optional[str] = None
+    summary: Optional[str] = None
+
+
 def _run_backend_code_v2_background(job_id: str, repo_path: str, task_dict: dict, spec_content: str, architecture_overview: str) -> None:
     """Run backend-code-v2 workflow in a background thread."""
     try:
@@ -639,6 +682,66 @@ def _run_backend_code_v2_background(job_id: str, repo_path: str, task_dict: dict
         update_job(job_id, error=str(e), status=JOB_STATUS_FAILED)
 
 
+def _run_frontend_agent_v2_background(job_id: str, repo_path: str, task_dict: dict, spec_content: str, architecture_overview: str) -> None:
+    """Run frontend-agent-v2 workflow in a background thread."""
+    try:
+        from pathlib import Path as _Path
+        from frontend_agent_v2 import FrontendAgentV2TeamLead
+        from shared.llm import get_llm_for_agent
+        from shared.models import Task, TaskStatus, TaskType, SystemArchitecture
+        import uuid as _uuid
+
+        update_job(job_id, status="running")
+
+        tid = task_dict.get("id") or f"fv2-{_uuid.uuid4().hex[:8]}"
+        task = Task(
+            id=tid,
+            title=task_dict.get("title", ""),
+            description=task_dict.get("description", ""),
+            requirements=task_dict.get("requirements", ""),
+            acceptance_criteria=task_dict.get("acceptance_criteria", []),
+            type=TaskType.FRONTEND,
+            assignee="frontend-agent-v2",
+            status=TaskStatus.PENDING,
+        )
+
+        arch = SystemArchitecture(overview=architecture_overview) if architecture_overview else None
+
+        team_lead = FrontendAgentV2TeamLead(get_llm_for_agent("frontend"))
+
+        phase_order = ["planning", "execution", "review", "problem_solving", "deliver"]
+
+        def _job_updater(**kwargs):
+            completed_phases = []
+            current = kwargs.get("current_phase", "")
+            for p in phase_order:
+                if p == current:
+                    break
+                completed_phases.append(p)
+            update_job(job_id, completed_phases=completed_phases, **kwargs)
+
+        result = team_lead.run_workflow(
+            repo_path=_Path(repo_path),
+            task=task,
+            spec_content=spec_content or "",
+            architecture=arch,
+            job_updater=_job_updater,
+        )
+
+        final_status = "completed" if result.success else "failed"
+        update_job(
+            job_id,
+            status=final_status,
+            progress=100 if result.success else (result.iterations_used * 20),
+            summary=result.summary,
+            error=result.failure_reason if not result.success else None,
+            current_phase=result.current_phase.value if result.current_phase else "deliver",
+        )
+    except Exception as e:
+        logger.exception("Frontend-agent-v2 workflow failed")
+        update_job(job_id, error=str(e), status=JOB_STATUS_FAILED)
+
+
 @app.post(
     "/backend-code-v2/run",
     response_model=BackendCodeV2RunResponse,
@@ -688,6 +791,69 @@ def get_backend_code_v2_status(job_id: str) -> BackendCodeV2StatusResponse:
         raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
 
     return BackendCodeV2StatusResponse(
+        job_id=job_id,
+        status=data.get("status", JOB_STATUS_PENDING),
+        repo_path=data.get("repo_path"),
+        current_phase=data.get("current_phase"),
+        current_microtask=data.get("current_microtask"),
+        progress=data.get("progress", 0),
+        microtasks_completed=data.get("microtasks_completed", 0),
+        microtasks_total=data.get("microtasks_total", 0),
+        completed_phases=data.get("completed_phases", []),
+        error=data.get("error"),
+        summary=data.get("summary"),
+    )
+
+
+@app.post(
+    "/frontend-agent-v2/run",
+    response_model=FrontendAgentV2RunResponse,
+    summary="Run frontend-agent-v2",
+    description="Submit a task and repo path. Starts the frontend-agent-v2 5-phase workflow in the background. "
+    "Returns job_id immediately. Poll GET /frontend-agent-v2/status/{job_id} for progress.",
+)
+def run_frontend_agent_v2(request: FrontendAgentV2RunRequest) -> FrontendAgentV2RunResponse:
+    """Start the frontend-agent-v2 team on a task."""
+    repo = Path(request.repo_path)
+    if not repo.is_dir():
+        raise HTTPException(status_code=400, detail=f"repo_path does not exist or is not a directory: {request.repo_path}")
+
+    job_id = str(uuid.uuid4())
+    create_job(job_id, request.repo_path)
+
+    thread = threading.Thread(
+        target=_run_frontend_agent_v2_background,
+        args=(
+            job_id,
+            request.repo_path,
+            request.task.model_dump(),
+            request.spec_content or "",
+            request.architecture or "",
+        ),
+    )
+    thread.daemon = True
+    thread.start()
+
+    return FrontendAgentV2RunResponse(
+        job_id=job_id,
+        status="running",
+        message="Frontend-agent-v2 workflow started. Poll GET /frontend-agent-v2/status/{job_id} for progress.",
+    )
+
+
+@app.get(
+    "/frontend-agent-v2/status/{job_id}",
+    response_model=FrontendAgentV2StatusResponse,
+    summary="Get frontend-agent-v2 job status",
+    description="Returns what is done, what is in progress, and overall completion percentage.",
+)
+def get_frontend_agent_v2_status(job_id: str) -> FrontendAgentV2StatusResponse:
+    """Get the status of a frontend-agent-v2 job."""
+    data = get_job(job_id)
+    if not data:
+        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+
+    return FrontendAgentV2StatusResponse(
         job_id=job_id,
         status=data.get("status", JOB_STATUS_PENDING),
         repo_path=data.get("repo_path"),

--- a/agents/software_engineering_team/frontend_agent_v2/__init__.py
+++ b/agents/software_engineering_team/frontend_agent_v2/__init__.py
@@ -1,0 +1,12 @@
+"""
+Frontend-Agent-V2 team — standalone experimental frontend development team.
+
+Delivers frontend implementation tasks through a 5-phase cycle:
+Planning → Execution → Review → Problem-solving → Deliver.
+
+This team does NOT import or reuse any code from ``frontend_team``.
+"""
+
+from .orchestrator import FrontendAgentV2TeamLead
+
+__all__ = ["FrontendAgentV2TeamLead"]

--- a/agents/software_engineering_team/frontend_agent_v2/models.py
+++ b/agents/software_engineering_team/frontend_agent_v2/models.py
@@ -1,0 +1,179 @@
+"""
+Models for the frontend-agent-v2 team.
+
+All types are defined from scratch — no reuse of ``frontend_agent`` models.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+class Phase(str, Enum):
+    """Lifecycle phases of the frontend-agent-v2 workflow."""
+
+    PLANNING = "planning"
+    EXECUTION = "execution"
+    REVIEW = "review"
+    PROBLEM_SOLVING = "problem_solving"
+    DELIVER = "deliver"
+
+
+class MicrotaskStatus(str, Enum):
+    PENDING = "pending"
+    IN_PROGRESS = "in_progress"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+
+
+class ToolAgentKind(str, Enum):
+    """Identifies which tool agent a microtask should be routed to."""
+
+    DATA_ENGINEERING = "data_engineering"
+    API_OPENAPI = "api_openapi"
+    AUTH = "auth"
+    CICD = "cicd"
+    CONTAINERIZATION = "containerization"
+    DOCUMENTATION = "documentation"
+    TESTING_QA = "testing_qa"
+    SECURITY = "security"
+    GENERAL = "general"
+
+
+# ---------------------------------------------------------------------------
+# Microtask
+# ---------------------------------------------------------------------------
+
+class Microtask(BaseModel):
+    """A single unit of work inside the Planning phase output."""
+
+    id: str = Field(..., description="Unique kebab-case ID, e.g. mt-create-user-model")
+    title: str = Field(default="", description="Short human-readable title")
+    description: str = Field(default="", description="What needs to be done")
+    tool_agent: ToolAgentKind = Field(
+        default=ToolAgentKind.GENERAL,
+        description="Which tool agent should handle this microtask",
+    )
+    status: MicrotaskStatus = Field(default=MicrotaskStatus.PENDING)
+    depends_on: List[str] = Field(default_factory=list, description="IDs of prerequisite microtasks")
+    output_files: Dict[str, str] = Field(
+        default_factory=dict,
+        description="Files produced by this microtask (path → content)",
+    )
+    notes: str = Field(default="", description="Free-form notes or recommendations from the tool agent")
+
+
+# ---------------------------------------------------------------------------
+# Phase results
+# ---------------------------------------------------------------------------
+
+class PlanningResult(BaseModel):
+    """Output of the Planning phase."""
+
+    microtasks: List[Microtask] = Field(default_factory=list)
+    language: str = Field(default="python", description="Detected language: python or java")
+    summary: str = Field(default="")
+
+
+class ExecutionResult(BaseModel):
+    """Aggregated output of the Execution phase."""
+
+    files: Dict[str, str] = Field(default_factory=dict, description="All files produced")
+    microtasks: List[Microtask] = Field(default_factory=list, description="Microtasks with updated status")
+    summary: str = Field(default="")
+
+
+class ReviewIssue(BaseModel):
+    """A single issue surfaced during Review."""
+
+    source: str = Field(default="", description="e.g. code_review, qa, security, build, lint")
+    severity: str = Field(default="medium", description="critical, high, medium, low, info")
+    description: str = Field(default="")
+    file_path: str = Field(default="")
+    recommendation: str = Field(default="")
+
+
+class ReviewResult(BaseModel):
+    """Output of the Review phase."""
+
+    passed: bool = Field(default=False)
+    issues: List[ReviewIssue] = Field(default_factory=list)
+    build_ok: bool = Field(default=False)
+    lint_ok: bool = Field(default=False)
+    summary: str = Field(default="")
+
+
+class ProblemSolvingResult(BaseModel):
+    """Output of the Problem-solving phase."""
+
+    fixes_applied: List[Dict[str, Any]] = Field(default_factory=list)
+    files: Dict[str, str] = Field(default_factory=dict, description="Updated files after fixes")
+    summary: str = Field(default="")
+    resolved: bool = Field(default=False)
+
+
+class DeliverResult(BaseModel):
+    """Output of the Deliver phase."""
+
+    branch_name: str = Field(default="")
+    merged: bool = Field(default=False)
+    commit_messages: List[str] = Field(default_factory=list)
+    summary: str = Field(default="")
+
+
+# ---------------------------------------------------------------------------
+# Workflow result
+# ---------------------------------------------------------------------------
+
+class FrontendAgentV2WorkflowResult(BaseModel):
+    """
+    Full result of the frontend-agent-v2 team's autonomous workflow.
+
+    Captures outcome of the 5-phase lifecycle:
+    Planning → Execution → Review → Problem-solving → Deliver.
+    """
+
+    task_id: str = Field(default="", description="ID of the task that was executed")
+    success: bool = Field(default=False)
+    current_phase: Phase = Field(default=Phase.PLANNING)
+    iterations_used: int = Field(default=0, description="Number of review/fix iterations")
+    planning_result: Optional[PlanningResult] = None
+    execution_result: Optional[ExecutionResult] = None
+    review_result: Optional[ReviewResult] = None
+    problem_solving_result: Optional[ProblemSolvingResult] = None
+    deliver_result: Optional[DeliverResult] = None
+    final_files: Dict[str, str] = Field(default_factory=dict)
+    summary: str = Field(default="")
+    failure_reason: str = Field(default="")
+    needs_followup: bool = Field(default=False)
+
+
+# ---------------------------------------------------------------------------
+# Tool-agent I/O base types
+# ---------------------------------------------------------------------------
+
+class ToolAgentInput(BaseModel):
+    """Base input for all team-owned tool agents."""
+
+    microtask: Microtask
+    repo_path: str = Field(default="")
+    existing_code: str = Field(default="")
+    spec_context: str = Field(default="")
+    language: str = Field(default="python")
+
+
+class ToolAgentOutput(BaseModel):
+    """Base output for all team-owned tool agents."""
+
+    files: Dict[str, str] = Field(default_factory=dict)
+    recommendations: List[str] = Field(default_factory=list)
+    summary: str = Field(default="")
+    success: bool = Field(default=True)

--- a/agents/software_engineering_team/frontend_agent_v2/orchestrator.py
+++ b/agents/software_engineering_team/frontend_agent_v2/orchestrator.py
@@ -1,0 +1,320 @@
+"""
+Frontend-Code-V2 team orchestrator: 5-phase state machine.
+
+Entry point used by the main orchestrator.
+No code from ``frontend_team`` is imported or reused.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from shared.llm import LLMClient
+from shared.models import SystemArchitecture, Task, TaskUpdate
+
+from .models import (
+    FrontendAgentV2WorkflowResult,
+    Phase,
+    ToolAgentKind,
+    ToolAgentInput,
+    ToolAgentOutput,
+)
+from .phases.planning import run_planning
+from .phases.execution import run_execution
+from .phases.review import run_review
+from .phases.problem_solving import run_problem_solving
+from .phases.deliver import run_deliver
+
+logger = logging.getLogger(__name__)
+
+MAX_REVIEW_ITERATIONS = 5
+
+
+class FrontendAgentV2TeamLead:
+    """
+    Orchestrates the frontend-agent-v2 5-phase lifecycle.
+
+    Invariants:
+        - ``self.llm`` is always a valid LLMClient.
+        - ``run_workflow`` never imports from ``frontend_team``.
+    """
+
+    def __init__(self, llm_client: LLMClient) -> None:
+        assert llm_client is not None, "llm_client is required"
+        self.llm = llm_client
+
+    # ------------------------------------------------------------------
+    # Internal: build tool-agent runners from team-owned agents
+    # ------------------------------------------------------------------
+
+    def _build_tool_runners(self) -> Dict[ToolAgentKind, Callable[[ToolAgentInput], ToolAgentOutput]]:
+        """
+        Create callables for each team-owned tool agent.
+
+        Imported lazily so the orchestrator module stays lightweight.
+        """
+        from .tool_agents.data_engineering import DataEngineeringToolAgent
+        from .tool_agents.api_openapi import ApiOpenApiToolAgent
+        from .tool_agents.auth import AuthToolAgent
+
+        data_eng = DataEngineeringToolAgent(self.llm)
+        api_oa = ApiOpenApiToolAgent(self.llm)
+        auth_ag = AuthToolAgent(self.llm)
+
+        return {
+            ToolAgentKind.DATA_ENGINEERING: data_eng.run,
+            ToolAgentKind.API_OPENAPI: api_oa.run,
+            ToolAgentKind.AUTH: auth_ag.run,
+        }
+
+    # ------------------------------------------------------------------
+    # Read existing repo code (simple, no frontend_team helpers)
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _read_repo_code(repo_path: Path, max_chars: int = 30_000) -> str:
+        """Read Python/Java source files from repo into a single string."""
+        extensions = {".py", ".java", ".kt", ".yaml", ".yml", ".json", ".toml", ".cfg", ".txt"}
+        parts: List[str] = []
+        total = 0
+        try:
+            for f in sorted(repo_path.rglob("*")):
+                if not f.is_file() or f.suffix not in extensions:
+                    continue
+                if any(skip in f.parts for skip in ("node_modules", ".git", "__pycache__", "venv", ".venv")):
+                    continue
+                try:
+                    content = f.read_text(encoding="utf-8", errors="replace")
+                except Exception:
+                    continue
+                rel = str(f.relative_to(repo_path))
+                chunk = f"--- {rel} ---\n{content}\n"
+                if total + len(chunk) > max_chars:
+                    break
+                parts.append(chunk)
+                total += len(chunk)
+        except Exception:
+            pass
+        return "\n".join(parts) if parts else "# No code files found"
+
+    # ------------------------------------------------------------------
+    # Public entry point
+    # ------------------------------------------------------------------
+
+    def run_workflow(
+        self,
+        *,
+        repo_path: Path,
+        task: Task,
+        spec_content: str = "",
+        architecture: Optional[SystemArchitecture] = None,
+        qa_agent: Any = None,
+        security_agent: Any = None,
+        code_review_agent: Any = None,
+        build_verifier: Optional[Callable[..., Tuple[bool, str]]] = None,
+        doc_agent: Any = None,
+        linting_tool_agent: Any = None,
+        tech_lead: Any = None,
+        completed_tasks: Optional[List[Task]] = None,
+        remaining_tasks: Optional[List[Task]] = None,
+        all_tasks: Optional[Dict[str, Task]] = None,
+        execution_queue: Optional[List[str]] = None,
+        append_task_fn: Optional[Callable[[Task], None]] = None,
+        build_fix_specialist: Any = None,
+        git_operations_tool_agent: Any = None,
+        acceptance_verifier_agent: Any = None,
+        dbc_agent: Any = None,
+        problem_solver_agent: Any = None,
+        job_updater: Optional[Callable[..., None]] = None,
+    ) -> FrontendAgentV2WorkflowResult:
+        """
+        Execute the full 5-phase frontend-agent-v2 lifecycle.
+
+        Phases:
+            1. Planning — decompose task into microtasks
+            2. Execution — implement microtasks via tool agents / LLM
+            3. Review — code review, build, lint, QA, security
+            4. Problem-solving — root-cause and fix loop (on review failure)
+            5. Deliver — commit and merge to development
+
+        Steps 2-4 repeat for up to ``MAX_REVIEW_ITERATIONS``.
+        """
+        task_id = task.id
+        start_time = time.monotonic()
+        result = FrontendAgentV2WorkflowResult(task_id=task_id)
+
+        def _update_job(**kwargs: Any) -> None:
+            if job_updater:
+                try:
+                    job_updater(**kwargs)
+                except Exception:
+                    pass
+
+        logger.info("[%s] WORKFLOW START: frontend-agent-v2 team", task_id)
+
+        existing_code = self._read_repo_code(repo_path)
+        tool_runners = self._build_tool_runners()
+
+        # ── Phase 1: Planning ──────────────────────────────────────────
+        result.current_phase = Phase.PLANNING
+        _update_job(current_phase="planning", progress=5)
+
+        try:
+            planning_result = run_planning(
+                llm=self.llm,
+                task=task,
+                repo_path=repo_path,
+                spec_content=spec_content,
+                architecture=architecture,
+                existing_code=existing_code,
+            )
+            result.planning_result = planning_result
+        except Exception as exc:
+            result.failure_reason = f"Planning failed: {exc}"
+            logger.error("[%s] %s", task_id, result.failure_reason)
+            return result
+
+        total_microtasks = len(planning_result.microtasks)
+        _update_job(
+            current_phase="planning",
+            progress=10,
+            microtasks_total=total_microtasks,
+            microtasks_completed=0,
+        )
+
+        # ── Phases 2-4: Execution → Review → Problem-solving loop ─────
+        current_files: Dict[str, str] = {}
+        for iteration in range(1, MAX_REVIEW_ITERATIONS + 1):
+            logger.info("[%s] ── Iteration %d/%d ──", task_id, iteration, MAX_REVIEW_ITERATIONS)
+
+            # Phase 2: Execution
+            result.current_phase = Phase.EXECUTION
+            _update_job(current_phase="execution", current_microtask="", progress=10 + iteration * 10)
+
+            def _progress_cb(done: int, total: int, title: str) -> None:
+                _update_job(
+                    current_phase="execution",
+                    current_microtask=title,
+                    microtasks_completed=done,
+                    microtasks_total=total,
+                    progress=min(10 + iteration * 10 + int(done / max(total, 1) * 20), 80),
+                )
+
+            try:
+                exec_result = run_execution(
+                    llm=self.llm,
+                    task=task,
+                    planning_result=planning_result,
+                    repo_path=repo_path,
+                    spec_content=spec_content,
+                    architecture=architecture,
+                    existing_code=existing_code,
+                    tool_runners=tool_runners,
+                    progress_callback=_progress_cb,
+                )
+                result.execution_result = exec_result
+                current_files.update(exec_result.files)
+            except Exception as exc:
+                result.failure_reason = f"Execution failed (iter {iteration}): {exc}"
+                logger.error("[%s] %s", task_id, result.failure_reason)
+                result.iterations_used = iteration
+                return result
+
+            if not current_files:
+                result.failure_reason = "Execution produced no files."
+                result.iterations_used = iteration
+                return result
+
+            # Write files to repo for build/review
+            from shared.repo_writer import write_agent_output
+
+            class _Payload:
+                def __init__(self, files: Dict[str, str]) -> None:
+                    self.files = files
+                    self.summary = ""
+                    self.suggested_commit_message = f"wip: iteration {iteration}"
+                    self.gitignore_entries: list[str] = []
+
+            write_agent_output(repo_path, _Payload(current_files), subdir="")
+
+            # Phase 3: Review
+            result.current_phase = Phase.REVIEW
+            _update_job(current_phase="review", progress=min(50 + iteration * 10, 85))
+
+            try:
+                review_result = run_review(
+                    llm=self.llm,
+                    task=task,
+                    execution_result=exec_result,
+                    repo_path=repo_path,
+                    build_verifier=build_verifier,
+                    qa_agent=qa_agent,
+                    security_agent=security_agent,
+                    code_review_agent=code_review_agent,
+                    linting_tool_agent=linting_tool_agent,
+                )
+                result.review_result = review_result
+            except Exception as exc:
+                logger.warning("[%s] Review failed (non-blocking): %s", task_id, exc)
+                break  # proceed to deliver anyway
+
+            if review_result.passed:
+                logger.info("[%s] Review passed on iteration %d", task_id, iteration)
+                break
+
+            # Phase 4: Problem-solving
+            result.current_phase = Phase.PROBLEM_SOLVING
+            _update_job(current_phase="problem_solving", progress=min(60 + iteration * 10, 85))
+
+            try:
+                ps_result = run_problem_solving(
+                    llm=self.llm,
+                    task=task,
+                    review_result=review_result,
+                    current_files=current_files,
+                    language=planning_result.language,
+                )
+                result.problem_solving_result = ps_result
+                current_files = ps_result.files
+            except Exception as exc:
+                logger.warning("[%s] Problem-solving failed (non-blocking): %s", task_id, exc)
+                break
+
+            result.iterations_used = iteration
+
+        result.iterations_used = max(result.iterations_used, 1)
+        result.final_files = current_files
+
+        # ── Phase 5: Deliver ───────────────────────────────────────────
+        result.current_phase = Phase.DELIVER
+        _update_job(current_phase="deliver", progress=90)
+
+        try:
+            deliver_result = run_deliver(
+                task_id=task_id,
+                repo_path=repo_path,
+                files=current_files,
+                summary=result.execution_result.summary if result.execution_result else "",
+                task_title=task.title or "",
+            )
+            result.deliver_result = deliver_result
+            result.success = deliver_result.merged
+            result.summary = deliver_result.summary
+        except Exception as exc:
+            result.failure_reason = f"Deliver failed: {exc}"
+            logger.error("[%s] %s", task_id, result.failure_reason)
+            return result
+
+        elapsed = time.monotonic() - start_time
+        _update_job(current_phase="deliver", progress=100 if result.success else 95)
+        logger.info(
+            "[%s] WORKFLOW %s in %.1fs (%d iterations)",
+            task_id,
+            "SUCCEEDED" if result.success else "FAILED",
+            elapsed,
+            result.iterations_used,
+        )
+        return result

--- a/agents/software_engineering_team/frontend_agent_v2/phases/__init__.py
+++ b/agents/software_engineering_team/frontend_agent_v2/phases/__init__.py
@@ -1,0 +1,1 @@
+"""Phase modules for the frontend-agent-v2 5-phase cycle."""

--- a/agents/software_engineering_team/frontend_agent_v2/phases/deliver.py
+++ b/agents/software_engineering_team/frontend_agent_v2/phases/deliver.py
@@ -1,0 +1,99 @@
+"""
+Deliver phase: write files, commit, and merge to development.
+
+Uses only ``shared.git_utils`` — no code from ``frontend_agent``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import Dict, Optional
+
+from shared.git_utils import (
+    DEVELOPMENT_BRANCH,
+    abort_merge,
+    branch_has_commits_ahead_of,
+    checkout_branch,
+    create_feature_branch,
+    delete_branch,
+    merge_branch,
+)
+from shared.repo_writer import write_agent_output, NO_FILES_TO_WRITE_MSG
+
+from ..models import DeliverResult
+from ..prompts import DELIVER_COMMIT_MSG_TEMPLATE
+
+logger = logging.getLogger(__name__)
+
+
+class _FilesPayload:
+    """Minimal duck-type wrapper so ``write_agent_output`` can consume it."""
+
+    def __init__(self, files: Dict[str, str], summary: str, commit_msg: str) -> None:
+        self.files = files
+        self.summary = summary
+        self.suggested_commit_message = commit_msg
+        self.gitignore_entries: list[str] = []
+
+
+def run_deliver(
+    *,
+    task_id: str,
+    repo_path: Path,
+    files: Dict[str, str],
+    summary: str,
+    task_title: str = "",
+) -> DeliverResult:
+    """
+    Create feature branch, write files, commit, merge to development.
+
+    If the feature branch already exists it is recreated from development.
+    """
+    result = DeliverResult()
+
+    if not files:
+        result.summary = "No files to deliver."
+        return result
+
+    # 1. Create feature branch
+    slug = re.sub(r"[^a-z0-9-]+", "-", (task_title or task_id).lower()).strip("-")[:40] or "task"
+    ok, branch_msg = create_feature_branch(repo_path, DEVELOPMENT_BRANCH, f"{task_id}-{slug}")
+    if not ok:
+        result.summary = f"Feature branch creation failed: {branch_msg}"
+        logger.error("[%s] Deliver: %s", task_id, result.summary)
+        checkout_branch(repo_path, DEVELOPMENT_BRANCH)
+        return result
+    result.branch_name = branch_msg or f"feature/{task_id}-{slug}"
+
+    # 2. Write files and commit
+    scope = slug[:20]
+    commit_msg = DELIVER_COMMIT_MSG_TEMPLATE.format(scope=scope, summary=summary[:72])
+    payload = _FilesPayload(files, summary, commit_msg)
+    write_ok, write_msg = write_agent_output(repo_path, payload, subdir="")
+    if not write_ok:
+        result.summary = f"Write failed: {write_msg}"
+        logger.error("[%s] Deliver: %s", task_id, result.summary)
+        checkout_branch(repo_path, DEVELOPMENT_BRANCH)
+        return result
+    result.commit_messages.append(commit_msg)
+
+    # 3. Merge to development
+    merge_ok, merge_msg = merge_branch(repo_path, result.branch_name, DEVELOPMENT_BRANCH)
+    if not merge_ok:
+        result.summary = f"Merge failed: {merge_msg}"
+        logger.error("[%s] Deliver: %s", task_id, result.summary)
+        abort_merge(repo_path)
+        checkout_branch(repo_path, DEVELOPMENT_BRANCH)
+        return result
+
+    result.merged = True
+
+    # 4. Cleanup feature branch
+    delete_branch(repo_path, result.branch_name)
+    checkout_branch(repo_path, DEVELOPMENT_BRANCH)
+
+    result.summary = f"Merged {result.branch_name} → {DEVELOPMENT_BRANCH}."
+    logger.info("[%s] Deliver: %s", task_id, result.summary)
+    return result

--- a/agents/software_engineering_team/frontend_agent_v2/phases/execution.py
+++ b/agents/software_engineering_team/frontend_agent_v2/phases/execution.py
@@ -1,0 +1,131 @@
+"""
+Execution phase: run each microtask via tool agents or general code gen.
+
+No code from ``frontend_agent`` is used.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from shared.llm import LLMClient
+from shared.models import SystemArchitecture, Task
+
+from ..models import (
+    ExecutionResult,
+    Microtask,
+    MicrotaskStatus,
+    PlanningResult,
+    ToolAgentKind,
+    ToolAgentInput,
+    ToolAgentOutput,
+)
+from ..prompts import EXECUTION_PROMPT, PYTHON_CONVENTIONS, JAVA_CONVENTIONS
+
+logger = logging.getLogger(__name__)
+
+ToolAgentRunner = Callable[[ToolAgentInput], ToolAgentOutput]
+
+
+def _language_conventions(language: str) -> str:
+    return JAVA_CONVENTIONS if language == "java" else PYTHON_CONVENTIONS
+
+
+def _run_general_microtask(
+    *,
+    llm: LLMClient,
+    microtask: Microtask,
+    task: Task,
+    language: str,
+    existing_code: str,
+    architecture: Optional[SystemArchitecture],
+) -> Dict[str, str]:
+    """Use the LLM to implement a general (non-specialist) microtask."""
+    arch_ctx = ""
+    if architecture:
+        arch_ctx = architecture.overview[:2000]
+
+    prompt = EXECUTION_PROMPT.format(
+        language_conventions=_language_conventions(language),
+        microtask_description=microtask.description or microtask.title,
+        requirements=task.requirements or task.description,
+        existing_code=existing_code[:8000] if existing_code else "(none)",
+        architecture_context=arch_ctx or "(none)",
+    )
+    raw = llm.complete_json(prompt)
+    return raw.get("files") or {}
+
+
+def run_execution(
+    *,
+    llm: LLMClient,
+    task: Task,
+    planning_result: PlanningResult,
+    repo_path: Path,
+    spec_content: str = "",
+    architecture: Optional[SystemArchitecture] = None,
+    existing_code: str = "",
+    tool_runners: Optional[Dict[ToolAgentKind, ToolAgentRunner]] = None,
+    progress_callback: Optional[Callable[[int, int, str], None]] = None,
+) -> ExecutionResult:
+    """
+    Execute all microtasks in dependency order.
+
+    ``tool_runners`` maps ToolAgentKind → callable(ToolAgentInput) → ToolAgentOutput.
+    For microtasks whose tool_agent has no runner, fall back to general LLM code gen.
+    ``progress_callback(completed, total, current_microtask_title)`` is called after each.
+    """
+    runners = tool_runners or {}
+    all_files: Dict[str, str] = {}
+    microtasks = list(planning_result.microtasks)
+    completed_ids: set[str] = set()
+    total = len(microtasks)
+
+    for idx, mt in enumerate(microtasks):
+        deps_met = all(d in completed_ids for d in mt.depends_on)
+        if not deps_met:
+            logger.warning("[%s] Microtask %s has unmet deps %s — running anyway", task.id, mt.id, mt.depends_on)
+
+        mt.status = MicrotaskStatus.IN_PROGRESS
+        logger.info("[%s] Execution: microtask %d/%d — %s (%s)", task.id, idx + 1, total, mt.id, mt.tool_agent.value)
+
+        try:
+            runner = runners.get(mt.tool_agent)
+            if runner is not None:
+                inp = ToolAgentInput(
+                    microtask=mt,
+                    repo_path=str(repo_path),
+                    existing_code=existing_code[:6000] if existing_code else "",
+                    spec_context=spec_content[:4000] if spec_content else "",
+                    language=planning_result.language,
+                )
+                out = runner(inp)
+                mt.output_files = out.files
+                mt.notes = out.summary
+            else:
+                files = _run_general_microtask(
+                    llm=llm,
+                    microtask=mt,
+                    task=task,
+                    language=planning_result.language,
+                    existing_code=existing_code,
+                    architecture=architecture,
+                )
+                mt.output_files = files
+
+            all_files.update(mt.output_files)
+            mt.status = MicrotaskStatus.COMPLETED
+            completed_ids.add(mt.id)
+        except Exception as exc:
+            logger.error("[%s] Microtask %s failed: %s", task.id, mt.id, exc)
+            mt.status = MicrotaskStatus.FAILED
+            mt.notes = str(exc)
+
+        if progress_callback:
+            progress_callback(len(completed_ids), total, mt.title or mt.id)
+
+    summary = f"Executed {len(completed_ids)}/{total} microtasks; {len(all_files)} files produced."
+    return ExecutionResult(files=all_files, microtasks=microtasks, summary=summary)

--- a/agents/software_engineering_team/frontend_agent_v2/phases/planning.py
+++ b/agents/software_engineering_team/frontend_agent_v2/phases/planning.py
@@ -1,0 +1,129 @@
+"""
+Planning phase: decompose a task into microtasks and assign tool agents.
+
+No code from ``frontend_agent`` is used.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from shared.llm import LLMClient
+from shared.models import SystemArchitecture, Task
+
+from ..models import (
+    Microtask,
+    MicrotaskStatus,
+    PlanningResult,
+    ToolAgentKind,
+)
+from ..prompts import PLANNING_PROMPT
+
+logger = logging.getLogger(__name__)
+
+
+def _detect_language(repo_path: Path, task: Task) -> str:
+    """Infer whether the project is Python or Java from the repo."""
+    if repo_path.is_dir():
+        if any(repo_path.rglob("pom.xml")) or any(repo_path.rglob("build.gradle")):
+            return "java"
+        if any(repo_path.rglob("requirements.txt")) or any(repo_path.rglob("pyproject.toml")):
+            return "python"
+        if any(repo_path.rglob("*.java")):
+            return "java"
+    desc = (task.description or "").lower() + " " + (task.requirements or "").lower()
+    if "spring" in desc or "java" in desc or "maven" in desc or "gradle" in desc:
+        return "java"
+    return "python"
+
+
+def _build_context(
+    task: Task,
+    spec_content: str,
+    architecture: Optional[SystemArchitecture],
+    existing_code: str,
+    language: str,
+) -> str:
+    """Build the full prompt context for the planning LLM call."""
+    parts: List[str] = [
+        PLANNING_PROMPT,
+        "",
+        "---",
+        "",
+        f"**Task title:** {task.title or task.id}",
+        f"**Task description:** {task.description}",
+        f"**Requirements:** {task.requirements or 'N/A'}",
+        f"**Acceptance criteria:** {', '.join(task.acceptance_criteria) if task.acceptance_criteria else 'N/A'}",
+        f"**Language:** {language}",
+    ]
+    if spec_content:
+        parts.extend(["", "**Project specification (excerpt):**", spec_content[:6000]])
+    if architecture:
+        parts.extend(["", "**Architecture overview:**", architecture.overview[:3000]])
+    if existing_code and existing_code != "# No code files found":
+        parts.extend(["", "**Existing codebase (excerpt):**", existing_code[:6000]])
+    return "\n".join(parts)
+
+
+def _parse_planning_output(raw: Dict[str, Any], language: str) -> PlanningResult:
+    """Convert the LLM JSON response into a PlanningResult."""
+    microtasks: List[Microtask] = []
+    for mt in raw.get("microtasks") or []:
+        if not isinstance(mt, dict) or not mt.get("id"):
+            continue
+        try:
+            kind = ToolAgentKind(mt.get("tool_agent", "general"))
+        except ValueError:
+            kind = ToolAgentKind.GENERAL
+        microtasks.append(
+            Microtask(
+                id=mt["id"],
+                title=mt.get("title", ""),
+                description=mt.get("description", ""),
+                tool_agent=kind,
+                status=MicrotaskStatus.PENDING,
+                depends_on=mt.get("depends_on") or [],
+            )
+        )
+    return PlanningResult(
+        microtasks=microtasks,
+        language=raw.get("language") or language,
+        summary=raw.get("summary", ""),
+    )
+
+
+def run_planning(
+    *,
+    llm: LLMClient,
+    task: Task,
+    repo_path: Path,
+    spec_content: str = "",
+    architecture: Optional[SystemArchitecture] = None,
+    existing_code: str = "",
+) -> PlanningResult:
+    """Execute the Planning phase and return a PlanningResult."""
+    language = _detect_language(repo_path, task)
+    prompt = _build_context(task, spec_content, architecture, existing_code, language)
+
+    logger.info("[%s] Planning phase: generating microtasks (language=%s)", task.id, language)
+    raw = llm.complete_json(prompt)
+    result = _parse_planning_output(raw, language)
+    logger.info(
+        "[%s] Planning phase: produced %d microtasks — %s",
+        task.id, len(result.microtasks), result.summary[:120],
+    )
+
+    if not result.microtasks:
+        result.microtasks = [
+            Microtask(
+                id="mt-implement-task",
+                title=task.title or "Implement task",
+                description=task.description or "Implement the full task as described.",
+                tool_agent=ToolAgentKind.GENERAL,
+            )
+        ]
+        result.summary = result.summary or "Single-microtask fallback."
+    return result

--- a/agents/software_engineering_team/frontend_agent_v2/phases/problem_solving.py
+++ b/agents/software_engineering_team/frontend_agent_v2/phases/problem_solving.py
@@ -1,0 +1,71 @@
+"""
+Problem-solving phase: root-cause analysis and fix loop.
+
+No code from ``frontend_agent`` is used.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+from shared.llm import LLMClient
+from shared.models import Task
+
+from ..models import ProblemSolvingResult, ReviewIssue, ReviewResult
+from ..prompts import PROBLEM_SOLVING_PROMPT, PYTHON_CONVENTIONS, JAVA_CONVENTIONS
+
+logger = logging.getLogger(__name__)
+
+
+def run_problem_solving(
+    *,
+    llm: LLMClient,
+    task: Task,
+    review_result: ReviewResult,
+    current_files: Dict[str, str],
+    language: str = "python",
+) -> ProblemSolvingResult:
+    """
+    Analyse review issues and produce fixes.
+
+    Returns updated files and a summary of what was changed.
+    """
+    task_id = task.id
+    actionable = [i for i in review_result.issues if i.severity in ("critical", "high", "medium")]
+    if not actionable:
+        logger.info("[%s] Problem-solving: no actionable issues.", task_id)
+        return ProblemSolvingResult(resolved=True, files=current_files, summary="No actionable issues.")
+
+    issues_text = "\n".join(
+        f"- [{i.severity}] {i.description} (file: {i.file_path or 'N/A'}) → {i.recommendation}"
+        for i in actionable
+    )
+    code_text = "\n\n".join(f"--- {p} ---\n{c}" for p, c in list(current_files.items())[:20])
+
+    lang_conv = JAVA_CONVENTIONS if language == "java" else PYTHON_CONVENTIONS
+    prompt = PROBLEM_SOLVING_PROMPT.format(
+        language_conventions=lang_conv,
+        issues=issues_text,
+        current_code=code_text[:12000],
+    )
+
+    logger.info("[%s] Problem-solving: sending %d issues to LLM for fixes", task_id, len(actionable))
+    raw = llm.complete_json(prompt)
+
+    fixed_files = raw.get("files") or {}
+    merged = dict(current_files)
+    merged.update(fixed_files)
+
+    fixes_applied = raw.get("fixes_applied") or []
+    resolved = raw.get("resolved", bool(fixed_files))
+    summary = raw.get("summary", f"Applied {len(fixes_applied)} fixes.")
+
+    logger.info("[%s] Problem-solving: %s — %s", task_id, "resolved" if resolved else "partial", summary[:120])
+
+    return ProblemSolvingResult(
+        fixes_applied=fixes_applied,
+        files=merged,
+        summary=summary,
+        resolved=resolved,
+    )

--- a/agents/software_engineering_team/frontend_agent_v2/phases/review.py
+++ b/agents/software_engineering_team/frontend_agent_v2/phases/review.py
@@ -1,0 +1,177 @@
+"""
+Review phase: code review, build verification, lint, QA, security.
+
+Invokes passed-in quality agents when available; otherwise uses the team's
+own LLM-based review. No code from ``frontend_agent`` is used.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from shared.llm import LLMClient
+from shared.models import Task
+
+from ..models import ExecutionResult, ReviewIssue, ReviewResult
+from ..prompts import REVIEW_PROMPT
+
+logger = logging.getLogger(__name__)
+
+
+def _run_llm_review(
+    *,
+    llm: LLMClient,
+    task: Task,
+    files: Dict[str, str],
+) -> List[ReviewIssue]:
+    """LLM-based code review when no external review agent is available."""
+    code_text = "\n\n".join(f"--- {p} ---\n{c}" for p, c in list(files.items())[:20])
+    prompt = REVIEW_PROMPT.format(
+        requirements=task.requirements or task.description,
+        acceptance_criteria=", ".join(task.acceptance_criteria) if task.acceptance_criteria else "N/A",
+        code=code_text[:12000],
+    )
+    raw = llm.complete_json(prompt)
+    issues: List[ReviewIssue] = []
+    for item in raw.get("issues") or []:
+        if isinstance(item, dict):
+            issues.append(ReviewIssue(
+                source=item.get("source", "code_review"),
+                severity=item.get("severity", "medium"),
+                description=item.get("description", ""),
+                file_path=item.get("file_path", ""),
+                recommendation=item.get("recommendation", ""),
+            ))
+    return issues
+
+
+def _run_build_verification(
+    repo_path: Path,
+    build_verifier: Optional[Callable[..., Tuple[bool, str]]],
+    task_id: str,
+) -> Tuple[bool, str]:
+    """Run the build verifier if provided, else assume success."""
+    if build_verifier is None:
+        return True, "No build verifier provided; skipping."
+    try:
+        return build_verifier(repo_path, "frontend_agent_v2", task_id)
+    except Exception as exc:
+        logger.warning("[%s] Build verifier raised: %s", task_id, exc)
+        return False, str(exc)
+
+
+def run_review(
+    *,
+    llm: LLMClient,
+    task: Task,
+    execution_result: ExecutionResult,
+    repo_path: Path,
+    build_verifier: Optional[Callable[..., Tuple[bool, str]]] = None,
+    qa_agent: Any = None,
+    security_agent: Any = None,
+    code_review_agent: Any = None,
+    linting_tool_agent: Any = None,
+) -> ReviewResult:
+    """
+    Execute the Review phase.
+
+    Uses passed-in quality agents (from the main orchestrator) when available,
+    falls back to team-internal LLM review otherwise.
+    """
+    task_id = task.id
+    issues: List[ReviewIssue] = []
+
+    # 1. Build verification
+    build_ok, build_msg = _run_build_verification(repo_path, build_verifier, task_id)
+    if not build_ok:
+        issues.append(ReviewIssue(
+            source="build",
+            severity="critical",
+            description=f"Build failed: {build_msg[:300]}",
+            recommendation="Fix compilation/test errors before proceeding.",
+        ))
+
+    # 2. Lint verification
+    lint_ok = True
+    if linting_tool_agent is not None:
+        try:
+            from linting_tool_agent.models import LintToolInput as _LintInput
+            lint_result = linting_tool_agent.run(_LintInput(
+                repo_path=str(repo_path),
+                task_id=task_id,
+                language="python",
+            ))
+            if lint_result and not getattr(lint_result, "passed", True):
+                lint_ok = False
+                for li in getattr(lint_result, "issues", []):
+                    issues.append(ReviewIssue(
+                        source="lint",
+                        severity="medium",
+                        description=getattr(li, "message", str(li)),
+                        file_path=getattr(li, "file_path", ""),
+                        recommendation=getattr(li, "fix", ""),
+                    ))
+        except Exception as exc:
+            logger.warning("[%s] Linting tool agent failed: %s", task_id, exc)
+
+    # 3. Code review agent (external) or LLM fallback
+    if code_review_agent is not None:
+        try:
+            cr_result = code_review_agent.run(execution_result.files, task)
+            for item in getattr(cr_result, "issues", []):
+                issues.append(ReviewIssue(
+                    source="code_review",
+                    severity=getattr(item, "severity", "medium"),
+                    description=getattr(item, "description", str(item)),
+                    file_path=getattr(item, "file_path", ""),
+                    recommendation=getattr(item, "recommendation", ""),
+                ))
+        except Exception as exc:
+            logger.warning("[%s] Code review agent failed, using LLM fallback: %s", task_id, exc)
+            issues.extend(_run_llm_review(llm=llm, task=task, files=execution_result.files))
+    else:
+        issues.extend(_run_llm_review(llm=llm, task=task, files=execution_result.files))
+
+    # 4. QA agent
+    if qa_agent is not None:
+        try:
+            qa_result = qa_agent.run(execution_result.files, task)
+            for item in getattr(qa_result, "issues", []):
+                issues.append(ReviewIssue(
+                    source="qa",
+                    severity=getattr(item, "severity", "medium"),
+                    description=getattr(item, "description", str(item)),
+                    recommendation=getattr(item, "recommendation", ""),
+                ))
+        except Exception as exc:
+            logger.warning("[%s] QA agent failed: %s", task_id, exc)
+
+    # 5. Security agent
+    if security_agent is not None:
+        try:
+            sec_result = security_agent.run(execution_result.files, task)
+            for item in getattr(sec_result, "issues", []):
+                issues.append(ReviewIssue(
+                    source="security",
+                    severity=getattr(item, "severity", "high"),
+                    description=getattr(item, "description", str(item)),
+                    recommendation=getattr(item, "recommendation", ""),
+                ))
+        except Exception as exc:
+            logger.warning("[%s] Security agent failed: %s", task_id, exc)
+
+    critical_or_high = [i for i in issues if i.severity in ("critical", "high")]
+    passed = build_ok and len(critical_or_high) == 0
+
+    summary = f"Review: build={'OK' if build_ok else 'FAIL'}, lint={'OK' if lint_ok else 'FAIL'}, {len(issues)} issues ({len(critical_or_high)} critical/high)."
+    logger.info("[%s] %s passed=%s", task_id, summary, passed)
+
+    return ReviewResult(
+        passed=passed,
+        issues=issues,
+        build_ok=build_ok,
+        lint_ok=lint_ok,
+        summary=summary,
+    )

--- a/agents/software_engineering_team/frontend_agent_v2/prompts.py
+++ b/agents/software_engineering_team/frontend_agent_v2/prompts.py
@@ -1,0 +1,212 @@
+"""
+Prompts for the frontend-agent-v2 team.
+
+Written from scratch — no reuse of ``frontend_agent`` prompts.
+"""
+
+# ---------------------------------------------------------------------------
+# Shared coding standards (injected into Execution and Problem-solving)
+# ---------------------------------------------------------------------------
+
+CODING_STANDARDS = """
+**Coding standards (apply to every file you produce):**
+
+1. Design by Contract: preconditions, postconditions, invariants on all public APIs.
+2. SOLID principles in class/module design.
+3. Docstrings on every class, method, and function.
+4. Unit tests targeting at least 85 % branch coverage.
+5. No commented-out code in production files.
+6. Explicit error handling — do not swallow exceptions silently.
+"""
+
+PYTHON_CONVENTIONS = """
+**Python conventions:**
+- Use type hints on all function signatures.
+- Follow PEP 8 naming (snake_case functions/variables, PascalCase classes).
+- FastAPI project layout: app/main.py, app/routers/, app/models/, app/schemas/, app/services/, app/database.py, tests/.
+- requirements.txt with pinned versions; always include httpx>=0.24,<0.28 for TestClient.
+- SQLAlchemy: use String(36) for UUID columns (SQLite compat), not sqlalchemy.UUID.
+- Pydantic v2 BaseModel for all request/response schemas.
+"""
+
+JAVA_CONVENTIONS = """
+**Java conventions:**
+- Follow standard Maven/Gradle project layout: src/main/java, src/test/java.
+- Spring Boot: @RestController, @Service, @Repository layering.
+- Use records or DTOs for request/response; Jackson for serialization.
+- JUnit 5 + Mockito for testing.
+- PascalCase classes, camelCase methods/fields.
+"""
+
+# ---------------------------------------------------------------------------
+# Planning phase
+# ---------------------------------------------------------------------------
+
+PLANNING_PROMPT = """You are the Planning Agent for a frontend development team.
+
+Your job: break a task into a set of concrete microtasks that, when completed together,
+fully satisfy the task requirements. Each microtask should be small enough that a single
+specialist tool-agent (or a general code-generation step) can handle it.
+
+**Available tool-agent domains you can assign microtasks to:**
+- data_engineering — schema design, migrations, data integrity, query optimisation
+- api_openapi — API endpoint design, OpenAPI contract, route implementation
+- auth — authentication, authorisation, RBAC, permissions, secure defaults
+- cicd — CI/CD pipeline configuration or updates
+- containerization — Dockerfile, docker-compose, container config
+- documentation — README, API docs, runbooks
+- testing_qa — test plan, test files, coverage improvements
+- security — security hardening, vulnerability fixes
+- general — anything else (default code generation)
+
+**Input you receive:**
+- Task description and requirements
+- Optional project spec, architecture, existing code context
+- Target language (python or java)
+
+**Output (JSON):**
+Return a JSON object:
+{
+  "microtasks": [
+    {
+      "id": "mt-<short-kebab>",
+      "title": "short title",
+      "description": "what to do (2-4 sentences)",
+      "tool_agent": "<domain from list above>",
+      "depends_on": ["mt-other-id"]
+    }
+  ],
+  "language": "python" or "java",
+  "summary": "1-2 sentence overview of the plan"
+}
+
+Rules:
+- Emit 2-10 microtasks. Prefer smaller, focused microtasks over large monolithic ones.
+- Include at least one testing_qa microtask unless the task is pure docs/config.
+- Dependency order matters: list prerequisites in depends_on.
+- Respond with valid JSON only (no markdown fences, no text before or after).
+"""
+
+# ---------------------------------------------------------------------------
+# Execution phase
+# ---------------------------------------------------------------------------
+
+EXECUTION_PROMPT = """You are a Senior Frontend Software Engineer implementing production-quality code.
+
+""" + CODING_STANDARDS + """
+
+{language_conventions}
+
+**Your task:**
+Implement the microtask described below. Produce complete, runnable code files.
+
+**Microtask:**
+{microtask_description}
+
+**Requirements:**
+{requirements}
+
+**Existing codebase (if any):**
+{existing_code}
+
+**Architecture context (if any):**
+{architecture_context}
+
+**Output (JSON):**
+Return a single JSON object:
+{{
+  "files": {{
+    "path/to/file.ext": "full file content",
+    ...
+  }},
+  "summary": "what you implemented",
+  "suggested_commit_message": "type(scope): description"
+}}
+
+- The "files" dict MUST be populated with complete file paths and full content.
+- All imports must be valid; all referenced modules must be included.
+- Respond with valid JSON only.
+"""
+
+# ---------------------------------------------------------------------------
+# Review phase
+# ---------------------------------------------------------------------------
+
+REVIEW_PROMPT = """You are a Code Review Agent for a frontend project.
+
+Review the code below for:
+1. Correctness — does it satisfy the stated requirements and acceptance criteria?
+2. Code quality — SOLID, DRY, proper error handling, no dead code.
+3. Security — injection, auth bypass, secrets in code, insecure defaults.
+4. Testing — are tests present and do they cover the main paths?
+5. Build/lint — would this code pass a build and lint check?
+
+**Requirements:**
+{requirements}
+
+**Acceptance criteria:**
+{acceptance_criteria}
+
+**Code to review:**
+{code}
+
+**Output (JSON):**
+{{
+  "passed": true/false,
+  "issues": [
+    {{
+      "source": "code_review",
+      "severity": "critical|high|medium|low|info",
+      "description": "what is wrong",
+      "file_path": "which file",
+      "recommendation": "how to fix it"
+    }}
+  ],
+  "summary": "overall assessment"
+}}
+
+Respond with valid JSON only.
+"""
+
+# ---------------------------------------------------------------------------
+# Problem-solving phase
+# ---------------------------------------------------------------------------
+
+PROBLEM_SOLVING_PROMPT = """You are a Problem-Solving Specialist for a frontend project.
+
+Given the issues found during review, produce fixes. Each fix should be a complete
+updated file that resolves the issue.
+
+""" + CODING_STANDARDS + """
+
+{language_conventions}
+
+**Issues to resolve:**
+{issues}
+
+**Current code:**
+{current_code}
+
+**Output (JSON):**
+{{
+  "files": {{
+    "path/to/file.ext": "full updated file content"
+  }},
+  "fixes_applied": [
+    {{
+      "issue": "summary of the issue",
+      "fix": "what was changed"
+    }}
+  ],
+  "summary": "overview of all fixes",
+  "resolved": true/false
+}}
+
+Respond with valid JSON only.
+"""
+
+# ---------------------------------------------------------------------------
+# Deliver phase (no LLM prompt needed — this is procedural git work)
+# ---------------------------------------------------------------------------
+
+DELIVER_COMMIT_MSG_TEMPLATE = "feat({scope}): {summary}"

--- a/agents/software_engineering_team/frontend_agent_v2/tool_agents/__init__.py
+++ b/agents/software_engineering_team/frontend_agent_v2/tool_agents/__init__.py
@@ -1,0 +1,1 @@
+"""Tool agents owned by the frontend-agent-v2 team."""

--- a/agents/software_engineering_team/frontend_agent_v2/tool_agents/api_openapi/__init__.py
+++ b/agents/software_engineering_team/frontend_agent_v2/tool_agents/api_openapi/__init__.py
@@ -1,0 +1,5 @@
+"""API / OpenAPI tool agent for the frontend-agent-v2 team."""
+
+from .agent import ApiOpenApiToolAgent
+
+__all__ = ["ApiOpenApiToolAgent"]

--- a/agents/software_engineering_team/frontend_agent_v2/tool_agents/api_openapi/agent.py
+++ b/agents/software_engineering_team/frontend_agent_v2/tool_agents/api_openapi/agent.py
@@ -1,0 +1,56 @@
+"""
+API / OpenAPI tool agent: contract design, endpoint implementation, spec validation.
+
+Implemented from scratch inside the frontend-agent-v2 team.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from shared.llm import LLMClient
+
+from ...models import ToolAgentInput, ToolAgentOutput
+
+logger = logging.getLogger(__name__)
+
+API_OPENAPI_PROMPT = """You are an API / OpenAPI specialist.
+
+Given a microtask about REST endpoint design, OpenAPI specification, or
+service contract work, produce the required files (routers, schemas,
+openapi.yaml fragments, etc.).
+
+**Microtask:** {description}
+**Language:** {language}
+**Existing code context:** {existing_code}
+
+**Output (JSON):**
+{{
+  "files": {{ "path/to/file": "content" }},
+  "recommendations": ["recommendation 1", ...],
+  "summary": "what was produced"
+}}
+
+Respond with valid JSON only.
+"""
+
+
+class ApiOpenApiToolAgent:
+    """Produces API routes, OpenAPI specs, and service contracts."""
+
+    def __init__(self, llm: LLMClient) -> None:
+        self.llm = llm
+
+    def run(self, inp: ToolAgentInput) -> ToolAgentOutput:
+        prompt = API_OPENAPI_PROMPT.format(
+            description=inp.microtask.description or inp.microtask.title,
+            language=inp.language,
+            existing_code=inp.existing_code[:4000] if inp.existing_code else "(none)",
+        )
+        logger.info("ApiOpenApi: running for microtask %s", inp.microtask.id)
+        raw = self.llm.complete_json(prompt)
+        return ToolAgentOutput(
+            files=raw.get("files") or {},
+            recommendations=raw.get("recommendations") or [],
+            summary=raw.get("summary", ""),
+        )

--- a/agents/software_engineering_team/frontend_agent_v2/tool_agents/auth/__init__.py
+++ b/agents/software_engineering_team/frontend_agent_v2/tool_agents/auth/__init__.py
@@ -1,0 +1,5 @@
+"""Authentication and Authorization tool agent for the frontend-agent-v2 team."""
+
+from .agent import AuthToolAgent
+
+__all__ = ["AuthToolAgent"]

--- a/agents/software_engineering_team/frontend_agent_v2/tool_agents/auth/agent.py
+++ b/agents/software_engineering_team/frontend_agent_v2/tool_agents/auth/agent.py
@@ -1,0 +1,55 @@
+"""
+Authentication and Authorization tool agent: login, RBAC, permissions.
+
+Implemented from scratch inside the frontend-agent-v2 team.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from shared.llm import LLMClient
+
+from ...models import ToolAgentInput, ToolAgentOutput
+
+logger = logging.getLogger(__name__)
+
+AUTH_PROMPT = """You are an Authentication and Authorization specialist.
+
+Given a microtask about login, JWT, RBAC, permission gates, or secure defaults,
+produce the required files (auth modules, middleware, permission models, etc.).
+
+**Microtask:** {description}
+**Language:** {language}
+**Existing code context:** {existing_code}
+
+**Output (JSON):**
+{{
+  "files": {{ "path/to/file": "content" }},
+  "recommendations": ["recommendation 1", ...],
+  "summary": "what was produced"
+}}
+
+Respond with valid JSON only.
+"""
+
+
+class AuthToolAgent:
+    """Produces authentication and authorization code and configurations."""
+
+    def __init__(self, llm: LLMClient) -> None:
+        self.llm = llm
+
+    def run(self, inp: ToolAgentInput) -> ToolAgentOutput:
+        prompt = AUTH_PROMPT.format(
+            description=inp.microtask.description or inp.microtask.title,
+            language=inp.language,
+            existing_code=inp.existing_code[:4000] if inp.existing_code else "(none)",
+        )
+        logger.info("Auth: running for microtask %s", inp.microtask.id)
+        raw = self.llm.complete_json(prompt)
+        return ToolAgentOutput(
+            files=raw.get("files") or {},
+            recommendations=raw.get("recommendations") or [],
+            summary=raw.get("summary", ""),
+        )

--- a/agents/software_engineering_team/frontend_agent_v2/tool_agents/cicd/__init__.py
+++ b/agents/software_engineering_team/frontend_agent_v2/tool_agents/cicd/__init__.py
@@ -1,0 +1,5 @@
+"""CI/CD adapter stub for the frontend-agent-v2 team."""
+
+from .agent import CicdAdapterAgent
+
+__all__ = ["CicdAdapterAgent"]

--- a/agents/software_engineering_team/frontend_agent_v2/tool_agents/cicd/agent.py
+++ b/agents/software_engineering_team/frontend_agent_v2/tool_agents/cicd/agent.py
@@ -1,0 +1,25 @@
+"""
+CI/CD adapter stub for the frontend-agent-v2 team.
+
+This is a thin adapter that can be extended to call DevOps Team APIs.
+No code from ``frontend_agent`` is used.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from ...models import ToolAgentInput, ToolAgentOutput
+
+logger = logging.getLogger(__name__)
+
+
+class CicdAdapterAgent:
+    """Stub CI/CD tool agent — extend to delegate to the DevOps team."""
+
+    def run(self, inp: ToolAgentInput) -> ToolAgentOutput:
+        logger.info("CI/CD stub: microtask %s (not yet implemented)", inp.microtask.id)
+        return ToolAgentOutput(
+            summary="CI/CD adapter stub — no changes applied.",
+            recommendations=["Integrate with DevOps Team CI/CD agents for full support."],
+        )

--- a/agents/software_engineering_team/frontend_agent_v2/tool_agents/containerization/__init__.py
+++ b/agents/software_engineering_team/frontend_agent_v2/tool_agents/containerization/__init__.py
@@ -1,0 +1,5 @@
+"""Containerization adapter stub for the frontend-agent-v2 team."""
+
+from .agent import ContainerizationAdapterAgent
+
+__all__ = ["ContainerizationAdapterAgent"]

--- a/agents/software_engineering_team/frontend_agent_v2/tool_agents/containerization/agent.py
+++ b/agents/software_engineering_team/frontend_agent_v2/tool_agents/containerization/agent.py
@@ -1,0 +1,24 @@
+"""
+Containerization adapter stub for the frontend-agent-v2 team.
+
+No code from ``frontend_agent`` is used.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from ...models import ToolAgentInput, ToolAgentOutput
+
+logger = logging.getLogger(__name__)
+
+
+class ContainerizationAdapterAgent:
+    """Stub containerization tool agent — extend to delegate to the DevOps team."""
+
+    def run(self, inp: ToolAgentInput) -> ToolAgentOutput:
+        logger.info("Containerization stub: microtask %s (not yet implemented)", inp.microtask.id)
+        return ToolAgentOutput(
+            summary="Containerization adapter stub — no changes applied.",
+            recommendations=["Integrate with DevOps Team deployment agents for full support."],
+        )

--- a/agents/software_engineering_team/frontend_agent_v2/tool_agents/data_engineering/__init__.py
+++ b/agents/software_engineering_team/frontend_agent_v2/tool_agents/data_engineering/__init__.py
@@ -1,0 +1,5 @@
+"""Data Engineering tool agent for the frontend-agent-v2 team."""
+
+from .agent import DataEngineeringToolAgent
+
+__all__ = ["DataEngineeringToolAgent"]

--- a/agents/software_engineering_team/frontend_agent_v2/tool_agents/data_engineering/agent.py
+++ b/agents/software_engineering_team/frontend_agent_v2/tool_agents/data_engineering/agent.py
@@ -1,0 +1,56 @@
+"""
+Data Engineering tool agent: schema design, migrations, data integrity.
+
+Implemented from scratch inside the frontend-agent-v2 team.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Dict
+
+from shared.llm import LLMClient
+
+from ...models import ToolAgentInput, ToolAgentOutput
+
+logger = logging.getLogger(__name__)
+
+DATA_ENGINEERING_PROMPT = """You are a Data Engineering specialist.
+
+Given a microtask about database schema, migrations, or data integrity,
+produce the required files (models, migration scripts, seed data, etc.).
+
+**Microtask:** {description}
+**Language:** {language}
+**Existing code context:** {existing_code}
+
+**Output (JSON):**
+{{
+  "files": {{ "path/to/file": "content" }},
+  "recommendations": ["recommendation 1", ...],
+  "summary": "what was produced"
+}}
+
+Respond with valid JSON only.
+"""
+
+
+class DataEngineeringToolAgent:
+    """Produces schema definitions, migration scripts, and data integrity checks."""
+
+    def __init__(self, llm: LLMClient) -> None:
+        self.llm = llm
+
+    def run(self, inp: ToolAgentInput) -> ToolAgentOutput:
+        prompt = DATA_ENGINEERING_PROMPT.format(
+            description=inp.microtask.description or inp.microtask.title,
+            language=inp.language,
+            existing_code=inp.existing_code[:4000] if inp.existing_code else "(none)",
+        )
+        logger.info("DataEngineering: running for microtask %s", inp.microtask.id)
+        raw = self.llm.complete_json(prompt)
+        return ToolAgentOutput(
+            files=raw.get("files") or {},
+            recommendations=raw.get("recommendations") or [],
+            summary=raw.get("summary", ""),
+        )

--- a/agents/software_engineering_team/shared/task_parsing.py
+++ b/agents/software_engineering_team/shared/task_parsing.py
@@ -181,6 +181,7 @@ def _assignee_to_task_type(assignee: str) -> TaskType:
         "backend": TaskType.BACKEND,
         "backend-code-v2": TaskType.BACKEND,
         "frontend": TaskType.FRONTEND,
+        "frontend-agent-v2": TaskType.FRONTEND,
         "devops": TaskType.DEVOPS,
     }
     return mapping.get(assignee, TaskType.BACKEND)

--- a/agents/software_engineering_team/tests/test_backend_code_v2_integration.py
+++ b/agents/software_engineering_team/tests/test_backend_code_v2_integration.py
@@ -33,6 +33,9 @@ class TestTaskParsingBackendCodeV2:
     def test_assignee_to_task_type_maps_backend(self):
         assert _assignee_to_task_type("backend") == TaskType.BACKEND
 
+    def test_assignee_to_task_type_maps_frontend_agent_v2(self):
+        assert _assignee_to_task_type("frontend-agent-v2") == TaskType.FRONTEND
+
     def test_parse_assignment_with_backend_code_v2(self):
         data = {
             "tasks": [

--- a/user-interface/src/app/components/frontend-agent-v2-job-status/frontend-agent-v2-job-status.component.html
+++ b/user-interface/src/app/components/frontend-agent-v2-job-status/frontend-agent-v2-job-status.component.html
@@ -1,0 +1,60 @@
+@if (error) {
+  <mat-card class="error-card">
+    <mat-card-content>
+      <p class="error-text">{{ error }}</p>
+    </mat-card-content>
+  </mat-card>
+}
+
+@if (status) {
+  <mat-card>
+    <mat-card-header>
+      <mat-card-title>Job {{ status.job_id | slice:0:8 }}...</mat-card-title>
+      <mat-card-subtitle>
+        Status: <strong>{{ status.status }}</strong>
+        @if (status.repo_path) {
+          &nbsp;|&nbsp; Repo: {{ status.repo_path }}
+        }
+      </mat-card-subtitle>
+    </mat-card-header>
+    <mat-card-content>
+      <div class="progress-section">
+        <mat-progress-bar
+          mode="determinate"
+          [value]="status.progress"
+          [color]="status.status === 'failed' ? 'warn' : 'primary'"
+        ></mat-progress-bar>
+        <span class="progress-label">{{ status.progress }}%</span>
+      </div>
+
+      <div class="phases-row">
+        @for (phase of phases; track phase) {
+          <div class="phase-item" [ngClass]="phaseClass(phase)">
+            <mat-icon>{{ phaseIcon(phase) }}</mat-icon>
+            <span class="phase-name">{{ phaseLabel(phase) }}</span>
+          </div>
+        }
+      </div>
+
+      @if (status.current_microtask) {
+        <p class="microtask-info">
+          Current microtask: <strong>{{ status.current_microtask }}</strong>
+        </p>
+      }
+
+      @if (status.microtasks_total > 0) {
+        <p class="microtask-info">
+          Microtasks: {{ status.microtasks_completed }} / {{ status.microtasks_total }} completed
+        </p>
+      }
+
+      @if (status.summary) {
+        <p class="summary">{{ status.summary }}</p>
+      }
+
+      @if (status.error) {
+        <p class="error-text">Error: {{ status.error }}</p>
+      }
+    </mat-card-content>
+  </mat-card>
+}

--- a/user-interface/src/app/components/frontend-agent-v2-job-status/frontend-agent-v2-job-status.component.scss
+++ b/user-interface/src/app/components/frontend-agent-v2-job-status/frontend-agent-v2-job-status.component.scss
@@ -1,0 +1,69 @@
+mat-card {
+  margin-top: 16px;
+}
+
+.error-card {
+  border-left: 4px solid #f44336;
+}
+
+.error-text {
+  color: #f44336;
+}
+
+.progress-section {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 16px 0;
+}
+
+mat-progress-bar {
+  flex: 1;
+}
+
+.progress-label {
+  font-weight: 500;
+  min-width: 40px;
+  text-align: right;
+}
+
+.phases-row {
+  display: flex;
+  gap: 24px;
+  flex-wrap: wrap;
+  margin: 16px 0;
+}
+
+.phase-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 14px;
+}
+
+.phase-done {
+  color: #4caf50;
+}
+
+.phase-active {
+  color: #2196f3;
+  font-weight: 500;
+}
+
+.phase-pending {
+  color: #9e9e9e;
+}
+
+.microtask-info {
+  color: #616161;
+  font-size: 14px;
+  margin: 4px 0;
+}
+
+.summary {
+  margin-top: 12px;
+  padding: 8px 12px;
+  background: #f5f5f5;
+  border-radius: 4px;
+  font-size: 14px;
+}

--- a/user-interface/src/app/components/frontend-agent-v2-job-status/frontend-agent-v2-job-status.component.ts
+++ b/user-interface/src/app/components/frontend-agent-v2-job-status/frontend-agent-v2-job-status.component.ts
@@ -1,0 +1,80 @@
+import { Component, Input, OnInit, OnDestroy, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatIconModule } from '@angular/material/icon';
+import { SoftwareEngineeringApiService } from '../../services/software-engineering-api.service';
+import type { FrontendAgentV2StatusResponse } from '../../models';
+
+@Component({
+  selector: 'app-frontend-agent-v2-job-status',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatCardModule,
+    MatProgressBarModule,
+    MatChipsModule,
+    MatIconModule,
+  ],
+  templateUrl: './frontend-agent-v2-job-status.component.html',
+  styleUrl: './frontend-agent-v2-job-status.component.scss',
+})
+export class FrontendAgentV2JobStatusComponent implements OnInit, OnDestroy {
+  @Input() jobId!: string;
+
+  private readonly api = inject(SoftwareEngineeringApiService);
+  private pollTimer: ReturnType<typeof setInterval> | null = null;
+
+  status: FrontendAgentV2StatusResponse | null = null;
+  error: string | null = null;
+
+  readonly phases = ['planning', 'execution', 'review', 'problem_solving', 'deliver'];
+
+  ngOnInit(): void {
+    this.poll();
+    this.pollTimer = setInterval(() => this.poll(), 3000);
+  }
+
+  ngOnDestroy(): void {
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer);
+    }
+  }
+
+  private poll(): void {
+    this.api.getFrontendAgentV2Status(this.jobId).subscribe({
+      next: (res) => {
+        this.status = res;
+        this.error = null;
+        if (res.status === 'completed' || res.status === 'failed') {
+          if (this.pollTimer) {
+            clearInterval(this.pollTimer);
+            this.pollTimer = null;
+          }
+        }
+      },
+      error: (err) => {
+        this.error = err?.error?.detail ?? err?.message ?? 'Failed to fetch status';
+      },
+    });
+  }
+
+  phaseIcon(phase: string): string {
+    if (!this.status) return 'radio_button_unchecked';
+    if (this.status.completed_phases.includes(phase)) return 'check_circle';
+    if (this.status.current_phase === phase) return 'pending';
+    return 'radio_button_unchecked';
+  }
+
+  phaseClass(phase: string): string {
+    if (!this.status) return '';
+    if (this.status.completed_phases.includes(phase)) return 'phase-done';
+    if (this.status.current_phase === phase) return 'phase-active';
+    return 'phase-pending';
+  }
+
+  phaseLabel(phase: string): string {
+    return phase.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+}

--- a/user-interface/src/app/components/frontend-agent-v2-run-form/frontend-agent-v2-run-form.component.html
+++ b/user-interface/src/app/components/frontend-agent-v2-run-form/frontend-agent-v2-run-form.component.html
@@ -1,0 +1,63 @@
+<mat-card>
+  <mat-card-header>
+    <mat-card-title>Run Frontend Agent (v2)</mat-card-title>
+    <mat-card-subtitle>Submit a frontend task and repository path to run the 5-phase workflow</mat-card-subtitle>
+  </mat-card-header>
+  <mat-card-content>
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Repository Path</mat-label>
+      <input matInput [(ngModel)]="repoPath" placeholder="/path/to/repo" />
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Task Title</mat-label>
+      <input matInput [(ngModel)]="title" placeholder="e.g. Build Product Card component with filters" />
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Task Description</mat-label>
+      <textarea matInput [(ngModel)]="description" rows="4" placeholder="Detailed description of what to implement..."></textarea>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Requirements (optional)</mat-label>
+      <textarea matInput [(ngModel)]="requirements" rows="3" placeholder="Technical requirements, frameworks, patterns..."></textarea>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Add Acceptance Criterion</mat-label>
+      <input matInput [(ngModel)]="criterionInput" placeholder="e.g. Product grid supports search and empty states" (keyup.enter)="addCriterion()" />
+      <button mat-icon-button matSuffix (click)="addCriterion()" [disabled]="!criterionInput.trim()">
+        <mat-icon>add</mat-icon>
+      </button>
+    </mat-form-field>
+
+    @if (acceptanceCriteria.length) {
+      <mat-chip-set>
+        @for (criterion of acceptanceCriteria; track criterion; let i = $index) {
+          <mat-chip (removed)="removeCriterion(i)">
+            {{ criterion }}
+            <button matChipRemove>
+              <mat-icon>cancel</mat-icon>
+            </button>
+          </mat-chip>
+        }
+      </mat-chip-set>
+    }
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Project Specification (optional)</mat-label>
+      <textarea matInput [(ngModel)]="specContent" rows="3" placeholder="Paste project spec context..."></textarea>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Architecture Overview (optional)</mat-label>
+      <textarea matInput [(ngModel)]="architecture" rows="3" placeholder="Architecture context..."></textarea>
+    </mat-form-field>
+  </mat-card-content>
+  <mat-card-actions align="end">
+    <button mat-raised-button color="primary" (click)="onSubmit()" [disabled]="!canSubmit">
+      Run Frontend-Agent-V2
+    </button>
+  </mat-card-actions>
+</mat-card>

--- a/user-interface/src/app/components/frontend-agent-v2-run-form/frontend-agent-v2-run-form.component.scss
+++ b/user-interface/src/app/components/frontend-agent-v2-run-form/frontend-agent-v2-run-form.component.scss
@@ -1,0 +1,11 @@
+.full-width {
+  width: 100%;
+}
+
+mat-card {
+  margin-bottom: 16px;
+}
+
+mat-chip-set {
+  margin-bottom: 16px;
+}

--- a/user-interface/src/app/components/frontend-agent-v2-run-form/frontend-agent-v2-run-form.component.ts
+++ b/user-interface/src/app/components/frontend-agent-v2-run-form/frontend-agent-v2-run-form.component.ts
@@ -1,0 +1,69 @@
+import { Component, EventEmitter, Output } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatIconModule } from '@angular/material/icon';
+import type { FrontendAgentV2RunRequest } from '../../models';
+
+@Component({
+  selector: 'app-frontend-agent-v2-run-form',
+  standalone: true,
+  imports: [
+    FormsModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatChipsModule,
+    MatIconModule,
+  ],
+  templateUrl: './frontend-agent-v2-run-form.component.html',
+  styleUrl: './frontend-agent-v2-run-form.component.scss',
+})
+export class FrontendAgentV2RunFormComponent {
+  @Output() submitRequest = new EventEmitter<FrontendAgentV2RunRequest>();
+
+  title = '';
+  description = '';
+  requirements = '';
+  repoPath = '';
+  specContent = '';
+  architecture = '';
+  criterionInput = '';
+  acceptanceCriteria: string[] = [];
+
+  addCriterion(): void {
+    const val = this.criterionInput.trim();
+    if (val) {
+      this.acceptanceCriteria.push(val);
+      this.criterionInput = '';
+    }
+  }
+
+  removeCriterion(index: number): void {
+    this.acceptanceCriteria.splice(index, 1);
+  }
+
+  get canSubmit(): boolean {
+    return !!(this.title.trim() && this.description.trim() && this.repoPath.trim());
+  }
+
+  onSubmit(): void {
+    if (!this.canSubmit) return;
+    const request: FrontendAgentV2RunRequest = {
+      task: {
+        title: this.title.trim(),
+        description: this.description.trim(),
+        requirements: this.requirements.trim() || undefined,
+        acceptance_criteria: this.acceptanceCriteria.length ? this.acceptanceCriteria : undefined,
+      },
+      repo_path: this.repoPath.trim(),
+      spec_content: this.specContent.trim() || undefined,
+      architecture: this.architecture.trim() || undefined,
+    };
+    this.submitRequest.emit(request);
+  }
+}

--- a/user-interface/src/app/components/software-engineering-dashboard/software-engineering-dashboard.component.html
+++ b/user-interface/src/app/components/software-engineering-dashboard/software-engineering-dashboard.component.html
@@ -55,6 +55,14 @@
       }
     </div>
   </mat-tab>
+  <mat-tab label="Frontend Agent (v2)">
+    <div class="tab-content">
+      <app-frontend-agent-v2-run-form (submitRequest)="onFrontendAgentV2Submit($event)" />
+      @if (frontendAgentV2JobId) {
+        <app-frontend-agent-v2-job-status [jobId]="frontendAgentV2JobId" />
+      }
+    </div>
+  </mat-tab>
   <mat-tab label="Architecture">
     <div class="tab-content">
       <mat-card>

--- a/user-interface/src/app/components/software-engineering-dashboard/software-engineering-dashboard.component.ts
+++ b/user-interface/src/app/components/software-engineering-dashboard/software-engineering-dashboard.component.ts
@@ -20,6 +20,8 @@ import { ExecutionStreamComponent } from '../execution-stream/execution-stream.c
 import { ArchitectureResultsComponent } from '../architecture-results/architecture-results.component';
 import { BackendCodeV2RunFormComponent } from '../backend-code-v2-run-form/backend-code-v2-run-form.component';
 import { BackendCodeV2JobStatusComponent } from '../backend-code-v2-job-status/backend-code-v2-job-status.component';
+import { FrontendAgentV2RunFormComponent } from '../frontend-agent-v2-run-form/frontend-agent-v2-run-form.component';
+import { FrontendAgentV2JobStatusComponent } from '../frontend-agent-v2-job-status/frontend-agent-v2-job-status.component';
 import type {
   RunTeamRequest,
   JobStatusResponse,
@@ -27,6 +29,7 @@ import type {
   ClarificationCreateRequest,
   ArchitectDesignResponse,
   BackendCodeV2RunRequest,
+  FrontendAgentV2RunRequest,
 } from '../../models';
 
 @Component({
@@ -53,6 +56,8 @@ import type {
     ArchitectureResultsComponent,
     BackendCodeV2RunFormComponent,
     BackendCodeV2JobStatusComponent,
+    FrontendAgentV2RunFormComponent,
+    FrontendAgentV2JobStatusComponent,
   ],
   templateUrl: './software-engineering-dashboard.component.html',
   styleUrl: './software-engineering-dashboard.component.scss',
@@ -68,6 +73,7 @@ export class SoftwareEngineeringDashboardComponent {
   architectSpec = '';
   architectResults: ArchitectDesignResponse | null = null;
   backendCodeV2JobId: string | null = null;
+  frontendAgentV2JobId: string | null = null;
 
   healthCheck = (): ReturnType<SoftwareEngineeringApiService['health']> =>
     this.api.health();
@@ -158,6 +164,22 @@ export class SoftwareEngineeringDashboardComponent {
       },
       error: (err) => {
         this.error = err?.error?.detail ?? err?.message ?? 'Architecture design failed';
+        this.loading = false;
+      },
+    });
+  }
+
+  onFrontendAgentV2Submit(request: FrontendAgentV2RunRequest): void {
+    this.loading = true;
+    this.error = null;
+    this.frontendAgentV2JobId = null;
+    this.api.runFrontendAgentV2(request).subscribe({
+      next: (res) => {
+        this.frontendAgentV2JobId = res.job_id;
+        this.loading = false;
+      },
+      error: (err) => {
+        this.error = err?.error?.detail ?? err?.message ?? 'Frontend-Agent-V2 request failed';
         this.loading = false;
       },
     });

--- a/user-interface/src/app/models/software-engineering.model.ts
+++ b/user-interface/src/app/models/software-engineering.model.ts
@@ -151,3 +151,42 @@ export interface BackendCodeV2StatusResponse {
   error?: string;
   summary?: string;
 }
+
+/** Task input for frontend-agent-v2. */
+export interface FrontendAgentV2TaskInput {
+  id?: string;
+  title: string;
+  description: string;
+  requirements?: string;
+  acceptance_criteria?: string[];
+}
+
+/** Request for POST /frontend-agent-v2/run. */
+export interface FrontendAgentV2RunRequest {
+  task: FrontendAgentV2TaskInput;
+  repo_path: string;
+  spec_content?: string;
+  architecture?: string;
+}
+
+/** Response from POST /frontend-agent-v2/run. */
+export interface FrontendAgentV2RunResponse {
+  job_id: string;
+  status: string;
+  message: string;
+}
+
+/** Response from GET /frontend-agent-v2/status/{job_id}. */
+export interface FrontendAgentV2StatusResponse {
+  job_id: string;
+  status: string;
+  repo_path?: string;
+  current_phase?: string;
+  current_microtask?: string;
+  progress: number;
+  microtasks_completed: number;
+  microtasks_total: number;
+  completed_phases: string[];
+  error?: string;
+  summary?: string;
+}

--- a/user-interface/src/app/services/software-engineering-api.service.ts
+++ b/user-interface/src/app/services/software-engineering-api.service.ts
@@ -18,6 +18,9 @@ import type {
   BackendCodeV2RunRequest,
   BackendCodeV2RunResponse,
   BackendCodeV2StatusResponse,
+  FrontendAgentV2RunRequest,
+  FrontendAgentV2RunResponse,
+  FrontendAgentV2StatusResponse,
 } from '../models';
 
 /**
@@ -181,6 +184,29 @@ export class SoftwareEngineeringApiService {
   ): Observable<BackendCodeV2StatusResponse> {
     return this.http.get<BackendCodeV2StatusResponse>(
       `${this.baseUrl}/backend-code-v2/status/${jobId}`
+    );
+  }
+
+  /**
+   * POST /frontend-agent-v2/run
+   */
+  runFrontendAgentV2(
+    request: FrontendAgentV2RunRequest
+  ): Observable<FrontendAgentV2RunResponse> {
+    return this.http.post<FrontendAgentV2RunResponse>(
+      `${this.baseUrl}/frontend-agent-v2/run`,
+      request
+    );
+  }
+
+  /**
+   * GET /frontend-agent-v2/status/{job_id}
+   */
+  getFrontendAgentV2Status(
+    jobId: string
+  ): Observable<FrontendAgentV2StatusResponse> {
+    return this.http.get<FrontendAgentV2StatusResponse>(
+      `${this.baseUrl}/frontend-agent-v2/status/${jobId}`
     );
   }
 


### PR DESCRIPTION
### Motivation
- Provide a standalone, v2 frontend engineering agent that mirrors the backend-code-v2 5-phase workflow so frontend implementation tasks can be executed autonomously and polled via API/UI.
- Integrate the new agent into existing orchestrator/task routing so `frontend-agent-v2` can be assigned and tracked like backend-code-v2.

### Description
- Added a new standalone package `agents/software_engineering_team/frontend_agent_v2` implementing the 5-phase lifecycle (planning, execution, review, problem_solving, deliver) with models, prompts, phases, and team-owned tool agents.
- Exposed API endpoints and models in `agents/software_engineering_team/api/main.py`:
  - `POST /frontend-agent-v2/run` to start a background job, and `GET /frontend-agent-v2/status/{job_id}` to poll status, plus background runner wiring to `FrontendAgentV2TeamLead`.
- Added Angular UI pieces and client support:
  - New components `frontend-agent-v2-run-form` and `frontend-agent-v2-job-status`, dashboard tab "Frontend Agent (v2)", TypeScript models, and API client methods in `user-interface/src/app/...`.
- Updated shared parsing so `frontend-agent-v2` maps to `TaskType.FRONTEND`, and added a small integration test assertion to cover the mapping.

### Testing
- Ran Python compile checks: `python -m compileall agents/software_engineering_team/frontend_agent_v2 agents/software_engineering_team/api/main.py agents/software_engineering_team/shared/task_parsing.py` (succeeded).
- Ran unit/integration tests: `pytest -q agents/software_engineering_team/tests/test_backend_code_v2_integration.py` (8 passed).
- Attempted front-end production build: `npm --prefix user-interface run build` failed in this environment due to external Google Fonts inlining returning HTTP 403 (environmental), not code defects.
- Started the Angular dev server and captured a UI screenshot to validate the new dashboard tab (dev server started and screenshot produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699c6eecfbb0832ea6d4a8ea6d48d2b1)