### PR TITLE
Add extended question metadata, specialist collaboration plan, and PRD orchestration updates

### DIFF
--- a/agents/software_engineering_team/product_requirements_analysis_agent/agent.py
+++ b/agents/software_engineering_team/product_requirements_analysis_agent/agent.py
@@ -975,6 +975,15 @@ Previously Answered Questions:
                 source="spec_review",
                 category=str(q_data.get("category", "general")),
                 priority=str(q_data.get("priority", "medium")),
+                constraint_domain=str(q_data.get("constraint_domain", "")),
+                constraint_layer=int(q_data.get("constraint_layer", 0) or 0),
+                depends_on=q_data.get("depends_on"),
+                blocking=bool(q_data.get("blocking", True)),
+                owner=str(q_data.get("owner", "user")),
+                section_impact=list(q_data.get("section_impact", []) or []),
+                due_date=str(q_data.get("due_date", "")),
+                status=str(q_data.get("status", "open")),
+                asked_via=list(q_data.get("asked_via", []) or []),
             )
 
         return OpenQuestion(
@@ -991,6 +1000,12 @@ Previously Answered Questions:
             ],
             allow_multiple=False,
             source="spec_review",
+            blocking=True,
+            owner="user",
+            section_impact=[],
+            due_date="",
+            status="open",
+            asked_via=[],
         )
 
     def _parse_question_option(self, opt_data: Any, index: int) -> QuestionOption:
@@ -1161,6 +1176,15 @@ Previously Answered Questions:
                     "source": q.source,
                     "category": q.category,
                     "priority": q.priority,
+                    "constraint_domain": q.constraint_domain,
+                    "constraint_layer": q.constraint_layer,
+                    "depends_on": q.depends_on,
+                    "blocking": q.blocking,
+                    "owner": q.owner,
+                    "section_impact": q.section_impact,
+                    "due_date": q.due_date,
+                    "status": q.status,
+                    "asked_via": q.asked_via,
                 }
             )
         return pending
@@ -1328,6 +1352,60 @@ Previously Answered Questions:
             lines.append("")
         return "\n".join(lines)
 
+
+    def _build_specialist_collaboration_plan(
+        self,
+        cleaned_spec: str,
+        answered_questions: List[AnsweredQuestion],
+    ) -> str:
+        """Build deterministic recommendations for specialist agents/tooling.
+
+        This gives the PRD writer concrete handoff guidance for areas that often
+        require cross-team collaboration (UX, architecture, risk, data, security).
+        """
+        spec_text = (cleaned_spec + "\n" + self._format_answered_questions(answered_questions)).lower()
+
+        recommendations: List[str] = []
+
+        def include(label: str, reason: str) -> None:
+            recommendations.append(f"- {label}: {reason}")
+
+        # Always include these core spokes for higher-quality PRDs.
+        include("Requirements Analyst Agent", "Own FR/NFR decomposition, prioritization, and traceability mapping.")
+        include("QA and Acceptance Criteria Agent", "Ensure every Must requirement has verifiable acceptance criteria.")
+        include("PRD Critic (Gatekeeper) Agent", "Run completeness/consistency/testability/traceability/pragmatism gates before Final.")
+
+        if any(k in spec_text for k in ["ui", "ux", "screen", "design", "workflow", "journey", "persona", "onboarding"]):
+            include("UX and Flows Agent", "Define textual workflows, edge cases, accessibility baseline, and screen/IA notes.")
+            include("Design System Tool Agent", "Capture reusable component patterns, interaction states, and consistency rules.")
+            include("Branding Guidance Agent", "Document tone, visual direction, and brand constraints for product surfaces.")
+
+        if any(k in spec_text for k in ["architecture", "api", "integration", "service", "event", "database", "deployment"]):
+            include("Architecture Agent", "Define high-level components, interfaces, and data flow boundaries.")
+            include("API and Integration Agent", "Specify integration contracts, failure modes, and auth patterns.")
+
+        if any(k in spec_text for k in ["risk", "assumption", "dependency", "migration", "rollout", "timeline"]):
+            include("Risk Analysis Agent", "Maintain risk register with owners, probabilities, impacts, and mitigations.")
+            include("Scope and Milestones Planner Agent", "Align MVP/V1/VNext scope to dependencies and timeline options.")
+
+        if any(k in spec_text for k in ["security", "privacy", "compliance", "pii", "retention", "audit", "auth"]):
+            include("Security, Privacy, and Compliance Agent", "Define data handling, retention, authz, and compliance questions.")
+
+        if any(k in spec_text for k in ["analytics", "kpi", "metric", "dashboard", "event tracking"]):
+            include("Data and Analytics Agent", "Define events, KPI ownership, and dashboards tied to goals.")
+
+        include("Question Concierge (Human Interface) Agent", "Bundle unresolved questions by owner/impact with due dates and escalation policy.")
+
+        # Keep deterministic output order and avoid duplicates.
+        seen = set()
+        deduped: List[str] = []
+        for item in recommendations:
+            if item not in seen:
+                seen.add(item)
+                deduped.append(item)
+
+        return "\n".join(deduped)
+
     def _generate_prd_document(
         self,
         cleaned_spec: str,
@@ -1345,10 +1423,16 @@ Previously Answered Questions:
         max_chars = 20000
         cleaned_spec_snippet = cleaned_spec[:max_chars]
         answered_summary_snippet = answered_summary[:max_chars]
+        specialist_plan = self._build_specialist_collaboration_plan(
+            cleaned_spec=cleaned_spec_snippet,
+            answered_questions=answered_questions,
+        )
+        specialist_plan_snippet = specialist_plan[:max_chars]
 
         prompt = PRD_PROMPT.format(
             cleaned_spec=cleaned_spec_snippet,
             answered_questions_summary=answered_summary_snippet,
+            specialist_collaboration_plan=specialist_plan_snippet,
         )
 
         try:

--- a/agents/software_engineering_team/product_requirements_analysis_agent/models.py
+++ b/agents/software_engineering_team/product_requirements_analysis_agent/models.py
@@ -81,6 +81,30 @@ class OpenQuestion(BaseModel):
         default=None,
         description="Question ID this depends on (for follow-up questions in a drilling chain)",
     )
+    blocking: bool = Field(
+        default=True,
+        description="Whether this question blocks final PRD completion",
+    )
+    owner: str = Field(
+        default="user",
+        description="Owner expected to answer (e.g. user, stakeholder, security_team)",
+    )
+    section_impact: List[str] = Field(
+        default_factory=list,
+        description="PRD sections impacted by this question",
+    )
+    due_date: str = Field(
+        default="",
+        description="Suggested due date (ISO date) for receiving an answer",
+    )
+    status: str = Field(
+        default="open",
+        description="Question lifecycle status: open, asked, answered, stale",
+    )
+    asked_via: List[str] = Field(
+        default_factory=list,
+        description="Delivery channels used for this question (slack, email, web_ui, etc.)",
+    )
 
 
 class AnsweredQuestion(BaseModel):

--- a/agents/software_engineering_team/product_requirements_analysis_agent/prompts.py
+++ b/agents/software_engineering_team/product_requirements_analysis_agent/prompts.py
@@ -171,6 +171,12 @@ Respond with a JSON object only, no markdown:
       "constraint_domain": "infrastructure",
       "constraint_layer": 1,
       "depends_on": null,
+      "blocking": true,
+      "owner": "user",
+      "section_impact": ["Technical Approach"],
+      "due_date": "2026-03-06",
+      "status": "open",
+      "asked_via": ["web_ui"],
       "options": [
         {{
           "id": "opt_paas",
@@ -212,6 +218,12 @@ Respond with a JSON object only, no markdown:
       "constraint_domain": "backend",
       "constraint_layer": 2,
       "depends_on": null,
+      "blocking": true,
+      "owner": "user",
+      "section_impact": ["Technical Approach"],
+      "due_date": "2026-03-06",
+      "status": "open",
+      "asked_via": ["web_ui"],
       "options": [
         {{
           "id": "opt_python",
@@ -300,7 +312,7 @@ Rules:
 - Merge options from duplicate questions: combine all unique options (by meaning), deduplicate options that say the same thing. Keep at most 4-5 options per question; drop redundant ones.
 - For each consolidated question, keep the highest priority among merged questions (high > medium > low) and the most specific category.
 - Preserve allow_multiple if any of the merged questions had it true.
-- Output the same JSON structure so each item has: id, question_text, context, category, priority, allow_multiple, options (each with id, label, is_default, rationale, confidence). Use short stable ids (e.g. auth_provider, token_handling).
+- Output the same JSON structure so each item preserves metadata fields used by orchestration: id, question_text, context, category, priority, allow_multiple, constraint_domain, constraint_layer, depends_on, blocking, owner, section_impact, due_date, status, asked_via, options (each with id, label, is_default, rationale, confidence). Use short stable ids (e.g. auth_provider, token_handling).
 
 Input questions (JSON array):
 {questions_json}
@@ -315,6 +327,15 @@ Respond with a JSON object only, no markdown:
       "category": "security",
       "priority": "high",
       "allow_multiple": false,
+      "constraint_domain": "auth",
+      "constraint_layer": 2,
+      "depends_on": null,
+      "blocking": true,
+      "owner": "user",
+      "section_impact": ["Technical Approach", "Security, Privacy, and Compliance"],
+      "due_date": "2026-03-06",
+      "status": "open",
+      "asked_via": ["web_ui"],
       "options": [
         {{ "id": "opt_github", "label": "GitHub", "is_default": true, "rationale": "...", "confidence": 0.7 }},
         {{ "id": "opt_google", "label": "Google", "is_default": false, "rationale": "...", "confidence": 0.6 }}
@@ -377,66 +398,87 @@ Respond with a JSON object only, no markdown:
 }}
 """
 
-PRD_PROMPT = """You are a senior Product Manager.
+PRD_PROMPT = """You are the PRD Orchestrator for a hub-and-spoke PRD Factory.
 
 You will be given:
 - A **cleaned and validated product specification**
 - A set of **answered clarification questions** with rationales and confidence scores
 
-Your goal is to synthesize these into a single, cohesive **Product Requirements Document (PRD)** written in clear, professional Markdown.
+Your goal is to synthesize these inputs into a complete, implementation-ready **Product Requirements Document (PRD)** in professional Markdown.
 
-### PRD Audience
-- Product managers
-- Engineering leads
-- Design/UX leads
-- Stakeholders and leadership
+## Core operating rules (non-negotiable)
+1. The PRD **cannot be marked Final** if blocking open questions remain.
+2. Every **Must** functional requirement must include explicit acceptance criteria.
+3. Every requirement and major decision must be traceable to evidence, answers, or approved assumptions.
+4. Use deterministic, inspectable structure. Avoid freeform sections outside the required template.
+5. If information is missing, keep it as TBD only when linked to a blocking question or approved assumption.
 
-### PRD Requirements
+## Required PRD template (use this ordering)
+1. Title, Owner, Date, Status (Draft | Review | Final)
+2. Executive Summary
+3. Problem Statement
+4. Goals and Non-Goals
+5. Personas and Target Users
+6. User Stories and Use Cases
+7. Requirements
+   - Functional Requirements (FR-###, with priority: must/should/could/wont)
+   - Non-Functional Requirements (measurable targets or selectable tiers)
+   - Constraints
+8. Scope
+   - In-scope
+   - Out-of-scope
+9. UX
+   - Key workflows
+   - Wireframe notes (text-only)
+   - Accessibility considerations
+   - Design system notes (components, interaction patterns, states)
+   - Branding guidance (voice/tone, visual direction, key brand constraints)
+10. Technical Approach (high level)
+    - Components
+    - Integrations
+    - Data flows
+    - Architecture overview
+11. Data and Analytics
+    - Events
+    - Dashboards
+    - KPIs tied to goals
+12. Risks, Assumptions, Dependencies
+13. Rollout Plan
+    - Milestones
+    - Feature flags
+    - Migration/backfill
+14. Acceptance Criteria
+15. Open Questions (id, owner, due date, section impact, blocking/non-blocking, status)
+16. Appendix
+    - Glossary
+    - References to source spec/evidence
 
-1. **Use the cleaned specification as the primary source of truth.**
-2. **Integrate all relevant answered questions**, especially those that:
-   - Resolve technology and architecture constraints (infrastructure, frontend, backend, database, auth)
-   - Clarify business rules, edge cases, and success criteria
-   - Add constraints that materially affect implementation
-3. **Do NOT introduce new requirements** that are not supported by the spec or answers.
-4. **Resolve ambiguities** by incorporating the clarifications directly into the requirements.
+## Team-of-agents simulation requirement
+Draft content as if specialist spokes contributed to sections below. Ensure these perspectives are reflected:
+- Requirements Analyst
+- Personas and Use-Case
+- Scope and Milestones Planner
+- UX and Flows
+- API and Integration
+- Data and Analytics
+- Non-Functional Requirements
+- Security, Privacy, and Compliance
+- Risks, Assumptions, Dependencies
+- QA and Acceptance Criteria
+- Editor and Consistency
+- PRD Critic (quality gate findings)
+- Question Concierge (human question management)
 
-### PRD Structure (Markdown)
+## Quality gates checklist (must be internally validated before output)
+- Completeness: all required sections present.
+- Consistency: no contradictions between scope, requirements, milestones.
+- Testability: FR/NFR are measurable/verifiable.
+- Traceability: requirements and decisions link to evidence or answers.
+- Pragmatism: rollout is feasible; risks have mitigations and owners.
 
-Use headings and subheadings similar to:
+If a gate would fail, call it out explicitly in Open Questions and Risks/Assumptions/Dependencies.
 
-1. Product Overview
-   - Vision
-   - Problem statement
-   - In-scope vs out-of-scope
-2. Target Users & Use Cases
-   - Primary personas
-   - Key user journeys
-3. Goals & Success Metrics
-   - Business goals
-   - User goals
-   - Measurable KPIs/metrics
-4. Functional Requirements
-   - Group by feature or area (e.g., Authentication, Onboarding, Dashboard, Reporting)
-   - For each requirement, be specific and testable
-5. Non-Functional Requirements
-   - Performance and scalability
-   - Reliability & availability
-   - Security & compliance
-   - Observability, logging, and monitoring
-6. Technology & Architecture Constraints
-   - Hosting / deployment decisions (infrastructure domain)
-   - Frontend stack (framework, rendering strategy, styling)
-   - Backend stack (language, framework, API style)
-   - Database & data stores (primary DB, additional stores, hosting model)
-   - Authentication & authorization strategy
-   - Any other hard constraints the implementation must follow
-7. Risks, Assumptions, and Open Questions
-   - Known risks or trade-offs
-   - Key assumptions
-   - Remaining open questions (if any)
-
-### Inputs
+## Inputs
 
 Cleaned specification:
 ---
@@ -448,11 +490,15 @@ Answered questions (including technology and constraint decisions):
 {answered_questions_summary}
 ---
 
-### Output Instructions
+Specialist collaboration recommendations (agents/tooling):
+---
+{specialist_collaboration_plan}
+---
 
+## Output instructions
 - Respond with **only** the final PRD in Markdown format.
-- Do **not** wrap the PRD in JSON or code fences.
-- Do **not** include any commentary about how you constructed it; just output the PRD content.
+- Do **not** wrap output in code fences or JSON.
+- Keep IDs stable and explicit where applicable (FR-###, Q-###).
 """
 
 QUESTION_GENERATION_PROMPT = """Based on the following gap or issue identified in the specification, generate a structured question with answer options.

--- a/agents/software_engineering_team/tests/test_product_requirements_analysis_agent.py
+++ b/agents/software_engineering_team/tests/test_product_requirements_analysis_agent.py
@@ -155,3 +155,107 @@ def test_run_workflow_renames_validated_spec_when_needs_more_detail(tmp_path: Pa
     assert v1.read_text() == "# Validated content", "v1 should contain the original validated content from the rename"
     assert len(update_spec_calls) >= 1
     assert update_spec_calls[0] == 2, "First _update_spec after rename should use version 2"
+
+
+def test_parse_open_question_preserves_extended_metadata() -> None:
+    """_parse_open_question should keep constraint and lifecycle metadata fields."""
+    llm = MagicMock()
+    agent = ProductRequirementsAnalysisAgent(llm)
+
+    parsed = agent._parse_open_question(
+        {
+            "id": "Q-002",
+            "question_text": "Which SLO tier should we target?",
+            "context": "NFR targets are missing.",
+            "category": "performance",
+            "priority": "high",
+            "constraint_domain": "backend",
+            "constraint_layer": 3,
+            "depends_on": "Q-001",
+            "blocking": True,
+            "owner": "user",
+            "section_impact": ["Requirements", "Acceptance Criteria"],
+            "due_date": "2026-03-06",
+            "status": "asked",
+            "asked_via": ["slack", "web_ui"],
+            "options": [
+                {
+                    "id": "opt_standard",
+                    "label": "Standard tier",
+                    "is_default": True,
+                    "rationale": "Balanced",
+                    "confidence": 0.8,
+                }
+            ],
+        },
+        index=0,
+    )
+
+    assert parsed.constraint_domain == "backend"
+    assert parsed.constraint_layer == 3
+    assert parsed.depends_on == "Q-001"
+    assert parsed.blocking is True
+    assert parsed.owner == "user"
+    assert parsed.section_impact == ["Requirements", "Acceptance Criteria"]
+    assert parsed.due_date == "2026-03-06"
+    assert parsed.status == "asked"
+    assert parsed.asked_via == ["slack", "web_ui"]
+
+
+def test_convert_to_pending_questions_includes_extended_metadata() -> None:
+    """Pending question payload should include gate-aware metadata for UI and orchestration."""
+    llm = MagicMock()
+    agent = ProductRequirementsAnalysisAgent(llm)
+    open_questions = [
+        OpenQuestion(
+            id="Q-100",
+            question_text="Choose deployment option",
+            context="Infrastructure unresolved",
+            category="infrastructure",
+            priority="high",
+            constraint_domain="infrastructure",
+            constraint_layer=1,
+            depends_on=None,
+            blocking=True,
+            owner="stakeholder",
+            section_impact=["Technical Approach"],
+            due_date="2026-03-10",
+            status="open",
+            asked_via=["email"],
+            options=[QuestionOption(id="opt_paas", label="PaaS", is_default=True, rationale="", confidence=0.7)],
+        )
+    ]
+
+    pending = agent._convert_to_pending_questions(open_questions)
+
+    assert pending[0]["constraint_domain"] == "infrastructure"
+    assert pending[0]["constraint_layer"] == 1
+    assert pending[0]["blocking"] is True
+    assert pending[0]["owner"] == "stakeholder"
+    assert pending[0]["section_impact"] == ["Technical Approach"]
+    assert pending[0]["due_date"] == "2026-03-10"
+    assert pending[0]["status"] == "open"
+    assert pending[0]["asked_via"] == ["email"]
+
+
+def test_build_specialist_collaboration_plan_recommends_ui_arch_and_risk_agents() -> None:
+    """Specialist plan should include new UI/UX, architecture, and risk-focused agents when relevant."""
+    llm = MagicMock()
+    agent = ProductRequirementsAnalysisAgent(llm)
+
+    cleaned_spec = """
+    Build a web UI onboarding workflow with multiple screens and design consistency.
+    The architecture includes API integrations, event tracking dashboards, and phased rollout.
+    We must capture key risks, dependencies, and security/privacy requirements.
+    """
+
+    plan = agent._build_specialist_collaboration_plan(cleaned_spec, answered_questions=[])
+
+    assert "UX and Flows Agent" in plan
+    assert "Design System Tool Agent" in plan
+    assert "Branding Guidance Agent" in plan
+    assert "Architecture Agent" in plan
+    assert "API and Integration Agent" in plan
+    assert "Risk Analysis Agent" in plan
+    assert "Security, Privacy, and Compliance Agent" in plan
+    assert "Data and Analytics Agent" in plan


### PR DESCRIPTION
### Motivation
- Enrich open-question modeling to support constraint drilling, ownership, lifecycle, and UI/orchestration metadata for gate-aware PRD workflows.
- Produce deterministic handoff guidance to specialist agents/tools so the PRD synthesizer can surface actionable cross-team collaboration recommendations.
- Ensure the PRD generator has the necessary context (answered questions + specialist recommendations) to create implementation-ready, traceable PRDs.

### Description
- Extend `OpenQuestion` model with fields: `constraint_domain`, `constraint_layer`, `depends_on`, `blocking`, `owner`, `section_impact`, `due_date`, `status`, and `asked_via` in `models.py`.
- Preserve and propagate the new metadata in parsing and conversion: updated `_parse_open_question`, `_parse_question_option`, and `_convert_to_pending_questions` payloads in `agent.py` and prompts in `prompts.py` to include the new fields.
- Add `_build_specialist_collaboration_plan` in `agent.py` to derive deterministic specialist agent/tool recommendations from the spec and answered questions, and integrate it into `_generate_prd_document` so the plan is injected into the PRD prompt.
- Update `PRD_PROMPT` and other prompt templates in `prompts.py` to accept and preserve the extended question metadata and the `specialist_collaboration_plan` input.

### Testing
- Added unit tests in `agents/software_engineering_team/tests/test_product_requirements_analysis_agent.py` covering ` _parse_open_question` metadata preservation, pending conversion payload, and `_build_specialist_collaboration_plan` behavior.
- Ran the test file with `pytest agents/software_engineering_team/tests/test_product_requirements_analysis_agent.py` and the new and existing tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a86ab6aa90832eb2814a555e7c9f4c)