### PR TITLE
docs: refresh top-level docs to match current 21-team platform

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,21 +4,45 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**Strands Agents** is a multi-agent orchestration platform that simulates autonomous software development teams and specialized business functions. It consists of 13+ agent "teams" (software engineering, blogging, market research, SOC2 compliance, etc.), each exposed as a FastAPI service, unified under a single Unified API with an Angular 19 frontend.
+**Strands Agents** is a multi-agent orchestration platform that simulates autonomous software development teams and specialized business functions. It currently mounts **21 enabled agent "teams"** (software engineering, blogging, personal assistant, market research, SOC2 compliance, social marketing, branding, agent provisioning, accessibility audit, AI systems, investment, nutrition & meal planning, planning v3, coding team, studio grid, sales, road trip planning, agentic team provisioning, startup advisor, user agent founder, deepthought) under a single Unified FastAPI app, with an Angular 19 frontend. The authoritative team list lives in `backend/unified_api/config.py` (`TEAM_CONFIGS`).
 
 ## Repository Structure
 
 ```
 backend/
   agents/                    # All agent team implementations
-    software_engineering_team/  # Primary team — full dev pipeline
+    software_engineering_team/  # Primary team — full dev pipeline; contains
+                                # backend_code_v2_team/, frontend_code_v2_team/,
+                                # devops_team/, planning_v2_team/, planning_v2_adapter.py,
+                                # planning_v3_adapter.py, integration_team/, qa_agent/, etc.
+    planning_v3_team/        # Client-facing discovery/PRD team (mounted at /api/planning-v3)
+    coding_team/             # SE sub-team: tech lead + stack specialists (logical sub-team)
     blogging/                # Blog content pipeline
+    personal_assistant_team/
+    market_research_team/
+    soc2_compliance_team/
+    social_media_marketing_team/
+    branding_team/
+    agent_provisioning_team/
+    accessibility_audit_team/
+    ai_systems_team/
+    investment_team/         # Advisor/IPS + Strategy Lab (one /api/investment prefix)
+    nutrition_meal_planning_team/
+    sales_team/
+    road_trip_planning_team/
+    agentic_team_provisioning/
+    startup_advisor/
+    user_agent_founder/
+    deepthought/
     llm_service/             # Centralized LLM client (Ollama, Claude)
-    integrations/            # Shared integration contracts
+    integrations/            # Shared integration contracts (Google login, Medium, etc.)
+    artifact_registry/       # Shared artifact persistence
+    event_bus/               # Cross-team event publishing
+    shared_temporal/         # Temporal worker/workflow plumbing
     api/                     # Legacy blog API surface (see blogging/ for current pipeline)
   unified_api/               # Single-entry-point FastAPI server (port 8080)
-    config.py                # Team routing + Temporal settings
-    main.py                  # App with team route mounting
+    config.py                # TEAM_CONFIGS, security gateway, Temporal settings
+    main.py                  # App with team route mounting + security gateway
   run_unified_api.py         # CLI launcher
   Makefile                   # Primary build/run targets
   requirements.txt           # Top-level Python deps
@@ -88,7 +112,7 @@ Each agent team has a **team-lead orchestrator** that coordinates role-separated
 
 ### Software Engineering Team Pipeline (4 phases)
 
-1. **Discovery**: Spec → LLM parsing → Planning-v2 (6-phase workflow) → planning_v2_adapter
+1. **Discovery**: Spec → LLM parsing → Planning (Planning-v2 6-phase workflow via `planning_v2_adapter.py`, or the newer `planning_v3_adapter.py` which delegates to the standalone `planning_v3_team`)
 2. **Design**: Tech Lead generates task assignments; Architecture Expert produces architecture docs
 3. **Execution** (parallel queues):
    - Prefix queue: git/DevOps setup (sequential)
@@ -102,9 +126,14 @@ Each agent team has a **team-lead orchestrator** that coordinates role-separated
 
 ### Sub-Team Variants
 
-- **Backend-Code-V2** (`backend_code_v2_team/`): 3-layer (Backend Tech Lead → Backend Dev Agent + 7 tool agents)
-- **Frontend-Code-V2** (`frontend_code_v2_team/`): 3-layer (Frontend Tech Lead → Frontend Dev Agent + 12 tool agents)
-- **DevOps Team**: 5-phase (Intake → Change Design → Write Artifacts → Validation → Completion)
+All three live **inside** `backend/agents/software_engineering_team/`:
+
+- **Backend-Code-V2** (`software_engineering_team/backend_code_v2_team/`): 3-layer (Backend Tech Lead → Backend Dev Agent + tool agents for linting, build, code review, security, QA, DbC, git ops)
+- **Frontend-Code-V2** (`software_engineering_team/frontend_code_v2_team/`): 3-layer (Frontend Tech Lead → Frontend Dev Agent + tool agents)
+- **DevOps Team** (`software_engineering_team/devops_team/`): 5-phase (Intake → Change Design → Write Artifacts → Validation → Completion)
+- **Planning V2** (`software_engineering_team/planning_v2_team/`): legacy 6-phase planning, still supported via `planning_v2_adapter.py`
+- **Coding Team** (`backend/agents/coding_team/`): standalone module mounted at `/api/coding-team` and used by SE as a logical sub-team (`parent_team_key="software_engineering"`)
+- **Planning V3** (`backend/agents/planning_v3_team/`): standalone client-facing discovery/PRD team mounted at `/api/planning-v3`; SE invokes it through `planning_v3_adapter.py`
 
 ### Unified API Routing
 
@@ -145,6 +174,15 @@ Environment variables for LLM: `LLM_PROVIDER`, `LLM_BASE_URL`, `LLM_MODEL`
 | `BLOG_PLANNING_MAX_ITERATIONS` | Blog planning refine loop cap (default 5) |
 | `BLOG_PLANNING_MAX_PARSE_RETRIES` | JSON parse/repair attempts per planning LLM call (default 3) |
 | `BLOG_PLANNING_MODEL` | Optional Ollama model name for **planning only** (same base URL as `LLM_*`) |
+| `INTEGRATIONS_BROWSER_SESSION_ROOT` | Root for Playwright `storage_state` files used by browser-based integrations (Medium, etc.); Docker maps to the shared `agents_data` volume |
+| `SE_WORKSPACE_DIR` | Root for software-engineering team per-job workspaces |
+| `AGENT_CACHE` | Shared cache root for all teams (Docker: `/data/agents`); each team namespaces under `{team_name}/` |
+| `UNIFIED_API_PORT` / `UNIFIED_API_HOST` | Bind address/port for the Unified API (default `0.0.0.0:8080`) |
+| `POSTGRES_HOST` (and `POSTGRES_PORT`/`USER`/`PASSWORD`/`DB`) | When set, enables Postgres-backed stores (job state, encrypted integration credentials, etc.); without it the platform falls back to local SQLite where supported |
+| `ARCHITECT_MODEL_SPECIALIST` / `ARCHITECT_MODEL_ORCHESTRATOR` | Per-role model overrides for the AI Systems team |
+| `ALPHA_VANTAGE_API_KEY` / `FRED_API_KEY` | Market data providers used by the Investment Strategy Lab |
+| `STRATEGY_LAB_MARKET_DATA_*` | Strategy Lab market-data cache/timeout/provider tuning |
+| `BRANDING_DB_PATH` / `STARTUP_ADVISOR_DB_PATH` / `USER_AGENT_FOUNDER_DB_PATH` | Local SQLite paths for those teams when Postgres is not configured |
 
 **Blogging pipeline:** `research → planning (ContentPlan) → writer → gates`; `POST /research-and-review` runs research + the same planning step. See `backend/agents/blogging/README.md` and repo `CHANGELOG.md`.
 
@@ -154,7 +192,7 @@ Environment variables for LLM: `LLM_PROVIDER`, `LLM_BASE_URL`, `LLM_MODEL`
 
 ## Testing
 
-- **Backend**: `pytest` — CI runs per-team test suites (SE, blogging, market research, SOC2, social marketing)
+- **Backend**: `pytest` — CI runs per-team test suites (SE, blogging, market research, SOC2, social marketing, investment, planning v3, sales, deepthought, etc.)
 - **Frontend**: Vitest + Angular testing utilities; 80% line coverage target for `src/app`
 - **CI**: GitHub Actions — ruff lint must pass first, then parallel test jobs, then docker smoke test
 

--- a/README.md
+++ b/README.md
@@ -7,15 +7,9 @@ Strands Agents is a monorepo for multi-agent "team" systems. Each team exposes a
 ```text
 strands-agents/
 ├── backend/
-│   ├── agents/                 # Team implementations + team-specific APIs (~19 mounted teams)
+│   ├── agents/                 # Team implementations + team-specific APIs (21 mounted teams)
 │   ├── unified_api/            # Unified FastAPI app mounting all teams
 │   ├── run_unified_api.py      # Unified API launcher
-│   ├── studiogrid/             # StudioGrid design-system workflow
-│   ├── blogging_service/       # Isolated blogging microservice container
-│   ├── job_service/            # Centralized job state tracking service (Postgres)
-│   ├── team_service/           # Generic team microservice container
-│   ├── studiogrid_service/     # StudioGrid microservice container
-│   ├── post_mortems/           # Agent failure audit log
 │   ├── Makefile                # Build, lint, test, run targets
 │   └── pyproject.toml          # Ruff + pytest config
 ├── user-interface/             # Angular 19 frontend
@@ -54,7 +48,7 @@ UI: <http://localhost:4200>
 
 ## Unified API team routes
 
-The Unified API mounts teams under `/api/*` prefixes. Current configured routes (19 teams):
+The Unified API mounts teams under `/api/*` prefixes. Current configured routes (21 enabled teams):
 
 - `/api/blogging`
 - `/api/software-engineering`
@@ -66,15 +60,17 @@ The Unified API mounts teams under `/api/*` prefixes. Current configured routes 
 - `/api/agent-provisioning`
 - `/api/accessibility-audit`
 - `/api/ai-systems`
-- `/api/investment`
+- `/api/investment` (also serves the Investment Strategy Lab sub-team — disabled as a separate mount)
 - `/api/nutrition-meal-planning`
 - `/api/planning-v3`
-- `/api/coding-team`
+- `/api/coding-team` (logical sub-team of software engineering)
 - `/api/studio-grid`
 - `/api/sales`
 - `/api/road-trip-planning`
 - `/api/agentic-team-provisioning`
 - `/api/startup-advisor`
+- `/api/user-agent-founder`
+- `/api/deepthought`
 
 ## Platform notes (cross-cutting)
 
@@ -104,6 +100,8 @@ The Unified API mounts teams under `/api/*` prefixes. Current configured routes 
 - `backend/agents/road_trip_planning_team/README.md` (Road Trip Planning)
 - `backend/agents/agentic_team_provisioning/` (Agentic Team Provisioning)
 - `backend/agents/startup_advisor/README.md` (Startup Advisor)
+- `backend/agents/user_agent_founder/README.md` (User Agent Founder)
+- `backend/agents/deepthought/README.md` (Deepthought recursive agent)
 
 ## Docker
 
@@ -118,8 +116,6 @@ See `docker/README.md` for env vars, ports, and deployment notes.
 ## Additional docs
 
 - `backend/unified_api/README.md` (mounts, `TeamConfig`, optional `parent_team_key`, logical disabled teams)
-- `backend/studiogrid/README.md`
-- `backend/post_mortems/POST_MORTEMS.md`
 - `ARCHITECTURE.md`
 - `CONTRIBUTORS.md`
 - `CLAUDE.md` (Cursor / Claude Code guidance for this repo)

--- a/user-interface/README.md
+++ b/user-interface/README.md
@@ -1,6 +1,6 @@
 # Strands Agents User Interface
 
-Angular application providing an interactive UI for all Strands agent APIs: Blogging, Software Engineering Team, Personal Assistant, Market Research, SOC2 Compliance, Social Media Marketing, Branding, Agent Provisioning, Accessibility Audit, AI Systems, Investment, Nutrition & Meal Planning, Planning V3, Coding Team, StudioGrid, AI Sales Team, Road Trip Planning, Agentic Team Provisioning, and Startup Advisor.
+Angular application providing an interactive UI for all Strands agent APIs: Blogging, Software Engineering Team, Personal Assistant, Market Research, SOC2 Compliance, Social Media Marketing, Branding, Agent Provisioning, Accessibility Audit, AI Systems, Investment (Advisor + Strategy Lab), Nutrition & Meal Planning, Planning V3, Coding Team, StudioGrid, AI Sales Team, Road Trip Planning, Agentic Team Provisioning, Startup Advisor, User Agent Founder, and Deepthought.
 
 ## Prerequisites
 
@@ -23,20 +23,14 @@ npm ci
 
 ## Configuration
 
-API base URLs are configured in `src/environments/environment.ts` (development) and `src/environments/environment.prod.ts` (production). Default ports:
+API base URLs are configured in `src/environments/environment.ts` (development) and `src/environments/environment.prod.ts` (production). All teams are served by the **Unified API**:
 
 | API | Default URL | Port |
 |-----|-------------|------|
-| Blogging | `http://localhost:8001` | 8001 |
-| Software Engineering Team | `http://localhost:8000` | 8000 |
-| Personal Assistant | `http://localhost:8015` | 8015 |
-| Market Research | `http://localhost:8011` | 8011 |
-| SOC2 Compliance | `http://localhost:8020` | 8020 |
-| Social Media Marketing | `http://localhost:8010` | 8010 |
-| Branding | `http://localhost:8012` | 8012 |
-| **Unified API** | `http://localhost:8080` | 8080 |
+| **Unified API (local)** | `http://localhost:8080` | 8080 |
+| **Unified API (Docker)** | `http://localhost:8888` | 8888 (host) → 8080 (container) |
 
-**Note:** The Unified API provides all 19 team APIs under a single endpoint with namespaced prefixes (e.g., `/api/blogging`, `/api/personal-assistant`, `/api/planning-v3`, `/api/coding-team`, `/api/sales`, `/api/road-trip-planning`, `/api/agentic-team-provisioning`, `/api/startup-advisor`). When running via Docker Compose the UI at port 4201 proxies all `/api/*` requests to the agents container at port 8888.
+**Note:** The Unified API provides all 21 team APIs under a single endpoint with namespaced prefixes — `/api/blogging`, `/api/software-engineering`, `/api/personal-assistant`, `/api/market-research`, `/api/soc2-compliance`, `/api/social-marketing`, `/api/branding`, `/api/agent-provisioning`, `/api/accessibility-audit`, `/api/ai-systems`, `/api/investment`, `/api/nutrition-meal-planning`, `/api/planning-v3`, `/api/coding-team`, `/api/studio-grid`, `/api/sales`, `/api/road-trip-planning`, `/api/agentic-team-provisioning`, `/api/startup-advisor`, `/api/user-agent-founder`, `/api/deepthought`. When running via Docker Compose the UI at port 4201 proxies all `/api/*` requests to the agents container exposed on host port 8888.
 
 To override, edit `src/environments/environment.ts` before building.
 


### PR DESCRIPTION
- CLAUDE.md: update team count (13+ -> 21), expand repo structure with
  current per-team directories, correct sub-team paths (backend_code_v2,
  frontend_code_v2, devops live inside software_engineering_team), note
  planning_v3_adapter alongside planning_v2_adapter, and document
  previously-missing env vars (INTEGRATIONS_BROWSER_SESSION_ROOT,
  SE_WORKSPACE_DIR, AGENT_CACHE, UNIFIED_API_PORT, POSTGRES_*, AI Systems
  architect model overrides, Strategy Lab market data keys, per-team DB paths).
- README.md: drop non-existent backend subdirs (blogging_service, job_service,
  team_service, studiogrid_service, studiogrid, post_mortems), bump team
  count to 21, list all enabled routes including user-agent-founder and
  deepthought, add their team READMEs.
- user-interface/README.md: replace stale per-team port table with the
  Unified API entry (local 8080 / Docker 8888), list all 21 mounted
  prefixes, mention User Agent Founder and Deepthought.