### PR TITLE
feat(agentic-teams): add interactive flow diagram with agent search and recommendations

### DIFF
--- a/backend/agents/agentic_team_provisioning/api/main.py
+++ b/backend/agents/agentic_team_provisioning/api/main.py
@@ -29,7 +29,6 @@ from agentic_team_provisioning.models import (
     ProcessDefinition,
     ProcessOutput,
     ProcessStatus,
-    ProcessStep,
     ProcessTrigger,
     RecommendAgentsResponse,
     RecommendedAgent,

--- a/backend/agents/agentic_team_provisioning/api/main.py
+++ b/backend/agents/agentic_team_provisioning/api/main.py
@@ -400,6 +400,22 @@ def send_message(conversation_id: str, req: SendMessageRequest):
     return _build_state_response(conversation_id, team_id, effective_process, suggestions)
 
 
+@app.put("/conversations/{conversation_id}/process")
+def set_conversation_process(conversation_id: str, body: dict):
+    """Link a process to the active conversation so chat stays in sync with the visual editor."""
+    team_id = _store.get_conversation_team_id(conversation_id)
+    if not team_id:
+        raise HTTPException(status_code=404, detail="Conversation not found")
+    process_id = body.get("process_id")
+    if not process_id:
+        raise HTTPException(status_code=400, detail="process_id is required")
+    process = _store.get_process(process_id)
+    if not process:
+        raise HTTPException(status_code=404, detail="Process not found")
+    _store.set_conversation_process(conversation_id, process_id)
+    return {"conversation_id": conversation_id, "process_id": process_id}
+
+
 @app.get("/conversations/{conversation_id}", response_model=ConversationStateResponse)
 def get_conversation(conversation_id: str):
     team_id = _store.get_conversation_team_id(conversation_id)

--- a/backend/agents/agentic_team_provisioning/api/main.py
+++ b/backend/agents/agentic_team_provisioning/api/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
@@ -26,6 +27,12 @@ from agentic_team_provisioning.models import (
     CreateTeamResponse,
     FormRecord,
     ProcessDefinition,
+    ProcessOutput,
+    ProcessStatus,
+    ProcessStep,
+    ProcessTrigger,
+    RecommendAgentsResponse,
+    RecommendedAgent,
     RosterValidationResult,
     SendMessageRequest,
     SubmitTeamAnswersRequest,
@@ -180,6 +187,117 @@ def get_process(process_id: str):
     if not process:
         raise HTTPException(status_code=404, detail="Process not found")
     return process
+
+
+@app.post("/teams/{team_id}/processes", response_model=ProcessDefinition, status_code=201)
+def create_process(team_id: str):
+    """Create a new blank process for the team."""
+    team = _store.get_team(team_id)
+    if not team:
+        raise HTTPException(status_code=404, detail="Team not found")
+    process = ProcessDefinition(
+        process_id=str(uuid.uuid4()),
+        name="New Process",
+        description="",
+        trigger=ProcessTrigger(),
+        steps=[],
+        output=ProcessOutput(),
+        status=ProcessStatus.DRAFT,
+    )
+    _store.save_process(team_id, process)
+    return process
+
+
+@app.put("/processes/{process_id}", response_model=ProcessDefinition)
+def update_process(process_id: str, process: ProcessDefinition):
+    """Update a process definition (visual editor saves)."""
+    existing = _store.get_process(process_id)
+    if not existing:
+        raise HTTPException(status_code=404, detail="Process not found")
+    if process.process_id != process_id:
+        raise HTTPException(status_code=400, detail="process_id in body must match URL")
+    # Find team_id from the store
+    team_id = _store.get_process_team_id(process_id)
+    if not team_id:
+        raise HTTPException(status_code=404, detail="Process team not found")
+    _store.save_process(team_id, process)
+    _after_process_saved(team_id, process)
+    return process
+
+
+@app.post(
+    "/processes/{process_id}/steps/{step_id}/recommend-agents",
+    response_model=RecommendAgentsResponse,
+)
+def recommend_agents_for_step(process_id: str, step_id: str):
+    """Recommend agents for a specific process step based on its description."""
+    process = _store.get_process(process_id)
+    if not process:
+        raise HTTPException(status_code=404, detail="Process not found")
+    step = next((s for s in process.steps if s.step_id == step_id), None)
+    if not step:
+        raise HTTPException(status_code=404, detail="Step not found")
+
+    team_id = _store.get_process_team_id(process_id)
+    recommendations: list[RecommendedAgent] = []
+
+    # Try registry-based recommendations via studiogrid
+    try:
+        from studiogrid.runtime.registry_loader import RegistryLoader
+
+        loader = RegistryLoader(Path(__file__).resolve().parents[4] / "studiogrid" / "src" / "studiogrid")
+        search_text = f"{step.name} {step.description}"
+        found = loader.find_assisting_agents(problem_description=search_text, required_skills=[], limit=5)
+        for agent in found:
+            recommendations.append(
+                RecommendedAgent(
+                    agent_name=agent.get("agent_id", ""),
+                    source="registry",
+                    role=agent.get("description", "")[:120],
+                    skills=agent.get("skills", []),
+                    tools=agent.get("resources", []),
+                    keywords=agent.get("match", {}).get("keywords", []),
+                    match_score=float(agent.get("score", 0)),
+                )
+            )
+    except Exception:
+        logger.debug("StudioGrid registry not available for recommendations", exc_info=True)
+
+    # Also recommend matching roster agents
+    if team_id:
+        team = _store.get_team(team_id)
+        if team:
+            search_tokens = {
+                t.lower()
+                for t in f"{step.name} {step.description}".split()
+                if len(t) > 2
+            }
+            for agent in team.agents:
+                agent_tokens = {
+                    t.lower()
+                    for t in (agent.skills + agent.capabilities + agent.tools + agent.expertise)
+                }
+                overlap = len(search_tokens & agent_tokens)
+                if overlap > 0:
+                    recommendations.append(
+                        RecommendedAgent(
+                            agent_name=agent.agent_name,
+                            source="roster",
+                            role=agent.role,
+                            skills=agent.skills,
+                            tools=agent.tools,
+                            match_score=float(overlap),
+                        )
+                    )
+
+    # Sort by score descending
+    recommendations.sort(key=lambda r: -r.match_score)
+
+    return RecommendAgentsResponse(
+        step_id=step_id,
+        step_name=step.name,
+        recommended_agents=recommendations[:10],
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/agentic_team_provisioning/api/main.py
+++ b/backend/agents/agentic_team_provisioning/api/main.py
@@ -255,7 +255,10 @@ def recommend_agents_for_step(process_id: str, step_id: str):
                     source="registry",
                     role=agent.get("description", "")[:120],
                     skills=agent.get("skills", []),
-                    tools=agent.get("resources", []),
+                    tools=[
+                        r.get("name", str(r)) if isinstance(r, dict) else str(r)
+                        for r in agent.get("resources", [])
+                    ],
                     keywords=agent.get("match", {}).get("keywords", []),
                     match_score=float(agent.get("score", 0)),
                 )

--- a/backend/agents/agentic_team_provisioning/assistant/store.py
+++ b/backend/agents/agentic_team_provisioning/assistant/store.py
@@ -199,6 +199,14 @@ class AgenticTeamStore:
                 return None
         return ProcessDefinition(**json.loads(row["data_json"]))
 
+    def get_process_team_id(self, process_id: str) -> Optional[str]:
+        """Return the team_id that owns a given process."""
+        with self._lock, self._connect() as conn:
+            row = conn.execute(
+                "SELECT team_id FROM processes WHERE process_id = ?", (process_id,)
+            ).fetchone()
+        return row["team_id"] if row else None
+
     def _load_processes(self, conn: sqlite3.Connection, team_id: str) -> list[ProcessDefinition]:
         rows = conn.execute(
             "SELECT data_json FROM processes WHERE team_id = ? ORDER BY created_at", (team_id,)

--- a/backend/agents/agentic_team_provisioning/models.py
+++ b/backend/agents/agentic_team_provisioning/models.py
@@ -291,6 +291,26 @@ class RosterValidationResult(BaseModel):
     summary: str = Field(default="", description="Human-readable summary of the validation")
 
 
+class RecommendedAgent(BaseModel):
+    """An agent recommended for a process step."""
+
+    agent_name: str = Field(..., description="Agent identifier")
+    source: str = Field(..., description="Where the recommendation came from: 'registry' or 'roster'")
+    role: str = Field(default="", description="Suggested role for this agent")
+    skills: list[str] = Field(default_factory=list)
+    tools: list[str] = Field(default_factory=list)
+    keywords: list[str] = Field(default_factory=list)
+    match_score: float = Field(default=0.0, description="Relevance score (higher is better)")
+
+
+class RecommendAgentsResponse(BaseModel):
+    """Response for agent recommendation requests."""
+
+    step_id: str
+    step_name: str
+    recommended_agents: list[RecommendedAgent] = Field(default_factory=list)
+
+
 class AgentEnvProvisionSummary(BaseModel):
     """Status of an Agent Provisioning run for a process step agent."""
 

--- a/user-interface/src/app/components/flow-step-editor/flow-step-editor.component.html
+++ b/user-interface/src/app/components/flow-step-editor/flow-step-editor.component.html
@@ -1,0 +1,223 @@
+<div class="step-editor-panel">
+  <div class="editor-header">
+    <h3>
+      <mat-icon>edit</mat-icon>
+      Edit Step
+    </h3>
+    <span class="spacer"></span>
+    <button mat-icon-button (click)="onClose()" matTooltip="Close editor">
+      <mat-icon>close</mat-icon>
+    </button>
+  </div>
+
+  <!-- Step Details Form -->
+  <div class="editor-section">
+    <form [formGroup]="form" class="step-form">
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Step Name</mat-label>
+        <input matInput formControlName="name" (blur)="onSave()" />
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Description</mat-label>
+        <textarea matInput formControlName="description" rows="2" (blur)="onSave()"></textarea>
+      </mat-form-field>
+
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Step Type</mat-label>
+        <mat-select formControlName="step_type" (selectionChange)="onSave()">
+          @for (t of stepTypes; track t.value) {
+            <mat-option [value]="t.value">{{ t.label }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+
+      @if (form.get('step_type')?.value === 'decision') {
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Condition</mat-label>
+          <input matInput formControlName="condition" placeholder="e.g. approval_status == 'approved'" (blur)="onSave()" />
+        </mat-form-field>
+      }
+    </form>
+  </div>
+
+  <mat-divider></mat-divider>
+
+  <!-- Assigned Agents -->
+  <div class="editor-section">
+    <h4>
+      <mat-icon>people</mat-icon>
+      Assigned Agents
+      <span class="count-badge">{{ assignedAgents().length }}</span>
+    </h4>
+
+    @if (assignedAgents().length === 0) {
+      <p class="empty-text">No agents assigned yet. Search or use recommendations below.</p>
+    } @else {
+      <div class="assigned-list">
+        @for (agent of assignedAgents(); track agent.agent_name) {
+          <div class="assigned-agent">
+            <mat-icon class="agent-icon">smart_toy</mat-icon>
+            <div class="agent-info">
+              <span class="agent-name">{{ agent.agent_name }}</span>
+              <span class="agent-role">{{ agent.role }}</span>
+            </div>
+            <button mat-icon-button (click)="removeAgent(agent.agent_name)" matTooltip="Remove agent" class="remove-btn">
+              <mat-icon>close</mat-icon>
+            </button>
+          </div>
+        }
+      </div>
+    }
+  </div>
+
+  <mat-divider></mat-divider>
+
+  <!-- Agent Search -->
+  <div class="editor-section">
+    <h4>
+      <mat-icon>search</mat-icon>
+      Search Agents
+    </h4>
+
+    <mat-form-field appearance="outline" class="full-width">
+      <mat-label>Search by skill, tool, or keyword...</mat-label>
+      <input matInput [value]="agentSearchTerm()" (input)="onSearchInput($event)" />
+      <mat-icon matSuffix>search</mat-icon>
+    </mat-form-field>
+
+    @if (searchLoading()) {
+      <mat-progress-bar mode="indeterminate" class="search-progress"></mat-progress-bar>
+    }
+
+    @if (agentSearchResults().length > 0) {
+      <div class="agent-results">
+        @for (agent of agentSearchResults(); track agent.agent_id) {
+          <div class="result-card" [class.already-assigned]="isAgentAssigned(agent.agent_id)">
+            <div class="result-header">
+              <mat-icon>smart_toy</mat-icon>
+              <span class="result-name">{{ agent.agent_id }}</span>
+              @if (!isAgentAssigned(agent.agent_id)) {
+                <button mat-stroked-button class="assign-btn" (click)="assignAgent(agent.agent_id, '')">
+                  <mat-icon>add</mat-icon> Assign
+                </button>
+              } @else {
+                <mat-chip class="assigned-chip">
+                  <mat-icon matChipAvatar>check</mat-icon>
+                  Assigned
+                </mat-chip>
+              }
+            </div>
+            @if (agent.skills && agent.skills.length > 0) {
+              <div class="result-tags">
+                @for (s of agent.skills; track s) {
+                  <span class="tag skill">{{ s }}</span>
+                }
+              </div>
+            }
+            @if (agent.tools && agent.tools.length > 0) {
+              <div class="result-tags">
+                @for (t of agent.tools; track t) {
+                  <span class="tag tool">{{ t }}</span>
+                }
+              </div>
+            }
+          </div>
+        }
+      </div>
+    }
+  </div>
+
+  <mat-divider></mat-divider>
+
+  <!-- Recommended Agents -->
+  <div class="editor-section">
+    <h4>
+      <mat-icon>auto_awesome</mat-icon>
+      Recommended Agents
+    </h4>
+
+    @if (recommendationsLoading()) {
+      <mat-progress-bar mode="indeterminate" class="search-progress"></mat-progress-bar>
+      <p class="loading-text">Analyzing step requirements...</p>
+    } @else if (recommendations().length === 0) {
+      <p class="empty-text">No recommendations available for this step.</p>
+    } @else {
+      <div class="agent-results">
+        @for (rec of recommendations(); track rec.agent_name) {
+          <div class="result-card recommendation" [class.already-assigned]="isAgentAssigned(rec.agent_name)">
+            <div class="result-header">
+              <mat-icon>{{ rec.source === 'roster' ? 'badge' : 'smart_toy' }}</mat-icon>
+              <span class="result-name">{{ rec.agent_name }}</span>
+              <span class="source-badge" [class]="rec.source">{{ rec.source }}</span>
+              @if (!isAgentAssigned(rec.agent_name)) {
+                <button mat-stroked-button class="assign-btn" (click)="assignAgent(rec.agent_name, rec.role)">
+                  <mat-icon>add</mat-icon> Assign
+                </button>
+              } @else {
+                <mat-chip class="assigned-chip">
+                  <mat-icon matChipAvatar>check</mat-icon>
+                  Assigned
+                </mat-chip>
+              }
+            </div>
+            @if (rec.role) {
+              <p class="rec-role">{{ rec.role }}</p>
+            }
+            @if (rec.skills.length > 0) {
+              <div class="result-tags">
+                @for (s of rec.skills; track s) {
+                  <span class="tag skill">{{ s }}</span>
+                }
+              </div>
+            }
+            <div class="match-score">
+              <mat-icon>trending_up</mat-icon>
+              <span>Match: {{ rec.match_score | number:'1.0-0' }}</span>
+            </div>
+          </div>
+        }
+      </div>
+    }
+  </div>
+
+  <mat-divider></mat-divider>
+
+  <!-- Next Steps -->
+  <div class="editor-section">
+    <h4>
+      <mat-icon>arrow_forward</mat-icon>
+      Connects To
+    </h4>
+
+    @if (otherSteps().length === 0) {
+      <p class="empty-text">No other steps to connect to.</p>
+    } @else {
+      <div class="next-steps-list">
+        @for (s of otherSteps(); track s.step_id) {
+          <div
+            class="next-step-option"
+            [class.selected]="isNextStep(s.step_id)"
+            (click)="toggleNextStep(s.step_id)"
+            role="checkbox"
+            tabindex="0"
+            [attr.aria-checked]="isNextStep(s.step_id)"
+            (keydown.enter)="toggleNextStep(s.step_id)"
+            (keydown.space)="$event.preventDefault(); toggleNextStep(s.step_id)"
+          >
+            <mat-icon>{{ isNextStep(s.step_id) ? 'check_box' : 'check_box_outline_blank' }}</mat-icon>
+            <span>{{ s.name }}</span>
+          </div>
+        }
+      </div>
+    }
+  </div>
+
+  <!-- Actions -->
+  <div class="editor-actions">
+    <button mat-raised-button color="warn" (click)="onDelete()" matTooltip="Delete this step">
+      <mat-icon>delete</mat-icon>
+      Delete Step
+    </button>
+  </div>
+</div>

--- a/user-interface/src/app/components/flow-step-editor/flow-step-editor.component.scss
+++ b/user-interface/src/app/components/flow-step-editor/flow-step-editor.component.scss
@@ -1,0 +1,362 @@
+.step-editor-panel {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow-y: auto;
+  background: #161b22;
+  border-left: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.editor-header {
+  display: flex;
+  align-items: center;
+  padding: 16px 16px 8px;
+  position: sticky;
+  top: 0;
+  background: #161b22;
+  z-index: 1;
+
+  h3 {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 0;
+    font-size: 1rem;
+    color: #f0f6fc;
+
+    mat-icon {
+      color: #58a6ff;
+    }
+  }
+
+  .spacer {
+    flex: 1;
+  }
+}
+
+.editor-section {
+  padding: 12px 16px;
+
+  h4 {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin: 0 0 10px;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: #c9d1d9;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+
+    mat-icon {
+      font-size: 16px;
+      width: 16px;
+      height: 16px;
+      color: #8b949e;
+    }
+  }
+}
+
+.count-badge {
+  background: rgba(88, 166, 255, 0.15);
+  color: #58a6ff;
+  font-size: 0.6875rem;
+  padding: 1px 7px;
+  border-radius: 10px;
+  margin-left: 6px;
+}
+
+.full-width {
+  width: 100%;
+}
+
+.step-form {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.empty-text {
+  color: #484f58;
+  font-size: 0.8125rem;
+  font-style: italic;
+  margin: 0;
+  line-height: 1.4;
+}
+
+.loading-text {
+  color: #8b949e;
+  font-size: 0.8125rem;
+  margin: 8px 0 0;
+}
+
+// Assigned agents list
+.assigned-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.assigned-agent {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  background: #0d1117;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+
+  .agent-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    color: #d2a8ff;
+  }
+
+  .agent-info {
+    flex: 1;
+    min-width: 0;
+
+    .agent-name {
+      display: block;
+      color: #f0f6fc;
+      font-size: 0.8125rem;
+      font-weight: 500;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+
+    .agent-role {
+      display: block;
+      color: #8b949e;
+      font-size: 0.6875rem;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+  }
+
+  .remove-btn {
+    color: #484f58;
+    width: 28px;
+    height: 28px;
+    line-height: 28px;
+
+    mat-icon {
+      font-size: 16px;
+      width: 16px;
+      height: 16px;
+    }
+
+    &:hover {
+      color: #f85149;
+    }
+  }
+}
+
+// Search progress
+.search-progress {
+  margin-bottom: 8px;
+}
+
+// Agent results (search + recommendations)
+.agent-results {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-height: 280px;
+  overflow-y: auto;
+}
+
+.result-card {
+  padding: 10px 12px;
+  background: #0d1117;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 8px;
+  transition: border-color 0.2s;
+
+  &:hover {
+    border-color: rgba(255, 255, 255, 0.14);
+  }
+
+  &.already-assigned {
+    opacity: 0.6;
+    border-color: rgba(63, 185, 80, 0.2);
+  }
+
+  &.recommendation {
+    border-left: 3px solid #d2a8ff;
+  }
+}
+
+.result-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 6px;
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    color: #58a6ff;
+  }
+
+  .result-name {
+    flex: 1;
+    color: #f0f6fc;
+    font-size: 0.8125rem;
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+}
+
+.assign-btn {
+  font-size: 0.6875rem !important;
+  line-height: 24px !important;
+  padding: 0 10px !important;
+  min-width: 0 !important;
+  border-color: rgba(88, 166, 255, 0.4) !important;
+  color: #58a6ff !important;
+
+  mat-icon {
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
+    margin-right: 2px;
+  }
+
+  &:hover {
+    background: rgba(88, 166, 255, 0.1) !important;
+  }
+}
+
+.assigned-chip {
+  font-size: 0.6875rem !important;
+  --mdc-chip-label-text-color: #3fb950;
+  --mdc-chip-elevated-container-color: rgba(63, 185, 80, 0.1);
+}
+
+.source-badge {
+  font-size: 0.625rem;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-weight: 600;
+  text-transform: uppercase;
+
+  &.registry {
+    background: rgba(88, 166, 255, 0.1);
+    color: #58a6ff;
+  }
+
+  &.roster {
+    background: rgba(210, 168, 255, 0.1);
+    color: #d2a8ff;
+  }
+}
+
+.rec-role {
+  color: #8b949e;
+  font-size: 0.75rem;
+  margin: 0 0 6px;
+  line-height: 1.4;
+}
+
+.result-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin-top: 4px;
+}
+
+.tag {
+  display: inline-block;
+  padding: 2px 7px;
+  border-radius: 10px;
+  font-size: 0.625rem;
+  font-weight: 500;
+
+  &.skill {
+    background: rgba(88, 166, 255, 0.1);
+    color: #58a6ff;
+    border: 1px solid rgba(88, 166, 255, 0.2);
+  }
+
+  &.tool {
+    background: rgba(210, 153, 34, 0.1);
+    color: #d29922;
+    border: 1px solid rgba(210, 153, 34, 0.2);
+  }
+}
+
+.match-score {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 6px;
+  color: #8b949e;
+  font-size: 0.6875rem;
+
+  mat-icon {
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
+    color: #3fb950;
+  }
+}
+
+// Next steps
+.next-steps-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.next-step-option {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  background: #0d1117;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: border-color 0.2s;
+  color: #c9d1d9;
+  font-size: 0.8125rem;
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    color: #484f58;
+  }
+
+  &:hover {
+    border-color: rgba(255, 255, 255, 0.14);
+  }
+
+  &.selected {
+    border-color: rgba(88, 166, 255, 0.3);
+    background: rgba(88, 166, 255, 0.05);
+
+    mat-icon {
+      color: #58a6ff;
+    }
+  }
+}
+
+// Actions bar
+.editor-actions {
+  padding: 16px;
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+  position: sticky;
+  bottom: 0;
+  background: #161b22;
+}

--- a/user-interface/src/app/components/flow-step-editor/flow-step-editor.component.ts
+++ b/user-interface/src/app/components/flow-step-editor/flow-step-editor.component.ts
@@ -1,0 +1,217 @@
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  OnChanges,
+  SimpleChanges,
+  inject,
+  signal,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatProgressBarModule } from '@angular/material/progress-bar';
+import { debounceTime, distinctUntilChanged, Subject } from 'rxjs';
+import { AgenticTeamApiService } from '../../services/agentic-team-api.service';
+import { StudioGridApiService } from '../../services/studio-grid-api.service';
+import type {
+  ProcessStep,
+  ProcessStepAgent,
+  StepType,
+  RecommendedAgent,
+  AgentInfo,
+  ProcessDefinition,
+} from '../../models';
+
+@Component({
+  selector: 'app-flow-step-editor',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatButtonModule,
+    MatIconModule,
+    MatChipsModule,
+    MatTooltipModule,
+    MatDividerModule,
+    MatProgressBarModule,
+  ],
+  templateUrl: './flow-step-editor.component.html',
+  styleUrl: './flow-step-editor.component.scss',
+})
+export class FlowStepEditorComponent implements OnChanges {
+  @Input() step!: ProcessStep;
+  @Input() process!: ProcessDefinition;
+  @Input() allSteps: ProcessStep[] = [];
+
+  @Output() stepUpdated = new EventEmitter<ProcessStep>();
+  @Output() stepDeleted = new EventEmitter<string>();
+  @Output() closed = new EventEmitter<void>();
+
+  private readonly agenticApi = inject(AgenticTeamApiService);
+  private readonly studioApi = inject(StudioGridApiService);
+  private readonly fb = inject(FormBuilder);
+
+  stepTypes: { value: StepType; label: string }[] = [
+    { value: 'action', label: 'Action' },
+    { value: 'decision', label: 'Decision' },
+    { value: 'parallel_split', label: 'Parallel Split' },
+    { value: 'parallel_join', label: 'Parallel Join' },
+    { value: 'wait', label: 'Wait' },
+    { value: 'subprocess', label: 'Subprocess' },
+  ];
+
+  form = this.fb.nonNullable.group({
+    name: ['', [Validators.required, Validators.minLength(1)]],
+    description: [''],
+    step_type: ['action' as StepType],
+    condition: [''],
+  });
+
+  // Agent search
+  agentSearchTerm = signal('');
+  agentSearchResults = signal<AgentInfo[]>([]);
+  searchLoading = signal(false);
+  private searchSubject = new Subject<string>();
+
+  // Recommendations
+  recommendations = signal<RecommendedAgent[]>([]);
+  recommendationsLoading = signal(false);
+
+  // Assigned agents (local working copy)
+  assignedAgents = signal<ProcessStepAgent[]>([]);
+
+  // Next steps selection
+  selectedNextSteps = signal<string[]>([]);
+
+  constructor() {
+    this.searchSubject
+      .pipe(debounceTime(400), distinctUntilChanged())
+      .subscribe((term) => this.executeSearch(term));
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['step'] && this.step) {
+      this.form.patchValue({
+        name: this.step.name,
+        description: this.step.description,
+        step_type: this.step.step_type,
+        condition: this.step.condition ?? '',
+      });
+      this.assignedAgents.set([...this.step.agents]);
+      this.selectedNextSteps.set([...this.step.next_steps]);
+      this.loadRecommendations();
+    }
+  }
+
+  onSearchInput(event: Event): void {
+    const value = (event.target as HTMLInputElement).value;
+    this.agentSearchTerm.set(value);
+    this.searchSubject.next(value);
+  }
+
+  private executeSearch(term: string): void {
+    if (!term.trim()) {
+      this.agentSearchResults.set([]);
+      return;
+    }
+    this.searchLoading.set(true);
+    this.studioApi.findAgents({ problem: term, skills: [], limit: 8 }).subscribe({
+      next: (res) => {
+        this.agentSearchResults.set(res.assisting_agents ?? []);
+        this.searchLoading.set(false);
+      },
+      error: () => {
+        this.agentSearchResults.set([]);
+        this.searchLoading.set(false);
+      },
+    });
+  }
+
+  private loadRecommendations(): void {
+    if (!this.process?.process_id || !this.step?.step_id) return;
+    this.recommendationsLoading.set(true);
+    this.agenticApi
+      .recommendAgentsForStep(this.process.process_id, this.step.step_id)
+      .subscribe({
+        next: (res) => {
+          this.recommendations.set(res.recommended_agents);
+          this.recommendationsLoading.set(false);
+        },
+        error: () => {
+          this.recommendations.set([]);
+          this.recommendationsLoading.set(false);
+        },
+      });
+  }
+
+  assignAgent(agentName: string, role: string): void {
+    const current = this.assignedAgents();
+    if (current.some((a) => a.agent_name === agentName)) return;
+    this.assignedAgents.set([...current, { agent_name: agentName, role }]);
+    this.emitUpdate();
+  }
+
+  removeAgent(agentName: string): void {
+    this.assignedAgents.update((agents) => agents.filter((a) => a.agent_name !== agentName));
+    this.emitUpdate();
+  }
+
+  toggleNextStep(stepId: string): void {
+    this.selectedNextSteps.update((steps) =>
+      steps.includes(stepId) ? steps.filter((s) => s !== stepId) : [...steps, stepId],
+    );
+    this.emitUpdate();
+  }
+
+  onSave(): void {
+    this.emitUpdate();
+  }
+
+  onDelete(): void {
+    this.stepDeleted.emit(this.step.step_id);
+  }
+
+  onClose(): void {
+    this.closed.emit();
+  }
+
+  private emitUpdate(): void {
+    const formValue = this.form.getRawValue();
+    const updated: ProcessStep = {
+      ...this.step,
+      name: formValue.name,
+      description: formValue.description,
+      step_type: formValue.step_type,
+      condition: formValue.condition || null,
+      agents: this.assignedAgents(),
+      next_steps: this.selectedNextSteps(),
+    };
+    this.stepUpdated.emit(updated);
+  }
+
+  isAgentAssigned(agentName: string): boolean {
+    return this.assignedAgents().some((a) => a.agent_name === agentName);
+  }
+
+  otherSteps(): ProcessStep[] {
+    return this.allSteps.filter((s) => s.step_id !== this.step.step_id);
+  }
+
+  isNextStep(stepId: string): boolean {
+    return this.selectedNextSteps().includes(stepId);
+  }
+}

--- a/user-interface/src/app/components/process-designer-chat/process-designer-chat.component.html
+++ b/user-interface/src/app/components/process-designer-chat/process-designer-chat.component.html
@@ -1,4 +1,4 @@
-<div class="designer-layout">
+<div class="designer-layout" [class.editor-open]="selectedStep()">
   <!-- Chat panel -->
   <div class="chat-panel">
     <mat-card class="chat-card">
@@ -224,33 +224,80 @@
           <mat-icon>account_tree</mat-icon>
           Process Diagram
         </mat-card-title>
+        <span class="spacer"></span>
+        @if (saving()) {
+          <mat-chip class="saving-badge">Saving...</mat-chip>
+        }
       </mat-card-header>
 
       <mat-card-content>
         @if (currentProcess(); as process) {
+          <!-- Process meta (editable) -->
           <div class="process-meta">
-            <h3 class="process-name">{{ process.name || 'Untitled Process' }}</h3>
-            @if (process.description) {
-              <p class="process-description">{{ process.description }}</p>
+            @if (editingProcessMeta()) {
+              <div class="meta-edit-form">
+                <mat-form-field appearance="outline" class="meta-field">
+                  <mat-label>Process Name</mat-label>
+                  <input matInput [value]="processNameEdit()" (input)="processNameEdit.set($any($event.target).value)" />
+                </mat-form-field>
+                <mat-form-field appearance="outline" class="meta-field">
+                  <mat-label>Description</mat-label>
+                  <input matInput [value]="processDescEdit()" (input)="processDescEdit.set($any($event.target).value)" />
+                </mat-form-field>
+                <div class="meta-edit-actions">
+                  <button mat-raised-button color="primary" (click)="saveProcessMeta()">
+                    <mat-icon>check</mat-icon> Save
+                  </button>
+                  <button mat-stroked-button (click)="cancelEditProcessMeta()">Cancel</button>
+                </div>
+              </div>
+            } @else {
+              <div class="meta-display" (click)="startEditProcessMeta()" role="button" tabindex="0" (keydown.enter)="startEditProcessMeta()">
+                <h3 class="process-name">
+                  {{ process.name || 'Untitled Process' }}
+                  <mat-icon class="edit-hint">edit</mat-icon>
+                </h3>
+                @if (process.description) {
+                  <p class="process-description">{{ process.description }}</p>
+                }
+              </div>
+              <mat-chip-set class="process-chips">
+                <mat-chip>
+                  <mat-icon matChipAvatar>play_arrow</mat-icon>
+                  {{ process.trigger.trigger_type }}
+                </mat-chip>
+                <mat-chip>{{ process.steps.length }} step{{ process.steps.length !== 1 ? 's' : '' }}</mat-chip>
+                <mat-chip [class]="'status-' + process.status">{{ process.status }}</mat-chip>
+              </mat-chip-set>
             }
-            <mat-chip-set class="process-chips">
-              <mat-chip>
-                <mat-icon matChipAvatar>play_arrow</mat-icon>
-                {{ process.trigger.trigger_type }}
-              </mat-chip>
-              <mat-chip>{{ process.steps.length }} step{{ process.steps.length !== 1 ? 's' : '' }}</mat-chip>
-              <mat-chip [class]="'status-' + process.status">{{ process.status }}</mat-chip>
-            </mat-chip-set>
+          </div>
+
+          <!-- Toolbar -->
+          <div class="diagram-toolbar">
+            <button mat-stroked-button (click)="addStep('action')" matTooltip="Add a new action step">
+              <mat-icon>add</mat-icon> Add Step
+            </button>
+            <button mat-stroked-button (click)="addStep('decision')" matTooltip="Add a decision point">
+              <mat-icon>call_split</mat-icon> Add Decision
+            </button>
           </div>
 
           @if (flowchartSvg()) {
-            <div class="flowchart-container" [innerHTML]="flowchartSvg()"></div>
+            <div class="flowchart-container" #flowchartContainer [innerHTML]="flowchartSvg()"></div>
+            <p class="flowchart-hint">Click a step to edit it and assign agents</p>
           }
 
           <!-- Step details list -->
           <div class="step-list">
             @for (step of process.steps; track step.step_id) {
-              <div class="step-detail">
+              <div
+                class="step-detail"
+                [class.selected]="selectedStepId() === step.step_id"
+                (click)="onStepClick(step.step_id)"
+                role="button"
+                tabindex="0"
+                (keydown.enter)="onStepClick(step.step_id)"
+              >
                 <div class="step-header">
                   @if (step.step_type === 'decision') {
                     <mat-icon class="step-icon decision">call_split</mat-icon>
@@ -262,6 +309,9 @@
                     <mat-icon class="step-icon action">play_circle</mat-icon>
                   }
                   <span class="step-name">{{ step.name }}</span>
+                  @if (step.agents.length === 0) {
+                    <mat-icon class="no-agent-warning" matTooltip="No agents assigned">warning</mat-icon>
+                  }
                 </div>
                 @if (step.description) {
                   <p class="step-description">{{ step.description }}</p>
@@ -295,10 +345,28 @@
         } @else {
           <div class="empty-process">
             <mat-icon class="empty-icon">account_tree</mat-icon>
-            <p>The process diagram will appear here as you define it through the chat.</p>
+            <p>No process defined yet. Use the chat to describe a process, or create one manually.</p>
+            <button mat-raised-button color="primary" (click)="createNewProcess()" [disabled]="saving()" class="create-process-btn">
+              <mat-icon>add</mat-icon>
+              Create New Process
+            </button>
           </div>
         }
       </mat-card-content>
     </mat-card>
   </div>
+
+  <!-- Step Editor slide-in panel -->
+  @if (selectedStep(); as step) {
+    <div class="step-editor-panel-wrapper">
+      <app-flow-step-editor
+        [step]="step"
+        [process]="currentProcess()!"
+        [allSteps]="currentProcess()!.steps"
+        (stepUpdated)="onStepUpdated($event)"
+        (stepDeleted)="onStepDeleted($event)"
+        (closed)="onStepEditorClosed()"
+      />
+    </div>
+  }
 </div>

--- a/user-interface/src/app/components/process-designer-chat/process-designer-chat.component.scss
+++ b/user-interface/src/app/components/process-designer-chat/process-designer-chat.component.scss
@@ -3,15 +3,30 @@
   grid-template-columns: 1fr minmax(300px, 380px) 1fr;
   gap: 20px;
   min-height: 600px;
+  transition: grid-template-columns 0.3s ease;
+
+  &.editor-open {
+    grid-template-columns: 1fr minmax(260px, 320px) 1fr minmax(320px, 380px);
+  }
 
   @media (max-width: 1280px) {
     grid-template-columns: 1fr 1fr;
     .roster-panel { order: 3; grid-column: 1 / -1; }
+
+    &.editor-open {
+      grid-template-columns: 1fr 1fr;
+      .step-editor-panel-wrapper { order: 4; grid-column: 1 / -1; }
+    }
   }
 
   @media (max-width: 960px) {
     grid-template-columns: 1fr;
     .roster-panel { order: 3; grid-column: auto; }
+
+    &.editor-open {
+      grid-template-columns: 1fr;
+      .step-editor-panel-wrapper { order: 4; grid-column: auto; }
+    }
   }
 }
 
@@ -493,6 +508,9 @@
   overflow-y: auto;
 
   mat-card-header {
+    display: flex;
+    align-items: center;
+
     mat-card-title {
       display: flex;
       align-items: center;
@@ -503,7 +521,15 @@
         color: #3fb950;
       }
     }
+
+    .spacer { flex: 1; }
   }
+}
+
+.saving-badge {
+  font-size: 0.6875rem !important;
+  --mdc-chip-label-text-color: #58a6ff;
+  --mdc-chip-elevated-container-color: rgba(88, 166, 255, 0.1);
 }
 
 .process-meta {
@@ -513,6 +539,33 @@
     margin: 0 0 4px;
     color: #f0f6fc;
     font-size: 1.125rem;
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .edit-hint {
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
+    color: #484f58;
+    opacity: 0;
+    transition: opacity 0.2s;
+  }
+
+  .meta-display {
+    cursor: pointer;
+    padding: 8px;
+    border-radius: 8px;
+    transition: background 0.2s;
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.03);
+
+      .edit-hint {
+        opacity: 1;
+      }
+    }
   }
 
   .process-description {
@@ -531,13 +584,69 @@
   }
 }
 
+.meta-edit-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  .meta-field {
+    width: 100%;
+  }
+
+  .meta-edit-actions {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 12px;
+  }
+}
+
+// Diagram toolbar
+.diagram-toolbar {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+  flex-wrap: wrap;
+
+  button {
+    font-size: 0.8125rem;
+    border-color: rgba(255, 255, 255, 0.15);
+    color: #c9d1d9;
+
+    mat-icon {
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+    }
+
+    &:hover {
+      background: rgba(255, 255, 255, 0.05);
+      border-color: #58a6ff;
+      color: #58a6ff;
+    }
+  }
+}
+
 .flowchart-container {
   background: #0d1117;
   border-radius: 8px;
   padding: 16px;
-  margin-bottom: 16px;
+  margin-bottom: 8px;
   overflow: auto;
   max-height: 400px;
+
+  ::ng-deep .flowchart-node {
+    &:hover {
+      opacity: 0.85;
+    }
+  }
+}
+
+.flowchart-hint {
+  text-align: center;
+  color: #484f58;
+  font-size: 0.6875rem;
+  margin: 0 0 16px;
+  font-style: italic;
 }
 
 .step-list {
@@ -552,6 +661,17 @@
   border: 1px solid rgba(255, 255, 255, 0.06);
   border-radius: 8px;
   padding: 12px 16px;
+  cursor: pointer;
+  transition: border-color 0.2s, background 0.2s;
+
+  &:hover {
+    border-color: rgba(255, 255, 255, 0.14);
+  }
+
+  &.selected {
+    border-color: #58a6ff;
+    background: rgba(88, 166, 255, 0.05);
+  }
 
   .step-header {
     display: flex;
@@ -573,6 +693,14 @@
       color: #f0f6fc;
       font-weight: 500;
       font-size: 0.9375rem;
+      flex: 1;
+    }
+
+    .no-agent-warning {
+      font-size: 16px;
+      width: 16px;
+      height: 16px;
+      color: #d29922;
     }
   }
 
@@ -650,5 +778,37 @@
     color: #8b949e;
     max-width: 280px;
     line-height: 1.5;
+    margin-bottom: 20px;
+  }
+
+  .create-process-btn {
+    mat-icon {
+      margin-right: 4px;
+    }
+  }
+}
+
+// -------------------------------------------------------
+// Step editor panel (4th column)
+// -------------------------------------------------------
+
+.step-editor-panel-wrapper {
+  display: flex;
+  flex-direction: column;
+  max-height: 800px;
+  overflow: hidden;
+  border-radius: 12px;
+  border: 1px solid rgba(88, 166, 255, 0.2);
+  animation: slideIn 0.25s ease-out;
+}
+
+@keyframes slideIn {
+  from {
+    opacity: 0;
+    transform: translateX(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
   }
 }

--- a/user-interface/src/app/components/process-designer-chat/process-designer-chat.component.ts
+++ b/user-interface/src/app/components/process-designer-chat/process-designer-chat.component.ts
@@ -152,10 +152,18 @@ export class ProcessDesignerChatComponent implements OnInit, OnChanges, AfterVie
     this.suggestedQuestions.set(res.suggested_questions);
     this.buildFlowchart(res.current_process);
     this.refreshRoster();
-    // Refresh selected step if editor is open
-    if (this.selectedStepId() && res.current_process) {
-      const step = res.current_process.steps.find((s) => s.step_id === this.selectedStepId());
-      this.selectedStep.set(step ?? null);
+    // Refresh selected step if editor is open; clear if process is gone
+    if (this.selectedStepId()) {
+      if (res.current_process) {
+        const step = res.current_process.steps.find((s) => s.step_id === this.selectedStepId());
+        this.selectedStep.set(step ?? null);
+        if (!step) {
+          this.selectedStepId.set(null);
+        }
+      } else {
+        this.selectedStepId.set(null);
+        this.selectedStep.set(null);
+      }
     }
   }
 

--- a/user-interface/src/app/components/process-designer-chat/process-designer-chat.component.ts
+++ b/user-interface/src/app/components/process-designer-chat/process-designer-chat.component.ts
@@ -20,14 +20,19 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatMenuModule } from '@angular/material/menu';
 import { AgenticTeamApiService } from '../../services/agentic-team-api.service';
+import { FlowStepEditorComponent } from '../flow-step-editor/flow-step-editor.component';
 import type {
   AgenticTeam,
   AgenticTeamAgent,
   AgenticConversationMessage,
   ProcessDefinition,
+  ProcessStep,
   RosterValidationResult,
 } from '../../models';
+
+let _stepCounter = 0;
 
 @Component({
   selector: 'app-process-designer-chat',
@@ -42,6 +47,8 @@ import type {
     MatIconModule,
     MatChipsModule,
     MatTooltipModule,
+    MatMenuModule,
+    FlowStepEditorComponent,
   ],
   templateUrl: './process-designer-chat.component.html',
   styleUrl: './process-designer-chat.component.scss',
@@ -50,6 +57,7 @@ export class ProcessDesignerChatComponent implements OnInit, OnChanges, AfterVie
   @Input() team!: AgenticTeam;
 
   @ViewChild('messagesContainer') messagesContainer!: ElementRef<HTMLDivElement>;
+  @ViewChild('flowchartContainer') flowchartContainer!: ElementRef<HTMLDivElement>;
 
   private readonly api = inject(AgenticTeamApiService);
   private readonly fb = inject(FormBuilder);
@@ -59,8 +67,16 @@ export class ProcessDesignerChatComponent implements OnInit, OnChanges, AfterVie
   currentProcess = signal<ProcessDefinition | null>(null);
   suggestedQuestions = signal<string[]>([]);
   loading = signal(false);
+  saving = signal(false);
   error = signal<string | null>(null);
   flowchartSvg = signal<SafeHtml | null>(null);
+
+  // Interactive diagram state
+  selectedStepId = signal<string | null>(null);
+  selectedStep = signal<ProcessStep | null>(null);
+  editingProcessMeta = signal(false);
+  processNameEdit = signal('');
+  processDescEdit = signal('');
 
   rosterAgents = signal<AgenticTeamAgent[]>([]);
   rosterValidation = signal<RosterValidationResult | null>(null);
@@ -85,6 +101,7 @@ export class ProcessDesignerChatComponent implements OnInit, OnChanges, AfterVie
 
   ngAfterViewChecked(): void {
     this.scrollToBottom();
+    this.attachFlowchartClickHandlers();
   }
 
   private scrollToBottom(): void {
@@ -94,12 +111,28 @@ export class ProcessDesignerChatComponent implements OnInit, OnChanges, AfterVie
     }
   }
 
+  private attachFlowchartClickHandlers(): void {
+    if (!this.flowchartContainer?.nativeElement) return;
+    const nodes = this.flowchartContainer.nativeElement.querySelectorAll('[data-step-id]');
+    nodes.forEach((node: Element) => {
+      if ((node as HTMLElement).dataset['bound']) return;
+      (node as HTMLElement).dataset['bound'] = '1';
+      node.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const stepId = (node as HTMLElement).dataset['stepId'];
+        if (stepId) this.onStepClick(stepId);
+      });
+    });
+  }
+
   private startConversation(): void {
     this.error.set(null);
     this.conversationId = null;
     this.messages.set([]);
     this.currentProcess.set(null);
     this.suggestedQuestions.set([]);
+    this.selectedStepId.set(null);
+    this.selectedStep.set(null);
 
     this.api.createConversation(this.team.team_id).subscribe({
       next: (res) => this.applyState(res),
@@ -119,6 +152,11 @@ export class ProcessDesignerChatComponent implements OnInit, OnChanges, AfterVie
     this.suggestedQuestions.set(res.suggested_questions);
     this.buildFlowchart(res.current_process);
     this.refreshRoster();
+    // Refresh selected step if editor is open
+    if (this.selectedStepId() && res.current_process) {
+      const step = res.current_process.steps.find((s) => s.step_id === this.selectedStepId());
+      this.selectedStep.set(step ?? null);
+    }
   }
 
   refreshRoster(): void {
@@ -193,9 +231,153 @@ export class ProcessDesignerChatComponent implements OnInit, OnChanges, AfterVie
     }
   }
 
+  // ---------------------------------------------------------------------------
+  // Interactive diagram: process CRUD
+  // ---------------------------------------------------------------------------
+
+  createNewProcess(): void {
+    this.saving.set(true);
+    this.api.createProcess(this.team.team_id).subscribe({
+      next: (process) => {
+        this.currentProcess.set(process);
+        this.buildFlowchart(process);
+        this.saving.set(false);
+      },
+      error: (err) => {
+        this.error.set(err?.error?.detail ?? 'Failed to create process');
+        this.saving.set(false);
+      },
+    });
+  }
+
+  addStep(stepType: 'action' | 'decision' = 'action'): void {
+    const process = this.currentProcess();
+    if (!process) return;
+
+    _stepCounter++;
+    const newStep: ProcessStep = {
+      step_id: `step_${Date.now()}_${_stepCounter}`,
+      name: stepType === 'decision' ? 'New Decision' : 'New Step',
+      description: '',
+      step_type: stepType,
+      agents: [],
+      next_steps: [],
+      condition: null,
+    };
+
+    // Wire up: last step → new step
+    const updatedSteps = [...process.steps];
+    if (updatedSteps.length > 0) {
+      const lastStep = { ...updatedSteps[updatedSteps.length - 1] };
+      if (lastStep.next_steps.length === 0) {
+        lastStep.next_steps = [newStep.step_id];
+        updatedSteps[updatedSteps.length - 1] = lastStep;
+      }
+    }
+    updatedSteps.push(newStep);
+
+    const updated = { ...process, steps: updatedSteps };
+    this.currentProcess.set(updated);
+    this.buildFlowchart(updated);
+    this.saveProcess(updated);
+    this.onStepClick(newStep.step_id);
+  }
+
+  onStepClick(stepId: string): void {
+    const process = this.currentProcess();
+    if (!process) return;
+    const step = process.steps.find((s) => s.step_id === stepId);
+    if (!step) return;
+    this.selectedStepId.set(stepId);
+    this.selectedStep.set({ ...step });
+    this.buildFlowchart(process); // re-render to highlight selected
+  }
+
+  onStepUpdated(updatedStep: ProcessStep): void {
+    const process = this.currentProcess();
+    if (!process) return;
+
+    const updatedSteps = process.steps.map((s) =>
+      s.step_id === updatedStep.step_id ? updatedStep : s,
+    );
+    const updated = { ...process, steps: updatedSteps };
+    this.currentProcess.set(updated);
+    this.selectedStep.set({ ...updatedStep });
+    this.buildFlowchart(updated);
+    this.saveProcess(updated);
+  }
+
+  onStepDeleted(stepId: string): void {
+    const process = this.currentProcess();
+    if (!process) return;
+
+    // Remove step and clean up references
+    const updatedSteps = process.steps
+      .filter((s) => s.step_id !== stepId)
+      .map((s) => ({
+        ...s,
+        next_steps: s.next_steps.filter((ns) => ns !== stepId),
+      }));
+    const updated = { ...process, steps: updatedSteps };
+    this.currentProcess.set(updated);
+    this.selectedStepId.set(null);
+    this.selectedStep.set(null);
+    this.buildFlowchart(updated);
+    this.saveProcess(updated);
+  }
+
+  onStepEditorClosed(): void {
+    this.selectedStepId.set(null);
+    this.selectedStep.set(null);
+    this.buildFlowchart(this.currentProcess());
+  }
+
+  startEditProcessMeta(): void {
+    const process = this.currentProcess();
+    if (!process) return;
+    this.processNameEdit.set(process.name);
+    this.processDescEdit.set(process.description);
+    this.editingProcessMeta.set(true);
+  }
+
+  saveProcessMeta(): void {
+    const process = this.currentProcess();
+    if (!process) return;
+    const updated = {
+      ...process,
+      name: this.processNameEdit(),
+      description: this.processDescEdit(),
+    };
+    this.currentProcess.set(updated);
+    this.editingProcessMeta.set(false);
+    this.saveProcess(updated);
+  }
+
+  cancelEditProcessMeta(): void {
+    this.editingProcessMeta.set(false);
+  }
+
+  private saveProcess(process: ProcessDefinition): void {
+    this.saving.set(true);
+    this.api.updateProcess(process.process_id, process).subscribe({
+      next: () => {
+        this.saving.set(false);
+        this.refreshRoster();
+      },
+      error: (err) => {
+        this.error.set(err?.error?.detail ?? 'Failed to save process');
+        this.saving.set(false);
+      },
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Flowchart SVG builder
+  // ---------------------------------------------------------------------------
+
   /**
    * Build a Mermaid-style flowchart as inline SVG from the process definition.
-   * We generate the SVG directly to avoid requiring an external Mermaid runtime.
+   * Nodes are interactive — clicking them opens the step editor.
    */
   private buildFlowchart(process: ProcessDefinition | null): void {
     if (!process || process.steps.length === 0) {
@@ -209,6 +391,7 @@ export class ProcessDesignerChatComponent implements OnInit, OnChanges, AfterVie
     const nodeHeight = 50;
     const padding = 40;
     const svgWidth = nodeWidth + padding * 2;
+    const selectedId = this.selectedStepId();
 
     // Build a map from step_id to index for layout
     const idxMap = new Map<string, number>();
@@ -224,6 +407,13 @@ export class ProcessDesignerChatComponent implements OnInit, OnChanges, AfterVie
       <marker id="arrowhead" markerWidth="10" markerHeight="7" refX="10" refY="3.5" orient="auto">
         <polygon points="0 0, 10 3.5, 0 7" fill="#58a6ff"/>
       </marker>
+      <filter id="glow">
+        <feGaussianBlur stdDeviation="3" result="blur"/>
+        <feMerge>
+          <feMergeNode in="blur"/>
+          <feMergeNode in="SourceGraphic"/>
+        </feMerge>
+      </filter>
     </defs>`;
 
     // Helper: node Y position
@@ -232,7 +422,7 @@ export class ProcessDesignerChatComponent implements OnInit, OnChanges, AfterVie
     // Draw trigger node (rounded rect, green tint)
     const trigY = nodeY(0);
     svg += `<rect x="${cx - nodeWidth / 2}" y="${trigY}" width="${nodeWidth}" height="${nodeHeight}" rx="25" ry="25" fill="#1a3a2a" stroke="#3fb950" stroke-width="1.5"/>`;
-    svg += `<text x="${cx}" y="${trigY + nodeHeight / 2 + 5}" text-anchor="middle" fill="#3fb950" font-size="12" font-family="sans-serif">${this.escSvg(process.trigger.trigger_type.toUpperCase())}: ${this.truncate(process.trigger.description, 20)}</text>`;
+    svg += `<text x="${cx}" y="${trigY + nodeHeight / 2 + 5}" text-anchor="middle" fill="#3fb950" font-size="12" font-family="sans-serif">${this.escSvg(process.trigger.trigger_type.toUpperCase())}: ${this.truncate(process.trigger.description || 'Trigger', 20)}</text>`;
 
     // Arrow from trigger to first step
     if (steps.length > 0) {
@@ -243,6 +433,11 @@ export class ProcessDesignerChatComponent implements OnInit, OnChanges, AfterVie
     steps.forEach((step, i) => {
       const y = nodeY(i + 1);
       const isDecision = step.step_type === 'decision';
+      const isSelected = step.step_id === selectedId;
+      const hasNoAgents = step.agents.length === 0;
+
+      // Clickable group
+      svg += `<g data-step-id="${this.escSvg(step.step_id)}" class="flowchart-node" style="cursor:pointer">`;
 
       if (isDecision) {
         // Diamond shape
@@ -250,10 +445,16 @@ export class ProcessDesignerChatComponent implements OnInit, OnChanges, AfterVie
         const hh = nodeHeight / 2;
         const dmx = cx;
         const dmy = y + hh;
-        svg += `<polygon points="${dmx},${y} ${dmx + hw},${dmy} ${dmx},${y + nodeHeight} ${dmx - hw},${dmy}" fill="#2d1b3d" stroke="#bc8cff" stroke-width="1.5"/>`;
+        const strokeColor = isSelected ? '#f0f6fc' : '#bc8cff';
+        const strokeWidth = isSelected ? '2.5' : '1.5';
+        const filter = isSelected ? ' filter="url(#glow)"' : '';
+        svg += `<polygon points="${dmx},${y} ${dmx + hw},${dmy} ${dmx},${y + nodeHeight} ${dmx - hw},${dmy}" fill="#2d1b3d" stroke="${strokeColor}" stroke-width="${strokeWidth}"${filter}/>`;
         svg += `<text x="${cx}" y="${dmy + 4}" text-anchor="middle" fill="#bc8cff" font-size="11" font-family="sans-serif">${this.escSvg(this.truncate(step.name, 22))}</text>`;
       } else {
-        svg += `<rect x="${cx - nodeWidth / 2}" y="${y}" width="${nodeWidth}" height="${nodeHeight}" rx="8" ry="8" fill="#161b22" stroke="#58a6ff" stroke-width="1.5"/>`;
+        const strokeColor = isSelected ? '#f0f6fc' : '#58a6ff';
+        const strokeWidth = isSelected ? '2.5' : '1.5';
+        const filter = isSelected ? ' filter="url(#glow)"' : '';
+        svg += `<rect x="${cx - nodeWidth / 2}" y="${y}" width="${nodeWidth}" height="${nodeHeight}" rx="8" ry="8" fill="#161b22" stroke="${strokeColor}" stroke-width="${strokeWidth}"${filter}/>`;
         svg += `<text x="${cx}" y="${y + 20}" text-anchor="middle" fill="#f0f6fc" font-size="12" font-family="sans-serif">${this.escSvg(this.truncate(step.name, 22))}</text>`;
 
         // Show agent names below step name
@@ -263,7 +464,15 @@ export class ProcessDesignerChatComponent implements OnInit, OnChanges, AfterVie
         }
       }
 
-      // Arrows to next steps (simplified: straight down to next sequential node)
+      // Warning indicator for steps with no agents
+      if (hasNoAgents) {
+        svg += `<circle cx="${cx + nodeWidth / 2 - 8}" cy="${y + 8}" r="6" fill="#d29922"/>`;
+        svg += `<text x="${cx + nodeWidth / 2 - 8}" y="${y + 12}" text-anchor="middle" fill="#0d1117" font-size="9" font-weight="bold" font-family="sans-serif">!</text>`;
+      }
+
+      svg += `</g>`;
+
+      // Arrows to next steps
       for (const nextId of step.next_steps) {
         const nextIdx = idxMap.get(nextId);
         if (nextIdx !== undefined) {

--- a/user-interface/src/app/components/process-designer-chat/process-designer-chat.component.ts
+++ b/user-interface/src/app/components/process-designer-chat/process-designer-chat.component.ts
@@ -242,6 +242,10 @@ export class ProcessDesignerChatComponent implements OnInit, OnChanges, AfterVie
         this.currentProcess.set(process);
         this.buildFlowchart(process);
         this.saving.set(false);
+        // Link the new process to the active conversation so chat stays in sync
+        if (this.conversationId) {
+          this.api.setConversationProcess(this.conversationId, process.process_id).subscribe();
+        }
       },
       error: (err) => {
         this.error.set(err?.error?.detail ?? 'Failed to create process');

--- a/user-interface/src/app/models/agentic-team.model.ts
+++ b/user-interface/src/app/models/agentic-team.model.ts
@@ -137,6 +137,24 @@ export interface AgenticConversationSummary {
   message_count: number;
 }
 
+/** An agent recommended for a process step. */
+export interface RecommendedAgent {
+  agent_name: string;
+  source: 'registry' | 'roster';
+  role: string;
+  skills: string[];
+  tools: string[];
+  keywords: string[];
+  match_score: number;
+}
+
+/** Response from the recommend-agents endpoint. */
+export interface RecommendAgentsResponse {
+  step_id: string;
+  step_name: string;
+  recommended_agents: RecommendedAgent[];
+}
+
 /** Per-step agent sandbox status (Agent Provisioning team). */
 export interface AgentEnvProvisionSummary {
   stable_key: string;

--- a/user-interface/src/app/services/agentic-team-api.service.ts
+++ b/user-interface/src/app/services/agentic-team-api.service.ts
@@ -81,6 +81,14 @@ export class AgenticTeamApiService {
     return this.http.get<AgenticConversationSummary[]>(`${this.base}/teams/${teamId}/conversations`);
   }
 
+  /** Link a process to a conversation so chat stays in sync with the visual editor. */
+  setConversationProcess(conversationId: string, processId: string): Observable<{ conversation_id: string; process_id: string }> {
+    return this.http.put<{ conversation_id: string; process_id: string }>(
+      `${this.base}/conversations/${conversationId}/process`,
+      { process_id: processId },
+    );
+  }
+
   /** Create a new blank process for a team. */
   createProcess(teamId: string): Observable<ProcessDefinition> {
     return this.http.post<ProcessDefinition>(`${this.base}/teams/${teamId}/processes`, {});

--- a/user-interface/src/app/services/agentic-team-api.service.ts
+++ b/user-interface/src/app/services/agentic-team-api.service.ts
@@ -12,6 +12,7 @@ import type {
   AgenticConversationSummary,
   AgentEnvProvisionSummary,
   ProcessDefinition,
+  RecommendAgentsResponse,
   RosterValidationResult,
 } from '../models';
 
@@ -78,6 +79,24 @@ export class AgenticTeamApiService {
 
   listConversations(teamId: string): Observable<AgenticConversationSummary[]> {
     return this.http.get<AgenticConversationSummary[]>(`${this.base}/teams/${teamId}/conversations`);
+  }
+
+  /** Create a new blank process for a team. */
+  createProcess(teamId: string): Observable<ProcessDefinition> {
+    return this.http.post<ProcessDefinition>(`${this.base}/teams/${teamId}/processes`, {});
+  }
+
+  /** Update a process definition (visual editor saves). */
+  updateProcess(processId: string, process: ProcessDefinition): Observable<ProcessDefinition> {
+    return this.http.put<ProcessDefinition>(`${this.base}/processes/${processId}`, process);
+  }
+
+  /** Get agent recommendations for a specific process step. */
+  recommendAgentsForStep(processId: string, stepId: string): Observable<RecommendAgentsResponse> {
+    return this.http.post<RecommendAgentsResponse>(
+      `${this.base}/processes/${processId}/steps/${stepId}/recommend-agents`,
+      {},
+    );
   }
 
   /** Sandbox provisioning status for each process step agent (Agent Provisioning team). */


### PR DESCRIPTION
Add visual flow diagram creation to the Agentic Team Provisioning page where
users can create/edit process steps, search for agents, and receive agent
recommendations for each step.

Backend:
- Add PUT /processes/{id} for direct process updates from visual editor
- Add POST /teams/{id}/processes for creating blank processes
- Add POST /processes/{id}/steps/{id}/recommend-agents for step-based agent
  recommendations (blends StudioGrid registry + team roster matching)
- Add RecommendedAgent and RecommendAgentsResponse models
- Add get_process_team_id() to store

Frontend:
- New flow-step-editor component with step details form, agent search
  (debounced, via StudioGrid findAgents), recommended agents panel, and
  next-step connection management
- Enhanced process-designer-chat with interactive SVG flowchart (clickable
  nodes with data-step-id), diagram toolbar (Add Step/Decision), inline
  process name/description editing, auto-save on changes, and 4-column
  layout when step editor is open
- Add AgentRecommendation models and service methods (createProcess,
  updateProcess, recommendAgentsForStep)

https://claude.ai/code/session_01HskeYPr8EWULVkazKDQ6Hv