### PR TITLE
refactor(investment): deduplicate agents, consolidate symbols and normalization

### DIFF
--- a/backend/agents/investment_team/agents.py
+++ b/backend/agents/investment_team/agents.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
@@ -130,6 +131,8 @@ class ValidationAgent:
 class PromotionGateAgent:
     """Applies universal promotion checklist and enforces separation-of-duties gates."""
 
+    _validator = ValidationAgent()
+
     def decide(
         self,
         strategy: StrategySpec,
@@ -204,8 +207,7 @@ class PromotionGateAgent:
             )
         )
 
-        validator = ValidationAgent()
-        failures = validator.checklist_failures(validation)
+        failures = self._validator.checklist_failures(validation)
         if validation.strategy_id != strategy.strategy_id:
             failures.append("Validation report strategy_id does not match strategy spec.")
         if failures:
@@ -608,7 +610,7 @@ class FinancialAdvisorAgent:
             "correct",
             "y",
         }
-        return any(c in lowered for c in confirms)
+        return any(re.search(rf"\b{re.escape(c)}\b", lowered) for c in confirms)
 
     def _extract_topic_data(self, session: AdvisorSession, text: str) -> None:  # noqa: C901
         """Parse the user reply and populate the relevant collected fields."""
@@ -827,8 +829,6 @@ class FinancialAdvisorAgent:
                 c.max_single_position_pct = 10.0
 
             # Parse asset class caps like "60% equities, 10% crypto"
-            import re
-
             cap_pattern = re.compile(
                 r"(\d+)%?\s*(equit|stock|bond|crypto|option|real.?estate|fx|commodit)", re.I
             )
@@ -882,22 +882,12 @@ class FinancialAdvisorAgent:
     @staticmethod
     def _extract_number(text: str) -> Optional[float]:
         """Extract the first number from text, handling k/m/b suffixes and commas."""
-        import re
-
-        text = text.replace(",", "").replace("$", "")
-        match = re.search(r"(\d+(?:\.\d+)?)\s*([kmb])?", text, re.I)
-        if not match:
-            return None
-        value = float(match.group(1))
-        suffix = (match.group(2) or "").lower()
-        multipliers = {"k": 1_000, "m": 1_000_000, "b": 1_000_000_000}
-        return value * multipliers.get(suffix, 1)
+        nums = FinancialAdvisorAgent._extract_all_numbers(text)
+        return nums[0] if nums else None
 
     @staticmethod
     def _extract_all_numbers(text: str) -> List[float]:
         """Extract all numbers from text, handling k/m/b suffixes and commas."""
-        import re
-
         text = text.replace(",", "").replace("$", "")
         results: List[float] = []
         for match in re.finditer(r"(\d+(?:\.\d+)?)\s*([kmb])?", text, re.I):

--- a/backend/agents/investment_team/api/main.py
+++ b/backend/agents/investment_team/api/main.py
@@ -135,6 +135,9 @@ _paper_trading_sessions: _PersistentDict = _PersistentDict("paper_trading_sessio
 _advisor_sessions: _PersistentDict = _PersistentDict("advisor_sessions")
 
 _advisor_agent = FinancialAdvisorAgent()
+_policy_guardian = PolicyGuardianAgent()
+_orchestrator = InvestmentTeamOrchestrator()
+_committee_agent = InvestmentCommitteeAgent()
 
 
 def _now() -> str:
@@ -474,8 +477,7 @@ def validate_proposal(
     if not ips:
         raise HTTPException(status_code=404, detail=f"No IPS found for user {request.user_id}")
 
-    guardian = PolicyGuardianAgent()
-    violations = guardian.check_portfolio(ips, proposal)
+    violations = _policy_guardian.check_portfolio(ips, proposal)
 
     return ValidateProposalResponse(
         proposal_id=proposal_id,
@@ -663,14 +665,13 @@ def promotion_decision(request: PromotionDecisionRequest) -> PromotionDecisionRe
     if not ips:
         raise HTTPException(status_code=404, detail=f"No IPS found for user {request.user_id}")
 
-    orchestrator = InvestmentTeamOrchestrator()
     approver = AgentIdentity(
         agent_id=request.approver_agent_id,
         role=request.approver_role,
         version=request.approver_version,
     )
 
-    decision = orchestrator.promotion_decision(
+    decision = _orchestrator.promotion_decision(
         state=_workflow_state,
         strategy=strategy,
         validation=validation,
@@ -714,8 +715,7 @@ def workflow_queues() -> QueuesResponse:
 @app.post("/memos", response_model=CreateMemoResponse)
 def create_memo(request: CreateMemoRequest) -> CreateMemoResponse:
     """Generate an investment committee memo."""
-    committee_agent = InvestmentCommitteeAgent()
-    memo = committee_agent.draft_memo(
+    memo = _committee_agent.draft_memo(
         user_id=request.user_id,
         recommendation=request.recommendation,
         rationale=request.rationale,
@@ -808,17 +808,9 @@ class StrategyLabResultsResponse(BaseModel):
 
 def _normalize_strategy_lab_asset_class(raw: object) -> str:
     """Map LLM output to canonical labels used by the simulated ledger."""
-    x = str(raw or "stocks").lower().strip()
-    if x in ("equities", "equity", "stock"):
-        return "stocks"
-    if x in ("fx",):
-        return "forex"
-    if x in ("commodity", "metal", "energy"):
-        return "commodities"
-    allowed = frozenset({"stocks", "crypto", "forex", "options", "futures", "commodities"})
-    if x in allowed:
-        return x
-    return "stocks"
+    from investment_team.strategy_lab_context import normalize_asset_class
+
+    return normalize_asset_class(raw)
 
 
 def _run_one_strategy_lab_cycle(

--- a/backend/agents/investment_team/backtesting_agent.py
+++ b/backend/agents/investment_team/backtesting_agent.py
@@ -23,7 +23,7 @@ from .trade_simulator import (
     OpenPosition,
     TradeSimulationEngine,
     compute_metrics,
-    format_bars_table,
+    evaluate_bar,
 )
 
 logger = logging.getLogger(__name__)
@@ -38,44 +38,6 @@ _EVALUATE_SYSTEM = (
     "Be disciplined — only trade when the rules are clearly met by the price data. "
     "Remember: this is a backtest, so you must only use information available on the current bar's date."
 )
-
-_EVALUATE_PROMPT = """\
-Evaluate whether the trading strategy's rules are triggered for this historical market data.
-
-## Strategy
-Asset class: {asset_class}
-Hypothesis: {hypothesis}
-Signal: {signal_definition}
-Entry rules: {entry_rules}
-Exit rules: {exit_rules}
-Sizing rules: {sizing_rules}
-Risk limits: {risk_limits}
-
-## Current Position
-{position_status}
-
-## Available Capital
-${capital:,.2f}
-
-## Current Bar ({symbol}, {current_date})
-Open: {open}  High: {high}  Low: {low}  Close: {close}  Volume: {volume}
-
-## Recent Price History ({symbol}, last {n_bars} bars)
-{recent_bars_text}
-
-## Instructions
-Based on the strategy rules and market data above, decide your action.
-If you have NO open position, evaluate ENTRY rules. If you HAVE an open position, evaluate EXIT rules.
-Be conservative — only enter when signals are clearly met, and respect risk limits.
-Do NOT use any future information — only data up to and including the current bar.
-
-Return ONLY a JSON object with no markdown:
-{{"action": "enter_long" or "enter_short" or "exit" or "hold", "confidence": 0.0 to 1.0, \
-"shares": number_of_shares_or_0, "reasoning": "brief explanation"}}
-
-For "hold", set shares to 0. For entries, calculate shares based on sizing rules and available capital.
-For exits, set shares to 0 (will close full position).
-"""
 
 
 # ---------------------------------------------------------------------------
@@ -109,72 +71,27 @@ class BacktestingAgent:
             slippage_bps=config.slippage_bps,
         )
 
-        def evaluate(
+        def _evaluate(
             symbol: str,
             bar: OHLCVBar,
             recent: List[OHLCVBar],
             position: Optional[OpenPosition],
             capital: float,
         ) -> Dict[str, Any]:
-            return self._evaluate_bar(strategy, symbol, bar, recent, position, capital)
+            return evaluate_bar(
+                self.llm.complete_json,
+                strategy,
+                _EVALUATE_SYSTEM,
+                symbol,
+                bar,
+                recent,
+                position,
+                capital,
+            )
 
-        sim = engine.run(market_data, evaluate)
+        sim = engine.run(market_data, _evaluate)
 
         result = compute_metrics(
             sim.trades, config.initial_capital, config.start_date, config.end_date
         )
         return result, sim.trades
-
-    def _evaluate_bar(
-        self,
-        strategy: StrategySpec,
-        symbol: str,
-        current_bar: OHLCVBar,
-        recent_bars: List[OHLCVBar],
-        open_position: Optional[OpenPosition],
-        capital: float,
-    ) -> Dict[str, Any]:
-        """Ask LLM to evaluate whether entry/exit rules are met for this bar."""
-        if open_position:
-            pos_status = (
-                f"OPEN {open_position.side.upper()} position in {symbol}: "
-                f"{open_position.shares} shares @ ${open_position.entry_price:.2f} "
-                f"(entered {open_position.entry_date})"
-            )
-        else:
-            pos_status = "No open position — looking for entry signals."
-
-        prompt = _EVALUATE_PROMPT.format(
-            asset_class=strategy.asset_class,
-            hypothesis=strategy.hypothesis,
-            signal_definition=strategy.signal_definition,
-            entry_rules="; ".join(strategy.entry_rules),
-            exit_rules="; ".join(strategy.exit_rules),
-            sizing_rules="; ".join(strategy.sizing_rules),
-            risk_limits=strategy.risk_limits,
-            position_status=pos_status,
-            capital=capital,
-            symbol=symbol,
-            current_date=current_bar.date,
-            open=current_bar.open,
-            high=current_bar.high,
-            low=current_bar.low,
-            close=current_bar.close,
-            volume=current_bar.volume,
-            n_bars=len(recent_bars),
-            recent_bars_text=format_bars_table(recent_bars),
-        )
-
-        data = self.llm.complete_json(
-            prompt,
-            temperature=0.2,
-            system_prompt=_EVALUATE_SYSTEM,
-            think=True,
-        )
-
-        return {
-            "action": str(data.get("action", "hold")),
-            "confidence": float(data.get("confidence", 0.0)),
-            "shares": float(data.get("shares", 0)),
-            "reasoning": str(data.get("reasoning", "")),
-        }

--- a/backend/agents/investment_team/market_data_service.py
+++ b/backend/agents/investment_team/market_data_service.py
@@ -12,51 +12,17 @@ import httpx
 from pydantic import BaseModel
 
 from .models import StrategySpec
+from .strategy_lab_context import normalize_asset_class
+from .symbols import (
+    COINGECKO_IDS,
+    COMMODITY_SYMBOLS,
+    CRYPTO_SYMBOLS,
+    FOREX_SYMBOLS,
+    FUTURES_SYMBOLS,
+    STOCK_SYMBOLS,
+)
 
 logger = logging.getLogger(__name__)
-
-# ---------------------------------------------------------------------------
-# Symbol mapping: internal symbol -> CoinGecko API id
-# ---------------------------------------------------------------------------
-
-_COINGECKO_IDS = {
-    "BTC": "bitcoin",
-    "ETH": "ethereum",
-    "SOL": "solana",
-    "BNB": "binancecoin",
-    "XRP": "ripple",
-    "MATIC": "matic-network",
-    "AVAX": "avalanche-2",
-    "LINK": "chainlink",
-    "ADA": "cardano",
-    "DOT": "polkadot",
-}
-
-# ---------------------------------------------------------------------------
-# Symbol lists by asset class
-# ---------------------------------------------------------------------------
-
-_STOCK_SYMBOLS = ["AAPL", "MSFT", "NVDA", "TSLA", "AMZN", "META", "GOOGL", "JPM", "AMD", "SPY"]
-_CRYPTO_SYMBOLS = ["BTC", "ETH", "SOL", "BNB", "XRP", "MATIC", "AVAX", "LINK", "ADA", "DOT"]
-# Forex pairs use yfinance's =X suffix
-_FOREX_SYMBOLS = [
-    "EURUSD=X",
-    "GBPUSD=X",
-    "USDJPY=X",
-    "AUDUSD=X",
-    "USDCAD=X",
-    "NZDUSD=X",
-    "USDCHF=X",
-    "EURGBP=X",
-    "EURJPY=X",
-    "GBPJPY=X",
-]
-# Futures use yfinance's =F suffix
-_FUTURES_SYMBOLS = ["ES=F", "NQ=F", "CL=F", "GC=F", "SI=F", "ZB=F", "NG=F"]
-# Commodity ETFs (liquid proxies for commodities via yfinance)
-_COMMODITY_SYMBOLS = ["GLD", "USO", "SLV", "DBA", "UNG", "PDBC", "DBC"]
-# Broad ETFs used as a fallback
-_OTHER_SYMBOLS = ["GLD", "USO", "TLT", "QQQ", "IWM", "EEM", "GDX", "XLE", "XLF"]
 
 
 class OHLCVBar(BaseModel):
@@ -94,8 +60,7 @@ class MarketDataService:
         self, symbol: str, asset_class: str, start_date: str, end_date: str
     ) -> List[OHLCVBar]:
         """Fetch OHLCV data for an explicit date range. Routes by asset class."""
-        asset = asset_class.lower()
-        if asset == "crypto":
+        if normalize_asset_class(asset_class) == "crypto":
             return self._fetch_crypto(symbol, start_date, end_date)
         # All non-crypto assets are fetched via yfinance (stocks, forex, futures,
         # commodities, options).  yfinance supports =X (forex) and =F (futures)
@@ -104,18 +69,16 @@ class MarketDataService:
 
     def get_symbols_for_strategy(self, strategy: StrategySpec) -> List[str]:
         """Return relevant symbols based on the strategy's asset class."""
-        asset = strategy.asset_class.lower()
-        if asset == "crypto":
-            return list(_CRYPTO_SYMBOLS)
-        if asset in ("stocks", "equities", "options"):
-            return list(_STOCK_SYMBOLS)
-        if asset in ("forex", "fx"):
-            return list(_FOREX_SYMBOLS)
-        if asset == "futures":
-            return list(_FUTURES_SYMBOLS)
-        if asset in ("commodities", "commodity"):
-            return list(_COMMODITY_SYMBOLS)
-        return list(_STOCK_SYMBOLS)
+        asset = normalize_asset_class(strategy.asset_class)
+        symbol_map = {
+            "crypto": CRYPTO_SYMBOLS,
+            "stocks": STOCK_SYMBOLS,
+            "options": STOCK_SYMBOLS,
+            "forex": FOREX_SYMBOLS,
+            "futures": FUTURES_SYMBOLS,
+            "commodities": COMMODITY_SYMBOLS,
+        }
+        return list(symbol_map.get(asset, STOCK_SYMBOLS))
 
     def fetch_multi_symbol(
         self, symbols: List[str], asset_class: str, days: int = 365
@@ -155,39 +118,74 @@ class MarketDataService:
     # Internal: Yahoo Finance (stocks, forex, futures, commodities)
     # ------------------------------------------------------------------
 
-    def _fetch_stock(self, symbol: str, start_date: str, end_date: str) -> List[OHLCVBar]:
-        """Fetch stock/ETF/forex/futures OHLCV data via yfinance for an arbitrary date range."""
+    def _fetch_stock(
+        self, symbol: str, start_date: str, end_date: str, max_retries: int = 3
+    ) -> List[OHLCVBar]:
+        """Fetch stock/ETF/forex/futures OHLCV data via yfinance for an arbitrary date range.
+
+        Retries with exponential backoff on transient failures, matching the
+        CoinGecko retry pattern.
+        """
         try:
             import yfinance as yf
         except ImportError:
             logger.warning("yfinance not installed — falling back to empty data for %s", symbol)
             return []
 
-        try:
-            ticker = yf.Ticker(symbol)
-            df = ticker.history(start=start_date, end=end_date, interval="1d")
-        except Exception as exc:
-            logger.error("yfinance fetch failed for %s: %s", symbol, exc)
-            return []
-
-        if df is None or df.empty:
-            logger.warning("No data returned from yfinance for %s", symbol)
-            return []
-
-        bars: List[OHLCVBar] = []
-        for idx, row in df.iterrows():
-            bar_date = idx.strftime("%Y-%m-%d") if hasattr(idx, "strftime") else str(idx)[:10]
-            bars.append(
-                OHLCVBar(
-                    date=bar_date,
-                    open=round(float(row["Open"]), 4),
-                    high=round(float(row["High"]), 4),
-                    low=round(float(row["Low"]), 4),
-                    close=round(float(row["Close"]), 4),
-                    volume=float(row.get("Volume", 0)),
+        for attempt in range(max_retries):
+            try:
+                ticker = yf.Ticker(symbol)
+                df = ticker.history(start=start_date, end=end_date, interval="1d")
+            except Exception as exc:
+                if attempt < max_retries - 1:
+                    wait = 2 ** (attempt + 1)
+                    logger.warning(
+                        "yfinance fetch failed for %s, retrying in %ds (attempt %d): %s",
+                        symbol,
+                        wait,
+                        attempt + 1,
+                        exc,
+                    )
+                    time.sleep(wait)
+                    continue
+                logger.error(
+                    "yfinance fetch failed for %s after %d attempts: %s", symbol, max_retries, exc
                 )
-            )
-        return bars
+                return []
+
+            if df is not None and not df.empty:
+                bars: List[OHLCVBar] = []
+                for idx, row in df.iterrows():
+                    bar_date = (
+                        idx.strftime("%Y-%m-%d") if hasattr(idx, "strftime") else str(idx)[:10]
+                    )
+                    bars.append(
+                        OHLCVBar(
+                            date=bar_date,
+                            open=round(float(row["Open"]), 4),
+                            high=round(float(row["High"]), 4),
+                            low=round(float(row["Low"]), 4),
+                            close=round(float(row["Close"]), 4),
+                            volume=float(row.get("Volume", 0)),
+                        )
+                    )
+                return bars
+
+            if attempt < max_retries - 1:
+                wait = 2 ** (attempt + 1)
+                logger.warning(
+                    "No data from yfinance for %s, retrying in %ds (attempt %d)",
+                    symbol,
+                    wait,
+                    attempt + 1,
+                )
+                time.sleep(wait)
+            else:
+                logger.warning(
+                    "No data returned from yfinance for %s after %d attempts", symbol, max_retries
+                )
+
+        return []
 
     # ------------------------------------------------------------------
     # Internal: CoinGecko (crypto)
@@ -199,7 +197,7 @@ class MarketDataService:
         Uses Unix timestamps so arbitrary historical windows work correctly.
         Includes retry with exponential backoff for rate-limit (429) responses.
         """
-        coin_id = _COINGECKO_IDS.get(symbol.upper())
+        coin_id = COINGECKO_IDS.get(symbol.upper())
         if not coin_id:
             logger.warning("Unknown crypto symbol %s — no CoinGecko mapping", symbol)
             return []

--- a/backend/agents/investment_team/market_lab_data/models.py
+++ b/backend/agents/investment_team/market_lab_data/models.py
@@ -21,16 +21,26 @@ class MarketLabContext(BaseModel):
     """
 
     fetched_at: str = Field(..., description="ISO UTC when snapshot was assembled")
-    degraded: bool = Field(default=False, description="True if one or more sources failed or timed out")
-    degraded_reason: Optional[str] = Field(default=None, description="Human-readable reason when degraded")
-    sources_used: List[str] = Field(default_factory=list, description="Provider ids included in this snapshot")
+    degraded: bool = Field(
+        default=False, description="True if one or more sources failed or timed out"
+    )
+    degraded_reason: Optional[str] = Field(
+        default=None, description="Human-readable reason when degraded"
+    )
+    sources_used: List[str] = Field(
+        default_factory=list, description="Provider ids included in this snapshot"
+    )
 
     fx_rates: dict[str, float] = Field(
         default_factory=dict,
         description="Sample FX vs USD (e.g. EUR, GBP, JPY keys with USD quote interpretation)",
     )
-    macro_snippets: List[str] = Field(default_factory=list, description="Short macro lines, e.g. DGS10")
-    crypto_snapshot: Optional[str] = Field(default=None, description="Optional crypto headline price line")
+    macro_snippets: List[str] = Field(
+        default_factory=list, description="Short macro lines, e.g. DGS10"
+    )
+    crypto_snapshot: Optional[str] = Field(
+        default=None, description="Optional crypto headline price line"
+    )
     social_sentiment: Optional[str] = Field(
         default=None,
         description="Optional social/sentiment line; often empty on free tier without dedicated API",

--- a/backend/agents/investment_team/paper_trading_agent.py
+++ b/backend/agents/investment_team/paper_trading_agent.py
@@ -30,7 +30,7 @@ from .trade_simulator import (
     OpenPosition,
     TradeSimulationEngine,
     compute_metrics,
-    format_bars_table,
+    evaluate_bar,
 )
 
 logger = logging.getLogger(__name__)
@@ -44,43 +44,6 @@ _EVALUATE_SYSTEM = (
     "You evaluate daily price bars against the strategy's entry and exit rules to decide whether to trade. "
     "Be disciplined — only trade when the rules are clearly met by the price data."
 )
-
-_EVALUATE_PROMPT = """\
-Evaluate whether the trading strategy's rules are triggered for this market data.
-
-## Strategy
-Asset class: {asset_class}
-Hypothesis: {hypothesis}
-Signal: {signal_definition}
-Entry rules: {entry_rules}
-Exit rules: {exit_rules}
-Sizing rules: {sizing_rules}
-Risk limits: {risk_limits}
-
-## Current Position
-{position_status}
-
-## Available Capital
-${capital:,.2f}
-
-## Current Bar ({symbol}, {current_date})
-Open: {open}  High: {high}  Low: {low}  Close: {close}  Volume: {volume}
-
-## Recent Price History ({symbol}, last {n_bars} bars)
-{recent_bars_text}
-
-## Instructions
-Based on the strategy rules and market data above, decide your action.
-If you have NO open position, evaluate ENTRY rules. If you HAVE an open position, evaluate EXIT rules.
-Be conservative — only enter when signals are clearly met, and respect risk limits.
-
-Return ONLY a JSON object with no markdown:
-{{"action": "enter_long" or "enter_short" or "exit" or "hold", "confidence": 0.0 to 1.0, \
-"shares": number_of_shares_or_0, "reasoning": "brief explanation"}}
-
-For "hold", set shares to 0. For entries, calculate shares based on sizing rules and available capital.
-For exits, set shares to 0 (will close full position).
-"""
 
 _DIVERGENCE_SYSTEM = (
     "You are a quantitative trading analyst specializing in strategy validation. "
@@ -276,49 +239,16 @@ class PaperTradingAgent:
         capital: float,
     ) -> Dict[str, Any]:
         """Ask LLM to evaluate whether entry/exit rules are met for this bar."""
-        if open_position:
-            pos_status = (
-                f"OPEN {open_position.side.upper()} position in {symbol}: "
-                f"{open_position.shares} shares @ ${open_position.entry_price:.2f} "
-                f"(entered {open_position.entry_date})"
-            )
-        else:
-            pos_status = "No open position — looking for entry signals."
-
-        prompt = _EVALUATE_PROMPT.format(
-            asset_class=strategy.asset_class,
-            hypothesis=strategy.hypothesis,
-            signal_definition=strategy.signal_definition,
-            entry_rules="; ".join(strategy.entry_rules),
-            exit_rules="; ".join(strategy.exit_rules),
-            sizing_rules="; ".join(strategy.sizing_rules),
-            risk_limits=strategy.risk_limits,
-            position_status=pos_status,
-            capital=capital,
-            symbol=symbol,
-            current_date=current_bar.date,
-            open=current_bar.open,
-            high=current_bar.high,
-            low=current_bar.low,
-            close=current_bar.close,
-            volume=current_bar.volume,
-            n_bars=len(recent_bars),
-            recent_bars_text=format_bars_table(recent_bars),
+        return evaluate_bar(
+            self.llm.complete_json,
+            strategy,
+            _EVALUATE_SYSTEM,
+            symbol,
+            current_bar,
+            recent_bars,
+            open_position,
+            capital,
         )
-
-        data = self.llm.complete_json(
-            prompt,
-            temperature=0.2,
-            system_prompt=_EVALUATE_SYSTEM,
-            think=True,
-        )
-
-        return {
-            "action": str(data.get("action", "hold")),
-            "confidence": float(data.get("confidence", 0.0)),
-            "shares": float(data.get("shares", 0)),
-            "reasoning": str(data.get("reasoning", "")),
-        }
 
     @staticmethod
     def compare_performance(

--- a/backend/agents/investment_team/signal_intelligence_models.py
+++ b/backend/agents/investment_team/signal_intelligence_models.py
@@ -17,7 +17,9 @@ class SignalIntelligenceBriefV1(BaseModel):
     micro_themes: List[str] = Field(default_factory=list)
     high_value_signal_hypotheses: List[str] = Field(default_factory=list)
     trade_structures_benefiting: List[str] = Field(default_factory=list)
-    pairing_guidance: str = Field(default="", description="How to combine signals / asset classes for this window")
+    pairing_guidance: str = Field(
+        default="", description="How to combine signals / asset classes for this window"
+    )
     evidence_from_priors: str = Field(
         default="",
         description="References to prior lab indices or 'none / first run'",

--- a/backend/agents/investment_team/spec_models.py
+++ b/backend/agents/investment_team/spec_models.py
@@ -1,4 +1,11 @@
-"""Codex-friendly implementation models for the multi-asset investment organization spec."""
+"""Codex-friendly implementation models for the multi-asset investment organization spec.
+
+.. deprecated::
+    This module provides V1 spec-level Pydantic models that parallel the runtime
+    models in ``models.py``.  New features (e.g. paper trading, advisor sessions)
+    should **not** add V1 mirrors here.  Prefer ``models.py`` for all new work.
+    These types are retained for backward compatibility only.
+"""
 
 from __future__ import annotations
 

--- a/backend/agents/investment_team/strategy_ideation_agent.py
+++ b/backend/agents/investment_team/strategy_ideation_agent.py
@@ -175,7 +175,9 @@ Return ONLY JSON with no markdown:
 """
 
 
-def _format_simulated_trades_summary(trades: List[TradeRecord], *, max_sample_rows: int = 14) -> str:
+def _format_simulated_trades_summary(
+    trades: List[TradeRecord], *, max_sample_rows: int = 14
+) -> str:
     """Compact evidence string from the simulated ledger for analysis + self-review."""
     if not trades:
         return "No simulated trades in ledger."
@@ -388,8 +390,5 @@ class StrategyIdeationAgent:
             revised = draft_narrative
 
         if verification:
-            return (
-                f"{revised}\n\n"
-                f"[Self-review: {verification}]"
-            )
+            return f"{revised}\n\n[Self-review: {verification}]"
         return revised

--- a/backend/agents/investment_team/strategy_lab_context.py
+++ b/backend/agents/investment_team/strategy_lab_context.py
@@ -20,8 +20,12 @@ _CANONICAL_ASSET_CLASSES: tuple[str, ...] = (
 )
 
 
-def normalize_asset_class(ac: str) -> str:
-    x = (ac or "").lower().strip()
+def normalize_asset_class(ac: object) -> str:
+    """Map any asset-class string variant to one of the canonical labels.
+
+    Accepts ``object`` so callers can pass raw LLM output without casting.
+    """
+    x = str(ac or "stocks").lower().strip()
     if x in ("equities", "equity", "stock"):
         return "stocks"
     if x in ("fx",):
@@ -88,9 +92,7 @@ def asset_class_mix_hint(records: List[StrategyLabRecord], *, tail: int = 24) ->
 
     parts: List[str] = [
         "Recent asset-class counts (last "
-        f"{n_sample} strategies): "
-        + ", ".join(f"{k}={v}" for k, v in counts.items())
-        + "."
+        f"{n_sample} strategies): " + ", ".join(f"{k}={v}" for k, v in counts.items()) + "."
     ]
     if stock_share > 0.35 and n_sample >= 2:
         parts.append(

--- a/backend/agents/investment_team/symbols.py
+++ b/backend/agents/investment_team/symbols.py
@@ -1,0 +1,80 @@
+"""Canonical symbol lists by asset class, shared across the investment team.
+
+Used by the market data service (real OHLCV fetching), the deterministic backtest
+engine (synthetic trade generation), and any future consumer that routes by asset class.
+"""
+
+from __future__ import annotations
+
+# CoinGecko API ID mapping for crypto symbols
+COINGECKO_IDS: dict[str, str] = {
+    "BTC": "bitcoin",
+    "ETH": "ethereum",
+    "SOL": "solana",
+    "BNB": "binancecoin",
+    "XRP": "ripple",
+    "MATIC": "matic-network",
+    "AVAX": "avalanche-2",
+    "LINK": "chainlink",
+    "ADA": "cardano",
+    "DOT": "polkadot",
+}
+
+STOCK_SYMBOLS: list[str] = [
+    "AAPL",
+    "MSFT",
+    "NVDA",
+    "TSLA",
+    "AMZN",
+    "META",
+    "GOOGL",
+    "JPM",
+    "AMD",
+    "SPY",
+]
+CRYPTO_SYMBOLS: list[str] = [
+    "BTC",
+    "ETH",
+    "SOL",
+    "BNB",
+    "XRP",
+    "MATIC",
+    "AVAX",
+    "LINK",
+    "ADA",
+    "DOT",
+]
+# Forex pairs use yfinance's =X suffix for real data; deterministic backtest uses bare names
+FOREX_SYMBOLS: list[str] = [
+    "EURUSD=X",
+    "GBPUSD=X",
+    "USDJPY=X",
+    "AUDUSD=X",
+    "USDCAD=X",
+    "NZDUSD=X",
+    "USDCHF=X",
+    "EURGBP=X",
+    "EURJPY=X",
+    "GBPJPY=X",
+]
+# Bare forex names for the deterministic backtest engine (no =X suffix)
+FOREX_SYMBOLS_BARE: list[str] = [
+    "EURUSD",
+    "GBPUSD",
+    "USDJPY",
+    "AUDUSD",
+    "USDCAD",
+    "NZDUSD",
+    "USDCHF",
+    "EURGBP",
+    "EURJPY",
+    "GBPJPY",
+]
+# Futures use yfinance's =F suffix
+FUTURES_SYMBOLS: list[str] = ["ES=F", "NQ=F", "CL=F", "GC=F", "SI=F", "ZB=F", "NG=F"]
+# Bare futures names for the deterministic backtest engine
+FUTURES_SYMBOLS_BARE: list[str] = ["ES", "NQ", "CL", "GC", "SI", "ZB", "NG", "ZM", "ZS"]
+# Commodity ETFs (liquid proxies for commodities via yfinance)
+COMMODITY_SYMBOLS: list[str] = ["GLD", "USO", "SLV", "DBA", "UNG", "PDBC", "DBC"]
+# Broad ETFs used as a fallback
+OTHER_SYMBOLS: list[str] = ["GLD", "USO", "TLT", "QQQ", "IWM", "EEM", "GDX", "XLE", "XLF"]

--- a/backend/agents/investment_team/trade_simulator.py
+++ b/backend/agents/investment_team/trade_simulator.py
@@ -14,7 +14,7 @@ from datetime import date as date_cls
 from typing import Any, Callable, Dict, List, Optional
 
 from .market_data_service import OHLCVBar
-from .models import BacktestResult, TradeRecord
+from .models import BacktestResult, StrategySpec, TradeRecord
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +41,118 @@ EvaluateCallback = Callable[
     [str, OHLCVBar, List[OHLCVBar], Optional[OpenPosition], float],
     Dict[str, Any],
 ]
+
+
+# ---------------------------------------------------------------------------
+# Shared LLM-based bar evaluation prompt and callback builder
+# ---------------------------------------------------------------------------
+
+_EVALUATE_PROMPT = """\
+Evaluate whether the trading strategy's rules are triggered for this market data.
+
+## Strategy
+Asset class: {asset_class}
+Hypothesis: {hypothesis}
+Signal: {signal_definition}
+Entry rules: {entry_rules}
+Exit rules: {exit_rules}
+Sizing rules: {sizing_rules}
+Risk limits: {risk_limits}
+
+## Current Position
+{position_status}
+
+## Available Capital
+${capital:,.2f}
+
+## Current Bar ({symbol}, {current_date})
+Open: {open}  High: {high}  Low: {low}  Close: {close}  Volume: {volume}
+
+## Recent Price History ({symbol}, last {n_bars} bars)
+{recent_bars_text}
+
+## Instructions
+Based on the strategy rules and market data above, decide your action.
+If you have NO open position, evaluate ENTRY rules. If you HAVE an open position, evaluate EXIT rules.
+Be conservative — only enter when signals are clearly met, and respect risk limits.
+
+Return ONLY a JSON object with no markdown:
+{{"action": "enter_long" or "enter_short" or "exit" or "hold", "confidence": 0.0 to 1.0, \
+"shares": number_of_shares_or_0, "reasoning": "brief explanation"}}
+
+For "hold", set shares to 0. For entries, calculate shares based on sizing rules and available capital.
+For exits, set shares to 0 (will close full position).
+"""
+
+
+def evaluate_bar(
+    llm_complete_json: Callable[..., Dict[str, Any]],
+    strategy: StrategySpec,
+    system_prompt: str,
+    symbol: str,
+    current_bar: OHLCVBar,
+    recent_bars: List[OHLCVBar],
+    open_position: Optional[OpenPosition],
+    capital: float,
+) -> Dict[str, Any]:
+    """Shared LLM-based bar evaluation used by both backtesting and paper trading agents.
+
+    Args:
+        llm_complete_json: Bound ``LLMClient.complete_json`` method.
+        strategy: The strategy spec being evaluated.
+        system_prompt: Agent-specific system prompt (backtest vs paper context).
+        symbol: Current symbol being evaluated.
+        current_bar: The OHLCV bar to evaluate.
+        recent_bars: Recent price history for context.
+        open_position: Current open position, if any.
+        capital: Available capital for sizing.
+
+    Returns:
+        Dict with keys: action, confidence, shares, reasoning.
+    """
+    if open_position:
+        pos_status = (
+            f"OPEN {open_position.side.upper()} position in {symbol}: "
+            f"{open_position.shares} shares @ ${open_position.entry_price:.2f} "
+            f"(entered {open_position.entry_date})"
+        )
+    else:
+        pos_status = "No open position — looking for entry signals."
+
+    prompt = _EVALUATE_PROMPT.format(
+        asset_class=strategy.asset_class,
+        hypothesis=strategy.hypothesis,
+        signal_definition=strategy.signal_definition,
+        entry_rules="; ".join(strategy.entry_rules),
+        exit_rules="; ".join(strategy.exit_rules),
+        sizing_rules="; ".join(strategy.sizing_rules),
+        risk_limits=strategy.risk_limits,
+        position_status=pos_status,
+        capital=capital,
+        symbol=symbol,
+        current_date=current_bar.date,
+        open=current_bar.open,
+        high=current_bar.high,
+        low=current_bar.low,
+        close=current_bar.close,
+        volume=current_bar.volume,
+        n_bars=len(recent_bars),
+        recent_bars_text=format_bars_table(recent_bars),
+    )
+
+    data = llm_complete_json(
+        prompt,
+        temperature=0.2,
+        system_prompt=system_prompt,
+        think=True,
+    )
+
+    return {
+        "action": str(data.get("action", "hold")),
+        "confidence": float(data.get("confidence", 0.0)),
+        "shares": float(data.get("shares", 0)),
+        "reasoning": str(data.get("reasoning", "")),
+    }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
- Extract shared evaluate_bar() and prompt template from BacktestingAgent
  and PaperTradingAgent into trade_simulator.py (eliminates 53-line duplication)
- Create symbols.py as single source of truth for asset-class symbol lists;
  remove duplicated lists from market_data_service.py
- Consolidate 5 asset-class normalization implementations to delegate to
  strategy_lab_context.normalize_asset_class()
- Add yfinance retry with exponential backoff (matching CoinGecko pattern)
- Singleton stateless agents in api/main.py (PolicyGuardian, Orchestrator,
  CommitteeAgent) and class-level ValidationAgent in PromotionGateAgent
- Fix _is_confirmation() false positives with word-boundary regex
- Consolidate _extract_number to delegate to _extract_all_numbers
- Add deprecation notice to spec_models.py V1 layer

https://claude.ai/code/session_01B9yVr8cb2odACBMua9L4Dy