### PR TITLE
Decouple investment orchestrator from concrete web coordinator and expand web interface exports

### DIFF
--- a/backend/agents/investment_team/orchestrator.py
+++ b/backend/agents/investment_team/orchestrator.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Protocol
 
 from .agents import AgentIdentity, PolicyGuardianAgent, PromotionGateAgent
 from .models import (
@@ -14,7 +14,17 @@ from .models import (
     ValidationReport,
     WorkflowMode,
 )
-from .tool_agents.web_interfaces import InvestmentWebInterfaceCoordinator
+
+class WebActionCoordinator(Protocol):
+    """Minimal contract for web action orchestration dependencies."""
+
+    def execute_action(
+        self,
+        action: str,
+        payload: Dict[str, Any] | None = None,
+        workspace_name: str | None = None,
+    ) -> Dict[str, Any]:
+        """Execute a provider-backed web action."""
 
 
 @dataclass
@@ -50,7 +60,7 @@ class InvestmentTeamOrchestrator:
     - Live promotion requires IPS permission and independent approver.
     """
 
-    def __init__(self, web_interface_coordinator: InvestmentWebInterfaceCoordinator | None = None) -> None:
+    def __init__(self, web_interface_coordinator: WebActionCoordinator | None = None) -> None:
         self.policy_guardian = PolicyGuardianAgent()
         self.promotion_gate = PromotionGateAgent()
         self.web_interface_coordinator = web_interface_coordinator

--- a/backend/agents/investment_team/tests/test_investment_team.py
+++ b/backend/agents/investment_team/tests/test_investment_team.py
@@ -180,6 +180,23 @@ def test_orchestrator_web_action_uses_optional_coordinator() -> None:
     assert result["results"]["open_workspace"]["details"]["workspace"] == "swing"
 
 
+def test_orchestrator_web_action_accepts_protocol_compatible_coordinator() -> None:
+    class _CoordinatorStub:
+        def execute_action(self, action, payload=None, workspace_name=None):
+            return {
+                "provider": "stub",
+                "results": {"run_action": {"action": action, "payload": payload}},
+                "workspace": workspace_name,
+            }
+
+    orch = InvestmentTeamOrchestrator(web_interface_coordinator=_CoordinatorStub())
+
+    result = orch.run_web_action(action="capture_chart", payload={"symbol": "IWM"}, workspace_name="test")
+
+    assert result["provider"] == "stub"
+    assert result["workspace"] == "test"
+
+
 def test_orchestrator_web_action_requires_configured_coordinator() -> None:
     orch = InvestmentTeamOrchestrator()
 
@@ -215,6 +232,17 @@ def test_web_interface_coordinator_accepts_string_browser_config() -> None:
     result = coordinator.execute_action(action="capture_chart", payload={"symbol": "QQQ"})
 
     assert result["results"]["login"]["details"]["browser"] == "firefox"
+
+
+def test_web_interface_coordinator_accepts_webkit_browser_config() -> None:
+    coordinator = InvestmentWebInterfaceCoordinator(
+        provider="tradingview",
+        config=WebAgentConfig(browser="webkit"),
+    )
+
+    result = coordinator.execute_action(action="capture_chart", payload={"symbol": "DIA"})
+
+    assert result["results"]["login"]["details"]["browser"] == "webkit"
 
 
 def test_web_interface_coordinator_logs_out_when_action_fails() -> None:

--- a/backend/agents/investment_team/tool_agents/web_interfaces/__init__.py
+++ b/backend/agents/investment_team/tool_agents/web_interfaces/__init__.py
@@ -1,11 +1,16 @@
 """Web automation interfaces for broker/platform providers."""
 
 from .coordinator import InvestmentWebInterfaceCoordinator, WebProvider
-from .interfaces import BrowserType, WebAgentConfig, WebBrokerInterface
+from .interfaces import BrowserType, WebActionResult, WebAgentConfig, WebBrokerInterface
+from .quantconnect_agent import QuantConnectWebAgent
+from .tradingview_agent import TradingViewWebAgent
 
 __all__ = [
     "BrowserType",
     "InvestmentWebInterfaceCoordinator",
+    "QuantConnectWebAgent",
+    "TradingViewWebAgent",
+    "WebActionResult",
     "WebAgentConfig",
     "WebBrokerInterface",
     "WebProvider",


### PR DESCRIPTION
### Motivation
- Reduce coupling between the investment orchestrator and browser-driven tooling by depending on a lightweight protocol instead of a concrete coordinator class so web automation remains optional and injectable.
- Make the web interfaces package easier to consume by exporting provider implementations and the shared action result type.
- Add small tests to exercise protocol-compatible coordinator injection and explicit `webkit` browser configuration to ensure flexible browser selection works as a configuration option.

### Description
- Introduced a `WebActionCoordinator` `Protocol` and changed `InvestmentTeamOrchestrator.__init__` to accept `WebActionCoordinator | None` instead of the concrete coordinator type, keeping web actions optional via DI (`backend/agents/investment_team/orchestrator.py`).
- Expanded `backend/agents/investment_team/tool_agents/web_interfaces/__init__.py` exports to include `QuantConnectWebAgent`, `TradingViewWebAgent`, and `WebActionResult` for easier consumption by other modules.
- Added tests validating that a protocol-compatible coordinator stub can be injected into the orchestrator and that `WebAgentConfig` accepts the `webkit` browser string (`backend/agents/investment_team/tests/test_investment_team.py`).
- Preserved existing `run_web_action` behavior and the provider-agnostic coordinator implementation so existing IPS/promotion flows remain unaffected.

### Testing
- Ran `PYTHONPATH=. pytest agents/investment_team/tests/test_investment_team.py -q` and the test suite completed with `15 passed`.
- An initial automated `pytest` invocation without `PYTHONPATH` did not locate the test module, after which the correct `PYTHONPATH` invocation succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69abd9d11c40832e816e5ca9dccb23b8)