### PR TITLE
Add credential-reference session models and session management endpoints

### DIFF
--- a/agents/investment_team/api/main.py
+++ b/agents/investment_team/api/main.py
@@ -35,6 +35,9 @@ from investment_team.models import (
     ValidationReport,
     ValidationStatus,
     WorkflowMode,
+    LoginRequest,
+    SessionState,
+    MfaChallenge,
 )
 from investment_team.orchestrator import InvestmentTeamOrchestrator, QueueItem, WorkflowState
 
@@ -52,7 +55,10 @@ _proposals: Dict[str, PortfolioProposal] = {}
 _strategies: Dict[str, StrategySpec] = {}
 _validations: Dict[str, ValidationReport] = {}
 _workflow_state = WorkflowState()
+_sessions: Dict[str, SessionState] = {}
 _lock = threading.Lock()
+
+SESSION_TTL_SECONDS = 900
 
 
 def _now() -> str:
@@ -208,6 +214,78 @@ class CreateMemoRequest(BaseModel):
 
 class CreateMemoResponse(BaseModel):
     memo: InvestmentCommitteeMemo
+
+
+class StartSessionResponse(BaseModel):
+    session: SessionState
+
+
+class SessionStatusResponse(BaseModel):
+    session: SessionState
+
+
+class TerminateSessionResponse(BaseModel):
+    session_id: str
+    terminated: bool
+
+
+@app.post("/sessions/login", response_model=StartSessionResponse)
+def start_authenticated_session(request: LoginRequest) -> StartSessionResponse:
+    """Start an authenticated session using a credential reference."""
+    session_id = f"sess-{uuid.uuid4().hex[:16]}"
+    session_material_id = f"smat-{uuid.uuid4().hex[:16]}"
+    issued = datetime.now(tz=timezone.utc)
+    expires = issued.timestamp() + SESSION_TTL_SECONDS
+
+    mfa_challenge: Optional[MfaChallenge] = None
+    status = "active"
+    if request.platform.value == "tradingview" and request.mfa_code is None:
+        status = "pending_mfa"
+        mfa_challenge = MfaChallenge(
+            challenge_id=f"mfa-{uuid.uuid4().hex[:10]}",
+            method="totp",
+            expires_at=datetime.fromtimestamp(expires, tz=timezone.utc).isoformat(),
+        )
+
+    session = SessionState(
+        session_id=session_id,
+        platform=request.platform,
+        credential_id=request.credential.credential_id,
+        status=status,
+        issued_at=issued.isoformat(),
+        expires_at=datetime.fromtimestamp(expires, tz=timezone.utc).isoformat(),
+        session_material_id=session_material_id,
+        mfa_challenge=mfa_challenge,
+    )
+
+    with _lock:
+        _sessions[session_id] = session
+
+    return StartSessionResponse(session=session)
+
+
+@app.get("/sessions/{session_id}", response_model=SessionStatusResponse)
+def get_session_status(session_id: str) -> SessionStatusResponse:
+    """Check current session status."""
+    with _lock:
+        session = _sessions.get(session_id)
+
+    if not session:
+        raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
+
+    return SessionStatusResponse(session=session)
+
+
+@app.delete("/sessions/{session_id}", response_model=TerminateSessionResponse)
+def terminate_session(session_id: str) -> TerminateSessionResponse:
+    """Terminate an authenticated session."""
+    with _lock:
+        removed = _sessions.pop(session_id, None)
+
+    if not removed:
+        raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
+
+    return TerminateSessionResponse(session_id=session_id, terminated=True)
 
 
 @app.get("/health")

--- a/agents/investment_team/api/main.py
+++ b/agents/investment_team/api/main.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import threading
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
 
 from fastapi import FastAPI, HTTPException
@@ -38,6 +38,7 @@ from investment_team.models import (
     LoginRequest,
     SessionState,
     MfaChallenge,
+    SessionStatus,
 )
 from investment_team.orchestrator import InvestmentTeamOrchestrator, QueueItem, WorkflowState
 
@@ -235,16 +236,16 @@ def start_authenticated_session(request: LoginRequest) -> StartSessionResponse:
     session_id = f"sess-{uuid.uuid4().hex[:16]}"
     session_material_id = f"smat-{uuid.uuid4().hex[:16]}"
     issued = datetime.now(tz=timezone.utc)
-    expires = issued.timestamp() + SESSION_TTL_SECONDS
+    expires_at = issued + timedelta(seconds=SESSION_TTL_SECONDS)
 
     mfa_challenge: Optional[MfaChallenge] = None
-    status = "active"
+    status = SessionStatus.ACTIVE
     if request.platform.value == "tradingview" and request.mfa_code is None:
-        status = "pending_mfa"
+        status = SessionStatus.PENDING_MFA
         mfa_challenge = MfaChallenge(
             challenge_id=f"mfa-{uuid.uuid4().hex[:10]}",
             method="totp",
-            expires_at=datetime.fromtimestamp(expires, tz=timezone.utc).isoformat(),
+            expires_at=expires_at.isoformat(),
         )
 
     session = SessionState(
@@ -253,7 +254,7 @@ def start_authenticated_session(request: LoginRequest) -> StartSessionResponse:
         credential_id=request.credential.credential_id,
         status=status,
         issued_at=issued.isoformat(),
-        expires_at=datetime.fromtimestamp(expires, tz=timezone.utc).isoformat(),
+        expires_at=expires_at.isoformat(),
         session_material_id=session_material_id,
         mfa_challenge=mfa_challenge,
     )
@@ -272,6 +273,14 @@ def get_session_status(session_id: str) -> SessionStatusResponse:
 
     if not session:
         raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
+
+    if session.status != SessionStatus.TERMINATED:
+        expires_at = datetime.fromisoformat(session.expires_at)
+        if expires_at <= datetime.now(tz=timezone.utc):
+            session.status = SessionStatus.EXPIRED
+            session.mfa_challenge = None
+            with _lock:
+                _sessions[session_id] = session
 
     return SessionStatusResponse(session=session)
 

--- a/agents/investment_team/api/main.py
+++ b/agents/investment_team/api/main.py
@@ -66,6 +66,11 @@ def _now() -> str:
     return datetime.now(tz=timezone.utc).isoformat()
 
 
+def _is_valid_mfa_code(code: Optional[str]) -> bool:
+    """Basic MFA code validation (6 numeric digits)."""
+    return bool(code and code.isdigit() and len(code) == 6)
+
+
 class CreateProfileRequest(BaseModel):
     user_id: str = Field(..., description="Unique user identifier")
     risk_tolerance: str = Field(..., description="low, medium, high, or very_high")
@@ -234,14 +239,16 @@ class TerminateSessionResponse(BaseModel):
 def start_authenticated_session(request: LoginRequest) -> StartSessionResponse:
     """Start an authenticated session using a credential reference."""
     session_id = f"sess-{uuid.uuid4().hex[:16]}"
-    session_material_id = f"smat-{uuid.uuid4().hex[:16]}"
     issued = datetime.now(tz=timezone.utc)
     expires_at = issued + timedelta(seconds=SESSION_TTL_SECONDS)
 
     mfa_challenge: Optional[MfaChallenge] = None
     status = SessionStatus.ACTIVE
-    if request.platform.value == "tradingview" and request.mfa_code is None:
+    session_material_id: Optional[str] = f"smat-{uuid.uuid4().hex[:16]}"
+
+    if request.platform.value == "tradingview" and not _is_valid_mfa_code(request.mfa_code):
         status = SessionStatus.PENDING_MFA
+        session_material_id = None
         mfa_challenge = MfaChallenge(
             challenge_id=f"mfa-{uuid.uuid4().hex[:10]}",
             method="totp",
@@ -270,17 +277,14 @@ def get_session_status(session_id: str) -> SessionStatusResponse:
     """Check current session status."""
     with _lock:
         session = _sessions.get(session_id)
+        if not session:
+            raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
 
-    if not session:
-        raise HTTPException(status_code=404, detail=f"Session {session_id} not found")
-
-    if session.status != SessionStatus.TERMINATED:
-        expires_at = datetime.fromisoformat(session.expires_at)
-        if expires_at <= datetime.now(tz=timezone.utc):
-            session.status = SessionStatus.EXPIRED
-            session.mfa_challenge = None
-            with _lock:
-                _sessions[session_id] = session
+        if session.status != SessionStatus.TERMINATED:
+            expires_at = datetime.fromisoformat(session.expires_at)
+            if expires_at <= datetime.now(tz=timezone.utc):
+                session.status = SessionStatus.EXPIRED
+                session.mfa_challenge = None
 
     return SessionStatusResponse(session=session)
 

--- a/agents/investment_team/models.py
+++ b/agents/investment_team/models.py
@@ -224,7 +224,7 @@ class OrderIntent(BaseModel):
 class ExecutionReport(BaseModel):
     strategy_id: str
     broker_order_id: str
-    status: str
+    status: SessionStatus
     avg_fill_price: Optional[float] = None
     slippage_bps: Optional[float] = None
     reconciled: bool = False
@@ -268,6 +268,15 @@ class ExternalPlatform(str, Enum):
     TRADINGVIEW = "tradingview"
 
 
+
+
+class SessionStatus(str, Enum):
+    ACTIVE = "active"
+    PENDING_MFA = "pending_mfa"
+    EXPIRED = "expired"
+    TERMINATED = "terminated"
+
+
 class CredentialRef(BaseModel):
     credential_id: str
 
@@ -288,7 +297,7 @@ class SessionState(BaseModel):
     session_id: str
     platform: ExternalPlatform
     credential_id: str
-    status: str
+    status: SessionStatus
     issued_at: str
     expires_at: str
     session_material_id: str

--- a/agents/investment_team/models.py
+++ b/agents/investment_team/models.py
@@ -300,5 +300,5 @@ class SessionState(BaseModel):
     status: SessionStatus
     issued_at: str
     expires_at: str
-    session_material_id: str
+    session_material_id: Optional[str] = None
     mfa_challenge: Optional[MfaChallenge] = None

--- a/agents/investment_team/models.py
+++ b/agents/investment_team/models.py
@@ -224,7 +224,7 @@ class OrderIntent(BaseModel):
 class ExecutionReport(BaseModel):
     strategy_id: str
     broker_order_id: str
-    status: SessionStatus
+    status: str
     avg_fill_price: Optional[float] = None
     slippage_bps: Optional[float] = None
     reconciled: bool = False

--- a/agents/investment_team/models.py
+++ b/agents/investment_team/models.py
@@ -261,3 +261,35 @@ class InvestmentCommitteeMemo(BaseModel):
     dissenting_views: List[str] = Field(default_factory=list)
     attachments: List[str] = Field(default_factory=list)
     audit: AuditContext = Field(default_factory=AuditContext)
+
+
+class ExternalPlatform(str, Enum):
+    QUANTCONNECT = "quantconnect"
+    TRADINGVIEW = "tradingview"
+
+
+class CredentialRef(BaseModel):
+    credential_id: str
+
+
+class MfaChallenge(BaseModel):
+    challenge_id: str
+    method: str
+    expires_at: str
+
+
+class LoginRequest(BaseModel):
+    platform: ExternalPlatform
+    credential: CredentialRef
+    mfa_code: Optional[str] = Field(default=None, description="Optional one-time MFA code")
+
+
+class SessionState(BaseModel):
+    session_id: str
+    platform: ExternalPlatform
+    credential_id: str
+    status: str
+    issued_at: str
+    expires_at: str
+    session_material_id: str
+    mfa_challenge: Optional[MfaChallenge] = None

--- a/agents/investment_team/tests/test_investment_team.py
+++ b/agents/investment_team/tests/test_investment_team.py
@@ -16,6 +16,7 @@ from agents.investment_team.models import (
     TaxProfile,
     UserGoal,
     UserPreferences,
+    ExecutionReport,
     ValidationCheck,
     ValidationReport,
     ValidationStatus,
@@ -145,3 +146,16 @@ def test_policy_guardian_rejects_excluded_asset_class() -> None:
     violations = PolicyGuardianAgent().check_portfolio(ips, proposal)
 
     assert any("excluded by IPS preferences" in item for item in violations)
+
+
+def test_execution_report_accepts_non_session_status_values() -> None:
+    report = ExecutionReport(
+        strategy_id="s1",
+        broker_order_id="ord-1",
+        status="filled",
+        avg_fill_price=101.25,
+        slippage_bps=1.5,
+        reconciled=True,
+    )
+
+    assert report.status == "filled"

--- a/agents/investment_team/tests/test_session_api.py
+++ b/agents/investment_team/tests/test_session_api.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from fastapi.testclient import TestClient
+
+from investment_team.api import main as api_main
+
+app = api_main.app
+
+
+client = TestClient(app)
+
+
+def test_start_session_uses_opaque_ids_and_pending_mfa() -> None:
+    response = client.post(
+        "/sessions/login",
+        json={"platform": "tradingview", "credential": {"credential_id": "cred-ref-1"}},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()["session"]
+
+    assert payload["platform"] == "tradingview"
+    assert payload["credential_id"] == "cred-ref-1"
+    assert payload["status"] == "pending_mfa"
+    assert payload["session_id"].startswith("sess-")
+    assert payload["session_material_id"].startswith("smat-")
+    assert "password" not in payload
+    assert payload["mfa_challenge"] is not None
+
+
+def test_get_and_terminate_session_lifecycle() -> None:
+    create_response = client.post(
+        "/sessions/login",
+        json={"platform": "quantconnect", "credential": {"credential_id": "cred-ref-2"}},
+    )
+    assert create_response.status_code == 200
+    session_id = create_response.json()["session"]["session_id"]
+
+    status_response = client.get(f"/sessions/{session_id}")
+    assert status_response.status_code == 200
+    assert status_response.json()["session"]["status"] == "active"
+
+    terminate_response = client.delete(f"/sessions/{session_id}")
+    assert terminate_response.status_code == 200
+    assert terminate_response.json() == {"session_id": session_id, "terminated": True}
+
+    not_found_response = client.get(f"/sessions/{session_id}")
+    assert not_found_response.status_code == 404
+
+
+def test_expired_session_status_is_reported() -> None:
+    create_response = client.post(
+        "/sessions/login",
+        json={"platform": "quantconnect", "credential": {"credential_id": "cred-ref-3"}},
+    )
+    assert create_response.status_code == 200
+
+    session = create_response.json()["session"]
+    session_id = session["session_id"]
+
+    # Overwrite timestamps to force expiration.
+    expired_time = (datetime.now(tz=timezone.utc) - timedelta(minutes=1)).isoformat()
+    api_main._sessions[session_id].expires_at = expired_time
+
+    status_response = client.get(f"/sessions/{session_id}")
+    assert status_response.status_code == 200
+    assert status_response.json()["session"]["status"] == "expired"

--- a/agents/investment_team/tests/test_session_api.py
+++ b/agents/investment_team/tests/test_session_api.py
@@ -25,7 +25,7 @@ def test_start_session_uses_opaque_ids_and_pending_mfa() -> None:
     assert payload["credential_id"] == "cred-ref-1"
     assert payload["status"] == "pending_mfa"
     assert payload["session_id"].startswith("sess-")
-    assert payload["session_material_id"].startswith("smat-")
+    assert payload["session_material_id"] is None
     assert "password" not in payload
     assert payload["mfa_challenge"] is not None
 
@@ -67,3 +67,57 @@ def test_expired_session_status_is_reported() -> None:
     status_response = client.get(f"/sessions/{session_id}")
     assert status_response.status_code == 200
     assert status_response.json()["session"]["status"] == "expired"
+
+
+def test_tradingview_invalid_or_empty_mfa_code_stays_pending() -> None:
+    for mfa_code in ["", "abcxyz", "12ab56", "12345"]:
+        response = client.post(
+            "/sessions/login",
+            json={
+                "platform": "tradingview",
+                "credential": {"credential_id": "cred-ref-invalid"},
+                "mfa_code": mfa_code,
+            },
+        )
+        assert response.status_code == 200
+        payload = response.json()["session"]
+        assert payload["status"] == "pending_mfa"
+        assert payload["session_material_id"] is None
+        assert payload["mfa_challenge"] is not None
+
+
+def test_tradingview_valid_mfa_code_activates_session() -> None:
+    response = client.post(
+        "/sessions/login",
+        json={
+            "platform": "tradingview",
+            "credential": {"credential_id": "cred-ref-valid"},
+            "mfa_code": "123456",
+        },
+    )
+    assert response.status_code == 200
+    payload = response.json()["session"]
+    assert payload["status"] == "active"
+    assert payload["session_material_id"].startswith("smat-")
+    assert payload["mfa_challenge"] is None
+
+
+def test_get_session_status_does_not_recreate_deleted_session_on_expiry_path() -> None:
+    create_response = client.post(
+        "/sessions/login",
+        json={"platform": "quantconnect", "credential": {"credential_id": "cred-ref-4"}},
+    )
+    assert create_response.status_code == 200
+    session_id = create_response.json()["session"]["session_id"]
+
+    expired_time = (datetime.now(tz=timezone.utc) - timedelta(minutes=1)).isoformat()
+    api_main._sessions[session_id].expires_at = expired_time
+
+    # Simulate a concurrent delete by removing under the lock before status read writes back.
+    with api_main._lock:
+        deleted = api_main._sessions.pop(session_id, None)
+    assert deleted is not None
+
+    status_response = client.get(f"/sessions/{session_id}")
+    assert status_response.status_code == 404
+    assert session_id not in api_main._sessions


### PR DESCRIPTION
### Motivation
- Provide a secure, credential-reference based authentication flow for external platforms without persisting raw passwords, and enable short-lived session material issuance for integration with brokers/third-party platforms.
- Support MFA-capable platforms (e.g., TradingView) with a pending-MFA flow and opaque challenge metadata.

### Description
- Added new models in `agents/investment_team/models.py`: `ExternalPlatform` enum (`quantconnect`, `tradingview`), `CredentialRef`, `MfaChallenge`, `LoginRequest`, and `SessionState` to represent credential references, MFA challenges, and ephemeral session state.
- Added in-memory session storage and TTL configuration (`_sessions`, `SESSION_TTL_SECONDS`) to `agents/investment_team/api/main.py` to track short-lived session records without storing secrets.
- Implemented session endpoints in `agents/investment_team/api/main.py`: `POST /sessions/login` to start a session from a `LoginRequest` (returns opaque `session_id` and `session_material_id` plus optional `MfaChallenge`), `GET /sessions/{session_id}` to return session status, and `DELETE /sessions/{session_id}` to terminate a session.
- The API only accepts credential references and returns opaque identifiers and status/timestamps; raw passwords or secrets are not stored or returned in responses.

### Testing
- Compiled the modified modules with `python -m compileall agents/investment_team/models.py agents/investment_team/api/main.py` which succeeded.
- Performed a FastAPI smoke test using `PYTHONPATH=agents` and `fastapi.testclient.TestClient` to exercise `POST /sessions/login`, `GET /sessions/{session_id}`, and `DELETE /sessions/{session_id}`, which passed.
- Ran `pytest -q` repository-wide which failed during collection due to unrelated import/path issues in other agent packages (these failures are external to the changes in the Investment Team API).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3795570a4832eafdca8a1cedfe841)