### PR TITLE
Add MCP tool gateway to shared integrations layer

### DIFF
--- a/backend/agents/integrations/README.md
+++ b/backend/agents/integrations/README.md
@@ -12,6 +12,7 @@ It is intentionally outside individual teams so integrations are configured once
 - One service entry point (`IntegrationService`) for all agent teams
 - Agent discovery API (`discover_integrations`) so agents can determine what each integration can do
 - Transport-agnostic adapter surface that supports API and MCP-backed providers
+- MCP Tool Gateway for discovering, selecting, adding, and configuring MCP tools per provider
 
 ## Module layout
 
@@ -21,7 +22,7 @@ agents/integrations/
   registry.py                   # provider registration and YAML loading
   router.py                     # capability -> provider resolution
   adapters.py                   # API/MCP adapter abstraction
-  service.py                    # shared integration entry point + discovery
+  service.py                    # shared integration entry point + MCP gateway + discovery
   config/providers.example.yaml # sample provider config
 ```
 
@@ -53,6 +54,7 @@ Each provider can define:
 - `actions` — human-readable action descriptions agents/planners can inspect.
 - `auth` — auth type/scopes needed.
 - `settings` — tenant/workspace/project defaults.
+- `mcp_tools` — tool catalog for MCP providers, including per-tool capabilities and config.
 
 ## Agent discovery flow
 
@@ -101,3 +103,14 @@ response = service.call(
 2. Add policy gates (approval, scope enforcement, DLP) before write actions.
 3. Add auth broker for OAuth/service-account token management.
 4. Add audit logging and reliability controls (retry/circuit breaker/idempotency).
+
+
+## MCP tool gateway
+
+`IntegrationService` exposes MCP tool lifecycle helpers for MCP-backed providers:
+
+- `list_mcp_tools(provider_name=None)`
+- `add_mcp_tool(provider_name, tool)`
+- `configure_mcp_tool(provider_name, tool_name, config)`
+
+This keeps MCP tool interaction behind one interface while still allowing provider-specific tool catalogs in config.

--- a/backend/agents/integrations/config/providers.example.yaml
+++ b/backend/agents/integrations/config/providers.example.yaml
@@ -16,6 +16,17 @@ providers:
       server: slack
       workspace: your-workspace
       default_channel: "#agent-updates"
+    mcp_tools:
+      - name: post_message
+        description: Send a message to a Slack channel.
+        capabilities: ["chat.notify"]
+        config:
+          require_channel: true
+      - name: list_channels
+        description: List visible channels in the configured workspace.
+        capabilities: ["chat.channel.list"]
+        config:
+          include_private: false
 
   - name: fireflies
     display_name: Fireflies.ai
@@ -80,6 +91,13 @@ providers:
     settings:
       server: obsidian
       vault: company-knowledge
+    mcp_tools:
+      - name: read_note
+        description: Read an Obsidian note by path.
+        capabilities: ["knowledge.read"]
+      - name: upsert_note
+        description: Create or update an Obsidian note.
+        capabilities: ["knowledge.write"]
 
   - name: figma
     display_name: Figma

--- a/backend/agents/integrations/contracts.py
+++ b/backend/agents/integrations/contracts.py
@@ -13,6 +13,9 @@ class IntegrationOperation(str, Enum):
     UPDATE = "update"
     NOTIFY = "notify"
     SCHEDULE = "schedule"
+    TOOL_LIST = "tool_list"
+    TOOL_ADD = "tool_add"
+    TOOL_UPDATE = "tool_update"
 
 
 class IntegrationRequest(BaseModel):

--- a/backend/agents/integrations/registry.py
+++ b/backend/agents/integrations/registry.py
@@ -8,6 +8,15 @@ import yaml
 
 
 @dataclass(slots=True)
+class McpToolConfig:
+    name: str
+    description: str = ""
+    capabilities: list[str] = field(default_factory=list)
+    enabled: bool = True
+    config: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
 class ProviderConfig:
     name: str
     transport: str
@@ -19,6 +28,7 @@ class ProviderConfig:
     description: str = ""
     auth: dict[str, Any] = field(default_factory=dict)
     actions: dict[str, str] = field(default_factory=dict)
+    mcp_tools: list[McpToolConfig] = field(default_factory=list)
 
 
 class IntegrationRegistry:
@@ -31,6 +41,10 @@ class IntegrationRegistry:
 
     def register(self, provider: ProviderConfig) -> None:
         self._providers[provider.name] = provider
+
+    def update_provider(self, provider: ProviderConfig) -> ProviderConfig:
+        self._providers[provider.name] = provider
+        return provider
 
     def list_enabled(self) -> list[ProviderConfig]:
         return [provider for provider in self._providers.values() if provider.enabled]
@@ -48,6 +62,44 @@ class IntegrationRegistry:
             raise LookupError(f"No enabled integration provider found for '{provider_name}'")
         return provider
 
+    def update_mcp_tool(
+        self,
+        provider_name: str,
+        tool_name: str,
+        *,
+        enabled: bool | None = None,
+        description: str | None = None,
+        capabilities: list[str] | None = None,
+        config: dict[str, Any] | None = None,
+    ) -> McpToolConfig:
+        provider = self.get_provider(provider_name)
+        if provider.transport != "mcp":
+            raise LookupError(f"Provider '{provider_name}' is not configured for MCP transport")
+
+        for tool in provider.mcp_tools:
+            if tool.name != tool_name:
+                continue
+            if enabled is not None:
+                tool.enabled = enabled
+            if description is not None:
+                tool.description = description
+            if capabilities is not None:
+                tool.capabilities = capabilities
+            if config:
+                tool.config.update(config)
+            return tool
+
+        raise LookupError(f"No MCP tool named '{tool_name}' found for provider '{provider_name}'")
+
+    def add_mcp_tool(self, provider_name: str, tool: McpToolConfig) -> McpToolConfig:
+        provider = self.get_provider(provider_name)
+        if provider.transport != "mcp":
+            raise LookupError(f"Provider '{provider_name}' is not configured for MCP transport")
+        if any(existing_tool.name == tool.name for existing_tool in provider.mcp_tools):
+            raise ValueError(f"Provider '{provider_name}' already has MCP tool '{tool.name}'")
+        provider.mcp_tools.append(tool)
+        return tool
+
     def describe(self) -> list[dict[str, Any]]:
         """Returns machine-readable integration metadata for agent planning."""
         return [
@@ -61,6 +113,17 @@ class IntegrationRegistry:
                 "actions": provider.actions,
                 "auth": provider.auth,
                 "settings": provider.settings,
+                "mcp_tools": [
+                    {
+                        "name": tool.name,
+                        "description": tool.description,
+                        "capabilities": tool.capabilities,
+                        "enabled": tool.enabled,
+                        "config": tool.config,
+                    }
+                    for tool in provider.mcp_tools
+                    if tool.enabled
+                ],
             }
             for provider in self.list_enabled()
         ]
@@ -82,6 +145,16 @@ class IntegrationRegistry:
                     description=item.get("description", ""),
                     auth=item.get("auth", {}),
                     actions=item.get("actions", {}),
+                    mcp_tools=[
+                        McpToolConfig(
+                            name=tool["name"],
+                            description=tool.get("description", ""),
+                            capabilities=tool.get("capabilities", []),
+                            enabled=tool.get("enabled", True),
+                            config=tool.get("config", {}),
+                        )
+                        for tool in item.get("mcp_tools", [])
+                    ],
                 )
             )
         return cls(providers)

--- a/backend/agents/integrations/service.py
+++ b/backend/agents/integrations/service.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any, Protocol
 
 from .contracts import IntegrationRequest, IntegrationResponse
-from .registry import IntegrationRegistry, ProviderConfig
+from .registry import IntegrationRegistry, McpToolConfig, ProviderConfig
 from .router import CapabilityRouter
 
 
@@ -11,12 +11,50 @@ class ProviderAdapter(Protocol):
     def execute(self, provider: ProviderConfig, request: IntegrationRequest) -> IntegrationResponse: ...
 
 
+
+
+class McpToolGateway:
+    """Gateway for MCP tool discovery, selection, and configuration."""
+
+    def __init__(self, registry: IntegrationRegistry) -> None:
+        self.registry = registry
+
+    def list_tools(self, provider_name: str | None = None) -> list[dict[str, Any]]:
+        providers = self.registry.list_enabled()
+        if provider_name:
+            providers = [self.registry.get_provider(provider_name)]
+
+        tools: list[dict[str, Any]] = []
+        for provider in providers:
+            if provider.transport != "mcp":
+                continue
+            for tool in provider.mcp_tools:
+                if not tool.enabled:
+                    continue
+                tools.append(
+                    {
+                        "provider": provider.name,
+                        "name": tool.name,
+                        "description": tool.description,
+                        "capabilities": tool.capabilities,
+                        "config": tool.config,
+                    }
+                )
+        return tools
+
+    def add_tool(self, provider_name: str, tool: McpToolConfig) -> McpToolConfig:
+        return self.registry.add_mcp_tool(provider_name, tool)
+
+    def configure_tool(self, provider_name: str, tool_name: str, config: dict[str, Any]) -> McpToolConfig:
+        return self.registry.update_mcp_tool(provider_name, tool_name, config=config)
+
 class IntegrationService:
     """Single entry point agents can use for tool integrations."""
 
     def __init__(self, router: CapabilityRouter, adapter: ProviderAdapter) -> None:
         self.router = router
         self.adapter = adapter
+        self.mcp_gateway = McpToolGateway(router.registry)
 
     @property
     def registry(self) -> IntegrationRegistry:
@@ -25,6 +63,15 @@ class IntegrationService:
     def call(self, request: IntegrationRequest) -> IntegrationResponse:
         provider = self.router.resolve(request)
         return self.adapter.execute(provider=provider, request=request)
+
+    def list_mcp_tools(self, provider_name: str | None = None) -> list[dict[str, Any]]:
+        return self.mcp_gateway.list_tools(provider_name=provider_name)
+
+    def add_mcp_tool(self, provider_name: str, tool: McpToolConfig) -> McpToolConfig:
+        return self.mcp_gateway.add_tool(provider_name=provider_name, tool=tool)
+
+    def configure_mcp_tool(self, provider_name: str, tool_name: str, config: dict[str, Any]) -> McpToolConfig:
+        return self.mcp_gateway.configure_tool(provider_name=provider_name, tool_name=tool_name, config=config)
 
     def discover_integrations(self) -> dict[str, Any]:
         """Expose enabled integrations and capabilities so agents can plan tool usage."""
@@ -37,4 +84,5 @@ class IntegrationService:
         return {
             "integrations": integrations,
             "capability_index": capability_index,
+            "mcp_tools": self.mcp_gateway.list_tools(),
         }

--- a/backend/agents/integrations/tests/test_integrations_layer.py
+++ b/backend/agents/integrations/tests/test_integrations_layer.py
@@ -2,10 +2,12 @@ from pathlib import Path
 
 from integrations.adapters import ApiMcpAdapter
 from integrations.contracts import IntegrationOperation, IntegrationRequest
-from integrations.registry import IntegrationRegistry, ProviderConfig
+from integrations.registry import IntegrationRegistry, McpToolConfig, ProviderConfig
 from integrations.router import CapabilityRouter
 from integrations.service import IntegrationService
 
+
+CONFIG_PATH = Path(__file__).resolve().parents[1] / "config/providers.example.yaml"
 
 REQUIRED_PROVIDERS = {
     "figma",
@@ -84,23 +86,21 @@ def test_service_returns_normalized_execution_plan() -> None:
 
 
 def test_registry_loads_yaml_configuration() -> None:
-    config_path = Path("agents/integrations/config/providers.example.yaml")
-
-    registry = IntegrationRegistry.from_yaml(config_path)
+    registry = IntegrationRegistry.from_yaml(CONFIG_PATH)
 
     assert registry.providers_for_capability("cloud.deploy")
     assert registry.providers_for_capability("meeting.transcript.read")
 
 
 def test_registry_yaml_includes_required_enterprise_providers() -> None:
-    registry = IntegrationRegistry.from_yaml("agents/integrations/config/providers.example.yaml")
+    registry = IntegrationRegistry.from_yaml(CONFIG_PATH)
     provider_names = {provider.name for provider in registry.list_enabled()}
 
     assert REQUIRED_PROVIDERS.issubset(provider_names)
 
 
 def test_discover_integrations_returns_capability_index_and_actions() -> None:
-    registry = IntegrationRegistry.from_yaml("agents/integrations/config/providers.example.yaml")
+    registry = IntegrationRegistry.from_yaml(CONFIG_PATH)
     service = IntegrationService(router=CapabilityRouter(registry), adapter=ApiMcpAdapter())
 
     catalog = service.discover_integrations()
@@ -162,3 +162,38 @@ def test_slack_notify_prefers_payload_channel_over_default() -> None:
     )
 
     assert response.result["target"]["channel"] == "#release-alerts"
+
+
+def test_discover_integrations_exposes_mcp_tools() -> None:
+    registry = IntegrationRegistry.from_yaml(CONFIG_PATH)
+    service = IntegrationService(router=CapabilityRouter(registry), adapter=ApiMcpAdapter())
+
+    catalog = service.discover_integrations()
+
+    assert "mcp_tools" in catalog
+    post_message_tool = next(tool for tool in catalog["mcp_tools"] if tool["name"] == "post_message")
+    assert post_message_tool["provider"] == "slack"
+
+
+def test_service_can_add_and_configure_mcp_tool() -> None:
+    registry = IntegrationRegistry(
+        [
+            ProviderConfig(
+                name="slack",
+                transport="mcp",
+                capabilities=["chat.notify"],
+                mcp_tools=[McpToolConfig(name="post_message", capabilities=["chat.notify"])],
+            )
+        ]
+    )
+    service = IntegrationService(router=CapabilityRouter(registry), adapter=ApiMcpAdapter())
+
+    service.add_mcp_tool(
+        "slack",
+        McpToolConfig(name="pin_message", description="Pin a message", capabilities=["chat.pin"]),
+    )
+    updated_tool = service.configure_mcp_tool("slack", "pin_message", {"max_pins": 10})
+
+    assert updated_tool.config["max_pins"] == 10
+    names = {tool["name"] for tool in service.list_mcp_tools("slack")}
+    assert {"post_message", "pin_message"}.issubset(names)


### PR DESCRIPTION
### Motivation
- Provide a single, consistent integration surface so agent teams can discover, select, add, and configure MCP-backed tools from any enabled provider.
- Extend the provider registry and config model to express per-provider MCP tool catalogs so tooling metadata can live in YAML and be updated at runtime.
- Make integration discovery return MCP tool metadata so planners and agents can include MCP tools in capability selection and planning.

### Description
- Added a `McpToolConfig` dataclass and a `mcp_tools` field on `ProviderConfig`, and enhanced `IntegrationRegistry` with `add_mcp_tool`, `update_mcp_tool`, and `update_provider`, plus YAML loading and `describe()` support for `mcp_tools`.
- Added MCP-related operations to `IntegrationOperation` (`TOOL_LIST`, `TOOL_ADD`, `TOOL_UPDATE`) in `contracts.py` to make intent explicit in provider-neutral requests.
- Implemented `McpToolGateway` in `service.py` and exposed `list_mcp_tools`, `add_mcp_tool`, and `configure_mcp_tool` on `IntegrationService`, and included `mcp_tools` in the `discover_integrations()` response.
- Updated the sample provider config `config/providers.example.yaml` with example `mcp_tools` for Slack and Obsidian and added tests in `agents/integrations/tests/test_integrations_layer.py` to cover discovery and add/configure flows.

### Testing
- Ran `PYTHONPATH=backend/agents pytest -q backend/agents/integrations/tests/test_integrations_layer.py` and all tests passed (`10 passed`).
- The test suite verifies YAML loading of `mcp_tools`, `discover_integrations()` exposes `mcp_tools`, and the runtime `add_mcp_tool`/`configure_mcp_tool` flows behave as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad92e444dc832ea808a112be476189)