### PR TITLE
Resolve agent registry merge conflicts; add team-aware discovery and CLI

### DIFF
--- a/backend/studiogrid/README.md
+++ b/backend/studiogrid/README.md
@@ -20,5 +20,6 @@ Agent registry helpers:
 
 ```bash
 PYTHONPATH=src python -m studiogrid.main registry list
-PYTHONPATH=src python -m studiogrid.main registry find --problem "Need accessibility review" --skills accessibility_review
+PYTHONPATH=src python -m studiogrid.main registry find --problem "Need accessibility review" --skills accessibility_review --requesting-agent design_lead
+PYTHONPATH=src python -m studiogrid.main team list --available-only
 ```

--- a/backend/studiogrid/src/studiogrid/main.py
+++ b/backend/studiogrid/src/studiogrid/main.py
@@ -69,6 +69,7 @@ def cmd_registry_find(args: argparse.Namespace) -> None:
     candidates = registry.find_assisting_agents(
         problem_description=args.problem,
         required_skills=skills,
+        requesting_agent_id=args.requesting_agent,
         limit=args.limit,
     )
     _print(
@@ -79,6 +80,11 @@ def cmd_registry_find(args: argparse.Namespace) -> None:
             "should_spawn_sub_agents": len(candidates) == 0,
         }
     )
+
+
+def cmd_team_list(args: argparse.Namespace) -> None:
+    registry = _build_registry()
+    _print({"teams": registry.list_teams(available_only=args.available_only)})
 
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="studiogrid")
@@ -115,8 +121,16 @@ def build_parser() -> argparse.ArgumentParser:
     registry_find = registry_sub.add_parser("find")
     registry_find.add_argument("--problem", required=True)
     registry_find.add_argument("--skills", default="")
+    registry_find.add_argument("--requesting-agent", default=None)
     registry_find.add_argument("--limit", type=int, default=5)
     registry_find.set_defaults(func=cmd_registry_find)
+
+    team = sub.add_parser("team")
+    team_sub = team.add_subparsers(dest="action", required=True)
+
+    team_list = team_sub.add_parser("list")
+    team_list.add_argument("--available-only", action="store_true")
+    team_list.set_defaults(func=cmd_team_list)
 
     return parser
 

--- a/backend/studiogrid/src/studiogrid/prompts/agents/qa_lead.md
+++ b/backend/studiogrid/src/studiogrid/prompts/agents/qa_lead.md
@@ -1,0 +1,3 @@
+# QA Lead Agent
+
+You are the QA Lead. Validate test strategy coverage, identify risks, and verify release readiness.

--- a/backend/studiogrid/src/studiogrid/runtime/registry_loader.py
+++ b/backend/studiogrid/src/studiogrid/runtime/registry_loader.py
@@ -11,13 +11,13 @@ class RegistryLoader:
         self.root = root
         self._registry = None
 
-    def _load(self) -> dict:
+    def _load(self) -> dict[str, Any]:
         if self._registry is None:
             with (self.root / "workflows" / "agent_registry.yaml").open("r", encoding="utf-8") as f:
                 self._registry = yaml.safe_load(f)
         return self._registry
 
-    def get_agent(self, agent_id: str) -> dict:
+    def get_agent(self, agent_id: str) -> dict[str, Any]:
         agents = self._load().get("agents", {})
         return agents[agent_id]
 
@@ -25,20 +25,44 @@ class RegistryLoader:
         agents = self._load().get("agents", {})
         return [{"agent_id": agent_id, **cfg} for agent_id, cfg in agents.items()]
 
-    def find_assisting_agents(self, *, problem_description: str, required_skills: list[str], limit: int | None = None) -> list[dict[str, Any]]:
+    def list_teams(self, *, available_only: bool = False) -> list[dict[str, Any]]:
+        teams = self._load().get("teams", {})
+        team_rows = [{"team_id": team_id, **cfg} for team_id, cfg in teams.items()]
+        if available_only:
+            team_rows = [team for team in team_rows if team.get("is_available", False)]
+        return sorted(team_rows, key=lambda team: team["team_id"])
+
+    def find_assisting_agents(
+        self,
+        *,
+        problem_description: str,
+        required_skills: list[str],
+        requesting_agent_id: str | None = None,
+        limit: int | None = None,
+    ) -> list[dict[str, Any]]:
         description_tokens = self._tokenize(problem_description)
         needed_skills = {skill.strip().lower() for skill in required_skills if skill.strip()}
+        requesting_agent_teams = self._team_ids_for_agent(requesting_agent_id) if requesting_agent_id else set()
+
         scored: list[dict[str, Any]] = []
         for entry in self.list_agents():
             agent_skills = {skill.lower() for skill in entry.get("skills", [])}
             keyword_tokens = self._tokenize(" ".join(entry.get("keywords", [])))
             skill_matches = sorted(needed_skills.intersection(agent_skills))
             keyword_matches = sorted(description_tokens.intersection(keyword_tokens))
-            score = (3 * len(skill_matches)) + len(keyword_matches)
+
             if needed_skills and not skill_matches:
                 continue
-            if score == 0 and description_tokens:
+
+            base_score = (3 * len(skill_matches)) + len(keyword_matches)
+            if base_score == 0 and description_tokens:
                 continue
+
+            candidate_teams = self._team_ids_for_agent(entry["agent_id"])
+            shared_teams = sorted(requesting_agent_teams.intersection(candidate_teams))
+            same_team_bonus = 100 if shared_teams else 0
+            score = base_score + same_team_bonus
+
             scored.append(
                 {
                     "agent_id": entry["agent_id"],
@@ -48,9 +72,11 @@ class RegistryLoader:
                     "actions": entry.get("actions", []),
                     "resources": entry.get("resources", []),
                     "schemas": entry.get("schemas", []),
+                    "teams": sorted(candidate_teams),
                     "match": {
                         "skills": skill_matches,
                         "keywords": keyword_matches,
+                        "shared_teams": shared_teams,
                     },
                 }
             )
@@ -59,6 +85,16 @@ class RegistryLoader:
         if limit is not None:
             return scored[:limit]
         return scored
+
+    def _team_ids_for_agent(self, agent_id: str | None) -> set[str]:
+        if not agent_id:
+            return set()
+        teams = self._load().get("teams", {})
+        return {
+            team_id
+            for team_id, team_cfg in teams.items()
+            if agent_id in team_cfg.get("agent_ids", [])
+        }
 
     @staticmethod
     def _tokenize(value: str) -> set[str]:

--- a/backend/studiogrid/src/studiogrid/workflows/agent_registry.yaml
+++ b/backend/studiogrid/src/studiogrid/workflows/agent_registry.yaml
@@ -32,3 +32,43 @@ agents:
     schemas:
       - kind: ARTIFACT
         artifact_type: task_out
+
+  qa_lead:
+    description: Owns quality strategy, test planning, and release-readiness validation for deliverables.
+    prompt_file: prompts/agents/qa_lead.md
+    tools:
+      - test_management_tool
+    permissions:
+      - read_artifacts
+    skills:
+      - accessibility_review
+      - test_strategy
+      - quality_assurance
+    actions:
+      - review_test_plan
+      - validate_release_quality
+    keywords:
+      - qa
+      - quality
+      - accessibility
+      - test
+      - validation
+    resources:
+      - type: artifact
+        name: test_plan
+        required: false
+    schemas:
+      - kind: ARTIFACT
+        artifact_type: review
+
+teams:
+  product_design:
+    description: Team focused on UX and design-system delivery.
+    is_available: true
+    agent_ids:
+      - design_lead
+  delivery_quality:
+    description: Team focused on QA, release confidence, and quality gates.
+    is_available: false
+    agent_ids:
+      - qa_lead

--- a/backend/studiogrid/tests/test_registry.py
+++ b/backend/studiogrid/tests/test_registry.py
@@ -16,16 +16,17 @@ def test_registry_lists_agents_with_metadata():
     assert isinstance(first.get("skills", []), list)
 
 
-def test_find_assisting_agents_matches_required_skills_and_problem_keywords():
+def test_find_assisting_agents_prefers_same_team_for_requesting_agent():
     matches = _registry().find_assisting_agents(
-        problem_description="Need a UI accessibility review for component specs",
+        problem_description="Need an accessibility review for the handoff",
         required_skills=["accessibility_review"],
+        requesting_agent_id="design_lead",
         limit=3,
     )
     assert matches
     top = matches[0]
     assert top["agent_id"] == "design_lead"
-    assert "accessibility_review" in top["match"]["skills"]
+    assert top["match"]["shared_teams"] == ["product_design"]
 
 
 def test_find_assisting_agents_returns_empty_without_matching_skills():
@@ -35,3 +36,15 @@ def test_find_assisting_agents_returns_empty_without_matching_skills():
         limit=3,
     )
     assert matches == []
+
+
+def test_list_teams_filters_by_availability():
+    teams = _registry().list_teams(available_only=True)
+    assert teams == [
+        {
+            "team_id": "product_design",
+            "description": "Team focused on UX and design-system delivery.",
+            "is_available": True,
+            "agent_ids": ["design_lead"],
+        }
+    ]


### PR DESCRIPTION
### Motivation

- Merge conflict fallout left registry functionality partially broken and missing team-awareness needed for agents to prefer same-team helpers and for orchestrators to discover available teams.

### Description

- Restore and enhance `RegistryLoader` by adding `list_teams()` and extending `find_assisting_agents()` to accept `requesting_agent_id` and prefer same-team agents via a `same_team` boost, plus helper `_team_ids_for_agent()` and team data in candidate results.
- Extend CLI in `studiogrid.main` to accept `--requesting-agent` for `registry find` and add a `team list --available-only` command with `cmd_team_list()` wiring.
- Enrich `workflows/agent_registry.yaml` with a `qa_lead` agent and a `teams` section to track membership and availability, and add a `qa_lead` prompt file under `prompts/agents/qa_lead.md`.
- Update tests in `backend/studiogrid/tests/test_registry.py` to validate same-team prioritization and team availability filtering, and update `backend/studiogrid/README.md` CLI examples.

### Testing

- Ran unit tests with `cd backend/studiogrid && PYTHONPATH=src pytest -q`, all tests passed (`9 passed`).
- Ran the CLI registry match with `cd backend/studiogrid && PYTHONPATH=src python -m studiogrid.main registry find --problem 'Need accessibility review and testing plan' --skills accessibility_review --requesting-agent design_lead`, which returned `design_lead` ranked first with `shared_teams` including `product_design`.
- Ran `cd backend/studiogrid && PYTHONPATH=src python -m studiogrid.main team list --available-only`, which returned the expected available team list.
- Attempted an external web search for guidance but network proxy returned `403 Forbidden` so that step was skipped.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ac9b4ec3fc832ea0286a06a9e4a2fb)