### PR TITLE
social_marketing: add Postgres-backed Winning Posts Bank + exemplar injection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -215,6 +215,9 @@ Environment variables for LLM: `LLM_PROVIDER`, `LLM_BASE_URL`, `LLM_MODEL`
 | `STRATEGY_LAB_MARKET_DATA_*` | Strategy Lab market-data cache/timeout/provider tuning |
 | `AUTHOR_PROFILE_PATH` | Path to user/author profile YAML injected into blogging prompts. Falls back to `$AGENT_CACHE/author_profile.yaml`, then to the bundled example. See `backend/agents/blogging/author_profile/`. |
 | `AUTHOR_PROFILE_STRICT` | When `true`, missing/invalid profile raises instead of falling back to the bundled example. Recommended for production. |
+| `SOCIAL_MARKETING_WINNING_POSTS_TOP_K` | Max exemplars retrieved from the social marketing Winning Posts Bank per concept run (default `5`). |
+| `SOCIAL_MARKETING_WINNING_POSTS_RERANK_ENABLED` | Enable LLM rerank stage in the Winning Posts Bank retrieval (default `true`; set to `false` to disable). |
+| `SOCIAL_MARKETING_WINNING_POSTS_INGEST_THRESHOLD` | Engagement-score cutoff (0..1) above which performance observations are auto-promoted into the Winning Posts Bank (default `0.7`). |
 
 **Blogging pipeline:** `research → planning (ContentPlan) → writer → gates`; `POST /research-and-review` runs research + the same planning step. See `backend/agents/blogging/README.md` and repo `CHANGELOG.md`.
 

--- a/backend/agents/social_media_marketing_team/agents.py
+++ b/backend/agents/social_media_marketing_team/agents.py
@@ -266,11 +266,13 @@ _CREATIVE_TESTING_ARCHETYPES = [
 ]
 
 
-def _format_exemplar_prefix(exemplars: Optional[List[Dict[str, Any]]]) -> str:
-    """Format Winning Posts Bank exemplars for injection into a concept.
+def _format_exemplar_context(exemplars: Optional[List[Dict[str, Any]]]) -> str:
+    """Format Winning Posts Bank exemplars for the ``prior_winners_context`` field.
 
-    Returns an empty string when no exemplars are supplied so existing
-    concept strings are byte-identical to pre-feature output.
+    Returns an empty string when no exemplars are supplied. Output is
+    stored on its own ``ConceptIdea`` field — never concatenated into
+    ``concept`` — so risk and routing scanners cannot misread terms in
+    exemplar text as belonging to the new concept.
     """
     if not exemplars:
         return ""
@@ -283,7 +285,7 @@ def _format_exemplar_prefix(exemplars: Optional[List[Dict[str, Any]]]) -> str:
         blocks.append(
             f"[Winning post on {platform} — engagement {score:.2f}]\n{title}\n{body}".rstrip()
         )
-    return "Prior winners (reference, do not copy):\n" + "\n\n".join(blocks) + "\n\n"
+    return "Prior winners (reference, do not copy):\n" + "\n\n".join(blocks)
 
 
 @dataclass
@@ -314,10 +316,10 @@ class ContentConceptAgent:
         """Generate a diverse, platform-aware set of candidate concepts.
 
         When *exemplars* are provided (from the Winning Posts Bank),
-        a prefix block listing past winners is prepended to each
-        generated ``concept`` string so downstream writers see
-        reference material without it leaking into scoring or
-        routing fields.
+        the formatted reference block is stored on the
+        ``prior_winners_context`` field. Crucially, it is NOT mixed
+        into ``concept`` so downstream scanners (risk/compliance,
+        routing) only see the agent's own copy.
         """
         base_topics = proposal.messaging_pillars or [
             "Educational insight",
@@ -327,7 +329,7 @@ class ContentConceptAgent:
         linked_goals = goals.goals or ["engagement"]
         archetypes = self._archetypes()
 
-        exemplar_prefix = _format_exemplar_prefix(exemplars)
+        exemplar_context = _format_exemplar_context(exemplars)
 
         ideas: List[ConceptIdea] = []
         idx = 0
@@ -391,7 +393,6 @@ class ContentConceptAgent:
                     ConceptIdea(
                         title=f"{topic} – {archetype_name}",
                         concept=(
-                            f"{exemplar_prefix}"
                             f"{archetype_prompt} {topic.lower()} for {goals.target_audience}. "
                             f"Close with a CTA tied to {goal} and the campaign objective: {proposal.objective}."
                         ),
@@ -405,6 +406,7 @@ class ContentConceptAgent:
                         audience_resonance_score=min(1.0, audience_resonance_score),
                         goal_alignment_score=min(1.0, goal_alignment_score),
                         estimated_engagement_probability=min(1.0, estimated_engagement_probability),
+                        prior_winners_context=exemplar_context,
                     )
                 )
         return ideas

--- a/backend/agents/social_media_marketing_team/agents.py
+++ b/backend/agents/social_media_marketing_team/agents.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Any, Dict, List, Optional
 
 from .models import (
     BrandGoals,
@@ -266,6 +266,26 @@ _CREATIVE_TESTING_ARCHETYPES = [
 ]
 
 
+def _format_exemplar_prefix(exemplars: Optional[List[Dict[str, Any]]]) -> str:
+    """Format Winning Posts Bank exemplars for injection into a concept.
+
+    Returns an empty string when no exemplars are supplied so existing
+    concept strings are byte-identical to pre-feature output.
+    """
+    if not exemplars:
+        return ""
+    blocks: List[str] = []
+    for e in exemplars:
+        platform = str(e.get("platform") or "unknown")
+        score = float(e.get("engagement_score") or 0.0)
+        title = str(e.get("title") or "")
+        body = str(e.get("body") or "")
+        blocks.append(
+            f"[Winning post on {platform} — engagement {score:.2f}]\n{title}\n{body}".rstrip()
+        )
+    return "Prior winners (reference, do not copy):\n" + "\n\n".join(blocks) + "\n\n"
+
+
 @dataclass
 class ContentConceptAgent:
     """Generates candidate post concepts before final filtering.
@@ -286,9 +306,19 @@ class ContentConceptAgent:
         return _STORYTELLING_ARCHETYPES + _CREATIVE_TESTING_ARCHETYPES
 
     def generate_candidates(
-        self, proposal: CampaignProposal, goals: BrandGoals
+        self,
+        proposal: CampaignProposal,
+        goals: BrandGoals,
+        exemplars: Optional[List[Dict[str, Any]]] = None,
     ) -> List[ConceptIdea]:
-        """Generate a diverse, platform-aware set of candidate concepts."""
+        """Generate a diverse, platform-aware set of candidate concepts.
+
+        When *exemplars* are provided (from the Winning Posts Bank),
+        a prefix block listing past winners is prepended to each
+        generated ``concept`` string so downstream writers see
+        reference material without it leaking into scoring or
+        routing fields.
+        """
         base_topics = proposal.messaging_pillars or [
             "Educational insight",
             "Proof point",
@@ -296,6 +326,8 @@ class ContentConceptAgent:
         ]
         linked_goals = goals.goals or ["engagement"]
         archetypes = self._archetypes()
+
+        exemplar_prefix = _format_exemplar_prefix(exemplars)
 
         ideas: List[ConceptIdea] = []
         idx = 0
@@ -359,6 +391,7 @@ class ContentConceptAgent:
                     ConceptIdea(
                         title=f"{topic} – {archetype_name}",
                         concept=(
+                            f"{exemplar_prefix}"
                             f"{archetype_prompt} {topic.lower()} for {goals.target_audience}. "
                             f"Close with a CTA tied to {goal} and the campaign objective: {proposal.objective}."
                         ),

--- a/backend/agents/social_media_marketing_team/api/main.py
+++ b/backend/agents/social_media_marketing_team/api/main.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 import logging
+import os
+import re
 import threading
 import uuid
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
-from typing import List
+from typing import Any, Dict, List, Optional
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Response
 
 from job_service_client import (
     JOB_STATUS_COMPLETED,
@@ -49,6 +51,10 @@ from .request_models import (
     RunMarketingTeamResponse,
     TrendLatestResponse,
     TrendRunResponse,
+    WinningPostCreateRequest,
+    WinningPostCreateResponse,
+    WinningPostDeleteResponse,
+    WinningPostResponse,
 )
 from .trend_scheduler import get_latest_digest, run_trend_job, start_scheduler, stop_scheduler
 
@@ -60,8 +66,25 @@ from .trend_scheduler import get_latest_digest, run_trend_job, start_scheduler, 
 @asynccontextmanager
 async def _lifespan(_application: FastAPI) -> AsyncIterator[None]:
     start_scheduler()
+    try:
+        from shared_postgres import register_team_schemas as _register_team_schemas
+        from social_media_marketing_team.postgres import SCHEMA as _SM_SCHEMA
+
+        _register_team_schemas(_SM_SCHEMA)
+    except Exception:
+        logging.getLogger(__name__).exception(
+            "social marketing postgres schema registration failed"
+        )
     yield
     stop_scheduler()
+    try:
+        from shared_postgres import close_pool as _close_pool
+
+        _close_pool()
+    except Exception:
+        logging.getLogger(__name__).warning(
+            "social marketing shared_postgres close_pool failed", exc_info=True
+        )
 
 
 init_otel(service_name="social-media-marketing-team", team_key="social_marketing")
@@ -94,6 +117,129 @@ def _now() -> str:
 
 def _update_job(job_id: str, **fields) -> None:
     _job_manager.update_job(job_id, **fields)
+
+
+# ---------------------------------------------------------------------------
+# Winning Posts Bank — helpers
+# ---------------------------------------------------------------------------
+
+
+_BANK_TOKEN_RE = re.compile(r"[a-zA-Z][a-zA-Z0-9]+")
+
+
+def _bank_ingest_threshold() -> float:
+    try:
+        return float(os.getenv("SOCIAL_MARKETING_WINNING_POSTS_INGEST_THRESHOLD", "0.7"))
+    except (TypeError, ValueError):
+        return 0.7
+
+
+def _metric_lookup(metrics: List[Any], name: str) -> float:
+    """Return the value of a named metric from a list of MetricDefinition-like objects."""
+    for m in metrics or []:
+        m_name = getattr(m, "name", None)
+        if m_name is None and isinstance(m, dict):
+            m_name = m.get("name")
+        if m_name == name:
+            value = getattr(m, "value", None)
+            if value is None and isinstance(m, dict):
+                value = m.get("value")
+            try:
+                return float(value or 0.0)
+            except (TypeError, ValueError):
+                return 0.0
+    return 0.0
+
+
+def _compute_engagement_score(metrics: List[Any]) -> float:
+    """Derive a 0..1 engagement score from a list of MetricDefinitions.
+
+    Prefers an explicit ``engagement_rate`` metric when present. Falls
+    back to a composite of likes/comments/shares/impressions.
+    """
+    rate = _metric_lookup(metrics, "engagement_rate")
+    if rate > 0:
+        return min(1.0, rate)
+    impressions = _metric_lookup(metrics, "impressions")
+    if impressions <= 0:
+        return 0.0
+    likes = _metric_lookup(metrics, "likes")
+    comments = _metric_lookup(metrics, "comments")
+    shares = _metric_lookup(metrics, "shares")
+    return min(1.0, (likes + 2 * comments + 3 * shares) / impressions)
+
+
+def _tokenize_for_bank(text: str) -> List[str]:
+    seen: set[str] = set()
+    result: List[str] = []
+    for match in _BANK_TOKEN_RE.findall(text or ""):
+        token = match.lower()
+        if len(token) >= 4 and token not in seen:
+            seen.add(token)
+            result.append(token)
+    return result
+
+
+def _linked_goals_from_job(job: Dict[str, Any], concept_title: str) -> List[str]:
+    """Look up linked_goals for a concept_title from a job's result proposal."""
+    result = job.get("result") if isinstance(job, dict) else None
+    if not isinstance(result, dict):
+        return []
+    plan = result.get("content_plan")
+    if isinstance(plan, dict):
+        for idea in plan.get("approved_ideas") or []:
+            if isinstance(idea, dict) and idea.get("title") == concept_title:
+                return list(idea.get("linked_goals") or [])
+    return []
+
+
+def _auto_ingest_winning_posts(job: Dict[str, Any], job_id: str, observations: List[Any]) -> int:
+    """Save observations that beat the engagement threshold to the bank.
+
+    Best-effort: failures are logged and ingestion of other
+    observations continues. Returns the number of rows inserted.
+    """
+    threshold = _bank_ingest_threshold()
+    try:
+        from social_media_marketing_team.shared import save_winning_post
+    except Exception as e:
+        logger.warning("Winning posts bank module unavailable: %s", e)
+        return 0
+
+    inserted = 0
+    for obs in observations or []:
+        try:
+            score = _compute_engagement_score(getattr(obs, "metrics", []) or [])
+            if score < threshold:
+                continue
+            platform = getattr(obs, "platform", "")
+            platform_str = platform.value if hasattr(platform, "value") else str(platform)
+            metrics_dict = {
+                m.name: float(m.value)
+                for m in (getattr(obs, "metrics", None) or [])
+                if getattr(m, "name", None) is not None
+            }
+            keywords = _tokenize_for_bank(
+                f"{getattr(obs, 'concept_title', '')} {getattr(obs, 'campaign_name', '')}"
+            )
+            save_winning_post(
+                title=getattr(obs, "concept_title", ""),
+                body="",
+                platform=platform_str,
+                keywords=keywords,
+                metrics=metrics_dict,
+                engagement_score=score,
+                linked_goals=_linked_goals_from_job(job, getattr(obs, "concept_title", "")),
+                source_job_id=job_id,
+            )
+            inserted += 1
+        except Exception as e:
+            logger.warning("Winning posts bank auto-ingest failed (non-fatal): %s", e)
+    if inserted:
+        logger.info(
+            "Winning posts bank: auto-ingested %d observation(s) from job %s", inserted, job_id
+        )
+    return inserted
 
 
 def mark_all_running_jobs_failed(reason: str) -> None:
@@ -313,6 +459,8 @@ def ingest_performance(job_id: str, payload: PerformanceIngestRequest) -> Perfor
     observations.extend([obs.model_dump() for obs in payload.observations])
     _job_manager.update_job(job_id, performance_observations=observations, last_updated_at=_now())
 
+    _auto_ingest_winning_posts(job, job_id, payload.observations)
+
     campaign_name = None
     result = job.get("result")
     if isinstance(result, dict):
@@ -454,40 +602,56 @@ def delete_marketing_job(job_id: str) -> DeleteMarketingJobResponse:
 def resume_marketing_job(job_id: str) -> RunMarketingTeamResponse:
     """Resume an interrupted marketing job by re-dispatching with stored inputs."""
     try:
-        job = validate_job_for_action(_job_manager.get_job(job_id), job_id, RESUMABLE_STATUSES, "resumed")
+        job = validate_job_for_action(
+            _job_manager.get_job(job_id), job_id, RESUMABLE_STATUSES, "resumed"
+        )
     except ValueError as exc:
         code = 404 if "not found" in str(exc) else 400
         raise HTTPException(status_code=code, detail=str(exc)) from exc
 
     payload = job.get("request_payload")
     if not isinstance(payload, dict):
-        raise HTTPException(status_code=400, detail="Original request payload not available for resume.")
+        raise HTTPException(
+            status_code=400, detail="Original request payload not available for resume."
+        )
 
     request = RunMarketingTeamRequest(**payload)
     _job_manager.update_job(job_id, status=JOB_STATUS_RUNNING, error=None, current_stage="resuming")
     dispatch_msg = _dispatch_job(job_id, request)
-    return RunMarketingTeamResponse(job_id=job_id, status="running", message=f"Job resumed. {dispatch_msg}")
+    return RunMarketingTeamResponse(
+        job_id=job_id, status="running", message=f"Job resumed. {dispatch_msg}"
+    )
 
 
 @app.post("/social-marketing/job/{job_id}/restart", response_model=RunMarketingTeamResponse)
 def restart_marketing_job(job_id: str) -> RunMarketingTeamResponse:
     """Restart a marketing job from scratch with the same inputs."""
     try:
-        job = validate_job_for_action(_job_manager.get_job(job_id), job_id, RESTARTABLE_STATUSES, "restarted")
+        job = validate_job_for_action(
+            _job_manager.get_job(job_id), job_id, RESTARTABLE_STATUSES, "restarted"
+        )
     except ValueError as exc:
         code = 404 if "not found" in str(exc) else 400
         raise HTTPException(status_code=code, detail=str(exc)) from exc
 
     payload = job.get("request_payload")
     if not isinstance(payload, dict):
-        raise HTTPException(status_code=400, detail="Original request payload not available for restart.")
+        raise HTTPException(
+            status_code=400, detail="Original request payload not available for restart."
+        )
 
     request = RunMarketingTeamRequest(**payload)
     _job_manager.update_job(
-        job_id, status=JOB_STATUS_PENDING, error=None, progress=0, current_stage="restart_queued",
+        job_id,
+        status=JOB_STATUS_PENDING,
+        error=None,
+        progress=0,
+        current_stage="restart_queued",
     )
     dispatch_msg = _dispatch_job(job_id, request)
-    return RunMarketingTeamResponse(job_id=job_id, status="running", message=f"Job restarted. {dispatch_msg}")
+    return RunMarketingTeamResponse(
+        job_id=job_id, status="running", message=f"Job restarted. {dispatch_msg}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -515,6 +679,93 @@ def get_latest_trends() -> TrendLatestResponse:
             detail="No trend digest available yet. Trigger one via POST /social-marketing/trends/run.",
         )
     return TrendLatestResponse(digest=digest)
+
+
+# ---------------------------------------------------------------------------
+# Routes — Winning Posts Bank
+# ---------------------------------------------------------------------------
+
+
+def _bank_503(exc: Exception) -> HTTPException:
+    """Translate bank-layer errors into an explicit 503 at the CRUD boundary."""
+    return HTTPException(
+        status_code=503,
+        detail=(
+            "Winning posts bank unavailable "
+            f"(is POSTGRES_HOST configured?): {type(exc).__name__}: {exc}"
+        ),
+    )
+
+
+@app.post(
+    "/social-marketing/winning-posts",
+    response_model=WinningPostCreateResponse,
+    status_code=201,
+)
+def create_winning_post(payload: WinningPostCreateRequest) -> WinningPostCreateResponse:
+    try:
+        from social_media_marketing_team.shared import save_winning_post
+    except Exception as e:
+        raise _bank_503(e) from e
+    try:
+        post_id = save_winning_post(
+            title=payload.title,
+            body=payload.body,
+            platform=payload.platform,
+            keywords=list(payload.keywords),
+            metrics=dict(payload.metrics),
+            engagement_score=payload.engagement_score,
+            linked_goals=list(payload.linked_goals),
+            source_job_id=payload.source_job_id,
+            summary=payload.summary,
+        )
+    except Exception as e:
+        raise _bank_503(e) from e
+    return WinningPostCreateResponse(id=post_id)
+
+
+@app.get("/social-marketing/winning-posts", response_model=List[WinningPostResponse])
+def list_winning_posts_route(limit: int = 50, offset: int = 0) -> List[WinningPostResponse]:
+    try:
+        from social_media_marketing_team.shared import list_winning_posts
+    except Exception as e:
+        raise _bank_503(e) from e
+    try:
+        rows = list_winning_posts(limit=max(1, min(limit, 500)), offset=max(0, offset))
+    except Exception as e:
+        raise _bank_503(e) from e
+    return [WinningPostResponse(**r) for r in rows]
+
+
+@app.get("/social-marketing/winning-posts/{post_id}", response_model=WinningPostResponse)
+def get_winning_post_route(post_id: str) -> WinningPostResponse:
+    try:
+        from social_media_marketing_team.shared import get_winning_post
+    except Exception as e:
+        raise _bank_503(e) from e
+    try:
+        row: Optional[Dict[str, Any]] = get_winning_post(post_id)
+    except Exception as e:
+        raise _bank_503(e) from e
+    if row is None:
+        raise HTTPException(status_code=404, detail=f"Winning post {post_id} not found")
+    return WinningPostResponse(**row)
+
+
+@app.delete("/social-marketing/winning-posts/{post_id}", response_model=WinningPostDeleteResponse)
+def delete_winning_post_route(post_id: str, response: Response) -> WinningPostDeleteResponse:
+    try:
+        from social_media_marketing_team.shared import delete_winning_post
+    except Exception as e:
+        raise _bank_503(e) from e
+    try:
+        removed = delete_winning_post(post_id)
+    except Exception as e:
+        raise _bank_503(e) from e
+    if not removed:
+        raise HTTPException(status_code=404, detail=f"Winning post {post_id} not found")
+    response.status_code = 200
+    return WinningPostDeleteResponse(id=post_id)
 
 
 @app.get("/health")

--- a/backend/agents/social_media_marketing_team/api/request_models.py
+++ b/backend/agents/social_media_marketing_team/api/request_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -99,3 +99,39 @@ class TrendRunResponse(BaseModel):
 
 class TrendLatestResponse(BaseModel):
     digest: TrendDigest
+
+
+class WinningPostCreateRequest(BaseModel):
+    title: str = Field(..., min_length=1, max_length=500)
+    body: str = Field(default="", max_length=50_000)
+    platform: str = Field(default="", max_length=64)
+    keywords: List[str] = Field(default_factory=list)
+    metrics: Dict[str, float] = Field(default_factory=dict)
+    engagement_score: float = Field(default=0.0, ge=0.0, le=1.0)
+    linked_goals: List[str] = Field(default_factory=list)
+    source_job_id: Optional[str] = Field(default=None, max_length=256)
+    summary: Optional[str] = Field(default=None, max_length=2_000)
+
+
+class WinningPostResponse(BaseModel):
+    id: str
+    title: str
+    body: str
+    platform: str
+    keywords: List[str]
+    metrics: Dict[str, Any]
+    engagement_score: float
+    linked_goals: List[str]
+    summary: str
+    source_job_id: Optional[str] = None
+    created_at: str
+
+
+class WinningPostCreateResponse(BaseModel):
+    id: str
+    message: str = "Winning post saved."
+
+
+class WinningPostDeleteResponse(BaseModel):
+    id: str
+    message: str = "Winning post deleted."

--- a/backend/agents/social_media_marketing_team/models.py
+++ b/backend/agents/social_media_marketing_team/models.py
@@ -67,6 +67,10 @@ class ConceptIdea(BaseModel):
     estimated_engagement_probability: float = Field(ge=0, le=1)
     risk_level: str = "low"
     risk_reasons: List[str] = Field(default_factory=list)
+    # Reference exemplars from the Winning Posts Bank. Stored on a
+    # separate field — never inlined into ``concept`` — so risk and
+    # routing scanners only see the agent's own copy.
+    prior_winners_context: str = ""
 
 
 class ContentPlan(BaseModel):

--- a/backend/agents/social_media_marketing_team/orchestrator.py
+++ b/backend/agents/social_media_marketing_team/orchestrator.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from typing import Dict, List
+import logging
+import os
+import re
+from typing import Any, Dict, List, Optional
 
 from .agents import (
     CampaignCollaborationAgent,
@@ -22,6 +25,69 @@ from .models import (
     Platform,
     TeamOutput,
 )
+
+logger = logging.getLogger(__name__)
+
+_TOKEN_RE = re.compile(r"[a-zA-Z][a-zA-Z0-9]+")
+
+
+def _extract_bank_keywords(goals: BrandGoals) -> List[str]:
+    """Extract ≥4-char lowercase tokens from BrandGoals for bank retrieval."""
+    sources: List[str] = []
+    sources.append(goals.target_audience or "")
+    sources.extend(goals.goals or [])
+    sources.extend(goals.messaging_pillars or [])
+    sources.append(goals.brand_objectives or "")
+    seen: set[str] = set()
+    result: List[str] = []
+    for text in sources:
+        for match in _TOKEN_RE.findall(text):
+            token = match.lower()
+            if len(token) >= 4 and token not in seen:
+                seen.add(token)
+                result.append(token)
+    return result
+
+
+def _bank_top_k() -> int:
+    try:
+        return int(os.getenv("SOCIAL_MARKETING_WINNING_POSTS_TOP_K", "5"))
+    except (TypeError, ValueError):
+        return 5
+
+
+def _retrieve_exemplars(
+    proposal: CampaignProposal, goals: BrandGoals, llm_client: Any
+) -> List[Dict[str, Any]]:
+    """Best-effort retrieval of exemplars from the Winning Posts Bank.
+
+    Returns ``[]`` on any failure (Postgres disabled, empty keyword
+    set, LLM rerank error) so orchestration never regresses.
+    """
+    keywords = _extract_bank_keywords(goals)
+    if not keywords:
+        return []
+    platforms: Optional[List[str]] = (
+        [p.value for p in proposal.channel_mix_strategy.keys()]
+        if proposal.channel_mix_strategy
+        else None
+    )
+    try:
+        from .shared import find_relevant_winning_posts
+
+        exemplars = find_relevant_winning_posts(
+            query_keywords=keywords,
+            limit=_bank_top_k(),
+            platforms=platforms,
+            rerank_context=proposal.objective,
+            llm_client=llm_client,
+        )
+        if exemplars:
+            logger.info("Winning posts bank: %d exemplar(s) injected", len(exemplars))
+        return exemplars
+    except Exception as e:
+        logger.warning("Winning posts bank retrieval failed (non-fatal): %s", e)
+        return []
 
 
 class SocialMediaMarketingOrchestrator:
@@ -196,9 +262,11 @@ class SocialMediaMarketingOrchestrator:
     ) -> ContentPlan:
         required_posts = goals.cadence_posts_per_day * goals.duration_days
 
+        exemplars = _retrieve_exemplars(proposal, goals, getattr(self, "_llm_client", None))
+
         candidates: List[ConceptIdea] = []
         for agent in self.concept_team:
-            candidates.extend(agent.generate_candidates(proposal, goals))
+            candidates.extend(agent.generate_candidates(proposal, goals, exemplars=exemplars))
 
         candidates = self._goal_traceability_filter(candidates, goals)
         candidates = self._calibrate_probabilities(candidates, performance)

--- a/backend/agents/social_media_marketing_team/postgres/__init__.py
+++ b/backend/agents/social_media_marketing_team/postgres/__init__.py
@@ -1,0 +1,39 @@
+"""Postgres schema for the social media marketing team.
+
+Declares the ``social_marketing_winning_posts`` table used by
+``shared/winning_posts_bank.py``. Registered from the team's FastAPI
+lifespan via ``shared_postgres.register_team_schemas``.
+"""
+
+from __future__ import annotations
+
+from shared_postgres import TeamSchema
+
+SCHEMA = TeamSchema(
+    team="social_marketing",
+    database=None,
+    statements=[
+        """CREATE TABLE IF NOT EXISTS social_marketing_winning_posts (
+            id                TEXT PRIMARY KEY,
+            title             TEXT NOT NULL,
+            body              TEXT NOT NULL,
+            platform          TEXT NOT NULL DEFAULT '',
+            keywords          JSONB NOT NULL DEFAULT '[]'::jsonb,
+            metrics           JSONB NOT NULL DEFAULT '{}'::jsonb,
+            engagement_score  DOUBLE PRECISION NOT NULL DEFAULT 0,
+            linked_goals      JSONB NOT NULL DEFAULT '[]'::jsonb,
+            summary           TEXT NOT NULL DEFAULT '',
+            source_job_id     TEXT,
+            created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_social_winning_posts_platform
+            ON social_marketing_winning_posts(platform)""",
+        """CREATE INDEX IF NOT EXISTS idx_social_winning_posts_source_job
+            ON social_marketing_winning_posts(source_job_id)""",
+        """CREATE INDEX IF NOT EXISTS idx_social_winning_posts_created
+            ON social_marketing_winning_posts(created_at DESC)""",
+        """CREATE INDEX IF NOT EXISTS idx_social_winning_posts_score
+            ON social_marketing_winning_posts(engagement_score DESC)""",
+    ],
+    table_names=["social_marketing_winning_posts"],
+)

--- a/backend/agents/social_media_marketing_team/shared/__init__.py
+++ b/backend/agents/social_media_marketing_team/shared/__init__.py
@@ -1,0 +1,17 @@
+"""Shared utilities for the social media marketing team."""
+
+from .winning_posts_bank import (
+    delete_winning_post,
+    find_relevant_winning_posts,
+    get_winning_post,
+    list_winning_posts,
+    save_winning_post,
+)
+
+__all__ = [
+    "delete_winning_post",
+    "find_relevant_winning_posts",
+    "get_winning_post",
+    "list_winning_posts",
+    "save_winning_post",
+]

--- a/backend/agents/social_media_marketing_team/shared/winning_posts_bank.py
+++ b/backend/agents/social_media_marketing_team/shared/winning_posts_bank.py
@@ -1,0 +1,305 @@
+"""Postgres-backed bank of winning social-media posts.
+
+Ported from ``blogging.shared.story_bank``. Stores posts whose
+engagement signals beat a configurable threshold, tagged with
+keywords, platform, metrics, and a one-sentence semantic summary, so
+they can be retrieved and injected as exemplars into future
+concept-generation prompts.
+
+Retrieval is two-stage:
+  1. Keyword overlap (set intersection) picks candidates, optionally
+     filtered by platform.
+  2. If an ``rerank_context`` and ``llm_client`` are supplied and the
+     ``SOCIAL_MARKETING_WINNING_POSTS_RERANK_ENABLED`` flag is on, an
+     LLM reranks candidates-with-summaries by semantic relevance.
+
+Storage: ``social_marketing_winning_posts`` table declared in
+``social_media_marketing_team.postgres``. This module is pure data
+access via ``shared_postgres.get_conn``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, Optional
+
+from psycopg.rows import dict_row
+
+from shared_postgres import Json, get_conn
+from shared_postgres.metrics import timed_query
+
+logger = logging.getLogger(__name__)
+
+_STORE = "social_marketing_winning_posts_bank"
+
+
+def _rerank_enabled() -> bool:
+    return os.getenv("SOCIAL_MARKETING_WINNING_POSTS_RERANK_ENABLED", "true").lower() not in (
+        "0",
+        "false",
+        "no",
+        "",
+    )
+
+
+def _row_ts(value: Any) -> str:
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return str(value or "")
+
+
+def _to_float(value: Any) -> float:
+    if isinstance(value, Decimal):
+        return float(value)
+    if value is None:
+        return 0.0
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _row_to_dict(row: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a ``dict_row`` cursor row into the public dict shape."""
+    return {
+        "id": row["id"],
+        "title": row["title"],
+        "body": row["body"],
+        "platform": row["platform"] or "",
+        "keywords": list(row["keywords"] or []),
+        "metrics": dict(row["metrics"] or {}),
+        "engagement_score": _to_float(row["engagement_score"]),
+        "linked_goals": list(row["linked_goals"] or []),
+        "summary": row["summary"] or "",
+        "source_job_id": row.get("source_job_id"),
+        "created_at": _row_ts(row["created_at"]),
+    }
+
+
+_SELECT_COLS = (
+    "id, title, body, platform, keywords, metrics, engagement_score, "
+    "linked_goals, summary, source_job_id, created_at"
+)
+
+
+@timed_query(store=_STORE, op="save_winning_post")
+def save_winning_post(
+    title: str,
+    body: str,
+    platform: str = "",
+    keywords: Optional[list[str]] = None,
+    metrics: Optional[dict[str, Any]] = None,
+    engagement_score: float = 0.0,
+    linked_goals: Optional[list[str]] = None,
+    source_job_id: Optional[str] = None,
+    summary: Optional[str] = None,
+    llm_client: Any = None,
+) -> str:
+    """Persist a winning post and return its ID.
+
+    If *summary* is None and *llm_client* is provided, generates a
+    one-sentence semantic summary for improved retrieval. Summary
+    generation is best-effort; failures are logged and the row still
+    lands with ``summary=''``.
+    """
+    post_id = uuid.uuid4().hex[:12]
+    now = datetime.now(timezone.utc)
+
+    if summary is None and llm_client is not None and body:
+        try:
+            summary = (
+                llm_client.complete(
+                    f"Summarize this social post in one sentence:\n\n{title}\n\n{body}",
+                    system_prompt="Write a single sentence summary. No preamble, no quotes.",
+                )
+                or ""
+            ).strip()
+        except Exception as e:
+            logger.warning("Winning posts bank: summary generation failed (non-fatal): %s", e)
+            summary = ""
+
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO social_marketing_winning_posts "
+            "(id, title, body, platform, keywords, metrics, engagement_score, "
+            "linked_goals, summary, source_job_id, created_at) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)",
+            (
+                post_id,
+                title,
+                body,
+                platform or "",
+                Json(list(keywords or [])),
+                Json(dict(metrics or {})),
+                float(engagement_score or 0.0),
+                Json(list(linked_goals or [])),
+                summary or "",
+                source_job_id,
+                now,
+            ),
+        )
+
+    logger.info(
+        "Winning posts bank: saved %s (platform=%s, score=%.2f, has_summary=%s)",
+        post_id,
+        platform,
+        float(engagement_score or 0.0),
+        bool(summary),
+    )
+    return post_id
+
+
+@timed_query(store=_STORE, op="find_relevant_winning_posts")
+def find_relevant_winning_posts(
+    query_keywords: list[str],
+    limit: int = 5,
+    platforms: Optional[list[str]] = None,
+    rerank_context: Optional[str] = None,
+    llm_client: Any = None,
+) -> list[dict[str, Any]]:
+    """Return winning posts relevant to *query_keywords*, ranked by relevance.
+
+    Two-stage retrieval:
+      1. Keyword overlap (set intersection); optionally filtered by
+         ``platforms`` (matches ``platform = ANY(...)``).
+      2. Optional LLM rerank when ``rerank_context`` + ``llm_client``
+         are supplied and more candidates-with-summaries than *limit*
+         exist.
+    """
+    if not query_keywords:
+        return []
+
+    candidates = _keyword_scored_candidates(
+        query_keywords, limit=max(limit, 10), platforms=platforms
+    )
+    if not candidates:
+        return []
+
+    candidates_with_summaries = [c for c in candidates if c.get("summary")]
+    if (
+        rerank_context
+        and llm_client
+        and _rerank_enabled()
+        and len(candidates_with_summaries) > limit
+    ):
+        reranked = _llm_rerank(candidates_with_summaries, rerank_context, llm_client, limit)
+        if reranked:
+            return reranked
+
+    return candidates[:limit]
+
+
+def _keyword_scored_candidates(
+    query_keywords: list[str],
+    limit: int = 10,
+    platforms: Optional[list[str]] = None,
+) -> list[dict[str, Any]]:
+    """Retrieve winning posts ranked by keyword-overlap count.
+
+    Reads every row (optionally pre-filtered by platform) because the
+    table is low-volume. Scoring is done in Python; a future
+    optimization could push the overlap into Postgres via the JSONB
+    ``?|`` operator.
+    """
+    with get_conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+        if platforms:
+            cur.execute(
+                f"SELECT {_SELECT_COLS} FROM social_marketing_winning_posts "
+                "WHERE platform = ANY(%s)",
+                (list(platforms),),
+            )
+        else:
+            cur.execute(f"SELECT {_SELECT_COLS} FROM social_marketing_winning_posts")
+        rows = cur.fetchall()
+
+    query_lower = {k.lower().strip() for k in query_keywords if k and k.strip()}
+    if not query_lower:
+        return []
+
+    scored: list[tuple[int, float, dict[str, Any]]] = []
+    for row in rows:
+        post_kw = {str(k).lower().strip() for k in (row["keywords"] or [])}
+        overlap = len(query_lower & post_kw)
+        if overlap > 0:
+            row_dict = _row_to_dict(row)
+            scored.append((overlap, row_dict["engagement_score"], row_dict))
+
+    # Primary: overlap count desc. Secondary: engagement_score desc.
+    scored.sort(key=lambda t: (t[0], t[1]), reverse=True)
+    return [item for _, _, item in scored[:limit]]
+
+
+def _llm_rerank(
+    candidates: list[dict[str, Any]],
+    rerank_context: str,
+    llm_client: Any,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Use an LLM to rerank candidates by semantic relevance."""
+    summaries = "\n".join(f"{i + 1}. {c['summary']}" for i, c in enumerate(candidates))
+    prompt = (
+        f"Context: {rerank_context}\n\n"
+        f"Candidate winning posts (by summary):\n{summaries}\n\n"
+        f"Return a JSON array of the top {limit} indices (1-based) ranked by relevance "
+        f"to the context. Most relevant first."
+    )
+    try:
+        data = llm_client.complete_json(
+            prompt,
+            system_prompt="Return a JSON array of integers only. No other text.",
+        )
+        indices = data if isinstance(data, list) else data.get("indices", data.get("text", []))
+        if isinstance(indices, list):
+            reranked: list[dict[str, Any]] = []
+            for idx in indices[:limit]:
+                try:
+                    i = int(idx) - 1
+                except (TypeError, ValueError):
+                    continue
+                if 0 <= i < len(candidates):
+                    reranked.append(candidates[i])
+            if reranked:
+                return reranked
+    except Exception as e:
+        logger.warning(
+            "Winning posts bank LLM rerank failed (falling back to keyword scoring): %s", e
+        )
+    return []
+
+
+@timed_query(store=_STORE, op="list_winning_posts")
+def list_winning_posts(limit: int = 50, offset: int = 0) -> list[dict[str, Any]]:
+    """Return winning posts, newest first, with LIMIT/OFFSET pagination."""
+    with get_conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            f"SELECT {_SELECT_COLS} FROM social_marketing_winning_posts "
+            "ORDER BY created_at DESC LIMIT %s OFFSET %s",
+            (limit, offset),
+        )
+        return [_row_to_dict(r) for r in cur.fetchall()]
+
+
+@timed_query(store=_STORE, op="get_winning_post")
+def get_winning_post(post_id: str) -> Optional[dict[str, Any]]:
+    """Return a single winning post by ID, or None."""
+    with get_conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            f"SELECT {_SELECT_COLS} FROM social_marketing_winning_posts WHERE id = %s",
+            (post_id,),
+        )
+        row = cur.fetchone()
+        if not row:
+            return None
+        return _row_to_dict(row)
+
+
+@timed_query(store=_STORE, op="delete_winning_post")
+def delete_winning_post(post_id: str) -> bool:
+    """Delete a winning post by ID. Returns True if a row was removed."""
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute("DELETE FROM social_marketing_winning_posts WHERE id = %s", (post_id,))
+        return cur.rowcount > 0

--- a/backend/agents/social_media_marketing_team/tests/test_exemplar_injection.py
+++ b/backend/agents/social_media_marketing_team/tests/test_exemplar_injection.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 from social_media_marketing_team.agents import (
     ContentConceptAgent,
-    _format_exemplar_prefix,
+    RiskComplianceAgent,
+    _format_exemplar_context,
 )
 from social_media_marketing_team.models import CampaignProposal, Platform
 from social_media_marketing_team.tests.conftest import make_goals
@@ -20,13 +21,13 @@ def _proposal() -> CampaignProposal:
     )
 
 
-def test_format_prefix_empty_returns_empty_string():
-    assert _format_exemplar_prefix(None) == ""
-    assert _format_exemplar_prefix([]) == ""
+def test_format_context_empty_returns_empty_string():
+    assert _format_exemplar_context(None) == ""
+    assert _format_exemplar_context([]) == ""
 
 
-def test_format_prefix_renders_blocks():
-    prefix = _format_exemplar_prefix(
+def test_format_context_renders_blocks():
+    ctx = _format_exemplar_context(
         [
             {
                 "platform": "linkedin",
@@ -36,13 +37,12 @@ def test_format_prefix_renders_blocks():
             }
         ]
     )
-    assert "Prior winners (reference, do not copy):" in prefix
-    assert "[Winning post on linkedin — engagement 0.84]" in prefix
-    assert "Why seed rounds fail" in prefix
-    assert prefix.endswith("\n\n")
+    assert "Prior winners (reference, do not copy):" in ctx
+    assert "[Winning post on linkedin — engagement 0.84]" in ctx
+    assert "Why seed rounds fail" in ctx
 
 
-def test_generate_candidates_injects_exemplars_into_concept():
+def test_generate_candidates_writes_exemplars_to_separate_field():
     agent = ContentConceptAgent("Brand Storytelling Lead")
     goals = make_goals()
     proposal = _proposal()
@@ -58,13 +58,17 @@ def test_generate_candidates_injects_exemplars_into_concept():
     ideas = agent.generate_candidates(proposal, goals, exemplars=exemplars)
     assert ideas, "Expected at least one generated idea"
     for idea in ideas:
-        assert "[Winning post on linkedin — engagement 0.91]" in idea.concept
-        assert "Our $100k pricing mistake" in idea.concept
-        assert idea.concept.startswith("Prior winners (reference, do not copy):")
+        # Exemplar text lives on its own field …
+        assert "[Winning post on linkedin — engagement 0.91]" in idea.prior_winners_context
+        assert "Our $100k pricing mistake" in idea.prior_winners_context
+        # … and never leaks into the concept the agent actually wrote.
+        assert "[Winning post on" not in idea.concept
+        assert "Prior winners" not in idea.concept
+        assert "Our $100k pricing mistake" not in idea.concept
 
 
-def test_generate_candidates_without_exemplars_matches_legacy_output():
-    """Regression guard: exemplars=None must leave concept strings unchanged."""
+def test_generate_candidates_without_exemplars_leaves_field_empty():
+    """Regression guard: no exemplars → empty context, concept unchanged."""
     agent = ContentConceptAgent("Brand Storytelling Lead")
     goals = make_goals()
     proposal = _proposal()
@@ -72,7 +76,8 @@ def test_generate_candidates_without_exemplars_matches_legacy_output():
     ideas_none = agent.generate_candidates(proposal, goals)
     ideas_empty = agent.generate_candidates(proposal, goals, exemplars=[])
 
-    for idea in ideas_none:
+    for idea in ideas_none + ideas_empty:
+        assert idea.prior_winners_context == ""
         assert "[Winning post on" not in idea.concept
         assert "Prior winners" not in idea.concept
 
@@ -93,6 +98,38 @@ def test_generate_candidates_preserves_scoring_with_exemplars():
 
     assert len(without) == len(with_ex)
     for a, b in zip(without, with_ex):
+        assert a.concept == b.concept  # exemplar must not change the agent's own copy
         assert a.brand_fit_score == b.brand_fit_score
         assert a.audience_resonance_score == b.audience_resonance_score
         assert a.goal_alignment_score == b.goal_alignment_score
+
+
+def test_risk_scorer_ignores_banned_terms_inside_exemplar():
+    """Critical: a winning post containing 'guarantee'/'overnight' must NOT
+    cause clean new concepts to be flagged high-risk."""
+    agent = ContentConceptAgent("Brand Storytelling Lead")
+    goals = make_goals()
+    proposal = _proposal()
+
+    poisoned_exemplars = [
+        {
+            "platform": "linkedin",
+            "engagement_score": 0.95,
+            "title": "We guarantee overnight results",
+            "body": "No risk, instant ROI for every customer.",
+        }
+    ]
+
+    ideas = agent.generate_candidates(proposal, goals, exemplars=poisoned_exemplars)
+    reviewer = RiskComplianceAgent()
+    reviewed = [reviewer.review_concept(i, goals) for i in ideas]
+
+    assert reviewed, "Expected at least one reviewed idea"
+    for idea in reviewed:
+        # The exemplar carries banned terms, but the new concept is clean.
+        assert idea.risk_level == "low", (
+            f"Exemplar text leaked into risk scoring: "
+            f"risk_level={idea.risk_level}, reasons={idea.risk_reasons}, "
+            f"concept={idea.concept!r}"
+        )
+        assert not any("risky claim" in r for r in idea.risk_reasons)

--- a/backend/agents/social_media_marketing_team/tests/test_exemplar_injection.py
+++ b/backend/agents/social_media_marketing_team/tests/test_exemplar_injection.py
@@ -1,0 +1,98 @@
+"""Tests for Winning Posts Bank exemplar injection into ContentConceptAgent."""
+
+from __future__ import annotations
+
+from social_media_marketing_team.agents import (
+    ContentConceptAgent,
+    _format_exemplar_prefix,
+)
+from social_media_marketing_team.models import CampaignProposal, Platform
+from social_media_marketing_team.tests.conftest import make_goals
+
+
+def _proposal() -> CampaignProposal:
+    return CampaignProposal(
+        campaign_name="Q2 growth sprint",
+        objective="Drive qualified inbound",
+        audience_hypothesis="Founders struggle with seed-stage GTM",
+        messaging_pillars=["Pricing", "Traction"],
+        channel_mix_strategy={Platform.LINKEDIN: "lead-gen"},
+    )
+
+
+def test_format_prefix_empty_returns_empty_string():
+    assert _format_exemplar_prefix(None) == ""
+    assert _format_exemplar_prefix([]) == ""
+
+
+def test_format_prefix_renders_blocks():
+    prefix = _format_exemplar_prefix(
+        [
+            {
+                "platform": "linkedin",
+                "engagement_score": 0.84,
+                "title": "Why seed rounds fail",
+                "body": "Founders skip...",
+            }
+        ]
+    )
+    assert "Prior winners (reference, do not copy):" in prefix
+    assert "[Winning post on linkedin — engagement 0.84]" in prefix
+    assert "Why seed rounds fail" in prefix
+    assert prefix.endswith("\n\n")
+
+
+def test_generate_candidates_injects_exemplars_into_concept():
+    agent = ContentConceptAgent("Brand Storytelling Lead")
+    goals = make_goals()
+    proposal = _proposal()
+    exemplars = [
+        {
+            "platform": "linkedin",
+            "engagement_score": 0.91,
+            "title": "Our $100k pricing mistake",
+            "body": "We almost lost 40% of customers...",
+        }
+    ]
+
+    ideas = agent.generate_candidates(proposal, goals, exemplars=exemplars)
+    assert ideas, "Expected at least one generated idea"
+    for idea in ideas:
+        assert "[Winning post on linkedin — engagement 0.91]" in idea.concept
+        assert "Our $100k pricing mistake" in idea.concept
+        assert idea.concept.startswith("Prior winners (reference, do not copy):")
+
+
+def test_generate_candidates_without_exemplars_matches_legacy_output():
+    """Regression guard: exemplars=None must leave concept strings unchanged."""
+    agent = ContentConceptAgent("Brand Storytelling Lead")
+    goals = make_goals()
+    proposal = _proposal()
+
+    ideas_none = agent.generate_candidates(proposal, goals)
+    ideas_empty = agent.generate_candidates(proposal, goals, exemplars=[])
+
+    for idea in ideas_none:
+        assert "[Winning post on" not in idea.concept
+        assert "Prior winners" not in idea.concept
+
+    assert [i.concept for i in ideas_none] == [i.concept for i in ideas_empty]
+
+
+def test_generate_candidates_preserves_scoring_with_exemplars():
+    agent = ContentConceptAgent("Brand Storytelling Lead")
+    goals = make_goals()
+    proposal = _proposal()
+
+    without = agent.generate_candidates(proposal, goals)
+    with_ex = agent.generate_candidates(
+        proposal,
+        goals,
+        exemplars=[{"platform": "x", "engagement_score": 0.5, "title": "t", "body": "b"}],
+    )
+
+    assert len(without) == len(with_ex)
+    for a, b in zip(without, with_ex):
+        assert a.brand_fit_score == b.brand_fit_score
+        assert a.audience_resonance_score == b.audience_resonance_score
+        assert a.goal_alignment_score == b.goal_alignment_score

--- a/backend/agents/social_media_marketing_team/tests/test_orchestrator_additional.py
+++ b/backend/agents/social_media_marketing_team/tests/test_orchestrator_additional.py
@@ -52,7 +52,9 @@ def test_plan_content_handles_no_initially_approved_ideas() -> None:
     goals = _goals()
 
     class LowConfidenceAgent(ContentConceptAgent):
-        def generate_candidates(self, proposal: CampaignProposal, goals: BrandGoals):
+        def generate_candidates(
+            self, proposal: CampaignProposal, goals: BrandGoals, exemplars=None
+        ):
             return [
                 ConceptIdea(
                     title="Low confidence",

--- a/backend/agents/social_media_marketing_team/tests/test_orchestrator_exemplar_wiring.py
+++ b/backend/agents/social_media_marketing_team/tests/test_orchestrator_exemplar_wiring.py
@@ -1,0 +1,165 @@
+"""Tests for orchestrator-level Winning Posts Bank wiring."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import pytest
+
+from social_media_marketing_team import orchestrator as orch_mod
+from social_media_marketing_team.models import BrandGoals, CampaignProposal, Platform
+from social_media_marketing_team.tests.conftest import make_goals
+
+
+def test_extract_bank_keywords_filters_short_tokens():
+    goals = make_goals(
+        target_audience="B2B SaaS founders",
+        goals=["engagement", "followers"],
+        messaging_pillars=["Pricing strategies"],
+        brand_objectives="Drive qualified demo requests",
+    )
+    keywords = orch_mod._extract_bank_keywords(goals)
+    assert "founders" in keywords
+    assert "saas" in keywords
+    assert "engagement" in keywords
+    assert "pricing" in keywords
+    assert "strategies" in keywords
+    # "b2b" is 3 chars after token-split → excluded by ≥4 filter.
+    assert "b2b" not in keywords
+
+
+def test_extract_bank_keywords_dedupes_case_insensitively():
+    goals = make_goals(
+        target_audience="Founders founders FOUNDERS",
+        goals=["growth"],
+    )
+    keywords = orch_mod._extract_bank_keywords(goals)
+    assert keywords.count("founders") == 1
+
+
+def test_retrieve_exemplars_returns_empty_when_no_keywords(monkeypatch):
+    goals = BrandGoals(
+        brand_name="N",
+        target_audience="a",  # ≤3 chars, filtered
+        goals=["x"],
+        messaging_pillars=[],
+        brand_objectives="",
+    )
+    proposal = CampaignProposal(
+        campaign_name="c",
+        objective="x",
+        audience_hypothesis="h",
+    )
+
+    called = {"yes": False}
+
+    def _fake_find(*args, **kwargs):
+        called["yes"] = True
+        return [{"id": "x"}]
+
+    monkeypatch.setattr(
+        "social_media_marketing_team.shared.find_relevant_winning_posts",
+        _fake_find,
+    )
+    result = orch_mod._retrieve_exemplars(proposal, goals, llm_client=None)
+    assert result == []
+    assert called["yes"] is False
+
+
+def test_retrieve_exemplars_passes_platforms_and_context(monkeypatch):
+    goals = make_goals(target_audience="founders", goals=["growth"])
+    proposal = CampaignProposal(
+        campaign_name="c",
+        objective="drive qualified pipeline",
+        audience_hypothesis="h",
+        channel_mix_strategy={Platform.LINKEDIN: "lead-gen", Platform.X: "awareness"},
+    )
+
+    captured: Dict[str, Any] = {}
+
+    def _fake_find(**kwargs):
+        captured.update(kwargs)
+        return [{"id": "e1", "platform": "linkedin"}]
+
+    monkeypatch.setattr(
+        "social_media_marketing_team.shared.find_relevant_winning_posts",
+        _fake_find,
+    )
+    result = orch_mod._retrieve_exemplars(proposal, goals, llm_client="LLM")
+    assert result == [{"id": "e1", "platform": "linkedin"}]
+    assert set(captured["platforms"]) == {"linkedin", "x"}
+    assert captured["rerank_context"] == "drive qualified pipeline"
+    assert captured["llm_client"] == "LLM"
+    assert "founders" in captured["query_keywords"]
+
+
+def test_retrieve_exemplars_swallows_failure(monkeypatch, caplog):
+    goals = make_goals(target_audience="founders", goals=["growth"])
+    proposal = CampaignProposal(
+        campaign_name="c",
+        objective="drive",
+        audience_hypothesis="h",
+    )
+
+    def _boom(**kwargs):
+        raise RuntimeError("pg disabled")
+
+    monkeypatch.setattr(
+        "social_media_marketing_team.shared.find_relevant_winning_posts",
+        _boom,
+    )
+    with caplog.at_level("WARNING"):
+        result = orch_mod._retrieve_exemplars(proposal, goals, llm_client=None)
+    assert result == []
+    assert any("Winning posts bank retrieval failed" in rec.message for rec in caplog.records)
+
+
+def test_plan_content_passes_exemplars_to_every_concept_agent(monkeypatch):
+    """Orchestrator must forward retrieved exemplars to each concept agent."""
+    from social_media_marketing_team.orchestrator import SocialMediaMarketingOrchestrator
+
+    orch = SocialMediaMarketingOrchestrator()
+
+    canned: List[Dict[str, Any]] = [
+        {"id": "e1", "platform": "linkedin", "engagement_score": 0.9, "title": "t", "body": "b"}
+    ]
+    monkeypatch.setattr(orch_mod, "_retrieve_exemplars", lambda *a, **k: canned)
+
+    seen: List[List[Dict[str, Any]]] = []
+
+    class _Spy:
+        def generate_candidates(self, proposal, goals, exemplars=None):
+            seen.append(exemplars or [])
+            return []
+
+    orch.concept_team = [_Spy(), _Spy()]
+
+    goals = make_goals()
+    proposal = CampaignProposal(
+        campaign_name="c",
+        objective="drive",
+        audience_hypothesis="h",
+    )
+    orch._plan_content(proposal, goals)
+
+    assert len(seen) == 2
+    for s in seen:
+        assert s == canned
+
+
+@pytest.mark.parametrize("exemplars", [[], None])
+def test_plan_content_tolerates_missing_exemplars(monkeypatch, exemplars):
+    from social_media_marketing_team.orchestrator import SocialMediaMarketingOrchestrator
+
+    orch = SocialMediaMarketingOrchestrator()
+    monkeypatch.setattr(orch_mod, "_retrieve_exemplars", lambda *a, **k: exemplars or [])
+
+    goals = make_goals()
+    proposal = CampaignProposal(
+        campaign_name="c",
+        objective="drive",
+        audience_hypothesis="h",
+    )
+    plan = orch._plan_content(proposal, goals)
+    # Should produce a valid (possibly empty-approved) content plan.
+    assert plan.campaign_name == "c"

--- a/backend/agents/social_media_marketing_team/tests/test_winning_posts_api.py
+++ b/backend/agents/social_media_marketing_team/tests/test_winning_posts_api.py
@@ -1,0 +1,212 @@
+"""API-level tests for Winning Posts Bank CRUD routes + auto-ingest hook.
+
+Swaps the bank module's ``get_conn`` for an in-process fake so the
+routes exercise their full happy-path without Postgres.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from social_media_marketing_team.adapters.branding import BrandContext
+from social_media_marketing_team.api.main import app
+from social_media_marketing_team.tests.test_winning_posts_bank import _FakeConn
+
+_BRAND_ADAPTER = "social_media_marketing_team.api.main"
+
+_MOCK_BRAND_CTX = BrandContext(
+    brand_name="Acme",
+    target_audience="B2B founders",
+    voice_and_tone="clear",
+    brand_guidelines="Positioning: Developer tools that just work.",
+    brand_objectives="Purpose: Empower developers.\nMission: Ship faster.",
+    messaging_pillars=["Developer empowerment"],
+    brand_story="Acme was born from frustration.",
+    tagline="Just works",
+)
+
+
+@pytest.fixture
+def fake_bank(monkeypatch: pytest.MonkeyPatch):
+    db: dict[str, Any] = {"posts": {}}
+
+    @contextmanager
+    def _fake_get_conn(database=None):
+        yield _FakeConn(db)
+
+    import social_media_marketing_team.shared.winning_posts_bank as wpb
+
+    monkeypatch.setattr(wpb, "get_conn", _fake_get_conn)
+    yield db
+
+
+def test_create_list_get_delete_roundtrip(fake_bank):
+    client = TestClient(app)
+
+    r = client.post(
+        "/social-marketing/winning-posts",
+        json={
+            "title": "Why seed rounds fail",
+            "body": "Founders skip...",
+            "platform": "linkedin",
+            "keywords": ["founders", "seed"],
+            "engagement_score": 0.88,
+            "linked_goals": ["awareness"],
+        },
+    )
+    assert r.status_code == 201, r.text
+    post_id = r.json()["id"]
+
+    r = client.get("/social-marketing/winning-posts")
+    assert r.status_code == 200
+    rows = r.json()
+    assert any(row["id"] == post_id for row in rows)
+
+    r = client.get(f"/social-marketing/winning-posts/{post_id}")
+    assert r.status_code == 200
+    assert r.json()["title"] == "Why seed rounds fail"
+    assert r.json()["platform"] == "linkedin"
+
+    r = client.delete(f"/social-marketing/winning-posts/{post_id}")
+    assert r.status_code == 200
+    assert r.json()["id"] == post_id
+
+    r = client.get(f"/social-marketing/winning-posts/{post_id}")
+    assert r.status_code == 404
+
+
+def test_get_missing_returns_404(fake_bank):
+    client = TestClient(app)
+    r = client.get("/social-marketing/winning-posts/does-not-exist")
+    assert r.status_code == 404
+
+
+def test_delete_missing_returns_404(fake_bank):
+    client = TestClient(app)
+    r = client.delete("/social-marketing/winning-posts/does-not-exist")
+    assert r.status_code == 404
+
+
+@patch(f"{_BRAND_ADAPTER}._fetch_and_validate_brand", return_value=_MOCK_BRAND_CTX)
+def test_performance_ingest_auto_promotes_high_engagement(_mock_brand, fake_bank):
+    """A high-engagement observation ingests into the Winning Posts Bank."""
+    client = TestClient(app)
+    run = client.post(
+        "/social-marketing/run",
+        json={
+            "client_id": "client_1",
+            "brand_id": "brand_1",
+            "llm_model_name": "llama3.1",
+            "human_approved_for_testing": True,
+        },
+    )
+    assert run.status_code == 200
+    job_id = run.json()["job_id"]
+
+    r = client.post(
+        f"/social-marketing/performance/{job_id}",
+        json={
+            "observations": [
+                {
+                    "campaign_name": "Acme growth sprint",
+                    "platform": "linkedin",
+                    "concept_title": "Pricing mistakes",
+                    "posted_at": "2026-04-17T12:00:00Z",
+                    "metrics": [{"name": "engagement_rate", "value": 0.81}],
+                }
+            ]
+        },
+    )
+    assert r.status_code == 200
+    assert r.json()["observations_ingested"] == 1
+
+    listing = client.get("/social-marketing/winning-posts").json()
+    assert len(listing) == 1
+    row = listing[0]
+    assert row["title"] == "Pricing mistakes"
+    assert row["platform"] == "linkedin"
+    assert row["engagement_score"] == pytest.approx(0.81)
+    assert row["source_job_id"] == job_id
+
+
+@patch(f"{_BRAND_ADAPTER}._fetch_and_validate_brand", return_value=_MOCK_BRAND_CTX)
+def test_performance_ingest_skips_low_engagement(_mock_brand, fake_bank):
+    client = TestClient(app)
+    run = client.post(
+        "/social-marketing/run",
+        json={
+            "client_id": "client_1",
+            "brand_id": "brand_1",
+            "llm_model_name": "llama3.1",
+            "human_approved_for_testing": True,
+        },
+    )
+    job_id = run.json()["job_id"]
+
+    r = client.post(
+        f"/social-marketing/performance/{job_id}",
+        json={
+            "observations": [
+                {
+                    "campaign_name": "Acme growth sprint",
+                    "platform": "linkedin",
+                    "concept_title": "Low scorer",
+                    "posted_at": "2026-04-17T12:00:00Z",
+                    "metrics": [{"name": "engagement_rate", "value": 0.2}],
+                }
+            ]
+        },
+    )
+    assert r.status_code == 200
+
+    listing = client.get("/social-marketing/winning-posts").json()
+    assert listing == []
+
+
+@patch(f"{_BRAND_ADAPTER}._fetch_and_validate_brand", return_value=_MOCK_BRAND_CTX)
+def test_performance_ingest_computes_composite_score(_mock_brand, fake_bank, monkeypatch):
+    """When no engagement_rate metric is present, composite formula kicks in."""
+    monkeypatch.setenv("SOCIAL_MARKETING_WINNING_POSTS_INGEST_THRESHOLD", "0.5")
+    client = TestClient(app)
+    run = client.post(
+        "/social-marketing/run",
+        json={
+            "client_id": "client_1",
+            "brand_id": "brand_1",
+            "llm_model_name": "llama3.1",
+            "human_approved_for_testing": True,
+        },
+    )
+    job_id = run.json()["job_id"]
+
+    # 100 likes + 2*50 comments + 3*50 shares = 350 over 500 impressions = 0.70
+    r = client.post(
+        f"/social-marketing/performance/{job_id}",
+        json={
+            "observations": [
+                {
+                    "campaign_name": "Acme",
+                    "platform": "x",
+                    "concept_title": "Composite winner",
+                    "posted_at": "2026-04-17T12:00:00Z",
+                    "metrics": [
+                        {"name": "impressions", "value": 500},
+                        {"name": "likes", "value": 100},
+                        {"name": "comments", "value": 50},
+                        {"name": "shares", "value": 50},
+                    ],
+                }
+            ]
+        },
+    )
+    assert r.status_code == 200
+
+    listing = client.get("/social-marketing/winning-posts").json()
+    assert len(listing) == 1
+    assert listing[0]["title"] == "Composite winner"
+    assert listing[0]["engagement_score"] == pytest.approx(0.7)

--- a/backend/agents/social_media_marketing_team/tests/test_winning_posts_bank.py
+++ b/backend/agents/social_media_marketing_team/tests/test_winning_posts_bank.py
@@ -1,0 +1,464 @@
+"""Unit tests for ``social_media_marketing_team.shared.winning_posts_bank``.
+
+Uses the dict-backed fake-Postgres pattern established by
+``blogging/tests/test_story_bank.py``: a ``_FakeCursor`` routes the SQL
+statements the module issues to an in-process store so save/find/
+rerank/list/get/delete can be exercised without a live Postgres.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+import pytest
+
+
+class _FakeCursor:
+    def __init__(self, db: dict[str, Any]) -> None:
+        self._db = db
+        self.rowcount = 0
+        self._last_fetch_one: dict | None = None
+        self._last_fetch_all: list[dict] = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def execute(self, sql: str, params: tuple | list = ()) -> None:
+        sql_l = " ".join(sql.split()).lower()
+        params = tuple(params)
+
+        if sql_l.startswith("insert into social_marketing_winning_posts"):
+            (
+                post_id,
+                title,
+                body,
+                platform,
+                keywords_json,
+                metrics_json,
+                engagement_score,
+                linked_goals_json,
+                summary,
+                source_job_id,
+                created_at,
+            ) = params
+            keywords = keywords_json.obj if hasattr(keywords_json, "obj") else keywords_json
+            metrics = metrics_json.obj if hasattr(metrics_json, "obj") else metrics_json
+            linked_goals = (
+                linked_goals_json.obj if hasattr(linked_goals_json, "obj") else linked_goals_json
+            )
+            self._db["posts"][post_id] = {
+                "id": post_id,
+                "title": title,
+                "body": body,
+                "platform": platform or "",
+                "keywords": list(keywords or []),
+                "metrics": dict(metrics or {}),
+                "engagement_score": float(engagement_score or 0.0),
+                "linked_goals": list(linked_goals or []),
+                "summary": summary or "",
+                "source_job_id": source_job_id,
+                "created_at": created_at,
+            }
+            self.rowcount = 1
+            return
+
+        if "from social_marketing_winning_posts where platform = any" in sql_l:
+            (platforms,) = params
+            allowed = set(platforms or [])
+            self._last_fetch_all = [
+                dict(row)
+                for row in self._db["posts"].values()
+                if (row["platform"] or "") in allowed
+            ]
+            return
+
+        if "order by created_at desc limit" in sql_l:
+            limit, offset = params
+            ordered = sorted(
+                self._db["posts"].values(),
+                key=lambda r: r["created_at"],
+                reverse=True,
+            )
+            self._last_fetch_all = [dict(row) for row in ordered[offset : offset + limit]]
+            return
+
+        if "where id = %s" in sql_l and sql_l.startswith("select"):
+            (post_id,) = params
+            row = self._db["posts"].get(post_id)
+            self._last_fetch_one = dict(row) if row else None
+            return
+
+        if sql_l.startswith("select") and "from social_marketing_winning_posts" in sql_l:
+            self._last_fetch_all = [dict(row) for row in self._db["posts"].values()]
+            return
+
+        if sql_l.startswith("delete from social_marketing_winning_posts where id"):
+            (post_id,) = params
+            if self._db["posts"].pop(post_id, None) is not None:
+                self.rowcount = 1
+            else:
+                self.rowcount = 0
+            return
+
+        raise AssertionError(f"unexpected SQL in fake cursor: {sql!r}")
+
+    def fetchone(self):
+        return self._last_fetch_one
+
+    def fetchall(self):
+        return self._last_fetch_all
+
+
+class _FakeConn:
+    def __init__(self, db: dict[str, Any]) -> None:
+        self._db = db
+
+    def cursor(self, row_factory=None):  # noqa: ANN001
+        return _FakeCursor(self._db)
+
+
+@pytest.fixture
+def fake_pg(monkeypatch: pytest.MonkeyPatch):
+    """Install a fake ``get_conn`` on the bank module."""
+    db: dict[str, Any] = {"posts": {}}
+
+    @contextmanager
+    def _fake_get_conn(database=None):
+        yield _FakeConn(db)
+
+    import social_media_marketing_team.shared.winning_posts_bank as wpb
+
+    monkeypatch.setattr(wpb, "get_conn", _fake_get_conn)
+    yield db
+
+
+# ---------------------------------------------------------------------------
+# save_winning_post
+# ---------------------------------------------------------------------------
+
+
+def test_save_persists_row_with_generated_id(fake_pg):
+    from social_media_marketing_team.shared.winning_posts_bank import save_winning_post
+
+    pid = save_winning_post(
+        title="Why seed rounds fail",
+        body="Founders often skip...",
+        platform="linkedin",
+        keywords=["founders", "seed"],
+        metrics={"engagement_rate": 0.81},
+        engagement_score=0.81,
+        linked_goals=["awareness"],
+        source_job_id="job-1",
+    )
+    assert isinstance(pid, str)
+    assert len(pid) == 12
+    row = fake_pg["posts"][pid]
+    assert row["title"] == "Why seed rounds fail"
+    assert row["platform"] == "linkedin"
+    assert row["keywords"] == ["founders", "seed"]
+    assert row["metrics"] == {"engagement_rate": 0.81}
+    assert row["engagement_score"] == pytest.approx(0.81)
+    assert row["linked_goals"] == ["awareness"]
+    assert row["source_job_id"] == "job-1"
+    assert row["summary"] == ""  # no llm client + no provided summary
+    assert isinstance(row["created_at"], datetime)
+    assert row["created_at"].tzinfo is timezone.utc
+
+
+def test_save_defaults_empty_for_optional_fields(fake_pg):
+    from social_media_marketing_team.shared.winning_posts_bank import save_winning_post
+
+    pid = save_winning_post(title="t", body="b")
+    row = fake_pg["posts"][pid]
+    assert row["platform"] == ""
+    assert row["keywords"] == []
+    assert row["metrics"] == {}
+    assert row["linked_goals"] == []
+    assert row["source_job_id"] is None
+    assert row["engagement_score"] == 0.0
+
+
+def test_save_calls_llm_for_summary_when_client_provided(fake_pg):
+    from social_media_marketing_team.shared.winning_posts_bank import save_winning_post
+
+    class _StubLLM:
+        def __init__(self):
+            self.calls = []
+
+        def complete(self, prompt: str, system_prompt: str = "") -> str:
+            self.calls.append(prompt)
+            return "  A concise summary.  "
+
+    llm = _StubLLM()
+    pid = save_winning_post(title="t", body="a long post body", llm_client=llm)
+    assert fake_pg["posts"][pid]["summary"] == "A concise summary."
+    assert len(llm.calls) == 1
+    assert "Summarize this social post" in llm.calls[0]
+
+
+def test_save_llm_failure_is_non_fatal(fake_pg, caplog):
+    from social_media_marketing_team.shared.winning_posts_bank import save_winning_post
+
+    class _ExplodingLLM:
+        def complete(self, *a, **k):
+            raise RuntimeError("llm is down")
+
+    with caplog.at_level("WARNING"):
+        pid = save_winning_post(title="t", body="b", llm_client=_ExplodingLLM())
+
+    assert fake_pg["posts"][pid]["summary"] == ""
+    assert any("summary generation failed" in rec.message for rec in caplog.records)
+
+
+def test_save_uses_provided_summary_and_skips_llm(fake_pg):
+    from social_media_marketing_team.shared.winning_posts_bank import save_winning_post
+
+    class _LLM:
+        def complete(self, *a, **k):
+            raise AssertionError("LLM should not be called when summary is provided")
+
+    pid = save_winning_post(title="t", body="b", summary="Already summarized.", llm_client=_LLM())
+    assert fake_pg["posts"][pid]["summary"] == "Already summarized."
+
+
+# ---------------------------------------------------------------------------
+# find_relevant_winning_posts
+# ---------------------------------------------------------------------------
+
+
+def test_find_returns_empty_for_empty_query(fake_pg):
+    from social_media_marketing_team.shared.winning_posts_bank import (
+        find_relevant_winning_posts,
+        save_winning_post,
+    )
+
+    save_winning_post(title="t", body="b", keywords=["founders"])
+    assert find_relevant_winning_posts([]) == []
+
+
+def test_find_scores_by_keyword_overlap(fake_pg):
+    from social_media_marketing_team.shared.winning_posts_bank import (
+        find_relevant_winning_posts,
+        save_winning_post,
+    )
+
+    a = save_winning_post(title="A", body="", keywords=["founders", "seed", "growth"])
+    b = save_winning_post(title="B", body="", keywords=["founders", "pricing"])
+    c = save_winning_post(title="C", body="", keywords=["saas", "growth"])
+    _d = save_winning_post(title="D", body="", keywords=["unrelated"])
+
+    results = find_relevant_winning_posts(["founders", "growth"], limit=3)
+    assert [r["id"] for r in results] == [a, b, c]
+
+
+def test_find_ignores_case_and_whitespace(fake_pg):
+    from social_media_marketing_team.shared.winning_posts_bank import (
+        find_relevant_winning_posts,
+        save_winning_post,
+    )
+
+    pid = save_winning_post(title="A", body="", keywords=["Founders", "  Growth  "])
+    results = find_relevant_winning_posts(["FOUNDERS"], limit=5)
+    assert [r["id"] for r in results] == [pid]
+
+
+def test_find_applies_platform_filter(fake_pg):
+    from social_media_marketing_team.shared.winning_posts_bank import (
+        find_relevant_winning_posts,
+        save_winning_post,
+    )
+
+    save_winning_post(title="LI", body="", platform="linkedin", keywords=["growth"])
+    save_winning_post(title="X", body="", platform="x", keywords=["growth"])
+
+    results = find_relevant_winning_posts(["growth"], platforms=["linkedin"])
+    assert len(results) == 1
+    assert results[0]["platform"] == "linkedin"
+
+
+def test_find_applies_limit(fake_pg):
+    from social_media_marketing_team.shared.winning_posts_bank import (
+        find_relevant_winning_posts,
+        save_winning_post,
+    )
+
+    for i in range(6):
+        save_winning_post(title=f"t-{i}", body="", keywords=["growth"])
+    results = find_relevant_winning_posts(["growth"], limit=3)
+    assert len(results) == 3
+
+
+def test_find_tiebreaks_by_engagement_score(fake_pg):
+    from social_media_marketing_team.shared.winning_posts_bank import (
+        find_relevant_winning_posts,
+        save_winning_post,
+    )
+
+    low = save_winning_post(title="low", body="", keywords=["growth"], engagement_score=0.4)
+    high = save_winning_post(title="high", body="", keywords=["growth"], engagement_score=0.9)
+
+    results = find_relevant_winning_posts(["growth"], limit=2)
+    assert results[0]["id"] == high
+    assert results[1]["id"] == low
+
+
+def test_find_llm_rerank_reorders_when_enough_candidates(fake_pg):
+    from social_media_marketing_team.shared.winning_posts_bank import (
+        find_relevant_winning_posts,
+        save_winning_post,
+    )
+
+    class _SummaryLLM:
+        def complete(self, *a, **k):
+            return "summary"
+
+        def complete_json(self, prompt: str, system_prompt: str = ""):
+            return [3, 2, 1]
+
+    llm = _SummaryLLM()
+    a = save_winning_post(title="A", body="body", keywords=["growth"], llm_client=llm)
+    b = save_winning_post(title="B", body="body", keywords=["growth"], llm_client=llm)
+    c = save_winning_post(title="C", body="body", keywords=["growth"], llm_client=llm)
+
+    results = find_relevant_winning_posts(
+        ["growth"],
+        limit=2,
+        rerank_context="need winners for growth campaign",
+        llm_client=llm,
+    )
+    assert len(results) == 2
+    assert {r["id"] for r in results} <= {a, b, c}
+
+
+def test_find_rerank_failure_falls_back_to_keyword(fake_pg):
+    from social_media_marketing_team.shared.winning_posts_bank import (
+        find_relevant_winning_posts,
+        save_winning_post,
+    )
+
+    class _BrokenLLM:
+        def complete(self, *a, **k):
+            return "ok"
+
+        def complete_json(self, *a, **k):
+            raise RuntimeError("llm down")
+
+    llm = _BrokenLLM()
+    for _ in range(6):
+        save_winning_post(title="t", body="b", keywords=["growth"], llm_client=llm)
+
+    results = find_relevant_winning_posts(
+        ["growth"],
+        limit=2,
+        rerank_context="ctx",
+        llm_client=llm,
+    )
+    assert len(results) == 2
+
+
+def test_find_rerank_disabled_via_env(fake_pg, monkeypatch):
+    from social_media_marketing_team.shared.winning_posts_bank import (
+        find_relevant_winning_posts,
+        save_winning_post,
+    )
+
+    monkeypatch.setenv("SOCIAL_MARKETING_WINNING_POSTS_RERANK_ENABLED", "false")
+
+    class _LoudLLM:
+        def complete(self, *a, **k):
+            return "summary"
+
+        def complete_json(self, *a, **k):
+            raise AssertionError("rerank must not run when disabled")
+
+    llm = _LoudLLM()
+    for _ in range(6):
+        save_winning_post(title="t", body="b", keywords=["growth"], llm_client=llm)
+
+    results = find_relevant_winning_posts(["growth"], limit=2, rerank_context="ctx", llm_client=llm)
+    assert len(results) == 2  # keyword path only
+
+
+# ---------------------------------------------------------------------------
+# list / get / delete
+# ---------------------------------------------------------------------------
+
+
+def test_list_orders_newest_first(fake_pg, monkeypatch):
+    import social_media_marketing_team.shared.winning_posts_bank as wpb
+
+    base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    counter = {"i": 0}
+
+    class _FakeDatetime:
+        @staticmethod
+        def now(tz=None):
+            counter["i"] += 1
+            return base + timedelta(minutes=counter["i"])
+
+    monkeypatch.setattr(wpb, "datetime", _FakeDatetime)
+
+    a = wpb.save_winning_post(title="oldest", body="")
+    b = wpb.save_winning_post(title="middle", body="")
+    c = wpb.save_winning_post(title="newest", body="")
+
+    listing = wpb.list_winning_posts(limit=10)
+    assert [r["id"] for r in listing] == [c, b, a]
+    assert all(isinstance(r["created_at"], str) for r in listing)
+
+
+def test_list_respects_limit_and_offset(fake_pg):
+    from social_media_marketing_team.shared.winning_posts_bank import (
+        list_winning_posts,
+        save_winning_post,
+    )
+
+    for i in range(5):
+        save_winning_post(title=f"t-{i}", body="")
+    page1 = list_winning_posts(limit=2, offset=0)
+    page2 = list_winning_posts(limit=2, offset=2)
+    assert len(page1) == 2
+    assert len(page2) == 2
+    assert {r["id"] for r in page1} & {r["id"] for r in page2} == set()
+
+
+def test_get_returns_dict_for_existing(fake_pg):
+    from social_media_marketing_team.shared.winning_posts_bank import (
+        get_winning_post,
+        save_winning_post,
+    )
+
+    pid = save_winning_post(title="t", body="b", keywords=["a", "b"])
+    row = get_winning_post(pid)
+    assert row is not None
+    assert row["id"] == pid
+    assert row["keywords"] == ["a", "b"]
+    assert isinstance(row["created_at"], str)
+
+
+def test_get_returns_none_for_missing(fake_pg):
+    from social_media_marketing_team.shared.winning_posts_bank import get_winning_post
+
+    assert get_winning_post("nope") is None
+
+
+def test_delete_returns_true_on_hit(fake_pg):
+    from social_media_marketing_team.shared.winning_posts_bank import (
+        delete_winning_post,
+        save_winning_post,
+    )
+
+    pid = save_winning_post(title="t", body="")
+    assert delete_winning_post(pid) is True
+    assert pid not in fake_pg["posts"]
+
+
+def test_delete_returns_false_on_miss(fake_pg):
+    from social_media_marketing_team.shared.winning_posts_bank import delete_winning_post
+
+    assert delete_winning_post("never-existed") is False


### PR DESCRIPTION
Ports the blogging team's story_bank pattern to social marketing so
past winners persist across jobs and feed concept generation. This is
the foundation for future metrics-driven improvements (post-mortem
loops, A/B pattern mining, platform-specific learning).

- New social_marketing_winning_posts table (shared_postgres SCHEMA)
- shared/winning_posts_bank.py: save/find/list/get/delete with two-stage
  (keyword + optional LLM rerank) retrieval and platform filtering
- ContentConceptAgent.generate_candidates accepts exemplars and prepends
  a formatted "Prior winners" block to each concept string
- Orchestrator retrieves exemplars from the bank before calling concept
  agents (best-effort; no-ops gracefully when Postgres is disabled)
- API: lifespan registers SCHEMA, CRUD routes under
  /social-marketing/winning-posts, and POST /performance/{job_id} now
  auto-promotes observations that beat
  SOCIAL_MARKETING_WINNING_POSTS_INGEST_THRESHOLD
- Env vars: SOCIAL_MARKETING_WINNING_POSTS_{TOP_K,RERANK_ENABLED,
  INGEST_THRESHOLD}
- Tests: 34 new tests (bank unit, API CRUD + auto-ingest,
  exemplar injection regression, orchestrator wiring); 99/99 pass

https://claude.ai/code/session_01SHSmqR8KJk9me1YqEegqmk