### PR TITLE
Integrate branding API for social marketing campaigns

### DIFF
--- a/backend/agents/social_media_marketing_team/adapters/branding.py
+++ b/backend/agents/social_media_marketing_team/adapters/branding.py
@@ -1,0 +1,256 @@
+"""Adapter to fetch and validate a Brand from the branding team API."""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import List, Optional
+
+import httpx
+from pydantic import BaseModel
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Exceptions
+# ---------------------------------------------------------------------------
+
+
+class BrandNotFoundError(Exception):
+    """Raised when the requested brand does not exist."""
+
+    def __init__(self, client_id: str, brand_id: str):
+        self.client_id = client_id
+        self.brand_id = brand_id
+        super().__init__(f"Brand '{brand_id}' not found for client '{client_id}'.")
+
+
+class BrandIncompleteError(Exception):
+    """Raised when the brand exists but required phases are not yet complete."""
+
+    def __init__(
+        self, client_id: str, brand_id: str, missing_phases: List[str], current_phase: str
+    ):
+        self.client_id = client_id
+        self.brand_id = brand_id
+        self.missing_phases = missing_phases
+        self.current_phase = current_phase
+        super().__init__(
+            f"Brand '{brand_id}' is missing required phases: {', '.join(missing_phases)}. "
+            f"Current phase: {current_phase}."
+        )
+
+
+# ---------------------------------------------------------------------------
+# BrandContext — the subset of brand data social marketing needs
+# ---------------------------------------------------------------------------
+
+
+class BrandContext(BaseModel):
+    """Brand data extracted and synthesized for social marketing use."""
+
+    brand_name: str
+    target_audience: str
+    voice_and_tone: str
+    brand_guidelines: str
+    brand_objectives: str
+    messaging_pillars: List[str] = []
+    brand_story: str = ""
+    tagline: str = ""
+
+
+# ---------------------------------------------------------------------------
+# HTTP fetch
+# ---------------------------------------------------------------------------
+
+_PHASE_DISPLAY_NAMES = {
+    "strategic_core": "Strategic Core (your positioning, values, and audience)",
+    "narrative_messaging": "Narrative & Messaging (your brand story, voice, and key messages)",
+}
+
+_REQUIRED_PHASES = ["strategic_core", "narrative_messaging"]
+
+
+def _base_url() -> Optional[str]:
+    return os.environ.get("UNIFIED_API_BASE_URL") or os.environ.get("SOCIAL_MARKETING_BRANDING_URL")
+
+
+def fetch_brand(client_id: str, brand_id: str) -> dict:
+    """Fetch a brand from the branding team API. Returns the raw JSON dict.
+
+    Raises ``BrandNotFoundError`` when the brand or client does not exist.
+    Raises ``RuntimeError`` on network / unexpected errors.
+    """
+    base = _base_url()
+    if not base:
+        raise RuntimeError(
+            "Branding API URL not configured. Set UNIFIED_API_BASE_URL or SOCIAL_MARKETING_BRANDING_URL."
+        )
+    url = f"{base.rstrip('/')}/api/branding/clients/{client_id}/brands/{brand_id}"
+    try:
+        with httpx.Client(timeout=30.0) as client_http:
+            resp = client_http.get(url)
+            if resp.status_code == 404:
+                raise BrandNotFoundError(client_id, brand_id)
+            resp.raise_for_status()
+            return resp.json()
+    except BrandNotFoundError:
+        raise
+    except (httpx.HTTPError, httpx.TimeoutException, ValueError) as e:
+        raise RuntimeError(f"Failed to fetch brand from branding API: {e}") from e
+
+
+# ---------------------------------------------------------------------------
+# Validation + extraction
+# ---------------------------------------------------------------------------
+
+
+def validate_brand_for_social_marketing(
+    brand_data: dict, client_id: str, brand_id: str
+) -> BrandContext:
+    """Validate that a brand has the required phases and extract a ``BrandContext``.
+
+    Raises ``BrandIncompleteError`` if Phase 1 or Phase 2 outputs are missing.
+    """
+    latest_output = brand_data.get("latest_output")
+    if not latest_output or not isinstance(latest_output, dict):
+        raise BrandIncompleteError(
+            client_id, brand_id, missing_phases=list(_REQUIRED_PHASES), current_phase="draft"
+        )
+
+    missing = [phase for phase in _REQUIRED_PHASES if not latest_output.get(phase)]
+    if missing:
+        current_phase = brand_data.get("current_phase", "unknown")
+        raise BrandIncompleteError(
+            client_id, brand_id, missing_phases=missing, current_phase=current_phase
+        )
+
+    mission = brand_data.get("mission") or {}
+    strategic_core = latest_output["strategic_core"]
+    narrative = latest_output["narrative_messaging"]
+
+    return _extract_brand_context(brand_data, mission, strategic_core, narrative)
+
+
+def _extract_brand_context(
+    brand_data: dict, mission: dict, strategic_core: dict, narrative: dict
+) -> BrandContext:
+    """Synthesize a ``BrandContext`` from raw branding API data."""
+    brand_name = brand_data.get("name", mission.get("company_name", "Brand"))
+
+    # Target audience -- combine mission + segment details
+    audience_parts = [mission.get("target_audience", "")]
+    for seg in strategic_core.get("target_audience_segments", []):
+        if isinstance(seg, dict):
+            name = seg.get("name", "")
+            desc = seg.get("description", "")
+            if name:
+                audience_parts.append(f"{name}: {desc}" if desc else name)
+    target_audience = "; ".join(p for p in audience_parts if p)
+
+    # Voice and tone -- combine mission voice + archetype traits
+    voice_parts = [mission.get("desired_voice", "")]
+    for archetype in narrative.get("brand_archetypes", []):
+        if isinstance(archetype, dict):
+            traits = archetype.get("personality_traits", [])
+            if traits:
+                voice_parts.append(", ".join(traits[:5]))
+    voice_and_tone = "; ".join(p for p in voice_parts if p) or "professional, clear, and human"
+
+    # Brand guidelines -- synthesize from strategic core + narrative
+    guideline_parts = []
+    if strategic_core.get("positioning_statement"):
+        guideline_parts.append(f"Positioning: {strategic_core['positioning_statement']}")
+    for val in strategic_core.get("core_values", []):
+        if isinstance(val, dict) and val.get("value"):
+            guideline_parts.append(
+                f"Value -- {val['value']}: {val.get('behavioral_definition', '')}"
+            )
+    for pillar in strategic_core.get("differentiation_pillars", []):
+        if isinstance(pillar, dict) and pillar.get("pillar"):
+            guideline_parts.append(
+                f"Differentiator -- {pillar['pillar']}: {pillar.get('competitive_context', '')}"
+            )
+    for aud_map in narrative.get("audience_message_maps", []):
+        if isinstance(aud_map, dict) and aud_map.get("tone_adjustments"):
+            guideline_parts.append(
+                f"Tone for {aud_map.get('audience_segment', 'audience')}: {aud_map['tone_adjustments']}"
+            )
+    brand_guidelines = "\n".join(guideline_parts)
+
+    # Brand objectives -- from strategic core purpose/mission/vision
+    objective_parts = []
+    if strategic_core.get("brand_purpose"):
+        objective_parts.append(f"Purpose: {strategic_core['brand_purpose']}")
+    if strategic_core.get("mission_statement"):
+        objective_parts.append(f"Mission: {strategic_core['mission_statement']}")
+    if strategic_core.get("vision_statement"):
+        objective_parts.append(f"Vision: {strategic_core['vision_statement']}")
+    if strategic_core.get("brand_promise"):
+        objective_parts.append(f"Promise: {strategic_core['brand_promise']}")
+    brand_objectives = "\n".join(objective_parts)
+
+    # Messaging pillars
+    messaging_pillars = []
+    for mp in narrative.get("messaging_framework", []):
+        if isinstance(mp, dict) and mp.get("pillar"):
+            messaging_pillars.append(mp["pillar"])
+
+    return BrandContext(
+        brand_name=brand_name,
+        target_audience=target_audience,
+        voice_and_tone=voice_and_tone,
+        brand_guidelines=brand_guidelines,
+        brand_objectives=brand_objectives,
+        messaging_pillars=messaging_pillars,
+        brand_story=narrative.get("brand_story", ""),
+        tagline=narrative.get("tagline", ""),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Error response builders (two-tier: structured API + warm user_message)
+# ---------------------------------------------------------------------------
+
+
+def build_brand_not_found_error(client_id: str, brand_id: str) -> dict:
+    """Build a structured error response for a missing brand."""
+    return {
+        "error": "brand_not_found",
+        "message": f"Brand '{brand_id}' was not found for client '{client_id}'.",
+        "user_message": (
+            "Before we can create campaigns for you, we need to understand your brand. "
+            "Here's how to get started:\n\n"
+            f"1. Create a client (if you haven't): POST /api/branding/clients\n"
+            f"2. Create a brand: POST /api/branding/clients/{client_id}/brands\n"
+            f"3. Run the branding pipeline: POST /api/branding/clients/{client_id}"
+            f"/brands/{{brand_id}}/run\n\n"
+            "The branding process covers your strategic positioning and messaging -- "
+            "it takes about 15-20 minutes and ensures your campaigns authentically "
+            "represent who you are."
+        ),
+        "branding_api_base": "/api/branding",
+    }
+
+
+def build_brand_incomplete_error(exc: BrandIncompleteError) -> dict:
+    """Build a structured error response for an incomplete brand."""
+    missing_display = "\n".join(f"- {_PHASE_DISPLAY_NAMES.get(p, p)}" for p in exc.missing_phases)
+    return {
+        "error": "brand_incomplete",
+        "message": f"Brand '{exc.brand_id}' needs more development before campaigns can be created.",
+        "user_message": (
+            "Your brand is off to a great start, but needs a bit more work before we can build "
+            "campaigns. Here's what's remaining:\n\n"
+            f"{missing_display}\n\n"
+            "This ensures your campaign content sounds authentically like your brand. "
+            f"Continue building your brand: POST /api/branding/clients/{exc.client_id}"
+            f"/brands/{exc.brand_id}/run\n\n"
+            "Once done, come back and we'll build campaigns that bring your brand to life."
+        ),
+        "required_phases": list(_REQUIRED_PHASES),
+        "missing_phases": exc.missing_phases,
+        "current_phase": exc.current_phase,
+        "branding_api_base": "/api/branding",
+    }

--- a/backend/agents/social_media_marketing_team/adapters/branding.py
+++ b/backend/agents/social_media_marketing_team/adapters/branding.py
@@ -59,15 +59,30 @@ class BrandContext(BaseModel):
     brand_story: str = ""
     tagline: str = ""
 
+    def to_brand_goals(
+        self, *, goals: List[str], cadence_posts_per_day: int, duration_days: int
+    ) -> BrandGoals:  # noqa: F821
+        """Convert to a ``BrandGoals`` instance, merging campaign-specific fields."""
+        from social_media_marketing_team.models import BrandGoals
+
+        return BrandGoals(
+            brand_name=self.brand_name,
+            target_audience=self.target_audience,
+            voice_and_tone=self.voice_and_tone,
+            brand_guidelines=self.brand_guidelines,
+            brand_objectives=self.brand_objectives,
+            messaging_pillars=self.messaging_pillars,
+            brand_story=self.brand_story,
+            tagline=self.tagline,
+            goals=goals,
+            cadence_posts_per_day=cadence_posts_per_day,
+            duration_days=duration_days,
+        )
+
 
 # ---------------------------------------------------------------------------
 # HTTP fetch
 # ---------------------------------------------------------------------------
-
-_PHASE_DISPLAY_NAMES = {
-    "strategic_core": "Strategic Core (your positioning, values, and audience)",
-    "narrative_messaging": "Narrative & Messaging (your brand story, voice, and key messages)",
-}
 
 _REQUIRED_PHASES = ["strategic_core", "narrative_messaging"]
 
@@ -119,7 +134,9 @@ def validate_brand_for_social_marketing(
             client_id, brand_id, missing_phases=list(_REQUIRED_PHASES), current_phase="draft"
         )
 
-    missing = [phase for phase in _REQUIRED_PHASES if not latest_output.get(phase)]
+    missing = [
+        phase for phase in _REQUIRED_PHASES if not isinstance(latest_output.get(phase), dict)
+    ]
     if missing:
         current_phase = brand_data.get("current_phase", "unknown")
         raise BrandIncompleteError(
@@ -207,50 +224,3 @@ def _extract_brand_context(
         brand_story=narrative.get("brand_story", ""),
         tagline=narrative.get("tagline", ""),
     )
-
-
-# ---------------------------------------------------------------------------
-# Error response builders (two-tier: structured API + warm user_message)
-# ---------------------------------------------------------------------------
-
-
-def build_brand_not_found_error(client_id: str, brand_id: str) -> dict:
-    """Build a structured error response for a missing brand."""
-    return {
-        "error": "brand_not_found",
-        "message": f"Brand '{brand_id}' was not found for client '{client_id}'.",
-        "user_message": (
-            "Before we can create campaigns for you, we need to understand your brand. "
-            "Here's how to get started:\n\n"
-            f"1. Create a client (if you haven't): POST /api/branding/clients\n"
-            f"2. Create a brand: POST /api/branding/clients/{client_id}/brands\n"
-            f"3. Run the branding pipeline: POST /api/branding/clients/{client_id}"
-            f"/brands/{{brand_id}}/run\n\n"
-            "The branding process covers your strategic positioning and messaging -- "
-            "it takes about 15-20 minutes and ensures your campaigns authentically "
-            "represent who you are."
-        ),
-        "branding_api_base": "/api/branding",
-    }
-
-
-def build_brand_incomplete_error(exc: BrandIncompleteError) -> dict:
-    """Build a structured error response for an incomplete brand."""
-    missing_display = "\n".join(f"- {_PHASE_DISPLAY_NAMES.get(p, p)}" for p in exc.missing_phases)
-    return {
-        "error": "brand_incomplete",
-        "message": f"Brand '{exc.brand_id}' needs more development before campaigns can be created.",
-        "user_message": (
-            "Your brand is off to a great start, but needs a bit more work before we can build "
-            "campaigns. Here's what's remaining:\n\n"
-            f"{missing_display}\n\n"
-            "This ensures your campaign content sounds authentically like your brand. "
-            f"Continue building your brand: POST /api/branding/clients/{exc.client_id}"
-            f"/brands/{exc.brand_id}/run\n\n"
-            "Once done, come back and we'll build campaigns that bring your brand to life."
-        ),
-        "required_phases": list(_REQUIRED_PHASES),
-        "missing_phases": exc.missing_phases,
-        "current_phase": exc.current_phase,
-        "branding_api_base": "/api/branding",
-    }

--- a/backend/agents/social_media_marketing_team/api/main.py
+++ b/backend/agents/social_media_marketing_team/api/main.py
@@ -3,13 +3,11 @@
 from __future__ import annotations
 
 import logging
-import os
 import threading
 import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import List
 
 from fastapi import FastAPI, HTTPException
@@ -21,6 +19,15 @@ from job_service_client import (
     JOB_STATUS_RUNNING,
     JobServiceClient,
     start_stale_job_monitor,
+)
+from social_media_marketing_team.adapters.branding import (
+    BrandContext,
+    BrandIncompleteError,
+    BrandNotFoundError,
+    build_brand_incomplete_error,
+    build_brand_not_found_error,
+    fetch_brand,
+    validate_brand_for_social_marketing,
 )
 from social_media_marketing_team.models import (
     BrandGoals,
@@ -43,21 +50,6 @@ from .request_models import (
     TrendRunResponse,
 )
 from .trend_scheduler import get_latest_digest, run_trend_job, start_scheduler, stop_scheduler
-
-# ---------------------------------------------------------------------------
-# Allowed base directories for brand document file reads.  Paths outside these
-# roots will be rejected to prevent path-traversal attacks.
-# ---------------------------------------------------------------------------
-_ALLOWED_FILE_ROOTS: List[Path] = []
-_agent_cache = os.getenv("AGENT_CACHE", "")
-if _agent_cache:
-    _ALLOWED_FILE_ROOTS.append(Path(_agent_cache).resolve())
-_data_dir = Path("/data")
-if _data_dir.is_dir():
-    _ALLOWED_FILE_ROOTS.append(_data_dir.resolve())
-_tmp_dir = Path("/tmp")
-if _tmp_dir.is_dir():
-    _ALLOWED_FILE_ROOTS.append(_tmp_dir.resolve())
 
 # ---------------------------------------------------------------------------
 # App & lifecycle
@@ -96,35 +88,6 @@ def _now() -> str:
     return datetime.now(tz=timezone.utc).isoformat()
 
 
-def _validate_file_path(path: str) -> Path:
-    """Resolve *path* and ensure it exists inside an allowed root directory.
-
-    Raises ``ValueError`` when the path does not exist, or lies outside every
-    configured allowed root.  When no roots are configured, **all** reads are
-    denied to prevent silent bypass of the protection in environments that
-    forgot to set ``AGENT_CACHE``.
-    """
-    fp = Path(path).expanduser().resolve()
-    if not fp.is_file():
-        raise ValueError(f"File not found: {path}")
-    if not _ALLOWED_FILE_ROOTS:
-        raise ValueError(
-            f"Access denied: no allowed file roots configured (set AGENT_CACHE or place files under /data or /tmp). "
-            f"Requested path: {path}"
-        )
-    if not any(fp == root or root in fp.parents for root in _ALLOWED_FILE_ROOTS):
-        raise ValueError(
-            f"Access denied: {path} is outside allowed directories. "
-            f"Allowed roots: {[str(r) for r in _ALLOWED_FILE_ROOTS]}"
-        )
-    return fp
-
-
-def _read_text_file(path: str) -> str:
-    fp = _validate_file_path(path)
-    return fp.read_text(encoding="utf-8", errors="replace")
-
-
 def _update_job(job_id: str, **fields) -> None:
     _job_manager.update_job(job_id, **fields)
 
@@ -139,43 +102,38 @@ def mark_all_running_jobs_failed(reason: str) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _run_team_job(job_id: str, request: RunMarketingTeamRequest) -> None:
+def _run_team_job(job_id: str, request: RunMarketingTeamRequest, brand_ctx: BrandContext) -> None:
     try:
         _update_job(
             job_id,
             status="running",
-            current_stage="loading_brand_documents",
-            progress=20,
-            eta_hint="~1-2 minutes",
-        )
-        guidelines_text = _read_text_file(request.brand_guidelines_path)
-        objectives_text = _read_text_file(request.brand_objectives_path)
-
-        _update_job(
-            job_id, current_stage="building_campaign_proposal", progress=50, eta_hint="~1 minute"
+            current_stage="building_campaign_proposal",
+            progress=30,
+            eta_hint="~1 minute",
         )
         orchestrator = SocialMediaMarketingOrchestrator(llm_model_name=request.llm_model_name)
         goals = BrandGoals(
-            brand_name=request.brand_name,
-            target_audience=request.target_audience,
+            brand_name=brand_ctx.brand_name,
+            target_audience=brand_ctx.target_audience,
             goals=request.goals,
-            voice_and_tone=request.voice_and_tone,
+            voice_and_tone=brand_ctx.voice_and_tone,
             cadence_posts_per_day=request.cadence_posts_per_day,
             duration_days=request.duration_days,
-            brand_guidelines_path=request.brand_guidelines_path,
-            brand_objectives_path=request.brand_objectives_path,
-            brand_guidelines=guidelines_text,
-            brand_objectives=objectives_text,
+            brand_guidelines=brand_ctx.brand_guidelines,
+            brand_objectives=brand_ctx.brand_objectives,
+            messaging_pillars=brand_ctx.messaging_pillars,
+            brand_story=brand_ctx.brand_story,
+            tagline=brand_ctx.tagline,
         )
 
         _update_job(
             job_id,
             current_stage="running_collaboration_and_planning",
-            progress=75,
+            progress=60,
             eta_hint="~30-60 seconds",
         )
         performance = CampaignPerformanceSnapshot(
-            campaign_name=f"{request.brand_name} multi-platform growth sprint",
+            campaign_name=f"{brand_ctx.brand_name} multi-platform growth sprint",
             observations=(_job_manager.get_job(job_id) or {}).get("performance_observations", []),
         )
         result = orchestrator.run(
@@ -206,7 +164,7 @@ def _run_team_job(job_id: str, request: RunMarketingTeamRequest) -> None:
         )
 
 
-def _dispatch_job(job_id: str, request: RunMarketingTeamRequest) -> str:
+def _dispatch_job(job_id: str, request: RunMarketingTeamRequest, brand_ctx: BrandContext) -> str:
     """Start a job via Temporal if enabled, otherwise in a daemon thread.
 
     Returns a human-readable message describing how the job was dispatched.
@@ -221,7 +179,7 @@ def _dispatch_job(job_id: str, request: RunMarketingTeamRequest) -> str:
     except ImportError:
         pass
 
-    thread = threading.Thread(target=_run_team_job, args=(job_id, request), daemon=True)
+    thread = threading.Thread(target=_run_team_job, args=(job_id, request, brand_ctx), daemon=True)
     thread.start()
     return f"Poll GET /social-marketing/status/{job_id} for updates."
 
@@ -231,13 +189,42 @@ def _dispatch_job(job_id: str, request: RunMarketingTeamRequest) -> str:
 # ---------------------------------------------------------------------------
 
 
+def _build_brand_summary(brand_ctx: BrandContext) -> str:
+    """Build a brief human-readable brand summary for the happy-path response."""
+    parts = [f"Using brand '{brand_ctx.brand_name}'"]
+    if brand_ctx.tagline:
+        parts.append(f"-- '{brand_ctx.tagline}'")
+    if brand_ctx.voice_and_tone:
+        parts.append(f"Voice: {brand_ctx.voice_and_tone[:80]}")
+    if brand_ctx.target_audience:
+        audience_short = brand_ctx.target_audience[:100]
+        parts.append(f"Audience: {audience_short}")
+    return ". ".join(parts) + "."
+
+
+def _fetch_and_validate_brand(client_id: str, brand_id: str) -> BrandContext:
+    """Fetch a brand and validate it has the required phases.
+
+    Raises ``HTTPException`` with a structured 422 error on failure.
+    """
+    try:
+        brand_data = fetch_brand(client_id, brand_id)
+    except BrandNotFoundError:
+        raise HTTPException(
+            status_code=422, detail=build_brand_not_found_error(client_id, brand_id)
+        )
+    except RuntimeError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+
+    try:
+        return validate_brand_for_social_marketing(brand_data, client_id, brand_id)
+    except BrandIncompleteError as exc:
+        raise HTTPException(status_code=422, detail=build_brand_incomplete_error(exc))
+
+
 @app.post("/social-marketing/run", response_model=RunMarketingTeamResponse)
 def run_marketing_team(request: RunMarketingTeamRequest) -> RunMarketingTeamResponse:
-    for p in (request.brand_guidelines_path, request.brand_objectives_path):
-        try:
-            _validate_file_path(p)
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+    brand_ctx = _fetch_and_validate_brand(request.client_id, request.brand_id)
 
     job_id = str(uuid.uuid4())
     now = _now()
@@ -248,8 +235,8 @@ def run_marketing_team(request: RunMarketingTeamRequest) -> RunMarketingTeamResp
         current_stage="queued",
         progress=0,
         llm_model_name=request.llm_model_name,
-        brand_guidelines_path=request.brand_guidelines_path,
-        brand_objectives_path=request.brand_objectives_path,
+        client_id=request.client_id,
+        brand_id=request.brand_id,
         result=None,
         error=None,
         eta_hint="queued",
@@ -260,11 +247,12 @@ def run_marketing_team(request: RunMarketingTeamRequest) -> RunMarketingTeamResp
         request_payload=request.model_dump(),
     )
 
-    dispatch_msg = _dispatch_job(job_id, request)
+    dispatch_msg = _dispatch_job(job_id, request, brand_ctx)
     return RunMarketingTeamResponse(
         job_id=job_id,
         status="running",
         message=f"Social marketing team started. {dispatch_msg}",
+        brand_summary=_build_brand_summary(brand_ctx),
     )
 
 
@@ -306,6 +294,8 @@ def revise_marketing_team(
         )
 
     original_request = RunMarketingTeamRequest(**original_payload)
+    brand_ctx = _fetch_and_validate_brand(original_request.client_id, original_request.brand_id)
+
     revised = original_request.model_copy(
         update={
             "human_feedback": request.feedback,
@@ -326,11 +316,12 @@ def revise_marketing_team(
         last_updated_at=_now(),
     )
 
-    dispatch_msg = _dispatch_job(job_id, revised)
+    dispatch_msg = _dispatch_job(job_id, revised, brand_ctx)
     return RunMarketingTeamResponse(
         job_id=job_id,
         status="running",
         message=f"Revision started for {job_id}. {dispatch_msg}",
+        brand_summary=_build_brand_summary(brand_ctx),
     )
 
 

--- a/backend/agents/social_media_marketing_team/api/main.py
+++ b/backend/agents/social_media_marketing_team/api/main.py
@@ -394,9 +394,26 @@ def get_marketing_job_status(job_id: str) -> MarketingJobStatusResponse:
     job = _job_manager.get_job(job_id)
     if not job:
         raise HTTPException(status_code=404, detail=f"Job {job_id} not found")
-    return MarketingJobStatusResponse(
-        **{k: v for k, v in job.items() if k in MarketingJobStatusResponse.model_fields}
-    )
+
+    data = {k: v for k, v in job.items() if k in MarketingJobStatusResponse.model_fields}
+
+    # Backfill client_id/brand_id from request_payload for jobs created
+    # before these fields were stored at the top level.
+    if "client_id" not in data or "brand_id" not in data:
+        payload = job.get("request_payload")
+        if isinstance(payload, dict):
+            data.setdefault("client_id", payload.get("client_id"))
+            data.setdefault("brand_id", payload.get("brand_id"))
+    if not data.get("client_id") or not data.get("brand_id"):
+        raise HTTPException(
+            status_code=410,
+            detail=(
+                f"Job {job_id} predates the brand requirement and cannot display "
+                f"brand context. Create a new job with client_id and brand_id."
+            ),
+        )
+
+    return MarketingJobStatusResponse(**data)
 
 
 @app.post("/social-marketing/job/{job_id}/cancel", response_model=CancelMarketingJobResponse)

--- a/backend/agents/social_media_marketing_team/api/main.py
+++ b/backend/agents/social_media_marketing_team/api/main.py
@@ -24,13 +24,10 @@ from social_media_marketing_team.adapters.branding import (
     BrandContext,
     BrandIncompleteError,
     BrandNotFoundError,
-    build_brand_incomplete_error,
-    build_brand_not_found_error,
     fetch_brand,
     validate_brand_for_social_marketing,
 )
 from social_media_marketing_team.models import (
-    BrandGoals,
     CampaignPerformanceSnapshot,
     HumanReview,
 )
@@ -112,18 +109,10 @@ def _run_team_job(job_id: str, request: RunMarketingTeamRequest, brand_ctx: Bran
             eta_hint="~1 minute",
         )
         orchestrator = SocialMediaMarketingOrchestrator(llm_model_name=request.llm_model_name)
-        goals = BrandGoals(
-            brand_name=brand_ctx.brand_name,
-            target_audience=brand_ctx.target_audience,
+        goals = brand_ctx.to_brand_goals(
             goals=request.goals,
-            voice_and_tone=brand_ctx.voice_and_tone,
             cadence_posts_per_day=request.cadence_posts_per_day,
             duration_days=request.duration_days,
-            brand_guidelines=brand_ctx.brand_guidelines,
-            brand_objectives=brand_ctx.brand_objectives,
-            messaging_pillars=brand_ctx.messaging_pillars,
-            brand_story=brand_ctx.brand_story,
-            tagline=brand_ctx.tagline,
         )
 
         _update_job(
@@ -191,15 +180,67 @@ def _dispatch_job(job_id: str, request: RunMarketingTeamRequest, brand_ctx: Bran
 
 def _build_brand_summary(brand_ctx: BrandContext) -> str:
     """Build a brief human-readable brand summary for the happy-path response."""
-    parts = [f"Using brand '{brand_ctx.brand_name}'"]
+    header = f"Using brand '{brand_ctx.brand_name}'"
     if brand_ctx.tagline:
-        parts.append(f"-- '{brand_ctx.tagline}'")
+        header += f" -- '{brand_ctx.tagline}'"
+    detail_parts = []
     if brand_ctx.voice_and_tone:
-        parts.append(f"Voice: {brand_ctx.voice_and_tone[:80]}")
+        detail_parts.append(f"Voice: {brand_ctx.voice_and_tone[:80]}")
     if brand_ctx.target_audience:
-        audience_short = brand_ctx.target_audience[:100]
-        parts.append(f"Audience: {audience_short}")
-    return ". ".join(parts) + "."
+        detail_parts.append(f"Audience: {brand_ctx.target_audience[:100]}")
+    if detail_parts:
+        return f"{header}. {'. '.join(detail_parts)}."
+    return f"{header}."
+
+
+_PHASE_DISPLAY_NAMES = {
+    "strategic_core": "Strategic Core (your positioning, values, and audience)",
+    "narrative_messaging": "Narrative & Messaging (your brand story, voice, and key messages)",
+}
+
+_REQUIRED_PHASES = ["strategic_core", "narrative_messaging"]
+
+
+def _build_brand_not_found_error(client_id: str, brand_id: str) -> dict:
+    """Build a structured error response for a missing brand."""
+    return {
+        "error": "brand_not_found",
+        "message": f"Brand '{brand_id}' was not found for client '{client_id}'.",
+        "user_message": (
+            "Before we can create campaigns for you, we need to understand your brand. "
+            "Here's how to get started:\n\n"
+            f"1. Create a client (if you haven't): POST /api/branding/clients\n"
+            f"2. Create a brand: POST /api/branding/clients/{client_id}/brands\n"
+            f"3. Run the branding pipeline: POST /api/branding/clients/{client_id}"
+            f"/brands/{{brand_id}}/run\n\n"
+            "The branding process covers your strategic positioning and messaging -- "
+            "it takes about 15-20 minutes and ensures your campaigns authentically "
+            "represent who you are."
+        ),
+        "branding_api_base": "/api/branding",
+    }
+
+
+def _build_brand_incomplete_error(exc: BrandIncompleteError) -> dict:
+    """Build a structured error response for an incomplete brand."""
+    missing_display = "\n".join(f"- {_PHASE_DISPLAY_NAMES.get(p, p)}" for p in exc.missing_phases)
+    return {
+        "error": "brand_incomplete",
+        "message": f"Brand '{exc.brand_id}' needs more development before campaigns can be created.",
+        "user_message": (
+            "Your brand is off to a great start, but needs a bit more work before we can build "
+            "campaigns. Here's what's remaining:\n\n"
+            f"{missing_display}\n\n"
+            "This ensures your campaign content sounds authentically like your brand. "
+            f"Continue building your brand: POST /api/branding/clients/{exc.client_id}"
+            f"/brands/{exc.brand_id}/run\n\n"
+            "Once done, come back and we'll build campaigns that bring your brand to life."
+        ),
+        "required_phases": list(_REQUIRED_PHASES),
+        "missing_phases": exc.missing_phases,
+        "current_phase": exc.current_phase,
+        "branding_api_base": "/api/branding",
+    }
 
 
 def _fetch_and_validate_brand(client_id: str, brand_id: str) -> BrandContext:
@@ -209,17 +250,17 @@ def _fetch_and_validate_brand(client_id: str, brand_id: str) -> BrandContext:
     """
     try:
         brand_data = fetch_brand(client_id, brand_id)
-    except BrandNotFoundError:
+    except BrandNotFoundError as exc:
         raise HTTPException(
-            status_code=422, detail=build_brand_not_found_error(client_id, brand_id)
-        )
+            status_code=422, detail=_build_brand_not_found_error(client_id, brand_id)
+        ) from exc
     except RuntimeError as exc:
         raise HTTPException(status_code=502, detail=str(exc)) from exc
 
     try:
         return validate_brand_for_social_marketing(brand_data, client_id, brand_id)
     except BrandIncompleteError as exc:
-        raise HTTPException(status_code=422, detail=build_brand_incomplete_error(exc))
+        raise HTTPException(status_code=422, detail=_build_brand_incomplete_error(exc)) from exc
 
 
 @app.post("/social-marketing/run", response_model=RunMarketingTeamResponse)

--- a/backend/agents/social_media_marketing_team/api/request_models.py
+++ b/backend/agents/social_media_marketing_team/api/request_models.py
@@ -11,17 +11,14 @@ from social_media_marketing_team.trend_models import TrendDigest
 
 
 class RunMarketingTeamRequest(BaseModel):
-    brand_guidelines_path: str = Field(
-        ..., max_length=4096, description="Path to brand guidelines document"
+    client_id: str = Field(
+        ..., max_length=256, description="Client identifier from the branding team"
     )
-    brand_objectives_path: str = Field(
-        ..., max_length=4096, description="Path to brand objectives document"
+    brand_id: str = Field(
+        ..., max_length=256, description="Brand identifier from the branding team"
     )
     llm_model_name: str = Field(..., max_length=256, description="Name of local LLM model to use")
-    brand_name: str = Field(default="Brand", max_length=256)
-    target_audience: str = Field(default="general audience", max_length=5000)
     goals: List[str] = Field(default_factory=lambda: ["engagement", "follower growth"])
-    voice_and_tone: str = Field(default="professional, clear, and human", max_length=5000)
     cadence_posts_per_day: int = Field(default=2, ge=1, le=24)
     duration_days: int = Field(default=14, ge=1, le=365)
     human_approved_for_testing: bool = Field(default=False)
@@ -37,6 +34,7 @@ class RunMarketingTeamResponse(BaseModel):
     job_id: str
     status: str
     message: str
+    brand_summary: Optional[str] = None
 
 
 class MarketingJobStatusResponse(BaseModel):
@@ -45,8 +43,8 @@ class MarketingJobStatusResponse(BaseModel):
     current_stage: str
     progress: int
     llm_model_name: str
-    brand_guidelines_path: str
-    brand_objectives_path: str
+    client_id: str
+    brand_id: str
     last_updated_at: str
     eta_hint: Optional[str] = None
     error: Optional[str] = None

--- a/backend/agents/social_media_marketing_team/api/request_models.py
+++ b/backend/agents/social_media_marketing_team/api/request_models.py
@@ -9,13 +9,24 @@ from pydantic import BaseModel, Field
 from social_media_marketing_team.models import PostPerformanceObservation, TeamOutput
 from social_media_marketing_team.trend_models import TrendDigest
 
+# Only allow alphanumeric, hyphens, and underscores in identifiers.
+# Prevents path-traversal (../) and query-string injection (?/#) when
+# the values are interpolated into URLs or error messages.
+_SAFE_ID_PATTERN = r"^[a-zA-Z0-9_-]+$"
+
 
 class RunMarketingTeamRequest(BaseModel):
     client_id: str = Field(
-        ..., max_length=256, description="Client identifier from the branding team"
+        ...,
+        max_length=256,
+        pattern=_SAFE_ID_PATTERN,
+        description="Client identifier from the branding team",
     )
     brand_id: str = Field(
-        ..., max_length=256, description="Brand identifier from the branding team"
+        ...,
+        max_length=256,
+        pattern=_SAFE_ID_PATTERN,
+        description="Brand identifier from the branding team",
     )
     llm_model_name: str = Field(..., max_length=256, description="Name of local LLM model to use")
     goals: List[str] = Field(default_factory=lambda: ["engagement", "follower growth"])

--- a/backend/agents/social_media_marketing_team/models.py
+++ b/backend/agents/social_media_marketing_team/models.py
@@ -28,10 +28,11 @@ class BrandGoals(BaseModel):
     voice_and_tone: str = "professional, clear, and human"
     cadence_posts_per_day: int = Field(default=2, ge=1, le=24)
     duration_days: int = Field(default=14, ge=1, le=365)
-    brand_guidelines_path: Optional[str] = None
-    brand_objectives_path: Optional[str] = None
     brand_guidelines: str = ""
     brand_objectives: str = ""
+    messaging_pillars: List[str] = Field(default_factory=list)
+    brand_story: str = ""
+    tagline: str = ""
 
 
 class CampaignProposal(BaseModel):

--- a/backend/agents/social_media_marketing_team/orchestrator.py
+++ b/backend/agents/social_media_marketing_team/orchestrator.py
@@ -94,13 +94,13 @@ class SocialMediaMarketingOrchestrator:
             experiment_notes="Start with 14-day test window and compare baseline vs campaign uplift.",
         )
 
-        if goals.brand_guidelines_path:
+        if goals.messaging_pillars:
+            proposal.messaging_pillars = goals.messaging_pillars
+        if goals.tagline:
+            proposal.communication_log.append(f"Brand tagline: {goals.tagline}")
+        if goals.brand_story:
             proposal.communication_log.append(
-                f"Using brand guidelines document at path: {goals.brand_guidelines_path}"
-            )
-        if goals.brand_objectives_path:
-            proposal.communication_log.append(
-                f"Using brand objectives document at path: {goals.brand_objectives_path}"
+                f"Brand story context injected ({len(goals.brand_story)} chars)."
             )
         if goals.brand_guidelines:
             proposal.communication_log.append(

--- a/backend/agents/social_media_marketing_team/temporal/activities.py
+++ b/backend/agents/social_media_marketing_team/temporal/activities.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any, Dict
 
 from temporalio import activity
+from temporalio.exceptions import ApplicationError
 
 logger = logging.getLogger(__name__)
 
@@ -16,9 +17,13 @@ def run_team_job_activity(job_id: str, request_dict: Dict[str, Any]) -> None:
 
     The activity re-fetches the brand from the branding API so that brand
     context is always current, even for Temporal replays or retries.
+    Brand-related failures (missing or incomplete brand) are marked
+    non-retryable since retrying won't fix them.
     """
     try:
         from social_media_marketing_team.adapters.branding import (
+            BrandIncompleteError,
+            BrandNotFoundError,
             fetch_brand,
             validate_brand_for_social_marketing,
         )
@@ -30,6 +35,9 @@ def run_team_job_activity(job_id: str, request_dict: Dict[str, Any]) -> None:
             brand_data, request.client_id, request.brand_id
         )
         _run_team_job(job_id, request, brand_ctx)
+    except (BrandNotFoundError, BrandIncompleteError) as exc:
+        logger.error("Brand unavailable for job %s: %s", job_id, exc)
+        raise ApplicationError(str(exc), non_retryable=True) from exc
     except Exception:
         logger.exception("Social marketing team job activity failed for job %s", job_id)
         raise

--- a/backend/agents/social_media_marketing_team/temporal/activities.py
+++ b/backend/agents/social_media_marketing_team/temporal/activities.py
@@ -12,12 +12,24 @@ logger = logging.getLogger(__name__)
 
 @activity.defn(name="run_social_marketing_team_job")
 def run_team_job_activity(job_id: str, request_dict: Dict[str, Any]) -> None:
-    """Run the social marketing team job (or run or revise)."""
+    """Run the social marketing team job (run or revise).
+
+    The activity re-fetches the brand from the branding API so that brand
+    context is always current, even for Temporal replays or retries.
+    """
     try:
+        from social_media_marketing_team.adapters.branding import (
+            fetch_brand,
+            validate_brand_for_social_marketing,
+        )
         from social_media_marketing_team.api.main import RunMarketingTeamRequest, _run_team_job
 
         request = RunMarketingTeamRequest(**request_dict)
-        _run_team_job(job_id, request)
+        brand_data = fetch_brand(request.client_id, request.brand_id)
+        brand_ctx = validate_brand_for_social_marketing(
+            brand_data, request.client_id, request.brand_id
+        )
+        _run_team_job(job_id, request, brand_ctx)
     except Exception:
         logger.exception("Social marketing team job activity failed for job %s", job_id)
         raise

--- a/backend/agents/social_media_marketing_team/tests/test_api.py
+++ b/backend/agents/social_media_marketing_team/tests/test_api.py
@@ -1,10 +1,27 @@
 import time
-from pathlib import Path
+from unittest.mock import patch
 
 from fastapi.testclient import TestClient
 
+from social_media_marketing_team.adapters.branding import (
+    BrandContext,
+    BrandNotFoundError,
+)
 from social_media_marketing_team.api.main import app
 from social_media_marketing_team.models import Platform
+
+_MOCK_BRAND_CTX = BrandContext(
+    brand_name="Acme",
+    target_audience="B2B founders and engineering leaders",
+    voice_and_tone="clear, confident, human",
+    brand_guidelines="Positioning: Developer tools that just work.",
+    brand_objectives="Purpose: Empower developers.\nMission: Ship faster.",
+    messaging_pillars=["Developer empowerment", "Simplicity"],
+    brand_story="Acme was born from frustration with overcomplicated tools.",
+    tagline="Developer tools that just work",
+)
+
+_BRAND_ADAPTER = "social_media_marketing_team.api.main"
 
 
 def _wait_for_done(client: TestClient, job_id: str):
@@ -20,26 +37,23 @@ def _wait_for_done(client: TestClient, job_id: str):
     return status_payload
 
 
-def test_run_endpoint_and_status_success(tmp_path: Path) -> None:
+@patch(f"{_BRAND_ADAPTER}._fetch_and_validate_brand", return_value=_MOCK_BRAND_CTX)
+def test_run_endpoint_and_status_success(_mock_brand) -> None:
     client = TestClient(app)
-    guidelines = tmp_path / "guidelines.md"
-    objectives = tmp_path / "objectives.md"
-    guidelines.write_text("Tone: expert but friendly")
-    objectives.write_text("Goals: engagement and qualified leads")
-
     resp = client.post(
         "/social-marketing/run",
         json={
-            "brand_guidelines_path": str(guidelines),
-            "brand_objectives_path": str(objectives),
+            "client_id": "client_1",
+            "brand_id": "brand_1",
             "llm_model_name": "llama3.1",
-            "brand_name": "Acme",
-            "target_audience": "B2B founders",
             "human_approved_for_testing": True,
         },
     )
     assert resp.status_code == 200
-    job_id = resp.json()["job_id"]
+    body = resp.json()
+    job_id = body["job_id"]
+    assert body["brand_summary"] is not None
+    assert "Acme" in body["brand_summary"]
 
     status_payload = _wait_for_done(client, job_id)
     assert status_payload is not None
@@ -50,21 +64,16 @@ def test_run_endpoint_and_status_success(tmp_path: Path) -> None:
     assert status_payload["result"]["llm_model_name"] == "llama3.1"
 
 
-def test_performance_ingest_and_revision_endpoints(tmp_path: Path) -> None:
+@patch(f"{_BRAND_ADAPTER}._fetch_and_validate_brand", return_value=_MOCK_BRAND_CTX)
+def test_performance_ingest_and_revision_endpoints(_mock_brand) -> None:
     client = TestClient(app)
-    guidelines = tmp_path / "guidelines.md"
-    objectives = tmp_path / "objectives.md"
-    guidelines.write_text("Tone: expert")
-    objectives.write_text("Goals: engagement")
-
     run = client.post(
         "/social-marketing/run",
         json={
-            "brand_guidelines_path": str(guidelines),
-            "brand_objectives_path": str(objectives),
+            "client_id": "client_1",
+            "brand_id": "brand_1",
             "llm_model_name": "mistral",
             "human_approved_for_testing": True,
-            "brand_name": "Acme",
         },
     )
     assert run.status_code == 200
@@ -99,17 +108,49 @@ def test_performance_ingest_and_revision_endpoints(tmp_path: Path) -> None:
     assert status["status"] == "completed"
 
 
-def test_run_endpoint_rejects_missing_files() -> None:
+@patch(
+    f"{_BRAND_ADAPTER}.fetch_brand",
+    side_effect=BrandNotFoundError("client_x", "brand_x"),
+)
+def test_run_endpoint_rejects_missing_brand(_mock_fetch) -> None:
     client = TestClient(app)
     resp = client.post(
         "/social-marketing/run",
         json={
-            "brand_guidelines_path": "/tmp/does-not-exist-1.md",
-            "brand_objectives_path": "/tmp/does-not-exist-2.md",
+            "client_id": "client_x",
+            "brand_id": "brand_x",
             "llm_model_name": "llama3.1",
         },
     )
-    assert resp.status_code == 400
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert detail["error"] == "brand_not_found"
+    assert "brand_x" in detail["message"]
+    assert "user_message" in detail
+
+
+@patch(
+    f"{_BRAND_ADAPTER}.fetch_brand",
+    return_value={
+        "latest_output": {"strategic_core": {"some": "data"}},
+        "current_phase": "strategic_core",
+    },
+)
+def test_run_endpoint_rejects_incomplete_brand(_mock_fetch) -> None:
+    client = TestClient(app)
+    resp = client.post(
+        "/social-marketing/run",
+        json={
+            "client_id": "client_y",
+            "brand_id": "brand_y",
+            "llm_model_name": "llama3.1",
+        },
+    )
+    assert resp.status_code == 422
+    detail = resp.json()["detail"]
+    assert detail["error"] == "brand_incomplete"
+    assert "narrative_messaging" in detail["missing_phases"]
+    assert "user_message" in detail
 
 
 def test_status_and_performance_404_for_unknown_job() -> None:

--- a/backend/agents/social_media_marketing_team/tests/test_api_internal.py
+++ b/backend/agents/social_media_marketing_team/tests/test_api_internal.py
@@ -157,3 +157,51 @@ def test_revise_marketing_team_missing_job_and_health(temp_job_manager: CentralJ
         )
 
     assert api_main.health() == {"status": "ok"}
+
+
+def test_legacy_job_without_brand_ids_returns_410(temp_job_manager: CentralJobManager) -> None:
+    """A job created before the brand requirement has no client_id/brand_id anywhere."""
+    api_main._job_manager.create_job(
+        "legacy-1",
+        status="completed",
+        current_stage="completed",
+        progress=100,
+        llm_model_name="llama3.1",
+        result=None,
+        error=None,
+        eta_hint="done",
+        last_updated_at=api_main._now(),
+        request_payload={
+            "brand_guidelines_path": "/tmp/old.md",
+            "brand_objectives_path": "/tmp/old.md",
+            "llm_model_name": "llama3.1",
+        },
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        api_main.get_marketing_job_status("legacy-1")
+    assert exc_info.value.status_code == 410
+    assert "predates the brand requirement" in exc_info.value.detail
+
+
+def test_job_backfills_brand_ids_from_request_payload(temp_job_manager: CentralJobManager) -> None:
+    """A job that has client_id/brand_id in request_payload but not at top level."""
+    api_main._job_manager.create_job(
+        "backfill-1",
+        status="completed",
+        current_stage="completed",
+        progress=100,
+        llm_model_name="llama3.1",
+        result=None,
+        error=None,
+        eta_hint="done",
+        last_updated_at=api_main._now(),
+        request_payload={
+            "client_id": "c_from_payload",
+            "brand_id": "b_from_payload",
+            "llm_model_name": "llama3.1",
+            "goals": ["engagement"],
+        },
+    )
+    status = api_main.get_marketing_job_status("backfill-1")
+    assert status.client_id == "c_from_payload"
+    assert status.brand_id == "b_from_payload"

--- a/backend/agents/social_media_marketing_team/tests/test_api_internal.py
+++ b/backend/agents/social_media_marketing_team/tests/test_api_internal.py
@@ -1,10 +1,23 @@
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from fastapi import HTTPException
 
 from shared_job_management import CentralJobManager
+from social_media_marketing_team.adapters.branding import BrandContext, BrandNotFoundError
 from social_media_marketing_team.api import main as api_main
+
+_MOCK_BRAND_CTX = BrandContext(
+    brand_name="Acme",
+    target_audience="operators",
+    voice_and_tone="direct and clear",
+    brand_guidelines="Keep tone direct",
+    brand_objectives="Grow followers",
+    messaging_pillars=["Growth", "Clarity"],
+    brand_story="Acme helps teams grow.",
+    tagline="Grow with clarity",
+)
 
 
 def _seed_job(job_id: str, request: api_main.RunMarketingTeamRequest) -> None:
@@ -14,8 +27,8 @@ def _seed_job(job_id: str, request: api_main.RunMarketingTeamRequest) -> None:
         current_stage="queued",
         progress=0,
         llm_model_name=request.llm_model_name,
-        brand_guidelines_path=request.brand_guidelines_path,
-        brand_objectives_path=request.brand_objectives_path,
+        client_id=request.client_id,
+        brand_id=request.brand_id,
         result=None,
         error=None,
         eta_hint="queued",
@@ -35,20 +48,13 @@ def temp_job_manager(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     return manager
 
 
-def test_read_text_file_and_update_job(tmp_path: Path, temp_job_manager: CentralJobManager) -> None:
-    file_path = tmp_path / "doc.txt"
-    file_path.write_text("hello")
-    assert api_main._read_text_file(str(file_path)) == "hello"
-
-    with pytest.raises(ValueError):
-        api_main._read_text_file(str(tmp_path / "missing.txt"))
-
+def test_update_job(tmp_path: Path, temp_job_manager: CentralJobManager) -> None:
     api_main._update_job("missing", status="running")
     assert temp_job_manager.get_job("missing") is not None
 
     req = api_main.RunMarketingTeamRequest(
-        brand_guidelines_path=str(file_path),
-        brand_objectives_path=str(file_path),
+        client_id="c1",
+        brand_id="b1",
         llm_model_name="x",
     )
     _seed_job("job-1", req)
@@ -59,51 +65,31 @@ def test_read_text_file_and_update_job(tmp_path: Path, temp_job_manager: Central
     assert job["last_heartbeat_at"] >= old_ts
 
 
-def test_run_team_job_success_and_failure(
-    tmp_path: Path, temp_job_manager: CentralJobManager
-) -> None:
-    guidelines = tmp_path / "guidelines.md"
-    objectives = tmp_path / "objectives.md"
-    guidelines.write_text("Keep tone direct")
-    objectives.write_text("Grow followers")
-
+def test_run_team_job_success(tmp_path: Path, temp_job_manager: CentralJobManager) -> None:
     req = api_main.RunMarketingTeamRequest(
-        brand_guidelines_path=str(guidelines),
-        brand_objectives_path=str(objectives),
+        client_id="c1",
+        brand_id="b1",
         llm_model_name="llama3.1",
-        brand_name="Acme",
-        target_audience="operators",
         human_approved_for_testing=True,
     )
     _seed_job("ok", req)
 
-    api_main._run_team_job("ok", req)
+    api_main._run_team_job("ok", req, _MOCK_BRAND_CTX)
     ok_job = temp_job_manager.get_job("ok")
     assert ok_job["status"] == "completed"
     assert ok_job["result"]["llm_model_name"] == "llama3.1"
 
-    bad_req = api_main.RunMarketingTeamRequest(
-        brand_guidelines_path=str(tmp_path / "missing-guidelines.md"),
-        brand_objectives_path=str(objectives),
-        llm_model_name="llama3.1",
-    )
-    _seed_job("bad", bad_req)
-    api_main._run_team_job("bad", bad_req)
-    bad_job = temp_job_manager.get_job("bad")
-    assert bad_job["status"] == "failed"
-    assert bad_job["error"]
 
-
+@patch(
+    "social_media_marketing_team.api.main._fetch_and_validate_brand",
+    return_value=_MOCK_BRAND_CTX,
+)
 def test_run_and_status_functions_with_inline_thread(
+    _mock_brand,
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     temp_job_manager: CentralJobManager,
 ) -> None:
-    guidelines = tmp_path / "guidelines.md"
-    objectives = tmp_path / "objectives.md"
-    guidelines.write_text("Voice guide")
-    objectives.write_text("Objective guide")
-
     class InlineThread:
         def __init__(self, target, args, daemon):
             self._target = target
@@ -116,13 +102,14 @@ def test_run_and_status_functions_with_inline_thread(
     monkeypatch.setattr(api_main.threading, "Thread", InlineThread)
 
     request = api_main.RunMarketingTeamRequest(
-        brand_guidelines_path=str(guidelines),
-        brand_objectives_path=str(objectives),
+        client_id="c1",
+        brand_id="b1",
         llm_model_name="mistral",
         human_approved_for_testing=False,
     )
     response = api_main.run_marketing_team(request)
     assert response.status == "running"
+    assert response.brand_summary is not None
 
     status = api_main.get_marketing_job_status(response.job_id)
     assert status.status == "completed"
@@ -143,16 +130,26 @@ def test_run_and_status_functions_with_inline_thread(
         api_main.get_marketing_job_status("missing-job-id")
 
 
-def test_run_marketing_team_validation_and_health(temp_job_manager: CentralJobManager) -> None:
-    with pytest.raises(HTTPException):
+@patch(
+    "social_media_marketing_team.api.main.fetch_brand",
+    side_effect=BrandNotFoundError("c_miss", "b_miss"),
+)
+def test_run_marketing_team_brand_not_found(
+    _mock_fetch, temp_job_manager: CentralJobManager
+) -> None:
+    with pytest.raises(HTTPException) as exc_info:
         api_main.run_marketing_team(
             api_main.RunMarketingTeamRequest(
-                brand_guidelines_path="/tmp/nope-guidelines.md",
-                brand_objectives_path="/tmp/nope-objectives.md",
+                client_id="c_miss",
+                brand_id="b_miss",
                 llm_model_name="model",
             )
         )
+    assert exc_info.value.status_code == 422
+    assert exc_info.value.detail["error"] == "brand_not_found"
 
+
+def test_revise_marketing_team_missing_job_and_health(temp_job_manager: CentralJobManager) -> None:
     with pytest.raises(HTTPException):
         api_main.revise_marketing_team(
             "missing",

--- a/backend/agents/social_media_marketing_team/tests/test_branding_adapter.py
+++ b/backend/agents/social_media_marketing_team/tests/test_branding_adapter.py
@@ -1,0 +1,234 @@
+"""Unit tests for the branding adapter validation and extraction logic."""
+
+import pytest
+
+from social_media_marketing_team.adapters.branding import (
+    BrandContext,
+    BrandIncompleteError,
+    validate_brand_for_social_marketing,
+)
+
+
+def _full_brand_data() -> dict:
+    """Return a realistic brand API response with both required phases."""
+    return {
+        "id": "brand_1",
+        "client_id": "client_1",
+        "name": "Acme Corp",
+        "current_phase": "narrative_messaging",
+        "mission": {
+            "company_name": "Acme Corp",
+            "company_description": "Developer tools",
+            "target_audience": "B2B engineering leaders",
+            "desired_voice": "clear, confident, human",
+            "values": ["transparency", "simplicity"],
+            "differentiators": ["ease of use"],
+        },
+        "latest_output": {
+            "strategic_core": {
+                "brand_purpose": "Empower developers to ship faster",
+                "mission_statement": "Make developer tools that just work",
+                "vision_statement": "A world where dev tools disappear into the background",
+                "brand_promise": "You'll ship in half the time",
+                "positioning_statement": "The simplest way to build and deploy",
+                "core_values": [
+                    {
+                        "value": "Simplicity",
+                        "behavioral_definition": "Remove unnecessary complexity",
+                    },
+                    {"value": "Speed", "behavioral_definition": "Ship fast, iterate faster"},
+                ],
+                "target_audience_segments": [
+                    {
+                        "name": "Startup CTOs",
+                        "description": "Technical founders at seed-stage companies",
+                    },
+                    {
+                        "name": "Platform Engineers",
+                        "description": "Infra engineers at mid-size companies",
+                    },
+                ],
+                "differentiation_pillars": [
+                    {
+                        "pillar": "Ease of use",
+                        "competitive_context": "Others require 10x more config",
+                    },
+                ],
+            },
+            "narrative_messaging": {
+                "brand_story": "Acme was born from frustration with overcomplicated tools.",
+                "tagline": "Developer tools that just work",
+                "brand_archetypes": [
+                    {
+                        "archetype": "Creator",
+                        "personality_traits": ["inventive", "expressive", "bold"],
+                    },
+                ],
+                "messaging_framework": [
+                    {
+                        "pillar": "Developer empowerment",
+                        "key_message": "Ship faster",
+                        "proof_points": [],
+                    },
+                    {
+                        "pillar": "Simplicity first",
+                        "key_message": "Less config, more code",
+                        "proof_points": [],
+                    },
+                ],
+                "audience_message_maps": [
+                    {
+                        "audience_segment": "Startup CTOs",
+                        "primary_message": "Move fast without breaking things",
+                        "tone_adjustments": "Direct and pragmatic",
+                    },
+                ],
+                "elevator_pitches": [],
+                "boilerplate_variants": [],
+                "persona_profiles": [],
+            },
+        },
+    }
+
+
+class TestValidateBrandHappyPath:
+    def test_extracts_brand_name(self) -> None:
+        ctx = validate_brand_for_social_marketing(_full_brand_data(), "c1", "b1")
+        assert ctx.brand_name == "Acme Corp"
+
+    def test_extracts_target_audience_with_segments(self) -> None:
+        ctx = validate_brand_for_social_marketing(_full_brand_data(), "c1", "b1")
+        assert "B2B engineering leaders" in ctx.target_audience
+        assert "Startup CTOs" in ctx.target_audience
+        assert "Platform Engineers" in ctx.target_audience
+
+    def test_extracts_voice_and_tone(self) -> None:
+        ctx = validate_brand_for_social_marketing(_full_brand_data(), "c1", "b1")
+        assert "clear, confident, human" in ctx.voice_and_tone
+        assert "inventive" in ctx.voice_and_tone
+
+    def test_extracts_brand_guidelines(self) -> None:
+        ctx = validate_brand_for_social_marketing(_full_brand_data(), "c1", "b1")
+        assert "Positioning:" in ctx.brand_guidelines
+        assert "Simplicity" in ctx.brand_guidelines
+        assert "Ease of use" in ctx.brand_guidelines
+        assert "Direct and pragmatic" in ctx.brand_guidelines
+
+    def test_extracts_brand_objectives(self) -> None:
+        ctx = validate_brand_for_social_marketing(_full_brand_data(), "c1", "b1")
+        assert "Purpose:" in ctx.brand_objectives
+        assert "Mission:" in ctx.brand_objectives
+        assert "Vision:" in ctx.brand_objectives
+        assert "Promise:" in ctx.brand_objectives
+
+    def test_extracts_messaging_pillars(self) -> None:
+        ctx = validate_brand_for_social_marketing(_full_brand_data(), "c1", "b1")
+        assert ctx.messaging_pillars == ["Developer empowerment", "Simplicity first"]
+
+    def test_extracts_brand_story_and_tagline(self) -> None:
+        ctx = validate_brand_for_social_marketing(_full_brand_data(), "c1", "b1")
+        assert "frustration" in ctx.brand_story
+        assert ctx.tagline == "Developer tools that just work"
+
+    def test_returns_brand_context_type(self) -> None:
+        ctx = validate_brand_for_social_marketing(_full_brand_data(), "c1", "b1")
+        assert isinstance(ctx, BrandContext)
+
+
+class TestValidateBrandMissingPhases:
+    def test_raises_when_latest_output_is_none(self) -> None:
+        data = _full_brand_data()
+        data["latest_output"] = None
+        with pytest.raises(BrandIncompleteError) as exc_info:
+            validate_brand_for_social_marketing(data, "c1", "b1")
+        assert set(exc_info.value.missing_phases) == {"strategic_core", "narrative_messaging"}
+
+    def test_raises_when_latest_output_missing(self) -> None:
+        data = _full_brand_data()
+        del data["latest_output"]
+        with pytest.raises(BrandIncompleteError) as exc_info:
+            validate_brand_for_social_marketing(data, "c1", "b1")
+        assert len(exc_info.value.missing_phases) == 2
+
+    def test_raises_when_strategic_core_missing(self) -> None:
+        data = _full_brand_data()
+        del data["latest_output"]["strategic_core"]
+        with pytest.raises(BrandIncompleteError) as exc_info:
+            validate_brand_for_social_marketing(data, "c1", "b1")
+        assert exc_info.value.missing_phases == ["strategic_core"]
+
+    def test_raises_when_narrative_messaging_missing(self) -> None:
+        data = _full_brand_data()
+        del data["latest_output"]["narrative_messaging"]
+        with pytest.raises(BrandIncompleteError) as exc_info:
+            validate_brand_for_social_marketing(data, "c1", "b1")
+        assert exc_info.value.missing_phases == ["narrative_messaging"]
+
+    def test_raises_when_phase_is_non_dict(self) -> None:
+        data = _full_brand_data()
+        data["latest_output"]["strategic_core"] = "not a dict"
+        with pytest.raises(BrandIncompleteError) as exc_info:
+            validate_brand_for_social_marketing(data, "c1", "b1")
+        assert "strategic_core" in exc_info.value.missing_phases
+
+    def test_raises_when_phase_is_boolean(self) -> None:
+        data = _full_brand_data()
+        data["latest_output"]["narrative_messaging"] = True
+        with pytest.raises(BrandIncompleteError) as exc_info:
+            validate_brand_for_social_marketing(data, "c1", "b1")
+        assert "narrative_messaging" in exc_info.value.missing_phases
+
+    def test_carries_current_phase(self) -> None:
+        data = _full_brand_data()
+        data["current_phase"] = "strategic_core"
+        del data["latest_output"]["narrative_messaging"]
+        with pytest.raises(BrandIncompleteError) as exc_info:
+            validate_brand_for_social_marketing(data, "c1", "b1")
+        assert exc_info.value.current_phase == "strategic_core"
+
+
+class TestValidateBrandEdgeCases:
+    def test_empty_mission_produces_defaults(self) -> None:
+        data = _full_brand_data()
+        data["mission"] = {}
+        ctx = validate_brand_for_social_marketing(data, "c1", "b1")
+        assert ctx.brand_name == "Acme Corp"  # falls back to data["name"]
+        assert ctx.voice_and_tone  # should still have archetype traits
+
+    def test_empty_segments_and_archetypes(self) -> None:
+        data = _full_brand_data()
+        data["latest_output"]["strategic_core"]["target_audience_segments"] = []
+        data["latest_output"]["narrative_messaging"]["brand_archetypes"] = []
+        data["mission"]["desired_voice"] = ""
+        ctx = validate_brand_for_social_marketing(data, "c1", "b1")
+        assert ctx.voice_and_tone == "professional, clear, and human"
+
+    def test_missing_name_falls_back_to_mission_company_name(self) -> None:
+        data = _full_brand_data()
+        del data["name"]
+        ctx = validate_brand_for_social_marketing(data, "c1", "b1")
+        assert ctx.brand_name == "Acme Corp"
+
+    def test_missing_name_and_mission_falls_back_to_brand(self) -> None:
+        data = _full_brand_data()
+        del data["name"]
+        data["mission"] = {}
+        ctx = validate_brand_for_social_marketing(data, "c1", "b1")
+        assert ctx.brand_name == "Brand"
+
+
+class TestBrandContextToGoals:
+    def test_to_brand_goals_maps_all_fields(self) -> None:
+        ctx = validate_brand_for_social_marketing(_full_brand_data(), "c1", "b1")
+        goals = ctx.to_brand_goals(goals=["engagement"], cadence_posts_per_day=3, duration_days=7)
+        assert goals.brand_name == ctx.brand_name
+        assert goals.target_audience == ctx.target_audience
+        assert goals.voice_and_tone == ctx.voice_and_tone
+        assert goals.brand_guidelines == ctx.brand_guidelines
+        assert goals.brand_objectives == ctx.brand_objectives
+        assert goals.messaging_pillars == ctx.messaging_pillars
+        assert goals.brand_story == ctx.brand_story
+        assert goals.tagline == ctx.tagline
+        assert goals.goals == ["engagement"]
+        assert goals.cadence_posts_per_day == 3
+        assert goals.duration_days == 7

--- a/backend/agents/social_media_marketing_team/tests/test_orchestrator_additional.py
+++ b/backend/agents/social_media_marketing_team/tests/test_orchestrator_additional.py
@@ -136,23 +136,25 @@ def test_calibration_changes_probabilities_when_engagement_observations_exist() 
     assert calibrated[0].estimated_engagement_probability > idea.estimated_engagement_probability
 
 
-def test_build_initial_proposal_includes_brand_document_context_and_model() -> None:
+def test_build_initial_proposal_includes_brand_context_and_model() -> None:
     orchestrator = SocialMediaMarketingOrchestrator(llm_model_name="llama3.1")
     goals = BrandGoals(
         brand_name="DocBrand",
         target_audience="professionals",
         goals=["engagement"],
-        brand_guidelines_path="/tmp/guidelines.md",
-        brand_objectives_path="/tmp/objectives.md",
         brand_guidelines="Always include clear CTA",
         brand_objectives="Increase comments by 20%",
+        messaging_pillars=["Developer empowerment", "Simplicity"],
+        brand_story="DocBrand was founded to simplify documentation.",
+        tagline="Docs done right",
     )
 
     proposal = orchestrator._build_initial_proposal(goals)
 
     assert "Ground strategy in brand objectives" in proposal.objective
-    assert any("brand guidelines document" in msg for msg in proposal.communication_log)
-    assert any("brand objectives document" in msg for msg in proposal.communication_log)
+    assert proposal.messaging_pillars == ["Developer empowerment", "Simplicity"]
+    assert any("Brand tagline" in msg for msg in proposal.communication_log)
+    assert any("Brand story context injected" in msg for msg in proposal.communication_log)
     assert any("Guideline context injected" in msg for msg in proposal.communication_log)
     assert any("Objective context injected" in msg for msg in proposal.communication_log)
     assert any("Configured LLM model" in msg for msg in proposal.communication_log)

--- a/backend/agents/team_assistant/config.py
+++ b/backend/agents/team_assistant/config.py
@@ -166,35 +166,38 @@ TEAM_ASSISTANT_CONFIGS: dict[str, TeamAssistantConfig] = {
         team_name="Social Media Marketing",
         system_prompt_context=(
             "A social media marketing team that plans cross-platform campaigns with content "
-            "calendars, post copy, and performance tracking. The user needs to describe their "
-            "brand and campaign goals."
+            "calendars, post copy, and performance tracking. The team works from a defined "
+            "brand strategy — the user must provide a client_id and brand_id referencing a "
+            "brand built via the Branding team (with at least Strategic Core and Narrative & "
+            "Messaging phases complete). Brand voice, audience, and messaging are pulled "
+            "automatically from the brand definition."
         ),
         required_fields=[
-            {"key": "brand_name", "description": "Name of the brand or company"},
-            {"key": "target_audience", "description": "Target audience for the campaign"},
+            {"key": "client_id", "description": "Client identifier from the branding team"},
+            {"key": "brand_id", "description": "Brand identifier from the branding team"},
         ],
         optional_fields=[
-            {"key": "brand_guidelines_path", "description": "Path to brand guidelines document"},
-            {"key": "brand_objectives_path", "description": "Path to brand objectives document"},
             {
                 "key": "goals",
                 "description": "Campaign goals (e.g. engagement, follower growth, conversions)",
-            },
-            {
-                "key": "voice_and_tone",
-                "description": "Brand voice and tone (e.g. professional, playful, bold)",
             },
             {"key": "cadence_posts_per_day", "description": "Number of posts per day"},
             {"key": "duration_days", "description": "Campaign duration in days"},
         ],
         welcome_message=(
-            "Welcome! I'm the Social Media Marketing team assistant. I'll help you plan a campaign.\n\n"
-            "What brand are you creating a campaign for, and who is your target audience?"
+            "Welcome! I'm your Social Media Marketing assistant. I help plan campaigns that "
+            "truly reflect your brand -- from content calendars to platform-specific strategies.\n\n"
+            "To create campaigns that resonate, I work from your brand's strategy and messaging. "
+            "If you haven't defined your brand yet, the Branding team can help you set that up "
+            "first -- it covers your strategic positioning and voice, and makes all the difference "
+            "in campaign quality.\n\n"
+            "Ready to get started? Tell me your client ID and brand ID, and I'll pull in your "
+            "brand context."
         ),
         default_suggested_questions=[
-            "I want to plan a 2-week social media campaign.",
-            "Help me create a content calendar for my brand.",
-            "I need to grow engagement on Instagram and LinkedIn.",
+            "I want to plan a 2-week social media campaign for my brand.",
+            "Help me create a content calendar using my brand's voice and messaging.",
+            "I haven't defined my brand yet -- where do I start?",
         ],
     ),
     # -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Refactor the social media marketing team to fetch brand data from a centralized branding API instead of requiring users to provide file paths to brand documents. This enables campaigns to be built from a unified brand definition managed by the branding team.

## Key Changes

- **New branding adapter** (`adapters/branding.py`): 
  - Fetches brand data from the branding team API via `fetch_brand()`
  - Validates that brands have completed required phases (Strategic Core and Narrative & Messaging)
  - Extracts a `BrandContext` object containing brand name, audience, voice, guidelines, objectives, messaging pillars, story, and tagline
  - Provides structured error responses with user-friendly guidance for missing or incomplete brands

- **Updated API request model** (`request_models.py`):
  - Replaced `brand_guidelines_path` and `brand_objectives_path` with `client_id` and `brand_id`
  - Removed `brand_name`, `target_audience`, and `voice_and_tone` fields (now sourced from brand definition)

- **Refactored main API** (`api/main.py`):
  - Removed file path validation and text file reading logic
  - Added `_fetch_and_validate_brand()` to retrieve and validate brands, raising HTTP 422 with structured errors on failure
  - Updated `/social-marketing/run` and `/revise` endpoints to fetch brand context before dispatching jobs
  - Added `brand_summary` field to `RunMarketingTeamResponse` for user feedback
  - Simplified job initialization by storing `client_id` and `brand_id` instead of file paths

- **Updated orchestrator** (`orchestrator.py`):
  - Modified `BrandGoals` model to accept brand data fields directly instead of file paths
  - Updated proposal building to use messaging pillars, tagline, and brand story from the brand context

- **Updated team assistant config** (`team_assistant/config.py`):
  - Changed required fields to `client_id` and `brand_id`
  - Updated system prompt and welcome message to reflect brand-driven workflow

- **Updated tests**:
  - Replaced file-based test fixtures with mocked `BrandContext` objects
  - Added tests for brand not found and incomplete brand error cases
  - Simplified test setup by mocking brand fetch/validation

## Implementation Details

- Brand validation ensures both "strategic_core" and "narrative_messaging" phases are complete before allowing campaign creation
- Error responses include both structured machine-readable fields and warm, actionable user messages guiding users through the branding process
- The `BrandContext` synthesizes data from multiple branding phases into a cohesive set of fields needed for social marketing
- HTTP status codes: 422 for validation errors (missing/incomplete brand), 502 for API connectivity issues

https://claude.ai/code/session_01LSD19Z1hXGUvBjtUfxKgr1