### PR TITLE
feat(slack): add bidirectional Slack app with Events API, slash commands, and multi-team routing

### DIFF
--- a/backend/agents/agent_git_tools/executor.py
+++ b/backend/agents/agent_git_tools/executor.py
@@ -9,12 +9,12 @@ from typing import Any, Callable, Dict
 
 from software_engineering_team.shared.git_utils import (
     DEVELOPMENT_BRANCH,
+    _run_git,
     checkout_branch,
     commit_working_tree,
     create_feature_branch,
     merge_branch,
     write_files_and_commit,
-    _run_git,
 )
 
 from .context import GitToolContext

--- a/backend/agents/agent_llm_tools_service/adapters/base.py
+++ b/backend/agents/agent_llm_tools_service/adapters/base.py
@@ -4,7 +4,12 @@ from __future__ import annotations
 
 from typing import Any, List, Protocol
 
-from agent_llm_tools_service.models import OperationDetail, ToolDetail, ToolDocumentation, ToolSummary
+from agent_llm_tools_service.models import (
+    OperationDetail,
+    ToolDetail,
+    ToolDocumentation,
+    ToolSummary,
+)
 
 
 class LlmToolAdapter(Protocol):

--- a/backend/agents/agent_llm_tools_service/adapters/git_adapter.py
+++ b/backend/agents/agent_llm_tools_service/adapters/git_adapter.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from typing import Any, Dict, List
 
 from agent_git_tools import GIT_TOOL_DEFINITIONS
-
 from agent_llm_tools_service.models import (
     ExecutionHints,
     OperationDetail,

--- a/backend/agents/agent_llm_tools_service/service.py
+++ b/backend/agents/agent_llm_tools_service/service.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 from typing import Dict, List, Optional
 
 from agent_llm_tools_service.adapters.base import LlmToolAdapter
-from agent_llm_tools_service.models import OperationDetail, ToolDetail, ToolDocumentation, ToolSummary
+from agent_llm_tools_service.models import (
+    OperationDetail,
+    ToolDetail,
+    ToolDocumentation,
+    ToolSummary,
+)
 from agent_llm_tools_service.registry import get_default_registry
 
 

--- a/backend/agents/agent_llm_tools_service/tests/test_service.py
+++ b/backend/agents/agent_llm_tools_service/tests/test_service.py
@@ -9,10 +9,10 @@ _agents = Path(__file__).resolve().parent.parent.parent
 if str(_agents) not in sys.path:
     sys.path.insert(0, str(_agents))
 
-import pytest
+import pytest  # noqa: E402
 
-from agent_git_tools import GIT_TOOL_DEFINITIONS
-from agent_llm_tools_service import LlmToolNotFoundError, LlmToolsService
+from agent_git_tools import GIT_TOOL_DEFINITIONS  # noqa: E402
+from agent_llm_tools_service import LlmToolNotFoundError, LlmToolsService  # noqa: E402
 
 
 def test_list_tools_includes_git() -> None:

--- a/backend/agents/llm_service/tests/test_tool_loop.py
+++ b/backend/agents/llm_service/tests/test_tool_loop.py
@@ -8,7 +8,7 @@ import pytest
 
 from llm_service.clients.dummy import DummyLLMClient
 from llm_service.interface import LLMPermanentError
-from llm_service.tool_loop import complete_json_with_tool_loop, _normalize_tool_calls_for_api
+from llm_service.tool_loop import _normalize_tool_calls_for_api, complete_json_with_tool_loop
 
 
 def test_normalize_tool_calls_serializes_dict_arguments() -> None:

--- a/backend/agents/llm_service/tool_loop.py
+++ b/backend/agents/llm_service/tool_loop.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List
 
 from .interface import LLMClient, LLMPermanentError
 

--- a/backend/slack_app_manifest.yml
+++ b/backend/slack_app_manifest.yml
@@ -1,0 +1,100 @@
+# Slack App Manifest for Strands Assistant
+# ==========================================
+#
+# How to use:
+#   1. Go to https://api.slack.com/apps
+#   2. Click "Create New App" → "From a manifest"
+#   3. Select your workspace
+#   4. Choose YAML tab and paste this file's contents
+#   5. Replace {YOUR_DOMAIN} with your actual public domain (e.g. strands.example.com)
+#   6. Click "Create"
+#
+# After creating:
+#   1. Go to "Basic Information" → copy the **Signing Secret**
+#   2. Go to "OAuth & Permissions" → "Install to Workspace" → authorize
+#   3. Copy the **Bot User OAuth Token** (xoxb-...)
+#   4. Save both in Strands:
+#      PUT /api/integrations/slack
+#      {
+#        "enabled": true,
+#        "mode": "bot",
+#        "signing_secret": "<your-signing-secret>",
+#        "client_id": "<your-client-id>",
+#        "client_secret": "<your-client-secret>",
+#        "bot_token": "<xoxb-token>",
+#        "default_channel": "#general"
+#      }
+#
+#   Or use the OAuth flow:
+#      - Save client_id, client_secret, and signing_secret via PUT /api/integrations/slack
+#      - GET /api/integrations/slack/oauth/connect → open returned URL → authorize
+#      - Bot token is stored automatically on callback
+#
+# The app will then respond to:
+#   - DMs (message the bot directly)
+#   - @mentions (mention the bot in any channel it's in)
+#   - /strands slash command (team switching, help, messages)
+
+display_information:
+  name: Strands Assistant
+  description: AI-powered multi-team assistant — chat with any specialist team (SE, blogging, market research, and more)
+  background_color: "#1a1a2e"
+  long_description: |
+    Strands Assistant connects your Slack workspace to the Strands Agents platform,
+    giving you access to 13+ specialist AI team assistants directly from Slack.
+
+    Available teams:
+    • Personal Assistant — email, calendar, tasks, deals, reservations
+    • Software Engineering — full dev team: architecture, planning, coding, review
+    • Blogging — content pipeline: research, plan, draft, edit, quality gates
+    • Market Research — user discovery and product viability
+    • SOC2 Compliance — security audit for code repositories
+    • Social Marketing — cross-platform campaign planning
+    • Road Trip Planning — multi-agent itinerary planner
+    • Accessibility Audit — WCAG 2.2 & Section 508 compliance
+    • Coding Team — Tech Lead + Senior Engineers with task graph
+    • Planning V3 — discovery & requirements → PRD + dev handoff
+    • AI Systems — spec-driven AI agent system factory
+    • Agent Provisioning — set up agent environments
+    • Sales Team — full B2B sales pod
+
+    Switch teams anytime with /strands team <name> or just DM the bot.
+
+features:
+  bot_user:
+    display_name: Strands Assistant
+    always_online: true
+  slash_commands:
+    - command: /strands
+      url: https://{YOUR_DOMAIN}/api/integrations/slack/commands
+      description: Interact with Strands agent teams
+      usage_hint: "[message] or team [name] or help or reset or status"
+      should_escape: false
+
+oauth_config:
+  scopes:
+    bot:
+      - chat:write              # Post messages
+      - chat:write.public       # Post to public channels without joining
+      - channels:read           # List channels
+      - app_mentions:read       # Receive @mention events
+      - im:history              # Read DM history (required for message.im events)
+      - im:read                 # View DM metadata
+      - im:write                # Open DMs with users
+      - commands                # Receive slash commands
+      - users:read              # Look up user info
+  redirect_urls:
+    - https://{YOUR_DOMAIN}/api/integrations/slack/oauth/callback
+
+settings:
+  event_subscriptions:
+    request_url: https://{YOUR_DOMAIN}/api/integrations/slack/events
+    bot_events:
+      - app_mention             # Bot @mentioned in a channel
+      - message.im              # DM sent to the bot
+  interactivity:
+    is_enabled: true
+    request_url: https://{YOUR_DOMAIN}/api/integrations/slack/interactive
+  org_deploy_enabled: false
+  socket_mode_enabled: false
+  token_rotation_enabled: false

--- a/backend/unified_api/integrations_store.py
+++ b/backend/unified_api/integrations_store.py
@@ -174,6 +174,7 @@ def get_slack_config() -> dict[str, Any]:
         # Sensitive: from encrypted DB
         "client_id": get_credential(_SLACK_SERVICE, "client_id"),
         "client_secret": get_credential(_SLACK_SERVICE, "client_secret"),
+        "signing_secret": get_credential(_SLACK_SERVICE, "signing_secret"),
         # Non-sensitive: from JSON
         "webhook_url": str(slack.get("webhook_url", "")).strip(),
         "bot_token": str(slack.get("bot_token", "")).strip(),
@@ -194,6 +195,7 @@ def set_slack_config(
     mode: str = "webhook",
     client_id: str = "",
     client_secret: str = "",
+    signing_secret: str = "",
     bot_token: str = "",
     default_channel: str = "",
     channel_display_name: str = "",
@@ -215,6 +217,8 @@ def set_slack_config(
         set_credential(_SLACK_SERVICE, "client_id", client_id.strip())
     if client_secret.strip():
         set_credential(_SLACK_SERVICE, "client_secret", client_secret.strip())
+    if signing_secret.strip():
+        set_credential(_SLACK_SERVICE, "signing_secret", signing_secret.strip())
 
     with _LOCK:
         data = _read_raw()

--- a/backend/unified_api/routes/integrations.py
+++ b/backend/unified_api/routes/integrations.py
@@ -60,7 +60,9 @@ _SLACK_AUTHORIZE_URL = "https://slack.com/oauth/v2/authorize"
 _SLACK_TOKEN_URL = "https://slack.com/api/oauth.v2.access"
 # Minimum scopes: post messages (chat:write) + post to public channels without
 # needing to join them first (chat:write.public) + list channels (channels:read)
-_SLACK_SCOPES = "chat:write,chat:write.public,channels:read"
+_SLACK_SCOPES = (
+    "chat:write,chat:write.public,channels:read,app_mentions:read,im:history,im:read,im:write,commands,users:read"
+)
 
 _GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth"
 _GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token"
@@ -83,6 +85,10 @@ class SlackConfigUpdate(BaseModel):
     )
     client_id: str = Field("", description="Slack app Client ID (required for OAuth).")
     client_secret: str = Field("", description="Slack app Client Secret (required for OAuth).")
+    signing_secret: str = Field(
+        "",
+        description="Slack app Signing Secret (from Basic Information page — required for receiving events and commands).",
+    )
     webhook_url: str = Field("", description="Slack Incoming Webhook URL (https://hooks.slack.com/...).")
     bot_token: str = Field("", description="Slack bot token (xoxb-...) used with chat.postMessage.")
     default_channel: str = Field("", description="Default target channel for bot mode (e.g. #eng or C123...).")
@@ -97,6 +103,9 @@ class SlackConfigResponse(BaseModel):
     enabled: bool
     mode: Literal["webhook", "bot"] = "webhook"
     client_id_configured: bool = Field(False, description="True if a Slack app Client ID is stored.")
+    signing_secret_configured: bool = Field(
+        False, description="True if signing secret is stored (required for events)."
+    )
     webhook_url: str | None = None
     webhook_configured: bool = Field(description="True if webhook URL is stored.")
     bot_token_configured: bool = Field(False, description="True if a bot token is configured.")
@@ -108,6 +117,9 @@ class SlackConfigResponse(BaseModel):
     oauth_connected: bool = Field(False, description="True when a bot token was obtained via OAuth.")
     team_name: str | None = Field(None, description="Slack workspace name (populated after OAuth).")
     team_id: str | None = Field(None, description="Slack team/workspace ID.")
+    # Event subscription URLs (for display — paste these into Slack app config)
+    events_url: str = Field("", description="URL for Slack Event Subscriptions Request URL.")
+    commands_url: str = Field("", description="URL for Slack Slash Commands Request URL.")
 
 
 class SlackOAuthConnectResponse(BaseModel):
@@ -188,10 +200,15 @@ class GoogleBrowserLoginStatusResponse(BaseModel):
 
 
 def _build_slack_config_response(cfg: dict) -> SlackConfigResponse:
+    base = os.getenv("SLACK_PUBLIC_URL", "").strip() or os.getenv("UI_BASE_URL", "http://localhost:8080").rstrip("/")
+    # If UI_BASE_URL points to frontend (4200), use the API port instead
+    if ":4200" in base:
+        base = base.replace(":4200", ":8080")
     return SlackConfigResponse(
         enabled=cfg["enabled"],
         mode=cfg.get("mode", "webhook"),
         client_id_configured=bool(cfg.get("client_id")),
+        signing_secret_configured=bool(cfg.get("signing_secret")),
         webhook_url=None,  # never expose raw URL
         webhook_configured=bool(cfg.get("webhook_url")),
         bot_token_configured=bool(cfg.get("bot_token")),
@@ -202,6 +219,8 @@ def _build_slack_config_response(cfg: dict) -> SlackConfigResponse:
         oauth_connected=bool(cfg.get("team_id")),
         team_name=cfg.get("team_name") or None,
         team_id=cfg.get("team_id") or None,
+        events_url=f"{base}/api/integrations/slack/events",
+        commands_url=f"{base}/api/integrations/slack/commands",
     )
 
 
@@ -364,6 +383,7 @@ async def update_slack(body: SlackConfigUpdate) -> SlackConfigResponse:
         mode=body.mode,
         client_id=(body.client_id or "").strip(),
         client_secret=(body.client_secret or "").strip(),
+        signing_secret=(body.signing_secret or "").strip(),
         webhook_url=webhook_url,
         bot_token=bot_token,
         default_channel=default_channel,
@@ -500,7 +520,119 @@ async def slack_oauth_disconnect() -> SlackConfigResponse:
 
 
 # ---------------------------------------------------------------------------
-# Shared Google / Gmail credentials for Playwright (any integration using “Sign in with Google”)
+# Slack Events API, Slash Commands, and Interactive Components
+# ---------------------------------------------------------------------------
+
+
+@router.post("/slack/events")
+async def slack_events(request: Request) -> Any:
+    """
+    Receive Slack Events API payloads.
+
+    Handles:
+    - url_verification: echo back the challenge token (required for Slack app setup)
+    - event_callback: app_mention and message.im events → routed to team assistants
+
+    Slack requires a 200 response within 3 seconds, so event processing runs async.
+    All requests are verified using the Slack signing secret (HMAC-SHA256).
+    """
+    from unified_api.slack_events_handler import (
+        dispatch_event,
+        handle_url_verification,
+        verify_slack_request,
+    )
+
+    body = await request.body()
+    timestamp = request.headers.get("X-Slack-Request-Timestamp", "")
+    signature = request.headers.get("X-Slack-Signature", "")
+
+    # Get signing secret
+    cfg = get_slack_config()
+    signing_secret = str(cfg.get("signing_secret") or "").strip()
+
+    # Verify signature (skip only for url_verification if no secret configured yet)
+    if signing_secret:
+        if not verify_slack_request(signing_secret, body, timestamp, signature):
+            raise HTTPException(status_code=401, detail="Invalid Slack signature")
+    else:
+        logger.warning("Slack signing secret not configured — skipping signature verification")
+
+    try:
+        payload = json.loads(body)
+    except (json.JSONDecodeError, ValueError) as e:
+        raise HTTPException(status_code=400, detail=f"Invalid JSON: {e}") from e
+
+    event_type = str(payload.get("type", "")).strip()
+
+    # URL verification challenge (Slack sends this when you set the Request URL)
+    if event_type == "url_verification":
+        return handle_url_verification(payload)
+
+    # Event callback — respond immediately, process async
+    if event_type == "event_callback":
+        dispatch_event(payload)
+        return {"ok": True}
+
+    return {"ok": True}
+
+
+@router.post("/slack/commands")
+async def slack_commands(request: Request) -> Any:
+    """
+    Receive Slack slash command payloads (/strands).
+
+    Returns an immediate acknowledgment, then processes the command in a
+    background thread and posts the result to response_url.
+    """
+    from unified_api.slack_events_handler import (
+        process_slash_command,
+        verify_slack_request,
+    )
+
+    body = await request.body()
+    timestamp = request.headers.get("X-Slack-Request-Timestamp", "")
+    signature = request.headers.get("X-Slack-Signature", "")
+
+    cfg = get_slack_config()
+    signing_secret = str(cfg.get("signing_secret") or "").strip()
+
+    if signing_secret and not verify_slack_request(signing_secret, body, timestamp, signature):
+        raise HTTPException(status_code=401, detail="Invalid Slack signature")
+
+    # Parse form-encoded body
+    form_data: dict[str, str] = {}
+    for pair in body.decode("utf-8").split("&"):
+        if "=" in pair:
+            key, value = pair.split("=", 1)
+            form_data[urllib.parse.unquote_plus(key)] = urllib.parse.unquote_plus(value)
+
+    return process_slash_command(form_data)
+
+
+@router.post("/slack/interactive")
+async def slack_interactive(request: Request) -> Any:
+    """
+    Receive Slack interactive component payloads (button clicks, menus, etc.).
+
+    Placeholder for future interactive component handling.
+    """
+    from unified_api.slack_events_handler import verify_slack_request
+
+    body = await request.body()
+    timestamp = request.headers.get("X-Slack-Request-Timestamp", "")
+    signature = request.headers.get("X-Slack-Signature", "")
+
+    cfg = get_slack_config()
+    signing_secret = str(cfg.get("signing_secret") or "").strip()
+
+    if signing_secret and not verify_slack_request(signing_secret, body, timestamp, signature):
+        raise HTTPException(status_code=401, detail="Invalid Slack signature")
+
+    return {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# Shared Google / Gmail credentials for Playwright (any integration using "Sign in with Google")
 # ---------------------------------------------------------------------------
 
 

--- a/backend/unified_api/slack_events_handler.py
+++ b/backend/unified_api/slack_events_handler.py
@@ -1,0 +1,648 @@
+"""
+Slack Events API handler: receive messages from Slack users and route them
+to the appropriate team assistant, then post the response back to Slack.
+
+Supports:
+- URL verification challenge (required for Slack app setup)
+- app_mention events (bot @mentioned in a channel)
+- message.im events (DMs to the bot)
+- /strands slash command (team switching, help, reset, messages)
+- Signature verification via HMAC-SHA256
+
+All message processing runs in background threads to meet Slack's 3-second
+response deadline.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import threading
+import time
+import urllib.request
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Team registry: maps team_key -> (display_name, prefix, description)
+# Built from unified_api.config at import time.
+# ---------------------------------------------------------------------------
+
+_TEAM_REGISTRY: dict[str, dict[str, str]] = {}
+
+
+def _build_team_registry() -> dict[str, dict[str, str]]:
+    """Populate team registry from config + team_assistant configs."""
+    global _TEAM_REGISTRY
+    if _TEAM_REGISTRY:
+        return _TEAM_REGISTRY
+
+    try:
+        from unified_api.config import TEAM_CONFIGS
+
+        registry: dict[str, dict[str, str]] = {}
+        # Only include teams that have a team_assistant config
+        try:
+            from team_assistant.config import TEAM_ASSISTANT_CONFIGS
+
+            assistant_keys = set(TEAM_ASSISTANT_CONFIGS.keys())
+        except ImportError:
+            assistant_keys = set(TEAM_CONFIGS.keys())
+
+        for key, cfg in TEAM_CONFIGS.items():
+            if key in assistant_keys and cfg.enabled:
+                registry[key] = {
+                    "name": cfg.name,
+                    "prefix": cfg.prefix,
+                    "description": cfg.description,
+                }
+
+        _TEAM_REGISTRY = registry
+    except ImportError:
+        logger.warning("Could not import team configs for Slack registry")
+    return _TEAM_REGISTRY
+
+
+def get_available_teams() -> dict[str, dict[str, str]]:
+    """Return {team_key: {name, prefix, description}} for all teams with assistants."""
+    return _build_team_registry()
+
+
+# ---------------------------------------------------------------------------
+# Signature verification
+# ---------------------------------------------------------------------------
+
+
+def verify_slack_request(
+    signing_secret: str,
+    body: bytes,
+    timestamp: str,
+    signature: str,
+) -> bool:
+    """
+    Verify a Slack request using HMAC-SHA256 signature.
+
+    Args:
+        signing_secret: Slack app signing secret.
+        body: Raw request body bytes.
+        timestamp: Value of X-Slack-Request-Timestamp header.
+        signature: Value of X-Slack-Signature header.
+
+    Returns:
+        True if signature is valid and request is fresh (< 5 minutes old).
+    """
+    # Reject stale requests (replay protection)
+    try:
+        ts = int(timestamp)
+    except (ValueError, TypeError):
+        return False
+    if abs(time.time() - ts) > 300:
+        return False
+
+    try:
+        from slack_sdk.signature import SignatureVerifier
+
+        verifier = SignatureVerifier(signing_secret)
+        return verifier.is_valid(
+            body=body.decode("utf-8"),
+            timestamp=timestamp,
+            signature=signature,
+        )
+    except Exception:
+        logger.exception("Slack signature verification error")
+        return False
+
+
+# ---------------------------------------------------------------------------
+# URL verification
+# ---------------------------------------------------------------------------
+
+
+def handle_url_verification(payload: dict[str, Any]) -> dict[str, str]:
+    """Handle Slack's url_verification challenge. Returns {"challenge": ...}."""
+    return {"challenge": str(payload.get("challenge", ""))}
+
+
+# ---------------------------------------------------------------------------
+# Team switching detection
+# ---------------------------------------------------------------------------
+
+# Pattern: "switch to <team>" or "use <team> team"
+_SWITCH_PATTERNS = [
+    re.compile(r"(?:switch|change|go)\s+to\s+(?:the\s+)?(.+?)(?:\s+team)?$", re.IGNORECASE),
+    re.compile(r"use\s+(?:the\s+)?(.+?)\s+team$", re.IGNORECASE),
+]
+
+
+def _normalize_team_key(raw: str) -> str | None:
+    """Try to match a user-provided team name to a valid team_key."""
+    registry = get_available_teams()
+    raw_lower = raw.strip().lower().replace("-", "_").replace(" ", "_")
+
+    # Exact match on key
+    if raw_lower in registry:
+        return raw_lower
+
+    # Match on display name (case-insensitive)
+    for key, info in registry.items():
+        if info["name"].lower().replace(" ", "_") == raw_lower:
+            return key
+        if info["name"].lower() == raw.strip().lower():
+            return key
+
+    # Partial/fuzzy: check if raw is a substring of key or name
+    for key, info in registry.items():
+        if raw_lower in key or raw_lower in info["name"].lower().replace(" ", "_"):
+            return key
+
+    return None
+
+
+def detect_team_switch(text: str) -> str | None:
+    """
+    If the text is a team-switch command, return the target team_key.
+    Returns None if it's not a switch command.
+    """
+    for pat in _SWITCH_PATTERNS:
+        m = pat.search(text.strip())
+        if m:
+            return _normalize_team_key(m.group(1))
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Message processing (runs in background thread)
+# ---------------------------------------------------------------------------
+
+
+def _strip_bot_mention(text: str, bot_user_id: str) -> str:
+    """Remove <@BOT_ID> mention prefix from message text."""
+    if bot_user_id:
+        text = re.sub(rf"<@{re.escape(bot_user_id)}>\s*", "", text, count=1)
+    return text.strip()
+
+
+def _get_bot_token() -> str:
+    """Get bot token from integrations store."""
+    try:
+        from unified_api.integrations_store import get_slack_config
+
+        cfg = get_slack_config()
+        return str(cfg.get("bot_token") or "").strip()
+    except ImportError:
+        return ""
+
+
+def _get_bot_user_id() -> str:
+    """Get the bot's own Slack user ID from stored config."""
+    try:
+        from unified_api.integrations_store import get_slack_config
+
+        cfg = get_slack_config()
+        return str(cfg.get("bot_user_id") or "").strip()
+    except ImportError:
+        return ""
+
+
+def _call_team_assistant(team_prefix: str, conversation_id: str | None, message: str) -> dict[str, Any] | None:
+    """
+    Call a team assistant's conversation/messages endpoint.
+
+    Uses httpx with ASGI transport to call in-process (no network round-trip).
+    Falls back to localhost HTTP if ASGI transport isn't available.
+    """
+    import httpx
+
+    path = f"{team_prefix}/assistant/conversation/messages"
+    params = {}
+    if conversation_id:
+        params["conversation_id"] = conversation_id
+
+    # Try ASGI in-process transport first
+    try:
+        from httpx import ASGITransport
+
+        from unified_api.main import app
+
+        with httpx.Client(transport=ASGITransport(app=app), base_url="http://internal") as client:
+            resp = client.post(path, params=params, json={"message": message}, timeout=120)
+            if resp.status_code == 200:
+                return resp.json()
+            logger.warning("Team assistant %s returned %s: %s", path, resp.status_code, resp.text[:200])
+            return None
+    except Exception:
+        logger.debug("ASGI transport failed, trying localhost HTTP", exc_info=True)
+
+    # Fallback: HTTP to localhost
+    port = os.getenv("UNIFIED_API_PORT", "8080")
+    try:
+        with httpx.Client(base_url=f"http://127.0.0.1:{port}") as client:
+            resp = client.post(path, params=params, json={"message": message}, timeout=120)
+            if resp.status_code == 200:
+                return resp.json()
+            logger.warning("Team assistant HTTP %s returned %s: %s", path, resp.status_code, resp.text[:200])
+    except Exception:
+        logger.exception("Team assistant HTTP call failed for %s", path)
+    return None
+
+
+def _create_conversation(team_prefix: str) -> str | None:
+    """Create a new conversation for a team assistant. Returns conversation_id or None."""
+    import httpx
+
+    path = f"{team_prefix}/assistant/conversations"
+
+    try:
+        from httpx import ASGITransport
+
+        from unified_api.main import app
+
+        with httpx.Client(transport=ASGITransport(app=app), base_url="http://internal") as client:
+            resp = client.post(path, timeout=30)
+            if resp.status_code == 200:
+                return resp.json().get("conversation_id")
+    except Exception:
+        logger.debug("ASGI create conversation failed, trying HTTP", exc_info=True)
+
+    port = os.getenv("UNIFIED_API_PORT", "8080")
+    try:
+        with httpx.Client(base_url=f"http://127.0.0.1:{port}") as client:
+            resp = client.post(path, timeout=30)
+            if resp.status_code == 200:
+                return resp.json().get("conversation_id")
+    except Exception:
+        logger.exception("Create conversation HTTP call failed for %s", path)
+    return None
+
+
+def _post_slack_message(
+    token: str,
+    channel: str,
+    text: str,
+    blocks: list[dict[str, Any]] | None = None,
+    thread_ts: str | None = None,
+) -> None:
+    """Post a message to Slack using the bot token."""
+    try:
+        from slack_sdk import WebClient
+
+        client = WebClient(token=token)
+        kwargs: dict[str, Any] = {"channel": channel, "text": text}
+        if blocks:
+            kwargs["blocks"] = blocks
+        if thread_ts:
+            kwargs["thread_ts"] = thread_ts
+        response = client.chat_postMessage(**kwargs)
+        if not bool(response.get("ok", False)):
+            logger.warning("Slack post failed: %s", response)
+    except Exception:
+        logger.exception("Failed to post Slack message to %s", channel)
+
+
+def _build_response_blocks(
+    team_name: str,
+    reply_text: str,
+    suggested_questions: list[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Build Block Kit blocks for the assistant response."""
+    blocks: list[dict[str, Any]] = [
+        {
+            "type": "context",
+            "elements": [{"type": "mrkdwn", "text": f"*{team_name}*"}],
+        },
+        {
+            "type": "section",
+            "text": {"type": "mrkdwn", "text": reply_text[:2900]},
+        },
+    ]
+    if suggested_questions:
+        hints = "\n".join(f"• {q}" for q in suggested_questions[:5])
+        blocks.append({"type": "divider"})
+        blocks.append(
+            {
+                "type": "context",
+                "elements": [{"type": "mrkdwn", "text": f"_Suggestions:_\n{hints}"}],
+            }
+        )
+    return blocks
+
+
+def process_slack_message(event: dict[str, Any]) -> None:
+    """
+    Process an incoming Slack message event (app_mention or DM).
+    Runs in a background thread.
+    """
+    from unified_api.slack_user_state import (
+        get_conversation_id,
+        get_user_team,
+        set_conversation_id,
+        set_user_team,
+    )
+
+    slack_user_id = str(event.get("user", "")).strip()
+    if not slack_user_id:
+        return
+
+    raw_text = str(event.get("text", "")).strip()
+    channel = str(event.get("channel", "")).strip()
+    thread_ts = str(event.get("thread_ts") or event.get("ts") or "").strip()
+
+    bot_user_id = _get_bot_user_id()
+    bot_token = _get_bot_token()
+    if not bot_token:
+        logger.warning("No Slack bot token configured; cannot respond to message")
+        return
+
+    text = _strip_bot_mention(raw_text, bot_user_id)
+    if not text:
+        return
+
+    registry = get_available_teams()
+
+    # Check for team-switch command
+    target_team = detect_team_switch(text)
+    if target_team and target_team in registry:
+        set_user_team(slack_user_id, target_team)
+        team_info = registry[target_team]
+        _post_slack_message(
+            bot_token,
+            channel,
+            f"Switched to *{team_info['name']}* team. {team_info['description']}",
+            thread_ts=thread_ts,
+        )
+        return
+
+    # Get current team
+    current_team = get_user_team(slack_user_id)
+    if current_team not in registry:
+        current_team = "personal_assistant"
+        set_user_team(slack_user_id, current_team)
+
+    team_info = registry.get(current_team)
+    if not team_info:
+        _post_slack_message(bot_token, channel, "No team assistant available.", thread_ts=thread_ts)
+        return
+
+    team_prefix = team_info["prefix"]
+    team_name = team_info["name"]
+
+    # Get or create conversation
+    conv_id = get_conversation_id(slack_user_id, current_team)
+    if not conv_id:
+        conv_id = _create_conversation(team_prefix)
+        if conv_id:
+            set_conversation_id(slack_user_id, current_team, conv_id)
+
+    # Call team assistant
+    result = _call_team_assistant(team_prefix, conv_id, text)
+    if not result:
+        _post_slack_message(
+            bot_token,
+            channel,
+            f"Sorry, the {team_name} assistant didn't respond. Please try again.",
+            thread_ts=thread_ts,
+        )
+        return
+
+    # If we got a new conversation_id from the response, store it
+    resp_conv_id = result.get("conversation_id")
+    if resp_conv_id and resp_conv_id != conv_id:
+        set_conversation_id(slack_user_id, current_team, resp_conv_id)
+
+    # Extract the assistant's reply (last assistant message)
+    messages = result.get("messages") or []
+    reply_text = ""
+    for msg in reversed(messages):
+        if msg.get("role") == "assistant":
+            reply_text = msg.get("content", "")
+            break
+
+    if not reply_text:
+        reply_text = "I processed your request but have no text response."
+
+    suggested_questions = result.get("suggested_questions") or []
+    blocks = _build_response_blocks(team_name, reply_text, suggested_questions)
+
+    _post_slack_message(
+        bot_token,
+        channel,
+        reply_text[:3000],
+        blocks=blocks,
+        thread_ts=thread_ts,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Slash command processing
+# ---------------------------------------------------------------------------
+
+
+def _build_team_list_text() -> str:
+    """Build formatted text listing all available teams."""
+    registry = get_available_teams()
+    lines = ["*Available Teams:*\n"]
+    for key, info in sorted(registry.items(), key=lambda x: x[1]["name"]):
+        lines.append(f"• `{key}` — *{info['name']}*: {info['description']}")
+    lines.append("\n_Switch with: `/strands team <name>`_")
+    return "\n".join(lines)
+
+
+def _build_help_text() -> str:
+    """Build help text for the /strands command."""
+    return (
+        "*Strands Assistant — Slash Commands*\n\n"
+        "• `/strands <message>` — Send a message to your current team's assistant\n"
+        "• `/strands team list` — List all available teams\n"
+        "• `/strands team <name>` — Switch to a different team\n"
+        "• `/strands reset` — Start a fresh conversation with current team\n"
+        "• `/strands status` — Show your current team\n"
+        "• `/strands help` — Show this help message\n"
+    )
+
+
+def process_slash_command(form_data: dict[str, str]) -> dict[str, Any]:
+    """
+    Process a /strands slash command.
+
+    Returns an immediate response dict for Slack. For messages that require
+    assistant processing, spawns a background thread and posts the result
+    to response_url.
+    """
+    from unified_api.slack_user_state import (
+        get_conversation_id,
+        get_user_team,
+        reset_conversation,
+        set_conversation_id,
+        set_user_team,
+    )
+
+    text = str(form_data.get("text", "")).strip()
+    slack_user_id = str(form_data.get("user_id", "")).strip()
+    response_url = str(form_data.get("response_url", "")).strip()
+
+    # /strands help
+    if not text or text.lower() == "help":
+        return {"response_type": "ephemeral", "text": _build_help_text()}
+
+    # /strands team list
+    if text.lower() in ("team list", "teams", "team"):
+        return {"response_type": "ephemeral", "text": _build_team_list_text()}
+
+    # /strands team <name>
+    if text.lower().startswith("team "):
+        team_raw = text[5:].strip()
+        if team_raw.lower() == "list":
+            return {"response_type": "ephemeral", "text": _build_team_list_text()}
+        target = _normalize_team_key(team_raw)
+        registry = get_available_teams()
+        if target and target in registry:
+            set_user_team(slack_user_id, target)
+            info = registry[target]
+            return {
+                "response_type": "ephemeral",
+                "text": f"Switched to *{info['name']}* team.\n_{info['description']}_",
+            }
+        return {
+            "response_type": "ephemeral",
+            "text": f"Unknown team: `{team_raw}`. Use `/strands team list` to see available teams.",
+        }
+
+    # /strands reset
+    if text.lower() == "reset":
+        current_team = get_user_team(slack_user_id)
+        reset_conversation(slack_user_id, current_team)
+        registry = get_available_teams()
+        name = registry.get(current_team, {}).get("name", current_team)
+        return {
+            "response_type": "ephemeral",
+            "text": f"Conversation reset for *{name}*. Your next message starts fresh.",
+        }
+
+    # /strands status
+    if text.lower() == "status":
+        current_team = get_user_team(slack_user_id)
+        registry = get_available_teams()
+        info = registry.get(current_team, {})
+        return {
+            "response_type": "ephemeral",
+            "text": f"Current team: *{info.get('name', current_team)}*\n_{info.get('description', '')}_",
+        }
+
+    # /strands <message> — send to current team assistant in background
+    def _process_in_background() -> None:
+        try:
+            registry = get_available_teams()
+            current_team = get_user_team(slack_user_id)
+            if current_team not in registry:
+                current_team = "personal_assistant"
+                set_user_team(slack_user_id, current_team)
+
+            team_info = registry.get(current_team)
+            if not team_info:
+                _post_to_response_url(response_url, "No team assistant available.")
+                return
+
+            team_prefix = team_info["prefix"]
+            team_name = team_info["name"]
+
+            conv_id = get_conversation_id(slack_user_id, current_team)
+            if not conv_id:
+                conv_id = _create_conversation(team_prefix)
+                if conv_id:
+                    set_conversation_id(slack_user_id, current_team, conv_id)
+
+            result = _call_team_assistant(team_prefix, conv_id, text)
+            if not result:
+                _post_to_response_url(response_url, f"The {team_name} assistant didn't respond. Please try again.")
+                return
+
+            resp_conv_id = result.get("conversation_id")
+            if resp_conv_id and resp_conv_id != conv_id:
+                set_conversation_id(slack_user_id, current_team, resp_conv_id)
+
+            messages = result.get("messages") or []
+            reply_text = ""
+            for msg in reversed(messages):
+                if msg.get("role") == "assistant":
+                    reply_text = msg.get("content", "")
+                    break
+
+            if not reply_text:
+                reply_text = "Request processed."
+
+            suggested = result.get("suggested_questions") or []
+            blocks = _build_response_blocks(team_name, reply_text, suggested)
+            _post_to_response_url(response_url, reply_text[:3000], blocks=blocks)
+        except Exception:
+            logger.exception("Slash command background processing failed")
+            _post_to_response_url(response_url, "An error occurred processing your request.")
+
+    if response_url:
+        threading.Thread(target=_process_in_background, daemon=True).start()
+
+    current_team = get_user_team(slack_user_id)
+    registry = get_available_teams()
+    team_name = registry.get(current_team, {}).get("name", current_team)
+    return {"response_type": "ephemeral", "text": f"Processing with *{team_name}*..."}
+
+
+def _post_to_response_url(
+    response_url: str,
+    text: str,
+    blocks: list[dict[str, Any]] | None = None,
+) -> None:
+    """Post a follow-up response to Slack's response_url."""
+    if not response_url:
+        return
+    payload: dict[str, Any] = {"response_type": "ephemeral", "text": text, "replace_original": False}
+    if blocks:
+        payload["blocks"] = blocks
+    try:
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            response_url,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=10) as resp:
+            if resp.status >= 400:
+                logger.warning("Slack response_url returned %s", resp.status)
+    except Exception:
+        logger.exception("Failed to post to Slack response_url")
+
+
+# ---------------------------------------------------------------------------
+# Event dispatch (called from the route handler)
+# ---------------------------------------------------------------------------
+
+
+def dispatch_event(payload: dict[str, Any]) -> None:
+    """
+    Dispatch a Slack event_callback payload. Runs in a background thread.
+
+    Handles:
+    - app_mention: bot was @mentioned in a channel
+    - message (channel_type=im): DM to the bot
+    """
+    event = payload.get("event") or {}
+    event_type = str(event.get("type", "")).strip()
+
+    # Ignore bot's own messages
+    if event.get("bot_id") or event.get("subtype") == "bot_message":
+        return
+
+    # Ignore message_changed, message_deleted, etc.
+    subtype = event.get("subtype")
+    if subtype and subtype != "file_share":
+        return
+
+    if event_type == "app_mention":
+        threading.Thread(target=process_slack_message, args=(event,), daemon=True).start()
+    elif event_type == "message":
+        channel_type = str(event.get("channel_type", "")).strip()
+        if channel_type == "im":
+            threading.Thread(target=process_slack_message, args=(event,), daemon=True).start()

--- a/backend/unified_api/slack_notifier.py
+++ b/backend/unified_api/slack_notifier.py
@@ -171,6 +171,36 @@ def notify_open_questions(
     _run_in_background(_send)
 
 
+def post_threaded_message(
+    token: str,
+    channel: str,
+    thread_ts: str | None,
+    text: str,
+    blocks: list[dict[str, Any]] | None = None,
+) -> None:
+    """Post a message to a specific channel and thread using bot token.
+
+    This is a synchronous helper used by the Slack events handler to respond
+    in the same thread where a message was received.
+    """
+    if not token or not channel:
+        return
+    try:
+        from slack_sdk import WebClient
+
+        client = WebClient(token=token)
+        kwargs: dict[str, Any] = {"channel": channel, "text": text}
+        if blocks:
+            kwargs["blocks"] = blocks
+        if thread_ts:
+            kwargs["thread_ts"] = thread_ts
+        response = client.chat_postMessage(**kwargs)
+        if not bool(response.get("ok", False)):
+            logger.warning("Slack threaded post failed: %s", response)
+    except Exception as e:
+        logger.warning("Slack threaded post failed: %s", e)
+
+
 def notify_pa_response(
     user_id: str,
     user_message: str,

--- a/backend/unified_api/slack_user_state.py
+++ b/backend/unified_api/slack_user_state.py
@@ -1,0 +1,125 @@
+"""
+Per-Slack-user state: current team selection and conversation IDs.
+
+Stored as JSON at {AGENT_CACHE}/slack_user_state.json.
+Thread-safe (same locking pattern as integrations_store.py).
+
+Structure:
+{
+  "U12345": {
+    "current_team": "personal_assistant",
+    "conversations": {
+      "personal_assistant": "conv-uuid-1",
+      "blogging": "conv-uuid-2"
+    }
+  }
+}
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_CACHE_DIR = ".agent_cache"
+_DEFAULT_TEAM = "personal_assistant"
+_LOCK = threading.Lock()
+
+
+def _get_state_path() -> Path:
+    cache_dir = os.getenv("AGENT_CACHE", _DEFAULT_CACHE_DIR)
+    path = Path(cache_dir)
+    path.mkdir(parents=True, exist_ok=True)
+    return path / "slack_user_state.json"
+
+
+def _read_all() -> dict[str, Any]:
+    path = _get_state_path()
+    if not path.exists():
+        return {}
+    try:
+        raw = path.read_text(encoding="utf-8")
+        if not raw.strip():
+            return {}
+        return json.loads(raw)
+    except (json.JSONDecodeError, OSError) as e:
+        logger.warning("Failed to read slack user state %s: %s", path, e)
+        return {}
+
+
+def _write_all(data: dict[str, Any]) -> None:
+    path = _get_state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    try:
+        tmp.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        tmp.replace(path)
+    except OSError as e:
+        logger.warning("Failed to write slack user state %s: %s", path, e)
+        if tmp.exists():
+            with contextlib.suppress(OSError):
+                tmp.unlink()
+
+
+def _get_user(data: dict, slack_user_id: str) -> dict:
+    """Return user entry, creating defaults if missing."""
+    if slack_user_id not in data:
+        data[slack_user_id] = {"current_team": _DEFAULT_TEAM, "conversations": {}}
+    user = data[slack_user_id]
+    if "current_team" not in user:
+        user["current_team"] = _DEFAULT_TEAM
+    if "conversations" not in user:
+        user["conversations"] = {}
+    return user
+
+
+def get_user_team(slack_user_id: str) -> str:
+    """Return the user's currently selected team key."""
+    with _LOCK:
+        data = _read_all()
+    user = data.get(slack_user_id) or {}
+    return str(user.get("current_team", _DEFAULT_TEAM)).strip() or _DEFAULT_TEAM
+
+
+def set_user_team(slack_user_id: str, team_key: str) -> None:
+    """Set the user's currently selected team."""
+    with _LOCK:
+        data = _read_all()
+        user = _get_user(data, slack_user_id)
+        user["current_team"] = team_key
+        _write_all(data)
+
+
+def get_conversation_id(slack_user_id: str, team_key: str) -> str | None:
+    """Return the conversation ID for the (user, team) pair, or None if not started."""
+    with _LOCK:
+        data = _read_all()
+    user = data.get(slack_user_id) or {}
+    convos = user.get("conversations") or {}
+    cid = convos.get(team_key)
+    return str(cid) if cid else None
+
+
+def set_conversation_id(slack_user_id: str, team_key: str, conversation_id: str) -> None:
+    """Store a conversation ID for the (user, team) pair."""
+    with _LOCK:
+        data = _read_all()
+        user = _get_user(data, slack_user_id)
+        user["conversations"][team_key] = conversation_id
+        _write_all(data)
+
+
+def reset_conversation(slack_user_id: str, team_key: str) -> None:
+    """Clear the conversation ID for the (user, team) pair so a fresh one is created next time."""
+    with _LOCK:
+        data = _read_all()
+        user = _get_user(data, slack_user_id)
+        user["conversations"].pop(team_key, None)
+        _write_all(data)

--- a/backend/unified_api/tests/test_slack_events_handler.py
+++ b/backend/unified_api/tests/test_slack_events_handler.py
@@ -1,0 +1,242 @@
+"""Unit tests for Slack events handler."""
+
+import hashlib
+import hmac
+import time
+from unittest.mock import MagicMock, patch
+
+from unified_api import slack_events_handler
+
+# ---------------------------------------------------------------------------
+# Signature verification
+# ---------------------------------------------------------------------------
+
+
+def _make_signature(secret: str, timestamp: str, body: str) -> str:
+    """Build a valid Slack v0 signature for testing."""
+    sig_basestring = f"v0:{timestamp}:{body}"
+    h = hmac.new(secret.encode(), sig_basestring.encode(), hashlib.sha256)
+    return f"v0={h.hexdigest()}"
+
+
+def test_verify_slack_request_valid() -> None:
+    secret = "test_signing_secret_abc"
+    body = '{"type":"url_verification","challenge":"xyz"}'
+    ts = str(int(time.time()))
+    sig = _make_signature(secret, ts, body)
+    assert slack_events_handler.verify_slack_request(secret, body.encode(), ts, sig) is True
+
+
+def test_verify_slack_request_invalid_signature() -> None:
+    secret = "test_signing_secret_abc"
+    body = '{"type":"url_verification","challenge":"xyz"}'
+    ts = str(int(time.time()))
+    assert slack_events_handler.verify_slack_request(secret, body.encode(), ts, "v0=bad_signature") is False
+
+
+def test_verify_slack_request_expired_timestamp() -> None:
+    secret = "test_signing_secret_abc"
+    body = '{"type":"url_verification","challenge":"xyz"}'
+    ts = str(int(time.time()) - 600)  # 10 minutes ago
+    sig = _make_signature(secret, ts, body)
+    assert slack_events_handler.verify_slack_request(secret, body.encode(), ts, sig) is False
+
+
+def test_verify_slack_request_bad_timestamp() -> None:
+    assert slack_events_handler.verify_slack_request("secret", b"body", "not_a_number", "v0=abc") is False
+
+
+# ---------------------------------------------------------------------------
+# URL verification
+# ---------------------------------------------------------------------------
+
+
+def test_handle_url_verification() -> None:
+    result = slack_events_handler.handle_url_verification({"challenge": "test_challenge_123"})
+    assert result == {"challenge": "test_challenge_123"}
+
+
+def test_handle_url_verification_empty() -> None:
+    result = slack_events_handler.handle_url_verification({})
+    assert result == {"challenge": ""}
+
+
+# ---------------------------------------------------------------------------
+# Team switching detection
+# ---------------------------------------------------------------------------
+
+_MOCK_REGISTRY = {
+    "personal_assistant": {"name": "Personal Assistant", "prefix": "/api/personal-assistant", "description": "PA"},
+    "blogging": {"name": "Blogging", "prefix": "/api/blogging", "description": "Blog"},
+    "software_engineering": {
+        "name": "Software Engineering",
+        "prefix": "/api/software-engineering",
+        "description": "SE",
+    },
+    "market_research": {"name": "Market Research", "prefix": "/api/market-research", "description": "MR"},
+    "sales_team": {"name": "AI Sales Team", "prefix": "/api/sales", "description": "Sales"},
+}
+
+
+def test_detect_team_switch_exact_key() -> None:
+    with patch.object(slack_events_handler, "_TEAM_REGISTRY", _MOCK_REGISTRY):
+        assert slack_events_handler.detect_team_switch("switch to blogging") == "blogging"
+
+
+def test_detect_team_switch_display_name() -> None:
+    with patch.object(slack_events_handler, "_TEAM_REGISTRY", _MOCK_REGISTRY):
+        assert slack_events_handler.detect_team_switch("switch to Market Research") == "market_research"
+
+
+def test_detect_team_switch_partial_match() -> None:
+    with patch.object(slack_events_handler, "_TEAM_REGISTRY", _MOCK_REGISTRY):
+        assert slack_events_handler.detect_team_switch("switch to software engineering team") == "software_engineering"
+
+
+def test_detect_team_switch_not_a_switch() -> None:
+    with patch.object(slack_events_handler, "_TEAM_REGISTRY", _MOCK_REGISTRY):
+        assert slack_events_handler.detect_team_switch("help me with my code") is None
+
+
+def test_detect_team_switch_use_pattern() -> None:
+    with patch.object(slack_events_handler, "_TEAM_REGISTRY", _MOCK_REGISTRY):
+        assert slack_events_handler.detect_team_switch("use the blogging team") == "blogging"
+
+
+# ---------------------------------------------------------------------------
+# Bot mention stripping
+# ---------------------------------------------------------------------------
+
+
+def test_strip_bot_mention() -> None:
+    assert slack_events_handler._strip_bot_mention("<@U123BOT> hello world", "U123BOT") == "hello world"
+
+
+def test_strip_bot_mention_no_mention() -> None:
+    assert slack_events_handler._strip_bot_mention("hello world", "U123BOT") == "hello world"
+
+
+def test_strip_bot_mention_empty_bot_id() -> None:
+    assert slack_events_handler._strip_bot_mention("<@UABC> hello", "") == "<@UABC> hello"
+
+
+# ---------------------------------------------------------------------------
+# Event dispatch
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_event_ignores_bot_messages() -> None:
+    payload = {"event": {"type": "message", "bot_id": "B123", "text": "hi"}}
+    with patch("unified_api.slack_events_handler.process_slack_message") as mock:
+        slack_events_handler.dispatch_event(payload)
+    mock.assert_not_called()
+
+
+def test_dispatch_event_ignores_subtypes() -> None:
+    payload = {"event": {"type": "message", "subtype": "message_changed", "text": "hi"}}
+    with patch("unified_api.slack_events_handler.process_slack_message") as mock:
+        slack_events_handler.dispatch_event(payload)
+    mock.assert_not_called()
+
+
+def test_dispatch_event_handles_app_mention() -> None:
+    payload = {"event": {"type": "app_mention", "user": "U001", "text": "<@BOT> hi", "channel": "C001"}}
+    with patch("threading.Thread") as mock_thread:
+        mock_thread.return_value.start = MagicMock()
+        slack_events_handler.dispatch_event(payload)
+    mock_thread.assert_called_once()
+
+
+def test_dispatch_event_handles_dm() -> None:
+    payload = {"event": {"type": "message", "channel_type": "im", "user": "U001", "text": "hello", "channel": "D001"}}
+    with patch("threading.Thread") as mock_thread:
+        mock_thread.return_value.start = MagicMock()
+        slack_events_handler.dispatch_event(payload)
+    mock_thread.assert_called_once()
+
+
+def test_dispatch_event_ignores_channel_messages() -> None:
+    payload = {"event": {"type": "message", "channel_type": "channel", "user": "U001", "text": "hi"}}
+    with patch("threading.Thread") as mock_thread:
+        slack_events_handler.dispatch_event(payload)
+    mock_thread.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Slash command processing
+# ---------------------------------------------------------------------------
+
+
+def test_slash_command_help() -> None:
+    result = slack_events_handler.process_slash_command({"text": "help", "user_id": "U001"})
+    assert result["response_type"] == "ephemeral"
+    assert "Slash Commands" in result["text"]
+
+
+def test_slash_command_empty_shows_help() -> None:
+    result = slack_events_handler.process_slash_command({"text": "", "user_id": "U001"})
+    assert "Slash Commands" in result["text"]
+
+
+def test_slash_command_team_list() -> None:
+    with patch.object(slack_events_handler, "_TEAM_REGISTRY", _MOCK_REGISTRY):
+        result = slack_events_handler.process_slash_command({"text": "team list", "user_id": "U001"})
+    assert result["response_type"] == "ephemeral"
+    assert "Available Teams" in result["text"]
+
+
+def test_slash_command_team_switch() -> None:
+    with (
+        patch.object(slack_events_handler, "_TEAM_REGISTRY", _MOCK_REGISTRY),
+        patch("unified_api.slack_user_state.set_user_team") as mock_set,
+    ):
+        result = slack_events_handler.process_slash_command({"text": "team blogging", "user_id": "U001"})
+    mock_set.assert_called_once_with("U001", "blogging")
+    assert "Blogging" in result["text"]
+
+
+def test_slash_command_team_unknown() -> None:
+    with patch.object(slack_events_handler, "_TEAM_REGISTRY", _MOCK_REGISTRY):
+        result = slack_events_handler.process_slash_command({"text": "team nonexistent", "user_id": "U001"})
+    assert "Unknown team" in result["text"]
+
+
+def test_slash_command_reset() -> None:
+    with (
+        patch("unified_api.slack_user_state.get_user_team", return_value="blogging"),
+        patch("unified_api.slack_user_state.reset_conversation") as mock_reset,
+        patch.object(slack_events_handler, "_TEAM_REGISTRY", _MOCK_REGISTRY),
+    ):
+        result = slack_events_handler.process_slash_command({"text": "reset", "user_id": "U001"})
+    mock_reset.assert_called_once_with("U001", "blogging")
+    assert "reset" in result["text"].lower()
+
+
+def test_slash_command_status() -> None:
+    with (
+        patch("unified_api.slack_user_state.get_user_team", return_value="blogging"),
+        patch.object(slack_events_handler, "_TEAM_REGISTRY", _MOCK_REGISTRY),
+    ):
+        result = slack_events_handler.process_slash_command({"text": "status", "user_id": "U001"})
+    assert "Blogging" in result["text"]
+
+
+# ---------------------------------------------------------------------------
+# Response block building
+# ---------------------------------------------------------------------------
+
+
+def test_build_response_blocks_basic() -> None:
+    blocks = slack_events_handler._build_response_blocks("Test Team", "Hello there")
+    assert len(blocks) == 2
+    assert blocks[0]["type"] == "context"
+    assert "Test Team" in blocks[0]["elements"][0]["text"]
+    assert blocks[1]["type"] == "section"
+    assert "Hello there" in blocks[1]["text"]["text"]
+
+
+def test_build_response_blocks_with_suggestions() -> None:
+    blocks = slack_events_handler._build_response_blocks("Team", "Reply", ["Q1?", "Q2?"])
+    assert len(blocks) == 4  # context, section, divider, context
+    assert blocks[2]["type"] == "divider"
+    assert "Q1?" in blocks[3]["elements"][0]["text"]

--- a/backend/unified_api/tests/test_slack_user_state.py
+++ b/backend/unified_api/tests/test_slack_user_state.py
@@ -1,0 +1,72 @@
+"""Unit tests for Slack user state management."""
+
+import os
+import tempfile
+from unittest.mock import patch
+
+from unified_api import slack_user_state
+
+
+def _with_temp_cache(fn):
+    """Run test with a temporary AGENT_CACHE directory."""
+
+    def wrapper():
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {"AGENT_CACHE": tmpdir}):
+            # Reset internal lock state is fine — threading.Lock is reentrant-safe
+            fn()
+
+    return wrapper
+
+
+@_with_temp_cache
+def test_get_user_team_returns_default() -> None:
+    assert slack_user_state.get_user_team("U999") == "personal_assistant"
+
+
+@_with_temp_cache
+def test_set_and_get_user_team() -> None:
+    slack_user_state.set_user_team("U001", "blogging")
+    assert slack_user_state.get_user_team("U001") == "blogging"
+
+
+@_with_temp_cache
+def test_get_conversation_id_returns_none_initially() -> None:
+    assert slack_user_state.get_conversation_id("U001", "blogging") is None
+
+
+@_with_temp_cache
+def test_set_and_get_conversation_id() -> None:
+    slack_user_state.set_conversation_id("U001", "blogging", "conv-abc")
+    assert slack_user_state.get_conversation_id("U001", "blogging") == "conv-abc"
+
+
+@_with_temp_cache
+def test_reset_conversation_clears_id() -> None:
+    slack_user_state.set_conversation_id("U001", "blogging", "conv-abc")
+    slack_user_state.reset_conversation("U001", "blogging")
+    assert slack_user_state.get_conversation_id("U001", "blogging") is None
+
+
+@_with_temp_cache
+def test_multiple_users_independent() -> None:
+    slack_user_state.set_user_team("U001", "blogging")
+    slack_user_state.set_user_team("U002", "sales_team")
+    assert slack_user_state.get_user_team("U001") == "blogging"
+    assert slack_user_state.get_user_team("U002") == "sales_team"
+
+
+@_with_temp_cache
+def test_multiple_teams_per_user() -> None:
+    slack_user_state.set_conversation_id("U001", "blogging", "conv-1")
+    slack_user_state.set_conversation_id("U001", "sales_team", "conv-2")
+    assert slack_user_state.get_conversation_id("U001", "blogging") == "conv-1"
+    assert slack_user_state.get_conversation_id("U001", "sales_team") == "conv-2"
+
+
+@_with_temp_cache
+def test_reset_only_affects_target_team() -> None:
+    slack_user_state.set_conversation_id("U001", "blogging", "conv-1")
+    slack_user_state.set_conversation_id("U001", "sales_team", "conv-2")
+    slack_user_state.reset_conversation("U001", "blogging")
+    assert slack_user_state.get_conversation_id("U001", "blogging") is None
+    assert slack_user_state.get_conversation_id("U001", "sales_team") == "conv-2"

--- a/user-interface/src/app/components/blogging-dashboard/blogging-dashboard.component.ts
+++ b/user-interface/src/app/components/blogging-dashboard/blogging-dashboard.component.ts
@@ -6,7 +6,7 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { marked } from 'marked';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatCardModule } from '@angular/material/card';
-import { Observable, Subscription, timer } from 'rxjs';
+import { Subscription, timer } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import type { BlogJobStreamEvent } from '../../models';
 import { BloggingApiService } from '../../services/blogging-api.service';


### PR DESCRIPTION
Transform the one-way Slack notification integration into a full Slack App that
users can interact with directly. Adds Events API handler for receiving DMs and
@mentions, /strands slash command for team switching and messaging, signature
verification (HMAC-SHA256), and per-user team/conversation state management.
Users can now chat with any of the 13 team assistants from Slack.

New files:
- slack_events_handler.py: Core event processing, team routing, message handling
- slack_user_state.py: Per-Slack-user state (current team, conversation IDs)
- slack_app_manifest.yml: Complete Slack app manifest for easy setup
- Tests for events handler (28 tests) and user state (8 tests)

Modified:
- routes/integrations.py: Added /slack/events, /slack/commands, /slack/interactive
  endpoints; updated OAuth scopes; added signing_secret to config model
- integrations_store.py: Added signing_secret to encrypted credential storage
- slack_notifier.py: Added post_threaded_message for in-thread responses

https://claude.ai/code/session_01RP9DCVYDkNDP1ssgpKXHM4