### PR TITLE
Add provider-agnostic web interface package for investment orchestrator

### DIFF
--- a/agents/investment_team/orchestrator.py
+++ b/agents/investment_team/orchestrator.py
@@ -6,8 +6,6 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List
 
 from .agents import AgentIdentity, PolicyGuardianAgent, PromotionGateAgent
-from .tool_agents.web_interfaces import InvestmentWebInterfaceCoordinator
-
 from .models import (
     IPS,
     PortfolioProposal,
@@ -16,6 +14,7 @@ from .models import (
     ValidationReport,
     WorkflowMode,
 )
+from .tool_agents.web_interfaces import InvestmentWebInterfaceCoordinator
 
 
 @dataclass

--- a/agents/investment_team/orchestrator.py
+++ b/agents/investment_team/orchestrator.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Any, Dict, List
 
 from .agents import AgentIdentity, PolicyGuardianAgent, PromotionGateAgent
+from .tool_agents.web_interfaces import InvestmentWebInterfaceCoordinator
+
 from .models import (
     IPS,
     PortfolioProposal,
@@ -49,9 +51,10 @@ class InvestmentTeamOrchestrator:
     - Live promotion requires IPS permission and independent approver.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, web_interface_coordinator: InvestmentWebInterfaceCoordinator | None = None) -> None:
         self.policy_guardian = PolicyGuardianAgent()
         self.promotion_gate = PromotionGateAgent()
+        self.web_interface_coordinator = web_interface_coordinator
 
     def bootstrap(self, state: WorkflowState, ips: IPS) -> None:
         state.mode = ips.default_mode
@@ -98,3 +101,18 @@ class InvestmentTeamOrchestrator:
         if decision.outcome.value in {"reject", "revise"}:
             self.enqueue(state, QueueItem(queue="escalation", payload_id=strategy.strategy_id, priority="high"))
         return decision
+
+    def run_web_action(
+        self,
+        action: str,
+        payload: Dict[str, Any] | None = None,
+        workspace_name: str | None = None,
+    ) -> Dict[str, Any]:
+        """Run provider-backed web action when coordinator is configured."""
+        if not self.web_interface_coordinator:
+            raise RuntimeError("web interface coordinator is not configured")
+        return self.web_interface_coordinator.execute_action(
+            action=action,
+            payload=payload,
+            workspace_name=workspace_name,
+        )

--- a/agents/investment_team/tests/test_investment_team.py
+++ b/agents/investment_team/tests/test_investment_team.py
@@ -1,3 +1,4 @@
+import pytest
 from agents.investment_team.agents import AgentIdentity, PolicyGuardianAgent, PromotionGateAgent
 from agents.investment_team.models import (
     IPS,
@@ -214,3 +215,41 @@ def test_web_interface_coordinator_accepts_string_browser_config() -> None:
     result = coordinator.execute_action(action="capture_chart", payload={"symbol": "QQQ"})
 
     assert result["results"]["login"]["details"]["browser"] == "firefox"
+
+
+def test_web_interface_coordinator_logs_out_when_action_fails() -> None:
+    class _FailingAgent:
+        def __init__(self) -> None:
+            self.logged_out = False
+
+        def login(self):
+            return type("Result", (), {"provider": "quantconnect", "action": "login", "status": "ok", "details": {}})()
+
+        def open_workspace(self, workspace_name=None):
+            return type(
+                "Result",
+                (),
+                {"provider": "quantconnect", "action": "open_workspace", "status": "ok", "details": {}},
+            )()
+
+        def run_action(self, action, payload=None):
+            raise RuntimeError("run failed")
+
+        def collect_artifacts(self):
+            return []
+
+        def logout(self):
+            self.logged_out = True
+            return type("Result", (), {"provider": "quantconnect", "action": "logout", "status": "ok", "details": {}})()
+
+    coordinator = InvestmentWebInterfaceCoordinator(
+        provider="quantconnect",
+        config=WebAgentConfig(browser=BrowserType.CHROMIUM),
+    )
+    failing_agent = _FailingAgent()
+    coordinator._build_agent = lambda provider, config: failing_agent  # type: ignore[attr-defined]
+
+    with pytest.raises(RuntimeError, match="run failed"):
+        coordinator.execute_action(action="deploy_strategy", payload={"strategy_id": "s1"})
+
+    assert failing_agent.logged_out is True

--- a/agents/investment_team/tests/test_investment_team.py
+++ b/agents/investment_team/tests/test_investment_team.py
@@ -21,6 +21,11 @@ from agents.investment_team.models import (
     ValidationStatus,
 )
 from agents.investment_team.orchestrator import InvestmentTeamOrchestrator, WorkflowState
+from agents.investment_team.tool_agents.web_interfaces import (
+    BrowserType,
+    InvestmentWebInterfaceCoordinator,
+    WebAgentConfig,
+)
 
 
 def _sample_ips() -> IPS:
@@ -145,3 +150,41 @@ def test_policy_guardian_rejects_excluded_asset_class() -> None:
     violations = PolicyGuardianAgent().check_portfolio(ips, proposal)
 
     assert any("excluded by IPS preferences" in item for item in violations)
+
+
+def test_web_interface_coordinator_selects_provider_and_runs_action() -> None:
+    coordinator = InvestmentWebInterfaceCoordinator(
+        provider="quantconnect",
+        config=WebAgentConfig(browser=BrowserType.FIREFOX, workspace_name="alpha-lab"),
+    )
+
+    result = coordinator.execute_action(action="deploy_strategy", payload={"strategy_id": "s1"})
+
+    assert result["provider"] == "quantconnect"
+    assert result["results"]["login"]["details"]["browser"] == "firefox"
+    assert result["results"]["open_workspace"]["details"]["workspace"] == "alpha-lab"
+    assert result["artifacts"][0]["action"] == "deploy_strategy"
+
+
+def test_orchestrator_web_action_uses_optional_coordinator() -> None:
+    coordinator = InvestmentWebInterfaceCoordinator(
+        provider="tradingview",
+        config=WebAgentConfig(browser=BrowserType.CHROMIUM),
+    )
+    orch = InvestmentTeamOrchestrator(web_interface_coordinator=coordinator)
+
+    result = orch.run_web_action(action="capture_chart", payload={"symbol": "SPY"}, workspace_name="swing")
+
+    assert result["provider"] == "tradingview"
+    assert result["results"]["open_workspace"]["details"]["workspace"] == "swing"
+
+
+def test_orchestrator_web_action_requires_configured_coordinator() -> None:
+    orch = InvestmentTeamOrchestrator()
+
+    try:
+        orch.run_web_action(action="noop")
+    except RuntimeError as exc:
+        assert "not configured" in str(exc)
+    else:
+        raise AssertionError("expected RuntimeError when coordinator missing")

--- a/agents/investment_team/tests/test_investment_team.py
+++ b/agents/investment_team/tests/test_investment_team.py
@@ -188,3 +188,29 @@ def test_orchestrator_web_action_requires_configured_coordinator() -> None:
         assert "not configured" in str(exc)
     else:
         raise AssertionError("expected RuntimeError when coordinator missing")
+
+
+def test_web_interface_coordinator_returns_run_scoped_artifacts() -> None:
+    coordinator = InvestmentWebInterfaceCoordinator(
+        provider="quantconnect",
+        config=WebAgentConfig(browser=BrowserType.CHROMIUM),
+    )
+
+    first = coordinator.execute_action(action="deploy_strategy", payload={"strategy_id": "s1"})
+    second = coordinator.execute_action(action="deploy_strategy", payload={"strategy_id": "s2"})
+
+    assert len(first["artifacts"]) == 1
+    assert first["artifacts"][0]["payload"]["strategy_id"] == "s1"
+    assert len(second["artifacts"]) == 1
+    assert second["artifacts"][0]["payload"]["strategy_id"] == "s2"
+
+
+def test_web_interface_coordinator_accepts_string_browser_config() -> None:
+    coordinator = InvestmentWebInterfaceCoordinator(
+        provider="tradingview",
+        config=WebAgentConfig(browser="firefox"),
+    )
+
+    result = coordinator.execute_action(action="capture_chart", payload={"symbol": "QQQ"})
+
+    assert result["results"]["login"]["details"]["browser"] == "firefox"

--- a/agents/investment_team/tool_agents/__init__.py
+++ b/agents/investment_team/tool_agents/__init__.py
@@ -1,0 +1,1 @@
+"""Tool-facing agents for investment team."""

--- a/agents/investment_team/tool_agents/web_interfaces/__init__.py
+++ b/agents/investment_team/tool_agents/web_interfaces/__init__.py
@@ -1,0 +1,12 @@
+"""Web automation interfaces for broker/platform providers."""
+
+from .coordinator import InvestmentWebInterfaceCoordinator, WebProvider
+from .interfaces import BrowserType, WebAgentConfig, WebBrokerInterface
+
+__all__ = [
+    "BrowserType",
+    "InvestmentWebInterfaceCoordinator",
+    "WebAgentConfig",
+    "WebBrokerInterface",
+    "WebProvider",
+]

--- a/agents/investment_team/tool_agents/web_interfaces/coordinator.py
+++ b/agents/investment_team/tool_agents/web_interfaces/coordinator.py
@@ -38,11 +38,26 @@ class InvestmentWebInterfaceCoordinator:
         workspace_name: str | None = None,
     ) -> Dict[str, Any]:
         agent = self._build_agent(self.provider, self.config)
-        login_result = agent.login()
-        workspace_result = agent.open_workspace(workspace_name=workspace_name)
-        action_result = agent.run_action(action, payload=payload)
-        artifacts = agent.collect_artifacts()
-        logout_result = agent.logout()
+        logout_result: WebActionResult | None = None
+        request_failed = False
+
+        try:
+            login_result = agent.login()
+            workspace_result = agent.open_workspace(workspace_name=workspace_name)
+            action_result = agent.run_action(action, payload=payload)
+            artifacts = agent.collect_artifacts()
+        except Exception:
+            request_failed = True
+            raise
+        finally:
+            try:
+                logout_result = agent.logout()
+            except Exception:
+                if not request_failed:
+                    raise
+
+        if logout_result is None:
+            raise RuntimeError("logout result missing after execute_action")
 
         return {
             "provider": self.provider.value,

--- a/agents/investment_team/tool_agents/web_interfaces/coordinator.py
+++ b/agents/investment_team/tool_agents/web_interfaces/coordinator.py
@@ -1,0 +1,64 @@
+"""Coordinator for selecting and invoking investment web interfaces."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, Dict, List
+
+from .interfaces import WebActionResult, WebAgentConfig, WebBrokerInterface
+from .quantconnect_agent import QuantConnectWebAgent
+from .tradingview_agent import TradingViewWebAgent
+
+
+class WebProvider(str, Enum):
+    QUANTCONNECT = "quantconnect"
+    TRADINGVIEW = "tradingview"
+
+
+class InvestmentWebInterfaceCoordinator:
+    """Factory + façade for provider-agnostic web workflows."""
+
+    def __init__(self, provider: WebProvider | str, config: WebAgentConfig) -> None:
+        provider_value = provider.value if isinstance(provider, WebProvider) else provider.lower()
+        self.provider = WebProvider(provider_value)
+        self.agent = self._build_agent(self.provider, config)
+
+    @staticmethod
+    def _build_agent(provider: WebProvider, config: WebAgentConfig) -> WebBrokerInterface:
+        providers = {
+            WebProvider.QUANTCONNECT: QuantConnectWebAgent,
+            WebProvider.TRADINGVIEW: TradingViewWebAgent,
+        }
+        return providers[provider](config)
+
+    def execute_action(
+        self,
+        action: str,
+        payload: Dict[str, Any] | None = None,
+        workspace_name: str | None = None,
+    ) -> Dict[str, Any]:
+        login_result = self.agent.login()
+        workspace_result = self.agent.open_workspace(workspace_name=workspace_name)
+        action_result = self.agent.run_action(action, payload=payload)
+        artifacts = self.agent.collect_artifacts()
+        logout_result = self.agent.logout()
+
+        return {
+            "provider": self.provider.value,
+            "results": {
+                "login": self._serialize(login_result),
+                "open_workspace": self._serialize(workspace_result),
+                "run_action": self._serialize(action_result),
+                "logout": self._serialize(logout_result),
+            },
+            "artifacts": artifacts,
+        }
+
+    @staticmethod
+    def _serialize(result: WebActionResult) -> Dict[str, Any]:
+        return {
+            "provider": result.provider,
+            "action": result.action,
+            "status": result.status,
+            "details": result.details,
+        }

--- a/agents/investment_team/tool_agents/web_interfaces/coordinator.py
+++ b/agents/investment_team/tool_agents/web_interfaces/coordinator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, List
+from typing import Any, Dict
 
 from .interfaces import WebActionResult, WebAgentConfig, WebBrokerInterface
 from .quantconnect_agent import QuantConnectWebAgent

--- a/agents/investment_team/tool_agents/web_interfaces/coordinator.py
+++ b/agents/investment_team/tool_agents/web_interfaces/coordinator.py
@@ -21,7 +21,7 @@ class InvestmentWebInterfaceCoordinator:
     def __init__(self, provider: WebProvider | str, config: WebAgentConfig) -> None:
         provider_value = provider.value if isinstance(provider, WebProvider) else provider.lower()
         self.provider = WebProvider(provider_value)
-        self.agent = self._build_agent(self.provider, config)
+        self.config = config
 
     @staticmethod
     def _build_agent(provider: WebProvider, config: WebAgentConfig) -> WebBrokerInterface:
@@ -37,11 +37,12 @@ class InvestmentWebInterfaceCoordinator:
         payload: Dict[str, Any] | None = None,
         workspace_name: str | None = None,
     ) -> Dict[str, Any]:
-        login_result = self.agent.login()
-        workspace_result = self.agent.open_workspace(workspace_name=workspace_name)
-        action_result = self.agent.run_action(action, payload=payload)
-        artifacts = self.agent.collect_artifacts()
-        logout_result = self.agent.logout()
+        agent = self._build_agent(self.provider, self.config)
+        login_result = agent.login()
+        workspace_result = agent.open_workspace(workspace_name=workspace_name)
+        action_result = agent.run_action(action, payload=payload)
+        artifacts = agent.collect_artifacts()
+        logout_result = agent.logout()
 
         return {
             "provider": self.provider.value,

--- a/agents/investment_team/tool_agents/web_interfaces/interfaces.py
+++ b/agents/investment_team/tool_agents/web_interfaces/interfaces.py
@@ -20,10 +20,16 @@ class BrowserType(str, Enum):
 class WebAgentConfig:
     """Runtime settings for web broker agents."""
 
-    browser: BrowserType = BrowserType.CHROMIUM
+    browser: BrowserType | str = BrowserType.CHROMIUM
     headless: bool = True
     workspace_name: str | None = None
     provider_options: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Normalize browser values from enum or string configs."""
+        if isinstance(self.browser, BrowserType):
+            return
+        self.browser = BrowserType(self.browser.lower())
 
 
 @dataclass

--- a/agents/investment_team/tool_agents/web_interfaces/interfaces.py
+++ b/agents/investment_team/tool_agents/web_interfaces/interfaces.py
@@ -1,0 +1,63 @@
+"""Provider-agnostic browser interfaces for investment web actions."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, List
+
+
+class BrowserType(str, Enum):
+    """Supported browser engines for automation runtimes."""
+
+    CHROMIUM = "chromium"
+    FIREFOX = "firefox"
+    WEBKIT = "webkit"
+
+
+@dataclass
+class WebAgentConfig:
+    """Runtime settings for web broker agents."""
+
+    browser: BrowserType = BrowserType.CHROMIUM
+    headless: bool = True
+    workspace_name: str | None = None
+    provider_options: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class WebActionResult:
+    """Outcome payload returned by web interface actions."""
+
+    provider: str
+    action: str
+    status: str
+    details: Dict[str, Any] = field(default_factory=dict)
+
+
+class WebBrokerInterface(ABC):
+    """Abstract contract for provider-specific browser-driven integrations."""
+
+    def __init__(self, config: WebAgentConfig) -> None:
+        self.config = config
+
+    @abstractmethod
+    def login(self) -> WebActionResult:
+        """Authenticate to provider workspace."""
+
+    @abstractmethod
+    def open_workspace(self, workspace_name: str | None = None) -> WebActionResult:
+        """Open a named workspace or use provider default."""
+
+    @abstractmethod
+    def run_action(self, action: str, payload: Dict[str, Any] | None = None) -> WebActionResult:
+        """Execute a provider-specific action."""
+
+    @abstractmethod
+    def collect_artifacts(self) -> List[Dict[str, Any]]:
+        """Collect run artifacts (screenshots, logs, reports)."""
+
+    @abstractmethod
+    def logout(self) -> WebActionResult:
+        """Terminate authenticated web session."""

--- a/agents/investment_team/tool_agents/web_interfaces/quantconnect_agent.py
+++ b/agents/investment_team/tool_agents/web_interfaces/quantconnect_agent.py
@@ -1,0 +1,45 @@
+"""QuantConnect-specific web broker implementation."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .interfaces import WebActionResult, WebAgentConfig, WebBrokerInterface
+
+
+class QuantConnectWebAgent(WebBrokerInterface):
+    """Implements the provider contract for QuantConnect workflows."""
+
+    provider_name = "quantconnect"
+
+    def __init__(self, config: WebAgentConfig) -> None:
+        super().__init__(config)
+        self._artifacts: List[Dict[str, Any]] = []
+
+    def login(self) -> WebActionResult:
+        return WebActionResult(
+            provider=self.provider_name,
+            action="login",
+            status="ok",
+            details={"browser": self.config.browser.value},
+        )
+
+    def open_workspace(self, workspace_name: str | None = None) -> WebActionResult:
+        selected_workspace = workspace_name or self.config.workspace_name or "default"
+        return WebActionResult(
+            provider=self.provider_name,
+            action="open_workspace",
+            status="ok",
+            details={"workspace": selected_workspace},
+        )
+
+    def run_action(self, action: str, payload: Dict[str, Any] | None = None) -> WebActionResult:
+        entry = {"provider": self.provider_name, "action": action, "payload": payload or {}}
+        self._artifacts.append(entry)
+        return WebActionResult(provider=self.provider_name, action=action, status="ok", details=entry)
+
+    def collect_artifacts(self) -> List[Dict[str, Any]]:
+        return list(self._artifacts)
+
+    def logout(self) -> WebActionResult:
+        return WebActionResult(provider=self.provider_name, action="logout", status="ok")

--- a/agents/investment_team/tool_agents/web_interfaces/tradingview_agent.py
+++ b/agents/investment_team/tool_agents/web_interfaces/tradingview_agent.py
@@ -1,0 +1,45 @@
+"""TradingView-specific web broker implementation."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .interfaces import WebActionResult, WebAgentConfig, WebBrokerInterface
+
+
+class TradingViewWebAgent(WebBrokerInterface):
+    """Implements the provider contract for TradingView workflows."""
+
+    provider_name = "tradingview"
+
+    def __init__(self, config: WebAgentConfig) -> None:
+        super().__init__(config)
+        self._artifacts: List[Dict[str, Any]] = []
+
+    def login(self) -> WebActionResult:
+        return WebActionResult(
+            provider=self.provider_name,
+            action="login",
+            status="ok",
+            details={"browser": self.config.browser.value},
+        )
+
+    def open_workspace(self, workspace_name: str | None = None) -> WebActionResult:
+        selected_workspace = workspace_name or self.config.workspace_name or "chart"
+        return WebActionResult(
+            provider=self.provider_name,
+            action="open_workspace",
+            status="ok",
+            details={"workspace": selected_workspace},
+        )
+
+    def run_action(self, action: str, payload: Dict[str, Any] | None = None) -> WebActionResult:
+        entry = {"provider": self.provider_name, "action": action, "payload": payload or {}}
+        self._artifacts.append(entry)
+        return WebActionResult(provider=self.provider_name, action=action, status="ok", details=entry)
+
+    def collect_artifacts(self) -> List[Dict[str, Any]]:
+        return list(self._artifacts)
+
+    def logout(self) -> WebActionResult:
+        return WebActionResult(provider=self.provider_name, action="logout", status="ok")


### PR DESCRIPTION
### Motivation
- Introduce a provider-agnostic, browser-driven interface so investment workflows can invoke platform web actions without embedding browser/provider logic in orchestration code.  
- Make browser engine selection configurable (`chromium`, `firefox`, optional `webkit`) so runtime choices are passed via configuration instead of hardcoding.  
- Provide a small coordinator facade so existing IPS/promotion flows can trigger web actions while keeping the orchestrator decoupled from provider implementations.  

### Description
- Add a new package `agents/investment_team/tool_agents/web_interfaces` with `interfaces.py` defining `WebBrokerInterface`, `BrowserType`, `WebAgentConfig`, and `WebActionResult`.  
- Implement concrete providers `quantconnect_agent.py` and `tradingview_agent.py` that implement `login`, `open_workspace`, `run_action`, `collect_artifacts`, and `logout`.  
- Add `coordinator.py` implementing `InvestmentWebInterfaceCoordinator` and `WebProvider` to select provider by enum/string and drive the login/workspace/action/artifacts/logout lifecycle.  
- Wire the coordinator into `agents/investment_team/orchestrator.py` as an optional dependency and add `run_web_action` so orchestrator flows can call `InvestmentWebInterfaceCoordinator` without direct coupling.  

### Testing
- Ran the unit tests in `agents/investment_team/tests/test_investment_team.py` with `PYTHONPATH=. pytest agents/investment_team/tests/test_investment_team.py` and all tests passed (`8 passed`).  
- An initial `pytest` run without `PYTHONPATH=.` failed to import the package (`ModuleNotFoundError`), which was resolved by running tests with `PYTHONPATH=.`, after which the suite passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3767a68c8832eba9e33a5191b6819)