### PR TITLE
Refactor title rating to immediate feedback with love-to-select

### DIFF
--- a/backend/agents/blogging/agent_implementations/blog_writing_process_v2.py
+++ b/backend/agents/blogging/agent_implementations/blog_writing_process_v2.py
@@ -590,7 +590,11 @@ def run_pipeline(
                 # Ask the LLM to generate better titles based on the feedback
                 feedback_prompt = (
                     "Generate 5 new blog post title candidates based on this feedback.\n\n"
-                    f"TOPIC: {plan.overarching_topic}\n\n"
+                    f"TOPIC (the article's core argument — every title MUST align with this): {plan.overarching_topic}\n\n"
+                    "REQUIREMENTS:\n"
+                    "- Each title MUST accurately reflect the topic above. Do NOT generate titles that contradict or misrepresent the article's argument.\n"
+                    "- Each title should promise the reader they will learn something concrete and valuable.\n"
+                    "- Avoid vague or generic titles. Be specific about what the reader will gain.\n\n"
                 )
                 if liked:
                     feedback_prompt += "Titles the user LIKED (generate titles with a similar style/angle):\n"

--- a/backend/agents/blogging/agent_implementations/blog_writing_process_v2.py
+++ b/backend/agents/blogging/agent_implementations/blog_writing_process_v2.py
@@ -540,15 +540,14 @@ def run_pipeline(
 
             while True:
                 title_round += 1
-                update_blog_job(
-                    job_id,
-                    waiting_for_title_selection=True,
-                    title_choices=title_choices,
-                )
+                # Use job_updater for all fields so SSE clients receive the
+                # waiting_for_title_selection and title_choices updates.
                 job_updater(
                     phase="title_selection",
                     progress=25,
                     status_text=f"Rate titles (round {title_round}, {len(title_choices)} candidates)...",
+                    waiting_for_title_selection=True,
+                    title_choices=title_choices,
                 )
 
                 # Block until user submits ratings
@@ -574,12 +573,14 @@ def run_pipeline(
                 # No love — collect ratings and generate new titles
                 round_ratings = job_data.get("title_ratings", [])
                 all_ratings.extend(round_ratings)
-                liked = [r["title"] for r in round_ratings if r.get("rating") == "like"]
-                disliked = [r["title"] for r in round_ratings if r.get("rating") == "dislike"]
+
+                # Build feedback from ALL accumulated ratings for richer signal
+                all_liked = [r["title"] for r in all_ratings if r.get("rating") == "like"]
+                all_disliked = [r["title"] for r in all_ratings if r.get("rating") == "dislike"]
 
                 logger.info(
-                    "Title ratings round %s: %s liked, %s disliked — generating new candidates",
-                    title_round, len(liked), len(disliked),
+                    "Title ratings round %s: %s liked, %s disliked (cumulative) — generating new candidates",
+                    title_round, len(all_liked), len(all_disliked),
                 )
                 job_updater(
                     phase="title_selection",
@@ -591,17 +592,25 @@ def run_pipeline(
                 feedback_prompt = (
                     "Generate 5 new blog post title candidates based on this feedback.\n\n"
                     f"TOPIC (the article's core argument — every title MUST align with this): {plan.overarching_topic}\n\n"
+                )
+                if plan.target_reader:
+                    feedback_prompt += f"TARGET READER: {plan.target_reader}\n\n"
+                section_titles = [sec.title for sec in sorted(plan.sections, key=lambda s: s.order)]
+                if section_titles:
+                    feedback_prompt += "ARTICLE SECTIONS:\n"
+                    feedback_prompt += "\n".join(f"- {t}" for t in section_titles) + "\n\n"
+                feedback_prompt += (
                     "REQUIREMENTS:\n"
                     "- Each title MUST accurately reflect the topic above. Do NOT generate titles that contradict or misrepresent the article's argument.\n"
                     "- Each title should promise the reader they will learn something concrete and valuable.\n"
                     "- Avoid vague or generic titles. Be specific about what the reader will gain.\n\n"
                 )
-                if liked:
+                if all_liked:
                     feedback_prompt += "Titles the user LIKED (generate titles with a similar style/angle):\n"
-                    feedback_prompt += "\n".join(f"- {t}" for t in liked) + "\n\n"
-                if disliked:
+                    feedback_prompt += "\n".join(f"- {t}" for t in all_liked) + "\n\n"
+                if all_disliked:
                     feedback_prompt += "Titles the user DISLIKED (avoid this style/angle):\n"
-                    feedback_prompt += "\n".join(f"- {t}" for t in disliked) + "\n\n"
+                    feedback_prompt += "\n".join(f"- {t}" for t in all_disliked) + "\n\n"
 
                 # Include all previous titles so the LLM doesn't repeat them
                 all_previous = [r["title"] for r in all_ratings]

--- a/backend/agents/blogging/blog_planning_agent/prompts.py
+++ b/backend/agents/blogging/blog_planning_agent/prompts.py
@@ -101,6 +101,15 @@ CRITICAL RULES FOR PLAN QUALITY — a plan is NOT acceptable unless it meets ALL
 
 13. **title_candidates** must have AT LEAST 5 titles. Each title must include a full scoring breakdown across 5 dimensions (curiosity_gap, specificity, audience_fit, seo_potential, emotional_pull — each 0.0 to 1.0) plus a rationale explaining the score. The overall probability_of_success is the weighted average: curiosity_gap * 0.25 + specificity * 0.25 + audience_fit * 0.20 + seo_potential * 0.15 + emotional_pull * 0.15. Vary the styles: include at least one "how-to", one provocative/contrarian, one numbered list, and one that leads with a specific outcome or result.
 
+TITLE ACCURACY RULES (hard requirements — reject any title that violates these):
+- Every title MUST accurately reflect the overarching_topic. If the post argues FOR multi-agent architectures, the title must not frame them negatively. If the post is about a specific technology, the title must reference that technology or its core concept.
+- Never generate a title that contradicts the article's stance. Example: if the overarching_topic is about choosing between agent patterns in AWS Strands, do NOT generate "Stop Over-Engineering: Why Single Agents Are All You Need" — that contradicts the nuanced argument.
+- Titles must not contain redundant or contradictory clauses (e.g., avoid titles where the subtitle restates or contradicts the main title).
+- Each title should promise the reader they will LEARN something concrete and valuable. The reader should think "I need to read this — I'll walk away knowing something I didn't before."
+  BAD: "A Guide to Agent Architectures" (vague, no learning promise)
+  GOOD: "The 3 Agent Patterns That Handle 90% of Real-World AI Tasks (and When to Use Each)" (specific, promises concrete takeaway)
+- Before finalizing each title, verify it against the overarching_topic: does the title support, reflect, or accurately tease the article's actual argument? If not, discard it and generate a replacement.
+
 Additional rules:
 - Do not invent citations; only reference themes present in the digest.
 - use research_support_note to tie sections to sources, or set gap_flag true if research is thin.

--- a/backend/agents/blogging/blog_planning_agent/prompts.py
+++ b/backend/agents/blogging/blog_planning_agent/prompts.py
@@ -108,7 +108,7 @@ TITLE ACCURACY RULES (hard requirements — reject any title that violates these
 - Each title should promise the reader they will LEARN something concrete and valuable. The reader should think "I need to read this — I'll walk away knowing something I didn't before."
   BAD: "A Guide to Agent Architectures" (vague, no learning promise)
   GOOD: "The 3 Agent Patterns That Handle 90% of Real-World AI Tasks (and When to Use Each)" (specific, promises concrete takeaway)
-- Before finalizing each title, verify it against the overarching_topic: does the title support, reflect, or accurately tease the article's actual argument? If not, discard it and generate a replacement.
+- Before finalizing each title, verify it against the overarching_topic: does the title support, reflect, or accurately tease the article's actual argument? If not, discard it and generate a replacement. Do NOT include any title that fails this check.
 
 Additional rules:
 - Do not invent citations; only reference themes present in the digest.

--- a/user-interface/src/app/components/blogging-dashboard/blogging-dashboard.component.html
+++ b/user-interface/src/app/components/blogging-dashboard/blogging-dashboard.component.html
@@ -276,7 +276,7 @@
         <mat-card-header>
           <mat-icon mat-card-avatar>spellcheck</mat-icon>
           <mat-card-title>Rate These Titles</mat-card-title>
-          <mat-card-subtitle>Love a title to select it, or rate them all and we'll generate better options</mat-card-subtitle>
+          <mat-card-subtitle>Love a title to use it. Like or dislike to get new suggestions.</mat-card-subtitle>
         </mat-card-header>
         <mat-card-content>
           @if (collaborationError) { <app-error-message [message]="collaborationError" /> }
@@ -289,6 +289,7 @@
                           [class.rating-active]="getTitleRating(choice.title) === 'dislike'"
                           class="rating-dislike"
                           (click)="rateTitle(choice.title, 'dislike')"
+                          [disabled]="titleRatingSubmitting"
                           matTooltip="Dislike">
                     <mat-icon>thumb_down</mat-icon>
                   </button>
@@ -296,6 +297,7 @@
                           [class.rating-active]="getTitleRating(choice.title) === 'like'"
                           class="rating-like"
                           (click)="rateTitle(choice.title, 'like')"
+                          [disabled]="titleRatingSubmitting"
                           matTooltip="Like">
                     <mat-icon>thumb_up</mat-icon>
                   </button>
@@ -303,6 +305,7 @@
                           [class.rating-active]="getTitleRating(choice.title) === 'love'"
                           class="rating-love"
                           (click)="rateTitle(choice.title, 'love')"
+                          [disabled]="titleRatingSubmitting"
                           matTooltip="Love — use this title">
                     <mat-icon>favorite</mat-icon>
                   </button>
@@ -310,18 +313,11 @@
               </div>
             }
           </div>
-          <div class="title-submit-row">
-            <button mat-raised-button color="primary"
-                    (click)="submitTitleRatings()"
-                    [disabled]="titleRatingSubmitting || !canSubmitTitleRatings()">
-              {{ titleRatingSubmitting ? 'Submitting...' : 'Submit Ratings' }}
-            </button>
-            <span class="title-submit-hint">
-              @if (!canSubmitTitleRatings()) {
-                Rate all titles to continue
-              }
-            </span>
-          </div>
+          @if (titleRatingSubmitting) {
+            <div class="title-submit-row">
+              <span class="title-submit-hint">Submitting...</span>
+            </div>
+          }
         </mat-card-content>
       </mat-card>
     }

--- a/user-interface/src/app/components/blogging-dashboard/blogging-dashboard.component.ts
+++ b/user-interface/src/app/components/blogging-dashboard/blogging-dashboard.component.ts
@@ -701,51 +701,51 @@ export class BloggingDashboardComponent implements OnInit, OnDestroy {
 
   rateTitle(title: string, rating: 'dislike' | 'like' | 'love'): void {
     this.titleRatings[title] = rating;
+    if (rating === 'love') {
+      this.selectTitle(title);
+    } else {
+      this.submitSingleTitleRating(title, rating);
+    }
   }
 
   getTitleRating(title: string): string | undefined {
     return this.titleRatings[title];
   }
 
-  canSubmitTitleRatings(): boolean {
-    const choices = this.selectedJobStatus?.title_choices ?? [];
-    return choices.length > 0 && choices.every((c) => !!this.titleRatings[c.title]);
-  }
-
-  submitTitleRatings(): void {
+  /** Submit a single like/dislike rating to trigger new title generation. */
+  submitSingleTitleRating(title: string, rating: 'dislike' | 'like'): void {
     const jobId = this.selectedBlogJob?.job_id;
-    if (!jobId) return;
-    const choices = this.selectedJobStatus?.title_choices ?? [];
-    const ratings = choices.map((c) => ({
-      title: c.title,
-      rating: this.titleRatings[c.title] ?? ('like' as const),
-    }));
+    if (!jobId || this.titleRatingSubmitting) return;
     this.titleRatingSubmitting = true;
     this.collaborationError = null;
-    this.api.rateTitles(jobId, ratings).subscribe({
+    this.api.rateTitles(jobId, [{ title, rating }]).subscribe({
       next: (status) => {
         this.selectedJobStatus = status;
         this.titleRatings = {};
         this.titleRatingSubmitting = false;
       },
       error: (err) => {
-        this.collaborationError = err?.error?.detail ?? err?.message ?? 'Failed to submit title ratings';
+        this.collaborationError = err?.error?.detail ?? err?.message ?? 'Failed to submit title rating';
         this.titleRatingSubmitting = false;
       },
     });
   }
 
-  /** Legacy: direct title selection (kept for backward compat). */
+  /** Select a loved title directly, advancing the pipeline. */
   selectTitle(title: string): void {
     const jobId = this.selectedBlogJob?.job_id;
-    if (!jobId) return;
+    if (!jobId || this.titleRatingSubmitting) return;
+    this.titleRatingSubmitting = true;
     this.collaborationError = null;
     this.api.selectTitle(jobId, title).subscribe({
       next: (status) => {
         this.selectedJobStatus = status;
+        this.titleRatings = {};
+        this.titleRatingSubmitting = false;
       },
       error: (err) => {
         this.collaborationError = err?.error?.detail ?? err?.message ?? 'Failed to submit title selection';
+        this.titleRatingSubmitting = false;
       },
     });
   }

--- a/user-interface/src/app/components/blogging-dashboard/blogging-dashboard.component.ts
+++ b/user-interface/src/app/components/blogging-dashboard/blogging-dashboard.component.ts
@@ -6,7 +6,7 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { marked } from 'marked';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatCardModule } from '@angular/material/card';
-import { Subscription, timer } from 'rxjs';
+import { Observable, Subscription, timer } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import type { BlogJobStreamEvent } from '../../models';
 import { BloggingApiService } from '../../services/blogging-api.service';
@@ -708,7 +708,7 @@ export class BloggingDashboardComponent implements OnInit, OnDestroy {
     }
   }
 
-  getTitleRating(title: string): string | undefined {
+  getTitleRating(title: string): 'dislike' | 'like' | 'love' | undefined {
     return this.titleRatings[title];
   }
 
@@ -716,9 +716,21 @@ export class BloggingDashboardComponent implements OnInit, OnDestroy {
   submitSingleTitleRating(title: string, rating: 'dislike' | 'like'): void {
     const jobId = this.selectedBlogJob?.job_id;
     if (!jobId || this.titleRatingSubmitting) return;
+    this.submitTitleAction(this.api.rateTitles(jobId, [{ title, rating }]));
+  }
+
+  /** Select a loved title directly, advancing the pipeline. */
+  selectTitle(title: string): void {
+    const jobId = this.selectedBlogJob?.job_id;
+    if (!jobId || this.titleRatingSubmitting) return;
+    this.submitTitleAction(this.api.selectTitle(jobId, title));
+  }
+
+  /** Shared handler for title selection API calls. */
+  private submitTitleAction(action$: Observable<BlogJobStatusResponse>): void {
     this.titleRatingSubmitting = true;
     this.collaborationError = null;
-    this.api.rateTitles(jobId, [{ title, rating }]).subscribe({
+    action$.subscribe({
       next: (status) => {
         this.selectedJobStatus = status;
         this.titleRatings = {};
@@ -726,25 +738,7 @@ export class BloggingDashboardComponent implements OnInit, OnDestroy {
       },
       error: (err) => {
         this.collaborationError = err?.error?.detail ?? err?.message ?? 'Failed to submit title rating';
-        this.titleRatingSubmitting = false;
-      },
-    });
-  }
-
-  /** Select a loved title directly, advancing the pipeline. */
-  selectTitle(title: string): void {
-    const jobId = this.selectedBlogJob?.job_id;
-    if (!jobId || this.titleRatingSubmitting) return;
-    this.titleRatingSubmitting = true;
-    this.collaborationError = null;
-    this.api.selectTitle(jobId, title).subscribe({
-      next: (status) => {
-        this.selectedJobStatus = status;
-        this.titleRatings = {};
-        this.titleRatingSubmitting = false;
-      },
-      error: (err) => {
-        this.collaborationError = err?.error?.detail ?? err?.message ?? 'Failed to submit title selection';
+        // Keep titleRatings so the user can see which title they tried to rate
         this.titleRatingSubmitting = false;
       },
     });


### PR DESCRIPTION
## Summary
This PR refactors the blog title rating workflow from a batch submission model to an immediate feedback model where each rating triggers an action: "like" and "dislike" ratings immediately request new title suggestions, while "love" ratings directly select the title.

## Key Changes

**Frontend (TypeScript & Template)**
- Replaced `submitTitleRatings()` batch submission with `submitSingleTitleRating()` that sends individual like/dislike ratings to trigger new title generation
- Modified `rateTitle()` to route "love" ratings to `selectTitle()` and other ratings to `submitSingleTitleRating()`
- Removed `canSubmitTitleRatings()` validation logic (no longer needed for batch submission)
- Updated `selectTitle()` to properly manage loading state and reset ratings after selection
- Removed the "Submit Ratings" button and submission hint from the UI; now shows "Submitting..." only during active requests
- Added `[disabled]="titleRatingSubmitting"` to all rating buttons to prevent multiple concurrent submissions
- Updated card subtitle to clarify the new interaction model: "Love a title to use it. Like or dislike to get new suggestions."

**Backend (Python)**
- Added explicit "TITLE ACCURACY RULES" section to the prompt with hard requirements:
  - Titles must accurately reflect the overarching topic and article stance
  - No contradictory or redundant clauses
  - Each title must promise concrete learning value to the reader
  - Verification step: confirm each title aligns with the overarching_topic before finalizing
- Enhanced title regeneration feedback prompt to emphasize topic alignment and concrete value promises
- Clarified that the overarching_topic represents "the article's core argument — every title MUST align with this"

## Implementation Details
- The refactor maintains the same API contracts but changes the interaction pattern from "rate all, then submit" to "rate one, get immediate feedback"
- Loading state (`titleRatingSubmitting`) now properly gates both rating submission and title selection to prevent race conditions
- Backend improvements focus on preventing title generation that contradicts or misrepresents the article's actual argument, addressing quality issues in the feedback loop

https://claude.ai/code/session_01GYpqUp297hBqjxSF97Jcge