### PR TITLE
Fix PRA agent to follow SOP sub-phase order

### DIFF
--- a/backend/agents/software_engineering_team/product_requirements_analysis_agent/agent.py
+++ b/backend/agents/software_engineering_team/product_requirements_analysis_agent/agent.py
@@ -51,6 +51,8 @@ from .prompts import (
     SOP_ARCHITECTURE_ANALYSIS_PROMPT,
     SOP_GENERATE_OPTIONS_PROMPT,
     SOP_SPEC_EXTRACTION_PROMPT,
+    SOP_SUB_PHASE_GAP_ANALYSIS_PROMPT,
+    SOP_SUB_PHASE_OBJECTIVES,
     SPEC_CLEANUP_CHUNK_PROMPT,
     SPEC_CLEANUP_PROMPT,
     SPEC_CONSISTENCY_CLARIFICATION_PROMPT,
@@ -2267,6 +2269,121 @@ Previously Answered Questions:
 
         return options
 
+    def _assess_sub_phase_gaps(
+        self,
+        sub_phase: SOPSubPhase,
+        spec_content: str,
+        all_decisions: List[SOPDecision],
+        decisions_map: Dict[str, str],
+    ) -> Tuple[bool, List[OpenQuestion]]:
+        """Assess whether a sub-phase is complete and generate follow-up questions for gaps.
+
+        Uses an LLM call to evaluate the sub-phase against its objectives and the
+        information collected so far (from spec + user answers). If gaps remain,
+        the LLM generates targeted follow-up questions with spec-aware options.
+
+        Returns (is_complete, follow_up_questions).
+        """
+        objective = SOP_SUB_PHASE_OBJECTIVES.get(sub_phase.value, "")
+        if not objective:
+            return True, []
+
+        # Collect decisions for this sub-phase only
+        sub_phase_decisions = [
+            {"sop_id": d.sop_id, "question": d.question_text, "decision": d.decision, "source": d.source}
+            for d in all_decisions if d.sub_phase == sub_phase
+        ]
+        # Also include all decisions for cross-referencing
+        all_decisions_summary = [
+            {"sop_id": d.sop_id, "sub_phase": d.sub_phase.value if isinstance(d.sub_phase, SOPSubPhase) else str(d.sub_phase), "decision": d.decision}
+            for d in all_decisions
+        ]
+
+        prompt = SOP_SUB_PHASE_GAP_ANALYSIS_PROMPT.format(
+            sub_phase_name=sub_phase.value,
+            sub_phase_objective=objective,
+            spec_excerpt=spec_content[:6000],
+            sub_phase_decisions=json.dumps(sub_phase_decisions, indent=2),
+            all_decisions=json.dumps(all_decisions_summary, indent=2),
+        )
+
+        try:
+            raw = self.llm.complete_text(prompt)
+            if not raw or not raw.strip():
+                return True, []  # On failure, consider complete to avoid blocking
+            parsed = self._parse_llm_json(raw)
+            if not isinstance(parsed, dict):
+                return True, []
+
+            is_complete = bool(parsed.get("is_complete", True))
+            if is_complete:
+                logger.info(
+                    "SOP Phase 1: Sub-phase '%s' assessed as COMPLETE: %s",
+                    sub_phase.value, str(parsed.get("completeness_rationale", ""))[:200],
+                )
+                return True, []
+
+            logger.info(
+                "SOP Phase 1: Sub-phase '%s' has GAPS: %s",
+                sub_phase.value, str(parsed.get("completeness_rationale", ""))[:200],
+            )
+
+            # Parse follow-up questions
+            raw_questions = parsed.get("follow_up_questions", [])
+            if not isinstance(raw_questions, list):
+                return False, []
+
+            follow_ups: List[OpenQuestion] = []
+            for rq in raw_questions:
+                if not isinstance(rq, dict) or "question_text" not in rq:
+                    continue
+                q_id = rq.get("id", f"P1.{sub_phase.value[:6]}.gen_{len(follow_ups) + 1}")
+                # Skip if we already have a decision for this question ID
+                if q_id in decisions_map:
+                    continue
+
+                # Parse options from LLM response
+                raw_opts = rq.get("options", [])
+                options: List[QuestionOption] = []
+                for i, opt in enumerate(raw_opts):
+                    if not isinstance(opt, dict) or "label" not in opt:
+                        continue
+                    options.append(
+                        QuestionOption(
+                            id=opt.get("id", f"opt_gen_{i}"),
+                            label=opt["label"],
+                            is_default=bool(opt.get("is_default", False)),
+                            rationale=str(opt.get("rationale", "")),
+                            confidence=float(opt.get("confidence", 0.5)),
+                        )
+                    )
+
+                # Ensure minimum 3 options
+                if len(options) < 3:
+                    if not any(o.label.lower() == "other" for o in options):
+                        options.append(QuestionOption(id="opt_other", label="Other", is_default=False, rationale="Specify your preference.", confidence=0.3))
+                    if len(options) < 3:
+                        options.insert(0, QuestionOption(id="opt_text", label="(Please type your answer)", is_default=True, rationale="", confidence=0.5))
+
+                follow_ups.append(
+                    OpenQuestion(
+                        id=q_id,
+                        question_text=rq["question_text"],
+                        context=str(rq.get("context", "")),
+                        category=str(rq.get("category", "general")),
+                        priority=str(rq.get("priority", "high")),
+                        allow_multiple=bool(rq.get("allow_multiple", False)),
+                        source="sop_phase1",
+                        sop_sub_phase=sub_phase.value,
+                        options=options,
+                    )
+                )
+
+            return False, follow_ups
+        except Exception as exc:
+            logger.warning("Sub-phase gap analysis failed for '%s': %s", sub_phase.value, str(exc)[:200])
+            return True, []  # On failure, consider complete to avoid blocking
+
     def _run_sop_phase1(
         self,
         spec_content: str,
@@ -2279,9 +2396,10 @@ Previously Answered Questions:
         Sequential sub-phase approach:
         1. Extract answers already present in the spec.
         2. Iterate through each sub-phase one at a time (DEPLOYMENT, REGULATIONS, ..., PRIORITIES).
-        3. For each sub-phase, collect askable questions and present them to the user.
-        4. Complete the sub-phase (including conditional follow-ups) before moving to the next.
-        5. Every question is guaranteed at least 3 answer options informed by the spec.
+        3. For each sub-phase, first ask the hardcoded SOP questions (with conditional follow-ups).
+        4. Then assess whether the sub-phase is complete using LLM gap analysis.
+        5. If gaps remain, generate and ask follow-up questions until the sub-phase is complete.
+        6. Every question is guaranteed at least 3 answer options informed by the spec.
 
         Returns (all_decisions, updated_spec, answered_questions).
         """
@@ -2301,10 +2419,8 @@ Previously Answered Questions:
         # Step 2: Iterate through sub-phases ONE AT A TIME in order
         for sub_phase in SOPSubPhase:
             q_defs = SOP_PHASE1_QUESTIONS.get(sub_phase, [])
-            if not q_defs:
-                continue
 
-            # Multiple rounds within a sub-phase to handle conditional follow-ups
+            # --- Phase A: Ask hardcoded SOP questions (including conditional follow-ups) ---
             for round_num in range(1, MAX_SOP_ROUNDS + 1):
                 sub_phase_questions: List[OpenQuestion] = []
 
@@ -2337,10 +2453,7 @@ Previously Answered Questions:
                     )
 
                 if not sub_phase_questions:
-                    logger.info(
-                        "SOP Phase 1: Sub-phase '%s' complete (all questions answered or skipped)", sub_phase.value,
-                    )
-                    break  # This sub-phase is done — move to the next
+                    break  # No more hardcoded questions for this sub-phase
 
                 logger.info(
                     "SOP Phase 1 sub-phase '%s' round %d: asking %d questions",
@@ -2366,6 +2479,59 @@ Previously Answered Questions:
                     break
 
                 # Record answers as SOPDecision objects
+                for aq in answered:
+                    decision = SOPDecision(
+                        sop_id=aq.question_id,
+                        sub_phase=sub_phase,
+                        question_text=aq.question_text,
+                        decision=aq.selected_answer,
+                        source="user",
+                        confidence=1.0,
+                    )
+                    all_decisions.append(decision)
+                    decisions_map[aq.question_id] = aq.selected_answer
+
+                all_answered.extend(answered)
+                self._record_answers(repo_path, answered, iteration=0)
+
+            # --- Phase B: Gap analysis — generate follow-up questions until sub-phase is complete ---
+            for gap_round in range(1, MAX_SOP_ROUNDS + 1):
+                job_updater(
+                    status_text=f"SOP Phase 1 — {sub_phase.value}: assessing completeness...",
+                )
+                is_complete, follow_ups = self._assess_sub_phase_gaps(
+                    sub_phase, spec_content, all_decisions, decisions_map,
+                )
+                if is_complete or not follow_ups:
+                    logger.info(
+                        "SOP Phase 1: Sub-phase '%s' is complete after %d gap-analysis round(s)",
+                        sub_phase.value, gap_round,
+                    )
+                    break
+
+                logger.info(
+                    "SOP Phase 1 sub-phase '%s' gap round %d: asking %d follow-up questions",
+                    sub_phase.value, gap_round, len(follow_ups),
+                )
+                job_updater(
+                    status_text=f"SOP Phase 1 — {sub_phase.value}: {len(follow_ups)} follow-up question(s) to fill gaps",
+                )
+
+                try:
+                    answered = self._communicate_with_user(
+                        job_id=job_id,
+                        open_questions=follow_ups,
+                        repo_path=repo_path,
+                        iteration=0,
+                    )
+                except Exception as exc:
+                    logger.error("SOP Phase 1 gap-analysis communication failed in sub-phase '%s': %s", sub_phase.value, exc)
+                    raise
+
+                if not answered:
+                    logger.info("SOP Phase 1: No answers to gap questions for sub-phase '%s'", sub_phase.value)
+                    break
+
                 for aq in answered:
                     decision = SOPDecision(
                         sop_id=aq.question_id,

--- a/backend/agents/software_engineering_team/product_requirements_analysis_agent/agent.py
+++ b/backend/agents/software_engineering_team/product_requirements_analysis_agent/agent.py
@@ -179,7 +179,8 @@ def _context_discovery_fallback_questions() -> List[OpenQuestion]:
 # ``depends_on`` are conditional — they are only asked when the parent
 # question's answer matches one of the listed values.
 
-MAX_SOP_ROUNDS = 5  # Safety limit for multi-round SOP Phase 1
+MAX_SOP_ROUNDS = 5  # Safety limit for multi-round SOP Phase 1 (hardcoded questions)
+MAX_GAP_ROUNDS = 3  # Safety limit for LLM gap-analysis follow-up rounds per sub-phase
 
 SOP_PHASE1_QUESTIONS: Dict[SOPSubPhase, List[Dict[str, Any]]] = {
     SOPSubPhase.DEPLOYMENT: [
@@ -2282,6 +2283,9 @@ Previously Answered Questions:
         information collected so far (from spec + user answers). If gaps remain,
         the LLM generates targeted follow-up questions with spec-aware options.
 
+        On LLM error or malformed response, returns ``(True, [])`` to gracefully
+        degrade and avoid blocking the workflow.
+
         Returns (is_complete, follow_up_questions).
         """
         objective = SOP_SUB_PHASE_OBJECTIVES.get(sub_phase.value, "")
@@ -2298,6 +2302,8 @@ Previously Answered Questions:
             {"sop_id": d.sop_id, "sub_phase": d.sub_phase.value if isinstance(d.sub_phase, SOPSubPhase) else str(d.sub_phase), "decision": d.decision}
             for d in all_decisions
         ]
+        # Build list of existing question IDs so the LLM avoids regenerating them
+        existing_ids_str = ", ".join(sorted(decisions_map.keys())) if decisions_map else "(none)"
 
         prompt = SOP_SUB_PHASE_GAP_ANALYSIS_PROMPT.format(
             sub_phase_name=sub_phase.value,
@@ -2305,6 +2311,7 @@ Previously Answered Questions:
             spec_excerpt=spec_content[:6000],
             sub_phase_decisions=json.dumps(sub_phase_decisions, indent=2),
             all_decisions=json.dumps(all_decisions_summary, indent=2),
+            existing_question_ids=existing_ids_str,
         )
 
         try:
@@ -2333,6 +2340,7 @@ Previously Answered Questions:
             if not isinstance(raw_questions, list):
                 return False, []
 
+            skipped_dupes = 0
             follow_ups: List[OpenQuestion] = []
             for rq in raw_questions:
                 if not isinstance(rq, dict) or "question_text" not in rq:
@@ -2340,6 +2348,7 @@ Previously Answered Questions:
                 q_id = rq.get("id", f"P1.{sub_phase.value[:6]}.gen_{len(follow_ups) + 1}")
                 # Skip if we already have a decision for this question ID
                 if q_id in decisions_map:
+                    skipped_dupes += 1
                     continue
 
                 # Parse options from LLM response
@@ -2363,7 +2372,16 @@ Previously Answered Questions:
                     if not any(o.label.lower() == "other" for o in options):
                         options.append(QuestionOption(id="opt_other", label="Other", is_default=False, rationale="Specify your preference.", confidence=0.3))
                     if len(options) < 3:
-                        options.insert(0, QuestionOption(id="opt_text", label="(Please type your answer)", is_default=True, rationale="", confidence=0.5))
+                        options.insert(0, QuestionOption(id="opt_text", label="(Please type your answer)", is_default=False, rationale="", confidence=0.5))
+
+                # Ensure exactly one is_default=True
+                defaults = [o for o in options if o.is_default]
+                if len(defaults) == 0 and options:
+                    options[0] = options[0].model_copy(update={"is_default": True})
+                elif len(defaults) > 1:
+                    for o in defaults[1:]:
+                        idx = options.index(o)
+                        options[idx] = o.model_copy(update={"is_default": False})
 
                 follow_ups.append(
                     OpenQuestion(
@@ -2379,9 +2397,15 @@ Previously Answered Questions:
                     )
                 )
 
+            if skipped_dupes:
+                logger.warning(
+                    "SOP Phase 1: Sub-phase '%s' gap analysis generated %d question(s) with duplicate IDs — skipped",
+                    sub_phase.value, skipped_dupes,
+                )
+
             return False, follow_ups
         except Exception as exc:
-            logger.warning("Sub-phase gap analysis failed for '%s': %s", sub_phase.value, str(exc)[:200])
+            logger.error("Sub-phase gap analysis failed for '%s': %s", sub_phase.value, str(exc)[:200])
             return True, []  # On failure, consider complete to avoid blocking
 
     def _run_sop_phase1(
@@ -2495,7 +2519,7 @@ Previously Answered Questions:
                 self._record_answers(repo_path, answered, iteration=0)
 
             # --- Phase B: Gap analysis — generate follow-up questions until sub-phase is complete ---
-            for gap_round in range(1, MAX_SOP_ROUNDS + 1):
+            for gap_round in range(1, MAX_GAP_ROUNDS + 1):
                 job_updater(
                     status_text=f"SOP Phase 1 — {sub_phase.value}: assessing completeness...",
                 )

--- a/backend/agents/software_engineering_team/product_requirements_analysis_agent/agent.py
+++ b/backend/agents/software_engineering_team/product_requirements_analysis_agent/agent.py
@@ -49,6 +49,7 @@ from .prompts import (
     PRD_PROMPT,
     REVIEW_QUESTIONS_ALIGNMENT_PROMPT,
     SOP_ARCHITECTURE_ANALYSIS_PROMPT,
+    SOP_GENERATE_OPTIONS_PROMPT,
     SOP_SPEC_EXTRACTION_PROMPT,
     SPEC_CLEANUP_CHUNK_PROMPT,
     SPEC_CLEANUP_PROMPT,
@@ -284,16 +285,30 @@ SOP_PHASE1_QUESTIONS: Dict[SOPSubPhase, List[Dict[str, Any]]] = {
             "sop_id": "P1.tools.b",
             "question_text": "What existing proprietary licenses or tools do you already have?",
             "category": "business",
-            "allow_multiple": False,
-            "options": [],
+            "allow_multiple": True,
+            "options": [
+                {"id": "opt_jira", "label": "Jira", "rationale": "Project tracking and issue management."},
+                {"id": "opt_confluence", "label": "Confluence", "rationale": "Documentation and knowledge base."},
+                {"id": "opt_datadog", "label": "Datadog", "rationale": "Monitoring and observability platform."},
+                {"id": "opt_pagerduty", "label": "PagerDuty", "rationale": "Incident management and alerting."},
+                {"id": "opt_splunk", "label": "Splunk", "rationale": "Log management and SIEM."},
+                {"id": "opt_other", "label": "Other", "rationale": "Specify your proprietary tools."},
+            ],
             "depends_on": {"P1.tools.a": ["Proprietary"]},
         },
         {
             "sop_id": "P1.tools.c",
             "question_text": "What open source tools/frameworks are you already familiar with?",
             "category": "business",
-            "allow_multiple": False,
-            "options": [],
+            "allow_multiple": True,
+            "options": [
+                {"id": "opt_docker", "label": "Docker", "rationale": "Containerization standard."},
+                {"id": "opt_kubernetes", "label": "Kubernetes", "rationale": "Container orchestration."},
+                {"id": "opt_postgres", "label": "PostgreSQL", "rationale": "Full-featured relational database."},
+                {"id": "opt_redis", "label": "Redis", "rationale": "In-memory data store and cache."},
+                {"id": "opt_nginx", "label": "Nginx", "rationale": "Web server and reverse proxy."},
+                {"id": "opt_other", "label": "Other", "rationale": "Specify your open source tools."},
+            ],
             "depends_on": {"P1.tools.a": ["Open Source"]},
         },
     ],
@@ -335,8 +350,17 @@ SOP_PHASE1_QUESTIONS: Dict[SOPSubPhase, List[Dict[str, Any]]] = {
             "sop_id": "P1.coding.c",
             "question_text": "Do you have any framework preferences?",
             "category": "architecture",
-            "allow_multiple": False,
-            "options": [],
+            "allow_multiple": True,
+            "options": [
+                {"id": "opt_fastapi", "label": "FastAPI", "rationale": "Modern Python async API framework.", "is_default": True},
+                {"id": "opt_django", "label": "Django", "rationale": "Full-featured Python web framework."},
+                {"id": "opt_flask", "label": "Flask", "rationale": "Lightweight Python web framework."},
+                {"id": "opt_express", "label": "Express.js", "rationale": "Minimal Node.js web framework."},
+                {"id": "opt_nextjs", "label": "Next.js", "rationale": "React meta-framework with SSR."},
+                {"id": "opt_spring", "label": "Spring Boot", "rationale": "Enterprise Java framework."},
+                {"id": "opt_rails", "label": "Ruby on Rails", "rationale": "Convention-over-configuration web framework."},
+                {"id": "opt_other", "label": "Other", "rationale": "Specify your framework."},
+            ],
             "depends_on": None,
         },
         {
@@ -344,7 +368,17 @@ SOP_PHASE1_QUESTIONS: Dict[SOPSubPhase, List[Dict[str, Any]]] = {
             "question_text": "Do you have a package management preference?",
             "category": "architecture",
             "allow_multiple": False,
-            "options": [],
+            "options": [
+                {"id": "opt_pip", "label": "pip", "rationale": "Standard Python package manager."},
+                {"id": "opt_poetry", "label": "Poetry", "rationale": "Modern Python dependency management.", "is_default": True},
+                {"id": "opt_npm", "label": "npm", "rationale": "Default Node.js package manager."},
+                {"id": "opt_yarn", "label": "yarn", "rationale": "Fast, reliable Node.js package manager."},
+                {"id": "opt_pnpm", "label": "pnpm", "rationale": "Efficient, disk-space-saving Node.js package manager."},
+                {"id": "opt_maven", "label": "Maven", "rationale": "Java/JVM build and dependency tool."},
+                {"id": "opt_gradle", "label": "Gradle", "rationale": "Flexible JVM build tool."},
+                {"id": "opt_cargo", "label": "Cargo", "rationale": "Rust package manager."},
+                {"id": "opt_other", "label": "Other", "rationale": "Specify your preference."},
+            ],
             "depends_on": None,
         },
         {
@@ -558,6 +592,7 @@ SOP_PHASE1_QUESTIONS: Dict[SOPSubPhase, List[Dict[str, Any]]] = {
             "options": [
                 {"id": "opt_yes", "label": "Yes", "rationale": "Budget is a factor in decisions."},
                 {"id": "opt_no", "label": "No", "rationale": "No specific budget constraint.", "is_default": True},
+                {"id": "opt_unsure", "label": "Unsure / Not yet determined", "rationale": "Budget still being finalized."},
             ],
             "depends_on": None,
         },
@@ -569,6 +604,7 @@ SOP_PHASE1_QUESTIONS: Dict[SOPSubPhase, List[Dict[str, Any]]] = {
             "options": [
                 {"id": "opt_flexible", "label": "Flexible (can exceed if justified)", "rationale": "Budget is a guideline.", "is_default": True},
                 {"id": "opt_rigid", "label": "Rigid (hard maximum spend)", "rationale": "Cannot exceed budget."},
+                {"id": "opt_phased", "label": "Phased (staged budget allocation)", "rationale": "Budget allocated in phases tied to milestones."},
             ],
             "depends_on": {"P1.budget.a": ["Yes"]},
         },
@@ -595,7 +631,12 @@ SOP_PHASE1_QUESTIONS: Dict[SOPSubPhase, List[Dict[str, Any]]] = {
             "question_text": "Please rank your selected priorities from most to least important.",
             "category": "business",
             "allow_multiple": False,
-            "options": [],
+            "options": [
+                {"id": "opt_security_first", "label": "Security > Performance > Simplicity", "rationale": "Security-first approach for sensitive applications."},
+                {"id": "opt_performance_first", "label": "Performance > Scalability > Simplicity", "rationale": "Performance-oriented for high-traffic applications."},
+                {"id": "opt_simplicity_first", "label": "Simplicity > Frugality > Security", "rationale": "Simplicity-first for rapid development and maintainability.", "is_default": True},
+                {"id": "opt_other", "label": "Other", "rationale": "Specify your custom priority ranking."},
+            ],
             "depends_on": None,
         },
     ],
@@ -607,7 +648,9 @@ def _sop_phase1_fallback_questions() -> List[OpenQuestion]:
 
     Used when LLM-based spec extraction AND question generation both fail.
     Only includes root questions (no conditional follow-ups).
+    Every question is guaranteed at least 3 options.
     """
+    MIN_OPTIONS = 3
     fallback: List[OpenQuestion] = []
     for sub_phase, questions in SOP_PHASE1_QUESTIONS.items():
         for q_def in questions:
@@ -624,8 +667,20 @@ def _sop_phase1_fallback_questions() -> List[OpenQuestion]:
                         confidence=0.5,
                     )
                 )
+            # Ensure at least MIN_OPTIONS options
+            if len(options) < MIN_OPTIONS:
+                # Add "Other" if not present
+                if not any(o.label.lower() == "other" for o in options):
+                    options.append(
+                        QuestionOption(id="opt_other", label="Other", is_default=False, rationale="Specify your preference.", confidence=0.3)
+                    )
+                # Add a free-text placeholder if still short
+                if len(options) < MIN_OPTIONS:
+                    options.insert(0, QuestionOption(
+                        id="opt_text", label="(Please type your answer)", is_default=True, rationale="", confidence=0.5,
+                    ))
             if not options:
-                continue  # Skip free-text-only questions in fallback
+                continue  # Should not happen after above logic, but guard anyway
             fallback.append(
                 OpenQuestion(
                     id=q_def["sop_id"],
@@ -2115,6 +2170,103 @@ Previously Answered Questions:
             logger.warning("SOP spec extraction failed, will ask all questions: %s", str(exc)[:200])
             return []
 
+    def _generate_spec_aware_options(
+        self,
+        q_def: Dict[str, Any],
+        spec_content: str,
+        decisions_map: Dict[str, str],
+    ) -> List[QuestionOption]:
+        """Generate answer options for a question using the LLM, informed by the spec and prior decisions.
+
+        Returns a list of QuestionOption objects. Falls back to an empty list on failure.
+        """
+        prior_decisions_str = json.dumps(decisions_map, indent=2) if decisions_map else "{}"
+        prompt = SOP_GENERATE_OPTIONS_PROMPT.format(
+            question_text=q_def["question_text"],
+            sop_id=q_def["sop_id"],
+            prior_decisions=prior_decisions_str,
+            spec_excerpt=spec_content[:4000],
+        )
+        try:
+            raw = self.llm.complete_text(prompt)
+            if not raw or not raw.strip():
+                return []
+            parsed = self._parse_llm_json(raw)
+            if not isinstance(parsed, dict):
+                return []
+            raw_options = parsed.get("options", [])
+            if not isinstance(raw_options, list):
+                return []
+            options: List[QuestionOption] = []
+            for i, opt in enumerate(raw_options):
+                if not isinstance(opt, dict) or "label" not in opt:
+                    continue
+                options.append(
+                    QuestionOption(
+                        id=opt.get("id", f"opt_gen_{i}"),
+                        label=opt["label"],
+                        is_default=bool(opt.get("is_default", False)),
+                        rationale=str(opt.get("rationale", "")),
+                        confidence=float(opt.get("confidence", 0.5)),
+                    )
+                )
+            return options
+        except Exception as exc:
+            logger.warning("Spec-aware option generation failed for %s: %s", q_def["sop_id"], str(exc)[:200])
+            return []
+
+    def _build_question_options(
+        self,
+        q_def: Dict[str, Any],
+        spec_content: str,
+        decisions_map: Dict[str, str],
+    ) -> List[QuestionOption]:
+        """Build options for a question, ensuring at least 3 valid options.
+
+        Uses hardcoded options if >= 3 are available. Otherwise generates spec-aware
+        options via LLM and merges them with any existing hardcoded options.
+        """
+        MIN_OPTIONS = 3
+
+        # Start with hardcoded options
+        hardcoded = q_def.get("options", [])
+        options: List[QuestionOption] = []
+        for i, opt in enumerate(hardcoded):
+            options.append(
+                QuestionOption(
+                    id=opt.get("id", f"opt{i}"),
+                    label=opt["label"],
+                    is_default=opt.get("is_default", False),
+                    rationale=opt.get("rationale", ""),
+                    confidence=0.5,
+                )
+            )
+
+        if len(options) >= MIN_OPTIONS:
+            return options
+
+        # Not enough options — generate spec-aware options via LLM
+        generated = self._generate_spec_aware_options(q_def, spec_content, decisions_map)
+        existing_labels = {o.label.lower() for o in options}
+        for gen_opt in generated:
+            if gen_opt.label.lower() not in existing_labels:
+                options.append(gen_opt)
+                existing_labels.add(gen_opt.label.lower())
+
+        # Ensure "Other" option exists
+        if not any(o.label.lower() == "other" for o in options):
+            options.append(
+                QuestionOption(id="opt_other", label="Other", is_default=False, rationale="Specify your preference.", confidence=0.3)
+            )
+
+        # Final safety: if still < MIN_OPTIONS, add a free-text placeholder
+        if len(options) < MIN_OPTIONS:
+            options.insert(0, QuestionOption(
+                id="opt_text", label="(Please type your answer)", is_default=True, rationale="", confidence=0.5,
+            ))
+
+        return options
+
     def _run_sop_phase1(
         self,
         spec_content: str,
@@ -2124,15 +2276,16 @@ Previously Answered Questions:
     ) -> Tuple[List[SOPDecision], str, List[AnsweredQuestion]]:
         """Run SOP Phase 1: Environment Constraints & Requirements.
 
-        Multi-round approach:
+        Sequential sub-phase approach:
         1. Extract answers already present in the spec.
-        2. For each round, collect all currently-askable questions (root Qs + conditional
-           Qs whose parents are answered). Present them to the user in one batch.
-        3. Repeat until no new questions emerge (max MAX_SOP_ROUNDS rounds).
+        2. Iterate through each sub-phase one at a time (DEPLOYMENT, REGULATIONS, ..., PRIORITIES).
+        3. For each sub-phase, collect askable questions and present them to the user.
+        4. Complete the sub-phase (including conditional follow-ups) before moving to the next.
+        5. Every question is guaranteed at least 3 answer options informed by the spec.
 
         Returns (all_decisions, updated_spec, answered_questions).
         """
-        # Step 1: Extract decisions from spec
+        # Step 1: Extract decisions from spec (single upfront call for efficiency)
         spec_decisions = self._extract_sop_decisions_from_spec(spec_content)
         decisions_map: Dict[str, str] = {d.sop_id: d.decision for d in spec_decisions}
         all_decisions = list(spec_decisions)
@@ -2145,43 +2298,31 @@ Previously Answered Questions:
                 [d.sop_id for d in spec_decisions],
             )
 
-        # Step 2: Multi-round question loop
-        for round_num in range(1, MAX_SOP_ROUNDS + 1):
-            round_questions: List[OpenQuestion] = []
+        # Step 2: Iterate through sub-phases ONE AT A TIME in order
+        for sub_phase in SOPSubPhase:
+            q_defs = SOP_PHASE1_QUESTIONS.get(sub_phase, [])
+            if not q_defs:
+                continue
 
-            for sub_phase in SOPSubPhase:
-                q_defs = SOP_PHASE1_QUESTIONS.get(sub_phase, [])
+            # Multiple rounds within a sub-phase to handle conditional follow-ups
+            for round_num in range(1, MAX_SOP_ROUNDS + 1):
+                sub_phase_questions: List[OpenQuestion] = []
+
                 for q_def in q_defs:
                     sop_id = q_def["sop_id"]
                     if sop_id in decisions_map:
-                        continue  # Already answered
+                        continue  # Already answered (from spec or prior round)
 
                     cond_result = self._evaluate_sop_conditionals(q_def, decisions_map)
                     if cond_result is False:
                         continue  # Condition not met
                     if cond_result is None:
-                        continue  # Parent not answered yet — defer
+                        continue  # Parent not answered yet — defer to next round within this sub-phase
 
-                    # Build OpenQuestion from the definition
-                    options = []
-                    for i, opt in enumerate(q_def.get("options", [])):
-                        options.append(
-                            QuestionOption(
-                                id=opt.get("id", f"opt{i}"),
-                                label=opt["label"],
-                                is_default=opt.get("is_default", False),
-                                rationale=opt.get("rationale", ""),
-                                confidence=0.5,
-                            )
-                        )
+                    # Build options ensuring at least 3 valid choices, informed by spec
+                    options = self._build_question_options(q_def, spec_content, decisions_map)
 
-                    if not options:
-                        # Free-text question — still include with minimal options
-                        options = [
-                            QuestionOption(id="opt_text", label="(Please type your answer)", is_default=True, rationale="", confidence=0.5),
-                        ]
-
-                    round_questions.append(
+                    sub_phase_questions.append(
                         OpenQuestion(
                             id=sop_id,
                             question_text=q_def["question_text"],
@@ -2195,46 +2336,40 @@ Previously Answered Questions:
                         )
                     )
 
-            if not round_questions:
-                logger.info("SOP Phase 1: All questions answered after round %d", round_num - 1)
-                break
+                if not sub_phase_questions:
+                    logger.info(
+                        "SOP Phase 1: Sub-phase '%s' complete (all questions answered or skipped)", sub_phase.value,
+                    )
+                    break  # This sub-phase is done — move to the next
 
-            logger.info("SOP Phase 1 round %d: asking %d questions", round_num, len(round_questions))
-            job_updater(
-                status_text=f"SOP Phase 1 round {round_num}: waiting for answers to {len(round_questions)} question(s)",
-            )
-
-            try:
-                answered = self._communicate_with_user(
-                    job_id=job_id,
-                    open_questions=round_questions,
-                    repo_path=repo_path,
-                    iteration=0,
+                logger.info(
+                    "SOP Phase 1 sub-phase '%s' round %d: asking %d questions",
+                    sub_phase.value, round_num, len(sub_phase_questions),
                 )
-            except Exception as exc:
-                logger.error("SOP Phase 1 communication failed: %s", exc)
-                raise
+                job_updater(
+                    status_text=f"SOP Phase 1 — {sub_phase.value}: waiting for answers to {len(sub_phase_questions)} question(s)",
+                )
 
-            if not answered:
-                logger.info("SOP Phase 1: No answers received in round %d", round_num)
-                break
+                try:
+                    answered = self._communicate_with_user(
+                        job_id=job_id,
+                        open_questions=sub_phase_questions,
+                        repo_path=repo_path,
+                        iteration=0,
+                    )
+                except Exception as exc:
+                    logger.error("SOP Phase 1 communication failed in sub-phase '%s': %s", sub_phase.value, exc)
+                    raise
 
-            # Record answers as SOPDecision objects
-            for aq in answered:
-                # Map question_id back to sub_phase
-                sub_phase_val = ""
-                for sp, q_defs in SOP_PHASE1_QUESTIONS.items():
-                    for q_def in q_defs:
-                        if q_def["sop_id"] == aq.question_id:
-                            sub_phase_val = sp
-                            break
-                    if sub_phase_val:
-                        break
+                if not answered:
+                    logger.info("SOP Phase 1: No answers received for sub-phase '%s' round %d", sub_phase.value, round_num)
+                    break
 
-                if sub_phase_val:
+                # Record answers as SOPDecision objects
+                for aq in answered:
                     decision = SOPDecision(
                         sop_id=aq.question_id,
-                        sub_phase=sub_phase_val,
+                        sub_phase=sub_phase,
                         question_text=aq.question_text,
                         decision=aq.selected_answer,
                         source="user",
@@ -2243,8 +2378,8 @@ Previously Answered Questions:
                     all_decisions.append(decision)
                     decisions_map[aq.question_id] = aq.selected_answer
 
-            all_answered.extend(answered)
-            self._record_answers(repo_path, answered, iteration=0)
+                all_answered.extend(answered)
+                self._record_answers(repo_path, answered, iteration=0)
 
         # Step 3: Inject all decisions into spec
         if all_answered:

--- a/backend/agents/software_engineering_team/product_requirements_analysis_agent/prompts.py
+++ b/backend/agents/software_engineering_team/product_requirements_analysis_agent/prompts.py
@@ -954,6 +954,9 @@ of a software project's environment constraints and requirements gathering.
 {all_decisions}
 ---
 
+## Already-used question IDs (do NOT regenerate these)
+{existing_question_ids}
+
 ## Your task
 1. Review the specification and the decisions already collected for the "{sub_phase_name}" sub-phase.
 2. Determine if we have ENOUGH information to consider this sub-phase COMPLETE. A sub-phase is complete when all the key aspects described in the objective have either been answered or can be clearly inferred from the spec.

--- a/backend/agents/software_engineering_team/product_requirements_analysis_agent/prompts.py
+++ b/backend/agents/software_engineering_team/product_requirements_analysis_agent/prompts.py
@@ -829,6 +829,44 @@ If no questions are answered by the spec, return:
 """
 
 # ---------------------------------------------------------------------------
+# SOP Phase 1: Generate spec-aware answer options for questions with few/no hardcoded options
+# ---------------------------------------------------------------------------
+
+SOP_GENERATE_OPTIONS_PROMPT = """You are an expert Product Analyst. Generate 3-6 relevant answer options for the following SOP question. \
+The options must be specific, actionable, and informed by the project specification and any prior decisions already made.
+
+Question: {question_text}
+Question ID: {sop_id}
+
+Prior decisions already made:
+---
+{prior_decisions}
+---
+
+Product Specification excerpt:
+---
+{spec_excerpt}
+---
+
+RULES:
+1. Generate 3-6 options that are RELEVANT to this specific project based on the spec and prior decisions.
+2. If prior decisions indicate a specific technology (e.g., Python was chosen as language), tailor options accordingly (e.g., suggest Python-specific frameworks like FastAPI, Django, Flask).
+3. Mark exactly ONE option as is_default (the one most aligned with the spec).
+4. Always include an "Other" option as the last option.
+5. Each option must have a brief rationale explaining why it is relevant.
+
+Respond with a JSON object only, no markdown:
+{{
+  "options": [
+    {{"id": "opt_1", "label": "Option label", "is_default": true, "rationale": "Why this fits the project.", "confidence": 0.7}},
+    {{"id": "opt_2", "label": "Another option", "is_default": false, "rationale": "Why this is relevant.", "confidence": 0.5}},
+    {{"id": "opt_3", "label": "Third option", "is_default": false, "rationale": "Why this could work.", "confidence": 0.4}},
+    {{"id": "opt_other", "label": "Other", "is_default": false, "rationale": "Specify your preference.", "confidence": 0.3}}
+  ]
+}}
+"""
+
+# ---------------------------------------------------------------------------
 # SOP Phase 1: Round Prompt — Generate questions for unanswered SOP items
 # ---------------------------------------------------------------------------
 

--- a/backend/agents/software_engineering_team/product_requirements_analysis_agent/prompts.py
+++ b/backend/agents/software_engineering_team/product_requirements_analysis_agent/prompts.py
@@ -4,6 +4,10 @@ Prompts for the Product Requirements Analysis Agent.
 Prompts for spec review, auto-answer generation, spec update, and spec cleanup phases.
 """
 
+from __future__ import annotations
+
+from typing import Dict
+
 # ---------------------------------------------------------------------------
 # Context and Constraints Discovery (pre-review)
 # ---------------------------------------------------------------------------
@@ -863,6 +867,135 @@ Respond with a JSON object only, no markdown:
     {{"id": "opt_3", "label": "Third option", "is_default": false, "rationale": "Why this could work.", "confidence": 0.4}},
     {{"id": "opt_other", "label": "Other", "is_default": false, "rationale": "Specify your preference.", "confidence": 0.3}}
   ]
+}}
+"""
+
+# ---------------------------------------------------------------------------
+# SOP Phase 1: Sub-phase gap analysis — assess completeness and generate follow-up questions
+# ---------------------------------------------------------------------------
+
+# Maps each sub-phase to a description of the information the PRA agent should collect.
+# Used by the gap-analysis prompt to help the LLM understand what "complete" means.
+SOP_SUB_PHASE_OBJECTIVES: Dict[str, str] = {
+    "deployment": (
+        "Determine WHERE and HOW the application will be hosted/deployed. "
+        "This includes: deployment model (cloud / on-prem / PaaS / hybrid), specific cloud provider(s), "
+        "compute model (serverless / containers / VMs), target environments (dev / staging / prod), "
+        "region/availability-zone requirements, and any infrastructure constraints."
+    ),
+    "regulations": (
+        "Identify ALL regulatory, compliance, and certification requirements. "
+        "This includes: data protection laws (GDPR, CCPA, HIPAA, PCI-DSS, etc.), "
+        "enterprise certifications (SOC2, ISO 27001, FedRAMP, etc.), data residency/sovereignty rules, "
+        "and any industry-specific regulations."
+    ),
+    "tool_preferences": (
+        "Understand the team's preference for open-source vs proprietary tools, "
+        "existing tool licenses and subscriptions, and familiarity with specific tools/platforms. "
+        "This helps avoid recommending tools that conflict with existing investments."
+    ),
+    "coding_preferences": (
+        "Determine the team's coding environment preferences: source control host, "
+        "programming language(s), framework(s), package managers, CI/CD pipeline, "
+        "code quality tools, and any coding standards or conventions."
+    ),
+    "data": (
+        "Understand ALL data storage and processing needs: types of data (structured, files, time-series, "
+        "events, graph), preferred databases/storage services, data volume estimates, "
+        "event/message streaming requirements, event sourcing, caching needs, and data migration concerns."
+    ),
+    "security": (
+        "Identify authentication/authorization approach, security scanning tools, "
+        "secrets/key management strategy, encryption requirements (at rest and in transit), "
+        "network security needs, and any security review/audit processes."
+    ),
+    "observability": (
+        "Determine monitoring, logging, tracing, and alerting strategy: "
+        "preferred tools (Prometheus, Grafana, Datadog, CloudWatch, etc.), "
+        "log aggregation approach, distributed tracing needs, SLO/SLI tracking, "
+        "and dashboard/alerting requirements."
+    ),
+    "sla": (
+        "Define service-level requirements: response time/latency targets, "
+        "uptime requirements (99.9%, 99.99%, etc.), RPO/RTO for disaster recovery, "
+        "throughput/concurrency expectations, and any contractual SLAs."
+    ),
+    "budget": (
+        "Understand budget constraints: whether a budget cap exists, "
+        "whether it is flexible or rigid, approximate monthly/annual budget range, "
+        "and any cost-optimization priorities (e.g., reserved instances, spot instances)."
+    ),
+    "priorities": (
+        "Determine project priorities and their relative ranking: "
+        "resiliency, performance, frugality, simplicity, security, scalability, "
+        "time-to-market, developer experience, and any other key priorities. "
+        "The ranking informs trade-off decisions throughout the project."
+    ),
+}
+
+SOP_SUB_PHASE_GAP_ANALYSIS_PROMPT = """You are an expert Product Analyst performing a gap analysis on the "{sub_phase_name}" sub-phase \
+of a software project's environment constraints and requirements gathering.
+
+## Objective for this sub-phase
+{sub_phase_objective}
+
+## Product Specification
+---
+{spec_excerpt}
+---
+
+## Decisions already collected for this sub-phase
+---
+{sub_phase_decisions}
+---
+
+## All decisions collected so far (across all sub-phases)
+---
+{all_decisions}
+---
+
+## Your task
+1. Review the specification and the decisions already collected for the "{sub_phase_name}" sub-phase.
+2. Determine if we have ENOUGH information to consider this sub-phase COMPLETE. A sub-phase is complete when all the key aspects described in the objective have either been answered or can be clearly inferred from the spec.
+3. If the sub-phase is NOT complete, generate 1-5 follow-up questions that target the specific gaps. Each question MUST have 3-6 answer options.
+
+RULES:
+- Only generate questions for GENUINE GAPS — do not re-ask things already answered.
+- Questions must be specific to THIS project based on the spec and prior decisions.
+- If prior decisions indicate a specific technology, tailor follow-up questions accordingly.
+- Each question must have 3-6 options with id, label, is_default (exactly one true), rationale, and confidence.
+- Always include an "Other" option as the last option for each question.
+- Set allow_multiple: true when the user might reasonably select more than one option.
+- Question IDs should follow the pattern "P1.{{sub_phase_short}}.gen_{{n}}" (e.g., "P1.deploy.gen_1").
+
+Respond with a JSON object only, no markdown:
+{{
+  "is_complete": true/false,
+  "completeness_rationale": "Brief explanation of why the sub-phase is or isn't complete.",
+  "follow_up_questions": [
+    {{
+      "id": "P1.deploy.gen_1",
+      "question_text": "Which AWS regions should the application be deployed in?",
+      "context": "Region selection affects latency, compliance, and cost.",
+      "category": "infrastructure",
+      "priority": "high",
+      "allow_multiple": true,
+      "sop_sub_phase": "deployment",
+      "options": [
+        {{"id": "opt_1", "label": "us-east-1 (Virginia)", "is_default": true, "rationale": "Most common, lowest cost.", "confidence": 0.7}},
+        {{"id": "opt_2", "label": "us-west-2 (Oregon)", "is_default": false, "rationale": "West coast proximity.", "confidence": 0.5}},
+        {{"id": "opt_3", "label": "eu-west-1 (Ireland)", "is_default": false, "rationale": "EU data residency.", "confidence": 0.4}},
+        {{"id": "opt_other", "label": "Other", "is_default": false, "rationale": "Specify your region(s).", "confidence": 0.3}}
+      ]
+    }}
+  ]
+}}
+
+If the sub-phase IS complete, return:
+{{
+  "is_complete": true,
+  "completeness_rationale": "All key aspects of {sub_phase_name} have been addressed: ...",
+  "follow_up_questions": []
 }}
 """
 

--- a/backend/agents/software_engineering_team/tests/test_product_requirements_analysis_agent.py
+++ b/backend/agents/software_engineering_team/tests/test_product_requirements_analysis_agent.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from product_requirements_analysis_agent import ProductRequirementsAnalysisAgent
 from product_requirements_analysis_agent.agent import (
+    MAX_GAP_ROUNDS,
     SOP_PHASE1_QUESTIONS,
     _context_discovery_fallback_questions,
     _sop_phase1_fallback_questions,
@@ -1236,3 +1237,263 @@ def test_sop_models_basic() -> None:
     arch = ArchitectureAnalysisResult()
     assert arch.architecture_type == ""
     assert arch.diagrams == {}
+
+
+# ---------------------------------------------------------------------------
+# _assess_sub_phase_gaps tests
+# ---------------------------------------------------------------------------
+
+
+def test_assess_sub_phase_gaps_complete() -> None:
+    """When LLM reports sub-phase as complete, returns (True, [])."""
+    llm = MagicMock()
+    llm.complete_text.return_value = json.dumps({
+        "is_complete": True,
+        "completeness_rationale": "All deployment aspects covered.",
+        "follow_up_questions": [],
+    })
+    agent = ProductRequirementsAnalysisAgent(llm)
+    is_complete, follow_ups = agent._assess_sub_phase_gaps(
+        SOPSubPhase.DEPLOYMENT,
+        "Deploy on AWS with ECS containers.",
+        [SOPDecision(sop_id="P1.deploy.a", sub_phase=SOPSubPhase.DEPLOYMENT, question_text="Where?", decision="AWS", source="spec")],
+        {"P1.deploy.a": "AWS"},
+    )
+    assert is_complete is True
+    assert follow_ups == []
+
+
+def test_assess_sub_phase_gaps_incomplete_with_follow_ups() -> None:
+    """When LLM reports gaps, returns (False, [OpenQuestion, ...])."""
+    llm = MagicMock()
+    llm.complete_text.return_value = json.dumps({
+        "is_complete": False,
+        "completeness_rationale": "Missing region info.",
+        "follow_up_questions": [
+            {
+                "id": "P1.deploy.gen_1",
+                "question_text": "Which AWS region?",
+                "context": "Region affects latency.",
+                "category": "infrastructure",
+                "priority": "high",
+                "allow_multiple": False,
+                "sop_sub_phase": "deployment",
+                "options": [
+                    {"id": "opt_1", "label": "us-east-1", "is_default": True, "rationale": "Common.", "confidence": 0.8},
+                    {"id": "opt_2", "label": "eu-west-1", "is_default": False, "rationale": "EU.", "confidence": 0.5},
+                    {"id": "opt_3", "label": "ap-southeast-1", "is_default": False, "rationale": "APAC.", "confidence": 0.4},
+                    {"id": "opt_other", "label": "Other", "is_default": False, "rationale": "Specify.", "confidence": 0.3},
+                ],
+            }
+        ],
+    })
+    agent = ProductRequirementsAnalysisAgent(llm)
+    is_complete, follow_ups = agent._assess_sub_phase_gaps(
+        SOPSubPhase.DEPLOYMENT, "Deploy on AWS.", [], {},
+    )
+    assert is_complete is False
+    assert len(follow_ups) == 1
+    assert follow_ups[0].id == "P1.deploy.gen_1"
+    assert follow_ups[0].question_text == "Which AWS region?"
+    assert len(follow_ups[0].options) == 4
+
+
+def test_assess_sub_phase_gaps_malformed_json() -> None:
+    """Malformed LLM JSON should degrade gracefully to (True, [])."""
+    llm = MagicMock()
+    llm.complete_text.return_value = "This is not valid JSON at all"
+    agent = ProductRequirementsAnalysisAgent(llm)
+    is_complete, follow_ups = agent._assess_sub_phase_gaps(
+        SOPSubPhase.DEPLOYMENT, "Some spec.", [], {},
+    )
+    assert is_complete is True
+    assert follow_ups == []
+
+
+def test_assess_sub_phase_gaps_llm_exception() -> None:
+    """LLM exception should degrade gracefully to (True, [])."""
+    llm = MagicMock()
+    llm.complete_text.side_effect = RuntimeError("LLM unavailable")
+    agent = ProductRequirementsAnalysisAgent(llm)
+    is_complete, follow_ups = agent._assess_sub_phase_gaps(
+        SOPSubPhase.SECURITY, "Some spec.", [], {},
+    )
+    assert is_complete is True
+    assert follow_ups == []
+
+
+def test_assess_sub_phase_gaps_duplicate_ids_skipped() -> None:
+    """Follow-up questions with IDs already in decisions_map are skipped with a warning."""
+    llm = MagicMock()
+    llm.complete_text.return_value = json.dumps({
+        "is_complete": False,
+        "completeness_rationale": "Gaps remain.",
+        "follow_up_questions": [
+            {
+                "id": "P1.deploy.a",
+                "question_text": "Duplicate question?",
+                "options": [
+                    {"id": "opt_1", "label": "A", "is_default": True, "rationale": ".", "confidence": 0.5},
+                    {"id": "opt_2", "label": "B", "is_default": False, "rationale": ".", "confidence": 0.5},
+                    {"id": "opt_3", "label": "C", "is_default": False, "rationale": ".", "confidence": 0.5},
+                ],
+            },
+            {
+                "id": "P1.deploy.gen_1",
+                "question_text": "New question?",
+                "options": [
+                    {"id": "opt_1", "label": "X", "is_default": True, "rationale": ".", "confidence": 0.5},
+                    {"id": "opt_2", "label": "Y", "is_default": False, "rationale": ".", "confidence": 0.5},
+                    {"id": "opt_3", "label": "Z", "is_default": False, "rationale": ".", "confidence": 0.5},
+                ],
+            },
+        ],
+    })
+    agent = ProductRequirementsAnalysisAgent(llm)
+    is_complete, follow_ups = agent._assess_sub_phase_gaps(
+        SOPSubPhase.DEPLOYMENT,
+        "Some spec.",
+        [SOPDecision(sop_id="P1.deploy.a", sub_phase=SOPSubPhase.DEPLOYMENT, question_text="Where?", decision="AWS", source="spec")],
+        {"P1.deploy.a": "AWS"},
+    )
+    assert is_complete is False
+    # Only the non-duplicate question should be returned
+    assert len(follow_ups) == 1
+    assert follow_ups[0].id == "P1.deploy.gen_1"
+
+
+def test_assess_sub_phase_gaps_all_dupes_returns_empty_follow_ups() -> None:
+    """When all LLM questions are duplicates, follow_ups is empty (loop will exit)."""
+    llm = MagicMock()
+    llm.complete_text.return_value = json.dumps({
+        "is_complete": False,
+        "completeness_rationale": "Gaps remain.",
+        "follow_up_questions": [
+            {
+                "id": "P1.deploy.a",
+                "question_text": "Dupe 1?",
+                "options": [{"id": "o1", "label": "A", "is_default": True, "rationale": ".", "confidence": 0.5}],
+            },
+        ],
+    })
+    agent = ProductRequirementsAnalysisAgent(llm)
+    is_complete, follow_ups = agent._assess_sub_phase_gaps(
+        SOPSubPhase.DEPLOYMENT, "Spec.", [], {"P1.deploy.a": "AWS"},
+    )
+    assert is_complete is False
+    assert follow_ups == []
+
+
+def test_assess_sub_phase_gaps_options_padded_to_min_3() -> None:
+    """When LLM returns < 3 options, they are padded to at least 3."""
+    llm = MagicMock()
+    llm.complete_text.return_value = json.dumps({
+        "is_complete": False,
+        "completeness_rationale": "Gaps.",
+        "follow_up_questions": [
+            {
+                "id": "P1.deploy.gen_1",
+                "question_text": "Which compute model?",
+                "options": [
+                    {"id": "opt_1", "label": "Serverless", "is_default": True, "rationale": ".", "confidence": 0.8},
+                ],
+            },
+        ],
+    })
+    agent = ProductRequirementsAnalysisAgent(llm)
+    is_complete, follow_ups = agent._assess_sub_phase_gaps(
+        SOPSubPhase.DEPLOYMENT, "Spec.", [], {},
+    )
+    assert is_complete is False
+    assert len(follow_ups) == 1
+    opts = follow_ups[0].options
+    assert len(opts) >= 3
+    # Should have "Other" added
+    assert any(o.label == "Other" for o in opts)
+
+
+def test_assess_sub_phase_gaps_exactly_one_default() -> None:
+    """After option padding/parsing, exactly one option has is_default=True."""
+    llm = MagicMock()
+    llm.complete_text.return_value = json.dumps({
+        "is_complete": False,
+        "completeness_rationale": "Gaps.",
+        "follow_up_questions": [
+            {
+                "id": "P1.data.gen_1",
+                "question_text": "Which database?",
+                "options": [
+                    {"id": "opt_1", "label": "PostgreSQL", "is_default": True, "rationale": ".", "confidence": 0.8},
+                    {"id": "opt_2", "label": "MySQL", "is_default": True, "rationale": ".", "confidence": 0.6},
+                    {"id": "opt_3", "label": "MongoDB", "is_default": False, "rationale": ".", "confidence": 0.4},
+                ],
+            },
+        ],
+    })
+    agent = ProductRequirementsAnalysisAgent(llm)
+    _, follow_ups = agent._assess_sub_phase_gaps(SOPSubPhase.DATA, "Spec.", [], {})
+    assert len(follow_ups) == 1
+    defaults = [o for o in follow_ups[0].options if o.is_default]
+    assert len(defaults) == 1, f"Expected 1 default, got {len(defaults)}"
+
+
+def test_assess_sub_phase_gaps_no_defaults_sets_first() -> None:
+    """When LLM returns no default option, the first option becomes default."""
+    llm = MagicMock()
+    llm.complete_text.return_value = json.dumps({
+        "is_complete": False,
+        "completeness_rationale": "Gaps.",
+        "follow_up_questions": [
+            {
+                "id": "P1.sec.gen_1",
+                "question_text": "Auth method?",
+                "options": [
+                    {"id": "opt_1", "label": "OAuth2", "is_default": False, "rationale": ".", "confidence": 0.7},
+                    {"id": "opt_2", "label": "SAML", "is_default": False, "rationale": ".", "confidence": 0.5},
+                    {"id": "opt_3", "label": "API Keys", "is_default": False, "rationale": ".", "confidence": 0.3},
+                ],
+            },
+        ],
+    })
+    agent = ProductRequirementsAnalysisAgent(llm)
+    _, follow_ups = agent._assess_sub_phase_gaps(SOPSubPhase.SECURITY, "Spec.", [], {})
+    assert len(follow_ups) == 1
+    assert follow_ups[0].options[0].is_default is True
+    # Only the first should be default
+    defaults = [o for o in follow_ups[0].options if o.is_default]
+    assert len(defaults) == 1
+
+
+def test_assess_sub_phase_gaps_empty_llm_response() -> None:
+    """Empty LLM response should degrade gracefully to (True, [])."""
+    llm = MagicMock()
+    llm.complete_text.return_value = ""
+    agent = ProductRequirementsAnalysisAgent(llm)
+    is_complete, follow_ups = agent._assess_sub_phase_gaps(
+        SOPSubPhase.BUDGET, "Spec.", [], {},
+    )
+    assert is_complete is True
+    assert follow_ups == []
+
+
+def test_assess_sub_phase_gaps_passes_existing_ids_to_prompt() -> None:
+    """Verify that existing question IDs are passed to the LLM prompt."""
+    llm = MagicMock()
+    llm.complete_text.return_value = json.dumps({"is_complete": True, "completeness_rationale": "Done.", "follow_up_questions": []})
+    agent = ProductRequirementsAnalysisAgent(llm)
+    agent._assess_sub_phase_gaps(
+        SOPSubPhase.DEPLOYMENT, "Spec.",
+        [SOPDecision(sop_id="P1.deploy.a", sub_phase=SOPSubPhase.DEPLOYMENT, question_text="Q", decision="A", source="user")],
+        {"P1.deploy.a": "AWS", "P1.deploy.b": "ECS"},
+    )
+    # The prompt should contain the existing question IDs
+    call_args = llm.complete_text.call_args[0][0]
+    assert "P1.deploy.a" in call_args
+    assert "P1.deploy.b" in call_args
+
+
+def test_max_gap_rounds_constant() -> None:
+    """MAX_GAP_ROUNDS should be a reasonable limit smaller than MAX_SOP_ROUNDS."""
+    assert MAX_GAP_ROUNDS == 3
+    from product_requirements_analysis_agent.agent import MAX_SOP_ROUNDS
+    assert MAX_GAP_ROUNDS <= MAX_SOP_ROUNDS


### PR DESCRIPTION
## Summary

- **Restructure SOP Phase 1** to process sub-phases sequentially (DEPLOYMENT → REGULATIONS → TOOL_PREFERENCES → ... → PRIORITIES), completing each before moving to the next
- **Guarantee ≥3 answer options** on every question via `_build_question_options()` — uses hardcoded options when sufficient, otherwise generates spec-aware options via LLM
- **Add spec-aware option generation** (`_generate_spec_aware_options()` + `SOP_GENERATE_OPTIONS_PROMPT`) so the agent considers the specification and prior decisions when creating answer choices
- **Add hardcoded options** to 5 previously empty questions (framework preferences, package management, proprietary tools, open source tools, priority ranking) and add a third option to budget questions

## Test plan

- [x] All 52 existing PRA agent tests pass (`pytest agents/software_engineering_team/tests/test_product_requirements_analysis_agent.py`)
- [x] Ruff lint passes on both changed files
- [ ] Manual verification: run a PRA workflow and confirm questions arrive one sub-phase at a time
- [ ] Verify every question presented has at least 3 selectable options
- [ ] Verify free-text questions (framework, package mgmt) now show spec-informed options

https://claude.ai/code/session_01CHNCeKqXumcc68B4hFDTG4