### PR TITLE
Add Strands/AWS integration and tests for accessibility audit team

### DIFF
--- a/agents/accessibility_audit_team/README.md
+++ b/agents/accessibility_audit_team/README.md
@@ -177,6 +177,27 @@ for finding in result.final_findings:
     print(f"  Fix: {finding.recommended_fix}")
 ```
 
+
+## AWS Strands Integration
+
+The accessibility audit team includes a Strands-compatible registration module at
+`accessibility_audit_team.strands_integration`.
+
+```python
+from accessibility_audit_team.strands_integration import get_team_spec
+
+spec = get_team_spec()
+# spec["input_model"] -> StrandsAuditInvocation
+# spec["output_model"] -> AccessibilityAuditResult
+```
+
+The returned spec exposes both:
+- `handler_factory`: synchronous wrapper for runtimes that call blocking handlers
+- `async_handler_factory`: async handler for native async runtimes
+
+Payloads must include an `audit_request` object matching `AuditRequest`, and may
+optionally include `tech_stack` metadata.
+
 ## API Endpoints
 
 The team exposes a REST API via FastAPI:

--- a/agents/accessibility_audit_team/__init__.py
+++ b/agents/accessibility_audit_team/__init__.py
@@ -7,6 +7,7 @@ Section 508 standards.
 """
 
 from .models import (
+    AuditRequest,
     AuditPlan,
     CoverageMatrix,
     CoverageRow,
@@ -19,9 +20,11 @@ from .models import (
     Severity,
     Surface,
     TestRunConfig,
+    WCAGLevel,
 )
 
 __all__ = [
+    "AuditRequest",
     "AuditPlan",
     "CoverageMatrix",
     "CoverageRow",
@@ -34,4 +37,5 @@ __all__ = [
     "Severity",
     "Surface",
     "TestRunConfig",
+    "WCAGLevel",
 ]

--- a/agents/accessibility_audit_team/strands_integration.py
+++ b/agents/accessibility_audit_team/strands_integration.py
@@ -1,0 +1,64 @@
+"""Strands/AWS integration helpers for the accessibility audit team."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, Optional
+
+from pydantic import BaseModel, Field
+
+from .models import AccessibilityAuditResult, AuditRequest
+from .orchestrator import AccessibilityAuditOrchestrator
+
+
+class StrandsAuditInvocation(BaseModel):
+    """Payload contract used by Strands runtimes for audit execution."""
+
+    audit_request: AuditRequest = Field(..., description="Accessibility audit request")
+    tech_stack: Dict[str, str] = Field(
+        default_factory=lambda: {"web": "other", "mobile": "other"},
+        description="Optional stack metadata used for remediation guidance",
+    )
+
+
+def create_accessibility_audit_orchestrator(
+    llm_client: Optional[Any] = None,
+) -> AccessibilityAuditOrchestrator:
+    """Construct an orchestrator instance compatible with Strands tool invocation."""
+    return AccessibilityAuditOrchestrator(llm_client=llm_client)
+
+
+async def run_audit_async(
+    llm_client: Optional[Any],
+    payload: Dict[str, Any],
+) -> AccessibilityAuditResult:
+    """Async entrypoint for Strands-compatible runtimes."""
+    invocation = StrandsAuditInvocation.model_validate(payload)
+    orchestrator = create_accessibility_audit_orchestrator(llm_client=llm_client)
+    return await orchestrator.run_audit(
+        audit_request=invocation.audit_request,
+        tech_stack=invocation.tech_stack,
+    )
+
+
+def run_audit_sync(
+    llm_client: Optional[Any],
+    payload: Dict[str, Any],
+) -> AccessibilityAuditResult:
+    """Sync wrapper for runtimes that invoke tools in a synchronous context."""
+    return asyncio.run(run_audit_async(llm_client=llm_client, payload=payload))
+
+
+def get_team_spec() -> Dict[str, Any]:
+    """Return Strands registration metadata for the accessibility audit team."""
+    return {
+        "name": "accessibility_audit_team",
+        "description": (
+            "Runs a full accessibility audit workflow across web/mobile targets "
+            "and returns structured findings and report metadata."
+        ),
+        "input_model": StrandsAuditInvocation,
+        "output_model": AccessibilityAuditResult,
+        "handler_factory": run_audit_sync,
+        "async_handler_factory": run_audit_async,
+    }

--- a/agents/accessibility_audit_team/tests/test_strands_integration.py
+++ b/agents/accessibility_audit_team/tests/test_strands_integration.py
@@ -1,0 +1,69 @@
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+from accessibility_audit_team.models import AuditRequest, WCAGLevel
+from accessibility_audit_team.strands_integration import (
+    StrandsAuditInvocation,
+    create_accessibility_audit_orchestrator,
+    get_team_spec,
+    run_audit_async,
+)
+
+
+def test_get_team_spec_contract() -> None:
+    spec = get_team_spec()
+
+    assert spec["name"] == "accessibility_audit_team"
+    assert spec["input_model"] is StrandsAuditInvocation
+    assert spec["handler_factory"]
+    assert spec["async_handler_factory"]
+
+
+def test_create_accessibility_audit_orchestrator() -> None:
+    orchestrator = create_accessibility_audit_orchestrator()
+    assert orchestrator is not None
+
+
+def test_strands_invocation_validation_defaults() -> None:
+    invocation = StrandsAuditInvocation.model_validate(
+        {
+            "audit_request": {
+                "name": "Smoke",
+                "web_urls": ["https://example.com"],
+                "critical_journeys": ["login"],
+                "wcag_levels": ["A", "AA"],
+            }
+        }
+    )
+
+    assert invocation.tech_stack == {"web": "other", "mobile": "other"}
+    assert invocation.audit_request.wcag_levels == [WCAGLevel.A, WCAGLevel.AA]
+
+
+def test_async_handler_uses_orchestrator() -> None:
+    payload = {
+        "audit_request": AuditRequest(
+            audit_id="audit_test",
+            name="Integration",
+            web_urls=["https://example.com"],
+            critical_journeys=["login"],
+        ).model_dump(),
+        "tech_stack": {"web": "react", "mobile": "swift"},
+    }
+
+    fake_result = Mock(success=True, total_findings=0)
+    fake_orchestrator = Mock()
+    fake_orchestrator.run_audit = AsyncMock(return_value=fake_result)
+
+    with patch(
+        "accessibility_audit_team.strands_integration.create_accessibility_audit_orchestrator",
+        return_value=fake_orchestrator,
+    ):
+        result = asyncio.run(run_audit_async(llm_client=None, payload=payload))
+
+    fake_orchestrator.run_audit.assert_awaited_once()
+    called_request = fake_orchestrator.run_audit.await_args.kwargs["audit_request"]
+    called_stack = fake_orchestrator.run_audit.await_args.kwargs["tech_stack"]
+    assert called_request.audit_id == "audit_test"
+    assert called_stack == {"web": "react", "mobile": "swift"}
+    assert result is fake_result


### PR DESCRIPTION
### Motivation
- Provide a Strands/AWS-compatible runtime contract so the accessibility audit team can be registered and invoked by Strands-style runtimes and agent hosts.
- Expose typed invocation models and a sync/async handler surface so both blocking and async runtimes can call the orchestrator reliably.
- Surface minimal exports and documentation to make it easy for external callers to build typed payloads and integrate the team.

### Description
- Added `agents/accessibility_audit_team/strands_integration.py` which defines `StrandsAuditInvocation`, `create_accessibility_audit_orchestrator`, `run_audit_async`, `run_audit_sync`, and `get_team_spec` (registration metadata and handler factories).
- Updated package exports in `agents/accessibility_audit_team/__init__.py` to include `AuditRequest` and `WCAGLevel` for easier typed payload construction by callers.
- Documented the integration in `agents/accessibility_audit_team/README.md` under a new "AWS Strands Integration" section with usage notes and payload expectations.
- Added unit tests in `agents/accessibility_audit_team/tests/test_strands_integration.py` that validate spec shape, invocation defaults/validation, orchestrator factory behavior, and that the async handler delegates to the orchestrator with expected args.

### Testing
- Ran `python -m compileall agents/accessibility_audit_team` and the package compiled successfully.
- Ran `PYTHONPATH=./agents pytest -q agents/accessibility_audit_team/tests/test_strands_integration.py` and all 4 tests passed (`4 passed`).
- Attempted external verification of Strands docs/package index via outbound requests (`urllib.request.urlopen('https://strandsagents.com/latest/')` and `python -m pip index versions strands-agents`) but those requests failed due to an environment proxy returning `403 Forbidden`, so external network validation could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa12853cbc832ebd6bc008e80bd712)