### PR TITLE
feat(accessibility-audit): add case study templates asset and generation tools

### DIFF
--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/approval_agent.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/approval_agent.py
@@ -1,3 +1,4 @@
+from ..models.phase_result import ApprovalResult
 from ..tools import persist_artifact, request_human_approval
 from .base import ToolContext, tool
 
@@ -9,4 +10,4 @@ def run_approval_and_comms(engagement_id: str, summary: str, tool_context: ToolC
         f"{tool_context.invocation_state['artifact_root']}/approval.json",
         approval.model_dump(),
     )
-    return {"phase": "approval", "artifact": artifact, "approved": approval.approved}
+    return ApprovalResult(artifact=artifact, approved=approval.approved).model_dump()

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/architecture_agent.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/architecture_agent.py
@@ -1,15 +1,77 @@
+"""Architecture Auditor — evaluates site navigation and IA for accessibility."""
+
+from __future__ import annotations
+
 from ..tools import persist_artifact
+from ..tools.architecture_tools import (
+    build_architecture_audit_report,
+    load_architecture_audit_template,
+    score_architecture_section,
+)
 from .base import ToolContext, tool
+
+
+def _flatten_checklist_items(section_def: dict) -> list[dict]:
+    """Extract all checklist items from a template section, including subsections."""
+    items: list[dict] = []
+    for sub in section_def.get("subsections", []):
+        for item in sub.get("checklist_items", []):
+            items.append(item)
+    return items
 
 
 @tool(context=True)
 def run_architecture_audit(target: str, tool_context: ToolContext) -> dict:
-    output = {
-        "target": target,
-        "navigation_consistency": "medium",
-        "recommendations": ["Improve breadcrumb semantics"],
+    """Run the site architecture and navigation accessibility audit.
+
+    Loads the structured audit template, evaluates each section's checklist
+    items against the provided results in ``tool_context.invocation_state``,
+    scores every section, and assembles the full audit report.
+
+    ``tool_context.invocation_state`` may contain:
+
+    * ``artifact_root`` — directory for persisting the output artifact.
+    * ``checklist_results`` — dict mapping checklist item IDs to
+      ``{"passed": bool, "notes": str}`` overrides.  Items not present
+      in this mapping default to ``passed=False``.
+    * ``recommendations`` — optional list of prioritized recommendation
+      strings to include in the report.
+    """
+    template = load_architecture_audit_template()
+    state = tool_context.invocation_state
+    overrides: dict = state.get("checklist_results", {})
+    recommendations: list[str] = state.get("recommendations", [])
+
+    section_results = []
+    for section_def in template.get("sections", []):
+        section_id = section_def["id"]
+        section_name = section_def["name"]
+        template_items = _flatten_checklist_items(section_def)
+
+        evaluated: list[dict] = []
+        for item in template_items:
+            item_id = item["id"]
+            override = overrides.get(item_id, {})
+            evaluated.append(
+                {
+                    "id": item_id,
+                    "label": item.get("label", ""),
+                    "passed": override.get("passed", False),
+                    "notes": override.get("notes", ""),
+                    "wcag_ref": item.get("wcag_ref"),
+                    "test_method": item.get("test_method", ""),
+                }
+            )
+
+        scored = score_architecture_section(section_id, section_name, evaluated)
+        section_results.append(scored)
+
+    report = build_architecture_audit_report(target, section_results, recommendations)
+    artifact_path = f"{state['artifact_root']}/architecture.json"
+    artifact = persist_artifact(artifact_path, report.model_dump())
+
+    return {
+        "phase": "architecture_audit",
+        "artifact": artifact,
+        "overall_grade": report.overall_grade,
     }
-    artifact = persist_artifact(
-        f"{tool_context.invocation_state['artifact_root']}/architecture.json", output
-    )
-    return {"phase": "architecture_audit", "artifact": artifact}

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/architecture_agent.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/architecture_agent.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from ..models.architecture import BusinessImpact
 from ..tools import persist_artifact
 from ..tools.architecture_tools import (
     build_architecture_audit_report,
@@ -9,6 +10,14 @@ from ..tools.architecture_tools import (
     score_architecture_section,
 )
 from .base import ToolContext, tool
+
+# Business-impact checklist item IDs → BusinessImpact boolean fields.
+_BIA_FIELD_MAP: dict[str, str] = {
+    "bia_01": "keyboard_tasks_completable",
+    "bia_02": "screen_reader_tasks_completable",
+    "bia_03": "mobile_tasks_completable",
+    "bia_04": "legal_compliance_risk",
+}
 
 
 def _flatten_checklist_items(section_def: dict) -> list[dict]:
@@ -18,6 +27,35 @@ def _flatten_checklist_items(section_def: dict) -> list[dict]:
         for item in sub.get("checklist_items", []):
             items.append(item)
     return items
+
+
+def _extract_business_impact(
+    overrides: dict[str, dict],
+) -> BusinessImpact:
+    """Build a :class:`BusinessImpact` from the override results.
+
+    Maps the ``bia_*`` checklist items to the typed boolean fields and
+    pulls free-text lists from the ``strengths_and_opportunities``
+    overrides (keyed ``top_strengths``, ``quick_wins``,
+    ``strategic_opportunities``).
+    """
+    kwargs: dict = {}
+    for item_id, field_name in _BIA_FIELD_MAP.items():
+        override = overrides.get(item_id, {})
+        # Only set the field if the item was actually tested.
+        if "passed" in override and override["passed"] is not None:
+            kwargs[field_name] = override["passed"]
+
+    # Free-text lists live alongside the checklist overrides keyed by
+    # the field id from the YAML's ``strengths_and_opportunities`` subsection.
+    for key in ("top_strengths", "quick_wins", "strategic_opportunities"):
+        value = overrides.get(key, {})
+        if isinstance(value, list):
+            kwargs[key] = value
+        elif isinstance(value, dict) and "items" in value:
+            kwargs[key] = value["items"]
+
+    return BusinessImpact(**kwargs)
 
 
 @tool(context=True)
@@ -32,8 +70,8 @@ def run_architecture_audit(target: str, tool_context: ToolContext) -> dict:
 
     * ``artifact_root`` — directory for persisting the output artifact.
     * ``checklist_results`` — dict mapping checklist item IDs to
-      ``{"passed": bool, "notes": str}`` overrides.  Items not present
-      in this mapping default to ``passed=False``.
+      ``{"passed": bool | None, "notes": str}`` overrides.  Items not
+      present in this mapping are left as ``passed=None`` (not tested).
     * ``recommendations`` — optional list of prioritized recommendation
       strings to include in the report.
     """
@@ -56,17 +94,22 @@ def run_architecture_audit(target: str, tool_context: ToolContext) -> dict:
                 {
                     "id": item_id,
                     "label": item.get("label", ""),
-                    "passed": override.get("passed", False),
+                    "passed": override.get("passed"),  # None when not tested
                     "notes": override.get("notes", ""),
                     "wcag_ref": item.get("wcag_ref"),
+                    "wcag_level": item.get("wcag_level"),
                     "test_method": item.get("test_method", ""),
                 }
             )
 
-        scored = score_architecture_section(section_id, section_name, evaluated)
+        scored = score_architecture_section(section_id, section_name, evaluated, template)
         section_results.append(scored)
 
-    report = build_architecture_audit_report(target, section_results, recommendations)
+    report = build_architecture_audit_report(target, section_results, recommendations, template)
+
+    # Populate business impact from the business_impact_assessment results.
+    report.business_impact = _extract_business_impact(overrides)
+
     artifact_path = f"{state['artifact_root']}/architecture.json"
     artifact = persist_artifact(artifact_path, report.model_dump())
 

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/architecture_agent.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/architecture_agent.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 from ..models.architecture import BusinessImpact
-from ..tools import persist_artifact
-from ..tools.architecture_tools import (
-    build_architecture_audit_report,
-    load_architecture_audit_template,
-    score_architecture_section,
-)
+from ..models.phase_result import ArchitecturePhaseResult
+from ..tools.template_audit_engine import TemplateAuditEngine
 from .base import ToolContext, tool
+
+_TEMPLATE_NAME = "site_architecture_audit_template.yaml"
 
 # Business-impact checklist item IDs → BusinessImpact boolean fields.
 _BIA_FIELD_MAP: dict[str, str] = {
@@ -20,34 +18,14 @@ _BIA_FIELD_MAP: dict[str, str] = {
 }
 
 
-def _flatten_checklist_items(section_def: dict) -> list[dict]:
-    """Extract all checklist items from a template section, including subsections."""
-    items: list[dict] = []
-    for sub in section_def.get("subsections", []):
-        for item in sub.get("checklist_items", []):
-            items.append(item)
-    return items
-
-
-def _extract_business_impact(
-    overrides: dict[str, dict],
-) -> BusinessImpact:
-    """Build a :class:`BusinessImpact` from the override results.
-
-    Maps the ``bia_*`` checklist items to the typed boolean fields and
-    pulls free-text lists from the ``strengths_and_opportunities``
-    overrides (keyed ``top_strengths``, ``quick_wins``,
-    ``strategic_opportunities``).
-    """
+def _extract_business_impact(overrides: dict[str, dict]) -> BusinessImpact:
+    """Build a :class:`BusinessImpact` from the override results."""
     kwargs: dict = {}
     for item_id, field_name in _BIA_FIELD_MAP.items():
         override = overrides.get(item_id, {})
-        # Only set the field if the item was actually tested.
         if "passed" in override and override["passed"] is not None:
             kwargs[field_name] = override["passed"]
 
-    # Free-text lists live alongside the checklist overrides keyed by
-    # the field id from the YAML's ``strengths_and_opportunities`` subsection.
     for key in ("top_strengths", "quick_wins", "strategic_opportunities"):
         value = overrides.get(key, {})
         if isinstance(value, list):
@@ -60,61 +38,17 @@ def _extract_business_impact(
 
 @tool(context=True)
 def run_architecture_audit(target: str, tool_context: ToolContext) -> dict:
-    """Run the site architecture and navigation accessibility audit.
-
-    Loads the structured audit template, evaluates each section's checklist
-    items against the provided results in ``tool_context.invocation_state``,
-    scores every section, and assembles the full audit report.
-
-    ``tool_context.invocation_state`` may contain:
-
-    * ``artifact_root`` — directory for persisting the output artifact.
-    * ``checklist_results`` — dict mapping checklist item IDs to
-      ``{"passed": bool | None, "notes": str}`` overrides.  Items not
-      present in this mapping are left as ``passed=None`` (not tested).
-    * ``recommendations`` — optional list of prioritized recommendation
-      strings to include in the report.
-    """
-    template = load_architecture_audit_template()
+    """Run the site architecture and navigation accessibility audit."""
     state = tool_context.invocation_state
     overrides: dict = state.get("checklist_results", {})
     recommendations: list[str] = state.get("recommendations", [])
 
-    section_results = []
-    for section_def in template.get("sections", []):
-        section_id = section_def["id"]
-        section_name = section_def["name"]
-        template_items = _flatten_checklist_items(section_def)
-
-        evaluated: list[dict] = []
-        for item in template_items:
-            item_id = item["id"]
-            override = overrides.get(item_id, {})
-            evaluated.append(
-                {
-                    "id": item_id,
-                    "label": item.get("label", ""),
-                    "passed": override.get("passed"),  # None when not tested
-                    "notes": override.get("notes", ""),
-                    "wcag_ref": item.get("wcag_ref"),
-                    "wcag_level": item.get("wcag_level"),
-                    "test_method": item.get("test_method", ""),
-                }
-            )
-
-        scored = score_architecture_section(section_id, section_name, evaluated, template)
-        section_results.append(scored)
-
-    report = build_architecture_audit_report(target, section_results, recommendations, template)
-
-    # Populate business impact from the business_impact_assessment results.
+    engine = TemplateAuditEngine(_TEMPLATE_NAME)
+    report = engine.evaluate(target, overrides, recommendations)
     report.business_impact = _extract_business_impact(overrides)
+    artifact = engine.persist(report, state["artifact_root"])
 
-    artifact_path = f"{state['artifact_root']}/architecture.json"
-    artifact = persist_artifact(artifact_path, report.model_dump())
-
-    return {
-        "phase": "architecture_audit",
-        "artifact": artifact,
-        "overall_grade": report.overall_grade,
-    }
+    return ArchitecturePhaseResult(
+        artifact=artifact,
+        overall_grade=report.overall_grade,
+    ).model_dump()

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/component_auditor.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/component_auditor.py
@@ -1,4 +1,5 @@
 from ..models import Finding
+from ..models.phase_result import ComponentAuditResult
 from ..tools import build_component_inventory, persist_artifact, run_axe_scan
 from .base import StubAgent, ToolContext, tool
 
@@ -26,8 +27,7 @@ def run_component_audit(component_id: str, tool_context: ToolContext) -> dict:
             "finding": finding.model_dump(),
         },
     )
-    return {
-        "phase": "component_audit",
-        "artifact": artifact,
-        "finding_id": finding.finding_id,
-    }
+    return ComponentAuditResult(
+        artifact=artifact,
+        finding_id=finding.finding_id,
+    ).model_dump()

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/discovery_agent.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/discovery_agent.py
@@ -1,4 +1,5 @@
 from ..models import ClientProfile, SamplingPlan, ScopeDefinition
+from ..models.phase_result import DiscoveryResult
 from ..tools import collect_client_discovery, persist_artifact
 from .base import StubAgent, ToolContext, tool
 
@@ -37,8 +38,7 @@ def run_discovery(raw_answers: dict, tool_context: ToolContext) -> dict:
             "sampling_plan": sampling.model_dump(),
         },
     )
-    return {
-        "phase": "discovery",
-        "artifact": artifact,
-        "tier1_count": len(sampling.tier1_pages),
-    }
+    return DiscoveryResult(
+        artifact=artifact,
+        tier1_count=len(sampling.tier1_pages),
+    ).model_dump()

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/evidence_agent.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/evidence_agent.py
@@ -1,4 +1,5 @@
 from ..models import EvidenceBundle
+from ..models.phase_result import EvidenceResult
 from ..tools import capture_dom_snippet, capture_screenshot, persist_artifact
 from .base import ToolContext, tool
 
@@ -17,4 +18,4 @@ def run_evidence_curation(finding_id: str, target: str, tool_context: ToolContex
         f"{tool_context.invocation_state['artifact_root']}/evidence_{finding_id}.json",
         bundle.model_dump(),
     )
-    return {"phase": "evidence", "artifact": artifact, "finding_id": finding_id}
+    return EvidenceResult(artifact=artifact, finding_id=finding_id).model_dump()

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/infrastructure_agent.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/infrastructure_agent.py
@@ -1,3 +1,4 @@
+from ..models.phase_result import InfrastructureAuditResult
 from ..tools import persist_artifact
 from .base import ToolContext, tool
 
@@ -13,4 +14,4 @@ def run_infrastructure_audit(target: str, tool_context: ToolContext) -> dict:
     artifact = persist_artifact(
         f"{tool_context.invocation_state['artifact_root']}/infrastructure.json", output
     )
-    return {"phase": "infrastructure_audit", "artifact": artifact}
+    return InfrastructureAuditResult(artifact=artifact).model_dump()

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/journey_agent.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/journey_agent.py
@@ -1,3 +1,4 @@
+from ..models.phase_result import JourneyAssessmentResult
 from ..tools import (
     log_keyboard_test,
     log_mobile_accessibility_test,
@@ -18,4 +19,4 @@ def run_journey_assessment(journey_id: str, tool_context: ToolContext) -> dict:
         f"{tool_context.invocation_state['artifact_root']}/journey_{journey_id}.json",
         results,
     )
-    return {"phase": "journey_assessment", "artifact": artifact, "journey": journey_id}
+    return JourneyAssessmentResult(artifact=artifact, journey=journey_id).model_dump()

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/orchestrator.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/orchestrator.py
@@ -32,8 +32,27 @@ class OrchestratorState:
     approval_granted: bool = False
 
 
+# ---------------------------------------------------------------------------
+# Phase registry — maps phase name → (handler, phase_name_for_mark_complete)
+# Simple phases that just forward (target/id, context) and mark complete.
+# ---------------------------------------------------------------------------
+
+_SIMPLE_PHASES = {
+    "architecture_audit": run_architecture_audit,
+    "infrastructure_audit": run_infrastructure_audit,
+    "sec508_mapping": run_508_mapping,
+    "scoring_prioritization": run_scoring_and_prioritization,
+    "retest": run_retest_cycle,
+}
+
+
 class EngagementOrchestrator:
-    """Deterministic control plane for the accessibility agency workflow."""
+    """Deterministic control plane for the accessibility agency workflow.
+
+    Simple pass-through phases use :meth:`run_phase` backed by the
+    ``_SIMPLE_PHASES`` registry. Phases with pre/post logic retain
+    dedicated methods.
+    """
 
     def __init__(self, invocation_state: dict):
         self.context = ToolContext(invocation_state=invocation_state)
@@ -43,6 +62,17 @@ class EngagementOrchestrator:
     def _mark_complete(self, phase: str) -> None:
         self.state.current_phase = phase
         self.state.completed_tasks.append(phase)
+
+    # -- generic phase runner ----------------------------------------------
+
+    def run_phase(self, phase: str, *args: object) -> dict:
+        """Run a registered simple phase by name."""
+        handler = _SIMPLE_PHASES[phase]
+        result = handler(*args, self.context)
+        self._mark_complete(phase)
+        return result
+
+    # -- phases with custom pre/post logic ---------------------------------
 
     def run_discovery(self, raw_answers: dict) -> dict:
         result = run_discovery(raw_answers, self.context)
@@ -72,14 +102,10 @@ class EngagementOrchestrator:
         return result
 
     def run_architecture_audit(self, target: str) -> dict:
-        result = run_architecture_audit(target, self.context)
-        self._mark_complete("architecture_audit")
-        return result
+        return self.run_phase("architecture_audit", target)
 
     def run_infrastructure_audit(self, target: str) -> dict:
-        result = run_infrastructure_audit(target, self.context)
-        self._mark_complete("infrastructure_audit")
-        return result
+        return self.run_phase("infrastructure_audit", target)
 
     def run_wcag_coverage(self, engagement_id: str) -> dict:
         result = run_wcag_coverage(engagement_id, self.context)
@@ -88,14 +114,10 @@ class EngagementOrchestrator:
         return result
 
     def run_508_mapping(self, engagement_id: str) -> dict:
-        result = run_508_mapping(engagement_id, self.context)
-        self._mark_complete("sec508_mapping")
-        return result
+        return self.run_phase("sec508_mapping", engagement_id)
 
     def run_scoring_and_prioritization(self, engagement_id: str) -> dict:
-        result = run_scoring_and_prioritization(engagement_id, self.context)
-        self._mark_complete("scoring_prioritization")
-        return result
+        return self.run_phase("scoring_prioritization", engagement_id)
 
     def run_reporting(self, engagement_id: str) -> dict:
         self._enforce_reporting_gate()
@@ -135,15 +157,15 @@ class EngagementOrchestrator:
         return {"phase": "delivery", "status": "ready"}
 
     def run_retest_cycle(self, engagement_id: str) -> dict:
-        result = run_retest_cycle(engagement_id, self.context)
-        self._mark_complete("retest")
-        return result
+        return self.run_phase("retest", engagement_id)
 
     def run_remediation_planning(self) -> dict:
         findings = [{"finding_id": fid} for fid in self.state.findings_index]
         result = run_remediation_planning(findings, self.context)
         self._mark_complete("remediation")
         return result
+
+    # -- gates -------------------------------------------------------------
 
     def _enforce_reporting_gate(self) -> None:
         required = {

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/page_auditor.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/page_auditor.py
@@ -1,3 +1,4 @@
+from ..models.phase_result import PageAuditResult
 from ..tools import build_page_inventory, persist_artifact, run_lighthouse_accessibility
 from .base import ToolContext, tool
 
@@ -10,4 +11,4 @@ def run_page_audit(page_id: str, tool_context: ToolContext) -> dict:
     artifact = persist_artifact(
         f"{tool_context.invocation_state['artifact_root']}/page_{page_id}.json", record
     )
-    return {"phase": "page_audit", "artifact": artifact, "page": page_id}
+    return PageAuditResult(artifact=artifact, page=page_id).model_dump()

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/remediation_agent.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/remediation_agent.py
@@ -1,3 +1,4 @@
+from ..models.phase_result import RemediationResult
 from ..tools import create_jira_issues, persist_artifact
 from .base import ToolContext, tool
 
@@ -14,4 +15,4 @@ def run_remediation_planning(findings: list[dict], tool_context: ToolContext) ->
         f"{tool_context.invocation_state['artifact_root']}/remediation_plan.json",
         {"tickets": tickets, "roadmap": roadmap},
     )
-    return {"phase": "remediation", "artifact": artifact, "tickets": tickets}
+    return RemediationResult(artifact=artifact, tickets=tickets).model_dump()

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/report_agent.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/report_agent.py
@@ -1,7 +1,8 @@
-from ..models import ReportPackage
+from ..models import CaseStudy, ReportPackage
 from ..tools import (
     export_backlog_csv,
     persist_artifact,
+    render_case_study,
     render_pdf,
     write_docx_from_template,
 )
@@ -11,6 +12,21 @@ from .base import ToolContext, tool
 @tool(context=True)
 def run_reporting(engagement_id: str, findings: list[dict], tool_context: ToolContext) -> dict:
     backlog = export_backlog_csv(findings)
+
+    # Determine case study template based on engagement context
+    client_context = tool_context.invocation_state.get("client_context", {})
+    template_key = client_context.get("service_tier", "comprehensive")
+    industry = client_context.get("industry")
+
+    case_study_data = render_case_study(
+        engagement_id=engagement_id,
+        findings=findings,
+        client_context=client_context,
+        template_key=template_key,
+        industry=industry,
+    )
+    case_study = CaseStudy(**case_study_data)
+
     report = ReportPackage(
         executive_summary="Executive summary",
         technical_report=write_docx_from_template(
@@ -21,13 +37,22 @@ def run_reporting(engagement_id: str, findings: list[dict], tool_context: ToolCo
         wcag_scorecard="WCAG scorecard",
         sec508_addendum="Section 508 addendum",
         backlog_export=backlog,
+        case_study=case_study,
     )
     pdf_path = render_pdf(report.technical_report)
+
+    # Persist the case study artifact separately for easy retrieval
+    case_study_artifact = persist_artifact(
+        f"{tool_context.invocation_state['artifact_root']}/case_study_{engagement_id}.json",
+        case_study.model_dump(),
+    )
+
     artifact = persist_artifact(
         f"{tool_context.invocation_state['artifact_root']}/report_package.json",
         {
             **report.model_dump(),
             "technical_report_pdf": pdf_path,
+            "case_study_artifact": case_study_artifact,
         },
     )
     return {"phase": "reporting", "artifact": artifact}

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/report_agent.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/report_agent.py
@@ -1,4 +1,5 @@
 from ..models import CaseStudy, ReportPackage
+from ..models.phase_result import ReportingResult
 from ..tools import (
     export_backlog_csv,
     persist_artifact,
@@ -13,7 +14,6 @@ from .base import ToolContext, tool
 def run_reporting(engagement_id: str, findings: list[dict], tool_context: ToolContext) -> dict:
     backlog = export_backlog_csv(findings)
 
-    # Determine case study template based on engagement context
     client_context = tool_context.invocation_state.get("client_context", {})
     template_key = client_context.get("service_tier", "comprehensive")
     industry = client_context.get("industry")
@@ -41,7 +41,6 @@ def run_reporting(engagement_id: str, findings: list[dict], tool_context: ToolCo
     )
     pdf_path = render_pdf(report.technical_report)
 
-    # Persist the case study artifact separately for easy retrieval
     case_study_artifact = persist_artifact(
         f"{tool_context.invocation_state['artifact_root']}/case_study_{engagement_id}.json",
         case_study.model_dump(),
@@ -55,4 +54,4 @@ def run_reporting(engagement_id: str, findings: list[dict], tool_context: ToolCo
             "case_study_artifact": case_study_artifact,
         },
     )
-    return {"phase": "reporting", "artifact": artifact}
+    return ReportingResult(artifact=artifact).model_dump()

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/retest_agent.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/retest_agent.py
@@ -1,3 +1,4 @@
+from ..models.phase_result import RetestResult
 from ..tools import persist_artifact
 from .base import ToolContext, tool
 
@@ -13,4 +14,4 @@ def run_retest_cycle(engagement_id: str, tool_context: ToolContext) -> dict:
     artifact = persist_artifact(
         f"{tool_context.invocation_state['artifact_root']}/retest.json", output
     )
-    return {"phase": "retest", "artifact": artifact}
+    return RetestResult(artifact=artifact).model_dump()

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/scoring_agent.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/scoring_agent.py
@@ -1,4 +1,5 @@
 from ..models import Scorecard
+from ..models.phase_result import ScoringResult
 from ..tools import persist_artifact
 from .base import ToolContext, tool
 
@@ -12,8 +13,7 @@ def run_scoring_and_prioritization(engagement_id: str, tool_context: ToolContext
         f"{tool_context.invocation_state['artifact_root']}/scorecard.json",
         scorecard.model_dump(),
     )
-    return {
-        "phase": "scoring_prioritization",
-        "artifact": artifact,
-        "site_score": scorecard.site_score,
-    }
+    return ScoringResult(
+        artifact=artifact,
+        site_score=scorecard.site_score,
+    ).model_dump()

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/sec508_agent.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/sec508_agent.py
@@ -1,3 +1,4 @@
+from ..models.phase_result import Sec508MappingResult
 from ..tools import persist_artifact
 from .base import ToolContext, tool
 
@@ -12,4 +13,4 @@ def run_508_mapping(engagement_id: str, tool_context: ToolContext) -> dict:
     artifact = persist_artifact(
         f"{tool_context.invocation_state['artifact_root']}/sec508.json", output
     )
-    return {"phase": "sec508_mapping", "artifact": artifact}
+    return Sec508MappingResult(artifact=artifact).model_dump()

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/wcag_agent.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/agents/wcag_agent.py
@@ -1,4 +1,5 @@
 from ..models import CoverageSummary
+from ..models.phase_result import WCAGCoverageResult
 from ..tools import persist_artifact, update_wcag_checklist_xlsx
 from .base import ToolContext, tool
 
@@ -17,8 +18,7 @@ def run_wcag_coverage(engagement_id: str, tool_context: ToolContext) -> dict:
         f"{tool_context.invocation_state['artifact_root']}/coverage.json",
         summary.model_dump(),
     )
-    return {
-        "phase": "wcag_coverage",
-        "artifact": artifact,
-        "overall_coverage": summary.overall_coverage,
-    }
+    return WCAGCoverageResult(
+        artifact=artifact,
+        overall_coverage=summary.overall_coverage,
+    ).model_dump()

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/models/__init__.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/models/__init__.py
@@ -1,4 +1,11 @@
 from .approvals import ApprovalRequest
+from .architecture import (
+    ArchitectureAuditResult,
+    ArchitectureChecklistItem,
+    ArchitectureSectionResult,
+    BusinessImpact,
+    WCAGCriterionStatus,
+)
 from .deliverables import CaseStudy, DeliveryResult, ReportPackage
 from .discovery import ClientProfile, SamplingPlan, ScopeDefinition
 from .findings import CoverageSummary, EvidenceBundle, Finding, TraceabilityLink
@@ -6,6 +13,11 @@ from .scorecards import Scorecard
 
 __all__ = [
     "ApprovalRequest",
+    "ArchitectureAuditResult",
+    "ArchitectureChecklistItem",
+    "ArchitectureSectionResult",
+    "BusinessImpact",
+    "WCAGCriterionStatus",
     "CaseStudy",
     "ClientProfile",
     "CoverageSummary",

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/models/__init__.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/models/__init__.py
@@ -1,11 +1,12 @@
 from .approvals import ApprovalRequest
-from .deliverables import DeliveryResult, ReportPackage
+from .deliverables import CaseStudy, DeliveryResult, ReportPackage
 from .discovery import ClientProfile, SamplingPlan, ScopeDefinition
 from .findings import CoverageSummary, EvidenceBundle, Finding, TraceabilityLink
 from .scorecards import Scorecard
 
 __all__ = [
     "ApprovalRequest",
+    "CaseStudy",
     "ClientProfile",
     "CoverageSummary",
     "DeliveryResult",

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/models/__init__.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/models/__init__.py
@@ -9,6 +9,8 @@ from .architecture import (
 from .deliverables import CaseStudy, DeliveryResult, ReportPackage
 from .discovery import ClientProfile, SamplingPlan, ScopeDefinition
 from .findings import CoverageSummary, EvidenceBundle, Finding, TraceabilityLink
+from .grading import GradingScale
+from .phase_result import PhaseResult
 from .scorecards import Scorecard
 
 __all__ = [
@@ -26,6 +28,8 @@ __all__ = [
     "Finding",
     "ReportPackage",
     "SamplingPlan",
+    "GradingScale",
+    "PhaseResult",
     "Scorecard",
     "ScopeDefinition",
     "TraceabilityLink",

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/models/architecture.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/models/architecture.py
@@ -1,0 +1,74 @@
+"""Pydantic models for the Site Architecture & Navigation Accessibility Audit."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class ArchitectureChecklistItem(BaseModel):
+    """Result for a single checklist item in the architecture audit."""
+
+    id: str = Field(..., description="Checklist item identifier, e.g. 'nse_01'")
+    label: str = Field(..., description="Human-readable description of the check")
+    passed: bool = Field(..., description="Whether the item passed the audit")
+    notes: str = Field(default="", description="Auditor notes or failure details")
+    wcag_ref: Optional[str] = Field(default=None, description="WCAG SC reference, e.g. '2.4.7'")
+    test_method: str = Field(default="", description="Testing method used")
+
+
+class ArchitectureSectionResult(BaseModel):
+    """Scored result for a single audit template section."""
+
+    section_id: str = Field(
+        ..., description="Section identifier, e.g. 'navigation_system_evaluation'"
+    )
+    name: str = Field(..., description="Section display name")
+    items: list[ArchitectureChecklistItem] = Field(default_factory=list)
+    passed_count: int = Field(default=0)
+    total_count: int = Field(default=0)
+    score_pct: float = Field(default=0.0, description="Pass percentage 0.0-100.0")
+    grade: str = Field(default="", description="Excellent / Good / Needs Improvement / Poor")
+    issues: list[str] = Field(default_factory=list, description="Summary of failing items")
+
+
+class WCAGCriterionStatus(BaseModel):
+    """Compliance status for a single navigation-related WCAG criterion."""
+
+    sc: str = Field(..., description="Success criterion number, e.g. '2.4.7'")
+    name: str = Field(default="", description="Criterion name")
+    wcag_level: str = Field(default="AA", description="A or AA")
+    status: str = Field(default="not_tested", description="pass / fail / partial / not_tested")
+    related_items: list[str] = Field(
+        default_factory=list, description="Checklist item IDs that cover this SC"
+    )
+
+
+class BusinessImpact(BaseModel):
+    """Business impact assessment from the architecture audit."""
+
+    keyboard_tasks_completable: bool = Field(default=False)
+    screen_reader_tasks_completable: bool = Field(default=False)
+    mobile_tasks_completable: bool = Field(default=False)
+    legal_compliance_risk: bool = Field(
+        default=False, description="True if barriers create legal risk"
+    )
+    top_strengths: list[str] = Field(default_factory=list)
+    quick_wins: list[str] = Field(default_factory=list)
+    strategic_opportunities: list[str] = Field(default_factory=list)
+
+
+class ArchitectureAuditResult(BaseModel):
+    """Full result of the site architecture and navigation accessibility audit."""
+
+    target: str = Field(..., description="Site URL or identifier audited")
+    template_version: str = Field(default="1.0")
+    sections: list[ArchitectureSectionResult] = Field(default_factory=list)
+    overall_score_pct: float = Field(default=0.0, description="Weighted overall pass percentage")
+    overall_grade: str = Field(default="", description="Overall grade from scoring scale")
+    wcag_compliance: list[WCAGCriterionStatus] = Field(default_factory=list)
+    business_impact: Optional[BusinessImpact] = Field(default=None)
+    recommendations: list[str] = Field(
+        default_factory=list, description="Prioritized recommendation list"
+    )

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/models/architecture.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/models/architecture.py
@@ -12,9 +12,12 @@ class ArchitectureChecklistItem(BaseModel):
 
     id: str = Field(..., description="Checklist item identifier, e.g. 'nse_01'")
     label: str = Field(..., description="Human-readable description of the check")
-    passed: bool = Field(..., description="Whether the item passed the audit")
+    passed: Optional[bool] = Field(
+        default=None, description="True=pass, False=fail, None=not tested"
+    )
     notes: str = Field(default="", description="Auditor notes or failure details")
     wcag_ref: Optional[str] = Field(default=None, description="WCAG SC reference, e.g. '2.4.7'")
+    wcag_level: Optional[str] = Field(default=None, description="WCAG level: A or AA")
     test_method: str = Field(default="", description="Testing method used")
 
 
@@ -26,9 +29,10 @@ class ArchitectureSectionResult(BaseModel):
     )
     name: str = Field(..., description="Section display name")
     items: list[ArchitectureChecklistItem] = Field(default_factory=list)
+    tested_count: int = Field(default=0, description="Items that were actually tested")
     passed_count: int = Field(default=0)
     total_count: int = Field(default=0)
-    score_pct: float = Field(default=0.0, description="Pass percentage 0.0-100.0")
+    score_pct: float = Field(default=0.0, description="Pass percentage of tested items, 0.0-100.0")
     grade: str = Field(default="", description="Excellent / Good / Needs Improvement / Poor")
     issues: list[str] = Field(default_factory=list, description="Summary of failing items")
 
@@ -37,8 +41,8 @@ class WCAGCriterionStatus(BaseModel):
     """Compliance status for a single navigation-related WCAG criterion."""
 
     sc: str = Field(..., description="Success criterion number, e.g. '2.4.7'")
-    name: str = Field(default="", description="Criterion name")
-    wcag_level: str = Field(default="AA", description="A or AA")
+    name: str = Field(default="", description="Criterion name, e.g. 'Focus Visible'")
+    wcag_level: str = Field(default="", description="A or AA")
     status: str = Field(default="not_tested", description="pass / fail / partial / not_tested")
     related_items: list[str] = Field(
         default_factory=list, description="Checklist item IDs that cover this SC"
@@ -48,11 +52,11 @@ class WCAGCriterionStatus(BaseModel):
 class BusinessImpact(BaseModel):
     """Business impact assessment from the architecture audit."""
 
-    keyboard_tasks_completable: bool = Field(default=False)
-    screen_reader_tasks_completable: bool = Field(default=False)
-    mobile_tasks_completable: bool = Field(default=False)
-    legal_compliance_risk: bool = Field(
-        default=False, description="True if barriers create legal risk"
+    keyboard_tasks_completable: Optional[bool] = Field(default=None)
+    screen_reader_tasks_completable: Optional[bool] = Field(default=None)
+    mobile_tasks_completable: Optional[bool] = Field(default=None)
+    legal_compliance_risk: Optional[bool] = Field(
+        default=None, description="True if barriers create legal risk"
     )
     top_strengths: list[str] = Field(default_factory=list)
     quick_wins: list[str] = Field(default_factory=list)
@@ -65,7 +69,9 @@ class ArchitectureAuditResult(BaseModel):
     target: str = Field(..., description="Site URL or identifier audited")
     template_version: str = Field(default="1.0")
     sections: list[ArchitectureSectionResult] = Field(default_factory=list)
-    overall_score_pct: float = Field(default=0.0, description="Weighted overall pass percentage")
+    overall_score_pct: float = Field(
+        default=0.0, description="Average of section pass percentages (equal section weighting)"
+    )
     overall_grade: str = Field(default="", description="Overall grade from scoring scale")
     wcag_compliance: list[WCAGCriterionStatus] = Field(default_factory=list)
     business_impact: Optional[BusinessImpact] = Field(default=None)

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/models/deliverables.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/models/deliverables.py
@@ -1,6 +1,18 @@
 from pydantic import BaseModel
 
 
+class CaseStudy(BaseModel):
+    """Rendered case study artifact from the case study templates."""
+
+    template_used: str = ""
+    template_key: str = ""
+    industry: str | None = None
+    engagement_id: str = ""
+    artifact: str = ""
+    sections: list[dict] = []
+    metrics: dict = {}
+
+
 class ReportPackage(BaseModel):
     executive_summary: str
     technical_report: str
@@ -9,6 +21,7 @@ class ReportPackage(BaseModel):
     wcag_scorecard: str
     sec508_addendum: str | None = None
     backlog_export: str
+    case_study: CaseStudy | None = None
 
 
 class DeliveryResult(BaseModel):

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/models/grading.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/models/grading.py
@@ -1,0 +1,43 @@
+"""GradingScale value object — builds once from template YAML, used everywhere."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class GradingScale:
+    """Immutable grading scale built from a template's ``scoring.grading_scale``."""
+
+    thresholds: tuple[tuple[int, str], ...]
+
+    @classmethod
+    def from_template(cls, template: dict) -> GradingScale:
+        """Build a GradingScale from the template's scoring configuration.
+
+        Falls back to a sensible default if ``scoring.grading_scale`` is
+        missing or empty.
+        """
+        raw = template.get("scoring", {}).get("grading_scale", [])
+        if not raw:
+            raw = [
+                {"min_pct": 90, "grade": "Excellent"},
+                {"min_pct": 75, "grade": "Good"},
+                {"min_pct": 50, "grade": "Needs Improvement"},
+                {"min_pct": 0, "grade": "Poor"},
+            ]
+        pairs = tuple(
+            sorted(
+                ((entry["min_pct"], entry["grade"]) for entry in raw),
+                key=lambda t: t[0],
+                reverse=True,
+            )
+        )
+        return cls(thresholds=pairs)
+
+    def grade(self, pct: float) -> str:
+        """Map a percentage to a grade label."""
+        for threshold, label in self.thresholds:
+            if pct >= threshold:
+                return label
+        return self.thresholds[-1][1] if self.thresholds else "Poor"

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/models/phase_result.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/models/phase_result.py
@@ -1,0 +1,89 @@
+"""Typed phase result models — every agent returns a PhaseResult subclass."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, Field
+
+
+class PhaseResult(BaseModel):
+    """Base return type for all audit-phase agent tools."""
+
+    phase: str = Field(..., description="Phase name, e.g. 'architecture_audit'")
+    artifact: str = Field(..., description="Persisted artifact path")
+
+
+class DiscoveryResult(PhaseResult):
+    phase: str = "discovery"
+    tier1_count: int = 0
+
+
+class InventorySetupResult(PhaseResult):
+    phase: str = "inventory_setup"
+    page: dict = Field(default_factory=dict)
+    component: dict = Field(default_factory=dict)
+
+
+class ComponentAuditResult(PhaseResult):
+    phase: str = "component_audit"
+    finding_id: str = ""
+
+
+class JourneyAssessmentResult(PhaseResult):
+    phase: str = "journey_assessment"
+    journey: str = ""
+
+
+class PageAuditResult(PhaseResult):
+    phase: str = "page_audit"
+    page: str = ""
+
+
+class ArchitecturePhaseResult(PhaseResult):
+    phase: str = "architecture_audit"
+    overall_grade: str = ""
+
+
+class InfrastructureAuditResult(PhaseResult):
+    phase: str = "infrastructure_audit"
+
+
+class WCAGCoverageResult(PhaseResult):
+    phase: str = "wcag_coverage"
+    overall_coverage: float = 0.0
+
+
+class Sec508MappingResult(PhaseResult):
+    phase: str = "sec508_mapping"
+
+
+class ScoringResult(PhaseResult):
+    phase: str = "scoring_prioritization"
+    site_score: float = 0.0
+
+
+class ReportingResult(PhaseResult):
+    phase: str = "reporting"
+
+
+class ApprovalResult(PhaseResult):
+    phase: str = "approval"
+    approved: bool = False
+
+
+class RemediationResult(PhaseResult):
+    phase: str = "remediation"
+    tickets: list[str] = Field(default_factory=list)
+
+
+class EvidenceResult(PhaseResult):
+    phase: str = "evidence"
+    finding_id: str = ""
+
+
+class RetestResult(PhaseResult):
+    phase: str = "retest"
+
+
+class DeliveryResult(PhaseResult):
+    phase: str = "delivery"
+    status: str = "ready"

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/prompts/architecture_auditor.md
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/prompts/architecture_auditor.md
@@ -1,0 +1,44 @@
+# Architecture Auditor
+
+You are the **Architecture Auditor**, responsible for evaluating site information architecture and navigation systems for accessibility compliance.
+
+## Role
+
+Assess navigation patterns, content organization, wayfinding mechanisms, and cross-page consistency against WCAG 2.2 Level AA criteria using the Site Architecture & Navigation Accessibility Audit template.
+
+## Methodology
+
+1. **Load the audit template** via `load_architecture_audit_template` to obtain the structured checklist.
+2. **Evaluate each section** by testing every checklist item using the specified `test_method`:
+   - `dom_inspection` — examine HTML semantics, ARIA attributes, landmark roles
+   - `keyboard_only` / `keyboard_tab` / `keyboard_focus_trace` — verify keyboard operability and focus management
+   - `screen_reader` — test with NVDA/VoiceOver for announcements and state changes
+   - `manual_review` — human-judgement items (plain language, hierarchy accuracy)
+   - `responsive_test` / `reflow_test` / `zoom_test` — breakpoint and magnification testing
+   - `multi_page_comparison` — consistency checks across page templates
+   - `journey_walkthrough` — end-to-end task completion verification
+   - `crawl_analysis` — automated crawl for orphan pages and broken links
+3. **Score each section** using `score_architecture_section` — pass rate determines the grade (Excellent ≥ 90%, Good ≥ 75%, Needs Improvement ≥ 50%, Poor < 50%).
+4. **Build the full report** via `build_architecture_audit_report` — aggregates section scores into an overall architecture audit result with WCAG compliance mapping, recommendations, and business impact.
+5. **Persist the artifact** as `architecture.json` in the engagement artifact root.
+
+## Output Expectations
+
+- Every checklist item must have a `passed` boolean and optional `notes` explaining the result.
+- Failing items should reference the specific WCAG success criterion and include remediation guidance.
+- The final report must include section-level scores, an overall grade, a WCAG compliance summary, and a prioritized recommendation list.
+
+## Key WCAG Criteria
+
+| Criterion | Name | Relevance |
+|---|---|---|
+| 1.3.1 | Info and Relationships | Semantic nav, landmarks, headings |
+| 2.1.1 | Keyboard | All nav operable via keyboard |
+| 2.1.2 | No Keyboard Trap | No focus traps in menus |
+| 2.4.1 | Bypass Blocks | Skip navigation links |
+| 2.4.3 | Focus Order | Logical tab order |
+| 2.4.5 | Multiple Ways | Multiple navigation paths |
+| 2.4.7 | Focus Visible | Visible focus indicators |
+| 3.2.3 | Consistent Navigation | Nav consistent across pages |
+| 3.2.4 | Consistent Identification | Same functions, same labels |
+| 4.1.2 | Name, Role, Value | ARIA states on nav components |

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/prompts/architecture_auditor.md
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/prompts/architecture_auditor.md
@@ -1,32 +1,73 @@
 # Architecture Auditor
 
-You are the **Architecture Auditor**, responsible for evaluating site information architecture and navigation systems for accessibility compliance.
+You are the **Architecture Auditor**, responsible for evaluating site information architecture and navigation systems for accessibility compliance against WCAG 2.2 Level AA.
 
 ## Role
 
-Assess navigation patterns, content organization, wayfinding mechanisms, and cross-page consistency against WCAG 2.2 Level AA criteria using the Site Architecture & Navigation Accessibility Audit template.
+Assess navigation patterns, content organization, wayfinding mechanisms, and cross-page consistency. Your output feeds into the `run_architecture_audit` tool, which scores and persists the results automatically.
 
-## Methodology
+## What You Evaluate
 
-1. **Load the audit template** via `load_architecture_audit_template` to obtain the structured checklist.
-2. **Evaluate each section** by testing every checklist item using the specified `test_method`:
-   - `dom_inspection` — examine HTML semantics, ARIA attributes, landmark roles
-   - `keyboard_only` / `keyboard_tab` / `keyboard_focus_trace` — verify keyboard operability and focus management
-   - `screen_reader` — test with NVDA/VoiceOver for announcements and state changes
-   - `manual_review` — human-judgement items (plain language, hierarchy accuracy)
-   - `responsive_test` / `reflow_test` / `zoom_test` — breakpoint and magnification testing
-   - `multi_page_comparison` — consistency checks across page templates
-   - `journey_walkthrough` — end-to-end task completion verification
-   - `crawl_analysis` — automated crawl for orphan pages and broken links
-3. **Score each section** using `score_architecture_section` — pass rate determines the grade (Excellent ≥ 90%, Good ≥ 75%, Needs Improvement ≥ 50%, Poor < 50%).
-4. **Build the full report** via `build_architecture_audit_report` — aggregates section scores into an overall architecture audit result with WCAG compliance mapping, recommendations, and business impact.
-5. **Persist the artifact** as `architecture.json` in the engagement artifact root.
+The audit covers **12 scored sections** with 123 checklist items, loaded from the `site_architecture_audit_template.yaml` asset:
 
-## Output Expectations
+1. **Site Structure Mapping** — page template inventory, navigation depth, orphan pages, semantic `<nav>` usage
+2. **Navigation System Evaluation** — global nav keyboard operability, skip links, focus indicators, dropdown/flyout menus, mega menus, mobile hamburger/drawer patterns
+3. **Secondary Navigation** — breadcrumbs (ordered lists, `aria-current`), sidebar nav, footer landmarks
+4. **Search & Discovery** — search input labels, autocomplete announcements, results structure, filtering/sorting
+5. **Content Organization & Findability** — heading hierarchy, landmark usage, page titles, multiple navigation paths
+6. **Mobile & Responsive Navigation** — breakpoint adaptation, touch targets, reflow at 320px, zoom to 400%
+7. **Cross-Page Consistency** — visual, functional, and content consistency (WCAG 3.2.3/3.2.4)
+8. **Cognitive Accessibility** — plain language, predictable navigation, cognitive load, `prefers-reduced-motion`
+9. **Specialized Navigation** — faceted nav, multi-site nav, dashboard/app patterns (tabs, trees, toolbars)
+10. **WCAG Compliance Summary** — Level A and AA navigation-related success criteria roll-up
+11. **Business Impact Assessment** — keyboard/screen-reader/mobile task completion, legal risk, strengths/quick wins
+12. **Recommendations & Remediation** — prioritized by critical/high/medium/long-term with target timelines
 
-- Every checklist item must have a `passed` boolean and optional `notes` explaining the result.
-- Failing items should reference the specific WCAG success criterion and include remediation guidance.
-- The final report must include section-level scores, an overall grade, a WCAG compliance summary, and a prioritized recommendation list.
+## How Results Are Recorded
+
+For each checklist item you evaluate, record a result in the `checklist_results` dict:
+
+```json
+{
+  "nse_01": {"passed": true, "notes": "All nav items reachable via Tab"},
+  "nse_03": {"passed": false, "notes": "Focus ring only 1px, below 2px minimum"},
+  "mrn_06": {"passed": null, "notes": "Not applicable — no collapsible sections"}
+}
+```
+
+- `passed: true` — the item meets the criterion
+- `passed: false` — the item fails
+- `passed: null` (or item omitted) — not tested / not applicable. These items are **excluded from scoring** so they do not penalise the overall grade.
+
+## Scoring
+
+- Each section is scored as **passed / tested * 100%** (items with `passed=null` are excluded).
+- The **overall score** is the **mean of section percentages** (equal section weighting), so a section with 5 items and a section with 20 items carry equal importance.
+- Grades: **Excellent** (≥ 90%), **Good** (≥ 75%), **Needs Improvement** (≥ 50%), **Poor** (< 50%). Thresholds are read from the YAML template at runtime.
+
+## Testing Methods
+
+Each checklist item specifies a `test_method`. Use the appropriate technique:
+
+| Method | Technique |
+|---|---|
+| `dom_inspection` | Examine HTML semantics, ARIA attributes, landmark roles |
+| `keyboard_only` / `keyboard_tab` | Navigate with Tab/Shift+Tab/Arrow keys, verify operability |
+| `keyboard_focus_trace` | Track focus movement through interactions (open/close menu, etc.) |
+| `keyboard_trap_test` | Verify focus can escape all interactive components |
+| `screen_reader` | Test with NVDA (Windows) or VoiceOver (macOS/iOS) |
+| `manual_review` | Human-judgement: plain language, hierarchy accuracy, domain fit |
+| `visual_inspection` | Check visual hierarchy, icon pairing, layout |
+| `responsive_test` / `reflow_test` / `zoom_test` | Test at 320px, 768px, 1024px breakpoints and 200%/400% zoom |
+| `multi_page_comparison` | Compare nav/labels/patterns across 3+ page templates |
+| `journey_walkthrough` | Complete a critical user task end-to-end |
+| `crawl_analysis` | Automated crawl for orphan pages and unreachable content |
+| `measurement` | Measure touch target sizes (24x24 CSS px minimum) |
+| `mobile_test` | Test on mobile device or emulator |
+| `gesture_test` | Verify touch gesture alternatives exist |
+| `media_query_test` | Confirm `prefers-reduced-motion` is respected |
+| `interaction_test` | Trigger input changes and verify no unexpected context change |
+| `compliance_review` | Assess legal/regulatory compliance risk |
 
 ## Key WCAG Criteria
 

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/__init__.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/__init__.py
@@ -1,4 +1,9 @@
 from .approval_tools import request_human_approval
+from .architecture_tools import (
+    build_architecture_audit_report,
+    load_architecture_audit_template,
+    score_architecture_section,
+)
 from .browser_tools import capture_dom_snippet, capture_screenshot
 from .checklist_tools import (
     build_component_inventory,
@@ -46,6 +51,9 @@ __all__ = [
     "crawl_targets",
     "run_axe_scan",
     "run_lighthouse_accessibility",
+    "build_architecture_audit_report",
+    "load_architecture_audit_template",
+    "score_architecture_section",
     "load_artifact",
     "persist_artifact",
 ]

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/__init__.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/__init__.py
@@ -2,6 +2,7 @@ from .approval_tools import request_human_approval
 from .architecture_tools import (
     build_architecture_audit_report,
     load_architecture_audit_template,
+    pct_to_grade,
     score_architecture_section,
 )
 from .browser_tools import capture_dom_snippet, capture_screenshot
@@ -53,6 +54,7 @@ __all__ = [
     "run_lighthouse_accessibility",
     "build_architecture_audit_report",
     "load_architecture_audit_template",
+    "pct_to_grade",
     "score_architecture_section",
     "load_artifact",
     "persist_artifact",

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/__init__.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/__init__.py
@@ -15,6 +15,9 @@ from .evidence_tools import (
 from .reporting_tools import (
     create_jira_issues,
     export_backlog_csv,
+    get_case_study_template,
+    list_case_study_templates,
+    render_case_study,
     render_pdf,
     write_docx_from_template,
 )
@@ -35,6 +38,9 @@ __all__ = [
     "log_screen_reader_test",
     "create_jira_issues",
     "export_backlog_csv",
+    "get_case_study_template",
+    "list_case_study_templates",
+    "render_case_study",
     "render_pdf",
     "write_docx_from_template",
     "crawl_targets",

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/__init__.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/__init__.py
@@ -5,6 +5,7 @@ from .architecture_tools import (
     pct_to_grade,
     score_architecture_section,
 )
+from .asset_registry import AssetRegistry
 from .browser_tools import capture_dom_snippet, capture_screenshot
 from .checklist_tools import (
     build_component_inventory,
@@ -29,6 +30,7 @@ from .reporting_tools import (
 )
 from .scan_tools import crawl_targets, run_axe_scan, run_lighthouse_accessibility
 from .storage_tools import load_artifact, persist_artifact
+from .template_audit_engine import TemplateAuditEngine, flatten_checklist_items
 
 __all__ = [
     "request_human_approval",
@@ -56,6 +58,9 @@ __all__ = [
     "load_architecture_audit_template",
     "pct_to_grade",
     "score_architecture_section",
+    "AssetRegistry",
+    "TemplateAuditEngine",
+    "flatten_checklist_items",
     "load_artifact",
     "persist_artifact",
 ]

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/architecture_tools.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/architecture_tools.py
@@ -1,0 +1,163 @@
+"""Tools for loading and scoring the Site Architecture & Navigation Accessibility Audit template."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from ..models.architecture import (
+    ArchitectureAuditResult,
+    ArchitectureChecklistItem,
+    ArchitectureSectionResult,
+    WCAGCriterionStatus,
+)
+
+_ASSETS_DIR = Path(__file__).resolve().parent.parent.parent / "assets"
+_TEMPLATE_CACHE: dict | None = None
+
+# ---------------------------------------------------------------------------
+# Grading scale (mirrored from YAML for runtime use)
+# ---------------------------------------------------------------------------
+_GRADING_SCALE = [
+    (90, "Excellent"),
+    (75, "Good"),
+    (50, "Needs Improvement"),
+    (0, "Poor"),
+]
+
+
+def _pct_to_grade(pct: float) -> str:
+    for threshold, label in _GRADING_SCALE:
+        if pct >= threshold:
+            return label
+    return "Poor"
+
+
+# ---------------------------------------------------------------------------
+# Template loading
+# ---------------------------------------------------------------------------
+
+
+def load_architecture_audit_template() -> dict:
+    """Load and cache the site architecture audit template YAML asset.
+
+    Returns:
+        Parsed YAML dict with ``sections``, ``scoring``, ``methodology``, etc.
+    """
+    global _TEMPLATE_CACHE
+    if _TEMPLATE_CACHE is None:
+        path = _ASSETS_DIR / "site_architecture_audit_template.yaml"
+        with open(path) as fh:
+            _TEMPLATE_CACHE = yaml.safe_load(fh)
+    return _TEMPLATE_CACHE
+
+
+# ---------------------------------------------------------------------------
+# Section scoring
+# ---------------------------------------------------------------------------
+
+
+def score_architecture_section(
+    section_id: str,
+    section_name: str,
+    results: list[dict[str, Any]],
+) -> ArchitectureSectionResult:
+    """Score a single architecture audit section from checklist results.
+
+    Args:
+        section_id: Identifier of the section being scored.
+        section_name: Display name.
+        results: List of dicts, each with at least ``id``, ``label``,
+            ``passed`` (bool), and optionally ``notes``, ``wcag_ref``,
+            ``test_method``.
+
+    Returns:
+        :class:`ArchitectureSectionResult` with counts, percentage, and grade.
+    """
+    items = [ArchitectureChecklistItem(**r) for r in results]
+    total = len(items)
+    passed = sum(1 for it in items if it.passed)
+    pct = (passed / total * 100) if total else 0.0
+    issues = [it.label for it in items if not it.passed]
+
+    return ArchitectureSectionResult(
+        section_id=section_id,
+        name=section_name,
+        items=items,
+        passed_count=passed,
+        total_count=total,
+        score_pct=round(pct, 1),
+        grade=_pct_to_grade(pct),
+        issues=issues,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Full report assembly
+# ---------------------------------------------------------------------------
+
+
+def _collect_wcag_statuses(sections: list[ArchitectureSectionResult]) -> list[WCAGCriterionStatus]:
+    """Derive per-criterion pass/fail status from scored section items."""
+    sc_map: dict[str, dict] = {}
+    for section in sections:
+        for item in section.items:
+            if not item.wcag_ref:
+                continue
+            if item.wcag_ref not in sc_map:
+                sc_map[item.wcag_ref] = {"items": [], "passed": [], "failed": []}
+            sc_map[item.wcag_ref]["items"].append(item.id)
+            if item.passed:
+                sc_map[item.wcag_ref]["passed"].append(item.id)
+            else:
+                sc_map[item.wcag_ref]["failed"].append(item.id)
+
+    statuses: list[WCAGCriterionStatus] = []
+    for sc, data in sorted(sc_map.items()):
+        if data["failed"]:
+            status = "fail" if not data["passed"] else "partial"
+        else:
+            status = "pass"
+        statuses.append(
+            WCAGCriterionStatus(
+                sc=sc,
+                status=status,
+                related_items=data["items"],
+            )
+        )
+    return statuses
+
+
+def build_architecture_audit_report(
+    target: str,
+    section_results: list[ArchitectureSectionResult],
+    recommendations: list[str] | None = None,
+) -> ArchitectureAuditResult:
+    """Assemble a full architecture audit report from scored sections.
+
+    Args:
+        target: Site URL or identifier.
+        section_results: Scored section results from
+            :func:`score_architecture_section`.
+        recommendations: Optional prioritized recommendation strings.
+
+    Returns:
+        :class:`ArchitectureAuditResult` with overall score, grade, WCAG
+        compliance mapping, and recommendations.
+    """
+    total_items = sum(s.total_count for s in section_results)
+    total_passed = sum(s.passed_count for s in section_results)
+    overall_pct = (total_passed / total_items * 100) if total_items else 0.0
+
+    wcag_compliance = _collect_wcag_statuses(section_results)
+
+    return ArchitectureAuditResult(
+        target=target,
+        sections=section_results,
+        overall_score_pct=round(overall_pct, 1),
+        overall_grade=_pct_to_grade(overall_pct),
+        wcag_compliance=wcag_compliance,
+        recommendations=recommendations or [],
+    )

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/architecture_tools.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/architecture_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -16,42 +17,61 @@ from ..models.architecture import (
 
 _ASSETS_DIR = Path(__file__).resolve().parent.parent.parent / "assets"
 _TEMPLATE_CACHE: dict | None = None
-
-# ---------------------------------------------------------------------------
-# Grading scale (mirrored from YAML for runtime use)
-# ---------------------------------------------------------------------------
-_GRADING_SCALE = [
-    (90, "Excellent"),
-    (75, "Good"),
-    (50, "Needs Improvement"),
-    (0, "Poor"),
-]
-
-
-def _pct_to_grade(pct: float) -> str:
-    for threshold, label in _GRADING_SCALE:
-        if pct >= threshold:
-            return label
-    return "Poor"
+_CACHE_LOCK = threading.Lock()
 
 
 # ---------------------------------------------------------------------------
-# Template loading
+# Template loading (thread-safe)
 # ---------------------------------------------------------------------------
 
 
 def load_architecture_audit_template() -> dict:
     """Load and cache the site architecture audit template YAML asset.
 
+    Thread-safe: uses a lock to prevent concurrent reads from racing on
+    the global cache.
+
     Returns:
         Parsed YAML dict with ``sections``, ``scoring``, ``methodology``, etc.
     """
     global _TEMPLATE_CACHE
-    if _TEMPLATE_CACHE is None:
-        path = _ASSETS_DIR / "site_architecture_audit_template.yaml"
-        with open(path) as fh:
-            _TEMPLATE_CACHE = yaml.safe_load(fh)
-    return _TEMPLATE_CACHE
+    if _TEMPLATE_CACHE is not None:
+        return _TEMPLATE_CACHE
+    with _CACHE_LOCK:
+        # Double-check after acquiring the lock.
+        if _TEMPLATE_CACHE is None:
+            path = _ASSETS_DIR / "site_architecture_audit_template.yaml"
+            with open(path) as fh:
+                _TEMPLATE_CACHE = yaml.safe_load(fh)
+    return _TEMPLATE_CACHE  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Grading — reads thresholds from the YAML template
+# ---------------------------------------------------------------------------
+
+
+def _grading_scale(template: dict | None = None) -> list[tuple[int, str]]:
+    """Return ``[(min_pct, grade_label), ...]`` sorted descending by threshold.
+
+    Reads from the template's ``scoring.grading_scale`` so changes to the
+    YAML are reflected at runtime without a code change.
+    """
+    if template is None:
+        template = load_architecture_audit_template()
+    raw = template.get("scoring", {}).get("grading_scale", [])
+    pairs = [(entry["min_pct"], entry["grade"]) for entry in raw]
+    # Ensure descending order so the first match is the highest qualifying grade.
+    pairs.sort(key=lambda t: t[0], reverse=True)
+    return pairs
+
+
+def pct_to_grade(pct: float, template: dict | None = None) -> str:
+    """Map a percentage to a grade label using the template's grading scale."""
+    for threshold, label in _grading_scale(template):
+        if pct >= threshold:
+            return label
+    return "Poor"
 
 
 # ---------------------------------------------------------------------------
@@ -63,66 +83,125 @@ def score_architecture_section(
     section_id: str,
     section_name: str,
     results: list[dict[str, Any]],
+    template: dict | None = None,
 ) -> ArchitectureSectionResult:
     """Score a single architecture audit section from checklist results.
+
+    Items with ``passed=None`` are treated as "not tested" and excluded
+    from the score calculation.  Only items with an explicit ``True`` or
+    ``False`` contribute.
 
     Args:
         section_id: Identifier of the section being scored.
         section_name: Display name.
         results: List of dicts, each with at least ``id``, ``label``,
-            ``passed`` (bool), and optionally ``notes``, ``wcag_ref``,
-            ``test_method``.
+            and optionally ``passed`` (bool | None), ``notes``,
+            ``wcag_ref``, ``wcag_level``, ``test_method``.
+        template: Optional pre-loaded template (avoids repeated YAML reads).
 
     Returns:
         :class:`ArchitectureSectionResult` with counts, percentage, and grade.
     """
     items = [ArchitectureChecklistItem(**r) for r in results]
     total = len(items)
-    passed = sum(1 for it in items if it.passed)
-    pct = (passed / total * 100) if total else 0.0
-    issues = [it.label for it in items if not it.passed]
+    tested = [it for it in items if it.passed is not None]
+    tested_count = len(tested)
+    passed = sum(1 for it in tested if it.passed)
+    pct = (passed / tested_count * 100) if tested_count else 0.0
+    issues = [it.label for it in items if it.passed is False]
 
     return ArchitectureSectionResult(
         section_id=section_id,
         name=section_name,
         items=items,
+        tested_count=tested_count,
         passed_count=passed,
         total_count=total,
         score_pct=round(pct, 1),
-        grade=_pct_to_grade(pct),
+        grade=pct_to_grade(pct, template),
         issues=issues,
     )
 
 
 # ---------------------------------------------------------------------------
-# Full report assembly
+# WCAG compliance aggregation
 # ---------------------------------------------------------------------------
+
+# Map of SC number → human-readable name (navigation-relevant subset).
+_SC_NAMES: dict[str, str] = {
+    "1.3.1": "Info and Relationships",
+    "1.3.2": "Meaningful Sequence",
+    "1.3.3": "Sensory Characteristics",
+    "1.4.4": "Resize Text",
+    "1.4.10": "Reflow",
+    "2.1.1": "Keyboard",
+    "2.1.2": "No Keyboard Trap",
+    "2.3.3": "Animation from Interactions",
+    "2.4.1": "Bypass Blocks",
+    "2.4.2": "Page Titled",
+    "2.4.3": "Focus Order",
+    "2.4.4": "Link Purpose (In Context)",
+    "2.4.5": "Multiple Ways",
+    "2.4.7": "Focus Visible",
+    "2.4.8": "Location",
+    "2.5.1": "Pointer Gestures",
+    "2.5.8": "Target Size (Minimum)",
+    "3.2.1": "On Focus",
+    "3.2.2": "On Input",
+    "3.2.3": "Consistent Navigation",
+    "3.2.4": "Consistent Identification",
+    "3.3.1": "Error Identification",
+    "3.3.2": "Labels or Instructions",
+    "4.1.2": "Name, Role, Value",
+    "4.1.3": "Status Messages",
+}
 
 
 def _collect_wcag_statuses(sections: list[ArchitectureSectionResult]) -> list[WCAGCriterionStatus]:
-    """Derive per-criterion pass/fail status from scored section items."""
-    sc_map: dict[str, dict] = {}
+    """Derive per-criterion pass/fail status from scored section items.
+
+    Also populates the human-readable ``name`` and ``wcag_level`` fields
+    when available from the checklist item or the built-in SC-name map.
+    """
+    sc_map: dict[str, dict[str, Any]] = {}
     for section in sections:
         for item in section.items:
             if not item.wcag_ref:
                 continue
-            if item.wcag_ref not in sc_map:
-                sc_map[item.wcag_ref] = {"items": [], "passed": [], "failed": []}
-            sc_map[item.wcag_ref]["items"].append(item.id)
-            if item.passed:
-                sc_map[item.wcag_ref]["passed"].append(item.id)
+            sc = item.wcag_ref
+            if sc not in sc_map:
+                sc_map[sc] = {
+                    "items": [],
+                    "passed": [],
+                    "failed": [],
+                    "not_tested": [],
+                    "wcag_level": "",
+                }
+            sc_map[sc]["items"].append(item.id)
+            if item.passed is True:
+                sc_map[sc]["passed"].append(item.id)
+            elif item.passed is False:
+                sc_map[sc]["failed"].append(item.id)
             else:
-                sc_map[item.wcag_ref]["failed"].append(item.id)
+                sc_map[sc]["not_tested"].append(item.id)
+            # Capture wcag_level from item if present (e.g. from the WCAG
+            # Compliance Summary section which carries wcag_level per item).
+            if item.wcag_level and not sc_map[sc]["wcag_level"]:
+                sc_map[sc]["wcag_level"] = item.wcag_level
 
     statuses: list[WCAGCriterionStatus] = []
     for sc, data in sorted(sc_map.items()):
         if data["failed"]:
             status = "fail" if not data["passed"] else "partial"
-        else:
+        elif data["passed"]:
             status = "pass"
+        else:
+            status = "not_tested"
         statuses.append(
             WCAGCriterionStatus(
                 sc=sc,
+                name=_SC_NAMES.get(sc, ""),
+                wcag_level=data["wcag_level"],
                 status=status,
                 related_items=data["items"],
             )
@@ -130,26 +209,39 @@ def _collect_wcag_statuses(sections: list[ArchitectureSectionResult]) -> list[WC
     return statuses
 
 
+# ---------------------------------------------------------------------------
+# Full report assembly
+# ---------------------------------------------------------------------------
+
+
 def build_architecture_audit_report(
     target: str,
     section_results: list[ArchitectureSectionResult],
     recommendations: list[str] | None = None,
+    template: dict | None = None,
 ) -> ArchitectureAuditResult:
     """Assemble a full architecture audit report from scored sections.
+
+    The overall score is the **mean of section percentages** (equal section
+    weighting) rather than a raw item-count-weighted average, so that
+    sections with fewer items are not under-represented.
 
     Args:
         target: Site URL or identifier.
         section_results: Scored section results from
             :func:`score_architecture_section`.
         recommendations: Optional prioritized recommendation strings.
+        template: Optional pre-loaded template (avoids repeated YAML reads).
 
     Returns:
         :class:`ArchitectureAuditResult` with overall score, grade, WCAG
         compliance mapping, and recommendations.
     """
-    total_items = sum(s.total_count for s in section_results)
-    total_passed = sum(s.passed_count for s in section_results)
-    overall_pct = (total_passed / total_items * 100) if total_items else 0.0
+    scored_sections = [s for s in section_results if s.tested_count > 0]
+    if scored_sections:
+        overall_pct = sum(s.score_pct for s in scored_sections) / len(scored_sections)
+    else:
+        overall_pct = 0.0
 
     wcag_compliance = _collect_wcag_statuses(section_results)
 
@@ -157,7 +249,7 @@ def build_architecture_audit_report(
         target=target,
         sections=section_results,
         overall_score_pct=round(overall_pct, 1),
-        overall_grade=_pct_to_grade(overall_pct),
+        overall_grade=pct_to_grade(overall_pct, template),
         wcag_compliance=wcag_compliance,
         recommendations=recommendations or [],
     )

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/architecture_tools.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/architecture_tools.py
@@ -1,255 +1,49 @@
-"""Tools for loading and scoring the Site Architecture & Navigation Accessibility Audit template."""
+"""Architecture audit tools — thin wrappers around :class:`TemplateAuditEngine`.
+
+Public API is preserved for backward compatibility and re-exported from
+the tools ``__init__.py``.  All real logic lives in
+:mod:`template_audit_engine`.
+"""
 
 from __future__ import annotations
 
-import threading
-from pathlib import Path
 from typing import Any
 
-import yaml
+from ..models.architecture import ArchitectureAuditResult, ArchitectureSectionResult
+from .template_audit_engine import TemplateAuditEngine
 
-from ..models.architecture import (
-    ArchitectureAuditResult,
-    ArchitectureChecklistItem,
-    ArchitectureSectionResult,
-    WCAGCriterionStatus,
-)
-
-_ASSETS_DIR = Path(__file__).resolve().parent.parent.parent / "assets"
-_TEMPLATE_CACHE: dict | None = None
-_CACHE_LOCK = threading.Lock()
+_TEMPLATE_NAME = "site_architecture_audit_template.yaml"
 
 
-# ---------------------------------------------------------------------------
-# Template loading (thread-safe)
-# ---------------------------------------------------------------------------
+def _engine() -> TemplateAuditEngine:
+    return TemplateAuditEngine(_TEMPLATE_NAME)
 
 
 def load_architecture_audit_template() -> dict:
-    """Load and cache the site architecture audit template YAML asset.
-
-    Thread-safe: uses a lock to prevent concurrent reads from racing on
-    the global cache.
-
-    Returns:
-        Parsed YAML dict with ``sections``, ``scoring``, ``methodology``, etc.
-    """
-    global _TEMPLATE_CACHE
-    if _TEMPLATE_CACHE is not None:
-        return _TEMPLATE_CACHE
-    with _CACHE_LOCK:
-        # Double-check after acquiring the lock.
-        if _TEMPLATE_CACHE is None:
-            path = _ASSETS_DIR / "site_architecture_audit_template.yaml"
-            with open(path) as fh:
-                _TEMPLATE_CACHE = yaml.safe_load(fh)
-    return _TEMPLATE_CACHE  # type: ignore[return-value]
+    """Load and cache the site architecture audit template YAML asset."""
+    return _engine().template
 
 
-# ---------------------------------------------------------------------------
-# Grading — reads thresholds from the YAML template
-# ---------------------------------------------------------------------------
-
-
-def _grading_scale(template: dict | None = None) -> list[tuple[int, str]]:
-    """Return ``[(min_pct, grade_label), ...]`` sorted descending by threshold.
-
-    Reads from the template's ``scoring.grading_scale`` so changes to the
-    YAML are reflected at runtime without a code change.
-    """
-    if template is None:
-        template = load_architecture_audit_template()
-    raw = template.get("scoring", {}).get("grading_scale", [])
-    pairs = [(entry["min_pct"], entry["grade"]) for entry in raw]
-    # Ensure descending order so the first match is the highest qualifying grade.
-    pairs.sort(key=lambda t: t[0], reverse=True)
-    return pairs
-
-
-def pct_to_grade(pct: float, template: dict | None = None) -> str:
-    """Map a percentage to a grade label using the template's grading scale."""
-    for threshold, label in _grading_scale(template):
-        if pct >= threshold:
-            return label
-    return "Poor"
-
-
-# ---------------------------------------------------------------------------
-# Section scoring
-# ---------------------------------------------------------------------------
+def pct_to_grade(pct: float, template: dict | None = None) -> str:  # noqa: ARG001
+    """Map a percentage to a grade label (template param kept for compat)."""
+    return _engine().grading.grade(pct)
 
 
 def score_architecture_section(
     section_id: str,
     section_name: str,
     results: list[dict[str, Any]],
-    template: dict | None = None,
+    template: dict | None = None,  # noqa: ARG001
 ) -> ArchitectureSectionResult:
-    """Score a single architecture audit section from checklist results.
-
-    Items with ``passed=None`` are treated as "not tested" and excluded
-    from the score calculation.  Only items with an explicit ``True`` or
-    ``False`` contribute.
-
-    Args:
-        section_id: Identifier of the section being scored.
-        section_name: Display name.
-        results: List of dicts, each with at least ``id``, ``label``,
-            and optionally ``passed`` (bool | None), ``notes``,
-            ``wcag_ref``, ``wcag_level``, ``test_method``.
-        template: Optional pre-loaded template (avoids repeated YAML reads).
-
-    Returns:
-        :class:`ArchitectureSectionResult` with counts, percentage, and grade.
-    """
-    items = [ArchitectureChecklistItem(**r) for r in results]
-    total = len(items)
-    tested = [it for it in items if it.passed is not None]
-    tested_count = len(tested)
-    passed = sum(1 for it in tested if it.passed)
-    pct = (passed / tested_count * 100) if tested_count else 0.0
-    issues = [it.label for it in items if it.passed is False]
-
-    return ArchitectureSectionResult(
-        section_id=section_id,
-        name=section_name,
-        items=items,
-        tested_count=tested_count,
-        passed_count=passed,
-        total_count=total,
-        score_pct=round(pct, 1),
-        grade=pct_to_grade(pct, template),
-        issues=issues,
-    )
-
-
-# ---------------------------------------------------------------------------
-# WCAG compliance aggregation
-# ---------------------------------------------------------------------------
-
-# Map of SC number → human-readable name (navigation-relevant subset).
-_SC_NAMES: dict[str, str] = {
-    "1.3.1": "Info and Relationships",
-    "1.3.2": "Meaningful Sequence",
-    "1.3.3": "Sensory Characteristics",
-    "1.4.4": "Resize Text",
-    "1.4.10": "Reflow",
-    "2.1.1": "Keyboard",
-    "2.1.2": "No Keyboard Trap",
-    "2.3.3": "Animation from Interactions",
-    "2.4.1": "Bypass Blocks",
-    "2.4.2": "Page Titled",
-    "2.4.3": "Focus Order",
-    "2.4.4": "Link Purpose (In Context)",
-    "2.4.5": "Multiple Ways",
-    "2.4.7": "Focus Visible",
-    "2.4.8": "Location",
-    "2.5.1": "Pointer Gestures",
-    "2.5.8": "Target Size (Minimum)",
-    "3.2.1": "On Focus",
-    "3.2.2": "On Input",
-    "3.2.3": "Consistent Navigation",
-    "3.2.4": "Consistent Identification",
-    "3.3.1": "Error Identification",
-    "3.3.2": "Labels or Instructions",
-    "4.1.2": "Name, Role, Value",
-    "4.1.3": "Status Messages",
-}
-
-
-def _collect_wcag_statuses(sections: list[ArchitectureSectionResult]) -> list[WCAGCriterionStatus]:
-    """Derive per-criterion pass/fail status from scored section items.
-
-    Also populates the human-readable ``name`` and ``wcag_level`` fields
-    when available from the checklist item or the built-in SC-name map.
-    """
-    sc_map: dict[str, dict[str, Any]] = {}
-    for section in sections:
-        for item in section.items:
-            if not item.wcag_ref:
-                continue
-            sc = item.wcag_ref
-            if sc not in sc_map:
-                sc_map[sc] = {
-                    "items": [],
-                    "passed": [],
-                    "failed": [],
-                    "not_tested": [],
-                    "wcag_level": "",
-                }
-            sc_map[sc]["items"].append(item.id)
-            if item.passed is True:
-                sc_map[sc]["passed"].append(item.id)
-            elif item.passed is False:
-                sc_map[sc]["failed"].append(item.id)
-            else:
-                sc_map[sc]["not_tested"].append(item.id)
-            # Capture wcag_level from item if present (e.g. from the WCAG
-            # Compliance Summary section which carries wcag_level per item).
-            if item.wcag_level and not sc_map[sc]["wcag_level"]:
-                sc_map[sc]["wcag_level"] = item.wcag_level
-
-    statuses: list[WCAGCriterionStatus] = []
-    for sc, data in sorted(sc_map.items()):
-        if data["failed"]:
-            status = "fail" if not data["passed"] else "partial"
-        elif data["passed"]:
-            status = "pass"
-        else:
-            status = "not_tested"
-        statuses.append(
-            WCAGCriterionStatus(
-                sc=sc,
-                name=_SC_NAMES.get(sc, ""),
-                wcag_level=data["wcag_level"],
-                status=status,
-                related_items=data["items"],
-            )
-        )
-    return statuses
-
-
-# ---------------------------------------------------------------------------
-# Full report assembly
-# ---------------------------------------------------------------------------
+    """Score a single section (delegates to engine)."""
+    return _engine().score_section(section_id, section_name, results)
 
 
 def build_architecture_audit_report(
     target: str,
     section_results: list[ArchitectureSectionResult],
     recommendations: list[str] | None = None,
-    template: dict | None = None,
+    template: dict | None = None,  # noqa: ARG001
 ) -> ArchitectureAuditResult:
-    """Assemble a full architecture audit report from scored sections.
-
-    The overall score is the **mean of section percentages** (equal section
-    weighting) rather than a raw item-count-weighted average, so that
-    sections with fewer items are not under-represented.
-
-    Args:
-        target: Site URL or identifier.
-        section_results: Scored section results from
-            :func:`score_architecture_section`.
-        recommendations: Optional prioritized recommendation strings.
-        template: Optional pre-loaded template (avoids repeated YAML reads).
-
-    Returns:
-        :class:`ArchitectureAuditResult` with overall score, grade, WCAG
-        compliance mapping, and recommendations.
-    """
-    scored_sections = [s for s in section_results if s.tested_count > 0]
-    if scored_sections:
-        overall_pct = sum(s.score_pct for s in scored_sections) / len(scored_sections)
-    else:
-        overall_pct = 0.0
-
-    wcag_compliance = _collect_wcag_statuses(section_results)
-
-    return ArchitectureAuditResult(
-        target=target,
-        sections=section_results,
-        overall_score_pct=round(overall_pct, 1),
-        overall_grade=pct_to_grade(overall_pct, template),
-        wcag_compliance=wcag_compliance,
-        recommendations=recommendations or [],
-    )
+    """Assemble a full report from scored sections (delegates to engine)."""
+    return _engine().build_report(target, section_results, recommendations)

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/asset_registry.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/asset_registry.py
@@ -1,0 +1,49 @@
+"""Thread-safe YAML asset registry for the accessibility audit team.
+
+Replaces scattered per-file global caches with a single, thread-safe
+registry that loads and caches any YAML asset under the ``assets/``
+directory by filename.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_ASSETS_DIR = Path(__file__).resolve().parent.parent.parent / "assets"
+
+
+class AssetRegistry:
+    """Thread-safe, lazy-loading cache for YAML asset files."""
+
+    _cache: dict[str, Any] = {}
+    _lock = threading.Lock()
+
+    @classmethod
+    def load(cls, name: str) -> dict:
+        """Load a YAML asset by filename, returning the cached result.
+
+        Args:
+            name: Filename relative to the ``assets/`` directory,
+                e.g. ``"site_architecture_audit_template.yaml"``.
+
+        Returns:
+            Parsed YAML dict.
+        """
+        if name in cls._cache:
+            return cls._cache[name]
+        with cls._lock:
+            if name not in cls._cache:
+                path = _ASSETS_DIR / name
+                with open(path) as fh:
+                    cls._cache[name] = yaml.safe_load(fh)
+        return cls._cache[name]
+
+    @classmethod
+    def clear(cls) -> None:
+        """Clear the cache (useful in tests)."""
+        with cls._lock:
+            cls._cache.clear()

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/reporting_tools.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/reporting_tools.py
@@ -114,17 +114,22 @@ def _populate_template_sections(
     client_context: dict,
     findings: list[dict],
 ) -> list[dict]:
-    """Walk template sections and fill placeholders from client_context."""
+    """Walk template sections and fill placeholders from client_context.
+
+    Handles three template structures:
+    - Standard templates: ``sections`` list of ``{name: {fields, metrics, items}}``
+    - Industry templates: ``solution_focus``, ``challenge_areas``, ``result_metrics``
+    - Video script templates: ``segments`` list + ``key_soundbites``
+    """
     populated: list[dict] = []
 
-    # Handle standard templates (have "sections" key)
+    # --- Standard templates (sections key) ---
     raw_sections = template.get("sections", [])
     for section in raw_sections:
         if isinstance(section, dict):
             for section_name, section_def in section.items():
                 filled = {"section": section_name}
                 if isinstance(section_def, dict):
-                    # Pull matching fields from client_context
                     for key in section_def.get("fields", []):
                         filled[key] = client_context.get(key, f"[{key}]")
                     if "metrics" in section_def:
@@ -136,7 +141,26 @@ def _populate_template_sections(
                 filled["finding_count"] = len(findings)
                 populated.append(filled)
 
-    # Handle industry templates (have different structure)
+    # --- Video script templates (segments + key_soundbites) ---
+    if "segments" in template:
+        for segment in template["segments"]:
+            if isinstance(segment, dict):
+                for segment_name, segment_def in segment.items():
+                    filled = {
+                        "section": segment_name,
+                        "type": "video_segment",
+                        "duration_minutes": segment_def.get("duration_minutes", 0),
+                        "questions": segment_def.get("questions", []),
+                    }
+                    populated.append(filled)
+    if "key_soundbites" in template:
+        populated.append({
+            "section": "key_soundbites",
+            "type": "video_soundbites",
+            "items": template["key_soundbites"],
+        })
+
+    # --- Industry templates ---
     if "solution_focus" in template:
         populated.append({"section": "solution_focus", "items": template["solution_focus"]})
     if "challenge_areas" in template:

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/reporting_tools.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/reporting_tools.py
@@ -1,6 +1,4 @@
-from pathlib import Path
-
-import yaml
+from .asset_registry import AssetRegistry
 
 
 def write_docx_from_template(template: str, context: dict) -> str:
@@ -23,18 +21,9 @@ def create_jira_issues(findings: list[dict]) -> list[str]:
 # Case study template helpers
 # ---------------------------------------------------------------------------
 
-_ASSETS_DIR = Path(__file__).resolve().parent.parent.parent / "assets"
-_TEMPLATES_CACHE: dict | None = None
-
-
 def _load_case_study_templates() -> dict:
     """Load and cache the case study templates YAML asset."""
-    global _TEMPLATES_CACHE
-    if _TEMPLATES_CACHE is None:
-        templates_path = _ASSETS_DIR / "case_study_templates.yaml"
-        with open(templates_path) as fh:
-            _TEMPLATES_CACHE = yaml.safe_load(fh)
-    return _TEMPLATES_CACHE
+    return AssetRegistry.load("case_study_templates.yaml")
 
 
 def get_case_study_template(

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/reporting_tools.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/reporting_tools.py
@@ -1,3 +1,8 @@
+from pathlib import Path
+
+import yaml
+
+
 def write_docx_from_template(template: str, context: dict) -> str:
     return f"docx://{template}?keys={','.join(sorted(context.keys()))}"
 
@@ -12,3 +17,167 @@ def export_backlog_csv(findings: list[dict]) -> str:
 
 def create_jira_issues(findings: list[dict]) -> list[str]:
     return [f"A11Y-{idx + 1}" for idx, _ in enumerate(findings)]
+
+
+# ---------------------------------------------------------------------------
+# Case study template helpers
+# ---------------------------------------------------------------------------
+
+_ASSETS_DIR = Path(__file__).resolve().parent.parent.parent / "assets"
+_TEMPLATES_CACHE: dict | None = None
+
+
+def _load_case_study_templates() -> dict:
+    """Load and cache the case study templates YAML asset."""
+    global _TEMPLATES_CACHE
+    if _TEMPLATES_CACHE is None:
+        templates_path = _ASSETS_DIR / "case_study_templates.yaml"
+        with open(templates_path) as fh:
+            _TEMPLATES_CACHE = yaml.safe_load(fh)
+    return _TEMPLATES_CACHE
+
+
+def get_case_study_template(
+    template_key: str,
+    industry: str | None = None,
+) -> dict:
+    """Return a case study template definition by key.
+
+    Args:
+        template_key: One of ``comprehensive``, ``basic_audit``,
+            ``premium_assessment``, ``enterprise_analysis``,
+            ``executive_summary``, or ``video_script``.
+        industry: Optional industry slug (``ecommerce``, ``saas``,
+            ``healthcare``) to fetch an industry-specific template instead.
+
+    Returns:
+        The template definition dict from the YAML asset.
+    """
+    data = _load_case_study_templates()
+    if industry and industry in data.get("industry_templates", {}):
+        return data["industry_templates"][industry]
+    return data["templates"].get(template_key, data["templates"]["comprehensive"])
+
+
+def render_case_study(
+    engagement_id: str,
+    findings: list[dict],
+    client_context: dict,
+    template_key: str = "comprehensive",
+    industry: str | None = None,
+) -> dict:
+    """Render a case study document from audit findings and client data.
+
+    This tool selects the appropriate template based on ``template_key``
+    and optional ``industry``, then merges the engagement findings and
+    ``client_context`` values into the template structure.
+
+    Args:
+        engagement_id: The engagement/audit identifier.
+        findings: List of finding dicts from the audit pipeline.
+        client_context: Client-provided data to populate template
+            placeholders (company name, metrics, testimonials, etc.).
+        template_key: Template variant to use.
+        industry: Optional industry slug for an industry-specific template.
+
+    Returns:
+        Dict with ``template_used``, ``artifact`` reference path,
+        ``sections`` populated with merged data, and summary ``metrics``.
+    """
+    template = get_case_study_template(template_key, industry)
+    template_name = template.get("name", template_key)
+
+    # Derive summary metrics from findings
+    severity_counts = {}
+    for f in findings:
+        sev = f.get("severity", "unknown")
+        severity_counts[sev] = severity_counts.get(sev, 0) + 1
+
+    metrics = {
+        "total_findings": len(findings),
+        "severity_breakdown": severity_counts,
+        "wcag_compliance_before_pct": client_context.get("wcag_compliance_before_pct"),
+        "wcag_compliance_after_pct": client_context.get("wcag_compliance_after_pct"),
+        "conversion_rate_improvement_pct": client_context.get("conversion_rate_improvement_pct"),
+        "user_satisfaction_before": client_context.get("user_satisfaction_before"),
+        "user_satisfaction_after": client_context.get("user_satisfaction_after"),
+    }
+    # Strip None values
+    metrics = {k: v for k, v in metrics.items() if v is not None}
+
+    sections = _populate_template_sections(template, client_context, findings)
+
+    artifact_ref = f"case_study_{engagement_id}_{template_key}.json"
+
+    return {
+        "template_used": template_name,
+        "template_key": template_key,
+        "industry": industry,
+        "engagement_id": engagement_id,
+        "artifact": artifact_ref,
+        "sections": sections,
+        "metrics": metrics,
+    }
+
+
+def _populate_template_sections(
+    template: dict,
+    client_context: dict,
+    findings: list[dict],
+) -> list[dict]:
+    """Walk template sections and fill placeholders from client_context."""
+    populated: list[dict] = []
+
+    # Handle standard templates (have "sections" key)
+    raw_sections = template.get("sections", [])
+    for section in raw_sections:
+        if isinstance(section, dict):
+            for section_name, section_def in section.items():
+                filled = {"section": section_name}
+                if isinstance(section_def, dict):
+                    # Pull matching fields from client_context
+                    for key in section_def.get("fields", []):
+                        filled[key] = client_context.get(key, f"[{key}]")
+                    if "metrics" in section_def:
+                        filled["metrics"] = {
+                            m: client_context.get(m) for m in section_def["metrics"]
+                        }
+                    if "items" in section_def:
+                        filled["items"] = section_def["items"]
+                filled["finding_count"] = len(findings)
+                populated.append(filled)
+
+    # Handle industry templates (have different structure)
+    if "solution_focus" in template:
+        populated.append({"section": "solution_focus", "items": template["solution_focus"]})
+    if "challenge_areas" in template:
+        populated.append({"section": "challenge_areas", "items": template["challenge_areas"]})
+    if "result_metrics" in template:
+        populated.append({
+            "section": "result_metrics",
+            "metrics": {m: client_context.get(m) for m in template["result_metrics"]},
+        })
+
+    return populated
+
+
+def list_case_study_templates() -> dict:
+    """Return a summary of all available case study templates.
+
+    Returns:
+        Dict with ``templates`` and ``industry_templates`` keys, each
+        mapping template keys to their name and description.
+    """
+    data = _load_case_study_templates()
+    summary: dict = {"templates": {}, "industry_templates": {}}
+    for key, tpl in data.get("templates", {}).items():
+        summary["templates"][key] = {
+            "name": tpl.get("name", key),
+            "description": tpl.get("description", ""),
+        }
+    for key, tpl in data.get("industry_templates", {}).items():
+        summary["industry_templates"][key] = {
+            "name": tpl.get("name", key),
+            "description": tpl.get("description", ""),
+        }
+    return summary

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/template_audit_engine.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/app/tools/template_audit_engine.py
@@ -1,0 +1,241 @@
+"""Generic template-driven audit engine.
+
+Owns the complete pipeline for any YAML-based accessibility audit:
+load template → walk sections → apply overrides → score → build report.
+
+The architecture audit is the first consumer; future template-based audits
+(forms, media, ARIA patterns, etc.) reuse the same engine with a different
+YAML template filename.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from ..models.architecture import (
+    ArchitectureAuditResult,
+    ArchitectureChecklistItem,
+    ArchitectureSectionResult,
+    WCAGCriterionStatus,
+)
+from ..models.grading import GradingScale
+from .asset_registry import AssetRegistry
+from .storage_tools import persist_artifact
+
+# ---------------------------------------------------------------------------
+# SC name extraction (refactoring #6 — derive from YAML, not Python)
+# ---------------------------------------------------------------------------
+
+# Regex to pull "X.Y.Z Name" from labels like
+# "2.4.7 Focus Visible - Visible focus indicator on all navigation items"
+_SC_LABEL_RE = re.compile(r"^(\d+\.\d+\.\d+)\s+(.+?)(?:\s*-|$)")
+
+
+def _extract_sc_names_from_template(template: dict) -> dict[str, str]:
+    """Build an SC-number → human-readable-name map from the WCAG
+    Compliance Summary section labels.
+
+    Falls back to an empty string for criteria not present in the template.
+    """
+    sc_names: dict[str, str] = {}
+    for section in template.get("sections", []):
+        if section.get("id") != "wcag_compliance_summary":
+            continue
+        for sub in section.get("subsections", []):
+            for item in sub.get("checklist_items", []):
+                label = item.get("label", "")
+                match = _SC_LABEL_RE.match(label)
+                if match:
+                    sc_names[match.group(1)] = match.group(2).strip()
+    return sc_names
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers (refactoring #5 — single public flattener)
+# ---------------------------------------------------------------------------
+
+
+def flatten_checklist_items(section_def: dict) -> list[dict]:
+    """Extract all checklist items from a template section's subsections.
+
+    This is the **single source of truth** for walking the
+    ``subsections → checklist_items`` hierarchy in any YAML audit template.
+    """
+    items: list[dict] = []
+    for sub in section_def.get("subsections", []):
+        for item in sub.get("checklist_items", []):
+            items.append(item)
+    return items
+
+
+# ---------------------------------------------------------------------------
+# Engine
+# ---------------------------------------------------------------------------
+
+
+class TemplateAuditEngine:
+    """Generic pipeline for YAML-template-driven accessibility audits.
+
+    Usage::
+
+        engine = TemplateAuditEngine("site_architecture_audit_template.yaml")
+        report = engine.evaluate("https://example.com", overrides, recs)
+        path   = engine.persist(report, "/artifacts/eng-123")
+    """
+
+    def __init__(self, template_name: str) -> None:
+        self.template: dict = AssetRegistry.load(template_name)
+        self.grading: GradingScale = GradingScale.from_template(self.template)
+        self._sc_names: dict[str, str] = _extract_sc_names_from_template(self.template)
+
+    # -- scoring -----------------------------------------------------------
+
+    def score_section(
+        self,
+        section_id: str,
+        section_name: str,
+        results: list[dict[str, Any]],
+    ) -> ArchitectureSectionResult:
+        """Score a single section from a list of checklist-item result dicts."""
+        items = [ArchitectureChecklistItem(**r) for r in results]
+        total = len(items)
+        tested = [it for it in items if it.passed is not None]
+        tested_count = len(tested)
+        passed = sum(1 for it in tested if it.passed)
+        pct = (passed / tested_count * 100) if tested_count else 0.0
+        issues = [it.label for it in items if it.passed is False]
+
+        return ArchitectureSectionResult(
+            section_id=section_id,
+            name=section_name,
+            items=items,
+            tested_count=tested_count,
+            passed_count=passed,
+            total_count=total,
+            score_pct=round(pct, 1),
+            grade=self.grading.grade(pct),
+            issues=issues,
+        )
+
+    # -- WCAG compliance ---------------------------------------------------
+
+    def _collect_wcag_statuses(
+        self, sections: list[ArchitectureSectionResult]
+    ) -> list[WCAGCriterionStatus]:
+        sc_map: dict[str, dict[str, Any]] = {}
+        for section in sections:
+            for item in section.items:
+                if not item.wcag_ref:
+                    continue
+                sc = item.wcag_ref
+                if sc not in sc_map:
+                    sc_map[sc] = {
+                        "items": [],
+                        "passed": [],
+                        "failed": [],
+                        "not_tested": [],
+                        "wcag_level": "",
+                    }
+                sc_map[sc]["items"].append(item.id)
+                if item.passed is True:
+                    sc_map[sc]["passed"].append(item.id)
+                elif item.passed is False:
+                    sc_map[sc]["failed"].append(item.id)
+                else:
+                    sc_map[sc]["not_tested"].append(item.id)
+                if item.wcag_level and not sc_map[sc]["wcag_level"]:
+                    sc_map[sc]["wcag_level"] = item.wcag_level
+
+        statuses: list[WCAGCriterionStatus] = []
+        for sc, data in sorted(sc_map.items()):
+            if data["failed"]:
+                status = "fail" if not data["passed"] else "partial"
+            elif data["passed"]:
+                status = "pass"
+            else:
+                status = "not_tested"
+            statuses.append(
+                WCAGCriterionStatus(
+                    sc=sc,
+                    name=self._sc_names.get(sc, ""),
+                    wcag_level=data["wcag_level"],
+                    status=status,
+                    related_items=data["items"],
+                )
+            )
+        return statuses
+
+    # -- full evaluate pipeline --------------------------------------------
+
+    def evaluate(
+        self,
+        target: str,
+        overrides: dict[str, dict[str, Any]] | None = None,
+        recommendations: list[str] | None = None,
+    ) -> ArchitectureAuditResult:
+        """Run the full template-driven audit pipeline.
+
+        Args:
+            target: URL or identifier being audited.
+            overrides: Map of checklist-item ID →
+                ``{"passed": bool | None, "notes": str}``.
+            recommendations: Prioritized recommendation strings.
+
+        Returns:
+            Fully scored :class:`ArchitectureAuditResult`.
+        """
+        overrides = overrides or {}
+        section_results: list[ArchitectureSectionResult] = []
+
+        for section_def in self.template.get("sections", []):
+            section_id = section_def["id"]
+            section_name = section_def["name"]
+            template_items = flatten_checklist_items(section_def)
+
+            evaluated: list[dict] = []
+            for item in template_items:
+                item_id = item["id"]
+                override = overrides.get(item_id, {})
+                evaluated.append(
+                    {
+                        "id": item_id,
+                        "label": item.get("label", ""),
+                        "passed": override.get("passed"),
+                        "notes": override.get("notes", ""),
+                        "wcag_ref": item.get("wcag_ref"),
+                        "wcag_level": item.get("wcag_level"),
+                        "test_method": item.get("test_method", ""),
+                    }
+                )
+
+            scored = self.score_section(section_id, section_name, evaluated)
+            section_results.append(scored)
+
+        return self.build_report(target, section_results, recommendations)
+
+    def build_report(
+        self,
+        target: str,
+        section_results: list[ArchitectureSectionResult],
+        recommendations: list[str] | None = None,
+    ) -> ArchitectureAuditResult:
+        """Assemble a full report from scored sections (equal section weighting)."""
+        scored = [s for s in section_results if s.tested_count > 0]
+        overall_pct = sum(s.score_pct for s in scored) / len(scored) if scored else 0.0
+        wcag_compliance = self._collect_wcag_statuses(section_results)
+
+        return ArchitectureAuditResult(
+            target=target,
+            sections=section_results,
+            overall_score_pct=round(overall_pct, 1),
+            overall_grade=self.grading.grade(overall_pct),
+            wcag_compliance=wcag_compliance,
+            recommendations=recommendations or [],
+        )
+
+    # -- persistence -------------------------------------------------------
+
+    def persist(self, result: ArchitectureAuditResult, artifact_root: str) -> str:
+        """Persist the audit result as ``architecture.json`` under *artifact_root*."""
+        return persist_artifact(f"{artifact_root}/architecture.json", result.model_dump())

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/assets/case_study_templates.yaml
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/assets/case_study_templates.yaml
@@ -1,0 +1,460 @@
+# Accessibility Audit Case Study Templates
+#
+# These templates are used by the reporting pipeline to generate
+# structured case study documents from audit findings and client data.
+# Agents select the appropriate template based on service tier and
+# industry, then populate placeholders with engagement-specific data.
+
+templates:
+  comprehensive:
+    name: "Comprehensive Case Study"
+    description: "Detailed success story for website and proposal use"
+    sections:
+      - header:
+          fields:
+            - client_company_name
+            - compelling_headline
+            - industry_sector
+            - employee_count
+            - service_tier
+            - timeline
+            - key_metric_improvement
+      - executive_summary:
+          fields:
+            - primary_objective
+            - key_results_summary
+            - additional_benefits
+          key_results:
+            count: 3
+            fields_per_result:
+              - metric_name
+              - improvement_percentage
+              - specific_area
+              - timeframe
+      - challenge:
+          subsections:
+            - business_context:
+                fields:
+                  - business_situation
+                  - strategic_objective
+                  - company_description
+                  - target_audience
+                  - competitive_landscape
+            - accessibility_challenges:
+                count: 3
+                fields_per_challenge:
+                  - challenge_name
+                  - detailed_description_with_impact
+            - business_impact:
+                categories:
+                  - user_experience_issues
+                  - business_consequences
+                  - compliance_concerns
+                  - competitive_disadvantages
+            - previous_attempts:
+                fields:
+                  - previous_attempts_description
+                  - limitations_of_previous_approaches
+                  - desired_outcome
+      - solution:
+          subsections:
+            - differentiators:
+                count: 3
+                fields_per_item:
+                  - differentiator_name
+                  - specific_advantage
+            - phases:
+                count: 3
+                fields_per_phase:
+                  - phase_name
+                  - duration
+                  - activities
+            - methodology_benefits:
+                count: 3
+                fields_per_item:
+                  - benefit_name
+                  - specific_advantage
+      - implementation:
+          subsections:
+            - team_collaboration:
+                count: 3
+                fields_per_stakeholder:
+                  - stakeholder_role
+                  - contribution
+            - highlights:
+                count: 3
+                fields_per_item:
+                  - highlight_name
+                  - description_and_impact
+            - challenges_overcome:
+                fields:
+                  - obstacle_encountered
+                  - how_addressed
+                  - positive_outcome
+            - client_testimonial:
+                fields:
+                  - quote
+                  - client_name
+                  - client_title
+      - results:
+          subsections:
+            - user_experience:
+                metrics:
+                  - task_completion_rate_before
+                  - task_completion_rate_after
+                  - user_satisfaction_before
+                  - user_satisfaction_after
+                  - support_ticket_reduction_pct
+            - business_performance:
+                metrics:
+                  - conversion_rate_improvement_pct
+                  - revenue_impact_amount
+                  - market_expansion_pct
+            - technical_excellence:
+                metrics:
+                  - wcag_compliance_before_pct
+                  - wcag_compliance_after_pct
+                  - performance_improvement
+                  - dev_efficiency_reduction_pct
+            - risk_mitigation:
+                fields:
+                  - legal_risk_reduction
+                  - brand_protection
+                  - regulatory_compliance
+            - strategic_benefits:
+                fields:
+                  - competitive_advantage
+                  - innovation_catalyst
+                  - team_capability
+      - long_term_impact:
+          subsections:
+            - ongoing_success:
+                count: 3
+                fields_per_metric:
+                  - metric_name
+                  - sustained_performance
+            - continued_partnership:
+                fields:
+                  - follow_up_engagements
+                  - referral_activity
+            - results_testimonial:
+                fields:
+                  - quote
+                  - client_name
+                  - client_title
+      - key_takeaways:
+          subsections:
+            - lessons:
+                count: 3
+                fields_per_lesson:
+                  - lesson_name
+                  - insight
+            - success_factors:
+                fields:
+                  - executive_sponsorship
+                  - cross_functional_collaboration
+                  - systematic_approach
+            - recommendations:
+                count: 3
+                fields_per_item:
+                  - recommendation
+                  - action_guidance
+
+  basic_audit:
+    name: "Basic Audit Case Study"
+    description: "Efficient accessibility compliance achievement"
+    sections:
+      - situation:
+          fields:
+            - client_company_name
+            - company_size
+            - industry
+            - business_reason
+      - solution:
+          items:
+            - "Strategic Planning: Business-aligned audit scope and prioritization"
+            - "Component Analysis: Systematic evaluation of 12 key UI patterns"
+            - "WCAG Assessment: Comprehensive Level A and AA compliance review"
+            - "Implementation Roadmap: Clear 30/60/90-day action plan"
+      - results:
+          metrics:
+            - wcag_compliance_before_pct
+            - wcag_compliance_after_pct
+            - component_fix_coverage_pct
+            - cost_savings_amount
+      - client_impact:
+          fields:
+            - testimonial_quote
+            - client_name
+            - client_title
+      - investment:
+          fields:
+            - duration
+            - investment_amount
+            - payback_period
+
+  premium_assessment:
+    name: "Premium Assessment Case Study"
+    description: "Complete user experience transformation"
+    sections:
+      - challenge:
+          fields:
+            - client_company_name
+            - transformation_goal
+            - comprehensive_assessment_need
+      - approach:
+          items:
+            - "User Journey Testing: End-to-end workflow evaluation with assistive technologies"
+            - "Navigation Architecture: Complete information architecture optimization"
+            - "Component Excellence: Advanced design system accessibility integration"
+            - "Cross-Platform Optimization: Mobile and responsive accessibility enhancement"
+      - results:
+          metrics:
+            - task_completion_improvement_pct
+            - customer_satisfaction_before
+            - customer_satisfaction_after
+            - conversion_rate_improvement_pct
+            - user_base_increase_pct
+      - strategic_benefits:
+          fields:
+            - competitive_advantage
+            - brand_enhancement
+            - innovation_catalyst
+            - team_development
+      - client_testimonial:
+          fields:
+            - quote
+            - client_name
+            - client_title
+
+  enterprise_analysis:
+    name: "Enterprise Analysis Case Study"
+    description: "Strategic accessibility leadership and organizational transformation"
+    sections:
+      - executive_summary:
+          fields:
+            - client_company_name
+            - company_size
+            - industry
+            - engagement_scope
+      - strategic_objectives:
+          items:
+            - "Establish accessibility as competitive differentiator"
+            - "Create sustainable organizational accessibility capabilities"
+            - "Quantify business impact and ROI of accessibility investments"
+            - "Develop multi-year strategic roadmap for accessibility excellence"
+      - approach:
+          items:
+            - "Executive Alignment: C-suite strategic planning and vision development"
+            - "Technical Transformation: Complete infrastructure optimization and automation"
+            - "Business Impact Analysis: Quantified ROI modeling using actual business metrics"
+            - "Organizational Development: Capability building and governance framework"
+      - financial_impact:
+          metrics:
+            - revenue_growth_amount
+            - roi_multiplier
+            - annual_cost_savings
+            - legal_liability_reduction
+      - organizational_transformation:
+          metrics:
+            - accessibility_maturity_before
+            - accessibility_maturity_after
+            - team_competency_pct
+            - release_testing_coverage_pct
+          fields:
+            - industry_recognition
+      - market_leadership:
+          metrics:
+            - market_share_increase_pct
+            - customer_satisfaction_improvement
+          fields:
+            - thought_leadership
+      - executive_testimonial:
+          fields:
+            - quote
+            - executive_name
+            - executive_title
+
+  executive_summary:
+    name: "One-Page Executive Summary"
+    description: "Quick stakeholder consumption format"
+    sections:
+      - header:
+          fields:
+            - client_company_name
+            - industry
+            - company_size
+            - service_tier
+            - timeline
+      - challenge:
+          fields:
+            - primary_challenge
+            - business_impact
+            - solution_requirement
+            - desired_outcome
+      - solution:
+          fields:
+            - key_solution_elements
+            - methodology_advantage
+      - results:
+          count: 3
+          fields_per_result:
+            - metric_name
+            - improvement_value
+      - client_quote:
+          fields:
+            - testimonial
+            - client_name
+            - client_title
+      - call_to_action:
+          fields:
+            - industry_benefit
+            - action_statement
+
+  video_script:
+    name: "Video Case Study Script"
+    description: "Client interview script template for testimonial videos"
+    duration_minutes: 15
+    segments:
+      - opening_context:
+          duration_minutes: 2
+          questions:
+            - "Tell me about your company and your role there."
+            - "What was happening in your business that made accessibility a priority?"
+      - challenge_exploration:
+          duration_minutes: 3
+          questions:
+            - "What specific accessibility challenges were you facing?"
+            - "How were these challenges affecting your business or users?"
+            - "What had you tried before working with us?"
+      - solution_experience:
+          duration_minutes: 4
+          questions:
+            - "What attracted you to our approach over other options?"
+            - "Can you walk me through what the engagement process was like?"
+            - "What surprised you most about our methodology?"
+      - results_discussion:
+          duration_minutes: 4
+          questions:
+            - "What specific results have you seen since implementation?"
+            - "How have these changes affected your business?"
+            - "What has the user feedback been like?"
+      - closing_recommendations:
+          duration_minutes: 2
+          questions:
+            - "What would you tell other companies considering accessibility improvements?"
+            - "Would you recommend us to other organizations?"
+    key_soundbites:
+      - "Problem Statement: Clear articulation of business challenge"
+      - "Solution Value: What made our approach different/better"
+      - "Quantified Results: Specific metrics and business impact"
+      - "Emotional Impact: How it felt to achieve the results"
+      - "Peer Recommendation: Advice for similar organizations"
+
+industry_templates:
+  ecommerce:
+    name: "E-commerce Case Study"
+    description: "Accessibility-driven conversion optimization"
+    context_fields:
+      - product_category
+      - customer_base
+      - annual_revenue
+    challenge_areas:
+      - "Cart abandonment during checkout process"
+      - "Product discovery difficulties for users with disabilities"
+      - "Mobile accessibility gaps"
+    solution_focus:
+      - "Shopping Journey Optimization: Complete purchase workflow accessibility"
+      - "Product Discovery Enhancement: Search, filtering, and navigation improvements"
+      - "Checkout Process Excellence: Payment and form accessibility optimization"
+      - "Mobile Commerce Accessibility: Touch interface and responsive design optimization"
+    result_metrics:
+      - conversion_rate_improvement_pct
+      - average_order_value_increase
+      - mobile_conversion_improvement_pct
+      - new_customer_conversion_increase_pct
+
+  saas:
+    name: "SaaS Platform Case Study"
+    description: "Enterprise software accessibility and market expansion"
+    context_fields:
+      - software_category
+      - target_market
+      - active_user_count
+      - annual_recurring_revenue
+    challenge_areas:
+      - "Large clients required WCAG compliance for procurement"
+      - "User onboarding had accessibility barriers"
+      - "Administrative interfaces not accessible to all users"
+    solution_focus:
+      - "User Interface Accessibility: Complete application accessibility audit"
+      - "Onboarding Optimization: New user experience accessibility enhancement"
+      - "Administrative Access: Backend interface accessibility for all user roles"
+      - "Documentation & Support: Accessible help system and user documentation"
+    result_metrics:
+      - enterprise_contract_value
+      - feature_adoption_improvement_pct
+      - accessibility_user_satisfaction_score
+      - new_market_access
+
+  healthcare:
+    name: "Healthcare Case Study"
+    description: "Patient access and regulatory compliance"
+    context_fields:
+      - healthcare_service
+      - patient_population
+    challenge_areas:
+      - "Elderly patients unable to access online scheduling"
+      - "Patients with disabilities facing barriers in portal usage"
+      - "Mobile accessibility gaps affecting patient engagement"
+    solution_focus:
+      - "Patient Portal Optimization: Complete accessibility overhaul for patient-facing systems"
+      - "Appointment Scheduling: Accessible online booking and management"
+      - "Health Information Access: Medical record and test result accessibility"
+      - "Mobile Health Integration: Accessible mobile app and responsive design"
+    result_metrics:
+      - portal_usage_increase_pct
+      - phone_scheduling_reduction_pct
+      - digital_experience_satisfaction_score
+      - wcag_compliance_level
+
+case_study_process:
+  information_gathering:
+    steps:
+      - "Schedule success review 30-60 days after project completion"
+      - "Prepare interview guide customized for project type"
+      - "Record session with client permission for accurate quotes"
+      - "Gather specific performance data and business impact numbers"
+      - "Follow-up clarifications to confirm accuracy of all claims"
+    data_collection_checklist:
+      - "Quantified business results (conversion rates, revenue, satisfaction scores)"
+      - "Technical improvements (compliance scores, performance metrics)"
+      - "User experience enhancements (task completion, user feedback)"
+      - "Organizational benefits (team efficiency, process improvements)"
+      - "Strategic outcomes (competitive advantage, market position)"
+
+  client_approval:
+    steps:
+      - "Send complete case study draft for client review"
+      - "Verify all metrics, quotes, and company information"
+      - "Client legal/marketing team approval if required"
+      - "Confirm approved usage (website, proposals, presentations)"
+      - "Finalize client name usage vs. anonymous reference"
+    usage_rights:
+      public: "Full company name and details (website, marketing)"
+      reference_only: "Company name with limited details (proposals)"
+      anonymous: "Industry and size only (competitive sensitivity)"
+      restricted: "Internal use only (confidential information)"
+
+  distribution:
+    formats:
+      - "Website Case Study Page: Full detailed version with SEO optimization"
+      - "Sales Proposal Integration: Relevant case studies inserted in proposals"
+      - "Presentation Slides: Key highlights for sales presentations"
+      - "Social Media Content: Key results and quotes for LinkedIn/Twitter"
+      - "Trade Publication Articles: Industry-specific success stories"
+    performance_metrics:
+      - "Website Engagement: Time on page, conversion to contact forms"
+      - "Sales Impact: Proposal close rates with vs. without case studies"
+      - "Lead Generation: Case study downloads and follow-up engagement"
+      - "Social Proof: References and testimonials generated from case studies"

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/assets/references.yaml
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/assets/references.yaml
@@ -11,6 +11,16 @@ assets:
       Includes comprehensive, basic audit, premium assessment, enterprise
       analysis, executive summary, and video script templates plus
       industry-specific variants for e-commerce, SaaS, and healthcare.
+  - name: Site Architecture Audit Template
+    file: site_architecture_audit_template.yaml
+    description: >
+      Structured checklist template for evaluating site information
+      architecture and navigation systems against WCAG 2.2 Level AA.
+      Covers 13 scored sections: site structure mapping, navigation
+      systems, secondary navigation, search and discovery, content
+      organization, mobile/responsive patterns, cross-page consistency,
+      cognitive accessibility, specialized navigation, WCAG compliance
+      summary, business impact, and recommendations.
 workflow_phases:
   - discovery
   - inventory_setup

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/assets/references.yaml
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/assets/references.yaml
@@ -3,6 +3,14 @@ frameworks:
     version: "2.2"
   - name: Section 508
     version: "2017 refresh"
+assets:
+  - name: Case Study Templates
+    file: case_study_templates.yaml
+    description: >
+      Structured templates for generating accessibility audit case studies.
+      Includes comprehensive, basic audit, premium assessment, enterprise
+      analysis, executive summary, and video script templates plus
+      industry-specific variants for e-commerce, SaaS, and healthcare.
 workflow_phases:
   - discovery
   - inventory_setup

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/assets/site_architecture_audit_template.yaml
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/assets/site_architecture_audit_template.yaml
@@ -1,0 +1,722 @@
+# Site Architecture & Navigation Accessibility Audit Template
+# Structured checklist for evaluating information architecture and navigation
+# systems against WCAG 2.2 Level AA criteria.
+
+template_version: "1.0"
+name: Site Architecture & Navigation Accessibility Audit
+description: >
+  Comprehensive audit template for evaluating site information architecture,
+  navigation systems, search and discovery mechanisms, content organization,
+  mobile/responsive patterns, cross-page consistency, and cognitive
+  accessibility against WCAG 2.2 Level AA criteria.
+
+scoring:
+  grading_scale:
+    - grade: Excellent
+      min_pct: 90
+      description: Meets or exceeds WCAG 2.2 AA for navigation
+    - grade: Good
+      min_pct: 75
+      description: Minor issues that should be addressed
+    - grade: Needs Improvement
+      min_pct: 50
+      description: Significant issues affecting navigation accessibility
+    - grade: Poor
+      min_pct: 0
+      description: Critical barriers to navigation access
+
+audit_info:
+  fields:
+    - id: site_name
+      label: Site/Application Name
+    - id: audit_date
+      label: Audit Date
+    - id: auditor
+      label: Auditor
+    - id: conformance_target
+      label: Conformance Target
+      default: WCAG 2.2 Level AA
+    - id: assistive_technologies
+      label: Assistive Technologies Used
+    - id: browsers_tested
+      label: Browsers/Devices Tested
+
+sections:
+  - id: site_structure_mapping
+    name: Site Structure Mapping
+    description: Evaluate overall information architecture complexity and primary navigation structure.
+    subsections:
+      - id: architecture_complexity
+        name: Architecture Complexity Assessment
+        checklist_items:
+          - id: ssm_01
+            label: Total number of unique page templates identified and documented
+            test_method: manual_review
+          - id: ssm_02
+            label: Navigation depth levels mapped (recommended max 3 clicks to any content)
+            test_method: manual_review
+          - id: ssm_03
+            label: Primary user paths identified and tested
+            test_method: journey_walkthrough
+          - id: ssm_04
+            label: Cross-linking patterns documented
+            test_method: manual_review
+          - id: ssm_05
+            label: Orphan pages identified (pages not reachable via navigation)
+            test_method: crawl_analysis
+      - id: primary_navigation_analysis
+        name: Primary Navigation Analysis
+        checklist_items:
+          - id: ssm_06
+            label: Main navigation uses semantic <nav> element with aria-label
+            wcag_ref: "1.3.1"
+            test_method: dom_inspection
+          - id: ssm_07
+            label: Navigation landmark is unique or distinctly labeled
+            wcag_ref: "1.3.1"
+            test_method: screen_reader
+          - id: ssm_08
+            label: Current page/section indicated visually and programmatically (aria-current)
+            wcag_ref: "1.3.1"
+            test_method: dom_inspection
+          - id: ssm_09
+            label: Navigation order matches visual presentation
+            wcag_ref: "1.3.2"
+            test_method: keyboard_tab
+          - id: ssm_10
+            label: Navigation is consistent across all pages
+            wcag_ref: "3.2.3"
+            test_method: multi_page_comparison
+
+  - id: navigation_system_evaluation
+    name: Navigation System Evaluation
+    description: Evaluate global navigation, mega menus, and mobile navigation patterns.
+    subsections:
+      - id: global_navigation
+        name: Global Navigation
+        wcag_criteria:
+          - "2.4.3"
+          - "2.4.1"
+        checklist_items:
+          - id: nse_01
+            label: All navigation items reachable via keyboard (Tab/Arrow keys)
+            wcag_ref: "2.1.1"
+            test_method: keyboard_only
+          - id: nse_02
+            label: Skip navigation link provided and functional
+            wcag_ref: "2.4.1"
+            test_method: keyboard_tab
+          - id: nse_03
+            label: Focus indicator visible on all navigation items (minimum 2px, 3:1 contrast)
+            wcag_ref: "2.4.7"
+            test_method: keyboard_visual
+          - id: nse_04
+            label: Navigation items have sufficient touch target size (minimum 24x24 CSS px)
+            wcag_ref: "2.5.8"
+            test_method: measurement
+          - id: nse_05
+            label: Dropdown/flyout menus operable with keyboard and pointer
+            wcag_ref: "2.1.1"
+            test_method: keyboard_and_pointer
+          - id: nse_06
+            label: Menu state changes announced to screen readers (expanded/collapsed)
+            wcag_ref: "4.1.2"
+            test_method: screen_reader
+          - id: nse_07
+            label: Focus management correct when opening/closing submenus
+            wcag_ref: "2.4.3"
+            test_method: keyboard_focus_trace
+          - id: nse_08
+            label: Escape key closes open menus and returns focus to trigger
+            wcag_ref: "2.1.1"
+            test_method: keyboard_only
+      - id: mega_menus
+        name: Mega Menus (if applicable)
+        checklist_items:
+          - id: nse_09
+            label: Mega menu content organized with headings or groups
+            wcag_ref: "1.3.1"
+            test_method: dom_inspection
+          - id: nse_10
+            label: Arrow key navigation works within mega menu panels
+            wcag_ref: "2.1.1"
+            test_method: keyboard_only
+          - id: nse_11
+            label: Mega menu does not trap keyboard focus
+            wcag_ref: "2.1.2"
+            test_method: keyboard_trap_test
+          - id: nse_12
+            label: Content behind mega menu is inert (aria-hidden or inert attribute)
+            wcag_ref: "4.1.2"
+            test_method: dom_inspection
+      - id: mobile_navigation
+        name: Mobile Navigation (Hamburger/Drawer)
+        checklist_items:
+          - id: nse_13
+            label: Mobile menu toggle button has accessible name (e.g. Menu)
+            wcag_ref: "4.1.2"
+            test_method: screen_reader
+          - id: nse_14
+            label: Menu state communicated (aria-expanded)
+            wcag_ref: "4.1.2"
+            test_method: dom_inspection
+          - id: nse_15
+            label: Focus moves into mobile menu when opened
+            wcag_ref: "2.4.3"
+            test_method: keyboard_focus_trace
+          - id: nse_16
+            label: Focus trapped within open mobile menu
+            wcag_ref: "2.1.2"
+            test_method: keyboard_only
+          - id: nse_17
+            label: Focus returns to toggle when menu is closed
+            wcag_ref: "2.4.3"
+            test_method: keyboard_focus_trace
+          - id: nse_18
+            label: Touch gestures have accessible alternatives
+            wcag_ref: "2.5.1"
+            test_method: gesture_test
+
+  - id: secondary_navigation
+    name: Secondary Navigation
+    description: Evaluate breadcrumbs, sidebar navigation, and footer navigation.
+    subsections:
+      - id: breadcrumbs
+        name: Breadcrumbs
+        wcag_criteria:
+          - "2.4.8"
+          - "1.3.1"
+        checklist_items:
+          - id: sn_01
+            label: Breadcrumb uses <nav> with aria-label="Breadcrumb"
+            wcag_ref: "1.3.1"
+            test_method: dom_inspection
+          - id: sn_02
+            label: Breadcrumb uses ordered list (<ol>) markup
+            wcag_ref: "1.3.1"
+            test_method: dom_inspection
+          - id: sn_03
+            label: Current page indicated with aria-current="page"
+            wcag_ref: "1.3.1"
+            test_method: dom_inspection
+          - id: sn_04
+            label: Separators are decorative (not read by screen readers via aria-hidden)
+            wcag_ref: "1.3.1"
+            test_method: screen_reader
+          - id: sn_05
+            label: Breadcrumb trail accurately reflects page hierarchy
+            test_method: manual_review
+      - id: sidebar_navigation
+        name: Sidebar Navigation
+        checklist_items:
+          - id: sn_06
+            label: Sidebar uses <nav> with distinct aria-label
+            wcag_ref: "1.3.1"
+            test_method: dom_inspection
+          - id: sn_07
+            label: Expandable sections use aria-expanded
+            wcag_ref: "4.1.2"
+            test_method: dom_inspection
+          - id: sn_08
+            label: Active page/section visually and programmatically indicated
+            wcag_ref: "1.3.1"
+            test_method: screen_reader
+          - id: sn_09
+            label: Sidebar scrollable content keyboard accessible
+            wcag_ref: "2.1.1"
+            test_method: keyboard_only
+      - id: footer_navigation
+        name: Footer Navigation
+        checklist_items:
+          - id: sn_10
+            label: Footer uses <footer> landmark or role="contentinfo"
+            wcag_ref: "1.3.1"
+            test_method: dom_inspection
+          - id: sn_11
+            label: Footer links organized with headings or lists
+            wcag_ref: "1.3.1"
+            test_method: dom_inspection
+          - id: sn_12
+            label: Footer links have descriptive text (no generic "click here")
+            wcag_ref: "2.4.4"
+            test_method: screen_reader
+
+  - id: search_and_discovery
+    name: Search & Discovery
+    description: Evaluate search UI, results presentation, and filtering/sorting mechanisms.
+    wcag_criteria:
+      - "3.3.2"
+      - "2.4.5"
+    subsections:
+      - id: search_interface
+        name: Search Interface
+        checklist_items:
+          - id: sd_01
+            label: Search input has visible label or accessible name
+            wcag_ref: "3.3.2"
+            test_method: screen_reader
+          - id: sd_02
+            label: Search is available from every page (WCAG 2.4.5 alternative)
+            wcag_ref: "2.4.5"
+            test_method: multi_page_comparison
+          - id: sd_03
+            label: Search suggestions/autocomplete announced to screen readers (aria-live or combobox)
+            wcag_ref: "4.1.3"
+            test_method: screen_reader
+          - id: sd_04
+            label: Search suggestions keyboard navigable
+            wcag_ref: "2.1.1"
+            test_method: keyboard_only
+          - id: sd_05
+            label: Search can be submitted via Enter key
+            wcag_ref: "2.1.1"
+            test_method: keyboard_only
+      - id: search_results
+        name: Search Results
+        checklist_items:
+          - id: sd_06
+            label: Search results count announced
+            wcag_ref: "4.1.3"
+            test_method: screen_reader
+          - id: sd_07
+            label: Results use semantic structure (headings, lists)
+            wcag_ref: "1.3.1"
+            test_method: dom_inspection
+          - id: sd_08
+            label: No-results state clearly communicated
+            wcag_ref: "4.1.3"
+            test_method: screen_reader
+          - id: sd_09
+            label: Pagination controls accessible and announce current position
+            wcag_ref: "4.1.2"
+            test_method: screen_reader
+      - id: filtering_and_sorting
+        name: Filtering & Sorting
+        checklist_items:
+          - id: sd_10
+            label: Filter controls are keyboard accessible
+            wcag_ref: "2.1.1"
+            test_method: keyboard_only
+          - id: sd_11
+            label: Applied filters visually shown and announced
+            wcag_ref: "4.1.3"
+            test_method: screen_reader
+          - id: sd_12
+            label: Filter changes communicate updated result count
+            wcag_ref: "4.1.3"
+            test_method: screen_reader
+          - id: sd_13
+            label: Sort controls indicate current sort direction
+            wcag_ref: "4.1.2"
+            test_method: dom_inspection
+
+  - id: content_organization
+    name: Content Organization & Findability
+    description: Evaluate information architecture and wayfinding patterns.
+    subsections:
+      - id: ia_assessment
+        name: Information Architecture Assessment
+        checklist_items:
+          - id: co_01
+            label: Heading hierarchy is logical (h1-h6 without skipping levels)
+            wcag_ref: "1.3.1"
+            test_method: heading_outline
+          - id: co_02
+            label: Landmarks used appropriately (main, nav, aside, footer, etc.)
+            wcag_ref: "1.3.1"
+            test_method: dom_inspection
+          - id: co_03
+            label: Page titles are unique and descriptive
+            wcag_ref: "2.4.2"
+            test_method: multi_page_comparison
+          - id: co_04
+            label: Multiple ways to find content (nav, search, sitemap)
+            wcag_ref: "2.4.5"
+            test_method: manual_review
+          - id: co_05
+            label: Related content is grouped and association communicated
+            wcag_ref: "1.3.1"
+            test_method: screen_reader
+      - id: wayfinding
+        name: Wayfinding
+        checklist_items:
+          - id: co_06
+            label: Users can determine current location within the site
+            wcag_ref: "2.4.8"
+            test_method: manual_review
+          - id: co_07
+            label: Back/forward browser navigation works correctly (especially in SPAs)
+            test_method: manual_review
+          - id: co_08
+            label: Deep-linked pages maintain navigation context
+            test_method: manual_review
+          - id: co_09
+            label: 404/error pages provide helpful navigation options
+            test_method: manual_review
+
+  - id: mobile_responsive_navigation
+    name: Mobile & Responsive Navigation
+    description: Evaluate responsive navigation patterns and progressive disclosure on mobile.
+    subsections:
+      - id: responsive_patterns
+        name: Responsive Patterns
+        checklist_items:
+          - id: mrn_01
+            label: Navigation adapts appropriately across breakpoints
+            wcag_ref: "1.4.10"
+            test_method: responsive_test
+          - id: mrn_02
+            label: No content or functionality lost at mobile breakpoints
+            wcag_ref: "1.4.10"
+            test_method: responsive_test
+          - id: mrn_03
+            label: Touch targets meet minimum size requirements (24x24 CSS px)
+            wcag_ref: "2.5.8"
+            test_method: measurement
+          - id: mrn_04
+            label: No horizontal scrolling required at 320 CSS px width
+            wcag_ref: "1.4.10"
+            test_method: reflow_test
+          - id: mrn_05
+            label: Zoom to 400% does not break navigation
+            wcag_ref: "1.4.4"
+            test_method: zoom_test
+      - id: progressive_disclosure
+        name: Progressive Disclosure
+        checklist_items:
+          - id: mrn_06
+            label: Collapsed content sections clearly indicate expandability
+            wcag_ref: "4.1.2"
+            test_method: screen_reader
+          - id: mrn_07
+            label: Show more/less controls accessible and state communicated
+            wcag_ref: "4.1.2"
+            test_method: screen_reader
+          - id: mrn_08
+            label: Tab bars/bottom navigation accessible on mobile
+            wcag_ref: "2.1.1"
+            test_method: mobile_test
+
+  - id: cross_page_consistency
+    name: Cross-Page Consistency
+    description: Evaluate visual, functional, and content consistency across pages.
+    wcag_criteria:
+      - "3.2.3"
+      - "3.2.4"
+    subsections:
+      - id: visual_consistency
+        name: Visual Consistency
+        checklist_items:
+          - id: cpc_01
+            label: Navigation position consistent across all page types
+            wcag_ref: "3.2.3"
+            test_method: multi_page_comparison
+          - id: cpc_02
+            label: Navigation labels consistent across all pages
+            wcag_ref: "3.2.3"
+            test_method: multi_page_comparison
+          - id: cpc_03
+            label: Interactive element styling consistent (buttons, links, forms)
+            wcag_ref: "3.2.4"
+            test_method: multi_page_comparison
+      - id: functional_consistency
+        name: Functional Consistency
+        checklist_items:
+          - id: cpc_04
+            label: Same keyboard patterns work throughout the site
+            wcag_ref: "3.2.4"
+            test_method: keyboard_only
+          - id: cpc_05
+            label: Screen reader experience consistent across similar components
+            wcag_ref: "3.2.4"
+            test_method: screen_reader
+          - id: cpc_06
+            label: Form interactions follow the same patterns site-wide
+            wcag_ref: "3.2.4"
+            test_method: keyboard_only
+      - id: content_consistency
+        name: Content Consistency
+        checklist_items:
+          - id: cpc_07
+            label: Error message patterns consistent across the site
+            wcag_ref: "3.3.1"
+            test_method: multi_page_comparison
+          - id: cpc_08
+            label: Help/support access consistent from all pages
+            test_method: multi_page_comparison
+          - id: cpc_09
+            label: Language and terminology consistent across navigation
+            test_method: manual_review
+
+  - id: cognitive_accessibility
+    name: Cognitive Accessibility
+    description: Evaluate mental model alignment, predictability, and cognitive load.
+    subsections:
+      - id: mental_model
+        name: Mental Model Alignment
+        checklist_items:
+          - id: ca_01
+            label: Navigation labels use plain language (no jargon)
+            test_method: manual_review
+          - id: ca_02
+            label: Navigation structure matches user expectations for the domain
+            test_method: manual_review
+          - id: ca_03
+            label: Category names are clear and mutually exclusive
+            test_method: manual_review
+      - id: predictability
+        name: Predictability
+        checklist_items:
+          - id: ca_04
+            label: No unexpected context changes on focus
+            wcag_ref: "3.2.1"
+            test_method: keyboard_focus_trace
+          - id: ca_05
+            label: No unexpected context changes on input
+            wcag_ref: "3.2.2"
+            test_method: interaction_test
+          - id: ca_06
+            label: Navigation changes are predictable and follow conventions
+            wcag_ref: "3.2.3"
+            test_method: manual_review
+      - id: cognitive_load
+        name: Cognitive Load Reduction
+        checklist_items:
+          - id: ca_07
+            label: Number of navigation items per level is manageable (Miller's Law, 7 plus/minus 2)
+            test_method: manual_review
+          - id: ca_08
+            label: Visual hierarchy clearly distinguishes primary from secondary navigation
+            test_method: visual_inspection
+          - id: ca_09
+            label: Icons paired with text labels (not icon-only navigation)
+            wcag_ref: "1.3.3"
+            test_method: visual_inspection
+          - id: ca_10
+            label: Animation/motion in navigation respects prefers-reduced-motion
+            wcag_ref: "2.3.3"
+            test_method: media_query_test
+
+  - id: specialized_navigation
+    name: Specialized Navigation Patterns
+    description: Evaluate faceted navigation, multi-site navigation, and dashboard/app navigation.
+    subsections:
+      - id: faceted_navigation
+        name: Faceted Navigation (if applicable)
+        checklist_items:
+          - id: spn_01
+            label: Facet groups use fieldset/legend or equivalent grouping
+            wcag_ref: "1.3.1"
+            test_method: dom_inspection
+          - id: spn_02
+            label: Selected facets visually and programmatically indicated
+            wcag_ref: "4.1.2"
+            test_method: screen_reader
+          - id: spn_03
+            label: Facet removal is keyboard accessible and announced
+            wcag_ref: "2.1.1"
+            test_method: keyboard_only
+          - id: spn_04
+            label: Real-time facet count updates announced to screen readers
+            wcag_ref: "4.1.3"
+            test_method: screen_reader
+      - id: multi_site_navigation
+        name: Multi-Site/Sub-Site Navigation (if applicable)
+        checklist_items:
+          - id: spn_05
+            label: Site transitions are clearly communicated
+            test_method: screen_reader
+          - id: spn_06
+            label: Consistent global navigation across sub-sites
+            wcag_ref: "3.2.3"
+            test_method: multi_page_comparison
+          - id: spn_07
+            label: Users can easily return to parent/main site
+            test_method: manual_review
+      - id: dashboard_app_navigation
+        name: Dashboard/Application Navigation (if applicable)
+        checklist_items:
+          - id: spn_08
+            label: Tab panels use correct ARIA tab pattern
+            wcag_ref: "4.1.2"
+            test_method: dom_inspection
+          - id: spn_09
+            label: Tree view navigation uses correct ARIA tree pattern
+            wcag_ref: "4.1.2"
+            test_method: dom_inspection
+          - id: spn_10
+            label: Data table navigation supports keyboard row/column traversal
+            wcag_ref: "2.1.1"
+            test_method: keyboard_only
+          - id: spn_11
+            label: Toolbar/ribbon navigation follows ARIA toolbar pattern
+            wcag_ref: "4.1.2"
+            test_method: dom_inspection
+
+  - id: wcag_compliance_summary
+    name: WCAG Compliance Summary
+    description: Summary of navigation-related WCAG 2.2 success criteria compliance.
+    subsections:
+      - id: level_a_criteria
+        name: Level A Navigation Criteria
+        checklist_items:
+          - id: wcs_01
+            label: "1.3.1 Info and Relationships - Navigation structure conveyed semantically"
+            wcag_ref: "1.3.1"
+            wcag_level: A
+          - id: wcs_02
+            label: "1.3.2 Meaningful Sequence - Navigation order matches visual order"
+            wcag_ref: "1.3.2"
+            wcag_level: A
+          - id: wcs_03
+            label: "2.1.1 Keyboard - All navigation operable via keyboard"
+            wcag_ref: "2.1.1"
+            wcag_level: A
+          - id: wcs_04
+            label: "2.1.2 No Keyboard Trap - No focus traps in navigation"
+            wcag_ref: "2.1.2"
+            wcag_level: A
+          - id: wcs_05
+            label: "2.4.1 Bypass Blocks - Skip navigation provided"
+            wcag_ref: "2.4.1"
+            wcag_level: A
+          - id: wcs_06
+            label: "2.4.2 Page Titled - Unique, descriptive page titles"
+            wcag_ref: "2.4.2"
+            wcag_level: A
+          - id: wcs_07
+            label: "2.4.3 Focus Order - Logical focus order through navigation"
+            wcag_ref: "2.4.3"
+            wcag_level: A
+          - id: wcs_08
+            label: "2.4.4 Link Purpose (In Context) - Navigation link text is descriptive"
+            wcag_ref: "2.4.4"
+            wcag_level: A
+          - id: wcs_09
+            label: "3.2.1 On Focus - No unexpected changes on navigation focus"
+            wcag_ref: "3.2.1"
+            wcag_level: A
+          - id: wcs_10
+            label: "3.2.2 On Input - No unexpected changes on navigation input"
+            wcag_ref: "3.2.2"
+            wcag_level: A
+          - id: wcs_11
+            label: "4.1.2 Name, Role, Value - Navigation components have proper ARIA"
+            wcag_ref: "4.1.2"
+            wcag_level: A
+      - id: level_aa_criteria
+        name: Level AA Navigation Criteria
+        checklist_items:
+          - id: wcs_12
+            label: "1.4.4 Resize Text - Navigation usable at 200% zoom"
+            wcag_ref: "1.4.4"
+            wcag_level: AA
+          - id: wcs_13
+            label: "1.4.10 Reflow - Navigation reflows at 320px without horizontal scroll"
+            wcag_ref: "1.4.10"
+            wcag_level: AA
+          - id: wcs_14
+            label: "2.4.5 Multiple Ways - Multiple navigation mechanisms available"
+            wcag_ref: "2.4.5"
+            wcag_level: AA
+          - id: wcs_15
+            label: "2.4.7 Focus Visible - Visible focus indicator on all navigation items"
+            wcag_ref: "2.4.7"
+            wcag_level: AA
+          - id: wcs_16
+            label: "2.5.8 Target Size (Minimum) - Navigation targets meet 24x24px minimum"
+            wcag_ref: "2.5.8"
+            wcag_level: AA
+          - id: wcs_17
+            label: "3.2.3 Consistent Navigation - Navigation consistent across pages"
+            wcag_ref: "3.2.3"
+            wcag_level: AA
+          - id: wcs_18
+            label: "3.2.4 Consistent Identification - Same functions identified consistently"
+            wcag_ref: "3.2.4"
+            wcag_level: AA
+          - id: wcs_19
+            label: "4.1.3 Status Messages - Dynamic navigation updates announced"
+            wcag_ref: "4.1.3"
+            wcag_level: AA
+
+  - id: business_impact_assessment
+    name: Business Impact Assessment
+    description: Assess the business impact of navigation accessibility barriers.
+    subsections:
+      - id: barrier_impact
+        name: Barrier Impact Analysis
+        checklist_items:
+          - id: bia_01
+            label: Critical user tasks completable with keyboard only
+            test_method: journey_walkthrough
+          - id: bia_02
+            label: Critical user tasks completable with screen reader
+            test_method: journey_walkthrough
+          - id: bia_03
+            label: Navigation does not prevent task completion on mobile
+            test_method: mobile_test
+          - id: bia_04
+            label: Navigation barriers do not create legal compliance risk
+            test_method: compliance_review
+      - id: strengths_and_opportunities
+        name: Strengths & Opportunities
+        fields:
+          - id: top_strengths
+            label: Top accessibility strengths (items to preserve)
+            field_type: text_list
+          - id: quick_wins
+            label: Quick wins (low-effort, high-impact improvements)
+            field_type: text_list
+          - id: strategic_opportunities
+            label: Strategic opportunities (longer-term improvements)
+            field_type: text_list
+
+  - id: recommendations
+    name: Recommendations & Remediation Roadmap
+    description: Prioritized recommendations for addressing identified issues.
+    priority_levels:
+      - level: critical
+        label: Critical (fix immediately)
+        description: Barriers that block access to core navigation/content for assistive technology users
+        target_timeline: 0-30 days
+      - level: high
+        label: High Priority (fix soon)
+        description: Significant friction that affects navigation usability for multiple user groups
+        target_timeline: 30-90 days
+      - level: medium
+        label: Medium Priority
+        description: Issues causing meaningful friction with workarounds available
+        target_timeline: 90-180 days
+      - level: long_term
+        label: Long-Term Improvements
+        description: Architectural or systemic improvements for sustainable accessibility
+        target_timeline: 180+ days
+    fields:
+      - id: critical_issues
+        label: Critical Issues
+        field_type: finding_list
+      - id: high_priority_issues
+        label: High Priority Issues
+        field_type: finding_list
+      - id: medium_priority_issues
+        label: Medium Priority Issues
+        field_type: finding_list
+      - id: long_term_improvements
+        label: Long-Term Improvements
+        field_type: finding_list
+
+methodology:
+  testing_approach:
+    - Automated scanning with axe-core for ARIA validation and semantic checks
+    - Manual keyboard navigation testing across all navigation patterns
+    - Screen reader testing with NVDA (Windows) and VoiceOver (macOS/iOS)
+    - Responsive testing at key breakpoints (320px, 768px, 1024px, 1920px)
+    - Cognitive walkthrough for navigation predictability and learnability
+  tools:
+    - axe-core
+    - Lighthouse
+    - NVDA
+    - VoiceOver
+    - Browser DevTools (Accessibility Inspector)
+    - Colour Contrast Analyser

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/tests/contract_tests/test_architecture_audit.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/tests/contract_tests/test_architecture_audit.py
@@ -1,0 +1,233 @@
+"""Tests for the architecture audit template, scoring tools, and agent."""
+
+import yaml
+from agents.accessibility_audit_team.a11y_agency_strands.app.agents.architecture_agent import (
+    _extract_business_impact,
+    run_architecture_audit,
+)
+from agents.accessibility_audit_team.a11y_agency_strands.app.agents.base import ToolContext
+from agents.accessibility_audit_team.a11y_agency_strands.app.tools.architecture_tools import (
+    build_architecture_audit_report,
+    load_architecture_audit_template,
+    pct_to_grade,
+    score_architecture_section,
+)
+
+# ---------------------------------------------------------------------------
+# Template loading
+# ---------------------------------------------------------------------------
+
+
+def test_template_loads_and_has_expected_structure():
+    template = load_architecture_audit_template()
+    assert "sections" in template
+    assert "scoring" in template
+    assert "methodology" in template
+    assert len(template["sections"]) == 12
+
+
+def test_template_yaml_is_valid():
+    """Verify the YAML parses without error via a cold load."""
+    from pathlib import Path
+
+    path = (
+        Path(__file__).resolve().parent.parent.parent
+        / "assets"
+        / "site_architecture_audit_template.yaml"
+    )
+    with open(path) as fh:
+        data = yaml.safe_load(fh)
+    assert data["template_version"] == "1.0"
+
+
+def test_all_checklist_items_have_unique_ids():
+    template = load_architecture_audit_template()
+    ids = []
+    for section in template["sections"]:
+        for sub in section.get("subsections", []):
+            for item in sub.get("checklist_items", []):
+                ids.append(item["id"])
+    assert len(ids) == len(set(ids)), f"Duplicate IDs found: {[x for x in ids if ids.count(x) > 1]}"
+
+
+# ---------------------------------------------------------------------------
+# Grading
+# ---------------------------------------------------------------------------
+
+
+def test_pct_to_grade_thresholds():
+    assert pct_to_grade(100.0) == "Excellent"
+    assert pct_to_grade(90.0) == "Excellent"
+    assert pct_to_grade(89.9) == "Good"
+    assert pct_to_grade(75.0) == "Good"
+    assert pct_to_grade(74.9) == "Needs Improvement"
+    assert pct_to_grade(50.0) == "Needs Improvement"
+    assert pct_to_grade(49.9) == "Poor"
+    assert pct_to_grade(0.0) == "Poor"
+
+
+# ---------------------------------------------------------------------------
+# Section scoring
+# ---------------------------------------------------------------------------
+
+
+def test_score_section_all_pass():
+    results = [
+        {"id": "a", "label": "Item A", "passed": True},
+        {"id": "b", "label": "Item B", "passed": True},
+    ]
+    section = score_architecture_section("sec1", "Section 1", results)
+    assert section.passed_count == 2
+    assert section.tested_count == 2
+    assert section.total_count == 2
+    assert section.score_pct == 100.0
+    assert section.grade == "Excellent"
+    assert section.issues == []
+
+
+def test_score_section_mixed():
+    results = [
+        {"id": "a", "label": "Item A", "passed": True},
+        {"id": "b", "label": "Item B", "passed": False, "notes": "Broken"},
+        {"id": "c", "label": "Item C", "passed": True},
+    ]
+    section = score_architecture_section("sec2", "Section 2", results)
+    assert section.passed_count == 2
+    assert section.tested_count == 3
+    assert section.score_pct == round(2 / 3 * 100, 1)
+    assert section.issues == ["Item B"]
+
+
+def test_score_section_excludes_not_tested():
+    """Items with passed=None should not count toward tested or score."""
+    results = [
+        {"id": "a", "label": "Item A", "passed": True},
+        {"id": "b", "label": "Item B", "passed": None},  # not tested
+        {"id": "c", "label": "Item C", "passed": False},
+    ]
+    section = score_architecture_section("sec3", "Section 3", results)
+    assert section.total_count == 3  # total items in template
+    assert section.tested_count == 2  # only a and c
+    assert section.passed_count == 1
+    assert section.score_pct == 50.0
+    assert "Item B" not in section.issues  # not-tested items aren't failures
+    assert "Item C" in section.issues
+
+
+def test_score_section_all_not_tested():
+    results = [
+        {"id": "a", "label": "A", "passed": None},
+        {"id": "b", "label": "B", "passed": None},
+    ]
+    section = score_architecture_section("sec4", "Section 4", results)
+    assert section.tested_count == 0
+    assert section.score_pct == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Report assembly
+# ---------------------------------------------------------------------------
+
+
+def test_report_uses_equal_section_weighting():
+    """Overall score should be mean of section percentages, not item-count-weighted."""
+    # Section A: 1/1 = 100%
+    sec_a = score_architecture_section("a", "A", [{"id": "a1", "label": "X", "passed": True}])
+    # Section B: 1/3 = 33.3%
+    sec_b = score_architecture_section(
+        "b",
+        "B",
+        [
+            {"id": "b1", "label": "X", "passed": True},
+            {"id": "b2", "label": "Y", "passed": False},
+            {"id": "b3", "label": "Z", "passed": False},
+        ],
+    )
+    report = build_architecture_audit_report("https://example.com", [sec_a, sec_b])
+    # Equal weighting: (100 + 33.3) / 2 = 66.65 → 66.7
+    # Item-count-weighted would be 2/4 = 50.0
+    expected = round((100.0 + round(1 / 3 * 100, 1)) / 2, 1)
+    assert report.overall_score_pct == expected
+    assert report.overall_score_pct != 50.0  # not item-count-weighted
+
+
+def test_report_skips_untested_sections_in_overall():
+    """Sections where nothing was tested should not pull down the overall score."""
+    sec_tested = score_architecture_section("a", "A", [{"id": "a1", "label": "X", "passed": True}])
+    sec_untested = score_architecture_section(
+        "b", "B", [{"id": "b1", "label": "Y", "passed": None}]
+    )
+    report = build_architecture_audit_report("https://example.com", [sec_tested, sec_untested])
+    assert report.overall_score_pct == 100.0  # only the tested section counts
+
+
+def test_wcag_compliance_aggregation():
+    results = [
+        {"id": "a", "label": "A", "passed": True, "wcag_ref": "2.4.7", "wcag_level": "AA"},
+        {"id": "b", "label": "B", "passed": False, "wcag_ref": "2.4.7"},
+        {"id": "c", "label": "C", "passed": True, "wcag_ref": "2.1.1"},
+    ]
+    section = score_architecture_section("s", "S", results)
+    report = build_architecture_audit_report("https://example.com", [section])
+
+    sc_map = {s.sc: s for s in report.wcag_compliance}
+    assert sc_map["2.4.7"].status == "partial"  # one pass, one fail
+    assert sc_map["2.4.7"].name == "Focus Visible"
+    assert sc_map["2.4.7"].wcag_level == "AA"
+    assert sc_map["2.1.1"].status == "pass"
+
+
+def test_wcag_not_tested_status():
+    results = [
+        {"id": "a", "label": "A", "passed": None, "wcag_ref": "2.4.1"},
+    ]
+    section = score_architecture_section("s", "S", results)
+    report = build_architecture_audit_report("https://example.com", [section])
+    sc_map = {s.sc: s for s in report.wcag_compliance}
+    assert sc_map["2.4.1"].status == "not_tested"
+
+
+# ---------------------------------------------------------------------------
+# Business impact extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extract_business_impact_from_overrides():
+    overrides = {
+        "bia_01": {"passed": True, "notes": "All tasks completable"},
+        "bia_02": {"passed": False, "notes": "Screen reader blocked on checkout"},
+        "bia_04": {"passed": True, "notes": "No legal risk identified"},
+        "top_strengths": {"items": ["Semantic nav", "Skip links"]},
+        "quick_wins": {"items": ["Add aria-current"]},
+    }
+    impact = _extract_business_impact(overrides)
+    assert impact.keyboard_tasks_completable is True
+    assert impact.screen_reader_tasks_completable is False
+    assert impact.mobile_tasks_completable is None  # bia_03 not provided
+    assert impact.legal_compliance_risk is True
+    assert impact.top_strengths == ["Semantic nav", "Skip links"]
+    assert impact.quick_wins == ["Add aria-current"]
+
+
+# ---------------------------------------------------------------------------
+# Full agent tool contract
+# ---------------------------------------------------------------------------
+
+
+def test_architecture_agent_tool_contract(tmp_path):
+    overrides = {
+        "ssm_01": {"passed": True, "notes": "5 templates found"},
+        "nse_01": {"passed": True},
+        "nse_03": {"passed": False, "notes": "Focus ring only 1px"},
+    }
+    context = ToolContext(
+        {
+            "artifact_root": str(tmp_path),
+            "checklist_results": overrides,
+            "recommendations": ["Fix focus indicators"],
+        }
+    )
+    result = run_architecture_audit("https://example.com", context)
+    assert result["phase"] == "architecture_audit"
+    assert result["artifact"].endswith("architecture.json")
+    assert result["overall_grade"] in {"Excellent", "Good", "Needs Improvement", "Poor"}

--- a/backend/agents/accessibility_audit_team/a11y_agency_strands/tests/contract_tests/test_refactored_abstractions.py
+++ b/backend/agents/accessibility_audit_team/a11y_agency_strands/tests/contract_tests/test_refactored_abstractions.py
@@ -1,0 +1,171 @@
+"""Tests for the refactored abstractions: AssetRegistry, GradingScale,
+TemplateAuditEngine, PhaseResult, and flatten_checklist_items."""
+
+from agents.accessibility_audit_team.a11y_agency_strands.app.models.grading import GradingScale
+from agents.accessibility_audit_team.a11y_agency_strands.app.models.phase_result import (
+    ArchitecturePhaseResult,
+    ComponentAuditResult,
+    PhaseResult,
+)
+from agents.accessibility_audit_team.a11y_agency_strands.app.tools.asset_registry import (
+    AssetRegistry,
+)
+from agents.accessibility_audit_team.a11y_agency_strands.app.tools.template_audit_engine import (
+    TemplateAuditEngine,
+    _extract_sc_names_from_template,
+    flatten_checklist_items,
+)
+
+# ---------------------------------------------------------------------------
+# AssetRegistry
+# ---------------------------------------------------------------------------
+
+
+class TestAssetRegistry:
+    def test_loads_yaml_by_name(self):
+        data = AssetRegistry.load("site_architecture_audit_template.yaml")
+        assert data["template_version"] == "1.0"
+
+    def test_caches_across_calls(self):
+        a = AssetRegistry.load("site_architecture_audit_template.yaml")
+        b = AssetRegistry.load("site_architecture_audit_template.yaml")
+        assert a is b
+
+    def test_loads_case_study_templates(self):
+        data = AssetRegistry.load("case_study_templates.yaml")
+        assert "templates" in data
+
+
+# ---------------------------------------------------------------------------
+# GradingScale
+# ---------------------------------------------------------------------------
+
+
+class TestGradingScale:
+    def test_from_template(self):
+        template = AssetRegistry.load("site_architecture_audit_template.yaml")
+        scale = GradingScale.from_template(template)
+        assert scale.grade(100) == "Excellent"
+        assert scale.grade(90) == "Excellent"
+        assert scale.grade(89) == "Good"
+        assert scale.grade(75) == "Good"
+        assert scale.grade(50) == "Needs Improvement"
+        assert scale.grade(49) == "Poor"
+
+    def test_fallback_when_scoring_missing(self):
+        scale = GradingScale.from_template({})
+        assert scale.grade(95) == "Excellent"
+        assert scale.grade(40) == "Poor"
+
+    def test_frozen(self):
+        scale = GradingScale.from_template({})
+        try:
+            scale.thresholds = ()  # type: ignore[misc]
+            raise AssertionError("Should be frozen")
+        except AttributeError:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# flatten_checklist_items
+# ---------------------------------------------------------------------------
+
+
+class TestFlattenChecklistItems:
+    def test_flattens_subsections(self):
+        section = {
+            "subsections": [
+                {"checklist_items": [{"id": "a"}, {"id": "b"}]},
+                {"checklist_items": [{"id": "c"}]},
+            ]
+        }
+        assert [it["id"] for it in flatten_checklist_items(section)] == ["a", "b", "c"]
+
+    def test_empty_section(self):
+        assert flatten_checklist_items({}) == []
+        assert flatten_checklist_items({"subsections": []}) == []
+
+
+# ---------------------------------------------------------------------------
+# SC names extraction from YAML (#6)
+# ---------------------------------------------------------------------------
+
+
+class TestSCNamesFromYAML:
+    def test_extracts_names_from_wcag_compliance_summary(self):
+        template = AssetRegistry.load("site_architecture_audit_template.yaml")
+        names = _extract_sc_names_from_template(template)
+        assert names["2.4.7"] == "Focus Visible"
+        assert names["2.1.1"] == "Keyboard"
+        assert names["4.1.3"] == "Status Messages"
+        # Should have entries for both Level A and AA
+        assert len(names) >= 15
+
+    def test_returns_empty_for_missing_section(self):
+        assert _extract_sc_names_from_template({"sections": []}) == {}
+
+
+# ---------------------------------------------------------------------------
+# TemplateAuditEngine
+# ---------------------------------------------------------------------------
+
+
+class TestTemplateAuditEngine:
+    def test_evaluate_returns_result(self):
+        engine = TemplateAuditEngine("site_architecture_audit_template.yaml")
+        report = engine.evaluate("https://example.com")
+        assert report.target == "https://example.com"
+        assert len(report.sections) == 12
+        assert report.overall_grade in {"Excellent", "Good", "Needs Improvement", "Poor"}
+
+    def test_evaluate_with_overrides(self):
+        engine = TemplateAuditEngine("site_architecture_audit_template.yaml")
+        overrides = {"nse_01": {"passed": True}, "nse_02": {"passed": False}}
+        report = engine.evaluate("https://example.com", overrides)
+        # At least nse_01 and nse_02 should be in a section's items
+        nav_section = next(
+            s for s in report.sections if s.section_id == "navigation_system_evaluation"
+        )
+        item_map = {it.id: it for it in nav_section.items}
+        assert item_map["nse_01"].passed is True
+        assert item_map["nse_02"].passed is False
+
+    def test_persist(self, tmp_path):
+        engine = TemplateAuditEngine("site_architecture_audit_template.yaml")
+        report = engine.evaluate("https://example.com")
+        path = engine.persist(report, str(tmp_path))
+        assert path.endswith("architecture.json")
+
+    def test_grading_scale_is_from_template(self):
+        engine = TemplateAuditEngine("site_architecture_audit_template.yaml")
+        assert engine.grading.grade(95) == "Excellent"
+
+    def test_wcag_names_derived_from_yaml(self):
+        engine = TemplateAuditEngine("site_architecture_audit_template.yaml")
+        assert "2.4.7" in engine._sc_names
+        assert engine._sc_names["2.4.7"] == "Focus Visible"
+
+
+# ---------------------------------------------------------------------------
+# PhaseResult
+# ---------------------------------------------------------------------------
+
+
+class TestPhaseResult:
+    def test_base_model_dump(self):
+        r = PhaseResult(phase="test", artifact="/path/to/artifact.json")
+        d = r.model_dump()
+        assert d["phase"] == "test"
+        assert d["artifact"] == "/path/to/artifact.json"
+
+    def test_subclass_includes_extra_fields(self):
+        r = ComponentAuditResult(artifact="/a.json", finding_id="cmp-nav")
+        d = r.model_dump()
+        assert d["phase"] == "component_audit"
+        assert d["finding_id"] == "cmp-nav"
+
+    def test_architecture_result(self):
+        r = ArchitecturePhaseResult(artifact="/a.json", overall_grade="Good")
+        d = r.model_dump()
+        assert d["phase"] == "architecture_audit"
+        assert d["overall_grade"] == "Good"

--- a/backend/agents/accessibility_audit_team/api/main.py
+++ b/backend/agents/accessibility_audit_team/api/main.py
@@ -451,6 +451,81 @@ async def export_backlog(
 
 
 # ---------------------------------------------------------------------------
+# Case Study Endpoints
+# ---------------------------------------------------------------------------
+
+
+class CaseStudyRequest(BaseModel):
+    """Request body for case study generation."""
+
+    template_key: str = Field(
+        default="comprehensive",
+        description="Template variant: comprehensive, basic_audit, premium_assessment, "
+        "enterprise_analysis, executive_summary, or video_script",
+    )
+    industry: Optional[str] = Field(
+        default=None,
+        description="Industry-specific template: ecommerce, saas, or healthcare",
+    )
+    client_context: Dict[str, Any] = Field(
+        default_factory=dict,
+        description="Client-provided data for template placeholders",
+    )
+
+
+@router.post("/audit/{audit_id}/case-study")
+async def generate_audit_case_study(
+    audit_id: str,
+    request: CaseStudyRequest,
+) -> Dict[str, Any]:
+    """
+    Generate a case study document from audit findings using the case study templates.
+    """
+    from ..tools.audit.generate_case_study import (
+        GenerateCaseStudyInput,
+        generate_case_study,
+    )
+
+    orchestrator = get_orchestrator()
+    status = orchestrator.get_audit_status(audit_id)
+
+    if status.get("status") == "not_found":
+        raise HTTPException(status_code=404, detail=f"Audit {audit_id} not found")
+
+    findings = orchestrator.get_findings(audit_id)
+
+    input_data = GenerateCaseStudyInput(
+        audit_id=audit_id,
+        findings=findings,
+        client_context=request.client_context,
+        template_key=request.template_key,
+        industry=request.industry,
+    )
+
+    result = await generate_case_study(input_data)
+
+    return {
+        "audit_id": audit_id,
+        "artifact_ref": result.artifact_ref,
+        "template_used": result.template_used,
+        "template_key": result.template_key,
+        "industry": result.industry,
+        "sections": result.sections,
+        "metrics": result.metrics,
+    }
+
+
+@router.get("/case-study-templates")
+async def list_case_study_templates() -> Dict[str, Any]:
+    """
+    List all available case study templates and their descriptions.
+    """
+    from ..tools.audit.generate_case_study import list_available_templates
+
+    return await list_available_templates()
+
+
+# ---------------------------------------------------------------------------
 # Monitoring Endpoints (ARM Add-on)
 # ---------------------------------------------------------------------------
 

--- a/backend/agents/accessibility_audit_team/api/main.py
+++ b/backend/agents/accessibility_audit_team/api/main.py
@@ -4,7 +4,7 @@ FastAPI endpoints for the Digital Accessibility Audit Team.
 
 import logging
 import uuid
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException
 from pydantic import BaseModel, Field, field_validator
@@ -458,14 +458,20 @@ async def export_backlog(
 class CaseStudyRequest(BaseModel):
     """Request body for case study generation."""
 
-    template_key: str = Field(
+    template_key: Literal[
+        "comprehensive",
+        "basic_audit",
+        "premium_assessment",
+        "enterprise_analysis",
+        "executive_summary",
+        "video_script",
+    ] = Field(
         default="comprehensive",
-        description="Template variant: comprehensive, basic_audit, premium_assessment, "
-        "enterprise_analysis, executive_summary, or video_script",
+        description="Template variant",
     )
-    industry: Optional[str] = Field(
+    industry: Optional[Literal["ecommerce", "saas", "healthcare"]] = Field(
         default=None,
-        description="Industry-specific template: ecommerce, saas, or healthcare",
+        description="Industry-specific template override",
     )
     client_context: Dict[str, Any] = Field(
         default_factory=dict,

--- a/backend/agents/accessibility_audit_team/models.py
+++ b/backend/agents/accessibility_audit_team/models.py
@@ -416,7 +416,9 @@ class CaseStudyResult(BaseModel):
     template_key: str = Field(default="", description="Key of the template applied")
     industry: Optional[str] = Field(default=None, description="Industry template used, if any")
     sections: List[Dict[str, Any]] = Field(default_factory=list, description="Populated sections")
-    metrics: Dict[str, Any] = Field(default_factory=dict, description="Summary metrics from findings")
+    metrics: Dict[str, Any] = Field(
+        default_factory=dict, description="Summary metrics from findings"
+    )
 
 
 class ReportPackagingResult(BaseModel):
@@ -607,6 +609,54 @@ class BacklogExportResponse(BaseModel):
     format: str
     artifact_ref: str
     counts: Dict[str, int] = Field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Architecture Audit Models
+# ---------------------------------------------------------------------------
+
+
+class ArchitectureChecklistItemResult(BaseModel):
+    """Result for a single checklist item in the architecture audit."""
+
+    id: str = Field(..., description="Checklist item identifier, e.g. 'nse_01'")
+    label: str = Field(default="", description="Human-readable description of the check")
+    passed: bool = Field(..., description="Whether the item passed the audit")
+    notes: str = Field(default="", description="Auditor notes or failure details")
+    wcag_ref: Optional[str] = Field(default=None, description="WCAG SC reference, e.g. '2.4.7'")
+    test_method: str = Field(default="", description="Testing method used")
+
+
+class ArchitectureSectionScore(BaseModel):
+    """Scored result for a single audit template section."""
+
+    section_id: str = Field(..., description="Section identifier")
+    name: str = Field(default="", description="Section display name")
+    passed_count: int = Field(default=0)
+    total_count: int = Field(default=0)
+    score_pct: float = Field(default=0.0, description="Pass percentage 0.0-100.0")
+    grade: str = Field(default="", description="Excellent / Good / Needs Improvement / Poor")
+    failing_items: List[str] = Field(default_factory=list, description="Labels of failing items")
+
+
+class ArchitectureWCAGStatus(BaseModel):
+    """Per-criterion compliance status from the architecture audit."""
+
+    sc: str = Field(..., description="Success criterion number, e.g. '2.4.7'")
+    status: str = Field(default="not_tested", description="pass / fail / partial / not_tested")
+    related_items: List[str] = Field(default_factory=list, description="Checklist item IDs")
+
+
+class ArchitectureAuditPhaseResult(BaseModel):
+    """Result of the site architecture and navigation accessibility audit."""
+
+    target: str = Field(..., description="Site URL or identifier audited")
+    template_version: str = Field(default="1.0")
+    section_scores: List[ArchitectureSectionScore] = Field(default_factory=list)
+    overall_score_pct: float = Field(default=0.0, description="Weighted overall pass percentage")
+    overall_grade: str = Field(default="", description="Overall grade from scoring scale")
+    wcag_compliance: List[ArchitectureWCAGStatus] = Field(default_factory=list)
+    recommendations: List[str] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/accessibility_audit_team/models.py
+++ b/backend/agents/accessibility_audit_team/models.py
@@ -11,6 +11,30 @@ from typing import Any, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field
 
+from .a11y_agency_strands.app.models.architecture import (
+    ArchitectureAuditResult as ArchitectureAuditPhaseResult,
+)
+from .a11y_agency_strands.app.models.architecture import (
+    ArchitectureChecklistItem as ArchitectureChecklistItemResult,
+)
+from .a11y_agency_strands.app.models.architecture import (
+    ArchitectureSectionResult as ArchitectureSectionScore,
+)
+from .a11y_agency_strands.app.models.architecture import (
+    BusinessImpact as ArchitectureBusinessImpact,
+)
+from .a11y_agency_strands.app.models.architecture import (
+    WCAGCriterionStatus as ArchitectureWCAGStatus,
+)
+
+__all__ = [
+    "ArchitectureAuditPhaseResult",
+    "ArchitectureBusinessImpact",
+    "ArchitectureChecklistItemResult",
+    "ArchitectureSectionScore",
+    "ArchitectureWCAGStatus",
+]
+
 # ---------------------------------------------------------------------------
 # Phase Enum
 # ---------------------------------------------------------------------------
@@ -476,6 +500,7 @@ class AccessibilityAuditResult(BaseModel):
     verification_result: Optional[VerificationResult] = None
     report_packaging_result: Optional[ReportPackagingResult] = None
     retest_result: Optional[RetestResult] = None
+    architecture_audit_result: Optional["ArchitectureAuditPhaseResult"] = None
 
     # Final outputs
     final_findings: List[Finding] = Field(default_factory=list)
@@ -609,54 +634,6 @@ class BacklogExportResponse(BaseModel):
     format: str
     artifact_ref: str
     counts: Dict[str, int] = Field(default_factory=dict)
-
-
-# ---------------------------------------------------------------------------
-# Architecture Audit Models
-# ---------------------------------------------------------------------------
-
-
-class ArchitectureChecklistItemResult(BaseModel):
-    """Result for a single checklist item in the architecture audit."""
-
-    id: str = Field(..., description="Checklist item identifier, e.g. 'nse_01'")
-    label: str = Field(default="", description="Human-readable description of the check")
-    passed: bool = Field(..., description="Whether the item passed the audit")
-    notes: str = Field(default="", description="Auditor notes or failure details")
-    wcag_ref: Optional[str] = Field(default=None, description="WCAG SC reference, e.g. '2.4.7'")
-    test_method: str = Field(default="", description="Testing method used")
-
-
-class ArchitectureSectionScore(BaseModel):
-    """Scored result for a single audit template section."""
-
-    section_id: str = Field(..., description="Section identifier")
-    name: str = Field(default="", description="Section display name")
-    passed_count: int = Field(default=0)
-    total_count: int = Field(default=0)
-    score_pct: float = Field(default=0.0, description="Pass percentage 0.0-100.0")
-    grade: str = Field(default="", description="Excellent / Good / Needs Improvement / Poor")
-    failing_items: List[str] = Field(default_factory=list, description="Labels of failing items")
-
-
-class ArchitectureWCAGStatus(BaseModel):
-    """Per-criterion compliance status from the architecture audit."""
-
-    sc: str = Field(..., description="Success criterion number, e.g. '2.4.7'")
-    status: str = Field(default="not_tested", description="pass / fail / partial / not_tested")
-    related_items: List[str] = Field(default_factory=list, description="Checklist item IDs")
-
-
-class ArchitectureAuditPhaseResult(BaseModel):
-    """Result of the site architecture and navigation accessibility audit."""
-
-    target: str = Field(..., description="Site URL or identifier audited")
-    template_version: str = Field(default="1.0")
-    section_scores: List[ArchitectureSectionScore] = Field(default_factory=list)
-    overall_score_pct: float = Field(default=0.0, description="Weighted overall pass percentage")
-    overall_grade: str = Field(default="", description="Overall grade from scoring scale")
-    wcag_compliance: List[ArchitectureWCAGStatus] = Field(default_factory=list)
-    recommendations: List[str] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/accessibility_audit_team/models.py
+++ b/backend/agents/accessibility_audit_team/models.py
@@ -408,6 +408,17 @@ class VerificationResult(BaseModel):
     error: Optional[str] = None
 
 
+class CaseStudyResult(BaseModel):
+    """Rendered case study artifact generated from audit findings."""
+
+    artifact_ref: str = Field(default="", description="Reference path to the case study artifact")
+    template_used: str = Field(default="", description="Name of the template applied")
+    template_key: str = Field(default="", description="Key of the template applied")
+    industry: Optional[str] = Field(default=None, description="Industry template used, if any")
+    sections: List[Dict[str, Any]] = Field(default_factory=list, description="Populated sections")
+    metrics: Dict[str, Any] = Field(default_factory=dict, description="Summary metrics from findings")
+
+
 class ReportPackagingResult(BaseModel):
     """Output of the Report Packaging phase (Phase 3)."""
 
@@ -417,6 +428,9 @@ class ReportPackagingResult(BaseModel):
     executive_summary: str = Field(default="")
     roadmap: List[str] = Field(default_factory=list)
     coverage_matrix: Optional[CoverageMatrix] = None
+    case_study: Optional[CaseStudyResult] = Field(
+        default=None, description="Generated case study artifact from templates"
+    )
     export_refs: Dict[str, str] = Field(
         default_factory=dict, description="References to exported artifacts"
     )

--- a/backend/agents/accessibility_audit_team/phases/report_packaging.py
+++ b/backend/agents/accessibility_audit_team/phases/report_packaging.py
@@ -17,6 +17,7 @@ from ..agents import (
 )
 from ..agents.base import MessageBus
 from ..models import (
+    CaseStudyResult,
     CoverageMatrix,
     Finding,
     PatternCluster,
@@ -31,6 +32,7 @@ async def run_report_packaging_phase(
     coverage_matrix: Optional[CoverageMatrix] = None,
     llm_client: Optional[Any] = None,
     message_bus: Optional[MessageBus] = None,
+    client_context: Optional[Dict[str, Any]] = None,
 ) -> ReportPackagingResult:
     """
     Run the report packaging phase for final QA and report generation.
@@ -94,12 +96,20 @@ async def run_report_packaging_phase(
 
     apl_result = await apl.safe_process(apl_context)
 
+    # Generate case study from templates
+    case_study = await _generate_case_study(
+        audit_id, approved_findings, client_context or {}
+    )
+
     if apl_result.get("success"):
         report_result: ReportPackagingResult = apl_result.get("report_packaging_result")
 
         # Add coverage matrix if provided
         if coverage_matrix:
             report_result.coverage_matrix = coverage_matrix
+
+        # Attach case study
+        report_result.case_study = case_study
 
         # Add rejected findings info to summary
         if rejected_findings:
@@ -115,8 +125,46 @@ async def run_report_packaging_phase(
         executive_summary="Report generation incomplete.",
         roadmap=["Review findings and create remediation plan."],
         coverage_matrix=coverage_matrix,
+        case_study=case_study,
         summary=f"Packaged {len(approved_findings)} findings (APL processing failed)",
     )
+
+
+async def _generate_case_study(
+    audit_id: str,
+    findings: List[Finding],
+    client_context: Dict[str, Any],
+) -> Optional[CaseStudyResult]:
+    """Generate a case study using the case study templates asset."""
+    try:
+        from ..tools.audit.generate_case_study import (
+            GenerateCaseStudyInput,
+            generate_case_study,
+        )
+
+        template_key = client_context.get("service_tier", "comprehensive")
+        industry = client_context.get("industry")
+
+        input_data = GenerateCaseStudyInput(
+            audit_id=audit_id,
+            findings=findings,
+            client_context=client_context,
+            template_key=template_key,
+            industry=industry,
+        )
+        output = await generate_case_study(input_data)
+
+        return CaseStudyResult(
+            artifact_ref=output.artifact_ref,
+            template_used=output.template_used,
+            template_key=output.template_key,
+            industry=output.industry,
+            sections=output.sections,
+            metrics=output.metrics,
+        )
+    except Exception:
+        # Case study generation is non-critical; don't block report packaging
+        return None
 
 
 async def export_final_report(

--- a/backend/agents/accessibility_audit_team/tools/audit/__init__.py
+++ b/backend/agents/accessibility_audit_team/tools/audit/__init__.py
@@ -7,6 +7,12 @@ from .build_coverage_matrix import (
 )
 from .create_plan import CreatePlanInput, CreatePlanOutput, create_plan
 from .export_backlog import ExportBacklogInput, ExportBacklogOutput, export_backlog
+from .generate_case_study import (
+    GenerateCaseStudyInput,
+    GenerateCaseStudyOutput,
+    generate_case_study,
+    list_available_templates,
+)
 
 __all__ = [
     "create_plan",
@@ -18,4 +24,8 @@ __all__ = [
     "export_backlog",
     "ExportBacklogInput",
     "ExportBacklogOutput",
+    "generate_case_study",
+    "GenerateCaseStudyInput",
+    "GenerateCaseStudyOutput",
+    "list_available_templates",
 ]

--- a/backend/agents/accessibility_audit_team/tools/audit/generate_case_study.py
+++ b/backend/agents/accessibility_audit_team/tools/audit/generate_case_study.py
@@ -124,9 +124,16 @@ def _populate_sections(
     client_context: dict,
     findings: List[Finding],
 ) -> List[Dict]:
-    """Walk template sections and merge client_context values."""
+    """Walk template sections and merge client_context values.
+
+    Handles three template structures:
+    - Standard templates: ``sections`` list of ``{name: {fields, metrics, items}}``
+    - Industry templates: ``solution_focus``, ``challenge_areas``, ``result_metrics``
+    - Video script templates: ``segments`` list + ``key_soundbites``
+    """
     populated: List[Dict] = []
 
+    # --- Standard templates (sections key) ---
     raw_sections = template.get("sections", [])
     for section in raw_sections:
         if isinstance(section, dict):
@@ -144,7 +151,26 @@ def _populate_sections(
                 filled["finding_count"] = len(findings)
                 populated.append(filled)
 
-    # Industry template special keys
+    # --- Video script templates (segments + key_soundbites) ---
+    if "segments" in template:
+        for segment in template["segments"]:
+            if isinstance(segment, dict):
+                for segment_name, segment_def in segment.items():
+                    filled = {
+                        "section": segment_name,
+                        "type": "video_segment",
+                        "duration_minutes": segment_def.get("duration_minutes", 0),
+                        "questions": segment_def.get("questions", []),
+                    }
+                    populated.append(filled)
+    if "key_soundbites" in template:
+        populated.append({
+            "section": "key_soundbites",
+            "type": "video_soundbites",
+            "items": template["key_soundbites"],
+        })
+
+    # --- Industry template special keys ---
     if "solution_focus" in template:
         populated.append({"section": "solution_focus", "items": template["solution_focus"]})
     if "challenge_areas" in template:

--- a/backend/agents/accessibility_audit_team/tools/audit/generate_case_study.py
+++ b/backend/agents/accessibility_audit_team/tools/audit/generate_case_study.py
@@ -1,0 +1,175 @@
+"""
+Tool: audit.generate_case_study
+
+Generate a case study document from audit findings and client context
+using the structured case study templates asset.
+"""
+
+from pathlib import Path
+from typing import Dict, List, Literal, Optional
+
+import yaml
+from pydantic import BaseModel, Field
+
+from ...models import Finding, Severity
+
+_ASSETS_DIR = Path(__file__).resolve().parent.parent.parent / "a11y_agency_strands" / "assets"
+_TEMPLATES_CACHE: Optional[dict] = None
+
+
+def _load_templates() -> dict:
+    """Load and cache case study templates from the YAML asset."""
+    global _TEMPLATES_CACHE
+    if _TEMPLATES_CACHE is None:
+        templates_path = _ASSETS_DIR / "case_study_templates.yaml"
+        with open(templates_path) as fh:
+            _TEMPLATES_CACHE = yaml.safe_load(fh)
+    return _TEMPLATES_CACHE
+
+
+class GenerateCaseStudyInput(BaseModel):
+    """Input for generating a case study from audit results."""
+
+    audit_id: str = Field(..., description="Audit identifier")
+    findings: List[Finding] = Field(default_factory=list, description="Audit findings")
+    client_context: Dict = Field(
+        default_factory=dict,
+        description="Client-provided data for template placeholders (company name, metrics, etc.)",
+    )
+    template_key: Literal[
+        "comprehensive",
+        "basic_audit",
+        "premium_assessment",
+        "enterprise_analysis",
+        "executive_summary",
+        "video_script",
+    ] = Field(default="comprehensive", description="Case study template variant")
+    industry: Optional[Literal["ecommerce", "saas", "healthcare"]] = Field(
+        default=None, description="Optional industry-specific template override"
+    )
+
+
+class GenerateCaseStudyOutput(BaseModel):
+    """Output from generating a case study."""
+
+    artifact_ref: str = Field(..., description="Reference path to the generated case study artifact")
+    template_used: str = Field(default="", description="Name of the template applied")
+    template_key: str = Field(default="", description="Key of the template applied")
+    industry: Optional[str] = Field(default=None, description="Industry template used, if any")
+    sections: List[Dict] = Field(default_factory=list, description="Populated case study sections")
+    metrics: Dict = Field(default_factory=dict, description="Summary metrics derived from findings")
+
+
+async def generate_case_study(input_data: GenerateCaseStudyInput) -> GenerateCaseStudyOutput:
+    """
+    Generate a case study document from audit findings and client context.
+
+    Selects the appropriate template from the case study templates asset,
+    populates it with finding data and client-provided context, and returns
+    a structured case study ready for rendering into final deliverable formats.
+    """
+    data = _load_templates()
+
+    # Select template
+    if input_data.industry and input_data.industry in data.get("industry_templates", {}):
+        template = data["industry_templates"][input_data.industry]
+    else:
+        template = data["templates"].get(
+            input_data.template_key,
+            data["templates"]["comprehensive"],
+        )
+
+    template_name = template.get("name", input_data.template_key)
+
+    # Derive metrics from findings
+    severity_counts = {
+        "total": len(input_data.findings),
+        "critical": sum(1 for f in input_data.findings if f.severity == Severity.CRITICAL),
+        "high": sum(1 for f in input_data.findings if f.severity == Severity.HIGH),
+        "medium": sum(1 for f in input_data.findings if f.severity == Severity.MEDIUM),
+        "low": sum(1 for f in input_data.findings if f.severity == Severity.LOW),
+    }
+
+    metrics = {"severity_breakdown": severity_counts}
+    # Merge relevant client-context metrics
+    for key in (
+        "wcag_compliance_before_pct",
+        "wcag_compliance_after_pct",
+        "conversion_rate_improvement_pct",
+        "user_satisfaction_before",
+        "user_satisfaction_after",
+        "revenue_impact_amount",
+        "roi_multiplier",
+    ):
+        if key in input_data.client_context:
+            metrics[key] = input_data.client_context[key]
+
+    # Populate sections
+    sections = _populate_sections(template, input_data.client_context, input_data.findings)
+
+    artifact_ref = f"case_study_{input_data.audit_id}_{input_data.template_key}.json"
+
+    return GenerateCaseStudyOutput(
+        artifact_ref=artifact_ref,
+        template_used=template_name,
+        template_key=input_data.template_key,
+        industry=input_data.industry,
+        sections=sections,
+        metrics=metrics,
+    )
+
+
+def _populate_sections(
+    template: dict,
+    client_context: dict,
+    findings: List[Finding],
+) -> List[Dict]:
+    """Walk template sections and merge client_context values."""
+    populated: List[Dict] = []
+
+    raw_sections = template.get("sections", [])
+    for section in raw_sections:
+        if isinstance(section, dict):
+            for section_name, section_def in section.items():
+                filled: Dict = {"section": section_name}
+                if isinstance(section_def, dict):
+                    for key in section_def.get("fields", []):
+                        filled[key] = client_context.get(key, f"[{key}]")
+                    if "metrics" in section_def:
+                        filled["metrics"] = {
+                            m: client_context.get(m) for m in section_def["metrics"]
+                        }
+                    if "items" in section_def:
+                        filled["items"] = section_def["items"]
+                filled["finding_count"] = len(findings)
+                populated.append(filled)
+
+    # Industry template special keys
+    if "solution_focus" in template:
+        populated.append({"section": "solution_focus", "items": template["solution_focus"]})
+    if "challenge_areas" in template:
+        populated.append({"section": "challenge_areas", "items": template["challenge_areas"]})
+    if "result_metrics" in template:
+        populated.append({
+            "section": "result_metrics",
+            "metrics": {m: client_context.get(m) for m in template["result_metrics"]},
+        })
+
+    return populated
+
+
+async def list_available_templates() -> Dict:
+    """Return a summary of all available case study templates."""
+    data = _load_templates()
+    summary: Dict = {"templates": {}, "industry_templates": {}}
+    for key, tpl in data.get("templates", {}).items():
+        summary["templates"][key] = {
+            "name": tpl.get("name", key),
+            "description": tpl.get("description", ""),
+        }
+    for key, tpl in data.get("industry_templates", {}).items():
+        summary["industry_templates"][key] = {
+            "name": tpl.get("name", key),
+            "description": tpl.get("description", ""),
+        }
+    return summary

--- a/backend/agents/accessibility_audit_team/tools/web/__init__.py
+++ b/backend/agents/accessibility_audit_team/tools/web/__init__.py
@@ -15,6 +15,11 @@ from .compute_contrast_and_focus import (
     ComputeContrastAndFocusOutput,
     compute_contrast_and_focus,
 )
+from .evaluate_site_architecture import (
+    EvaluateSiteArchitectureInput,
+    EvaluateSiteArchitectureOutput,
+    evaluate_site_architecture,
+)
 from .record_keyboard_flow import (
     RecordKeyboardFlowInput,
     RecordKeyboardFlowOutput,
@@ -42,4 +47,7 @@ __all__ = [
     "compute_contrast_and_focus",
     "ComputeContrastAndFocusInput",
     "ComputeContrastAndFocusOutput",
+    "evaluate_site_architecture",
+    "EvaluateSiteArchitectureInput",
+    "EvaluateSiteArchitectureOutput",
 ]

--- a/backend/agents/accessibility_audit_team/tools/web/evaluate_site_architecture.py
+++ b/backend/agents/accessibility_audit_team/tools/web/evaluate_site_architecture.py
@@ -1,0 +1,207 @@
+"""
+Tool: web.evaluate_site_architecture
+
+Evaluate site architecture and navigation for accessibility using the
+structured audit template.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Template loading (shared asset)
+# ---------------------------------------------------------------------------
+
+_ASSETS_DIR = Path(__file__).resolve().parent.parent.parent / "a11y_agency_strands" / "assets"
+_TEMPLATE_CACHE: dict | None = None
+
+_GRADING_SCALE = [
+    (90, "Excellent"),
+    (75, "Good"),
+    (50, "Needs Improvement"),
+    (0, "Poor"),
+]
+
+
+def _pct_to_grade(pct: float) -> str:
+    for threshold, label in _GRADING_SCALE:
+        if pct >= threshold:
+            return label
+    return "Poor"
+
+
+def _load_template() -> dict:
+    global _TEMPLATE_CACHE
+    if _TEMPLATE_CACHE is None:
+        path = _ASSETS_DIR / "site_architecture_audit_template.yaml"
+        with open(path) as fh:
+            _TEMPLATE_CACHE = yaml.safe_load(fh)
+    return _TEMPLATE_CACHE
+
+
+# ---------------------------------------------------------------------------
+# I/O models
+# ---------------------------------------------------------------------------
+
+
+class ChecklistItemResult(BaseModel):
+    """Result for a single checklist item."""
+
+    id: str
+    passed: bool
+    notes: str = ""
+
+
+class SectionScore(BaseModel):
+    """Scored result for one template section."""
+
+    section_id: str
+    name: str
+    passed_count: int = 0
+    total_count: int = 0
+    score_pct: float = 0.0
+    grade: str = ""
+    failing_items: List[str] = Field(default_factory=list)
+
+
+class WCAGCriterionResult(BaseModel):
+    """Per-criterion pass/fail derived from checklist items."""
+
+    sc: str
+    status: str = "not_tested"
+    related_items: List[str] = Field(default_factory=list)
+
+
+class EvaluateSiteArchitectureInput(BaseModel):
+    """Input for evaluating site architecture accessibility."""
+
+    audit_id: str = Field(..., description="Audit identifier")
+    url: str = Field(..., description="Root URL of the site being audited")
+    checklist_overrides: Dict[str, Dict[str, Any]] = Field(
+        default_factory=dict,
+        description="Map of checklist item ID to {passed: bool, notes: str}",
+    )
+    recommendations: Optional[List[str]] = Field(
+        default=None,
+        description="Prioritized recommendation strings",
+    )
+
+
+class EvaluateSiteArchitectureOutput(BaseModel):
+    """Output from site architecture evaluation."""
+
+    url: str
+    template_version: str = "1.0"
+    section_scores: List[SectionScore] = Field(default_factory=list)
+    overall_score_pct: float = 0.0
+    overall_grade: str = ""
+    wcag_compliance: List[WCAGCriterionResult] = Field(default_factory=list)
+    recommendations: List[str] = Field(default_factory=list)
+    raw_ref: str = Field(default="", description="Reference to raw results artifact")
+
+
+# ---------------------------------------------------------------------------
+# Tool implementation
+# ---------------------------------------------------------------------------
+
+
+def _flatten_items(section_def: dict) -> list[dict]:
+    items: list[dict] = []
+    for sub in section_def.get("subsections", []):
+        for item in sub.get("checklist_items", []):
+            items.append(item)
+    return items
+
+
+async def evaluate_site_architecture(
+    input_data: EvaluateSiteArchitectureInput,
+) -> EvaluateSiteArchitectureOutput:
+    """Evaluate site architecture and navigation accessibility.
+
+    Loads the structured audit template, applies any checklist result
+    overrides from ``input_data``, scores each section, and returns
+    an overall assessment with WCAG compliance mapping.
+
+    This tool is typically called by the Web Audit Specialist (WAS)
+    or a dedicated Architecture Auditor during the architecture_audit phase.
+    """
+    template = _load_template()
+    overrides = input_data.checklist_overrides
+
+    section_scores: list[SectionScore] = []
+    # Track per-SC results for WCAG compliance mapping
+    sc_map: dict[str, dict] = {}
+
+    for section_def in template.get("sections", []):
+        section_id = section_def["id"]
+        section_name = section_def["name"]
+        template_items = _flatten_items(section_def)
+
+        total = len(template_items)
+        passed = 0
+        failing: list[str] = []
+
+        for item in template_items:
+            item_id = item["id"]
+            override = overrides.get(item_id, {})
+            item_passed = override.get("passed", False)
+
+            if item_passed:
+                passed += 1
+            else:
+                failing.append(item.get("label", item_id))
+
+            # Aggregate WCAG criterion status
+            wcag_ref = item.get("wcag_ref")
+            if wcag_ref:
+                if wcag_ref not in sc_map:
+                    sc_map[wcag_ref] = {"items": [], "passed": [], "failed": []}
+                sc_map[wcag_ref]["items"].append(item_id)
+                if item_passed:
+                    sc_map[wcag_ref]["passed"].append(item_id)
+                else:
+                    sc_map[wcag_ref]["failed"].append(item_id)
+
+        pct = (passed / total * 100) if total else 0.0
+        section_scores.append(
+            SectionScore(
+                section_id=section_id,
+                name=section_name,
+                passed_count=passed,
+                total_count=total,
+                score_pct=round(pct, 1),
+                grade=_pct_to_grade(pct),
+                failing_items=failing,
+            )
+        )
+
+    # Overall score
+    total_items = sum(s.total_count for s in section_scores)
+    total_passed = sum(s.passed_count for s in section_scores)
+    overall_pct = (total_passed / total_items * 100) if total_items else 0.0
+
+    # WCAG compliance
+    wcag_compliance: list[WCAGCriterionResult] = []
+    for sc, data in sorted(sc_map.items()):
+        if data["failed"]:
+            status = "fail" if not data["passed"] else "partial"
+        else:
+            status = "pass"
+        wcag_compliance.append(
+            WCAGCriterionResult(sc=sc, status=status, related_items=data["items"])
+        )
+
+    return EvaluateSiteArchitectureOutput(
+        url=input_data.url,
+        section_scores=section_scores,
+        overall_score_pct=round(overall_pct, 1),
+        overall_grade=_pct_to_grade(overall_pct),
+        wcag_compliance=wcag_compliance,
+        recommendations=input_data.recommendations or [],
+        raw_ref=f"arch_audit_{input_data.audit_id}_{hash(input_data.url) % 10000}",
+    )

--- a/backend/agents/accessibility_audit_team/tools/web/evaluate_site_architecture.py
+++ b/backend/agents/accessibility_audit_team/tools/web/evaluate_site_architecture.py
@@ -3,78 +3,30 @@ Tool: web.evaluate_site_architecture
 
 Evaluate site architecture and navigation for accessibility using the
 structured audit template.
+
+Delegates scoring and grading to the shared architecture tools in the
+strands implementation — no logic is duplicated here.
 """
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-import yaml
 from pydantic import BaseModel, Field
 
-# ---------------------------------------------------------------------------
-# Template loading (shared asset)
-# ---------------------------------------------------------------------------
-
-_ASSETS_DIR = Path(__file__).resolve().parent.parent.parent / "a11y_agency_strands" / "assets"
-_TEMPLATE_CACHE: dict | None = None
-
-_GRADING_SCALE = [
-    (90, "Excellent"),
-    (75, "Good"),
-    (50, "Needs Improvement"),
-    (0, "Poor"),
-]
-
-
-def _pct_to_grade(pct: float) -> str:
-    for threshold, label in _GRADING_SCALE:
-        if pct >= threshold:
-            return label
-    return "Poor"
-
-
-def _load_template() -> dict:
-    global _TEMPLATE_CACHE
-    if _TEMPLATE_CACHE is None:
-        path = _ASSETS_DIR / "site_architecture_audit_template.yaml"
-        with open(path) as fh:
-            _TEMPLATE_CACHE = yaml.safe_load(fh)
-    return _TEMPLATE_CACHE
-
+from ...a11y_agency_strands.app.models.architecture import (
+    ArchitectureSectionResult,
+    WCAGCriterionStatus,
+)
+from ...a11y_agency_strands.app.tools.architecture_tools import (
+    build_architecture_audit_report,
+    load_architecture_audit_template,
+    score_architecture_section,
+)
 
 # ---------------------------------------------------------------------------
-# I/O models
+# I/O models (thin wrappers specific to the async web-tool interface)
 # ---------------------------------------------------------------------------
-
-
-class ChecklistItemResult(BaseModel):
-    """Result for a single checklist item."""
-
-    id: str
-    passed: bool
-    notes: str = ""
-
-
-class SectionScore(BaseModel):
-    """Scored result for one template section."""
-
-    section_id: str
-    name: str
-    passed_count: int = 0
-    total_count: int = 0
-    score_pct: float = 0.0
-    grade: str = ""
-    failing_items: List[str] = Field(default_factory=list)
-
-
-class WCAGCriterionResult(BaseModel):
-    """Per-criterion pass/fail derived from checklist items."""
-
-    sc: str
-    status: str = "not_tested"
-    related_items: List[str] = Field(default_factory=list)
 
 
 class EvaluateSiteArchitectureInput(BaseModel):
@@ -84,7 +36,7 @@ class EvaluateSiteArchitectureInput(BaseModel):
     url: str = Field(..., description="Root URL of the site being audited")
     checklist_overrides: Dict[str, Dict[str, Any]] = Field(
         default_factory=dict,
-        description="Map of checklist item ID to {passed: bool, notes: str}",
+        description="Map of checklist item ID to {passed: bool | None, notes: str}",
     )
     recommendations: Optional[List[str]] = Field(
         default=None,
@@ -92,15 +44,61 @@ class EvaluateSiteArchitectureInput(BaseModel):
     )
 
 
+class SectionScoreSummary(BaseModel):
+    """Compact section score for the tool output (no full item list)."""
+
+    section_id: str
+    name: str = ""
+    tested_count: int = 0
+    passed_count: int = 0
+    total_count: int = 0
+    score_pct: float = 0.0
+    grade: str = ""
+    failing_items: List[str] = Field(default_factory=list)
+
+    @classmethod
+    def from_section_result(cls, result: ArchitectureSectionResult) -> "SectionScoreSummary":
+        return cls(
+            section_id=result.section_id,
+            name=result.name,
+            tested_count=result.tested_count,
+            passed_count=result.passed_count,
+            total_count=result.total_count,
+            score_pct=result.score_pct,
+            grade=result.grade,
+            failing_items=result.issues,
+        )
+
+
+class WCAGComplianceEntry(BaseModel):
+    """Per-criterion result for the tool output."""
+
+    sc: str
+    name: str = ""
+    wcag_level: str = ""
+    status: str = "not_tested"
+    related_items: List[str] = Field(default_factory=list)
+
+    @classmethod
+    def from_status(cls, status: WCAGCriterionStatus) -> "WCAGComplianceEntry":
+        return cls(
+            sc=status.sc,
+            name=status.name,
+            wcag_level=status.wcag_level,
+            status=status.status,
+            related_items=status.related_items,
+        )
+
+
 class EvaluateSiteArchitectureOutput(BaseModel):
     """Output from site architecture evaluation."""
 
     url: str
     template_version: str = "1.0"
-    section_scores: List[SectionScore] = Field(default_factory=list)
+    section_scores: List[SectionScoreSummary] = Field(default_factory=list)
     overall_score_pct: float = 0.0
     overall_grade: str = ""
-    wcag_compliance: List[WCAGCriterionResult] = Field(default_factory=list)
+    wcag_compliance: List[WCAGComplianceEntry] = Field(default_factory=list)
     recommendations: List[str] = Field(default_factory=list)
     raw_ref: str = Field(default="", description="Reference to raw results artifact")
 
@@ -124,84 +122,51 @@ async def evaluate_site_architecture(
     """Evaluate site architecture and navigation accessibility.
 
     Loads the structured audit template, applies any checklist result
-    overrides from ``input_data``, scores each section, and returns
-    an overall assessment with WCAG compliance mapping.
+    overrides from ``input_data``, delegates scoring to the shared
+    architecture tools, and returns an overall assessment with WCAG
+    compliance mapping.
 
     This tool is typically called by the Web Audit Specialist (WAS)
     or a dedicated Architecture Auditor during the architecture_audit phase.
     """
-    template = _load_template()
+    template = load_architecture_audit_template()
     overrides = input_data.checklist_overrides
 
-    section_scores: list[SectionScore] = []
-    # Track per-SC results for WCAG compliance mapping
-    sc_map: dict[str, dict] = {}
-
+    section_results: list[ArchitectureSectionResult] = []
     for section_def in template.get("sections", []):
         section_id = section_def["id"]
         section_name = section_def["name"]
         template_items = _flatten_items(section_def)
 
-        total = len(template_items)
-        passed = 0
-        failing: list[str] = []
-
+        evaluated: list[dict] = []
         for item in template_items:
             item_id = item["id"]
             override = overrides.get(item_id, {})
-            item_passed = override.get("passed", False)
-
-            if item_passed:
-                passed += 1
-            else:
-                failing.append(item.get("label", item_id))
-
-            # Aggregate WCAG criterion status
-            wcag_ref = item.get("wcag_ref")
-            if wcag_ref:
-                if wcag_ref not in sc_map:
-                    sc_map[wcag_ref] = {"items": [], "passed": [], "failed": []}
-                sc_map[wcag_ref]["items"].append(item_id)
-                if item_passed:
-                    sc_map[wcag_ref]["passed"].append(item_id)
-                else:
-                    sc_map[wcag_ref]["failed"].append(item_id)
-
-        pct = (passed / total * 100) if total else 0.0
-        section_scores.append(
-            SectionScore(
-                section_id=section_id,
-                name=section_name,
-                passed_count=passed,
-                total_count=total,
-                score_pct=round(pct, 1),
-                grade=_pct_to_grade(pct),
-                failing_items=failing,
+            evaluated.append(
+                {
+                    "id": item_id,
+                    "label": item.get("label", ""),
+                    "passed": override.get("passed"),
+                    "notes": override.get("notes", ""),
+                    "wcag_ref": item.get("wcag_ref"),
+                    "wcag_level": item.get("wcag_level"),
+                    "test_method": item.get("test_method", ""),
+                }
             )
-        )
 
-    # Overall score
-    total_items = sum(s.total_count for s in section_scores)
-    total_passed = sum(s.passed_count for s in section_scores)
-    overall_pct = (total_passed / total_items * 100) if total_items else 0.0
+        scored = score_architecture_section(section_id, section_name, evaluated, template)
+        section_results.append(scored)
 
-    # WCAG compliance
-    wcag_compliance: list[WCAGCriterionResult] = []
-    for sc, data in sorted(sc_map.items()):
-        if data["failed"]:
-            status = "fail" if not data["passed"] else "partial"
-        else:
-            status = "pass"
-        wcag_compliance.append(
-            WCAGCriterionResult(sc=sc, status=status, related_items=data["items"])
-        )
+    report = build_architecture_audit_report(
+        input_data.url, section_results, input_data.recommendations, template
+    )
 
     return EvaluateSiteArchitectureOutput(
         url=input_data.url,
-        section_scores=section_scores,
-        overall_score_pct=round(overall_pct, 1),
-        overall_grade=_pct_to_grade(overall_pct),
-        wcag_compliance=wcag_compliance,
-        recommendations=input_data.recommendations or [],
+        section_scores=[SectionScoreSummary.from_section_result(s) for s in report.sections],
+        overall_score_pct=report.overall_score_pct,
+        overall_grade=report.overall_grade,
+        wcag_compliance=[WCAGComplianceEntry.from_status(s) for s in report.wcag_compliance],
+        recommendations=report.recommendations,
         raw_ref=f"arch_audit_{input_data.audit_id}_{hash(input_data.url) % 10000}",
     )

--- a/backend/agents/accessibility_audit_team/tools/web/evaluate_site_architecture.py
+++ b/backend/agents/accessibility_audit_team/tools/web/evaluate_site_architecture.py
@@ -2,10 +2,8 @@
 Tool: web.evaluate_site_architecture
 
 Evaluate site architecture and navigation for accessibility using the
-structured audit template.
-
-Delegates scoring and grading to the shared architecture tools in the
-strands implementation — no logic is duplicated here.
+structured audit template.  Delegates all scoring to
+:class:`TemplateAuditEngine` — no logic is duplicated here.
 """
 
 from __future__ import annotations
@@ -18,11 +16,9 @@ from ...a11y_agency_strands.app.models.architecture import (
     ArchitectureSectionResult,
     WCAGCriterionStatus,
 )
-from ...a11y_agency_strands.app.tools.architecture_tools import (
-    build_architecture_audit_report,
-    load_architecture_audit_template,
-    score_architecture_section,
-)
+from ...a11y_agency_strands.app.tools.template_audit_engine import TemplateAuditEngine
+
+_TEMPLATE_NAME = "site_architecture_audit_template.yaml"
 
 # ---------------------------------------------------------------------------
 # I/O models (thin wrappers specific to the async web-tool interface)
@@ -108,57 +104,17 @@ class EvaluateSiteArchitectureOutput(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def _flatten_items(section_def: dict) -> list[dict]:
-    items: list[dict] = []
-    for sub in section_def.get("subsections", []):
-        for item in sub.get("checklist_items", []):
-            items.append(item)
-    return items
-
-
 async def evaluate_site_architecture(
     input_data: EvaluateSiteArchitectureInput,
 ) -> EvaluateSiteArchitectureOutput:
     """Evaluate site architecture and navigation accessibility.
 
-    Loads the structured audit template, applies any checklist result
-    overrides from ``input_data``, delegates scoring to the shared
-    architecture tools, and returns an overall assessment with WCAG
-    compliance mapping.
-
-    This tool is typically called by the Web Audit Specialist (WAS)
-    or a dedicated Architecture Auditor during the architecture_audit phase.
+    Delegates entirely to :class:`TemplateAuditEngine` for template loading,
+    section scoring, and report assembly.
     """
-    template = load_architecture_audit_template()
-    overrides = input_data.checklist_overrides
-
-    section_results: list[ArchitectureSectionResult] = []
-    for section_def in template.get("sections", []):
-        section_id = section_def["id"]
-        section_name = section_def["name"]
-        template_items = _flatten_items(section_def)
-
-        evaluated: list[dict] = []
-        for item in template_items:
-            item_id = item["id"]
-            override = overrides.get(item_id, {})
-            evaluated.append(
-                {
-                    "id": item_id,
-                    "label": item.get("label", ""),
-                    "passed": override.get("passed"),
-                    "notes": override.get("notes", ""),
-                    "wcag_ref": item.get("wcag_ref"),
-                    "wcag_level": item.get("wcag_level"),
-                    "test_method": item.get("test_method", ""),
-                }
-            )
-
-        scored = score_architecture_section(section_id, section_name, evaluated, template)
-        section_results.append(scored)
-
-    report = build_architecture_audit_report(
-        input_data.url, section_results, input_data.recommendations, template
+    engine = TemplateAuditEngine(_TEMPLATE_NAME)
+    report = engine.evaluate(
+        input_data.url, input_data.checklist_overrides, input_data.recommendations
     )
 
     return EvaluateSiteArchitectureOutput(


### PR DESCRIPTION
Add structured case study templates (comprehensive, basic audit, premium
assessment, enterprise analysis, executive summary, video script, and
industry-specific variants for e-commerce, SaaS, healthcare) as a YAML
asset. Integrate case study generation into both the Strands-native and
main audit pipelines so reports automatically include case study artifacts.

https://claude.ai/code/session_015WHSoTkGTeba8uWHMgYB8N