### PR TITLE
Add manual refresh trigger for jobs list polling

### DIFF
--- a/user-interface/src/app/components/blogging-dashboard/blogging-dashboard.component.ts
+++ b/user-interface/src/app/components/blogging-dashboard/blogging-dashboard.component.ts
@@ -6,8 +6,8 @@ import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
 import { marked } from 'marked';
 import { MatTabsModule } from '@angular/material/tabs';
 import { MatCardModule } from '@angular/material/card';
-import { Subscription, timer } from 'rxjs';
-import { switchMap } from 'rxjs/operators';
+import { Subject, Subscription, timer } from 'rxjs';
+import { startWith, switchMap } from 'rxjs/operators';
 import type { BlogJobStreamEvent } from '../../models';
 import { BloggingApiService } from '../../services/blogging-api.service';
 import { TeamAssistantApiService } from '../../services/team-assistant-api.service';
@@ -105,6 +105,7 @@ export class BloggingDashboardComponent implements OnInit, OnDestroy {
   private sseSub: Subscription | null = null;
   private queryParamsSub: Subscription | null = null;
   private pendingJobId: string | null = null;
+  private refreshTrigger$ = new Subject<void>();
 
   private static readonly ASSISTANT_URL = '/api/blogging/assistant';
 
@@ -198,6 +199,7 @@ export class BloggingDashboardComponent implements OnInit, OnDestroy {
         this.api.getJobStatus(jobId).subscribe({
           next: (status) => {
             this.selectedJobStatus = status;
+            this.triggerJobsRefresh();
           },
         });
       },
@@ -214,6 +216,7 @@ export class BloggingDashboardComponent implements OnInit, OnDestroy {
     this.api.deleteJob(jobId).subscribe({
       next: () => {
         this.clearSelection();
+        this.triggerJobsRefresh();
       },
       error: (err) => {
         this.error = err?.error?.detail ?? err?.message ?? 'Failed to delete job';
@@ -235,8 +238,10 @@ export class BloggingDashboardComponent implements OnInit, OnDestroy {
       const id = params['jobId'];
       if (id) this.pendingJobId = id;
     });
-    this.jobsSub = timer(0, POLL_JOBS_MS).pipe(
-      switchMap(() => this.api.getJobs(false))
+    this.jobsSub = this.refreshTrigger$.pipe(
+      startWith(undefined as void),
+      switchMap(() => timer(0, POLL_JOBS_MS)),
+      switchMap(() => this.api.getJobs(false)),
     ).subscribe({
       next: (jobs) => {
         this.allJobs = jobs;
@@ -276,6 +281,7 @@ export class BloggingDashboardComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.queryParamsSub?.unsubscribe();
     this.jobsSub?.unsubscribe();
+    this.refreshTrigger$.complete();
     this.stopJobStreaming();
   }
 
@@ -342,6 +348,7 @@ export class BloggingDashboardComponent implements OnInit, OnDestroy {
 
   cancelJobFromList(jobId: string): void {
     this.api.cancelJob(jobId).subscribe({
+      next: () => { this.triggerJobsRefresh(); },
       error: (err) => { this.error = err?.error?.detail ?? err?.message ?? 'Failed to cancel job'; },
     });
   }
@@ -351,6 +358,7 @@ export class BloggingDashboardComponent implements OnInit, OnDestroy {
     this.api.deleteJob(jobId).subscribe({
       next: () => {
         if (this.selectedBlogJob?.job_id === jobId) this.clearSelection();
+        this.triggerJobsRefresh();
       },
       error: (err) => { this.error = err?.error?.detail ?? err?.message ?? 'Failed to delete job'; },
     });
@@ -397,6 +405,8 @@ export class BloggingDashboardComponent implements OnInit, OnDestroy {
         }
         this.pendingJobId = resp.job_id;
         this.activeView = 'jobs';
+        // Small delay so the backend has time to persist the new job record
+        setTimeout(() => this.triggerJobsRefresh(), 500);
       },
       error: (err) => {
         this.launching = false;
@@ -418,6 +428,11 @@ export class BloggingDashboardComponent implements OnInit, OnDestroy {
     this.storyResponseText = '';
     this.qaAnswers = {};
     this.draftFeedbackText = '';
+  }
+
+  /** Immediately refresh the jobs list and reset the polling timer. */
+  private triggerJobsRefresh(): void {
+    this.refreshTrigger$.next();
   }
 
   /** Tear down both SSE and polling subscriptions. */
@@ -672,6 +687,7 @@ export class BloggingDashboardComponent implements OnInit, OnDestroy {
       next: (status) => {
         this.selectedJobStatus = status;
         this.error = null;
+        this.triggerJobsRefresh();
       },
       error: (err) => {
         this.error = err?.error?.detail ?? err?.message ?? 'Failed to approve job';
@@ -685,6 +701,7 @@ export class BloggingDashboardComponent implements OnInit, OnDestroy {
       next: (status) => {
         this.selectedJobStatus = status;
         this.error = null;
+        this.triggerJobsRefresh();
       },
       error: (err) => {
         this.error = err?.error?.detail ?? err?.message ?? 'Failed to unapprove job';


### PR DESCRIPTION
## Summary
Refactored the jobs list polling mechanism to support manual refresh triggers in addition to the existing timer-based polling. This allows the UI to immediately refresh the jobs list when relevant state changes occur (job creation, deletion, cancellation, approval status changes) rather than waiting for the next polling interval.

## Key Changes
- Added `refreshTrigger$` Subject to enable manual triggering of jobs list refreshes
- Restructured the polling observable chain to start with the refresh trigger and reset the timer on each manual trigger
- Added `triggerJobsRefresh()` method that emits to the refresh trigger subject
- Integrated manual refresh calls at strategic points:
  - After job creation (with 500ms delay to allow backend persistence)
  - After job deletion
  - After job cancellation
  - After job status updates (get, approve, unapprove)
- Updated RxJS imports to include `Subject` and `startWith` operator
- Properly clean up the refresh trigger subject in `ngOnDestroy()`

## Implementation Details
The polling now uses a `startWith(undefined)` operator to ensure immediate execution on component initialization, followed by the timer-based polling. When `triggerJobsRefresh()` is called, it emits a value through the subject, which resets the entire polling chain and fetches fresh job data immediately. This provides a better user experience by showing updated job statuses without waiting for the next scheduled poll interval.

https://claude.ai/code/session_01CXH2wLraigti3UyrgUGYJj