### PR TITLE
feat(blogging): add blog landing page for first-time users

### DIFF
--- a/user-interface/src/app/app.routes.ts
+++ b/user-interface/src/app/app.routes.ts
@@ -1,6 +1,7 @@
 import { Routes } from '@angular/router';
 import { AppShellComponent } from './components/app-shell/app-shell.component';
 import { JobsDashboardComponent } from './components/jobs-dashboard/jobs-dashboard.component';
+import { BlogLandingComponent } from './components/blog-landing/blog-landing.component';
 import { BloggingDashboardComponent } from './components/blogging-dashboard/blogging-dashboard.component';
 import { BlogArtifactViewerComponent } from './components/blog-artifact-viewer/blog-artifact-viewer.component';
 import { MarketResearchDashboardComponent } from './components/market-research-dashboard/market-research-dashboard.component';
@@ -31,7 +32,8 @@ export const routes: Routes = [
     children: [
       { path: '', redirectTo: '/dashboard', pathMatch: 'full' },
       { path: 'dashboard', component: JobsDashboardComponent },
-      { path: 'blogging', component: BloggingDashboardComponent },
+      { path: 'blogging', component: BlogLandingComponent },
+      { path: 'blogging/dashboard', component: BloggingDashboardComponent },
       { path: 'blogging/jobs/:jobId/artifacts/:artifactName', component: BlogArtifactViewerComponent },
       { path: 'software-engineering', component: SoftwareEngineeringDashboardComponent },
       { path: 'software-engineering/planning-v3', component: PlanningV3PageComponent },

--- a/user-interface/src/app/components/app-shell/app-shell.component.html
+++ b/user-interface/src/app/components/app-shell/app-shell.component.html
@@ -26,9 +26,13 @@
 
       <div class="nav-group">
         <div class="nav-group-label">Content</div>
-        <a routerLink="/blogging" routerLinkActive="active" class="nav-link">
+        <a routerLink="/blogging" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="nav-link">
           <mat-icon>article</mat-icon>
           <span>Blogging</span>
+        </a>
+        <a routerLink="/blogging/dashboard" routerLinkActive="active" class="nav-link nav-link-nested">
+          <mat-icon>space_dashboard</mat-icon>
+          <span>Pipeline Dashboard</span>
         </a>
         <a routerLink="/branding" routerLinkActive="active" class="nav-link">
           <mat-icon>palette</mat-icon>

--- a/user-interface/src/app/components/blog-landing/blog-landing.component.html
+++ b/user-interface/src/app/components/blog-landing/blog-landing.component.html
@@ -1,0 +1,109 @@
+<!-- ================================================================
+     Hero Section
+     ================================================================ -->
+<section class="hero">
+  <div class="hero-glow"></div>
+  <div class="hero-content">
+    <span class="hero-badge">AI-Powered Blogging</span>
+    <h1 class="hero-title">
+      Write your first blog post<br />
+      <span class="hero-highlight">with an AI team behind you</span>
+    </h1>
+    <p class="hero-subtitle">
+      From research to publication-ready drafts, nine specialized AI agents handle
+      the heavy lifting while you stay in creative control. Just describe what you
+      want to write about and let the pipeline do the rest.
+    </p>
+    <div class="hero-actions">
+      <button mat-flat-button class="cta-primary" (click)="navigateToFullPipeline()">
+        <mat-icon>rocket_launch</mat-icon>
+        Start Writing
+      </button>
+      <button mat-stroked-button class="cta-secondary" (click)="navigateToResearch()">
+        <mat-icon>search</mat-icon>
+        Research a Topic First
+      </button>
+    </div>
+  </div>
+</section>
+
+<!-- ================================================================
+     How It Works — Pipeline Phases
+     ================================================================ -->
+<section class="pipeline-section">
+  <div class="section-header">
+    <h2 class="section-title">How it works</h2>
+    <p class="section-subtitle">
+      Eight phases, nine agents, one seamless pipeline. Every post goes through research,
+      planning, drafting, editing, and rigorous quality gates before it's ready to publish.
+    </p>
+  </div>
+
+  <div class="pipeline-track">
+    <div class="pipeline-line" aria-hidden="true"></div>
+    @for (phase of pipelinePhases; track phase.title; let i = $index) {
+      <div class="pipeline-step" [style.--step-delay]="(i * 60) + 'ms'">
+        <div class="step-marker">
+          <div class="step-icon-wrap">
+            <mat-icon>{{ phase.icon }}</mat-icon>
+          </div>
+          <span class="step-number">{{ i + 1 }}</span>
+        </div>
+        <div class="step-body">
+          <h3 class="step-title">{{ phase.title }}</h3>
+          <p class="step-description">{{ phase.description }}</p>
+        </div>
+      </div>
+    }
+  </div>
+</section>
+
+<!-- ================================================================
+     Features Grid
+     ================================================================ -->
+<section class="features-section">
+  <div class="section-header">
+    <h2 class="section-title">Built for serious content creators</h2>
+    <p class="section-subtitle">
+      Everything you need to produce research-backed, brand-aligned, publication-ready
+      content at a professional standard.
+    </p>
+  </div>
+
+  <div class="features-grid">
+    @for (feature of features; track feature.title) {
+      <div class="feature-card">
+        <div class="feature-icon-wrap">
+          <mat-icon>{{ feature.icon }}</mat-icon>
+        </div>
+        <h3 class="feature-title">{{ feature.title }}</h3>
+        <p class="feature-description">{{ feature.description }}</p>
+      </div>
+    }
+  </div>
+</section>
+
+<!-- ================================================================
+     Final CTA
+     ================================================================ -->
+<section class="final-cta">
+  <div class="cta-card">
+    <div class="cta-card-content">
+      <h2 class="cta-heading">Ready to write something great?</h2>
+      <p class="cta-text">
+        Describe your topic, choose a content profile, and let the AI blogging team
+        research, plan, draft, and polish your post. You stay in control at every step.
+      </p>
+      <div class="cta-buttons">
+        <button mat-flat-button class="cta-primary" (click)="navigateToFullPipeline()">
+          <mat-icon>edit</mat-icon>
+          Write My First Post
+        </button>
+        <button mat-stroked-button class="cta-secondary" (click)="navigateToDashboard()">
+          <mat-icon>dashboard</mat-icon>
+          Go to Dashboard
+        </button>
+      </div>
+    </div>
+  </div>
+</section>

--- a/user-interface/src/app/components/blog-landing/blog-landing.component.scss
+++ b/user-interface/src/app/components/blog-landing/blog-landing.component.scss
@@ -1,0 +1,410 @@
+// ============================================================================
+// Blog Landing Page — Premium Dark + Amber (Khala Design System)
+// ============================================================================
+
+:host {
+  display: block;
+  max-width: 960px;
+  margin: 0 auto;
+  padding-bottom: var(--kh-space-12);
+}
+
+// ── Hero ─────────────────────────────────────────────────────────────────────
+
+.hero {
+  position: relative;
+  padding: var(--kh-space-12) 0 var(--kh-space-10);
+  text-align: center;
+  overflow: hidden;
+}
+
+.hero-glow {
+  position: absolute;
+  top: -120px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 600px;
+  height: 600px;
+  background: radial-gradient(circle, rgba(251, 191, 36, 0.08) 0%, transparent 70%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.hero-content {
+  position: relative;
+  z-index: 1;
+}
+
+.hero-badge {
+  display: inline-block;
+  padding: var(--kh-space-1) var(--kh-space-4);
+  background: var(--kh-accent-subtle, rgba(251, 191, 36, 0.1));
+  color: var(--kh-accent-text);
+  font-size: var(--kh-text-xs);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  border-radius: var(--kh-radius-full);
+  border: 1px solid rgba(251, 191, 36, 0.2);
+  margin-bottom: var(--kh-space-6);
+}
+
+.hero-title {
+  margin: 0 0 var(--kh-space-5) 0;
+  font-size: clamp(2rem, 5vw, 3rem);
+  font-weight: 700;
+  line-height: 1.15;
+  color: var(--kh-text-primary);
+  letter-spacing: -0.02em;
+}
+
+.hero-highlight {
+  background: var(--kh-accent-gradient);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.hero-subtitle {
+  max-width: 620px;
+  margin: 0 auto var(--kh-space-8);
+  font-size: var(--kh-text-md);
+  line-height: 1.7;
+  color: var(--kh-text-tertiary);
+}
+
+.hero-actions {
+  display: flex;
+  gap: var(--kh-space-4);
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+// ── Shared Button Styles ─────────────────────────────────────────────────────
+
+.cta-primary {
+  background: var(--kh-accent-gradient) !important;
+  color: #000 !important;
+  font-weight: 600 !important;
+  padding: var(--kh-space-2) var(--kh-space-6) !important;
+  border-radius: var(--kh-radius-md) !important;
+  font-size: var(--kh-text-sm) !important;
+  height: 44px !important;
+  transition: box-shadow 0.2s ease, transform 0.15s ease !important;
+
+  mat-icon {
+    margin-right: var(--kh-space-2);
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+  }
+
+  &:hover {
+    box-shadow: var(--kh-shadow-glow) !important;
+    transform: translateY(-1px);
+  }
+}
+
+.cta-secondary {
+  border-color: var(--kh-border-strong) !important;
+  color: var(--kh-text-secondary) !important;
+  font-weight: 500 !important;
+  padding: var(--kh-space-2) var(--kh-space-6) !important;
+  border-radius: var(--kh-radius-md) !important;
+  font-size: var(--kh-text-sm) !important;
+  height: 44px !important;
+  transition: all 0.2s ease !important;
+
+  mat-icon {
+    margin-right: var(--kh-space-2);
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+  }
+
+  &:hover {
+    border-color: var(--kh-accent) !important;
+    color: var(--kh-accent-text) !important;
+    background: var(--kh-accent-subtle, rgba(251, 191, 36, 0.06)) !important;
+  }
+}
+
+// ── Section Headers ──────────────────────────────────────────────────────────
+
+.section-header {
+  text-align: center;
+  margin-bottom: var(--kh-space-10);
+}
+
+.section-title {
+  margin: 0 0 var(--kh-space-3) 0;
+  font-size: var(--kh-text-2xl);
+  font-weight: 700;
+  color: var(--kh-text-primary);
+  letter-spacing: -0.01em;
+}
+
+.section-subtitle {
+  max-width: 560px;
+  margin: 0 auto;
+  font-size: var(--kh-text-sm);
+  line-height: 1.7;
+  color: var(--kh-text-muted);
+}
+
+// ── Pipeline Section ─────────────────────────────────────────────────────────
+
+.pipeline-section {
+  padding: var(--kh-space-10) 0;
+}
+
+.pipeline-track {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: var(--kh-space-6) var(--kh-space-5);
+  max-width: 100%;
+}
+
+.pipeline-line {
+  display: none; // Hidden on grid layout; visual continuity is handled by step markers
+}
+
+.pipeline-step {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  animation: fadeInUp 0.4s ease both;
+  animation-delay: var(--step-delay, 0ms);
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(12px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.step-marker {
+  position: relative;
+  margin-bottom: var(--kh-space-4);
+}
+
+.step-icon-wrap {
+  width: 56px;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--kh-radius-lg);
+  background: var(--kh-surface-2);
+  border: 1px solid var(--kh-border);
+  transition: all 0.25s ease;
+
+  mat-icon {
+    font-size: 26px;
+    width: 26px;
+    height: 26px;
+    color: var(--kh-accent);
+  }
+
+  .pipeline-step:hover & {
+    background: var(--kh-accent-subtle, rgba(251, 191, 36, 0.08));
+    border-color: rgba(251, 191, 36, 0.3);
+    box-shadow: 0 0 16px rgba(251, 191, 36, 0.12);
+  }
+}
+
+.step-number {
+  position: absolute;
+  top: -6px;
+  right: -6px;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.6rem;
+  font-weight: 700;
+  color: #000;
+  background: var(--kh-accent);
+  border-radius: var(--kh-radius-full);
+}
+
+.step-title {
+  margin: 0 0 var(--kh-space-2) 0;
+  font-size: var(--kh-text-sm);
+  font-weight: 600;
+  color: var(--kh-text-primary);
+}
+
+.step-description {
+  margin: 0;
+  font-size: var(--kh-text-xs);
+  line-height: 1.6;
+  color: var(--kh-text-muted);
+}
+
+// ── Features Section ─────────────────────────────────────────────────────────
+
+.features-section {
+  padding: var(--kh-space-10) 0;
+}
+
+.features-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--kh-space-5);
+}
+
+.feature-card {
+  padding: var(--kh-space-6);
+  background: var(--kh-surface-2);
+  border: 1px solid var(--kh-border);
+  border-radius: var(--kh-radius-lg);
+  transition: all 0.25s ease;
+
+  &:hover {
+    border-color: rgba(251, 191, 36, 0.25);
+    background: var(--kh-surface-3);
+    transform: translateY(-2px);
+    box-shadow: var(--kh-shadow-md);
+  }
+}
+
+.feature-icon-wrap {
+  width: 42px;
+  height: 42px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--kh-radius-md);
+  background: var(--kh-accent-subtle, rgba(251, 191, 36, 0.08));
+  margin-bottom: var(--kh-space-4);
+
+  mat-icon {
+    font-size: 22px;
+    width: 22px;
+    height: 22px;
+    color: var(--kh-accent);
+  }
+}
+
+.feature-title {
+  margin: 0 0 var(--kh-space-2) 0;
+  font-size: var(--kh-text-sm);
+  font-weight: 600;
+  color: var(--kh-text-primary);
+}
+
+.feature-description {
+  margin: 0;
+  font-size: var(--kh-text-xs);
+  line-height: 1.6;
+  color: var(--kh-text-muted);
+}
+
+// ── Final CTA ────────────────────────────────────────────────────────────────
+
+.final-cta {
+  padding: var(--kh-space-8) 0 0;
+}
+
+.cta-card {
+  position: relative;
+  overflow: hidden;
+  border-radius: var(--kh-radius-xl, 16px);
+  border: 1px solid rgba(251, 191, 36, 0.2);
+  background:
+    radial-gradient(ellipse at 30% 50%, rgba(251, 191, 36, 0.06) 0%, transparent 60%),
+    var(--kh-surface-2);
+}
+
+.cta-card-content {
+  padding: var(--kh-space-10) var(--kh-space-8);
+  text-align: center;
+}
+
+.cta-heading {
+  margin: 0 0 var(--kh-space-3) 0;
+  font-size: var(--kh-text-xl);
+  font-weight: 700;
+  color: var(--kh-text-primary);
+}
+
+.cta-text {
+  max-width: 520px;
+  margin: 0 auto var(--kh-space-6);
+  font-size: var(--kh-text-sm);
+  line-height: 1.7;
+  color: var(--kh-text-tertiary);
+}
+
+.cta-buttons {
+  display: flex;
+  gap: var(--kh-space-4);
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+// ── Responsive ───────────────────────────────────────────────────────────────
+
+@media (max-width: 900px) {
+  .pipeline-track {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .features-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 600px) {
+  :host {
+    padding-left: var(--kh-space-4);
+    padding-right: var(--kh-space-4);
+  }
+
+  .hero {
+    padding: var(--kh-space-8) 0 var(--kh-space-6);
+  }
+
+  .hero-title {
+    font-size: 1.75rem;
+  }
+
+  .pipeline-track {
+    grid-template-columns: 1fr;
+    gap: var(--kh-space-4);
+  }
+
+  .pipeline-step {
+    flex-direction: row;
+    text-align: left;
+    gap: var(--kh-space-4);
+  }
+
+  .step-marker {
+    margin-bottom: 0;
+    flex-shrink: 0;
+  }
+
+  .features-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .cta-card-content {
+    padding: var(--kh-space-6) var(--kh-space-4);
+  }
+
+  .hero-actions,
+  .cta-buttons {
+    flex-direction: column;
+    align-items: stretch;
+  }
+}

--- a/user-interface/src/app/components/blog-landing/blog-landing.component.spec.ts
+++ b/user-interface/src/app/components/blog-landing/blog-landing.component.spec.ts
@@ -1,0 +1,71 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { BlogLandingComponent } from './blog-landing.component';
+import { Router } from '@angular/router';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
+describe('BlogLandingComponent', () => {
+  let component: BlogLandingComponent;
+  let fixture: ComponentFixture<BlogLandingComponent>;
+  let router: Router;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BlogLandingComponent, NoopAnimationsModule],
+      providers: [
+        {
+          provide: Router,
+          useValue: { navigate: vi.fn() },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BlogLandingComponent);
+    component = fixture.componentInstance;
+    router = TestBed.inject(Router);
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should navigate to dashboard on navigateToDashboard', () => {
+    component.navigateToDashboard();
+    expect(router.navigate).toHaveBeenCalledWith(['/blogging/dashboard']);
+  });
+
+  it('should navigate to full pipeline tab', () => {
+    component.navigateToFullPipeline();
+    expect(router.navigate).toHaveBeenCalledWith(['/blogging/dashboard'], { queryParams: { tab: 'full-pipeline' } });
+  });
+
+  it('should navigate to research tab', () => {
+    component.navigateToResearch();
+    expect(router.navigate).toHaveBeenCalledWith(['/blogging/dashboard'], { queryParams: { tab: 'research' } });
+  });
+
+  it('should have 8 pipeline phases', () => {
+    expect(component.pipelinePhases.length).toBe(8);
+  });
+
+  it('should have 6 features', () => {
+    expect(component.features.length).toBe(6);
+  });
+
+  it('should render hero title', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('.hero-title')?.textContent).toContain('Write your first blog post');
+  });
+
+  it('should render pipeline steps', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    const steps = compiled.querySelectorAll('.pipeline-step');
+    expect(steps.length).toBe(8);
+  });
+
+  it('should render feature cards', () => {
+    const compiled = fixture.nativeElement as HTMLElement;
+    const cards = compiled.querySelectorAll('.feature-card');
+    expect(cards.length).toBe(6);
+  });
+});

--- a/user-interface/src/app/components/blog-landing/blog-landing.component.ts
+++ b/user-interface/src/app/components/blog-landing/blog-landing.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { Router } from '@angular/router';
 import { MatButtonModule } from '@angular/material/button';
@@ -12,7 +12,7 @@ import { MatIconModule } from '@angular/material/icon';
   styleUrl: './blog-landing.component.scss',
 })
 export class BlogLandingComponent {
-  constructor(private readonly router: Router) {}
+  private readonly router = inject(Router);
 
   navigateToDashboard(): void {
     this.router.navigate(['/blogging/dashboard']);

--- a/user-interface/src/app/components/blog-landing/blog-landing.component.ts
+++ b/user-interface/src/app/components/blog-landing/blog-landing.component.ts
@@ -1,0 +1,104 @@
+import { Component } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+
+@Component({
+  selector: 'app-blog-landing',
+  standalone: true,
+  imports: [CommonModule, MatButtonModule, MatIconModule],
+  templateUrl: './blog-landing.component.html',
+  styleUrl: './blog-landing.component.scss',
+})
+export class BlogLandingComponent {
+  constructor(private readonly router: Router) {}
+
+  navigateToDashboard(): void {
+    this.router.navigate(['/blogging/dashboard']);
+  }
+
+  navigateToFullPipeline(): void {
+    this.router.navigate(['/blogging/dashboard'], { queryParams: { tab: 'full-pipeline' } });
+  }
+
+  navigateToResearch(): void {
+    this.router.navigate(['/blogging/dashboard'], { queryParams: { tab: 'research' } });
+  }
+
+  readonly pipelinePhases = [
+    {
+      icon: 'travel_explore',
+      title: 'Research',
+      description: 'AI scours the web and arXiv for relevant sources, ranks them, and compiles a research document.',
+    },
+    {
+      icon: 'architecture',
+      title: 'Planning',
+      description: 'Generates a structured content plan with title options, narrative flow, and per-section coverage.',
+    },
+    {
+      icon: 'edit_note',
+      title: 'Drafting',
+      description: 'Produces a full draft from your research and plan, guided by your brand voice and style.',
+    },
+    {
+      icon: 'rate_review',
+      title: 'Copy Edit',
+      description: 'An AI editor reviews structure, clarity, and tone with actionable feedback and revisions.',
+    },
+    {
+      icon: 'fact_check',
+      title: 'Fact Check',
+      description: 'Extracts claims, assesses risk, and flags anything that needs verification before publishing.',
+    },
+    {
+      icon: 'verified',
+      title: 'Compliance',
+      description: 'Enforces your brand spec and writing guidelines. Hard gate: a failure blocks publication.',
+    },
+    {
+      icon: 'loop',
+      title: 'Rewrite',
+      description: 'If any gate fails, targeted fixes are applied and gates re-run automatically (up to 3 rounds).',
+    },
+    {
+      icon: 'publish',
+      title: 'Finalize',
+      description: 'Generates platform-specific versions for Medium, dev.to, and Substack, plus a publishing pack.',
+    },
+  ];
+
+  readonly features = [
+    {
+      icon: 'tune',
+      title: 'Content Profiles',
+      description: 'Choose from short listicle, standard article, technical deep dive, or series instalment.',
+    },
+    {
+      icon: 'people',
+      title: 'Audience Targeting',
+      description: 'Define skill level, profession, and interests so the AI tailors language and depth.',
+    },
+    {
+      icon: 'auto_stories',
+      title: 'Story Bank',
+      description: 'A ghost writer interviews you for first-person narratives, stored for reuse across posts.',
+    },
+    {
+      icon: 'chat',
+      title: 'Interactive Collaboration',
+      description: 'Choose titles, answer questions, and share stories as the pipeline works alongside you.',
+    },
+    {
+      icon: 'analytics',
+      title: 'Medium Analytics',
+      description: 'Scrape your Medium dashboard stats to inform content strategy with real performance data.',
+    },
+    {
+      icon: 'inventory_2',
+      title: 'Rich Artifacts',
+      description: '16 versioned artifacts from research packets to compliance reports, all downloadable.',
+    },
+  ];
+}


### PR DESCRIPTION
## Summary

- Adds a professionally designed landing page at `/blogging` that welcomes users and encourages them to write their first blog post with the AI team
- Showcases the 8-phase pipeline (Research → Planning → Drafting → Copy Edit → Fact Check → Compliance → Rewrite → Finalize) with an animated step-by-step visual
- Highlights 6 key features: Content Profiles, Audience Targeting, Story Bank, Interactive Collaboration, Medium Analytics, and Rich Artifacts
- Provides clear CTAs to start writing (full pipeline) or research a topic first
- Moves the existing blogging dashboard to `/blogging/dashboard` with a nested sidebar link under "Blogging"
- Follows the Khala Design System (dark + amber theme) with responsive layout for mobile/tablet/desktop
- Includes 9 passing unit tests

## Test plan

- [x] `npx ng build --configuration=development` succeeds
- [x] All 9 unit tests pass (`vitest run blog-landing.component.spec.ts`)
- [ ] Navigate to `/blogging` — landing page renders with hero, pipeline, features, and CTA sections
- [ ] Click "Start Writing" — navigates to `/blogging/dashboard?tab=full-pipeline`
- [ ] Click "Research a Topic First" — navigates to `/blogging/dashboard?tab=research`
- [ ] Click "Go to Dashboard" — navigates to `/blogging/dashboard`
- [ ] Sidebar shows "Blogging" link (landing) and nested "Pipeline Dashboard" link
- [ ] Responsive: verify layout at 600px, 900px, and 1200px widths

https://claude.ai/code/session_012RXUZzm3ZS4AhQMFojPSsU