### PR TITLE
Document startup advisor team architecture and design decisions

### DIFF
--- a/backend/agents/startup_advisor/system_design/README.md
+++ b/backend/agents/startup_advisor/system_design/README.md
@@ -1,0 +1,55 @@
+# Startup Advisor — System Design Documentation
+
+This folder is the architectural and design reference for the startup
+advisor team (`backend/agents/startup_advisor/`). It documents the
+team as it exists in code today: a persistent, conversational startup
+advisor that runs as a **single FastAPI app with one specialist LLM
+agent**, a **singleton per-deployment conversation** persisted in
+Postgres, and an optional Temporal workflow wrapper around its
+message handler.
+
+The top-level `backend/agents/startup_advisor/README.md` stays the
+user-facing operational reference (prefix, one-line description).
+These documents focus on **why** and **how** — the design decisions,
+data flow, and internal structure — so future contributors do not
+have to reverse-engineer the team from source files.
+
+## Documents in this folder
+
+| Document | Purpose |
+|---|---|
+| [`architecture.md`](./architecture.md) | Static architecture: layered component diagram, architectural principles, key design decisions. |
+| [`system_design.md`](./system_design.md) | Detailed system design: module layout, domain model, API surface, persistence schema, LLM integration, runtime modes, configuration. |
+| [`use_cases.md`](./use_cases.md) | Actors and numbered use cases with triggers, preconditions, main/alternate flows, and entry-point endpoints. |
+| [`flow_charts.md`](./flow_charts.md) | Sequence and flow diagrams for every runtime path (get-or-create, probing dialogue, artifact generation, LLM fallback, context accumulation, Temporal, lifespan). |
+
+## Source files referenced across these documents
+
+| Area | Path |
+|---|---|
+| FastAPI app / endpoints | `backend/agents/startup_advisor/api/main.py` |
+| Conversational agent | `backend/agents/startup_advisor/assistant/agent.py` |
+| Postgres store | `backend/agents/startup_advisor/store.py` |
+| Postgres schema | `backend/agents/startup_advisor/postgres/__init__.py` |
+| Temporal wrapper | `backend/agents/startup_advisor/temporal/__init__.py` |
+| Store unit tests | `backend/agents/startup_advisor/tests/test_store.py` |
+| Team mount config | `backend/unified_api/config.py` (lines 202-209) |
+| Top-level README | `backend/agents/startup_advisor/README.md` |
+
+## Conventions used in this documentation
+
+- **Mermaid only** for diagrams — matches the existing team
+  documentation style (branding, investment, accessibility audit).
+- **Line-referenced citations** (e.g. `store.py:231`) whenever a
+  claim describes specific code behavior.
+- **Neutral technical tone**, no emojis.
+- All file paths are relative to the repository root.
+- The team has **no explicit orchestrator module** — the FastAPI
+  route handler itself coordinates store + agent. These docs reflect
+  that faithfully rather than inventing a "team lead" layer.
+- The **singleton conversation** design (one row in
+  `startup_advisor_conversations` per deployment) is described as a
+  deliberate choice; see `store.py:231-247` and the cross-reference
+  in `architecture.md`.
+- **Temporal** flows are marked as optional, gated on
+  `is_temporal_enabled()` (`temporal/__init__.py:38-41`).

--- a/backend/agents/startup_advisor/system_design/architecture.md
+++ b/backend/agents/startup_advisor/system_design/architecture.md
@@ -1,0 +1,249 @@
+# Startup Advisor — Architecture
+
+## Overview
+
+The startup advisor is a **probing-dialogue advisory service**: it
+talks to a founder, asks one to three focused questions at a time,
+accumulates structured facts about the startup, and — once it has
+gathered enough context on a topic — produces a structured artifact
+(action plan, GTM strategy, fundraising brief, etc.).
+
+Unlike the larger teams in the Khala monorepo (software engineering,
+branding, investment), it is intentionally small:
+
+1. **No orchestrator module.** The FastAPI route handler
+   `send_message` (`api/main.py:187-242`) is the entire coordination
+   layer. It calls the store, calls the single specialist agent, and
+   writes the results back.
+2. **One specialist agent.** `StartupAdvisorAgent`
+   (`assistant/agent.py:105-177`) is the only domain agent in the
+   team. It talks to an LLM through `llm_service.get_client` with
+   `think=True` (chain-of-thought) and returns a JSON object the
+   handler decodes.
+3. **Singleton conversation.** Exactly one conversation row lives in
+   `startup_advisor_conversations` per deployment. Every request
+   resolves the conversation through `get_or_create_singleton`
+   (`store.py:231-247`) rather than accepting a `conversation_id`
+   path parameter.
+
+## Architectural principles
+
+- **Single persistent conversation per deployment.**
+  `get_or_create_singleton()` in `store.py:231-247` returns the
+  oldest row by `created_at`, creating one if the table is empty.
+  The four endpoints in `api/main.py` all start from this singleton
+  rather than accepting a `conversation_id`. This is a deliberate
+  product choice — the advisor is modelled as a long-running
+  coaching relationship, not as one-shot sessions.
+- **Stateless store backed by a connection pool.**
+  `StartupAdvisorConversationStore.__init__` takes no arguments and
+  holds no state (`store.py:88-90`). Every method opens a
+  short-lived connection through `shared_postgres.get_conn()`
+  (`store.py:29`), which is pool-backed, and each method is wrapped
+  in `@timed_query` so slow reads and writes surface as structured
+  log lines (`store.py:92,105,132,156,167,186,206,230`).
+- **Structured-output LLM contract.** The agent does not return
+  free text. `SYSTEM_PROMPT` in `assistant/agent.py:16-72` instructs
+  the model to emit a JSON object with four fields (`reply`,
+  `context_update`, `suggested_questions`, `artifact`), and
+  `_parse_response` in `assistant/agent.py:87-102` decodes it with
+  a markdown-fence-stripping regex. This is what lets a single HTTP
+  response carry both the chat reply and the side-effects (context
+  delta + optional artifact).
+- **Non-empty-only context merge.** `_merge_context` in
+  `api/main.py:148-154` only overwrites an existing key when the
+  new value is neither `None` nor the empty string. This prevents a
+  noisy LLM turn from wiping facts that have already been
+  established earlier in the conversation.
+- **Graceful LLM fallback.** If `self._llm.complete` raises, the
+  agent catches the exception, logs it, and returns a hard-coded
+  reply with three canned probing questions and no context update
+  (`assistant/agent.py:146-164`). The founder never sees a 500.
+- **Observability wired in at every layer.** The FastAPI app calls
+  `init_otel(service_name="startup-advisor", team_key="startup_advisor")`
+  at import time and `instrument_fastapi_app` once the app object
+  exists (`api/main.py:17,43`). Every store method carries a
+  `@timed_query(store=_STORE, op=...)` decorator
+  (`store.py:92,105,132,156,167,186,206,230`).
+- **Optional Temporal mode.** `temporal/__init__.py:38-41` starts a
+  `startup_advisor-queue` worker only when
+  `shared_temporal.is_temporal_enabled()` returns true (i.e. when
+  `TEMPORAL_ADDRESS` is set). The team works identically in thread
+  mode without Temporal.
+- **Lazy module-level singletons.** Both the store
+  (`store.py:254-266`) and the agent (`assistant/agent.py:170-177`)
+  are instantiated on first use through module-level
+  `get_conversation_store()` / `get_advisor_agent()` helpers. The
+  FastAPI handlers never import them eagerly — they go through
+  `_get_store` / `_get_agent` (`api/main.py:108-117`) so
+  `import startup_advisor.api.main` stays cheap and never touches
+  Postgres or the LLM at import time.
+
+## Component diagram
+
+```mermaid
+flowchart TB
+    subgraph clients[External clients]
+        UI["Angular UI"]
+        CLI["curl / CLI"]
+        Other["Other Khala teams"]
+    end
+
+    subgraph gateway[Unified API gateway]
+        UnifiedAPI["Unified API<br/>/api/startup-advisor/*<br/>unified_api/config.py:202-209"]
+    end
+
+    subgraph api_layer["FastAPI app — api/main.py"]
+        direction TB
+        GetConv["GET /conversation<br/>api/main.py:162"]
+        PostMsg["POST /conversation/messages<br/>api/main.py:187"]
+        GetArt["GET /conversation/artifacts<br/>api/main.py:245"]
+        Health["GET /health<br/>api/main.py:263"]
+        Lifespan["_lifespan()<br/>api/main.py:20-34<br/>register_team_schemas + close_pool"]
+    end
+
+    subgraph domain[Domain layer]
+        direction TB
+        Agent["StartupAdvisorAgent<br/>assistant/agent.py:105-177<br/>respond() -> (reply, ctx_update,<br/>suggested, artifact)"]
+        Merge["_merge_context()<br/>api/main.py:148-154<br/>non-empty overwrite"]
+    end
+
+    subgraph persistence[Persistence layer]
+        direction TB
+        Store["StartupAdvisorConversationStore<br/>store.py:78-247<br/>@timed_query on every op"]
+        Pool["shared_postgres.get_conn()<br/>pool-backed"]
+        PG[(Postgres<br/>startup_advisor_conversations<br/>startup_advisor_conv_messages<br/>startup_advisor_conv_artifacts)]
+    end
+
+    subgraph llm[LLM layer]
+        LLMClient["llm_service.get_client('startup_advisor')<br/>complete(prompt, think=True)"]
+        Model["Ollama / Claude<br/>(provider-configurable)"]
+    end
+
+    subgraph temporal_opt["Temporal (optional)"]
+        Worker["startup_advisor-queue worker<br/>temporal/__init__.py:38-41"]
+        Workflow["StartupAdvisorWorkflow.run<br/>temporal/__init__.py:22-30"]
+        Activity["run_pipeline_activity<br/>temporal/__init__.py:11-19"]
+    end
+
+    clients --> UnifiedAPI
+    UnifiedAPI --> GetConv
+    UnifiedAPI --> PostMsg
+    UnifiedAPI --> GetArt
+    UnifiedAPI --> Health
+
+    GetConv --> Store
+    PostMsg --> Store
+    PostMsg --> Agent
+    PostMsg --> Merge
+    GetArt --> Store
+
+    Agent --> LLMClient
+    LLMClient --> Model
+
+    Store --> Pool
+    Pool --> PG
+
+    Lifespan -. "app start" .-> Store
+    Lifespan -. "app stop" .-> Pool
+
+    Worker -. "optional" .-> Workflow
+    Workflow -. "execute_activity" .-> Activity
+    Activity -. "calls send_message" .-> PostMsg
+```
+
+## Key design decisions
+
+### 1. Singleton conversation instead of per-session IDs
+
+**Decision.** The team exposes `GET /conversation`,
+`POST /conversation/messages`, and `GET /conversation/artifacts`
+with no `conversation_id` path parameter. Internally, every call
+resolves the single row via `get_or_create_singleton`
+(`store.py:231-247`, called from `api/main.py:166,193,249`).
+
+**Why.** The product is modelled as a long-lived coaching
+relationship. A founder returning a week later should land back in
+the same conversation with the advisor still remembering stage,
+team size, runway, and prior artifacts. Exposing session IDs would
+add client-side state (cookies, local storage) for no product
+benefit.
+
+**Trade-off.** This means the store layer still supports multiple
+conversations (`create`, `list_conversations`, `get(conversation_id)`
+in `store.py:92-103,207-228`) but the API intentionally surfaces
+only one. If a multi-tenant deployment is needed later, the API
+layer is the only thing that has to change.
+
+### 2. JSON-structured LLM output (reply + side-effects)
+
+**Decision.** `SYSTEM_PROMPT` in `assistant/agent.py:53-72`
+mandates a JSON object with `reply`, `context_update`,
+`suggested_questions`, and `artifact`. `_parse_response` in
+`assistant/agent.py:87-102` strips markdown fencing and decodes it;
+on decode failure it falls back to returning the raw text as
+`reply` and empty defaults for the other three fields.
+
+**Why.** A single LLM round trip has to carry three distinct
+side-effects: the chat reply that the UI renders, the structured
+facts to merge into the persistent context, and an optional
+artifact to persist and display. Parsing them out of one JSON
+object is cheaper and more reliable than making three separate
+calls or asking the LLM to emit a custom delimiter format.
+
+### 3. Non-empty-only context merge
+
+**Decision.** `_merge_context` in `api/main.py:148-154` iterates
+over the update dict and only writes back keys whose value is
+neither `None` nor `""`.
+
+**Why.** LLMs intermittently emit partial `context_update` dicts
+with empty strings for keys they have "no update for". Without
+the filter, a later turn could wipe `startup_name` or
+`target_audience` that were established five turns earlier. The
+filter is the defence against that.
+
+### 4. No orchestrator module
+
+**Decision.** Unlike the software engineering team (with a
+`TeamLead`) or branding team (with a 5-phase orchestrator class),
+the startup advisor has no separate orchestration layer. The
+FastAPI handler `send_message` directly sequences the store +
+agent calls (`api/main.py:187-242`).
+
+**Why.** There is only one agent, no phase gates, no fan-out, and
+no human-in-the-loop gate. A dedicated orchestrator would add a
+layer of indirection without carrying any logic. The team can
+grow into one later if a second specialist agent is added; for
+now the handler is the orchestrator.
+
+### 5. Lazy singletons for store and agent
+
+**Decision.** `_get_store` and `_get_agent` (`api/main.py:108-117`)
+import and resolve the module-level helpers
+`get_conversation_store()` (`store.py:257-266`) and
+`get_advisor_agent()` (`assistant/agent.py:173-177`) on first call.
+
+**Why.** Deferred import keeps `import startup_advisor.api.main`
+free of Postgres handshakes and LLM client construction. That
+matters for test collection, for the unified API boot path
+(which imports every team module eagerly), and for the Temporal
+activity which re-imports `send_message` on every invocation
+(`temporal/__init__.py:13`).
+
+### 6. Optional Temporal wrapper reusing `send_message`
+
+**Decision.** The Temporal activity
+`run_pipeline_activity` (`temporal/__init__.py:11-19`) simply
+deserializes the request into `SendMessageRequest`, calls
+`send_message(req)`, and serializes the result via
+`model_dump()`. The workflow executes that single activity with
+a 30-minute `start_to_close_timeout`
+(`temporal/__init__.py:22-30`).
+
+**Why.** The team has no long-running compute, no phases, and no
+retries that require Temporal's durability. The wrapper exists
+only so the team can be driven through a Temporal workflow
+alongside other teams in the monorepo — there is no separate
+Temporal code path, and the thread-mode handler remains the
+canonical implementation.

--- a/backend/agents/startup_advisor/system_design/flow_charts.md
+++ b/backend/agents/startup_advisor/system_design/flow_charts.md
@@ -1,0 +1,362 @@
+# Startup Advisor — Flow Charts
+
+Sequence diagrams and state charts for every runtime path in the
+startup advisor team. Each diagram is citation-linked to the source
+file + line range that implements the flow.
+
+## Flow A — Get or create conversation
+
+Entry point: `GET /api/startup-advisor/conversation` →
+`get_or_create_conversation` at `api/main.py:162-184`.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Founder
+    participant API as FastAPI handler<br/>(api/main.py:162)
+    participant Store as StartupAdvisorConversationStore
+    participant PG as Postgres
+
+    Founder->>API: GET /conversation
+    API->>Store: get_or_create_singleton()
+    Store->>PG: SELECT conversation_id FROM<br/>startup_advisor_conversations<br/>ORDER BY created_at ASC LIMIT 1
+    alt Row exists
+        PG-->>Store: existing conversation_id
+    else No rows
+        Store->>PG: INSERT conversation (uuid, {}, now, now)
+        PG-->>Store: OK
+    end
+    Store-->>API: cid
+
+    API->>Store: get(cid)
+    Store->>PG: SELECT context_json
+    Store->>PG: SELECT messages ORDER BY id
+    PG-->>Store: (messages, context)
+    Store-->>API: (messages, context)
+
+    API->>Store: get_artifacts(cid)
+    Store->>PG: SELECT * FROM conv_artifacts
+    PG-->>Store: artifacts
+    Store-->>API: artifacts
+
+    alt Transcript is empty
+        API->>Store: append_message(cid, "assistant", WELCOME)
+        Store->>PG: INSERT message + UPDATE updated_at
+        PG-->>Store: OK
+        API->>Store: get(cid)
+        Store-->>API: (messages w/ welcome, context)
+    end
+
+    API-->>Founder: ConversationStateResponse
+```
+
+The welcome-insertion branch at `api/main.py:175-180` only runs on
+the very first call after the row has just been created.
+`_DEFAULT_SUGGESTED` (`api/main.py:101-105`) is returned as the
+`suggested_questions` array whenever the transcript has 0 or 1
+entries.
+
+---
+
+## Flow B — Probing dialogue turn (no artifact)
+
+Entry point: `POST /api/startup-advisor/conversation/messages` →
+`send_message` at `api/main.py:187-242`. This is the hot path for
+UC-2.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Founder
+    participant API as FastAPI handler<br/>(api/main.py:187)
+    participant Store as StartupAdvisorConversationStore
+    participant Agent as StartupAdvisorAgent<br/>(assistant/agent.py:105)
+    participant LLM as llm_service client
+    participant PG as Postgres
+
+    Founder->>API: POST /conversation/messages<br/>{"message": "..."}
+    API->>Store: get_or_create_singleton()
+    Store->>PG: SELECT oldest / INSERT if none
+    PG-->>Store: cid
+    Store-->>API: cid
+
+    API->>Store: get(cid)
+    Store->>PG: SELECT context_json + messages
+    PG-->>Store: (messages, context)
+    Store-->>API: state
+
+    Note over API: If transcript empty, append WELCOME first<br/>(api/main.py:201-206)
+
+    API->>Store: append_message(cid, "user", msg)
+    Store->>PG: INSERT msg + UPDATE updated_at
+    PG-->>Store: OK
+
+    API->>Agent: respond(history, context, msg)
+    Note over Agent: Build USER_TURN_TEMPLATE<br/>assistant/agent.py:74-84
+    Agent->>LLM: complete(prompt, system_prompt,<br/>temperature=0.5, think=True)
+    LLM-->>Agent: raw JSON string
+    Note over Agent: _parse_response strips fences +<br/>json.loads (agent.py:87-102)
+    Agent-->>API: (reply, ctx_update, suggested, artifact=None)
+
+    opt ctx_update non-empty
+        API->>API: _merge_context(existing, update)<br/>non-empty overwrite<br/>(api/main.py:148-154)
+        API->>Store: update_context(cid, merged)
+        Store->>PG: UPDATE context_json
+        PG-->>Store: OK
+    end
+
+    API->>Store: append_message(cid, "assistant", reply)
+    Store->>PG: INSERT msg + UPDATE updated_at
+    PG-->>Store: OK
+
+    API->>Store: get(cid)
+    Store->>PG: SELECT context_json + messages
+    PG-->>Store: refreshed state
+    API->>Store: get_artifacts(cid)
+    Store->>PG: SELECT artifacts
+    PG-->>Store: artifacts
+
+    API-->>Founder: ConversationStateResponse<br/>(transcript, context, artifacts,<br/>suggested_questions)
+```
+
+Key code references:
+
+- User-turn persistence before the LLM call (`api/main.py:209`) —
+  guarantees the message is stored even if the LLM call later
+  raises (see Flow D).
+- Transcript assembly (`api/main.py:212-213`) includes the new
+  user message so the LLM sees it as part of history.
+- Reload + artifact fetch after the LLM response
+  (`api/main.py:236-240`) — the response always reflects the
+  latest persisted state.
+
+---
+
+## Flow C — Turn that yields an artifact
+
+Same handler (`api/main.py:187-242`), highlighting the
+`add_artifact` branch at `api/main.py:229-233`.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Founder
+    participant API as FastAPI handler
+    participant Agent as StartupAdvisorAgent
+    participant LLM as llm_service client
+    participant Store as ConversationStore
+    participant PG as Postgres
+
+    Founder->>API: POST /conversation/messages<br/>"We're ready to take this to market"
+    Note over API: ... same prelude as Flow B ...
+    API->>Agent: respond(history, context, msg)
+    Agent->>LLM: complete(prompt, think=True)
+    LLM-->>Agent: {"reply": "...",<br/>"context_update": {...},<br/>"suggested_questions": [],<br/>"artifact": {<br/>  "type": "gtm_strategy",<br/>  "title": "GTM: Fintech SaaS",<br/>  "content": {...}<br/>}}
+    Agent-->>API: (reply, ctx_update, [], artifact)
+
+    API->>Store: update_context(cid, merged)
+    Store->>PG: UPDATE context_json
+
+    API->>Store: append_message(cid, "assistant", reply)
+    Store->>PG: INSERT msg
+
+    Note over API: artifact is a dict → enter branch<br/>(api/main.py:229-233)
+    API->>API: artifact_type = artifact.get("type","advice")<br/>title = artifact.get("title","Untitled")<br/>content = artifact.get("content", artifact)
+    API->>Store: add_artifact(cid, type, title, content)
+    Store->>PG: INSERT INTO conv_artifacts RETURNING id
+    PG-->>Store: new_id
+    Store-->>API: new_id
+
+    API->>Store: get(cid) + get_artifacts(cid)
+    Store-->>API: state with artifact included
+    API-->>Founder: ConversationStateResponse<br/>artifacts=[...new artifact]
+```
+
+Note that the artifact payload is stored as `JSONB` and is
+free-form: the store accepts any dict shape
+(`store.py:167-184`) and the API returns it verbatim through
+`ArtifactResponse.payload`.
+
+---
+
+## Flow D — LLM failure fallback
+
+Triggered inside `StartupAdvisorAgent.respond` at
+`assistant/agent.py:146-164`. This is UC-5.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Founder
+    participant API as FastAPI handler
+    participant Store as ConversationStore
+    participant Agent as StartupAdvisorAgent
+    participant LLM as llm_service client
+    participant PG as Postgres
+    participant Logs as Service logs
+
+    Founder->>API: POST /conversation/messages<br/>{"message": "..."}
+    API->>Store: append_message(cid, "user", msg)
+    Store->>PG: INSERT user msg
+    Note over API: User turn is persisted<br/>BEFORE the LLM call<br/>(api/main.py:209)
+
+    API->>Agent: respond(history, context, msg)
+    Agent->>LLM: complete(prompt, think=True)
+    LLM--xAgent: Exception (timeout /<br/>network / 5xx)
+    Agent->>Logs: logger.exception(...)
+    Note over Agent: Return hard-coded fallback<br/>(agent.py:153-164)
+    Agent-->>API: (canned reply, {}, [3 canned Qs], None)
+
+    Note over API: ctx_update is empty →<br/>no update_context call<br/>(api/main.py:221-223)
+
+    API->>Store: append_message(cid, "assistant", canned_reply)
+    Store->>PG: INSERT assistant msg
+
+    API->>Store: get(cid) + get_artifacts(cid)
+    Store-->>API: refreshed state
+    API-->>Founder: ConversationStateResponse<br/>(looks like a normal reply)
+```
+
+The founder sees a normal reply with three canned probing
+questions. The failure is visible only in service logs via
+`logger.exception("LLM call failed for startup advisor")`.
+
+---
+
+## Flow E — Context accumulation state chart
+
+Shows how the JSON `context` field on
+`startup_advisor_conversations` evolves turn by turn. The merge
+strategy is at `api/main.py:148-154`: non-empty values overwrite,
+`None` / `""` are ignored.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Empty : row created\nvia create()
+
+    Empty --> PartiallyKnown : turn 1\nLLM emits\n{"industry": "B2B SaaS"}
+    PartiallyKnown --> StageKnown : turn 2\n{"stage": "idea_validation",\n"target_audience": "..."}
+    StageKnown --> TeamKnown : turn 3\n{"team_size": 3,\n"runway_months": 9}
+    TeamKnown --> GoalKnown : turn 4\n{"primary_challenge":\n"ICP definition"}
+    GoalKnown --> ArtifactReady : turn N\nagent decides it\nhas enough context
+
+    ArtifactReady --> GoalKnown : further probing /\nnew challenge
+
+    note right of PartiallyKnown
+      Every transition is a
+      _merge_context call
+      (api/main.py:148-154).
+      Missing or empty
+      values are dropped.
+    end note
+
+    note right of ArtifactReady
+      Non-null artifact persisted
+      via store.add_artifact
+      (api/main.py:229-233).
+      Context is preserved.
+    end note
+```
+
+The context JSON is replaced, not patched, at the database level —
+`update_context` writes the full merged dict in one statement
+(`store.py:156-165`). The non-empty filter lives in the handler,
+not the store, so tests can drive the store with full-overwrite
+semantics directly.
+
+---
+
+## Flow F — Temporal workflow path (optional)
+
+Only active when `is_temporal_enabled()` is true. Code lives in
+`temporal/__init__.py:11-41`.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Client as External Temporal client
+    participant TemporalSvc as Temporal service
+    participant Worker as startup_advisor-queue worker
+    participant WF as StartupAdvisorWorkflow
+    participant Act as run_pipeline_activity
+    participant Handler as send_message(api/main.py:187)
+    participant Store as ConversationStore
+    participant PG as Postgres
+    participant LLM as llm_service
+
+    Client->>TemporalSvc: start_workflow(<br/>StartupAdvisorWorkflow,<br/>request_dict)
+    TemporalSvc->>Worker: dispatch task
+    Worker->>WF: run(request_dict)
+    WF->>TemporalSvc: execute_activity(<br/>run_pipeline_activity,<br/>timeout=30m)
+    TemporalSvc->>Worker: dispatch activity
+    Worker->>Act: run_pipeline_activity(request_dict)
+    Note over Act: Deferred import of<br/>SendMessageRequest + send_message<br/>(temporal/__init__.py:13)
+    Act->>Handler: send_message(SendMessageRequest(**request))
+    Handler->>Store: ... Flow B / Flow C ...
+    Store->>PG: ... same SQL ...
+    Handler->>LLM: ... same complete(...) call ...
+    Handler-->>Act: ConversationStateResponse
+    Act->>Act: result.model_dump()
+    Act-->>WF: dict
+    WF-->>TemporalSvc: workflow result
+    TemporalSvc-->>Client: dict
+```
+
+The Temporal path is a thin wrapper — no alternate SQL, no
+alternate agent, no alternate context merge. If you need to trace a
+Temporal-triggered message, the breakpoints are the same ones used
+for Flow B / Flow C.
+
+---
+
+## Flow G — Startup & shutdown lifespan
+
+`_lifespan` at `api/main.py:20-34` wraps the FastAPI app.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant Uvicorn
+    participant App as FastAPI app
+    participant Lifespan as _lifespan()<br/>api/main.py:20-34
+    participant Registry as shared_postgres.register_team_schemas
+    participant Pool as shared_postgres pool
+    participant PG as Postgres
+
+    Uvicorn->>App: startup
+    App->>Lifespan: __aenter__
+    Lifespan->>Registry: register_team_schemas(<br/>STARTUP_ADVISOR_POSTGRES_SCHEMA)
+    Registry->>Pool: get_conn()
+    Pool->>PG: connect
+    Registry->>PG: execute SCHEMA.statements<br/>(3x CREATE TABLE + 2x CREATE INDEX)
+    PG-->>Registry: OK
+    Registry-->>Lifespan: registered
+    Lifespan-->>App: ready
+
+    Note over App: serve requests (Flows A-F)
+
+    Uvicorn->>App: shutdown
+    App->>Lifespan: __aexit__
+    Lifespan->>Pool: close_pool()
+    Pool->>PG: close all connections
+    PG-->>Pool: OK
+    Lifespan-->>App: clean shutdown
+```
+
+Both the registration and the pool close are wrapped in
+`try/except`: registration failure logs via `logger.exception` but
+still yields so the app starts (`api/main.py:26-28`), and pool
+close failure is logged at `warning` level only
+(`api/main.py:33-34`). The team never crashes its own lifespan.
+
+Separately, at module import time, `init_otel` is called at
+`api/main.py:17` and `instrument_fastapi_app(app,
+team_key="startup_advisor")` at `api/main.py:43` — these happen
+before the lifespan runs and do not block on Postgres.
+
+If Temporal is enabled, the `startup_advisor-queue` worker also
+starts at import time via
+`start_team_worker("startup_advisor", WORKFLOWS, ACTIVITIES,
+task_queue="startup_advisor-queue")` in
+`temporal/__init__.py:38-41`. This is independent of the FastAPI
+lifespan.

--- a/backend/agents/startup_advisor/system_design/system_design.md
+++ b/backend/agents/startup_advisor/system_design/system_design.md
@@ -1,0 +1,307 @@
+# Startup Advisor — System Design
+
+This document describes the internal structure of the startup advisor
+team: module layout, domain model, API surface, persistence schema,
+LLM integration, runtime modes, and configuration.
+
+## Module layout
+
+```
+backend/agents/startup_advisor/
+├── README.md                     # User-facing operational reference (3 lines)
+├── __init__.py                   # Empty module init
+├── api/
+│   ├── __init__.py
+│   └── main.py                   # FastAPI app, 4 endpoints, request/response models
+├── assistant/
+│   ├── __init__.py
+│   └── agent.py                  # StartupAdvisorAgent + system prompt + JSON parser
+├── postgres/
+│   └── __init__.py               # TeamSchema (3 tables + 2 indexes)
+├── store.py                      # StartupAdvisorConversationStore (Postgres DAL)
+├── temporal/
+│   └── __init__.py               # StartupAdvisorWorkflow + run_pipeline_activity
+├── system_design/                # This folder
+│   ├── README.md
+│   ├── architecture.md
+│   ├── system_design.md
+│   ├── use_cases.md
+│   └── flow_charts.md
+└── tests/
+    ├── __init__.py
+    └── test_store.py             # Store unit tests with a fake psycopg cursor
+```
+
+## Domain model
+
+The team uses three layers of data models. All three are deliberately
+thin: there is no ORM and no domain service layer between them.
+
+### API-layer Pydantic models (`api/main.py:51-88`)
+
+| Model | Line | Purpose |
+|---|---|---|
+| `CreateConversationRequest` | 51-54 | Unused reserve shape (no endpoint currently consumes it; kept for a possible future "new session" endpoint). |
+| `SendMessageRequest` | 57-58 | Single required field `message: str` with `min_length=1`. |
+| `ConversationMessageResponse` | 61-64 | One turn in the transcript: `role`, `content`, `timestamp` (ISO-8601). |
+| `ArtifactResponse` | 67-72 | A generated deliverable: `artifact_id`, `artifact_type`, `title`, `payload` (free-form dict), `created_at`. |
+| `ConversationStateResponse` | 75-80 | Full state returned from every turn: `conversation_id`, `messages[]`, `context` (accumulated founder facts), `artifacts[]`, `suggested_questions[]`. |
+| `ConversationSummaryResponse` | 83-87 | Reserve shape mirroring the store-layer `ConversationSummary`. |
+
+### Store-layer dataclasses (`store.py:54-75`)
+
+| Model | Line | Purpose |
+|---|---|---|
+| `StoredMessage` | 54-58 | Row projection from `startup_advisor_conv_messages` (`role`, `content`, `timestamp`). |
+| `StoredArtifact` | 61-67 | Row projection from `startup_advisor_conv_artifacts` (`artifact_id`, `artifact_type`, `title`, `payload`, `created_at`). |
+| `ConversationSummary` | 70-75 | Projection used by `list_conversations()` — `conversation_id`, `created_at`, `updated_at`, `message_count`. |
+
+`_row_ts` at `store.py:41-51` normalises a psycopg `datetime` to
+ISO-8601 so the public dataclass contract always exposes timestamps
+as strings.
+
+### LLM-layer JSON contract (`assistant/agent.py:53-72,87-102`)
+
+Every call to `StartupAdvisorAgent.respond` expects the LLM to emit
+exactly this shape:
+
+```json
+{
+  "reply": "<conversational response>",
+  "context_update": {"startup_name": "Acme", "stage": "mvp", "team_size": 3},
+  "suggested_questions": ["<up to 3 follow-up prompts>"],
+  "artifact": null
+}
+```
+
+When `artifact` is non-null it must be a dict of the form
+`{"type": "<artifact_type>", "title": "<short title>", "content": {...}}`.
+`_parse_response` (`assistant/agent.py:87-102`) strips markdown
+code fences before decoding and, on decode failure, returns the raw
+text as `reply` plus empty defaults so the handler never has to
+special-case malformed LLM output.
+
+The **context keys** the prompt instructs the model to extract
+(`assistant/agent.py:63-67`): `startup_name`, `stage`, `industry`,
+`target_audience`, `team_size`, `revenue`, `runway_months`,
+`primary_challenge`, `business_model`, `competitors`,
+`traction_metrics`, `funding_status`, plus any other structured facts
+the founder shares.
+
+## API surface
+
+All endpoints are mounted under `/api/startup-advisor` via the Unified
+API. The `TeamConfig` entry lives at
+`backend/unified_api/config.py:202-209`.
+
+| Method | Path | Request | Response | File / line | Description |
+|---|---|---|---|---|---|
+| GET | `/conversation` | — | `ConversationStateResponse` | `api/main.py:162-184` | Resolve the singleton conversation, creating it and inserting the welcome message if the row is empty. Returns the default suggested questions when the transcript has 0 or 1 messages. |
+| POST | `/conversation/messages` | `SendMessageRequest` | `ConversationStateResponse` | `api/main.py:187-242` | Append the user message, call the advisor agent, merge context updates, persist the reply + optional artifact, and return the refreshed state. |
+| GET | `/conversation/artifacts` | — | `list[ArtifactResponse]` | `api/main.py:245-260` | List every artifact generated on the singleton conversation, ordered by insertion `id`. |
+| GET | `/health` | — | `dict[str, str]` | `api/main.py:263-265` | Liveness probe — returns `{"status": "ok"}`. |
+
+The welcome message body (`_WELCOME_MESSAGE` at
+`api/main.py:94-99`) and the default starter prompts
+(`_DEFAULT_SUGGESTED` at `api/main.py:101-105`) are module-level
+constants rather than LLM output so that a brand-new conversation is
+bootstrapped deterministically without touching the LLM.
+
+## Persistence layer
+
+### Schema (`postgres/__init__.py:11-46`)
+
+Three tables plus two indexes. The DDL is registered by the FastAPI
+lifespan via `shared_postgres.register_team_schemas(SCHEMA)`
+(`api/main.py:20-28`) and the team registers its `TeamSchema`
+constant at module-import time so the schema registry stays pure
+data (Pattern B in the `shared_postgres` README).
+
+```mermaid
+erDiagram
+    startup_advisor_conversations ||--o{ startup_advisor_conv_messages : has
+    startup_advisor_conversations ||--o{ startup_advisor_conv_artifacts : has
+
+    startup_advisor_conversations {
+        TEXT conversation_id PK
+        JSONB context_json
+        TIMESTAMPTZ created_at
+        TIMESTAMPTZ updated_at
+    }
+    startup_advisor_conv_messages {
+        BIGSERIAL id PK
+        TEXT conversation_id FK
+        TEXT role
+        TEXT content
+        TIMESTAMPTZ timestamp
+    }
+    startup_advisor_conv_artifacts {
+        BIGSERIAL id PK
+        TEXT conversation_id FK
+        TEXT artifact_type
+        TEXT title
+        JSONB payload_json
+        TIMESTAMPTZ created_at
+    }
+```
+
+Indexes:
+
+- `idx_startup_advisor_conv_messages_conv` on
+  `startup_advisor_conv_messages(conversation_id)`
+  (`postgres/__init__.py:28-29`).
+- `idx_startup_advisor_conv_artifacts_conv` on
+  `startup_advisor_conv_artifacts(conversation_id)`
+  (`postgres/__init__.py:38-39`).
+
+Note that there are no declared foreign-key constraints: the
+relationship is enforced in application code via `append_message`,
+which checks the parent row exists before inserting
+(`store.py:138-144`).
+
+### Store public API (`store.py:78-247`)
+
+| Method | Line | SQL | Notes |
+|---|---|---|---|
+| `create(conversation_id=None, context=None)` | 92-103 | INSERT conversation with UUID, empty JSONB context, UTC timestamps | Accepts an explicit id for tests; returns the id. |
+| `get(conversation_id)` | 105-130 | SELECT context_json + SELECT messages ORDER BY id | Returns `(messages, context)` or `None`. |
+| `append_message(conversation_id, role, content)` | 132-154 | INSERT into messages + UPDATE `updated_at` | Rejects unknown roles (only `user`, `assistant`); returns `False` if parent row missing. |
+| `update_context(conversation_id, context)` | 156-165 | UPDATE `context_json` + `updated_at` | Replaces the full context JSON. |
+| `add_artifact(conversation_id, artifact_type, title, payload)` | 167-184 | INSERT RETURNING id | Returns the new artifact row id as `int`. |
+| `get_artifacts(conversation_id)` | 186-204 | SELECT all artifacts ORDER BY id | Returns `list[StoredArtifact]`. |
+| `list_conversations()` | 206-228 | LEFT JOIN count ORDER BY `updated_at` DESC | Returns `list[ConversationSummary]`; used by tooling, not the API. |
+| `get_or_create_singleton()` | 230-247 | SELECT oldest by `created_at` LIMIT 1; CREATE if empty | The entry point used by every API handler. |
+
+Every method is wrapped in `@timed_query(store="startup_advisor",
+op=...)` from `shared_postgres.metrics`
+(`store.py:92,105,132,156,167,186,206,230`) so slow queries are
+logged as structured JSON without needing a Prometheus exporter.
+
+### Lazy singleton (`store.py:254-266`)
+
+`get_conversation_store()` returns a process-wide
+`StartupAdvisorConversationStore` instance. The store holds no
+state; the singleton exists purely to give callers a stable
+identity for mocking in tests.
+
+## LLM integration
+
+`StartupAdvisorAgent` (`assistant/agent.py:105-177`) wraps an
+`llm_service.LLMClient`:
+
+1. **Constructor.** Accepts an injected `llm` (for tests) or lazily
+   resolves `llm_service.get_client("startup_advisor")` on first
+   use (`assistant/agent.py:108-114`).
+2. **Prompt assembly (`respond`).** Builds a transcript string by
+   prefixing each history turn with `Founder: ` or `Assistant: `,
+   then fills `USER_TURN_TEMPLATE` (`assistant/agent.py:74-84`)
+   with the accumulated context (pretty-printed JSON), the
+   transcript, and the latest message.
+3. **LLM call.** `self._llm.complete(prompt, temperature=0.5,
+   system_prompt=SYSTEM_PROMPT, think=True)`
+   (`assistant/agent.py:146-152`). `think=True` asks the model for
+   chain-of-thought reasoning before emitting the JSON payload.
+4. **Response parsing.** `_parse_response`
+   (`assistant/agent.py:87-102`) strips markdown fences and decodes
+   the JSON, returning a 4-tuple
+   `(reply, context_update, suggested_questions, artifact)`.
+5. **Fallback.** If `complete` raises anything, the handler logs via
+   `logger.exception` and returns a hard-coded reply plus three
+   canned probing questions
+   (`assistant/agent.py:153-164`).
+
+### System prompt (`assistant/agent.py:16-72`)
+
+The `SYSTEM_PROMPT` anchors the advisor persona with explicit
+frameworks:
+
+- Y Combinator
+- Paul Graham essays
+- Techstars, MassChallenge, Founder Institute, Entrepreneur First
+- First Round Review
+- Disciplined Entrepreneurship (Bill Aulet)
+- The Mom Test (Rob Fitzpatrick)
+
+And it enumerates the **six artifact types** the agent may emit:
+
+| Artifact type | Purpose |
+|---|---|
+| `action_plan` | Prioritised list of next steps |
+| `customer_discovery_guide` | Interview questions + ICP definition |
+| `gtm_strategy` | Go-to-market plan with channels and metrics |
+| `fundraising_brief` | Investor narrative and financial highlights |
+| `competitive_analysis` | Market positioning and differentiation |
+| `milestone_roadmap` | Time-bound milestones with success metrics |
+
+## Runtime modes
+
+### Thread mode (default)
+
+Every request is handled in the FastAPI worker thread. The handler
+is synchronous (`def send_message(...)` at `api/main.py:188`),
+which keeps psycopg's sync cursor and the LLM's blocking HTTP
+client on the calling thread. No background workers are required.
+
+### Temporal mode (optional)
+
+When `shared_temporal.is_temporal_enabled()` returns true,
+`temporal/__init__.py:38-41` starts a `startup_advisor-queue`
+worker at import time. The worker exposes:
+
+- **`StartupAdvisorWorkflow`** (`temporal/__init__.py:22-30`) —
+  single-activity workflow with a 30-minute
+  `start_to_close_timeout`.
+- **`run_pipeline_activity`** (`temporal/__init__.py:11-19`) —
+  deserialises the request dict into `SendMessageRequest`, calls
+  `send_message(req)`, and returns `result.model_dump()` so the
+  workflow output is JSON-serializable.
+
+The exported symbols are:
+
+```python
+WORKFLOWS = [StartupAdvisorWorkflow]
+ACTIVITIES = [run_pipeline_activity]
+```
+
+which is the Pattern A shape expected by
+`shared_temporal.start_team_worker`.
+
+## Configuration
+
+### Environment variables consumed
+
+| Variable | Used for | Read by |
+|---|---|---|
+| `POSTGRES_HOST` / `POSTGRES_PORT` / `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` | Connection to Postgres (required — no SQLite fallback). | `shared_postgres.get_conn()` (called from `store.py:96,107,137,159,176,188,208,239`). |
+| `POSTGRES_POOL_MIN_SIZE` / `POSTGRES_POOL_MAX_SIZE` / `POSTGRES_SLOW_QUERY_MS` | Pool sizing + slow-query threshold. | `shared_postgres` pool + `@timed_query`. |
+| `TEMPORAL_ADDRESS` (+ `TEMPORAL_NAMESPACE`, `TEMPORAL_TASK_QUEUE`) | Enable the optional Temporal worker. | `shared_temporal.is_temporal_enabled()` at `temporal/__init__.py:38`. |
+| `LLM_PROVIDER` / `LLM_BASE_URL` / `LLM_MODEL` / `OLLAMA_API_KEY` | LLM provider selection. | `llm_service.get_client("startup_advisor")` at `assistant/agent.py:112`. |
+
+### Team mount (`unified_api/config.py:202-209`)
+
+```python
+"startup_advisor": TeamConfig(
+    name="Startup Advisor",
+    prefix="/api/startup-advisor",
+    description="Persistent conversational startup advisor with probing dialogue and artifact generation",
+    tags=["startup", "advisor", "coaching", "strategy"],
+    cell="business",
+    timeout_seconds=120.0,
+),
+```
+
+- **`prefix`** — every endpoint is served under `/api/startup-advisor`.
+- **`cell`** — `business`, grouping the team with other
+  business-domain teams for failure-domain isolation.
+- **`timeout_seconds`** — 120 seconds, which bounds the full
+  request round-trip including the LLM call.
+
+### Observability
+
+- `init_otel(service_name="startup-advisor", team_key="startup_advisor")`
+  runs at module import (`api/main.py:17`).
+- `instrument_fastapi_app(app, team_key="startup_advisor")`
+  runs immediately after the `FastAPI(...)` constructor
+  (`api/main.py:43`).
+- `@timed_query` emits structured slow-query log lines on every
+  store operation (`store.py:92,105,132,156,167,186,206,230`).

--- a/backend/agents/startup_advisor/system_design/use_cases.md
+++ b/backend/agents/startup_advisor/system_design/use_cases.md
@@ -1,0 +1,252 @@
+# Startup Advisor — Use Cases
+
+This document enumerates the actors that interact with the startup
+advisor team and the concrete use cases it supports. Every use case
+is traceable to an entry-point endpoint or workflow defined in the
+team's code.
+
+## Actors
+
+| Actor | Role | Interaction style |
+|---|---|---|
+| **Founder** (primary) | A human founder seeking advisory guidance. Sends free-text messages, receives probing questions and eventually artifacts. | HTTPS via the Angular UI or `curl`. |
+| **Unified API** (system) | The gateway at `/api/startup-advisor/*` that proxies to this team. Managed in `backend/unified_api/config.py:202-209`. | Mounts the FastAPI sub-app. |
+| **Temporal worker** (system, optional) | A `startup_advisor-queue` worker started at import time when `is_temporal_enabled()` is true. Runs `StartupAdvisorWorkflow` on demand. | Only live when `TEMPORAL_ADDRESS` is configured (`temporal/__init__.py:38-41`). |
+
+## Use-case overview
+
+```mermaid
+flowchart LR
+    Founder(("Founder"))
+    Temporal(("Temporal<br/>worker"))
+
+    subgraph team[Startup Advisor]
+        UC1["UC-1: Start advisory session"]
+        UC2["UC-2: Probing dialogue turn"]
+        UC3["UC-3: Generate an artifact"]
+        UC4["UC-4: Review generated artifacts"]
+        UC5["UC-5: Graceful recovery from<br/>LLM failure"]
+        UC6["UC-6: Temporal-driven<br/>message handling"]
+    end
+
+    Founder --- UC1
+    Founder --- UC2
+    Founder --- UC3
+    Founder --- UC4
+    Founder -. "transparent" .- UC5
+    Temporal --- UC6
+    UC6 -. "calls" .- UC2
+```
+
+---
+
+## UC-1 — Start advisory session
+
+- **Entry point.** `GET /api/startup-advisor/conversation` →
+  `get_or_create_conversation` (`api/main.py:162-184`).
+- **Actors.** Founder, Unified API.
+- **Trigger.** The founder opens the advisor UI or hits the
+  endpoint for the first time.
+- **Preconditions.**
+  - Postgres is reachable and the `shared_postgres` pool is
+    healthy.
+  - `register_team_schemas(SCHEMA)` has completed in the FastAPI
+    lifespan so the three tables exist (`api/main.py:20-28`).
+- **Main flow.**
+  1. Handler calls `store.get_or_create_singleton()`
+     (`api/main.py:166`). The existing row is returned.
+  2. Handler calls `store.get(cid)` to load messages + context.
+  3. Artifacts are loaded via `store.get_artifacts(cid)`.
+  4. The transcript + context + artifacts are returned as a
+     `ConversationStateResponse`. If the transcript has 0 or 1
+     messages, the default suggested questions from
+     `_DEFAULT_SUGGESTED` (`api/main.py:101-105`) are attached.
+- **Alternate flow — first ever call (empty database).**
+  1. `get_or_create_singleton` finds no row, calls `create`
+     (`store.py:247`), and returns the new UUID.
+  2. `store.get(cid)` returns an empty transcript.
+  3. The handler detects `len(messages) == 0` and appends the
+     welcome message as an `assistant` turn via `append_message`
+     (`api/main.py:175-180`).
+  4. State is reloaded and returned.
+- **Postconditions.** Exactly one row exists in
+  `startup_advisor_conversations`. The response contains the
+  welcome message as the first transcript entry.
+- **Failure modes.** A Postgres outage bubbles up as HTTP 500 from
+  the `store.get` check at `api/main.py:168-169`.
+
+---
+
+## UC-2 — Probing dialogue turn
+
+- **Entry point.** `POST /api/startup-advisor/conversation/messages`
+  → `send_message` (`api/main.py:187-242`).
+- **Actors.** Founder, Unified API.
+- **Trigger.** The founder submits a free-text message (for
+  example: "I'm validating a B2B SaaS idea for accounting teams").
+- **Preconditions.** A singleton conversation exists (UC-1 may
+  have been called implicitly; `send_message` calls
+  `get_or_create_singleton` itself at `api/main.py:193`).
+- **Main flow.**
+  1. Handler resolves the singleton conversation.
+  2. If the transcript is empty, the welcome message is appended
+     first (`api/main.py:201-206`) so the LLM sees the advisor's
+     greeting.
+  3. The founder's message is persisted via `append_message`
+     (`api/main.py:209`).
+  4. `msg_pairs` is built from the transcript including the new
+     user turn (`api/main.py:212-213`).
+  5. `agent.respond(msg_pairs, context, payload.message)` is
+     called (`api/main.py:216-218`). The agent formats
+     `USER_TURN_TEMPLATE`, calls the LLM with `think=True`, and
+     returns a 4-tuple.
+  6. `_merge_context` merges only non-empty fields back into the
+     context (`api/main.py:148-154,221-223`) and
+     `store.update_context` persists it.
+  7. The advisor's reply is persisted via `append_message`
+     (`api/main.py:226`).
+  8. The artifact branch (UC-3) is skipped because
+     `artifact is None`.
+  9. State is reloaded via `store.get` + `store.get_artifacts` and
+     returned with the LLM-supplied `suggested_questions`.
+- **Postconditions.**
+  - Two new rows exist in `startup_advisor_conv_messages` (the
+    user turn and the advisor reply).
+  - `context_json` on the singleton row may have been updated
+    with new keys.
+- **Failure modes.** UC-5 handles LLM failure transparently; any
+  Postgres failure raises HTTP 500 from the reload check at
+  `api/main.py:237-238`.
+
+---
+
+## UC-3 — Generate an artifact
+
+- **Entry point.** `POST /api/startup-advisor/conversation/messages`
+  → same handler as UC-2 (`api/main.py:187-242`).
+- **Actors.** Founder, Unified API.
+- **Trigger.** The LLM decides — based on the accumulated context
+  — that it has enough information to produce a structured
+  deliverable and returns a non-null `artifact` field.
+- **Preconditions.** Enough probing-dialogue turns have happened
+  that `context_json` contains the keys the system prompt expects
+  for the relevant artifact type (see
+  `assistant/agent.py:63-67`).
+- **Main flow.**
+  1. Steps 1-7 of UC-2.
+  2. Handler checks `artifact and isinstance(artifact, dict)`
+     (`api/main.py:229`).
+  3. `artifact_type`, `title`, and `content` are extracted with
+     safe defaults (`api/main.py:230-232`).
+  4. `store.add_artifact(cid, artifact_type, title, content)` is
+     called (`api/main.py:233`), inserting the row and returning
+     the new id.
+  5. State is reloaded and the artifact is included in the
+     `artifacts[]` array on the response
+     (`ConversationStateResponse`).
+- **Artifact subtypes.** Exactly the six types enumerated in the
+  system prompt (`assistant/agent.py:39-44`):
+  `action_plan`, `customer_discovery_guide`, `gtm_strategy`,
+  `fundraising_brief`, `competitive_analysis`,
+  `milestone_roadmap`. The agent may also emit any other `type`
+  string; the store does not validate the vocabulary.
+- **Postconditions.** A new row exists in
+  `startup_advisor_conv_artifacts` and is visible on subsequent
+  `GET /conversation/artifacts` calls (UC-4).
+
+---
+
+## UC-4 — Review generated artifacts
+
+- **Entry point.** `GET /api/startup-advisor/conversation/artifacts`
+  → `list_artifacts` (`api/main.py:245-260`).
+- **Actors.** Founder, Unified API.
+- **Trigger.** The founder wants to re-read past deliverables
+  without scrolling through the full transcript.
+- **Preconditions.** Singleton conversation exists. Zero or more
+  artifacts are present.
+- **Main flow.**
+  1. Handler resolves the singleton via
+     `store.get_or_create_singleton` (`api/main.py:249`).
+  2. `store.get_artifacts(cid)` is called (`api/main.py:250`),
+     returning artifacts ordered by insertion id.
+  3. Each `StoredArtifact` is mapped to an `ArtifactResponse`.
+- **Postconditions.** Read-only. No state changes.
+
+---
+
+## UC-5 — Graceful recovery from LLM failure
+
+- **Entry point.** Triggered inside UC-2 / UC-3 when
+  `self._llm.complete` raises.
+- **Actors.** Founder (experiences a normal-looking response),
+  Unified API.
+- **Trigger.** The LLM backend returns an error, times out, or is
+  unreachable while processing a `POST /conversation/messages`
+  request.
+- **Preconditions.** The handler has already persisted the user's
+  turn (`api/main.py:209` runs before the LLM call at
+  `api/main.py:216`).
+- **Main flow.**
+  1. `StartupAdvisorAgent.respond` wraps the `complete` call in
+     `try/except Exception` (`assistant/agent.py:146-164`).
+  2. On exception, `logger.exception("LLM call failed for startup
+     advisor")` is emitted.
+  3. The agent returns a hard-coded fallback 4-tuple:
+     - `reply`: "I'm here to help with your startup. Could you tell
+       me about what you're building and what stage you're at?"
+     - `context_update`: `{}`
+     - `suggested_questions`: three canned probing prompts.
+     - `artifact`: `None`.
+  4. The handler proceeds through the normal merge + persist +
+     reload path. Because `context_update` is empty,
+     `_merge_context` is a no-op and `update_context` is skipped
+     (`api/main.py:221-223`).
+- **Postconditions.**
+  - The user's turn **is** persisted (it was written before the
+    LLM call).
+  - The fallback reply **is** persisted as a regular assistant
+    turn.
+  - The founder sees a normal `ConversationStateResponse` with no
+    indication of the failure.
+- **Why.** The advisor is a coaching product — surfacing a raw 500
+  to a founder mid-thought is strictly worse than replying with a
+  generic follow-up question. The failure is still visible in the
+  service logs via `logger.exception`.
+
+---
+
+## UC-6 — Temporal-driven message handling (optional)
+
+- **Entry point.** `StartupAdvisorWorkflow.run` at
+  `temporal/__init__.py:22-30`.
+- **Actors.** Temporal worker, external Temporal client.
+- **Trigger.** An external orchestrator submits a
+  `StartupAdvisorWorkflow` execution to the Temporal cluster with
+  a request payload that matches `SendMessageRequest`.
+- **Preconditions.**
+  - `TEMPORAL_ADDRESS` is set so `is_temporal_enabled()` returns
+    true and the `startup_advisor-queue` worker was started at
+    import time (`temporal/__init__.py:38-41`).
+  - Postgres and the LLM provider are reachable (same as UC-2).
+- **Main flow.**
+  1. Temporal calls
+     `StartupAdvisorWorkflow.run(request: dict)`.
+  2. The workflow executes `run_pipeline_activity` with a
+     30-minute `start_to_close_timeout`
+     (`temporal/__init__.py:26-30`).
+  3. The activity re-imports `SendMessageRequest` and
+     `send_message` from `startup_advisor.api.main`
+     (`temporal/__init__.py:13`).
+  4. It deserialises the dict into `SendMessageRequest(**request)`
+     and calls `send_message(req)` — the exact same handler UC-2
+     runs.
+  5. The returned `ConversationStateResponse` is serialised via
+     `model_dump()` and returned as the activity result
+     (`temporal/__init__.py:17-19`).
+- **Postconditions.** Identical to UC-2 / UC-3. There is no
+  separate Temporal-specific data path; the workflow is a thin
+  wrapper so the team can participate in cross-team orchestration.
+- **Note.** The 30-minute activity timeout exists only to absorb
+  slow LLM calls — the actual handler is synchronous and typically
+  completes in seconds.


### PR DESCRIPTION
Add a system_design/ folder for the startup advisor team matching the
convention used by the branding, investment, and accessibility audit
teams. The team previously shipped only a 3-line README, leaving its
architectural choices (singleton conversation, single-agent handler,
JSON-structured LLM output, non-empty context merge, LLM fallback path,
optional Temporal wrapper) undocumented.

The new docs are citation-linked into the code so future contributors
can map every claim back to a specific file and line range:

- README.md          index + source-file table + conventions
- architecture.md    principles, component diagram, key design decisions
- system_design.md   module layout, domain model, API surface, schema ER,
                     LLM integration, runtime modes, configuration
- use_cases.md       actors + six numbered use cases with main/alternate
                     flows, all traceable to HTTP endpoints or workflows
- flow_charts.md     seven Mermaid sequence/state diagrams covering
                     get-or-create, probing turn, artifact turn, LLM
                     fallback, context accumulation, Temporal, lifespan