### PR TITLE
Add LLM-driven paper trading and real-data backtesting agents

### DIFF
--- a/backend/agents/investment_team/api/main.py
+++ b/backend/agents/investment_team/api/main.py
@@ -743,6 +743,8 @@ def _run_real_data_backtest(
 
     Returns (BacktestResult, trade_ledger).
     """
+    # Lazy imports: yfinance is slow to import and the LLM client has side-effects;
+    # deferring keeps application startup fast and avoids loading these until needed.
     from investment_team.backtesting_agent import BacktestingAgent
     from investment_team.market_data_service import MarketDataService
     from llm_service.factory import get_client
@@ -1073,6 +1075,12 @@ class RunPaperTradingRequest(BaseModel):
     slippage_bps: float = Field(default=2.0, ge=0)
     min_trades: int = Field(default=50, ge=10, description="Minimum trades before evaluation")
     lookback_days: int = Field(default=365, ge=30, description="Days of historical data to fetch")
+    max_evaluations: int = Field(
+        default=5000,
+        ge=100,
+        le=50000,
+        description="Cap on LLM evaluations to bound execution time.",
+    )
 
 
 class PaperTradingResponse(BaseModel):
@@ -1145,6 +1153,7 @@ def run_paper_trading(request: RunPaperTradingRequest) -> PaperTradingResponse:
         )
 
     # 3 — Run paper trading session
+    # Lazy imports: yfinance and LLM client are heavy; deferring keeps app startup fast.
     llm = get_client("paper_trading")
     agent = PaperTradingAgent(llm_client=llm)
 
@@ -1168,20 +1177,29 @@ def run_paper_trading(request: RunPaperTradingRequest) -> PaperTradingResponse:
     with _lock:
         _paper_trading_sessions[session.session_id] = session
 
-    # 5 — Build response message
+    # 5 — Build response message (include a warning when min_trades was not reached)
+    trade_count = len(session.trades)
+    shortfall = ""
+    if trade_count < request.min_trades:
+        shortfall = (
+            f" WARNING: Only {trade_count}/{request.min_trades} trades were completed "
+            f"(insufficient data or evaluation budget). Results may be unreliable."
+        )
+
     if session.verdict == PaperTradingVerdict.READY_FOR_LIVE:
         message = (
-            f"Paper trading completed with {len(session.trades)} trades. "
+            f"Paper trading completed with {trade_count} trades. "
             f"Performance aligns with backtest expectations — strategy is READY FOR LIVE TESTING."
+            f"{shortfall}"
         )
     elif session.verdict == PaperTradingVerdict.NOT_PERFORMANT:
         message = (
-            f"Paper trading completed with {len(session.trades)} trades. "
+            f"Paper trading completed with {trade_count} trades. "
             f"Performance does NOT align with backtest expectations — strategy is NOT PERFORMANT "
-            f"with live data. See divergence_analysis for details."
+            f"with live data. See divergence_analysis for details.{shortfall}"
         )
     else:
-        message = f"Paper trading completed with {len(session.trades)} trades."
+        message = f"Paper trading completed with {trade_count} trades.{shortfall}"
 
     return PaperTradingResponse(session=session, message=message)
 

--- a/backend/agents/investment_team/api/main.py
+++ b/backend/agents/investment_team/api/main.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import threading
 import uuid
-from datetime import date, datetime, timedelta, timezone
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from fastapi import FastAPI, HTTPException
@@ -575,40 +574,15 @@ def validate_strategy(
 
 @app.post("/backtests", response_model=RunBacktestResponse)
 def run_backtest(request: RunBacktestRequest) -> RunBacktestResponse:
-    """Run a deterministic backtest simulation and store the result."""
+    """Run a backtest using real historical market data and LLM-driven trade decisions."""
     with _lock:
         strategy = _strategies.get(request.strategy_id)
 
     if not strategy:
         raise HTTPException(status_code=404, detail=f"Strategy {request.strategy_id} not found")
 
-    def _calc(base: float, factor: float, floor: float = 0.0) -> float:
-        value = round(base + factor, 2)
-        return value if value >= floor else floor
+    strategy = StrategySpec(**strategy) if isinstance(strategy, dict) else strategy
 
-    strategy_signal_score = (
-        len(strategy.entry_rules)
-        + len(strategy.exit_rules)
-        + len(strategy.sizing_rules)
-        + (1 if strategy.speculative else 0)
-    )
-    period_span = max(len(request.start_date) + len(request.end_date), 1)
-
-    total_return = _calc(
-        6.0, (strategy_signal_score % 11) * 0.9 - request.transaction_cost_bps * 0.03, -95.0
-    )
-    annualized_return = _calc(4.0, total_return * 0.35 - request.slippage_bps * 0.02, -95.0)
-    volatility = _calc(10.0, (strategy_signal_score % 7) * 1.4 + (period_span % 5) * 0.7, 0.1)
-    sharpe = round(annualized_return / volatility if volatility else 0.0, 2)
-    max_drawdown = _calc(8.0, (strategy_signal_score % 5) * 1.8 + request.slippage_bps * 0.1, 0.0)
-    win_rate = _calc(
-        45.0, (strategy_signal_score % 9) * 2.2 - request.transaction_cost_bps * 0.1, 1.0
-    )
-    profit_factor = round(
-        max(1.01, 1.05 + (strategy_signal_score % 6) * 0.08 - request.slippage_bps * 0.01), 2
-    )
-
-    backtest_id = f"bt-{uuid.uuid4().hex[:8]}"
     config = BacktestConfig(
         start_date=request.start_date,
         end_date=request.end_date,
@@ -618,15 +592,16 @@ def run_backtest(request: RunBacktestRequest) -> RunBacktestResponse:
         transaction_cost_bps=request.transaction_cost_bps,
         slippage_bps=request.slippage_bps,
     )
-    result = BacktestResult(
-        total_return_pct=total_return,
-        annualized_return_pct=annualized_return,
-        volatility_pct=volatility,
-        sharpe_ratio=sharpe,
-        max_drawdown_pct=max_drawdown,
-        win_rate_pct=win_rate,
-        profit_factor=profit_factor,
-    )
+
+    try:
+        result, trades = _run_real_data_backtest(strategy, config)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("Backtest failed for strategy %s: %s", request.strategy_id, exc)
+        raise HTTPException(status_code=500, detail=f"Backtest failed: {exc}") from exc
+
+    backtest_id = f"bt-{uuid.uuid4().hex[:8]}"
     now = _now()
     record = BacktestRecord(
         backtest_id=backtest_id,
@@ -638,6 +613,7 @@ def run_backtest(request: RunBacktestRequest) -> RunBacktestResponse:
         completed_at=now,
         result=result,
         notes=request.notes,
+        trades=trades,
     )
 
     with _lock:
@@ -745,236 +721,48 @@ def create_memo(request: CreateMemoRequest) -> CreateMemoResponse:
 # ---------------------------------------------------------------------------
 
 
-_STOCK_SYMBOLS = ["AAPL", "MSFT", "NVDA", "TSLA", "AMZN", "META", "GOOGL", "JPM", "AMD", "SPY"]
-_CRYPTO_SYMBOLS = ["BTC", "ETH", "SOL", "BNB", "XRP", "MATIC", "AVAX", "LINK", "ADA", "DOT"]
-_OTHER_SYMBOLS = ["GLD", "USO", "TLT", "VIX", "QQQ", "IWM", "EEM", "GDX", "XLE", "XLF"]
-
-_SYMBOL_BASE_PRICES = {
-    "AAPL": 170,
-    "MSFT": 380,
-    "NVDA": 490,
-    "TSLA": 240,
-    "AMZN": 180,
-    "META": 490,
-    "GOOGL": 170,
-    "JPM": 190,
-    "AMD": 170,
-    "SPY": 480,
-    "BTC": 42000,
-    "ETH": 2500,
-    "SOL": 105,
-    "BNB": 380,
-    "XRP": 0.60,
-    "MATIC": 0.90,
-    "AVAX": 38,
-    "LINK": 18,
-    "ADA": 0.55,
-    "DOT": 8,
-    "GLD": 190,
-    "USO": 75,
-    "TLT": 95,
-    "VIX": 18,
-    "QQQ": 425,
-    "IWM": 200,
-    "EEM": 40,
-    "GDX": 29,
-    "XLE": 92,
-    "XLF": 40,
-}
-
-
-def _lcg(seed: int) -> int:
-    """One step of a linear congruential generator — fast deterministic pseudo-random."""
-    return (seed * 1664525 + 1013904223) & 0xFFFFFFFF
-
-
-def _generate_trade_ledger(
-    strategy: StrategySpec,
-    config: BacktestConfig,
-    result: BacktestResult,
-) -> List[TradeRecord]:
-    """
-    Generate a deterministic per-trade ledger consistent with the summary BacktestResult.
-
-    All values are derived from the strategy hash, so the same strategy always
-    produces the same trade list.  No randomness — fully reproducible.
-    """
-    strat_hash = int(
-        hashlib.md5((strategy.hypothesis + strategy.signal_definition).encode()).hexdigest()[:8],
-        16,
-    )
-
-    # Symbol universe based on asset class
-    asset = strategy.asset_class.lower()
-    if asset == "crypto":
-        symbols = _CRYPTO_SYMBOLS
-    elif asset in ("stocks", "equities"):
-        symbols = _STOCK_SYMBOLS
-    else:
-        symbols = _OTHER_SYMBOLS
-
-    # Date range
-    try:
-        start_dt = date.fromisoformat(config.start_date)
-        end_dt = date.fromisoformat(config.end_date)
-    except ValueError:
-        start_dt = date(2021, 1, 1)
-        end_dt = date(2024, 12, 31)
-
-    total_days = max((end_dt - start_dt).days, 1)
-
-    # Trade count: ~50-80 trades/year for swing trading
-    trades_per_year = 50 + (strat_hash % 31)  # 50-80
-    num_trades = max(10, min(200, int(total_days / 365.25 * trades_per_year)))
-
-    # Position size: 5-10% of capital per trade
-    position_pct = 0.05 + (strat_hash % 6) * 0.01  # 5-10%
-    position_value_base = config.initial_capital * position_pct
-    cost_pct = (config.transaction_cost_bps + config.slippage_bps) / 10000.0
-
-    win_rate_dec = result.win_rate_pct / 100.0
-    # Derive average win/loss magnitudes that are consistent with profit_factor & win_rate
-    # profit_factor = (avg_win × win_rate) / (avg_loss × loss_rate)
-    loss_rate = 1.0 - win_rate_dec
-    avg_loss_pct = 1.8 + (strat_hash % 15) * 0.12  # 1.8% to 3.5%
-    if loss_rate > 0:
-        avg_win_pct = result.profit_factor * avg_loss_pct * loss_rate / win_rate_dec
-    else:
-        avg_win_pct = avg_loss_pct * result.profit_factor
-
-    trades: List[TradeRecord] = []
-    cumulative_pnl = 0.0
-    seed = strat_hash
-
-    for i in range(num_trades):
-        seed = _lcg(seed)
-        s2 = _lcg(seed)
-        s3 = _lcg(s2)
-        s4 = _lcg(s3)
-
-        # Entry date — evenly spaced with small jitter
-        base_offset = int(total_days * i / num_trades)
-        jitter = (seed % 5) - 2  # -2 to +2 days
-        entry_offset = max(0, min(total_days - 2, base_offset + jitter))
-        entry_dt = start_dt + timedelta(days=entry_offset)
-
-        # Hold period: 2–13 days
-        hold_days = 2 + (s2 % 12)
-        exit_dt = entry_dt + timedelta(days=hold_days)
-        if exit_dt >= end_dt:
-            exit_dt = end_dt - timedelta(days=1)
-            hold_days = max(1, (exit_dt - entry_dt).days)
-
-        # Symbol selection
-        symbol = symbols[s3 % len(symbols)]
-        base_price = _SYMBOL_BASE_PRICES.get(symbol, 100.0)
-
-        # Entry price: small variation around base (±15%)
-        price_jitter = (s4 % 301 - 150) / 1000.0  # -15% to +15%
-        entry_price = round(base_price * (1.0 + price_jitter), 2 if base_price >= 1 else 6)
-
-        # Win or loss — use modular position within win-rate bands
-        is_win = (seed % 100) < result.win_rate_pct
-
-        # Return magnitude for this trade (varies around average ±40%)
-        mag_var = 1.0 + ((s2 % 81 - 40) / 100.0)  # 0.6× to 1.4× the average
-        if is_win:
-            trade_return_pct = round(avg_win_pct * mag_var, 3)
-        else:
-            trade_return_pct = round(-avg_loss_pct * mag_var, 3)
-
-        exit_price = round(
-            entry_price * (1.0 + trade_return_pct / 100.0), 2 if base_price >= 1 else 6
-        )
-        shares = round(position_value_base / entry_price, 4 if base_price < 10 else 2)
-        position_value = round(entry_price * shares, 2)
-        gross_pnl = round(shares * (exit_price - entry_price), 2)
-        transaction_cost = round(position_value * cost_pct * 2, 2)  # entry + exit
-        net_pnl = round(gross_pnl - transaction_cost, 2)
-        cumulative_pnl = round(cumulative_pnl + net_pnl, 2)
-
-        trades.append(
-            TradeRecord(
-                trade_num=i + 1,
-                entry_date=entry_dt.isoformat(),
-                exit_date=exit_dt.isoformat(),
-                symbol=symbol,
-                side="long",
-                entry_price=entry_price,
-                exit_price=exit_price,
-                shares=shares,
-                position_value=position_value,
-                gross_pnl=gross_pnl,
-                net_pnl=net_pnl,
-                return_pct=trade_return_pct,
-                hold_days=hold_days,
-                outcome="win" if is_win else "loss",
-                cumulative_pnl=cumulative_pnl,
-            )
-        )
-
-    return trades
-
-
-def _strategy_lab_backtest(
+def _run_real_data_backtest(
     strategy: StrategySpec,
     config: BacktestConfig,
 ) -> tuple[BacktestResult, List[TradeRecord]]:
     """
-    Content-aware deterministic backtest for the strategy lab.
+    Run a backtest using real historical market data and LLM-driven trade decisions.
 
-    Returns (BacktestResult, trade_ledger).  Uses a hash of
-    (hypothesis + signal_definition) for reproducible variance across strategies.
+    Fetches OHLCV data from Yahoo Finance (stocks/ETFs) or CoinGecko (crypto)
+    for the backtest period, then walks through bars chronologically with the LLM
+    interpreting the strategy's entry/exit rules to decide trades.
+
+    Returns (BacktestResult, trade_ledger).
     """
-    strat_hash = int(
-        hashlib.md5((strategy.hypothesis + strategy.signal_definition).encode()).hexdigest()[:8],
-        16,
+    from investment_team.backtesting_agent import BacktestingAgent
+    from investment_team.market_data_service import MarketDataService
+    from llm_service.factory import get_client
+
+    market_service = MarketDataService()
+    symbols = market_service.get_symbols_for_strategy(strategy)
+    # Use top 5 symbols to keep data fetching reasonable
+    symbols = symbols[:5]
+
+    logger.info(
+        "Fetching historical data for %s backtest (%s to %s, %d symbols)...",
+        strategy.asset_class,
+        config.start_date,
+        config.end_date,
+        len(symbols),
+    )
+    market_data = market_service.fetch_multi_symbol_range(
+        symbols, strategy.asset_class, config.start_date, config.end_date
     )
 
-    signal_score = (
-        len(strategy.entry_rules)
-        + len(strategy.exit_rules)
-        + len(strategy.sizing_rules)
-        + (1 if strategy.speculative else 0)
-    )
+    if not market_data:
+        raise HTTPException(
+            status_code=502,
+            detail="Failed to fetch historical market data. Please check the date range and try again.",
+        )
 
-    asset_class_base = {
-        "crypto": 5.5,
-        "stocks": 3.5,
-        "options": 4.5,
-        "forex": 2.5,
-        "commodities": 2.0,
-    }.get(strategy.asset_class.lower(), 3.5)
-
-    # hash_factor in range -8.0 to +12.0 (asymmetric — harder to win)
-    hash_factor = (strat_hash % 201 - 80) / 10.0
-    rule_bonus = (signal_score % 6) * 0.7  # 0 to 3.5
-
-    annualized_return = round(
-        asset_class_base + hash_factor + rule_bonus - config.slippage_bps * 0.02,
-        2,
-    )
-    total_return = round(annualized_return * 2.5, 2)
-    volatility = round(12.0 + (strat_hash % 15) * 0.8, 2)
-    sharpe = round(annualized_return / volatility if volatility > 0 else 0.0, 2)
-    max_drawdown = round(10.0 + (strat_hash % 20) * 0.9, 2)
-    win_rate = round(
-        max(20.0, 48.0 + (strat_hash % 25) * 0.6 - config.transaction_cost_bps * 0.1),
-        2,
-    )
-    profit_factor = round(max(0.80, 1.0 + annualized_return * 0.05), 2)
-
-    result = BacktestResult(
-        total_return_pct=total_return,
-        annualized_return_pct=annualized_return,
-        volatility_pct=volatility,
-        sharpe_ratio=sharpe,
-        max_drawdown_pct=max_drawdown,
-        win_rate_pct=win_rate,
-        profit_factor=profit_factor,
-    )
-    trades = _generate_trade_ledger(strategy, config, result)
-    return result, trades
+    llm = get_client("backtesting")
+    agent = BacktestingAgent(llm_client=llm)
+    return agent.run_backtest(strategy, config, market_data)
 
 
 class RunStrategyLabRequest(BaseModel):
@@ -1046,7 +834,7 @@ def run_strategy_lab(request: RunStrategyLabRequest) -> StrategyLabRunResponse:
         transaction_cost_bps=request.transaction_cost_bps,
         slippage_bps=request.slippage_bps,
     )
-    result, trades = _strategy_lab_backtest(strategy, config)
+    result, trades = _run_real_data_backtest(strategy, config)
 
     now = _now()
     backtest_id = f"bt-lab-{uuid.uuid4().hex[:8]}"

--- a/backend/agents/investment_team/api/main.py
+++ b/backend/agents/investment_team/api/main.py
@@ -30,6 +30,8 @@ from investment_team.models import (
     InvestmentProfile,
     LiquidityNeeds,
     NetWorth,
+    PaperTradingSession,
+    PaperTradingVerdict,
     PortfolioConstraints,
     PortfolioPosition,
     PortfolioProposal,
@@ -121,6 +123,7 @@ _strategies: _PersistentDict = _PersistentDict("strategies")
 _validations: _PersistentDict = _PersistentDict("validations")
 _backtests: _PersistentDict = _PersistentDict("backtests")
 _strategy_lab_records: _PersistentDict = _PersistentDict("strategy_lab_records")
+_paper_trading_sessions: _PersistentDict = _PersistentDict("paper_trading_sessions")
 _advisor_sessions: _PersistentDict = _PersistentDict("advisor_sessions")
 
 _advisor_agent = FinancialAdvisorAgent()
@@ -1128,6 +1131,176 @@ def get_strategy_lab_results(winning: Optional[bool] = None) -> StrategyLabResul
         winning_count=winning_count,
         losing_count=losing_count,
     )
+
+
+# ---------------------------------------------------------------------------
+# Paper Trading — simulated live trading with real market data
+# ---------------------------------------------------------------------------
+
+
+class RunPaperTradingRequest(BaseModel):
+    """Start a paper trading session for a winning strategy."""
+
+    lab_record_id: str = Field(..., description="ID of a winning StrategyLabRecord to paper trade")
+    initial_capital: float = Field(default=100000.0, gt=0)
+    transaction_cost_bps: float = Field(default=5.0, ge=0)
+    slippage_bps: float = Field(default=2.0, ge=0)
+    min_trades: int = Field(default=50, ge=10, description="Minimum trades before evaluation")
+    lookback_days: int = Field(default=365, ge=30, description="Days of historical data to fetch")
+
+
+class PaperTradingResponse(BaseModel):
+    session: PaperTradingSession
+    message: str = "Paper trading session completed."
+
+
+class PaperTradingResultsResponse(BaseModel):
+    items: List[PaperTradingSession] = Field(default_factory=list)
+    count: int = 0
+    ready_for_live_count: int = 0
+    not_performant_count: int = 0
+
+
+@app.post("/strategy-lab/paper-trade", response_model=PaperTradingResponse)
+def run_paper_trading(request: RunPaperTradingRequest) -> PaperTradingResponse:
+    """
+    Run a paper trading session for a winning strategy using real market data.
+
+    Fetches live price data, uses the LLM to interpret the strategy's entry/exit rules
+    against each bar, simulates trade execution, and compares performance to the backtest.
+    Strategies that align with backtest expectations are flagged as ready for live testing.
+    Underperforming strategies receive a detailed divergence analysis.
+    """
+    from investment_team.market_data_service import MarketDataService
+    from investment_team.paper_trading_agent import PaperTradingAgent
+    from llm_service.factory import get_client
+
+    # 1 — Look up the winning strategy lab record
+    with _lock:
+        raw_record = _strategy_lab_records.get(request.lab_record_id)
+
+    if raw_record is None:
+        raise HTTPException(
+            status_code=404, detail=f"Strategy lab record '{request.lab_record_id}' not found."
+        )
+
+    lab_record = StrategyLabRecord(**raw_record) if isinstance(raw_record, dict) else raw_record
+
+    if not lab_record.is_winning:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Strategy '{request.lab_record_id}' is not a winning strategy. "
+            "Only winning strategies (>8% annualized return) can be paper traded.",
+        )
+
+    strategy = lab_record.strategy
+    backtest_record = lab_record.backtest
+
+    # 2 — Fetch real market data
+    market_service = MarketDataService()
+    symbols = market_service.get_symbols_for_strategy(strategy)
+    # Use a subset of symbols (top 5) to keep data fetching reasonable
+    symbols = symbols[:5]
+
+    logger.info(
+        "Fetching %d days of market data for %d symbols (%s) ...",
+        request.lookback_days,
+        len(symbols),
+        strategy.asset_class,
+    )
+    market_data = market_service.fetch_multi_symbol(
+        symbols, strategy.asset_class, request.lookback_days
+    )
+
+    if not market_data:
+        raise HTTPException(
+            status_code=502,
+            detail="Failed to fetch market data from external sources. Please try again later.",
+        )
+
+    # 3 — Run paper trading session
+    llm = get_client("paper_trading")
+    agent = PaperTradingAgent(llm_client=llm)
+
+    try:
+        session = agent.run_session(
+            strategy=strategy,
+            backtest_record=backtest_record,
+            market_data=market_data,
+            initial_capital=request.initial_capital,
+            transaction_cost_bps=request.transaction_cost_bps,
+            slippage_bps=request.slippage_bps,
+            min_trades=request.min_trades,
+        )
+    except Exception as exc:
+        logger.error("Paper trading session failed: %s", exc)
+        raise HTTPException(status_code=500, detail=f"Paper trading session failed: {exc}") from exc
+
+    session.lab_record_id = request.lab_record_id
+
+    # 4 — Persist the session
+    with _lock:
+        _paper_trading_sessions[session.session_id] = session
+
+    # 5 — Build response message
+    if session.verdict == PaperTradingVerdict.READY_FOR_LIVE:
+        message = (
+            f"Paper trading completed with {len(session.trades)} trades. "
+            f"Performance aligns with backtest expectations — strategy is READY FOR LIVE TESTING."
+        )
+    elif session.verdict == PaperTradingVerdict.NOT_PERFORMANT:
+        message = (
+            f"Paper trading completed with {len(session.trades)} trades. "
+            f"Performance does NOT align with backtest expectations — strategy is NOT PERFORMANT "
+            f"with live data. See divergence_analysis for details."
+        )
+    else:
+        message = f"Paper trading completed with {len(session.trades)} trades."
+
+    return PaperTradingResponse(session=session, message=message)
+
+
+@app.get("/strategy-lab/paper-trade/results", response_model=PaperTradingResultsResponse)
+def get_paper_trading_results(
+    verdict: Optional[str] = None,
+) -> PaperTradingResultsResponse:
+    """
+    Return all paper trading sessions, sorted newest-first.
+    Filter by verdict with ?verdict=ready_for_live or ?verdict=not_performant.
+    """
+    with _lock:
+        raw = list(_paper_trading_sessions.values())
+
+    items = [PaperTradingSession(**r) if isinstance(r, dict) else r for r in raw]
+    items.sort(key=lambda s: s.completed_at or s.started_at, reverse=True)
+
+    ready_count = sum(1 for s in items if s.verdict == PaperTradingVerdict.READY_FOR_LIVE)
+    not_perf_count = sum(1 for s in items if s.verdict == PaperTradingVerdict.NOT_PERFORMANT)
+
+    if verdict is not None:
+        items = [s for s in items if s.verdict and s.verdict.value == verdict]
+
+    return PaperTradingResultsResponse(
+        items=items,
+        count=len(items),
+        ready_for_live_count=ready_count,
+        not_performant_count=not_perf_count,
+    )
+
+
+@app.get("/strategy-lab/paper-trade/{session_id}", response_model=PaperTradingResponse)
+def get_paper_trading_session(session_id: str) -> PaperTradingResponse:
+    """Return a specific paper trading session by ID."""
+    with _lock:
+        raw = _paper_trading_sessions.get(session_id)
+
+    if raw is None:
+        raise HTTPException(
+            status_code=404, detail=f"Paper trading session '{session_id}' not found."
+        )
+
+    session = PaperTradingSession(**raw) if isinstance(raw, dict) else raw
+    return PaperTradingResponse(session=session)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/backtesting_agent.py
+++ b/backend/agents/investment_team/backtesting_agent.py
@@ -1,0 +1,403 @@
+"""
+Backtesting Agent — runs historical backtests using real market data and LLM-driven trade decisions.
+
+Fetches real OHLCV data for the backtest period, walks through bars chronologically,
+uses the LLM to interpret the strategy's entry/exit rules, and simulates trade execution
+with realistic slippage and transaction costs.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any, Dict, List, Optional
+
+from llm_service.interface import LLMClient
+
+from .market_data_service import OHLCVBar
+from .models import (
+    BacktestConfig,
+    BacktestResult,
+    StrategySpec,
+    TradeRecord,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Prompts
+# ---------------------------------------------------------------------------
+
+_EVALUATE_SYSTEM = (
+    "You are an expert quantitative trader backtesting a swing trading strategy against historical data. "
+    "You evaluate daily price bars against the strategy's entry and exit rules to decide whether to trade. "
+    "Be disciplined — only trade when the rules are clearly met by the price data. "
+    "Remember: this is a backtest, so you must only use information available on the current bar's date."
+)
+
+_EVALUATE_PROMPT = """\
+Evaluate whether the trading strategy's rules are triggered for this historical market data.
+
+## Strategy
+Asset class: {asset_class}
+Hypothesis: {hypothesis}
+Signal: {signal_definition}
+Entry rules: {entry_rules}
+Exit rules: {exit_rules}
+Sizing rules: {sizing_rules}
+Risk limits: {risk_limits}
+
+## Current Position
+{position_status}
+
+## Available Capital
+${capital:,.2f}
+
+## Current Bar ({symbol}, {current_date})
+Open: {open}  High: {high}  Low: {low}  Close: {close}  Volume: {volume}
+
+## Recent Price History ({symbol}, last {n_bars} bars)
+{recent_bars_text}
+
+## Instructions
+Based on the strategy rules and market data above, decide your action.
+If you have NO open position, evaluate ENTRY rules. If you HAVE an open position, evaluate EXIT rules.
+Be conservative — only enter when signals are clearly met, and respect risk limits.
+Do NOT use any future information — only data up to and including the current bar.
+
+Return ONLY a JSON object with no markdown:
+{{"action": "enter_long" or "enter_short" or "exit" or "hold", "confidence": 0.0 to 1.0, \
+"shares": number_of_shares_or_0, "reasoning": "brief explanation"}}
+
+For "hold", set shares to 0. For entries, calculate shares based on sizing rules and available capital.
+For exits, set shares to 0 (will close full position).
+"""
+
+
+def _format_bars_table(bars: List[OHLCVBar]) -> str:
+    """Format a list of OHLCV bars as a compact text table."""
+    if not bars:
+        return "No data available."
+    lines = ["Date       | Open     | High     | Low      | Close    | Volume"]
+    for b in bars:
+        lines.append(
+            f"{b.date} | {b.open:<8.2f} | {b.high:<8.2f} | {b.low:<8.2f} | {b.close:<8.2f} | {b.volume:.0f}"
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+
+class BacktestingAgent:
+    """
+    Runs backtests against real historical market data by walking through OHLCV bars
+    chronologically and using the LLM to interpret strategy entry/exit rules.
+    """
+
+    def __init__(self, llm_client: LLMClient) -> None:
+        self.llm = llm_client
+
+    def run_backtest(
+        self,
+        strategy: StrategySpec,
+        config: BacktestConfig,
+        market_data: Dict[str, List[OHLCVBar]],
+    ) -> tuple[BacktestResult, List[TradeRecord]]:
+        """
+        Walk through historical market data bar-by-bar, making LLM-driven trade decisions.
+
+        Returns (BacktestResult, trade_ledger).
+        """
+        capital = config.initial_capital
+        cost_pct = (config.transaction_cost_bps + config.slippage_bps) / 10_000.0
+        slippage_bps = config.slippage_bps
+
+        # Build a unified timeline: merge all symbols' bars sorted by date
+        timeline: List[tuple[str, str, OHLCVBar]] = []
+        for symbol, bars in market_data.items():
+            for bar in bars:
+                timeline.append((bar.date, symbol, bar))
+        timeline.sort(key=lambda x: x[0])
+
+        # Per-symbol bar history for context lookups
+        symbol_history: Dict[str, List[OHLCVBar]] = {sym: [] for sym in market_data}
+
+        open_positions: Dict[str, Dict[str, Any]] = {}
+        trades: List[TradeRecord] = []
+        trade_num = 0
+        cumulative_pnl = 0.0
+
+        for bar_date, symbol, bar in timeline:
+            symbol_history[symbol].append(bar)
+            recent = symbol_history[symbol][-20:]
+            has_position = symbol in open_positions
+
+            # Ask LLM to evaluate this bar
+            try:
+                decision = self._evaluate_bar(
+                    strategy=strategy,
+                    symbol=symbol,
+                    current_bar=bar,
+                    recent_bars=recent,
+                    open_position=open_positions.get(symbol),
+                    capital=capital,
+                )
+            except Exception as exc:
+                logger.warning("LLM evaluation failed for %s on %s: %s", symbol, bar_date, exc)
+                continue
+
+            action = decision.get("action", "hold")
+
+            if action in ("enter_long", "enter_short") and not has_position:
+                shares = float(decision.get("shares", 0))
+                if shares <= 0:
+                    position_pct = 0.06
+                    shares = round(capital * position_pct / bar.close, 4 if bar.close < 10 else 2)
+
+                if shares > 0 and capital >= shares * bar.close:
+                    slippage_mult = 1.0 + slippage_bps / 10_000.0
+                    entry_price = round(bar.close * slippage_mult, 4 if bar.close < 10 else 2)
+                    position_value = round(entry_price * shares, 2)
+                    capital -= position_value
+
+                    open_positions[symbol] = {
+                        "side": "long" if action == "enter_long" else "short",
+                        "entry_date": bar_date,
+                        "entry_price": entry_price,
+                        "shares": shares,
+                        "position_value": position_value,
+                    }
+
+            elif action == "exit" and has_position:
+                pos = open_positions.pop(symbol)
+                trade_num += 1
+
+                slippage_mult = 1.0 - slippage_bps / 10_000.0
+                exit_price = round(bar.close * slippage_mult, 4 if bar.close < 10 else 2)
+
+                gross_pnl = round(pos["shares"] * (exit_price - pos["entry_price"]), 2)
+                if pos["side"] == "short":
+                    gross_pnl = -gross_pnl
+
+                tx_cost = round(pos["position_value"] * cost_pct * 2, 2)
+                net_pnl = round(gross_pnl - tx_cost, 2)
+                cumulative_pnl = round(cumulative_pnl + net_pnl, 2)
+                return_pct = round((exit_price - pos["entry_price"]) / pos["entry_price"] * 100, 3)
+                if pos["side"] == "short":
+                    return_pct = -return_pct
+
+                hold_days = self._date_diff_days(pos["entry_date"], bar_date)
+                capital += round(pos["shares"] * exit_price, 2)
+
+                trades.append(
+                    TradeRecord(
+                        trade_num=trade_num,
+                        entry_date=pos["entry_date"],
+                        exit_date=bar_date,
+                        symbol=symbol,
+                        side=pos["side"],
+                        entry_price=pos["entry_price"],
+                        exit_price=exit_price,
+                        shares=pos["shares"],
+                        position_value=pos["position_value"],
+                        gross_pnl=gross_pnl,
+                        net_pnl=net_pnl,
+                        return_pct=return_pct,
+                        hold_days=hold_days,
+                        outcome="win" if net_pnl > 0 else "loss",
+                        cumulative_pnl=cumulative_pnl,
+                    )
+                )
+
+        # Force-close any remaining positions on the last available bar
+        for symbol, pos in list(open_positions.items()):
+            if symbol in symbol_history and symbol_history[symbol]:
+                last_bar = symbol_history[symbol][-1]
+                trade_num += 1
+                exit_price = round(
+                    last_bar.close * (1.0 - slippage_bps / 10_000.0),
+                    4 if last_bar.close < 10 else 2,
+                )
+                gross_pnl = round(pos["shares"] * (exit_price - pos["entry_price"]), 2)
+                if pos["side"] == "short":
+                    gross_pnl = -gross_pnl
+                tx_cost = round(pos["position_value"] * cost_pct * 2, 2)
+                net_pnl = round(gross_pnl - tx_cost, 2)
+                cumulative_pnl = round(cumulative_pnl + net_pnl, 2)
+                return_pct = round((exit_price - pos["entry_price"]) / pos["entry_price"] * 100, 3)
+                if pos["side"] == "short":
+                    return_pct = -return_pct
+                hold_days = self._date_diff_days(pos["entry_date"], last_bar.date)
+
+                trades.append(
+                    TradeRecord(
+                        trade_num=trade_num,
+                        entry_date=pos["entry_date"],
+                        exit_date=last_bar.date,
+                        symbol=symbol,
+                        side=pos["side"],
+                        entry_price=pos["entry_price"],
+                        exit_price=exit_price,
+                        shares=pos["shares"],
+                        position_value=pos["position_value"],
+                        gross_pnl=gross_pnl,
+                        net_pnl=net_pnl,
+                        return_pct=return_pct,
+                        hold_days=hold_days,
+                        outcome="win" if net_pnl > 0 else "loss",
+                        cumulative_pnl=cumulative_pnl,
+                    )
+                )
+
+        result = self._compute_metrics(
+            trades, config.initial_capital, config.start_date, config.end_date
+        )
+        return result, trades
+
+    def _evaluate_bar(
+        self,
+        strategy: StrategySpec,
+        symbol: str,
+        current_bar: OHLCVBar,
+        recent_bars: List[OHLCVBar],
+        open_position: Optional[Dict[str, Any]],
+        capital: float,
+    ) -> Dict[str, Any]:
+        """Ask LLM to evaluate whether entry/exit rules are met for this bar."""
+        if open_position:
+            pos_status = (
+                f"OPEN {open_position['side'].upper()} position in {symbol}: "
+                f"{open_position['shares']} shares @ ${open_position['entry_price']:.2f} "
+                f"(entered {open_position['entry_date']})"
+            )
+        else:
+            pos_status = "No open position — looking for entry signals."
+
+        prompt = _EVALUATE_PROMPT.format(
+            asset_class=strategy.asset_class,
+            hypothesis=strategy.hypothesis,
+            signal_definition=strategy.signal_definition,
+            entry_rules="; ".join(strategy.entry_rules),
+            exit_rules="; ".join(strategy.exit_rules),
+            sizing_rules="; ".join(strategy.sizing_rules),
+            risk_limits=strategy.risk_limits,
+            position_status=pos_status,
+            capital=capital,
+            symbol=symbol,
+            current_date=current_bar.date,
+            open=current_bar.open,
+            high=current_bar.high,
+            low=current_bar.low,
+            close=current_bar.close,
+            volume=current_bar.volume,
+            n_bars=len(recent_bars),
+            recent_bars_text=_format_bars_table(recent_bars),
+        )
+
+        data = self.llm.complete_json(
+            prompt,
+            temperature=0.2,
+            system_prompt=_EVALUATE_SYSTEM,
+            think=True,
+        )
+
+        return {
+            "action": str(data.get("action", "hold")),
+            "confidence": float(data.get("confidence", 0.0)),
+            "shares": float(data.get("shares", 0)),
+            "reasoning": str(data.get("reasoning", "")),
+        }
+
+    @staticmethod
+    def _compute_metrics(
+        trades: List[TradeRecord],
+        initial_capital: float,
+        start_date: str,
+        end_date: str,
+    ) -> BacktestResult:
+        """Compute aggregate performance metrics from completed backtest trades."""
+        if not trades:
+            return BacktestResult(
+                total_return_pct=0.0,
+                annualized_return_pct=0.0,
+                volatility_pct=0.0,
+                sharpe_ratio=0.0,
+                max_drawdown_pct=0.0,
+                win_rate_pct=0.0,
+                profit_factor=0.0,
+            )
+
+        wins = [t for t in trades if t.outcome == "win"]
+        losses = [t for t in trades if t.outcome == "loss"]
+
+        total_pnl = sum(t.net_pnl for t in trades)
+        total_return_pct = round(total_pnl / initial_capital * 100, 2)
+
+        # Annualize based on the backtest period
+        total_days = BacktestingAgent._date_diff_days(start_date, end_date)
+        years = max(total_days / 365.25, 0.01)
+        annualized_return = round(total_return_pct / years, 2)
+
+        # Win rate
+        win_rate = round(len(wins) / len(trades) * 100, 2) if trades else 0.0
+
+        # Profit factor
+        gross_wins = sum(t.gross_pnl for t in wins) if wins else 0.0
+        gross_losses = abs(sum(t.gross_pnl for t in losses)) if losses else 0.0
+        profit_factor = (
+            round(gross_wins / gross_losses, 2)
+            if gross_losses > 0
+            else round(max(gross_wins, 0.0), 2)
+        )
+
+        # Volatility of per-trade returns
+        returns = [t.return_pct for t in trades]
+        if len(returns) > 1:
+            mean_ret = sum(returns) / len(returns)
+            variance = sum((r - mean_ret) ** 2 for r in returns) / (len(returns) - 1)
+            daily_vol = math.sqrt(variance)
+            annualized_vol = round(
+                daily_vol * math.sqrt(252 / max(years * 252 / len(trades), 1)), 2
+            )
+        else:
+            annualized_vol = 0.0
+
+        # Sharpe ratio
+        sharpe = round(annualized_return / annualized_vol, 2) if annualized_vol > 0 else 0.0
+
+        # Max drawdown
+        peak = initial_capital
+        max_dd = 0.0
+        equity = initial_capital
+        for t in trades:
+            equity += t.net_pnl
+            if equity > peak:
+                peak = equity
+            dd = (peak - equity) / peak * 100 if peak > 0 else 0.0
+            if dd > max_dd:
+                max_dd = dd
+
+        return BacktestResult(
+            total_return_pct=total_return_pct,
+            annualized_return_pct=annualized_return,
+            volatility_pct=annualized_vol,
+            sharpe_ratio=sharpe,
+            max_drawdown_pct=round(max_dd, 2),
+            win_rate_pct=win_rate,
+            profit_factor=profit_factor,
+        )
+
+    @staticmethod
+    def _date_diff_days(d1: str, d2: str) -> int:
+        """Compute days between two ISO date strings."""
+        try:
+            from datetime import date as date_cls
+
+            dt1 = date_cls.fromisoformat(d1[:10])
+            dt2 = date_cls.fromisoformat(d2[:10])
+            return max(1, abs((dt2 - dt1).days))
+        except (ValueError, TypeError):
+            return 1

--- a/backend/agents/investment_team/backtesting_agent.py
+++ b/backend/agents/investment_team/backtesting_agent.py
@@ -112,7 +112,7 @@ class BacktestingAgent:
         Returns (BacktestResult, trade_ledger).
         """
         capital = config.initial_capital
-        cost_pct = (config.transaction_cost_bps + config.slippage_bps) / 10_000.0
+        cost_pct = config.transaction_cost_bps / 10_000.0
         slippage_bps = config.slippage_bps
 
         # Build a unified timeline: merge all symbols' bars sorted by date

--- a/backend/agents/investment_team/backtesting_agent.py
+++ b/backend/agents/investment_team/backtesting_agent.py
@@ -1,15 +1,13 @@
 """
 Backtesting Agent — runs historical backtests using real market data and LLM-driven trade decisions.
 
-Fetches real OHLCV data for the backtest period, walks through bars chronologically,
-uses the LLM to interpret the strategy's entry/exit rules, and simulates trade execution
-with realistic slippage and transaction costs.
+Delegates the bar-walking simulation to :class:`TradeSimulationEngine` and provides
+the LLM evaluation callback with backtest-specific prompt context.
 """
 
 from __future__ import annotations
 
 import logging
-import math
 from typing import Any, Dict, List, Optional
 
 from llm_service.interface import LLMClient
@@ -20,6 +18,12 @@ from .models import (
     BacktestResult,
     StrategySpec,
     TradeRecord,
+)
+from .trade_simulator import (
+    OpenPosition,
+    TradeSimulationEngine,
+    compute_metrics,
+    format_bars_table,
 )
 
 logger = logging.getLogger(__name__)
@@ -74,18 +78,6 @@ For exits, set shares to 0 (will close full position).
 """
 
 
-def _format_bars_table(bars: List[OHLCVBar]) -> str:
-    """Format a list of OHLCV bars as a compact text table."""
-    if not bars:
-        return "No data available."
-    lines = ["Date       | Open     | High     | Low      | Close    | Volume"]
-    for b in bars:
-        lines.append(
-            f"{b.date} | {b.open:<8.2f} | {b.high:<8.2f} | {b.low:<8.2f} | {b.close:<8.2f} | {b.volume:.0f}"
-        )
-    return "\n".join(lines)
-
-
 # ---------------------------------------------------------------------------
 # Agent
 # ---------------------------------------------------------------------------
@@ -111,151 +103,27 @@ class BacktestingAgent:
 
         Returns (BacktestResult, trade_ledger).
         """
-        capital = config.initial_capital
-        cost_pct = config.transaction_cost_bps / 10_000.0
-        slippage_bps = config.slippage_bps
-
-        # Build a unified timeline: merge all symbols' bars sorted by date
-        timeline: List[tuple[str, str, OHLCVBar]] = []
-        for symbol, bars in market_data.items():
-            for bar in bars:
-                timeline.append((bar.date, symbol, bar))
-        timeline.sort(key=lambda x: x[0])
-
-        # Per-symbol bar history for context lookups
-        symbol_history: Dict[str, List[OHLCVBar]] = {sym: [] for sym in market_data}
-
-        open_positions: Dict[str, Dict[str, Any]] = {}
-        trades: List[TradeRecord] = []
-        trade_num = 0
-        cumulative_pnl = 0.0
-
-        for bar_date, symbol, bar in timeline:
-            symbol_history[symbol].append(bar)
-            recent = symbol_history[symbol][-20:]
-            has_position = symbol in open_positions
-
-            # Ask LLM to evaluate this bar
-            try:
-                decision = self._evaluate_bar(
-                    strategy=strategy,
-                    symbol=symbol,
-                    current_bar=bar,
-                    recent_bars=recent,
-                    open_position=open_positions.get(symbol),
-                    capital=capital,
-                )
-            except Exception as exc:
-                logger.warning("LLM evaluation failed for %s on %s: %s", symbol, bar_date, exc)
-                continue
-
-            action = decision.get("action", "hold")
-
-            if action in ("enter_long", "enter_short") and not has_position:
-                shares = float(decision.get("shares", 0))
-                if shares <= 0:
-                    position_pct = 0.06
-                    shares = round(capital * position_pct / bar.close, 4 if bar.close < 10 else 2)
-
-                if shares > 0 and capital >= shares * bar.close:
-                    slippage_mult = 1.0 + slippage_bps / 10_000.0
-                    entry_price = round(bar.close * slippage_mult, 4 if bar.close < 10 else 2)
-                    position_value = round(entry_price * shares, 2)
-                    capital -= position_value
-
-                    open_positions[symbol] = {
-                        "side": "long" if action == "enter_long" else "short",
-                        "entry_date": bar_date,
-                        "entry_price": entry_price,
-                        "shares": shares,
-                        "position_value": position_value,
-                    }
-
-            elif action == "exit" and has_position:
-                pos = open_positions.pop(symbol)
-                trade_num += 1
-
-                slippage_mult = 1.0 - slippage_bps / 10_000.0
-                exit_price = round(bar.close * slippage_mult, 4 if bar.close < 10 else 2)
-
-                gross_pnl = round(pos["shares"] * (exit_price - pos["entry_price"]), 2)
-                if pos["side"] == "short":
-                    gross_pnl = -gross_pnl
-
-                tx_cost = round(pos["position_value"] * cost_pct * 2, 2)
-                net_pnl = round(gross_pnl - tx_cost, 2)
-                cumulative_pnl = round(cumulative_pnl + net_pnl, 2)
-                return_pct = round((exit_price - pos["entry_price"]) / pos["entry_price"] * 100, 3)
-                if pos["side"] == "short":
-                    return_pct = -return_pct
-
-                hold_days = self._date_diff_days(pos["entry_date"], bar_date)
-                capital += round(pos["shares"] * exit_price, 2)
-
-                trades.append(
-                    TradeRecord(
-                        trade_num=trade_num,
-                        entry_date=pos["entry_date"],
-                        exit_date=bar_date,
-                        symbol=symbol,
-                        side=pos["side"],
-                        entry_price=pos["entry_price"],
-                        exit_price=exit_price,
-                        shares=pos["shares"],
-                        position_value=pos["position_value"],
-                        gross_pnl=gross_pnl,
-                        net_pnl=net_pnl,
-                        return_pct=return_pct,
-                        hold_days=hold_days,
-                        outcome="win" if net_pnl > 0 else "loss",
-                        cumulative_pnl=cumulative_pnl,
-                    )
-                )
-
-        # Force-close any remaining positions on the last available bar
-        for symbol, pos in list(open_positions.items()):
-            if symbol in symbol_history and symbol_history[symbol]:
-                last_bar = symbol_history[symbol][-1]
-                trade_num += 1
-                exit_price = round(
-                    last_bar.close * (1.0 - slippage_bps / 10_000.0),
-                    4 if last_bar.close < 10 else 2,
-                )
-                gross_pnl = round(pos["shares"] * (exit_price - pos["entry_price"]), 2)
-                if pos["side"] == "short":
-                    gross_pnl = -gross_pnl
-                tx_cost = round(pos["position_value"] * cost_pct * 2, 2)
-                net_pnl = round(gross_pnl - tx_cost, 2)
-                cumulative_pnl = round(cumulative_pnl + net_pnl, 2)
-                return_pct = round((exit_price - pos["entry_price"]) / pos["entry_price"] * 100, 3)
-                if pos["side"] == "short":
-                    return_pct = -return_pct
-                hold_days = self._date_diff_days(pos["entry_date"], last_bar.date)
-
-                trades.append(
-                    TradeRecord(
-                        trade_num=trade_num,
-                        entry_date=pos["entry_date"],
-                        exit_date=last_bar.date,
-                        symbol=symbol,
-                        side=pos["side"],
-                        entry_price=pos["entry_price"],
-                        exit_price=exit_price,
-                        shares=pos["shares"],
-                        position_value=pos["position_value"],
-                        gross_pnl=gross_pnl,
-                        net_pnl=net_pnl,
-                        return_pct=return_pct,
-                        hold_days=hold_days,
-                        outcome="win" if net_pnl > 0 else "loss",
-                        cumulative_pnl=cumulative_pnl,
-                    )
-                )
-
-        result = self._compute_metrics(
-            trades, config.initial_capital, config.start_date, config.end_date
+        engine = TradeSimulationEngine(
+            initial_capital=config.initial_capital,
+            transaction_cost_bps=config.transaction_cost_bps,
+            slippage_bps=config.slippage_bps,
         )
-        return result, trades
+
+        def evaluate(
+            symbol: str,
+            bar: OHLCVBar,
+            recent: List[OHLCVBar],
+            position: Optional[OpenPosition],
+            capital: float,
+        ) -> Dict[str, Any]:
+            return self._evaluate_bar(strategy, symbol, bar, recent, position, capital)
+
+        sim = engine.run(market_data, evaluate)
+
+        result = compute_metrics(
+            sim.trades, config.initial_capital, config.start_date, config.end_date
+        )
+        return result, sim.trades
 
     def _evaluate_bar(
         self,
@@ -263,15 +131,15 @@ class BacktestingAgent:
         symbol: str,
         current_bar: OHLCVBar,
         recent_bars: List[OHLCVBar],
-        open_position: Optional[Dict[str, Any]],
+        open_position: Optional[OpenPosition],
         capital: float,
     ) -> Dict[str, Any]:
         """Ask LLM to evaluate whether entry/exit rules are met for this bar."""
         if open_position:
             pos_status = (
-                f"OPEN {open_position['side'].upper()} position in {symbol}: "
-                f"{open_position['shares']} shares @ ${open_position['entry_price']:.2f} "
-                f"(entered {open_position['entry_date']})"
+                f"OPEN {open_position.side.upper()} position in {symbol}: "
+                f"{open_position.shares} shares @ ${open_position.entry_price:.2f} "
+                f"(entered {open_position.entry_date})"
             )
         else:
             pos_status = "No open position — looking for entry signals."
@@ -294,7 +162,7 @@ class BacktestingAgent:
             close=current_bar.close,
             volume=current_bar.volume,
             n_bars=len(recent_bars),
-            recent_bars_text=_format_bars_table(recent_bars),
+            recent_bars_text=format_bars_table(recent_bars),
         )
 
         data = self.llm.complete_json(
@@ -310,94 +178,3 @@ class BacktestingAgent:
             "shares": float(data.get("shares", 0)),
             "reasoning": str(data.get("reasoning", "")),
         }
-
-    @staticmethod
-    def _compute_metrics(
-        trades: List[TradeRecord],
-        initial_capital: float,
-        start_date: str,
-        end_date: str,
-    ) -> BacktestResult:
-        """Compute aggregate performance metrics from completed backtest trades."""
-        if not trades:
-            return BacktestResult(
-                total_return_pct=0.0,
-                annualized_return_pct=0.0,
-                volatility_pct=0.0,
-                sharpe_ratio=0.0,
-                max_drawdown_pct=0.0,
-                win_rate_pct=0.0,
-                profit_factor=0.0,
-            )
-
-        wins = [t for t in trades if t.outcome == "win"]
-        losses = [t for t in trades if t.outcome == "loss"]
-
-        total_pnl = sum(t.net_pnl for t in trades)
-        total_return_pct = round(total_pnl / initial_capital * 100, 2)
-
-        # Annualize based on the backtest period
-        total_days = BacktestingAgent._date_diff_days(start_date, end_date)
-        years = max(total_days / 365.25, 0.01)
-        annualized_return = round(total_return_pct / years, 2)
-
-        # Win rate
-        win_rate = round(len(wins) / len(trades) * 100, 2) if trades else 0.0
-
-        # Profit factor
-        gross_wins = sum(t.gross_pnl for t in wins) if wins else 0.0
-        gross_losses = abs(sum(t.gross_pnl for t in losses)) if losses else 0.0
-        profit_factor = (
-            round(gross_wins / gross_losses, 2)
-            if gross_losses > 0
-            else round(max(gross_wins, 0.0), 2)
-        )
-
-        # Volatility of per-trade returns
-        returns = [t.return_pct for t in trades]
-        if len(returns) > 1:
-            mean_ret = sum(returns) / len(returns)
-            variance = sum((r - mean_ret) ** 2 for r in returns) / (len(returns) - 1)
-            daily_vol = math.sqrt(variance)
-            annualized_vol = round(
-                daily_vol * math.sqrt(252 / max(years * 252 / len(trades), 1)), 2
-            )
-        else:
-            annualized_vol = 0.0
-
-        # Sharpe ratio
-        sharpe = round(annualized_return / annualized_vol, 2) if annualized_vol > 0 else 0.0
-
-        # Max drawdown
-        peak = initial_capital
-        max_dd = 0.0
-        equity = initial_capital
-        for t in trades:
-            equity += t.net_pnl
-            if equity > peak:
-                peak = equity
-            dd = (peak - equity) / peak * 100 if peak > 0 else 0.0
-            if dd > max_dd:
-                max_dd = dd
-
-        return BacktestResult(
-            total_return_pct=total_return_pct,
-            annualized_return_pct=annualized_return,
-            volatility_pct=annualized_vol,
-            sharpe_ratio=sharpe,
-            max_drawdown_pct=round(max_dd, 2),
-            win_rate_pct=win_rate,
-            profit_factor=profit_factor,
-        )
-
-    @staticmethod
-    def _date_diff_days(d1: str, d2: str) -> int:
-        """Compute days between two ISO date strings."""
-        try:
-            from datetime import date as date_cls
-
-            dt1 = date_cls.fromisoformat(d1[:10])
-            dt2 = date_cls.fromisoformat(d2[:10])
-            return max(1, abs((dt2 - dt1).days))
-        except (ValueError, TypeError):
-            return 1

--- a/backend/agents/investment_team/market_data_service.py
+++ b/backend/agents/investment_team/market_data_service.py
@@ -1,0 +1,159 @@
+"""Market data service — fetches real OHLCV price data from free public APIs."""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, timedelta
+from typing import Dict, List
+
+import httpx
+from pydantic import BaseModel
+
+from .models import StrategySpec
+
+logger = logging.getLogger(__name__)
+
+# Symbol mapping: internal symbol -> CoinGecko API id
+_COINGECKO_IDS = {
+    "BTC": "bitcoin",
+    "ETH": "ethereum",
+    "SOL": "solana",
+    "BNB": "binancecoin",
+    "XRP": "ripple",
+    "MATIC": "matic-network",
+    "AVAX": "avalanche-2",
+    "LINK": "chainlink",
+    "ADA": "cardano",
+    "DOT": "polkadot",
+}
+
+_STOCK_SYMBOLS = ["AAPL", "MSFT", "NVDA", "TSLA", "AMZN", "META", "GOOGL", "JPM", "AMD", "SPY"]
+_CRYPTO_SYMBOLS = ["BTC", "ETH", "SOL", "BNB", "XRP", "MATIC", "AVAX", "LINK", "ADA", "DOT"]
+_OTHER_SYMBOLS = ["GLD", "USO", "TLT", "QQQ", "IWM", "EEM", "GDX", "XLE", "XLF"]
+
+
+class OHLCVBar(BaseModel):
+    """A single OHLCV price bar."""
+
+    date: str
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float
+
+
+class MarketDataService:
+    """Fetches real market data from public sources.
+
+    - Stocks/ETFs: Yahoo Finance via yfinance
+    - Crypto: CoinGecko free API (no key required)
+    """
+
+    def __init__(self, http_timeout: float = 30.0) -> None:
+        self._timeout = http_timeout
+
+    def fetch_ohlcv(self, symbol: str, asset_class: str, days: int = 365) -> List[OHLCVBar]:
+        """Route to best data source for the asset class."""
+        asset = asset_class.lower()
+        if asset == "crypto":
+            return self._fetch_crypto(symbol, days)
+        return self._fetch_stock(symbol, days)
+
+    def _fetch_stock(self, symbol: str, days: int) -> List[OHLCVBar]:
+        """Fetch stock/ETF OHLCV data via yfinance."""
+        try:
+            import yfinance as yf
+        except ImportError:
+            logger.warning("yfinance not installed — falling back to empty data for %s", symbol)
+            return []
+
+        end_dt = date.today()
+        start_dt = end_dt - timedelta(days=days)
+
+        try:
+            ticker = yf.Ticker(symbol)
+            df = ticker.history(start=start_dt.isoformat(), end=end_dt.isoformat(), interval="1d")
+        except Exception as exc:
+            logger.error("yfinance fetch failed for %s: %s", symbol, exc)
+            return []
+
+        if df is None or df.empty:
+            logger.warning("No data returned from yfinance for %s", symbol)
+            return []
+
+        bars: List[OHLCVBar] = []
+        for idx, row in df.iterrows():
+            bar_date = idx.strftime("%Y-%m-%d") if hasattr(idx, "strftime") else str(idx)[:10]
+            bars.append(
+                OHLCVBar(
+                    date=bar_date,
+                    open=round(float(row["Open"]), 4),
+                    high=round(float(row["High"]), 4),
+                    low=round(float(row["Low"]), 4),
+                    close=round(float(row["Close"]), 4),
+                    volume=float(row.get("Volume", 0)),
+                )
+            )
+        return bars
+
+    def _fetch_crypto(self, symbol: str, days: int) -> List[OHLCVBar]:
+        """Fetch crypto OHLCV data via CoinGecko free API."""
+        coin_id = _COINGECKO_IDS.get(symbol.upper())
+        if not coin_id:
+            logger.warning("Unknown crypto symbol %s — no CoinGecko mapping", symbol)
+            return []
+
+        url = f"https://api.coingecko.com/api/v3/coins/{coin_id}/ohlc"
+        params = {"vs_currency": "usd", "days": str(min(days, 365))}
+
+        try:
+            with httpx.Client(timeout=self._timeout) as client:
+                resp = client.get(url, params=params)
+                resp.raise_for_status()
+                raw = resp.json()
+        except Exception as exc:
+            logger.error("CoinGecko fetch failed for %s: %s", symbol, exc)
+            return []
+
+        if not isinstance(raw, list):
+            logger.warning("Unexpected CoinGecko response for %s", symbol)
+            return []
+
+        bars: List[OHLCVBar] = []
+        for entry in raw:
+            if len(entry) < 5:
+                continue
+            ts_ms, o, h, l_, c = entry[0], entry[1], entry[2], entry[3], entry[4]
+            bar_date = date.fromtimestamp(ts_ms / 1000).isoformat()
+            bars.append(
+                OHLCVBar(
+                    date=bar_date,
+                    open=round(float(o), 4),
+                    high=round(float(h), 4),
+                    low=round(float(l_), 4),
+                    close=round(float(c), 4),
+                    volume=0.0,  # CoinGecko OHLC endpoint doesn't include volume
+                )
+            )
+        return bars
+
+    def get_symbols_for_strategy(self, strategy: StrategySpec) -> List[str]:
+        """Return relevant symbols based on the strategy's asset class."""
+        asset = strategy.asset_class.lower()
+        if asset == "crypto":
+            return list(_CRYPTO_SYMBOLS)
+        if asset in ("stocks", "equities"):
+            return list(_STOCK_SYMBOLS)
+        return list(_OTHER_SYMBOLS)
+
+    def fetch_multi_symbol(
+        self, symbols: List[str], asset_class: str, days: int = 365
+    ) -> Dict[str, List[OHLCVBar]]:
+        """Fetch OHLCV data for multiple symbols."""
+        result: Dict[str, List[OHLCVBar]] = {}
+        for sym in symbols:
+            bars = self.fetch_ohlcv(sym, asset_class, days)
+            if bars:
+                result[sym] = bars
+        return result

--- a/backend/agents/investment_team/market_data_service.py
+++ b/backend/agents/investment_team/market_data_service.py
@@ -54,26 +54,31 @@ class MarketDataService:
         self._timeout = http_timeout
 
     def fetch_ohlcv(self, symbol: str, asset_class: str, days: int = 365) -> List[OHLCVBar]:
-        """Route to best data source for the asset class."""
+        """Route to best data source for the asset class (recent N days)."""
+        end_dt = date.today()
+        start_dt = end_dt - timedelta(days=days)
+        return self.fetch_ohlcv_range(symbol, asset_class, start_dt.isoformat(), end_dt.isoformat())
+
+    def fetch_ohlcv_range(
+        self, symbol: str, asset_class: str, start_date: str, end_date: str
+    ) -> List[OHLCVBar]:
+        """Fetch OHLCV data for an explicit date range. Routes by asset class."""
         asset = asset_class.lower()
         if asset == "crypto":
-            return self._fetch_crypto(symbol, days)
-        return self._fetch_stock(symbol, days)
+            return self._fetch_crypto(symbol, start_date, end_date)
+        return self._fetch_stock(symbol, start_date, end_date)
 
-    def _fetch_stock(self, symbol: str, days: int) -> List[OHLCVBar]:
-        """Fetch stock/ETF OHLCV data via yfinance."""
+    def _fetch_stock(self, symbol: str, start_date: str, end_date: str) -> List[OHLCVBar]:
+        """Fetch stock/ETF OHLCV data via yfinance for an arbitrary date range."""
         try:
             import yfinance as yf
         except ImportError:
             logger.warning("yfinance not installed — falling back to empty data for %s", symbol)
             return []
 
-        end_dt = date.today()
-        start_dt = end_dt - timedelta(days=days)
-
         try:
             ticker = yf.Ticker(symbol)
-            df = ticker.history(start=start_dt.isoformat(), end=end_dt.isoformat(), interval="1d")
+            df = ticker.history(start=start_date, end=end_date, interval="1d")
         except Exception as exc:
             logger.error("yfinance fetch failed for %s: %s", symbol, exc)
             return []
@@ -97,12 +102,20 @@ class MarketDataService:
             )
         return bars
 
-    def _fetch_crypto(self, symbol: str, days: int) -> List[OHLCVBar]:
-        """Fetch crypto OHLCV data via CoinGecko free API."""
+    def _fetch_crypto(self, symbol: str, start_date: str, end_date: str) -> List[OHLCVBar]:
+        """Fetch crypto OHLCV data via CoinGecko free API for a date range."""
         coin_id = _COINGECKO_IDS.get(symbol.upper())
         if not coin_id:
             logger.warning("Unknown crypto symbol %s — no CoinGecko mapping", symbol)
             return []
+
+        # CoinGecko OHLC endpoint uses days param; compute from date range
+        try:
+            start_dt = date.fromisoformat(start_date)
+            end_dt = date.fromisoformat(end_date)
+            days = max(1, (end_dt - start_dt).days)
+        except ValueError:
+            days = 365
 
         url = f"https://api.coingecko.com/api/v3/coins/{coin_id}/ohlc"
         params = {"vs_currency": "usd", "days": str(min(days, 365))}
@@ -126,6 +139,9 @@ class MarketDataService:
                 continue
             ts_ms, o, h, l_, c = entry[0], entry[1], entry[2], entry[3], entry[4]
             bar_date = date.fromtimestamp(ts_ms / 1000).isoformat()
+            # Filter to requested date range
+            if bar_date < start_date or bar_date > end_date:
+                continue
             bars.append(
                 OHLCVBar(
                     date=bar_date,
@@ -150,10 +166,21 @@ class MarketDataService:
     def fetch_multi_symbol(
         self, symbols: List[str], asset_class: str, days: int = 365
     ) -> Dict[str, List[OHLCVBar]]:
-        """Fetch OHLCV data for multiple symbols."""
+        """Fetch OHLCV data for multiple symbols (recent N days)."""
         result: Dict[str, List[OHLCVBar]] = {}
         for sym in symbols:
             bars = self.fetch_ohlcv(sym, asset_class, days)
+            if bars:
+                result[sym] = bars
+        return result
+
+    def fetch_multi_symbol_range(
+        self, symbols: List[str], asset_class: str, start_date: str, end_date: str
+    ) -> Dict[str, List[OHLCVBar]]:
+        """Fetch OHLCV data for multiple symbols over an explicit date range."""
+        result: Dict[str, List[OHLCVBar]] = {}
+        for sym in symbols:
+            bars = self.fetch_ohlcv_range(sym, asset_class, start_date, end_date)
             if bars:
                 result[sym] = bars
         return result

--- a/backend/agents/investment_team/market_data_service.py
+++ b/backend/agents/investment_team/market_data_service.py
@@ -103,22 +103,45 @@ class MarketDataService:
         return bars
 
     def _fetch_crypto(self, symbol: str, start_date: str, end_date: str) -> List[OHLCVBar]:
-        """Fetch crypto OHLCV data via CoinGecko free API for a date range."""
+        """Fetch crypto OHLCV data via CoinGecko free API for an arbitrary date range.
+
+        Uses the ``/coins/{id}/market_chart/range`` endpoint with Unix timestamps
+        so that historical windows (e.g. 2021-2024) work correctly, unlike the
+        ``/ohlc`` endpoint which only returns the most recent N days.
+        """
         coin_id = _COINGECKO_IDS.get(symbol.upper())
         if not coin_id:
             logger.warning("Unknown crypto symbol %s — no CoinGecko mapping", symbol)
             return []
 
-        # CoinGecko OHLC endpoint uses days param; compute from date range
         try:
             start_dt = date.fromisoformat(start_date)
             end_dt = date.fromisoformat(end_date)
-            days = max(1, (end_dt - start_dt).days)
         except ValueError:
-            days = 365
+            logger.error("Invalid date range for crypto fetch: %s - %s", start_date, end_date)
+            return []
 
-        url = f"https://api.coingecko.com/api/v3/coins/{coin_id}/ohlc"
-        params = {"vs_currency": "usd", "days": str(min(days, 365))}
+        # Convert to Unix timestamps (start of day UTC)
+        import calendar
+        from datetime import datetime, timezone
+
+        start_ts = int(
+            calendar.timegm(
+                datetime(
+                    start_dt.year, start_dt.month, start_dt.day, tzinfo=timezone.utc
+                ).timetuple()
+            )
+        )
+        end_ts = int(
+            calendar.timegm(
+                datetime(
+                    end_dt.year, end_dt.month, end_dt.day, 23, 59, 59, tzinfo=timezone.utc
+                ).timetuple()
+            )
+        )
+
+        url = f"https://api.coingecko.com/api/v3/coins/{coin_id}/market_chart/range"
+        params = {"vs_currency": "usd", "from": str(start_ts), "to": str(end_ts)}
 
         try:
             with httpx.Client(timeout=self._timeout) as client:
@@ -129,27 +152,28 @@ class MarketDataService:
             logger.error("CoinGecko fetch failed for %s: %s", symbol, exc)
             return []
 
-        if not isinstance(raw, list):
+        if not isinstance(raw, dict) or "prices" not in raw:
             logger.warning("Unexpected CoinGecko response for %s", symbol)
             return []
 
-        bars: List[OHLCVBar] = []
-        for entry in raw:
-            if len(entry) < 5:
-                continue
-            ts_ms, o, h, l_, c = entry[0], entry[1], entry[2], entry[3], entry[4]
+        # market_chart/range returns {prices: [[ts, price], ...], ...}
+        # Group by date to build daily OHLCV bars from the price points
+        daily: Dict[str, List[float]] = {}
+        for ts_ms, price in raw.get("prices", []):
             bar_date = date.fromtimestamp(ts_ms / 1000).isoformat()
-            # Filter to requested date range
-            if bar_date < start_date or bar_date > end_date:
-                continue
+            daily.setdefault(bar_date, []).append(float(price))
+
+        bars: List[OHLCVBar] = []
+        for bar_date in sorted(daily):
+            prices = daily[bar_date]
             bars.append(
                 OHLCVBar(
                     date=bar_date,
-                    open=round(float(o), 4),
-                    high=round(float(h), 4),
-                    low=round(float(l_), 4),
-                    close=round(float(c), 4),
-                    volume=0.0,  # CoinGecko OHLC endpoint doesn't include volume
+                    open=round(prices[0], 4),
+                    high=round(max(prices), 4),
+                    low=round(min(prices), 4),
+                    close=round(prices[-1], 4),
+                    volume=0.0,  # market_chart/range doesn't provide volume per bar
                 )
             )
         return bars

--- a/backend/agents/investment_team/market_data_service.py
+++ b/backend/agents/investment_team/market_data_service.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import logging
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import date, timedelta
 from typing import Dict, List
 
@@ -13,7 +15,10 @@ from .models import StrategySpec
 
 logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
 # Symbol mapping: internal symbol -> CoinGecko API id
+# ---------------------------------------------------------------------------
+
 _COINGECKO_IDS = {
     "BTC": "bitcoin",
     "ETH": "ethereum",
@@ -27,8 +32,30 @@ _COINGECKO_IDS = {
     "DOT": "polkadot",
 }
 
+# ---------------------------------------------------------------------------
+# Symbol lists by asset class
+# ---------------------------------------------------------------------------
+
 _STOCK_SYMBOLS = ["AAPL", "MSFT", "NVDA", "TSLA", "AMZN", "META", "GOOGL", "JPM", "AMD", "SPY"]
 _CRYPTO_SYMBOLS = ["BTC", "ETH", "SOL", "BNB", "XRP", "MATIC", "AVAX", "LINK", "ADA", "DOT"]
+# Forex pairs use yfinance's =X suffix
+_FOREX_SYMBOLS = [
+    "EURUSD=X",
+    "GBPUSD=X",
+    "USDJPY=X",
+    "AUDUSD=X",
+    "USDCAD=X",
+    "NZDUSD=X",
+    "USDCHF=X",
+    "EURGBP=X",
+    "EURJPY=X",
+    "GBPJPY=X",
+]
+# Futures use yfinance's =F suffix
+_FUTURES_SYMBOLS = ["ES=F", "NQ=F", "CL=F", "GC=F", "SI=F", "ZB=F", "NG=F"]
+# Commodity ETFs (liquid proxies for commodities via yfinance)
+_COMMODITY_SYMBOLS = ["GLD", "USO", "SLV", "DBA", "UNG", "PDBC", "DBC"]
+# Broad ETFs used as a fallback
 _OTHER_SYMBOLS = ["GLD", "USO", "TLT", "QQQ", "IWM", "EEM", "GDX", "XLE", "XLF"]
 
 
@@ -46,12 +73,16 @@ class OHLCVBar(BaseModel):
 class MarketDataService:
     """Fetches real market data from public sources.
 
-    - Stocks/ETFs: Yahoo Finance via yfinance
+    - Stocks/ETFs/Forex/Futures: Yahoo Finance via yfinance
     - Crypto: CoinGecko free API (no key required)
     """
 
     def __init__(self, http_timeout: float = 30.0) -> None:
         self._timeout = http_timeout
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
 
     def fetch_ohlcv(self, symbol: str, asset_class: str, days: int = 365) -> List[OHLCVBar]:
         """Route to best data source for the asset class (recent N days)."""
@@ -66,10 +97,66 @@ class MarketDataService:
         asset = asset_class.lower()
         if asset == "crypto":
             return self._fetch_crypto(symbol, start_date, end_date)
+        # All non-crypto assets are fetched via yfinance (stocks, forex, futures,
+        # commodities, options).  yfinance supports =X (forex) and =F (futures)
+        # suffixes natively.
         return self._fetch_stock(symbol, start_date, end_date)
 
+    def get_symbols_for_strategy(self, strategy: StrategySpec) -> List[str]:
+        """Return relevant symbols based on the strategy's asset class."""
+        asset = strategy.asset_class.lower()
+        if asset == "crypto":
+            return list(_CRYPTO_SYMBOLS)
+        if asset in ("stocks", "equities", "options"):
+            return list(_STOCK_SYMBOLS)
+        if asset in ("forex", "fx"):
+            return list(_FOREX_SYMBOLS)
+        if asset == "futures":
+            return list(_FUTURES_SYMBOLS)
+        if asset in ("commodities", "commodity"):
+            return list(_COMMODITY_SYMBOLS)
+        return list(_STOCK_SYMBOLS)
+
+    def fetch_multi_symbol(
+        self, symbols: List[str], asset_class: str, days: int = 365
+    ) -> Dict[str, List[OHLCVBar]]:
+        """Fetch OHLCV data for multiple symbols in parallel (recent N days)."""
+        end_dt = date.today()
+        start_dt = end_dt - timedelta(days=days)
+        return self.fetch_multi_symbol_range(
+            symbols, asset_class, start_dt.isoformat(), end_dt.isoformat()
+        )
+
+    def fetch_multi_symbol_range(
+        self, symbols: List[str], asset_class: str, start_date: str, end_date: str
+    ) -> Dict[str, List[OHLCVBar]]:
+        """Fetch OHLCV data for multiple symbols over an explicit date range.
+
+        Uses a thread pool to fetch symbols in parallel.
+        """
+        result: Dict[str, List[OHLCVBar]] = {}
+        workers = min(len(symbols), 5)
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            futures = {
+                executor.submit(self.fetch_ohlcv_range, sym, asset_class, start_date, end_date): sym
+                for sym in symbols
+            }
+            for future in as_completed(futures):
+                sym = futures[future]
+                try:
+                    bars = future.result()
+                    if bars:
+                        result[sym] = bars
+                except Exception as exc:
+                    logger.warning("Failed to fetch %s: %s", sym, exc)
+        return result
+
+    # ------------------------------------------------------------------
+    # Internal: Yahoo Finance (stocks, forex, futures, commodities)
+    # ------------------------------------------------------------------
+
     def _fetch_stock(self, symbol: str, start_date: str, end_date: str) -> List[OHLCVBar]:
-        """Fetch stock/ETF OHLCV data via yfinance for an arbitrary date range."""
+        """Fetch stock/ETF/forex/futures OHLCV data via yfinance for an arbitrary date range."""
         try:
             import yfinance as yf
         except ImportError:
@@ -102,12 +189,15 @@ class MarketDataService:
             )
         return bars
 
-    def _fetch_crypto(self, symbol: str, start_date: str, end_date: str) -> List[OHLCVBar]:
-        """Fetch crypto OHLCV data via CoinGecko free API for an arbitrary date range.
+    # ------------------------------------------------------------------
+    # Internal: CoinGecko (crypto)
+    # ------------------------------------------------------------------
 
-        Uses the ``/coins/{id}/market_chart/range`` endpoint with Unix timestamps
-        so that historical windows (e.g. 2021-2024) work correctly, unlike the
-        ``/ohlc`` endpoint which only returns the most recent N days.
+    def _fetch_crypto(self, symbol: str, start_date: str, end_date: str) -> List[OHLCVBar]:
+        """Fetch crypto OHLCV data via CoinGecko ``/market_chart/range`` endpoint.
+
+        Uses Unix timestamps so arbitrary historical windows work correctly.
+        Includes retry with exponential backoff for rate-limit (429) responses.
         """
         coin_id = _COINGECKO_IDS.get(symbol.upper())
         if not coin_id:
@@ -121,21 +211,19 @@ class MarketDataService:
             logger.error("Invalid date range for crypto fetch: %s - %s", start_date, end_date)
             return []
 
-        # Convert to Unix timestamps (start of day UTC)
         import calendar
-        from datetime import datetime, timezone
+        from datetime import datetime as dt_cls
+        from datetime import timezone as tz_cls
 
         start_ts = int(
             calendar.timegm(
-                datetime(
-                    start_dt.year, start_dt.month, start_dt.day, tzinfo=timezone.utc
-                ).timetuple()
+                dt_cls(start_dt.year, start_dt.month, start_dt.day, tzinfo=tz_cls.utc).timetuple()
             )
         )
         end_ts = int(
             calendar.timegm(
-                datetime(
-                    end_dt.year, end_dt.month, end_dt.day, 23, 59, 59, tzinfo=timezone.utc
+                dt_cls(
+                    end_dt.year, end_dt.month, end_dt.day, 23, 59, 59, tzinfo=tz_cls.utc
                 ).timetuple()
             )
         )
@@ -143,21 +231,17 @@ class MarketDataService:
         url = f"https://api.coingecko.com/api/v3/coins/{coin_id}/market_chart/range"
         params = {"vs_currency": "usd", "from": str(start_ts), "to": str(end_ts)}
 
-        try:
-            with httpx.Client(timeout=self._timeout) as client:
-                resp = client.get(url, params=params)
-                resp.raise_for_status()
-                raw = resp.json()
-        except Exception as exc:
-            logger.error("CoinGecko fetch failed for %s: %s", symbol, exc)
+        raw = self._coingecko_get(url, params)
+        if raw is None:
             return []
 
         if not isinstance(raw, dict) or "prices" not in raw:
             logger.warning("Unexpected CoinGecko response for %s", symbol)
             return []
 
-        # market_chart/range returns {prices: [[ts, price], ...], ...}
-        # Group by date to build daily OHLCV bars from the price points
+        # Group price points by date to build daily OHLCV bars.
+        # The /market_chart/range endpoint returns granularity based on span
+        # (5-min for <1 day, hourly for 1-90 days, daily for >90 days).
         daily: Dict[str, List[float]] = {}
         for ts_ms, price in raw.get("prices", []):
             bar_date = date.fromtimestamp(ts_ms / 1000).isoformat()
@@ -173,38 +257,30 @@ class MarketDataService:
                     high=round(max(prices), 4),
                     low=round(min(prices), 4),
                     close=round(prices[-1], 4),
-                    volume=0.0,  # market_chart/range doesn't provide volume per bar
+                    volume=0.0,
                 )
             )
         return bars
 
-    def get_symbols_for_strategy(self, strategy: StrategySpec) -> List[str]:
-        """Return relevant symbols based on the strategy's asset class."""
-        asset = strategy.asset_class.lower()
-        if asset == "crypto":
-            return list(_CRYPTO_SYMBOLS)
-        if asset in ("stocks", "equities"):
-            return list(_STOCK_SYMBOLS)
-        return list(_OTHER_SYMBOLS)
-
-    def fetch_multi_symbol(
-        self, symbols: List[str], asset_class: str, days: int = 365
-    ) -> Dict[str, List[OHLCVBar]]:
-        """Fetch OHLCV data for multiple symbols (recent N days)."""
-        result: Dict[str, List[OHLCVBar]] = {}
-        for sym in symbols:
-            bars = self.fetch_ohlcv(sym, asset_class, days)
-            if bars:
-                result[sym] = bars
-        return result
-
-    def fetch_multi_symbol_range(
-        self, symbols: List[str], asset_class: str, start_date: str, end_date: str
-    ) -> Dict[str, List[OHLCVBar]]:
-        """Fetch OHLCV data for multiple symbols over an explicit date range."""
-        result: Dict[str, List[OHLCVBar]] = {}
-        for sym in symbols:
-            bars = self.fetch_ohlcv_range(sym, asset_class, start_date, end_date)
-            if bars:
-                result[sym] = bars
-        return result
+    def _coingecko_get(self, url: str, params: Dict[str, str], max_retries: int = 3) -> object:
+        """HTTP GET with retry + exponential backoff for CoinGecko rate limits."""
+        for attempt in range(max_retries):
+            try:
+                with httpx.Client(timeout=self._timeout) as client:
+                    resp = client.get(url, params=params)
+                    resp.raise_for_status()
+                    return resp.json()
+            except httpx.HTTPStatusError as exc:
+                if exc.response.status_code == 429 and attempt < max_retries - 1:
+                    wait = 2 ** (attempt + 1)
+                    logger.warning(
+                        "CoinGecko rate limited, retrying in %ds (attempt %d)", wait, attempt + 1
+                    )
+                    time.sleep(wait)
+                else:
+                    logger.error("CoinGecko request failed: %s", exc)
+                    return None
+            except Exception as exc:
+                logger.error("CoinGecko request failed: %s", exc)
+                return None
+        return None

--- a/backend/agents/investment_team/models.py
+++ b/backend/agents/investment_team/models.py
@@ -356,6 +356,65 @@ class StrategyLabRecord(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Paper Trading models
+# ---------------------------------------------------------------------------
+
+
+class PaperTradingStatus(str, Enum):
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class PaperTradingVerdict(str, Enum):
+    READY_FOR_LIVE = "ready_for_live"
+    NOT_PERFORMANT = "not_performant"
+
+
+class PaperTradingComparison(BaseModel):
+    """Side-by-side comparison of paper trading vs backtest metrics."""
+
+    backtest_win_rate_pct: float
+    paper_win_rate_pct: float
+    backtest_annualized_return_pct: float
+    paper_annualized_return_pct: float
+    backtest_sharpe_ratio: float
+    paper_sharpe_ratio: float
+    backtest_max_drawdown_pct: float
+    paper_max_drawdown_pct: float
+    backtest_profit_factor: float
+    paper_profit_factor: float
+    win_rate_aligned: bool
+    return_aligned: bool
+    sharpe_aligned: bool
+    drawdown_aligned: bool
+    overall_aligned: bool
+
+
+class PaperTradingSession(BaseModel):
+    """Full state of a paper trading session."""
+
+    session_id: str
+    lab_record_id: str
+    strategy: StrategySpec
+    status: PaperTradingStatus
+    initial_capital: float
+    current_capital: float
+    trades: List[TradeRecord] = Field(default_factory=list)
+    trade_decisions: List[Dict[str, Any]] = Field(default_factory=list)
+    result: Optional[BacktestResult] = None
+    comparison: Optional[PaperTradingComparison] = None
+    verdict: Optional[PaperTradingVerdict] = None
+    divergence_analysis: Optional[str] = None
+    symbols_traded: List[str] = Field(default_factory=list)
+    data_source: str = ""
+    data_period_start: str = ""
+    data_period_end: str = ""
+    started_at: str = ""
+    completed_at: str = ""
+
+
+# ---------------------------------------------------------------------------
 # Financial Advisor chatbot models
 # ---------------------------------------------------------------------------
 

--- a/backend/agents/investment_team/paper_trading_agent.py
+++ b/backend/agents/investment_team/paper_trading_agent.py
@@ -1,11 +1,14 @@
 """
 Paper Trading Agent — runs simulated live trading using LLM to interpret strategy rules against real market data.
+
+Delegates the bar-walking simulation to :class:`TradeSimulationEngine` and adds
+paper-trading-specific features: performance comparison, divergence analysis, and
+verdict generation.
 """
 
 from __future__ import annotations
 
 import logging
-import math
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
@@ -22,6 +25,12 @@ from .models import (
     PaperTradingVerdict,
     StrategySpec,
     TradeRecord,
+)
+from .trade_simulator import (
+    OpenPosition,
+    TradeSimulationEngine,
+    compute_metrics,
+    format_bars_table,
 )
 
 logger = logging.getLogger(__name__)
@@ -127,18 +136,6 @@ Return ONLY a JSON object with no markdown:
 """
 
 
-def _format_bars_table(bars: List[OHLCVBar]) -> str:
-    """Format a list of OHLCV bars as a compact text table."""
-    if not bars:
-        return "No data available."
-    lines = ["Date       | Open     | High     | Low      | Close    | Volume"]
-    for b in bars:
-        lines.append(
-            f"{b.date} | {b.open:<8.2f} | {b.high:<8.2f} | {b.low:<8.2f} | {b.close:<8.2f} | {b.volume:.0f}"
-        )
-    return "\n".join(lines)
-
-
 def _format_trades_table(trades: List[TradeRecord]) -> str:
     """Format trade records as a compact text table."""
     if not trades:
@@ -194,6 +191,9 @@ class PaperTradingAgent:
         asset = strategy.asset_class.lower()
         data_source = "coingecko" if asset == "crypto" else "yahoo_finance"
 
+        # Count total available bars to warn if min_trades may not be reachable
+        total_bars = sum(len(bars) for bars in market_data.values())
+
         session = PaperTradingSession(
             session_id=session_id,
             lab_record_id="",  # set by caller
@@ -208,170 +208,44 @@ class PaperTradingAgent:
             started_at=now,
         )
 
-        # Build a unified timeline: merge all symbols' bars sorted by date
-        timeline: List[tuple[str, str, OHLCVBar]] = []  # (date, symbol, bar)
-        for symbol, bars in market_data.items():
-            for bar in bars:
-                timeline.append((bar.date, symbol, bar))
-        timeline.sort(key=lambda x: x[0])
+        # Run simulation via shared engine
+        engine = TradeSimulationEngine(
+            initial_capital=initial_capital,
+            transaction_cost_bps=transaction_cost_bps,
+            slippage_bps=slippage_bps,
+        )
 
-        # Build per-symbol bar history for context lookups
-        symbol_history: Dict[str, List[OHLCVBar]] = {sym: [] for sym in market_data}
+        def evaluate(
+            symbol: str,
+            bar: OHLCVBar,
+            recent: List[OHLCVBar],
+            position: Optional[OpenPosition],
+            capital: float,
+        ) -> Dict[str, Any]:
+            return self._evaluate_bar(strategy, symbol, bar, recent, position, capital)
 
-        capital = initial_capital
-        open_positions: Dict[str, Dict[str, Any]] = {}  # symbol -> position info
-        trades: List[TradeRecord] = []
-        decisions: List[Dict[str, Any]] = []
-        cost_pct = transaction_cost_bps / 10_000.0
-        trade_num = 0
-        cumulative_pnl = 0.0
+        sim = engine.run(market_data, evaluate, max_trades=min_trades, record_decisions=True)
 
-        for bar_date, symbol, bar in timeline:
-            symbol_history[symbol].append(bar)
+        if total_bars > 0 and len(sim.trades) < min_trades:
+            logger.warning(
+                "Paper trading session completed with only %d/%d requested trades "
+                "(%d bars available across %d symbols).",
+                len(sim.trades),
+                min_trades,
+                total_bars,
+                len(market_data),
+            )
 
-            # Provide last 20 bars as context
-            recent = symbol_history[symbol][-20:]
-            has_position = symbol in open_positions
-
-            # Ask LLM to evaluate this bar
-            try:
-                decision = self._evaluate_bar(
-                    strategy=strategy,
-                    symbol=symbol,
-                    current_bar=bar,
-                    recent_bars=recent,
-                    open_position=open_positions.get(symbol),
-                    capital=capital,
-                )
-            except Exception as exc:
-                logger.warning("LLM evaluation failed for %s on %s: %s", symbol, bar_date, exc)
-                decision = {
-                    "action": "hold",
-                    "confidence": 0.0,
-                    "shares": 0,
-                    "reasoning": f"LLM error: {exc}",
-                }
-
-            decisions.append({"date": bar_date, "symbol": symbol, **decision})
-            action = decision.get("action", "hold")
-
-            if action in ("enter_long", "enter_short") and not has_position:
-                shares = float(decision.get("shares", 0))
-                if shares <= 0:
-                    # Default position sizing: 5-8% of capital
-                    position_pct = 0.06
-                    shares = round(capital * position_pct / bar.close, 4 if bar.close < 10 else 2)
-
-                if shares > 0 and capital >= shares * bar.close:
-                    # Apply slippage to entry: buy at slightly higher price
-                    slippage_mult = 1.0 + slippage_bps / 10_000.0
-                    entry_price = round(bar.close * slippage_mult, 4 if bar.close < 10 else 2)
-                    position_value = round(entry_price * shares, 2)
-                    capital -= position_value
-
-                    open_positions[symbol] = {
-                        "side": "long" if action == "enter_long" else "short",
-                        "entry_date": bar_date,
-                        "entry_price": entry_price,
-                        "shares": shares,
-                        "position_value": position_value,
-                    }
-
-            elif action == "exit" and has_position:
-                pos = open_positions.pop(symbol)
-                trade_num += 1
-
-                # Apply slippage to exit: sell at slightly lower price
-                slippage_mult = 1.0 - slippage_bps / 10_000.0
-                exit_price = round(bar.close * slippage_mult, 4 if bar.close < 10 else 2)
-
-                gross_pnl = round(pos["shares"] * (exit_price - pos["entry_price"]), 2)
-                if pos["side"] == "short":
-                    gross_pnl = -gross_pnl
-
-                tx_cost = round(pos["position_value"] * cost_pct * 2, 2)
-                net_pnl = round(gross_pnl - tx_cost, 2)
-                cumulative_pnl = round(cumulative_pnl + net_pnl, 2)
-                return_pct = round((exit_price - pos["entry_price"]) / pos["entry_price"] * 100, 3)
-                if pos["side"] == "short":
-                    return_pct = -return_pct
-
-                hold_days = self._date_diff_days(pos["entry_date"], bar_date)
-
-                capital += round(pos["shares"] * exit_price, 2)
-
-                trades.append(
-                    TradeRecord(
-                        trade_num=trade_num,
-                        entry_date=pos["entry_date"],
-                        exit_date=bar_date,
-                        symbol=symbol,
-                        side=pos["side"],
-                        entry_price=pos["entry_price"],
-                        exit_price=exit_price,
-                        shares=pos["shares"],
-                        position_value=pos["position_value"],
-                        gross_pnl=gross_pnl,
-                        net_pnl=net_pnl,
-                        return_pct=return_pct,
-                        hold_days=hold_days,
-                        outcome="win" if net_pnl > 0 else "loss",
-                        cumulative_pnl=cumulative_pnl,
-                    )
-                )
-
-            if len(trades) >= min_trades:
-                break
-
-        # Force-close any remaining open positions on the last available bar
-        for symbol, pos in list(open_positions.items()):
-            if symbol in symbol_history and symbol_history[symbol]:
-                last_bar = symbol_history[symbol][-1]
-                trade_num += 1
-                exit_price = round(
-                    last_bar.close * (1.0 - slippage_bps / 10_000.0),
-                    4 if last_bar.close < 10 else 2,
-                )
-                gross_pnl = round(pos["shares"] * (exit_price - pos["entry_price"]), 2)
-                if pos["side"] == "short":
-                    gross_pnl = -gross_pnl
-                tx_cost = round(pos["position_value"] * cost_pct * 2, 2)
-                net_pnl = round(gross_pnl - tx_cost, 2)
-                cumulative_pnl = round(cumulative_pnl + net_pnl, 2)
-                return_pct = round((exit_price - pos["entry_price"]) / pos["entry_price"] * 100, 3)
-                if pos["side"] == "short":
-                    return_pct = -return_pct
-                hold_days = self._date_diff_days(pos["entry_date"], last_bar.date)
-                capital += round(pos["shares"] * exit_price, 2)
-
-                trades.append(
-                    TradeRecord(
-                        trade_num=trade_num,
-                        entry_date=pos["entry_date"],
-                        exit_date=last_bar.date,
-                        symbol=symbol,
-                        side=pos["side"],
-                        entry_price=pos["entry_price"],
-                        exit_price=exit_price,
-                        shares=pos["shares"],
-                        position_value=pos["position_value"],
-                        gross_pnl=gross_pnl,
-                        net_pnl=net_pnl,
-                        return_pct=return_pct,
-                        hold_days=hold_days,
-                        outcome="win" if net_pnl > 0 else "loss",
-                        cumulative_pnl=cumulative_pnl,
-                    )
-                )
-
-        # Compute session metrics
-        session.trades = trades
-        session.trade_decisions = decisions
-        session.current_capital = capital
+        # Populate session from simulation result
+        session.trades = sim.trades
+        session.trade_decisions = sim.decisions
+        session.current_capital = sim.final_capital
         session.completed_at = datetime.now(tz=timezone.utc).isoformat()
 
-        if trades:
-            session.result = self._compute_session_metrics(trades, initial_capital)
+        if sim.trades:
+            first_date = sim.trades[0].entry_date
+            last_date = sim.trades[-1].exit_date
+            session.result = compute_metrics(sim.trades, initial_capital, first_date, last_date)
             session.comparison = self.compare_performance(session.result, backtest_record.result)
 
             if session.comparison.overall_aligned:
@@ -398,15 +272,15 @@ class PaperTradingAgent:
         symbol: str,
         current_bar: OHLCVBar,
         recent_bars: List[OHLCVBar],
-        open_position: Optional[Dict[str, Any]],
+        open_position: Optional[OpenPosition],
         capital: float,
     ) -> Dict[str, Any]:
         """Ask LLM to evaluate whether entry/exit rules are met for this bar."""
         if open_position:
             pos_status = (
-                f"OPEN {open_position['side'].upper()} position in {symbol}: "
-                f"{open_position['shares']} shares @ ${open_position['entry_price']:.2f} "
-                f"(entered {open_position['entry_date']})"
+                f"OPEN {open_position.side.upper()} position in {symbol}: "
+                f"{open_position.shares} shares @ ${open_position.entry_price:.2f} "
+                f"(entered {open_position.entry_date})"
             )
         else:
             pos_status = "No open position — looking for entry signals."
@@ -429,7 +303,7 @@ class PaperTradingAgent:
             close=current_bar.close,
             volume=current_bar.volume,
             n_bars=len(recent_bars),
-            recent_bars_text=_format_bars_table(recent_bars),
+            recent_bars_text=format_bars_table(recent_bars),
         )
 
         data = self.llm.complete_json(
@@ -445,84 +319,6 @@ class PaperTradingAgent:
             "shares": float(data.get("shares", 0)),
             "reasoning": str(data.get("reasoning", "")),
         }
-
-    @staticmethod
-    def _compute_session_metrics(
-        trades: List[TradeRecord], initial_capital: float
-    ) -> BacktestResult:
-        """Compute aggregate performance metrics from completed paper trades."""
-        if not trades:
-            return BacktestResult(
-                total_return_pct=0.0,
-                annualized_return_pct=0.0,
-                volatility_pct=0.0,
-                sharpe_ratio=0.0,
-                max_drawdown_pct=0.0,
-                win_rate_pct=0.0,
-                profit_factor=0.0,
-            )
-
-        wins = [t for t in trades if t.outcome == "win"]
-        losses = [t for t in trades if t.outcome == "loss"]
-
-        total_pnl = sum(t.net_pnl for t in trades)
-        total_return_pct = round(total_pnl / initial_capital * 100, 2)
-
-        # Estimate annualized return from total days spanned
-        first_date = trades[0].entry_date
-        last_date = trades[-1].exit_date
-        total_days = PaperTradingAgent._date_diff_days(first_date, last_date)
-        years = max(total_days / 365.25, 0.01)
-        annualized_return = round(total_return_pct / years, 2)
-
-        # Win rate
-        win_rate = round(len(wins) / len(trades) * 100, 2) if trades else 0.0
-
-        # Profit factor
-        gross_wins = sum(t.gross_pnl for t in wins) if wins else 0.0
-        gross_losses = abs(sum(t.gross_pnl for t in losses)) if losses else 0.0
-        profit_factor = (
-            round(gross_wins / gross_losses, 2)
-            if gross_losses > 0
-            else round(max(gross_wins, 0.0), 2)
-        )
-
-        # Volatility of returns
-        returns = [t.return_pct for t in trades]
-        if len(returns) > 1:
-            mean_ret = sum(returns) / len(returns)
-            variance = sum((r - mean_ret) ** 2 for r in returns) / (len(returns) - 1)
-            daily_vol = math.sqrt(variance)
-            annualized_vol = round(
-                daily_vol * math.sqrt(252 / max(years * 252 / len(trades), 1)), 2
-            )
-        else:
-            annualized_vol = 0.0
-
-        # Sharpe ratio
-        sharpe = round(annualized_return / annualized_vol, 2) if annualized_vol > 0 else 0.0
-
-        # Max drawdown
-        peak = initial_capital
-        max_dd = 0.0
-        equity = initial_capital
-        for t in trades:
-            equity += t.net_pnl
-            if equity > peak:
-                peak = equity
-            dd = (peak - equity) / peak * 100 if peak > 0 else 0.0
-            if dd > max_dd:
-                max_dd = dd
-
-        return BacktestResult(
-            total_return_pct=total_return_pct,
-            annualized_return_pct=annualized_return,
-            volatility_pct=annualized_vol,
-            sharpe_ratio=sharpe,
-            max_drawdown_pct=round(max_dd, 2),
-            win_rate_pct=win_rate,
-            profit_factor=profit_factor,
-        )
 
     @staticmethod
     def compare_performance(
@@ -621,15 +417,3 @@ class PaperTradingAgent:
             think=True,
         )
         return str(data.get("analysis", "Divergence analysis not available."))
-
-    @staticmethod
-    def _date_diff_days(d1: str, d2: str) -> int:
-        """Compute days between two ISO date strings."""
-        try:
-            from datetime import date as date_cls
-
-            dt1 = date_cls.fromisoformat(d1[:10])
-            dt2 = date_cls.fromisoformat(d2[:10])
-            return max(1, abs((dt2 - dt1).days))
-        except (ValueError, TypeError):
-            return 1

--- a/backend/agents/investment_team/paper_trading_agent.py
+++ b/backend/agents/investment_team/paper_trading_agent.py
@@ -1,0 +1,594 @@
+"""
+Paper Trading Agent — runs simulated live trading using LLM to interpret strategy rules against real market data.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional
+
+from llm_service.interface import LLMClient
+
+from .market_data_service import OHLCVBar
+from .models import (
+    BacktestRecord,
+    BacktestResult,
+    PaperTradingComparison,
+    PaperTradingSession,
+    PaperTradingStatus,
+    PaperTradingVerdict,
+    StrategySpec,
+    TradeRecord,
+)
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Prompts
+# ---------------------------------------------------------------------------
+
+_EVALUATE_SYSTEM = (
+    "You are an expert quantitative trader executing a swing trading strategy. "
+    "You evaluate daily price bars against the strategy's entry and exit rules to decide whether to trade. "
+    "Be disciplined — only trade when the rules are clearly met by the price data."
+)
+
+_EVALUATE_PROMPT = """\
+Evaluate whether the trading strategy's rules are triggered for this market data.
+
+## Strategy
+Asset class: {asset_class}
+Hypothesis: {hypothesis}
+Signal: {signal_definition}
+Entry rules: {entry_rules}
+Exit rules: {exit_rules}
+Sizing rules: {sizing_rules}
+Risk limits: {risk_limits}
+
+## Current Position
+{position_status}
+
+## Available Capital
+${capital:,.2f}
+
+## Current Bar ({symbol}, {current_date})
+Open: {open}  High: {high}  Low: {low}  Close: {close}  Volume: {volume}
+
+## Recent Price History ({symbol}, last {n_bars} bars)
+{recent_bars_text}
+
+## Instructions
+Based on the strategy rules and market data above, decide your action.
+If you have NO open position, evaluate ENTRY rules. If you HAVE an open position, evaluate EXIT rules.
+Be conservative — only enter when signals are clearly met, and respect risk limits.
+
+Return ONLY a JSON object with no markdown:
+{{"action": "enter_long" or "enter_short" or "exit" or "hold", "confidence": 0.0 to 1.0, \
+"shares": number_of_shares_or_0, "reasoning": "brief explanation"}}
+
+For "hold", set shares to 0. For entries, calculate shares based on sizing rules and available capital.
+For exits, set shares to 0 (will close full position).
+"""
+
+_DIVERGENCE_SYSTEM = (
+    "You are a quantitative trading analyst specializing in strategy validation. "
+    "You compare paper trading results against backtesting results to identify "
+    "why live-data performance diverges from historical simulations."
+)
+
+_DIVERGENCE_PROMPT = """\
+Analyze why this strategy's paper trading performance diverges from its backtest results.
+
+## Strategy
+Asset class: {asset_class}
+Hypothesis: {hypothesis}
+Signal: {signal_definition}
+Entry rules: {entry_rules}
+Exit rules: {exit_rules}
+
+## Backtest Results (historical simulation)
+Period: {bt_start} to {bt_end}
+Annualized return: {bt_annual_return:.1f}%
+Win rate: {bt_win_rate:.1f}%
+Sharpe ratio: {bt_sharpe:.2f}
+Max drawdown: {bt_max_dd:.1f}%
+Profit factor: {bt_profit_factor:.2f}
+Total trades: {bt_trade_count}
+
+## Paper Trading Results (real market data)
+Period: {pt_start} to {pt_end}
+Annualized return: {pt_annual_return:.1f}%
+Win rate: {pt_win_rate:.1f}%
+Sharpe ratio: {pt_sharpe:.2f}
+Max drawdown: {pt_max_dd:.1f}%
+Profit factor: {pt_profit_factor:.2f}
+Total trades: {pt_trade_count}
+
+## Backtest Trade Sample (first 10 trades)
+{bt_trades_text}
+
+## Paper Trading Trades (first 20 trades)
+{pt_trades_text}
+
+## Instructions
+Write a thorough analysis covering:
+1. **Metric Divergence**: Which metrics diverged most and by how much
+2. **Trade Pattern Analysis**: Compare entry/exit patterns between backtest and paper trading
+3. **Root Cause Hypotheses**: Why paper trading underperforms (overfitting, regime change, \
+lookahead bias, market microstructure, data quality differences, etc.)
+4. **Actionable Improvements**: Specific changes to strategy rules, signals, or risk management \
+that could improve future live-data performance
+
+Return ONLY a JSON object with no markdown:
+{{"analysis": "your full analysis here"}}
+"""
+
+
+def _format_bars_table(bars: List[OHLCVBar]) -> str:
+    """Format a list of OHLCV bars as a compact text table."""
+    if not bars:
+        return "No data available."
+    lines = ["Date       | Open     | High     | Low      | Close    | Volume"]
+    for b in bars:
+        lines.append(
+            f"{b.date} | {b.open:<8.2f} | {b.high:<8.2f} | {b.low:<8.2f} | {b.close:<8.2f} | {b.volume:.0f}"
+        )
+    return "\n".join(lines)
+
+
+def _format_trades_table(trades: List[TradeRecord]) -> str:
+    """Format trade records as a compact text table."""
+    if not trades:
+        return "No trades."
+    lines = [
+        "# | Symbol | Side | Entry Date | Exit Date  | Entry$   | Exit$    | Return%  | Outcome"
+    ]
+    for t in trades:
+        lines.append(
+            f"{t.trade_num} | {t.symbol} | {t.side} | {t.entry_date} | {t.exit_date} | "
+            f"{t.entry_price:<8.2f} | {t.exit_price:<8.2f} | {t.return_pct:+.2f}% | {t.outcome}"
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+
+class PaperTradingAgent:
+    """
+    Runs paper trading sessions by walking through real market data bar-by-bar,
+    using the LLM to interpret strategy entry/exit rules, and simulating trade execution.
+    """
+
+    def __init__(self, llm_client: LLMClient) -> None:
+        self.llm = llm_client
+
+    def run_session(
+        self,
+        strategy: StrategySpec,
+        backtest_record: BacktestRecord,
+        market_data: Dict[str, List[OHLCVBar]],
+        initial_capital: float = 100_000.0,
+        transaction_cost_bps: float = 5.0,
+        slippage_bps: float = 2.0,
+        min_trades: int = 50,
+    ) -> PaperTradingSession:
+        """Walk through market data bar-by-bar, making LLM-driven trade decisions."""
+        session_id = f"pt-{uuid.uuid4().hex[:8]}"
+        now = datetime.now(tz=timezone.utc).isoformat()
+
+        # Determine data period
+        all_dates: List[str] = []
+        for bars in market_data.values():
+            all_dates.extend(b.date for b in bars)
+        all_dates.sort()
+        data_start = all_dates[0] if all_dates else ""
+        data_end = all_dates[-1] if all_dates else ""
+
+        # Determine data source from asset class
+        asset = strategy.asset_class.lower()
+        data_source = "coingecko" if asset == "crypto" else "yahoo_finance"
+
+        session = PaperTradingSession(
+            session_id=session_id,
+            lab_record_id="",  # set by caller
+            strategy=strategy,
+            status=PaperTradingStatus.RUNNING,
+            initial_capital=initial_capital,
+            current_capital=initial_capital,
+            symbols_traded=list(market_data.keys()),
+            data_source=data_source,
+            data_period_start=data_start,
+            data_period_end=data_end,
+            started_at=now,
+        )
+
+        # Build a unified timeline: merge all symbols' bars sorted by date
+        timeline: List[tuple[str, str, OHLCVBar]] = []  # (date, symbol, bar)
+        for symbol, bars in market_data.items():
+            for bar in bars:
+                timeline.append((bar.date, symbol, bar))
+        timeline.sort(key=lambda x: x[0])
+
+        # Build per-symbol bar history for context lookups
+        symbol_history: Dict[str, List[OHLCVBar]] = {sym: [] for sym in market_data}
+
+        capital = initial_capital
+        open_positions: Dict[str, Dict[str, Any]] = {}  # symbol -> position info
+        trades: List[TradeRecord] = []
+        decisions: List[Dict[str, Any]] = []
+        cost_pct = (transaction_cost_bps + slippage_bps) / 10_000.0
+        trade_num = 0
+        cumulative_pnl = 0.0
+
+        for bar_date, symbol, bar in timeline:
+            symbol_history[symbol].append(bar)
+
+            # Provide last 20 bars as context
+            recent = symbol_history[symbol][-20:]
+            has_position = symbol in open_positions
+
+            # Ask LLM to evaluate this bar
+            try:
+                decision = self._evaluate_bar(
+                    strategy=strategy,
+                    symbol=symbol,
+                    current_bar=bar,
+                    recent_bars=recent,
+                    open_position=open_positions.get(symbol),
+                    capital=capital,
+                )
+            except Exception as exc:
+                logger.warning("LLM evaluation failed for %s on %s: %s", symbol, bar_date, exc)
+                decision = {
+                    "action": "hold",
+                    "confidence": 0.0,
+                    "shares": 0,
+                    "reasoning": f"LLM error: {exc}",
+                }
+
+            decisions.append({"date": bar_date, "symbol": symbol, **decision})
+            action = decision.get("action", "hold")
+
+            if action in ("enter_long", "enter_short") and not has_position:
+                shares = float(decision.get("shares", 0))
+                if shares <= 0:
+                    # Default position sizing: 5-8% of capital
+                    position_pct = 0.06
+                    shares = round(capital * position_pct / bar.close, 4 if bar.close < 10 else 2)
+
+                if shares > 0 and capital >= shares * bar.close:
+                    # Apply slippage to entry: buy at slightly higher price
+                    slippage_mult = 1.0 + slippage_bps / 10_000.0
+                    entry_price = round(bar.close * slippage_mult, 4 if bar.close < 10 else 2)
+                    position_value = round(entry_price * shares, 2)
+                    capital -= position_value
+
+                    open_positions[symbol] = {
+                        "side": "long" if action == "enter_long" else "short",
+                        "entry_date": bar_date,
+                        "entry_price": entry_price,
+                        "shares": shares,
+                        "position_value": position_value,
+                    }
+
+            elif action == "exit" and has_position:
+                pos = open_positions.pop(symbol)
+                trade_num += 1
+
+                # Apply slippage to exit: sell at slightly lower price
+                slippage_mult = 1.0 - slippage_bps / 10_000.0
+                exit_price = round(bar.close * slippage_mult, 4 if bar.close < 10 else 2)
+
+                gross_pnl = round(pos["shares"] * (exit_price - pos["entry_price"]), 2)
+                if pos["side"] == "short":
+                    gross_pnl = -gross_pnl
+
+                tx_cost = round(pos["position_value"] * cost_pct * 2, 2)
+                net_pnl = round(gross_pnl - tx_cost, 2)
+                cumulative_pnl = round(cumulative_pnl + net_pnl, 2)
+                return_pct = round((exit_price - pos["entry_price"]) / pos["entry_price"] * 100, 3)
+                if pos["side"] == "short":
+                    return_pct = -return_pct
+
+                hold_days = self._date_diff_days(pos["entry_date"], bar_date)
+
+                capital += round(pos["shares"] * exit_price, 2)
+
+                trades.append(
+                    TradeRecord(
+                        trade_num=trade_num,
+                        entry_date=pos["entry_date"],
+                        exit_date=bar_date,
+                        symbol=symbol,
+                        side=pos["side"],
+                        entry_price=pos["entry_price"],
+                        exit_price=exit_price,
+                        shares=pos["shares"],
+                        position_value=pos["position_value"],
+                        gross_pnl=gross_pnl,
+                        net_pnl=net_pnl,
+                        return_pct=return_pct,
+                        hold_days=hold_days,
+                        outcome="win" if net_pnl > 0 else "loss",
+                        cumulative_pnl=cumulative_pnl,
+                    )
+                )
+
+            if len(trades) >= min_trades:
+                break
+
+        # Compute session metrics
+        session.trades = trades
+        session.trade_decisions = decisions
+        session.current_capital = capital
+        session.completed_at = datetime.now(tz=timezone.utc).isoformat()
+
+        if trades:
+            session.result = self._compute_session_metrics(trades, initial_capital)
+            session.comparison = self.compare_performance(session.result, backtest_record.result)
+
+            if session.comparison.overall_aligned:
+                session.verdict = PaperTradingVerdict.READY_FOR_LIVE
+            else:
+                session.verdict = PaperTradingVerdict.NOT_PERFORMANT
+                try:
+                    session.divergence_analysis = self.analyze_divergence(session, backtest_record)
+                except Exception as exc:
+                    logger.warning("Divergence analysis failed: %s", exc)
+                    session.divergence_analysis = (
+                        f"Paper trading did not align with backtest expectations. "
+                        f"Paper win rate: {session.result.win_rate_pct:.1f}% vs "
+                        f"backtest: {backtest_record.result.win_rate_pct:.1f}%. "
+                        f"Automated analysis unavailable."
+                    )
+
+        session.status = PaperTradingStatus.COMPLETED
+        return session
+
+    def _evaluate_bar(
+        self,
+        strategy: StrategySpec,
+        symbol: str,
+        current_bar: OHLCVBar,
+        recent_bars: List[OHLCVBar],
+        open_position: Optional[Dict[str, Any]],
+        capital: float,
+    ) -> Dict[str, Any]:
+        """Ask LLM to evaluate whether entry/exit rules are met for this bar."""
+        if open_position:
+            pos_status = (
+                f"OPEN {open_position['side'].upper()} position in {symbol}: "
+                f"{open_position['shares']} shares @ ${open_position['entry_price']:.2f} "
+                f"(entered {open_position['entry_date']})"
+            )
+        else:
+            pos_status = "No open position — looking for entry signals."
+
+        prompt = _EVALUATE_PROMPT.format(
+            asset_class=strategy.asset_class,
+            hypothesis=strategy.hypothesis,
+            signal_definition=strategy.signal_definition,
+            entry_rules="; ".join(strategy.entry_rules),
+            exit_rules="; ".join(strategy.exit_rules),
+            sizing_rules="; ".join(strategy.sizing_rules),
+            risk_limits=strategy.risk_limits,
+            position_status=pos_status,
+            capital=capital,
+            symbol=symbol,
+            current_date=current_bar.date,
+            open=current_bar.open,
+            high=current_bar.high,
+            low=current_bar.low,
+            close=current_bar.close,
+            volume=current_bar.volume,
+            n_bars=len(recent_bars),
+            recent_bars_text=_format_bars_table(recent_bars),
+        )
+
+        data = self.llm.complete_json(
+            prompt,
+            temperature=0.2,
+            system_prompt=_EVALUATE_SYSTEM,
+            think=True,
+        )
+
+        return {
+            "action": str(data.get("action", "hold")),
+            "confidence": float(data.get("confidence", 0.0)),
+            "shares": float(data.get("shares", 0)),
+            "reasoning": str(data.get("reasoning", "")),
+        }
+
+    @staticmethod
+    def _compute_session_metrics(
+        trades: List[TradeRecord], initial_capital: float
+    ) -> BacktestResult:
+        """Compute aggregate performance metrics from completed paper trades."""
+        if not trades:
+            return BacktestResult(
+                total_return_pct=0.0,
+                annualized_return_pct=0.0,
+                volatility_pct=0.0,
+                sharpe_ratio=0.0,
+                max_drawdown_pct=0.0,
+                win_rate_pct=0.0,
+                profit_factor=0.0,
+            )
+
+        wins = [t for t in trades if t.outcome == "win"]
+        losses = [t for t in trades if t.outcome == "loss"]
+
+        total_pnl = sum(t.net_pnl for t in trades)
+        total_return_pct = round(total_pnl / initial_capital * 100, 2)
+
+        # Estimate annualized return from total days spanned
+        first_date = trades[0].entry_date
+        last_date = trades[-1].exit_date
+        total_days = PaperTradingAgent._date_diff_days(first_date, last_date)
+        years = max(total_days / 365.25, 0.01)
+        annualized_return = round(total_return_pct / years, 2)
+
+        # Win rate
+        win_rate = round(len(wins) / len(trades) * 100, 2) if trades else 0.0
+
+        # Profit factor
+        gross_wins = sum(t.gross_pnl for t in wins) if wins else 0.0
+        gross_losses = abs(sum(t.gross_pnl for t in losses)) if losses else 0.0
+        profit_factor = (
+            round(gross_wins / gross_losses, 2)
+            if gross_losses > 0
+            else round(max(gross_wins, 0.0), 2)
+        )
+
+        # Volatility of returns
+        returns = [t.return_pct for t in trades]
+        if len(returns) > 1:
+            mean_ret = sum(returns) / len(returns)
+            variance = sum((r - mean_ret) ** 2 for r in returns) / (len(returns) - 1)
+            daily_vol = math.sqrt(variance)
+            annualized_vol = round(
+                daily_vol * math.sqrt(252 / max(years * 252 / len(trades), 1)), 2
+            )
+        else:
+            annualized_vol = 0.0
+
+        # Sharpe ratio
+        sharpe = round(annualized_return / annualized_vol, 2) if annualized_vol > 0 else 0.0
+
+        # Max drawdown
+        peak = initial_capital
+        max_dd = 0.0
+        equity = initial_capital
+        for t in trades:
+            equity += t.net_pnl
+            if equity > peak:
+                peak = equity
+            dd = (peak - equity) / peak * 100 if peak > 0 else 0.0
+            if dd > max_dd:
+                max_dd = dd
+
+        return BacktestResult(
+            total_return_pct=total_return_pct,
+            annualized_return_pct=annualized_return,
+            volatility_pct=annualized_vol,
+            sharpe_ratio=sharpe,
+            max_drawdown_pct=round(max_dd, 2),
+            win_rate_pct=win_rate,
+            profit_factor=profit_factor,
+        )
+
+    @staticmethod
+    def compare_performance(
+        paper_result: BacktestResult,
+        backtest_result: BacktestResult,
+    ) -> PaperTradingComparison:
+        """Compare paper trading metrics against backtest expectations with tolerances."""
+        # Win rate: within ±10 percentage points
+        win_rate_aligned = abs(paper_result.win_rate_pct - backtest_result.win_rate_pct) <= 10.0
+
+        # Annualized return: within ±40% relative (or ±3pp absolute for small values)
+        bt_ret = backtest_result.annualized_return_pct
+        pt_ret = paper_result.annualized_return_pct
+        if abs(bt_ret) > 5.0:
+            return_aligned = abs(pt_ret - bt_ret) / abs(bt_ret) <= 0.40
+        else:
+            return_aligned = abs(pt_ret - bt_ret) <= 3.0
+
+        # Sharpe: within ±0.3
+        sharpe_aligned = abs(paper_result.sharpe_ratio - backtest_result.sharpe_ratio) <= 0.3
+
+        # Max drawdown: paper drawdown no more than 1.5x backtest drawdown
+        if backtest_result.max_drawdown_pct > 0:
+            drawdown_aligned = (
+                paper_result.max_drawdown_pct <= backtest_result.max_drawdown_pct * 1.5
+            )
+        else:
+            drawdown_aligned = paper_result.max_drawdown_pct <= 5.0
+
+        overall = win_rate_aligned and return_aligned and sharpe_aligned and drawdown_aligned
+
+        return PaperTradingComparison(
+            backtest_win_rate_pct=backtest_result.win_rate_pct,
+            paper_win_rate_pct=paper_result.win_rate_pct,
+            backtest_annualized_return_pct=backtest_result.annualized_return_pct,
+            paper_annualized_return_pct=paper_result.annualized_return_pct,
+            backtest_sharpe_ratio=backtest_result.sharpe_ratio,
+            paper_sharpe_ratio=paper_result.sharpe_ratio,
+            backtest_max_drawdown_pct=backtest_result.max_drawdown_pct,
+            paper_max_drawdown_pct=paper_result.max_drawdown_pct,
+            backtest_profit_factor=backtest_result.profit_factor,
+            paper_profit_factor=paper_result.profit_factor,
+            win_rate_aligned=win_rate_aligned,
+            return_aligned=return_aligned,
+            sharpe_aligned=sharpe_aligned,
+            drawdown_aligned=drawdown_aligned,
+            overall_aligned=overall,
+        )
+
+    def analyze_divergence(
+        self,
+        session: PaperTradingSession,
+        backtest_record: BacktestRecord,
+    ) -> str:
+        """LLM-driven analysis of why paper trading diverges from backtest results."""
+        strategy = session.strategy
+        bt = backtest_record.result
+        pt = session.result
+
+        if pt is None:
+            return "No paper trading results available for analysis."
+
+        bt_trades_sample = backtest_record.trades[:10]
+        pt_trades_sample = session.trades[:20]
+
+        prompt = _DIVERGENCE_PROMPT.format(
+            asset_class=strategy.asset_class,
+            hypothesis=strategy.hypothesis,
+            signal_definition=strategy.signal_definition,
+            entry_rules="; ".join(strategy.entry_rules),
+            exit_rules="; ".join(strategy.exit_rules),
+            bt_start=backtest_record.config.start_date,
+            bt_end=backtest_record.config.end_date,
+            bt_annual_return=bt.annualized_return_pct,
+            bt_win_rate=bt.win_rate_pct,
+            bt_sharpe=bt.sharpe_ratio,
+            bt_max_dd=bt.max_drawdown_pct,
+            bt_profit_factor=bt.profit_factor,
+            bt_trade_count=len(backtest_record.trades),
+            pt_start=session.data_period_start,
+            pt_end=session.data_period_end,
+            pt_annual_return=pt.annualized_return_pct,
+            pt_win_rate=pt.win_rate_pct,
+            pt_sharpe=pt.sharpe_ratio,
+            pt_max_dd=pt.max_drawdown_pct,
+            pt_profit_factor=pt.profit_factor,
+            pt_trade_count=len(session.trades),
+            bt_trades_text=_format_trades_table(bt_trades_sample),
+            pt_trades_text=_format_trades_table(pt_trades_sample),
+        )
+
+        data = self.llm.complete_json(
+            prompt,
+            temperature=0.3,
+            system_prompt=_DIVERGENCE_SYSTEM,
+            think=True,
+        )
+        return str(data.get("analysis", "Divergence analysis not available."))
+
+    @staticmethod
+    def _date_diff_days(d1: str, d2: str) -> int:
+        """Compute days between two ISO date strings."""
+        try:
+            from datetime import date as date_cls
+
+            dt1 = date_cls.fromisoformat(d1[:10])
+            dt2 = date_cls.fromisoformat(d2[:10])
+            return max(1, abs((dt2 - dt1).days))
+        except (ValueError, TypeError):
+            return 1

--- a/backend/agents/investment_team/paper_trading_agent.py
+++ b/backend/agents/investment_team/paper_trading_agent.py
@@ -222,7 +222,7 @@ class PaperTradingAgent:
         open_positions: Dict[str, Dict[str, Any]] = {}  # symbol -> position info
         trades: List[TradeRecord] = []
         decisions: List[Dict[str, Any]] = []
-        cost_pct = (transaction_cost_bps + slippage_bps) / 10_000.0
+        cost_pct = transaction_cost_bps / 10_000.0
         trade_num = 0
         cumulative_pnl = 0.0
 
@@ -322,6 +322,47 @@ class PaperTradingAgent:
 
             if len(trades) >= min_trades:
                 break
+
+        # Force-close any remaining open positions on the last available bar
+        for symbol, pos in list(open_positions.items()):
+            if symbol in symbol_history and symbol_history[symbol]:
+                last_bar = symbol_history[symbol][-1]
+                trade_num += 1
+                exit_price = round(
+                    last_bar.close * (1.0 - slippage_bps / 10_000.0),
+                    4 if last_bar.close < 10 else 2,
+                )
+                gross_pnl = round(pos["shares"] * (exit_price - pos["entry_price"]), 2)
+                if pos["side"] == "short":
+                    gross_pnl = -gross_pnl
+                tx_cost = round(pos["position_value"] * cost_pct * 2, 2)
+                net_pnl = round(gross_pnl - tx_cost, 2)
+                cumulative_pnl = round(cumulative_pnl + net_pnl, 2)
+                return_pct = round((exit_price - pos["entry_price"]) / pos["entry_price"] * 100, 3)
+                if pos["side"] == "short":
+                    return_pct = -return_pct
+                hold_days = self._date_diff_days(pos["entry_date"], last_bar.date)
+                capital += round(pos["shares"] * exit_price, 2)
+
+                trades.append(
+                    TradeRecord(
+                        trade_num=trade_num,
+                        entry_date=pos["entry_date"],
+                        exit_date=last_bar.date,
+                        symbol=symbol,
+                        side=pos["side"],
+                        entry_price=pos["entry_price"],
+                        exit_price=exit_price,
+                        shares=pos["shares"],
+                        position_value=pos["position_value"],
+                        gross_pnl=gross_pnl,
+                        net_pnl=net_pnl,
+                        return_pct=return_pct,
+                        hold_days=hold_days,
+                        outcome="win" if net_pnl > 0 else "loss",
+                        cumulative_pnl=cumulative_pnl,
+                    )
+                )
 
         # Compute session metrics
         session.trades = trades

--- a/backend/agents/investment_team/tests/test_investment_team.py
+++ b/backend/agents/investment_team/tests/test_investment_team.py
@@ -26,6 +26,7 @@ from agents.investment_team.models import (
     SavingsRate,
     StrategySpec,
     TaxProfile,
+    TradeRecord,
     UserGoal,
     UserPreferences,
     ValidationCheck,
@@ -570,3 +571,244 @@ def test_agent_catalog_includes_financial_advisor() -> None:
     from agents.investment_team.agent_catalog import CORE_AGENTS
 
     assert any(agent.name == "Financial Advisor Agent" for agent in CORE_AGENTS)
+
+
+# ---------------------------------------------------------------------------
+# Paper Trading tests
+# ---------------------------------------------------------------------------
+
+
+def test_paper_trading_session_model_creation() -> None:
+    from agents.investment_team.models import (
+        PaperTradingSession,
+        PaperTradingStatus,
+    )
+
+    session = PaperTradingSession(
+        session_id="pt-test-001",
+        lab_record_id="lab-abc123",
+        strategy=StrategySpec(
+            strategy_id="s-pt",
+            authored_by="test",
+            asset_class="stocks",
+            hypothesis="mean reversion",
+            signal_definition="RSI oversold bounce",
+        ),
+        status=PaperTradingStatus.COMPLETED,
+        initial_capital=100000.0,
+        current_capital=105000.0,
+        symbols_traded=["AAPL", "MSFT"],
+        data_source="yahoo_finance",
+        started_at="2026-01-01T00:00:00Z",
+        completed_at="2026-03-01T00:00:00Z",
+    )
+
+    assert session.session_id == "pt-test-001"
+    assert session.lab_record_id == "lab-abc123"
+    assert session.status == PaperTradingStatus.COMPLETED
+    assert session.initial_capital == 100000.0
+    assert len(session.symbols_traded) == 2
+
+
+def test_paper_trading_comparison_alignment_flags() -> None:
+    from agents.investment_team.models import PaperTradingComparison
+
+    # All aligned
+    comparison = PaperTradingComparison(
+        backtest_win_rate_pct=55.0,
+        paper_win_rate_pct=52.0,
+        backtest_annualized_return_pct=12.0,
+        paper_annualized_return_pct=10.0,
+        backtest_sharpe_ratio=0.8,
+        paper_sharpe_ratio=0.7,
+        backtest_max_drawdown_pct=15.0,
+        paper_max_drawdown_pct=18.0,
+        backtest_profit_factor=1.5,
+        paper_profit_factor=1.3,
+        win_rate_aligned=True,
+        return_aligned=True,
+        sharpe_aligned=True,
+        drawdown_aligned=True,
+        overall_aligned=True,
+    )
+
+    assert comparison.overall_aligned is True
+    assert comparison.win_rate_aligned is True
+
+
+def test_compute_session_metrics_from_trades() -> None:
+    from agents.investment_team.paper_trading_agent import PaperTradingAgent
+
+    trades = [
+        TradeRecord(
+            trade_num=1,
+            entry_date="2026-01-05",
+            exit_date="2026-01-12",
+            symbol="AAPL",
+            side="long",
+            entry_price=170.0,
+            exit_price=178.0,
+            shares=50,
+            position_value=8500.0,
+            gross_pnl=400.0,
+            net_pnl=390.0,
+            return_pct=4.71,
+            hold_days=7,
+            outcome="win",
+            cumulative_pnl=390.0,
+        ),
+        TradeRecord(
+            trade_num=2,
+            entry_date="2026-01-15",
+            exit_date="2026-01-22",
+            symbol="MSFT",
+            side="long",
+            entry_price=380.0,
+            exit_price=370.0,
+            shares=20,
+            position_value=7600.0,
+            gross_pnl=-200.0,
+            net_pnl=-210.0,
+            return_pct=-2.63,
+            hold_days=7,
+            outcome="loss",
+            cumulative_pnl=180.0,
+        ),
+        TradeRecord(
+            trade_num=3,
+            entry_date="2026-01-25",
+            exit_date="2026-02-01",
+            symbol="AAPL",
+            side="long",
+            entry_price=175.0,
+            exit_price=182.0,
+            shares=50,
+            position_value=8750.0,
+            gross_pnl=350.0,
+            net_pnl=340.0,
+            return_pct=4.0,
+            hold_days=7,
+            outcome="win",
+            cumulative_pnl=520.0,
+        ),
+    ]
+
+    result = PaperTradingAgent._compute_session_metrics(trades, initial_capital=100000.0)
+
+    assert result.win_rate_pct == pytest.approx(66.67, abs=0.1)
+    assert result.total_return_pct == pytest.approx(0.52, abs=0.01)
+    assert result.profit_factor > 1.0
+    assert result.max_drawdown_pct >= 0.0
+
+
+def test_compare_performance_aligned() -> None:
+    from agents.investment_team.paper_trading_agent import PaperTradingAgent
+
+    backtest = BacktestResult(
+        total_return_pct=25.0,
+        annualized_return_pct=10.0,
+        volatility_pct=14.0,
+        sharpe_ratio=0.71,
+        max_drawdown_pct=12.0,
+        win_rate_pct=55.0,
+        profit_factor=1.4,
+    )
+    paper = BacktestResult(
+        total_return_pct=22.0,
+        annualized_return_pct=9.0,
+        volatility_pct=13.0,
+        sharpe_ratio=0.69,
+        max_drawdown_pct=14.0,
+        win_rate_pct=53.0,
+        profit_factor=1.3,
+    )
+
+    comparison = PaperTradingAgent.compare_performance(paper, backtest)
+
+    assert comparison.overall_aligned is True
+    assert comparison.win_rate_aligned is True
+    assert comparison.return_aligned is True
+    assert comparison.sharpe_aligned is True
+    assert comparison.drawdown_aligned is True
+
+
+def test_compare_performance_divergent() -> None:
+    from agents.investment_team.paper_trading_agent import PaperTradingAgent
+
+    backtest = BacktestResult(
+        total_return_pct=25.0,
+        annualized_return_pct=10.0,
+        volatility_pct=14.0,
+        sharpe_ratio=0.71,
+        max_drawdown_pct=12.0,
+        win_rate_pct=55.0,
+        profit_factor=1.4,
+    )
+    paper = BacktestResult(
+        total_return_pct=5.0,
+        annualized_return_pct=2.0,
+        volatility_pct=20.0,
+        sharpe_ratio=0.10,
+        max_drawdown_pct=30.0,
+        win_rate_pct=38.0,
+        profit_factor=0.8,
+    )
+
+    comparison = PaperTradingAgent.compare_performance(paper, backtest)
+
+    assert comparison.overall_aligned is False
+    assert comparison.win_rate_aligned is False
+    assert comparison.return_aligned is False
+
+
+def test_market_data_service_get_symbols_for_strategy() -> None:
+    from agents.investment_team.market_data_service import MarketDataService
+
+    service = MarketDataService()
+
+    stock_strategy = StrategySpec(
+        strategy_id="s1",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="h",
+        signal_definition="s",
+    )
+    symbols = service.get_symbols_for_strategy(stock_strategy)
+    assert "AAPL" in symbols
+    assert "BTC" not in symbols
+
+    crypto_strategy = StrategySpec(
+        strategy_id="s2",
+        authored_by="test",
+        asset_class="crypto",
+        hypothesis="h",
+        signal_definition="s",
+    )
+    symbols = service.get_symbols_for_strategy(crypto_strategy)
+    assert "BTC" in symbols
+    assert "AAPL" not in symbols
+
+
+def test_paper_trading_date_diff() -> None:
+    from agents.investment_team.paper_trading_agent import PaperTradingAgent
+
+    assert PaperTradingAgent._date_diff_days("2026-01-01", "2026-01-08") == 7
+    assert PaperTradingAgent._date_diff_days("2026-01-01", "2026-01-01") == 1
+    assert PaperTradingAgent._date_diff_days("invalid", "invalid") == 1
+
+
+def test_paper_trading_verdict_enum_values() -> None:
+    from agents.investment_team.models import PaperTradingVerdict
+
+    assert PaperTradingVerdict.READY_FOR_LIVE.value == "ready_for_live"
+    assert PaperTradingVerdict.NOT_PERFORMANT.value == "not_performant"
+
+
+def test_compute_session_metrics_empty_trades() -> None:
+    from agents.investment_team.paper_trading_agent import PaperTradingAgent
+
+    result = PaperTradingAgent._compute_session_metrics([], initial_capital=100000.0)
+
+    assert result.total_return_pct == 0.0
+    assert result.win_rate_pct == 0.0
+    assert result.sharpe_ratio == 0.0

--- a/backend/agents/investment_team/tests/test_investment_team.py
+++ b/backend/agents/investment_team/tests/test_investment_team.py
@@ -574,70 +574,21 @@ def test_agent_catalog_includes_financial_advisor() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Paper Trading tests
+# Trade Simulator (shared engine) tests
 # ---------------------------------------------------------------------------
 
 
-def test_paper_trading_session_model_creation() -> None:
-    from agents.investment_team.models import (
-        PaperTradingSession,
-        PaperTradingStatus,
-    )
+def test_date_diff_days() -> None:
+    from agents.investment_team.trade_simulator import date_diff_days
 
-    session = PaperTradingSession(
-        session_id="pt-test-001",
-        lab_record_id="lab-abc123",
-        strategy=StrategySpec(
-            strategy_id="s-pt",
-            authored_by="test",
-            asset_class="stocks",
-            hypothesis="mean reversion",
-            signal_definition="RSI oversold bounce",
-        ),
-        status=PaperTradingStatus.COMPLETED,
-        initial_capital=100000.0,
-        current_capital=105000.0,
-        symbols_traded=["AAPL", "MSFT"],
-        data_source="yahoo_finance",
-        started_at="2026-01-01T00:00:00Z",
-        completed_at="2026-03-01T00:00:00Z",
-    )
-
-    assert session.session_id == "pt-test-001"
-    assert session.lab_record_id == "lab-abc123"
-    assert session.status == PaperTradingStatus.COMPLETED
-    assert session.initial_capital == 100000.0
-    assert len(session.symbols_traded) == 2
+    assert date_diff_days("2023-01-01", "2023-12-31") == 364
+    assert date_diff_days("2026-01-01", "2026-01-08") == 7
+    assert date_diff_days("2026-01-01", "2026-01-01") == 1
+    assert date_diff_days("invalid", "invalid") == 1
 
 
-def test_paper_trading_comparison_alignment_flags() -> None:
-    from agents.investment_team.models import PaperTradingComparison
-
-    # All aligned
-    comparison = PaperTradingComparison(
-        backtest_win_rate_pct=55.0,
-        paper_win_rate_pct=52.0,
-        backtest_annualized_return_pct=12.0,
-        paper_annualized_return_pct=10.0,
-        backtest_sharpe_ratio=0.8,
-        paper_sharpe_ratio=0.7,
-        backtest_max_drawdown_pct=15.0,
-        paper_max_drawdown_pct=18.0,
-        backtest_profit_factor=1.5,
-        paper_profit_factor=1.3,
-        win_rate_aligned=True,
-        return_aligned=True,
-        sharpe_aligned=True,
-        drawdown_aligned=True,
-        overall_aligned=True,
-    )
-
-    assert comparison.overall_aligned is True
-    assert comparison.win_rate_aligned is True
-
-
-def test_compute_session_metrics_from_trades() -> None:
-    from agents.investment_team.paper_trading_agent import PaperTradingAgent
+def test_compute_metrics_from_trades() -> None:
+    from agents.investment_team.trade_simulator import compute_metrics
 
     trades = [
         TradeRecord(
@@ -693,12 +644,251 @@ def test_compute_session_metrics_from_trades() -> None:
         ),
     ]
 
-    result = PaperTradingAgent._compute_session_metrics(trades, initial_capital=100000.0)
+    result = compute_metrics(trades, 100000.0, "2026-01-05", "2026-02-01")
 
     assert result.win_rate_pct == pytest.approx(66.67, abs=0.1)
     assert result.total_return_pct == pytest.approx(0.52, abs=0.01)
     assert result.profit_factor > 1.0
     assert result.max_drawdown_pct >= 0.0
+
+
+def test_compute_metrics_empty_trades() -> None:
+    from agents.investment_team.trade_simulator import compute_metrics
+
+    result = compute_metrics([], 100000.0, "2023-01-01", "2023-12-31")
+
+    assert result.total_return_pct == 0.0
+    assert result.win_rate_pct == 0.0
+    assert result.sharpe_ratio == 0.0
+
+
+def test_compute_metrics_uses_cagr() -> None:
+    """Verify annualized return uses CAGR, not linear scaling."""
+    from agents.investment_team.trade_simulator import compute_metrics
+
+    # 25% total return over 2.5 years → CAGR ≈ 9.54%, not 10%
+    trades = [
+        TradeRecord(
+            trade_num=1,
+            entry_date="2021-01-01",
+            exit_date="2023-07-01",
+            symbol="SPY",
+            side="long",
+            entry_price=100.0,
+            exit_price=125.0,
+            shares=1000,
+            position_value=100000.0,
+            gross_pnl=25000.0,
+            net_pnl=25000.0,
+            return_pct=25.0,
+            hold_days=912,
+            outcome="win",
+            cumulative_pnl=25000.0,
+        ),
+    ]
+
+    result = compute_metrics(trades, 100000.0, "2021-01-01", "2023-07-01")
+
+    # CAGR for 25% over ~2.5 years should be ~9.5%, NOT 10%
+    assert result.annualized_return_pct < 10.0
+    assert result.annualized_return_pct > 9.0
+
+
+# ---------------------------------------------------------------------------
+# Trade Simulation Engine tests
+# ---------------------------------------------------------------------------
+
+
+def test_simulation_engine_force_closes_open_positions() -> None:
+    """Verify the engine force-closes positions when data runs out."""
+    from agents.investment_team.market_data_service import OHLCVBar
+    from agents.investment_team.trade_simulator import TradeSimulationEngine
+
+    bars = [
+        OHLCVBar(date="2023-01-01", open=100.0, high=105.0, low=99.0, close=103.0, volume=1e6),
+        OHLCVBar(date="2023-01-02", open=103.0, high=108.0, low=102.0, close=106.0, volume=1e6),
+        OHLCVBar(date="2023-01-03", open=106.0, high=110.0, low=104.0, close=108.0, volume=1e6),
+    ]
+    market_data = {"TEST": bars}
+
+    call_count = 0
+
+    def fake_evaluate(symbol, bar, recent, position, capital):
+        nonlocal call_count
+        call_count += 1
+        # Enter on first bar, never exit
+        if position is None and call_count == 1:
+            return {"action": "enter_long", "confidence": 0.8, "shares": 10, "reasoning": "test"}
+        return {"action": "hold", "confidence": 0.5, "shares": 0, "reasoning": "hold"}
+
+    engine = TradeSimulationEngine(
+        initial_capital=100_000.0,
+        transaction_cost_bps=5.0,
+        slippage_bps=2.0,
+        min_history_bars=1,
+        pre_filter_pct=0.0,  # disable pre-filter for deterministic test
+    )
+    result = engine.run(market_data, fake_evaluate)
+
+    assert result.forced_close_count == 1
+    assert len(result.trades) == 1
+    assert result.trades[0].exit_date == "2023-01-03"
+    assert result.trades[0].symbol == "TEST"
+
+
+def test_simulation_engine_respects_max_trades() -> None:
+    """Verify the engine stops after max_trades completed trades."""
+    from agents.investment_team.market_data_service import OHLCVBar
+    from agents.investment_team.trade_simulator import TradeSimulationEngine
+
+    # Generate enough bars for several trades
+    bars = []
+    for i in range(20):
+        price = 100.0 + i * 0.5
+        bars.append(
+            OHLCVBar(
+                date=f"2023-01-{i + 1:02d}",
+                open=price,
+                high=price + 2,
+                low=price - 1,
+                close=price + 1,
+                volume=1e6,
+            )
+        )
+
+    call_count = 0
+
+    def fake_evaluate(symbol, bar, recent, position, capital):
+        nonlocal call_count
+        call_count += 1
+        # Alternate: enter then exit
+        if position is None:
+            return {"action": "enter_long", "confidence": 0.8, "shares": 5, "reasoning": "enter"}
+        return {"action": "exit", "confidence": 0.8, "shares": 0, "reasoning": "exit"}
+
+    engine = TradeSimulationEngine(
+        initial_capital=100_000.0, min_history_bars=1, pre_filter_pct=0.0
+    )
+    result = engine.run({"SYM": bars}, fake_evaluate, max_trades=3)
+
+    assert len(result.trades) == 3
+
+
+def test_simulation_engine_respects_max_evaluations() -> None:
+    """Verify the engine stops after max_evaluations LLM calls."""
+    from agents.investment_team.market_data_service import OHLCVBar
+    from agents.investment_team.trade_simulator import TradeSimulationEngine
+
+    bars = [
+        OHLCVBar(
+            date=f"2023-01-{i + 1:02d}", open=100.0, high=105.0, low=95.0, close=100.0, volume=1e6
+        )
+        for i in range(50)
+    ]
+
+    def fake_evaluate(symbol, bar, recent, position, capital):
+        return {"action": "hold", "confidence": 0.0, "shares": 0, "reasoning": "hold"}
+
+    engine = TradeSimulationEngine(
+        initial_capital=100_000.0,
+        min_history_bars=1,
+        pre_filter_pct=0.0,
+        max_evaluations=10,
+    )
+    result = engine.run({"SYM": bars}, fake_evaluate)
+
+    assert result.evaluations_performed == 10
+
+
+def test_simulation_engine_pre_filter_skips_quiet_bars() -> None:
+    """Verify pre-filter skips bars when price hasn't moved significantly."""
+    from agents.investment_team.market_data_service import OHLCVBar
+    from agents.investment_team.trade_simulator import TradeSimulationEngine
+
+    # All bars at exactly the same price — no movement
+    bars = [
+        OHLCVBar(
+            date=f"2023-01-{i + 1:02d}", open=100.0, high=100.0, low=100.0, close=100.0, volume=1e6
+        )
+        for i in range(20)
+    ]
+
+    eval_count = 0
+
+    def fake_evaluate(symbol, bar, recent, position, capital):
+        nonlocal eval_count
+        eval_count += 1
+        return {"action": "hold", "confidence": 0.0, "shares": 0, "reasoning": "hold"}
+
+    engine = TradeSimulationEngine(
+        initial_capital=100_000.0,
+        min_history_bars=5,
+        pre_filter_pct=1.0,  # require 1% move
+    )
+    result = engine.run({"SYM": bars}, fake_evaluate)
+
+    # All bars are flat, so all should be skipped after the warm-up period
+    assert result.bars_skipped_by_filter > 0
+    assert eval_count == 0
+
+
+def test_simulation_engine_records_decisions() -> None:
+    """Verify decisions are recorded when record_decisions=True."""
+    from agents.investment_team.market_data_service import OHLCVBar
+    from agents.investment_team.trade_simulator import TradeSimulationEngine
+
+    bars = [
+        OHLCVBar(date="2023-01-10", open=100.0, high=120.0, low=80.0, close=110.0, volume=1e6),
+    ]
+
+    def fake_evaluate(symbol, bar, recent, position, capital):
+        return {"action": "hold", "confidence": 0.5, "shares": 0, "reasoning": "test"}
+
+    engine = TradeSimulationEngine(min_history_bars=1, pre_filter_pct=0.0)
+    result = engine.run({"A": bars}, fake_evaluate, record_decisions=True)
+
+    assert len(result.decisions) == 1
+    assert result.decisions[0]["symbol"] == "A"
+
+    result_no_record = engine.run({"A": bars}, fake_evaluate, record_decisions=False)
+    assert len(result_no_record.decisions) == 0
+
+
+# ---------------------------------------------------------------------------
+# Paper Trading tests
+# ---------------------------------------------------------------------------
+
+
+def test_paper_trading_session_model_creation() -> None:
+    from agents.investment_team.models import (
+        PaperTradingSession,
+        PaperTradingStatus,
+    )
+
+    session = PaperTradingSession(
+        session_id="pt-test-001",
+        lab_record_id="lab-abc123",
+        strategy=StrategySpec(
+            strategy_id="s-pt",
+            authored_by="test",
+            asset_class="stocks",
+            hypothesis="mean reversion",
+            signal_definition="RSI oversold bounce",
+        ),
+        status=PaperTradingStatus.COMPLETED,
+        initial_capital=100000.0,
+        current_capital=105000.0,
+        symbols_traded=["AAPL", "MSFT"],
+        data_source="yahoo_finance",
+        started_at="2026-01-01T00:00:00Z",
+        completed_at="2026-03-01T00:00:00Z",
+    )
+
+    assert session.session_id == "pt-test-001"
+    assert session.lab_record_id == "lab-abc123"
+    assert session.status == PaperTradingStatus.COMPLETED
+    assert session.initial_capital == 100000.0
+    assert len(session.symbols_traded) == 2
 
 
 def test_compare_performance_aligned() -> None:
@@ -761,6 +951,86 @@ def test_compare_performance_divergent() -> None:
     assert comparison.return_aligned is False
 
 
+def test_compare_performance_zero_backtest_drawdown() -> None:
+    """When backtest drawdown is 0, paper drawdown up to 5% is aligned."""
+    from agents.investment_team.paper_trading_agent import PaperTradingAgent
+
+    backtest = BacktestResult(
+        total_return_pct=10.0,
+        annualized_return_pct=10.0,
+        volatility_pct=5.0,
+        sharpe_ratio=2.0,
+        max_drawdown_pct=0.0,
+        win_rate_pct=100.0,
+        profit_factor=100.0,
+    )
+    paper = BacktestResult(
+        total_return_pct=9.0,
+        annualized_return_pct=9.0,
+        volatility_pct=6.0,
+        sharpe_ratio=1.8,
+        max_drawdown_pct=4.0,
+        win_rate_pct=95.0,
+        profit_factor=90.0,
+    )
+
+    comparison = PaperTradingAgent.compare_performance(paper, backtest)
+    assert comparison.drawdown_aligned is True
+
+    # Paper drawdown > 5% when backtest is 0 → not aligned
+    paper_bad = BacktestResult(
+        total_return_pct=9.0,
+        annualized_return_pct=9.0,
+        volatility_pct=6.0,
+        sharpe_ratio=1.8,
+        max_drawdown_pct=6.0,
+        win_rate_pct=95.0,
+        profit_factor=90.0,
+    )
+    comparison_bad = PaperTradingAgent.compare_performance(paper_bad, backtest)
+    assert comparison_bad.drawdown_aligned is False
+
+
+def test_compare_performance_small_return_uses_absolute_tolerance() -> None:
+    """When backtest return is ≤5%, use ±3pp absolute tolerance."""
+    from agents.investment_team.paper_trading_agent import PaperTradingAgent
+
+    backtest = BacktestResult(
+        total_return_pct=12.0,
+        annualized_return_pct=5.0,
+        volatility_pct=10.0,
+        sharpe_ratio=0.5,
+        max_drawdown_pct=10.0,
+        win_rate_pct=55.0,
+        profit_factor=1.2,
+    )
+    paper = BacktestResult(
+        total_return_pct=7.0,
+        annualized_return_pct=2.5,
+        volatility_pct=11.0,
+        sharpe_ratio=0.23,
+        max_drawdown_pct=12.0,
+        win_rate_pct=52.0,
+        profit_factor=1.1,
+    )
+
+    comparison = PaperTradingAgent.compare_performance(paper, backtest)
+    # |2.5 - 5.0| = 2.5 < 3.0 → aligned
+    assert comparison.return_aligned is True
+
+
+def test_paper_trading_verdict_enum_values() -> None:
+    from agents.investment_team.models import PaperTradingVerdict
+
+    assert PaperTradingVerdict.READY_FOR_LIVE.value == "ready_for_live"
+    assert PaperTradingVerdict.NOT_PERFORMANT.value == "not_performant"
+
+
+# ---------------------------------------------------------------------------
+# Market Data Service tests
+# ---------------------------------------------------------------------------
+
+
 def test_market_data_service_get_symbols_for_strategy() -> None:
     from agents.investment_team.market_data_service import MarketDataService
 
@@ -789,100 +1059,49 @@ def test_market_data_service_get_symbols_for_strategy() -> None:
     assert "AAPL" not in symbols
 
 
-def test_paper_trading_date_diff() -> None:
-    from agents.investment_team.paper_trading_agent import PaperTradingAgent
+def test_market_data_service_get_symbols_for_forex() -> None:
+    from agents.investment_team.market_data_service import MarketDataService
 
-    assert PaperTradingAgent._date_diff_days("2026-01-01", "2026-01-08") == 7
-    assert PaperTradingAgent._date_diff_days("2026-01-01", "2026-01-01") == 1
-    assert PaperTradingAgent._date_diff_days("invalid", "invalid") == 1
-
-
-def test_paper_trading_verdict_enum_values() -> None:
-    from agents.investment_team.models import PaperTradingVerdict
-
-    assert PaperTradingVerdict.READY_FOR_LIVE.value == "ready_for_live"
-    assert PaperTradingVerdict.NOT_PERFORMANT.value == "not_performant"
-
-
-def test_compute_session_metrics_empty_trades() -> None:
-    from agents.investment_team.paper_trading_agent import PaperTradingAgent
-
-    result = PaperTradingAgent._compute_session_metrics([], initial_capital=100000.0)
-
-    assert result.total_return_pct == 0.0
-    assert result.win_rate_pct == 0.0
-    assert result.sharpe_ratio == 0.0
+    service = MarketDataService()
+    strategy = StrategySpec(
+        strategy_id="s-fx",
+        authored_by="test",
+        asset_class="forex",
+        hypothesis="h",
+        signal_definition="s",
+    )
+    symbols = service.get_symbols_for_strategy(strategy)
+    assert any("=X" in s for s in symbols)
 
 
-# ---------------------------------------------------------------------------
-# Backtesting Agent tests (real data backtesting)
-# ---------------------------------------------------------------------------
+def test_market_data_service_get_symbols_for_futures() -> None:
+    from agents.investment_team.market_data_service import MarketDataService
+
+    service = MarketDataService()
+    strategy = StrategySpec(
+        strategy_id="s-fut",
+        authored_by="test",
+        asset_class="futures",
+        hypothesis="h",
+        signal_definition="s",
+    )
+    symbols = service.get_symbols_for_strategy(strategy)
+    assert any("=F" in s for s in symbols)
 
 
-def test_backtesting_agent_compute_metrics_from_trades() -> None:
-    from agents.investment_team.backtesting_agent import BacktestingAgent
+def test_market_data_service_get_symbols_for_commodities() -> None:
+    from agents.investment_team.market_data_service import MarketDataService
 
-    trades = [
-        TradeRecord(
-            trade_num=1,
-            entry_date="2023-03-01",
-            exit_date="2023-03-08",
-            symbol="AAPL",
-            side="long",
-            entry_price=150.0,
-            exit_price=157.5,
-            shares=40,
-            position_value=6000.0,
-            gross_pnl=300.0,
-            net_pnl=290.0,
-            return_pct=5.0,
-            hold_days=7,
-            outcome="win",
-            cumulative_pnl=290.0,
-        ),
-        TradeRecord(
-            trade_num=2,
-            entry_date="2023-03-15",
-            exit_date="2023-03-22",
-            symbol="MSFT",
-            side="long",
-            entry_price=280.0,
-            exit_price=272.0,
-            shares=20,
-            position_value=5600.0,
-            gross_pnl=-160.0,
-            net_pnl=-170.0,
-            return_pct=-2.86,
-            hold_days=7,
-            outcome="loss",
-            cumulative_pnl=120.0,
-        ),
-    ]
-
-    result = BacktestingAgent._compute_metrics(trades, 100000.0, "2023-01-01", "2023-12-31")
-
-    assert result.win_rate_pct == 50.0
-    assert result.total_return_pct == pytest.approx(0.12, abs=0.01)
-    assert result.profit_factor > 1.0
-    assert result.max_drawdown_pct >= 0.0
-
-
-def test_backtesting_agent_compute_metrics_empty() -> None:
-    from agents.investment_team.backtesting_agent import BacktestingAgent
-
-    result = BacktestingAgent._compute_metrics([], 100000.0, "2023-01-01", "2023-12-31")
-
-    assert result.total_return_pct == 0.0
-    assert result.win_rate_pct == 0.0
-    assert result.sharpe_ratio == 0.0
-
-
-def test_backtesting_agent_date_diff() -> None:
-    from agents.investment_team.backtesting_agent import BacktestingAgent
-
-    assert BacktestingAgent._date_diff_days("2023-01-01", "2023-12-31") == 364
-    assert BacktestingAgent._date_diff_days("2023-01-01", "2023-01-01") == 1
-    assert BacktestingAgent._date_diff_days("bad", "date") == 1
+    service = MarketDataService()
+    strategy = StrategySpec(
+        strategy_id="s-com",
+        authored_by="test",
+        asset_class="commodities",
+        hypothesis="h",
+        signal_definition="s",
+    )
+    symbols = service.get_symbols_for_strategy(strategy)
+    assert "GLD" in symbols
 
 
 def test_market_data_service_fetch_ohlcv_range_routes_by_asset_class() -> None:
@@ -900,6 +1119,11 @@ def test_market_data_service_fetch_ohlcv_range_routes_by_asset_class() -> None:
     with patch.object(service, "_fetch_crypto", return_value=[]) as mock_crypto:
         service.fetch_ohlcv_range("BTC", "crypto", "2023-01-01", "2023-12-31")
         mock_crypto.assert_called_once_with("BTC", "2023-01-01", "2023-12-31")
+
+    # Forex routes through _fetch_stock (yfinance)
+    with patch.object(service, "_fetch_stock", return_value=[]) as mock_stock:
+        service.fetch_ohlcv_range("EURUSD=X", "forex", "2023-01-01", "2023-12-31")
+        mock_stock.assert_called_once_with("EURUSD=X", "2023-01-01", "2023-12-31")
 
 
 def test_market_data_service_fetch_multi_symbol_range() -> None:

--- a/backend/agents/investment_team/tests/test_investment_team.py
+++ b/backend/agents/investment_team/tests/test_investment_team.py
@@ -812,3 +812,112 @@ def test_compute_session_metrics_empty_trades() -> None:
     assert result.total_return_pct == 0.0
     assert result.win_rate_pct == 0.0
     assert result.sharpe_ratio == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Backtesting Agent tests (real data backtesting)
+# ---------------------------------------------------------------------------
+
+
+def test_backtesting_agent_compute_metrics_from_trades() -> None:
+    from agents.investment_team.backtesting_agent import BacktestingAgent
+
+    trades = [
+        TradeRecord(
+            trade_num=1,
+            entry_date="2023-03-01",
+            exit_date="2023-03-08",
+            symbol="AAPL",
+            side="long",
+            entry_price=150.0,
+            exit_price=157.5,
+            shares=40,
+            position_value=6000.0,
+            gross_pnl=300.0,
+            net_pnl=290.0,
+            return_pct=5.0,
+            hold_days=7,
+            outcome="win",
+            cumulative_pnl=290.0,
+        ),
+        TradeRecord(
+            trade_num=2,
+            entry_date="2023-03-15",
+            exit_date="2023-03-22",
+            symbol="MSFT",
+            side="long",
+            entry_price=280.0,
+            exit_price=272.0,
+            shares=20,
+            position_value=5600.0,
+            gross_pnl=-160.0,
+            net_pnl=-170.0,
+            return_pct=-2.86,
+            hold_days=7,
+            outcome="loss",
+            cumulative_pnl=120.0,
+        ),
+    ]
+
+    result = BacktestingAgent._compute_metrics(trades, 100000.0, "2023-01-01", "2023-12-31")
+
+    assert result.win_rate_pct == 50.0
+    assert result.total_return_pct == pytest.approx(0.12, abs=0.01)
+    assert result.profit_factor > 1.0
+    assert result.max_drawdown_pct >= 0.0
+
+
+def test_backtesting_agent_compute_metrics_empty() -> None:
+    from agents.investment_team.backtesting_agent import BacktestingAgent
+
+    result = BacktestingAgent._compute_metrics([], 100000.0, "2023-01-01", "2023-12-31")
+
+    assert result.total_return_pct == 0.0
+    assert result.win_rate_pct == 0.0
+    assert result.sharpe_ratio == 0.0
+
+
+def test_backtesting_agent_date_diff() -> None:
+    from agents.investment_team.backtesting_agent import BacktestingAgent
+
+    assert BacktestingAgent._date_diff_days("2023-01-01", "2023-12-31") == 364
+    assert BacktestingAgent._date_diff_days("2023-01-01", "2023-01-01") == 1
+    assert BacktestingAgent._date_diff_days("bad", "date") == 1
+
+
+def test_market_data_service_fetch_ohlcv_range_routes_by_asset_class() -> None:
+    """Verify fetch_ohlcv_range dispatches to the right internal method based on asset class."""
+    from unittest.mock import patch
+
+    from agents.investment_team.market_data_service import MarketDataService
+
+    service = MarketDataService()
+
+    with patch.object(service, "_fetch_stock", return_value=[]) as mock_stock:
+        service.fetch_ohlcv_range("AAPL", "stocks", "2023-01-01", "2023-12-31")
+        mock_stock.assert_called_once_with("AAPL", "2023-01-01", "2023-12-31")
+
+    with patch.object(service, "_fetch_crypto", return_value=[]) as mock_crypto:
+        service.fetch_ohlcv_range("BTC", "crypto", "2023-01-01", "2023-12-31")
+        mock_crypto.assert_called_once_with("BTC", "2023-01-01", "2023-12-31")
+
+
+def test_market_data_service_fetch_multi_symbol_range() -> None:
+    from unittest.mock import patch
+
+    from agents.investment_team.market_data_service import MarketDataService, OHLCVBar
+
+    service = MarketDataService()
+    sample_bar = OHLCVBar(
+        date="2023-06-01", open=150.0, high=155.0, low=148.0, close=153.0, volume=1000000
+    )
+
+    with patch.object(service, "fetch_ohlcv_range", return_value=[sample_bar]):
+        result = service.fetch_multi_symbol_range(
+            ["AAPL", "MSFT"], "stocks", "2023-01-01", "2023-12-31"
+        )
+
+    assert "AAPL" in result
+    assert "MSFT" in result
+    assert len(result["AAPL"]) == 1
+    assert result["AAPL"][0].close == 153.0

--- a/backend/agents/investment_team/trade_simulator.py
+++ b/backend/agents/investment_team/trade_simulator.py
@@ -1,0 +1,428 @@
+"""Shared trade simulation engine used by both BacktestingAgent and PaperTradingAgent.
+
+Consolidates the bar-walking loop, position tracking, slippage/cost simulation,
+force-close logic, metrics computation, and LLM call pre-filtering into a single
+reusable module.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass, field
+from datetime import date as date_cls
+from typing import Any, Callable, Dict, List, Optional
+
+from .market_data_service import OHLCVBar
+from .models import BacktestResult, TradeRecord
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Position tracking
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class OpenPosition:
+    """Typed container for an open trading position."""
+
+    symbol: str
+    side: str  # "long" or "short"
+    entry_date: str
+    entry_price: float
+    shares: float
+    position_value: float
+
+
+# Callback signature: (symbol, bar, recent_bars, open_position, capital) -> decision dict
+EvaluateCallback = Callable[
+    [str, OHLCVBar, List[OHLCVBar], Optional[OpenPosition], float],
+    Dict[str, Any],
+]
+
+
+# ---------------------------------------------------------------------------
+# Simulation result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SimulationResult:
+    """Container for results from a trade simulation run."""
+
+    trades: List[TradeRecord] = field(default_factory=list)
+    decisions: List[Dict[str, Any]] = field(default_factory=list)
+    final_capital: float = 0.0
+    forced_close_count: int = 0
+    evaluations_performed: int = 0
+    bars_skipped_by_filter: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Shared utilities
+# ---------------------------------------------------------------------------
+
+
+def date_diff_days(d1: str, d2: str) -> int:
+    """Compute days between two ISO date strings. Returns at least 1."""
+    try:
+        dt1 = date_cls.fromisoformat(d1[:10])
+        dt2 = date_cls.fromisoformat(d2[:10])
+        return max(1, abs((dt2 - dt1).days))
+    except (ValueError, TypeError):
+        return 1
+
+
+def format_bars_table(bars: List[OHLCVBar]) -> str:
+    """Format a list of OHLCV bars as a compact text table."""
+    if not bars:
+        return "No data available."
+    lines = ["Date       | Open     | High     | Low      | Close    | Volume"]
+    for b in bars:
+        lines.append(
+            f"{b.date} | {b.open:<8.2f} | {b.high:<8.2f} | {b.low:<8.2f} | {b.close:<8.2f} | {b.volume:.0f}"
+        )
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Metrics computation
+# ---------------------------------------------------------------------------
+
+
+def compute_metrics(
+    trades: List[TradeRecord],
+    initial_capital: float,
+    start_date: str,
+    end_date: str,
+) -> BacktestResult:
+    """Compute aggregate performance metrics from trade records.
+
+    Uses CAGR for annualized returns and an equity-curve approach for volatility,
+    scaling by the average inter-trade gap rather than assuming daily returns.
+    """
+    if not trades:
+        return BacktestResult(
+            total_return_pct=0.0,
+            annualized_return_pct=0.0,
+            volatility_pct=0.0,
+            sharpe_ratio=0.0,
+            max_drawdown_pct=0.0,
+            win_rate_pct=0.0,
+            profit_factor=0.0,
+        )
+
+    wins = [t for t in trades if t.outcome == "win"]
+    losses = [t for t in trades if t.outcome == "loss"]
+
+    # Total return
+    total_pnl = sum(t.net_pnl for t in trades)
+    total_return_frac = total_pnl / initial_capital
+    total_return_pct = round(total_return_frac * 100, 2)
+
+    # CAGR-based annualized return
+    total_days = date_diff_days(start_date, end_date)
+    years = max(total_days / 365.25, 0.01)
+    if total_return_frac > -1.0:
+        annualized_return = round(((1 + total_return_frac) ** (1 / years) - 1) * 100, 2)
+    else:
+        annualized_return = -100.0
+
+    # Win rate
+    win_rate = round(len(wins) / len(trades) * 100, 2)
+
+    # Profit factor
+    gross_wins = sum(t.gross_pnl for t in wins) if wins else 0.0
+    gross_losses = abs(sum(t.gross_pnl for t in losses)) if losses else 0.0
+    profit_factor = (
+        round(gross_wins / gross_losses, 2) if gross_losses > 0 else round(max(gross_wins, 0.0), 2)
+    )
+
+    # Volatility from equity curve at trade exits.
+    # Compute returns between consecutive trade exits and annualize by the
+    # average gap between exits, avoiding the incorrect assumption that
+    # per-trade returns are daily returns.
+    exit_equities: List[tuple[str, float]] = []
+    equity = initial_capital
+    for t in trades:
+        equity += t.net_pnl
+        exit_equities.append((t.exit_date, equity))
+
+    annualized_vol = 0.0
+    if len(exit_equities) > 1:
+        inter_trade_returns: List[float] = []
+        prev_eq = initial_capital
+        for _, eq in exit_equities:
+            if prev_eq > 0:
+                inter_trade_returns.append((eq - prev_eq) / prev_eq)
+            prev_eq = eq
+
+        if len(inter_trade_returns) > 1:
+            mean_r = sum(inter_trade_returns) / len(inter_trade_returns)
+            var = sum((r - mean_r) ** 2 for r in inter_trade_returns) / (
+                len(inter_trade_returns) - 1
+            )
+            total_span = date_diff_days(exit_equities[0][0], exit_equities[-1][0])
+            avg_gap = max(total_span / len(inter_trade_returns), 1)
+            periods_per_year = 365.25 / avg_gap
+            annualized_vol = round(math.sqrt(var * periods_per_year), 2)
+
+    # Sharpe ratio
+    sharpe = round(annualized_return / annualized_vol, 2) if annualized_vol > 0 else 0.0
+
+    # Max drawdown
+    peak = initial_capital
+    max_dd = 0.0
+    equity = initial_capital
+    for t in trades:
+        equity += t.net_pnl
+        if equity > peak:
+            peak = equity
+        dd = (peak - equity) / peak * 100 if peak > 0 else 0.0
+        if dd > max_dd:
+            max_dd = dd
+
+    return BacktestResult(
+        total_return_pct=total_return_pct,
+        annualized_return_pct=annualized_return,
+        volatility_pct=annualized_vol,
+        sharpe_ratio=sharpe,
+        max_drawdown_pct=round(max_dd, 2),
+        win_rate_pct=win_rate,
+        profit_factor=profit_factor,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Simulation engine
+# ---------------------------------------------------------------------------
+
+
+class TradeSimulationEngine:
+    """Walks through OHLCV bars chronologically and simulates trade execution.
+
+    Accepts an ``evaluate_fn`` callback (typically an LLM call) that decides
+    entry/exit for each bar.  A pre-filter skips bars with minimal price
+    movement when no position is held, substantially reducing evaluate calls.
+    """
+
+    def __init__(
+        self,
+        initial_capital: float = 100_000.0,
+        transaction_cost_bps: float = 5.0,
+        slippage_bps: float = 2.0,
+        *,
+        min_history_bars: int = 5,
+        pre_filter_pct: float = 1.0,
+        max_evaluations: int = 5000,
+    ) -> None:
+        self.initial_capital = initial_capital
+        self.cost_pct = transaction_cost_bps / 10_000.0
+        self.slippage_bps = slippage_bps
+        self.min_history_bars = min_history_bars
+        self.pre_filter_pct = pre_filter_pct
+        self.max_evaluations = max_evaluations
+
+    # ------------------------------------------------------------------
+
+    def run(
+        self,
+        market_data: Dict[str, List[OHLCVBar]],
+        evaluate_fn: EvaluateCallback,
+        *,
+        max_trades: Optional[int] = None,
+        record_decisions: bool = False,
+    ) -> SimulationResult:
+        """Walk through market data bar-by-bar, executing trades via *evaluate_fn*.
+
+        Args:
+            market_data: ``{symbol: [OHLCVBar, ...]}``
+            evaluate_fn: callback returning ``{action, confidence, shares, reasoning}``
+            max_trades: stop after this many completed trades (``None`` = no limit)
+            record_decisions: store every evaluation result in ``SimulationResult.decisions``
+        """
+        # Build unified timeline sorted by date
+        timeline: List[tuple[str, str, OHLCVBar]] = []
+        for symbol, bars in market_data.items():
+            for bar in bars:
+                timeline.append((bar.date, symbol, bar))
+        timeline.sort(key=lambda x: x[0])
+
+        symbol_history: Dict[str, List[OHLCVBar]] = {sym: [] for sym in market_data}
+
+        capital = self.initial_capital
+        open_positions: Dict[str, OpenPosition] = {}
+        trades: List[TradeRecord] = []
+        decisions: List[Dict[str, Any]] = []
+        trade_num = 0
+        cumulative_pnl = 0.0
+        evaluations = 0
+        skipped = 0
+
+        for bar_date, symbol, bar in timeline:
+            symbol_history[symbol].append(bar)
+            recent = symbol_history[symbol][-20:]
+            has_position = symbol in open_positions
+
+            # Check evaluation budget
+            if evaluations >= self.max_evaluations:
+                logger.warning(
+                    "Reached max evaluations (%d), stopping simulation with %d trades",
+                    self.max_evaluations,
+                    len(trades),
+                )
+                break
+
+            # Pre-filter: skip bars unlikely to trigger signals
+            if not self._should_evaluate(recent, has_position):
+                skipped += 1
+                continue
+
+            # Call the evaluate callback
+            try:
+                decision = evaluate_fn(symbol, bar, recent, open_positions.get(symbol), capital)
+            except Exception as exc:
+                logger.warning("Evaluation failed for %s on %s: %s", symbol, bar_date, exc)
+                decision = {
+                    "action": "hold",
+                    "confidence": 0.0,
+                    "shares": 0,
+                    "reasoning": f"Error: {exc}",
+                }
+
+            evaluations += 1
+            if record_decisions:
+                decisions.append({"date": bar_date, "symbol": symbol, **decision})
+
+            if evaluations % 500 == 0:
+                logger.info(
+                    "Simulation progress: %d evaluations, %d trades completed",
+                    evaluations,
+                    len(trades),
+                )
+
+            action = decision.get("action", "hold")
+
+            # --- Entry ---
+            if action in ("enter_long", "enter_short") and not has_position:
+                shares = float(decision.get("shares", 0))
+                if shares <= 0:
+                    position_pct = 0.06
+                    shares = round(capital * position_pct / bar.close, 4 if bar.close < 10 else 2)
+
+                if shares > 0 and capital >= shares * bar.close:
+                    slippage_mult = 1.0 + self.slippage_bps / 10_000.0
+                    entry_price = round(bar.close * slippage_mult, 4 if bar.close < 10 else 2)
+                    position_value = round(entry_price * shares, 2)
+                    capital -= position_value
+
+                    open_positions[symbol] = OpenPosition(
+                        symbol=symbol,
+                        side="long" if action == "enter_long" else "short",
+                        entry_date=bar_date,
+                        entry_price=entry_price,
+                        shares=shares,
+                        position_value=position_value,
+                    )
+
+            # --- Exit ---
+            elif action == "exit" and has_position:
+                pos = open_positions.pop(symbol)
+                trade_num += 1
+                trade = self._close_position(pos, bar.close, bar_date, trade_num, cumulative_pnl)
+                cumulative_pnl = trade.cumulative_pnl
+                capital += round(pos.shares * trade.exit_price, 2)
+                trades.append(trade)
+
+            # Check trade limit
+            if max_trades is not None and len(trades) >= max_trades:
+                break
+
+        # Force-close remaining open positions
+        forced = 0
+        for symbol, pos in list(open_positions.items()):
+            if symbol in symbol_history and symbol_history[symbol]:
+                last_bar = symbol_history[symbol][-1]
+                trade_num += 1
+                trade = self._close_position(
+                    pos, last_bar.close, last_bar.date, trade_num, cumulative_pnl
+                )
+                cumulative_pnl = trade.cumulative_pnl
+                capital += round(pos.shares * trade.exit_price, 2)
+                trades.append(trade)
+                forced += 1
+
+        return SimulationResult(
+            trades=trades,
+            decisions=decisions,
+            final_capital=capital,
+            forced_close_count=forced,
+            evaluations_performed=evaluations,
+            bars_skipped_by_filter=skipped,
+        )
+
+    # ------------------------------------------------------------------
+
+    def _should_evaluate(self, recent_bars: List[OHLCVBar], has_position: bool) -> bool:
+        """Pre-filter: decide whether this bar warrants an LLM evaluation.
+
+        Always evaluates when a position is open (exit signals).  For entry
+        signals, requires minimum history and meaningful price movement
+        relative to the recent average.
+        """
+        if has_position:
+            return True
+        if len(recent_bars) < self.min_history_bars:
+            return False
+        closes = [b.close for b in recent_bars[-self.min_history_bars :]]
+        avg = sum(closes) / len(closes)
+        if avg <= 0:
+            return True
+        move_pct = abs(recent_bars[-1].close - avg) / avg * 100
+        return move_pct >= self.pre_filter_pct
+
+    def _close_position(
+        self,
+        pos: OpenPosition,
+        close_price: float,
+        exit_date: str,
+        trade_num: int,
+        cumulative_pnl: float,
+    ) -> TradeRecord:
+        """Close a position and return a ``TradeRecord``."""
+        slippage_mult = 1.0 - self.slippage_bps / 10_000.0
+        exit_price = round(close_price * slippage_mult, 4 if close_price < 10 else 2)
+
+        gross_pnl = round(pos.shares * (exit_price - pos.entry_price), 2)
+        if pos.side == "short":
+            gross_pnl = -gross_pnl
+
+        tx_cost = round(pos.position_value * self.cost_pct * 2, 2)
+        net_pnl = round(gross_pnl - tx_cost, 2)
+        cumulative_pnl = round(cumulative_pnl + net_pnl, 2)
+
+        return_pct = round((exit_price - pos.entry_price) / pos.entry_price * 100, 3)
+        if pos.side == "short":
+            return_pct = -return_pct
+
+        hold_days = date_diff_days(pos.entry_date, exit_date)
+
+        return TradeRecord(
+            trade_num=trade_num,
+            entry_date=pos.entry_date,
+            exit_date=exit_date,
+            symbol=pos.symbol,
+            side=pos.side,
+            entry_price=pos.entry_price,
+            exit_price=exit_price,
+            shares=pos.shares,
+            position_value=pos.position_value,
+            gross_pnl=gross_pnl,
+            net_pnl=net_pnl,
+            return_pct=return_pct,
+            hold_days=hold_days,
+            outcome="win" if net_pnl > 0 else "loss",
+            cumulative_pnl=cumulative_pnl,
+        )

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -17,3 +17,4 @@ APScheduler>=3.10,<4.0
 pytz>=2024.1
 playwright>=1.49,<1.51
 psycopg[binary]>=3.1,<3.3
+yfinance>=0.2.36,<1.0


### PR DESCRIPTION
## Summary
This PR introduces two new agents for strategy validation using real market data and LLM-driven trade decisions:

1. **BacktestingAgent** — runs historical backtests by walking through real OHLCV data chronologically and using the LLM to interpret strategy entry/exit rules
2. **PaperTradingAgent** — runs simulated live trading on real market data with the same LLM-driven decision logic
3. **MarketDataService** — fetches real OHLCV data from Yahoo Finance (stocks/ETFs) and CoinGecko (crypto)

These replace the previous deterministic mock backtesting with actual market data and intelligent rule interpretation.

## Key Changes

### New Agents
- **`backtesting_agent.py`** (403 lines): Walks through historical bars chronologically, uses LLM to evaluate strategy rules against real data, simulates trade execution with slippage/costs, and computes performance metrics
- **`paper_trading_agent.py`** (594 lines): Similar to backtesting but for live/real-time data; includes performance comparison logic, divergence analysis via LLM, and verdict generation (ready for live vs. not performant)

### Market Data Service
- **`market_data_service.py`** (186 lines): Fetches real OHLCV data from:
  - Yahoo Finance for stocks/ETFs (via yfinance)
  - CoinGecko free API for crypto
  - Supports arbitrary date ranges and recent N-day windows

### Model Updates
- **`models.py`**: Added `PaperTradingStatus`, `PaperTradingVerdict`, `PaperTradingComparison`, and `PaperTradingSession` enums and dataclasses
- Added `TradeRecord` to test imports for validation

### API Integration
- **`api/main.py`**: 
  - Replaced deterministic mock backtest logic with call to `_run_real_data_backtest()` 
  - Added `_paper_trading_sessions` persistent storage
  - Removed hardcoded symbol lists and price generation (now fetched from real sources)
  - Imports `BacktestingAgent` and `MarketDataService` for real-data backtesting

### Testing
- **`test_investment_team.py`**: Added 15+ tests covering:
  - Paper trading session model creation and status tracking
  - Performance comparison alignment detection
  - Trade metrics computation from real trade records
  - Market data service symbol routing by asset class
  - Backtesting agent metrics calculation

## Implementation Details

- **LLM Prompts**: Both agents use structured JSON prompts to ask the LLM to evaluate entry/exit rules against current bar data with recent price history context
- **Trade Execution**: Realistic slippage applied to entry (buy higher) and exit (sell lower) prices; transaction costs deducted from P&L
- **Performance Metrics**: Win rate, Sharpe ratio, max drawdown, profit factor computed from actual trade ledgers
- **Divergence Analysis**: Paper trading agent compares results against backtest and uses LLM to analyze why live performance diverges (overfitting, regime change, data quality, etc.)
- **Verdict Logic**: Sessions marked "ready for live" only if paper trading metrics align with backtest within tolerance thresholds

## Dependencies
- Added `yfinance>=0.2.36,<1.0` for stock/ETF data fetching

https://claude.ai/code/session_01Ec5dyKUm68YjwWmMWxeBp4