### PR TITLE
Add centralized job service microservice with HTTP client

### DIFF
--- a/backend/agents/accessibility_audit_team/api/main.py
+++ b/backend/agents/accessibility_audit_team/api/main.py
@@ -9,11 +9,11 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, BackgroundTasks, HTTPException
 from pydantic import BaseModel, Field
 
-from shared_job_management import (
+from job_service_client import (
     JOB_STATUS_FAILED,
     JOB_STATUS_PENDING,
     JOB_STATUS_RUNNING,
-    CentralJobManager,
+    JobServiceClient,
     start_stale_job_monitor,
 )
 
@@ -33,7 +33,7 @@ from ..orchestrator import AccessibilityAuditOrchestrator
 router = APIRouter()
 logger = logging.getLogger(__name__)
 
-_job_manager = CentralJobManager(team="accessibility_audit_team")
+_job_manager = JobServiceClient(team="accessibility_audit_team")
 _stale_monitor_stop = start_stale_job_monitor(
     _job_manager,
     interval_seconds=15.0,
@@ -63,6 +63,7 @@ def get_orchestrator() -> AccessibilityAuditOrchestrator:
     global _orchestrator
     if _orchestrator is None:
         from llm_service import get_client
+
         _orchestrator = AccessibilityAuditOrchestrator(llm_client=get_client("accessibility_audit"))
     return _orchestrator
 
@@ -81,19 +82,13 @@ class CreateAuditRequest(BaseModel):
         default_factory=list,
         description="Mobile apps: [{platform, name, version, build}]",
     )
-    critical_journeys: List[str] = Field(
-        default_factory=list, description="Critical user journeys"
-    )
-    timebox_hours: Optional[int] = Field(
-        default=None, description="Maximum hours for the audit"
-    )
+    critical_journeys: List[str] = Field(default_factory=list, description="Critical user journeys")
+    timebox_hours: Optional[int] = Field(default=None, description="Maximum hours for the audit")
     auth_required: bool = Field(default=False)
     max_pages: Optional[int] = Field(default=None)
     sampling_strategy: str = Field(default="journey_based")
     wcag_levels: List[str] = Field(default_factory=lambda: ["A", "AA"])
-    tech_stack: Dict[str, str] = Field(
-        default_factory=lambda: {"web": "other", "mobile": "other"}
-    )
+    tech_stack: Dict[str, str] = Field(default_factory=lambda: {"web": "other", "mobile": "other"})
 
 
 class RetestRequest(BaseModel):
@@ -206,7 +201,9 @@ async def create_audit(
     # Run audit in background
     async def run_audit_task():
         try:
-            _job_manager.update_job(job_id, status=JOB_STATUS_RUNNING, current_phase="discovery", progress=20)
+            _job_manager.update_job(
+                job_id, status=JOB_STATUS_RUNNING, current_phase="discovery", progress=20
+            )
             orchestrator = get_orchestrator()
             result = await orchestrator.run_audit(audit_request, request.tech_stack)
             _job_manager.update_job(
@@ -220,7 +217,9 @@ async def create_audit(
                 error=result.failure_reason if result and not result.success else None,
             )
             if not result.success:
-                _job_manager.update_job(job_id, status=JOB_STATUS_FAILED, error=result.failure_reason)
+                _job_manager.update_job(
+                    job_id, status=JOB_STATUS_FAILED, error=result.failure_reason
+                )
         except Exception as e:
             _job_manager.update_job(job_id, status=JOB_STATUS_FAILED, error=str(e))
 

--- a/backend/agents/agent_provisioning_team/shared/job_store.py
+++ b/backend/agents/agent_provisioning_team/shared/job_store.py
@@ -1,19 +1,16 @@
 """
-Job store for Agent Provisioning team: persists async job status via CentralJobManager.
-
-Jobs are stored under {cache_dir}/agent_provisioning_team/jobs/{job_id}.json
+Job store for Agent Provisioning team: persists async job status via the job service.
 """
 
 from __future__ import annotations
 
-import copy
 import logging
 import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from shared_job_management import CentralJobManager
+from job_service_client import JobServiceClient
 
 logger = logging.getLogger(__name__)
 
@@ -26,8 +23,8 @@ JOB_STATUS_CANCELLED = "cancelled"
 DEFAULT_CACHE_DIR: Path = Path(os.environ.get("AGENT_CACHE", ".agent_cache"))
 
 
-def _manager(cache_dir: Path | str = DEFAULT_CACHE_DIR) -> CentralJobManager:
-    return CentralJobManager(team="agent_provisioning_team", cache_dir=cache_dir)
+def _client(cache_dir: Path | str = DEFAULT_CACHE_DIR) -> JobServiceClient:
+    return JobServiceClient(team="agent_provisioning_team", cache_dir=str(cache_dir))
 
 
 def create_job(
@@ -54,8 +51,9 @@ def create_job(
         "result": None,
         "created_at": now,
         "updated_at": now,
+        "events": [],
     }
-    _manager(cache_dir).create_job(job_id, status=JOB_STATUS_PENDING, **data)
+    _client(cache_dir).create_job(job_id, status=JOB_STATUS_PENDING, **data)
 
 
 def get_job(
@@ -63,8 +61,7 @@ def get_job(
     cache_dir: Path = DEFAULT_CACHE_DIR,
 ) -> Dict[str, Any]:
     """Get job data by ID. Returns empty dict if not found."""
-    data = _manager(cache_dir).get_job(job_id)
-    return copy.deepcopy(data) if data else {}
+    return _client(cache_dir).get_job(job_id) or {}
 
 
 def update_job(
@@ -73,7 +70,7 @@ def update_job(
     **kwargs: Any,
 ) -> None:
     """Update job fields. Merges kwargs into existing job data."""
-    _manager(cache_dir).update_job(job_id, **kwargs)
+    _client(cache_dir).update_job(job_id, **kwargs)
 
 
 def list_jobs(
@@ -84,7 +81,7 @@ def list_jobs(
     statuses: Optional[List[str]] = (
         [JOB_STATUS_PENDING, JOB_STATUS_RUNNING] if running_only else None
     )
-    return _manager(cache_dir).list_jobs(statuses=statuses)
+    return _client(cache_dir).list_jobs(statuses=statuses)
 
 
 def mark_all_running_jobs_failed(
@@ -93,11 +90,7 @@ def mark_all_running_jobs_failed(
 ) -> None:
     """Mark all pending or running provisioning jobs as failed (e.g. on server shutdown)."""
     try:
-        jobs = list_jobs(running_only=True, cache_dir=cache_dir)
-        for job in jobs:
-            job_id = job.get("job_id")
-            if job_id:
-                update_job(job_id, cache_dir=cache_dir, status=JOB_STATUS_FAILED, error=reason)
+        _client(cache_dir).mark_all_active_jobs_failed(reason)
     except Exception as e:
         logger.warning("mark_all_running_jobs_failed: %s", e)
 
@@ -110,7 +103,7 @@ def cancel_job(
     data = get_job(job_id, cache_dir=cache_dir)
     if not data:
         return False
-    _manager(cache_dir).update_job(job_id, status=JOB_STATUS_CANCELLED, heartbeat=False)
+    _client(cache_dir).update_job(job_id, status=JOB_STATUS_CANCELLED, heartbeat=False)
     return True
 
 
@@ -196,5 +189,5 @@ def delete_job(
     job_id: str,
     cache_dir: Path = DEFAULT_CACHE_DIR,
 ) -> bool:
-    """Delete a job file. Returns True if deleted, False if not found."""
-    return _manager(cache_dir).delete_job(job_id)
+    """Delete a job. Returns True if deleted, False if not found."""
+    return _client(cache_dir).delete_job(job_id)

--- a/backend/agents/ai_systems_team/shared/job_store.py
+++ b/backend/agents/ai_systems_team/shared/job_store.py
@@ -1,19 +1,16 @@
 """
-Job store for AI Systems team: persists async job status via CentralJobManager.
-
-Jobs are stored under {cache_dir}/ai_systems_team/jobs/{job_id}.json
+Job store for AI Systems team: persists async job status via the job service.
 """
 
 from __future__ import annotations
 
-import copy
 import logging
 import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from shared_job_management import CentralJobManager
+from job_service_client import JobServiceClient
 
 logger = logging.getLogger(__name__)
 
@@ -26,8 +23,8 @@ JOB_STATUS_CANCELLED = "cancelled"
 DEFAULT_CACHE_DIR: Path = Path(os.environ.get("AGENT_CACHE", ".agent_cache"))
 
 
-def _manager(cache_dir: Path | str = DEFAULT_CACHE_DIR) -> CentralJobManager:
-    return CentralJobManager(team="ai_systems_team", cache_dir=cache_dir)
+def _client(cache_dir: Path | str = DEFAULT_CACHE_DIR) -> JobServiceClient:
+    return JobServiceClient(team="ai_systems_team", cache_dir=str(cache_dir))
 
 
 def create_job(
@@ -53,8 +50,9 @@ def create_job(
         "error": None,
         "created_at": now,
         "updated_at": now,
+        "events": [],
     }
-    _manager(cache_dir).create_job(job_id, status=JOB_STATUS_PENDING, **data)
+    _client(cache_dir).create_job(job_id, status=JOB_STATUS_PENDING, **data)
 
 
 def get_job(
@@ -62,8 +60,7 @@ def get_job(
     cache_dir: Path = DEFAULT_CACHE_DIR,
 ) -> Dict[str, Any]:
     """Get job data by ID. Returns empty dict if not found."""
-    data = _manager(cache_dir).get_job(job_id)
-    return copy.deepcopy(data) if data else {}
+    return _client(cache_dir).get_job(job_id) or {}
 
 
 def update_job(
@@ -72,7 +69,7 @@ def update_job(
     **kwargs: Any,
 ) -> None:
     """Update job fields. Merges kwargs into existing job data."""
-    _manager(cache_dir).update_job(job_id, **kwargs)
+    _client(cache_dir).update_job(job_id, **kwargs)
 
 
 def list_jobs(
@@ -83,7 +80,7 @@ def list_jobs(
     statuses: Optional[List[str]] = (
         [JOB_STATUS_PENDING, JOB_STATUS_RUNNING] if running_only else None
     )
-    return _manager(cache_dir).list_jobs(statuses=statuses)
+    return _client(cache_dir).list_jobs(statuses=statuses)
 
 
 def mark_all_running_jobs_failed(
@@ -92,11 +89,7 @@ def mark_all_running_jobs_failed(
 ) -> None:
     """Mark all pending or running AI systems jobs as failed (e.g. on server shutdown)."""
     try:
-        jobs = list_jobs(running_only=True, cache_dir=cache_dir)
-        for job in jobs:
-            job_id = job.get("job_id")
-            if job_id:
-                update_job(job_id, cache_dir=cache_dir, status=JOB_STATUS_FAILED, error=reason)
+        _client(cache_dir).mark_all_active_jobs_failed(reason)
     except Exception as e:
         logger.warning("mark_all_running_jobs_failed: %s", e)
 
@@ -109,7 +102,7 @@ def cancel_job(
     data = get_job(job_id, cache_dir=cache_dir)
     if not data:
         return False
-    _manager(cache_dir).update_job(job_id, status=JOB_STATUS_CANCELLED, heartbeat=False)
+    _client(cache_dir).update_job(job_id, status=JOB_STATUS_CANCELLED, heartbeat=False)
     return True
 
 
@@ -182,5 +175,5 @@ def delete_job(
     job_id: str,
     cache_dir: Path = DEFAULT_CACHE_DIR,
 ) -> bool:
-    """Delete a job file. Returns True if deleted, False if not found."""
-    return _manager(cache_dir).delete_job(job_id)
+    """Delete a job. Returns True if deleted, False if not found."""
+    return _client(cache_dir).delete_job(job_id)

--- a/backend/agents/blogging/shared/blog_job_store.py
+++ b/backend/agents/blogging/shared/blog_job_store.py
@@ -350,15 +350,14 @@ def skip_current_story_gap(
     job_id: str,
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> None:
-    """Skip the current story gap and advance to the next one (clears waiting flag)."""
-    # Need to read current index, increment, then write
-    job = _client(cache_dir).get_job(job_id)
-    if job is None:
-        return
-    new_index = job.get("current_story_gap_index", 0) + 1
+    """Skip the current story gap and advance to the next one (clears waiting flag).
+
+    Uses an atomic increment so concurrent skip requests cannot lose an update.
+    """
     _client(cache_dir).atomic_update(
         job_id,
-        merge_fields={"current_story_gap_index": new_index, "waiting_for_story_input": False},
+        merge_fields={"waiting_for_story_input": False},
+        increment={"current_story_gap_index": 1},
     )
 
 

--- a/backend/agents/blogging/shared/blog_job_store.py
+++ b/backend/agents/blogging/shared/blog_job_store.py
@@ -1,8 +1,9 @@
 """
-Job store for blogging pipeline: persists job status and progress via CentralJobManager.
+Job store for blogging pipeline: persists job status and progress via the job service.
 
-Jobs are stored under {cache_dir}/blogging_team/jobs/{job_id}.json so state survives
-process restarts. This enables async API endpoints with polling for UI progress tracking.
+Uses ``JobServiceClient`` to communicate with the job service container over
+HTTP when ``JOB_SERVICE_URL`` is set, falling back to a local
+``CentralJobManager`` for non-Docker development.
 
 Note: Jobs created before migration from the legacy store (under .agent_cache/blog_jobs/)
 are not automatically migrated. New jobs use the central store only. Historical jobs
@@ -11,14 +12,13 @@ in the old path are not read by this module.
 
 from __future__ import annotations
 
-import copy
 import logging
 import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from shared_job_management import CentralJobManager, start_stale_job_monitor
+from job_service_client import JobServiceClient, start_stale_job_monitor
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +32,7 @@ def _start_blog_stale_monitor() -> None:
         return
     try:
         _blog_stale_monitor_stop = start_stale_job_monitor(
-            _manager(DEFAULT_CACHE_DIR),
+            _client(DEFAULT_CACHE_DIR),
             interval_seconds=300.0,
             stale_after_seconds=3600.0,
             reason="Blog pipeline job heartbeat stale (pending/running too long without progress)",
@@ -40,6 +40,7 @@ def _start_blog_stale_monitor() -> None:
         logger.info("Started blog job stale monitor (stale_after=3600s)")
     except Exception as e:
         logger.warning("Could not start blog stale job monitor: %s", e)
+
 
 # Job status constants
 JOB_STATUS_PENDING = "pending"
@@ -52,8 +53,8 @@ JOB_STATUS_NEEDS_REVIEW = "needs_human_review"
 DEFAULT_CACHE_DIR: Path = Path(os.environ.get("AGENT_CACHE", ".agent_cache")).resolve()
 
 
-def _manager(cache_dir: str | Path = DEFAULT_CACHE_DIR) -> CentralJobManager:
-    return CentralJobManager(team="blogging_team", cache_dir=cache_dir)
+def _client(cache_dir: str | Path = DEFAULT_CACHE_DIR) -> JobServiceClient:
+    return JobServiceClient(team="blogging_team", cache_dir=str(cache_dir))
 
 
 def medium_stats_run_dir(job_id: str, cache_dir: str | Path = DEFAULT_CACHE_DIR) -> Path:
@@ -80,16 +81,14 @@ def create_blog_job(
     job_type: Optional[str] = None,
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> None:
-    """Create a new blog job with pending status and persist to cache."""
+    """Create a new blog job with pending status."""
     now = datetime.now(timezone.utc).isoformat()
-    data: Dict[str, Any] = {
-        "job_id": job_id,
+    fields: Dict[str, Any] = {
         "brief": brief,
         "audience": audience,
         "tone_or_purpose": tone_or_purpose,
         "work_dir": work_dir,
         "job_type": job_type,
-        "status": JOB_STATUS_PENDING,
         "phase": None,
         "progress": 0,
         "status_text": "Initializing...",
@@ -117,41 +116,41 @@ def create_blog_job(
         "pending_questions": [],
         "waiting_for_answers": False,
         "submitted_answers": [],
+        "events": [],
     }
-    # create_job(job_id, **fields) expects job_id as first arg; omit job_id from **data to avoid duplicate
-    fields = {k: v for k, v in data.items() if k != "job_id"}
-    _manager(cache_dir).create_job(job_id, **fields)
+    _client(cache_dir).create_job(job_id, status=JOB_STATUS_PENDING, **fields)
 
 
 def get_blog_job(
     job_id: str,
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> Optional[Dict[str, Any]]:
-    """Get job data from cache, or None if not found."""
-    data = _manager(cache_dir).get_job(job_id)
-    return copy.deepcopy(data) if data else None
+    """Get job data, or None if not found."""
+    return _client(cache_dir).get_job(job_id)
 
 
 def list_blog_jobs(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
     running_only: bool = False,
 ) -> List[Dict[str, Any]]:
-    """List blog jobs from cache. If running_only is True, only include pending or running."""
+    """List blog jobs. If running_only is True, only include pending or running."""
     statuses: Optional[List[str]] = (
         [JOB_STATUS_PENDING, JOB_STATUS_RUNNING] if running_only else None
     )
-    raw = _manager(cache_dir).list_jobs(statuses=statuses)
+    raw = _client(cache_dir).list_jobs(statuses=statuses)
     result: List[Dict[str, Any]] = []
     for data in raw:
-        result.append({
-            "job_id": data.get("job_id", ""),
-            "status": data.get("status", JOB_STATUS_PENDING),
-            "brief": (data.get("brief") or "")[:100],
-            "phase": data.get("phase"),
-            "progress": data.get("progress", 0),
-            "created_at": data.get("created_at"),
-            "job_type": data.get("job_type"),
-        })
+        result.append(
+            {
+                "job_id": data.get("job_id", ""),
+                "status": data.get("status", JOB_STATUS_PENDING),
+                "brief": (data.get("brief") or "")[:100],
+                "phase": data.get("phase"),
+                "progress": data.get("progress", 0),
+                "created_at": data.get("created_at"),
+                "job_type": data.get("job_type"),
+            }
+        )
     return result
 
 
@@ -160,8 +159,8 @@ def update_blog_job(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
     **kwargs: Any,
 ) -> None:
-    """Update job fields. Merges with existing data and persists to cache."""
-    _manager(cache_dir).update_job(job_id, **kwargs)
+    """Update job fields. Merges with existing data."""
+    _client(cache_dir).update_job(job_id, **kwargs)
 
 
 def start_blog_job(
@@ -195,7 +194,9 @@ def complete_blog_job(
         "status": status,
         "phase": "finalize",
         "progress": 100,
-        "status_text": "Pipeline complete" if status == JOB_STATUS_COMPLETED else "Needs human review",
+        "status_text": "Pipeline complete"
+        if status == JOB_STATUS_COMPLETED
+        else "Needs human review",
         "completed_at": datetime.now(timezone.utc).isoformat(),
     }
     if title_choices is not None:
@@ -241,11 +242,7 @@ def mark_all_running_jobs_failed(
 ) -> None:
     """Mark all pending or running blog jobs as failed (e.g. on server shutdown)."""
     try:
-        jobs = list_blog_jobs(cache_dir=cache_dir, running_only=True)
-        for job in jobs:
-            job_id = job.get("job_id")
-            if job_id:
-                fail_blog_job(job_id, error=reason, cache_dir=cache_dir)
+        _client(cache_dir).mark_all_active_jobs_failed(reason)
     except Exception as e:
         logger.warning("mark_all_running_jobs_failed: %s", e)
 
@@ -285,8 +282,8 @@ def delete_blog_job(
     job_id: str,
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> bool:
-    """Delete a job from the cache. Returns True if deleted, False if not found."""
-    return _manager(cache_dir).delete_job(job_id)
+    """Delete a job from the store. Returns True if deleted, False if not found."""
+    return _client(cache_dir).delete_job(job_id)
 
 
 # ---------------------------------------------------------------------------
@@ -300,11 +297,10 @@ def submit_title_selection(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> None:
     """Store the selected title and resume the pipeline (clears waiting_for_title_selection)."""
-    def apply(data: Dict[str, Any]) -> None:
-        data["selected_title"] = title
-        data["waiting_for_title_selection"] = False
-
-    _manager(cache_dir).apply_to_job(job_id, apply)
+    _client(cache_dir).atomic_update(
+        job_id,
+        merge_fields={"selected_title": title, "waiting_for_title_selection": False},
+    )
 
 
 def is_waiting_for_title_selection(
@@ -312,7 +308,7 @@ def is_waiting_for_title_selection(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> bool:
     """Return True if the pipeline is paused waiting for a title selection."""
-    job = _manager(cache_dir).get_job(job_id)
+    job = _client(cache_dir).get_job(job_id)
     return bool(job.get("waiting_for_title_selection")) if job else False
 
 
@@ -328,13 +324,13 @@ def add_story_agent_message(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> None:
     """Append a ghost-writer agent message to the story chat history and pause for user input."""
-    def apply(data: Dict[str, Any]) -> None:
-        history: List[Dict[str, Any]] = data.get("story_chat_history", [])
-        history.append({"role": "agent", "content": content, "gap_index": gap_index})
-        data["story_chat_history"] = history
-        data["waiting_for_story_input"] = True
-
-    _manager(cache_dir).apply_to_job(job_id, apply)
+    _client(cache_dir).atomic_update(
+        job_id,
+        merge_fields={"waiting_for_story_input": True},
+        append_to={
+            "story_chat_history": [{"role": "agent", "content": content, "gap_index": gap_index}]
+        },
+    )
 
 
 def submit_story_user_message(
@@ -343,13 +339,11 @@ def submit_story_user_message(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> None:
     """Append a user message to the story chat history and resume the pipeline."""
-    def apply(data: Dict[str, Any]) -> None:
-        history: List[Dict[str, Any]] = data.get("story_chat_history", [])
-        history.append({"role": "user", "content": message})
-        data["story_chat_history"] = history
-        data["waiting_for_story_input"] = False
-
-    _manager(cache_dir).apply_to_job(job_id, apply)
+    _client(cache_dir).atomic_update(
+        job_id,
+        merge_fields={"waiting_for_story_input": False},
+        append_to={"story_chat_history": [{"role": "user", "content": message}]},
+    )
 
 
 def skip_current_story_gap(
@@ -357,11 +351,15 @@ def skip_current_story_gap(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> None:
     """Skip the current story gap and advance to the next one (clears waiting flag)."""
-    def apply(data: Dict[str, Any]) -> None:
-        data["current_story_gap_index"] = data.get("current_story_gap_index", 0) + 1
-        data["waiting_for_story_input"] = False
-
-    _manager(cache_dir).apply_to_job(job_id, apply)
+    # Need to read current index, increment, then write
+    job = _client(cache_dir).get_job(job_id)
+    if job is None:
+        return
+    new_index = job.get("current_story_gap_index", 0) + 1
+    _client(cache_dir).atomic_update(
+        job_id,
+        merge_fields={"current_story_gap_index": new_index, "waiting_for_story_input": False},
+    )
 
 
 def complete_story_elicitation(
@@ -370,11 +368,10 @@ def complete_story_elicitation(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> None:
     """Store compiled elicited story narratives; clears all story-wait flags."""
-    def apply(data: Dict[str, Any]) -> None:
-        data["elicited_stories"] = elicited_stories
-        data["waiting_for_story_input"] = False
-
-    _manager(cache_dir).apply_to_job(job_id, apply)
+    _client(cache_dir).atomic_update(
+        job_id,
+        merge_fields={"elicited_stories": elicited_stories, "waiting_for_story_input": False},
+    )
 
 
 def is_waiting_for_story_input(
@@ -382,7 +379,7 @@ def is_waiting_for_story_input(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> bool:
     """Return True if the pipeline is paused waiting for a story message."""
-    job = _manager(cache_dir).get_job(job_id)
+    job = _client(cache_dir).get_job(job_id)
     return bool(job.get("waiting_for_story_input")) if job else False
 
 
@@ -397,11 +394,10 @@ def add_blog_pending_questions(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> None:
     """Store pending questions and pause the pipeline for answers."""
-    def apply(data: Dict[str, Any]) -> None:
-        data["pending_questions"] = questions
-        data["waiting_for_answers"] = True
-
-    _manager(cache_dir).apply_to_job(job_id, apply)
+    _client(cache_dir).atomic_update(
+        job_id,
+        merge_fields={"pending_questions": questions, "waiting_for_answers": True},
+    )
 
 
 def submit_blog_answers(
@@ -410,14 +406,11 @@ def submit_blog_answers(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> None:
     """Store submitted answers, clear pending questions, and resume the pipeline."""
-    def apply(data: Dict[str, Any]) -> None:
-        existing: List[Dict[str, Any]] = data.get("submitted_answers", [])
-        existing.extend(answers)
-        data["submitted_answers"] = existing
-        data["pending_questions"] = []
-        data["waiting_for_answers"] = False
-
-    _manager(cache_dir).apply_to_job(job_id, apply)
+    _client(cache_dir).atomic_update(
+        job_id,
+        merge_fields={"pending_questions": [], "waiting_for_answers": False},
+        append_to={"submitted_answers": answers},
+    )
 
 
 def is_waiting_for_blog_answers(
@@ -425,7 +418,7 @@ def is_waiting_for_blog_answers(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> bool:
     """Return True if the pipeline is paused waiting for Q&A answers."""
-    job = _manager(cache_dir).get_job(job_id)
+    job = _client(cache_dir).get_job(job_id)
     return bool(job.get("waiting_for_answers")) if job else False
 
 

--- a/backend/agents/coding_team/job_store.py
+++ b/backend/agents/coding_team/job_store.py
@@ -1,24 +1,24 @@
 """
-Job store for coding_team: persists job status and task graph snapshot via CentralJobManager.
+Job store for coding_team: persists job status and task graph snapshot via the job service.
 Used for status API and resume; task graph snapshot and agent_task_map are stored on the job.
 """
 
 from __future__ import annotations
 
-import copy
 import logging
 import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+from job_service_client import JobServiceClient
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_CACHE_DIR: Path = Path(os.getenv("AGENT_CACHE", ".agent_cache"))
 
 
-def _manager(cache_dir: str | Path = DEFAULT_CACHE_DIR):
-    from shared_job_management import CentralJobManager
-    return CentralJobManager(team="coding_team", cache_dir=cache_dir)
+def _client(cache_dir: str | Path = DEFAULT_CACHE_DIR) -> JobServiceClient:
+    return JobServiceClient(team="coding_team", cache_dir=str(cache_dir))
 
 
 def create_job(
@@ -29,9 +29,7 @@ def create_job(
 ) -> None:
     """Create a new coding_team job with pending status."""
     data: Dict[str, Any] = {
-        "job_id": job_id,
         "repo_path": repo_path,
-        "status": "pending",
         "phase": "task_graph",
         "status_text": "",
         "progress": 0,
@@ -40,8 +38,9 @@ def create_job(
         "stack_specs": [],
         "error": None,
         "plan_input": plan_input or {},
+        "events": [],
     }
-    _manager(cache_dir).create_job(**data)
+    _client(cache_dir).create_job(job_id, status="pending", **data)
 
 
 def get_job(
@@ -49,8 +48,7 @@ def get_job(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> Optional[Dict[str, Any]]:
     """Get job data. Returns None if not found."""
-    data = _manager(cache_dir).get_job(job_id)
-    return copy.deepcopy(data) if data else None
+    return _client(cache_dir).get_job(job_id)
 
 
 def update_job(
@@ -60,7 +58,7 @@ def update_job(
     **fields: Any,
 ) -> None:
     """Update job with given fields (e.g. status, phase, status_text, task_graph_snapshot, agent_task_map)."""
-    _manager(cache_dir).update_job(job_id, heartbeat=heartbeat, **fields)
+    _client(cache_dir).update_job(job_id, heartbeat=heartbeat, **fields)
 
 
 def update_job_task_graph(
@@ -84,5 +82,4 @@ def list_jobs(
 ) -> List[Dict[str, Any]]:
     """List coding_team jobs. If running_only, only pending or running."""
     statuses = ["pending", "running"] if running_only else None
-    jobs = _manager(cache_dir).list_jobs(statuses=statuses)
-    return [copy.deepcopy(j) for j in jobs]
+    return _client(cache_dir).list_jobs(statuses=statuses)

--- a/backend/agents/job_service_client.py
+++ b/backend/agents/job_service_client.py
@@ -275,8 +275,9 @@ class JobServiceClient:
         merge_fields: Optional[Dict[str, Any]] = None,
         merge_nested: Optional[Dict[str, Any]] = None,
         append_to: Optional[Dict[str, List[Any]]] = None,
+        increment: Optional[Dict[str, int]] = None,
     ) -> None:
-        """Perform an atomic batch of merge + append operations."""
+        """Perform an atomic batch of merge + append + increment operations."""
         if not self._is_remote:
 
             def _fn(d: Dict[str, Any]) -> None:
@@ -302,6 +303,12 @@ class JobServiceClient:
                             existing_list = []
                         existing_list.extend(items)
                         d[field_name] = existing_list
+                if increment:
+                    for field_name, delta in increment.items():
+                        current = d.get(field_name, 0)
+                        if not isinstance(current, (int, float)):
+                            current = 0
+                        d[field_name] = current + delta
 
             self._get_local().apply_to_job(job_id, _fn)
             return
@@ -312,8 +319,13 @@ class JobServiceClient:
                 "merge_fields": merge_fields,
                 "merge_nested": merge_nested,
                 "append_to": append_to,
+                "increment": increment,
             },
         )
+
+    def increment_field(self, job_id: str, field: str, delta: int = 1) -> None:
+        """Atomically increment an integer field by *delta*."""
+        self.atomic_update(job_id, increment={field: delta})
 
     def heartbeat(self, job_id: str) -> None:
         """Touch last_heartbeat_at for a job."""

--- a/backend/agents/job_service_client.py
+++ b/backend/agents/job_service_client.py
@@ -210,9 +210,14 @@ class JobServiceClient:
 
     def mark_all_active_jobs_failed(self, reason: str) -> List[str]:
         if not self._is_remote:
-            return self._get_local().mark_stale_active_jobs_failed(
-                stale_after_seconds=0, reason=reason
-            )
+            local = self._get_local()
+            failed: List[str] = []
+            for job in local.list_jobs(statuses=list(_ACTIVE_STATUSES)):
+                jid = job.get("job_id")
+                if jid:
+                    local.update_job(jid, status=JOB_STATUS_FAILED, error=reason)
+                    failed.append(jid)
+            return failed
         resp = self._request(
             "POST",
             self._url(f"/jobs/{self.team}/mark-all-running-failed"),

--- a/backend/agents/job_service_client.py
+++ b/backend/agents/job_service_client.py
@@ -1,0 +1,357 @@
+"""HTTP client for the containerized job service.
+
+This module provides ``JobServiceClient`` — a drop-in replacement for
+``CentralJobManager`` that talks to the job service over HTTP.  All agent
+teams import this instead of ``CentralJobManager`` directly.
+
+When ``JOB_SERVICE_URL`` is **not** set the client falls back to a local
+``CentralJobManager`` instance so that ``make run`` and ``pytest`` work
+without requiring the job service container.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any, Callable, Dict, List, Optional
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+_ACTIVE_STATUSES = {"pending", "running"}
+
+# Re-export status constants so teams can import from here
+JOB_STATUS_PENDING = "pending"
+JOB_STATUS_RUNNING = "running"
+JOB_STATUS_COMPLETED = "completed"
+JOB_STATUS_FAILED = "failed"
+JOB_STATUS_CANCELLED = "cancelled"
+
+
+def _default_base_url() -> str:
+    return os.environ.get("JOB_SERVICE_URL", "")
+
+
+def _is_remote_mode() -> bool:
+    return bool(_default_base_url())
+
+
+class JobServiceClient:
+    """HTTP client for the containerized job service.
+
+    Drop-in replacement for ``CentralJobManager``.  When ``JOB_SERVICE_URL``
+    is set, communicates with the job service over HTTP.  Otherwise delegates
+    to a local ``CentralJobManager`` for backwards-compatible local dev.
+    """
+
+    def __init__(
+        self, team: str, base_url: str | None = None, cache_dir: str | None = None
+    ) -> None:
+        self.team = team
+        self._base_url = base_url or _default_base_url()
+        self._cache_dir = cache_dir
+        self._local: Any = None  # Lazy-init CentralJobManager for local fallback
+
+    @property
+    def _is_remote(self) -> bool:
+        return bool(self._base_url)
+
+    def _get_local(self):
+        """Lazy-create a local CentralJobManager for non-Docker usage."""
+        if self._local is None:
+            from shared_job_management import CentralJobManager
+
+            cache_dir = self._cache_dir or os.getenv("AGENT_CACHE", ".agent_cache")
+            self._local = CentralJobManager(team=self.team, cache_dir=cache_dir)
+        return self._local
+
+    # ------------------------------------------------------------------
+    # HTTP helpers
+    # ------------------------------------------------------------------
+
+    def _url(self, path: str) -> str:
+        return f"{self._base_url}{path}"
+
+    @staticmethod
+    def _request(method: str, url: str, **kwargs) -> httpx.Response:
+        """Execute an HTTP request with retry on transient errors."""
+        delays = [0.5, 1.0, 2.0]
+        last_exc: Exception | None = None
+        for attempt in range(len(delays) + 1):
+            try:
+                with httpx.Client(timeout=30.0) as client:
+                    resp = client.request(method, url, **kwargs)
+                    resp.raise_for_status()
+                    return resp
+            except (
+                httpx.ConnectError,
+                httpx.ReadTimeout,
+                httpx.WriteTimeout,
+                httpx.PoolTimeout,
+            ) as exc:
+                last_exc = exc
+                if attempt < len(delays):
+                    time.sleep(delays[attempt])
+                    continue
+                raise
+            except httpx.HTTPStatusError:
+                raise
+        raise last_exc  # type: ignore[misc]
+
+    # ------------------------------------------------------------------
+    # Core CRUD
+    # ------------------------------------------------------------------
+
+    def create_job(self, job_id: str, *, status: str = JOB_STATUS_PENDING, **fields: Any) -> None:
+        if not self._is_remote:
+            self._get_local().create_job(job_id, status=status, **fields)
+            return
+        self._request(
+            "POST",
+            self._url(f"/jobs/{self.team}"),
+            json={"job_id": job_id, "status": status, "fields": fields},
+        )
+
+    def replace_job(self, job_id: str, payload: Dict[str, Any]) -> None:
+        if not self._is_remote:
+            self._get_local().replace_job(job_id, payload)
+            return
+        self._request(
+            "POST",
+            self._url(f"/jobs/{self.team}/{job_id}/replace"),
+            json={"payload": payload},
+        )
+
+    def get_job(self, job_id: str) -> Optional[Dict[str, Any]]:
+        if not self._is_remote:
+            return self._get_local().get_job(job_id)
+        resp = self._request("GET", self._url(f"/jobs/{self.team}/{job_id}"))
+        return resp.json().get("job")
+
+    def delete_job(self, job_id: str) -> bool:
+        if not self._is_remote:
+            return self._get_local().delete_job(job_id)
+        resp = self._request("DELETE", self._url(f"/jobs/{self.team}/{job_id}"))
+        return resp.json().get("deleted", False)
+
+    def list_jobs(self, *, statuses: Optional[List[str]] = None) -> List[Dict[str, Any]]:
+        if not self._is_remote:
+            return self._get_local().list_jobs(statuses=statuses)
+        params = {}
+        if statuses:
+            params["statuses"] = statuses
+        resp = self._request("GET", self._url(f"/jobs/{self.team}"), params=params)
+        return resp.json().get("jobs", [])
+
+    def update_job(self, job_id: str, *, heartbeat: bool = True, **fields: Any) -> None:
+        if not self._is_remote:
+            self._get_local().update_job(job_id, heartbeat=heartbeat, **fields)
+            return
+        self._request(
+            "PATCH",
+            self._url(f"/jobs/{self.team}/{job_id}"),
+            json={"heartbeat": heartbeat, "fields": fields},
+        )
+
+    def apply_to_job(self, job_id: str, fn: Callable[[Dict[str, Any]], None]) -> None:
+        """For local fallback only. Remote callers should use merge_nested/append_to_list/atomic_update."""
+        if not self._is_remote:
+            self._get_local().apply_to_job(job_id, fn)
+            return
+        raise NotImplementedError(
+            "apply_to_job with callables is not supported over HTTP. "
+            "Use merge_nested(), append_to_list(), or atomic_update() instead."
+        )
+
+    def append_event(
+        self,
+        job_id: str,
+        *,
+        action: str,
+        outcome: Optional[str] = None,
+        details: Optional[Dict[str, Any]] = None,
+        status: Optional[str] = None,
+    ) -> None:
+        if not self._is_remote:
+            self._get_local().append_event(
+                job_id, action=action, outcome=outcome, details=details, status=status
+            )
+            return
+        self._request(
+            "POST",
+            self._url(f"/jobs/{self.team}/{job_id}/event"),
+            json={"action": action, "outcome": outcome, "details": details, "status": status},
+        )
+
+    def mark_stale_active_jobs_failed(
+        self,
+        *,
+        stale_after_seconds: float,
+        reason: str,
+        waiting_field: str = "waiting_for_answers",
+    ) -> List[str]:
+        if not self._is_remote:
+            return self._get_local().mark_stale_active_jobs_failed(
+                stale_after_seconds=stale_after_seconds, reason=reason, waiting_field=waiting_field
+            )
+        resp = self._request(
+            "POST",
+            self._url(f"/jobs/{self.team}/mark-stale-failed"),
+            json={
+                "stale_after_seconds": stale_after_seconds,
+                "reason": reason,
+                "waiting_field": waiting_field,
+            },
+        )
+        return resp.json().get("failed_job_ids", [])
+
+    def mark_all_active_jobs_failed(self, reason: str) -> List[str]:
+        if not self._is_remote:
+            return self._get_local().mark_stale_active_jobs_failed(
+                stale_after_seconds=0, reason=reason
+            )
+        resp = self._request(
+            "POST",
+            self._url(f"/jobs/{self.team}/mark-all-running-failed"),
+            json={"reason": reason},
+        )
+        return resp.json().get("failed_job_ids", [])
+
+    # ------------------------------------------------------------------
+    # Atomic patch helpers (HTTP-safe replacements for apply_to_job)
+    # ------------------------------------------------------------------
+
+    def merge_nested(self, job_id: str, path: str, data: Dict[str, Any]) -> None:
+        """Merge *data* into a nested dict at *path* (dot-separated)."""
+        if not self._is_remote:
+
+            def _fn(d: Dict[str, Any]) -> None:
+                parts = path.split(".")
+                target = d
+                for part in parts[:-1]:
+                    target = target.setdefault(part, {})
+                leaf = parts[-1]
+                existing = target.get(leaf, {})
+                if isinstance(existing, dict) and isinstance(data, dict):
+                    existing.update(data)
+                    target[leaf] = existing
+                else:
+                    target[leaf] = data
+
+            self._get_local().apply_to_job(job_id, _fn)
+            return
+        self._request(
+            "POST",
+            self._url(f"/jobs/{self.team}/{job_id}/apply"),
+            json={"merge_nested": {path: data}},
+        )
+
+    def append_to_list(self, job_id: str, field: str, items: List[Any]) -> None:
+        """Append *items* to the list stored at *field*."""
+        if not self._is_remote:
+
+            def _fn(d: Dict[str, Any]) -> None:
+                existing = d.get(field, [])
+                if not isinstance(existing, list):
+                    existing = []
+                existing.extend(items)
+                d[field] = existing
+
+            self._get_local().apply_to_job(job_id, _fn)
+            return
+        self._request(
+            "POST",
+            self._url(f"/jobs/{self.team}/{job_id}/apply"),
+            json={"append_to": {field: items}},
+        )
+
+    def atomic_update(
+        self,
+        job_id: str,
+        *,
+        merge_fields: Optional[Dict[str, Any]] = None,
+        merge_nested: Optional[Dict[str, Any]] = None,
+        append_to: Optional[Dict[str, List[Any]]] = None,
+    ) -> None:
+        """Perform an atomic batch of merge + append operations."""
+        if not self._is_remote:
+
+            def _fn(d: Dict[str, Any]) -> None:
+                if merge_fields:
+                    d.update(merge_fields)
+                if merge_nested:
+                    for dotted_path, value in merge_nested.items():
+                        parts = dotted_path.split(".")
+                        target = d
+                        for part in parts[:-1]:
+                            target = target.setdefault(part, {})
+                        leaf = parts[-1]
+                        existing = target.get(leaf, {})
+                        if isinstance(existing, dict) and isinstance(value, dict):
+                            existing.update(value)
+                            target[leaf] = existing
+                        else:
+                            target[leaf] = value
+                if append_to:
+                    for field_name, items in append_to.items():
+                        existing_list = d.get(field_name, [])
+                        if not isinstance(existing_list, list):
+                            existing_list = []
+                        existing_list.extend(items)
+                        d[field_name] = existing_list
+
+            self._get_local().apply_to_job(job_id, _fn)
+            return
+        self._request(
+            "POST",
+            self._url(f"/jobs/{self.team}/{job_id}/apply"),
+            json={
+                "merge_fields": merge_fields,
+                "merge_nested": merge_nested,
+                "append_to": append_to,
+            },
+        )
+
+    def heartbeat(self, job_id: str) -> None:
+        """Touch last_heartbeat_at for a job."""
+        if not self._is_remote:
+            self._get_local().update_job(job_id)
+            return
+        self._request("POST", self._url(f"/jobs/{self.team}/{job_id}/heartbeat"))
+
+
+# ---------------------------------------------------------------------------
+# Stale job monitor (remote-compatible)
+# ---------------------------------------------------------------------------
+
+
+def start_stale_job_monitor(
+    client: JobServiceClient,
+    *,
+    interval_seconds: float,
+    stale_after_seconds: float,
+    reason: str,
+) -> threading.Event:
+    """Start a background thread that periodically marks stale jobs as failed.
+
+    Works with both remote (HTTP) and local (file-backed) modes.
+    """
+    stop_event = threading.Event()
+
+    def _run() -> None:
+        while not stop_event.is_set():
+            try:
+                client.mark_stale_active_jobs_failed(
+                    stale_after_seconds=stale_after_seconds,
+                    reason=reason,
+                )
+            except Exception as exc:
+                logger.warning("stale job monitor error (%s): %s", client.team, exc)
+            stop_event.wait(interval_seconds)
+
+    thread = threading.Thread(target=_run, name=f"{client.team}-stale-job-monitor", daemon=True)
+    thread.start()
+    return stop_event

--- a/backend/agents/nutrition_meal_planning_team/shared/job_store.py
+++ b/backend/agents/nutrition_meal_planning_team/shared/job_store.py
@@ -1,16 +1,15 @@
 """
-Job store for Nutrition & Meal Planning team: persists async job status via CentralJobManager.
+Job store for Nutrition & Meal Planning team: persists async job status via the job service.
 """
 
 from __future__ import annotations
 
-import copy
 import logging
 import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from shared_job_management import CentralJobManager
+from job_service_client import JobServiceClient
 
 logger = logging.getLogger(__name__)
 
@@ -22,17 +21,17 @@ JOB_STATUS_CANCELLED = "cancelled"
 
 DEFAULT_CACHE_DIR: Path = Path(os.environ.get("AGENT_CACHE", ".agent_cache"))
 
-_manager_instance: Optional[CentralJobManager] = None
+_client_instance: Optional[JobServiceClient] = None
 
 
-def _manager(cache_dir: str | Path = DEFAULT_CACHE_DIR) -> CentralJobManager:
-    global _manager_instance
-    if _manager_instance is None:
-        _manager_instance = CentralJobManager(
+def _client(cache_dir: str | Path = DEFAULT_CACHE_DIR) -> JobServiceClient:
+    global _client_instance
+    if _client_instance is None:
+        _client_instance = JobServiceClient(
             team="nutrition_meal_planning_team",
-            cache_dir=cache_dir,
+            cache_dir=str(cache_dir),
         )
-    return _manager_instance
+    return _client_instance
 
 
 def create_job(
@@ -41,7 +40,7 @@ def create_job(
     **fields: Any,
 ) -> None:
     """Create a new job with pending status."""
-    _manager(cache_dir).create_job(job_id, status=JOB_STATUS_PENDING, **fields)
+    _client(cache_dir).create_job(job_id, status=JOB_STATUS_PENDING, **fields)
 
 
 def get_job(
@@ -49,8 +48,7 @@ def get_job(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> Optional[Dict[str, Any]]:
     """Get job data, or None if not found."""
-    data = _manager(cache_dir).get_job(job_id)
-    return copy.deepcopy(data) if data else None
+    return _client(cache_dir).get_job(job_id)
 
 
 def update_job(
@@ -59,7 +57,7 @@ def update_job(
     **fields: Any,
 ) -> None:
     """Update job fields."""
-    _manager(cache_dir).update_job(job_id, **fields)
+    _client(cache_dir).update_job(job_id, **fields)
 
 
 def list_jobs(
@@ -67,7 +65,7 @@ def list_jobs(
     statuses: Optional[List[str]] = None,
 ) -> List[Dict[str, Any]]:
     """List jobs, optionally filtered by status."""
-    return _manager(cache_dir).list_jobs(statuses=statuses)
+    return _client(cache_dir).list_jobs(statuses=statuses)
 
 
 def cancel_job(
@@ -78,7 +76,7 @@ def cancel_job(
     data = get_job(job_id, cache_dir=cache_dir)
     if not data:
         return False
-    _manager(cache_dir).update_job(job_id, status=JOB_STATUS_CANCELLED, heartbeat=False)
+    _client(cache_dir).update_job(job_id, status=JOB_STATUS_CANCELLED, heartbeat=False)
     return True
 
 
@@ -97,10 +95,6 @@ def mark_all_running_jobs_failed(
 ) -> None:
     """Mark all pending or running jobs as failed (e.g. on server shutdown)."""
     try:
-        jobs = list_jobs(cache_dir=cache_dir, statuses=[JOB_STATUS_PENDING, JOB_STATUS_RUNNING])
-        for job in jobs:
-            job_id = job.get("job_id")
-            if job_id:
-                update_job(job_id, status=JOB_STATUS_FAILED, error=reason, cache_dir=cache_dir)
+        _client(cache_dir).mark_all_active_jobs_failed(reason)
     except Exception as e:
         logger.warning("mark_all_running_jobs_failed: %s", e)

--- a/backend/agents/personal_assistant_team/shared/pa_job_store.py
+++ b/backend/agents/personal_assistant_team/shared/pa_job_store.py
@@ -1,19 +1,15 @@
 """
-Job store for Personal Assistant API: persists job status and progress via CentralJobManager.
-
-Jobs are stored under {cache_dir}/personal_assistant_team/jobs/{job_id}.json
+Job store for Personal Assistant API: persists job status and progress via the job service.
 """
 
 from __future__ import annotations
 
-import copy
 import logging
 import os
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from shared_job_management import CentralJobManager
+from job_service_client import JobServiceClient
 
 logger = logging.getLogger(__name__)
 
@@ -26,8 +22,8 @@ PA_JOB_STATUS_CANCELLED = "cancelled"
 DEFAULT_CACHE_DIR: Path = Path(os.environ.get("AGENT_CACHE", ".agent_cache")).resolve()
 
 
-def _manager(cache_dir: str | Path = DEFAULT_CACHE_DIR) -> CentralJobManager:
-    return CentralJobManager(team="personal_assistant_team", cache_dir=cache_dir)
+def _client(cache_dir: str | Path = DEFAULT_CACHE_DIR) -> JobServiceClient:
+    return JobServiceClient(team="personal_assistant_team", cache_dir=str(cache_dir))
 
 
 def create_job(
@@ -38,12 +34,12 @@ def create_job(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
     context: Optional[Dict[str, Any]] = None,
 ) -> None:
-    """Create a new job with pending status and persist to cache."""
+    """Create a new job with pending status."""
+    from datetime import datetime, timezone
+
     now = datetime.now(timezone.utc).isoformat()
     data: Dict[str, Any] = {
-        "job_id": job_id,
         "user_id": user_id,
-        "status": PA_JOB_STATUS_PENDING,
         "request_type": request_type,
         "request_message": message,
         "context": context or {},
@@ -53,17 +49,17 @@ def create_job(
         "error": None,
         "created_at": now,
         "updated_at": now,
+        "events": [],
     }
-    _manager(cache_dir).create_job(job_id, status=PA_JOB_STATUS_PENDING, **data)
+    _client(cache_dir).create_job(job_id, status=PA_JOB_STATUS_PENDING, **data)
 
 
 def get_job(
     job_id: str,
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> Optional[Dict[str, Any]]:
-    """Get job data from cache, or None if not found."""
-    data = _manager(cache_dir).get_job(job_id)
-    return copy.deepcopy(data) if data else None
+    """Get job data, or None if not found."""
+    return _client(cache_dir).get_job(job_id)
 
 
 def update_job(
@@ -71,8 +67,8 @@ def update_job(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
     **kwargs: Any,
 ) -> None:
-    """Update job fields. Merges with existing data and persists to cache."""
-    _manager(cache_dir).update_job(job_id, **kwargs)
+    """Update job fields. Merges with existing data."""
+    _client(cache_dir).update_job(job_id, **kwargs)
 
 
 def list_jobs(
@@ -81,25 +77,27 @@ def list_jobs(
     running_only: bool = False,
     limit: int = 50,
 ) -> List[Dict[str, Any]]:
-    """List jobs from cache. Optionally filter by user_id and running status."""
+    """List jobs. Optionally filter by user_id and running status."""
     statuses: Optional[List[str]] = (
         [PA_JOB_STATUS_PENDING, PA_JOB_STATUS_RUNNING] if running_only else None
     )
-    raw = _manager(cache_dir).list_jobs(statuses=statuses)
+    raw = _client(cache_dir).list_jobs(statuses=statuses)
     result: List[Dict[str, Any]] = []
     for data in raw:
         if user_id is not None and data.get("user_id") != user_id:
             continue
-        result.append({
-            "job_id": data.get("job_id"),
-            "user_id": data.get("user_id"),
-            "status": data.get("status", PA_JOB_STATUS_PENDING),
-            "request_type": data.get("request_type"),
-            "progress": data.get("progress", 0),
-            "status_text": data.get("status_text"),
-            "created_at": data.get("created_at"),
-            "updated_at": data.get("updated_at"),
-        })
+        result.append(
+            {
+                "job_id": data.get("job_id"),
+                "user_id": data.get("user_id"),
+                "status": data.get("status", PA_JOB_STATUS_PENDING),
+                "request_type": data.get("request_type"),
+                "progress": data.get("progress", 0),
+                "status_text": data.get("status_text"),
+                "created_at": data.get("created_at"),
+                "updated_at": data.get("updated_at"),
+            }
+        )
     return result[:limit]
 
 
@@ -109,11 +107,7 @@ def mark_all_running_jobs_failed(
 ) -> None:
     """Mark all pending or running PA jobs as failed (e.g. on server shutdown)."""
     try:
-        jobs = list_jobs(cache_dir=cache_dir, running_only=True, limit=10000)
-        for job in jobs:
-            job_id = job.get("job_id")
-            if job_id:
-                update_job(job_id, status=PA_JOB_STATUS_FAILED, error=reason, cache_dir=cache_dir)
+        _client(cache_dir).mark_all_active_jobs_failed(reason)
     except Exception as e:
         logger.warning("mark_all_running_jobs_failed: %s", e)
 
@@ -129,7 +123,7 @@ def cancel_job(
     status = data.get("status")
     if status not in (PA_JOB_STATUS_PENDING, PA_JOB_STATUS_RUNNING):
         return False
-    _manager(cache_dir).update_job(
+    _client(cache_dir).update_job(
         job_id,
         status=PA_JOB_STATUS_CANCELLED,
         status_text="Job cancelled by user",
@@ -151,5 +145,5 @@ def delete_job(
     job_id: str,
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> bool:
-    """Delete a job from the cache. Returns True if deleted, False if not found."""
-    return _manager(cache_dir).delete_job(job_id)
+    """Delete a job. Returns True if deleted, False if not found."""
+    return _client(cache_dir).delete_job(job_id)

--- a/backend/agents/planning_v3_team/shared/job_store.py
+++ b/backend/agents/planning_v3_team/shared/job_store.py
@@ -1,5 +1,5 @@
 """
-Job store for Planning V3 API: persists job status via CentralJobManager.
+Job store for Planning V3 API: persists job status via the job service.
 """
 
 from __future__ import annotations
@@ -9,10 +9,7 @@ import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-try:
-    from shared_job_management import CentralJobManager
-except ImportError:
-    CentralJobManager = None  # type: ignore
+from job_service_client import JobServiceClient
 
 logger = logging.getLogger(__name__)
 
@@ -22,19 +19,17 @@ JOB_STATUS_COMPLETED = "completed"
 JOB_STATUS_FAILED = "failed"
 
 DEFAULT_CACHE_DIR: Path = Path(os.getenv("AGENT_CACHE", ".agent_cache"))
-_manager_instance: Optional[CentralJobManager] = None
+_client_instance: Optional[JobServiceClient] = None
 
 
-def _manager(cache_dir: str | Path = DEFAULT_CACHE_DIR) -> CentralJobManager:
-    global _manager_instance
-    if _manager_instance is None:
-        if CentralJobManager is None:
-            raise RuntimeError("shared_job_management not available")
-        _manager_instance = CentralJobManager(
+def _client(cache_dir: str | Path = DEFAULT_CACHE_DIR) -> JobServiceClient:
+    global _client_instance
+    if _client_instance is None:
+        _client_instance = JobServiceClient(
             team="planning_v3_team",
-            cache_dir=cache_dir,
+            cache_dir=str(cache_dir),
         )
-    return _manager_instance
+    return _client_instance
 
 
 def create_job(
@@ -53,39 +48,45 @@ def create_job(
         "pending_questions": [],
         "waiting_for_answers": False,
         "job_type": "planning_v3",
+        "events": [],
     }
     data.update(fields)
-    _manager(cache_dir).create_job(job_id=job_id, status=JOB_STATUS_PENDING, **data)
+    _client(cache_dir).create_job(job_id, status=JOB_STATUS_PENDING, **data)
 
 
 def get_job(job_id: str, cache_dir: str | Path = DEFAULT_CACHE_DIR) -> Optional[Dict[str, Any]]:
-    return _manager(cache_dir).get_job(job_id)
+    return _client(cache_dir).get_job(job_id)
 
 
 def update_job(job_id: str, cache_dir: str | Path = DEFAULT_CACHE_DIR, **fields: Any) -> None:
-    _manager(cache_dir).update_job(job_id, **fields)
+    _client(cache_dir).update_job(job_id, **fields)
 
 
 def list_jobs(
     running_only: bool = False,
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> List[Dict[str, Any]]:
-    statuses: Optional[List[str]] = [JOB_STATUS_PENDING, JOB_STATUS_RUNNING] if running_only else None
-    return _manager(cache_dir).list_jobs(statuses=statuses) or []
+    statuses: Optional[List[str]] = (
+        [JOB_STATUS_PENDING, JOB_STATUS_RUNNING] if running_only else None
+    )
+    return _client(cache_dir).list_jobs(statuses=statuses) or []
 
 
-def mark_job_completed(job_id: str, cache_dir: str | Path = DEFAULT_CACHE_DIR, **fields: Any) -> None:
-    _manager(cache_dir).update_job(job_id, status=JOB_STATUS_COMPLETED, progress=100, heartbeat=False, **fields)
+def mark_job_completed(
+    job_id: str, cache_dir: str | Path = DEFAULT_CACHE_DIR, **fields: Any
+) -> None:
+    _client(cache_dir).update_job(
+        job_id, status=JOB_STATUS_COMPLETED, progress=100, heartbeat=False, **fields
+    )
 
 
 def mark_job_failed(job_id: str, error: str, cache_dir: str | Path = DEFAULT_CACHE_DIR) -> None:
-    _manager(cache_dir).update_job(job_id, status=JOB_STATUS_FAILED, error=error, heartbeat=False)
+    _client(cache_dir).update_job(job_id, status=JOB_STATUS_FAILED, error=error, heartbeat=False)
 
 
 def mark_all_running_jobs_failed(reason: str) -> None:
     """Called on shutdown to mark running jobs as failed."""
-    jobs = list_jobs(running_only=True)
-    for j in jobs:
-        jid = j.get("job_id")
-        if jid and j.get("status") in (JOB_STATUS_PENDING, JOB_STATUS_RUNNING):
-            mark_job_failed(jid, reason)
+    try:
+        _client().mark_all_active_jobs_failed(reason)
+    except Exception as e:
+        logger.warning("mark_all_running_jobs_failed: %s", e)

--- a/backend/agents/road_trip_planning_team/shared/job_store.py
+++ b/backend/agents/road_trip_planning_team/shared/job_store.py
@@ -1,14 +1,13 @@
-"""Job store for Road Trip Planning team: persists async job status via CentralJobManager."""
+"""Job store for Road Trip Planning team: persists async job status via the job service."""
 
 from __future__ import annotations
 
-import copy
 import logging
 import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from shared_job_management import CentralJobManager
+from job_service_client import JobServiceClient
 
 logger = logging.getLogger(__name__)
 
@@ -20,43 +19,40 @@ JOB_STATUS_CANCELLED = "cancelled"
 
 DEFAULT_CACHE_DIR: Path = Path(os.environ.get("AGENT_CACHE", ".agent_cache"))
 
-_manager_instance: Optional[CentralJobManager] = None
+_client_instance: Optional[JobServiceClient] = None
 
 
-def _manager(cache_dir: str | Path = DEFAULT_CACHE_DIR) -> CentralJobManager:
-    global _manager_instance
-    if _manager_instance is None:
-        _manager_instance = CentralJobManager(
+def _client(cache_dir: str | Path = DEFAULT_CACHE_DIR) -> JobServiceClient:
+    global _client_instance
+    if _client_instance is None:
+        _client_instance = JobServiceClient(
             team="road_trip_planning_team",
-            cache_dir=cache_dir,
+            cache_dir=str(cache_dir),
         )
-    return _manager_instance
+    return _client_instance
 
 
 def create_job(job_id: str, cache_dir: str | Path = DEFAULT_CACHE_DIR, **fields: Any) -> None:
-    _manager(cache_dir).create_job(job_id, status=JOB_STATUS_PENDING, **fields)
+    _client(cache_dir).create_job(job_id, status=JOB_STATUS_PENDING, **fields)
 
 
 def get_job(job_id: str, cache_dir: str | Path = DEFAULT_CACHE_DIR) -> Optional[Dict[str, Any]]:
-    data = _manager(cache_dir).get_job(job_id)
-    return copy.deepcopy(data) if data else None
+    return _client(cache_dir).get_job(job_id)
 
 
 def update_job(job_id: str, cache_dir: str | Path = DEFAULT_CACHE_DIR, **fields: Any) -> None:
-    _manager(cache_dir).update_job(job_id, **fields)
+    _client(cache_dir).update_job(job_id, **fields)
 
 
-def list_jobs(cache_dir: str | Path = DEFAULT_CACHE_DIR, statuses: Optional[List[str]] = None) -> List[Dict[str, Any]]:
-    return _manager(cache_dir).list_jobs(statuses=statuses)
+def list_jobs(
+    cache_dir: str | Path = DEFAULT_CACHE_DIR, statuses: Optional[List[str]] = None
+) -> List[Dict[str, Any]]:
+    return _client(cache_dir).list_jobs(statuses=statuses)
 
 
 def mark_all_running_jobs_failed(reason: str, cache_dir: str | Path = DEFAULT_CACHE_DIR) -> None:
     """Mark all pending or running jobs as failed (e.g. on server shutdown)."""
     try:
-        jobs = list_jobs(cache_dir=cache_dir, statuses=[JOB_STATUS_PENDING, JOB_STATUS_RUNNING])
-        for job in jobs:
-            job_id = job.get("job_id")
-            if job_id:
-                update_job(job_id, status=JOB_STATUS_FAILED, error=reason, cache_dir=cache_dir)
+        _client(cache_dir).mark_all_active_jobs_failed(reason)
     except Exception as e:
         logger.warning("mark_all_running_jobs_failed: %s", e)

--- a/backend/agents/sales_team/api/main.py
+++ b/backend/agents/sales_team/api/main.py
@@ -11,6 +11,14 @@ from typing import Any, Dict, List, Optional
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
+from job_service_client import (
+    JOB_STATUS_COMPLETED,
+    JOB_STATUS_FAILED,
+    JOB_STATUS_PENDING,
+    JOB_STATUS_RUNNING,
+    JobServiceClient,
+    start_stale_job_monitor,
+)
 from sales_team.learning_engine import LearningEngine
 from sales_team.models import (
     CoachingRequest,
@@ -36,14 +44,6 @@ from sales_team.outcome_store import (
     record_deal_outcome,
     record_stage_outcome,
 )
-from shared_job_management import (
-    JOB_STATUS_COMPLETED,
-    JOB_STATUS_FAILED,
-    JOB_STATUS_PENDING,
-    JOB_STATUS_RUNNING,
-    CentralJobManager,
-    start_stale_job_monitor,
-)
 
 app = FastAPI(
     title="AI Sales Team API",
@@ -57,7 +57,7 @@ app = FastAPI(
 )
 
 logger = logging.getLogger(__name__)
-_job_manager = CentralJobManager(team="sales_team")
+_job_manager = JobServiceClient(team="sales_team")
 _stale_monitor_stop = start_stale_job_monitor(
     _job_manager,
     interval_seconds=15.0,
@@ -281,9 +281,7 @@ def cancel_pipeline_job(job_id: str) -> CancelJobResponse:
         raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
     current = job.get("status", JOB_STATUS_PENDING)
     if current not in (JOB_STATUS_PENDING, JOB_STATUS_RUNNING):
-        raise HTTPException(
-            status_code=400, detail=f"Job is already in terminal state: {current}"
-        )
+        raise HTTPException(status_code=400, detail=f"Job is already in terminal state: {current}")
     _job_manager.update_job(job_id, status="cancelled", heartbeat=False)
     return CancelJobResponse(job_id=job_id)
 

--- a/backend/agents/soc2_compliance_team/api/main.py
+++ b/backend/agents/soc2_compliance_team/api/main.py
@@ -7,11 +7,12 @@ import threading
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
+from job_service_client import JobServiceClient, start_stale_job_monitor
 from soc2_compliance_team.models import SOC2AuditResult
 from soc2_compliance_team.orchestrator import SOC2AuditOrchestrator
 
@@ -24,8 +25,13 @@ app = FastAPI(
     version="1.0.0",
 )
 
-_jobs: Dict[str, dict] = {}
-_jobs_lock = threading.Lock()
+_job_manager = JobServiceClient(team="soc2_compliance_team")
+_stale_monitor_stop = start_stale_job_monitor(
+    _job_manager,
+    interval_seconds=15.0,
+    stale_after_seconds=300.0,
+    reason="Job heartbeat stale while pending/running",
+)
 
 
 def _now() -> str:
@@ -59,29 +65,24 @@ class AuditStatusResponse(BaseModel):
         description="pending | running | completed | failed",
     )
     repo_path: Optional[str] = Field(None, description="Repository path being audited.")
-    current_stage: Optional[str] = Field(None, description="Current audit stage (e.g. Security TSC).")
+    current_stage: Optional[str] = Field(
+        None, description="Current audit stage (e.g. Security TSC)."
+    )
     last_updated_at: Optional[str] = Field(None, description="Last status update (ISO).")
     error: Optional[str] = Field(None, description="Error message if failed.")
-    result: Optional[SOC2AuditResult] = Field(None, description="Full audit result when status is completed.")
+    result: Optional[SOC2AuditResult] = Field(
+        None, description="Full audit result when status is completed."
+    )
 
 
 def _update_job(job_id: str, **fields: Any) -> None:
-    with _jobs_lock:
-        if job_id in _jobs:
-            _jobs[job_id].update(fields)
-            _jobs[job_id]["last_updated_at"] = _now()
+    _job_manager.update_job(job_id, **fields)
 
 
 def mark_all_running_jobs_failed(reason: str) -> None:
     """Mark all pending or running SOC2 audit jobs as failed (e.g. on server shutdown)."""
     try:
-        with _jobs_lock:
-            for job_id, job in list(_jobs.items()):
-                if job.get("status") in ("pending", "running"):
-                    job["status"] = "failed"
-                    job["error"] = reason
-                    job["current_stage"] = "Failed"
-                    job["last_updated_at"] = _now()
+        _job_manager.mark_all_active_jobs_failed(reason)
     except Exception as e:
         logger.warning("mark_all_running_jobs_failed: %s", e)
 
@@ -118,23 +119,25 @@ def run_audit(request: RunAuditRequest) -> RunAuditResponse:
     """Start a SOC2 compliance audit on the given repository path."""
     repo_path = Path(request.repo_path).expanduser().resolve()
     if not repo_path.is_dir():
-        raise HTTPException(status_code=400, detail=f"Repository path is not a directory: {request.repo_path}")
+        raise HTTPException(
+            status_code=400, detail=f"Repository path is not a directory: {request.repo_path}"
+        )
 
     job_id = str(uuid.uuid4())
-    with _jobs_lock:
-        _jobs[job_id] = {
-            "job_id": job_id,
-            "status": "pending",
-            "repo_path": str(repo_path),
-            "current_stage": None,
-            "last_updated_at": _now(),
-            "error": None,
-            "result": None,
-        }
+    _job_manager.create_job(
+        job_id,
+        status="pending",
+        repo_path=str(repo_path),
+        current_stage=None,
+        error=None,
+        result=None,
+        events=[],
+    )
 
     try:
         from soc2_compliance_team.temporal.client import is_temporal_enabled
         from soc2_compliance_team.temporal.start_workflow import start_audit_workflow
+
         if is_temporal_enabled():
             start_audit_workflow(job_id, str(repo_path))
             return RunAuditResponse(
@@ -164,8 +167,7 @@ def run_audit(request: RunAuditRequest) -> RunAuditResponse:
 )
 def get_audit_status(job_id: str) -> AuditStatusResponse:
     """Get the status and result of an audit job."""
-    with _jobs_lock:
-        job = _jobs.get(job_id)
+    job = _job_manager.get_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
 
@@ -178,7 +180,7 @@ def get_audit_status(job_id: str) -> AuditStatusResponse:
         status=job.get("status", "pending"),
         repo_path=job.get("repo_path"),
         current_stage=job.get("current_stage"),
-        last_updated_at=job.get("last_updated_at"),
+        last_updated_at=job.get("updated_at"),
         error=job.get("error"),
         result=result,
     )

--- a/backend/agents/social_media_marketing_team/api/main.py
+++ b/backend/agents/social_media_marketing_team/api/main.py
@@ -16,15 +16,15 @@ from blog_research_agent.tools.web_search import OllamaWebSearch
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
-from llm_service import get_client
-from shared_job_management import (
+from job_service_client import (
     JOB_STATUS_COMPLETED,
     JOB_STATUS_FAILED,
     JOB_STATUS_PENDING,
     JOB_STATUS_RUNNING,
-    CentralJobManager,
+    JobServiceClient,
     start_stale_job_monitor,
 )
+from llm_service import get_client
 from social_media_marketing_team.models import (
     BrandGoals,
     CampaignPerformanceSnapshot,
@@ -39,7 +39,7 @@ from social_media_marketing_team.trend_models import TrendDigest
 app = FastAPI(title="Social Media Marketing Team API", version="1.0.0")
 
 logger = logging.getLogger(__name__)
-_job_manager = CentralJobManager(team="social_media_marketing_team")
+_job_manager = JobServiceClient(team="social_media_marketing_team")
 _stale_monitor_stop = start_stale_job_monitor(
     _job_manager,
     interval_seconds=15.0,
@@ -55,8 +55,12 @@ _scheduler: Optional[BackgroundScheduler] = None
 
 
 class RunMarketingTeamRequest(BaseModel):
-    brand_guidelines_path: str = Field(..., max_length=4096, description="Path to brand guidelines document")
-    brand_objectives_path: str = Field(..., max_length=4096, description="Path to brand objectives document")
+    brand_guidelines_path: str = Field(
+        ..., max_length=4096, description="Path to brand guidelines document"
+    )
+    brand_objectives_path: str = Field(
+        ..., max_length=4096, description="Path to brand objectives document"
+    )
     llm_model_name: str = Field(..., max_length=256, description="Name of local LLM model to use")
     brand_name: str = Field(default="Brand", max_length=256)
     target_audience: str = Field(default="general audience", max_length=5000)
@@ -145,7 +149,9 @@ def _run_team_job(job_id: str, request: RunMarketingTeamRequest) -> None:
         guidelines_text = _read_text_file(request.brand_guidelines_path)
         objectives_text = _read_text_file(request.brand_objectives_path)
 
-        _update_job(job_id, current_stage="building_campaign_proposal", progress=50, eta_hint="~1 minute")
+        _update_job(
+            job_id, current_stage="building_campaign_proposal", progress=50, eta_hint="~1 minute"
+        )
         orchestrator = SocialMediaMarketingOrchestrator(llm_model_name=request.llm_model_name)
         goals = BrandGoals(
             brand_name=request.brand_name,
@@ -188,7 +194,9 @@ def _run_team_job(job_id: str, request: RunMarketingTeamRequest) -> None:
             result=result.model_dump(),
         )
     except Exception as exc:
-        _update_job(job_id, status=JOB_STATUS_FAILED, current_stage="failed", error=str(exc), eta_hint=None)
+        _update_job(
+            job_id, status=JOB_STATUS_FAILED, current_stage="failed", error=str(exc), eta_hint=None
+        )
 
 
 @app.post("/social-marketing/run", response_model=RunMarketingTeamResponse)
@@ -221,6 +229,7 @@ def run_marketing_team(request: RunMarketingTeamRequest) -> RunMarketingTeamResp
     try:
         from social_media_marketing_team.temporal.client import is_temporal_enabled
         from social_media_marketing_team.temporal.start_workflow import start_team_job_workflow
+
         if is_temporal_enabled():
             start_team_job_workflow(job_id, request.model_dump())
             return RunMarketingTeamResponse(
@@ -263,19 +272,25 @@ def ingest_performance(job_id: str, payload: PerformanceIngestRequest) -> Perfor
 
 
 @app.post("/social-marketing/revise/{job_id}", response_model=RunMarketingTeamResponse)
-def revise_marketing_team(job_id: str, request: ReviseMarketingTeamRequest) -> RunMarketingTeamResponse:
+def revise_marketing_team(
+    job_id: str, request: ReviseMarketingTeamRequest
+) -> RunMarketingTeamResponse:
     job = _job_manager.get_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
     original_payload = job.get("request_payload")
     if not isinstance(original_payload, dict):
-        raise HTTPException(status_code=400, detail="Original run payload not available for revision")
+        raise HTTPException(
+            status_code=400, detail="Original run payload not available for revision"
+        )
 
     original_request = RunMarketingTeamRequest(**original_payload)
-    revised = original_request.model_copy(update={
-        "human_feedback": request.feedback,
-        "human_approved_for_testing": request.approved_for_testing,
-    })
+    revised = original_request.model_copy(
+        update={
+            "human_feedback": request.feedback,
+            "human_approved_for_testing": request.approved_for_testing,
+        }
+    )
     revision_history = job.get("revision_history", [])
     revision_history.append(request.feedback)
     _job_manager.update_job(
@@ -293,6 +308,7 @@ def revise_marketing_team(job_id: str, request: ReviseMarketingTeamRequest) -> R
     try:
         from social_media_marketing_team.temporal.client import is_temporal_enabled
         from social_media_marketing_team.temporal.start_workflow import start_team_job_workflow
+
         if is_temporal_enabled():
             start_team_job_workflow(job_id, revised.model_dump())
             return RunMarketingTeamResponse(
@@ -340,7 +356,9 @@ def get_marketing_job_status(job_id: str) -> MarketingJobStatusResponse:
     job = _job_manager.get_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
-    return MarketingJobStatusResponse(**{k: v for k, v in job.items() if k in MarketingJobStatusResponse.model_fields})
+    return MarketingJobStatusResponse(
+        **{k: v for k, v in job.items() if k in MarketingJobStatusResponse.model_fields}
+    )
 
 
 class CancelMarketingJobResponse(BaseModel):
@@ -436,7 +454,9 @@ def run_trend_discovery() -> TrendRunResponse:
     """Trigger trend discovery immediately (runs in background, returns at once)."""
     thread = threading.Thread(target=_run_trend_job, daemon=True, name="trend_discovery_manual")
     thread.start()
-    return TrendRunResponse(message="Trend discovery started. Poll GET /social-marketing/trends/latest for results.")
+    return TrendRunResponse(
+        message="Trend discovery started. Poll GET /social-marketing/trends/latest for results."
+    )
 
 
 @app.get("/social-marketing/trends/latest", response_model=TrendLatestResponse)

--- a/backend/agents/software_engineering_team/shared/job_store.py
+++ b/backend/agents/software_engineering_team/shared/job_store.py
@@ -1,10 +1,9 @@
 """
-Job store for async API: persists job status and progress per job in a cache directory.
+Job store for async API: persists job status and progress via the centralized job service.
 
-Uses AGENT_CACHE environment variable when set (otherwise .agent_cache), resolved to an
-absolute path so list/create use the same directory regardless of process CWD. Each job
-is stored under {cache_dir}/software_engineering_team/jobs/{job_id}.json via
-CentralJobManager so state survives process restarts.
+Uses ``JobServiceClient`` to communicate with the job service container over
+HTTP when ``JOB_SERVICE_URL`` is set, falling back to a local
+``CentralJobManager`` for non-Docker development.
 
 Stale jobs: JOB_STALE_AFTER_SECONDS (env JOB_STALE_AFTER_SECONDS, default 1800) is the
 age in seconds after which a pending/running job with no recent heartbeat is marked failed.
@@ -14,7 +13,6 @@ POST /run-team/{job_id}/resume (the workflow may still be running or can be rest
 
 from __future__ import annotations
 
-import copy
 import logging
 import os
 import threading
@@ -23,7 +21,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from shared_job_management import CentralJobManager
+from job_service_client import JobServiceClient
 
 logger = logging.getLogger(__name__)
 
@@ -38,11 +36,10 @@ JOB_STATUS_AGENT_CRASH = "agent_crash"
 JOB_STATUS_PAUSED_LLM_CONNECTIVITY = "paused_llm_connectivity"
 
 # Sentinel failure reason when LLM is unreachable after 3 attempts (frontend team retry + circuit breaker)
-LLM_UNREACHABLE_AFTER_RETRIES = (
-    "LLM unreachable after 3 attempts with exponential backoff. Check connectivity and resume when ready."
-)
+LLM_UNREACHABLE_AFTER_RETRIES = "LLM unreachable after 3 attempts with exponential backoff. Check connectivity and resume when ready."
 
 DEFAULT_CACHE_DIR: Path = Path(os.getenv("AGENT_CACHE", ".agent_cache"))
+
 
 # Seconds after which a pending/running job with no recent heartbeat is marked failed.
 # Set via env JOB_STALE_AFTER_SECONDS (default 1800).
@@ -56,13 +53,14 @@ def get_stale_after_seconds() -> float:
 _jobs_path_logged = False
 
 
-def _manager(cache_dir: str | Path = DEFAULT_CACHE_DIR) -> CentralJobManager:
+def _client(cache_dir: str | Path = DEFAULT_CACHE_DIR) -> JobServiceClient:
     global _jobs_path_logged
     if not _jobs_path_logged:
-        jobs_dir = Path(cache_dir) / "software_engineering_team" / "jobs"
-        logger.info("Software engineering job store path: %s", jobs_dir)
+        logger.info(
+            "Software engineering job store using JobServiceClient (team=software_engineering_team)"
+        )
         _jobs_path_logged = True
-    return CentralJobManager(team="software_engineering_team", cache_dir=cache_dir)
+    return JobServiceClient(team="software_engineering_team", cache_dir=str(cache_dir))
 
 
 def create_job(
@@ -71,11 +69,9 @@ def create_job(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
     job_type: Optional[str] = None,
 ) -> None:
-    """Create a new job with pending status and persist to cache."""
+    """Create a new job with pending status and persist to the job service."""
     data: Dict[str, Any] = {
-        "job_id": job_id,
         "repo_path": repo_path,
-        "status": JOB_STATUS_PENDING,
         "progress": 0,
         "current_task": None,
         "status_text": None,
@@ -88,11 +84,11 @@ def create_job(
         "waiting_for_answers": False,
         "submitted_answers": [],
         "cancel_requested": False,
-        "created_at": datetime.now(timezone.utc).isoformat(),
+        "events": [],
     }
     if job_type is not None:
         data["job_type"] = job_type
-    _manager(cache_dir).create_job(**data)
+    _client(cache_dir).create_job(job_id, status=JOB_STATUS_PENDING, **data)
 
 
 def reset_job(
@@ -103,11 +99,7 @@ def reset_job(
 ) -> None:
     """Reset an existing job to initial state (same job_id). Preserves created_at so job order is unchanged."""
     existing = get_job(job_id, cache_dir)
-    created_at = (
-        existing.get("created_at")
-        if existing
-        else datetime.now(timezone.utc).isoformat()
-    )
+    created_at = existing.get("created_at") if existing else datetime.now(timezone.utc).isoformat()
     now = datetime.now(timezone.utc).isoformat()
     data: Dict[str, Any] = {
         "job_id": job_id,
@@ -133,16 +125,15 @@ def reset_job(
     }
     if job_type is not None:
         data["job_type"] = job_type
-    _manager(cache_dir).replace_job(job_id, data)
+    _client(cache_dir).replace_job(job_id, data)
 
 
 def get_job(
     job_id: str,
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> Optional[Dict[str, Any]]:
-    """Get job data from cache, or None if not found."""
-    data = _manager(cache_dir).get_job(job_id)
-    return copy.deepcopy(data) if data else None
+    """Get job data, or None if not found."""
+    return _client(cache_dir).get_job(job_id)
 
 
 def delete_job(
@@ -150,7 +141,7 @@ def delete_job(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> bool:
     """Remove the job from the store. Returns True if removed, False if not found."""
-    return _manager(cache_dir).delete_job(job_id)
+    return _client(cache_dir).delete_job(job_id)
 
 
 def list_jobs(
@@ -158,22 +149,24 @@ def list_jobs(
     running_only: bool = False,
     job_type: Optional[str] = None,
 ) -> List[Dict[str, Any]]:
-    """List jobs from cache. If running_only is True, only include pending or running.
+    """List jobs. If running_only is True, only include pending or running.
     If job_type is set, only include jobs with that job_type."""
-    running_statuses = (JOB_STATUS_PENDING, JOB_STATUS_RUNNING)
+    running_statuses = [JOB_STATUS_PENDING, JOB_STATUS_RUNNING]
+    statuses = running_statuses if running_only else None
+    jobs = _client(cache_dir).list_jobs(statuses=statuses)
     result: List[Dict[str, Any]] = []
-    statuses = list(running_statuses) if running_only else None
-    jobs = _manager(cache_dir).list_jobs(statuses=statuses)
     for data in jobs:
         if job_type is not None and data.get("job_type") != job_type:
             continue
-        result.append({
-            "job_id": data.get("job_id", ""),
-            "status": data.get("status", JOB_STATUS_PENDING),
-            "repo_path": data.get("repo_path"),
-            "job_type": data.get("job_type"),
-            "created_at": data.get("created_at"),
-        })
+        result.append(
+            {
+                "job_id": data.get("job_id", ""),
+                "status": data.get("status", JOB_STATUS_PENDING),
+                "repo_path": data.get("repo_path"),
+                "job_type": data.get("job_type"),
+                "created_at": data.get("created_at"),
+            }
+        )
     return result
 
 
@@ -183,11 +176,7 @@ def mark_all_running_jobs_failed(
 ) -> None:
     """Mark all pending or running jobs as failed (e.g. on server shutdown)."""
     try:
-        jobs = list_jobs(cache_dir=cache_dir, running_only=True)
-        for job in jobs:
-            job_id = job.get("job_id")
-            if job_id:
-                update_job(job_id, status=JOB_STATUS_FAILED, error=reason, cache_dir=cache_dir)
+        _client(cache_dir).mark_all_active_jobs_failed(reason)
     except Exception as e:
         logger.warning("mark_all_running_jobs_failed: %s", e)
 
@@ -198,7 +187,7 @@ def mark_stale_jobs_failed(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> List[str]:
     """Mark stale pending/running jobs as failed unless they are waiting for answers."""
-    return _manager(cache_dir).mark_stale_active_jobs_failed(
+    return _client(cache_dir).mark_stale_active_jobs_failed(
         stale_after_seconds=stale_after_seconds,
         reason=reason,
     )
@@ -209,8 +198,8 @@ def update_job(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
     **kwargs: Any,
 ) -> None:
-    """Update job fields. Merges with existing data and persists to cache."""
-    _manager(cache_dir).update_job(job_id, **kwargs)
+    """Update job fields. Merges with existing data."""
+    _client(cache_dir).update_job(job_id, **kwargs)
 
 
 def start_job_heartbeat_thread(
@@ -232,10 +221,9 @@ def start_job_heartbeat_thread(
                     return
                 if data.get("status") not in active_statuses:
                     return
-                update_job(job_id, cache_dir=cache_dir)
+                _client(cache_dir).heartbeat(job_id)
             except Exception as exc:
                 logger.warning("Job heartbeat thread for %s: %s", job_id, exc)
-                # Continue loop so one failure does not kill the thread
 
     thread = threading.Thread(
         target=_heartbeat_loop,
@@ -252,11 +240,7 @@ def update_task_state(
     **kwargs: Any,
 ) -> None:
     """Update state for a single task. Merges kwargs into job["task_states"][task_id]."""
-    def merge(data: Dict[str, Any]) -> None:
-        task_states = data.setdefault("task_states", {})
-        existing = task_states.get(task_id, {})
-        task_states[task_id] = {**existing, **kwargs}
-    _manager(cache_dir).apply_to_job(job_id, merge)
+    _client(cache_dir).merge_nested(job_id, f"task_states.{task_id}", kwargs)
 
 
 def update_job_team_progress(
@@ -266,11 +250,7 @@ def update_job_team_progress(
     **kwargs: Any,
 ) -> None:
     """Update progress for a single team. Merges kwargs into job["team_progress"][team_id]."""
-    def merge(data: Dict[str, Any]) -> None:
-        team_progress = data.setdefault("team_progress", {})
-        existing = team_progress.get(team_id, {})
-        team_progress[team_id] = {**existing, **kwargs}
-    _manager(cache_dir).apply_to_job(job_id, merge)
+    _client(cache_dir).merge_nested(job_id, f"team_progress.{team_id}", kwargs)
 
 
 def add_task_result(
@@ -278,12 +258,8 @@ def add_task_result(
     result: Dict[str, Any],
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> None:
-    """Append a task result to the job and persist to cache."""
-    def append(data: Dict[str, Any]) -> None:
-        results = data.get("task_results", [])
-        results.append(result)
-        data["task_results"] = results
-    _manager(cache_dir).apply_to_job(job_id, append)
+    """Append a task result to the job."""
+    _client(cache_dir).append_to_list(job_id, "task_results", [result])
 
 
 def add_pending_questions(
@@ -292,12 +268,11 @@ def add_pending_questions(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> None:
     """Add pending questions and set waiting_for_answers=True to pause job."""
-    def add(data: Dict[str, Any]) -> None:
-        existing = data.get("pending_questions", [])
-        existing.extend(questions)
-        data["pending_questions"] = existing
-        data["waiting_for_answers"] = True
-    _manager(cache_dir).apply_to_job(job_id, add)
+    _client(cache_dir).atomic_update(
+        job_id,
+        merge_fields={"waiting_for_answers": True},
+        append_to={"pending_questions": questions},
+    )
 
 
 def submit_answers(
@@ -306,13 +281,11 @@ def submit_answers(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> None:
     """Store submitted answers, clear pending questions, and resume job."""
-    def apply(data: Dict[str, Any]) -> None:
-        existing_answers = data.get("submitted_answers", [])
-        existing_answers.extend(answers)
-        data["submitted_answers"] = existing_answers
-        data["pending_questions"] = []
-        data["waiting_for_answers"] = False
-    _manager(cache_dir).apply_to_job(job_id, apply)
+    _client(cache_dir).atomic_update(
+        job_id,
+        merge_fields={"pending_questions": [], "waiting_for_answers": False},
+        append_to={"submitted_answers": answers},
+    )
 
 
 def is_waiting_for_answers(
@@ -320,7 +293,7 @@ def is_waiting_for_answers(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> bool:
     """Check if job is waiting for user answers."""
-    data = _manager(cache_dir).get_job(job_id)
+    data = _client(cache_dir).get_job(job_id)
     return bool(data.get("waiting_for_answers", False)) if data else False
 
 
@@ -329,7 +302,7 @@ def get_submitted_answers(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> List[Dict[str, Any]]:
     """Get submitted answers for a job."""
-    data = _manager(cache_dir).get_job(job_id)
+    data = _client(cache_dir).get_job(job_id)
     return list(data.get("submitted_answers", [])) if data else []
 
 
@@ -343,19 +316,21 @@ def request_cancel(
     Returns False if the job was not found or is already in a terminal state.
     """
     terminal_statuses = (JOB_STATUS_COMPLETED, JOB_STATUS_FAILED, JOB_STATUS_CANCELLED)
-    data = _manager(cache_dir).get_job(job_id)
+    data = _client(cache_dir).get_job(job_id)
     if data is None:
         return False
     current_status = data.get("status", JOB_STATUS_PENDING)
     if current_status in terminal_statuses:
         return False
 
-    def set_cancelled(d: Dict[str, Any]) -> None:
-        d["cancel_requested"] = True
-        d["status"] = JOB_STATUS_CANCELLED
-        d["cancelled_at"] = datetime.now(timezone.utc).isoformat()
-
-    _manager(cache_dir).apply_to_job(job_id, set_cancelled)
+    _client(cache_dir).atomic_update(
+        job_id,
+        merge_fields={
+            "cancel_requested": True,
+            "status": JOB_STATUS_CANCELLED,
+            "cancelled_at": datetime.now(timezone.utc).isoformat(),
+        },
+    )
     logger.info("Job %s cancellation requested", job_id)
     return True
 
@@ -365,5 +340,5 @@ def is_cancel_requested(
     cache_dir: str | Path = DEFAULT_CACHE_DIR,
 ) -> bool:
     """Check if cancellation has been requested for a job."""
-    data = _manager(cache_dir).get_job(job_id)
+    data = _client(cache_dir).get_job(job_id)
     return bool(data.get("cancel_requested", False)) if data else False

--- a/backend/job_service/Dockerfile
+++ b/backend/job_service/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+ENV PYTHONUNBUFFERED=1
+EXPOSE 8085
+
+CMD ["python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8085"]

--- a/backend/job_service/db.py
+++ b/backend/job_service/db.py
@@ -282,8 +282,9 @@ def apply_patch(
     merge_fields: dict[str, Any] | None = None,
     merge_nested: dict[str, Any] | None = None,
     append_to: dict[str, list[Any]] | None = None,
+    increment: dict[str, int] | None = None,
 ) -> None:
-    """Atomic read-modify-write: merge fields, merge into nested dicts, append to lists."""
+    """Atomic read-modify-write: merge fields, merge into nested dicts, append to lists, increment counters."""
     with get_conn() as conn, conn.cursor() as cur:
         cur.execute(
             "SELECT data, status FROM jobs WHERE team = %s AND job_id = %s FOR UPDATE",
@@ -325,6 +326,14 @@ def apply_patch(
                     existing_list = []
                 existing_list.extend(items)
                 data[field] = existing_list
+
+        # 4. Increment integer fields
+        if increment:
+            for field, delta in increment.items():
+                current = data.get(field, 0)
+                if not isinstance(current, (int, float)):
+                    current = 0
+                data[field] = current + delta
 
         now = _now_iso()
         cur.execute(

--- a/backend/job_service/db.py
+++ b/backend/job_service/db.py
@@ -1,0 +1,453 @@
+"""Postgres persistence layer for the job service.
+
+Stores jobs in a single ``jobs`` table with a JSONB ``data`` column for
+team-specific fields.  Top-level columns (status, timestamps) are extracted
+for efficient indexing and querying.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections.abc import Generator
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Any
+
+import psycopg2
+import psycopg2.extras
+import psycopg2.pool
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Connection pool
+# ---------------------------------------------------------------------------
+
+_pool: psycopg2.pool.ThreadedConnectionPool | None = None
+
+
+def _dsn() -> str:
+    host = os.environ.get("POSTGRES_HOST", "localhost")
+    port = os.environ.get("POSTGRES_PORT", "5432")
+    user = os.environ.get("POSTGRES_USER", "strands")
+    password = os.environ.get("POSTGRES_PASSWORD", "strands")
+    dbname = os.environ.get("POSTGRES_DB", "strands_jobs")
+    return f"host={host} port={port} dbname={dbname} user={user} password={password}"
+
+
+def get_pool() -> psycopg2.pool.ThreadedConnectionPool:
+    global _pool
+    if _pool is None or _pool.closed:
+        _pool = psycopg2.pool.ThreadedConnectionPool(minconn=2, maxconn=20, dsn=_dsn())
+    return _pool
+
+
+@contextmanager
+def get_conn() -> Generator:
+    pool = get_pool()
+    conn = pool.getconn()
+    try:
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        pool.putconn(conn)
+
+
+def ensure_schema() -> None:
+    """Create the jobs table and indexes if they do not already exist."""
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute("""
+                CREATE TABLE IF NOT EXISTS jobs (
+                    job_id            TEXT NOT NULL,
+                    team              TEXT NOT NULL,
+                    status            TEXT NOT NULL DEFAULT 'pending',
+                    data              JSONB NOT NULL DEFAULT '{}',
+                    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    last_heartbeat_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                    PRIMARY KEY (team, job_id)
+                )
+            """)
+        cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_jobs_team_status
+                ON jobs (team, status)
+            """)
+        cur.execute("""
+                CREATE INDEX IF NOT EXISTS idx_jobs_heartbeat
+                ON jobs (team, last_heartbeat_at)
+                WHERE status IN ('pending', 'running')
+            """)
+    logger.info("Job service schema ensured")
+
+
+def close_pool() -> None:
+    global _pool
+    if _pool and not _pool.closed:
+        _pool.closeall()
+        _pool = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _now_iso() -> str:
+    return _now().isoformat()
+
+
+def _row_to_dict(row: tuple, cur) -> dict[str, Any]:
+    """Convert a DB row to a merged dict (top-level columns + JSONB data)."""
+    col_names = [desc[0] for desc in cur.description]
+    row_dict = dict(zip(col_names, row, strict=False))
+    data = row_dict.pop("data", {}) or {}
+    if isinstance(data, str):
+        data = json.loads(data)
+    result = {**data}
+    result["job_id"] = row_dict["job_id"]
+    result["team"] = row_dict["team"]
+    result["status"] = row_dict["status"]
+    result["created_at"] = row_dict["created_at"].isoformat() if row_dict.get("created_at") else None
+    result["updated_at"] = row_dict["updated_at"].isoformat() if row_dict.get("updated_at") else None
+    result["last_heartbeat_at"] = (
+        row_dict["last_heartbeat_at"].isoformat() if row_dict.get("last_heartbeat_at") else None
+    )
+    return result
+
+
+# ---------------------------------------------------------------------------
+# CRUD operations
+# ---------------------------------------------------------------------------
+
+
+def create_job(team: str, job_id: str, status: str = "pending", **fields: Any) -> None:
+    now = _now()
+    # Extract top-level columns from fields if present, otherwise use defaults
+    created_at = fields.pop("created_at", now.isoformat())
+    updated_at = fields.pop("updated_at", now.isoformat())
+    last_heartbeat_at = fields.pop("last_heartbeat_at", now.isoformat())
+    # Remove duplicates from data payload
+    fields.pop("job_id", None)
+    fields.pop("team", None)
+    fields.pop("status", None)
+
+    data_json = json.dumps(fields)
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+                INSERT INTO jobs (job_id, team, status, data, created_at, updated_at, last_heartbeat_at)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (team, job_id) DO UPDATE SET
+                    status = EXCLUDED.status,
+                    data = EXCLUDED.data,
+                    updated_at = EXCLUDED.updated_at,
+                    last_heartbeat_at = EXCLUDED.last_heartbeat_at
+                """,
+            (job_id, team, status, data_json, created_at, updated_at, last_heartbeat_at),
+        )
+
+
+def replace_job(team: str, job_id: str, payload: dict[str, Any]) -> None:
+    status = payload.get("status", "pending")
+    created_at = payload.get("created_at", _now_iso())
+    updated_at = payload.get("updated_at", _now_iso())
+    last_heartbeat_at = payload.get("last_heartbeat_at", _now_iso())
+    # Build data without top-level columns
+    data = {
+        k: v
+        for k, v in payload.items()
+        if k not in ("job_id", "team", "status", "created_at", "updated_at", "last_heartbeat_at")
+    }
+    data_json = json.dumps(data)
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+                INSERT INTO jobs (job_id, team, status, data, created_at, updated_at, last_heartbeat_at)
+                VALUES (%s, %s, %s, %s, %s, %s, %s)
+                ON CONFLICT (team, job_id) DO UPDATE SET
+                    status = EXCLUDED.status,
+                    data = EXCLUDED.data,
+                    created_at = EXCLUDED.created_at,
+                    updated_at = EXCLUDED.updated_at,
+                    last_heartbeat_at = EXCLUDED.last_heartbeat_at
+                """,
+            (job_id, team, status, data_json, created_at, updated_at, last_heartbeat_at),
+        )
+
+
+def get_job(team: str, job_id: str) -> dict[str, Any] | None:
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute("SELECT * FROM jobs WHERE team = %s AND job_id = %s", (team, job_id))
+        row = cur.fetchone()
+        if row is None:
+            return None
+        return _row_to_dict(row, cur)
+
+
+def delete_job(team: str, job_id: str) -> bool:
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute("DELETE FROM jobs WHERE team = %s AND job_id = %s", (team, job_id))
+        return cur.rowcount > 0
+
+
+def list_jobs(team: str, statuses: list[str] | None = None) -> list[dict[str, Any]]:
+    with get_conn() as conn, conn.cursor() as cur:
+        if statuses:
+            cur.execute(
+                "SELECT * FROM jobs WHERE team = %s AND status = ANY(%s) ORDER BY created_at DESC",
+                (team, statuses),
+            )
+        else:
+            cur.execute(
+                "SELECT * FROM jobs WHERE team = %s ORDER BY created_at DESC",
+                (team,),
+            )
+        rows = cur.fetchall()
+        return [_row_to_dict(row, cur) for row in rows]
+
+
+def update_job(team: str, job_id: str, heartbeat: bool = True, **fields: Any) -> None:
+    now = _now_iso()
+    # If status is being updated, update the top-level column too
+    new_status = fields.pop("status", None)
+    # Remove other top-level columns from fields if present
+    fields.pop("job_id", None)
+    fields.pop("team", None)
+    fields.pop("created_at", None)
+    fields.pop("updated_at", None)
+    fields.pop("last_heartbeat_at", None)
+
+    with get_conn() as conn, conn.cursor() as cur:
+        if new_status is not None:
+            if heartbeat:
+                cur.execute(
+                    """
+                        UPDATE jobs
+                        SET data = data || %s::jsonb,
+                            status = %s,
+                            updated_at = %s,
+                            last_heartbeat_at = %s
+                        WHERE team = %s AND job_id = %s
+                        """,
+                    (json.dumps(fields), new_status, now, now, team, job_id),
+                )
+            else:
+                cur.execute(
+                    """
+                        UPDATE jobs
+                        SET data = data || %s::jsonb,
+                            status = %s,
+                            updated_at = %s
+                        WHERE team = %s AND job_id = %s
+                        """,
+                    (json.dumps(fields), new_status, now, team, job_id),
+                )
+        else:
+            if heartbeat:
+                cur.execute(
+                    """
+                        UPDATE jobs
+                        SET data = data || %s::jsonb,
+                            updated_at = %s,
+                            last_heartbeat_at = %s
+                        WHERE team = %s AND job_id = %s
+                        """,
+                    (json.dumps(fields), now, now, team, job_id),
+                )
+            else:
+                cur.execute(
+                    """
+                        UPDATE jobs
+                        SET data = data || %s::jsonb,
+                            updated_at = %s
+                        WHERE team = %s AND job_id = %s
+                        """,
+                    (json.dumps(fields), now, team, job_id),
+                )
+
+
+def apply_patch(
+    team: str,
+    job_id: str,
+    *,
+    merge_fields: dict[str, Any] | None = None,
+    merge_nested: dict[str, Any] | None = None,
+    append_to: dict[str, list[Any]] | None = None,
+) -> None:
+    """Atomic read-modify-write: merge fields, merge into nested dicts, append to lists."""
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "SELECT data, status FROM jobs WHERE team = %s AND job_id = %s FOR UPDATE",
+            (team, job_id),
+        )
+        row = cur.fetchone()
+        if row is None:
+            return
+        data = row[0] if isinstance(row[0], dict) else json.loads(row[0])
+        current_status = row[1]
+        new_status = current_status
+
+        # 1. Merge top-level fields
+        if merge_fields:
+            if "status" in merge_fields:
+                new_status = merge_fields.pop("status")
+            data.update(merge_fields)
+
+        # 2. Merge into nested dicts (e.g., "task_states.task_1" -> {"status": "done"})
+        if merge_nested:
+            for dotted_path, value in merge_nested.items():
+                parts = dotted_path.split(".")
+                target = data
+                for part in parts[:-1]:
+                    target = target.setdefault(part, {})
+                leaf = parts[-1]
+                existing = target.get(leaf, {})
+                if isinstance(existing, dict) and isinstance(value, dict):
+                    existing.update(value)
+                    target[leaf] = existing
+                else:
+                    target[leaf] = value
+
+        # 3. Append to lists
+        if append_to:
+            for field, items in append_to.items():
+                existing_list = data.get(field, [])
+                if not isinstance(existing_list, list):
+                    existing_list = []
+                existing_list.extend(items)
+                data[field] = existing_list
+
+        now = _now_iso()
+        cur.execute(
+            """
+                UPDATE jobs
+                SET data = %s, status = %s, updated_at = %s, last_heartbeat_at = %s
+                WHERE team = %s AND job_id = %s
+                """,
+            (json.dumps(data), new_status, now, now, team, job_id),
+        )
+
+
+def append_event(
+    team: str,
+    job_id: str,
+    *,
+    action: str,
+    outcome: str | None = None,
+    details: dict[str, Any] | None = None,
+    status: str | None = None,
+) -> None:
+    """Append an event to the job's events list and optionally update status."""
+    now = _now_iso()
+    event = {"timestamp": now, "action": action, "outcome": outcome, "details": details or {}}
+
+    with get_conn() as conn, conn.cursor() as cur:
+        if status is not None:
+            cur.execute(
+                """
+                    UPDATE jobs
+                    SET data = jsonb_set(
+                            data,
+                            '{events}',
+                            COALESCE(data->'events', '[]'::jsonb) || %s::jsonb
+                        ),
+                        status = %s,
+                        updated_at = %s,
+                        last_heartbeat_at = %s
+                    WHERE team = %s AND job_id = %s
+                    """,
+                (json.dumps([event]), status, now, now, team, job_id),
+            )
+        else:
+            cur.execute(
+                """
+                    UPDATE jobs
+                    SET data = jsonb_set(
+                            data,
+                            '{events}',
+                            COALESCE(data->'events', '[]'::jsonb) || %s::jsonb
+                        ),
+                        updated_at = %s,
+                        last_heartbeat_at = %s
+                    WHERE team = %s AND job_id = %s
+                    """,
+                (json.dumps([event]), now, now, team, job_id),
+            )
+
+
+def heartbeat(team: str, job_id: str) -> bool:
+    """Touch last_heartbeat_at and updated_at for a job. Returns True if the job exists."""
+    now = _now_iso()
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "UPDATE jobs SET last_heartbeat_at = %s, updated_at = %s WHERE team = %s AND job_id = %s",
+            (now, now, team, job_id),
+        )
+        return cur.rowcount > 0
+
+
+def mark_stale_active_jobs_failed(
+    team: str,
+    *,
+    stale_after_seconds: float,
+    reason: str,
+    waiting_field: str = "waiting_for_answers",
+) -> list[str]:
+    """Mark pending/running jobs with no recent heartbeat as failed.
+
+    Excludes jobs where data->>waiting_field is 'true'.
+    """
+    now = _now()
+    failed_ids: list[str] = []
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+                UPDATE jobs
+                SET status = 'failed',
+                    data = data || %s::jsonb,
+                    updated_at = %s
+                WHERE team = %s
+                  AND status IN ('pending', 'running')
+                  AND COALESCE((data->>%s)::boolean, false) = false
+                  AND last_heartbeat_at < %s
+                RETURNING job_id
+                """,
+            (
+                json.dumps({"error": reason}),
+                now.isoformat(),
+                team,
+                waiting_field,
+                (now - __import__("datetime").timedelta(seconds=stale_after_seconds)).isoformat(),
+            ),
+        )
+        failed_ids = [row[0] for row in cur.fetchall()]
+    if failed_ids:
+        logger.warning("Marked stale jobs failed for team %s: %s", team, failed_ids)
+    return failed_ids
+
+
+def mark_all_active_jobs_failed(team: str, reason: str) -> list[str]:
+    """Mark all pending/running jobs as failed (e.g. on shutdown)."""
+    now = _now_iso()
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+                UPDATE jobs
+                SET status = 'failed',
+                    data = data || %s::jsonb,
+                    updated_at = %s
+                WHERE team = %s AND status IN ('pending', 'running')
+                RETURNING job_id
+                """,
+            (json.dumps({"error": reason}), now, team),
+        )
+        return [row[0] for row in cur.fetchall()]

--- a/backend/job_service/main.py
+++ b/backend/job_service/main.py
@@ -142,6 +142,7 @@ def apply_patch(team: str, job_id: str, req: ApplyPatchRequest):
         merge_fields=req.merge_fields,
         merge_nested=req.merge_nested,
         append_to=req.append_to,
+        increment=req.increment,
     )
     return JobResponse(job=db_get_job(team, job_id))
 

--- a/backend/job_service/main.py
+++ b/backend/job_service/main.py
@@ -1,0 +1,189 @@
+"""Job Service — a standalone FastAPI microservice for centralized job management.
+
+Persists job data in a dedicated Postgres database (``strands_jobs``).  All
+agent teams interact with this service over HTTP via the ``JobServiceClient``.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+
+from db import (
+    append_event as db_append_event,
+)
+from db import (
+    apply_patch as db_apply_patch,
+)
+from db import (
+    close_pool,
+    ensure_schema,
+)
+from db import (
+    create_job as db_create_job,
+)
+from db import (
+    delete_job as db_delete_job,
+)
+from db import (
+    get_job as db_get_job,
+)
+from db import (
+    heartbeat as db_heartbeat,
+)
+from db import (
+    list_jobs as db_list_jobs,
+)
+from db import (
+    mark_all_active_jobs_failed as db_mark_all_active_jobs_failed,
+)
+from db import (
+    mark_stale_active_jobs_failed as db_mark_stale_active_jobs_failed,
+)
+from db import (
+    replace_job as db_replace_job,
+)
+from db import (
+    update_job as db_update_job,
+)
+from fastapi import FastAPI, HTTPException, Query
+from models import (
+    AppendEventRequest,
+    ApplyPatchRequest,
+    CreateJobRequest,
+    DeleteResponse,
+    HealthResponse,
+    JobListResponse,
+    JobResponse,
+    MarkAllFailedRequest,
+    MarkStaleRequest,
+    MarkStaleResponse,
+    ReplaceJobRequest,
+    UpdateJobRequest,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+logger = logging.getLogger("job_service")
+
+
+@asynccontextmanager
+async def lifespan(application: FastAPI):
+    ensure_schema()
+    logger.info("Job service started")
+    yield
+    close_pool()
+    logger.info("Job service stopped")
+
+
+app = FastAPI(title="Strands Job Service", version="1.0.0", lifespan=lifespan)
+
+
+# ---------------------------------------------------------------------------
+# Health
+# ---------------------------------------------------------------------------
+
+
+@app.get("/health", response_model=HealthResponse)
+def health():
+    return HealthResponse(status="ok")
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+
+@app.post("/jobs/{team}", response_model=JobResponse)
+def create_job(team: str, req: CreateJobRequest):
+    db_create_job(team, req.job_id, status=req.status, **req.fields)
+    return JobResponse(job=db_get_job(team, req.job_id))
+
+
+@app.post("/jobs/{team}/{job_id}/replace", response_model=JobResponse)
+def replace_job(team: str, job_id: str, req: ReplaceJobRequest):
+    db_replace_job(team, job_id, req.payload)
+    return JobResponse(job=db_get_job(team, job_id))
+
+
+@app.get("/jobs/{team}/{job_id}", response_model=JobResponse)
+def get_job(team: str, job_id: str):
+    job = db_get_job(team, job_id)
+    return JobResponse(job=job)
+
+
+@app.delete("/jobs/{team}/{job_id}", response_model=DeleteResponse)
+def delete_job(team: str, job_id: str):
+    deleted = db_delete_job(team, job_id)
+    return DeleteResponse(deleted=deleted)
+
+
+@app.get("/jobs/{team}", response_model=JobListResponse)
+def list_jobs(team: str, statuses: list[str] | None = Query(default=None)):  # noqa: B008
+    jobs = db_list_jobs(team, statuses=statuses)
+    return JobListResponse(jobs=jobs)
+
+
+@app.patch("/jobs/{team}/{job_id}", response_model=JobResponse)
+def update_job(team: str, job_id: str, req: UpdateJobRequest):
+    db_update_job(team, job_id, heartbeat=req.heartbeat, **req.fields)
+    return JobResponse(job=db_get_job(team, job_id))
+
+
+# ---------------------------------------------------------------------------
+# Atomic operations
+# ---------------------------------------------------------------------------
+
+
+@app.post("/jobs/{team}/{job_id}/apply", response_model=JobResponse)
+def apply_patch(team: str, job_id: str, req: ApplyPatchRequest):
+    db_apply_patch(
+        team,
+        job_id,
+        merge_fields=req.merge_fields,
+        merge_nested=req.merge_nested,
+        append_to=req.append_to,
+    )
+    return JobResponse(job=db_get_job(team, job_id))
+
+
+@app.post("/jobs/{team}/{job_id}/event", response_model=JobResponse)
+def append_event(team: str, job_id: str, req: AppendEventRequest):
+    db_append_event(
+        team,
+        job_id,
+        action=req.action,
+        outcome=req.outcome,
+        details=req.details,
+        status=req.status,
+    )
+    return JobResponse(job=db_get_job(team, job_id))
+
+
+@app.post("/jobs/{team}/{job_id}/heartbeat")
+def heartbeat(team: str, job_id: str):
+    found = db_heartbeat(team, job_id)
+    if not found:
+        raise HTTPException(status_code=404, detail=f"Job {job_id} not found for team {team}")
+    return {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# Bulk / lifecycle
+# ---------------------------------------------------------------------------
+
+
+@app.post("/jobs/{team}/mark-stale-failed", response_model=MarkStaleResponse)
+def mark_stale_failed(team: str, req: MarkStaleRequest):
+    failed_ids = db_mark_stale_active_jobs_failed(
+        team,
+        stale_after_seconds=req.stale_after_seconds,
+        reason=req.reason,
+        waiting_field=req.waiting_field,
+    )
+    return MarkStaleResponse(failed_job_ids=failed_ids)
+
+
+@app.post("/jobs/{team}/mark-all-running-failed", response_model=MarkStaleResponse)
+def mark_all_running_failed(team: str, req: MarkAllFailedRequest):
+    failed_ids = db_mark_all_active_jobs_failed(team, req.reason)
+    return MarkStaleResponse(failed_job_ids=failed_ids)

--- a/backend/job_service/models.py
+++ b/backend/job_service/models.py
@@ -26,6 +26,7 @@ class ApplyPatchRequest(BaseModel):
     merge_fields: dict[str, Any] | None = None
     merge_nested: dict[str, Any] | None = None
     append_to: dict[str, list[Any]] | None = None
+    increment: dict[str, int] | None = None
 
 
 class AppendEventRequest(BaseModel):

--- a/backend/job_service/models.py
+++ b/backend/job_service/models.py
@@ -1,0 +1,70 @@
+"""Pydantic request/response models for the job service API."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel
+
+
+class CreateJobRequest(BaseModel):
+    job_id: str
+    status: str = "pending"
+    fields: dict[str, Any] = {}
+
+
+class ReplaceJobRequest(BaseModel):
+    payload: dict[str, Any]
+
+
+class UpdateJobRequest(BaseModel):
+    heartbeat: bool = True
+    fields: dict[str, Any] = {}
+
+
+class ApplyPatchRequest(BaseModel):
+    merge_fields: dict[str, Any] | None = None
+    merge_nested: dict[str, Any] | None = None
+    append_to: dict[str, list[Any]] | None = None
+
+
+class AppendEventRequest(BaseModel):
+    action: str
+    outcome: str | None = None
+    details: dict[str, Any] | None = None
+    status: str | None = None
+
+
+class MarkStaleRequest(BaseModel):
+    stale_after_seconds: float
+    reason: str
+    waiting_field: str = "waiting_for_answers"
+
+
+class MarkAllFailedRequest(BaseModel):
+    reason: str
+
+
+class JobResponse(BaseModel):
+    """Single job data returned from get/create endpoints."""
+
+    job: dict[str, Any] | None = None
+
+
+class JobListResponse(BaseModel):
+    """List of jobs returned from list endpoint."""
+
+    jobs: list[dict[str, Any]]
+
+
+class DeleteResponse(BaseModel):
+    deleted: bool
+
+
+class MarkStaleResponse(BaseModel):
+    failed_job_ids: list[str]
+
+
+class HealthResponse(BaseModel):
+    status: str
+    service: str = "job-service"

--- a/backend/job_service/requirements.txt
+++ b/backend/job_service/requirements.txt
@@ -1,0 +1,4 @@
+fastapi>=0.110.0,<1.0
+uvicorn>=0.29.0,<1.0
+pydantic>=2.0,<3.0
+psycopg2-binary>=2.9,<3.0

--- a/backend/unified_api/main.py
+++ b/backend/unified_api/main.py
@@ -98,33 +98,37 @@ class SecurityErrorResponse(BaseModel):
 # Track mounted routers for health checks
 _mounted_teams: dict[str, bool] = {}
 
-# Team keys that have async jobs: on shutdown, call their mark_all_running_jobs_failed(reason).
-# Maps team_key -> (module_dot_path, function_name).
-SHUTDOWN_HOOKS: dict[str, tuple] = {
-    "blogging": ("blogging.shared.blog_job_store", "mark_all_running_jobs_failed"),
-    "software_engineering": ("software_engineering_team.shared.job_store", "mark_all_running_jobs_failed"),
-    "personal_assistant": ("personal_assistant_team.shared.pa_job_store", "mark_all_running_jobs_failed"),
-    "agent_provisioning": ("agent_provisioning_team.shared.job_store", "mark_all_running_jobs_failed"),
-    "ai_systems": ("ai_systems_team.shared.job_store", "mark_all_running_jobs_failed"),
-    "soc2_compliance": ("soc2_compliance_team.api.main", "mark_all_running_jobs_failed"),
-    "social_marketing": ("social_media_marketing_team.api.main", "mark_all_running_jobs_failed"),
-    "accessibility_audit": ("accessibility_audit_team.api.main", "mark_all_running_jobs_failed"),
-    "nutrition_meal_planning": ("nutrition_meal_planning_team.shared.job_store", "mark_all_running_jobs_failed"),
-    "planning_v3": ("planning_v3_team.shared.job_store", "mark_all_running_jobs_failed"),
-    "sales_team": ("sales_team.api.main", "mark_all_running_jobs_failed"),
-    "road_trip_planning": ("road_trip_planning_team.shared.job_store", "mark_all_running_jobs_failed"),
+# Team keys that have async jobs: on shutdown, mark all running jobs as failed via the job service.
+# Maps team_key -> team name used in the job service.
+SHUTDOWN_HOOKS: dict[str, str] = {
+    "blogging": "blogging_team",
+    "software_engineering": "software_engineering_team",
+    "personal_assistant": "personal_assistant_team",
+    "agent_provisioning": "agent_provisioning_team",
+    "ai_systems": "ai_systems_team",
+    "soc2_compliance": "soc2_compliance_team",
+    "social_marketing": "social_media_marketing_team",
+    "accessibility_audit": "accessibility_audit_team",
+    "nutrition_meal_planning": "nutrition_meal_planning_team",
+    "planning_v3": "planning_v3_team",
+    "sales_team": "sales_team",
+    "road_trip_planning": "road_trip_planning_team",
 }
 
 
 def _run_shutdown_hooks(reason: str) -> None:
-    """Call each mounted team's mark_all_running_jobs_failed(reason). Used by lifespan and atexit."""
-    for team_key, (module_path, func_name) in SHUTDOWN_HOOKS.items():
+    """Mark all running jobs as failed for each mounted team via the job service. Used by lifespan and atexit."""
+    try:
+        from job_service_client import JobServiceClient
+    except ImportError:
+        logger.warning("job_service_client not available; skipping shutdown hooks")
+        return
+    for team_key, team_name in SHUTDOWN_HOOKS.items():
         if not _mounted_teams.get(team_key):
             continue
         try:
-            mod = importlib.import_module(module_path)
-            fn = getattr(mod, func_name)
-            fn(reason)
+            client = JobServiceClient(team=team_name)
+            client.mark_all_active_jobs_failed(reason)
         except Exception as e:
             logger.warning("Shutdown hook for team %s failed: %s", team_key, e)
 
@@ -434,10 +438,19 @@ async def lifespan(app: FastAPI):
         "personal_assistant": ("personal_assistant_team.temporal.worker", "start_pa_temporal_worker_thread"),
         "ai_systems": ("ai_systems_team.temporal.worker", "start_ai_systems_temporal_worker_thread"),
         "planning_v3": ("planning_v3_team.temporal.worker", "start_planning_v3_temporal_worker_thread"),
-        "agent_provisioning": ("agent_provisioning_team.temporal.worker", "start_agent_provisioning_temporal_worker_thread"),
-        "nutrition_meal_planning": ("nutrition_meal_planning_team.temporal.worker", "start_nutrition_temporal_worker_thread"),
+        "agent_provisioning": (
+            "agent_provisioning_team.temporal.worker",
+            "start_agent_provisioning_temporal_worker_thread",
+        ),
+        "nutrition_meal_planning": (
+            "nutrition_meal_planning_team.temporal.worker",
+            "start_nutrition_temporal_worker_thread",
+        ),
         "soc2_compliance": ("soc2_compliance_team.temporal.worker", "start_soc2_temporal_worker_thread"),
-        "social_marketing": ("social_media_marketing_team.temporal.worker", "start_social_marketing_temporal_worker_thread"),
+        "social_marketing": (
+            "social_media_marketing_team.temporal.worker",
+            "start_social_marketing_temporal_worker_thread",
+        ),
     }
     for team_key, (mod_path, func_name) in _temporal_worker_starters.items():
         if not _mounted_teams.get(team_key):

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -44,6 +44,12 @@ TEMPORAL_ADDRESS=temporal:7233
 # TEMPORAL_TASK_QUEUE=software-engineering
 
 # ---------------------------------------------------------------------------
+# Job Service (centralized job management)
+# ---------------------------------------------------------------------------
+# URL for the job service container. Teams use this to persist job state.
+JOB_SERVICE_URL=http://job-service:8085
+
+# ---------------------------------------------------------------------------
 # Logs API (testing only)
 # ---------------------------------------------------------------------------
 # Set to 1 to enable GET /api/software-engineering/logs (returns supervisor log content)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -66,6 +66,38 @@ services:
       stack:
         ipv4_address: 172.28.0.4
 
+  job-service:
+    build:
+      context: ../backend/job_service
+      dockerfile: Dockerfile
+    image: strands-job-service
+    container_name: strands-job-service
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      POSTGRES_HOST: postgres
+      POSTGRES_PORT: "5432"
+      POSTGRES_USER: strands
+      POSTGRES_PASSWORD: strands
+      POSTGRES_DB: strands_jobs
+      PYTHONUNBUFFERED: "1"
+    extra_hosts:
+      - "postgres:172.28.0.2"
+    ports:
+      - "8585:8085"
+    networks:
+      stack:
+        ipv4_address: 172.28.0.5
+        aliases:
+          - job-service
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8085/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
   strands-agents:
     build:
       context: ../backend
@@ -77,6 +109,8 @@ services:
         condition: service_healthy
       temporal:
         condition: service_started
+      job-service:
+        condition: service_healthy
     volumes:
       - agents_workspace:/workspace
     ports:
@@ -104,9 +138,11 @@ services:
       POSTGRES_DB: ${POSTGRES_DB:-postgres}
       ENABLE_LOG_API: ${ENABLE_LOG_API:-0}
       TEMPORAL_ADDRESS: temporal:7233
+      JOB_SERVICE_URL: http://job-service:8085
     extra_hosts:
       - "postgres:172.28.0.2"
       - "temporal:172.28.0.3"
+      - "job-service:172.28.0.5"
     networks:
       stack:
         ipv4_address: 172.28.0.6

--- a/docker/postgres/init/01-create-databases.sh
+++ b/docker/postgres/init/01-create-databases.sh
@@ -10,4 +10,5 @@ psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-E
 
   CREATE USER strands WITH PASSWORD 'strands';
   CREATE DATABASE strands OWNER strands;
+  CREATE DATABASE strands_jobs OWNER strands;
 EOSQL

--- a/docker/postgres/init/03-create-jobs-table.sql
+++ b/docker/postgres/init/03-create-jobs-table.sql
@@ -1,0 +1,19 @@
+-- Job service schema: runs against strands_jobs database.
+-- This file is executed by the Postgres entrypoint on first init.
+
+\connect strands_jobs;
+
+CREATE TABLE IF NOT EXISTS jobs (
+    job_id            TEXT NOT NULL,
+    team              TEXT NOT NULL,
+    status            TEXT NOT NULL DEFAULT 'pending',
+    data              JSONB NOT NULL DEFAULT '{}',
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_heartbeat_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (team, job_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_jobs_team_status ON jobs (team, status);
+CREATE INDEX IF NOT EXISTS idx_jobs_heartbeat ON jobs (team, last_heartbeat_at)
+    WHERE status IN ('pending', 'running');


### PR DESCRIPTION
## Summary

Introduces a new **Job Service** — a standalone FastAPI microservice for centralized job management across all agent teams. This replaces direct file-based job storage with a Postgres-backed service that all teams communicate with via HTTP, enabling better scalability, consistency, and monitoring.

## Key Changes

### New Job Service Infrastructure
- **`backend/job_service/main.py`**: FastAPI microservice with REST endpoints for job CRUD, atomic operations, and stale job detection
- **`backend/job_service/db.py`**: Postgres persistence layer using a single `jobs` table with JSONB `data` column for team-specific fields; top-level columns (status, timestamps) extracted for efficient indexing
- **`backend/job_service/models.py`**: Pydantic request/response models for all API endpoints
- **`backend/job_service/Dockerfile`** & **`requirements.txt`**: Container configuration for the service

### HTTP Client for Agent Teams
- **`backend/agents/job_service_client.py`**: Drop-in replacement for `CentralJobManager` that communicates with the job service over HTTP when `JOB_SERVICE_URL` is set; falls back to local `CentralJobManager` for non-Docker development
- Supports all core operations: create, get, update, delete, list jobs
- Atomic patch operations: `merge_nested()`, `append_to_list()`, `atomic_update()` for safe concurrent modifications
- Built-in retry logic with exponential backoff for transient network errors
- Exports status constants (`JOB_STATUS_PENDING`, etc.) for backward compatibility

### Team Integration
Updated all agent team job stores to use `JobServiceClient` instead of `CentralJobManager`:
- `blogging/shared/blog_job_store.py`
- `software_engineering_team/shared/job_store.py`
- `personal_assistant_team/shared/pa_job_store.py`
- `planning_v3_team/shared/job_store.py`
- `agent_provisioning_team/shared/job_store.py`
- `ai_systems_team/shared/job_store.py`
- `nutrition_meal_planning_team/shared/job_store.py`
- `road_trip_planning_team/shared/job_store.py`
- `coding_team/job_store.py`
- `soc2_compliance_team/api/main.py`
- `social_media_marketing_team/api/main.py`
- `accessibility_audit_team/api/main.py`
- `sales_team/api/main.py`

### Docker & Database
- **`docker/docker-compose.yml`**: Added `job-service` container with Postgres dependency, health checks, and networking
- **`docker/postgres/init/03-create-jobs-table.sql`**: SQL schema initialization for the jobs table and indexes
- **`docker/postgres/init/01-create-databases.sh`**: Creates `strands_jobs` database for the service
- **`docker/.env.example`**: Added `JOB_SERVICE_URL` configuration example

## Notable Implementation Details

- **Hybrid mode**: Client automatically detects `JOB_SERVICE_URL` environment variable; when unset, uses local fallback for backward compatibility with `make run` and `pytest`
- **JSONB storage**: Team-specific fields stored in JSONB column; top-level columns (job_id, team, status, timestamps) indexed for efficient queries
- **Atomic operations**: `apply_patch()` uses `FOR UPDATE` locking for safe concurrent read-modify-write operations
- **Heartbeat tracking**: `last_heartbeat_at` column with partial index on active jobs for stale job detection
- **Connection pooling**: Threaded connection pool (2–20 connections) for efficient Postgres access
- **Stale job detection**: Service-side `mark_stale_active_jobs_failed()` and `mark_all_active_jobs_failed()` for automatic failure of hung jobs

https://claude.ai/code/session_01MvmhV7Gf7bxG4xMFdKJkvA