### PR TITLE
Migrate market research team to AWS Strands Agents SDK

### DIFF
--- a/backend/agents/market_research_team/agents.py
+++ b/backend/agents/market_research_team/agents.py
@@ -1,12 +1,264 @@
-"""Specialist agent implementations for market research workflows."""
+"""AWS Strands AI agent implementations for market research workflows.
+
+Each agent wraps a strands.Agent with a methodology-rich system prompt grounded in:
+- Clayton Christensen (Jobs-to-be-Done theory)
+- Tony Ulwick (Outcome-Driven Innovation)
+- Rob Fitzpatrick (The Mom Test — evidence quality heuristics)
+- BJ Fogg (Behavior Model: B=MAP)
+- Everett Rogers (Diffusion of Innovation)
+- Eric Ries / Steve Blank (Lean Startup, Customer Development)
+- Sean Ellis (Product-Market Fit test)
+
+The strands SDK is a hard dependency. The system will fail fast if it is not installed.
+"""
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import json
+import logging
+from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List
+from typing import Any, List
+
+from strands import Agent as StrandsAgent
+from strands_tools import current_time, http_request, python_repl
 
 from .models import InterviewInsight, MarketSignal, ResearchMission, ViabilityRecommendation
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_TOOLS = [http_request, python_repl, current_time]
+
+
+# ---------------------------------------------------------------------------
+# Base helpers (matches sales_team pattern)
+# ---------------------------------------------------------------------------
+
+
+def _build_strands_agent(system_prompt: str, tools: list | None = None) -> StrandsAgent:
+    """Construct a strands.Agent."""
+    return StrandsAgent(
+        system_prompt=system_prompt,
+        tools=tools if tools is not None else _DEFAULT_TOOLS,
+    )
+
+
+def _call_agent(agent: StrandsAgent, prompt: str) -> str:
+    """Call a strands.Agent and return its text output."""
+    result = agent(prompt)
+    if hasattr(result, "message"):
+        content = result.message
+    else:
+        content = str(result)
+    return content.strip()
+
+
+def _parse_json(raw: str, fallback: object) -> object:
+    """Best-effort JSON parse; returns fallback on failure."""
+    if not raw or not raw.strip():
+        return fallback
+    stripped = raw.strip()
+    if stripped.startswith("```"):
+        lines = stripped.splitlines()
+        stripped = "\n".join(lines[1:-1] if lines[-1].strip() == "```" else lines[1:])
+    try:
+        return json.loads(stripped)
+    except (json.JSONDecodeError, ValueError):
+        logger.warning("Could not parse agent JSON output; using fallback. Raw: %s", raw[:200])
+        return fallback
+
+
+# ---------------------------------------------------------------------------
+# System prompts (encoding market research methodology)
+# ---------------------------------------------------------------------------
+
+_UX_RESEARCH_SYSTEM_PROMPT = """\
+You are an elite UX Research Lead specializing in user discovery interviews.
+
+## Your Methodology
+
+### Jobs-to-be-Done (Clayton Christensen)
+- Identify the functional, emotional, and social jobs users are hiring a product to do.
+- Distinguish between the core job and related jobs (consumption chain analysis).
+- Focus on the circumstance of the struggle, not demographics.
+
+### Outcome-Driven Innovation (Tony Ulwick)
+- Extract desired outcomes in the form: "Minimize the time it takes to [verb] [object of control]."
+- Separate overserved from underserved outcomes — underserved outcomes are innovation opportunities.
+
+### The Mom Test (Rob Fitzpatrick)
+- Weight evidence by quality: direct quotes > observed behavior > stated preferences > hypotheticals.
+- Discard compliments and generic enthusiasm — they carry zero signal.
+- Flag leading questions in the transcript and discount responses to them.
+
+### Customer Development (Steve Blank)
+- Classify statements as: pain statements, gain statements, workaround descriptions, or trigger events.
+- Pain statements where the user already pays money or significant time to solve the problem are highest priority.
+
+## Output Format
+Return ONLY a valid JSON object (no markdown, no commentary) with these exact keys:
+- "user_jobs": array of strings — specific jobs the user is trying to accomplish
+- "pain_points": array of strings — frustrations, frictions, and problems mentioned
+- "desired_outcomes": array of strings — what success looks like to the user
+- "direct_quotes": array of strings — verbatim quotes from the transcript that carry strong signal
+
+Limit each array to at most 5 items. Prioritize specificity over generality.
+"""
+
+_USER_PSYCHOLOGY_SYSTEM_PROMPT = """\
+You are a User Psychology Researcher who derives adoption and behavior-change signals \
+from interview insights.
+
+## Your Methodology
+
+### BJ Fogg Behavior Model (B=MAP)
+- Behavior = Motivation + Ability + Prompt. All three must converge.
+- Assess motivation: is the pain acute enough that users actively seek solutions?
+- Assess ability: can users adopt the solution without significant behavior change?
+- Assess prompt: is there a natural trigger event that would cause users to seek this product?
+
+### Kano Model
+- Must-be needs: so fundamental that their absence causes strong dissatisfaction (high urgency).
+- One-dimensional needs: more is linearly better (moderate urgency).
+- Attractive needs: delighters that users don't expect (low urgency, high differentiation).
+
+### Rogers' Diffusion of Innovation
+- Look for early adopter signals: users who have built DIY workarounds, cobbled together partial \
+solutions, or expressed willingness to try unproven approaches.
+- Laggard signals: users who resist change, express satisfaction with status quo, or dismiss the problem.
+
+### Loss Aversion & Status Quo Bias
+- Gauge how strongly users resist the current state versus how much they fear change.
+- Products must deliver 3-10x improvement to overcome status quo bias.
+
+## Output Format
+Return ONLY a valid JSON array (no markdown, no commentary). Each element must be an object with:
+- "signal": string — a descriptive name for the market signal
+- "confidence": float 0.0-1.0 — calibrated confidence based on evidence quality and quantity
+- "evidence": array of strings — specific observations supporting this signal
+
+Return at least 2 signals. Suggested signal types: "User pain urgency", \
+"Adoption motivation clarity", "Early adopter presence", "Switching cost tolerance", \
+"Willingness to pay indicators".
+"""
+
+_MARKET_VIABILITY_SYSTEM_PROMPT = """\
+You are a Business Viability Strategist who evaluates product concept viability based on \
+market signals and interview evidence.
+
+## Your Methodology
+
+### Lean Startup Validation (Eric Ries)
+- Minimum viable experiments: what is the cheapest test to validate the riskiest assumption?
+- Build-Measure-Learn loops: recommend experiments that produce quantifiable signal.
+- Kill criteria: define what evidence would falsify the hypothesis.
+
+### Sean Ellis PMF Test
+- "Very disappointed" benchmark: would 40%+ of target users be very disappointed without this product?
+- If evidence suggests yes → "promising_with_risks"
+- If unclear or < 40% → "needs_more_validation"
+
+### Experiment Design
+- Prioritize experiments by: (1) assumption risk, (2) cost to test, (3) time to signal.
+- Concierge MVP, Wizard of Oz, landing page tests, pricing sensitivity interviews.
+
+## Verdict Rules
+You MUST use exactly one of these verdict strings:
+- "insufficient_evidence" — not enough data to form a judgment
+- "needs_more_validation" — some signal exists but not enough confidence to proceed
+- "promising_with_risks" — strong signal with identified risks that need mitigation
+
+## Output Format
+Return ONLY a valid JSON object (no markdown, no commentary) with these exact keys:
+- "verdict": string — one of the three verdict strings above
+- "confidence": float 0.0-1.0 — overall confidence in the assessment
+- "rationale": array of strings — key reasons supporting the verdict
+- "suggested_next_experiments": array of strings — prioritized next steps to increase confidence
+"""
+
+_RESEARCH_SCRIPT_SYSTEM_PROMPT = """\
+You are a Research Operations Specialist who creates interview scripts, transcript tagging \
+guides, and decision checkpoint templates.
+
+## Your Methodology
+
+### Interview Design Principles
+- Use open-ended questions that start with "Tell me about...", "Walk me through...", "Describe..."
+- Follow the laddering technique: Why? → What happens then? → How does that make you feel?
+- Avoid leading questions, hypotheticals, and future-state projections.
+- Include warm-up, core exploration, and wrap-up sections.
+
+### Problem vs. Solution Interviews (Lean Customer Development)
+- Problem interviews: validate the problem exists and matters (early stage).
+- Solution interviews: validate the solution approach resonates (after problem validation).
+- Include questions that surface workarounds and current spending patterns.
+
+### Transcript Tagging (Thematic Coding)
+- Standard tags: job_to_be_done, pain_point, desired_outcome, workaround, trigger_event, \
+direct_quote, emotional_response.
+- Track frequency counts for repeated themes across interviews.
+- Flag contradictions between stated preferences and observed behavior.
+
+### Decision Checkpoints
+- What evidence improved our confidence since the last checkpoint?
+- What assumptions remain unvalidated?
+- What experiment is approved for the next sprint?
+- What is the kill criterion that would cause us to pivot or stop?
+
+## Output Format
+Return ONLY a valid JSON array of exactly 3 strings (no markdown, no commentary). Each string is \
+a complete research artifact:
+1. An interview script with numbered questions tailored to the product concept and target users
+2. A transcript tagging guide with standard labels and instructions
+3. A decision checkpoint template with structured review questions
+"""
+
+# ---------------------------------------------------------------------------
+# Default fallback values (preserve backward-compatible defaults)
+# ---------------------------------------------------------------------------
+
+_DEFAULT_USER_JOBS = ["Identify the core user job-to-be-done through follow-up interviews."]
+_DEFAULT_PAIN_POINTS = ["Validate top workflow frictions from observed user behavior."]
+_DEFAULT_DESIRED_OUTCOMES = ["Confirm measurable success criteria users care about."]
+
+_DEFAULT_SIGNALS_FALLBACK = [
+    {
+        "signal": "User pain urgency",
+        "confidence": 0.5,
+        "evidence": ["No direct pain statements yet; run discovery interviews."],
+    },
+    {
+        "signal": "Adoption motivation clarity",
+        "confidence": 0.5,
+        "evidence": ["No clear desired outcomes captured yet."],
+    },
+]
+
+_DEFAULT_SCRIPTS_FALLBACK = [
+    (
+        "Interview script:\n"
+        "1) Tell me about your current workflow.\n"
+        "2) What is hardest or most frustrating today?\n"
+        "3) What have you already tried and why did it fail?\n"
+        "4) If this problem disappeared tomorrow, what outcome would change?"
+    ),
+    (
+        "Transcript tagging guide:\n"
+        "- Label each statement as job_to_be_done, pain_point, desired_outcome, workaround, or trigger_event.\n"
+        "- Track frequency count for repeated themes across interviews."
+    ),
+    (
+        "Decision checkpoint template:\n"
+        "- What evidence improved confidence?\n"
+        "- What assumptions remain unproven?\n"
+        "- What experiment is approved for next sprint?"
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Agent implementations
+# ---------------------------------------------------------------------------
 
 
 @dataclass
@@ -33,84 +285,94 @@ class TranscriptIngestionAgent:
 
 @dataclass
 class UXResearchAgent:
-    """Extracts user jobs and outcomes from transcripts."""
+    """Extracts user jobs and outcomes from transcripts using LLM analysis."""
 
     role: str = "UX Research Lead"
+    _system_prompt: str = field(default=_UX_RESEARCH_SYSTEM_PROMPT, init=False, repr=False)
 
     def analyze(self, source: str, transcript: str) -> InterviewInsight:
-        lines = [line.strip(" -•\t") for line in transcript.splitlines() if line.strip()]
-        user_jobs = [
-            line for line in lines if "job" in line.lower() or "trying to" in line.lower()
-        ][:4]
-        pain_points = [
-            line
-            for line in lines
-            if any(k in line.lower() for k in ("pain", "friction", "issue", "problem"))
-        ][:4]
-        desired_outcomes = [
-            line
-            for line in lines
-            if any(k in line.lower() for k in ("want", "need", "goal", "outcome"))
-        ][:4]
-        direct_quotes = [line for line in lines if '"' in line][:3]
+        # Fresh agent per call to avoid history pollution across transcripts.
+        agent = _build_strands_agent(self._system_prompt, _DEFAULT_TOOLS)
+        prompt = (
+            f"Analyze the following user interview transcript.\n\n"
+            f"Source: {source}\n\n"
+            f"--- TRANSCRIPT START ---\n{transcript}\n--- TRANSCRIPT END ---\n\n"
+            f"Extract user jobs, pain points, desired outcomes, and direct quotes. "
+            f"Return ONLY valid JSON matching the schema described in your instructions."
+        )
+        raw = _call_agent(agent, prompt)
+        data = _parse_json(raw, {})
 
-        if not user_jobs:
-            user_jobs = ["Identify the core user job-to-be-done through follow-up interviews."]
-        if not pain_points:
-            pain_points = ["Validate top workflow frictions from observed user behavior."]
-        if not desired_outcomes:
-            desired_outcomes = ["Confirm measurable success criteria users care about."]
+        if not isinstance(data, dict):
+            data = {}
 
         return InterviewInsight(
             source=source,
-            user_jobs=user_jobs,
-            pain_points=pain_points,
-            desired_outcomes=desired_outcomes,
-            direct_quotes=direct_quotes,
+            user_jobs=data.get("user_jobs", _DEFAULT_USER_JOBS),
+            pain_points=data.get("pain_points", _DEFAULT_PAIN_POINTS),
+            desired_outcomes=data.get("desired_outcomes", _DEFAULT_DESIRED_OUTCOMES),
+            direct_quotes=data.get("direct_quotes", []),
         )
 
 
 @dataclass
 class UserPsychologyAgent:
-    """Derives adoption and behavior-change signals from insights."""
+    """Derives adoption and behavior-change signals from insights using LLM analysis."""
 
     role: str = "User Psychology Researcher"
+    _agent: Any = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._agent = _build_strands_agent(_USER_PSYCHOLOGY_SYSTEM_PROMPT, _DEFAULT_TOOLS)
 
     def derive_signals(self, insights: List[InterviewInsight]) -> List[MarketSignal]:
-        all_pains = [p for insight in insights for p in insight.pain_points]
-        all_outcomes = [o for insight in insights for o in insight.desired_outcomes]
+        insights_json = json.dumps([i.model_dump() for i in insights], indent=2)
+        prompt = (
+            f"Analyze the following interview insights and derive market signals "
+            f"about user psychology, adoption readiness, and behavior-change potential.\n\n"
+            f"Interview insights ({len(insights)} interviews):\n{insights_json}\n\n"
+            f"Return ONLY a valid JSON array of signal objects."
+        )
+        raw = _call_agent(self._agent, prompt)
+        data = _parse_json(raw, _DEFAULT_SIGNALS_FALLBACK)
 
-        urgency = 0.55 + min(0.35, len(all_pains) * 0.04)
-        willingness = 0.5 + min(0.35, len(all_outcomes) * 0.035)
+        if not isinstance(data, list):
+            data = _DEFAULT_SIGNALS_FALLBACK
 
-        return [
-            MarketSignal(
-                signal="User pain urgency",
-                confidence=min(1.0, urgency),
-                evidence=all_pains[:4]
-                or ["No direct pain statements yet; run discovery interviews."],
-            ),
-            MarketSignal(
-                signal="Adoption motivation clarity",
-                confidence=min(1.0, willingness),
-                evidence=all_outcomes[:4] or ["No clear desired outcomes captured yet."],
-            ),
-        ]
+        signals: List[MarketSignal] = []
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+            signals.append(
+                MarketSignal(
+                    signal=str(item.get("signal", "Unknown signal")),
+                    confidence=min(1.0, max(0.0, float(item.get("confidence", 0.5)))),
+                    evidence=item.get("evidence", []),
+                )
+            )
+
+        # Ensure at least 2 signals (pad with defaults).
+        while len(signals) < 2:
+            fallback = _DEFAULT_SIGNALS_FALLBACK[len(signals)]
+            signals.append(MarketSignal(**fallback))
+
+        return signals
 
 
 @dataclass
 class MarketViabilityAgent:
-    """Generates a viability recommendation and next experiments."""
+    """Generates a viability recommendation and next experiments using LLM analysis."""
 
     role: str = "Business Viability Strategist"
+    _agent: Any = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._agent = _build_strands_agent(_MARKET_VIABILITY_SYSTEM_PROMPT, _DEFAULT_TOOLS)
 
     def recommend(
         self, mission: ResearchMission, signals: List[MarketSignal], insight_count: int
     ) -> ViabilityRecommendation:
-        avg_confidence = (
-            sum(signal.confidence for signal in signals) / len(signals) if signals else 0.45
-        )
-
+        # Deterministic response for zero-evidence case (no LLM call needed).
         if insight_count == 0:
             return ViabilityRecommendation(
                 verdict="insufficient_evidence",
@@ -126,47 +388,63 @@ class MarketViabilityAgent:
                 ],
             )
 
-        verdict = "promising_with_risks" if avg_confidence >= 0.65 else "needs_more_validation"
+        signals_json = json.dumps([s.model_dump() for s in signals], indent=2)
+        prompt = (
+            f"Evaluate the viability of the following product concept based on market signals.\n\n"
+            f"Product concept: {mission.product_concept}\n"
+            f"Target users: {mission.target_users}\n"
+            f"Business goal: {mission.business_goal}\n"
+            f"Number of interviews analyzed: {insight_count}\n\n"
+            f"Market signals:\n{signals_json}\n\n"
+            f"Return ONLY valid JSON with verdict, confidence, rationale, and suggested_next_experiments."
+        )
+        raw = _call_agent(self._agent, prompt)
+        data = _parse_json(raw, {})
+
+        if not isinstance(data, dict):
+            data = {}
+
+        valid_verdicts = {"insufficient_evidence", "needs_more_validation", "promising_with_risks"}
+        verdict = data.get("verdict", "needs_more_validation")
+        if verdict not in valid_verdicts:
+            verdict = "needs_more_validation"
+
         return ViabilityRecommendation(
             verdict=verdict,
-            confidence=round(avg_confidence, 2),
-            rationale=[
-                f"Mission concept: {mission.product_concept}.",
-                f"Target users: {mission.target_users}.",
-                f"Signals indicate {'moderate-to-strong' if avg_confidence >= 0.65 else 'early'} demand potential.",
-            ],
-            suggested_next_experiments=[
-                "Run a concierge MVP with 3-5 target users for one core workflow.",
-                "Test value proposition copy with a short ad + landing page experiment.",
-                "Quantify willingness to pay via pricing sensitivity interviews.",
-            ],
+            confidence=min(1.0, max(0.0, float(data.get("confidence", 0.5)))),
+            rationale=data.get("rationale", [f"Mission concept: {mission.product_concept}."]),
+            suggested_next_experiments=data.get(
+                "suggested_next_experiments",
+                [
+                    "Run a concierge MVP with 3-5 target users for one core workflow.",
+                ],
+            ),
         )
 
 
 @dataclass
 class ResearchScriptAgent:
-    """Produces interview and data collection scripts for the user."""
+    """Produces interview and data collection scripts using LLM analysis."""
 
     role: str = "Research Operations Specialist"
+    _agent: Any = field(default=None, init=False, repr=False)
+
+    def __post_init__(self) -> None:
+        self._agent = _build_strands_agent(_RESEARCH_SCRIPT_SYSTEM_PROMPT, _DEFAULT_TOOLS)
 
     def build_scripts(self, mission: ResearchMission) -> List[str]:
-        return [
-            (
-                "Interview script:\n"
-                f"1) Tell me about how you currently handle {mission.business_goal}.\n"
-                "2) What is hardest or most frustrating today?\n"
-                "3) What have you already tried and why did it fail?\n"
-                "4) If this problem disappeared tomorrow, what outcome would change?"
-            ),
-            (
-                "Transcript tagging guide:\n"
-                "- Label each statement as job_to_be_done, pain_point, desired_outcome, workaround, or trigger_event.\n"
-                "- Track frequency count for repeated themes across interviews."
-            ),
-            (
-                "Decision checkpoint template:\n"
-                "- What evidence improved confidence?\n"
-                "- What assumptions remain unproven?\n"
-                "- What experiment is approved for next sprint?"
-            ),
-        ]
+        prompt = (
+            f"Create research artifacts for the following product concept.\n\n"
+            f"Product concept: {mission.product_concept}\n"
+            f"Target users: {mission.target_users}\n"
+            f"Business goal: {mission.business_goal}\n\n"
+            f"Return ONLY a valid JSON array of exactly 3 strings: "
+            f"an interview script, a transcript tagging guide, and a decision checkpoint template."
+        )
+        raw = _call_agent(self._agent, prompt)
+        data = _parse_json(raw, _DEFAULT_SCRIPTS_FALLBACK)
+
+        if isinstance(data, list) and all(isinstance(s, str) for s in data) and len(data) >= 1:
+            return data
+
+        return list(_DEFAULT_SCRIPTS_FALLBACK)

--- a/backend/agents/market_research_team/orchestrator.py
+++ b/backend/agents/market_research_team/orchestrator.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from collections import Counter
+import json
+import logging
+from typing import List
 
 from .agents import (
     MarketViabilityAgent,
@@ -10,15 +12,49 @@ from .agents import (
     TranscriptIngestionAgent,
     UserPsychologyAgent,
     UXResearchAgent,
+    _build_strands_agent,
+    _call_agent,
+    _parse_json,
 )
 from .models import (
     HumanReview,
+    InterviewInsight,
     MarketSignal,
     ResearchMission,
     TeamOutput,
     TeamTopology,
     WorkflowStatus,
 )
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Consistency analysis system prompt
+# ---------------------------------------------------------------------------
+
+_CONSISTENCY_SYSTEM_PROMPT = """\
+You are a Cross-Interview Consistency Analyst. Your job is to identify recurring themes \
+across multiple user interviews and assess how consistent the evidence is.
+
+## Your Methodology
+- Compare pain points, user jobs, and desired outcomes across all interviews.
+- Identify themes that appear in 2+ interviews — these are the strongest signals.
+- Assess whether different interviewees describe the same underlying problem in different words \
+(semantic similarity, not just exact matches).
+- Higher consistency = higher confidence that the problem is real and widespread.
+
+## Confidence Calibration
+- 5+ interviews with 3+ repeated themes: confidence 0.8-0.95
+- 3-4 interviews with 2+ repeated themes: confidence 0.6-0.8
+- 1-2 interviews or few repeated themes: confidence 0.4-0.6
+- Contradictory signals across interviews: confidence 0.2-0.4
+
+## Output Format
+Return ONLY a valid JSON object (no markdown, no commentary) with these exact keys:
+- "signal": always "Cross-interview theme consistency"
+- "confidence": float 0.0-1.0
+- "evidence": array of strings — the repeated themes or patterns found across interviews
+"""
 
 
 class MarketResearchOrchestrator:
@@ -30,15 +66,38 @@ class MarketResearchOrchestrator:
         self.psychology = UserPsychologyAgent()
         self.viability = MarketViabilityAgent()
         self.script_builder = ResearchScriptAgent()
+        self._consistency_agent = _build_strands_agent(_CONSISTENCY_SYSTEM_PROMPT)
 
-    @staticmethod
-    def _cross_interview_consistency_signal() -> MarketSignal:
+    def _cross_interview_consistency_signal(self, insights: List[InterviewInsight]) -> MarketSignal:
+        if not insights:
+            return MarketSignal(
+                signal="Cross-interview theme consistency",
+                confidence=0.55,
+                evidence=[
+                    "Insufficient transcript volume for consistency scoring; collect 5+ interviews."
+                ],
+            )
+
+        insights_json = json.dumps([i.model_dump() for i in insights], indent=2)
+        prompt = (
+            f"Analyze the following {len(insights)} interview insights for cross-interview "
+            f"theme consistency.\n\n{insights_json}\n\n"
+            f"Identify recurring themes and rate the consistency confidence. "
+            f"Return ONLY valid JSON."
+        )
+        raw = _call_agent(self._consistency_agent, prompt)
+        data = _parse_json(raw, {})
+
+        if not isinstance(data, dict):
+            data = {}
+
         return MarketSignal(
-            signal="Cross-interview theme consistency",
-            confidence=0.55,
-            evidence=[
-                "Insufficient transcript volume for consistency scoring; collect 5+ interviews."
-            ],
+            signal=data.get("signal", "Cross-interview theme consistency"),
+            confidence=min(1.0, max(0.0, float(data.get("confidence", 0.55)))),
+            evidence=data.get(
+                "evidence",
+                ["No repeated pains found yet; gather more interviews for consistency checks."],
+            ),
         )
 
     def _run_split_signals(self, mission: ResearchMission) -> tuple[list, list[MarketSignal]]:
@@ -46,24 +105,7 @@ class MarketResearchOrchestrator:
         insights = [self.ux_research.analyze(source, text) for source, text in loaded]
 
         base_signals = self.psychology.derive_signals(insights)
-        if not insights:
-            return insights, [*base_signals, self._cross_interview_consistency_signal()]
-
-        theme_counter: Counter[str] = Counter()
-        for insight in insights:
-            theme_counter.update(insight.pain_points)
-
-        repeated = [theme for theme, count in theme_counter.items() if count > 1]
-        confidence = min(1.0, 0.55 + (len(repeated) * 0.1))
-        evidence = repeated[:4] or [
-            "No repeated pains found yet; gather more interviews for consistency checks."
-        ]
-
-        consistency = MarketSignal(
-            signal="Cross-interview theme consistency",
-            confidence=confidence,
-            evidence=evidence,
-        )
+        consistency = self._cross_interview_consistency_signal(insights)
         return insights, [*base_signals, consistency]
 
     def _run_unified_signals(self, mission: ResearchMission) -> tuple[list, list[MarketSignal]]:

--- a/backend/agents/market_research_team/temporal/__init__.py
+++ b/backend/agents/market_research_team/temporal/__init__.py
@@ -17,10 +17,20 @@ from temporalio import activity, workflow
 @activity.defn(name="market_research_run_pipeline")
 def run_pipeline_activity(request: dict[str, Any]) -> dict[str, Any]:
     from market_research_team.api.main import RunMarketResearchRequest
+    from market_research_team.models import HumanReview, ResearchMission
     from market_research_team.orchestrator import MarketResearchOrchestrator
 
     req = RunMarketResearchRequest(**request)
-    result = MarketResearchOrchestrator().run(req)
+    mission = ResearchMission(
+        product_concept=req.product_concept,
+        target_users=req.target_users,
+        business_goal=req.business_goal,
+        topology=req.topology,
+        transcript_folder_path=req.transcript_folder_path,
+        transcripts=req.transcripts,
+    )
+    human_review = HumanReview(approved=req.human_approved, feedback=req.human_feedback)
+    result = MarketResearchOrchestrator().run(mission, human_review)
     if hasattr(result, "model_dump"):
         return result.model_dump()
     return result if isinstance(result, dict) else {"result": result}
@@ -43,6 +53,4 @@ ACTIVITIES = [run_pipeline_activity]
 from shared_temporal import is_temporal_enabled, start_team_worker  # noqa: E402
 
 if is_temporal_enabled():
-    start_team_worker(
-        "market_research", WORKFLOWS, ACTIVITIES, task_queue="market_research-queue"
-    )
+    start_team_worker("market_research", WORKFLOWS, ACTIVITIES, task_queue="market_research-queue")

--- a/backend/agents/market_research_team/tests/conftest.py
+++ b/backend/agents/market_research_team/tests/conftest.py
@@ -1,6 +1,123 @@
+import json
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
 
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+# ---------------------------------------------------------------------------
+# Sample JSON responses that mock LLM output for each agent
+# ---------------------------------------------------------------------------
+
+SAMPLE_INSIGHT_JSON = json.dumps(
+    {
+        "user_jobs": ["Speed up onboarding for new hires"],
+        "pain_points": ["Manual handoffs across teams cause delays"],
+        "desired_outcomes": ["Reduce onboarding time by 50%"],
+        "direct_quotes": ["I spend half my day just chasing people for status updates."],
+    }
+)
+
+SAMPLE_SIGNALS_JSON = json.dumps(
+    [
+        {
+            "signal": "User pain urgency",
+            "confidence": 0.72,
+            "evidence": ["Users report spending 50% of time on manual handoffs"],
+        },
+        {
+            "signal": "Adoption motivation clarity",
+            "confidence": 0.65,
+            "evidence": ["Clear desired outcome: reduce onboarding time by 50%"],
+        },
+    ]
+)
+
+SAMPLE_VIABILITY_JSON = json.dumps(
+    {
+        "verdict": "promising_with_risks",
+        "confidence": 0.68,
+        "rationale": [
+            "Strong pain signal from multiple interviewees.",
+            "Clear willingness to adopt new tools.",
+        ],
+        "suggested_next_experiments": [
+            "Run a concierge MVP with 3 target users.",
+            "Test value prop with a landing page experiment.",
+        ],
+    }
+)
+
+SAMPLE_VIABILITY_LOW_JSON = json.dumps(
+    {
+        "verdict": "needs_more_validation",
+        "confidence": 0.45,
+        "rationale": ["Limited evidence from interviews.", "Need more data points."],
+        "suggested_next_experiments": ["Conduct 5 more problem interviews."],
+    }
+)
+
+SAMPLE_SCRIPTS_JSON = json.dumps(
+    [
+        "Interview script:\n1) Tell me about your onboarding process.\n2) What frustrates you most?\n3) What have you tried?\n4) What would ideal look like?",
+        "Transcript tagging guide:\n- job_to_be_done\n- pain_point\n- desired_outcome\n- workaround\n- trigger_event",
+        "Decision checkpoint:\n- What evidence improved confidence?\n- What assumptions remain?\n- What experiment next?",
+    ]
+)
+
+SAMPLE_CONSISTENCY_JSON = json.dumps(
+    {
+        "signal": "Cross-interview theme consistency",
+        "confidence": 0.7,
+        "evidence": [
+            "Manual handoffs mentioned in 3/4 interviews",
+            "Onboarding delay is recurring theme",
+        ],
+    }
+)
+
+
+@pytest.fixture(autouse=True)
+def _mock_strands(monkeypatch):
+    """Patch Strands agent construction and calls for all tests.
+
+    _build_strands_agent returns a MagicMock (no AWS credentials needed).
+    _call_agent returns appropriate JSON based on the prompt content.
+    """
+    monkeypatch.setattr(
+        "market_research_team.agents._build_strands_agent",
+        lambda *args, **kwargs: MagicMock(),
+    )
+
+    # Also patch in the orchestrator module for the consistency agent.
+    monkeypatch.setattr(
+        "market_research_team.orchestrator._build_strands_agent",
+        lambda *args, **kwargs: MagicMock(),
+    )
+
+    def _fake_call_agent(agent, prompt):
+        """Return mock JSON based on prompt keywords."""
+        prompt_lower = prompt.lower()
+        if "transcript" in prompt_lower and "analyze" in prompt_lower:
+            return SAMPLE_INSIGHT_JSON
+        if (
+            "psychology" in prompt_lower
+            or "adoption" in prompt_lower
+            or "market signals" in prompt_lower
+        ):
+            return SAMPLE_SIGNALS_JSON
+        if "viability" in prompt_lower or "verdict" in prompt_lower:
+            return SAMPLE_VIABILITY_JSON
+        if "research artifacts" in prompt_lower or "interview script" in prompt_lower:
+            return SAMPLE_SCRIPTS_JSON
+        if "consistency" in prompt_lower or "cross-interview" in prompt_lower:
+            return SAMPLE_CONSISTENCY_JSON
+        # Fallback
+        return SAMPLE_INSIGHT_JSON
+
+    monkeypatch.setattr("market_research_team.agents._call_agent", _fake_call_agent)
+    monkeypatch.setattr("market_research_team.orchestrator._call_agent", _fake_call_agent)

--- a/backend/agents/market_research_team/tests/test_agents.py
+++ b/backend/agents/market_research_team/tests/test_agents.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 from market_research_team.agents import (
@@ -6,8 +7,13 @@ from market_research_team.agents import (
     TranscriptIngestionAgent,
     UserPsychologyAgent,
     UXResearchAgent,
+    _parse_json,
 )
 from market_research_team.models import InterviewInsight, MarketSignal, ResearchMission
+
+# ---------------------------------------------------------------------------
+# TranscriptIngestionAgent (unchanged — pure I/O, no LLM)
+# ---------------------------------------------------------------------------
 
 
 def test_transcript_ingestion_loads_inline_and_folder(tmp_path: Path) -> None:
@@ -43,27 +49,44 @@ def test_transcript_ingestion_handles_missing_folder() -> None:
     assert TranscriptIngestionAgent().load_transcripts(mission) == []
 
 
-def test_ux_research_extracts_expected_fields_and_fallbacks() -> None:
-    transcript = (
-        '"I need this fixed"\n'
-        "I am trying to speed up onboarding.\n"
-        "Main pain is handoffs across teams.\n"
-        "Desired outcome is fewer escalations."
-    )
-    insight = UXResearchAgent().analyze("source.txt", transcript)
+# ---------------------------------------------------------------------------
+# UXResearchAgent (Strands-powered)
+# ---------------------------------------------------------------------------
+
+
+def test_ux_research_extracts_fields_from_llm_response() -> None:
+    agent = UXResearchAgent()
+    insight = agent.analyze("source.txt", "Some transcript about user pain and jobs.")
+
     assert insight.source == "source.txt"
-    assert insight.user_jobs
-    assert insight.pain_points
-    assert insight.desired_outcomes
-    assert insight.direct_quotes
-
-    fallback = UXResearchAgent().analyze("source2.txt", "just neutral text")
-    assert fallback.user_jobs[0].startswith("Identify the core user job")
-    assert fallback.pain_points[0].startswith("Validate top workflow frictions")
-    assert fallback.desired_outcomes[0].startswith("Confirm measurable success")
+    assert isinstance(insight.user_jobs, list)
+    assert len(insight.user_jobs) >= 1
+    assert isinstance(insight.pain_points, list)
+    assert len(insight.pain_points) >= 1
+    assert isinstance(insight.desired_outcomes, list)
+    assert isinstance(insight.direct_quotes, list)
 
 
-def test_user_psychology_signals_with_and_without_insights() -> None:
+def test_ux_research_fallback_on_bad_llm_response(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "market_research_team.agents._call_agent",
+        lambda agent, prompt: "not valid json at all",
+    )
+    agent = UXResearchAgent()
+    insight = agent.analyze("source.txt", "neutral text")
+
+    assert insight.source == "source.txt"
+    assert insight.user_jobs[0].startswith("Identify the core user job")
+    assert insight.pain_points[0].startswith("Validate top workflow frictions")
+    assert insight.desired_outcomes[0].startswith("Confirm measurable success")
+
+
+# ---------------------------------------------------------------------------
+# UserPsychologyAgent (Strands-powered)
+# ---------------------------------------------------------------------------
+
+
+def test_user_psychology_returns_signals() -> None:
     insights = [
         InterviewInsight(
             source="a",
@@ -72,48 +95,148 @@ def test_user_psychology_signals_with_and_without_insights() -> None:
         )
     ]
     signals = UserPsychologyAgent().derive_signals(insights)
-    assert len(signals) == 2
-    assert signals[0].signal == "User pain urgency"
-    assert signals[1].signal == "Adoption motivation clarity"
-
-    empty_signals = UserPsychologyAgent().derive_signals([])
-    assert empty_signals[0].evidence[0].startswith("No direct pain")
-    assert empty_signals[1].evidence[0].startswith("No clear desired")
+    assert len(signals) >= 2
+    assert all(isinstance(s, MarketSignal) for s in signals)
+    assert all(0.0 <= s.confidence <= 1.0 for s in signals)
 
 
-def test_market_viability_recommendation_branches() -> None:
+def test_user_psychology_handles_empty_insights() -> None:
+    signals = UserPsychologyAgent().derive_signals([])
+    assert len(signals) >= 2
+    assert all(isinstance(s, MarketSignal) for s in signals)
+
+
+def test_user_psychology_pads_to_minimum_two_signals(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "market_research_team.agents._call_agent",
+        lambda agent, prompt: json.dumps(
+            [{"signal": "Only one", "confidence": 0.6, "evidence": ["e1"]}]
+        ),
+    )
+    signals = UserPsychologyAgent().derive_signals([])
+    assert len(signals) >= 2
+
+
+# ---------------------------------------------------------------------------
+# MarketViabilityAgent (Strands-powered)
+# ---------------------------------------------------------------------------
+
+
+def test_market_viability_insufficient_evidence_no_llm() -> None:
     mission = ResearchMission(
         product_concept="Concept",
         target_users="Users",
         business_goal="Goal",
     )
-    agent = MarketViabilityAgent()
+    result = MarketViabilityAgent().recommend(mission, [], 0)
+    assert result.verdict == "insufficient_evidence"
+    assert result.confidence == 0.3
 
-    insufficient = agent.recommend(mission, [], 0)
-    assert insufficient.verdict == "insufficient_evidence"
-    assert insufficient.confidence == 0.3
 
-    low = agent.recommend(
-        mission,
-        [MarketSignal(signal="s1", confidence=0.5), MarketSignal(signal="s2", confidence=0.7)],
-        1,
+def test_market_viability_with_signals() -> None:
+    mission = ResearchMission(
+        product_concept="Concept",
+        target_users="Users",
+        business_goal="Goal",
     )
-    assert low.verdict == "needs_more_validation"
+    signals = [
+        MarketSignal(signal="s1", confidence=0.7, evidence=["e1"]),
+        MarketSignal(signal="s2", confidence=0.8, evidence=["e2"]),
+    ]
+    result = MarketViabilityAgent().recommend(mission, signals, 2)
+    assert result.verdict in {
+        "insufficient_evidence",
+        "needs_more_validation",
+        "promising_with_risks",
+    }
+    assert 0.0 <= result.confidence <= 1.0
+    assert isinstance(result.rationale, list)
+    assert isinstance(result.suggested_next_experiments, list)
 
-    high = agent.recommend(
-        mission,
-        [MarketSignal(signal="s1", confidence=0.9), MarketSignal(signal="s2", confidence=0.8)],
-        2,
+
+def test_market_viability_fallback_on_bad_response(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "market_research_team.agents._call_agent",
+        lambda agent, prompt: "broken json",
     )
-    assert high.verdict == "promising_with_risks"
+    mission = ResearchMission(
+        product_concept="Concept",
+        target_users="Users",
+        business_goal="Goal",
+    )
+    result = MarketViabilityAgent().recommend(
+        mission, [MarketSignal(signal="s1", confidence=0.5)], 1
+    )
+    assert result.verdict == "needs_more_validation"
 
 
-def test_research_script_builder_includes_business_goal() -> None:
+def test_market_viability_invalid_verdict_defaults(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "market_research_team.agents._call_agent",
+        lambda agent, prompt: json.dumps(
+            {
+                "verdict": "INVALID_VALUE",
+                "confidence": 0.5,
+                "rationale": [],
+                "suggested_next_experiments": [],
+            }
+        ),
+    )
+    mission = ResearchMission(
+        product_concept="Concept",
+        target_users="Users",
+        business_goal="Goal",
+    )
+    result = MarketViabilityAgent().recommend(
+        mission, [MarketSignal(signal="s1", confidence=0.5)], 1
+    )
+    assert result.verdict == "needs_more_validation"
+
+
+# ---------------------------------------------------------------------------
+# ResearchScriptAgent (Strands-powered)
+# ---------------------------------------------------------------------------
+
+
+def test_research_script_builder_returns_scripts() -> None:
     mission = ResearchMission(
         product_concept="Concept",
         target_users="Users",
         business_goal="prioritizing roadmap items",
     )
     scripts = ResearchScriptAgent().build_scripts(mission)
+    assert isinstance(scripts, list)
+    assert len(scripts) >= 1
+    assert all(isinstance(s, str) for s in scripts)
+
+
+def test_research_script_builder_fallback_on_bad_response(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "market_research_team.agents._call_agent",
+        lambda agent, prompt: "not json",
+    )
+    mission = ResearchMission(
+        product_concept="Concept",
+        target_users="Users",
+        business_goal="Goal",
+    )
+    scripts = ResearchScriptAgent().build_scripts(mission)
+    assert isinstance(scripts, list)
     assert len(scripts) == 3
-    assert "prioritizing roadmap items" in scripts[0]
+
+
+# ---------------------------------------------------------------------------
+# _parse_json helper
+# ---------------------------------------------------------------------------
+
+
+def test_parse_json_strips_markdown_fences() -> None:
+    raw = '```json\n{"key": "value"}\n```'
+    result = _parse_json(raw, {})
+    assert result == {"key": "value"}
+
+
+def test_parse_json_returns_fallback_on_invalid_input() -> None:
+    assert _parse_json("", {"default": True}) == {"default": True}
+    assert _parse_json("not json", []) == []
+    assert _parse_json(None, "fallback") == "fallback"

--- a/backend/agents/market_research_team/tests/test_market_research_orchestrator.py
+++ b/backend/agents/market_research_team/tests/test_market_research_orchestrator.py
@@ -41,7 +41,11 @@ def test_orchestrator_ready_for_execution_with_approval() -> None:
 
     assert output.status == WorkflowStatus.READY_FOR_EXECUTION
     assert output.topology == TeamTopology.SPLIT
-    assert output.recommendation.verdict in {"promising_with_risks", "needs_more_validation"}
+    assert output.recommendation.verdict in {
+        "promising_with_risks",
+        "needs_more_validation",
+        "insufficient_evidence",
+    }
     assert any(
         signal.signal == "Cross-interview theme consistency" for signal in output.market_signals
     )


### PR DESCRIPTION
Replace heuristic keyword-matching agents with LLM-powered Strands agents,
following the same patterns used by the sales team and 16+ other teams.

- UXResearchAgent: JTBD + ODI + Mom Test methodology in system prompt
- UserPsychologyAgent: BJ Fogg + Kano + Rogers diffusion analysis
- MarketViabilityAgent: Lean Startup + Sean Ellis PMF evaluation
- ResearchScriptAgent: interview design + thematic coding generation
- TranscriptIngestionAgent: unchanged (pure I/O, no LLM needed)
- Orchestrator: LLM-powered cross-interview consistency signal
- Fix Temporal workflow interface mismatch (was passing wrong type)
- All agents have defensive JSON parsing with backward-compatible fallbacks
- Tests mock _call_agent and _build_strands_agent for deterministic results

https://claude.ai/code/session_011KAYmcyYDkrGg4yMqg8mKL