### PR TITLE
Remove SW_LLM_* backward compatibility environment variables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       run:
         working-directory: backend/agents
     env:
-      SW_LLM_PROVIDER: dummy
+      LLM_PROVIDER: dummy
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -112,7 +112,7 @@ All teams mount under `/api/{team-slug}`. Team configs are defined in `backend/u
 - **Ollama** (local inference or Cloud API via `OLLAMA_API_KEY`) — including thinking mode
 - **Claude** (via httpx direct calls)
 
-Environment variables for LLM: `SW_LLM_PROVIDER`, `SW_LLM_BASE_URL`, `SW_LLM_MODEL`
+Environment variables for LLM: `LLM_PROVIDER`, `LLM_BASE_URL`, `LLM_MODEL`
 
 ## Code Style
 
@@ -127,9 +127,9 @@ Environment variables for LLM: `SW_LLM_PROVIDER`, `SW_LLM_BASE_URL`, `SW_LLM_MOD
 | Variable | Purpose |
 |---|---|
 | `OLLAMA_API_KEY` | Required for Ollama Cloud API |
-| `SW_LLM_PROVIDER` | LLM provider selection |
-| `SW_LLM_BASE_URL` | LLM server URL |
-| `SW_LLM_MODEL` | Model name |
+| `LLM_PROVIDER` | LLM provider selection |
+| `LLM_BASE_URL` | LLM server URL |
+| `LLM_MODEL` | Model name |
 | `TEMPORAL_ADDRESS` | Enables Temporal mode when set |
 | `TEMPORAL_NAMESPACE` | Temporal namespace |
 | `TEMPORAL_TASK_QUEUE` | Temporal task queue name |
@@ -139,7 +139,7 @@ Environment variables for LLM: `SW_LLM_PROVIDER`, `SW_LLM_BASE_URL`, `SW_LLM_MOD
 | `MEDIUM_GOOGLE_REDIRECT_URI` | Optional; fixed OAuth redirect for Medium’s Google identity link (`…/api/integrations/medium/oauth/google/callback`) when the API is behind a proxy |
 | `BLOG_PLANNING_MAX_ITERATIONS` | Blog planning refine loop cap (default 5) |
 | `BLOG_PLANNING_MAX_PARSE_RETRIES` | JSON parse/repair attempts per planning LLM call (default 3) |
-| `BLOG_PLANNING_MODEL` | Optional Ollama model name for **planning only** (same base URL as `SW_LLM_*`) |
+| `BLOG_PLANNING_MODEL` | Optional Ollama model name for **planning only** (same base URL as `LLM_*`) |
 
 **Blogging pipeline:** `research → planning (ContentPlan) → draft → gates`; `POST /research-and-review` runs research + the same planning step. See `backend/agents/blogging/README.md` and repo `CHANGELOG.md`.
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -93,9 +93,9 @@ Create a `.env` file in `agents/` (or export in your shell) for local developmen
 OLLAMA_API_KEY=your_ollama_key
 
 # Software Engineering (for real LLM runs)
-SW_LLM_PROVIDER=ollama
-SW_LLM_MODEL=qwen3.5:397b-cloud
-SW_LLM_BASE_URL=http://127.0.0.1:11434
+LLM_PROVIDER=ollama
+LLM_MODEL=qwen3.5:397b-cloud
+LLM_BASE_URL=http://127.0.0.1:11434
 
 # SOC2 (optional)
 SOC2_LLM_PROVIDER=ollama

--- a/backend/agents/blogging/README.md
+++ b/backend/agents/blogging/README.md
@@ -73,7 +73,7 @@ When `work_dir` is provided, the pipeline persists all outputs as versioned arti
 
 **API**: `POST /full-pipeline` runs the full pipeline with gates. `POST /research-and-review` runs **research + planning** (same planning step as the full pipeline) and accepts optional `work_dir` or `run_id` to persist artifacts.
 
-**Env (planning):** `BLOG_PLANNING_MAX_ITERATIONS` (default 5), `BLOG_PLANNING_MAX_PARSE_RETRIES` (default 3), optional `BLOG_PLANNING_MODEL` (Ollama model name for planning only; same API base as `SW_LLM_*`).
+**Env (planning):** `BLOG_PLANNING_MAX_ITERATIONS` (default 5), `BLOG_PLANNING_MAX_PARSE_RETRIES` (default 3), optional `BLOG_PLANNING_MODEL` (Ollama model name for planning only; same API base as `LLM_*`).
 
 ### Planning definition of done (refine loop)
 

--- a/backend/agents/blogging/shared/planning_config.py
+++ b/backend/agents/blogging/shared/planning_config.py
@@ -18,7 +18,7 @@ def planning_model_override() -> Optional[str]:
     """
     When set, the planning phase uses this Ollama model name instead of the pipeline default.
 
-    Same base URL and auth as `SW_LLM_*` / `OLLAMA_API_KEY`. Ignored for non-Ollama test clients.
+    Same base URL and auth as `LLM_*` / `OLLAMA_API_KEY`. Ignored for non-Ollama test clients.
     """
     raw = (os.environ.get("BLOG_PLANNING_MODEL") or "").strip()
     return raw or None

--- a/backend/agents/blogging/tests/test_blog_draft_agent_integration.py
+++ b/backend/agents/blogging/tests/test_blog_draft_agent_integration.py
@@ -81,8 +81,7 @@ _skip_reason = "Integration test requires real LLM (set LLM_PROVIDER=ollama and 
 
 
 @pytest.mark.skipif(
-    os.environ.get("LLM_PROVIDER", "").lower() == "dummy"
-    or os.environ.get("SW_LLM_PROVIDER", "").lower() == "dummy",
+    os.environ.get("LLM_PROVIDER", "").lower() == "dummy",
     reason=_skip_reason,
 )
 def test_draft_agent_with_ollama_produces_real_content() -> None:

--- a/backend/agents/docker-compose.yml
+++ b/backend/agents/docker-compose.yml
@@ -16,9 +16,9 @@ services:
       - "8080:8080"
     environment:
       PYTHONUNBUFFERED: "1"
-      SW_LLM_PROVIDER: ${SW_LLM_PROVIDER:-ollama}
-      SW_LLM_BASE_URL: ${SW_LLM_BASE_URL:-http://host.docker.internal:11434}
-      SW_LLM_MODEL: ${SW_LLM_MODEL:-qwen3.5:397b-cloud}
+      LLM_PROVIDER: ${LLM_PROVIDER:-ollama}
+      LLM_BASE_URL: ${LLM_BASE_URL:-http://host.docker.internal:11434}
+      LLM_MODEL: ${LLM_MODEL:-qwen3.5:397b-cloud}
     extra_hosts:
       - "host.docker.internal:host-gateway"
     restart: unless-stopped

--- a/backend/agents/docker/README.md
+++ b/backend/agents/docker/README.md
@@ -32,15 +32,15 @@ curl http://localhost:18005/health
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `SW_LLM_PROVIDER` | `ollama` | LLM provider (ollama or dummy) |
-| `SW_LLM_BASE_URL` | `http://host.docker.internal:11434` | Ollama API URL. Use this to reach Ollama on the host. |
-| `SW_LLM_MODEL` | `qwen3.5:397b-cloud` | Default model for agents |
-| `SW_LLM_MODEL_<AGENT_KEY>` | - | Per-agent model override (e.g. `SW_LLM_MODEL_BACKEND_EXPERT`) |
+| `LLM_PROVIDER` | `ollama` | LLM provider (ollama or dummy) |
+| `LLM_BASE_URL` | `http://host.docker.internal:11434` | Ollama API URL. Use this to reach Ollama on the host. |
+| `LLM_MODEL` | `qwen3.5:397b-cloud` | Default model for agents |
+| `LLM_MODEL_<AGENT_KEY>` | - | Per-agent model override (e.g. `LLM_MODEL_BACKEND_EXPERT`) |
 | `PYTHONUNBUFFERED` | `1` | Ensures Python output is not buffered |
 
-To override the default model, create a `.env` file with `SW_LLM_MODEL=your-model` and add it to the service, or run:
+To override the default model, create a `.env` file with `LLM_MODEL=your-model` and add it to the service, or run:
 ```bash
-SW_LLM_MODEL=llama3.2:latest docker-compose up -d
+LLM_MODEL=llama3.2:latest docker-compose up -d
 ```
 
 ## Port Mapping
@@ -151,7 +151,7 @@ docker exec strands-agents supervisorctl status
 **Solutions:**
 1. Ensure Ollama is running on the host: `curl http://localhost:11434/api/tags`
 2. On Linux, `host.docker.internal` requires `extra_hosts: host.docker.internal:host-gateway` (included in docker-compose.yml)
-3. If using a custom Ollama URL, set `SW_LLM_BASE_URL` (e.g. `http://192.168.1.100:11434`)
+3. If using a custom Ollama URL, set `LLM_BASE_URL` (e.g. `http://192.168.1.100:11434`)
 
 ### Docker Build Failures
 

--- a/backend/agents/llm_service/README.md
+++ b/backend/agents/llm_service/README.md
@@ -22,21 +22,21 @@ max_ctx = client.get_max_context_tokens()
 
 ## Config (environment variables)
 
-| Variable | Meaning | Backward compat |
-|----------|---------|-----------------|
-| `LLM_PROVIDER` | `dummy` or `ollama` | `SW_LLM_PROVIDER` |
-| `LLM_MODEL` | Model name | `SW_LLM_MODEL` |
-| `LLM_MODEL_<agent_key>` | Per-agent model override | `SW_LLM_MODEL_<agent_key>` |
-| `LLM_BASE_URL` | Ollama base URL (default `https://ollama.com`) | `SW_LLM_BASE_URL` |
-| `LLM_TIMEOUT` | Request timeout in seconds (default 600; raise for slow cloud models / long prompts) | `SW_LLM_TIMEOUT` |
-| `LLM_CONTEXT_SIZE` | Override context size | `SW_LLM_CONTEXT_SIZE` |
-| `LLM_MAX_TOKENS` | Max output tokens | `SW_LLM_MAX_TOKENS` |
-| `LLM_MAX_RETRIES` | Retries for transient errors | `SW_LLM_MAX_RETRIES` |
-| `LLM_BACKOFF_BASE` | Backoff base (seconds) | `SW_LLM_BACKOFF_BASE` |
-| `LLM_BACKOFF_MAX` | Max backoff (seconds) | `SW_LLM_BACKOFF_MAX_SECONDS` |
-| `LLM_MAX_CONCURRENCY` | Max concurrent Ollama calls | `SW_LLM_MAX_CONCURRENCY` |
-| `LLM_ENABLE_THINKING` | Enable thinking for qwen3.5 | `SW_LLM_ENABLE_THINKING` |
-| `OLLAMA_API_KEY` | **Required for Ollama Cloud.** API key from https://ollama.com/settings/keys. All LLM requests use this when set. | `LLM_OLLAMA_API_KEY`, `SW_LLM_OLLAMA_API_KEY` (overrides) |
+| Variable | Meaning |
+|----------|---------|
+| `LLM_PROVIDER` | `dummy` or `ollama` |
+| `LLM_MODEL` | Model name |
+| `LLM_MODEL_<agent_key>` | Per-agent model override |
+| `LLM_BASE_URL` | Ollama base URL (default `https://ollama.com`) |
+| `LLM_TIMEOUT` | Request timeout in seconds (default 600; raise for slow cloud models / long prompts) |
+| `LLM_CONTEXT_SIZE` | Override context size |
+| `LLM_MAX_TOKENS` | Max output tokens |
+| `LLM_MAX_RETRIES` | Retries for transient errors |
+| `LLM_BACKOFF_BASE` | Backoff base (seconds) |
+| `LLM_BACKOFF_MAX` | Max backoff (seconds) |
+| `LLM_MAX_CONCURRENCY` | Max concurrent Ollama calls |
+| `LLM_ENABLE_THINKING` | Enable thinking for qwen3.5 |
+| `OLLAMA_API_KEY` | **Required for Ollama Cloud.** API key from https://ollama.com/settings/keys. All LLM requests use this when set. |
 
 ### Troubleshooting
 
@@ -48,13 +48,13 @@ max_ctx = client.get_max_context_tokens()
 
 **500 Internal Server Error from Ollama Cloud**
 
-- **Thinking mode:** With `qwen3.5:397b-cloud`, the client may send `think: true`, which some endpoints reject. Set `LLM_ENABLE_THINKING=false` (or `SW_LLM_ENABLE_THINKING=false`) and retry.
+- **Thinking mode:** With `qwen3.5:397b-cloud`, the client may send `think: true`, which some endpoints reject. Set `LLM_ENABLE_THINKING=false` and retry.
 - **Quota / capacity:** Check your Ollama Cloud account and https://status.ollama.com (or Ollama’s status page) for outages or rate limits.
 - **Model / size:** Try a smaller model (e.g. `LLM_MODEL=qwen3.5:8b-cloud`) or reduce prompt size to rule out server-side overload.
 
 ### Docker and name resolution
 
-If the app runs inside Docker, the default `LLM_BASE_URL` (`https://ollama.com`) may be unreachable (e.g. "Temporary failure in name resolution") if the container has no outbound DNS or network. Set `LLM_BASE_URL` (or `SW_LLM_BASE_URL`) to a reachable endpoint:
+If the app runs inside Docker, the default `LLM_BASE_URL` (`https://ollama.com`) may be unreachable (e.g. "Temporary failure in name resolution") if the container has no outbound DNS or network. Set `LLM_BASE_URL` to a reachable endpoint:
 
 - **Local Ollama on the host:** `http://host.docker.internal:11434` (Mac/Windows Docker Desktop) or the host’s LAN IP and port (e.g. `http://192.168.1.2:11434`).
 - **Ollama in another container:** Use the Docker service name and port (e.g. `http://ollama:11434`) and ensure both containers share a network.
@@ -62,7 +62,6 @@ If the app runs inside Docker, the default `LLM_BASE_URL` (`https://ollama.com`)
 
 **Legacy mapping (same behavior via central config):**
 
-- `SW_LLM_*` → read when `LLM_*` unset (software engineering / shared)
 - `BLOG_LLM_*` → use `LLM_*` or `LLM_MODEL_blog`
 - `SOC2_LLM_*` → use `LLM_*` or `LLM_MODEL_soc2`
 

--- a/backend/agents/llm_service/clients/ollama.py
+++ b/backend/agents/llm_service/clients/ollama.py
@@ -1049,9 +1049,7 @@ class OllamaLLMClient(LLMClient):
             self.model,
             use_think,
         )
-        env_max = os.environ.get(llm_config.ENV_LLM_MAX_TOKENS) or os.environ.get(
-            llm_config.ENV_LLM_MAX_TOKENS_SW
-        )
+        env_max = os.environ.get(llm_config.ENV_LLM_MAX_TOKENS)
         if max_tokens is None:
             if env_max:
                 try:

--- a/backend/agents/llm_service/clients/ollama.py
+++ b/backend/agents/llm_service/clients/ollama.py
@@ -86,21 +86,9 @@ def _parse_retry_config() -> tuple[int, float, float]:
 
     Backoff is exponential: wait initial * 2^attempt after each failure (first retry ~initial seconds).
     """
-    raw_retries = (
-        os.environ.get(llm_config.ENV_LLM_MAX_RETRIES)
-        or os.environ.get(llm_config.ENV_LLM_MAX_RETRIES_SW)
-        or "6"
-    )
-    raw_initial = (
-        os.environ.get(llm_config.ENV_LLM_BACKOFF_BASE)
-        or os.environ.get(llm_config.ENV_LLM_BACKOFF_BASE_SW)
-        or "2"
-    )
-    raw_max = (
-        os.environ.get(llm_config.ENV_LLM_BACKOFF_MAX)
-        or os.environ.get(llm_config.ENV_LLM_BACKOFF_MAX_SW)
-        or "120"
-    )
+    raw_retries = os.environ.get(llm_config.ENV_LLM_MAX_RETRIES) or "6"
+    raw_initial = os.environ.get(llm_config.ENV_LLM_BACKOFF_BASE) or "2"
+    raw_max = os.environ.get(llm_config.ENV_LLM_BACKOFF_MAX) or "120"
     try:
         max_retries = max(0, int(raw_retries))
     except ValueError:
@@ -134,11 +122,7 @@ def _get_ollama_semaphore() -> threading.BoundedSemaphore:
     global _ollama_semaphore
     with _semaphore_lock:
         if _ollama_semaphore is None:
-            raw = (
-                os.environ.get(llm_config.ENV_LLM_MAX_CONCURRENCY)
-                or os.environ.get(llm_config.ENV_LLM_MAX_CONCURRENCY_SW)
-                or "4"
-            )
+            raw = os.environ.get(llm_config.ENV_LLM_MAX_CONCURRENCY) or "4"
             try:
                 limit = max(1, int(raw))
             except ValueError:
@@ -167,7 +151,6 @@ class OllamaLLMClient(LLMClient):
         key = (
             (os.environ.get("OLLAMA_API_KEY") or "")
             or (os.environ.get(llm_config.ENV_LLM_OLLAMA_API_KEY) or "")
-            or (os.environ.get(llm_config.ENV_LLM_OLLAMA_API_KEY_SW) or "")
         ).strip()
         if not key:
             return {}
@@ -477,11 +460,7 @@ class OllamaLLMClient(LLMClient):
 
     def _should_enable_thinking(self) -> bool:
         """Global default: enable thinking for all models; disable via LLM_ENABLE_THINKING=false."""
-        env_val = (
-            os.environ.get(llm_config.ENV_LLM_ENABLE_THINKING)
-            or os.environ.get(llm_config.ENV_LLM_ENABLE_THINKING_SW)
-            or ""
-        ).lower()
+        env_val = (os.environ.get(llm_config.ENV_LLM_ENABLE_THINKING) or "").lower()
         return env_val != "false"
 
     def _resolve_think(self, think: Optional[bool]) -> bool:
@@ -744,7 +723,7 @@ class OllamaLLMClient(LLMClient):
                                     )
                                 if status == 401:
                                     auth_hint = (
-                                        " Set OLLAMA_API_KEY (or LLM_OLLAMA_API_KEY / SW_LLM_OLLAMA_API_KEY) for Ollama Cloud."
+                                        " Set OLLAMA_API_KEY (or LLM_OLLAMA_API_KEY) for Ollama Cloud."
                                         if not headers
                                         else " Check that the key is valid and not expired."
                                     )
@@ -846,7 +825,7 @@ class OllamaLLMClient(LLMClient):
                 timeout_hint = ""
                 if isinstance(e, httpx.ReadTimeout):
                     timeout_hint = (
-                        f" Per-request timeout is {int(self.timeout)}s; increase LLM_TIMEOUT or SW_LLM_TIMEOUT "
+                        f" Per-request timeout is {int(self.timeout)}s; increase LLM_TIMEOUT "
                         "(e.g. 900–1200) for slow cloud models or very long prompts."
                     )
                 logger.error(
@@ -891,9 +870,7 @@ class OllamaLLMClient(LLMClient):
         )
         max_tokens = kwargs.pop("max_tokens", None)
         if max_tokens is None:
-            env_max = os.environ.get(llm_config.ENV_LLM_MAX_TOKENS) or os.environ.get(
-                llm_config.ENV_LLM_MAX_TOKENS_SW
-            )
+            env_max = os.environ.get(llm_config.ENV_LLM_MAX_TOKENS)
             if env_max:
                 try:
                     max_tokens = min(int(env_max), DEFAULT_MAX_OUTPUT_TOKENS)

--- a/backend/agents/llm_service/config.py
+++ b/backend/agents/llm_service/config.py
@@ -1,8 +1,7 @@
 """
 Single source of configuration for the LLM service.
 
-Environment variables use LLM_* prefix with backward compatibility for SW_LLM_*
-(and optionally BLOG_LLM_*, SOC2_LLM_* for migration). Known model context and
+Environment variables use LLM_* prefix. Known model context and
 per-agent default models live here.
 """
 
@@ -15,41 +14,21 @@ from typing import Optional
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Environment variable names (prefer LLM_*, fallback to SW_LLM_*)
+# Environment variable names (LLM_*)
 # ---------------------------------------------------------------------------
 
-
-def _env(key_llm: str, key_sw: str, default: str) -> str:
-    """Return env value: LLM_* if set, else SW_LLM_*, else default."""
-    v = os.environ.get(key_llm) or os.environ.get(key_sw)
-    return (v or default).strip()
-
-
-# Primary (LLM_*) and backward-compat (SW_LLM_*)
 ENV_LLM_PROVIDER = "LLM_PROVIDER"
-ENV_LLM_PROVIDER_SW = "SW_LLM_PROVIDER"
 ENV_LLM_MODEL = "LLM_MODEL"
-ENV_LLM_MODEL_SW = "SW_LLM_MODEL"
 ENV_LLM_BASE_URL = "LLM_BASE_URL"
-ENV_LLM_BASE_URL_SW = "SW_LLM_BASE_URL"
 ENV_LLM_TIMEOUT = "LLM_TIMEOUT"
-ENV_LLM_TIMEOUT_SW = "SW_LLM_TIMEOUT"
 ENV_LLM_CONTEXT_SIZE = "LLM_CONTEXT_SIZE"
-ENV_LLM_CONTEXT_SIZE_SW = "SW_LLM_CONTEXT_SIZE"
 ENV_LLM_MAX_TOKENS = "LLM_MAX_TOKENS"
-ENV_LLM_MAX_TOKENS_SW = "SW_LLM_MAX_TOKENS"
 ENV_LLM_MAX_RETRIES = "LLM_MAX_RETRIES"
-ENV_LLM_MAX_RETRIES_SW = "SW_LLM_MAX_RETRIES"
 ENV_LLM_BACKOFF_BASE = "LLM_BACKOFF_BASE"
-ENV_LLM_BACKOFF_BASE_SW = "SW_LLM_BACKOFF_BASE"
 ENV_LLM_BACKOFF_MAX = "LLM_BACKOFF_MAX"
-ENV_LLM_BACKOFF_MAX_SW = "SW_LLM_BACKOFF_MAX_SECONDS"
 ENV_LLM_MAX_CONCURRENCY = "LLM_MAX_CONCURRENCY"
-ENV_LLM_MAX_CONCURRENCY_SW = "SW_LLM_MAX_CONCURRENCY"
 ENV_LLM_ENABLE_THINKING = "LLM_ENABLE_THINKING"
-ENV_LLM_ENABLE_THINKING_SW = "SW_LLM_ENABLE_THINKING"
 ENV_LLM_OLLAMA_API_KEY = "LLM_OLLAMA_API_KEY"
-ENV_LLM_OLLAMA_API_KEY_SW = "SW_LLM_OLLAMA_API_KEY"
 
 # Default cap for max_tokens (many APIs limit output to 32K even when context is 256K)
 DEFAULT_MAX_OUTPUT_TOKENS = 32768
@@ -115,7 +94,7 @@ DEFAULT_FALLBACK_MODEL = "qwen3.5:397b-cloud"
 
 def resolve_provider() -> str:
     """Return effective LLM provider: 'dummy' or 'ollama' (default)."""
-    return _env(ENV_LLM_PROVIDER, ENV_LLM_PROVIDER_SW, "ollama").lower().strip()
+    return (os.environ.get(ENV_LLM_PROVIDER) or "ollama").lower().strip()
 
 
 def resolve_model(agent_key: Optional[str] = None) -> str:
@@ -123,12 +102,10 @@ def resolve_model(agent_key: Optional[str] = None) -> str:
     Resolve model name: LLM_MODEL_<agent_key>, then LLM_MODEL, then AGENT_DEFAULT_MODELS[agent_key], then fallback.
     """
     if agent_key:
-        per_agent = os.environ.get(f"LLM_MODEL_{agent_key}") or os.environ.get(
-            f"SW_LLM_MODEL_{agent_key}"
-        )
+        per_agent = os.environ.get(f"LLM_MODEL_{agent_key}")
         if per_agent:
             return per_agent.strip()
-    global_model = _env(ENV_LLM_MODEL, ENV_LLM_MODEL_SW, "")
+    global_model = (os.environ.get(ENV_LLM_MODEL) or "").strip()
     if global_model:
         return global_model
     if agent_key and agent_key in AGENT_DEFAULT_MODELS:
@@ -138,16 +115,16 @@ def resolve_model(agent_key: Optional[str] = None) -> str:
 
 def resolve_base_url() -> str:
     """Return Ollama base URL (default https://ollama.com for Ollama Cloud)."""
-    return _env(ENV_LLM_BASE_URL, ENV_LLM_BASE_URL_SW, "https://ollama.com").rstrip("/")
+    return (os.environ.get(ENV_LLM_BASE_URL) or "https://ollama.com").strip().rstrip("/")
 
 
 def resolve_timeout(agent_key: Optional[str] = None) -> float:
     """Return timeout in seconds (default 600).
 
     Large cloud models (e.g. long copy-edit prompts) often exceed 300s per request; override with
-    LLM_TIMEOUT / SW_LLM_TIMEOUT if you need higher.
+    LLM_TIMEOUT if you need higher.
     """
-    raw = os.environ.get(ENV_LLM_TIMEOUT) or os.environ.get(ENV_LLM_TIMEOUT_SW) or "600"
+    raw = os.environ.get(ENV_LLM_TIMEOUT) or "600"
     try:
         return float(raw)
     except ValueError:
@@ -159,7 +136,7 @@ def resolve_context_size_for_model(model: str) -> Optional[int]:
     Resolve context size (tokens) for a model: env LLM_CONTEXT_SIZE (global override),
     then KNOWN_MODEL_CONTEXT[model], else None (caller may use /api/show or default).
     """
-    raw = os.environ.get(ENV_LLM_CONTEXT_SIZE) or os.environ.get(ENV_LLM_CONTEXT_SIZE_SW)
+    raw = os.environ.get(ENV_LLM_CONTEXT_SIZE)
     if raw:
         try:
             return max(2048, int(raw))

--- a/backend/agents/llm_service/tests/test_config.py
+++ b/backend/agents/llm_service/tests/test_config.py
@@ -7,7 +7,6 @@ from llm_service import config
 
 def test_resolve_provider_default(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LLM_PROVIDER", raising=False)
-    monkeypatch.delenv("SW_LLM_PROVIDER", raising=False)
     assert config.resolve_provider() == "ollama"
 
 
@@ -16,15 +15,8 @@ def test_resolve_provider_dummy(monkeypatch: pytest.MonkeyPatch) -> None:
     assert config.resolve_provider() == "dummy"
 
 
-def test_resolve_provider_sw_backward_compat(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("LLM_PROVIDER", raising=False)
-    monkeypatch.setenv("SW_LLM_PROVIDER", "dummy")
-    assert config.resolve_provider() == "dummy"
-
-
 def test_resolve_model_agent_key_override(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LLM_MODEL", raising=False)
-    monkeypatch.delenv("SW_LLM_MODEL", raising=False)
     monkeypatch.setenv("LLM_MODEL_soc2", "custom-model")
     assert config.resolve_model("soc2") == "custom-model"
 
@@ -37,26 +29,22 @@ def test_resolve_model_global_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def test_resolve_model_agent_default(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LLM_MODEL", raising=False)
-    monkeypatch.delenv("SW_LLM_MODEL", raising=False)
     monkeypatch.delenv("LLM_MODEL_backend", raising=False)
     assert config.resolve_model("backend") == "qwen3.5:397b-cloud"
 
 
 def test_resolve_base_url_default(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LLM_BASE_URL", raising=False)
-    monkeypatch.delenv("SW_LLM_BASE_URL", raising=False)
     assert config.resolve_base_url() == "https://ollama.com"
 
 
 def test_resolve_timeout_default(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LLM_TIMEOUT", raising=False)
-    monkeypatch.delenv("SW_LLM_TIMEOUT", raising=False)
     assert config.resolve_timeout() == 600.0
 
 
 def test_resolve_context_size_for_model_known(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LLM_CONTEXT_SIZE", raising=False)
-    monkeypatch.delenv("SW_LLM_CONTEXT_SIZE", raising=False)
     assert config.resolve_context_size_for_model("qwen3.5:397b-cloud") == 262144
 
 

--- a/backend/agents/llm_service/tests/test_ollama_client.py
+++ b/backend/agents/llm_service/tests/test_ollama_client.py
@@ -11,7 +11,6 @@ from llm_service.interface import LLMPermanentError, LLMRateLimitError, LLMTempo
 
 def test_ollama_get_max_context_tokens_known_model(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("LLM_CONTEXT_SIZE", raising=False)
-    monkeypatch.delenv("SW_LLM_CONTEXT_SIZE", raising=False)
     client = OllamaLLMClient(
         model="qwen3.5:397b-cloud", base_url="http://localhost:9999", timeout=5
     )

--- a/backend/agents/personal_assistant_team/.env.example
+++ b/backend/agents/personal_assistant_team/.env.example
@@ -1,10 +1,10 @@
 # Personal Assistant Team Environment Variables
 
 # LLM Configuration
-SW_LLM_PROVIDER=ollama
-SW_LLM_MODEL=llama3.2
-SW_LLM_BASE_URL=http://127.0.0.1:11434
-SW_LLM_TIMEOUT=180
+LLM_PROVIDER=ollama
+LLM_MODEL=llama3.2
+LLM_BASE_URL=http://127.0.0.1:11434
+LLM_TIMEOUT=180
 
 # API Server
 PA_HOST=0.0.0.0

--- a/backend/agents/personal_assistant_team/README.md
+++ b/backend/agents/personal_assistant_team/README.md
@@ -174,9 +174,9 @@ curl "http://127.0.0.1:8015/users/user123/tasks/lists"
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `SW_LLM_PROVIDER` | LLM provider (ollama, dummy) | ollama |
-| `SW_LLM_MODEL` | LLM model name | llama3.2 |
-| `SW_LLM_BASE_URL` | Ollama base URL | http://127.0.0.1:11434 |
+| `LLM_PROVIDER` | LLM provider (ollama, dummy) | ollama |
+| `LLM_MODEL` | LLM model name | llama3.2 |
+| `LLM_BASE_URL` | Ollama base URL | http://127.0.0.1:11434 |
 | `PA_HOST` | API server host | 0.0.0.0 |
 | `PA_PORT` | API server port | 8015 |
 | `PA_CREDENTIAL_KEY` | Fernet encryption key | (required) |

--- a/backend/agents/personal_assistant_team/agent_implementations/run_api_server.py
+++ b/backend/agents/personal_assistant_team/agent_implementations/run_api_server.py
@@ -41,8 +41,8 @@ def main():
     port = int(os.getenv("PA_PORT", "8015"))
 
     logger.info("Starting Personal Assistant API server on %s:%d", host, port)
-    logger.info("LLM Provider: %s", os.getenv("SW_LLM_PROVIDER", "ollama"))
-    logger.info("LLM Model: %s", os.getenv("SW_LLM_MODEL", "default"))
+    logger.info("LLM Provider: %s", os.getenv("LLM_PROVIDER", "ollama"))
+    logger.info("LLM Model: %s", os.getenv("LLM_MODEL", "default"))
     logger.info("UI available at http://%s:%d/", host if host != "0.0.0.0" else "localhost", port)
 
     from personal_assistant_team.api.main import app

--- a/backend/agents/personal_assistant_team/shared/llm.py
+++ b/backend/agents/personal_assistant_team/shared/llm.py
@@ -299,12 +299,12 @@ class LLMClient(_BaseLLMClient):
                 "Try reducing context or being more concise."
             )
         suggestions.append("Use a larger model with higher token limits.")
-        suggestions.append("Check LLM configuration: SW_LLM_MODEL and SW_LLM_BASE_URL.")
+        suggestions.append("Check LLM configuration: LLM_MODEL and LLM_BASE_URL.")
         if raw_responses and (
             "error" in raw_responses[-1].lower() or "cannot" in raw_responses[-1].lower()
         ):
             suggestions.append("Review LLM response: The model may be refusing the request.")
-        suggestions.append("Increase timeout: Set SW_LLM_TIMEOUT to a higher value.")
+        suggestions.append("Increase timeout: Set LLM_TIMEOUT to a higher value.")
         return suggestions
 
 

--- a/backend/agents/personal_assistant_team/shared/robust_json.py
+++ b/backend/agents/personal_assistant_team/shared/robust_json.py
@@ -409,7 +409,7 @@ class RobustJSONExtractor:
         )
 
         suggestions.append(
-            "Check LLM configuration: Ensure SW_LLM_MODEL and SW_LLM_BASE_URL are "
+            "Check LLM configuration: Ensure LLM_MODEL and LLM_BASE_URL are "
             "correctly configured for a capable model."
         )
 
@@ -422,7 +422,7 @@ class RobustJSONExtractor:
                 )
 
         suggestions.append(
-            "Increase timeout: Set SW_LLM_TIMEOUT to a higher value (e.g., 300) "
+            "Increase timeout: Set LLM_TIMEOUT to a higher value (e.g., 300) "
             "if the model needs more time to generate complete responses."
         )
 

--- a/backend/agents/software_engineering_team/README.md
+++ b/backend/agents/software_engineering_team/README.md
@@ -171,20 +171,20 @@ By default, the script uses `DummyLLMClient` for testing without an LLM. To use 
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `SW_LLM_PROVIDER` | `dummy` or `ollama` | `dummy` |
-| `SW_LLM_MODEL` | Model name for Ollama | `qwen3.5:397b-cloud` |
-| `SW_LLM_BASE_URL` | Ollama API base URL | `http://127.0.0.1:11434` |
-| `SW_LLM_TIMEOUT` | Timeout in seconds | `1800` |
-| `SW_LLM_MAX_RETRIES` | Max retries for 429/5xx errors | `4` |
-| `SW_LLM_BACKOFF_BASE` | Base seconds for exponential backoff | `2` |
-| `SW_LLM_BACKOFF_MAX_SECONDS` | Max backoff seconds | `60` |
-| `SW_LLM_MAX_CONCURRENCY` | Max concurrent LLM calls (default 4; set 4–6 for faster runs with parallel planning and backend+frontend workers; lower to 2 if GPU/memory limited) | `4` |
-| `SW_LLM_MAX_TOKENS` | Max tokens to generate; if unset, uses min(context size, 32768) so APIs that cap output (e.g. 32K) work | 32768 (capped) |
-| `SW_LLM_CONTEXT_SIZE` | Context window in tokens; if unset, uses known model table or Ollama /api/show. Effective context = max minus largest agent reservation. qwen3.5:397b-cloud: 256K max (242K effective). | (model-dependent) |
-| `SW_LLM_ENABLE_THINKING` | Enable thinking mode for qwen3.5 models; improves reasoning quality but increases latency and token usage. Set to `false` to disable. | `true` (for qwen3.5) |
+| `LLM_PROVIDER` | `dummy` or `ollama` | `dummy` |
+| `LLM_MODEL` | Model name for Ollama | `qwen3.5:397b-cloud` |
+| `LLM_BASE_URL` | Ollama API base URL | `http://127.0.0.1:11434` |
+| `LLM_TIMEOUT` | Timeout in seconds | `1800` |
+| `LLM_MAX_RETRIES` | Max retries for 429/5xx errors | `4` |
+| `LLM_BACKOFF_BASE` | Base seconds for exponential backoff | `2` |
+| `LLM_BACKOFF_MAX_SECONDS` | Max backoff seconds | `60` |
+| `LLM_MAX_CONCURRENCY` | Max concurrent LLM calls (default 4; set 4–6 for faster runs with parallel planning and backend+frontend workers; lower to 2 if GPU/memory limited) | `4` |
+| `LLM_MAX_TOKENS` | Max tokens to generate; if unset, uses min(context size, 32768) so APIs that cap output (e.g. 32K) work | 32768 (capped) |
+| `LLM_CONTEXT_SIZE` | Context window in tokens; if unset, uses known model table or Ollama /api/show. Effective context = max minus largest agent reservation. qwen3.5:397b-cloud: 256K max (242K effective). | (model-dependent) |
+| `LLM_ENABLE_THINKING` | Enable thinking mode for qwen3.5 models; improves reasoning quality but increases latency and token usage. Set to `false` to disable. | `true` (for qwen3.5) |
 | `SW_ENABLE_PLANNING_CACHE` | Reuse cached TaskAssignment when spec and architecture unchanged; set to `0` or `false` to disable | `1` (enabled) |
 
-**Per-agent model configuration:** Each agent can use a different model. Set `SW_LLM_MODEL_<agent_key>` to override (e.g. `SW_LLM_MODEL_backend`, `SW_LLM_MODEL_tech_lead`). Model resolution order: per-agent env var → `SW_LLM_MODEL` (global fallback) → recommended default for that agent → `qwen3.5:397b-cloud`.
+**Per-agent model configuration:** Each agent can use a different model. Set `LLM_MODEL_<agent_key>` to override (e.g. `LLM_MODEL_backend`, `LLM_MODEL_tech_lead`). Model resolution order: per-agent env var → `LLM_MODEL` (global fallback) → recommended default for that agent → `qwen3.5:397b-cloud`.
 
 Recommended defaults (all :cloud versions) when no overrides are set:
 
@@ -192,16 +192,16 @@ Recommended defaults (all :cloud versions) when no overrides are set:
 |-------|--------|
 | qwen3.5:397b-cloud | All agents (backend, frontend, code_review, repair, devops, dbc_comments, tech_lead, architecture, spec_intake, spec_clarification, product_analysis, project_planning, integration, api_contract, data_architecture, ui_ux, frontend_architecture, infrastructure, devops_planning, qa_test_strategy, security_planning, observability, acceptance_verifier, documentation, qa, security, accessibility) |
 
-Example: `export SW_LLM_MODEL_tech_lead=qwen3.5:cloud` overrides only the Tech Lead; other agents use their defaults or `SW_LLM_MODEL`.
+Example: `export LLM_MODEL_tech_lead=qwen3.5:cloud` overrides only the Tech Lead; other agents use their defaults or `LLM_MODEL`.
 
 Example with Ollama:
 ```bash
-export SW_LLM_PROVIDER=ollama
-export SW_LLM_MODEL=qwen3.5:397b-cloud
+export LLM_PROVIDER=ollama
+export LLM_MODEL=qwen3.5:397b-cloud
 python -m agent_implementations.run_team
 ```
 
-Ensure Ollama is running with the model (e.g. `ollama run qwen3.5:397b-cloud`). If you use a different API (OpenRouter, Together, etc.) or get a "model not found" error, set `SW_LLM_MODEL` to a model your API supports (e.g. `export SW_LLM_MODEL=llama3.2` for Ollama, or your provider's model id).
+Ensure Ollama is running with the model (e.g. `ollama run qwen3.5:397b-cloud`). If you use a different API (OpenRouter, Together, etc.) or get a "model not found" error, set `LLM_MODEL` to a model your API supports (e.g. `export LLM_MODEL=llama3.2` for Ollama, or your provider's model id).
 
 **Iteration caps (environment variables):** Lowering these can speed runs but may reduce refinement.
 
@@ -232,7 +232,7 @@ When `SW_ENABLE_PLANNING_CACHE=1` (default), the first successful planning run s
 ### Faster runs summary
 
 - **Parallel planning:** Domain planning agents (API Contract, Data Arch, UI/UX, Infra, etc.) run in dependency tiers with internal parallelism (Tier 1 → Tier 2 → Tier 3).
-- **LLM concurrency:** Default `SW_LLM_MAX_CONCURRENCY=4`; set 4–6 for faster runs when GPU/memory allows.
+- **LLM concurrency:** Default `LLM_MAX_CONCURRENCY=4`; set 4–6 for faster runs when GPU/memory allows.
 - **Skip planning:** `SW_SKIP_PLANNING_AGENTS` or `SW_MINIMAL_PLANNING=1` for time-sensitive runs.
 - **Iteration caps:** Lower `SW_MAX_*` env vars to reduce refinement rounds (may reduce quality).
 

--- a/backend/agents/software_engineering_team/agent_implementations/run_team.py
+++ b/backend/agents/software_engineering_team/agent_implementations/run_team.py
@@ -34,7 +34,7 @@ from software_engineering_team.shared.models import ProductRequirements, TaskTyp
 logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
 logger = logging.getLogger(__name__)
 
-# Uses get_llm_client() which reads SW_LLM_PROVIDER, SW_LLM_MODEL (default: qwen3.5:397b-cloud)
+# Uses get_llm_client() which reads LLM_PROVIDER, LLM_MODEL (default: qwen3.5:397b-cloud)
 LLM = get_client()
 
 # Example product requirements

--- a/backend/agents/software_engineering_team/shared/README.md
+++ b/backend/agents/software_engineering_team/shared/README.md
@@ -40,15 +40,15 @@ The LLM client provides a unified interface for text and JSON generation with su
 
 | Environment Variable | Description | Default |
 |---------------------|-------------|---------|
-| `SW_LLM_PROVIDER` | `ollama` or `dummy` | `dummy` |
-| `SW_LLM_MODEL` | Model name | `qwen3.5:397b-cloud` |
-| `SW_LLM_BASE_URL` | Ollama API URL | `http://127.0.0.1:11434` |
-| `SW_LLM_TIMEOUT` | Request timeout (seconds) | 600 |
-| `SW_LLM_MAX_RETRIES` | Retry attempts | 4 |
-| `SW_LLM_MAX_CONCURRENCY` | Concurrent calls | 2 |
-| `SW_LLM_MAX_TOKENS` | Max output tokens | min(context, 32768) |
-| `SW_LLM_CONTEXT_SIZE` | Context window | Model-specific |
-| `SW_LLM_MODEL_<AGENT>` | Per-agent model override | — |
+| `LLM_PROVIDER` | `ollama` or `dummy` | `dummy` |
+| `LLM_MODEL` | Model name | `qwen3.5:397b-cloud` |
+| `LLM_BASE_URL` | Ollama API URL | `http://127.0.0.1:11434` |
+| `LLM_TIMEOUT` | Request timeout (seconds) | 600 |
+| `LLM_MAX_RETRIES` | Retry attempts | 4 |
+| `LLM_MAX_CONCURRENCY` | Concurrent calls | 2 |
+| `LLM_MAX_TOKENS` | Max output tokens | min(context, 32768) |
+| `LLM_CONTEXT_SIZE` | Context window | Model-specific |
+| `LLM_MODEL_<AGENT>` | Per-agent model override | — |
 
 ### Agent-Specific Models
 
@@ -91,7 +91,7 @@ result = llm.complete_json(
 ```python
 from shared.llm import get_llm_for_agent
 
-# Uses SW_LLM_MODEL_BACKEND or agent default
+# Uses LLM_MODEL_BACKEND or agent default
 llm = get_llm_for_agent("backend")
 ```
 

--- a/backend/agents/software_engineering_team/shared/continuation.py
+++ b/backend/agents/software_engineering_team/shared/continuation.py
@@ -22,15 +22,15 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-ENV_LLM_ENABLE_THINKING = "SW_LLM_ENABLE_THINKING"
-ENV_LLM_OLLAMA_API_KEY = "SW_LLM_OLLAMA_API_KEY"
-ENV_LLM_MAX_TOKENS = "SW_LLM_MAX_TOKENS"
+ENV_LLM_ENABLE_THINKING = "LLM_ENABLE_THINKING"
+ENV_LLM_OLLAMA_API_KEY = "LLM_OLLAMA_API_KEY"
+ENV_LLM_MAX_TOKENS = "LLM_MAX_TOKENS"
 DEFAULT_MAX_OUTPUT_TOKENS = 32768
 
 
 def _ollama_auth_headers() -> Dict[str, str]:
     """Return Authorization Bearer header for Ollama Cloud when API key is set."""
-    key = os.environ.get(ENV_LLM_OLLAMA_API_KEY) or os.environ.get("OLLAMA_API_KEY")
+    key = os.environ.get("OLLAMA_API_KEY") or os.environ.get(ENV_LLM_OLLAMA_API_KEY)
     if not key:
         return {}
     return {"Authorization": f"Bearer {key}"}
@@ -107,7 +107,7 @@ class ResponseContinuator:
             timeout: Request timeout in seconds.
             max_cycles: Maximum number of continuation cycles.
             num_predict: Max tokens to generate per continuation turn. If None, uses
-                SW_LLM_MAX_TOKENS env or DEFAULT_MAX_OUTPUT_TOKENS (32768) to match main LLM client.
+                LLM_MAX_TOKENS env or DEFAULT_MAX_OUTPUT_TOKENS (32768) to match main LLM client.
         """
         self.base_url = base_url.rstrip("/")
         self.model = model

--- a/backend/agents/software_engineering_team/shared/post_mortem.py
+++ b/backend/agents/software_engineering_team/shared/post_mortem.py
@@ -264,7 +264,7 @@ class PostMortemWriter:
                 )
 
         suggestions.append(
-            "- **Review token limits**: Check `SW_LLM_MAX_TOKENS` and model context size."
+            "- **Review token limits**: Check `LLM_MAX_TOKENS` and model context size."
         )
         suggestions.append(
             "- **Reduce prompt complexity**: Simplify the original prompt or provide "

--- a/backend/agents/software_engineering_team/tests/test_ai_agent_development_team.py
+++ b/backend/agents/software_engineering_team/tests/test_ai_agent_development_team.py
@@ -10,7 +10,7 @@ from software_engineering_team.shared.models import Task, TaskType
 
 
 class FakeLLM:
-    def complete_json(self, prompt: str):
+    def complete_json(self, prompt: str, **kwargs):
         if "spec intake specialist" in prompt:
             return {
                 "system_goal": "Build a spec-driven support agent system",
@@ -92,7 +92,7 @@ def test_ai_agent_development_workflow_success(tmp_path: Path):
 
 def test_ai_agent_development_workflow_problem_solving(tmp_path: Path):
     class SparseLLM(FakeLLM):
-        def complete_json(self, prompt: str):
+        def complete_json(self, prompt: str, **kwargs):
             if "delivery coordinator" in prompt:
                 return {"summary": "done", "handoff_notes": [], "runbook": []}
             if "AI systems planner" in prompt:

--- a/backend/agents/software_engineering_team/tests/test_api.py
+++ b/backend/agents/software_engineering_team/tests/test_api.py
@@ -225,9 +225,9 @@ def test_run_team_poll_status(client: TestClient, temp_work_path: Path) -> None:
         time.sleep(1)
 
     assert data is not None
-    # When SW_LLM_PROVIDER=dummy (CI without a real LLM) the job may still be
+    # When LLM_PROVIDER=dummy (CI without a real LLM) the job may still be
     # running after the timeout – the polling mechanism has already been verified.
-    if os.getenv("SW_LLM_PROVIDER", "") not in ("dummy", ""):
+    if os.getenv("LLM_PROVIDER", "") not in ("dummy", ""):
         assert data["status"] in ("completed", "failed")
     if data["status"] == "completed":
         assert "requirements_title" in data or data.get("architecture_overview") is not None

--- a/backend/agents/software_engineering_team/tests/test_llm.py
+++ b/backend/agents/software_engineering_team/tests/test_llm.py
@@ -31,7 +31,7 @@ def test_ollama_429_raises_rate_limit_error_after_retries() -> None:
         mock_client.stream.return_value.__enter__.return_value = mock_response
         mock_client_cls.return_value.__enter__.return_value = mock_client
 
-        with patch.dict(os.environ, {"SW_LLM_MAX_RETRIES": "1"}, clear=False):
+        with patch.dict(os.environ, {"LLM_MAX_RETRIES": "1"}, clear=False):
             with pytest.raises(LLMRateLimitError) as exc_info:
                 client.complete_json("test prompt")
 
@@ -55,7 +55,7 @@ def test_ollama_500_raises_temporary_error_after_retries() -> None:
         mock_client.stream.return_value.__enter__.return_value = mock_response
         mock_client_cls.return_value.__enter__.return_value = mock_client
 
-        with patch.dict(os.environ, {"SW_LLM_MAX_RETRIES": "1"}, clear=False):
+        with patch.dict(os.environ, {"LLM_MAX_RETRIES": "1"}, clear=False):
             with pytest.raises(LLMTemporaryError) as exc_info:
                 client.complete_json("test prompt")
 
@@ -130,7 +130,7 @@ def test_ollama_connection_error_raises_temporary_error_after_retries() -> None:
         mock_client.stream.side_effect = httpx.ConnectError("Connection refused")
         mock_client_cls.return_value.__enter__.return_value = mock_client
 
-        with patch.dict(os.environ, {"SW_LLM_MAX_RETRIES": "1"}, clear=False):
+        with patch.dict(os.environ, {"LLM_MAX_RETRIES": "1"}, clear=False):
             with pytest.raises(LLMTemporaryError) as exc_info:
                 client.complete_json("test prompt")
 
@@ -249,7 +249,7 @@ def test_get_llm_for_agent_per_agent_env_overrides() -> None:
 
 
 def test_get_llm_for_agent_global_fallback() -> None:
-    """When no per-agent env, SW_LLM_MODEL is used."""
+    """When no per-agent env, LLM_MODEL is used."""
     _clear_client_cache_for_testing()
     with patch.dict(
         os.environ,

--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -12,9 +12,9 @@ services:
       - "8080:8080"
     environment:
       PYTHONUNBUFFERED: "1"
-      SW_LLM_PROVIDER: ${SW_LLM_PROVIDER:-ollama}
-      SW_LLM_BASE_URL: ${SW_LLM_BASE_URL:-https://ollama.com}
-      SW_LLM_MODEL: ${SW_LLM_MODEL:-qwen3.5:397b-cloud}
+      LLM_PROVIDER: ${LLM_PROVIDER:-ollama}
+      LLM_BASE_URL: ${LLM_BASE_URL:-https://ollama.com}
+      LLM_MODEL: ${LLM_MODEL:-qwen3.5:397b-cloud}
       OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/backend/post_mortems/POST_MORTEMS.md
+++ b/backend/post_mortems/POST_MORTEMS.md
@@ -50,7 +50,7 @@ Build a web-based todo app where users can:
 
 ### Suggested Fixes
 
-- **Review token limits**: Check `SW_LLM_MAX_TOKENS` and model context size.
+- **Review token limits**: Check `LLM_MAX_TOKENS` and model context size.
 - **Reduce prompt complexity**: Simplify the original prompt or provide more focused instructions.
 - **Check for infinite loops**: Ensure the LLM isn't generating repetitive content that never terminates naturally.
 

--- a/backend/unified_api/README.md
+++ b/backend/unified_api/README.md
@@ -105,7 +105,7 @@ python run_unified_api.py --workers 4 --log-level warning
 | `SLACK_WEBHOOK_URL` | (none) | Optional. Slack Incoming Webhook URL; used as fallback when not set via Integrations UI. When set, open questions and Personal Assistant replies can be sent to Slack if Slack integration is enabled. |
 | `UI_BASE_URL` | `http://localhost:4200` | Base URL of the Angular UI; used in Slack messages for "Answer in UI" links. |
 
-Team-specific environment variables (e.g., `OLLAMA_API_KEY`, `SW_LLM_*`, `PA_*`) are passed through to the mounted team APIs.
+Team-specific environment variables (e.g., `OLLAMA_API_KEY`, `LLM_*`, `PA_*`) are passed through to the mounted team APIs.
 
 ## CLI Options
 

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -11,19 +11,19 @@ OLLAMA_API_KEY=
 # LLM (agents)
 # ---------------------------------------------------------------------------
 # Base URL for Ollama: https://ollama.com for cloud, or http://ollama:11434 for local stack
-SW_LLM_BASE_URL=https://ollama.com
-SW_LLM_MODEL=qwen3.5:397b-cloud
+LLM_BASE_URL=https://ollama.com
+LLM_MODEL=qwen3.5:397b-cloud
 # Optional: request timeout in seconds (default 300). Increase if Ollama Cloud is slow.
-SW_LLM_TIMEOUT=600
+LLM_TIMEOUT=600
 # Disable "thinking" for qwen3.5 on Ollama Cloud to avoid 500 errors from unsupported think parameter.
-SW_LLM_ENABLE_THINKING=false
+LLM_ENABLE_THINKING=false
 
 # ---------------------------------------------------------------------------
 # Blogging team — content planning (optional)
 # ---------------------------------------------------------------------------
 # BLOG_PLANNING_MAX_ITERATIONS=5
 # BLOG_PLANNING_MAX_PARSE_RETRIES=3
-# Optional: Ollama model name for planning only (defaults to SW_LLM_MODEL)
+# Optional: Ollama model name for planning only (defaults to LLM_MODEL)
 # BLOG_PLANNING_MODEL=
 
 # ---------------------------------------------------------------------------

--- a/docker/README.md
+++ b/docker/README.md
@@ -53,8 +53,8 @@ This directory defines a **Docker Compose stack** that runs:
 
 Optional (defaults in compose / `docker/.env.example`; copy to `docker/.env` and set as needed):
 
-- **SW_LLM_BASE_URL** – default is `https://ollama.com` (Ollama Cloud). Set to `http://ollama:11434` to use the local Ollama container instead.
-- **SW_LLM_MODEL** – default `qwen3.5:397b-cloud`
+- **LLM_BASE_URL** – default is `https://ollama.com` (Ollama Cloud). Set to `http://ollama:11434` to use the local Ollama container instead.
+- **LLM_MODEL** – default `qwen3.5:397b-cloud`
 - **POSTGRES_USER**, **POSTGRES_PASSWORD**, **POSTGRES_DB** – used for the default Postgres superuser; init scripts create `temporal` and `strands` DBs and users.
 
 Personal Assistant credential encryption uses a key generated at **Docker image build time** (stored in the image), so credentials persist across container restarts without setting any env var.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -114,9 +114,9 @@ services:
       temporal: { condition: service_started }
       job-service: { condition: service_healthy }
     environment:
-      SW_LLM_PROVIDER: ${SW_LLM_PROVIDER:-ollama}
-      SW_LLM_BASE_URL: ${SW_LLM_BASE_URL:-https://ollama.com}
-      SW_LLM_MODEL: ${SW_LLM_MODEL:-qwen3.5:397b-cloud}
+      LLM_PROVIDER: ${LLM_PROVIDER:-ollama}
+      LLM_BASE_URL: ${LLM_BASE_URL:-https://ollama.com}
+      LLM_MODEL: ${LLM_MODEL:-qwen3.5:397b-cloud}
       OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
       PYTHONUNBUFFERED: "1"
       POSTGRES_HOST: postgres
@@ -156,9 +156,9 @@ services:
       temporal: { condition: service_started }
       job-service: { condition: service_healthy }
     environment: &team-env-base
-      SW_LLM_PROVIDER: ${SW_LLM_PROVIDER:-ollama}
-      SW_LLM_BASE_URL: ${SW_LLM_BASE_URL:-https://ollama.com}
-      SW_LLM_MODEL: ${SW_LLM_MODEL:-qwen3.5:397b-cloud}
+      LLM_PROVIDER: ${LLM_PROVIDER:-ollama}
+      LLM_BASE_URL: ${LLM_BASE_URL:-https://ollama.com}
+      LLM_MODEL: ${LLM_MODEL:-qwen3.5:397b-cloud}
       OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
       PYTHONUNBUFFERED: "1"
       POSTGRES_HOST: postgres
@@ -651,9 +651,9 @@ services:
     cpus: "8"
     mem_limit: 2g
     environment:
-      SW_LLM_PROVIDER: ${SW_LLM_PROVIDER:-ollama}
-      SW_LLM_BASE_URL: ${SW_LLM_BASE_URL:-https://ollama.com}
-      SW_LLM_MODEL: ${SW_LLM_MODEL:-qwen3.5:397b-cloud}
+      LLM_PROVIDER: ${LLM_PROVIDER:-ollama}
+      LLM_BASE_URL: ${LLM_BASE_URL:-https://ollama.com}
+      LLM_MODEL: ${LLM_MODEL:-qwen3.5:397b-cloud}
       OLLAMA_API_KEY: ${OLLAMA_API_KEY:-}
       PYTHONUNBUFFERED: "1"
       POSTGRES_HOST: postgres

--- a/user-interface/src/app/components/accessibility-dashboard/accessibility-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/accessibility-dashboard/accessibility-dashboard.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideHttpClient } from '@angular/common/http';
 import { vi } from 'vitest';
 import { AccessibilityApiService } from '../../services/accessibility-api.service';
 import { AccessibilityDashboardComponent } from './accessibility-dashboard.component';
@@ -22,7 +23,7 @@ describe('AccessibilityDashboardComponent', () => {
     };
     await TestBed.configureTestingModule({
       imports: [AccessibilityDashboardComponent, NoopAnimationsModule],
-      providers: [{ provide: AccessibilityApiService, useValue: apiSpy }],
+      providers: [provideHttpClient(), { provide: AccessibilityApiService, useValue: apiSpy }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AccessibilityDashboardComponent);

--- a/user-interface/src/app/components/agent-provisioning-dashboard/agent-provisioning-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/agent-provisioning-dashboard/agent-provisioning-dashboard.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { provideRouter } from '@angular/router';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideHttpClient } from '@angular/common/http';
 import { vi } from 'vitest';
 import { AgentProvisioningApiService } from '../../services/agent-provisioning-api.service';
 import { AgentProvisioningDashboardComponent } from './agent-provisioning-dashboard.component';
@@ -25,7 +26,7 @@ describe('AgentProvisioningDashboardComponent', () => {
     };
     await TestBed.configureTestingModule({
       imports: [AgentProvisioningDashboardComponent, NoopAnimationsModule],
-      providers: [provideRouter([]), { provide: AgentProvisioningApiService, useValue: apiSpy }],
+      providers: [provideHttpClient(), provideRouter([]), { provide: AgentProvisioningApiService, useValue: apiSpy }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AgentProvisioningDashboardComponent);

--- a/user-interface/src/app/components/ai-systems-dashboard/ai-systems-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/ai-systems-dashboard/ai-systems-dashboard.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of } from 'rxjs';
 import { provideRouter } from '@angular/router';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideHttpClient } from '@angular/common/http';
 import { vi } from 'vitest';
 import { AISystemsApiService } from '../../services/ai-systems-api.service';
 import { AISystemsDashboardComponent } from './ai-systems-dashboard.component';
@@ -25,7 +26,7 @@ describe('AISystemsDashboardComponent', () => {
     };
     await TestBed.configureTestingModule({
       imports: [AISystemsDashboardComponent, NoopAnimationsModule],
-      providers: [provideRouter([]), { provide: AISystemsApiService, useValue: apiSpy }],
+      providers: [provideHttpClient(), provideRouter([]), { provide: AISystemsApiService, useValue: apiSpy }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(AISystemsDashboardComponent);

--- a/user-interface/src/app/components/blogging-dashboard/blogging-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/blogging-dashboard/blogging-dashboard.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
 import { provideRouter } from '@angular/router';
+import { provideHttpClient } from '@angular/common/http';
 import { BloggingApiService } from '../../services/blogging-api.service';
 import { BloggingDashboardComponent } from './blogging-dashboard.component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -40,7 +41,7 @@ describe('BloggingDashboardComponent', () => {
 
     await TestBed.configureTestingModule({
       imports: [BloggingDashboardComponent, NoopAnimationsModule],
-      providers: [provideRouter([]), { provide: BloggingApiService, useValue: apiSpy }],
+      providers: [provideHttpClient(), provideRouter([]), { provide: BloggingApiService, useValue: apiSpy }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(BloggingDashboardComponent);

--- a/user-interface/src/app/components/market-research-dashboard/market-research-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/market-research-dashboard/market-research-dashboard.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
 import { vi } from 'vitest';
+import { provideHttpClient } from '@angular/common/http';
 import { MarketResearchApiService } from '../../services/market-research-api.service';
 import { MarketResearchDashboardComponent } from './market-research-dashboard.component';
 
@@ -16,7 +17,7 @@ describe('MarketResearchDashboardComponent', () => {
     };
     await TestBed.configureTestingModule({
       imports: [MarketResearchDashboardComponent],
-      providers: [{ provide: MarketResearchApiService, useValue: apiSpy }],
+      providers: [provideHttpClient(), { provide: MarketResearchApiService, useValue: apiSpy }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(MarketResearchDashboardComponent);

--- a/user-interface/src/app/components/soc2-compliance-dashboard/soc2-compliance-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/soc2-compliance-dashboard/soc2-compliance-dashboard.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
 import { vi } from 'vitest';
+import { provideHttpClient } from '@angular/common/http';
 import { Soc2ComplianceApiService } from '../../services/soc2-compliance-api.service';
 import { Soc2ComplianceDashboardComponent } from './soc2-compliance-dashboard.component';
 
@@ -16,7 +17,7 @@ describe('Soc2ComplianceDashboardComponent', () => {
     };
     await TestBed.configureTestingModule({
       imports: [Soc2ComplianceDashboardComponent],
-      providers: [{ provide: Soc2ComplianceApiService, useValue: apiSpy }],
+      providers: [provideHttpClient(), { provide: Soc2ComplianceApiService, useValue: apiSpy }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(Soc2ComplianceDashboardComponent);

--- a/user-interface/src/app/components/social-marketing-dashboard/social-marketing-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/social-marketing-dashboard/social-marketing-dashboard.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
 import { provideRouter } from '@angular/router';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideHttpClient } from '@angular/common/http';
 import { vi } from 'vitest';
 import { SocialMarketingApiService } from '../../services/social-marketing-api.service';
 import { SocialMarketingDashboardComponent } from './social-marketing-dashboard.component';
@@ -25,7 +26,7 @@ describe('SocialMarketingDashboardComponent', () => {
     };
     await TestBed.configureTestingModule({
       imports: [SocialMarketingDashboardComponent, NoopAnimationsModule],
-      providers: [provideRouter([]), { provide: SocialMarketingApiService, useValue: apiSpy }],
+      providers: [provideHttpClient(), provideRouter([]), { provide: SocialMarketingApiService, useValue: apiSpy }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SocialMarketingDashboardComponent);

--- a/user-interface/src/app/components/software-engineering-dashboard/software-engineering-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/software-engineering-dashboard/software-engineering-dashboard.component.spec.ts
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { provideHttpClient } from '@angular/common/http';
 import { vi } from 'vitest';
 import { SoftwareEngineeringApiService } from '../../services/software-engineering-api.service';
 import { PlanningV3ApiService } from '../../services/planning-v3-api.service';
@@ -41,6 +42,7 @@ describe('SoftwareEngineeringDashboardComponent', () => {
     await TestBed.configureTestingModule({
       imports: [SoftwareEngineeringDashboardComponent, NoopAnimationsModule],
       providers: [
+        provideHttpClient(),
         { provide: SoftwareEngineeringApiService, useValue: apiSpy },
         { provide: PlanningV3ApiService, useValue: planningV3ApiSpy },
         { provide: ActivatedRoute, useValue: { queryParams: of({}) } },


### PR DESCRIPTION
## Summary
Remove all backward compatibility support for `SW_LLM_*` prefixed environment variables. The codebase now exclusively uses the `LLM_*` prefix for LLM configuration, simplifying environment variable handling and reducing technical debt.

## Key Changes

- **Removed backward compatibility layer**: Deleted the `_env()` helper function that provided fallback support for `SW_LLM_*` variables
- **Simplified environment variable resolution**: All configuration functions now directly read from `LLM_*` variables without fallback logic
- **Updated all references**: Changed all environment variable names throughout the codebase:
  - `LLM_PROVIDER`, `LLM_MODEL`, `LLM_BASE_URL`, `LLM_TIMEOUT`, `LLM_CONTEXT_SIZE`, `LLM_MAX_TOKENS`, `LLM_MAX_RETRIES`, `LLM_BACKOFF_BASE`, `LLM_BACKOFF_MAX`, `LLM_MAX_CONCURRENCY`, `LLM_ENABLE_THINKING`, `LLM_OLLAMA_API_KEY`
- **Updated documentation**: Removed "backward compat" columns from README tables and updated all example configurations
- **Updated Docker Compose files**: Changed environment variable declarations from `SW_LLM_*` to `LLM_*` across all services
- **Updated tests**: Removed test cases that verified `SW_LLM_*` backward compatibility
- **Updated CI/CD**: Changed GitHub Actions workflow to use `LLM_PROVIDER=dummy` instead of `SW_LLM_PROVIDER=dummy`

## Files Modified

- Core LLM service configuration and clients
- Documentation (README files across multiple teams)
- Docker Compose configurations (main stack and agent services)
- Environment example files
- Test files
- CI/CD workflow configuration
- Various team-specific implementations and shared utilities

## Migration Notes

Users relying on `SW_LLM_*` environment variables must update their configurations to use the `LLM_*` prefix. The migration is straightforward - simply rename the environment variables (e.g., `SW_LLM_MODEL` → `LLM_MODEL`).

https://claude.ai/code/session_0123Gbu2qryWGVtiqjA4QzZ6