### PR TITLE
feat(blogging): add independent plan-critic LLM pass with brand-spec-driven rubric

### DIFF
--- a/backend/agents/blogging/agent_implementations/blog_writing_process_v2.py
+++ b/backend/agents/blogging/agent_implementations/blog_writing_process_v2.py
@@ -18,6 +18,7 @@ from blog_compliance_agent import BlogComplianceAgent
 from blog_copy_editor_agent import BlogCopyEditorAgent, CopyEditorInput
 from blog_copy_editor_agent.models import FeedbackItem
 from blog_fact_check_agent import BlogFactCheckAgent
+from blog_plan_critic_agent import BlogPlanCriticAgent
 from blog_publication_agent.models import PublishingPack
 from blog_research_agent.models import ResearchBriefInput
 from blog_writer_agent import BlogWriterAgent, ReviseWriterInput, WriterInput
@@ -53,7 +54,12 @@ from shared.errors import (
     PlanningError,
 )
 from shared.models import BlogPhase, get_phase_progress
-from shared.planning_config import planning_model_override
+from shared.planning_config import (
+    plan_critic_enabled,
+    plan_critic_max_iterations,
+    plan_critic_model_override,
+    planning_model_override,
+)
 from shared.style_loader import append_guidelines, load_style_file
 from temporalio.exceptions import CancelledError
 from validators.runner import run_validators_from_work_dir
@@ -107,6 +113,28 @@ def planning_llm_client(base: LLMClient) -> LLMClient:
     return base
 
 
+def plan_critic_llm_client(base: LLMClient) -> LLMClient:
+    """Use BLOG_PLAN_CRITIC_MODEL for the plan critic when set (Ollama clients only).
+
+    Per the architectural tenet, the critic runs on the same model as the writer
+    by default. This hook exists so per-role model diversification can be flipped
+    on later without further code changes.
+    """
+    model = plan_critic_model_override()
+    if not model:
+        return base
+    if isinstance(base, OllamaLLMClient):
+        return OllamaLLMClient(model=model, base_url=base.base_url, timeout=base.timeout)
+    return base
+
+
+def build_plan_critic_agent(base: LLMClient) -> Optional[BlogPlanCriticAgent]:
+    """Construct the plan-critic agent when enabled, else return None."""
+    if not plan_critic_enabled():
+        return None
+    return BlogPlanCriticAgent(llm_client=plan_critic_llm_client(base))
+
+
 def run_planning(
     brief: ResearchBriefInput,
     *,
@@ -156,16 +184,43 @@ def run_planning(
         series_context_block=series_context_block(series_context),
     )
 
+    # Load the author's brand spec + writing guidelines so the plan critic can
+    # evaluate against the author-owned sources of truth. These are safe to load
+    # even when the critic is disabled — the BlogWriterAgent used for drafting
+    # wants them too, but planning uses an empty-style instance by design.
+    try:
+        brand_spec_for_critic = load_brand_spec_prompt(BRAND_SPEC_PROMPT_PATH)
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("Could not load brand spec for plan critic: %s", e)
+        brand_spec_for_critic = ""
+    try:
+        writing_guidelines_for_critic = load_style_file(STYLE_GUIDE_PATH)
+    except Exception as e:  # pragma: no cover - defensive
+        logger.warning("Could not load writing guidelines for plan critic: %s", e)
+        writing_guidelines_for_critic = ""
+
+    plan_critic = build_plan_critic_agent(llm_client)
+
+    # Planning convergence cap: honour the critic's max iterations when the
+    # critic is enabled, since the critic can reject plans the planner would
+    # otherwise accept. Fall back to the planner's own iteration cap otherwise.
+    planning_max_iter = (
+        plan_critic_max_iterations() if plan_critic is not None else 5
+    )
+
     try:
         planning_draft_agent = BlogWriterAgent(
             llm_client=planning_llm_client(llm_client),
-            writing_style_guide_content="",
-            brand_spec_content="",
+            writing_style_guide_content=writing_guidelines_for_critic,
+            brand_spec_content=brand_spec_for_critic,
         )
         planning_phase_result = planning_draft_agent.plan_content(
             planning_input,
             length_policy=length_policy,
             on_llm_request=lambda msg: _update(BlogPhase.PLANNING, status_text=msg),
+            plan_critic=plan_critic,
+            work_dir=work_dir,
+            max_iterations=planning_max_iter,
         )
     except BloggingError:
         raise
@@ -201,6 +256,18 @@ def run_planning(
         write_artifact(work_dir, "outline.md", content_plan_to_outline_markdown(plan))
         write_artifact(work_dir, "content_brief.md", content_plan_to_content_brief_markdown(plan))
         logger.info("Persisted content_plan.json, content_plan.md, outline.md, content_brief.md")
+        # Persist the critic's final verdict under a stable filename for easy inspection;
+        # per-iteration reports (plan_critic_report_v{N}.json) remain in work_dir too.
+        if planning_phase_result.plan_critic_report is not None:
+            write_artifact(
+                work_dir,
+                "plan_critic_report.json",
+                planning_phase_result.plan_critic_report,
+            )
+            logger.info(
+                "Persisted plan_critic_report.json (status=%s)",
+                planning_phase_result.plan_critic_report.get("status"),
+            )
 
     return planning_phase_result
 

--- a/backend/agents/blogging/blog_plan_critic_agent/__init__.py
+++ b/backend/agents/blogging/blog_plan_critic_agent/__init__.py
@@ -1,0 +1,6 @@
+"""Independent LLM critic for content plans produced by the planning phase."""
+
+from .agent import BlogPlanCriticAgent
+from .models import PlanCriticReport, PlanViolation
+
+__all__ = ["BlogPlanCriticAgent", "PlanCriticReport", "PlanViolation"]

--- a/backend/agents/blogging/blog_plan_critic_agent/agent.py
+++ b/backend/agents/blogging/blog_plan_critic_agent/agent.py
@@ -1,0 +1,266 @@
+"""Independent LLM pass that evaluates a ContentPlan against the author's brand spec + rubric.
+
+The critic's verdict is authoritative: the planning loop terminates only when the
+critic approves, and refine feedback is built from the critic's structured
+violations instead of a generic string.
+
+This agent intentionally runs as its own strands Agent (own session, own system
+prompt) so the model critiques without being primed as the author's voice. It
+uses the same LLM client as the planner per the project's tenet that per-role
+model diversification is a future concern; only the role (prompt + session) is
+separate today.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import Any, Callable, Optional, Union
+
+from blog_planning_agent.json_utils import parse_json_object
+from shared.content_plan import ContentPlan
+from strands import Agent
+
+from .models import PlanCriticReport, PlanViolation
+from .prompts import PLAN_CRITIC_SYSTEM, PLAN_CRITIC_USER_TEMPLATE
+
+try:
+    from shared.artifacts import write_artifact
+except ImportError:  # pragma: no cover - defensive; artifacts may be unavailable in tests
+    write_artifact = None  # type: ignore[assignment]
+
+logger = logging.getLogger(__name__)
+
+_JSON_RETRY_SUFFIX = (
+    "\n\nRespond with a single JSON object only (no markdown, no code fences). "
+    'Keys: "status", "approved", "violations", "notes", "rubric_version".'
+)
+
+_MAX_CRITIC_LLM_ATTEMPTS = 2
+
+_RESEARCH_DIGEST_CHAR_CAP = 8000
+_BRAND_SPEC_CHAR_CAP = 16000
+_WRITING_GUIDELINES_CHAR_CAP = 16000
+
+
+def _fallback_report(reason: str) -> PlanCriticReport:
+    """When the critic LLM cannot be parsed, fail closed with an actionable note."""
+    return PlanCriticReport(
+        status="FAIL",
+        approved=False,
+        violations=[],
+        notes=(
+            "Plan critic did not produce parseable JSON after retries; treating as FAIL "
+            "so the refine loop continues. Reason: " + reason
+        ),
+    )
+
+
+class BlogPlanCriticAgent:
+    """Evaluates a ContentPlan against the brand spec + writing guidelines + rubric.
+
+    The agent is constructed once and reused across refine iterations. ``run`` is
+    stateless: each call opens a fresh strands ``Agent`` with the critic system
+    prompt so no context leaks between plans.
+    """
+
+    def __init__(self, llm_client: Any) -> None:
+        assert llm_client is not None, "llm_client is required"
+        self._model = llm_client
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def run(
+        self,
+        *,
+        plan: ContentPlan,
+        brand_spec_prompt: str,
+        writing_guidelines: str,
+        research_digest: str = "",
+        on_llm_request: Optional[Callable[[str], None]] = None,
+        work_dir: Optional[Union[str, Path]] = None,
+        artifact_name: str = "plan_critic_report.json",
+    ) -> PlanCriticReport:
+        """Evaluate ``plan`` and return a ``PlanCriticReport``.
+
+        Parameters:
+            plan: the ContentPlan to evaluate.
+            brand_spec_prompt: rendered brand spec text (author-owned source of truth).
+            writing_guidelines: rendered writing guidelines text (author-owned).
+            research_digest: optional research digest used by the planner; may be empty.
+            on_llm_request: optional progress callback.
+            work_dir: when provided, persists the report as JSON for inspection.
+            artifact_name: override for the persisted filename (useful per iteration).
+        """
+        user_prompt = PLAN_CRITIC_USER_TEMPLATE.format(
+            brand_spec_prompt=(brand_spec_prompt or "").strip()[:_BRAND_SPEC_CHAR_CAP],
+            writing_guidelines=(writing_guidelines or "").strip()[:_WRITING_GUIDELINES_CHAR_CAP],
+            research_digest=(research_digest or "").strip()[:_RESEARCH_DIGEST_CHAR_CAP]
+            or "(no research digest supplied)",
+            plan_json=json.dumps(plan.model_dump(mode="json"), indent=2),
+        )
+
+        if on_llm_request:
+            on_llm_request("Plan critic: evaluating plan against brand spec + rubric...")
+
+        data: Optional[dict[str, Any]] = None
+        last_err: Optional[Exception] = None
+        for attempt in range(_MAX_CRITIC_LLM_ATTEMPTS):
+            suffix = (
+                "\n\nRespond with valid JSON only, no markdown fences."
+                if attempt == 0
+                else _JSON_RETRY_SUFFIX
+            )
+            try:
+                agent = Agent(model=self._model, system_prompt=PLAN_CRITIC_SYSTEM)
+                raw = str(agent(user_prompt + suffix)).strip()
+                data = parse_json_object(raw)
+                break
+            except (json.JSONDecodeError, TypeError, ValueError) as e:
+                last_err = e
+                logger.warning(
+                    "Plan critic JSON parse failed on attempt %s/%s: %s",
+                    attempt + 1,
+                    _MAX_CRITIC_LLM_ATTEMPTS,
+                    e,
+                )
+            except Exception as e:  # pragma: no cover - network / infra errors
+                last_err = e
+                logger.warning(
+                    "Plan critic LLM call failed on attempt %s/%s: %s",
+                    attempt + 1,
+                    _MAX_CRITIC_LLM_ATTEMPTS,
+                    e,
+                )
+
+        if data is None:
+            report = _fallback_report(str(last_err) if last_err else "unknown")
+        else:
+            report = self._coerce_report(data)
+
+        # Enforce the invariant: approved iff status == PASS with no must_fix items
+        approved = report.status == "PASS" and report.must_fix_count() == 0
+        if approved != report.approved:
+            report = report.model_copy(update={"approved": approved})
+
+        if work_dir and write_artifact is not None:
+            try:
+                write_artifact(work_dir, artifact_name, report.to_dict())
+                logger.info(
+                    "Wrote %s: status=%s, violations=%d",
+                    artifact_name,
+                    report.status,
+                    len(report.violations),
+                )
+            except Exception as e:  # pragma: no cover - artifact writing is best-effort
+                logger.warning("Failed to persist %s: %s", artifact_name, e)
+
+        return report
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _coerce_report(data: dict[str, Any]) -> PlanCriticReport:
+        """Best-effort coercion of raw LLM JSON into a PlanCriticReport.
+
+        When the LLM returns partial or slightly-malformed fields, coerce to a
+        conservative FAIL rather than crashing.
+        """
+        status_raw = (data.get("status") or "FAIL").upper() if isinstance(data, dict) else "FAIL"
+        status = "PASS" if status_raw == "PASS" else "FAIL"
+
+        raw_violations = data.get("violations") or []
+        if not isinstance(raw_violations, list):
+            raw_violations = []
+
+        violations: list[PlanViolation] = []
+        for v in raw_violations:
+            if not isinstance(v, dict):
+                continue
+            rule_id = str(v.get("rule_id") or "unknown").strip() or "unknown"
+            severity_raw = str(v.get("severity") or "must_fix").lower()
+            if severity_raw not in ("must_fix", "should_fix", "consider"):
+                severity_raw = "must_fix"
+            description = (v.get("description") or "").strip() or "(no description provided)"
+            suggested_fix = (v.get("suggested_fix") or "").strip() or "(no suggested fix provided)"
+            evidence_quote = v.get("evidence_quote")
+            if isinstance(evidence_quote, str):
+                evidence_quote = evidence_quote.strip() or None
+            else:
+                evidence_quote = None
+            section = v.get("section")
+            if isinstance(section, str):
+                section = section.strip() or None
+            else:
+                section = None
+            violations.append(
+                PlanViolation(
+                    rule_id=rule_id,
+                    severity=severity_raw,  # type: ignore[arg-type]
+                    section=section,
+                    evidence_quote=evidence_quote,
+                    description=description,
+                    suggested_fix=suggested_fix,
+                )
+            )
+
+        approved_raw = data.get("approved")
+        approved = bool(approved_raw) if isinstance(approved_raw, bool) else (status == "PASS")
+
+        notes = data.get("notes")
+        if not isinstance(notes, str):
+            notes = None
+
+        rubric_version = data.get("rubric_version")
+        if not isinstance(rubric_version, str) or not rubric_version.strip():
+            rubric_version = "v1"
+
+        return PlanCriticReport(
+            status=status,
+            approved=approved,
+            violations=violations,
+            notes=notes,
+            rubric_version=rubric_version,
+        )
+
+
+def build_refine_feedback_from_critic(report: PlanCriticReport) -> str:
+    """Format the critic's violations into refine-loop feedback the planner can act on.
+
+    Sorted by severity (must_fix first) so the refiner can't miss the blockers.
+    """
+    if not report.violations:
+        if report.approved:
+            return "Plan critic approved the plan; no refinement needed."
+        return (
+            "Plan critic rejected the plan but did not list violations; "
+            "revisit the 13 rubric rules and tighten vague sections."
+        )
+
+    severity_order = {"must_fix": 0, "should_fix": 1, "consider": 2}
+    ordered = sorted(
+        report.violations,
+        key=lambda v: (severity_order.get(v.severity, 3), v.rule_id),
+    )
+
+    lines: list[str] = [
+        "An independent plan critic reviewed the previous plan and rejected it.",
+        "Address every must_fix violation and resolve should_fix items where possible.",
+        "",
+    ]
+    for v in ordered:
+        where = f"[{v.section}] " if v.section else ""
+        evidence = f'\n   evidence: "{v.evidence_quote}"' if v.evidence_quote else ""
+        lines.append(
+            f"- {v.severity.upper()} {where}{v.rule_id}: {v.description}{evidence}\n"
+            f"   fix: {v.suggested_fix}"
+        )
+    if report.notes:
+        lines.append("")
+        lines.append(f"Critic notes: {report.notes}")
+    return "\n".join(lines)

--- a/backend/agents/blogging/blog_plan_critic_agent/models.py
+++ b/backend/agents/blogging/blog_plan_critic_agent/models.py
@@ -1,0 +1,68 @@
+"""Models for the blog plan critic (independent plan evaluator)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+PlanStatus = Literal["PASS", "FAIL"]
+PlanSeverity = Literal["must_fix", "should_fix", "consider"]
+
+
+class PlanViolation(BaseModel):
+    """A single rubric or brand-spec violation found in the plan."""
+
+    rule_id: str = Field(
+        ...,
+        description=(
+            "Rubric identifier, e.g. 'overarching_topic.stance_not_label', "
+            "'section.key_points.specificity', 'brand.voice_mismatch'."
+        ),
+    )
+    severity: PlanSeverity = Field(
+        default="must_fix",
+        description="must_fix blocks critic approval; should_fix and consider are advisory.",
+    )
+    section: Optional[str] = Field(
+        default=None,
+        description="Section title this violation applies to, or 'overall' for plan-wide issues.",
+    )
+    evidence_quote: Optional[str] = Field(
+        default=None,
+        description="Exact quote from the offending plan field (keep under ~120 chars).",
+    )
+    description: str = Field(..., description="What is wrong and why it matters.")
+    suggested_fix: str = Field(
+        ...,
+        description="Concrete, actionable instruction the refiner can apply next iteration.",
+    )
+
+
+class PlanCriticReport(BaseModel):
+    """Structured critique of a ContentPlan against the author's brand spec and the rubric."""
+
+    status: PlanStatus = Field(
+        ...,
+        description="PASS when no must_fix violations exist; FAIL otherwise.",
+    )
+    approved: bool = Field(
+        ...,
+        description=(
+            "True when the critic considers the plan shippable to the draft phase. "
+            "Should equal (status == 'PASS')."
+        ),
+    )
+    violations: List[PlanViolation] = Field(default_factory=list)
+    notes: Optional[str] = Field(
+        default=None,
+        description="Optional short critic notes, e.g. parse-failure hints or context.",
+    )
+    rubric_version: str = Field(default="v1")
+
+    def must_fix_count(self) -> int:
+        return sum(1 for v in self.violations if v.severity == "must_fix")
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Export for JSON serialization."""
+        return self.model_dump(exclude_none=True)

--- a/backend/agents/blogging/blog_plan_critic_agent/prompts.py
+++ b/backend/agents/blogging/blog_plan_critic_agent/prompts.py
@@ -1,0 +1,88 @@
+"""Prompts for the independent plan critic."""
+
+from __future__ import annotations
+
+PLAN_CRITIC_SYSTEM = """\
+You are an independent Content-Plan Critic. You did NOT write this plan; your job is to evaluate it against three authoritative sources:
+
+ 1. The author's BRAND SPEC — identity, voice, values, audience.
+ 2. The author's WRITING GUIDELINES — hard rules for how this author's posts are constructed.
+ 3. The PLAN-QUALITY RUBRIC below — the 13 rules that separate a specific, shippable plan from a vague one.
+
+You will be given the brand spec, the writing guidelines, the research digest the plan is grounded in, and the plan itself (as JSON). Produce a structured critique.
+
+REJECT the plan (status=FAIL) if ANY must_fix violation below is present. For every violation, emit a PlanViolation with a concrete suggested_fix the refiner can apply next iteration.
+
+RUBRIC (13 rules — use these rule_id slugs):
+
+ 1. overarching_topic.stance_not_label — overarching_topic must be a STANCE, not a label. "Choosing the right architecture isn't about complexity — it's about matching the pattern" is a stance. "A guide to architecture patterns" is a label. FAIL label-style topics. rule_id: `overarching_topic.stance_not_label`.
+
+ 2. narrative_flow.reader_journey — narrative_flow describes the reader's intellectual journey / belief shift, not a summary of the section headings. rule_id: `narrative_flow.reader_journey`.
+
+ 3. opening_strategy.specific — opening_strategy names a specific, actionable opening — a concrete moment, a stat, a pain point. Not "start with a hook". rule_id: `opening_strategy.specific`.
+
+ 4. conclusion_guidance.has_insight_cta_next — conclusion_guidance specifies (a) the final insight, (b) the call to action, (c) the reader's next step. rule_id: `conclusion_guidance.has_insight_cta_next`.
+
+ 5. target_reader.specific — target_reader is specific enough that the writer knows what to explain vs what to skip. rule_id: `target_reader.specific`.
+
+ 6. section.key_points.specificity — every section has 3–5 SPECIFIC key_points. "Discuss scaling" fails; "Show the 4x latency drop switching from N+1 queries to batched loaders" passes. rule_id: `section.key_points.specificity`.
+
+ 7. section.what_to_avoid.present — every section has 1–3 what_to_avoid entries that prevent common traps. rule_id: `section.what_to_avoid.present`.
+
+ 8. section.reader_takeaway.one_sentence_belief — reader_takeaway is ONE sentence stating what the reader now believes after the section. rule_id: `section.reader_takeaway.one_sentence_belief`.
+
+ 9. section.narrative_thread — opening_hook and transition_to_next connect sections as a narrative thread, not mechanical connectives. rule_id: `section.narrative_thread`.
+
+10. section.strongest_point.defensible — strongest_point for each section is a defensible, distinctive claim, the section's "hill to die on". rule_id: `section.strongest_point.defensible`.
+
+11. section.story_opportunity.intentional — story_opportunity is populated where a lived-experience anecdote strengthens the section, OR explicitly null when data/explanation is better. Never a vague "maybe". rule_id: `section.story_opportunity.intentional`.
+
+12. requirements_analysis.honest — requirements_analysis is honest: if anything above is vague, plan_acceptable must be false. rule_id: `requirements_analysis.honest`.
+
+13. title_candidates.minimum_and_aligned — at least 5 title_candidates, each with full 5-dim scoring, and every title accurately reflects the overarching_topic's stance. rule_id: `title_candidates.minimum_and_aligned`.
+
+BRAND-SPEC-GROUNDED checks (use `brand.*` rule_ids):
+ - Voice/audience in the plan should match what the author's brand spec declares. rule_id: `brand.voice_mismatch`.
+ - Sections that promise reader-experiences the brand spec says this author doesn't cover should FAIL. rule_id: `brand.out_of_scope_for_author`.
+ - Tone implied by key_points should match the brand's tone words. rule_id: `brand.tone_words_mismatch`.
+
+OUTPUT contract:
+ - Output a SINGLE JSON object matching this schema:
+   {
+     "status": "PASS" | "FAIL",
+     "approved": true | false,
+     "violations": [
+       {
+         "rule_id": "<rubric rule_id>",
+         "severity": "must_fix" | "should_fix" | "consider",
+         "section": "<section title or 'overall'>",
+         "evidence_quote": "<quoted plan text under ~120 chars>",
+         "description": "<what is wrong and why>",
+         "suggested_fix": "<concrete instruction the refiner can apply>"
+       },
+       ...
+     ],
+     "notes": "<optional short note>",
+     "rubric_version": "v1"
+   }
+ - `status` is PASS only when no must_fix violations exist. `approved` must equal (status == "PASS").
+ - Return JSON only. No markdown fences. No prose outside the object.
+"""
+
+
+PLAN_CRITIC_USER_TEMPLATE = """\
+--- BRAND SPEC ---
+{brand_spec_prompt}
+
+--- WRITING GUIDELINES ---
+{writing_guidelines}
+
+--- RESEARCH DIGEST ---
+{research_digest}
+
+--- CONTENT PLAN (JSON) ---
+{plan_json}
+
+--- TASK ---
+Evaluate the content plan against the brand spec, writing guidelines, and the rubric in your system prompt. Return a single PlanCriticReport JSON object only.
+"""

--- a/backend/agents/blogging/blog_planning_agent/agent.py
+++ b/backend/agents/blogging/blog_planning_agent/agent.py
@@ -8,7 +8,8 @@ import json
 import logging
 import re
 import time
-from typing import Any, Callable, Optional
+from pathlib import Path
+from typing import Any, Callable, Optional, Union
 
 from shared.content_plan import (
     ContentPlan,
@@ -89,10 +90,25 @@ def _build_refine_prompt(inp: PlanningInput, previous: ContentPlan, feedback: st
 
 
 class BlogPlanningAgent:
-    """Generates and refines a ContentPlan until acceptance criteria or max iterations."""
+    """Generates and refines a ContentPlan until acceptance criteria or max iterations.
 
-    def __init__(self, llm_client: Any) -> None:
+    When constructed with ``plan_critic``, its approval gates the refine loop
+    alongside the planner's own self-evaluation, and its violations drive the
+    refine feedback passed back into the model.
+    """
+
+    def __init__(
+        self,
+        llm_client: Any,
+        *,
+        plan_critic: Optional[Any] = None,
+        brand_spec_prompt: str = "",
+        writing_guidelines: str = "",
+    ) -> None:
         self._model = llm_client
+        self._plan_critic = plan_critic
+        self._brand_spec_prompt = (brand_spec_prompt or "").strip()
+        self._writing_guidelines = (writing_guidelines or "").strip()
 
     def _call_agent(self, prompt: str, system: str) -> str:
         """Call a Strands Agent with the given prompt and system prompt, return raw text."""
@@ -160,15 +176,20 @@ class BlogPlanningAgent:
         on_llm_request: Optional[Callable[[str], None]] = None,
         max_iterations: Optional[int] = None,
         max_parse_retries: Optional[int] = None,
+        work_dir: Optional[Union[str, Path]] = None,
     ) -> PlanningPhaseResult:
         max_iter = max_iterations if max_iterations is not None else planning_max_iterations()
         max_parse = (
             max_parse_retries if max_parse_retries is not None else planning_max_parse_retries()
         )
 
+        # Deferred import to keep this module dependency-free when the critic isn't wired.
+        from blog_plan_critic_agent.agent import build_refine_feedback_from_critic
+
         t0 = time.monotonic()
         total_parse_retries = 0
         last_plan: Optional[ContentPlan] = None
+        last_critic_report: Optional[Any] = None
 
         for iteration in range(1, max_iter + 1):
             if iteration == 1:
@@ -176,12 +197,15 @@ class BlogPlanningAgent:
                 system = GENERATE_PLAN_SYSTEM
             else:
                 assert last_plan is not None
-                feedback = (
-                    "The plan is not yet acceptable. "
-                    f"requirements_analysis: plan_acceptable={last_plan.requirements_analysis.plan_acceptable}, "
-                    f"scope_feasible={last_plan.requirements_analysis.scope_feasible}. "
-                    "Fix gaps, scope, and research alignment."
-                )
+                if last_critic_report is not None:
+                    feedback = build_refine_feedback_from_critic(last_critic_report)
+                else:
+                    feedback = (
+                        "The plan is not yet acceptable. "
+                        f"requirements_analysis: plan_acceptable={last_plan.requirements_analysis.plan_acceptable}, "
+                        f"scope_feasible={last_plan.requirements_analysis.scope_feasible}. "
+                        "Fix gaps, scope, and research alignment."
+                    )
                 prompt = _build_refine_prompt(planning_input, last_plan, feedback)
                 system = REFINE_PLAN_SYSTEM
 
@@ -217,20 +241,42 @@ class BlogPlanningAgent:
             last_plan = plan
             plan = plan.model_copy(update={"plan_version": iteration})
 
-            if _planning_done(plan):
+            planner_ok = _planning_done(plan)
+            critic_report = None
+            if self._plan_critic is not None:
+                critic_report = self._plan_critic.run(
+                    plan=plan,
+                    brand_spec_prompt=self._brand_spec_prompt,
+                    writing_guidelines=self._writing_guidelines,
+                    research_digest=planning_input.research_digest,
+                    on_llm_request=on_llm_request,
+                    work_dir=work_dir,
+                    artifact_name=f"plan_critic_report_v{iteration}.json",
+                )
+                last_critic_report = critic_report
+
+            critic_ok = critic_report is None or getattr(critic_report, "approved", False)
+            if planner_ok and critic_ok:
                 wall_ms = (time.monotonic() - t0) * 1000.0
+                critic_dict = (
+                    critic_report.to_dict()
+                    if critic_report is not None and hasattr(critic_report, "to_dict")
+                    else None
+                )
                 return PlanningPhaseResult(
                     content_plan=plan,
                     planning_iterations_used=iteration,
                     parse_retry_count=total_parse_retries,
                     planning_wall_ms_total=wall_ms,
+                    plan_critic_report=critic_dict,
                 )
 
             logger.info(
-                "Planning iteration %s not done: plan_acceptable=%s scope_feasible=%s",
+                "Planning iteration %s not done: plan_acceptable=%s scope_feasible=%s critic_approved=%s",
                 iteration,
                 plan.requirements_analysis.plan_acceptable,
                 plan.requirements_analysis.scope_feasible,
+                getattr(critic_report, "approved", None),
             )
 
         assert last_plan is not None

--- a/backend/agents/blogging/blog_writer_agent/agent.py
+++ b/backend/agents/blogging/blog_writer_agent/agent.py
@@ -12,6 +12,9 @@ import time
 from pathlib import Path
 from typing import Any, Callable, Optional, Union
 
+from blog_plan_critic_agent import BlogPlanCriticAgent
+from blog_plan_critic_agent.agent import build_refine_feedback_from_critic
+from blog_plan_critic_agent.models import PlanCriticReport
 from blog_planning_agent.json_utils import parse_json_object
 from blog_planning_agent.prompts import GENERATE_PLAN_SYSTEM, REFINE_PLAN_SYSTEM
 from shared.content_plan import (
@@ -301,22 +304,35 @@ class BlogWriterAgent:
         on_llm_request: Optional[Callable[[str], None]] = None,
         max_iterations: int = 5,
         max_parse_retries: int = 3,
+        plan_critic: Optional[BlogPlanCriticAgent] = None,
+        work_dir: Optional[Union[str, Path]] = None,
     ) -> PlanningPhaseResult:
+        """Generate and refine a ContentPlan until the planner (and optional critic) agree.
+
+        When ``plan_critic`` is supplied, its verdict is authoritative: the loop
+        terminates only when the planner's self-eval is done AND the critic
+        approves. Refine feedback comes from the critic's structured violations
+        instead of a generic string. When absent, legacy planner-self-eval only.
+        """
         t0 = time.monotonic()
         total_parse_retries = 0
         last_plan: Optional[ContentPlan] = None
+        last_critic_report: Optional[PlanCriticReport] = None
         for iteration in range(1, max_iterations + 1):
             if iteration == 1:
                 prompt = self._build_generate_plan_prompt(planning_input)
                 system = GENERATE_PLAN_SYSTEM
             else:
                 assert last_plan is not None
-                feedback = (
-                    "The plan is not yet acceptable. "
-                    f"requirements_analysis: plan_acceptable={last_plan.requirements_analysis.plan_acceptable}, "
-                    f"scope_feasible={last_plan.requirements_analysis.scope_feasible}. "
-                    "Fix gaps, scope, and research alignment."
-                )
+                if last_critic_report is not None:
+                    feedback = build_refine_feedback_from_critic(last_critic_report)
+                else:
+                    feedback = (
+                        "The plan is not yet acceptable. "
+                        f"requirements_analysis: plan_acceptable={last_plan.requirements_analysis.plan_acceptable}, "
+                        f"scope_feasible={last_plan.requirements_analysis.scope_feasible}. "
+                        "Fix gaps, scope, and research alignment."
+                    )
                 prompt = self._build_refine_plan_prompt(planning_input, last_plan, feedback)
                 system = REFINE_PLAN_SYSTEM
             data, pr = self._complete_plan_json(
@@ -347,13 +363,30 @@ class BlogWriterAgent:
                     }
                 )
             last_plan = plan.model_copy(update={"plan_version": iteration})
-            if self._planning_done(last_plan):
+
+            planner_ok = self._planning_done(last_plan)
+            critic_report: Optional[PlanCriticReport] = None
+            if plan_critic is not None:
+                critic_report = plan_critic.run(
+                    plan=last_plan,
+                    brand_spec_prompt=self._brand_spec_prompt,
+                    writing_guidelines=self._writing_style_prompt,
+                    research_digest=planning_input.research_digest,
+                    on_llm_request=on_llm_request,
+                    work_dir=work_dir,
+                    artifact_name=f"plan_critic_report_v{iteration}.json",
+                )
+                last_critic_report = critic_report
+
+            critic_ok = critic_report is None or critic_report.approved
+            if planner_ok and critic_ok:
                 wall_ms = (time.monotonic() - t0) * 1000.0
                 return PlanningPhaseResult(
                     content_plan=last_plan,
                     planning_iterations_used=iteration,
                     parse_retry_count=total_parse_retries,
                     planning_wall_ms_total=wall_ms,
+                    plan_critic_report=critic_report.to_dict() if critic_report is not None else None,
                 )
         raise PlanningError(
             f"Planning did not converge after {max_iterations} iterations",

--- a/backend/agents/blogging/shared/content_plan.py
+++ b/backend/agents/blogging/shared/content_plan.py
@@ -216,6 +216,13 @@ class PlanningPhaseResult(BaseModel):
     parse_retry_count: int = Field(0, ge=0)
     planning_wall_ms_total: float = Field(0.0, ge=0.0)
     planning_failure_reason: Optional[PlanningFailureReason] = None
+    plan_critic_report: Optional[Any] = Field(
+        default=None,
+        description=(
+            "PlanCriticReport from the independent critic pass when enabled. "
+            "Typed as Any here to avoid a hard dependency on blog_plan_critic_agent in this shared module."
+        ),
+    )
 
 
 # --- Section count expectations by profile (for post-validation / thresholds) ---

--- a/backend/agents/blogging/shared/planning_config.py
+++ b/backend/agents/blogging/shared/planning_config.py
@@ -22,3 +22,37 @@ def planning_model_override() -> Optional[str]:
     """
     raw = (os.environ.get("BLOG_PLANNING_MODEL") or "").strip()
     return raw or None
+
+
+def plan_critic_enabled() -> bool:
+    """Master toggle for the independent plan-critic LLM pass.
+
+    Defaults to OFF to allow safe rollout: flip to on once the critic has been
+    calibrated against the golden eval set. When disabled, the planner behaves
+    exactly as before the critic was introduced.
+    """
+    raw = (os.environ.get("BLOG_PLAN_CRITIC_ENABLED") or "false").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def plan_critic_max_iterations() -> int:
+    """Cap on critic-driven refine iterations.
+
+    Bounded to [1, 10] to prevent runaway loops when critic and planner oscillate.
+    """
+    raw = os.environ.get("BLOG_PLAN_CRITIC_MAX_ITERATIONS") or "3"
+    try:
+        return max(1, min(10, int(raw)))
+    except ValueError:
+        return 3
+
+
+def plan_critic_model_override() -> Optional[str]:
+    """
+    When set, the plan-critic uses this Ollama model instead of the pipeline default.
+
+    Unset by default; stays on qwen3.5 via the shared client. This hook exists so
+    per-role model diversification can be enabled later without further code changes.
+    """
+    raw = (os.environ.get("BLOG_PLAN_CRITIC_MODEL") or "").strip()
+    return raw or None

--- a/backend/agents/blogging/tests/test_blog_plan_critic_agent.py
+++ b/backend/agents/blogging/tests/test_blog_plan_critic_agent.py
@@ -1,0 +1,325 @@
+"""Tests for the independent plan critic.
+
+These tests drive the critic directly via a fake Strands Agent so we can
+exercise the full parse → coerce → report path without hitting an LLM, plus
+an integration test that runs the critic inside BlogPlanningAgent.run.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from blog_plan_critic_agent import BlogPlanCriticAgent, PlanCriticReport
+from blog_plan_critic_agent.agent import build_refine_feedback_from_critic
+from blog_planning_agent import BlogPlanningAgent
+from shared.content_plan import (
+    ContentPlan,
+    ContentPlanSection,
+    PlanningInput,
+    RequirementsAnalysis,
+    TitleCandidate,
+)
+from shared.content_profile import ContentProfile, LengthPolicy, resolve_length_policy
+
+from llm_service import DummyLLMClient
+
+
+def _policy_standard() -> LengthPolicy:
+    return resolve_length_policy(content_profile=ContentProfile.standard_article)
+
+
+def _minimal_plan(topic: str = "A stance about X that readers should adopt") -> ContentPlan:
+    return ContentPlan(
+        overarching_topic=topic,
+        narrative_flow="Reader journey from skepticism to conviction.",
+        sections=[
+            ContentPlanSection(
+                title=f"S{i}",
+                coverage_description="Specific coverage.",
+                key_points=[f"Point {i}A", f"Point {i}B", f"Point {i}C"],
+                what_to_avoid=["Generic advice"],
+                reader_takeaway="After this section, the reader believes X.",
+                strongest_point="The specific hill to die on.",
+                opening_hook="A concrete question.",
+                transition_to_next="Tension that leads forward.",
+                order=i,
+            )
+            for i in range(4)
+        ],
+        title_candidates=[
+            TitleCandidate(title=f"Title candidate {i}", probability_of_success=0.7)
+            for i in range(5)
+        ],
+        requirements_analysis=RequirementsAnalysis(
+            plan_acceptable=True,
+            scope_feasible=True,
+            research_gaps=[],
+        ),
+    )
+
+
+class _FakeAgent:
+    """Drop-in replacement for strands.Agent that returns a canned response.
+
+    Tracks every call so tests can assert how many critic passes ran.
+    """
+
+    calls: list[tuple[str, str]] = []
+    responses: list[str] = []
+
+    def __init__(self, model: Any, system_prompt: str = "") -> None:
+        self._system = system_prompt
+
+    def __call__(self, user_prompt: str) -> str:
+        _FakeAgent.calls.append((self._system, user_prompt))
+        if _FakeAgent.responses:
+            return _FakeAgent.responses.pop(0)
+        return json.dumps(
+            {
+                "status": "PASS",
+                "approved": True,
+                "violations": [],
+                "notes": None,
+                "rubric_version": "v1",
+            }
+        )
+
+
+@pytest.fixture(autouse=True)
+def _reset_fake_agent():
+    _FakeAgent.calls = []
+    _FakeAgent.responses = []
+    yield
+    _FakeAgent.calls = []
+    _FakeAgent.responses = []
+
+
+# ---------------------------------------------------------------------------
+# Agent unit tests
+# ---------------------------------------------------------------------------
+
+
+def test_critic_returns_pass_on_clean_json() -> None:
+    _FakeAgent.responses = [
+        json.dumps(
+            {
+                "status": "PASS",
+                "approved": True,
+                "violations": [],
+                "notes": "Plan looks good.",
+                "rubric_version": "v1",
+            }
+        )
+    ]
+    critic = BlogPlanCriticAgent(llm_client=DummyLLMClient())
+    with patch("blog_plan_critic_agent.agent.Agent", _FakeAgent):
+        report = critic.run(
+            plan=_minimal_plan(),
+            brand_spec_prompt="Brand spec text.",
+            writing_guidelines="Writing guidelines text.",
+            research_digest="Research.",
+        )
+    assert report.status == "PASS"
+    assert report.approved is True
+    assert report.violations == []
+    assert len(_FakeAgent.calls) == 1
+
+
+def test_critic_surfaces_violations_and_fails() -> None:
+    _FakeAgent.responses = [
+        json.dumps(
+            {
+                "status": "FAIL",
+                "approved": False,
+                "violations": [
+                    {
+                        "rule_id": "overarching_topic.stance_not_label",
+                        "severity": "must_fix",
+                        "section": "overall",
+                        "evidence_quote": "A guide to caching",
+                        "description": "Topic is a label, not a stance.",
+                        "suggested_fix": "Rewrite as a stance.",
+                    },
+                    {
+                        "rule_id": "section.key_points.specificity",
+                        "severity": "must_fix",
+                        "section": "Introduction",
+                        "evidence_quote": "Discuss scaling",
+                        "description": "Vague key point.",
+                        "suggested_fix": "Replace with a specific claim.",
+                    },
+                ],
+                "rubric_version": "v1",
+            }
+        )
+    ]
+    critic = BlogPlanCriticAgent(llm_client=DummyLLMClient())
+    with patch("blog_plan_critic_agent.agent.Agent", _FakeAgent):
+        report = critic.run(
+            plan=_minimal_plan(),
+            brand_spec_prompt="Brand spec text.",
+            writing_guidelines="Writing guidelines text.",
+        )
+    assert report.status == "FAIL"
+    assert report.approved is False
+    assert report.must_fix_count() == 2
+    assert {v.rule_id for v in report.violations} == {
+        "overarching_topic.stance_not_label",
+        "section.key_points.specificity",
+    }
+
+
+def test_critic_approved_invariant_enforced() -> None:
+    """approved must equal (status == PASS) regardless of what the LLM returned."""
+    _FakeAgent.responses = [
+        json.dumps(
+            {
+                "status": "FAIL",
+                "approved": True,  # inconsistent with status; critic should fix
+                "violations": [
+                    {
+                        "rule_id": "x",
+                        "severity": "must_fix",
+                        "description": "y",
+                        "suggested_fix": "z",
+                    }
+                ],
+                "rubric_version": "v1",
+            }
+        )
+    ]
+    critic = BlogPlanCriticAgent(llm_client=DummyLLMClient())
+    with patch("blog_plan_critic_agent.agent.Agent", _FakeAgent):
+        report = critic.run(
+            plan=_minimal_plan(),
+            brand_spec_prompt="b",
+            writing_guidelines="g",
+        )
+    assert report.status == "FAIL"
+    assert report.approved is False
+
+
+def test_critic_parse_failure_falls_back_to_fail() -> None:
+    _FakeAgent.responses = ["not json at all", "also not json"]
+    critic = BlogPlanCriticAgent(llm_client=DummyLLMClient())
+    with patch("blog_plan_critic_agent.agent.Agent", _FakeAgent):
+        report = critic.run(
+            plan=_minimal_plan(),
+            brand_spec_prompt="b",
+            writing_guidelines="g",
+        )
+    assert report.status == "FAIL"
+    assert report.approved is False
+    assert report.notes is not None
+    assert "parseable JSON" in (report.notes or "")
+
+
+def test_critic_persists_report_to_work_dir(tmp_path) -> None:
+    _FakeAgent.responses = [
+        json.dumps(
+            {
+                "status": "PASS",
+                "approved": True,
+                "violations": [],
+                "rubric_version": "v1",
+            }
+        )
+    ]
+    critic = BlogPlanCriticAgent(llm_client=DummyLLMClient())
+    with patch("blog_plan_critic_agent.agent.Agent", _FakeAgent):
+        critic.run(
+            plan=_minimal_plan(),
+            brand_spec_prompt="b",
+            writing_guidelines="g",
+            work_dir=tmp_path,
+            artifact_name="plan_critic_report_v1.json",
+        )
+    assert (tmp_path / "plan_critic_report_v1.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Refine-feedback formatting
+# ---------------------------------------------------------------------------
+
+
+def test_refine_feedback_lists_must_fix_first() -> None:
+    report = PlanCriticReport(
+        status="FAIL",
+        approved=False,
+        violations=[
+            {
+                "rule_id": "z.consider",
+                "severity": "consider",
+                "description": "consider item",
+                "suggested_fix": "consider fix",
+            },  # type: ignore[list-item]
+            {
+                "rule_id": "a.must_fix",
+                "severity": "must_fix",
+                "description": "must fix item",
+                "suggested_fix": "must fix fix",
+            },  # type: ignore[list-item]
+            {
+                "rule_id": "m.should_fix",
+                "severity": "should_fix",
+                "description": "should fix item",
+                "suggested_fix": "should fix fix",
+            },  # type: ignore[list-item]
+        ],
+    )
+    feedback = build_refine_feedback_from_critic(report)
+    must_idx = feedback.index("a.must_fix")
+    should_idx = feedback.index("m.should_fix")
+    consider_idx = feedback.index("z.consider")
+    assert must_idx < should_idx < consider_idx
+    assert "independent plan critic reviewed" in feedback
+
+
+def test_refine_feedback_empty_when_approved() -> None:
+    report = PlanCriticReport(status="PASS", approved=True, violations=[])
+    assert "no refinement needed" in build_refine_feedback_from_critic(report)
+
+
+# ---------------------------------------------------------------------------
+# Integration: BlogPlanningAgent with the critic
+# ---------------------------------------------------------------------------
+
+
+def test_planning_agent_integrates_critic_and_persists_reports(tmp_path) -> None:
+    """When a critic is attached, the planner gates on critic approval and writes artifacts."""
+    llm = DummyLLMClient()
+    critic = BlogPlanCriticAgent(llm_client=llm)
+    agent = BlogPlanningAgent(
+        llm,
+        plan_critic=critic,
+        brand_spec_prompt="Brand: tests.",
+        writing_guidelines="Guidelines: keep it short.",
+    )
+    inp = PlanningInput(
+        brief="Test brief about observability.",
+        research_digest="## Sources\n- Source one: summary.",
+        length_policy_context=_policy_standard().length_guidance,
+    )
+    result = agent.run(inp, length_policy=_policy_standard(), work_dir=tmp_path)
+    assert result.content_plan.requirements_analysis.plan_acceptable is True
+    # Critic report is attached to the result and persisted.
+    assert result.plan_critic_report is not None
+    assert result.plan_critic_report["status"] == "PASS"
+    assert result.plan_critic_report["approved"] is True
+    assert (tmp_path / "plan_critic_report_v1.json").exists()
+
+
+def test_planning_agent_without_critic_keeps_legacy_behaviour() -> None:
+    """When no critic is attached, the planner's self-eval is authoritative."""
+    llm = DummyLLMClient()
+    agent = BlogPlanningAgent(llm)
+    inp = PlanningInput(
+        brief="Test brief about observability.",
+        research_digest="## Sources\n- Source one: summary.",
+        length_policy_context=_policy_standard().length_guidance,
+    )
+    result = agent.run(inp, length_policy=_policy_standard())
+    assert result.plan_critic_report is None

--- a/backend/agents/llm_service/clients/dummy.py
+++ b/backend/agents/llm_service/clients/dummy.py
@@ -699,6 +699,15 @@ class DummyLLMClient(LLMClient, Model):
                 "commands_run": [],
                 "ready_for_review": True,
             }
+        # Blogging: plan-critic report (token lives in the user prompt tail)
+        elif "plancriticreport" in lowered or "return a single plancriticreport" in lowered:
+            return {
+                "status": "PASS",
+                "approved": True,
+                "violations": [],
+                "notes": "Dummy plan critic: rubber-stamp PASS for tests.",
+                "rubric_version": "v1",
+            }
         # Blogging: structured content plan JSON (planning agent; token in user prompt)
         elif "content_plan_json_v1" in lowered:
             return {


### PR DESCRIPTION
Implements recommendation #1 from the blogging quality review: an independent
critic agent (own session, own system prompt) evaluates every ContentPlan
against the author's brand spec, writing guidelines, and the 13-rule planning
rubric. Stays on qwen3.5; per-role model diversification is a future concern.

When enabled, the critic's verdict gates planning convergence: the loop
terminates only when the planner self-eval AND the critic agree. Refine-loop
feedback now contains rule-level violations (rule_id, evidence_quote,
suggested_fix) instead of the legacy generic string. Critic reports persist as
plan_critic_report_v{N}.json per iteration plus a stable plan_critic_report.json.

Off by default (BLOG_PLAN_CRITIC_ENABLED=false) for safe rollout; flip on after
golden-set calibration.

- New module: backend/agents/blogging/blog_plan_critic_agent/
  (agent, prompts, models, package init)
- Wires into both BlogWriterAgent.plan_content() (live v2 path) and
  BlogPlanningAgent.run() (the alternate planner used by tests)
- New env vars in shared.planning_config:
  BLOG_PLAN_CRITIC_ENABLED, BLOG_PLAN_CRITIC_MAX_ITERATIONS,
  BLOG_PLAN_CRITIC_MODEL
- Adds plan_critic_report field to PlanningPhaseResult
- Orchestrator constructs critic via build_plan_critic_agent() and passes the
  brand spec + writing guidelines to BlogWriterAgent so the critic can evaluate
  against the author-owned sources of truth
- DummyLLMClient gains a critic-prompt branch returning a stub PASS report so
  tests that enable the critic do not need real LLM connectivity
- 9 new tests in tests/test_blog_plan_critic_agent.py covering PASS/FAIL paths,
  approved-invariant enforcement, parse-failure fallback, artifact persistence,
  refine-feedback ordering, and end-to-end planning integration

https://claude.ai/code/session_01J73VC3zVkyZmqpacv8Zg4m