### PR TITLE
ci: replace smoke-test workflow with full CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,23 +1,46 @@
-name: CI
+name: CI/CD
 
 on:
-  push:
-    branches: [main, development]
   pull_request:
     types: [opened, synchronize, reopened]
     branches: [main, development]
+  push:
+    branches: [main, development]
 
 jobs:
+  # ── Lint ────────────────────────────────────────────────────────────────────
+
   lint-python:
     name: Lint Python (ruff)
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
       - run: pip install ruff
-      - run: ruff check agents/
+      - run: ruff check agents/ unified_api/
+
+  lint-frontend:
+    name: Lint Angular (ng lint)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: user-interface
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: user-interface/package-lock.json
+      - run: npm ci
+      - run: npm run lint
+
+  # ── Tests ───────────────────────────────────────────────────────────────────
 
   test-software-engineering:
     name: Test – Software Engineering Team
@@ -25,7 +48,7 @@ jobs:
     needs: lint-python
     defaults:
       run:
-        working-directory: agents
+        working-directory: backend/agents
     env:
       SW_LLM_PROVIDER: dummy
     steps:
@@ -44,7 +67,7 @@ jobs:
     needs: lint-python
     defaults:
       run:
-        working-directory: agents
+        working-directory: backend/agents
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -60,7 +83,7 @@ jobs:
     needs: lint-python
     defaults:
       run:
-        working-directory: agents
+        working-directory: backend/agents
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -76,7 +99,7 @@ jobs:
     needs: lint-python
     defaults:
       run:
-        working-directory: agents
+        working-directory: backend/agents
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -92,7 +115,7 @@ jobs:
     needs: lint-python
     defaults:
       run:
-        working-directory: agents
+        working-directory: backend/agents
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -105,6 +128,7 @@ jobs:
   test-ui:
     name: Test – Angular UI
     runs-on: ubuntu-latest
+    needs: lint-frontend
     defaults:
       run:
         working-directory: user-interface
@@ -116,12 +140,91 @@ jobs:
           cache: npm
           cache-dependency-path: user-interface/package-lock.json
       - run: npm ci
-      - run: npx ng test --no-watch --browsers=ChromeHeadless
+      - run: npm run test:coverage
 
-  docker-build:
-    name: Docker build (smoke test)
+  # ── Build & Deploy ──────────────────────────────────────────────────────────
+  # On pull_request: build only (validates the image can be built).
+  # On push to main/development (merged PR): build + push to Docker Hub.
+  #
+  # Required secrets:  DOCKERHUB_TOKEN
+  # Required variables: DOCKERHUB_USERNAME  (repository variable, not a secret)
+
+  build-backend:
+    name: Build Backend Docker image
     runs-on: ubuntu-latest
-    needs: [test-software-engineering, test-blogging]
+    needs:
+      - test-software-engineering
+      - test-blogging
+      - test-market-research
+      - test-soc2
+      - test-social-marketing
     steps:
       - uses: actions/checkout@v4
-      - run: docker build -t strands-agents:ci agents/
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ vars.DOCKERHUB_USERNAME }}/strands-agents
+          tags: |
+            type=sha
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=pr
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: backend
+          file: backend/Dockerfile
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-frontend:
+    name: Build Frontend Docker image
+    runs-on: ubuntu-latest
+    needs:
+      - test-ui
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        if: github.event_name == 'push'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ vars.DOCKERHUB_USERNAME }}/strands-ui
+          tags: |
+            type=sha
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=ref,event=pr
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: user-interface
+          file: user-interface/Dockerfile
+          push: ${{ github.event_name == 'push' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,24 @@ jobs:
       - run: npm ci
       - run: npm run test:coverage
 
+  # ── Gate ────────────────────────────────────────────────────────────────────
+  # Single convergence point: both build jobs must wait for every test suite
+  # (backend and frontend) so neither image can be published while any suite
+  # is red, preventing partial releases where only one image reaches Docker Hub.
+
+  all-checks:
+    name: All checks passed
+    runs-on: ubuntu-latest
+    needs:
+      - test-software-engineering
+      - test-blogging
+      - test-market-research
+      - test-soc2
+      - test-social-marketing
+      - test-ui
+    steps:
+      - run: echo "All lint, test, and build checks passed."
+
   # ── Build & Deploy ──────────────────────────────────────────────────────────
   # On pull_request: build only (validates the image can be built).
   # On push to main/development (merged PR): build + push to Docker Hub.
@@ -153,11 +171,7 @@ jobs:
     name: Build Backend Docker image
     runs-on: ubuntu-latest
     needs:
-      - test-software-engineering
-      - test-blogging
-      - test-market-research
-      - test-soc2
-      - test-social-marketing
+      - all-checks
     steps:
       - uses: actions/checkout@v4
 
@@ -195,7 +209,7 @@ jobs:
     name: Build Frontend Docker image
     runs-on: ubuntu-latest
     needs:
-      - test-ui
+      - all-checks
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
- Lint runs on every PR event (opened, synchronize, reopened) and on push
- All test suites gate on lint passing; run in parallel across teams
- Backend tests now use correct working-directory (backend/agents)
- Frontend tests use npm run test:coverage (Vitest CI config) instead of raw ng test
- Two build jobs (backend + frontend) validate Docker images build on every PR
- On push to main/development (merged PR), both images are pushed to Docker Hub
  tagged with git SHA and `latest` (main only)
- Uses docker/build-push-action cache (type=gha) to speed up rebuilds
- Requires DOCKERHUB_TOKEN secret and DOCKERHUB_USERNAME repository variable

https://claude.ai/code/session_01ReB1xBop5LhDiCQMnn2oXv