### PR TITLE
feat(deepthought): add recursive self-organising multi-agent system

### DIFF
--- a/backend/agents/deepthought/__init__.py
+++ b/backend/agents/deepthought/__init__.py
@@ -1,0 +1,21 @@
+"""Deepthought — recursive self-organizing multi-agent system."""
+
+from deepthought.models import (
+    AgentResult,
+    AgentSpec,
+    DeepthoughtRequest,
+    DeepthoughtResponse,
+    QueryAnalysis,
+    SkillRequirement,
+)
+from deepthought.orchestrator import DeepthoughtOrchestrator
+
+__all__ = [
+    "AgentResult",
+    "AgentSpec",
+    "DeepthoughtOrchestrator",
+    "DeepthoughtRequest",
+    "DeepthoughtResponse",
+    "QueryAnalysis",
+    "SkillRequirement",
+]

--- a/backend/agents/deepthought/__init__.py
+++ b/backend/agents/deepthought/__init__.py
@@ -1,21 +1,33 @@
-"""Deepthought — recursive self-organizing multi-agent system."""
+"""Deepthought — recursive self-organising multi-agent system."""
 
+from deepthought.knowledge_base import SharedKnowledgeBase
 from deepthought.models import (
+    AgentEvent,
+    AgentEventType,
     AgentResult,
     AgentSpec,
+    DecompositionStrategy,
     DeepthoughtRequest,
     DeepthoughtResponse,
+    KnowledgeEntry,
     QueryAnalysis,
     SkillRequirement,
 )
 from deepthought.orchestrator import DeepthoughtOrchestrator
+from deepthought.result_cache import ResultCache
 
 __all__ = [
+    "AgentEvent",
+    "AgentEventType",
     "AgentResult",
     "AgentSpec",
+    "DecompositionStrategy",
     "DeepthoughtOrchestrator",
     "DeepthoughtRequest",
     "DeepthoughtResponse",
+    "KnowledgeEntry",
     "QueryAnalysis",
+    "ResultCache",
+    "SharedKnowledgeBase",
     "SkillRequirement",
 ]

--- a/backend/agents/deepthought/agent.py
+++ b/backend/agents/deepthought/agent.py
@@ -1,7 +1,9 @@
 """DeepthoughtAgent — a single recursive specialist node.
 
 Each instance has a specialist role and focus question.  It can either
-answer directly or spawn child agents in parallel, then synthesise.
+answer directly or spawn child agents in parallel, then deliberate and
+synthesise.  Agents share a knowledge base for deduplication and a result
+cache for cross-conversation reuse.
 """
 
 from __future__ import annotations
@@ -11,15 +13,30 @@ import uuid
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any
 
-from deepthought.models import AgentResult, AgentSpec, QueryAnalysis, SkillRequirement
+from deepthought.knowledge_base import SharedKnowledgeBase
+from deepthought.models import (
+    AgentEvent,
+    AgentEventType,
+    AgentResult,
+    AgentSpec,
+    DecompositionStrategy,
+    KnowledgeEntry,
+    QueryAnalysis,
+    SkillRequirement,
+)
 from deepthought.prompts import (
     ANALYSIS_SYSTEM_PROMPT,
     ANALYSIS_USER_PROMPT,
+    DELIBERATION_SYSTEM_PROMPT,
+    DELIBERATION_USER_PROMPT,
     SPECIALIST_SYSTEM_PROMPT,
+    STRATEGY_INSTRUCTIONS,
     SYNTHESIS_SYSTEM_PROMPT,
     SYNTHESIS_USER_PROMPT,
+    format_conversation_history,
     format_specialist_results,
 )
+from deepthought.result_cache import ResultCache
 
 logger = logging.getLogger(__name__)
 
@@ -28,6 +45,9 @@ MAX_CHILDREN_PER_AGENT = 5
 
 # Global budget — shared across the whole tree via the orchestrator callback.
 DEFAULT_AGENT_BUDGET = 50
+
+# Max chars to include per child answer in synthesis to control token usage.
+MAX_CHARS_PER_CHILD_ANSWER = 3000
 
 
 class DeepthoughtAgent:
@@ -39,61 +59,133 @@ class DeepthoughtAgent:
         spec: AgentSpec,
         llm: Any,
         parent_question: str = "",
+        original_query: str = "",
+        conversation_history: list[dict] | None = None,
+        decomposition_strategy: DecompositionStrategy = DecompositionStrategy.AUTO,
+        knowledge_base: SharedKnowledgeBase | None = None,
+        result_cache: ResultCache | None = None,
         on_agent_spawned: Any | None = None,
+        on_event: Any | None = None,
     ) -> None:
         self.spec = spec
         self.llm = llm
         self.parent_question = parent_question
+        self.original_query = original_query or spec.focus_question
+        self.conversation_history = conversation_history or []
+        self.decomposition_strategy = decomposition_strategy
+        self.knowledge_base = knowledge_base or SharedKnowledgeBase()
+        self.result_cache = result_cache
         # Callback invoked each time a child agent is created; returns False to halt.
         self._on_agent_spawned = on_agent_spawned
+        # Callback for streaming events: on_event(AgentEvent) -> None
+        self._on_event = on_event
 
     # ------------------------------------------------------------------
     # Public
     # ------------------------------------------------------------------
 
     def execute(self, max_depth: int) -> AgentResult:
-        """Run analysis → optional decomposition → synthesis and return a result."""
-        logger.info(
-            "Agent %s (depth=%d) analysing: %s",
-            self.spec.name,
-            self.spec.depth,
-            self.spec.focus_question[:120],
-        )
+        """Run analysis -> optional decomposition -> deliberation -> synthesis."""
+        self._emit(AgentEventType.AGENT_ANALYSING, "Analysing question")
 
-        analysis = self._analyse(max_depth)
+        # Check result cache first
+        if self.result_cache:
+            cached = self.result_cache.get(self.spec.focus_question)
+            if cached is not None:
+                self._emit(AgentEventType.KNOWLEDGE_REUSED, "Serving from cache")
+                cached_copy = cached.model_copy(
+                    update={"agent_id": self.spec.agent_id, "reused_from_cache": True}
+                )
+                return cached_copy
 
-        # Direct answer path
-        if analysis.can_answer_directly or self.spec.depth >= max_depth:
-            answer = analysis.direct_answer or ""
-            if not answer and self.spec.depth >= max_depth:
-                answer = self._force_direct_answer()
+        # Check knowledge base for near-duplicate work
+        similar = self.knowledge_base.find_similar(self.spec.focus_question)
+        if similar and self.spec.depth > 0:
+            best = max(similar, key=lambda e: e.confidence)
+            self._emit(
+                AgentEventType.KNOWLEDGE_REUSED,
+                f"Reusing finding from {best.agent_name}",
+            )
             return AgentResult(
                 agent_id=self.spec.agent_id,
                 agent_name=self.spec.name,
                 depth=self.spec.depth,
                 focus_question=self.spec.focus_question,
+                answer=best.finding,
+                confidence=best.confidence,
+                child_results=[],
+                was_decomposed=False,
+                reused_from_cache=True,
+            )
+
+        analysis = self._analyse(max_depth)
+
+        # Direct answer path
+        if analysis.can_answer_directly or self.spec.depth >= max_depth:
+            self._emit(AgentEventType.AGENT_ANSWERING, "Answering directly")
+            answer = analysis.direct_answer or ""
+            if not answer and self.spec.depth >= max_depth:
+                answer = self._force_direct_answer()
+            confidence = self._compute_structural_confidence(
+                was_decomposed=False,
+                self_assessed=analysis.confidence,
+                child_results=[],
+            )
+            # Store in knowledge base
+            self._store_finding(answer, confidence)
+            result = AgentResult(
+                agent_id=self.spec.agent_id,
+                agent_name=self.spec.name,
+                depth=self.spec.depth,
+                focus_question=self.spec.focus_question,
                 answer=answer,
-                confidence=analysis.confidence,
+                confidence=confidence,
                 child_results=[],
                 was_decomposed=False,
             )
+            self._cache_result(result)
+            self._emit(AgentEventType.AGENT_COMPLETE, "Direct answer complete")
+            return result
 
         # Decomposition path — spawn children in parallel
+        self._emit(
+            AgentEventType.AGENT_DECOMPOSING,
+            f"Spawning {len(analysis.skill_requirements)} specialists",
+        )
         children_specs = self._build_child_specs(analysis.skill_requirements)
         child_results = self._run_children_parallel(children_specs, max_depth)
 
-        synthesised = self._synthesise(child_results)
+        # Deliberation phase — review child results for contradictions/gaps
+        self._emit(AgentEventType.AGENT_DELIBERATING, "Reviewing specialist results")
+        deliberation_notes = self._deliberate(child_results)
 
-        return AgentResult(
+        # Synthesis
+        self._emit(AgentEventType.AGENT_SYNTHESISING, "Synthesising results")
+        synthesised = self._synthesise(child_results, deliberation_notes)
+
+        confidence = self._compute_structural_confidence(
+            was_decomposed=True,
+            self_assessed=0.0,
+            child_results=child_results,
+            deliberation_notes=deliberation_notes,
+        )
+
+        self._store_finding(synthesised, confidence)
+
+        result = AgentResult(
             agent_id=self.spec.agent_id,
             agent_name=self.spec.name,
             depth=self.spec.depth,
             focus_question=self.spec.focus_question,
             answer=synthesised,
-            confidence=self._aggregate_confidence(child_results),
+            confidence=confidence,
             child_results=child_results,
             was_decomposed=True,
+            deliberation_notes=deliberation_notes,
         )
+        self._cache_result(result)
+        self._emit(AgentEventType.AGENT_COMPLETE, "Synthesis complete")
+        return result
 
     # ------------------------------------------------------------------
     # Analysis
@@ -101,10 +193,18 @@ class DeepthoughtAgent:
 
     def _analyse(self, max_depth: int) -> QueryAnalysis:
         """Ask the LLM whether we can answer directly or need sub-agents."""
+        strategy_key = self.decomposition_strategy.value
+        strategy_instruction = STRATEGY_INSTRUCTIONS.get(
+            strategy_key, STRATEGY_INSTRUCTIONS["auto"]
+        )
+
         system = ANALYSIS_SYSTEM_PROMPT.format(
             role_description=self.spec.role_description,
             depth=self.spec.depth,
             max_depth=max_depth,
+            original_query=self.original_query,
+            strategy_instruction=strategy_instruction,
+            knowledge_summary=self.knowledge_base.summary_for_prompt(max_chars=2000),
         )
         context_text = (
             f"Parent question: {self.parent_question}"
@@ -113,6 +213,7 @@ class DeepthoughtAgent:
         )
         user = ANALYSIS_USER_PROMPT.format(
             context=context_text,
+            conversation_context=format_conversation_history(self.conversation_history),
             question=self.spec.focus_question,
         )
 
@@ -158,11 +259,13 @@ class DeepthoughtAgent:
         )
 
     def _force_direct_answer(self) -> str:
-        """Produce a direct answer when we've hit depth limits or fallback."""
+        """Produce a direct answer when depth limit hit or analysis failed."""
         system = SPECIALIST_SYSTEM_PROMPT.format(
             role_description=self.spec.role_description,
             specialist_description=self.spec.role_description,
             parent_question=self.parent_question or self.spec.focus_question,
+            original_query=self.original_query,
+            knowledge_summary=self.knowledge_base.summary_for_prompt(max_chars=1500),
         )
         try:
             return self.llm.complete(
@@ -218,7 +321,13 @@ class DeepthoughtAgent:
                 spec=child_spec,
                 llm=self.llm,
                 parent_question=self.spec.focus_question,
+                original_query=self.original_query,
+                conversation_history=self.conversation_history,
+                decomposition_strategy=self.decomposition_strategy,
+                knowledge_base=self.knowledge_base,
+                result_cache=self.result_cache,
                 on_agent_spawned=self._on_agent_spawned,
+                on_event=self._on_event,
             )
             return child.execute(max_depth)
 
@@ -247,26 +356,55 @@ class DeepthoughtAgent:
         return results
 
     # ------------------------------------------------------------------
+    # Deliberation
+    # ------------------------------------------------------------------
+
+    def _deliberate(self, child_results: list[AgentResult]) -> str:
+        """Review child results for contradictions, gaps, and quality issues."""
+        if len(child_results) < 2:
+            return ""
+
+        system = DELIBERATION_SYSTEM_PROMPT.format(
+            role_description=self.spec.role_description,
+        )
+        specialist_dicts = self._results_to_dicts(child_results)
+        user = DELIBERATION_USER_PROMPT.format(
+            question=self.spec.focus_question,
+            original_query=self.original_query,
+            specialist_results=format_specialist_results(
+                specialist_dicts, max_chars_per_result=MAX_CHARS_PER_CHILD_ANSWER
+            ),
+        )
+
+        try:
+            raw = self.llm.complete(
+                user,
+                temperature=0.2,
+                system_prompt=system,
+                think=True,
+            )
+            return raw
+        except Exception:
+            logger.exception("Deliberation LLM call failed for agent %s", self.spec.name)
+            return ""
+
+    # ------------------------------------------------------------------
     # Synthesis
     # ------------------------------------------------------------------
 
-    def _synthesise(self, child_results: list[AgentResult]) -> str:
+    def _synthesise(self, child_results: list[AgentResult], deliberation_notes: str) -> str:
         """Merge child results into a single coherent answer."""
         system = SYNTHESIS_SYSTEM_PROMPT.format(
             role_description=self.spec.role_description,
+            original_query=self.original_query,
+            deliberation_notes=deliberation_notes or "(No deliberation notes.)",
         )
-        specialist_dicts = [
-            {
-                "agent_name": r.agent_name,
-                "focus_question": r.focus_question,
-                "confidence": r.confidence,
-                "answer": r.answer,
-            }
-            for r in child_results
-        ]
+        specialist_dicts = self._results_to_dicts(child_results)
         user = SYNTHESIS_USER_PROMPT.format(
             question=self.spec.focus_question,
-            specialist_results=format_specialist_results(specialist_dicts),
+            specialist_results=format_specialist_results(
+                specialist_dicts, max_chars_per_result=MAX_CHARS_PER_CHILD_ANSWER
+            ),
         )
 
         try:
@@ -278,14 +416,101 @@ class DeepthoughtAgent:
             )
         except Exception:
             logger.exception("Synthesis LLM call failed for agent %s", self.spec.name)
-            # Fallback: concatenate child answers.
             parts = [f"**{r.agent_name}:** {r.answer}" for r in child_results]
             return "\n\n".join(parts)
 
+    # ------------------------------------------------------------------
+    # Structural confidence
+    # ------------------------------------------------------------------
+
     @staticmethod
-    def _aggregate_confidence(child_results: list[AgentResult]) -> float:
-        """Compute a weighted average confidence from child results."""
+    def _compute_structural_confidence(
+        *,
+        was_decomposed: bool,
+        self_assessed: float,
+        child_results: list[AgentResult],
+        deliberation_notes: str = "",
+    ) -> float:
+        """Derive confidence from structural signals rather than LLM self-assessment.
+
+        Signals used:
+        - Direct answers get a modest base (the LLM self-assessment is just one signal).
+        - Decomposed answers: weighted by child agreement and coverage.
+        - Penalty for contradictions found in deliberation.
+        - Bonus for multiple children agreeing (convergence).
+        """
+        if not was_decomposed:
+            # Blend: 40% structural base + 60% self-assessed (dampened)
+            return round(0.4 + 0.6 * min(self_assessed, 0.95), 3)
+
         if not child_results:
-            return 0.0
-        total = sum(r.confidence for r in child_results)
-        return round(total / len(child_results), 3)
+            return 0.3
+
+        child_confs = [r.confidence for r in child_results]
+        avg_child = sum(child_confs) / len(child_confs)
+        # More children = more perspectives = higher base confidence
+        coverage_bonus = min(len(child_results) * 0.05, 0.2)
+        # Penalty for contradictions mentioned in deliberation
+        contradiction_penalty = 0.0
+        if deliberation_notes:
+            # Count occurrences of "contradict" as a rough proxy
+            contradiction_count = deliberation_notes.lower().count("contradict")
+            contradiction_penalty = min(contradiction_count * 0.05, 0.15)
+        # Penalty for any cached/reused results (lower novelty)
+        reused = sum(1 for r in child_results if r.reused_from_cache)
+        reuse_penalty = min(reused * 0.02, 0.1)
+
+        raw = avg_child + coverage_bonus - contradiction_penalty - reuse_penalty
+        return round(max(0.1, min(raw, 0.95)), 3)
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _store_finding(self, answer: str, confidence: float) -> None:
+        """Write this agent's finding to the shared knowledge base."""
+        # Extract first ~500 chars as the finding summary
+        finding = answer[:500] if len(answer) > 500 else answer
+        tags = [w.lower().strip("?.,!;:") for w in self.spec.name.split("_") if len(w) > 2]
+        self.knowledge_base.add(
+            KnowledgeEntry(
+                agent_id=self.spec.agent_id,
+                agent_name=self.spec.name,
+                focus_question=self.spec.focus_question,
+                finding=finding,
+                confidence=confidence,
+                tags=tags,
+            )
+        )
+
+    def _cache_result(self, result: AgentResult) -> None:
+        """Store result in the cross-conversation cache."""
+        if self.result_cache and not result.reused_from_cache:
+            self.result_cache.put(self.spec.focus_question, result)
+
+    def _emit(self, event_type: AgentEventType, detail: str) -> None:
+        """Emit a streaming event if a listener is registered."""
+        if self._on_event:
+            event = AgentEvent(
+                event_type=event_type,
+                agent_id=self.spec.agent_id,
+                agent_name=self.spec.name,
+                depth=self.spec.depth,
+                detail=detail,
+            )
+            try:
+                self._on_event(event)
+            except Exception:
+                logger.debug("Event emission failed", exc_info=True)
+
+    @staticmethod
+    def _results_to_dicts(child_results: list[AgentResult]) -> list[dict]:
+        return [
+            {
+                "agent_name": r.agent_name,
+                "focus_question": r.focus_question,
+                "confidence": r.confidence,
+                "answer": r.answer,
+            }
+            for r in child_results
+        ]

--- a/backend/agents/deepthought/agent.py
+++ b/backend/agents/deepthought/agent.py
@@ -1,0 +1,291 @@
+"""DeepthoughtAgent — a single recursive specialist node.
+
+Each instance has a specialist role and focus question.  It can either
+answer directly or spawn child agents in parallel, then synthesise.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Any
+
+from deepthought.models import AgentResult, AgentSpec, QueryAnalysis, SkillRequirement
+from deepthought.prompts import (
+    ANALYSIS_SYSTEM_PROMPT,
+    ANALYSIS_USER_PROMPT,
+    SPECIALIST_SYSTEM_PROMPT,
+    SYNTHESIS_SYSTEM_PROMPT,
+    SYNTHESIS_USER_PROMPT,
+    format_specialist_results,
+)
+
+logger = logging.getLogger(__name__)
+
+# Maximum child agents any single node may spawn.
+MAX_CHILDREN_PER_AGENT = 5
+
+# Global budget — shared across the whole tree via the orchestrator callback.
+DEFAULT_AGENT_BUDGET = 50
+
+
+class DeepthoughtAgent:
+    """A single node in the Deepthought recursive agent tree."""
+
+    def __init__(
+        self,
+        *,
+        spec: AgentSpec,
+        llm: Any,
+        parent_question: str = "",
+        on_agent_spawned: Any | None = None,
+    ) -> None:
+        self.spec = spec
+        self.llm = llm
+        self.parent_question = parent_question
+        # Callback invoked each time a child agent is created; returns False to halt.
+        self._on_agent_spawned = on_agent_spawned
+
+    # ------------------------------------------------------------------
+    # Public
+    # ------------------------------------------------------------------
+
+    def execute(self, max_depth: int) -> AgentResult:
+        """Run analysis → optional decomposition → synthesis and return a result."""
+        logger.info(
+            "Agent %s (depth=%d) analysing: %s",
+            self.spec.name,
+            self.spec.depth,
+            self.spec.focus_question[:120],
+        )
+
+        analysis = self._analyse(max_depth)
+
+        # Direct answer path
+        if analysis.can_answer_directly or self.spec.depth >= max_depth:
+            answer = analysis.direct_answer or ""
+            if not answer and self.spec.depth >= max_depth:
+                answer = self._force_direct_answer()
+            return AgentResult(
+                agent_id=self.spec.agent_id,
+                agent_name=self.spec.name,
+                depth=self.spec.depth,
+                focus_question=self.spec.focus_question,
+                answer=answer,
+                confidence=analysis.confidence,
+                child_results=[],
+                was_decomposed=False,
+            )
+
+        # Decomposition path — spawn children in parallel
+        children_specs = self._build_child_specs(analysis.skill_requirements)
+        child_results = self._run_children_parallel(children_specs, max_depth)
+
+        synthesised = self._synthesise(child_results)
+
+        return AgentResult(
+            agent_id=self.spec.agent_id,
+            agent_name=self.spec.name,
+            depth=self.spec.depth,
+            focus_question=self.spec.focus_question,
+            answer=synthesised,
+            confidence=self._aggregate_confidence(child_results),
+            child_results=child_results,
+            was_decomposed=True,
+        )
+
+    # ------------------------------------------------------------------
+    # Analysis
+    # ------------------------------------------------------------------
+
+    def _analyse(self, max_depth: int) -> QueryAnalysis:
+        """Ask the LLM whether we can answer directly or need sub-agents."""
+        system = ANALYSIS_SYSTEM_PROMPT.format(
+            role_description=self.spec.role_description,
+            depth=self.spec.depth,
+            max_depth=max_depth,
+        )
+        context_text = (
+            f"Parent question: {self.parent_question}"
+            if self.parent_question
+            else "Top-level query"
+        )
+        user = ANALYSIS_USER_PROMPT.format(
+            context=context_text,
+            question=self.spec.focus_question,
+        )
+
+        try:
+            data = self.llm.complete_json(
+                user,
+                temperature=0.3,
+                system_prompt=system,
+                think=True,
+            )
+            return self._parse_analysis(data)
+        except Exception:
+            logger.exception("Analysis LLM call failed for agent %s", self.spec.name)
+            return QueryAnalysis(
+                summary=self.spec.focus_question,
+                can_answer_directly=True,
+                direct_answer=self._force_direct_answer(),
+                confidence=0.3,
+                skill_requirements=[],
+            )
+
+    def _parse_analysis(self, data: dict[str, Any]) -> QueryAnalysis:
+        """Parse raw LLM JSON into a QueryAnalysis, with defensive defaults."""
+        skills_raw = data.get("skill_requirements") or []
+        skills = []
+        for s in skills_raw[:MAX_CHILDREN_PER_AGENT]:
+            try:
+                skills.append(SkillRequirement(**s))
+            except Exception:
+                logger.warning("Skipping malformed skill requirement: %s", s)
+
+        can_answer = bool(data.get("can_answer_directly", False))
+        # If the LLM says it can't answer but provides no skills, force direct.
+        if not can_answer and not skills:
+            can_answer = True
+
+        return QueryAnalysis(
+            summary=data.get("summary", self.spec.focus_question),
+            can_answer_directly=can_answer,
+            direct_answer=data.get("direct_answer") if can_answer else None,
+            confidence=float(data.get("confidence", 0.5)) if can_answer else 0.0,
+            skill_requirements=[] if can_answer else skills,
+        )
+
+    def _force_direct_answer(self) -> str:
+        """Produce a direct answer when we've hit depth limits or fallback."""
+        system = SPECIALIST_SYSTEM_PROMPT.format(
+            role_description=self.spec.role_description,
+            specialist_description=self.spec.role_description,
+            parent_question=self.parent_question or self.spec.focus_question,
+        )
+        try:
+            return self.llm.complete(
+                f"Answer this question directly and thoroughly:\n\n{self.spec.focus_question}",
+                temperature=0.5,
+                system_prompt=system,
+                think=True,
+            )
+        except Exception:
+            logger.exception("Force-direct LLM call failed for agent %s", self.spec.name)
+            return f"Unable to provide analysis for: {self.spec.focus_question}"
+
+    # ------------------------------------------------------------------
+    # Child spawning
+    # ------------------------------------------------------------------
+
+    def _build_child_specs(self, skills: list[SkillRequirement]) -> list[AgentSpec]:
+        """Create AgentSpec objects for each required specialist."""
+        specs = []
+        for skill in skills[:MAX_CHILDREN_PER_AGENT]:
+            spec = AgentSpec(
+                agent_id=str(uuid.uuid4()),
+                name=skill.name,
+                role_description=skill.description,
+                focus_question=skill.focus_question,
+                depth=self.spec.depth + 1,
+                parent_id=self.spec.agent_id,
+            )
+            specs.append(spec)
+        return specs
+
+    def _run_children_parallel(self, specs: list[AgentSpec], max_depth: int) -> list[AgentResult]:
+        """Execute child agents in parallel threads."""
+        results: list[AgentResult] = []
+        if not specs:
+            return results
+
+        def _run_child(child_spec: AgentSpec) -> AgentResult:
+            # Notify orchestrator of spawn; it may veto via budget.
+            if self._on_agent_spawned and not self._on_agent_spawned(child_spec):
+                return AgentResult(
+                    agent_id=child_spec.agent_id,
+                    agent_name=child_spec.name,
+                    depth=child_spec.depth,
+                    focus_question=child_spec.focus_question,
+                    answer="Agent budget exceeded — analysis truncated.",
+                    confidence=0.0,
+                    child_results=[],
+                    was_decomposed=False,
+                )
+
+            child = DeepthoughtAgent(
+                spec=child_spec,
+                llm=self.llm,
+                parent_question=self.spec.focus_question,
+                on_agent_spawned=self._on_agent_spawned,
+            )
+            return child.execute(max_depth)
+
+        max_workers = min(len(specs), MAX_CHILDREN_PER_AGENT)
+        with ThreadPoolExecutor(max_workers=max_workers) as pool:
+            futures = {pool.submit(_run_child, s): s for s in specs}
+            for future in as_completed(futures):
+                spec = futures[future]
+                try:
+                    results.append(future.result())
+                except Exception:
+                    logger.exception("Child agent %s failed", spec.name)
+                    results.append(
+                        AgentResult(
+                            agent_id=spec.agent_id,
+                            agent_name=spec.name,
+                            depth=spec.depth,
+                            focus_question=spec.focus_question,
+                            answer=f"Error analysing: {spec.focus_question}",
+                            confidence=0.0,
+                            child_results=[],
+                            was_decomposed=False,
+                        )
+                    )
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Synthesis
+    # ------------------------------------------------------------------
+
+    def _synthesise(self, child_results: list[AgentResult]) -> str:
+        """Merge child results into a single coherent answer."""
+        system = SYNTHESIS_SYSTEM_PROMPT.format(
+            role_description=self.spec.role_description,
+        )
+        specialist_dicts = [
+            {
+                "agent_name": r.agent_name,
+                "focus_question": r.focus_question,
+                "confidence": r.confidence,
+                "answer": r.answer,
+            }
+            for r in child_results
+        ]
+        user = SYNTHESIS_USER_PROMPT.format(
+            question=self.spec.focus_question,
+            specialist_results=format_specialist_results(specialist_dicts),
+        )
+
+        try:
+            return self.llm.complete(
+                user,
+                temperature=0.4,
+                system_prompt=system,
+                think=True,
+            )
+        except Exception:
+            logger.exception("Synthesis LLM call failed for agent %s", self.spec.name)
+            # Fallback: concatenate child answers.
+            parts = [f"**{r.agent_name}:** {r.answer}" for r in child_results]
+            return "\n\n".join(parts)
+
+    @staticmethod
+    def _aggregate_confidence(child_results: list[AgentResult]) -> float:
+        """Compute a weighted average confidence from child results."""
+        if not child_results:
+            return 0.0
+        total = sum(r.confidence for r in child_results)
+        return round(total / len(child_results), 3)

--- a/backend/agents/deepthought/api/main.py
+++ b/backend/agents/deepthought/api/main.py
@@ -1,0 +1,46 @@
+"""FastAPI application for the Deepthought recursive agent system."""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+
+from deepthought.models import DeepthoughtRequest, DeepthoughtResponse
+from deepthought.orchestrator import DeepthoughtOrchestrator
+
+logger = logging.getLogger(__name__)
+
+app = FastAPI(
+    title="Deepthought API",
+    description=(
+        "Recursive self-organising multi-agent system that dynamically creates "
+        "specialist sub-agents to answer complex questions."
+    ),
+    version="1.0.0",
+)
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.get("/health")
+def health() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/deepthought/ask", response_model=DeepthoughtResponse)
+def ask(request: DeepthoughtRequest) -> DeepthoughtResponse:
+    """Submit a question and receive a recursively-decomposed answer.
+
+    The response includes the synthesised answer and the full agent
+    decomposition tree showing which specialists were consulted.
+    """
+    orchestrator = DeepthoughtOrchestrator()
+    return orchestrator.process_message(request)

--- a/backend/agents/deepthought/api/main.py
+++ b/backend/agents/deepthought/api/main.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+import json
 import logging
+import queue
+import threading
+from typing import Generator
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import StreamingResponse
 
-from deepthought.models import DeepthoughtRequest, DeepthoughtResponse
+from deepthought.models import AgentEvent, DeepthoughtRequest, DeepthoughtResponse
 from deepthought.orchestrator import DeepthoughtOrchestrator
 
 logger = logging.getLogger(__name__)
@@ -18,7 +23,7 @@ app = FastAPI(
         "Recursive self-organising multi-agent system that dynamically creates "
         "specialist sub-agents to answer complex questions."
     ),
-    version="1.0.0",
+    version="2.0.0",
 )
 
 app.add_middleware(
@@ -39,8 +44,67 @@ def health() -> dict[str, str]:
 def ask(request: DeepthoughtRequest) -> DeepthoughtResponse:
     """Submit a question and receive a recursively-decomposed answer.
 
-    The response includes the synthesised answer and the full agent
-    decomposition tree showing which specialists were consulted.
+    The response includes the synthesised answer, the full agent
+    decomposition tree, knowledge base entries, and event log.
     """
     orchestrator = DeepthoughtOrchestrator()
     return orchestrator.process_message(request)
+
+
+@app.post("/deepthought/ask/stream")
+def ask_stream(request: DeepthoughtRequest) -> StreamingResponse:
+    """Submit a question and receive SSE events as agents work, then the final result.
+
+    Events are sent as ``text/event-stream`` with types:
+    - ``agent_event``: real-time agent activity (spawn, analyse, synthesise, etc.)
+    - ``result``: the final ``DeepthoughtResponse`` JSON
+    - ``error``: if something goes wrong
+    - ``done``: signals the stream is complete
+    """
+    event_queue: queue.Queue[AgentEvent | None] = queue.Queue()
+    result_holder: list[DeepthoughtResponse | Exception] = []
+
+    def _run() -> None:
+        try:
+            orchestrator = DeepthoughtOrchestrator()
+            # Override the event collector to push to our queue
+            original_collect = orchestrator._collect_event
+
+            def _push_event(event: AgentEvent) -> None:
+                original_collect(event)
+                event_queue.put(event)
+
+            orchestrator._collect_event = _push_event  # type: ignore[assignment]
+            resp = orchestrator.process_message(request)
+            result_holder.append(resp)
+        except Exception as exc:
+            result_holder.append(exc)
+        finally:
+            event_queue.put(None)  # sentinel
+
+    thread = threading.Thread(target=_run, daemon=True)
+    thread.start()
+
+    def _generate() -> Generator[str, None, None]:
+        while True:
+            event = event_queue.get()
+            if event is None:
+                break
+            yield f"event: agent_event\ndata: {event.model_dump_json()}\n\n"
+
+        if result_holder and isinstance(result_holder[0], DeepthoughtResponse):
+            yield f"event: result\ndata: {result_holder[0].model_dump_json()}\n\n"
+        elif result_holder and isinstance(result_holder[0], Exception):
+            error_msg = json.dumps({"error": str(result_holder[0])})
+            yield f"event: error\ndata: {error_msg}\n\n"
+
+        yield "event: done\ndata: {}\n\n"
+
+    return StreamingResponse(
+        _generate(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/backend/agents/deepthought/knowledge_base.py
+++ b/backend/agents/deepthought/knowledge_base.py
@@ -1,0 +1,102 @@
+"""Thread-safe shared knowledge base for cross-agent deduplication and reuse.
+
+Every agent in the recursive tree can write findings and read what siblings/
+cousins have already discovered.  The orchestrator owns the instance and
+passes it down through the tree.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import threading
+
+from deepthought.models import KnowledgeEntry
+
+logger = logging.getLogger(__name__)
+
+# Similarity threshold for fuzzy question matching (0-1).  Two focus
+# questions with a normalised overlap above this are considered duplicates.
+_SIMILARITY_THRESHOLD = 0.70
+
+
+def _normalise(text: str) -> set[str]:
+    """Cheap bag-of-words normalisation for similarity checks."""
+    return {w.lower().strip("?.,!;:") for w in text.split() if len(w) > 2}
+
+
+def _similarity(a: str, b: str) -> float:
+    """Jaccard similarity between two strings."""
+    sa, sb = _normalise(a), _normalise(b)
+    if not sa or not sb:
+        return 0.0
+    return len(sa & sb) / len(sa | sb)
+
+
+class SharedKnowledgeBase:
+    """Centralised, thread-safe store of findings for one Deepthought run."""
+
+    def __init__(self) -> None:
+        self._entries: list[KnowledgeEntry] = []
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Write
+    # ------------------------------------------------------------------
+
+    def add(self, entry: KnowledgeEntry) -> None:
+        """Store a finding.  Thread-safe."""
+        with self._lock:
+            self._entries.append(entry)
+            logger.debug(
+                "Knowledge added by %s: %.80s (tags=%s)",
+                entry.agent_name,
+                entry.finding,
+                entry.tags,
+            )
+
+    # ------------------------------------------------------------------
+    # Read / Query
+    # ------------------------------------------------------------------
+
+    def find_similar(
+        self, question: str, threshold: float = _SIMILARITY_THRESHOLD
+    ) -> list[KnowledgeEntry]:
+        """Return entries whose focus_question is similar to *question*."""
+        with self._lock:
+            return [
+                e for e in self._entries if _similarity(e.focus_question, question) >= threshold
+            ]
+
+    def find_by_tags(self, tags: list[str]) -> list[KnowledgeEntry]:
+        """Return entries sharing at least one tag."""
+        tag_set = set(tags)
+        with self._lock:
+            return [e for e in self._entries if tag_set & set(e.tags)]
+
+    def all_entries(self) -> list[KnowledgeEntry]:
+        """Return a snapshot of all entries."""
+        with self._lock:
+            return list(self._entries)
+
+    def summary_for_prompt(self, max_chars: int = 4000) -> str:
+        """Render a concise text summary of all findings for prompt injection."""
+        with self._lock:
+            if not self._entries:
+                return "(No prior findings.)"
+            parts: list[str] = []
+            total = 0
+            for e in self._entries:
+                line = f"- [{e.agent_name}] {e.finding[:200]}"
+                if total + len(line) > max_chars:
+                    parts.append(
+                        f"... and {len(self._entries) - len(parts)} more entries (truncated)"
+                    )
+                    break
+                parts.append(line)
+                total += len(line)
+            return "\n".join(parts)
+
+    def cache_key(self, question: str) -> str:
+        """Deterministic hash for a focus question (for result caching)."""
+        return hashlib.sha256(question.strip().lower().encode()).hexdigest()[:16]

--- a/backend/agents/deepthought/models.py
+++ b/backend/agents/deepthought/models.py
@@ -2,9 +2,75 @@
 
 from __future__ import annotations
 
+from enum import Enum
 from typing import Any
 
 from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Decomposition strategies
+# ---------------------------------------------------------------------------
+
+
+class DecompositionStrategy(str, Enum):
+    """How to break a question into sub-agent tasks."""
+
+    AUTO = "auto"
+    BY_DISCIPLINE = "by_discipline"  # factual: decompose by knowledge domain
+    BY_CONCERN = "by_concern"  # design: decompose by feasibility, cost, risk, etc.
+    BY_OPTION = "by_option"  # comparison: decompose by each option to evaluate
+    BY_PERSPECTIVE = "by_perspective"  # opinion/policy: decompose by stakeholder viewpoint
+    NONE = "none"  # force direct answer, no decomposition
+
+
+# ---------------------------------------------------------------------------
+# Streaming events
+# ---------------------------------------------------------------------------
+
+
+class AgentEventType(str, Enum):
+    """Types of events emitted during recursive execution."""
+
+    AGENT_SPAWNED = "agent_spawned"
+    AGENT_ANALYSING = "agent_analysing"
+    AGENT_ANSWERING = "agent_answering"
+    AGENT_DECOMPOSING = "agent_decomposing"
+    AGENT_DELIBERATING = "agent_deliberating"
+    AGENT_SYNTHESISING = "agent_synthesising"
+    AGENT_COMPLETE = "agent_complete"
+    BUDGET_WARNING = "budget_warning"
+    KNOWLEDGE_REUSED = "knowledge_reused"
+
+
+class AgentEvent(BaseModel):
+    """A single event emitted during agent execution, for SSE streaming."""
+
+    event_type: AgentEventType
+    agent_id: str
+    agent_name: str
+    depth: int
+    detail: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Shared knowledge base
+# ---------------------------------------------------------------------------
+
+
+class KnowledgeEntry(BaseModel):
+    """A single finding stored in the shared knowledge base."""
+
+    agent_id: str
+    agent_name: str
+    focus_question: str
+    finding: str
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    tags: list[str] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Core agent models
+# ---------------------------------------------------------------------------
 
 
 class SkillRequirement(BaseModel):
@@ -61,10 +127,21 @@ class AgentResult(BaseModel):
         default_factory=list, description="Results from sub-agents"
     )
     was_decomposed: bool = Field(default=False, description="Whether this agent spawned children")
+    deliberation_notes: str | None = Field(
+        None, description="Notes from the deliberation phase (contradiction resolution, follow-ups)"
+    )
+    reused_from_cache: bool = Field(
+        default=False, description="True if this result was served from the knowledge cache"
+    )
 
 
 # Allow recursive reference resolution
 AgentResult.model_rebuild()
+
+
+# ---------------------------------------------------------------------------
+# Request / Response
+# ---------------------------------------------------------------------------
 
 
 class DeepthoughtRequest(BaseModel):
@@ -76,6 +153,10 @@ class DeepthoughtRequest(BaseModel):
         default_factory=list,
         description="Prior conversation turns as [{role, content}, ...]",
     )
+    decomposition_strategy: DecompositionStrategy = Field(
+        default=DecompositionStrategy.AUTO,
+        description="Strategy for decomposing the question into sub-agents",
+    )
 
 
 class DeepthoughtResponse(BaseModel):
@@ -85,3 +166,9 @@ class DeepthoughtResponse(BaseModel):
     agent_tree: AgentResult = Field(..., description="Full tree of agent decomposition")
     total_agents_spawned: int = Field(default=0, description="Number of agents created")
     max_depth_reached: int = Field(default=0, description="Deepest recursion level used")
+    knowledge_entries: list[KnowledgeEntry] = Field(
+        default_factory=list, description="All findings stored in the shared knowledge base"
+    )
+    events: list[AgentEvent] = Field(
+        default_factory=list, description="Chronological log of agent activity events"
+    )

--- a/backend/agents/deepthought/models.py
+++ b/backend/agents/deepthought/models.py
@@ -1,0 +1,87 @@
+"""Pydantic models for the Deepthought recursive agent system."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class SkillRequirement(BaseModel):
+    """A specialist skill/knowledge area identified during query analysis."""
+
+    name: str = Field(..., description="Short identifier, e.g. 'quantum_physics_expert'")
+    description: str = Field(..., description="What this specialist knows or does")
+    focus_question: str = Field(
+        ..., description="The specific sub-question for this specialist to answer"
+    )
+    reasoning: str = Field(..., description="Why this specialist is needed for the query")
+
+
+class QueryAnalysis(BaseModel):
+    """Result of analysing a user query or sub-query."""
+
+    summary: str = Field(..., description="Concise restatement of the question")
+    can_answer_directly: bool = Field(
+        ..., description="True when the agent can answer without spawning sub-agents"
+    )
+    direct_answer: str | None = Field(
+        None, description="The answer text when can_answer_directly is True"
+    )
+    confidence: float = Field(
+        default=0.0, ge=0.0, le=1.0, description="Confidence in the direct answer (0-1)"
+    )
+    skill_requirements: list[SkillRequirement] = Field(
+        default_factory=list,
+        description="Specialist skills needed if the agent cannot answer directly (max 5)",
+    )
+
+
+class AgentSpec(BaseModel):
+    """Specification for a dynamically created sub-agent."""
+
+    agent_id: str = Field(..., description="Unique identifier (UUID)")
+    name: str = Field(..., description="Human-readable specialist name")
+    role_description: str = Field(..., description="What this agent specialises in")
+    focus_question: str = Field(..., description="The question this agent must answer")
+    depth: int = Field(..., ge=0, description="Current recursion depth")
+    parent_id: str | None = Field(None, description="Parent agent ID (None for root)")
+
+
+class AgentResult(BaseModel):
+    """Result from a single agent's work, forming a recursive tree."""
+
+    agent_id: str
+    agent_name: str
+    depth: int
+    focus_question: str
+    answer: str = Field(..., description="This agent's synthesised answer")
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    child_results: list[AgentResult] = Field(
+        default_factory=list, description="Results from sub-agents"
+    )
+    was_decomposed: bool = Field(default=False, description="Whether this agent spawned children")
+
+
+# Allow recursive reference resolution
+AgentResult.model_rebuild()
+
+
+class DeepthoughtRequest(BaseModel):
+    """Top-level request to the Deepthought system."""
+
+    message: str = Field(..., min_length=1, description="The user's question or message")
+    max_depth: int = Field(default=10, ge=1, le=10, description="Maximum recursion depth (1-10)")
+    conversation_history: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="Prior conversation turns as [{role, content}, ...]",
+    )
+
+
+class DeepthoughtResponse(BaseModel):
+    """Top-level response from the Deepthought system."""
+
+    answer: str = Field(..., description="Final synthesised answer")
+    agent_tree: AgentResult = Field(..., description="Full tree of agent decomposition")
+    total_agents_spawned: int = Field(default=0, description="Number of agents created")
+    max_depth_reached: int = Field(default=0, description="Deepest recursion level used")

--- a/backend/agents/deepthought/orchestrator.py
+++ b/backend/agents/deepthought/orchestrator.py
@@ -1,0 +1,126 @@
+"""DeepthoughtOrchestrator — manages the recursive agent tree."""
+
+from __future__ import annotations
+
+import logging
+import threading
+import uuid
+from typing import Any
+
+from deepthought.agent import DEFAULT_AGENT_BUDGET, DeepthoughtAgent
+from deepthought.models import AgentResult, AgentSpec, DeepthoughtRequest, DeepthoughtResponse
+
+logger = logging.getLogger(__name__)
+
+
+class DeepthoughtOrchestrator:
+    """Top-level controller that creates the root agent and tracks metrics."""
+
+    def __init__(self, *, llm: Any = None, agent_budget: int = DEFAULT_AGENT_BUDGET) -> None:
+        if llm is not None:
+            self._llm = llm
+        else:
+            from llm_service import get_client
+
+            self._llm = get_client("deepthought")
+
+        self._agent_budget = agent_budget
+        self._agents_spawned = 0
+        self._max_depth_reached = 0
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Public
+    # ------------------------------------------------------------------
+
+    def process_message(self, request: DeepthoughtRequest) -> DeepthoughtResponse:
+        """Run the full recursive analysis for a user message."""
+        self._agents_spawned = 0
+        self._max_depth_reached = 0
+
+        root_spec = AgentSpec(
+            agent_id=str(uuid.uuid4()),
+            name="general_analyst",
+            role_description=(
+                "General analyst who assesses complex questions and identifies "
+                "what specialist knowledge is needed to provide a comprehensive answer"
+            ),
+            focus_question=request.message,
+            depth=0,
+            parent_id=None,
+        )
+
+        # Count root as first agent
+        self._register_spawn(root_spec)
+
+        root_agent = DeepthoughtAgent(
+            spec=root_spec,
+            llm=self._llm,
+            parent_question="",
+            on_agent_spawned=self._register_spawn,
+        )
+
+        result = root_agent.execute(max_depth=request.max_depth)
+
+        answer = self._format_answer(result)
+
+        return DeepthoughtResponse(
+            answer=answer,
+            agent_tree=result,
+            total_agents_spawned=self._agents_spawned,
+            max_depth_reached=self._max_depth_reached,
+        )
+
+    # ------------------------------------------------------------------
+    # Budget tracking (thread-safe)
+    # ------------------------------------------------------------------
+
+    def _register_spawn(self, spec: AgentSpec) -> bool:
+        """Track a newly spawned agent.  Returns False to veto if budget exhausted."""
+        with self._lock:
+            if self._agents_spawned >= self._agent_budget:
+                logger.warning(
+                    "Agent budget (%d) exhausted — vetoing agent %s at depth %d",
+                    self._agent_budget,
+                    spec.name,
+                    spec.depth,
+                )
+                return False
+            self._agents_spawned += 1
+            if spec.depth > self._max_depth_reached:
+                self._max_depth_reached = spec.depth
+            logger.info(
+                "Agent spawned: %s (depth=%d, total=%d/%d)",
+                spec.name,
+                spec.depth,
+                self._agents_spawned,
+                self._agent_budget,
+            )
+            return True
+
+    # ------------------------------------------------------------------
+    # Formatting
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _format_answer(result: AgentResult) -> str:
+        """Append a 'Specialists consulted' footer to the answer when decomposition occurred."""
+        if not result.was_decomposed:
+            return result.answer
+
+        specialists = _collect_specialists(result)
+        if not specialists:
+            return result.answer
+
+        footer_lines = [f"- **{name}**: {focus}" for name, focus in specialists]
+        footer = "\n\n---\n**Specialists consulted:**\n" + "\n".join(footer_lines)
+        return result.answer + footer
+
+
+def _collect_specialists(result: AgentResult) -> list[tuple[str, str]]:
+    """Recursively collect (name, focus_question) for all child agents."""
+    specialists: list[tuple[str, str]] = []
+    for child in result.child_results:
+        specialists.append((child.agent_name, child.focus_question))
+        specialists.extend(_collect_specialists(child))
+    return specialists

--- a/backend/agents/deepthought/orchestrator.py
+++ b/backend/agents/deepthought/orchestrator.py
@@ -2,21 +2,42 @@
 
 from __future__ import annotations
 
+import json
 import logging
 import threading
 import uuid
 from typing import Any
 
 from deepthought.agent import DEFAULT_AGENT_BUDGET, DeepthoughtAgent
-from deepthought.models import AgentResult, AgentSpec, DeepthoughtRequest, DeepthoughtResponse
+from deepthought.knowledge_base import SharedKnowledgeBase
+from deepthought.models import (
+    AgentEvent,
+    AgentEventType,
+    AgentResult,
+    AgentSpec,
+    DecompositionStrategy,
+    DeepthoughtRequest,
+    DeepthoughtResponse,
+)
+from deepthought.prompts import CLASSIFY_QUESTION_SYSTEM_PROMPT
+from deepthought.result_cache import ResultCache
 
 logger = logging.getLogger(__name__)
+
+# Module-level result cache shared across requests (survives request lifecycle).
+_global_result_cache = ResultCache()
 
 
 class DeepthoughtOrchestrator:
     """Top-level controller that creates the root agent and tracks metrics."""
 
-    def __init__(self, *, llm: Any = None, agent_budget: int = DEFAULT_AGENT_BUDGET) -> None:
+    def __init__(
+        self,
+        *,
+        llm: Any = None,
+        agent_budget: int = DEFAULT_AGENT_BUDGET,
+        result_cache: ResultCache | None = None,
+    ) -> None:
         if llm is not None:
             self._llm = llm
         else:
@@ -25,8 +46,10 @@ class DeepthoughtOrchestrator:
             self._llm = get_client("deepthought")
 
         self._agent_budget = agent_budget
+        self._result_cache = result_cache if result_cache is not None else _global_result_cache
         self._agents_spawned = 0
         self._max_depth_reached = 0
+        self._events: list[AgentEvent] = []
         self._lock = threading.Lock()
 
     # ------------------------------------------------------------------
@@ -37,6 +60,13 @@ class DeepthoughtOrchestrator:
         """Run the full recursive analysis for a user message."""
         self._agents_spawned = 0
         self._max_depth_reached = 0
+        self._events = []
+
+        # Classify question to determine decomposition strategy
+        strategy = self._resolve_strategy(request)
+
+        # Fresh knowledge base per request
+        knowledge_base = SharedKnowledgeBase()
 
         root_spec = AgentSpec(
             agent_id=str(uuid.uuid4()),
@@ -57,7 +87,13 @@ class DeepthoughtOrchestrator:
             spec=root_spec,
             llm=self._llm,
             parent_question="",
+            original_query=request.message,
+            conversation_history=request.conversation_history,
+            decomposition_strategy=strategy,
+            knowledge_base=knowledge_base,
+            result_cache=self._result_cache,
             on_agent_spawned=self._register_spawn,
+            on_event=self._collect_event,
         )
 
         result = root_agent.execute(max_depth=request.max_depth)
@@ -69,7 +105,39 @@ class DeepthoughtOrchestrator:
             agent_tree=result,
             total_agents_spawned=self._agents_spawned,
             max_depth_reached=self._max_depth_reached,
+            knowledge_entries=knowledge_base.all_entries(),
+            events=list(self._events),
         )
+
+    # ------------------------------------------------------------------
+    # Strategy classification
+    # ------------------------------------------------------------------
+
+    def _resolve_strategy(self, request: DeepthoughtRequest) -> DecompositionStrategy:
+        """Determine decomposition strategy — use explicit if provided, else auto-classify."""
+        if request.decomposition_strategy != DecompositionStrategy.AUTO:
+            return request.decomposition_strategy
+
+        try:
+            raw = self._llm.complete(
+                f"Classify this question:\n\n{request.message}",
+                temperature=0.1,
+                system_prompt=CLASSIFY_QUESTION_SYSTEM_PROMPT,
+                think=False,
+            )
+            # Parse JSON from response
+            cleaned = raw.strip().strip("`").strip()
+            if cleaned.startswith("json"):
+                cleaned = cleaned[4:].strip()
+            data = json.loads(cleaned)
+            strategy_str = data.get("strategy", "auto")
+            try:
+                return DecompositionStrategy(strategy_str)
+            except ValueError:
+                return DecompositionStrategy.AUTO
+        except Exception:
+            logger.debug("Strategy classification failed, using AUTO", exc_info=True)
+            return DecompositionStrategy.AUTO
 
     # ------------------------------------------------------------------
     # Budget tracking (thread-safe)
@@ -85,6 +153,15 @@ class DeepthoughtOrchestrator:
                     spec.name,
                     spec.depth,
                 )
+                self._events.append(
+                    AgentEvent(
+                        event_type=AgentEventType.BUDGET_WARNING,
+                        agent_id=spec.agent_id,
+                        agent_name=spec.name,
+                        depth=spec.depth,
+                        detail=f"Budget exhausted ({self._agent_budget}), agent vetoed",
+                    )
+                )
                 return False
             self._agents_spawned += 1
             if spec.depth > self._max_depth_reached:
@@ -97,6 +174,11 @@ class DeepthoughtOrchestrator:
                 self._agent_budget,
             )
             return True
+
+    def _collect_event(self, event: AgentEvent) -> None:
+        """Thread-safe event collection for streaming."""
+        with self._lock:
+            self._events.append(event)
 
     # ------------------------------------------------------------------
     # Formatting

--- a/backend/agents/deepthought/prompts.py
+++ b/backend/agents/deepthought/prompts.py
@@ -1,6 +1,27 @@
 """LLM prompt templates for the Deepthought recursive agent system."""
 
 # ---------------------------------------------------------------------------
+# Question-type classification (drives decomposition strategy)
+# ---------------------------------------------------------------------------
+
+CLASSIFY_QUESTION_SYSTEM_PROMPT = """\
+You classify questions into one of these categories to determine
+the best decomposition strategy.  Respond with ONLY a JSON object.
+
+Categories:
+- "by_discipline": Factual or analytical questions best split by knowledge domain
+  (e.g. physics, economics, biology).
+- "by_concern": Design or decision questions best split by concern
+  (feasibility, cost, risk, timeline, ethics).
+- "by_option": Comparison questions best split by evaluating each option separately.
+- "by_perspective": Opinion, policy, or societal questions best split by
+  stakeholder viewpoint (industry, government, public, academic).
+- "none": Simple, narrow questions that need no decomposition at all.
+
+Respond: {{"strategy": "<category>", "reasoning": "<one sentence>"}}\
+"""
+
+# ---------------------------------------------------------------------------
 # Analysis prompt — decides whether to answer directly or decompose
 # ---------------------------------------------------------------------------
 
@@ -9,23 +30,36 @@ You are a Deepthought analysis engine. Your role: "{role_description}"
 
 You are at recursion depth {depth} of a maximum {max_depth}.
 
+## Original user question (top-level)
+{original_query}
+
+## Decomposition strategy
+{strategy_instruction}
+
 Given a question, you must decide:
 1. Can you answer it directly with high confidence given your specialist role?
 2. Or does it require decomposition into sub-questions handled by different specialists?
 
 Rules:
-- If the question is narrow, well-defined, or you can provide a confident expert answer, answer directly.
-- If the question is broad, multi-faceted, or requires expertise you lack, identify 1-5 specialist sub-agents.
+- If the question is narrow, well-defined, or you can provide a confident expert answer, \
+answer directly.
+- If the question is broad, multi-faceted, or requires expertise you lack, identify 1-5 \
+specialist sub-agents.
 - At depth {depth}/{max_depth}, prefer answering directly if at all possible.
 - Never create more than 5 sub-agents.
 - Each sub-agent should have a distinct, non-overlapping focus.
 - Sub-agent focus questions must be specific and self-contained.
+- IMPORTANT: Check the prior findings below — if a specialist has already covered a topic, \
+do NOT create a duplicate sub-agent for it. Reference the existing finding instead.
+
+## Prior findings from other agents
+{knowledge_summary}
 
 Respond with ONLY a JSON object (no markdown fencing) matching this schema:
 {{
   "summary": "<concise restatement of the question>",
   "can_answer_directly": true/false,
-  "direct_answer": "<your answer if can_answer_directly is true, else null>",
+  "direct_answer": "<your THOROUGH answer if can_answer_directly is true, else null>",
   "confidence": <0.0-1.0>,
   "skill_requirements": [
     {{
@@ -45,9 +79,40 @@ ANALYSIS_USER_PROMPT = """\
 ## Context
 {context}
 
+## Conversation History
+{conversation_context}
+
 ## Question
 {question}\
 """
+
+# ---------------------------------------------------------------------------
+# Decomposition strategy instructions (injected into analysis prompt)
+# ---------------------------------------------------------------------------
+
+STRATEGY_INSTRUCTIONS = {
+    "auto": "Use your best judgment to decide how to decompose this question.",
+    "by_discipline": (
+        "Decompose by KNOWLEDGE DOMAIN. Each sub-agent should represent a different "
+        "academic or professional discipline (e.g. physics, economics, biology, engineering)."
+    ),
+    "by_concern": (
+        "Decompose by CONCERN. Each sub-agent should evaluate a different dimension "
+        "of the problem (e.g. feasibility, cost, risk, timeline, ethics, user impact)."
+    ),
+    "by_option": (
+        "Decompose by OPTION. Each sub-agent should evaluate one specific alternative "
+        "or approach, then the synthesis will compare them."
+    ),
+    "by_perspective": (
+        "Decompose by STAKEHOLDER PERSPECTIVE. Each sub-agent should represent a different "
+        "viewpoint (e.g. industry, government, public, academic, affected communities)."
+    ),
+    "none": (
+        "Do NOT decompose. Answer this question directly regardless of complexity. "
+        "Set can_answer_directly to true."
+    ),
+}
 
 # ---------------------------------------------------------------------------
 # Specialist system prompt — gives each sub-agent its identity
@@ -60,10 +125,53 @@ Your role: {role_description}
 Your expertise: {specialist_description}
 
 You have been created to provide expert analysis on a specific aspect of a larger question.
+The original user question was: "{original_query}"
 The parent question was: "{parent_question}"
 
+## Prior findings from other agents
+{knowledge_summary}
+
 Provide thorough, accurate, and well-reasoned analysis within your area of expertise.
-If you encounter aspects outside your expertise, acknowledge them honestly rather than guessing.\
+If you encounter aspects outside your expertise, acknowledge them honestly rather than guessing.
+Build on prior findings where relevant rather than repeating what others have already established.\
+"""
+
+# ---------------------------------------------------------------------------
+# Deliberation prompt — reviews child results before synthesis
+# ---------------------------------------------------------------------------
+
+DELIBERATION_SYSTEM_PROMPT = """\
+You are a Deepthought deliberation engine. Your role: "{role_description}"
+
+You have collected analyses from specialist sub-agents. Before synthesising them,
+you must review the results for quality and coherence.
+
+Analyse the specialist results and produce a JSON object:
+{{
+  "contradictions": [
+    {{"between": ["agent_a", "agent_b"], "issue": "<what they disagree on>", \
+"resolution": "<your assessment of which is more likely correct and why>"}}
+  ],
+  "gaps": ["<important aspect not covered by any specialist>"],
+  "agreements": ["<key point where multiple specialists converge>"],
+  "quality_flags": [
+    {{"agent": "<name>", "issue": "<low confidence / vague / off-topic>"}}
+  ],
+  "synthesis_guidance": "<brief instruction for how to best synthesise these results>"
+}}\
+"""
+
+DELIBERATION_USER_PROMPT = """\
+## Original Question
+{question}
+
+## Original User Query
+{original_query}
+
+## Specialist Results
+{specialist_results}
+
+Review these results for contradictions, gaps, agreements, and quality issues.\
 """
 
 # ---------------------------------------------------------------------------
@@ -76,11 +184,16 @@ You are a Deepthought synthesis engine. Your role: "{role_description}"
 You have delegated parts of a question to specialist sub-agents. Each has provided their analysis.
 Your job is to synthesise their results into a single, coherent, comprehensive answer.
 
+The original user question was: "{original_query}"
+
+## Deliberation Notes
+{deliberation_notes}
+
 Guidelines:
 - Integrate all specialist perspectives into a unified response.
 - Where specialists agree, present the consensus confidently.
-- Where specialists disagree, acknowledge the tension and present both views fairly.
-- Fill any gaps between specialist answers with your own reasoning.
+- Where specialists disagree, use the deliberation notes to resolve the tension.
+- Address any gaps identified in deliberation with your own reasoning.
 - The final answer should read as a single, well-structured response — not a list of agent outputs.
 - Be thorough but concise. Avoid redundancy.\
 """
@@ -96,7 +209,7 @@ Synthesise the above specialist analyses into a single comprehensive answer to t
 """
 
 # ---------------------------------------------------------------------------
-# Conversation-level prompt — wraps Deepthought in a conversational frame
+# Conversation-level prompt
 # ---------------------------------------------------------------------------
 
 CONVERSATION_SYSTEM_PROMPT = """\
@@ -111,14 +224,37 @@ When responding to users:
 """
 
 
-def format_specialist_results(results: list[dict]) -> str:
-    """Format child agent results for the synthesis prompt."""
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def format_specialist_results(results: list[dict], max_chars_per_result: int = 3000) -> str:
+    """Format child agent results for the synthesis prompt, with truncation."""
     parts = []
     for i, r in enumerate(results, 1):
+        answer = r["answer"]
+        if len(answer) > max_chars_per_result:
+            answer = answer[:max_chars_per_result] + "\n\n[... truncated for length]"
         parts.append(
             f"### Specialist {i}: {r['agent_name']}\n"
             f"**Focus:** {r['focus_question']}\n"
             f"**Confidence:** {r['confidence']:.0%}\n\n"
-            f"{r['answer']}"
+            f"{answer}"
         )
     return "\n\n---\n\n".join(parts)
+
+
+def format_conversation_history(history: list[dict], max_turns: int = 10) -> str:
+    """Format conversation history for prompt injection."""
+    if not history:
+        return "(New conversation)"
+    recent = history[-max_turns:]
+    lines = []
+    for turn in recent:
+        role = turn.get("role", "user").capitalize()
+        content = turn.get("content", "")
+        if len(content) > 500:
+            content = content[:500] + "..."
+        lines.append(f"{role}: {content}")
+    return "\n".join(lines)

--- a/backend/agents/deepthought/prompts.py
+++ b/backend/agents/deepthought/prompts.py
@@ -1,0 +1,124 @@
+"""LLM prompt templates for the Deepthought recursive agent system."""
+
+# ---------------------------------------------------------------------------
+# Analysis prompt — decides whether to answer directly or decompose
+# ---------------------------------------------------------------------------
+
+ANALYSIS_SYSTEM_PROMPT = """\
+You are a Deepthought analysis engine. Your role: "{role_description}"
+
+You are at recursion depth {depth} of a maximum {max_depth}.
+
+Given a question, you must decide:
+1. Can you answer it directly with high confidence given your specialist role?
+2. Or does it require decomposition into sub-questions handled by different specialists?
+
+Rules:
+- If the question is narrow, well-defined, or you can provide a confident expert answer, answer directly.
+- If the question is broad, multi-faceted, or requires expertise you lack, identify 1-5 specialist sub-agents.
+- At depth {depth}/{max_depth}, prefer answering directly if at all possible.
+- Never create more than 5 sub-agents.
+- Each sub-agent should have a distinct, non-overlapping focus.
+- Sub-agent focus questions must be specific and self-contained.
+
+Respond with ONLY a JSON object (no markdown fencing) matching this schema:
+{{
+  "summary": "<concise restatement of the question>",
+  "can_answer_directly": true/false,
+  "direct_answer": "<your answer if can_answer_directly is true, else null>",
+  "confidence": <0.0-1.0>,
+  "skill_requirements": [
+    {{
+      "name": "<short_snake_case_identifier>",
+      "description": "<what this specialist knows/does>",
+      "focus_question": "<specific question for this specialist>",
+      "reasoning": "<why this specialist is needed>"
+    }}
+  ]
+}}
+
+If can_answer_directly is true, skill_requirements must be an empty list.
+If can_answer_directly is false, direct_answer must be null and confidence should be 0.0.\
+"""
+
+ANALYSIS_USER_PROMPT = """\
+## Context
+{context}
+
+## Question
+{question}\
+"""
+
+# ---------------------------------------------------------------------------
+# Specialist system prompt — gives each sub-agent its identity
+# ---------------------------------------------------------------------------
+
+SPECIALIST_SYSTEM_PROMPT = """\
+You are a specialist agent in the Deepthought recursive analysis system.
+
+Your role: {role_description}
+Your expertise: {specialist_description}
+
+You have been created to provide expert analysis on a specific aspect of a larger question.
+The parent question was: "{parent_question}"
+
+Provide thorough, accurate, and well-reasoned analysis within your area of expertise.
+If you encounter aspects outside your expertise, acknowledge them honestly rather than guessing.\
+"""
+
+# ---------------------------------------------------------------------------
+# Synthesis prompt — merges child agent results into a coherent answer
+# ---------------------------------------------------------------------------
+
+SYNTHESIS_SYSTEM_PROMPT = """\
+You are a Deepthought synthesis engine. Your role: "{role_description}"
+
+You have delegated parts of a question to specialist sub-agents. Each has provided their analysis.
+Your job is to synthesise their results into a single, coherent, comprehensive answer.
+
+Guidelines:
+- Integrate all specialist perspectives into a unified response.
+- Where specialists agree, present the consensus confidently.
+- Where specialists disagree, acknowledge the tension and present both views fairly.
+- Fill any gaps between specialist answers with your own reasoning.
+- The final answer should read as a single, well-structured response — not a list of agent outputs.
+- Be thorough but concise. Avoid redundancy.\
+"""
+
+SYNTHESIS_USER_PROMPT = """\
+## Original Question
+{question}
+
+## Specialist Results
+{specialist_results}
+
+Synthesise the above specialist analyses into a single comprehensive answer to the original question.\
+"""
+
+# ---------------------------------------------------------------------------
+# Conversation-level prompt — wraps Deepthought in a conversational frame
+# ---------------------------------------------------------------------------
+
+CONVERSATION_SYSTEM_PROMPT = """\
+You are Deepthought, a recursive multi-agent analysis system. You help users by breaking down \
+complex questions into specialist perspectives and synthesising comprehensive answers.
+
+When responding to users:
+- Be conversational and clear.
+- Reference the specialist analysis that informed your answer when relevant.
+- If the question is simple, answer directly without unnecessary complexity.
+- For follow-up questions, build on prior conversation context.\
+"""
+
+
+def format_specialist_results(results: list[dict]) -> str:
+    """Format child agent results for the synthesis prompt."""
+    parts = []
+    for i, r in enumerate(results, 1):
+        parts.append(
+            f"### Specialist {i}: {r['agent_name']}\n"
+            f"**Focus:** {r['focus_question']}\n"
+            f"**Confidence:** {r['confidence']:.0%}\n\n"
+            f"{r['answer']}"
+        )
+    return "\n\n---\n\n".join(parts)

--- a/backend/agents/deepthought/result_cache.py
+++ b/backend/agents/deepthought/result_cache.py
@@ -1,0 +1,77 @@
+"""Simple in-memory result cache for Deepthought agent results.
+
+Caches agent results keyed by a normalised hash of the focus question so
+that identical or near-identical sub-questions across conversations (or
+within the same tree) can be served from cache instead of re-running.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import threading
+import time
+
+from deepthought.models import AgentResult
+
+logger = logging.getLogger(__name__)
+
+# Default TTL: 30 minutes.
+DEFAULT_TTL_SECONDS = 1800
+
+
+class _CacheEntry:
+    __slots__ = ("result", "expires_at")
+
+    def __init__(self, result: AgentResult, ttl: float) -> None:
+        self.result = result
+        self.expires_at = time.monotonic() + ttl
+
+
+class ResultCache:
+    """Thread-safe LRU-ish cache mapping question hashes to AgentResults."""
+
+    def __init__(self, max_size: int = 256, ttl: float = DEFAULT_TTL_SECONDS) -> None:
+        self._store: dict[str, _CacheEntry] = {}
+        self._lock = threading.Lock()
+        self._max_size = max_size
+        self._ttl = ttl
+
+    @staticmethod
+    def _key(question: str) -> str:
+        return hashlib.sha256(question.strip().lower().encode()).hexdigest()[:24]
+
+    def get(self, question: str) -> AgentResult | None:
+        """Return cached result if present and not expired, else None."""
+        key = self._key(question)
+        with self._lock:
+            entry = self._store.get(key)
+            if entry is None:
+                return None
+            if time.monotonic() > entry.expires_at:
+                del self._store[key]
+                return None
+            logger.info("Cache hit for question: %.80s", question)
+            return entry.result
+
+    def put(self, question: str, result: AgentResult) -> None:
+        """Store a result.  Evicts oldest entries if at capacity."""
+        key = self._key(question)
+        with self._lock:
+            if len(self._store) >= self._max_size:
+                self._evict_expired_or_oldest()
+            self._store[key] = _CacheEntry(result, self._ttl)
+
+    def _evict_expired_or_oldest(self) -> None:
+        """Remove expired entries; if still at capacity, drop the oldest."""
+        now = time.monotonic()
+        expired = [k for k, v in self._store.items() if now > v.expires_at]
+        for k in expired:
+            del self._store[k]
+        if len(self._store) >= self._max_size:
+            oldest_key = min(self._store, key=lambda k: self._store[k].expires_at)
+            del self._store[oldest_key]
+
+    def clear(self) -> None:
+        with self._lock:
+            self._store.clear()

--- a/backend/agents/deepthought/tests/test_agent.py
+++ b/backend/agents/deepthought/tests/test_agent.py
@@ -1,0 +1,267 @@
+"""Tests for DeepthoughtAgent — recursive specialist node."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from deepthought.agent import MAX_CHILDREN_PER_AGENT, DeepthoughtAgent
+from deepthought.models import AgentSpec
+
+
+@pytest.fixture()
+def root_spec():
+    return AgentSpec(
+        agent_id="root-1",
+        name="general_analyst",
+        role_description="General analyst",
+        focus_question="What is the meaning of life?",
+        depth=0,
+        parent_id=None,
+    )
+
+
+@pytest.fixture()
+def mock_llm():
+    return MagicMock()
+
+
+def _make_agent(spec, llm, on_spawned=None):
+    return DeepthoughtAgent(spec=spec, llm=llm, on_agent_spawned=on_spawned)
+
+
+# ------------------------------------------------------------------
+# Direct answer path
+# ------------------------------------------------------------------
+
+
+def test_direct_answer(root_spec, mock_llm):
+    """When the LLM says can_answer_directly=True, no children are spawned."""
+    mock_llm.complete_json.return_value = {
+        "summary": "Meaning of life",
+        "can_answer_directly": True,
+        "direct_answer": "42",
+        "confidence": 0.95,
+        "skill_requirements": [],
+    }
+
+    agent = _make_agent(root_spec, mock_llm)
+    result = agent.execute(max_depth=10)
+
+    assert not result.was_decomposed
+    assert result.answer == "42"
+    assert result.confidence == 0.95
+    assert result.child_results == []
+    mock_llm.complete_json.assert_called_once()
+
+
+# ------------------------------------------------------------------
+# Depth limit enforcement
+# ------------------------------------------------------------------
+
+
+def test_depth_limit_forces_direct(mock_llm):
+    """At max depth, agent must answer directly even if analysis wants to decompose."""
+    spec = AgentSpec(
+        agent_id="deep-1",
+        name="deep_agent",
+        role_description="Deep specialist",
+        focus_question="Sub-question?",
+        depth=5,
+        parent_id="parent-1",
+    )
+    # LLM analysis says decompose, but depth is at max
+    mock_llm.complete_json.return_value = {
+        "summary": "Sub-question",
+        "can_answer_directly": False,
+        "direct_answer": None,
+        "confidence": 0.0,
+        "skill_requirements": [
+            {
+                "name": "sub_expert",
+                "description": "Sub-expert",
+                "focus_question": "More detail?",
+                "reasoning": "needed",
+            }
+        ],
+    }
+    mock_llm.complete.return_value = "Forced direct answer"
+
+    agent = _make_agent(spec, mock_llm)
+    result = agent.execute(max_depth=5)
+
+    assert not result.was_decomposed
+    assert result.answer == "Forced direct answer"
+    assert result.child_results == []
+
+
+# ------------------------------------------------------------------
+# Decomposition path
+# ------------------------------------------------------------------
+
+
+def test_single_level_decomposition(root_spec, mock_llm):
+    """Agent decomposes into children, each answers directly, then synthesises."""
+    # Root analysis: needs 2 specialists
+    mock_llm.complete_json.side_effect = [
+        # Root analysis
+        {
+            "summary": "Complex question",
+            "can_answer_directly": False,
+            "direct_answer": None,
+            "confidence": 0.0,
+            "skill_requirements": [
+                {
+                    "name": "philosophy_expert",
+                    "description": "Philosopher",
+                    "focus_question": "What do philosophers say?",
+                    "reasoning": "Need philosophical perspective",
+                },
+                {
+                    "name": "science_expert",
+                    "description": "Scientist",
+                    "focus_question": "What does science say?",
+                    "reasoning": "Need scientific perspective",
+                },
+            ],
+        },
+        # Child 1 analysis: direct answer
+        {
+            "summary": "Philosophy perspective",
+            "can_answer_directly": True,
+            "direct_answer": "Philosophers say 42",
+            "confidence": 0.8,
+            "skill_requirements": [],
+        },
+        # Child 2 analysis: direct answer
+        {
+            "summary": "Science perspective",
+            "can_answer_directly": True,
+            "direct_answer": "Science says 42",
+            "confidence": 0.9,
+            "skill_requirements": [],
+        },
+    ]
+    mock_llm.complete.return_value = "Synthesised: both say 42"
+
+    spawned = []
+
+    def track_spawn(spec):
+        spawned.append(spec)
+        return True
+
+    agent = _make_agent(root_spec, mock_llm, on_spawned=track_spawn)
+    result = agent.execute(max_depth=10)
+
+    assert result.was_decomposed
+    assert len(result.child_results) == 2
+    assert result.answer == "Synthesised: both say 42"
+    assert len(spawned) == 2
+
+
+# ------------------------------------------------------------------
+# Budget enforcement
+# ------------------------------------------------------------------
+
+
+def test_budget_exceeded_vetoes_children(root_spec, mock_llm):
+    """When on_agent_spawned returns False, child gets a truncation message."""
+    mock_llm.complete_json.return_value = {
+        "summary": "Question",
+        "can_answer_directly": False,
+        "direct_answer": None,
+        "confidence": 0.0,
+        "skill_requirements": [
+            {
+                "name": "expert_a",
+                "description": "Expert A",
+                "focus_question": "Q?",
+                "reasoning": "needed",
+            }
+        ],
+    }
+    mock_llm.complete.return_value = "Synthesised from truncated"
+
+    def deny_spawn(_spec):
+        return False
+
+    agent = _make_agent(root_spec, mock_llm, on_spawned=deny_spawn)
+    result = agent.execute(max_depth=10)
+
+    assert result.was_decomposed
+    assert len(result.child_results) == 1
+    assert "budget exceeded" in result.child_results[0].answer.lower()
+
+
+# ------------------------------------------------------------------
+# Max children cap
+# ------------------------------------------------------------------
+
+
+def test_max_children_capped(root_spec, mock_llm):
+    """Even if LLM returns >5 skills, only MAX_CHILDREN_PER_AGENT are used."""
+    skills = [
+        {
+            "name": f"expert_{i}",
+            "description": f"Expert {i}",
+            "focus_question": f"Q{i}?",
+            "reasoning": "needed",
+        }
+        for i in range(8)
+    ]
+
+    # Root returns 8 skills
+    analysis_responses = [
+        {
+            "summary": "Big question",
+            "can_answer_directly": False,
+            "direct_answer": None,
+            "confidence": 0.0,
+            "skill_requirements": skills,
+        }
+    ]
+    # Each child answers directly
+    for i in range(MAX_CHILDREN_PER_AGENT):
+        analysis_responses.append(
+            {
+                "summary": f"Sub {i}",
+                "can_answer_directly": True,
+                "direct_answer": f"Answer {i}",
+                "confidence": 0.8,
+                "skill_requirements": [],
+            }
+        )
+
+    mock_llm.complete_json.side_effect = analysis_responses
+    mock_llm.complete.return_value = "Synthesised"
+
+    spawned = []
+
+    def track_spawn(spec):
+        spawned.append(spec)
+        return True
+
+    agent = _make_agent(root_spec, mock_llm, on_spawned=track_spawn)
+    result = agent.execute(max_depth=10)
+
+    assert result.was_decomposed
+    assert len(result.child_results) <= MAX_CHILDREN_PER_AGENT
+    assert len(spawned) <= MAX_CHILDREN_PER_AGENT
+
+
+# ------------------------------------------------------------------
+# Fallback on LLM error
+# ------------------------------------------------------------------
+
+
+def test_analysis_llm_error_fallback(root_spec, mock_llm):
+    """If the analysis LLM call raises, agent falls back to a direct answer."""
+    mock_llm.complete_json.side_effect = RuntimeError("LLM unavailable")
+    mock_llm.complete.return_value = "Fallback answer"
+
+    agent = _make_agent(root_spec, mock_llm)
+    result = agent.execute(max_depth=10)
+
+    assert not result.was_decomposed
+    assert result.answer == "Fallback answer"

--- a/backend/agents/deepthought/tests/test_agent.py
+++ b/backend/agents/deepthought/tests/test_agent.py
@@ -7,7 +7,9 @@ from unittest.mock import MagicMock
 import pytest
 
 from deepthought.agent import MAX_CHILDREN_PER_AGENT, DeepthoughtAgent
-from deepthought.models import AgentSpec
+from deepthought.knowledge_base import SharedKnowledgeBase
+from deepthought.models import AgentEvent, AgentSpec
+from deepthought.result_cache import ResultCache
 
 
 @pytest.fixture()
@@ -27,8 +29,21 @@ def mock_llm():
     return MagicMock()
 
 
-def _make_agent(spec, llm, on_spawned=None):
-    return DeepthoughtAgent(spec=spec, llm=llm, on_agent_spawned=on_spawned)
+@pytest.fixture()
+def knowledge_base():
+    return SharedKnowledgeBase()
+
+
+def _make_agent(spec, llm, on_spawned=None, kb=None, cache=None, on_event=None, **kwargs):
+    return DeepthoughtAgent(
+        spec=spec,
+        llm=llm,
+        knowledge_base=kb or SharedKnowledgeBase(),
+        result_cache=cache,
+        on_agent_spawned=on_spawned,
+        on_event=on_event,
+        **kwargs,
+    )
 
 
 # ------------------------------------------------------------------
@@ -51,9 +66,30 @@ def test_direct_answer(root_spec, mock_llm):
 
     assert not result.was_decomposed
     assert result.answer == "42"
-    assert result.confidence == 0.95
     assert result.child_results == []
     mock_llm.complete_json.assert_called_once()
+
+
+# ------------------------------------------------------------------
+# Structural confidence
+# ------------------------------------------------------------------
+
+
+def test_structural_confidence_direct(root_spec, mock_llm):
+    """Direct answers use blended structural confidence, not raw self-assessment."""
+    mock_llm.complete_json.return_value = {
+        "summary": "Q",
+        "can_answer_directly": True,
+        "direct_answer": "Answer",
+        "confidence": 0.9,
+        "skill_requirements": [],
+    }
+
+    agent = _make_agent(root_spec, mock_llm)
+    result = agent.execute(max_depth=10)
+
+    # 0.4 + 0.6 * min(0.9, 0.95) = 0.4 + 0.54 = 0.94
+    assert result.confidence == 0.94
 
 
 # ------------------------------------------------------------------
@@ -71,7 +107,6 @@ def test_depth_limit_forces_direct(mock_llm):
         depth=5,
         parent_id="parent-1",
     )
-    # LLM analysis says decompose, but depth is at max
     mock_llm.complete_json.return_value = {
         "summary": "Sub-question",
         "can_answer_directly": False,
@@ -97,13 +132,12 @@ def test_depth_limit_forces_direct(mock_llm):
 
 
 # ------------------------------------------------------------------
-# Decomposition path
+# Decomposition with deliberation
 # ------------------------------------------------------------------
 
 
-def test_single_level_decomposition(root_spec, mock_llm):
-    """Agent decomposes into children, each answers directly, then synthesises."""
-    # Root analysis: needs 2 specialists
+def test_decomposition_with_deliberation(root_spec, mock_llm):
+    """Agent decomposes, deliberates, then synthesises."""
     mock_llm.complete_json.side_effect = [
         # Root analysis
         {
@@ -143,7 +177,12 @@ def test_single_level_decomposition(root_spec, mock_llm):
             "skill_requirements": [],
         },
     ]
-    mock_llm.complete.return_value = "Synthesised: both say 42"
+    # First complete call = deliberation, second = synthesis
+    mock_llm.complete.side_effect = [
+        '{"contradictions": [], "gaps": [], "agreements": ["Both say 42"], '
+        '"quality_flags": [], "synthesis_guidance": "Straightforward agreement"}',
+        "Synthesised: both say 42",
+    ]
 
     spawned = []
 
@@ -157,7 +196,201 @@ def test_single_level_decomposition(root_spec, mock_llm):
     assert result.was_decomposed
     assert len(result.child_results) == 2
     assert result.answer == "Synthesised: both say 42"
+    assert result.deliberation_notes is not None
     assert len(spawned) == 2
+
+
+# ------------------------------------------------------------------
+# Knowledge base deduplication
+# ------------------------------------------------------------------
+
+
+def test_knowledge_base_deduplication(mock_llm, knowledge_base):
+    """When a similar question already has a finding, the agent reuses it."""
+    from deepthought.models import KnowledgeEntry
+
+    # Pre-populate knowledge base with a finding for a similar question
+    knowledge_base.add(
+        KnowledgeEntry(
+            agent_id="prior-1",
+            agent_name="prior_expert",
+            focus_question="What is the meaning of life?",
+            finding="The meaning is 42",
+            confidence=0.9,
+            tags=["meaning", "life"],
+        )
+    )
+
+    spec = AgentSpec(
+        agent_id="dup-1",
+        name="duplicate_analyst",
+        role_description="Analyst",
+        focus_question="What is the meaning of life?",
+        depth=1,  # depth > 0 enables dedup
+        parent_id="root-1",
+    )
+
+    agent = _make_agent(spec, mock_llm, kb=knowledge_base)
+    result = agent.execute(max_depth=10)
+
+    assert result.reused_from_cache
+    assert result.answer == "The meaning is 42"
+    # LLM should not have been called
+    mock_llm.complete_json.assert_not_called()
+
+
+# ------------------------------------------------------------------
+# Result cache
+# ------------------------------------------------------------------
+
+
+def test_result_cache_hit(mock_llm):
+    """Cached results are returned without LLM calls."""
+    from deepthought.models import AgentResult
+
+    cache = ResultCache()
+    cached_result = AgentResult(
+        agent_id="old-1",
+        agent_name="old_agent",
+        depth=0,
+        focus_question="cached question",
+        answer="cached answer",
+        confidence=0.85,
+    )
+    cache.put("cached question", cached_result)
+
+    spec = AgentSpec(
+        agent_id="new-1",
+        name="new_agent",
+        role_description="Agent",
+        focus_question="cached question",
+        depth=0,
+        parent_id=None,
+    )
+
+    agent = _make_agent(spec, mock_llm, cache=cache)
+    result = agent.execute(max_depth=10)
+
+    assert result.reused_from_cache
+    assert result.answer == "cached answer"
+    assert result.agent_id == "new-1"  # ID should be updated
+    mock_llm.complete_json.assert_not_called()
+
+
+# ------------------------------------------------------------------
+# Event emission
+# ------------------------------------------------------------------
+
+
+def test_events_emitted(root_spec, mock_llm):
+    """Agent emits events during execution."""
+    mock_llm.complete_json.return_value = {
+        "summary": "Q",
+        "can_answer_directly": True,
+        "direct_answer": "A",
+        "confidence": 0.9,
+        "skill_requirements": [],
+    }
+
+    events: list[AgentEvent] = []
+
+    agent = _make_agent(root_spec, mock_llm, on_event=events.append)
+    agent.execute(max_depth=10)
+
+    event_types = [e.event_type for e in events]
+    assert AgentEvent.model_fields  # sanity check
+    assert len(events) >= 2
+    # Should have at least ANALYSING and COMPLETE
+    from deepthought.models import AgentEventType
+
+    assert AgentEventType.AGENT_ANALYSING in event_types
+    assert AgentEventType.AGENT_COMPLETE in event_types
+
+
+# ------------------------------------------------------------------
+# Original query threading
+# ------------------------------------------------------------------
+
+
+def test_original_query_threaded_to_children(root_spec, mock_llm):
+    """Children receive the original_query from the root."""
+    original_msg = "Top-level user question about everything"
+
+    mock_llm.complete_json.side_effect = [
+        {
+            "summary": "Big Q",
+            "can_answer_directly": False,
+            "direct_answer": None,
+            "confidence": 0.0,
+            "skill_requirements": [
+                {
+                    "name": "child_expert",
+                    "description": "Child",
+                    "focus_question": "Sub Q?",
+                    "reasoning": "needed",
+                }
+            ],
+        },
+        {
+            "summary": "Sub Q",
+            "can_answer_directly": True,
+            "direct_answer": "Sub answer",
+            "confidence": 0.8,
+            "skill_requirements": [],
+        },
+    ]
+    mock_llm.complete.side_effect = [
+        "deliberation",
+        "synthesis",
+    ]
+
+    spawned_agents = []
+
+    def track(spec):
+        spawned_agents.append(spec)
+        return True
+
+    agent = _make_agent(
+        root_spec,
+        mock_llm,
+        on_spawned=track,
+        original_query=original_msg,
+    )
+    agent.execute(max_depth=10)
+
+    # Verify the original_query appears in the analysis system prompt
+    # by checking the LLM calls
+    first_call_kwargs = mock_llm.complete_json.call_args_list[0]
+    system_prompt = first_call_kwargs.kwargs.get("system_prompt", "")
+    assert original_msg in system_prompt
+
+
+# ------------------------------------------------------------------
+# Conversation history threading
+# ------------------------------------------------------------------
+
+
+def test_conversation_history_in_prompt(root_spec, mock_llm):
+    """Conversation history is included in the analysis prompt."""
+    history = [
+        {"role": "user", "content": "Tell me about Mars"},
+        {"role": "assistant", "content": "Mars is the 4th planet."},
+    ]
+    mock_llm.complete_json.return_value = {
+        "summary": "Q",
+        "can_answer_directly": True,
+        "direct_answer": "Follow-up answer",
+        "confidence": 0.9,
+        "skill_requirements": [],
+    }
+
+    agent = _make_agent(root_spec, mock_llm, conversation_history=history)
+    agent.execute(max_depth=10)
+
+    # The user prompt should contain the conversation history
+    first_call_args = mock_llm.complete_json.call_args_list[0]
+    user_prompt = first_call_args.args[0] if first_call_args.args else ""
+    assert "Mars" in user_prompt
 
 
 # ------------------------------------------------------------------
@@ -181,7 +414,7 @@ def test_budget_exceeded_vetoes_children(root_spec, mock_llm):
             }
         ],
     }
-    mock_llm.complete.return_value = "Synthesised from truncated"
+    mock_llm.complete.side_effect = ["deliberation", "Synthesised from truncated"]
 
     def deny_spawn(_spec):
         return False
@@ -211,7 +444,6 @@ def test_max_children_capped(root_spec, mock_llm):
         for i in range(8)
     ]
 
-    # Root returns 8 skills
     analysis_responses = [
         {
             "summary": "Big question",
@@ -221,7 +453,6 @@ def test_max_children_capped(root_spec, mock_llm):
             "skill_requirements": skills,
         }
     ]
-    # Each child answers directly
     for i in range(MAX_CHILDREN_PER_AGENT):
         analysis_responses.append(
             {
@@ -234,7 +465,7 @@ def test_max_children_capped(root_spec, mock_llm):
         )
 
     mock_llm.complete_json.side_effect = analysis_responses
-    mock_llm.complete.return_value = "Synthesised"
+    mock_llm.complete.side_effect = ["deliberation notes", "Synthesised"]
 
     spawned = []
 
@@ -265,3 +496,27 @@ def test_analysis_llm_error_fallback(root_spec, mock_llm):
 
     assert not result.was_decomposed
     assert result.answer == "Fallback answer"
+
+
+# ------------------------------------------------------------------
+# Knowledge base population
+# ------------------------------------------------------------------
+
+
+def test_findings_stored_in_knowledge_base(root_spec, mock_llm, knowledge_base):
+    """After answering, the agent stores its finding in the knowledge base."""
+    mock_llm.complete_json.return_value = {
+        "summary": "Q",
+        "can_answer_directly": True,
+        "direct_answer": "The answer",
+        "confidence": 0.9,
+        "skill_requirements": [],
+    }
+
+    agent = _make_agent(root_spec, mock_llm, kb=knowledge_base)
+    agent.execute(max_depth=10)
+
+    entries = knowledge_base.all_entries()
+    assert len(entries) == 1
+    assert entries[0].finding == "The answer"
+    assert entries[0].agent_name == "general_analyst"

--- a/backend/agents/deepthought/tests/test_api.py
+++ b/backend/agents/deepthought/tests/test_api.py
@@ -1,0 +1,88 @@
+"""Tests for Deepthought FastAPI endpoints."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from deepthought.api.main import app
+
+
+@patch("deepthought.api.main.DeepthoughtOrchestrator")
+def test_ask_endpoint(mock_orch_cls):
+    """POST /deepthought/ask returns a valid DeepthoughtResponse."""
+    from deepthought.models import AgentResult, DeepthoughtResponse
+
+    mock_orch = MagicMock()
+    mock_orch_cls.return_value = mock_orch
+    mock_orch.process_message.return_value = DeepthoughtResponse(
+        answer="The answer is 42.",
+        agent_tree=AgentResult(
+            agent_id="root",
+            agent_name="general_analyst",
+            depth=0,
+            focus_question="What is the answer?",
+            answer="The answer is 42.",
+            confidence=0.95,
+            child_results=[],
+            was_decomposed=False,
+        ),
+        total_agents_spawned=1,
+        max_depth_reached=0,
+    )
+
+    client = TestClient(app)
+    resp = client.post(
+        "/deepthought/ask",
+        json={"message": "What is the answer?"},
+    )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["answer"] == "The answer is 42."
+    assert data["total_agents_spawned"] == 1
+    assert data["agent_tree"]["agent_name"] == "general_analyst"
+
+
+def test_health_endpoint():
+    """GET /health returns ok."""
+    client = TestClient(app)
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+
+@patch("deepthought.api.main.DeepthoughtOrchestrator")
+def test_ask_with_custom_depth(mock_orch_cls):
+    """POST /deepthought/ask respects max_depth parameter."""
+    from deepthought.models import AgentResult, DeepthoughtResponse
+
+    mock_orch = MagicMock()
+    mock_orch_cls.return_value = mock_orch
+    mock_orch.process_message.return_value = DeepthoughtResponse(
+        answer="Shallow answer",
+        agent_tree=AgentResult(
+            agent_id="root",
+            agent_name="general_analyst",
+            depth=0,
+            focus_question="Q?",
+            answer="Shallow answer",
+            confidence=0.9,
+            child_results=[],
+            was_decomposed=False,
+        ),
+        total_agents_spawned=1,
+        max_depth_reached=0,
+    )
+
+    client = TestClient(app)
+    resp = client.post(
+        "/deepthought/ask",
+        json={"message": "Question?", "max_depth": 3},
+    )
+
+    assert resp.status_code == 200
+    # Verify the request was passed with max_depth=3
+    call_args = mock_orch.process_message.call_args
+    assert call_args[0][0].max_depth == 3

--- a/backend/agents/deepthought/tests/test_api.py
+++ b/backend/agents/deepthought/tests/test_api.py
@@ -83,6 +83,92 @@ def test_ask_with_custom_depth(mock_orch_cls):
     )
 
     assert resp.status_code == 200
-    # Verify the request was passed with max_depth=3
     call_args = mock_orch.process_message.call_args
     assert call_args[0][0].max_depth == 3
+
+
+@patch("deepthought.api.main.DeepthoughtOrchestrator")
+def test_ask_with_decomposition_strategy(mock_orch_cls):
+    """POST /deepthought/ask respects decomposition_strategy parameter."""
+    from deepthought.models import AgentResult, DeepthoughtResponse
+
+    mock_orch = MagicMock()
+    mock_orch_cls.return_value = mock_orch
+    mock_orch.process_message.return_value = DeepthoughtResponse(
+        answer="Answer",
+        agent_tree=AgentResult(
+            agent_id="root",
+            agent_name="general_analyst",
+            depth=0,
+            focus_question="Q?",
+            answer="Answer",
+            confidence=0.9,
+        ),
+        total_agents_spawned=1,
+        max_depth_reached=0,
+    )
+
+    client = TestClient(app)
+    resp = client.post(
+        "/deepthought/ask",
+        json={"message": "Compare X and Y", "decomposition_strategy": "by_option"},
+    )
+
+    assert resp.status_code == 200
+    call_args = mock_orch.process_message.call_args
+    assert call_args[0][0].decomposition_strategy.value == "by_option"
+
+
+@patch("deepthought.api.main.DeepthoughtOrchestrator")
+def test_stream_endpoint(mock_orch_cls):
+    """POST /deepthought/ask/stream returns SSE events."""
+    from deepthought.models import (
+        AgentEvent,
+        AgentEventType,
+        AgentResult,
+        DeepthoughtResponse,
+    )
+
+    mock_orch = MagicMock()
+    mock_orch_cls.return_value = mock_orch
+
+    # Simulate the orchestrator with event collection
+    events_to_emit = [
+        AgentEvent(
+            event_type=AgentEventType.AGENT_ANALYSING,
+            agent_id="root",
+            agent_name="general_analyst",
+            depth=0,
+            detail="Analysing",
+        ),
+    ]
+
+    def fake_process(request):
+        return DeepthoughtResponse(
+            answer="Streamed answer",
+            agent_tree=AgentResult(
+                agent_id="root",
+                agent_name="general_analyst",
+                depth=0,
+                focus_question="Q?",
+                answer="Streamed answer",
+                confidence=0.9,
+            ),
+            total_agents_spawned=1,
+            max_depth_reached=0,
+            events=events_to_emit,
+        )
+
+    mock_orch.process_message.side_effect = fake_process
+    mock_orch._collect_event = MagicMock()
+
+    client = TestClient(app)
+    resp = client.post(
+        "/deepthought/ask/stream",
+        json={"message": "Stream test"},
+    )
+
+    assert resp.status_code == 200
+    assert "text/event-stream" in resp.headers["content-type"]
+    body = resp.text
+    assert "event: result" in body or "event: done" in body

--- a/backend/agents/deepthought/tests/test_knowledge_base.py
+++ b/backend/agents/deepthought/tests/test_knowledge_base.py
@@ -1,0 +1,89 @@
+"""Tests for SharedKnowledgeBase."""
+
+from deepthought.knowledge_base import SharedKnowledgeBase
+from deepthought.models import KnowledgeEntry
+
+
+def _entry(name="agent_1", question="What is X?", finding="X is Y", conf=0.8, tags=None):
+    return KnowledgeEntry(
+        agent_id="id-1",
+        agent_name=name,
+        focus_question=question,
+        finding=finding,
+        confidence=conf,
+        tags=tags or [],
+    )
+
+
+def test_add_and_retrieve():
+    kb = SharedKnowledgeBase()
+    kb.add(_entry())
+    assert len(kb.all_entries()) == 1
+
+
+def test_find_similar_exact():
+    kb = SharedKnowledgeBase()
+    kb.add(_entry(question="What is the meaning of life?"))
+    results = kb.find_similar("What is the meaning of life?")
+    assert len(results) == 1
+
+
+def test_find_similar_close_match():
+    kb = SharedKnowledgeBase()
+    kb.add(_entry(question="What is the economic impact of climate change?"))
+    results = kb.find_similar("What is the economic effect of climate change?")
+    assert len(results) == 1
+
+
+def test_find_similar_no_match():
+    kb = SharedKnowledgeBase()
+    kb.add(_entry(question="What is quantum entanglement?"))
+    results = kb.find_similar("How do I bake a cake?")
+    assert len(results) == 0
+
+
+def test_find_by_tags():
+    kb = SharedKnowledgeBase()
+    kb.add(_entry(tags=["physics", "quantum"]))
+    kb.add(_entry(name="agent_2", tags=["biology"]))
+    results = kb.find_by_tags(["physics"])
+    assert len(results) == 1
+    assert results[0].agent_name == "agent_1"
+
+
+def test_summary_for_prompt_empty():
+    kb = SharedKnowledgeBase()
+    assert "No prior findings" in kb.summary_for_prompt()
+
+
+def test_summary_for_prompt_truncation():
+    kb = SharedKnowledgeBase()
+    for i in range(100):
+        kb.add(_entry(name=f"agent_{i}", finding="X" * 200))
+    summary = kb.summary_for_prompt(max_chars=500)
+    assert len(summary) <= 600  # some slack for the truncation message
+    assert "truncated" in summary
+
+
+def test_thread_safety():
+    """Multiple threads can write concurrently without corruption."""
+    import threading
+
+    kb = SharedKnowledgeBase()
+    errors = []
+
+    def writer(idx):
+        try:
+            for j in range(50):
+                kb.add(_entry(name=f"thread_{idx}_{j}"))
+        except Exception as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=writer, args=(i,)) for i in range(5)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert not errors
+    assert len(kb.all_entries()) == 250

--- a/backend/agents/deepthought/tests/test_models.py
+++ b/backend/agents/deepthought/tests/test_models.py
@@ -1,10 +1,14 @@
 """Tests for Deepthought Pydantic models."""
 
 from deepthought.models import (
+    AgentEvent,
+    AgentEventType,
     AgentResult,
     AgentSpec,
+    DecompositionStrategy,
     DeepthoughtRequest,
     DeepthoughtResponse,
+    KnowledgeEntry,
     QueryAnalysis,
     SkillRequirement,
 )
@@ -64,7 +68,7 @@ def test_agent_spec_creation():
     assert spec.parent_id == "parent-1"
 
 
-def test_agent_result_recursive():
+def test_agent_result_recursive_with_deliberation():
     child = AgentResult(
         agent_id="child-1",
         agent_name="child",
@@ -84,22 +88,38 @@ def test_agent_result_recursive():
         confidence=0.85,
         child_results=[child],
         was_decomposed=True,
+        deliberation_notes="No contradictions found.",
     )
     assert parent.was_decomposed
+    assert parent.deliberation_notes == "No contradictions found."
     assert len(parent.child_results) == 1
-    assert parent.child_results[0].agent_name == "child"
 
     # Verify JSON roundtrip preserves nested structure
     data = parent.model_dump()
     restored = AgentResult(**data)
     assert len(restored.child_results) == 1
     assert restored.child_results[0].answer == "Sub-answer"
+    assert restored.deliberation_notes is not None
+
+
+def test_agent_result_reused_from_cache():
+    result = AgentResult(
+        agent_id="cached-1",
+        agent_name="cached_agent",
+        depth=2,
+        focus_question="Cached Q?",
+        answer="Cached answer",
+        confidence=0.9,
+        reused_from_cache=True,
+    )
+    assert result.reused_from_cache
 
 
 def test_deepthought_request_defaults():
     req = DeepthoughtRequest(message="Hello")
     assert req.max_depth == 10
     assert req.conversation_history == []
+    assert req.decomposition_strategy == DecompositionStrategy.AUTO
 
 
 def test_deepthought_request_custom():
@@ -107,9 +127,11 @@ def test_deepthought_request_custom():
         message="Complex query",
         max_depth=5,
         conversation_history=[{"role": "user", "content": "prior msg"}],
+        decomposition_strategy=DecompositionStrategy.BY_CONCERN,
     )
     assert req.max_depth == 5
     assert len(req.conversation_history) == 1
+    assert req.decomposition_strategy == DecompositionStrategy.BY_CONCERN
 
 
 def test_deepthought_response_serialisation():
@@ -128,7 +150,62 @@ def test_deepthought_response_serialisation():
         agent_tree=tree,
         total_agents_spawned=1,
         max_depth_reached=0,
+        knowledge_entries=[
+            KnowledgeEntry(
+                agent_id="root",
+                agent_name="root_agent",
+                focus_question="Q?",
+                finding="A",
+                confidence=0.9,
+                tags=["root"],
+            )
+        ],
+        events=[
+            AgentEvent(
+                event_type=AgentEventType.AGENT_COMPLETE,
+                agent_id="root",
+                agent_name="root_agent",
+                depth=0,
+                detail="done",
+            )
+        ],
     )
     data = resp.model_dump()
     assert data["total_agents_spawned"] == 1
     assert data["agent_tree"]["agent_name"] == "root_agent"
+    assert len(data["knowledge_entries"]) == 1
+    assert len(data["events"]) == 1
+
+
+def test_decomposition_strategy_values():
+    assert DecompositionStrategy.AUTO == "auto"
+    assert DecompositionStrategy.BY_DISCIPLINE == "by_discipline"
+    assert DecompositionStrategy.BY_CONCERN == "by_concern"
+    assert DecompositionStrategy.BY_OPTION == "by_option"
+    assert DecompositionStrategy.BY_PERSPECTIVE == "by_perspective"
+    assert DecompositionStrategy.NONE == "none"
+
+
+def test_agent_event_serialisation():
+    event = AgentEvent(
+        event_type=AgentEventType.AGENT_SPAWNED,
+        agent_id="a1",
+        agent_name="test",
+        depth=3,
+        detail="Spawned for testing",
+    )
+    data = event.model_dump()
+    assert data["event_type"] == "agent_spawned"
+    assert data["depth"] == 3
+
+
+def test_knowledge_entry_tags():
+    entry = KnowledgeEntry(
+        agent_id="e1",
+        agent_name="physics_expert",
+        focus_question="Force?",
+        finding="F=ma",
+        confidence=0.9,
+        tags=["physics", "mechanics"],
+    )
+    assert "physics" in entry.tags

--- a/backend/agents/deepthought/tests/test_models.py
+++ b/backend/agents/deepthought/tests/test_models.py
@@ -1,0 +1,134 @@
+"""Tests for Deepthought Pydantic models."""
+
+from deepthought.models import (
+    AgentResult,
+    AgentSpec,
+    DeepthoughtRequest,
+    DeepthoughtResponse,
+    QueryAnalysis,
+    SkillRequirement,
+)
+
+
+def test_skill_requirement_roundtrip():
+    sr = SkillRequirement(
+        name="physics_expert",
+        description="Expert in classical mechanics",
+        focus_question="What is Newton's second law?",
+        reasoning="The question involves force and acceleration",
+    )
+    data = sr.model_dump()
+    restored = SkillRequirement(**data)
+    assert restored.name == "physics_expert"
+
+
+def test_query_analysis_direct():
+    qa = QueryAnalysis(
+        summary="Simple question",
+        can_answer_directly=True,
+        direct_answer="42",
+        confidence=0.95,
+        skill_requirements=[],
+    )
+    assert qa.can_answer_directly
+    assert qa.direct_answer == "42"
+    assert qa.skill_requirements == []
+
+
+def test_query_analysis_decompose():
+    qa = QueryAnalysis(
+        summary="Complex question",
+        can_answer_directly=False,
+        direct_answer=None,
+        confidence=0.0,
+        skill_requirements=[
+            SkillRequirement(
+                name="econ", description="Economist", focus_question="GDP?", reasoning="needed"
+            )
+        ],
+    )
+    assert not qa.can_answer_directly
+    assert len(qa.skill_requirements) == 1
+
+
+def test_agent_spec_creation():
+    spec = AgentSpec(
+        agent_id="abc-123",
+        name="test_agent",
+        role_description="Test role",
+        focus_question="What is X?",
+        depth=3,
+        parent_id="parent-1",
+    )
+    assert spec.depth == 3
+    assert spec.parent_id == "parent-1"
+
+
+def test_agent_result_recursive():
+    child = AgentResult(
+        agent_id="child-1",
+        agent_name="child",
+        depth=1,
+        focus_question="Sub-question?",
+        answer="Sub-answer",
+        confidence=0.8,
+        child_results=[],
+        was_decomposed=False,
+    )
+    parent = AgentResult(
+        agent_id="parent-1",
+        agent_name="parent",
+        depth=0,
+        focus_question="Main question?",
+        answer="Synthesised answer",
+        confidence=0.85,
+        child_results=[child],
+        was_decomposed=True,
+    )
+    assert parent.was_decomposed
+    assert len(parent.child_results) == 1
+    assert parent.child_results[0].agent_name == "child"
+
+    # Verify JSON roundtrip preserves nested structure
+    data = parent.model_dump()
+    restored = AgentResult(**data)
+    assert len(restored.child_results) == 1
+    assert restored.child_results[0].answer == "Sub-answer"
+
+
+def test_deepthought_request_defaults():
+    req = DeepthoughtRequest(message="Hello")
+    assert req.max_depth == 10
+    assert req.conversation_history == []
+
+
+def test_deepthought_request_custom():
+    req = DeepthoughtRequest(
+        message="Complex query",
+        max_depth=5,
+        conversation_history=[{"role": "user", "content": "prior msg"}],
+    )
+    assert req.max_depth == 5
+    assert len(req.conversation_history) == 1
+
+
+def test_deepthought_response_serialisation():
+    tree = AgentResult(
+        agent_id="root",
+        agent_name="root_agent",
+        depth=0,
+        focus_question="Q?",
+        answer="A",
+        confidence=0.9,
+        child_results=[],
+        was_decomposed=False,
+    )
+    resp = DeepthoughtResponse(
+        answer="Final answer",
+        agent_tree=tree,
+        total_agents_spawned=1,
+        max_depth_reached=0,
+    )
+    data = resp.model_dump()
+    assert data["total_agents_spawned"] == 1
+    assert data["agent_tree"]["agent_name"] == "root_agent"

--- a/backend/agents/deepthought/tests/test_orchestrator.py
+++ b/backend/agents/deepthought/tests/test_orchestrator.py
@@ -1,0 +1,228 @@
+"""Tests for DeepthoughtOrchestrator."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from deepthought.models import DeepthoughtRequest
+from deepthought.orchestrator import DeepthoughtOrchestrator
+
+
+def _make_orchestrator(mock_llm, budget=50):
+    return DeepthoughtOrchestrator(llm=mock_llm, agent_budget=budget)
+
+
+def test_simple_direct_answer():
+    """Orchestrator handles a simple question that needs no decomposition."""
+    llm = MagicMock()
+    llm.complete_json.return_value = {
+        "summary": "Simple question",
+        "can_answer_directly": True,
+        "direct_answer": "The answer is 42.",
+        "confidence": 0.95,
+        "skill_requirements": [],
+    }
+
+    orch = _make_orchestrator(llm)
+    req = DeepthoughtRequest(message="What is 6 times 7?")
+    resp = orch.process_message(req)
+
+    assert resp.answer == "The answer is 42."
+    assert resp.total_agents_spawned == 1  # root only
+    assert resp.max_depth_reached == 0
+    assert not resp.agent_tree.was_decomposed
+
+
+def test_one_level_decomposition():
+    """Orchestrator decomposes one level and synthesises."""
+    llm = MagicMock()
+    llm.complete_json.side_effect = [
+        # Root analysis
+        {
+            "summary": "Multi-part question",
+            "can_answer_directly": False,
+            "direct_answer": None,
+            "confidence": 0.0,
+            "skill_requirements": [
+                {
+                    "name": "expert_a",
+                    "description": "Expert A",
+                    "focus_question": "Part A?",
+                    "reasoning": "Covers first aspect",
+                },
+            ],
+        },
+        # Child analysis: direct answer
+        {
+            "summary": "Part A",
+            "can_answer_directly": True,
+            "direct_answer": "A says yes",
+            "confidence": 0.9,
+            "skill_requirements": [],
+        },
+    ]
+    llm.complete.return_value = "Synthesised: A says yes"
+
+    orch = _make_orchestrator(llm)
+    req = DeepthoughtRequest(message="Complex question")
+    resp = orch.process_message(req)
+
+    assert resp.total_agents_spawned == 2  # root + 1 child
+    assert resp.max_depth_reached == 1
+    assert resp.agent_tree.was_decomposed
+    assert len(resp.agent_tree.child_results) == 1
+    # Answer should include specialists footer
+    assert "Specialists consulted" in resp.answer
+
+
+def test_agent_budget_limits_spawning():
+    """Orchestrator stops spawning when budget is reached."""
+    llm = MagicMock()
+    # Root analysis: wants 3 children
+    llm.complete_json.side_effect = [
+        {
+            "summary": "Big question",
+            "can_answer_directly": False,
+            "direct_answer": None,
+            "confidence": 0.0,
+            "skill_requirements": [
+                {
+                    "name": f"expert_{i}",
+                    "description": f"Expert {i}",
+                    "focus_question": f"Part {i}?",
+                    "reasoning": "needed",
+                }
+                for i in range(3)
+            ],
+        },
+        # Child 0 direct
+        {
+            "summary": "Part 0",
+            "can_answer_directly": True,
+            "direct_answer": "Answer 0",
+            "confidence": 0.8,
+            "skill_requirements": [],
+        },
+        # Child 1 direct (won't reach due to budget=2)
+        {
+            "summary": "Part 1",
+            "can_answer_directly": True,
+            "direct_answer": "Answer 1",
+            "confidence": 0.8,
+            "skill_requirements": [],
+        },
+        # Child 2 direct (won't reach due to budget=2)
+        {
+            "summary": "Part 2",
+            "can_answer_directly": True,
+            "direct_answer": "Answer 2",
+            "confidence": 0.8,
+            "skill_requirements": [],
+        },
+    ]
+    llm.complete.return_value = "Synthesised with budget limits"
+
+    # Budget of 2: root + 1 child, then budget exhausted
+    orch = _make_orchestrator(llm, budget=2)
+    req = DeepthoughtRequest(message="Big question")
+    resp = orch.process_message(req)
+
+    assert resp.total_agents_spawned == 2
+    # Some children should have budget-exceeded messages
+    budget_exceeded = [
+        c for c in resp.agent_tree.child_results if "budget exceeded" in c.answer.lower()
+    ]
+    assert len(budget_exceeded) >= 1
+
+
+def test_max_depth_tracking():
+    """Orchestrator correctly tracks the maximum depth reached."""
+    llm = MagicMock()
+    # Root decomposes, child decomposes, grandchild answers directly
+    llm.complete_json.side_effect = [
+        # Root
+        {
+            "summary": "Level 0",
+            "can_answer_directly": False,
+            "direct_answer": None,
+            "confidence": 0.0,
+            "skill_requirements": [
+                {
+                    "name": "mid_expert",
+                    "description": "Mid-level",
+                    "focus_question": "Mid question?",
+                    "reasoning": "needed",
+                }
+            ],
+        },
+        # Child at depth 1
+        {
+            "summary": "Level 1",
+            "can_answer_directly": False,
+            "direct_answer": None,
+            "confidence": 0.0,
+            "skill_requirements": [
+                {
+                    "name": "deep_expert",
+                    "description": "Deep",
+                    "focus_question": "Deep question?",
+                    "reasoning": "needed",
+                }
+            ],
+        },
+        # Grandchild at depth 2: direct
+        {
+            "summary": "Level 2",
+            "can_answer_directly": True,
+            "direct_answer": "Deep answer",
+            "confidence": 0.85,
+            "skill_requirements": [],
+        },
+    ]
+    llm.complete.side_effect = [
+        "Mid synthesis",  # depth 1 synthesis
+        "Root synthesis",  # depth 0 synthesis
+    ]
+
+    orch = _make_orchestrator(llm)
+    req = DeepthoughtRequest(message="Deep question", max_depth=10)
+    resp = orch.process_message(req)
+
+    assert resp.max_depth_reached == 2
+    assert resp.total_agents_spawned == 3
+
+
+def test_specialists_footer_format():
+    """The answer includes a specialists-consulted footer when decomposed."""
+    llm = MagicMock()
+    llm.complete_json.side_effect = [
+        {
+            "summary": "Q",
+            "can_answer_directly": False,
+            "direct_answer": None,
+            "confidence": 0.0,
+            "skill_requirements": [
+                {
+                    "name": "physics_expert",
+                    "description": "Physicist",
+                    "focus_question": "Physics angle?",
+                    "reasoning": "need physics",
+                }
+            ],
+        },
+        {
+            "summary": "Physics",
+            "can_answer_directly": True,
+            "direct_answer": "F=ma",
+            "confidence": 0.9,
+            "skill_requirements": [],
+        },
+    ]
+    llm.complete.return_value = "Force equals mass times acceleration."
+
+    orch = _make_orchestrator(llm)
+    resp = orch.process_message(DeepthoughtRequest(message="Explain force"))
+
+    assert "Specialists consulted" in resp.answer
+    assert "physics_expert" in resp.answer
+    assert "Physics angle?" in resp.answer

--- a/backend/agents/deepthought/tests/test_orchestrator.py
+++ b/backend/agents/deepthought/tests/test_orchestrator.py
@@ -4,17 +4,22 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from deepthought.models import DeepthoughtRequest
+from deepthought.models import DecompositionStrategy, DeepthoughtRequest
 from deepthought.orchestrator import DeepthoughtOrchestrator
+from deepthought.result_cache import ResultCache
 
 
-def _make_orchestrator(mock_llm, budget=50):
-    return DeepthoughtOrchestrator(llm=mock_llm, agent_budget=budget)
+def _make_orchestrator(mock_llm, budget=50, cache=None):
+    return DeepthoughtOrchestrator(
+        llm=mock_llm, agent_budget=budget, result_cache=cache or ResultCache()
+    )
 
 
 def test_simple_direct_answer():
     """Orchestrator handles a simple question that needs no decomposition."""
     llm = MagicMock()
+    # Strategy classification call
+    llm.complete.side_effect = ['{"strategy": "none", "reasoning": "simple"}']
     llm.complete_json.return_value = {
         "summary": "Simple question",
         "can_answer_directly": True,
@@ -27,14 +32,18 @@ def test_simple_direct_answer():
     req = DeepthoughtRequest(message="What is 6 times 7?")
     resp = orch.process_message(req)
 
-    assert resp.answer == "The answer is 42."
-    assert resp.total_agents_spawned == 1  # root only
+    assert "42" in resp.answer
+    assert resp.total_agents_spawned == 1
     assert resp.max_depth_reached == 0
     assert not resp.agent_tree.was_decomposed
+    # Should have knowledge entries
+    assert len(resp.knowledge_entries) >= 1
+    # Should have events
+    assert len(resp.events) >= 1
 
 
-def test_one_level_decomposition():
-    """Orchestrator decomposes one level and synthesises."""
+def test_one_level_decomposition_with_deliberation():
+    """Orchestrator decomposes, deliberates, and synthesises."""
     llm = MagicMock()
     llm.complete_json.side_effect = [
         # Root analysis
@@ -61,24 +70,27 @@ def test_one_level_decomposition():
             "skill_requirements": [],
         },
     ]
-    llm.complete.return_value = "Synthesised: A says yes"
+    # strategy classification, then deliberation, then synthesis
+    llm.complete.side_effect = [
+        '{"strategy": "by_discipline", "reasoning": "factual"}',
+        "Deliberation: no contradictions, all good",
+        "Synthesised: A says yes",
+    ]
 
     orch = _make_orchestrator(llm)
     req = DeepthoughtRequest(message="Complex question")
     resp = orch.process_message(req)
 
-    assert resp.total_agents_spawned == 2  # root + 1 child
+    assert resp.total_agents_spawned == 2
     assert resp.max_depth_reached == 1
     assert resp.agent_tree.was_decomposed
-    assert len(resp.agent_tree.child_results) == 1
-    # Answer should include specialists footer
+    assert resp.agent_tree.deliberation_notes is not None
     assert "Specialists consulted" in resp.answer
 
 
 def test_agent_budget_limits_spawning():
     """Orchestrator stops spawning when budget is reached."""
     llm = MagicMock()
-    # Root analysis: wants 3 children
     llm.complete_json.side_effect = [
         {
             "summary": "Big question",
@@ -95,7 +107,6 @@ def test_agent_budget_limits_spawning():
                 for i in range(3)
             ],
         },
-        # Child 0 direct
         {
             "summary": "Part 0",
             "can_answer_directly": True,
@@ -103,7 +114,6 @@ def test_agent_budget_limits_spawning():
             "confidence": 0.8,
             "skill_requirements": [],
         },
-        # Child 1 direct (won't reach due to budget=2)
         {
             "summary": "Part 1",
             "can_answer_directly": True,
@@ -111,7 +121,6 @@ def test_agent_budget_limits_spawning():
             "confidence": 0.8,
             "skill_requirements": [],
         },
-        # Child 2 direct (won't reach due to budget=2)
         {
             "summary": "Part 2",
             "can_answer_directly": True,
@@ -120,25 +129,29 @@ def test_agent_budget_limits_spawning():
             "skill_requirements": [],
         },
     ]
-    llm.complete.return_value = "Synthesised with budget limits"
+    llm.complete.side_effect = [
+        '{"strategy": "auto", "reasoning": "general"}',
+        "deliberation",
+        "Synthesised with budget limits",
+    ]
 
-    # Budget of 2: root + 1 child, then budget exhausted
     orch = _make_orchestrator(llm, budget=2)
     req = DeepthoughtRequest(message="Big question")
     resp = orch.process_message(req)
 
     assert resp.total_agents_spawned == 2
-    # Some children should have budget-exceeded messages
     budget_exceeded = [
         c for c in resp.agent_tree.child_results if "budget exceeded" in c.answer.lower()
     ]
     assert len(budget_exceeded) >= 1
+    # Budget warning events should exist
+    budget_events = [e for e in resp.events if e.event_type.value == "budget_warning"]
+    assert len(budget_events) >= 1
 
 
 def test_max_depth_tracking():
     """Orchestrator correctly tracks the maximum depth reached."""
     llm = MagicMock()
-    # Root decomposes, child decomposes, grandchild answers directly
     llm.complete_json.side_effect = [
         # Root
         {
@@ -180,7 +193,10 @@ def test_max_depth_tracking():
         },
     ]
     llm.complete.side_effect = [
+        '{"strategy": "auto", "reasoning": "complex"}',
+        "deliberation depth 1",  # depth-1 deliberation (skipped, <2 children)
         "Mid synthesis",  # depth 1 synthesis
+        "deliberation depth 0",
         "Root synthesis",  # depth 0 synthesis
     ]
 
@@ -190,6 +206,76 @@ def test_max_depth_tracking():
 
     assert resp.max_depth_reached == 2
     assert resp.total_agents_spawned == 3
+
+
+def test_explicit_strategy_skips_classification():
+    """When strategy is explicitly set, no classification LLM call is made."""
+    llm = MagicMock()
+    llm.complete_json.return_value = {
+        "summary": "Q",
+        "can_answer_directly": True,
+        "direct_answer": "A",
+        "confidence": 0.9,
+        "skill_requirements": [],
+    }
+    # complete should NOT be called for classification
+    llm.complete.side_effect = RuntimeError("Should not be called for classification")
+
+    orch = _make_orchestrator(llm)
+    req = DeepthoughtRequest(
+        message="Test",
+        decomposition_strategy=DecompositionStrategy.BY_CONCERN,
+    )
+    resp = orch.process_message(req)
+
+    assert "A" in resp.answer
+
+
+def test_conversation_history_passed_through():
+    """Conversation history from the request reaches the agent."""
+    llm = MagicMock()
+    llm.complete.return_value = '{"strategy": "none", "reasoning": "simple"}'
+    llm.complete_json.return_value = {
+        "summary": "Q",
+        "can_answer_directly": True,
+        "direct_answer": "Follow-up answer",
+        "confidence": 0.9,
+        "skill_requirements": [],
+    }
+
+    orch = _make_orchestrator(llm)
+    req = DeepthoughtRequest(
+        message="Follow up on Mars",
+        conversation_history=[
+            {"role": "user", "content": "Tell me about Mars"},
+            {"role": "assistant", "content": "Mars is the 4th planet."},
+        ],
+    )
+    orch.process_message(req)
+
+    # The analysis prompt should contain conversation history
+    call_args = llm.complete_json.call_args_list[0]
+    user_prompt = call_args.args[0]
+    assert "Mars" in user_prompt
+
+
+def test_knowledge_entries_in_response():
+    """Response includes knowledge base entries from all agents."""
+    llm = MagicMock()
+    llm.complete.return_value = '{"strategy": "none", "reasoning": "simple"}'
+    llm.complete_json.return_value = {
+        "summary": "Q",
+        "can_answer_directly": True,
+        "direct_answer": "Knowledge answer",
+        "confidence": 0.9,
+        "skill_requirements": [],
+    }
+
+    orch = _make_orchestrator(llm)
+    resp = orch.process_message(DeepthoughtRequest(message="Q"))
+
+    assert len(resp.knowledge_entries) >= 1
+    assert resp.knowledge_entries[0].finding.startswith("Knowledge answer")
 
 
 def test_specialists_footer_format():
@@ -218,11 +304,14 @@ def test_specialists_footer_format():
             "skill_requirements": [],
         },
     ]
-    llm.complete.return_value = "Force equals mass times acceleration."
+    llm.complete.side_effect = [
+        '{"strategy": "by_discipline", "reasoning": "physics"}',
+        "deliberation",
+        "Force equals mass times acceleration.",
+    ]
 
     orch = _make_orchestrator(llm)
     resp = orch.process_message(DeepthoughtRequest(message="Explain force"))
 
     assert "Specialists consulted" in resp.answer
     assert "physics_expert" in resp.answer
-    assert "Physics angle?" in resp.answer

--- a/backend/agents/deepthought/tests/test_result_cache.py
+++ b/backend/agents/deepthought/tests/test_result_cache.py
@@ -1,0 +1,61 @@
+"""Tests for ResultCache."""
+
+import time
+
+from deepthought.models import AgentResult
+from deepthought.result_cache import ResultCache
+
+
+def _result(answer="test answer"):
+    return AgentResult(
+        agent_id="a1",
+        agent_name="test_agent",
+        depth=0,
+        focus_question="Q?",
+        answer=answer,
+        confidence=0.9,
+    )
+
+
+def test_put_and_get():
+    cache = ResultCache()
+    cache.put("What is X?", _result("X is Y"))
+    hit = cache.get("What is X?")
+    assert hit is not None
+    assert hit.answer == "X is Y"
+
+
+def test_case_insensitive_key():
+    cache = ResultCache()
+    cache.put("What is X?", _result())
+    assert cache.get("what is x?") is not None
+    assert cache.get("WHAT IS X?") is not None
+
+
+def test_miss():
+    cache = ResultCache()
+    assert cache.get("nonexistent") is None
+
+
+def test_ttl_expiration():
+    cache = ResultCache(ttl=0.05)  # 50ms TTL
+    cache.put("Q?", _result())
+    assert cache.get("Q?") is not None
+    time.sleep(0.1)
+    assert cache.get("Q?") is None
+
+
+def test_max_size_eviction():
+    cache = ResultCache(max_size=3)
+    for i in range(5):
+        cache.put(f"question {i}", _result(f"answer {i}"))
+    # Should not exceed max_size
+    # The most recent entries should be present
+    assert cache.get("question 4") is not None
+
+
+def test_clear():
+    cache = ResultCache()
+    cache.put("Q?", _result())
+    cache.clear()
+    assert cache.get("Q?") is None

--- a/backend/agents/llm_service/config.py
+++ b/backend/agents/llm_service/config.py
@@ -85,6 +85,7 @@ AGENT_DEFAULT_MODELS: dict[str, str] = {
     "accessibility_audit": "llama3.1",
     "strategy_ideation": "qwen3.5:397b-cloud",
     "signal_intelligence": "qwen3.5:397b-cloud",
+    "deepthought": "qwen3.5:397b-cloud",
 }
 
 DEFAULT_FALLBACK_MODEL = "qwen3.5:397b-cloud"

--- a/backend/agents/team_assistant/config.py
+++ b/backend/agents/team_assistant/config.py
@@ -399,6 +399,33 @@ TEAM_ASSISTANT_CONFIGS: dict[str, TeamAssistantConfig] = {
         ],
     ),
     # -----------------------------------------------------------------------
+    "deepthought": TeamAssistantConfig(
+        team_key="deepthought",
+        team_name="Deepthought",
+        system_prompt_context=(
+            "A recursive, self-organising agent system that analyses complex questions, "
+            "identifies what specialist knowledge is needed, and dynamically creates "
+            "expert sub-agents to provide comprehensive answers. Each sub-agent can "
+            "further decompose its task up to 10 levels deep."
+        ),
+        required_fields=[],
+        optional_fields=[
+            {"key": "max_depth", "description": "Maximum recursion depth (1-10, default 10)"},
+        ],
+        welcome_message=(
+            "Welcome to Deepthought! I'm a recursive multi-agent system that breaks down "
+            "complex questions into specialist perspectives.\n\n"
+            "Ask me anything — I'll analyse your question, identify what expertise is needed, "
+            "and dynamically assemble a team of specialist agents to provide a comprehensive answer."
+        ),
+        default_suggested_questions=[
+            "What are the economic implications of universal basic income?",
+            "Explain how mRNA vaccines work and their future applications.",
+            "What would it take to establish a self-sustaining Mars colony?",
+        ],
+        llm_agent_key="deepthought",
+    ),
+    # -----------------------------------------------------------------------
     "sales_team": TeamAssistantConfig(
         team_key="sales_team",
         team_name="AI Sales Team",

--- a/backend/unified_api/config.py
+++ b/backend/unified_api/config.py
@@ -178,6 +178,12 @@ TEAM_CONFIGS: dict[str, TeamConfig] = {
         description="Autonomous startup founder agent that drives the SE team to build a task management service",
         tags=["user-agent", "founder", "simulation"],
     ),
+    "deepthought": TeamConfig(
+        name="Deepthought",
+        prefix="/api/deepthought",
+        description="Recursive self-organising agent that dynamically creates specialist sub-agents to answer complex questions",
+        tags=["deepthought", "recursive", "multi-agent"],
+    ),
 }
 
 

--- a/backend/unified_api/main.py
+++ b/backend/unified_api/main.py
@@ -104,6 +104,7 @@ TEAM_SERVICE_URL_ENVS: dict[str, str] = {
     "agentic_team_provisioning": "AGENTIC_TEAM_PROVISIONING_SERVICE_URL",
     "startup_advisor": "STARTUP_ADVISOR_SERVICE_URL",
     "user_agent_founder": "USER_AGENT_FOUNDER_SERVICE_URL",
+    "deepthought": "DEEPTHOUGHT_SERVICE_URL",
 }
 
 # Track which teams were successfully registered (for health endpoint).


### PR DESCRIPTION
Deepthought analyses user queries, identifies what specialist knowledge
is needed, and dynamically creates sub-agents to provide comprehensive
answers. Each sub-agent recursively decomposes its task (up to 10
levels) with parallel execution via ThreadPoolExecutor. Results bubble
up through synthesis at each level.

Includes: models, agent, orchestrator, prompts, FastAPI API, team
assistant registration, and 22 unit tests.

https://claude.ai/code/session_01ByxW1J6n8sCrRkqZjYCbWZ