### PR TITLE
Add interactive testing mode for agent chat and pipeline execution

### DIFF
--- a/backend/agents/agentic_team_provisioning/api/main.py
+++ b/backend/agents/agentic_team_provisioning/api/main.py
@@ -864,19 +864,17 @@ def start_pipeline_run(team_id: str, req: StartPipelineRunRequest):
 
     # Find the process
     process = None
-    for p in team.get("processes", []):
-        pid = p.get("process_id") if isinstance(p, dict) else p.process_id
-        if pid == req.process_id:
+    for p in team.processes:
+        if p.process_id == req.process_id:
             process = p
             break
     if process is None:
         raise HTTPException(status_code=404, detail="Process not found")
 
     # Build ProcessDefinition from stored data
-    if isinstance(process, dict):
-        process_def = ProcessDefinition(**process)
-    else:
-        process_def = process
+    process_def = (
+        process if isinstance(process, ProcessDefinition) else ProcessDefinition(**process)
+    )
 
     run_id = str(uuid.uuid4())
     run_row = _test_store.create_pipeline_run(run_id, team_id, req.process_id, req.initial_input)
@@ -933,4 +931,3 @@ def cancel_pipeline_run(team_id: str, run_id: str):
     _pipeline_runner.cancel_run(run_id)
     updated = _test_store.get_pipeline_run(run_id)
     return TestPipelineRun(**(updated or row))
-    return Response(status_code=204)

--- a/backend/agents/agentic_team_provisioning/api/main.py
+++ b/backend/agents/agentic_team_provisioning/api/main.py
@@ -19,6 +19,7 @@ from agentic_team_provisioning.infrastructure import get_team_infrastructure, pr
 from agentic_team_provisioning.models import (
     AgentEnvProvisionSummary,
     AgenticTeamAgent,
+    AgentQualityScore,
     AssetInfo,
     ConversationStateResponse,
     ConversationSummaryResponse,
@@ -26,24 +27,46 @@ from agentic_team_provisioning.models import (
     CreateFormRecordRequest,
     CreateTeamRequest,
     CreateTeamResponse,
+    CreateTestChatSessionRequest,
     FormRecord,
     ProcessDefinition,
     ProcessOutput,
     ProcessStatus,
     ProcessTrigger,
+    RateMessageRequest,
     RecommendAgentsResponse,
     RecommendedAgent,
+    RenameTestChatSessionRequest,
     RosterValidationResult,
     SendMessageRequest,
+    SendTestChatMessageRequest,
+    SetTeamModeRequest,
+    StartPipelineRunRequest,
+    SubmitPipelineInputRequest,
     SubmitTeamAnswersRequest,
     TeamDetailResponse,
     TeamJobDetail,
     TeamJobSummary,
     TeamPendingQuestion,
     TeamSummary,
+    TestChatMessage,
+    TestChatSession,
+    TestChatSessionDetail,
+    TestPipelineRun,
     UpdateFormRecordRequest,
 )
 from agentic_team_provisioning.postgres import SCHEMA as AGENTIC_POSTGRES_SCHEMA
+from agentic_team_provisioning.runtime.agent_builder import (
+    build_agent as _build_test_agent,
+)
+from agentic_team_provisioning.runtime.agent_builder import (
+    call_agent as _call_test_agent,
+)
+from agentic_team_provisioning.runtime.agent_builder import (
+    generate_starter_prompts,
+)
+from agentic_team_provisioning.runtime.pipeline_runner import get_pipeline_runner
+from agentic_team_provisioning.testing.store import get_test_store
 from shared_observability import init_otel, instrument_fastapi_app
 
 logger = logging.getLogger(__name__)
@@ -77,6 +100,10 @@ instrument_fastapi_app(app, team_key="agentic_team_provisioning")
 
 _store = AgenticTeamStore()
 _agent = ProcessDesignerAgent()
+
+# Interactive testing mode singletons
+_test_store = get_test_store()
+_pipeline_runner = get_pipeline_runner(_test_store)
 
 # Retroactive provisioning: ensure all existing teams have infrastructure
 try:
@@ -633,4 +660,277 @@ def delete_team_form_record(team_id: str, form_key: str, record_id: str):
     infra = _get_infra_or_404(team_id)
     if not infra.form_store.delete_record(record_id):
         raise HTTPException(status_code=404, detail="Record not found")
+
+
+# ---------------------------------------------------------------------------
+# Interactive Testing Mode
+# ---------------------------------------------------------------------------
+
+
+@app.put("/teams/{team_id}/mode")
+def set_team_mode(team_id: str, req: SetTeamModeRequest):
+    """Toggle team between development and testing mode."""
+    team = _store.get_team(team_id)
+    if not team:
+        raise HTTPException(status_code=404, detail="Team not found")
+    _test_store.set_team_mode(team_id, req.mode.value)
+    return {"team_id": team_id, "mode": req.mode.value}
+
+
+# ---------------------------------------------------------------------------
+# Agent Chat Testing
+# ---------------------------------------------------------------------------
+
+
+def _find_agent_in_roster(team_id: str, agent_name: str) -> AgenticTeamAgent:
+    """Look up an agent by name in the team roster."""
+    agents = _store.list_team_agents(team_id)
+    for a in agents:
+        if a.agent_name == agent_name:
+            return a
+    raise HTTPException(status_code=404, detail=f"Agent '{agent_name}' not found in team roster")
+
+
+@app.post("/teams/{team_id}/test-chat/sessions", response_model=TestChatSession, status_code=201)
+def create_test_chat_session(team_id: str, req: CreateTestChatSessionRequest):
+    """Create a new chat test session for an agent."""
+    team = _store.get_team(team_id)
+    if not team:
+        raise HTTPException(status_code=404, detail="Team not found")
+    _find_agent_in_roster(team_id, req.agent_name)
+    session_id = str(uuid.uuid4())
+    row = _test_store.create_chat_session(session_id, team_id, req.agent_name)
+    return TestChatSession(**row)
+
+
+@app.get("/teams/{team_id}/test-chat/sessions", response_model=List[TestChatSession])
+def list_test_chat_sessions(team_id: str, agent_name: Optional[str] = None):
+    """List chat test sessions for a team, optionally filtered by agent."""
+    rows = _test_store.list_chat_sessions(team_id, agent_name=agent_name)
+    return [TestChatSession(**r) for r in rows]
+
+
+@app.get("/teams/{team_id}/test-chat/sessions/{session_id}", response_model=TestChatSessionDetail)
+def get_test_chat_session(team_id: str, session_id: str):
+    """Get a chat session with full message history and suggested prompts."""
+    session_row = _test_store.get_chat_session(session_id)
+    if not session_row or session_row["team_id"] != team_id:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    messages = _test_store.list_chat_messages(session_id)
+    session = TestChatSession(**session_row)
+
+    # Generate suggested prompts if no messages yet
+    prompts: list[str] = []
+    if not messages:
+        try:
+            agent_def = _find_agent_in_roster(team_id, session.agent_name)
+            prompts = generate_starter_prompts(
+                agent_def.agent_name, agent_def.role, agent_def.skills, agent_def.expertise
+            )
+        except HTTPException:
+            pass
+
+    return TestChatSessionDetail(
+        session=session,
+        messages=[TestChatMessage(**m) for m in messages],
+        suggested_prompts=prompts,
+    )
+
+
+@app.put("/teams/{team_id}/test-chat/sessions/{session_id}/name")
+def rename_test_chat_session(team_id: str, session_id: str, req: RenameTestChatSessionRequest):
+    """Rename a chat test session."""
+    session_row = _test_store.get_chat_session(session_id)
+    if not session_row or session_row["team_id"] != team_id:
+        raise HTTPException(status_code=404, detail="Session not found")
+    _test_store.rename_chat_session(session_id, req.session_name)
+    return {"session_id": session_id, "session_name": req.session_name}
+
+
+@app.delete("/teams/{team_id}/test-chat/sessions/{session_id}", status_code=204)
+def delete_test_chat_session(team_id: str, session_id: str):
+    """Delete a chat test session and its messages."""
+    session_row = _test_store.get_chat_session(session_id)
+    if not session_row or session_row["team_id"] != team_id:
+        raise HTTPException(status_code=404, detail="Session not found")
+    _test_store.delete_chat_session(session_id)
+
+
+@app.post("/teams/{team_id}/test-chat/sessions/{session_id}/messages")
+def send_test_chat_message(team_id: str, session_id: str, req: SendTestChatMessageRequest):
+    """Send a message to an agent and get a synchronous response.
+
+    The full conversation history is sent to the agent for multi-turn
+    context. Both user and assistant messages are stored.
+    """
+    session_row = _test_store.get_chat_session(session_id)
+    if not session_row or session_row["team_id"] != team_id:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    agent_name = session_row["agent_name"]
+    agent_def = _find_agent_in_roster(team_id, agent_name)
+
+    # Store user message
+    user_msg_id = str(uuid.uuid4())
+    _test_store.create_chat_message(user_msg_id, session_id, "user", req.content)
+
+    # Build conversation context from history
+    history = _test_store.list_chat_messages(session_id)
+    context_parts = []
+    for msg in history[:-1]:  # Exclude the just-added user message (will add below)
+        prefix = "User" if msg["role"] == "user" else "Assistant"
+        context_parts.append(f"{prefix}: {msg['content']}")
+    context_parts.append(f"User: {req.content}")
+    full_context = "\n\n".join(context_parts)
+
+    # Build and invoke agent
+    agent_instance = _build_test_agent(
+        agent_def.agent_name,
+        agent_def.role,
+        agent_def.skills,
+        agent_def.capabilities,
+        agent_def.tools,
+        agent_def.expertise,
+    )
+    response_text = _call_test_agent(agent_instance, full_context)
+
+    # Store assistant message
+    asst_msg_id = str(uuid.uuid4())
+    _test_store.create_chat_message(asst_msg_id, session_id, "assistant", response_text)
+
+    # Return all messages
+    all_messages = _test_store.list_chat_messages(session_id)
+    return {
+        "session": TestChatSession(**session_row),
+        "messages": [TestChatMessage(**m) for m in all_messages],
+    }
+
+
+@app.get("/teams/{team_id}/test-chat/sessions/{session_id}/export")
+def export_test_chat_session(team_id: str, session_id: str):
+    """Export a chat session transcript as Markdown text."""
+    session_row = _test_store.get_chat_session(session_id)
+    if not session_row or session_row["team_id"] != team_id:
+        raise HTTPException(status_code=404, detail="Session not found")
+
+    messages = _test_store.list_chat_messages(session_id)
+    agent_name = session_row["agent_name"]
+    session_name = session_row.get("session_name") or f"Chat with {agent_name}"
+
+    lines = [f"# {session_name}", f"Agent: {agent_name}", ""]
+    for msg in messages:
+        role_label = "**User**" if msg["role"] == "user" else f"**{agent_name}**"
+        rating_str = ""
+        if msg.get("rating"):
+            rating_str = " \u2705" if msg["rating"] == "thumbs_up" else " \u274c"
+        lines.append(f"{role_label}{rating_str}:")
+        lines.append(msg["content"])
+        lines.append("")
+
+    return Response(
+        content="\n".join(lines),
+        media_type="text/markdown",
+        headers={"Content-Disposition": f'attachment; filename="{session_id}.md"'},
+    )
+
+
+@app.put("/teams/{team_id}/test-chat/messages/{message_id}/rating")
+def rate_test_chat_message(team_id: str, message_id: str, req: RateMessageRequest):
+    """Rate an assistant message (thumbs up/thumbs down)."""
+    if not _test_store.update_message_rating(message_id, req.rating.value):
+        raise HTTPException(status_code=404, detail="Message not found")
+    return {"message_id": message_id, "rating": req.rating.value}
+
+
+@app.get("/teams/{team_id}/test-chat/quality-scores", response_model=List[AgentQualityScore])
+def get_agent_quality_scores(team_id: str):
+    """Get aggregated quality scores per agent based on chat ratings."""
+    rows = _test_store.get_agent_quality_scores(team_id)
+    return [AgentQualityScore(**r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Pipeline Testing (End-to-End Walkthrough)
+# ---------------------------------------------------------------------------
+
+
+@app.post("/teams/{team_id}/test-pipeline/runs", response_model=TestPipelineRun, status_code=201)
+def start_pipeline_run(team_id: str, req: StartPipelineRunRequest):
+    """Start an end-to-end pipeline test run."""
+    team = _store.get_team(team_id)
+    if not team:
+        raise HTTPException(status_code=404, detail="Team not found")
+
+    # Find the process
+    process = None
+    for p in team.get("processes", []):
+        pid = p.get("process_id") if isinstance(p, dict) else p.process_id
+        if pid == req.process_id:
+            process = p
+            break
+    if process is None:
+        raise HTTPException(status_code=404, detail="Process not found")
+
+    # Build ProcessDefinition from stored data
+    if isinstance(process, dict):
+        process_def = ProcessDefinition(**process)
+    else:
+        process_def = process
+
+    run_id = str(uuid.uuid4())
+    run_row = _test_store.create_pipeline_run(run_id, team_id, req.process_id, req.initial_input)
+
+    # Gather team agents
+    team_agents_raw = _store.list_team_agents(team_id)
+    team_agents = [
+        a if isinstance(a, AgenticTeamAgent) else AgenticTeamAgent(**a) for a in team_agents_raw
+    ]
+
+    # Start the pipeline in a background thread
+    _pipeline_runner.start_run(run_id, team_agents, process_def)
+
+    return TestPipelineRun(**run_row)
+
+
+@app.get("/teams/{team_id}/test-pipeline/runs", response_model=List[TestPipelineRun])
+def list_pipeline_runs(team_id: str):
+    """List pipeline test runs for a team."""
+    rows = _test_store.list_pipeline_runs(team_id)
+    return [TestPipelineRun(**r) for r in rows]
+
+
+@app.get("/teams/{team_id}/test-pipeline/runs/{run_id}", response_model=TestPipelineRun)
+def get_pipeline_run(team_id: str, run_id: str):
+    """Get the current status and step results of a pipeline test run."""
+    row = _test_store.get_pipeline_run(run_id)
+    if not row or row["team_id"] != team_id:
+        raise HTTPException(status_code=404, detail="Pipeline run not found")
+    return TestPipelineRun(**row)
+
+
+@app.post("/teams/{team_id}/test-pipeline/runs/{run_id}/input")
+def submit_pipeline_input(team_id: str, run_id: str, req: SubmitPipelineInputRequest):
+    """Submit human input at a WAIT step to resume the pipeline."""
+    row = _test_store.get_pipeline_run(run_id)
+    if not row or row["team_id"] != team_id:
+        raise HTTPException(status_code=404, detail="Pipeline run not found")
+    if row["status"] != "waiting_for_input":
+        raise HTTPException(status_code=400, detail="Pipeline is not waiting for input")
+    _pipeline_runner.submit_human_input(run_id, req.input)
+    updated = _test_store.get_pipeline_run(run_id)
+    return TestPipelineRun(**(updated or row))
+
+
+@app.post("/teams/{team_id}/test-pipeline/runs/{run_id}/cancel")
+def cancel_pipeline_run(team_id: str, run_id: str):
+    """Cancel a running or waiting pipeline test run."""
+    row = _test_store.get_pipeline_run(run_id)
+    if not row or row["team_id"] != team_id:
+        raise HTTPException(status_code=404, detail="Pipeline run not found")
+    if row["status"] not in ("running", "waiting_for_input"):
+        raise HTTPException(status_code=400, detail="Pipeline is not in a cancellable state")
+    _pipeline_runner.cancel_run(run_id)
+    updated = _test_store.get_pipeline_run(run_id)
+    return TestPipelineRun(**(updated or row))
     return Response(status_code=204)

--- a/backend/agents/agentic_team_provisioning/models.py
+++ b/backend/agents/agentic_team_provisioning/models.py
@@ -40,6 +40,30 @@ class ProcessStatus(str, Enum):
     ARCHIVED = "archived"
 
 
+class TeamMode(str, Enum):
+    """Toggle between development and interactive testing."""
+
+    DEVELOPMENT = "development"
+    TESTING = "testing"
+
+
+class MessageRating(str, Enum):
+    """Thumbs-up / thumbs-down rating for a chat message."""
+
+    THUMBS_UP = "thumbs_up"
+    THUMBS_DOWN = "thumbs_down"
+
+
+class PipelineRunStatus(str, Enum):
+    """Lifecycle of an end-to-end pipeline test run."""
+
+    RUNNING = "running"
+    WAITING_FOR_INPUT = "waiting_for_input"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
 # ---------------------------------------------------------------------------
 # Process building blocks
 # ---------------------------------------------------------------------------
@@ -140,6 +164,7 @@ class AgenticTeam(BaseModel):
     team_id: str = Field(..., description="Unique id (UUID)")
     name: str = Field(..., description="Team display name")
     description: str = Field(default="", description="Short description of what the team does")
+    mode: TeamMode = Field(default=TeamMode.DEVELOPMENT)
     agents: list[AgenticTeamAgent] = Field(
         default_factory=list, description="Named agents pool (Agent 1 … Agent N)"
     )
@@ -295,7 +320,9 @@ class RecommendedAgent(BaseModel):
     """An agent recommended for a process step."""
 
     agent_name: str = Field(..., description="Agent identifier")
-    source: str = Field(..., description="Where the recommendation came from: 'registry' or 'roster'")
+    source: str = Field(
+        ..., description="Where the recommendation came from: 'registry' or 'roster'"
+    )
     role: str = Field(default="", description="Suggested role for this agent")
     skills: list[str] = Field(default_factory=list)
     tools: list[str] = Field(default_factory=list)
@@ -326,3 +353,107 @@ class AgentEnvProvisionSummary(BaseModel):
     error_message: Optional[str] = None
     created_at: str = ""
     updated_at: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Interactive Testing Mode models
+# ---------------------------------------------------------------------------
+
+
+class TestChatSession(BaseModel):
+    """An interactive chat test session with a specific agent."""
+
+    session_id: str
+    team_id: str
+    agent_name: str
+    session_name: str = Field(default="")
+    created_at: str = ""
+    updated_at: str = ""
+
+
+class TestChatMessage(BaseModel):
+    """A single message in a test chat session."""
+
+    message_id: str
+    session_id: str
+    role: str = Field(..., pattern=r"^(user|assistant)$")
+    content: str
+    rating: Optional[MessageRating] = None
+    created_at: str = ""
+
+
+class TestChatSessionDetail(BaseModel):
+    """Session with full message history and starter prompts."""
+
+    session: TestChatSession
+    messages: list[TestChatMessage] = Field(default_factory=list)
+    suggested_prompts: list[str] = Field(default_factory=list)
+
+
+class AgentQualityScore(BaseModel):
+    """Aggregated quality score for an agent based on chat ratings."""
+
+    agent_name: str
+    total_rated: int = 0
+    thumbs_up: int = 0
+    thumbs_down: int = 0
+    score_pct: float = Field(default=0.0, description="Percentage of positive ratings (0-100)")
+
+
+class PipelineStepResult(BaseModel):
+    """Output of a single step within a pipeline test run."""
+
+    step_id: str
+    step_name: str = ""
+    agent_name: str = ""
+    input: str = ""
+    output: str = ""
+    status: str = "pending"
+
+
+class TestPipelineRun(BaseModel):
+    """An end-to-end pipeline test run."""
+
+    run_id: str
+    team_id: str
+    process_id: str
+    status: PipelineRunStatus = PipelineRunStatus.RUNNING
+    current_step_id: Optional[str] = None
+    initial_input: Optional[str] = None
+    step_results: list[PipelineStepResult] = Field(default_factory=list)
+    human_prompt: Optional[str] = None
+    error: Optional[str] = None
+    started_at: str = ""
+    finished_at: Optional[str] = None
+
+
+# Test mode request DTOs
+
+
+class SetTeamModeRequest(BaseModel):
+    mode: TeamMode
+
+
+class CreateTestChatSessionRequest(BaseModel):
+    agent_name: str = Field(..., min_length=1)
+
+
+class RenameTestChatSessionRequest(BaseModel):
+    session_name: str = Field(..., min_length=1, max_length=200)
+
+
+class SendTestChatMessageRequest(BaseModel):
+    content: str = Field(..., min_length=1)
+
+
+class RateMessageRequest(BaseModel):
+    rating: MessageRating
+
+
+class StartPipelineRunRequest(BaseModel):
+    process_id: str = Field(..., min_length=1)
+    initial_input: Optional[str] = None
+
+
+class SubmitPipelineInputRequest(BaseModel):
+    input: str = Field(..., min_length=1)

--- a/backend/agents/agentic_team_provisioning/postgres/__init__.py
+++ b/backend/agents/agentic_team_provisioning/postgres/__init__.py
@@ -81,6 +81,40 @@ SCHEMA = TeamSchema(
         )""",
         "CREATE INDEX IF NOT EXISTS idx_agentic_form_data_team ON agentic_form_data(team_id)",
         "CREATE INDEX IF NOT EXISTS idx_agentic_form_data_key ON agentic_form_data(form_key)",
+        # --- Interactive Testing Mode tables ---
+        "ALTER TABLE agentic_teams ADD COLUMN IF NOT EXISTS mode TEXT NOT NULL DEFAULT 'development'",
+        """CREATE TABLE IF NOT EXISTS agentic_test_chat_sessions (
+            session_id   TEXT PRIMARY KEY,
+            team_id      TEXT NOT NULL REFERENCES agentic_teams(team_id),
+            agent_name   TEXT NOT NULL,
+            session_name TEXT NOT NULL DEFAULT '',
+            created_at   TIMESTAMPTZ NOT NULL,
+            updated_at   TIMESTAMPTZ NOT NULL
+        )""",
+        "CREATE INDEX IF NOT EXISTS idx_agentic_test_chat_sessions_team ON agentic_test_chat_sessions(team_id)",
+        """CREATE TABLE IF NOT EXISTS agentic_test_chat_messages (
+            message_id  TEXT PRIMARY KEY,
+            session_id  TEXT NOT NULL REFERENCES agentic_test_chat_sessions(session_id) ON DELETE CASCADE,
+            role        TEXT NOT NULL,
+            content     TEXT NOT NULL,
+            rating      TEXT,
+            created_at  TIMESTAMPTZ NOT NULL
+        )""",
+        "CREATE INDEX IF NOT EXISTS idx_agentic_test_chat_messages_session ON agentic_test_chat_messages(session_id)",
+        """CREATE TABLE IF NOT EXISTS agentic_test_pipeline_runs (
+            run_id          TEXT PRIMARY KEY,
+            team_id         TEXT NOT NULL REFERENCES agentic_teams(team_id),
+            process_id      TEXT NOT NULL,
+            status          TEXT NOT NULL DEFAULT 'running',
+            current_step_id TEXT,
+            initial_input   TEXT,
+            step_results    JSONB NOT NULL DEFAULT '[]'::jsonb,
+            human_prompt    TEXT,
+            error           TEXT,
+            started_at      TIMESTAMPTZ NOT NULL,
+            finished_at     TIMESTAMPTZ
+        )""",
+        "CREATE INDEX IF NOT EXISTS idx_agentic_test_pipeline_runs_team ON agentic_test_pipeline_runs(team_id, started_at DESC)",
     ],
     table_names=[
         "agentic_teams",
@@ -90,5 +124,8 @@ SCHEMA = TeamSchema(
         "agentic_team_agents",
         "agentic_env_provisions",
         "agentic_form_data",
+        "agentic_test_chat_sessions",
+        "agentic_test_chat_messages",
+        "agentic_test_pipeline_runs",
     ],
 )

--- a/backend/agents/agentic_team_provisioning/runtime/__init__.py
+++ b/backend/agents/agentic_team_provisioning/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Runtime modules for live agent execution in test mode."""

--- a/backend/agents/agentic_team_provisioning/runtime/agent_builder.py
+++ b/backend/agents/agentic_team_provisioning/runtime/agent_builder.py
@@ -1,0 +1,160 @@
+"""Compile an AgenticTeamAgent roster definition into a live strands.Agent.
+
+Used by the interactive testing mode to turn declarative agent
+definitions (role, skills, capabilities, tools, expertise) into
+runnable agents that can respond to user messages.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# Optional strands import — graceful degradation when not installed.
+try:
+    from strands import Agent as StrandsAgent
+
+    HAS_STRANDS = True
+except ImportError:
+    HAS_STRANDS = False
+    StrandsAgent = None  # type: ignore[assignment,misc]
+
+# Optional common tools from strands_tools.
+_COMMON_TOOLS: list[Any] = []
+try:
+    from strands_tools import (  # type: ignore[import-untyped]
+        current_time,
+        http_request,
+        python_repl,
+    )
+
+    _COMMON_TOOLS = [http_request, python_repl, current_time]
+except ImportError:
+    pass
+
+# Registry mapping tool name strings from the roster to actual tool objects.
+TOOL_REGISTRY: dict[str, Any] = {}
+if len(_COMMON_TOOLS) >= 3:
+    TOOL_REGISTRY.update(
+        {
+            "http_request": _COMMON_TOOLS[0],
+            "http": _COMMON_TOOLS[0],
+            "python_repl": _COMMON_TOOLS[1],
+            "python": _COMMON_TOOLS[1],
+            "current_time": _COMMON_TOOLS[2],
+        }
+    )
+
+
+def build_system_prompt(
+    agent_name: str,
+    role: str,
+    skills: list[str],
+    capabilities: list[str],
+    tools: list[str],
+    expertise: list[str],
+) -> str:
+    """Construct a system prompt from the roster agent's metadata."""
+    parts = [f"You are {agent_name}, a specialist agent."]
+    parts.append(f"\nRole: {role}")
+    if skills:
+        parts.append(f"\nSkills: {', '.join(skills)}")
+    if capabilities:
+        parts.append(f"\nCapabilities: {', '.join(capabilities)}")
+    if expertise:
+        parts.append(f"\nExpertise: {', '.join(expertise)}")
+    if tools:
+        parts.append(f"\nAvailable tools: {', '.join(tools)}")
+    parts.append(
+        "\n\nRespond helpfully and concisely. Use your specialized knowledge "
+        "to provide high-quality, actionable answers."
+    )
+    return "\n".join(parts)
+
+
+def resolve_tools(tool_names: list[str]) -> list[Any]:
+    """Map tool name strings from the roster to actual tool objects."""
+    resolved = []
+    for name in tool_names:
+        normalized = name.lower().replace(" ", "_").replace("-", "_")
+        if normalized in TOOL_REGISTRY:
+            resolved.append(TOOL_REGISTRY[normalized])
+        else:
+            logger.debug("Unrecognized tool %r — will mention in system prompt", name)
+    return resolved or _COMMON_TOOLS
+
+
+def build_agent(
+    agent_name: str,
+    role: str,
+    skills: list[str],
+    capabilities: list[str],
+    tools: list[str],
+    expertise: list[str],
+) -> Optional[Any]:
+    """Compile roster agent metadata into a live strands.Agent.
+
+    Returns ``None`` if the strands SDK is not installed.
+    """
+    if not HAS_STRANDS:
+        logger.warning("strands SDK not available; agent %s will use stub mode", agent_name)
+        return None
+
+    system_prompt = build_system_prompt(agent_name, role, skills, capabilities, tools, expertise)
+    resolved = resolve_tools(tools)
+    model = os.environ.get("AGENTIC_TEAM_TEST_MODEL", "us.anthropic.claude-sonnet-4-20250514")
+
+    return StrandsAgent(
+        model=model,
+        system_prompt=system_prompt,
+        tools=resolved,
+        callback_handler=None,
+    )
+
+
+def call_agent(agent_instance: Any, message: str) -> str:
+    """Invoke a strands.Agent and extract the text response."""
+    if agent_instance is None:
+        return f"[Stub response — strands SDK not available. Input: {message[:200]}]"
+    try:
+        result = agent_instance(message)
+        if hasattr(result, "message"):
+            return str(result.message).strip()
+        return str(result).strip()
+    except Exception as exc:
+        logger.error("Agent call failed: %s", exc, exc_info=True)
+        return f"[Agent error: {exc}]"
+
+
+def generate_starter_prompts(
+    agent_name: str, role: str, skills: list[str], expertise: list[str]
+) -> list[str]:
+    """Generate contextual starter prompts for an agent chat session.
+
+    Uses template interpolation (no LLM call) to avoid latency on
+    session creation.
+    """
+    prompts: list[str] = []
+
+    if role:
+        prompts.append(f"Describe how you approach your role as {role}.")
+
+    if skills:
+        skill = skills[0]
+        prompts.append(f"Walk me through how you would use your {skill} skill.")
+
+    if expertise:
+        domain = expertise[0]
+        prompts.append(f"What are the key challenges in {domain}?")
+
+    if not prompts:
+        prompts = [
+            f"Introduce yourself and explain what you do, {agent_name}.",
+            "What kind of tasks are you best suited for?",
+            "Give me an example of how you'd handle a typical request.",
+        ]
+
+    return prompts[:3]

--- a/backend/agents/agentic_team_provisioning/runtime/pipeline_runner.py
+++ b/backend/agents/agentic_team_provisioning/runtime/pipeline_runner.py
@@ -1,0 +1,307 @@
+"""Pipeline runner: walks a ProcessDefinition DAG step-by-step.
+
+Runs in a background thread. Auto-advances through ACTION, DECISION,
+PARALLEL_SPLIT, PARALLEL_JOIN, and SUBPROCESS steps. Pauses at WAIT
+steps until human input is submitted via the API.
+
+Follows the background-thread pattern from ``ai_systems_team/api/main.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from agentic_team_provisioning.models import (
+    AgenticTeamAgent,
+    ProcessDefinition,
+    ProcessStep,
+    StepType,
+)
+from agentic_team_provisioning.runtime.agent_builder import build_agent, call_agent
+from agentic_team_provisioning.testing.store import AgenticTestStore
+
+logger = logging.getLogger(__name__)
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+class PipelineRunner:
+    """Walks the process DAG, runs agents at each step, pauses at WAIT steps."""
+
+    def __init__(self, store: AgenticTestStore) -> None:
+        self._store = store
+        self._resume_events: dict[str, threading.Event] = {}
+        self._human_inputs: dict[str, str] = {}
+
+    def start_run(
+        self,
+        run_id: str,
+        team_agents: list[AgenticTeamAgent],
+        process: ProcessDefinition,
+    ) -> None:
+        """Spawn a background thread to execute the pipeline."""
+        event = threading.Event()
+        self._resume_events[run_id] = event
+        thread = threading.Thread(
+            target=self._execute,
+            args=(run_id, team_agents, process, event),
+            daemon=True,
+            name=f"pipeline-{run_id[:16]}",
+        )
+        thread.start()
+
+    def submit_human_input(self, run_id: str, user_input: str) -> None:
+        """Resume a paused pipeline run with human input."""
+        self._human_inputs[run_id] = user_input
+        self._store.update_pipeline_run(run_id, status="running", human_prompt=None)
+        event = self._resume_events.get(run_id)
+        if event:
+            event.set()
+
+    def cancel_run(self, run_id: str) -> None:
+        """Cancel a running or waiting pipeline run."""
+        self._store.update_pipeline_run(run_id, status="cancelled", finished_at=_now_iso())
+        event = self._resume_events.get(run_id)
+        if event:
+            event.set()
+
+    def _execute(
+        self,
+        run_id: str,
+        team_agents: list[AgenticTeamAgent],
+        process: ProcessDefinition,
+        resume_event: threading.Event,
+    ) -> None:
+        """Main pipeline execution loop."""
+        try:
+            agents_by_name: dict[str, AgenticTeamAgent] = {a.agent_name: a for a in team_agents}
+            step_order = self._topological_sort(process.steps)
+
+            # Use initial_input as starting context for the first step
+            run_data = self._store.get_pipeline_run(run_id)
+            prev_output = (run_data or {}).get("initial_input") or ""
+            step_results: list[dict[str, Any]] = []
+
+            for step in step_order:
+                # Check for cancellation before each step
+                run_data = self._store.get_pipeline_run(run_id)
+                if run_data and run_data.get("status") == "cancelled":
+                    return
+
+                self._store.update_pipeline_run(
+                    run_id, current_step_id=step.step_id, status="running"
+                )
+
+                if step.step_type == StepType.WAIT:
+                    prev_output = self._handle_wait_step(
+                        run_id, step, prev_output, step_results, resume_event
+                    )
+                    # Check if cancelled while waiting
+                    run_data = self._store.get_pipeline_run(run_id)
+                    if run_data and run_data.get("status") == "cancelled":
+                        return
+                elif step.step_type == StepType.DECISION:
+                    prev_output = self._handle_decision_step(
+                        run_id, step, prev_output, step_results, agents_by_name
+                    )
+                else:
+                    prev_output = self._handle_action_step(
+                        run_id, step, prev_output, step_results, agents_by_name
+                    )
+
+            self._store.update_pipeline_run(
+                run_id,
+                status="completed",
+                step_results=step_results,
+                finished_at=_now_iso(),
+            )
+        except Exception as exc:
+            logger.exception("Pipeline run %s failed", run_id)
+            self._store.update_pipeline_run(
+                run_id, status="failed", error=str(exc), finished_at=_now_iso()
+            )
+        finally:
+            self._resume_events.pop(run_id, None)
+            self._human_inputs.pop(run_id, None)
+
+    def _handle_action_step(
+        self,
+        run_id: str,
+        step: ProcessStep,
+        prev_output: str,
+        step_results: list[dict[str, Any]],
+        agents_by_name: dict[str, AgenticTeamAgent],
+    ) -> str:
+        """Build the agent, invoke it, store the result."""
+        agent_name = step.agents[0].agent_name if step.agents else ""
+        agent_def = agents_by_name.get(agent_name)
+
+        step_input = f"Task: {step.name}\nDescription: {step.description}\n\nContext from previous step:\n{prev_output}"
+
+        if agent_def:
+            agent_instance = build_agent(
+                agent_def.agent_name,
+                agent_def.role,
+                agent_def.skills,
+                agent_def.capabilities,
+                agent_def.tools,
+                agent_def.expertise,
+            )
+            output = call_agent(agent_instance, step_input)
+        else:
+            output = f"[No agent assigned to step '{step.name}']"
+
+        result = {
+            "step_id": step.step_id,
+            "step_name": step.name,
+            "agent_name": agent_name,
+            "input": prev_output[:500],
+            "output": output,
+            "status": "completed",
+        }
+        step_results.append(result)
+        self._store.update_pipeline_run(run_id, step_results=step_results)
+        return output
+
+    def _handle_wait_step(
+        self,
+        run_id: str,
+        step: ProcessStep,
+        prev_output: str,
+        step_results: list[dict[str, Any]],
+        resume_event: threading.Event,
+    ) -> str:
+        """Pause execution and wait for human input."""
+        prompt_text = step.description or f"Human input required for: {step.name}"
+
+        result = {
+            "step_id": step.step_id,
+            "step_name": step.name,
+            "agent_name": "",
+            "input": prev_output[:500],
+            "output": "",
+            "status": "waiting_for_input",
+        }
+        step_results.append(result)
+        self._store.update_pipeline_run(
+            run_id,
+            status="waiting_for_input",
+            human_prompt=prompt_text,
+            step_results=step_results,
+        )
+
+        # Block until human input arrives or run is cancelled
+        resume_event.clear()
+        resume_event.wait()
+
+        # Retrieve the human input
+        human_input = self._human_inputs.pop(run_id, "")
+        result["output"] = human_input
+        result["status"] = "completed"
+        self._store.update_pipeline_run(run_id, step_results=step_results)
+        return human_input
+
+    def _handle_decision_step(
+        self,
+        run_id: str,
+        step: ProcessStep,
+        prev_output: str,
+        step_results: list[dict[str, Any]],
+        agents_by_name: dict[str, AgenticTeamAgent],
+    ) -> str:
+        """Evaluate condition and record the decision."""
+        agent_name = step.agents[0].agent_name if step.agents else ""
+        agent_def = agents_by_name.get(agent_name)
+
+        condition_prompt = (
+            f"Decision step: {step.name}\n"
+            f"Condition: {step.condition or 'Choose the best next step'}\n"
+            f"Previous output:\n{prev_output}\n\n"
+            f"Available branches: {', '.join(step.next_steps)}\n"
+            f"Which branch should be taken? Reply with only the step_id."
+        )
+
+        if agent_def:
+            agent_instance = build_agent(
+                agent_def.agent_name,
+                agent_def.role,
+                agent_def.skills,
+                agent_def.capabilities,
+                agent_def.tools,
+                agent_def.expertise,
+            )
+            decision = call_agent(agent_instance, condition_prompt)
+        else:
+            decision = step.next_steps[0] if step.next_steps else "none"
+
+        result = {
+            "step_id": step.step_id,
+            "step_name": step.name,
+            "agent_name": agent_name,
+            "input": prev_output[:500],
+            "output": f"Decision: {decision}",
+            "status": "completed",
+        }
+        step_results.append(result)
+        self._store.update_pipeline_run(run_id, step_results=step_results)
+        return decision
+
+    @staticmethod
+    def _topological_sort(steps: list[ProcessStep]) -> list[ProcessStep]:
+        """Sort steps in execution order following next_steps edges.
+
+        Finds entry points (steps not referenced as next_step by any
+        other step) and walks the DAG breadth-first. Falls back to the
+        original order if the graph structure is ambiguous.
+        """
+        if not steps:
+            return []
+
+        step_map = {s.step_id: s for s in steps}
+        all_next: set[str] = set()
+        for s in steps:
+            all_next.update(s.next_steps)
+
+        entry_ids = [s.step_id for s in steps if s.step_id not in all_next]
+        if not entry_ids:
+            entry_ids = [steps[0].step_id]
+
+        visited: set[str] = set()
+        ordered: list[ProcessStep] = []
+        queue = list(entry_ids)
+
+        while queue:
+            sid = queue.pop(0)
+            if sid in visited:
+                continue
+            visited.add(sid)
+            step = step_map.get(sid)
+            if step:
+                ordered.append(step)
+                queue.extend(step.next_steps)
+
+        # Include any unreachable steps at the end
+        for s in steps:
+            if s.step_id not in visited:
+                ordered.append(s)
+
+        return ordered
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton
+# ---------------------------------------------------------------------------
+
+_default_runner: Optional[PipelineRunner] = None
+
+
+def get_pipeline_runner(store: AgenticTestStore) -> PipelineRunner:
+    global _default_runner  # noqa: PLW0603
+    if _default_runner is None:
+        _default_runner = PipelineRunner(store)
+    return _default_runner

--- a/backend/agents/agentic_team_provisioning/testing/__init__.py
+++ b/backend/agents/agentic_team_provisioning/testing/__init__.py
@@ -1,0 +1,5 @@
+"""Interactive testing mode for agentic team provisioning.
+
+Provides agent chat testing (with ratings) and end-to-end pipeline
+walkthrough execution.
+"""

--- a/backend/agents/agentic_team_provisioning/testing/store.py
+++ b/backend/agents/agentic_team_provisioning/testing/store.py
@@ -1,0 +1,332 @@
+"""Postgres-backed store for interactive testing mode.
+
+Follows the ``startup_advisor/store.py`` pattern exactly:
+stateless class, ``@timed_query`` on every method, short-lived
+connections via ``shared_postgres.get_conn``.
+
+All DDL lives in ``agentic_team_provisioning.postgres`` and is
+registered from the team's FastAPI lifespan.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from psycopg.rows import dict_row
+from psycopg.types.json import Json
+
+from shared_postgres import get_conn
+from shared_postgres.metrics import timed_query
+
+logger = logging.getLogger(__name__)
+
+_STORE = "agentic_team_testing"
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _row_ts(value: Any) -> str:
+    """Normalize a Postgres TIMESTAMPTZ to an ISO-8601 string."""
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value or "")
+
+
+class AgenticTestStore:
+    """Postgres-backed store for test chat sessions, messages, and pipeline runs."""
+
+    def __init__(self) -> None:
+        pass  # Stateless; pool lives in shared_postgres
+
+    # ------------------------------------------------------------------
+    # Team mode
+    # ------------------------------------------------------------------
+
+    @timed_query(store=_STORE, op="set_team_mode")
+    def set_team_mode(self, team_id: str, mode: str) -> None:
+        now = _now()
+        with get_conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "UPDATE agentic_teams SET mode = %s, updated_at = %s WHERE team_id = %s",
+                (mode, now, team_id),
+            )
+
+    @timed_query(store=_STORE, op="get_team_mode")
+    def get_team_mode(self, team_id: str) -> str:
+        with get_conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+            cur.execute("SELECT mode FROM agentic_teams WHERE team_id = %s", (team_id,))
+            row = cur.fetchone()
+            return row["mode"] if row else "development"
+
+    # ------------------------------------------------------------------
+    # Chat sessions
+    # ------------------------------------------------------------------
+
+    @timed_query(store=_STORE, op="create_chat_session")
+    def create_chat_session(
+        self, session_id: str, team_id: str, agent_name: str, session_name: str = ""
+    ) -> dict:
+        now = _now()
+        with get_conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO agentic_test_chat_sessions "
+                "(session_id, team_id, agent_name, session_name, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s)",
+                (session_id, team_id, agent_name, session_name, now, now),
+            )
+        return {
+            "session_id": session_id,
+            "team_id": team_id,
+            "agent_name": agent_name,
+            "session_name": session_name,
+            "created_at": now.isoformat(),
+            "updated_at": now.isoformat(),
+        }
+
+    @timed_query(store=_STORE, op="list_chat_sessions")
+    def list_chat_sessions(self, team_id: str, agent_name: Optional[str] = None) -> list[dict]:
+        sql = (
+            "SELECT session_id, team_id, agent_name, session_name, created_at, updated_at "
+            "FROM agentic_test_chat_sessions WHERE team_id = %s"
+        )
+        params: list[Any] = [team_id]
+        if agent_name:
+            sql += " AND agent_name = %s"
+            params.append(agent_name)
+        sql += " ORDER BY updated_at DESC"
+        with get_conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(sql, params)
+            rows = cur.fetchall()
+        return [
+            {**r, "created_at": _row_ts(r["created_at"]), "updated_at": _row_ts(r["updated_at"])}
+            for r in rows
+        ]
+
+    @timed_query(store=_STORE, op="get_chat_session")
+    def get_chat_session(self, session_id: str) -> Optional[dict]:
+        with get_conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                "SELECT session_id, team_id, agent_name, session_name, created_at, updated_at "
+                "FROM agentic_test_chat_sessions WHERE session_id = %s",
+                (session_id,),
+            )
+            row = cur.fetchone()
+        if not row:
+            return None
+        return {
+            **row,
+            "created_at": _row_ts(row["created_at"]),
+            "updated_at": _row_ts(row["updated_at"]),
+        }
+
+    @timed_query(store=_STORE, op="rename_chat_session")
+    def rename_chat_session(self, session_id: str, session_name: str) -> bool:
+        now = _now()
+        with get_conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "UPDATE agentic_test_chat_sessions SET session_name = %s, updated_at = %s "
+                "WHERE session_id = %s",
+                (session_name, now, session_id),
+            )
+            return cur.rowcount > 0
+
+    @timed_query(store=_STORE, op="delete_chat_session")
+    def delete_chat_session(self, session_id: str) -> bool:
+        with get_conn() as conn, conn.cursor() as cur:
+            # Messages cascade on delete via FK
+            cur.execute(
+                "DELETE FROM agentic_test_chat_sessions WHERE session_id = %s",
+                (session_id,),
+            )
+            return cur.rowcount > 0
+
+    # ------------------------------------------------------------------
+    # Chat messages
+    # ------------------------------------------------------------------
+
+    @timed_query(store=_STORE, op="create_chat_message")
+    def create_chat_message(
+        self, message_id: str, session_id: str, role: str, content: str
+    ) -> dict:
+        now = _now()
+        with get_conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO agentic_test_chat_messages "
+                "(message_id, session_id, role, content, created_at) "
+                "VALUES (%s, %s, %s, %s, %s)",
+                (message_id, session_id, role, content, now),
+            )
+            # Touch session updated_at
+            cur.execute(
+                "UPDATE agentic_test_chat_sessions SET updated_at = %s WHERE session_id = %s",
+                (now, session_id),
+            )
+        return {
+            "message_id": message_id,
+            "session_id": session_id,
+            "role": role,
+            "content": content,
+            "rating": None,
+            "created_at": now.isoformat(),
+        }
+
+    @timed_query(store=_STORE, op="list_chat_messages")
+    def list_chat_messages(self, session_id: str) -> list[dict]:
+        with get_conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                "SELECT message_id, session_id, role, content, rating, created_at "
+                "FROM agentic_test_chat_messages WHERE session_id = %s ORDER BY created_at",
+                (session_id,),
+            )
+            rows = cur.fetchall()
+        return [{**r, "created_at": _row_ts(r["created_at"])} for r in rows]
+
+    @timed_query(store=_STORE, op="update_message_rating")
+    def update_message_rating(self, message_id: str, rating: str) -> bool:
+        with get_conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "UPDATE agentic_test_chat_messages SET rating = %s WHERE message_id = %s",
+                (rating, message_id),
+            )
+            return cur.rowcount > 0
+
+    @timed_query(store=_STORE, op="get_agent_quality_scores")
+    def get_agent_quality_scores(self, team_id: str) -> list[dict]:
+        sql = """
+            SELECT s.agent_name,
+                   COUNT(m.message_id) FILTER (WHERE m.rating IS NOT NULL) AS total_rated,
+                   COUNT(m.message_id) FILTER (WHERE m.rating = 'thumbs_up') AS thumbs_up,
+                   COUNT(m.message_id) FILTER (WHERE m.rating = 'thumbs_down') AS thumbs_down
+            FROM agentic_test_chat_sessions s
+            JOIN agentic_test_chat_messages m ON m.session_id = s.session_id
+            WHERE s.team_id = %s AND m.role = 'assistant'
+            GROUP BY s.agent_name
+        """
+        with get_conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(sql, (team_id,))
+            rows = cur.fetchall()
+        results = []
+        for r in rows:
+            total = r["total_rated"] or 0
+            up = r["thumbs_up"] or 0
+            down = r["thumbs_down"] or 0
+            pct = (up / total * 100) if total > 0 else 0.0
+            results.append(
+                {
+                    "agent_name": r["agent_name"],
+                    "total_rated": total,
+                    "thumbs_up": up,
+                    "thumbs_down": down,
+                    "score_pct": round(pct, 1),
+                }
+            )
+        return results
+
+    # ------------------------------------------------------------------
+    # Pipeline runs
+    # ------------------------------------------------------------------
+
+    @timed_query(store=_STORE, op="create_pipeline_run")
+    def create_pipeline_run(
+        self, run_id: str, team_id: str, process_id: str, initial_input: Optional[str] = None
+    ) -> dict:
+        now = _now()
+        with get_conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "INSERT INTO agentic_test_pipeline_runs "
+                "(run_id, team_id, process_id, status, initial_input, step_results, started_at) "
+                "VALUES (%s, %s, %s, %s, %s, %s, %s)",
+                (run_id, team_id, process_id, "running", initial_input, Json([]), now),
+            )
+        return {
+            "run_id": run_id,
+            "team_id": team_id,
+            "process_id": process_id,
+            "status": "running",
+            "current_step_id": None,
+            "initial_input": initial_input,
+            "step_results": [],
+            "human_prompt": None,
+            "error": None,
+            "started_at": now.isoformat(),
+            "finished_at": None,
+        }
+
+    @timed_query(store=_STORE, op="get_pipeline_run")
+    def get_pipeline_run(self, run_id: str) -> Optional[dict]:
+        with get_conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                "SELECT run_id, team_id, process_id, status, current_step_id, "
+                "initial_input, step_results, human_prompt, error, started_at, finished_at "
+                "FROM agentic_test_pipeline_runs WHERE run_id = %s",
+                (run_id,),
+            )
+            row = cur.fetchone()
+        if not row:
+            return None
+        return {
+            **row,
+            "started_at": _row_ts(row["started_at"]),
+            "finished_at": _row_ts(row["finished_at"]) if row["finished_at"] else None,
+        }
+
+    @timed_query(store=_STORE, op="update_pipeline_run")
+    def update_pipeline_run(self, run_id: str, **fields: Any) -> bool:
+        if not fields:
+            return False
+        set_clauses = []
+        params: list[Any] = []
+        for key, val in fields.items():
+            if key == "step_results":
+                set_clauses.append("step_results = %s")
+                params.append(Json(val))
+            else:
+                set_clauses.append(f"{key} = %s")
+                params.append(val)
+        params.append(run_id)
+        sql = f"UPDATE agentic_test_pipeline_runs SET {', '.join(set_clauses)} WHERE run_id = %s"
+        with get_conn() as conn, conn.cursor() as cur:
+            cur.execute(sql, params)
+            return cur.rowcount > 0
+
+    @timed_query(store=_STORE, op="list_pipeline_runs")
+    def list_pipeline_runs(self, team_id: str, limit: int = 20) -> list[dict]:
+        with get_conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                "SELECT run_id, team_id, process_id, status, current_step_id, "
+                "initial_input, step_results, human_prompt, error, started_at, finished_at "
+                "FROM agentic_test_pipeline_runs WHERE team_id = %s "
+                "ORDER BY started_at DESC LIMIT %s",
+                (team_id, limit),
+            )
+            rows = cur.fetchall()
+        return [
+            {
+                **r,
+                "started_at": _row_ts(r["started_at"]),
+                "finished_at": _row_ts(r["finished_at"]) if r["finished_at"] else None,
+            }
+            for r in rows
+        ]
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton accessor
+# ---------------------------------------------------------------------------
+
+_default_store: Optional[AgenticTestStore] = None
+
+
+def get_test_store() -> AgenticTestStore:
+    global _default_store  # noqa: PLW0603
+    if _default_store is None:
+        _default_store = AgenticTestStore()
+    return _default_store

--- a/user-interface/src/app/components/agent-test-chat/agent-test-chat.component.html
+++ b/user-interface/src/app/components/agent-test-chat/agent-test-chat.component.html
@@ -1,0 +1,201 @@
+<div class="chat-layout">
+  <!-- Left sidebar: agent selector + quality + sessions -->
+  <div class="sidebar">
+    <mat-card class="sidebar-card">
+      <mat-card-header>
+        <mat-card-title>
+          <mat-icon>smart_toy</mat-icon>
+          Agent
+        </mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <!-- Agent selector -->
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Select Agent</mat-label>
+          <mat-select [value]="selectedAgent()?.agent_name" (selectionChange)="selectAgent(team.agents[$event.value])">
+            @for (agent of team.agents; track agent.agent_name; let i = $index) {
+              <mat-option [value]="i">{{ agent.agent_name }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+
+        <!-- Quality score -->
+        @if (selectedAgent(); as agent) {
+          @let score = getScoreForAgent(agent.agent_name);
+          <div class="quality-section">
+            <span class="quality-label">Quality</span>
+            @if (score && score.total_rated > 0) {
+              <div class="quality-badge" [class]="scoreColor(score)">
+                <span class="quality-pct">{{ score.score_pct | number:'1.0-0' }}% positive</span>
+                <span class="quality-count">{{ score.total_rated }} rated</span>
+              </div>
+              <div class="quality-bar">
+                <div class="quality-fill" [class]="scoreColor(score)" [style.width.%]="score.score_pct"></div>
+              </div>
+            } @else {
+              <div class="quality-badge neutral">
+                <span>No ratings yet</span>
+              </div>
+            }
+          </div>
+        }
+
+        <!-- Sessions -->
+        <div class="sessions-section">
+          <span class="sessions-label">Sessions</span>
+          @if (sessions().length === 0) {
+            <p class="no-sessions">No sessions yet</p>
+          } @else {
+            <div class="session-list">
+              @for (session of sessions(); track session.session_id) {
+                <div
+                  class="session-item"
+                  [class.active]="activeSession()?.session_id === session.session_id"
+                  (click)="openSession(session.session_id)"
+                  role="button"
+                  tabindex="0"
+                  (keydown.enter)="openSession(session.session_id)"
+                >
+                  @if (renamingSessionId() === session.session_id) {
+                    <form [formGroup]="renameForm" (ngSubmit)="confirmRename(session.session_id)" class="rename-form">
+                      <input
+                        matInput
+                        formControlName="name"
+                        (click)="$event.stopPropagation()"
+                        (keydown.escape)="cancelRename()"
+                        class="rename-input"
+                      />
+                      <button mat-icon-button type="submit" (click)="$event.stopPropagation()">
+                        <mat-icon>check</mat-icon>
+                      </button>
+                    </form>
+                  } @else {
+                    <span class="session-name">{{ session.session_name || formatTime(session.created_at) || 'New Session' }}</span>
+                    <button mat-icon-button (click)="$event.stopPropagation(); startRename(session)" matTooltip="Rename" class="session-action">
+                      <mat-icon>edit</mat-icon>
+                    </button>
+                    <button mat-icon-button (click)="$event.stopPropagation(); deleteSession(session.session_id)" matTooltip="Delete" class="session-action">
+                      <mat-icon>delete</mat-icon>
+                    </button>
+                  }
+                </div>
+              }
+            </div>
+          }
+          <button mat-stroked-button (click)="createSession()" class="new-session-btn">
+            <mat-icon>add</mat-icon> New Session
+          </button>
+          @if (activeSession()) {
+            <button mat-stroked-button (click)="exportSession()" class="export-btn">
+              <mat-icon>download</mat-icon> Export
+            </button>
+          }
+        </div>
+      </mat-card-content>
+    </mat-card>
+  </div>
+
+  <!-- Right panel: chat -->
+  <div class="chat-panel">
+    <mat-card class="chat-card">
+      @if (selectedAgent(); as agent) {
+        <mat-card-header>
+          <mat-card-title>
+            <mat-icon>smart_toy</mat-icon>
+            Chat: {{ agent.agent_name }}
+          </mat-card-title>
+        </mat-card-header>
+      }
+
+      <mat-card-content>
+        @if (error()) {
+          <p class="error-text">{{ error() }}</p>
+        }
+
+        @if (!selectedAgent()) {
+          <!-- Empty state: no agent selected -->
+          <div class="empty-state">
+            <mat-icon class="empty-icon">smart_toy</mat-icon>
+            <h3>Select an agent to start testing</h3>
+            <p>Choose an agent from the roster to evaluate their responses</p>
+          </div>
+        } @else if (!activeSession() && sessions().length === 0) {
+          <!-- Empty state: no sessions -->
+          <div class="empty-state">
+            <mat-icon class="empty-icon">chat</mat-icon>
+            <h3>Start chatting with {{ selectedAgent()!.agent_name }}</h3>
+            <p>Evaluate their responses and rate quality</p>
+            <button mat-raised-button color="primary" (click)="createSession()">Start Chat</button>
+          </div>
+        } @else {
+          <!-- Messages container -->
+          <div class="messages-container" #messagesContainer>
+            @for (msg of messages(); track msg.message_id) {
+              <div class="message" [class.user]="msg.role === 'user'" [class.assistant]="msg.role === 'assistant'">
+                <div class="message-content">{{ msg.content }}</div>
+                <div class="message-time">{{ formatTime(msg.created_at) }}</div>
+                @if (msg.role === 'assistant' && !msg.message_id.startsWith('temp-')) {
+                  <div class="rating-buttons">
+                    <button
+                      mat-icon-button
+                      (click)="rateMessage(msg.message_id, 'thumbs_up')"
+                      [class.active-up]="msg.rating === 'thumbs_up'"
+                      aria-label="Rate response as helpful"
+                    >
+                      <mat-icon>thumb_up</mat-icon>
+                    </button>
+                    <button
+                      mat-icon-button
+                      (click)="rateMessage(msg.message_id, 'thumbs_down')"
+                      [class.active-down]="msg.rating === 'thumbs_down'"
+                      aria-label="Rate response as unhelpful"
+                    >
+                      <mat-icon>thumb_down</mat-icon>
+                    </button>
+                  </div>
+                }
+              </div>
+            }
+
+            @if (loading()) {
+              <div class="message assistant">
+                <div class="typing-indicator">
+                  <span></span>
+                  <span></span>
+                  <span></span>
+                </div>
+              </div>
+            }
+          </div>
+
+          <!-- Input form -->
+          <form [formGroup]="form" (ngSubmit)="onSubmit()" class="input-form">
+            <mat-form-field appearance="outline" class="message-input">
+              <mat-label>Type your message...</mat-label>
+              <input
+                matInput
+                formControlName="message"
+                aria-label="Message input"
+                (keydown.enter)="$event.preventDefault(); onSubmit()"
+              />
+            </mat-form-field>
+            <button mat-fab color="primary" type="submit" [disabled]="form.invalid || loading()" aria-label="Send message">
+              <mat-icon>send</mat-icon>
+            </button>
+          </form>
+
+          <!-- Suggested starter prompts -->
+          @if (suggestedPrompts().length > 0 && messages().length === 0) {
+            <div class="suggested-prompts">
+              @for (prompt of suggestedPrompts(); track prompt) {
+                <button mat-stroked-button (click)="onSuggestedPrompt(prompt)" [disabled]="loading()">
+                  {{ prompt }}
+                </button>
+              }
+            </div>
+          }
+        }
+      </mat-card-content>
+    </mat-card>
+  </div>
+</div>

--- a/user-interface/src/app/components/agent-test-chat/agent-test-chat.component.scss
+++ b/user-interface/src/app/components/agent-test-chat/agent-test-chat.component.scss
@@ -1,0 +1,291 @@
+.chat-layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 16px;
+  min-height: 500px;
+}
+
+.sidebar-card, .chat-card {
+  background: #161b22;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  height: 100%;
+}
+
+.full-width {
+  width: 100%;
+}
+
+// Quality section
+.quality-section {
+  margin-bottom: 16px;
+}
+
+.quality-label, .sessions-label {
+  display: block;
+  font-size: 0.75rem;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 8px;
+}
+
+.quality-badge {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 6px 10px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+  margin-bottom: 6px;
+
+  &.good {
+    color: #3fb950;
+    background: rgba(63, 185, 80, 0.1);
+  }
+  &.ok {
+    color: #d29922;
+    background: rgba(210, 153, 34, 0.1);
+  }
+  &.poor {
+    color: #f85149;
+    background: rgba(248, 81, 73, 0.1);
+  }
+  &.neutral {
+    color: #8b949e;
+    background: rgba(255, 255, 255, 0.04);
+  }
+}
+
+.quality-bar {
+  height: 4px;
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.quality-fill {
+  height: 100%;
+  border-radius: 2px;
+  transition: width 0.3s ease;
+
+  &.good { background: #3fb950; }
+  &.ok { background: #d29922; }
+  &.poor { background: #f85149; }
+}
+
+// Sessions section
+.sessions-section {
+  margin-top: 16px;
+}
+
+.no-sessions {
+  color: #484f58;
+  font-size: 0.85rem;
+  margin: 8px 0;
+}
+
+.session-list {
+  max-height: 200px;
+  overflow-y: auto;
+  margin-bottom: 8px;
+}
+
+.session-item {
+  display: flex;
+  align-items: center;
+  padding: 6px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  gap: 4px;
+
+  &:hover { background: rgba(255, 255, 255, 0.04); }
+  &.active { background: rgba(88, 166, 255, 0.1); border: 1px solid rgba(88, 166, 255, 0.2); }
+
+  .session-name {
+    flex: 1;
+    font-size: 0.85rem;
+    color: #c9d1d9;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .session-action {
+    opacity: 0;
+    transition: opacity 0.15s;
+    width: 28px;
+    height: 28px;
+    mat-icon { font-size: 16px; width: 16px; height: 16px; }
+  }
+
+  &:hover .session-action { opacity: 0.6; }
+}
+
+.rename-form {
+  display: flex;
+  align-items: center;
+  flex: 1;
+}
+
+.rename-input {
+  flex: 1;
+  background: #0d1117;
+  border: 1px solid #58a6ff;
+  border-radius: 4px;
+  color: #f0f6fc;
+  padding: 4px 8px;
+  font-size: 0.85rem;
+  outline: none;
+}
+
+.new-session-btn, .export-btn {
+  width: 100%;
+  margin-top: 4px;
+  font-size: 0.8rem;
+}
+
+// Chat panel
+.messages-container {
+  height: 400px;
+  overflow-y: auto;
+  padding: 16px 0;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.message {
+  max-width: 80%;
+  padding: 12px 16px;
+  border-radius: 16px;
+  font-size: 0.9rem;
+  line-height: 1.5;
+
+  &.user {
+    align-self: flex-end;
+    background: linear-gradient(135deg, #1f6feb, #58a6ff);
+    color: #fff;
+    border-bottom-right-radius: 4px;
+  }
+
+  &.assistant {
+    align-self: flex-start;
+    background: #21262d;
+    color: #f0f6fc;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-bottom-left-radius: 4px;
+  }
+}
+
+.message-time {
+  font-size: 0.7rem;
+  color: #8b949e;
+  margin-top: 4px;
+}
+
+.rating-buttons {
+  display: flex;
+  gap: 4px;
+  margin-top: 4px;
+
+  button {
+    width: 32px;
+    height: 32px;
+    color: #484f58;
+
+    mat-icon {
+      font-size: 16px;
+      width: 16px;
+      height: 16px;
+    }
+
+    &.active-up {
+      color: #3fb950;
+      background: rgba(63, 185, 80, 0.1);
+    }
+
+    &.active-down {
+      color: #f85149;
+      background: rgba(248, 81, 73, 0.1);
+    }
+  }
+}
+
+.typing-indicator {
+  display: flex;
+  gap: 4px;
+  padding: 4px 0;
+
+  span {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: #484f58;
+    animation: typing 1.4s infinite ease-in-out both;
+
+    &:nth-child(1) { animation-delay: 0s; }
+    &:nth-child(2) { animation-delay: 0.2s; }
+    &:nth-child(3) { animation-delay: 0.4s; }
+  }
+}
+
+@keyframes typing {
+  0%, 80%, 100% { transform: scale(0.6); opacity: 0.4; }
+  40% { transform: scale(1); opacity: 1; }
+}
+
+.input-form {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 8px;
+
+  .message-input {
+    flex: 1;
+  }
+}
+
+.suggested-prompts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+
+  button {
+    font-size: 0.8rem;
+    text-align: left;
+  }
+}
+
+.error-text {
+  color: #f85149;
+  font-size: 0.85rem;
+  margin-bottom: 8px;
+}
+
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 24px;
+  text-align: center;
+
+  .empty-icon {
+    font-size: 48px;
+    width: 48px;
+    height: 48px;
+    color: #484f58;
+    margin-bottom: 16px;
+  }
+
+  h3 {
+    color: #f0f6fc;
+    margin: 0 0 8px;
+  }
+
+  p {
+    color: #8b949e;
+    margin: 0 0 16px;
+  }
+}

--- a/user-interface/src/app/components/agent-test-chat/agent-test-chat.component.ts
+++ b/user-interface/src/app/components/agent-test-chat/agent-test-chat.component.ts
@@ -65,6 +65,7 @@ export class AgentTestChatComponent implements OnInit, OnChanges, AfterViewCheck
   loading = signal(false);
   error = signal<string | null>(null);
   renamingSessionId = signal<string | null>(null);
+  private shouldAutoScroll = false;
 
   form = this.fb.nonNullable.group({
     message: ['', [Validators.required, Validators.minLength(1)]],
@@ -89,7 +90,10 @@ export class AgentTestChatComponent implements OnInit, OnChanges, AfterViewCheck
   }
 
   ngAfterViewChecked(): void {
-    this.scrollToBottom();
+    if (this.shouldAutoScroll) {
+      this.scrollToBottom();
+      this.shouldAutoScroll = false;
+    }
   }
 
   private scrollToBottom(): void {
@@ -123,6 +127,7 @@ export class AgentTestChatComponent implements OnInit, OnChanges, AfterViewCheck
       next: (detail) => {
         this.activeSession.set(detail.session);
         this.messages.set(detail.messages);
+        this.shouldAutoScroll = true;
         this.suggestedPrompts.set(detail.suggested_prompts);
       },
     });
@@ -231,6 +236,7 @@ export class AgentTestChatComponent implements OnInit, OnChanges, AfterViewCheck
         created_at: new Date().toISOString(),
       },
     ]);
+    this.shouldAutoScroll = true;
     this.loading.set(true);
     this.error.set(null);
     this.suggestedPrompts.set([]);
@@ -238,6 +244,7 @@ export class AgentTestChatComponent implements OnInit, OnChanges, AfterViewCheck
     this.api.sendTestChatMessage(this.team.team_id, sessionId, content).subscribe({
       next: (res) => {
         this.messages.set(res.messages);
+        this.shouldAutoScroll = true;
         this.loading.set(false);
       },
       error: (err) => {

--- a/user-interface/src/app/components/agent-test-chat/agent-test-chat.component.ts
+++ b/user-interface/src/app/components/agent-test-chat/agent-test-chat.component.ts
@@ -1,0 +1,280 @@
+import {
+  Component,
+  Input,
+  Output,
+  EventEmitter,
+  OnInit,
+  OnChanges,
+  SimpleChanges,
+  ViewChild,
+  ElementRef,
+  AfterViewChecked,
+  inject,
+  signal,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSelectModule } from '@angular/material/select';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { AgenticTeamApiService } from '../../services/agentic-team-api.service';
+import type {
+  AgenticTeam,
+  AgenticTeamAgent,
+  AgentQualityScore,
+  TestChatSession,
+  TestChatMessage,
+} from '../../models';
+
+@Component({
+  selector: 'app-agent-test-chat',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatSelectModule,
+    MatTooltipModule,
+  ],
+  templateUrl: './agent-test-chat.component.html',
+  styleUrl: './agent-test-chat.component.scss',
+})
+export class AgentTestChatComponent implements OnInit, OnChanges, AfterViewChecked {
+  @Input() team!: AgenticTeam;
+  @Input() qualityScores: AgentQualityScore[] = [];
+  @Output() scoresChanged = new EventEmitter<void>();
+
+  @ViewChild('messagesContainer') messagesContainer!: ElementRef<HTMLDivElement>;
+
+  private readonly api = inject(AgenticTeamApiService);
+  private readonly fb = inject(FormBuilder);
+
+  selectedAgent = signal<AgenticTeamAgent | null>(null);
+  sessions = signal<TestChatSession[]>([]);
+  activeSession = signal<TestChatSession | null>(null);
+  messages = signal<TestChatMessage[]>([]);
+  suggestedPrompts = signal<string[]>([]);
+  loading = signal(false);
+  error = signal<string | null>(null);
+  renamingSessionId = signal<string | null>(null);
+
+  form = this.fb.nonNullable.group({
+    message: ['', [Validators.required, Validators.minLength(1)]],
+  });
+
+  renameForm = this.fb.nonNullable.group({
+    name: ['', [Validators.required, Validators.minLength(1)]],
+  });
+
+  ngOnInit(): void {
+    if (this.team.agents.length > 0) {
+      this.selectAgent(this.team.agents[0]);
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['team'] && !changes['team'].firstChange) {
+      if (this.team.agents.length > 0) {
+        this.selectAgent(this.team.agents[0]);
+      }
+    }
+  }
+
+  ngAfterViewChecked(): void {
+    this.scrollToBottom();
+  }
+
+  private scrollToBottom(): void {
+    if (this.messagesContainer?.nativeElement) {
+      const el = this.messagesContainer.nativeElement;
+      el.scrollTop = el.scrollHeight;
+    }
+  }
+
+  selectAgent(agent: AgenticTeamAgent): void {
+    this.selectedAgent.set(agent);
+    this.activeSession.set(null);
+    this.messages.set([]);
+    this.suggestedPrompts.set([]);
+    this.loadSessions(agent.agent_name);
+  }
+
+  private loadSessions(agentName: string): void {
+    this.api.listTestChatSessions(this.team.team_id, agentName).subscribe({
+      next: (sessions) => {
+        this.sessions.set(sessions);
+        if (sessions.length > 0) {
+          this.openSession(sessions[0].session_id);
+        }
+      },
+    });
+  }
+
+  openSession(sessionId: string): void {
+    this.api.getTestChatSession(this.team.team_id, sessionId).subscribe({
+      next: (detail) => {
+        this.activeSession.set(detail.session);
+        this.messages.set(detail.messages);
+        this.suggestedPrompts.set(detail.suggested_prompts);
+      },
+    });
+  }
+
+  createSession(): void {
+    const agent = this.selectedAgent();
+    if (!agent) return;
+    this.api.createTestChatSession(this.team.team_id, agent.agent_name).subscribe({
+      next: (session) => {
+        this.sessions.update((s) => [session, ...s]);
+        this.openSession(session.session_id);
+      },
+    });
+  }
+
+  deleteSession(sessionId: string): void {
+    this.api.deleteTestChatSession(this.team.team_id, sessionId).subscribe({
+      next: () => {
+        this.sessions.update((s) => s.filter((ss) => ss.session_id !== sessionId));
+        if (this.activeSession()?.session_id === sessionId) {
+          this.activeSession.set(null);
+          this.messages.set([]);
+          this.suggestedPrompts.set([]);
+        }
+      },
+    });
+  }
+
+  startRename(session: TestChatSession): void {
+    this.renamingSessionId.set(session.session_id);
+    this.renameForm.reset({ name: session.session_name || '' });
+  }
+
+  confirmRename(sessionId: string): void {
+    const name = this.renameForm.getRawValue().name.trim();
+    if (!name) return;
+    this.api.renameTestChatSession(this.team.team_id, sessionId, name).subscribe({
+      next: () => {
+        this.sessions.update((s) =>
+          s.map((ss) => (ss.session_id === sessionId ? { ...ss, session_name: name } : ss)),
+        );
+        this.renamingSessionId.set(null);
+      },
+    });
+  }
+
+  cancelRename(): void {
+    this.renamingSessionId.set(null);
+  }
+
+  exportSession(): void {
+    const session = this.activeSession();
+    if (!session) return;
+    this.api.exportTestChatSession(this.team.team_id, session.session_id).subscribe({
+      next: (blob) => {
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `${session.session_name || session.agent_name}-chat.md`;
+        a.click();
+        URL.revokeObjectURL(url);
+      },
+    });
+  }
+
+  onSubmit(): void {
+    if (this.form.invalid || this.loading()) return;
+    const message = this.form.getRawValue().message.trim();
+    if (!message) return;
+    this.sendMessage(message);
+  }
+
+  onSuggestedPrompt(prompt: string): void {
+    this.sendMessage(prompt);
+  }
+
+  private sendMessage(content: string): void {
+    let session = this.activeSession();
+    if (!session) {
+      // Auto-create session on first message
+      const agent = this.selectedAgent();
+      if (!agent) return;
+      this.api.createTestChatSession(this.team.team_id, agent.agent_name).subscribe({
+        next: (newSession) => {
+          this.sessions.update((s) => [newSession, ...s]);
+          this.activeSession.set(newSession);
+          this._sendToSession(newSession.session_id, content);
+        },
+      });
+      return;
+    }
+    this._sendToSession(session.session_id, content);
+  }
+
+  private _sendToSession(sessionId: string, content: string): void {
+    this.form.reset({ message: '' });
+    this.messages.update((msgs) => [
+      ...msgs,
+      {
+        message_id: `temp-${Date.now()}`,
+        session_id: sessionId,
+        role: 'user' as const,
+        content,
+        rating: null,
+        created_at: new Date().toISOString(),
+      },
+    ]);
+    this.loading.set(true);
+    this.error.set(null);
+    this.suggestedPrompts.set([]);
+
+    this.api.sendTestChatMessage(this.team.team_id, sessionId, content).subscribe({
+      next: (res) => {
+        this.messages.set(res.messages);
+        this.loading.set(false);
+      },
+      error: (err) => {
+        this.error.set(err?.error?.detail ?? 'Failed to send message');
+        this.loading.set(false);
+      },
+    });
+  }
+
+  rateMessage(messageId: string, rating: 'thumbs_up' | 'thumbs_down'): void {
+    this.api.rateTestChatMessage(this.team.team_id, messageId, rating).subscribe({
+      next: () => {
+        this.messages.update((msgs) =>
+          msgs.map((m) => (m.message_id === messageId ? { ...m, rating } : m)),
+        );
+        this.scoresChanged.emit();
+      },
+    });
+  }
+
+  getScoreForAgent(agentName: string): AgentQualityScore | undefined {
+    return this.qualityScores.find((s) => s.agent_name === agentName);
+  }
+
+  scoreColor(score: AgentQualityScore | undefined): string {
+    if (!score || score.total_rated === 0) return 'neutral';
+    if (score.score_pct > 70) return 'good';
+    if (score.score_pct >= 40) return 'ok';
+    return 'poor';
+  }
+
+  formatTime(timestamp: string): string {
+    if (!timestamp) return '';
+    try {
+      return new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    } catch {
+      return '';
+    }
+  }
+}

--- a/user-interface/src/app/components/agent-test-chat/agent-test-chat.component.ts
+++ b/user-interface/src/app/components/agent-test-chat/agent-test-chat.component.ts
@@ -206,7 +206,7 @@ export class AgentTestChatComponent implements OnInit, OnChanges, AfterViewCheck
   }
 
   private sendMessage(content: string): void {
-    let session = this.activeSession();
+    const session = this.activeSession();
     if (!session) {
       // Auto-create session on first message
       const agent = this.selectedAgent();

--- a/user-interface/src/app/components/agentic-team-dashboard/agentic-team-dashboard.component.html
+++ b/user-interface/src/app/components/agentic-team-dashboard/agentic-team-dashboard.component.html
@@ -27,7 +27,20 @@
     </mat-chip-set>
   </div>
 
-  <app-process-designer-chat [team]="team" />
+  <mat-button-toggle-group [value]="viewMode()" (change)="onModeChange($event.value)" class="mode-toggle">
+    <mat-button-toggle value="development">
+      <mat-icon>design_services</mat-icon> Design
+    </mat-button-toggle>
+    <mat-button-toggle value="testing">
+      <mat-icon>science</mat-icon> Test
+    </mat-button-toggle>
+  </mat-button-toggle-group>
+
+  @if (viewMode() === 'development') {
+    <app-process-designer-chat [team]="team" />
+  } @else {
+    <app-agentic-team-test-panel [team]="team" />
+  }
 
 } @else {
 

--- a/user-interface/src/app/components/agentic-team-dashboard/agentic-team-dashboard.component.scss
+++ b/user-interface/src/app/components/agentic-team-dashboard/agentic-team-dashboard.component.scss
@@ -152,3 +152,17 @@
     }
   }
 }
+
+.mode-toggle {
+  margin-bottom: 16px;
+
+  mat-button-toggle {
+    mat-icon {
+      margin-right: 4px;
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+      vertical-align: middle;
+    }
+  }
+}

--- a/user-interface/src/app/components/agentic-team-dashboard/agentic-team-dashboard.component.ts
+++ b/user-interface/src/app/components/agentic-team-dashboard/agentic-team-dashboard.component.ts
@@ -8,10 +8,12 @@ import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
 import { MatListModule } from '@angular/material/list';
 import { MatChipsModule } from '@angular/material/chips';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { AgenticTeamApiService } from '../../services/agentic-team-api.service';
 import { ProcessDesignerChatComponent } from '../process-designer-chat/process-designer-chat.component';
+import { AgenticTeamTestPanelComponent } from '../agentic-team-test-panel/agentic-team-test-panel.component';
 import { DashboardShellComponent } from '../../shared/dashboard-shell/dashboard-shell.component';
-import type { AgenticTeamSummary, AgenticTeam } from '../../models';
+import type { AgenticTeamSummary, AgenticTeam, TeamMode } from '../../models';
 
 @Component({
   selector: 'app-agentic-team-dashboard',
@@ -26,7 +28,9 @@ import type { AgenticTeamSummary, AgenticTeam } from '../../models';
     MatIconModule,
     MatListModule,
     MatChipsModule,
+    MatButtonToggleModule,
     ProcessDesignerChatComponent,
+    AgenticTeamTestPanelComponent,
     DashboardShellComponent,
   ],
   templateUrl: './agentic-team-dashboard.component.html',
@@ -38,6 +42,7 @@ export class AgenticTeamDashboardComponent implements OnInit {
 
   teams = signal<AgenticTeamSummary[]>([]);
   selectedTeam = signal<AgenticTeam | null>(null);
+  viewMode = signal<TeamMode>('development');
   showCreateForm = signal(false);
   creating = signal(false);
   error = signal<string | null>(null);
@@ -87,8 +92,20 @@ export class AgenticTeamDashboardComponent implements OnInit {
 
   selectTeam(teamId: string): void {
     this.api.getTeam(teamId).subscribe({
-      next: (res) => this.selectedTeam.set(res.team),
+      next: (res) => {
+        this.selectedTeam.set(res.team);
+        this.viewMode.set(res.team.mode ?? 'development');
+      },
       error: (err) => this.error.set(err?.error?.detail ?? 'Failed to load team'),
+    });
+  }
+
+  onModeChange(newMode: TeamMode): void {
+    const team = this.selectedTeam();
+    if (!team) return;
+    this.viewMode.set(newMode);
+    this.api.setTeamMode(team.team_id, newMode).subscribe({
+      error: (err) => this.error.set(err?.error?.detail ?? 'Failed to change mode'),
     });
   }
 

--- a/user-interface/src/app/components/agentic-team-test-panel/agentic-team-test-panel.component.html
+++ b/user-interface/src/app/components/agentic-team-test-panel/agentic-team-test-panel.component.html
@@ -1,0 +1,20 @@
+<div class="test-panel">
+  <mat-button-toggle-group [value]="activeTab()" (change)="activeTab.set($event.value)" class="tab-toggle">
+    <mat-button-toggle value="chat">
+      <mat-icon>chat</mat-icon> Chat with Agent
+    </mat-button-toggle>
+    <mat-button-toggle value="pipeline">
+      <mat-icon>play_arrow</mat-icon> Run Pipeline
+    </mat-button-toggle>
+  </mat-button-toggle-group>
+
+  @if (activeTab() === 'chat') {
+    <app-agent-test-chat
+      [team]="team"
+      [qualityScores]="qualityScores()"
+      (scoresChanged)="loadQualityScores()"
+    />
+  } @else {
+    <app-pipeline-test-runner [team]="team" />
+  }
+</div>

--- a/user-interface/src/app/components/agentic-team-test-panel/agentic-team-test-panel.component.scss
+++ b/user-interface/src/app/components/agentic-team-test-panel/agentic-team-test-panel.component.scss
@@ -1,0 +1,17 @@
+.test-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.tab-toggle {
+  mat-button-toggle {
+    mat-icon {
+      margin-right: 4px;
+      font-size: 18px;
+      width: 18px;
+      height: 18px;
+      vertical-align: middle;
+    }
+  }
+}

--- a/user-interface/src/app/components/agentic-team-test-panel/agentic-team-test-panel.component.ts
+++ b/user-interface/src/app/components/agentic-team-test-panel/agentic-team-test-panel.component.ts
@@ -1,0 +1,41 @@
+import { Component, Input, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonToggleModule } from '@angular/material/button-toggle';
+import { MatIconModule } from '@angular/material/icon';
+import { AgenticTeamApiService } from '../../services/agentic-team-api.service';
+import { AgentTestChatComponent } from '../agent-test-chat/agent-test-chat.component';
+import { PipelineTestRunnerComponent } from '../pipeline-test-runner/pipeline-test-runner.component';
+import type { AgenticTeam, AgentQualityScore } from '../../models';
+
+@Component({
+  selector: 'app-agentic-team-test-panel',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatButtonToggleModule,
+    MatIconModule,
+    AgentTestChatComponent,
+    PipelineTestRunnerComponent,
+  ],
+  templateUrl: './agentic-team-test-panel.component.html',
+  styleUrl: './agentic-team-test-panel.component.scss',
+})
+export class AgenticTeamTestPanelComponent {
+  @Input() team!: AgenticTeam;
+
+  private readonly api = inject(AgenticTeamApiService);
+
+  activeTab = signal<'chat' | 'pipeline'>('chat');
+  qualityScores = signal<AgentQualityScore[]>([]);
+
+  ngOnInit(): void {
+    this.loadQualityScores();
+  }
+
+  loadQualityScores(): void {
+    if (!this.team) return;
+    this.api.getAgentQualityScores(this.team.team_id).subscribe({
+      next: (scores) => this.qualityScores.set(scores),
+    });
+  }
+}

--- a/user-interface/src/app/components/agentic-team-test-panel/agentic-team-test-panel.component.ts
+++ b/user-interface/src/app/components/agentic-team-test-panel/agentic-team-test-panel.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input, inject, signal } from '@angular/core';
+import { Component, Input, OnInit, inject, signal } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { MatButtonToggleModule } from '@angular/material/button-toggle';
 import { MatIconModule } from '@angular/material/icon';
@@ -20,7 +20,7 @@ import type { AgenticTeam, AgentQualityScore } from '../../models';
   templateUrl: './agentic-team-test-panel.component.html',
   styleUrl: './agentic-team-test-panel.component.scss',
 })
-export class AgenticTeamTestPanelComponent {
+export class AgenticTeamTestPanelComponent implements OnInit {
   @Input() team!: AgenticTeam;
 
   private readonly api = inject(AgenticTeamApiService);

--- a/user-interface/src/app/components/pipeline-test-runner/pipeline-test-runner.component.html
+++ b/user-interface/src/app/components/pipeline-test-runner/pipeline-test-runner.component.html
@@ -1,0 +1,190 @@
+<div class="pipeline-layout">
+  <!-- Left sidebar: process selector + run controls + history -->
+  <div class="sidebar">
+    <mat-card class="sidebar-card">
+      <mat-card-header>
+        <mat-card-title>
+          <mat-icon>account_tree</mat-icon>
+          Pipeline
+        </mat-card-title>
+      </mat-card-header>
+      <mat-card-content>
+        <!-- Process selector -->
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Process</mat-label>
+          <mat-select [value]="selectedProcessId()" (selectionChange)="selectedProcessId.set($event.value)">
+            @for (process of team.processes; track process.process_id) {
+              <mat-option [value]="process.process_id">{{ process.name || 'Untitled' }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+
+        <!-- Initial input -->
+        <mat-form-field appearance="outline" class="full-width">
+          <mat-label>Initial Input (optional)</mat-label>
+          <textarea
+            matInput
+            [value]="initialInput()"
+            (input)="initialInput.set($any($event.target).value)"
+            rows="3"
+            placeholder="Describe the scenario or trigger context..."
+          ></textarea>
+        </mat-form-field>
+
+        <!-- Run controls -->
+        <button
+          mat-raised-button
+          color="primary"
+          (click)="startRun()"
+          [disabled]="!selectedProcessId() || (activeRun() && !['completed', 'failed', 'cancelled'].includes(activeRun()!.status))"
+          class="full-width run-btn"
+        >
+          <mat-icon>play_arrow</mat-icon> Start Run
+        </button>
+
+        @if (activeRun(); as run) {
+          @if (run.status === 'running' || run.status === 'waiting_for_input') {
+            <button mat-stroked-button color="warn" (click)="cancelRun()" class="full-width cancel-btn">
+              <mat-icon>cancel</mat-icon> Cancel Run
+            </button>
+          }
+        }
+
+        <!-- Run history -->
+        <div class="runs-section">
+          <span class="runs-label">Run History</span>
+          @if (runs().length === 0) {
+            <p class="no-runs">No runs yet</p>
+          } @else {
+            <div class="runs-list">
+              @for (run of runs(); track run.run_id) {
+                <div
+                  class="run-item"
+                  [class.active]="activeRun()?.run_id === run.run_id"
+                  (click)="selectRun(run)"
+                  role="button"
+                  tabindex="0"
+                  (keydown.enter)="selectRun(run)"
+                >
+                  <mat-icon [class]="getStatusChipClass(run.status)">{{ getStepIcon(run.status) }}</mat-icon>
+                  <span class="run-time">{{ run.started_at | date:'short' }}</span>
+                </div>
+              }
+            </div>
+          }
+        </div>
+      </mat-card-content>
+    </mat-card>
+  </div>
+
+  <!-- Right panel: step progress -->
+  <div class="run-panel">
+    <mat-card class="run-card">
+      @if (activeRun(); as run) {
+        <mat-card-header>
+          <mat-card-title>
+            <mat-icon>play_circle</mat-icon>
+            Pipeline Run
+          </mat-card-title>
+          <span class="spacer"></span>
+          <mat-chip [class]="getStatusChipClass(run.status)">
+            {{ run.status.replace('_', ' ') | uppercase }}
+          </mat-chip>
+          @if (run.started_at) {
+            <span class="duration">{{ formatDuration(run) }}</span>
+          }
+        </mat-card-header>
+
+        <mat-card-content>
+          @if (error()) {
+            <p class="error-text">{{ error() }}</p>
+          }
+
+          <div class="step-list">
+            @for (step of getProcessSteps(); track step.step_id) {
+              @let result = getStepResult(step.step_id);
+              @let status = result?.status ?? 'pending';
+
+              <div class="step-card" [class]="getStepIconClass(status)">
+                <div class="step-header" (click)="toggleStep(step.step_id)" role="button" tabindex="0" (keydown.enter)="toggleStep(step.step_id)">
+                  <mat-icon [class]="getStepIconClass(status)">{{ getStepIcon(status) }}</mat-icon>
+                  <div class="step-info">
+                    <span class="step-name">{{ step.name }}</span>
+                    @if (step.agent_name) {
+                      <span class="step-agent">{{ step.agent_name }}</span>
+                    }
+                  </div>
+                  @if (result?.output) {
+                    <mat-icon class="expand-icon">
+                      {{ expandedStepId() === step.step_id ? 'expand_less' : 'expand_more' }}
+                    </mat-icon>
+                  }
+                </div>
+
+                <!-- WAIT step input form -->
+                @if (status === 'waiting_for_input' && run.status === 'waiting_for_input') {
+                  <div class="wait-input-card">
+                    <p class="wait-prompt">{{ run.human_prompt }}</p>
+                    <form [formGroup]="waitInputForm" (ngSubmit)="submitWaitInput()">
+                      <mat-form-field appearance="outline" class="full-width">
+                        <mat-label>Your input</mat-label>
+                        <textarea matInput formControlName="input" rows="3"></textarea>
+                      </mat-form-field>
+                      <button mat-raised-button color="primary" type="submit" [disabled]="waitInputForm.invalid">
+                        Submit & Continue
+                      </button>
+                    </form>
+                  </div>
+                }
+
+                <!-- Expanded output -->
+                @if (expandedStepId() === step.step_id && result?.output) {
+                  <div class="step-output">
+                    <pre>{{ result.output }}</pre>
+                  </div>
+                }
+
+                <!-- One-line summary when collapsed -->
+                @if (expandedStepId() !== step.step_id && result?.output && status === 'completed') {
+                  <div class="step-summary">{{ result.output | slice:0:120 }}{{ result.output.length > 120 ? '...' : '' }}</div>
+                }
+
+                <!-- Error display -->
+                @if (status === 'failed' && result) {
+                  <div class="step-error">
+                    {{ result.output || 'Step failed' }}
+                  </div>
+                }
+              </div>
+            }
+          </div>
+
+          <!-- Final output for completed runs -->
+          @if (run.status === 'completed' && run.step_results.length > 0) {
+            <div class="final-output">
+              <h4><mat-icon>output</mat-icon> Final Output</h4>
+              <pre>{{ run.step_results[run.step_results.length - 1].output }}</pre>
+            </div>
+          }
+
+          <!-- Error for failed runs -->
+          @if (run.status === 'failed' && run.error) {
+            <div class="run-error">
+              <mat-icon>error</mat-icon>
+              <span>{{ run.error }}</span>
+            </div>
+          }
+        </mat-card-content>
+      } @else {
+        <!-- Empty state -->
+        <mat-card-content>
+          <div class="empty-state">
+            <mat-icon class="empty-icon">play_circle</mat-icon>
+            <h3>Run the pipeline to test the full agent workflow</h3>
+            <p>Select a process and click Start Run to see agents work through each step</p>
+          </div>
+        </mat-card-content>
+      }
+    </mat-card>
+  </div>
+</div>

--- a/user-interface/src/app/components/pipeline-test-runner/pipeline-test-runner.component.html
+++ b/user-interface/src/app/components/pipeline-test-runner/pipeline-test-runner.component.html
@@ -140,13 +140,13 @@
                 <!-- Expanded output -->
                 @if (expandedStepId() === step.step_id && result?.output) {
                   <div class="step-output">
-                    <pre>{{ result.output }}</pre>
+                    <pre>{{ result!.output }}</pre>
                   </div>
                 }
 
                 <!-- One-line summary when collapsed -->
                 @if (expandedStepId() !== step.step_id && result?.output && status === 'completed') {
-                  <div class="step-summary">{{ result.output | slice:0:120 }}{{ result.output.length > 120 ? '...' : '' }}</div>
+                  <div class="step-summary">{{ result!.output | slice:0:120 }}{{ result!.output.length > 120 ? '...' : '' }}</div>
                 }
 
                 <!-- Error display -->

--- a/user-interface/src/app/components/pipeline-test-runner/pipeline-test-runner.component.scss
+++ b/user-interface/src/app/components/pipeline-test-runner/pipeline-test-runner.component.scss
@@ -1,0 +1,262 @@
+.pipeline-layout {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: 16px;
+  min-height: 500px;
+}
+
+.sidebar-card, .run-card {
+  background: #161b22;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  height: 100%;
+}
+
+.full-width { width: 100%; }
+
+.run-btn {
+  margin-bottom: 8px;
+}
+
+.cancel-btn {
+  margin-bottom: 8px;
+}
+
+// Run history
+.runs-section {
+  margin-top: 16px;
+}
+
+.runs-label {
+  display: block;
+  font-size: 0.75rem;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin-bottom: 8px;
+}
+
+.no-runs {
+  color: #484f58;
+  font-size: 0.85rem;
+}
+
+.runs-list {
+  max-height: 200px;
+  overflow-y: auto;
+}
+
+.run-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  color: #c9d1d9;
+
+  &:hover { background: rgba(255, 255, 255, 0.04); }
+  &.active { background: rgba(88, 166, 255, 0.1); border: 1px solid rgba(88, 166, 255, 0.2); }
+
+  .run-time { flex: 1; }
+}
+
+// Header
+.spacer { flex: 1; }
+
+.duration {
+  font-size: 0.8rem;
+  color: #8b949e;
+  margin-left: 8px;
+}
+
+// Status classes
+.status-completed { color: #3fb950 !important; background: rgba(63, 185, 80, 0.1); }
+.status-running { color: #58a6ff !important; background: rgba(88, 166, 255, 0.1); }
+.status-waiting { color: #d29922 !important; background: rgba(210, 153, 34, 0.1); }
+.status-failed { color: #f85149 !important; background: rgba(248, 81, 73, 0.1); }
+.status-cancelled { color: #8b949e !important; background: rgba(255, 255, 255, 0.04); }
+
+// Step list
+.step-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin: 16px 0;
+}
+
+.step-card {
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  background: #0d1117;
+  overflow: hidden;
+
+  &.step-waiting {
+    border-color: #d29922;
+    background: rgba(210, 153, 34, 0.06);
+  }
+
+  &.step-failed {
+    border-color: #f85149;
+  }
+}
+
+.step-header {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 16px;
+  cursor: pointer;
+
+  &:hover { background: rgba(255, 255, 255, 0.02); }
+}
+
+.step-info {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.step-name {
+  font-size: 0.9rem;
+  color: #f0f6fc;
+}
+
+.step-agent {
+  font-size: 0.75rem;
+  color: #8b949e;
+}
+
+.expand-icon {
+  color: #484f58;
+}
+
+// Step icon status colors
+.step-completed { color: #3fb950; }
+.step-running {
+  color: #58a6ff;
+  animation: spin 1.5s linear infinite;
+}
+.step-waiting { color: #d29922; }
+.step-failed { color: #f85149; }
+.step-cancelled { color: #8b949e; }
+.step-pending { color: #484f58; }
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+// WAIT step input
+.wait-input-card {
+  padding: 12px 16px;
+  border-top: 1px solid rgba(210, 153, 34, 0.2);
+}
+
+.wait-prompt {
+  color: #c9d1d9;
+  font-size: 0.9rem;
+  margin: 0 0 12px;
+}
+
+// Step output
+.step-output {
+  padding: 12px 16px;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+
+  pre {
+    margin: 0;
+    white-space: pre-wrap;
+    font-size: 0.8rem;
+    color: #c9d1d9;
+    line-height: 1.5;
+  }
+}
+
+.step-summary {
+  padding: 4px 16px 12px;
+  font-size: 0.8rem;
+  color: #8b949e;
+}
+
+.step-error {
+  padding: 8px 16px;
+  border-top: 1px solid rgba(248, 81, 73, 0.2);
+  color: #f85149;
+  font-size: 0.85rem;
+}
+
+// Final output
+.final-output {
+  border: 1px solid rgba(63, 185, 80, 0.2);
+  background: rgba(63, 185, 80, 0.06);
+  border-radius: 8px;
+  padding: 16px;
+  margin-top: 16px;
+
+  h4 {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    color: #3fb950;
+    margin: 0 0 8px;
+    font-size: 0.9rem;
+  }
+
+  pre {
+    margin: 0;
+    white-space: pre-wrap;
+    color: #c9d1d9;
+    font-size: 0.85rem;
+    line-height: 1.5;
+  }
+}
+
+// Run error
+.run-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 12px;
+  border: 1px solid #f85149;
+  background: rgba(248, 81, 73, 0.06);
+  border-radius: 8px;
+  margin-top: 16px;
+  color: #f0f6fc;
+  font-size: 0.85rem;
+
+  mat-icon { color: #f85149; }
+}
+
+.error-text {
+  color: #f85149;
+  font-size: 0.85rem;
+}
+
+// Empty state
+.empty-state {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 24px;
+  text-align: center;
+
+  .empty-icon {
+    font-size: 48px;
+    width: 48px;
+    height: 48px;
+    color: #484f58;
+    margin-bottom: 16px;
+  }
+
+  h3 {
+    color: #f0f6fc;
+    margin: 0 0 8px;
+  }
+
+  p {
+    color: #8b949e;
+    margin: 0;
+  }
+}

--- a/user-interface/src/app/components/pipeline-test-runner/pipeline-test-runner.component.ts
+++ b/user-interface/src/app/components/pipeline-test-runner/pipeline-test-runner.component.ts
@@ -1,0 +1,219 @@
+import {
+  Component,
+  Input,
+  OnDestroy,
+  inject,
+  signal,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatCardModule } from '@angular/material/card';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule } from '@angular/material/icon';
+import { MatSelectModule } from '@angular/material/select';
+import { MatChipsModule } from '@angular/material/chips';
+import { Subscription, interval, switchMap, takeWhile } from 'rxjs';
+import { AgenticTeamApiService } from '../../services/agentic-team-api.service';
+import type {
+  AgenticTeam,
+  ProcessDefinition,
+  TestPipelineRun,
+  PipelineStepResult,
+} from '../../models';
+
+@Component({
+  selector: 'app-pipeline-test-runner',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatSelectModule,
+    MatChipsModule,
+  ],
+  templateUrl: './pipeline-test-runner.component.html',
+  styleUrl: './pipeline-test-runner.component.scss',
+})
+export class PipelineTestRunnerComponent implements OnDestroy {
+  @Input() team!: AgenticTeam;
+
+  private readonly api = inject(AgenticTeamApiService);
+  private readonly fb = inject(FormBuilder);
+
+  selectedProcessId = signal<string | null>(null);
+  initialInput = signal('');
+  activeRun = signal<TestPipelineRun | null>(null);
+  runs = signal<TestPipelineRun[]>([]);
+  expandedStepId = signal<string | null>(null);
+  error = signal<string | null>(null);
+
+  waitInputForm = this.fb.nonNullable.group({
+    input: ['', [Validators.required, Validators.minLength(1)]],
+  });
+
+  private pollSub: Subscription | null = null;
+
+  ngOnInit(): void {
+    if (this.team.processes.length > 0) {
+      this.selectedProcessId.set(this.team.processes[0].process_id);
+    }
+    this.loadRuns();
+  }
+
+  ngOnDestroy(): void {
+    this.stopPolling();
+  }
+
+  loadRuns(): void {
+    this.api.listPipelineRuns(this.team.team_id).subscribe({
+      next: (runs) => this.runs.set(runs),
+    });
+  }
+
+  startRun(): void {
+    const processId = this.selectedProcessId();
+    if (!processId) return;
+
+    const input = this.initialInput().trim() || undefined;
+    this.api.startPipelineRun(this.team.team_id, processId, input).subscribe({
+      next: (run) => {
+        this.activeRun.set(run);
+        this.runs.update((r) => [run, ...r]);
+        this.startPolling(run.run_id);
+      },
+      error: (err) => this.error.set(err?.error?.detail ?? 'Failed to start run'),
+    });
+  }
+
+  cancelRun(): void {
+    const run = this.activeRun();
+    if (!run) return;
+    this.api.cancelPipelineRun(this.team.team_id, run.run_id).subscribe({
+      next: (updated) => {
+        this.activeRun.set(updated);
+        this.updateRunInList(updated);
+        this.stopPolling();
+      },
+    });
+  }
+
+  submitWaitInput(): void {
+    const run = this.activeRun();
+    if (!run || this.waitInputForm.invalid) return;
+    const input = this.waitInputForm.getRawValue().input.trim();
+    this.api.submitPipelineInput(this.team.team_id, run.run_id, input).subscribe({
+      next: (updated) => {
+        this.activeRun.set(updated);
+        this.updateRunInList(updated);
+        this.waitInputForm.reset({ input: '' });
+      },
+    });
+  }
+
+  selectRun(run: TestPipelineRun): void {
+    this.activeRun.set(run);
+    if (this.isTerminal(run.status)) {
+      this.stopPolling();
+    } else {
+      this.startPolling(run.run_id);
+    }
+  }
+
+  toggleStep(stepId: string): void {
+    this.expandedStepId.update((cur) => (cur === stepId ? null : stepId));
+  }
+
+  getStepIcon(status: string): string {
+    switch (status) {
+      case 'completed': return 'check_circle';
+      case 'running': return 'sync';
+      case 'waiting_for_input': return 'pause_circle';
+      case 'failed': return 'error';
+      case 'cancelled': return 'cancel';
+      default: return 'hourglass_empty';
+    }
+  }
+
+  getStepIconClass(status: string): string {
+    switch (status) {
+      case 'completed': return 'step-completed';
+      case 'running': return 'step-running';
+      case 'waiting_for_input': return 'step-waiting';
+      case 'failed': return 'step-failed';
+      case 'cancelled': return 'step-cancelled';
+      default: return 'step-pending';
+    }
+  }
+
+  getStatusChipClass(status: string): string {
+    switch (status) {
+      case 'completed': return 'status-completed';
+      case 'running': return 'status-running';
+      case 'waiting_for_input': return 'status-waiting';
+      case 'failed': return 'status-failed';
+      case 'cancelled': return 'status-cancelled';
+      default: return '';
+    }
+  }
+
+  getProcessSteps(): { step_id: string; name: string; agent_name: string }[] {
+    const processId = this.activeRun()?.process_id ?? this.selectedProcessId();
+    const process = this.team.processes.find((p) => p.process_id === processId);
+    if (!process) return [];
+    return process.steps.map((s) => ({
+      step_id: s.step_id,
+      name: s.name,
+      agent_name: s.agents[0]?.agent_name ?? '',
+    }));
+  }
+
+  getStepResult(stepId: string): PipelineStepResult | undefined {
+    return this.activeRun()?.step_results?.find((r) => r.step_id === stepId);
+  }
+
+  formatDuration(run: TestPipelineRun): string {
+    if (!run.started_at) return '';
+    const start = new Date(run.started_at).getTime();
+    const end = run.finished_at ? new Date(run.finished_at).getTime() : Date.now();
+    const seconds = Math.floor((end - start) / 1000);
+    if (seconds < 60) return `${seconds}s`;
+    const minutes = Math.floor(seconds / 60);
+    return `${minutes}m ${seconds % 60}s`;
+  }
+
+  private startPolling(runId: string): void {
+    this.stopPolling();
+    this.pollSub = interval(2000)
+      .pipe(
+        switchMap(() => this.api.getPipelineRun(this.team.team_id, runId)),
+        takeWhile((run) => !this.isTerminal(run.status), true),
+      )
+      .subscribe({
+        next: (run) => {
+          this.activeRun.set(run);
+          this.updateRunInList(run);
+        },
+      });
+  }
+
+  private stopPolling(): void {
+    this.pollSub?.unsubscribe();
+    this.pollSub = null;
+  }
+
+  private isTerminal(status: string): boolean {
+    return ['completed', 'failed', 'cancelled'].includes(status);
+  }
+
+  private updateRunInList(updated: TestPipelineRun): void {
+    this.runs.update((list) =>
+      list.map((r) => (r.run_id === updated.run_id ? updated : r)),
+    );
+  }
+}

--- a/user-interface/src/app/components/pipeline-test-runner/pipeline-test-runner.component.ts
+++ b/user-interface/src/app/components/pipeline-test-runner/pipeline-test-runner.component.ts
@@ -2,6 +2,7 @@ import {
   Component,
   Input,
   OnDestroy,
+  OnInit,
   inject,
   signal,
 } from '@angular/core';
@@ -18,7 +19,6 @@ import { Subscription, interval, switchMap, takeWhile } from 'rxjs';
 import { AgenticTeamApiService } from '../../services/agentic-team-api.service';
 import type {
   AgenticTeam,
-  ProcessDefinition,
   TestPipelineRun,
   PipelineStepResult,
 } from '../../models';
@@ -40,7 +40,7 @@ import type {
   templateUrl: './pipeline-test-runner.component.html',
   styleUrl: './pipeline-test-runner.component.scss',
 })
-export class PipelineTestRunnerComponent implements OnDestroy {
+export class PipelineTestRunnerComponent implements OnInit, OnDestroy {
   @Input() team!: AgenticTeam;
 
   private readonly api = inject(AgenticTeamApiService);

--- a/user-interface/src/app/models/agentic-team.model.ts
+++ b/user-interface/src/app/models/agentic-team.model.ts
@@ -71,6 +71,7 @@ export interface AgenticTeam {
   team_id: string;
   name: string;
   description: string;
+  mode?: TeamMode;
   agents: AgenticTeamAgent[];
   processes: ProcessDefinition[];
   created_at: string;
@@ -166,4 +167,67 @@ export interface AgentEnvProvisionSummary {
   error_message?: string | null;
   created_at: string;
   updated_at: string;
+}
+
+// ---------------------------------------------------------------------------
+// Interactive Testing Mode
+// ---------------------------------------------------------------------------
+
+export type TeamMode = 'development' | 'testing';
+export type MessageRating = 'thumbs_up' | 'thumbs_down';
+export type PipelineRunStatus = 'running' | 'waiting_for_input' | 'completed' | 'failed' | 'cancelled';
+
+export interface TestChatSession {
+  session_id: string;
+  team_id: string;
+  agent_name: string;
+  session_name: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface TestChatMessage {
+  message_id: string;
+  session_id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  rating: MessageRating | null;
+  created_at: string;
+}
+
+export interface TestChatSessionDetail {
+  session: TestChatSession;
+  messages: TestChatMessage[];
+  suggested_prompts: string[];
+}
+
+export interface AgentQualityScore {
+  agent_name: string;
+  total_rated: number;
+  thumbs_up: number;
+  thumbs_down: number;
+  score_pct: number;
+}
+
+export interface PipelineStepResult {
+  step_id: string;
+  step_name: string;
+  agent_name: string;
+  input: string;
+  output: string;
+  status: string;
+}
+
+export interface TestPipelineRun {
+  run_id: string;
+  team_id: string;
+  process_id: string;
+  status: PipelineRunStatus;
+  current_step_id: string | null;
+  initial_input: string | null;
+  step_results: PipelineStepResult[];
+  human_prompt: string | null;
+  error: string | null;
+  started_at: string;
+  finished_at: string | null;
 }

--- a/user-interface/src/app/services/agentic-team-api.service.ts
+++ b/user-interface/src/app/services/agentic-team-api.service.ts
@@ -11,9 +11,15 @@ import type {
   AgenticConversationStateResponse,
   AgenticConversationSummary,
   AgentEnvProvisionSummary,
+  AgentQualityScore,
   ProcessDefinition,
   RecommendAgentsResponse,
   RosterValidationResult,
+  TeamMode,
+  TestChatSession,
+  TestChatSessionDetail,
+  TestChatMessage,
+  TestPipelineRun,
 } from '../models';
 
 @Injectable({ providedIn: 'root' })
@@ -110,5 +116,104 @@ export class AgenticTeamApiService {
   /** Sandbox provisioning status for each process step agent (Agent Provisioning team). */
   listAgentEnvironments(teamId: string): Observable<AgentEnvProvisionSummary[]> {
     return this.http.get<AgentEnvProvisionSummary[]>(`${this.base}/teams/${teamId}/agent-environments`);
+  }
+
+  // -------------------------------------------------------------------------
+  // Interactive Testing Mode
+  // -------------------------------------------------------------------------
+
+  setTeamMode(teamId: string, mode: TeamMode): Observable<{ team_id: string; mode: string }> {
+    return this.http.put<{ team_id: string; mode: string }>(`${this.base}/teams/${teamId}/mode`, { mode });
+  }
+
+  // Agent Chat Testing
+
+  createTestChatSession(teamId: string, agentName: string): Observable<TestChatSession> {
+    return this.http.post<TestChatSession>(`${this.base}/teams/${teamId}/test-chat/sessions`, {
+      agent_name: agentName,
+    });
+  }
+
+  listTestChatSessions(teamId: string, agentName?: string): Observable<TestChatSession[]> {
+    const params = agentName ? `?agent_name=${encodeURIComponent(agentName)}` : '';
+    return this.http.get<TestChatSession[]>(`${this.base}/teams/${teamId}/test-chat/sessions${params}`);
+  }
+
+  getTestChatSession(teamId: string, sessionId: string): Observable<TestChatSessionDetail> {
+    return this.http.get<TestChatSessionDetail>(
+      `${this.base}/teams/${teamId}/test-chat/sessions/${sessionId}`,
+    );
+  }
+
+  renameTestChatSession(
+    teamId: string, sessionId: string, sessionName: string,
+  ): Observable<{ session_id: string; session_name: string }> {
+    return this.http.put<{ session_id: string; session_name: string }>(
+      `${this.base}/teams/${teamId}/test-chat/sessions/${sessionId}/name`,
+      { session_name: sessionName },
+    );
+  }
+
+  deleteTestChatSession(teamId: string, sessionId: string): Observable<void> {
+    return this.http.delete<void>(`${this.base}/teams/${teamId}/test-chat/sessions/${sessionId}`);
+  }
+
+  sendTestChatMessage(
+    teamId: string, sessionId: string, content: string,
+  ): Observable<{ session: TestChatSession; messages: TestChatMessage[] }> {
+    return this.http.post<{ session: TestChatSession; messages: TestChatMessage[] }>(
+      `${this.base}/teams/${teamId}/test-chat/sessions/${sessionId}/messages`,
+      { content },
+    );
+  }
+
+  exportTestChatSession(teamId: string, sessionId: string): Observable<Blob> {
+    return this.http.get(`${this.base}/teams/${teamId}/test-chat/sessions/${sessionId}/export`, {
+      responseType: 'blob',
+    });
+  }
+
+  rateTestChatMessage(
+    teamId: string, messageId: string, rating: string,
+  ): Observable<{ message_id: string; rating: string }> {
+    return this.http.put<{ message_id: string; rating: string }>(
+      `${this.base}/teams/${teamId}/test-chat/messages/${messageId}/rating`,
+      { rating },
+    );
+  }
+
+  getAgentQualityScores(teamId: string): Observable<AgentQualityScore[]> {
+    return this.http.get<AgentQualityScore[]>(`${this.base}/teams/${teamId}/test-chat/quality-scores`);
+  }
+
+  // Pipeline Testing
+
+  startPipelineRun(teamId: string, processId: string, initialInput?: string): Observable<TestPipelineRun> {
+    return this.http.post<TestPipelineRun>(`${this.base}/teams/${teamId}/test-pipeline/runs`, {
+      process_id: processId,
+      initial_input: initialInput ?? null,
+    });
+  }
+
+  listPipelineRuns(teamId: string): Observable<TestPipelineRun[]> {
+    return this.http.get<TestPipelineRun[]>(`${this.base}/teams/${teamId}/test-pipeline/runs`);
+  }
+
+  getPipelineRun(teamId: string, runId: string): Observable<TestPipelineRun> {
+    return this.http.get<TestPipelineRun>(`${this.base}/teams/${teamId}/test-pipeline/runs/${runId}`);
+  }
+
+  submitPipelineInput(teamId: string, runId: string, inputText: string): Observable<TestPipelineRun> {
+    return this.http.post<TestPipelineRun>(
+      `${this.base}/teams/${teamId}/test-pipeline/runs/${runId}/input`,
+      { input: inputText },
+    );
+  }
+
+  cancelPipelineRun(teamId: string, runId: string): Observable<TestPipelineRun> {
+    return this.http.post<TestPipelineRun>(
+      `${this.base}/teams/${teamId}/test-pipeline/runs/${runId}/cancel`,
+      {},
+    );
   }
 }


### PR DESCRIPTION
## Summary
This PR introduces a comprehensive interactive testing mode for the agentic team provisioning system, enabling developers to test individual agents via chat and execute end-to-end pipeline workflows with human-in-the-loop capabilities.

## Key Changes

### Backend Infrastructure
- **Testing Store** (`testing/store.py`): Postgres-backed stateless store for managing test chat sessions, messages, pipeline runs, and quality ratings. Follows the `startup_advisor/store.py` pattern with `@timed_query` decorators and short-lived connections.
- **Pipeline Runner** (`runtime/pipeline_runner.py`): Background thread-based executor that walks ProcessDefinition DAGs step-by-step, auto-advancing through ACTION/DECISION/PARALLEL steps and pausing at WAIT steps for human input.
- **Agent Builder** (`runtime/agent_builder.py`): Compiles AgenticTeamAgent roster definitions into live strands.Agent instances with system prompts, tools, and capabilities.
- **Database Schema**: Added `agentic_teams.mode` column and new tables for test chat sessions, messages, pipeline runs, and quality ratings.

### API Endpoints
- **Team Mode Management**: `PUT /teams/{team_id}/mode` to toggle between development and testing modes
- **Agent Chat Testing**:
  - `POST /teams/{team_id}/test-chat/sessions` - Create chat session
  - `GET /teams/{team_id}/test-chat/sessions` - List sessions
  - `GET /teams/{team_id}/test-chat/sessions/{session_id}` - Get session with history
  - `POST /teams/{team_id}/test-chat/sessions/{session_id}/messages` - Send message
  - `PUT /teams/{team_id}/test-chat/messages/{message_id}/rating` - Rate message quality
  - Session management (rename, delete, export)
- **Pipeline Testing**:
  - `POST /teams/{team_id}/pipeline-runs` - Start pipeline execution
  - `GET /teams/{team_id}/pipeline-runs` - List runs
  - `GET /teams/{team_id}/pipeline-runs/{run_id}` - Get run details
  - `POST /teams/{team_id}/pipeline-runs/{run_id}/input` - Submit human input at WAIT steps
  - `POST /teams/{team_id}/pipeline-runs/{run_id}/cancel` - Cancel running pipeline

### Frontend Components
- **Agent Test Chat** (`agent-test-chat.component.*`): Interactive chat interface with:
  - Agent selector with quality score visualization
  - Session management (create, rename, delete, export)
  - Message history with thumbs-up/down ratings
  - Suggested starter prompts
  - Real-time typing indicators
- **Pipeline Test Runner** (`pipeline-test-runner.component.*`): Visual pipeline execution with:
  - Process selector and initial input configuration
  - Step-by-step execution visualization with status indicators
  - Human input submission at WAIT steps
  - Run history and detailed step results
  - Error handling and cancellation
- **Test Panel** (`agentic-team-test-panel.component.*`): Tab-based UI switching between chat and pipeline testing modes

### Models & Types
- New enums: `TeamMode`, `MessageRating`, `PipelineRunStatus`
- New data models: `TestChatSession`, `TestChatMessage`, `TestPipelineRun`, `PipelineStepResult`, `AgentQualityScore`
- Updated `AgenticTeam` model with `mode` field

## Implementation Details
- **Stateless Architecture**: Store and runner follow shared connection pool pattern for scalability
- **Background Execution**: Pipeline runs execute in daemon threads with event-based synchronization for pause/resume
- **Quality Tracking**: Message ratings aggregated into per-agent quality scores (percentage positive)
- **Graceful Degradation**: Agent builder handles optional strands/tools imports
- **Dark Theme UI**: Frontend components styled to match GitHub dark theme with status-based color coding
- **Auto-scroll & Polling**: Chat auto-scrolls on new messages; pipeline runs poll for status updates

https://claude.ai/code/session_01Wh3JzeSLPJvr3ayadsaBRv