### PR TITLE
Add pre-execution gate for external UI actions in orchestrator

### DIFF
--- a/agents/investment_team/orchestrator.py
+++ b/agents/investment_team/orchestrator.py
@@ -49,6 +49,16 @@ class ExternalUIAction:
             WebActionClass.ACCOUNT_SETTINGS,
         }
 
+    @property
+    def semantic_action_class(self) -> WebActionClass:
+        operation_class_map = {
+            "submit_live_order": WebActionClass.LIVE_TRADING,
+            "modify_account_settings": WebActionClass.ACCOUNT_SETTINGS,
+            "submit_paper_order": WebActionClass.PAPER_TRADING,
+            "read_market_data": WebActionClass.READ_ONLY,
+        }
+        return operation_class_map.get(self.operation, self.action_class)
+
 
 @dataclass
 class WorkflowState:
@@ -166,11 +176,12 @@ class InvestmentTeamOrchestrator:
             },
             WorkflowMode.ADVISORY: {WebActionClass.READ_ONLY},
         }
+        effective_action_class = action.semantic_action_class
         allowed_actions = mode_gate.get(state.mode, {WebActionClass.READ_ONLY})
-        if action.action_class not in allowed_actions:
+        if effective_action_class not in allowed_actions:
             return False, f"mode_blocked:{state.mode.value}"
 
-        if action.action_class == WebActionClass.LIVE_TRADING and not ips.live_trading_enabled:
+        if effective_action_class == WebActionClass.LIVE_TRADING and not ips.live_trading_enabled:
             return False, "ips_live_trading_disabled"
 
         if action.requires_human_approval and not human_approval:

--- a/agents/investment_team/orchestrator.py
+++ b/agents/investment_team/orchestrator.py
@@ -143,7 +143,7 @@ class InvestmentTeamOrchestrator:
         action: ExternalUIAction,
         human_approval: bool = False,
     ) -> bool:
-        allowed, reason = self._pre_execution_gate(
+        allowed, reason, effective_action_class = self._pre_execution_gate(
             state=state,
             ips=ips,
             action=action,
@@ -152,7 +152,7 @@ class InvestmentTeamOrchestrator:
         normalized_event_id = self._normalize_event_id(action.event_id)
         verdict = "approved" if allowed else "denied"
         state.audit_log.append(
-            f"ui_action:{normalized_event_id}:{action.platform}:{action.action_class.value}:{verdict}:{reason}"
+            f"ui_action:{normalized_event_id}:{action.platform}:{effective_action_class.value}:{verdict}:{reason}"
         )
         if allowed:
             self.enqueue(state, QueueItem(queue="execution", payload_id=normalized_event_id, priority="high"))
@@ -164,7 +164,7 @@ class InvestmentTeamOrchestrator:
         ips: IPS,
         action: ExternalUIAction,
         human_approval: bool,
-    ) -> tuple[bool, str]:
+    ) -> tuple[bool, str, WebActionClass]:
         mode_gate = {
             WorkflowMode.MONITOR_ONLY: {WebActionClass.READ_ONLY},
             WorkflowMode.PAPER: {WebActionClass.READ_ONLY, WebActionClass.PAPER_TRADING},
@@ -179,15 +179,15 @@ class InvestmentTeamOrchestrator:
         effective_action_class = action.semantic_action_class
         allowed_actions = mode_gate.get(state.mode, {WebActionClass.READ_ONLY})
         if effective_action_class not in allowed_actions:
-            return False, f"mode_blocked:{state.mode.value}"
+            return False, f"mode_blocked:{state.mode.value}", effective_action_class
 
         if effective_action_class == WebActionClass.LIVE_TRADING and not ips.live_trading_enabled:
-            return False, "ips_live_trading_disabled"
+            return False, "ips_live_trading_disabled", effective_action_class
 
         if action.requires_human_approval and not human_approval:
-            return False, "missing_human_approval"
+            return False, "missing_human_approval", effective_action_class
 
-        return True, "gate_pass"
+        return True, "gate_pass", effective_action_class
 
     def _normalize_event_id(self, event_id: str) -> str:
         normalized = "".join(ch if ch.isalnum() else "_" for ch in event_id.strip().lower())

--- a/agents/investment_team/orchestrator.py
+++ b/agents/investment_team/orchestrator.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Dict, List
 
 from .agents import AgentIdentity, PolicyGuardianAgent, PromotionGateAgent
@@ -21,6 +22,32 @@ class QueueItem:
     queue: str
     payload_id: str
     priority: str = "normal"
+
+
+class WebActionClass(str, Enum):
+    READ_ONLY = "read_only"
+    PAPER_TRADING = "paper_trading"
+    LIVE_TRADING = "live_trading"
+    ACCOUNT_SETTINGS = "account_settings"
+
+
+@dataclass
+class ExternalUIAction:
+    event_id: str
+    platform: str
+    action_class: WebActionClass
+    operation: str
+
+    @property
+    def requires_human_approval(self) -> bool:
+        irreversible_ops = {
+            "submit_live_order",
+            "modify_account_settings",
+        }
+        return self.operation in irreversible_ops or self.action_class in {
+            WebActionClass.LIVE_TRADING,
+            WebActionClass.ACCOUNT_SETTINGS,
+        }
 
 
 @dataclass
@@ -98,3 +125,61 @@ class InvestmentTeamOrchestrator:
         if decision.outcome.value in {"reject", "revise"}:
             self.enqueue(state, QueueItem(queue="escalation", payload_id=strategy.strategy_id, priority="high"))
         return decision
+
+    def dispatch_external_ui_action(
+        self,
+        state: WorkflowState,
+        ips: IPS,
+        action: ExternalUIAction,
+        human_approval: bool = False,
+    ) -> bool:
+        allowed, reason = self._pre_execution_gate(
+            state=state,
+            ips=ips,
+            action=action,
+            human_approval=human_approval,
+        )
+        normalized_event_id = self._normalize_event_id(action.event_id)
+        verdict = "approved" if allowed else "denied"
+        state.audit_log.append(
+            f"ui_action:{normalized_event_id}:{action.platform}:{action.action_class.value}:{verdict}:{reason}"
+        )
+        if allowed:
+            self.enqueue(state, QueueItem(queue="execution", payload_id=normalized_event_id, priority="high"))
+        return allowed
+
+    def _pre_execution_gate(
+        self,
+        state: WorkflowState,
+        ips: IPS,
+        action: ExternalUIAction,
+        human_approval: bool,
+    ) -> tuple[bool, str]:
+        mode_gate = {
+            WorkflowMode.MONITOR_ONLY: {WebActionClass.READ_ONLY},
+            WorkflowMode.PAPER: {WebActionClass.READ_ONLY, WebActionClass.PAPER_TRADING},
+            WorkflowMode.LIVE: {
+                WebActionClass.READ_ONLY,
+                WebActionClass.PAPER_TRADING,
+                WebActionClass.LIVE_TRADING,
+                WebActionClass.ACCOUNT_SETTINGS,
+            },
+            WorkflowMode.ADVISORY: {WebActionClass.READ_ONLY},
+        }
+        allowed_actions = mode_gate.get(state.mode, {WebActionClass.READ_ONLY})
+        if action.action_class not in allowed_actions:
+            return False, f"mode_blocked:{state.mode.value}"
+
+        if action.action_class == WebActionClass.LIVE_TRADING and not ips.live_trading_enabled:
+            return False, "ips_live_trading_disabled"
+
+        if action.requires_human_approval and not human_approval:
+            return False, "missing_human_approval"
+
+        return True, "gate_pass"
+
+    def _normalize_event_id(self, event_id: str) -> str:
+        normalized = "".join(ch if ch.isalnum() else "_" for ch in event_id.strip().lower())
+        while "__" in normalized:
+            normalized = normalized.replace("__", "_")
+        return normalized.strip("_") or "ui_action"

--- a/agents/investment_team/tests/test_investment_team.py
+++ b/agents/investment_team/tests/test_investment_team.py
@@ -165,6 +165,41 @@ def test_external_ui_action_gate_blocks_live_action_in_paper_mode() -> None:
     assert state.audit_log[-1] == "ui_action:order_123:alpaca:live_trading:denied:mode_blocked:paper"
 
 
+def test_external_ui_action_gate_blocks_mislabeled_live_operation_in_paper_mode() -> None:
+    state = WorkflowState(mode=WorkflowMode.PAPER)
+    ips = _sample_ips()
+    orch = InvestmentTeamOrchestrator()
+    action = ExternalUIAction(
+        event_id="Order 456",
+        platform="alpaca",
+        action_class=WebActionClass.PAPER_TRADING,
+        operation="submit_live_order",
+    )
+
+    allowed = orch.dispatch_external_ui_action(state=state, ips=ips, action=action, human_approval=True)
+
+    assert not allowed
+    assert state.audit_log[-1] == "ui_action:order_456:alpaca:paper_trading:denied:mode_blocked:paper"
+
+
+def test_external_ui_action_gate_blocks_mislabeled_live_operation_when_ips_disabled() -> None:
+    state = WorkflowState(mode=WorkflowMode.LIVE)
+    ips = _sample_ips()
+    ips.live_trading_enabled = False
+    orch = InvestmentTeamOrchestrator()
+    action = ExternalUIAction(
+        event_id="Order 789",
+        platform="ibkr",
+        action_class=WebActionClass.READ_ONLY,
+        operation="submit_live_order",
+    )
+
+    allowed = orch.dispatch_external_ui_action(state=state, ips=ips, action=action, human_approval=True)
+
+    assert not allowed
+    assert state.audit_log[-1] == "ui_action:order_789:ibkr:read_only:denied:ips_live_trading_disabled"
+
+
 def test_external_ui_action_gate_requires_human_approval_for_irreversible_action() -> None:
     state = WorkflowState(mode=WorkflowMode.LIVE)
     ips = _sample_ips()

--- a/agents/investment_team/tests/test_investment_team.py
+++ b/agents/investment_team/tests/test_investment_team.py
@@ -179,7 +179,7 @@ def test_external_ui_action_gate_blocks_mislabeled_live_operation_in_paper_mode(
     allowed = orch.dispatch_external_ui_action(state=state, ips=ips, action=action, human_approval=True)
 
     assert not allowed
-    assert state.audit_log[-1] == "ui_action:order_456:alpaca:paper_trading:denied:mode_blocked:paper"
+    assert state.audit_log[-1] == "ui_action:order_456:alpaca:live_trading:denied:mode_blocked:paper"
 
 
 def test_external_ui_action_gate_blocks_mislabeled_live_operation_when_ips_disabled() -> None:
@@ -197,7 +197,7 @@ def test_external_ui_action_gate_blocks_mislabeled_live_operation_when_ips_disab
     allowed = orch.dispatch_external_ui_action(state=state, ips=ips, action=action, human_approval=True)
 
     assert not allowed
-    assert state.audit_log[-1] == "ui_action:order_789:ibkr:read_only:denied:ips_live_trading_disabled"
+    assert state.audit_log[-1] == "ui_action:order_789:ibkr:live_trading:denied:ips_live_trading_disabled"
 
 
 def test_external_ui_action_gate_requires_human_approval_for_irreversible_action() -> None:

--- a/agents/investment_team/tests/test_investment_team.py
+++ b/agents/investment_team/tests/test_investment_team.py
@@ -19,8 +19,9 @@ from agents.investment_team.models import (
     ValidationCheck,
     ValidationReport,
     ValidationStatus,
+    WorkflowMode,
 )
-from agents.investment_team.orchestrator import InvestmentTeamOrchestrator, WorkflowState
+from agents.investment_team.orchestrator import ExternalUIAction, InvestmentTeamOrchestrator, WebActionClass, WorkflowState
 
 
 def _sample_ips() -> IPS:
@@ -145,3 +146,58 @@ def test_policy_guardian_rejects_excluded_asset_class() -> None:
     violations = PolicyGuardianAgent().check_portfolio(ips, proposal)
 
     assert any("excluded by IPS preferences" in item for item in violations)
+
+
+def test_external_ui_action_gate_blocks_live_action_in_paper_mode() -> None:
+    state = WorkflowState(mode=WorkflowMode.PAPER)
+    ips = _sample_ips()
+    orch = InvestmentTeamOrchestrator()
+    action = ExternalUIAction(
+        event_id="Order 123",
+        platform="alpaca",
+        action_class=WebActionClass.LIVE_TRADING,
+        operation="submit_live_order",
+    )
+
+    allowed = orch.dispatch_external_ui_action(state=state, ips=ips, action=action, human_approval=True)
+
+    assert not allowed
+    assert state.audit_log[-1] == "ui_action:order_123:alpaca:live_trading:denied:mode_blocked:paper"
+
+
+def test_external_ui_action_gate_requires_human_approval_for_irreversible_action() -> None:
+    state = WorkflowState(mode=WorkflowMode.LIVE)
+    ips = _sample_ips()
+    orch = InvestmentTeamOrchestrator()
+    action = ExternalUIAction(
+        event_id="SETTINGS-01",
+        platform="broker_portal",
+        action_class=WebActionClass.ACCOUNT_SETTINGS,
+        operation="modify_account_settings",
+    )
+
+    allowed = orch.dispatch_external_ui_action(state=state, ips=ips, action=action, human_approval=False)
+
+    assert not allowed
+    assert state.audit_log[-1] == (
+        "ui_action:settings_01:broker_portal:account_settings:denied:missing_human_approval"
+    )
+
+
+def test_external_ui_action_gate_approves_and_queues_action() -> None:
+    state = WorkflowState(mode=WorkflowMode.LIVE)
+    ips = _sample_ips()
+    orch = InvestmentTeamOrchestrator()
+    action = ExternalUIAction(
+        event_id="Live-Order#ABC",
+        platform="ibkr",
+        action_class=WebActionClass.LIVE_TRADING,
+        operation="submit_live_order",
+    )
+
+    allowed = orch.dispatch_external_ui_action(state=state, ips=ips, action=action, human_approval=True)
+
+    assert allowed
+    assert state.audit_log[-1] == "enqueued:execution:live_order_abc:high"
+    assert state.audit_log[-2] == "ui_action:live_order_abc:ibkr:live_trading:approved:gate_pass"
+    assert state.queues["execution"][-1].payload_id == "live_order_abc"


### PR DESCRIPTION
### Motivation
- Prevent accidental or unauthorized external UI actions by introducing an explicit pre-execution gate that enforces workflow mode and IPS constraints before any web action is dispatched.
- Make irreversible operations (like submitting live orders or changing account settings) require explicit human approval and be auditable.
- Normalize event identifiers and record structured audit entries to make action provenance and review easier.

### Description
- Added `WebActionClass` enum and `ExternalUIAction` dataclass to model external UI actions and detect irreversible operations like `submit_live_order` and `modify_account_settings` in `agents/investment_team/orchestrator.py`.
- Implemented `dispatch_external_ui_action`, `_pre_execution_gate`, and `_normalize_event_id` methods on `InvestmentTeamOrchestrator` to enforce workflow `mode` compatibility, `IPS.live_trading_enabled`, and the explicit `human_approval` flag before dispatching or queuing actions.
- Approved actions are enqueued to the `execution` queue via existing `QueueItem` semantics, and every approval/denial is appended to `WorkflowState.audit_log` with a normalized event id, platform, action class, verdict, and reason.
- Updated unit tests in `agents/investment_team/tests/test_investment_team.py` to cover mode-based blocking, missing human-approval denial, and successful approval + normalized-id enqueueing.

### Testing
- Ran the unit test module with `PYTHONPATH=. pytest -q agents/investment_team/tests/test_investment_team.py` and all tests passed (`8 passed`).
- An initial test collection run without `PYTHONPATH` failed due to import resolution, after which tests were executed with `PYTHONPATH` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a38d059fcc832e961b50ae946e7dac)