### PR TITLE
Add system design documentation for investment team

### DIFF
--- a/backend/agents/investment_team/system_design/README.md
+++ b/backend/agents/investment_team/system_design/README.md
@@ -1,0 +1,63 @@
+# Investment Team — System Design Documentation
+
+This folder captures the **architectural and design decisions** of the Khala
+investment team. It is the diagram-first companion to the two existing docs:
+
+- [`../README.md`](../README.md) — operational overview (tracks, endpoints,
+  catalog roles, promotion checklist)
+- [`../ARCHITECTURE_REVIEW.md`](../ARCHITECTURE_REVIEW.md) — critique and
+  phased migration roadmap (known issues, not current design)
+
+The investment team exposes a single HTTP prefix `/api/investment` that hides
+**two distinct tracks**:
+
+| Track | Purpose | Needs `user_id` / IPS? |
+|---|---|---|
+| **Advisor / IPS** | Build an Investment Policy Statement from a user conversation, create and validate portfolio proposals, draft Investment Committee memos | Yes |
+| **Strategy Lab** | LLM-driven strategy ideation, historical backtesting, and paper-trading against a free-tier market snapshot | No |
+
+The **universal promotion gate** (`POST /promotions/decide`) is the bridge
+between the two: a validated Strategy Lab strategy can be promoted to paper or
+live under a specific client only after the six-gate checklist runs against
+that client's IPS.
+
+## Reading order
+
+1. **[`architecture.md`](./architecture.md)** — C4-style container view of the
+   team and its dependencies. Start here.
+2. **[`system_design.md`](./system_design.md)** — component view of the API
+   router and class diagram of the core Pydantic domain models.
+3. **[`use_cases.md`](./use_cases.md)** — UML-style use-case diagram grouping
+   every endpoint by actor and track.
+4. **[`flow_charts.md`](./flow_charts.md)** — sequence and state diagrams for
+   the four most important end-to-end flows (advisor session, strategy lab
+   batch, promotion gate, orchestrator safety).
+
+## Where things live
+
+| Concept | Source |
+|---|---|
+| Two-track API, all 30+ endpoints | [`api/main.py`](../api/main.py) (2063 lines) |
+| Core agents (Advisor, PolicyGuardian, ValidationAgent, PromotionGate, InvestmentCommittee) | [`agents.py`](../agents.py) (933 lines) |
+| Strategy Lab agents (SignalIntelligenceExpert, StrategyIdeationAgent, BacktestingAgent, PaperTradingAgent, TradeSimulationEngine) | [`agents/`](../agents/) |
+| Orchestrator state machine, 6 queues, promotion entry point | [`orchestrator.py`](../orchestrator.py) (133 lines) |
+| Pydantic domain models (profile, IPS, strategy, backtest, promotion, advisor, paper trading) | [`models.py`](../models.py) (477 lines) |
+| Strategy Lab background worker + per-cycle loop | [`api/main.py`](../api/main.py) `_strategy_lab_worker`, `_run_one_strategy_lab_cycle` |
+| SSE fan-out for run progress | [`api/job_event_bus.py`](../api/job_event_bus.py) |
+| Persistence wrapper over Khala job service | [`api/main.py`](../api/main.py) `_PersistentDict` (line 85) |
+| Multi-provider OHLCV fetcher | [`market_data_service.py`](../market_data_service.py) |
+| Strategy Lab market snapshot (Frankfurter / FRED / CoinGecko) | [`market_lab_data/free_tier.py`](../market_lab_data/free_tier.py) |
+| QuantConnect / TradingView browser automation | [`tool_agents/web_interfaces/coordinator.py`](../tool_agents/web_interfaces/coordinator.py) |
+| Catalog of core + specialist desk agents | [`agent_catalog.py`](../agent_catalog.py) |
+| Unified-API mount point | [`backend/unified_api/config.py`](../../../unified_api/config.py) |
+
+## Diagram conventions
+
+All diagrams are authored in **Mermaid**, matching the pattern already used in
+[`../README.md`](../README.md). They render natively on GitHub, in VS Code with
+the Mermaid extension, and in [mermaid.live](https://mermaid.live).
+
+- **flowchart** — containers, components, decision trees
+- **sequenceDiagram** — request / response over time
+- **classDiagram** — domain model relationships
+- **stateDiagram-v2** — workflow mode transitions

--- a/backend/agents/investment_team/system_design/architecture.md
+++ b/backend/agents/investment_team/system_design/architecture.md
@@ -1,0 +1,291 @@
+# Architecture — Investment Team
+
+A C4-style **container view** of the investment team. It shows the major
+runtime pieces, the boundaries between them, and the external services they
+depend on. For the detailed component view and data model, see
+[`system_design.md`](./system_design.md).
+
+## Container diagram
+
+```mermaid
+flowchart TB
+  subgraph clients[Clients]
+    UI[Angular 19 UI<br/>user-interface/]
+    OtherTeams[Other Khala teams<br/>e.g. SE, planning_v3]
+    CLI[External callers / CLI]
+  end
+
+  subgraph gateway[Khala Unified API — port 8080]
+    UAPI[unified_api/main.py<br/>Security Gateway<br/>mounts /api/investment]
+  end
+
+  subgraph invteam[Investment Team — backend/agents/investment_team/]
+    direction TB
+
+    subgraph api_layer[API Layer — api/main.py]
+      AdvisorEP[Advisor endpoints<br/>/profiles /proposals<br/>/advisor/sessions /memos]
+      LabEP[Strategy Lab endpoints<br/>/strategy-lab/run<br/>/strategy-lab/runs/.../stream<br/>/strategy-lab/paper-trade]
+      SharedEP[Shared endpoints<br/>/strategies /backtests<br/>/promotions/decide<br/>/workflow/status]
+    end
+
+    subgraph core_agents[Core Agents — agents.py]
+      FA[FinancialAdvisorAgent<br/>L420-933]
+      PG[PolicyGuardianAgent<br/>L49-103]
+      VA[ValidationAgent<br/>L106-128]
+      PGate[PromotionGateAgent<br/>L131-302]
+      IC[InvestmentCommitteeAgent<br/>L303-407]
+    end
+
+    subgraph lab_agents[Strategy Lab Agents — agents/]
+      SIE[SignalIntelligenceExpert<br/>signal_intelligence_agent.py]
+      SIA[StrategyIdeationAgent<br/>strategy_ideation_agent.py]
+      BTA[BacktestingAgent<br/>backtesting_agent.py]
+      PTA[PaperTradingAgent<br/>paper_trading_agent.py]
+      TSE[TradeSimulationEngine<br/>trade_simulator.py]
+    end
+
+    subgraph orch[Orchestration — orchestrator.py]
+      ORCH[InvestmentTeamOrchestrator]
+      WS[WorkflowState<br/>6 queues + mode + audit_log]
+    end
+
+    subgraph worker[Background Worker — api/main.py]
+      Worker[_strategy_lab_worker<br/>daemon thread per run_id<br/>L1083]
+      Cycle[_run_one_strategy_lab_cycle<br/>L902]
+      EventBus[job_event_bus.py<br/>SSE fan-out<br/>76 lines]
+    end
+
+    subgraph persistence[Persistence]
+      PDict[_PersistentDict<br/>dict-like wrapper<br/>api/main.py L85]
+      Buckets[(_profiles, _proposals,<br/>_strategies, _validations,<br/>_backtests, _strategy_lab_records,<br/>_paper_trading_sessions,<br/>_advisor_sessions)]
+    end
+
+    subgraph tools[Tool Agents]
+      Coord[InvestmentWebInterfaceCoordinator<br/>tool_agents/web_interfaces/coordinator.py]
+      QC[QuantConnectAgent]
+      TV[TradingViewAgent]
+    end
+
+    subgraph data[Market Data]
+      MDS[MarketDataService<br/>multi-provider OHLCV]
+      MLDP[FreeTierMarketDataProvider<br/>market_lab_data/free_tier.py]
+    end
+  end
+
+  subgraph external[External Services]
+    JS[(Khala Job Service<br/>Postgres khala_jobs)]
+    LLM[LLM Service<br/>Ollama / Claude]
+    YF[Yahoo Finance<br/>yfinance]
+    TD[Twelve Data]
+    CG[CoinGecko]
+    AV[Alpha Vantage]
+    FRED[FRED<br/>US 10Y yield]
+    FRANK[Frankfurter<br/>FX]
+    QCWeb[QuantConnect<br/>Playwright]
+    TVWeb[TradingView<br/>Playwright]
+  end
+
+  UI --> UAPI
+  OtherTeams --> UAPI
+  CLI --> UAPI
+  UAPI --> AdvisorEP
+  UAPI --> LabEP
+  UAPI --> SharedEP
+
+  AdvisorEP --> FA
+  AdvisorEP --> PG
+  AdvisorEP --> IC
+  SharedEP --> VA
+  SharedEP --> PGate
+  SharedEP --> ORCH
+
+  LabEP --> Worker
+  Worker --> Cycle
+  Cycle --> SIE
+  Cycle --> SIA
+  Cycle --> BTA
+  BTA --> TSE
+  LabEP --> PTA
+  PTA --> TSE
+
+  ORCH --> PG
+  ORCH --> PGate
+  ORCH --> WS
+  ORCH --> Coord
+  Coord --> QC
+  Coord --> TV
+  QC --> QCWeb
+  TV --> TVWeb
+
+  FA --> LLM
+  IC --> LLM
+  SIE --> LLM
+  SIA --> LLM
+  BTA --> LLM
+  PTA --> LLM
+
+  SIE --> MLDP
+  BTA --> MDS
+  PTA --> MDS
+
+  MDS --> YF
+  MDS --> TD
+  MDS --> CG
+  MDS --> AV
+  MLDP --> FRANK
+  MLDP --> FRED
+  MLDP --> CG
+
+  AdvisorEP --> PDict
+  LabEP --> PDict
+  SharedEP --> PDict
+  Worker --> PDict
+  PDict --> Buckets
+  Buckets --> JS
+
+  Worker --> EventBus
+  EventBus -->|"SSE /strategy-lab/runs/{id}/stream"| UI
+```
+
+## Design decisions
+
+### 1. Two tracks behind one prefix
+
+Advisor and Strategy Lab could have been separate teams, but they live together
+because the **promotion gate is the bridge**: a Strategy Lab strategy that
+passes validation is only promotable to paper/live when it is evaluated against
+a specific client's IPS. Keeping both tracks in one package lets
+`PromotionGateAgent` depend on both `StrategySpec` (lab side) and `IPS`
+(advisor side) without cross-team imports. This framing is authoritative in
+[`../README.md`](../README.md):1-56.
+
+### 2. IPS-first, hard-constraint model
+
+Every advisor-side recommendation must survive `PolicyGuardianAgent`
+([`agents.py`](../agents.py):49-103) before it can reach a user. IPS caps
+(per-position, asset-class, speculative sleeve) and explicit permissions
+(options, crypto, live trading) are treated as **hard constraints** — not
+soft scores. A proposal that violates them is rejected outright and never
+reaches the Investment Committee agent. This is the team's most important
+invariant.
+
+### 3. Separation of duties is structural
+
+`PromotionGateAgent.decide` ([`agents.py`](../agents.py):131-302) refuses to
+let the same agent propose and approve a strategy. This isn't a policy toggle
+— it is the first gate in the six-gate checklist, and a failure short-circuits
+the remaining gates to `reject`. The orchestrator does not offer an override.
+
+### 4. Universal 6-gate promotion checklist
+
+The same gate logic runs regardless of which track originated a strategy:
+
+1. Separation of duties (reject on violation)
+2. Risk veto (reject)
+3. Required validation completeness & pass criteria (revise if incomplete)
+4. IPS live-trading permission (fall back to paper if not enabled)
+5. Human live-approval flag (paper if pending)
+6. Live promotion only if every gate passes
+
+Every decision is recorded as a `PromotionDecision.gate_results` list with an
+`AuditContext`, so every outcome is traceable back to the inputs and gates.
+See [`flow_charts.md`](./flow_charts.md) for the decision tree.
+
+### 5. Safe-by-default workflow mode
+
+`InvestmentTeamOrchestrator.bootstrap` ([`orchestrator.py`](../orchestrator.py):69-71)
+reads `IPS.default_mode` at startup and is expected to begin in
+`WorkflowMode.MONITOR_ONLY`. Any data-integrity failure triggers
+`handle_data_integrity(False)` which **unconditionally degrades** the workflow
+to `monitor_only` and writes
+`data_integrity_failed:degrade_to_monitor_only` to the audit log
+([`orchestrator.py`](../orchestrator.py):77-80). There is no auto-recovery —
+the mode only rises again through an explicit operator action. This is the
+team's second-most-important invariant.
+
+### 6. Persistence via the Khala job service (not a team schema)
+
+Unlike teams that own a Postgres schema via `shared_postgres`, the investment
+team persists **everything** through the job service:
+
+- `_PersistentDict` ([`api/main.py`](../api/main.py):85) presents a dict-like
+  interface backed by `JobServiceClient`.
+- Separate logical buckets per artifact type: `investment_profiles`,
+  `investment_proposals`, `investment_strategies`, `investment_validations`,
+  `investment_backtests`, `investment_strategy_lab_records`,
+  `investment_paper_trading_sessions`, `investment_advisor_sessions`.
+- Survives server restart; no in-memory-only state for artifacts.
+
+Trade-off: the team does **not** publish a `shared_postgres` `SCHEMA` constant
+— artifact storage is opaque to the job DB. Operators cleaning up strategy-lab
+data query the `jobs` table directly (see
+[`../README.md`](../README.md):77-86) or use `DELETE /strategy-lab/storage`.
+
+### 7. Background worker, not Temporal (yet)
+
+A strategy-lab run is a long-running, multi-cycle loop (signal → ideation →
+backtest → analysis → self-review). Today each run spawns a **daemon thread**
+via `_strategy_lab_worker` ([`api/main.py`](../api/main.py):1083). Run state
+lives in an `_active_runs` dict and is also persisted through `_PersistentDict`
+so a restart can reload in-flight runs (`_load_run_from_job_service`).
+
+Temporal activities are declared in
+[`temporal/__init__.py`](../temporal/__init__.py) but are **not yet wired** to
+the API layer. This is a deliberate staged migration documented in
+[`../ARCHITECTURE_REVIEW.md`](../ARCHITECTURE_REVIEW.md) (Phase 3).
+
+### 8. SSE fan-out for run progress
+
+Clients don't poll the worker — they subscribe to cycle events. The worker
+publishes to a per-run topic in
+[`api/job_event_bus.py`](../api/job_event_bus.py) (76 lines of queue-per-subscriber
+fan-out), and `GET /strategy-lab/runs/{run_id}/stream`
+([`api/main.py`](../api/main.py):1550) drains the queue as an HTTP SSE stream
+to the Angular UI. A polling fallback (`/strategy-lab/runs/{run_id}/status`,
+line 1534) is also exposed.
+
+### 9. Market data is tiered by free vs pay
+
+Two distinct providers exist on purpose:
+
+- **`MarketDataService`** ([`market_data_service.py`](../market_data_service.py))
+  is the OHLCV fetcher the backtester uses. It prioritizes Yahoo Finance
+  (`yfinance`), falls back to Twelve Data, CoinGecko for crypto, and Alpha
+  Vantage only if `ALPHA_VANTAGE_API_KEY` is set.
+- **`FreeTierMarketDataProvider`**
+  ([`market_lab_data/free_tier.py`](../market_lab_data/free_tier.py)) is a
+  narrower *snapshot* used by `SignalIntelligenceExpert` to build a brief for
+  the ideation step. It pulls FX from Frankfurter, the US 10-year from FRED
+  (optional `FRED_API_KEY`), and crypto from CoinGecko. Cache TTL and timeout
+  are tunable via `STRATEGY_LAB_MARKET_DATA_CACHE_TTL_SEC` and
+  `STRATEGY_LAB_MARKET_DATA_FETCH_TIMEOUT_SEC`.
+
+Keeping them separate means the signal-intelligence pipeline can evolve its
+prompt-side data shape without destabilizing the backtester.
+
+### 10. LLM access goes through the shared service
+
+Every agent takes an `LLMClient` from `backend/agents/llm_service/` and calls
+`.complete_json(...)`. Provider (Ollama vs Claude), base URL, and model are
+selected by `LLM_PROVIDER`, `LLM_BASE_URL`, and `LLM_MODEL` — the same
+environment variables used by every other Khala team.
+
+## Environment variables consumed by this team
+
+| Variable | Purpose |
+|---|---|
+| `ALPHA_VANTAGE_API_KEY` | Optional OHLCV fallback in `MarketDataService` |
+| `FRED_API_KEY` | Optional US 10Y yield in strategy-lab snapshot |
+| `STRATEGY_LAB_MARKET_DATA_FETCH_TIMEOUT_SEC` | Per-fetch timeout (default 8.0) |
+| `STRATEGY_LAB_MARKET_DATA_CACHE_TTL_SEC` | Snapshot cache TTL (default 120.0) |
+| `STRATEGY_LAB_MARKET_DATA_PROVIDER` | Provider key (only `free_tier` is implemented) |
+| `STRATEGY_LAB_SIGNAL_EXPERT_ENABLED` | Toggles the signal-intelligence step |
+| `LLM_PROVIDER` / `LLM_BASE_URL` / `LLM_MODEL` | Shared LLM client config |
+| `POSTGRES_HOST` (+ friends) | Enables job-service persistence (required for non-trivial use) |
+
+## Known issues & roadmap
+
+Architectural critiques and the phased migration plan (Phase 0 foundation
+cleanup through Phase 3+ Temporal / Strands SDK migration) live in
+[`../ARCHITECTURE_REVIEW.md`](../ARCHITECTURE_REVIEW.md). This document
+describes the current design; that document describes where it is headed.

--- a/backend/agents/investment_team/system_design/architecture.md
+++ b/backend/agents/investment_team/system_design/architecture.md
@@ -161,13 +161,23 @@ a specific client's IPS. Keeping both tracks in one package lets
 
 ### 2. IPS-first, hard-constraint model
 
-Every advisor-side recommendation must survive `PolicyGuardianAgent`
-([`agents.py`](../agents.py):49-103) before it can reach a user. IPS caps
+`PolicyGuardianAgent` ([`agents.py`](../agents.py):49-103) treats IPS caps
 (per-position, asset-class, speculative sleeve) and explicit permissions
-(options, crypto, live trading) are treated as **hard constraints** — not
-soft scores. A proposal that violates them is rejected outright and never
-reaches the Investment Committee agent. This is the team's most important
-invariant.
+(options, crypto, live trading) as **hard constraints** — not soft scores.
+When a proposal is run through `POST /proposals/{proposal_id}/validate`
+([`api/main.py`](../api/main.py):534-555) the guardian returns a structured
+list of violations that the caller is expected to gate on before acting.
+
+**Scope of enforcement (today).** The guardian is only invoked by the
+proposal-validation endpoint. It is **not** automatically applied by
+`POST /memos` ([`api/main.py`](../api/main.py):783-793) — that endpoint calls
+`InvestmentCommitteeAgent.draft_memo` directly — nor by `POST /promotions/decide`,
+which consumes a `ValidationReport` rather than a `PortfolioProposal`. In
+practice, enforcement is the caller's responsibility: validate the proposal
+first, then decide whether to request a memo or promote a strategy. Closing
+this gap (automatic PolicyGuardian pre-check on memo and promotion paths) is
+tracked in [`../ARCHITECTURE_REVIEW.md`](../ARCHITECTURE_REVIEW.md) as part of
+the Phase 0 foundation cleanup.
 
 ### 3. Separation of duties is structural
 
@@ -193,15 +203,29 @@ See [`flow_charts.md`](./flow_charts.md) for the decision tree.
 
 ### 5. Safe-by-default workflow mode
 
-`InvestmentTeamOrchestrator.bootstrap` ([`orchestrator.py`](../orchestrator.py):69-71)
-reads `IPS.default_mode` at startup and is expected to begin in
-`WorkflowMode.MONITOR_ONLY`. Any data-integrity failure triggers
-`handle_data_integrity(False)` which **unconditionally degrades** the workflow
-to `monitor_only` and writes
-`data_integrity_failed:degrade_to_monitor_only` to the audit log
-([`orchestrator.py`](../orchestrator.py):77-80). There is no auto-recovery —
-the mode only rises again through an explicit operator action. This is the
-team's second-most-important invariant.
+The API module constructs a single process-wide `WorkflowState()` at
+import time ([`api/main.py`](../api/main.py):78). `WorkflowState` is a
+dataclass whose `mode` field defaults to `WorkflowMode.MONITOR_ONLY`
+([`orchestrator.py`](../orchestrator.py):50), so the running system always
+boots in `monitor_only` regardless of any user's `IPS.default_mode`. The only
+endpoints that expose the workflow state are the read-only
+`GET /workflow/status` ([`api/main.py`](../api/main.py):756) and
+`GET /workflow/queues` ([`api/main.py`](../api/main.py):767).
+
+**What is designed but not wired.** `InvestmentTeamOrchestrator.bootstrap`
+([`orchestrator.py`](../orchestrator.py):69-71) — which would copy
+`ips.default_mode` into `WorkflowState` — and
+`handle_data_integrity(False)` ([`orchestrator.py`](../orchestrator.py):77-80)
+— which would degrade the mode on an integrity failure and write
+`data_integrity_failed:degrade_to_monitor_only` to the audit log — exist as
+methods on the orchestrator and are exercised by
+[`tests/test_investment_team.py`](../tests/test_investment_team.py), but
+**neither is called from the API layer today**. The current production
+behavior is therefore: start in `monitor_only`, stay in `monitor_only`, and
+rely on the fact that no code path mutates `_workflow_state.mode`. Wiring
+these hooks into the FastAPI lifespan (and exposing an operator endpoint to
+raise the mode) is tracked in
+[`../ARCHITECTURE_REVIEW.md`](../ARCHITECTURE_REVIEW.md).
 
 ### 6. Persistence via the Khala job service (not a team schema)
 

--- a/backend/agents/investment_team/system_design/flow_charts.md
+++ b/backend/agents/investment_team/system_design/flow_charts.md
@@ -1,0 +1,256 @@
+# Flow Charts — Investment Team
+
+Four diagrams covering the most important end-to-end paths through the
+investment team:
+
+1. [Advisor session → IPS](#1-advisor-session--ips-flow) (sequence diagram)
+2. [Strategy Lab batch run](#2-strategy-lab-batch-run-flow) (sequence diagram)
+3. [Promotion-gate decision tree](#3-promotion-gate-decision-tree) (flowchart)
+4. [Orchestrator workflow mode](#4-orchestrator-workflow-mode) (state diagram)
+
+Line references point to [`api/main.py`](../api/main.py),
+[`agents.py`](../agents.py), and [`orchestrator.py`](../orchestrator.py).
+
+---
+
+## 1. Advisor session → IPS flow
+
+Conversational flow that walks a user through topics to accumulate a
+`CollectedProfileData` object, converts it to an `InvestmentProfile`, and
+wraps it in an `IPS`.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant UI as Angular UI
+    participant API as api/main.py
+    participant FA as FinancialAdvisorAgent
+    participant LLM as LLM Service
+    participant Store as _PersistentDict
+
+    UI->>API: POST /advisor/sessions (L1981)
+    API->>FA: start_session() (agents.py:433)
+    FA->>FA: create AdvisorSession<br/>topic = GREETING
+    FA-->>API: session + opening question
+    API->>Store: _advisor_sessions[id] = session
+    API-->>UI: StartAdvisorSessionResponse
+
+    loop While session.status == active
+        UI->>API: POST /advisor/sessions/{id}/messages (L1997)
+        API->>Store: load session
+        API->>FA: handle_message(session, user_msg) (agents.py:449)
+        FA->>FA: _extract_topic_data(current_topic, msg)<br/>(regex-heavy, agents.py:615-881)
+        alt extraction succeeded
+            FA->>FA: append to collected, advance topic<br/>(_next_topic, agents.py:408)
+        else needs clarification
+            FA->>LLM: optional clarification prompt
+            LLM-->>FA: follow-up question
+        end
+        FA-->>API: updated session + next question
+        API->>Store: _advisor_sessions[id] = session
+        API-->>UI: SendAdvisorMessageResponse
+    end
+
+    UI->>API: POST /advisor/sessions/{id}/complete (L2033)
+    API->>FA: build_ips(session) (agents.py:509)
+    FA->>FA: CollectedProfileData → InvestmentProfile → IPS
+    FA-->>API: IPS
+    API->>Store: _profiles[user_id] = ips
+    API-->>UI: CompleteAdvisorSessionResponse
+```
+
+**Key notes**
+
+- Regex extraction (≈266 lines in `agents.py`:615-881) is deliberately local /
+  deterministic so profile data never leaves the process when building the
+  IPS. This is flagged as HIGH-4 in
+  [`../ARCHITECTURE_REVIEW.md`](../ARCHITECTURE_REVIEW.md) — a future local-LLM
+  extractor is planned.
+- Topic order is a strict DAG driven by `_next_topic`
+  ([`agents.py`](../agents.py):408): `GREETING → RISK → HORIZON → INCOME →
+  NET_WORTH → SAVINGS → TAX → LIQUIDITY → GOALS → PREFERENCES → CONSTRAINTS →
+  REVIEW`.
+- `build_ips` sets `IPS.default_mode` from collected preferences; typically
+  `WorkflowMode.MONITOR_ONLY` so promotion is always opt-in.
+
+---
+
+## 2. Strategy Lab batch run flow
+
+The long-running flow kicked off by `POST /strategy-lab/run`. The API returns
+immediately with a `run_id`; the worker thread runs the per-cycle loop and
+publishes SSE events that the UI subscribes to.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Client
+    participant API as api/main.py
+    participant Worker as _strategy_lab_worker<br/>(daemon thread)
+    participant MLDP as FreeTierMarketDataProvider
+    participant SIE as SignalIntelligenceExpert
+    participant SIA as StrategyIdeationAgent
+    participant BTA as BacktestingAgent
+    participant MDS as MarketDataService
+    participant LLM as LLM Service
+    participant Store as _PersistentDict
+    participant Bus as job_event_bus
+
+    Client->>API: POST /strategy-lab/run (L1251)
+    API->>API: allocate run_id, init state
+    API->>Store: _active_runs[run_id] persisted
+    API->>Worker: spawn thread(_strategy_lab_worker, L1083)
+    API-->>Client: StrategyLabRunStartResponse (run_id)
+
+    opt Real-time subscription
+        Client->>API: GET /strategy-lab/runs/{run_id}/stream (L1550)
+        API->>Bus: subscribe(run_id)
+    end
+
+    Worker->>MLDP: fetch_context()<br/>(Frankfurter + FRED + CoinGecko)
+    MLDP-->>Worker: MarketLabContext
+    Worker->>Store: load prior StrategyLabRecords
+
+    loop for each cycle in batch
+        alt Signal expert enabled
+            Worker->>SIE: produce_signal_brief(priors, context)
+            SIE->>LLM: complete_json(temp=0.58)
+            LLM-->>SIE: SignalIntelligenceBriefV1
+            SIE-->>Worker: brief
+        end
+
+        Worker->>SIA: ideate_strategy(brief, priors)
+        SIA->>LLM: complete_json(temp=0.85)
+        LLM-->>SIA: StrategySpec (creative)
+        SIA-->>Worker: strategy
+
+        Worker->>BTA: run_backtest(strategy, config)
+        BTA->>MDS: fetch OHLCV per symbol
+        MDS-->>BTA: bars
+        loop per qualifying bar
+            BTA->>LLM: complete_json(temp=0.2)
+            LLM-->>BTA: enter/exit/hold decision
+        end
+        BTA-->>Worker: BacktestResult + trades
+
+        Worker->>SIA: _analyze_strategy(win/lose)
+        SIA->>LLM: complete_json(temp=0.35)
+        LLM-->>SIA: draft narrative
+        Worker->>SIA: _self_review_analysis(draft)
+        SIA->>LLM: complete_json(temp=0.15)
+        LLM-->>SIA: validated narrative
+        SIA-->>Worker: narrative
+
+        Worker->>Store: persist StrategyLabRecord
+        Worker->>Bus: publish(run_id, cycle_complete event)
+        Bus-->>Client: SSE event
+    end
+
+    Worker->>Store: mark run complete
+    Worker->>Bus: publish(run_id, run_complete)
+    Bus-->>Client: SSE event (close)
+```
+
+**Key notes**
+
+- The per-bar LLM call inside `BacktestingAgent.run_backtest` is expensive —
+  it's the CRITICAL-1 issue in
+  [`../ARCHITECTURE_REVIEW.md`](../ARCHITECTURE_REVIEW.md). The long-term plan
+  is rule compilation + batched Tier-2 evaluation.
+- Worker state lives in both an in-memory `_active_runs` dict **and** the
+  `_PersistentDict` bucket so restarts can reload in-flight runs via
+  `_load_run_from_job_service`.
+- `STRATEGY_LAB_SIGNAL_EXPERT_ENABLED` toggles the signal-expert step off for
+  A/B comparison or cost control.
+- Polling clients can use `GET /strategy-lab/runs/{run_id}/status` (L1534)
+  instead of SSE.
+
+---
+
+## 3. Promotion-gate decision tree
+
+Six-gate checklist from `PromotionGateAgent.decide`
+([`agents.py`](../agents.py):131-302). Each gate either short-circuits to a
+terminal outcome (`reject`), falls through to a softer outcome (`revise` /
+`paper`), or continues to the next gate. Rejects and revises auto-enqueue to
+the `escalation` queue in
+[`orchestrator.py`](../orchestrator.py):113-117.
+
+```mermaid
+flowchart TD
+    START([POST /promotions/decide<br/>L719]) --> G1{Gate 1<br/>Separation of duties<br/>proposer_id ≠ approver.agent_id?}
+    G1 -- No --> REJ1[outcome = reject<br/>gate: separation_of_duties = fail]
+    G1 -- Yes --> G2{Gate 2<br/>Risk veto?}
+    G2 -- Yes --> REJ2[outcome = reject<br/>gate: risk_veto = fail]
+    G2 -- No --> G3{Gate 3<br/>ValidationReport<br/>complete &<br/>all required passed?}
+    G3 -- No --> REV[outcome = revise<br/>gate: validation = fail]
+    G3 -- Yes --> G4{Gate 4<br/>IPS.live_trading_enabled?}
+    G4 -- No --> PAP1[outcome = paper<br/>gate: ips_live = warn]
+    G4 -- Yes --> G5{Gate 5<br/>IPS.human_approval_required_for_live<br/>&amp; human_live_approval?}
+    G5 -- approval pending --> PAP2[outcome = paper<br/>gate: human_approval = warn]
+    G5 -- approval granted<br/>or not required --> LIVE[outcome = live<br/>gate: live_promote = pass]
+
+    REJ1 --> ESC[[Enqueue to escalation queue<br/>priority=high<br/>orchestrator.py L113-117]]
+    REJ2 --> ESC
+    REV --> ESC
+    PAP1 --> AUD[(Record PromotionDecision<br/>+ AuditContext)]
+    PAP2 --> AUD
+    LIVE --> AUD
+    ESC --> AUD
+```
+
+**Key notes**
+
+- Every gate writes a `GateCheckResult(gate, result, details)` to
+  `PromotionDecision.gate_results`, so the full trace survives in persistence
+  (`investment_strategies` bucket) for audit.
+- `PromotionDecision.audit: AuditContext` captures the snapshot ID,
+  assumptions, and agent version that produced the decision.
+- The gate is the **only** path between a validated strategy and paper/live
+  execution — all tracks funnel through here.
+
+---
+
+## 4. Orchestrator workflow mode
+
+`WorkflowMode` governs what the orchestrator will let through. It is
+initialized from `IPS.default_mode` at bootstrap, can be raised by explicit
+operator action, and is automatically clamped to `monitor_only` on any
+data-integrity failure.
+
+```mermaid
+stateDiagram-v2
+    [*] --> monitor_only : orchestrator.bootstrap(ips)<br/>reads ips.default_mode<br/>(orchestrator.py:69-71)
+
+    monitor_only --> paper : operator raises mode<br/>(validated paper-trading plan)
+    paper --> live : operator raises mode<br/>+ passed 6-gate promotion<br/>+ ips.live_trading_enabled
+    live --> paper : operator lowers mode<br/>(e.g. regime change)
+    paper --> monitor_only : operator lowers mode
+
+    monitor_only --> monitor_only : bootstrap / refresh
+    paper --> monitor_only : handle_data_integrity(False)<br/>(orchestrator.py:77-80)
+    live --> monitor_only : handle_data_integrity(False)<br/>(orchestrator.py:77-80)
+
+    note right of monitor_only
+        Safe default.
+        Everything is dry-run;
+        no proposal leaves the team.
+    end note
+    note right of live
+        Requires IPS permission
+        + human approval
+        + risk officer sign-off.
+    end note
+```
+
+**Key notes**
+
+- `handle_data_integrity(False)` writes
+  `data_integrity_failed:degrade_to_monitor_only` to `WorkflowState.audit_log`
+  and cannot be overridden without operator intervention.
+- `GET /workflow/status` ([`api/main.py`](../api/main.py):756) exposes the
+  current mode plus the full audit log so an operator can see exactly why
+  a degrade happened.
+- Mode transitions that *raise* the mode (`monitor_only → paper → live`) are
+  **not** automatic — they require explicit operator calls. The only automatic
+  transition in the system is the degrade to `monitor_only`.

--- a/backend/agents/investment_team/system_design/flow_charts.md
+++ b/backend/agents/investment_team/system_design/flow_charts.md
@@ -213,44 +213,59 @@ flowchart TD
 
 ## 4. Orchestrator workflow mode
 
-`WorkflowMode` governs what the orchestrator will let through. It is
-initialized from `IPS.default_mode` at bootstrap, can be raised by explicit
-operator action, and is automatically clamped to `monitor_only` on any
-data-integrity failure.
+`WorkflowMode` is the orchestrator's safety throttle. The diagram below
+distinguishes **what is live today** (solid transitions implemented in
+`api/main.py`) from **what is designed but not yet wired** (dashed
+transitions defined on the orchestrator but only exercised by tests).
 
 ```mermaid
 stateDiagram-v2
-    [*] --> monitor_only : orchestrator.bootstrap(ips)<br/>reads ips.default_mode<br/>(orchestrator.py:69-71)
+    [*] --> monitor_only : WorkflowState() default<br/>(orchestrator.py:50)<br/>instantiated at api/main.py:78
 
-    monitor_only --> paper : operator raises mode<br/>(validated paper-trading plan)
-    paper --> live : operator raises mode<br/>+ passed 6-gate promotion<br/>+ ips.live_trading_enabled
-    live --> paper : operator lowers mode<br/>(e.g. regime change)
-    paper --> monitor_only : operator lowers mode
+    monitor_only --> monitor_only : GET /workflow/status<br/>(read-only)
 
-    monitor_only --> monitor_only : bootstrap / refresh
-    paper --> monitor_only : handle_data_integrity(False)<br/>(orchestrator.py:77-80)
-    live --> monitor_only : handle_data_integrity(False)<br/>(orchestrator.py:77-80)
+    monitor_only --> paper : designed: operator raises mode<br/>(not wired to any endpoint)
+    paper --> live : designed: operator raises mode<br/>+ passed 6-gate promotion<br/>+ ips.live_trading_enabled
+    live --> paper : designed: operator lowers mode
+    paper --> monitor_only : designed: operator lowers mode
+    paper --> monitor_only : designed: handle_data_integrity(False)<br/>(orchestrator.py:77-80, tests only)
+    live --> monitor_only : designed: handle_data_integrity(False)<br/>(orchestrator.py:77-80, tests only)
 
     note right of monitor_only
-        Safe default.
-        Everything is dry-run;
-        no proposal leaves the team.
+        Today: the process always
+        stays here. No code path
+        mutates _workflow_state.mode.
     end note
     note right of live
-        Requires IPS permission
-        + human approval
-        + risk officer sign-off.
+        Requires IPS permission,
+        human approval, and risk
+        officer sign-off by design —
+        no endpoint exposes the
+        transition yet.
     end note
 ```
 
 **Key notes**
 
-- `handle_data_integrity(False)` writes
-  `data_integrity_failed:degrade_to_monitor_only` to `WorkflowState.audit_log`
-  and cannot be overridden without operator intervention.
-- `GET /workflow/status` ([`api/main.py`](../api/main.py):756) exposes the
-  current mode plus the full audit log so an operator can see exactly why
-  a degrade happened.
-- Mode transitions that *raise* the mode (`monitor_only → paper → live`) are
-  **not** automatic — they require explicit operator calls. The only automatic
-  transition in the system is the degrade to `monitor_only`.
+- **Current behavior.** `_workflow_state = WorkflowState()` is created once
+  at module import ([`api/main.py`](../api/main.py):78) and the dataclass
+  default pins `mode = WorkflowMode.MONITOR_ONLY`
+  ([`orchestrator.py`](../orchestrator.py):50). `GET /workflow/status`
+  ([`api/main.py`](../api/main.py):756) and `GET /workflow/queues`
+  ([`api/main.py`](../api/main.py):767) are the only endpoints that touch
+  it, and both are read-only.
+- **What is defined but not called.** `InvestmentTeamOrchestrator.bootstrap`
+  ([`orchestrator.py`](../orchestrator.py):69-71) (which would copy
+  `ips.default_mode` into the state) and `handle_data_integrity`
+  ([`orchestrator.py`](../orchestrator.py):77-80) (which would degrade the
+  mode and write `data_integrity_failed:degrade_to_monitor_only` to the
+  audit log) are only invoked from
+  [`tests/test_investment_team.py`](../tests/test_investment_team.py). No
+  production path calls them, and there is no FastAPI `lifespan` wiring them
+  to startup.
+- **Why the dashed transitions still appear.** They document the orchestrator
+  contract that downstream code is expected to adopt in Phase 0 of the
+  migration roadmap in
+  [`../ARCHITECTURE_REVIEW.md`](../ARCHITECTURE_REVIEW.md). Once wiring lands,
+  the dashed edges become solid and the safe-degrade invariant is enforced at
+  runtime rather than only in tests.

--- a/backend/agents/investment_team/system_design/system_design.md
+++ b/backend/agents/investment_team/system_design/system_design.md
@@ -1,0 +1,351 @@
+# System Design — Investment Team
+
+Component view of the API router, detail on the orchestrator queues and
+promotion gates, and a class diagram of the core Pydantic domain models.
+
+For the container-level view of how this team fits into Khala, see
+[`architecture.md`](./architecture.md).
+
+## Component diagram — API router
+
+How each endpoint reaches an agent or orchestrator call and which persistence
+bucket it reads/writes. Every line number below is from
+[`api/main.py`](../api/main.py).
+
+```mermaid
+flowchart LR
+  subgraph advisor_api[Advisor Endpoints]
+    E1["POST /advisor/sessions<br/>L1981"]
+    E2["POST /advisor/sessions/{id}/messages<br/>L1997"]
+    E3["GET /advisor/sessions/{id}<br/>L2022"]
+    E4["POST /advisor/sessions/{id}/complete<br/>L2033"]
+    E5["POST /profiles<br/>L395"]
+    E6["GET /profiles/{user_id}<br/>L474"]
+    E7["POST /proposals/create<br/>L484"]
+    E8["GET /proposals/{id}<br/>L524"]
+    E9["POST /proposals/{id}/validate<br/>L534"]
+    E10["POST /memos<br/>L783"]
+  end
+
+  subgraph shared_api[Shared Endpoints]
+    S1["POST /strategies<br/>L557"]
+    S2["POST /strategies/{id}/validate<br/>L581"]
+    S3["POST /backtests<br/>L654"]
+    S4["GET /backtests<br/>L704"]
+    S5["POST /promotions/decide<br/>L719"]
+    S6["GET /workflow/status<br/>L756"]
+    S7["GET /workflow/queues<br/>L767"]
+    S8["GET /health<br/>L389"]
+  end
+
+  subgraph lab_api[Strategy Lab Endpoints]
+    L1["POST /strategy-lab/run<br/>L1251"]
+    L2["GET /strategy-lab/results<br/>L1294"]
+    L3["GET /strategy-lab/jobs<br/>L1340"]
+    L4["POST /strategy-lab/runs/{id}/resume<br/>L1402"]
+    L5["POST /strategy-lab/runs/{id}/restart<br/>L1467"]
+    L6["GET /strategy-lab/runs<br/>L1526"]
+    L7["GET /strategy-lab/runs/{id}/status<br/>L1534"]
+    L8["GET /strategy-lab/runs/{id}/stream<br/>L1550"]
+    L9["DELETE /strategy-lab/records/{id}<br/>L1692"]
+    L10["DELETE /strategy-lab/storage<br/>L1732"]
+    L11["POST /strategy-lab/paper-trade<br/>L1792"]
+    L12["GET /strategy-lab/paper-trade/results<br/>L1901"]
+    L13["GET /strategy-lab/paper-trade/{id}<br/>L1929"]
+  end
+
+  subgraph handlers[Agents & Orchestrator]
+    FA[FinancialAdvisorAgent]
+    PG[PolicyGuardianAgent]
+    VA[ValidationAgent]
+    PGate[PromotionGateAgent]
+    IC[InvestmentCommitteeAgent]
+    SIE[SignalIntelligenceExpert]
+    SIA[StrategyIdeationAgent]
+    BTA[BacktestingAgent]
+    PTA[PaperTradingAgent]
+    ORCH[InvestmentTeamOrchestrator]
+    Worker[_strategy_lab_worker]
+    EventBus[job_event_bus]
+  end
+
+  subgraph buckets[Persistent Buckets via _PersistentDict]
+    B1[(investment_advisor_sessions)]
+    B2[(investment_profiles)]
+    B3[(investment_proposals)]
+    B4[(investment_strategies)]
+    B5[(investment_validations)]
+    B6[(investment_backtests)]
+    B7[(investment_strategy_lab_records)]
+    B8[(investment_paper_trading_sessions)]
+  end
+
+  E1 --> FA --> B1
+  E2 --> FA --> B1
+  E3 --> B1
+  E4 --> FA --> B2
+  E5 --> B2
+  E6 --> B2
+  E7 --> B3
+  E8 --> B3
+  E9 --> PG --> B3
+  E10 --> IC
+
+  S1 --> B4
+  S2 --> VA --> B5
+  S3 --> BTA --> B6
+  S4 --> B6
+  S5 --> ORCH --> PGate
+  PGate -.reads.-> B2
+  PGate -.reads.-> B4
+  PGate -.reads.-> B5
+  S6 --> ORCH
+  S7 --> ORCH
+
+  L1 --> Worker
+  Worker --> SIE
+  Worker --> SIA
+  Worker --> BTA
+  Worker --> B7
+  Worker --> EventBus
+  L2 --> B7
+  L3 --> B7
+  L4 --> Worker
+  L5 --> Worker
+  L6 --> Worker
+  L7 --> Worker
+  L8 --> EventBus
+  L9 --> B7
+  L10 --> B7
+  L11 --> PTA --> B8
+  L12 --> B8
+  L13 --> B8
+```
+
+## Orchestrator — six queues
+
+Defined in [`orchestrator.py`](../orchestrator.py):38-51 as
+`WorkflowState.queues`. Each queue is a FIFO of `QueueItem(queue, payload_id,
+priority)`:
+
+| Queue | Purpose | Enqueue source |
+|---|---|---|
+| `research` | Strategy ideation / discovery work waiting for bandwidth | Ad hoc via `orchestrator.enqueue` |
+| `portfolio_design` | Proposals being assembled against an IPS | Ad hoc |
+| `validation` | Strategies awaiting `ValidationAgent` checks | Ad hoc |
+| `promotion` | Validated strategies awaiting promotion decision | Ad hoc |
+| `execution` | Accepted strategies awaiting execution routing | Ad hoc |
+| `escalation` | Rejected / revised strategies needing human review | **Automatic**: any `PromotionDecision` with outcome `reject` or `revise` is enqueued here with `priority="high"` ([`orchestrator.py`](../orchestrator.py):113-117) |
+
+`GET /workflow/queues` ([`api/main.py`](../api/main.py):767) exposes the
+current contents of every queue; `GET /workflow/status` ([`api/main.py`](../api/main.py):756)
+returns the current `WorkflowMode` and the audit log.
+
+## Orchestrator — promotion gates
+
+`PromotionGateAgent.decide` ([`agents.py`](../agents.py):131-302) runs the
+six gates in strict order. Short-circuit semantics: any `reject` terminates
+the checklist; missing validation forces `revise`; failure to unlock a live
+precondition falls back to `paper`.
+
+| # | Gate | Fails when | Outcome on failure |
+|---|---|---|---|
+| 1 | Separation of duties | `proposer_agent_id == approver.agent_id` | `reject` |
+| 2 | Risk veto | `risk_veto == True` | `reject` |
+| 3 | Validation completeness & pass criteria | Any required check missing or failed | `revise` |
+| 4 | IPS live-trading permission | `ips.live_trading_enabled == False` | fall back to `paper` |
+| 5 | Human live approval | `ips.human_approval_required_for_live and not human_live_approval` | fall back to `paper` |
+| 6 | Promote to live | All gates pass | `live` |
+
+Every gate records a `GateCheckResult(gate, result, details)` in
+`PromotionDecision.gate_results` and the decision carries an `AuditContext`
+for traceability.
+
+## Domain model — class diagram
+
+Core Pydantic models from [`models.py`](../models.py) (477 lines). Only the
+most important fields are shown; enums are in the lower block.
+
+```mermaid
+classDiagram
+    class InvestmentProfile {
+      +user_id: str
+      +risk_tolerance: RiskTolerance
+      +time_horizon_years: int
+      +income: IncomeProfile
+      +net_worth: NetWorth
+      +savings: SavingsRate
+      +tax: TaxProfile
+      +liquidity: LiquidityNeeds
+      +goals: List~UserGoal~
+      +preferences: UserPreferences
+      +constraints: PortfolioConstraints
+    }
+    class IPS {
+      +profile: InvestmentProfile
+      +live_trading_enabled: bool
+      +human_approval_required_for_live: bool
+      +speculative_sleeve_cap_pct: float
+      +default_mode: WorkflowMode
+    }
+    class PortfolioProposal {
+      +proposal_id: str
+      +user_id: str
+      +positions: List~PortfolioPosition~
+      +asset_universe: AssetUniverse
+      +audit: AuditContext
+    }
+    class PortfolioPosition {
+      +symbol: str
+      +weight_pct: float
+      +asset_class: str
+    }
+    class StrategySpec {
+      +strategy_id: str
+      +asset_class: str
+      +hypothesis: str
+      +signal_definition: str
+      +entry_rules: str
+      +exit_rules: str
+      +sizing_rules: str
+      +risk_limits: dict
+      +speculative: bool
+    }
+    class ValidationReport {
+      +strategy_id: str
+      +checks: List~ValidationCheck~
+      +summary: str
+    }
+    class BacktestConfig {
+      +start_date: date
+      +end_date: date
+      +initial_capital: float
+      +benchmark: str
+      +rebalance: str
+      +costs_bps: float
+      +slippage_bps: float
+    }
+    class BacktestResult {
+      +total_return_pct: float
+      +annualized_return_pct: float
+      +volatility_pct: float
+      +sharpe_ratio: float
+      +max_drawdown_pct: float
+      +win_rate_pct: float
+      +profit_factor: float
+    }
+    class BacktestRecord {
+      +backtest_id: str
+      +strategy: StrategySpec
+      +config: BacktestConfig
+      +result: BacktestResult
+      +trades: List~TradeRecord~
+      +submitted_by: str
+      +created_at: str
+    }
+    class StrategyLabRecord {
+      +lab_record_id: str
+      +strategy: StrategySpec
+      +backtest: BacktestRecord
+      +is_winning: bool
+      +narrative: str
+      +signal_brief: dict
+    }
+    class PromotionDecision {
+      +strategy_id: str
+      +outcome: PromotionStage
+      +gate_results: List~GateCheckResult~
+      +audit: AuditContext
+    }
+    class GateCheckResult {
+      +gate: PromotionGate
+      +result: GateResult
+      +details: str
+    }
+    class AdvisorSession {
+      +session_id: str
+      +status: AdvisorSessionStatus
+      +current_topic: AdvisorTopic
+      +messages: List~ChatMessage~
+      +collected: CollectedProfileData
+    }
+    class ChatMessage {
+      +role: str
+      +content: str
+      +timestamp: str
+    }
+    class CollectedProfileData {
+      +risk_tolerance?: RiskTolerance
+      +time_horizon_years?: int
+      +income?: IncomeProfile
+      +net_worth?: NetWorth
+      +...
+    }
+    class PaperTradingSession {
+      +session_id: str
+      +strategy_id: str
+      +status: PaperTradingStatus
+      +verdict: PaperTradingVerdict
+      +start_date: date
+      +end_date: date
+      +result: BacktestResult
+      +comparison: PaperTradingComparison
+    }
+    class PaperTradingComparison {
+      +backtest_sharpe: float
+      +paper_sharpe: float
+      +divergence_pct: float
+      +analysis: str
+    }
+    class AuditContext {
+      +snapshot_id: str
+      +assumptions: List~str~
+      +agent_version: str
+    }
+
+    InvestmentProfile --> IPS : wraps
+    IPS --> PortfolioProposal : constrains
+    PortfolioProposal o-- PortfolioPosition
+    PortfolioProposal --> AuditContext
+    StrategySpec --> ValidationReport : validated by
+    StrategySpec --> BacktestConfig : run with
+    BacktestConfig --> BacktestResult : produces
+    BacktestResult --> BacktestRecord : wrapped in
+    StrategySpec --> StrategyLabRecord : ideated into
+    BacktestRecord --> StrategyLabRecord : wrapped in
+    StrategySpec --> PromotionDecision : decided by
+    ValidationReport --> PromotionDecision : input to
+    IPS --> PromotionDecision : input to
+    PromotionDecision o-- GateCheckResult
+    PromotionDecision --> AuditContext
+    AdvisorSession o-- ChatMessage
+    AdvisorSession --> CollectedProfileData
+    CollectedProfileData ..> InvestmentProfile : builds
+    StrategySpec --> PaperTradingSession : simulated in
+    PaperTradingSession --> PaperTradingComparison
+```
+
+### Enums
+
+| Enum | Values | Defined |
+|---|---|---|
+| `RiskTolerance` | `conservative`, `moderate_conservative`, `moderate`, `moderate_aggressive`, `aggressive` | [`models.py`](../models.py):11 |
+| `WorkflowMode` | `monitor_only`, `paper`, `live` | [`models.py`](../models.py):55 |
+| `PromotionStage` | `reject`, `revise`, `paper`, `live` | [`models.py`](../models.py):42 |
+| `PromotionGate` | `separation_of_duties`, `risk_veto`, `validation`, `ips_live`, `human_approval`, `live_promote` | [`models.py`](../models.py):62 |
+| `GateResult` | `pass`, `fail`, `warn` | [`models.py`](../models.py):70 |
+| `AdvisorTopic` | `greeting`, `risk`, `horizon`, `income`, `net_worth`, `savings`, `tax`, `liquidity`, `goals`, `preferences`, `constraints`, `review` | [`models.py`](../models.py):24 |
+| `AdvisorSessionStatus` | `active`, `completed`, `abandoned` | [`models.py`](../models.py):18 |
+| `PaperTradingStatus` | `running`, `completed`, `failed` | [`models.py`](../models.py):367 |
+| `PaperTradingVerdict` | `ready_for_live`, `not_performant`, `requires_review` | [`models.py`](../models.py):373 |
+
+## Persistence strategy (recap)
+
+Instead of owning a `shared_postgres` schema, the team pushes every artifact
+through the `_PersistentDict` wrapper ([`api/main.py`](../api/main.py):85-132).
+Reads and writes look like a normal Python dict but the backing store is the
+Khala job service (`JobServiceClient`), which persists to the `khala_jobs`
+Postgres database. The bucket names double as the job-service `team` field so
+operators can clean up with SQL filters like
+`WHERE team = 'investment_strategy_lab_records'` — see
+[`../README.md`](../README.md):77-86.

--- a/backend/agents/investment_team/system_design/use_cases.md
+++ b/backend/agents/investment_team/system_design/use_cases.md
@@ -1,0 +1,183 @@
+# Use Cases — Investment Team
+
+UML-style use case view. Actors are on the left and right; the system boundary
+in the middle groups every investment-team use case. Each use case is mapped
+to the HTTP endpoint that triggers it and the agent(s) that handle it.
+
+## Actors
+
+| Actor | Role |
+|---|---|
+| **End User** | Retail investor using the Angular UI — drives the advisor conversation, reviews proposals and memos |
+| **Proposer Agent** | Upstream agent (another Khala team, a CLI, or a human operator) that submits strategies for validation and promotion |
+| **Approver / Risk Officer** | Separate principal that holds risk-veto and human-approval authority; enforces separation of duties |
+| **Operations** | Admin role responsible for workflow monitoring and lab storage cleanup |
+| **Market Data Providers** *(secondary)* | External OHLCV and snapshot sources (Yahoo Finance, Twelve Data, CoinGecko, Alpha Vantage, FRED, Frankfurter) |
+| **LLM Service** *(secondary)* | Ollama / Claude inference backend used by every agent |
+
+## Use case diagram
+
+```mermaid
+flowchart LR
+  EndUser((End User))
+  Proposer((Proposer Agent))
+  Approver((Approver /<br/>Risk Officer))
+  Ops((Operations))
+  MarketData((Market Data<br/>Providers))
+  LLM((LLM Service))
+
+  subgraph system[Investment Team — /api/investment]
+    direction TB
+
+    subgraph advisor_uc[Advisor / IPS track]
+      UC1([Start advisor session])
+      UC2([Answer profile questions])
+      UC3([Review IPS draft])
+      UC4([Finalize IPS])
+      UC5([Upsert profile directly])
+      UC6([Create portfolio proposal])
+      UC7([Validate proposal<br/>against IPS])
+      UC8([Request investment<br/>committee memo])
+    end
+
+    subgraph shared_uc[Shared — strategy, backtest, promotion]
+      UC9([Create strategy spec])
+      UC10([Validate strategy])
+      UC11([Run backtest])
+      UC12([List backtests])
+      UC13([Decide promotion<br/>6-gate checklist])
+      UC14([View workflow status])
+      UC15([View workflow queues])
+    end
+
+    subgraph lab_uc[Strategy Lab track]
+      UC16([Run strategy lab batch])
+      UC17([Stream run progress<br/>via SSE])
+      UC18([Poll run status])
+      UC19([Resume paused run])
+      UC20([Restart failed run])
+      UC21([List active runs])
+      UC22([List winners / losers])
+      UC23([List lab jobs])
+      UC24([Delete lab record])
+      UC25([Purge lab storage])
+      UC26([Run paper-trading session])
+      UC27([List paper sessions])
+      UC28([Get paper session detail])
+    end
+  end
+
+  EndUser --> UC1
+  EndUser --> UC2
+  EndUser --> UC3
+  EndUser --> UC4
+  EndUser --> UC5
+  EndUser --> UC6
+  EndUser --> UC7
+  EndUser --> UC8
+  EndUser --> UC17
+
+  Proposer --> UC9
+  Proposer --> UC10
+  Proposer --> UC11
+  Proposer --> UC12
+  Proposer --> UC16
+  Proposer --> UC26
+
+  Approver --> UC13
+
+  Ops --> UC14
+  Ops --> UC15
+  Ops --> UC18
+  Ops --> UC19
+  Ops --> UC20
+  Ops --> UC21
+  Ops --> UC22
+  Ops --> UC23
+  Ops --> UC24
+  Ops --> UC25
+  Ops --> UC27
+  Ops --> UC28
+
+  UC11 --> MarketData
+  UC16 --> MarketData
+  UC26 --> MarketData
+
+  UC1 --> LLM
+  UC2 --> LLM
+  UC8 --> LLM
+  UC11 --> LLM
+  UC16 --> LLM
+  UC26 --> LLM
+```
+
+> *Mermaid flowchart is used here as a pragmatic stand-in for a classical UML
+> use-case diagram — GitHub does not ship a dedicated use-case renderer.
+> Actors are circular nodes, use cases are ovals (`([ ])`), and the system
+> boundary is the subgraph labeled "Investment Team".*
+
+## Use case → endpoint → agent map
+
+### Advisor / IPS track
+
+| Use case | Endpoint | Agent(s) | Persists to |
+|---|---|---|---|
+| Start advisor session | `POST /advisor/sessions` | `FinancialAdvisorAgent.start_session` ([`agents.py`](../agents.py):433) | `investment_advisor_sessions` |
+| Answer profile questions | `POST /advisor/sessions/{id}/messages` | `FinancialAdvisorAgent.handle_message` ([`agents.py`](../agents.py):449) | `investment_advisor_sessions` |
+| Review IPS draft | `GET /advisor/sessions/{id}` | — (read-only) | `investment_advisor_sessions` |
+| Finalize IPS | `POST /advisor/sessions/{id}/complete` | `FinancialAdvisorAgent.build_ips` ([`agents.py`](../agents.py):509) | `investment_profiles` |
+| Upsert profile directly | `POST /profiles` | — | `investment_profiles` |
+| Get profile / IPS | `GET /profiles/{user_id}` | — (read-only) | `investment_profiles` |
+| Create portfolio proposal | `POST /proposals/create` | — | `investment_proposals` |
+| Get proposal | `GET /proposals/{proposal_id}` | — (read-only) | `investment_proposals` |
+| Validate proposal against IPS | `POST /proposals/{proposal_id}/validate` | `PolicyGuardianAgent.check_portfolio` ([`agents.py`](../agents.py):49) | `investment_proposals` |
+| Request investment committee memo | `POST /memos` | `InvestmentCommitteeAgent.draft_memo` ([`agents.py`](../agents.py):303) | — |
+
+### Shared — strategy, backtest, promotion
+
+| Use case | Endpoint | Agent(s) | Persists to |
+|---|---|---|---|
+| Create strategy spec | `POST /strategies` | — | `investment_strategies` |
+| Validate strategy | `POST /strategies/{id}/validate` | `ValidationAgent.checklist_failures` ([`agents.py`](../agents.py):106) | `investment_validations` |
+| Run backtest | `POST /backtests` | `BacktestingAgent.run_backtest` | `investment_backtests` |
+| List backtests | `GET /backtests` | — (read-only) | `investment_backtests` |
+| Decide promotion | `POST /promotions/decide` | `InvestmentTeamOrchestrator.promotion_decision` → `PromotionGateAgent.decide` ([`orchestrator.py`](../orchestrator.py):92, [`agents.py`](../agents.py):131) | audit log + escalation queue on reject/revise |
+| View workflow status | `GET /workflow/status` | `InvestmentTeamOrchestrator` | — |
+| View workflow queues | `GET /workflow/queues` | `InvestmentTeamOrchestrator` | — |
+| Health check | `GET /health` | — | — |
+
+### Strategy Lab track
+
+| Use case | Endpoint | Agent(s) | Persists to |
+|---|---|---|---|
+| Run strategy lab batch | `POST /strategy-lab/run` | `_strategy_lab_worker` → `SignalIntelligenceExpert` → `StrategyIdeationAgent` → `BacktestingAgent` | `investment_strategy_lab_records` |
+| Stream run progress | `GET /strategy-lab/runs/{id}/stream` | `job_event_bus` subscription | — |
+| Poll run status | `GET /strategy-lab/runs/{id}/status` | `_active_runs` + `_load_run_from_job_service` | — |
+| Resume paused run | `POST /strategy-lab/runs/{id}/resume` | `_strategy_lab_worker` | `investment_strategy_lab_records` |
+| Restart failed run | `POST /strategy-lab/runs/{id}/restart` | `_strategy_lab_worker` | `investment_strategy_lab_records` |
+| List active runs | `GET /strategy-lab/runs` | `_active_runs` | — |
+| List winners / losers | `GET /strategy-lab/results` | — (read-only) | `investment_strategy_lab_records` |
+| List lab jobs | `GET /strategy-lab/jobs` | — (read-only) | `investment_strategy_lab_records` |
+| Delete lab record | `DELETE /strategy-lab/records/{id}` | — | `investment_strategy_lab_records` + linked strategies / backtests / paper sessions |
+| Purge lab storage | `DELETE /strategy-lab/storage` | — | all strategy-lab buckets |
+| Run paper-trading session | `POST /strategy-lab/paper-trade` | `PaperTradingAgent.run_paper_trading` | `investment_paper_trading_sessions` |
+| List paper sessions | `GET /strategy-lab/paper-trade/results` | — (read-only) | `investment_paper_trading_sessions` |
+| Get paper session detail | `GET /strategy-lab/paper-trade/{session_id}` | — (read-only) | `investment_paper_trading_sessions` |
+
+## Profile requirement per use case
+
+Matches the authoritative list in [`../README.md`](../README.md):58-76.
+
+**Requires `user_id` / IPS loaded from store:**
+`POST /profiles`, `GET /profiles/{user_id}`,
+`POST /proposals/create`, `POST /proposals/{proposal_id}/validate`,
+`POST /promotions/decide`, `POST /memos`,
+`POST /advisor/sessions` (and messages / complete).
+
+**Does not require a user investment profile:**
+`POST /strategies`, `POST /strategies/{strategy_id}/validate`,
+`POST /backtests`, `GET /backtests`,
+`POST /strategy-lab/run`, `GET /strategy-lab/results`,
+`DELETE /strategy-lab/records/{lab_record_id}`, `DELETE /strategy-lab/storage`,
+`GET /workflow/status`, `GET /workflow/queues`, and every other
+`/strategy-lab/*` endpoint.


### PR DESCRIPTION
Document the architectural and design decisions of the investment team in a
new backend/agents/investment_team/system_design/ folder with five
diagram-heavy markdown files: an index README, a C4-style architecture
container view, a component + class-diagram system design, a UML-style use
case view, and four flow charts (advisor session, strategy lab batch,
promotion-gate decision tree, orchestrator workflow mode). All diagrams use
Mermaid so they render on GitHub without extra tooling, and every reference
links back to source files and line numbers.

https://claude.ai/code/session_01X4UJ1XpCEcNxqJHteVqobU