### PR TITLE
fix(deepthought): avoid duplicating active turn in conversation history

### DIFF
--- a/user-interface/src/app/components/deepthought-dashboard/deepthought-dashboard.component.ts
+++ b/user-interface/src/app/components/deepthought-dashboard/deepthought-dashboard.component.ts
@@ -120,7 +120,13 @@ export class DeepthoughtDashboardComponent implements AfterViewChecked, OnDestro
     this.error = null;
     this.lastFailedMessage = null;
 
-    // Push user message
+    // Capture history *before* appending the current turn — the backend
+    // receives the active question via the top-level `message` field, so
+    // including it in `conversation_history` too would duplicate it in the
+    // model context, wasting tokens and skewing decomposition decisions.
+    const priorHistory = [...this.conversationHistory];
+
+    // Push user message to UI and history
     this.messages = [
       ...this.messages,
       { role: 'user', content: message, timestamp: new Date().toISOString() },
@@ -141,7 +147,7 @@ export class DeepthoughtDashboardComponent implements AfterViewChecked, OnDestro
       .askStream({
         message,
         max_depth: this.maxDepth,
-        conversation_history: this.conversationHistory,
+        conversation_history: priorHistory,
         decomposition_strategy: this.decompositionStrategy,
       })
       .subscribe({


### PR DESCRIPTION
## Summary

- Fix conversation history duplication in the Deepthought dashboard: the current user message was being sent in both the top-level `message` field and as the last entry in `conversation_history`, doubling it in the model context
- Snapshot `conversationHistory` before appending the current turn, then pass the prior-only copy to `askStream()`

## Test plan

- [ ] Send a multi-turn conversation to Deepthought and verify the backend only sees the active question once (in `message`), with prior turns in `conversation_history`
- [ ] Confirm agent decomposition quality is not skewed by repeated context
- [ ] Verify lint (`npm run lint`) and build (`npm run build`) pass

https://claude.ai/code/session_01Byexfa1JVdy2McnoXfXCxi