### PR TITLE
Add AI Sales Team — full B2B sales pod powered by AWS Strands agents

### DIFF
--- a/backend/agents/sales_team/__init__.py
+++ b/backend/agents/sales_team/__init__.py
@@ -2,8 +2,10 @@
 
 from .models import (
     ClosingStrategy,
+    DealOutcome,
     DiscoveryPlan,
     IdealCustomerProfile,
+    LearningInsights,
     NurtureSequence,
     OutreachSequence,
     PipelineStage,
@@ -12,6 +14,7 @@ from .models import (
     SalesPipelineRequest,
     SalesPipelineResult,
     SalesProposal,
+    StageOutcome,
 )
 from .orchestrator import SalesPodOrchestrator
 
@@ -28,4 +31,7 @@ __all__ = [
     "DiscoveryPlan",
     "SalesProposal",
     "ClosingStrategy",
+    "StageOutcome",
+    "DealOutcome",
+    "LearningInsights",
 ]

--- a/backend/agents/sales_team/__init__.py
+++ b/backend/agents/sales_team/__init__.py
@@ -1,0 +1,31 @@
+"""AI Sales Team — full B2B sales pod powered by AWS Strands agents."""
+
+from .models import (
+    ClosingStrategy,
+    DiscoveryPlan,
+    IdealCustomerProfile,
+    NurtureSequence,
+    OutreachSequence,
+    PipelineStage,
+    Prospect,
+    QualificationScore,
+    SalesPipelineRequest,
+    SalesPipelineResult,
+    SalesProposal,
+)
+from .orchestrator import SalesPodOrchestrator
+
+__all__ = [
+    "SalesPodOrchestrator",
+    "SalesPipelineRequest",
+    "SalesPipelineResult",
+    "PipelineStage",
+    "IdealCustomerProfile",
+    "Prospect",
+    "OutreachSequence",
+    "QualificationScore",
+    "NurtureSequence",
+    "DiscoveryPlan",
+    "SalesProposal",
+    "ClosingStrategy",
+]

--- a/backend/agents/sales_team/__init__.py
+++ b/backend/agents/sales_team/__init__.py
@@ -3,6 +3,7 @@
 from .models import (
     ClosingStrategy,
     DealOutcome,
+    DealResult,
     DiscoveryPlan,
     IdealCustomerProfile,
     LearningInsights,
@@ -33,5 +34,6 @@ __all__ = [
     "ClosingStrategy",
     "StageOutcome",
     "DealOutcome",
+    "DealResult",
     "LearningInsights",
 ]

--- a/backend/agents/sales_team/agents.py
+++ b/backend/agents/sales_team/agents.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Callable, List
+from typing import Any, Callable, List, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +78,13 @@ def _call_agent(agent: Any | None, prompt: str, stub_response: str) -> str:
     except Exception as exc:
         logger.error("Strands agent call failed: %s", exc, exc_info=True)
         return stub_response
+
+
+def _with_insights(base_prompt: str, insights_context: Optional[str]) -> str:
+    """Prepend learned-pattern context to a prompt when available."""
+    if not insights_context or not insights_context.strip():
+        return base_prompt
+    return f"{insights_context}\n\n---\n\n{base_prompt}"
 
 
 # ---------------------------------------------------------------------------
@@ -384,15 +391,19 @@ class ProspectorAgent:
         self._agent = _build_strands_agent(_PROSPECTOR_SYSTEM_PROMPT, _DEFAULT_TOOLS)
 
     def prospect(self, icp_json: str, product_name: str, value_proposition: str,
-                 max_prospects: int, company_context: str) -> str:
-        prompt = (
+                 max_prospects: int, company_context: str,
+                 insights_context: Optional[str] = None) -> str:
+        prompt = _with_insights(
             f"You are prospecting for: {product_name}\n"
             f"Value proposition: {value_proposition}\n"
             f"Company context: {company_context}\n\n"
             f"Ideal Customer Profile:\n{icp_json}\n\n"
             f"Research and return up to {max_prospects} prospects that match this ICP. "
+            "Use learning context above (if any) to prioritise industries and trigger-event "
+            "types that have historically produced wins. "
             "Use web search to find real companies, recent trigger events, and likely contacts. "
-            "Return a JSON array of prospect objects."
+            "Return a JSON array of prospect objects.",
+            insights_context,
         )
         stub = json.dumps([
             {
@@ -426,15 +437,19 @@ class OutreachAgent:
         self._agent = _build_strands_agent(_OUTREACH_SYSTEM_PROMPT, _DEFAULT_TOOLS)
 
     def generate_sequence(self, prospect_json: str, product_name: str,
-                          value_proposition: str, case_studies: str, company_context: str) -> str:
-        prompt = (
+                          value_proposition: str, case_studies: str, company_context: str,
+                          insights_context: Optional[str] = None) -> str:
+        prompt = _with_insights(
             f"Create a complete 6-touch outreach sequence for this prospect:\n{prospect_json}\n\n"
             f"Product: {product_name}\n"
             f"Value proposition: {value_proposition}\n"
             f"Company context: {company_context}\n"
             f"Customer wins to reference: {case_studies}\n\n"
             "Apply Salesfolk personalization, SNAP principles, and the Jeb Blount 6-touch cadence. "
-            "Return a JSON object with email_sequence, call_script, linkedin_message, sequence_rationale."
+            "Use the learning context above (if any) to replicate high-reply subject line angles "
+            "and avoid outreach patterns associated with low response rates. "
+            "Return a JSON object with email_sequence, call_script, linkedin_message, sequence_rationale.",
+            insights_context,
         )
         stub = json.dumps({
             "email_sequence": [
@@ -478,15 +493,19 @@ class LeadQualifierAgent:
         self._agent = _build_strands_agent(_QUALIFIER_SYSTEM_PROMPT, _DEFAULT_TOOLS)
 
     def qualify(self, prospect_json: str, product_name: str,
-                value_proposition: str, call_notes: str) -> str:
-        prompt = (
+                value_proposition: str, call_notes: str,
+                insights_context: Optional[str] = None) -> str:
+        prompt = _with_insights(
             f"Qualify this prospect for {product_name}:\n{prospect_json}\n\n"
             f"Value proposition: {value_proposition}\n"
             f"Notes from any prior conversation: {call_notes or 'None yet'}\n\n"
             "Score BANT (0–10 each), evaluate all 6 MEDDIC signals, assign Iannarino value tier (1–4), "
             "and recommend: advance / nurture / disqualify. "
+            "Use the learning context above (if any) to calibrate scores — e.g. if the data shows "
+            "that deals with authority < 6 rarely close, weigh authority more heavily. "
             "Return a JSON object with bant, meddic, overall_score, value_creation_level, "
-            "recommended_action, disqualification_reason, qualification_notes."
+            "recommended_action, disqualification_reason, qualification_notes.",
+            insights_context,
         )
         stub = json.dumps({
             "bant": {"budget": 7, "authority": 6, "need": 9, "timeline": 6},
@@ -524,15 +543,19 @@ class NurtureAgent:
         self._agent = _build_strands_agent(_NURTURE_SYSTEM_PROMPT, _DEFAULT_TOOLS)
 
     def build_sequence(self, prospect_json: str, product_name: str,
-                       value_proposition: str, duration_days: int) -> str:
-        prompt = (
+                       value_proposition: str, duration_days: int,
+                       insights_context: Optional[str] = None) -> str:
+        prompt = _with_insights(
             f"Build a {duration_days}-day nurture sequence for:\n{prospect_json}\n\n"
             f"Product: {product_name}\n"
             f"Value proposition: {value_proposition}\n\n"
             "Apply HubSpot content-stage mapping (Awareness → Consideration → Decision), "
             "Gong Labs cadence research, and SNAP re-engagement principles. "
+            "Use the learning context above (if any) to select content types that historically "
+            "re-engaged stalled prospects and to set re-engagement triggers that match real patterns. "
             "Return a JSON object with duration_days, touchpoints (array), "
-            "re_engagement_triggers (array), content_recommendations (array)."
+            "re_engagement_triggers (array), content_recommendations (array).",
+            insights_context,
         )
         stub = json.dumps({
             "duration_days": duration_days,
@@ -596,8 +619,9 @@ class DiscoveryAgent:
         self._agent = _build_strands_agent(_DISCOVERY_SYSTEM_PROMPT, _DEFAULT_TOOLS)
 
     def prepare(self, prospect_json: str, qualification_json: str,
-                product_name: str, value_proposition: str) -> str:
-        prompt = (
+                product_name: str, value_proposition: str,
+                insights_context: Optional[str] = None) -> str:
+        prompt = _with_insights(
             f"Prepare a complete discovery call guide for:\nProspect: {prospect_json}\n"
             f"Qualification context: {qualification_json}\n\n"
             f"Product: {product_name}\n"
@@ -605,8 +629,11 @@ class DiscoveryAgent:
             "Write SPIN questions in all four categories, craft a Challenger Sale insight-led opener, "
             "build a tailored demo agenda (features tied to confirmed pains only), "
             "list expected objections, and define success criteria for this call. "
+            "Use the learning context above (if any) to pre-populate expected_objections with "
+            "the objections that have most commonly appeared in past deals. "
             "Return a JSON object with spin_questions {situation, problem, implication, need_payoff}, "
-            "challenger_insight, demo_agenda, expected_objections, success_criteria_for_call."
+            "challenger_insight, demo_agenda, expected_objections, success_criteria_for_call.",
+            insights_context,
         )
         stub = json.dumps({
             "spin_questions": {
@@ -669,8 +696,9 @@ class ProposalAgent:
 
     def write(self, prospect_json: str, product_name: str, value_proposition: str,
               annual_cost_usd: float, discovery_notes: str,
-              case_studies: str, company_context: str) -> str:
-        prompt = (
+              case_studies: str, company_context: str,
+              insights_context: Optional[str] = None) -> str:
+        prompt = _with_insights(
             f"Write a complete sales proposal for:\nProspect: {prospect_json}\n\n"
             f"Product: {product_name}\n"
             f"Value proposition: {value_proposition}\n"
@@ -679,10 +707,14 @@ class ProposalAgent:
             f"Customer wins: {case_studies}\n"
             f"Company context: {company_context}\n\n"
             "Follow Iannarino's proposal structure. Calculate realistic ROI. "
+            "Use the learning context above (if any) to pre-emptively address the most common "
+            "objections in the risk_mitigation section, and to frame the proposal around "
+            "the value dimensions that historically correlated with wins. "
             "Return a JSON object with executive_summary, situation_analysis, proposed_solution, "
             "roi_model {annual_cost_usd, estimated_annual_benefit_usd, payback_months, roi_percentage, assumptions}, "
             "investment_table, implementation_timeline, risk_mitigation, next_steps (array), "
-            "custom_sections (array of {heading, content})."
+            "custom_sections (array of {heading, content}).",
+            insights_context,
         )
         benefit = annual_cost_usd * 2.8
         stub = json.dumps({
@@ -750,8 +782,9 @@ class CloserAgent:
         self._agent = _build_strands_agent(_CLOSER_SYSTEM_PROMPT, _DEFAULT_TOOLS)
 
     def develop_strategy(self, prospect_json: str, proposal_json: str,
-                         product_name: str, value_proposition: str) -> str:
-        prompt = (
+                         product_name: str, value_proposition: str,
+                         insights_context: Optional[str] = None) -> str:
+        prompt = _with_insights(
             f"Develop a closing strategy for:\nProspect: {prospect_json}\n"
             f"Proposal context: {proposal_json}\n\n"
             f"Product: {product_name}\n"
@@ -759,9 +792,13 @@ class CloserAgent:
             "Select the most appropriate Zig Ziglar closing technique for this prospect, "
             "write the close script, prepare objection handlers (with Feel/Felt/Found), "
             "identify a legitimate urgency lever, and define walk-away criteria. "
+            "Use the learning context above (if any) to: (1) prefer the close technique with the "
+            "highest observed win rate, (2) include pre-written handlers for the most common "
+            "historically-observed objections. "
             "Return a JSON object with recommended_close_technique, close_script, "
             "objection_handlers (array of {objection, response, feel_felt_found}), "
-            "urgency_framing, walk_away_criteria, emotional_intelligence_notes."
+            "urgency_framing, walk_away_criteria, emotional_intelligence_notes.",
+            insights_context,
         )
         stub = json.dumps({
             "recommended_close_technique": "summary",
@@ -826,15 +863,19 @@ class SalesCoachAgent:
     def __post_init__(self) -> None:
         self._agent = _build_strands_agent(_COACH_SYSTEM_PROMPT, _DEFAULT_TOOLS)
 
-    def review(self, prospects_json: str, product_name: str, pipeline_context: str) -> str:
-        prompt = (
+    def review(self, prospects_json: str, product_name: str, pipeline_context: str,
+               insights_context: Optional[str] = None) -> str:
+        prompt = _with_insights(
             f"Review this sales pipeline for {product_name}:\n{prospects_json}\n\n"
             f"Additional pipeline context: {pipeline_context or 'None provided'}\n\n"
             "Identify deal risk signals (using Gong Labs framework), provide talk/listen ratio advice, "
             "velocity insights, forecast categorization, top priority deals, and specific next actions. "
+            "Use the learning context above (if any) to compare this pipeline's patterns against "
+            "historical win/loss data and flag deals that match known losing patterns. "
             "Return a JSON object with prospects_reviewed, deal_risk_signals (array of {signal, severity, recommended_action}), "
             "talk_listen_ratio_advice, velocity_insights, forecast_category, "
-            "top_priority_deals (array), recommended_next_actions (array), coaching_summary."
+            "top_priority_deals (array), recommended_next_actions (array), coaching_summary.",
+            insights_context,
         )
         stub = json.dumps({
             "prospects_reviewed": 1,

--- a/backend/agents/sales_team/agents.py
+++ b/backend/agents/sales_team/agents.py
@@ -1,0 +1,880 @@
+"""AWS Strands AI agent implementations for the Sales Team pod.
+
+Each agent wraps a strands.Agent with a methodology-rich system prompt grounded in:
+- Gong Labs Blog (pipeline velocity, talk/listen ratios, deal risk signals)
+- Jeb Blount (Fanatical Prospecting, Sales EQ, objection handling)
+- HubSpot Sales Blog (lead scoring, nurture sequences, inbound methodology)
+- Anthony Iannarino (Level 1-4 Value Creation, sales-specific advisory selling)
+- Jill Konrath (SNAP Selling, SPIN framework application)
+- Sales Hacker Blog (modern cadence frameworks, tech-stack prospecting)
+- Salesfolk (hyper-personalized cold email copy)
+- Zig Ziglar (classic closing techniques: assumptive, summary, urgency, etc.)
+
+If the `strands` package is not installed the agents degrade gracefully, returning
+structured-text stubs so the API remains functional and tests can run without the SDK.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, List
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Optional Strands SDK import
+# ---------------------------------------------------------------------------
+
+try:
+    from strands import Agent as StrandsAgent  # type: ignore[import]
+
+    try:
+        from strands_tools import current_time, http_request, python_repl  # type: ignore[import]
+
+        _DEFAULT_TOOLS = [http_request, python_repl, current_time]
+    except ImportError:
+        _DEFAULT_TOOLS = []
+
+    HAS_STRANDS = True
+    logger.info("AWS Strands SDK loaded — sales agents will use strands.Agent")
+except ImportError:
+    HAS_STRANDS = False
+    _DEFAULT_TOOLS = []
+    logger.warning(
+        "strands package not found — sales agents running in stub mode. "
+        "Install strands-agents and strands-agents-tools for full LLM capability."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Base helper
+# ---------------------------------------------------------------------------
+
+
+def _build_strands_agent(system_prompt: str, tools: list | None = None) -> Any | None:
+    """Construct a strands.Agent if the SDK is available, else return None."""
+    if not HAS_STRANDS:
+        return None
+    return StrandsAgent(
+        system_prompt=system_prompt,
+        tools=tools if tools is not None else _DEFAULT_TOOLS,
+    )
+
+
+def _call_agent(agent: Any | None, prompt: str, stub_response: str) -> str:
+    """Call a strands.Agent and return its text output, falling back to the stub."""
+    if agent is None:
+        return stub_response
+    try:
+        result = agent(prompt)
+        # strands.Agent may return an AgentResult or a str
+        if hasattr(result, "message"):
+            content = result.message
+        else:
+            content = str(result)
+        return content.strip()
+    except Exception as exc:
+        logger.error("Strands agent call failed: %s", exc, exc_info=True)
+        return stub_response
+
+
+# ---------------------------------------------------------------------------
+# System prompts (encoding methodology)
+# ---------------------------------------------------------------------------
+
+_PROSPECTOR_SYSTEM_PROMPT = """You are an elite Sales Development Representative (SDR) and prospecting specialist.
+
+## Your Methodology
+You follow Jeb Blount's *Fanatical Prospecting* principles:
+- Respect the 30-Day Rule: a prospect who enters the pipeline today closes 30–90 days from now, so
+  never stop filling the top of the funnel.
+- Multi-channel outreach: phone → email → social — in that priority order.
+- Protect prime selling time (PST): block 8–11 AM and 4–6 PM for prospecting only.
+
+You apply Sales Hacker ICP-scoring practices:
+- Score prospects on firmographic fit (industry, size, revenue), technographic fit (their stack),
+  intent signals (hiring trends, funding news, product launches), and trigger events (leadership changes, expansions).
+- A score below 0.4 is disqualify-on-sight. Between 0.4–0.7 is nurture. Above 0.7 is immediate outreach.
+
+You research using publicly available signals:
+- LinkedIn for company growth rate, headcount, and buyer titles.
+- Company news/press releases for trigger events.
+- Job postings as a proxy for pain: a company hiring 5 "data engineers" likely needs data tooling.
+- G2 / Capterra reviews of their current vendor for switching intent.
+
+## Output Format
+Return a JSON array of prospect objects. Each object must include:
+company_name, website, contact_name, contact_title, contact_email (if findable), linkedin_url,
+company_size_estimate, industry, icp_match_score (0.0–1.0), research_notes, trigger_events (array).
+
+Be specific. Do not hallucinate emails — mark as null if not found.
+"""
+
+_OUTREACH_SYSTEM_PROMPT = """You are a world-class Sales Outreach Specialist writing cold email sequences and call scripts.
+
+## Your Methodology
+
+### Salesfolk Email Principles
+- Every email must be hyper-personalized to a specific trigger event or pain point.
+- Subject lines: 3–7 words, curiosity-driven, never click-bait. Reference something specific to the prospect.
+- Body: 3–5 sentences max. Lead with *their* world, not yours.
+- CTA: one specific ask. "Are you open to a 15-minute call Thursday at 2 PM?"
+
+### Jill Konrath's SNAP Framework
+Every message must be:
+- **Simple** — strip every word that doesn't earn its place.
+- **iNvaluable** — offer insight, a benchmark, or a POV they haven't heard before.
+- **Aligned** — connect to their stated priorities (use their own language from public sources).
+- **Priority** — create urgency tied to a real trigger, not artificial pressure.
+
+### Sales Hacker Cadence (Jeb Blount)
+Build a 6-touch sequence:
+1. Day 1: Personalized email (pain-first)
+2. Day 3: Cold call with voicemail
+3. Day 5: Follow-up email referencing the call attempt
+4. Day 8: LinkedIn connection request with value note
+5. Day 12: Email with case study or social proof
+6. Day 15: Break-up email (polite, leaves door open)
+
+### Cold Call Structure (Jeb Blount)
+Opening: "Hi [Name], this is [SDR] from [Company]. I know I'm calling out of the blue — do you have 27 seconds?"
+Elevator pitch: One sentence on what you do and who you help.
+Pivot to pain: "We work with [title] at [ICP companies] who struggle with [pain]. Is that on your radar at all?"
+Book the meeting: "I'd love to learn more about your situation — are you open to 15 minutes [day]?"
+
+## Output Format
+Return a JSON object with keys:
+- email_sequence: array of {day, subject_line, body, personalization_tokens, call_to_action}
+- call_script: full call script as a string
+- linkedin_message: connection request copy
+- sequence_rationale: brief explanation of angle chosen
+"""
+
+_QUALIFIER_SYSTEM_PROMPT = """You are a Lead Qualification Specialist with deep expertise in BANT, MEDDIC,
+and Anthony Iannarino's value-creation framework.
+
+## Your Methodology
+
+### BANT Scoring (0–10 per dimension)
+- **Budget**: Do they have a funded initiative or approved budget? Have they quantified the cost of inaction?
+- **Authority**: Is the contact the Economic Buyer (EB), or do you have a path to the EB?
+- **Need**: Is there a confirmed, urgent, documented business pain? Is the status quo painful enough to act?
+- **Timeline**: Is there a hard deadline (compliance, end-of-year budget, contract renewal)?
+
+### MEDDIC Boolean Signals
+- Metrics: Have you quantified the business impact of solving the pain?
+- Economic Buyer: Do you know who writes the check?
+- Decision Criteria: Do you understand what they use to evaluate solutions?
+- Decision Process: Have you mapped who is involved and what approvals are needed?
+- Identify Pain: Have you confirmed the root cause of the problem at the executive level?
+- Champion: Do you have an internal advocate who will sell for you internally?
+
+### Iannarino's Value Creation Levels
+1. Level 1 — Product/service value (commodity)
+2. Level 2 — Business outcomes (ROI, cost reduction)
+3. Level 3 — Strategic outcomes (competitive advantage, market share)
+4. Level 4 — Personal/organizational transformation (career impact, cultural shift)
+Aim for Level 3 or 4 to win without competing on price.
+
+### Recommended Actions
+- BANT composite ≥ 0.7 AND ≥ 4 MEDDIC signals → Advance to Discovery
+- BANT 0.4–0.69 OR < 4 MEDDIC → Nurture with targeted content
+- BANT < 0.4 → Disqualify politely; log for future cycles
+
+## Output Format
+Return a JSON object with keys: bant {budget, authority, need, timeline}, meddic {all 6 booleans},
+overall_score (0.0–1.0 weighted composite), value_creation_level (1–4), recommended_action,
+disqualification_reason (null if advancing), qualification_notes.
+"""
+
+_NURTURE_SYSTEM_PROMPT = """You are a Lead Nurture Strategist specializing in long-cycle B2B nurture programs.
+
+## Your Methodology
+
+### HubSpot Inbound Nurture Model
+- Match content to buyer stage: Awareness (educational) → Consideration (comparison) → Decision (ROI/case study).
+- Every touchpoint must provide value — not just a check-in.
+- Use progressive profiling: each interaction should reveal more about the buyer's situation.
+
+### Gong Labs Cadence Research
+- Optimal follow-up cadence for cold nurture: 3 touches/week for weeks 1–2, then 1/week.
+- After 60 days of silence from the prospect, send a "permission to close your file" break-up to reset or disqualify.
+- Calls booked within 5 minutes of a prospect's digital action (content download, email open) convert at 9× the rate.
+
+### Jill Konrath's SNAP (for re-engagement)
+- Re-engagement emails must reference a *new* trigger (funding round, leadership change, industry trend).
+- Never send a "just checking in" email — always attach a specific piece of value.
+
+### Content Types (priority order)
+1. Industry benchmark / research snippet
+2. Customer case study (1–2 sentence win)
+3. Educational how-to (linked article or video)
+4. ROI / cost-of-inaction calculator
+5. Peer comparison or competitive insight
+
+### Re-engagement Triggers
+Watch for: new funding, product launches, leadership changes, industry events, end-of-quarter.
+
+## Output Format
+Return a JSON object with keys: duration_days, touchpoints (array of {day, channel, content_type, message, goal}),
+re_engagement_triggers (array), content_recommendations (array of content titles/descriptions).
+"""
+
+_DISCOVERY_SYSTEM_PROMPT = """You are an expert Account Executive facilitating B2B discovery calls and product demos.
+
+## Your Methodology
+
+### SPIN Selling (Jill Konrath's application)
+Build questions in all four SPIN categories:
+- **Situation** — understand their current state (avoid over-questioning; 2–3 max).
+- **Problem** — surface dissatisfaction with the status quo. "What's the biggest challenge with X today?"
+- **Implication** — amplify consequences of inaction. "What happens to [metric] if this isn't solved by Q3?"
+- **Need-payoff** — get the prospect to articulate the value of solving it. "If you could solve X, what would that mean for your team?"
+
+### The Challenger Sale Insight-Led Opening
+Start with a provocative commercial insight — something counterintuitive that reframes how they think about their
+problem. This positions you as an expert, not a vendor.
+Example format: "Most [titles] we talk to believe [common assumption]. What we've found is actually [counterintuitive truth backed by data]."
+
+### Gong Labs Discovery Best Practices
+- Talk/listen ratio during discovery: aim for 43% talking, 57% listening.
+- Ask questions in clusters of 2, then pause.
+- Use "Why?" and "Tell me more" as power phrases.
+- Always close discovery with: "Based on what you've shared, here is what I think we should do next..."
+
+### Demo Structure
+1. Set the agenda (2 min) — confirm what success looks like for the call.
+2. Insight hook (2 min) — Challenger opening.
+3. Situation validation (5 min) — confirm key SPIN findings.
+4. Tailored demo (15 min) — show only features tied to confirmed pains. Never feature-dump.
+5. Objection checkpoint (5 min) — invite concerns before moving to next steps.
+6. Next steps (3 min) — propose a specific date for the next meeting.
+
+## Output Format
+Return a JSON object with keys: spin_questions {situation, problem, implication, need_payoff (all arrays)},
+challenger_insight, demo_agenda (array), expected_objections (array), success_criteria_for_call.
+"""
+
+_PROPOSAL_SYSTEM_PROMPT = """You are a Senior Account Executive and proposal writer specializing in high-value B2B proposals.
+
+## Your Methodology
+
+### Anthony Iannarino's Proposal Structure
+Every proposal must follow this Level-4 Value Creation structure:
+1. **Executive Brief** — 1 page. Connect their strategic initiative to your solution. Use their exact language.
+2. **Situation Analysis** — Prove you understood their problem better than anyone else.
+3. **Proposed Solution** — Describe the outcome, not the features. "You will have..." not "We offer..."
+4. **ROI Model** — Quantify the return. Include payback period. Use conservative assumptions.
+5. **Investment Table** — Clear pricing with options (Good/Better/Best when possible).
+6. **Implementation Timeline** — Show you have a plan; reduce perceived risk.
+7. **Risk Mitigation** — Address the top 2–3 objections before they surface.
+8. **Next Steps** — Specific, time-bound. "Sign by [date] to begin [milestone] by [date]."
+
+### ROI Calculation Principles
+- Use the prospect's own numbers when possible.
+- Calculate: Annual Benefit ÷ Annual Cost × 100 = ROI%
+- Payback months = Annual Cost ÷ Monthly Benefit
+- List all assumptions explicitly — credibility requires transparency.
+
+### HubSpot Proposal Best Practices
+- Include a video walkthrough link placeholder for remote deals.
+- Limit the proposal to the single package most appropriate — choice paralysis kills deals.
+- Always include an expiration date (Zig Ziglar urgency principle).
+
+## Output Format
+Return a JSON object with keys: executive_summary, situation_analysis, proposed_solution, roi_model
+{annual_cost_usd, estimated_annual_benefit_usd, payback_months, roi_percentage, assumptions},
+investment_table, implementation_timeline, risk_mitigation, next_steps (array),
+custom_sections (array of {heading, content}).
+"""
+
+_CLOSER_SYSTEM_PROMPT = """You are a master sales closer grounded in Zig Ziglar's proven closing techniques
+and Jeb Blount's Sales EQ (emotional intelligence in sales).
+
+## Your Methodology
+
+### Zig Ziglar's Closing Techniques
+- **Assumptive Close**: Proceed as if the decision is already made. "When we get started next week, which team member should I coordinate with for onboarding?"
+- **Summary Close**: Summarize agreed-upon benefits and pain points, then ask for the order. "So we've agreed X saves you Y and solves Z — shall we move forward?"
+- **Urgency/Scarcity Close**: Use legitimate urgency (not manufactured). "Implementation slots fill up 3 weeks out — to hit your Q2 goal, we'd need to sign this week."
+- **Alternative Choice Close**: Never ask yes/no. "Would you prefer to start with the annual plan or monthly?" Both options assume a yes.
+- **Sharp Angle Close**: When they ask for a concession, attach a condition. "If I can get the implementation fee waived, can we sign today?"
+- **Feel/Felt/Found** (Jeb Blount): "I understand how you feel. Others have felt the same way. What they found was..."
+
+### Jeb Blount's Sales EQ Principles
+- Acknowledge the prospect's emotional state before presenting logic.
+- Never argue with an objection — validate it, then redirect.
+- Silence after closing question = power. Do not fill it.
+- The most dangerous word in closing is "but." Replace with "and."
+- Mirror the prospect's urgency level; rushing a slow buyer loses deals.
+
+### Objection Handling Framework
+For every objection:
+1. Acknowledge ("That's a fair point.")
+2. Clarify ("Help me understand — is it the budget itself, or the ROI timing?")
+3. Isolate ("If we resolved that, would you be ready to move forward?")
+4. Respond with Feel/Felt/Found or a proof point
+5. Re-ask the closing question
+
+## Output Format
+Return a JSON object with keys: recommended_close_technique, close_script,
+objection_handlers (array of {objection, response, feel_felt_found}),
+urgency_framing, walk_away_criteria, emotional_intelligence_notes.
+"""
+
+_COACH_SYSTEM_PROMPT = """You are a Sales Manager and pipeline coach with deep expertise in Gong Labs research,
+pipeline velocity optimization, and deal risk assessment.
+
+## Your Methodology
+
+### Gong Labs Deal Risk Signals
+Flag deals that show:
+- **Single-threaded**: Only one contact engaged — high churn risk.
+- **No next step**: No confirmed follow-up on calendar after last interaction.
+- **Stalled post-proposal**: No activity for > 10 days after proposal sent.
+- **Competitor mentioned 3+ times**: High risk of competitive loss.
+- **Economic buyer absent**: Champion engaged but EB never on a call.
+- **Late-stage expansion**: Prospect asking for scope changes late in cycle (usually a delay tactic).
+
+### Gong Labs Talk/Listen Ratio Benchmarks
+- Discovery calls: Reps should talk 43%, listen 57%.
+- Demos: Reps talk 65%, listen 35%.
+- Closing calls: Reps talk < 40%, listen > 60%.
+Red flag: any rep talking > 70% on any call type.
+
+### Pipeline Velocity Formula (HubSpot / Salesforce standard)
+Velocity = (# Deals × Average Deal Size × Win Rate) ÷ Average Sales Cycle Length
+Coaching actions that improve velocity: increase # deals in pipe, qualify out non-fits, shorten cycle with multi-threading.
+
+### Anthony Iannarino's Coaching Framework
+- Review each deal against the Level-1–4 value hierarchy. Deals stuck at Level 1–2 compete on price.
+- Identify which deals have a confirmed champion vs. a gatekeeper.
+- For at-risk deals: assign a specific "save" play (executive sponsor outreach, competitive battlecard, discount justification).
+
+### Forecast Categories (Salesforce standard)
+- Pipeline: Early stage, may or may not close this period.
+- Best Case: Has a path to close; needs conditions to align.
+- Commit: High-confidence close within the period.
+
+## Output Format
+Return a JSON object with keys: prospects_reviewed, deal_risk_signals (array of {signal, severity, recommended_action}),
+talk_listen_ratio_advice, velocity_insights, forecast_category,
+top_priority_deals (array of company names), recommended_next_actions (array), coaching_summary.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Agent dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ProspectorAgent:
+    """SDR: identifies and researches prospects matching the ICP.
+
+    Grounded in Jeb Blount's Fanatical Prospecting and Sales Hacker ICP frameworks.
+    """
+
+    role: str = "Prospector (SDR)"
+    _agent: Any = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._agent = _build_strands_agent(_PROSPECTOR_SYSTEM_PROMPT, _DEFAULT_TOOLS)
+
+    def prospect(self, icp_json: str, product_name: str, value_proposition: str,
+                 max_prospects: int, company_context: str) -> str:
+        prompt = (
+            f"You are prospecting for: {product_name}\n"
+            f"Value proposition: {value_proposition}\n"
+            f"Company context: {company_context}\n\n"
+            f"Ideal Customer Profile:\n{icp_json}\n\n"
+            f"Research and return up to {max_prospects} prospects that match this ICP. "
+            "Use web search to find real companies, recent trigger events, and likely contacts. "
+            "Return a JSON array of prospect objects."
+        )
+        stub = json.dumps([
+            {
+                "company_name": "Acme Corp",
+                "website": "https://acme.example.com",
+                "contact_name": "Jane Smith",
+                "contact_title": "VP of Sales",
+                "contact_email": None,
+                "linkedin_url": "https://linkedin.com/in/jane-smith-example",
+                "company_size_estimate": "200–500",
+                "industry": "SaaS",
+                "icp_match_score": 0.85,
+                "research_notes": "Recently raised Series B; hiring 10 AEs; uses Salesforce.",
+                "trigger_events": ["Series B funding announced", "Headcount growing 40% YoY"],
+            }
+        ])
+        return _call_agent(self._agent, prompt, stub)
+
+
+@dataclass
+class OutreachAgent:
+    """SDR/BDR: crafts hyper-personalized cold outreach sequences.
+
+    Grounded in Salesfolk, Jill Konrath SNAP, and Jeb Blount's 6-touch cadence.
+    """
+
+    role: str = "Outreach Specialist (SDR/BDR)"
+    _agent: Any = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._agent = _build_strands_agent(_OUTREACH_SYSTEM_PROMPT, _DEFAULT_TOOLS)
+
+    def generate_sequence(self, prospect_json: str, product_name: str,
+                          value_proposition: str, case_studies: str, company_context: str) -> str:
+        prompt = (
+            f"Create a complete 6-touch outreach sequence for this prospect:\n{prospect_json}\n\n"
+            f"Product: {product_name}\n"
+            f"Value proposition: {value_proposition}\n"
+            f"Company context: {company_context}\n"
+            f"Customer wins to reference: {case_studies}\n\n"
+            "Apply Salesfolk personalization, SNAP principles, and the Jeb Blount 6-touch cadence. "
+            "Return a JSON object with email_sequence, call_script, linkedin_message, sequence_rationale."
+        )
+        stub = json.dumps({
+            "email_sequence": [
+                {
+                    "day": 1,
+                    "subject_line": "{{company_name}} + [Product] — quick thought",
+                    "body": (
+                        "Hi {{contact_name}},\n\nSaw {{trigger_event}} — congrats on the momentum.\n\n"
+                        "We help [titles] at companies like yours [core outcome] without [key friction].\n\n"
+                        "Worth a 15-min call this week?"
+                    ),
+                    "personalization_tokens": ["{{company_name}}", "{{contact_name}}", "{{trigger_event}}"],
+                    "call_to_action": "15-minute call this week",
+                },
+            ],
+            "call_script": (
+                "Hi {{contact_name}}, this is [SDR] from [Company]. "
+                "I know I'm calling out of the blue — do you have 27 seconds? "
+                "[Pause] We help [titles] solve [pain]. Is that on your radar?"
+            ),
+            "linkedin_message": (
+                "Hi {{contact_name}}, noticed {{trigger_event}} — impressive growth. "
+                "I work with similar [titles] on [outcome]. Would love to connect."
+            ),
+            "sequence_rationale": "Trigger-event hook chosen to maximize relevance and open rates.",
+        })
+        return _call_agent(self._agent, prompt, stub)
+
+
+@dataclass
+class LeadQualifierAgent:
+    """BDR: scores leads using BANT, MEDDIC, and Iannarino's value tiers.
+
+    Grounded in Anthony Iannarino and HubSpot lead scoring methodology.
+    """
+
+    role: str = "Lead Qualifier (BDR)"
+    _agent: Any = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._agent = _build_strands_agent(_QUALIFIER_SYSTEM_PROMPT, _DEFAULT_TOOLS)
+
+    def qualify(self, prospect_json: str, product_name: str,
+                value_proposition: str, call_notes: str) -> str:
+        prompt = (
+            f"Qualify this prospect for {product_name}:\n{prospect_json}\n\n"
+            f"Value proposition: {value_proposition}\n"
+            f"Notes from any prior conversation: {call_notes or 'None yet'}\n\n"
+            "Score BANT (0–10 each), evaluate all 6 MEDDIC signals, assign Iannarino value tier (1–4), "
+            "and recommend: advance / nurture / disqualify. "
+            "Return a JSON object with bant, meddic, overall_score, value_creation_level, "
+            "recommended_action, disqualification_reason, qualification_notes."
+        )
+        stub = json.dumps({
+            "bant": {"budget": 7, "authority": 6, "need": 9, "timeline": 6},
+            "meddic": {
+                "metrics_identified": True,
+                "economic_buyer_known": False,
+                "decision_criteria_understood": True,
+                "decision_process_mapped": False,
+                "identify_pain": True,
+                "champion_found": True,
+            },
+            "overall_score": 0.72,
+            "value_creation_level": 3,
+            "recommended_action": "Advance to Discovery — schedule 30-min discovery call",
+            "disqualification_reason": None,
+            "qualification_notes": (
+                "Strong need and champion present. EB not yet identified — must multi-thread "
+                "before proposal stage. Budget likely available but not confirmed."
+            ),
+        })
+        return _call_agent(self._agent, prompt, stub)
+
+
+@dataclass
+class NurtureAgent:
+    """AM: builds long-cycle nurture sequences for leads not ready to buy.
+
+    Grounded in HubSpot inbound methodology and Gong Labs optimal cadence research.
+    """
+
+    role: str = "Nurture Specialist (AM)"
+    _agent: Any = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._agent = _build_strands_agent(_NURTURE_SYSTEM_PROMPT, _DEFAULT_TOOLS)
+
+    def build_sequence(self, prospect_json: str, product_name: str,
+                       value_proposition: str, duration_days: int) -> str:
+        prompt = (
+            f"Build a {duration_days}-day nurture sequence for:\n{prospect_json}\n\n"
+            f"Product: {product_name}\n"
+            f"Value proposition: {value_proposition}\n\n"
+            "Apply HubSpot content-stage mapping (Awareness → Consideration → Decision), "
+            "Gong Labs cadence research, and SNAP re-engagement principles. "
+            "Return a JSON object with duration_days, touchpoints (array), "
+            "re_engagement_triggers (array), content_recommendations (array)."
+        )
+        stub = json.dumps({
+            "duration_days": duration_days,
+            "touchpoints": [
+                {
+                    "day": 1,
+                    "channel": "email",
+                    "content_type": "educational article",
+                    "message": "Sharing a benchmark report on [pain area] that peers in your space found useful.",
+                    "goal": "Establish thought leadership and keep top of mind",
+                },
+                {
+                    "day": 14,
+                    "channel": "linkedin",
+                    "content_type": "case study snippet",
+                    "message": "Quick win: [Customer] reduced [metric] by 40% in 60 days with [Product].",
+                    "goal": "Introduce social proof at consideration stage",
+                },
+                {
+                    "day": 30,
+                    "channel": "email",
+                    "content_type": "ROI calculator",
+                    "message": "I built a quick calculator showing the cost of [pain] for a company your size.",
+                    "goal": "Move prospect from consideration to decision stage",
+                },
+                {
+                    "day": 60,
+                    "channel": "phone",
+                    "content_type": "check-in call",
+                    "message": "Following up to see if [trigger event or industry change] has shifted priorities.",
+                    "goal": "Re-qualify and determine readiness to advance",
+                },
+            ],
+            "re_engagement_triggers": [
+                "New funding round announced",
+                "Leadership change in buying committee",
+                "End-of-quarter budget release",
+                "Competitor product incident",
+            ],
+            "content_recommendations": [
+                "Industry benchmark report: [Pain area] in 2026",
+                "Customer case study: How [Similar Company] solved [Pain]",
+                "Blog post: 5 signs your [current solution] is costing you more than you think",
+                "ROI calculator: Cost of [problem] for [company size] teams",
+            ],
+        })
+        return _call_agent(self._agent, prompt, stub)
+
+
+@dataclass
+class DiscoveryAgent:
+    """AE: prepares discovery call guides and demo agendas.
+
+    Grounded in SPIN Selling (Jill Konrath), the Challenger Sale, and Gong Labs discovery research.
+    """
+
+    role: str = "Discovery & Demo Specialist (AE)"
+    _agent: Any = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._agent = _build_strands_agent(_DISCOVERY_SYSTEM_PROMPT, _DEFAULT_TOOLS)
+
+    def prepare(self, prospect_json: str, qualification_json: str,
+                product_name: str, value_proposition: str) -> str:
+        prompt = (
+            f"Prepare a complete discovery call guide for:\nProspect: {prospect_json}\n"
+            f"Qualification context: {qualification_json}\n\n"
+            f"Product: {product_name}\n"
+            f"Value proposition: {value_proposition}\n\n"
+            "Write SPIN questions in all four categories, craft a Challenger Sale insight-led opener, "
+            "build a tailored demo agenda (features tied to confirmed pains only), "
+            "list expected objections, and define success criteria for this call. "
+            "Return a JSON object with spin_questions {situation, problem, implication, need_payoff}, "
+            "challenger_insight, demo_agenda, expected_objections, success_criteria_for_call."
+        )
+        stub = json.dumps({
+            "spin_questions": {
+                "situation": [
+                    "Walk me through how your team currently handles [process].",
+                    "How many people are involved in [process], and what tools do they use?",
+                ],
+                "problem": [
+                    "What's the biggest frustration your team has with [current approach]?",
+                    "Where do deals most commonly fall through in your current process?",
+                ],
+                "implication": [
+                    "What happens to your [key metric] when [pain] occurs?",
+                    "If this isn't resolved by Q3, what's the downstream impact on your team's targets?",
+                ],
+                "need_payoff": [
+                    "If you could eliminate [pain] entirely, what would that free your team to focus on?",
+                    "What would a 20% improvement in [metric] mean for your business this year?",
+                ],
+            },
+            "challenger_insight": (
+                "Most [titles] we talk to assume [common belief]. "
+                "What our data across 200+ customers shows is that [counterintuitive truth] — "
+                "which means the real leverage point is [reframe]."
+            ),
+            "demo_agenda": [
+                "Set agenda & confirm success criteria (2 min)",
+                "Challenger insight: reframe the problem (2 min)",
+                "Validate key pains from discovery (5 min)",
+                "Show [Feature A] — ties to confirmed pain #1 (5 min)",
+                "Show [Feature B] — ties to confirmed pain #2 (5 min)",
+                "Objection checkpoint — invite concerns (5 min)",
+                "Propose next steps (3 min)",
+            ],
+            "expected_objections": [
+                "We already have [competitor] — why switch?",
+                "This isn't in the budget right now.",
+                "I need to loop in [other stakeholder] before we can move forward.",
+            ],
+            "success_criteria_for_call": (
+                "Confirmed 2 quantified pain points, identified the Economic Buyer, "
+                "and booked a follow-up with the full buying committee within 5 business days."
+            ),
+        })
+        return _call_agent(self._agent, prompt, stub)
+
+
+@dataclass
+class ProposalAgent:
+    """AE: generates structured, ROI-driven sales proposals.
+
+    Grounded in Anthony Iannarino's Level-4 Value Creation proposal methodology.
+    """
+
+    role: str = "Proposal Writer (AE)"
+    _agent: Any = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._agent = _build_strands_agent(_PROPOSAL_SYSTEM_PROMPT, [*_DEFAULT_TOOLS])
+
+    def write(self, prospect_json: str, product_name: str, value_proposition: str,
+              annual_cost_usd: float, discovery_notes: str,
+              case_studies: str, company_context: str) -> str:
+        prompt = (
+            f"Write a complete sales proposal for:\nProspect: {prospect_json}\n\n"
+            f"Product: {product_name}\n"
+            f"Value proposition: {value_proposition}\n"
+            f"Annual cost (USD): {annual_cost_usd}\n"
+            f"Discovery notes: {discovery_notes or 'See prospect research notes'}\n"
+            f"Customer wins: {case_studies}\n"
+            f"Company context: {company_context}\n\n"
+            "Follow Iannarino's proposal structure. Calculate realistic ROI. "
+            "Return a JSON object with executive_summary, situation_analysis, proposed_solution, "
+            "roi_model {annual_cost_usd, estimated_annual_benefit_usd, payback_months, roi_percentage, assumptions}, "
+            "investment_table, implementation_timeline, risk_mitigation, next_steps (array), "
+            "custom_sections (array of {heading, content})."
+        )
+        benefit = annual_cost_usd * 2.8
+        stub = json.dumps({
+            "executive_summary": (
+                f"This proposal outlines how {product_name} will help {{company_name}} achieve "
+                "[strategic outcome] by [specific date], delivering measurable ROI within [N] months."
+            ),
+            "situation_analysis": (
+                "Based on our discovery conversations, {{company_name}} is facing [confirmed pain #1] "
+                "and [confirmed pain #2], costing an estimated $[X] per year in [metric]."
+            ),
+            "proposed_solution": (
+                f"You will have a fully operational {product_name} environment within [N] weeks, "
+                "enabling [outcome #1] and [outcome #2] without [key friction]."
+            ),
+            "roi_model": {
+                "annual_cost_usd": annual_cost_usd,
+                "estimated_annual_benefit_usd": round(benefit, 2),
+                "payback_months": round(12 / ((benefit - annual_cost_usd) / annual_cost_usd), 1),
+                "roi_percentage": round(((benefit - annual_cost_usd) / annual_cost_usd) * 100, 1),
+                "assumptions": [
+                    "10% productivity gain across [N] team members",
+                    "20% reduction in [metric] based on comparable customer data",
+                    "Conservative 80% adoption rate in first 90 days",
+                ],
+            },
+            "investment_table": (
+                f"Annual subscription: ${annual_cost_usd:,.0f}\n"
+                "Implementation & onboarding: Included\n"
+                "Dedicated customer success: Included\n"
+                f"Total Year 1: ${annual_cost_usd:,.0f}"
+            ),
+            "implementation_timeline": (
+                "Week 1–2: Technical setup and data migration\n"
+                "Week 3: Admin training and workflow configuration\n"
+                "Week 4: Team onboarding and go-live\n"
+                "Day 90: Business review and optimization session"
+            ),
+            "risk_mitigation": (
+                "1. Change management: Dedicated CSM for 90-day onboarding.\n"
+                "2. Data security: SOC2 Type II certified; your data never leaves [region].\n"
+                "3. ROI risk: 30-day money-back guarantee if [specific outcome] not achieved."
+            ),
+            "next_steps": [
+                "Review this proposal with your team by [date]",
+                "Schedule a 30-min Q&A call with our technical team",
+                f"Sign and return by [date] to secure [implementation slot]",
+            ],
+            "custom_sections": [],
+        })
+        return _call_agent(self._agent, prompt, stub)
+
+
+@dataclass
+class CloserAgent:
+    """AE: develops closing strategies and objection handlers.
+
+    Grounded in Zig Ziglar's closing techniques and Jeb Blount's Sales EQ.
+    """
+
+    role: str = "Closer (AE)"
+    _agent: Any = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._agent = _build_strands_agent(_CLOSER_SYSTEM_PROMPT, _DEFAULT_TOOLS)
+
+    def develop_strategy(self, prospect_json: str, proposal_json: str,
+                         product_name: str, value_proposition: str) -> str:
+        prompt = (
+            f"Develop a closing strategy for:\nProspect: {prospect_json}\n"
+            f"Proposal context: {proposal_json}\n\n"
+            f"Product: {product_name}\n"
+            f"Value proposition: {value_proposition}\n\n"
+            "Select the most appropriate Zig Ziglar closing technique for this prospect, "
+            "write the close script, prepare objection handlers (with Feel/Felt/Found), "
+            "identify a legitimate urgency lever, and define walk-away criteria. "
+            "Return a JSON object with recommended_close_technique, close_script, "
+            "objection_handlers (array of {objection, response, feel_felt_found}), "
+            "urgency_framing, walk_away_criteria, emotional_intelligence_notes."
+        )
+        stub = json.dumps({
+            "recommended_close_technique": "summary",
+            "close_script": (
+                "So we've agreed that [pain #1] is costing you [metric], "
+                "and [pain #2] is blocking [outcome]. "
+                f"{product_name} solves both, and you'll see ROI within [N] months. "
+                "Shall we get the paperwork started so you can hit [Q goal]?"
+            ),
+            "objection_handlers": [
+                {
+                    "objection": "The price is too high.",
+                    "response": (
+                        "I understand — and I want to make sure this makes sense for you financially. "
+                        "The ROI model shows a [N]-month payback. "
+                        "Is the concern the absolute cost, or the timing of the spend?"
+                    ),
+                    "feel_felt_found": (
+                        "I understand how you feel — many of our customers felt the same way. "
+                        "What they found was that after 90 days the ROI more than justified the investment."
+                    ),
+                },
+                {
+                    "objection": "We need to think about it.",
+                    "response": (
+                        "Of course — what specifically would you like to think through? "
+                        "I want to make sure you have everything you need to make a confident decision."
+                    ),
+                    "feel_felt_found": None,
+                },
+            ],
+            "urgency_framing": (
+                "Implementation slots are currently booking [N] weeks out. "
+                "To hit your [Q] deadline, we'd need to sign by [date]. "
+                "I can hold your slot until [date + 3 days] — no pressure, but I wanted you to know."
+            ),
+            "walk_away_criteria": (
+                "If budget is genuinely unavailable for 6+ months OR the prospect repeatedly "
+                "avoids scheduling next steps after 3 follow-up attempts, "
+                "politely disengage and flag for nurture re-entry in 90 days."
+            ),
+            "emotional_intelligence_notes": (
+                "This buyer appears analytical — lead with data before emotion. "
+                "Validate their thoroughness: 'It makes sense that you want to be thorough — "
+                "this is a significant decision.' Mirror their deliberate pace; "
+                "rushing this buyer will lose the deal."
+            ),
+        })
+        return _call_agent(self._agent, prompt, stub)
+
+
+@dataclass
+class SalesCoachAgent:
+    """Sales Manager: reviews the pipeline and provides Gong-style coaching.
+
+    Grounded in Gong Labs research, pipeline velocity metrics, and Iannarino's coaching framework.
+    """
+
+    role: str = "Sales Coach (Manager)"
+    _agent: Any = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._agent = _build_strands_agent(_COACH_SYSTEM_PROMPT, _DEFAULT_TOOLS)
+
+    def review(self, prospects_json: str, product_name: str, pipeline_context: str) -> str:
+        prompt = (
+            f"Review this sales pipeline for {product_name}:\n{prospects_json}\n\n"
+            f"Additional pipeline context: {pipeline_context or 'None provided'}\n\n"
+            "Identify deal risk signals (using Gong Labs framework), provide talk/listen ratio advice, "
+            "velocity insights, forecast categorization, top priority deals, and specific next actions. "
+            "Return a JSON object with prospects_reviewed, deal_risk_signals (array of {signal, severity, recommended_action}), "
+            "talk_listen_ratio_advice, velocity_insights, forecast_category, "
+            "top_priority_deals (array), recommended_next_actions (array), coaching_summary."
+        )
+        stub = json.dumps({
+            "prospects_reviewed": 1,
+            "deal_risk_signals": [
+                {
+                    "signal": "Single-threaded — only one contact engaged",
+                    "severity": "high",
+                    "recommended_action": (
+                        "Request an intro to the Economic Buyer within the next call. "
+                        "Use: 'Who else on your team would need to be involved in a decision like this?'"
+                    ),
+                },
+                {
+                    "signal": "No confirmed next step on calendar",
+                    "severity": "medium",
+                    "recommended_action": (
+                        "Do not end any call without a specific next-step booked. "
+                        "Use calendar link in outreach footer."
+                    ),
+                },
+            ],
+            "talk_listen_ratio_advice": (
+                "On discovery calls, aim for 43% talk / 57% listen. "
+                "Ask SPIN questions in clusters of 2, then pause and let silence work for you."
+            ),
+            "velocity_insights": (
+                "Average stage duration in this pipeline appears longer than benchmark (14 days in qualification). "
+                "Recommend qualifying or disqualifying within 7 days by applying hard BANT questions in call #2."
+            ),
+            "forecast_category": "pipeline",
+            "top_priority_deals": ["Acme Corp"],
+            "recommended_next_actions": [
+                "Multi-thread Acme Corp — request intro to VP Finance by EOW",
+                "Send Acme Corp ROI model from proposal before next call",
+                "Set a 5-day follow-up reminder for any prospect with no activity",
+            ],
+            "coaching_summary": (
+                "Pipeline is early-stage and needs multi-threading. "
+                "Primary risk is single-threaded deals with no Economic Buyer identified. "
+                "Focus this week on advancing qualification conversations and securing EB meetings."
+            ),
+        })
+        return _call_agent(self._agent, prompt, stub)

--- a/backend/agents/sales_team/api/main.py
+++ b/backend/agents/sales_team/api/main.py
@@ -1,0 +1,406 @@
+"""FastAPI endpoints for the AI Sales Team pod."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+
+from shared_job_management import (
+    JOB_STATUS_COMPLETED,
+    JOB_STATUS_FAILED,
+    JOB_STATUS_PENDING,
+    JOB_STATUS_RUNNING,
+    CentralJobManager,
+    start_stale_job_monitor,
+)
+
+from sales_team.models import (
+    CoachingRequest,
+    NurtureRequest,
+    OutreachRequest,
+    PipelineStage,
+    ProposalRequest,
+    ProspectingRequest,
+    QualificationRequest,
+    SalesPipelineRequest,
+    SalesPipelineResult,
+)
+from sales_team.orchestrator import SalesPodOrchestrator
+
+app = FastAPI(
+    title="AI Sales Team API",
+    version="1.0.0",
+    description=(
+        "Full-stack B2B sales pod powered by AWS Strands agents. "
+        "Handles prospecting, cold outreach, lead qualification, nurturing, "
+        "discovery, proposals, and closing — grounded in Gong Labs, Jeb Blount, "
+        "HubSpot, Anthony Iannarino, Jill Konrath, Sales Hacker, Salesfolk, and Zig Ziglar."
+    ),
+)
+
+logger = logging.getLogger(__name__)
+_job_manager = CentralJobManager(team="sales_team")
+_stale_monitor_stop = start_stale_job_monitor(
+    _job_manager,
+    interval_seconds=15.0,
+    stale_after_seconds=300.0,
+    reason="Job heartbeat stale while pending/running",
+)
+
+
+# ---------------------------------------------------------------------------
+# Response models
+# ---------------------------------------------------------------------------
+
+
+class SalesPipelineRunResponse(BaseModel):
+    job_id: str
+    status: str
+    message: str
+
+
+class SalesPipelineStatusResponse(BaseModel):
+    job_id: str
+    status: str
+    current_stage: str
+    progress: int
+    product_name: str
+    last_updated_at: str
+    eta_hint: Optional[str] = None
+    error: Optional[str] = None
+    result: Optional[SalesPipelineResult] = None
+
+
+class SalesPipelineJobListItem(BaseModel):
+    job_id: str
+    status: str
+    current_stage: str
+    progress: int
+    product_name: str
+    created_at: Optional[str] = None
+    last_updated_at: Optional[str] = None
+
+
+class CancelJobResponse(BaseModel):
+    job_id: str
+    status: str = "cancelled"
+    message: str = "Job cancellation requested."
+
+
+class DeleteJobResponse(BaseModel):
+    job_id: str
+    message: str = "Job deleted."
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _now() -> str:
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def _update_job(job_id: str, **fields: Any) -> None:
+    _job_manager.update_job(job_id, **fields)
+
+
+def mark_all_running_jobs_failed(reason: str) -> None:
+    """Mark all active sales pipeline jobs as failed (called on server shutdown)."""
+    _job_manager.mark_stale_active_jobs_failed(stale_after_seconds=0, reason=reason)
+
+
+# ---------------------------------------------------------------------------
+# Background job runner
+# ---------------------------------------------------------------------------
+
+
+def _run_pipeline_job(job_id: str, request: SalesPipelineRequest) -> None:
+    try:
+        _update_job(
+            job_id,
+            status=JOB_STATUS_RUNNING,
+            current_stage="initializing",
+            progress=2,
+            eta_hint="Starting pipeline...",
+        )
+
+        orchestrator = SalesPodOrchestrator()
+
+        def on_update(stage: str, pct: int) -> None:
+            _update_job(job_id, current_stage=stage, progress=pct, last_updated_at=_now())
+
+        result = orchestrator.run(request, job_id=job_id, update_cb=on_update)
+
+        _update_job(
+            job_id,
+            status=JOB_STATUS_COMPLETED,
+            current_stage="completed",
+            progress=100,
+            eta_hint="done",
+            result=result.model_dump(),
+            last_updated_at=_now(),
+        )
+    except Exception as exc:
+        logger.error("Sales pipeline job %s failed: %s", job_id, exc, exc_info=True)
+        _update_job(
+            job_id,
+            status=JOB_STATUS_FAILED,
+            current_stage="failed",
+            error=str(exc),
+            eta_hint=None,
+            last_updated_at=_now(),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Pipeline endpoints (async, job-based)
+# ---------------------------------------------------------------------------
+
+
+@app.post("/sales/pipeline/run", response_model=SalesPipelineRunResponse, tags=["pipeline"])
+def run_pipeline(request: SalesPipelineRequest) -> SalesPipelineRunResponse:
+    """Start a full sales pipeline run from the specified entry stage.
+
+    Returns a job_id to poll for status and results.
+    Entry stages: prospecting → outreach → qualification → nurturing → discovery → proposal → negotiation.
+    """
+    job_id = str(uuid.uuid4())
+    now = _now()
+    _job_manager.create_job(
+        job_id,
+        job_type="sales_pipeline",
+        status=JOB_STATUS_PENDING,
+        current_stage="queued",
+        progress=0,
+        product_name=request.product_name,
+        entry_stage=request.entry_stage.value,
+        result=None,
+        error=None,
+        eta_hint="queued",
+        created_at=now,
+        last_updated_at=now,
+    )
+    thread = threading.Thread(target=_run_pipeline_job, args=(job_id, request), daemon=True)
+    thread.start()
+    return SalesPipelineRunResponse(
+        job_id=job_id,
+        status=JOB_STATUS_RUNNING,
+        message=(
+            f"Sales pipeline started (entry: {request.entry_stage.value}). "
+            f"Poll GET /sales/pipeline/status/{job_id} for updates."
+        ),
+    )
+
+
+@app.get(
+    "/sales/pipeline/status/{job_id}",
+    response_model=SalesPipelineStatusResponse,
+    tags=["pipeline"],
+)
+def get_pipeline_status(job_id: str) -> SalesPipelineStatusResponse:
+    """Poll the status of a running or completed pipeline job."""
+    job = _job_manager.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+
+    result_data = job.get("result")
+    result_obj = None
+    if result_data and isinstance(result_data, dict):
+        try:
+            result_obj = SalesPipelineResult(**result_data)
+        except Exception:
+            result_obj = None
+
+    return SalesPipelineStatusResponse(
+        job_id=job_id,
+        status=job.get("status", JOB_STATUS_PENDING),
+        current_stage=job.get("current_stage", ""),
+        progress=job.get("progress", 0),
+        product_name=job.get("product_name", ""),
+        last_updated_at=job.get("last_updated_at", now := _now()),
+        eta_hint=job.get("eta_hint"),
+        error=job.get("error"),
+        result=result_obj,
+    )
+
+
+@app.get(
+    "/sales/pipeline/jobs",
+    response_model=List[SalesPipelineJobListItem],
+    tags=["pipeline"],
+)
+def list_pipeline_jobs(running_only: bool = False) -> List[SalesPipelineJobListItem]:
+    """List all sales pipeline jobs, optionally filtered to active jobs."""
+    jobs = _job_manager.list_jobs()
+    if running_only:
+        jobs = [j for j in jobs if j.get("status") in (JOB_STATUS_PENDING, JOB_STATUS_RUNNING)]
+    items = [
+        SalesPipelineJobListItem(
+            job_id=j.get("job_id", ""),
+            status=j.get("status", JOB_STATUS_PENDING),
+            current_stage=j.get("current_stage", ""),
+            progress=j.get("progress", 0),
+            product_name=j.get("product_name", ""),
+            created_at=j.get("created_at"),
+            last_updated_at=j.get("last_updated_at"),
+        )
+        for j in jobs
+    ]
+    items.sort(key=lambda x: x.created_at or x.last_updated_at or "", reverse=True)
+    return items
+
+
+@app.post(
+    "/sales/pipeline/job/{job_id}/cancel",
+    response_model=CancelJobResponse,
+    tags=["pipeline"],
+)
+def cancel_pipeline_job(job_id: str) -> CancelJobResponse:
+    """Cancel a pending or running pipeline job."""
+    job = _job_manager.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+    current = job.get("status", JOB_STATUS_PENDING)
+    if current not in (JOB_STATUS_PENDING, JOB_STATUS_RUNNING):
+        raise HTTPException(
+            status_code=400, detail=f"Job is already in terminal state: {current}"
+        )
+    _job_manager.update_job(job_id, status="cancelled", heartbeat=False)
+    return CancelJobResponse(job_id=job_id)
+
+
+@app.delete(
+    "/sales/pipeline/job/{job_id}",
+    response_model=DeleteJobResponse,
+    tags=["pipeline"],
+)
+def delete_pipeline_job(job_id: str) -> DeleteJobResponse:
+    """Delete a pipeline job from the store."""
+    if not _job_manager.delete_job(job_id):
+        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+    return DeleteJobResponse(job_id=job_id, message="Job deleted.")
+
+
+# ---------------------------------------------------------------------------
+# Synchronous single-stage endpoints
+# ---------------------------------------------------------------------------
+
+
+@app.post("/sales/prospect", tags=["stages"])
+def prospect(request: ProspectingRequest) -> Dict[str, Any]:
+    """Identify prospects matching the ICP using the Prospector agent.
+
+    Grounded in Jeb Blount's Fanatical Prospecting and Sales Hacker ICP frameworks.
+    """
+    orchestrator = SalesPodOrchestrator()
+    prospects = orchestrator.prospect_only(
+        icp=request.icp,
+        product_name=request.product_name,
+        value_proposition=request.value_proposition,
+        max_prospects=request.max_prospects,
+        company_context=request.company_context,
+    )
+    return {"prospects": [p.model_dump() for p in prospects], "count": len(prospects)}
+
+
+@app.post("/sales/outreach", tags=["stages"])
+def generate_outreach(request: OutreachRequest) -> Dict[str, Any]:
+    """Generate personalized cold outreach sequences for a list of prospects.
+
+    Grounded in Salesfolk, Jill Konrath SNAP, and the Jeb Blount 6-touch cadence.
+    """
+    orchestrator = SalesPodOrchestrator()
+    sequences = orchestrator.outreach_only(
+        prospects=request.prospects,
+        product_name=request.product_name,
+        value_proposition=request.value_proposition,
+        case_study_snippets=request.case_study_snippets,
+        company_context=request.company_context,
+    )
+    return {"sequences": [s.model_dump() for s in sequences], "count": len(sequences)}
+
+
+@app.post("/sales/qualify", tags=["stages"])
+def qualify_lead(request: QualificationRequest) -> Dict[str, Any]:
+    """Qualify a prospect using BANT, MEDDIC, and Iannarino's value-creation tiers.
+
+    Returns a score, recommended action (advance / nurture / disqualify), and coaching notes.
+    """
+    orchestrator = SalesPodOrchestrator()
+    score = orchestrator.qualify_only(
+        prospect=request.prospect,
+        product_name=request.product_name,
+        value_proposition=request.value_proposition,
+        call_notes=request.call_notes,
+    )
+    if not score:
+        raise HTTPException(status_code=500, detail="Qualification agent failed to return a result")
+    return score.model_dump()
+
+
+@app.post("/sales/nurture", tags=["stages"])
+def build_nurture(request: NurtureRequest) -> Dict[str, Any]:
+    """Build long-cycle nurture sequences for leads not ready to buy.
+
+    Grounded in HubSpot inbound methodology and Gong Labs cadence research.
+    """
+    orchestrator = SalesPodOrchestrator()
+    sequences = orchestrator.nurture_only(
+        prospects=request.prospects,
+        product_name=request.product_name,
+        value_proposition=request.value_proposition,
+        duration_days=request.duration_days,
+    )
+    return {"sequences": [s.model_dump() for s in sequences], "count": len(sequences)}
+
+
+@app.post("/sales/proposal", tags=["stages"])
+def write_proposal(request: ProposalRequest) -> Dict[str, Any]:
+    """Generate a structured sales proposal with ROI model.
+
+    Grounded in Anthony Iannarino's Level-4 Value Creation proposal methodology.
+    """
+    orchestrator = SalesPodOrchestrator()
+    proposal = orchestrator.propose_only(request)
+    if not proposal:
+        raise HTTPException(status_code=500, detail="Proposal agent failed to return a result")
+    return proposal.model_dump()
+
+
+@app.post("/sales/coaching", tags=["stages"])
+def get_coaching(request: CoachingRequest) -> Dict[str, Any]:
+    """Generate a Gong Labs-style pipeline coaching report.
+
+    Flags deal risk signals, gives talk/listen ratio advice, and recommends next actions.
+    """
+    orchestrator = SalesPodOrchestrator()
+    report = orchestrator.coach_only(
+        prospects=request.prospects,
+        product_name=request.product_name,
+        pipeline_context=request.pipeline_context,
+    )
+    if not report:
+        raise HTTPException(status_code=500, detail="Coach agent failed to return a result")
+    return report.model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Health
+# ---------------------------------------------------------------------------
+
+
+@app.get("/health", tags=["health"])
+def health() -> Dict[str, str]:
+    from sales_team.agents import HAS_STRANDS
+
+    return {
+        "status": "ok",
+        "strands_sdk": "available" if HAS_STRANDS else "stub_mode",
+    }

--- a/backend/agents/sales_team/api/main.py
+++ b/backend/agents/sales_team/api/main.py
@@ -20,18 +20,32 @@ from shared_job_management import (
     start_stale_job_monitor,
 )
 
+from sales_team.learning_engine import LearningEngine
 from sales_team.models import (
     CoachingRequest,
+    DealOutcome,
+    LearningInsights,
     NurtureRequest,
     OutreachRequest,
     PipelineStage,
     ProposalRequest,
     ProspectingRequest,
     QualificationRequest,
+    RecordDealOutcomeRequest,
+    RecordStageOutcomeRequest,
     SalesPipelineRequest,
     SalesPipelineResult,
+    StageOutcome,
 )
 from sales_team.orchestrator import SalesPodOrchestrator
+from sales_team.outcome_store import (
+    load_current_insights,
+    load_deal_outcomes,
+    load_stage_outcomes,
+    outcome_counts,
+    record_deal_outcome,
+    record_stage_outcome,
+)
 
 app = FastAPI(
     title="AI Sales Team API",
@@ -392,6 +406,157 @@ def get_coaching(request: CoachingRequest) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Outcome recording endpoints
+# ---------------------------------------------------------------------------
+
+
+class RecordOutcomeResponse(BaseModel):
+    outcome_id: str
+    message: str
+
+
+@app.post("/sales/outcomes/stage", response_model=RecordOutcomeResponse, tags=["learning"])
+def record_stage_outcome_endpoint(request: RecordStageOutcomeRequest) -> RecordOutcomeResponse:
+    """Record the outcome of a single pipeline stage for a prospect.
+
+    Use this endpoint to feed real-world results back into the learning loop.
+    Examples:
+    - Outreach email got a reply → stage=outreach, outcome=converted
+    - Prospect raised a price objection → stage=negotiation, outcome=objection
+    - Lead went cold after discovery → stage=discovery, outcome=stalled
+
+    The learning engine uses these records to improve future pipeline runs.
+    """
+    outcome = StageOutcome(
+        pipeline_job_id=request.pipeline_job_id,
+        company_name=request.company_name,
+        industry=request.industry,
+        stage=request.stage,
+        outcome=request.outcome,
+        icp_match_score=request.icp_match_score,
+        qualification_score=request.qualification_score,
+        email_touch_number=request.email_touch_number,
+        subject_line_used=request.subject_line_used,
+        objection_text=request.objection_text,
+        close_technique_used=request.close_technique_used,
+        notes=request.notes,
+    )
+    saved = record_stage_outcome(outcome)
+    return RecordOutcomeResponse(
+        outcome_id=saved.outcome_id,
+        message=f"Stage outcome recorded for {request.company_name} @ {request.stage.value}.",
+    )
+
+
+@app.post("/sales/outcomes/deal", response_model=RecordOutcomeResponse, tags=["learning"])
+def record_deal_outcome_endpoint(request: RecordDealOutcomeRequest) -> RecordOutcomeResponse:
+    """Record the final outcome of a deal (won or lost).
+
+    This is the highest-signal feedback for the learning engine. Always record
+    a deal outcome when a deal closes — win or loss.
+
+    The more deal outcomes you record, the more precisely the learning engine
+    can identify winning vs. losing patterns and adapt agent behavior.
+    """
+    outcome = DealOutcome(
+        pipeline_job_id=request.pipeline_job_id,
+        company_name=request.company_name,
+        industry=request.industry,
+        deal_size_usd=request.deal_size_usd,
+        final_stage_reached=request.final_stage_reached,
+        result=request.result,
+        loss_reason=request.loss_reason,
+        win_factor=request.win_factor,
+        close_technique_used=request.close_technique_used,
+        objections_raised=request.objections_raised,
+        stages_completed=request.stages_completed,
+        icp_match_score=request.icp_match_score,
+        qualification_score=request.qualification_score,
+        sales_cycle_days=request.sales_cycle_days,
+        notes=request.notes,
+    )
+    saved = record_deal_outcome(outcome)
+    return RecordOutcomeResponse(
+        outcome_id=saved.outcome_id,
+        message=f"Deal outcome ({request.result.value}) recorded for {request.company_name}.",
+    )
+
+
+@app.get("/sales/outcomes/summary", tags=["learning"])
+def get_outcome_summary() -> Dict[str, Any]:
+    """Return a count of recorded outcomes and whether insights have been generated."""
+    return outcome_counts()
+
+
+@app.get("/sales/outcomes/stage", response_model=List[StageOutcome], tags=["learning"])
+def list_stage_outcomes(limit: int = 100) -> List[StageOutcome]:
+    """List recorded stage outcomes (newest first, up to limit)."""
+    return load_stage_outcomes(limit=min(limit, 500))
+
+
+@app.get("/sales/outcomes/deal", response_model=List[DealOutcome], tags=["learning"])
+def list_deal_outcomes(limit: int = 100) -> List[DealOutcome]:
+    """List recorded deal outcomes (newest first, up to limit)."""
+    return load_deal_outcomes(limit=min(limit, 500))
+
+
+# ---------------------------------------------------------------------------
+# Learning insights endpoints
+# ---------------------------------------------------------------------------
+
+
+@app.get("/sales/insights", response_model=LearningInsights, tags=["learning"])
+def get_insights() -> LearningInsights:
+    """Return the current LearningInsights snapshot.
+
+    Returns 404 if no outcomes have been recorded yet.
+    Call POST /sales/insights/refresh to generate or update insights.
+    """
+    insights = load_current_insights()
+    if not insights:
+        raise HTTPException(
+            status_code=404,
+            detail=(
+                "No learning insights available yet. "
+                "Record outcomes via POST /sales/outcomes/stage or /sales/outcomes/deal, "
+                "then call POST /sales/insights/refresh."
+            ),
+        )
+    return insights
+
+
+class InsightsRefreshResponse(BaseModel):
+    message: str
+    insights_version: int
+    total_outcomes_analyzed: int
+    win_rate: float
+
+
+@app.post("/sales/insights/refresh", response_model=InsightsRefreshResponse, tags=["learning"])
+def refresh_insights() -> InsightsRefreshResponse:
+    """Trigger a learning engine run to regenerate insights from all recorded outcomes.
+
+    This runs synchronously (may take a few seconds with the Strands SDK).
+    The updated insights are immediately applied to the next pipeline run.
+
+    Tip: call this endpoint after recording a batch of outcomes (e.g. end-of-week
+    pipeline review) to keep the learning loop current.
+    """
+    engine = LearningEngine()
+    insights = engine.refresh()
+    return InsightsRefreshResponse(
+        message=(
+            f"Insights refreshed to v{insights.insights_version}. "
+            f"Analyzed {insights.total_outcomes_analyzed} outcomes. "
+            "All future pipeline runs will use these updated patterns."
+        ),
+        insights_version=insights.insights_version,
+        total_outcomes_analyzed=insights.total_outcomes_analyzed,
+        win_rate=insights.win_rate,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Health
 # ---------------------------------------------------------------------------
 
@@ -400,7 +565,11 @@ def get_coaching(request: CoachingRequest) -> Dict[str, Any]:
 def health() -> Dict[str, str]:
     from sales_team.agents import HAS_STRANDS
 
+    counts = outcome_counts()
     return {
         "status": "ok",
         "strands_sdk": "available" if HAS_STRANDS else "stub_mode",
+        "stage_outcomes_recorded": str(counts["stage_outcomes"]),
+        "deal_outcomes_recorded": str(counts["deal_outcomes"]),
+        "insights_available": str(counts["has_insights"]),
     }

--- a/backend/agents/sales_team/api/main.py
+++ b/backend/agents/sales_team/api/main.py
@@ -296,7 +296,20 @@ def cancel_pipeline_job(job_id: str) -> CancelJobResponse:
     tags=["pipeline"],
 )
 def delete_pipeline_job(job_id: str) -> DeleteJobResponse:
-    """Delete a pipeline job from the store."""
+    """Delete a pipeline job from the store.
+
+    Returns 404 if the job does not exist and 409 if the job is still
+    pending or running (cancel it first before deleting).
+    """
+    job = _job_manager.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
+    current_status = job.get("status", JOB_STATUS_PENDING)
+    if current_status in (JOB_STATUS_PENDING, JOB_STATUS_RUNNING):
+        raise HTTPException(
+            status_code=409,
+            detail=f"Cannot delete an active job (status={current_status}). Cancel it first.",
+        )
     if not _job_manager.delete_job(job_id):
         raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
     return DeleteJobResponse(job_id=job_id, message="Job deleted.")

--- a/backend/agents/sales_team/learning_engine.py
+++ b/backend/agents/sales_team/learning_engine.py
@@ -1,0 +1,312 @@
+"""LearningEngine — Strands agent that analyzes accumulated sales outcomes
+and extracts actionable patterns to improve the pipeline.
+
+The engine is called on demand (via POST /sales/insights/refresh) or
+automatically after every N deal outcomes are recorded. It:
+
+1. Loads all StageOutcome and DealOutcome records from the outcome store.
+2. Passes them to a Strands agent with a specialized analysis prompt.
+3. Parses the JSON response into a LearningInsights object.
+4. Falls back to heuristic computation (outcome_store.compute_heuristic_insights)
+   when the Strands SDK is not available.
+5. Persists the result to the outcome store so all agents can read it on the
+   next pipeline run.
+
+The analysis prompt is grounded in the same sales methodologies used by the
+specialist agents — so the extracted patterns speak the same language as the
+agents that consume them.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Any, List, Optional
+
+from .models import DealOutcome, LearningInsights, StageOutcome
+from .outcome_store import (
+    compute_heuristic_insights,
+    load_current_insights,
+    load_deal_outcomes,
+    load_stage_outcomes,
+    save_insights,
+)
+
+logger = logging.getLogger(__name__)
+
+try:
+    from strands import Agent as StrandsAgent  # type: ignore[import]
+
+    try:
+        from strands_tools import python_repl  # type: ignore[import]
+
+        _LEARNING_TOOLS = [python_repl]
+    except ImportError:
+        _LEARNING_TOOLS = []
+
+    _HAS_STRANDS = True
+except ImportError:
+    _HAS_STRANDS = False
+    _LEARNING_TOOLS = []
+
+_LEARNING_SYSTEM_PROMPT = """You are a Sales Analytics Expert who analyzes historical sales pipeline data
+to extract patterns that help sales teams improve their win rates and process efficiency.
+
+## Your Analytical Framework
+
+### Win/Loss Pattern Analysis (Gong Labs)
+Identify which behaviors, deal traits, and timing patterns correlate with wins vs. losses:
+- Multi-threading (multiple contacts engaged) → higher win rate
+- Champion present + EB on a call → 3× win rate
+- Proposal sent within 24h of discovery → faster cycle
+- No next step booked → 80% stall rate
+
+### ICP Signal Evaluation (Jeb Blount / Sales Hacker)
+Score which firmographic traits predicted deal success:
+- Industries with win rate > 50% are tier-1 ICP targets
+- ICP match score thresholds that correlated with closed-won deals
+- Trigger events (funding, hiring, leadership change) that predicted faster cycles
+
+### Outreach Effectiveness (Salesfolk / Gong Labs)
+Identify which outreach patterns drove replies and meetings:
+- Which email touch number got the most replies (Gong: #2 or #3 most common)
+- Subject line patterns with high open/reply correlation
+- Channels that drove conversion at each stage
+
+### Qualification Accuracy (Anthony Iannarino / MEDDIC)
+Assess whether the qualification signals were reliable predictors:
+- Did high BANT scores reliably predict wins?
+- Which MEDDIC signals were present in won deals but absent in lost deals?
+- What was the average qualification score for won vs. lost deals?
+
+### Objection Intelligence (Zig Ziglar / Jeb Blount)
+Map objections to outcomes:
+- Which objections were successfully overcome (led to close)?
+- Which objections were consistent loss predictors?
+- Which close techniques had highest win rates?
+
+### Pipeline Velocity (HubSpot)
+Identify velocity bottlenecks:
+- Average stage duration for won vs. lost deals
+- Which stage had the lowest conversion rate (biggest leak in the funnel)?
+- How does sales cycle length correlate with deal size?
+
+## Output Requirements
+Return a JSON object with exactly these keys:
+{
+  "total_outcomes_analyzed": <int>,
+  "win_rate": <float 0-1>,
+  "stage_conversion_rates": {"stage_name": <float>, ...},
+  "top_performing_industries": [<string>, ...],
+  "top_icp_signals": [<string>, ...],
+  "best_outreach_angles": [<string>, ...],
+  "common_objections": [<string>, ...],
+  "best_close_techniques": [<string>, ...],
+  "winning_patterns": [<string>, ...],
+  "losing_patterns": [<string>, ...],
+  "avg_deal_size_won_usd": <float or null>,
+  "avg_sales_cycle_days": <float or null>,
+  "actionable_recommendations": [<string>, ...]
+}
+
+Each string in arrays should be a specific, actionable insight — not generic advice.
+Recommendations must reference specific numbers from the data when available.
+"""
+
+
+def _parse_insights_json(raw: str, current_version: int, n_analyzed: int) -> Optional[LearningInsights]:
+    """Parse LLM output into a LearningInsights model."""
+    if not raw or not raw.strip():
+        return None
+    stripped = raw.strip()
+    if stripped.startswith("```"):
+        lines = stripped.splitlines()
+        stripped = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
+    try:
+        data = json.loads(stripped)
+    except (json.JSONDecodeError, ValueError):
+        logger.warning("LearningEngine: could not parse JSON. Raw: %s", raw[:300])
+        return None
+
+    if not isinstance(data, dict):
+        return None
+
+    from .outcome_store import _now
+
+    try:
+        return LearningInsights(
+            total_outcomes_analyzed=data.get("total_outcomes_analyzed", n_analyzed),
+            win_rate=float(data.get("win_rate", 0.0)),
+            stage_conversion_rates=data.get("stage_conversion_rates", {}),
+            top_performing_industries=data.get("top_performing_industries", []),
+            top_icp_signals=data.get("top_icp_signals", []),
+            best_outreach_angles=data.get("best_outreach_angles", []),
+            common_objections=data.get("common_objections", []),
+            best_close_techniques=data.get("best_close_techniques", []),
+            winning_patterns=data.get("winning_patterns", []),
+            losing_patterns=data.get("losing_patterns", []),
+            avg_deal_size_won_usd=data.get("avg_deal_size_won_usd"),
+            avg_sales_cycle_days=data.get("avg_sales_cycle_days"),
+            actionable_recommendations=data.get("actionable_recommendations", []),
+            generated_at=_now(),
+            insights_version=current_version + 1,
+        )
+    except Exception as exc:
+        logger.warning("LearningEngine: could not build LearningInsights: %s", exc)
+        return None
+
+
+@dataclass
+class LearningEngine:
+    """Analyzes accumulated outcomes and refreshes LearningInsights.
+
+    Call `.refresh()` to run the analysis and persist updated insights.
+    """
+
+    _agent: Any = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        if _HAS_STRANDS:
+            self._agent = StrandsAgent(
+                system_prompt=_LEARNING_SYSTEM_PROMPT,
+                tools=_LEARNING_TOOLS,
+            )
+
+    def refresh(
+        self,
+        stage_outcomes: Optional[List[StageOutcome]] = None,
+        deal_outcomes: Optional[List[DealOutcome]] = None,
+    ) -> LearningInsights:
+        """Analyze outcomes and return (and persist) updated LearningInsights.
+
+        If stage_outcomes / deal_outcomes are not provided, they are loaded
+        from the outcome store automatically.
+        """
+        if stage_outcomes is None:
+            stage_outcomes = load_stage_outcomes()
+        if deal_outcomes is None:
+            deal_outcomes = load_deal_outcomes()
+
+        current = load_current_insights()
+        current_version = current.insights_version if current else 0
+        n_analyzed = len(stage_outcomes) + len(deal_outcomes)
+
+        if n_analyzed == 0:
+            logger.info("LearningEngine: no outcomes to analyze yet — returning empty insights")
+            empty = LearningInsights(
+                total_outcomes_analyzed=0,
+                actionable_recommendations=[
+                    "No outcomes recorded yet. Use POST /sales/outcomes/stage or "
+                    "POST /sales/outcomes/deal to log results as you work deals."
+                ],
+                generated_at=__import__("datetime").datetime.now(
+                    __import__("datetime").timezone.utc
+                ).isoformat(),
+                insights_version=current_version + 1,
+            )
+            save_insights(empty)
+            return empty
+
+        if self._agent is not None:
+            insights = self._run_with_strands(stage_outcomes, deal_outcomes, current_version, n_analyzed)
+        else:
+            logger.info("LearningEngine: Strands SDK not available — using heuristic analysis")
+            insights = compute_heuristic_insights(stage_outcomes, deal_outcomes, current_version)
+
+        save_insights(insights)
+        logger.info(
+            "LearningEngine: insights refreshed to v%d — win_rate=%.0f%%, %d outcomes",
+            insights.insights_version,
+            insights.win_rate * 100,
+            insights.total_outcomes_analyzed,
+        )
+        return insights
+
+    def _run_with_strands(
+        self,
+        stage_outcomes: List[StageOutcome],
+        deal_outcomes: List[DealOutcome],
+        current_version: int,
+        n_analyzed: int,
+    ) -> LearningInsights:
+        stage_data = [s.model_dump() for s in stage_outcomes]
+        deal_data = [d.model_dump() for d in deal_outcomes]
+        prompt = (
+            f"Analyze these sales pipeline outcomes and extract actionable patterns.\n\n"
+            f"STAGE OUTCOMES ({len(stage_outcomes)} records):\n"
+            f"{json.dumps(stage_data, indent=2)}\n\n"
+            f"DEAL OUTCOMES ({len(deal_outcomes)} records):\n"
+            f"{json.dumps(deal_data, indent=2)}\n\n"
+            "Return a single JSON object with the insights schema defined in your system prompt. "
+            "All insights must be grounded in the specific data above — no generic advice."
+        )
+        try:
+            result = self._agent(prompt)
+            raw = result.message if hasattr(result, "message") else str(result)
+            insights = _parse_insights_json(raw.strip(), current_version, n_analyzed)
+            if insights:
+                return insights
+        except Exception as exc:
+            logger.error("LearningEngine Strands call failed: %s", exc, exc_info=True)
+
+        # Fall back to heuristics if Strands call or parse fails
+        logger.warning("LearningEngine: falling back to heuristic analysis after Strands failure")
+        return compute_heuristic_insights(stage_outcomes, deal_outcomes, current_version)
+
+
+def format_insights_for_prompt(insights: Optional[LearningInsights]) -> str:
+    """Format LearningInsights as a concise block for injection into agent prompts.
+
+    Returns an empty string if insights is None or has no analyzed outcomes.
+    """
+    if not insights or insights.total_outcomes_analyzed == 0:
+        return ""
+
+    lines = [
+        f"\n## Learned from {insights.total_outcomes_analyzed} past outcomes "
+        f"(win rate: {insights.win_rate:.0%}, insights v{insights.insights_version})\n"
+    ]
+
+    if insights.winning_patterns:
+        lines.append("**What's working:**")
+        for p in insights.winning_patterns[:3]:
+            lines.append(f"- {p}")
+
+    if insights.losing_patterns:
+        lines.append("\n**Watch out for:**")
+        for p in insights.losing_patterns[:3]:
+            lines.append(f"- {p}")
+
+    if insights.top_performing_industries:
+        lines.append(f"\n**Top industries:** {', '.join(insights.top_performing_industries)}")
+
+    if insights.common_objections:
+        lines.append("\n**Most frequent objections to prepare for:**")
+        for o in insights.common_objections[:3]:
+            lines.append(f"- {o}")
+
+    if insights.best_close_techniques:
+        lines.append(f"\n**Best close techniques (by win rate):** {', '.join(insights.best_close_techniques)}")
+
+    if insights.best_outreach_angles:
+        lines.append("\n**High-reply outreach angles:**")
+        for a in insights.best_outreach_angles[:2]:
+            lines.append(f"- {a}")
+
+    if insights.actionable_recommendations:
+        lines.append("\n**Top recommendations:**")
+        for r in insights.actionable_recommendations[:3]:
+            lines.append(f"- {r}")
+
+    if insights.avg_sales_cycle_days:
+        lines.append(f"\n**Avg sales cycle (won):** {insights.avg_sales_cycle_days:.0f} days")
+
+    if insights.stage_conversion_rates:
+        worst = min(insights.stage_conversion_rates, key=lambda k: insights.stage_conversion_rates[k])
+        lines.append(
+            f"**Biggest funnel leak:** {worst} stage "
+            f"({insights.stage_conversion_rates[worst]:.0%} conversion)"
+        )
+
+    return "\n".join(lines)

--- a/backend/agents/sales_team/models.py
+++ b/backend/agents/sales_team/models.py
@@ -401,6 +401,168 @@ class CoachingRequest(BaseModel):
     )
 
 
+# ---------------------------------------------------------------------------
+# Outcome tracking models
+# ---------------------------------------------------------------------------
+
+
+class OutcomeResult(str, Enum):
+    """What happened at a specific pipeline stage for a prospect."""
+
+    CONVERTED = "converted"        # Moved forward to next stage
+    STALLED = "stalled"            # No response / no movement
+    OBJECTION = "objection"        # Objection raised; outcome pending
+    DISQUALIFIED = "disqualified"  # Explicitly ruled out
+    WON = "won"                    # Deal closed won
+    LOST = "lost"                  # Deal closed lost
+
+
+class StageOutcome(BaseModel):
+    """Records what happened at a single pipeline stage for one prospect."""
+
+    outcome_id: str = Field(default="", description="UUID assigned by the store on write")
+    recorded_at: str = Field(default="", description="ISO-8601 UTC timestamp")
+    pipeline_job_id: Optional[str] = None
+    company_name: str
+    industry: Optional[str] = None
+    stage: PipelineStage
+    outcome: OutcomeResult
+    icp_match_score: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    qualification_score: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    # Stage-specific details (open to extension)
+    email_touch_number: Optional[int] = Field(
+        default=None, description="Which email touch got the reply (outreach stage)"
+    )
+    subject_line_used: Optional[str] = Field(
+        default=None, description="Subject line that drove the reply (outreach stage)"
+    )
+    objection_text: Optional[str] = Field(
+        default=None, description="Objection raised, if any"
+    )
+    close_technique_used: Optional[CloseType] = Field(
+        default=None, description="Close technique attempted (negotiation stage)"
+    )
+    notes: str = Field(default="")
+
+
+class DealOutcome(BaseModel):
+    """Full deal outcome — recorded when a deal reaches closed_won or closed_lost."""
+
+    outcome_id: str = Field(default="", description="UUID assigned by the store on write")
+    recorded_at: str = Field(default="", description="ISO-8601 UTC timestamp")
+    pipeline_job_id: Optional[str] = None
+    company_name: str
+    industry: Optional[str] = None
+    deal_size_usd: Optional[float] = Field(default=None, gt=0)
+    final_stage_reached: PipelineStage
+    result: OutcomeResult  # WON or LOST
+    loss_reason: Optional[str] = Field(
+        default=None,
+        description="Why the deal was lost (price, competitor, timing, no champion, etc.)"
+    )
+    win_factor: Optional[str] = Field(
+        default=None, description="Primary reason the deal was won"
+    )
+    close_technique_used: Optional[CloseType] = None
+    objections_raised: List[str] = Field(default_factory=list)
+    stages_completed: List[PipelineStage] = Field(default_factory=list)
+    icp_match_score: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    qualification_score: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    sales_cycle_days: Optional[int] = Field(
+        default=None, description="Total days from first contact to close"
+    )
+    notes: str = Field(default="")
+
+
+class LearningInsights(BaseModel):
+    """Extracted patterns from historical outcomes — injected into agent prompts."""
+
+    total_outcomes_analyzed: int = 0
+    win_rate: float = Field(default=0.0, ge=0.0, le=1.0, description="Fraction of deals won")
+    stage_conversion_rates: dict = Field(
+        default_factory=dict,
+        description="stage_name → conversion % to next stage"
+    )
+    top_performing_industries: List[str] = Field(
+        default_factory=list,
+        description="Industries with highest win rates"
+    )
+    top_icp_signals: List[str] = Field(
+        default_factory=list,
+        description="ICP traits / trigger events that correlated with wins"
+    )
+    best_outreach_angles: List[str] = Field(
+        default_factory=list,
+        description="Subject line patterns or email angles with high reply rates"
+    )
+    common_objections: List[str] = Field(
+        default_factory=list,
+        description="Objections that appear most frequently across all deals"
+    )
+    best_close_techniques: List[str] = Field(
+        default_factory=list,
+        description="Close techniques with highest observed win rates"
+    )
+    winning_patterns: List[str] = Field(
+        default_factory=list,
+        description="Behaviors / deal traits that consistently preceded wins"
+    )
+    losing_patterns: List[str] = Field(
+        default_factory=list,
+        description="Behaviors / deal traits that consistently preceded losses"
+    )
+    avg_deal_size_won_usd: Optional[float] = None
+    avg_sales_cycle_days: Optional[float] = None
+    actionable_recommendations: List[str] = Field(
+        default_factory=list,
+        description="Specific, prioritized advice to improve the current pipeline"
+    )
+    generated_at: str = Field(default="", description="ISO-8601 UTC timestamp of last refresh")
+    insights_version: int = Field(default=0, description="Increments on each refresh")
+
+
+# ---------------------------------------------------------------------------
+# Outcome ingestion request models (used by API)
+# ---------------------------------------------------------------------------
+
+
+class RecordStageOutcomeRequest(BaseModel):
+    """API payload to record the outcome of a single pipeline stage."""
+
+    company_name: str
+    stage: PipelineStage
+    outcome: OutcomeResult
+    pipeline_job_id: Optional[str] = None
+    industry: Optional[str] = None
+    icp_match_score: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    qualification_score: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    email_touch_number: Optional[int] = None
+    subject_line_used: Optional[str] = None
+    objection_text: Optional[str] = None
+    close_technique_used: Optional[CloseType] = None
+    notes: str = Field(default="")
+
+
+class RecordDealOutcomeRequest(BaseModel):
+    """API payload to record a final deal outcome (won or lost)."""
+
+    company_name: str
+    result: OutcomeResult  # WON or LOST
+    final_stage_reached: PipelineStage
+    pipeline_job_id: Optional[str] = None
+    industry: Optional[str] = None
+    deal_size_usd: Optional[float] = Field(default=None, gt=0)
+    loss_reason: Optional[str] = None
+    win_factor: Optional[str] = None
+    close_technique_used: Optional[CloseType] = None
+    objections_raised: List[str] = Field(default_factory=list)
+    stages_completed: List[PipelineStage] = Field(default_factory=list)
+    icp_match_score: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    qualification_score: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    sales_cycle_days: Optional[int] = None
+    notes: str = Field(default="")
+
+
 class SalesPipelineResult(BaseModel):
     """Full output of a sales pod pipeline run."""
 

--- a/backend/agents/sales_team/models.py
+++ b/backend/agents/sales_team/models.py
@@ -417,6 +417,13 @@ class OutcomeResult(str, Enum):
     LOST = "lost"                  # Deal closed lost
 
 
+class DealResult(str, Enum):
+    """Final close result for a deal — only valid values for DealOutcome records."""
+
+    WON = "won"
+    LOST = "lost"
+
+
 class StageOutcome(BaseModel):
     """Records what happened at a single pipeline stage for one prospect."""
 
@@ -455,7 +462,7 @@ class DealOutcome(BaseModel):
     industry: Optional[str] = None
     deal_size_usd: Optional[float] = Field(default=None, gt=0)
     final_stage_reached: PipelineStage
-    result: OutcomeResult  # WON or LOST
+    result: DealResult
     loss_reason: Optional[str] = Field(
         default=None,
         description="Why the deal was lost (price, competitor, timing, no champion, etc.)"
@@ -547,7 +554,7 @@ class RecordDealOutcomeRequest(BaseModel):
     """API payload to record a final deal outcome (won or lost)."""
 
     company_name: str
-    result: OutcomeResult  # WON or LOST
+    result: DealResult
     final_stage_reached: PipelineStage
     pipeline_job_id: Optional[str] = None
     industry: Optional[str] = None

--- a/backend/agents/sales_team/models.py
+++ b/backend/agents/sales_team/models.py
@@ -1,0 +1,418 @@
+"""Pydantic models for the AI Sales Team pipeline."""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+# ---------------------------------------------------------------------------
+# Enums
+# ---------------------------------------------------------------------------
+
+
+class PipelineStage(str, Enum):
+    PROSPECTING = "prospecting"
+    OUTREACH = "outreach"
+    QUALIFICATION = "qualification"
+    NURTURING = "nurturing"
+    DISCOVERY = "discovery"
+    PROPOSAL = "proposal"
+    NEGOTIATION = "negotiation"
+    CLOSED_WON = "closed_won"
+    CLOSED_LOST = "closed_lost"
+
+
+class OutreachChannel(str, Enum):
+    EMAIL = "email"
+    PHONE = "phone"
+    LINKEDIN = "linkedin"
+    VIDEO = "video"
+
+
+class CloseType(str, Enum):
+    ASSUMPTIVE = "assumptive"
+    SUMMARY = "summary"
+    URGENCY = "urgency"
+    ALTERNATIVE_CHOICE = "alternative_choice"
+    SHARP_ANGLE = "sharp_angle"
+    FEEL_FELT_FOUND = "feel_felt_found"
+
+
+class ForecastCategory(str, Enum):
+    PIPELINE = "pipeline"
+    BEST_CASE = "best_case"
+    COMMIT = "commit"
+    CLOSED = "closed"
+    OMITTED = "omitted"
+
+
+# ---------------------------------------------------------------------------
+# ICP & Prospect models
+# ---------------------------------------------------------------------------
+
+
+class IdealCustomerProfile(BaseModel):
+    """Defines the Ideal Customer Profile used to score and filter prospects."""
+
+    industry: List[str] = Field(default_factory=list, description="Target industries, e.g. ['SaaS', 'FinTech']")
+    company_size_min: int = Field(default=10, description="Minimum employee count")
+    company_size_max: int = Field(default=5000, description="Maximum employee count")
+    job_titles: List[str] = Field(default_factory=list, description="Target buyer titles, e.g. ['VP Sales', 'CRO']")
+    pain_points: List[str] = Field(default_factory=list, description="Core pains the product solves")
+    budget_range_usd: str = Field(default="$10k–$100k/yr", description="Expected ACV range")
+    geographic_focus: List[str] = Field(default_factory=list, description="Target regions or countries")
+    tech_stack_keywords: List[str] = Field(
+        default_factory=list, description="Technologies the prospect likely uses"
+    )
+    disqualifying_traits: List[str] = Field(
+        default_factory=list, description="Traits that rule out a prospect"
+    )
+
+
+class Prospect(BaseModel):
+    """Raw lead identified during prospecting — not yet contacted."""
+
+    company_name: str
+    website: Optional[str] = None
+    contact_name: Optional[str] = None
+    contact_title: Optional[str] = None
+    contact_email: Optional[str] = None
+    linkedin_url: Optional[str] = None
+    company_size_estimate: Optional[str] = None
+    industry: Optional[str] = None
+    icp_match_score: float = Field(default=0.0, ge=0.0, le=1.0, description="0–1 ICP fit score")
+    research_notes: str = Field(default="", description="Key intel gathered during prospecting")
+    trigger_events: List[str] = Field(
+        default_factory=list, description="Recent events making them likely to buy now"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Outreach models
+# ---------------------------------------------------------------------------
+
+
+class EmailTouch(BaseModel):
+    """A single email in a multi-touch cold outreach sequence."""
+
+    day: int = Field(..., description="Day in the sequence to send this email (0-indexed)")
+    subject_line: str
+    body: str
+    personalization_tokens: List[str] = Field(
+        default_factory=list, description="Merge fields to fill before sending"
+    )
+    call_to_action: str = Field(default="", description="Specific ask at the end of this touch")
+
+
+class OutreachSequence(BaseModel):
+    """Complete multi-channel outreach plan for a prospect."""
+
+    prospect: Prospect
+    email_sequence: List[EmailTouch] = Field(default_factory=list)
+    call_script: str = Field(default="", description="Cold-call opener and talk track")
+    linkedin_message: str = Field(default="", description="Connection request / InMail copy")
+    sequence_rationale: str = Field(
+        default="", description="Why this angle was chosen for this prospect"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Qualification models
+# ---------------------------------------------------------------------------
+
+
+class BANTScore(BaseModel):
+    """BANT qualification framework scores."""
+
+    budget: int = Field(..., ge=0, le=10, description="Does the prospect have budget? 0–10")
+    authority: int = Field(..., ge=0, le=10, description="Is the contact a decision-maker? 0–10")
+    need: int = Field(..., ge=0, le=10, description="Is there a confirmed, urgent need? 0–10")
+    timeline: int = Field(..., ge=0, le=10, description="Is there a defined purchase timeline? 0–10")
+
+
+class MEDDICScore(BaseModel):
+    """MEDDIC qualification framework signals."""
+
+    metrics_identified: bool = Field(default=False, description="Quantified business impact defined")
+    economic_buyer_known: bool = Field(default=False)
+    decision_criteria_understood: bool = Field(default=False)
+    decision_process_mapped: bool = Field(default=False)
+    identify_pain: bool = Field(default=False, description="Root pain confirmed")
+    champion_found: bool = Field(default=False, description="Internal champion identified")
+
+
+class QualificationScore(BaseModel):
+    """Combined BANT + MEDDIC qualification result for a lead."""
+
+    prospect: Prospect
+    bant: BANTScore
+    meddic: MEDDICScore
+    overall_score: float = Field(..., ge=0.0, le=1.0, description="Weighted composite 0–1")
+    value_creation_level: int = Field(
+        ..., ge=1, le=4, description="Iannarino Level 1–4 value tier"
+    )
+    recommended_action: str = Field(
+        ..., description="Next step: advance, nurture, or disqualify"
+    )
+    disqualification_reason: Optional[str] = None
+    qualification_notes: str = Field(default="")
+
+
+# ---------------------------------------------------------------------------
+# Nurture models
+# ---------------------------------------------------------------------------
+
+
+class NurtureTouchpoint(BaseModel):
+    """A single step in a nurture sequence."""
+
+    day: int
+    channel: OutreachChannel
+    content_type: str = Field(
+        ..., description="e.g. 'case study email', 'ROI calculator link', 'check-in call'"
+    )
+    message: str
+    goal: str = Field(default="", description="What this touch is designed to accomplish")
+
+
+class NurtureSequence(BaseModel):
+    """Long-cycle follow-up plan for leads not ready to buy yet."""
+
+    prospect: Prospect
+    duration_days: int = Field(default=90)
+    touchpoints: List[NurtureTouchpoint] = Field(default_factory=list)
+    re_engagement_triggers: List[str] = Field(
+        default_factory=list,
+        description="Events that should pull the lead back into active pipeline",
+    )
+    content_recommendations: List[str] = Field(
+        default_factory=list,
+        description="Blog posts, case studies, or assets to share over the sequence",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Discovery models
+# ---------------------------------------------------------------------------
+
+
+class SPINQuestions(BaseModel):
+    """SPIN Selling question set for discovery calls."""
+
+    situation: List[str] = Field(default_factory=list, description="Questions about current state")
+    problem: List[str] = Field(default_factory=list, description="Questions that surface pain")
+    implication: List[str] = Field(
+        default_factory=list, description="Questions that amplify consequences of inaction"
+    )
+    need_payoff: List[str] = Field(
+        default_factory=list, description="Questions that surface the value of solving the problem"
+    )
+
+
+class DiscoveryPlan(BaseModel):
+    """Prep pack for a discovery call or product demo."""
+
+    prospect: Prospect
+    spin_questions: SPINQuestions
+    challenger_insight: str = Field(
+        default="",
+        description="Provocative insight to open the call and reframe the prospect's thinking",
+    )
+    demo_agenda: List[str] = Field(default_factory=list, description="Ordered demo talking points")
+    expected_objections: List[str] = Field(default_factory=list)
+    success_criteria_for_call: str = Field(default="", description="What a successful call looks like")
+
+
+# ---------------------------------------------------------------------------
+# Proposal models
+# ---------------------------------------------------------------------------
+
+
+class ROIModel(BaseModel):
+    """Simple ROI / payback calculation for a proposal."""
+
+    annual_cost_usd: float
+    estimated_annual_benefit_usd: float
+    payback_months: float
+    roi_percentage: float
+    assumptions: List[str] = Field(default_factory=list)
+
+
+class ProposalSection(BaseModel):
+    heading: str
+    content: str
+
+
+class SalesProposal(BaseModel):
+    """Full written sales proposal."""
+
+    prospect: Prospect
+    executive_summary: str
+    situation_analysis: str
+    proposed_solution: str
+    roi_model: ROIModel
+    investment_table: str = Field(default="", description="Pricing and packaging breakdown")
+    implementation_timeline: str = Field(default="")
+    risk_mitigation: str = Field(default="")
+    next_steps: List[str] = Field(default_factory=list)
+    custom_sections: List[ProposalSection] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Closing models
+# ---------------------------------------------------------------------------
+
+
+class ObjectionHandler(BaseModel):
+    objection: str
+    response: str
+    feel_felt_found: Optional[str] = None
+
+
+class ClosingStrategy(BaseModel):
+    """Closing pack grounded in Zig Ziglar and Jeb Blount's Sales EQ."""
+
+    prospect: Prospect
+    recommended_close_technique: CloseType
+    close_script: str
+    objection_handlers: List[ObjectionHandler] = Field(default_factory=list)
+    urgency_framing: str = Field(default="", description="Legitimate urgency lever to accelerate decision")
+    walk_away_criteria: str = Field(
+        default="", description="Conditions under which to disengage from the deal"
+    )
+    emotional_intelligence_notes: str = Field(
+        default="",
+        description="Sales EQ guidance: acknowledge emotions before logic",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Coaching models
+# ---------------------------------------------------------------------------
+
+
+class DealRiskSignal(BaseModel):
+    signal: str
+    severity: str = Field(..., description="low | medium | high")
+    recommended_action: str
+
+
+class PipelineCoachingReport(BaseModel):
+    """Gong Labs-style pipeline review and coaching output."""
+
+    prospects_reviewed: int
+    deal_risk_signals: List[DealRiskSignal] = Field(default_factory=list)
+    talk_listen_ratio_advice: str = Field(default="")
+    velocity_insights: str = Field(default="", description="Pipeline velocity and stage duration analysis")
+    forecast_category: ForecastCategory = ForecastCategory.PIPELINE
+    top_priority_deals: List[str] = Field(default_factory=list)
+    recommended_next_actions: List[str] = Field(default_factory=list)
+    coaching_summary: str = Field(default="")
+
+
+# ---------------------------------------------------------------------------
+# Pipeline-level request/response models
+# ---------------------------------------------------------------------------
+
+
+class SalesPipelineRequest(BaseModel):
+    """Top-level request to run the full sales pod pipeline."""
+
+    product_name: str = Field(..., min_length=1, max_length=200)
+    value_proposition: str = Field(..., min_length=10, max_length=5000)
+    icp: IdealCustomerProfile
+    entry_stage: PipelineStage = PipelineStage.PROSPECTING
+    max_prospects: int = Field(default=5, ge=1, le=20, description="Max leads to generate")
+    existing_prospects: List[Prospect] = Field(
+        default_factory=list,
+        description="Pre-existing leads to skip prospecting (used when entry_stage != PROSPECTING)",
+    )
+    company_context: str = Field(
+        default="",
+        max_length=5000,
+        description="About your company: size, mission, differentiators",
+    )
+    case_study_snippets: List[str] = Field(
+        default_factory=list,
+        description="1–3 sentence customer wins to use in outreach/proposals",
+    )
+
+
+class ProspectingRequest(BaseModel):
+    """Standalone prospecting request."""
+
+    icp: IdealCustomerProfile
+    product_name: str
+    value_proposition: str
+    max_prospects: int = Field(default=5, ge=1, le=20)
+    company_context: str = Field(default="", max_length=5000)
+
+
+class OutreachRequest(BaseModel):
+    """Generate outreach sequences for a list of prospects."""
+
+    prospects: List[Prospect]
+    product_name: str
+    value_proposition: str
+    case_study_snippets: List[str] = Field(default_factory=list)
+    company_context: str = Field(default="", max_length=5000)
+
+
+class QualificationRequest(BaseModel):
+    """Qualify a single prospect."""
+
+    prospect: Prospect
+    product_name: str
+    value_proposition: str
+    call_notes: str = Field(default="", description="Notes from any discovery call or conversation")
+
+
+class NurtureRequest(BaseModel):
+    """Build a nurture sequence for prospects not ready to buy."""
+
+    prospects: List[Prospect]
+    product_name: str
+    value_proposition: str
+    duration_days: int = Field(default=90, ge=7, le=365)
+
+
+class ProposalRequest(BaseModel):
+    """Generate a sales proposal for a qualified opportunity."""
+
+    prospect: Prospect
+    product_name: str
+    value_proposition: str
+    annual_cost_usd: float = Field(..., gt=0)
+    discovery_notes: str = Field(default="", description="Notes from discovery call")
+    case_study_snippets: List[str] = Field(default_factory=list)
+    company_context: str = Field(default="", max_length=5000)
+
+
+class CoachingRequest(BaseModel):
+    """Request a pipeline coaching report."""
+
+    prospects: List[Prospect]
+    product_name: str
+    pipeline_context: str = Field(
+        default="", description="Additional context about deal status, stage durations, etc."
+    )
+
+
+class SalesPipelineResult(BaseModel):
+    """Full output of a sales pod pipeline run."""
+
+    job_id: str
+    entry_stage: PipelineStage
+    product_name: str
+    prospects: List[Prospect] = Field(default_factory=list)
+    outreach_sequences: List[OutreachSequence] = Field(default_factory=list)
+    qualified_leads: List[QualificationScore] = Field(default_factory=list)
+    nurture_sequences: List[NurtureSequence] = Field(default_factory=list)
+    discovery_plans: List[DiscoveryPlan] = Field(default_factory=list)
+    proposals: List[SalesProposal] = Field(default_factory=list)
+    closing_strategies: List[ClosingStrategy] = Field(default_factory=list)
+    coaching_report: Optional[PipelineCoachingReport] = None
+    summary: str = Field(default="", description="Plain-English summary of the full pipeline run")

--- a/backend/agents/sales_team/orchestrator.py
+++ b/backend/agents/sales_team/orchestrator.py
@@ -16,14 +16,18 @@ from .agents import (
     ProspectorAgent,
     SalesCoachAgent,
 )
+from .learning_engine import LearningEngine, format_insights_for_prompt
 from .models import (
     BANTScore,
     ClosingStrategy,
+    DealOutcome,
     DiscoveryPlan,
     IdealCustomerProfile,
+    LearningInsights,
     MEDDICScore,
     NurtureSequence,
     ObjectionHandler,
+    OutcomeResult,
     OutreachSequence,
     PipelineCoachingReport,
     PipelineStage,
@@ -35,7 +39,9 @@ from .models import (
     SalesPipelineResult,
     SalesProposal,
     SPINQuestions,
+    StageOutcome,
 )
+from .outcome_store import load_current_insights, record_deal_outcome, record_stage_outcome
 
 logger = logging.getLogger(__name__)
 
@@ -289,6 +295,10 @@ class SalesPodOrchestrator:
 
     Stages run sequentially from the requested entry point. Each stage's
     output is passed as context to the next stage.
+
+    On each run, current LearningInsights are loaded from the outcome store
+    and injected into every agent prompt so the pod continuously improves
+    based on historical win/loss data.
     """
 
     def __init__(self) -> None:
@@ -300,6 +310,7 @@ class SalesPodOrchestrator:
         self.proposal = ProposalAgent()
         self.closer = CloserAgent()
         self.coach = SalesCoachAgent()
+        self.learning_engine = LearningEngine()
 
     def _should_run(self, stage: PipelineStage, entry: PipelineStage) -> bool:
         try:
@@ -324,6 +335,19 @@ class SalesPodOrchestrator:
         cases = "\n".join(request.case_study_snippets) if request.case_study_snippets else ""
         entry = request.entry_stage
 
+        # Load current learning insights and format them for prompt injection
+        current_insights: Optional[LearningInsights] = load_current_insights()
+        insights_ctx: Optional[str] = format_insights_for_prompt(current_insights)
+        if current_insights and current_insights.total_outcomes_analyzed > 0:
+            logger.info(
+                "Sales pod [%s]: injecting learning insights v%d "
+                "(%d outcomes, win_rate=%.0f%%)",
+                job_id,
+                current_insights.insights_version,
+                current_insights.total_outcomes_analyzed,
+                current_insights.win_rate * 100,
+            )
+
         result = SalesPipelineResult(job_id=job_id, entry_stage=entry, product_name=product)
 
         # ------------------------------------------------------------------
@@ -335,7 +359,7 @@ class SalesPodOrchestrator:
             if request.existing_prospects:
                 prospects = request.existing_prospects
             else:
-                raw = self.prospector.prospect(icp_json, product, vp, request.max_prospects, ctx)
+                raw = self.prospector.prospect(icp_json, product, vp, request.max_prospects, ctx, insights_ctx)
                 prospects = _prospects_from_json(raw)
             result.prospects = prospects
             update("prospecting", 15)
@@ -357,7 +381,7 @@ class SalesPodOrchestrator:
             sequences: List[OutreachSequence] = []
             for p in prospects:
                 raw = self.outreach.generate_sequence(
-                    p.model_dump_json(indent=2), product, vp, cases, ctx
+                    p.model_dump_json(indent=2), product, vp, cases, ctx, insights_ctx
                 )
                 seq = _outreach_from_json(raw, p)
                 if seq:
@@ -373,7 +397,7 @@ class SalesPodOrchestrator:
             update("qualification", 40)
             logger.info("Sales pod [%s]: qualification stage", job_id)
             for p in prospects:
-                raw = self.qualifier.qualify(p.model_dump_json(indent=2), product, vp, "")
+                raw = self.qualifier.qualify(p.model_dump_json(indent=2), product, vp, "", insights_ctx)
                 score = _qual_from_json(raw, p)
                 if score:
                     qualified.append(score)
@@ -403,7 +427,7 @@ class SalesPodOrchestrator:
             logger.info("Sales pod [%s]: nurturing %d prospects", job_id, len(nurture_prospects))
             nurture_seqs: List[NurtureSequence] = []
             for p in nurture_prospects:
-                raw = self.nurture.build_sequence(p.model_dump_json(indent=2), product, vp, 90)
+                raw = self.nurture.build_sequence(p.model_dump_json(indent=2), product, vp, 90, insights_ctx)
                 seq = _nurture_from_json(raw, p, 90)
                 if seq:
                     nurture_seqs.append(seq)
@@ -423,7 +447,7 @@ class SalesPodOrchestrator:
                     if q.prospect.company_name == p.company_name:
                         qual_json = q.model_dump_json(indent=2)
                         break
-                raw = self.discovery.prepare(p.model_dump_json(indent=2), qual_json, product, vp)
+                raw = self.discovery.prepare(p.model_dump_json(indent=2), qual_json, product, vp, insights_ctx)
                 plan = _discovery_from_json(raw, p)
                 if plan:
                     plans.append(plan)
@@ -440,7 +464,7 @@ class SalesPodOrchestrator:
             annual_cost = 25000.0  # Default; real requests should supply per-prospect pricing
             for p in qualified_prospects:
                 raw = self.proposal.write(
-                    p.model_dump_json(indent=2), product, vp, annual_cost, "", cases, ctx
+                    p.model_dump_json(indent=2), product, vp, annual_cost, "", cases, ctx, insights_ctx
                 )
                 prop = _proposal_from_json(raw, p, annual_cost)
                 if prop:
@@ -462,7 +486,7 @@ class SalesPodOrchestrator:
                         prop_json = prop.model_dump_json(indent=2)
                         break
                 raw = self.closer.develop_strategy(
-                    p.model_dump_json(indent=2), prop_json, product, vp
+                    p.model_dump_json(indent=2), prop_json, product, vp, insights_ctx
                 )
                 strat = _closing_from_json(raw, p)
                 if strat:
@@ -476,13 +500,21 @@ class SalesPodOrchestrator:
         update("coaching", 97)
         logger.info("Sales pod [%s]: generating coaching report", job_id)
         prospects_json = json.dumps([p.model_dump() for p in prospects], indent=2)
-        raw = self.coach.review(prospects_json, product, "")
+        raw = self.coach.review(prospects_json, product, "", insights_ctx)
         coaching = _coaching_from_json(raw, len(prospects))
         result.coaching_report = coaching
 
+        # Auto-record prospecting outcomes so the ICP accuracy learns over time
+        self._record_prospecting_outcomes(result.prospects, job_id)
+
         # Summary
+        insights_note = (
+            f" (learning insights v{current_insights.insights_version} applied)"
+            if current_insights and current_insights.total_outcomes_analyzed > 0
+            else " (no learning history yet — record outcomes to improve future runs)"
+        )
         result.summary = (
-            f"Sales pod completed pipeline from '{entry.value}' stage. "
+            f"Sales pod completed pipeline from '{entry.value}' stage{insights_note}. "
             f"Prospects identified: {len(result.prospects)}. "
             f"Outreach sequences generated: {len(result.outreach_sequences)}. "
             f"Leads qualified: {len(result.qualified_leads)}. "
@@ -496,9 +528,32 @@ class SalesPodOrchestrator:
         logger.info("Sales pod [%s]: pipeline complete — %s", job_id, result.summary)
         return result
 
+    def _record_prospecting_outcomes(self, prospects: List[Prospect], job_id: str) -> None:
+        """Auto-record each identified prospect as a PROSPECTING / CONVERTED stage outcome.
+
+        This seeds the outcome store so the learning engine has data even before
+        the user manually records deal-level outcomes.
+        """
+        for p in prospects:
+            try:
+                record_stage_outcome(StageOutcome(
+                    pipeline_job_id=job_id,
+                    company_name=p.company_name,
+                    industry=p.industry,
+                    stage=PipelineStage.PROSPECTING,
+                    outcome=OutcomeResult.CONVERTED,
+                    icp_match_score=p.icp_match_score,
+                ))
+            except Exception as exc:
+                logger.debug("Could not auto-record prospecting outcome: %s", exc)
+
     # ------------------------------------------------------------------
     # Convenience single-stage methods (used by standalone API endpoints)
     # ------------------------------------------------------------------
+
+    def _load_insights_ctx(self) -> Optional[str]:
+        """Load current insights and format for prompt injection."""
+        return format_insights_for_prompt(load_current_insights())
 
     def prospect_only(
         self,
@@ -508,8 +563,9 @@ class SalesPodOrchestrator:
         max_prospects: int,
         company_context: str,
     ) -> List[Prospect]:
+        ctx = self._load_insights_ctx()
         raw = self.prospector.prospect(
-            icp.model_dump_json(indent=2), product_name, value_proposition, max_prospects, company_context
+            icp.model_dump_json(indent=2), product_name, value_proposition, max_prospects, company_context, ctx
         )
         return _prospects_from_json(raw)
 
@@ -521,11 +577,12 @@ class SalesPodOrchestrator:
         case_study_snippets: List[str],
         company_context: str,
     ) -> List[OutreachSequence]:
+        ctx = self._load_insights_ctx()
         cases = "\n".join(case_study_snippets)
         sequences = []
         for p in prospects:
             raw = self.outreach.generate_sequence(
-                p.model_dump_json(indent=2), product_name, value_proposition, cases, company_context
+                p.model_dump_json(indent=2), product_name, value_proposition, cases, company_context, ctx
             )
             seq = _outreach_from_json(raw, p)
             if seq:
@@ -535,8 +592,9 @@ class SalesPodOrchestrator:
     def qualify_only(
         self, prospect: Prospect, product_name: str, value_proposition: str, call_notes: str
     ) -> Optional[QualificationScore]:
+        ctx = self._load_insights_ctx()
         raw = self.qualifier.qualify(
-            prospect.model_dump_json(indent=2), product_name, value_proposition, call_notes
+            prospect.model_dump_json(indent=2), product_name, value_proposition, call_notes, ctx
         )
         return _qual_from_json(raw, prospect)
 
@@ -547,10 +605,11 @@ class SalesPodOrchestrator:
         value_proposition: str,
         duration_days: int,
     ) -> List[NurtureSequence]:
+        ctx = self._load_insights_ctx()
         sequences = []
         for p in prospects:
             raw = self.nurture.build_sequence(
-                p.model_dump_json(indent=2), product_name, value_proposition, duration_days
+                p.model_dump_json(indent=2), product_name, value_proposition, duration_days, ctx
             )
             seq = _nurture_from_json(raw, p, duration_days)
             if seq:
@@ -558,6 +617,7 @@ class SalesPodOrchestrator:
         return sequences
 
     def propose_only(self, req: ProposalRequest) -> Optional[SalesProposal]:
+        ctx = self._load_insights_ctx()
         cases = "\n".join(req.case_study_snippets)
         raw = self.proposal.write(
             req.prospect.model_dump_json(indent=2),
@@ -567,12 +627,14 @@ class SalesPodOrchestrator:
             req.discovery_notes,
             cases,
             req.company_context,
+            ctx,
         )
         return _proposal_from_json(raw, req.prospect, req.annual_cost_usd)
 
     def coach_only(
         self, prospects: List[Prospect], product_name: str, pipeline_context: str
     ) -> Optional[PipelineCoachingReport]:
+        ctx = self._load_insights_ctx()
         prospects_json = json.dumps([p.model_dump() for p in prospects], indent=2)
-        raw = self.coach.review(prospects_json, product_name, pipeline_context)
+        raw = self.coach.review(prospects_json, product_name, pipeline_context, ctx)
         return _coaching_from_json(raw, len(prospects))

--- a/backend/agents/sales_team/orchestrator.py
+++ b/backend/agents/sales_team/orchestrator.py
@@ -406,18 +406,20 @@ class SalesPodOrchestrator:
 
         # Determine which prospects advance vs. go to nurture
         if qualified:
+            # Qualification ran — only explicitly advanced leads proceed downstream.
+            # Disqualified and stalled leads are intentionally excluded.
             advance = [q for q in qualified if q.recommended_action.lower().startswith("advance")]
             nurture_prospects = [
                 q.prospect for q in qualified
                 if not q.recommended_action.lower().startswith("advance")
                 and not q.recommended_action.lower().startswith("disqualify")
             ]
+            qualified_prospects = [q.prospect for q in advance]
         else:
-            # No qualification ran — advance all prospects
+            # No qualification ran — all prospects advance to downstream stages
             advance = []
             nurture_prospects = []
-            qualified_all = prospects  # type: ignore[assignment]
-        qualified_prospects = [q.prospect for q in advance] if advance else prospects
+            qualified_prospects = prospects
 
         # ------------------------------------------------------------------
         # Stage 4: Nurturing

--- a/backend/agents/sales_team/orchestrator.py
+++ b/backend/agents/sales_team/orchestrator.py
@@ -1,0 +1,578 @@
+"""SalesPodOrchestrator — coordinates all sales team agents through the pipeline."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Callable, List, Optional
+
+from .agents import (
+    CloserAgent,
+    DiscoveryAgent,
+    LeadQualifierAgent,
+    NurtureAgent,
+    OutreachAgent,
+    ProposalAgent,
+    ProspectorAgent,
+    SalesCoachAgent,
+)
+from .models import (
+    BANTScore,
+    ClosingStrategy,
+    DiscoveryPlan,
+    IdealCustomerProfile,
+    MEDDICScore,
+    NurtureSequence,
+    ObjectionHandler,
+    OutreachSequence,
+    PipelineCoachingReport,
+    PipelineStage,
+    Prospect,
+    ProposalRequest,
+    QualificationScore,
+    ROIModel,
+    SalesPipelineRequest,
+    SalesPipelineResult,
+    SalesProposal,
+    SPINQuestions,
+)
+
+logger = logging.getLogger(__name__)
+
+UpdateCallback = Callable[[str, int], None]
+
+_STAGE_ORDER = [
+    PipelineStage.PROSPECTING,
+    PipelineStage.OUTREACH,
+    PipelineStage.QUALIFICATION,
+    PipelineStage.NURTURING,
+    PipelineStage.DISCOVERY,
+    PipelineStage.PROPOSAL,
+    PipelineStage.NEGOTIATION,
+]
+
+
+def _parse_json(raw: str, fallback: object) -> object:
+    """Best-effort JSON parse; returns fallback on failure."""
+    if not raw or not raw.strip():
+        return fallback
+    # Strip markdown code fences if the LLM wrapped the output
+    stripped = raw.strip()
+    if stripped.startswith("```"):
+        lines = stripped.splitlines()
+        stripped = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
+    try:
+        return json.loads(stripped)
+    except (json.JSONDecodeError, ValueError):
+        logger.warning("Could not parse agent JSON output; using fallback. Raw: %s", raw[:200])
+        return fallback
+
+
+def _prospects_from_json(raw: str) -> List[Prospect]:
+    data = _parse_json(raw, [])
+    if not isinstance(data, list):
+        data = [data] if isinstance(data, dict) else []
+    results = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        try:
+            results.append(Prospect(**item))
+        except Exception as exc:
+            logger.warning("Could not parse prospect: %s — %s", item, exc)
+    return results
+
+
+def _qual_from_json(raw: str, prospect: Prospect) -> Optional[QualificationScore]:
+    data = _parse_json(raw, {})
+    if not isinstance(data, dict):
+        return None
+    try:
+        bant_data = data.get("bant", {})
+        meddic_data = data.get("meddic", {})
+        return QualificationScore(
+            prospect=prospect,
+            bant=BANTScore(**bant_data),
+            meddic=MEDDICScore(**meddic_data),
+            overall_score=float(data.get("overall_score", 0.5)),
+            value_creation_level=int(data.get("value_creation_level", 2)),
+            recommended_action=data.get("recommended_action", "Nurture"),
+            disqualification_reason=data.get("disqualification_reason"),
+            qualification_notes=data.get("qualification_notes", ""),
+        )
+    except Exception as exc:
+        logger.warning("Could not build QualificationScore: %s", exc)
+        return None
+
+
+def _outreach_from_json(raw: str, prospect: Prospect) -> Optional[OutreachSequence]:
+    from .models import EmailTouch
+
+    data = _parse_json(raw, {})
+    if not isinstance(data, dict):
+        return None
+    try:
+        email_seq = [EmailTouch(**e) for e in data.get("email_sequence", [])]
+        return OutreachSequence(
+            prospect=prospect,
+            email_sequence=email_seq,
+            call_script=data.get("call_script", ""),
+            linkedin_message=data.get("linkedin_message", ""),
+            sequence_rationale=data.get("sequence_rationale", ""),
+        )
+    except Exception as exc:
+        logger.warning("Could not build OutreachSequence: %s", exc)
+        return None
+
+
+def _nurture_from_json(raw: str, prospect: Prospect, duration_days: int) -> Optional[NurtureSequence]:
+    from .models import NurtureTouchpoint, OutreachChannel
+
+    data = _parse_json(raw, {})
+    if not isinstance(data, dict):
+        return None
+    try:
+        touchpoints = []
+        for t in data.get("touchpoints", []):
+            tp = NurtureTouchpoint(
+                day=t.get("day", 0),
+                channel=OutreachChannel(t.get("channel", "email")),
+                content_type=t.get("content_type", "email"),
+                message=t.get("message", ""),
+                goal=t.get("goal", ""),
+            )
+            touchpoints.append(tp)
+        return NurtureSequence(
+            prospect=prospect,
+            duration_days=data.get("duration_days", duration_days),
+            touchpoints=touchpoints,
+            re_engagement_triggers=data.get("re_engagement_triggers", []),
+            content_recommendations=data.get("content_recommendations", []),
+        )
+    except Exception as exc:
+        logger.warning("Could not build NurtureSequence: %s", exc)
+        return None
+
+
+def _discovery_from_json(raw: str, prospect: Prospect) -> Optional[DiscoveryPlan]:
+    data = _parse_json(raw, {})
+    if not isinstance(data, dict):
+        return None
+    try:
+        sq = data.get("spin_questions", {})
+        return DiscoveryPlan(
+            prospect=prospect,
+            spin_questions=SPINQuestions(
+                situation=sq.get("situation", []),
+                problem=sq.get("problem", []),
+                implication=sq.get("implication", []),
+                need_payoff=sq.get("need_payoff", []),
+            ),
+            challenger_insight=data.get("challenger_insight", ""),
+            demo_agenda=data.get("demo_agenda", []),
+            expected_objections=data.get("expected_objections", []),
+            success_criteria_for_call=data.get("success_criteria_for_call", ""),
+        )
+    except Exception as exc:
+        logger.warning("Could not build DiscoveryPlan: %s", exc)
+        return None
+
+
+def _proposal_from_json(raw: str, prospect: Prospect, annual_cost: float) -> Optional[SalesProposal]:
+    data = _parse_json(raw, {})
+    if not isinstance(data, dict):
+        return None
+    try:
+        roi_data = data.get("roi_model", {})
+        roi = ROIModel(
+            annual_cost_usd=float(roi_data.get("annual_cost_usd", annual_cost)),
+            estimated_annual_benefit_usd=float(roi_data.get("estimated_annual_benefit_usd", annual_cost * 2.5)),
+            payback_months=float(roi_data.get("payback_months", 8.0)),
+            roi_percentage=float(roi_data.get("roi_percentage", 150.0)),
+            assumptions=roi_data.get("assumptions", []),
+        )
+        from .models import ProposalSection
+
+        custom_sections = [
+            ProposalSection(**s) for s in data.get("custom_sections", []) if isinstance(s, dict)
+        ]
+        return SalesProposal(
+            prospect=prospect,
+            executive_summary=data.get("executive_summary", ""),
+            situation_analysis=data.get("situation_analysis", ""),
+            proposed_solution=data.get("proposed_solution", ""),
+            roi_model=roi,
+            investment_table=data.get("investment_table", ""),
+            implementation_timeline=data.get("implementation_timeline", ""),
+            risk_mitigation=data.get("risk_mitigation", ""),
+            next_steps=data.get("next_steps", []),
+            custom_sections=custom_sections,
+        )
+    except Exception as exc:
+        logger.warning("Could not build SalesProposal: %s", exc)
+        return None
+
+
+def _closing_from_json(raw: str, prospect: Prospect) -> Optional[ClosingStrategy]:
+    from .models import CloseType
+
+    data = _parse_json(raw, {})
+    if not isinstance(data, dict):
+        return None
+    try:
+        handlers = [
+            ObjectionHandler(
+                objection=h.get("objection", ""),
+                response=h.get("response", ""),
+                feel_felt_found=h.get("feel_felt_found"),
+            )
+            for h in data.get("objection_handlers", [])
+            if isinstance(h, dict)
+        ]
+        technique_raw = data.get("recommended_close_technique", "summary")
+        try:
+            technique = CloseType(technique_raw)
+        except ValueError:
+            technique = CloseType.SUMMARY
+        return ClosingStrategy(
+            prospect=prospect,
+            recommended_close_technique=technique,
+            close_script=data.get("close_script", ""),
+            objection_handlers=handlers,
+            urgency_framing=data.get("urgency_framing", ""),
+            walk_away_criteria=data.get("walk_away_criteria", ""),
+            emotional_intelligence_notes=data.get("emotional_intelligence_notes", ""),
+        )
+    except Exception as exc:
+        logger.warning("Could not build ClosingStrategy: %s", exc)
+        return None
+
+
+def _coaching_from_json(raw: str, n_prospects: int) -> Optional[PipelineCoachingReport]:
+    from .models import DealRiskSignal, ForecastCategory
+
+    data = _parse_json(raw, {})
+    if not isinstance(data, dict):
+        return None
+    try:
+        signals = [
+            DealRiskSignal(
+                signal=s.get("signal", ""),
+                severity=s.get("severity", "medium"),
+                recommended_action=s.get("recommended_action", ""),
+            )
+            for s in data.get("deal_risk_signals", [])
+            if isinstance(s, dict)
+        ]
+        fc_raw = data.get("forecast_category", "pipeline")
+        try:
+            fc = ForecastCategory(fc_raw)
+        except ValueError:
+            fc = ForecastCategory.PIPELINE
+        return PipelineCoachingReport(
+            prospects_reviewed=data.get("prospects_reviewed", n_prospects),
+            deal_risk_signals=signals,
+            talk_listen_ratio_advice=data.get("talk_listen_ratio_advice", ""),
+            velocity_insights=data.get("velocity_insights", ""),
+            forecast_category=fc,
+            top_priority_deals=data.get("top_priority_deals", []),
+            recommended_next_actions=data.get("recommended_next_actions", []),
+            coaching_summary=data.get("coaching_summary", ""),
+        )
+    except Exception as exc:
+        logger.warning("Could not build PipelineCoachingReport: %s", exc)
+        return None
+
+
+class SalesPodOrchestrator:
+    """Coordinates all sales pod agents through the full pipeline.
+
+    Stages run sequentially from the requested entry point. Each stage's
+    output is passed as context to the next stage.
+    """
+
+    def __init__(self) -> None:
+        self.prospector = ProspectorAgent()
+        self.outreach = OutreachAgent()
+        self.qualifier = LeadQualifierAgent()
+        self.nurture = NurtureAgent()
+        self.discovery = DiscoveryAgent()
+        self.proposal = ProposalAgent()
+        self.closer = CloserAgent()
+        self.coach = SalesCoachAgent()
+
+    def _should_run(self, stage: PipelineStage, entry: PipelineStage) -> bool:
+        try:
+            return _STAGE_ORDER.index(stage) >= _STAGE_ORDER.index(entry)
+        except ValueError:
+            return False
+
+    def run(
+        self,
+        request: SalesPipelineRequest,
+        job_id: str,
+        update_cb: Optional[UpdateCallback] = None,
+    ) -> SalesPipelineResult:
+        def update(stage: str, pct: int) -> None:
+            if update_cb:
+                update_cb(stage, pct)
+
+        icp_json = request.icp.model_dump_json(indent=2)
+        product = request.product_name
+        vp = request.value_proposition
+        ctx = request.company_context
+        cases = "\n".join(request.case_study_snippets) if request.case_study_snippets else ""
+        entry = request.entry_stage
+
+        result = SalesPipelineResult(job_id=job_id, entry_stage=entry, product_name=product)
+
+        # ------------------------------------------------------------------
+        # Stage 1: Prospecting
+        # ------------------------------------------------------------------
+        if self._should_run(PipelineStage.PROSPECTING, entry):
+            update("prospecting", 5)
+            logger.info("Sales pod [%s]: prospecting stage", job_id)
+            if request.existing_prospects:
+                prospects = request.existing_prospects
+            else:
+                raw = self.prospector.prospect(icp_json, product, vp, request.max_prospects, ctx)
+                prospects = _prospects_from_json(raw)
+            result.prospects = prospects
+            update("prospecting", 15)
+        else:
+            prospects = request.existing_prospects
+            result.prospects = prospects
+
+        if not prospects:
+            logger.warning("Sales pod [%s]: no prospects found — stopping pipeline", job_id)
+            result.summary = "No prospects found or provided. Pipeline halted."
+            return result
+
+        # ------------------------------------------------------------------
+        # Stage 2: Outreach
+        # ------------------------------------------------------------------
+        if self._should_run(PipelineStage.OUTREACH, entry):
+            update("outreach", 20)
+            logger.info("Sales pod [%s]: outreach stage for %d prospects", job_id, len(prospects))
+            sequences: List[OutreachSequence] = []
+            for p in prospects:
+                raw = self.outreach.generate_sequence(
+                    p.model_dump_json(indent=2), product, vp, cases, ctx
+                )
+                seq = _outreach_from_json(raw, p)
+                if seq:
+                    sequences.append(seq)
+            result.outreach_sequences = sequences
+            update("outreach", 35)
+
+        # ------------------------------------------------------------------
+        # Stage 3: Qualification
+        # ------------------------------------------------------------------
+        qualified: List[QualificationScore] = []
+        if self._should_run(PipelineStage.QUALIFICATION, entry):
+            update("qualification", 40)
+            logger.info("Sales pod [%s]: qualification stage", job_id)
+            for p in prospects:
+                raw = self.qualifier.qualify(p.model_dump_json(indent=2), product, vp, "")
+                score = _qual_from_json(raw, p)
+                if score:
+                    qualified.append(score)
+            result.qualified_leads = qualified
+            update("qualification", 50)
+
+        # Determine which prospects advance vs. go to nurture
+        if qualified:
+            advance = [q for q in qualified if q.recommended_action.lower().startswith("advance")]
+            nurture_prospects = [
+                q.prospect for q in qualified
+                if not q.recommended_action.lower().startswith("advance")
+                and not q.recommended_action.lower().startswith("disqualify")
+            ]
+        else:
+            # No qualification ran — advance all prospects
+            advance = []
+            nurture_prospects = []
+            qualified_all = prospects  # type: ignore[assignment]
+        qualified_prospects = [q.prospect for q in advance] if advance else prospects
+
+        # ------------------------------------------------------------------
+        # Stage 4: Nurturing
+        # ------------------------------------------------------------------
+        if self._should_run(PipelineStage.NURTURING, entry) and nurture_prospects:
+            update("nurturing", 55)
+            logger.info("Sales pod [%s]: nurturing %d prospects", job_id, len(nurture_prospects))
+            nurture_seqs: List[NurtureSequence] = []
+            for p in nurture_prospects:
+                raw = self.nurture.build_sequence(p.model_dump_json(indent=2), product, vp, 90)
+                seq = _nurture_from_json(raw, p, 90)
+                if seq:
+                    nurture_seqs.append(seq)
+            result.nurture_sequences = nurture_seqs
+            update("nurturing", 62)
+
+        # ------------------------------------------------------------------
+        # Stage 5: Discovery
+        # ------------------------------------------------------------------
+        if self._should_run(PipelineStage.DISCOVERY, entry) and qualified_prospects:
+            update("discovery", 65)
+            logger.info("Sales pod [%s]: discovery stage for %d prospects", job_id, len(qualified_prospects))
+            plans: List[DiscoveryPlan] = []
+            for p in qualified_prospects:
+                qual_json = "{}"
+                for q in qualified:
+                    if q.prospect.company_name == p.company_name:
+                        qual_json = q.model_dump_json(indent=2)
+                        break
+                raw = self.discovery.prepare(p.model_dump_json(indent=2), qual_json, product, vp)
+                plan = _discovery_from_json(raw, p)
+                if plan:
+                    plans.append(plan)
+            result.discovery_plans = plans
+            update("discovery", 75)
+
+        # ------------------------------------------------------------------
+        # Stage 6: Proposal
+        # ------------------------------------------------------------------
+        if self._should_run(PipelineStage.PROPOSAL, entry) and qualified_prospects:
+            update("proposal", 78)
+            logger.info("Sales pod [%s]: proposal stage for %d prospects", job_id, len(qualified_prospects))
+            proposals: List[SalesProposal] = []
+            annual_cost = 25000.0  # Default; real requests should supply per-prospect pricing
+            for p in qualified_prospects:
+                raw = self.proposal.write(
+                    p.model_dump_json(indent=2), product, vp, annual_cost, "", cases, ctx
+                )
+                prop = _proposal_from_json(raw, p, annual_cost)
+                if prop:
+                    proposals.append(prop)
+            result.proposals = proposals
+            update("proposal", 87)
+
+        # ------------------------------------------------------------------
+        # Stage 7: Negotiation / Closing
+        # ------------------------------------------------------------------
+        if self._should_run(PipelineStage.NEGOTIATION, entry) and qualified_prospects:
+            update("negotiation", 90)
+            logger.info("Sales pod [%s]: closing strategy stage", job_id)
+            strategies: List[ClosingStrategy] = []
+            for p in qualified_prospects:
+                prop_json = "{}"
+                for prop in result.proposals:
+                    if prop.prospect.company_name == p.company_name:
+                        prop_json = prop.model_dump_json(indent=2)
+                        break
+                raw = self.closer.develop_strategy(
+                    p.model_dump_json(indent=2), prop_json, product, vp
+                )
+                strat = _closing_from_json(raw, p)
+                if strat:
+                    strategies.append(strat)
+            result.closing_strategies = strategies
+            update("negotiation", 95)
+
+        # ------------------------------------------------------------------
+        # Final: Pipeline Coaching Report
+        # ------------------------------------------------------------------
+        update("coaching", 97)
+        logger.info("Sales pod [%s]: generating coaching report", job_id)
+        prospects_json = json.dumps([p.model_dump() for p in prospects], indent=2)
+        raw = self.coach.review(prospects_json, product, "")
+        coaching = _coaching_from_json(raw, len(prospects))
+        result.coaching_report = coaching
+
+        # Summary
+        result.summary = (
+            f"Sales pod completed pipeline from '{entry.value}' stage. "
+            f"Prospects identified: {len(result.prospects)}. "
+            f"Outreach sequences generated: {len(result.outreach_sequences)}. "
+            f"Leads qualified: {len(result.qualified_leads)}. "
+            f"Nurture sequences: {len(result.nurture_sequences)}. "
+            f"Discovery plans: {len(result.discovery_plans)}. "
+            f"Proposals written: {len(result.proposals)}. "
+            f"Closing strategies: {len(result.closing_strategies)}."
+        )
+
+        update("completed", 100)
+        logger.info("Sales pod [%s]: pipeline complete — %s", job_id, result.summary)
+        return result
+
+    # ------------------------------------------------------------------
+    # Convenience single-stage methods (used by standalone API endpoints)
+    # ------------------------------------------------------------------
+
+    def prospect_only(
+        self,
+        icp: IdealCustomerProfile,
+        product_name: str,
+        value_proposition: str,
+        max_prospects: int,
+        company_context: str,
+    ) -> List[Prospect]:
+        raw = self.prospector.prospect(
+            icp.model_dump_json(indent=2), product_name, value_proposition, max_prospects, company_context
+        )
+        return _prospects_from_json(raw)
+
+    def outreach_only(
+        self,
+        prospects: List[Prospect],
+        product_name: str,
+        value_proposition: str,
+        case_study_snippets: List[str],
+        company_context: str,
+    ) -> List[OutreachSequence]:
+        cases = "\n".join(case_study_snippets)
+        sequences = []
+        for p in prospects:
+            raw = self.outreach.generate_sequence(
+                p.model_dump_json(indent=2), product_name, value_proposition, cases, company_context
+            )
+            seq = _outreach_from_json(raw, p)
+            if seq:
+                sequences.append(seq)
+        return sequences
+
+    def qualify_only(
+        self, prospect: Prospect, product_name: str, value_proposition: str, call_notes: str
+    ) -> Optional[QualificationScore]:
+        raw = self.qualifier.qualify(
+            prospect.model_dump_json(indent=2), product_name, value_proposition, call_notes
+        )
+        return _qual_from_json(raw, prospect)
+
+    def nurture_only(
+        self,
+        prospects: List[Prospect],
+        product_name: str,
+        value_proposition: str,
+        duration_days: int,
+    ) -> List[NurtureSequence]:
+        sequences = []
+        for p in prospects:
+            raw = self.nurture.build_sequence(
+                p.model_dump_json(indent=2), product_name, value_proposition, duration_days
+            )
+            seq = _nurture_from_json(raw, p, duration_days)
+            if seq:
+                sequences.append(seq)
+        return sequences
+
+    def propose_only(self, req: ProposalRequest) -> Optional[SalesProposal]:
+        cases = "\n".join(req.case_study_snippets)
+        raw = self.proposal.write(
+            req.prospect.model_dump_json(indent=2),
+            req.product_name,
+            req.value_proposition,
+            req.annual_cost_usd,
+            req.discovery_notes,
+            cases,
+            req.company_context,
+        )
+        return _proposal_from_json(raw, req.prospect, req.annual_cost_usd)
+
+    def coach_only(
+        self, prospects: List[Prospect], product_name: str, pipeline_context: str
+    ) -> Optional[PipelineCoachingReport]:
+        prospects_json = json.dumps([p.model_dump() for p in prospects], indent=2)
+        raw = self.coach.review(prospects_json, product_name, pipeline_context)
+        return _coaching_from_json(raw, len(prospects))

--- a/backend/agents/sales_team/outcome_store.py
+++ b/backend/agents/sales_team/outcome_store.py
@@ -1,0 +1,278 @@
+"""Persistent file-backed store for sales outcome records and learned insights.
+
+Outcomes are written as individual JSON files under:
+  .agent_cache/sales_team/outcomes/stage/<id>.json
+  .agent_cache/sales_team/outcomes/deal/<id>.json
+
+The current LearningInsights snapshot is stored at:
+  .agent_cache/sales_team/insights/current.json
+
+Thread-safe via a single module-level lock (same process) and atomic
+file-writes (write to tmp then rename) for cross-process safety.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional
+
+from .models import DealOutcome, LearningInsights, StageOutcome
+
+logger = logging.getLogger(__name__)
+
+_LOCK = threading.Lock()
+_CACHE_ROOT = Path(os.getenv("AGENT_CACHE_DIR", ".agent_cache")) / "sales_team" / "outcomes"
+_INSIGHTS_PATH = Path(os.getenv("AGENT_CACHE_DIR", ".agent_cache")) / "sales_team" / "insights" / "current.json"
+
+
+def _now() -> str:
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def _atomic_write(path: Path, data: dict) -> None:
+    """Write JSON atomically: write to .tmp then rename."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _read_json(path: Path) -> Optional[dict]:
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        logger.warning("Could not read %s: %s", path, exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Public write API
+# ---------------------------------------------------------------------------
+
+
+def record_stage_outcome(outcome: StageOutcome) -> StageOutcome:
+    """Persist a stage outcome and return it with outcome_id and recorded_at set."""
+    with _LOCK:
+        oid = outcome.outcome_id or str(uuid.uuid4())
+        ts = outcome.recorded_at or _now()
+        filled = outcome.model_copy(update={"outcome_id": oid, "recorded_at": ts})
+        path = _CACHE_ROOT / "stage" / f"{oid}.json"
+        _atomic_write(path, filled.model_dump())
+        logger.debug("Recorded stage outcome %s for %s @ %s", oid, outcome.company_name, outcome.stage)
+        return filled
+
+
+def record_deal_outcome(outcome: DealOutcome) -> DealOutcome:
+    """Persist a deal outcome and return it with outcome_id and recorded_at set."""
+    with _LOCK:
+        oid = outcome.outcome_id or str(uuid.uuid4())
+        ts = outcome.recorded_at or _now()
+        filled = outcome.model_copy(update={"outcome_id": oid, "recorded_at": ts})
+        path = _CACHE_ROOT / "deal" / f"{oid}.json"
+        _atomic_write(path, filled.model_dump())
+        logger.debug("Recorded deal outcome %s for %s: %s", oid, outcome.company_name, outcome.result)
+        return filled
+
+
+# ---------------------------------------------------------------------------
+# Public read API
+# ---------------------------------------------------------------------------
+
+
+def load_stage_outcomes(limit: int = 500) -> List[StageOutcome]:
+    """Return up to *limit* stage outcomes, newest first."""
+    stage_dir = _CACHE_ROOT / "stage"
+    if not stage_dir.exists():
+        return []
+    files = sorted(stage_dir.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True)[:limit]
+    results = []
+    for f in files:
+        data = _read_json(f)
+        if data:
+            try:
+                results.append(StageOutcome(**data))
+            except Exception as exc:
+                logger.warning("Corrupt stage outcome file %s: %s", f, exc)
+    return results
+
+
+def load_deal_outcomes(limit: int = 500) -> List[DealOutcome]:
+    """Return up to *limit* deal outcomes, newest first."""
+    deal_dir = _CACHE_ROOT / "deal"
+    if not deal_dir.exists():
+        return []
+    files = sorted(deal_dir.glob("*.json"), key=lambda p: p.stat().st_mtime, reverse=True)[:limit]
+    results = []
+    for f in files:
+        data = _read_json(f)
+        if data:
+            try:
+                results.append(DealOutcome(**data))
+            except Exception as exc:
+                logger.warning("Corrupt deal outcome file %s: %s", f, exc)
+    return results
+
+
+def load_current_insights() -> Optional[LearningInsights]:
+    """Return the latest persisted LearningInsights, or None if never generated."""
+    data = _read_json(_INSIGHTS_PATH)
+    if not data:
+        return None
+    try:
+        return LearningInsights(**data)
+    except Exception as exc:
+        logger.warning("Could not parse insights: %s", exc)
+        return None
+
+
+def save_insights(insights: LearningInsights) -> None:
+    """Persist a refreshed LearningInsights snapshot."""
+    with _LOCK:
+        _atomic_write(_INSIGHTS_PATH, insights.model_dump())
+        logger.info("Saved learning insights v%d (%d outcomes)", insights.insights_version, insights.total_outcomes_analyzed)
+
+
+def outcome_counts() -> dict:
+    """Return a quick summary dict (no heavy parsing)."""
+    stage_dir = _CACHE_ROOT / "stage"
+    deal_dir = _CACHE_ROOT / "deal"
+    return {
+        "stage_outcomes": len(list(stage_dir.glob("*.json"))) if stage_dir.exists() else 0,
+        "deal_outcomes": len(list(deal_dir.glob("*.json"))) if deal_dir.exists() else 0,
+        "has_insights": _INSIGHTS_PATH.exists(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Heuristic fallback — compute basic insights without an LLM
+# ---------------------------------------------------------------------------
+
+
+def compute_heuristic_insights(
+    stage_outcomes: List[StageOutcome],
+    deal_outcomes: List[DealOutcome],
+    current_version: int = 0,
+) -> LearningInsights:
+    """Derive LearningInsights from raw outcome data using pure heuristics.
+
+    This runs when the Strands SDK is unavailable, ensuring the learning loop
+    always produces *something* useful.
+    """
+    from collections import Counter
+
+    total = len(deal_outcomes)
+    won = [d for d in deal_outcomes if d.result.value == "won"]
+    lost = [d for d in deal_outcomes if d.result.value == "lost"]
+    win_rate = round(len(won) / total, 3) if total else 0.0
+
+    # Top industries (by win count)
+    industry_wins: Counter[str] = Counter()
+    for d in won:
+        if d.industry:
+            industry_wins[d.industry] += 1
+    top_industries = [i for i, _ in industry_wins.most_common(3)]
+
+    # Common objections across all stage outcomes + deal outcomes
+    obj_counter: Counter[str] = Counter()
+    for s in stage_outcomes:
+        if s.objection_text:
+            obj_counter[s.objection_text] += 1
+    for d in deal_outcomes:
+        for obj in d.objections_raised:
+            obj_counter[obj] += 1
+    common_objections = [o for o, _ in obj_counter.most_common(5)]
+
+    # Best close techniques (by win association)
+    close_wins: Counter[str] = Counter()
+    for d in won:
+        if d.close_technique_used:
+            close_wins[d.close_technique_used.value] += 1
+    best_closes = [c for c, _ in close_wins.most_common(3)]
+
+    # Stage conversion rates from stage_outcomes
+    stage_counts: Counter[str] = Counter()
+    stage_converts: Counter[str] = Counter()
+    for s in stage_outcomes:
+        stage_counts[s.stage.value] += 1
+        if s.outcome.value == "converted":
+            stage_converts[s.stage.value] += 1
+    conversion_rates = {
+        stage: round(stage_converts[stage] / stage_counts[stage], 3)
+        for stage in stage_counts
+    }
+
+    # Win / loss patterns
+    loss_reasons: Counter[str] = Counter()
+    win_factors: Counter[str] = Counter()
+    for d in lost:
+        if d.loss_reason:
+            loss_reasons[d.loss_reason] += 1
+    for d in won:
+        if d.win_factor:
+            win_factors[d.win_factor] += 1
+    losing_patterns = [r for r, _ in loss_reasons.most_common(3)]
+    winning_patterns = [f for f, _ in win_factors.most_common(3)]
+
+    # Avg deal size and cycle
+    won_sizes = [d.deal_size_usd for d in won if d.deal_size_usd]
+    avg_deal = round(sum(won_sizes) / len(won_sizes), 2) if won_sizes else None
+    won_cycles = [d.sales_cycle_days for d in won if d.sales_cycle_days]
+    avg_cycle = round(sum(won_cycles) / len(won_cycles), 1) if won_cycles else None
+
+    # Email subject lines that drove replies
+    subject_counter: Counter[str] = Counter()
+    for s in stage_outcomes:
+        if s.stage.value == "outreach" and s.outcome.value == "converted" and s.subject_line_used:
+            subject_counter[s.subject_line_used] += 1
+    best_angles = [sl for sl, _ in subject_counter.most_common(3)]
+
+    # ICP signals from won deals
+    icp_signals: List[str] = []
+    high_score_wins = [d for d in won if d.icp_match_score and d.icp_match_score >= 0.75]
+    if high_score_wins:
+        icp_signals.append(f"ICP match ≥ 0.75 correlated with {len(high_score_wins)}/{len(won)} wins")
+    low_score_losses = [d for d in lost if d.icp_match_score and d.icp_match_score < 0.5]
+    if low_score_losses:
+        icp_signals.append(f"ICP match < 0.5 → {len(low_score_losses)}/{len(lost)} losses; tighten ICP filter")
+
+    # Actionable recommendations
+    recs: List[str] = []
+    if win_rate < 0.3 and total >= 5:
+        recs.append(f"Win rate is {win_rate:.0%} — review qualification criteria; disqualify low-BANT leads earlier")
+    if common_objections:
+        recs.append(f"Most common objection: '{common_objections[0]}' — prepare a pre-emptive response in proposals")
+    if best_closes:
+        recs.append(f"'{best_closes[0]}' close has highest win association — default to it for similar deals")
+    if top_industries:
+        recs.append(f"Focus prospecting on {', '.join(top_industries)} — highest win rates observed")
+    if not recs:
+        recs.append(
+            f"Pipeline has {total} recorded deal outcomes. "
+            "Keep logging outcomes to generate statistically reliable recommendations."
+        )
+
+    return LearningInsights(
+        total_outcomes_analyzed=len(stage_outcomes) + len(deal_outcomes),
+        win_rate=win_rate,
+        stage_conversion_rates=conversion_rates,
+        top_performing_industries=top_industries,
+        top_icp_signals=icp_signals,
+        best_outreach_angles=best_angles,
+        common_objections=common_objections,
+        best_close_techniques=best_closes,
+        winning_patterns=winning_patterns,
+        losing_patterns=losing_patterns,
+        avg_deal_size_won_usd=avg_deal,
+        avg_sales_cycle_days=avg_cycle,
+        actionable_recommendations=recs,
+        generated_at=_now(),
+        insights_version=current_version + 1,
+    )

--- a/backend/agents/sales_team/tests/test_sales_team.py
+++ b/backend/agents/sales_team/tests/test_sales_team.py
@@ -473,6 +473,21 @@ class TestAPI:
         response = api_client.delete("/sales/pipeline/job/nonexistent")
         assert response.status_code == 404
 
+    def test_delete_active_job_returns_409(self, api_client, sample_icp):
+        """Deleting a running job must be rejected with 409 — cancel first."""
+        payload = {
+            "product_name": "TestProduct",
+            "value_proposition": "We help sales teams close more deals faster",
+            "icp": sample_icp.model_dump(),
+            "max_prospects": 1,
+        }
+        run_resp = api_client.post("/sales/pipeline/run", json=payload)
+        assert run_resp.status_code == 200
+        job_id = run_resp.json()["job_id"]
+        # Job starts as running/pending — delete should fail
+        del_resp = api_client.delete(f"/sales/pipeline/job/{job_id}")
+        assert del_resp.status_code == 409
+
 
 # ---------------------------------------------------------------------------
 # Outcome store tests

--- a/backend/agents/sales_team/tests/test_sales_team.py
+++ b/backend/agents/sales_team/tests/test_sales_team.py
@@ -1,4 +1,4 @@
-"""Tests for the AI Sales Team pod.
+"""Tests for the AI Sales Team pod — including outcome tracking and learning loop.
 
 All tests run without the strands SDK installed (agents operate in stub mode),
 making them suitable for CI environments without AWS credentials.
@@ -7,6 +7,8 @@ making them suitable for CI environments without AWS credentials.
 from __future__ import annotations
 
 import json
+import tempfile
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -14,18 +16,25 @@ from fastapi.testclient import TestClient
 
 from sales_team.models import (
     BANTScore,
+    CloseType,
     CoachingRequest,
+    DealOutcome,
     ForecastCategory,
     IdealCustomerProfile,
+    LearningInsights,
     MEDDICScore,
     NurtureRequest,
+    OutcomeResult,
     OutreachRequest,
     PipelineStage,
     Prospect,
     ProspectingRequest,
     QualificationRequest,
+    RecordDealOutcomeRequest,
+    RecordStageOutcomeRequest,
     SalesPipelineRequest,
     SalesPipelineResult,
+    StageOutcome,
 )
 from sales_team.orchestrator import SalesPodOrchestrator, _parse_json, _prospects_from_json
 
@@ -463,3 +472,368 @@ class TestAPI:
     def test_delete_nonexistent_job(self, api_client):
         response = api_client.delete("/sales/pipeline/job/nonexistent")
         assert response.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Outcome store tests
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeStore:
+    """Test file-backed outcome persistence in isolation using a temp directory."""
+
+    @pytest.fixture(autouse=True)
+    def _tmp_cache(self, tmp_path, monkeypatch):
+        """Redirect all store I/O to a temporary directory."""
+        import sales_team.outcome_store as store
+
+        monkeypatch.setattr(store, "_CACHE_ROOT", tmp_path / "outcomes")
+        monkeypatch.setattr(store, "_INSIGHTS_PATH", tmp_path / "insights" / "current.json")
+
+    def test_record_and_load_stage_outcome(self):
+        from sales_team.outcome_store import load_stage_outcomes, record_stage_outcome
+
+        outcome = StageOutcome(
+            company_name="TestCo",
+            stage=PipelineStage.OUTREACH,
+            outcome=OutcomeResult.CONVERTED,
+            subject_line_used="Saw your Series B — quick thought",
+            email_touch_number=2,
+        )
+        saved = record_stage_outcome(outcome)
+
+        assert saved.outcome_id != ""
+        assert saved.recorded_at != ""
+
+        loaded = load_stage_outcomes()
+        assert len(loaded) == 1
+        assert loaded[0].company_name == "TestCo"
+        assert loaded[0].outcome == OutcomeResult.CONVERTED
+        assert loaded[0].subject_line_used == "Saw your Series B — quick thought"
+
+    def test_record_and_load_deal_outcome(self):
+        from sales_team.outcome_store import load_deal_outcomes, record_deal_outcome
+
+        outcome = DealOutcome(
+            company_name="WinCo",
+            industry="SaaS",
+            deal_size_usd=48000.0,
+            final_stage_reached=PipelineStage.NEGOTIATION,
+            result=OutcomeResult.WON,
+            win_factor="Champion + EB both engaged from discovery",
+            close_technique_used=CloseType.SUMMARY,
+            stages_completed=[PipelineStage.PROSPECTING, PipelineStage.OUTREACH, PipelineStage.QUALIFICATION],
+            icp_match_score=0.88,
+            qualification_score=0.79,
+            sales_cycle_days=34,
+        )
+        saved = record_deal_outcome(outcome)
+
+        assert saved.outcome_id != ""
+        loaded = load_deal_outcomes()
+        assert len(loaded) == 1
+        assert loaded[0].result == OutcomeResult.WON
+        assert loaded[0].deal_size_usd == 48000.0
+
+    def test_multiple_outcomes_sorted_newest_first(self):
+        from sales_team.outcome_store import load_stage_outcomes, record_stage_outcome
+
+        for i in range(3):
+            record_stage_outcome(StageOutcome(
+                company_name=f"Co{i}",
+                stage=PipelineStage.QUALIFICATION,
+                outcome=OutcomeResult.STALLED,
+            ))
+        loaded = load_stage_outcomes()
+        assert len(loaded) == 3
+
+    def test_outcome_counts(self):
+        from sales_team.outcome_store import outcome_counts, record_deal_outcome, record_stage_outcome
+
+        assert outcome_counts()["stage_outcomes"] == 0
+        record_stage_outcome(StageOutcome(
+            company_name="A", stage=PipelineStage.OUTREACH, outcome=OutcomeResult.CONVERTED
+        ))
+        assert outcome_counts()["stage_outcomes"] == 1
+
+    def test_save_and_load_insights(self):
+        from sales_team.outcome_store import load_current_insights, save_insights
+
+        insights = LearningInsights(
+            total_outcomes_analyzed=10,
+            win_rate=0.4,
+            top_performing_industries=["SaaS"],
+            insights_version=1,
+        )
+        save_insights(insights)
+        loaded = load_current_insights()
+        assert loaded is not None
+        assert loaded.win_rate == 0.4
+        assert loaded.insights_version == 1
+
+
+# ---------------------------------------------------------------------------
+# Heuristic learning engine tests
+# ---------------------------------------------------------------------------
+
+
+class TestHeuristicLearning:
+    """Test heuristic insight computation without requiring Strands SDK."""
+
+    def test_empty_outcomes(self):
+        from sales_team.outcome_store import compute_heuristic_insights
+
+        insights = compute_heuristic_insights([], [])
+        assert insights.total_outcomes_analyzed == 0
+        assert insights.win_rate == 0.0
+        assert len(insights.actionable_recommendations) > 0
+
+    def test_win_rate_calculation(self):
+        from sales_team.outcome_store import compute_heuristic_insights
+
+        deals = [
+            DealOutcome(
+                company_name=f"Co{i}",
+                final_stage_reached=PipelineStage.NEGOTIATION,
+                result=OutcomeResult.WON if i < 3 else OutcomeResult.LOST,
+            )
+            for i in range(5)
+        ]
+        insights = compute_heuristic_insights([], deals)
+        assert insights.win_rate == pytest.approx(0.6)
+
+    def test_top_industries_from_wins(self):
+        from sales_team.outcome_store import compute_heuristic_insights
+
+        deals = [
+            DealOutcome(
+                company_name=f"SaasCo{i}",
+                industry="SaaS",
+                final_stage_reached=PipelineStage.NEGOTIATION,
+                result=OutcomeResult.WON,
+            )
+            for i in range(3)
+        ] + [
+            DealOutcome(
+                company_name="FinCo",
+                industry="FinTech",
+                final_stage_reached=PipelineStage.NEGOTIATION,
+                result=OutcomeResult.LOST,
+            )
+        ]
+        insights = compute_heuristic_insights([], deals)
+        assert "SaaS" in insights.top_performing_industries
+
+    def test_common_objections_from_stage_outcomes(self):
+        from sales_team.outcome_store import compute_heuristic_insights
+
+        stages = [
+            StageOutcome(
+                company_name=f"Co{i}",
+                stage=PipelineStage.NEGOTIATION,
+                outcome=OutcomeResult.OBJECTION,
+                objection_text="Price is too high",
+            )
+            for i in range(4)
+        ]
+        insights = compute_heuristic_insights(stages, [])
+        assert "Price is too high" in insights.common_objections
+
+    def test_best_close_techniques_from_wins(self):
+        from sales_team.outcome_store import compute_heuristic_insights
+
+        deals = [
+            DealOutcome(
+                company_name=f"Co{i}",
+                final_stage_reached=PipelineStage.NEGOTIATION,
+                result=OutcomeResult.WON,
+                close_technique_used=CloseType.SUMMARY,
+            )
+            for i in range(3)
+        ]
+        insights = compute_heuristic_insights([], deals)
+        assert "summary" in insights.best_close_techniques
+
+    def test_stage_conversion_rates(self):
+        from sales_team.outcome_store import compute_heuristic_insights
+
+        stages = (
+            [StageOutcome(
+                company_name=f"Co{i}", stage=PipelineStage.OUTREACH, outcome=OutcomeResult.CONVERTED
+            ) for i in range(3)]
+            + [StageOutcome(
+                company_name=f"Co{i+3}", stage=PipelineStage.OUTREACH, outcome=OutcomeResult.STALLED
+            ) for i in range(1)]
+        )
+        insights = compute_heuristic_insights(stages, [])
+        assert "outreach" in insights.stage_conversion_rates
+        assert insights.stage_conversion_rates["outreach"] == pytest.approx(0.75)
+
+    def test_insights_version_increments(self):
+        from sales_team.outcome_store import compute_heuristic_insights
+
+        i1 = compute_heuristic_insights([], [], current_version=0)
+        i2 = compute_heuristic_insights([], [], current_version=i1.insights_version)
+        assert i2.insights_version == i1.insights_version + 1
+
+
+# ---------------------------------------------------------------------------
+# LearningEngine integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestLearningEngine:
+    @pytest.fixture(autouse=True)
+    def _tmp_cache(self, tmp_path, monkeypatch):
+        import sales_team.outcome_store as store
+
+        monkeypatch.setattr(store, "_CACHE_ROOT", tmp_path / "outcomes")
+        monkeypatch.setattr(store, "_INSIGHTS_PATH", tmp_path / "insights" / "current.json")
+
+    def test_refresh_empty_store(self):
+        from sales_team.learning_engine import LearningEngine
+
+        engine = LearningEngine()
+        insights = engine.refresh()
+        assert insights.total_outcomes_analyzed == 0
+        assert len(insights.actionable_recommendations) > 0
+
+    def test_refresh_with_outcomes(self):
+        from sales_team.learning_engine import LearningEngine
+        from sales_team.outcome_store import record_deal_outcome, record_stage_outcome
+
+        record_stage_outcome(StageOutcome(
+            company_name="A", stage=PipelineStage.OUTREACH, outcome=OutcomeResult.CONVERTED,
+            subject_line_used="Funding trigger hook"
+        ))
+        record_deal_outcome(DealOutcome(
+            company_name="A", industry="SaaS",
+            final_stage_reached=PipelineStage.NEGOTIATION,
+            result=OutcomeResult.WON,
+            close_technique_used=CloseType.SUMMARY,
+            sales_cycle_days=30,
+        ))
+
+        engine = LearningEngine()
+        insights = engine.refresh()
+        assert insights.total_outcomes_analyzed == 2
+        assert insights.win_rate == 1.0
+        assert insights.insights_version >= 1
+
+    def test_refresh_persists_insights(self):
+        from sales_team.learning_engine import LearningEngine
+        from sales_team.outcome_store import load_current_insights
+
+        engine = LearningEngine()
+        engine.refresh()
+        loaded = load_current_insights()
+        assert loaded is not None
+        assert loaded.insights_version >= 1
+
+    def test_format_insights_empty(self):
+        from sales_team.learning_engine import format_insights_for_prompt
+
+        assert format_insights_for_prompt(None) == ""
+        assert format_insights_for_prompt(LearningInsights()) == ""
+
+    def test_format_insights_with_data(self):
+        from sales_team.learning_engine import format_insights_for_prompt
+
+        insights = LearningInsights(
+            total_outcomes_analyzed=20,
+            win_rate=0.55,
+            winning_patterns=["Champion + EB both engaged"],
+            common_objections=["Price too high"],
+            best_close_techniques=["summary"],
+            actionable_recommendations=["Focus on SaaS"],
+            insights_version=3,
+        )
+        text = format_insights_for_prompt(insights)
+        assert "20 past outcomes" in text
+        assert "55%" in text
+        assert "Champion + EB" in text
+        assert "Price too high" in text
+        assert "summary" in text
+
+
+# ---------------------------------------------------------------------------
+# Outcome + insights API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestOutcomeAPI:
+    def test_record_stage_outcome(self, api_client, tmp_path, monkeypatch):
+        import sales_team.outcome_store as store
+
+        monkeypatch.setattr(store, "_CACHE_ROOT", tmp_path / "outcomes")
+        monkeypatch.setattr(store, "_INSIGHTS_PATH", tmp_path / "insights" / "current.json")
+
+        payload = {
+            "company_name": "Acme Corp",
+            "stage": "outreach",
+            "outcome": "converted",
+            "email_touch_number": 2,
+            "subject_line_used": "Congrats on your Series B",
+        }
+        response = api_client.post("/sales/outcomes/stage", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert "outcome_id" in data
+        assert data["outcome_id"] != ""
+
+    def test_record_deal_outcome_won(self, api_client, tmp_path, monkeypatch):
+        import sales_team.outcome_store as store
+
+        monkeypatch.setattr(store, "_CACHE_ROOT", tmp_path / "outcomes")
+        monkeypatch.setattr(store, "_INSIGHTS_PATH", tmp_path / "insights" / "current.json")
+
+        payload = {
+            "company_name": "WinCo",
+            "result": "won",
+            "final_stage_reached": "negotiation",
+            "deal_size_usd": 48000,
+            "win_factor": "Strong champion + EB both on final call",
+            "close_technique_used": "summary",
+            "stages_completed": ["prospecting", "outreach", "qualification"],
+            "sales_cycle_days": 28,
+        }
+        response = api_client.post("/sales/outcomes/deal", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert "won" in data["message"]
+
+    def test_outcome_summary(self, api_client):
+        response = api_client.get("/sales/outcomes/summary")
+        assert response.status_code == 200
+        data = response.json()
+        assert "stage_outcomes" in data
+        assert "deal_outcomes" in data
+
+    def test_insights_not_found_before_refresh(self, api_client, tmp_path, monkeypatch):
+        import sales_team.outcome_store as store
+
+        monkeypatch.setattr(store, "_CACHE_ROOT", tmp_path / "outcomes")
+        monkeypatch.setattr(store, "_INSIGHTS_PATH", tmp_path / "insights" / "current.json")
+
+        response = api_client.get("/sales/insights")
+        assert response.status_code == 404
+
+    def test_refresh_insights_endpoint(self, api_client, tmp_path, monkeypatch):
+        import sales_team.outcome_store as store
+
+        monkeypatch.setattr(store, "_CACHE_ROOT", tmp_path / "outcomes")
+        monkeypatch.setattr(store, "_INSIGHTS_PATH", tmp_path / "insights" / "current.json")
+
+        response = api_client.post("/sales/insights/refresh")
+        assert response.status_code == 200
+        data = response.json()
+        assert "insights_version" in data
+        assert data["insights_version"] >= 1
+
+    def test_health_includes_learning_stats(self, api_client):
+        response = api_client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert "stage_outcomes_recorded" in data
+        assert "deal_outcomes_recorded" in data
+        assert "insights_available" in data

--- a/backend/agents/sales_team/tests/test_sales_team.py
+++ b/backend/agents/sales_team/tests/test_sales_team.py
@@ -1,0 +1,465 @@
+"""Tests for the AI Sales Team pod.
+
+All tests run without the strands SDK installed (agents operate in stub mode),
+making them suitable for CI environments without AWS credentials.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from sales_team.models import (
+    BANTScore,
+    CoachingRequest,
+    ForecastCategory,
+    IdealCustomerProfile,
+    MEDDICScore,
+    NurtureRequest,
+    OutreachRequest,
+    PipelineStage,
+    Prospect,
+    ProspectingRequest,
+    QualificationRequest,
+    SalesPipelineRequest,
+    SalesPipelineResult,
+)
+from sales_team.orchestrator import SalesPodOrchestrator, _parse_json, _prospects_from_json
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sample_icp() -> IdealCustomerProfile:
+    return IdealCustomerProfile(
+        industry=["SaaS", "FinTech"],
+        company_size_min=50,
+        company_size_max=2000,
+        job_titles=["VP Sales", "CRO", "Head of Revenue"],
+        pain_points=["manual reporting", "long sales cycles", "poor pipeline visibility"],
+        budget_range_usd="$20k–$80k/yr",
+        geographic_focus=["United States", "Canada"],
+        tech_stack_keywords=["Salesforce", "HubSpot", "Outreach"],
+        disqualifying_traits=["non-profit", "government"],
+    )
+
+
+@pytest.fixture()
+def sample_prospect() -> Prospect:
+    return Prospect(
+        company_name="Acme Corp",
+        website="https://acme.example.com",
+        contact_name="Jane Smith",
+        contact_title="VP of Sales",
+        contact_email=None,
+        linkedin_url="https://linkedin.com/in/jane-smith-example",
+        company_size_estimate="200–500",
+        industry="SaaS",
+        icp_match_score=0.85,
+        research_notes="Recently raised Series B; hiring 10 AEs; uses Salesforce.",
+        trigger_events=["Series B funding announced"],
+    )
+
+
+@pytest.fixture()
+def orchestrator() -> SalesPodOrchestrator:
+    return SalesPodOrchestrator()
+
+
+@pytest.fixture()
+def api_client():
+    from sales_team.api.main import app
+
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Model tests
+# ---------------------------------------------------------------------------
+
+
+class TestModels:
+    def test_icp_defaults(self):
+        icp = IdealCustomerProfile()
+        assert icp.company_size_min == 10
+        assert icp.company_size_max == 5000
+        assert icp.industry == []
+
+    def test_prospect_score_bounds(self):
+        with pytest.raises(Exception):
+            Prospect(company_name="X", icp_match_score=1.5)
+
+        with pytest.raises(Exception):
+            Prospect(company_name="X", icp_match_score=-0.1)
+
+    def test_prospect_valid(self, sample_prospect):
+        assert sample_prospect.icp_match_score == 0.85
+        assert sample_prospect.company_name == "Acme Corp"
+
+    def test_bant_score_bounds(self):
+        with pytest.raises(Exception):
+            BANTScore(budget=11, authority=5, need=5, timeline=5)
+
+    def test_bant_score_valid(self):
+        bant = BANTScore(budget=7, authority=6, need=9, timeline=6)
+        assert bant.budget == 7
+
+    def test_pipeline_stage_enum(self):
+        assert PipelineStage.PROSPECTING.value == "prospecting"
+        assert PipelineStage.CLOSED_WON.value == "closed_won"
+
+    def test_sales_pipeline_request_defaults(self, sample_icp, sample_prospect):
+        req = SalesPipelineRequest(
+            product_name="AcmeSales",
+            value_proposition="Close more deals faster",
+            icp=sample_icp,
+        )
+        assert req.entry_stage == PipelineStage.PROSPECTING
+        assert req.max_prospects == 5
+        assert req.existing_prospects == []
+
+    def test_max_prospects_bounds(self, sample_icp):
+        with pytest.raises(Exception):
+            SalesPipelineRequest(
+                product_name="X",
+                value_proposition="Y",
+                icp=sample_icp,
+                max_prospects=25,
+            )
+
+
+# ---------------------------------------------------------------------------
+# Parser helper tests
+# ---------------------------------------------------------------------------
+
+
+class TestParsers:
+    def test_parse_json_valid(self):
+        result = _parse_json('{"key": "value"}', {})
+        assert result == {"key": "value"}
+
+    def test_parse_json_array(self):
+        result = _parse_json('[{"a": 1}]', [])
+        assert result == [{"a": 1}]
+
+    def test_parse_json_invalid_returns_fallback(self):
+        result = _parse_json("not valid json", {"fallback": True})
+        assert result == {"fallback": True}
+
+    def test_parse_json_empty_returns_fallback(self):
+        result = _parse_json("", [])
+        assert result == []
+
+    def test_parse_json_strips_markdown_fences(self):
+        raw = "```json\n{\"key\": 1}\n```"
+        result = _parse_json(raw, {})
+        assert result == {"key": 1}
+
+    def test_prospects_from_json_valid(self, sample_prospect):
+        data = json.dumps([sample_prospect.model_dump()])
+        prospects = _prospects_from_json(data)
+        assert len(prospects) == 1
+        assert prospects[0].company_name == "Acme Corp"
+
+    def test_prospects_from_json_invalid(self):
+        prospects = _prospects_from_json("not json at all")
+        assert prospects == []
+
+    def test_prospects_from_json_empty_array(self):
+        prospects = _prospects_from_json("[]")
+        assert prospects == []
+
+
+# ---------------------------------------------------------------------------
+# Agent stub tests (no strands SDK required)
+# ---------------------------------------------------------------------------
+
+
+class TestAgentStubs:
+    """Verify agents work correctly in stub mode (no strands SDK)."""
+
+    def test_prospector_returns_parseable_json(self, orchestrator, sample_icp):
+        raw = orchestrator.prospector.prospect(
+            sample_icp.model_dump_json(), "TestProduct", "We help X", 3, ""
+        )
+        data = json.loads(raw)
+        assert isinstance(data, list)
+        assert len(data) > 0
+        assert "company_name" in data[0]
+        assert "icp_match_score" in data[0]
+
+    def test_outreach_returns_parseable_json(self, orchestrator, sample_prospect):
+        raw = orchestrator.outreach.generate_sequence(
+            sample_prospect.model_dump_json(), "TestProduct", "We help X", "", ""
+        )
+        data = json.loads(raw)
+        assert "email_sequence" in data
+        assert "call_script" in data
+        assert "linkedin_message" in data
+
+    def test_qualifier_returns_parseable_json(self, orchestrator, sample_prospect):
+        raw = orchestrator.qualifier.qualify(
+            sample_prospect.model_dump_json(), "TestProduct", "We help X", ""
+        )
+        data = json.loads(raw)
+        assert "bant" in data
+        assert "meddic" in data
+        assert "overall_score" in data
+        assert 0.0 <= data["overall_score"] <= 1.0
+
+    def test_nurture_returns_parseable_json(self, orchestrator, sample_prospect):
+        raw = orchestrator.nurture.build_sequence(
+            sample_prospect.model_dump_json(), "TestProduct", "We help X", 90
+        )
+        data = json.loads(raw)
+        assert "touchpoints" in data
+        assert "re_engagement_triggers" in data
+        assert isinstance(data["touchpoints"], list)
+
+    def test_discovery_returns_parseable_json(self, orchestrator, sample_prospect):
+        raw = orchestrator.discovery.prepare(
+            sample_prospect.model_dump_json(), "{}", "TestProduct", "We help X"
+        )
+        data = json.loads(raw)
+        assert "spin_questions" in data
+        assert "situation" in data["spin_questions"]
+        assert "demo_agenda" in data
+
+    def test_proposal_returns_parseable_json(self, orchestrator, sample_prospect):
+        raw = orchestrator.proposal.write(
+            sample_prospect.model_dump_json(), "TestProduct", "We help X",
+            25000.0, "", "", ""
+        )
+        data = json.loads(raw)
+        assert "executive_summary" in data
+        assert "roi_model" in data
+        assert data["roi_model"]["annual_cost_usd"] == 25000.0
+
+    def test_closer_returns_parseable_json(self, orchestrator, sample_prospect):
+        raw = orchestrator.closer.develop_strategy(
+            sample_prospect.model_dump_json(), "{}", "TestProduct", "We help X"
+        )
+        data = json.loads(raw)
+        assert "recommended_close_technique" in data
+        assert "objection_handlers" in data
+
+    def test_coach_returns_parseable_json(self, orchestrator, sample_prospect):
+        raw = orchestrator.coach.review(
+            json.dumps([sample_prospect.model_dump()]), "TestProduct", ""
+        )
+        data = json.loads(raw)
+        assert "deal_risk_signals" in data
+        assert "coaching_summary" in data
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator integration tests
+# ---------------------------------------------------------------------------
+
+
+class TestOrchestrator:
+    def test_prospect_only(self, orchestrator, sample_icp):
+        prospects = orchestrator.prospect_only(sample_icp, "TestProduct", "We help X", 3, "")
+        assert isinstance(prospects, list)
+        assert len(prospects) > 0
+        assert all(hasattr(p, "company_name") for p in prospects)
+
+    def test_outreach_only(self, orchestrator, sample_prospect):
+        sequences = orchestrator.outreach_only(
+            [sample_prospect], "TestProduct", "We help X", [], ""
+        )
+        assert len(sequences) == 1
+        assert sequences[0].prospect.company_name == "Acme Corp"
+
+    def test_qualify_only(self, orchestrator, sample_prospect):
+        score = orchestrator.qualify_only(sample_prospect, "TestProduct", "We help X", "")
+        assert score is not None
+        assert 0.0 <= score.overall_score <= 1.0
+        assert score.value_creation_level in (1, 2, 3, 4)
+
+    def test_nurture_only(self, orchestrator, sample_prospect):
+        sequences = orchestrator.nurture_only([sample_prospect], "TestProduct", "We help X", 60)
+        assert len(sequences) == 1
+        assert sequences[0].duration_days > 0
+
+    def test_coach_only(self, orchestrator, sample_prospect):
+        report = orchestrator.coach_only([sample_prospect], "TestProduct", "")
+        assert report is not None
+        assert report.prospects_reviewed >= 0
+        assert isinstance(report.deal_risk_signals, list)
+
+    def test_should_run_logic(self, orchestrator):
+        assert orchestrator._should_run(PipelineStage.PROSPECTING, PipelineStage.PROSPECTING)
+        assert orchestrator._should_run(PipelineStage.OUTREACH, PipelineStage.PROSPECTING)
+        assert not orchestrator._should_run(PipelineStage.PROSPECTING, PipelineStage.OUTREACH)
+        assert orchestrator._should_run(PipelineStage.PROPOSAL, PipelineStage.PROPOSAL)
+
+    def test_full_pipeline_from_prospecting(self, orchestrator, sample_icp):
+        request = SalesPipelineRequest(
+            product_name="TestProduct",
+            value_proposition="We help sales teams close more deals faster",
+            icp=sample_icp,
+            max_prospects=1,
+        )
+        stages_called = []
+
+        def on_update(stage: str, pct: int) -> None:
+            stages_called.append(stage)
+
+        result = orchestrator.run(request, job_id="test-job-001", update_cb=on_update)
+
+        assert isinstance(result, SalesPipelineResult)
+        assert result.job_id == "test-job-001"
+        assert len(result.prospects) > 0
+        assert len(result.outreach_sequences) > 0
+        assert len(result.qualified_leads) > 0
+        assert "prospecting" in stages_called
+
+    def test_full_pipeline_with_existing_prospects(self, orchestrator, sample_prospect, sample_icp):
+        request = SalesPipelineRequest(
+            product_name="TestProduct",
+            value_proposition="We help sales teams close more deals faster",
+            icp=sample_icp,
+            entry_stage=PipelineStage.OUTREACH,
+            existing_prospects=[sample_prospect],
+        )
+        result = orchestrator.run(request, job_id="test-job-002")
+        # Should skip prospecting, start at outreach
+        assert len(result.outreach_sequences) > 0
+
+    def test_pipeline_stops_gracefully_with_no_prospects(self, orchestrator, sample_icp):
+        request = SalesPipelineRequest(
+            product_name="TestProduct",
+            value_proposition="We help sales teams close more deals faster",
+            icp=sample_icp,
+            entry_stage=PipelineStage.OUTREACH,
+            existing_prospects=[],
+        )
+        # Patch the outreach stage to skip since no prospects
+        result = orchestrator.run(request, job_id="test-job-003")
+        assert result.summary != ""
+
+
+# ---------------------------------------------------------------------------
+# API endpoint tests
+# ---------------------------------------------------------------------------
+
+
+class TestAPI:
+    def test_health(self, api_client):
+        response = api_client.get("/health")
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "ok"
+        assert "strands_sdk" in data
+
+    def test_prospect_endpoint(self, api_client, sample_icp):
+        payload = {
+            "icp": sample_icp.model_dump(),
+            "product_name": "TestProduct",
+            "value_proposition": "We help sales teams close faster",
+            "max_prospects": 2,
+        }
+        response = api_client.post("/sales/prospect", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert "prospects" in data
+        assert "count" in data
+        assert data["count"] >= 0
+
+    def test_outreach_endpoint(self, api_client, sample_prospect):
+        payload = {
+            "prospects": [sample_prospect.model_dump()],
+            "product_name": "TestProduct",
+            "value_proposition": "We help X",
+        }
+        response = api_client.post("/sales/outreach", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert "sequences" in data
+
+    def test_qualify_endpoint(self, api_client, sample_prospect):
+        payload = {
+            "prospect": sample_prospect.model_dump(),
+            "product_name": "TestProduct",
+            "value_proposition": "We help X",
+            "call_notes": "",
+        }
+        response = api_client.post("/sales/qualify", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert "overall_score" in data
+        assert "recommended_action" in data
+
+    def test_nurture_endpoint(self, api_client, sample_prospect):
+        payload = {
+            "prospects": [sample_prospect.model_dump()],
+            "product_name": "TestProduct",
+            "value_proposition": "We help X",
+            "duration_days": 30,
+        }
+        response = api_client.post("/sales/nurture", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert "sequences" in data
+
+    def test_proposal_endpoint(self, api_client, sample_prospect):
+        payload = {
+            "prospect": sample_prospect.model_dump(),
+            "product_name": "TestProduct",
+            "value_proposition": "We help X",
+            "annual_cost_usd": 24000.0,
+        }
+        response = api_client.post("/sales/proposal", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert "executive_summary" in data
+        assert "roi_model" in data
+
+    def test_coaching_endpoint(self, api_client, sample_prospect):
+        payload = {
+            "prospects": [sample_prospect.model_dump()],
+            "product_name": "TestProduct",
+            "pipeline_context": "",
+        }
+        response = api_client.post("/sales/coaching", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert "coaching_summary" in data
+        assert "deal_risk_signals" in data
+
+    def test_pipeline_run_returns_job_id(self, api_client, sample_icp):
+        payload = {
+            "product_name": "TestProduct",
+            "value_proposition": "We help sales teams close more deals faster",
+            "icp": sample_icp.model_dump(),
+            "max_prospects": 1,
+        }
+        response = api_client.post("/sales/pipeline/run", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert "job_id" in data
+        assert "status" in data
+
+    def test_pipeline_status_not_found(self, api_client):
+        response = api_client.get("/sales/pipeline/status/nonexistent-job-id")
+        assert response.status_code == 404
+
+    def test_pipeline_list_jobs(self, api_client):
+        response = api_client.get("/sales/pipeline/jobs")
+        assert response.status_code == 200
+        assert isinstance(response.json(), list)
+
+    def test_cancel_nonexistent_job(self, api_client):
+        response = api_client.post("/sales/pipeline/job/nonexistent/cancel")
+        assert response.status_code == 404
+
+    def test_delete_nonexistent_job(self, api_client):
+        response = api_client.delete("/sales/pipeline/job/nonexistent")
+        assert response.status_code == 404

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,6 @@
 python-dotenv>=1.0,<2.0
+strands-agents>=0.1
+strands-agents-tools>=0.1
 pydantic>=2.8,<3.0
 httpx>=0.27,<0.28
 PyYAML>=6.0,<7.0

--- a/backend/unified_api/config.py
+++ b/backend/unified_api/config.py
@@ -122,6 +122,15 @@ TEAM_CONFIGS: Dict[str, TeamConfig] = {
         description="Design-system multi-agent workflow: wireframes, design system, hi-fi, handoff",
         tags=["design", "ux"],
     ),
+    "sales_team": TeamConfig(
+        name="AI Sales Team",
+        prefix="/api/sales",
+        description=(
+            "Full B2B sales pod: prospecting, cold outreach, qualification, nurturing, "
+            "discovery, proposals, and closing — powered by AWS Strands agents"
+        ),
+        tags=["sales", "crm", "pipeline", "outreach"],
+    ),
 }
 
 

--- a/backend/unified_api/main.py
+++ b/backend/unified_api/main.py
@@ -112,6 +112,7 @@ SHUTDOWN_HOOKS: Dict[str, tuple] = {
     "accessibility_audit": ("accessibility_audit_team.api.main", "mark_all_running_jobs_failed"),
     "nutrition_meal_planning": ("nutrition_meal_planning_team.shared.job_store", "mark_all_running_jobs_failed"),
     "planning_v3": ("planning_v3_team.shared.job_store", "mark_all_running_jobs_failed"),
+    "sales_team": ("sales_team.api.main", "mark_all_running_jobs_failed"),
 }
 
 
@@ -350,6 +351,20 @@ def _try_mount_studio_grid(app: FastAPI) -> bool:
         return False
 
 
+def _try_mount_sales_team(app: FastAPI) -> bool:
+    """Mount AI Sales Team API."""
+    try:
+        from sales_team.api.main import app as sales_app
+
+        config = TEAM_CONFIGS["sales_team"]
+        app.mount(config.prefix, sales_app)
+        logger.info("Mounted %s at %s", config.name, config.prefix)
+        return True
+    except ImportError as e:
+        logger.warning("Could not mount Sales Team API: %s", e)
+        return False
+
+
 def mount_all_teams(app: FastAPI) -> Dict[str, bool]:
     """Mount all enabled team APIs and return mount status."""
     mount_functions = {
@@ -368,6 +383,7 @@ def mount_all_teams(app: FastAPI) -> Dict[str, bool]:
         "planning_v3": _try_mount_planning_v3,
         "coding_team": _try_mount_coding_team,
         "studio_grid": _try_mount_studio_grid,
+        "sales_team": _try_mount_sales_team,
     }
 
     results = {}
@@ -444,6 +460,7 @@ Unified API server providing access to all Strands Agent team capabilities.
 - **AI Systems** (`/api/ai-systems`) - Spec-driven AI agent system factory
 - **Investment** (`/api/investment`) - Investment analysis and portfolio management
 - **Nutrition & Meal Planning** (`/api/nutrition-meal-planning`) - Personal nutrition and meal planning with learning from feedback
+- **AI Sales Team** (`/api/sales`) - Full B2B sales pod: prospecting, outreach, qualification, nurturing, proposals, closing
 
 Each team's endpoints are available under their respective prefix.
 Visit the team-specific `/docs` endpoint for detailed API documentation

--- a/user-interface/src/app/app.routes.ts
+++ b/user-interface/src/app/app.routes.ts
@@ -16,6 +16,7 @@ import { AISystemsDashboardComponent } from './components/ai-systems-dashboard/a
 import { InvestmentDashboardComponent } from './components/investment-dashboard/investment-dashboard.component';
 import { IntegrationsDashboardComponent } from './components/integrations-dashboard/integrations-dashboard.component';
 import { StudioGridDashboardComponent } from './components/studio-grid-dashboard/studio-grid-dashboard.component';
+import { SalesDashboardComponent } from './components/sales-dashboard/sales-dashboard.component';
 
 export const routes: Routes = [
   {
@@ -39,6 +40,7 @@ export const routes: Routes = [
       { path: 'investment', component: InvestmentDashboardComponent },
       { path: 'integrations', component: IntegrationsDashboardComponent },
       { path: 'studio-grid', component: StudioGridDashboardComponent },
+      { path: 'sales', component: SalesDashboardComponent },
     ],
   },
   { path: '**', redirectTo: '/dashboard' },

--- a/user-interface/src/app/components/app-shell/app-shell.component.html
+++ b/user-interface/src/app/components/app-shell/app-shell.component.html
@@ -85,6 +85,14 @@
       </div>
 
       <div class="nav-group">
+        <div class="nav-group-label">Revenue</div>
+        <a routerLink="/sales" routerLinkActive="active" class="nav-link">
+          <mat-icon>trending_up</mat-icon>
+          <span>Sales</span>
+        </a>
+      </div>
+
+      <div class="nav-group">
         <div class="nav-group-label">Personal</div>
         <a routerLink="/personal-assistant" routerLinkActive="active" class="nav-link">
           <mat-icon>smart_toy</mat-icon>

--- a/user-interface/src/app/components/sales-dashboard/sales-dashboard.component.html
+++ b/user-interface/src/app/components/sales-dashboard/sales-dashboard.component.html
@@ -1,0 +1,154 @@
+<div class="sales-layout">
+
+  <!-- Page header -->
+  <div class="page-header">
+    <div class="page-title-row">
+      <mat-icon class="page-icon">trending_up</mat-icon>
+      <div>
+        <h1 class="page-title">AI Sales Team</h1>
+        <p class="page-subtitle">Autonomous B2B sales pipeline — prospect, qualify, propose, and close</p>
+      </div>
+    </div>
+  </div>
+
+  <!-- Main two-column layout -->
+  <div class="dashboard-columns">
+
+    <!-- Left: main content (tabs) -->
+    <div class="main-col">
+      <mat-tab-group
+        [(selectedIndex)]="activeTabIndex"
+        animationDuration="150ms"
+        class="sales-tabs"
+      >
+
+        <!-- Tab 0: Pipeline (configure + run) -->
+        <mat-tab>
+          <ng-template mat-tab-label>
+            <mat-icon class="tab-icon">rocket_launch</mat-icon>
+            Pipeline
+          </ng-template>
+          <div class="tab-content">
+            <app-sales-pipeline-form
+              (pipelineStarted)="onPipelineStarted($event)"
+            />
+          </div>
+        </mat-tab>
+
+        <!-- Tab 1: Results -->
+        <mat-tab>
+          <ng-template mat-tab-label>
+            <mat-icon class="tab-icon">bar_chart</mat-icon>
+            Results
+          </ng-template>
+          <div class="tab-content">
+            @if (selectedJobStatus && !isTerminal(selectedJobStatus.status)) {
+              <!-- Running job progress card -->
+              <mat-card class="progress-card">
+                <mat-card-content>
+                  <div class="progress-header">
+                    <mat-icon class="running-icon pulse">autorenew</mat-icon>
+                    <div>
+                      <div class="progress-title">{{ selectedJobStatus.product_name }} — running</div>
+                      <div class="progress-stage">
+                        Stage: <strong>{{ selectedJobStatus.current_stage ?? 'Starting…' }}</strong>
+                        @if (selectedJobStatus.eta_hint) {
+                          &nbsp;·&nbsp;{{ selectedJobStatus.eta_hint }}
+                        }
+                      </div>
+                    </div>
+                    <span class="spacer"></span>
+                    <span class="progress-pct">{{ ((selectedJobStatus.progress ?? 0) * 100) | number:'1.0-0' }}%</span>
+                  </div>
+                  <div class="progress-bar-wrap">
+                    <div class="progress-bar-fill" [style.width.%]="(selectedJobStatus.progress ?? 0) * 100"></div>
+                  </div>
+                </mat-card-content>
+              </mat-card>
+            }
+            <app-sales-pipeline-results [result]="selectedResult" />
+          </div>
+        </mat-tab>
+
+        <!-- Tab 2: Jobs history -->
+        <mat-tab>
+          <ng-template mat-tab-label>
+            <mat-icon class="tab-icon">history</mat-icon>
+            Jobs
+          </ng-template>
+          <div class="tab-content">
+            <div class="jobs-tab-grid">
+              @for (job of jobs; track job.job_id) {
+                <mat-card
+                  class="job-history-card"
+                  [class.selected]="job.job_id === selectedJobId"
+                  (click)="onJobSelected(job.job_id)"
+                >
+                  <mat-card-content>
+                    <div class="job-row">
+                      <div class="job-info">
+                        <span class="job-product">{{ job.product_name }}</span>
+                        <span class="job-meta">
+                          {{ job.current_stage ?? 'pending' }}
+                          @if (job.created_at) {
+                            &nbsp;·&nbsp;{{ job.created_at | date:'MMM d, h:mm a' }}
+                          }
+                        </span>
+                      </div>
+                      <div class="job-right">
+                        <span class="status-pill status-{{ job.status }}">{{ job.status }}</span>
+                        @if (isTerminal(job.status)) {
+                          <button
+                            mat-icon-button
+                            class="delete-btn"
+                            (click)="onJobDeleted(job.job_id); $event.stopPropagation()"
+                            title="Delete job"
+                          >
+                            <mat-icon>delete_outline</mat-icon>
+                          </button>
+                        }
+                      </div>
+                    </div>
+                    @if (!isTerminal(job.status)) {
+                      <div class="mini-progress-wrap">
+                        <div class="mini-progress-fill" [style.width.%]="(job.progress ?? 0) * 100"></div>
+                      </div>
+                    }
+                  </mat-card-content>
+                </mat-card>
+              } @empty {
+                <div class="empty-jobs">
+                  <mat-icon>inbox</mat-icon>
+                  <p>No pipeline jobs yet. Configure and run a pipeline from the Pipeline tab.</p>
+                </div>
+              }
+            </div>
+          </div>
+        </mat-tab>
+
+        <!-- Tab 3: Learning -->
+        <mat-tab>
+          <ng-template mat-tab-label>
+            <mat-icon class="tab-icon">school</mat-icon>
+            Learning
+          </ng-template>
+          <div class="tab-content">
+            <app-sales-learning-panel />
+          </div>
+        </mat-tab>
+
+      </mat-tab-group>
+    </div>
+
+    <!-- Right: jobs sidebar -->
+    <div class="sidebar-col">
+      <app-sales-jobs-panel
+        [jobs]="jobs"
+        [selectedJobId]="selectedJobId"
+        (jobSelected)="onJobSelected($event)"
+        (jobDeleted)="onJobDeleted($event)"
+      />
+    </div>
+
+  </div>
+</div>

--- a/user-interface/src/app/components/sales-dashboard/sales-dashboard.component.scss
+++ b/user-interface/src/app/components/sales-dashboard/sales-dashboard.component.scss
@@ -1,0 +1,289 @@
+.sales-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  padding: 1.5rem;
+  max-width: 1600px;
+  margin: 0 auto;
+}
+
+// ── Page header ─────────────────────────────────────────────────────────────
+
+.page-header {
+  padding-bottom: 0.25rem;
+}
+
+.page-title-row {
+  display: flex;
+  align-items: center;
+  gap: 0.875rem;
+}
+
+.page-icon {
+  font-size: 2rem;
+  width: 2rem;
+  height: 2rem;
+  color: var(--mat-sys-primary, #3b82f6);
+}
+
+.page-title {
+  margin: 0;
+  font-size: 1.5rem;
+  font-weight: 700;
+  line-height: 1.2;
+  color: var(--mat-sys-on-surface, #e6edf3);
+}
+
+.page-subtitle {
+  margin: 0.2rem 0 0;
+  font-size: 0.875rem;
+  color: var(--mat-sys-on-surface-variant, rgba(230, 237, 243, 0.6));
+}
+
+// ── Two-column layout ────────────────────────────────────────────────────────
+
+.dashboard-columns {
+  display: flex;
+  gap: 1.25rem;
+  align-items: flex-start;
+}
+
+.main-col {
+  flex: 1;
+  min-width: 0;
+}
+
+.sidebar-col {
+  width: 360px;
+  flex-shrink: 0;
+  position: sticky;
+  top: 1rem;
+}
+
+// ── Tabs ─────────────────────────────────────────────────────────────────────
+
+.sales-tabs {
+  .tab-icon {
+    font-size: 1.125rem;
+    width: 1.125rem;
+    height: 1.125rem;
+    margin-right: 0.375rem;
+    vertical-align: middle;
+  }
+}
+
+.tab-content {
+  padding: 1.25rem 0 0;
+}
+
+// ── Running job progress card ────────────────────────────────────────────────
+
+.progress-card {
+  margin-bottom: 1rem;
+  border: 1px solid var(--mat-sys-outline-variant, rgba(48, 54, 61, 0.8));
+}
+
+.progress-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 0.625rem;
+}
+
+.running-icon {
+  color: var(--mat-sys-primary, #3b82f6);
+  font-size: 1.375rem;
+  width: 1.375rem;
+  height: 1.375rem;
+  flex-shrink: 0;
+}
+
+.pulse {
+  animation: spin 1.6s linear infinite;
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to   { transform: rotate(360deg); }
+}
+
+.progress-title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--mat-sys-on-surface, #e6edf3);
+}
+
+.progress-stage {
+  font-size: 0.8125rem;
+  color: var(--mat-sys-on-surface-variant, rgba(230, 237, 243, 0.6));
+  margin-top: 0.15rem;
+}
+
+.spacer {
+  flex: 1;
+}
+
+.progress-pct {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: var(--mat-sys-primary, #3b82f6);
+  flex-shrink: 0;
+}
+
+.progress-bar-wrap {
+  height: 6px;
+  border-radius: 3px;
+  background: var(--mat-sys-surface-container, rgba(255, 255, 255, 0.06));
+  overflow: hidden;
+}
+
+.progress-bar-fill {
+  height: 100%;
+  border-radius: 3px;
+  background: var(--mat-sys-primary, #3b82f6);
+  transition: width 0.4s ease;
+  min-width: 2px;
+}
+
+// ── Jobs history tab ─────────────────────────────────────────────────────────
+
+.jobs-tab-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.job-history-card {
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+  border: 1px solid var(--mat-sys-outline-variant, rgba(48, 54, 61, 0.8));
+
+  &:hover {
+    border-color: var(--mat-sys-primary, #3b82f6);
+  }
+
+  &.selected {
+    border-color: var(--mat-sys-primary, #3b82f6);
+    background: rgba(59, 130, 246, 0.06);
+  }
+}
+
+.job-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.job-info {
+  display: flex;
+  flex-direction: column;
+  gap: 0.15rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.job-product {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  color: var(--mat-sys-on-surface, #e6edf3);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.job-meta {
+  font-size: 0.75rem;
+  color: var(--mat-sys-on-surface-variant, rgba(230, 237, 243, 0.5));
+}
+
+.job-right {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  flex-shrink: 0;
+}
+
+.delete-btn {
+  opacity: 0.4;
+  transition: opacity 0.15s;
+  width: 1.75rem;
+  height: 1.75rem;
+  font-size: 1rem;
+
+  .job-history-card:hover & {
+    opacity: 0.8;
+  }
+}
+
+.mini-progress-wrap {
+  height: 3px;
+  border-radius: 2px;
+  background: var(--mat-sys-surface-container, rgba(255, 255, 255, 0.06));
+  overflow: hidden;
+  margin-top: 0.5rem;
+}
+
+.mini-progress-fill {
+  height: 100%;
+  border-radius: 2px;
+  background: var(--mat-sys-primary, #3b82f6);
+  transition: width 0.4s ease;
+  min-width: 2px;
+}
+
+// ── Status pills ─────────────────────────────────────────────────────────────
+
+.status-pill {
+  display: inline-block;
+  padding: 0.15rem 0.55rem;
+  border-radius: 20px;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+
+  &.status-running  { background: rgba(59, 130, 246, 0.15); color: #58a6ff; }
+  &.status-pending  { background: rgba(139, 148, 158, 0.12); color: #8b949e; }
+  &.status-completed { background: rgba(46, 160, 67, 0.15); color: #3fb950; }
+  &.status-failed   { background: rgba(248, 81, 73, 0.15); color: #f85149; }
+  &.status-cancelled { background: rgba(139, 148, 158, 0.1); color: #6e7681; }
+}
+
+// ── Empty state ───────────────────────────────────────────────────────────────
+
+.empty-jobs {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 3rem 1rem;
+  text-align: center;
+  color: var(--mat-sys-on-surface-variant, rgba(230, 237, 243, 0.4));
+
+  mat-icon {
+    font-size: 2.5rem;
+    width: 2.5rem;
+    height: 2.5rem;
+    opacity: 0.35;
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.9rem;
+    max-width: 360px;
+    line-height: 1.5;
+  }
+}
+
+// ── Responsive ────────────────────────────────────────────────────────────────
+
+@media (max-width: 1024px) {
+  .dashboard-columns {
+    flex-direction: column;
+  }
+
+  .sidebar-col {
+    width: 100%;
+    position: static;
+  }
+}

--- a/user-interface/src/app/components/sales-dashboard/sales-dashboard.component.ts
+++ b/user-interface/src/app/components/sales-dashboard/sales-dashboard.component.ts
@@ -1,0 +1,154 @@
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { Subscription, timer } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { SalesApiService } from '../../services/sales-api.service';
+import { SalesPipelineFormComponent } from '../sales-pipeline-form/sales-pipeline-form.component';
+import { SalesPipelineResultsComponent } from '../sales-pipeline-results/sales-pipeline-results.component';
+import { SalesJobsPanelComponent } from '../sales-jobs-panel/sales-jobs-panel.component';
+import { SalesLearningPanelComponent } from '../sales-learning-panel/sales-learning-panel.component';
+import type { SalesPipelineJobListItem, SalesPipelineResult, SalesPipelineStatusResponse } from '../../models';
+
+const TERMINAL_STATUSES = ['completed', 'failed', 'cancelled'] as const;
+const POLL_JOBS_MS = 12000;
+const POLL_STATUS_MS = 2000;
+
+@Component({
+  selector: 'app-sales-dashboard',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatTabsModule,
+    MatCardModule,
+    MatIconModule,
+    MatButtonModule,
+    MatSnackBarModule,
+    SalesPipelineFormComponent,
+    SalesPipelineResultsComponent,
+    SalesJobsPanelComponent,
+    SalesLearningPanelComponent,
+  ],
+  templateUrl: './sales-dashboard.component.html',
+  styleUrl: './sales-dashboard.component.scss',
+})
+export class SalesDashboardComponent implements OnInit, OnDestroy {
+  private readonly api = inject(SalesApiService);
+  private readonly snackBar = inject(MatSnackBar);
+
+  private jobsSub: Subscription | null = null;
+  private statusPollSub: Subscription | null = null;
+
+  jobs: SalesPipelineJobListItem[] = [];
+  selectedJobId: string | null = null;
+  selectedJobStatus: SalesPipelineStatusResponse | null = null;
+  selectedResult: SalesPipelineResult | null = null;
+  activeTabIndex = 0; // 0=Pipeline, 1=Results, 2=Jobs, 3=Learning
+
+  isTerminal(status: string): boolean {
+    return (TERMINAL_STATUSES as readonly string[]).includes(status);
+  }
+
+  ngOnInit(): void {
+    this.jobsSub = timer(0, POLL_JOBS_MS).pipe(
+      switchMap(() => this.api.listPipelineJobs())
+    ).subscribe({
+      next: (jobs) => {
+        this.jobs = jobs;
+        // If selected job disappeared, clear selection
+        if (this.selectedJobId && !jobs.find(j => j.job_id === this.selectedJobId)) {
+          this.clearSelection();
+        }
+      },
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.jobsSub?.unsubscribe();
+    this.statusPollSub?.unsubscribe();
+  }
+
+  onPipelineStarted(jobId: string): void {
+    this.selectedJobId = jobId;
+    this.selectedResult = null;
+    this.startStatusPoll(jobId);
+    // Optimistically add the job to the list
+    this.api.listPipelineJobs().subscribe({
+      next: (jobs) => { this.jobs = jobs; },
+    });
+  }
+
+  onJobSelected(jobId: string): void {
+    if (this.selectedJobId === jobId) return;
+    this.selectedJobId = jobId;
+    this.selectedResult = null;
+    this.statusPollSub?.unsubscribe();
+    const job = this.jobs.find(j => j.job_id === jobId);
+    if (job && this.isTerminal(job.status)) {
+      this.loadJobResult(jobId);
+    } else {
+      this.startStatusPoll(jobId);
+    }
+  }
+
+  onJobDeleted(jobId: string): void {
+    this.api.deleteJob(jobId).subscribe({
+      next: () => {
+        if (this.selectedJobId === jobId) this.clearSelection();
+        this.api.listPipelineJobs().subscribe({ next: (jobs) => { this.jobs = jobs; } });
+      },
+      error: (err) => {
+        this.snackBar.open(err?.error?.detail ?? 'Failed to delete job.', 'Dismiss', { duration: 3000 });
+      },
+    });
+  }
+
+  private startStatusPoll(jobId: string): void {
+    this.statusPollSub?.unsubscribe();
+    this.statusPollSub = timer(0, POLL_STATUS_MS).pipe(
+      switchMap(() => this.api.getPipelineStatus(jobId))
+    ).subscribe({
+      next: (status) => {
+        this.selectedJobStatus = status;
+        // Update the job in the list with fresh progress
+        this.jobs = this.jobs.map(j =>
+          j.job_id === jobId
+            ? { ...j, status: status.status, progress: status.progress, current_stage: status.current_stage }
+            : j
+        );
+        if (this.isTerminal(status.status)) {
+          this.statusPollSub?.unsubscribe();
+          if (status.status === 'completed') {
+            this.loadJobResult(jobId);
+          } else if (status.status === 'failed') {
+            this.snackBar.open(`Pipeline failed: ${status.error ?? 'Unknown error'}`, 'Dismiss', { duration: 5000 });
+          }
+        }
+      },
+    });
+  }
+
+  private loadJobResult(jobId: string): void {
+    this.api.getPipelineStatus(jobId).subscribe({
+      next: (status) => {
+        this.selectedJobStatus = status;
+        if (status.result) {
+          this.selectedResult = status.result;
+          this.activeTabIndex = 1; // Auto-switch to Results tab
+        }
+      },
+    });
+  }
+
+  private clearSelection(): void {
+    this.selectedJobId = null;
+    this.selectedJobStatus = null;
+    this.selectedResult = null;
+    this.statusPollSub?.unsubscribe();
+    this.statusPollSub = null;
+  }
+}

--- a/user-interface/src/app/components/sales-jobs-panel/sales-jobs-panel.component.html
+++ b/user-interface/src/app/components/sales-jobs-panel/sales-jobs-panel.component.html
@@ -1,0 +1,84 @@
+<mat-card class="jobs-card">
+  <mat-card-header>
+    <mat-card-title>
+      <mat-icon>work_history</mat-icon>
+      Pipeline Runs
+    </mat-card-title>
+  </mat-card-header>
+
+  <mat-card-content>
+    @if (jobs.length === 0) {
+      <p class="no-jobs">No pipeline runs yet. Configure and run your first sales pipeline above.</p>
+    }
+
+    @if (runningJobs.length > 0) {
+      <div class="jobs-list-section">
+        <p class="list-section-title">Running</p>
+        <div class="jobs-list">
+          @for (job of runningJobs; track job.job_id) {
+            <button
+              class="job-item"
+              [class.selected]="selectedJobId === job.job_id"
+              (click)="selectJob(job.job_id)"
+            >
+              <div class="job-item-top">
+                <span class="job-brief">{{ job.product_name }}</span>
+                <span class="job-status-pill status-{{ job.status }}">{{ job.status }}</span>
+              </div>
+              <div class="job-stage">
+                <mat-icon class="stage-icon">{{ job.status === 'pending' ? 'schedule' : 'sync' }}</mat-icon>
+                {{ stageLabel(job.current_stage) }}
+              </div>
+              <mat-progress-bar
+                mode="determinate"
+                [value]="job.progress"
+                class="job-progress"
+              />
+              <span class="job-time">{{ timeAgo(job.last_updated_at) }}</span>
+            </button>
+          }
+        </div>
+      </div>
+    }
+
+    @if (completedJobs.length > 0) {
+      <div class="jobs-list-section">
+        @if (runningJobs.length > 0) {
+          <div class="panel-divider"></div>
+        }
+        <p class="list-section-title">Recent Runs</p>
+        <div class="jobs-list">
+          @for (job of completedJobs; track job.job_id) {
+            <button
+              class="job-item"
+              [class.selected]="selectedJobId === job.job_id"
+              (click)="selectJob(job.job_id)"
+            >
+              <div class="job-item-top">
+                <span class="job-brief">{{ job.product_name }}</span>
+                <div class="job-item-actions">
+                  <span class="job-status-pill status-{{ job.status }}">{{ job.status }}</span>
+                  @if (isTerminal(job)) {
+                    <button
+                      mat-icon-button
+                      class="delete-btn"
+                      [matTooltip]="'Delete job'"
+                      (click)="deleteJob($event, job.job_id)"
+                    >
+                      <mat-icon>delete_outline</mat-icon>
+                    </button>
+                  }
+                </div>
+              </div>
+              <div class="job-stage">
+                <mat-icon class="stage-icon">{{ job.status === 'completed' ? 'check_circle' : 'error_outline' }}</mat-icon>
+                {{ stageLabel(job.current_stage) }}
+              </div>
+              <span class="job-time">{{ timeAgo(job.last_updated_at) }}</span>
+            </button>
+          }
+        </div>
+      </div>
+    }
+  </mat-card-content>
+</mat-card>

--- a/user-interface/src/app/components/sales-jobs-panel/sales-jobs-panel.component.scss
+++ b/user-interface/src/app/components/sales-jobs-panel/sales-jobs-panel.component.scss
@@ -1,0 +1,179 @@
+.jobs-card {
+  mat-card-header {
+    mat-card-title {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-size: 0.9375rem;
+      font-weight: 600;
+
+      mat-icon {
+        color: var(--mat-sys-primary);
+        font-size: 1.125rem;
+        width: 1.125rem;
+        height: 1.125rem;
+      }
+    }
+  }
+
+  mat-card-content {
+    padding-top: 0.5rem;
+  }
+}
+
+.no-jobs {
+  margin: 0.5rem 0;
+  font-size: 0.875rem;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+  line-height: 1.4;
+}
+
+.jobs-list-section {
+  margin-bottom: 0.5rem;
+}
+
+.list-section-title {
+  margin: 0 0 0.5rem 0;
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+}
+
+.jobs-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.job-item {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  text-align: left;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.12));
+  border-radius: 6px;
+  background: transparent;
+  cursor: pointer;
+  width: 100%;
+  gap: 0.3rem;
+  transition: background 0.15s, border-color 0.15s;
+
+  &:hover {
+    background: var(--mat-sys-surface-container-highest, rgba(0, 0, 0, 0.04));
+  }
+
+  &.selected {
+    border-color: var(--mat-sys-primary);
+    background: var(--mat-sys-surface-container-high, rgba(25, 118, 210, 0.08));
+  }
+}
+
+.job-item-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  gap: 0.5rem;
+}
+
+.job-item-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  flex-shrink: 0;
+}
+
+.job-brief {
+  font-weight: 500;
+  font-size: 0.875rem;
+  line-height: 1.3;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+  color: var(--mat-sys-on-surface, rgba(0, 0, 0, 0.87));
+}
+
+.job-stage {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.75rem;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+
+  .stage-icon {
+    font-size: 0.875rem;
+    width: 0.875rem;
+    height: 0.875rem;
+  }
+}
+
+.job-progress {
+  width: 100%;
+  height: 3px;
+  border-radius: 2px;
+}
+
+.job-time {
+  font-size: 0.6875rem;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.45));
+}
+
+.job-status-pill {
+  flex-shrink: 0;
+  padding: 0.15rem 0.45rem;
+  border-radius: 4px;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+  line-height: 1.5;
+
+  &.status-running,
+  &.status-pending {
+    background: var(--mat-sys-primary-container, #e3f2fd);
+    color: var(--mat-sys-on-primary-container, #1565c0);
+  }
+
+  &.status-completed {
+    background: var(--mat-sys-tertiary-container, #e8f5e9);
+    color: var(--mat-sys-on-tertiary-container, #2e7d32);
+  }
+
+  &.status-failed {
+    background: var(--mat-sys-error-container, #ffebee);
+    color: var(--mat-sys-on-error-container, #c62828);
+  }
+
+  &.status-cancelled {
+    background: var(--mat-sys-surface-variant, #f5f5f5);
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+  }
+}
+
+.delete-btn {
+  width: 24px;
+  height: 24px;
+  line-height: 24px;
+  opacity: 0.6;
+
+  mat-icon {
+    font-size: 1rem;
+    width: 1rem;
+    height: 1rem;
+  }
+
+  &:hover {
+    opacity: 1;
+    color: var(--mat-sys-error, #c62828);
+  }
+}
+
+.panel-divider {
+  border-top: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.12));
+  margin: 0.75rem 0;
+}

--- a/user-interface/src/app/components/sales-jobs-panel/sales-jobs-panel.component.ts
+++ b/user-interface/src/app/components/sales-jobs-panel/sales-jobs-panel.component.ts
@@ -1,0 +1,66 @@
+import { Component, Input, Output, EventEmitter, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatButtonModule } from '@angular/material/button';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import type { SalesPipelineJobListItem } from '../../models';
+
+@Component({
+  selector: 'app-sales-jobs-panel',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    CommonModule,
+    MatCardModule,
+    MatIconModule,
+    MatButtonModule,
+    MatProgressBarModule,
+    MatTooltipModule,
+  ],
+  templateUrl: './sales-jobs-panel.component.html',
+  styleUrl: './sales-jobs-panel.component.scss',
+})
+export class SalesJobsPanelComponent {
+  @Input() jobs: SalesPipelineJobListItem[] = [];
+  @Input() selectedJobId: string | null = null;
+  @Output() jobSelected = new EventEmitter<string>();
+  @Output() jobDeleted = new EventEmitter<string>();
+
+  get runningJobs(): SalesPipelineJobListItem[] {
+    return this.jobs.filter(j => j.status === 'running' || j.status === 'pending');
+  }
+
+  get completedJobs(): SalesPipelineJobListItem[] {
+    return this.jobs.filter(j => j.status !== 'running' && j.status !== 'pending');
+  }
+
+  isTerminal(job: SalesPipelineJobListItem): boolean {
+    return job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled';
+  }
+
+  stageLabel(stage: string): string {
+    return stage.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+  }
+
+  timeAgo(isoString?: string): string {
+    if (!isoString) return '';
+    const diff = Date.now() - new Date(isoString).getTime();
+    const mins = Math.floor(diff / 60000);
+    if (mins < 1) return 'just now';
+    if (mins < 60) return `${mins}m ago`;
+    const hrs = Math.floor(mins / 60);
+    if (hrs < 24) return `${hrs}h ago`;
+    return `${Math.floor(hrs / 24)}d ago`;
+  }
+
+  selectJob(jobId: string): void {
+    this.jobSelected.emit(jobId);
+  }
+
+  deleteJob(event: MouseEvent, jobId: string): void {
+    event.stopPropagation();
+    this.jobDeleted.emit(jobId);
+  }
+}

--- a/user-interface/src/app/components/sales-learning-panel/sales-learning-panel.component.html
+++ b/user-interface/src/app/components/sales-learning-panel/sales-learning-panel.component.html
@@ -1,0 +1,407 @@
+<div class="learning-layout">
+
+  <!-- ================================================================== -->
+  <!-- Insights panel                                                       -->
+  <!-- ================================================================== -->
+  <mat-card class="insights-card">
+    <mat-card-header>
+      <mat-card-title>
+        <mat-icon>lightbulb</mat-icon>
+        Learning Insights
+      </mat-card-title>
+      <mat-card-subtitle>Patterns extracted from recorded pipeline outcomes</mat-card-subtitle>
+    </mat-card-header>
+
+    <mat-card-content>
+      @if (loadingInsights) {
+        <div class="loading-row">
+          <mat-progress-spinner diameter="24" mode="indeterminate" />
+          <span>Loading insights…</span>
+        </div>
+      } @else if (insightsError) {
+        <div class="error-block">
+          <mat-icon>error_outline</mat-icon>
+          {{ insightsError }}
+        </div>
+      } @else if (!insights || insights.total_outcomes_analyzed === 0) {
+        <div class="empty-insights">
+          <mat-icon>analytics</mat-icon>
+          <p>No insights yet. Record deal outcomes below, then click <strong>Refresh Insights</strong> to generate patterns.</p>
+          <p class="empty-sub">Every pipeline run automatically logs prospecting outcomes. Win/loss data needs to be logged manually after each deal closes.</p>
+        </div>
+      } @else {
+        <!-- Stats row -->
+        <div class="insights-stats">
+          <div class="stat-block">
+            <span class="stat-val win-rate">{{ winRatePercent() }}%</span>
+            <span class="stat-label">Win Rate</span>
+          </div>
+          <div class="stat-block">
+            <span class="stat-val">{{ insights.total_outcomes_analyzed }}</span>
+            <span class="stat-label">Outcomes analyzed</span>
+          </div>
+          <div class="stat-block">
+            <span class="stat-val">v{{ insights.insights_version }}</span>
+            <span class="stat-label">Insights version</span>
+          </div>
+          @if (insights.avg_deal_size_won_usd) {
+            <div class="stat-block">
+              <span class="stat-val">${{ insights.avg_deal_size_won_usd | number:'1.0-0' }}</span>
+              <span class="stat-label">Avg deal size (won)</span>
+            </div>
+          }
+          @if (insights.avg_sales_cycle_days) {
+            <div class="stat-block">
+              <span class="stat-val">{{ insights.avg_sales_cycle_days | number:'1.0-0' }}d</span>
+              <span class="stat-label">Avg cycle (won)</span>
+            </div>
+          }
+        </div>
+
+        <!-- Patterns two-col -->
+        @if (insights.winning_patterns.length || insights.losing_patterns.length) {
+          <div class="patterns-row">
+            @if (insights.winning_patterns.length) {
+              <div class="pattern-col winning">
+                <div class="pattern-label">
+                  <mat-icon>trending_up</mat-icon>
+                  What's Working
+                </div>
+                <ul>
+                  @for (p of insights.winning_patterns; track p) {
+                    <li>{{ p }}</li>
+                  }
+                </ul>
+              </div>
+            }
+            @if (insights.losing_patterns.length) {
+              <div class="pattern-col losing">
+                <div class="pattern-label">
+                  <mat-icon>trending_down</mat-icon>
+                  Watch Out For
+                </div>
+                <ul>
+                  @for (p of insights.losing_patterns; track p) {
+                    <li>{{ p }}</li>
+                  }
+                </ul>
+              </div>
+            }
+          </div>
+        }
+
+        <!-- Recommendations -->
+        @if (insights.actionable_recommendations.length) {
+          <div class="recs-section">
+            <div class="section-label">
+              <mat-icon>task_alt</mat-icon>
+              Recommendations
+            </div>
+            <div class="recs-list">
+              @for (rec of insights.actionable_recommendations; track rec) {
+                <div class="rec-item">
+                  <mat-icon>arrow_forward</mat-icon>
+                  {{ rec }}
+                </div>
+              }
+            </div>
+          </div>
+        }
+
+        <!-- Industry + techniques row -->
+        <div class="chips-row">
+          @if (insights.top_performing_industries.length) {
+            <div class="chips-block">
+              <span class="chips-label">Top industries</span>
+              <div class="chips">
+                @for (ind of insights.top_performing_industries; track ind) {
+                  <span class="data-chip">{{ ind }}</span>
+                }
+              </div>
+            </div>
+          }
+          @if (insights.best_close_techniques.length) {
+            <div class="chips-block">
+              <span class="chips-label">Best close techniques</span>
+              <div class="chips">
+                @for (ct of insights.best_close_techniques; track ct) {
+                  <span class="data-chip">{{ ct }}</span>
+                }
+              </div>
+            </div>
+          }
+        </div>
+
+        <!-- Common objections -->
+        @if (insights.common_objections.length) {
+          <div class="objections-section">
+            <div class="section-label">
+              <mat-icon>help_outline</mat-icon>
+              Most Common Objections
+            </div>
+            <ol class="objections-list">
+              @for (obj of insights.common_objections; track obj) {
+                <li>{{ obj }}</li>
+              }
+            </ol>
+          </div>
+        }
+
+        <!-- Stage conversion rates -->
+        @if (stageEntries().length) {
+          <div class="conversion-section">
+            <div class="section-label">
+              <mat-icon>funnel</mat-icon>
+              Stage Conversion Rates
+            </div>
+            <div class="conversion-table">
+              @for (entry of stageEntries(); track entry.stage) {
+                <div class="conv-row">
+                  <span class="conv-stage">{{ entry.stage }}</span>
+                  <div class="conv-bar-wrap">
+                    <div class="conv-bar" [style.width.%]="entry.rate"></div>
+                  </div>
+                  <span class="conv-pct">{{ entry.rate }}%</span>
+                </div>
+              }
+            </div>
+          </div>
+        }
+      }
+    </mat-card-content>
+
+    <mat-card-actions>
+      <button
+        mat-stroked-button
+        (click)="refreshInsights()"
+        [disabled]="refreshing"
+      >
+        @if (refreshing) {
+          <mat-progress-spinner diameter="16" mode="indeterminate" />
+          Refreshing…
+        } @else {
+          <mat-icon>refresh</mat-icon>
+          Refresh Insights
+        }
+      </button>
+    </mat-card-actions>
+  </mat-card>
+
+  <!-- ================================================================== -->
+  <!-- Record outcomes                                                      -->
+  <!-- ================================================================== -->
+  <mat-card class="outcomes-card">
+    <mat-card-header>
+      <mat-card-title>
+        <mat-icon>add_chart</mat-icon>
+        Record Outcomes
+      </mat-card-title>
+      <mat-card-subtitle>Feed results back into the learning loop</mat-card-subtitle>
+    </mat-card-header>
+
+    <mat-card-content>
+
+      <!-- Stage outcome form -->
+      <mat-expansion-panel class="outcome-panel">
+        <mat-expansion-panel-header>
+          <mat-panel-title>
+            <mat-icon>timeline</mat-icon>
+            Stage Outcome
+          </mat-panel-title>
+          <mat-panel-description>What happened at a single pipeline stage</mat-panel-description>
+        </mat-expansion-panel-header>
+
+        <form [formGroup]="stageForm" (ngSubmit)="submitStageOutcome()" class="outcome-form">
+          <div class="form-row">
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Company Name</mat-label>
+              <input matInput formControlName="company_name" placeholder="Acme Corp" />
+              @if (stageForm.get('company_name')?.hasError('required') && stageForm.get('company_name')?.touched) {
+                <mat-error>Required</mat-error>
+              }
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Industry</mat-label>
+              <input matInput formControlName="industry" placeholder="SaaS" />
+            </mat-form-field>
+          </div>
+
+          <div class="form-row">
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Stage</mat-label>
+              <mat-select formControlName="stage">
+                @for (s of PIPELINE_STAGES; track s.value) {
+                  <mat-option [value]="s.value">{{ s.label }}</mat-option>
+                }
+              </mat-select>
+              @if (stageForm.get('stage')?.hasError('required') && stageForm.get('stage')?.touched) {
+                <mat-error>Required</mat-error>
+              }
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Outcome</mat-label>
+              <mat-select formControlName="outcome">
+                @for (o of OUTCOME_RESULTS; track o.value) {
+                  <mat-option [value]="o.value">{{ o.label }}</mat-option>
+                }
+              </mat-select>
+              @if (stageForm.get('outcome')?.hasError('required') && stageForm.get('outcome')?.touched) {
+                <mat-error>Required</mat-error>
+              }
+            </mat-form-field>
+          </div>
+
+          <div class="form-row">
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Subject Line Used <span class="opt">(optional)</span></mat-label>
+              <input matInput formControlName="subject_line_used" placeholder="The subject line that got a reply" />
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" class="narrow-field">
+              <mat-label>Email Touch #</mat-label>
+              <input matInput type="number" formControlName="email_touch_number" min="1" max="20" />
+            </mat-form-field>
+          </div>
+
+          <mat-form-field appearance="outline" class="full-width">
+            <mat-label>Objection Text <span class="opt">(optional)</span></mat-label>
+            <input matInput formControlName="objection_text" placeholder="Price is too high" />
+          </mat-form-field>
+
+          <div class="form-row">
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Close Technique Used <span class="opt">(optional)</span></mat-label>
+              <mat-select formControlName="close_technique_used">
+                <mat-option [value]="null">None</mat-option>
+                @for (ct of CLOSE_TYPES; track ct.value) {
+                  <mat-option [value]="ct.value">{{ ct.label }}</mat-option>
+                }
+              </mat-select>
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Notes <span class="opt">(optional)</span></mat-label>
+              <input matInput formControlName="notes" />
+            </mat-form-field>
+          </div>
+
+          <button mat-raised-button color="primary" type="submit" [disabled]="recordingStage" class="submit-btn">
+            @if (recordingStage) {
+              <mat-progress-spinner diameter="16" mode="indeterminate" />
+              Saving…
+            } @else {
+              <mat-icon>save</mat-icon>
+              Record Stage Outcome
+            }
+          </button>
+        </form>
+      </mat-expansion-panel>
+
+      <!-- Deal outcome form -->
+      <mat-expansion-panel class="outcome-panel">
+        <mat-expansion-panel-header>
+          <mat-panel-title>
+            <mat-icon>handshake</mat-icon>
+            Deal Outcome (Won / Lost)
+          </mat-panel-title>
+          <mat-panel-description>High-signal data that drives learning</mat-panel-description>
+        </mat-expansion-panel-header>
+
+        <form [formGroup]="dealForm" (ngSubmit)="submitDealOutcome()" class="outcome-form">
+          <div class="form-row">
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Company Name</mat-label>
+              <input matInput formControlName="company_name" placeholder="Acme Corp" />
+              @if (dealForm.get('company_name')?.hasError('required') && dealForm.get('company_name')?.touched) {
+                <mat-error>Required</mat-error>
+              }
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Industry</mat-label>
+              <input matInput formControlName="industry" placeholder="SaaS" />
+            </mat-form-field>
+          </div>
+
+          <div class="form-row">
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Result</mat-label>
+              <mat-select formControlName="result">
+                <mat-option value="won">Won</mat-option>
+                <mat-option value="lost">Lost</mat-option>
+              </mat-select>
+              @if (dealForm.get('result')?.hasError('required') && dealForm.get('result')?.touched) {
+                <mat-error>Required</mat-error>
+              }
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Final Stage Reached</mat-label>
+              <mat-select formControlName="final_stage_reached">
+                @for (s of PIPELINE_STAGES; track s.value) {
+                  <mat-option [value]="s.value">{{ s.label }}</mat-option>
+                }
+              </mat-select>
+              @if (dealForm.get('final_stage_reached')?.hasError('required') && dealForm.get('final_stage_reached')?.touched) {
+                <mat-error>Required</mat-error>
+              }
+            </mat-form-field>
+          </div>
+
+          <div class="form-row">
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Deal Size (USD) <span class="opt">(optional)</span></mat-label>
+              <input matInput type="number" formControlName="deal_size_usd" min="0" />
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" class="narrow-field">
+              <mat-label>Sales Cycle Days</mat-label>
+              <input matInput type="number" formControlName="sales_cycle_days" min="1" />
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Close Technique <span class="opt">(optional)</span></mat-label>
+              <mat-select formControlName="close_technique_used">
+                <mat-option [value]="null">None</mat-option>
+                @for (ct of CLOSE_TYPES; track ct.value) {
+                  <mat-option [value]="ct.value">{{ ct.label }}</mat-option>
+                }
+              </mat-select>
+            </mat-form-field>
+          </div>
+
+          <div class="form-row">
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Win Factor <span class="opt">(optional)</span></mat-label>
+              <input matInput formControlName="win_factor" placeholder="Champion + EB on final call" />
+            </mat-form-field>
+
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Loss Reason <span class="opt">(optional)</span></mat-label>
+              <input matInput formControlName="loss_reason" placeholder="Price, competitor, timing…" />
+            </mat-form-field>
+          </div>
+
+          <mat-form-field appearance="outline" class="full-width">
+            <mat-label>Objections Raised <span class="opt">(optional, one per line)</span></mat-label>
+            <textarea matInput formControlName="objections_raised" rows="2" placeholder="Price too high&#10;No budget this quarter"></textarea>
+          </mat-form-field>
+
+          <button mat-raised-button color="primary" type="submit" [disabled]="recordingDeal" class="submit-btn">
+            @if (recordingDeal) {
+              <mat-progress-spinner diameter="16" mode="indeterminate" />
+              Saving…
+            } @else {
+              <mat-icon>save</mat-icon>
+              Record Deal Outcome
+            }
+          </button>
+        </form>
+      </mat-expansion-panel>
+
+    </mat-card-content>
+  </mat-card>
+
+</div>

--- a/user-interface/src/app/components/sales-learning-panel/sales-learning-panel.component.scss
+++ b/user-interface/src/app/components/sales-learning-panel/sales-learning-panel.component.scss
@@ -1,0 +1,371 @@
+.learning-layout {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+// Insights card
+.insights-card, .outcomes-card {
+  mat-card-title {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 1rem;
+    font-weight: 600;
+
+    mat-icon {
+      color: var(--mat-sys-primary);
+      font-size: 1.125rem;
+      width: 1.125rem;
+      height: 1.125rem;
+    }
+  }
+}
+
+.loading-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1rem 0;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+  font-size: 0.875rem;
+}
+
+.error-block {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  background: var(--mat-sys-error-container, #ffebee);
+  color: var(--mat-sys-on-error-container, #c62828);
+  font-size: 0.875rem;
+
+  mat-icon { font-size: 1rem; width: 1rem; height: 1rem; }
+}
+
+.empty-insights {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.5rem;
+  padding: 2rem 1rem;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+
+  mat-icon {
+    font-size: 2.5rem;
+    width: 2.5rem;
+    height: 2.5rem;
+    opacity: 0.35;
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.9375rem;
+    line-height: 1.5;
+    max-width: 420px;
+  }
+
+  .empty-sub {
+    font-size: 0.8125rem;
+    opacity: 0.75;
+  }
+}
+
+// Stats row
+.insights-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 0.875rem 1rem;
+  border-radius: 8px;
+  background: var(--mat-sys-surface-container, rgba(0, 0, 0, 0.03));
+  border: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.08));
+  margin-bottom: 1rem;
+}
+
+.stat-block {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.125rem;
+  min-width: 60px;
+}
+
+.stat-val {
+  font-size: 1.375rem;
+  font-weight: 800;
+  line-height: 1;
+  color: var(--mat-sys-on-surface, rgba(0, 0, 0, 0.87));
+
+  &.win-rate {
+    color: var(--mat-sys-primary, #1976d2);
+  }
+}
+
+.stat-label {
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+  font-weight: 500;
+  text-align: center;
+}
+
+// Patterns
+.patterns-row {
+  display: flex;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+  flex-wrap: wrap;
+}
+
+.pattern-col {
+  flex: 1;
+  min-width: 200px;
+  padding: 0.75rem 0.875rem;
+  border-radius: 6px;
+  border: 1px solid;
+
+  .pattern-label {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.5rem;
+
+    mat-icon { font-size: 0.875rem; width: 0.875rem; height: 0.875rem; }
+  }
+
+  ul {
+    margin: 0;
+    padding-left: 1.125rem;
+    font-size: 0.8125rem;
+
+    li { line-height: 1.45; margin-bottom: 0.25rem; }
+  }
+
+  &.winning {
+    border-color: rgba(46, 125, 50, 0.25);
+    background: rgba(46, 125, 50, 0.05);
+
+    .pattern-label { color: #2e7d32; }
+  }
+
+  &.losing {
+    border-color: rgba(198, 40, 40, 0.2);
+    background: rgba(198, 40, 40, 0.04);
+
+    .pattern-label { color: #c62828; }
+  }
+}
+
+// Recommendations
+.recs-section {
+  margin-bottom: 1rem;
+}
+
+.section-label {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+  margin-bottom: 0.5rem;
+
+  mat-icon { font-size: 0.875rem; width: 0.875rem; height: 0.875rem; }
+}
+
+.recs-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.rec-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.375rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 6px;
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.2);
+  font-size: 0.875rem;
+  line-height: 1.45;
+  color: var(--mat-sys-on-surface, rgba(0, 0, 0, 0.8));
+
+  mat-icon {
+    font-size: 0.875rem;
+    width: 0.875rem;
+    height: 0.875rem;
+    flex-shrink: 0;
+    margin-top: 0.1rem;
+    color: #b45309;
+  }
+}
+
+// Chips
+.chips-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 0.875rem;
+}
+
+.chips-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.chips-label {
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+  font-weight: 600;
+}
+
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.375rem;
+}
+
+.data-chip {
+  display: inline-block;
+  padding: 0.2rem 0.55rem;
+  border-radius: 20px;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  background: var(--mat-sys-primary-container, #e3f2fd);
+  color: var(--mat-sys-on-primary-container, #1565c0);
+}
+
+// Objections
+.objections-section {
+  margin-bottom: 0.875rem;
+
+  .objections-list {
+    margin: 0;
+    padding-left: 1.25rem;
+    font-size: 0.875rem;
+
+    li { line-height: 1.5; margin-bottom: 0.2rem; }
+  }
+}
+
+// Conversion rates
+.conversion-section {
+  margin-bottom: 0.5rem;
+
+  .conversion-table {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+}
+
+.conv-row {
+  display: flex;
+  align-items: center;
+  gap: 0.625rem;
+
+  .conv-stage {
+    font-size: 0.75rem;
+    font-weight: 500;
+    width: 7rem;
+    flex-shrink: 0;
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.65));
+  }
+
+  .conv-bar-wrap {
+    flex: 1;
+    height: 6px;
+    border-radius: 3px;
+    background: var(--mat-sys-surface-container, rgba(0, 0, 0, 0.08));
+    overflow: hidden;
+  }
+
+  .conv-bar {
+    height: 100%;
+    border-radius: 3px;
+    background: var(--mat-sys-primary, #1976d2);
+    min-width: 2px;
+    transition: width 0.3s ease;
+  }
+
+  .conv-pct {
+    font-size: 0.75rem;
+    font-weight: 600;
+    width: 2.5rem;
+    text-align: right;
+    flex-shrink: 0;
+  }
+}
+
+// Outcomes card
+.outcome-panel {
+  border: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.1));
+  border-radius: 6px;
+  margin-bottom: 0.5rem;
+
+  mat-panel-title {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 500;
+
+    mat-icon { color: var(--mat-sys-primary); font-size: 1.125rem; width: 1.125rem; height: 1.125rem; }
+  }
+}
+
+.outcome-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+  padding-top: 0.25rem;
+}
+
+.form-row {
+  display: flex;
+  gap: 0.625rem;
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+
+.flex-field {
+  flex: 1;
+  min-width: 160px;
+}
+
+.narrow-field {
+  width: 100px;
+  flex-shrink: 0;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.opt {
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+  margin-left: 0.2rem;
+}
+
+.submit-btn {
+  align-self: flex-start;
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  margin-top: 0.25rem;
+}

--- a/user-interface/src/app/components/sales-learning-panel/sales-learning-panel.component.ts
+++ b/user-interface/src/app/components/sales-learning-panel/sales-learning-panel.component.ts
@@ -1,0 +1,218 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { SalesApiService } from '../../services/sales-api.service';
+import type {
+  LearningInsights,
+  PipelineStage,
+  OutcomeResult,
+  CloseType,
+} from '../../models';
+
+@Component({
+  selector: 'app-sales-learning-panel',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatCardModule,
+    MatButtonModule,
+    MatIconModule,
+    MatExpansionModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatProgressSpinnerModule,
+    MatSnackBarModule,
+  ],
+  templateUrl: './sales-learning-panel.component.html',
+  styleUrl: './sales-learning-panel.component.scss',
+})
+export class SalesLearningPanelComponent implements OnInit {
+  private readonly api = inject(SalesApiService);
+  private readonly fb = inject(FormBuilder);
+  private readonly snackBar = inject(MatSnackBar);
+
+  insights: LearningInsights | null = null;
+  loadingInsights = false;
+  refreshing = false;
+  insightsError: string | null = null;
+
+  recordingStage = false;
+  recordingDeal = false;
+
+  readonly PIPELINE_STAGES: { value: PipelineStage; label: string }[] = [
+    { value: 'prospecting', label: 'Prospecting' },
+    { value: 'outreach', label: 'Outreach' },
+    { value: 'qualification', label: 'Qualification' },
+    { value: 'nurturing', label: 'Nurturing' },
+    { value: 'discovery', label: 'Discovery' },
+    { value: 'proposal', label: 'Proposal' },
+    { value: 'negotiation', label: 'Negotiation' },
+    { value: 'closed_won', label: 'Closed Won' },
+    { value: 'closed_lost', label: 'Closed Lost' },
+  ];
+
+  readonly OUTCOME_RESULTS: { value: OutcomeResult; label: string }[] = [
+    { value: 'converted', label: 'Converted — moved to next stage' },
+    { value: 'stalled', label: 'Stalled — no response' },
+    { value: 'objection', label: 'Objection raised' },
+    { value: 'disqualified', label: 'Disqualified' },
+    { value: 'won', label: 'Won' },
+    { value: 'lost', label: 'Lost' },
+  ];
+
+  readonly CLOSE_TYPES: { value: CloseType; label: string }[] = [
+    { value: 'assumptive', label: 'Assumptive' },
+    { value: 'summary', label: 'Summary' },
+    { value: 'urgency', label: 'Urgency' },
+    { value: 'alternative_choice', label: 'Alternative Choice' },
+    { value: 'sharp_angle', label: 'Sharp Angle' },
+    { value: 'feel_felt_found', label: 'Feel / Felt / Found' },
+  ];
+
+  stageForm = this.fb.group({
+    company_name: ['', Validators.required],
+    stage: ['' as PipelineStage, Validators.required],
+    outcome: ['' as OutcomeResult, Validators.required],
+    industry: [''],
+    email_touch_number: [null as number | null],
+    subject_line_used: [''],
+    objection_text: [''],
+    close_technique_used: [null as CloseType | null],
+    notes: [''],
+  });
+
+  dealForm = this.fb.group({
+    company_name: ['', Validators.required],
+    result: ['' as OutcomeResult, Validators.required],
+    final_stage_reached: ['' as PipelineStage, Validators.required],
+    industry: [''],
+    deal_size_usd: [null as number | null],
+    win_factor: [''],
+    loss_reason: [''],
+    close_technique_used: [null as CloseType | null],
+    objections_raised: [''],
+    sales_cycle_days: [null as number | null],
+    notes: [''],
+  });
+
+  ngOnInit(): void {
+    this.loadInsights();
+  }
+
+  loadInsights(): void {
+    this.loadingInsights = true;
+    this.insightsError = null;
+    this.api.getInsights().subscribe({
+      next: (insights) => {
+        this.insights = insights;
+        this.loadingInsights = false;
+      },
+      error: (err) => {
+        this.loadingInsights = false;
+        if (err.status === 404) {
+          this.insightsError = null; // 404 is expected — show empty state
+        } else {
+          this.insightsError = err?.error?.detail ?? 'Failed to load insights.';
+        }
+      },
+    });
+  }
+
+  refreshInsights(): void {
+    this.refreshing = true;
+    this.api.refreshInsights().subscribe({
+      next: (resp) => {
+        this.refreshing = false;
+        this.snackBar.open(
+          `Insights refreshed to v${resp.insights_version} (${resp.total_outcomes_analyzed} outcomes analyzed)`,
+          'Dismiss',
+          { duration: 4000 }
+        );
+        this.loadInsights();
+      },
+      error: (err) => {
+        this.refreshing = false;
+        this.snackBar.open(err?.error?.detail ?? 'Refresh failed.', 'Dismiss', { duration: 3000 });
+      },
+    });
+  }
+
+  submitStageOutcome(): void {
+    if (this.stageForm.invalid) { this.stageForm.markAllAsTouched(); return; }
+    this.recordingStage = true;
+    const v = this.stageForm.value;
+    this.api.recordStageOutcome({
+      company_name: v.company_name!,
+      stage: v.stage as PipelineStage,
+      outcome: v.outcome as OutcomeResult,
+      industry: v.industry || undefined,
+      email_touch_number: v.email_touch_number ?? undefined,
+      subject_line_used: v.subject_line_used || undefined,
+      objection_text: v.objection_text || undefined,
+      close_technique_used: (v.close_technique_used as CloseType) || undefined,
+      notes: v.notes || '',
+    }).subscribe({
+      next: () => {
+        this.recordingStage = false;
+        this.stageForm.reset();
+        this.snackBar.open('Stage outcome recorded.', 'Dismiss', { duration: 3000 });
+      },
+      error: (err) => {
+        this.recordingStage = false;
+        this.snackBar.open(err?.error?.detail ?? 'Failed to record outcome.', 'Dismiss', { duration: 3000 });
+      },
+    });
+  }
+
+  submitDealOutcome(): void {
+    if (this.dealForm.invalid) { this.dealForm.markAllAsTouched(); return; }
+    this.recordingDeal = true;
+    const v = this.dealForm.value;
+    this.api.recordDealOutcome({
+      company_name: v.company_name!,
+      result: v.result as OutcomeResult,
+      final_stage_reached: v.final_stage_reached as PipelineStage,
+      industry: v.industry || undefined,
+      deal_size_usd: v.deal_size_usd ?? undefined,
+      win_factor: v.win_factor || undefined,
+      loss_reason: v.loss_reason || undefined,
+      close_technique_used: (v.close_technique_used as CloseType) || undefined,
+      objections_raised: v.objections_raised ? v.objections_raised.split('\n').map((s: string) => s.trim()).filter(Boolean) : [],
+      sales_cycle_days: v.sales_cycle_days ?? undefined,
+      notes: v.notes || '',
+    }).subscribe({
+      next: () => {
+        this.recordingDeal = false;
+        this.dealForm.reset();
+        this.snackBar.open('Deal outcome recorded.', 'Dismiss', { duration: 3000 });
+      },
+      error: (err) => {
+        this.recordingDeal = false;
+        this.snackBar.open(err?.error?.detail ?? 'Failed to record outcome.', 'Dismiss', { duration: 3000 });
+      },
+    });
+  }
+
+  winRatePercent(): number {
+    return Math.round((this.insights?.win_rate ?? 0) * 100);
+  }
+
+  stageEntries(): { stage: string; rate: number }[] {
+    const rates = this.insights?.stage_conversion_rates ?? {};
+    return Object.entries(rates).map(([stage, rate]) => ({
+      stage: stage.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase()),
+      rate: Math.round(rate * 100),
+    }));
+  }
+}

--- a/user-interface/src/app/components/sales-pipeline-form/sales-pipeline-form.component.html
+++ b/user-interface/src/app/components/sales-pipeline-form/sales-pipeline-form.component.html
@@ -1,0 +1,212 @@
+<form [formGroup]="form" (ngSubmit)="submit()" class="pipeline-form">
+
+  <!-- ------------------------------------------------------------------ -->
+  <!-- Section: Product                                                     -->
+  <!-- ------------------------------------------------------------------ -->
+  <div class="form-section">
+    <h3 class="section-title">
+      <mat-icon>inventory_2</mat-icon>
+      Product Details
+    </h3>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Product / Solution Name</mat-label>
+      <input matInput formControlName="product_name" placeholder="e.g. Acme CRM Pro" />
+      @if (form.get('product_name')?.hasError('required') && form.get('product_name')?.touched) {
+        <mat-error>Product name is required.</mat-error>
+      }
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Value Proposition</mat-label>
+      <textarea
+        matInput
+        formControlName="value_proposition"
+        placeholder="Describe the core benefit: who you help, what problem you solve, and the measurable outcome."
+        rows="3"
+      ></textarea>
+      @if (form.get('value_proposition')?.hasError('required') && form.get('value_proposition')?.touched) {
+        <mat-error>Value proposition is required.</mat-error>
+      }
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Company Context <span class="optional-label">(optional)</span></mat-label>
+      <textarea
+        matInput
+        formControlName="company_context"
+        placeholder="Your company size, mission, key differentiators, and any context that helps personalize outreach."
+        rows="2"
+      ></textarea>
+    </mat-form-field>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Customer Win Snippets <span class="optional-label">(optional)</span></mat-label>
+      <textarea
+        matInput
+        formControlName="case_study_snippets"
+        placeholder="One per line. e.g. &quot;Acme reduced churn by 40% in 90 days using our platform.&quot;"
+        rows="2"
+      ></textarea>
+      <mat-hint>Each line is treated as a separate case study snippet used in outreach and proposals.</mat-hint>
+    </mat-form-field>
+  </div>
+
+  <!-- ------------------------------------------------------------------ -->
+  <!-- Section: ICP (collapsible)                                           -->
+  <!-- ------------------------------------------------------------------ -->
+  <mat-expansion-panel
+    class="icp-panel"
+    [(expanded)]="icpPanelOpen"
+    hideToggle
+  >
+    <mat-expansion-panel-header>
+      <mat-panel-title>
+        <mat-icon>person_search</mat-icon>
+        Ideal Customer Profile (ICP)
+      </mat-panel-title>
+      <mat-panel-description>
+        <span class="icp-hint">Define who to target</span>
+        <mat-icon>{{ icpPanelOpen ? 'expand_less' : 'expand_more' }}</mat-icon>
+      </mat-panel-description>
+    </mat-expansion-panel-header>
+
+    <div class="icp-fields">
+      <div class="field-row">
+        <mat-form-field appearance="outline" class="flex-field">
+          <mat-label>Target Industries</mat-label>
+          <input matInput formControlName="icp_industry" placeholder="SaaS, FinTech, HealthTech" />
+          <mat-hint>Comma-separated</mat-hint>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="flex-field">
+          <mat-label>Target Job Titles</mat-label>
+          <input matInput formControlName="icp_job_titles" placeholder="VP Sales, CRO, Head of Revenue" />
+          <mat-hint>Comma-separated</mat-hint>
+        </mat-form-field>
+      </div>
+
+      <div class="field-row">
+        <mat-form-field appearance="outline" class="size-field">
+          <mat-label>Min Employees</mat-label>
+          <input matInput type="number" formControlName="icp_size_min" min="1" />
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="size-field">
+          <mat-label>Max Employees</mat-label>
+          <input matInput type="number" formControlName="icp_size_max" min="1" />
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="flex-field">
+          <mat-label>Budget Range</mat-label>
+          <input matInput formControlName="icp_budget_range" placeholder="$10k–$100k/yr" />
+        </mat-form-field>
+      </div>
+
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Pain Points</mat-label>
+        <textarea
+          matInput
+          formControlName="icp_pain_points"
+          placeholder="One per line. e.g. Manual reporting taking 10+ hours/week"
+          rows="3"
+        ></textarea>
+        <mat-hint>Problems your product solves — one per line</mat-hint>
+      </mat-form-field>
+
+      <div class="field-row">
+        <mat-form-field appearance="outline" class="flex-field">
+          <mat-label>Geographic Focus</mat-label>
+          <input matInput formControlName="icp_geographic_focus" placeholder="US, UK, Canada" />
+          <mat-hint>Comma-separated</mat-hint>
+        </mat-form-field>
+
+        <mat-form-field appearance="outline" class="flex-field">
+          <mat-label>Tech Stack Keywords</mat-label>
+          <input matInput formControlName="icp_tech_stack" placeholder="Salesforce, HubSpot, Slack" />
+          <mat-hint>Comma-separated</mat-hint>
+        </mat-form-field>
+      </div>
+
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Disqualifying Traits <span class="optional-label">(optional)</span></mat-label>
+        <input matInput formControlName="icp_disqualifying_traits" placeholder="No budget, no decision maker, competitor's customer" />
+        <mat-hint>Comma-separated traits that rule out a prospect</mat-hint>
+      </mat-form-field>
+    </div>
+  </mat-expansion-panel>
+
+  <!-- ------------------------------------------------------------------ -->
+  <!-- Section: Run Configuration                                           -->
+  <!-- ------------------------------------------------------------------ -->
+  <div class="form-section">
+    <h3 class="section-title">
+      <mat-icon>settings</mat-icon>
+      Run Configuration
+    </h3>
+
+    <div class="config-row">
+      <mat-form-field appearance="outline" class="stage-field">
+        <mat-label>Entry Stage</mat-label>
+        <mat-select formControlName="entry_stage">
+          @for (stage of pipelineStages; track stage.value) {
+            <mat-option [value]="stage.value">{{ stage.label }}</mat-option>
+          }
+        </mat-select>
+        <mat-hint>Pipeline will run from this stage onward</mat-hint>
+      </mat-form-field>
+
+      <div class="prospects-field">
+        <label class="prospects-label">
+          Max Prospects
+          <span class="prospects-value">{{ maxProspectsValue }}</span>
+        </label>
+        <mat-slider min="1" max="20" step="1" showTickMarks discrete class="prospects-slider">
+          <input matSliderThumb formControlName="max_prospects" />
+        </mat-slider>
+      </div>
+    </div>
+  </div>
+
+  <!-- ------------------------------------------------------------------ -->
+  <!-- Error                                                                -->
+  <!-- ------------------------------------------------------------------ -->
+  @if (error) {
+    <div class="form-error">
+      <mat-icon>error_outline</mat-icon>
+      {{ error }}
+    </div>
+  }
+
+  <!-- ------------------------------------------------------------------ -->
+  <!-- Actions                                                              -->
+  <!-- ------------------------------------------------------------------ -->
+  <div class="form-actions">
+    <button
+      mat-raised-button
+      color="primary"
+      type="submit"
+      [disabled]="loading"
+      class="run-btn"
+    >
+      @if (loading) {
+        <mat-progress-spinner diameter="18" mode="indeterminate" class="btn-spinner" />
+        Starting…
+      } @else {
+        <mat-icon>play_circle</mat-icon>
+        Run Sales Pipeline
+      }
+    </button>
+
+    <button
+      mat-stroked-button
+      type="button"
+      [disabled]="loading"
+      (click)="reset()"
+    >
+      <mat-icon>refresh</mat-icon>
+      Reset
+    </button>
+  </div>
+
+</form>

--- a/user-interface/src/app/components/sales-pipeline-form/sales-pipeline-form.component.scss
+++ b/user-interface/src/app/components/sales-pipeline-form/sales-pipeline-form.component.scss
@@ -1,0 +1,184 @@
+.pipeline-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.form-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+}
+
+.section-title {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 0.25rem 0;
+  font-size: 0.875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+
+  mat-icon {
+    font-size: 1rem;
+    width: 1rem;
+    height: 1rem;
+  }
+}
+
+.full-width {
+  width: 100%;
+}
+
+.optional-label {
+  font-size: 0.75rem;
+  font-weight: 400;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+  margin-left: 0.25rem;
+}
+
+// ICP panel
+.icp-panel {
+  border: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.12));
+  border-radius: 8px;
+
+  mat-panel-title {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9375rem;
+    font-weight: 500;
+
+    mat-icon {
+      color: var(--mat-sys-primary);
+      font-size: 1.125rem;
+      width: 1.125rem;
+      height: 1.125rem;
+    }
+  }
+
+  mat-panel-description {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 0.5rem;
+    flex: 1;
+  }
+
+  .icp-hint {
+    font-size: 0.8125rem;
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+  }
+}
+
+.icp-fields {
+  display: flex;
+  flex-direction: column;
+  gap: 0.875rem;
+  padding-top: 0.5rem;
+}
+
+.field-row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+
+.flex-field {
+  flex: 1;
+  min-width: 180px;
+}
+
+.size-field {
+  width: 120px;
+  flex-shrink: 0;
+}
+
+// Run config
+.config-row {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  align-items: flex-start;
+}
+
+.stage-field {
+  flex: 1;
+  min-width: 240px;
+}
+
+.prospects-field {
+  flex-shrink: 0;
+  min-width: 180px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding-top: 0.75rem;
+}
+
+.prospects-label {
+  font-size: 0.875rem;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.prospects-value {
+  font-weight: 600;
+  color: var(--mat-sys-primary);
+  font-size: 1rem;
+}
+
+.prospects-slider {
+  width: 100%;
+}
+
+// Error
+.form-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  background: var(--mat-sys-error-container, #ffebee);
+  color: var(--mat-sys-on-error-container, #c62828);
+  font-size: 0.875rem;
+  line-height: 1.4;
+
+  mat-icon {
+    font-size: 1.125rem;
+    width: 1.125rem;
+    height: 1.125rem;
+    flex-shrink: 0;
+    margin-top: 0.05rem;
+  }
+}
+
+// Actions
+.form-actions {
+  display: flex;
+  gap: 0.75rem;
+  align-items: center;
+  flex-wrap: wrap;
+  padding-top: 0.25rem;
+}
+
+.run-btn {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+
+  mat-icon {
+    font-size: 1.125rem;
+    width: 1.125rem;
+    height: 1.125rem;
+  }
+}
+
+.btn-spinner {
+  display: inline-block;
+}

--- a/user-interface/src/app/components/sales-pipeline-form/sales-pipeline-form.component.ts
+++ b/user-interface/src/app/components/sales-pipeline-form/sales-pipeline-form.component.ts
@@ -1,0 +1,147 @@
+import { Component, Output, EventEmitter, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatSliderModule } from '@angular/material/slider';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { SalesApiService } from '../../services/sales-api.service';
+import type { SalesPipelineRequest, IdealCustomerProfile, PipelineStage } from '../../models';
+
+const PIPELINE_STAGES: { value: PipelineStage; label: string }[] = [
+  { value: 'prospecting', label: 'Prospecting — Identify leads' },
+  { value: 'outreach', label: 'Outreach — Cold sequences' },
+  { value: 'qualification', label: 'Qualification — BANT + MEDDIC scoring' },
+  { value: 'nurturing', label: 'Nurturing — Long-cycle follow-up' },
+  { value: 'discovery', label: 'Discovery — Call prep & demo' },
+  { value: 'proposal', label: 'Proposal — Full written proposal' },
+  { value: 'negotiation', label: 'Negotiation — Close strategy' },
+];
+
+function splitLines(val: string): string[] {
+  return val.split('\n').map(s => s.trim()).filter(Boolean);
+}
+
+function splitCommas(val: string): string[] {
+  return val.split(',').map(s => s.trim()).filter(Boolean);
+}
+
+@Component({
+  selector: 'app-sales-pipeline-form',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatButtonModule,
+    MatIconModule,
+    MatExpansionModule,
+    MatSliderModule,
+    MatProgressSpinnerModule,
+    MatTooltipModule,
+  ],
+  templateUrl: './sales-pipeline-form.component.html',
+  styleUrl: './sales-pipeline-form.component.scss',
+})
+export class SalesPipelineFormComponent {
+  @Output() pipelineStarted = new EventEmitter<string>();
+
+  private readonly api = inject(SalesApiService);
+  private readonly fb = inject(FormBuilder);
+
+  readonly pipelineStages = PIPELINE_STAGES;
+
+  loading = false;
+  error: string | null = null;
+  icpPanelOpen = false;
+  advancedOpen = false;
+
+  form = this.fb.group({
+    // Product
+    product_name: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(200)]],
+    value_proposition: ['', [Validators.required, Validators.minLength(10)]],
+    company_context: [''],
+    case_study_snippets: [''],
+
+    // ICP
+    icp_industry: [''],
+    icp_job_titles: [''],
+    icp_pain_points: [''],
+    icp_size_min: [10],
+    icp_size_max: [5000],
+    icp_budget_range: ['$10k–$100k/yr'],
+    icp_geographic_focus: [''],
+    icp_tech_stack: [''],
+    icp_disqualifying_traits: [''],
+
+    // Run config
+    entry_stage: ['prospecting' as PipelineStage],
+    max_prospects: [5],
+  });
+
+  get maxProspectsValue(): number {
+    return this.form.get('max_prospects')?.value ?? 5;
+  }
+
+  submit(): void {
+    if (this.form.invalid) {
+      this.form.markAllAsTouched();
+      return;
+    }
+    this.loading = true;
+    this.error = null;
+
+    const v = this.form.value;
+    const icp: IdealCustomerProfile = {
+      industry: splitCommas(v.icp_industry ?? ''),
+      company_size_min: Number(v.icp_size_min ?? 10),
+      company_size_max: Number(v.icp_size_max ?? 5000),
+      job_titles: splitCommas(v.icp_job_titles ?? ''),
+      pain_points: splitLines(v.icp_pain_points ?? ''),
+      budget_range_usd: v.icp_budget_range ?? '$10k–$100k/yr',
+      geographic_focus: splitCommas(v.icp_geographic_focus ?? ''),
+      tech_stack_keywords: splitCommas(v.icp_tech_stack ?? ''),
+      disqualifying_traits: splitLines(v.icp_disqualifying_traits ?? ''),
+    };
+
+    const request: SalesPipelineRequest = {
+      product_name: v.product_name ?? '',
+      value_proposition: v.value_proposition ?? '',
+      icp,
+      entry_stage: (v.entry_stage as PipelineStage) ?? 'prospecting',
+      max_prospects: Number(v.max_prospects ?? 5),
+      company_context: v.company_context ?? '',
+      case_study_snippets: splitLines(v.case_study_snippets ?? ''),
+    };
+
+    this.api.runPipeline(request).subscribe({
+      next: (resp) => {
+        this.loading = false;
+        this.pipelineStarted.emit(resp.job_id);
+      },
+      error: (err) => {
+        this.loading = false;
+        this.error = err?.error?.detail ?? err?.message ?? 'Pipeline failed to start.';
+      },
+    });
+  }
+
+  reset(): void {
+    this.form.reset({
+      entry_stage: 'prospecting',
+      max_prospects: 5,
+      icp_size_min: 10,
+      icp_size_max: 5000,
+      icp_budget_range: '$10k–$100k/yr',
+    });
+    this.error = null;
+    this.icpPanelOpen = false;
+  }
+}

--- a/user-interface/src/app/components/sales-pipeline-results/sales-pipeline-results.component.html
+++ b/user-interface/src/app/components/sales-pipeline-results/sales-pipeline-results.component.html
@@ -1,0 +1,692 @@
+@if (!result) {
+  <div class="empty-state">
+    <mat-icon>assessment</mat-icon>
+    <p>No pipeline results yet. Run a pipeline to see stage-by-stage output here.</p>
+  </div>
+} @else {
+
+  <!-- Summary banner -->
+  <div class="summary-banner">
+    <mat-icon>check_circle</mat-icon>
+    <div class="summary-text">
+      <span class="summary-product">{{ result.product_name }}</span>
+      <span class="summary-body">{{ result.summary }}</span>
+    </div>
+    <span class="entry-stage-chip">From: {{ stageLabel(result.entry_stage) }}</span>
+  </div>
+
+  <!-- ------------------------------------------------------------------ -->
+  <!-- Stats row                                                            -->
+  <!-- ------------------------------------------------------------------ -->
+  <div class="stats-row">
+    <div class="stat-chip">
+      <mat-icon>search</mat-icon>
+      <span>{{ result.prospects.length }} prospects</span>
+    </div>
+    @if (result.outreach_sequences.length) {
+      <div class="stat-chip">
+        <mat-icon>mail</mat-icon>
+        <span>{{ result.outreach_sequences.length }} sequences</span>
+      </div>
+    }
+    @if (result.qualified_leads.length) {
+      <div class="stat-chip">
+        <mat-icon>verified</mat-icon>
+        <span>{{ result.qualified_leads.length }} qualified</span>
+      </div>
+    }
+    @if (result.proposals.length) {
+      <div class="stat-chip">
+        <mat-icon>description</mat-icon>
+        <span>{{ result.proposals.length }} proposals</span>
+      </div>
+    }
+    @if (result.closing_strategies.length) {
+      <div class="stat-chip">
+        <mat-icon>gavel</mat-icon>
+        <span>{{ result.closing_strategies.length }} closing packs</span>
+      </div>
+    }
+  </div>
+
+  <!-- ------------------------------------------------------------------ -->
+  <!-- Section 1: Prospects                                                 -->
+  <!-- ------------------------------------------------------------------ -->
+  @if (result.prospects.length) {
+    <mat-expansion-panel class="results-section" expanded>
+      <mat-expansion-panel-header>
+        <mat-panel-title>
+          <mat-icon class="section-icon">search</mat-icon>
+          Prospects
+          <span class="section-count">{{ result.prospects.length }}</span>
+        </mat-panel-title>
+        <mat-panel-description>Leads identified matching your ICP</mat-panel-description>
+      </mat-expansion-panel-header>
+
+      <div class="prospects-grid">
+        @for (p of result.prospects; track p.company_name) {
+          <div class="prospect-card">
+            <div class="prospect-header">
+              <div class="prospect-name-block">
+                <span class="prospect-company">{{ p.company_name }}</span>
+                @if (p.industry) {
+                  <span class="industry-chip">{{ p.industry }}</span>
+                }
+              </div>
+              <div class="icp-score-badge" [class]="icpScoreClass(p.icp_match_score)" [matTooltip]="icpScoreLabel(p.icp_match_score)">
+                {{ outcomeScorePercent(p.icp_match_score) }}%
+              </div>
+            </div>
+
+            @if (p.contact_name || p.contact_title) {
+              <div class="prospect-contact">
+                <mat-icon>person</mat-icon>
+                <span>{{ p.contact_name }}{{ p.contact_title ? ' · ' + p.contact_title : '' }}</span>
+              </div>
+            }
+            @if (p.contact_email) {
+              <div class="prospect-contact">
+                <mat-icon>mail_outline</mat-icon>
+                <span>{{ p.contact_email }}</span>
+              </div>
+            }
+            @if (p.company_size_estimate) {
+              <div class="prospect-contact">
+                <mat-icon>groups</mat-icon>
+                <span>{{ p.company_size_estimate }}</span>
+              </div>
+            }
+
+            @if (p.trigger_events.length) {
+              <div class="trigger-events">
+                <span class="trigger-label">Trigger events</span>
+                <ul class="trigger-list">
+                  @for (t of p.trigger_events; track t) {
+                    <li>{{ t }}</li>
+                  }
+                </ul>
+              </div>
+            }
+
+            @if (p.research_notes) {
+              <p class="research-notes">{{ p.research_notes }}</p>
+            }
+
+            <mat-progress-bar
+              class="icp-bar"
+              mode="determinate"
+              [value]="bantPercent(p.icp_match_score * 10)"
+              [color]="p.icp_match_score >= 0.75 ? 'primary' : p.icp_match_score >= 0.5 ? 'accent' : 'warn'"
+            />
+          </div>
+        }
+      </div>
+    </mat-expansion-panel>
+  }
+
+  <!-- ------------------------------------------------------------------ -->
+  <!-- Section 2: Outreach Sequences                                        -->
+  <!-- ------------------------------------------------------------------ -->
+  @if (result.outreach_sequences.length) {
+    <mat-expansion-panel class="results-section" expanded>
+      <mat-expansion-panel-header>
+        <mat-panel-title>
+          <mat-icon class="section-icon">mail</mat-icon>
+          Outreach Sequences
+          <span class="section-count">{{ result.outreach_sequences.length }}</span>
+        </mat-panel-title>
+        <mat-panel-description>Multi-touch cold outreach cadences</mat-panel-description>
+      </mat-expansion-panel-header>
+
+      <mat-accordion>
+        @for (seq of result.outreach_sequences; track seq.prospect.company_name) {
+          <mat-expansion-panel class="inner-panel">
+            <mat-expansion-panel-header>
+              <mat-panel-title>{{ seq.prospect.company_name }}</mat-panel-title>
+              <mat-panel-description>{{ seq.email_sequence.length }} email touches</mat-panel-description>
+            </mat-expansion-panel-header>
+
+            @if (seq.sequence_rationale) {
+              <div class="rationale-block">
+                <mat-icon>lightbulb</mat-icon>
+                <span>{{ seq.sequence_rationale }}</span>
+              </div>
+            }
+
+            <div class="email-sequence">
+              @for (touch of seq.email_sequence; track touch.day) {
+                <div class="email-touch">
+                  <div class="touch-day">Day {{ touch.day + 1 }}</div>
+                  <div class="touch-body">
+                    <div class="touch-subject">{{ touch.subject_line }}</div>
+                    <pre class="touch-text">{{ touch.body }}</pre>
+                    @if (touch.call_to_action) {
+                      <div class="touch-cta">
+                        <mat-icon>arrow_forward</mat-icon>
+                        {{ touch.call_to_action }}
+                      </div>
+                    }
+                  </div>
+                </div>
+              }
+            </div>
+
+            @if (seq.call_script) {
+              <div class="script-block">
+                <div class="script-label">
+                  <mat-icon>phone</mat-icon>
+                  Call Script
+                </div>
+                <pre class="script-text">{{ seq.call_script }}</pre>
+              </div>
+            }
+
+            @if (seq.linkedin_message) {
+              <div class="script-block">
+                <div class="script-label">
+                  <mat-icon>person_add</mat-icon>
+                  LinkedIn Message
+                </div>
+                <p class="script-text">{{ seq.linkedin_message }}</p>
+              </div>
+            }
+          </mat-expansion-panel>
+        }
+      </mat-accordion>
+    </mat-expansion-panel>
+  }
+
+  <!-- ------------------------------------------------------------------ -->
+  <!-- Section 3: Qualified Leads                                           -->
+  <!-- ------------------------------------------------------------------ -->
+  @if (result.qualified_leads.length) {
+    <mat-expansion-panel class="results-section" expanded>
+      <mat-expansion-panel-header>
+        <mat-panel-title>
+          <mat-icon class="section-icon">verified</mat-icon>
+          Qualification Scores
+          <span class="section-count">{{ result.qualified_leads.length }}</span>
+        </mat-panel-title>
+        <mat-panel-description>BANT + MEDDIC scoring and recommendations</mat-panel-description>
+      </mat-expansion-panel-header>
+
+      <div class="qual-grid">
+        @for (q of result.qualified_leads; track q.prospect.company_name) {
+          <div class="qual-card">
+            <div class="qual-header">
+              <span class="qual-company">{{ q.prospect.company_name }}</span>
+              <div class="qual-scores-header">
+                <span class="overall-score" [class]="icpScoreClass(q.overall_score)">
+                  {{ outcomeScorePercent(q.overall_score) }}%
+                </span>
+                <span class="value-tier" [matTooltip]="'Iannarino value tier'">L{{ q.value_creation_level }}</span>
+              </div>
+            </div>
+
+            <div class="recommendation-chip" [class]="recommendationClass(q.recommended_action)">
+              {{ q.recommended_action }}
+            </div>
+
+            <div class="bant-scores">
+              <div class="bant-row">
+                <span class="bant-label">Budget</span>
+                <mat-progress-bar mode="determinate" [value]="bantPercent(q.bant.budget)" [color]="bantBarColor(q.bant.budget)" />
+                <span class="bant-val">{{ q.bant.budget }}/10</span>
+              </div>
+              <div class="bant-row">
+                <span class="bant-label">Authority</span>
+                <mat-progress-bar mode="determinate" [value]="bantPercent(q.bant.authority)" [color]="bantBarColor(q.bant.authority)" />
+                <span class="bant-val">{{ q.bant.authority }}/10</span>
+              </div>
+              <div class="bant-row">
+                <span class="bant-label">Need</span>
+                <mat-progress-bar mode="determinate" [value]="bantPercent(q.bant.need)" [color]="bantBarColor(q.bant.need)" />
+                <span class="bant-val">{{ q.bant.need }}/10</span>
+              </div>
+              <div class="bant-row">
+                <span class="bant-label">Timeline</span>
+                <mat-progress-bar mode="determinate" [value]="bantPercent(q.bant.timeline)" [color]="bantBarColor(q.bant.timeline)" />
+                <span class="bant-val">{{ q.bant.timeline }}/10</span>
+              </div>
+            </div>
+
+            <div class="meddic-grid">
+              @for (item of meddic(q); track item.key) {
+                <div class="meddic-item" [class.checked]="item.checked">
+                  <mat-icon>{{ item.checked ? 'check_circle' : 'radio_button_unchecked' }}</mat-icon>
+                  {{ item.label }}
+                </div>
+              }
+            </div>
+
+            @if (q.qualification_notes) {
+              <p class="qual-notes">{{ q.qualification_notes }}</p>
+            }
+          </div>
+        }
+      </div>
+    </mat-expansion-panel>
+  }
+
+  <!-- ------------------------------------------------------------------ -->
+  <!-- Section 4: Nurture Sequences                                         -->
+  <!-- ------------------------------------------------------------------ -->
+  @if (result.nurture_sequences.length) {
+    <mat-expansion-panel class="results-section">
+      <mat-expansion-panel-header>
+        <mat-panel-title>
+          <mat-icon class="section-icon">water_drop</mat-icon>
+          Nurture Sequences
+          <span class="section-count">{{ result.nurture_sequences.length }}</span>
+        </mat-panel-title>
+        <mat-panel-description>Long-cycle follow-up for not-ready leads</mat-panel-description>
+      </mat-expansion-panel-header>
+
+      <mat-accordion>
+        @for (ns of result.nurture_sequences; track ns.prospect.company_name) {
+          <mat-expansion-panel class="inner-panel">
+            <mat-expansion-panel-header>
+              <mat-panel-title>{{ ns.prospect.company_name }}</mat-panel-title>
+              <mat-panel-description>{{ ns.duration_days }}-day sequence · {{ ns.touchpoints.length }} touchpoints</mat-panel-description>
+            </mat-expansion-panel-header>
+
+            <div class="nurture-timeline">
+              @for (tp of ns.touchpoints; track tp.day) {
+                <div class="timeline-item">
+                  <div class="timeline-day">Day {{ tp.day }}</div>
+                  <div class="timeline-connector"></div>
+                  <div class="timeline-content">
+                    <div class="timeline-header">
+                      <mat-icon class="channel-icon">{{ channelIcon(tp.channel) }}</mat-icon>
+                      <span class="content-type">{{ tp.content_type }}</span>
+                      @if (tp.goal) {
+                        <span class="tp-goal">{{ tp.goal }}</span>
+                      }
+                    </div>
+                    <p class="tp-message">{{ tp.message }}</p>
+                  </div>
+                </div>
+              }
+            </div>
+
+            @if (ns.re_engagement_triggers.length) {
+              <div class="triggers-block">
+                <span class="triggers-label">
+                  <mat-icon>notifications_active</mat-icon>
+                  Re-engagement triggers
+                </span>
+                <ul class="triggers-list">
+                  @for (t of ns.re_engagement_triggers; track t) {
+                    <li>{{ t }}</li>
+                  }
+                </ul>
+              </div>
+            }
+          </mat-expansion-panel>
+        }
+      </mat-accordion>
+    </mat-expansion-panel>
+  }
+
+  <!-- ------------------------------------------------------------------ -->
+  <!-- Section 5: Discovery Plans                                           -->
+  <!-- ------------------------------------------------------------------ -->
+  @if (result.discovery_plans.length) {
+    <mat-expansion-panel class="results-section" expanded>
+      <mat-expansion-panel-header>
+        <mat-panel-title>
+          <mat-icon class="section-icon">explore</mat-icon>
+          Discovery Plans
+          <span class="section-count">{{ result.discovery_plans.length }}</span>
+        </mat-panel-title>
+        <mat-panel-description>SPIN questions, Challenger insight, demo agendas</mat-panel-description>
+      </mat-expansion-panel-header>
+
+      <mat-accordion>
+        @for (dp of result.discovery_plans; track dp.prospect.company_name) {
+          <mat-expansion-panel class="inner-panel">
+            <mat-expansion-panel-header>
+              <mat-panel-title>{{ dp.prospect.company_name }}</mat-panel-title>
+            </mat-expansion-panel-header>
+
+            @if (dp.challenger_insight) {
+              <div class="insight-block">
+                <mat-icon>lightbulb</mat-icon>
+                <div>
+                  <strong>Challenger Insight</strong>
+                  <p>{{ dp.challenger_insight }}</p>
+                </div>
+              </div>
+            }
+
+            <div class="spin-grid">
+              @if (dp.spin_questions.situation.length) {
+                <div class="spin-col">
+                  <div class="spin-label situation">Situation</div>
+                  <ul>
+                    @for (q of dp.spin_questions.situation; track q) {
+                      <li>{{ q }}</li>
+                    }
+                  </ul>
+                </div>
+              }
+              @if (dp.spin_questions.problem.length) {
+                <div class="spin-col">
+                  <div class="spin-label problem">Problem</div>
+                  <ul>
+                    @for (q of dp.spin_questions.problem; track q) {
+                      <li>{{ q }}</li>
+                    }
+                  </ul>
+                </div>
+              }
+              @if (dp.spin_questions.implication.length) {
+                <div class="spin-col">
+                  <div class="spin-label implication">Implication</div>
+                  <ul>
+                    @for (q of dp.spin_questions.implication; track q) {
+                      <li>{{ q }}</li>
+                    }
+                  </ul>
+                </div>
+              }
+              @if (dp.spin_questions.need_payoff.length) {
+                <div class="spin-col">
+                  <div class="spin-label need-payoff">Need-Payoff</div>
+                  <ul>
+                    @for (q of dp.spin_questions.need_payoff; track q) {
+                      <li>{{ q }}</li>
+                    }
+                  </ul>
+                </div>
+              }
+            </div>
+
+            @if (dp.demo_agenda.length) {
+              <div class="demo-agenda">
+                <div class="demo-label">
+                  <mat-icon>slideshow</mat-icon>
+                  Demo Agenda
+                </div>
+                <ol class="agenda-list">
+                  @for (item of dp.demo_agenda; track item) {
+                    <li>{{ item }}</li>
+                  }
+                </ol>
+              </div>
+            }
+
+            @if (dp.expected_objections.length) {
+              <div class="objections-block">
+                <div class="obj-label">
+                  <mat-icon>help_outline</mat-icon>
+                  Expected Objections
+                </div>
+                <ul>
+                  @for (obj of dp.expected_objections; track obj) {
+                    <li>{{ obj }}</li>
+                  }
+                </ul>
+              </div>
+            }
+
+            @if (dp.success_criteria_for_call) {
+              <div class="success-criteria">
+                <mat-icon>flag</mat-icon>
+                <strong>Success criteria:</strong>
+                {{ dp.success_criteria_for_call }}
+              </div>
+            }
+          </mat-expansion-panel>
+        }
+      </mat-accordion>
+    </mat-expansion-panel>
+  }
+
+  <!-- ------------------------------------------------------------------ -->
+  <!-- Section 6: Proposals                                                 -->
+  <!-- ------------------------------------------------------------------ -->
+  @if (result.proposals.length) {
+    <mat-expansion-panel class="results-section" expanded>
+      <mat-expansion-panel-header>
+        <mat-panel-title>
+          <mat-icon class="section-icon">description</mat-icon>
+          Proposals
+          <span class="section-count">{{ result.proposals.length }}</span>
+        </mat-panel-title>
+        <mat-panel-description>Full written proposals with ROI models</mat-panel-description>
+      </mat-expansion-panel-header>
+
+      <mat-accordion>
+        @for (prop of result.proposals; track prop.prospect.company_name) {
+          <mat-expansion-panel class="inner-panel">
+            <mat-expansion-panel-header>
+              <mat-panel-title>{{ prop.prospect.company_name }}</mat-panel-title>
+              @if (prop.roi_model) {
+                <mat-panel-description>{{ formatCurrency(prop.roi_model.annual_cost_usd) }}/yr · {{ prop.roi_model.roi_percentage }}% ROI</mat-panel-description>
+              }
+            </mat-expansion-panel-header>
+
+            @if (prop.executive_summary) {
+              <div class="proposal-section-block">
+                <div class="prop-section-label">Executive Summary</div>
+                <p>{{ prop.executive_summary }}</p>
+              </div>
+            }
+
+            @if (prop.situation_analysis) {
+              <div class="proposal-section-block">
+                <div class="prop-section-label">Situation Analysis</div>
+                <p>{{ prop.situation_analysis }}</p>
+              </div>
+            }
+
+            @if (prop.proposed_solution) {
+              <div class="proposal-section-block">
+                <div class="prop-section-label">Proposed Solution</div>
+                <p>{{ prop.proposed_solution }}</p>
+              </div>
+            }
+
+            @if (prop.roi_model) {
+              <div class="roi-grid">
+                <div class="roi-cell">
+                  <span class="roi-label">Annual Cost</span>
+                  <span class="roi-value cost">{{ formatCurrency(prop.roi_model.annual_cost_usd) }}</span>
+                </div>
+                <div class="roi-cell">
+                  <span class="roi-label">Annual Benefit</span>
+                  <span class="roi-value benefit">{{ formatCurrency(prop.roi_model.estimated_annual_benefit_usd) }}</span>
+                </div>
+                <div class="roi-cell">
+                  <span class="roi-label">Payback</span>
+                  <span class="roi-value">{{ prop.roi_model.payback_months }} months</span>
+                </div>
+                <div class="roi-cell">
+                  <span class="roi-label">ROI</span>
+                  <span class="roi-value roi">{{ prop.roi_model.roi_percentage }}%</span>
+                </div>
+              </div>
+            }
+
+            @if (prop.next_steps.length) {
+              <div class="proposal-section-block">
+                <div class="prop-section-label">
+                  <mat-icon>arrow_forward</mat-icon>
+                  Next Steps
+                </div>
+                <ol class="next-steps-list">
+                  @for (step of prop.next_steps; track step) {
+                    <li>{{ step }}</li>
+                  }
+                </ol>
+              </div>
+            }
+          </mat-expansion-panel>
+        }
+      </mat-accordion>
+    </mat-expansion-panel>
+  }
+
+  <!-- ------------------------------------------------------------------ -->
+  <!-- Section 7: Closing Strategies                                        -->
+  <!-- ------------------------------------------------------------------ -->
+  @if (result.closing_strategies.length) {
+    <mat-expansion-panel class="results-section" expanded>
+      <mat-expansion-panel-header>
+        <mat-panel-title>
+          <mat-icon class="section-icon">gavel</mat-icon>
+          Closing Strategies
+          <span class="section-count">{{ result.closing_strategies.length }}</span>
+        </mat-panel-title>
+        <mat-panel-description>Close scripts and objection handling packs</mat-panel-description>
+      </mat-expansion-panel-header>
+
+      <mat-accordion>
+        @for (cs of result.closing_strategies; track cs.prospect.company_name) {
+          <mat-expansion-panel class="inner-panel">
+            <mat-expansion-panel-header>
+              <mat-panel-title>{{ cs.prospect.company_name }}</mat-panel-title>
+              <mat-panel-description>{{ closeTypeLabel(cs.recommended_close_technique) }}</mat-panel-description>
+            </mat-expansion-panel-header>
+
+            <div class="close-technique-chip">
+              <mat-icon>gavel</mat-icon>
+              {{ closeTypeLabel(cs.recommended_close_technique) }}
+            </div>
+
+            @if (cs.close_script) {
+              <div class="script-block">
+                <div class="script-label">
+                  <mat-icon>record_voice_over</mat-icon>
+                  Close Script
+                </div>
+                <pre class="script-text">{{ cs.close_script }}</pre>
+              </div>
+            }
+
+            @if (cs.objection_handlers.length) {
+              <div class="objections-section">
+                <div class="obj-label">
+                  <mat-icon>help_outline</mat-icon>
+                  Objection Handlers
+                </div>
+                @for (h of cs.objection_handlers; track h.objection) {
+                  <div class="objection-handler">
+                    <div class="objection-text">
+                      <mat-icon>question_mark</mat-icon>
+                      {{ h.objection }}
+                    </div>
+                    <div class="response-text">
+                      <mat-icon>reply</mat-icon>
+                      {{ h.response }}
+                    </div>
+                    @if (h.feel_felt_found) {
+                      <div class="fff-text">
+                        <mat-icon>favorite</mat-icon>
+                        {{ h.feel_felt_found }}
+                      </div>
+                    }
+                  </div>
+                }
+              </div>
+            }
+
+            @if (cs.urgency_framing) {
+              <div class="urgency-block">
+                <mat-icon>timer</mat-icon>
+                <div>
+                  <strong>Urgency lever:</strong>
+                  {{ cs.urgency_framing }}
+                </div>
+              </div>
+            }
+
+            @if (cs.emotional_intelligence_notes) {
+              <div class="eq-block">
+                <mat-icon>psychology</mat-icon>
+                <p>{{ cs.emotional_intelligence_notes }}</p>
+              </div>
+            }
+          </mat-expansion-panel>
+        }
+      </mat-accordion>
+    </mat-expansion-panel>
+  }
+
+  <!-- ------------------------------------------------------------------ -->
+  <!-- Section 8: Coaching Report                                           -->
+  <!-- ------------------------------------------------------------------ -->
+  @if (result.coaching_report) {
+    <mat-expansion-panel class="results-section" expanded>
+      <mat-expansion-panel-header>
+        <mat-panel-title>
+          <mat-icon class="section-icon">school</mat-icon>
+          Pipeline Coaching Report
+        </mat-panel-title>
+        <mat-panel-description>Gong Labs-style deal risk analysis</mat-panel-description>
+      </mat-expansion-panel-header>
+
+      @let cr = result.coaching_report;
+
+      <div class="coaching-header-row">
+        <div class="forecast-chip forecast-{{ cr.forecast_category }}">
+          <mat-icon>bar_chart</mat-icon>
+          {{ forecastLabel(cr.forecast_category) }}
+        </div>
+        <span class="prospects-reviewed">{{ cr.prospects_reviewed }} prospects reviewed</span>
+      </div>
+
+      @if (cr.coaching_summary) {
+        <div class="coaching-summary">{{ cr.coaching_summary }}</div>
+      }
+
+      @if (cr.deal_risk_signals.length) {
+        <div class="risk-signals-section">
+          <div class="risk-label">Deal Risk Signals</div>
+          @for (sig of cr.deal_risk_signals; track sig.signal) {
+            <div class="risk-signal" [class]="severityClass(sig.severity)">
+              <div class="signal-header">
+                <mat-icon>warning</mat-icon>
+                <span class="signal-text">{{ sig.signal }}</span>
+                <span class="severity-badge severity-{{ sig.severity }}">{{ sig.severity }}</span>
+              </div>
+              <div class="signal-action">
+                <mat-icon>arrow_forward</mat-icon>
+                {{ sig.recommended_action }}
+              </div>
+            </div>
+          }
+        </div>
+      }
+
+      @if (cr.recommended_next_actions.length) {
+        <div class="coaching-actions">
+          <div class="actions-label">
+            <mat-icon>task_alt</mat-icon>
+            Recommended Next Actions
+          </div>
+          <ul>
+            @for (a of cr.recommended_next_actions; track a) {
+              <li>{{ a }}</li>
+            }
+          </ul>
+        </div>
+      }
+
+      @if (cr.velocity_insights) {
+        <div class="velocity-block">
+          <mat-icon>speed</mat-icon>
+          <p>{{ cr.velocity_insights }}</p>
+        </div>
+      }
+
+      @if (cr.talk_listen_ratio_advice) {
+        <div class="tl-block">
+          <mat-icon>mic</mat-icon>
+          <p>{{ cr.talk_listen_ratio_advice }}</p>
+        </div>
+      }
+    </mat-expansion-panel>
+  }
+}

--- a/user-interface/src/app/components/sales-pipeline-results/sales-pipeline-results.component.scss
+++ b/user-interface/src/app/components/sales-pipeline-results/sales-pipeline-results.component.scss
@@ -1,0 +1,1107 @@
+// Empty state
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+  padding: 3rem 1rem;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+  text-align: center;
+
+  mat-icon {
+    font-size: 2.5rem;
+    width: 2.5rem;
+    height: 2.5rem;
+    opacity: 0.4;
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.9375rem;
+    line-height: 1.5;
+    max-width: 340px;
+  }
+}
+
+// Summary banner
+.summary-banner {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.75rem;
+  padding: 0.875rem 1rem;
+  border-radius: 8px;
+  background: var(--mat-sys-primary-container, #e3f2fd);
+  color: var(--mat-sys-on-primary-container, #0d47a1);
+  margin-bottom: 0.5rem;
+
+  mat-icon {
+    font-size: 1.25rem;
+    width: 1.25rem;
+    height: 1.25rem;
+    margin-top: 0.05rem;
+    flex-shrink: 0;
+  }
+
+  .summary-text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    flex: 1;
+    min-width: 0;
+  }
+
+  .summary-product {
+    font-weight: 700;
+    font-size: 1rem;
+  }
+
+  .summary-body {
+    font-size: 0.8125rem;
+    line-height: 1.4;
+    opacity: 0.85;
+  }
+
+  .entry-stage-chip {
+    flex-shrink: 0;
+    font-size: 0.75rem;
+    font-weight: 500;
+    padding: 0.2rem 0.5rem;
+    border-radius: 4px;
+    background: rgba(0, 0, 0, 0.12);
+    align-self: flex-start;
+    white-space: nowrap;
+  }
+}
+
+// Stats row
+.stats-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-bottom: 0.25rem;
+}
+
+.stat-chip {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  padding: 0.25rem 0.625rem;
+  border-radius: 20px;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  background: var(--mat-sys-surface-container, rgba(0, 0, 0, 0.04));
+  border: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.1));
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+
+  mat-icon {
+    font-size: 0.875rem;
+    width: 0.875rem;
+    height: 0.875rem;
+  }
+}
+
+// Section panels
+.results-section {
+  margin-bottom: 0.5rem;
+  border: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.1));
+  border-radius: 8px;
+
+  .section-icon {
+    color: var(--mat-sys-primary);
+    font-size: 1.125rem;
+    width: 1.125rem;
+    height: 1.125rem;
+  }
+
+  mat-panel-title {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 600;
+  }
+}
+
+.section-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.375rem;
+  height: 1.375rem;
+  border-radius: 20px;
+  background: var(--mat-sys-primary-container, #e3f2fd);
+  color: var(--mat-sys-on-primary-container, #1565c0);
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0 0.4rem;
+}
+
+.inner-panel {
+  border: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.08));
+  border-radius: 6px;
+  margin-bottom: 0.375rem;
+}
+
+// -------------------------------------------------------------------------
+// Prospects grid
+// -------------------------------------------------------------------------
+
+.prospects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 0.75rem;
+}
+
+.prospect-card {
+  padding: 0.875rem;
+  border: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.1));
+  border-radius: 8px;
+  background: var(--mat-sys-surface-container-low, rgba(0, 0, 0, 0.02));
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.prospect-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.prospect-name-block {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  flex: 1;
+  min-width: 0;
+}
+
+.prospect-company {
+  font-weight: 700;
+  font-size: 1rem;
+  line-height: 1.2;
+}
+
+.industry-chip {
+  display: inline-block;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  padding: 0.1rem 0.4rem;
+  border-radius: 3px;
+  background: var(--mat-sys-surface-container, rgba(0, 0, 0, 0.06));
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+  align-self: flex-start;
+}
+
+.icp-score-badge {
+  flex-shrink: 0;
+  font-size: 0.8125rem;
+  font-weight: 700;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+
+  &.score-high {
+    background: rgba(46, 125, 50, 0.15);
+    color: #2e7d32;
+  }
+  &.score-mid {
+    background: rgba(245, 158, 11, 0.15);
+    color: #b45309;
+  }
+  &.score-low {
+    background: rgba(198, 40, 40, 0.1);
+    color: #c62828;
+  }
+}
+
+.prospect-contact {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.8125rem;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+
+  mat-icon {
+    font-size: 0.875rem;
+    width: 0.875rem;
+    height: 0.875rem;
+  }
+}
+
+.trigger-events {
+  .trigger-label {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+    font-weight: 600;
+  }
+
+  .trigger-list {
+    margin: 0.25rem 0 0 0;
+    padding-left: 1.25rem;
+    font-size: 0.8125rem;
+
+    li {
+      line-height: 1.4;
+    }
+  }
+}
+
+.research-notes {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+  line-height: 1.4;
+  font-style: italic;
+}
+
+.icp-bar {
+  height: 3px;
+  border-radius: 2px;
+}
+
+// -------------------------------------------------------------------------
+// Outreach
+// -------------------------------------------------------------------------
+
+.rationale-block {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  padding: 0.625rem 0.75rem;
+  border-radius: 6px;
+  background: var(--mat-sys-surface-container, rgba(0, 0, 0, 0.03));
+  font-size: 0.875rem;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.7));
+  margin-bottom: 0.75rem;
+  font-style: italic;
+
+  mat-icon {
+    font-size: 1rem;
+    width: 1rem;
+    height: 1rem;
+    color: var(--mat-sys-primary);
+    flex-shrink: 0;
+    margin-top: 0.05rem;
+  }
+}
+
+.email-sequence {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1rem;
+}
+
+.email-touch {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.touch-day {
+  flex-shrink: 0;
+  width: 3.5rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--mat-sys-primary);
+  padding-top: 0.125rem;
+  text-align: center;
+}
+
+.touch-body {
+  flex: 1;
+  min-width: 0;
+  border-left: 2px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.12));
+  padding-left: 0.75rem;
+}
+
+.touch-subject {
+  font-weight: 600;
+  font-size: 0.9375rem;
+  margin-bottom: 0.375rem;
+}
+
+.touch-text {
+  margin: 0;
+  font-size: 0.8125rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.5;
+  font-family: inherit;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.75));
+}
+
+.touch-cta {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin-top: 0.5rem;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--mat-sys-primary);
+
+  mat-icon {
+    font-size: 0.875rem;
+    width: 0.875rem;
+    height: 0.875rem;
+  }
+}
+
+.script-block {
+  margin-top: 0.75rem;
+  border-top: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.1));
+  padding-top: 0.75rem;
+}
+
+.script-label {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+  margin-bottom: 0.5rem;
+
+  mat-icon {
+    font-size: 0.875rem;
+    width: 0.875rem;
+    height: 0.875rem;
+  }
+}
+
+.script-text {
+  margin: 0;
+  font-size: 0.875rem;
+  white-space: pre-wrap;
+  word-break: break-word;
+  line-height: 1.5;
+  font-family: inherit;
+}
+
+// -------------------------------------------------------------------------
+// Qualification
+// -------------------------------------------------------------------------
+
+.qual-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 0.75rem;
+}
+
+.qual-card {
+  padding: 0.875rem;
+  border: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.1));
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+}
+
+.qual-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.qual-company {
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.qual-scores-header {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+}
+
+.overall-score {
+  font-size: 1.125rem;
+  font-weight: 800;
+  &.score-high { color: #2e7d32; }
+  &.score-mid { color: #b45309; }
+  &.score-low { color: #c62828; }
+}
+
+.value-tier {
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.15rem 0.4rem;
+  border-radius: 3px;
+  background: var(--mat-sys-surface-container, rgba(0, 0, 0, 0.06));
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+  cursor: default;
+}
+
+.recommendation-chip {
+  display: inline-flex;
+  align-self: flex-start;
+  padding: 0.25rem 0.625rem;
+  border-radius: 20px;
+  font-size: 0.8125rem;
+  font-weight: 600;
+
+  &.chip-advance {
+    background: rgba(46, 125, 50, 0.15);
+    color: #2e7d32;
+  }
+  &.chip-nurture {
+    background: rgba(245, 158, 11, 0.12);
+    color: #b45309;
+  }
+  &.chip-disqualify {
+    background: rgba(198, 40, 40, 0.1);
+    color: #c62828;
+  }
+}
+
+.bant-scores {
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+}
+
+.bant-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+
+  .bant-label {
+    font-size: 0.75rem;
+    width: 4.5rem;
+    flex-shrink: 0;
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+    font-weight: 500;
+  }
+
+  mat-progress-bar {
+    flex: 1;
+    height: 6px;
+    border-radius: 3px;
+  }
+
+  .bant-val {
+    font-size: 0.75rem;
+    width: 2.5rem;
+    text-align: right;
+    font-weight: 600;
+    flex-shrink: 0;
+  }
+}
+
+.meddic-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.25rem 0.5rem;
+}
+
+.meddic-item {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.75rem;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.45));
+
+  mat-icon {
+    font-size: 0.875rem;
+    width: 0.875rem;
+    height: 0.875rem;
+  }
+
+  &.checked {
+    color: var(--mat-sys-on-surface, rgba(0, 0, 0, 0.8));
+
+    mat-icon {
+      color: #2e7d32;
+    }
+  }
+}
+
+.qual-notes {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+  font-style: italic;
+}
+
+// -------------------------------------------------------------------------
+// Nurture timeline
+// -------------------------------------------------------------------------
+
+.nurture-timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+}
+
+.timeline-item {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.timeline-day {
+  flex-shrink: 0;
+  width: 3rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--mat-sys-primary);
+  text-align: center;
+  padding-top: 0.1rem;
+}
+
+.timeline-connector {
+  flex-shrink: 0;
+  width: 2px;
+  background: var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.12));
+  border-radius: 1px;
+}
+
+.timeline-content {
+  flex: 1;
+  padding-bottom: 0.5rem;
+}
+
+.timeline-header {
+  display: flex;
+  align-items: center;
+  gap: 0.375rem;
+  margin-bottom: 0.25rem;
+  flex-wrap: wrap;
+
+  .channel-icon {
+    font-size: 0.875rem;
+    width: 0.875rem;
+    height: 0.875rem;
+    color: var(--mat-sys-primary);
+  }
+
+  .content-type {
+    font-size: 0.8125rem;
+    font-weight: 600;
+  }
+
+  .tp-goal {
+    font-size: 0.75rem;
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+    font-style: italic;
+  }
+}
+
+.tp-message {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.45;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.75));
+}
+
+.triggers-block {
+  margin-top: 0.75rem;
+  border-top: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.1));
+  padding-top: 0.75rem;
+
+  .triggers-label {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+    margin-bottom: 0.375rem;
+
+    mat-icon {
+      font-size: 0.875rem;
+      width: 0.875rem;
+      height: 0.875rem;
+    }
+  }
+
+  .triggers-list {
+    margin: 0;
+    padding-left: 1.25rem;
+    font-size: 0.8125rem;
+
+    li { line-height: 1.5; }
+  }
+}
+
+// -------------------------------------------------------------------------
+// Discovery
+// -------------------------------------------------------------------------
+
+.insight-block {
+  display: flex;
+  gap: 0.5rem;
+  align-items: flex-start;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  background: var(--mat-sys-primary-container, #e3f2fd);
+  color: var(--mat-sys-on-primary-container, #0d47a1);
+  margin-bottom: 0.75rem;
+
+  mat-icon {
+    font-size: 1.125rem;
+    width: 1.125rem;
+    height: 1.125rem;
+    flex-shrink: 0;
+    margin-top: 0.2rem;
+  }
+
+  strong {
+    display: block;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    margin-bottom: 0.25rem;
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    font-style: italic;
+  }
+}
+
+.spin-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.spin-col {
+  border: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.1));
+  border-radius: 6px;
+  padding: 0.75rem;
+
+  ul {
+    margin: 0.375rem 0 0 0;
+    padding-left: 1.125rem;
+    font-size: 0.8125rem;
+
+    li { line-height: 1.45; margin-bottom: 0.25rem; }
+  }
+}
+
+.spin-label {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  padding: 0.15rem 0.5rem;
+  border-radius: 3px;
+  display: inline-block;
+
+  &.situation { background: rgba(59, 130, 246, 0.12); color: #1d4ed8; }
+  &.problem { background: rgba(245, 158, 11, 0.12); color: #b45309; }
+  &.implication { background: rgba(198, 40, 40, 0.1); color: #c62828; }
+  &.need-payoff { background: rgba(46, 125, 50, 0.12); color: #2e7d32; }
+}
+
+.demo-agenda {
+  margin-bottom: 0.75rem;
+
+  .demo-label {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+    margin-bottom: 0.375rem;
+
+    mat-icon { font-size: 0.875rem; width: 0.875rem; height: 0.875rem; }
+  }
+}
+
+.agenda-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  font-size: 0.875rem;
+
+  li { line-height: 1.5; margin-bottom: 0.25rem; }
+}
+
+.objections-block {
+  .obj-label {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+    margin-bottom: 0.375rem;
+
+    mat-icon { font-size: 0.875rem; width: 0.875rem; height: 0.875rem; }
+  }
+
+  ul {
+    margin: 0;
+    padding-left: 1.25rem;
+    font-size: 0.875rem;
+
+    li { line-height: 1.5; margin-bottom: 0.2rem; }
+  }
+}
+
+.success-criteria {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.375rem;
+  font-size: 0.875rem;
+  margin-top: 0.625rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 5px;
+  background: rgba(46, 125, 50, 0.08);
+  color: #2e7d32;
+
+  mat-icon { font-size: 0.875rem; width: 0.875rem; height: 0.875rem; margin-top: 0.1rem; flex-shrink: 0; }
+  strong { font-weight: 600; }
+}
+
+// -------------------------------------------------------------------------
+// Proposal
+// -------------------------------------------------------------------------
+
+.proposal-section-block {
+  margin-bottom: 0.75rem;
+
+  .prop-section-label {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.6875rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+    margin-bottom: 0.25rem;
+
+    mat-icon { font-size: 0.875rem; width: 0.875rem; height: 0.875rem; }
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.875rem;
+    line-height: 1.55;
+  }
+}
+
+.roi-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.5rem;
+  padding: 0.875rem;
+  border-radius: 8px;
+  background: var(--mat-sys-surface-container, rgba(0, 0, 0, 0.03));
+  border: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.1));
+  margin-bottom: 0.75rem;
+
+  @media (max-width: 600px) {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.roi-cell {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+
+  .roi-label {
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+    font-weight: 500;
+  }
+
+  .roi-value {
+    font-size: 1rem;
+    font-weight: 700;
+
+    &.cost { color: var(--mat-sys-error, #c62828); }
+    &.benefit { color: #2e7d32; }
+    &.roi { color: var(--mat-sys-primary); font-size: 1.25rem; }
+  }
+}
+
+.next-steps-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  font-size: 0.875rem;
+
+  li { line-height: 1.5; margin-bottom: 0.25rem; }
+}
+
+// -------------------------------------------------------------------------
+// Closing
+// -------------------------------------------------------------------------
+
+.close-technique-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 20px;
+  background: var(--mat-sys-primary-container, #e3f2fd);
+  color: var(--mat-sys-on-primary-container, #0d47a1);
+  font-size: 0.875rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+
+  mat-icon {
+    font-size: 1rem;
+    width: 1rem;
+    height: 1rem;
+  }
+}
+
+.objections-section {
+  margin-top: 0.75rem;
+
+  .obj-label {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+    margin-bottom: 0.5rem;
+
+    mat-icon { font-size: 0.875rem; width: 0.875rem; height: 0.875rem; }
+  }
+}
+
+.objection-handler {
+  padding: 0.625rem 0.75rem;
+  border-radius: 6px;
+  border: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.1));
+  margin-bottom: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.375rem;
+
+  .objection-text,
+  .response-text,
+  .fff-text {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.375rem;
+    font-size: 0.875rem;
+    line-height: 1.4;
+
+    mat-icon {
+      font-size: 0.875rem;
+      width: 0.875rem;
+      height: 0.875rem;
+      flex-shrink: 0;
+      margin-top: 0.125rem;
+    }
+  }
+
+  .objection-text { color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.7)); font-style: italic; }
+  .response-text { color: var(--mat-sys-on-surface, rgba(0, 0, 0, 0.87)); }
+  .fff-text { color: var(--mat-sys-primary); font-style: italic; }
+}
+
+.urgency-block, .eq-block {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  padding: 0.625rem 0.75rem;
+  border-radius: 6px;
+  margin-top: 0.5rem;
+  font-size: 0.875rem;
+
+  mat-icon {
+    font-size: 1.125rem;
+    width: 1.125rem;
+    height: 1.125rem;
+    flex-shrink: 0;
+    margin-top: 0.05rem;
+  }
+}
+
+.urgency-block {
+  background: rgba(245, 158, 11, 0.1);
+  color: #92400e;
+
+  mat-icon { color: #b45309; }
+  strong { font-weight: 600; }
+}
+
+.eq-block {
+  background: var(--mat-sys-surface-container, rgba(0, 0, 0, 0.03));
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.7));
+
+  p { margin: 0; line-height: 1.5; }
+}
+
+// -------------------------------------------------------------------------
+// Coaching report
+// -------------------------------------------------------------------------
+
+.coaching-header-row {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  margin-bottom: 0.75rem;
+}
+
+.forecast-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  padding: 0.3rem 0.75rem;
+  border-radius: 20px;
+  font-size: 0.875rem;
+  font-weight: 600;
+  background: var(--mat-sys-primary-container, #e3f2fd);
+  color: var(--mat-sys-on-primary-container, #0d47a1);
+
+  mat-icon { font-size: 1rem; width: 1rem; height: 1rem; }
+
+  &.forecast-commit {
+    background: rgba(46, 125, 50, 0.15);
+    color: #1b5e20;
+  }
+  &.forecast-closed {
+    background: rgba(46, 125, 50, 0.25);
+    color: #1b5e20;
+  }
+  &.forecast-omitted {
+    background: var(--mat-sys-surface-variant, #f5f5f5);
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+  }
+}
+
+.prospects-reviewed {
+  font-size: 0.8125rem;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+}
+
+.coaching-summary {
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  background: var(--mat-sys-surface-container, rgba(0, 0, 0, 0.03));
+  font-size: 0.9375rem;
+  line-height: 1.55;
+  margin-bottom: 0.875rem;
+}
+
+.risk-signals-section {
+  margin-bottom: 0.875rem;
+
+  .risk-label {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+    margin-bottom: 0.5rem;
+  }
+}
+
+.risk-signal {
+  padding: 0.625rem 0.75rem;
+  border-radius: 6px;
+  border-left: 3px solid;
+  margin-bottom: 0.5rem;
+  background: var(--mat-sys-surface-container-low, rgba(0, 0, 0, 0.02));
+
+  &.severity-high {
+    border-color: #c62828;
+    background: rgba(198, 40, 40, 0.05);
+  }
+  &.severity-medium {
+    border-color: #b45309;
+    background: rgba(245, 158, 11, 0.06);
+  }
+  &.severity-low {
+    border-color: var(--mat-sys-primary, #1976d2);
+    background: rgba(25, 118, 210, 0.04);
+  }
+
+  .signal-header {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    margin-bottom: 0.25rem;
+
+    mat-icon { font-size: 1rem; width: 1rem; height: 1rem; opacity: 0.6; }
+    .signal-text { font-weight: 500; font-size: 0.875rem; flex: 1; }
+  }
+
+  .signal-action {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.3rem;
+    font-size: 0.8125rem;
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+    padding-left: 1.375rem;
+
+    mat-icon { font-size: 0.75rem; width: 0.75rem; height: 0.75rem; margin-top: 0.1rem; }
+  }
+}
+
+.severity-badge {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  padding: 0.1rem 0.375rem;
+  border-radius: 3px;
+
+  &.severity-high { background: rgba(198, 40, 40, 0.15); color: #c62828; }
+  &.severity-medium { background: rgba(245, 158, 11, 0.15); color: #b45309; }
+  &.severity-low { background: rgba(25, 118, 210, 0.1); color: #1565c0; }
+}
+
+.coaching-actions {
+  .actions-label {
+    display: flex;
+    align-items: center;
+    gap: 0.375rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.5));
+    margin-bottom: 0.375rem;
+
+    mat-icon { font-size: 0.875rem; width: 0.875rem; height: 0.875rem; }
+  }
+
+  ul {
+    margin: 0;
+    padding-left: 1.25rem;
+    font-size: 0.875rem;
+
+    li { line-height: 1.5; margin-bottom: 0.25rem; }
+  }
+}
+
+.velocity-block, .tl-block {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
+  font-size: 0.875rem;
+  margin-top: 0.625rem;
+  color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.7));
+
+  mat-icon { font-size: 1rem; width: 1rem; height: 1rem; flex-shrink: 0; margin-top: 0.05rem; }
+  p { margin: 0; line-height: 1.5; }
+}

--- a/user-interface/src/app/components/sales-pipeline-results/sales-pipeline-results.component.ts
+++ b/user-interface/src/app/components/sales-pipeline-results/sales-pipeline-results.component.ts
@@ -1,0 +1,134 @@
+import { Component, Input, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatCardModule } from '@angular/material/card';
+import { MatIconModule } from '@angular/material/icon';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import type {
+  SalesPipelineResult,
+  Prospect,
+  QualificationScore,
+  BANTScore,
+  DealRiskSignal,
+  CloseType,
+  ForecastCategory,
+  NurtureTouchpoint,
+  OutreachChannel,
+} from '../../models';
+
+@Component({
+  selector: 'app-sales-pipeline-results',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [
+    CommonModule,
+    MatExpansionModule,
+    MatCardModule,
+    MatIconModule,
+    MatChipsModule,
+    MatProgressBarModule,
+    MatDividerModule,
+    MatTooltipModule,
+  ],
+  templateUrl: './sales-pipeline-results.component.html',
+  styleUrl: './sales-pipeline-results.component.scss',
+})
+export class SalesPipelineResultsComponent {
+  @Input() result: SalesPipelineResult | null = null;
+
+  icpScoreClass(score: number): string {
+    if (score >= 0.75) return 'score-high';
+    if (score >= 0.5) return 'score-mid';
+    return 'score-low';
+  }
+
+  icpScoreLabel(score: number): string {
+    if (score >= 0.75) return 'Strong ICP fit';
+    if (score >= 0.5) return 'Moderate ICP fit';
+    return 'Weak ICP fit';
+  }
+
+  bantBarColor(score: number): 'primary' | 'accent' | 'warn' {
+    if (score >= 7) return 'primary';
+    if (score >= 4) return 'accent';
+    return 'warn';
+  }
+
+  bantPercent(score: number): number {
+    return (score / 10) * 100;
+  }
+
+  meddic(q: QualificationScore): { label: string; key: keyof typeof q.meddic; checked: boolean }[] {
+    return [
+      { label: 'Metrics identified', key: 'metrics_identified', checked: q.meddic.metrics_identified },
+      { label: 'Economic buyer known', key: 'economic_buyer_known', checked: q.meddic.economic_buyer_known },
+      { label: 'Decision criteria understood', key: 'decision_criteria_understood', checked: q.meddic.decision_criteria_understood },
+      { label: 'Decision process mapped', key: 'decision_process_mapped', checked: q.meddic.decision_process_mapped },
+      { label: 'Pain identified', key: 'identify_pain', checked: q.meddic.identify_pain },
+      { label: 'Champion found', key: 'champion_found', checked: q.meddic.champion_found },
+    ];
+  }
+
+  recommendationClass(action: string): string {
+    const lower = action.toLowerCase();
+    if (lower.startsWith('advance')) return 'chip-advance';
+    if (lower.startsWith('disqualify')) return 'chip-disqualify';
+    return 'chip-nurture';
+  }
+
+  severityClass(severity: string): string {
+    switch (severity) {
+      case 'high': return 'severity-high';
+      case 'medium': return 'severity-medium';
+      default: return 'severity-low';
+    }
+  }
+
+  closeTypeLabel(type: CloseType): string {
+    const labels: Record<CloseType, string> = {
+      assumptive: 'Assumptive Close',
+      summary: 'Summary Close',
+      urgency: 'Urgency Close',
+      alternative_choice: 'Alternative Choice',
+      sharp_angle: 'Sharp Angle',
+      feel_felt_found: 'Feel / Felt / Found',
+    };
+    return labels[type] ?? type;
+  }
+
+  forecastLabel(cat: ForecastCategory): string {
+    const labels: Record<ForecastCategory, string> = {
+      pipeline: 'Pipeline',
+      best_case: 'Best Case',
+      commit: 'Commit',
+      closed: 'Closed',
+      omitted: 'Omitted',
+    };
+    return labels[cat] ?? cat;
+  }
+
+  channelIcon(channel: OutreachChannel): string {
+    const icons: Record<OutreachChannel, string> = {
+      email: 'mail',
+      phone: 'phone',
+      linkedin: 'person',
+      video: 'videocam',
+    };
+    return icons[channel] ?? 'contact_mail';
+  }
+
+  outcomeScorePercent(score: number): number {
+    return Math.round(score * 100);
+  }
+
+  formatCurrency(val: number): string {
+    return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD', maximumFractionDigits: 0 }).format(val);
+  }
+
+  stageLabel(stage: string): string {
+    return stage.replace(/_/g, ' ').replace(/\b\w/g, c => c.toUpperCase());
+  }
+}

--- a/user-interface/src/app/models/index.ts
+++ b/user-interface/src/app/models/index.ts
@@ -16,3 +16,4 @@ export * from './jobs-dashboard.model';
 export * from './integrations.model';
 export * from './planning-v3.model';
 export * from './studio-grid.model';
+export * from './sales-team.model';

--- a/user-interface/src/app/models/sales-team.model.ts
+++ b/user-interface/src/app/models/sales-team.model.ts
@@ -1,0 +1,410 @@
+/** TypeScript models for the AI Sales Team API. */
+
+// -------------------------------------------------------------------------
+// Enums (string literal unions matching backend Python enums)
+// -------------------------------------------------------------------------
+
+export type PipelineStage =
+  | 'prospecting'
+  | 'outreach'
+  | 'qualification'
+  | 'nurturing'
+  | 'discovery'
+  | 'proposal'
+  | 'negotiation'
+  | 'closed_won'
+  | 'closed_lost';
+
+export type OutreachChannel = 'email' | 'phone' | 'linkedin' | 'video';
+
+export type CloseType =
+  | 'assumptive'
+  | 'summary'
+  | 'urgency'
+  | 'alternative_choice'
+  | 'sharp_angle'
+  | 'feel_felt_found';
+
+export type ForecastCategory = 'pipeline' | 'best_case' | 'commit' | 'closed' | 'omitted';
+
+export type OutcomeResult = 'converted' | 'stalled' | 'objection' | 'disqualified' | 'won' | 'lost';
+
+// -------------------------------------------------------------------------
+// ICP & Prospect
+// -------------------------------------------------------------------------
+
+export interface IdealCustomerProfile {
+  industry: string[];
+  company_size_min: number;
+  company_size_max: number;
+  job_titles: string[];
+  pain_points: string[];
+  budget_range_usd: string;
+  geographic_focus: string[];
+  tech_stack_keywords: string[];
+  disqualifying_traits: string[];
+}
+
+export interface Prospect {
+  company_name: string;
+  website?: string;
+  contact_name?: string;
+  contact_title?: string;
+  contact_email?: string;
+  linkedin_url?: string;
+  company_size_estimate?: string;
+  industry?: string;
+  icp_match_score: number;
+  research_notes: string;
+  trigger_events: string[];
+}
+
+// -------------------------------------------------------------------------
+// Outreach
+// -------------------------------------------------------------------------
+
+export interface EmailTouch {
+  day: number;
+  subject_line: string;
+  body: string;
+  personalization_tokens: string[];
+  call_to_action: string;
+}
+
+export interface OutreachSequence {
+  prospect: Prospect;
+  email_sequence: EmailTouch[];
+  call_script: string;
+  linkedin_message: string;
+  sequence_rationale: string;
+}
+
+// -------------------------------------------------------------------------
+// Qualification
+// -------------------------------------------------------------------------
+
+export interface BANTScore {
+  budget: number;
+  authority: number;
+  need: number;
+  timeline: number;
+}
+
+export interface MEDDICScore {
+  metrics_identified: boolean;
+  economic_buyer_known: boolean;
+  decision_criteria_understood: boolean;
+  decision_process_mapped: boolean;
+  identify_pain: boolean;
+  champion_found: boolean;
+}
+
+export interface QualificationScore {
+  prospect: Prospect;
+  bant: BANTScore;
+  meddic: MEDDICScore;
+  overall_score: number;
+  value_creation_level: number;
+  recommended_action: string;
+  disqualification_reason?: string;
+  qualification_notes: string;
+}
+
+// -------------------------------------------------------------------------
+// Nurture
+// -------------------------------------------------------------------------
+
+export interface NurtureTouchpoint {
+  day: number;
+  channel: OutreachChannel;
+  content_type: string;
+  message: string;
+  goal: string;
+}
+
+export interface NurtureSequence {
+  prospect: Prospect;
+  duration_days: number;
+  touchpoints: NurtureTouchpoint[];
+  re_engagement_triggers: string[];
+  content_recommendations: string[];
+}
+
+// -------------------------------------------------------------------------
+// Discovery
+// -------------------------------------------------------------------------
+
+export interface SPINQuestions {
+  situation: string[];
+  problem: string[];
+  implication: string[];
+  need_payoff: string[];
+}
+
+export interface DiscoveryPlan {
+  prospect: Prospect;
+  spin_questions: SPINQuestions;
+  challenger_insight: string;
+  demo_agenda: string[];
+  expected_objections: string[];
+  success_criteria_for_call: string;
+}
+
+// -------------------------------------------------------------------------
+// Proposal
+// -------------------------------------------------------------------------
+
+export interface ROIModel {
+  annual_cost_usd: number;
+  estimated_annual_benefit_usd: number;
+  payback_months: number;
+  roi_percentage: number;
+  assumptions: string[];
+}
+
+export interface ProposalSection {
+  heading: string;
+  content: string;
+}
+
+export interface SalesProposal {
+  prospect: Prospect;
+  executive_summary: string;
+  situation_analysis: string;
+  proposed_solution: string;
+  roi_model: ROIModel;
+  investment_table: string;
+  implementation_timeline: string;
+  risk_mitigation: string;
+  next_steps: string[];
+  custom_sections: ProposalSection[];
+}
+
+// -------------------------------------------------------------------------
+// Closing
+// -------------------------------------------------------------------------
+
+export interface ObjectionHandler {
+  objection: string;
+  response: string;
+  feel_felt_found?: string;
+}
+
+export interface ClosingStrategy {
+  prospect: Prospect;
+  recommended_close_technique: CloseType;
+  close_script: string;
+  objection_handlers: ObjectionHandler[];
+  urgency_framing: string;
+  walk_away_criteria: string;
+  emotional_intelligence_notes: string;
+}
+
+// -------------------------------------------------------------------------
+// Coaching
+// -------------------------------------------------------------------------
+
+export interface DealRiskSignal {
+  signal: string;
+  severity: 'low' | 'medium' | 'high';
+  recommended_action: string;
+}
+
+export interface PipelineCoachingReport {
+  prospects_reviewed: number;
+  deal_risk_signals: DealRiskSignal[];
+  talk_listen_ratio_advice: string;
+  velocity_insights: string;
+  forecast_category: ForecastCategory;
+  top_priority_deals: string[];
+  recommended_next_actions: string[];
+  coaching_summary: string;
+}
+
+// -------------------------------------------------------------------------
+// Pipeline I/O
+// -------------------------------------------------------------------------
+
+export interface SalesPipelineRequest {
+  product_name: string;
+  value_proposition: string;
+  icp: IdealCustomerProfile;
+  entry_stage?: PipelineStage;
+  max_prospects?: number;
+  existing_prospects?: Prospect[];
+  company_context?: string;
+  case_study_snippets?: string[];
+}
+
+export interface SalesPipelineResult {
+  job_id: string;
+  entry_stage: PipelineStage;
+  product_name: string;
+  prospects: Prospect[];
+  outreach_sequences: OutreachSequence[];
+  qualified_leads: QualificationScore[];
+  nurture_sequences: NurtureSequence[];
+  discovery_plans: DiscoveryPlan[];
+  proposals: SalesProposal[];
+  closing_strategies: ClosingStrategy[];
+  coaching_report?: PipelineCoachingReport;
+  summary: string;
+}
+
+// -------------------------------------------------------------------------
+// Job management
+// -------------------------------------------------------------------------
+
+export interface SalesPipelineRunResponse {
+  job_id: string;
+  status: string;
+  message: string;
+}
+
+export interface SalesPipelineStatusResponse {
+  job_id: string;
+  status: string;
+  current_stage: string;
+  progress: number;
+  product_name: string;
+  last_updated_at: string;
+  eta_hint?: string;
+  error?: string;
+  result?: SalesPipelineResult;
+}
+
+export interface SalesPipelineJobListItem {
+  job_id: string;
+  status: string;
+  current_stage: string;
+  progress: number;
+  product_name: string;
+  created_at?: string;
+  last_updated_at?: string;
+}
+
+// -------------------------------------------------------------------------
+// Outcomes
+// -------------------------------------------------------------------------
+
+export interface StageOutcome {
+  outcome_id: string;
+  recorded_at: string;
+  pipeline_job_id?: string;
+  company_name: string;
+  industry?: string;
+  stage: PipelineStage;
+  outcome: OutcomeResult;
+  icp_match_score?: number;
+  qualification_score?: number;
+  email_touch_number?: number;
+  subject_line_used?: string;
+  objection_text?: string;
+  close_technique_used?: CloseType;
+  notes: string;
+}
+
+export interface DealOutcome {
+  outcome_id: string;
+  recorded_at: string;
+  pipeline_job_id?: string;
+  company_name: string;
+  industry?: string;
+  deal_size_usd?: number;
+  final_stage_reached: PipelineStage;
+  result: OutcomeResult;
+  loss_reason?: string;
+  win_factor?: string;
+  close_technique_used?: CloseType;
+  objections_raised: string[];
+  stages_completed: PipelineStage[];
+  icp_match_score?: number;
+  qualification_score?: number;
+  sales_cycle_days?: number;
+  notes: string;
+}
+
+export interface RecordStageOutcomeRequest {
+  company_name: string;
+  stage: PipelineStage;
+  outcome: OutcomeResult;
+  pipeline_job_id?: string;
+  industry?: string;
+  icp_match_score?: number;
+  qualification_score?: number;
+  email_touch_number?: number;
+  subject_line_used?: string;
+  objection_text?: string;
+  close_technique_used?: CloseType;
+  notes?: string;
+}
+
+export interface RecordDealOutcomeRequest {
+  company_name: string;
+  result: OutcomeResult;
+  final_stage_reached: PipelineStage;
+  pipeline_job_id?: string;
+  industry?: string;
+  deal_size_usd?: number;
+  loss_reason?: string;
+  win_factor?: string;
+  close_technique_used?: CloseType;
+  objections_raised?: string[];
+  stages_completed?: PipelineStage[];
+  icp_match_score?: number;
+  qualification_score?: number;
+  sales_cycle_days?: number;
+  notes?: string;
+}
+
+export interface RecordOutcomeResponse {
+  outcome_id: string;
+  message: string;
+}
+
+// -------------------------------------------------------------------------
+// Learning Insights
+// -------------------------------------------------------------------------
+
+export interface LearningInsights {
+  total_outcomes_analyzed: number;
+  win_rate: number;
+  stage_conversion_rates: Record<string, number>;
+  top_performing_industries: string[];
+  top_icp_signals: string[];
+  best_outreach_angles: string[];
+  common_objections: string[];
+  best_close_techniques: string[];
+  winning_patterns: string[];
+  losing_patterns: string[];
+  avg_deal_size_won_usd?: number;
+  avg_sales_cycle_days?: number;
+  actionable_recommendations: string[];
+  generated_at: string;
+  insights_version: number;
+}
+
+export interface InsightsRefreshResponse {
+  message: string;
+  insights_version: number;
+  total_outcomes_analyzed: number;
+  win_rate: number;
+}
+
+export interface OutcomeSummary {
+  stage_outcomes: number;
+  deal_outcomes: number;
+  has_insights: boolean;
+}
+
+// -------------------------------------------------------------------------
+// Health
+// -------------------------------------------------------------------------
+
+export interface SalesHealthResponse {
+  status: string;
+  strands_sdk: string;
+  stage_outcomes_recorded: string;
+  deal_outcomes_recorded: string;
+  insights_available: string;
+}

--- a/user-interface/src/app/services/sales-api.service.ts
+++ b/user-interface/src/app/services/sales-api.service.ts
@@ -1,0 +1,123 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+import type {
+  SalesPipelineRequest,
+  SalesPipelineRunResponse,
+  SalesPipelineStatusResponse,
+  SalesPipelineJobListItem,
+  SalesPipelineResult,
+  RecordStageOutcomeRequest,
+  RecordDealOutcomeRequest,
+  RecordOutcomeResponse,
+  StageOutcome,
+  DealOutcome,
+  OutcomeSummary,
+  LearningInsights,
+  InsightsRefreshResponse,
+  SalesHealthResponse,
+} from '../models';
+
+/**
+ * Service for the AI Sales Team API.
+ * Base URL from environment.salesApiUrl  →  /api/sales
+ */
+@Injectable({ providedIn: 'root' })
+export class SalesApiService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = environment.salesApiUrl;
+
+  // -------------------------------------------------------------------------
+  // Health
+  // -------------------------------------------------------------------------
+
+  health(): Observable<SalesHealthResponse> {
+    return this.http.get<SalesHealthResponse>(`${this.baseUrl}/health`);
+  }
+
+  // -------------------------------------------------------------------------
+  // Pipeline (async job-based)
+  // -------------------------------------------------------------------------
+
+  runPipeline(request: SalesPipelineRequest): Observable<SalesPipelineRunResponse> {
+    return this.http.post<SalesPipelineRunResponse>(
+      `${this.baseUrl}/sales/pipeline/run`,
+      request
+    );
+  }
+
+  getPipelineStatus(jobId: string): Observable<SalesPipelineStatusResponse> {
+    return this.http.get<SalesPipelineStatusResponse>(
+      `${this.baseUrl}/sales/pipeline/status/${jobId}`
+    );
+  }
+
+  listPipelineJobs(runningOnly = false): Observable<SalesPipelineJobListItem[]> {
+    const params = new HttpParams().set('running_only', String(runningOnly));
+    return this.http.get<SalesPipelineJobListItem[]>(
+      `${this.baseUrl}/sales/pipeline/jobs`,
+      { params }
+    );
+  }
+
+  cancelJob(jobId: string): Observable<unknown> {
+    return this.http.post(
+      `${this.baseUrl}/sales/pipeline/job/${jobId}/cancel`,
+      {}
+    );
+  }
+
+  deleteJob(jobId: string): Observable<unknown> {
+    return this.http.delete(
+      `${this.baseUrl}/sales/pipeline/job/${jobId}`
+    );
+  }
+
+  // -------------------------------------------------------------------------
+  // Outcomes
+  // -------------------------------------------------------------------------
+
+  recordStageOutcome(request: RecordStageOutcomeRequest): Observable<RecordOutcomeResponse> {
+    return this.http.post<RecordOutcomeResponse>(
+      `${this.baseUrl}/sales/outcomes/stage`,
+      request
+    );
+  }
+
+  recordDealOutcome(request: RecordDealOutcomeRequest): Observable<RecordOutcomeResponse> {
+    return this.http.post<RecordOutcomeResponse>(
+      `${this.baseUrl}/sales/outcomes/deal`,
+      request
+    );
+  }
+
+  getOutcomeSummary(): Observable<OutcomeSummary> {
+    return this.http.get<OutcomeSummary>(`${this.baseUrl}/sales/outcomes/summary`);
+  }
+
+  listStageOutcomes(limit = 100): Observable<StageOutcome[]> {
+    const params = new HttpParams().set('limit', String(limit));
+    return this.http.get<StageOutcome[]>(`${this.baseUrl}/sales/outcomes/stage`, { params });
+  }
+
+  listDealOutcomes(limit = 100): Observable<DealOutcome[]> {
+    const params = new HttpParams().set('limit', String(limit));
+    return this.http.get<DealOutcome[]>(`${this.baseUrl}/sales/outcomes/deal`, { params });
+  }
+
+  // -------------------------------------------------------------------------
+  // Learning Insights
+  // -------------------------------------------------------------------------
+
+  getInsights(): Observable<LearningInsights> {
+    return this.http.get<LearningInsights>(`${this.baseUrl}/sales/insights`);
+  }
+
+  refreshInsights(): Observable<InsightsRefreshResponse> {
+    return this.http.post<InsightsRefreshResponse>(
+      `${this.baseUrl}/sales/insights/refresh`,
+      {}
+    );
+  }
+}

--- a/user-interface/src/environments/environment.ts
+++ b/user-interface/src/environments/environment.ts
@@ -20,5 +20,6 @@ export const environment = {
   integrationsApiUrl: `${apiBase}/api/integrations`,
   /** StudioGrid design-system workflow API */
   studioGridApiUrl: `${apiBase}/api/studio-grid`,
+  salesApiUrl: `${apiBase}/api/sales`,
 };
 


### PR DESCRIPTION
Implements a complete tech-sales pod (modeled on modern sales pod structure)
covering every stage of the pipeline from prospecting through close.

## Sales Pod Agents (8 AWS Strands agents)
- ProspectorAgent (SDR): ICP-based lead identification via Jeb Blount's
  Fanatical Prospecting 30-day rule and Sales Hacker ICP scoring
- OutreachAgent (SDR/BDR): 6-touch cold sequences per Salesfolk email
  principles, Jill Konrath SNAP framework, and Jeb Blount cadence
- LeadQualifierAgent (BDR): BANT + MEDDIC scoring with Anthony Iannarino's
  Level 1-4 Value Creation tier assignment
- NurtureAgent (AM): Long-cycle follow-up via HubSpot inbound content model
  and Gong Labs optimal cadence research
- DiscoveryAgent (AE): SPIN Selling question sets (Jill Konrath) + Challenger
  Sale insight-led openings + tailored demo agendas
- ProposalAgent (AE): Iannarino Level-4 proposals with full ROI/payback model
- CloserAgent (AE): Zig Ziglar closing techniques + Jeb Blount Sales EQ
  objection handling (Feel/Felt/Found)
- SalesCoachAgent (Manager): Gong Labs deal risk signals, pipeline velocity
  analysis, talk/listen ratio coaching

## Pipeline Stages
Prospecting → Outreach → Qualification → Nurturing →
Discovery → Proposal → Negotiation → Closed (Won/Lost)

## API
- POST /api/sales/pipeline/run — async full pipeline (job-based)
- POST /api/sales/prospect|outreach|qualify|nurture|proposal|coaching — sync
- GET /api/sales/pipeline/status/{job_id} — poll job
- GET /api/sales/pipeline/jobs — list all jobs
- POST/DELETE /api/sales/pipeline/job/{id}/cancel|delete

45 tests pass (stub mode — no strands SDK required in CI).

https://claude.ai/code/session_013s4jNXogzKJdZd2vXEu6oE