### PR TITLE
Add persona testing dashboard and audit panel UI

### DIFF
--- a/backend/agents/user_agent_founder/api/main.py
+++ b/backend/agents/user_agent_founder/api/main.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import logging
+import os
 import threading
-from typing import Optional
+from typing import Any, Optional
 
+import httpx
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
@@ -177,6 +179,83 @@ def get_decisions(run_id: str) -> list[DecisionResponse]:
         )
         for d in decisions
     ]
+
+
+class PersonaInfo(BaseModel):
+    id: str
+    name: str
+    description: str
+    icon: str
+
+
+class PersonaListResponse(BaseModel):
+    personas: list[PersonaInfo]
+
+
+class RunArtifactsResponse(BaseModel):
+    run_id: str
+    se_job_id: Optional[str] = None
+    se_job_status: Optional[dict[str, Any]] = None
+    repo_path: Optional[str] = None
+    spec_content: Optional[str] = None
+
+
+UNIFIED_API_BASE = os.environ.get("UNIFIED_API_BASE_URL", "http://localhost:8080")
+SE_PREFIX = "/api/software-engineering"
+_HTTP_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
+
+
+@app.get("/personas", response_model=PersonaListResponse)
+def list_personas() -> PersonaListResponse:
+    """Return the list of available project personas for SE team testing."""
+    return PersonaListResponse(
+        personas=[
+            PersonaInfo(
+                id="startup-founder",
+                name="Startup Founder",
+                description=(
+                    "Alex Chen — a bootstrapped startup founder building TaskFlow. "
+                    "Budget-conscious, speed-first, UX-obsessed. Generates a task management "
+                    "product spec and drives the SE team autonomously."
+                ),
+                icon="rocket_launch",
+            ),
+        ]
+    )
+
+
+@app.get("/runs/{run_id}/artifacts", response_model=RunArtifactsResponse)
+def get_run_artifacts(run_id: str) -> RunArtifactsResponse:
+    """Get artifacts produced during a persona test run.
+
+    Proxies to the SE team job status to retrieve task results,
+    task states, and other pipeline outputs.
+    """
+    store = get_founder_store()
+    run = store.get_run(run_id)
+    if run is None:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+
+    se_job_status: dict[str, Any] | None = None
+    if run.se_job_id:
+        try:
+            with httpx.Client() as client:
+                resp = client.get(
+                    f"{UNIFIED_API_BASE}{SE_PREFIX}/run-team/{run.se_job_id}",
+                    timeout=_HTTP_TIMEOUT,
+                )
+                if resp.status_code < 400:
+                    se_job_status = resp.json()
+        except httpx.HTTPError:
+            logger.warning("Failed to fetch SE job status for %s", run.se_job_id)
+
+    return RunArtifactsResponse(
+        run_id=run.run_id,
+        se_job_id=run.se_job_id,
+        se_job_status=se_job_status,
+        repo_path=run.repo_path,
+        spec_content=run.spec_content,
+    )
 
 
 @app.get("/health")

--- a/user-interface/src/app/app.routes.ts
+++ b/user-interface/src/app/app.routes.ts
@@ -24,6 +24,8 @@ import { NutritionDashboardComponent } from './components/nutrition-dashboard/nu
 import { StartupAdvisorDashboardComponent } from './components/startup-advisor-dashboard/startup-advisor-dashboard.component';
 import { AgenticTeamDashboardComponent } from './components/agentic-team-dashboard/agentic-team-dashboard.component';
 import { PlanningArtifactDetailComponent } from './components/planning-artifact-detail/planning-artifact-detail.component';
+import { PersonaTestingDashboardComponent } from './components/persona-testing-dashboard/persona-testing-dashboard.component';
+import { PersonaTestAuditPanelComponent } from './components/persona-test-audit-panel/persona-test-audit-panel.component';
 
 export const routes: Routes = [
   {
@@ -60,6 +62,8 @@ export const routes: Routes = [
       { path: 'nutrition', component: NutritionDashboardComponent },
       { path: 'agentic-teams', component: AgenticTeamDashboardComponent },
       { path: 'startup-advisor', component: StartupAdvisorDashboardComponent },
+      { path: 'persona-testing', component: PersonaTestingDashboardComponent },
+      { path: 'persona-testing/audit/:runId', component: PersonaTestAuditPanelComponent },
     ],
   },
   { path: '**', redirectTo: '/dashboard' },

--- a/user-interface/src/app/components/app-shell/app-shell.component.html
+++ b/user-interface/src/app/components/app-shell/app-shell.component.html
@@ -62,6 +62,10 @@
           <mat-icon>code</mat-icon>
           <span>Coding Team</span>
         </a>
+        <a routerLink="/persona-testing" routerLinkActive="active" class="nav-link nav-link-nested">
+          <mat-icon>science</mat-icon>
+          <span>Persona Testing</span>
+        </a>
       </div>
 
       <div class="nav-group">

--- a/user-interface/src/app/components/persona-test-audit-panel/persona-test-audit-panel.component.html
+++ b/user-interface/src/app/components/persona-test-audit-panel/persona-test-audit-panel.component.html
@@ -1,0 +1,203 @@
+<div class="page-header">
+  <a routerLink="/persona-testing" class="back-link">
+    <mat-icon>arrow_back</mat-icon> Back to Persona Testing
+  </a>
+  <h1>Test Run Audit</h1>
+  @if (run) {
+    <div class="run-meta">
+      <span class="run-id">{{ run.run_id }}</span>
+      <span class="run-status" [class]="statusClass">{{ formatStatus(run.status) }}</span>
+    </div>
+  }
+</div>
+
+@if (loading) {
+  <div class="loading-state">
+    <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+    <p>Loading run details...</p>
+  </div>
+}
+
+@if (error) {
+  <div class="error-state">
+    <mat-icon>error_outline</mat-icon>
+    <p>{{ error }}</p>
+  </div>
+}
+
+@if (run) {
+  <mat-tab-group animationDuration="200ms">
+
+    <!-- ═══════════ Overview Tab ═══════════ -->
+    <mat-tab label="Overview">
+      <div class="tab-content">
+        <mat-card appearance="outlined">
+          <mat-card-header>
+            <mat-card-title>Run Details</mat-card-title>
+          </mat-card-header>
+          <mat-card-content>
+            <div class="detail-grid">
+              <div class="detail-item">
+                <span class="detail-label">Run ID</span>
+                <span class="detail-value mono">{{ run.run_id }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="detail-label">Status</span>
+                <span class="detail-value">
+                  <span class="run-status" [class]="statusClass">{{ formatStatus(run.status) }}</span>
+                </span>
+              </div>
+              <div class="detail-item">
+                <span class="detail-label">Created</span>
+                <span class="detail-value">{{ run.created_at }}</span>
+              </div>
+              <div class="detail-item">
+                <span class="detail-label">Updated</span>
+                <span class="detail-value">{{ run.updated_at }}</span>
+              </div>
+              @if (run.se_job_id) {
+                <div class="detail-item">
+                  <span class="detail-label">SE Job ID</span>
+                  <span class="detail-value mono">{{ run.se_job_id }}</span>
+                </div>
+              }
+              @if (run.analysis_job_id) {
+                <div class="detail-item">
+                  <span class="detail-label">Analysis Job ID</span>
+                  <span class="detail-value mono">{{ run.analysis_job_id }}</span>
+                </div>
+              }
+              @if (run.repo_path) {
+                <div class="detail-item">
+                  <span class="detail-label">Repository Path</span>
+                  <span class="detail-value mono">{{ run.repo_path }}</span>
+                </div>
+              }
+              @if (run.error) {
+                <div class="detail-item detail-item-full">
+                  <span class="detail-label">Error</span>
+                  <span class="detail-value error-text">{{ run.error }}</span>
+                </div>
+              }
+            </div>
+          </mat-card-content>
+        </mat-card>
+
+        @if (!isTerminal) {
+          <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+          <p class="muted-text">Test is still running. This page auto-refreshes every 10 seconds.</p>
+        }
+      </div>
+    </mat-tab>
+
+    <!-- ═══════════ Spec Tab ═══════════ -->
+    <mat-tab label="Generated Spec">
+      <div class="tab-content">
+        @if (run.spec_content) {
+          <mat-card appearance="outlined" class="spec-card">
+            <mat-card-content>
+              <div class="spec-content markdown-content">
+                <pre class="spec-pre">{{ run.spec_content }}</pre>
+              </div>
+            </mat-card-content>
+          </mat-card>
+        } @else {
+          <div class="empty-tab">
+            <mat-icon>description</mat-icon>
+            <p>No spec generated yet. The persona will generate a product specification as the first step.</p>
+          </div>
+        }
+      </div>
+    </mat-tab>
+
+    <!-- ═══════════ Decisions Tab ═══════════ -->
+    <mat-tab label="Decisions ({{ decisions.length }})">
+      <div class="tab-content">
+        @if (decisions.length) {
+          <mat-accordion>
+            @for (d of decisions; track d.decision_id) {
+              <mat-expansion-panel>
+                <mat-expansion-panel-header>
+                  <mat-panel-title>
+                    {{ d.question_text | slice:0:80 }}@if (d.question_text.length > 80) {... }
+                  </mat-panel-title>
+                  <mat-panel-description>
+                    {{ d.timestamp }}
+                  </mat-panel-description>
+                </mat-expansion-panel-header>
+                <div class="decision-detail">
+                  <div class="decision-field">
+                    <span class="field-label">Question</span>
+                    <p>{{ d.question_text }}</p>
+                  </div>
+                  <div class="decision-field">
+                    <span class="field-label">Answer</span>
+                    <p class="answer-text">{{ d.answer_text }}</p>
+                  </div>
+                  @if (d.rationale) {
+                    <div class="decision-field">
+                      <span class="field-label">Rationale</span>
+                      <p class="rationale-text">{{ d.rationale }}</p>
+                    </div>
+                  }
+                </div>
+              </mat-expansion-panel>
+            }
+          </mat-accordion>
+        } @else {
+          <div class="empty-tab">
+            <mat-icon>question_answer</mat-icon>
+            <p>No decisions recorded yet. The persona will answer questions from the SE team as they arise.</p>
+          </div>
+        }
+      </div>
+    </mat-tab>
+
+    <!-- ═══════════ Artifacts Tab ═══════════ -->
+    <mat-tab label="Artifacts">
+      <div class="tab-content">
+        @if (artifacts?.se_job_status) {
+          <mat-card appearance="outlined">
+            <mat-card-header>
+              <mat-card-title>SE Team Pipeline</mat-card-title>
+            </mat-card-header>
+            <mat-card-content>
+              @if (seJobProgress !== null) {
+                <div class="detail-item">
+                  <span class="detail-label">Progress</span>
+                  <mat-progress-bar mode="determinate" [value]="seJobProgress"></mat-progress-bar>
+                  <span class="progress-pct">{{ seJobProgress }}%</span>
+                </div>
+              }
+
+              @if (artifacts?.repo_path) {
+                <div class="detail-item">
+                  <span class="detail-label">Output Repository</span>
+                  <span class="detail-value mono">{{ artifacts!.repo_path }}</span>
+                </div>
+              }
+
+              @if (seJobTaskIds.length) {
+                <h4 class="tasks-heading">Tasks</h4>
+                <div class="tasks-list">
+                  @for (taskId of seJobTaskIds; track taskId) {
+                    <div class="task-item">
+                      <span class="task-status" [class]="'status-' + getTaskStatus(taskId)">{{ getTaskStatus(taskId) }}</span>
+                      <span class="task-title">{{ getTaskTitle(taskId) }}</span>
+                    </div>
+                  }
+                </div>
+              }
+            </mat-card-content>
+          </mat-card>
+        } @else {
+          <div class="empty-tab">
+            <mat-icon>inventory_2</mat-icon>
+            <p>No artifacts available yet. Artifacts will appear once the SE team begins processing.</p>
+          </div>
+        }
+      </div>
+    </mat-tab>
+
+  </mat-tab-group>
+}

--- a/user-interface/src/app/components/persona-test-audit-panel/persona-test-audit-panel.component.scss
+++ b/user-interface/src/app/components/persona-test-audit-panel/persona-test-audit-panel.component.scss
@@ -1,0 +1,290 @@
+.page-header {
+  margin-bottom: var(--kh-space-4, 1rem);
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--kh-space-1, 0.25rem);
+  color: var(--mat-sys-primary, #1976d2);
+  text-decoration: none;
+  font-size: var(--kh-text-sm, 0.875rem);
+  margin-bottom: var(--kh-space-2, 0.5rem);
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+.run-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--kh-space-3, 0.75rem);
+  margin-top: var(--kh-space-1, 0.25rem);
+}
+
+.run-id {
+  font-family: var(--kh-font-mono, monospace);
+  font-size: var(--kh-text-sm, 0.875rem);
+  color: var(--kh-text-secondary, rgba(0, 0, 0, 0.7));
+}
+
+.run-status {
+  padding: 2px 10px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+
+  &.status-pending,
+  &.status-generating_spec,
+  &.status-submitting_analysis,
+  &.status-polling_analysis,
+  &.status-answering_analysis_questions,
+  &.status-submitting_build,
+  &.status-polling_build,
+  &.status-answering_build_questions {
+    background: var(--kh-accent-subtle, #e3f2fd);
+    color: var(--kh-accent-text, #1565c0);
+  }
+
+  &.status-completed {
+    background: var(--kh-success-subtle, #e8f5e9);
+    color: var(--kh-success, #2e7d32);
+  }
+
+  &.status-failed {
+    background: var(--kh-error-subtle, #ffebee);
+    color: var(--kh-error, #c62828);
+  }
+}
+
+// ── Tab Content ───────────────────────────────────────────────────────────
+
+.tab-content {
+  padding: var(--kh-space-4, 1rem) 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--kh-space-4, 1rem);
+  max-width: 900px;
+}
+
+.muted-text {
+  color: var(--kh-text-muted, rgba(0, 0, 0, 0.54));
+  font-size: var(--kh-text-sm, 0.875rem);
+}
+
+.error-text {
+  color: var(--kh-error, #c62828);
+}
+
+// ── Detail Grid ───────────────────────────────────────────────────────────
+
+.detail-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--kh-space-4, 1rem);
+  padding: var(--kh-space-2, 0.5rem) 0;
+}
+
+.detail-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--kh-space-1, 0.25rem);
+
+  &.detail-item-full {
+    grid-column: 1 / -1;
+  }
+}
+
+.detail-label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--kh-text-muted, rgba(0, 0, 0, 0.54));
+}
+
+.detail-value {
+  font-size: var(--kh-text-sm, 0.875rem);
+  color: var(--kh-text-primary, rgba(0, 0, 0, 0.87));
+
+  &.mono {
+    font-family: var(--kh-font-mono, monospace);
+    font-size: 0.8rem;
+    word-break: break-all;
+  }
+}
+
+// ── Spec Content ──────────────────────────────────────────────────────────
+
+.spec-card {
+  max-width: 100%;
+}
+
+.spec-pre {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  font-family: var(--kh-font-mono, monospace);
+  font-size: 0.8rem;
+  line-height: 1.6;
+  margin: 0;
+  color: var(--kh-text-primary, rgba(0, 0, 0, 0.87));
+}
+
+// ── Decisions ─────────────────────────────────────────────────────────────
+
+.decision-detail {
+  display: flex;
+  flex-direction: column;
+  gap: var(--kh-space-3, 0.75rem);
+  padding: var(--kh-space-2, 0.5rem) 0;
+}
+
+.decision-field {
+  .field-label {
+    display: block;
+    font-size: 0.7rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--kh-text-muted, rgba(0, 0, 0, 0.54));
+    margin-bottom: var(--kh-space-1, 0.25rem);
+  }
+
+  p {
+    margin: 0;
+    font-size: var(--kh-text-sm, 0.875rem);
+    line-height: 1.5;
+  }
+
+  .answer-text {
+    font-weight: 500;
+    color: var(--mat-sys-primary, #1976d2);
+  }
+
+  .rationale-text {
+    color: var(--kh-text-secondary, rgba(0, 0, 0, 0.7));
+    font-style: italic;
+  }
+}
+
+// ── Artifacts / Tasks ─────────────────────────────────────────────────────
+
+.tasks-heading {
+  margin: var(--kh-space-4, 1rem) 0 var(--kh-space-2, 0.5rem);
+  font-size: var(--kh-text-sm, 0.875rem);
+  font-weight: 600;
+}
+
+.tasks-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--kh-space-1, 0.25rem);
+}
+
+.task-item {
+  display: flex;
+  align-items: center;
+  gap: var(--kh-space-2, 0.5rem);
+  padding: 0.35rem 0.5rem;
+  border-radius: var(--kh-radius-md, 4px);
+  font-size: var(--kh-text-sm, 0.875rem);
+
+  .task-status {
+    padding: 1px 6px;
+    border-radius: 999px;
+    font-size: 0.6rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    min-width: 60px;
+    text-align: center;
+
+    &.status-completed {
+      background: var(--kh-success-subtle, #e8f5e9);
+      color: var(--kh-success, #2e7d32);
+    }
+    &.status-running, &.status-in_progress {
+      background: var(--kh-accent-subtle, #e3f2fd);
+      color: var(--kh-accent-text, #1565c0);
+    }
+    &.status-pending, &.status-queued {
+      background: rgba(113, 113, 122, 0.1);
+      color: var(--kh-text-muted, rgba(0, 0, 0, 0.54));
+    }
+    &.status-failed {
+      background: var(--kh-error-subtle, #ffebee);
+      color: var(--kh-error, #c62828);
+    }
+  }
+
+  .task-title {
+    color: var(--kh-text-primary, rgba(0, 0, 0, 0.87));
+  }
+}
+
+.progress-pct {
+  font-size: 0.75rem;
+  color: var(--kh-text-muted, rgba(0, 0, 0, 0.54));
+  margin-top: var(--kh-space-1, 0.25rem);
+}
+
+// ── Empty / Loading / Error States ────────────────────────────────────────
+
+.loading-state,
+.error-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: var(--kh-space-6, 1.5rem);
+  gap: var(--kh-space-2, 0.5rem);
+  text-align: center;
+
+  mat-icon {
+    font-size: 48px;
+    width: 48px;
+    height: 48px;
+    color: var(--kh-text-muted, rgba(0, 0, 0, 0.38));
+  }
+
+  p {
+    color: var(--kh-text-muted, rgba(0, 0, 0, 0.54));
+    font-size: var(--kh-text-md, 0.9375rem);
+  }
+}
+
+.error-state mat-icon {
+  color: var(--kh-error, #c62828);
+}
+
+.empty-tab {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: var(--kh-space-8, 3rem) var(--kh-space-4, 1rem);
+  text-align: center;
+
+  mat-icon {
+    font-size: 48px;
+    width: 48px;
+    height: 48px;
+    color: var(--kh-text-muted, rgba(0, 0, 0, 0.38));
+    opacity: 0.4;
+    margin-bottom: var(--kh-space-3, 0.75rem);
+  }
+
+  p {
+    margin: 0;
+    color: var(--kh-text-muted, rgba(0, 0, 0, 0.54));
+    font-size: var(--kh-text-md, 0.9375rem);
+    max-width: 420px;
+  }
+}

--- a/user-interface/src/app/components/persona-test-audit-panel/persona-test-audit-panel.component.spec.ts
+++ b/user-interface/src/app/components/persona-test-audit-panel/persona-test-audit-panel.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
+import { PersonaTestAuditPanelComponent } from './persona-test-audit-panel.component';
+
+describe('PersonaTestAuditPanelComponent', () => {
+  let component: PersonaTestAuditPanelComponent;
+  let fixture: ComponentFixture<PersonaTestAuditPanelComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PersonaTestAuditPanelComponent],
+      providers: [provideHttpClient(), provideRouter([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PersonaTestAuditPanelComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/user-interface/src/app/components/persona-test-audit-panel/persona-test-audit-panel.component.ts
+++ b/user-interface/src/app/components/persona-test-audit-panel/persona-test-audit-panel.component.ts
@@ -1,0 +1,135 @@
+import { Component, inject, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { Subscription, timer, EMPTY } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTabsModule } from '@angular/material/tabs';
+import { MatCardModule } from '@angular/material/card';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { PersonaTestingApiService } from '../../services/persona-testing-api.service';
+import type { PersonaTestRunDetail, PersonaDecision, RunArtifacts } from '../../models';
+
+const POLL_MS = 10_000;
+const TERMINAL_STATUSES = ['completed', 'failed'];
+
+@Component({
+  selector: 'app-persona-test-audit-panel',
+  standalone: true,
+  imports: [
+    CommonModule,
+    RouterLink,
+    MatButtonModule,
+    MatIconModule,
+    MatTabsModule,
+    MatCardModule,
+    MatExpansionModule,
+    MatProgressBarModule,
+  ],
+  templateUrl: './persona-test-audit-panel.component.html',
+  styleUrl: './persona-test-audit-panel.component.scss',
+})
+export class PersonaTestAuditPanelComponent implements OnInit, OnDestroy {
+  private readonly api = inject(PersonaTestingApiService);
+  private readonly route = inject(ActivatedRoute);
+  private statusSub: Subscription | null = null;
+
+  runId = '';
+  run: PersonaTestRunDetail | null = null;
+  artifacts: RunArtifacts | null = null;
+  loading = true;
+  error: string | null = null;
+
+  ngOnInit(): void {
+    this.runId = this.route.snapshot.paramMap.get('runId') ?? '';
+    if (!this.runId) {
+      this.error = 'No run ID provided';
+      this.loading = false;
+      return;
+    }
+
+    this.statusSub = timer(0, POLL_MS)
+      .pipe(
+        switchMap(() => {
+          if (this.run && TERMINAL_STATUSES.includes(this.run.status)) {
+            return EMPTY;
+          }
+          return this.api.getRunStatus(this.runId);
+        }),
+      )
+      .subscribe({
+        next: (detail) => {
+          this.run = detail;
+          this.loading = false;
+          if (TERMINAL_STATUSES.includes(detail.status)) {
+            this.loadArtifacts();
+          }
+        },
+        error: (err) => {
+          this.error = err?.error?.detail ?? 'Failed to load run status';
+          this.loading = false;
+        },
+      });
+
+    this.loadArtifacts();
+  }
+
+  ngOnDestroy(): void {
+    this.statusSub?.unsubscribe();
+  }
+
+  private loadArtifacts(): void {
+    this.api.getRunArtifacts(this.runId).subscribe({
+      next: (a) => (this.artifacts = a),
+    });
+  }
+
+  get isTerminal(): boolean {
+    return !!this.run && TERMINAL_STATUSES.includes(this.run.status);
+  }
+
+  get decisions(): PersonaDecision[] {
+    return this.run?.decisions ?? [];
+  }
+
+  get statusClass(): string {
+    return this.run ? `status-${this.run.status}` : '';
+  }
+
+  formatStatus(status: string): string {
+    return status.replace(/_/g, ' ');
+  }
+
+  get seJobProgress(): number | null {
+    const s = this.artifacts?.se_job_status as Record<string, unknown> | undefined;
+    if (!s) return null;
+    return (s['progress'] as number) ?? null;
+  }
+
+  get seJobTaskStates(): Record<string, unknown> | null {
+    const s = this.artifacts?.se_job_status as Record<string, unknown> | undefined;
+    if (!s) return null;
+    return (s['task_states'] as Record<string, unknown>) ?? null;
+  }
+
+  get seJobTaskIds(): string[] {
+    const states = this.seJobTaskStates;
+    return states ? Object.keys(states) : [];
+  }
+
+  getTaskStatus(taskId: string): string {
+    const states = this.seJobTaskStates;
+    if (!states) return '';
+    const task = states[taskId] as Record<string, unknown> | undefined;
+    return (task?.['status'] as string) ?? '';
+  }
+
+  getTaskTitle(taskId: string): string {
+    const states = this.seJobTaskStates;
+    if (!states) return taskId;
+    const task = states[taskId] as Record<string, unknown> | undefined;
+    return (task?.['title'] as string) ?? taskId;
+  }
+}

--- a/user-interface/src/app/components/persona-testing-dashboard/persona-testing-dashboard.component.html
+++ b/user-interface/src/app/components/persona-testing-dashboard/persona-testing-dashboard.component.html
@@ -1,0 +1,96 @@
+<div class="page-header">
+  <h1>Persona Testing</h1>
+  <p class="page-subtitle">Test the software engineering team by selecting a project persona and running an autonomous end-to-end build.</p>
+</div>
+
+<!-- ════════════════════════════════════════════════════════════════════════ -->
+<!-- Persona Selector                                                       -->
+<!-- ════════════════════════════════════════════════════════════════════════ -->
+<section class="persona-selector">
+  <h2 class="section-title">Select a Persona</h2>
+  <div class="persona-cards">
+    @for (persona of personas; track persona.id) {
+      <mat-card class="persona-card" appearance="outlined">
+        <mat-card-header>
+          <mat-icon mat-card-avatar class="persona-icon">{{ persona.icon }}</mat-icon>
+          <mat-card-title>{{ persona.name }}</mat-card-title>
+          <mat-card-subtitle>{{ persona.id }}</mat-card-subtitle>
+        </mat-card-header>
+        <mat-card-content>
+          <p>{{ persona.description }}</p>
+        </mat-card-content>
+        <mat-card-actions align="end">
+          <button mat-raised-button color="primary" (click)="startTest()" [disabled]="starting">
+            <mat-icon>play_arrow</mat-icon>
+            @if (starting) {
+              Starting...
+            } @else {
+              Start Test
+            }
+          </button>
+        </mat-card-actions>
+      </mat-card>
+    }
+  </div>
+  @if (startError) {
+    <p class="error-text">{{ startError }}</p>
+  }
+  @if (!personas.length) {
+    <p class="muted-text">Loading personas...</p>
+  }
+</section>
+
+<!-- ════════════════════════════════════════════════════════════════════════ -->
+<!-- Running Tests                                                          -->
+<!-- ════════════════════════════════════════════════════════════════════════ -->
+@if (runningRuns.length) {
+  <section class="runs-section">
+    <h3 class="list-section-title">Running</h3>
+    <div class="runs-list">
+      @for (run of runningRuns; track run.run_id) {
+        <div class="run-item" (click)="openAudit(run.run_id)">
+          <div class="run-row">
+            <span class="run-id">{{ run.run_id }}</span>
+            <span class="run-status status-running">{{ formatStatus(run.status) }}</span>
+          </div>
+          <span class="run-date">Started {{ run.created_at }}</span>
+          <mat-progress-bar mode="indeterminate"></mat-progress-bar>
+        </div>
+      }
+    </div>
+  </section>
+}
+
+<!-- ════════════════════════════════════════════════════════════════════════ -->
+<!-- Completed Tests                                                        -->
+<!-- ════════════════════════════════════════════════════════════════════════ -->
+@if (completedRuns.length) {
+  <section class="runs-section">
+    <h3 class="list-section-title">Completed</h3>
+    <div class="runs-list">
+      @for (run of completedRuns; track run.run_id) {
+        <div class="run-item" (click)="openAudit(run.run_id)">
+          <div class="run-row">
+            <span class="run-id">{{ run.run_id }}</span>
+            <span class="run-status" [class]="'status-' + run.status">{{ formatStatus(run.status) }}</span>
+          </div>
+          <span class="run-date">{{ run.updated_at }}</span>
+          @if (run.error) {
+            <span class="run-error">{{ run.error }}</span>
+          }
+        </div>
+      }
+    </div>
+  </section>
+}
+
+<!-- ════════════════════════════════════════════════════════════════════════ -->
+<!-- Empty State                                                            -->
+<!-- ════════════════════════════════════════════════════════════════════════ -->
+@if (!runningRuns.length && !completedRuns.length && personas.length) {
+  <div class="empty-state">
+    <mat-icon class="empty-state-icon">science</mat-icon>
+    <h2>No test runs yet</h2>
+    <p>Select a persona above and click "Start Test" to begin an autonomous test of the software engineering team.</p>
+  </div>
+}

--- a/user-interface/src/app/components/persona-testing-dashboard/persona-testing-dashboard.component.html
+++ b/user-interface/src/app/components/persona-testing-dashboard/persona-testing-dashboard.component.html
@@ -48,7 +48,7 @@
     <h3 class="list-section-title">Running</h3>
     <div class="runs-list">
       @for (run of runningRuns; track run.run_id) {
-        <div class="run-item" (click)="openAudit(run.run_id)">
+        <div class="run-item" tabindex="0" role="button" (click)="openAudit(run.run_id)" (keydown.enter)="openAudit(run.run_id)">
           <div class="run-row">
             <span class="run-id">{{ run.run_id }}</span>
             <span class="run-status status-running">{{ formatStatus(run.status) }}</span>
@@ -69,7 +69,7 @@
     <h3 class="list-section-title">Completed</h3>
     <div class="runs-list">
       @for (run of completedRuns; track run.run_id) {
-        <div class="run-item" (click)="openAudit(run.run_id)">
+        <div class="run-item" tabindex="0" role="button" (click)="openAudit(run.run_id)" (keydown.enter)="openAudit(run.run_id)">
           <div class="run-row">
             <span class="run-id">{{ run.run_id }}</span>
             <span class="run-status" [class]="'status-' + run.status">{{ formatStatus(run.status) }}</span>

--- a/user-interface/src/app/components/persona-testing-dashboard/persona-testing-dashboard.component.scss
+++ b/user-interface/src/app/components/persona-testing-dashboard/persona-testing-dashboard.component.scss
@@ -1,0 +1,185 @@
+.page-subtitle {
+  margin-top: var(--kh-space-1, 0.25rem);
+  margin-bottom: var(--kh-space-2, 0.5rem);
+  color: var(--kh-text-tertiary, rgba(0, 0, 0, 0.54));
+  font-size: var(--kh-text-md, 0.9375rem);
+}
+
+// ── Persona Selector ──────────────────────────────────────────────────────
+
+.section-title {
+  margin: 0 0 var(--kh-space-3, 0.75rem) 0;
+  font-size: var(--kh-text-lg, 1.125rem);
+  font-weight: 600;
+}
+
+.persona-cards {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+  gap: var(--kh-space-4, 1rem);
+  margin-bottom: var(--kh-space-6, 1.5rem);
+}
+
+.persona-card {
+  .persona-icon {
+    font-size: 40px;
+    width: 40px;
+    height: 40px;
+    color: var(--mat-sys-primary, #1976d2);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  mat-card-content p {
+    font-size: var(--kh-text-sm, 0.875rem);
+    color: var(--kh-text-secondary, rgba(0, 0, 0, 0.7));
+    line-height: 1.5;
+  }
+}
+
+.error-text {
+  color: var(--kh-error, #c62828);
+  font-size: var(--kh-text-sm, 0.875rem);
+}
+
+.muted-text {
+  color: var(--kh-text-muted, rgba(0, 0, 0, 0.54));
+  font-size: var(--kh-text-sm, 0.875rem);
+}
+
+// ── Runs List ─────────────────────────────────────────────────────────────
+
+.runs-section {
+  max-width: 720px;
+  margin-bottom: var(--kh-space-4, 1rem);
+}
+
+.list-section-title {
+  margin: 0 0 var(--kh-space-2, 0.5rem) 0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--kh-text-muted, rgba(0, 0, 0, 0.54));
+}
+
+.runs-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--kh-space-2, 0.5rem);
+}
+
+.run-item {
+  display: flex;
+  flex-direction: column;
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--kh-border, rgba(0, 0, 0, 0.12));
+  border-radius: var(--kh-radius-md, 4px);
+  background: var(--kh-surface-2, transparent);
+  cursor: pointer;
+  gap: var(--kh-space-1, 0.25rem);
+  transition: all 0.15s ease;
+
+  &:hover {
+    background: var(--kh-surface-3, rgba(0, 0, 0, 0.04));
+    border-color: var(--kh-border-strong, rgba(0, 0, 0, 0.24));
+  }
+
+  .run-row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--kh-space-2, 0.5rem);
+  }
+
+  .run-id {
+    font-size: 0.75rem;
+    font-family: var(--kh-font-mono, monospace);
+    color: var(--kh-text-primary, inherit);
+    font-weight: 500;
+  }
+
+  .run-date {
+    font-size: 0.7rem;
+    color: var(--kh-text-muted, rgba(0, 0, 0, 0.54));
+  }
+
+  .run-error {
+    font-size: 0.75rem;
+    color: var(--kh-error, #c62828);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .run-status {
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+
+    &.status-running,
+    &.status-pending,
+    &.status-generating_spec,
+    &.status-submitting_analysis,
+    &.status-polling_analysis,
+    &.status-answering_analysis_questions,
+    &.status-submitting_build,
+    &.status-polling_build,
+    &.status-answering_build_questions {
+      background: var(--kh-accent-subtle, #e3f2fd);
+      color: var(--kh-accent-text, #1565c0);
+    }
+
+    &.status-completed {
+      background: var(--kh-success-subtle, #e8f5e9);
+      color: var(--kh-success, #2e7d32);
+    }
+
+    &.status-failed {
+      background: var(--kh-error-subtle, #ffebee);
+      color: var(--kh-error, #c62828);
+    }
+  }
+
+  mat-progress-bar {
+    margin-top: var(--kh-space-1, 0.25rem);
+  }
+}
+
+// ── Empty State ───────────────────────────────────────────────────────────
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--kh-space-10, 4rem) var(--kh-space-4, 1rem);
+  text-align: center;
+
+  .empty-state-icon {
+    font-size: 64px;
+    width: 64px;
+    height: 64px;
+    color: var(--kh-text-muted, rgba(0, 0, 0, 0.38));
+    margin-bottom: var(--kh-space-4, 1rem);
+    opacity: 0.4;
+  }
+
+  h2 {
+    margin: 0 0 var(--kh-space-2, 0.5rem) 0;
+    color: var(--kh-text-secondary, rgba(0, 0, 0, 0.7));
+    font-size: var(--kh-text-xl, 1.25rem);
+    font-weight: 600;
+  }
+
+  p {
+    margin: 0;
+    color: var(--kh-text-muted, rgba(0, 0, 0, 0.54));
+    font-size: var(--kh-text-md, 0.9375rem);
+    max-width: 480px;
+  }
+}

--- a/user-interface/src/app/components/persona-testing-dashboard/persona-testing-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/persona-testing-dashboard/persona-testing-dashboard.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideRouter } from '@angular/router';
+import { PersonaTestingDashboardComponent } from './persona-testing-dashboard.component';
+
+describe('PersonaTestingDashboardComponent', () => {
+  let component: PersonaTestingDashboardComponent;
+  let fixture: ComponentFixture<PersonaTestingDashboardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PersonaTestingDashboardComponent],
+      providers: [provideHttpClient(), provideRouter([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PersonaTestingDashboardComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/user-interface/src/app/components/persona-testing-dashboard/persona-testing-dashboard.component.ts
+++ b/user-interface/src/app/components/persona-testing-dashboard/persona-testing-dashboard.component.ts
@@ -1,0 +1,83 @@
+import { Component, inject, OnInit, OnDestroy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { Subscription, timer } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatCardModule } from '@angular/material/card';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { PersonaTestingApiService } from '../../services/persona-testing-api.service';
+import type { PersonaInfo, PersonaTestRun } from '../../models';
+
+const POLL_RUNS_MS = 15_000;
+const TERMINAL_STATUSES = ['completed', 'failed'];
+
+@Component({
+  selector: 'app-persona-testing-dashboard',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatIconModule,
+    MatCardModule,
+    MatProgressBarModule,
+  ],
+  templateUrl: './persona-testing-dashboard.component.html',
+  styleUrl: './persona-testing-dashboard.component.scss',
+})
+export class PersonaTestingDashboardComponent implements OnInit, OnDestroy {
+  private readonly api = inject(PersonaTestingApiService);
+  private readonly router = inject(Router);
+  private runsSub: Subscription | null = null;
+
+  personas: PersonaInfo[] = [];
+  allRuns: PersonaTestRun[] = [];
+  runningRuns: PersonaTestRun[] = [];
+  completedRuns: PersonaTestRun[] = [];
+  starting = false;
+  startError: string | null = null;
+
+  ngOnInit(): void {
+    this.api.getPersonas().subscribe({
+      next: (resp) => (this.personas = resp.personas),
+    });
+
+    this.runsSub = timer(0, POLL_RUNS_MS)
+      .pipe(switchMap(() => this.api.getRuns()))
+      .subscribe({
+        next: (resp) => {
+          this.allRuns = resp.runs;
+          this.runningRuns = this.allRuns.filter((r) => !TERMINAL_STATUSES.includes(r.status));
+          this.completedRuns = this.allRuns.filter((r) => TERMINAL_STATUSES.includes(r.status));
+        },
+      });
+  }
+
+  ngOnDestroy(): void {
+    this.runsSub?.unsubscribe();
+  }
+
+  startTest(): void {
+    this.starting = true;
+    this.startError = null;
+    this.api.startTest().subscribe({
+      next: (resp) => {
+        this.starting = false;
+        this.router.navigate(['/persona-testing/audit', resp.run_id]);
+      },
+      error: (err) => {
+        this.starting = false;
+        this.startError = err?.error?.detail ?? 'Failed to start test';
+      },
+    });
+  }
+
+  openAudit(runId: string): void {
+    this.router.navigate(['/persona-testing/audit', runId]);
+  }
+
+  formatStatus(status: string): string {
+    return status.replace(/_/g, ' ');
+  }
+}

--- a/user-interface/src/app/models/index.ts
+++ b/user-interface/src/app/models/index.ts
@@ -21,3 +21,4 @@ export * from './sales-team.model';
 export * from './startup-advisor.model';
 export * from './agentic-team.model';
 export * from './team-assistant.model';
+export * from './persona-testing.model';

--- a/user-interface/src/app/models/persona-testing.model.ts
+++ b/user-interface/src/app/models/persona-testing.model.ts
@@ -1,0 +1,44 @@
+/** Available persona for SE team testing. */
+export interface PersonaInfo {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+}
+
+/** Summary of a persona test run (from GET /runs). */
+export interface PersonaTestRun {
+  run_id: string;
+  status: string;
+  se_job_id?: string;
+  analysis_job_id?: string;
+  created_at: string;
+  updated_at: string;
+  error?: string;
+}
+
+/** A single decision made by the persona during a test run. */
+export interface PersonaDecision {
+  decision_id: number;
+  question_id: string;
+  question_text: string;
+  answer_text: string;
+  rationale: string;
+  timestamp: string;
+}
+
+/** Full detail of a persona test run including decisions (from GET /status/{run_id}). */
+export interface PersonaTestRunDetail extends PersonaTestRun {
+  spec_content?: string;
+  repo_path?: string;
+  decisions: PersonaDecision[];
+}
+
+/** Artifacts produced during a persona test run (from GET /runs/{run_id}/artifacts). */
+export interface RunArtifacts {
+  run_id: string;
+  se_job_id?: string;
+  se_job_status?: Record<string, unknown>;
+  repo_path?: string;
+  spec_content?: string;
+}

--- a/user-interface/src/app/services/persona-testing-api.service.ts
+++ b/user-interface/src/app/services/persona-testing-api.service.ts
@@ -1,0 +1,44 @@
+import { HttpClient } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+import type {
+  PersonaInfo,
+  PersonaTestRun,
+  PersonaTestRunDetail,
+  PersonaDecision,
+  RunArtifacts,
+} from '../models';
+
+@Injectable({ providedIn: 'root' })
+export class PersonaTestingApiService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = environment.personaTestingApiUrl;
+
+  getPersonas(): Observable<{ personas: PersonaInfo[] }> {
+    return this.http.get<{ personas: PersonaInfo[] }>(`${this.baseUrl}/personas`);
+  }
+
+  startTest(): Observable<{ run_id: string; status: string; message: string }> {
+    return this.http.post<{ run_id: string; status: string; message: string }>(
+      `${this.baseUrl}/start`,
+      {},
+    );
+  }
+
+  getRuns(): Observable<{ runs: PersonaTestRun[] }> {
+    return this.http.get<{ runs: PersonaTestRun[] }>(`${this.baseUrl}/runs`);
+  }
+
+  getRunStatus(runId: string): Observable<PersonaTestRunDetail> {
+    return this.http.get<PersonaTestRunDetail>(`${this.baseUrl}/status/${runId}`);
+  }
+
+  getDecisions(runId: string): Observable<PersonaDecision[]> {
+    return this.http.get<PersonaDecision[]>(`${this.baseUrl}/decisions/${runId}`);
+  }
+
+  getRunArtifacts(runId: string): Observable<RunArtifacts> {
+    return this.http.get<RunArtifacts>(`${this.baseUrl}/runs/${runId}/artifacts`);
+  }
+}

--- a/user-interface/src/environments/environment.prod.ts
+++ b/user-interface/src/environments/environment.prod.ts
@@ -25,4 +25,5 @@ export const environment = {
   salesApiUrl: `${apiBase}/api/sales`,
   agenticTeamProvisioningApiUrl: `${apiBase}/api/agentic-team-provisioning`,
   startupAdvisorApiUrl: `${apiBase}/api/startup-advisor`,
+  personaTestingApiUrl: `${apiBase}/api/user-agent-founder`,
 };

--- a/user-interface/src/environments/environment.ts
+++ b/user-interface/src/environments/environment.ts
@@ -26,5 +26,6 @@ export const environment = {
   salesApiUrl: `${apiBase}/api/sales`,
   agenticTeamProvisioningApiUrl: `${apiBase}/api/agentic-team-provisioning`,
   startupAdvisorApiUrl: `${apiBase}/api/startup-advisor`,
+  personaTestingApiUrl: `${apiBase}/api/user-agent-founder`,
 };
 


### PR DESCRIPTION
## Summary
This PR adds a comprehensive persona testing interface to the user interface, allowing users to run autonomous end-to-end builds with different project personas and audit the results. It includes a new dashboard for persona selection and test management, an audit panel for detailed test run inspection, and supporting backend API endpoints.

## Key Changes

### Frontend Components
- **PersonaTestingDashboardComponent**: Main dashboard displaying available personas as selectable cards, listing running and completed test runs with real-time polling (15s interval), and providing navigation to audit details
- **PersonaTestAuditPanelComponent**: Detailed audit view with tabbed interface showing:
  - Overview tab with run metadata and status
  - Generated Spec tab displaying the persona-generated product specification
  - Decisions tab with expandable decision records (questions, answers, rationale)
  - Artifacts tab showing SE team pipeline progress and task status
  - Auto-polling for run status updates (10s interval) until terminal state

### Styling
- Comprehensive SCSS stylesheets for both components using design system variables (--kh-* custom properties)
- Status badge styling for different run states (pending, running, completed, failed)
- Responsive grid layouts for detail cards and persona selection
- Empty state and loading state UI patterns

### Services & Models
- **PersonaTestingApiService**: HTTP client service for all persona testing API endpoints
- **persona-testing.model.ts**: TypeScript interfaces for PersonaInfo, PersonaTestRun, PersonaTestRunDetail, PersonaDecision, and RunArtifacts

### Backend API Endpoints
- `GET /personas`: Returns list of available project personas with metadata
- `GET /runs/{run_id}/artifacts`: Retrieves artifacts and SE job status for a test run, with HTTP proxying to the unified SE team API

### Routing & Navigation
- Added `/persona-testing` and `/persona-testing/audit/:runId` routes
- Integrated navigation link in app shell sidebar
- Updated environment configuration with persona testing API URL

### Implementation Details
- Uses Angular's new control flow syntax (@if, @for) for template rendering
- Implements RxJS polling with `timer()` and `switchMap()` for auto-refresh
- Stops polling when run reaches terminal status (completed/failed)
- Graceful error handling with user-friendly error messages
- Material Design components (tabs, cards, expansion panels, progress bars)
- Monospace font rendering for IDs and technical values
- Status-based color coding (blue for running, green for completed, red for failed)

https://claude.ai/code/session_01MhqWLK7yvmgu11egdhiPUC