### PR TITLE
Add Prometheus + Grafana observability stack

### DIFF
--- a/backend/agents/requirements.txt
+++ b/backend/agents/requirements.txt
@@ -14,3 +14,5 @@ psycopg[binary]>=3.1,<3.3
 temporalio>=1.5,<1.6
 APScheduler>=3.10,<4.0
 pytz>=2024.1
+# Observability: exposes /metrics on the unified API for Prometheus scraping
+prometheus-fastapi-instrumentator>=7.0,<8.0

--- a/backend/blogging_service/entrypoint.py
+++ b/backend/blogging_service/entrypoint.py
@@ -24,12 +24,28 @@ def _start_temporal_worker() -> None:
 
 if __name__ == "__main__":
     _start_temporal_worker()
+
+    # Import the app object so we can instrument it in-process before uvicorn
+    # starts. Safe because workers=1 (see note below).
+    from blogging.api.main import app as _blogging_app
+
+    try:
+        from prometheus_fastapi_instrumentator import Instrumentator
+
+        Instrumentator(
+            should_group_status_codes=True,
+            should_ignore_untemplated=True,
+            excluded_handlers=["/metrics", "/health"],
+        ).instrument(_blogging_app).expose(_blogging_app, endpoint="/metrics", include_in_schema=False)
+    except Exception:
+        logger.warning("prometheus instrumentator unavailable", exc_info=True)
+
     # workers=1 is required: the Temporal worker thread stores the client and
     # event loop in module-level globals. With workers>1 uvicorn forks, and
     # child processes lose access to the parent's globals. Using 1 worker
     # keeps the Temporal client and API handler in the same process.
     uvicorn.run(
-        "blogging.api.main:app",
+        _blogging_app,
         host="0.0.0.0",
         port=8090,
         workers=1,

--- a/backend/blogging_service/requirements.txt
+++ b/backend/blogging_service/requirements.txt
@@ -12,3 +12,5 @@ playwright>=1.49,<1.51
 cryptography>=41.0.0
 psycopg[binary]>=3.1,<3.3
 temporalio>=1.5,<1.6
+# Observability: exposes /metrics for Prometheus scraping
+prometheus-fastapi-instrumentator>=7.0,<8.0

--- a/backend/job_service/main.py
+++ b/backend/job_service/main.py
@@ -85,6 +85,18 @@ async def lifespan(application: FastAPI):
 
 app = FastAPI(title="Strands Job Service", version="1.0.0", lifespan=lifespan)
 
+# Prometheus metrics — exposes GET /metrics for scraping.
+try:
+    from prometheus_fastapi_instrumentator import Instrumentator
+
+    Instrumentator(
+        should_group_status_codes=True,
+        should_ignore_untemplated=True,
+        excluded_handlers=["/metrics", "/health"],
+    ).instrument(app).expose(app, endpoint="/metrics", include_in_schema=False)
+except Exception:
+    logger.warning("prometheus instrumentator unavailable", exc_info=True)
+
 
 # ---------------------------------------------------------------------------
 # Health

--- a/backend/job_service/requirements.txt
+++ b/backend/job_service/requirements.txt
@@ -4,3 +4,5 @@ pydantic>=2.0,<3.0
 psycopg2-binary>=2.9,<3.0
 # shared_postgres uses psycopg v3 (lightweight per-call connect for startup DDL).
 psycopg[binary]>=3.1,<3.3
+# Observability: exposes /metrics for Prometheus scraping
+prometheus-fastapi-instrumentator>=7.0,<8.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -19,3 +19,4 @@ pytz>=2024.1
 playwright>=1.49,<1.51
 psycopg[binary]>=3.1,<3.3
 yfinance>=1.2,<2.0
+prometheus-fastapi-instrumentator>=7.0,<8.0

--- a/backend/team_service/entrypoint.py
+++ b/backend/team_service/entrypoint.py
@@ -68,10 +68,14 @@ def _shutdown_hook() -> None:
 
 
 def _resolve_app() -> str:
-    """Return a uvicorn import string for the ASGI app.
+    """Return a uvicorn import string for the instrumented ASGI app.
 
-    If TEAM_APP_ATTR points to an APIRouter (not a FastAPI app), write a
-    wrapper module to disk so uvicorn worker processes can import it.
+    Always writes /app/_team_wrapper.py so every team gets:
+      * A FastAPI app (wrapping a router if TEAM_APP_ATTR == "router", else
+        re-exporting the team's own FastAPI app).
+      * prometheus-fastapi-instrumentator installed and /metrics exposed.
+    The wrapper is re-imported by each uvicorn worker on fork, so per-worker
+    instrumentation state is fine with workers>1.
     """
     # Validate the team module can be imported (fail fast with a clear error).
     try:
@@ -80,20 +84,39 @@ def _resolve_app() -> str:
         logger.exception("FATAL: cannot import team module %s", TEAM_MODULE)
         raise
 
-    if TEAM_APP_ATTR == "router":
-        # Write a real Python file that uvicorn workers can import.
-        import pathlib
+    import pathlib
 
-        wrapper_path = pathlib.Path("/app/_team_wrapper.py")
-        wrapper_path.write_text(
-            f"from fastapi import FastAPI\n"
+    wrapper_path = pathlib.Path("/app/_team_wrapper.py")
+
+    if TEAM_APP_ATTR == "router":
+        body = (
+            "from fastapi import FastAPI\n"
             f"from {TEAM_MODULE} import {TEAM_APP_ATTR} as _router\n"
             f"app = FastAPI(title='{TEAM_NAME} API')\n"
-            f"app.include_router(_router)\n",
-            encoding="utf-8",
+            "app.include_router(_router)\n"
         )
-        return "_team_wrapper:app"
-    return f"{TEAM_MODULE}:{TEAM_APP_ATTR}"
+    else:
+        body = f"from {TEAM_MODULE} import {TEAM_APP_ATTR} as app\n"
+
+    body += (
+        "try:\n"
+        "    from prometheus_fastapi_instrumentator import Instrumentator\n"
+        "    Instrumentator(\n"
+        "        should_group_status_codes=True,\n"
+        "        should_ignore_untemplated=True,\n"
+        "        excluded_handlers=['/metrics', '/health'],\n"
+        "    ).instrument(app).expose(\n"
+        "        app, endpoint='/metrics', include_in_schema=False\n"
+        "    )\n"
+        "except Exception:\n"
+        "    import logging\n"
+        "    logging.getLogger('team_service').warning(\n"
+        "        'prometheus instrumentator unavailable', exc_info=True\n"
+        "    )\n"
+    )
+
+    wrapper_path.write_text(body, encoding="utf-8")
+    return "_team_wrapper:app"
 
 
 if __name__ == "__main__":

--- a/backend/team_service/requirements.txt
+++ b/backend/team_service/requirements.txt
@@ -18,3 +18,5 @@ APScheduler>=3.10,<4.0
 pytz>=2024.1
 python-dotenv>=1.0,<2.0
 yfinance>=1.2,<2.0
+# Observability: team services auto-expose /metrics via team_service/entrypoint.py
+prometheus-fastapi-instrumentator>=7.0,<8.0

--- a/backend/unified_api/main.py
+++ b/backend/unified_api/main.py
@@ -293,6 +293,19 @@ from unified_api.middleware import SecurityGatewayMiddleware
 
 app.add_middleware(SecurityGatewayMiddleware)
 
+# Prometheus metrics — exposes GET /metrics for scraping. SecurityGatewayMiddleware
+# only intercepts /api/{team}/* paths, so /metrics bypasses it automatically.
+try:
+    from prometheus_fastapi_instrumentator import Instrumentator
+
+    Instrumentator(
+        should_group_status_codes=True,
+        should_ignore_untemplated=True,
+        excluded_handlers=["/metrics", "/health"],
+    ).instrument(app).expose(app, endpoint="/metrics", include_in_schema=False, tags=["observability"])
+except Exception:
+    logger.warning("prometheus instrumentator unavailable", exc_info=True)
+
 # Integrations API (Slack config, etc.)
 from unified_api.routes.analytics import router as analytics_router
 from unified_api.routes.integrations import router as integrations_router

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -72,3 +72,15 @@ ENABLE_LOG_API=0
 # Base directory where SE team project workspaces are created via file upload.
 # Falls back to ENV_WORKSPACE_ROOT if set, then ./se_workspaces relative to CWD.
 # SE_WORKSPACE_DIR=/path/to/workspaces
+
+# ---------------------------------------------------------------------------
+# Observability (Prometheus + Grafana)
+# ---------------------------------------------------------------------------
+# Grafana admin credentials. NOTE: only read on first boot (when the
+# grafana_data volume is empty). Changing these later has no effect — reset
+# via the Grafana UI or remove the grafana_data volume.
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=admin
+
+# Prometheus on-disk retention window. Accepts s/m/h/d/w/y suffixes.
+PROMETHEUS_RETENTION=15d

--- a/docker/README.md
+++ b/docker/README.md
@@ -42,6 +42,8 @@ This directory defines a **Docker Compose stack** that runs:
    | **Angular UI** | http://localhost:4201       (proxies /api to agents; nested routes e.g. SE Planning/Coding Team, Investment Advisor/Strategy Lab, Agentic roster) |
    | Agents API     | http://localhost:8888       (direct) |
    | Temporal UI    | http://localhost:8080       |
+   | Prometheus     | http://localhost:9090       (scrape targets: `/targets`; metric browser: `/graph`) |
+   | Grafana        | http://localhost:3000       (login `admin`/`admin` by default; Strands folder holds the FastAPI overview dashboard) |
    | Postgres       | localhost:5432 (user `postgres` / `temporal` / `strands`) |
    | Ollama (local) | http://localhost:11434      |
 
@@ -90,6 +92,8 @@ When **ENABLE_LOG_API** is not set or is 0, the endpoint returns **404** so it i
 |-------------------|----------------|---------|
 | `postgres_data_v18` | PostgreSQL   | Database files (Temporal + app DBs). Suffix tracks the Postgres major version — renaming the volume on each major bump gives a fresh data dir declaratively. |
 | `agents_workspace`| strands-agents | Agent workspace at `/workspace` (repos, generated code, artifacts). |
+| `prometheus_data` | Prometheus    | Prometheus TSDB (metric samples). Retention window controlled by `PROMETHEUS_RETENTION` (default `15d`). |
+| `grafana_data`    | Grafana       | Grafana state (users, saved dashboards, datasource cache). |
 
 Data in these volumes survives `docker compose down` and container restarts. To wipe persisted data, run `docker compose down -v`.
 
@@ -100,6 +104,8 @@ Data in these volumes survives `docker compose down` and container restarts. To 
 | 5432  | PostgreSQL     |
 | 7233  | Temporal gRPC  |
 | 8080  | Temporal UI    |
+| 3000  | Grafana        |
+| 9090  | Prometheus     |
 | 4201  | Angular UI (proxies /api to agents) |
 | 8888  | Agents API (direct) |
 | 8108  | Agentic Team Provisioning API (direct; also proxied at `/api/agentic-team-provisioning` on 8888) |
@@ -124,6 +130,19 @@ On **macOS** with Podman Machine, container memory is capped by the machine’s 
 
 When running in this stack, the **strands-agents** service uses the **stack’s Postgres** (database `strands`, user `strands`) via **POSTGRES_HOST=postgres**. The container does not start its own PostgreSQL. The init script in `docker/postgres/init/` creates the `strands` database and user on first run.
 
+## Observability (Prometheus + Grafana)
+
+The stack ships with a Prometheus server and Grafana instance pre-wired.
+
+- **Prometheus** at http://localhost:9090 scrapes `/metrics` on the unified API (`strands-agents:8080`), the job service (`job-service:8085`), and every team microservice on its own port. Config file: `docker/prometheus/prometheus.yml`. View scrape health at http://localhost:9090/targets — every target should report `UP` once containers are healthy.
+- **Grafana** at http://localhost:3000 (default `admin`/`admin`, override via `GRAFANA_ADMIN_USER` / `GRAFANA_ADMIN_PASSWORD` in `.env`). The Prometheus datasource is provisioned automatically from `docker/grafana/provisioning/datasources/prometheus.yml`. A starter **Strands FastAPI Overview** dashboard (request rate, p95 latency, 5xx rate, scrape health) is provisioned under the "Strands" folder.
+- **Retention** is controlled by `PROMETHEUS_RETENTION` (default `15d`). Data persists in the `prometheus_data` and `grafana_data` named volumes.
+- **Grafana admin password caveat**: `GRAFANA_ADMIN_PASSWORD` is only read on first boot (when `grafana_data` is empty). Changing it later has no effect — reset via the Grafana UI, or remove the volume with `docker volume rm docker_grafana_data` to re-seed from env vars.
+
+Metrics are produced by `prometheus-fastapi-instrumentator` which is installed into the unified API (`backend/unified_api/main.py`), the job service (`backend/job_service/main.py`), the blogging service (`backend/blogging_service/entrypoint.py`), and the generic team entrypoint (`backend/team_service/entrypoint.py`). That means every team container automatically exposes `/metrics` without any per-team code changes. Dropping additional dashboard JSON files into `docker/grafana/provisioning/dashboards/` picks them up automatically every 30 seconds.
+
+Add a new team? Edit `docker/prometheus/prometheus.yml` and append a new target entry to the `team-services` job with the service's DNS name and port, then add a matching `extra_hosts` entry to the `prometheus` service in `docker-compose.yml`.
+
 ## Verification
 
 After starting the stack:
@@ -132,6 +151,9 @@ After starting the stack:
 2. **Temporal UI** – Open http://localhost:8080 and confirm the Temporal Web UI loads.
 3. **Agents** – `curl http://localhost:8888/health` should return `{"status":"ok"}` (agents use stack Postgres and Ollama Cloud when configured).
 4. **Logs API** – With `ENABLE_LOG_API=1` in `.env`, `curl "http://localhost:8888/api/software-engineering/logs?service=sw_api&lines=100"` should return 200 and log content. With `ENABLE_LOG_API` unset, the same URL should return 404.
+5. **Metrics endpoints** – `curl -sf http://localhost:8888/metrics | head` and the same on `:8585` (job service) and `:8090`–`:8110` (team services) should return Prometheus text-format output (`# HELP ...`).
+6. **Prometheus targets** – Open http://localhost:9090/targets; all rows should be green (`UP`). Or run `curl -s 'http://localhost:9090/api/v1/query?query=up' | jq '.data.result[] | {service:.metric.service, up:.value[1]}'`.
+7. **Grafana datasource** – `curl -sf -u admin:admin http://localhost:3000/api/datasources | jq` should list one `Prometheus` datasource. Then open http://localhost:3000 → Dashboards → Strands → **Strands FastAPI Overview** and confirm the panels render live data after generating some traffic (e.g. `for i in {1..20}; do curl -sf http://localhost:8888/health > /dev/null; done`).
 
 ## Security
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -890,6 +890,96 @@ services:
         ipv4_address: 172.28.0.7
     restart: unless-stopped
 
+  # ── Observability (Prometheus + Grafana) ───────────────────────────────────
+  # Prometheus scrapes /metrics on the unified API, job-service, and every
+  # team microservice (exposed automatically via prometheus-fastapi-instrumentator
+  # in backend/team_service/entrypoint.py). Grafana ships with a pre-provisioned
+  # Prometheus datasource and a starter FastAPI dashboard.
+
+  prometheus:
+    image: prom/prometheus:v3.11.0
+    container_name: strands-stack-prometheus
+    depends_on:
+      strands-agents: { condition: service_healthy }
+      job-service: { condition: service_healthy }
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--storage.tsdb.retention.time=${PROMETHEUS_RETENTION:-15d}"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
+      - "--web.enable-lifecycle"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus_data:/prometheus
+    extra_hosts:
+      - "strands-agents:172.28.0.6"
+      - "job-service:172.28.0.5"
+      - "blogging-service:172.28.0.8"
+      - "se-service:172.28.0.9"
+      - "pa-service:172.28.0.10"
+      - "market-research-service:172.28.0.11"
+      - "soc2-service:172.28.0.12"
+      - "social-marketing-service:172.28.0.13"
+      - "branding-service:172.28.0.14"
+      - "agent-provisioning-service:172.28.0.15"
+      - "a11y-service:172.28.0.16"
+      - "ai-systems-service:172.28.0.17"
+      - "investment-service:172.28.0.18"
+      - "nutrition-service:172.28.0.19"
+      - "planning-v3-service:172.28.0.20"
+      - "coding-team-service:172.28.0.21"
+      - "studio-grid-service:172.28.0.22"
+      - "sales-service:172.28.0.23"
+      - "road-trip-service:172.28.0.24"
+      - "startup-advisor-service:172.28.0.25"
+      - "agentic-team-provisioning-service:172.28.0.26"
+      - "user-agent-founder-service:172.28.0.27"
+      - "deepthought-service:172.28.0.28"
+    ports:
+      - "9090:9090"
+    networks:
+      stack:
+        ipv4_address: 172.28.0.29
+        aliases:
+          - prometheus
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:9090/-/healthy"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+
+  grafana:
+    image: grafana/grafana:12.4.2
+    container_name: strands-stack-grafana
+    depends_on:
+      prometheus: { condition: service_healthy }
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_ANALYTICS_REPORTING_ENABLED: "false"
+      GF_ANALYTICS_CHECK_FOR_UPDATES: "false"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - grafana_data:/var/lib/grafana
+    extra_hosts:
+      - "prometheus:172.28.0.29"
+    ports:
+      - "3000:3000"
+    networks:
+      stack:
+        ipv4_address: 172.28.0.30
+        aliases:
+          - grafana
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:3000/api/health || exit 1"]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+
 networks:
   stack:
     name: strands-stack
@@ -904,3 +994,5 @@ volumes:
   postgres_data_v18:
   agents_workspace:
   agents_data:
+  prometheus_data:
+  grafana_data:

--- a/docker/grafana/provisioning/dashboards/dashboards.yml
+++ b/docker/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,15 @@
+apiVersion: 1
+
+providers:
+  - name: strands-default
+    orgId: 1
+    folder: Strands
+    folderUid: strands
+    type: file
+    disableDeletion: false
+    editable: true
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards
+      foldersFromFilesStructure: false

--- a/docker/grafana/provisioning/dashboards/fastapi-overview.json
+++ b/docker/grafana/provisioning/dashboards/fastapi-overview.json
@@ -1,0 +1,225 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": { "type": "datasource", "uid": "grafana" },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "strands-prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "strands-prometheus" },
+          "editorMode": "code",
+          "expr": "sum by (service) (rate(http_requests_total[5m]))",
+          "legendFormat": "{{service}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Request rate by service",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "strands-prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "strands-prometheus" },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum by (le, service) (rate(http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "{{service}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "p95 latency by service",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "strands-prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 20,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": { "type": "linear" },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": { "group": "A", "mode": "none" },
+            "thresholdsStyle": { "mode": "off" }
+          },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 0, "y": 9 },
+      "id": 3,
+      "options": {
+        "legend": { "calcs": ["mean", "max"], "displayMode": "table", "placement": "bottom", "showLegend": true },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "strands-prometheus" },
+          "editorMode": "code",
+          "expr": "sum by (service) (rate(http_requests_total{status=~\"5..\"}[5m]))",
+          "legendFormat": "{{service}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "5xx error rate by service",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "strands-prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [
+            { "options": { "0": { "color": "red", "index": 0, "text": "DOWN" } }, "type": "value" },
+            { "options": { "1": { "color": "green", "index": 1, "text": "UP" } }, "type": "value" }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              { "color": "red", "value": null },
+              { "color": "green", "value": 1 }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 9, "w": 12, "x": 12, "y": 9 },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "pluginVersion": "12.4.2",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "strands-prometheus" },
+          "editorMode": "code",
+          "expr": "up{job=~\"unified-api|job-service|team-services\"}",
+          "legendFormat": "{{service}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Scrape target health",
+      "type": "stat"
+    }
+  ],
+  "refresh": "15s",
+  "schemaVersion": 39,
+  "tags": ["strands", "fastapi", "observability"],
+  "templating": { "list": [] },
+  "time": { "from": "now-1h", "to": "now" },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Strands FastAPI Overview",
+  "uid": "strands-fastapi-overview",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docker/grafana/provisioning/datasources/prometheus.yml
+++ b/docker/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: strands-prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true
+    jsonData:
+      httpMethod: POST
+      timeInterval: 15s

--- a/docker/prometheus/prometheus.yml
+++ b/docker/prometheus/prometheus.yml
@@ -1,0 +1,73 @@
+# Prometheus scrape config for the Strands stack.
+# All targets use container DNS names on the strands-stack network. The
+# prometheus service declares matching extra_hosts entries in docker-compose.yml
+# so DNS resolution does not depend on Podman's embedded DNS.
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
+  external_labels:
+    stack: strands
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: unified-api
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["strands-agents:8080"]
+        labels: { service: unified-api, component: router }
+
+  - job_name: job-service
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["job-service:8085"]
+        labels: { service: job-service, component: platform }
+
+  - job_name: team-services
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["blogging-service:8090"]
+        labels: { service: blogging-service, team: blogging }
+      - targets: ["se-service:8091"]
+        labels: { service: se-service, team: software_engineering }
+      - targets: ["pa-service:8092"]
+        labels: { service: pa-service, team: personal_assistant }
+      - targets: ["market-research-service:8093"]
+        labels: { service: market-research-service, team: market_research }
+      - targets: ["soc2-service:8094"]
+        labels: { service: soc2-service, team: soc2_compliance }
+      - targets: ["social-marketing-service:8095"]
+        labels: { service: social-marketing-service, team: social_marketing }
+      - targets: ["branding-service:8096"]
+        labels: { service: branding-service, team: branding }
+      - targets: ["agent-provisioning-service:8097"]
+        labels: { service: agent-provisioning-service, team: agent_provisioning }
+      - targets: ["a11y-service:8098"]
+        labels: { service: a11y-service, team: accessibility_audit }
+      - targets: ["ai-systems-service:8099"]
+        labels: { service: ai-systems-service, team: ai_systems }
+      - targets: ["investment-service:8100"]
+        labels: { service: investment-service, team: investment }
+      - targets: ["nutrition-service:8101"]
+        labels: { service: nutrition-service, team: nutrition_meal_planning }
+      - targets: ["planning-v3-service:8102"]
+        labels: { service: planning-v3-service, team: planning_v3 }
+      - targets: ["coding-team-service:8103"]
+        labels: { service: coding-team-service, team: coding_team }
+      - targets: ["studio-grid-service:8104"]
+        labels: { service: studio-grid-service, team: studio_grid }
+      - targets: ["sales-service:8105"]
+        labels: { service: sales-service, team: sales_team }
+      - targets: ["road-trip-service:8106"]
+        labels: { service: road-trip-service, team: road_trip_planning }
+      - targets: ["startup-advisor-service:8107"]
+        labels: { service: startup-advisor-service, team: startup_advisor }
+      - targets: ["agentic-team-provisioning-service:8108"]
+        labels: { service: agentic-team-provisioning-service, team: agentic_team_provisioning }
+      - targets: ["user-agent-founder-service:8109"]
+        labels: { service: user-agent-founder-service, team: user_agent_founder }
+      - targets: ["deepthought-service:8110"]
+        labels: { service: deepthought-service, team: deepthought }


### PR DESCRIPTION
Introduces full metrics observability for the 25-service Docker stack.
Prometheus (v3.11.0) scrapes /metrics on the unified API, job service, and
every team microservice; Grafana (12.4.2) ships with a pre-provisioned
Prometheus datasource and starter FastAPI overview dashboard.

All FastAPI apps expose /metrics via prometheus-fastapi-instrumentator.
A single edit to team_service/entrypoint.py instruments all 21 team
services by always writing _team_wrapper.py with the Instrumentator block
baked in, preserving workers=2 because each forked worker re-imports the
wrapper. Unified API, job-service, and blogging-service get their own
in-module instrumentation. SecurityGatewayMiddleware doesn't affect
/metrics because it only intercepts /api/{team}/* paths.