### PR TITLE
Thinking-flag-per-request

### DIFF
--- a/backend/agents/agentic_team_provisioning/assistant/store.py
+++ b/backend/agents/agentic_team_provisioning/assistant/store.py
@@ -100,7 +100,9 @@ class AgenticTeamStore:
                 "INSERT INTO teams (team_id, name, description, created_at, updated_at) VALUES (?, ?, ?, ?, ?)",
                 (team_id, name, description, now, now),
             )
-        return AgenticTeam(team_id=team_id, name=name, description=description, created_at=now, updated_at=now)
+        return AgenticTeam(
+            team_id=team_id, name=name, description=description, created_at=now, updated_at=now
+        )
 
     def get_team(self, team_id: str) -> Optional[AgenticTeam]:
         with self._lock, self._connect() as conn:
@@ -145,7 +147,9 @@ class AgenticTeamStore:
         now = _now_iso()
         data = process.model_dump(mode="json")
         with self._lock, self._connect() as conn:
-            existing = conn.execute("SELECT 1 FROM processes WHERE process_id = ?", (process.process_id,)).fetchone()
+            existing = conn.execute(
+                "SELECT 1 FROM processes WHERE process_id = ?", (process.process_id,)
+            ).fetchone()
             if existing:
                 conn.execute(
                     "UPDATE processes SET data_json = ?, updated_at = ? WHERE process_id = ?",
@@ -160,7 +164,9 @@ class AgenticTeamStore:
 
     def get_process(self, process_id: str) -> Optional[ProcessDefinition]:
         with self._lock, self._connect() as conn:
-            row = conn.execute("SELECT data_json FROM processes WHERE process_id = ?", (process_id,)).fetchone()
+            row = conn.execute(
+                "SELECT data_json FROM processes WHERE process_id = ?", (process_id,)
+            ).fetchone()
             if not row:
                 return None
         return ProcessDefinition(**json.loads(row["data_json"]))
@@ -214,7 +220,10 @@ class AgenticTeamStore:
                 "INSERT INTO conv_messages (conversation_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
                 (conversation_id, role, content, now),
             )
-            conn.execute("UPDATE conversations SET updated_at = ? WHERE conversation_id = ?", (now, conversation_id))
+            conn.execute(
+                "UPDATE conversations SET updated_at = ? WHERE conversation_id = ?",
+                (now, conversation_id),
+            )
 
     def get_messages(self, conversation_id: str) -> list[ConversationMessage]:
         with self._lock, self._connect() as conn:
@@ -222,7 +231,10 @@ class AgenticTeamStore:
                 "SELECT role, content, timestamp FROM conv_messages WHERE conversation_id = ? ORDER BY id",
                 (conversation_id,),
             ).fetchall()
-        return [ConversationMessage(role=r["role"], content=r["content"], timestamp=r["timestamp"]) for r in rows]
+        return [
+            ConversationMessage(role=r["role"], content=r["content"], timestamp=r["timestamp"])
+            for r in rows
+        ]
 
     def list_conversations(self, team_id: str) -> list[dict]:
         with self._lock, self._connect() as conn:

--- a/backend/agents/agentic_team_provisioning/models.py
+++ b/backend/agents/agentic_team_provisioning/models.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field
 # Enums
 # ---------------------------------------------------------------------------
 
+
 class TriggerType(str, Enum):
     """How a process is initiated."""
 
@@ -43,6 +44,7 @@ class ProcessStatus(str, Enum):
 # Process building blocks
 # ---------------------------------------------------------------------------
 
+
 class ProcessStepAgent(BaseModel):
     """An agent assigned to a process step."""
 
@@ -57,9 +59,15 @@ class ProcessStep(BaseModel):
     name: str = Field(..., description="Human-readable step name")
     description: str = Field(default="", description="What happens in this step")
     step_type: StepType = Field(default=StepType.ACTION)
-    agents: list[ProcessStepAgent] = Field(default_factory=list, description="Agents responsible for this step")
-    next_steps: list[str] = Field(default_factory=list, description="step_ids that follow this step")
-    condition: Optional[str] = Field(default=None, description="Condition expression for decision steps")
+    agents: list[ProcessStepAgent] = Field(
+        default_factory=list, description="Agents responsible for this step"
+    )
+    next_steps: list[str] = Field(
+        default_factory=list, description="step_ids that follow this step"
+    )
+    condition: Optional[str] = Field(
+        default=None, description="Condition expression for decision steps"
+    )
 
 
 class ProcessTrigger(BaseModel):
@@ -92,6 +100,7 @@ class ProcessDefinition(BaseModel):
 # Agentic Team
 # ---------------------------------------------------------------------------
 
+
 class AgenticTeam(BaseModel):
     """Top-level team definition containing processes."""
 
@@ -106,6 +115,7 @@ class AgenticTeam(BaseModel):
 # ---------------------------------------------------------------------------
 # API request / response models
 # ---------------------------------------------------------------------------
+
 
 class CreateTeamRequest(BaseModel):
     name: str = Field(..., min_length=1, max_length=200)
@@ -135,6 +145,7 @@ class TeamDetailResponse(BaseModel):
 # ---------------------------------------------------------------------------
 # Conversation models
 # ---------------------------------------------------------------------------
+
 
 class ConversationMessage(BaseModel):
     role: str = Field(..., pattern=r"^(user|assistant)$")

--- a/backend/agents/blogging/blog_research_agent/agent.py
+++ b/backend/agents/blogging/blog_research_agent/agent.py
@@ -263,7 +263,7 @@ class ResearchAgent:
             prompt += f"Tone/Purpose: {brief_input.tone_or_purpose}\n"
 
         self._report_llm("Parsing brief...", 0.05)
-        parsed = self.llm.complete_json(prompt, temperature=0.0)
+        parsed = self.llm.complete_json(prompt, temperature=0.0, think=False)
 
         return {
             "core_topics": parsed.get("core_topics") or [brief_input.brief],
@@ -287,7 +287,7 @@ class ResearchAgent:
             tone_or_purpose=brief_input.tone_or_purpose or "",
         )
         self._report_llm("Generating search queries...", 0.10)
-        data = self.llm.complete_json(prompt, temperature=0.3)
+        data = self.llm.complete_json(prompt, temperature=0.3, think=False)
         queries_data = data.get("queries") or []
 
         queries: List[SearchQuery] = []
@@ -398,7 +398,7 @@ class ResearchAgent:
                 f"Document content:\n{doc_content}\n"
             )
         )
-        data = self.llm.complete_json(prompt, temperature=0.0)
+        data = self.llm.complete_json(prompt, temperature=0.0, think=False)
         rel = data.get("relevance_score")
         auth = data.get("authority_score")
         acc = data.get("accuracy_score")
@@ -483,7 +483,7 @@ class ResearchAgent:
             f"Document content:\n{doc_content}\n"
         )
         try:
-            data = self.llm.complete_json(prompt, temperature=0.2)
+            data = self.llm.complete_json(prompt, temperature=0.2, think=False)
             summary = data.get("summary") or ""
             key_points = data.get("key_points") or []
         except Exception as e:
@@ -659,7 +659,7 @@ class ResearchAgent:
         )
         self._report_llm("Finding similar topics...", 0.90)
         try:
-            data = self.llm.complete_json(prompt, temperature=0.2)
+            data = self.llm.complete_json(prompt, temperature=0.2, think=False)
             items = data.get("similar_topics") or []
             topics: List[str] = []
             for item in items if isinstance(items, list) else []:

--- a/backend/agents/blogging/tests/test_agent_workflow.py
+++ b/backend/agents/blogging/tests/test_agent_workflow.py
@@ -14,7 +14,7 @@ from llm_service import LLMClient
 class StubLLM(LLMClient):
     """Deterministic LLM stub for tests."""
 
-    def complete_json(self, prompt: str, *, temperature: float = 0.0):
+    def complete_json(self, prompt: str, *, temperature: float = 0.0, think=None, **kwargs):
         lowered = prompt.lower()
         if "core_topics" in lowered and "angle" in lowered and "constraints" in lowered:
             return {

--- a/backend/agents/branding_team/api/main.py
+++ b/backend/agents/branding_team/api/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import logging
 import sqlite3
 import threading
 from dataclasses import dataclass
@@ -31,6 +32,8 @@ from branding_team.models import (
 )
 from branding_team.orchestrator import BrandingTeamOrchestrator
 from branding_team.store import get_default_store
+
+logger = logging.getLogger(__name__)
 
 app = FastAPI(title="Branding Team API", version="2.0.0")
 branding_store = get_default_store()
@@ -453,19 +456,14 @@ def create_brand(client_id: str, payload: CreateBrandRequest) -> Brand:
         existing_brand_material=payload.existing_brand_material,
         wiki_path=payload.wiki_path,
     )
-    # Check if this will be the first brand across all clients (for orphan adoption).
-    existing_brand_count = sum(
-        len(branding_store.list_brands_for_client(c.id)) for c in branding_store.list_clients()
-    )
 
     brand = branding_store.create_brand(client_id=client_id, mission=mission, name=payload.name)
     if not brand:
         raise HTTPException(status_code=404, detail="Client not found")
 
-    # When the very first brand is created, adopt all unattached conversations so
-    # prior chats are automatically associated with this brand.
-    if existing_brand_count == 0:
-        conversation_store.adopt_unattached_conversations(brand.id)
+    # Create the single, permanent conversation for this brand.
+    conv_id = conversation_store.create(brand_id=brand.id, mission=mission)
+    brand = branding_store.update_brand(client_id, brand.id, conversation_id=conv_id)
 
     return brand
 
@@ -530,6 +528,21 @@ def update_brand(client_id: str, brand_id: str, payload: UpdateBrandRequest) -> 
     if not updated:
         raise HTTPException(status_code=404, detail="Brand not found")
     return updated
+
+
+@app.get(
+    "/clients/{client_id}/brands/{brand_id}/conversation", response_model=ConversationStateResponse
+)
+def get_brand_conversation(client_id: str, brand_id: str) -> ConversationStateResponse:
+    """Return the single conversation for a brand."""
+    brand = branding_store.get_brand(client_id, brand_id)
+    if not brand:
+        raise HTTPException(status_code=404, detail="Brand not found")
+    result = conversation_store.get_by_brand_id(brand_id)
+    if not result:
+        raise HTTPException(status_code=404, detail="Brand has no conversation")
+    cid, messages, mission, latest_output = result
+    return _conversation_to_response(cid, brand_id, messages, mission, latest_output, [])
 
 
 # ---------------------------------------------------------------------------
@@ -763,15 +776,8 @@ def create_branding_conversation(
         if not _brand_exists(brand_id):
             raise HTTPException(status_code=404, detail="Brand not found")
 
-    # When no brand_id is provided and exactly one brand exists, auto-assign the
-    # conversation to that brand so all chats stay associated.
-    if not brand_id:
-        all_brands = []
-        for client in branding_store.list_clients():
-            all_brands.extend(branding_store.list_brands_for_client(client.id))
-        if len(all_brands) == 1:
-            brand_id = all_brands[0].id
-
+    # Conversations are created unattached; auto-create-brand logic in
+    # send_message will attach them once the mission has enough info.
     conversation_id = conversation_store.create(brand_id=brand_id)
     initial_message = (req.initial_message or "").strip()
     suggested_questions: List[str] = []
@@ -819,6 +825,15 @@ def create_branding_conversation(
     )
 
 
+def _ensure_default_client() -> str:
+    """Find or create a default workspace client; return client_id."""
+    clients = branding_store.list_clients()
+    if clients:
+        return clients[0].id
+    client = branding_store.create_client(name="My brands")
+    return client.id
+
+
 @app.post("/conversations/{conversation_id}/messages", response_model=ConversationStateResponse)
 def send_branding_conversation_message(
     conversation_id: str, payload: SendMessageRequest
@@ -839,6 +854,23 @@ def send_branding_conversation_message(
     output = _run_orchestrator_if_ready(updated_mission)
     if output is not None:
         conversation_store.update_output(conversation_id, output)
+
+    # Auto-create a brand when the mission has enough info and conversation is unattached.
+    if not brand_id and _mission_has_minimal_required_fields(updated_mission):
+        client_id = _ensure_default_client()
+        brand = branding_store.create_brand(
+            client_id=client_id,
+            mission=updated_mission,
+            name=updated_mission.company_name,
+        )
+        if brand:
+            conversation_store.set_brand(conversation_id, brand.id)
+            branding_store.update_brand(client_id, brand.id, conversation_id=conversation_id)
+            if output:
+                branding_store.append_brand_version(client_id, brand.id, output)
+            brand_id = brand.id
+            logger.info("Auto-created brand %s from conversation %s", brand.id, conversation_id)
+
     messages, mission, latest_output = conversation_store.get(conversation_id) or (
         [],
         updated_mission,

--- a/backend/agents/branding_team/assistant/store.py
+++ b/backend/agents/branding_team/assistant/store.py
@@ -108,6 +108,30 @@ class BrandingConversationStore:
             conn.execute("ALTER TABLE conversations ADD COLUMN updated_at TEXT")
             conn.execute("UPDATE conversations SET updated_at = ? WHERE updated_at IS NULL", (ts,))
 
+        # Enforce one conversation per brand.  For brands with multiple conversations,
+        # keep the one with the most messages and detach the rest.
+        dupes = conn.execute(
+            "SELECT brand_id, COUNT(*) FROM conversations WHERE brand_id IS NOT NULL GROUP BY brand_id HAVING COUNT(*) > 1"
+        ).fetchall()
+        for brand_id, _ in dupes:
+            rows = conn.execute(
+                "SELECT c.conversation_id, COUNT(m.id) AS cnt"
+                " FROM conversations c LEFT JOIN conv_messages m ON m.conversation_id = c.conversation_id"
+                " WHERE c.brand_id = ? GROUP BY c.conversation_id ORDER BY cnt DESC",
+                (brand_id,),
+            ).fetchall()
+            # Keep the first (most messages), detach the rest
+            for row in rows[1:]:
+                conn.execute(
+                    "UPDATE conversations SET brand_id = NULL WHERE conversation_id = ?",
+                    (row[0],),
+                )
+                logger.info("Detached duplicate conversation %s from brand %s", row[0], brand_id)
+        conn.execute(
+            "CREATE UNIQUE INDEX IF NOT EXISTS idx_conv_brand_unique ON conversations(brand_id)"
+            " WHERE brand_id IS NOT NULL"
+        )
+
     @contextlib.contextmanager
     def _db(self) -> Iterator[sqlite3.Connection]:
         if self._mem_conn is not None:
@@ -218,22 +242,29 @@ class BrandingConversationStore:
             )
         return result.rowcount > 0
 
-    def adopt_unattached_conversations(self, brand_id: str) -> int:
-        """Bulk-assign all conversations with ``brand_id IS NULL`` to *brand_id*.
+    def get_by_brand_id(
+        self, brand_id: str
+    ) -> Optional[tuple[str, List[_StoredMessage], BrandingMission, Optional[TeamOutput]]]:
+        """Return the single conversation for *brand_id*, or None.
 
-        Used when the first brand is created so that every prior conversation
-        is automatically associated with it.  Returns the number of rows updated.
+        Returns ``(conversation_id, messages, mission, latest_output)``.
         """
-        ts = datetime.now(tz=timezone.utc).isoformat()
         with self._db() as conn:
-            result = conn.execute(
-                "UPDATE conversations SET brand_id = ?, updated_at = ? WHERE brand_id IS NULL",
-                (brand_id, ts),
-            )
-        count = result.rowcount
-        if count:
-            logger.info("Adopted %d unattached conversation(s) → brand %s", count, brand_id)
-        return count
+            row = conn.execute(
+                "SELECT conversation_id, mission_json, latest_output_json FROM conversations WHERE brand_id = ?",
+                (brand_id,),
+            ).fetchone()
+            if row is None:
+                return None
+            cid = str(row[0])
+            mission = BrandingMission.model_validate_json(row[1])
+            latest_output = TeamOutput.model_validate_json(row[2]) if row[2] else None
+            msg_rows = conn.execute(
+                "SELECT role, content, timestamp FROM conv_messages WHERE conversation_id = ? ORDER BY id",
+                (cid,),
+            ).fetchall()
+            messages = [_StoredMessage(role=r[0], content=r[1], timestamp=r[2]) for r in msg_rows]
+        return (cid, messages, mission, latest_output)
 
     def list_conversations(self, brand_id: Optional[str] = None) -> List[ConversationSummary]:
         with self._db() as conn:

--- a/backend/agents/branding_team/models.py
+++ b/backend/agents/branding_team/models.py
@@ -521,6 +521,7 @@ class Brand(BaseModel):
     current_phase: BrandPhase = BrandPhase.STRATEGIC_CORE
     mission: BrandingMission
     latest_output: Optional[TeamOutput] = None
+    conversation_id: Optional[str] = None
     version: int = 0
     history: List[BrandVersionSummary] = Field(default_factory=list)
     created_at: str = ""

--- a/backend/agents/branding_team/store.py
+++ b/backend/agents/branding_team/store.py
@@ -189,6 +189,7 @@ class BrandingStore:
         mission: Optional[BrandingMission] = None,
         status: Optional[BrandStatus] = None,
         name: Optional[str] = None,
+        conversation_id: Optional[str] = None,
     ) -> Optional[Brand]:
         with self._db() as conn:
             row = conn.execute(
@@ -205,6 +206,8 @@ class BrandingStore:
                 updates["status"] = status
             if name is not None:
                 updates["name"] = name
+            if conversation_id is not None:
+                updates["conversation_id"] = conversation_id
             updated = brand.model_copy(update=updates)
             conn.execute(
                 "UPDATE brands SET data = ? WHERE id = ? AND client_id = ?",

--- a/backend/agents/branding_team/tests/test_api.py
+++ b/backend/agents/branding_team/tests/test_api.py
@@ -319,28 +319,23 @@ def test_get_conversation_404_for_unknown_id() -> None:
     assert resp.status_code == 404
 
 
-def test_list_conversations_and_attach_brand() -> None:
-    conv = client.post("/conversations", json={})
-    assert conv.status_code == 200
-    conversation_id = conv.json()["conversation_id"]
-
-    create_c = client.post("/clients", json={"name": "Attach Client"})
+def test_brand_creation_auto_creates_conversation() -> None:
+    """Creating a brand auto-creates a single permanent conversation."""
+    create_c = client.post("/clients", json={"name": "AutoConv Client"})
     client_id = create_c.json()["id"]
     create_b = client.post(
         f"/clients/{client_id}/brands",
         json={
-            "company_name": "AttachCo",
-            "company_description": "Company for attaching chat conversations",
+            "company_name": "AutoConvCo",
+            "company_description": "Company with auto-created conversation",
             "target_audience": "teams",
         },
     )
-    brand_id = create_b.json()["id"]
+    assert create_b.status_code == 201
+    brand = create_b.json()
+    assert brand["conversation_id"] is not None
 
-    attach = client.post(f"/conversations/{conversation_id}/brand", json={"brand_id": brand_id})
-    assert attach.status_code == 200
-    assert attach.json()["brand_id"] == brand_id
-
-    listed = client.get("/conversations")
-    assert listed.status_code == 200
-    rows = listed.json()
-    assert any(r["conversation_id"] == conversation_id and r["brand_id"] == brand_id for r in rows)
+    # The brand's conversation endpoint should return the conversation.
+    conv_resp = client.get(f"/clients/{client_id}/brands/{brand['id']}/conversation")
+    assert conv_resp.status_code == 200
+    assert conv_resp.json()["conversation_id"] == brand["conversation_id"]

--- a/backend/agents/llm_service/clients/dummy.py
+++ b/backend/agents/llm_service/clients/dummy.py
@@ -142,6 +142,7 @@ class DummyLLMClient(LLMClient):
         temperature: float = 0.7,
         max_tokens: Optional[int] = None,
         system_prompt: Optional[str] = None,
+        think: Optional[bool] = None,
     ) -> str:
         self._request_count += 1
         return "Dummy text completion (no LLM)."
@@ -153,6 +154,7 @@ class DummyLLMClient(LLMClient):
         temperature: float = 0.0,
         system_prompt: Optional[str] = None,
         tools: Optional[list] = None,
+        think: Optional[bool] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         lowered = prompt.lower()

--- a/backend/agents/llm_service/clients/ollama.py
+++ b/backend/agents/llm_service/clients/ollama.py
@@ -460,13 +460,19 @@ class OllamaLLMClient(LLMClient):
         )
 
     def _should_enable_thinking(self) -> bool:
-        """Enable thinking mode for all models by default; disable via LLM_ENABLE_THINKING=false."""
+        """Global default: enable thinking for all models; disable via LLM_ENABLE_THINKING=false."""
         env_val = (
             os.environ.get(llm_config.ENV_LLM_ENABLE_THINKING)
             or os.environ.get(llm_config.ENV_LLM_ENABLE_THINKING_SW)
             or ""
         ).lower()
         return env_val != "false"
+
+    def _resolve_think(self, think: Optional[bool]) -> bool:
+        """Resolve per-call think override against global default."""
+        if think is not None:
+            return think
+        return self._should_enable_thinking()
 
     def _parse_response_content(self, data: dict) -> str:
         """Extract content or tool_calls from OpenAI-compatible response.
@@ -564,6 +570,7 @@ class OllamaLLMClient(LLMClient):
                                 content_parts: list[str] = []
                                 finish_reason: Optional[str] = None
                                 tool_call_buffers: dict[int, dict] = {}
+                                has_reasoning: bool = False
                                 for line in response.iter_lines():
                                     if not line or not line.startswith("data:"):
                                         continue
@@ -582,6 +589,14 @@ class OllamaLLMClient(LLMClient):
                                         piece = delta.get("content")
                                         if piece:
                                             content_parts.append(piece)
+                                        # Track reasoning tokens so we can distinguish
+                                        # "model thought but produced no answer" from
+                                        # "model returned nothing at all".
+                                        reasoning = delta.get("reasoning_content") or delta.get(
+                                            "thinking"
+                                        )
+                                        if reasoning:
+                                            has_reasoning = True
                                         for tc in delta.get("tool_calls") or []:
                                             idx = tc.get("index", 0)
                                             if idx not in tool_call_buffers:
@@ -604,7 +619,20 @@ class OllamaLLMClient(LLMClient):
                                         if fr:
                                             finish_reason = fr
                                 elapsed = time.monotonic() - t0
-                                logger.info("LLM streaming response complete in %.1fs", elapsed)
+                                joined_content = "".join(content_parts)
+                                logger.info(
+                                    "LLM streaming response complete in %.1fs (content=%d chars, reasoning=%s, finish=%s)",
+                                    elapsed,
+                                    len(joined_content),
+                                    has_reasoning,
+                                    finish_reason or "stop",
+                                )
+                                if not joined_content.strip() and has_reasoning:
+                                    logger.warning(
+                                        "LLM produced reasoning tokens but no content — "
+                                        "model likely spent its token budget on thinking. "
+                                        "Consider raising max_tokens or disabling thinking (LLM_ENABLE_THINKING=false)."
+                                    )
                                 tool_calls = None
                                 if tool_call_buffers:
                                     tool_calls = []
@@ -621,7 +649,7 @@ class OllamaLLMClient(LLMClient):
                                     "choices": [
                                         {
                                             "message": {
-                                                "content": "".join(content_parts),
+                                                "content": joined_content,
                                                 "tool_calls": tool_calls,
                                             },
                                             "finish_reason": finish_reason or "stop",
@@ -822,12 +850,19 @@ class OllamaLLMClient(LLMClient):
         *,
         temperature: float = 0.0,
         system_prompt: Optional[str] = None,
+        think: Optional[bool] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """Run the model with JSON mode and return a decoded dict."""
         max_retries, backoff_base, backoff_max = _parse_retry_config()
         sem = _get_ollama_semaphore()
-        logger.info("LLM request: provider=ollama model=%s base_url=%s", self.model, self.base_url)
+        use_think = self._resolve_think(think)
+        logger.info(
+            "LLM request: provider=ollama model=%s base_url=%s think=%s",
+            self.model,
+            self.base_url,
+            use_think,
+        )
         system_message = system_prompt or (
             "You are a strict JSON generator. Respond with a single valid JSON object only, "
             "no explanatory text, no Markdown, no code fences. "
@@ -855,7 +890,7 @@ class OllamaLLMClient(LLMClient):
                 {"role": "system", "content": system_message},
                 {"role": "user", "content": prompt},
             ],
-            "think": self._should_enable_thinking(),
+            "think": use_think,
         }
         if tools:
             payload["tools"] = tools
@@ -890,6 +925,7 @@ class OllamaLLMClient(LLMClient):
                 backoff_base=backoff_base,
                 backoff_max=backoff_max,
                 sem=sem,
+                use_think=use_think,
             )
         except LLMJsonParseError:
             # If content starts with '{' but is unparseable, the server likely cut off the
@@ -911,6 +947,7 @@ class OllamaLLMClient(LLMClient):
                     backoff_base=backoff_base,
                     backoff_max=backoff_max,
                     sem=sem,
+                    use_think=use_think,
                 )
             raise
 
@@ -947,6 +984,7 @@ class OllamaLLMClient(LLMClient):
         backoff_base: float,
         backoff_max: float,
         sem: threading.BoundedSemaphore,
+        use_think: bool = True,
     ) -> Dict[str, Any]:
         """On truncation: continue via multi-turn conversation, then parse JSON (same as SE team)."""
         accumulated = initial_partial
@@ -969,7 +1007,7 @@ class OllamaLLMClient(LLMClient):
                 "max_tokens": max_tokens,
                 "response_format": {"type": "json_object"},
                 "messages": messages,
-                "think": self._should_enable_thinking(),
+                "think": use_think,
             }
 
             try:
@@ -999,12 +1037,17 @@ class OllamaLLMClient(LLMClient):
         max_tokens: Optional[int] = None,
         system_prompt: Optional[str] = None,
         tools: Optional[list] = None,
+        think: Optional[bool] = None,
     ) -> str:
         """Return raw text from the model (no JSON mode). Pass tools for function/tool calling."""
         max_retries, backoff_base, backoff_max = _parse_retry_config()
         sem = _get_ollama_semaphore()
+        use_think = self._resolve_think(think)
         logger.info(
-            "LLM request (text): provider=ollama model=%s base_url=%s", self.model, self.base_url
+            "LLM request (text): provider=ollama model=%s base_url=%s think=%s",
+            self.model,
+            self.base_url,
+            use_think,
         )
         env_max = os.environ.get(llm_config.ENV_LLM_MAX_TOKENS) or os.environ.get(
             llm_config.ENV_LLM_MAX_TOKENS_SW
@@ -1023,7 +1066,7 @@ class OllamaLLMClient(LLMClient):
             "temperature": temperature,
             "max_tokens": max_tokens,
             "messages": [{"role": "user", "content": prompt}],
-            "think": self._should_enable_thinking(),
+            "think": use_think,
         }
         if system_prompt:
             payload["messages"] = [
@@ -1045,6 +1088,7 @@ class OllamaLLMClient(LLMClient):
                 backoff_base=backoff_base,
                 backoff_max=backoff_max,
                 sem=sem,
+                use_think=use_think,
             )
 
     def _complete_text_with_continuation(
@@ -1058,6 +1102,7 @@ class OllamaLLMClient(LLMClient):
         backoff_base: float,
         backoff_max: float,
         sem: threading.BoundedSemaphore,
+        use_think: bool = True,
     ) -> str:
         """On truncation: continue via multi-turn conversation, return merged text."""
         accumulated = initial_partial
@@ -1082,7 +1127,7 @@ class OllamaLLMClient(LLMClient):
                 "temperature": temperature,
                 "max_tokens": max_tokens,
                 "messages": messages,
-                "think": self._should_enable_thinking(),
+                "think": use_think,
             }
             try:
                 next_content = self._ollama_post(

--- a/backend/agents/llm_service/interface.py
+++ b/backend/agents/llm_service/interface.py
@@ -103,6 +103,7 @@ class LLMClient(ABC):
         temperature: float = 0.0,
         system_prompt: Optional[str] = None,
         tools: Optional[list] = None,
+        think: Optional[bool] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         """
@@ -112,6 +113,11 @@ class LLMClient(ABC):
         When the model invokes a tool, the returned dict has the key ``__tool_calls__`` whose
         value is a list of tool-call objects (id, type, function.name, function.arguments).
         Optional kwargs may include expected_keys, decomposition_hints for PA-style robust extraction.
+
+        ``think`` controls chain-of-thought / reasoning mode:
+        - ``None`` (default): use the global setting (``LLM_ENABLE_THINKING`` env var).
+        - ``True``: force thinking on for this call.
+        - ``False``: force thinking off (use for simple extraction / scoring).
         """
         ...
 
@@ -123,18 +129,22 @@ class LLMClient(ABC):
         max_tokens: Optional[int] = None,
         system_prompt: Optional[str] = None,
         tools: Optional[list] = None,
+        think: Optional[bool] = None,
     ) -> str:
         """
         Run the model and return raw text.
 
         Override in implementations that support it. Default uses complete_json and extracts text.
         Pass ``tools`` for function/tool calling; tool-call responses are returned as JSON strings.
+
+        ``think`` controls chain-of-thought / reasoning mode (see ``complete_json``).
         """
         result = self.complete_json(
             prompt,
             temperature=temperature,
             system_prompt=system_prompt,
             tools=tools,
+            think=think,
         )
         if isinstance(result, dict) and len(result) == 1 and "text" in result:
             return str(result["text"])
@@ -150,6 +160,10 @@ class LLMClient(ABC):
         return 16384
 
     # Alias for SE code that uses complete_text
-    def complete_text(self, prompt: str, *, temperature: float = 0.0) -> str:
+    def complete_text(
+        self, prompt: str, *, temperature: float = 0.0, think: Optional[bool] = None
+    ) -> str:
         """Alias for complete() for backward compatibility with SE team."""
-        return self.complete(prompt, temperature=temperature, max_tokens=None, system_prompt=None)
+        return self.complete(
+            prompt, temperature=temperature, max_tokens=None, system_prompt=None, think=think
+        )

--- a/backend/agents/personal_assistant_team/calendar_agent/agent.py
+++ b/backend/agents/personal_assistant_team/calendar_agent/agent.py
@@ -161,6 +161,7 @@ class CalendarAgent:
                 prompt,
                 temperature=0.1,
                 expected_keys=["events", "ambiguities"],
+                think=False,
             )
         except JSONExtractionFailure as e:
             logger.error("Failed to parse event from text (JSON extraction failed):\n%s", e)
@@ -348,6 +349,7 @@ class CalendarAgent:
                 prompt,
                 temperature=0.3,
                 expected_keys=["suggestions"],
+                think=False,
             )
         except JSONExtractionFailure as e:
             logger.error("Failed to generate schedule suggestions (JSON extraction failed):\n%s", e)

--- a/backend/agents/personal_assistant_team/deal_finder_agent/agent.py
+++ b/backend/agents/personal_assistant_team/deal_finder_agent/agent.py
@@ -254,6 +254,7 @@ class DealFinderAgent:
                 prompt,
                 temperature=0.2,
                 expected_keys=["relevance_score", "matching_preferences"],
+                think=False,
             )
             deal.relevance_score = float(data.get("relevance_score", 0.5))
             deal.matching_preferences = data.get("matching_preferences", [])
@@ -348,6 +349,7 @@ class DealFinderAgent:
                 prompt,
                 temperature=0.4,
                 expected_keys=["queries"],
+                think=False,
             )
             queries = data.get("queries", [])
         except JSONExtractionFailure as e:

--- a/backend/agents/personal_assistant_team/doc_generator_agent/agent.py
+++ b/backend/agents/personal_assistant_team/doc_generator_agent/agent.py
@@ -121,6 +121,7 @@ class DocGeneratorAgent:
                 prompt,
                 temperature=0.3,
                 expected_keys=["title", "content"],
+                think=False,
             )
         except JSONExtractionFailure as e:
             logger.error("Failed to generate process doc (JSON extraction failed):\n%s", e)
@@ -180,6 +181,7 @@ class DocGeneratorAgent:
                 prompt,
                 temperature=0.2,
                 expected_keys=["title", "items"],
+                think=False,
             )
         except JSONExtractionFailure as e:
             logger.error("Failed to generate checklist (JSON extraction failed):\n%s", e)
@@ -232,6 +234,7 @@ class DocGeneratorAgent:
                 prompt,
                 temperature=0.3,
                 expected_keys=["title", "content", "fields"],
+                think=False,
             )
         except JSONExtractionFailure as e:
             logger.error("Failed to generate template (JSON extraction failed):\n%s", e)
@@ -305,6 +308,7 @@ class DocGeneratorAgent:
                 prompt,
                 temperature=0.2,
                 expected_keys=["title", "content"],
+                think=False,
             )
         except JSONExtractionFailure as e:
             logger.error("Failed to generate SOP (JSON extraction failed):\n%s", e)
@@ -372,6 +376,7 @@ class DocGeneratorAgent:
                 prompt,
                 temperature=0.3,
                 expected_keys=["title", "content"],
+                think=False,
             )
         except JSONExtractionFailure as e:
             logger.error("Failed to generate meeting agenda (JSON extraction failed):\n%s", e)

--- a/backend/agents/personal_assistant_team/email_agent/agent.py
+++ b/backend/agents/personal_assistant_team/email_agent/agent.py
@@ -141,6 +141,7 @@ class EmailAgent:
                     "action_items",
                     "sentiment",
                 ],
+                think=False,
             )
         except JSONExtractionFailure as e:
             logger.error("Failed to summarize email (JSON extraction failed):\n%s", e)
@@ -218,7 +219,7 @@ class EmailAgent:
         )
 
         try:
-            data = self.llm.complete_json(prompt, temperature=0.1)
+            data = self.llm.complete_json(prompt, temperature=0.1, think=False)
             return data.get("events", [])
         except Exception as e:
             logger.error("Failed to extract events: %s", e)
@@ -286,7 +287,7 @@ class EmailAgent:
         )
 
         try:
-            data = self.llm.complete_json(prompt, temperature=0.4)
+            data = self.llm.complete_json(prompt, temperature=0.4, think=False)
         except Exception as e:
             logger.error("Failed to draft email: %s", e)
             return DraftResult(
@@ -318,7 +319,7 @@ class EmailAgent:
         )
 
         try:
-            data = self.llm.complete_json(prompt, temperature=0.5)
+            data = self.llm.complete_json(prompt, temperature=0.5, think=False)
             return data.get("replies", [])
         except Exception as e:
             logger.error("Failed to generate quick replies: %s", e)

--- a/backend/agents/personal_assistant_team/orchestrator/agent.py
+++ b/backend/agents/personal_assistant_team/orchestrator/agent.py
@@ -84,6 +84,7 @@ class PersonalAssistantOrchestrator:
                 prompt,
                 temperature=0.1,
                 expected_keys=["primary_intent", "secondary_intents", "entities", "confidence"],
+                think=False,
             )
         except JSONExtractionFailure as e:
             logger.error("Intent classification failed with JSON extraction error:\n%s", e)
@@ -599,7 +600,7 @@ class PersonalAssistantOrchestrator:
         )
 
         try:
-            data = self.llm.complete_json(prompt, temperature=0.4)
+            data = self.llm.complete_json(prompt, temperature=0.4, think=False)
             response_message = data.get("message", "I've processed your request.")
             suggestions = data.get("follow_up_suggestions", [])
         except Exception as e:

--- a/backend/agents/personal_assistant_team/reservation_agent/agent.py
+++ b/backend/agents/personal_assistant_team/reservation_agent/agent.py
@@ -218,6 +218,7 @@ class ReservationAgent:
                 prompt,
                 temperature=0.1,
                 expected_keys=["reservation_type", "venue_name", "datetime", "party_size", "notes"],
+                think=False,
             )
             return data
         except JSONExtractionFailure as e:

--- a/backend/agents/personal_assistant_team/shared/llm.py
+++ b/backend/agents/personal_assistant_team/shared/llm.py
@@ -93,6 +93,7 @@ class LLMClient(_BaseLLMClient):
         max_tokens: Optional[int] = None,
         system_prompt: Optional[str] = None,
         json_mode: bool = False,
+        think: Optional[bool] = None,
     ) -> str:
         """Override in subclasses to call the LLM and return raw text."""
         raise NotImplementedError("Subclasses must implement _ollama_complete")
@@ -117,9 +118,14 @@ class LLMClient(_BaseLLMClient):
         continuation_attempts = 0
         decomposition_attempts = 0
 
+        think = kwargs.pop("think", None)
         # --- direct attempt ---
         response = self._ollama_complete(
-            prompt, temperature=temperature, system_prompt=system_prompt, json_mode=True
+            prompt,
+            temperature=temperature,
+            system_prompt=system_prompt,
+            json_mode=True,
+            think=think,
         )
         raw_responses.append(response)
         attempts_made += 1
@@ -138,6 +144,7 @@ class LLMClient(_BaseLLMClient):
                 temperature=temperature,
                 system_prompt=system_prompt,
                 json_mode=True,
+                think=think,
             )
             raw_responses.append(continuation)
             attempts_made += 1
@@ -154,7 +161,11 @@ class LLMClient(_BaseLLMClient):
             if decomposition_attempts >= self.MAX_DECOMPOSITION_ATTEMPTS:
                 break
             resp = self._ollama_complete(
-                subtask_prompt, temperature=temperature, system_prompt=system_prompt, json_mode=True
+                subtask_prompt,
+                temperature=temperature,
+                system_prompt=system_prompt,
+                json_mode=True,
+                think=think,
             )
             raw_responses.append(resp)
             attempts_made += 1
@@ -311,12 +322,14 @@ class _PALLMClientWrapper(LLMClient):
         max_tokens: Optional[int] = None,
         system_prompt: Optional[str] = None,
         json_mode: bool = False,
+        think: Optional[bool] = None,
     ) -> str:
         return self._inner.complete(
             prompt,
             temperature=temperature,
             max_tokens=max_tokens or 4096,
             system_prompt=system_prompt,
+            think=think,
         )
 
     def complete_json(
@@ -325,6 +338,7 @@ class _PALLMClientWrapper(LLMClient):
         *,
         temperature: float = 0.0,
         system_prompt: Optional[str] = None,
+        think: Optional[bool] = None,
         **kwargs: Any,
     ) -> Dict[str, Any]:
         try:
@@ -332,6 +346,7 @@ class _PALLMClientWrapper(LLMClient):
                 prompt,
                 temperature=temperature,
                 system_prompt=system_prompt,
+                think=think,
             )
         except LLMJsonParseError as e:
             raise JSONExtractionFailure(

--- a/backend/agents/personal_assistant_team/task_agent/agent.py
+++ b/backend/agents/personal_assistant_team/task_agent/agent.py
@@ -226,6 +226,7 @@ class TaskAgent:
                 prompt,
                 temperature=0.2,
                 expected_keys=["items", "list_name"],
+                think=False,
             )
         except JSONExtractionFailure as e:
             logger.error("Failed to parse tasks (JSON extraction failed):\n%s", e)
@@ -421,6 +422,7 @@ class TaskAgent:
                 prompt,
                 temperature=0.1,
                 expected_keys=["categorized_items"],
+                think=False,
             )
             return data.get("categorized_items", [])
         except JSONExtractionFailure as e:
@@ -472,6 +474,7 @@ class TaskAgent:
                 prompt,
                 temperature=0.4,
                 expected_keys=["suggestions"],
+                think=False,
             )
             return data.get("suggestions", [])
         except JSONExtractionFailure as e:

--- a/backend/agents/personal_assistant_team/tests/test_robust_json.py
+++ b/backend/agents/personal_assistant_team/tests/test_robust_json.py
@@ -23,6 +23,7 @@ class MockLLMClient(LLMClient):
         max_tokens=None,
         system_prompt=None,
         json_mode: bool = False,
+        think=None,
     ) -> str:
         self.prompts.append(prompt)
         if self.call_count < len(self.responses):

--- a/backend/agents/personal_assistant_team/user_profile_agent/agent.py
+++ b/backend/agents/personal_assistant_team/user_profile_agent/agent.py
@@ -115,6 +115,7 @@ class UserProfileAgent:
                 prompt,
                 temperature=0.2,
                 expected_keys=["extracted_info", "reasoning"],
+                think=False,
             )
         except JSONExtractionFailure as e:
             logger.error("Failed to extract preferences (JSON extraction failed):\n%s", e)

--- a/backend/agents/software_engineering_team/api/main.py
+++ b/backend/agents/software_engineering_team/api/main.py
@@ -279,6 +279,10 @@ class PendingQuestion(BaseModel):
         description="Selectable answer options. Always includes an 'other' option automatically.",
     )
     required: bool = Field(default=True, description="Whether this question must be answered.")
+    allow_multiple: bool = Field(
+        default=False,
+        description="True = checkboxes (select all that apply), False = radio buttons (select one).",
+    )
     source: str = Field(
         default="planning",
         description="Source of the question: planning, tech_lead, execution, etc.",

--- a/backend/agents/software_engineering_team/product_requirements_analysis_agent/agent.py
+++ b/backend/agents/software_engineering_team/product_requirements_analysis_agent/agent.py
@@ -509,12 +509,32 @@ SOP_PHASE1_QUESTIONS: Dict[SOPSubPhase, List[Dict[str, Any]]] = {
             "category": "business",
             "allow_multiple": True,
             "options": [
-                {"id": "opt_jira", "label": "Jira", "rationale": "Project tracking and issue management."},
-                {"id": "opt_confluence", "label": "Confluence", "rationale": "Documentation and knowledge base."},
-                {"id": "opt_datadog", "label": "Datadog", "rationale": "Monitoring and observability platform."},
-                {"id": "opt_pagerduty", "label": "PagerDuty", "rationale": "Incident management and alerting."},
+                {
+                    "id": "opt_jira",
+                    "label": "Jira",
+                    "rationale": "Project tracking and issue management.",
+                },
+                {
+                    "id": "opt_confluence",
+                    "label": "Confluence",
+                    "rationale": "Documentation and knowledge base.",
+                },
+                {
+                    "id": "opt_datadog",
+                    "label": "Datadog",
+                    "rationale": "Monitoring and observability platform.",
+                },
+                {
+                    "id": "opt_pagerduty",
+                    "label": "PagerDuty",
+                    "rationale": "Incident management and alerting.",
+                },
                 {"id": "opt_splunk", "label": "Splunk", "rationale": "Log management and SIEM."},
-                {"id": "opt_other", "label": "Other", "rationale": "Specify your proprietary tools."},
+                {
+                    "id": "opt_other",
+                    "label": "Other",
+                    "rationale": "Specify your proprietary tools.",
+                },
             ],
             "depends_on": {"P1.tools.a": ["Proprietary"]},
         },
@@ -525,11 +545,27 @@ SOP_PHASE1_QUESTIONS: Dict[SOPSubPhase, List[Dict[str, Any]]] = {
             "allow_multiple": True,
             "options": [
                 {"id": "opt_docker", "label": "Docker", "rationale": "Containerization standard."},
-                {"id": "opt_kubernetes", "label": "Kubernetes", "rationale": "Container orchestration."},
-                {"id": "opt_postgres", "label": "PostgreSQL", "rationale": "Full-featured relational database."},
-                {"id": "opt_redis", "label": "Redis", "rationale": "In-memory data store and cache."},
+                {
+                    "id": "opt_kubernetes",
+                    "label": "Kubernetes",
+                    "rationale": "Container orchestration.",
+                },
+                {
+                    "id": "opt_postgres",
+                    "label": "PostgreSQL",
+                    "rationale": "Full-featured relational database.",
+                },
+                {
+                    "id": "opt_redis",
+                    "label": "Redis",
+                    "rationale": "In-memory data store and cache.",
+                },
                 {"id": "opt_nginx", "label": "Nginx", "rationale": "Web server and reverse proxy."},
-                {"id": "opt_other", "label": "Other", "rationale": "Specify your open source tools."},
+                {
+                    "id": "opt_other",
+                    "label": "Other",
+                    "rationale": "Specify your open source tools.",
+                },
             ],
             "depends_on": {"P1.tools.a": ["Open Source"]},
         },
@@ -616,13 +652,42 @@ SOP_PHASE1_QUESTIONS: Dict[SOPSubPhase, List[Dict[str, Any]]] = {
             "category": "architecture",
             "allow_multiple": True,
             "options": [
-                {"id": "opt_fastapi", "label": "FastAPI", "rationale": "Modern Python async API framework.", "is_default": True},
-                {"id": "opt_django", "label": "Django", "rationale": "Full-featured Python web framework."},
-                {"id": "opt_flask", "label": "Flask", "rationale": "Lightweight Python web framework."},
-                {"id": "opt_express", "label": "Express.js", "rationale": "Minimal Node.js web framework."},
-                {"id": "opt_nextjs", "label": "Next.js", "rationale": "React meta-framework with SSR."},
-                {"id": "opt_spring", "label": "Spring Boot", "rationale": "Enterprise Java framework."},
-                {"id": "opt_rails", "label": "Ruby on Rails", "rationale": "Convention-over-configuration web framework."},
+                {
+                    "id": "opt_fastapi",
+                    "label": "FastAPI",
+                    "rationale": "Modern Python async API framework.",
+                    "is_default": True,
+                },
+                {
+                    "id": "opt_django",
+                    "label": "Django",
+                    "rationale": "Full-featured Python web framework.",
+                },
+                {
+                    "id": "opt_flask",
+                    "label": "Flask",
+                    "rationale": "Lightweight Python web framework.",
+                },
+                {
+                    "id": "opt_express",
+                    "label": "Express.js",
+                    "rationale": "Minimal Node.js web framework.",
+                },
+                {
+                    "id": "opt_nextjs",
+                    "label": "Next.js",
+                    "rationale": "React meta-framework with SSR.",
+                },
+                {
+                    "id": "opt_spring",
+                    "label": "Spring Boot",
+                    "rationale": "Enterprise Java framework.",
+                },
+                {
+                    "id": "opt_rails",
+                    "label": "Ruby on Rails",
+                    "rationale": "Convention-over-configuration web framework.",
+                },
                 {"id": "opt_other", "label": "Other", "rationale": "Specify your framework."},
             ],
             "depends_on": None,
@@ -634,11 +699,28 @@ SOP_PHASE1_QUESTIONS: Dict[SOPSubPhase, List[Dict[str, Any]]] = {
             "allow_multiple": False,
             "options": [
                 {"id": "opt_pip", "label": "pip", "rationale": "Standard Python package manager."},
-                {"id": "opt_poetry", "label": "Poetry", "rationale": "Modern Python dependency management.", "is_default": True},
+                {
+                    "id": "opt_poetry",
+                    "label": "Poetry",
+                    "rationale": "Modern Python dependency management.",
+                    "is_default": True,
+                },
                 {"id": "opt_npm", "label": "npm", "rationale": "Default Node.js package manager."},
-                {"id": "opt_yarn", "label": "yarn", "rationale": "Fast, reliable Node.js package manager."},
-                {"id": "opt_pnpm", "label": "pnpm", "rationale": "Efficient, disk-space-saving Node.js package manager."},
-                {"id": "opt_maven", "label": "Maven", "rationale": "Java/JVM build and dependency tool."},
+                {
+                    "id": "opt_yarn",
+                    "label": "yarn",
+                    "rationale": "Fast, reliable Node.js package manager.",
+                },
+                {
+                    "id": "opt_pnpm",
+                    "label": "pnpm",
+                    "rationale": "Efficient, disk-space-saving Node.js package manager.",
+                },
+                {
+                    "id": "opt_maven",
+                    "label": "Maven",
+                    "rationale": "Java/JVM build and dependency tool.",
+                },
                 {"id": "opt_gradle", "label": "Gradle", "rationale": "Flexible JVM build tool."},
                 {"id": "opt_cargo", "label": "Cargo", "rationale": "Rust package manager."},
                 {"id": "opt_other", "label": "Other", "rationale": "Specify your preference."},
@@ -1150,10 +1232,27 @@ SOP_PHASE1_QUESTIONS: Dict[SOPSubPhase, List[Dict[str, Any]]] = {
             "category": "business",
             "allow_multiple": False,
             "options": [
-                {"id": "opt_security_first", "label": "Security > Performance > Simplicity", "rationale": "Security-first approach for sensitive applications."},
-                {"id": "opt_performance_first", "label": "Performance > Scalability > Simplicity", "rationale": "Performance-oriented for high-traffic applications."},
-                {"id": "opt_simplicity_first", "label": "Simplicity > Frugality > Security", "rationale": "Simplicity-first for rapid development and maintainability.", "is_default": True},
-                {"id": "opt_other", "label": "Other", "rationale": "Specify your custom priority ranking."},
+                {
+                    "id": "opt_security_first",
+                    "label": "Security > Performance > Simplicity",
+                    "rationale": "Security-first approach for sensitive applications.",
+                },
+                {
+                    "id": "opt_performance_first",
+                    "label": "Performance > Scalability > Simplicity",
+                    "rationale": "Performance-oriented for high-traffic applications.",
+                },
+                {
+                    "id": "opt_simplicity_first",
+                    "label": "Simplicity > Frugality > Security",
+                    "rationale": "Simplicity-first for rapid development and maintainability.",
+                    "is_default": True,
+                },
+                {
+                    "id": "opt_other",
+                    "label": "Other",
+                    "rationale": "Specify your custom priority ranking.",
+                },
             ],
             "depends_on": None,
         },
@@ -1190,13 +1289,26 @@ def _sop_phase1_fallback_questions() -> List[OpenQuestion]:
                 # Add "Other" if not present
                 if not any(o.label.lower() == "other" for o in options):
                     options.append(
-                        QuestionOption(id="opt_other", label="Other", is_default=False, rationale="Specify your preference.", confidence=0.3)
+                        QuestionOption(
+                            id="opt_other",
+                            label="Other",
+                            is_default=False,
+                            rationale="Specify your preference.",
+                            confidence=0.3,
+                        )
                     )
                 # Add a free-text placeholder if still short
                 if len(options) < MIN_OPTIONS:
-                    options.insert(0, QuestionOption(
-                        id="opt_text", label="(Please type your answer)", is_default=True, rationale="", confidence=0.5,
-                    ))
+                    options.insert(
+                        0,
+                        QuestionOption(
+                            id="opt_text",
+                            label="(Please type your answer)",
+                            is_default=True,
+                            rationale="",
+                            confidence=0.5,
+                        ),
+                    )
             if not options:
                 continue  # Should not happen after above logic, but guard anyway
             fallback.append(
@@ -2884,7 +2996,9 @@ Previously Answered Questions:
                 )
             return options
         except Exception as exc:
-            logger.warning("Spec-aware option generation failed for %s: %s", q_def["sop_id"], str(exc)[:200])
+            logger.warning(
+                "Spec-aware option generation failed for %s: %s", q_def["sop_id"], str(exc)[:200]
+            )
             return []
 
     def _build_question_options(
@@ -2928,14 +3042,27 @@ Previously Answered Questions:
         # Ensure "Other" option exists
         if not any(o.label.lower() == "other" for o in options):
             options.append(
-                QuestionOption(id="opt_other", label="Other", is_default=False, rationale="Specify your preference.", confidence=0.3)
+                QuestionOption(
+                    id="opt_other",
+                    label="Other",
+                    is_default=False,
+                    rationale="Specify your preference.",
+                    confidence=0.3,
+                )
             )
 
         # Final safety: if still < MIN_OPTIONS, add a free-text placeholder
         if len(options) < MIN_OPTIONS:
-            options.insert(0, QuestionOption(
-                id="opt_text", label="(Please type your answer)", is_default=True, rationale="", confidence=0.5,
-            ))
+            options.insert(
+                0,
+                QuestionOption(
+                    id="opt_text",
+                    label="(Please type your answer)",
+                    is_default=True,
+                    rationale="",
+                    confidence=0.5,
+                ),
+            )
 
         return options
 
@@ -2963,12 +3090,24 @@ Previously Answered Questions:
 
         # Collect decisions for this sub-phase only
         sub_phase_decisions = [
-            {"sop_id": d.sop_id, "question": d.question_text, "decision": d.decision, "source": d.source}
-            for d in all_decisions if d.sub_phase == sub_phase
+            {
+                "sop_id": d.sop_id,
+                "question": d.question_text,
+                "decision": d.decision,
+                "source": d.source,
+            }
+            for d in all_decisions
+            if d.sub_phase == sub_phase
         ]
         # Also include all decisions for cross-referencing
         all_decisions_summary = [
-            {"sop_id": d.sop_id, "sub_phase": d.sub_phase.value if isinstance(d.sub_phase, SOPSubPhase) else str(d.sub_phase), "decision": d.decision}
+            {
+                "sop_id": d.sop_id,
+                "sub_phase": d.sub_phase.value
+                if isinstance(d.sub_phase, SOPSubPhase)
+                else str(d.sub_phase),
+                "decision": d.decision,
+            }
             for d in all_decisions
         ]
         # Build list of existing question IDs so the LLM avoids regenerating them
@@ -2995,13 +3134,15 @@ Previously Answered Questions:
             if is_complete:
                 logger.info(
                     "SOP Phase 1: Sub-phase '%s' assessed as COMPLETE: %s",
-                    sub_phase.value, str(parsed.get("completeness_rationale", ""))[:200],
+                    sub_phase.value,
+                    str(parsed.get("completeness_rationale", ""))[:200],
                 )
                 return True, []
 
             logger.info(
                 "SOP Phase 1: Sub-phase '%s' has GAPS: %s",
-                sub_phase.value, str(parsed.get("completeness_rationale", ""))[:200],
+                sub_phase.value,
+                str(parsed.get("completeness_rationale", ""))[:200],
             )
 
             # Parse follow-up questions
@@ -3039,9 +3180,26 @@ Previously Answered Questions:
                 # Ensure minimum 3 options
                 if len(options) < 3:
                     if not any(o.label.lower() == "other" for o in options):
-                        options.append(QuestionOption(id="opt_other", label="Other", is_default=False, rationale="Specify your preference.", confidence=0.3))
+                        options.append(
+                            QuestionOption(
+                                id="opt_other",
+                                label="Other",
+                                is_default=False,
+                                rationale="Specify your preference.",
+                                confidence=0.3,
+                            )
+                        )
                     if len(options) < 3:
-                        options.insert(0, QuestionOption(id="opt_text", label="(Please type your answer)", is_default=False, rationale="", confidence=0.5))
+                        options.insert(
+                            0,
+                            QuestionOption(
+                                id="opt_text",
+                                label="(Please type your answer)",
+                                is_default=False,
+                                rationale="",
+                                confidence=0.5,
+                            ),
+                        )
 
                 # Ensure exactly one is_default=True
                 defaults = [o for o in options if o.is_default]
@@ -3069,12 +3227,15 @@ Previously Answered Questions:
             if skipped_dupes:
                 logger.warning(
                     "SOP Phase 1: Sub-phase '%s' gap analysis generated %d question(s) with duplicate IDs — skipped",
-                    sub_phase.value, skipped_dupes,
+                    sub_phase.value,
+                    skipped_dupes,
                 )
 
             return False, follow_ups
         except Exception as exc:
-            logger.error("Sub-phase gap analysis failed for '%s': %s", sub_phase.value, str(exc)[:200])
+            logger.error(
+                "Sub-phase gap analysis failed for '%s': %s", sub_phase.value, str(exc)[:200]
+            )
             return True, []  # On failure, consider complete to avoid blocking
 
     def _run_sop_phase1(
@@ -3127,7 +3288,7 @@ Previously Answered Questions:
                         continue  # Condition not met
                     if cond_result is None:
                         continue  # Parent not answered yet — defer to next round within this sub-phase
-                        
+
                     # Build options ensuring at least 3 valid choices, informed by spec
                     options = self._build_question_options(q_def, spec_content, decisions_map)
 
@@ -3150,7 +3311,9 @@ Previously Answered Questions:
 
                 logger.info(
                     "SOP Phase 1 sub-phase '%s' round %d: asking %d questions",
-                    sub_phase.value, round_num, len(sub_phase_questions),
+                    sub_phase.value,
+                    round_num,
+                    len(sub_phase_questions),
                 )
                 job_updater(
                     status_text=f"SOP Phase 1 — {sub_phase.value}: waiting for answers to {len(sub_phase_questions)} question(s)",
@@ -3164,11 +3327,19 @@ Previously Answered Questions:
                         iteration=0,
                     )
                 except Exception as exc:
-                    logger.error("SOP Phase 1 communication failed in sub-phase '%s': %s", sub_phase.value, exc)
+                    logger.error(
+                        "SOP Phase 1 communication failed in sub-phase '%s': %s",
+                        sub_phase.value,
+                        exc,
+                    )
                     raise
 
                 if not answered:
-                    logger.info("SOP Phase 1: No answers received for sub-phase '%s' round %d", sub_phase.value, round_num)
+                    logger.info(
+                        "SOP Phase 1: No answers received for sub-phase '%s' round %d",
+                        sub_phase.value,
+                        round_num,
+                    )
                     break
 
                 # Record answers as SOPDecision objects
@@ -3193,18 +3364,24 @@ Previously Answered Questions:
                     status_text=f"SOP Phase 1 — {sub_phase.value}: assessing completeness...",
                 )
                 is_complete, follow_ups = self._assess_sub_phase_gaps(
-                    sub_phase, spec_content, all_decisions, decisions_map,
+                    sub_phase,
+                    spec_content,
+                    all_decisions,
+                    decisions_map,
                 )
                 if is_complete or not follow_ups:
                     logger.info(
                         "SOP Phase 1: Sub-phase '%s' is complete after %d gap-analysis round(s)",
-                        sub_phase.value, gap_round,
+                        sub_phase.value,
+                        gap_round,
                     )
                     break
 
                 logger.info(
                     "SOP Phase 1 sub-phase '%s' gap round %d: asking %d follow-up questions",
-                    sub_phase.value, gap_round, len(follow_ups),
+                    sub_phase.value,
+                    gap_round,
+                    len(follow_ups),
                 )
                 job_updater(
                     status_text=f"SOP Phase 1 — {sub_phase.value}: {len(follow_ups)} follow-up question(s) to fill gaps",
@@ -3218,11 +3395,18 @@ Previously Answered Questions:
                         iteration=0,
                     )
                 except Exception as exc:
-                    logger.error("SOP Phase 1 gap-analysis communication failed in sub-phase '%s': %s", sub_phase.value, exc)
+                    logger.error(
+                        "SOP Phase 1 gap-analysis communication failed in sub-phase '%s': %s",
+                        sub_phase.value,
+                        exc,
+                    )
                     raise
 
                 if not answered:
-                    logger.info("SOP Phase 1: No answers to gap questions for sub-phase '%s'", sub_phase.value)
+                    logger.info(
+                        "SOP Phase 1: No answers to gap questions for sub-phase '%s'",
+                        sub_phase.value,
+                    )
                     break
 
                 for aq in answered:

--- a/backend/agents/software_engineering_team/tests/test_product_requirements_analysis_agent.py
+++ b/backend/agents/software_engineering_team/tests/test_product_requirements_analysis_agent.py
@@ -1380,16 +1380,26 @@ def test_sop_models_basic() -> None:
 def test_assess_sub_phase_gaps_complete() -> None:
     """When LLM reports sub-phase as complete, returns (True, [])."""
     llm = MagicMock()
-    llm.complete_text.return_value = json.dumps({
-        "is_complete": True,
-        "completeness_rationale": "All deployment aspects covered.",
-        "follow_up_questions": [],
-    })
+    llm.complete_text.return_value = json.dumps(
+        {
+            "is_complete": True,
+            "completeness_rationale": "All deployment aspects covered.",
+            "follow_up_questions": [],
+        }
+    )
     agent = ProductRequirementsAnalysisAgent(llm)
     is_complete, follow_ups = agent._assess_sub_phase_gaps(
         SOPSubPhase.DEPLOYMENT,
         "Deploy on AWS with ECS containers.",
-        [SOPDecision(sop_id="P1.deploy.a", sub_phase=SOPSubPhase.DEPLOYMENT, question_text="Where?", decision="AWS", source="spec")],
+        [
+            SOPDecision(
+                sop_id="P1.deploy.a",
+                sub_phase=SOPSubPhase.DEPLOYMENT,
+                question_text="Where?",
+                decision="AWS",
+                source="spec",
+            )
+        ],
         {"P1.deploy.a": "AWS"},
     )
     assert is_complete is True
@@ -1399,30 +1409,59 @@ def test_assess_sub_phase_gaps_complete() -> None:
 def test_assess_sub_phase_gaps_incomplete_with_follow_ups() -> None:
     """When LLM reports gaps, returns (False, [OpenQuestion, ...])."""
     llm = MagicMock()
-    llm.complete_text.return_value = json.dumps({
-        "is_complete": False,
-        "completeness_rationale": "Missing region info.",
-        "follow_up_questions": [
-            {
-                "id": "P1.deploy.gen_1",
-                "question_text": "Which AWS region?",
-                "context": "Region affects latency.",
-                "category": "infrastructure",
-                "priority": "high",
-                "allow_multiple": False,
-                "sop_sub_phase": "deployment",
-                "options": [
-                    {"id": "opt_1", "label": "us-east-1", "is_default": True, "rationale": "Common.", "confidence": 0.8},
-                    {"id": "opt_2", "label": "eu-west-1", "is_default": False, "rationale": "EU.", "confidence": 0.5},
-                    {"id": "opt_3", "label": "ap-southeast-1", "is_default": False, "rationale": "APAC.", "confidence": 0.4},
-                    {"id": "opt_other", "label": "Other", "is_default": False, "rationale": "Specify.", "confidence": 0.3},
-                ],
-            }
-        ],
-    })
+    llm.complete_text.return_value = json.dumps(
+        {
+            "is_complete": False,
+            "completeness_rationale": "Missing region info.",
+            "follow_up_questions": [
+                {
+                    "id": "P1.deploy.gen_1",
+                    "question_text": "Which AWS region?",
+                    "context": "Region affects latency.",
+                    "category": "infrastructure",
+                    "priority": "high",
+                    "allow_multiple": False,
+                    "sop_sub_phase": "deployment",
+                    "options": [
+                        {
+                            "id": "opt_1",
+                            "label": "us-east-1",
+                            "is_default": True,
+                            "rationale": "Common.",
+                            "confidence": 0.8,
+                        },
+                        {
+                            "id": "opt_2",
+                            "label": "eu-west-1",
+                            "is_default": False,
+                            "rationale": "EU.",
+                            "confidence": 0.5,
+                        },
+                        {
+                            "id": "opt_3",
+                            "label": "ap-southeast-1",
+                            "is_default": False,
+                            "rationale": "APAC.",
+                            "confidence": 0.4,
+                        },
+                        {
+                            "id": "opt_other",
+                            "label": "Other",
+                            "is_default": False,
+                            "rationale": "Specify.",
+                            "confidence": 0.3,
+                        },
+                    ],
+                }
+            ],
+        }
+    )
     agent = ProductRequirementsAnalysisAgent(llm)
     is_complete, follow_ups = agent._assess_sub_phase_gaps(
-        SOPSubPhase.DEPLOYMENT, "Deploy on AWS.", [], {},
+        SOPSubPhase.DEPLOYMENT,
+        "Deploy on AWS.",
+        [],
+        {},
     )
     assert is_complete is False
     assert len(follow_ups) == 1
@@ -1437,7 +1476,10 @@ def test_assess_sub_phase_gaps_malformed_json() -> None:
     llm.complete_text.return_value = "This is not valid JSON at all"
     agent = ProductRequirementsAnalysisAgent(llm)
     is_complete, follow_ups = agent._assess_sub_phase_gaps(
-        SOPSubPhase.DEPLOYMENT, "Some spec.", [], {},
+        SOPSubPhase.DEPLOYMENT,
+        "Some spec.",
+        [],
+        {},
     )
     assert is_complete is True
     assert follow_ups == []
@@ -1449,7 +1491,10 @@ def test_assess_sub_phase_gaps_llm_exception() -> None:
     llm.complete_text.side_effect = RuntimeError("LLM unavailable")
     agent = ProductRequirementsAnalysisAgent(llm)
     is_complete, follow_ups = agent._assess_sub_phase_gaps(
-        SOPSubPhase.SECURITY, "Some spec.", [], {},
+        SOPSubPhase.SECURITY,
+        "Some spec.",
+        [],
+        {},
     )
     assert is_complete is True
     assert follow_ups == []
@@ -1458,35 +1503,81 @@ def test_assess_sub_phase_gaps_llm_exception() -> None:
 def test_assess_sub_phase_gaps_duplicate_ids_skipped() -> None:
     """Follow-up questions with IDs already in decisions_map are skipped with a warning."""
     llm = MagicMock()
-    llm.complete_text.return_value = json.dumps({
-        "is_complete": False,
-        "completeness_rationale": "Gaps remain.",
-        "follow_up_questions": [
-            {
-                "id": "P1.deploy.a",
-                "question_text": "Duplicate question?",
-                "options": [
-                    {"id": "opt_1", "label": "A", "is_default": True, "rationale": ".", "confidence": 0.5},
-                    {"id": "opt_2", "label": "B", "is_default": False, "rationale": ".", "confidence": 0.5},
-                    {"id": "opt_3", "label": "C", "is_default": False, "rationale": ".", "confidence": 0.5},
-                ],
-            },
-            {
-                "id": "P1.deploy.gen_1",
-                "question_text": "New question?",
-                "options": [
-                    {"id": "opt_1", "label": "X", "is_default": True, "rationale": ".", "confidence": 0.5},
-                    {"id": "opt_2", "label": "Y", "is_default": False, "rationale": ".", "confidence": 0.5},
-                    {"id": "opt_3", "label": "Z", "is_default": False, "rationale": ".", "confidence": 0.5},
-                ],
-            },
-        ],
-    })
+    llm.complete_text.return_value = json.dumps(
+        {
+            "is_complete": False,
+            "completeness_rationale": "Gaps remain.",
+            "follow_up_questions": [
+                {
+                    "id": "P1.deploy.a",
+                    "question_text": "Duplicate question?",
+                    "options": [
+                        {
+                            "id": "opt_1",
+                            "label": "A",
+                            "is_default": True,
+                            "rationale": ".",
+                            "confidence": 0.5,
+                        },
+                        {
+                            "id": "opt_2",
+                            "label": "B",
+                            "is_default": False,
+                            "rationale": ".",
+                            "confidence": 0.5,
+                        },
+                        {
+                            "id": "opt_3",
+                            "label": "C",
+                            "is_default": False,
+                            "rationale": ".",
+                            "confidence": 0.5,
+                        },
+                    ],
+                },
+                {
+                    "id": "P1.deploy.gen_1",
+                    "question_text": "New question?",
+                    "options": [
+                        {
+                            "id": "opt_1",
+                            "label": "X",
+                            "is_default": True,
+                            "rationale": ".",
+                            "confidence": 0.5,
+                        },
+                        {
+                            "id": "opt_2",
+                            "label": "Y",
+                            "is_default": False,
+                            "rationale": ".",
+                            "confidence": 0.5,
+                        },
+                        {
+                            "id": "opt_3",
+                            "label": "Z",
+                            "is_default": False,
+                            "rationale": ".",
+                            "confidence": 0.5,
+                        },
+                    ],
+                },
+            ],
+        }
+    )
     agent = ProductRequirementsAnalysisAgent(llm)
     is_complete, follow_ups = agent._assess_sub_phase_gaps(
         SOPSubPhase.DEPLOYMENT,
         "Some spec.",
-        [SOPDecision(sop_id="P1.deploy.a", sub_phase=SOPSubPhase.DEPLOYMENT, question_text="Where?", decision="AWS", source="spec")],
+        [
+            SOPDecision(
+                sop_id="P1.deploy.a",
+                sub_phase=SOPSubPhase.DEPLOYMENT,
+                question_text="Where?",
+                decision="AWS",
+                source="spec",
+            )
+        ],
         {"P1.deploy.a": "AWS"},
     )
     assert is_complete is False
@@ -1498,20 +1589,33 @@ def test_assess_sub_phase_gaps_duplicate_ids_skipped() -> None:
 def test_assess_sub_phase_gaps_all_dupes_returns_empty_follow_ups() -> None:
     """When all LLM questions are duplicates, follow_ups is empty (loop will exit)."""
     llm = MagicMock()
-    llm.complete_text.return_value = json.dumps({
-        "is_complete": False,
-        "completeness_rationale": "Gaps remain.",
-        "follow_up_questions": [
-            {
-                "id": "P1.deploy.a",
-                "question_text": "Dupe 1?",
-                "options": [{"id": "o1", "label": "A", "is_default": True, "rationale": ".", "confidence": 0.5}],
-            },
-        ],
-    })
+    llm.complete_text.return_value = json.dumps(
+        {
+            "is_complete": False,
+            "completeness_rationale": "Gaps remain.",
+            "follow_up_questions": [
+                {
+                    "id": "P1.deploy.a",
+                    "question_text": "Dupe 1?",
+                    "options": [
+                        {
+                            "id": "o1",
+                            "label": "A",
+                            "is_default": True,
+                            "rationale": ".",
+                            "confidence": 0.5,
+                        }
+                    ],
+                },
+            ],
+        }
+    )
     agent = ProductRequirementsAnalysisAgent(llm)
     is_complete, follow_ups = agent._assess_sub_phase_gaps(
-        SOPSubPhase.DEPLOYMENT, "Spec.", [], {"P1.deploy.a": "AWS"},
+        SOPSubPhase.DEPLOYMENT,
+        "Spec.",
+        [],
+        {"P1.deploy.a": "AWS"},
     )
     assert is_complete is False
     assert follow_ups == []
@@ -1520,22 +1624,33 @@ def test_assess_sub_phase_gaps_all_dupes_returns_empty_follow_ups() -> None:
 def test_assess_sub_phase_gaps_options_padded_to_min_3() -> None:
     """When LLM returns < 3 options, they are padded to at least 3."""
     llm = MagicMock()
-    llm.complete_text.return_value = json.dumps({
-        "is_complete": False,
-        "completeness_rationale": "Gaps.",
-        "follow_up_questions": [
-            {
-                "id": "P1.deploy.gen_1",
-                "question_text": "Which compute model?",
-                "options": [
-                    {"id": "opt_1", "label": "Serverless", "is_default": True, "rationale": ".", "confidence": 0.8},
-                ],
-            },
-        ],
-    })
+    llm.complete_text.return_value = json.dumps(
+        {
+            "is_complete": False,
+            "completeness_rationale": "Gaps.",
+            "follow_up_questions": [
+                {
+                    "id": "P1.deploy.gen_1",
+                    "question_text": "Which compute model?",
+                    "options": [
+                        {
+                            "id": "opt_1",
+                            "label": "Serverless",
+                            "is_default": True,
+                            "rationale": ".",
+                            "confidence": 0.8,
+                        },
+                    ],
+                },
+            ],
+        }
+    )
     agent = ProductRequirementsAnalysisAgent(llm)
     is_complete, follow_ups = agent._assess_sub_phase_gaps(
-        SOPSubPhase.DEPLOYMENT, "Spec.", [], {},
+        SOPSubPhase.DEPLOYMENT,
+        "Spec.",
+        [],
+        {},
     )
     assert is_complete is False
     assert len(follow_ups) == 1
@@ -1548,21 +1663,41 @@ def test_assess_sub_phase_gaps_options_padded_to_min_3() -> None:
 def test_assess_sub_phase_gaps_exactly_one_default() -> None:
     """After option padding/parsing, exactly one option has is_default=True."""
     llm = MagicMock()
-    llm.complete_text.return_value = json.dumps({
-        "is_complete": False,
-        "completeness_rationale": "Gaps.",
-        "follow_up_questions": [
-            {
-                "id": "P1.data.gen_1",
-                "question_text": "Which database?",
-                "options": [
-                    {"id": "opt_1", "label": "PostgreSQL", "is_default": True, "rationale": ".", "confidence": 0.8},
-                    {"id": "opt_2", "label": "MySQL", "is_default": True, "rationale": ".", "confidence": 0.6},
-                    {"id": "opt_3", "label": "MongoDB", "is_default": False, "rationale": ".", "confidence": 0.4},
-                ],
-            },
-        ],
-    })
+    llm.complete_text.return_value = json.dumps(
+        {
+            "is_complete": False,
+            "completeness_rationale": "Gaps.",
+            "follow_up_questions": [
+                {
+                    "id": "P1.data.gen_1",
+                    "question_text": "Which database?",
+                    "options": [
+                        {
+                            "id": "opt_1",
+                            "label": "PostgreSQL",
+                            "is_default": True,
+                            "rationale": ".",
+                            "confidence": 0.8,
+                        },
+                        {
+                            "id": "opt_2",
+                            "label": "MySQL",
+                            "is_default": True,
+                            "rationale": ".",
+                            "confidence": 0.6,
+                        },
+                        {
+                            "id": "opt_3",
+                            "label": "MongoDB",
+                            "is_default": False,
+                            "rationale": ".",
+                            "confidence": 0.4,
+                        },
+                    ],
+                },
+            ],
+        }
+    )
     agent = ProductRequirementsAnalysisAgent(llm)
     _, follow_ups = agent._assess_sub_phase_gaps(SOPSubPhase.DATA, "Spec.", [], {})
     assert len(follow_ups) == 1
@@ -1573,21 +1708,41 @@ def test_assess_sub_phase_gaps_exactly_one_default() -> None:
 def test_assess_sub_phase_gaps_no_defaults_sets_first() -> None:
     """When LLM returns no default option, the first option becomes default."""
     llm = MagicMock()
-    llm.complete_text.return_value = json.dumps({
-        "is_complete": False,
-        "completeness_rationale": "Gaps.",
-        "follow_up_questions": [
-            {
-                "id": "P1.sec.gen_1",
-                "question_text": "Auth method?",
-                "options": [
-                    {"id": "opt_1", "label": "OAuth2", "is_default": False, "rationale": ".", "confidence": 0.7},
-                    {"id": "opt_2", "label": "SAML", "is_default": False, "rationale": ".", "confidence": 0.5},
-                    {"id": "opt_3", "label": "API Keys", "is_default": False, "rationale": ".", "confidence": 0.3},
-                ],
-            },
-        ],
-    })
+    llm.complete_text.return_value = json.dumps(
+        {
+            "is_complete": False,
+            "completeness_rationale": "Gaps.",
+            "follow_up_questions": [
+                {
+                    "id": "P1.sec.gen_1",
+                    "question_text": "Auth method?",
+                    "options": [
+                        {
+                            "id": "opt_1",
+                            "label": "OAuth2",
+                            "is_default": False,
+                            "rationale": ".",
+                            "confidence": 0.7,
+                        },
+                        {
+                            "id": "opt_2",
+                            "label": "SAML",
+                            "is_default": False,
+                            "rationale": ".",
+                            "confidence": 0.5,
+                        },
+                        {
+                            "id": "opt_3",
+                            "label": "API Keys",
+                            "is_default": False,
+                            "rationale": ".",
+                            "confidence": 0.3,
+                        },
+                    ],
+                },
+            ],
+        }
+    )
     agent = ProductRequirementsAnalysisAgent(llm)
     _, follow_ups = agent._assess_sub_phase_gaps(SOPSubPhase.SECURITY, "Spec.", [], {})
     assert len(follow_ups) == 1
@@ -1603,7 +1758,10 @@ def test_assess_sub_phase_gaps_empty_llm_response() -> None:
     llm.complete_text.return_value = ""
     agent = ProductRequirementsAnalysisAgent(llm)
     is_complete, follow_ups = agent._assess_sub_phase_gaps(
-        SOPSubPhase.BUDGET, "Spec.", [], {},
+        SOPSubPhase.BUDGET,
+        "Spec.",
+        [],
+        {},
     )
     assert is_complete is True
     assert follow_ups == []
@@ -1612,11 +1770,22 @@ def test_assess_sub_phase_gaps_empty_llm_response() -> None:
 def test_assess_sub_phase_gaps_passes_existing_ids_to_prompt() -> None:
     """Verify that existing question IDs are passed to the LLM prompt."""
     llm = MagicMock()
-    llm.complete_text.return_value = json.dumps({"is_complete": True, "completeness_rationale": "Done.", "follow_up_questions": []})
+    llm.complete_text.return_value = json.dumps(
+        {"is_complete": True, "completeness_rationale": "Done.", "follow_up_questions": []}
+    )
     agent = ProductRequirementsAnalysisAgent(llm)
     agent._assess_sub_phase_gaps(
-        SOPSubPhase.DEPLOYMENT, "Spec.",
-        [SOPDecision(sop_id="P1.deploy.a", sub_phase=SOPSubPhase.DEPLOYMENT, question_text="Q", decision="A", source="user")],
+        SOPSubPhase.DEPLOYMENT,
+        "Spec.",
+        [
+            SOPDecision(
+                sop_id="P1.deploy.a",
+                sub_phase=SOPSubPhase.DEPLOYMENT,
+                question_text="Q",
+                decision="A",
+                source="user",
+            )
+        ],
         {"P1.deploy.a": "AWS", "P1.deploy.b": "ECS"},
     )
     # The prompt should contain the existing question IDs
@@ -1629,4 +1798,5 @@ def test_max_gap_rounds_constant() -> None:
     """MAX_GAP_ROUNDS should be a reasonable limit smaller than MAX_SOP_ROUNDS."""
     assert MAX_GAP_ROUNDS == 3
     from product_requirements_analysis_agent.agent import MAX_SOP_ROUNDS
+
     assert MAX_GAP_ROUNDS <= MAX_SOP_ROUNDS

--- a/backend/unified_api/main.py
+++ b/backend/unified_api/main.py
@@ -401,7 +401,9 @@ def _try_mount_road_trip_planning(app: FastAPI) -> bool:
 def _try_mount_agentic_team_provisioning(app: FastAPI) -> bool:
     """Mount Agentic Team Provisioning API."""
     return try_mount_or_proxy(
-        app, "agentic_team_provisioning", "agentic_team_provisioning.api.main",
+        app,
+        "agentic_team_provisioning",
+        "agentic_team_provisioning.api.main",
         service_url_env="AGENTIC_TEAM_PROVISIONING_SERVICE_URL",
     )
 

--- a/backend/unified_api/team_proxy.py
+++ b/backend/unified_api/team_proxy.py
@@ -54,12 +54,22 @@ async def proxy_request(request: Request, target_base_url: str, path: str) -> Re
 
     body = await request.body()
 
-    resp = await client.request(
-        method=request.method,
-        url=url,
-        headers=headers,
-        content=body,
-    )
+    try:
+        resp = await client.request(
+            method=request.method,
+            url=url,
+            headers=headers,
+            content=body,
+        )
+    except httpx.ConnectError as exc:
+        logger.error("Proxy connect error: %s %s -> %s", request.method, request.url.path, url)
+        raise exc
+    except httpx.ConnectTimeout as exc:
+        logger.error("Proxy connect timeout: %s %s -> %s", request.method, request.url.path, url)
+        raise exc
+    except httpx.HTTPError as exc:
+        logger.error("Proxy HTTP error: %s %s -> %s: %s", request.method, request.url.path, url, exc)
+        raise exc
 
     resp_headers = {k: v for k, v in resp.headers.items() if k.lower() not in _HOP_BY_HOP_RESPONSE}
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -710,9 +710,10 @@ services:
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
-      interval: 30s
+      start_period: 60s
+      interval: 15s
       timeout: 10s
-      retries: 3
+      retries: 10
 
   frontend:
     build:

--- a/user-interface/src/app/components/branding-chat/branding-chat.component.ts
+++ b/user-interface/src/app/components/branding-chat/branding-chat.component.ts
@@ -51,6 +51,7 @@ export class BrandingChatComponent implements OnInit, OnChanges, AfterViewChecke
   @Input() conversationId: string | null = null;
   @Input() brandId: string | null = null;
   @Output() stateChange = new EventEmitter<BrandingChatState>();
+  @Output() brandAutoCreated = new EventEmitter<string>();
 
   @ViewChild('messagesContainer') messagesContainer!: ElementRef<HTMLDivElement>;
 
@@ -99,6 +100,8 @@ export class BrandingChatComponent implements OnInit, OnChanges, AfterViewChecke
     }
   }
 
+  private _lastBrandId: string | null = null;
+
   private applyState(res: ConversationStateResponse): void {
     this.messages = res.messages ?? [];
     this.mission = res.mission ?? null;
@@ -107,6 +110,11 @@ export class BrandingChatComponent implements OnInit, OnChanges, AfterViewChecke
     if (res.conversation_id) {
       this._conversationId = res.conversation_id;
     }
+    // Detect auto-created brand: brand_id appeared where there was none before.
+    if (res.brand_id && !this._lastBrandId) {
+      this.brandAutoCreated.emit(res.brand_id);
+    }
+    this._lastBrandId = res.brand_id ?? null;
     this.emitState();
   }
 
@@ -134,10 +142,7 @@ export class BrandingChatComponent implements OnInit, OnChanges, AfterViewChecke
   retryStartConversation(): void {
     this.error = null;
     this.loading = true;
-    const starter = this.brandId
-      ? this.api.createConversationForBrand(this.brandId)
-      : this.api.createConversation();
-    starter.subscribe({
+    this.api.createConversation().subscribe({
       next: (res) => {
         this.applyState(res);
         this.loading = false;
@@ -153,8 +158,10 @@ export class BrandingChatComponent implements OnInit, OnChanges, AfterViewChecke
 
   private bootstrapConversation(): void {
     this.error = null;
+    // If a conversation ID is provided (e.g. from a brand), load it directly.
     if (this.conversationId) {
       this._conversationId = this.conversationId;
+      this._lastBrandId = this.brandId ?? null;
       this.api.getConversation(this.conversationId).subscribe({
         next: (res) => this.applyState(res),
         error: (err) => {
@@ -165,10 +172,9 @@ export class BrandingChatComponent implements OnInit, OnChanges, AfterViewChecke
       });
       return;
     }
-    const starter = this.brandId
-      ? this.api.createConversationForBrand(this.brandId)
-      : this.api.createConversation();
-    starter.subscribe({
+    // No conversation ID — create a new unattached conversation.
+    // The backend will auto-create a brand once the user provides enough info.
+    this.api.createConversation().subscribe({
       next: (res) => this.applyState(res),
       error: (err) => {
         this.error = this.isUnreachableError(err)
@@ -189,10 +195,7 @@ export class BrandingChatComponent implements OnInit, OnChanges, AfterViewChecke
         { role: 'user', content: message, timestamp: new Date().toISOString() },
       ];
       this.loading = true;
-      const starter = this.brandId
-        ? this.api.createConversationForBrand(this.brandId, message)
-        : this.api.createConversation(message);
-      starter.subscribe({
+      this.api.createConversation(message).subscribe({
         next: (res) => {
           this.applyState(res);
           this.error = null;

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.html
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.html
@@ -77,53 +77,18 @@
       <div class="split-panel">
         <div class="panel chat-panel">
           <div class="chat-toolbar">
-            @if (selectedBrand) {
-              <button mat-stroked-button type="button" (click)="startFreshConversation()">
-                <mat-icon>add_comment</mat-icon>
-                New conversation
-              </button>
-            }
-            @if (hasConversationHistory && conversationMission) {
+            @if (!selectedBrand && conversationMission) {
               <button mat-stroked-button color="primary" type="button" (click)="onOpenSaveAsBrand()" [disabled]="!canCreateBrandFromChat">
                 Save conversation as brand
               </button>
             }
           </div>
           <app-branding-chat
-            [conversationId]="selectedHistoryConversationId"
+            [conversationId]="activeConversationId"
             [brandId]="selectedBrand?.id ?? null"
             (stateChange)="onChatStateChange($event)"
+            (brandAutoCreated)="onBrandAutoCreated($event)"
           />
-
-          @if (conversationHistory.length > 0) {
-            <mat-card class="history-card">
-              <mat-card-header>
-                <mat-card-title>Past conversations</mat-card-title>
-                <mat-card-subtitle>
-                  Continue a conversation below.
-                  @if (selectedBrand) {
-                    Showing threads for {{ selectedBrand.name }}; change brand above to load others.
-                  } @else {
-                    Pick a row to resume chatting.
-                  }
-                </mat-card-subtitle>
-              </mat-card-header>
-              <mat-card-content>
-                <div class="history-list">
-                  @for (item of conversationHistory; track item.conversation_id) {
-                    <button
-                      mat-stroked-button
-                      [color]="selectedHistoryConversationId === item.conversation_id ? 'primary' : undefined"
-                      (click)="selectConversationHistory(item)"
-                    >
-                      {{ item.brand_name || 'Unassigned' }} · {{ formatConversationTime(item.updated_at) }} ·
-                      {{ item.message_count }} messages
-                    </button>
-                  }
-                </div>
-              </mat-card-content>
-            </mat-card>
-          }
         </div>
         <div class="panel preview-panel">
           @if (isCompactLayout) {

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.spec.ts
@@ -19,11 +19,9 @@ describe('BrandingDashboardComponent', () => {
     listClients: ReturnType<typeof vi.fn>;
     listBrands: ReturnType<typeof vi.fn>;
     createClient: ReturnType<typeof vi.fn>;
-    listConversations: ReturnType<typeof vi.fn>;
     createBrand: ReturnType<typeof vi.fn>;
     getBrand: ReturnType<typeof vi.fn>;
     createConversation: ReturnType<typeof vi.fn>;
-    createConversationForBrand: ReturnType<typeof vi.fn>;
   };
   let snackBarSpy: { open: ReturnType<typeof vi.fn> };
 
@@ -39,11 +37,9 @@ describe('BrandingDashboardComponent', () => {
       listClients: vi.fn().mockReturnValue(of([workspaceClient])),
       listBrands: vi.fn().mockReturnValue(of([])),
       createClient: vi.fn(),
-      listConversations: vi.fn().mockReturnValue(of([])),
       createBrand: vi.fn(),
       getBrand: vi.fn(),
       createConversation: vi.fn().mockReturnValue(of(emptyConversationState)),
-      createConversationForBrand: vi.fn().mockReturnValue(of(emptyConversationState)),
     };
     await TestBed.configureTestingModule({
       imports: [BrandingDashboardComponent, NoopAnimationsModule],
@@ -106,21 +102,22 @@ describe('BrandingDashboardComponent', () => {
     expect(apiSpy.health).toHaveBeenCalled();
   });
 
-  it('refreshConversations should call listConversations with selected brand id when set', () => {
-    component.selectedClient = workspaceClient as any;
-    component.selectedBrand = {
+  it('selectBrandForChat should set activeConversationId from brand', () => {
+    const brand = {
       id: 'b1',
       client_id: 'w1',
       name: 'B',
-      status: 'draft',
+      status: 'draft' as const,
+      conversation_id: 'conv-123',
       mission: {} as any,
       version: 1,
       history: [],
       created_at: '',
       updated_at: '',
     };
-    component.refreshConversations();
-    expect(apiSpy.listConversations).toHaveBeenCalledWith('b1');
+    component.selectBrandForChat(brand);
+    expect(component.selectedBrand).toEqual(brand);
+    expect(component.activeConversationId).toBe('conv-123');
   });
 });
 
@@ -137,11 +134,9 @@ describe('BrandingDashboardComponent workspace bootstrap', () => {
       }),
       listBrands: vi.fn().mockReturnValue(of([])),
       createClient: vi.fn().mockReturnValue(of(workspaceClient)),
-      listConversations: vi.fn().mockReturnValue(of([])),
       createBrand: vi.fn(),
       getBrand: vi.fn(),
       createConversation: vi.fn().mockReturnValue(of(emptyConversationState2)),
-      createConversationForBrand: vi.fn().mockReturnValue(of(emptyConversationState2)),
     };
 
     TestBed.resetTestingModule();

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
@@ -26,7 +26,6 @@ import type {
   BrandingSessionResponse,
   BrandingTeamOutput,
   Client,
-  ConversationSummary,
   CreateBrandRequest,
   RunBrandingTeamRequest,
 } from '../../models';
@@ -78,8 +77,6 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
   conversationMission: BrandingMissionSnapshot | null = null;
   conversationLatestOutput: BrandingTeamOutput | null = null;
   activeConversationId: string | null = null;
-  conversationHistory: ConversationSummary[] = [];
-  selectedHistoryConversationId: string | null = null;
 
   /** True during initial workspace bootstrap or heavy session operations (full-page spinner). */
   loading = false;
@@ -126,8 +123,27 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
     this.conversationMission = state.mission;
     this.conversationLatestOutput = state.latest_output;
     this.syncBrandPreviewFromSelection();
-    this.refreshConversations();
     this.syncQueryParams();
+  }
+
+  /** Handle auto-created brand from chat: refresh brands and select it. */
+  onBrandAutoCreated(brandId: string): void {
+    if (!this.selectedClient) return;
+    this.api.listBrands(this.selectedClient.id).subscribe({
+      next: (brands) => {
+        this.brands = brands;
+        const created = brands.find((b) => b.id === brandId);
+        if (created) {
+          this.selectedBrand = created;
+          this.conversationMission = created.mission;
+          this.snackBar.open(
+            `Brand "${created.name}" auto-created from your conversation.`,
+            'Dismiss',
+            { duration: 6000 }
+          );
+        }
+      },
+    });
   }
 
   /** Keep URL query params in sync so the user can bookmark / deep-link back. */
@@ -209,12 +225,9 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
     this.saveToAgencyError = null;
     this.api.createBrand(clientId, request).subscribe({
       next: (brand) => {
-        if (this.activeConversationId) {
-          this.api.attachConversationToBrand(this.activeConversationId, brand.id).subscribe({
-            // eslint-disable-next-line @typescript-eslint/no-empty-function
-            next: () => {},
-          });
-        }
+        // Brand creation now auto-creates a conversation on the backend.
+        // Switch to the brand's permanent conversation.
+        this.activeConversationId = brand.conversation_id ?? null;
         this.api.runBrand(clientId, brand.id).subscribe({
           next: () => {
             this.snackBar.open(`Brand "${brand.name}" saved and run completed.`, 'Dismiss', { duration: 5000 });
@@ -330,7 +343,6 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
         this.brands = list;
         this.applyDefaultBrandSelection();
         this.syncBrandPreviewFromSelection();
-        this.refreshConversations();
         this.loading = false;
       },
       error: () => {
@@ -356,31 +368,14 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
     if (this.pendingBrandId) {
       const match = this.brands.find((b) => b.id === this.pendingBrandId);
       if (match) {
-        this.selectedBrand = match;
-        this.conversationMission = match.mission;
-        this.conversationLatestOutput = (match.latest_output as BrandingTeamOutput | null) ?? null;
-        if (this.pendingConversationId) {
-          this.selectedHistoryConversationId = this.pendingConversationId;
-          this.activeConversationId = this.pendingConversationId;
-        } else {
-          this.resumeLatestConversation(match);
-        }
+        this.resumeOrStartBrand(match);
         this.pendingBrandId = null;
         this.pendingConversationId = null;
-        this.refreshConversations();
         return;
       }
     }
-    if (this.pendingConversationId) {
-      this.selectedHistoryConversationId = this.pendingConversationId;
-      this.activeConversationId = this.pendingConversationId;
-      this.pendingConversationId = null;
-      this.pendingBrandId = null;
-      const last = this.brands[this.brands.length - 1];
-      this.selectedBrand = last;
-      this.refreshConversations();
-      return;
-    }
+    this.pendingBrandId = null;
+    this.pendingConversationId = null;
 
     if (!this.selectedBrand) {
       const last = this.brands[this.brands.length - 1];
@@ -398,82 +393,21 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
    * Select a brand and try to resume the most recent conversation for it.
    * Falls back to creating a new conversation if none exist.
    */
+  /** Select a brand and open its single permanent conversation. */
   private resumeOrStartBrand(brand: Brand): void {
     this.selectedBrand = brand;
     this.conversationMission = brand.mission;
     this.conversationLatestOutput = (brand.latest_output as BrandingTeamOutput | null) ?? null;
-    this.resumeLatestConversation(brand);
-  }
-
-  /**
-   * Load conversations for the given brand and auto-select the most recent one.
-   * If no conversations exist, resets to a new conversation state.
-   */
-  private resumeLatestConversation(brand: Brand): void {
-    this.api.listConversations(brand.id).subscribe({
-      next: (rows) => {
-        this.conversationHistory = rows;
-        if (rows.length > 0) {
-          const latest = rows[0];
-          this.selectedHistoryConversationId = latest.conversation_id;
-          this.activeConversationId = latest.conversation_id;
-          this.syncQueryParams();
-        } else {
-          this.selectedHistoryConversationId = null;
-          this.activeConversationId = null;
-        }
-      },
-      error: () => {
-        this.conversationHistory = [];
-        this.selectedHistoryConversationId = null;
-        this.activeConversationId = null;
-      },
-    });
-  }
-
-  refreshConversations(): void {
-    if (!this.selectedClient) {
-      this.conversationHistory = [];
-      return;
-    }
-    const q = this.selectedBrand?.id ?? undefined;
-    this.api.listConversations(q).subscribe({
-      next: (rows) => {
-        this.conversationHistory = rows;
-      },
-      error: () => {
-        this.conversationHistory = [];
-      },
-    });
+    this.activeConversationId = brand.conversation_id ?? null;
+    this.syncQueryParams();
   }
 
   selectBrandForChat(brand: Brand): void {
-    this.selectedBrand = brand;
-    this.conversationMission = brand.mission;
-    this.conversationLatestOutput = (brand.latest_output as BrandingTeamOutput | null) ?? null;
-    this.resumeLatestConversation(brand);
-  }
-
-  selectConversationHistory(item: ConversationSummary): void {
-    this.selectedHistoryConversationId = item.conversation_id;
-    this.activeConversationId = item.conversation_id;
-    if (item.brand_id) {
-      const match = this.brands.find((b) => b.id === item.brand_id) ?? null;
-      this.selectedBrand = match;
-    }
-    this.refreshConversations();
-    this.syncQueryParams();
+    this.resumeOrStartBrand(brand);
   }
 
   startNewBrandConversation(brand: Brand): void {
     this.resumeOrStartBrand(brand);
-  }
-
-  /** Explicitly start a fresh conversation for the currently selected brand. */
-  startFreshConversation(): void {
-    this.selectedHistoryConversationId = null;
-    this.activeConversationId = null;
-    this.syncQueryParams();
   }
 
   openFormTabForNewBrand(): void {
@@ -491,9 +425,7 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
     return !!this.activeConversationId && !!this.conversationMission;
   }
 
-  get hasConversationHistory(): boolean {
-    return !!this.activeConversationId;
-  }
+
 
   private syncBrandPreviewFromSelection(): void {
     if (!this.selectedBrand) return;

--- a/user-interface/src/app/components/pending-questions/question-card/question-card.component.html
+++ b/user-interface/src/app/components/pending-questions/question-card/question-card.component.html
@@ -104,37 +104,71 @@
   }
 
   <div class="options-list">
-    <!-- All questions use checkboxes for multi-select -->
-    <div class="multi-select-hint">
-      <mat-icon>info_outline</mat-icon>
-      <span>Select all that apply</span>
-    </div>
-    @for (option of question.options; track option.id) {
+    @if (isMultiSelect) {
+      <div class="select-hint">
+        <mat-icon>info_outline</mat-icon>
+        <span>Select all that apply</span>
+      </div>
+      @for (option of question.options; track option.id) {
+        <div class="option-wrapper">
+          <mat-checkbox
+            [checked]="isOptionSelected(option.id)"
+            (change)="onOptionToggle(option.id, $event.checked)"
+            class="option-checkbox"
+          >
+            {{ option.label }}
+            @if (option.is_default) {
+              <span class="default-badge">Recommended</span>
+            }
+          </mat-checkbox>
+          @if (option.rationale) {
+            <p class="option-rationale">{{ option.rationale }}</p>
+          }
+        </div>
+      }
       <div class="option-wrapper">
         <mat-checkbox
-          [checked]="isOptionSelected(option.id)"
-          (change)="onOptionToggle(option.id, $event.checked)"
-          class="option-checkbox"
+          [checked]="isOtherSelected()"
+          (change)="onOptionToggle('other', $event.checked)"
+          class="option-checkbox other-option"
         >
-          {{ option.label }}
-          @if (option.is_default) {
-            <span class="default-badge">Recommended</span>
-          }
+          Other (specify below)
         </mat-checkbox>
-        @if (option.rationale) {
-          <p class="option-rationale">{{ option.rationale }}</p>
-        }
       </div>
+    } @else {
+      <div class="select-hint">
+        <mat-icon>info_outline</mat-icon>
+        <span>Select one option</span>
+      </div>
+      <mat-radio-group class="radio-group" (change)="onRadioChange($event.value)">
+        @for (option of question.options; track option.id) {
+          <div class="option-wrapper">
+            <mat-radio-button
+              [value]="option.id"
+              [checked]="isOptionSelected(option.id)"
+              class="option-radio"
+            >
+              {{ option.label }}
+              @if (option.is_default) {
+                <span class="default-badge">Recommended</span>
+              }
+            </mat-radio-button>
+            @if (option.rationale) {
+              <p class="option-rationale">{{ option.rationale }}</p>
+            }
+          </div>
+        }
+        <div class="option-wrapper">
+          <mat-radio-button
+            value="other"
+            [checked]="isOtherSelected()"
+            class="option-radio other-option"
+          >
+            Other (specify below)
+          </mat-radio-button>
+        </div>
+      </mat-radio-group>
     }
-    <div class="option-wrapper">
-      <mat-checkbox
-        [checked]="isOtherSelected()"
-        (change)="onOptionToggle('other', $event.checked)"
-        class="option-checkbox other-option"
-      >
-        Other (specify below)
-      </mat-checkbox>
-    </div>
 
     @if (isOtherSelected()) {
       <mat-form-field appearance="outline" class="other-input">

--- a/user-interface/src/app/components/pending-questions/question-card/question-card.component.scss
+++ b/user-interface/src/app/components/pending-questions/question-card/question-card.component.scss
@@ -226,7 +226,7 @@
 .options-list {
   padding-left: 40px;
 
-  .multi-select-hint {
+  .select-hint {
     display: flex;
     align-items: center;
     gap: 0.5rem;
@@ -245,8 +245,14 @@
     }
   }
 
+  .radio-group {
+    display: flex;
+    flex-direction: column;
+  }
+
   .option-wrapper {
-    .option-checkbox {
+    .option-checkbox,
+    .option-radio {
       margin-bottom: 0;
     }
 

--- a/user-interface/src/app/components/pending-questions/question-card/question-card.component.ts
+++ b/user-interface/src/app/components/pending-questions/question-card/question-card.component.ts
@@ -2,6 +2,7 @@ import { Component, EventEmitter, Input, Output, ChangeDetectionStrategy } from 
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MatRadioModule } from '@angular/material/radio';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
@@ -17,6 +18,7 @@ import type { PendingQuestion, AutoAnswerResponse } from '../../../models';
     CommonModule,
     FormsModule,
     MatCheckboxModule,
+    MatRadioModule,
     MatButtonModule,
     MatIconModule,
     MatProgressSpinnerModule,
@@ -44,8 +46,17 @@ export class QuestionCardComponent {
   wasAutoAnswered = false;
   autoAnswerConfidence = 0;
 
+  get isMultiSelect(): boolean {
+    return this.question.allow_multiple !== false;
+  }
+
   onOptionToggle(optionId: string, checked: boolean): void {
-    if (checked) {
+    if (!this.isMultiSelect && checked) {
+      // Single-select: clear all other selections, then set the new one.
+      this.selectedOptionIds.clear();
+      this.otherText = '';
+      this.selectedOptionIds.add(optionId);
+    } else if (checked) {
       this.selectedOptionIds.add(optionId);
     } else {
       this.selectedOptionIds.delete(optionId);
@@ -55,6 +66,14 @@ export class QuestionCardComponent {
     }
     this.wasAutoAnswered = false;
     this.optionToggled.emit({ optionId, checked });
+  }
+
+  onRadioChange(optionId: string): void {
+    this.selectedOptionIds.clear();
+    this.otherText = '';
+    this.selectedOptionIds.add(optionId);
+    this.wasAutoAnswered = false;
+    this.optionToggled.emit({ optionId, checked: true });
   }
 
   isOptionSelected(optionId: string): boolean {

--- a/user-interface/src/app/models/branding.model.ts
+++ b/user-interface/src/app/models/branding.model.ts
@@ -42,6 +42,7 @@ export interface Brand {
   client_id: string;
   name: string;
   status: 'draft' | 'active' | 'evolving' | 'archived';
+  conversation_id?: string | null;
   mission: BrandingMissionSnapshot;
   latest_output?: unknown | null;
   version: number;

--- a/user-interface/src/app/services/branding-api.service.ts
+++ b/user-interface/src/app/services/branding-api.service.ts
@@ -7,7 +7,6 @@ import type {
   BrandingQuestion,
   BrandingSessionResponse,
   Client,
-  ConversationSummary,
   CompetitiveSnapshot,
   ConversationStateResponse,
   CreateBrandRequest,
@@ -99,14 +98,6 @@ export class BrandingApiService {
     return this.http.post<ConversationStateResponse>(`${this.baseUrl}/conversations`, body);
   }
 
-  createConversationForBrand(brandId: string, initialMessage?: string | null): Observable<ConversationStateResponse> {
-    const body: CreateConversationRequest = {
-      brand_id: brandId,
-      ...(initialMessage != null ? { initial_message: initialMessage } : {}),
-    };
-    return this.http.post<ConversationStateResponse>(`${this.baseUrl}/conversations`, body);
-  }
-
   sendConversationMessage(conversationId: string, message: string): Observable<ConversationStateResponse> {
     return this.http.post<ConversationStateResponse>(
       `${this.baseUrl}/conversations/${conversationId}/messages`,
@@ -118,17 +109,9 @@ export class BrandingApiService {
     return this.http.get<ConversationStateResponse>(`${this.baseUrl}/conversations/${conversationId}`);
   }
 
-  listConversations(brandId?: string | null): Observable<ConversationSummary[]> {
-    if (brandId) {
-      return this.http.get<ConversationSummary[]>(`${this.baseUrl}/conversations?brand_id=${encodeURIComponent(brandId)}`);
-    }
-    return this.http.get<ConversationSummary[]>(`${this.baseUrl}/conversations`);
-  }
-
-  attachConversationToBrand(conversationId: string, brandId: string): Observable<ConversationStateResponse> {
-    return this.http.post<ConversationStateResponse>(
-      `${this.baseUrl}/conversations/${conversationId}/brand`,
-      { brand_id: brandId }
+  getBrandConversation(clientId: string, brandId: string): Observable<ConversationStateResponse> {
+    return this.http.get<ConversationStateResponse>(
+      `${this.baseUrl}/clients/${clientId}/brands/${brandId}/conversation`
     );
   }
 


### PR DESCRIPTION
- Introduced a new optional `conversation_id` field in the Brand model to associate conversations with brands.
- Updated the BrandingStore to handle conversation IDs during brand creation and updates.
- Enhanced the API to automatically create a conversation when a brand is created, ensuring a single permanent conversation is linked to each brand.
- Implemented logic to detach duplicate conversations from brands, maintaining only the one with the most messages.
- Updated frontend components to reflect changes in conversation handling and to emit events when brands are auto-created.
- Added tests to verify the new functionality and ensure proper integration with existing features.