### PR TITLE
ci: trigger PR workflow on opened/synchronize/reopened

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main, development]
   pull_request:
+    types: [opened, synchronize, reopened]
     branches: [main, development]
 
 jobs:


### PR DESCRIPTION
### Motivation
- Ensure CI runs when a PR is created and on subsequent pushes by explicitly specifying `pull_request` event `types` so the existing linting and test jobs run on PR open/sync/reopen.

### Description
- Updated `.github/workflows/ci.yml` to add `types: [opened, synchronize, reopened]` under the `pull_request` trigger and left all jobs and branch filters unchanged.

### Testing
- No automated tests were executed for this change; validation consisted of reviewing the updated `git diff` for `.github/workflows/ci.yml` and committing the file.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9e2c1fc88832e92b0f1e0c8b7db0d)