### PR TITLE
feat(ui): add Deepthought agent dashboard with chat and agent hierarchy visualization

### DIFF
--- a/user-interface/src/app/app.routes.ts
+++ b/user-interface/src/app/app.routes.ts
@@ -26,6 +26,7 @@ import { AgenticTeamDashboardComponent } from './components/agentic-team-dashboa
 import { PlanningArtifactDetailComponent } from './components/planning-artifact-detail/planning-artifact-detail.component';
 import { PersonaTestingDashboardComponent } from './components/persona-testing-dashboard/persona-testing-dashboard.component';
 import { PersonaTestAuditPanelComponent } from './components/persona-test-audit-panel/persona-test-audit-panel.component';
+import { DeepthoughtDashboardComponent } from './components/deepthought-dashboard/deepthought-dashboard.component';
 
 export const routes: Routes = [
   {
@@ -64,6 +65,7 @@ export const routes: Routes = [
       { path: 'startup-advisor', component: StartupAdvisorDashboardComponent },
       { path: 'persona-testing', component: PersonaTestingDashboardComponent },
       { path: 'persona-testing/audit/:runId', component: PersonaTestAuditPanelComponent },
+      { path: 'deepthought', component: DeepthoughtDashboardComponent },
     ],
   },
   { path: '**', redirectTo: '/dashboard' },

--- a/user-interface/src/app/components/app-shell/app-shell.component.html
+++ b/user-interface/src/app/components/app-shell/app-shell.component.html
@@ -143,6 +143,10 @@
           <mat-icon>groups</mat-icon>
           <span>Agentic Teams</span>
         </a>
+        <a routerLink="/deepthought" routerLinkActive="active" class="nav-link">
+          <mat-icon>psychology</mat-icon>
+          <span>Deepthought</span>
+        </a>
       </div>
 
       <div class="nav-group">

--- a/user-interface/src/app/components/deepthought-dashboard/deepthought-dashboard.component.html
+++ b/user-interface/src/app/components/deepthought-dashboard/deepthought-dashboard.component.html
@@ -1,0 +1,300 @@
+@if (error) {
+  <div class="error-banner">
+    <p class="error-text">{{ error }}</p>
+    @if (lastFailedMessage) {
+      <button mat-stroked-button (click)="retryLastMessage()" [disabled]="isProcessing">Retry</button>
+    }
+  </div>
+}
+
+<div class="deepthought-layout"
+     [class.mobile]="isMobile"
+     [class.show-chat]="mobileTab === 'chat'"
+     [class.show-tree]="mobileTab === 'tree'">
+
+  <!-- ================================================================== -->
+  <!-- LEFT: Chat Panel                                                    -->
+  <!-- ================================================================== -->
+  <section class="chat-panel">
+    <div class="panel-header">
+      <mat-icon>psychology</mat-icon>
+      <span class="panel-title">Deepthought</span>
+      <span class="spacer"></span>
+      <div class="header-actions">
+        <button mat-icon-button (click)="toggleSettings()" matTooltip="Settings"
+                [class.active]="showSettings">
+          <mat-icon>tune</mat-icon>
+        </button>
+        <button mat-icon-button (click)="newConversation()" matTooltip="New conversation">
+          <mat-icon>add_comment</mat-icon>
+        </button>
+      </div>
+    </div>
+
+    <!-- Collapsible settings -->
+    @if (showSettings) {
+      <div class="settings-bar">
+        <div class="setting-group">
+          <span class="setting-label" id="depth-label">Max Depth</span>
+          <mat-slider min="1" max="10" step="1" discrete showTickMarks class="depth-slider">
+            <input matSliderThumb [(ngModel)]="maxDepth" aria-labelledby="depth-label" />
+          </mat-slider>
+          <span class="setting-value">{{ maxDepth }}</span>
+        </div>
+        <div class="setting-group">
+          <span class="setting-label" id="strategy-label">Strategy</span>
+          <mat-select [(ngModel)]="decompositionStrategy" class="strategy-select" aria-labelledby="strategy-label">
+            @for (s of strategies; track s.value) {
+              <mat-option [value]="s.value" [matTooltip]="s.description">{{ s.label }}</mat-option>
+            }
+          </mat-select>
+        </div>
+      </div>
+    }
+
+    <!-- Messages -->
+    <div class="messages-container" #messagesContainer>
+      <!-- Welcome empty state -->
+      @if (messages.length === 0 && !isProcessing) {
+        <div class="welcome-state">
+          <div class="welcome-icon-container">
+            <mat-icon class="welcome-icon">psychology</mat-icon>
+          </div>
+          <h2 class="welcome-title">Ask Deepthought</h2>
+          <p class="welcome-description">
+            I dynamically create specialist agents to analyze your question from multiple angles,
+            then synthesize their findings into a comprehensive answer.
+          </p>
+          <div class="example-questions">
+            @for (q of exampleQuestions; track q) {
+              <button class="example-chip" (click)="sendMessage(q)">
+                <mat-icon>arrow_forward</mat-icon>
+                {{ q }}
+              </button>
+            }
+          </div>
+        </div>
+      }
+
+      <!-- Message list -->
+      @for (msg of messages; track msg.timestamp + msg.role) {
+        <div class="message"
+             [class.user]="msg.role === 'user'"
+             [class.assistant]="msg.role === 'assistant'"
+             [class.selected]="msg.agentTree && selectedTreeSnapshot === msg.agentTree">
+          @if (msg.role === 'assistant') {
+            <div class="message-content markdown-body" [innerHTML]="renderMarkdown(msg.content)"></div>
+          } @else {
+            <div class="message-content">{{ msg.content }}</div>
+          }
+          <div class="message-meta">
+            <span class="message-time">{{ formatTime(msg.timestamp) }}</span>
+            @if (msg.agentTree) {
+              <button class="tree-link" (click)="selectTree(msg.agentTree!); $event.stopPropagation()">
+                <mat-icon>account_tree</mat-icon>
+                <span>{{ msg.totalAgents }} agents</span>
+              </button>
+            }
+          </div>
+        </div>
+      }
+
+      <!-- Processing indicator -->
+      @if (isProcessing) {
+        <div class="message assistant processing">
+          <div class="processing-status">
+            <div class="typing-indicator"><span></span><span></span><span></span></div>
+            <span class="processing-text">
+              @if (activeAgentCount > 0) {
+                {{ activeAgentCount }} agent{{ activeAgentCount !== 1 ? 's' : '' }} working...
+              } @else {
+                Thinking...
+              }
+            </span>
+          </div>
+        </div>
+      }
+    </div>
+
+    <!-- Input form -->
+    <form class="input-form" (ngSubmit)="onSubmit()">
+      <mat-form-field appearance="outline" class="message-input">
+        <textarea matInput
+                  [formControl]="messageControl"
+                  placeholder="Ask a complex question..."
+                  rows="1"
+                  cdkTextareaAutosize
+                  cdkAutosizeMinRows="1"
+                  cdkAutosizeMaxRows="4"
+                  (keydown.enter)="$event.preventDefault(); onSubmit()">
+        </textarea>
+      </mat-form-field>
+      <button mat-fab color="primary" type="submit"
+              [disabled]="messageControl.invalid || isProcessing"
+              aria-label="Send message">
+        <mat-icon>send</mat-icon>
+      </button>
+    </form>
+  </section>
+
+  <!-- ================================================================== -->
+  <!-- RIGHT: Agent Hierarchy Panel                                        -->
+  <!-- ================================================================== -->
+  <section class="hierarchy-panel">
+    <div class="panel-header">
+      <mat-icon>account_tree</mat-icon>
+      <span class="panel-title">Agent Hierarchy</span>
+      <span class="spacer"></span>
+      @if (isProcessing && activeAgentCount > 0) {
+        <span class="stats-badge live">
+          <span class="live-dot"></span>
+          {{ activeAgentCount }} agents
+        </span>
+      } @else if (selectedTreeSnapshot) {
+        <span class="stats-badge">
+          {{ countAgents(selectedTreeSnapshot) }} agents · depth {{ getMaxDepth(selectedTreeSnapshot) }}
+        </span>
+      }
+    </div>
+
+    <div class="tree-container">
+      <!-- Live processing tree -->
+      @if (isProcessing && liveAgentNodes.size > 0) {
+        <div class="live-tree">
+          @for (node of liveAgentNodesArray; track node.agent_id) {
+            <div class="tree-node"
+                 [class]="'status-' + node.status"
+                 [style.padding-left.px]="node.depth * 24 + 16">
+              <div class="node-connector" [style.left.px]="node.depth * 24 + 4"></div>
+              <div class="node-status-dot"></div>
+              <div class="node-content">
+                <span class="node-name">{{ formatAgentName(node.agent_name) }}</span>
+                <span class="node-detail">{{ node.detail || node.status }}</span>
+              </div>
+            </div>
+          }
+        </div>
+      }
+
+      <!-- Completed result tree -->
+      @else if (selectedTreeSnapshot) {
+        <div class="result-tree">
+          <ng-container *ngTemplateOutlet="agentNodeTpl; context: { $implicit: selectedTreeSnapshot }"></ng-container>
+        </div>
+      }
+
+      <!-- Empty state -->
+      @else {
+        <div class="tree-empty-state">
+          <mat-icon>device_hub</mat-icon>
+          <p>Agent activity will appear here as Deepthought processes your question.</p>
+        </div>
+      }
+    </div>
+
+    <!-- Knowledge base -->
+    @if (selectedKnowledge.length > 0) {
+      <div class="knowledge-section">
+        <button class="knowledge-toggle" (click)="showKnowledge = !showKnowledge">
+          <mat-icon>{{ showKnowledge ? 'expand_more' : 'chevron_right' }}</mat-icon>
+          <span>Knowledge Base ({{ selectedKnowledge.length }} entries)</span>
+        </button>
+        @if (showKnowledge) {
+          <div class="knowledge-entries">
+            @for (entry of selectedKnowledge; track entry.agent_id + entry.focus_question) {
+              <div class="knowledge-entry">
+                <span class="ke-agent">{{ formatAgentName(entry.agent_name) }}</span>
+                <span class="ke-finding">{{ entry.finding }}</span>
+                <div class="ke-meta">
+                  <span class="ke-confidence" [matTooltip]="'Confidence: ' + (entry.confidence * 100).toFixed(0) + '%'">
+                    {{ (entry.confidence * 100).toFixed(0) }}%
+                  </span>
+                  @for (tag of entry.tags; track tag) {
+                    <span class="ke-tag">{{ tag }}</span>
+                  }
+                </div>
+              </div>
+            }
+          </div>
+        }
+      </div>
+    }
+  </section>
+</div>
+
+<!-- ================================================================== -->
+<!-- Recursive template for completed tree nodes                         -->
+<!-- ================================================================== -->
+<ng-template #agentNodeTpl let-node>
+  <div class="result-node"
+       [class.expanded]="expandedNodes.has(node.agent_id)"
+       [class.cached]="node.reused_from_cache"
+       [class.has-children]="node.child_results?.length > 0">
+
+    <div class="node-row" role="button" tabindex="0"
+         (click)="toggleNode(node.agent_id)"
+         (keydown.enter)="toggleNode(node.agent_id)"
+         (keydown.space)="toggleNode(node.agent_id); $event.preventDefault()">
+      <div class="node-status-dot complete"></div>
+      @if (node.child_results?.length) {
+        <mat-icon class="expand-icon">
+          {{ expandedNodes.has(node.agent_id) ? 'expand_more' : 'chevron_right' }}
+        </mat-icon>
+      } @else {
+        <span class="expand-spacer"></span>
+      }
+      <div class="node-info">
+        <div class="node-header">
+          <span class="node-name">{{ formatAgentName(node.agent_name) }}</span>
+          @if (node.reused_from_cache) {
+            <span class="cache-badge" matTooltip="Result from knowledge cache">cached</span>
+          }
+        </div>
+        <div class="node-question">{{ node.focus_question }}</div>
+        <div class="confidence-bar">
+          <div class="confidence-fill" [style.width.%]="node.confidence * 100"></div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Expanded detail -->
+    @if (expandedNodes.has(node.agent_id)) {
+      <div class="node-detail-panel">
+        <div class="node-answer markdown-body" [innerHTML]="renderMarkdown(node.answer)"></div>
+        @if (node.deliberation_notes) {
+          <div class="node-deliberation">
+            <mat-icon>lightbulb</mat-icon>
+            <span>{{ node.deliberation_notes }}</span>
+          </div>
+        }
+      </div>
+
+      <!-- Children -->
+      @if (node.child_results?.length) {
+        <div class="node-children">
+          @for (child of node.child_results; track child.agent_id) {
+            <ng-container *ngTemplateOutlet="agentNodeTpl; context: { $implicit: child }"></ng-container>
+          }
+        </div>
+      }
+    }
+  </div>
+</ng-template>
+
+<!-- Mobile tab bar -->
+@if (isMobile) {
+  <div class="mobile-tab-bar">
+    <button [class.active]="mobileTab === 'chat'" (click)="mobileTab = 'chat'">
+      <mat-icon>chat</mat-icon>
+      <span>Chat</span>
+    </button>
+    <button [class.active]="mobileTab === 'tree'" (click)="mobileTab = 'tree'"
+            [class.has-activity]="isProcessing">
+      <mat-icon>account_tree</mat-icon>
+      <span>Agents</span>
+      @if (isProcessing && activeAgentCount > 0) {
+        <span class="activity-badge">{{ activeAgentCount }}</span>
+      }
+    </button>
+  </div>
+}

--- a/user-interface/src/app/components/deepthought-dashboard/deepthought-dashboard.component.scss
+++ b/user-interface/src/app/components/deepthought-dashboard/deepthought-dashboard.component.scss
@@ -1,0 +1,899 @@
+// ============================================================================
+// Deepthought Dashboard — Professional Chat + Agent Hierarchy UI
+// ============================================================================
+
+// --- Error banner ---
+.error-banner {
+  padding: 8px 16px;
+  margin-bottom: 12px;
+  background: var(--kh-error-subtle, rgba(248, 113, 113, 0.12));
+  border: 1px solid rgba(248, 113, 113, 0.3);
+  border-radius: var(--kh-radius-md, 8px);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+
+  .error-text {
+    color: var(--kh-error, #f87171);
+    font-size: var(--kh-text-base, 0.875rem);
+    margin: 0;
+    flex: 1;
+  }
+}
+
+// --- Two-panel layout ---
+.deepthought-layout {
+  display: flex;
+  gap: 20px;
+  height: calc(100vh - 140px);
+  min-height: 500px;
+}
+
+.chat-panel,
+.hierarchy-panel {
+  display: flex;
+  flex-direction: column;
+  background: var(--kh-surface-2, #171717);
+  border: 1px solid var(--kh-border, rgba(255, 255, 255, 0.16));
+  border-radius: var(--kh-radius-lg, 12px);
+  overflow: hidden;
+}
+
+.chat-panel {
+  flex: 1.2;
+}
+
+.hierarchy-panel {
+  flex: 1;
+}
+
+// --- Panel headers ---
+.panel-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--kh-border, rgba(255, 255, 255, 0.16));
+  flex-shrink: 0;
+
+  > mat-icon {
+    color: var(--kh-accent, #fbbf24);
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+  }
+
+  .panel-title {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--kh-text-primary, #ffffff);
+  }
+
+  .spacer {
+    flex: 1;
+  }
+
+  .header-actions {
+    display: flex;
+    gap: 2px;
+
+    button {
+      color: var(--kh-text-muted, #71717a);
+      &:hover, &.active {
+        color: var(--kh-accent, #fbbf24);
+      }
+    }
+  }
+}
+
+// --- Stats badge ---
+.stats-badge {
+  font-size: var(--kh-text-xs, 0.75rem);
+  padding: 2px 10px;
+  border-radius: var(--kh-radius-full, 9999px);
+  background: var(--kh-glass, rgba(255, 255, 255, 0.06));
+  border: 1px solid var(--kh-border-subtle, rgba(255, 255, 255, 0.10));
+  color: var(--kh-text-secondary, #d4d4d8);
+  white-space: nowrap;
+
+  &.live {
+    border-color: var(--kh-success, #4ade80);
+    color: var(--kh-success, #4ade80);
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+}
+
+.live-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--kh-success, #4ade80);
+  animation: pulse 1.5s ease-in-out infinite;
+}
+
+// --- Settings bar ---
+.settings-bar {
+  display: flex;
+  gap: 24px;
+  padding: 10px 16px;
+  background: var(--kh-surface-3, #262626);
+  border-bottom: 1px solid var(--kh-border-subtle, rgba(255, 255, 255, 0.10));
+  flex-shrink: 0;
+  animation: slideDown 0.15s ease;
+
+  .setting-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .setting-label {
+    font-size: var(--kh-text-xs, 0.75rem);
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--kh-text-muted, #71717a);
+    white-space: nowrap;
+  }
+
+  .setting-value {
+    font-size: var(--kh-text-sm, 0.8125rem);
+    font-weight: 600;
+    color: var(--kh-accent, #fbbf24);
+    min-width: 20px;
+    text-align: center;
+  }
+
+  .depth-slider {
+    width: 140px;
+  }
+
+  .strategy-select {
+    width: 160px;
+  }
+}
+
+@keyframes slideDown {
+  from { max-height: 0; opacity: 0; padding-top: 0; padding-bottom: 0; }
+  to { max-height: 60px; opacity: 1; }
+}
+
+// --- Messages area ---
+.messages-container {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  &::-webkit-scrollbar { width: 6px; }
+  &::-webkit-scrollbar-track { background: transparent; }
+  &::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 3px;
+    &:hover { background: rgba(255, 255, 255, 0.15); }
+  }
+}
+
+// --- Welcome state ---
+.welcome-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  padding: 32px 24px;
+  text-align: center;
+}
+
+.welcome-icon-container {
+  width: 72px;
+  height: 72px;
+  border-radius: 50%;
+  background: var(--kh-accent-muted, rgba(251, 191, 36, 0.12));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 16px;
+
+  .welcome-icon {
+    font-size: 36px;
+    width: 36px;
+    height: 36px;
+    color: var(--kh-accent, #fbbf24);
+  }
+}
+
+.welcome-title {
+  font-size: var(--kh-text-xl, 1.5rem);
+  font-weight: 700;
+  color: var(--kh-text-primary, #ffffff);
+  margin: 0 0 8px;
+}
+
+.welcome-description {
+  font-size: var(--kh-text-base, 0.875rem);
+  color: var(--kh-text-tertiary, #a1a1aa);
+  max-width: 480px;
+  line-height: 1.6;
+  margin: 0 0 24px;
+}
+
+.example-questions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+  max-width: 480px;
+}
+
+.example-chip {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 14px;
+  border-radius: var(--kh-radius-md, 8px);
+  background: var(--kh-surface-3, #262626);
+  border: 1px solid var(--kh-border-subtle, rgba(255, 255, 255, 0.10));
+  color: var(--kh-text-secondary, #d4d4d8);
+  font-size: var(--kh-text-sm, 0.8125rem);
+  text-align: left;
+  cursor: pointer;
+  transition: all var(--kh-transition, 0.15s ease);
+
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    color: var(--kh-text-muted, #71717a);
+    flex-shrink: 0;
+  }
+
+  &:hover {
+    border-color: var(--kh-accent, #fbbf24);
+    color: var(--kh-text-primary, #ffffff);
+    background: var(--kh-glass-hover, rgba(255, 255, 255, 0.12));
+
+    mat-icon {
+      color: var(--kh-accent, #fbbf24);
+    }
+  }
+}
+
+// --- Chat messages ---
+.message {
+  max-width: 85%;
+  padding: 10px 14px;
+  border-radius: 14px;
+  line-height: 1.6;
+  font-size: var(--kh-text-base, 0.875rem);
+
+  &.user {
+    align-self: flex-end;
+    background: linear-gradient(135deg, #3b82f6 0%, #1d4ed8 100%);
+    color: #fff;
+    border-bottom-right-radius: 4px;
+
+    .message-time { color: rgba(255, 255, 255, 0.7); }
+  }
+
+  &.assistant {
+    align-self: flex-start;
+    background: var(--kh-surface-3, #262626);
+    color: var(--kh-text-primary, #ffffff);
+    border: 1px solid var(--kh-border-subtle, rgba(255, 255, 255, 0.10));
+    border-bottom-left-radius: 4px;
+
+    &.selected {
+      border-left: 3px solid var(--kh-accent, #fbbf24);
+    }
+  }
+
+  &.processing {
+    background: var(--kh-surface-3, #262626);
+    border: 1px solid var(--kh-border-subtle, rgba(255, 255, 255, 0.10));
+    border-bottom-left-radius: 4px;
+  }
+}
+
+.message-content {
+  word-break: break-word;
+
+  // Markdown content styling
+  &.markdown-body {
+    h1, h2, h3, h4, h5, h6 {
+      color: var(--kh-text-primary, #ffffff);
+      margin-top: 12px;
+      margin-bottom: 6px;
+      &:first-child { margin-top: 0; }
+    }
+    p { margin: 6px 0; }
+    code {
+      font-family: var(--kh-font-mono, 'JetBrains Mono', monospace);
+      font-size: 0.8125rem;
+      background: var(--kh-surface-4, #333333);
+      padding: 1px 4px;
+      border-radius: 3px;
+    }
+    pre {
+      background: var(--kh-surface-4, #333333);
+      border-radius: var(--kh-radius-md, 8px);
+      padding: 10px 14px;
+      overflow-x: auto;
+      code { background: none; padding: 0; }
+    }
+    ul, ol { padding-left: 20px; }
+    strong { color: var(--kh-text-primary, #ffffff); }
+    hr {
+      border: none;
+      border-top: 1px solid var(--kh-border-subtle, rgba(255, 255, 255, 0.10));
+      margin: 12px 0;
+    }
+    a { color: var(--kh-accent, #fbbf24); }
+  }
+}
+
+.message-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 4px;
+}
+
+.message-time {
+  font-size: 0.6875rem;
+  color: var(--kh-text-muted, #71717a);
+}
+
+.tree-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.6875rem;
+  color: var(--kh-accent, #fbbf24);
+  background: none;
+  border: none;
+  cursor: pointer;
+  padding: 0;
+  opacity: 0.8;
+
+  mat-icon {
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
+  }
+
+  &:hover { opacity: 1; }
+}
+
+// --- Processing indicator ---
+.processing-status {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.processing-text {
+  font-size: var(--kh-text-sm, 0.8125rem);
+  color: var(--kh-text-tertiary, #a1a1aa);
+}
+
+.typing-indicator {
+  display: flex;
+  gap: 4px;
+  padding: 4px 0;
+
+  span {
+    width: 7px;
+    height: 7px;
+    background: var(--kh-text-muted, #71717a);
+    border-radius: 50%;
+    animation: bounce 1.4s infinite ease-in-out;
+    &:nth-child(1) { animation-delay: 0s; }
+    &:nth-child(2) { animation-delay: 0.2s; }
+    &:nth-child(3) { animation-delay: 0.4s; }
+  }
+}
+
+@keyframes bounce {
+  0%, 80%, 100% { transform: translateY(0); }
+  40% { transform: translateY(-5px); }
+}
+
+// --- Input form ---
+.input-form {
+  display: flex;
+  gap: 10px;
+  align-items: flex-start;
+  padding: 12px 16px;
+  border-top: 1px solid var(--kh-border, rgba(255, 255, 255, 0.16));
+  flex-shrink: 0;
+
+  .message-input { flex: 1; }
+  button[mat-fab] { margin-top: 4px; }
+}
+
+// ============================================================================
+// Agent Hierarchy Panel
+// ============================================================================
+
+.tree-container {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+
+  &::-webkit-scrollbar { width: 6px; }
+  &::-webkit-scrollbar-track { background: transparent; }
+  &::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 3px;
+    &:hover { background: rgba(255, 255, 255, 0.15); }
+  }
+}
+
+// --- Empty state ---
+.tree-empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  padding: 32px;
+  text-align: center;
+
+  mat-icon {
+    font-size: 48px;
+    width: 48px;
+    height: 48px;
+    color: var(--kh-text-muted, #71717a);
+    opacity: 0.4;
+    margin-bottom: 12px;
+  }
+
+  p {
+    font-size: var(--kh-text-sm, 0.8125rem);
+    color: var(--kh-text-muted, #71717a);
+    max-width: 280px;
+  }
+}
+
+// --- Live tree (during processing) ---
+.live-tree {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.tree-node {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: var(--kh-radius-sm, 6px);
+  position: relative;
+  animation: slideIn 0.25s ease;
+
+  .node-connector {
+    position: absolute;
+    top: 0;
+    bottom: 50%;
+    width: 1px;
+    background: var(--kh-border-subtle, rgba(255, 255, 255, 0.10));
+  }
+
+  .node-status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+  }
+
+  .node-content {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    min-width: 0;
+  }
+
+  .node-name {
+    font-size: var(--kh-text-sm, 0.8125rem);
+    font-weight: 600;
+    color: var(--kh-text-primary, #ffffff);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  .node-detail {
+    font-size: var(--kh-text-xs, 0.75rem);
+    color: var(--kh-text-muted, #71717a);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  // Status-specific colors
+  &.status-spawned .node-status-dot { background: var(--kh-info, #93c5fd); }
+  &.status-analysing .node-status-dot,
+  &.status-decomposing .node-status-dot {
+    background: var(--kh-warning, #fbbf24);
+    animation: pulse 1.5s ease-in-out infinite;
+  }
+  &.status-answering .node-status-dot,
+  &.status-deliberating .node-status-dot,
+  &.status-synthesising .node-status-dot {
+    background: var(--kh-accent, #fbbf24);
+    animation: pulse 1.5s ease-in-out infinite;
+  }
+  &.status-complete .node-status-dot { background: var(--kh-success, #4ade80); }
+  &.status-budget_warning .node-status-dot { background: var(--kh-error, #f87171); }
+  &.status-knowledge_reused .node-status-dot { background: var(--kh-info, #93c5fd); }
+
+  &:hover {
+    background: var(--kh-glass, rgba(255, 255, 255, 0.06));
+  }
+}
+
+@keyframes slideIn {
+  from { opacity: 0; transform: translateX(-8px); }
+  to { opacity: 1; transform: translateX(0); }
+}
+
+@keyframes pulse {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.6; transform: scale(1.3); }
+}
+
+// --- Result tree (completed) ---
+.result-tree {
+  display: flex;
+  flex-direction: column;
+}
+
+.result-node {
+  position: relative;
+  margin-left: 8px;
+
+  &.has-children > .node-row {
+    cursor: pointer;
+  }
+}
+
+.node-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 6px 8px;
+  border-radius: var(--kh-radius-sm, 6px);
+  cursor: pointer;
+  transition: background var(--kh-transition, 0.15s ease);
+
+  &:hover {
+    background: var(--kh-glass, rgba(255, 255, 255, 0.06));
+  }
+
+  .node-status-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    margin-top: 5px;
+
+    &.complete { background: var(--kh-success, #4ade80); }
+  }
+
+  .expand-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    color: var(--kh-text-muted, #71717a);
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+
+  .expand-spacer {
+    width: 18px;
+    flex-shrink: 0;
+  }
+
+  .node-info {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .node-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+
+  .node-name {
+    font-size: var(--kh-text-sm, 0.8125rem);
+    font-weight: 600;
+    color: var(--kh-text-primary, #ffffff);
+  }
+
+  .cache-badge {
+    font-size: 0.625rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 1px 6px;
+    border-radius: var(--kh-radius-full, 9999px);
+    background: var(--kh-info-subtle, rgba(147, 197, 253, 0.18));
+    color: var(--kh-info, #93c5fd);
+  }
+
+  .node-question {
+    font-size: var(--kh-text-xs, 0.75rem);
+    color: var(--kh-text-tertiary, #a1a1aa);
+    margin-top: 2px;
+    line-height: 1.4;
+  }
+
+  .confidence-bar {
+    height: 3px;
+    width: 100%;
+    max-width: 120px;
+    background: var(--kh-surface-4, #333333);
+    border-radius: 2px;
+    margin-top: 4px;
+    overflow: hidden;
+
+    .confidence-fill {
+      height: 100%;
+      background: var(--kh-accent, #fbbf24);
+      border-radius: 2px;
+      transition: width 0.3s ease;
+    }
+  }
+}
+
+// --- Node detail panel ---
+.node-detail-panel {
+  margin: 4px 0 4px 32px;
+  padding: 10px 14px;
+  background: var(--kh-surface-3, #262626);
+  border-radius: var(--kh-radius-md, 8px);
+  border: 1px solid var(--kh-border-subtle, rgba(255, 255, 255, 0.10));
+
+  .node-answer {
+    font-size: var(--kh-text-sm, 0.8125rem);
+    color: var(--kh-text-secondary, #d4d4d8);
+    line-height: 1.6;
+
+    &.markdown-body {
+      h1, h2, h3 {
+        font-size: var(--kh-text-base, 0.875rem);
+        color: var(--kh-text-primary, #ffffff);
+        margin: 8px 0 4px;
+        &:first-child { margin-top: 0; }
+      }
+      p { margin: 4px 0; }
+      code {
+        font-family: var(--kh-font-mono, 'JetBrains Mono', monospace);
+        font-size: 0.75rem;
+        background: var(--kh-surface-4, #333333);
+        padding: 1px 4px;
+        border-radius: 3px;
+      }
+      pre {
+        background: var(--kh-surface-4, #333333);
+        border-radius: var(--kh-radius-sm, 6px);
+        padding: 8px 12px;
+        overflow-x: auto;
+        code { background: none; padding: 0; }
+      }
+      strong { color: var(--kh-text-primary, #ffffff); }
+    }
+  }
+
+  .node-deliberation {
+    display: flex;
+    align-items: flex-start;
+    gap: 6px;
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid var(--kh-border-subtle, rgba(255, 255, 255, 0.10));
+    font-size: var(--kh-text-xs, 0.75rem);
+    color: var(--kh-text-muted, #71717a);
+    font-style: italic;
+
+    mat-icon {
+      font-size: 14px;
+      width: 14px;
+      height: 14px;
+      color: var(--kh-warning, #fbbf24);
+      flex-shrink: 0;
+      margin-top: 1px;
+    }
+  }
+}
+
+// --- Node children ---
+.node-children {
+  margin-left: 16px;
+  padding-left: 12px;
+  border-left: 1px solid var(--kh-border-subtle, rgba(255, 255, 255, 0.10));
+}
+
+// --- Knowledge base section ---
+.knowledge-section {
+  border-top: 1px solid var(--kh-border, rgba(255, 255, 255, 0.16));
+  flex-shrink: 0;
+}
+
+.knowledge-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 10px 16px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: var(--kh-text-sm, 0.8125rem);
+  font-weight: 600;
+  color: var(--kh-text-secondary, #d4d4d8);
+
+  mat-icon {
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    color: var(--kh-text-muted, #71717a);
+  }
+
+  &:hover {
+    background: var(--kh-glass, rgba(255, 255, 255, 0.06));
+  }
+}
+
+.knowledge-entries {
+  max-height: 200px;
+  overflow-y: auto;
+  padding: 0 16px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+
+  &::-webkit-scrollbar { width: 6px; }
+  &::-webkit-scrollbar-track { background: transparent; }
+  &::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 3px;
+  }
+}
+
+.knowledge-entry {
+  padding: 8px 10px;
+  background: var(--kh-surface-3, #262626);
+  border-radius: var(--kh-radius-sm, 6px);
+  border: 1px solid var(--kh-border-subtle, rgba(255, 255, 255, 0.10));
+
+  .ke-agent {
+    display: block;
+    font-size: var(--kh-text-xs, 0.75rem);
+    font-weight: 600;
+    color: var(--kh-accent, #fbbf24);
+    margin-bottom: 2px;
+  }
+
+  .ke-finding {
+    display: block;
+    font-size: var(--kh-text-xs, 0.75rem);
+    color: var(--kh-text-secondary, #d4d4d8);
+    line-height: 1.4;
+  }
+
+  .ke-meta {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-top: 4px;
+  }
+
+  .ke-confidence {
+    font-size: 0.625rem;
+    font-weight: 600;
+    padding: 1px 6px;
+    border-radius: var(--kh-radius-full, 9999px);
+    background: var(--kh-accent-muted, rgba(251, 191, 36, 0.12));
+    color: var(--kh-accent, #fbbf24);
+  }
+
+  .ke-tag {
+    font-size: 0.625rem;
+    padding: 1px 6px;
+    border-radius: var(--kh-radius-full, 9999px);
+    background: var(--kh-glass, rgba(255, 255, 255, 0.06));
+    color: var(--kh-text-muted, #71717a);
+  }
+}
+
+// ============================================================================
+// Mobile Tab Bar
+// ============================================================================
+
+.mobile-tab-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  background: var(--kh-surface-2, #171717);
+  border-top: 1px solid var(--kh-border, rgba(255, 255, 255, 0.16));
+  z-index: 100;
+
+  button {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    padding: 12px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-size: var(--kh-text-sm, 0.8125rem);
+    color: var(--kh-text-muted, #71717a);
+    position: relative;
+
+    mat-icon {
+      font-size: 20px;
+      width: 20px;
+      height: 20px;
+    }
+
+    &.active {
+      color: var(--kh-accent, #fbbf24);
+    }
+
+    .activity-badge {
+      position: absolute;
+      top: 6px;
+      right: calc(50% - 28px);
+      font-size: 0.5625rem;
+      font-weight: 700;
+      padding: 1px 4px;
+      border-radius: var(--kh-radius-full, 9999px);
+      background: var(--kh-success, #4ade80);
+      color: var(--kh-surface-0, #000000);
+    }
+  }
+}
+
+// ============================================================================
+// Responsive
+// ============================================================================
+
+@media (max-width: 1024px) {
+  .deepthought-layout {
+    height: calc(100vh - 200px); // Account for tab bar
+
+    &.mobile {
+      .chat-panel { display: none; }
+      .hierarchy-panel { display: none; }
+
+      &.show-chat .chat-panel { display: flex; flex: 1; }
+      &.show-tree .hierarchy-panel { display: flex; flex: 1; }
+    }
+  }
+}
+
+@media (max-width: 600px) {
+  .settings-bar {
+    flex-direction: column;
+    gap: 12px;
+  }
+
+  .example-chip {
+    font-size: var(--kh-text-xs, 0.75rem);
+  }
+
+  .message {
+    max-width: 92%;
+  }
+}

--- a/user-interface/src/app/components/deepthought-dashboard/deepthought-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/deepthought-dashboard/deepthought-dashboard.component.spec.ts
@@ -1,0 +1,78 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideAnimations } from '@angular/platform-browser/animations';
+import { DeepthoughtDashboardComponent } from './deepthought-dashboard.component';
+
+describe('DeepthoughtDashboardComponent', () => {
+  let component: DeepthoughtDashboardComponent;
+  let fixture: ComponentFixture<DeepthoughtDashboardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [DeepthoughtDashboardComponent],
+      providers: [provideHttpClient(), provideAnimations()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(DeepthoughtDashboardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should start with empty messages', () => {
+    expect(component.messages.length).toBe(0);
+  });
+
+  it('should format agent names correctly', () => {
+    expect(component.formatAgentName('quantum_physics_expert')).toBe('Quantum Physics Expert');
+    expect(component.formatAgentName('general_analyst')).toBe('General Analyst');
+  });
+
+  it('should count agents in tree', () => {
+    const tree = {
+      agent_id: '1',
+      agent_name: 'root',
+      depth: 0,
+      focus_question: 'q',
+      answer: 'a',
+      confidence: 0.9,
+      was_decomposed: true,
+      deliberation_notes: null,
+      reused_from_cache: false,
+      child_results: [
+        {
+          agent_id: '2',
+          agent_name: 'child',
+          depth: 1,
+          focus_question: 'q2',
+          answer: 'a2',
+          confidence: 0.8,
+          was_decomposed: false,
+          deliberation_notes: null,
+          reused_from_cache: false,
+          child_results: [],
+        },
+      ],
+    };
+    expect(component.countAgents(tree)).toBe(2);
+  });
+
+  it('should toggle settings', () => {
+    expect(component.showSettings).toBe(false);
+    component.toggleSettings();
+    expect(component.showSettings).toBe(true);
+    component.toggleSettings();
+    expect(component.showSettings).toBe(false);
+  });
+
+  it('should clear state on new conversation', () => {
+    component.messages = [{ role: 'user', content: 'test', timestamp: '2024-01-01' }];
+    component.newConversation();
+    expect(component.messages.length).toBe(0);
+    expect(component.conversationHistory.length).toBe(0);
+    expect(component.selectedTreeSnapshot).toBeNull();
+  });
+});

--- a/user-interface/src/app/components/deepthought-dashboard/deepthought-dashboard.component.ts
+++ b/user-interface/src/app/components/deepthought-dashboard/deepthought-dashboard.component.ts
@@ -1,0 +1,338 @@
+import {
+  Component,
+  ViewChild,
+  ElementRef,
+  AfterViewChecked,
+  OnDestroy,
+  inject,
+  HostListener,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule, FormControl, Validators } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatSliderModule } from '@angular/material/slider';
+import { MatSelectModule } from '@angular/material/select';
+import { Subscription } from 'rxjs';
+import { marked } from 'marked';
+
+import { DeepthoughtApiService, StreamEvent } from '../../services/deepthought-api.service';
+import type {
+  AgentResult,
+  ChatMessage,
+  DecompositionStrategy,
+  KnowledgeEntry,
+  LiveAgentNode,
+  AgentNodeStatus,
+} from '../../models/deepthought.model';
+import { DECOMPOSITION_STRATEGIES } from '../../models/deepthought.model';
+
+@Component({
+  selector: 'app-deepthought-dashboard',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FormsModule,
+    ReactiveFormsModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatTooltipModule,
+    MatSliderModule,
+    MatSelectModule,
+  ],
+  templateUrl: './deepthought-dashboard.component.html',
+  styleUrl: './deepthought-dashboard.component.scss',
+})
+export class DeepthoughtDashboardComponent implements AfterViewChecked, OnDestroy {
+  @ViewChild('messagesContainer') messagesContainer!: ElementRef<HTMLDivElement>;
+
+  private readonly api = inject(DeepthoughtApiService);
+  private streamSub: Subscription | null = null;
+
+  // Chat state
+  messages: ChatMessage[] = [];
+  conversationHistory: { role: string; content: string }[] = [];
+  messageControl = new FormControl('', [Validators.required, Validators.minLength(1)]);
+  isProcessing = false;
+  error: string | null = null;
+  lastFailedMessage: string | null = null;
+
+  // Agent tree state
+  liveAgentNodes = new Map<string, LiveAgentNode>();
+  activeAgentCount = 0;
+  selectedTreeSnapshot: AgentResult | null = null;
+  selectedKnowledge: KnowledgeEntry[] = [];
+  expandedNodes = new Set<string>();
+  showKnowledge = false;
+
+  // Settings
+  showSettings = false;
+  maxDepth = 3;
+  decompositionStrategy: DecompositionStrategy = 'auto';
+  strategies = DECOMPOSITION_STRATEGIES;
+
+  // Mobile
+  isMobile = false;
+  mobileTab: 'chat' | 'tree' = 'chat';
+
+  // Welcome state
+  readonly exampleQuestions = [
+    'What are the economic implications of universal basic income?',
+    'Compare microservices vs monolith architectures for a startup',
+    'Should a mid-size company adopt AI for customer support?',
+    'What is the future of quantum computing in cryptography?',
+  ];
+
+  constructor() {
+    this.checkMobile();
+  }
+
+  @HostListener('window:resize')
+  onResize(): void {
+    this.checkMobile();
+  }
+
+  ngAfterViewChecked(): void {
+    this.scrollToBottom();
+  }
+
+  ngOnDestroy(): void {
+    this.streamSub?.unsubscribe();
+  }
+
+  // --- Actions ---
+
+  onSubmit(): void {
+    const msg = this.messageControl.value?.trim();
+    if (!msg || this.isProcessing) return;
+    this.sendMessage(msg);
+  }
+
+  sendMessage(message: string): void {
+    this.messageControl.reset('');
+    this.error = null;
+    this.lastFailedMessage = null;
+
+    // Push user message
+    this.messages = [
+      ...this.messages,
+      { role: 'user', content: message, timestamp: new Date().toISOString() },
+    ];
+    this.conversationHistory = [
+      ...this.conversationHistory,
+      { role: 'user', content: message },
+    ];
+
+    // Reset live tree
+    this.liveAgentNodes = new Map();
+    this.activeAgentCount = 0;
+    this.isProcessing = true;
+
+    // Start SSE stream
+    this.streamSub?.unsubscribe();
+    this.streamSub = this.api
+      .askStream({
+        message,
+        max_depth: this.maxDepth,
+        conversation_history: this.conversationHistory,
+        decomposition_strategy: this.decompositionStrategy,
+      })
+      .subscribe({
+        next: (event: StreamEvent) => this.handleStreamEvent(event),
+        error: () => {
+          this.error = 'Connection lost. Please try again.';
+          this.lastFailedMessage = message;
+          this.isProcessing = false;
+        },
+      });
+  }
+
+  retryLastMessage(): void {
+    if (this.lastFailedMessage) {
+      // Remove the failed user message from history to avoid duplicates
+      this.messages = this.messages.slice(0, -1);
+      this.conversationHistory = this.conversationHistory.slice(0, -1);
+      this.sendMessage(this.lastFailedMessage);
+    }
+  }
+
+  toggleSettings(): void {
+    this.showSettings = !this.showSettings;
+  }
+
+  newConversation(): void {
+    this.streamSub?.unsubscribe();
+    this.messages = [];
+    this.conversationHistory = [];
+    this.liveAgentNodes = new Map();
+    this.activeAgentCount = 0;
+    this.selectedTreeSnapshot = null;
+    this.selectedKnowledge = [];
+    this.expandedNodes = new Set();
+    this.isProcessing = false;
+    this.error = null;
+    this.lastFailedMessage = null;
+    this.showKnowledge = false;
+  }
+
+  selectTree(tree: AgentResult): void {
+    this.selectedTreeSnapshot = tree;
+    // Find matching knowledge entries from the message
+    const msg = this.messages.find((m) => m.agentTree === tree);
+    this.selectedKnowledge = [];
+    // Collect knowledge from the response events if stored, otherwise empty
+    if (msg) {
+      // Knowledge entries are stored at the response level, not on individual messages.
+      // We'll look for the matching response in our history.
+      const responseMsg = this.messages.find(
+        (m) => m.agentTree === tree && m.role === 'assistant'
+      );
+      if (responseMsg && (responseMsg as ChatMessage & { knowledge?: KnowledgeEntry[] }).knowledge) {
+        this.selectedKnowledge =
+          (responseMsg as ChatMessage & { knowledge?: KnowledgeEntry[] }).knowledge ?? [];
+      }
+    }
+    this.expandedNodes = new Set();
+    // Auto-expand root
+    this.expandedNodes.add(tree.agent_id);
+
+    if (this.isMobile) {
+      this.mobileTab = 'tree';
+    }
+  }
+
+  toggleNode(agentId: string): void {
+    if (this.expandedNodes.has(agentId)) {
+      this.expandedNodes.delete(agentId);
+    } else {
+      this.expandedNodes.add(agentId);
+    }
+  }
+
+  // --- Helpers ---
+
+  get liveAgentNodesArray(): LiveAgentNode[] {
+    return Array.from(this.liveAgentNodes.values());
+  }
+
+  formatAgentName(name: string): string {
+    return name
+      .replace(/_/g, ' ')
+      .replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+
+  formatTime(timestamp: string): string {
+    if (!timestamp) return '';
+    try {
+      return new Date(timestamp).toLocaleTimeString([], {
+        hour: '2-digit',
+        minute: '2-digit',
+      });
+    } catch {
+      return '';
+    }
+  }
+
+  renderMarkdown(content: string): string {
+    if (!content) return '';
+    return marked.parse(content, { async: false }) as string;
+  }
+
+  countAgents(node: AgentResult): number {
+    let count = 1;
+    for (const child of node.child_results ?? []) {
+      count += this.countAgents(child);
+    }
+    return count;
+  }
+
+  getMaxDepth(node: AgentResult): number {
+    if (!node.child_results?.length) return node.depth;
+    return Math.max(...node.child_results.map((c) => this.getMaxDepth(c)));
+  }
+
+  // --- Private ---
+
+  private handleStreamEvent(event: StreamEvent): void {
+    switch (event.type) {
+      case 'agent_event': {
+        const e = event.payload;
+        const status = this.eventTypeToStatus(e.event_type);
+        this.liveAgentNodes.set(e.agent_id, {
+          agent_id: e.agent_id,
+          agent_name: e.agent_name,
+          depth: e.depth,
+          status,
+          detail: e.detail,
+        });
+        // Recount active agents
+        this.activeAgentCount = this.liveAgentNodes.size;
+        break;
+      }
+      case 'result': {
+        const resp = event.payload;
+        const assistantMsg: ChatMessage & { knowledge?: KnowledgeEntry[] } = {
+          role: 'assistant',
+          content: resp.answer,
+          timestamp: new Date().toISOString(),
+          agentTree: resp.agent_tree,
+          totalAgents: resp.total_agents_spawned,
+          knowledge: resp.knowledge_entries,
+        };
+        this.messages = [...this.messages, assistantMsg];
+        this.conversationHistory = [
+          ...this.conversationHistory,
+          { role: 'assistant', content: resp.answer },
+        ];
+        this.selectedTreeSnapshot = resp.agent_tree;
+        this.selectedKnowledge = resp.knowledge_entries ?? [];
+        this.expandedNodes = new Set([resp.agent_tree.agent_id]);
+        break;
+      }
+      case 'error':
+        this.error = event.payload;
+        this.lastFailedMessage = this.messages.at(-1)?.role === 'user'
+          ? this.messages.at(-1)!.content
+          : null;
+        this.isProcessing = false;
+        break;
+      case 'done':
+        this.isProcessing = false;
+        this.liveAgentNodes = new Map();
+        break;
+    }
+  }
+
+  private eventTypeToStatus(eventType: string): AgentNodeStatus {
+    const map: Record<string, AgentNodeStatus> = {
+      agent_spawned: 'spawned',
+      agent_analysing: 'analysing',
+      agent_answering: 'answering',
+      agent_decomposing: 'decomposing',
+      agent_deliberating: 'deliberating',
+      agent_synthesising: 'synthesising',
+      agent_complete: 'complete',
+      budget_warning: 'budget_warning',
+      knowledge_reused: 'knowledge_reused',
+    };
+    return map[eventType] ?? 'spawned';
+  }
+
+  private scrollToBottom(): void {
+    if (this.messagesContainer?.nativeElement) {
+      const el = this.messagesContainer.nativeElement;
+      el.scrollTop = el.scrollHeight;
+    }
+  }
+
+  private checkMobile(): void {
+    this.isMobile = window.innerWidth <= 1024;
+  }
+}

--- a/user-interface/src/app/models/deepthought.model.ts
+++ b/user-interface/src/app/models/deepthought.model.ts
@@ -1,0 +1,114 @@
+// ---------------------------------------------------------------------------
+// Deepthought Recursive Agent System — Frontend Models
+// ---------------------------------------------------------------------------
+
+export type DecompositionStrategy =
+  | 'auto'
+  | 'by_discipline'
+  | 'by_concern'
+  | 'by_option'
+  | 'by_perspective'
+  | 'none';
+
+export type AgentEventType =
+  | 'agent_spawned'
+  | 'agent_analysing'
+  | 'agent_answering'
+  | 'agent_decomposing'
+  | 'agent_deliberating'
+  | 'agent_synthesising'
+  | 'agent_complete'
+  | 'budget_warning'
+  | 'knowledge_reused';
+
+export interface AgentEvent {
+  event_type: AgentEventType;
+  agent_id: string;
+  agent_name: string;
+  depth: number;
+  detail: string;
+}
+
+export interface KnowledgeEntry {
+  agent_id: string;
+  agent_name: string;
+  focus_question: string;
+  finding: string;
+  confidence: number;
+  tags: string[];
+}
+
+export interface AgentResult {
+  agent_id: string;
+  agent_name: string;
+  depth: number;
+  focus_question: string;
+  answer: string;
+  confidence: number;
+  child_results: AgentResult[];
+  was_decomposed: boolean;
+  deliberation_notes: string | null;
+  reused_from_cache: boolean;
+}
+
+export interface DeepthoughtRequest {
+  message: string;
+  max_depth?: number;
+  conversation_history?: { role: string; content: string }[];
+  decomposition_strategy?: DecompositionStrategy;
+}
+
+export interface DeepthoughtResponse {
+  answer: string;
+  agent_tree: AgentResult;
+  total_agents_spawned: number;
+  max_depth_reached: number;
+  knowledge_entries: KnowledgeEntry[];
+  events: AgentEvent[];
+}
+
+// ---------------------------------------------------------------------------
+// UI-only types
+// ---------------------------------------------------------------------------
+
+export type AgentNodeStatus =
+  | 'spawned'
+  | 'analysing'
+  | 'answering'
+  | 'decomposing'
+  | 'deliberating'
+  | 'synthesising'
+  | 'complete'
+  | 'budget_warning'
+  | 'knowledge_reused';
+
+export interface LiveAgentNode {
+  agent_id: string;
+  agent_name: string;
+  depth: number;
+  status: AgentNodeStatus;
+  detail: string;
+}
+
+export interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: string;
+  agentTree?: AgentResult;
+  totalAgents?: number;
+}
+
+export interface DecompositionStrategyOption {
+  value: DecompositionStrategy;
+  label: string;
+  description: string;
+}
+
+export const DECOMPOSITION_STRATEGIES: DecompositionStrategyOption[] = [
+  { value: 'auto', label: 'Auto', description: 'Automatically choose the best strategy' },
+  { value: 'by_discipline', label: 'By Discipline', description: 'Decompose by knowledge domain' },
+  { value: 'by_concern', label: 'By Concern', description: 'Decompose by feasibility, cost, risk' },
+  { value: 'by_option', label: 'By Option', description: 'Evaluate each option separately' },
+  { value: 'by_perspective', label: 'By Perspective', description: 'Decompose by stakeholder viewpoint' },
+  { value: 'none', label: 'None', description: 'Direct answer without decomposition' },
+];

--- a/user-interface/src/app/services/deepthought-api.service.ts
+++ b/user-interface/src/app/services/deepthought-api.service.ts
@@ -1,0 +1,128 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { environment } from '../../environments/environment';
+import type {
+  AgentEvent,
+  DeepthoughtRequest,
+  DeepthoughtResponse,
+} from '../models/deepthought.model';
+
+/** Discriminated union for SSE stream emissions. */
+export type StreamEvent =
+  | { type: 'agent_event'; payload: AgentEvent }
+  | { type: 'result'; payload: DeepthoughtResponse }
+  | { type: 'error'; payload: string }
+  | { type: 'done' };
+
+@Injectable({ providedIn: 'root' })
+export class DeepthoughtApiService {
+  private readonly baseUrl = environment.deepthoughtApiUrl;
+
+  /**
+   * Stream agent events via SSE from the POST endpoint.
+   *
+   * Uses `fetch()` + `ReadableStream` because `EventSource` only supports GET.
+   * Returns an Observable that emits typed `StreamEvent` items and completes
+   * when the server sends the `done` event or the connection closes.
+   */
+  askStream(request: DeepthoughtRequest): Observable<StreamEvent> {
+    const url = `${this.baseUrl}/deepthought/ask/stream`;
+
+    return new Observable<StreamEvent>((subscriber) => {
+      const controller = new AbortController();
+
+      fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(request),
+        signal: controller.signal,
+      })
+        .then((res) => {
+          if (!res.ok) {
+            subscriber.next({ type: 'error', payload: `HTTP ${res.status}: ${res.statusText}` });
+            subscriber.complete();
+            return;
+          }
+          const reader = res.body!.getReader();
+          const decoder = new TextDecoder();
+          let buffer = '';
+
+          const pump = (): Promise<void> =>
+            reader.read().then(({ done, value }) => {
+              if (done) {
+                subscriber.next({ type: 'done' });
+                subscriber.complete();
+                return;
+              }
+
+              buffer += decoder.decode(value, { stream: true });
+              const blocks = buffer.split('\n\n');
+              // Keep last incomplete block in buffer
+              buffer = blocks.pop() ?? '';
+
+              for (const block of blocks) {
+                const parsed = parseSSEBlock(block);
+                if (parsed) {
+                  subscriber.next(parsed);
+                  if (parsed.type === 'done') {
+                    subscriber.complete();
+                    return;
+                  }
+                }
+              }
+
+              return pump();
+            });
+
+          pump().catch((err) => {
+            if (err.name !== 'AbortError') {
+              subscriber.next({ type: 'error', payload: String(err) });
+              subscriber.complete();
+            }
+          });
+        })
+        .catch((err) => {
+          if (err.name !== 'AbortError') {
+            subscriber.next({ type: 'error', payload: String(err) });
+            subscriber.complete();
+          }
+        });
+
+      // Teardown: abort the fetch when unsubscribed
+      return () => controller.abort();
+    });
+  }
+}
+
+/** Parse a single SSE text block into a typed StreamEvent. */
+function parseSSEBlock(block: string): StreamEvent | null {
+  let eventType = '';
+  let data = '';
+
+  for (const line of block.split('\n')) {
+    if (line.startsWith('event: ')) {
+      eventType = line.slice(7).trim();
+    } else if (line.startsWith('data: ')) {
+      data = line.slice(6);
+    }
+  }
+
+  if (!eventType) return null;
+
+  try {
+    switch (eventType) {
+      case 'agent_event':
+        return { type: 'agent_event', payload: JSON.parse(data) as AgentEvent };
+      case 'result':
+        return { type: 'result', payload: JSON.parse(data) as DeepthoughtResponse };
+      case 'error':
+        return { type: 'error', payload: JSON.parse(data).error ?? data };
+      case 'done':
+        return { type: 'done' };
+      default:
+        return null;
+    }
+  } catch {
+    return null;
+  }
+}

--- a/user-interface/src/environments/environment.prod.ts
+++ b/user-interface/src/environments/environment.prod.ts
@@ -26,4 +26,5 @@ export const environment = {
   agenticTeamProvisioningApiUrl: `${apiBase}/api/agentic-team-provisioning`,
   startupAdvisorApiUrl: `${apiBase}/api/startup-advisor`,
   personaTestingApiUrl: `${apiBase}/api/user-agent-founder`,
+  deepthoughtApiUrl: `${apiBase}/api/deepthought`,
 };

--- a/user-interface/src/environments/environment.ts
+++ b/user-interface/src/environments/environment.ts
@@ -27,5 +27,6 @@ export const environment = {
   agenticTeamProvisioningApiUrl: `${apiBase}/api/agentic-team-provisioning`,
   startupAdvisorApiUrl: `${apiBase}/api/startup-advisor`,
   personaTestingApiUrl: `${apiBase}/api/user-agent-founder`,
+  deepthoughtApiUrl: `${apiBase}/api/deepthought`,
 };
 


### PR DESCRIPTION
Two-panel dashboard at /deepthought with real-time SSE streaming:
- Chat panel with markdown rendering, conversation history, and configurable settings (max depth, decomposition strategy)
- Agent hierarchy panel showing live tree visualization during processing with color-coded status dots, expandable completed nodes with confidence bars, and collapsible knowledge base
- Welcome state with example questions, mobile-responsive tab layout, error recovery with retry

https://claude.ai/code/session_01Byexfa1JVdy2McnoXfXCxi