### PR TITLE
Add StudioGrid runtime unit tests and fix create_run mapping

### DIFF
--- a/backend/studiogrid/src/studiogrid/runtime/orchestrator.py
+++ b/backend/studiogrid/src/studiogrid/runtime/orchestrator.py
@@ -64,7 +64,12 @@ class Orchestrator:
 
     def create_run(self, *, project_id: str, idempotency_key: str) -> RunContext:
         result = self._idempotent(idempotency_key, lambda: self._create_run(project_id))
-        return RunContext(**result)
+        return RunContext(
+            project_id=result["project_id"],
+            run_id=result["run_id"],
+            phase=result["phase"],
+            contract_version=result["contract_version"],
+        )
 
     def _create_run(self, project_id: str) -> dict:
         run_id = f"run_{uuid.uuid4().hex[:10]}"

--- a/backend/studiogrid/tests/test_orchestrator_runtime.py
+++ b/backend/studiogrid/tests/test_orchestrator_runtime.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from studiogrid.runtime.errors import SchemaValidationError
+from studiogrid.runtime.orchestrator import Orchestrator, RunContext
+from studiogrid.runtime.storage.postgres_store import PostgresStore
+from studiogrid.runtime.storage.s3_store import S3Store
+
+
+class ArtifactRegistry:
+    def run(self, agent_id: str, task_envelope: dict) -> dict:
+        del agent_id, task_envelope
+        return {
+            "kind": "ARTIFACT",
+            "payload": {
+                "artifact_type": "design_tokens",
+                "format": "json",
+                "payload": {"tokens": ["primary", "secondary"]},
+            },
+        }
+
+
+class ReviewRegistry:
+    def run(self, agent_id: str, task_envelope: dict) -> dict:
+        del agent_id, task_envelope
+        return {
+            "kind": "REVIEW",
+            "payload": {
+                "gate": "consistency",
+                "passed": True,
+                "required_fixes": [],
+            },
+        }
+
+
+def _orchestrator(registry: object) -> Orchestrator:
+    return Orchestrator(PostgresStore(), S3Store(), registry, {}, None, {})
+
+
+def test_create_run_and_status_transitions() -> None:
+    orch = _orchestrator(ArtifactRegistry())
+
+    project_id = orch.create_project(name="Visual Audit", idempotency_key="project")
+    run = orch.create_run(project_id=project_id, idempotency_key="run")
+
+    assert run.phase == "INTAKE"
+    assert orch.store.runs[run.run_id]["status"] == "RUNNING"
+
+    orch.set_phase(run_id=run.run_id, phase="DESIGN", idempotency_key="phase")
+    orch.set_waiting_for_human(
+        run_id=run.run_id,
+        decision_id="dec_123",
+        reason="Need explicit contrast exception",
+        expires_at=None,
+        idempotency_key="wait",
+    )
+    orch.set_running(run_id=run.run_id, idempotency_key="resume")
+    orch.set_done(run_id=run.run_id, idempotency_key="done")
+
+    run_row = orch.store.runs[run.run_id]
+    assert run_row["phase"] == "DONE"
+    assert run_row["status"] == "DONE"
+    assert "updated_at" in run_row
+
+
+def test_decision_lifecycle_round_trip() -> None:
+    orch = _orchestrator(ArtifactRegistry())
+    decision_id = orch.create_decision(
+        run_id="run_1",
+        title="Choose CTA styling",
+        context="Need AA contrast",
+        options=[{"key": "A", "label": "Blue"}, {"key": "B", "label": "Black"}],
+        idempotency_key="decision",
+    )
+
+    orch.resolve_decision(decision_id=decision_id, selected_option_key="B", idempotency_key="resolve")
+
+    decision = orch.get_decision(decision_id=decision_id)
+    assert decision["status"] == "CHOSEN"
+    assert decision["selected_option_key"] == "B"
+
+
+def test_dispatch_task_persists_artifact_ref() -> None:
+    orch = _orchestrator(ArtifactRegistry())
+    ctx = RunContext(project_id="proj", run_id="run_1", phase="DESIGN", contract_version=1)
+    task = orch.build_phase_tasks(ctx=ctx)[0]
+
+    refs = orch.dispatch_task_to_agent(ctx=ctx, task=task, idempotency_key="dispatch")
+
+    assert len(refs) == 1
+    ref = refs[0]
+    assert ref.artifact_type == "design_tokens"
+    assert ref.version == 1
+    assert ref.uri.startswith("s3://studiogrid/run_1/design_tokens/")
+
+
+def test_dispatch_task_rejects_non_artifact_envelope() -> None:
+    orch = _orchestrator(ReviewRegistry())
+    ctx = RunContext(project_id="proj", run_id="run_2", phase="DESIGN", contract_version=1)
+
+    with pytest.raises(SchemaValidationError, match="must emit ARTIFACT"):
+        orch.dispatch_task_to_agent(
+            ctx=ctx,
+            task={"owner_agent": "design_lead", "task_id": "task_1"},
+            idempotency_key="bad-dispatch",
+        )
+
+
+def test_persist_artifact_uses_raw_bytes_when_present() -> None:
+    orch = _orchestrator(ArtifactRegistry())
+    ctx = RunContext(project_id="proj", run_id="run_3", phase="HANDOFF", contract_version=1)
+
+    ref = orch.persist_artifact(
+        ctx=ctx,
+        artifact_payload={"artifact_type": "report", "format": "md", "payload": {"body": "ignored"}},
+        raw_bytes=b"# external markdown",
+        idempotency_key="persist-bytes",
+    )
+
+    assert orch.s3.objects[ref.uri] == b"# external markdown"
+
+
+def test_assemble_handoff_kit_contains_latest_artifacts_for_run_only() -> None:
+    orch = _orchestrator(ArtifactRegistry())
+    ctx = RunContext(project_id="proj", run_id="run_4", phase="HANDOFF", contract_version=1)
+
+    orch.persist_artifact(
+        ctx=ctx,
+        artifact_payload={"artifact_type": "tokens", "format": "json", "payload": {"ok": True}},
+        raw_bytes=None,
+        idempotency_key="tokens",
+    )
+    orch.persist_artifact(
+        ctx=RunContext(project_id="proj", run_id="run_other", phase="HANDOFF", contract_version=1),
+        artifact_payload={"artifact_type": "tokens", "format": "json", "payload": {"ok": False}},
+        raw_bytes=None,
+        idempotency_key="tokens-other",
+    )
+
+    kit_ref = orch.assemble_handoff_kit(ctx=ctx, idempotency_key="kit")
+    kit_payload = json.loads(orch.s3.objects[kit_ref.uri].decode("utf-8"))
+
+    assert kit_payload["run_id"] == "run_4"
+    assert len(kit_payload["latest_artifacts"]) == 1
+    assert kit_payload["latest_artifacts"][0]["run_id"] == "run_4"

--- a/backend/studiogrid/tests/test_runtime_utilities.py
+++ b/backend/studiogrid/tests/test_runtime_utilities.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+from studiogrid.runtime.errors import PermissionError, SchemaValidationError
+from studiogrid.runtime.router import PhaseRouter
+from studiogrid.runtime.tool_factory import ToolFactory
+from studiogrid.runtime.validators.schema_validator import validate_envelope, validate_payload
+
+
+def test_phase_router_returns_tasks_unchanged() -> None:
+    router = PhaseRouter()
+    tasks = [{"task_id": "t1"}, {"task_id": "t2"}]
+
+    assert router.route("DESIGN", tasks) == tasks
+
+
+def test_tool_factory_builds_requested_tools_in_order() -> None:
+    tools = {"figma": object(), "contrast_check": object()}
+    factory = ToolFactory(tools)
+
+    built = factory.build_tools(["contrast_check", "figma"], permissions=["*"])
+
+    assert built == [tools["contrast_check"], tools["figma"]]
+
+
+def test_tool_factory_rejects_unknown_tool() -> None:
+    factory = ToolFactory({"figma": object()})
+
+    with pytest.raises(PermissionError, match="Unknown or forbidden"):
+        factory.build_tools(["figma", "slack_notify"], permissions=["*"])
+
+
+def test_validate_envelope_rejects_non_dict() -> None:
+    with pytest.raises(SchemaValidationError, match="Envelope must be an object"):
+        validate_envelope("not-a-dict")  # type: ignore[arg-type]
+
+
+def test_validate_payload_for_review_and_decision_require_fields() -> None:
+    validate_payload("REVIEW", {"gate": "g1", "passed": True, "required_fixes": []})
+    validate_payload("DECISION", {"title": "Pick", "options": []})
+
+    with pytest.raises(SchemaValidationError, match="Missing required fields"):
+        validate_payload("DECISION", {"title": "Pick"})


### PR DESCRIPTION
### Motivation
- Improve unit test coverage for the StudioGrid runtime components to capture lifecycle, artifact persistence, and validator behavior.
- Fix a runtime bug where `Orchestrator.create_run` attempted to initialize `RunContext` by unpacking an internal run row that included non-dataclass fields like `status`.

### Description
- Added `backend/studiogrid/tests/test_orchestrator_runtime.py` with tests for run lifecycle transitions, decision lifecycle, task dispatch/persistence, non-`ARTIFACT` dispatch rejection, raw-bytes persistence, and handoff kit assembly filtering by run.
- Added `backend/studiogrid/tests/test_runtime_utilities.py` with tests for `PhaseRouter`, `ToolFactory`, and the schema validators (`validate_envelope`, `validate_payload`).
- Updated `Orchestrator.create_run` to construct `RunContext` by explicitly mapping `project_id`, `run_id`, `phase`, and `contract_version` from the persisted run row instead of unpacking the whole row.

### Testing
- Ran the StudioGrid test suite with `PYTHONPATH=studiogrid/src pytest studiogrid/tests -q` from the `backend/` directory.
- All tests passed: `19 passed`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ae0bc565b8832e8aeb9b5d8884977a)