### PR TITLE
Update README docs to reflect current 19-team architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,18 @@ Strands Agents is a monorepo for multi-agent "team" systems. Each team exposes a
 ```text
 strands-agents/
 ├── backend/
-│   ├── agents/                 # Team implementations + team-specific APIs
+│   ├── agents/                 # Team implementations + team-specific APIs (19 teams)
 │   ├── unified_api/            # Unified FastAPI app mounting all teams
 │   ├── run_unified_api.py      # Unified API launcher
-│   └── studiogrid/             # Temporal workflows and worker stack
-├── user-interface/             # Angular frontend
+│   ├── studiogrid/             # StudioGrid design-system workflow
+│   ├── blogging_service/       # Isolated blogging microservice container
+│   ├── job_service/            # Centralized job state tracking service (Postgres)
+│   ├── team_service/           # Generic team microservice container
+│   ├── studiogrid_service/     # StudioGrid microservice container
+│   ├── post_mortems/           # Agent failure audit log
+│   ├── Makefile                # Build, lint, test, run targets
+│   └── pyproject.toml          # Ruff + pytest config
+├── user-interface/             # Angular 19 frontend
 └── docker/                     # Full-stack Docker Compose setup
 ```
 
@@ -20,7 +27,9 @@ strands-agents/
 ### 1) Backend dependencies
 
 ```bash
-cd backend/agents
+cd backend
+make install          # Create venv, install deps
+# Or manually:
 pip install -r requirements.txt
 ```
 
@@ -45,7 +54,7 @@ UI: <http://localhost:4200>
 
 ## Unified API team routes
 
-The Unified API mounts teams under `/api/*` prefixes. Current configured routes:
+The Unified API mounts teams under `/api/*` prefixes. Current configured routes (19 teams):
 
 - `/api/blogging`
 - `/api/software-engineering`
@@ -64,6 +73,8 @@ The Unified API mounts teams under `/api/*` prefixes. Current configured routes:
 - `/api/studio-grid`
 - `/api/sales`
 - `/api/road-trip-planning`
+- `/api/agentic-team-provisioning`
+- `/api/startup-advisor`
 
 ## Team documentation
 
@@ -82,13 +93,17 @@ The Unified API mounts teams under `/api/*` prefixes. Current configured routes:
 - `backend/agents/nutrition_meal_planning_team/README.md`
 - `backend/agents/planning_v3_team/README.md`
 - `backend/agents/coding_team/README.md`
+- `backend/agents/sales_team/` (AI Sales Team)
+- `backend/agents/road_trip_planning_team/` (Road Trip Planning)
+- `backend/agents/agentic_team_provisioning/` (Agentic Team Provisioning)
+- `backend/agents/startup_advisor/` (Startup Advisor)
 
 ## Docker
 
 For the full stack (Postgres, Temporal, optional Ollama, backend APIs, and UI):
 
 ```bash
-docker compose -f docker/docker-compose.yml up --build
+docker compose -f docker/docker-compose.yml --env-file docker/.env up --build
 ```
 
 See `docker/README.md` for env vars, ports, and deployment notes.
@@ -97,5 +112,6 @@ See `docker/README.md` for env vars, ports, and deployment notes.
 
 - `backend/unified_api/README.md`
 - `backend/studiogrid/README.md`
+- `backend/post_mortems/POST_MORTEMS.md`
 - `ARCHITECTURE.md`
 - `CONTRIBUTORS.md`

--- a/backend/agents/README.md
+++ b/backend/agents/README.md
@@ -17,16 +17,20 @@ backend/agents/
 ├── soc2_compliance_team/
 ├── branding_team/
 ├── agent_provisioning_team/
+├── agentic_team_provisioning/         # Conversational team/process creation
 ├── accessibility_audit_team/
 ├── ai_systems_team/
 ├── investment_team/
 ├── nutrition_meal_planning_team/
 ├── road_trip_planning_team/
 ├── sales_team/
-├── agent_repair_team/
+├── startup_advisor/                   # Persistent conversational startup advisor
+├── agent_repair_team/                 # Agent crash recovery
 ├── integrations/                      # Shared integrations layer used across teams
 ├── llm_service/                       # Centralized LLM client (Ollama, dummy)
 ├── docker/                            # Agents-only Docker assets
+├── shared_job_management.py           # Shared job state helpers
+├── job_service_client.py              # HTTP client for centralized job service
 ├── Dockerfile
 ├── docker-compose.yml
 └── requirements.txt
@@ -40,7 +44,7 @@ From `backend/`:
 python run_unified_api.py
 ```
 
-This mounts all enabled team APIs behind one server on port `8080` by default.
+This mounts all 19 enabled team APIs behind one server on port `8080` by default.
 
 ## Running individual team APIs
 
@@ -77,6 +81,10 @@ For team-specific setup and env vars, use each team's README.
 - `ai_systems_team/README.md`
 - `investment_team/README.md`
 - `nutrition_meal_planning_team/README.md`
+- `road_trip_planning_team/`
+- `sales_team/`
+- `startup_advisor/`
+- `agentic_team_provisioning/`
 - `llm_service/README.md`
 
 ## Shared integrations

--- a/backend/unified_api/README.md
+++ b/backend/unified_api/README.md
@@ -4,7 +4,7 @@ The Unified API Server consolidates all Strands Agent team APIs under a single e
 
 ## Overview
 
-Instead of running multiple API servers on different ports, the unified server mounts all team APIs under namespaced prefixes on a single port (default: 8080).
+Instead of running multiple API servers on different ports, the unified server mounts all 19 team APIs under namespaced prefixes on a single port (default: 8080). Teams can also be deployed as standalone microservices; when a `*_SERVICE_URL` env var is set for a team, the unified API proxies requests to that external service instead of mounting in-process.
 
 ```mermaid
 graph TB
@@ -31,6 +31,8 @@ graph TB
             Studio["/api/studio-grid"]
             Sales["/api/sales"]
             RoadTrip["/api/road-trip-planning"]
+            AgenticProv["/api/agentic-team-provisioning"]
+            StartupAdv["/api/startup-advisor"]
         end
     end
     
@@ -87,6 +89,8 @@ python run_unified_api.py --workers 4 --log-level warning
 | StudioGrid | `/api/studio-grid` | `/api/studio-grid/docs` |
 | AI Sales Team | `/api/sales` | `/api/sales/docs` |
 | Road Trip Planning | `/api/road-trip-planning` | `/api/road-trip-planning/docs` |
+| Agentic Team Provisioning | `/api/agentic-team-provisioning` | `/api/agentic-team-provisioning/docs` |
+| Startup Advisor | `/api/startup-advisor` | `/api/startup-advisor/docs` |
 
 ## Environment Variables
 
@@ -181,7 +185,7 @@ If a team API fails to import (missing dependencies, configuration errors), the 
 
 ```
 2024-01-15 10:00:00 [WARNING] unified_api: Could not mount Investment Team API: No module named 'investment_team'
-2024-01-15 10:00:00 [INFO] unified_api: Mounted 7/8 team APIs
+2024-01-15 10:00:00 [INFO] unified_api: Mounted 18/19 team APIs
 ```
 
 ## Example Usage

--- a/user-interface/README.md
+++ b/user-interface/README.md
@@ -1,6 +1,6 @@
 # Strands Agents User Interface
 
-Angular application providing an interactive UI for all Strands agent APIs: Blogging, Software Engineering Team, Personal Assistant, Market Research, SOC2 Compliance, Social Media Marketing, Branding, Agent Provisioning, Accessibility Audit, AI Systems, Investment, Nutrition & Meal Planning, Planning V3, Coding Team, StudioGrid, AI Sales Team, and Road Trip Planning.
+Angular application providing an interactive UI for all Strands agent APIs: Blogging, Software Engineering Team, Personal Assistant, Market Research, SOC2 Compliance, Social Media Marketing, Branding, Agent Provisioning, Accessibility Audit, AI Systems, Investment, Nutrition & Meal Planning, Planning V3, Coding Team, StudioGrid, AI Sales Team, Road Trip Planning, Agentic Team Provisioning, and Startup Advisor.
 
 ## Prerequisites
 
@@ -36,7 +36,7 @@ API base URLs are configured in `src/environments/environment.ts` (development) 
 | Branding | `http://localhost:8012` | 8012 |
 | **Unified API** | `http://localhost:8080` | 8080 |
 
-**Note:** The Unified API provides all team APIs under a single endpoint with namespaced prefixes (e.g., `/api/blogging`, `/api/personal-assistant`, `/api/planning-v3`, `/api/coding-team`, `/api/sales`, `/api/road-trip-planning`). When running via Docker Compose the UI at port 4201 proxies all `/api/*` requests to the agents container at port 8888.
+**Note:** The Unified API provides all 19 team APIs under a single endpoint with namespaced prefixes (e.g., `/api/blogging`, `/api/personal-assistant`, `/api/planning-v3`, `/api/coding-team`, `/api/sales`, `/api/road-trip-planning`, `/api/agentic-team-provisioning`, `/api/startup-advisor`). When running via Docker Compose the UI at port 4201 proxies all `/api/*` requests to the agents container at port 8888.
 
 To override, edit `src/environments/environment.ts` before building.
 


### PR DESCRIPTION
## Summary

- **Add missing teams** (`agentic-team-provisioning`, `startup-advisor`) to all route listings, Mermaid diagrams, and team documentation links across 4 README files
- **Update root README repo layout** to include newer backend services (`blogging_service/`, `job_service/`, `team_service/`, `studiogrid_service/`, `post_mortems/`, `Makefile`, `pyproject.toml`)
- **Fix quick-start instructions** — point to `backend/` (not `backend/agents/`) and reference `make install`; add `--env-file docker/.env` to Docker command
- **Document microservice proxy pattern** in unified API README (teams can be deployed standalone via `*_SERVICE_URL` env vars)
- **Update team counts** from stale numbers to 19 across all docs

### Files changed

| File | Changes |
|------|---------|
| `README.md` | Repo layout, quick-start, routes, team docs links, Docker command |
| `backend/agents/README.md` | Directory tree, team count, README links |
| `backend/unified_api/README.md` | Mermaid diagram, API table, proxy docs, example log |
| `user-interface/README.md` | Team list, route examples |

## Test plan

- [ ] Verify all 19 routes listed match `backend/unified_api/config.py` TEAM_CONFIGS
- [ ] Confirm Mermaid diagram renders correctly in GitHub
- [ ] Spot-check that linked team directories exist

https://claude.ai/code/session_01NnQXWLYLuzrXmT1VYoGQLx