### PR TITLE
Blogging-containerized

### DIFF
--- a/backend/agents/blogging/README.md
+++ b/backend/agents/blogging/README.md
@@ -176,6 +176,16 @@ Optional: `work_dir` or `run_id` – when set, persists `research_packet.md` and
 
 Interactive docs: http://localhost:8000/docs
 
+## Dedicated container deployment (behind Unified API)
+
+You can run blogging as a standalone container and keep the public route at `/api/blogging` via unified API proxy mode:
+
+1. Start a dedicated blogging service (e.g. uvicorn `blogging.api.main:app` on `:8081` in Docker network).
+2. Set `BLOGGING_REMOTE_URL` in unified API (for example `http://blogging-api:8081`).
+3. Keep UI and external clients calling unified API at `/api/blogging/*` unchanged.
+
+Rollback: unset `BLOGGING_REMOTE_URL` to return to in-process blogging mount.
+
 ## Style guide and brand spec
 
 The Draft and Copy Editor agents do **not** accept file paths. Callers must load the writing style guide and brand spec **before** instantiating the agents, then pass the **full file contents** as strings:

--- a/backend/agents/llm_service/clients/ollama.py
+++ b/backend/agents/llm_service/clients/ollama.py
@@ -47,6 +47,7 @@ _EXPECTED_KEYS = frozenset({
     "tasks", "execution_order",
     "bugs_found", "integration_tests", "unit_tests", "readme_content",
 })
+_JSON_NOISE_RE = re.compile(r"[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f\uFFFD]")
 
 
 def _parse_retry_config() -> tuple[int, float, float]:
@@ -206,8 +207,16 @@ class OllamaLLMClient(LLMClient):
         s = re.sub(r",\s*([}\]])", r"\1", s)
         return s
 
+    def _strip_json_noise(self, s: str) -> str:
+        """Drop transport artifacts (BOM/replacement chars/control bytes) from JSON-ish text."""
+        if not s:
+            return s
+        s = s.replace("\ufeff", "")
+        return _JSON_NOISE_RE.sub("", s)
+
     def _extract_json(self, text: str) -> Dict[str, Any]:
         """Extract a single JSON object from model output. Raises LLMJsonParseError on failure."""
+        text = self._strip_json_noise(text)
         if "---DRAFT---" in text:
             parts = text.split("---DRAFT---", 1)
             if len(parts) == 2 and parts[1].strip():

--- a/backend/agents/llm_service/tests/test_ollama_client.py
+++ b/backend/agents/llm_service/tests/test_ollama_client.py
@@ -73,3 +73,11 @@ def test_ollama_complete_json_404_raises_permanent(monkeypatch: pytest.MonkeyPat
         with pytest.raises(LLMPermanentError) as exc_info:
             client.complete_json("hello", temperature=0)
         assert exc_info.value.status_code == 404
+
+
+def test_extract_json_tolerates_replacement_char_noise() -> None:
+    client = OllamaLLMClient(model="test", base_url="http://localhost:9999", timeout=5)
+    noisy = '{\n  "approved": false,\n�  "summary": "ok",\n  "feedback_items": []\n}'
+    parsed = client._extract_json(noisy)
+    assert parsed["approved"] is False
+    assert parsed["summary"] == "ok"

--- a/backend/unified_api/README.md
+++ b/backend/unified_api/README.md
@@ -93,6 +93,17 @@ python run_unified_api.py --workers 4 --log-level warning
 
 Team-specific environment variables (e.g., `OLLAMA_API_KEY`, `SW_LLM_*`, `PA_*`) are passed through to the mounted team APIs.
 
+### Optional blogging remote mode
+
+Set `BLOGGING_REMOTE_URL` (example: `http://blogging-api:8081`) to proxy `/api/blogging/*` to a dedicated blogging container/service instead of mounting blogging in-process.
+
+- When `BLOGGING_REMOTE_URL` is set:
+  - Unified API forwards `/api/blogging` and `/api/blogging/{path}` requests to the remote target.
+  - Blogging Temporal worker is not started in unified API.
+  - Blogging shutdown job-failure hook is not run in unified API.
+- When `BLOGGING_REMOTE_URL` is unset:
+  - Existing in-process blogging mount behavior is preserved.
+
 ## CLI Options
 
 ```
@@ -292,6 +303,16 @@ Check the console output for import errors:
 ```
 
 Fix: Install missing dependencies (`pip install cryptography`).
+
+### Blogging route returns 503
+
+If `/api/blogging/*` returns `503` with `Blogging service unavailable`, unified API is in remote-blogging mode and cannot reach `BLOGGING_REMOTE_URL`.
+
+Checklist:
+
+1. Verify `BLOGGING_REMOTE_URL` is reachable from the unified API container.
+2. Verify blogging service health endpoint responds (`/health`).
+3. For immediate rollback, unset `BLOGGING_REMOTE_URL` and restart unified API to use local mount mode.
 
 ### Port Already in Use
 

--- a/backend/unified_api/config.py
+++ b/backend/unified_api/config.py
@@ -30,6 +30,11 @@ TEMPORAL_ADDRESS = os.getenv("TEMPORAL_ADDRESS", "").strip() or None
 TEMPORAL_NAMESPACE = os.getenv("TEMPORAL_NAMESPACE", "default").strip()
 TEMPORAL_TASK_QUEUE = os.getenv("TEMPORAL_TASK_QUEUE", "software-engineering").strip()
 
+# Optional: proxy /api/blogging to an external blogging container/service.
+# When set, unified_api will route blogging requests to this URL instead of
+# mounting blogging.api.main in-process.
+BLOGGING_REMOTE_URL = os.getenv("BLOGGING_REMOTE_URL", "").strip() or None
+
 # Team configurations with route prefixes
 TEAM_CONFIGS: Dict[str, TeamConfig] = {
     "blogging": TeamConfig(

--- a/backend/unified_api/main.py
+++ b/backend/unified_api/main.py
@@ -25,9 +25,11 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any, Dict, List
 
+import httpx
 from fastapi import FastAPI
+from fastapi import Request
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
 from pydantic import BaseModel
 
 # Add agents directory to path for imports
@@ -43,7 +45,7 @@ _studiogrid_src = _project_root / "studiogrid" / "src"
 if str(_studiogrid_src) not in sys.path:
     sys.path.insert(0, str(_studiogrid_src))
 
-from unified_api.config import TEAM_CONFIGS, get_enabled_teams
+from unified_api.config import BLOGGING_REMOTE_URL, TEAM_CONFIGS, get_enabled_teams
 
 logging.basicConfig(
     level=logging.INFO,
@@ -98,6 +100,7 @@ class SecurityErrorResponse(BaseModel):
 
 # Track mounted routers for health checks
 _mounted_teams: Dict[str, bool] = {}
+_locally_mounted_teams: Dict[str, bool] = {}
 
 # Team keys that have async jobs: on shutdown, call their mark_all_running_jobs_failed(reason).
 # Maps team_key -> (module_dot_path, function_name).
@@ -119,7 +122,7 @@ SHUTDOWN_HOOKS: Dict[str, tuple] = {
 def _run_shutdown_hooks(reason: str) -> None:
     """Call each mounted team's mark_all_running_jobs_failed(reason). Used by lifespan and atexit."""
     for team_key, (module_path, func_name) in SHUTDOWN_HOOKS.items():
-        if not _mounted_teams.get(team_key):
+        if not _locally_mounted_teams.get(team_key):
             continue
         try:
             mod = importlib.import_module(module_path)
@@ -129,8 +132,69 @@ def _run_shutdown_hooks(reason: str) -> None:
             logger.warning("Shutdown hook for team %s failed: %s", team_key, e)
 
 
+def _proxyable_headers(headers: Dict[str, str]) -> Dict[str, str]:
+    """Drop hop-by-hop headers before proxying."""
+    blocked = {"host", "content-length", "connection", "transfer-encoding"}
+    return {k: v for k, v in headers.items() if k.lower() not in blocked}
+
+
+def _register_blogging_proxy_routes(app: FastAPI, remote_base: str) -> None:
+    """Proxy /api/blogging requests to a dedicated blogging container."""
+
+    async def _proxy(request: Request, subpath: str = "") -> Response:
+        target_url = f"{remote_base.rstrip('/')}/{subpath.lstrip('/')}" if subpath else remote_base.rstrip("/")
+        if request.url.query:
+            target_url = f"{target_url}?{request.url.query}"
+
+        body = await request.body()
+        headers = _proxyable_headers(dict(request.headers))
+
+        try:
+            async with httpx.AsyncClient(timeout=120.0) as client:
+                upstream = await client.request(
+                    request.method,
+                    target_url,
+                    content=body,
+                    headers=headers,
+                )
+        except httpx.RequestError as exc:
+            return JSONResponse(
+                status_code=503,
+                content={
+                    "detail": "Blogging service unavailable",
+                    "error": str(exc),
+                },
+            )
+
+        passthrough = {}
+        content_type = upstream.headers.get("content-type")
+        if content_type:
+            passthrough["content-type"] = content_type
+        content_disposition = upstream.headers.get("content-disposition")
+        if content_disposition:
+            passthrough["content-disposition"] = content_disposition
+
+        return Response(
+            content=upstream.content,
+            status_code=upstream.status_code,
+            headers=passthrough,
+        )
+
+    app.add_api_route("/api/blogging", _proxy, methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"])
+    app.add_api_route(
+        "/api/blogging/{subpath:path}",
+        _proxy,
+        methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"],
+    )
+
+
 def _try_mount_blogging(app: FastAPI) -> bool:
     """Mount blogging team API."""
+    if BLOGGING_REMOTE_URL:
+        remote = BLOGGING_REMOTE_URL.rstrip("/")
+        _register_blogging_proxy_routes(app, remote)
+        logger.info("Configured Blogging API proxy at /api/blogging -> %s", remote)
+        return True
     try:
         from blogging.api.main import app as blogging_app
 
@@ -387,15 +451,22 @@ def mount_all_teams(app: FastAPI) -> Dict[str, bool]:
     }
 
     results = {}
+    local_results: Dict[str, bool] = {}
     enabled_teams = get_enabled_teams()
 
     for team_key, mount_fn in mount_functions.items():
         if team_key in enabled_teams:
             results[team_key] = mount_fn(app)
+            local_results[team_key] = bool(results[team_key])
+            if team_key == "blogging" and BLOGGING_REMOTE_URL:
+                local_results[team_key] = False
         else:
             results[team_key] = False
+            local_results[team_key] = False
             logger.info("Team %s is disabled, skipping mount", team_key)
 
+    global _locally_mounted_teams
+    _locally_mounted_teams = local_results
     return results
 
 
@@ -424,7 +495,7 @@ async def lifespan(app: FastAPI):
         "social_marketing": ("social_media_marketing_team.temporal.worker", "start_social_marketing_temporal_worker_thread"),
     }
     for team_key, (mod_path, func_name) in _temporal_worker_starters.items():
-        if not _mounted_teams.get(team_key):
+        if not _locally_mounted_teams.get(team_key):
             continue
         try:
             mod = importlib.import_module(mod_path)

--- a/backend/unified_api/tests/test_blogging_proxy.py
+++ b/backend/unified_api/tests/test_blogging_proxy.py
@@ -1,0 +1,56 @@
+"""Tests for blogging remote proxy wiring."""
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def test_try_mount_blogging_registers_proxy_when_remote_url_set() -> None:
+    from unified_api import main as unified_main
+
+    app = FastAPI()
+    with patch.object(unified_main, "BLOGGING_REMOTE_URL", "http://blogging-api:8081"):
+        mounted = unified_main._try_mount_blogging(app)
+
+    assert mounted is True
+    paths = {route.path for route in app.routes}
+    assert "/api/blogging" in paths
+    assert "/api/blogging/{subpath:path}" in paths
+
+
+def test_blogging_proxy_forwards_success_response() -> None:
+    from unified_api import main as unified_main
+
+    app = FastAPI()
+    unified_main._register_blogging_proxy_routes(app, "http://blogging-api:8081")
+
+    mock_response = AsyncMock()
+    mock_response.content = b'{"status":"ok"}'
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/json"}
+
+    with patch("httpx.AsyncClient.request", new=AsyncMock(return_value=mock_response)):
+        with TestClient(app) as client:
+            resp = client.get("/api/blogging/health")
+
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "ok"}
+
+
+def test_blogging_proxy_returns_503_when_upstream_unavailable() -> None:
+    import httpx
+    from unified_api import main as unified_main
+
+    app = FastAPI()
+    unified_main._register_blogging_proxy_routes(app, "http://blogging-api:8081")
+
+    with patch(
+        "httpx.AsyncClient.request",
+        new=AsyncMock(side_effect=httpx.RequestError("boom")),
+    ):
+        with TestClient(app) as client:
+            resp = client.get("/api/blogging/health")
+
+    assert resp.status_code == 503
+    assert "Blogging service unavailable" in resp.text

--- a/backend/unified_api/tests/test_shutdown_hooks.py
+++ b/backend/unified_api/tests/test_shutdown_hooks.py
@@ -10,7 +10,7 @@ def test_run_shutdown_hooks_calls_mounted_team_hook() -> None:
     from unified_api import main as unified_main
 
     mock_fn = MagicMock()
-    with patch.dict(unified_main._mounted_teams, {"blogging": True}, clear=False):
+    with patch.dict(unified_main._locally_mounted_teams, {"blogging": True}, clear=False):
         with patch("importlib.import_module") as import_mock:
             mod = MagicMock()
             mod.mark_all_running_jobs_failed = mock_fn
@@ -26,7 +26,7 @@ def test_run_shutdown_hooks_skips_unmounted_teams() -> None:
     """_run_shutdown_hooks does not call hook for teams that are not mounted."""
     from unified_api import main as unified_main
 
-    with patch.dict(unified_main._mounted_teams, {"blogging": False, "software_engineering": False}, clear=False):
+    with patch.dict(unified_main._locally_mounted_teams, {"blogging": False, "software_engineering": False}, clear=False):
         with patch("importlib.import_module") as import_mock:
             unified_main._run_shutdown_hooks("test")
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -6,7 +6,8 @@ This directory defines a **Docker Compose stack** that runs:
 - **Temporal** – workflow engine (Postgres-backed, no Elasticsearch)
 - **Temporal UI** – Web UI for workflows
 - **Ollama** (optional) – local Ollama server if you override LLM to use it
-- **Strands Agents** – all agent APIs; **default LLM is Ollama Cloud** (https://ollama.com) when running from Docker
+- **Strands Agents (Unified API)** – public entrypoint on `:8888` for all team routes
+- **Blogging API** – dedicated blogging container (proxied by Unified API at `/api/blogging`)
 
 ## Quick start
 
@@ -40,7 +41,8 @@ This directory defines a **Docker Compose stack** that runs:
    | Service        | URL                         |
    |----------------|-----------------------------|
    | **Angular UI** | http://localhost:4201       (proxies /api to agents) |
-   | Agents API     | http://localhost:8888       (direct) |
+| Agents API (Unified) | http://localhost:8888  (direct) |
+| Blogging API (internal service) | `http://blogging-api:8081` inside Docker network |
    | Temporal UI    | http://localhost:8080       |
    | Postgres       | localhost:5432 (user `postgres` / `temporal` / `strands`) |
    | Ollama (local) | http://localhost:11434      |
@@ -55,6 +57,7 @@ Optional (defaults in compose / `docker/.env.example`; copy to `docker/.env` and
 
 - **SW_LLM_BASE_URL** – default is `https://ollama.com` (Ollama Cloud). Set to `http://ollama:11434` to use the local Ollama container instead.
 - **SW_LLM_MODEL** – default `qwen3.5:397b-cloud`
+- **BLOGGING_REMOTE_URL** – default `http://blogging-api:8081`; when set in the unified container, `/api/blogging/*` is proxied to the dedicated blogging service.
 - **POSTGRES_USER**, **POSTGRES_PASSWORD**, **POSTGRES_DB** – used for the default Postgres superuser; init scripts create `temporal` and `strands` DBs and users.
 
 Personal Assistant credential encryption uses a key generated at **Docker image build time** (stored in the image), so credentials persist across container restarts without setting any env var.
@@ -128,7 +131,17 @@ After starting the stack:
 1. **Compose up** – `docker compose -f docker/docker-compose.yml --env-file docker/.env up -d --build` should bring up all services without errors.
 2. **Temporal UI** – Open http://localhost:8080 and confirm the Temporal Web UI loads.
 3. **Agents** – `curl http://localhost:8888/health` should return `{"status":"ok"}` (agents use stack Postgres and Ollama Cloud when configured).
-4. **Logs API** – With `ENABLE_LOG_API=1` in `.env`, `curl "http://localhost:8888/api/software-engineering/logs?service=sw_api&lines=100"` should return 200 and log content. With `ENABLE_LOG_API` unset, the same URL should return 404.
+4. **Blogging proxy** – `curl http://localhost:8888/api/blogging/health` should return blogging health through unified proxy.
+5. **Failure-path check** – stop `blogging-api` and verify `curl http://localhost:8888/api/blogging/health` returns `503` while other teams still respond.
+6. **Logs API** – With `ENABLE_LOG_API=1` in `.env`, `curl "http://localhost:8888/api/software-engineering/logs?service=sw_api&lines=100"` should return 200 and log content. With `ENABLE_LOG_API` unset, the same URL should return 404.
+
+## Rollback
+
+To roll back quickly to in-process blogging mount in unified API:
+
+1. Set `BLOGGING_REMOTE_URL` to empty for the `strands-agents` service.
+2. Recreate `strands-agents`.
+3. (Optional) stop/remove `blogging-api`.
 
 ## Security
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -104,9 +104,11 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-postgres}
       ENABLE_LOG_API: ${ENABLE_LOG_API:-0}
       TEMPORAL_ADDRESS: temporal:7233
+      BLOGGING_REMOTE_URL: ${BLOGGING_REMOTE_URL:-http://blogging-api:8081}
     extra_hosts:
       - "postgres:172.28.0.2"
       - "temporal:172.28.0.3"
+      - "blogging-api:172.28.0.8"
     networks:
       stack:
         ipv4_address: 172.28.0.6
@@ -115,6 +117,46 @@ services:
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
+  blogging-api:
+    build:
+      context: ../backend
+      dockerfile: Dockerfile
+    image: strands-blogging-api
+    container_name: strands-blogging-api
+    depends_on:
+      postgres:
+        condition: service_healthy
+      temporal:
+        condition: service_started
+    volumes:
+      - agents_workspace:/workspace
+    environment:
+      SW_LLM_PROVIDER: ${SW_LLM_PROVIDER:-ollama}
+      SW_LLM_BASE_URL: ${SW_LLM_BASE_URL:-https://ollama.com}
+      SW_LLM_MODEL: ${SW_LLM_MODEL:-qwen3.5:397b-cloud}
+      OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
+      PYTHONUNBUFFERED: "1"
+      POSTGRES_HOST: postgres
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
+      POSTGRES_DB: ${POSTGRES_DB:-postgres}
+      TEMPORAL_ADDRESS: temporal:7233
+    command: ["python", "-m", "uvicorn", "blogging.api.main:app", "--host", "0.0.0.0", "--port", "8081"]
+    extra_hosts:
+      - "postgres:172.28.0.2"
+      - "temporal:172.28.0.3"
+    networks:
+      stack:
+        ipv4_address: 172.28.0.8
+        aliases:
+          - blogging-api
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8081/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -129,6 +171,8 @@ services:
       - "4201:80"
     depends_on:
       strands-agents:
+        condition: service_healthy
+      blogging-api:
         condition: service_healthy
     extra_hosts:
       - "unified-api:172.28.0.6"


### PR DESCRIPTION
- Added support for a dedicated blogging container by introducing the `BLOGGING_REMOTE_URL` environment variable, allowing the Unified API to proxy requests to an external blogging service.
- Updated the Unified API to register proxy routes for `/api/blogging` and handle requests to the dedicated blogging service.
- Enhanced documentation to reflect the new remote blogging mode and rollback procedures.
- Introduced tests to verify the proxy functionality and error handling for unavailable blogging services.