### PR TITLE
Add chat/manual form toggle to startup advisor UI

### DIFF
--- a/user-interface/src/app/components/startup-advisor-dashboard/startup-advisor-dashboard.component.html
+++ b/user-interface/src/app/components/startup-advisor-dashboard/startup-advisor-dashboard.component.html
@@ -8,70 +8,142 @@
       <p>Your persistent AI advisor for strategic startup guidance. Pick up right where you left off.</p>
     </div>
   </div>
+
+  <mat-button-toggle-group
+    class="mode-toggle"
+    [value]="mode"
+    (change)="mode = $event.value"
+    aria-label="Interaction mode"
+  >
+    <mat-button-toggle value="chat">
+      <mat-icon>chat</mat-icon>
+      Chat with Advisor
+    </mat-button-toggle>
+    <mat-button-toggle value="form">
+      <mat-icon>edit_note</mat-icon>
+      Fill in Manually
+    </mat-button-toggle>
+  </mat-button-toggle-group>
 </section>
 
 <div class="advisor-layout">
-  <mat-card class="chat-card">
-    <mat-card-content>
-      @if (error) {
-        <p class="error-text">{{ error }}</p>
-        <button mat-stroked-button (click)="retryConnect()" [disabled]="loading">
-          Retry
-        </button>
-      }
-
-      <div class="messages-container" #messagesContainer>
-        @for (msg of messages; track msg.timestamp + msg.content) {
-          <div class="message" [class.user]="msg.role === 'user'" [class.assistant]="msg.role === 'assistant'">
-            <div class="message-content">{{ msg.content }}</div>
-            <div class="message-time">{{ formatTime(msg.timestamp) }}</div>
-          </div>
+  <!-- ======== CHAT MODE ======== -->
+  @if (mode === 'chat') {
+    <mat-card class="chat-card">
+      <mat-card-content>
+        @if (error) {
+          <p class="error-text">{{ error }}</p>
+          <button mat-stroked-button (click)="retryConnect()" [disabled]="loading">
+            Retry
+          </button>
         }
 
-        @if (loading && messages.length > 0 && messages[messages.length - 1].role === 'user') {
-          <div class="message assistant">
-            <div class="typing-indicator">
-              <span></span>
-              <span></span>
-              <span></span>
+        <div class="messages-container" #messagesContainer>
+          @for (msg of messages; track msg.timestamp + msg.content) {
+            <div class="message" [class.user]="msg.role === 'user'" [class.assistant]="msg.role === 'assistant'">
+              <div class="message-content">{{ msg.content }}</div>
+              <div class="message-time">{{ formatTime(msg.timestamp) }}</div>
             </div>
-          </div>
-        }
-      </div>
+          }
 
-      <form [formGroup]="form" (ngSubmit)="onSubmit()" class="input-form">
-        <mat-form-field appearance="outline" class="message-input">
-          <mat-label>Ask your startup advisor...</mat-label>
-          <input
-            matInput
-            formControlName="message"
-            [attr.aria-label]="'Message input'"
-            (keydown.enter)="$event.preventDefault(); onSubmit()"
-          />
-        </mat-form-field>
-        <button
-          mat-fab
-          color="primary"
-          type="submit"
-          [disabled]="form.invalid || loading"
-          [attr.aria-label]="'Send message'"
-        >
-          <mat-icon>send</mat-icon>
-        </button>
-      </form>
-
-      @if (suggestedQuestions.length > 0) {
-        <div class="suggested-questions">
-          @for (q of suggestedQuestions; track q) {
-            <button mat-stroked-button (click)="onSuggestedQuestion(q)" [disabled]="loading">
-              {{ q }}
-            </button>
+          @if (loading && messages.length > 0 && messages[messages.length - 1].role === 'user') {
+            <div class="message assistant">
+              <div class="typing-indicator">
+                <span></span>
+                <span></span>
+                <span></span>
+              </div>
+            </div>
           }
         </div>
-      }
-    </mat-card-content>
-  </mat-card>
 
+        <form [formGroup]="form" (ngSubmit)="onSubmit()" class="input-form">
+          <mat-form-field appearance="outline" class="message-input">
+            <mat-label>Ask your startup advisor...</mat-label>
+            <input
+              matInput
+              formControlName="message"
+              [attr.aria-label]="'Message input'"
+              (keydown.enter)="$event.preventDefault(); onSubmit()"
+            />
+          </mat-form-field>
+          <button
+            mat-fab
+            color="primary"
+            type="submit"
+            [disabled]="form.invalid || loading"
+            [attr.aria-label]="'Send message'"
+          >
+            <mat-icon>send</mat-icon>
+          </button>
+        </form>
+
+        @if (suggestedQuestions.length > 0) {
+          <div class="suggested-questions">
+            @for (q of suggestedQuestions; track q) {
+              <button mat-stroked-button (click)="onSuggestedQuestion(q)" [disabled]="loading">
+                {{ q }}
+              </button>
+            }
+          </div>
+        }
+      </mat-card-content>
+    </mat-card>
+  }
+
+  <!-- ======== MANUAL FORM MODE ======== -->
+  @if (mode === 'form') {
+    <mat-card class="form-card">
+      <mat-card-header>
+        <mat-icon mat-card-avatar>edit_note</mat-icon>
+        <mat-card-title>Founder Profile</mat-card-title>
+        <mat-card-subtitle>Fill in your startup details directly. The advisor will use this context in future conversations.</mat-card-subtitle>
+      </mat-card-header>
+
+      <mat-card-content>
+        @if (error) {
+          <p class="error-text">{{ error }}</p>
+        }
+
+        <form [formGroup]="profileForm" (ngSubmit)="onSaveProfile()" class="profile-form">
+          @for (field of profileFields; track field.key) {
+            <mat-form-field appearance="outline" class="profile-field">
+              <mat-label>{{ field.label }}</mat-label>
+              <input
+                matInput
+                [formControlName]="field.key"
+                [placeholder]="field.placeholder"
+                [attr.aria-label]="field.label"
+              />
+            </mat-form-field>
+          }
+
+          <div class="form-actions">
+            <span class="field-count">{{ filledFieldCount() }} of {{ profileFields.length }} fields filled</span>
+            <button
+              mat-flat-button
+              color="primary"
+              type="submit"
+              [disabled]="savingProfile || filledFieldCount() === 0"
+            >
+              @if (savingProfile) {
+                Saving...
+              } @else {
+                Save Profile
+              }
+            </button>
+          </div>
+        </form>
+
+        <div class="form-hint">
+          <mat-icon>info</mat-icon>
+          <span>You can fill in as many or as few fields as you like. Switch to chat mode anytime to continue the conversation with this context.</span>
+        </div>
+      </mat-card-content>
+    </mat-card>
+  }
+
+  <!-- ======== SIDEBAR ======== -->
   <div class="sidebar">
     <mat-card class="context-card">
       <mat-card-header>
@@ -81,13 +153,43 @@
       </mat-card-header>
       <mat-card-content>
         @if (contextEntries().length === 0) {
-          <p class="empty-hint">Start chatting and the advisor will build your profile as you share details.</p>
+          <p class="empty-hint">Start chatting or fill in the form to build your profile.</p>
         } @else {
           <div class="context-grid">
             @for (entry of contextEntries(); track entry[0]) {
               <div class="context-item">
-                <span class="context-label">{{ formatContextKey(entry[0]) }}</span>
-                <span class="context-value">{{ entry[1] }}</span>
+                @if (editingContextKey === entry[0]) {
+                  <span class="context-label">{{ formatContextKey(entry[0]) }}</span>
+                  <div class="context-edit-row">
+                    <input
+                      class="context-edit-input"
+                      [value]="editingContextValue"
+                      (input)="editingContextValue = $any($event.target).value"
+                      (keydown.enter)="saveEditContext()"
+                      (keydown.escape)="cancelEditContext()"
+                      aria-label="Edit value"
+                    />
+                    <button mat-icon-button (click)="saveEditContext()" aria-label="Save">
+                      <mat-icon>check</mat-icon>
+                    </button>
+                    <button mat-icon-button (click)="cancelEditContext()" aria-label="Cancel">
+                      <mat-icon>close</mat-icon>
+                    </button>
+                  </div>
+                } @else {
+                  <span class="context-label">{{ formatContextKey(entry[0]) }}</span>
+                  <div class="context-value-row">
+                    <span class="context-value">{{ entry[1] }}</span>
+                    <button
+                      mat-icon-button
+                      class="context-edit-btn"
+                      (click)="startEditContext(entry[0], entry[1])"
+                      aria-label="Edit"
+                    >
+                      <mat-icon>edit</mat-icon>
+                    </button>
+                  </div>
+                }
               </div>
             }
           </div>
@@ -114,6 +216,25 @@
               </mat-card-content>
             </mat-card>
           }
+        </mat-card-content>
+      </mat-card>
+    }
+
+    @if (suggestedQuestions.length > 0 && mode === 'form') {
+      <mat-card class="suggestions-card">
+        <mat-card-header>
+          <mat-icon mat-card-avatar>lightbulb</mat-icon>
+          <mat-card-title>Suggested Topics</mat-card-title>
+          <mat-card-subtitle>Click to switch to chat and discuss</mat-card-subtitle>
+        </mat-card-header>
+        <mat-card-content>
+          <div class="suggested-questions">
+            @for (q of suggestedQuestions; track q) {
+              <button mat-stroked-button (click)="onSuggestedQuestion(q)" [disabled]="loading">
+                {{ q }}
+              </button>
+            }
+          </div>
         </mat-card-content>
       </mat-card>
     }

--- a/user-interface/src/app/components/startup-advisor-dashboard/startup-advisor-dashboard.component.scss
+++ b/user-interface/src/app/components/startup-advisor-dashboard/startup-advisor-dashboard.component.scss
@@ -1,5 +1,10 @@
 .workspace-header {
   margin-bottom: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 1rem;
 }
 
 .title-block {
@@ -34,6 +39,30 @@
     font-size: 28px;
     width: 28px;
     height: 28px;
+  }
+}
+
+.mode-toggle {
+  border-radius: 10px;
+  overflow: hidden;
+
+  ::ng-deep .mat-button-toggle-appearance-standard {
+    background: #161b22;
+    color: #8b949e;
+    border-color: rgba(255, 255, 255, 0.08);
+  }
+
+  ::ng-deep .mat-button-toggle-checked .mat-button-toggle-appearance-standard {
+    background: rgba(59, 130, 246, 0.18);
+    color: #58a6ff;
+  }
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    margin-right: 6px;
+    vertical-align: middle;
   }
 }
 
@@ -192,6 +221,61 @@
   }
 }
 
+// -- Manual form card --
+
+.form-card {
+  background: #161b22;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+}
+
+.profile-form {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem 1rem;
+  margin-top: 0.5rem;
+}
+
+.profile-field {
+  width: 100%;
+}
+
+.form-actions {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 0.25rem;
+}
+
+.field-count {
+  font-size: 0.82rem;
+  color: #8b949e;
+}
+
+.form-hint {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-top: 1rem;
+  padding: 12px 16px;
+  border-radius: 8px;
+  background: rgba(88, 166, 255, 0.08);
+  border: 1px solid rgba(88, 166, 255, 0.15);
+  font-size: 0.84rem;
+  color: #8b949e;
+  line-height: 1.5;
+
+  mat-icon {
+    color: #58a6ff;
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+}
+
 // -- Sidebar --
 
 .sidebar {
@@ -201,7 +285,8 @@
 }
 
 .context-card,
-.artifacts-card {
+.artifacts-card,
+.suggestions-card {
   border-radius: 12px;
 }
 
@@ -242,6 +327,53 @@
   color: #d4dde7;
 }
 
+.context-value-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 4px;
+
+  .context-edit-btn {
+    opacity: 0;
+    transition: opacity 0.15s;
+    width: 28px;
+    height: 28px;
+    flex-shrink: 0;
+
+    mat-icon {
+      font-size: 16px;
+      width: 16px;
+      height: 16px;
+      color: #8b949e;
+    }
+  }
+
+  &:hover .context-edit-btn {
+    opacity: 1;
+  }
+}
+
+.context-edit-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.context-edit-input {
+  flex: 1;
+  background: #0d1117;
+  border: 1px solid rgba(88, 166, 255, 0.4);
+  border-radius: 6px;
+  color: #f0f6fc;
+  padding: 6px 10px;
+  font-size: 0.88rem;
+  outline: none;
+
+  &:focus {
+    border-color: #58a6ff;
+  }
+}
+
 .artifact-item {
   margin-bottom: 0.75rem;
   border: 1px solid rgba(148, 163, 184, 0.18);
@@ -268,6 +400,10 @@
 
 @media (max-width: 1024px) {
   .advisor-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .profile-form {
     grid-template-columns: 1fr;
   }
 }

--- a/user-interface/src/app/components/startup-advisor-dashboard/startup-advisor-dashboard.component.ts
+++ b/user-interface/src/app/components/startup-advisor-dashboard/startup-advisor-dashboard.component.ts
@@ -7,18 +7,23 @@ import {
   inject,
 } from '@angular/core';
 import { JsonPipe } from '@angular/common';
-import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { FormBuilder, FormGroup, FormControl, ReactiveFormsModule, Validators } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatChipsModule } from '@angular/material/chips';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { StartupAdvisorApiService } from '../../services/startup-advisor-api.service';
-import type {
-  StartupAdvisorMessage,
-  StartupAdvisorArtifact,
+import {
+  STARTUP_ADVISOR_PROFILE_FIELDS,
+  type StartupAdvisorMessage,
+  type StartupAdvisorArtifact,
 } from '../../models';
+
+type InteractionMode = 'chat' | 'form';
 
 @Component({
   selector: 'app-startup-advisor-dashboard',
@@ -32,6 +37,8 @@ import type {
     MatButtonModule,
     MatIconModule,
     MatChipsModule,
+    MatButtonToggleModule,
+    MatSnackBarModule,
   ],
   templateUrl: './startup-advisor-dashboard.component.html',
   styleUrl: './startup-advisor-dashboard.component.scss',
@@ -41,6 +48,9 @@ export class StartupAdvisorDashboardComponent implements OnInit, AfterViewChecke
 
   private readonly api = inject(StartupAdvisorApiService);
   private readonly fb = inject(FormBuilder);
+  private readonly snackBar = inject(MatSnackBar);
+
+  readonly profileFields = STARTUP_ADVISOR_PROFILE_FIELDS;
 
   messages: StartupAdvisorMessage[] = [];
   artifacts: StartupAdvisorArtifact[] = [];
@@ -50,16 +60,46 @@ export class StartupAdvisorDashboardComponent implements OnInit, AfterViewChecke
   error: string | null = null;
   conversationId: string | null = null;
 
+  mode: InteractionMode = 'chat';
+
+  /** Chat input form */
   form = this.fb.nonNullable.group({
     message: ['', [Validators.required, Validators.minLength(1)]],
   });
 
+  /** Manual profile form — built dynamically from profileFields */
+  profileForm!: FormGroup;
+
+  /** Tracks which sidebar context field is being inline-edited */
+  editingContextKey: string | null = null;
+  editingContextValue = '';
+
+  savingProfile = false;
+
   ngOnInit(): void {
+    this.buildProfileForm();
     this.loadConversation();
   }
 
   ngAfterViewChecked(): void {
     this.scrollToBottom();
+  }
+
+  private buildProfileForm(): void {
+    const controls: Record<string, FormControl<string>> = {};
+    for (const field of this.profileFields) {
+      controls[field.key] = new FormControl('', { nonNullable: true });
+    }
+    this.profileForm = new FormGroup(controls);
+  }
+
+  private syncProfileFormFromContext(): void {
+    for (const field of this.profileFields) {
+      const val = this.context[field.key];
+      if (val != null && val !== '') {
+        this.profileForm.get(field.key)?.setValue(String(val), { emitEvent: false });
+      }
+    }
   }
 
   private scrollToBottom(): void {
@@ -79,6 +119,7 @@ export class StartupAdvisorDashboardComponent implements OnInit, AfterViewChecke
         this.artifacts = state.artifacts;
         this.context = state.context;
         this.suggestedQuestions = state.suggested_questions;
+        this.syncProfileFormFromContext();
         this.loading = false;
       },
       error: (err) => {
@@ -90,6 +131,8 @@ export class StartupAdvisorDashboardComponent implements OnInit, AfterViewChecke
     });
   }
 
+  // -- Chat mode --
+
   onSubmit(): void {
     if (this.form.invalid || this.loading) return;
     const message = this.form.getRawValue().message.trim();
@@ -98,6 +141,7 @@ export class StartupAdvisorDashboardComponent implements OnInit, AfterViewChecke
   }
 
   onSuggestedQuestion(question: string): void {
+    this.mode = 'chat';
     this.sendMessage(question);
   }
 
@@ -120,6 +164,7 @@ export class StartupAdvisorDashboardComponent implements OnInit, AfterViewChecke
         this.artifacts = state.artifacts;
         this.context = state.context;
         this.suggestedQuestions = state.suggested_questions;
+        this.syncProfileFormFromContext();
         this.loading = false;
       },
       error: (err) => {
@@ -128,6 +173,83 @@ export class StartupAdvisorDashboardComponent implements OnInit, AfterViewChecke
       },
     });
   }
+
+  // -- Manual form mode --
+
+  onSaveProfile(): void {
+    const values: Record<string, string> = {};
+    for (const field of this.profileFields) {
+      const val = (this.profileForm.get(field.key)?.value ?? '').trim();
+      if (val) {
+        values[field.key] = val;
+      }
+    }
+
+    if (Object.keys(values).length === 0) return;
+
+    this.savingProfile = true;
+    this.error = null;
+
+    this.api.updateContext(values).subscribe({
+      next: (state) => {
+        this.context = state.context;
+        this.messages = state.messages;
+        this.artifacts = state.artifacts;
+        this.suggestedQuestions = state.suggested_questions;
+        this.syncProfileFormFromContext();
+        this.savingProfile = false;
+        this.snackBar.open('Profile updated', 'OK', { duration: 2500 });
+      },
+      error: (err) => {
+        this.error = err?.error?.detail ?? err?.message ?? 'Failed to update profile.';
+        this.savingProfile = false;
+      },
+    });
+  }
+
+  /** Count how many profile form fields have values */
+  filledFieldCount(): number {
+    let count = 0;
+    for (const field of this.profileFields) {
+      if ((this.profileForm.get(field.key)?.value ?? '').trim()) count++;
+    }
+    return count;
+  }
+
+  // -- Sidebar inline editing --
+
+  startEditContext(key: string, value: unknown): void {
+    this.editingContextKey = key;
+    this.editingContextValue = String(value ?? '');
+  }
+
+  cancelEditContext(): void {
+    this.editingContextKey = null;
+    this.editingContextValue = '';
+  }
+
+  saveEditContext(): void {
+    if (!this.editingContextKey) return;
+    const key = this.editingContextKey;
+    const val = this.editingContextValue.trim();
+
+    this.editingContextKey = null;
+    this.editingContextValue = '';
+
+    if (!val) return;
+
+    this.api.updateContext({ [key]: val }).subscribe({
+      next: (state) => {
+        this.context = state.context;
+        this.syncProfileFormFromContext();
+      },
+      error: (err) => {
+        this.snackBar.open(err?.error?.detail ?? 'Failed to update field.', 'OK', { duration: 3000 });
+      },
+    });
+  }
+
+  // -- Formatting helpers --
 
   formatTime(timestamp: string): string {
     if (!timestamp) return '';

--- a/user-interface/src/app/models/startup-advisor.model.ts
+++ b/user-interface/src/app/models/startup-advisor.model.ts
@@ -25,3 +25,19 @@ export interface StartupAdvisorConversationState {
 export interface StartupAdvisorSendMessageRequest {
   message: string;
 }
+
+export interface StartupAdvisorUpdateContextRequest {
+  context: Record<string, string>;
+}
+
+/** Standard profile fields the manual form exposes. */
+export const STARTUP_ADVISOR_PROFILE_FIELDS: { key: string; label: string; placeholder: string }[] = [
+  { key: 'company_name', label: 'Company Name', placeholder: 'e.g. Acme Inc.' },
+  { key: 'industry', label: 'Industry', placeholder: 'e.g. FinTech, HealthTech, SaaS' },
+  { key: 'stage', label: 'Stage', placeholder: 'e.g. Pre-seed, Seed, Series A' },
+  { key: 'target_market', label: 'Target Market', placeholder: 'e.g. SMBs in North America' },
+  { key: 'business_model', label: 'Business Model', placeholder: 'e.g. B2B SaaS, Marketplace' },
+  { key: 'team_size', label: 'Team Size', placeholder: 'e.g. 3 co-founders, 2 engineers' },
+  { key: 'funding_status', label: 'Funding Status', placeholder: 'e.g. Bootstrapped, $500K raised' },
+  { key: 'main_challenge', label: 'Main Challenge', placeholder: 'What are you struggling with most?' },
+];

--- a/user-interface/src/app/services/startup-advisor-api.service.ts
+++ b/user-interface/src/app/services/startup-advisor-api.service.ts
@@ -5,6 +5,7 @@ import { environment } from '../../environments/environment';
 import type {
   StartupAdvisorConversationState,
   StartupAdvisorArtifact,
+  StartupAdvisorUpdateContextRequest,
 } from '../models';
 
 @Injectable({ providedIn: 'root' })
@@ -28,5 +29,13 @@ export class StartupAdvisorApiService {
   /** GET /conversation/artifacts — list all artifacts */
   getArtifacts(): Observable<StartupAdvisorArtifact[]> {
     return this.http.get<StartupAdvisorArtifact[]>(`${this.baseUrl}/conversation/artifacts`);
+  }
+
+  /** PUT /conversation/context — manually update the founder profile context */
+  updateContext(context: Record<string, string>): Observable<StartupAdvisorConversationState> {
+    return this.http.put<StartupAdvisorConversationState>(
+      `${this.baseUrl}/conversation/context`,
+      { context } as StartupAdvisorUpdateContextRequest
+    );
   }
 }


### PR DESCRIPTION
Users can now switch between "Chat with Advisor" and "Fill in Manually"
modes. The manual form provides structured profile fields (company name,
industry, stage, target market, etc.) that update the advisor context
directly. Sidebar context values are also inline-editable via hover
edit buttons. Suggested questions in form mode appear in the sidebar
and switch to chat mode when clicked.

https://claude.ai/code/session_01BqifWjbn5GrcDFqKaavKVZ