### PR TITLE
Add agent registry discovery and matching CLI

### DIFF
--- a/studiogrid/README.md
+++ b/studiogrid/README.md
@@ -15,3 +15,10 @@ Run CLI:
 ```bash
 PYTHONPATH=src python -m studiogrid.main run start --project-name Demo --intake examples/intake.json
 ```
+
+Agent registry helpers:
+
+```bash
+PYTHONPATH=src python -m studiogrid.main registry list
+PYTHONPATH=src python -m studiogrid.main registry find --problem "Need accessibility review" --skills accessibility_review
+```

--- a/studiogrid/src/studiogrid/main.py
+++ b/studiogrid/src/studiogrid/main.py
@@ -4,6 +4,7 @@ import argparse
 import json
 from pathlib import Path
 
+from studiogrid.runtime.registry_loader import RegistryLoader
 from studiogrid.runtime.runtime_factory import build_orchestrator
 
 
@@ -49,6 +50,36 @@ def cmd_decision_choose(args: argparse.Namespace) -> None:
     _print(orch.get_decision(decision_id=args.decision_id))
 
 
+
+
+def _build_registry() -> RegistryLoader:
+    root = Path(__file__).resolve().parent
+    return RegistryLoader(root)
+
+
+def cmd_registry_list(args: argparse.Namespace) -> None:
+    del args
+    registry = _build_registry()
+    _print({"agents": registry.list_agents()})
+
+
+def cmd_registry_find(args: argparse.Namespace) -> None:
+    registry = _build_registry()
+    skills = [skill.strip() for skill in args.skills.split(",") if skill.strip()]
+    candidates = registry.find_assisting_agents(
+        problem_description=args.problem,
+        required_skills=skills,
+        limit=args.limit,
+    )
+    _print(
+        {
+            "problem": args.problem,
+            "required_skills": skills,
+            "assisting_agents": candidates,
+            "should_spawn_sub_agents": len(candidates) == 0,
+        }
+    )
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="studiogrid")
     sub = parser.add_subparsers(dest="group", required=True)
@@ -74,6 +105,18 @@ def build_parser() -> argparse.ArgumentParser:
     choose.add_argument("--decision-id", required=True)
     choose.add_argument("--option", required=True)
     choose.set_defaults(func=cmd_decision_choose)
+
+    registry = sub.add_parser("registry")
+    registry_sub = registry.add_subparsers(dest="action", required=True)
+
+    registry_list = registry_sub.add_parser("list")
+    registry_list.set_defaults(func=cmd_registry_list)
+
+    registry_find = registry_sub.add_parser("find")
+    registry_find.add_argument("--problem", required=True)
+    registry_find.add_argument("--skills", default="")
+    registry_find.add_argument("--limit", type=int, default=5)
+    registry_find.set_defaults(func=cmd_registry_find)
 
     return parser
 

--- a/studiogrid/src/studiogrid/runtime/registry_loader.py
+++ b/studiogrid/src/studiogrid/runtime/registry_loader.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -19,6 +20,50 @@ class RegistryLoader:
     def get_agent(self, agent_id: str) -> dict:
         agents = self._load().get("agents", {})
         return agents[agent_id]
+
+    def list_agents(self) -> list[dict[str, Any]]:
+        agents = self._load().get("agents", {})
+        return [{"agent_id": agent_id, **cfg} for agent_id, cfg in agents.items()]
+
+    def find_assisting_agents(self, *, problem_description: str, required_skills: list[str], limit: int | None = None) -> list[dict[str, Any]]:
+        description_tokens = self._tokenize(problem_description)
+        needed_skills = {skill.strip().lower() for skill in required_skills if skill.strip()}
+        scored: list[dict[str, Any]] = []
+        for entry in self.list_agents():
+            agent_skills = {skill.lower() for skill in entry.get("skills", [])}
+            keyword_tokens = self._tokenize(" ".join(entry.get("keywords", [])))
+            skill_matches = sorted(needed_skills.intersection(agent_skills))
+            keyword_matches = sorted(description_tokens.intersection(keyword_tokens))
+            score = (3 * len(skill_matches)) + len(keyword_matches)
+            if needed_skills and not skill_matches:
+                continue
+            if score == 0 and description_tokens:
+                continue
+            scored.append(
+                {
+                    "agent_id": entry["agent_id"],
+                    "score": score,
+                    "description": entry.get("description", ""),
+                    "skills": entry.get("skills", []),
+                    "actions": entry.get("actions", []),
+                    "resources": entry.get("resources", []),
+                    "schemas": entry.get("schemas", []),
+                    "match": {
+                        "skills": skill_matches,
+                        "keywords": keyword_matches,
+                    },
+                }
+            )
+
+        scored.sort(key=lambda item: (-item["score"], item["agent_id"]))
+        if limit is not None:
+            return scored[:limit]
+        return scored
+
+    @staticmethod
+    def _tokenize(value: str) -> set[str]:
+        cleaned = "".join(ch.lower() if ch.isalnum() else " " for ch in value)
+        return {part for part in cleaned.split() if part}
 
     def load_prompt(self, prompt_file: str) -> str:
         return (self.root / prompt_file).read_text(encoding="utf-8")

--- a/studiogrid/src/studiogrid/workflows/agent_registry.yaml
+++ b/studiogrid/src/studiogrid/workflows/agent_registry.yaml
@@ -1,5 +1,6 @@
 agents:
   design_lead:
+    description: Leads design-system planning and turns intake requirements into implementation-ready artifacts.
     prompt_file: prompts/agents/design_lead.md
     tools:
       - figma_tool
@@ -7,3 +8,27 @@ agents:
     permissions:
       - read_artifacts
       - write_artifacts
+    skills:
+      - design_system_architecture
+      - accessibility_review
+      - ui_specification
+    actions:
+      - produce_design_spec
+      - validate_accessibility
+    keywords:
+      - design
+      - component
+      - accessibility
+      - figma
+      - ui
+      - specification
+    resources:
+      - type: artifact
+        name: intake
+        required: true
+      - type: tool
+        name: figma_tool
+        required: true
+    schemas:
+      - kind: ARTIFACT
+        artifact_type: task_out

--- a/studiogrid/tests/test_registry.py
+++ b/studiogrid/tests/test_registry.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+from studiogrid.runtime.registry_loader import RegistryLoader
+
+
+def _registry() -> RegistryLoader:
+    return RegistryLoader(Path(__file__).resolve().parents[1] / "src" / "studiogrid")
+
+
+def test_registry_lists_agents_with_metadata():
+    agents = _registry().list_agents()
+    assert agents
+    first = agents[0]
+    assert "agent_id" in first
+    assert "description" in first
+    assert isinstance(first.get("skills", []), list)
+
+
+def test_find_assisting_agents_matches_required_skills_and_problem_keywords():
+    matches = _registry().find_assisting_agents(
+        problem_description="Need a UI accessibility review for component specs",
+        required_skills=["accessibility_review"],
+        limit=3,
+    )
+    assert matches
+    top = matches[0]
+    assert top["agent_id"] == "design_lead"
+    assert "accessibility_review" in top["match"]["skills"]
+
+
+def test_find_assisting_agents_returns_empty_without_matching_skills():
+    matches = _registry().find_assisting_agents(
+        problem_description="Need database sharding strategy",
+        required_skills=["distributed_databases"],
+        limit=3,
+    )
+    assert matches == []


### PR DESCRIPTION
### Motivation
- Provide a machine-readable registry so agents can discover and evaluate other agents that can assist with a problem based on metadata, skills and expected resources.
- Enable programmatic selection of assisting agents to decide whether to collaborate with existing agents or spawn sub-agents for a task.

### Description
- Expand `workflows/agent_registry.yaml` to include richer agent metadata fields (`description`, `skills`, `actions`, `keywords`, `resources`, `schemas`) for each agent.
- Extend `RegistryLoader` with `list_agents()` and `find_assisting_agents(problem_description, required_skills, limit)` plus a `_tokenize()` helper to score and rank candidates by skill overlap and keyword relevance.
- Add CLI commands in `studiogrid.main`: `registry list` to enumerate agents and `registry find --problem ... --skills ... --limit ...` to return ranked candidates and a `should_spawn_sub_agents` indicator.
- Add tests in `studiogrid/tests/test_registry.py` covering agent listing, positive matching, and no-match behavior, and update `README.md` with registry usage examples.

### Testing
- Ran the unit test suite with `cd studiogrid && PYTHONPATH=src pytest -q`, which passed all tests (`8 passed`).
- Executed the new CLI commands `PYTHONPATH=src python -m studiogrid.main registry list` and `PYTHONPATH=src python -m studiogrid.main registry find --problem "Need accessibility review for UI" --skills accessibility_review` to validate runtime behavior and outputs.
- Fixed a path issue (using `Path(__file__).resolve().parent`) so the registry loader can locate `workflows/agent_registry.yaml` during CLI and tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9a75c4720832e92b19f955ad98715)