### PR TITLE
Allow attaching existing conversations to brands

### DIFF
--- a/backend/agents/branding_team/api/main.py
+++ b/backend/agents/branding_team/api/main.py
@@ -79,6 +79,7 @@ class CreateBrandRequest(BaseModel):
     desired_voice: str = Field(default="clear, confident, human")
     existing_brand_material: List[str] = Field(default_factory=list)
     wiki_path: Optional[str] = None
+    conversation_id: Optional[str] = None
 
 
 class UpdateBrandRequest(BaseModel):
@@ -316,6 +317,12 @@ def _parse_target_phase(raw: Optional[str]) -> Optional[BrandPhase]:
         raise HTTPException(status_code=400, detail=f"Invalid target_phase: {raw}")
 
 
+def _mission_has_brand_name(mission: BrandingMission) -> bool:
+    """True if company_name is a real value (not a placeholder)."""
+    placeholders = ("TBD", "To be discussed.", "—", "")
+    return (mission.company_name or "").strip() not in placeholders
+
+
 def _mission_has_minimal_required_fields(mission: BrandingMission) -> bool:
     """True if we have real company name, description, and target audience (not placeholders)."""
     placeholders = ("TBD", "To be discussed.", "—", "")
@@ -461,8 +468,14 @@ def create_brand(client_id: str, payload: CreateBrandRequest) -> Brand:
     if not brand:
         raise HTTPException(status_code=404, detail="Client not found")
 
-    # Create the single, permanent conversation for this brand.
-    conv_id = conversation_store.create(brand_id=brand.id, mission=mission)
+    # Attach an existing conversation if provided, otherwise create a new one.
+    existing_conv_id = (payload.conversation_id or "").strip() or None
+    if existing_conv_id and conversation_store.get(existing_conv_id) is not None:
+        conversation_store.set_brand(existing_conv_id, brand.id)
+        conversation_store.update_mission(existing_conv_id, mission)
+        conv_id = existing_conv_id
+    else:
+        conv_id = conversation_store.create(brand_id=brand.id, mission=mission)
     brand = branding_store.update_brand(client_id, brand.id, conversation_id=conv_id)
 
     return brand
@@ -798,6 +811,23 @@ def create_branding_conversation(
         output = _run_orchestrator_if_ready(updated_mission)
         if output is not None:
             conversation_store.update_output(conversation_id, output)
+
+        # Auto-create a brand when the user provided enough info in the initial message.
+        if not brand_id and _mission_has_brand_name(updated_mission):
+            client_id = _ensure_default_client()
+            brand = branding_store.create_brand(
+                client_id=client_id,
+                mission=updated_mission,
+                name=updated_mission.company_name,
+            )
+            if brand:
+                conversation_store.set_brand(conversation_id, brand.id)
+                branding_store.update_brand(client_id, brand.id, conversation_id=conversation_id)
+                if output:
+                    branding_store.append_brand_version(client_id, brand.id, output)
+                brand_id = brand.id
+                logger.info("Auto-created brand %s from initial message in conversation %s", brand.id, conversation_id)
+
         messages, mission, latest_output = conversation_store.get(conversation_id) or (
             [],
             updated_mission,
@@ -855,8 +885,8 @@ def send_branding_conversation_message(
     if output is not None:
         conversation_store.update_output(conversation_id, output)
 
-    # Auto-create a brand when the mission has enough info and conversation is unattached.
-    if not brand_id and _mission_has_minimal_required_fields(updated_mission):
+    # Auto-create a brand when the user has provided at least a company name and conversation is unattached.
+    if not brand_id and _mission_has_brand_name(updated_mission):
         client_id = _ensure_default_client()
         brand = branding_store.create_brand(
             client_id=client_id,

--- a/backend/agents/branding_team/api/main.py
+++ b/backend/agents/branding_team/api/main.py
@@ -471,6 +471,12 @@ def create_brand(client_id: str, payload: CreateBrandRequest) -> Brand:
     # Attach an existing conversation if provided, otherwise create a new one.
     existing_conv_id = (payload.conversation_id or "").strip() or None
     if existing_conv_id and conversation_store.get(existing_conv_id) is not None:
+        existing_brand = conversation_store.get_conversation_brand_id(existing_conv_id)
+        if existing_brand:
+            raise HTTPException(
+                status_code=409,
+                detail="Conversation is already attached to another brand",
+            )
         conversation_store.set_brand(existing_conv_id, brand.id)
         conversation_store.update_mission(existing_conv_id, mission)
         conv_id = existing_conv_id

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.html
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.html
@@ -51,6 +51,9 @@
                 }
               </mat-menu>
             }
+            <button mat-stroked-button color="primary" type="button" (click)="startFreshConversation()">
+              New brand
+            </button>
           </div>
         } @else if (brands.length > 0) {
           <div class="current-brand-bar__main">

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
@@ -221,12 +221,12 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
       differentiators: mission.differentiators,
       desired_voice: mission.desired_voice,
       existing_brand_material: mission.existing_brand_material,
+      conversation_id: this.activeConversationId,
     };
     this.saveToAgencyError = null;
     this.api.createBrand(clientId, request).subscribe({
       next: (brand) => {
-        // Brand creation now auto-creates a conversation on the backend.
-        // Switch to the brand's permanent conversation.
+        // Switch to the brand's conversation (existing chat is now attached).
         this.activeConversationId = brand.conversation_id ?? null;
         this.api.runBrand(clientId, brand.id).subscribe({
           next: () => {
@@ -423,6 +423,15 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
 
   get canCreateBrandFromChat(): boolean {
     return !!this.activeConversationId && !!this.conversationMission;
+  }
+
+  /** Deselect current brand and start a fresh unattached conversation for a new brand. */
+  startFreshConversation(): void {
+    this.selectedBrand = null;
+    this.activeConversationId = null;
+    this.conversationMission = null;
+    this.conversationLatestOutput = null;
+    this.syncQueryParams();
   }
 
 

--- a/user-interface/src/app/models/branding.model.ts
+++ b/user-interface/src/app/models/branding.model.ts
@@ -101,6 +101,7 @@ export interface CreateBrandRequest {
   desired_voice?: string;
   existing_brand_material?: string[];
   wiki_path?: string | null;
+  conversation_id?: string | null;
 }
 
 export interface UpdateBrandRequest {


### PR DESCRIPTION
## Summary
This PR enables users to attach an existing conversation to a brand during creation, and implements auto-brand-creation when a conversation has sufficient information. This allows for more flexible workflows where users can start a conversation, gather requirements, and then formally create a brand while preserving the chat history.

## Key Changes

- **Backend API Enhancement**
  - Added `conversation_id` optional field to `CreateBrandRequest` to allow attaching existing conversations
  - Modified `create_brand()` endpoint to reuse an existing conversation if provided, otherwise create a new one
  - Added `_mission_has_brand_name()` helper function to check if a mission has a real company name (not a placeholder)
  - Lowered auto-brand-creation threshold from requiring "minimal required fields" to just requiring a company name
  - Implemented auto-brand-creation in `create_branding_conversation()` when initial message provides enough info
  - Updated `send_branding_conversation_message()` to use the new `_mission_has_brand_name()` check for consistency

- **Frontend UI Updates**
  - Modified `createBrand()` call to pass the active conversation ID when creating a brand
  - Added `startFreshConversation()` method to allow users to deselect a brand and start a new unattached conversation
  - Added "New brand" button in the branding dashboard to trigger fresh conversation creation
  - Updated comments to reflect that brand creation now attaches existing conversations rather than always creating new ones

- **Type Updates**
  - Added `conversation_id` field to `CreateBrandRequest` interface in the branding model

## Notable Implementation Details

- The backend validates that an existing conversation actually exists before attaching it
- When attaching an existing conversation, both the brand reference and mission are updated in the conversation store
- Auto-brand-creation now triggers with just a company name, enabling earlier brand creation in the workflow
- The "New brand" button allows users to reset their selection and start a fresh conversation without an attached brand

https://claude.ai/code/session_01GpxjrirSL5AESL6LyXiL7T