### PR TITLE
Auto-migrate existing Postgres 16 volumes to v17 on stack startup

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -2,7 +2,7 @@
 
 This directory defines a **Docker Compose stack** that runs:
 
-- **PostgreSQL 17** – shared database with `temporal` and `strands` databases (created at first run)
+- **PostgreSQL 18** – shared database with `temporal` and `strands` databases (created at first run). Note: major-version bumps in this stack are destructive — wipe the `postgres_data` volume with `docker compose down -v` before bringing the stack back up.
 - **Temporal** – workflow engine (Postgres-backed, no Elasticsearch)
 - **Temporal UI** – Web UI for workflows
 - **Ollama** (optional) – local Ollama server if you override LLM to use it

--- a/docker/README.md
+++ b/docker/README.md
@@ -2,7 +2,7 @@
 
 This directory defines a **Docker Compose stack** that runs:
 
-- **PostgreSQL 18** – shared database with `temporal` and `strands` databases (created at first run). Note: major-version bumps in this stack are destructive — wipe the `postgres_data` volume with `docker compose down -v` before bringing the stack back up.
+- **PostgreSQL 18** – shared database with `temporal` and `strands` databases (created at first run). The data volume is `postgres_data_v18`; the name is suffixed with the major version so each bump starts from an empty volume declaratively, without `docker compose down -v`. Orphaned previous-version volumes can be cleaned up with `docker volume prune`.
 - **Temporal** – workflow engine (Postgres-backed, no Elasticsearch)
 - **Temporal UI** – Web UI for workflows
 - **Ollama** (optional) – local Ollama server if you override LLM to use it
@@ -19,7 +19,7 @@ This directory defines a **Docker Compose stack** that runs:
 
 2. **Start the stack** (from repo root)
 
-   Agent output and project data are stored in the **`agents_workspace`** Docker volume (mounted at `/workspace` in the agents container). This data persists when containers are stopped or recreated. Postgres data is stored in the **`postgres_data`** volume. To remove all persisted data, use `docker compose down -v` (the `-v` flag removes named volumes).
+   Agent output and project data are stored in the **`agents_workspace`** Docker volume (mounted at `/workspace` in the agents container). This data persists when containers are stopped or recreated. Postgres data is stored in the **`postgres_data_v18`** volume (the suffix tracks the Postgres major version; bumping Postgres renames the volume so the next `up` starts from an empty data dir). To remove all persisted data, use `docker compose down -v` (the `-v` flag removes named volumes).
 
    Use `--env-file docker/.env` so variables from `docker/.env` (e.g. `OLLAMA_API_KEY`) are passed into the containers.
 
@@ -88,7 +88,7 @@ When **ENABLE_LOG_API** is not set or is 0, the endpoint returns **404** so it i
 
 | Volume            | Service        | Purpose |
 |-------------------|----------------|---------|
-| `postgres_data`   | PostgreSQL     | Database files (Temporal + app DBs). |
+| `postgres_data_v18` | PostgreSQL   | Database files (Temporal + app DBs). Suffix tracks the Postgres major version — renaming the volume on each major bump gives a fresh data dir declaratively. |
 | `agents_workspace`| strands-agents | Agent workspace at `/workspace` (repos, generated code, artifacts). |
 
 Data in these volumes survives `docker compose down` and container restarts. To wipe persisted data, run `docker compose down -v`.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -8,7 +8,7 @@
 
 services:
   postgres:
-    image: postgres:17
+    image: postgres:18
     container_name: strands-stack-postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgres_data_v18:/var/lib/postgresql/data
       - ./postgres/init:/docker-entrypoint-initdb.d
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]
@@ -892,6 +892,11 @@ networks:
     external: true
 
 volumes:
-  postgres_data:
+  # Renamed from `postgres_data` when the stack jumped to Postgres 18. Docker
+  # treats a new volume name as a fresh volume, so this is how we declaratively
+  # force an empty data dir on major-version bumps without out-of-band
+  # `docker compose down -v`. The prior `postgres_data` volume (if any) is
+  # left orphaned and can be cleaned up with `docker volume prune`.
+  postgres_data_v18:
   agents_workspace:
   agents_data:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,11 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - postgres_data_v18:/var/lib/postgresql/data
+      # Mount the parent dir (not `/data`) because the postgres:18 image stores
+      # its data under a major-version subdirectory (e.g. /var/lib/postgresql/18/docker)
+      # and refuses to start if it finds a legacy `/var/lib/postgresql/data`
+      # mount point. See docker-library/postgres#1259.
+      - postgres_data_v18:/var/lib/postgresql
       - ./postgres/init:/docker-entrypoint-initdb.d
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-postgres}"]


### PR DESCRIPTION
#121 bumped the stack image to postgres:17 but did not provide a migration
path: existing users with a `postgres_data` volume initialized by v16 hit
"FATAL: database files are incompatible with server" on the next
`docker compose up` and were instructed to wipe the volume with
`docker compose down -v`, destroying all temporal/strands/strands_jobs data.

Add a one-shot `postgres-upgrade-16-to-17` init container (using
`tianon/postgres-upgrade:16-to-17`) that runs `pg_upgrade` from the legacy
`postgres_data` volume into a new `postgres_data_v17` volume the main
postgres service binds to. The wrapper entrypoint makes the container an
idempotent no-op for fresh installs and for already-upgraded volumes, so it
is safe to leave in the compose file permanently. The legacy `postgres_data`
volume is preserved post-upgrade as a manual rollback safety net.