### PR TITLE
Track previously addressed feedback in blog revision prompts

### DIFF
--- a/backend/agents/blogging/agent_implementations/blog_writing_process_v2.py
+++ b/backend/agents/blogging/agent_implementations/blog_writing_process_v2.py
@@ -889,7 +889,7 @@ def run_pipeline(
                     selected_title=selected_title or None,
                     elicited_stories=elicited_stories_text or None,
                 )
-                previous_feedback_items = copy_editor_result.feedback_items
+                previous_feedback_items = previous_feedback_items + list(copy_editor_result.feedback_items)
                 draft_output_path = (Path(work_dir) / f"draft_v{iteration}.md") if work_dir is not None else None
                 draft_result = draft_agent.revise(
                     revise_input,

--- a/backend/agents/blogging/blog_draft_agent/agent.py
+++ b/backend/agents/blogging/blog_draft_agent/agent.py
@@ -498,11 +498,25 @@ class BlogDraftAgent:
             "---",
             feedback_block,
             "",
+        ]
+        if revise_input.previous_feedback_items:
+            prev_lines = []
+            for i, item in enumerate(revise_input.previous_feedback_items, 1):
+                loc = f" [{item.location}]" if item.location else ""
+                prev_lines.append(f"{i}. [{item.severity}] {item.category}{loc}: {item.issue}")
+            prompt_parts.extend([
+                "---",
+                "PREVIOUSLY ADDRESSED FEEDBACK (do NOT regress on these fixes — the editor already flagged them):",
+                "---",
+                "\n".join(prev_lines),
+                "",
+            ])
+        prompt_parts.extend([
             "---",
             "CURRENT DRAFT:",
             "---",
             draft,
-        ]
+        ])
         if revise_input.audience:
             prompt_parts.insert(0, f"Audience: {revise_input.audience}\n")
         if revise_input.tone_or_purpose:


### PR DESCRIPTION
## Summary
This change improves the blog revision process by explicitly tracking and referencing previously addressed feedback items in the revision prompts, preventing regressions on fixes that have already been made.

## Key Changes
- **Enhanced revision prompt**: Added a new "PREVIOUSLY ADDRESSED FEEDBACK" section to the revision prompt that lists all feedback items from previous iterations, reminding the agent not to regress on already-fixed issues
- **Cumulative feedback tracking**: Modified the feedback accumulation logic to append new feedback items to the running list rather than replacing it, ensuring all historical feedback is preserved across revision iterations
- **Improved prompt structure**: Reorganized prompt building to conditionally include the previous feedback section only when such items exist

## Implementation Details
- The `_build_revise_all_items_prompt` method now checks for `revise_input.previous_feedback_items` and formats them with severity, category, location, and issue description
- In `blog_writing_process_v2.py`, the feedback accumulation now uses `previous_feedback_items + list(copy_editor_result.feedback_items)` instead of direct assignment, maintaining a complete history across iterations
- The prompt structure ensures previously addressed feedback is clearly separated and marked as items the editor has already flagged, providing context to prevent regressions

https://claude.ai/code/session_016d3Z6hgcqzRG7rGefU2BDU