### PR TITLE
feat(branding): redesign brand preview panel with premium SaaS UI

### DIFF
--- a/user-interface/src/app/components/brand-preview/brand-preview.component.html
+++ b/user-interface/src/app/components/brand-preview/brand-preview.component.html
@@ -1,316 +1,493 @@
-<mat-card class="preview-card">
-  <mat-card-header>
-    <mat-card-title>Brand preview</mat-card-title>
+<div class="preview-panel" [class.has-content]="hasContent">
+  <!-- Header -->
+  <div class="panel-header">
+    <div class="header-left">
+      <div class="header-icon">
+        <mat-icon>auto_awesome</mat-icon>
+      </div>
+      <div class="header-text">
+        <h2 class="panel-title">Brand Studio</h2>
+        <span class="panel-subtitle" [class.active]="hasContent">
+          @if (hasOutput) {
+            Brand complete
+          } @else if (hasMissionData) {
+            Building your brand...
+          } @else {
+            Waiting for input
+          }
+        </span>
+      </div>
+    </div>
     @if (hasOutput) {
-      <button mat-stroked-button color="primary" type="button" (click)="saveAsBrand.emit()" class="save-btn">
-        <mat-icon>save</mat-icon>
-        Save as brand
+      <button class="save-btn" (click)="saveAsBrand.emit()">
+        <mat-icon>bookmark_add</mat-icon>
+        Save brand
       </button>
     }
-  </mat-card-header>
-  <mat-card-content>
-    @if (!hasContent) {
-      <div class="empty-state">
-        <mat-icon>palette</mat-icon>
-        <p>Your brand will appear here as we talk.</p>
-        <p class="empty-hint">Answer a few questions in the chat and your brand will take shape in real time.</p>
+  </div>
+
+  <!-- Progress indicator -->
+  @if (hasMissionData && !hasOutput) {
+    <div class="progress-track">
+      <div class="progress-bar" [style.width]="completionPercent + '%'"></div>
+    </div>
+    <div class="progress-label">{{ completionPercent }}% defined</div>
+  }
+
+  <!-- Empty State -->
+  @if (!hasContent) {
+    <div class="empty-state">
+      <div class="empty-visual">
+        <div class="orb orb-1"></div>
+        <div class="orb orb-2"></div>
+        <div class="orb orb-3"></div>
+        <mat-icon class="empty-icon">palette</mat-icon>
       </div>
-    } @else if (!hasOutput) {
-      <!-- Live mission preview — updates as the conversation progresses -->
-      <div class="live-preview">
-        <!-- Foundation -->
-        @if (mission?.company_name && mission!.company_name !== 'TBD') {
-          <section class="preview-section">
-            <h3 class="section-title">
-              <mat-icon>business</mat-icon>
-              Foundation
-            </h3>
-            <div class="foundation-item">
-              <span class="label">Company</span>
-              <span class="value">{{ mission!.company_name }}</span>
+      <h3 class="empty-title">Your brand starts here</h3>
+      <p class="empty-description">
+        Start chatting with the branding assistant. Your brand identity will take shape in real time as we explore your vision together.
+      </p>
+      <div class="empty-hints">
+        <div class="hint-item">
+          <mat-icon>chat_bubble_outline</mat-icon>
+          <span>Describe your company</span>
+        </div>
+        <div class="hint-item">
+          <mat-icon>tune</mat-icon>
+          <span>Define your values</span>
+        </div>
+        <div class="hint-item">
+          <mat-icon>color_lens</mat-icon>
+          <span>Pick your colors</span>
+        </div>
+      </div>
+    </div>
+  } @else if (!hasOutput) {
+    <!-- Live Mission Preview -->
+    <div class="live-preview">
+      <!-- Foundation -->
+      @if (mission?.company_name && mission!.company_name !== 'TBD') {
+        <section class="preview-section" [@sectionEnter]>
+          <div class="section-header">
+            <div class="section-icon foundation-icon">
+              <mat-icon>domain</mat-icon>
+            </div>
+            <h3 class="section-label">Foundation</h3>
+          </div>
+          <div class="foundation-grid">
+            <div class="foundation-card">
+              <span class="field-label">Company</span>
+              <span class="field-value">{{ mission!.company_name }}</span>
             </div>
             @if (mission!.company_description && mission!.company_description !== 'To be discussed.') {
-              <div class="foundation-item">
-                <span class="label">Description</span>
-                <span class="value">{{ mission!.company_description }}</span>
+              <div class="foundation-card full-width">
+                <span class="field-label">Description</span>
+                <span class="field-value">{{ mission!.company_description }}</span>
               </div>
             }
             @if (mission!.target_audience && mission!.target_audience !== 'TBD') {
-              <div class="foundation-item">
-                <span class="label">Audience</span>
-                <span class="value">{{ mission!.target_audience }}</span>
+              <div class="foundation-card">
+                <span class="field-label">Target audience</span>
+                <span class="field-value">{{ mission!.target_audience }}</span>
               </div>
             }
-          </section>
-        }
+          </div>
+        </section>
+      }
 
-        <!-- Values & Differentiators -->
-        @if (missionValues.length > 0 || missionDifferentiators.length > 0) {
-          <section class="preview-section">
-            <h3 class="section-title">
-              <mat-icon>star</mat-icon>
-              Values &amp; Differentiators
-            </h3>
-            @if (missionValues.length > 0) {
-              <div class="chip-group">
-                <span class="chip-label">Values</span>
-                <mat-chip-set>
-                  @for (v of missionValues; track v) {
-                    <mat-chip>{{ v }}</mat-chip>
-                  }
-                </mat-chip-set>
+      <!-- Values & Differentiators -->
+      @if (missionValues.length > 0 || missionDifferentiators.length > 0) {
+        <section class="preview-section" [@sectionEnter]>
+          <div class="section-header">
+            <div class="section-icon values-icon">
+              <mat-icon>diamond</mat-icon>
+            </div>
+            <h3 class="section-label">Values &amp; Differentiators</h3>
+          </div>
+          @if (missionValues.length > 0) {
+            <div class="tag-group">
+              <span class="tag-group-label">Core values</span>
+              <div class="tag-row">
+                @for (v of missionValues; track v) {
+                  <span class="tag tag-value">{{ v }}</span>
+                }
               </div>
-            }
-            @if (missionDifferentiators.length > 0) {
-              <div class="chip-group">
-                <span class="chip-label">Differentiators</span>
-                <mat-chip-set>
-                  @for (d of missionDifferentiators; track d) {
-                    <mat-chip>{{ d }}</mat-chip>
-                  }
-                </mat-chip-set>
+            </div>
+          }
+          @if (missionDifferentiators.length > 0) {
+            <div class="tag-group">
+              <span class="tag-group-label">Differentiators</span>
+              <div class="tag-row">
+                @for (d of missionDifferentiators; track d) {
+                  <span class="tag tag-diff">{{ d }}</span>
+                }
               </div>
-            }
-          </section>
-        }
+            </div>
+          }
+        </section>
+      }
 
-        <!-- Voice -->
-        @if (mission?.desired_voice && mission!.desired_voice !== 'clear, confident, human') {
-          <section class="preview-section">
-            <h3 class="section-title">
+      <!-- Voice -->
+      @if (mission?.desired_voice && mission!.desired_voice !== 'clear, confident, human') {
+        <section class="preview-section" [@sectionEnter]>
+          <div class="section-header">
+            <div class="section-icon voice-icon">
               <mat-icon>record_voice_over</mat-icon>
-              Brand Voice
-            </h3>
-            <p class="voice-description">{{ mission!.desired_voice }}</p>
-          </section>
-        }
+            </div>
+            <h3 class="section-label">Brand Voice</h3>
+          </div>
+          <div class="voice-card">
+            <p class="voice-text">{{ mission!.desired_voice }}</p>
+          </div>
+        </section>
+      }
 
-        <!-- Color Inspiration -->
-        @if (missionColorInspiration.length > 0) {
-          <section class="preview-section">
-            <h3 class="section-title">
+      <!-- Color Inspiration -->
+      @if (missionColorInspiration.length > 0) {
+        <section class="preview-section" [@sectionEnter]>
+          <div class="section-header">
+            <div class="section-icon color-icon">
               <mat-icon>color_lens</mat-icon>
-              Color Inspiration
-            </h3>
-            <mat-chip-set>
-              @for (c of missionColorInspiration; track c) {
-                <mat-chip>{{ c }}</mat-chip>
-              }
-            </mat-chip-set>
-          </section>
-        }
+            </div>
+            <h3 class="section-label">Color Inspiration</h3>
+          </div>
+          <div class="tag-row">
+            @for (c of missionColorInspiration; track c) {
+              <span class="tag tag-color">{{ c }}</span>
+            }
+          </div>
+        </section>
+      }
 
-        <!-- Color Palettes -->
-        @if (missionPalettes.length > 0) {
-          <section class="preview-section">
-            <h3 class="section-title">
+      <!-- Color Palettes -->
+      @if (missionPalettes.length > 0) {
+        <section class="preview-section" [@sectionEnter]>
+          <div class="section-header">
+            <div class="section-icon palette-icon">
               <mat-icon>palette</mat-icon>
-              Color Palettes
-            </h3>
+            </div>
+            <h3 class="section-label">Color Palettes</h3>
+          </div>
+          <div class="palettes-grid">
             @for (palette of missionPalettes; track palette.name; let i = $index) {
               <div class="palette-card" [class.palette-selected]="isPaletteSelected(i)">
-                <div class="palette-header">
+                <div class="palette-top">
                   <span class="palette-name">{{ palette.name }}</span>
                   @if (isPaletteSelected(i)) {
-                    <mat-icon class="selected-icon">check_circle</mat-icon>
+                    <span class="selected-badge">
+                      <mat-icon>check</mat-icon>
+                      Selected
+                    </span>
                   }
                 </div>
                 @if (palette.description) {
                   <p class="palette-description">{{ palette.description }}</p>
                 }
-                <div class="palette-swatches">
+                <div class="swatch-strip">
                   @for (color of palette.colors; track color) {
-                    <div class="palette-swatch" [style.background]="parseColor(color)" [title]="color">
-                      <span class="swatch-label">{{ color }}</span>
+                    <div class="swatch-block" [style.background]="parseColor(color)" [title]="color">
+                      <span class="swatch-hex">{{ color }}</span>
                     </div>
                   }
                 </div>
                 @if (palette.sentiment) {
-                  <p class="palette-sentiment">{{ palette.sentiment }}</p>
+                  <p class="palette-mood">{{ palette.sentiment }}</p>
                 }
               </div>
             }
-          </section>
-        }
+          </div>
+        </section>
+      }
 
-        <!-- Visual Style -->
-        @if (mission?.visual_style || mission?.interface_density) {
-          <section class="preview-section">
-            <h3 class="section-title">
-              <mat-icon>style</mat-icon>
-              Visual Style
-            </h3>
+      <!-- Visual Style -->
+      @if (mission?.visual_style || mission?.interface_density) {
+        <section class="preview-section" [@sectionEnter]>
+          <div class="section-header">
+            <div class="section-icon style-icon">
+              <mat-icon>dashboard_customize</mat-icon>
+            </div>
+            <h3 class="section-label">Visual Style</h3>
+          </div>
+          <div class="foundation-grid">
             @if (mission!.visual_style) {
-              <div class="foundation-item">
-                <span class="label">Style</span>
-                <span class="value">{{ mission!.visual_style }}</span>
+              <div class="foundation-card">
+                <span class="field-label">Style</span>
+                <span class="field-value">{{ mission!.visual_style }}</span>
               </div>
             }
             @if (mission!.interface_density) {
-              <div class="foundation-item">
-                <span class="label">Layout</span>
-                <span class="value">{{ mission!.interface_density }}</span>
+              <div class="foundation-card">
+                <span class="field-label">Layout density</span>
+                <span class="field-value">{{ mission!.interface_density }}</span>
               </div>
             }
-          </section>
-        }
-
-        <!-- Typography -->
-        @if (mission?.typography_preference) {
-          <section class="preview-section">
-            <h3 class="section-title">
-              <mat-icon>text_fields</mat-icon>
-              Typography
-            </h3>
-            <p class="voice-description">{{ mission!.typography_preference }}</p>
-          </section>
-        }
-      </div>
-    } @else {
-      <!-- Full output tabs — shown after orchestrator run -->
-      <mat-tab-group class="preview-tabs" animationDuration="200ms">
-        <mat-tab label="Summary">
-          <div class="tab-content">
-            <p class="mission-summary">{{ latestOutput!.mission_summary }}</p>
           </div>
-        </mat-tab>
-        <mat-tab label="Codification">
-          @if (latestOutput?.codification; as cod) {
-            <div class="tab-content">
-              <h4>Positioning</h4>
-              <p>{{ cod.positioning_statement }}</p>
-              <h4>Brand promise</h4>
-              <p>{{ cod.brand_promise }}</p>
-              <h4>Narrative pillars</h4>
-              <ul>
+        </section>
+      }
+
+      <!-- Typography -->
+      @if (mission?.typography_preference) {
+        <section class="preview-section" [@sectionEnter]>
+          <div class="section-header">
+            <div class="section-icon type-icon">
+              <mat-icon>format_size</mat-icon>
+            </div>
+            <h3 class="section-label">Typography</h3>
+          </div>
+          <div class="voice-card">
+            <p class="voice-text">{{ mission!.typography_preference }}</p>
+          </div>
+        </section>
+      }
+    </div>
+  } @else {
+    <!-- Full Output — Tabbed View -->
+    <mat-tab-group class="output-tabs" animationDuration="200ms">
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon>summarize</mat-icon>
+          <span>Summary</span>
+        </ng-template>
+        <div class="tab-body">
+          <p class="summary-text">{{ latestOutput!.mission_summary }}</p>
+        </div>
+      </mat-tab>
+
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon>hub</mat-icon>
+          <span>Codification</span>
+        </ng-template>
+        @if (latestOutput?.codification; as cod) {
+          <div class="tab-body">
+            <div class="output-block">
+              <h4 class="block-title">Positioning</h4>
+              <p class="block-text">{{ cod.positioning_statement }}</p>
+            </div>
+            <div class="output-block">
+              <h4 class="block-title">Brand promise</h4>
+              <p class="block-text">{{ cod.brand_promise }}</p>
+            </div>
+            <div class="output-block">
+              <h4 class="block-title">Narrative pillars</h4>
+              <ul class="block-list">
                 @for (p of cod.narrative_pillars; track p) {
                   <li>{{ p }}</li>
                 }
               </ul>
             </div>
-          }
-        </mat-tab>
-        <mat-tab label="Mood boards">
-          <div class="tab-content">
-            @if (latestOutput?.mood_boards?.length) {
-              @for (mb of latestOutput!.mood_boards!; track mb.title) {
-                <mat-expansion-panel class="mood-card">
-                  <mat-expansion-panel-header>
-                    <mat-panel-title>{{ mb.title }}</mat-panel-title>
-                  </mat-expansion-panel-header>
-                  <p><strong>Visual direction:</strong> {{ mb.visual_direction }}</p>
-                  @if (mb.color_story.length) {
-                    <p><strong>Color story:</strong> {{ mb.color_story.join(', ') }}</p>
-                  }
-                  <p><strong>Typography:</strong> {{ mb.typography_direction }}</p>
-                  @if (mb.image_style.length) {
-                    <p><strong>Image style:</strong> {{ mb.image_style.join(', ') }}</p>
-                  }
-                </mat-expansion-panel>
-              }
-            } @else {
-              <p>No mood boards yet.</p>
-            }
           </div>
-        </mat-tab>
-        <mat-tab label="Color palette">
-          <div class="tab-content">
-            @if (selectedPalette) {
-              <div class="palette-card palette-selected" style="margin-bottom: 1rem;">
-                <div class="palette-header">
-                  <span class="palette-name">{{ selectedPalette.name }}</span>
-                  <mat-icon class="selected-icon">check_circle</mat-icon>
-                </div>
-                <div class="palette-swatches">
-                  @for (color of selectedPalette.colors; track color) {
-                    <div class="palette-swatch" [style.background]="parseColor(color)" [title]="color">
-                      <span class="swatch-label">{{ color }}</span>
+        }
+      </mat-tab>
+
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon>dashboard</mat-icon>
+          <span>Moodboards</span>
+        </ng-template>
+        <div class="tab-body">
+          @if (latestOutput?.mood_boards?.length) {
+            <div class="moodboard-grid">
+              @for (mb of latestOutput!.mood_boards!; track mb.title) {
+                <div class="moodboard-card">
+                  <h4 class="moodboard-title">{{ mb.title }}</h4>
+                  <div class="moodboard-detail">
+                    <span class="detail-label">Visual direction</span>
+                    <p>{{ mb.visual_direction }}</p>
+                  </div>
+                  @if (mb.color_story.length) {
+                    <div class="moodboard-colors">
+                      @for (c of mb.color_story; track c) {
+                        <div class="mini-swatch" [style.background]="parseColor(c)" [title]="c"></div>
+                      }
+                    </div>
+                  }
+                  <div class="moodboard-detail">
+                    <span class="detail-label">Typography</span>
+                    <p>{{ mb.typography_direction }}</p>
+                  </div>
+                  @if (mb.image_style.length) {
+                    <div class="moodboard-detail">
+                      <span class="detail-label">Image style</span>
+                      <div class="tag-row compact">
+                        @for (s of mb.image_style; track s) {
+                          <span class="tag tag-muted">{{ s }}</span>
+                        }
+                      </div>
                     </div>
                   }
                 </div>
-                @if (selectedPalette.sentiment) {
-                  <p class="palette-sentiment">{{ selectedPalette.sentiment }}</p>
+              }
+            </div>
+          } @else {
+            <div class="empty-tab">
+              <mat-icon>dashboard</mat-icon>
+              <p>Moodboards will appear after the branding team runs.</p>
+            </div>
+          }
+        </div>
+      </mat-tab>
+
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon>palette</mat-icon>
+          <span>Colors</span>
+        </ng-template>
+        <div class="tab-body">
+          @if (selectedPalette) {
+            <div class="palette-card palette-selected featured">
+              <div class="palette-top">
+                <span class="palette-name">{{ selectedPalette.name }}</span>
+                <span class="selected-badge">
+                  <mat-icon>check</mat-icon>
+                  Active
+                </span>
+              </div>
+              <div class="swatch-strip large">
+                @for (color of selectedPalette.colors; track color) {
+                  <div class="swatch-block" [style.background]="parseColor(color)" [title]="color">
+                    <span class="swatch-hex">{{ color }}</span>
+                  </div>
                 }
               </div>
-            }
-            @if (colorStories.length) {
-              <div class="color-swatches">
-                @for (c of colorStories; track c) {
-                  <div class="swatch" [style.background]="parseColor(c)" [title]="c">{{ c }}</div>
-                }
-              </div>
-            } @else if (!selectedPalette) {
-              <p>Colors will appear from mood boards and design system.</p>
-            }
-          </div>
-        </mat-tab>
-        <mat-tab label="Writing guidelines">
-          @if (latestOutput?.writing_guidelines; as wg) {
-            <div class="tab-content">
-              <h4>Voice principles</h4>
-              <ul>
+              @if (selectedPalette.sentiment) {
+                <p class="palette-mood">{{ selectedPalette.sentiment }}</p>
+              }
+            </div>
+          }
+          @if (colorStories.length) {
+            <h4 class="block-title">Color stories</h4>
+            <div class="color-story-strip">
+              @for (c of colorStories; track c) {
+                <div class="story-swatch" [style.background]="parseColor(c)" [title]="c"></div>
+              }
+            </div>
+          } @else if (!selectedPalette) {
+            <div class="empty-tab">
+              <mat-icon>palette</mat-icon>
+              <p>Colors will emerge from moodboards and the design system.</p>
+            </div>
+          }
+        </div>
+      </mat-tab>
+
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon>edit_note</mat-icon>
+          <span>Writing</span>
+        </ng-template>
+        @if (latestOutput?.writing_guidelines; as wg) {
+          <div class="tab-body">
+            <div class="output-block">
+              <h4 class="block-title">Voice principles</h4>
+              <ul class="block-list">
                 @for (v of wg.voice_principles; track v) {
                   <li>{{ v }}</li>
                 }
               </ul>
-              <h4>Do</h4>
-              <ul>
-                @for (d of wg.style_dos; track d) {
-                  <li>{{ d }}</li>
-                }
-              </ul>
-              <h4>Don't</h4>
-              <ul>
-                @for (d of wg.style_donts; track d) {
-                  <li>{{ d }}</li>
+            </div>
+            <div class="do-dont-grid">
+              <div class="output-block do-block">
+                <h4 class="block-title do-title">
+                  <mat-icon>check_circle</mat-icon>
+                  Do
+                </h4>
+                <ul class="block-list">
+                  @for (d of wg.style_dos; track d) {
+                    <li>{{ d }}</li>
+                  }
+                </ul>
+              </div>
+              <div class="output-block dont-block">
+                <h4 class="block-title dont-title">
+                  <mat-icon>cancel</mat-icon>
+                  Don't
+                </h4>
+                <ul class="block-list">
+                  @for (d of wg.style_donts; track d) {
+                    <li>{{ d }}</li>
+                  }
+                </ul>
+              </div>
+            </div>
+          </div>
+        }
+      </mat-tab>
+
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon>design_services</mat-icon>
+          <span>Design</span>
+        </ng-template>
+        @if (latestOutput?.design_system; as ds) {
+          <div class="tab-body">
+            <div class="output-block">
+              <h4 class="block-title">Design principles</h4>
+              <ul class="block-list">
+                @for (p of ds.design_principles; track p) {
+                  <li>{{ p }}</li>
                 }
               </ul>
             </div>
-          }
-        </mat-tab>
-        <mat-tab label="Design system">
-          @if (latestOutput?.design_system; as ds) {
-            <div class="tab-content">
-            <h4>Design principles</h4>
-            <ul>
-              @for (p of ds.design_principles; track p) {
-                <li>{{ p }}</li>
-              }
-            </ul>
-            <h4>Foundation tokens</h4>
-            <ul>
-              @for (t of ds.foundation_tokens; track t) {
-                <li>{{ t }}</li>
-              }
-            </ul>
-            <h4>Component standards</h4>
-            <ul>
-              @for (c of ds.component_standards; track c) {
-                <li>{{ c }}</li>
-              }
-            </ul>
+            <div class="output-block">
+              <h4 class="block-title">Foundation tokens</h4>
+              <ul class="block-list">
+                @for (t of ds.foundation_tokens; track t) {
+                  <li>{{ t }}</li>
+                }
+              </ul>
             </div>
-          }
-        </mat-tab>
-        <mat-tab label="Brand guidelines">
-          <div class="tab-content">
-            <ul class="guidelines-list">
-              @for (g of latestOutput?.brand_guidelines ?? []; track g) {
+            <div class="output-block">
+              <h4 class="block-title">Component standards</h4>
+              <ul class="block-list">
+                @for (c of ds.component_standards; track c) {
+                  <li>{{ c }}</li>
+                }
+              </ul>
+            </div>
+          </div>
+        }
+      </mat-tab>
+
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon>menu_book</mat-icon>
+          <span>Guidelines</span>
+        </ng-template>
+        <div class="tab-body">
+          @if (latestOutput?.brand_guidelines?.length) {
+            <ul class="block-list">
+              @for (g of latestOutput!.brand_guidelines; track g) {
                 <li>{{ g }}</li>
               }
             </ul>
-          </div>
-        </mat-tab>
-        <mat-tab label="Brand book">
-          @if (latestOutput?.brand_book?.content; as content) {
-            <div class="tab-content">
-              <div class="brand-book-content">{{ content }}</div>
-            </div>
           } @else {
-            <div class="tab-content"><p>No brand book content yet.</p></div>
+            <div class="empty-tab">
+              <mat-icon>menu_book</mat-icon>
+              <p>Brand guidelines will appear after orchestration.</p>
+            </div>
           }
-        </mat-tab>
-      </mat-tab-group>
-    }
-  </mat-card-content>
-</mat-card>
+        </div>
+      </mat-tab>
+
+      <mat-tab>
+        <ng-template mat-tab-label>
+          <mat-icon>auto_stories</mat-icon>
+          <span>Brand Book</span>
+        </ng-template>
+        @if (latestOutput?.brand_book?.content; as content) {
+          <div class="tab-body">
+            <div class="brand-book-prose">{{ content }}</div>
+          </div>
+        } @else {
+          <div class="tab-body">
+            <div class="empty-tab">
+              <mat-icon>auto_stories</mat-icon>
+              <p>No brand book content yet.</p>
+            </div>
+          </div>
+        }
+      </mat-tab>
+    </mat-tab-group>
+  }
+</div>

--- a/user-interface/src/app/components/brand-preview/brand-preview.component.scss
+++ b/user-interface/src/app/components/brand-preview/brand-preview.component.scss
@@ -1,279 +1,923 @@
-.preview-card {
-  background: #161b22;
-  border: 1px solid rgba(255, 255, 255, 0.08);
+// ---------------------------------------------------------------------------
+// Brand Preview Panel — Premium SaaS Design
+// ---------------------------------------------------------------------------
+
+$surface-base: #0c0f14;
+$surface-raised: #12161e;
+$surface-card: #181d27;
+$border-subtle: rgba(255, 255, 255, 0.06);
+$border-default: rgba(255, 255, 255, 0.1);
+$text-primary: #f0f3f8;
+$text-secondary: #8b95a5;
+$text-muted: #5c6678;
+$accent-blue: #6c8cff;
+$accent-purple: #a78bfa;
+$accent-teal: #2dd4bf;
+$accent-green: #34d399;
+$accent-amber: #fbbf24;
+$accent-rose: #fb7185;
+$radius-sm: 8px;
+$radius-md: 12px;
+$radius-lg: 16px;
+
+// ---------------------------------------------------------------------------
+// Panel container
+// ---------------------------------------------------------------------------
+
+.preview-panel {
+  background: $surface-base;
+  border: 1px solid $border-subtle;
+  border-radius: $radius-lg;
   height: 100%;
   min-height: 400px;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
+  position: relative;
 
-  mat-card-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    flex-wrap: wrap;
-    gap: 8px;
-
-    .save-btn {
-      margin-left: auto;
-    }
+  &.has-content {
+    border-color: $border-default;
   }
 
-  mat-card-content {
-    flex: 1;
-    overflow: auto;
-  }
-}
-
-.empty-state {
-  text-align: center;
-  padding: 2rem 1rem;
-  color: #8b949e;
-
-  mat-icon {
-    font-size: 48px;
-    width: 48px;
-    height: 48px;
-    margin-bottom: 1rem;
-    opacity: 0.6;
-  }
-
-  p {
-    margin: 0 0 0.5rem;
-    font-size: 1rem;
-  }
-
-  .empty-hint {
-    font-size: 0.875rem;
-    max-width: 280px;
-    margin-left: auto;
-    margin-right: auto;
+  // Ambient glow at top
+  &::before {
+    content: '';
+    position: absolute;
+    top: -1px;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 60%;
+    height: 1px;
+    background: linear-gradient(90deg, transparent, $accent-blue, transparent);
+    opacity: 0.5;
+    z-index: 1;
   }
 }
 
 // ---------------------------------------------------------------------------
-// Live preview — mission-driven sections shown during conversation
+// Header
 // ---------------------------------------------------------------------------
 
-.live-preview {
-  padding: 0.5rem 0;
-}
-
-.preview-section {
-  margin-bottom: 1.25rem;
-  padding-bottom: 1rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
-
-  &:last-child {
-    border-bottom: none;
-    margin-bottom: 0;
-  }
-}
-
-.section-title {
+.panel-header {
   display: flex;
   align-items: center;
-  gap: 8px;
-  font-size: 0.8125rem;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid $border-subtle;
+  flex-shrink: 0;
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.header-icon {
+  width: 36px;
+  height: 36px;
+  border-radius: 10px;
+  background: linear-gradient(135deg, rgba($accent-blue, 0.15), rgba($accent-purple, 0.15));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  mat-icon {
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+    background: linear-gradient(135deg, $accent-blue, $accent-purple);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+  }
+}
+
+.panel-title {
+  font-size: 0.9375rem;
   font-weight: 600;
-  color: #8b949e;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
-  margin: 0 0 0.75rem;
+  color: $text-primary;
+  margin: 0;
+  letter-spacing: -0.01em;
+}
+
+.panel-subtitle {
+  font-size: 0.75rem;
+  color: $text-muted;
+  transition: color 0.3s;
+
+  &.active {
+    color: $accent-teal;
+  }
+}
+
+.save-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 16px;
+  border-radius: $radius-sm;
+  border: 1px solid rgba($accent-blue, 0.3);
+  background: rgba($accent-blue, 0.08);
+  color: $accent-blue;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
 
   mat-icon {
     font-size: 18px;
     width: 18px;
     height: 18px;
-    color: #58a6ff;
+  }
+
+  &:hover {
+    background: rgba($accent-blue, 0.16);
+    border-color: rgba($accent-blue, 0.5);
+    box-shadow: 0 0 16px rgba($accent-blue, 0.15);
   }
 }
 
-.foundation-item {
-  display: flex;
-  gap: 12px;
-  margin-bottom: 0.5rem;
-  font-size: 0.875rem;
-  line-height: 1.5;
+// ---------------------------------------------------------------------------
+// Progress bar
+// ---------------------------------------------------------------------------
 
-  .label {
-    color: #8b949e;
-    min-width: 80px;
+.progress-track {
+  height: 2px;
+  background: $border-subtle;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+
+.progress-bar {
+  height: 100%;
+  background: linear-gradient(90deg, $accent-blue, $accent-purple);
+  border-radius: 1px;
+  transition: width 0.6s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.progress-label {
+  padding: 6px 20px 0;
+  font-size: 0.6875rem;
+  color: $text-muted;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+.empty-state {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2.5rem 1.5rem;
+  text-align: center;
+}
+
+.empty-visual {
+  position: relative;
+  width: 80px;
+  height: 80px;
+  margin-bottom: 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.empty-icon {
+  font-size: 36px;
+  width: 36px;
+  height: 36px;
+  z-index: 1;
+  background: linear-gradient(135deg, $accent-blue, $accent-purple);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+}
+
+.orb {
+  position: absolute;
+  border-radius: 50%;
+  animation: float 6s ease-in-out infinite;
+
+  &.orb-1 {
+    width: 60px;
+    height: 60px;
+    background: radial-gradient(circle, rgba($accent-blue, 0.15) 0%, transparent 70%);
+    top: -5px;
+    left: -5px;
+    animation-delay: 0s;
+  }
+
+  &.orb-2 {
+    width: 50px;
+    height: 50px;
+    background: radial-gradient(circle, rgba($accent-purple, 0.12) 0%, transparent 70%);
+    bottom: -10px;
+    right: -10px;
+    animation-delay: -2s;
+  }
+
+  &.orb-3 {
+    width: 40px;
+    height: 40px;
+    background: radial-gradient(circle, rgba($accent-teal, 0.1) 0%, transparent 70%);
+    top: 5px;
+    right: 0;
+    animation-delay: -4s;
+  }
+}
+
+@keyframes float {
+  0%, 100% { transform: translateY(0) scale(1); }
+  50% { transform: translateY(-8px) scale(1.05); }
+}
+
+.empty-title {
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: $text-primary;
+  margin: 0 0 0.5rem;
+  letter-spacing: -0.01em;
+}
+
+.empty-description {
+  font-size: 0.875rem;
+  color: $text-secondary;
+  line-height: 1.6;
+  max-width: 300px;
+  margin: 0 0 1.5rem;
+}
+
+.empty-hints {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  max-width: 220px;
+}
+
+.hint-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 14px;
+  border-radius: $radius-sm;
+  background: $surface-raised;
+  border: 1px solid $border-subtle;
+  font-size: 0.8125rem;
+  color: $text-secondary;
+  transition: all 0.2s;
+
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    color: $accent-blue;
     flex-shrink: 0;
   }
 
-  .value {
-    color: #f0f6fc;
+  &:hover {
+    border-color: $border-default;
+    color: $text-primary;
   }
 }
 
-.chip-group {
-  margin-bottom: 0.75rem;
+// ---------------------------------------------------------------------------
+// Live preview
+// ---------------------------------------------------------------------------
 
-  .chip-label {
-    display: block;
-    font-size: 0.75rem;
-    color: #8b949e;
-    margin-bottom: 6px;
+.live-preview {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 20px;
+
+  &::-webkit-scrollbar {
+    width: 4px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.08);
+    border-radius: 2px;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.14);
+    }
   }
 }
 
-.voice-description {
+.preview-section {
+  margin-bottom: 20px;
+  padding-bottom: 20px;
+  border-bottom: 1px solid $border-subtle;
+
+  &:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+    padding-bottom: 0;
+  }
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.section-icon {
+  width: 28px;
+  height: 28px;
+  border-radius: 7px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
+
+  &.foundation-icon {
+    background: rgba($accent-blue, 0.12);
+    mat-icon { color: $accent-blue; }
+  }
+  &.values-icon {
+    background: rgba($accent-purple, 0.12);
+    mat-icon { color: $accent-purple; }
+  }
+  &.voice-icon {
+    background: rgba($accent-teal, 0.12);
+    mat-icon { color: $accent-teal; }
+  }
+  &.color-icon {
+    background: rgba($accent-amber, 0.12);
+    mat-icon { color: $accent-amber; }
+  }
+  &.palette-icon {
+    background: rgba($accent-rose, 0.12);
+    mat-icon { color: $accent-rose; }
+  }
+  &.style-icon {
+    background: rgba($accent-green, 0.12);
+    mat-icon { color: $accent-green; }
+  }
+  &.type-icon {
+    background: rgba($accent-blue, 0.12);
+    mat-icon { color: $accent-blue; }
+  }
+}
+
+.section-label {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: $text-secondary;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0;
+}
+
+// Foundation cards
+.foundation-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 8px;
+}
+
+.foundation-card {
+  background: $surface-raised;
+  border: 1px solid $border-subtle;
+  border-radius: $radius-sm;
+  padding: 10px 14px;
+  transition: border-color 0.2s;
+
+  &:hover {
+    border-color: $border-default;
+  }
+
+  &.full-width {
+    grid-column: 1 / -1;
+  }
+}
+
+.field-label {
+  display: block;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: $text-muted;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 4px;
+}
+
+.field-value {
+  display: block;
+  font-size: 0.8125rem;
+  color: $text-primary;
+  line-height: 1.5;
+}
+
+// Tags
+.tag-group {
+  margin-bottom: 10px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.tag-group-label {
+  display: block;
+  font-size: 0.6875rem;
+  color: $text-muted;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 6px;
+}
+
+.tag-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+
+  &.compact {
+    gap: 4px;
+  }
+}
+
+.tag {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 20px;
+  font-size: 0.75rem;
+  font-weight: 500;
+  border: 1px solid;
+
+  &.tag-value {
+    background: rgba($accent-purple, 0.08);
+    border-color: rgba($accent-purple, 0.2);
+    color: $accent-purple;
+  }
+
+  &.tag-diff {
+    background: rgba($accent-teal, 0.08);
+    border-color: rgba($accent-teal, 0.2);
+    color: $accent-teal;
+  }
+
+  &.tag-color {
+    background: rgba($accent-amber, 0.08);
+    border-color: rgba($accent-amber, 0.2);
+    color: $accent-amber;
+  }
+
+  &.tag-muted {
+    background: $surface-raised;
+    border-color: $border-default;
+    color: $text-secondary;
+  }
+}
+
+// Voice card
+.voice-card {
+  background: $surface-raised;
+  border: 1px solid $border-subtle;
+  border-radius: $radius-sm;
+  padding: 12px 16px;
+  border-left: 3px solid $accent-teal;
+}
+
+.voice-text {
+  font-size: 0.8125rem;
+  color: $text-primary;
+  line-height: 1.6;
+  margin: 0;
+  font-style: italic;
+}
+
+// ---------------------------------------------------------------------------
+// Palette cards (shared live + output)
+// ---------------------------------------------------------------------------
+
+.palettes-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.palette-card {
+  background: $surface-raised;
+  border: 1px solid $border-subtle;
+  border-radius: $radius-md;
+  padding: 14px;
+  transition: all 0.25s;
+
+  &.palette-selected {
+    border-color: rgba($accent-green, 0.4);
+    background: rgba($accent-green, 0.04);
+  }
+
+  &.featured {
+    margin-bottom: 16px;
+  }
+}
+
+.palette-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.palette-name {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: $text-primary;
+}
+
+.selected-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: $accent-green;
+  background: rgba($accent-green, 0.1);
+  padding: 3px 8px;
+  border-radius: 20px;
+
+  mat-icon {
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
+  }
+}
+
+.palette-description {
+  font-size: 0.75rem;
+  color: $text-secondary;
+  margin: 0 0 10px;
+  line-height: 1.5;
+}
+
+.swatch-strip {
+  display: flex;
+  gap: 4px;
+  border-radius: $radius-sm;
+  overflow: hidden;
+
+  &.large {
+    gap: 6px;
+  }
+}
+
+.swatch-block {
+  flex: 1;
+  height: 44px;
+  border-radius: 6px;
+  position: relative;
+  overflow: hidden;
+  cursor: default;
+  transition: transform 0.15s;
+
+  &:hover {
+    transform: scaleY(1.1);
+
+    .swatch-hex {
+      opacity: 1;
+    }
+  }
+
+  .large & {
+    height: 56px;
+    border-radius: $radius-sm;
+  }
+}
+
+.swatch-hex {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background: rgba(0, 0, 0, 0.6);
+  backdrop-filter: blur(4px);
+  color: #fff;
+  font-size: 0.5625rem;
+  text-align: center;
+  padding: 2px;
+  opacity: 0;
+  transition: opacity 0.15s;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-family: 'SF Mono', 'Fira Code', monospace;
+}
+
+.palette-mood {
+  font-size: 0.6875rem;
+  color: $text-muted;
+  font-style: italic;
+  margin: 8px 0 0;
+}
+
+// ---------------------------------------------------------------------------
+// Output tabs
+// ---------------------------------------------------------------------------
+
+.output-tabs {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+
+  ::ng-deep {
+    .mat-mdc-tab-labels {
+      padding: 0 12px;
+      gap: 2px;
+    }
+
+    .mat-mdc-tab {
+      min-width: 0;
+      padding: 0 10px;
+      height: 40px;
+      font-size: 0.75rem;
+
+      .mdc-tab__text-label {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        letter-spacing: 0;
+      }
+
+      mat-icon {
+        font-size: 16px;
+        width: 16px;
+        height: 16px;
+      }
+    }
+
+    .mat-mdc-tab-body-wrapper {
+      flex: 1;
+      overflow: hidden;
+    }
+
+    .mat-mdc-tab-body-content {
+      overflow-y: auto;
+      &::-webkit-scrollbar {
+        width: 4px;
+      }
+      &::-webkit-scrollbar-thumb {
+        background: rgba(255, 255, 255, 0.08);
+        border-radius: 2px;
+      }
+    }
+  }
+}
+
+.tab-body {
+  padding: 16px 20px;
+}
+
+.summary-text {
+  font-size: 0.9375rem;
+  line-height: 1.7;
+  color: $text-primary;
+  margin: 0;
+}
+
+.output-block {
+  margin-bottom: 20px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.block-title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: $text-secondary;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin: 0 0 8px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.block-text {
+  font-size: 0.8125rem;
+  color: $text-primary;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.block-list {
+  margin: 0;
+  padding-left: 1.125rem;
+  font-size: 0.8125rem;
+  color: $text-primary;
+  line-height: 1.7;
+
+  li {
+    margin-bottom: 4px;
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    &::marker {
+      color: $text-muted;
+    }
+  }
+}
+
+// Do / Don't grid
+.do-dont-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+
+.do-block {
+  background: rgba($accent-green, 0.04);
+  border: 1px solid rgba($accent-green, 0.12);
+  border-radius: $radius-sm;
+  padding: 12px;
+}
+
+.dont-block {
+  background: rgba($accent-rose, 0.04);
+  border: 1px solid rgba($accent-rose, 0.12);
+  border-radius: $radius-sm;
+  padding: 12px;
+}
+
+.do-title {
+  color: $accent-green !important;
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.dont-title {
+  color: $accent-rose !important;
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
+}
+
+// Moodboard grid
+.moodboard-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.moodboard-card {
+  background: $surface-raised;
+  border: 1px solid $border-subtle;
+  border-radius: $radius-md;
+  padding: 16px;
+  transition: border-color 0.2s;
+
+  &:hover {
+    border-color: $border-default;
+  }
+}
+
+.moodboard-title {
   font-size: 0.875rem;
-  color: #f0f6fc;
+  font-weight: 600;
+  color: $text-primary;
+  margin: 0 0 12px;
+}
+
+.moodboard-detail {
+  margin-bottom: 10px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
+.detail-label {
+  display: block;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  color: $text-muted;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-bottom: 4px;
+}
+
+.moodboard-detail p {
+  font-size: 0.8125rem;
+  color: $text-secondary;
   line-height: 1.5;
   margin: 0;
 }
 
-// ---------------------------------------------------------------------------
-// Palette cards — used in both live preview and full output
-// ---------------------------------------------------------------------------
-
-.palette-card {
-  background: #0d1117;
-  border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 8px;
-  padding: 12px;
+.moodboard-colors {
+  display: flex;
+  gap: 4px;
   margin-bottom: 10px;
-  transition: border-color 0.2s;
-
-  &.palette-selected {
-    border-color: #3fb950;
-    background: rgba(63, 185, 80, 0.06);
-  }
 }
 
-.palette-header {
+.mini-swatch {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  border: 1px solid $border-default;
+}
+
+// Color stories
+.color-story-strip {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 6px;
-}
-
-.palette-name {
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: #f0f6fc;
-}
-
-.selected-icon {
-  color: #3fb950;
-  font-size: 20px;
-  width: 20px;
-  height: 20px;
-}
-
-.palette-description {
-  font-size: 0.8125rem;
-  color: #c9d1d9;
-  margin: 0 0 8px;
-}
-
-.palette-swatches {
-  display: flex;
-  gap: 6px;
+  gap: 4px;
   flex-wrap: wrap;
-  margin-bottom: 6px;
 }
 
-.palette-swatch {
-  width: 48px;
-  height: 48px;
-  border-radius: 8px;
-  border: 1px solid rgba(255, 255, 255, 0.15);
-  position: relative;
-  overflow: hidden;
-  cursor: default;
+.story-swatch {
+  width: 36px;
+  height: 36px;
+  border-radius: $radius-sm;
+  border: 1px solid $border-default;
+  transition: transform 0.15s;
 
-  .swatch-label {
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    background: rgba(0, 0, 0, 0.65);
-    color: #fff;
-    font-size: 0.5625rem;
-    text-align: center;
-    padding: 2px 1px;
-    line-height: 1.2;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  &:hover {
+    transform: scale(1.1);
   }
 }
 
-.palette-sentiment {
-  font-size: 0.75rem;
-  color: #8b949e;
-  font-style: italic;
-  margin: 0;
-}
+// Empty tab state
+.empty-tab {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1rem;
+  text-align: center;
+  color: $text-muted;
 
-// ---------------------------------------------------------------------------
-// Full output tabs (existing styles)
-// ---------------------------------------------------------------------------
-
-.preview-tabs {
-  .tab-content {
-    padding: 1rem 0;
-    max-height: 400px;
-    overflow-y: auto;
+  mat-icon {
+    font-size: 32px;
+    width: 32px;
+    height: 32px;
+    margin-bottom: 0.75rem;
+    opacity: 0.4;
   }
 
-  .mission-summary {
-    font-size: 0.9375rem;
-    line-height: 1.5;
-    margin: 0;
-  }
-
-  h4 {
+  p {
     font-size: 0.8125rem;
-    margin: 1rem 0 0.5rem;
-    color: #8b949e;
-  }
-
-  ul {
-    margin: 0 0 0.5rem;
-    padding-left: 1.25rem;
-  }
-
-  .mood-card {
-    margin-bottom: 0.5rem;
-  }
-
-  .color-swatches {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 8px;
-    margin-top: 0.5rem;
-  }
-
-  .swatch {
-    width: 40px;
-    height: 40px;
-    border-radius: 8px;
-    border: 1px solid rgba(255, 255, 255, 0.15);
-    font-size: 0.625rem;
-    overflow: hidden;
-    text-indent: -999px;
-  }
-
-  .guidelines-list {
-    list-style: disc;
-  }
-
-  .brand-book-content {
-    white-space: pre-wrap;
-    font-size: 0.875rem;
-    line-height: 1.5;
+    margin: 0;
+    max-width: 240px;
   }
 }
+
+// Brand book
+.brand-book-prose {
+  white-space: pre-wrap;
+  font-size: 0.8125rem;
+  line-height: 1.7;
+  color: $text-primary;
+}
+
+// ---------------------------------------------------------------------------
+// Responsive
+// ---------------------------------------------------------------------------
 
 @media (max-width: 768px) {
-  .preview-card {
+  .preview-panel {
     min-height: 300px;
   }
 
-  .preview-tabs .tab-content {
-    max-height: 300px;
+  .do-dont-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .panel-header {
+    padding: 12px 16px;
+  }
+
+  .live-preview {
+    padding: 12px 16px;
+  }
+
+  .tab-body {
+    padding: 12px 16px;
   }
 }

--- a/user-interface/src/app/components/brand-preview/brand-preview.component.spec.ts
+++ b/user-interface/src/app/components/brand-preview/brand-preview.component.spec.ts
@@ -1,4 +1,5 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { BrandPreviewComponent } from './brand-preview.component';
 
 describe('BrandPreviewComponent', () => {
@@ -8,6 +9,7 @@ describe('BrandPreviewComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [BrandPreviewComponent],
+      providers: [provideNoopAnimations()],
     }).compileComponents();
 
     fixture = TestBed.createComponent(BrandPreviewComponent);

--- a/user-interface/src/app/components/brand-preview/brand-preview.component.ts
+++ b/user-interface/src/app/components/brand-preview/brand-preview.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
+import { trigger, transition, style, animate } from '@angular/animations';
 import { MatCardModule } from '@angular/material/card';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatExpansionModule } from '@angular/material/expansion';
@@ -20,6 +21,14 @@ import type { BrandingMissionSnapshot, BrandingTeamOutput, ColorPalette } from '
   ],
   templateUrl: './brand-preview.component.html',
   styleUrl: './brand-preview.component.scss',
+  animations: [
+    trigger('sectionEnter', [
+      transition(':enter', [
+        style({ opacity: 0, transform: 'translateY(8px)' }),
+        animate('300ms cubic-bezier(0.23, 1, 0.32, 1)', style({ opacity: 1, transform: 'translateY(0)' })),
+      ]),
+    ]),
+  ],
 })
 export class BrandPreviewComponent {
   @Input() mission: BrandingMissionSnapshot | null = null;
@@ -47,6 +56,23 @@ export class BrandPreviewComponent {
   /** True when there is anything to display (mission or output). */
   get hasContent(): boolean {
     return this.hasOutput || this.hasMissionData;
+  }
+
+  /** Rough percentage of mission fields that have meaningful data. */
+  get completionPercent(): number {
+    const m = this.mission;
+    if (!m) return 0;
+    let filled = 0;
+    const total = 8;
+    if (m.company_name && m.company_name !== 'TBD') filled++;
+    if (m.company_description && m.company_description !== 'To be discussed.') filled++;
+    if (m.target_audience && m.target_audience !== 'TBD') filled++;
+    if ((m.values?.length ?? 0) > 0) filled++;
+    if ((m.differentiators?.length ?? 0) > 0) filled++;
+    if (m.desired_voice && m.desired_voice !== 'clear, confident, human') filled++;
+    if ((m.color_palettes?.length ?? 0) > 0 || (m.color_inspiration?.length ?? 0) > 0) filled++;
+    if (m.visual_style || m.typography_preference) filled++;
+    return Math.round((filled / total) * 100);
   }
 
   get missionValues(): string[] {


### PR DESCRIPTION
Replace the mat-card-based brand preview with a modern, designer-grade
panel featuring glassmorphism-inspired dark surfaces, gradient accent
colors, animated section reveals, a live completion progress bar,
contextual empty state with floating orbs, color-coded section icons,
elevated palette swatches with hover reveals, Do/Don't writing grids,
and moodboard cards — targeting UI designers and startup founders.

https://claude.ai/code/session_01PfJmVHp7f1we4h6GZVgQWC