### PR TITLE
Fix stale team counts and missing entries across README docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Khala is a monorepo for multi-agent "team" systems. Each team exposes a FastAPI 
 ```text
 khala/
 ├── backend/
-│   ├── agents/                 # Team implementations + team-specific APIs (21 mounted teams)
+│   ├── agents/                 # Team implementations + team-specific APIs (20 enabled teams)
 │   ├── unified_api/            # Unified FastAPI app mounting all teams
 │   ├── run_unified_api.py      # Unified API launcher
 │   ├── Makefile                # Build, lint, test, run targets
@@ -50,7 +50,7 @@ UI: <http://localhost:4200>
 
 ## Unified API team routes
 
-The Unified API mounts teams under `/api/*` prefixes. Current configured routes (21 enabled teams):
+The Unified API mounts teams under `/api/*` prefixes. Current configured routes (20 enabled teams):
 
 - `/api/blogging`
 - `/api/software-engineering`

--- a/backend/agents/README.md
+++ b/backend/agents/README.md
@@ -6,29 +6,41 @@ This directory contains the Khala agent-team implementations and their APIs.
 
 ```text
 backend/agents/
+├── accessibility_audit_team/
+├── agent_git_tools/                   # Shared Git tooling for agents
+├── agent_llm_tools_service/           # LLM tools discovery service
+├── agent_provisioning_team/
+├── agent_repair_team/                 # Agent crash recovery
+├── agentic_team_provisioning/         # Conversational team/process creation (see README.md)
+├── ai_systems_team/
+├── analytics/                         # Analytics utilities
 ├── api/                               # Legacy blog research-and-review API package
 ├── blogging/
-├── software_engineering_team/
-├── coding_team/
-├── planning_v3_team/
-├── personal_assistant_team/
-├── social_media_marketing_team/
-├── market_research_team/
-├── soc2_compliance_team/
 ├── branding_team/
-├── agent_provisioning_team/
-├── agentic_team_provisioning/         # Conversational team/process creation (see README.md)
-├── accessibility_audit_team/
-├── ai_systems_team/
+├── coding_team/
+├── continuation_logs/                 # Continuation log storage
+├── deepthought/                       # Recursive self-organising agent
+├── docker/                            # Agents-only Docker assets
+├── integrations/                      # Shared integrations layer used across teams
 ├── investment_team/
+├── llm_service/                       # Centralized LLM client (Ollama, dummy)
+├── market_research_team/
 ├── nutrition_meal_planning_team/
+├── personal_assistant_team/
+├── planning_v3_team/
+├── plans/                             # Planning artifacts
 ├── road_trip_planning_team/
 ├── sales_team/
+├── shared_observability/              # Shared observability (Prometheus, logging)
+├── shared_postgres/                   # Shared Postgres utilities
+├── shared_temporal/                   # Shared Temporal workflow utilities
+├── soc2_compliance_team/
+├── social_media_marketing_team/
+├── software_engineering_team/
 ├── startup_advisor/                   # Persistent conversational startup advisor
-├── agent_repair_team/                 # Agent crash recovery
-├── integrations/                      # Shared integrations layer used across teams
-├── llm_service/                       # Centralized LLM client (Ollama, dummy)
-├── docker/                            # Agents-only Docker assets
+├── team_assistant/                    # Team assistant utilities
+├── team_contract/                     # Team contract definitions
+├── user_agent_founder/                # Autonomous startup founder agent
 ├── shared_job_management.py           # Shared job state helpers
 ├── job_service_client.py              # HTTP client for centralized job service
 ├── Dockerfile
@@ -44,7 +56,7 @@ From `backend/`:
 python run_unified_api.py
 ```
 
-This mounts all 19 enabled team APIs behind one server on port `8080` by default.
+This mounts all 20 enabled team APIs behind one server on port `8080` by default.
 
 ## Running individual team APIs
 
@@ -85,6 +97,8 @@ For team-specific setup and env vars, use each team's README.
 - `sales_team/README.md`
 - `startup_advisor/README.md`
 - `agentic_team_provisioning/README.md`
+- `user_agent_founder/README.md`
+- `deepthought/README.md`
 - `llm_service/README.md`
 
 ## Shared integrations

--- a/backend/agents/deepthought/README.md
+++ b/backend/agents/deepthought/README.md
@@ -1,0 +1,7 @@
+# Deepthought
+
+Recursive self-organising agent that dynamically creates specialist sub-agents to answer complex questions. Unified API prefix: `/api/deepthought`.
+
+## Khala platform
+
+This package is part of the [Khala](../../../README.md) monorepo (Unified API, Angular UI, and full team index).

--- a/backend/agents/user_agent_founder/README.md
+++ b/backend/agents/user_agent_founder/README.md
@@ -1,0 +1,7 @@
+# User Agent Founder
+
+Autonomous startup founder agent that drives the SE team to build a task management service. Unified API prefix: `/api/user-agent-founder`.
+
+## Khala platform
+
+This package is part of the [Khala](../../../README.md) monorepo (Unified API, Angular UI, and full team index).

--- a/backend/unified_api/README.md
+++ b/backend/unified_api/README.md
@@ -4,7 +4,7 @@ The Unified API Server consolidates all Khala team APIs under a single entry poi
 
 ## Overview
 
-Instead of running multiple API servers on different ports, the unified server mounts all 19 team APIs under namespaced prefixes on a single port (default: 8080). Teams can also be deployed as standalone microservices; when a `*_SERVICE_URL` env var is set for a team, the unified API proxies requests to that external service instead of mounting in-process.
+Instead of running multiple API servers on different ports, the unified server mounts all 20 team APIs under namespaced prefixes on a single port (default: 8080). Teams can also be deployed as standalone microservices; when a `*_SERVICE_URL` env var is set for a team, the unified API proxies requests to that external service instead of mounting in-process.
 
 ```mermaid
 graph TB
@@ -32,6 +32,8 @@ graph TB
             RoadTrip["/api/road-trip-planning"]
             AgenticProv["/api/agentic-team-provisioning"]
             StartupAdv["/api/startup-advisor"]
+            UAFounder["/api/user-agent-founder"]
+            Deep["/api/deepthought"]
         end
     end
     
@@ -100,6 +102,8 @@ Execution stays in agent code (e.g. `agent_git_tools` + `GitToolContext`); these
 | Road Trip Planning | `/api/road-trip-planning` | `/api/road-trip-planning/docs` |
 | Agentic Team Provisioning | `/api/agentic-team-provisioning` | `/api/agentic-team-provisioning/docs` |
 | Startup Advisor | `/api/startup-advisor` | `/api/startup-advisor/docs` |
+| User Agent Founder | `/api/user-agent-founder` | `/api/user-agent-founder/docs` |
+| Deepthought | `/api/deepthought` | `/api/deepthought/docs` |
 
 ### Team configuration hierarchy (`config.py`)
 
@@ -201,7 +205,7 @@ If a team API fails to import (missing dependencies, configuration errors), the 
 
 ```
 2024-01-15 10:00:00 [WARNING] unified_api: Could not mount Investment Team API: No module named 'investment_team'
-2024-01-15 10:00:00 [INFO] unified_api: Mounted 18/19 team APIs
+2024-01-15 10:00:00 [INFO] unified_api: Mounted 19/20 team APIs
 ```
 
 ## Example Usage


### PR DESCRIPTION
The source of truth (config.py) defines 20 enabled teams, but several
READMEs still referenced 19 or 21. This updates all counts to 20, adds
the user_agent_founder and deepthought teams to directory listings,
Mermaid diagrams, and API tables, and creates stub READMEs for those
two teams (already referenced from the root README but missing on disk).

https://claude.ai/code/session_0116fegTWQDtPZCN9f8oRKBD