### PR TITLE
docs: rebrand top-level README with marketing hero and roster tour

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ And the roster keeps growing. The team you need next is probably already being w
 
 ---
 
+> [!WARNING]
+> **Khala is experimental.** The agents in this project are active research, not a production-ready product. Outputs can be incomplete, inconsistent, or just plain wrong; APIs change without notice; a team that shipped a feature yesterday may hit a wall today. Run it in isolated environments, keep humans in the loop for anything that matters, and treat every generated artifact (code, audits, trades, compliance reports) as a draft that needs review before you rely on it. If you're looking for a hardened platform with SLAs, this isn't it — yet. If you're looking to build, tinker, and help push the frontier of multi-agent systems, welcome aboard.
+
+---
+
 ## Meet the current roster
 
 Khala groups its teams into four *cells* — failure-isolated neighborhoods that share infrastructure and deploy together. This list grows every release; the authoritative source is always [`backend/unified_api/config.py`](backend/unified_api/config.py).

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Khala groups its teams into four *cells* — failure-isolated neighborhoods that
 | **Nutrition & Meal Planning** | `/api/nutrition-meal-planning` | Personalized meal plans that learn from your feedback |
 | **Road Trip Planning** | `/api/road-trip-planning` | Profiling, route optimization, activity recommendations, logistics |
 
-> …and more on the way. Run `GET /api/teams` on a live instance for the authoritative roster.
+> …and more on the way. Run `GET /teams` on a live instance for the authoritative roster.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,124 +1,235 @@
-# Khala
+<p align="center">
+  <img src="docs/assets/khala-banner.png" alt="Khala — Many minds. One objective. Yours." width="100%"/>
+</p>
 
-Khala is a monorepo for multi-agent "team" systems. Each team exposes a FastAPI service and the platform also provides a Unified API plus an Angular UI.
+<h1 align="center">Khala</h1>
 
-(Named after the Protoss unifying religion from StarCraft — a psionic link joining many minds into one.)
+<p align="center">
+  <em>Many minds. One objective… yours.</em><br/>
+  <sub>A growing collective of specialist AI agent teams. One gateway. Your mission.</sub>
+</p>
 
-## Repository layout
+<p align="center">
+  <img alt="Python" src="https://img.shields.io/badge/python-3.10%2B-3776AB?logo=python&logoColor=white">
+  <img alt="Node" src="https://img.shields.io/badge/node-22-339933?logo=node.js&logoColor=white">
+  <img alt="Angular" src="https://img.shields.io/badge/angular-19-DD0031?logo=angular&logoColor=white">
+  <img alt="FastAPI" src="https://img.shields.io/badge/fastapi-unified%20gateway-009688?logo=fastapi&logoColor=white">
+  <img alt="Temporal" src="https://img.shields.io/badge/temporal-durable-000?logo=temporal&logoColor=white">
+  <img alt="Docker" src="https://img.shields.io/badge/docker-compose-2496ED?logo=docker&logoColor=white">
+  <img alt="License" src="https://img.shields.io/badge/license-see%20LICENSE-blue">
+</p>
 
-```text
-khala/
-├── backend/
-│   ├── agents/                 # Team implementations + team-specific APIs (20 enabled teams)
-│   ├── unified_api/            # Unified FastAPI app mounting all teams
-│   ├── run_unified_api.py      # Unified API launcher
-│   ├── Makefile                # Build, lint, test, run targets
-│   └── pyproject.toml          # Ruff + pytest config
-├── user-interface/             # Angular 19 frontend
-└── docker/                     # Full-stack Docker Compose setup
-```
+---
 
-## Quick start
+## You don't need a team. You need a Khala.
 
-### 1) Backend dependencies
+Khala is a living collective of specialist AI agents that works like the best company you've ever seen — except it boots in sixty seconds, never sits in meetings, and never leaves Slack unread.
 
-```bash
-cd backend
-make install          # Create venv, install deps
-# Or manually:
-pip install -r requirements.txt
-```
+Point it at a spec and a full software engineering org spins up to design, code, review, secure, and ship the feature end-to-end. Point it at a market and researchers interview users, surface demand, and hand a PRD to the planners. Point it at a launch and blog writers draft, copy-editors polish, and social specialists fan the campaign across every platform. Sales agents prospect, qualify, and close. Compliance agents drag you toward SOC2. Accessibility agents catch every WCAG 2.2 violation before your users do. Financial agents write your IPS and backtest your strategy. A recursive meta-agent called **Deepthought** spawns its own sub-agents when the problem doesn't fit anywhere else.
 
-### 2) Run the Unified API (recommended)
+They share a psionic link — durable Temporal workflows, a Postgres memory, a pluggable LLM brain — so context doesn't evaporate between steps and crashes don't cost you work. They run in parallel. They hand artifacts to each other. They don't sleep.
 
-```bash
-cd backend
-python run_unified_api.py
-```
+And the roster keeps growing. The team you need next is probably already being written — or you can **provision your own** by describing it in plain English to the Agentic Team Provisioning team. Agents all the way down.
 
-Unified API docs: <http://localhost:8080/docs>
+> **Many minds. One objective. Yours.**
 
-### 3) Run the UI
+<sub>*(Named after the Protoss unifying religion from StarCraft — a psionic link joining many minds into one.)*</sub>
 
-```bash
-cd user-interface
-npm ci
-npm start
-```
+---
 
-UI: <http://localhost:4200>
+## Why Khala?
 
-## Unified API team routes
+- **🌩️ One gateway, a whole roster** — every agent mounts under `/api/*`. One auth. One UI. One deploy. New teams join every release.
+- **⚡ Durable by default** — set `TEMPORAL_ADDRESS` and your workflows laugh at restarts, crashes, and redeploys.
+- **🧠 Bring your own brain** — Ollama Cloud, local Ollama, or Claude. Swap per-agent via env vars.
+- **🏗️ Real engineering, not demos** — 4-phase SDLC, parallel worker queues, planning cache, crash recovery, 8+ quality gates. This isn't a toy.
+- **🧬 Built to expand** — add a new team in one PR. Agentic Team Provisioning can even design the roster for you.
+- **🚀 Ship in 60 seconds** — `docker compose up` and the whole stack (Postgres, Temporal, Ollama, API, UI) is live.
 
-The Unified API mounts teams under `/api/*` prefixes. Current configured routes (20 enabled teams):
+---
 
-- `/api/blogging`
-- `/api/software-engineering`
-- `/api/personal-assistant`
-- `/api/market-research`
-- `/api/soc2-compliance`
-- `/api/social-marketing`
-- `/api/branding`
-- `/api/agent-provisioning`
-- `/api/accessibility-audit`
-- `/api/ai-systems`
-- `/api/investment` (also serves the Investment Strategy Lab sub-team — disabled as a separate mount)
-- `/api/nutrition-meal-planning`
-- `/api/planning-v3`
-- `/api/coding-team` (logical sub-team of software engineering)
-- `/api/sales`
-- `/api/road-trip-planning`
-- `/api/agentic-team-provisioning`
-- `/api/startup-advisor`
-- `/api/user-agent-founder`
-- `/api/deepthought`
+## Meet the current roster
 
-## Platform notes (cross-cutting)
+Khala groups its teams into four *cells* — failure-isolated neighborhoods that share infrastructure and deploy together. This list grows every release; the authoritative source is always [`backend/unified_api/config.py`](backend/unified_api/config.py).
 
-- **Software Engineering sub-teams (UI):** Under **Development**, the UI nests **Planning** (`/software-engineering/planning-v3`) and **Coding Team** (`/software-engineering/coding-team`). The **Coding Team** is also a **logical sub-team** in Unified API config (`parent_team_key`: software engineering); HTTP API remains `/api/coding-team`.
-- **Investment (two tracks):** One API prefix (`/api/investment`) covers **Advisor / IPS** (user profile) and **Strategy Lab** (ideation and backtests without a profile). UI routes: `/investment`, `/investment/advisor`, `/investment/strategy-lab`. See `backend/agents/investment_team/README.md`.
-- **Agentic Team Provisioning:** Conversational design of rosters and processes; roster validation and optional Agent Provisioning bridge. See `backend/agents/agentic_team_provisioning/README.md` and `AGENTIC_TEAM_ARCHITECTURE.md`.
-- **Agent anatomy (single agents):** `backend/agents/agent_provisioning_team/AGENT_ANATOMY.md` — standard structure for provisioned AI agents (I/O, tools, memory, prompts, guardrails, subagents).
+### 🛠️ Core Dev — build, plan, and evolve software
 
-## Team documentation
+| Team | Route | What it does |
+|---|---|---|
+| **Software Engineering** | `/api/software-engineering` | Full dev-team simulation: architecture, planning, coding, review, release |
+| **Planning V3** | `/api/planning-v3` | Client-facing discovery and PRDs; hands off to dev/UX |
+| **Coding Team** | `/api/coding-team` | SE sub-team: tech lead + stack specialists with a task graph |
+| **AI Systems** | `/api/ai-systems` | Spec-driven factory that builds new AI agent systems |
+| **Agent Provisioning** | `/api/agent-provisioning` | Stands up agent environments (databases, git, docker) |
+| **Agentic Team Provisioning** | `/api/agentic-team-provisioning` | Designs new teams and their processes by conversation |
+| **User Agent Founder** | `/api/user-agent-founder` | Autonomous "founder" agent that drives the SE team |
+| **Deepthought** | `/api/deepthought` | Recursive self-organizing agent that spawns its own sub-agents |
 
-- `backend/agents/README.md` (backend agent monorepo overview)
-- `backend/agents/software_engineering_team/README.md`
-- `backend/agents/blogging/README.md`
-- `backend/agents/personal_assistant_team/README.md`
-- `backend/agents/social_media_marketing_team/README.md`
-- `backend/agents/market_research_team/README.md`
-- `backend/agents/soc2_compliance_team/README.md`
-- `backend/agents/branding_team/README.md`
-- `backend/agents/agent_provisioning_team/README.md`
-- `backend/agents/accessibility_audit_team/README.md`
-- `backend/agents/ai_systems_team/README.md`
-- `backend/agents/investment_team/README.md`
-- `backend/agents/nutrition_meal_planning_team/README.md`
-- `backend/agents/planning_v3_team/README.md`
-- `backend/agents/coding_team/README.md`
-- `backend/agents/sales_team/README.md` (AI Sales Team)
-- `backend/agents/road_trip_planning_team/README.md` (Road Trip Planning)
-- `backend/agents/agentic_team_provisioning/` (Agentic Team Provisioning)
-- `backend/agents/startup_advisor/README.md` (Startup Advisor)
-- `backend/agents/user_agent_founder/README.md` (User Agent Founder)
-- `backend/agents/deepthought/README.md` (Deepthought recursive agent)
+### 💼 Business — the grown-up functions
 
-## Docker
+| Team | Route | What it does |
+|---|---|---|
+| **Market Research** | `/api/market-research` | User discovery and product-concept viability research |
+| **SOC2 Compliance** | `/api/soc2-compliance` | SOC2 audit and certification workflow |
+| **Investment** | `/api/investment` | Financial advisor (IPS, proposals) + Strategy Lab (ideation, backtests) |
+| **AI Sales Team** | `/api/sales` | Full B2B sales pod: prospect → qualify → nurture → close |
+| **Startup Advisor** | `/api/startup-advisor` | Persistent conversational advisor with probing dialogue |
 
-For the full stack (Postgres, Temporal, optional Ollama, backend APIs, and UI):
+### ✍️ Content — ideas into words into reach
+
+| Team | Route | What it does |
+|---|---|---|
+| **Blogging** | `/api/blogging` | Research → planning → draft → copy-edit → publish |
+| **Social Marketing** | `/api/social-marketing` | Cross-platform campaigns with per-platform specialists |
+| **Branding** | `/api/branding` | Brand strategy, moodboards, and design/writing standards |
+
+### 🧘 Personal — life, optimized
+
+| Team | Route | What it does |
+|---|---|---|
+| **Personal Assistant** | `/api/personal-assistant` | Email, calendar, tasks, deals, reservations |
+| **Accessibility Audit** | `/api/accessibility-audit` | WCAG 2.2 and Section 508 auditing for web and mobile |
+| **Nutrition & Meal Planning** | `/api/nutrition-meal-planning` | Personalized meal plans that learn from your feedback |
+| **Road Trip Planning** | `/api/road-trip-planning` | Profiling, route optimization, activity recommendations, logistics |
+
+> …and more on the way. Run `GET /api/teams` on a live instance for the authoritative roster.
+
+---
+
+## Ship in 60 seconds
+
+### 🚢 The Docker way (recommended — entire stack live)
 
 ```bash
+cp docker/.env.example docker/.env   # then set OLLAMA_API_KEY (or your LLM provider)
 docker compose -f docker/docker-compose.yml --env-file docker/.env up --build
 ```
 
-See `docker/README.md` for env vars, ports, and deployment notes.
+Then open:
+- 🖥️ **UI:** http://localhost:4201
+- 🔌 **Unified API + docs:** http://localhost:8888/docs
+- ⏱️ **Temporal UI:** http://localhost:8080
 
-## Additional docs
+Full details in [`docker/README.md`](docker/README.md).
 
-- `backend/unified_api/README.md` (mounts, `TeamConfig`, optional `parent_team_key`, logical disabled teams)
-- `ARCHITECTURE.md`
-- `CONTRIBUTORS.md`
-- `CLAUDE.md` (Cursor / Claude Code guidance for this repo)
+### 🧑‍💻 The local way (hack on the code)
 
-Individual package READMEs under `backend/agents/**` and `user-interface/` end with a **Khala platform** link back to this file.
+```bash
+# 1) Backend (terminal 1)
+cd backend
+make install            # venv + deps
+python run_unified_api.py
+# → http://localhost:8080/docs
+
+# 2) Frontend (terminal 2)
+cd user-interface
+nvm use                 # Node 22
+npm ci
+npm start
+# → http://localhost:4200
+```
+
+Handy Makefile targets: `make lint`, `make lint-fix`, `make test`, `make run`, `make deploy`.
+
+---
+
+## Architecture at a glance
+
+```mermaid
+flowchart LR
+    User([👤 You]) --> UI[Angular 19 UI]
+    UI -->|/api/*| Gateway{{Unified API<br/>Gateway}}
+
+    Gateway --> Core[🛠️ Core Dev teams]
+    Gateway --> Biz[💼 Business teams]
+    Gateway --> Content[✍️ Content teams]
+    Gateway --> Personal[🧘 Personal teams]
+    Gateway --> Grow[⚡ …and growing]
+
+    Gateway -.-> Temporal[(Temporal<br/>durable workflows)]
+    Gateway -.-> Postgres[(Postgres<br/>shared brain)]
+    Gateway -.-> LLM[[LLM backend<br/>Ollama · Claude]]
+```
+
+The full system — 4-phase SDLC, task graphs, parallel worker queues, planning cache, quality gates, DevOps pipeline — is documented with Mermaid diagrams in [`ARCHITECTURE.md`](ARCHITECTURE.md).
+
+---
+
+## Add your own team
+
+Khala is built to grow. You have two ways to add a new team:
+
+1. **Talk to the Agentic Team Provisioning team.** Describe the roster you want in plain English; it validates the design and (optionally) bridges to Agent Provisioning to stand up the environment. See [`backend/agents/agentic_team_provisioning/`](backend/agents/agentic_team_provisioning/).
+2. **Write it yourself.** Follow the agent structure in [`AGENT_ANATOMY.md`](backend/agents/agent_provisioning_team/AGENT_ANATOMY.md) (I/O, tools, memory, prompts, guardrails, sub-agents), register the team in [`backend/unified_api/config.py`](backend/unified_api/config.py) (`TEAM_CONFIGS`), and it mounts at `/api/<your-slug>` on next restart.
+
+---
+
+## Deep dives
+
+<details>
+<summary><strong>Per-team READMEs (click to expand)</strong></summary>
+
+### Core Dev
+- [`backend/agents/software_engineering_team/`](backend/agents/software_engineering_team/README.md) — the flagship SE pipeline (planning, coding, review, release)
+- [`backend/agents/planning_v3_team/`](backend/agents/planning_v3_team/README.md)
+- [`backend/agents/coding_team/`](backend/agents/coding_team/README.md)
+- [`backend/agents/ai_systems_team/`](backend/agents/ai_systems_team/README.md)
+- [`backend/agents/agent_provisioning_team/`](backend/agents/agent_provisioning_team/README.md)
+- [`backend/agents/agentic_team_provisioning/`](backend/agents/agentic_team_provisioning/)
+- [`backend/agents/user_agent_founder/`](backend/agents/user_agent_founder/README.md)
+- [`backend/agents/deepthought/`](backend/agents/deepthought/README.md)
+
+### Business
+- [`backend/agents/market_research_team/`](backend/agents/market_research_team/README.md)
+- [`backend/agents/soc2_compliance_team/`](backend/agents/soc2_compliance_team/README.md)
+- [`backend/agents/investment_team/`](backend/agents/investment_team/README.md) — Advisor/IPS + Strategy Lab
+- [`backend/agents/sales_team/`](backend/agents/sales_team/README.md)
+- [`backend/agents/startup_advisor/`](backend/agents/startup_advisor/README.md)
+
+### Content
+- [`backend/agents/blogging/`](backend/agents/blogging/README.md)
+- [`backend/agents/social_media_marketing_team/`](backend/agents/social_media_marketing_team/README.md)
+- [`backend/agents/branding_team/`](backend/agents/branding_team/README.md)
+
+### Personal
+- [`backend/agents/personal_assistant_team/`](backend/agents/personal_assistant_team/README.md)
+- [`backend/agents/accessibility_audit_team/`](backend/agents/accessibility_audit_team/README.md)
+- [`backend/agents/nutrition_meal_planning_team/`](backend/agents/nutrition_meal_planning_team/README.md)
+- [`backend/agents/road_trip_planning_team/`](backend/agents/road_trip_planning_team/README.md)
+
+### Platform
+- [`backend/agents/`](backend/agents/README.md) — backend agent monorepo overview
+- [`backend/unified_api/`](backend/unified_api/README.md) — mounts, `TeamConfig`, logical sub-teams
+
+</details>
+
+---
+
+## Developer guide
+
+| Env var | Purpose |
+|---|---|
+| `LLM_PROVIDER` / `LLM_BASE_URL` / `LLM_MODEL` | Pick and configure the LLM backend |
+| `OLLAMA_API_KEY` | Required for Ollama Cloud |
+| `TEMPORAL_ADDRESS` / `TEMPORAL_NAMESPACE` / `TEMPORAL_TASK_QUEUE` | Enable durable workflows when set |
+| `POSTGRES_HOST` / `POSTGRES_PORT` / `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` | Required for migrated teams (blogging, branding, startup_advisor, nutrition, agentic_team_provisioning, team_assistant, user_agent_founder, unified_api credentials) |
+| `SECURITY_GATEWAY_ENABLED` | Toggle the request-scanning gateway (default: `true`) |
+| `AGENT_CACHE` | Shared cache root; each team namespaces under `{team_name}/` |
+
+More reference:
+
+- 📐 [**`ARCHITECTURE.md`**](ARCHITECTURE.md) — 26KB deep-dive with Mermaid diagrams (SDLC phases, task graphs, worker pipelines, DevOps gates)
+- 🤝 [**`CONTRIBUTORS.md`**](CONTRIBUTORS.md) — setup, branch conventions, code standards, testing, PR process
+- 🤖 [**`CLAUDE.md`**](CLAUDE.md) — guidance for Claude Code / Cursor when working in this repo
+- 📝 [**`CHANGELOG.md`**](CHANGELOG.md) — what shipped recently
+- 🧬 [**`AGENT_ANATOMY.md`**](backend/agents/agent_provisioning_team/AGENT_ANATOMY.md) — the standard structure for a Khala-native agent
+
+---
+
+## License
+
+See [`LICENSE`](LICENSE).
+
+<p align="center">
+  <sub>Built by humans and their Khala.  ·  Many minds. One objective. Yours.</sub>
+</p>

--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -1,0 +1,26 @@
+# Khala — branding assets
+
+Drop generated branding assets in this folder.
+
+## Expected files
+
+| File | Used by | Size / aspect | How to regenerate |
+|---|---|---|---|
+| `khala-banner.png` | Top-level [`README.md`](../../README.md) hero | Ultrawide **21:9** (e.g. 1568×672) | See the Nano Banana prompt below |
+
+## Nano Banana prompt for `khala-banner.png`
+
+Paste this into [Nano Banana](https://nanobanana.ai/) / Gemini 2.5 Flash Image and select aspect ratio **21:9**:
+
+> Epic cinematic banner, ultrawide 21:9, hyper-detailed concept art, hero shot. A colossal swirling vortex of electric-cyan and violet psionic energy dominates the center, crackling with lightning and shooting tendrils of gold light outward. Being pulled into this vortex from all sides: dozens of glowing holographic glyphs and icons representing specialist AI agents — a blueprint, a quill, a circuit board, a microscope, a stock chart, a compass, a chef's knife, a shield, a stethoscope, a gavel, a rocket, a gear — each one streaking with motion blur and leaving neon comet trails. Where the tendrils converge at the core, they fuse into a single blinding gold-white singularity that radiates lens flares and volumetric god-rays across the entire frame, pointing outward toward the viewer as if the entire storm is aimed at them. Obsidian-black background bleeding into deep purple nebula, shot through with electric-blue nerve-like filaments and scattered star bursts. Dramatic rim lighting, heavy atmospheric haze, chromatic aberration on the highlights, cinematic bloom. On the left third, the word "KHALA" rendered HUGE in a bold, sharp, futuristic display typeface — brilliant white core with a thick cyan outer glow and faint violet shadow, edges fizzing with tiny electric sparks. Directly beneath it, tagline in thin spaced uppercase sans-serif, slightly smaller and in warm gold: "MANY MINDS · ONE OBJECTIVE · YOURS". Style references: the marketing art of Nvidia GTC keynotes, Cyberpunk 2077 splash screens, Dune: Part Two posters, and Marvel title cards. Maximum drama, maximum contrast, unapologetically bold. No humans, no recognizable sci-fi IP, no text errors, no watermarks, no borders.
+
+### Optional remixes
+
+- Swap the tagline in the prompt: `"MANY MINDS · ONE OBJECTIVE · YOURS"` → `"THE HIVEMIND FOR BUILDERS"` or `"MANY MINDS · ONE STORM"`
+- Add `"bright god-rays piercing through the logo letters"` for extra typography drama
+- Add `"foreground debris and floating glass shards catching the light"` for Marvel-poster feel
+- Swap `"cyan and violet"` → `"magenta and teal"` for a synthwave palette
+- Append `"shot on 70mm IMAX"` to push photo-realism
+- Append `"oil painting texture, thick impasto brushstrokes"` for a painterly hero
+
+Save the final render as `khala-banner.png` in this folder and the top-level README will pick it up automatically.


### PR DESCRIPTION
The previous README read like internal reference docs — team list, repo
layout, quick-start commands — with nothing to hook a new developer or
communicate what Khala actually is. This rewrite leads with a hero
banner slot, a "you don't need a team, you need a Khala" pitch, and a
four-cell roster table so Khala's breadth (and ongoing expansion) is
visible at a glance, while keeping the existing sub-READMEs as the
source of truth via an expandable deep-dives section.

Also adds docs/assets/README.md with the Nano Banana prompt to
regenerate the hero banner.

https://claude.ai/code/session_011wpPqiEnurVUHWdx8QX5hm