### PR TITLE
Prefer same-team agents in registry matches and add team availability listing

### DIFF
--- a/studiogrid/README.md
+++ b/studiogrid/README.md
@@ -15,3 +15,26 @@ Run CLI:
 ```bash
 PYTHONPATH=src python -m studiogrid.main run start --project-name Demo --intake examples/intake.json
 ```
+
+## Registry CLI
+
+List registered agents:
+
+```bash
+PYTHONPATH=src python -m studiogrid.main registry list
+```
+
+Find assisting agents for a task and prefer same-team agents when `--requesting-agent` is set:
+
+```bash
+PYTHONPATH=src python -m studiogrid.main registry find \
+  --problem "Need accessibility review for updated dashboard" \
+  --skills accessibility_review \
+  --requesting-agent design_lead
+```
+
+List teams currently available for orchestrator selection:
+
+```bash
+PYTHONPATH=src python -m studiogrid.main team list --available-only
+```

--- a/studiogrid/src/studiogrid/main.py
+++ b/studiogrid/src/studiogrid/main.py
@@ -4,6 +4,7 @@ import argparse
 import json
 from pathlib import Path
 
+from studiogrid.runtime.registry_loader import RegistryLoader
 from studiogrid.runtime.runtime_factory import build_orchestrator
 
 
@@ -49,6 +50,29 @@ def cmd_decision_choose(args: argparse.Namespace) -> None:
     _print(orch.get_decision(decision_id=args.decision_id))
 
 
+
+def cmd_registry_list(args: argparse.Namespace) -> None:
+    registry = RegistryLoader(Path(__file__).parent)
+    _print({"agents": registry.list_agents()})
+
+
+def cmd_registry_find(args: argparse.Namespace) -> None:
+    registry = RegistryLoader(Path(__file__).parent)
+    skills = [skill.strip() for skill in args.skills.split(",") if skill.strip()] if args.skills else []
+    _print(
+        registry.find_assisting_agents(
+            problem_description=args.problem,
+            required_skills=skills,
+            requesting_agent_id=args.requesting_agent,
+            limit=args.limit,
+        )
+    )
+
+
+def cmd_team_list(args: argparse.Namespace) -> None:
+    registry = RegistryLoader(Path(__file__).parent)
+    _print({"teams": registry.list_teams(available_only=args.available_only)})
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="studiogrid")
     sub = parser.add_subparsers(dest="group", required=True)
@@ -74,6 +98,26 @@ def build_parser() -> argparse.ArgumentParser:
     choose.add_argument("--decision-id", required=True)
     choose.add_argument("--option", required=True)
     choose.set_defaults(func=cmd_decision_choose)
+
+    registry = sub.add_parser("registry")
+    registry_sub = registry.add_subparsers(dest="action", required=True)
+
+    registry_list = registry_sub.add_parser("list")
+    registry_list.set_defaults(func=cmd_registry_list)
+
+    registry_find = registry_sub.add_parser("find")
+    registry_find.add_argument("--problem", required=True)
+    registry_find.add_argument("--skills", default="")
+    registry_find.add_argument("--requesting-agent")
+    registry_find.add_argument("--limit", type=int, default=5)
+    registry_find.set_defaults(func=cmd_registry_find)
+
+    team = sub.add_parser("team")
+    team_sub = team.add_subparsers(dest="action", required=True)
+
+    team_list = team_sub.add_parser("list")
+    team_list.add_argument("--available-only", action="store_true")
+    team_list.set_defaults(func=cmd_team_list)
 
     return parser
 

--- a/studiogrid/src/studiogrid/runtime/registry_loader.py
+++ b/studiogrid/src/studiogrid/runtime/registry_loader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import yaml
@@ -22,3 +23,88 @@ class RegistryLoader:
 
     def load_prompt(self, prompt_file: str) -> str:
         return (self.root / prompt_file).read_text(encoding="utf-8")
+
+    def list_agents(self) -> list[dict]:
+        agents = self._load().get("agents", {})
+        return [self._agent_payload(agent_id, agent_cfg) for agent_id, agent_cfg in agents.items()]
+
+    def list_teams(self, available_only: bool = False) -> list[dict]:
+        teams = self._load().get("teams", {})
+        payload = []
+        for team_id, team_cfg in teams.items():
+            availability = team_cfg.get("availability", "unknown")
+            if available_only and availability != "available":
+                continue
+            payload.append(
+                {
+                    "team_id": team_id,
+                    "description": team_cfg.get("description", ""),
+                    "availability": availability,
+                    "agents": team_cfg.get("agents", []),
+                }
+            )
+        return payload
+
+    def find_assisting_agents(
+        self,
+        problem_description: str,
+        required_skills: list[str] | None = None,
+        requesting_agent_id: str | None = None,
+        limit: int = 5,
+    ) -> dict:
+        required = {skill.lower() for skill in (required_skills or [])}
+        problem_tokens = self._tokenize(problem_description)
+        team_members = self._team_members(requesting_agent_id) if requesting_agent_id else set()
+
+        ranked = []
+        for agent_id, agent_cfg in self._load().get("agents", {}).items():
+            agent_skills = {skill.lower() for skill in agent_cfg.get("skills", [])}
+            if required and not required.issubset(agent_skills):
+                continue
+
+            keywords = {kw.lower() for kw in agent_cfg.get("keywords", [])}
+            skill_score = len(required.intersection(agent_skills))
+            keyword_score = len(problem_tokens.intersection(keywords))
+            team_affinity_score = 2 if agent_id in team_members else 0
+            score = (skill_score * 3) + keyword_score + team_affinity_score
+
+            if required and score == 0:
+                continue
+
+            ranked.append(
+                {
+                    **self._agent_payload(agent_id, agent_cfg),
+                    "score": score,
+                    "is_same_team": agent_id in team_members,
+                }
+            )
+
+        ranked.sort(key=lambda item: (item["is_same_team"], item["score"], item["agent_id"]), reverse=True)
+        return {
+            "requesting_agent_id": requesting_agent_id,
+            "required_skills": sorted(required),
+            "matches": ranked[:limit],
+            "should_spawn_sub_agents": len(ranked) == 0,
+        }
+
+    def _team_members(self, agent_id: str) -> set[str]:
+        teams = self._load().get("teams", {})
+        for team_cfg in teams.values():
+            members = set(team_cfg.get("agents", []))
+            if agent_id in members:
+                return members
+        return set()
+
+    def _agent_payload(self, agent_id: str, agent_cfg: dict) -> dict:
+        return {
+            "agent_id": agent_id,
+            "description": agent_cfg.get("description", ""),
+            "skills": agent_cfg.get("skills", []),
+            "actions": agent_cfg.get("actions", []),
+            "keywords": agent_cfg.get("keywords", []),
+            "resources": agent_cfg.get("resources", []),
+            "schemas": agent_cfg.get("schemas", {}),
+        }
+
+    def _tokenize(self, text: str) -> set[str]:
+        return {token.lower() for token in re.findall(r"[a-zA-Z0-9_]+", text or "")}

--- a/studiogrid/src/studiogrid/workflows/agent_registry.yaml
+++ b/studiogrid/src/studiogrid/workflows/agent_registry.yaml
@@ -1,5 +1,25 @@
 agents:
   design_lead:
+    description: Leads UX strategy and UI quality standards across product initiatives.
+    skills:
+      - ui_design
+      - accessibility_review
+      - design_systems
+    actions:
+      - review_wireframes
+      - recommend_ui_improvements
+      - define_design_direction
+    keywords:
+      - ux
+      - accessibility
+      - interface
+      - design
+    resources:
+      - figma_files
+      - design_tokens
+    schemas:
+      input: schemas/task.schema.json
+      output: schemas/review.schema.json
     prompt_file: prompts/agents/design_lead.md
     tools:
       - figma_tool
@@ -7,3 +27,69 @@ agents:
     permissions:
       - read_artifacts
       - write_artifacts
+  qa_specialist:
+    description: Performs QA validation, usability checks, and regression risk assessment.
+    skills:
+      - accessibility_review
+      - regression_testing
+      - quality_assurance
+    actions:
+      - validate_acceptance_criteria
+      - create_test_plan
+      - identify_regressions
+    keywords:
+      - testing
+      - qa
+      - validation
+      - quality
+    resources:
+      - test_cases
+      - qa_reports
+    schemas:
+      input: schemas/task.schema.json
+      output: schemas/review.schema.json
+    prompt_file: prompts/agents/design_lead.md
+    tools:
+      - contrast_check_tool
+    permissions:
+      - read_artifacts
+  backend_architect:
+    description: Designs backend services, APIs, and integration strategies.
+    skills:
+      - api_design
+      - systems_design
+      - scalability
+    actions:
+      - draft_service_architecture
+      - define_api_contracts
+      - assess_system_constraints
+    keywords:
+      - backend
+      - api
+      - architecture
+      - integration
+    resources:
+      - service_diagrams
+      - api_specs
+    schemas:
+      input: schemas/task.schema.json
+      output: schemas/decision.schema.json
+    prompt_file: prompts/agents/design_lead.md
+    tools:
+      - token_export_tool
+    permissions:
+      - read_artifacts
+      - write_artifacts
+
+teams:
+  product_design_team:
+    description: Product design and UX quality team.
+    availability: available
+    agents:
+      - design_lead
+      - qa_specialist
+  platform_engineering_team:
+    description: Platform architecture and integration team.
+    availability: available
+    agents:
+      - backend_architect

--- a/studiogrid/tests/test_registry.py
+++ b/studiogrid/tests/test_registry.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+
+from studiogrid.runtime.registry_loader import RegistryLoader
+
+
+def _loader() -> RegistryLoader:
+    return RegistryLoader(Path(__file__).resolve().parents[1] / "src" / "studiogrid")
+
+
+def test_list_agents_returns_metadata():
+    agents = _loader().list_agents()
+    assert any(agent["agent_id"] == "design_lead" for agent in agents)
+    assert any("skills" in agent for agent in agents)
+
+
+def test_find_assisting_agents_prefers_same_team():
+    loader = _loader()
+    result = loader.find_assisting_agents(
+        problem_description="Need accessibility review and QA on interface updates",
+        required_skills=["accessibility_review"],
+        requesting_agent_id="design_lead",
+        limit=3,
+    )
+
+    assert result["matches"]
+    assert result["matches"][0]["agent_id"] in {"design_lead", "qa_specialist"}
+    assert result["matches"][0]["is_same_team"] is True
+
+
+def test_list_teams_available_only_filters_unavailable():
+    teams = _loader().list_teams(available_only=True)
+    assert teams
+    assert all(team["availability"] == "available" for team in teams)


### PR DESCRIPTION
### Motivation

- Make agents discoverable to other agents with richer metadata so they can collaborate and communicate expected schemas and resources via a registry.
- Prefer recommending agents that are already on the same team as the requesting agent to improve collaboration locality and reduce cross-team coordination.
- Allow orchestrators to discover available teams so they can choose which teams to engage for complex tasks.

### Description

- Extend the registry data model in `src/studiogrid/workflows/agent_registry.yaml` by adding per-agent metadata (`description`, `skills`, `actions`, `keywords`, `resources`, `schemas`) and a new `teams` section that tracks membership and `availability`.
- Implement `RegistryLoader` enhancements in `src/studiogrid/runtime/registry_loader.py` including `list_agents()`, `list_teams(available_only=...)`, `find_assisting_agents(...)` with lightweight tokenization and scoring that boosts same-team agents when `requesting_agent_id` is provided, and helper methods for team lookup and payload formatting.
- Add CLI endpoints in `src/studiogrid/main.py` for `registry list`, `registry find --problem ... --skills ... --requesting-agent ... --limit ...`, and `team list --available-only` to expose the new features.
- Add tests in `studiogrid/tests/test_registry.py` to validate agent metadata listing, same-team preference behavior, and available-team filtering, and document usage in `studiogrid/README.md`.

### Testing

- Ran the test suite with `PYTHONPATH=src pytest -q` and all tests passed (`8 passed`).
- The new tests in `tests/test_registry.py` executed and validated metadata listing, same-team preference, and available-team filtering successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9b0339af0832e95de2ddd5abb8468)