### PR TITLE
Add stop/resume/restart controls for run-team jobs (API + UI)

### DIFF
--- a/agents/software_engineering_team/api/main.py
+++ b/agents/software_engineering_team/api/main.py
@@ -602,6 +602,12 @@ def cancel_job(job_id: str) -> CancelJobResponse:
 
 
 RESUMABLE_STATUSES = (JOB_STATUS_PENDING, JOB_STATUS_RUNNING, JOB_STATUS_AGENT_CRASH)
+RESTARTABLE_STATUSES = (
+    JOB_STATUS_COMPLETED,
+    JOB_STATUS_FAILED,
+    JOB_STATUS_CANCELLED,
+    JOB_STATUS_AGENT_CRASH,
+)
 
 
 @app.post(
@@ -659,6 +665,63 @@ def resume_run_team_job(job_id: str) -> RunTeamResponse:
         job_id=job_id,
         status="running",
         message="Job resumed. Poll GET /run-team/{job_id} for status.",
+    )
+
+
+@app.post(
+    "/run-team/{job_id}/restart",
+    response_model=RunTeamResponse,
+    summary="Restart a completed/failed/cancelled run-team job",
+    description="Creates a new run-team job using the same repo_path as the referenced job. "
+    "Only allowed when the existing job is in a terminal state (completed, failed, cancelled, or agent_crash). "
+    "Returns a new job_id.",
+)
+def restart_run_team_job(job_id: str) -> RunTeamResponse:
+    """Restart a run_team job by creating a brand-new job for the same repo path."""
+    data = get_job(job_id)
+    if not data:
+        raise HTTPException(status_code=404, detail="Job not found")
+
+    job_type = data.get("job_type")
+    if job_type is not None and job_type != "run_team":
+        raise HTTPException(
+            status_code=400,
+            detail=f"Only run_team jobs can be restarted via this endpoint (job_type={job_type}).",
+        )
+
+    status = data.get("status", JOB_STATUS_PENDING)
+    if status not in RESTARTABLE_STATUSES:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Job cannot be restarted (status={status}). "
+                "Restart is only allowed for completed, failed, cancelled, or agent_crash jobs."
+            ),
+        )
+
+    repo_path = data.get("repo_path")
+    if not repo_path:
+        raise HTTPException(status_code=400, detail="Job has no repo_path; cannot restart.")
+
+    try:
+        validate_work_path(repo_path)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    new_job_id = str(uuid.uuid4())
+    create_job(new_job_id, str(repo_path), job_type="run_team")
+
+    thread = threading.Thread(
+        target=_run_orchestrator_background,
+        args=(new_job_id, str(repo_path)),
+        daemon=True,
+    )
+    thread.start()
+
+    return RunTeamResponse(
+        job_id=new_job_id,
+        status="running",
+        message=f"Job restarted from {job_id}. Poll GET /run-team/{{job_id}} for status.",
     )
 
 

--- a/agents/software_engineering_team/tests/test_api.py
+++ b/agents/software_engineering_team/tests/test_api.py
@@ -315,3 +315,57 @@ def test_mark_all_running_jobs_failed(tmp_path: Path) -> None:
     assert job_data is not None
     assert job_data.get("status") == "failed"
     assert job_data.get("error") == "test"
+
+
+# --- Restart endpoint tests ---
+
+
+def test_restart_404_when_job_missing(client: TestClient) -> None:
+    """POST /run-team/{job_id}/restart returns 404 for unknown job."""
+    job_id = str(uuid.uuid4())
+    r = client.post(f"/run-team/{job_id}/restart")
+    assert r.status_code == 404
+
+
+def test_restart_400_when_status_running(client: TestClient, temp_work_path: Path) -> None:
+    """POST /run-team/{job_id}/restart returns 400 when job is still active."""
+    from software_engineering_team.shared.job_store import create_job
+
+    job_id = str(uuid.uuid4())
+    create_job(job_id, str(temp_work_path), job_type="run_team")
+
+    r = client.post(f"/run-team/{job_id}/restart")
+    assert r.status_code == 400
+    assert "cannot be restarted" in r.json().get("detail", "").lower() or "status" in r.json().get("detail", "").lower()
+
+
+def test_restart_400_when_job_type_not_run_team(client: TestClient, temp_work_path: Path) -> None:
+    """POST /run-team/{job_id}/restart returns 400 for non-run_team jobs."""
+    from software_engineering_team.shared.job_store import create_job, update_job
+
+    job_id = str(uuid.uuid4())
+    create_job(job_id, str(temp_work_path), job_type="planning_v2")
+    update_job(job_id, status="failed")
+
+    r = client.post(f"/run-team/{job_id}/restart")
+    assert r.status_code == 400
+
+
+def test_restart_200_when_failed_creates_new_job(client: TestClient, temp_work_path: Path) -> None:
+    """POST /run-team/{job_id}/restart returns 200 and creates a new running job."""
+    from software_engineering_team.shared.job_store import create_job, get_job, update_job
+
+    old_job_id = str(uuid.uuid4())
+    create_job(old_job_id, str(temp_work_path), job_type="run_team")
+    update_job(old_job_id, status="failed")
+
+    r = client.post(f"/run-team/{old_job_id}/restart")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["status"] == "running"
+    assert data["job_id"] != old_job_id
+
+    new_job = get_job(data["job_id"])
+    assert new_job is not None
+    assert new_job.get("status") == "running"
+    assert new_job.get("repo_path") == str(temp_work_path)

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.html
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.html
@@ -123,12 +123,28 @@
                 <span class="time-ago">{{ getTimeAgo(job.unified.createdAt) }}</span>
               </td>
               <td class="col-actions">
-                @if (canCancelJob(job)) {
+                @if (canStopJob(job)) {
                   <button mat-icon-button
                           class="stop-button"
-                          (click)="cancelJob($event, job)"
+                          (click)="stopJob($event, job)"
                           matTooltip="Stop job">
                     <mat-icon>stop</mat-icon>
+                  </button>
+                }
+                @if (canResumeJob(job)) {
+                  <button mat-icon-button
+                          class="resume-button"
+                          (click)="resumeJob($event, job)"
+                          matTooltip="Resume job">
+                    <mat-icon>play_arrow</mat-icon>
+                  </button>
+                }
+                @if (canRestartJob(job)) {
+                  <button mat-icon-button
+                          class="restart-button"
+                          (click)="restartJob($event, job)"
+                          matTooltip="Restart job">
+                    <mat-icon>replay</mat-icon>
                   </button>
                 }
               </td>

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
@@ -196,8 +196,13 @@
 }
 
 .col-actions {
-  width: 60px;
+  width: 140px;
   text-align: center;
+
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
 }
 
 .status-badge {
@@ -430,5 +435,22 @@
 
   .jobs-table {
     min-width: 900px;
+  }
+}
+
+
+.resume-button {
+  color: #58a6ff;
+
+  &:hover {
+    background: rgba(88, 166, 255, 0.1);
+  }
+}
+
+.restart-button {
+  color: #bb80ff;
+
+  &:hover {
+    background: rgba(187, 128, 255, 0.1);
   }
 }

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
@@ -374,7 +374,7 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
     }
   }
 
-  cancelJob(event: Event, job: DashboardRow): void {
+  stopJob(event: Event, job: DashboardRow): void {
     event.stopPropagation();
     if (job.unified.source !== 'software_engineering') return;
     const label = job.unified.label;
@@ -384,16 +384,53 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
     this.seApi.cancelJob(job.unified.jobId).subscribe({
       next: () => this.refresh(),
       error: (err) => {
-        console.error('Failed to cancel job:', err);
-        this.error = err?.error?.detail ?? err?.message ?? 'Failed to cancel job';
+        console.error('Failed to stop job:', err);
+        this.error = err?.error?.detail ?? err?.message ?? 'Failed to stop job';
       },
     });
   }
 
-  canCancelJob(job: DashboardRow): boolean {
+  resumeJob(event: Event, job: DashboardRow): void {
+    event.stopPropagation();
+    if (job.unified.source !== 'software_engineering') return;
+    this.seApi.resumeRunTeamJob(job.unified.jobId).subscribe({
+      next: () => this.refresh(),
+      error: (err) => {
+        console.error('Failed to resume job:', err);
+        this.error = err?.error?.detail ?? err?.message ?? 'Failed to resume job';
+      },
+    });
+  }
+
+  restartJob(event: Event, job: DashboardRow): void {
+    event.stopPropagation();
+    if (job.unified.source !== 'software_engineering') return;
+    if (!confirm(`Restart job for "${job.unified.label}" from scratch?`)) {
+      return;
+    }
+    this.seApi.restartRunTeamJob(job.unified.jobId).subscribe({
+      next: () => this.refresh(),
+      error: (err) => {
+        console.error('Failed to restart job:', err);
+        this.error = err?.error?.detail ?? err?.message ?? 'Failed to restart job';
+      },
+    });
+  }
+
+  canStopJob(job: DashboardRow): boolean {
     if (job.unified.source !== 'software_engineering') return false;
     const status = job.unified.status;
     return status === 'running' || status === 'pending';
+  }
+
+  canResumeJob(job: DashboardRow): boolean {
+    if (job.unified.source !== 'software_engineering') return false;
+    return ['pending', 'running', 'agent_crash'].includes(job.unified.status);
+  }
+
+  canRestartJob(job: DashboardRow): boolean {
+    if (job.unified.source !== 'software_engineering') return false;
+    return ['completed', 'failed', 'cancelled', 'agent_crash'].includes(job.unified.status);
   }
 
   trackByJobId(_index: number, job: DashboardRow): string {

--- a/user-interface/src/app/services/software-engineering-api.service.ts
+++ b/user-interface/src/app/services/software-engineering-api.service.ts
@@ -88,6 +88,17 @@ export class SoftwareEngineeringApiService {
   }
 
   /**
+   * POST /run-team/{job_id}/restart
+   * Start a brand-new job using the same repo as an existing terminal run_team job.
+   */
+  restartRunTeamJob(jobId: string): Observable<RunTeamResponse> {
+    return this.http.post<RunTeamResponse>(
+      `${this.baseUrl}/run-team/${jobId}/restart`,
+      {}
+    );
+  }
+
+  /**
    * POST /run-team/{job_id}/cancel
    * Request cancellation for a running or pending job.
    */


### PR DESCRIPTION
### Motivation
- Provide consistent, centralized job control so operators can stop, resume, and restart software-engineering `run_team` jobs from the UI. 
- Allow teams to reliably recover from crashes or restart completed/failed runs without manual recreation of work folders. 

### Description
- Added a new backend endpoint `POST /run-team/{job_id}/restart` that validates the referenced job, reuses its `repo_path`, creates a new job id, and starts orchestration in a background thread. 
- Introduced `RESTARTABLE_STATUSES` and restart logic in `agents/software_engineering_team/api/main.py` while preserving existing `resume` and `cancel` semantics. 
- Added integration tests for restart behavior in `agents/software_engineering_team/tests/test_api.py` covering missing job (404), invalid state/type (400), and successful restart (200 creates new running job). 
- Exposed restart action in the frontend by adding `restartRunTeamJob()` to `SoftwareEngineeringApiService`, and updated the Jobs Dashboard UI (`jobs-dashboard.component.*`) to show Stop / Resume / Restart buttons with status-based gating and supporting styles and handlers. 

### Testing
- Ran targeted backend tests: `python -m pytest agents/software_engineering_team/tests/test_api.py -k "resume_200_when_pending or resume_400_when_status_cancelled or restart_"` and the selected tests passed (`6 passed, 17 deselected`).
- Attempted Angular production build with `npm run build`; the build failed in this environment due to external Google Fonts inlining returning HTTP 403 (environment/network restriction), not due to the UI code changes. 
- Executed an automated browser script to render the Jobs Dashboard and capture a screenshot of the new controls, which completed and produced `artifacts/jobs-dashboard-controls.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8709e32f0832e84bd83cc99217465)