### PR TITLE
Replace ta library with built-in indicators module

### DIFF
--- a/backend/agents/investment_team/strategy_lab/executor/indicators.py
+++ b/backend/agents/investment_team/strategy_lab/executor/indicators.py
@@ -1,0 +1,144 @@
+"""Pre-built technical indicators using only pandas and numpy.
+
+Available in the strategy sandbox via: from indicators import <function_name>
+
+Every function takes pd.Series (or multiple Series) and returns pd.Series
+or a tuple of pd.Series.  NaN values propagate naturally through pandas
+rolling/ewm windows — callers should skip warmup rows where indicators
+are NaN.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+
+
+def sma(series: pd.Series, period: int) -> pd.Series:
+    """Simple Moving Average."""
+    return series.rolling(window=period).mean()
+
+
+def ema(series: pd.Series, period: int) -> pd.Series:
+    """Exponential Moving Average."""
+    return series.ewm(span=period, adjust=False).mean()
+
+
+def rsi(series: pd.Series, period: int = 14) -> pd.Series:
+    """Relative Strength Index (0–100)."""
+    delta = series.diff()
+    gain = delta.clip(lower=0)
+    loss = (-delta).clip(lower=0)
+    avg_gain = gain.ewm(alpha=1 / period, min_periods=period, adjust=False).mean()
+    avg_loss = loss.ewm(alpha=1 / period, min_periods=period, adjust=False).mean()
+    rs = avg_gain / avg_loss.replace(0, np.nan)
+    return 100 - (100 / (1 + rs))
+
+
+def macd(
+    series: pd.Series,
+    fast: int = 12,
+    slow: int = 26,
+    signal: int = 9,
+) -> tuple[pd.Series, pd.Series, pd.Series]:
+    """MACD line, signal line, histogram."""
+    fast_ema = ema(series, fast)
+    slow_ema = ema(series, slow)
+    macd_line = fast_ema - slow_ema
+    signal_line = ema(macd_line, signal)
+    histogram = macd_line - signal_line
+    return macd_line, signal_line, histogram
+
+
+def bollinger_bands(
+    series: pd.Series,
+    period: int = 20,
+    num_std: float = 2.0,
+) -> tuple[pd.Series, pd.Series, pd.Series]:
+    """Upper band, middle band (SMA), lower band."""
+    middle = sma(series, period)
+    std = series.rolling(window=period).std()
+    upper = middle + num_std * std
+    lower = middle - num_std * std
+    return upper, middle, lower
+
+
+def atr(
+    high: pd.Series,
+    low: pd.Series,
+    close: pd.Series,
+    period: int = 14,
+) -> pd.Series:
+    """Average True Range."""
+    prev_close = close.shift(1)
+    tr = pd.concat(
+        [high - low, (high - prev_close).abs(), (low - prev_close).abs()],
+        axis=1,
+    ).max(axis=1)
+    return tr.rolling(window=period).mean()
+
+
+def adx(
+    high: pd.Series,
+    low: pd.Series,
+    close: pd.Series,
+    period: int = 14,
+) -> pd.Series:
+    """Average Directional Index (0–100).
+
+    Uses Wilder's smoothing (alpha = 1/period) for directional indicators.
+    """
+    prev_high = high.shift(1)
+    prev_low = low.shift(1)
+
+    plus_dm = (high - prev_high).clip(lower=0)
+    minus_dm = (prev_low - low).clip(lower=0)
+
+    # Zero out the smaller of the two
+    mask_plus = plus_dm < minus_dm
+    mask_minus = minus_dm <= plus_dm
+    plus_dm = plus_dm.where(~mask_plus, 0)
+    minus_dm = minus_dm.where(~mask_minus, 0)
+
+    atr_val = atr(high, low, close, period)
+    safe_atr = atr_val.replace(0, np.nan)
+
+    plus_di = 100 * plus_dm.ewm(alpha=1 / period, min_periods=period, adjust=False).mean() / safe_atr
+    minus_di = 100 * minus_dm.ewm(alpha=1 / period, min_periods=period, adjust=False).mean() / safe_atr
+
+    di_sum = (plus_di + minus_di).replace(0, np.nan)
+    dx = 100 * (plus_di - minus_di).abs() / di_sum
+    return dx.ewm(alpha=1 / period, min_periods=period, adjust=False).mean()
+
+
+def stochastic(
+    high: pd.Series,
+    low: pd.Series,
+    close: pd.Series,
+    k_period: int = 14,
+    d_period: int = 3,
+) -> tuple[pd.Series, pd.Series]:
+    """Stochastic Oscillator (%K, %D)."""
+    lowest_low = low.rolling(window=k_period).min()
+    highest_high = high.rolling(window=k_period).max()
+    denom = (highest_high - lowest_low).replace(0, np.nan)
+    pct_k = 100 * (close - lowest_low) / denom
+    pct_d = pct_k.rolling(window=d_period).mean()
+    return pct_k, pct_d
+
+
+def vwap(
+    high: pd.Series,
+    low: pd.Series,
+    close: pd.Series,
+    volume: pd.Series,
+) -> pd.Series:
+    """Cumulative Volume Weighted Average Price.
+
+    Note: this is a cumulative VWAP with no intraday reset, appropriate
+    for daily OHLCV bars.
+    """
+    typical_price = (high + low + close) / 3
+    cum_tp_vol = (typical_price * volume).cumsum()
+    cum_vol = volume.cumsum().replace(0, np.nan)
+    return cum_tp_vol / cum_vol

--- a/backend/agents/investment_team/strategy_lab/executor/indicators.py
+++ b/backend/agents/investment_team/strategy_lab/executor/indicators.py
@@ -32,7 +32,10 @@ def rsi(series: pd.Series, period: int = 14) -> pd.Series:
     avg_gain = gain.ewm(alpha=1 / period, min_periods=period, adjust=False).mean()
     avg_loss = loss.ewm(alpha=1 / period, min_periods=period, adjust=False).mean()
     rs = avg_gain / avg_loss.replace(0, np.nan)
-    return 100 - (100 / (1 + rs))
+    result = 100 - (100 / (1 + rs))
+    # When avg_loss is zero (sustained uptrend) RS is infinite → RSI = 100
+    result = result.fillna(np.where(avg_loss == 0, 100.0, np.nan))
+    return result
 
 
 def macd(
@@ -100,8 +103,14 @@ def adx(
     plus_dm = plus_dm.where(~mask_plus, 0)
     minus_dm = minus_dm.where(~mask_minus, 0)
 
-    atr_val = atr(high, low, close, period)
-    safe_atr = atr_val.replace(0, np.nan)
+    # Wilder-smoothed True Range (same smoothing as DM to keep ADX consistent)
+    prev_close = close.shift(1)
+    tr = pd.concat(
+        [high - low, (high - prev_close).abs(), (low - prev_close).abs()],
+        axis=1,
+    ).max(axis=1)
+    atr_wilder = tr.ewm(alpha=1 / period, min_periods=period, adjust=False).mean()
+    safe_atr = atr_wilder.replace(0, np.nan)
 
     plus_di = 100 * plus_dm.ewm(alpha=1 / period, min_periods=period, adjust=False).mean() / safe_atr
     minus_di = 100 * minus_dm.ewm(alpha=1 / period, min_periods=period, adjust=False).mean() / safe_atr

--- a/backend/agents/investment_team/strategy_lab/executor/sandbox_runner.py
+++ b/backend/agents/investment_team/strategy_lab/executor/sandbox_runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -65,6 +66,10 @@ class SandboxRunner:
                 strategy_path = os.path.join(tmpdir, "strategy.py")
                 with open(strategy_path, "w", encoding="utf-8") as f:
                     f.write(strategy_code)
+
+                # 2b. Copy indicators library so `from indicators import ...` works
+                indicators_src = os.path.join(os.path.dirname(__file__), "indicators.py")
+                shutil.copy2(indicators_src, os.path.join(tmpdir, "indicators.py"))
 
                 # 3. Write harness script
                 harness_path = os.path.join(tmpdir, "_harness.py")

--- a/backend/agents/investment_team/strategy_lab/prompts/ideation_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/ideation_system.md
@@ -10,7 +10,7 @@ Follow this decomposed reasoning process for every strategy:
 2. **HYPOTHESIZE** a novel multi-signal trading thesis that differs from prior attempts and addresses identified failure modes.
 3. **DESIGN** specific entry/exit/sizing rules with concrete indicator parameters (e.g., "RSI(14) < 30 AND close > SMA(50)").
 4. **STRESS-TEST** your rules mentally: consider regime changes (trending vs ranging), transaction cost drag, drawdown scenarios, and edge cases.
-5. **CODE** the strategy as a Python function using pandas, numpy, and the `ta` library for technical indicators.
+5. **CODE** the strategy by filling in the boilerplate template below with your strategy logic.
 6. **OUTPUT** the complete JSON response.
 
 ## Signal families to combine
@@ -26,15 +26,19 @@ Design strategies as a **mixture of signal types**, not a single indicator. Comb
 Diversify across: stocks, crypto, forex, options, futures, commodities.
 Do NOT default to equities unless explicitly directed.
 
-## Generated code contract
+## Boilerplate template
 
-Your Python code MUST define this exact function:
+Your code MUST follow this exact skeleton. Fill in ONLY the marked sections.
 
 ```python
+import pandas as pd
+import numpy as np
+from indicators import sma, ema, rsi, macd, bollinger_bands, atr, adx, stochastic, vwap
+
 def run_strategy(data: dict, config: dict) -> list:
     """
     Args:
-        data: dict mapping symbol (str) to pandas DataFrame with columns:
+        data: dict mapping symbol (str) to DataFrame with columns:
               ['date', 'open', 'high', 'low', 'close', 'volume']
               Sorted by date ascending. 'date' column is a string (YYYY-MM-DD).
         config: dict with keys:
@@ -52,24 +56,104 @@ def run_strategy(data: dict, config: dict) -> list:
         - exit_price: float (raw market price at exit)
         - shares: float (positive number)
     """
+    trades = []
+    capital = config['initial_capital']
+
+    for symbol, df in data.items():
+        df = df.copy().reset_index(drop=True)
+        df['date'] = df['date'].astype(str)
+
+        # ── COMPUTE INDICATORS (fill in) ──────────────────────
+        # Example: df['sma_50'] = sma(df['close'], 50)
+        # <YOUR INDICATORS HERE>
+
+        # ── DETERMINE WARMUP PERIOD ───────────────────────────
+        warmup = 50  # set to your max indicator lookback period
+        df = df.iloc[warmup:].reset_index(drop=True)
+        if len(df) < 2:
+            continue
+
+        # ── GENERATE SIGNALS & EXECUTE TRADES (fill in) ──────
+        position = None  # None, 'long', or 'short'
+        entry_price = 0.0
+        entry_date = ''
+        shares = 0.0
+
+        for i in range(len(df)):
+            row = df.iloc[i]
+            price = row['close']
+            date = row['date']
+
+            if position is None:
+                # <YOUR ENTRY LOGIC HERE>
+                # To enter long:
+                #   position = 'long'
+                #   entry_price = price
+                #   entry_date = date
+                #   shares = (capital * position_pct) / price
+                pass
+            else:
+                # <YOUR EXIT LOGIC HERE>
+                # To exit:
+                #   trades.append({
+                #       'symbol': symbol, 'side': position,
+                #       'entry_date': entry_date, 'entry_price': entry_price,
+                #       'exit_date': date, 'exit_price': price,
+                #       'shares': shares,
+                #   })
+                #   position = None
+                pass
+
+        # ── FORCE-CLOSE at end of data ────────────────────────
+        if position is not None:
+            trades.append({
+                'symbol': symbol,
+                'side': position,
+                'entry_date': entry_date,
+                'entry_price': entry_price,
+                'exit_date': df.iloc[-1]['date'],
+                'exit_price': df.iloc[-1]['close'],
+                'shares': shares,
+            })
+
+    return trades
 ```
+
+Replace the `<YOUR ... HERE>` sections with your strategy logic. Do NOT modify the boilerplate structure (imports, function signature, data preparation, force-close block, return statement).
+
+## Available indicators
+
+The `indicators` module is pre-loaded in the sandbox. Import only what you need:
+
+```python
+from indicators import sma, ema, rsi, macd, bollinger_bands, atr, adx, stochastic, vwap
+```
+
+| Function | Signature | Returns |
+|---|---|---|
+| `sma` | `sma(series, period)` | Series |
+| `ema` | `ema(series, period)` | Series |
+| `rsi` | `rsi(series, period=14)` | Series (0–100) |
+| `macd` | `macd(series, fast=12, slow=26, signal=9)` | (macd_line, signal_line, histogram) |
+| `bollinger_bands` | `bollinger_bands(series, period=20, num_std=2.0)` | (upper, middle, lower) |
+| `atr` | `atr(high, low, close, period=14)` | Series |
+| `adx` | `adx(high, low, close, period=14)` | Series (0–100) |
+| `stochastic` | `stochastic(high, low, close, k_period=14, d_period=3)` | (pct_k, pct_d) |
+| `vwap` | `vwap(high, low, close, volume)` | Series |
 
 ## Allowed imports
 
 ONLY these libraries are available:
 - `pandas` (as pd)
 - `numpy` (as np)
-- `ta` (technical analysis library — ta.trend, ta.momentum, ta.volatility, ta.volume, etc.)
+- `indicators` (pre-built technical indicators — see table above)
 - `math`, `datetime`, `collections`, `itertools`, `functools`, `re`, `copy`, `statistics`
 
-Do NOT import: os, sys, subprocess, socket, http, requests, or any filesystem/network module.
+Do NOT import: os, sys, subprocess, socket, http, requests, ta, or any filesystem/network module.
 Do NOT use: exec(), eval(), open(), or any dynamic code execution.
 
 ## Code quality requirements
 
-- Handle the case where indicators need warmup (e.g., skip rows where SMA is NaN)
 - Use `config['initial_capital']` for position sizing — do not hardcode capital amounts
-- Force-close any open position at the end of the data
-- Use defensive programming: check for NaN values, empty DataFrames, etc.
 - Keep code under 200 lines; prefer clarity over cleverness
 - Do NOT apply slippage or transaction costs — the harness handles that post-hoc

--- a/backend/agents/investment_team/strategy_lab/prompts/refinement_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/refinement_system.md
@@ -18,7 +18,7 @@ Your task: fix and refine a generated trading strategy's Python code based on er
 ### Code execution errors (syntax, import, runtime)
 - Fix the Python code directly
 - Do NOT change the strategy logic unless the error reveals a logical flaw
-- Common issues: NaN handling, empty DataFrames, index errors, wrong ta API usage
+- Common issues: NaN handling, empty DataFrames, index errors, wrong indicator usage
 
 ### Quality gate: backtest anomaly
 - If too few trades: lower entry thresholds or widen conditions
@@ -33,7 +33,10 @@ Your task: fix and refine a generated trading strategy's Python code based on er
 
 ### Quality gate: code safety
 - Remove any banned imports or function calls
-- Replace with allowed alternatives from: pandas, numpy, ta, math, datetime
+- Replace with allowed alternatives from: pandas, numpy, indicators, math, datetime
+- The `indicators` module provides: sma, ema, rsi, macd, bollinger_bands, atr, adx, stochastic, vwap
+- Do NOT use the `ta` library — use `from indicators import ...` instead
+- Preserve the boilerplate structure (data preparation, warmup, force-close pattern)
 
 ## Generated code contract
 

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -19,7 +19,7 @@ BANNED_IMPORTS = frozenset({
 })
 
 ALLOWED_IMPORTS = frozenset({
-    "pandas", "numpy", "ta", "math", "datetime", "collections",
+    "pandas", "numpy", "indicators", "math", "datetime", "collections",
     "itertools", "functools", "typing", "dataclasses", "enum", "abc",
     "re", "copy", "statistics", "decimal", "fractions", "operator",
     "json",

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -22,7 +22,6 @@ psycopg[binary]>=3.3,<4.0
 yfinance>=1.2,<2.0
 pandas>=3.0,<4.0
 numpy>=2.4,<3.0
-ta>=0.11,<1.0
 prometheus-fastapi-instrumentator>=7.1,<8.0
 opentelemetry-api>=1.41,<2.0
 opentelemetry-sdk>=1.41,<2.0


### PR DESCRIPTION
## Changes

- **Added `indicators.py`**: Pre-built technical indicators module (SMA, EMA, RSI, MACD, Bollinger Bands, ATR, ADX, Stochastic, VWAP) using only pandas and numpy
- **Updated `sandbox_runner.py`**: Copy indicators.py to sandbox so strategies can `from indicators import ...`
- **Expanded `ideation_system.md`**: Added complete boilerplate template with filled-in structure, indicator reference table, and clearer guidance
- **Updated `refinement_system.md`**: Document indicator module usage and removal of ta library references
- **Modified `code_safety.py`**: Swap `ta` with `indicators` in allowed imports
- **Removed from `requirements.txt`**: Dependency on `ta>=0.11,<1.0`

## Benefits

- Eliminates external ta library dependency
- Provides self-contained, auditable indicator implementations
- Simplifies sandbox environment and reduces attack surface
- Makes boilerplate template explicit and easier to follow for code generation