### PR TITLE
Add unified API test coverage for previously untested modules

### DIFF
--- a/backend/unified_api/tests/test_config.py
+++ b/backend/unified_api/tests/test_config.py
@@ -1,0 +1,115 @@
+"""Unit tests for unified_api.config."""
+
+import sys
+from pathlib import Path
+
+_backend = Path(__file__).resolve().parent.parent.parent
+if str(_backend) not in sys.path:
+    sys.path.insert(0, str(_backend))
+
+import pytest
+
+from unified_api.config import TEAM_CONFIGS, TeamConfig, get_enabled_teams
+
+
+def test_team_config_defaults():
+    """TeamConfig.enabled defaults to True and tags defaults to empty list."""
+    cfg = TeamConfig(name="Test", prefix="/api/test", description="A test team")
+    assert cfg.enabled is True
+    assert cfg.tags == []
+
+
+def test_team_config_can_be_disabled():
+    """TeamConfig accepts enabled=False."""
+    cfg = TeamConfig(name="Test", prefix="/api/test", description="desc", enabled=False)
+    assert cfg.enabled is False
+
+
+def test_team_configs_has_expected_teams():
+    """TEAM_CONFIGS contains all expected team keys."""
+    expected = {
+        "blogging",
+        "software_engineering",
+        "personal_assistant",
+        "market_research",
+        "soc2_compliance",
+        "social_marketing",
+        "branding",
+        "agent_provisioning",
+        "accessibility_audit",
+        "ai_systems",
+        "investment",
+        "nutrition_meal_planning",
+        "planning_v3",
+        "coding_team",
+        "studio_grid",
+        "sales_team",
+        "road_trip_planning",
+    }
+    assert expected.issubset(set(TEAM_CONFIGS.keys()))
+
+
+def test_team_configs_prefixes_start_with_api():
+    """All team prefixes start with /api/."""
+    for key, cfg in TEAM_CONFIGS.items():
+        assert cfg.prefix.startswith("/api/"), f"{key} prefix {cfg.prefix!r} does not start with /api/"
+
+
+def test_team_configs_prefixes_are_unique():
+    """No two teams share the same prefix."""
+    prefixes = [cfg.prefix for cfg in TEAM_CONFIGS.values()]
+    assert len(prefixes) == len(set(prefixes)), "Duplicate prefixes found"
+
+
+def test_team_configs_all_have_non_empty_name_and_description():
+    """All team configs have a non-empty name and description."""
+    for key, cfg in TEAM_CONFIGS.items():
+        assert cfg.name, f"Team {key} has empty name"
+        assert cfg.description, f"Team {key} has empty description"
+
+
+def test_get_enabled_teams_returns_only_enabled():
+    """get_enabled_teams() returns only teams where enabled=True."""
+    enabled = get_enabled_teams()
+    for key, cfg in enabled.items():
+        assert cfg.enabled is True, f"Team {key} should be enabled but enabled={cfg.enabled}"
+
+
+def test_get_enabled_teams_excludes_disabled():
+    """get_enabled_teams() excludes teams set to enabled=False."""
+    import unified_api.config as cfg_mod
+
+    original = cfg_mod.TEAM_CONFIGS["blogging"]
+    try:
+        cfg_mod.TEAM_CONFIGS["blogging"] = TeamConfig(
+            name="Blogging", prefix="/api/blogging", description="test", enabled=False
+        )
+        enabled = cfg_mod.get_enabled_teams()
+        assert "blogging" not in enabled
+    finally:
+        cfg_mod.TEAM_CONFIGS["blogging"] = original
+
+
+def test_get_enabled_teams_is_subset_of_all_teams():
+    """get_enabled_teams() is always a subset of all TEAM_CONFIGS."""
+    enabled = get_enabled_teams()
+    assert set(enabled.keys()).issubset(set(TEAM_CONFIGS.keys()))
+
+
+def test_blogging_team_config_structure():
+    """Blogging team config has correct prefix and tags."""
+    cfg = TEAM_CONFIGS["blogging"]
+    assert cfg.prefix == "/api/blogging"
+    assert "blogging" in cfg.tags
+
+
+def test_software_engineering_team_config_structure():
+    """Software engineering team config has correct prefix."""
+    cfg = TEAM_CONFIGS["software_engineering"]
+    assert cfg.prefix == "/api/software-engineering"
+
+
+def test_team_config_tags_is_list():
+    """All TeamConfig.tags fields are lists."""
+    for key, cfg in TEAM_CONFIGS.items():
+        assert isinstance(cfg.tags, list), f"Team {key} tags is not a list"

--- a/backend/unified_api/tests/test_integration_credentials.py
+++ b/backend/unified_api/tests/test_integration_credentials.py
@@ -1,0 +1,162 @@
+"""Unit tests for unified_api.integration_credentials (SQLite + Fernet store)."""
+
+import importlib
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_backend = Path(__file__).resolve().parent.parent.parent
+if str(_backend) not in sys.path:
+    sys.path.insert(0, str(_backend))
+
+
+def _reload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point AGENT_CACHE at tmp_path and reload module to pick up fresh DB + key paths."""
+    monkeypatch.setenv("AGENT_CACHE", str(tmp_path))
+    monkeypatch.delenv("INTEGRATION_ENCRYPTION_KEY", raising=False)
+    import unified_api.integration_credentials as mod
+
+    importlib.reload(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Key management
+# ---------------------------------------------------------------------------
+
+
+def test_load_or_create_key_uses_env_var(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """_load_or_create_key returns the INTEGRATION_ENCRYPTION_KEY env var when set."""
+    import base64
+    import os
+
+    key = base64.urlsafe_b64encode(os.urandom(32)).decode()
+    monkeypatch.setenv("INTEGRATION_ENCRYPTION_KEY", key)
+    mod = _reload(tmp_path, monkeypatch)
+    # Re-set after reload so the module picks it up
+    monkeypatch.setenv("INTEGRATION_ENCRYPTION_KEY", key)
+    assert mod._load_or_create_key() == key.encode()
+
+
+def test_load_or_create_key_generates_and_persists(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """_load_or_create_key generates a key, saves it, and returns the same key on the next call."""
+    mod = _reload(tmp_path, monkeypatch)
+    key1 = mod._load_or_create_key()
+    key_path = tmp_path / "integration.key"
+    assert key_path.exists()
+    key2 = mod._load_or_create_key()
+    assert key1 == key2
+
+
+def test_load_or_create_key_reads_existing_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """_load_or_create_key reads an existing integration.key file."""
+    import base64
+    import os
+
+    key = base64.urlsafe_b64encode(os.urandom(32))
+    key_path = tmp_path / "integration.key"
+    key_path.write_bytes(key)
+    mod = _reload(tmp_path, monkeypatch)
+    assert mod._load_or_create_key() == key
+
+
+def test_get_integration_fernet_returns_fernet(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """get_integration_fernet() returns an object that can encrypt and decrypt round-trip."""
+    mod = _reload(tmp_path, monkeypatch)
+    fernet = mod.get_integration_fernet()
+    # Verify it can encrypt and decrypt
+    token = fernet.encrypt(b"test_data")
+    assert fernet.decrypt(token) == b"test_data"
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+
+def test_set_and_get_credential_round_trip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """set_credential and get_credential are a lossless round-trip."""
+    mod = _reload(tmp_path, monkeypatch)
+    mod.set_credential("svc", "api_key", "supersecret")
+    assert mod.get_credential("svc", "api_key") == "supersecret"
+
+
+def test_get_credential_returns_empty_when_missing(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """get_credential returns '' when the key does not exist."""
+    mod = _reload(tmp_path, monkeypatch)
+    assert mod.get_credential("nonexistent", "key") == ""
+
+
+def test_set_credential_empty_value_deletes_row(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """set_credential with an empty value removes the existing row."""
+    mod = _reload(tmp_path, monkeypatch)
+    mod.set_credential("svc", "key", "value")
+    mod.set_credential("svc", "key", "")
+    assert mod.get_credential("svc", "key") == ""
+
+
+def test_delete_credential_removes_only_target_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """delete_credential removes one key without touching sibling keys."""
+    mod = _reload(tmp_path, monkeypatch)
+    mod.set_credential("svc", "a", "aaa")
+    mod.set_credential("svc", "b", "bbb")
+    mod.delete_credential("svc", "a")
+    assert mod.get_credential("svc", "a") == ""
+    assert mod.get_credential("svc", "b") == "bbb"
+
+
+def test_delete_service_credentials_removes_all_keys_for_service(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """delete_service_credentials removes all keys for the target service."""
+    mod = _reload(tmp_path, monkeypatch)
+    mod.set_credential("svc", "key1", "v1")
+    mod.set_credential("svc", "key2", "v2")
+    mod.set_credential("other", "key", "vother")
+    mod.delete_service_credentials("svc")
+    assert mod.get_credential("svc", "key1") == ""
+    assert mod.get_credential("svc", "key2") == ""
+    # Other service is untouched
+    assert mod.get_credential("other", "key") == "vother"
+
+
+def test_delete_credential_nonexistent_is_noop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """delete_credential on a non-existent key does not raise."""
+    mod = _reload(tmp_path, monkeypatch)
+    mod.delete_credential("svc", "never_existed")  # should not raise
+
+
+def test_multiple_services_are_independent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Credentials for different services do not interfere with each other."""
+    mod = _reload(tmp_path, monkeypatch)
+    mod.set_credential("slack", "client_id", "slack-cid")
+    mod.set_credential("medium", "refresh_token", "medium-rt")
+    assert mod.get_credential("slack", "client_id") == "slack-cid"
+    assert mod.get_credential("medium", "refresh_token") == "medium-rt"
+
+
+# ---------------------------------------------------------------------------
+# Encryption assurance
+# ---------------------------------------------------------------------------
+
+
+def test_credentials_not_stored_in_plain_text(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Raw SQLite rows do not contain the plaintext secret value."""
+    mod = _reload(tmp_path, monkeypatch)
+    mod.set_credential("svc", "secret_key", "my_plaintext_secret_xyz")
+    db_path = tmp_path / "integration_credentials.db"
+    conn = sqlite3.connect(str(db_path))
+    rows = conn.execute("SELECT value FROM service_integrations").fetchall()
+    conn.close()
+    raw_values = [row[0] for row in rows]
+    assert all("my_plaintext_secret_xyz" not in v for v in raw_values)
+
+
+def test_db_file_is_created_in_agent_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """The SQLite DB is created inside the AGENT_CACHE directory."""
+    mod = _reload(tmp_path, monkeypatch)
+    mod.set_credential("svc", "k", "v")
+    db_path = tmp_path / "integration_credentials.db"
+    assert db_path.exists()

--- a/backend/unified_api/tests/test_integrations_routes.py
+++ b/backend/unified_api/tests/test_integrations_routes.py
@@ -1,0 +1,595 @@
+"""Tests for /api/integrations/* endpoints and route helper functions."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_backend = Path(__file__).resolve().parent.parent.parent
+if str(_backend) not in sys.path:
+    sys.path.insert(0, str(_backend))
+_agents = _backend / "agents"
+if str(_agents) not in sys.path:
+    sys.path.insert(0, str(_agents))
+
+from fastapi.testclient import TestClient
+
+from unified_api.main import app
+
+client = TestClient(app, follow_redirects=False)
+
+
+# ---------------------------------------------------------------------------
+# Helper: default store stubs
+# ---------------------------------------------------------------------------
+
+_DEFAULT_SLACK_CFG = {
+    "enabled": False,
+    "mode": "webhook",
+    "webhook_url": "",
+    "bot_token": "",
+    "default_channel": "",
+    "channel_display_name": "",
+    "notify_open_questions": True,
+    "notify_pa_responses": True,
+    "client_id": "",
+    "client_secret": "",
+    "team_id": "",
+    "team_name": "",
+    "bot_user_id": "",
+}
+
+_DEFAULT_MEDIUM_CFG = {
+    "enabled": False,
+    "oauth_provider": "google",
+    "oauth_identity_connected": False,
+    "google_client_id": "",
+    "google_client_secret": "",
+    "session_configured": False,
+    "linked_email": "",
+    "linked_name": "",
+}
+
+_STORE_MODULE = "unified_api.routes.integrations"
+
+
+# ---------------------------------------------------------------------------
+# Helper validators (pure unit tests, no HTTP)
+# ---------------------------------------------------------------------------
+
+
+def test_validate_webhook_url_accepts_valid_url():
+    """_validate_webhook_url does not raise for a valid hooks.slack.com URL."""
+    from unified_api.routes.integrations import _validate_webhook_url
+
+    _validate_webhook_url("https://hooks.slack.com/services/T/B/" + "x" * 40)
+
+
+def test_validate_webhook_url_raises_for_wrong_domain():
+    """_validate_webhook_url raises 400 for a URL not starting with hooks.slack.com."""
+    from fastapi import HTTPException
+
+    from unified_api.routes.integrations import _validate_webhook_url
+
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_webhook_url("https://evil.com/hooks/slack")
+    assert exc_info.value.status_code == 400
+
+
+def test_validate_webhook_url_raises_for_too_short_url():
+    """_validate_webhook_url raises 400 when the URL is shorter than 50 chars."""
+    from fastapi import HTTPException
+
+    from unified_api.routes.integrations import _validate_webhook_url
+
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_webhook_url("https://hooks.slack.com/short")
+    assert exc_info.value.status_code == 400
+
+
+def test_validate_webhook_url_is_noop_for_empty_string():
+    """_validate_webhook_url does not raise for an empty/blank string."""
+    from unified_api.routes.integrations import _validate_webhook_url
+
+    _validate_webhook_url("")
+    _validate_webhook_url("   ")
+
+
+def test_validate_bot_token_accepts_valid_token():
+    """_validate_bot_token does not raise for an xoxb- prefixed token."""
+    from unified_api.routes.integrations import _validate_bot_token
+
+    _validate_bot_token("xoxb-valid-token")
+
+
+def test_validate_bot_token_raises_for_missing_token():
+    """_validate_bot_token raises 400 when token is empty."""
+    from fastapi import HTTPException
+
+    from unified_api.routes.integrations import _validate_bot_token
+
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_bot_token("")
+    assert exc_info.value.status_code == 400
+
+
+def test_validate_bot_token_raises_for_wrong_prefix():
+    """_validate_bot_token raises 400 when token does not start with xoxb-."""
+    from fastapi import HTTPException
+
+    from unified_api.routes.integrations import _validate_bot_token
+
+    with pytest.raises(HTTPException) as exc_info:
+        _validate_bot_token("xoxa-some-token")
+    assert exc_info.value.status_code == 400
+
+
+def test_build_slack_config_response_masks_webhook_url():
+    """_build_slack_config_response always returns webhook_url=None (never exposes raw URL)."""
+    from unified_api.routes.integrations import _build_slack_config_response
+
+    cfg = dict(_DEFAULT_SLACK_CFG, webhook_url="https://hooks.slack.com/services/T/B/X", enabled=True)
+    resp = _build_slack_config_response(cfg)
+    assert resp.webhook_url is None
+    assert resp.webhook_configured is True
+
+
+def test_build_slack_config_response_oauth_connected_set_from_team_id():
+    """_build_slack_config_response sets oauth_connected=True when team_id is present."""
+    from unified_api.routes.integrations import _build_slack_config_response
+
+    cfg = dict(_DEFAULT_SLACK_CFG, team_id="T12345", team_name="Acme")
+    resp = _build_slack_config_response(cfg)
+    assert resp.oauth_connected is True
+    assert resp.team_name == "Acme"
+    assert resp.team_id == "T12345"
+
+
+def test_build_medium_config_response_defaults_to_google_provider():
+    """_build_medium_config_response coerces unknown oauth_provider to 'google'."""
+    from unified_api.routes.integrations import _build_medium_config_response
+
+    cfg = dict(_DEFAULT_MEDIUM_CFG, oauth_provider="unknown_provider")
+    resp = _build_medium_config_response(cfg)
+    assert resp.oauth_provider == "google"
+
+
+# ---------------------------------------------------------------------------
+# GET /api/integrations
+# ---------------------------------------------------------------------------
+
+
+def test_list_integrations_returns_200():
+    """GET /api/integrations returns HTTP 200."""
+    with patch(f"{_STORE_MODULE}.get_integrations_list", return_value=[
+        {"id": "slack", "type": "slack", "enabled": False, "channel": None},
+        {"id": "medium", "type": "medium", "enabled": False, "channel": None},
+    ]):
+        resp = client.get("/api/integrations")
+    assert resp.status_code == 200
+
+
+def test_list_integrations_returns_list():
+    """GET /api/integrations returns a JSON list."""
+    with patch(f"{_STORE_MODULE}.get_integrations_list", return_value=[
+        {"id": "slack", "type": "slack", "enabled": False, "channel": None},
+    ]):
+        resp = client.get("/api/integrations")
+    assert isinstance(resp.json(), list)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/integrations/slack
+# ---------------------------------------------------------------------------
+
+
+def test_get_slack_returns_200():
+    """GET /api/integrations/slack returns HTTP 200."""
+    with patch(f"{_STORE_MODULE}.get_slack_config", return_value=dict(_DEFAULT_SLACK_CFG)):
+        resp = client.get("/api/integrations/slack")
+    assert resp.status_code == 200
+
+
+def test_get_slack_response_shape():
+    """GET /api/integrations/slack returns expected fields."""
+    with patch(f"{_STORE_MODULE}.get_slack_config", return_value=dict(_DEFAULT_SLACK_CFG)):
+        resp = client.get("/api/integrations/slack")
+    data = resp.json()
+    assert "enabled" in data
+    assert "webhook_configured" in data
+    assert "bot_token_configured" in data
+    # Sensitive field must NOT be in response
+    assert "webhook_url" in data  # field exists but is None
+    assert data.get("webhook_url") is None
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/integrations/slack validation
+# ---------------------------------------------------------------------------
+
+
+def test_put_slack_disabled_requires_no_validation():
+    """PUT /api/integrations/slack with enabled=False succeeds without url/token."""
+    with patch(f"{_STORE_MODULE}.get_slack_config", return_value=dict(_DEFAULT_SLACK_CFG)), \
+         patch(f"{_STORE_MODULE}.set_slack_config"):
+        resp = client.put("/api/integrations/slack", json={"enabled": False, "mode": "webhook"})
+    assert resp.status_code == 200
+
+
+def test_put_slack_webhook_mode_requires_webhook_url():
+    """PUT /api/integrations/slack with enabled=True, mode=webhook, no URL returns 400."""
+    with patch(f"{_STORE_MODULE}.get_slack_config", return_value=dict(_DEFAULT_SLACK_CFG)):
+        resp = client.put("/api/integrations/slack", json={"enabled": True, "mode": "webhook", "webhook_url": ""})
+    assert resp.status_code == 400
+
+
+def test_put_slack_webhook_mode_rejects_non_slack_url():
+    """PUT /api/integrations/slack rejects webhook_url not starting with hooks.slack.com."""
+    with patch(f"{_STORE_MODULE}.get_slack_config", return_value=dict(_DEFAULT_SLACK_CFG)):
+        resp = client.put("/api/integrations/slack", json={
+            "enabled": True,
+            "mode": "webhook",
+            "webhook_url": "https://evil.com/hook",
+        })
+    assert resp.status_code == 400
+
+
+def test_put_slack_bot_mode_requires_default_channel():
+    """PUT /api/integrations/slack with mode=bot, missing default_channel returns 400."""
+    with patch(f"{_STORE_MODULE}.get_slack_config", return_value=dict(_DEFAULT_SLACK_CFG)):
+        resp = client.put("/api/integrations/slack", json={
+            "enabled": True,
+            "mode": "bot",
+            "bot_token": "xoxb-some-token",
+            "default_channel": "",
+        })
+    assert resp.status_code == 400
+
+
+def test_put_slack_bot_mode_accepts_valid_token_and_channel():
+    """PUT /api/integrations/slack with mode=bot, valid token and channel returns 200."""
+    with patch(f"{_STORE_MODULE}.get_slack_config", return_value=dict(_DEFAULT_SLACK_CFG)), \
+         patch(f"{_STORE_MODULE}.set_slack_config"):
+        resp = client.put("/api/integrations/slack", json={
+            "enabled": True,
+            "mode": "bot",
+            "bot_token": "xoxb-valid",
+            "default_channel": "#eng",
+        })
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# GET /api/integrations/slack/oauth/connect
+# ---------------------------------------------------------------------------
+
+
+def test_slack_oauth_connect_returns_400_when_client_id_missing():
+    """GET /slack/oauth/connect returns 400 when Client ID is not configured."""
+    with patch(f"{_STORE_MODULE}.get_slack_config", return_value=dict(_DEFAULT_SLACK_CFG)):
+        resp = client.get("/api/integrations/slack/oauth/connect")
+    assert resp.status_code == 400
+    assert "Client ID" in resp.json()["detail"]
+
+
+def test_slack_oauth_connect_returns_400_when_client_secret_missing():
+    """GET /slack/oauth/connect returns 400 when Client Secret is not configured."""
+    with patch(f"{_STORE_MODULE}.get_slack_config",
+               return_value=dict(_DEFAULT_SLACK_CFG, client_id="my-id")):
+        resp = client.get("/api/integrations/slack/oauth/connect")
+    assert resp.status_code == 400
+    assert "Client Secret" in resp.json()["detail"]
+
+
+def test_slack_oauth_connect_returns_url_and_client_id():
+    """GET /slack/oauth/connect returns the Slack authorization URL and client_id."""
+    with patch(f"{_STORE_MODULE}.get_slack_config",
+               return_value=dict(_DEFAULT_SLACK_CFG, client_id="cid-123", client_secret="csec")), \
+         patch(f"{_STORE_MODULE}.generate_oauth_state", return_value="test-state-xyz"):
+        resp = client.get("/api/integrations/slack/oauth/connect")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "slack.com/oauth/v2/authorize" in data["url"]
+    assert data["client_id"] == "cid-123"
+    assert "test-state-xyz" in data["url"]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/integrations/slack/oauth/callback
+# ---------------------------------------------------------------------------
+
+
+def test_slack_oauth_callback_redirects_on_error_param():
+    """GET /slack/oauth/callback with error= param redirects with slack_error."""
+    resp = client.get("/api/integrations/slack/oauth/callback?error=access_denied")
+    assert resp.status_code in (302, 307)
+    assert "slack_error=access_denied" in resp.headers["location"]
+
+
+def test_slack_oauth_callback_redirects_on_missing_code():
+    """GET /slack/oauth/callback without code or state redirects with error."""
+    resp = client.get("/api/integrations/slack/oauth/callback")
+    assert resp.status_code in (302, 307)
+    assert "slack_error" in resp.headers["location"]
+
+
+def test_slack_oauth_callback_redirects_on_invalid_state():
+    """GET /slack/oauth/callback with invalid state redirects with invalid_state error."""
+    with patch(f"{_STORE_MODULE}.verify_and_clear_oauth_state", return_value=False):
+        resp = client.get("/api/integrations/slack/oauth/callback?code=abc&state=bad-state")
+    assert resp.status_code in (302, 307)
+    assert "invalid_state" in resp.headers["location"]
+
+
+def test_slack_oauth_callback_redirects_on_missing_credentials():
+    """GET /slack/oauth/callback redirects with missing_credentials when store has no client_id."""
+    with patch(f"{_STORE_MODULE}.verify_and_clear_oauth_state", return_value=True), \
+         patch(f"{_STORE_MODULE}.get_slack_config", return_value=dict(_DEFAULT_SLACK_CFG)):
+        resp = client.get("/api/integrations/slack/oauth/callback?code=abc&state=valid-state")
+    assert resp.status_code in (302, 307)
+    assert "missing_credentials" in resp.headers["location"]
+
+
+def test_slack_oauth_callback_success_stores_token_and_redirects():
+    """GET /slack/oauth/callback on success calls set_slack_oauth_token and redirects."""
+    mock_exchange = {
+        "ok": True,
+        "access_token": "xoxb-new",
+        "team": {"id": "T1", "name": "Acme"},
+        "bot_user_id": "U1",
+    }
+    with patch(f"{_STORE_MODULE}.verify_and_clear_oauth_state", return_value=True), \
+         patch(f"{_STORE_MODULE}.get_slack_config",
+               return_value=dict(_DEFAULT_SLACK_CFG, client_id="cid", client_secret="csec")), \
+         patch(f"{_STORE_MODULE}._exchange_code", return_value=mock_exchange), \
+         patch(f"{_STORE_MODULE}.set_slack_oauth_token") as mock_set_token:
+        resp = client.get("/api/integrations/slack/oauth/callback?code=authcode&state=valid")
+    assert resp.status_code in (302, 307)
+    assert "slack_connected=1" in resp.headers["location"]
+    mock_set_token.assert_called_once_with(
+        bot_token="xoxb-new",
+        team_id="T1",
+        team_name="Acme",
+        bot_user_id="U1",
+    )
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/integrations/slack/oauth
+# ---------------------------------------------------------------------------
+
+
+def test_slack_oauth_disconnect_calls_clear_and_returns_200():
+    """DELETE /slack/oauth clears OAuth state and returns updated config."""
+    with patch(f"{_STORE_MODULE}.clear_slack_oauth"), \
+         patch(f"{_STORE_MODULE}.get_slack_config", return_value=dict(_DEFAULT_SLACK_CFG)):
+        resp = client.delete("/api/integrations/slack/oauth")
+    assert resp.status_code == 200
+    assert resp.json()["enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# Google browser-login credentials
+# ---------------------------------------------------------------------------
+
+
+def test_get_google_browser_login_status_returns_200():
+    """GET /google-browser-login returns HTTP 200 with configured and storage_available."""
+    with patch(f"{_STORE_MODULE}.google_browser_login_credentials_configured", return_value=False), \
+         patch(f"{_STORE_MODULE}.google_browser_login_storage_available", return_value=False):
+        resp = client.get("/api/integrations/google-browser-login")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert "configured" in data
+    assert "storage_available" in data
+
+
+def test_put_google_browser_login_stores_credentials():
+    """PUT /google-browser-login stores credentials and returns configured=True."""
+    with patch(f"{_STORE_MODULE}.set_google_browser_login_credentials"), \
+         patch(f"{_STORE_MODULE}.google_browser_login_storage_available", return_value=True):
+        resp = client.put(
+            "/api/integrations/google-browser-login",
+            json={"email": "user@example.com", "password": "secret"},
+        )
+    assert resp.status_code == 200
+    assert resp.json()["configured"] is True
+
+
+def test_put_google_browser_login_returns_400_on_validation_error():
+    """PUT /google-browser-login propagates ValueError as HTTP 400."""
+    with patch(f"{_STORE_MODULE}.set_google_browser_login_credentials",
+               side_effect=ValueError("Invalid email")):
+        resp = client.put(
+            "/api/integrations/google-browser-login",
+            json={"email": "", "password": ""},
+        )
+    assert resp.status_code == 400
+
+
+def test_put_google_browser_login_returns_503_when_storage_unavailable():
+    """PUT /google-browser-login propagates RuntimeError (no Postgres) as HTTP 503."""
+    with patch(f"{_STORE_MODULE}.set_google_browser_login_credentials",
+               side_effect=RuntimeError("POSTGRES_HOST is not set")):
+        resp = client.put(
+            "/api/integrations/google-browser-login",
+            json={"email": "user@example.com", "password": "pw"},
+        )
+    assert resp.status_code == 503
+
+
+def test_delete_google_browser_login_returns_200():
+    """DELETE /google-browser-login clears credentials and returns configured=False."""
+    with patch(f"{_STORE_MODULE}.clear_google_browser_login_credentials"), \
+         patch(f"{_STORE_MODULE}.google_browser_login_storage_available", return_value=True):
+        resp = client.delete("/api/integrations/google-browser-login")
+    assert resp.status_code == 200
+    assert resp.json()["configured"] is False
+
+
+# ---------------------------------------------------------------------------
+# Medium integration config
+# ---------------------------------------------------------------------------
+
+
+def test_get_medium_returns_200():
+    """GET /medium returns HTTP 200."""
+    with patch(f"{_STORE_MODULE}.get_medium_config", return_value=dict(_DEFAULT_MEDIUM_CFG)):
+        resp = client.get("/api/integrations/medium")
+    assert resp.status_code == 200
+
+
+def test_get_medium_response_fields():
+    """GET /medium response includes enabled, oauth_provider, and status flags."""
+    with patch(f"{_STORE_MODULE}.get_medium_config", return_value=dict(_DEFAULT_MEDIUM_CFG)):
+        resp = client.get("/api/integrations/medium")
+    data = resp.json()
+    assert "enabled" in data
+    assert "oauth_provider" in data
+    assert "oauth_identity_connected" in data
+    assert "session_configured" in data
+
+
+def test_put_medium_saves_config():
+    """PUT /medium saves the integration config and returns updated state."""
+    with patch(f"{_STORE_MODULE}.set_medium_config") as mock_set, \
+         patch(f"{_STORE_MODULE}.get_medium_config",
+               return_value=dict(_DEFAULT_MEDIUM_CFG, enabled=True)):
+        resp = client.put("/api/integrations/medium", json={"enabled": True, "oauth_provider": "google"})
+    assert resp.status_code == 200
+    mock_set.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Medium Google OAuth connect
+# ---------------------------------------------------------------------------
+
+
+def test_medium_google_oauth_connect_returns_400_when_provider_not_google():
+    """GET /medium/oauth/google/connect returns 400 when oauth_provider != google."""
+    with patch(f"{_STORE_MODULE}.get_medium_config",
+               return_value=dict(_DEFAULT_MEDIUM_CFG, oauth_provider="apple")):
+        resp = client.get("/api/integrations/medium/oauth/google/connect")
+    assert resp.status_code == 400
+
+
+def test_medium_google_oauth_connect_returns_400_when_client_credentials_missing():
+    """GET /medium/oauth/google/connect returns 400 when Google client credentials are absent."""
+    with patch(f"{_STORE_MODULE}.get_medium_config",
+               return_value=dict(_DEFAULT_MEDIUM_CFG, oauth_provider="google")):
+        resp = client.get("/api/integrations/medium/oauth/google/connect")
+    assert resp.status_code == 400
+
+
+def test_medium_google_oauth_connect_returns_auth_url():
+    """GET /medium/oauth/google/connect returns a Google authorization URL."""
+    with patch(f"{_STORE_MODULE}.get_medium_config", return_value=dict(
+        _DEFAULT_MEDIUM_CFG,
+        oauth_provider="google",
+        google_client_id="gid",
+        google_client_secret="gsec",
+    )), patch(f"{_STORE_MODULE}.generate_medium_google_oauth_state", return_value="mg-state"):
+        resp = client.get("/api/integrations/medium/oauth/google/connect")
+    assert resp.status_code == 200
+    assert "accounts.google.com" in resp.json()["url"]
+    assert "mg-state" in resp.json()["url"]
+
+
+# ---------------------------------------------------------------------------
+# Medium Google OAuth callback
+# ---------------------------------------------------------------------------
+
+
+def test_medium_google_oauth_callback_redirects_on_error():
+    """GET /medium/oauth/google/callback with error= redirects with medium_error."""
+    resp = client.get("/api/integrations/medium/oauth/google/callback?error=access_denied")
+    assert resp.status_code in (302, 307)
+    assert "medium_error=access_denied" in resp.headers["location"]
+
+
+def test_medium_google_oauth_callback_redirects_on_missing_params():
+    """GET /medium/oauth/google/callback without code or state redirects with error."""
+    resp = client.get("/api/integrations/medium/oauth/google/callback")
+    assert resp.status_code in (302, 307)
+    assert "medium_error" in resp.headers["location"]
+
+
+def test_medium_google_oauth_callback_redirects_on_invalid_state():
+    """GET /medium/oauth/google/callback with stale state redirects with invalid_state."""
+    with patch(f"{_STORE_MODULE}.verify_and_clear_medium_google_oauth_state", return_value=False):
+        resp = client.get("/api/integrations/medium/oauth/google/callback?code=c&state=bad")
+    assert resp.status_code in (302, 307)
+    assert "invalid_state" in resp.headers["location"]
+
+
+def test_medium_google_oauth_callback_success_stores_identity():
+    """GET /medium/oauth/google/callback on success stores identity and redirects."""
+    with patch(f"{_STORE_MODULE}.verify_and_clear_medium_google_oauth_state", return_value=True), \
+         patch(f"{_STORE_MODULE}.get_medium_config", return_value=dict(
+             _DEFAULT_MEDIUM_CFG,
+             google_client_id="gid",
+             google_client_secret="gsec",
+         )), \
+         patch(f"{_STORE_MODULE}._exchange_google_oauth_code",
+               return_value={"access_token": "at", "refresh_token": "rt"}), \
+         patch(f"{_STORE_MODULE}._google_userinfo",
+               return_value={"email": "user@example.com", "name": "User"}), \
+         patch(f"{_STORE_MODULE}.set_medium_google_oauth_identity") as mock_set_id:
+        resp = client.get("/api/integrations/medium/oauth/google/callback?code=c&state=valid")
+    assert resp.status_code in (302, 307)
+    assert "medium_google_connected=1" in resp.headers["location"]
+    mock_set_id.assert_called_once_with(
+        refresh_token="rt",
+        linked_email="user@example.com",
+        linked_name="User",
+    )
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/integrations/medium/oauth/google
+# ---------------------------------------------------------------------------
+
+
+def test_medium_google_oauth_disconnect_returns_200():
+    """DELETE /medium/oauth/google clears identity and returns updated config."""
+    with patch(f"{_STORE_MODULE}.clear_medium_google_oauth_identity"), \
+         patch(f"{_STORE_MODULE}.get_medium_config", return_value=dict(_DEFAULT_MEDIUM_CFG)):
+        resp = client.delete("/api/integrations/medium/oauth/google")
+    assert resp.status_code == 200
+    assert resp.json()["oauth_identity_connected"] is False
+
+
+# ---------------------------------------------------------------------------
+# Medium session import / clear
+# ---------------------------------------------------------------------------
+
+
+def test_medium_import_session_stores_state():
+    """POST /medium/session stores storage_state and returns updated config."""
+    with patch(f"{_STORE_MODULE}.set_medium_session_storage_state_json") as mock_set, \
+         patch(f"{_STORE_MODULE}.get_medium_config",
+               return_value=dict(_DEFAULT_MEDIUM_CFG, session_configured=True)):
+        resp = client.post(
+            "/api/integrations/medium/session",
+            json={"storage_state": {"cookies": [], "origins": []}},
+        )
+    assert resp.status_code == 200
+    mock_set.assert_called_once()
+    assert resp.json()["session_configured"] is True
+
+
+def test_medium_import_session_returns_400_on_invalid_state():
+    """POST /medium/session returns 400 when storage_state is missing."""
+    resp = client.post("/api/integrations/medium/session", json={})
+    assert resp.status_code == 422  # Pydantic validation error
+
+
+def test_medium_clear_session_returns_200():
+    """DELETE /medium/session clears storage and returns session_configured=False."""
+    with patch(f"{_STORE_MODULE}.clear_medium_session_storage"), \
+         patch(f"{_STORE_MODULE}.get_medium_config",
+               return_value=dict(_DEFAULT_MEDIUM_CFG, session_configured=False)):
+        resp = client.delete("/api/integrations/medium/session")
+    assert resp.status_code == 200
+    assert resp.json()["session_configured"] is False

--- a/backend/unified_api/tests/test_main_routes.py
+++ b/backend/unified_api/tests/test_main_routes.py
@@ -1,0 +1,213 @@
+"""Tests for unified API root endpoints: GET /, GET /health, GET /teams, and mount helpers."""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_backend = Path(__file__).resolve().parent.parent.parent
+if str(_backend) not in sys.path:
+    sys.path.insert(0, str(_backend))
+_agents = _backend / "agents"
+if str(_agents) not in sys.path:
+    sys.path.insert(0, str(_agents))
+
+from fastapi.testclient import TestClient
+
+from unified_api.main import app
+
+client = TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# GET /
+# ---------------------------------------------------------------------------
+
+
+def test_root_returns_200():
+    """GET / returns HTTP 200."""
+    resp = client.get("/")
+    assert resp.status_code == 200
+
+
+def test_root_response_has_required_fields():
+    """GET / response contains name, version, teams, and docs_url."""
+    resp = client.get("/")
+    data = resp.json()
+    assert data["name"] == "Strands Agents Unified API"
+    assert data["version"] == "1.0.0"
+    assert isinstance(data["teams"], list)
+    assert len(data["teams"]) > 0
+    assert data["docs_url"] == "/docs"
+
+
+def test_root_teams_have_required_fields():
+    """Each team entry in GET / has name, prefix, description, tags, and enabled."""
+    resp = client.get("/")
+    for team in resp.json()["teams"]:
+        assert "name" in team, f"Missing 'name' in team entry: {team}"
+        assert "prefix" in team, f"Missing 'prefix' in team entry: {team}"
+        assert "description" in team, f"Missing 'description' in team entry: {team}"
+        assert "tags" in team, f"Missing 'tags' in team entry: {team}"
+        assert "enabled" in team, f"Missing 'enabled' in team entry: {team}"
+
+
+def test_root_teams_prefixes_start_with_api():
+    """All team prefixes reported by GET / start with /api/."""
+    resp = client.get("/")
+    for team in resp.json()["teams"]:
+        assert team["prefix"].startswith("/api/"), f"Bad prefix: {team['prefix']}"
+
+
+# ---------------------------------------------------------------------------
+# GET /health
+# ---------------------------------------------------------------------------
+
+
+def test_health_returns_200():
+    """GET /health returns HTTP 200."""
+    resp = client.get("/health")
+    assert resp.status_code == 200
+
+
+def test_health_response_has_required_fields():
+    """GET /health response contains status, version, and teams."""
+    resp = client.get("/health")
+    data = resp.json()
+    assert "status" in data
+    assert "version" in data
+    assert "teams" in data
+    assert data["version"] == "1.0.0"
+
+
+def test_health_status_is_valid_value():
+    """GET /health status is either 'healthy' or 'degraded'."""
+    resp = client.get("/health")
+    assert resp.json()["status"] in ("healthy", "degraded")
+
+
+def test_health_teams_have_required_fields():
+    """Each team in GET /health has name, prefix, status, and enabled."""
+    resp = client.get("/health")
+    for team in resp.json()["teams"]:
+        assert "name" in team
+        assert "prefix" in team
+        assert "status" in team
+        assert "enabled" in team
+        assert team["status"] in ("healthy", "unavailable"), f"Unexpected status: {team['status']}"
+
+
+def test_health_degraded_when_enabled_team_not_mounted():
+    """GET /health returns 'degraded' when an enabled team failed to mount."""
+    from unified_api import main as unified_main
+    from unified_api.config import TEAM_CONFIGS, TeamConfig
+
+    # Insert a fake enabled team that is not mounted
+    fake_key = "_test_fake_team"
+    TEAM_CONFIGS[fake_key] = TeamConfig(name="Fake", prefix="/api/fake", description="test", enabled=True)
+    original_mounted = unified_main._mounted_teams.get(fake_key, False)
+    unified_main._mounted_teams[fake_key] = False
+
+    try:
+        resp = client.get("/health")
+        assert resp.json()["status"] == "degraded"
+    finally:
+        del TEAM_CONFIGS[fake_key]
+        unified_main._mounted_teams.pop(fake_key, None)
+
+
+# ---------------------------------------------------------------------------
+# GET /teams
+# ---------------------------------------------------------------------------
+
+
+def test_list_teams_returns_200():
+    """GET /teams returns HTTP 200."""
+    resp = client.get("/teams")
+    assert resp.status_code == 200
+
+
+def test_list_teams_response_structure():
+    """GET /teams returns a 'teams' dict with per-team info objects."""
+    resp = client.get("/teams")
+    data = resp.json()
+    assert "teams" in data
+    teams = data["teams"]
+    assert isinstance(teams, dict)
+    for key, info in teams.items():
+        assert "name" in info, f"Team {key} missing 'name'"
+        assert "prefix" in info, f"Team {key} missing 'prefix'"
+        assert "mounted" in info, f"Team {key} missing 'mounted'"
+        assert "enabled" in info, f"Team {key} missing 'enabled'"
+
+
+def test_list_teams_includes_all_configured_teams():
+    """GET /teams includes every key from TEAM_CONFIGS."""
+    from unified_api.config import TEAM_CONFIGS
+
+    resp = client.get("/teams")
+    teams = resp.json()["teams"]
+    for key in TEAM_CONFIGS:
+        assert key in teams, f"Team {key} missing from /teams response"
+
+
+def test_list_teams_docs_url_none_when_not_mounted():
+    """GET /teams sets docs_url to null for teams that are not mounted."""
+    resp = client.get("/teams")
+    for key, info in resp.json()["teams"].items():
+        if not info["mounted"]:
+            assert info["docs_url"] is None, f"Team {key}: expected null docs_url when not mounted"
+
+
+def test_list_teams_docs_url_set_when_mounted():
+    """GET /teams sets docs_url to <prefix>/docs for mounted teams."""
+    resp = client.get("/teams")
+    for key, info in resp.json()["teams"].items():
+        if info["mounted"]:
+            assert info["docs_url"] == f"{info['prefix']}/docs"
+
+
+# ---------------------------------------------------------------------------
+# mount_all_teams / _try_mount_* helpers
+# ---------------------------------------------------------------------------
+
+
+def test_mount_all_teams_returns_dict_with_all_team_keys():
+    """mount_all_teams() returns a dict keyed by every team defined in mount_functions."""
+    from fastapi import FastAPI
+
+    from unified_api.main import mount_all_teams
+
+    test_app = FastAPI()
+    with patch("unified_api.main.get_enabled_teams", return_value={}):
+        result = mount_all_teams(test_app)
+
+    assert isinstance(result, dict)
+    # All teams should be False (disabled/not mounted)
+    assert all(v is False for v in result.values())
+
+
+def test_try_mount_blogging_returns_false_on_import_error():
+    """_try_mount_blogging returns False when the blogging module cannot be imported."""
+    from fastapi import FastAPI
+
+    from unified_api.main import _try_mount_blogging
+
+    test_app = FastAPI()
+    with patch.dict("sys.modules", {"blogging.api.main": None}):
+        with patch("unified_api.main.importlib") as _:
+            # Simulate ImportError by patching the import inside the function
+            import builtins
+
+            real_import = builtins.__import__
+
+            def _fail_blogging(name, *args, **kwargs):
+                if "blogging" in name:
+                    raise ImportError("no blogging module")
+                return real_import(name, *args, **kwargs)
+
+            with patch("builtins.__import__", side_effect=_fail_blogging):
+                result = _try_mount_blogging(test_app)
+
+    assert result is False

--- a/backend/unified_api/tests/test_postgres_encrypted_credentials.py
+++ b/backend/unified_api/tests/test_postgres_encrypted_credentials.py
@@ -1,0 +1,171 @@
+"""Unit tests for unified_api.postgres_encrypted_credentials."""
+
+import importlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_backend = Path(__file__).resolve().parent.parent.parent
+if str(_backend) not in sys.path:
+    sys.path.insert(0, str(_backend))
+
+
+def _reload(monkeypatch: pytest.MonkeyPatch, postgres_host: str = ""):
+    """Reload the module with the given POSTGRES_HOST environment variable."""
+    monkeypatch.setenv("POSTGRES_HOST", postgres_host)
+    import unified_api.postgres_encrypted_credentials as mod
+
+    importlib.reload(mod)
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# postgres_credentials_enabled
+# ---------------------------------------------------------------------------
+
+
+def test_postgres_credentials_enabled_false_when_no_host(monkeypatch: pytest.MonkeyPatch):
+    """postgres_credentials_enabled() returns False when POSTGRES_HOST is not set."""
+    mod = _reload(monkeypatch, postgres_host="")
+    assert mod.postgres_credentials_enabled() is False
+
+
+def test_postgres_credentials_enabled_false_when_whitespace(monkeypatch: pytest.MonkeyPatch):
+    """postgres_credentials_enabled() returns False when POSTGRES_HOST is only whitespace."""
+    monkeypatch.setenv("POSTGRES_HOST", "   ")
+    mod = _reload(monkeypatch, postgres_host="   ")
+    assert mod.postgres_credentials_enabled() is False
+
+
+def test_postgres_credentials_enabled_true_when_host_set(monkeypatch: pytest.MonkeyPatch):
+    """postgres_credentials_enabled() returns True when POSTGRES_HOST has a non-empty value."""
+    mod = _reload(monkeypatch, postgres_host="localhost")
+    assert mod.postgres_credentials_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# _dsn
+# ---------------------------------------------------------------------------
+
+
+def test_dsn_builds_correct_url(monkeypatch: pytest.MonkeyPatch):
+    """_dsn() assembles a postgresql:// URL from environment variables."""
+    monkeypatch.setenv("POSTGRES_HOST", "myhost")
+    monkeypatch.setenv("POSTGRES_USER", "myuser")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "mypassword")
+    monkeypatch.setenv("POSTGRES_DB", "mydb")
+    monkeypatch.setenv("POSTGRES_PORT", "5433")
+    mod = _reload(monkeypatch, postgres_host="myhost")
+    dsn = mod._dsn()
+    assert "postgresql://" in dsn
+    assert "myhost" in dsn
+    assert "myuser" in dsn
+    assert "mydb" in dsn
+    assert "5433" in dsn
+
+
+def test_dsn_uses_defaults_for_optional_vars(monkeypatch: pytest.MonkeyPatch):
+    """_dsn() uses sensible defaults when optional env vars are absent."""
+    monkeypatch.setenv("POSTGRES_HOST", "host")
+    monkeypatch.delenv("POSTGRES_USER", raising=False)
+    monkeypatch.delenv("POSTGRES_DB", raising=False)
+    monkeypatch.delenv("POSTGRES_PORT", raising=False)
+    monkeypatch.delenv("POSTGRES_PASSWORD", raising=False)
+    mod = _reload(monkeypatch, postgres_host="host")
+    dsn = mod._dsn()
+    # Defaults: user=postgres, db=postgres, port=5432
+    assert "postgres" in dsn
+    assert "5432" in dsn
+
+
+def test_dsn_url_encodes_special_chars_in_password(monkeypatch: pytest.MonkeyPatch):
+    """_dsn() percent-encodes special characters in the password."""
+    monkeypatch.setenv("POSTGRES_HOST", "host")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "p@ss:word!")
+    mod = _reload(monkeypatch, postgres_host="host")
+    dsn = mod._dsn()
+    # Raw password must not appear; @ must be encoded
+    assert "p@ss:word!" not in dsn
+    assert "p%40ss" in dsn  # @ -> %40
+
+
+# ---------------------------------------------------------------------------
+# _get_psycopg lazy import
+# ---------------------------------------------------------------------------
+
+
+def test_get_psycopg_returns_none_when_not_installed(monkeypatch: pytest.MonkeyPatch):
+    """_get_psycopg() returns None and sets flag when psycopg is not importable."""
+    mod = _reload(monkeypatch)
+    # Reset cached state so it retries
+    mod._psycopg_module = None
+    mod._psycopg_import_failed = False
+
+    original_import = __builtins__.__import__ if hasattr(__builtins__, "__import__") else __import__
+
+    def _failing_import(name, *args, **kwargs):
+        if name == "psycopg":
+            raise ModuleNotFoundError("No module named 'psycopg'")
+        return original_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=_failing_import):
+        result = mod._get_psycopg()
+
+    assert result is None
+    assert mod._psycopg_import_failed is True
+
+
+def test_get_psycopg_returns_cached_module(monkeypatch: pytest.MonkeyPatch):
+    """_get_psycopg() returns the previously cached module without re-importing."""
+    mod = _reload(monkeypatch)
+    fake_psycopg = MagicMock()
+    mod._psycopg_module = fake_psycopg
+    mod._psycopg_import_failed = False
+    result = mod._get_psycopg()
+    assert result is fake_psycopg
+
+
+def test_get_psycopg_returns_none_when_import_previously_failed(monkeypatch: pytest.MonkeyPatch):
+    """_get_psycopg() skips import attempt when it already failed."""
+    mod = _reload(monkeypatch)
+    mod._psycopg_module = None
+    mod._psycopg_import_failed = True
+    result = mod._get_psycopg()
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# pg_* operations when Postgres is disabled
+# ---------------------------------------------------------------------------
+
+
+def test_pg_get_credential_returns_empty_when_disabled(monkeypatch: pytest.MonkeyPatch):
+    """pg_get_credential() returns '' without connecting when POSTGRES_HOST is unset."""
+    mod = _reload(monkeypatch, postgres_host="")
+    assert mod.pg_get_credential("svc", "key") == ""
+
+
+def test_pg_set_credential_raises_runtime_error_when_disabled(monkeypatch: pytest.MonkeyPatch):
+    """pg_set_credential() raises RuntimeError when POSTGRES_HOST is not set."""
+    mod = _reload(monkeypatch, postgres_host="")
+    with pytest.raises(RuntimeError, match="POSTGRES_HOST is not set"):
+        mod.pg_set_credential("svc", "key", "value")
+
+
+def test_pg_set_credential_raises_runtime_error_when_psycopg_missing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """pg_set_credential() raises RuntimeError when psycopg is not installed."""
+    mod = _reload(monkeypatch, postgres_host="localhost")
+    mod._psycopg_module = None
+    mod._psycopg_import_failed = True  # simulate missing psycopg
+    with pytest.raises(RuntimeError, match="psycopg is not installed"):
+        mod.pg_set_credential("svc", "key", "value")
+
+
+def test_pg_delete_credential_noop_when_disabled(monkeypatch: pytest.MonkeyPatch):
+    """pg_delete_credential() is a no-op and does not raise when POSTGRES_HOST is unset."""
+    mod = _reload(monkeypatch, postgres_host="")
+    mod.pg_delete_credential("svc", "key")  # must not raise


### PR DESCRIPTION
Adds 101 new tests across 5 files covering:
- test_config.py: TeamConfig dataclass, TEAM_CONFIGS structure, get_enabled_teams()
- test_integration_credentials.py: Fernet key management, SQLite CRUD, encryption assurance
- test_postgres_encrypted_credentials.py: postgres_credentials_enabled(), DSN building, lazy psycopg import, disabled-mode guards
- test_main_routes.py: GET /, /health, /teams endpoints; mount_all_teams ImportError handling
- test_integrations_routes.py: all /api/integrations/* endpoints (Slack, Google browser-login, Medium); helper validators

https://claude.ai/code/session_01VUXUADAa63NyD6ZL1XwbsK