### PR TITLE
Add chat-first interface for investment team advisor

### DIFF
--- a/user-interface/src/app/components/investment-chat/investment-chat.component.html
+++ b/user-interface/src/app/components/investment-chat/investment-chat.component.html
@@ -1,0 +1,95 @@
+<div class="chat-container">
+  <!-- Session Status Bar -->
+  @if (sessionId) {
+    <div class="session-bar">
+      <div class="session-info">
+        <mat-icon>forum</mat-icon>
+        <span class="session-label">Session active</span>
+        @if (currentTopic) {
+          <span class="session-topic">{{ currentTopic }}</span>
+        }
+      </div>
+      @if (missingFields.length > 0) {
+        <div class="missing-fields">
+          <span class="missing-label">Still needed:</span>
+          @for (field of missingFields; track field) {
+            <span class="missing-chip">{{ field }}</span>
+          }
+        </div>
+      }
+    </div>
+  }
+
+  <!-- Messages -->
+  <div class="messages-container" #messagesContainer>
+    @for (msg of messages; track msg.timestamp) {
+      <div class="message" [class.user]="msg.role === 'user'" [class.assistant]="msg.role === 'assistant'">
+        @if (msg.role === 'assistant') {
+          <mat-icon class="avatar">account_balance</mat-icon>
+        }
+        <div class="message-bubble">
+          <div class="message-content">{{ msg.content }}</div>
+          <div class="message-time">{{ formatTime(msg.timestamp) }}</div>
+        </div>
+      </div>
+    }
+
+    @if (loading) {
+      <div class="message assistant">
+        <mat-icon class="avatar">account_balance</mat-icon>
+        <div class="message-bubble">
+          <div class="typing-indicator">
+            <span></span>
+            <span></span>
+            <span></span>
+          </div>
+        </div>
+      </div>
+    }
+  </div>
+
+  <!-- Confirmation Banner -->
+  @if (sessionStatus === 'awaiting_confirmation') {
+    <div class="confirmation-banner">
+      <mat-icon>task_alt</mat-icon>
+      <span>Your advisor has gathered enough information to build your profile.</span>
+      <button mat-flat-button color="primary" (click)="onConfirmProfile()" [disabled]="loading">
+        <mat-icon>check</mat-icon>
+        Create My IPS
+      </button>
+    </div>
+  }
+
+  <!-- Input Area -->
+  <form [formGroup]="form" (ngSubmit)="onSubmit()" class="input-form">
+    <mat-form-field appearance="outline" class="message-input">
+      <mat-label>Ask your investment advisor...</mat-label>
+      <input
+        matInput
+        formControlName="message"
+        [attr.aria-label]="'Message input'"
+        (keydown.enter)="$event.preventDefault(); onSubmit()"
+      />
+    </mat-form-field>
+    <button
+      mat-fab
+      color="primary"
+      type="submit"
+      [disabled]="form.invalid || loading"
+      [attr.aria-label]="'Send message'"
+    >
+      <mat-icon>send</mat-icon>
+    </button>
+  </form>
+
+  <!-- Quick Actions -->
+  @if (messages.length <= 1) {
+    <div class="quick-actions">
+      @for (action of quickActions; track action.label) {
+        <button mat-stroked-button (click)="onQuickAction(action)" [disabled]="loading">
+          {{ action.label }}
+        </button>
+      }
+    </div>
+  }
+</div>

--- a/user-interface/src/app/components/investment-chat/investment-chat.component.scss
+++ b/user-interface/src/app/components/investment-chat/investment-chat.component.scss
@@ -1,0 +1,251 @@
+.chat-container {
+  display: flex;
+  flex-direction: column;
+  height: calc(100vh - 220px);
+  min-height: 480px;
+  max-height: 800px;
+}
+
+.session-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 8px;
+  padding: 8px 16px;
+  background: var(--mat-sys-surface-container, rgba(0, 0, 0, 0.02));
+  border: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.12));
+  border-radius: 8px;
+  margin-bottom: 8px;
+
+  .session-info {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+
+    mat-icon {
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+      color: var(--mat-sys-primary, #1976d2);
+    }
+
+    .session-label {
+      font-size: 0.8125rem;
+      font-weight: 500;
+      color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+    }
+
+    .session-topic {
+      font-size: 0.8125rem;
+      color: var(--mat-sys-primary, #1976d2);
+      font-weight: 600;
+    }
+  }
+
+  .missing-fields {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-wrap: wrap;
+
+    .missing-label {
+      font-size: 0.75rem;
+      color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.54));
+    }
+
+    .missing-chip {
+      font-size: 0.7rem;
+      padding: 2px 8px;
+      border-radius: 12px;
+      background: var(--mat-sys-surface-variant, rgba(0, 0, 0, 0.06));
+      color: var(--mat-sys-on-surface-variant, rgba(0, 0, 0, 0.6));
+    }
+  }
+}
+
+.messages-container {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1rem;
+  background: var(--mat-sys-surface, #0d1117);
+  border-radius: 8px;
+  margin-bottom: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+
+  &::-webkit-scrollbar {
+    width: 6px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 3px;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.15);
+    }
+  }
+}
+
+.message {
+  display: flex;
+  gap: 10px;
+  max-width: 85%;
+
+  &.user {
+    align-self: flex-end;
+    flex-direction: row-reverse;
+
+    .message-bubble {
+      background: linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%);
+      color: #fff;
+      border-bottom-right-radius: 4px;
+    }
+
+    .message-time {
+      color: rgba(255, 255, 255, 0.7);
+      text-align: right;
+    }
+  }
+
+  &.assistant {
+    align-self: flex-start;
+
+    .message-bubble {
+      background: #21262d;
+      color: #f0f6fc;
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-bottom-left-radius: 4px;
+    }
+  }
+
+  .avatar {
+    flex-shrink: 0;
+    width: 32px;
+    height: 32px;
+    font-size: 32px;
+    color: #58a6ff;
+    margin-top: 4px;
+  }
+}
+
+.message-bubble {
+  padding: 12px 16px;
+  border-radius: 16px;
+  line-height: 1.5;
+}
+
+.message-content {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.message-time {
+  font-size: 0.75rem;
+  color: #8b949e;
+  margin-top: 6px;
+}
+
+.typing-indicator {
+  display: flex;
+  gap: 4px;
+  padding: 4px 0;
+
+  span {
+    width: 8px;
+    height: 8px;
+    background: #8b949e;
+    border-radius: 50%;
+    animation: bounce 1.4s infinite ease-in-out;
+
+    &:nth-child(1) { animation-delay: 0s; }
+    &:nth-child(2) { animation-delay: 0.2s; }
+    &:nth-child(3) { animation-delay: 0.4s; }
+  }
+}
+
+@keyframes bounce {
+  0%, 80%, 100% { transform: translateY(0); }
+  40% { transform: translateY(-6px); }
+}
+
+.confirmation-banner {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  background: #e8f5e9;
+  border: 1px solid #a5d6a7;
+  border-radius: 8px;
+  margin-bottom: 12px;
+
+  mat-icon {
+    color: #2e7d32;
+    flex-shrink: 0;
+  }
+
+  span {
+    flex: 1;
+    font-size: 0.875rem;
+    color: #1b5e20;
+  }
+
+  button {
+    flex-shrink: 0;
+  }
+}
+
+.input-form {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+
+  .message-input {
+    flex: 1;
+  }
+
+  button[mat-fab] {
+    margin-top: 4px;
+  }
+}
+
+.quick-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 8px;
+
+  button {
+    font-size: 0.8125rem;
+    border-color: rgba(255, 255, 255, 0.15);
+    color: #c9d1d9;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.05);
+      border-color: #58a6ff;
+      color: #58a6ff;
+    }
+  }
+}
+
+@media (max-width: 768px) {
+  .chat-container {
+    height: calc(100vh - 180px);
+    min-height: 360px;
+  }
+
+  .message {
+    max-width: 92%;
+  }
+
+  .session-bar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/user-interface/src/app/components/investment-chat/investment-chat.component.ts
+++ b/user-interface/src/app/components/investment-chat/investment-chat.component.ts
@@ -1,0 +1,197 @@
+import {
+  Component,
+  EventEmitter,
+  Input,
+  Output,
+  inject,
+  OnInit,
+  ViewChild,
+  ElementRef,
+  AfterViewChecked,
+} from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatChipsModule } from '@angular/material/chips';
+import { InvestmentApiService } from '../../services/investment-api.service';
+import type { AdvisorChatMessage, IPS } from '../../models';
+
+@Component({
+  selector: 'app-investment-chat',
+  standalone: true,
+  imports: [
+    ReactiveFormsModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatProgressSpinnerModule,
+    MatChipsModule,
+  ],
+  templateUrl: './investment-chat.component.html',
+  styleUrl: './investment-chat.component.scss',
+})
+export class InvestmentChatComponent implements OnInit, AfterViewChecked {
+  @Input() userId = 'default';
+  @Output() profileCreated = new EventEmitter<IPS>();
+  @ViewChild('messagesContainer') messagesContainer!: ElementRef<HTMLDivElement>;
+
+  private readonly api = inject(InvestmentApiService);
+  private readonly fb = inject(FormBuilder);
+
+  messages: AdvisorChatMessage[] = [];
+  loading = false;
+  sessionId: string | null = null;
+  sessionStatus: 'active' | 'completed' | 'awaiting_confirmation' | null = null;
+  currentTopic: string | null = null;
+  missingFields: string[] = [];
+  form: FormGroup;
+
+  quickActions = [
+    { label: 'Build my profile', message: "I'd like to set up my investment profile." },
+    { label: 'Review my portfolio', message: 'Can you review my current portfolio allocation?' },
+    { label: 'Strategy ideas', message: 'What trading strategies would you recommend for my risk level?' },
+    { label: 'Market outlook', message: "What's your current market outlook?" },
+  ];
+
+  constructor() {
+    this.form = this.fb.nonNullable.group({
+      message: ['', [Validators.required, Validators.minLength(1)]],
+    });
+  }
+
+  ngOnInit(): void {
+    this.messages.push({
+      role: 'assistant',
+      content: `Hello! I'm your investment advisor. I can help you with:
+
+\u2022 Building your Investment Policy Statement (IPS)
+\u2022 Reviewing portfolio allocations and proposals
+\u2022 Discussing trading strategies and risk management
+\u2022 Answering questions about your investment options
+
+What would you like to work on today?`,
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  ngAfterViewChecked(): void {
+    this.scrollToBottom();
+  }
+
+  private scrollToBottom(): void {
+    if (this.messagesContainer) {
+      const el = this.messagesContainer.nativeElement;
+      el.scrollTop = el.scrollHeight;
+    }
+  }
+
+  onSubmit(): void {
+    if (this.form.valid && !this.loading) {
+      const message = this.form.getRawValue().message.trim();
+      this.sendMessage(message);
+    }
+  }
+
+  onQuickAction(action: { label: string; message: string }): void {
+    this.sendMessage(action.message);
+  }
+
+  onConfirmProfile(): void {
+    if (!this.sessionId) return;
+    this.loading = true;
+    this.api.completeAdvisorSession(this.sessionId).subscribe({
+      next: (res) => {
+        this.messages.push({
+          role: 'assistant',
+          content: res.message || 'Your Investment Policy Statement has been created successfully!',
+          timestamp: new Date().toISOString(),
+        });
+        this.sessionStatus = 'completed';
+        this.loading = false;
+        if (res.ips) {
+          this.profileCreated.emit(res.ips);
+        }
+      },
+      error: (err) => {
+        this.messages.push({
+          role: 'assistant',
+          content: `Sorry, I couldn't finalize the profile: ${err?.error?.detail || err?.message || 'Unknown error'}`,
+          timestamp: new Date().toISOString(),
+        });
+        this.loading = false;
+      },
+    });
+  }
+
+  private sendMessage(message: string): void {
+    this.messages.push({
+      role: 'user',
+      content: message,
+      timestamp: new Date().toISOString(),
+    });
+    this.form.reset();
+    this.loading = true;
+
+    if (!this.sessionId) {
+      this.startSessionAndSend(message);
+    } else {
+      this.sendToSession(message);
+    }
+  }
+
+  private startSessionAndSend(message: string): void {
+    this.api.startAdvisorSession({ user_id: this.userId }).subscribe({
+      next: (res) => {
+        this.sessionId = res.session_id;
+        this.updateSessionState(res);
+        // Now send the actual message
+        this.sendToSession(message);
+      },
+      error: (err) => {
+        this.handleError(err);
+      },
+    });
+  }
+
+  private sendToSession(message: string): void {
+    this.api.sendAdvisorMessage(this.sessionId!, { message }).subscribe({
+      next: (res) => {
+        this.updateSessionState(res);
+        this.messages.push({
+          role: 'assistant',
+          content: res.advisor_message,
+          timestamp: new Date().toISOString(),
+        });
+        this.loading = false;
+      },
+      error: (err) => {
+        this.handleError(err);
+      },
+    });
+  }
+
+  private updateSessionState(res: { session_status: string; current_topic?: string; missing_fields?: string[] }): void {
+    this.sessionStatus = res.session_status as 'active' | 'completed' | 'awaiting_confirmation';
+    this.currentTopic = res.current_topic ?? null;
+    this.missingFields = res.missing_fields ?? [];
+  }
+
+  private handleError(err: { error?: { detail?: string }; message?: string }): void {
+    this.messages.push({
+      role: 'assistant',
+      content: `Sorry, something went wrong: ${err?.error?.detail || err?.message || 'Unknown error'}`,
+      timestamp: new Date().toISOString(),
+    });
+    this.loading = false;
+  }
+
+  formatTime(timestamp: string): string {
+    return new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  }
+}

--- a/user-interface/src/app/components/investment-dashboard/investment-dashboard.component.html
+++ b/user-interface/src/app/components/investment-dashboard/investment-dashboard.component.html
@@ -2,21 +2,33 @@
 
 <div class="page-header">
   <p class="mat-body-2 page-subtitle">Portfolio management, strategy validation, and promotion workflows</p>
-  <div class="health-indicator" [class]="healthStatus">
-    @switch (healthStatus) {
-      @case ('checking') {
-        <mat-icon>hourglass_empty</mat-icon>
-        <span>Checking...</span>
+  <div class="header-controls">
+    <mat-button-toggle-group [(value)]="viewMode" class="view-toggle" aria-label="Interaction mode">
+      <mat-button-toggle value="chat" matTooltip="Chat with your investment advisor">
+        <mat-icon>chat</mat-icon>
+        <span class="toggle-label">Chat</span>
+      </mat-button-toggle>
+      <mat-button-toggle value="forms" matTooltip="Use forms to manage investments directly">
+        <mat-icon>dashboard</mat-icon>
+        <span class="toggle-label">Forms</span>
+      </mat-button-toggle>
+    </mat-button-toggle-group>
+    <div class="health-indicator" [class]="healthStatus">
+      @switch (healthStatus) {
+        @case ('checking') {
+          <mat-icon>hourglass_empty</mat-icon>
+          <span>Checking...</span>
+        }
+        @case ('healthy') {
+          <mat-icon>check_circle</mat-icon>
+          <span>API Online</span>
+        }
+        @case ('unhealthy') {
+          <mat-icon>error</mat-icon>
+          <span>API Offline</span>
+        }
       }
-      @case ('healthy') {
-        <mat-icon>check_circle</mat-icon>
-        <span>API Online</span>
-      }
-      @case ('unhealthy') {
-        <mat-icon>error</mat-icon>
-        <span>API Offline</span>
-      }
-    }
+    </div>
   </div>
 </div>
 
@@ -42,152 +54,161 @@
   </div>
 }
 
-<!-- Tab Navigation -->
-<mat-tab-group [(selectedIndex)]="selectedTabIndex" animationDuration="200ms" class="dashboard-tabs">
-  <!-- Profile Tab -->
-  <mat-tab>
-    <ng-template mat-tab-label>
-      <mat-icon>person_add</mat-icon>
-      <span>Profile</span>
-    </ng-template>
-    <div class="tab-content">
-      @if (!currentIPS || showProfileForm) {
-        <app-investment-profile-form
-          (profileCreated)="onProfileCreated($event)"
-          (cancelled)="onProfileFormCancelled()"
-        ></app-investment-profile-form>
-      } @else {
-        <mat-card class="profile-summary-card">
-          <mat-card-header>
-            <mat-icon mat-card-avatar>verified_user</mat-icon>
-            <mat-card-title>Investment Policy Statement</mat-card-title>
-            <mat-card-subtitle>Profile for {{ currentIPS.profile.user_id }}</mat-card-subtitle>
-          </mat-card-header>
-          <mat-card-content>
-            <div class="ips-grid">
-              <div class="ips-item">
-                <span class="label">Risk Tolerance</span>
-                <span class="value">{{ currentIPS.profile.risk_tolerance | titlecase }}</span>
-              </div>
-              <div class="ips-item">
-                <span class="label">Time Horizon</span>
-                <span class="value">{{ currentIPS.profile.time_horizon_years }} years</span>
-              </div>
-              <div class="ips-item">
-                <span class="label">Max Drawdown</span>
-                <span class="value">{{ currentIPS.profile.max_drawdown_tolerance_pct }}%</span>
-              </div>
-              <div class="ips-item">
-                <span class="label">Investable Assets</span>
-                <span class="value">${{ currentIPS.profile.net_worth.investable_assets | number }}</span>
-              </div>
-              <div class="ips-item">
-                <span class="label">Default Mode</span>
-                <span class="value">{{ currentIPS.default_mode | titlecase }}</span>
-              </div>
-              <div class="ips-item">
-                <span class="label">Rebalance Frequency</span>
-                <span class="value">{{ currentIPS.rebalance_frequency | titlecase }}</span>
-              </div>
-            </div>
+<!-- Chat View (Primary) -->
+@if (viewMode === 'chat') {
+  <app-investment-chat
+    (profileCreated)="onProfileCreated($event)"
+  ></app-investment-chat>
+}
 
-            <mat-divider></mat-divider>
-
-            <div class="preferences-section">
-              <h4>Preferences</h4>
-              <div class="preference-chips">
-                @if (currentIPS.profile.preferences.crypto_allowed) {
-                  <mat-chip>Crypto Allowed</mat-chip>
-                }
-                @if (currentIPS.profile.preferences.options_allowed) {
-                  <mat-chip>Options Allowed</mat-chip>
-                }
-                @if (currentIPS.profile.preferences.leverage_allowed) {
-                  <mat-chip>Leverage Allowed</mat-chip>
-                }
-                @if (currentIPS.live_trading_enabled) {
-                  <mat-chip color="primary">Live Trading</mat-chip>
-                }
-                @if (currentIPS.human_approval_required_for_live) {
-                  <mat-chip>Human Approval Required</mat-chip>
-                }
+<!-- Forms View -->
+@if (viewMode === 'forms') {
+  <mat-tab-group [(selectedIndex)]="selectedTabIndex" animationDuration="200ms" class="dashboard-tabs">
+    <!-- Profile Tab -->
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <mat-icon>person_add</mat-icon>
+        <span>Profile</span>
+      </ng-template>
+      <div class="tab-content">
+        @if (!currentIPS || showProfileForm) {
+          <app-investment-profile-form
+            (profileCreated)="onProfileCreated($event)"
+            (cancelled)="onProfileFormCancelled()"
+          ></app-investment-profile-form>
+        } @else {
+          <mat-card class="profile-summary-card">
+            <mat-card-header>
+              <mat-icon mat-card-avatar>verified_user</mat-icon>
+              <mat-card-title>Investment Policy Statement</mat-card-title>
+              <mat-card-subtitle>Profile for {{ currentIPS.profile.user_id }}</mat-card-subtitle>
+            </mat-card-header>
+            <mat-card-content>
+              <div class="ips-grid">
+                <div class="ips-item">
+                  <span class="label">Risk Tolerance</span>
+                  <span class="value">{{ currentIPS.profile.risk_tolerance | titlecase }}</span>
+                </div>
+                <div class="ips-item">
+                  <span class="label">Time Horizon</span>
+                  <span class="value">{{ currentIPS.profile.time_horizon_years }} years</span>
+                </div>
+                <div class="ips-item">
+                  <span class="label">Max Drawdown</span>
+                  <span class="value">{{ currentIPS.profile.max_drawdown_tolerance_pct }}%</span>
+                </div>
+                <div class="ips-item">
+                  <span class="label">Investable Assets</span>
+                  <span class="value">${{ currentIPS.profile.net_worth.investable_assets | number }}</span>
+                </div>
+                <div class="ips-item">
+                  <span class="label">Default Mode</span>
+                  <span class="value">{{ currentIPS.default_mode | titlecase }}</span>
+                </div>
+                <div class="ips-item">
+                  <span class="label">Rebalance Frequency</span>
+                  <span class="value">{{ currentIPS.rebalance_frequency | titlecase }}</span>
+                </div>
               </div>
-            </div>
-          </mat-card-content>
-          <mat-card-actions>
-            <button mat-stroked-button (click)="showProfileForm = true">
-              <mat-icon>add</mat-icon>
-              Create New Profile
-            </button>
-          </mat-card-actions>
-        </mat-card>
-      }
-    </div>
-  </mat-tab>
 
-  <!-- Proposals Tab -->
-  <mat-tab>
-    <ng-template mat-tab-label>
-      <mat-icon>pie_chart</mat-icon>
-      <span>Proposals</span>
-    </ng-template>
-    <div class="tab-content">
-      <app-investment-proposal
-        [ips]="currentIPS"
-        [existingProposal]="currentProposal"
-        (proposalCreated)="onProposalCreated($event)"
-      ></app-investment-proposal>
-    </div>
-  </mat-tab>
+              <mat-divider></mat-divider>
 
-  <!-- Strategies Tab -->
-  <mat-tab>
-    <ng-template mat-tab-label>
-      <mat-icon>psychology</mat-icon>
-      <span>Strategies</span>
-    </ng-template>
-    <div class="tab-content">
-      <app-investment-strategy
-        [existingStrategy]="currentStrategy"
-        (strategyCreated)="onStrategyCreated($event)"
-      ></app-investment-strategy>
-    </div>
-  </mat-tab>
+              <div class="preferences-section">
+                <h4>Preferences</h4>
+                <div class="preference-chips">
+                  @if (currentIPS.profile.preferences.crypto_allowed) {
+                    <mat-chip>Crypto Allowed</mat-chip>
+                  }
+                  @if (currentIPS.profile.preferences.options_allowed) {
+                    <mat-chip>Options Allowed</mat-chip>
+                  }
+                  @if (currentIPS.profile.preferences.leverage_allowed) {
+                    <mat-chip>Leverage Allowed</mat-chip>
+                  }
+                  @if (currentIPS.live_trading_enabled) {
+                    <mat-chip color="primary">Live Trading</mat-chip>
+                  }
+                  @if (currentIPS.human_approval_required_for_live) {
+                    <mat-chip>Human Approval Required</mat-chip>
+                  }
+                </div>
+              </div>
+            </mat-card-content>
+            <mat-card-actions>
+              <button mat-stroked-button (click)="showProfileForm = true">
+                <mat-icon>add</mat-icon>
+                Create New Profile
+              </button>
+            </mat-card-actions>
+          </mat-card>
+        }
+      </div>
+    </mat-tab>
 
-  <!-- Promotion Tab -->
-  <mat-tab>
-    <ng-template mat-tab-label>
-      <mat-icon>gavel</mat-icon>
-      <span>Promotion</span>
-    </ng-template>
-    <div class="tab-content">
-      <app-investment-promotion
-        [ips]="currentIPS"
-        [strategy]="currentStrategy"
-        (decisionMade)="onDecisionMade($event)"
-      ></app-investment-promotion>
-    </div>
-  </mat-tab>
+    <!-- Proposals Tab -->
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <mat-icon>pie_chart</mat-icon>
+        <span>Proposals</span>
+      </ng-template>
+      <div class="tab-content">
+        <app-investment-proposal
+          [ips]="currentIPS"
+          [existingProposal]="currentProposal"
+          (proposalCreated)="onProposalCreated($event)"
+        ></app-investment-proposal>
+      </div>
+    </mat-tab>
 
-  <!-- Workflow Tab -->
-  <mat-tab>
-    <ng-template mat-tab-label>
-      <mat-icon>account_tree</mat-icon>
-      <span>Workflow</span>
-    </ng-template>
-    <div class="tab-content">
-      <app-investment-workflow></app-investment-workflow>
-    </div>
-  </mat-tab>
+    <!-- Strategies Tab -->
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <mat-icon>psychology</mat-icon>
+        <span>Strategies</span>
+      </ng-template>
+      <div class="tab-content">
+        <app-investment-strategy
+          [existingStrategy]="currentStrategy"
+          (strategyCreated)="onStrategyCreated($event)"
+        ></app-investment-strategy>
+      </div>
+    </mat-tab>
 
-  <!-- Strategy Lab Tab -->
-  <mat-tab>
-    <ng-template mat-tab-label>
-      <mat-icon>science</mat-icon>
-      <span>Strategy Lab</span>
-    </ng-template>
-    <div class="tab-content">
-      <app-strategy-lab></app-strategy-lab>
-    </div>
-  </mat-tab>
-</mat-tab-group>
+    <!-- Promotion Tab -->
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <mat-icon>gavel</mat-icon>
+        <span>Promotion</span>
+      </ng-template>
+      <div class="tab-content">
+        <app-investment-promotion
+          [ips]="currentIPS"
+          [strategy]="currentStrategy"
+          (decisionMade)="onDecisionMade($event)"
+        ></app-investment-promotion>
+      </div>
+    </mat-tab>
+
+    <!-- Workflow Tab -->
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <mat-icon>account_tree</mat-icon>
+        <span>Workflow</span>
+      </ng-template>
+      <div class="tab-content">
+        <app-investment-workflow></app-investment-workflow>
+      </div>
+    </mat-tab>
+
+    <!-- Strategy Lab Tab -->
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <mat-icon>science</mat-icon>
+        <span>Strategy Lab</span>
+      </ng-template>
+      <div class="tab-content">
+        <app-strategy-lab></app-strategy-lab>
+      </div>
+    </mat-tab>
+  </mat-tab-group>
+}

--- a/user-interface/src/app/components/investment-dashboard/investment-dashboard.component.scss
+++ b/user-interface/src/app/components/investment-dashboard/investment-dashboard.component.scss
@@ -13,6 +13,19 @@
   margin-bottom: 1rem;
 }
 
+.header-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.view-toggle {
+  .toggle-label {
+    margin-left: 6px;
+    font-size: 0.8125rem;
+  }
+}
+
 .health-indicator {
   display: flex;
   align-items: center;
@@ -175,6 +188,10 @@ mat-card-actions {
   .page-header {
     flex-direction: column;
     align-items: flex-start;
+  }
+
+  .header-controls {
+    flex-wrap: wrap;
   }
 
   .profile-banner {

--- a/user-interface/src/app/components/investment-dashboard/investment-dashboard.component.ts
+++ b/user-interface/src/app/components/investment-dashboard/investment-dashboard.component.ts
@@ -7,8 +7,10 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatDividerModule } from '@angular/material/divider';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
 
 import { InvestmentApiService } from '../../services/investment-api.service';
+import { InvestmentChatComponent } from '../investment-chat/investment-chat.component';
 import { InvestmentProfileFormComponent } from '../investment-profile-form/investment-profile-form.component';
 import { InvestmentProposalComponent } from '../investment-proposal/investment-proposal.component';
 import { InvestmentStrategyComponent } from '../investment-strategy/investment-strategy.component';
@@ -34,6 +36,8 @@ import {
     MatChipsModule,
     MatTooltipModule,
     MatDividerModule,
+    MatButtonToggleModule,
+    InvestmentChatComponent,
     InvestmentProfileFormComponent,
     InvestmentProposalComponent,
     InvestmentStrategyComponent,
@@ -47,6 +51,7 @@ import {
 export class InvestmentDashboardComponent implements OnInit {
   private readonly api = inject(InvestmentApiService);
 
+  viewMode: 'chat' | 'forms' = 'chat';
   selectedTabIndex = 0;
   healthStatus: 'checking' | 'healthy' | 'unhealthy' = 'checking';
 

--- a/user-interface/src/app/components/nutrition-dashboard/nutrition-dashboard.component.html
+++ b/user-interface/src/app/components/nutrition-dashboard/nutrition-dashboard.component.html
@@ -9,14 +9,26 @@
           <p class="subtitle">Your personal meal planning assistant</p>
         </div>
       </div>
-      <span class="health-chip" [class]="healthStatus">
-        @if (healthStatus === 'healthy') { Online }
-        @if (healthStatus === 'checking') { Connecting… }
-        @if (healthStatus === 'unhealthy') { Offline }
-      </span>
+      <div class="header-controls">
+        <mat-button-toggle-group [(value)]="viewMode" class="view-toggle" aria-label="Interaction mode">
+          <mat-button-toggle value="chat" matTooltip="Chat with your nutritionist">
+            <mat-icon>chat</mat-icon>
+            <span class="toggle-label">Chat</span>
+          </mat-button-toggle>
+          <mat-button-toggle value="forms" matTooltip="Manage profile and plans using forms">
+            <mat-icon>dashboard</mat-icon>
+            <span class="toggle-label">Forms</span>
+          </mat-button-toggle>
+        </mat-button-toggle-group>
+        <span class="health-chip" [class]="healthStatus">
+          @if (healthStatus === 'healthy') { Online }
+          @if (healthStatus === 'checking') { Connecting… }
+          @if (healthStatus === 'unhealthy') { Offline }
+        </span>
+      </div>
     </div>
 
-    @if (clientIdConfirmed) {
+    @if (viewMode === 'chat' && clientIdConfirmed) {
       <div class="phase-progress">
         @for (p of phases; track p.key; let i = $index) {
           <div
@@ -41,8 +53,14 @@
     }
   </header>
 
+  <!-- Forms View -->
+  @if (viewMode === 'forms') {
+    <app-nutrition-forms [clientId]="clientId"></app-nutrition-forms>
+  }
+
+  <!-- Chat View (Primary) -->
   <!-- Client ID gate -->
-  @if (!clientIdConfirmed) {
+  @if (viewMode === 'chat' && !clientIdConfirmed) {
     <mat-card class="id-card" appearance="outlined">
       <mat-card-content>
         <p class="id-intro">
@@ -79,7 +97,7 @@
   }
 
   <!-- Chat area -->
-  @if (clientIdConfirmed) {
+  @if (viewMode === 'chat' && clientIdConfirmed) {
     <div class="chat-container">
       <div class="messages-area" #messagesContainer>
         @for (msg of messages; track msg.timestamp) {

--- a/user-interface/src/app/components/nutrition-dashboard/nutrition-dashboard.component.scss
+++ b/user-interface/src/app/components/nutrition-dashboard/nutrition-dashboard.component.scss
@@ -46,6 +46,19 @@
   color: #81c784;
 }
 
+.header-controls {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.view-toggle {
+  .toggle-label {
+    margin-left: 6px;
+    font-size: 0.8125rem;
+  }
+}
+
 .health-chip {
   display: inline-block;
   padding: 0.2rem 0.6rem;

--- a/user-interface/src/app/components/nutrition-dashboard/nutrition-dashboard.component.ts
+++ b/user-interface/src/app/components/nutrition-dashboard/nutrition-dashboard.component.ts
@@ -11,7 +11,9 @@ import { MatDividerModule } from '@angular/material/divider';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { FormsModule } from '@angular/forms';
 import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { NutritionApiService } from '../../services/nutrition-api.service';
+import { NutritionFormsComponent } from '../nutrition-forms/nutrition-forms.component';
 import type {
   ClientProfile,
   MealRecommendation,
@@ -45,6 +47,8 @@ const PHASES = [
     MatDividerModule,
     MatTooltipModule,
     MatSlideToggleModule,
+    MatButtonToggleModule,
+    NutritionFormsComponent,
   ],
   templateUrl: './nutrition-dashboard.component.html',
   styleUrl: './nutrition-dashboard.component.scss',
@@ -56,6 +60,7 @@ export class NutritionDashboardComponent implements OnInit, AfterViewChecked {
   private readonly fb = inject(FormBuilder);
 
   // --- State ---
+  viewMode: 'chat' | 'forms' = 'chat';
   clientId = '';
   clientIdConfirmed = false;
   loading = false;

--- a/user-interface/src/app/components/nutrition-forms/nutrition-forms.component.html
+++ b/user-interface/src/app/components/nutrition-forms/nutrition-forms.component.html
@@ -1,0 +1,409 @@
+<!-- Status Banner -->
+@if (statusMessage) {
+  <div class="status-banner" [class.success]="statusType === 'success'" [class.error]="statusType === 'error'">
+    <mat-icon>{{ statusType === 'success' ? 'check_circle' : 'error' }}</mat-icon>
+    <span>{{ statusMessage }}</span>
+  </div>
+}
+
+<!-- Client ID Required -->
+@if (!clientId.trim()) {
+  <mat-card appearance="outlined" class="notice-card">
+    <mat-card-content>
+      <mat-icon>info</mat-icon>
+      <span>Enter a client ID in chat mode first, then switch to forms to manage your profile manually.</span>
+    </mat-card-content>
+  </mat-card>
+} @else {
+  <mat-tab-group [(selectedIndex)]="selectedTabIndex" animationDuration="200ms" class="forms-tabs">
+    <!-- Profile Tab -->
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <mat-icon>person</mat-icon>
+        <span>Profile</span>
+      </ng-template>
+      <div class="tab-content">
+        <div class="tab-actions">
+          <button mat-stroked-button (click)="loadProfile()" [disabled]="loading">
+            <mat-icon>download</mat-icon>
+            Load Existing Profile
+          </button>
+        </div>
+
+        <form [formGroup]="profileForm" (ngSubmit)="saveProfile()" class="profile-form">
+          <!-- Household -->
+          <h3 class="section-title">
+            <mat-icon>family_restroom</mat-icon>
+            Household
+          </h3>
+          <div class="form-row">
+            <mat-form-field appearance="outline">
+              <mat-label>Number of people</mat-label>
+              <input matInput type="number" formControlName="numberOfPeople" min="1" />
+            </mat-form-field>
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Description</mat-label>
+              <input matInput formControlName="description" placeholder="e.g. Family of 4 with toddler" />
+            </mat-form-field>
+          </div>
+
+          <!-- Dietary Needs & Allergies -->
+          <h3 class="section-title">
+            <mat-icon>local_dining</mat-icon>
+            Diet & Allergies
+          </h3>
+          <div class="form-row">
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Dietary needs</mat-label>
+              <input matInput formControlName="dietaryNeeds" placeholder="e.g. vegetarian, gluten-free" />
+              <mat-hint>Comma-separated</mat-hint>
+            </mat-form-field>
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Allergies & intolerances</mat-label>
+              <input matInput formControlName="allergies" placeholder="e.g. peanuts, lactose" />
+              <mat-hint>Comma-separated</mat-hint>
+            </mat-form-field>
+          </div>
+
+          <!-- Lifestyle -->
+          <h3 class="section-title">
+            <mat-icon>schedule</mat-icon>
+            Lifestyle
+          </h3>
+          <div class="form-row">
+            <mat-form-field appearance="outline">
+              <mat-label>Max cooking time (min)</mat-label>
+              <input matInput type="number" formControlName="maxCookingTime" />
+            </mat-form-field>
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Lunch context</mat-label>
+              <input matInput formControlName="lunchContext" placeholder="e.g. eat at office, pack lunch" />
+            </mat-form-field>
+          </div>
+          <div class="form-row">
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Equipment constraints</mat-label>
+              <input matInput formControlName="equipmentConstraints" placeholder="e.g. no oven, small kitchen" />
+              <mat-hint>Comma-separated</mat-hint>
+            </mat-form-field>
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Other constraints</mat-label>
+              <input matInput formControlName="otherConstraints" placeholder="e.g. budget-friendly" />
+            </mat-form-field>
+          </div>
+
+          <!-- Preferences -->
+          <h3 class="section-title">
+            <mat-icon>thumb_up</mat-icon>
+            Preferences
+          </h3>
+          <div class="form-row">
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Cuisines liked</mat-label>
+              <input matInput formControlName="cuisinesLiked" placeholder="e.g. Italian, Mexican, Thai" />
+              <mat-hint>Comma-separated</mat-hint>
+            </mat-form-field>
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Cuisines disliked</mat-label>
+              <input matInput formControlName="cuisinesDisliked" placeholder="e.g. French" />
+              <mat-hint>Comma-separated</mat-hint>
+            </mat-form-field>
+          </div>
+          <div class="form-row">
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Ingredients disliked</mat-label>
+              <input matInput formControlName="ingredientsDisliked" placeholder="e.g. cilantro, olives" />
+              <mat-hint>Comma-separated</mat-hint>
+            </mat-form-field>
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Other preferences</mat-label>
+              <input matInput formControlName="preferencesFreeText" placeholder="Free-form notes" />
+            </mat-form-field>
+          </div>
+
+          <!-- Goals -->
+          <h3 class="section-title">
+            <mat-icon>flag</mat-icon>
+            Goals
+          </h3>
+          <div class="form-row">
+            <mat-form-field appearance="outline">
+              <mat-label>Goal type</mat-label>
+              <mat-select formControlName="goalType">
+                @for (opt of goalOptions; track opt.value) {
+                  <mat-option [value]="opt.value">{{ opt.label }}</mat-option>
+                }
+              </mat-select>
+            </mat-form-field>
+            <mat-form-field appearance="outline" class="flex-field">
+              <mat-label>Goal notes</mat-label>
+              <input matInput formControlName="goalNotes" placeholder="Any additional details" />
+            </mat-form-field>
+          </div>
+
+          <div class="form-actions">
+            <button mat-flat-button color="primary" type="submit" [disabled]="profileForm.invalid || loading">
+              @if (loading) {
+                <mat-spinner diameter="20"></mat-spinner>
+              } @else {
+                <mat-icon>save</mat-icon>
+                Save Profile
+              }
+            </button>
+          </div>
+        </form>
+      </div>
+    </mat-tab>
+
+    <!-- Nutrition Plan Tab -->
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <mat-icon>monitoring</mat-icon>
+        <span>Nutrition Plan</span>
+      </ng-template>
+      <div class="tab-content">
+        <p class="tab-description">Generate a personalized nutrition plan based on your profile.</p>
+        <div class="tab-actions">
+          <button mat-flat-button color="primary" (click)="generateNutritionPlan()" [disabled]="loading">
+            @if (loading) {
+              <mat-spinner diameter="20"></mat-spinner>
+            } @else {
+              <mat-icon>auto_awesome</mat-icon>
+              Generate Nutrition Plan
+            }
+          </button>
+        </div>
+
+        @if (nutritionPlan) {
+          <mat-card appearance="outlined" class="result-card">
+            <mat-card-header>
+              <mat-icon mat-card-avatar>monitoring</mat-icon>
+              <mat-card-title>Your Nutrition Snapshot</mat-card-title>
+              @if (nutritionPlan.plan.generated_at) {
+                <mat-card-subtitle>Generated {{ nutritionPlan.plan.generated_at }}</mat-card-subtitle>
+              }
+            </mat-card-header>
+            <mat-card-content>
+              <h4>Daily Targets</h4>
+              <div class="targets-grid">
+                @if (nutritionPlan.plan.daily_targets.calories_kcal) {
+                  <div class="target-item"><span class="target-value">{{ nutritionPlan.plan.daily_targets.calories_kcal }}</span><span class="target-label">kcal</span></div>
+                }
+                @if (nutritionPlan.plan.daily_targets.protein_g) {
+                  <div class="target-item"><span class="target-value">{{ nutritionPlan.plan.daily_targets.protein_g }}g</span><span class="target-label">Protein</span></div>
+                }
+                @if (nutritionPlan.plan.daily_targets.carbs_g) {
+                  <div class="target-item"><span class="target-value">{{ nutritionPlan.plan.daily_targets.carbs_g }}g</span><span class="target-label">Carbs</span></div>
+                }
+                @if (nutritionPlan.plan.daily_targets.fat_g) {
+                  <div class="target-item"><span class="target-value">{{ nutritionPlan.plan.daily_targets.fat_g }}g</span><span class="target-label">Fat</span></div>
+                }
+                @if (nutritionPlan.plan.daily_targets.fiber_g) {
+                  <div class="target-item"><span class="target-value">{{ nutritionPlan.plan.daily_targets.fiber_g }}g</span><span class="target-label">Fiber</span></div>
+                }
+              </div>
+
+              @if (nutritionPlan.plan.balance_guidelines.length > 0) {
+                <mat-divider></mat-divider>
+                <h4>Balance Guidelines</h4>
+                <ul class="guidelines-list">
+                  @for (g of nutritionPlan.plan.balance_guidelines; track g) {
+                    <li>{{ g }}</li>
+                  }
+                </ul>
+              }
+
+              @if (nutritionPlan.plan.foods_to_emphasize.length > 0) {
+                <h4>Foods to Emphasize</h4>
+                <div class="food-chips">
+                  @for (f of nutritionPlan.plan.foods_to_emphasize; track f) {
+                    <span class="food-chip emphasize">{{ f }}</span>
+                  }
+                </div>
+              }
+
+              @if (nutritionPlan.plan.foods_to_avoid.length > 0) {
+                <h4>Foods to Avoid</h4>
+                <div class="food-chips">
+                  @for (f of nutritionPlan.plan.foods_to_avoid; track f) {
+                    <span class="food-chip avoid">{{ f }}</span>
+                  }
+                </div>
+              }
+
+              @if (nutritionPlan.plan.notes) {
+                <mat-divider></mat-divider>
+                <p class="plan-notes">{{ nutritionPlan.plan.notes }}</p>
+              }
+            </mat-card-content>
+          </mat-card>
+        }
+      </div>
+    </mat-tab>
+
+    <!-- Meal Plan Tab -->
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <mat-icon>restaurant_menu</mat-icon>
+        <span>Meal Plan</span>
+      </ng-template>
+      <div class="tab-content">
+        <p class="tab-description">Generate meal suggestions based on your nutrition plan.</p>
+
+        <div class="meal-plan-controls">
+          <mat-form-field appearance="outline">
+            <mat-label>Plan for (days)</mat-label>
+            <input matInput type="number" [(ngModel)]="mealPlanDays" min="1" max="14" />
+          </mat-form-field>
+          <div class="meal-type-toggles">
+            <span class="toggle-label">Meal types:</span>
+            @for (opt of mealTypeOptions; track opt.value) {
+              <button
+                mat-stroked-button
+                [class.selected]="isMealTypeSelected(opt.value)"
+                (click)="toggleMealType(opt.value)"
+              >
+                {{ opt.label }}
+              </button>
+            }
+          </div>
+          <button mat-flat-button color="primary" (click)="generateMealPlan()" [disabled]="loading || mealTypes.length === 0">
+            @if (loading) {
+              <mat-spinner diameter="20"></mat-spinner>
+            } @else {
+              <mat-icon>auto_awesome</mat-icon>
+              Generate Meals
+            }
+          </button>
+        </div>
+
+        @if (mealSuggestions.length > 0) {
+          <div class="meals-grid">
+            @for (meal of mealSuggestions; track meal.recommendation_id) {
+              <mat-card
+                appearance="outlined"
+                class="meal-card"
+                [class.selected]="feedbackMealId === meal.recommendation_id"
+                (click)="selectMealForFeedback(meal)"
+              >
+                <mat-card-header>
+                  <mat-card-title>{{ meal.name }}</mat-card-title>
+                  <mat-card-subtitle>
+                    <span class="meal-type-badge">{{ meal.meal_type }}</span>
+                    @if (meal.suggested_date) {
+                      <span>{{ meal.suggested_date }}</span>
+                    }
+                  </mat-card-subtitle>
+                </mat-card-header>
+                <mat-card-content>
+                  <p class="meal-rationale">{{ meal.rationale }}</p>
+                  @if (meal.ingredients.length > 0) {
+                    <details>
+                      <summary>Ingredients ({{ meal.ingredients.length }})</summary>
+                      <ul>
+                        @for (ing of meal.ingredients; track ing) {
+                          <li>{{ ing }}</li>
+                        }
+                      </ul>
+                    </details>
+                  }
+                  @if (meal.prep_time_minutes !== null || meal.cook_time_minutes !== null) {
+                    <span class="meal-meta">
+                      Prep {{ meal.prep_time_minutes ?? '—' }}m · Cook {{ meal.cook_time_minutes ?? '—' }}m
+                      @if (meal.portions_servings) { · {{ meal.portions_servings }} }
+                    </span>
+                  }
+                </mat-card-content>
+              </mat-card>
+            }
+          </div>
+
+          <!-- Feedback form for selected meal -->
+          @if (feedbackMealId) {
+            <mat-card appearance="outlined" class="feedback-card">
+              <mat-card-header>
+                <mat-icon mat-card-avatar>rate_review</mat-icon>
+                <mat-card-title>Rate this meal</mat-card-title>
+              </mat-card-header>
+              <mat-card-content>
+                <div class="feedback-controls">
+                  <mat-form-field appearance="outline">
+                    <mat-label>Rating (1-5)</mat-label>
+                    <input matInput type="number" min="1" max="5" [(ngModel)]="feedbackRating" />
+                  </mat-form-field>
+                  <mat-slide-toggle [(ngModel)]="feedbackWouldMakeAgain">Would make again</mat-slide-toggle>
+                </div>
+                <mat-form-field appearance="outline" class="full-width">
+                  <mat-label>Notes (optional)</mat-label>
+                  <input matInput [(ngModel)]="feedbackNotes" />
+                </mat-form-field>
+              </mat-card-content>
+              <mat-card-actions>
+                <button mat-flat-button color="primary" (click)="submitFeedback()" [disabled]="loading">
+                  Submit Feedback
+                </button>
+                <button mat-stroked-button (click)="feedbackMealId = ''">Cancel</button>
+              </mat-card-actions>
+            </mat-card>
+          }
+        }
+      </div>
+    </mat-tab>
+
+    <!-- History Tab -->
+    <mat-tab>
+      <ng-template mat-tab-label>
+        <mat-icon>history</mat-icon>
+        <span>History</span>
+      </ng-template>
+      <div class="tab-content">
+        <div class="tab-actions">
+          <button mat-flat-button color="primary" (click)="loadHistory()" [disabled]="loading">
+            @if (loading) {
+              <mat-spinner diameter="20"></mat-spinner>
+            } @else {
+              <mat-icon>refresh</mat-icon>
+              Load Meal History
+            }
+          </button>
+        </div>
+
+        @if (mealHistory && mealHistory.entries.length > 0) {
+          <div class="history-list">
+            @for (entry of mealHistory.entries; track entry.recommendation_id) {
+              <mat-card appearance="outlined" class="history-card">
+                <mat-card-header>
+                  <mat-card-title>{{ entry.meal_snapshot['name'] || 'Meal' }}</mat-card-title>
+                  @if (entry.recommended_at) {
+                    <mat-card-subtitle>Recommended {{ entry.recommended_at }}</mat-card-subtitle>
+                  }
+                </mat-card-header>
+                <mat-card-content>
+                  @if (entry.meal_snapshot['meal_type']) {
+                    <span class="meal-type-badge">{{ entry.meal_snapshot['meal_type'] }}</span>
+                  }
+                  @if (entry.feedback) {
+                    <div class="history-feedback">
+                      <mat-icon>star</mat-icon>
+                      <span>Rating: {{ entry.feedback.rating ?? 'N/A' }}/5</span>
+                      @if (entry.feedback.would_make_again !== null) {
+                        <span>{{ entry.feedback.would_make_again ? 'Would make again' : 'Would not make again' }}</span>
+                      }
+                      @if (entry.feedback.notes) {
+                        <span class="feedback-note">"{{ entry.feedback.notes }}"</span>
+                      }
+                    </div>
+                  } @else {
+                    <span class="no-feedback">No feedback yet</span>
+                  }
+                </mat-card-content>
+              </mat-card>
+            }
+          </div>
+        } @else if (mealHistory && mealHistory.entries.length === 0) {
+          <p class="empty-state">No meal history found. Generate meal plans and submit feedback to build your history.</p>
+        }
+      </div>
+    </mat-tab>
+  </mat-tab-group>
+}

--- a/user-interface/src/app/components/nutrition-forms/nutrition-forms.component.scss
+++ b/user-interface/src/app/components/nutrition-forms/nutrition-forms.component.scss
@@ -1,0 +1,390 @@
+.status-banner {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  font-size: 0.875rem;
+
+  &.success {
+    background: rgba(76, 175, 80, 0.12);
+    color: #a5d6a7;
+    border: 1px solid rgba(129, 199, 132, 0.3);
+
+    mat-icon { color: #81c784; }
+  }
+
+  &.error {
+    background: rgba(244, 67, 54, 0.1);
+    color: #ef9a9a;
+    border: 1px solid rgba(239, 154, 154, 0.3);
+
+    mat-icon { color: #ef9a9a; }
+  }
+}
+
+.notice-card {
+  mat-card-content {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    padding: 16px;
+
+    mat-icon {
+      color: #90caf9;
+      flex-shrink: 0;
+    }
+  }
+}
+
+.forms-tabs {
+  margin-top: 0.5rem;
+}
+
+.tab-content {
+  padding: 0;
+}
+
+.tab-description {
+  font-size: 0.875rem;
+  opacity: 0.7;
+  margin: 0 0 1rem;
+}
+
+.tab-actions {
+  margin-bottom: 1rem;
+}
+
+// --- Profile form ---
+
+.section-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin: 1.25rem 0 0.75rem;
+  color: #81c784;
+
+  mat-icon {
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+  }
+}
+
+.form-row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+
+  mat-form-field {
+    min-width: 140px;
+  }
+
+  .flex-field {
+    flex: 1;
+    min-width: 200px;
+  }
+}
+
+.form-actions {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+
+  button {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+}
+
+// --- Nutrition plan ---
+
+.result-card {
+  margin-top: 1rem;
+
+  mat-card-header {
+    mat-icon[mat-card-avatar] {
+      font-size: 36px;
+      width: 36px;
+      height: 36px;
+      color: #81c784;
+    }
+  }
+
+  h4 {
+    font-size: 0.82rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: rgba(255, 255, 255, 0.6);
+    margin: 1rem 0 0.5rem;
+  }
+}
+
+.targets-grid {
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.target-item {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 8px 14px;
+  border-radius: 8px;
+  background: rgba(129, 199, 132, 0.08);
+  border: 1px solid rgba(129, 199, 132, 0.2);
+
+  .target-value {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: #a5d6a7;
+  }
+
+  .target-label {
+    font-size: 0.72rem;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    opacity: 0.6;
+  }
+}
+
+.guidelines-list {
+  padding-left: 1.25rem;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  opacity: 0.85;
+}
+
+.food-chips {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+}
+
+.food-chip {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+
+  &.emphasize {
+    background: rgba(129, 199, 132, 0.12);
+    color: #a5d6a7;
+  }
+
+  &.avoid {
+    background: rgba(239, 154, 154, 0.1);
+    color: #ef9a9a;
+  }
+}
+
+.plan-notes {
+  font-size: 0.875rem;
+  opacity: 0.75;
+  line-height: 1.5;
+  margin-top: 0.75rem;
+}
+
+// --- Meal plan ---
+
+.meal-plan-controls {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  margin-bottom: 1rem;
+
+  mat-form-field {
+    width: 140px;
+  }
+}
+
+.meal-type-toggles {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  flex-wrap: wrap;
+
+  .toggle-label {
+    font-size: 0.82rem;
+    opacity: 0.6;
+    margin-right: 4px;
+  }
+
+  button {
+    font-size: 0.78rem;
+    border-color: rgba(255, 255, 255, 0.12);
+
+    &.selected {
+      background: rgba(129, 199, 132, 0.15);
+      border-color: #81c784;
+      color: #81c784;
+    }
+  }
+}
+
+.meals-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 12px;
+  margin-bottom: 1rem;
+}
+
+.meal-card {
+  cursor: pointer;
+  transition: border-color 0.15s ease;
+
+  &:hover {
+    border-color: rgba(129, 199, 132, 0.4);
+  }
+
+  &.selected {
+    border-color: #81c784;
+    background: rgba(76, 175, 80, 0.04);
+  }
+}
+
+.meal-type-badge {
+  display: inline-block;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 8px;
+  border-radius: 4px;
+  background: rgba(100, 181, 246, 0.15);
+  color: #90caf9;
+  margin-right: 8px;
+}
+
+.meal-rationale {
+  font-size: 0.82rem;
+  opacity: 0.8;
+  line-height: 1.4;
+  margin: 0.25rem 0;
+}
+
+.meal-meta {
+  display: block;
+  font-size: 0.75rem;
+  opacity: 0.55;
+  margin-top: 0.5rem;
+}
+
+details {
+  font-size: 0.82rem;
+  opacity: 0.75;
+  margin-top: 0.35rem;
+
+  summary {
+    cursor: pointer;
+    font-weight: 500;
+  }
+
+  ul {
+    margin: 0.25rem 0 0;
+    padding-left: 1rem;
+  }
+}
+
+// --- Feedback ---
+
+.feedback-card {
+  margin-top: 1rem;
+
+  mat-card-header {
+    mat-icon[mat-card-avatar] {
+      font-size: 36px;
+      width: 36px;
+      height: 36px;
+      color: #81c784;
+    }
+  }
+}
+
+.feedback-controls {
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 0.5rem;
+
+  mat-form-field {
+    width: 120px;
+  }
+}
+
+.full-width {
+  width: 100%;
+}
+
+// --- History ---
+
+.history-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.history-card {
+  .history-feedback {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-top: 8px;
+    font-size: 0.82rem;
+
+    mat-icon {
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+      color: #ffd54f;
+    }
+
+    .feedback-note {
+      font-style: italic;
+      opacity: 0.7;
+    }
+  }
+
+  .no-feedback {
+    font-size: 0.82rem;
+    opacity: 0.5;
+    font-style: italic;
+  }
+}
+
+.empty-state {
+  text-align: center;
+  opacity: 0.5;
+  padding: 2rem;
+  font-size: 0.875rem;
+}
+
+mat-divider {
+  margin: 8px 0;
+}
+
+@media (max-width: 768px) {
+  .form-row {
+    flex-direction: column;
+
+    .flex-field {
+      min-width: 100%;
+    }
+  }
+
+  .meal-plan-controls {
+    flex-direction: column;
+  }
+
+  .meals-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/user-interface/src/app/components/nutrition-forms/nutrition-forms.component.ts
+++ b/user-interface/src/app/components/nutrition-forms/nutrition-forms.component.ts
@@ -1,0 +1,318 @@
+import { Component, Input, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators, FormArray, FormGroup } from '@angular/forms';
+import { FormsModule } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatSelectModule } from '@angular/material/select';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { NutritionApiService } from '../../services/nutrition-api.service';
+import type {
+  ClientProfile,
+  MealRecommendation,
+  NutritionPlanResponse,
+  MealHistoryResponse,
+} from '../../models';
+
+@Component({
+  selector: 'app-nutrition-forms',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatTabsModule,
+    MatSelectModule,
+    MatChipsModule,
+    MatDividerModule,
+    MatProgressSpinnerModule,
+    MatSlideToggleModule,
+    MatTooltipModule,
+  ],
+  templateUrl: './nutrition-forms.component.html',
+  styleUrl: './nutrition-forms.component.scss',
+})
+export class NutritionFormsComponent {
+  @Input() clientId = '';
+
+  private readonly api = inject(NutritionApiService);
+  private readonly fb = inject(FormBuilder);
+
+  selectedTabIndex = 0;
+  loading = false;
+  statusMessage = '';
+  statusType: 'success' | 'error' | '' = '';
+
+  // Profile state
+  profile: ClientProfile | null = null;
+  profileForm = this.fb.group({
+    numberOfPeople: [1, [Validators.required, Validators.min(1)]],
+    description: [''],
+    dietaryNeeds: [''],
+    allergies: [''],
+    maxCookingTime: [null as number | null],
+    lunchContext: [''],
+    equipmentConstraints: [''],
+    otherConstraints: [''],
+    cuisinesLiked: [''],
+    cuisinesDisliked: [''],
+    ingredientsDisliked: [''],
+    preferencesFreeText: [''],
+    goalType: ['maintain'],
+    goalNotes: [''],
+  });
+
+  // Nutrition plan state
+  nutritionPlan: NutritionPlanResponse | null = null;
+
+  // Meal plan state
+  mealPlanDays = 7;
+  mealTypes = ['breakfast', 'lunch', 'dinner'];
+  mealSuggestions: MealRecommendation[] = [];
+
+  // Feedback state
+  feedbackMealId = '';
+  feedbackRating: number | undefined;
+  feedbackWouldMakeAgain: boolean | undefined;
+  feedbackNotes = '';
+
+  // History state
+  mealHistory: MealHistoryResponse | null = null;
+
+  readonly goalOptions = [
+    { value: 'maintain', label: 'Maintain weight' },
+    { value: 'lose_weight', label: 'Lose weight' },
+    { value: 'gain_weight', label: 'Gain weight' },
+    { value: 'build_muscle', label: 'Build muscle' },
+    { value: 'improve_health', label: 'Improve overall health' },
+    { value: 'manage_condition', label: 'Manage health condition' },
+  ];
+
+  readonly mealTypeOptions = [
+    { value: 'breakfast', label: 'Breakfast' },
+    { value: 'lunch', label: 'Lunch' },
+    { value: 'dinner', label: 'Dinner' },
+    { value: 'snack', label: 'Snack' },
+  ];
+
+  // --- Profile ---
+
+  loadProfile(): void {
+    if (!this.clientId.trim()) return;
+    this.loading = true;
+    this.clearStatus();
+    this.api.getProfile(this.clientId).subscribe({
+      next: (profile) => {
+        this.profile = profile;
+        this.populateProfileForm(profile);
+        this.showStatus('Profile loaded successfully.', 'success');
+        this.loading = false;
+      },
+      error: (err) => {
+        if (err.status === 404) {
+          this.showStatus('No existing profile found. Fill out the form to create one.', 'success');
+        } else {
+          this.showStatus(`Failed to load profile: ${err?.error?.detail || err?.message || 'Unknown error'}`, 'error');
+        }
+        this.loading = false;
+      },
+    });
+  }
+
+  saveProfile(): void {
+    if (!this.clientId.trim() || this.profileForm.invalid) return;
+    this.loading = true;
+    this.clearStatus();
+    const v = this.profileForm.getRawValue();
+    this.api
+      .upsertProfile(this.clientId, {
+        household: {
+          number_of_people: v.numberOfPeople ?? 1,
+          description: v.description ?? '',
+          ages_if_relevant: [],
+        },
+        dietary_needs: this.splitComma(v.dietaryNeeds),
+        allergies_and_intolerances: this.splitComma(v.allergies),
+        lifestyle: {
+          max_cooking_time_minutes: v.maxCookingTime,
+          lunch_context: v.lunchContext ?? '',
+          equipment_constraints: this.splitComma(v.equipmentConstraints),
+          other_constraints: v.otherConstraints ?? '',
+        },
+        preferences: {
+          cuisines_liked: this.splitComma(v.cuisinesLiked),
+          cuisines_disliked: this.splitComma(v.cuisinesDisliked),
+          ingredients_disliked: this.splitComma(v.ingredientsDisliked),
+          preferences_free_text: v.preferencesFreeText ?? '',
+        },
+        goals: {
+          goal_type: v.goalType ?? 'maintain',
+          notes: v.goalNotes ?? '',
+        },
+      })
+      .subscribe({
+        next: (profile) => {
+          this.profile = profile;
+          this.showStatus('Profile saved successfully!', 'success');
+          this.loading = false;
+        },
+        error: (err) => {
+          this.showStatus(`Failed to save profile: ${err?.error?.detail || err?.message || 'Unknown error'}`, 'error');
+          this.loading = false;
+        },
+      });
+  }
+
+  // --- Nutrition Plan ---
+
+  generateNutritionPlan(): void {
+    if (!this.clientId.trim()) return;
+    this.loading = true;
+    this.clearStatus();
+    this.api.generateNutritionPlan(this.clientId).subscribe({
+      next: (plan) => {
+        this.nutritionPlan = plan;
+        this.showStatus('Nutrition plan generated!', 'success');
+        this.loading = false;
+      },
+      error: (err) => {
+        this.showStatus(
+          `Failed to generate nutrition plan: ${err?.error?.detail || err?.message || 'Unknown error'}. Make sure you have a saved profile first.`,
+          'error'
+        );
+        this.loading = false;
+      },
+    });
+  }
+
+  // --- Meal Plan ---
+
+  toggleMealType(type: string): void {
+    const idx = this.mealTypes.indexOf(type);
+    if (idx >= 0) {
+      this.mealTypes.splice(idx, 1);
+    } else {
+      this.mealTypes.push(type);
+    }
+  }
+
+  isMealTypeSelected(type: string): boolean {
+    return this.mealTypes.includes(type);
+  }
+
+  generateMealPlan(): void {
+    if (!this.clientId.trim() || this.mealTypes.length === 0) return;
+    this.loading = true;
+    this.clearStatus();
+    this.api.generateMealPlan(this.clientId, this.mealPlanDays, this.mealTypes).subscribe({
+      next: (res) => {
+        this.mealSuggestions = res.suggestions;
+        this.showStatus(`Generated ${res.suggestions.length} meal suggestions!`, 'success');
+        this.loading = false;
+      },
+      error: (err) => {
+        this.showStatus(
+          `Failed to generate meal plan: ${err?.error?.detail || err?.message || 'Unknown error'}. Make sure you have a saved profile and nutrition plan first.`,
+          'error'
+        );
+        this.loading = false;
+      },
+    });
+  }
+
+  selectMealForFeedback(meal: MealRecommendation): void {
+    this.feedbackMealId = meal.recommendation_id;
+  }
+
+  submitFeedback(): void {
+    if (!this.clientId.trim() || !this.feedbackMealId.trim()) return;
+    this.loading = true;
+    this.api
+      .submitFeedback(this.clientId, this.feedbackMealId, this.feedbackRating, this.feedbackWouldMakeAgain, this.feedbackNotes)
+      .subscribe({
+        next: () => {
+          this.showStatus('Feedback submitted! Future meal plans will reflect your preferences.', 'success');
+          this.feedbackMealId = '';
+          this.feedbackRating = undefined;
+          this.feedbackWouldMakeAgain = undefined;
+          this.feedbackNotes = '';
+          this.loading = false;
+        },
+        error: (err) => {
+          this.showStatus(`Failed to submit feedback: ${err?.error?.detail || err?.message || 'Unknown error'}`, 'error');
+          this.loading = false;
+        },
+      });
+  }
+
+  // --- History ---
+
+  loadHistory(): void {
+    if (!this.clientId.trim()) return;
+    this.loading = true;
+    this.clearStatus();
+    this.api.getMealHistory(this.clientId).subscribe({
+      next: (history) => {
+        this.mealHistory = history;
+        this.showStatus(`Loaded ${history.entries.length} history entries.`, 'success');
+        this.loading = false;
+      },
+      error: (err) => {
+        this.showStatus(`Failed to load history: ${err?.error?.detail || err?.message || 'Unknown error'}`, 'error');
+        this.loading = false;
+      },
+    });
+  }
+
+  // --- Helpers ---
+
+  private populateProfileForm(p: ClientProfile): void {
+    this.profileForm.patchValue({
+      numberOfPeople: p.household.number_of_people,
+      description: p.household.description,
+      dietaryNeeds: p.dietary_needs.join(', '),
+      allergies: p.allergies_and_intolerances.join(', '),
+      maxCookingTime: p.lifestyle.max_cooking_time_minutes ?? null,
+      lunchContext: p.lifestyle.lunch_context,
+      equipmentConstraints: p.lifestyle.equipment_constraints.join(', '),
+      otherConstraints: p.lifestyle.other_constraints,
+      cuisinesLiked: p.preferences.cuisines_liked.join(', '),
+      cuisinesDisliked: p.preferences.cuisines_disliked.join(', '),
+      ingredientsDisliked: p.preferences.ingredients_disliked.join(', '),
+      preferencesFreeText: p.preferences.preferences_free_text,
+      goalType: p.goals.goal_type || 'maintain',
+      goalNotes: p.goals.notes,
+    });
+  }
+
+  private splitComma(value: string | null | undefined): string[] {
+    if (!value) return [];
+    return value
+      .split(',')
+      .map((s) => s.trim())
+      .filter((s) => s.length > 0);
+  }
+
+  private showStatus(message: string, type: 'success' | 'error'): void {
+    this.statusMessage = message;
+    this.statusType = type;
+  }
+
+  private clearStatus(): void {
+    this.statusMessage = '';
+    this.statusType = '';
+  }
+}

--- a/user-interface/src/app/components/nutrition-forms/nutrition-forms.component.ts
+++ b/user-interface/src/app/components/nutrition-forms/nutrition-forms.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormBuilder, ReactiveFormsModule, Validators, FormArray, FormGroup } from '@angular/forms';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
 import { FormsModule } from '@angular/forms';
 import { MatCardModule } from '@angular/material/card';
 import { MatFormFieldModule } from '@angular/material/form-field';

--- a/user-interface/src/app/models/investment.model.ts
+++ b/user-interface/src/app/models/investment.model.ts
@@ -502,3 +502,43 @@ export interface StrategyLabResultsResponse {
   winning_count: number;
   losing_count: number;
 }
+
+// ---------------------------------------------------------------------------
+// Financial Advisor (Chat) Models
+// ---------------------------------------------------------------------------
+
+export interface StartAdvisorSessionRequest {
+  user_id: string;
+}
+
+export interface SendAdvisorMessageRequest {
+  message: string;
+}
+
+export interface AdvisorSessionResponse {
+  session_id: string;
+  advisor_message: string;
+  session_status: 'active' | 'completed' | 'awaiting_confirmation';
+  current_topic?: string;
+  missing_fields?: string[];
+}
+
+export interface AdvisorSessionStateResponse {
+  session_id: string;
+  session_status: 'active' | 'completed' | 'awaiting_confirmation';
+  current_topic?: string;
+  missing_fields?: string[];
+  messages: AdvisorChatMessage[];
+}
+
+export interface AdvisorChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: string;
+}
+
+export interface CompleteAdvisorSessionResponse {
+  session_id: string;
+  ips: IPS;
+  message: string;
+}

--- a/user-interface/src/app/services/investment-api.service.ts
+++ b/user-interface/src/app/services/investment-api.service.ts
@@ -25,6 +25,11 @@ import type {
   RunStrategyLabRequest,
   StrategyLabRunResponse,
   StrategyLabResultsResponse,
+  StartAdvisorSessionRequest,
+  SendAdvisorMessageRequest,
+  AdvisorSessionResponse,
+  AdvisorSessionStateResponse,
+  CompleteAdvisorSessionResponse,
 } from '../models';
 
 /**
@@ -166,6 +171,40 @@ export class InvestmentApiService {
     return this.http.get<StrategyLabResultsResponse>(
       `${this.baseUrl}/strategy-lab/results`,
       { params }
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Financial Advisor (Chat)
+  // ---------------------------------------------------------------------------
+
+  startAdvisorSession(request: StartAdvisorSessionRequest): Observable<AdvisorSessionResponse> {
+    return this.http.post<AdvisorSessionResponse>(
+      `${this.baseUrl}/advisor/sessions`,
+      request
+    );
+  }
+
+  sendAdvisorMessage(
+    sessionId: string,
+    request: SendAdvisorMessageRequest
+  ): Observable<AdvisorSessionResponse> {
+    return this.http.post<AdvisorSessionResponse>(
+      `${this.baseUrl}/advisor/sessions/${sessionId}/messages`,
+      request
+    );
+  }
+
+  getAdvisorSession(sessionId: string): Observable<AdvisorSessionStateResponse> {
+    return this.http.get<AdvisorSessionStateResponse>(
+      `${this.baseUrl}/advisor/sessions/${sessionId}`
+    );
+  }
+
+  completeAdvisorSession(sessionId: string): Observable<CompleteAdvisorSessionResponse> {
+    return this.http.post<CompleteAdvisorSessionResponse>(
+      `${this.baseUrl}/advisor/sessions/${sessionId}/complete`,
+      {}
     );
   }
 }


### PR DESCRIPTION
Replace the forms-only investment dashboard with a chat-primary layout.
Users interact with a financial advisor via conversational chat by default,
with a toggle to switch to the existing manual forms view.

- Create InvestmentChatComponent with advisor session management
- Add advisor session models and API methods (start, send, complete)
- Update dashboard with Chat/Forms toggle (chat is default)
- Show session status, current topic, and missing fields in chat UI
- Support IPS creation confirmation flow from chat

https://claude.ai/code/session_01FVUUQ3JvQXconxyQrtkydi