### PR TITLE
Enforce PRD completeness with required sections, repair pass, and tests

### DIFF
--- a/agents/software_engineering_team/product_requirements_analysis_agent/PRD_GAP_ANALYSIS.md
+++ b/agents/software_engineering_team/product_requirements_analysis_agent/PRD_GAP_ANALYSIS.md
@@ -1,0 +1,60 @@
+# Product Requirements Analysis Team — PRD Gap Analysis
+
+## Scope and method
+
+This analysis compares the **current Product Requirements Analysis (PRA) workflow in this repository** with the content expected in a complete PRD (who/what/where/why/how), aligned to the Aha! PRD guidance requested in Slack.
+
+> Note: direct retrieval of the Aha! page was blocked in this environment (proxy 403), so the expected PRD sections below use the standard Aha-style PRD structure (overview, goals, personas, features/requirements, release, assumptions, and open issues) as the comparison baseline.
+
+## What the PRA team currently does
+
+From code review of the PRA agent and prompts:
+
+1. Runs iterative spec review to find issues/gaps/questions.
+2. Focuses heavily on technical constraint drilling (infrastructure/frontend/backend/database/auth).
+3. Auto-answers and applies clarifications to the spec.
+4. Cleans/validates the spec.
+5. Generates a markdown PRD from cleaned spec + answered questions.
+6. Saves output under `plan/product_analysis/validated_spec.md` and `product_requirements_document.md`.
+
+## Gap matrix: current vs needed for a real PRD
+
+| PRD area (who/what/where/why/how) | Current PRA coverage | Gap | Impact | What is needed |
+|---|---|---|---|---|
+| **Why: strategic context** (business objective, market problem, urgency, strategic fit) | Partially implied by source spec; not enforced as required sections | No required checks/prompts for explicit strategic context | Teams can build correct software for unclear business intent | Add mandatory sections and validation checks for business objective, market/customer problem, and strategy linkage |
+| **Who: customer and stakeholder definition** (personas, segments, buyer vs user, stakeholder map) | PRD prompt mentions “primary personas” but no mandatory extraction/validation | Personas can be absent and still pass cleanup | Solution may optimize for wrong user | Require persona table, stakeholder owners, and user segment assumptions with confidence |
+| **Where: operating context** (platforms, channels, geographies, environments, compliance jurisdictions) | Strong on hosting/deployment technology; weak on user/channel/geography context | “Where users experience the product” is not systematically captured | Missed channel constraints and localization/compliance needs | Add required “Operating Context” section: channels, devices, geo/language, deployment environment, regulatory region |
+| **What: feature scope and behavior** (functional requirements, user stories, edge behavior) | Functional requirements are requested in PRD prompt | No requirement schema (IDs, priority, rationale, acceptance test linkage) | Ambiguous requirements and traceability gaps | Require structured requirement entries: ID, user value, behavior, acceptance criteria, priority, dependency |
+| **How: delivery approach** (UX approach, architecture boundaries, milestones, release plan) | Strong technical stack constraints; no explicit release/milestone template | PRD can omit release sequencing and rollout | Planning/execution lacks phased plan | Add release plan sections: milestones, phased scope, rollout strategy, launch checklist |
+| **Success metrics / outcomes** | Prompt asks for KPIs but cleanup does not enforce measurable quality | Non-measurable goals can pass | Hard to evaluate success post-launch | Enforce metric quality checks: baseline, target, timeframe, owner, instrumentation source |
+| **Non-functional requirements quality** | Prompt lists performance/reliability/security/observability | No explicit SLO/SLA/SLI format enforcement | NFRs may be vague (“fast”, “secure”) | Add required NFR template with measurable thresholds and test methods |
+| **Dependencies and cross-team impact** | Not a first-class output section | External dependencies often implicit | Delivery risk hidden until late | Require dependency register: team/system dependency, owner, due date, risk |
+| **Assumptions, risks, trade-offs** | Prompt includes risks/assumptions/open questions section | No quantitative risk scoring or mitigation ownership requirement | Risks are documented but not managed | Require risk table with likelihood/impact/mitigation/owner/trigger |
+| **Open questions governance** | Questions asked/answered during iteration | Remaining open questions not required to have closure plan | Unresolved blockers can drift into build phase | Require unresolved-question log with decision owner and due date |
+| **Out of scope / non-goals** | Mentioned in overview guidance | Not validated as mandatory | Scope creep likely | Add mandatory out-of-scope list + anti-goals |
+| **Design and UX definition depth** | “Target users & journeys” suggested | No required UX artifacts or decision criteria | UI implementation divergence across teams | Require UX requirements section: key flows, states, accessibility bar, content/system constraints |
+| **Data and analytics instrumentation** | Not explicit beyond observability mention | Event taxonomy and analytics plan absent | Cannot validate user outcomes | Add measurement plan: events, properties, funnels, dashboards, owner |
+| **Lifecycle and operations** (support, runbooks, incident expectations) | Observability appears in NFR guidance only | Operability not required for launch readiness | Post-launch reliability/support gaps | Add operational readiness section: support model, alerts, runbooks, escalation |
+| **Document governance** (version, approvers, decision log) | Artifacts are written to disk; no PRD metadata standard | No formal approval/workflow metadata inside PRD | Auditability and accountability gaps | Add PRD header with owner, approvers, status, revision history, linked decisions |
+
+## Repository-specific evidence for the gaps
+
+- The review and question system is optimized for implementation constraints and clarification loops, especially technology decisions across five constraint domains, but does not force business/market/user completeness dimensions.
+- The PRD prompt is a good start but acts as “guidance,” not a strict schema with pass/fail checks.
+- The cleanup stage validates clarity/structure/actionability generally, but not completeness against a required PRD checklist.
+
+## Recommended minimum PRD completeness gate
+
+Before PRA marks analysis complete, require all fields below to be present and non-empty:
+
+1. **Why**: problem statement, business objective, strategic fit, success hypothesis.
+2. **Who**: personas/segments, key stakeholders, ownership.
+3. **Where**: channels/platforms, geographies/languages, environments/compliance context.
+4. **What**: prioritized functional requirements with IDs and acceptance criteria.
+5. **How**: UX principles, technical approach constraints, release plan, dependencies.
+6. **Measure**: KPI set with baseline/target/timeframe/instrumentation.
+7. **Govern**: risks/assumptions/open questions with owners and dates, approvals/versioning.
+
+## Short conclusion
+
+The current PRA process is strongest at clarifying *implementation constraints* and producing a coherent markdown artifact, but it does not yet guarantee a fully decision-ready PRD across the complete who/what/where/why/how dimensions. Converting the current prompt guidance into a **required PRD schema + validation gate** is the key change needed to produce a consistently “real” PRD.

--- a/agents/software_engineering_team/product_requirements_analysis_agent/agent.py
+++ b/agents/software_engineering_team/product_requirements_analysis_agent/agent.py
@@ -27,12 +27,13 @@ from .models import (
 )
 from .prompts import (
     CONSOLIDATE_QUESTIONS_PROMPT,
+    PRD_COMPLETENESS_REPAIR_PROMPT,
+    PRD_PROMPT,
     SPEC_CLEANUP_CHUNK_PROMPT,
     SPEC_CLEANUP_PROMPT,
     SPEC_REVIEW_CHUNK_PROMPT,
     SPEC_REVIEW_PROMPT,
     SPEC_UPDATE_PROMPT,
-    PRD_PROMPT,
 )
 from planning_v2_team.tool_agents.json_utils import (
     parse_json_with_recovery,
@@ -53,6 +54,19 @@ MAX_GAPS = 10
 
 # Subdirectory under repo where PRA writes all artifacts (validated_spec, PRD, updated_spec*, qa_history).
 PRODUCT_ANALYSIS_SUBDIR = "plan/product_analysis"
+
+PRD_REQUIRED_SECTIONS = [
+    "Product Overview",
+    "Objectives and Success Metrics",
+    "Target Users and Personas",
+    "User Journeys and Use Cases",
+    "Scope",
+    "Functional Requirements",
+    "Non-Functional Requirements",
+    "Technical and Operational Constraints",
+    "Release Plan and Milestones",
+    "Risks, Assumptions, and Open Questions",
+]
 
 
 # ---------------------------------------------------------------------------
@@ -1364,7 +1378,69 @@ Previously Answered Questions:
             )
             return cleaned_spec
 
+        missing_sections = self._find_missing_prd_sections(prd_content)
+        if not missing_sections:
+            return prd_content
+
+        logger.warning(
+            "Product Requirements Analysis: PRD missing required sections: %s",
+            ", ".join(missing_sections),
+        )
+
+        repaired_prd = self._repair_prd_completeness(
+            cleaned_spec=cleaned_spec_snippet,
+            answered_questions_summary=answered_summary_snippet,
+            initial_prd=prd_content,
+            missing_sections=missing_sections,
+        )
+
+        if repaired_prd:
+            repaired_missing = self._find_missing_prd_sections(repaired_prd)
+            if not repaired_missing:
+                return repaired_prd
+            logger.warning(
+                "Product Requirements Analysis: PRD still missing sections after repair: %s",
+                ", ".join(repaired_missing),
+            )
+
         return prd_content
+
+    def _repair_prd_completeness(
+        self,
+        cleaned_spec: str,
+        answered_questions_summary: str,
+        initial_prd: str,
+        missing_sections: List[str],
+    ) -> str:
+        """Attempt one LLM pass to repair missing PRD sections."""
+        prompt = PRD_COMPLETENESS_REPAIR_PROMPT.format(
+            cleaned_spec=cleaned_spec,
+            answered_questions_summary=answered_questions_summary,
+            initial_prd=initial_prd[:20000],
+            missing_sections="\n".join(f"- {section}" for section in missing_sections),
+        )
+        try:
+            repaired_prd = self.llm.complete_text(prompt)
+        except Exception as exc:
+            logger.error("Failed to repair PRD completeness: %s", exc)
+            return ""
+
+        if not isinstance(repaired_prd, str) or not repaired_prd.strip():
+            return ""
+        return repaired_prd
+
+    def _find_missing_prd_sections(self, prd_content: str) -> List[str]:
+        """Return required sections that are absent from PRD markdown headings."""
+        headings = {
+            match.group(1).strip().lower()
+            for match in re.finditer(r"^#{1,6}\s+(.+)$", prd_content, flags=re.MULTILINE)
+        }
+
+        missing: List[str] = []
+        for section in PRD_REQUIRED_SECTIONS:
+            if section.lower() not in headings:
+                missing.append(section)
+        return missing
 
     def _update_spec_from_duplicates(
         self,

--- a/agents/software_engineering_team/product_requirements_analysis_agent/prompts.py
+++ b/agents/software_engineering_team/product_requirements_analysis_agent/prompts.py
@@ -403,38 +403,51 @@ Your goal is to synthesize these into a single, cohesive **Product Requirements 
 
 ### PRD Structure (Markdown)
 
-Use headings and subheadings similar to:
+Use these **required sections** so the PRD is complete across who/what/where/why/how:
 
 1. Product Overview
    - Vision
    - Problem statement
-   - In-scope vs out-of-scope
-2. Target Users & Use Cases
-   - Primary personas
-   - Key user journeys
-3. Goals & Success Metrics
-   - Business goals
-   - User goals
-   - Measurable KPIs/metrics
-4. Functional Requirements
-   - Group by feature or area (e.g., Authentication, Onboarding, Dashboard, Reporting)
-   - For each requirement, be specific and testable
-5. Non-Functional Requirements
-   - Performance and scalability
-   - Reliability & availability
-   - Security & compliance
-   - Observability, logging, and monitoring
-6. Technology & Architecture Constraints
-   - Hosting / deployment decisions (infrastructure domain)
-   - Frontend stack (framework, rendering strategy, styling)
-   - Backend stack (language, framework, API style)
-   - Database & data stores (primary DB, additional stores, hosting model)
-   - Authentication & authorization strategy
-   - Any other hard constraints the implementation must follow
-7. Risks, Assumptions, and Open Questions
-   - Known risks or trade-offs
-   - Key assumptions
-   - Remaining open questions (if any)
+   - Strategic/business objective (the "why")
+2. Objectives and Success Metrics
+   - Business outcomes
+   - User outcomes
+   - Measurable KPIs (include baseline if known, target, and timeframe)
+3. Target Users and Personas
+   - Primary personas (who)
+   - Stakeholders/owners
+   - Persona pain points/jobs-to-be-done
+4. User Journeys and Use Cases
+   - Key end-to-end workflows
+   - Primary use cases and trigger conditions
+5. Scope
+   - In scope
+   - Out of scope / non-goals
+6. Functional Requirements
+   - Group by feature area
+   - Make each requirement specific and testable
+   - Include acceptance criteria for each major feature
+7. Non-Functional Requirements
+   - Performance and scalability targets
+   - Reliability & availability expectations
+   - Security & compliance constraints
+   - Observability, logging, and monitoring expectations
+8. Technical and Operational Constraints
+   - Deployment/hosting decisions (where the product runs)
+   - Frontend/backend/database/auth constraints
+   - Dependencies and integration constraints
+9. Release Plan and Milestones
+   - Delivery phases / milestones
+   - Launch readiness notes
+10. Risks, Assumptions, and Open Questions
+   - Key risks and trade-offs
+   - Critical assumptions
+   - Remaining open questions with suggested owner if clear
+
+Important completeness rules:
+- Do not omit any required section above.
+- If an input does not provide enough detail for a section, include the section and explicitly state what is currently unknown.
+- Keep all content grounded in the provided cleaned spec and answered questions.
 
 ### Inputs
 
@@ -453,6 +466,55 @@ Answered questions (including technology and constraint decisions):
 - Respond with **only** the final PRD in Markdown format.
 - Do **not** wrap the PRD in JSON or code fences.
 - Do **not** include any commentary about how you constructed it; just output the PRD content.
+"""
+
+PRD_COMPLETENESS_REPAIR_PROMPT = """You are a senior Product Manager improving a draft PRD.
+
+You are given:
+1) A cleaned product specification
+2) Answered clarification questions
+3) An initial PRD draft
+4) A list of missing required PRD sections
+
+Task:
+- Return a revised PRD in Markdown that preserves the original valid content,
+  and adds the missing sections so it is complete across who/what/where/why/how.
+- Do not invent unsupported requirements. If a section lacks source detail, explicitly
+  state that details are currently unspecified and should be confirmed.
+
+Required section checklist:
+- Product Overview
+- Objectives and Success Metrics
+- Target Users and Personas
+- User Journeys and Use Cases
+- Scope
+- Functional Requirements
+- Non-Functional Requirements
+- Technical and Operational Constraints
+- Release Plan and Milestones
+- Risks, Assumptions, and Open Questions
+
+Cleaned specification:
+---
+{cleaned_spec}
+---
+
+Answered questions:
+---
+{answered_questions_summary}
+---
+
+Initial PRD draft:
+---
+{initial_prd}
+---
+
+Missing sections:
+---
+{missing_sections}
+---
+
+Respond with only the revised PRD in Markdown.
 """
 
 QUESTION_GENERATION_PROMPT = """Based on the following gap or issue identified in the specification, generate a structured question with answer options.

--- a/agents/software_engineering_team/tests/test_product_requirements_analysis_agent.py
+++ b/agents/software_engineering_team/tests/test_product_requirements_analysis_agent.py
@@ -155,3 +155,52 @@ def test_run_workflow_renames_validated_spec_when_needs_more_detail(tmp_path: Pa
     assert v1.read_text() == "# Validated content", "v1 should contain the original validated content from the rename"
     assert len(update_spec_calls) >= 1
     assert update_spec_calls[0] == 2, "First _update_spec after rename should use version 2"
+
+
+def test_find_missing_prd_sections_detects_expected_gaps() -> None:
+    """Missing required PRD sections should be reported."""
+    llm = MagicMock()
+    agent = ProductRequirementsAnalysisAgent(llm)
+
+    prd = """
+# Product Overview
+
+## Functional Requirements
+
+## Risks, Assumptions, and Open Questions
+"""
+    missing = agent._find_missing_prd_sections(prd)
+
+    assert "Objectives and Success Metrics" in missing
+    assert "Target Users and Personas" in missing
+    assert "Release Plan and Milestones" in missing
+    assert "Product Overview" not in missing
+
+
+def test_generate_prd_repairs_missing_sections_with_second_pass() -> None:
+    """When first PRD draft is incomplete, agent should run repair prompt and return repaired output."""
+    llm = MagicMock()
+    llm.complete_text.side_effect = [
+        "# Product Overview\n\n## Functional Requirements\n",  # missing most required sections
+        """
+# Product Overview
+## Objectives and Success Metrics
+## Target Users and Personas
+## User Journeys and Use Cases
+## Scope
+## Functional Requirements
+## Non-Functional Requirements
+## Technical and Operational Constraints
+## Release Plan and Milestones
+## Risks, Assumptions, and Open Questions
+""",
+    ]
+    agent = ProductRequirementsAnalysisAgent(llm)
+
+    prd = agent._generate_prd_document(
+        cleaned_spec="# Cleaned spec",
+        answered_questions=[],
+    )
+
+    assert "## Release Plan and Milestones" in prd
+    assert llm.complete_text.call_count == 2


### PR DESCRIPTION
### Motivation
- Ensure the product requirements document (PRD) generated by the Product Requirements Analysis agent is decision-ready by covering the full who/what/where/why/how PRD dimensions.
- Prevent downstream planning and implementation from proceeding with partial or ambiguous PRDs by making completeness an enforceable part of the output flow.
- Capture repository-specific analysis and recommended completeness gates to drive future validation and workflow changes via `PRD_GAP_ANALYSIS.md`.

### Description
- Added a required PRD sections checklist as `PRD_REQUIRED_SECTIONS` and implemented section-detection via `ProductRequirementsAnalysisAgent._find_missing_prd_sections` that inspects Markdown headings.
- Updated PRD generation flow to detect missing sections and attempt an automated repair using a second LLM pass via `ProductRequirementsAnalysisAgent._repair_prd_completeness` when gaps are found.
- Added a dedicated repair prompt `PRD_COMPLETENESS_REPAIR_PROMPT` and strengthened `PRD_PROMPT` to list required sections and explicit completeness rules in `prompts.py`.
- Added `agents/.../PRD_GAP_ANALYSIS.md` with gap matrix and recommended minimum PRD completeness gate, and added unit tests that assert missing-section detection and the two-pass repair behavior in `tests/test_product_requirements_analysis_agent.py`.

### Testing
- Ran `pytest agents/software_engineering_team/tests/test_product_requirements_analysis_agent.py::test_find_missing_prd_sections_detects_expected_gaps` and it passed, confirming missing sections are detected.
- Ran `pytest agents/software_engineering_team/tests/test_product_requirements_analysis_agent.py::test_generate_prd_repairs_missing_sections_with_second_pass` and it passed, confirming the agent triggers a second LLM pass and returns a repaired PRD.
- Ran the agent test module (`pytest agents/software_engineering_team/tests/test_product_requirements_analysis_agent.py`) and all tests in the file succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a8356a4c54832eb6f961dec10b915e)