### PR TITLE
fix(blogging): fix post-editor-approval gate errors in rewrite loop

### DIFF
--- a/backend/agents/blogging/agent_implementations/blog_writing_process_v2.py
+++ b/backend/agents/blogging/agent_implementations/blog_writing_process_v2.py
@@ -734,32 +734,93 @@ def run_pipeline(
                 rewrite_iterations=rewrite_iter + 1,
             )
             
-            feedback_items = [
-                FeedbackItem(
-                    category="compliance",
-                    severity="must_fix",
-                    location=None,
-                    issue=fix,
-                    suggestion=fix,
+            # --- Build feedback from ALL gates ---
+            feedback_items: list[FeedbackItem] = []
+
+            # 1. Validator failed checks
+            if validator_report.status == "FAIL":
+                for check in validator_report.checks:
+                    if check.status == "FAIL":
+                        details_str = ""
+                        if check.details:
+                            if "matches" in check.details:
+                                details_str = f" Found: {', '.join(str(m) for m in check.details['matches'][:3])}"
+                            elif "violations" in check.details:
+                                details_str = f" Violations: {', '.join(str(v) for v in check.details['violations'][:3])}"
+                            elif "fk_grade" in check.details:
+                                details_str = f" FK grade: {check.details['fk_grade']}"
+                        feedback_items.append(
+                            FeedbackItem(
+                                category="validator",
+                                severity="must_fix",
+                                location=None,
+                                issue=f"Validator check '{check.name}' failed.{details_str}",
+                                suggestion=f"Fix the '{check.name}' violation identified by the deterministic validator.",
+                            )
+                        )
+
+            # 2. Fact-check failures
+            if fact_report.claims_status == "FAIL" or fact_report.risk_status == "FAIL":
+                for flag in fact_report.risk_flags:
+                    feedback_items.append(
+                        FeedbackItem(
+                            category="fact_check",
+                            severity="must_fix",
+                            location=None,
+                            issue=f"Risk flag: {flag}",
+                            suggestion=f"Address risk flag: {flag}",
+                        )
+                    )
+                for disclaimer in fact_report.required_disclaimers:
+                    feedback_items.append(
+                        FeedbackItem(
+                            category="fact_check",
+                            severity="must_fix",
+                            location=None,
+                            issue=f"Missing required disclaimer: {disclaimer}",
+                            suggestion=f"Add disclaimer: {disclaimer}",
+                        )
+                    )
+
+            # 3. Compliance fixes
+            for fix in compliance_report.required_fixes:
+                feedback_items.append(
+                    FeedbackItem(
+                        category="compliance",
+                        severity="must_fix",
+                        location=None,
+                        issue=fix,
+                        suggestion=fix,
+                    )
                 )
-                for fix in compliance_report.required_fixes
-            ]
+
             if not feedback_items:
                 feedback_items = [
                     FeedbackItem(
                         category="compliance",
                         severity="must_fix",
                         location=None,
-                        issue="Validator or compliance check failed; see validator_report.json and compliance_report.json",
-                        suggestion="Address all violations and re-run.",
+                        issue="Validator, fact-check, or compliance check failed; see reports for details.",
+                        suggestion="Address all violations from validator_report.json, fact_check_report.json, and compliance_report.json.",
                     )
                 ]
-            
+
+            # Build a summary reflecting all gate failures
+            gate_failures = []
+            if validator_report.status == "FAIL":
+                failed_checks = [c.name for c in validator_report.checks if c.status == "FAIL"]
+                gate_failures.append(f"Validator FAIL ({', '.join(failed_checks)})")
+            if fact_report.claims_status == "FAIL" or fact_report.risk_status == "FAIL":
+                gate_failures.append(f"Fact-check FAIL (claims={fact_report.claims_status}, risk={fact_report.risk_status})")
+            if compliance_report.status == "FAIL":
+                gate_failures.append(f"Compliance FAIL ({len(compliance_report.violations)} violations)")
+            feedback_summary = "; ".join(gate_failures) if gate_failures else "Gates failed"
+
             try:
                 revise_input = ReviseDraftInput(
                     draft=draft_result.draft,
                     feedback_items=feedback_items,
-                    feedback_summary=f"Compliance FAIL: {len(compliance_report.violations)} violations. Apply required_fixes.",
+                    feedback_summary=feedback_summary,
                     research_document=research_document,
                     content_plan=plan,
                     audience=brief.audience,

--- a/backend/agents/blogging/blog_compliance_agent/agent.py
+++ b/backend/agents/blogging/blog_compliance_agent/agent.py
@@ -9,12 +9,17 @@ All errors are raised explicitly - no silent failures.
 
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Union
 
 from llm_service import LLMClient
+from llm_service.interface import (
+    LLMError as LLMServiceError,
+)
+from llm_service.interface import (
+    LLMJsonParseError as LLMServiceJsonParseError,
+)
 
 from .models import ComplianceReport, Violation
 from .prompts import COMPLIANCE_PROMPT
@@ -33,6 +38,8 @@ except ImportError:
         pass
     class LLMError(Exception):
         pass
+
+_MAX_JSON_RETRIES = 2
 
 logger = logging.getLogger(__name__)
 
@@ -70,26 +77,68 @@ class BlogComplianceAgent:
             ComplianceReport with status PASS or FAIL.
         """
         brand_summary = (brand_spec_prompt or "").strip()
-        validator_str = json.dumps(validator_report, indent=2) if validator_report else "{}"
+
+        # Pass only a concise summary of the validator report to avoid LLM echoing
+        # long markdown content that breaks JSON parsing.
+        if validator_report:
+            checks = validator_report.get("checks", [])
+            failed = [c.get("name", "unknown") for c in checks if c.get("status") == "FAIL"]
+            validator_summary = (
+                f"Overall: {validator_report.get('status', 'unknown')}. "
+                f"Failed checks: {', '.join(failed) or 'none'}."
+            )
+        else:
+            validator_summary = "No validator report available."
 
         prompt = COMPLIANCE_PROMPT.format(
             brand_spec_summary=brand_summary,
-            validator_report=validator_str,
+            validator_summary=validator_summary,
             draft=draft[:15000],
         )
 
         if on_llm_request:
             on_llm_request("Checking compliance with brand guidelines...")
-        try:
-            data = self.llm.complete_json(prompt, temperature=0.1)
-        except LLMError:
-            raise
-        except Exception as e:
-            logger.error("Compliance check failed: %s", e)
-            raise ComplianceError(
-                f"Compliance check failed: {e}",
-                cause=e,
-            ) from e
+
+        data = None
+        for attempt in range(_MAX_JSON_RETRIES):
+            current_prompt = prompt
+            if attempt > 0:
+                current_prompt = prompt + (
+                    "\n\nCRITICAL: Your previous response contained invalid JSON. "
+                    "Output ONLY a single valid JSON object. Do NOT embed code blocks, "
+                    "markdown formatting, or literal newlines inside string values. "
+                    "Keep evidence_quotes to under 80 characters each."
+                )
+            try:
+                data = self.llm.complete_json(current_prompt, temperature=0.1)
+                break
+            except LLMServiceJsonParseError as e:
+                logger.warning(
+                    "Compliance JSON parse failed (attempt %d/%d): %s",
+                    attempt + 1, _MAX_JSON_RETRIES, e,
+                )
+                continue
+            except (LLMServiceError, LLMError):
+                raise
+            except Exception as e:
+                logger.error("Compliance check failed: %s", e)
+                raise ComplianceError(f"Compliance check failed: {e}", cause=e) from e
+
+        if data is None:
+            logger.warning(
+                "Compliance JSON parse failed after %d attempts; using fallback FAIL report",
+                _MAX_JSON_RETRIES,
+            )
+            report = ComplianceReport(
+                status="FAIL",
+                violations=[],
+                required_fixes=["Could not parse compliance check result; re-run compliance."],
+                notes=f"Fallback report: JSON parse failed after {_MAX_JSON_RETRIES} attempts.",
+            )
+            if work_dir and write_artifact:
+                write_artifact(work_dir, "compliance_report.json", report.to_dict())
+                logger.info("Wrote compliance_report.json: status=FAIL (fallback)")
+            return report
 
         status = (data.get("status") or "FAIL").upper()
         if status not in ("PASS", "FAIL"):

--- a/backend/agents/blogging/blog_compliance_agent/prompts.py
+++ b/backend/agents/blogging/blog_compliance_agent/prompts.py
@@ -28,14 +28,19 @@ If there are NO violations, set status to "PASS" and leave violations and requir
 Output JSON only, in this exact format:
 {{"status": "PASS" or "FAIL", "violations": [{{"rule_id": "...", "description": "...", "evidence_quotes": ["..."], "location_hint": "..."}}], "required_fixes": ["...", "..."], "notes": "..."}}
 
+IMPORTANT OUTPUT RULES:
+- evidence_quotes: each quote MUST be under 80 characters. Truncate with "..." if needed.
+- Do NOT include code blocks, markdown fences, or literal newlines inside any JSON string value.
+- notes must be a single short sentence.
+
 BRAND SPEC:
 ---
 {brand_spec_summary}
 ---
 
-VALIDATOR REPORT (already run):
+VALIDATOR REPORT SUMMARY (deterministic checks already run — do NOT re-check these):
 ---
-{validator_report}
+{validator_summary}
 ---
 
 DRAFT:

--- a/backend/agents/blogging/blog_fact_check_agent/agent.py
+++ b/backend/agents/blogging/blog_fact_check_agent/agent.py
@@ -14,6 +14,12 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Union
 
 from llm_service import LLMClient
+from llm_service.interface import (
+    LLMError as LLMServiceError,
+)
+from llm_service.interface import (
+    LLMJsonParseError as LLMServiceJsonParseError,
+)
 
 from .models import FactCheckReport
 from .prompts import FACT_CHECK_PROMPT
@@ -30,6 +36,8 @@ except ImportError:
         pass
     class LLMError(Exception):
         pass
+
+_MAX_JSON_RETRIES = 2
 
 logger = logging.getLogger(__name__)
 
@@ -79,16 +87,47 @@ class BlogFactCheckAgent:
 
         if on_llm_request:
             on_llm_request("Checking facts and claims...")
-        try:
-            data = self.llm.complete_json(prompt, temperature=0.1)
-        except LLMError:
-            raise
-        except Exception as e:
-            logger.error("Fact-check failed: %s", e)
-            raise FactCheckError(
-                f"Fact-check failed: {e}",
-                cause=e,
-            ) from e
+
+        data = None
+        for attempt in range(_MAX_JSON_RETRIES):
+            current_prompt = prompt
+            if attempt > 0:
+                current_prompt = prompt + (
+                    "\n\nCRITICAL: Your previous response contained invalid JSON. "
+                    "Output ONLY a single valid JSON object. No code blocks or markdown in values."
+                )
+            try:
+                data = self.llm.complete_json(current_prompt, temperature=0.1)
+                break
+            except LLMServiceJsonParseError as e:
+                logger.warning(
+                    "Fact-check JSON parse failed (attempt %d/%d): %s",
+                    attempt + 1, _MAX_JSON_RETRIES, e,
+                )
+                continue
+            except (LLMServiceError, LLMError):
+                raise
+            except Exception as e:
+                logger.error("Fact-check failed: %s", e)
+                raise FactCheckError(f"Fact-check failed: {e}", cause=e) from e
+
+        if data is None:
+            logger.warning(
+                "Fact-check JSON parse failed after %d attempts; using fallback FAIL report",
+                _MAX_JSON_RETRIES,
+            )
+            report = FactCheckReport(
+                claims_status="FAIL",
+                risk_status="FAIL",
+                risk_flags=["Could not parse fact-check result; re-run fact check."],
+                required_disclaimers=[],
+                notes=f"Fallback report: JSON parse failed after {_MAX_JSON_RETRIES} attempts.",
+            )
+            if work_dir and write_artifact:
+                fc_data = report.dict() if hasattr(report, "dict") else report.model_dump()
+                write_artifact(work_dir, "fact_check_report.json", fc_data)
+                logger.info("Wrote fact_check_report.json: claims=FAIL risk=FAIL (fallback)")
+            return report
 
         claims_status = (data.get("claims_status") or "PASS").upper()
         if claims_status not in ("PASS", "FAIL"):

--- a/backend/agents/blogging/tests/test_compliance.py
+++ b/backend/agents/blogging/tests/test_compliance.py
@@ -1,12 +1,15 @@
 """Tests for the blog compliance agent."""
 
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 from blog_compliance_agent import BlogComplianceAgent
 from shared.brand_spec import load_brand_spec_prompt
 
 from llm_service import DummyLLMClient
+from llm_service.interface import LLMError as LLMServiceError
+from llm_service.interface import LLMJsonParseError as LLMServiceJsonParseError
 
 
 @pytest.fixture
@@ -46,3 +49,39 @@ def test_compliance_agent_with_work_dir(brand_spec_prompt, tmp_path):
     draft = "Short draft."
     agent.run(draft, brand_spec_prompt, work_dir=tmp_path)
     assert (tmp_path / "compliance_report.json").exists()
+
+
+def test_compliance_json_parse_retry_then_success(brand_spec_prompt):
+    """On first JSON parse failure, retries and succeeds on second attempt."""
+    llm = MagicMock()
+    llm.complete_json = MagicMock(
+        side_effect=[
+            LLMServiceJsonParseError("bad json"),
+            {"status": "PASS", "violations": [], "required_fixes": [], "notes": "ok"},
+        ]
+    )
+    agent = BlogComplianceAgent(llm_client=llm)
+    report = agent.run("Test draft.", brand_spec_prompt)
+    assert report.status == "PASS"
+    assert llm.complete_json.call_count == 2
+
+
+def test_compliance_json_parse_all_retries_fail_returns_fallback(brand_spec_prompt, tmp_path):
+    """When all JSON parse retries fail, returns a fallback FAIL report."""
+    llm = MagicMock()
+    llm.complete_json = MagicMock(side_effect=LLMServiceJsonParseError("bad json"))
+    agent = BlogComplianceAgent(llm_client=llm)
+    report = agent.run("Test draft.", brand_spec_prompt, work_dir=tmp_path)
+    assert report.status == "FAIL"
+    assert any("Could not parse" in fix for fix in report.required_fixes)
+    assert "Fallback" in (report.notes or "")
+    assert (tmp_path / "compliance_report.json").exists()
+
+
+def test_compliance_llm_service_error_propagates(brand_spec_prompt):
+    """LLMServiceError from the LLM client propagates without wrapping."""
+    llm = MagicMock()
+    llm.complete_json = MagicMock(side_effect=LLMServiceError("rate limit"))
+    agent = BlogComplianceAgent(llm_client=llm)
+    with pytest.raises(LLMServiceError, match="rate limit"):
+        agent.run("Test draft.", brand_spec_prompt)

--- a/backend/agents/blogging/tests/test_fact_check.py
+++ b/backend/agents/blogging/tests/test_fact_check.py
@@ -1,0 +1,63 @@
+"""Tests for the blog fact-check agent."""
+
+from unittest.mock import MagicMock
+
+import pytest
+from blog_fact_check_agent import BlogFactCheckAgent
+
+from llm_service import DummyLLMClient
+from llm_service.interface import LLMError as LLMServiceError
+from llm_service.interface import LLMJsonParseError as LLMServiceJsonParseError
+
+
+def test_fact_check_agent_run():
+    """BlogFactCheckAgent returns a FactCheckReport with status fields."""
+    llm = DummyLLMClient()
+    agent = BlogFactCheckAgent(llm_client=llm)
+    report = agent.run("This is a test draft about software engineering.")
+    assert report.claims_status in ("PASS", "FAIL")
+    assert report.risk_status in ("PASS", "FAIL")
+
+
+def test_fact_check_json_parse_retry_then_success():
+    """On first JSON parse failure, retries and succeeds on second attempt."""
+    llm = MagicMock()
+    llm.complete_json = MagicMock(
+        side_effect=[
+            LLMServiceJsonParseError("bad json"),
+            {
+                "claims_status": "PASS",
+                "risk_status": "PASS",
+                "claims_verified": [],
+                "risk_flags": [],
+                "required_disclaimers": [],
+                "notes": "ok",
+            },
+        ]
+    )
+    agent = BlogFactCheckAgent(llm_client=llm)
+    report = agent.run("Test draft.")
+    assert report.claims_status == "PASS"
+    assert llm.complete_json.call_count == 2
+
+
+def test_fact_check_json_parse_all_retries_fail_returns_fallback(tmp_path):
+    """When all JSON parse retries fail, returns a fallback FAIL report."""
+    llm = MagicMock()
+    llm.complete_json = MagicMock(side_effect=LLMServiceJsonParseError("bad json"))
+    agent = BlogFactCheckAgent(llm_client=llm)
+    report = agent.run("Test draft.", work_dir=tmp_path)
+    assert report.claims_status == "FAIL"
+    assert report.risk_status == "FAIL"
+    assert any("Could not parse" in flag for flag in report.risk_flags)
+    assert "Fallback" in (report.notes or "")
+    assert (tmp_path / "fact_check_report.json").exists()
+
+
+def test_fact_check_llm_service_error_propagates():
+    """LLMServiceError from the LLM client propagates without wrapping."""
+    llm = MagicMock()
+    llm.complete_json = MagicMock(side_effect=LLMServiceError("rate limit"))
+    agent = BlogFactCheckAgent(llm_client=llm)
+    with pytest.raises(LLMServiceError, match="rate limit"):
+        agent.run("Test draft.")


### PR DESCRIPTION
## Summary

- **Fix exception class mismatch** in compliance and fact-check agents: `complete_json()` raises `llm_service.interface.LLMJsonParseError` but agents caught `shared.errors.LLMError` (different hierarchy). Added retry with stricter prompt (up to 2 attempts) and fallback FAIL report when all retries fail.
- **Aggregate rewrite feedback from all three gates**: previously only `compliance_report.required_fixes` fed into the rewrite loop; now validator failed checks, fact-check risk flags/disclaimers, and compliance fixes all become `FeedbackItem` objects with a combined `feedback_summary`.
- **Harden compliance prompt**: pass concise validator summary instead of full JSON report, constrain `evidence_quotes` to 80 chars, and prohibit code blocks/markdown in JSON string values to prevent parse failures.

## Test plan

- [x] New tests: compliance agent JSON parse retry, fallback on all-retry failure, LLM service error propagation (3 tests)
- [x] New tests: fact-check agent JSON parse retry, fallback, error propagation (3 tests)
- [x] Existing compliance tests still pass (2 tests)
- [ ] Ruff lint passes on all changed files
- [ ] Full blogging test suite passes
- [ ] End-to-end: run pipeline through editor approval → verify rewrite loop receives feedback from all gates

https://claude.ai/code/session_015KanEewCQxC4RGqeZYBwzx