### PR TITLE
Add shared_postgres schema registry mirroring shared_temporal

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,6 +86,11 @@ Each agent team has a **team-lead orchestrator** that coordinates role-separated
 - **Thread mode** (default, local dev): agents run as Python threads
 - **Temporal mode** (when `TEMPORAL_ADDRESS` is set): durable workflow execution using Temporal 1.24.2 — state survives server restarts
 
+### Shared infrastructure modules
+
+- **`backend/agents/shared_temporal/`** — Temporal client + per-team worker registry. Teams export `WORKFLOWS`/`ACTIVITIES` from `<team>/temporal/__init__.py`; workers start on import (Pattern A).
+- **`backend/agents/shared_postgres/`** — Postgres schema registry. Each team exports a `SCHEMA: TeamSchema` constant from `<team>/postgres/__init__.py` (pure data, no side effects), and the team's FastAPI lifespan calls `register_team_schemas(SCHEMA)` at startup (Pattern B). No-op when `POSTGRES_HOST` is unset. See `backend/agents/shared_postgres/README.md`.
+
 ### Software Engineering Team Pipeline (4 phases)
 
 1. **Discovery**: Spec → LLM parsing → Planning-v2 (6-phase workflow) → planning_v2_adapter

--- a/backend/agents/agentic_team_provisioning/api/main.py
+++ b/backend/agents/agentic_team_provisioning/api/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 import uuid
+from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import List, Optional
@@ -42,12 +43,32 @@ from agentic_team_provisioning.models import (
     TeamSummary,
     UpdateFormRecordRequest,
 )
+from agentic_team_provisioning.postgres import SCHEMA as AGENTIC_POSTGRES_SCHEMA
 
 logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def _lifespan(application: FastAPI):
+    try:
+        from shared_postgres import register_team_schemas
+
+        register_team_schemas(AGENTIC_POSTGRES_SCHEMA)
+    except Exception:
+        logger.exception("agentic_team_provisioning postgres schema registration failed")
+    yield
+    try:
+        from shared_postgres import close_pool
+
+        close_pool()
+    except Exception:
+        logger.warning("agentic_team_provisioning shared_postgres close_pool failed", exc_info=True)
+
 
 app = FastAPI(
     title="Agentic Team Provisioning API",
     description="Create agentic teams and define their processes through conversation",
+    lifespan=_lifespan,
 )
 
 _store = AgenticTeamStore()
@@ -244,9 +265,13 @@ def recommend_agents_for_step(process_id: str, step_id: str):
     try:
         from studiogrid.runtime.registry_loader import RegistryLoader
 
-        loader = RegistryLoader(Path(__file__).resolve().parents[4] / "studiogrid" / "src" / "studiogrid")
+        loader = RegistryLoader(
+            Path(__file__).resolve().parents[4] / "studiogrid" / "src" / "studiogrid"
+        )
         search_text = f"{step.name} {step.description}"
-        found = loader.find_assisting_agents(problem_description=search_text, required_skills=[], limit=5)
+        found = loader.find_assisting_agents(
+            problem_description=search_text, required_skills=[], limit=5
+        )
         for agent in found:
             recommendations.append(
                 RecommendedAgent(
@@ -270,9 +295,7 @@ def recommend_agents_for_step(process_id: str, step_id: str):
         team = _store.get_team(team_id)
         if team:
             search_tokens = {
-                t.lower()
-                for t in f"{step.name} {step.description}".split()
-                if len(t) > 2
+                t.lower() for t in f"{step.name} {step.description}".split() if len(t) > 2
             }
             for agent in team.agents:
                 agent_tokens = {

--- a/backend/agents/agentic_team_provisioning/postgres/__init__.py
+++ b/backend/agents/agentic_team_provisioning/postgres/__init__.py
@@ -1,0 +1,85 @@
+"""Postgres schema for the agentic team provisioning team.
+
+Ports ``backend/agents/agentic_team_provisioning/assistant/store.py`` and
+``backend/agents/agentic_team_provisioning/infrastructure.py`` (currently
+SQLite) to Postgres. Registered from the team's FastAPI lifespan.
+"""
+
+from __future__ import annotations
+
+from shared_postgres import TeamSchema
+
+SCHEMA = TeamSchema(
+    team="agentic_team_provisioning",
+    database=None,
+    statements=[
+        # assistant/store.py
+        """CREATE TABLE IF NOT EXISTS agentic_teams (
+            team_id     TEXT PRIMARY KEY,
+            name        TEXT NOT NULL,
+            description TEXT NOT NULL DEFAULT '',
+            created_at  TIMESTAMPTZ NOT NULL,
+            updated_at  TIMESTAMPTZ NOT NULL
+        )""",
+        """CREATE TABLE IF NOT EXISTS agentic_processes (
+            process_id TEXT PRIMARY KEY,
+            team_id    TEXT NOT NULL REFERENCES agentic_teams(team_id),
+            data_json  JSONB NOT NULL DEFAULT '{}'::jsonb,
+            created_at TIMESTAMPTZ NOT NULL,
+            updated_at TIMESTAMPTZ NOT NULL
+        )""",
+        "CREATE INDEX IF NOT EXISTS idx_agentic_processes_team ON agentic_processes(team_id)",
+        """CREATE TABLE IF NOT EXISTS agentic_conversations (
+            conversation_id TEXT PRIMARY KEY,
+            team_id         TEXT NOT NULL REFERENCES agentic_teams(team_id),
+            process_id      TEXT,
+            created_at      TIMESTAMPTZ NOT NULL,
+            updated_at      TIMESTAMPTZ NOT NULL
+        )""",
+        "CREATE INDEX IF NOT EXISTS idx_agentic_conversations_team ON agentic_conversations(team_id)",
+        """CREATE TABLE IF NOT EXISTS agentic_conv_messages (
+            id              BIGSERIAL PRIMARY KEY,
+            conversation_id TEXT NOT NULL REFERENCES agentic_conversations(conversation_id),
+            role            TEXT NOT NULL,
+            content         TEXT NOT NULL,
+            timestamp       TIMESTAMPTZ NOT NULL
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_agentic_conv_messages_conv
+            ON agentic_conv_messages(conversation_id)""",
+        """CREATE TABLE IF NOT EXISTS agentic_team_agents (
+            team_id    TEXT NOT NULL REFERENCES agentic_teams(team_id),
+            agent_name TEXT NOT NULL,
+            data_json  JSONB NOT NULL DEFAULT '{}'::jsonb,
+            created_at TIMESTAMPTZ NOT NULL,
+            updated_at TIMESTAMPTZ NOT NULL,
+            PRIMARY KEY (team_id, agent_name)
+        )""",
+        "CREATE INDEX IF NOT EXISTS idx_agentic_team_agents_team ON agentic_team_agents(team_id)",
+        """CREATE TABLE IF NOT EXISTS agentic_env_provisions (
+            team_id               TEXT NOT NULL,
+            stable_key            TEXT NOT NULL,
+            process_id            TEXT NOT NULL,
+            step_id               TEXT NOT NULL,
+            agent_name            TEXT NOT NULL,
+            provisioning_agent_id TEXT NOT NULL,
+            status                TEXT NOT NULL DEFAULT 'running',
+            error_message         TEXT,
+            created_at            TIMESTAMPTZ NOT NULL,
+            updated_at            TIMESTAMPTZ NOT NULL,
+            PRIMARY KEY (team_id, stable_key)
+        )""",
+        "CREATE INDEX IF NOT EXISTS idx_agentic_env_provisions_team ON agentic_env_provisions(team_id)",
+        # infrastructure.py — form_data (namespaced so a future migration
+        # can move per-team SQLite form stores into the shared DB).
+        """CREATE TABLE IF NOT EXISTS agentic_form_data (
+            record_id  TEXT PRIMARY KEY,
+            team_id    TEXT NOT NULL,
+            form_key   TEXT NOT NULL,
+            data_json  JSONB NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL,
+            updated_at TIMESTAMPTZ NOT NULL
+        )""",
+        "CREATE INDEX IF NOT EXISTS idx_agentic_form_data_team ON agentic_form_data(team_id)",
+        "CREATE INDEX IF NOT EXISTS idx_agentic_form_data_key ON agentic_form_data(form_key)",
+    ],
+)

--- a/backend/agents/blogging/api/main.py
+++ b/backend/agents/blogging/api/main.py
@@ -173,7 +173,21 @@ def _run_blogging_service_shutdown() -> None:
 
 @asynccontextmanager
 async def _blogging_lifespan(app: FastAPI):
+    # Register Postgres schema (no-op when POSTGRES_HOST is unset).
+    try:
+        from blogging.postgres import SCHEMA as BLOGGING_POSTGRES_SCHEMA
+        from shared_postgres import register_team_schemas
+
+        register_team_schemas(BLOGGING_POSTGRES_SCHEMA)
+    except Exception:
+        logger.exception("blogging postgres schema registration failed")
     yield
+    try:
+        from shared_postgres import close_pool
+
+        close_pool()
+    except Exception:
+        logger.warning("blogging shared_postgres close_pool failed", exc_info=True)
     _run_blogging_service_shutdown()
 
 
@@ -665,6 +679,7 @@ def _publish_terminal_event(job_id: str, event_type: str, **kwargs: Any) -> None
     """Publish a terminal SSE event and clean up subscribers."""
     try:
         from shared.job_event_bus import cleanup_job, publish
+
         publish(job_id, kwargs, event_type=event_type)
         cleanup_job(job_id)
     except Exception:
@@ -706,6 +721,7 @@ def _run_pipeline_with_tracking(job_id: str, request: FullPipelineRequest) -> No
                     logger.warning("Failed to update job %s: %s", job_id, e)
             try:
                 from shared.job_event_bus import publish
+
                 publish(job_id, kwargs, event_type="update")
             except Exception:
                 pass
@@ -955,9 +971,11 @@ def stream_job_status(job_id: str) -> StreamingResponse:
 
     # If the job is already terminal, send a snapshot + done and close immediately.
     if job.get("status") in _TERMINAL_STATUSES:
+
         def _terminal_gen():
             yield _sse_line(_snapshot_event())
             yield _sse_line({"type": "done"})
+
         return StreamingResponse(_terminal_gen(), media_type="text/event-stream")
 
     def event_generator():
@@ -1074,9 +1092,13 @@ def resume_blog_job(job_id: str) -> StartPipelineResponse:
 
     payload = job.get("request_payload")
     if not isinstance(payload, dict):
-        raise HTTPException(status_code=400, detail="Original request payload not available for resume.")
+        raise HTTPException(
+            status_code=400, detail="Original request payload not available for resume."
+        )
 
-    update_blog_job(job_id, status="running", error=None, failed_phase=None, status_text="Resuming...")
+    update_blog_job(
+        job_id, status="running", error=None, failed_phase=None, status_text="Resuming..."
+    )
 
     request = FullPipelineRequest(**payload)
 
@@ -1120,7 +1142,9 @@ def restart_blog_job(job_id: str) -> StartPipelineResponse:
 
     payload = job.get("request_payload")
     if not isinstance(payload, dict):
-        raise HTTPException(status_code=400, detail="Original request payload not available for restart.")
+        raise HTTPException(
+            status_code=400, detail="Original request payload not available for restart."
+        )
 
     from blogging.shared.blog_job_store import reset_blog_job
 

--- a/backend/agents/blogging/postgres/__init__.py
+++ b/backend/agents/blogging/postgres/__init__.py
@@ -1,0 +1,29 @@
+"""Postgres schema for the blogging team.
+
+Ports ``backend/agents/blogging/shared/story_bank.py`` (currently
+SQLite) to Postgres. Registered from the blogging service's FastAPI
+lifespan.
+"""
+
+from __future__ import annotations
+
+from shared_postgres import TeamSchema
+
+SCHEMA = TeamSchema(
+    team="blogging",
+    database=None,
+    statements=[
+        """CREATE TABLE IF NOT EXISTS blogging_stories (
+            id              TEXT PRIMARY KEY,
+            narrative       TEXT NOT NULL,
+            section_title   TEXT NOT NULL DEFAULT '',
+            section_context TEXT NOT NULL DEFAULT '',
+            keywords        JSONB NOT NULL DEFAULT '[]'::jsonb,
+            summary         TEXT NOT NULL DEFAULT '',
+            source_job_id   TEXT,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_blogging_stories_source_job
+            ON blogging_stories(source_job_id)""",
+    ],
+)

--- a/backend/agents/branding_team/api/main.py
+++ b/backend/agents/branding_team/api/main.py
@@ -7,6 +7,7 @@ import json
 import logging
 import sqlite3
 import threading
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Tuple
@@ -31,11 +32,31 @@ from branding_team.models import (
     TeamOutput,
 )
 from branding_team.orchestrator import BrandingTeamOrchestrator
+from branding_team.postgres import SCHEMA as BRANDING_POSTGRES_SCHEMA
 from branding_team.store import get_default_store
 
 logger = logging.getLogger(__name__)
 
-app = FastAPI(title="Branding Team API", version="2.0.0")
+
+@asynccontextmanager
+async def _lifespan(application: FastAPI):
+    # Register Postgres schema (no-op when POSTGRES_HOST is unset).
+    try:
+        from shared_postgres import register_team_schemas
+
+        register_team_schemas(BRANDING_POSTGRES_SCHEMA)
+    except Exception:
+        logger.exception("branding postgres schema registration failed")
+    yield
+    try:
+        from shared_postgres import close_pool
+
+        close_pool()
+    except Exception:
+        logger.warning("branding shared_postgres close_pool failed", exc_info=True)
+
+
+app = FastAPI(title="Branding Team API", version="2.0.0", lifespan=_lifespan)
 branding_store = get_default_store()
 orchestrator = BrandingTeamOrchestrator()
 conversation_store = get_conversation_store()
@@ -832,7 +853,11 @@ def create_branding_conversation(
                 if output:
                     branding_store.append_brand_version(client_id, brand.id, output)
                 brand_id = brand.id
-                logger.info("Auto-created brand %s from initial message in conversation %s", brand.id, conversation_id)
+                logger.info(
+                    "Auto-created brand %s from initial message in conversation %s",
+                    brand.id,
+                    conversation_id,
+                )
 
         messages, mission, latest_output = conversation_store.get(conversation_id) or (
             [],

--- a/backend/agents/branding_team/postgres/__init__.py
+++ b/backend/agents/branding_team/postgres/__init__.py
@@ -1,0 +1,59 @@
+"""Postgres schema for the branding team.
+
+Pure-data declaration — no side effects on import. The team's FastAPI
+lifespan calls ``register_team_schemas(SCHEMA)`` at startup. Tables are
+prefixed with ``branding_`` to avoid collisions in the shared
+``POSTGRES_DB``.
+
+Current persistence is SQLite (see ``branding_team/store.py`` and
+``branding_team/assistant/store.py``); these DDL statements are the
+Postgres port ready for a future data migration.
+"""
+
+from __future__ import annotations
+
+from shared_postgres import TeamSchema
+
+SCHEMA = TeamSchema(
+    team="branding",
+    database=None,  # default POSTGRES_DB
+    statements=[
+        # store.py — clients + brand versions
+        """CREATE TABLE IF NOT EXISTS branding_clients (
+            id         TEXT PRIMARY KEY,
+            data       JSONB NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )""",
+        """CREATE TABLE IF NOT EXISTS branding_brands (
+            id         TEXT PRIMARY KEY,
+            client_id  TEXT NOT NULL,
+            data       JSONB NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )""",
+        "CREATE INDEX IF NOT EXISTS idx_branding_brands_client ON branding_brands(client_id)",
+        # api/main.py — per-session store
+        """CREATE TABLE IF NOT EXISTS branding_sessions (
+            session_id   TEXT PRIMARY KEY,
+            session_json JSONB NOT NULL,
+            updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )""",
+        # assistant/store.py — conversation store
+        """CREATE TABLE IF NOT EXISTS branding_conversations (
+            conversation_id    TEXT PRIMARY KEY,
+            brand_id           TEXT,
+            mission_json       JSONB NOT NULL,
+            latest_output_json JSONB,
+            created_at         TIMESTAMPTZ NOT NULL,
+            updated_at         TIMESTAMPTZ NOT NULL
+        )""",
+        """CREATE TABLE IF NOT EXISTS branding_conv_messages (
+            id              BIGSERIAL PRIMARY KEY,
+            conversation_id TEXT NOT NULL,
+            role            TEXT NOT NULL,
+            content         TEXT NOT NULL,
+            timestamp       TIMESTAMPTZ NOT NULL
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_branding_conv_messages_conv
+            ON branding_conv_messages(conversation_id)""",
+    ],
+)

--- a/backend/agents/shared_postgres/README.md
+++ b/backend/agents/shared_postgres/README.md
@@ -1,0 +1,132 @@
+# shared_postgres
+
+Shared Postgres schema registration for Strands agent teams. Sibling to
+`shared_temporal/`: each team declares its tables once, and the team's
+FastAPI lifespan applies them at startup when `POSTGRES_HOST` is set.
+
+## Why
+
+Before this module, Postgres DDL lived in three places:
+
+1. `backend/job_service/db.py::ensure_schema()` — one hand-rolled call in a lifespan
+2. `backend/unified_api/postgres_encrypted_credentials.py` — `CREATE TABLE IF NOT EXISTS` run on **every** read/write
+3. `docker/postgres/init/*.sql` — fires **only** on first container init; silent after that
+
+SQLite-backed teams (branding, startup_advisor, user_agent_founder,
+team_assistant, agentic_team_provisioning, blogging) had no Postgres
+story at all. `shared_postgres` unifies all of this behind one pattern.
+
+## The pattern
+
+### 1. Each team exports a `TeamSchema` as pure data
+
+`backend/agents/<team>/postgres/__init__.py`:
+
+```python
+from shared_postgres import TeamSchema
+
+SCHEMA = TeamSchema(
+    team="branding",
+    database=None,  # None = default POSTGRES_DB
+    statements=[
+        """CREATE TABLE IF NOT EXISTS branding_clients (
+            id TEXT PRIMARY KEY,
+            data JSONB NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_branding_clients_created ON branding_clients(created_at)""",
+    ],
+)
+```
+
+The module must be a **pure declaration**. No `ensure_team_schema`
+call, no connection attempts, no top-level side effects.
+
+### 2. The team's lifespan calls `register_team_schemas`
+
+`backend/agents/<team>/api/main.py`:
+
+```python
+from contextlib import asynccontextmanager
+
+from shared_postgres import close_pool, register_team_schemas
+from branding_team.postgres import SCHEMA
+
+@asynccontextmanager
+async def _lifespan(app: FastAPI):
+    try:
+        register_team_schemas(SCHEMA)
+    except Exception:
+        logger.exception("branding postgres schema registration failed")
+    yield
+    try:
+        close_pool()
+    except Exception:
+        pass
+```
+
+`register_team_schemas` is a no-op when `POSTGRES_HOST` is unset, so
+local dev runs without Postgres keep working.
+
+## Pattern A vs Pattern B
+
+`shared_temporal` uses **Pattern A** — `temporal/__init__.py` calls
+`start_team_worker(...)` at module-import time, which launches a
+daemon thread. That works because:
+
+- Temporal workers run in a background thread, so import-time kicks
+  never block the main flow.
+- Worker startup failures are caught inside the thread.
+
+`shared_postgres` uses **Pattern B** — the team exports only data,
+and the lifespan calls `register_team_schemas` explicitly. This is
+required because:
+
+- DDL is synchronous blocking I/O. Importing `branding_team.postgres`
+  from a unit test, linter, or sibling tool would otherwise open a
+  pooled connection and run `CREATE TABLE`.
+- Lifespan ordering matters: logging and env vars must be initialized
+  before DDL runs, which only Pattern B guarantees.
+- Startup errors surface as lifespan log lines, not opaque
+  `ModuleNotFoundError` chains.
+
+## Environment
+
+| Var | Default | Purpose |
+|---|---|---|
+| `POSTGRES_HOST` | (unset) | Gates everything — no host means no registration. |
+| `POSTGRES_PORT` | `5432` | |
+| `POSTGRES_USER` | `postgres` | |
+| `POSTGRES_PASSWORD` | (empty) | |
+| `POSTGRES_DB` | `postgres` | Default database; overridden per-team via `TeamSchema.database`. |
+
+## API
+
+```python
+from shared_postgres import (
+    TeamSchema,              # dataclass — the data contract
+    is_postgres_enabled,     # bool gate
+    register_team_schemas,   # no-op when disabled; else runs DDL
+    ensure_team_schema,      # raises if disabled; forces DDL run
+    get_conn,                # context manager (database override)
+    close_pool,              # lifespan shutdown
+    register_all_team_schemas,  # CLI / test-harness helper
+    TEAM_POSTGRES_MODULES,   # registry dict
+)
+```
+
+## The registry
+
+`TEAM_POSTGRES_MODULES` in `registry.py` maps each team slug to its
+`<team>.postgres` dotted path. `register_all_team_schemas()` imports
+each module lazily and applies its `SCHEMA`. The unified API does
+**not** call this — each team container registers its own schema from
+its own lifespan. `register_all_team_schemas` exists for CLI
+migrations and test harnesses.
+
+## See also
+
+- `backend/agents/shared_temporal/README.md` — sibling module for
+  Temporal workflow registration.
+- `backend/job_service/db.py` — original `ensure_schema()` pattern this
+  module generalizes.

--- a/backend/agents/shared_postgres/__init__.py
+++ b/backend/agents/shared_postgres/__init__.py
@@ -1,0 +1,37 @@
+"""Shared Postgres schema registration for team microservices.
+
+Mirrors ``shared_temporal`` in structure but uses **Pattern B**
+(explicit lifespan call) rather than Pattern A (import side effect),
+because schema DDL is synchronous blocking I/O. See the README for
+details.
+
+Typical usage in a team's ``api/main.py`` lifespan::
+
+    from shared_postgres import close_pool, register_team_schemas
+    from my_team.postgres import SCHEMA
+
+    @asynccontextmanager
+    async def _lifespan(app: FastAPI):
+        try:
+            register_team_schemas(SCHEMA)
+        except Exception:
+            logger.exception("postgres schema registration failed")
+        yield
+        close_pool()
+"""
+
+from shared_postgres.client import close_pool, get_conn, is_postgres_enabled
+from shared_postgres.registry import TEAM_POSTGRES_MODULES, register_all_team_schemas
+from shared_postgres.runner import ensure_team_schema, register_team_schemas
+from shared_postgres.schema import TeamSchema
+
+__all__ = [
+    "TEAM_POSTGRES_MODULES",
+    "TeamSchema",
+    "close_pool",
+    "ensure_team_schema",
+    "get_conn",
+    "is_postgres_enabled",
+    "register_all_team_schemas",
+    "register_team_schemas",
+]

--- a/backend/agents/shared_postgres/client.py
+++ b/backend/agents/shared_postgres/client.py
@@ -1,0 +1,116 @@
+"""Shared Postgres client.
+
+Env-var helpers plus a thin wrapper around ``psycopg`` (v3) for opening
+short-lived connections. Used by ``ensure_team_schema`` at startup to
+run DDL; heavy CRUD paths (e.g. ``job_service/db.py``) keep their own
+pool because DDL doesn't need pooling and the agents image already
+pins ``psycopg[binary]``.
+
+Env vars (identical to ``job_service/db.py`` and
+``backend/unified_api/postgres_encrypted_credentials.py``):
+
+    POSTGRES_HOST, POSTGRES_PORT, POSTGRES_USER, POSTGRES_PASSWORD,
+    POSTGRES_DB
+
+``is_postgres_enabled()`` returns ``True`` only when ``POSTGRES_HOST`` is
+set.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from collections.abc import Generator
+from contextlib import contextmanager
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Track connections currently being used per database so ``close_pool``
+# can log anomalies; the module does not keep a real pool open.
+_active_conns_lock = threading.Lock()
+_active_conns: dict[str, int] = {}
+
+
+def is_postgres_enabled() -> bool:
+    """True when ``POSTGRES_HOST`` is set (e.g. in the Docker stack)."""
+    return bool(os.getenv("POSTGRES_HOST", "").strip())
+
+
+def _default_database() -> str:
+    return os.environ.get("POSTGRES_DB", "postgres")
+
+
+def _dsn(database: Optional[str] = None) -> str:
+    """Build a libpq DSN for ``database`` (defaults to ``POSTGRES_DB``)."""
+    host = os.environ.get("POSTGRES_HOST", "localhost")
+    port = os.environ.get("POSTGRES_PORT", "5432")
+    user = os.environ.get("POSTGRES_USER", "postgres")
+    password = os.environ.get("POSTGRES_PASSWORD", "")
+    dbname = database or _default_database()
+    return f"host={host} port={port} dbname={dbname} user={user} password={password}"
+
+
+def _connect(database: Optional[str] = None):
+    """Open a fresh ``psycopg`` connection.
+
+    Raises ``RuntimeError`` when Postgres is disabled or psycopg is not
+    installed, so callers fail loudly instead of silently skipping writes.
+    """
+    if not is_postgres_enabled():
+        raise RuntimeError("POSTGRES_HOST is not set; cannot open a Postgres connection.")
+    try:
+        import psycopg
+    except ImportError as e:
+        raise RuntimeError(
+            "psycopg is not installed; install psycopg[binary] to use shared_postgres."
+        ) from e
+    return psycopg.connect(_dsn(database))
+
+
+@contextmanager
+def get_conn(database: Optional[str] = None) -> Generator:
+    """Yield a fresh ``psycopg`` connection for ``database``.
+
+    Commits on clean exit, rolls back on exception, always closes the
+    connection. Suitable for startup DDL and infrequent operations; for
+    high-throughput CRUD, use a dedicated pool.
+    """
+    db = database or _default_database()
+    conn = _connect(database)
+    with _active_conns_lock:
+        _active_conns[db] = _active_conns.get(db, 0) + 1
+    try:
+        yield conn
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        try:
+            conn.close()
+        finally:
+            with _active_conns_lock:
+                _active_conns[db] = max(0, _active_conns.get(db, 0) - 1)
+
+
+def close_pool(database: Optional[str] = None) -> None:
+    """No-op for the per-call client; kept for lifespan API parity.
+
+    Connections opened by ``get_conn`` are closed automatically when
+    their context manager exits. This function exists so team lifespans
+    can mirror the ``shared_temporal``/FastAPI shape without special
+    casing. Logs a warning if any connections are still reported active.
+    """
+    with _active_conns_lock:
+        dbs = [database] if database is not None else list(_active_conns.keys())
+        for db in dbs:
+            leaked = _active_conns.get(db, 0)
+            if leaked > 0:
+                logger.warning(
+                    "shared_postgres close_pool: %d active connection(s) reported for database=%s",
+                    leaked,
+                    db,
+                )
+            _active_conns.pop(db, None)

--- a/backend/agents/shared_postgres/registry.py
+++ b/backend/agents/shared_postgres/registry.py
@@ -1,0 +1,69 @@
+"""Central registry of team Postgres schema modules.
+
+Analogue of ``shared_temporal/teams_registry.py``. Each entry maps a
+team slug to the dotted path of a module that exports ``SCHEMA:
+TeamSchema``. ``register_all_team_schemas`` imports each module lazily
+and applies its schema; it is not wired into the ``unified_api``
+lifespan (teams run in their own containers and register themselves),
+but is useful for CLI migrations, tests, and standalone harnesses.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from collections.abc import Iterable
+from typing import Optional
+
+from shared_postgres.runner import register_team_schemas
+from shared_postgres.schema import TeamSchema
+
+logger = logging.getLogger(__name__)
+
+# team_slug -> module dotted path exporting ``SCHEMA``
+TEAM_POSTGRES_MODULES: dict[str, str] = {
+    # unified_api owns the shared encrypted credentials table.
+    "unified_api": "unified_api.postgres",
+    # job_service owns the ``jobs`` table in the ``strands_jobs`` DB.
+    "job_service": "job_service.postgres",
+    # Teams with persistence being moved to Postgres.
+    "branding": "branding_team.postgres",
+    "startup_advisor": "startup_advisor.postgres",
+    "user_agent_founder": "user_agent_founder.postgres",
+    "team_assistant": "team_assistant.postgres",
+    "agentic_team_provisioning": "agentic_team_provisioning.postgres",
+    "blogging": "blogging.postgres",
+}
+
+
+def register_all_team_schemas(only: Optional[Iterable[str]] = None) -> dict[str, bool]:
+    """Import each registered team module and apply its schema.
+
+    Returns a ``{team: success}`` map. A team whose module fails to
+    import is logged and recorded as ``False`` so one bad team doesn't
+    block the rest. The ``only`` filter accepts an iterable of team
+    slugs to restrict the run.
+    """
+    results: dict[str, bool] = {}
+    teams: Iterable[tuple[str, str]] = TEAM_POSTGRES_MODULES.items()
+    if only is not None:
+        wanted = set(only)
+        teams = [(t, m) for t, m in teams if t in wanted]
+
+    for team, module_path in teams:
+        try:
+            mod = importlib.import_module(module_path)
+            schema = getattr(mod, "SCHEMA", None)
+            if not isinstance(schema, TeamSchema):
+                logger.warning(
+                    "Team %s module %s does not export a SCHEMA: TeamSchema; skipping",
+                    team,
+                    module_path,
+                )
+                results[team] = False
+                continue
+            results[team] = register_team_schemas(schema)
+        except Exception as e:
+            logger.exception("Failed to register postgres schema for %s: %s", team, e)
+            results[team] = False
+    return results

--- a/backend/agents/shared_postgres/runner.py
+++ b/backend/agents/shared_postgres/runner.py
@@ -1,0 +1,82 @@
+"""Schema application runner.
+
+``ensure_team_schema`` executes each DDL statement in its own
+transaction so a broken ``CREATE INDEX`` doesn't abort the ``CREATE
+TABLE`` that came before it. Per-statement errors are logged at
+``ERROR`` (not ``WARNING``) so CI surfaces them.
+
+``register_team_schemas`` is the no-op-safe wrapper teams call from
+their FastAPI lifespan: it returns immediately when ``POSTGRES_HOST`` is
+unset, so lifespans can unconditionally invoke it.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from shared_postgres.client import get_conn, is_postgres_enabled
+from shared_postgres.schema import TeamSchema
+
+logger = logging.getLogger(__name__)
+
+
+def ensure_team_schema(schema: TeamSchema) -> int:
+    """Apply every DDL statement in ``schema`` idempotently.
+
+    Returns the number of statements that applied cleanly. Raises
+    ``RuntimeError`` only when Postgres is disabled (to make misuse
+    obvious); individual DDL failures are logged and skipped.
+    """
+    if not is_postgres_enabled():
+        raise RuntimeError(
+            f"ensure_team_schema called for team={schema.team} but POSTGRES_HOST is not set."
+        )
+
+    applied = 0
+    failed: list[str] = []
+
+    for idx, statement in enumerate(schema.statements):
+        try:
+            with get_conn(schema.database) as conn, conn.cursor() as cur:
+                cur.execute(statement)
+            applied += 1
+        except Exception as e:
+            # Truncate the statement so log lines stay readable; keep
+            # enough to identify which DDL tripped.
+            preview = " ".join(statement.split())[:120]
+            logger.error(
+                "postgres schema DDL failed: team=%s database=%s stmt_index=%d preview=%r error=%s",
+                schema.team,
+                schema.database or "<default>",
+                idx,
+                preview,
+                e,
+            )
+            failed.append(preview)
+
+    logger.info(
+        "postgres schema ensured: team=%s database=%s applied=%d/%d failed=%d",
+        schema.team,
+        schema.database or "<default>",
+        applied,
+        len(schema.statements),
+        len(failed),
+    )
+    return applied
+
+
+def register_team_schemas(schema: TeamSchema) -> bool:
+    """FastAPI-lifespan-friendly wrapper around ``ensure_team_schema``.
+
+    Returns ``True`` when the schema was applied, ``False`` when
+    Postgres is disabled. Safe to call unconditionally from any team's
+    startup hook — teams that don't run in Docker stay a no-op.
+    """
+    if not is_postgres_enabled():
+        logger.info(
+            "postgres disabled; skipping schema registration for team=%s",
+            schema.team,
+        )
+        return False
+    ensure_team_schema(schema)
+    return True

--- a/backend/agents/shared_postgres/schema.py
+++ b/backend/agents/shared_postgres/schema.py
@@ -1,0 +1,40 @@
+"""TeamSchema dataclass — the data contract each team exports.
+
+Every team that owns Postgres tables creates a ``postgres/__init__.py``
+module that exports a single ``SCHEMA: TeamSchema`` constant. The module
+must be pure data: importing it should have **no side effects** (no
+connection attempts, no DDL execution). DDL runs only when a FastAPI
+lifespan explicitly calls ``register_team_schemas(SCHEMA)``.
+
+This is the main contrast with ``shared_temporal``'s Pattern A, which
+launches a daemon worker thread as an import side effect. Schema DDL is
+synchronous blocking I/O and must not fire from a unit test or linter
+import.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class TeamSchema:
+    """The Postgres schema owned by one team.
+
+    Attributes:
+        team: Team slug used in log lines and the registry. Lowercase,
+            underscore-separated, e.g. ``"branding"``, ``"job_service"``.
+        database: Optional Postgres database name. ``None`` means use the
+            default ``POSTGRES_DB`` env var. Legacy services like
+            ``job_service`` override this to ``"strands_jobs"``.
+        statements: List of DDL strings to execute idempotently at
+            startup. Each should be a ``CREATE TABLE IF NOT EXISTS`` /
+            ``CREATE INDEX IF NOT EXISTS`` / ``ALTER TABLE ...`` string.
+            Statements run in order, each in its own transaction, so a
+            failure in one doesn't abort the rest.
+    """
+
+    team: str
+    statements: list[str] = field(default_factory=list)
+    database: Optional[str] = None

--- a/backend/agents/shared_postgres/tests/conftest.py
+++ b/backend/agents/shared_postgres/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/backend/agents/shared_postgres/tests/test_shared_postgres.py
+++ b/backend/agents/shared_postgres/tests/test_shared_postgres.py
@@ -1,0 +1,392 @@
+"""Tests for shared_postgres — all mocked, no live Postgres required."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+
+from shared_postgres import (
+    TEAM_POSTGRES_MODULES,
+    TeamSchema,
+    close_pool,
+    ensure_team_schema,
+    is_postgres_enabled,
+    register_all_team_schemas,
+    register_team_schemas,
+)
+from shared_postgres import client as client_mod
+from shared_postgres import registry as registry_mod
+from shared_postgres import runner as runner_mod
+
+# ---------------------------------------------------------------------------
+# Env-var gating
+# ---------------------------------------------------------------------------
+
+
+def test_is_postgres_enabled_false_when_unset(monkeypatch):
+    monkeypatch.delenv("POSTGRES_HOST", raising=False)
+    assert is_postgres_enabled() is False
+
+
+def test_is_postgres_enabled_false_when_empty(monkeypatch):
+    monkeypatch.setenv("POSTGRES_HOST", "   ")
+    assert is_postgres_enabled() is False
+
+
+def test_is_postgres_enabled_true_when_set(monkeypatch):
+    monkeypatch.setenv("POSTGRES_HOST", "postgres")
+    assert is_postgres_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# TeamSchema dataclass
+# ---------------------------------------------------------------------------
+
+
+def test_team_schema_defaults():
+    schema = TeamSchema(team="foo")
+    assert schema.team == "foo"
+    assert schema.database is None
+    assert schema.statements == []
+
+
+def test_team_schema_frozen():
+    schema = TeamSchema(team="foo")
+    with pytest.raises(Exception):
+        schema.team = "bar"  # type: ignore[misc]
+
+
+def test_team_schema_database_override():
+    schema = TeamSchema(team="job_service", database="strands_jobs", statements=["SELECT 1"])
+    assert schema.database == "strands_jobs"
+    assert schema.statements == ["SELECT 1"]
+
+
+# ---------------------------------------------------------------------------
+# ensure_team_schema (mocked connection)
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _fake_conn_factory(executed: list[str], fail_on: set[int] | None = None):
+    """Yield a fake connection whose cursor.execute records statements."""
+    call_index = {"n": 0}
+    fail_on = fail_on or set()
+
+    cursor = MagicMock()
+
+    def _execute(sql: str) -> None:
+        idx = call_index["n"]
+        call_index["n"] += 1
+        if idx in fail_on:
+            raise RuntimeError(f"synthetic DDL failure at {idx}")
+        executed.append(sql)
+
+    cursor.execute.side_effect = _execute
+    cursor.__enter__ = lambda self: cursor
+    cursor.__exit__ = lambda self, *a: None
+
+    conn = MagicMock()
+    conn.cursor.return_value = cursor
+    yield conn
+
+
+def test_ensure_team_schema_runs_all_ddl(monkeypatch):
+    monkeypatch.setenv("POSTGRES_HOST", "postgres")
+
+    executed: list[str] = []
+
+    @contextmanager
+    def fake_get_conn(database=None):
+        with _fake_conn_factory(executed) as c:
+            yield c
+
+    monkeypatch.setattr(runner_mod, "get_conn", fake_get_conn)
+
+    schema = TeamSchema(
+        team="demo",
+        statements=[
+            "CREATE TABLE IF NOT EXISTS demo_a (id TEXT PRIMARY KEY)",
+            "CREATE TABLE IF NOT EXISTS demo_b (id TEXT PRIMARY KEY)",
+            "CREATE INDEX IF NOT EXISTS idx_demo_a_id ON demo_a(id)",
+        ],
+    )
+
+    applied = ensure_team_schema(schema)
+    assert applied == 3
+    assert len(executed) == 3
+    assert "demo_a" in executed[0]
+    assert "demo_b" in executed[1]
+    assert "idx_demo_a_id" in executed[2]
+
+
+def test_ensure_team_schema_continues_past_failure(monkeypatch, caplog):
+    monkeypatch.setenv("POSTGRES_HOST", "postgres")
+
+    state = {"call": 0}
+
+    @contextmanager
+    def fake_get_conn(database=None):
+        cursor = MagicMock()
+
+        def _execute(sql):
+            idx = state["call"]
+            state["call"] += 1
+            if idx == 1:  # fail on second statement
+                raise RuntimeError("boom")
+
+        cursor.execute.side_effect = _execute
+        cursor.__enter__ = lambda self: cursor
+        cursor.__exit__ = lambda self, *a: None
+        conn = MagicMock()
+        conn.cursor.return_value = cursor
+        yield conn
+
+    monkeypatch.setattr(runner_mod, "get_conn", fake_get_conn)
+
+    schema = TeamSchema(
+        team="demo",
+        statements=[
+            "CREATE TABLE IF NOT EXISTS demo_a (id TEXT)",
+            "CREATE TABLE IF NOT EXISTS demo_b (id TEXT)",
+            "CREATE TABLE IF NOT EXISTS demo_c (id TEXT)",
+        ],
+    )
+
+    with caplog.at_level("ERROR"):
+        applied = ensure_team_schema(schema)
+
+    assert applied == 2
+    assert any("stmt_index=1" in rec.message for rec in caplog.records)
+
+
+def test_ensure_team_schema_raises_when_disabled(monkeypatch):
+    monkeypatch.delenv("POSTGRES_HOST", raising=False)
+    schema = TeamSchema(team="demo", statements=["SELECT 1"])
+    with pytest.raises(RuntimeError, match="POSTGRES_HOST is not set"):
+        ensure_team_schema(schema)
+
+
+# ---------------------------------------------------------------------------
+# register_team_schemas (the no-op-safe wrapper)
+# ---------------------------------------------------------------------------
+
+
+def test_register_team_schemas_noop_when_disabled(monkeypatch, caplog):
+    monkeypatch.delenv("POSTGRES_HOST", raising=False)
+
+    schema = TeamSchema(team="demo", statements=["SELECT 1"])
+    with caplog.at_level("INFO"):
+        result = register_team_schemas(schema)
+
+    assert result is False
+    assert any("postgres disabled" in rec.message for rec in caplog.records)
+
+
+def test_register_team_schemas_runs_when_enabled(monkeypatch):
+    monkeypatch.setenv("POSTGRES_HOST", "postgres")
+    called = {"n": 0}
+
+    def fake_ensure(schema):
+        called["n"] += 1
+        return len(schema.statements)
+
+    monkeypatch.setattr(runner_mod, "ensure_team_schema", fake_ensure)
+    result = register_team_schemas(TeamSchema(team="demo", statements=["SELECT 1"]))
+    assert result is True
+    assert called["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# register_all_team_schemas (registry iteration)
+# ---------------------------------------------------------------------------
+
+
+def test_register_all_team_schemas_imports_and_calls(monkeypatch):
+    monkeypatch.setenv("POSTGRES_HOST", "postgres")
+
+    stub_schema = TeamSchema(team="stub_team", statements=["SELECT 1"])
+
+    class _StubModule:
+        SCHEMA = stub_schema
+
+    def fake_import_module(name):
+        if name == "fake.stub":
+            return _StubModule
+        raise ImportError(name)
+
+    monkeypatch.setattr(registry_mod, "TEAM_POSTGRES_MODULES", {"stub_team": "fake.stub"})
+    monkeypatch.setattr(registry_mod.importlib, "import_module", fake_import_module)
+
+    calls: list[TeamSchema] = []
+
+    def fake_register(schema):
+        calls.append(schema)
+        return True
+
+    monkeypatch.setattr(registry_mod, "register_team_schemas", fake_register)
+
+    results = register_all_team_schemas()
+    assert results == {"stub_team": True}
+    assert len(calls) == 1
+    assert calls[0] is stub_schema
+
+
+def test_register_all_team_schemas_only_filter(monkeypatch):
+    monkeypatch.setattr(
+        registry_mod,
+        "TEAM_POSTGRES_MODULES",
+        {"a": "fake.a", "b": "fake.b"},
+    )
+
+    def fake_import(name):
+        class M:
+            SCHEMA = TeamSchema(team=name.split(".")[-1], statements=[])
+
+        return M
+
+    monkeypatch.setattr(registry_mod.importlib, "import_module", fake_import)
+    monkeypatch.setattr(registry_mod, "register_team_schemas", lambda s: True)
+
+    results = register_all_team_schemas(only=["a"])
+    assert list(results.keys()) == ["a"]
+
+
+def test_register_all_team_schemas_skips_module_missing_schema(monkeypatch, caplog):
+    class _NoSchemaModule:
+        pass
+
+    monkeypatch.setattr(registry_mod, "TEAM_POSTGRES_MODULES", {"broken": "fake.broken"})
+    monkeypatch.setattr(registry_mod.importlib, "import_module", lambda name: _NoSchemaModule)
+
+    with caplog.at_level("WARNING"):
+        results = register_all_team_schemas()
+
+    assert results == {"broken": False}
+    assert any("does not export a SCHEMA" in rec.message for rec in caplog.records)
+
+
+def test_register_all_team_schemas_import_failure_is_isolated(monkeypatch, caplog):
+    def _boom(_name):
+        raise ImportError("synthetic")
+
+    monkeypatch.setattr(
+        registry_mod,
+        "TEAM_POSTGRES_MODULES",
+        {"broken": "fake.broken", "ok": "fake.ok"},
+    )
+    call_log: list[str] = []
+
+    def fake_import(name):
+        call_log.append(name)
+        if name == "fake.broken":
+            raise ImportError("synthetic")
+
+        class M:
+            SCHEMA = TeamSchema(team="ok", statements=[])
+
+        return M
+
+    monkeypatch.setattr(registry_mod.importlib, "import_module", fake_import)
+    monkeypatch.setattr(registry_mod, "register_team_schemas", lambda s: True)
+
+    with caplog.at_level("ERROR"):
+        results = register_all_team_schemas()
+
+    assert results == {"broken": False, "ok": True}
+
+
+def test_registry_has_expected_entries():
+    # Sanity check on the real registry — every expected team appears.
+    for team in (
+        "unified_api",
+        "job_service",
+        "branding",
+        "startup_advisor",
+        "user_agent_founder",
+        "team_assistant",
+        "agentic_team_provisioning",
+        "blogging",
+    ):
+        assert team in TEAM_POSTGRES_MODULES, f"{team} missing from TEAM_POSTGRES_MODULES"
+
+
+# ---------------------------------------------------------------------------
+# Connection helpers — guard paths exercised without a live DB
+# ---------------------------------------------------------------------------
+
+
+def test_connect_raises_when_disabled(monkeypatch):
+    monkeypatch.delenv("POSTGRES_HOST", raising=False)
+    with pytest.raises(RuntimeError, match="POSTGRES_HOST is not set"):
+        client_mod._connect()
+
+
+def test_dsn_defaults(monkeypatch):
+    monkeypatch.setenv("POSTGRES_HOST", "h")
+    monkeypatch.setenv("POSTGRES_PORT", "1234")
+    monkeypatch.setenv("POSTGRES_USER", "u")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "p")
+    monkeypatch.setenv("POSTGRES_DB", "d")
+    dsn = client_mod._dsn()
+    assert "host=h" in dsn
+    assert "port=1234" in dsn
+    assert "dbname=d" in dsn
+    assert "user=u" in dsn
+    assert "password=p" in dsn
+
+
+def test_dsn_database_override(monkeypatch):
+    monkeypatch.setenv("POSTGRES_HOST", "h")
+    monkeypatch.setenv("POSTGRES_DB", "default_db")
+    dsn = client_mod._dsn("other_db")
+    assert "dbname=other_db" in dsn
+
+
+def test_close_pool_is_idempotent(monkeypatch):
+    # No connections tracked — close_pool must not raise.
+    client_mod._active_conns.clear()
+    close_pool()
+    close_pool("some_db")
+
+
+def test_close_pool_warns_on_leaked_conns(monkeypatch, caplog):
+    client_mod._active_conns.clear()
+    client_mod._active_conns["mydb"] = 2
+    with caplog.at_level("WARNING"):
+        close_pool()
+    assert any("active connection" in rec.message for rec in caplog.records)
+    assert client_mod._active_conns == {}
+
+
+def test_get_conn_commits_on_success(monkeypatch):
+    monkeypatch.setenv("POSTGRES_HOST", "postgres")
+
+    conn = MagicMock()
+    monkeypatch.setattr(client_mod, "_connect", lambda database=None: conn)
+    client_mod._active_conns.clear()
+
+    with client_mod.get_conn() as c:
+        assert c is conn
+
+    conn.commit.assert_called_once()
+    conn.rollback.assert_not_called()
+    conn.close.assert_called_once()
+    assert client_mod._active_conns.get("postgres", 0) == 0
+
+
+def test_get_conn_rolls_back_on_error(monkeypatch):
+    monkeypatch.setenv("POSTGRES_HOST", "postgres")
+
+    conn = MagicMock()
+    monkeypatch.setattr(client_mod, "_connect", lambda database=None: conn)
+    client_mod._active_conns.clear()
+
+    with pytest.raises(RuntimeError), client_mod.get_conn():
+        raise RuntimeError("boom")
+
+    conn.rollback.assert_called_once()
+    conn.close.assert_called_once()
+    assert client_mod._active_conns.get("postgres", 0) == 0

--- a/backend/agents/shared_temporal/README.md
+++ b/backend/agents/shared_temporal/README.md
@@ -75,3 +75,12 @@ for either mode.
 - `TEMPORAL_ADDRESS` — enables Temporal mode; unset falls back to threads.
 - `TEMPORAL_NAMESPACE` — default `default`.
 - `TEMPORAL_TASK_QUEUE` — default `strands-agents`.
+
+## See also
+
+- **`backend/agents/shared_postgres/`** — sibling module that applies the
+  same registry idea to Postgres DDL. Each team exports a `SCHEMA:
+  TeamSchema` from `<team>/postgres/__init__.py` and its FastAPI lifespan
+  calls `register_team_schemas(SCHEMA)` at startup. Unlike `shared_temporal`'s
+  Pattern A (import-time side effect), `shared_postgres` uses Pattern B
+  (explicit lifespan call) because DDL is synchronous blocking I/O.

--- a/backend/agents/startup_advisor/api/main.py
+++ b/backend/agents/startup_advisor/api/main.py
@@ -3,17 +3,39 @@
 from __future__ import annotations
 
 import logging
+from contextlib import asynccontextmanager
 from typing import Any, Optional
 
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
+from startup_advisor.postgres import SCHEMA as STARTUP_ADVISOR_POSTGRES_SCHEMA
+
 logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def _lifespan(application: FastAPI):
+    try:
+        from shared_postgres import register_team_schemas
+
+        register_team_schemas(STARTUP_ADVISOR_POSTGRES_SCHEMA)
+    except Exception:
+        logger.exception("startup_advisor postgres schema registration failed")
+    yield
+    try:
+        from shared_postgres import close_pool
+
+        close_pool()
+    except Exception:
+        logger.warning("startup_advisor shared_postgres close_pool failed", exc_info=True)
+
 
 app = FastAPI(
     title="Startup Advisor API",
     description="Persistent conversational startup advisor with probing dialogue",
     version="1.0.0",
+    lifespan=_lifespan,
 )
 
 

--- a/backend/agents/startup_advisor/postgres/__init__.py
+++ b/backend/agents/startup_advisor/postgres/__init__.py
@@ -1,0 +1,41 @@
+"""Postgres schema for the startup advisor team.
+
+Ports ``backend/agents/startup_advisor/store.py`` (currently SQLite)
+to Postgres. Registered from the team's FastAPI lifespan.
+"""
+
+from __future__ import annotations
+
+from shared_postgres import TeamSchema
+
+SCHEMA = TeamSchema(
+    team="startup_advisor",
+    database=None,
+    statements=[
+        """CREATE TABLE IF NOT EXISTS startup_advisor_conversations (
+            conversation_id TEXT PRIMARY KEY,
+            context_json    JSONB NOT NULL DEFAULT '{}'::jsonb,
+            created_at      TIMESTAMPTZ NOT NULL,
+            updated_at      TIMESTAMPTZ NOT NULL
+        )""",
+        """CREATE TABLE IF NOT EXISTS startup_advisor_conv_messages (
+            id              BIGSERIAL PRIMARY KEY,
+            conversation_id TEXT NOT NULL,
+            role            TEXT NOT NULL,
+            content         TEXT NOT NULL,
+            timestamp       TIMESTAMPTZ NOT NULL
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_startup_advisor_conv_messages_conv
+            ON startup_advisor_conv_messages(conversation_id)""",
+        """CREATE TABLE IF NOT EXISTS startup_advisor_conv_artifacts (
+            id              BIGSERIAL PRIMARY KEY,
+            conversation_id TEXT NOT NULL,
+            artifact_type   TEXT NOT NULL,
+            title           TEXT NOT NULL DEFAULT '',
+            payload_json    JSONB NOT NULL,
+            created_at      TIMESTAMPTZ NOT NULL
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_startup_advisor_conv_artifacts_conv
+            ON startup_advisor_conv_artifacts(conversation_id)""",
+    ],
+)

--- a/backend/agents/team_assistant/postgres/__init__.py
+++ b/backend/agents/team_assistant/postgres/__init__.py
@@ -1,0 +1,46 @@
+"""Postgres schema for the generic team assistant conversation store.
+
+Ports ``backend/agents/team_assistant/store.py`` (currently SQLite) to
+Postgres. The assistant sub-apps are hosted in-process by the unified
+API, so this schema is registered from the unified_api lifespan when
+the team_assistant module is imported for mounting.
+"""
+
+from __future__ import annotations
+
+from shared_postgres import TeamSchema
+
+SCHEMA = TeamSchema(
+    team="team_assistant",
+    database=None,
+    statements=[
+        """CREATE TABLE IF NOT EXISTS team_assistant_conversations (
+            conversation_id TEXT PRIMARY KEY,
+            job_id          TEXT,
+            context_json    JSONB NOT NULL DEFAULT '{}'::jsonb,
+            created_at      TIMESTAMPTZ NOT NULL,
+            updated_at      TIMESTAMPTZ NOT NULL
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_team_assistant_conversations_job_id
+            ON team_assistant_conversations(job_id)""",
+        """CREATE TABLE IF NOT EXISTS team_assistant_conv_messages (
+            id              BIGSERIAL PRIMARY KEY,
+            conversation_id TEXT NOT NULL,
+            role            TEXT NOT NULL,
+            content         TEXT NOT NULL,
+            timestamp       TIMESTAMPTZ NOT NULL
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_team_assistant_conv_messages_conv
+            ON team_assistant_conv_messages(conversation_id)""",
+        """CREATE TABLE IF NOT EXISTS team_assistant_conv_artifacts (
+            id              BIGSERIAL PRIMARY KEY,
+            conversation_id TEXT NOT NULL,
+            artifact_type   TEXT NOT NULL,
+            title           TEXT NOT NULL DEFAULT '',
+            payload_json    JSONB NOT NULL,
+            created_at      TIMESTAMPTZ NOT NULL
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_team_assistant_conv_artifacts_conv
+            ON team_assistant_conv_artifacts(conversation_id)""",
+    ],
+)

--- a/backend/agents/user_agent_founder/api/main.py
+++ b/backend/agents/user_agent_founder/api/main.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
+from contextlib import asynccontextmanager
 from typing import Any, Optional
 
 import httpx
@@ -13,9 +14,28 @@ from pydantic import BaseModel, Field
 
 from user_agent_founder.agent import get_founder_agent
 from user_agent_founder.orchestrator import run_workflow
+from user_agent_founder.postgres import SCHEMA as USER_AGENT_FOUNDER_POSTGRES_SCHEMA
 from user_agent_founder.store import get_founder_store
 
 logger = logging.getLogger(__name__)
+
+
+@asynccontextmanager
+async def _lifespan(application: FastAPI):
+    try:
+        from shared_postgres import register_team_schemas
+
+        register_team_schemas(USER_AGENT_FOUNDER_POSTGRES_SCHEMA)
+    except Exception:
+        logger.exception("user_agent_founder postgres schema registration failed")
+    yield
+    try:
+        from shared_postgres import close_pool
+
+        close_pool()
+    except Exception:
+        logger.warning("user_agent_founder shared_postgres close_pool failed", exc_info=True)
+
 
 app = FastAPI(
     title="User Agent Founder API",
@@ -25,6 +45,7 @@ app = FastAPI(
         "through the lens of a budget-conscious, speed-first, UX-obsessed founder."
     ),
     version="1.0.0",
+    lifespan=_lifespan,
 )
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/user_agent_founder/postgres/__init__.py
+++ b/backend/agents/user_agent_founder/postgres/__init__.py
@@ -1,0 +1,38 @@
+"""Postgres schema for the user agent founder team.
+
+Ports ``backend/agents/user_agent_founder/store.py`` (currently SQLite)
+to Postgres. Registered from the team's FastAPI lifespan.
+"""
+
+from __future__ import annotations
+
+from shared_postgres import TeamSchema
+
+SCHEMA = TeamSchema(
+    team="user_agent_founder",
+    database=None,
+    statements=[
+        """CREATE TABLE IF NOT EXISTS user_agent_founder_runs (
+            run_id          TEXT PRIMARY KEY,
+            status          TEXT NOT NULL DEFAULT 'pending',
+            se_job_id       TEXT,
+            analysis_job_id TEXT,
+            spec_content    TEXT,
+            repo_path       TEXT,
+            created_at      TIMESTAMPTZ NOT NULL,
+            updated_at      TIMESTAMPTZ NOT NULL,
+            error           TEXT
+        )""",
+        """CREATE TABLE IF NOT EXISTS user_agent_founder_decisions (
+            id             BIGSERIAL PRIMARY KEY,
+            run_id         TEXT NOT NULL,
+            question_id    TEXT NOT NULL,
+            question_text  TEXT NOT NULL,
+            answer_text    TEXT NOT NULL,
+            rationale      TEXT NOT NULL DEFAULT '',
+            timestamp      TIMESTAMPTZ NOT NULL
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_user_agent_founder_decisions_run
+            ON user_agent_founder_decisions(run_id)""",
+    ],
+)

--- a/backend/blogging_service/Dockerfile
+++ b/backend/blogging_service/Dockerfile
@@ -29,6 +29,9 @@ COPY agents/job_service_client.py /app/job_service_client.py
 # Integration contracts (used by integrations_store)
 COPY agents/integrations /app/integrations
 
+# Postgres schema registry (used by blogging lifespan to register its schema)
+COPY agents/shared_postgres /app/shared_postgres
+
 # Minimal unified_api modules needed by blogging Medium integration.
 # These are lazy-imported by blogging/shared/medium_integration_access.py.
 COPY unified_api/__init__.py /app/unified_api/__init__.py

--- a/backend/job_service/Dockerfile
+++ b/backend/job_service/Dockerfile
@@ -4,12 +4,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends curl libpq-dev 
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /app
-COPY requirements.txt .
+
+# NOTE: build context must be ../backend (i.e. the parent of job_service/),
+# so the Dockerfile can COPY from agents/shared_postgres.
+COPY job_service/requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-COPY . .
+# Shared Postgres client + schema registry
+COPY agents/shared_postgres /app/shared_postgres
+
+# Job service source
+COPY job_service /app/
 
 ENV PYTHONUNBUFFERED=1
+ENV PYTHONPATH=/app
 EXPOSE 8085
 
 CMD ["python", "-m", "uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8085"]

--- a/backend/job_service/db.py
+++ b/backend/job_service/db.py
@@ -3,6 +3,11 @@
 Stores jobs in a single ``jobs`` table with a JSONB ``data`` column for
 team-specific fields.  Top-level columns (status, timestamps) are extracted
 for efficient indexing and querying.
+
+DDL is declared in :mod:`job_service.postgres` and applied at startup via
+``shared_postgres.register_team_schemas``. This module keeps its own
+``psycopg2.pool.ThreadedConnectionPool`` for high-throughput CRUD (see
+``close_pool`` below — it closes this local pool, not the shared one).
 """
 
 from __future__ import annotations
@@ -22,7 +27,8 @@ import psycopg2.pool
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
-# Connection pool
+# Connection pool (job-service-local; separate from shared_postgres which
+# is only used at startup for DDL).
 # ---------------------------------------------------------------------------
 
 _pool: psycopg2.pool.ThreadedConnectionPool | None = None
@@ -56,33 +62,6 @@ def get_conn() -> Generator:
         raise
     finally:
         pool.putconn(conn)
-
-
-def ensure_schema() -> None:
-    """Create the jobs table and indexes if they do not already exist."""
-    with get_conn() as conn, conn.cursor() as cur:
-        cur.execute("""
-                CREATE TABLE IF NOT EXISTS jobs (
-                    job_id            TEXT NOT NULL,
-                    team              TEXT NOT NULL,
-                    status            TEXT NOT NULL DEFAULT 'pending',
-                    data              JSONB NOT NULL DEFAULT '{}',
-                    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                    last_heartbeat_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-                    PRIMARY KEY (team, job_id)
-                )
-            """)
-        cur.execute("""
-                CREATE INDEX IF NOT EXISTS idx_jobs_team_status
-                ON jobs (team, status)
-            """)
-        cur.execute("""
-                CREATE INDEX IF NOT EXISTS idx_jobs_heartbeat
-                ON jobs (team, last_heartbeat_at)
-                WHERE status IN ('pending', 'running')
-            """)
-    logger.info("Job service schema ensured")
 
 
 def close_pool() -> None:

--- a/backend/job_service/main.py
+++ b/backend/job_service/main.py
@@ -16,8 +16,7 @@ from db import (
     apply_patch as db_apply_patch,
 )
 from db import (
-    close_pool,
-    ensure_schema,
+    close_pool as db_close_pool,
 )
 from db import (
     create_job as db_create_job,
@@ -65,6 +64,10 @@ from models import (
     ReplaceJobRequest,
     UpdateJobRequest,
 )
+from postgres import SCHEMA as JOB_SERVICE_SCHEMA
+
+from shared_postgres import close_pool as shared_close_pool
+from shared_postgres import register_team_schemas
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
 logger = logging.getLogger("job_service")
@@ -72,10 +75,11 @@ logger = logging.getLogger("job_service")
 
 @asynccontextmanager
 async def lifespan(application: FastAPI):
-    ensure_schema()
+    register_team_schemas(JOB_SERVICE_SCHEMA)
     logger.info("Job service started")
     yield
-    close_pool()
+    db_close_pool()
+    shared_close_pool()
     logger.info("Job service stopped")
 
 

--- a/backend/job_service/postgres.py
+++ b/backend/job_service/postgres.py
@@ -1,0 +1,35 @@
+"""Postgres schema for the strands job service.
+
+Owns the single ``jobs`` table that every agent team reads/writes via
+``JobServiceClient``. The table lives in the ``strands_jobs`` database
+(see `docker-compose.yml` — the container sets ``POSTGRES_DB`` to
+``strands_jobs``, so ``database=None`` below resolves to it).
+"""
+
+from __future__ import annotations
+
+from shared_postgres import TeamSchema
+
+SCHEMA = TeamSchema(
+    team="job_service",
+    # None = use the container's POSTGRES_DB env var. In Docker this is
+    # already ``strands_jobs``; in other contexts the caller may set
+    # POSTGRES_DB explicitly.
+    database=None,
+    statements=[
+        """CREATE TABLE IF NOT EXISTS jobs (
+            job_id            TEXT NOT NULL,
+            team              TEXT NOT NULL,
+            status            TEXT NOT NULL DEFAULT 'pending',
+            data              JSONB NOT NULL DEFAULT '{}',
+            created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            last_heartbeat_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            PRIMARY KEY (team, job_id)
+        )""",
+        "CREATE INDEX IF NOT EXISTS idx_jobs_team_status ON jobs (team, status)",
+        """CREATE INDEX IF NOT EXISTS idx_jobs_heartbeat
+            ON jobs (team, last_heartbeat_at)
+            WHERE status IN ('pending', 'running')""",
+    ],
+)

--- a/backend/job_service/requirements.txt
+++ b/backend/job_service/requirements.txt
@@ -2,3 +2,5 @@ fastapi>=0.110.0,<1.0
 uvicorn>=0.29.0,<1.0
 pydantic>=2.0,<3.0
 psycopg2-binary>=2.9,<3.0
+# shared_postgres uses psycopg v3 (lightweight per-call connect for startup DDL).
+psycopg[binary]>=3.1,<3.3

--- a/backend/unified_api/main.py
+++ b/backend/unified_api/main.py
@@ -173,7 +173,9 @@ def _register_proxy_routes(app: FastAPI) -> dict[str, bool]:
         ) -> Any:
             return await proxy_request(request, _url, path, team_key=_team_key, timeout=_timeout)
 
-        logger.info("Proxying %s -> %s (timeout=%.0fs, cell=%s)", config.prefix, url, config.timeout_seconds, config.cell)
+        logger.info(
+            "Proxying %s -> %s (timeout=%.0fs, cell=%s)", config.prefix, url, config.timeout_seconds, config.cell
+        )
         results[team_key] = True
 
     return results
@@ -186,13 +188,33 @@ def _register_proxy_routes(app: FastAPI) -> dict[str, bool]:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    """Application lifespan: mount assistant sub-apps, then register proxy routes.
+    """Application lifespan: register own Postgres schemas, mount assistant sub-apps,
+    then register proxy routes.
 
     Order matters: assistant sub-apps must be mounted before proxy catch-all routes,
     otherwise the proxy's ``/{path:path}`` pattern swallows assistant requests.
     """
     global _registered_teams
     logger.info("Starting Unified API Server...")
+
+    # 0. Register Postgres schemas for modules that run in-process here
+    #    (unified_api itself + the team_assistant conversation store that we
+    #    mount as sub-apps). No-op when POSTGRES_HOST is unset.
+    try:
+        from shared_postgres import register_team_schemas
+        from unified_api.postgres import SCHEMA as UNIFIED_API_SCHEMA
+
+        register_team_schemas(UNIFIED_API_SCHEMA)
+    except Exception:
+        logger.exception("unified_api postgres schema registration failed")
+
+    try:
+        from shared_postgres import register_team_schemas
+        from team_assistant.postgres import SCHEMA as TEAM_ASSISTANT_SCHEMA
+
+        register_team_schemas(TEAM_ASSISTANT_SCHEMA)
+    except Exception:
+        logger.exception("team_assistant postgres schema registration failed")
 
     # 1. Mount team assistant conversational sub-apps (before proxy routes).
     try:
@@ -230,6 +252,14 @@ async def lifespan(app: FastAPI):
     yield
 
     health_task.cancel()
+
+    # Close Postgres connection pools owned by shared_postgres.
+    try:
+        from shared_postgres import close_pool
+
+        close_pool()
+    except Exception:
+        logger.warning("shared_postgres close_pool failed", exc_info=True)
 
     logger.info("Shutting down Unified API Server...")
 
@@ -320,9 +350,7 @@ async def health() -> UnifiedHealthResponse:
             status = "unavailable"
         if config.enabled and status in ("unavailable", "unhealthy"):
             all_healthy = False
-        teams.append(
-            TeamHealth(name=config.name, prefix=config.prefix, status=status, enabled=config.enabled)
-        )
+        teams.append(TeamHealth(name=config.name, prefix=config.prefix, status=status, enabled=config.enabled))
     return UnifiedHealthResponse(
         status="healthy" if all_healthy else "degraded",
         version="1.0.0",

--- a/backend/unified_api/postgres/__init__.py
+++ b/backend/unified_api/postgres/__init__.py
@@ -1,0 +1,24 @@
+"""Postgres schema owned by the unified_api.
+
+Declares the single ``encrypted_integration_credentials`` table that
+``postgres_encrypted_credentials.py`` and ``google_browser_login_credentials.py``
+both read/write. Registered from the unified_api's FastAPI lifespan.
+"""
+
+from __future__ import annotations
+
+from shared_postgres import TeamSchema
+
+SCHEMA = TeamSchema(
+    team="unified_api",
+    database=None,  # default POSTGRES_DB
+    statements=[
+        """CREATE TABLE IF NOT EXISTS encrypted_integration_credentials (
+            service TEXT NOT NULL,
+            credential_key TEXT NOT NULL,
+            ciphertext TEXT NOT NULL,
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            PRIMARY KEY (service, credential_key)
+        )""",
+    ],
+)

--- a/backend/unified_api/postgres_encrypted_credentials.py
+++ b/backend/unified_api/postgres_encrypted_credentials.py
@@ -42,17 +42,6 @@ def _get_psycopg():
         return None
 
 
-_DDL = """
-CREATE TABLE IF NOT EXISTS encrypted_integration_credentials (
-    service TEXT NOT NULL,
-    credential_key TEXT NOT NULL,
-    ciphertext TEXT NOT NULL,
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    PRIMARY KEY (service, credential_key)
-);
-"""
-
-
 def postgres_credentials_enabled() -> bool:
     return bool(os.getenv("POSTGRES_HOST", "").strip())
 
@@ -67,12 +56,12 @@ def _dsn() -> str:
     return f"postgresql://{user}:{pwd}@{host}:{port}/{db}"
 
 
-def _ensure_table(cur) -> None:
-    cur.execute(_DDL)
-
-
 def pg_get_credential(service: str, key: str) -> str:
-    """Return decrypted plaintext or empty string."""
+    """Return decrypted plaintext or empty string.
+
+    The ``encrypted_integration_credentials`` table is created at startup
+    by ``shared_postgres.register_team_schemas`` — no per-call DDL here.
+    """
     if not postgres_credentials_enabled():
         return ""
     row: tuple | None = None
@@ -81,7 +70,6 @@ def pg_get_credential(service: str, key: str) -> str:
 
         try:
             with psycopg.connect(_dsn(), autocommit=True) as conn, conn.cursor() as cur:
-                _ensure_table(cur)
                 cur.execute(
                     "SELECT ciphertext FROM encrypted_integration_credentials "
                     "WHERE service = %s AND credential_key = %s",
@@ -116,7 +104,6 @@ def pg_set_credential(service: str, key: str, value: str) -> None:
     encrypted = get_integration_fernet().encrypt(value.encode()).decode()
 
     with _LOCK, psycopg.connect(_dsn(), autocommit=True) as conn, conn.cursor() as cur:
-        _ensure_table(cur)
         cur.execute(
             """
                     INSERT INTO encrypted_integration_credentials (service, credential_key, ciphertext, updated_at)
@@ -138,7 +125,6 @@ def pg_delete_credential(service: str, key: str) -> None:
     with _LOCK:
         try:
             with psycopg.connect(_dsn(), autocommit=True) as conn, conn.cursor() as cur:
-                _ensure_table(cur)
                 cur.execute(
                     "DELETE FROM encrypted_integration_credentials WHERE service = %s AND credential_key = %s",
                     (service, key),

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -72,8 +72,8 @@ services:
 
   job-service:
     build:
-      context: ../backend/job_service
-      dockerfile: Dockerfile
+      context: ../backend
+      dockerfile: job_service/Dockerfile
     image: strands-job-service
     container_name: strands-job-service
     depends_on:


### PR DESCRIPTION
Introduces a team-registered Postgres schema pattern so every service
declares its tables in one place and applies them at startup, instead
of the current mix of per-call DDL, docker init scripts, and
hand-rolled ensure_schema() calls.

Each team exports a `SCHEMA: TeamSchema` from `<team>/postgres/__init__.py`
as pure data. The team's FastAPI lifespan calls
`shared_postgres.register_team_schemas(SCHEMA)` at startup, which is a
no-op when `POSTGRES_HOST` is unset. Unlike shared_temporal's Pattern A
(import-time side effect), shared_postgres uses Pattern B (explicit
lifespan call) because DDL is synchronous blocking I/O.

Retrofits job_service and unified_api encrypted credentials onto the
new framework and adds ported SCHEMA modules (tables not yet active
as a backend) for the six SQLite-backed teams so a future migration
has a clean landing zone.

https://claude.ai/code/session_01YNEk6NoeqTueGEkdowhVWw