### PR TITLE
Fix look-ahead bias and add Kraken fees to Strategy Lab

### DIFF
--- a/backend/agents/investment_team/api/main.py
+++ b/backend/agents/investment_team/api/main.py
@@ -2171,8 +2171,16 @@ class RunPaperTradingRequest(BaseModel):
 
     lab_record_id: str = Field(..., description="ID of a winning StrategyLabRecord to paper trade")
     initial_capital: float = Field(default=100000.0, gt=0)
-    transaction_cost_bps: float = Field(default=5.0, ge=0)
-    slippage_bps: float = Field(default=2.0, ge=0)
+    transaction_cost_bps: Optional[float] = Field(
+        default=None,
+        ge=0,
+        description="Override tx cost (bps); auto-detected from asset class when omitted",
+    )
+    slippage_bps: Optional[float] = Field(
+        default=None,
+        ge=0,
+        description="Override slippage (bps); auto-detected from asset class when omitted",
+    )
     lookback_days: int = Field(
         default=365, ge=30, description="Days of recent market data to fetch"
     )

--- a/backend/agents/investment_team/api/main.py
+++ b/backend/agents/investment_team/api/main.py
@@ -1072,13 +1072,16 @@ def _run_one_strategy_lab_cycle(
     else:
         _emit("paper_trading", {"strategy": strategy_preview})
         try:
+            # Use the backtest record's config which has asset-class-resolved
+            # fees (the orchestrator may have overridden generic defaults).
+            bt_config = record.backtest.config
             session = _run_paper_trading_step(
                 strategy=record.strategy,
                 strategy_code=record.strategy_code,
                 backtest_record=record.backtest,
-                initial_capital=config.initial_capital,
-                transaction_cost_bps=config.transaction_cost_bps,
-                slippage_bps=config.slippage_bps,
+                initial_capital=bt_config.initial_capital,
+                transaction_cost_bps=bt_config.transaction_cost_bps,
+                slippage_bps=bt_config.slippage_bps,
                 lookback_days=paper_trading_lookback_days,
             )
             session.lab_record_id = record.lab_record_id

--- a/backend/agents/investment_team/models.py
+++ b/backend/agents/investment_team/models.py
@@ -231,6 +231,26 @@ class BacktestConfig(BaseModel):
     slippage_bps: float = Field(default=2.0, ge=0)
 
 
+# Asset-class-aware fee defaults.  Crypto uses Kraken taker fees (lowest
+# volume tier).  Other classes use representative retail broker fees.
+ASSET_CLASS_FEE_DEFAULTS: dict[str, dict[str, float]] = {
+    "crypto": {"transaction_cost_bps": 26.0, "slippage_bps": 10.0},
+    "forex": {"transaction_cost_bps": 8.0, "slippage_bps": 5.0},
+    "stocks": {"transaction_cost_bps": 5.0, "slippage_bps": 2.0},
+    "futures": {"transaction_cost_bps": 10.0, "slippage_bps": 5.0},
+    "commodities": {"transaction_cost_bps": 12.0, "slippage_bps": 5.0},
+    "options": {"transaction_cost_bps": 15.0, "slippage_bps": 8.0},
+}
+
+
+def get_fee_defaults(asset_class: str) -> dict[str, float]:
+    """Return transaction_cost_bps and slippage_bps for a given asset class."""
+    return ASSET_CLASS_FEE_DEFAULTS.get(
+        asset_class.lower(),
+        {"transaction_cost_bps": 10.0, "slippage_bps": 5.0},
+    )
+
+
 class BacktestResult(BaseModel):
     total_return_pct: float
     annualized_return_pct: float

--- a/backend/agents/investment_team/paper_trading_agent.py
+++ b/backend/agents/investment_team/paper_trading_agent.py
@@ -13,7 +13,7 @@ import json
 import logging
 import uuid
 from datetime import datetime, timezone
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from strands import Agent
 
@@ -30,6 +30,7 @@ from .models import (
     PaperTradingVerdict,
     StrategySpec,
     TradeRecord,
+    get_fee_defaults,
 )
 from .strategy_lab.executor.sandbox_runner import SandboxRunner
 from .strategy_lab.executor.trade_builder import build_trade_records
@@ -139,10 +140,18 @@ class PaperTradingAgent:
         backtest_record: BacktestRecord,
         market_data: Dict[str, List[OHLCVBar]],
         initial_capital: float = 100_000.0,
-        transaction_cost_bps: float = 5.0,
-        slippage_bps: float = 2.0,
+        transaction_cost_bps: Optional[float] = None,
+        slippage_bps: Optional[float] = None,
     ) -> PaperTradingSession:
         """Run strategy code against recent market data in the subprocess sandbox."""
+        # Resolve fees from strategy's asset class when not explicitly provided
+        if transaction_cost_bps is None or slippage_bps is None:
+            fee_defaults = get_fee_defaults(strategy.asset_class)
+            if transaction_cost_bps is None:
+                transaction_cost_bps = fee_defaults["transaction_cost_bps"]
+            if slippage_bps is None:
+                slippage_bps = fee_defaults["slippage_bps"]
+
         session_id = f"pt-{uuid.uuid4().hex[:8]}"
         now = datetime.now(tz=timezone.utc).isoformat()
 

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -24,6 +24,7 @@ from ..models import (
     StrategyLabRecord,
     StrategySpec,
     TradeRecord,
+    get_fee_defaults,
 )
 from ..signal_intelligence_models import SignalIntelligenceBriefV1
 from ..trade_simulator import compute_metrics
@@ -114,17 +115,33 @@ class StrategyLabOrchestrator:
             strategy_code=code,
         )
 
-        emit("ideating", {"sub_phase": "completed", "strategy": {
-            "asset_class": spec.asset_class,
-            "hypothesis": spec.hypothesis[:120],
-        }})
+        # Override generic fee defaults with asset-class-appropriate values
+        if config.transaction_cost_bps == 5.0 and config.slippage_bps == 2.0:
+            fee_defaults = get_fee_defaults(spec.asset_class)
+            config = config.model_copy(update=fee_defaults)
+
+        emit(
+            "ideating",
+            {
+                "sub_phase": "completed",
+                "strategy": {
+                    "asset_class": spec.asset_class,
+                    "hypothesis": spec.hypothesis[:120],
+                },
+            },
+        )
 
         all_gate_results: List[QualityGateResult] = []
         refinement_attempts: List[str] = []
         trades: List[TradeRecord] = []
         metrics = BacktestResult(
-            total_return_pct=0, annualized_return_pct=0, volatility_pct=0,
-            sharpe_ratio=0, max_drawdown_pct=0, win_rate_pct=0, profit_factor=0,
+            total_return_pct=0,
+            annualized_return_pct=0,
+            volatility_pct=0,
+            sharpe_ratio=0,
+            max_drawdown_pct=0,
+            win_rate_pct=0,
+            profit_factor=0,
         )
         execution_succeeded = False
         market_data: Optional[Dict[str, List[OHLCVBar]]] = None
@@ -152,127 +169,235 @@ class StrategyLabOrchestrator:
             checks_total = len(round_gate_results)
             checks_passed = sum(1 for g in round_gate_results if g.passed)
 
-            critical_failures = [g for g in round_gate_results if not g.passed and g.severity == "critical"]
+            critical_failures = [
+                g for g in round_gate_results if not g.passed and g.severity == "critical"
+            ]
             if critical_failures:
-                emit("coding", {
-                    "sub_phase": "failed", "refinement_round": round_num,
-                    "checks_passed": checks_passed, "checks_total": checks_total,
-                })
+                emit(
+                    "coding",
+                    {
+                        "sub_phase": "failed",
+                        "refinement_round": round_num,
+                        "checks_passed": checks_passed,
+                        "checks_total": checks_total,
+                    },
+                )
                 if round_num < MAX_CODE_REFINEMENT_ROUNDS - 1:
-                    emit("coding", {"sub_phase": "refining", "refinement_round": round_num, "failure_phase": "validation"})
-                    failure_details = "\n".join(f"- [{g.gate_name}] {g.details}" for g in critical_failures)
-                    updates, code = self._refine(spec, code, "validation", failure_details, None, refinement_attempts)
+                    emit(
+                        "coding",
+                        {
+                            "sub_phase": "refining",
+                            "refinement_round": round_num,
+                            "failure_phase": "validation",
+                        },
+                    )
+                    failure_details = "\n".join(
+                        f"- [{g.gate_name}] {g.details}" for g in critical_failures
+                    )
+                    updates, code = self._refine(
+                        spec, code, "validation", failure_details, None, refinement_attempts
+                    )
                     spec = self._apply_updates(spec, updates, code)
                     changes = updates.get("changes_made", "validation fix")
                     refinement_attempts.append(changes)
-                    emit("coding", {"sub_phase": "refined", "refinement_round": round_num, "changes_made": changes})
+                    emit(
+                        "coding",
+                        {
+                            "sub_phase": "refined",
+                            "refinement_round": round_num,
+                            "changes_made": changes,
+                        },
+                    )
                     continue
                 else:
-                    logger.warning("Max code refinement rounds reached on validation for %s", spec.strategy_id)
+                    logger.warning(
+                        "Max code refinement rounds reached on validation for %s", spec.strategy_id
+                    )
                     break
 
-            emit("coding", {
-                "sub_phase": "completed", "refinement_round": round_num,
-                "checks_passed": checks_passed, "checks_total": checks_total,
-            })
+            emit(
+                "coding",
+                {
+                    "sub_phase": "completed",
+                    "refinement_round": round_num,
+                    "checks_passed": checks_passed,
+                    "checks_total": checks_total,
+                },
+            )
 
             # ── 2b: FETCH DATA (once, reuse across rounds) ───────────
             if market_data is None:
                 emit("backtesting", {"sub_phase": "fetching_data"})
                 market_data = self._fetch_market_data(spec, config)
                 if not market_data:
-                    all_gate_results.append(QualityGateResult(
-                        gate_name="market_data", passed=False, severity="critical",
-                        details=f"No market data available for asset class '{spec.asset_class}'.",
-                        refinement_round=round_num,
-                    ))
+                    all_gate_results.append(
+                        QualityGateResult(
+                            gate_name="market_data",
+                            passed=False,
+                            severity="critical",
+                            details=f"No market data available for asset class '{spec.asset_class}'.",
+                            refinement_round=round_num,
+                        )
+                    )
                     break
                 total_bars = sum(len(bars) for bars in market_data.values())
-                emit("backtesting", {
-                    "sub_phase": "data_loaded",
-                    "symbols_count": len(market_data),
-                    "bars_count": total_bars,
-                })
+                emit(
+                    "backtesting",
+                    {
+                        "sub_phase": "data_loaded",
+                        "symbols_count": len(market_data),
+                        "bars_count": total_bars,
+                    },
+                )
 
             # ── 2c: EXECUTE (syntax / runtime correctness) ───────────
             emit("backtesting", {"sub_phase": "running_code", "refinement_round": round_num})
             exec_result = self.sandbox.run(code, market_data, config)
 
             if not exec_result.success:
-                all_gate_results.append(QualityGateResult(
-                    gate_name="code_execution", passed=False, severity="critical",
-                    details=f"Execution failed ({exec_result.error_type}): {exec_result.stderr[:500]}",
-                    refinement_round=round_num,
-                ))
+                all_gate_results.append(
+                    QualityGateResult(
+                        gate_name="code_execution",
+                        passed=False,
+                        severity="critical",
+                        details=f"Execution failed ({exec_result.error_type}): {exec_result.stderr[:500]}",
+                        refinement_round=round_num,
+                    )
+                )
                 if round_num < MAX_CODE_REFINEMENT_ROUNDS - 1:
-                    emit("coding", {"sub_phase": "refining", "refinement_round": round_num, "failure_phase": "execution"})
+                    emit(
+                        "coding",
+                        {
+                            "sub_phase": "refining",
+                            "refinement_round": round_num,
+                            "failure_phase": "execution",
+                        },
+                    )
                     failure_details = (
                         f"Error type: {exec_result.error_type}\n"
                         f"stderr:\n{exec_result.stderr[:2000]}"
                     )
-                    updates, code = self._refine(spec, code, "execution", failure_details, None, refinement_attempts)
+                    updates, code = self._refine(
+                        spec, code, "execution", failure_details, None, refinement_attempts
+                    )
                     spec = self._apply_updates(spec, updates, code)
                     changes = updates.get("changes_made", "execution fix")
                     refinement_attempts.append(changes)
-                    emit("coding", {"sub_phase": "refined", "refinement_round": round_num, "changes_made": changes})
+                    emit(
+                        "coding",
+                        {
+                            "sub_phase": "refined",
+                            "refinement_round": round_num,
+                            "changes_made": changes,
+                        },
+                    )
                     continue
                 else:
-                    logger.warning("Max code refinement rounds reached on execution for %s", spec.strategy_id)
+                    logger.warning(
+                        "Max code refinement rounds reached on execution for %s", spec.strategy_id
+                    )
                     break
 
             # ── 2d: VALIDATE TRADE OUTPUT ─────────────────────────────
             try:
                 trades = build_trade_records(exec_result.raw_trades, config)
             except ValueError as ve:
-                all_gate_results.append(QualityGateResult(
-                    gate_name="trade_validation", passed=False, severity="critical",
-                    details=f"Invalid trade output: {ve}",
-                    refinement_round=round_num,
-                ))
+                all_gate_results.append(
+                    QualityGateResult(
+                        gate_name="trade_validation",
+                        passed=False,
+                        severity="critical",
+                        details=f"Invalid trade output: {ve}",
+                        refinement_round=round_num,
+                    )
+                )
                 if round_num < MAX_CODE_REFINEMENT_ROUNDS - 1:
-                    emit("coding", {"sub_phase": "refining", "refinement_round": round_num, "failure_phase": "execution"})
-                    updates, code = self._refine(spec, code, "execution", str(ve), None, refinement_attempts)
+                    emit(
+                        "coding",
+                        {
+                            "sub_phase": "refining",
+                            "refinement_round": round_num,
+                            "failure_phase": "execution",
+                        },
+                    )
+                    updates, code = self._refine(
+                        spec, code, "execution", str(ve), None, refinement_attempts
+                    )
                     spec = self._apply_updates(spec, updates, code)
                     changes = updates.get("changes_made", "trade validation fix")
                     refinement_attempts.append(changes)
-                    emit("coding", {"sub_phase": "refined", "refinement_round": round_num, "changes_made": changes})
+                    emit(
+                        "coding",
+                        {
+                            "sub_phase": "refined",
+                            "refinement_round": round_num,
+                            "changes_made": changes,
+                        },
+                    )
                     continue
                 else:
                     break
 
-            emit("backtesting", {
-                "sub_phase": "completed",
-                "trades_count": len(exec_result.raw_trades),
-                "execution_time": exec_result.execution_time_seconds,
-            })
+            emit(
+                "backtesting",
+                {
+                    "sub_phase": "completed",
+                    "trades_count": len(exec_result.raw_trades),
+                    "execution_time": exec_result.execution_time_seconds,
+                },
+            )
 
             # ── 2e: BACKTEST EVALUATION ───────────────────────────────
             # Code ran cleanly — now compute metrics and check for
             # anomalies.  Critical anomalies (zero trades, implausible
             # returns, etc.) trigger refinement while budget remains.
-            metrics = compute_metrics(trades, config.initial_capital, config.start_date, config.end_date)
+            metrics = compute_metrics(
+                trades, config.initial_capital, config.start_date, config.end_date
+            )
 
             anomaly_gates = self.anomaly_detector.check(metrics, trades)
             for g in anomaly_gates:
                 g.refinement_round = round_num
             all_gate_results.extend(anomaly_gates)
 
-            critical_anomalies = [g for g in anomaly_gates if not g.passed and g.severity == "critical"]
+            critical_anomalies = [
+                g for g in anomaly_gates if not g.passed and g.severity == "critical"
+            ]
             if critical_anomalies:
                 if round_num < MAX_CODE_REFINEMENT_ROUNDS - 1:
-                    emit("coding", {"sub_phase": "refining", "refinement_round": round_num, "failure_phase": "evaluation"})
+                    emit(
+                        "coding",
+                        {
+                            "sub_phase": "refining",
+                            "refinement_round": round_num,
+                            "failure_phase": "evaluation",
+                        },
+                    )
                     failure_details = "\n".join(f"- {g.details}" for g in critical_anomalies)
                     updates, code = self._refine(
-                        spec, code, "evaluation (backtest anomaly)",
-                        failure_details, metrics, refinement_attempts,
+                        spec,
+                        code,
+                        "evaluation (backtest anomaly)",
+                        failure_details,
+                        metrics,
+                        refinement_attempts,
                     )
                     spec = self._apply_updates(spec, updates, code)
                     changes = updates.get("changes_made", "anomaly fix")
                     refinement_attempts.append(changes)
-                    emit("coding", {"sub_phase": "refined", "refinement_round": round_num, "changes_made": changes})
+                    emit(
+                        "coding",
+                        {
+                            "sub_phase": "refined",
+                            "refinement_round": round_num,
+                            "changes_made": changes,
+                        },
+                    )
                     continue
                 else:
-                    logger.warning("Max code refinement rounds reached on evaluation for %s", spec.strategy_id)
+                    logger.warning(
+                        "Max code refinement rounds reached on evaluation for %s", spec.strategy_id
+                    )
                     execution_succeeded = True  # anomalous but code is correct
                     break
 
@@ -285,10 +410,13 @@ class StrategyLabOrchestrator:
         if execution_succeeded and trades:
             emit("analyzing", {"sub_phase": "draft"})
             try:
+
                 def _on_analysis_sub(sub: str) -> None:
                     emit("analyzing", {"sub_phase": sub})
 
-                narrative = self.analysis_agent.run(spec, metrics, trades, rationale, on_sub_phase=_on_analysis_sub)
+                narrative = self.analysis_agent.run(
+                    spec, metrics, trades, rationale, on_sub_phase=_on_analysis_sub
+                )
                 is_w = metrics.annualized_return_pct > WINNING_THRESHOLD
                 emit("analyzing", {"sub_phase": "completed", "is_winning": is_w})
             except Exception:
@@ -342,12 +470,15 @@ class StrategyLabOrchestrator:
         # Update convergence tracker
         self.convergence_tracker.record(spec, all_gate_results)
 
-        emit("complete", {
-            "record_id": lab_record_id,
-            "is_winning": is_winning,
-            "metrics": metrics.model_dump(),
-            "refinement_rounds": len(refinement_attempts),
-        })
+        emit(
+            "complete",
+            {
+                "record_id": lab_record_id,
+                "is_winning": is_winning,
+                "metrics": metrics.model_dump(),
+                "refinement_rounds": len(refinement_attempts),
+            },
+        )
 
         return record
 

--- a/backend/agents/investment_team/strategy_lab/prompts/ideation_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/ideation_system.md
@@ -43,8 +43,8 @@ def run_strategy(data: dict, config: dict) -> list:
               Sorted by date ascending. 'date' column is a string (YYYY-MM-DD).
         config: dict with keys:
               'initial_capital': float (e.g., 100000.0)
-              'transaction_cost_bps': float (e.g., 5.0)
-              'slippage_bps': float (e.g., 2.0)
+              'transaction_cost_bps': float (e.g., 26.0 for crypto)
+              'slippage_bps': float (e.g., 10.0 for crypto)
 
     Returns:
         list of trade dicts, each with keys:
@@ -58,6 +58,8 @@ def run_strategy(data: dict, config: dict) -> list:
     """
     trades = []
     capital = config['initial_capital']
+    cost_mult = config['transaction_cost_bps'] / 10_000
+    slip_mult = config['slippage_bps'] / 10_000
 
     for symbol, df in data.items():
         df = df.copy().reset_index(drop=True)
@@ -73,28 +75,38 @@ def run_strategy(data: dict, config: dict) -> list:
         if len(df) < 2:
             continue
 
+        # ── CONVERT TO ROW LIST (prevents look-ahead bias) ───
+        rows = df.to_dict('records')
+        del df  # prevent any forward-looking DataFrame access
+
         # ── GENERATE SIGNALS & EXECUTE TRADES (fill in) ──────
         position = None  # None, 'long', or 'short'
         entry_price = 0.0
         entry_date = ''
         shares = 0.0
 
-        for i in range(len(df)):
-            row = df.iloc[i]
+        for i, row in enumerate(rows):
+            prev_row = rows[i - 1] if i > 0 else None
             price = row['close']
             date = row['date']
 
             if position is None:
                 # <YOUR ENTRY LOGIC HERE>
                 # To enter long:
-                #   position = 'long'
-                #   entry_price = price
-                #   entry_date = date
+                #   position_pct = 0.06  # 6% of capital
                 #   shares = (capital * position_pct) / price
+                #   entry_cost = shares * price * (1 + slip_mult + cost_mult)
+                #   if entry_cost <= capital:
+                #       capital -= entry_cost
+                #       position = 'long'
+                #       entry_price = price
+                #       entry_date = date
                 pass
             else:
                 # <YOUR EXIT LOGIC HERE>
                 # To exit:
+                #   exit_proceeds = shares * price * (1 - slip_mult - cost_mult)
+                #   capital += exit_proceeds
                 #   trades.append({
                 #       'symbol': symbol, 'side': position,
                 #       'entry_date': entry_date, 'entry_price': entry_price,
@@ -106,20 +118,23 @@ def run_strategy(data: dict, config: dict) -> list:
 
         # ── FORCE-CLOSE at end of data ────────────────────────
         if position is not None:
+            last = rows[-1]
+            exit_proceeds = shares * last['close'] * (1 - slip_mult - cost_mult)
+            capital += exit_proceeds
             trades.append({
                 'symbol': symbol,
                 'side': position,
                 'entry_date': entry_date,
                 'entry_price': entry_price,
-                'exit_date': df.iloc[-1]['date'],
-                'exit_price': df.iloc[-1]['close'],
+                'exit_date': last['date'],
+                'exit_price': last['close'],
                 'shares': shares,
             })
 
     return trades
 ```
 
-Replace the `<YOUR ... HERE>` sections with your strategy logic. Do NOT modify the boilerplate structure (imports, function signature, data preparation, force-close block, return statement).
+Replace the `<YOUR ... HERE>` sections with your strategy logic. Do NOT modify the boilerplate structure (imports, function signature, data preparation, row conversion, force-close block, return statement).
 
 ## Available indicators
 
@@ -133,11 +148,11 @@ from indicators import sma, ema, rsi, macd, bollinger_bands, atr, adx, stochasti
 |---|---|---|
 | `sma` | `sma(series, period)` | Series |
 | `ema` | `ema(series, period)` | Series |
-| `rsi` | `rsi(series, period=14)` | Series (0–100) |
+| `rsi` | `rsi(series, period=14)` | Series (0-100) |
 | `macd` | `macd(series, fast=12, slow=26, signal=9)` | (macd_line, signal_line, histogram) |
 | `bollinger_bands` | `bollinger_bands(series, period=20, num_std=2.0)` | (upper, middle, lower) |
 | `atr` | `atr(high, low, close, period=14)` | Series |
-| `adx` | `adx(high, low, close, period=14)` | Series (0–100) |
+| `adx` | `adx(high, low, close, period=14)` | Series (0-100) |
 | `stochastic` | `stochastic(high, low, close, k_period=14, d_period=3)` | (pct_k, pct_d) |
 | `vwap` | `vwap(high, low, close, volume)` | Series |
 
@@ -146,14 +161,32 @@ from indicators import sma, ema, rsi, macd, bollinger_bands, atr, adx, stochasti
 ONLY these libraries are available:
 - `pandas` (as pd)
 - `numpy` (as np)
-- `indicators` (pre-built technical indicators — see table above)
+- `indicators` (pre-built technical indicators - see table above)
 - `math`, `datetime`, `collections`, `itertools`, `functools`, `re`, `copy`, `statistics`
 
 Do NOT import: os, sys, subprocess, socket, http, requests, ta, or any filesystem/network module.
 Do NOT use: exec(), eval(), open(), or any dynamic code execution.
 
+## CRITICAL: No look-ahead access
+
+Inside the trading loop, you ONLY have access to:
+- `row`: dict with the current bar's OHLCV data and all pre-computed indicator values
+- `prev_row`: dict with the previous bar's data (None on first iteration)
+- `rows[:i]`: historical rows up to (not including) the current bar
+
+The full DataFrame (`df`) is deleted before the loop starts. Do NOT reference `df` inside the loop.
+For crossover detection, compare `row['indicator']` vs `prev_row['indicator']`.
+
+## Capital and cost management
+
+- Deduct approximate entry cost from `capital` when opening a position:
+  `entry_cost = shares * price * (1 + slip_mult + cost_mult)`
+- Add approximate exit proceeds to `capital` when closing:
+  `exit_proceeds = shares * price * (1 - slip_mult - cost_mult)`
+- Record RAW market prices in trade dicts (entry_price, exit_price) - the harness applies precise cost adjustments post-hoc for metrics
+- Always check `entry_cost <= capital` before entering a position
+
 ## Code quality requirements
 
-- Use `config['initial_capital']` for position sizing — do not hardcode capital amounts
+- Use `config['initial_capital']` for position sizing - do not hardcode capital amounts
 - Keep code under 200 lines; prefer clarity over cleverness
-- Do NOT apply slippage or transaction costs — the harness handles that post-hoc

--- a/backend/agents/investment_team/strategy_lab/prompts/refinement_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/refinement_system.md
@@ -36,7 +36,21 @@ Your task: fix and refine a generated trading strategy's Python code based on er
 - Replace with allowed alternatives from: pandas, numpy, indicators, math, datetime
 - The `indicators` module provides: sma, ema, rsi, macd, bollinger_bands, atr, adx, stochastic, vwap
 - Do NOT use the `ta` library — use `from indicators import ...` instead
-- Preserve the boilerplate structure (data preparation, warmup, force-close pattern)
+- Preserve the boilerplate structure (data preparation, warmup, row conversion, force-close pattern)
+
+### Quality gate: look-ahead bias detected
+- The code accesses future data (e.g., `df.iloc[i+1]`, `.shift(-1)`, or using `df` inside the loop)
+- Fix: use only `row` (current bar) and `prev_row` (previous bar) for decisions
+- All indicator values are pre-computed as DataFrame columns before conversion to row dicts
+- For crossover detection, compare `row['indicator']` vs `prev_row['indicator']`
+- NEVER access the raw DataFrame inside the trading loop — it has been deleted via `del df`
+
+### Phantom capital / over-allocation
+- If the strategy enters more capital than available, `capital` is not being updated correctly
+- On entry: deduct `shares * price * (1 + slip_mult + cost_mult)` from capital
+- On exit: add `shares * price * (1 - slip_mult - cost_mult)` to capital
+- Always guard entries with `if entry_cost <= capital`
+- Use `cost_mult = config['transaction_cost_bps'] / 10_000` and `slip_mult = config['slippage_bps'] / 10_000`
 
 ## Generated code contract
 

--- a/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
@@ -22,53 +22,101 @@ class BacktestAnomalyDetector:
 
         # 1. Zero trades
         if not trades:
-            results.append(QualityGateResult(
-                gate_name=GATE, passed=False, severity="critical",
-                details="Backtest produced zero trades — strategy code never entered a position.",
-            ))
+            results.append(
+                QualityGateResult(
+                    gate_name=GATE,
+                    passed=False,
+                    severity="critical",
+                    details="Backtest produced zero trades — strategy code never entered a position.",
+                )
+            )
             return results
 
         # 2. Too few trades
         if len(trades) < 5:
-            results.append(QualityGateResult(
-                gate_name=GATE, passed=False, severity="critical",
-                details=f"Only {len(trades)} trades — statistically meaningless for a multi-year backtest.",
-            ))
+            results.append(
+                QualityGateResult(
+                    gate_name=GATE,
+                    passed=False,
+                    severity="critical",
+                    details=f"Only {len(trades)} trades — statistically meaningless for a multi-year backtest.",
+                )
+            )
 
         # 3. Annualized return > 200%
         if metrics.annualized_return_pct > 200:
-            results.append(QualityGateResult(
-                gate_name=GATE, passed=False, severity="critical",
-                details=f"Annualized return {metrics.annualized_return_pct:.1f}% is suspiciously high (>200%) — likely a data or logic bug.",
-            ))
+            results.append(
+                QualityGateResult(
+                    gate_name=GATE,
+                    passed=False,
+                    severity="critical",
+                    details=f"Annualized return {metrics.annualized_return_pct:.1f}% is suspiciously high (>200%) — likely a data or logic bug.",
+                )
+            )
 
         # 4. Win rate thresholds
         if metrics.win_rate_pct > 95:
-            results.append(QualityGateResult(
-                gate_name=GATE, passed=False, severity="critical",
-                details=f"Win rate {metrics.win_rate_pct:.1f}% exceeds 95% — almost certainly overfitting or lookahead bias.",
-            ))
+            results.append(
+                QualityGateResult(
+                    gate_name=GATE,
+                    passed=False,
+                    severity="critical",
+                    details=f"Win rate {metrics.win_rate_pct:.1f}% exceeds 95% — almost certainly overfitting or lookahead bias.",
+                )
+            )
         elif metrics.win_rate_pct > 90:
-            results.append(QualityGateResult(
-                gate_name=GATE, passed=False, severity="warning",
-                details=f"Win rate {metrics.win_rate_pct:.1f}% exceeds 90% — review for possible overfitting.",
-            ))
+            results.append(
+                QualityGateResult(
+                    gate_name=GATE,
+                    passed=False,
+                    severity="warning",
+                    details=f"Win rate {metrics.win_rate_pct:.1f}% exceeds 90% — review for possible overfitting.",
+                )
+            )
 
         # 5. Extreme profit factor
         if metrics.profit_factor > 10:
-            results.append(QualityGateResult(
-                gate_name=GATE, passed=False, severity="critical",
-                details=f"Profit factor {metrics.profit_factor:.1f} exceeds 10 — likely data snooping or bug.",
-            ))
+            results.append(
+                QualityGateResult(
+                    gate_name=GATE,
+                    passed=False,
+                    severity="critical",
+                    details=f"Profit factor {metrics.profit_factor:.1f} exceeds 10 — likely data snooping or bug.",
+                )
+            )
+
+        # 5b. Sharpe ratio thresholds
+        if metrics.sharpe_ratio > 5.0:
+            results.append(
+                QualityGateResult(
+                    gate_name=GATE,
+                    passed=False,
+                    severity="critical",
+                    details=f"Sharpe ratio {metrics.sharpe_ratio:.2f} exceeds 5.0 — almost certainly indicates look-ahead bias or a calculation artifact.",
+                )
+            )
+        elif metrics.sharpe_ratio > 3.0:
+            results.append(
+                QualityGateResult(
+                    gate_name=GATE,
+                    passed=False,
+                    severity="warning",
+                    details=f"Sharpe ratio {metrics.sharpe_ratio:.2f} exceeds 3.0 — review for overfitting or data snooping.",
+                )
+            )
 
         # 6. Average hold time < 1 day (possible lookahead)
         if trades:
             avg_hold = sum(t.hold_days for t in trades) / len(trades)
             if avg_hold < 1:
-                results.append(QualityGateResult(
-                    gate_name=GATE, passed=False, severity="warning",
-                    details=f"Average hold time {avg_hold:.1f} days — sub-day holds may indicate lookahead bias in daily data.",
-                ))
+                results.append(
+                    QualityGateResult(
+                        gate_name=GATE,
+                        passed=False,
+                        severity="warning",
+                        details=f"Average hold time {avg_hold:.1f} days — sub-day holds may indicate lookahead bias in daily data.",
+                    )
+                )
 
         # 7. Single trade concentration
         if trades:
@@ -76,25 +124,55 @@ class BacktestAnomalyDetector:
             if total_pnl > 0:
                 max_single = max(abs(t.net_pnl) for t in trades)
                 if max_single / total_pnl > 0.5:
-                    results.append(QualityGateResult(
-                        gate_name=GATE, passed=False, severity="warning",
-                        details=f"Largest single trade is {max_single / total_pnl:.0%} of total absolute P&L — high concentration risk.",
-                    ))
+                    results.append(
+                        QualityGateResult(
+                            gate_name=GATE,
+                            passed=False,
+                            severity="warning",
+                            details=f"Largest single trade is {max_single / total_pnl:.0%} of total absolute P&L — high concentration risk.",
+                        )
+                    )
 
         # 8. All trades identical direction and symbol
         if len(trades) > 1:
             sides = {t.side for t in trades}
             symbols = {t.symbol for t in trades}
             if len(sides) == 1 and len(symbols) == 1:
-                results.append(QualityGateResult(
-                    gate_name=GATE, passed=False, severity="warning",
-                    details=f"All {len(trades)} trades are {next(iter(sides))} on {next(iter(symbols))} — no diversification.",
-                ))
+                results.append(
+                    QualityGateResult(
+                        gate_name=GATE,
+                        passed=False,
+                        severity="warning",
+                        details=f"All {len(trades)} trades are {next(iter(sides))} on {next(iter(symbols))} — no diversification.",
+                    )
+                )
+
+        # 9. Cost sensitivity — edge consumed by transaction costs
+        if trades:
+            gross_wins = sum(t.gross_pnl for t in trades if t.gross_pnl > 0)
+            gross_losses = abs(sum(t.gross_pnl for t in trades if t.gross_pnl <= 0))
+            gross_pf = gross_wins / gross_losses if gross_losses > 0 else 0.0
+            if gross_pf > 1.0 and metrics.profit_factor < 1.0:
+                results.append(
+                    QualityGateResult(
+                        gate_name=GATE,
+                        passed=False,
+                        severity="warning",
+                        details=(
+                            f"Profit factor drops from {gross_pf:.2f} (gross) to "
+                            f"{metrics.profit_factor:.2f} (net) — strategy edge is consumed by transaction costs."
+                        ),
+                    )
+                )
 
         if not results:
-            results.append(QualityGateResult(
-                gate_name=GATE, passed=True, severity="info",
-                details="Backtest results passed all anomaly checks.",
-            ))
+            results.append(
+                QualityGateResult(
+                    gate_name=GATE,
+                    passed=True,
+                    severity="info",
+                    details="Backtest results passed all anomaly checks.",
+                )
+            )
 
         return results

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -10,20 +10,60 @@ from .models import QualityGateResult
 
 GATE = "code_safety"
 
-BANNED_IMPORTS = frozenset({
-    "os", "sys", "subprocess", "socket", "http", "urllib", "requests",
-    "shutil", "pathlib", "importlib", "ctypes", "pickle", "shelve",
-    "sqlite3", "multiprocessing", "threading", "signal", "io",
-    "tempfile", "glob", "webbrowser", "ftplib", "smtplib", "telnetlib",
-    "xmlrpc", "asyncio",
-})
+BANNED_IMPORTS = frozenset(
+    {
+        "os",
+        "sys",
+        "subprocess",
+        "socket",
+        "http",
+        "urllib",
+        "requests",
+        "shutil",
+        "pathlib",
+        "importlib",
+        "ctypes",
+        "pickle",
+        "shelve",
+        "sqlite3",
+        "multiprocessing",
+        "threading",
+        "signal",
+        "io",
+        "tempfile",
+        "glob",
+        "webbrowser",
+        "ftplib",
+        "smtplib",
+        "telnetlib",
+        "xmlrpc",
+        "asyncio",
+    }
+)
 
-ALLOWED_IMPORTS = frozenset({
-    "pandas", "numpy", "indicators", "math", "datetime", "collections",
-    "itertools", "functools", "typing", "dataclasses", "enum", "abc",
-    "re", "copy", "statistics", "decimal", "fractions", "operator",
-    "json",
-})
+ALLOWED_IMPORTS = frozenset(
+    {
+        "pandas",
+        "numpy",
+        "indicators",
+        "math",
+        "datetime",
+        "collections",
+        "itertools",
+        "functools",
+        "typing",
+        "dataclasses",
+        "enum",
+        "abc",
+        "re",
+        "copy",
+        "statistics",
+        "decimal",
+        "fractions",
+        "operator",
+        "json",
+    }
+)
 
 # Regex patterns for dangerous calls that AST analysis might miss in edge cases.
 _BANNED_CALL_PATTERNS = [
@@ -33,6 +73,18 @@ _BANNED_CALL_PATTERNS = [
     re.compile(r"\b__import__\s*\("),
     re.compile(r"\bglobals\s*\("),
     re.compile(r"\bbreakpoint\s*\("),
+]
+
+# Look-ahead bias patterns — accessing future data in the trading loop.
+_LOOKAHEAD_PATTERNS = [
+    (
+        re.compile(r"\.shift\s*\(\s*-"),
+        "shift(-N) accesses future data — use only positive shift values",
+    ),
+    (
+        re.compile(r"rows\s*\[\s*i\s*\+"),
+        "rows[i+N] accesses future bars — use only row and prev_row",
+    ),
 ]
 
 
@@ -46,10 +98,14 @@ class CodeSafetyChecker:
         try:
             tree = ast.parse(code)
         except SyntaxError as e:
-            results.append(QualityGateResult(
-                gate_name=GATE, passed=False, severity="critical",
-                details=f"Code has a syntax error: {e}",
-            ))
+            results.append(
+                QualityGateResult(
+                    gate_name=GATE,
+                    passed=False,
+                    severity="critical",
+                    details=f"Code has a syntax error: {e}",
+                )
+            )
             return results
 
         # 2. Check run_strategy function exists with correct signature
@@ -59,17 +115,25 @@ class CodeSafetyChecker:
                 run_strategy_found = True
                 param_count = len(node.args.args)
                 if param_count != 2:
-                    results.append(QualityGateResult(
-                        gate_name=GATE, passed=False, severity="critical",
-                        details=f"run_strategy() must accept exactly 2 parameters (data, config), found {param_count}.",
-                    ))
+                    results.append(
+                        QualityGateResult(
+                            gate_name=GATE,
+                            passed=False,
+                            severity="critical",
+                            details=f"run_strategy() must accept exactly 2 parameters (data, config), found {param_count}.",
+                        )
+                    )
                 break
 
         if not run_strategy_found:
-            results.append(QualityGateResult(
-                gate_name=GATE, passed=False, severity="critical",
-                details="Code does not define a run_strategy() function.",
-            ))
+            results.append(
+                QualityGateResult(
+                    gate_name=GATE,
+                    passed=False,
+                    severity="critical",
+                    details="Code does not define a run_strategy() function.",
+                )
+            )
 
         # 3. Walk AST for banned imports
         for node in ast.walk(tree):
@@ -77,72 +141,141 @@ class CodeSafetyChecker:
                 for alias in node.names:
                     top_module = alias.name.split(".")[0]
                     if top_module in BANNED_IMPORTS:
-                        results.append(QualityGateResult(
-                            gate_name=GATE, passed=False, severity="critical",
-                            details=f"Banned import: '{alias.name}' — network/filesystem/system access not allowed.",
-                        ))
+                        results.append(
+                            QualityGateResult(
+                                gate_name=GATE,
+                                passed=False,
+                                severity="critical",
+                                details=f"Banned import: '{alias.name}' — network/filesystem/system access not allowed.",
+                            )
+                        )
                     elif top_module not in ALLOWED_IMPORTS:
-                        results.append(QualityGateResult(
-                            gate_name=GATE, passed=False, severity="warning",
-                            details=f"Non-allowlisted import: '{alias.name}' — may not be available in sandbox.",
-                        ))
+                        results.append(
+                            QualityGateResult(
+                                gate_name=GATE,
+                                passed=False,
+                                severity="warning",
+                                details=f"Non-allowlisted import: '{alias.name}' — may not be available in sandbox.",
+                            )
+                        )
 
             elif isinstance(node, ast.ImportFrom):
                 if node.module:
                     top_module = node.module.split(".")[0]
                     if top_module in BANNED_IMPORTS:
-                        results.append(QualityGateResult(
-                            gate_name=GATE, passed=False, severity="critical",
-                            details=f"Banned import: 'from {node.module}' — network/filesystem/system access not allowed.",
-                        ))
+                        results.append(
+                            QualityGateResult(
+                                gate_name=GATE,
+                                passed=False,
+                                severity="critical",
+                                details=f"Banned import: 'from {node.module}' — network/filesystem/system access not allowed.",
+                            )
+                        )
                     elif top_module not in ALLOWED_IMPORTS:
-                        results.append(QualityGateResult(
-                            gate_name=GATE, passed=False, severity="warning",
-                            details=f"Non-allowlisted import: 'from {node.module}' — may not be available in sandbox.",
-                        ))
+                        results.append(
+                            QualityGateResult(
+                                gate_name=GATE,
+                                passed=False,
+                                severity="warning",
+                                details=f"Non-allowlisted import: 'from {node.module}' — may not be available in sandbox.",
+                            )
+                        )
 
         # 4. Walk AST for banned function calls
         for node in ast.walk(tree):
             if isinstance(node, ast.Call):
                 func_name = _get_call_name(node)
                 if func_name in ("exec", "eval", "compile", "__import__", "globals", "breakpoint"):
-                    results.append(QualityGateResult(
-                        gate_name=GATE, passed=False, severity="critical",
-                        details=f"Banned function call: '{func_name}()' — dynamic code execution not allowed.",
-                    ))
+                    results.append(
+                        QualityGateResult(
+                            gate_name=GATE,
+                            passed=False,
+                            severity="critical",
+                            details=f"Banned function call: '{func_name}()' — dynamic code execution not allowed.",
+                        )
+                    )
                 if func_name == "open":
-                    results.append(QualityGateResult(
-                        gate_name=GATE, passed=False, severity="critical",
-                        details="Banned function call: 'open()' — file I/O not allowed in strategy code.",
-                    ))
+                    results.append(
+                        QualityGateResult(
+                            gate_name=GATE,
+                            passed=False,
+                            severity="critical",
+                            details="Banned function call: 'open()' — file I/O not allowed in strategy code.",
+                        )
+                    )
                 if func_name in ("setattr", "delattr"):
-                    results.append(QualityGateResult(
-                        gate_name=GATE, passed=False, severity="critical",
-                        details=f"Banned function call: '{func_name}()' — attribute manipulation not allowed.",
-                    ))
+                    results.append(
+                        QualityGateResult(
+                            gate_name=GATE,
+                            passed=False,
+                            severity="critical",
+                            details=f"Banned function call: '{func_name}()' — attribute manipulation not allowed.",
+                        )
+                    )
 
         # 5. Regex fallback for patterns AST might miss
         for pattern in _BANNED_CALL_PATTERNS:
             if pattern.search(code):
                 match_text = pattern.pattern.replace(r"\b", "").replace(r"\s*\(", "(")
-                results.append(QualityGateResult(
-                    gate_name=GATE, passed=False, severity="critical",
-                    details=f"Regex detected banned pattern: '{match_text}'.",
-                ))
+                results.append(
+                    QualityGateResult(
+                        gate_name=GATE,
+                        passed=False,
+                        severity="critical",
+                        details=f"Regex detected banned pattern: '{match_text}'.",
+                    )
+                )
 
-        # 6. Code length
+        # 6. Look-ahead bias detection
+        for pattern, reason in _LOOKAHEAD_PATTERNS:
+            if pattern.search(code):
+                results.append(
+                    QualityGateResult(
+                        gate_name=GATE,
+                        passed=False,
+                        severity="critical",
+                        details=f"Look-ahead bias: {reason}",
+                    )
+                )
+
+        # 6b. Detect DataFrame access after del df (loop body should not use df)
+        if "del df" in code:
+            # Find code after 'del df' and check for df usage
+            del_pos = code.index("del df")
+            post_del = code[del_pos:]
+            # Skip the 'del df' line itself, then look for df[, df., df.iloc, etc.
+            df_after_del = re.search(r"\bdf\s*[\[.]", post_del[len("del df") :])
+            if df_after_del:
+                results.append(
+                    QualityGateResult(
+                        gate_name=GATE,
+                        passed=False,
+                        severity="critical",
+                        details="Look-ahead bias: code references 'df' after 'del df' — use only row and prev_row in the trading loop.",
+                    )
+                )
+
+        # 7. Code length
         line_count = len(code.splitlines())
         if line_count > 1000:
-            results.append(QualityGateResult(
-                gate_name=GATE, passed=False, severity="warning",
-                details=f"Code is {line_count} lines — consider simplifying (limit: 1000).",
-            ))
+            results.append(
+                QualityGateResult(
+                    gate_name=GATE,
+                    passed=False,
+                    severity="warning",
+                    details=f"Code is {line_count} lines — consider simplifying (limit: 1000).",
+                )
+            )
 
         if not results:
-            results.append(QualityGateResult(
-                gate_name=GATE, passed=True, severity="info",
-                details="Code passed all safety checks.",
-            ))
+            results.append(
+                QualityGateResult(
+                    gate_name=GATE,
+                    passed=True,
+                    severity="info",
+                    details="Code passed all safety checks.",
+                )
+            )
 
         return results
 

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -226,9 +226,11 @@ class CodeSafetyChecker:
                     )
                 )
 
-        # 6. Look-ahead bias detection
+        # 6. Look-ahead bias detection (run against executable code only,
+        #    excluding comments and string literals to avoid false positives)
+        executable = _strip_comments_and_strings(code)
         for pattern, reason in _LOOKAHEAD_PATTERNS:
-            if pattern.search(code):
+            if pattern.search(executable):
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
@@ -239,11 +241,9 @@ class CodeSafetyChecker:
                 )
 
         # 6b. Detect DataFrame access after del df (loop body should not use df)
-        if "del df" in code:
-            # Find code after 'del df' and check for df usage
-            del_pos = code.index("del df")
-            post_del = code[del_pos:]
-            # Skip the 'del df' line itself, then look for df[, df., df.iloc, etc.
+        if "del df" in executable:
+            del_pos = executable.index("del df")
+            post_del = executable[del_pos:]
             df_after_del = re.search(r"\bdf\s*[\[.]", post_del[len("del df") :])
             if df_after_del:
                 results.append(
@@ -287,3 +287,21 @@ def _get_call_name(node: ast.Call) -> str:
     if isinstance(node.func, ast.Attribute):
         return node.func.attr
     return ""
+
+
+# Regex that matches Python comments and string literals (single/double,
+# triple-quoted, and raw strings).  Used to produce a "code-only" view
+# for look-ahead bias scanning so that examples in comments or docstrings
+# don't trigger false-positive critical failures.
+_COMMENTS_AND_STRINGS = re.compile(
+    r"#[^\n]*"  # line comments
+    r'|"""[\s\S]*?"""'  # triple-double-quoted strings
+    r"|'''[\s\S]*?'''"  # triple-single-quoted strings
+    r'|"(?:\\.|[^"\\])*"'  # double-quoted strings
+    r"|'(?:\\.|[^'\\])*'",  # single-quoted strings
+)
+
+
+def _strip_comments_and_strings(code: str) -> str:
+    """Replace comments and string literals with whitespace-equivalent placeholders."""
+    return _COMMENTS_AND_STRINGS.sub(lambda m: " " * len(m.group()), code)


### PR DESCRIPTION
## Changes

### Look-Ahead Bias Prevention
- Convert DataFrame to row list in trading loop to prevent forward-looking access
- Delete DataFrame reference before loop starts
- Update strategy template to use `row` and `prev_row` for all decisions
- Add detection patterns in code safety checker for look-ahead violations
- Document that only current and previous bar data are accessible in loop

### Asset-Class Fee Defaults
- Add `ASSET_CLASS_FEE_DEFAULTS` mapping with appropriate fees for each asset class
- Crypto now uses Kraken taker fees (26 bps) instead of generic 5 bps
- Auto-detect fees from asset class when not explicitly provided in paper trading
- Make transaction_cost_bps and slippage_bps optional in API requests

### Documentation & Validation Improvements
- Clarify capital management in template (entry_cost/exit_proceeds calculations)
- Update prompts to emphasize cost deduction from capital before entering positions
- Add Sharpe ratio thresholds to anomaly detection (critical >5.0, warning >3.0)
- Add cost sensitivity check: detect when edge is consumed by transaction costs
- Enhance code safety checker for look-ahead patterns

### Code Quality
- Format emit() calls consistently across orchestrator
- Improve QualityGateResult construction formatting
- Expand ALLOWED_IMPORTS and BANNED_IMPORTS readability