### PR TITLE
Add shared integrations layer (registry, router, adapters, service) with example config and tests

### DIFF
--- a/agents/README.md
+++ b/agents/README.md
@@ -11,6 +11,18 @@ This repository provides **multiple Strands-style agent systems** in a monorepo:
 - **Branding team** – Brand strategy codification, moodboard ideation, design and writing standards, plus an asynchronous open-question feed and answer workflow.
 - **AI systems team** – Agent-factory workflow that takes a structured spec and designs/builds a goal-aligned AI agent system with orchestration, safety gates, and evaluation criteria.
 
+## Shared integrations layer
+
+This repository now includes a shared integrations module at `integrations/` that can be used by **any** agent team.
+
+- Provider-neutral contracts (`discover/read/create/update/notify/schedule` via request metadata)
+- Capability routing (`ticketing.create`, `chat.notify`, `cloud.deploy`, etc.)
+- Registry-driven provider configuration from YAML (Slack, Fireflies.ai, Jira, Trello, Obsidian, Figma, Google Drive/Workspace, Dropbox, AWS/GCP/DigitalOcean/Heroku, Zapier/n8n, GitHub/GitLab)
+- Discovery metadata so agents can inspect each integration's capabilities/actions before use
+- API/MCP transport abstraction to support both vendor APIs and MCP servers
+
+See [integrations/README.md](integrations/README.md) for architecture and setup.
+
 ## Project structure
 
 ```
@@ -24,6 +36,7 @@ strands-agents/
 ├── market_research_team/       # Market research and concept viability
 ├── branding_team/              # Branding strategy + interactive clarification API
 ├── ai_systems_team/            # Spec-to-agent-system blueprint and build workflow
+├── integrations/               # Shared API/MCP integration layer used by all teams
 └── requirements.txt            # Shared dependencies
 ```
 
@@ -37,6 +50,7 @@ strands-agents/
 | [investment_team/](investment_team/README.md) | Multi-asset investment organization with IPS constraints, validation/promotion gates, and safety-first orchestration. |
 | [market_research_team/](market_research_team/README.md) | Market research and business concept viability; transcript ingestion, UX synthesis, experiment scripts, human approval gates. |
 | [ai_systems_team/](ai_systems_team/README.md) | Spec-driven AI agent factory: maps goals to agent roles, orchestration, guardrails, and acceptance tests. |
+| [integrations/](integrations/README.md) | Shared tool integration layer (provider registry, capability router, API/MCP adapter service) reusable by every team. |
 
 ```mermaid
 flowchart LR

--- a/agents/integrations/README.md
+++ b/agents/integrations/README.md
@@ -1,0 +1,103 @@
+# Shared Integrations Layer
+
+This module provides a **single, shared integrations layer** that any agent team can use.
+
+It is intentionally outside individual teams so integrations are configured once and reused by all workflows.
+
+## What this gives you
+
+- A canonical request/response contract (`IntegrationRequest`/`IntegrationResponse`)
+- A registry-driven provider catalog loaded from YAML
+- Capability routing (map `ticketing.create` to Jira/Trello, `chat.notify` to Slack, etc.)
+- One service entry point (`IntegrationService`) for all agent teams
+- Agent discovery API (`discover_integrations`) so agents can determine what each integration can do
+- Transport-agnostic adapter surface that supports API and MCP-backed providers
+
+## Module layout
+
+```text
+agents/integrations/
+  contracts.py                  # canonical request/response model
+  registry.py                   # provider registration and YAML loading
+  router.py                     # capability -> provider resolution
+  adapters.py                   # API/MCP adapter abstraction
+  service.py                    # shared integration entry point + discovery
+  config/providers.example.yaml # sample provider config
+```
+
+## Supported integration catalog (configurable)
+
+The example config now includes detailed capability/action metadata for:
+
+- Slack
+- Fireflies.ai
+- Jira
+- Trello
+- Obsidian
+- Figma
+- Google Drive
+- Dropbox
+- Google Workspace
+- AWS
+- Google Cloud
+- DigitalOcean
+- Heroku
+- Zapier
+- n8n
+- GitHub
+- GitLab
+
+Each provider can define:
+
+- `capabilities` — canonical capability IDs agents can request.
+- `actions` — human-readable action descriptions agents/planners can inspect.
+- `auth` — auth type/scopes needed.
+- `settings` — tenant/workspace/project defaults.
+
+## Agent discovery flow
+
+Agents can inspect all enabled integrations and capabilities before selecting tools:
+
+```python
+from integrations.adapters import ApiMcpAdapter
+from integrations.registry import IntegrationRegistry
+from integrations.router import CapabilityRouter
+from integrations.service import IntegrationService
+
+registry = IntegrationRegistry.from_yaml("integrations/config/providers.example.yaml")
+service = IntegrationService(router=CapabilityRouter(registry), adapter=ApiMcpAdapter())
+
+catalog = service.discover_integrations()
+# catalog["integrations"] -> full provider metadata
+# catalog["capability_index"] -> capability -> providers mapping
+```
+
+## Slack channel targeting
+
+Slack can be configured to post to a specific channel in two ways:
+
+1. Set a provider default in `config/providers.example.yaml` via `settings.default_channel`.
+2. Override per request with `payload["channel"]` when sending `chat.notify`.
+
+The adapter resolves channel target as: request payload channel -> provider default channel.
+
+```python
+from integrations.contracts import IntegrationOperation, IntegrationRequest
+
+response = service.call(
+    IntegrationRequest(
+        operation=IntegrationOperation.NOTIFY,
+        capability="chat.notify",
+        payload={"message": "Build passed", "channel": "#release-alerts"},
+        actor_id="agent:devops",
+        purpose="Notify deployment status",
+    )
+)
+```
+
+## Next implementation steps
+
+1. Add concrete API/MCP clients per provider under `agents/integrations/providers/`.
+2. Add policy gates (approval, scope enforcement, DLP) before write actions.
+3. Add auth broker for OAuth/service-account token management.
+4. Add audit logging and reliability controls (retry/circuit breaker/idempotency).

--- a/agents/integrations/__init__.py
+++ b/agents/integrations/__init__.py
@@ -1,0 +1,13 @@
+"""Shared tool integration layer for all agent teams."""
+
+from .contracts import IntegrationRequest, IntegrationResponse
+from .registry import IntegrationRegistry, ProviderConfig
+from .router import CapabilityRouter
+
+__all__ = [
+    "CapabilityRouter",
+    "IntegrationRegistry",
+    "IntegrationRequest",
+    "IntegrationResponse",
+    "ProviderConfig",
+]

--- a/agents/integrations/adapters.py
+++ b/agents/integrations/adapters.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .contracts import IntegrationRequest, IntegrationResponse
+from .registry import ProviderConfig
+
+
+class ApiMcpAdapter:
+    """Minimal adapter that normalizes outbound API/MCP requests.
+
+    This class is intentionally transport-agnostic for now: it returns a
+    normalized execution plan that teams can wire to concrete clients.
+    """
+
+    def execute(self, provider: ProviderConfig, request: IntegrationRequest) -> IntegrationResponse:
+        result: dict[str, Any] = {
+            "transport": provider.transport,
+            "capability": request.capability,
+            "operation": request.operation.value,
+            "settings": provider.settings,
+            "payload": request.payload,
+        }
+
+        if provider.name == "slack" and request.capability == "chat.notify":
+            default_channel = provider.settings.get("default_channel")
+            selected_channel = request.payload.get("channel") or default_channel
+            if selected_channel:
+                result["target"] = {"channel": selected_channel}
+
+        return IntegrationResponse(provider=provider.name, status="planned", result=result)

--- a/agents/integrations/config/providers.example.yaml
+++ b/agents/integrations/config/providers.example.yaml
@@ -1,0 +1,278 @@
+providers:
+  - name: slack
+    display_name: Slack
+    category: communication
+    description: Team chat and notifications.
+    transport: mcp
+    capabilities: ["chat.notify", "chat.read", "chat.channel.list"]
+    actions:
+      chat.notify: Post messages
+      chat.read: Read channel history
+      chat.channel.list: List available channels
+    auth:
+      type: oauth2
+      scopes: ["chat:write", "channels:history", "channels:read"]
+    settings:
+      server: slack
+      workspace: your-workspace
+      default_channel: "#agent-updates"
+
+  - name: fireflies
+    display_name: Fireflies.ai
+    category: meetings
+    description: Meeting transcripts and AI summaries.
+    transport: api
+    capabilities: ["meeting.transcript.read", "meeting.summary.read"]
+    actions:
+      meeting.transcript.read: Fetch transcript by meeting ID
+      meeting.summary.read: Fetch summary and action items
+    auth:
+      type: api_key
+    settings:
+      base_url: https://api.fireflies.ai/graphql
+
+  - name: jira
+    display_name: Jira
+    category: project_management
+    description: Issue and sprint management.
+    transport: api
+    capabilities: ["ticketing.create", "ticketing.update", "ticketing.read", "ticketing.search"]
+    actions:
+      ticketing.create: Create issues
+      ticketing.update: Transition/update issues
+      ticketing.read: Read issue details
+      ticketing.search: Run JQL searches
+    auth:
+      type: oauth2
+      scopes: ["read:jira-work", "write:jira-work"]
+    settings:
+      base_url: https://your-domain.atlassian.net
+      project_key: ENG
+
+  - name: trello
+    display_name: Trello
+    category: project_management
+    description: Board and card workflow management.
+    transport: api
+    capabilities: ["ticketing.create", "ticketing.update", "ticketing.read"]
+    actions:
+      ticketing.create: Create cards
+      ticketing.update: Move/update cards
+      ticketing.read: Read board/card data
+    auth:
+      type: api_key
+    settings:
+      workspace_id: your-workspace-id
+      default_board_id: your-board-id
+
+  - name: obsidian
+    display_name: Obsidian
+    category: knowledge
+    description: Knowledge base notes in vaults.
+    transport: mcp
+    capabilities: ["knowledge.read", "knowledge.write", "knowledge.search"]
+    actions:
+      knowledge.read: Read notes
+      knowledge.write: Create/update notes
+      knowledge.search: Search notes by keyword/tag
+    auth:
+      type: local_or_mcp
+    settings:
+      server: obsidian
+      vault: company-knowledge
+
+  - name: figma
+    display_name: Figma
+    category: design
+    description: Design file and comment workflows.
+    transport: api
+    capabilities: ["design.read", "design.comment", "design.export"]
+    actions:
+      design.read: Read file metadata/components
+      design.comment: Create/resolve comments
+      design.export: Export assets
+    auth:
+      type: oauth2
+      scopes: ["file_read", "file_write"]
+    settings:
+      team_id: your-team-id
+
+  - name: google_drive
+    display_name: Google Drive
+    category: storage
+    description: File storage and sharing.
+    transport: api
+    capabilities: ["storage.read", "storage.write", "docs.share", "docs.search"]
+    actions:
+      storage.read: Read files and metadata
+      storage.write: Upload/update files
+      docs.share: Share files with users/groups
+      docs.search: Search files
+    auth:
+      type: oauth2
+      scopes: ["https://www.googleapis.com/auth/drive"]
+    settings:
+      default_folder_id: your-folder-id
+
+  - name: dropbox
+    display_name: Dropbox
+    category: storage
+    description: Cloud file storage and collaboration.
+    transport: api
+    capabilities: ["storage.read", "storage.write", "docs.share"]
+    actions:
+      storage.read: Read files and metadata
+      storage.write: Upload/update files
+      docs.share: Create shared links
+    auth:
+      type: oauth2
+    settings:
+      root_path: /agents
+
+  - name: google_workspace
+    display_name: Google Workspace
+    category: productivity
+    description: Gmail, Calendar, Docs, and Slides operations.
+    transport: api
+    capabilities: ["mail.send", "calendar.read", "calendar.create", "docs.create", "slides.create"]
+    actions:
+      mail.send: Send emails
+      calendar.read: Read calendar events
+      calendar.create: Create calendar events
+      docs.create: Create docs
+      slides.create: Create slide decks
+    auth:
+      type: oauth2
+      scopes:
+        - https://www.googleapis.com/auth/gmail.send
+        - https://www.googleapis.com/auth/calendar
+        - https://www.googleapis.com/auth/documents
+        - https://www.googleapis.com/auth/presentations
+    settings:
+      domain: your-company.com
+
+  - name: aws
+    display_name: AWS
+    category: cloud
+    description: Amazon Web Services cloud operations.
+    transport: api
+    capabilities: ["cloud.deploy", "cloud.logs.read", "cloud.resource.read"]
+    actions:
+      cloud.deploy: Deploy workloads
+      cloud.logs.read: Read CloudWatch logs
+      cloud.resource.read: Query cloud resources
+    auth:
+      type: iam_role_or_keys
+    settings:
+      region: us-east-1
+
+  - name: google_cloud
+    display_name: Google Cloud
+    category: cloud
+    description: Google Cloud Platform operations.
+    transport: api
+    capabilities: ["cloud.deploy", "cloud.logs.read", "cloud.resource.read"]
+    actions:
+      cloud.deploy: Deploy workloads
+      cloud.logs.read: Read Cloud Logging
+      cloud.resource.read: Query project resources
+    auth:
+      type: service_account
+      scopes: ["https://www.googleapis.com/auth/cloud-platform"]
+    settings:
+      project_id: your-project-id
+
+  - name: digitalocean
+    display_name: DigitalOcean
+    category: cloud
+    description: App platform, droplets, and networking.
+    transport: api
+    capabilities: ["cloud.deploy", "cloud.logs.read", "cloud.resource.read"]
+    actions:
+      cloud.deploy: Deploy apps
+      cloud.logs.read: Read app logs
+      cloud.resource.read: Read droplets/services
+    auth:
+      type: api_token
+    settings:
+      region: nyc1
+
+  - name: heroku
+    display_name: Heroku
+    category: cloud
+    description: Application deployment and logs.
+    transport: api
+    capabilities: ["cloud.deploy", "cloud.logs.read", "cloud.resource.read"]
+    actions:
+      cloud.deploy: Release/deploy app
+      cloud.logs.read: Read app logs
+      cloud.resource.read: Read app/dyno state
+    auth:
+      type: oauth2
+    settings:
+      app_name: your-app-name
+
+  - name: zapier
+    display_name: Zapier
+    category: automation
+    description: Trigger and orchestrate third-party workflows.
+    transport: api
+    capabilities: ["automation.trigger", "automation.workflow.run", "automation.workflow.list"]
+    actions:
+      automation.trigger: Trigger automation
+      automation.workflow.run: Run workflow with inputs
+      automation.workflow.list: List available workflows
+    auth:
+      type: oauth2
+    settings:
+      workspace: your-workspace
+
+  - name: n8n
+    display_name: n8n
+    category: automation
+    description: Self-hosted workflow automation.
+    transport: api
+    capabilities: ["automation.trigger", "automation.workflow.run", "automation.workflow.list"]
+    actions:
+      automation.trigger: Trigger workflow webhook
+      automation.workflow.run: Start workflow execution
+      automation.workflow.list: List workflows
+    auth:
+      type: api_key
+    settings:
+      base_url: https://n8n.your-company.com
+
+  - name: github
+    display_name: GitHub
+    category: engineering
+    description: Repositories, issues, and pull requests.
+    transport: api
+    capabilities: ["scm.pr.create", "scm.issue.create", "scm.repo.read", "scm.ci.status.read"]
+    actions:
+      scm.pr.create: Open pull requests
+      scm.issue.create: Create issues
+      scm.repo.read: Read repository contents
+      scm.ci.status.read: Read workflow status
+    auth:
+      type: oauth2
+      scopes: ["repo", "workflow"]
+    settings:
+      owner: your-org
+      repo: your-repo
+
+  - name: gitlab
+    display_name: GitLab
+    category: engineering
+    description: Repositories, merge requests, pipelines.
+    transport: api
+    capabilities: ["scm.pr.create", "scm.issue.create", "scm.repo.read", "scm.ci.status.read"]
+    actions:
+      scm.pr.create: Open merge requests
+      scm.issue.create: Create issues
+      scm.repo.read: Read repository/project contents
+      scm.ci.status.read: Read pipeline status
+    auth:
+      type: oauth2_or_pat
+      scopes: ["api", "read_repository", "write_repository"]
+    settings:
+      project_id: your-project-id

--- a/agents/integrations/contracts.py
+++ b/agents/integrations/contracts.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class IntegrationOperation(str, Enum):
+    DISCOVER = "discover"
+    READ = "read"
+    CREATE = "create"
+    UPDATE = "update"
+    NOTIFY = "notify"
+    SCHEDULE = "schedule"
+
+
+class IntegrationRequest(BaseModel):
+    """Provider-neutral request envelope for any tool integration."""
+
+    operation: IntegrationOperation
+    capability: str = Field(..., description="High-level capability such as ticketing.create")
+    payload: dict[str, Any] = Field(default_factory=dict)
+    actor_id: str
+    purpose: str
+    data_classification: str = "internal"
+    idempotency_key: str | None = None
+    approval_token: str | None = None
+    context: dict[str, Any] = Field(default_factory=dict)
+
+
+class IntegrationResponse(BaseModel):
+    """Normalized response returned by a provider adapter."""
+
+    provider: str
+    status: str
+    result: dict[str, Any] = Field(default_factory=dict)
+    raw: dict[str, Any] | None = None

--- a/agents/integrations/registry.py
+++ b/agents/integrations/registry.py
@@ -1,0 +1,87 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+@dataclass(slots=True)
+class ProviderConfig:
+    name: str
+    transport: str
+    capabilities: list[str]
+    settings: dict[str, Any] = field(default_factory=dict)
+    enabled: bool = True
+    display_name: str | None = None
+    category: str = "general"
+    description: str = ""
+    auth: dict[str, Any] = field(default_factory=dict)
+    actions: dict[str, str] = field(default_factory=dict)
+
+
+class IntegrationRegistry:
+    """Registry of integration providers available to all agent teams."""
+
+    def __init__(self, providers: list[ProviderConfig] | None = None) -> None:
+        self._providers: dict[str, ProviderConfig] = {}
+        for provider in providers or []:
+            self.register(provider)
+
+    def register(self, provider: ProviderConfig) -> None:
+        self._providers[provider.name] = provider
+
+    def list_enabled(self) -> list[ProviderConfig]:
+        return [provider for provider in self._providers.values() if provider.enabled]
+
+    def providers_for_capability(self, capability: str) -> list[ProviderConfig]:
+        return [
+            provider
+            for provider in self.list_enabled()
+            if capability in provider.capabilities or "*" in provider.capabilities
+        ]
+
+    def get_provider(self, provider_name: str) -> ProviderConfig:
+        provider = self._providers.get(provider_name)
+        if not provider or not provider.enabled:
+            raise LookupError(f"No enabled integration provider found for '{provider_name}'")
+        return provider
+
+    def describe(self) -> list[dict[str, Any]]:
+        """Returns machine-readable integration metadata for agent planning."""
+        return [
+            {
+                "name": provider.name,
+                "display_name": provider.display_name or provider.name,
+                "category": provider.category,
+                "description": provider.description,
+                "transport": provider.transport,
+                "capabilities": provider.capabilities,
+                "actions": provider.actions,
+                "auth": provider.auth,
+                "settings": provider.settings,
+            }
+            for provider in self.list_enabled()
+        ]
+
+    @classmethod
+    def from_yaml(cls, file_path: str | Path) -> "IntegrationRegistry":
+        payload = yaml.safe_load(Path(file_path).read_text(encoding="utf-8")) or {}
+        providers: list[ProviderConfig] = []
+        for item in payload.get("providers", []):
+            providers.append(
+                ProviderConfig(
+                    name=item["name"],
+                    transport=item.get("transport", "api"),
+                    capabilities=item.get("capabilities", []),
+                    settings=item.get("settings", {}),
+                    enabled=item.get("enabled", True),
+                    display_name=item.get("display_name"),
+                    category=item.get("category", "general"),
+                    description=item.get("description", ""),
+                    auth=item.get("auth", {}),
+                    actions=item.get("actions", {}),
+                )
+            )
+        return cls(providers)

--- a/agents/integrations/router.py
+++ b/agents/integrations/router.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from .contracts import IntegrationRequest
+from .registry import IntegrationRegistry, ProviderConfig
+
+
+class CapabilityRouter:
+    """Resolves a request capability to an enabled integration provider."""
+
+    def __init__(self, registry: IntegrationRegistry, preferred_providers: dict[str, str] | None = None) -> None:
+        self.registry = registry
+        self.preferred_providers = preferred_providers or {}
+
+    def resolve(self, request: IntegrationRequest) -> ProviderConfig:
+        candidates = self.registry.providers_for_capability(request.capability)
+        if not candidates:
+            raise LookupError(f"No integration provider found for capability '{request.capability}'")
+
+        preferred = self.preferred_providers.get(request.capability)
+        if preferred:
+            for candidate in candidates:
+                if candidate.name == preferred:
+                    return candidate
+
+        return candidates[0]

--- a/agents/integrations/service.py
+++ b/agents/integrations/service.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from .contracts import IntegrationRequest, IntegrationResponse
+from .registry import IntegrationRegistry, ProviderConfig
+from .router import CapabilityRouter
+
+
+class ProviderAdapter(Protocol):
+    def execute(self, provider: ProviderConfig, request: IntegrationRequest) -> IntegrationResponse: ...
+
+
+class IntegrationService:
+    """Single entry point agents can use for tool integrations."""
+
+    def __init__(self, router: CapabilityRouter, adapter: ProviderAdapter) -> None:
+        self.router = router
+        self.adapter = adapter
+
+    @property
+    def registry(self) -> IntegrationRegistry:
+        return self.router.registry
+
+    def call(self, request: IntegrationRequest) -> IntegrationResponse:
+        provider = self.router.resolve(request)
+        return self.adapter.execute(provider=provider, request=request)
+
+    def discover_integrations(self) -> dict[str, Any]:
+        """Expose enabled integrations and capabilities so agents can plan tool usage."""
+        integrations = self.registry.describe()
+        capability_index: dict[str, list[str]] = {}
+        for provider in self.registry.list_enabled():
+            for capability in provider.capabilities:
+                capability_index.setdefault(capability, []).append(provider.name)
+
+        return {
+            "integrations": integrations,
+            "capability_index": capability_index,
+        }

--- a/agents/integrations/tests/test_integrations_layer.py
+++ b/agents/integrations/tests/test_integrations_layer.py
@@ -1,0 +1,164 @@
+from pathlib import Path
+
+from integrations.adapters import ApiMcpAdapter
+from integrations.contracts import IntegrationOperation, IntegrationRequest
+from integrations.registry import IntegrationRegistry, ProviderConfig
+from integrations.router import CapabilityRouter
+from integrations.service import IntegrationService
+
+
+REQUIRED_PROVIDERS = {
+    "figma",
+    "fireflies",
+    "jira",
+    "trello",
+    "obsidian",
+    "slack",
+    "google_drive",
+    "dropbox",
+    "google_workspace",
+    "aws",
+    "google_cloud",
+    "digitalocean",
+    "heroku",
+    "zapier",
+    "n8n",
+    "github",
+    "gitlab",
+}
+
+
+def test_registry_filters_enabled_providers() -> None:
+    registry = IntegrationRegistry(
+        [
+            ProviderConfig(name="jira", transport="api", capabilities=["ticketing.create"]),
+            ProviderConfig(name="trello", transport="api", capabilities=["ticketing.create"], enabled=False),
+        ]
+    )
+
+    providers = registry.providers_for_capability("ticketing.create")
+
+    assert [provider.name for provider in providers] == ["jira"]
+
+
+def test_router_uses_preferred_provider_when_available() -> None:
+    registry = IntegrationRegistry(
+        [
+            ProviderConfig(name="jira", transport="api", capabilities=["ticketing.create"]),
+            ProviderConfig(name="trello", transport="api", capabilities=["ticketing.create"]),
+        ]
+    )
+    router = CapabilityRouter(registry, preferred_providers={"ticketing.create": "trello"})
+
+    provider = router.resolve(
+        IntegrationRequest(
+            operation=IntegrationOperation.CREATE,
+            capability="ticketing.create",
+            payload={"title": "Task"},
+            actor_id="agent:test",
+            purpose="create task",
+        )
+    )
+
+    assert provider.name == "trello"
+
+
+def test_service_returns_normalized_execution_plan() -> None:
+    registry = IntegrationRegistry([ProviderConfig(name="slack", transport="mcp", capabilities=["chat.notify"])])
+    router = CapabilityRouter(registry)
+    service = IntegrationService(router=router, adapter=ApiMcpAdapter())
+
+    response = service.call(
+        IntegrationRequest(
+            operation=IntegrationOperation.NOTIFY,
+            capability="chat.notify",
+            payload={"message": "hello"},
+            actor_id="agent:writer",
+            purpose="notify reviewer",
+        )
+    )
+
+    assert response.provider == "slack"
+    assert response.status == "planned"
+    assert response.result["transport"] == "mcp"
+
+
+def test_registry_loads_yaml_configuration() -> None:
+    config_path = Path("agents/integrations/config/providers.example.yaml")
+
+    registry = IntegrationRegistry.from_yaml(config_path)
+
+    assert registry.providers_for_capability("cloud.deploy")
+    assert registry.providers_for_capability("meeting.transcript.read")
+
+
+def test_registry_yaml_includes_required_enterprise_providers() -> None:
+    registry = IntegrationRegistry.from_yaml("agents/integrations/config/providers.example.yaml")
+    provider_names = {provider.name for provider in registry.list_enabled()}
+
+    assert REQUIRED_PROVIDERS.issubset(provider_names)
+
+
+def test_discover_integrations_returns_capability_index_and_actions() -> None:
+    registry = IntegrationRegistry.from_yaml("agents/integrations/config/providers.example.yaml")
+    service = IntegrationService(router=CapabilityRouter(registry), adapter=ApiMcpAdapter())
+
+    catalog = service.discover_integrations()
+
+    assert "integrations" in catalog
+    assert "capability_index" in catalog
+    assert "chat.notify" in catalog["capability_index"]
+    slack = next(item for item in catalog["integrations"] if item["name"] == "slack")
+    assert "chat.notify" in slack["actions"]
+
+
+def test_slack_notify_uses_default_channel_from_provider_settings() -> None:
+    registry = IntegrationRegistry(
+        [
+            ProviderConfig(
+                name="slack",
+                transport="mcp",
+                capabilities=["chat.notify"],
+                settings={"default_channel": "#agent-updates"},
+            )
+        ]
+    )
+    service = IntegrationService(router=CapabilityRouter(registry), adapter=ApiMcpAdapter())
+
+    response = service.call(
+        IntegrationRequest(
+            operation=IntegrationOperation.NOTIFY,
+            capability="chat.notify",
+            payload={"message": "hello"},
+            actor_id="agent:writer",
+            purpose="notify reviewer",
+        )
+    )
+
+    assert response.result["target"]["channel"] == "#agent-updates"
+
+
+def test_slack_notify_prefers_payload_channel_over_default() -> None:
+    registry = IntegrationRegistry(
+        [
+            ProviderConfig(
+                name="slack",
+                transport="mcp",
+                capabilities=["chat.notify"],
+                settings={"default_channel": "#agent-updates"},
+            )
+        ]
+    )
+    service = IntegrationService(router=CapabilityRouter(registry), adapter=ApiMcpAdapter())
+
+    response = service.call(
+        IntegrationRequest(
+            operation=IntegrationOperation.NOTIFY,
+            capability="chat.notify",
+            payload={"message": "hello", "channel": "#release-alerts"},
+            actor_id="agent:writer",
+            purpose="notify reviewer",
+        )
+    )
+
+    assert response.result["target"]["channel"] == "#release-alerts"


### PR DESCRIPTION
### Motivation

- Provide a reusable, provider-agnostic integrations layer so multiple agent teams can share tool/provider configuration and runtime wiring. 
- Expose a canonical request/response contract and discovery surface so agents can inspect available capabilities before invoking tools. 
- Centralize provider configuration in YAML to avoid duplicated integration code across agent suites. 

### Description

- Added a new `agents/integrations/` module with core components: `contracts.py` (canonical `IntegrationRequest`/`IntegrationResponse` and `IntegrationOperation`), `registry.py` (`ProviderConfig` and `IntegrationRegistry` with `from_yaml`), `router.py` (`CapabilityRouter`), `adapters.py` (`ApiMcpAdapter`), and `service.py` (`IntegrationService` and `ProviderAdapter` protocol). 
- Included an example provider catalog at `agents/integrations/config/providers.example.yaml` with many common providers and capability/action metadata. 
- Exported public API via `agents/integrations/__init__.py` and documented module usage and architecture in `agents/integrations/README.md`. 
- Updated top-level `agents/README.md` to mention the shared `integrations/` layer and added a few references in the project structure. 
- Added unit tests in `agents/integrations/tests/test_integrations_layer.py` that cover registry loading, capability filtering, router preference resolution, service call execution plan, discovery/catalog output, and Slack channel default/override behavior. 

### Testing

- Ran the new integration unit tests in `agents/integrations/tests/test_integrations_layer.py` via `pytest` targeting that file. All assertions in the test file passed. 
- Verified `IntegrationRegistry.from_yaml` loads `agents/integrations/config/providers.example.yaml` and populates the capability index as asserted by the tests. 
- Exercised `CapabilityRouter.resolve` and `IntegrationService.call` to confirm provider selection and the normalized execution plan produced by `ApiMcpAdapter`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a119a793c8832e897fadd35c961b40)