### PR TITLE
Upgrade PostgreSQL from version 16 to 17

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -2,7 +2,7 @@
 
 This directory defines a **Docker Compose stack** that runs:
 
-- **PostgreSQL 16** – shared database with `temporal` and `strands` databases (created at first run)
+- **PostgreSQL 17** – shared database with `temporal` and `strands` databases (created at first run)
 - **Temporal** – workflow engine (Postgres-backed, no Elasticsearch)
 - **Temporal UI** – Web UI for workflows
 - **Ollama** (optional) – local Ollama server if you override LLM to use it

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@
 
 services:
   postgres:
-    image: postgres:16
+    image: postgres:17
     container_name: strands-stack-postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}


### PR DESCRIPTION
## Summary
This PR upgrades the PostgreSQL database image used in the Docker Compose stack from version 16 to version 17.

## Changes
- Updated PostgreSQL image from `postgres:16` to `postgres:17` in docker-compose.yml
- Updated documentation in README.md to reflect the new PostgreSQL 17 version

## Details
The upgrade affects the shared database service that supports both the `temporal` and `strands` databases. PostgreSQL 17 includes performance improvements and new features while maintaining compatibility with existing database schemas and applications in the stack.

https://claude.ai/code/session_01U6VtNAGoJJcUqXVWWGW357