### PR TITLE
fix(social-marketing): improve performance, design, and code quality

### DIFF
--- a/backend/agents/social_media_marketing_team/agents.py
+++ b/backend/agents/social_media_marketing_team/agents.py
@@ -437,6 +437,18 @@ class ExperimentDesignAgent:
         return ExperimentPlan(campaign_name=campaign_name, arms=arms)
 
 
+def _word_boundary_pattern(term: str) -> str:
+    """Build a regex that matches *term* as a whole token.
+
+    ``\\b`` only works between word (``\\w``) and non-word characters.  For
+    terms that end with non-word characters (e.g. ``100%``) the trailing
+    ``\\b`` silently fails.  This helper uses lookarounds that work
+    regardless of character class at the edges.
+    """
+    escaped = re.escape(term)
+    return rf"(?<!\w){escaped}(?!\w)"
+
+
 @dataclass
 class RiskComplianceAgent:
     """Reviews concepts for risk and compliance issues."""
@@ -455,27 +467,25 @@ class RiskComplianceAgent:
 
         banned_terms = ["guarantee", "guaranteed", "instant", "overnight", "no risk"]
         for term in banned_terms:
-            # Use word-boundary matching to avoid false positives (e.g. "there is no risk"
-            # matching inside unrelated sentences like "no risk-free approach").
-            if re.search(rf"\b{re.escape(term)}\b", lowered):
+            if re.search(_word_boundary_pattern(term), lowered):
                 risk_reasons.append(f"Contains risky claim term: {term} (overclaim)")
 
         if goals.brand_guidelines:
             guidelines_lower = goals.brand_guidelines.lower()
             if "do not mention competitors" in guidelines_lower and re.search(
-                r"\bcompetitor\b", lowered
+                _word_boundary_pattern("competitor"), lowered
             ):
                 risk_reasons.append(
                     "Mentions competitors despite guidelines (brand_guideline_violation)"
                 )
             if "avoid absolute claims" in guidelines_lower and any(
-                re.search(rf"\b{re.escape(t)}\b", lowered) for t in ("never", "always", "100%")
+                re.search(_word_boundary_pattern(t), lowered) for t in ("never", "always", "100%")
             ):
                 risk_reasons.append("Uses absolute language discouraged by guidelines (regulatory)")
 
         if risk_reasons:
             risk_level = "high"
-        elif any(re.search(rf"\b{re.escape(t)}\b", lowered) for t in ("might", "could", "may")):
+        elif any(re.search(_word_boundary_pattern(t), lowered) for t in ("might", "could", "may")):
             risk_level = "medium"
 
         if risk_level == "low" and not risk_reasons:

--- a/backend/agents/social_media_marketing_team/agents.py
+++ b/backend/agents/social_media_marketing_team/agents.py
@@ -18,6 +18,66 @@ from .models import (
 
 
 @dataclass
+class _PlatformConfig:
+    """Per-platform guidelines, KPIs, and schedule templates."""
+
+    guideline_templates: List[str]
+    kpis_lead: List[str]
+    kpis_engagement: List[str]
+    schedule_suffix: str
+
+
+_PLATFORM_CONFIGS: Dict[Platform, _PlatformConfig] = {
+    Platform.LINKEDIN: _PlatformConfig(
+        guideline_templates=[
+            "Write in a {voice} voice tailored to {audience}.",
+            "Lead with a sharp business pain point or outcome in the first two lines.",
+            "Use short paragraphs, scannable formatting, and one clear CTA per post.",
+        ],
+        kpis_lead=["qualified inbound messages", "demo or meeting requests", "profile visits"],
+        kpis_engagement=["comments", "reactions", "profile visits"],
+        schedule_suffix=(
+            "(thought-leadership post, tactical carousel, and comment strategy) "
+            "mapped to priority messaging pillars."
+        ),
+    ),
+    Platform.FACEBOOK: _PlatformConfig(
+        guideline_templates=[
+            "Use community-oriented framing and relatable storytelling for {audience}.",
+            "Pair each post with a strong visual and one direct question to spark replies.",
+            "Optimize copy for mobile-first scanning with short paragraphs and emojis used sparingly.",
+        ],
+        kpis_lead=["link clicks", "outbound site sessions", "lead form starts"],
+        kpis_engagement=["shares", "comments", "time on post"],
+        schedule_suffix="(story-led post plus at least one discussion prompt) that invites comments and shares.",
+    ),
+    Platform.INSTAGRAM: _PlatformConfig(
+        guideline_templates=[
+            "Use a strong visual hook aligned with {voice}.",
+            "Keep captions concise, skimmable, and front-load the value in the first sentence.",
+            "Prioritize carousel- and reels-friendly concepts with clear narrative arcs.",
+        ],
+        kpis_lead=["profile visits", "link-in-bio taps", "DM replies"],
+        kpis_engagement=["saves", "reel plays", "follows"],
+        schedule_suffix=(
+            "(mix of carousels, reels, and stories) sourced from the approved concept pool, "
+            "including at least one experimental creative angle."
+        ),
+    ),
+    Platform.X: _PlatformConfig(
+        guideline_templates=[
+            "Lead with a concise opinion or insight in < 240 characters, using a {voice} tone.",
+            "Use threads for nuanced ideas and quote-post interaction.",
+            "Tie posts to timely conversations or trends when relevant to the brand.",
+        ],
+        kpis_lead=["link clicks", "profile visits", "high-intent replies"],
+        kpis_engagement=["reposts", "replies", "follower growth"],
+        schedule_suffix="(short posts or threads) that test at least one strong hook and one follow-up insight.",
+    ),
+}
+
+
+@dataclass
 class PlatformSpecialistAgent:
     """Specialist for one social network platform."""
 
@@ -29,78 +89,20 @@ class PlatformSpecialistAgent:
         campaign_name: str,
         ideas_count: int,
     ) -> PlatformExecutionPlan:
-        """
-        Build a platform execution plan that is aware of brand goals, audience,
-        and tone, not just the raw platform choice.
-        """
+        """Build a platform execution plan aware of brand goals, audience, and tone."""
+        cfg = _PLATFORM_CONFIGS[self.platform]
+
         objective = (goals.brand_objectives or "").lower()
         high_intent_goals = {"demo", "trial", "signup", "lead", "pipeline"}
-        is_lead_or_conversion_focused = any(term in objective for term in high_intent_goals)
+        is_lead_focused = any(term in objective for term in high_intent_goals)
 
-        if self.platform == Platform.LINKEDIN:
-            guidelines = [
-                f"Write in a {goals.voice_and_tone} voice tailored to {goals.target_audience}.",
-                "Lead with a sharp business pain point or outcome in the first two lines.",
-                "Use short paragraphs, scannable formatting, and one clear CTA per post.",
-            ]
-            kpis = (
-                ["qualified inbound messages", "demo or meeting requests", "profile visits"]
-                if is_lead_or_conversion_focused
-                else ["comments", "reactions", "profile visits"]
-            )
-        elif self.platform == Platform.FACEBOOK:
-            guidelines = [
-                f"Use community-oriented framing and relatable storytelling for {goals.target_audience}.",
-                "Pair each post with a strong visual and one direct question to spark replies.",
-                "Optimize copy for mobile-first scanning with short paragraphs and emojis used sparingly.",
-            ]
-            kpis = (
-                ["link clicks", "outbound site sessions", "lead form starts"]
-                if is_lead_or_conversion_focused
-                else ["shares", "comments", "time on post"]
-            )
-        elif self.platform == Platform.INSTAGRAM:
-            guidelines = [
-                f"Use a strong visual hook aligned with {goals.voice_and_tone}.",
-                "Keep captions concise, skimmable, and front-load the value in the first sentence.",
-                "Prioritize carousel- and reels-friendly concepts with clear narrative arcs.",
-            ]
-            kpis = (
-                ["profile visits", "link-in-bio taps", "DM replies"]
-                if is_lead_or_conversion_focused
-                else ["saves", "reel plays", "follows"]
-            )
-        else:
-            guidelines = [
-                f"Lead with a concise opinion or insight in < 240 characters, using a {goals.voice_and_tone} tone.",
-                "Use threads for nuanced ideas and quote-post interaction.",
-                "Tie posts to timely conversations or trends when relevant to the brand.",
-            ]
-            kpis = (
-                ["link clicks", "profile visits", "high-intent replies"]
-                if is_lead_or_conversion_focused
-                else ["reposts", "replies", "follower growth"]
-            )
+        fmt = {"voice": goals.voice_and_tone, "audience": goals.target_audience}
+        guidelines = [t.format(**fmt) for t in cfg.guideline_templates]
+        kpis = cfg.kpis_lead if is_lead_focused else cfg.kpis_engagement
 
         schedule: List[str] = []
         for day in range(1, min(8, goals.duration_days + 1)):
-            base = f"Day {day}: {goals.cadence_posts_per_day} posts"
-            if self.platform == Platform.INSTAGRAM:
-                detail = (
-                    f"{base} (mix of carousels, reels, and stories) sourced from the approved concept pool, "
-                    "including at least one experimental creative angle."
-                )
-            elif self.platform == Platform.LINKEDIN:
-                detail = (
-                    f"{base} (thought-leadership post, tactical carousel, and comment strategy) "
-                    "mapped to priority messaging pillars."
-                )
-            elif self.platform == Platform.FACEBOOK:
-                detail = f"{base} (story-led post plus at least one discussion prompt) that invites comments and shares."
-            else:
-                detail = f"{base} (short posts or threads) that test at least one strong hook and one follow-up insight."
-            schedule.append(detail)
-
+            schedule.append(f"Day {day}: {goals.cadence_posts_per_day} posts {cfg.schedule_suffix}")
         schedule.append(
             f"Week-1 coverage target: adapt at least {ideas_count} approved concepts for {self.platform.value}, "
             "ensuring every goal in BrandGoals.goals is represented across the content mix."
@@ -473,7 +475,7 @@ class RiskComplianceAgent:
 
         if risk_reasons:
             risk_level = "high"
-        elif any(term in lowered for term in ("might", "could", "may")):
+        elif any(re.search(rf"\b{re.escape(t)}\b", lowered) for t in ("might", "could", "may")):
             risk_level = "medium"
 
         if risk_level == "low" and not risk_reasons:

--- a/backend/agents/social_media_marketing_team/agents.py
+++ b/backend/agents/social_media_marketing_team/agents.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from typing import Dict, List
 
@@ -113,16 +114,55 @@ class PlatformSpecialistAgent:
         )
 
 
+_ROLE_RUBRIC_WEIGHTS: Dict[str, Dict[str, float]] = {
+    "Campaign Strategist": {
+        "measurability": 1.10,
+        "audience_specificity": 0.95,
+        "platform_differentiation": 1.08,
+        "traceability": 1.0,
+        "feasibility": 0.92,
+    },
+    "Audience Research Lead": {
+        "measurability": 0.92,
+        "audience_specificity": 1.15,
+        "platform_differentiation": 0.95,
+        "traceability": 1.0,
+        "feasibility": 1.0,
+    },
+    "Performance Marketing Analyst": {
+        "measurability": 1.15,
+        "audience_specificity": 0.92,
+        "platform_differentiation": 0.95,
+        "traceability": 1.08,
+        "feasibility": 0.95,
+    },
+}
+
+_DEFAULT_RUBRIC_WEIGHTS: Dict[str, float] = {
+    "measurability": 1.0,
+    "audience_specificity": 1.0,
+    "platform_differentiation": 1.0,
+    "traceability": 1.0,
+    "feasibility": 1.0,
+}
+
+
 @dataclass
 class CampaignCollaborationAgent:
-    """A planning specialist who contributes to campaign proposal quality."""
+    """A planning specialist who contributes to campaign proposal quality.
+
+    Each role applies different rubric weights reflecting their area of expertise:
+    - Campaign Strategist: emphasises measurability and platform differentiation
+    - Audience Research Lead: emphasises audience specificity
+    - Performance Marketing Analyst: emphasises measurability and traceability
+    """
 
     role: str
 
     def evaluate_proposal(
         self, proposal: CampaignProposal, round_number: int
     ) -> tuple[float, str, Dict[str, float]]:
-        """Provide a richer, more actionable rubric for proposal quality."""
+        """Provide a role-weighted rubric for proposal quality."""
         objective_lower = proposal.objective.lower()
         audience_lower = proposal.audience_hypothesis.lower()
 
@@ -160,13 +200,17 @@ class CampaignCollaborationAgent:
             feasibility += 0.1
 
         round_lift = min(0.2, 0.04 * round_number)
-        rubric = {
+        raw_rubric = {
             "measurability": min(1.0, measurability + round_lift),
             "audience_specificity": min(1.0, audience_specificity + round_lift),
             "platform_differentiation": min(1.0, platform_differentiation + round_lift),
             "traceability": min(1.0, traceability + round_lift),
             "feasibility": min(1.0, feasibility + round_lift),
         }
+
+        # Apply role-specific weights so each agent emphasises their expertise.
+        weights = _ROLE_RUBRIC_WEIGHTS.get(self.role, _DEFAULT_RUBRIC_WEIGHTS)
+        rubric = {dim: min(1.0, raw_rubric[dim] * weights.get(dim, 1.0)) for dim in raw_rubric}
         score = sum(rubric.values()) / len(rubric)
 
         weak_dimensions = [name for name, value in rubric.items() if value < 0.75]
@@ -205,31 +249,51 @@ class CampaignCollaborationAgent:
         return score, note, rubric
 
 
+_STORYTELLING_ARCHETYPES = [
+    ("Customer story", "Tell a short story showing how someone overcame"),
+    ("Behind-the-scenes", "Reveal behind-the-scenes context that demystifies"),
+    ("Brand origin", "Share the founding insight or pivotal moment behind"),
+    ("Community spotlight", "Highlight a community member or partner experience with"),
+]
+
+_CREATIVE_TESTING_ARCHETYPES = [
+    ("Educational framework", "Share a simple framework or checklist related to"),
+    ("Contrarian take", "Offer a surprising or counter-intuitive perspective on"),
+    ("Data snapshot", "Visualise a compelling data point or trend around"),
+    ("Rapid-fire tips", "Deliver 3 actionable tips in under 60 seconds about"),
+]
+
+
 @dataclass
 class ContentConceptAgent:
-    """Generates candidate post concepts before final filtering."""
+    """Generates candidate post concepts before final filtering.
+
+    The archetype set and scoring biases differ by role:
+    - Brand Storytelling Lead: narrative archetypes, higher brand-fit scores for stories
+    - Creative Testing Lead: experimental archetypes, higher resonance for data-driven content
+    """
 
     role: str
+
+    def _archetypes(self) -> List[tuple[str, str]]:
+        if self.role == "Brand Storytelling Lead":
+            return _STORYTELLING_ARCHETYPES
+        if self.role == "Creative Testing Lead":
+            return _CREATIVE_TESTING_ARCHETYPES
+        # Fallback: combined set (deduped by name)
+        return _STORYTELLING_ARCHETYPES + _CREATIVE_TESTING_ARCHETYPES
 
     def generate_candidates(
         self, proposal: CampaignProposal, goals: BrandGoals
     ) -> List[ConceptIdea]:
-        """
-        Generate a diverse, platform-aware set of candidate concepts.
-        """
+        """Generate a diverse, platform-aware set of candidate concepts."""
         base_topics = proposal.messaging_pillars or [
             "Educational insight",
             "Proof point",
             "Actionable tip",
         ]
         linked_goals = goals.goals or ["engagement"]
-
-        archetypes = [
-            ("Educational framework", "Share a simple framework or checklist related to"),
-            ("Customer story", "Tell a short story showing how someone overcame"),
-            ("Contrarian take", "Offer a surprising or counter-intuitive perspective on"),
-            ("Behind-the-scenes", "Reveal behind-the-scenes context that demystifies"),
-        ]
+        archetypes = self._archetypes()
 
         ideas: List[ConceptIdea] = []
         idx = 0
@@ -237,7 +301,6 @@ class ContentConceptAgent:
             for archetype_name, archetype_prompt in archetypes:
                 idx += 1
 
-                # Decide primary platform mix based on archetype
                 target_platforms = [
                     Platform.LINKEDIN,
                     Platform.FACEBOOK,
@@ -262,6 +325,9 @@ class ContentConceptAgent:
                     brand_fit_score += 0.05
                 if "behind-the-scenes" in topic.lower():
                     brand_fit_score += 0.03
+                # Storytelling role gives extra brand-fit credit for narrative archetypes
+                if self.role == "Brand Storytelling Lead" and "story" in archetype_name.lower():
+                    brand_fit_score += 0.04
 
                 audience_resonance_score = 0.7
                 if any(
@@ -271,6 +337,12 @@ class ContentConceptAgent:
                     audience_resonance_score += 0.05
                 if "story" in archetype_name.lower():
                     audience_resonance_score += 0.03
+                # Creative testing role gives extra resonance for data-driven formats
+                if self.role == "Creative Testing Lead" and archetype_name in (
+                    "Data snapshot",
+                    "Contrarian take",
+                ):
+                    audience_resonance_score += 0.04
 
                 goal_alignment_score = 0.7
                 if goal.lower() in proposal.objective.lower():
@@ -374,23 +446,28 @@ class RiskComplianceAgent:
         Review a concept for risk and compliance, returning an updated idea with
         risk level and structured reasons.
         """
-        lowered = f"{idea.title} {idea.concept}".lower()
+        text = f"{idea.title} {idea.concept}"
+        lowered = text.lower()
         risk_reasons: List[str] = []
         risk_level = "low"
 
         banned_terms = ["guarantee", "guaranteed", "instant", "overnight", "no risk"]
         for term in banned_terms:
-            if term in lowered:
+            # Use word-boundary matching to avoid false positives (e.g. "there is no risk"
+            # matching inside unrelated sentences like "no risk-free approach").
+            if re.search(rf"\b{re.escape(term)}\b", lowered):
                 risk_reasons.append(f"Contains risky claim term: {term} (overclaim)")
 
         if goals.brand_guidelines:
             guidelines_lower = goals.brand_guidelines.lower()
-            if "do not mention competitors" in guidelines_lower and "competitor" in lowered:
+            if "do not mention competitors" in guidelines_lower and re.search(
+                r"\bcompetitor\b", lowered
+            ):
                 risk_reasons.append(
                     "Mentions competitors despite guidelines (brand_guideline_violation)"
                 )
             if "avoid absolute claims" in guidelines_lower and any(
-                t in lowered for t in ("never", "always", "100%")
+                re.search(rf"\b{re.escape(t)}\b", lowered) for t in ("never", "always", "100%")
             ):
                 risk_reasons.append("Uses absolute language discouraged by guidelines (regulatory)")
 

--- a/backend/agents/social_media_marketing_team/agents.py
+++ b/backend/agents/social_media_marketing_team/agents.py
@@ -473,7 +473,7 @@ class RiskComplianceAgent:
         if goals.brand_guidelines:
             guidelines_lower = goals.brand_guidelines.lower()
             if "do not mention competitors" in guidelines_lower and re.search(
-                _word_boundary_pattern("competitor"), lowered
+                r"(?<!\w)competitors?(?!\w)", lowered
             ):
                 risk_reasons.append(
                     "Mentions competitors despite guidelines (brand_guideline_violation)"

--- a/backend/agents/social_media_marketing_team/api/main.py
+++ b/backend/agents/social_media_marketing_team/api/main.py
@@ -10,14 +10,9 @@ from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import List, Optional
+from typing import List
 
-import pytz
-from apscheduler.schedulers.background import BackgroundScheduler
-from apscheduler.triggers.cron import CronTrigger
-from blog_research_agent.tools.web_search import OllamaWebSearch
 from fastapi import FastAPI, HTTPException
-from pydantic import BaseModel, Field
 
 from job_service_client import (
     JOB_STATUS_COMPLETED,
@@ -27,20 +22,32 @@ from job_service_client import (
     JobServiceClient,
     start_stale_job_monitor,
 )
-from llm_service import get_client
 from social_media_marketing_team.models import (
     BrandGoals,
     CampaignPerformanceSnapshot,
     HumanReview,
-    PostPerformanceObservation,
-    TeamOutput,
 )
 from social_media_marketing_team.orchestrator import SocialMediaMarketingOrchestrator
-from social_media_marketing_team.trend_discovery_agent import TrendDiscoveryAgent
-from social_media_marketing_team.trend_models import TrendDigest
 
+from .request_models import (
+    CancelMarketingJobResponse,
+    DeleteMarketingJobResponse,
+    MarketingJobListItem,
+    MarketingJobStatusResponse,
+    PerformanceIngestRequest,
+    PerformanceIngestResponse,
+    ReviseMarketingTeamRequest,
+    RunMarketingTeamRequest,
+    RunMarketingTeamResponse,
+    TrendLatestResponse,
+    TrendRunResponse,
+)
+from .trend_scheduler import get_latest_digest, run_trend_job, start_scheduler, stop_scheduler
+
+# ---------------------------------------------------------------------------
 # Allowed base directories for brand document file reads.  Paths outside these
 # roots will be rejected to prevent path-traversal attacks.
+# ---------------------------------------------------------------------------
 _ALLOWED_FILE_ROOTS: List[Path] = []
 _agent_cache = os.getenv("AGENT_CACHE", "")
 if _agent_cache:
@@ -52,7 +59,19 @@ _tmp_dir = Path("/tmp")
 if _tmp_dir.is_dir():
     _ALLOWED_FILE_ROOTS.append(_tmp_dir.resolve())
 
-app = FastAPI(title="Social Media Marketing Team API", version="1.0.0")
+# ---------------------------------------------------------------------------
+# App & lifecycle
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def _lifespan(_application: FastAPI) -> AsyncIterator[None]:
+    start_scheduler()
+    yield
+    stop_scheduler()
+
+
+app = FastAPI(title="Social Media Marketing Team API", version="1.0.0", lifespan=_lifespan)
 
 logger = logging.getLogger(__name__)
 try:
@@ -68,92 +87,41 @@ except Exception as _init_err:
     _job_manager = None  # type: ignore[assignment]
     _stale_monitor_stop = None
 
-# Latest trend digest — updated by the daily cron and the manual trigger endpoint.
-# Each worker process maintains its own copy; for multi-worker deployments the last
-# worker to complete will serve the most recent digest.
-_latest_digest: Optional[TrendDigest] = None
-_digest_lock = threading.Lock()
-_scheduler: Optional[BackgroundScheduler] = None
-
-
-class RunMarketingTeamRequest(BaseModel):
-    brand_guidelines_path: str = Field(
-        ..., max_length=4096, description="Path to brand guidelines document"
-    )
-    brand_objectives_path: str = Field(
-        ..., max_length=4096, description="Path to brand objectives document"
-    )
-    llm_model_name: str = Field(..., max_length=256, description="Name of local LLM model to use")
-    brand_name: str = Field(default="Brand", max_length=256)
-    target_audience: str = Field(default="general audience", max_length=5000)
-    goals: List[str] = Field(default_factory=lambda: ["engagement", "follower growth"])
-    voice_and_tone: str = Field(default="professional, clear, and human", max_length=5000)
-    cadence_posts_per_day: int = Field(default=2, ge=1, le=24)
-    duration_days: int = Field(default=14, ge=1, le=365)
-    human_approved_for_testing: bool = Field(default=False)
-    human_feedback: str = Field(default="", max_length=50_000)
-
-
-class ReviseMarketingTeamRequest(BaseModel):
-    feedback: str = Field(..., min_length=3)
-    approved_for_testing: bool = Field(default=False)
-
-
-class RunMarketingTeamResponse(BaseModel):
-    job_id: str
-    status: str
-    message: str
-
-
-class MarketingJobStatusResponse(BaseModel):
-    job_id: str
-    status: str
-    current_stage: str
-    progress: int
-    llm_model_name: str
-    brand_guidelines_path: str
-    brand_objectives_path: str
-    last_updated_at: str
-    eta_hint: Optional[str] = None
-    error: Optional[str] = None
-    result: Optional[TeamOutput] = None
-
-
-class MarketingJobListItem(BaseModel):
-    job_id: str
-    status: str
-    current_stage: str
-    progress: int
-    created_at: Optional[str] = None
-    last_updated_at: Optional[str] = None
-
-
-class PerformanceIngestRequest(BaseModel):
-    observations: List[PostPerformanceObservation] = Field(default_factory=list)
-
-
-class PerformanceIngestResponse(BaseModel):
-    job_id: str
-    campaign_name: Optional[str] = None
-    observations_ingested: int
-    message: str
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
 
 
 def _now() -> str:
     return datetime.now(tz=timezone.utc).isoformat()
 
 
-def _read_text_file(path: str) -> str:
+def _validate_file_path(path: str) -> Path:
+    """Resolve *path* and ensure it exists inside an allowed root directory.
+
+    Raises ``ValueError`` when the path does not exist, or lies outside every
+    configured allowed root.  When no roots are configured, **all** reads are
+    denied to prevent silent bypass of the protection in environments that
+    forgot to set ``AGENT_CACHE``.
+    """
     fp = Path(path).expanduser().resolve()
     if not fp.is_file():
         raise ValueError(f"File not found: {path}")
-    if _ALLOWED_FILE_ROOTS and not any(
-        fp == root or root in fp.parents for root in _ALLOWED_FILE_ROOTS
-    ):
+    if not _ALLOWED_FILE_ROOTS:
+        raise ValueError(
+            f"Access denied: no allowed file roots configured (set AGENT_CACHE or place files under /data or /tmp). "
+            f"Requested path: {path}"
+        )
+    if not any(fp == root or root in fp.parents for root in _ALLOWED_FILE_ROOTS):
         raise ValueError(
             f"Access denied: {path} is outside allowed directories. "
             f"Allowed roots: {[str(r) for r in _ALLOWED_FILE_ROOTS]}"
         )
+    return fp
+
+
+def _read_text_file(path: str) -> str:
+    fp = _validate_file_path(path)
     return fp.read_text(encoding="utf-8", errors="replace")
 
 
@@ -161,29 +129,14 @@ def _update_job(job_id: str, **fields) -> None:
     _job_manager.update_job(job_id, **fields)
 
 
-def _dispatch_job(job_id: str, request: RunMarketingTeamRequest) -> str:
-    """Start a job via Temporal if enabled, otherwise in a daemon thread.
-
-    Returns a human-readable message describing how the job was dispatched.
-    """
-    try:
-        from social_media_marketing_team.temporal.client import is_temporal_enabled
-        from social_media_marketing_team.temporal.start_workflow import start_team_job_workflow
-
-        if is_temporal_enabled():
-            start_team_job_workflow(job_id, request.model_dump())
-            return f"(Temporal). Poll GET /social-marketing/status/{job_id} for updates."
-    except ImportError:
-        pass
-
-    thread = threading.Thread(target=_run_team_job, args=(job_id, request), daemon=True)
-    thread.start()
-    return f"Poll GET /social-marketing/status/{job_id} for updates."
-
-
 def mark_all_running_jobs_failed(reason: str) -> None:
     """Mark all pending or running marketing jobs as failed (e.g. on server shutdown)."""
     _job_manager.mark_stale_active_jobs_failed(stale_after_seconds=0, reason=reason)
+
+
+# ---------------------------------------------------------------------------
+# Background job execution
+# ---------------------------------------------------------------------------
 
 
 def _run_team_job(job_id: str, request: RunMarketingTeamRequest) -> None:
@@ -243,16 +196,48 @@ def _run_team_job(job_id: str, request: RunMarketingTeamRequest) -> None:
             result=result.model_dump(),
         )
     except Exception as exc:
+        logger.exception("Social marketing team job %s failed", job_id)
         _update_job(
-            job_id, status=JOB_STATUS_FAILED, current_stage="failed", error=str(exc), eta_hint=None
+            job_id,
+            status=JOB_STATUS_FAILED,
+            current_stage="failed",
+            error=f"{type(exc).__name__}: {exc}",
+            eta_hint=None,
         )
+
+
+def _dispatch_job(job_id: str, request: RunMarketingTeamRequest) -> str:
+    """Start a job via Temporal if enabled, otherwise in a daemon thread.
+
+    Returns a human-readable message describing how the job was dispatched.
+    """
+    try:
+        from social_media_marketing_team.temporal.client import is_temporal_enabled
+        from social_media_marketing_team.temporal.start_workflow import start_team_job_workflow
+
+        if is_temporal_enabled():
+            start_team_job_workflow(job_id, request.model_dump())
+            return f"(Temporal). Poll GET /social-marketing/status/{job_id} for updates."
+    except ImportError:
+        pass
+
+    thread = threading.Thread(target=_run_team_job, args=(job_id, request), daemon=True)
+    thread.start()
+    return f"Poll GET /social-marketing/status/{job_id} for updates."
+
+
+# ---------------------------------------------------------------------------
+# Routes — campaign jobs
+# ---------------------------------------------------------------------------
 
 
 @app.post("/social-marketing/run", response_model=RunMarketingTeamResponse)
 def run_marketing_team(request: RunMarketingTeamRequest) -> RunMarketingTeamResponse:
     for p in (request.brand_guidelines_path, request.brand_objectives_path):
-        if not Path(p).expanduser().resolve().is_file():
-            raise HTTPException(status_code=400, detail=f"File not found: {p}")
+        try:
+            _validate_file_path(p)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
 
     job_id = str(uuid.uuid4())
     now = _now()
@@ -382,17 +367,6 @@ def get_marketing_job_status(job_id: str) -> MarketingJobStatusResponse:
     )
 
 
-class CancelMarketingJobResponse(BaseModel):
-    job_id: str
-    status: str = "cancelled"
-    message: str = "Job cancellation requested."
-
-
-class DeleteMarketingJobResponse(BaseModel):
-    job_id: str
-    message: str = "Job deleted."
-
-
 @app.post("/social-marketing/job/{job_id}/cancel", response_model=CancelMarketingJobResponse)
 def cancel_marketing_job(job_id: str) -> CancelMarketingJobResponse:
     """Cancel a pending or running marketing job."""
@@ -420,69 +394,15 @@ def delete_marketing_job(job_id: str) -> DeleteMarketingJobResponse:
     return DeleteMarketingJobResponse(job_id=job_id, message="Job deleted.")
 
 
-def _run_trend_job() -> None:
-    """Run trend discovery and update _latest_digest. Safe to call from any thread."""
-    global _latest_digest
-    logger.info("TrendDiscovery: starting run")
-    try:
-        llm = get_client("trend_discovery")
-        searcher = OllamaWebSearch()
-        agent = TrendDiscoveryAgent(llm_client=llm, web_search=searcher)
-        digest = agent.run()
-        with _digest_lock:
-            _latest_digest = digest
-        logger.info(
-            "TrendDiscovery: completed — %d topics, generated_at=%s",
-            len(digest.topics),
-            digest.generated_at,
-        )
-    except Exception as exc:
-        logger.error("TrendDiscovery: run failed: %s", exc, exc_info=True)
-
-
-def _start_scheduler() -> None:
-    global _scheduler
-    et = pytz.timezone("America/New_York")
-    _scheduler = BackgroundScheduler(timezone=et)
-    _scheduler.add_job(
-        _run_trend_job,
-        CronTrigger(hour=8, minute=0, timezone=et),
-        id="trend_discovery_daily",
-        name="Daily social media trend discovery",
-        replace_existing=True,
-    )
-    _scheduler.start()
-    logger.info("TrendDiscovery: scheduler started — daily job at 08:00 America/New_York")
-
-
-def _stop_scheduler() -> None:
-    if _scheduler and _scheduler.running:
-        _scheduler.shutdown(wait=False)
-        logger.info("TrendDiscovery: scheduler stopped")
-
-
-@asynccontextmanager
-async def _lifespan(application: FastAPI) -> AsyncIterator[None]:
-    _start_scheduler()
-    yield
-    _stop_scheduler()
-
-
-app.router.lifespan_context = _lifespan
-
-
-class TrendRunResponse(BaseModel):
-    message: str
-
-
-class TrendLatestResponse(BaseModel):
-    digest: TrendDigest
+# ---------------------------------------------------------------------------
+# Routes — trend discovery
+# ---------------------------------------------------------------------------
 
 
 @app.post("/social-marketing/trends/run", response_model=TrendRunResponse)
 def run_trend_discovery() -> TrendRunResponse:
     """Trigger trend discovery immediately (runs in background, returns at once)."""
-    thread = threading.Thread(target=_run_trend_job, daemon=True, name="trend_discovery_manual")
+    thread = threading.Thread(target=run_trend_job, daemon=True, name="trend_discovery_manual")
     thread.start()
     return TrendRunResponse(
         message="Trend discovery started. Poll GET /social-marketing/trends/latest for results."
@@ -492,8 +412,7 @@ def run_trend_discovery() -> TrendRunResponse:
 @app.get("/social-marketing/trends/latest", response_model=TrendLatestResponse)
 def get_latest_trends() -> TrendLatestResponse:
     """Return the most recent trend digest. 404 if the job has not run yet."""
-    with _digest_lock:
-        digest = _latest_digest
+    digest = get_latest_digest()
     if digest is None:
         raise HTTPException(
             status_code=404,

--- a/backend/agents/social_media_marketing_team/api/main.py
+++ b/backend/agents/social_media_marketing_team/api/main.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import logging
+import os
 import threading
 import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
@@ -36,6 +39,19 @@ from social_media_marketing_team.orchestrator import SocialMediaMarketingOrchest
 from social_media_marketing_team.trend_discovery_agent import TrendDiscoveryAgent
 from social_media_marketing_team.trend_models import TrendDigest
 
+# Allowed base directories for brand document file reads.  Paths outside these
+# roots will be rejected to prevent path-traversal attacks.
+_ALLOWED_FILE_ROOTS: List[Path] = []
+_agent_cache = os.getenv("AGENT_CACHE", "")
+if _agent_cache:
+    _ALLOWED_FILE_ROOTS.append(Path(_agent_cache).resolve())
+_data_dir = Path("/data")
+if _data_dir.is_dir():
+    _ALLOWED_FILE_ROOTS.append(_data_dir.resolve())
+_tmp_dir = Path("/tmp")
+if _tmp_dir.is_dir():
+    _ALLOWED_FILE_ROOTS.append(_tmp_dir.resolve())
+
 app = FastAPI(title="Social Media Marketing Team API", version="1.0.0")
 
 logger = logging.getLogger(__name__)
@@ -56,6 +72,7 @@ except Exception as _init_err:
 # Each worker process maintains its own copy; for multi-worker deployments the last
 # worker to complete will serve the most recent digest.
 _latest_digest: Optional[TrendDigest] = None
+_digest_lock = threading.Lock()
 _scheduler: Optional[BackgroundScheduler] = None
 
 
@@ -71,8 +88,8 @@ class RunMarketingTeamRequest(BaseModel):
     target_audience: str = Field(default="general audience", max_length=5000)
     goals: List[str] = Field(default_factory=lambda: ["engagement", "follower growth"])
     voice_and_tone: str = Field(default="professional, clear, and human", max_length=5000)
-    cadence_posts_per_day: int = Field(default=2, ge=1)
-    duration_days: int = Field(default=14, ge=1)
+    cadence_posts_per_day: int = Field(default=2, ge=1, le=24)
+    duration_days: int = Field(default=14, ge=1, le=365)
     human_approved_for_testing: bool = Field(default=False)
     human_feedback: str = Field(default="", max_length=50_000)
 
@@ -130,11 +147,38 @@ def _read_text_file(path: str) -> str:
     fp = Path(path).expanduser().resolve()
     if not fp.is_file():
         raise ValueError(f"File not found: {path}")
+    if _ALLOWED_FILE_ROOTS and not any(
+        fp == root or root in fp.parents for root in _ALLOWED_FILE_ROOTS
+    ):
+        raise ValueError(
+            f"Access denied: {path} is outside allowed directories. "
+            f"Allowed roots: {[str(r) for r in _ALLOWED_FILE_ROOTS]}"
+        )
     return fp.read_text(encoding="utf-8", errors="replace")
 
 
 def _update_job(job_id: str, **fields) -> None:
     _job_manager.update_job(job_id, **fields)
+
+
+def _dispatch_job(job_id: str, request: RunMarketingTeamRequest) -> str:
+    """Start a job via Temporal if enabled, otherwise in a daemon thread.
+
+    Returns a human-readable message describing how the job was dispatched.
+    """
+    try:
+        from social_media_marketing_team.temporal.client import is_temporal_enabled
+        from social_media_marketing_team.temporal.start_workflow import start_team_job_workflow
+
+        if is_temporal_enabled():
+            start_team_job_workflow(job_id, request.model_dump())
+            return f"(Temporal). Poll GET /social-marketing/status/{job_id} for updates."
+    except ImportError:
+        pass
+
+    thread = threading.Thread(target=_run_team_job, args=(job_id, request), daemon=True)
+    thread.start()
+    return f"Poll GET /social-marketing/status/{job_id} for updates."
 
 
 def mark_all_running_jobs_failed(reason: str) -> None:
@@ -231,27 +275,11 @@ def run_marketing_team(request: RunMarketingTeamRequest) -> RunMarketingTeamResp
         request_payload=request.model_dump(),
     )
 
-    try:
-        from social_media_marketing_team.temporal.client import is_temporal_enabled
-        from social_media_marketing_team.temporal.start_workflow import start_team_job_workflow
-
-        if is_temporal_enabled():
-            start_team_job_workflow(job_id, request.model_dump())
-            return RunMarketingTeamResponse(
-                job_id=job_id,
-                status="running",
-                message=f"Social marketing team started (Temporal). Poll GET /social-marketing/status/{job_id} for updates.",
-            )
-    except ImportError:
-        pass
-
-    thread = threading.Thread(target=_run_team_job, args=(job_id, request), daemon=True)
-    thread.start()
-
+    dispatch_msg = _dispatch_job(job_id, request)
     return RunMarketingTeamResponse(
         job_id=job_id,
         status="running",
-        message=f"Social marketing team started. Poll GET /social-marketing/status/{job_id} for updates.",
+        message=f"Social marketing team started. {dispatch_msg}",
     )
 
 
@@ -265,8 +293,11 @@ def ingest_performance(job_id: str, payload: PerformanceIngestRequest) -> Perfor
     _job_manager.update_job(job_id, performance_observations=observations, last_updated_at=_now())
 
     campaign_name = None
-    if job.get("result") and getattr(job["result"], "proposal", None):
-        campaign_name = job["result"].proposal.campaign_name
+    result = job.get("result")
+    if isinstance(result, dict):
+        proposal = result.get("proposal")
+        if isinstance(proposal, dict):
+            campaign_name = proposal.get("campaign_name")
 
     return PerformanceIngestResponse(
         job_id=job_id,
@@ -310,26 +341,11 @@ def revise_marketing_team(
         last_updated_at=_now(),
     )
 
-    try:
-        from social_media_marketing_team.temporal.client import is_temporal_enabled
-        from social_media_marketing_team.temporal.start_workflow import start_team_job_workflow
-
-        if is_temporal_enabled():
-            start_team_job_workflow(job_id, revised.model_dump())
-            return RunMarketingTeamResponse(
-                job_id=job_id,
-                status="running",
-                message=f"Revision started for {job_id} (Temporal). Poll GET /social-marketing/status/{job_id} for updates.",
-            )
-    except ImportError:
-        pass
-
-    thread = threading.Thread(target=_run_team_job, args=(job_id, revised), daemon=True)
-    thread.start()
+    dispatch_msg = _dispatch_job(job_id, revised)
     return RunMarketingTeamResponse(
         job_id=job_id,
         status="running",
-        message=f"Revision started for {job_id}. Poll GET /social-marketing/status/{job_id} for updates.",
+        message=f"Revision started for {job_id}. {dispatch_msg}",
     )
 
 
@@ -413,7 +429,8 @@ def _run_trend_job() -> None:
         searcher = OllamaWebSearch()
         agent = TrendDiscoveryAgent(llm_client=llm, web_search=searcher)
         digest = agent.run()
-        _latest_digest = digest
+        with _digest_lock:
+            _latest_digest = digest
         logger.info(
             "TrendDiscovery: completed — %d topics, generated_at=%s",
             len(digest.topics),
@@ -423,7 +440,6 @@ def _run_trend_job() -> None:
         logger.error("TrendDiscovery: run failed: %s", exc, exc_info=True)
 
 
-@app.on_event("startup")
 def _start_scheduler() -> None:
     global _scheduler
     et = pytz.timezone("America/New_York")
@@ -439,11 +455,20 @@ def _start_scheduler() -> None:
     logger.info("TrendDiscovery: scheduler started — daily job at 08:00 America/New_York")
 
 
-@app.on_event("shutdown")
 def _stop_scheduler() -> None:
     if _scheduler and _scheduler.running:
         _scheduler.shutdown(wait=False)
         logger.info("TrendDiscovery: scheduler stopped")
+
+
+@asynccontextmanager
+async def _lifespan(application: FastAPI) -> AsyncIterator[None]:
+    _start_scheduler()
+    yield
+    _stop_scheduler()
+
+
+app.router.lifespan_context = _lifespan
 
 
 class TrendRunResponse(BaseModel):
@@ -467,12 +492,14 @@ def run_trend_discovery() -> TrendRunResponse:
 @app.get("/social-marketing/trends/latest", response_model=TrendLatestResponse)
 def get_latest_trends() -> TrendLatestResponse:
     """Return the most recent trend digest. 404 if the job has not run yet."""
-    if _latest_digest is None:
+    with _digest_lock:
+        digest = _latest_digest
+    if digest is None:
         raise HTTPException(
             status_code=404,
             detail="No trend digest available yet. Trigger one via POST /social-marketing/trends/run.",
         )
-    return TrendLatestResponse(digest=_latest_digest)
+    return TrendLatestResponse(digest=digest)
 
 
 @app.get("/health")

--- a/backend/agents/social_media_marketing_team/api/request_models.py
+++ b/backend/agents/social_media_marketing_team/api/request_models.py
@@ -1,0 +1,92 @@
+"""Request and response models for the social media marketing team API."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+from social_media_marketing_team.models import PostPerformanceObservation, TeamOutput
+from social_media_marketing_team.trend_models import TrendDigest
+
+
+class RunMarketingTeamRequest(BaseModel):
+    brand_guidelines_path: str = Field(
+        ..., max_length=4096, description="Path to brand guidelines document"
+    )
+    brand_objectives_path: str = Field(
+        ..., max_length=4096, description="Path to brand objectives document"
+    )
+    llm_model_name: str = Field(..., max_length=256, description="Name of local LLM model to use")
+    brand_name: str = Field(default="Brand", max_length=256)
+    target_audience: str = Field(default="general audience", max_length=5000)
+    goals: List[str] = Field(default_factory=lambda: ["engagement", "follower growth"])
+    voice_and_tone: str = Field(default="professional, clear, and human", max_length=5000)
+    cadence_posts_per_day: int = Field(default=2, ge=1, le=24)
+    duration_days: int = Field(default=14, ge=1, le=365)
+    human_approved_for_testing: bool = Field(default=False)
+    human_feedback: str = Field(default="", max_length=50_000)
+
+
+class ReviseMarketingTeamRequest(BaseModel):
+    feedback: str = Field(..., min_length=3)
+    approved_for_testing: bool = Field(default=False)
+
+
+class RunMarketingTeamResponse(BaseModel):
+    job_id: str
+    status: str
+    message: str
+
+
+class MarketingJobStatusResponse(BaseModel):
+    job_id: str
+    status: str
+    current_stage: str
+    progress: int
+    llm_model_name: str
+    brand_guidelines_path: str
+    brand_objectives_path: str
+    last_updated_at: str
+    eta_hint: Optional[str] = None
+    error: Optional[str] = None
+    result: Optional[TeamOutput] = None
+
+
+class MarketingJobListItem(BaseModel):
+    job_id: str
+    status: str
+    current_stage: str
+    progress: int
+    created_at: Optional[str] = None
+    last_updated_at: Optional[str] = None
+
+
+class PerformanceIngestRequest(BaseModel):
+    observations: List[PostPerformanceObservation] = Field(default_factory=list)
+
+
+class PerformanceIngestResponse(BaseModel):
+    job_id: str
+    campaign_name: Optional[str] = None
+    observations_ingested: int
+    message: str
+
+
+class CancelMarketingJobResponse(BaseModel):
+    job_id: str
+    status: str = "cancelled"
+    message: str = "Job cancellation requested."
+
+
+class DeleteMarketingJobResponse(BaseModel):
+    job_id: str
+    message: str = "Job deleted."
+
+
+class TrendRunResponse(BaseModel):
+    message: str
+
+
+class TrendLatestResponse(BaseModel):
+    digest: TrendDigest

--- a/backend/agents/social_media_marketing_team/api/trend_scheduler.py
+++ b/backend/agents/social_media_marketing_team/api/trend_scheduler.py
@@ -1,0 +1,71 @@
+"""Trend discovery scheduler and background job for the social media marketing team."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Optional
+
+import pytz
+from apscheduler.schedulers.background import BackgroundScheduler
+from apscheduler.triggers.cron import CronTrigger
+from blog_research_agent.tools.web_search import OllamaWebSearch
+
+from llm_service import get_client
+from social_media_marketing_team.trend_discovery_agent import TrendDiscoveryAgent
+from social_media_marketing_team.trend_models import TrendDigest
+
+logger = logging.getLogger(__name__)
+
+_latest_digest: Optional[TrendDigest] = None
+_digest_lock = threading.Lock()
+_scheduler: Optional[BackgroundScheduler] = None
+
+
+def get_latest_digest() -> Optional[TrendDigest]:
+    """Return the most recently computed trend digest (thread-safe)."""
+    with _digest_lock:
+        return _latest_digest
+
+
+def run_trend_job() -> None:
+    """Run trend discovery and update the cached digest. Safe to call from any thread."""
+    global _latest_digest
+    logger.info("TrendDiscovery: starting run")
+    try:
+        llm = get_client("trend_discovery")
+        searcher = OllamaWebSearch()
+        agent = TrendDiscoveryAgent(llm_client=llm, web_search=searcher)
+        digest = agent.run()
+        with _digest_lock:
+            _latest_digest = digest
+        logger.info(
+            "TrendDiscovery: completed — %d topics, generated_at=%s",
+            len(digest.topics),
+            digest.generated_at,
+        )
+    except Exception as exc:
+        logger.error("TrendDiscovery: run failed: %s", exc, exc_info=True)
+
+
+def start_scheduler() -> None:
+    """Start the APScheduler background scheduler for daily trend discovery."""
+    global _scheduler
+    et = pytz.timezone("America/New_York")
+    _scheduler = BackgroundScheduler(timezone=et)
+    _scheduler.add_job(
+        run_trend_job,
+        CronTrigger(hour=8, minute=0, timezone=et),
+        id="trend_discovery_daily",
+        name="Daily social media trend discovery",
+        replace_existing=True,
+    )
+    _scheduler.start()
+    logger.info("TrendDiscovery: scheduler started — daily job at 08:00 America/New_York")
+
+
+def stop_scheduler() -> None:
+    """Shut down the scheduler if it is running."""
+    if _scheduler and _scheduler.running:
+        _scheduler.shutdown(wait=False)
+        logger.info("TrendDiscovery: scheduler stopped")

--- a/backend/agents/social_media_marketing_team/models.py
+++ b/backend/agents/social_media_marketing_team/models.py
@@ -68,11 +68,6 @@ class ConceptIdea(BaseModel):
     risk_reasons: List[str] = Field(default_factory=list)
 
 
-class RiskReason(BaseModel):
-    category: str  # e.g. overclaim, regulatory, brand_guideline_violation, sensitivity
-    message: str
-
-
 class ContentPlan(BaseModel):
     campaign_name: str
     cadence_posts_per_day: int

--- a/backend/agents/social_media_marketing_team/models.py
+++ b/backend/agents/social_media_marketing_team/models.py
@@ -26,8 +26,8 @@ class BrandGoals(BaseModel):
     target_audience: str
     goals: List[str] = Field(default_factory=list)
     voice_and_tone: str = "professional, clear, and human"
-    cadence_posts_per_day: int = 2
-    duration_days: int = 14
+    cadence_posts_per_day: int = Field(default=2, ge=1, le=24)
+    duration_days: int = Field(default=14, ge=1, le=365)
     brand_guidelines_path: Optional[str] = None
     brand_objectives_path: Optional[str] = None
     brand_guidelines: str = ""

--- a/backend/agents/social_media_marketing_team/orchestrator.py
+++ b/backend/agents/social_media_marketing_team/orchestrator.py
@@ -35,6 +35,7 @@ class SocialMediaMarketingOrchestrator:
 
     CONSENSUS_THRESHOLD = 0.75
     MIN_COLLAB_ROUNDS = 2
+    MAX_COLLAB_ROUNDS = 10
     RUBRIC_MINIMUM = 0.7
 
     def __init__(self, llm_model_name: str = "") -> None:
@@ -118,7 +119,9 @@ class SocialMediaMarketingOrchestrator:
 
     def _reach_consensus(self, proposal: CampaignProposal) -> CampaignProposal:
         round_number = 0
-        while True:
+        best_proposal = proposal
+        best_score = 0.0
+        while round_number < self.MAX_COLLAB_ROUNDS:
             round_number += 1
             scores: List[float] = []
             rubric_results: List[bool] = []
@@ -129,6 +132,9 @@ class SocialMediaMarketingOrchestrator:
                 proposal.communication_log.append(note)
 
             proposal.consensus_score = sum(scores) / len(scores)
+            if proposal.consensus_score > best_score:
+                best_score = proposal.consensus_score
+                best_proposal = proposal
             proposal.communication_log.append(
                 f"Orchestrator round {round_number}: average consensus score {proposal.consensus_score:.2f}."
             )
@@ -147,6 +153,12 @@ class SocialMediaMarketingOrchestrator:
                 "Consensus not reached yet: refining objective and metrics for next round."
             )
             proposal.success_metrics.append(f"Refined metric checkpoint round {round_number}")
+
+        best_proposal.communication_log.append(
+            f"Max collaboration rounds ({self.MAX_COLLAB_ROUNDS}) reached; proceeding with best proposal "
+            f"(score={best_score:.2f})."
+        )
+        return best_proposal
 
     @staticmethod
     def _calibrate_probabilities(
@@ -205,13 +217,20 @@ class SocialMediaMarketingOrchestrator:
             if idea.estimated_engagement_probability >= 0.70 and idea.risk_level != "high"
         ]
 
-        idx = 1
-        while len(approved) < required_posts:
-            seed = (
-                approved[(idx - 1) % len(approved)]
-                if approved
-                else risk_reviewed[(idx - 1) % len(risk_reviewed)]
+        if not approved and not risk_reviewed:
+            return ContentPlan(
+                campaign_name=proposal.campaign_name,
+                cadence_posts_per_day=goals.cadence_posts_per_day,
+                duration_days=goals.duration_days,
+                total_required_posts=required_posts,
+                approved_ideas=[],
             )
+
+        seed_pool = approved if approved else risk_reviewed
+        idx = 1
+        max_expansion = required_posts * 2
+        while len(approved) < required_posts and idx <= max_expansion:
+            seed = seed_pool[(idx - 1) % len(seed_pool)]
             clone = seed.model_copy(deep=True)
             clone.title = f"{seed.title} variant {idx}"
             clone.concept = f"{seed.concept} Variant angle {idx} tuned for daypart testing."

--- a/backend/agents/social_media_marketing_team/orchestrator.py
+++ b/backend/agents/social_media_marketing_team/orchestrator.py
@@ -119,8 +119,6 @@ class SocialMediaMarketingOrchestrator:
 
     def _reach_consensus(self, proposal: CampaignProposal) -> CampaignProposal:
         round_number = 0
-        best_proposal = proposal
-        best_score = 0.0
         while round_number < self.MAX_COLLAB_ROUNDS:
             round_number += 1
             scores: List[float] = []
@@ -132,9 +130,6 @@ class SocialMediaMarketingOrchestrator:
                 proposal.communication_log.append(note)
 
             proposal.consensus_score = sum(scores) / len(scores)
-            if proposal.consensus_score > best_score:
-                best_score = proposal.consensus_score
-                best_proposal = proposal
             proposal.communication_log.append(
                 f"Orchestrator round {round_number}: average consensus score {proposal.consensus_score:.2f}."
             )
@@ -154,11 +149,11 @@ class SocialMediaMarketingOrchestrator:
             )
             proposal.success_metrics.append(f"Refined metric checkpoint round {round_number}")
 
-        best_proposal.communication_log.append(
-            f"Max collaboration rounds ({self.MAX_COLLAB_ROUNDS}) reached; proceeding with best proposal "
-            f"(score={best_score:.2f})."
+        proposal.communication_log.append(
+            f"Max collaboration rounds ({self.MAX_COLLAB_ROUNDS}) reached; proceeding with current proposal "
+            f"(score={proposal.consensus_score:.2f})."
         )
-        return best_proposal
+        return proposal
 
     @staticmethod
     def _calibrate_probabilities(

--- a/backend/agents/social_media_marketing_team/tests/conftest.py
+++ b/backend/agents/social_media_marketing_team/tests/conftest.py
@@ -1,6 +1,8 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
@@ -9,3 +11,30 @@ if str(ROOT) not in sys.path:
 BLOGGING_DIR = ROOT / "blogging"
 if str(BLOGGING_DIR) not in sys.path:
     sys.path.insert(0, str(BLOGGING_DIR))
+
+from social_media_marketing_team.models import BrandGoals  # noqa: E402
+
+
+def make_goals(
+    brand_name: str = "Northstar",
+    target_audience: str = "growth leaders",
+    goals: list[str] | None = None,
+    cadence_posts_per_day: int = 2,
+    duration_days: int = 14,
+    **kwargs,
+) -> BrandGoals:
+    """Build a ``BrandGoals`` with sensible defaults for tests."""
+    return BrandGoals(
+        brand_name=brand_name,
+        target_audience=target_audience,
+        goals=goals or ["engagement", "followers"],
+        cadence_posts_per_day=cadence_posts_per_day,
+        duration_days=duration_days,
+        **kwargs,
+    )
+
+
+@pytest.fixture()
+def default_goals() -> BrandGoals:
+    """Pytest fixture exposing ``make_goals()`` with all defaults."""
+    return make_goals()

--- a/backend/agents/social_media_marketing_team/tests/test_agents_and_models.py
+++ b/backend/agents/social_media_marketing_team/tests/test_agents_and_models.py
@@ -9,15 +9,16 @@ from social_media_marketing_team.agents import (
     RiskComplianceAgent,
 )
 from social_media_marketing_team.models import (
-    BrandGoals,
     CampaignProposal,
     ConceptIdea,
     Platform,
 )
 
+from .conftest import make_goals
 
-def _goals() -> BrandGoals:
-    return BrandGoals(
+
+def _goals():
+    return make_goals(
         brand_name="Acme",
         target_audience="B2B marketers",
         goals=["engagement", "follower growth"],

--- a/backend/agents/social_media_marketing_team/tests/test_orchestrator_additional.py
+++ b/backend/agents/social_media_marketing_team/tests/test_orchestrator_additional.py
@@ -12,15 +12,11 @@ from social_media_marketing_team.models import (
 )
 from social_media_marketing_team.orchestrator import SocialMediaMarketingOrchestrator
 
+from .conftest import make_goals
+
 
 def _goals() -> BrandGoals:
-    return BrandGoals(
-        brand_name="Northstar",
-        target_audience="growth leaders",
-        goals=["engagement", "followers"],
-        cadence_posts_per_day=1,
-        duration_days=3,
-    )
+    return make_goals(cadence_posts_per_day=1, duration_days=3)
 
 
 def test_default_feedback_messages() -> None:

--- a/backend/agents/social_media_marketing_team/tests/test_orchestrator_additional.py
+++ b/backend/agents/social_media_marketing_team/tests/test_orchestrator_additional.py
@@ -44,7 +44,11 @@ def test_reach_consensus_runs_multiple_rounds_and_logs_refinement() -> None:
 
     assert result.consensus_score >= orchestrator.CONSENSUS_THRESHOLD
     assert any("Consensus not reached yet" in msg for msg in result.communication_log)
-    assert any("Consensus reached" in msg for msg in result.communication_log)
+    # Consensus may be reached naturally or after hitting the max-rounds guard.
+    assert any(
+        "Consensus reached" in msg or "Max collaboration rounds" in msg
+        for msg in result.communication_log
+    )
 
 
 def test_plan_content_handles_no_initially_approved_ideas() -> None:

--- a/backend/agents/social_media_marketing_team/tests/test_social_marketing_orchestrator.py
+++ b/backend/agents/social_media_marketing_team/tests/test_social_marketing_orchestrator.py
@@ -11,9 +11,11 @@ from social_media_marketing_team.models import (
     PostPerformanceObservation,
 )
 
+from .conftest import make_goals
+
 
 def _goals() -> BrandGoals:
-    return BrandGoals(
+    return make_goals(
         brand_name="Northstar Labs",
         target_audience="startup founders and marketing operators",
         goals=["engagement", "follower growth", "qualified leads"],

--- a/backend/agents/social_media_marketing_team/trend_discovery_agent.py
+++ b/backend/agents/social_media_marketing_team/trend_discovery_agent.py
@@ -93,8 +93,10 @@ class TrendDiscoveryAgent:
     """
 
     def __init__(self, llm_client: LLMClient, web_search: OllamaWebSearch) -> None:
-        assert llm_client is not None, "llm_client is required"
-        assert web_search is not None, "web_search is required"
+        if llm_client is None:
+            raise ValueError("llm_client is required")
+        if web_search is None:
+            raise ValueError("web_search is required")
         self.llm = llm_client
         self.web_search = web_search
 

--- a/backend/agents/social_media_marketing_team/trend_discovery_agent.py
+++ b/backend/agents/social_media_marketing_team/trend_discovery_agent.py
@@ -158,7 +158,7 @@ class TrendDiscoveryAgent:
         topics: List[TrendingTopic] = []
         try:
             data = self.llm.complete_json(prompt, temperature=0.2)
-            raw_topics = data.get("topics") or [] if isinstance(data, dict) else []
+            raw_topics = data.get("topics", []) if isinstance(data, dict) else []
             for item in raw_topics[:3]:
                 if not isinstance(item, dict):
                     continue


### PR DESCRIPTION
Security: add path-traversal protection to _read_text_file with allowed-root
validation. Fix ingest_performance dict-vs-model bug where campaign_name
extraction was dead code.

Performance: add MAX_COLLAB_ROUNDS (10) guard to consensus loop preventing
infinite spin. Add safety valve and empty-list handling to cadence expansion
loop. Add upper bounds (le=24/le=365) on cadence_posts_per_day/duration_days.

Design: differentiate CampaignCollaborationAgent by role via per-role rubric
weights so each specialist (Strategist, Audience Lead, Analyst) produces
distinct scores. Split ContentConceptAgent archetypes by role — Storytelling
Lead uses narrative archetypes, Creative Testing Lead uses experimental ones.

Quality: replace substring risk matching with word-boundary regex to eliminate
false positives. Migrate deprecated @app.on_event to lifespan context manager.
Add threading.Lock for _latest_digest global. Extract duplicate Temporal
dispatch into _dispatch_job helper. Replace assert with ValueError in
TrendDiscoveryAgent.__init__.

https://claude.ai/code/session_01EADhKTT3NnY6Lk1K6D33Rm