### PR TITLE
investment_team: live paper trading + sub-daily backtests (PR 2 of 3)

### DIFF
--- a/backend/agents/investment_team/api/main.py
+++ b/backend/agents/investment_team/api/main.py
@@ -2547,6 +2547,28 @@ def _live_paper_enabled() -> bool:
 _live_paper_stop_controllers: Dict[str, Any] = {}
 
 
+# Default fees used when the request omits explicit overrides. Sits at module
+# scope so tests can exercise the resolution logic directly.
+_DEFAULT_TX_COST_BPS = 5.0
+_DEFAULT_SLIPPAGE_BPS = 2.0
+
+
+def _resolve_fee_overrides(request: "RunPaperTradingRequest") -> tuple[float, float]:
+    """Return ``(transaction_cost_bps, slippage_bps)`` for the live config.
+
+    Uses explicit ``None`` checks instead of ``or`` so a caller asking for
+    zero-fee / zero-slippage experiments isn't silently bumped to the
+    defaults — ``0.0`` is falsy but semantically meaningful here.
+    """
+    tx = (
+        request.transaction_cost_bps
+        if request.transaction_cost_bps is not None
+        else _DEFAULT_TX_COST_BPS
+    )
+    slip = request.slippage_bps if request.slippage_bps is not None else _DEFAULT_SLIPPAGE_BPS
+    return tx, slip
+
+
 def _run_live_paper_trading_background(
     session_id: str,
     lab_record_id: str,
@@ -2581,12 +2603,13 @@ def _run_live_paper_trading_background(
 
         strategy_timeframe = request.timeframe or getattr(strategy, "timeframe", None) or "1m"
 
+        tx_cost, slip = _resolve_fee_overrides(request)
         bt_config = _BC(
             start_date=datetime.now(tz=timezone.utc).date().isoformat(),
             end_date=datetime.now(tz=timezone.utc).date().isoformat(),
             initial_capital=request.initial_capital,
-            transaction_cost_bps=request.transaction_cost_bps or 5.0,
-            slippage_bps=request.slippage_bps or 2.0,
+            transaction_cost_bps=tx_cost,
+            slippage_bps=slip,
             metrics_engine="legacy",
         )
         paper_cfg = PaperTradeConfig(
@@ -2777,20 +2800,34 @@ def _recover_orphaned_paper_trading_sessions() -> None:
         return
 
     now_iso = datetime.now(tz=timezone.utc).isoformat()
+    # Active statuses that indicate an in-flight session. PR 1 only used
+    # RUNNING; PR 2's live path transitions through OPENING → WARMING_UP →
+    # LIVE. A SIGKILL during any of those leaves the row orphaned; without
+    # recovery the new per-strategy concurrency guard (409) would lock out
+    # future runs for that strategy indefinitely.
+    _active_statuses = {
+        PaperTradingStatus.RUNNING,
+        PaperTradingStatus.OPENING,
+        PaperTradingStatus.WARMING_UP,
+        PaperTradingStatus.LIVE,
+    }
     recovered = 0
     for raw in raw_sessions:
         try:
             session = PaperTradingSession(**raw) if isinstance(raw, dict) else raw
         except Exception:
             continue
-        if session.status != PaperTradingStatus.RUNNING:
+        if session.status not in _active_statuses:
             continue
         session.status = PaperTradingStatus.FAILED
         session.completed_at = now_iso
-        session.divergence_analysis = (
-            "Paper trading did not complete — the worker process exited before finalizing "
-            "the session. Re-run the paper trade from the Strategy Lab."
+        session.terminated_reason = "process_exit"
+        session.error = (
+            "Paper trading did not complete — the worker process exited before "
+            "finalizing the session. Re-run the paper trade from the Strategy Lab."
         )
+        # Preserve the legacy free-form field too so older clients still read a message.
+        session.divergence_analysis = session.error
         try:
             with _lock:
                 _paper_trading_sessions[session.session_id] = session
@@ -2803,7 +2840,7 @@ def _recover_orphaned_paper_trading_sessions() -> None:
 
     if recovered:
         logger.info(
-            "Paper-trade recovery: marked %d orphaned running session(s) as failed",
+            "Paper-trade recovery: marked %d orphaned active session(s) as failed",
             recovered,
         )
 

--- a/backend/agents/investment_team/api/main.py
+++ b/backend/agents/investment_team/api/main.py
@@ -2234,7 +2234,14 @@ def clear_strategy_lab_storage() -> ClearStrategyLabStorageResponse:
 
 
 class RunPaperTradingRequest(BaseModel):
-    """Start a paper trading session for a winning strategy."""
+    """Start a paper trading session for a winning strategy.
+
+    PR 2 live-mode fields (``provider_id``, ``min_fills``, ``max_hours``,
+    ``warmup_bars``, ``timeframe``) take effect only when
+    ``INVESTMENT_LIVE_PAPER_ENABLED=true``. When the flag is off (the
+    default), the legacy recent-OHLCV path runs and the new fields are
+    ignored so existing clients and tests remain unaffected.
+    """
 
     lab_record_id: str = Field(..., description="ID of a winning StrategyLabRecord to paper trade")
     initial_capital: float = Field(default=100000.0, gt=0)
@@ -2249,7 +2256,44 @@ class RunPaperTradingRequest(BaseModel):
         description="Override slippage (bps); auto-detected from asset class when omitted",
     )
     lookback_days: int = Field(
-        default=365, ge=30, description="Days of recent market data to fetch"
+        default=365, ge=30, description="Days of recent market data to fetch (legacy path)"
+    )
+    # ------------------------------------------------------------------
+    # Live-mode additions (honored only when INVESTMENT_LIVE_PAPER_ENABLED=true)
+    # ------------------------------------------------------------------
+    provider_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Explicit provider override (e.g. 'binance', 'coinbase', 'polygon'). "
+            "Omit to use registry default. See GET /providers for the configured list."
+        ),
+    )
+    min_fills: int = Field(
+        default=20,
+        ge=1,
+        le=10_000,
+        description=(
+            "Terminate the session once this many trades have closed. "
+            "Values below 20 are accepted but add 'min_fills_below_recommended' to session.warnings."
+        ),
+    )
+    max_hours: float = Field(
+        default=72.0,
+        gt=0.0,
+        description="Wall-clock safety guard — session terminates after this many hours regardless of fill count.",
+    )
+    warmup_bars: int = Field(
+        default=500,
+        ge=0,
+        le=5_000,
+        description="Historical bars to replay as ctx.is_warmup=True before the live feed starts.",
+    )
+    timeframe: Optional[str] = Field(
+        default=None,
+        description=(
+            "Override the strategy's declared timeframe. Must be one of "
+            "{'1s','15s','30s','1m','5m','15m','30m','1h','4h','1d'}."
+        ),
     )
 
 
@@ -2392,15 +2436,50 @@ def run_paper_trading(request: RunPaperTradingRequest) -> PaperTradingResponse:
     # 2 — Create initial "running" session and persist immediately
     session_id = f"pt-{uuid.uuid4().hex[:8]}"
     now = datetime.now(tz=timezone.utc).isoformat()
+    use_live = _live_paper_enabled()
+
+    # 2a — Concurrency guard (spec §7.2): one live session per strategy_id.
+    # Only enforced for the live path — the legacy recent-OHLCV path
+    # completes in seconds and isn't subject to the "one at a time"
+    # invariant.
+    if use_live:
+        _active_states = {
+            PaperTradingStatus.OPENING,
+            PaperTradingStatus.WARMING_UP,
+            PaperTradingStatus.LIVE,
+            PaperTradingStatus.RUNNING,  # legacy value — treat as active too
+        }
+        with _lock:
+            for existing in _paper_trading_sessions.values():
+                existing_session = (
+                    PaperTradingSession(**existing) if isinstance(existing, dict) else existing
+                )
+                if (
+                    existing_session.strategy.strategy_id == strategy.strategy_id
+                    and existing_session.status in _active_states
+                ):
+                    raise HTTPException(
+                        status_code=409,
+                        detail=(
+                            f"Strategy '{strategy.strategy_id}' already has an "
+                            f"active live paper-trading session "
+                            f"'{existing_session.session_id}' "
+                            f"(status={existing_session.status.value}). Stop it "
+                            f"via POST /strategy-lab/paper-trade/"
+                            f"{existing_session.session_id}/stop before "
+                            f"starting a new one."
+                        ),
+                    )
+
     running_session = PaperTradingSession(
         session_id=session_id,
         lab_record_id=request.lab_record_id,
         strategy=strategy,
-        status=PaperTradingStatus.RUNNING,
+        status=PaperTradingStatus.OPENING if use_live else PaperTradingStatus.RUNNING,
         initial_capital=request.initial_capital,
         current_capital=request.initial_capital,
         symbols_traded=[],
-        data_source="yahoo_finance",
+        data_source="live" if use_live else "yahoo_finance",
         data_period_start="",
         data_period_end="",
         started_at=now,
@@ -2408,31 +2487,233 @@ def run_paper_trading(request: RunPaperTradingRequest) -> PaperTradingResponse:
     with _lock:
         _paper_trading_sessions[session_id] = running_session
 
-    # 3 — Kick off background worker (market data fetch + sandbox + divergence analysis).
-    # Non-daemon so graceful shutdown (SIGTERM) waits for in-flight work to finalize the
-    # session status instead of leaving it stuck in "running". Orphaned sessions from
-    # hard kills are recovered on startup (see _recover_orphaned_paper_trading_sessions).
-    thread = threading.Thread(
-        target=_run_paper_trading_background,
-        args=(
-            session_id,
-            request.lab_record_id,
-            strategy,
-            strategy_code,
-            backtest_record,
-            request.lookback_days,
-            request.initial_capital,
-            request.transaction_cost_bps,
-            request.slippage_bps,
-        ),
-        name=f"paper-trade-{session_id}",
-        daemon=False,
-    )
+    # 3 — Kick off background worker. The live path (PR 2) is gated behind
+    # INVESTMENT_LIVE_PAPER_ENABLED so operators opt in; otherwise the legacy
+    # recent-OHLCV replay path remains the default.
+    if use_live:
+        thread = threading.Thread(
+            target=_run_live_paper_trading_background,
+            args=(session_id, request.lab_record_id, strategy, request),
+            name=f"live-paper-trade-{session_id}",
+            daemon=False,
+        )
+    else:
+        thread = threading.Thread(
+            target=_run_paper_trading_background,
+            args=(
+                session_id,
+                request.lab_record_id,
+                strategy,
+                strategy_code,
+                backtest_record,
+                request.lookback_days,
+                request.initial_capital,
+                request.transaction_cost_bps,
+                request.slippage_bps,
+            ),
+            name=f"paper-trade-{session_id}",
+            daemon=False,
+        )
     thread.start()
 
     return PaperTradingResponse(
         session=running_session,
         message=f"Paper trading started. Poll GET /strategy-lab/paper-trade/{session_id} for progress.",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Live-mode paper trading (PR 2)
+# ---------------------------------------------------------------------------
+#
+# The live path consumes a streaming market-data feed and drives the same
+# TradingService used by backtests. It is gated behind INVESTMENT_LIVE_PAPER_ENABLED
+# so existing deployments keep the legacy recent-OHLCV behavior until operators
+# opt in. See ``system_design/pr2_live_data_and_paper_cutover.md``.
+
+
+def _live_paper_enabled() -> bool:
+    """Return True when the live paper-trading path is opted in via env var."""
+    return os.environ.get("INVESTMENT_LIVE_PAPER_ENABLED", "false").lower() in {
+        "true",
+        "1",
+        "yes",
+    }
+
+
+# Per-session StopController registry. The POST /stop endpoint looks up the
+# controller by session_id and calls ``request_stop()``; the running session
+# polls it between bars. Guarded by ``_lock`` shared with other session state.
+_live_paper_stop_controllers: Dict[str, Any] = {}
+
+
+def _run_live_paper_trading_background(
+    session_id: str,
+    lab_record_id: str,
+    strategy: StrategySpec,
+    request: "RunPaperTradingRequest",
+) -> None:
+    """Background worker for the PR 2 live paper-trading path.
+
+    Resolves a provider, opens the live stream, drives ``TradingService``
+    until termination, then writes the final ``PaperTradingSession``.
+    """
+    from investment_team.models import BacktestConfig as _BC
+    from investment_team.trading_service.modes.paper_trade import (
+        PaperTradeConfig,
+        StopController,
+        run_paper_trade,
+    )
+
+    controller = StopController()
+    with _lock:
+        _live_paper_stop_controllers[session_id] = controller
+
+    try:
+        # Choose symbols the same way the legacy path does — but only up to the
+        # first few to keep bandwidth bounded during paper trading.
+        from investment_team.market_data_service import MarketDataService
+
+        market_service = MarketDataService()
+        symbols = market_service.get_symbols_for_strategy(strategy)[:5]
+        if not symbols:
+            raise RuntimeError("no symbols resolved for strategy")
+
+        strategy_timeframe = request.timeframe or getattr(strategy, "timeframe", None) or "1m"
+
+        bt_config = _BC(
+            start_date=datetime.now(tz=timezone.utc).date().isoformat(),
+            end_date=datetime.now(tz=timezone.utc).date().isoformat(),
+            initial_capital=request.initial_capital,
+            transaction_cost_bps=request.transaction_cost_bps or 5.0,
+            slippage_bps=request.slippage_bps or 2.0,
+            metrics_engine="legacy",
+        )
+        paper_cfg = PaperTradeConfig(
+            symbols=symbols,
+            asset_class=strategy.asset_class,
+            strategy_timeframe=strategy_timeframe,
+            min_fills=request.min_fills,
+            max_hours=request.max_hours,
+            warmup_bars=request.warmup_bars,
+            provider_id=request.provider_id,
+        )
+
+        run_result = run_paper_trade(
+            strategy=strategy,
+            backtest_config=bt_config,
+            paper_config=paper_cfg,
+            stop_controller=controller,
+        )
+
+        # Persist the completed session.
+        with _lock:
+            raw = _paper_trading_sessions.get(session_id)
+            if raw is None:
+                return
+            session = PaperTradingSession(**raw) if isinstance(raw, dict) else raw
+            session.trades = run_result.trades
+            session.fill_count = run_result.fill_count
+            session.cutover_ts = run_result.cutover_ts
+            session.provider_id = run_result.provider_id
+            session.terminated_reason = run_result.terminated_reason
+            session.warnings = run_result.warnings
+            session.error = (run_result.error or "")[:500] or None
+            session.symbols_traded = symbols
+            session.data_source = f"live:{run_result.provider_id}"
+            session.completed_at = datetime.now(tz=timezone.utc).isoformat()
+            if run_result.error or run_result.terminated_reason in {
+                "lookahead_violation",
+                "provider_error",
+                "region_blocked",
+                "no_provider",
+            }:
+                session.status = PaperTradingStatus.FAILED
+            else:
+                session.status = PaperTradingStatus.COMPLETED
+            _paper_trading_sessions[session_id] = session
+        logger.info(
+            "Live paper trade %s: terminated (%s), provider=%s, fills=%d, trades=%d",
+            session_id,
+            run_result.terminated_reason,
+            run_result.provider_id,
+            run_result.fill_count,
+            len(run_result.trades),
+        )
+    except Exception as exc:
+        logger.exception("Live paper trade %s: background worker crashed", session_id)
+        with _lock:
+            raw = _paper_trading_sessions.get(session_id)
+            if raw is not None:
+                session = PaperTradingSession(**raw) if isinstance(raw, dict) else raw
+                session.status = PaperTradingStatus.FAILED
+                session.error = str(exc)[:500]
+                session.completed_at = datetime.now(tz=timezone.utc).isoformat()
+                _paper_trading_sessions[session_id] = session
+    finally:
+        with _lock:
+            _live_paper_stop_controllers.pop(session_id, None)
+
+
+@app.post("/strategy-lab/paper-trade/{session_id}/stop", response_model=PaperTradingResponse)
+def stop_live_paper_trading(session_id: str) -> PaperTradingResponse:
+    """Idempotent user-stop for a live paper-trading session.
+
+    Sets the session's stop flag; the background worker terminates at the next
+    bar boundary. Returns the session's current state (still ``live`` /
+    ``warming_up`` if the worker hasn't yet noticed — clients poll
+    ``GET /strategy-lab/paper-trade/{session_id}`` for the final record).
+    """
+    if not _live_paper_enabled():
+        raise HTTPException(
+            status_code=404,
+            detail="Live paper trading is not enabled (set INVESTMENT_LIVE_PAPER_ENABLED=true).",
+        )
+    with _lock:
+        raw = _paper_trading_sessions.get(session_id)
+        if raw is None:
+            raise HTTPException(
+                status_code=404, detail=f"Paper trading session '{session_id}' not found."
+            )
+        session = PaperTradingSession(**raw) if isinstance(raw, dict) else raw
+        controller = _live_paper_stop_controllers.get(session_id)
+        if controller is not None:
+            controller.request_stop()
+            session.user_stop_requested_at = datetime.now(tz=timezone.utc).isoformat()
+            _paper_trading_sessions[session_id] = session
+    return PaperTradingResponse(
+        session=session,
+        message="Stop requested. Poll the session to see the final state.",
+    )
+
+
+class ProviderDescriptor(BaseModel):
+    """One row of the ``GET /providers`` response."""
+
+    name: str
+    supports: List[str] = Field(default_factory=list)
+    is_paid: bool = False
+    has_key: bool = False
+    is_default_for: List[str] = Field(default_factory=list)
+    historical_timeframes: List[str] = Field(default_factory=list)
+    live_timeframes: List[str] = Field(default_factory=list)
+
+
+class ProvidersListResponse(BaseModel):
+    live_paper_enabled: bool
+    providers: List[ProviderDescriptor] = Field(default_factory=list)
+
+
+@app.get("/providers", response_model=ProvidersListResponse)
+def list_providers() -> ProvidersListResponse:
+    """Enumerate registered market-data providers and their capabilities."""
+    from investment_team.trading_service.providers import default_registry
+
+    registry = default_registry()
+    rows = [ProviderDescriptor(**row) for row in registry.describe_all()]
+    return ProvidersListResponse(
+        live_paper_enabled=_live_paper_enabled(),
+        providers=rows,
     )
 
 

--- a/backend/agents/investment_team/models.py
+++ b/backend/agents/investment_team/models.py
@@ -413,6 +413,12 @@ class PaperTradingStatus(str, Enum):
     RUNNING = "running"
     COMPLETED = "completed"
     FAILED = "failed"
+    # PR 2 live-mode states. The legacy three values remain for backwards
+    # compatibility with records created before live streaming landed; the
+    # paper-trade mode reports its progress through the new ones.
+    OPENING = "opening"
+    WARMING_UP = "warming_up"
+    LIVE = "live"
 
 
 class PaperTradingVerdict(str, Enum):
@@ -507,6 +513,40 @@ class PaperTradingSession(BaseModel):
     data_period_end: str = ""
     started_at: str = ""
     completed_at: str = ""
+
+    # PR 2 live-mode fields (all optional; null on legacy records).
+    provider_id: Optional[str] = Field(
+        default=None,
+        description="Resolved live provider id (e.g. 'binance', 'coinbase'). Null for legacy rows.",
+    )
+    cutover_ts: Optional[str] = Field(
+        default=None,
+        description="ISO-8601 timestamp of the first live bar — boundary between warm-up and live phase.",
+    )
+    fill_count: int = Field(
+        default=0,
+        description="Running count of closed trades during the live phase.",
+    )
+    terminated_reason: Optional[str] = Field(
+        default=None,
+        description=(
+            "'fill_target_reached' | 'user_stop' | 'max_hours' | 'max_drawdown' "
+            "| 'provider_error' | 'region_blocked' | 'lookahead_violation' "
+            "| 'no_provider' | 'provider_end' | 'upstream_end'; null for legacy rows."
+        ),
+    )
+    user_stop_requested_at: Optional[str] = Field(
+        default=None,
+        description="ISO-8601 instant the user invoked POST /stop; null if not stopped.",
+    )
+    warnings: List[str] = Field(
+        default_factory=list,
+        description="Non-fatal advisories (e.g. 'min_fills_below_recommended').",
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Truncated error text if the session ended abnormally.",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/system_design/pr2_live_data_and_paper_cutover.md
+++ b/backend/agents/investment_team/system_design/pr2_live_data_and_paper_cutover.md
@@ -1,0 +1,614 @@
+# PR 2 — Live Data Feed & Paper Trading Cut-over
+
+**Status:** Spec (pre-implementation) · **Author:** Trading Service ·
+**Target branch:** `claude/gifted-kalam` · **Depends on:** PR 1
+(`8be4481 investment_team: unified streaming Trading Service`)
+
+PR 1 landed the mode-agnostic `TradingService`, the `MarketDataStream`
+protocol, and a historical replay source. **This PR finishes the "one
+engine, two modes" design** by adding:
+
+1. A **live-data stream** implementation fed from a pluggable provider
+   registry (free-first defaults, paid alternatives via integrations).
+2. **Candle resampling** from the smallest-bar aggregate each provider
+   offers, up to the timeframe the strategy asks for.
+3. A **paper-trading cut-over** path through the existing
+   `TradingService` event loop: warm-up from recent history, then live
+   bars only, terminating on ≥ 20 fills or user stop.
+4. Sub-daily timeframes for **backtests** too (same provider registry,
+   historical aggregates where the provider supports them).
+
+PR 3 remains the cleanup: retire `TradeSimulationEngine` and the batch
+`SandboxRunner`.
+
+---
+
+## 1. Goals and non-goals
+
+### Goals
+
+| # | Goal |
+|---|---|
+| G1 | A single `TradingService.run(stream)` call can execute either a backtest or a paper-trading session; the engine code does not branch on mode. |
+| G2 | Paper trading uses **live data only** once warm-up is complete. No recent OHLCV is ever fed to the strategy during the live phase. |
+| G3 | The trading service always consumes the **lowest-timeframe feed a provider exposes** for the selected symbol and asset class, and resamples up to the strategy's declared timeframe. |
+| G4 | Resampling and fill simulation continue to preserve the PR 1 look-ahead invariant: the strategy subprocess can never see a bar the engine has not already finalized. |
+| G5 | The **default** provider stack is free across all three asset classes (crypto, equities, FX). Paid providers plug in as optional integrations. |
+| G6 | A paper-trading session runs until **≥ 20 fills** have accumulated *or* the user requests termination, whichever comes first. |
+| G7 | Provider failures (rate limit, disconnect, empty stream) degrade gracefully: the session records a structured error and is safe to resume. |
+
+### Non-goals (explicitly deferred)
+
+| # | Non-goal |
+|---|---|
+| N1 | Placing live orders against a real broker. Paper only. |
+| N2 | Migrating strategy execution from daemon threads to Temporal activities — tracked in the ARCHITECTURE_REVIEW Phase 3 work. |
+| N3 | Partial fills, options chains, L2 order books. PR 2 trades a single price level per bar, same as PR 1. |
+| N4 | Cross-provider failover mid-session. A session is bound to one provider at start; restart to switch. |
+| N5 | Retiring `TradeSimulationEngine` / `SandboxRunner` — PR 3. |
+
+---
+
+## 2. Provider evaluation (free-first)
+
+### 2.1 Selection criteria
+
+A data provider is eligible for the **free default** if it satisfies
+all of:
+
+1. Genuinely free tier (no trial, no credit card on signup).
+2. True real-time stream (not ≥ 1 min delayed — Yahoo/Polygon free
+   tier are 15-minute delayed and **disqualified** for paper mode).
+3. At least one aggregate ≤ 1 min, or a trade/quote stream from which
+   the engine can build 1s candles.
+4. Stable programmatic access (websocket or long-polling REST).
+5. Terms of service permit automated reads for personal research.
+
+### 2.2 Recommended defaults
+
+| Asset class | Default provider | Live feed granularity | Notes |
+|---|---|---|---|
+| **Crypto** | **Binance** (spot, public market-data WS) — primary; **Coinbase Exchange WS** — secondary | Trade stream (tick) → engine builds 1s bars; Binance also exposes `kline_1s`, `kline_15s`, `kline_1m` natively; Coinbase exposes trade + 1m aggregates | Both keyless, 24/7. Binance is preferred for the broader kline menu. On a Binance region block (HTTP 451 / geo error) at session open, the registry auto-fails over to Coinbase *before the first bar is accepted* — a session is still bound to exactly one adapter after that. No mid-session failover. |
+| **Equities** | **Alpaca** (free account, IEX feed via `wss://stream.data.alpaca.markets/v2/iex`) | Trades + 1-min aggregates from IEX venue only | ≈ 2–3% of national volume. Shipped as the free default to satisfy G5; the session response carries a `provider_notes` field warning that fill realism for low-IEX-volume names will be understated. Users needing full tape configure Polygon or Alpaca SIP. |
+| **FX** | **OANDA v20** practice account (free) | Tick pricing stream; engine builds 1s/1m bars | Practice account is free and perpetual, but the token is **not** keyless — one-time manual signup is a documented first-run setup step. If `OANDA_API_TOKEN` is absent, `POST /strategy-lab/paper-trade` for an FX strategy returns HTTP 422 with a pointer to the setup doc. |
+
+### 2.3 Paid alternatives (integrations)
+
+Each paid provider is installed the same way any other Khala
+integration is: an env var toggle + optional API key in settings. If
+the key is present, the paid provider is **preferred** for the asset
+classes it covers; otherwise the free default is used.
+
+| Provider | Covers | Why paid | Env var |
+|---|---|---|---|
+| **Polygon.io** | Stocks, options, crypto, FX | Full SIP equities, lower latency, backfill depth | `POLYGON_API_KEY` |
+| **Databento** | Stocks, futures, options | Institutional-grade historical + live | `DATABENTO_API_KEY` |
+| **Alpaca (paid SIP)** | Stocks | Upgrades the same Alpaca code path from IEX to SIP | `ALPACA_PAID_FEED=sip` + `ALPACA_API_KEY_ID` / `ALPACA_API_SECRET_KEY` |
+| **Twelve Data Pro** | Stocks, FX, crypto | Higher rate limits, more timeframes | `TWELVE_DATA_API_KEY` (+ `TWELVE_DATA_PLAN=pro`) |
+
+### 2.4 Rejected candidates
+
+| Provider | Rejection reason |
+|---|---|
+| Yahoo Finance (live) | 15-min delay on free tier → violates G2. Still used for historical daily bars. |
+| IEX Cloud | Legacy platform, shutdown trajectory. |
+| CoinGecko | REST-only, no sub-minute stream. |
+| Finnhub free | Trades WS exists but TOS restricts redistribution + very low rate limit. Fallback only. |
+| Coinbase (as primary) | Solid feed and keyless, but narrower kline menu than Binance (no native 1s / 15s klines). Used as the **secondary** crypto default for Binance-blocked regions, not primary. |
+| FRED | Macro data, not trade data. Used in `market_lab_data/` for context, not here. |
+
+---
+
+## 3. Component architecture
+
+### 3.1 New module layout
+
+```
+backend/agents/investment_team/trading_service/
+  data_stream/
+    protocol.py              (unchanged; PR 1)
+    historical_replay.py     (extended — sub-daily aggregates)
+    live_stream.py           (NEW — adapter-driven live feed)
+    resampler.py             (NEW — provider-native → strategy-timeframe)
+    providers/
+      __init__.py            (provider registry)
+      base.py                (NEW — ProviderAdapter Protocol)
+      binance.py             (NEW — crypto primary default)
+      coinbase.py            (NEW — crypto secondary default; Binance geo-block failover)
+      alpaca.py              (NEW — equities default; paid SIP toggle)
+      oanda.py               (NEW — FX default)
+      polygon.py             (NEW — paid alt, all classes)
+      databento.py           (NEW — paid alt, stocks/futures/options)
+      twelve_data.py         (NEW — paid alt, all classes)
+  modes/
+    backtest.py              (unchanged entry point; extended to support sub-daily)
+    paper_trade.py           (NEW — public entry point for live sessions)
+  session/
+    store.py                 (NEW — paper session persistence + resume)
+```
+
+### 3.2 Provider adapter protocol
+
+All adapters implement the same Protocol so the live-stream builder
+treats them identically.
+
+```python
+# trading_service/data_stream/providers/base.py
+class ProviderAdapter(Protocol):
+    name: str
+    supports: set[str]            # subset of {"crypto", "equities", "fx"}
+    native_timeframes: list[str]  # e.g. ["tick", "1s", "1m"]
+
+    def historical(
+        self, symbols: list[str], asset_class: str,
+        start: str, end: str, timeframe: str,
+    ) -> Iterator[BarEvent]: ...
+
+    def live(
+        self, symbols: list[str], asset_class: str,
+        native_timeframe: str,
+    ) -> Iterator[BarEvent]: ...
+
+    def smallest_available(self, asset_class: str) -> str:
+        """The shortest timeframe (or "tick") this provider offers for the class."""
+```
+
+Concrete adapters are permitted to implement only `historical` or only
+`live` — the registry records which methods each supports. The
+`providers/__init__.py` registry selects adapters in this order:
+
+1. Explicit override from request (e.g. `RunPaperTradeRequest.provider_id`).
+2. Paid provider with a matching API key present.
+3. Free default for the asset class.
+
+If a chosen adapter does not support the requested direction
+(historical vs. live), the registry falls back to the next eligible
+adapter with a structured log event. A session is still bound to **one
+adapter per direction** once the stream is opened.
+
+**Binance → Coinbase geo-failover (crypto only, open-time only).** At
+session open, if the selected Binance adapter returns a region-block
+signal (HTTP 451 / documented geo-error codes / resolved-DNS → blocked
+IP on the WS upgrade), the registry re-selects the Coinbase adapter
+**before the first bar is emitted** and records `provider_id =
+"coinbase"` on the session. The failover does not apply mid-session:
+a provider disconnect after the first live bar terminates the session
+with `terminated_reason = "provider_error"` (§5.4). This preserves the
+"one adapter per session" invariant while keeping the free-default
+experience working for geo-restricted users.
+
+### 3.3 Live stream assembly
+
+```mermaid
+flowchart LR
+    U[Paper-trade request] --> REG[Provider registry]
+    REG --> PROV[Chosen adapter]
+    PROV -- native ticks / smallest bars --> RS[Resampler]
+    RS -- BarEvents at strategy timeframe --> SVC[TradingService.run]
+    SVC -- orders via harness --> STRAT[Strategy subprocess]
+    SVC -- fills --> SESS[PaperTradingSession store]
+    SESS -- stop signal --> SVC
+```
+
+### 3.4 Resampler
+
+The resampler sits between the provider adapter and `TradingService`.
+It consumes the provider's native stream (ticks or smallest native
+bars) and emits `BarEvent`s at the strategy-requested timeframe.
+
+Key invariants:
+
+- **Only finalized bars are emitted.** A bar for timeframe `tf`
+  closing at `t_close` is emitted strictly *after* a native bar/tick
+  with timestamp `> t_close` has been observed. No partial candles
+  leak to the engine, and therefore none to the strategy.
+- **Monotonic timestamps.** The resampler drops out-of-order native
+  events (late prints) and records a metric; a new bar never carries
+  an earlier close than the previous one.
+- **Session boundaries** (equities only). Day close / halts are
+  surfaced as gaps — the resampler does not fabricate bars in a gap.
+- **Timeframe alignment.** Bars close on clock-aligned boundaries
+  (e.g. `:00` for 1m), matching standard charting conventions. The
+  first bar after warm-up may be a partial period and is suppressed.
+
+```python
+# Public shape
+class Resampler:
+    def __init__(self, target_timeframe: str): ...
+    def feed_native(self, event: NativeEvent) -> Iterator[BarEvent]: ...
+    def flush_on_end(self) -> Iterator[BarEvent]: ...  # no partials — just drains
+```
+
+`NativeEvent` is a small internal union (`NativeTick | NativeBar`)
+carrying `ts`, `price`, `size` (ticks) or OHLCV (bars). It is private
+to the resampler; the engine only ever sees `BarEvent`.
+
+### 3.5 Look-ahead invariants (preserved from PR 1)
+
+| Invariant | PR 1 mechanism | PR 2 extension |
+|---|---|---|
+| Strategy never sees a bar it shouldn't | Subprocess isolation; only `history()` accessor | Unchanged. Live bars arrive via the same `send_bar` harness call. |
+| Fill simulator's one-bar-forward peek is parent-only | `FillSimulator` runs in parent | Unchanged. Live-mode fills are applied using the *next* arriving bar, same as backtest. |
+| Resampler cannot leak in-progress periods | N/A | Explicit: only emits after a later native event arrives. |
+| No `ctx.future_*` accessor exists | Structural | Still no accessor. Adding any new `ctx.*` method requires a look-ahead audit in review. |
+
+---
+
+## 4. Candle construction rules
+
+### 4.1 Required strategy timeframe comes from the strategy spec
+
+`StrategySpec` already carries a `timeframe` field (e.g. `"1d"`,
+`"15m"`, `"1m"`). In PR 2:
+
+- If the provider offers the target timeframe **natively**, subscribe
+  to it directly and bypass the resampler.
+- Otherwise, subscribe to the **smallest** native timeframe (or tick
+  stream) and resample up.
+
+### 4.2 Precedence when multiple native timeframes exist
+
+Given provider `P` offering `["tick", "1s", "1m", "1h"]` and strategy
+asking for `"15m"`:
+
+1. Prefer `"1m"` (smallest aggregate that evenly divides 15m, cheapest
+   to stream).
+2. Only fall back to `"1s"` or `"tick"` if the provider's 1m feed is
+   unavailable or has a documented gap profile that would harm fill
+   realism.
+
+Rationale: tick streams are the highest fidelity but the most
+expensive to consume (CPU, bandwidth, rate-limit budget). Use them
+only where the realism gain is material.
+
+### 4.3 Fill realism upgrade: intra-bar fills
+
+In PR 1 a limit/stop order placed on bar *t* evaluates against the
+high/low of bar *t+1* only. With sub-daily bars this coarseness
+becomes less acceptable. For PR 2:
+
+- When the **native** timeframe is smaller than the **strategy**
+  timeframe, `FillSimulator` has the option to consult the finer
+  native stream to check whether the limit/stop would have triggered
+  intra-bar.
+- This is **still parent-only**; the strategy never sees the sub-bar
+  data.
+- Off by default; toggled with `FillSimulatorConfig.intrabar_fills`
+  (planned for PR 2, default `False` to preserve parity with PR 1).
+
+### 4.4 Tick-to-candle construction
+
+When the provider gives ticks, the resampler builds OHLCV for the
+target timeframe with these rules:
+
+- `open` = price of the first tick whose ts ∈ [bar_start, bar_end)
+- `high` / `low` = max / min over that interval
+- `close` = price of the last tick in the interval
+- `volume` = sum of sizes in the interval
+- If no ticks arrived in a fully elapsed interval, emit **no bar** (a
+  gap, not a zero-volume placeholder).
+
+---
+
+## 5. Paper-trading cut-over
+
+### 5.1 Session lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> opening
+    opening --> warming_up: provider connected
+    opening --> failed: provider error
+    warming_up --> live: warm-up history delivered (is_warmup=True)
+    live --> terminating: fills >= 20
+    live --> terminating: user_stop
+    live --> terminating: provider_error
+    terminating --> complete
+    failed --> [*]
+    complete --> [*]
+```
+
+### 5.2 Warm-up
+
+Before the first live bar, the service replays the last
+`paper_trading_warmup_bars` (default: **500** bars of the strategy
+timeframe) from the provider's historical endpoint. At the default,
+this covers ≈ 5 trading days at `15m`, ≈ 8 hours at `1m`, or ≈ 2 years
+at `1d` — enough headroom for chained indicators (e.g. SMA-of-RSI)
+without a punitive startup cost. Requests may set `warmup_bars = 0`
+to disable warm-up entirely for stateless strategies. Each is delivered
+with `is_warmup=True` so the strategy can populate indicators but
+**must not emit orders** — orders emitted during warm-up are dropped
+with a log event `warmup_order_dropped`.
+
+Rationale: indicator-based strategies need prior bars to compute a
+first signal. Without warm-up the first N live bars would be unusable.
+This is **not** a look-ahead violation: warm-up bars are strictly
+older than the cut-over timestamp, and the strategy is told explicitly
+via `ctx.is_warmup`.
+
+The cut-over timestamp (`cutover_ts`) is captured at the moment the
+first live bar is accepted from the provider. Any warm-up bar with
+`timestamp >= cutover_ts` is rejected — this is the guardrail enforcing
+"live data only during live phase".
+
+### 5.3 Live phase
+
+- Provider stream is consumed by the resampler.
+- Each finalized bar flows through the same `TradingService` event
+  loop used by backtests. Fills update `PaperTradingSession.trades`.
+- Session equity curve is sampled on every bar close.
+- Session state is persisted after each fill (see §7) so the process
+  can crash without losing the session.
+
+### 5.4 Termination
+
+A session terminates when **any** of:
+
+| Trigger | Field set |
+|---|---|
+| Fills count ≥ `paper_trading_min_fills` (default **20**) | `terminated_reason = "fill_target_reached"` |
+| User calls `POST /strategy-lab/paper-trade/{session_id}/stop` | `terminated_reason = "user_stop"` |
+| Provider emits unrecoverable error | `terminated_reason = "provider_error"` |
+| Drawdown circuit-breaker fires (inherited from PR 1) | `terminated_reason = "max_drawdown"` |
+| Strategy raises `lookahead_violation` | `terminated_reason = "lookahead_violation"` |
+
+On termination the service:
+
+1. Calls `harness.send_end()`.
+2. Closes the provider connection.
+3. Computes metrics via `trade_simulator.compute_metrics(...)`.
+4. Runs the existing `PaperTradingAgent` divergence analysis vs the
+   associated backtest (if any).
+5. Writes final `PaperTradingSession` record with verdict
+   (`"ready_for_live"` / `"not_performant"`).
+
+### 5.5 Why 20 fills?
+
+Statistically small but large enough to flag gross bugs (wrong side,
+never-exit strategies, always-hit stop-loss). The number is
+configurable per request (`paper_trading_min_fills`) so users can ask
+for more for longer-horizon strategies. The upper bound is enforced by
+a max-wall-clock guard (`paper_trading_max_hours`, default 72h) so a
+session that never fills 20 times still terminates.
+
+---
+
+## 6. API surface
+
+### 6.1 New & changed endpoints
+
+| Method | Path | Purpose | Change |
+|---|---|---|---|
+| `POST` | `/api/investment/strategy-lab/paper-trade` | Start paper-trade session | **Extended**: new fields `provider_id`, `min_fills`, `max_hours`, `warmup_bars`. Removes `paper_trading_lookback_days` (warm-up supersedes it). |
+| `GET` | `/api/investment/strategy-lab/paper-trade/{session_id}` | Fetch session | Unchanged schema; adds `status` (`opening`/`warming_up`/`live`/`complete`/`failed`), `cutover_ts`, `fill_count`, `terminated_reason`. |
+| `POST` | `/api/investment/strategy-lab/paper-trade/{session_id}/stop` | **NEW** — user stop | Idempotent. Sets `terminated_reason="user_stop"`. |
+| `GET` | `/api/investment/strategy-lab/paper-trade/{session_id}/stream` | **NEW** — SSE of live updates | Emits `bar`, `fill`, `status`, `error` events until session terminates. |
+| `GET` | `/api/investment/providers` | **NEW** — list configured providers | Returns `[{name, supports, has_key, is_default_for}]`. Useful for UI. |
+| `POST` | `/api/investment/backtests` | Existing | **Extended**: `timeframe` now honored sub-daily (e.g. `"15m"`). |
+
+### 6.2 Request schema additions
+
+```python
+class RunPaperTradeRequest(BaseModel):
+    lab_record_id: str
+    # Existing:
+    initial_capital: float = 100_000.0
+    transaction_cost_bps: float = 5.0
+    slippage_bps: float = 2.0
+    # New:
+    provider_id: Optional[str] = None     # override registry selection
+    min_fills: int = 20                   # Field(ge=1, le=10_000)
+    max_hours: float = 72.0               # wall-clock guard
+    warmup_bars: int = 500                # Field(ge=0, le=5_000)
+    timeframe: Optional[str] = None       # overrides strategy.timeframe if set
+```
+
+### 6.3 Validation rules
+
+- `min_fills >= 1` is **hard-enforced** (422 if violated).
+- `min_fills < 20` is **accepted with a warning**: the session's
+  response body includes `warnings: ["min_fills_below_recommended"]`
+  and the metric commentary flags the result as
+  `sample_size = "exploratory"`. This keeps experimentation cheap
+  while making small-sample caveats explicit.
+- `timeframe` must be one of `{"1s", "15s", "30s", "1m", "5m", "15m",
+  "30m", "1h", "4h", "1d"}`. Ticks are never exposed to the strategy —
+  a strategy that declares `timeframe = "tick"` is rejected.
+- If strategy timeframe is unknown, the API returns 422 — paper mode is
+  not allowed without one.
+- FX strategies require `OANDA_API_TOKEN` (or a paid FX provider key)
+  to be configured. Absent any FX provider key, the request returns
+  422 with `error_code = "fx_provider_not_configured"` and a pointer
+  to the OANDA setup doc.
+
+---
+
+## 7. Persistence
+
+Paper sessions outlive any single HTTP request. They must survive API
+restarts (the current `_PersistentDict` approach is fine).
+
+### 7.1 Storage
+
+- Table / bucket: `_paper_trading_sessions` (already exists).
+- **New fields** on `PaperTradingSession`:
+
+| Field | Type | Notes |
+|---|---|---|
+| `status` | `str` | `opening` / `warming_up` / `live` / `complete` / `failed` |
+| `provider_id` | `str` | e.g. `"binance"` |
+| `cutover_ts` | `str` (ISO-8601) | first live bar timestamp |
+| `fill_count` | `int` | updated after each fill |
+| `terminated_reason` | `Optional[str]` | see §5.4 table |
+| `user_stop_requested_at` | `Optional[str]` | set by `/stop` endpoint |
+| `error` | `Optional[str]` | truncated exception text |
+
+- Writes happen at three points: (a) session open, (b) after every
+  fill, (c) on terminate. Bars themselves are **not** persisted
+  individually — the strategy can reconstruct from `history()` during
+  the run, and after-the-fact audit uses the trade ledger.
+
+### 7.2 Concurrency
+
+- Exactly **one** live paper session per `(strategy_id, user_id)` at a
+  time. Attempting to start a second returns 409.
+- The `/stop` endpoint writes `user_stop_requested_at` and sets a
+  shared flag the service polls between bar deliveries. Stop is best-
+  effort: the current bar finishes processing first.
+
+### 7.3 Crash recovery (best-effort, not the primary design goal)
+
+If the process exits mid-session, the session row is left in `live`
+status with the last persisted fill. On startup the API does **not**
+automatically resume — it marks such rows `failed` with
+`error="process_exit"`. True resumability is a Temporal-activity job
+and is deferred to the Phase 3 migration (ARCHITECTURE_REVIEW).
+
+---
+
+## 8. Configuration
+
+### 8.1 Environment variables (additions)
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `INVESTMENT_LIVE_PROVIDER_CRYPTO` | `binance` | Override default crypto provider |
+| `INVESTMENT_LIVE_PROVIDER_EQUITIES` | `alpaca` | Override default equities provider |
+| `INVESTMENT_LIVE_PROVIDER_FX` | `oanda` | Override default FX provider |
+| `INVESTMENT_PAPER_MIN_FILLS` | `20` | Default for `min_fills` if request omits |
+| `INVESTMENT_PAPER_MAX_HOURS` | `72` | Wall-clock guard |
+| `INVESTMENT_PAPER_WARMUP_BARS` | `500` | Default warm-up count |
+| `INVESTMENT_INTRABAR_FILLS` | `false` | Toggle §4.3 sub-bar fill simulation |
+| `BINANCE_WS_URL` | `wss://stream.binance.com:9443` | Overridable for regional mirrors / tests |
+| `COINBASE_WS_URL` | `wss://ws-feed.exchange.coinbase.com` | Overridable for tests; Coinbase is the crypto secondary default used when Binance is geo-blocked |
+| `ALPACA_API_KEY_ID` / `ALPACA_API_SECRET_KEY` | — | Required for free Alpaca feed (free key, just needs signup) |
+| `ALPACA_PAID_FEED` | `iex` | Set to `sip` to upgrade to paid feed if key has entitlement |
+| `OANDA_API_TOKEN` / `OANDA_ACCOUNT_ID` | — | Required for OANDA v20 (practice token is free) |
+| `POLYGON_API_KEY` | — | Paid alt |
+| `DATABENTO_API_KEY` | — | Paid alt |
+| `TWELVE_DATA_API_KEY` | — | Paid alt |
+
+### 8.2 CLAUDE.md additions
+
+`backend/` root CLAUDE.md already documents
+`ALPHA_VANTAGE_API_KEY` and the Strategy Lab market-data tuning knobs.
+PR 2 adds rows for each of the variables above in the same table.
+
+---
+
+## 9. Testing strategy
+
+### 9.1 Unit tests
+
+- `test_resampler.py`
+  - tick-stream → 1s / 15s / 1m construction
+  - out-of-order tick dropped, metric incremented
+  - gap preserved (no fabricated bars)
+  - partial period at end of stream **not** emitted
+- `test_live_stream.py`
+  - provider adapter mocked; live stream yields BarEvents in order
+  - warm-up bars tagged with `is_warmup=True`
+  - order emitted during warm-up → dropped, log captured
+- `test_paper_session_termination.py`
+  - fill count ≥ min_fills → `terminated_reason="fill_target_reached"`
+  - user_stop flag mid-run → `terminated_reason="user_stop"`
+  - provider raises → `terminated_reason="provider_error"`
+  - wall-clock exceeded → `terminated_reason="max_hours"`
+- `test_lookahead_live.py`
+  - strategy that attempts to access `ctx.future_bar` during live
+    mode → `lookahead_violation` (same as backtest)
+  - resampler does not emit a bar until a newer native event arrives
+
+### 9.2 Provider adapter tests
+
+Each adapter gets a **canned-replay test** that feeds a recorded
+fixture of provider output (saved to `tests/fixtures/`) and asserts
+the adapter produces the expected BarEvent sequence. Network calls
+are never made from CI.
+
+### 9.3 Integration tests
+
+- `test_paper_to_backtest_parity.py` — run a deterministic strategy
+  on a fixed historical window via both the backtest path and a
+  paper-session path (provider mocked to replay the same data) and
+  assert trade ledgers match modulo ID columns.
+- `test_sub_daily_backtest.py` — end-to-end backtest at `"15m"`
+  timeframe using resampled fixture data; verify fill timestamps and
+  P&L.
+
+### 9.4 What we **do not** test in CI
+
+Live websocket connectivity to third parties. Those are tested by a
+manual smoke script under `backend/agents/investment_team/scripts/`
+that is run pre-release.
+
+---
+
+## 10. Rollout plan
+
+1. **Merge order**: resampler → provider base + Binance → live_stream →
+   paper_trade mode → Alpaca + OANDA → API wiring → paid adapters.
+   Each step is a commit; each step keeps tests green.
+2. **Feature flag**: `INVESTMENT_LIVE_PAPER_ENABLED` (default `false`
+   in PR 2). When `false`, `POST /strategy-lab/paper-trade` falls
+   back to the legacy behavior (replay recent OHLCV as in PR 1).
+   Flipped to `true` in a follow-up after smoke tests.
+3. **Documentation**: update `README.md`, `ARCHITECTURE_REVIEW.md`,
+   and the `system_design/` index to reflect the new module layout.
+   Add a one-line entry in the repo `CHANGELOG.md` at merge time.
+4. **PR 3** (separate): delete `TradeSimulationEngine` + `SandboxRunner`
+   once the paper/backtest paths have been soaked for at least one
+   strategy-lab cycle release.
+
+---
+
+## 11. Resolved decisions
+
+The open questions previously in this section have been resolved. The
+decisions and their rationale are recorded here so future readers can
+tell what is settled and what is not.
+
+| # | Question | Decision | Rationale |
+|---|---|---|---|
+| D1 | Equities free default: ship Alpaca IEX or gate behind paid? | **Ship Alpaca IEX as the free default.** Session response includes `provider_notes` flagging the IEX-volume caveat. Users needing full-tape realism configure Polygon or Alpaca SIP. | Gating behind paid violates G5 (free default across all three asset classes). The IEX feed is real-time and adequate for plausibility checks; users who care about low-IEX-volume fillability can opt into paid. |
+| D2 | Binance geo-block → auto-failover? | **Yes — register Coinbase Exchange WS as the crypto secondary default. Auto-failover only at session open**, before the first bar is accepted. No mid-session failover. | Preserves the "one adapter per session" invariant while keeping the free-default experience working in Binance-blocked regions. Mid-session failover would complicate ordering, resampler state, and reconciliation — not worth the complexity for paper mode. |
+| D3 | OANDA signup as documented first-run step? | **Accept.** No keyless free FX provider exists. FX paper-trade requests without `OANDA_API_TOKEN` return 422 with a setup-doc link. | Users who want FX paper trading can reasonably spend two minutes on a free signup. Silent failure would be worse; a 422 with a direct link is the clearest developer experience. |
+| D4 | `/stop` control over SSE? | **REST-only.** SSE stays strictly one-way (server → client). | SSE is designed as a one-way channel; bidirectional control over it requires out-of-band mechanisms or WebSocket. A separate `POST .../stop` is trivial for clients and keeps the transport contract clean. |
+| D5 | Warm-up bar default: 200 vs 500? | **500.** Request may override `0..5000`. | 200-period SMAs are common; chained indicators (e.g. RSI-of-SMA) push retention needs higher. 500 × 15m ≈ 5 trading days, 500 × 1m ≈ 8h — acceptable startup cost. Strategies that want cold-start behavior set `warmup_bars = 0`. |
+| D6 | `min_fills < 20`: warn or reject? | **Warn, don't reject.** Hard-reject only `min_fills < 1`. Response includes `warnings: ["min_fills_below_recommended"]` and the metric commentary tags the run `sample_size = "exploratory"`. | Small-sample paper trading still catches gross strategy bugs (wrong side, never-exit). Rejecting would make experimentation expensive. Explicit warning + commentary keeps the caveat visible without blocking the user. |
+
+---
+
+## 12. Traceability
+
+| Requirement (user prompt) | Where addressed |
+|---|---|
+| Single unified trading service | §3 (architecture); reuses PR 1 `TradingService.run` |
+| Data stream fed by mode | §3.3, §5; backtest = HistoricalReplayStream, paper = LiveStream via resampler |
+| Backtest pulls historical data, streams it | PR 1 + §4.1 for sub-daily |
+| Eliminate look-ahead from strategy | §3.5, §5.2 cut-over guard |
+| Engine may look ahead for realistic fills | §4.3 intrabar_fills toggle |
+| Paper trading uses live data only | §5.2 `cutover_ts` guard + warm-up tagging |
+| Never use recent/historical during live phase | §5.2 reject `ts >= cutover_ts` on warm-up; live provider only after cut-over |
+| Lowest-timeframe feed, provider-dependent | §4.1–4.2 precedence rules |
+| Build candles from high-frequency data | §4.4 tick-to-candle rules; §3.4 resampler |
+| Free default, paid via integrations | §2.2–2.3 provider tables; §8.1 env vars |
+| All three asset classes at once | §2.2 crypto / equities / FX defaults |
+| ≥ 20 fills or user stop | §5.4 termination table; §6.2 `min_fills`; §7.2 stop semantics |
+| Spec before implementation | This document |
+
+---
+
+## 13. Appendix — provider coverage matrix
+
+| Timeframe \ class | Crypto — Binance (primary) | Crypto — Coinbase (secondary) | Equities (Alpaca IEX) | FX (OANDA) |
+|---|---|---|---|---|
+| tick | ✅ trade stream | ✅ trade stream | ✅ trades WS | ✅ pricing stream |
+| 1s | ✅ native `kline_1s` | build from ticks | build from ticks | build from ticks |
+| 15s | ✅ native `kline_15s` | build from ticks | build from ticks | build from ticks |
+| 1m | ✅ native | ✅ native aggregates | ✅ native aggregates | build from ticks |
+| 5m / 15m / 1h / 1d | resample from 1m | resample from 1m | resample from 1m | resample from 1m |
+
+Polygon, Databento, and Twelve Data Pro fill in the gaps when
+configured (e.g. native 1s for equities via Polygon).

--- a/backend/agents/investment_team/tests/test_binance_ws.py
+++ b/backend/agents/investment_team/tests/test_binance_ws.py
@@ -1,0 +1,177 @@
+"""Unit tests for the Binance websocket message parsers.
+
+The async pump itself (``run_binance_live``) is exercised via manual
+smoke scripts with real network; these tests cover the pure-function
+parsing layer that converts Binance's JSON wire format to our
+:class:`NativeTick` / :class:`NativeBar` types. Keeping parsing separate
+from I/O is what makes this layer testable without network access.
+"""
+
+from __future__ import annotations
+
+from investment_team.trading_service.data_stream.resampler import (
+    NativeBar,
+    NativeTick,
+)
+from investment_team.trading_service.providers.binance_ws import (
+    _build_stream_url,
+    dispatch_binance_message,
+    parse_binance_kline,
+    parse_binance_trade,
+)
+
+# ---------------------------------------------------------------------------
+# Trade parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_binance_trade_typical() -> None:
+    # Binance @trade schema — the "T" field is trade-time in ms.
+    msg = {
+        "e": "trade",
+        "E": 1700000000100,
+        "s": "BTCUSDT",
+        "t": 12345,
+        "p": "60000.10",
+        "q": "0.01",
+        "T": 1700000000050,
+        "m": True,
+        "M": True,
+    }
+    tick = parse_binance_trade(msg)
+    assert isinstance(tick, NativeTick)
+    assert tick.symbol == "BTCUSDT"
+    assert tick.price == 60000.10
+    assert tick.size == 0.01
+    # 1700000000050 ms → 2023-11-14T22:13:20.050Z
+    assert tick.timestamp.startswith("2023-11-14T22:13:20")
+
+
+# ---------------------------------------------------------------------------
+# Kline parsing — only emit on close (x=True)
+# ---------------------------------------------------------------------------
+
+
+def test_parse_binance_kline_open_is_none() -> None:
+    """In-progress (x=False) klines must NOT emit — that would leak a partial."""
+    msg = {
+        "e": "kline",
+        "k": {
+            "t": 1700000000000,
+            "T": 1700000059999,
+            "s": "BTCUSDT",
+            "i": "1m",
+            "o": "60000.0",
+            "c": "60010.0",
+            "h": "60020.0",
+            "l": "59990.0",
+            "v": "1.2",
+            "x": False,
+        },
+    }
+    assert parse_binance_kline(msg) is None
+
+
+def test_parse_binance_kline_close_emits_bar() -> None:
+    msg = {
+        "e": "kline",
+        "k": {
+            "t": 1700000000000,
+            "T": 1700000059999,
+            "s": "BTCUSDT",
+            "i": "1m",
+            "o": "60000.0",
+            "c": "60015.0",
+            "h": "60020.0",
+            "l": "59990.0",
+            "v": "1.2",
+            "x": True,
+        },
+    }
+    bar = parse_binance_kline(msg)
+    assert isinstance(bar, NativeBar)
+    assert bar.symbol == "BTCUSDT"
+    assert bar.timeframe == "1m"
+    assert bar.open == 60000.0
+    assert bar.close == 60015.0
+    assert bar.high == 60020.0
+    assert bar.low == 59990.0
+    assert bar.volume == 1.2
+    # Close timestamp should be Binance's T + 1ms → 1700000060000 ms
+    assert bar.timestamp.startswith("2023-11-14T22:14:20")
+
+
+# ---------------------------------------------------------------------------
+# dispatch_binance_message — routing + combined-stream envelope
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_routes_trade_to_tick() -> None:
+    msg = {"e": "trade", "s": "ETHUSDT", "p": "3000", "q": "0.5", "T": 1700000000000}
+    result = dispatch_binance_message(msg)
+    assert isinstance(result, NativeTick)
+    assert result.symbol == "ETHUSDT"
+
+
+def test_dispatch_unwraps_combined_stream_envelope() -> None:
+    """Combined-stream messages wrap the payload under ``data``."""
+    envelope = {
+        "stream": "btcusdt@trade",
+        "data": {
+            "e": "trade",
+            "s": "BTCUSDT",
+            "p": "60000",
+            "q": "0.1",
+            "T": 1700000000000,
+        },
+    }
+    result = dispatch_binance_message(envelope)
+    assert isinstance(result, NativeTick)
+    assert result.symbol == "BTCUSDT"
+
+
+def test_dispatch_ignores_unknown_event_type() -> None:
+    """Subscription acks / heartbeats / unknown events drop silently."""
+    assert dispatch_binance_message({"result": None, "id": 1}) is None
+    assert dispatch_binance_message({"e": "bookTicker"}) is None
+
+
+def test_dispatch_kline_in_progress_returns_none() -> None:
+    """Even when routing, an in-progress kline should not emit."""
+    msg = {
+        "e": "kline",
+        "k": {
+            "t": 0,
+            "T": 59999,
+            "s": "BTCUSDT",
+            "i": "1m",
+            "o": "1",
+            "c": "1",
+            "h": "1",
+            "l": "1",
+            "v": "0",
+            "x": False,
+        },
+    }
+    assert dispatch_binance_message(msg) is None
+
+
+# ---------------------------------------------------------------------------
+# URL construction
+# ---------------------------------------------------------------------------
+
+
+def test_build_stream_url_tick_uses_trade_channel() -> None:
+    url = _build_stream_url("wss://stream.binance.com:9443", ["BTCUSDT", "ETHUSDT"], "tick")
+    assert url == "wss://stream.binance.com:9443/stream?streams=btcusdt@trade/ethusdt@trade"
+
+
+def test_build_stream_url_kline_uses_kline_channel() -> None:
+    url = _build_stream_url("wss://stream.binance.com:9443", ["BTCUSDT"], "1m")
+    assert url == "wss://stream.binance.com:9443/stream?streams=btcusdt@kline_1m"
+
+
+def test_build_stream_url_normalises_symbol_case() -> None:
+    # Symbols should always be lowercased for Binance's stream names.
+    url = _build_stream_url("wss://stream.binance.com:9443", ["btcUSDT"], "tick")
+    assert "btcusdt@trade" in url

--- a/backend/agents/investment_team/tests/test_paper_trade.py
+++ b/backend/agents/investment_team/tests/test_paper_trade.py
@@ -1,0 +1,382 @@
+"""End-to-end tests for the paper-trade mode.
+
+These tests use a stub provider that emits a canned sequence of historical
+warm-up bars followed by live native bars — no network, no real websockets.
+The focus is on the orchestration contract:
+
+* warm-up orders are dropped (belt-and-suspenders)
+* ``min_fills`` terminates cleanly
+* ``StopController`` terminates cleanly
+* cutover timestamp is captured
+* region-block on primary triggers geo-failover to secondary
+* live bars whose timestamp is earlier than cutover are defensively dropped
+"""
+
+from __future__ import annotations
+
+import textwrap
+from typing import Iterator, List, Optional
+
+import pytest
+
+from investment_team.models import BacktestConfig, StrategySpec
+from investment_team.trading_service.data_stream.protocol import BarEvent
+from investment_team.trading_service.data_stream.resampler import (
+    NativeBar,
+    NativeEvent,
+)
+from investment_team.trading_service.modes.paper_trade import (
+    PaperTradeConfig,
+    StopController,
+    run_paper_trade,
+)
+from investment_team.trading_service.providers.base import (
+    ProviderCapabilities,
+    ProviderRegionBlocked,
+)
+from investment_team.trading_service.providers.registry import ProviderRegistry
+from investment_team.trading_service.strategy.contract import Bar
+
+# ---------------------------------------------------------------------------
+# A deterministic "trade every bar" strategy — one round-trip per 2 live bars.
+# ---------------------------------------------------------------------------
+
+
+_ALTERNATING_STRATEGY = textwrap.dedent('''\
+    """Alternates entries and exits on every bar. Deterministic.
+
+    Respects ctx.is_warmup — no orders emitted during warm-up. Every live bar:
+      - If no position: submit LONG MARKET (qty=1)
+      - If position: submit SHORT MARKET (qty=pos.qty) to close
+    """
+    from contract import OrderSide, OrderType, Strategy
+
+
+    class AlternatingTrader(Strategy):
+        def on_bar(self, ctx, bar):
+            if ctx.is_warmup:
+                return
+            pos = ctx.position(bar.symbol)
+            if pos is None:
+                ctx.submit_order(
+                    symbol=bar.symbol,
+                    side=OrderSide.LONG,
+                    qty=1,
+                    order_type=OrderType.MARKET,
+                    reason="enter",
+                )
+            else:
+                ctx.submit_order(
+                    symbol=bar.symbol,
+                    side=OrderSide.SHORT,
+                    qty=pos.qty,
+                    order_type=OrderType.MARKET,
+                    reason="exit",
+                )
+''')
+
+
+_WARMUP_SUBMIT_STRATEGY = textwrap.dedent('''\
+    """Ignores ctx.is_warmup and always submits — tests the dropping safety net."""
+    from contract import OrderSide, OrderType, Strategy
+
+
+    class IgnoresWarmup(Strategy):
+        def on_bar(self, ctx, bar):
+            pos = ctx.position(bar.symbol)
+            if pos is None:
+                ctx.submit_order(
+                    symbol=bar.symbol,
+                    side=OrderSide.LONG,
+                    qty=1,
+                    order_type=OrderType.MARKET,
+                    reason="ignore_warmup",
+                )
+''')
+
+
+# ---------------------------------------------------------------------------
+# Stub provider
+# ---------------------------------------------------------------------------
+
+
+class _StubProvider:
+    def __init__(
+        self,
+        *,
+        name: str = "stub",
+        supports: Optional[set[str]] = None,
+        historical_bars: Optional[List[BarEvent]] = None,
+        live_events: Optional[List[NativeEvent]] = None,
+        live_raises: Optional[Exception] = None,
+    ) -> None:
+        self.capabilities = ProviderCapabilities(
+            name=name,
+            supports=supports or {"crypto"},
+            historical_timeframes={"1m"},
+            live_timeframes={"1m"},
+        )
+        self._historical_bars = historical_bars or []
+        self._live_events = live_events or []
+        self._live_raises = live_raises
+
+    def smallest_available(self, asset_class: str, *, live: bool) -> Optional[str]:
+        return "1m"
+
+    def historical(self, **kwargs) -> Iterator[BarEvent]:
+        yield from self._historical_bars
+
+    def live(self, **kwargs) -> Iterator[NativeEvent]:
+        if self._live_raises is not None:
+            raise self._live_raises
+        yield from self._live_events
+
+
+def _hist_bar(ts: str, close: float, symbol: str = "BTC") -> BarEvent:
+    return BarEvent(
+        bar=Bar(
+            symbol=symbol,
+            timestamp=ts,
+            timeframe="1m",
+            open=close,
+            high=close,
+            low=close,
+            close=close,
+            volume=1.0,
+        )
+    )
+
+
+def _native_bar(close_ts: str, close: float, symbol: str = "BTC", tf: str = "1m") -> NativeBar:
+    return NativeBar(
+        symbol=symbol,
+        timestamp=close_ts,
+        timeframe=tf,
+        open=close,
+        high=close,
+        low=close,
+        close=close,
+        volume=1.0,
+    )
+
+
+def _registry_with(
+    primary: _StubProvider, fallback: Optional[_StubProvider] = None
+) -> ProviderRegistry:
+    reg = ProviderRegistry()
+    reg.register(
+        lambda p=primary: p,
+        primary.capabilities,
+        default_for=list(primary.capabilities.supports),
+    )
+    if fallback is not None:
+        reg.register(
+            lambda f=fallback: f,
+            fallback.capabilities,
+            secondary_for=list(fallback.capabilities.supports),
+        )
+    return reg
+
+
+def _strategy(code: str) -> StrategySpec:
+    return StrategySpec(
+        strategy_id="stub-strat",
+        authored_by="test",
+        asset_class="crypto",
+        hypothesis="h",
+        signal_definition="s",
+        entry_rules=[],
+        exit_rules=[],
+        strategy_code=code,
+    )
+
+
+def _btc_config() -> BacktestConfig:
+    return BacktestConfig(
+        start_date="2024-01-01",
+        end_date="2024-01-02",
+        initial_capital=100_000.0,
+        transaction_cost_bps=0.0,
+        slippage_bps=0.0,
+        metrics_engine="legacy",
+    )
+
+
+def _paper_config(**overrides) -> PaperTradeConfig:
+    kwargs = dict(
+        symbols=["BTC"],
+        asset_class="crypto",
+        strategy_timeframe="1m",
+        min_fills=2,
+        max_hours=1.0,
+        warmup_bars=3,
+    )
+    kwargs.update(overrides)
+    return PaperTradeConfig(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_min_fills_terminates_live_phase() -> None:
+    # Warm-up: 3 bars, all dropped by the strategy (it honors ctx.is_warmup).
+    warmup = [
+        _hist_bar("2024-05-01T11:57:00Z", 100.0),
+        _hist_bar("2024-05-01T11:58:00Z", 101.0),
+        _hist_bar("2024-05-01T11:59:00Z", 102.0),
+    ]
+    # Live: enough native bars for 2 full round-trips (4 bars = 2 trades).
+    # Each native bar equals the target timeframe so passthrough applies.
+    live = [
+        _native_bar("2024-05-01T12:01:00Z", 103.0),  # strategy enters LONG
+        _native_bar("2024-05-01T12:02:00Z", 104.0),  # fill entry + exit submitted
+        _native_bar("2024-05-01T12:03:00Z", 105.0),  # fill exit -> trade 1
+        _native_bar("2024-05-01T12:04:00Z", 106.0),  # enter again
+        _native_bar("2024-05-01T12:05:00Z", 107.0),  # fill entry + exit submitted
+        _native_bar("2024-05-01T12:06:00Z", 108.0),  # fill exit -> trade 2
+        # Buffer bars in case the service loop needs one more iteration
+        _native_bar("2024-05-01T12:07:00Z", 109.0),
+        _native_bar("2024-05-01T12:08:00Z", 110.0),
+    ]
+    provider = _StubProvider(historical_bars=warmup, live_events=live)
+    result = run_paper_trade(
+        strategy=_strategy(_ALTERNATING_STRATEGY),
+        backtest_config=_btc_config(),
+        paper_config=_paper_config(min_fills=2),
+        registry=_registry_with(provider),
+    )
+
+    assert result.terminated_reason == "fill_target_reached"
+    assert result.fill_count >= 2
+    assert result.cutover_ts == "2024-05-01T12:01:00Z"
+    assert result.provider_id == "stub"
+    # Warm-up strategy honored ctx.is_warmup -> no dropped-orders counter.
+    assert result.service_result.warmup_orders_dropped == 0
+
+
+def test_warmup_orders_are_dropped() -> None:
+    warmup = [_hist_bar("2024-05-01T11:58:00Z", 100.0), _hist_bar("2024-05-01T11:59:00Z", 101.0)]
+    live = [_native_bar("2024-05-01T12:01:00Z", 102.0)]
+    provider = _StubProvider(historical_bars=warmup, live_events=live)
+    result = run_paper_trade(
+        strategy=_strategy(_WARMUP_SUBMIT_STRATEGY),  # deliberately submits during warm-up
+        backtest_config=_btc_config(),
+        paper_config=_paper_config(warmup_bars=2, min_fills=999),
+        registry=_registry_with(provider),
+    )
+    # Strategy tried to submit on every warm-up bar; all were dropped.
+    assert result.service_result.warmup_orders_dropped == 2
+    # No trade happened because the "entry order" submitted on the one live
+    # bar has no *next* bar to fill against in this canned stream.
+    assert result.fill_count == 0
+
+
+def test_user_stop_terminates_cleanly() -> None:
+    warmup: List[BarEvent] = []  # skip warmup to simplify
+    live = [_native_bar(f"2024-05-01T12:{i:02d}:00Z", 100.0 + i) for i in range(1, 20)]
+    provider = _StubProvider(historical_bars=warmup, live_events=live)
+    controller = StopController()
+    controller.request_stop()  # immediate stop
+
+    result = run_paper_trade(
+        strategy=_strategy(_ALTERNATING_STRATEGY),
+        backtest_config=_btc_config(),
+        paper_config=_paper_config(warmup_bars=0, min_fills=999),
+        stop_controller=controller,
+        registry=_registry_with(provider),
+    )
+    assert result.terminated_reason == "user_stop"
+
+
+def test_cutover_timestamp_is_first_live_bar() -> None:
+    live = [
+        _native_bar("2024-05-01T12:10:00Z", 100.0),
+        _native_bar("2024-05-01T12:11:00Z", 101.0),
+    ]
+    provider = _StubProvider(historical_bars=[], live_events=live)
+    result = run_paper_trade(
+        strategy=_strategy(_ALTERNATING_STRATEGY),
+        backtest_config=_btc_config(),
+        paper_config=_paper_config(warmup_bars=0, min_fills=999),
+        stop_controller=StopController(),
+        registry=_registry_with(provider),
+    )
+    assert result.cutover_ts == "2024-05-01T12:10:00Z"
+
+
+def test_region_blocked_primary_falls_over_to_secondary() -> None:
+    primary = _StubProvider(
+        name="binance",
+        live_raises=ProviderRegionBlocked("binance blocked"),
+    )
+    secondary_live = [
+        _native_bar("2024-05-01T12:01:00Z", 100.0),
+        _native_bar("2024-05-01T12:02:00Z", 101.0),
+        _native_bar("2024-05-01T12:03:00Z", 102.0),
+    ]
+    secondary = _StubProvider(name="coinbase", live_events=secondary_live)
+    reg = _registry_with(primary, secondary)
+
+    stop = StopController()
+
+    result = run_paper_trade(
+        strategy=_strategy(_ALTERNATING_STRATEGY),
+        backtest_config=_btc_config(),
+        paper_config=_paper_config(warmup_bars=0, min_fills=1),
+        stop_controller=stop,
+        registry=reg,
+    )
+    assert result.provider_id == "coinbase"
+    assert result.cutover_ts == "2024-05-01T12:01:00Z"
+
+
+def test_max_hours_wall_clock_guard() -> None:
+    live = [_native_bar(f"2024-05-01T12:{i:02d}:00Z", 100.0 + i) for i in range(1, 10)]
+    provider = _StubProvider(historical_bars=[], live_events=live)
+
+    clock_state = {"t": 1_000_000.0}
+
+    def _clock() -> float:
+        clock_state["t"] += 3_600.0 * 2.0  # each call advances 2h — beyond max_hours
+        return clock_state["t"]
+
+    result = run_paper_trade(
+        strategy=_strategy(_ALTERNATING_STRATEGY),
+        backtest_config=_btc_config(),
+        paper_config=_paper_config(warmup_bars=0, min_fills=999, max_hours=1.0),
+        stop_controller=StopController(),
+        registry=_registry_with(provider),
+        clock=_clock,
+    )
+    assert result.terminated_reason == "max_hours"
+
+
+def test_min_fills_below_20_emits_warning() -> None:
+    provider = _StubProvider(historical_bars=[], live_events=[])
+    result = run_paper_trade(
+        strategy=_strategy(_ALTERNATING_STRATEGY),
+        backtest_config=_btc_config(),
+        paper_config=_paper_config(warmup_bars=0, min_fills=5),
+        registry=_registry_with(provider),
+    )
+    assert "min_fills_below_recommended" in result.warnings
+
+
+def test_missing_strategy_code_raises() -> None:
+    provider = _StubProvider()
+    with pytest.raises(ValueError, match="strategy_code is required"):
+        run_paper_trade(
+            strategy=StrategySpec(
+                strategy_id="x",
+                authored_by="test",
+                asset_class="crypto",
+                hypothesis="h",
+                signal_definition="s",
+                strategy_code=None,
+            ),
+            backtest_config=_btc_config(),
+            paper_config=_paper_config(),
+            registry=_registry_with(provider),
+        )

--- a/backend/agents/investment_team/tests/test_paper_trade_api_fixes.py
+++ b/backend/agents/investment_team/tests/test_paper_trade_api_fixes.py
@@ -1,0 +1,154 @@
+"""Regression tests for the three Codex-flagged PR 2 issues.
+
+Covers:
+* ``_resolve_fee_overrides`` preserves explicit zero overrides (``0.0`` is
+  a valid user intent for zero-fee / zero-slip experiments).
+* ``_recover_orphaned_paper_trading_sessions`` marks sessions in any of
+  the PR 2 active states (OPENING / WARMING_UP / LIVE), not just the
+  legacy RUNNING state, so SIGKILL orphans cannot block the new
+  per-strategy concurrency guard.
+"""
+
+from __future__ import annotations
+
+from investment_team.api.main import (
+    RunPaperTradingRequest,
+    _paper_trading_sessions,
+    _recover_orphaned_paper_trading_sessions,
+    _resolve_fee_overrides,
+)
+from investment_team.models import (
+    PaperTradingSession,
+    PaperTradingStatus,
+    StrategySpec,
+)
+
+# ---------------------------------------------------------------------------
+# Fee-override resolution
+# ---------------------------------------------------------------------------
+
+
+def test_explicit_zero_tx_cost_is_preserved() -> None:
+    req = RunPaperTradingRequest(
+        lab_record_id="x",
+        transaction_cost_bps=0.0,
+        slippage_bps=0.0,
+    )
+    tx, slip = _resolve_fee_overrides(req)
+    assert tx == 0.0
+    assert slip == 0.0
+
+
+def test_missing_overrides_fall_back_to_defaults() -> None:
+    req = RunPaperTradingRequest(lab_record_id="x")
+    tx, slip = _resolve_fee_overrides(req)
+    assert tx == 5.0
+    assert slip == 2.0
+
+
+def test_mixed_overrides_default_only_what_is_missing() -> None:
+    req = RunPaperTradingRequest(lab_record_id="x", transaction_cost_bps=0.0)
+    tx, slip = _resolve_fee_overrides(req)
+    assert tx == 0.0  # explicit zero preserved
+    assert slip == 2.0  # default applied
+
+
+def test_nonzero_override_is_preserved() -> None:
+    req = RunPaperTradingRequest(
+        lab_record_id="x",
+        transaction_cost_bps=1.5,
+        slippage_bps=3.0,
+    )
+    tx, slip = _resolve_fee_overrides(req)
+    assert tx == 1.5
+    assert slip == 3.0
+
+
+# ---------------------------------------------------------------------------
+# Orphan recovery for PR 2 live statuses
+# ---------------------------------------------------------------------------
+
+
+def _make_session(session_id: str, status: PaperTradingStatus) -> PaperTradingSession:
+    return PaperTradingSession(
+        session_id=session_id,
+        lab_record_id="lr-1",
+        strategy=StrategySpec(
+            strategy_id=f"strat-{session_id}",
+            authored_by="test",
+            asset_class="crypto",
+            hypothesis="h",
+            signal_definition="s",
+        ),
+        status=status,
+        initial_capital=100_000.0,
+        current_capital=100_000.0,
+    )
+
+
+def _install_session(session: PaperTradingSession) -> None:
+    _paper_trading_sessions[session.session_id] = session
+
+
+def _fetch_session(session_id: str) -> PaperTradingSession:
+    raw = _paper_trading_sessions[session_id]
+    return PaperTradingSession(**raw) if isinstance(raw, dict) else raw
+
+
+def test_recovery_fails_opening_session() -> None:
+    session = _make_session("pt-opening", PaperTradingStatus.OPENING)
+    _install_session(session)
+    try:
+        _recover_orphaned_paper_trading_sessions()
+        recovered = _fetch_session("pt-opening")
+        assert recovered.status == PaperTradingStatus.FAILED
+        assert recovered.terminated_reason == "process_exit"
+        assert recovered.error is not None
+        assert "did not complete" in recovered.error
+    finally:
+        _paper_trading_sessions.pop("pt-opening", None)
+
+
+def test_recovery_fails_warming_up_session() -> None:
+    session = _make_session("pt-warm", PaperTradingStatus.WARMING_UP)
+    _install_session(session)
+    try:
+        _recover_orphaned_paper_trading_sessions()
+        assert _fetch_session("pt-warm").status == PaperTradingStatus.FAILED
+    finally:
+        _paper_trading_sessions.pop("pt-warm", None)
+
+
+def test_recovery_fails_live_session() -> None:
+    session = _make_session("pt-live", PaperTradingStatus.LIVE)
+    _install_session(session)
+    try:
+        _recover_orphaned_paper_trading_sessions()
+        assert _fetch_session("pt-live").status == PaperTradingStatus.FAILED
+    finally:
+        _paper_trading_sessions.pop("pt-live", None)
+
+
+def test_recovery_still_fails_legacy_running_session() -> None:
+    """The PR 1 behavior must remain intact after PR 2's extension."""
+    session = _make_session("pt-legacy", PaperTradingStatus.RUNNING)
+    _install_session(session)
+    try:
+        _recover_orphaned_paper_trading_sessions()
+        assert _fetch_session("pt-legacy").status == PaperTradingStatus.FAILED
+    finally:
+        _paper_trading_sessions.pop("pt-legacy", None)
+
+
+def test_recovery_leaves_terminal_sessions_untouched() -> None:
+    completed = _make_session("pt-done", PaperTradingStatus.COMPLETED)
+    failed = _make_session("pt-err", PaperTradingStatus.FAILED)
+    _install_session(completed)
+    _install_session(failed)
+    try:
+        _recover_orphaned_paper_trading_sessions()
+        assert _fetch_session("pt-done").status == PaperTradingStatus.COMPLETED
+        assert _fetch_session("pt-err").status == PaperTradingStatus.FAILED
+    finally:
+        _paper_trading_sessions.pop("pt-done", None)
+        _paper_trading_sessions.pop("pt-err", None)

--- a/backend/agents/investment_team/tests/test_provider_registry.py
+++ b/backend/agents/investment_team/tests/test_provider_registry.py
@@ -200,6 +200,76 @@ def test_describe_all_reports_has_key(monkeypatch: pytest.MonkeyPatch) -> None:
     assert polygon_row["has_key"] is True
 
 
+# ---------------------------------------------------------------------------
+# Env-var overrides (INVESTMENT_{LIVE,HISTORICAL}_PROVIDER_*)
+# ---------------------------------------------------------------------------
+
+
+def test_env_live_override_forces_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Operator env override must beat the free default."""
+    reg = _registry_with_defaults()
+    monkeypatch.setenv("INVESTMENT_LIVE_PROVIDER_CRYPTO", "coinbase")
+    adapter = reg.resolve(asset_class="crypto", direction="live")
+    assert adapter.capabilities.name == "coinbase"
+
+
+def test_env_live_override_beats_paid_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Env override outranks paid-with-key; only request-level explicit beats it."""
+    reg = _registry_with_defaults()
+    monkeypatch.setenv("POLYGON_API_KEY_TEST", "sekret")
+    monkeypatch.setenv("INVESTMENT_LIVE_PROVIDER_CRYPTO", "binance")
+    adapter = reg.resolve(asset_class="crypto", direction="live")
+    assert adapter.capabilities.name == "binance"
+
+
+def test_explicit_request_pin_beats_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    reg = _registry_with_defaults()
+    monkeypatch.setenv("INVESTMENT_LIVE_PROVIDER_CRYPTO", "coinbase")
+    adapter = reg.resolve(asset_class="crypto", direction="live", explicit="binance")
+    assert adapter.capabilities.name == "binance"
+
+
+def test_historical_env_override_uses_separate_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Historical and live env vars are independent knobs."""
+    reg = _registry_with_defaults()
+    # Set only LIVE; historical should still hit the free default.
+    monkeypatch.setenv("INVESTMENT_LIVE_PROVIDER_CRYPTO", "coinbase")
+    monkeypatch.delenv("INVESTMENT_HISTORICAL_PROVIDER_CRYPTO", raising=False)
+    live_adapter = reg.resolve(asset_class="crypto", direction="live")
+    hist_adapter = reg.resolve(asset_class="crypto", direction="historical")
+    assert live_adapter.capabilities.name == "coinbase"
+    assert hist_adapter.capabilities.name == "binance"
+
+
+def test_invalid_env_override_falls_back_silently(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A misconfigured env var must not wedge the server."""
+    reg = _registry_with_defaults()
+    monkeypatch.setenv("INVESTMENT_LIVE_PROVIDER_CRYPTO", "nonexistent_provider")
+    adapter = reg.resolve(asset_class="crypto", direction="live")
+    # Falls through to paid-with-key (none set) → free default.
+    assert adapter.capabilities.name == "binance"
+
+
+def test_env_override_for_unsupported_asset_class_falls_back(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the pinned provider doesn't support the class, fall back cleanly."""
+    reg = _registry_with_defaults()
+    # binance only supports crypto; asking for equities with a binance pin
+    # should ignore the pin and fall back through the selection chain. In
+    # this registry there's no equities provider, so LookupError is expected.
+    monkeypatch.setenv("INVESTMENT_LIVE_PROVIDER_EQUITIES", "binance")
+    with pytest.raises(LookupError):
+        reg.resolve(asset_class="equities", direction="live")
+
+
+def test_empty_env_var_is_ignored(monkeypatch: pytest.MonkeyPatch) -> None:
+    reg = _registry_with_defaults()
+    monkeypatch.setenv("INVESTMENT_LIVE_PROVIDER_CRYPTO", "   ")
+    adapter = reg.resolve(asset_class="crypto", direction="live")
+    assert adapter.capabilities.name == "binance"
+
+
 def test_registering_duplicate_name_raises() -> None:
     reg = _registry_with_defaults()
     with pytest.raises(ValueError, match="already registered"):

--- a/backend/agents/investment_team/tests/test_provider_registry.py
+++ b/backend/agents/investment_team/tests/test_provider_registry.py
@@ -1,0 +1,214 @@
+"""Unit tests for the provider registry selection logic.
+
+Covers the three-tier selection order from §3.2 plus the crypto
+Binance → Coinbase geo-failover from the Binance-blocked-region table.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterator, Optional
+
+import pytest
+
+from investment_team.trading_service.data_stream.protocol import BarEvent
+from investment_team.trading_service.data_stream.resampler import NativeEvent
+from investment_team.trading_service.providers.base import (
+    ProviderCapabilities,
+    ProviderRegionBlocked,
+)
+from investment_team.trading_service.providers.registry import ProviderRegistry
+
+
+class _StubAdapter:
+    """Minimal in-memory adapter used by the tests."""
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        supports: set[str],
+        is_paid: bool = False,
+        historical: bool = True,
+        live: bool = True,
+        region_block: bool = False,
+    ) -> None:
+        self.capabilities = ProviderCapabilities(
+            name=name,
+            supports=supports,
+            is_paid=is_paid,
+            historical_timeframes={"1m"} if historical else set(),
+            live_timeframes={"1m"} if live else set(),
+        )
+        self._region_block = region_block
+
+    def smallest_available(self, asset_class: str, *, live: bool) -> Optional[str]:
+        return "1m"
+
+    def historical(self, **kwargs) -> Iterator[BarEvent]:
+        return iter(())
+
+    def live(self, **kwargs) -> Iterator[NativeEvent]:
+        if self._region_block:
+            raise ProviderRegionBlocked(f"{self.capabilities.name} region-blocked")
+        return iter(())
+
+
+# ---------------------------------------------------------------------------
+# Selection precedence
+# ---------------------------------------------------------------------------
+
+
+def _registry_with_defaults() -> ProviderRegistry:
+    reg = ProviderRegistry()
+    reg.register(
+        lambda: _StubAdapter("binance", supports={"crypto"}),
+        ProviderCapabilities(
+            name="binance",
+            supports={"crypto"},
+            historical_timeframes={"1m"},
+            live_timeframes={"1m"},
+        ),
+        default_for=["crypto"],
+    )
+    reg.register(
+        lambda: _StubAdapter("coinbase", supports={"crypto"}),
+        ProviderCapabilities(
+            name="coinbase",
+            supports={"crypto"},
+            historical_timeframes={"1m"},
+            live_timeframes={"1m"},
+        ),
+        secondary_for=["crypto"],
+    )
+    reg.register(
+        lambda: _StubAdapter("polygon", supports={"crypto", "equities"}, is_paid=True),
+        ProviderCapabilities(
+            name="polygon",
+            supports={"crypto", "equities"},
+            is_paid=True,
+            historical_timeframes={"1m"},
+            live_timeframes={"1m"},
+        ),
+        api_key_env="POLYGON_API_KEY_TEST",
+    )
+    return reg
+
+
+def test_free_default_selected_when_no_paid_key() -> None:
+    reg = _registry_with_defaults()
+    os.environ.pop("POLYGON_API_KEY_TEST", None)
+    adapter = reg.resolve(asset_class="crypto", direction="live")
+    assert adapter.capabilities.name == "binance"
+
+
+def test_paid_provider_preferred_when_key_is_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    reg = _registry_with_defaults()
+    monkeypatch.setenv("POLYGON_API_KEY_TEST", "sekret")
+    adapter = reg.resolve(asset_class="crypto", direction="live")
+    assert adapter.capabilities.name == "polygon"
+
+
+def test_explicit_override_wins_over_paid_and_free(monkeypatch: pytest.MonkeyPatch) -> None:
+    reg = _registry_with_defaults()
+    monkeypatch.setenv("POLYGON_API_KEY_TEST", "sekret")
+    adapter = reg.resolve(asset_class="crypto", direction="live", explicit="binance")
+    assert adapter.capabilities.name == "binance"
+
+
+def test_explicit_unknown_provider_raises() -> None:
+    reg = _registry_with_defaults()
+    with pytest.raises(KeyError, match="nope"):
+        reg.resolve(asset_class="crypto", direction="live", explicit="nope")
+
+
+def test_explicit_provider_without_asset_support_raises() -> None:
+    reg = _registry_with_defaults()
+    # binance only supports crypto, not equities
+    with pytest.raises(ValueError, match="does not support asset_class"):
+        reg.resolve(asset_class="equities", direction="live", explicit="binance")
+
+
+def test_direction_filter_excludes_historical_only_adapters() -> None:
+    reg = ProviderRegistry()
+    reg.register(
+        lambda: _StubAdapter("hist_only", supports={"crypto"}, live=False),
+        ProviderCapabilities(
+            name="hist_only",
+            supports={"crypto"},
+            historical_timeframes={"1m"},
+            live_timeframes=set(),
+        ),
+        default_for=["crypto"],
+    )
+    with pytest.raises(LookupError, match="no provider available"):
+        reg.resolve(asset_class="crypto", direction="live")
+
+
+def test_no_provider_available_raises() -> None:
+    reg = ProviderRegistry()
+    with pytest.raises(LookupError, match="no provider available"):
+        reg.resolve(asset_class="crypto", direction="live")
+
+
+# ---------------------------------------------------------------------------
+# Geo-failover
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_live_returns_fallback_for_crypto_when_no_explicit() -> None:
+    reg = _registry_with_defaults()
+    resolution = reg.resolve_live(asset_class="crypto")
+    assert resolution.primary_name == "binance"
+    assert resolution.fallback_name == "coinbase"
+
+
+def test_resolve_live_no_fallback_when_user_pins_provider() -> None:
+    reg = _registry_with_defaults()
+    resolution = reg.resolve_live(asset_class="crypto", explicit="binance")
+    assert resolution.primary_name == "binance"
+    # An explicit pin means the user opted out of auto-failover.
+    assert resolution.fallback is None
+
+
+def test_resolve_live_paid_primary_no_crypto_secondary(monkeypatch: pytest.MonkeyPatch) -> None:
+    reg = _registry_with_defaults()
+    monkeypatch.setenv("POLYGON_API_KEY_TEST", "sekret")
+    resolution = reg.resolve_live(asset_class="crypto")
+    assert resolution.primary_name == "polygon"
+    # Coinbase is still the secondary_for crypto — failover still applies even
+    # when the primary is paid (covers "paid API key is flaky / regional").
+    assert resolution.fallback_name == "coinbase"
+
+
+# ---------------------------------------------------------------------------
+# describe_all
+# ---------------------------------------------------------------------------
+
+
+def test_describe_all_reports_has_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    reg = _registry_with_defaults()
+    monkeypatch.delenv("POLYGON_API_KEY_TEST", raising=False)
+    listing = reg.describe_all()
+    polygon_row = next(r for r in listing if r["name"] == "polygon")
+    assert polygon_row["has_key"] is False
+    assert polygon_row["is_paid"] is True
+
+    monkeypatch.setenv("POLYGON_API_KEY_TEST", "sekret")
+    listing = reg.describe_all()
+    polygon_row = next(r for r in listing if r["name"] == "polygon")
+    assert polygon_row["has_key"] is True
+
+
+def test_registering_duplicate_name_raises() -> None:
+    reg = _registry_with_defaults()
+    with pytest.raises(ValueError, match="already registered"):
+        reg.register(
+            lambda: _StubAdapter("binance", supports={"crypto"}),
+            ProviderCapabilities(
+                name="binance",
+                supports={"crypto"},
+                historical_timeframes={"1m"},
+                live_timeframes={"1m"},
+            ),
+        )

--- a/backend/agents/investment_team/tests/test_resampler.py
+++ b/backend/agents/investment_team/tests/test_resampler.py
@@ -1,0 +1,273 @@
+"""Unit tests for the candle resampler.
+
+Focus: the three invariants from ``system_design/pr2_live_data_and_paper_cutover.md``
+§3.4 — only finalized bars leave, monotonic timestamps, no fabricated bars in
+gaps — plus the passthrough and upscale-from-native-bar paths.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from investment_team.trading_service.data_stream.protocol import BarEvent
+from investment_team.trading_service.data_stream.resampler import (
+    NativeBar,
+    NativeTick,
+    Resampler,
+    timeframe_to_seconds,
+)
+
+# ---------------------------------------------------------------------------
+# Timeframe parsing
+# ---------------------------------------------------------------------------
+
+
+def test_timeframe_to_seconds_known_values() -> None:
+    assert timeframe_to_seconds("1s") == 1
+    assert timeframe_to_seconds("15s") == 15
+    assert timeframe_to_seconds("1m") == 60
+    assert timeframe_to_seconds("15m") == 900
+    assert timeframe_to_seconds("1h") == 3600
+    assert timeframe_to_seconds("1d") == 86_400
+
+
+def test_timeframe_to_seconds_unknown_raises() -> None:
+    with pytest.raises(ValueError, match="unknown timeframe"):
+        timeframe_to_seconds("42q")
+
+
+# ---------------------------------------------------------------------------
+# Tick path
+# ---------------------------------------------------------------------------
+
+
+def _tick(ts: str, price: float, size: float = 1.0, symbol: str = "BTC") -> NativeTick:
+    return NativeTick(timestamp=ts, symbol=symbol, price=price, size=size)
+
+
+def _collect(iterator) -> List[BarEvent]:
+    return list(iterator)
+
+
+def test_ticks_into_1m_bar_emits_on_next_interval_boundary() -> None:
+    """A 1m bar is emitted only after a tick in the *next* minute arrives."""
+    r = Resampler("1m")
+    emitted: List[BarEvent] = []
+
+    # All three ticks fall within the same minute [12:00:00, 12:01:00).
+    emitted += _collect(r.feed_native(_tick("2024-05-01T12:00:05Z", 100.0, 10)))
+    emitted += _collect(r.feed_native(_tick("2024-05-01T12:00:30Z", 102.0, 5)))
+    emitted += _collect(r.feed_native(_tick("2024-05-01T12:00:59Z", 101.5, 3)))
+    assert emitted == []  # no bar yet — minute not closed
+
+    # The first tick of the next minute finalizes the previous bar.
+    emitted += _collect(r.feed_native(_tick("2024-05-01T12:01:02Z", 103.0, 2)))
+    assert len(emitted) == 1
+    bar = emitted[0].bar
+    assert bar.symbol == "BTC"
+    assert bar.timeframe == "1m"
+    assert bar.timestamp == "2024-05-01T12:01:00Z"  # close time of the 12:00 bar
+    assert bar.open == 100.0
+    assert bar.high == 102.0
+    assert bar.low == 100.0
+    assert bar.close == 101.5
+    assert bar.volume == 18.0
+
+
+def test_ticks_partial_bar_is_not_emitted_on_flush() -> None:
+    """End-of-stream must NOT emit an in-progress bar (look-ahead safety)."""
+    r = Resampler("1m")
+    _collect(r.feed_native(_tick("2024-05-01T12:00:05Z", 100.0)))
+    _collect(r.feed_native(_tick("2024-05-01T12:00:30Z", 101.0)))
+    # No later tick arrives.
+    assert _collect(r.flush_on_end()) == []
+
+
+def test_ticks_gap_emits_no_fabricated_bars() -> None:
+    """If a full minute passes with no tick, no placeholder bar is emitted."""
+    r = Resampler("1m")
+    emitted: List[BarEvent] = []
+    emitted += _collect(r.feed_native(_tick("2024-05-01T12:00:05Z", 100.0)))
+    # Skip 12:01 entirely; next tick is at 12:02:05.
+    emitted += _collect(r.feed_native(_tick("2024-05-01T12:02:05Z", 110.0)))
+    # Only one bar emitted: the 12:00 bar, finalized by the 12:02 tick.
+    # The 12:01 gap is preserved as absence, not a zero-volume bar.
+    assert len(emitted) == 1
+    assert emitted[0].bar.timestamp == "2024-05-01T12:01:00Z"
+    assert emitted[0].bar.close == 100.0
+
+
+def test_out_of_order_tick_is_dropped_and_counted() -> None:
+    r = Resampler("1m")
+    # Advance past 12:00 — first bar finalized by a 12:01 tick.
+    _collect(r.feed_native(_tick("2024-05-01T12:00:05Z", 100.0)))
+    emitted = _collect(r.feed_native(_tick("2024-05-01T12:01:30Z", 101.0)))
+    assert len(emitted) == 1
+
+    # Now send a late print from 12:00 — must be dropped.
+    late = _collect(r.feed_native(_tick("2024-05-01T12:00:45Z", 999.0)))
+    assert late == []
+    assert r.stats.out_of_order_dropped == 1
+
+
+def test_multi_symbol_ticks_are_independent() -> None:
+    r = Resampler("1m")
+    emitted: List[BarEvent] = []
+    emitted += _collect(r.feed_native(_tick("2024-05-01T12:00:05Z", 100.0, symbol="BTC")))
+    emitted += _collect(r.feed_native(_tick("2024-05-01T12:00:10Z", 50.0, symbol="ETH")))
+    emitted += _collect(r.feed_native(_tick("2024-05-01T12:01:01Z", 101.0, symbol="BTC")))
+    # Only BTC's 12:00 bar is done — ETH's isn't (no later ETH tick yet).
+    assert len(emitted) == 1
+    assert emitted[0].bar.symbol == "BTC"
+
+    # ETH later tick finalizes ETH's bar.
+    emitted += _collect(r.feed_native(_tick("2024-05-01T12:01:02Z", 51.0, symbol="ETH")))
+    assert len(emitted) == 2
+    assert emitted[1].bar.symbol == "ETH"
+
+
+def test_ticks_resampled_to_15m() -> None:
+    r = Resampler("15m")
+    # Three ticks inside [12:00, 12:15), then one in the next interval.
+    _collect(r.feed_native(_tick("2024-05-01T12:00:00Z", 100.0, 10)))
+    _collect(r.feed_native(_tick("2024-05-01T12:07:30Z", 95.0, 5)))  # low
+    _collect(r.feed_native(_tick("2024-05-01T12:14:59Z", 110.0, 3)))  # high then close?
+    # Tick order determines "last price" — close is last tick's price.
+    emitted = _collect(r.feed_native(_tick("2024-05-01T12:15:10Z", 112.0, 1)))
+    assert len(emitted) == 1
+    bar = emitted[0].bar
+    assert bar.timestamp == "2024-05-01T12:15:00Z"
+    assert bar.open == 100.0
+    assert bar.high == 110.0
+    assert bar.low == 95.0
+    assert bar.close == 110.0  # last tick IN the interval
+    assert bar.volume == 18.0
+
+
+# ---------------------------------------------------------------------------
+# Native-bar passthrough (native == target)
+# ---------------------------------------------------------------------------
+
+
+def _native_bar(
+    close_ts: str,
+    tf: str,
+    o: float,
+    h: float,
+    low_: float,
+    c: float,
+    vol: float = 0.0,
+    symbol: str = "BTC",
+) -> NativeBar:
+    return NativeBar(
+        timestamp=close_ts,
+        symbol=symbol,
+        timeframe=tf,
+        open=o,
+        high=h,
+        low=low_,
+        close=c,
+        volume=vol,
+    )
+
+
+def test_native_bar_passthrough_when_tf_matches_target() -> None:
+    r = Resampler("1m")
+    emitted = _collect(
+        r.feed_native(_native_bar("2024-05-01T12:01:00Z", "1m", 100, 102, 99, 101, 500))
+    )
+    assert len(emitted) == 1
+    bar = emitted[0].bar
+    assert bar.timestamp == "2024-05-01T12:01:00Z"
+    assert bar.timeframe == "1m"
+    assert bar.close == 101
+    assert bar.volume == 500
+
+
+def test_native_bar_coarser_than_target_raises() -> None:
+    r = Resampler("1m")
+    with pytest.raises(ValueError, match="coarser than target"):
+        _collect(r.feed_native(_native_bar("2024-05-01T12:05:00Z", "5m", 100, 102, 99, 101)))
+
+
+# ---------------------------------------------------------------------------
+# Upscale (native < target)
+# ---------------------------------------------------------------------------
+
+
+def test_upscale_1m_native_bars_into_5m() -> None:
+    """Five 1m native bars fold into one 5m target bar."""
+    r = Resampler("5m")
+    emitted: List[BarEvent] = []
+
+    # 12:01 close covers [12:00, 12:01)
+    emitted += _collect(
+        r.feed_native(_native_bar("2024-05-01T12:01:00Z", "1m", 100, 101, 99, 100.5, 10))
+    )
+    emitted += _collect(
+        r.feed_native(_native_bar("2024-05-01T12:02:00Z", "1m", 100.5, 103, 100, 102, 20))
+    )
+    emitted += _collect(
+        r.feed_native(_native_bar("2024-05-01T12:03:00Z", "1m", 102, 104, 101, 103, 15))
+    )
+    emitted += _collect(
+        r.feed_native(_native_bar("2024-05-01T12:04:00Z", "1m", 103, 103.5, 102, 102.5, 5))
+    )
+    # Fifth bar closes at 12:05:00 — exactly on the 5m boundary. Should
+    # finalize eagerly.
+    emitted += _collect(
+        r.feed_native(_native_bar("2024-05-01T12:05:00Z", "1m", 102.5, 105, 102, 104.5, 25))
+    )
+
+    assert len(emitted) == 1
+    bar = emitted[0].bar
+    assert bar.timestamp == "2024-05-01T12:05:00Z"
+    assert bar.timeframe == "5m"
+    assert bar.open == 100  # first-native open
+    assert bar.high == 105
+    assert bar.low == 99
+    assert bar.close == 104.5  # last-native close
+    assert bar.volume == 75  # sum
+
+
+def test_upscale_with_gap_does_not_fabricate_bars() -> None:
+    r = Resampler("5m")
+    emitted: List[BarEvent] = []
+    # Two 1m bars in [12:00, 12:05)...
+    emitted += _collect(
+        r.feed_native(_native_bar("2024-05-01T12:01:00Z", "1m", 100, 101, 99, 100.5, 10))
+    )
+    emitted += _collect(
+        r.feed_native(_native_bar("2024-05-01T12:02:00Z", "1m", 100.5, 102, 100, 101, 5))
+    )
+    # Gap: no bars for 12:02-12:05. Next bar arrives in [12:05, 12:10).
+    emitted += _collect(
+        r.feed_native(_native_bar("2024-05-01T12:06:00Z", "1m", 110, 111, 109, 110.5, 20))
+    )
+    # The [12:00, 12:05) 5m bar is now finalized (because 12:06 > 12:05).
+    # No bars for the gap should appear.
+    assert len(emitted) == 1
+    assert emitted[0].bar.timestamp == "2024-05-01T12:05:00Z"
+    assert emitted[0].bar.close == 101
+    # The new partial (for [12:05, 12:10)) is not yet emitted.
+
+
+# ---------------------------------------------------------------------------
+# Stats
+# ---------------------------------------------------------------------------
+
+
+def test_stats_count_bars_and_symbols() -> None:
+    r = Resampler("1m")
+    _collect(r.feed_native(_tick("2024-05-01T12:00:05Z", 100.0, symbol="BTC")))
+    _collect(
+        r.feed_native(_tick("2024-05-01T12:01:05Z", 101.0, symbol="BTC"))
+    )  # finalizes BTC 12:00
+    _collect(r.feed_native(_tick("2024-05-01T12:00:10Z", 50.0, symbol="ETH")))
+    _collect(
+        r.feed_native(_tick("2024-05-01T12:01:10Z", 51.0, symbol="ETH"))
+    )  # finalizes ETH 12:00
+    assert r.stats.bars_emitted == 2
+    assert r.stats.symbols == {"BTC": 1, "ETH": 1}

--- a/backend/agents/investment_team/tests/test_subdaily_backtest.py
+++ b/backend/agents/investment_team/tests/test_subdaily_backtest.py
@@ -1,0 +1,230 @@
+"""Sub-daily backtest end-to-end via provider registry.
+
+PR 2 §4.1 — the provider-driven backtest path should resolve a historical
+adapter through the registry and stream bars at the strategy's declared
+timeframe (e.g. ``"15m"``), sharing the exact event loop and metrics
+computation the daily-bar backtest uses.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from typing import Iterator, List, Optional
+
+import pytest
+
+from investment_team.models import BacktestConfig, StrategySpec
+from investment_team.trading_service.data_stream.protocol import BarEvent
+from investment_team.trading_service.data_stream.resampler import NativeEvent
+from investment_team.trading_service.modes.backtest import run_backtest
+from investment_team.trading_service.providers.base import ProviderCapabilities
+from investment_team.trading_service.providers.registry import ProviderRegistry
+from investment_team.trading_service.strategy.contract import Bar
+
+_SMA_STRATEGY_CODE = textwrap.dedent("""\
+    from contract import OrderSide, OrderType, Strategy
+
+
+    class SmaCrossover(Strategy):
+        WINDOW = 3
+
+        def on_bar(self, ctx, bar):
+            history = ctx.history(bar.symbol, self.WINDOW)
+            if len(history) < self.WINDOW:
+                return
+            sma = sum(b.close for b in history) / self.WINDOW
+            pos = ctx.position(bar.symbol)
+            if pos is None and bar.close > sma:
+                ctx.submit_order(
+                    symbol=bar.symbol,
+                    side=OrderSide.LONG,
+                    qty=1,
+                    order_type=OrderType.MARKET,
+                    reason="x",
+                )
+            elif pos is not None and bar.close < sma:
+                ctx.submit_order(
+                    symbol=bar.symbol,
+                    side=OrderSide.SHORT,
+                    qty=pos.qty,
+                    order_type=OrderType.MARKET,
+                    reason="y",
+                )
+""")
+
+
+class _StubHistoricalProvider:
+    """Emits a fixed list of BarEvents for any (symbols, range, timeframe)."""
+
+    capabilities = ProviderCapabilities(
+        name="stub_hist",
+        supports={"crypto"},
+        historical_timeframes={"15m", "1h", "1d"},
+        live_timeframes=set(),
+    )
+
+    def __init__(self, bars: List[BarEvent]) -> None:
+        self._bars = bars
+        self.last_call: Optional[dict] = None
+
+    def smallest_available(self, asset_class: str, *, live: bool) -> Optional[str]:
+        if asset_class != "crypto" or live:
+            return None
+        return "15m"
+
+    def historical(self, **kwargs) -> Iterator[BarEvent]:
+        self.last_call = kwargs
+        yield from self._bars
+
+    def live(self, **kwargs) -> Iterator[NativeEvent]:
+        raise NotImplementedError("historical-only stub")
+
+
+def _bar(ts: str, close: float, symbol: str = "BTC", tf: str = "15m") -> BarEvent:
+    return BarEvent(
+        bar=Bar(
+            symbol=symbol,
+            timestamp=ts,
+            timeframe=tf,
+            open=close - 0.1,
+            high=close + 0.1,
+            low=close - 0.2,
+            close=close,
+            volume=1.0,
+        )
+    )
+
+
+def _strategy() -> StrategySpec:
+    return StrategySpec(
+        strategy_id="sub-daily",
+        authored_by="test",
+        asset_class="crypto",
+        hypothesis="h",
+        signal_definition="s",
+        entry_rules=[],
+        exit_rules=[],
+        strategy_code=_SMA_STRATEGY_CODE,
+    )
+
+
+def _config() -> BacktestConfig:
+    return BacktestConfig(
+        start_date="2024-05-01",
+        end_date="2024-05-02",
+        initial_capital=100_000.0,
+        transaction_cost_bps=0.0,
+        slippage_bps=0.0,
+        metrics_engine="legacy",
+    )
+
+
+def _registry_with(provider: _StubHistoricalProvider) -> ProviderRegistry:
+    reg = ProviderRegistry()
+    reg.register(
+        lambda p=provider: p,
+        provider.capabilities,
+        default_for=["crypto"],
+    )
+    return reg
+
+
+def test_provider_driven_backtest_15m() -> None:
+    """End-to-end 15m backtest with at least one closed trade."""
+    bars = [
+        # Priming bars for the SMA(3) window, then an up-move that triggers entry,
+        # followed by a down-move that triggers exit.
+        _bar("2024-05-01T00:15:00Z", 100.0),
+        _bar("2024-05-01T00:30:00Z", 100.5),
+        _bar("2024-05-01T00:45:00Z", 101.0),
+        _bar("2024-05-01T01:00:00Z", 104.0),  # crosses above SMA → entry
+        _bar("2024-05-01T01:15:00Z", 106.0),  # fill entry
+        _bar("2024-05-01T01:30:00Z", 102.0),
+        _bar("2024-05-01T01:45:00Z", 95.0),  # crosses below SMA → exit
+        _bar("2024-05-01T02:00:00Z", 92.0),  # fill exit
+    ]
+    provider = _StubHistoricalProvider(bars)
+    run = run_backtest(
+        strategy=_strategy(),
+        config=_config(),
+        symbols=["BTC"],
+        asset_class="crypto",
+        timeframe="15m",
+        registry=_registry_with(provider),
+    )
+    assert run.service_result.error is None, run.service_result.error
+    assert len(run.trades) >= 1
+    assert provider.last_call is not None
+    assert provider.last_call["timeframe"] == "15m"
+    assert provider.last_call["symbols"] == ["BTC"]
+
+
+def test_explicit_provider_id_routes_to_that_provider() -> None:
+    primary = _StubHistoricalProvider([])
+    secondary = _StubHistoricalProvider([])
+    reg = ProviderRegistry()
+    reg.register(lambda: primary, primary.capabilities, default_for=["crypto"])
+    reg.register(
+        lambda: secondary,
+        ProviderCapabilities(
+            name="secondary",
+            supports={"crypto"},
+            historical_timeframes={"15m"},
+            live_timeframes=set(),
+        ),
+    )
+    run_backtest(
+        strategy=_strategy(),
+        config=_config(),
+        symbols=["BTC"],
+        asset_class="crypto",
+        timeframe="15m",
+        provider_id="secondary",
+        registry=reg,
+    )
+    # Primary's `last_call` should remain None; secondary should have been used.
+    assert primary.last_call is None
+
+
+def test_neither_data_source_raises() -> None:
+    with pytest.raises(ValueError, match="exactly one data source"):
+        run_backtest(
+            strategy=_strategy(),
+            config=_config(),
+        )
+
+
+def test_both_data_sources_raises() -> None:
+    with pytest.raises(ValueError, match="exactly one data source"):
+        run_backtest(
+            strategy=_strategy(),
+            config=_config(),
+            market_data={},
+            symbols=["BTC"],
+            asset_class="crypto",
+        )
+
+
+def test_legacy_market_data_path_still_works() -> None:
+    """The legacy pre-fetched-dict path should be unchanged from PR 1."""
+    from investment_team.market_data_service import OHLCVBar
+
+    market_data = {
+        "BTC": [
+            OHLCVBar(
+                date="2024-05-01",
+                open=100.0,
+                high=101.0,
+                low=99.0,
+                close=100.5,
+                volume=1.0,
+            )
+        ]
+    }
+    run = run_backtest(
+        strategy=_strategy(),
+        config=_config(),
+        market_data=market_data,
+        timeframe="1d",
+    )
+    assert run.service_result.error is None

--- a/backend/agents/investment_team/trading_service/data_stream/__init__.py
+++ b/backend/agents/investment_team/trading_service/data_stream/__init__.py
@@ -1,12 +1,46 @@
 """Market data streams consumed by the Trading Service event loop."""
 
 from .historical_replay import HistoricalReplayStream
+from .live_stream import (
+    CutoverEvent,
+    LiveBarEvent,
+    LiveStream,
+    LiveStreamConfig,
+    LiveStreamEnd,
+    LiveStreamError,
+    LiveStreamEvent,
+    WarmupBarEvent,
+)
 from .protocol import BarEvent, EndOfStreamEvent, MarketDataStream, StreamEvent
+from .provider_stream import ProviderHistoricalStream
+from .resampler import (
+    NativeBar,
+    NativeEvent,
+    NativeTick,
+    Resampler,
+    ResamplerStats,
+    timeframe_to_seconds,
+)
 
 __all__ = [
     "BarEvent",
+    "CutoverEvent",
     "EndOfStreamEvent",
     "HistoricalReplayStream",
+    "LiveBarEvent",
+    "LiveStream",
+    "LiveStreamConfig",
+    "LiveStreamEnd",
+    "LiveStreamError",
+    "LiveStreamEvent",
     "MarketDataStream",
+    "NativeBar",
+    "NativeEvent",
+    "NativeTick",
+    "ProviderHistoricalStream",
+    "Resampler",
+    "ResamplerStats",
     "StreamEvent",
+    "WarmupBarEvent",
+    "timeframe_to_seconds",
 ]

--- a/backend/agents/investment_team/trading_service/data_stream/live_stream.py
+++ b/backend/agents/investment_team/trading_service/data_stream/live_stream.py
@@ -1,0 +1,291 @@
+"""Live market-data stream — adapter → resampler → BarEvent.
+
+:class:`LiveStream` composes a :class:`ProviderAdapter` with the
+:class:`Resampler` to produce a :class:`MarketDataStream` that can drive
+:class:`TradingService` exactly the same way the backtest's
+:class:`HistoricalReplayStream` does.
+
+The live stream has two phases:
+
+1. **Warm-up** — yields :class:`BarEvent` objects marked with metadata so
+   the paper-trade mode can deliver them to the strategy harness with
+   ``is_warmup=True``. Warm-up bars come from the provider's **historical**
+   endpoint (bar.timestamp strictly < cut-over).
+2. **Live** — yields BarEvents from the live feed after resampling.
+
+The cut-over is captured when the *first* live native event arrives. Any
+warm-up bar whose timestamp ``>= cutover_ts`` is dropped (defense in
+depth against a provider returning "recent" data that bleeds past the cut-
+over instant).
+
+``LiveStream`` is **not** a MarketDataStream directly — because the
+warm-up vs. live tagging is relevant to the paper-trade mode, the stream
+yields its own :class:`LiveStreamEvent` union and the paper-trade mode
+translates those into the underlying engine events. That keeps the
+engine's ``StreamEvent`` contract narrow (bars + end) and puts the
+live-specific concerns in one place.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Callable, Iterator, List, Optional, Union
+
+from ..providers.base import ProviderAdapter, ProviderError, ProviderRegionBlocked
+from ..strategy.contract import Bar
+from .resampler import Resampler
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Events emitted by LiveStream to the paper-trade mode.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class WarmupBarEvent:
+    """A bar delivered during warm-up; strategy sees it with is_warmup=True."""
+
+    bar: Bar
+
+
+@dataclass
+class LiveBarEvent:
+    """A finalized bar from the live feed."""
+
+    bar: Bar
+
+
+@dataclass
+class CutoverEvent:
+    """Emitted exactly once, between warm-up and live, carrying the cutover ts."""
+
+    cutover_ts: str
+
+
+@dataclass
+class LiveStreamError:
+    """Terminal event — the live feed ended with an error."""
+
+    reason: str
+    is_region_block: bool = False
+
+
+@dataclass
+class LiveStreamEnd:
+    """Terminal event — the live feed ended cleanly (e.g., user stop)."""
+
+    reason: str = "stopped"
+
+
+LiveStreamEvent = Union[
+    WarmupBarEvent,
+    CutoverEvent,
+    LiveBarEvent,
+    LiveStreamError,
+    LiveStreamEnd,
+]
+
+
+# ---------------------------------------------------------------------------
+# LiveStream
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class LiveStreamConfig:
+    symbols: List[str]
+    asset_class: str
+    strategy_timeframe: str
+    warmup_bars: int = 500
+    stop_flag: Optional[Callable[[], bool]] = None  # returns True when session should stop
+
+
+class LiveStream:
+    """Compose provider + resampler into a paper-trade-ready event stream.
+
+    Instances are single-use; iterate :meth:`events` to drain.
+    """
+
+    def __init__(
+        self,
+        *,
+        provider: ProviderAdapter,
+        config: LiveStreamConfig,
+    ) -> None:
+        self._provider = provider
+        self._config = config
+        self._resampler = Resampler(config.strategy_timeframe)
+        self._cutover_ts: Optional[str] = None
+
+    # ------------------------------------------------------------------
+
+    @property
+    def cutover_ts(self) -> Optional[str]:
+        return self._cutover_ts
+
+    # ------------------------------------------------------------------
+
+    def events(self) -> Iterator[LiveStreamEvent]:
+        try:
+            yield from self._warmup()
+        except ProviderRegionBlocked as exc:
+            yield LiveStreamError(reason=str(exc), is_region_block=True)
+            return
+        except ProviderError as exc:
+            yield LiveStreamError(reason=str(exc))
+            return
+
+        # Now open the live feed. The provider may raise
+        # ProviderRegionBlocked on the first iteration of its generator;
+        # that is the geo-failover hand-off point.
+        try:
+            yield from self._live()
+        except ProviderRegionBlocked as exc:
+            # Only a concern if this happens before the first live bar; the
+            # registry-level failover runs before us. If we see it here, the
+            # session is already committed and must terminate.
+            yield LiveStreamError(reason=str(exc), is_region_block=True)
+        except ProviderError as exc:
+            yield LiveStreamError(reason=str(exc))
+
+    # ------------------------------------------------------------------
+    # Warm-up: pull historical bars from the provider at the strategy
+    # timeframe, emitting them as WarmupBarEvents.
+    # ------------------------------------------------------------------
+
+    def _warmup(self) -> Iterator[LiveStreamEvent]:
+        if self._config.warmup_bars <= 0:
+            return
+        tf = self._config.strategy_timeframe
+        if tf not in self._provider.capabilities.historical_timeframes:
+            # Provider can't serve the strategy timeframe natively on its
+            # historical endpoint. Warm-up is best-effort: log and skip rather
+            # than fail the session — many strategies work without warm-up.
+            logger.warning(
+                "provider %s does not expose timeframe %s on its historical "
+                "endpoint; skipping warm-up",
+                self._provider.capabilities.name,
+                tf,
+            )
+            return
+
+        start, end = _warmup_window(timeframe=tf, warmup_bars=self._config.warmup_bars)
+        try:
+            hist_iter = self._provider.historical(
+                symbols=self._config.symbols,
+                asset_class=self._config.asset_class,
+                start=start,
+                end=end,
+                timeframe=tf,
+            )
+            for bar_event in hist_iter:
+                yield WarmupBarEvent(bar=bar_event.bar)
+                if self._should_stop():
+                    yield LiveStreamEnd(reason="stopped_during_warmup")
+                    return
+        except NotImplementedError as exc:
+            # Provider has a valid shape but the historical pump isn't wired
+            # yet. Don't fail the session — continue to live phase without
+            # warm-up.
+            logger.warning(
+                "provider %s historical pump not implemented: %s — continuing without warm-up",
+                self._provider.capabilities.name,
+                exc,
+            )
+
+    # ------------------------------------------------------------------
+    # Live: stream native events through the resampler, tagging cutover
+    # on the first event.
+    # ------------------------------------------------------------------
+
+    def _live(self) -> Iterator[LiveStreamEvent]:
+        native_tf = self._provider.smallest_available(self._config.asset_class, live=True)
+        if native_tf is None:
+            yield LiveStreamError(
+                reason=(
+                    f"provider {self._provider.capabilities.name} has no live "
+                    f"feed for asset_class={self._config.asset_class!r}"
+                )
+            )
+            return
+
+        native_iter = self._provider.live(
+            symbols=self._config.symbols,
+            asset_class=self._config.asset_class,
+            native_timeframe=native_tf,
+        )
+
+        # Materialize the generator one event at a time. The provider is
+        # responsible for raising ProviderRegionBlocked / ProviderError;
+        # we catch them in the outer events() method.
+        for native_event in native_iter:
+            if self._cutover_ts is None:
+                # Capture the cut-over moment using the first live event's
+                # timestamp. Ticks and NativeBars both carry a ``timestamp``.
+                self._cutover_ts = getattr(native_event, "timestamp", None) or _now_iso()
+                yield CutoverEvent(cutover_ts=self._cutover_ts)
+
+            for bar_event in self._resampler.feed_native(native_event):
+                yield LiveBarEvent(bar=bar_event.bar)
+
+            if self._should_stop():
+                yield LiveStreamEnd(reason="user_stop")
+                return
+
+        # Provider generator exhausted without error — unusual for a live
+        # feed, but treat as clean end.
+        yield LiveStreamEnd(reason="provider_end")
+
+    # ------------------------------------------------------------------
+
+    def _should_stop(self) -> bool:
+        flag = self._config.stop_flag
+        return bool(flag and flag())
+
+
+# ---------------------------------------------------------------------------
+# Warm-up window computation.
+# ---------------------------------------------------------------------------
+
+
+def _warmup_window(*, timeframe: str, warmup_bars: int) -> tuple[str, str]:
+    """Return an (``start_iso``, ``end_iso``) pair covering at least
+    ``warmup_bars`` of the given ``timeframe``, ending slightly before "now".
+
+    The end is pulled back one full timeframe to avoid fetching the current
+    (partial) bar — the historical endpoint will typically return only
+    finalized bars anyway, but the belt-and-suspenders keeps us from
+    accidentally emitting a warm-up bar whose timestamp equals cut-over.
+    """
+    from .resampler import timeframe_to_seconds
+
+    tf_sec = timeframe_to_seconds(timeframe)
+    now_epoch = datetime.now(tz=timezone.utc).timestamp()
+    # Snap end to the prior bar boundary and subtract one extra bar of slack.
+    end_epoch = (int(now_epoch) // tf_sec) * tf_sec - tf_sec
+    start_epoch = end_epoch - warmup_bars * tf_sec
+    return _iso(start_epoch), _iso(end_epoch)
+
+
+def _iso(epoch: float) -> str:
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _now_iso() -> str:
+    return _iso(datetime.now(tz=timezone.utc).timestamp())
+
+
+__all__ = [
+    "CutoverEvent",
+    "LiveBarEvent",
+    "LiveStream",
+    "LiveStreamConfig",
+    "LiveStreamEnd",
+    "LiveStreamError",
+    "LiveStreamEvent",
+    "WarmupBarEvent",
+]

--- a/backend/agents/investment_team/trading_service/data_stream/protocol.py
+++ b/backend/agents/investment_team/trading_service/data_stream/protocol.py
@@ -16,9 +16,15 @@ from ..strategy.contract import Bar
 
 
 class BarEvent(BaseModel):
-    """A single finalized candle destined for the strategy."""
+    """A single finalized candle destined for the strategy.
+
+    When ``is_warmup`` is True, the service delivers the bar to the strategy
+    with ``ctx.is_warmup = True`` and suppresses fill simulation for that
+    bar — warm-up bars populate indicator history without side effects.
+    """
 
     bar: Bar
+    is_warmup: bool = False
 
 
 class EndOfStreamEvent(BaseModel):

--- a/backend/agents/investment_team/trading_service/data_stream/provider_stream.py
+++ b/backend/agents/investment_team/trading_service/data_stream/provider_stream.py
@@ -1,0 +1,64 @@
+"""Provider-backed historical stream.
+
+Thin adapter that iterates a :class:`ProviderAdapter`'s ``historical()``
+method and appends the :class:`EndOfStreamEvent` sentinel, so that a
+historical feed resolved through the registry can drive the same
+:class:`TradingService.run` that ``HistoricalReplayStream`` drives.
+
+Used by :func:`run_backtest` when the caller provides ``(symbols,
+asset_class)`` instead of a pre-fetched market-data dict — this is the
+path that unlocks sub-daily backtests without any changes to
+``MarketDataService``.
+"""
+
+from __future__ import annotations
+
+from typing import Iterator, List
+
+from ..providers.base import ProviderAdapter
+from .protocol import BarEvent, EndOfStreamEvent, StreamEvent
+
+
+class ProviderHistoricalStream:
+    """Iterate a provider's historical endpoint as a ``StreamEvent`` sequence."""
+
+    def __init__(
+        self,
+        *,
+        provider: ProviderAdapter,
+        symbols: List[str],
+        asset_class: str,
+        start: str,
+        end: str,
+        timeframe: str,
+    ) -> None:
+        self._provider = provider
+        self._symbols = symbols
+        self._asset_class = asset_class
+        self._start = start
+        self._end = end
+        self._timeframe = timeframe
+
+    def __iter__(self) -> Iterator[StreamEvent]:
+        for event in self._provider.historical(
+            symbols=self._symbols,
+            asset_class=self._asset_class,
+            start=self._start,
+            end=self._end,
+            timeframe=self._timeframe,
+        ):
+            # Providers already yield BarEvent — pass through unchanged.
+            if isinstance(event, BarEvent):
+                yield event
+            else:  # pragma: no cover - defensive
+                # If a provider ever starts emitting other event kinds, the
+                # engine would silently ignore them. Surface that here so it
+                # shows up in tests.
+                raise TypeError(
+                    f"provider returned non-BarEvent during historical stream: "
+                    f"{type(event).__name__}"
+                )
+        yield EndOfStreamEvent()
+
+
+__all__ = ["ProviderHistoricalStream"]

--- a/backend/agents/investment_team/trading_service/data_stream/resampler.py
+++ b/backend/agents/investment_team/trading_service/data_stream/resampler.py
@@ -1,0 +1,372 @@
+"""Candle resampler — provider-native events → strategy-timeframe BarEvents.
+
+The resampler is the bridge between whatever a provider natively emits
+(ticks, 1s/1m aggregates, etc.) and the timeframe the strategy asked for
+(``"15m"``, ``"1m"``, ``"1h"``, …). It enforces three invariants critical
+to the look-ahead guarantee:
+
+1. **Only finalized bars leave.** A bar for interval ``[t_start, t_end)``
+   is emitted strictly *after* a native event with timestamp ``>= t_end``
+   arrives. The in-progress bar is never observable.
+
+2. **Monotonic timestamps.** Native events whose timestamp is earlier
+   than the last emitted bar close are dropped (and counted) as late
+   prints. A bar never carries an earlier close than its predecessor.
+
+3. **No fabricated bars in gaps.** If no native event arrives in a full
+   interval, the resampler emits nothing for that interval — a new bar
+   is opened when a later event comes in, aligned to its own interval.
+
+See ``system_design/pr2_live_data_and_paper_cutover.md`` §3.4 / §4.4.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Dict, Iterator, Union
+
+from pydantic import BaseModel
+
+from ..strategy.contract import Bar
+from .protocol import BarEvent
+
+# ---------------------------------------------------------------------------
+# Native event types (internal to the data_stream layer).
+# ---------------------------------------------------------------------------
+
+
+class NativeTick(BaseModel):
+    """A single trade print from a provider tick feed."""
+
+    timestamp: str  # ISO-8601; may or may not include offset (parsed as UTC if naive)
+    symbol: str
+    price: float
+    size: float = 0.0
+
+
+class NativeBar(BaseModel):
+    """A provider-native finalized candle (e.g. Binance kline_1m)."""
+
+    timestamp: str  # bar **close** time, ISO-8601
+    symbol: str
+    timeframe: str  # provider-native timeframe label; informational only
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float = 0.0
+
+
+NativeEvent = Union[NativeTick, NativeBar]
+
+
+# ---------------------------------------------------------------------------
+# Timeframe parsing
+# ---------------------------------------------------------------------------
+
+
+_TIMEFRAME_SECONDS: Dict[str, int] = {
+    "1s": 1,
+    "5s": 5,
+    "15s": 15,
+    "30s": 30,
+    "1m": 60,
+    "5m": 5 * 60,
+    "15m": 15 * 60,
+    "30m": 30 * 60,
+    "1h": 60 * 60,
+    "4h": 4 * 60 * 60,
+    "1d": 24 * 60 * 60,
+}
+
+
+def timeframe_to_seconds(tf: str) -> int:
+    """Return the duration of ``tf`` in seconds, raising on unknown labels."""
+    try:
+        return _TIMEFRAME_SECONDS[tf]
+    except KeyError as exc:
+        raise ValueError(
+            f"unknown timeframe {tf!r}; supported: {sorted(_TIMEFRAME_SECONDS)}"
+        ) from exc
+
+
+def _parse_iso(ts: str) -> datetime:
+    """Parse an ISO-8601 timestamp. Naive values are assumed to be UTC."""
+    # Python stdlib fromisoformat accepts most ISO strings; trailing 'Z' needs
+    # a tiny replacement to stay compatible across 3.10 / 3.11.
+    s = ts.replace("Z", "+00:00") if ts.endswith("Z") else ts
+    dt = datetime.fromisoformat(s)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _to_epoch(ts: str) -> float:
+    return _parse_iso(ts).timestamp()
+
+
+def _from_epoch(epoch: float) -> str:
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+# ---------------------------------------------------------------------------
+# Per-symbol partial-bar state.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _PartialBar:
+    """Working state for the currently-open target bar for one symbol."""
+
+    bar_start_epoch: float
+    bar_end_epoch: float
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: float = 0.0
+
+
+@dataclass
+class ResamplerStats:
+    """Diagnostic counters; callers may observe these for metrics."""
+
+    out_of_order_dropped: int = 0
+    bars_emitted: int = 0
+    symbols: Dict[str, int] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Resampler
+# ---------------------------------------------------------------------------
+
+
+class Resampler:
+    """Build strategy-timeframe candles from a provider-native event stream.
+
+    Call :meth:`feed_native` for each incoming event and iterate the yielded
+    ``BarEvent`` values (zero or more per call). When the upstream feed is
+    closing, call :meth:`flush_on_end` to drain state; partial (not-yet-
+    finalized) bars are *not* emitted — this is by design.
+    """
+
+    def __init__(self, target_timeframe: str) -> None:
+        self._target_timeframe = target_timeframe
+        self._target_seconds = timeframe_to_seconds(target_timeframe)
+        self._partial: Dict[str, _PartialBar] = {}
+        # Highest bar-end epoch emitted so far, per symbol. Used to reject
+        # late native events — a bar whose close time precedes this watermark
+        # would violate monotonicity and is dropped.
+        self._watermark: Dict[str, float] = {}
+        self.stats = ResamplerStats()
+
+    # ------------------------------------------------------------------
+
+    @property
+    def target_timeframe(self) -> str:
+        return self._target_timeframe
+
+    # ------------------------------------------------------------------
+    # Ingestion
+    # ------------------------------------------------------------------
+
+    def feed_native(self, event: NativeEvent) -> Iterator[BarEvent]:
+        """Feed one native event; yield zero-or-more finalized BarEvents."""
+        if isinstance(event, NativeTick):
+            yield from self._feed_tick(event)
+        elif isinstance(event, NativeBar):
+            yield from self._feed_native_bar(event)
+        else:  # pragma: no cover - defensive
+            raise TypeError(f"unknown native event type: {type(event).__name__}")
+
+    def flush_on_end(self) -> Iterator[BarEvent]:
+        """Drain state at end-of-stream.
+
+        Partial bars are **not** emitted — they would violate the "only
+        finalized bars leave" invariant. This method exists so callers can
+        explicitly signal end-of-stream without the resampler guessing.
+        """
+        # Intentionally empty: no partial bars are emitted.
+        return iter(())
+
+    # ------------------------------------------------------------------
+    # Internals — tick path
+    # ------------------------------------------------------------------
+
+    def _feed_tick(self, tick: NativeTick) -> Iterator[BarEvent]:
+        ts_epoch = _to_epoch(tick.timestamp)
+        # Late-print guard: if the tick's enclosing bar-end is at or before
+        # the watermark for this symbol, drop it.
+        bar_start, bar_end = self._interval_for(ts_epoch)
+        wm = self._watermark.get(tick.symbol)
+        if wm is not None and bar_end <= wm:
+            self.stats.out_of_order_dropped += 1
+            return
+
+        partial = self._partial.get(tick.symbol)
+        if partial is not None and bar_start > partial.bar_start_epoch:
+            # A new interval has begun — finalize the old one before opening
+            # the new partial.
+            yield self._finalize(tick.symbol, partial)
+            partial = None
+
+        if partial is None:
+            partial = _PartialBar(
+                bar_start_epoch=bar_start,
+                bar_end_epoch=bar_end,
+                open=tick.price,
+                high=tick.price,
+                low=tick.price,
+                close=tick.price,
+                volume=tick.size,
+            )
+            self._partial[tick.symbol] = partial
+            return
+
+        # Extend the in-progress bar.
+        partial.high = max(partial.high, tick.price)
+        partial.low = min(partial.low, tick.price)
+        partial.close = tick.price
+        partial.volume += tick.size
+
+    # ------------------------------------------------------------------
+    # Internals — native-bar path
+    # ------------------------------------------------------------------
+
+    def _feed_native_bar(self, nb: NativeBar) -> Iterator[BarEvent]:
+        """Upscale provider-native bars into the target timeframe.
+
+        Native timeframe must divide the target evenly. If they are equal,
+        the native bar is emitted directly as a ``BarEvent`` with the
+        target-timeframe label. If the native timeframe is coarser than the
+        target (configuration error), we raise — that would require downscaling
+        which is not safe without price-path information.
+        """
+        native_seconds = timeframe_to_seconds(nb.timeframe)
+        if native_seconds > self._target_seconds:
+            raise ValueError(
+                f"native timeframe {nb.timeframe} is coarser than target "
+                f"{self._target_timeframe}; downscaling is unsafe"
+            )
+        if self._target_seconds % native_seconds != 0:
+            raise ValueError(
+                f"native timeframe {nb.timeframe} does not evenly divide "
+                f"target {self._target_timeframe}"
+            )
+
+        # Native bar timestamps are their *close* time; translate to the
+        # enclosing interval using the close - 1ns boundary. We use close -
+        # half-a-native-interval to land safely inside the bar.
+        close_epoch = _to_epoch(nb.timestamp)
+        mid_epoch = close_epoch - (native_seconds / 2.0)
+        bar_start, bar_end = self._interval_for(mid_epoch)
+
+        wm = self._watermark.get(nb.symbol)
+        if wm is not None and bar_end <= wm:
+            self.stats.out_of_order_dropped += 1
+            return
+
+        partial = self._partial.get(nb.symbol)
+
+        if native_seconds == self._target_seconds:
+            # Direct passthrough — emit a target-tf bar at this close time.
+            if partial is not None:
+                # Flush any in-progress bar if native/target equal (shouldn't
+                # normally happen, but keep state consistent).
+                yield self._finalize(nb.symbol, partial)
+                partial = None
+            bar_event = BarEvent(
+                bar=Bar(
+                    symbol=nb.symbol,
+                    timestamp=_from_epoch(bar_end),
+                    timeframe=self._target_timeframe,
+                    open=nb.open,
+                    high=nb.high,
+                    low=nb.low,
+                    close=nb.close,
+                    volume=nb.volume,
+                )
+            )
+            self._watermark[nb.symbol] = bar_end
+            self.stats.bars_emitted += 1
+            self.stats.symbols[nb.symbol] = self.stats.symbols.get(nb.symbol, 0) + 1
+            yield bar_event
+            return
+
+        # Upscale: fold this native bar into the target-tf partial.
+        if partial is not None and bar_start > partial.bar_start_epoch:
+            yield self._finalize(nb.symbol, partial)
+            partial = None
+
+        if partial is None:
+            partial = _PartialBar(
+                bar_start_epoch=bar_start,
+                bar_end_epoch=bar_end,
+                open=nb.open,
+                high=nb.high,
+                low=nb.low,
+                close=nb.close,
+                volume=nb.volume,
+            )
+            self._partial[nb.symbol] = partial
+        else:
+            partial.high = max(partial.high, nb.high)
+            partial.low = min(partial.low, nb.low)
+            partial.close = nb.close
+            partial.volume += nb.volume
+
+        # Finalize eagerly if this native bar closed on a target boundary —
+        # the next native event will belong to a new interval.
+        if abs(close_epoch - partial.bar_end_epoch) < 1e-6:
+            yield self._finalize(nb.symbol, partial)
+
+    # ------------------------------------------------------------------
+    # Shared helpers
+    # ------------------------------------------------------------------
+
+    def _interval_for(self, ts_epoch: float) -> tuple[float, float]:
+        """Return the (bar_start, bar_end) epochs for ``ts_epoch``.
+
+        Alignment is to the Unix epoch — consistent across time zones and
+        matches how exchanges align candles (``:00``, ``:15``, ``:30``, …
+        in UTC).
+        """
+        bar_start = (int(ts_epoch) // self._target_seconds) * self._target_seconds
+        bar_end = bar_start + self._target_seconds
+        return float(bar_start), float(bar_end)
+
+    def _finalize(self, symbol: str, partial: _PartialBar) -> BarEvent:
+        """Emit the given partial bar and clear per-symbol state."""
+        bar_event = BarEvent(
+            bar=Bar(
+                symbol=symbol,
+                timestamp=_from_epoch(partial.bar_end_epoch),
+                timeframe=self._target_timeframe,
+                open=partial.open,
+                high=partial.high,
+                low=partial.low,
+                close=partial.close,
+                volume=partial.volume,
+            )
+        )
+        self._watermark[symbol] = partial.bar_end_epoch
+        # Remove whichever is the current partial for this symbol (it may be
+        # a different instance than ``partial`` if the caller already moved on,
+        # but typically this clears it).
+        cur = self._partial.get(symbol)
+        if cur is partial:
+            del self._partial[symbol]
+        self.stats.bars_emitted += 1
+        self.stats.symbols[symbol] = self.stats.symbols.get(symbol, 0) + 1
+        return bar_event
+
+
+__all__ = [
+    "NativeBar",
+    "NativeEvent",
+    "NativeTick",
+    "Resampler",
+    "ResamplerStats",
+    "timeframe_to_seconds",
+]

--- a/backend/agents/investment_team/trading_service/modes/backtest.py
+++ b/backend/agents/investment_team/trading_service/modes/backtest.py
@@ -1,22 +1,33 @@
 """Backtest mode — replays historical bars through the Trading Service.
 
-This is the only public entrypoint for running a Strategy-Lab-generated
-script against historical data. Callers provide pre-fetched market data
-(kept compatible with the existing ``MarketDataService``) and the
-:class:`StrategySpec` whose ``strategy_code`` defines a subclass of
-``Strategy``.
+Two supported data-sourcing paths:
+
+1. **Pre-fetched market data** (legacy): callers pass a
+   ``Dict[str, List[OHLCVBar]]`` produced by ``MarketDataService``. Daily
+   bars only, unchanged from PR 1.
+2. **Provider-driven** (PR 2): callers pass ``(symbols, asset_class)``
+   plus an optional ``provider_id`` / ``registry`` override. The function
+   resolves a historical provider and pulls data at the requested
+   ``timeframe`` — this is the path that unlocks sub-daily backtests
+   (e.g. ``"15m"`` via Binance REST klines) without any change to
+   ``MarketDataService``.
+
+The two paths share the same event-loop and metric-computation code; the
+only branch is where the ``MarketDataStream`` comes from.
 """
 
 from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from ...market_data_service import OHLCVBar
 from ...models import BacktestConfig, BacktestResult, StrategySpec, TradeRecord
 from ...trade_simulator import compute_metrics
 from ..data_stream.historical_replay import HistoricalReplayStream
+from ..data_stream.provider_stream import ProviderHistoricalStream
+from ..providers import ProviderRegistry, default_registry
 from ..service import TradingService, TradingServiceResult
 
 logger = logging.getLogger(__name__)
@@ -33,13 +44,25 @@ def run_backtest(
     *,
     strategy: StrategySpec,
     config: BacktestConfig,
-    market_data: Dict[str, List[OHLCVBar]],
+    market_data: Optional[Dict[str, List[OHLCVBar]]] = None,
+    symbols: Optional[List[str]] = None,
+    asset_class: Optional[str] = None,
     timeframe: str = "1d",
+    provider_id: Optional[str] = None,
+    registry: Optional[ProviderRegistry] = None,
 ) -> BacktestRunResult:
-    """Run a backtest for ``strategy`` against ``market_data``.
+    """Run a backtest for ``strategy``.
 
-    Raises ``ValueError`` if the strategy has no ``strategy_code`` —
-    the LLM-per-bar fallback is intentionally gone.
+    Exactly one data source must be provided:
+
+    * ``market_data`` — pre-fetched dict of symbol→bars (legacy daily path).
+    * ``(symbols, asset_class)`` — resolve a historical provider and stream
+      bars at ``timeframe``. ``provider_id`` explicitly overrides registry
+      selection; ``registry`` defaults to the process-wide registry.
+
+    Raises ``ValueError`` if neither or both data sources are supplied, or
+    if ``strategy.strategy_code`` is missing (the LLM-per-bar fallback is
+    intentionally gone).
     """
     if not strategy.strategy_code:
         raise ValueError(
@@ -48,7 +71,33 @@ def run_backtest(
             "Lab ideation agent."
         )
 
-    stream = HistoricalReplayStream(market_data, timeframe=timeframe)
+    has_legacy = market_data is not None
+    has_provider = symbols is not None and asset_class is not None
+    if has_legacy == has_provider:
+        raise ValueError(
+            "run_backtest requires exactly one data source: either "
+            "'market_data' (pre-fetched) or ('symbols', 'asset_class') "
+            "(provider-driven)"
+        )
+
+    if has_legacy:
+        stream = HistoricalReplayStream(market_data, timeframe=timeframe)
+    else:
+        reg = registry or default_registry()
+        provider = reg.resolve(
+            asset_class=asset_class,
+            direction="historical",
+            explicit=provider_id,
+        )
+        stream = ProviderHistoricalStream(
+            provider=provider,
+            symbols=symbols,
+            asset_class=asset_class,
+            start=config.start_date,
+            end=config.end_date,
+            timeframe=timeframe,
+        )
+
     service = TradingService(
         strategy_code=strategy.strategy_code,
         config=config,

--- a/backend/agents/investment_team/trading_service/modes/paper_trade.py
+++ b/backend/agents/investment_team/trading_service/modes/paper_trade.py
@@ -1,0 +1,335 @@
+"""Paper-trade mode — drives :class:`TradingService` against a LiveStream.
+
+Public entrypoint: :func:`run_paper_trade`. The mode:
+
+1. Resolves a live provider via the registry (with Binance → Coinbase
+   geo-failover at session open for crypto).
+2. Builds a :class:`LiveStream` that warms up from history, then streams
+   live bars.
+3. Feeds the resulting event stream through the same
+   :class:`TradingService` used by backtests, setting ``is_warmup`` on
+   warm-up bars so the service suppresses fills for them.
+4. Enforces termination: ≥ ``min_fills`` OR user stop OR wall-clock
+   guard OR provider error.
+5. Returns a :class:`PaperTradeRunResult` that the API layer wraps into a
+   :class:`PaperTradingSession`.
+
+See ``system_design/pr2_live_data_and_paper_cutover.md`` §5.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Iterator, List, Optional
+
+from ...models import BacktestConfig, StrategySpec, TradeRecord
+from ..data_stream.live_stream import (
+    CutoverEvent,
+    LiveBarEvent,
+    LiveStream,
+    LiveStreamConfig,
+    LiveStreamEnd,
+    LiveStreamError,
+    LiveStreamEvent,
+    WarmupBarEvent,
+)
+from ..data_stream.protocol import BarEvent, EndOfStreamEvent, StreamEvent
+from ..providers import ProviderRegionBlocked, ProviderRegistry, default_registry
+from ..service import TradingService, TradingServiceResult
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Config + result
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PaperTradeConfig:
+    """Paper-mode-specific knobs layered on top of :class:`BacktestConfig`."""
+
+    symbols: List[str]
+    asset_class: str
+    strategy_timeframe: str
+    min_fills: int = 20
+    max_hours: float = 72.0
+    warmup_bars: int = 500
+    provider_id: Optional[str] = None  # explicit registry override
+
+
+@dataclass
+class PaperTradeRunResult:
+    trades: List[TradeRecord]
+    service_result: TradingServiceResult
+    provider_id: str
+    cutover_ts: Optional[str]
+    fill_count: int
+    terminated_reason: str
+    warnings: List[str] = field(default_factory=list)
+    error: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Stop controller (shared with API layer to wire up POST /stop)
+# ---------------------------------------------------------------------------
+
+
+class StopController:
+    """Thread-safe flag read by :class:`LiveStream`'s stop hook.
+
+    The API's ``POST /strategy-lab/paper-trade/{session_id}/stop`` endpoint
+    sets the flag; the running session inspects it between bars and ends
+    the iterator cleanly. Idempotent.
+    """
+
+    def __init__(self) -> None:
+        self._ev = threading.Event()
+
+    def request_stop(self) -> None:
+        self._ev.set()
+
+    def is_stopped(self) -> bool:
+        return self._ev.is_set()
+
+
+# ---------------------------------------------------------------------------
+# Public entrypoint
+# ---------------------------------------------------------------------------
+
+
+def run_paper_trade(
+    *,
+    strategy: StrategySpec,
+    backtest_config: BacktestConfig,
+    paper_config: PaperTradeConfig,
+    stop_controller: Optional[StopController] = None,
+    registry: Optional[ProviderRegistry] = None,
+    clock: Callable[[], float] = time.time,
+) -> PaperTradeRunResult:
+    """Run a paper-trading session until termination.
+
+    ``strategy.strategy_code`` must be present (same rule as backtests —
+    the LLM-per-bar fallback is gone).
+    """
+    if not strategy.strategy_code:
+        raise ValueError(
+            "StrategySpec.strategy_code is required; regenerate the strategy "
+            "via the Strategy Lab ideation agent"
+        )
+
+    reg = registry or default_registry()
+
+    # ------------------------------------------------------------------
+    # Resolve provider (with crypto geo-failover at session open).
+    # ------------------------------------------------------------------
+    try:
+        resolution = reg.resolve_live(
+            asset_class=paper_config.asset_class,
+            explicit=paper_config.provider_id,
+        )
+    except LookupError as exc:
+        return PaperTradeRunResult(
+            trades=[],
+            service_result=TradingServiceResult(),
+            provider_id="",
+            cutover_ts=None,
+            fill_count=0,
+            terminated_reason="no_provider",
+            error=str(exc),
+        )
+
+    provider = resolution.primary
+    provider_id = resolution.primary_name
+
+    # ------------------------------------------------------------------
+    # Run — wrapped in a fill-count + wall-clock termination guard.
+    # ------------------------------------------------------------------
+    warnings: List[str] = []
+    if paper_config.min_fills < 20:
+        warnings.append("min_fills_below_recommended")
+
+    controller = stop_controller or StopController()
+    start_wall = clock()
+    deadline = start_wall + paper_config.max_hours * 3600.0
+
+    fill_counter = _FillCounter()
+    cutover_seen: dict = {"ts": None}
+    terminated_reason = {"reason": "unknown"}
+
+    def _should_stop() -> bool:
+        if controller.is_stopped():
+            terminated_reason["reason"] = "user_stop"
+            return True
+        if fill_counter.count >= paper_config.min_fills:
+            terminated_reason["reason"] = "fill_target_reached"
+            return True
+        if clock() >= deadline:
+            terminated_reason["reason"] = "max_hours"
+            return True
+        return False
+
+    def _build_live_stream(provider_adapter) -> LiveStream:
+        return LiveStream(
+            provider=provider_adapter,
+            config=LiveStreamConfig(
+                symbols=paper_config.symbols,
+                asset_class=paper_config.asset_class,
+                strategy_timeframe=paper_config.strategy_timeframe,
+                warmup_bars=paper_config.warmup_bars,
+                stop_flag=_should_stop,
+            ),
+        )
+
+    service = TradingService(
+        strategy_code=strategy.strategy_code,
+        config=backtest_config,
+        risk_limits=strategy.risk_limits,
+    )
+
+    # First attempt: primary provider.
+    try:
+        stream_source = _translate(
+            _build_live_stream(provider).events(),
+            fill_counter=fill_counter,
+            cutover_seen=cutover_seen,
+            terminated_reason=terminated_reason,
+        )
+        service_result = service.run(
+            stream_source, on_trade=lambda _trade: fill_counter.increment()
+        )
+    except ProviderRegionBlocked as exc:
+        # Geo-failover: try secondary if one was resolved.
+        if resolution.fallback is None:
+            return PaperTradeRunResult(
+                trades=[],
+                service_result=TradingServiceResult(),
+                provider_id=provider_id,
+                cutover_ts=None,
+                fill_count=0,
+                terminated_reason="region_blocked",
+                error=str(exc),
+                warnings=warnings,
+            )
+        logger.info(
+            "primary provider %s region-blocked; failing over to %s",
+            provider_id,
+            resolution.fallback_name,
+        )
+        provider = resolution.fallback
+        provider_id = resolution.fallback_name or "unknown"
+        stream_source = _translate(
+            _build_live_stream(provider).events(),
+            fill_counter=fill_counter,
+            cutover_seen=cutover_seen,
+            terminated_reason=terminated_reason,
+        )
+        service_result = service.run(
+            stream_source, on_trade=lambda _trade: fill_counter.increment()
+        )
+
+    # ------------------------------------------------------------------
+    # Determine final termination reason.
+    # ------------------------------------------------------------------
+    if service_result.lookahead_violation:
+        final_reason = "lookahead_violation"
+    elif service_result.error:
+        final_reason = "provider_error"
+    elif service_result.terminated_reason and service_result.terminated_reason.startswith(
+        "max_drawdown"
+    ):
+        final_reason = "max_drawdown"
+    elif terminated_reason["reason"] != "unknown":
+        final_reason = terminated_reason["reason"]
+    else:
+        final_reason = "provider_end"
+
+    return PaperTradeRunResult(
+        trades=service_result.trades,
+        service_result=service_result,
+        provider_id=provider_id,
+        cutover_ts=cutover_seen["ts"],
+        fill_count=fill_counter.count,
+        terminated_reason=final_reason,
+        warnings=warnings,
+        error=service_result.error,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Event translation: LiveStreamEvent → StreamEvent
+# ---------------------------------------------------------------------------
+
+
+class _FillCounter:
+    """Side-channel counter updated by the TradingService's ``on_trade`` hook.
+
+    The paper-trade mode reads this inside its ``_should_stop`` closure so
+    termination (``min_fills``) doesn't require the service to know about
+    paper-mode concerns.
+    """
+
+    def __init__(self) -> None:
+        self._count = 0
+
+    def increment(self) -> None:
+        self._count += 1
+
+    @property
+    def count(self) -> int:
+        return self._count
+
+
+def _translate(
+    live_events: Iterator[LiveStreamEvent],
+    *,
+    fill_counter: _FillCounter,
+    cutover_seen: dict,
+    terminated_reason: dict,
+) -> Iterator[StreamEvent]:
+    """Convert :class:`LiveStreamEvent` to :class:`StreamEvent` the engine understands."""
+    for event in live_events:
+        if isinstance(event, WarmupBarEvent):
+            yield BarEvent(bar=event.bar, is_warmup=True)
+        elif isinstance(event, CutoverEvent):
+            cutover_seen["ts"] = event.cutover_ts
+            # No StreamEvent to emit — the service doesn't care about the
+            # cut-over, only whether a bar is marked warm-up or not.
+        elif isinstance(event, LiveBarEvent):
+            # Defense in depth: live bars must have a timestamp >= cutover.
+            ts = event.bar.timestamp
+            if cutover_seen["ts"] is not None and ts < cutover_seen["ts"]:
+                logger.warning(
+                    "dropping live bar with timestamp %s < cutover %s",
+                    ts,
+                    cutover_seen["ts"],
+                )
+                continue
+            yield BarEvent(bar=event.bar, is_warmup=False)
+        elif isinstance(event, LiveStreamEnd):
+            # Preserve the reason the _should_stop closure already recorded;
+            # LiveStream only knows a generic "stopped"-style label.
+            if terminated_reason["reason"] == "unknown":
+                terminated_reason["reason"] = event.reason
+            yield EndOfStreamEvent(reason=event.reason)
+            return
+        elif isinstance(event, LiveStreamError):
+            if event.is_region_block:
+                raise ProviderRegionBlocked(event.reason)
+            terminated_reason["reason"] = "provider_error"
+            yield EndOfStreamEvent(reason="provider_error")
+            return
+
+    # Upstream iterator exhausted without a terminal event.
+    yield EndOfStreamEvent(reason="upstream_end")
+
+
+__all__ = [
+    "PaperTradeConfig",
+    "PaperTradeRunResult",
+    "StopController",
+    "run_paper_trade",
+]

--- a/backend/agents/investment_team/trading_service/providers/__init__.py
+++ b/backend/agents/investment_team/trading_service/providers/__init__.py
@@ -1,5 +1,88 @@
 """External market-data provider adapters.
 
-PR 1 reuses ``MarketDataService`` for historical data (daily bars). The
-Polygon.io REST + websocket adapter lands in PR 2.
+PR 2 introduces a provider registry with free-first defaults (Binance /
+Coinbase / Alpaca IEX / OANDA) and paid alternatives that activate when
+their API keys are configured (Polygon, Databento, Twelve Data Pro).
+
+The registry is a lazy singleton. Tests build their own via
+:class:`ProviderRegistry` directly to avoid globals.
 """
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from .base import (
+    ProviderAdapter,
+    ProviderCapabilities,
+    ProviderError,
+    ProviderRegionBlocked,
+)
+from .registry import LiveResolution, ProviderRegistry
+
+
+@lru_cache(maxsize=1)
+def default_registry() -> ProviderRegistry:
+    """Build (once) and return the process-wide default registry."""
+    from . import alpaca, binance, coinbase, databento, oanda, polygon, twelve_data
+
+    reg = ProviderRegistry()
+
+    # ------------------------------------------------------------------
+    # Paid providers first — they get evaluated earlier in selection,
+    # but only activate when their API key env var is set.
+    # ------------------------------------------------------------------
+    reg.register(
+        polygon.build,
+        polygon.CAPABILITIES,
+        api_key_env="POLYGON_API_KEY",
+    )
+    reg.register(
+        databento.build,
+        databento.CAPABILITIES,
+        api_key_env="DATABENTO_API_KEY",
+    )
+    reg.register(
+        twelve_data.build,
+        twelve_data.CAPABILITIES,
+        api_key_env="TWELVE_DATA_API_KEY",
+    )
+
+    # ------------------------------------------------------------------
+    # Free defaults, in the order declared in the spec.
+    # ------------------------------------------------------------------
+    reg.register(
+        binance.build,
+        binance.CAPABILITIES,
+        default_for=["crypto"],
+    )
+    reg.register(
+        coinbase.build,
+        coinbase.CAPABILITIES,
+        secondary_for=["crypto"],  # Binance geo-block failover
+    )
+    reg.register(
+        alpaca.build,
+        alpaca.CAPABILITIES,
+        default_for=["equities"],
+        api_key_env="ALPACA_API_KEY_ID",  # free but required for auth handshake
+    )
+    reg.register(
+        oanda.build,
+        oanda.CAPABILITIES,
+        default_for=["fx"],
+        api_key_env="OANDA_API_TOKEN",  # free practice token — still required
+    )
+
+    return reg
+
+
+__all__ = [
+    "LiveResolution",
+    "ProviderAdapter",
+    "ProviderCapabilities",
+    "ProviderError",
+    "ProviderRegionBlocked",
+    "ProviderRegistry",
+    "default_registry",
+]

--- a/backend/agents/investment_team/trading_service/providers/alpaca.py
+++ b/backend/agents/investment_team/trading_service/providers/alpaca.py
@@ -1,0 +1,81 @@
+"""Alpaca provider adapter — equities default (free IEX feed).
+
+Free tier requires a keyless-but-registered signup (``ALPACA_API_KEY_ID`` /
+``ALPACA_API_SECRET_KEY``). Set ``ALPACA_PAID_FEED=sip`` to upgrade to the
+paid full-tape SIP feed — same code path, different entitlement.
+
+REST: ``https://data.alpaca.markets/v2/stocks/bars``.
+Live WS: ``wss://stream.data.alpaca.markets/v2/{iex|sip}``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterator, List, Optional
+
+from ..data_stream.protocol import BarEvent
+from ..data_stream.resampler import NativeEvent
+from .base import ProviderCapabilities
+
+CAPABILITIES = ProviderCapabilities(
+    name="alpaca",
+    supports={"equities"},
+    is_paid=False,  # the free IEX feed is the default; paid SIP is an entitlement toggle
+    historical_timeframes={"1m", "5m", "15m", "1h", "1d"},
+    live_timeframes={"tick", "1m"},
+)
+
+
+class AlpacaAdapter:
+    capabilities = CAPABILITIES
+
+    def __init__(self) -> None:
+        self._key_id = os.environ.get("ALPACA_API_KEY_ID")
+        self._secret = os.environ.get("ALPACA_API_SECRET_KEY")
+        self._feed = os.environ.get("ALPACA_PAID_FEED", "iex").lower()
+        if self._feed not in {"iex", "sip"}:
+            raise ValueError(f"ALPACA_PAID_FEED must be 'iex' or 'sip', got {self._feed!r}")
+
+    def smallest_available(self, asset_class: str, *, live: bool) -> Optional[str]:
+        if asset_class != "equities":
+            return None
+        return "tick" if live else "1m"
+
+    def historical(
+        self,
+        *,
+        symbols: List[str],
+        asset_class: str,
+        start: str,
+        end: str,
+        timeframe: str,
+    ) -> Iterator[BarEvent]:
+        if not self._key_id or not self._secret:
+            raise RuntimeError(
+                "alpaca adapter requires ALPACA_API_KEY_ID and ALPACA_API_SECRET_KEY "
+                "(free signup). See docs/providers/alpaca.md for setup."
+            )
+        raise NotImplementedError("alpaca historical REST pump is not yet wired")
+        yield  # pragma: no cover
+
+    def live(
+        self,
+        *,
+        symbols: List[str],
+        asset_class: str,
+        native_timeframe: str,
+    ) -> Iterator[NativeEvent]:
+        if not self._key_id or not self._secret:
+            raise RuntimeError(
+                "alpaca adapter requires ALPACA_API_KEY_ID and ALPACA_API_SECRET_KEY "
+                "(free signup). See docs/providers/alpaca.md for setup."
+            )
+        raise NotImplementedError(f"alpaca live websocket pump ({self._feed}) is not yet wired")
+        yield  # pragma: no cover
+
+
+def build() -> AlpacaAdapter:
+    return AlpacaAdapter()
+
+
+__all__ = ["AlpacaAdapter", "CAPABILITIES", "build"]

--- a/backend/agents/investment_team/trading_service/providers/base.py
+++ b/backend/agents/investment_team/trading_service/providers/base.py
@@ -1,0 +1,108 @@
+"""Provider adapter Protocol and capability descriptor.
+
+All concrete adapters (Binance, Coinbase, Alpaca, OANDA, Polygon, Databento,
+Twelve Data) implement this shape. The :class:`LiveStream` and
+:class:`HistoricalReplayStream` builders depend only on this Protocol, so
+swapping providers does not touch engine code.
+
+See ``system_design/pr2_live_data_and_paper_cutover.md`` §3.2.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Iterator, Optional, Protocol, Set, runtime_checkable
+
+from ..data_stream.protocol import BarEvent
+from ..data_stream.resampler import NativeEvent
+
+
+class ProviderRegionBlocked(Exception):
+    """Raised by an adapter when the current host region is not served.
+
+    The registry uses this at session-open time to trigger geo-failover
+    (currently Binance → Coinbase for crypto). It is **not** raised
+    mid-session; mid-session failures terminate the session via
+    :class:`ProviderError` so the "one adapter per session" invariant is
+    preserved.
+    """
+
+
+class ProviderError(Exception):
+    """Unrecoverable adapter error during streaming."""
+
+
+@dataclass
+class ProviderCapabilities:
+    """What a given adapter supports. Plain data, no behavior."""
+
+    #: Stable id used in API responses and env-var overrides (e.g. ``"binance"``).
+    name: str
+    #: Subset of ``{"crypto", "equities", "fx"}`` this adapter can serve.
+    supports: Set[str] = field(default_factory=set)
+    #: True if the adapter is a *paid* provider (requires an API key to
+    #: function). The registry prefers paid adapters for the asset classes
+    #: they cover when a key is configured.
+    is_paid: bool = False
+    #: Allowed-list of native timeframes the adapter exposes on its
+    #: historical endpoint. ``"tick"`` is reserved for the live feed.
+    historical_timeframes: Set[str] = field(default_factory=set)
+    #: Live-feed granularity labels the adapter can stream. ``"tick"`` means
+    #: a trade/quote stream the resampler will turn into 1s+ candles.
+    live_timeframes: Set[str] = field(default_factory=set)
+
+
+@runtime_checkable
+class ProviderAdapter(Protocol):
+    """Adapter contract. All methods are synchronous iterators.
+
+    Adapters are free to implement ``historical`` only, ``live`` only, or
+    both. The registry records which directions each adapter supports and
+    excludes it from selection for unsupported directions.
+    """
+
+    capabilities: ProviderCapabilities
+
+    def smallest_available(self, asset_class: str, *, live: bool) -> Optional[str]:
+        """Return the shortest timeframe (or ``"tick"``) the adapter offers.
+
+        ``None`` means the adapter has no feed for that asset class in that
+        direction. Used by ``LiveStream`` / ``HistoricalReplayStream`` to
+        pick a native subscription before handing to the resampler.
+        """
+        ...
+
+    def historical(
+        self,
+        *,
+        symbols: list[str],
+        asset_class: str,
+        start: str,
+        end: str,
+        timeframe: str,
+    ) -> Iterator[BarEvent]:
+        """Historical replay source. Emits ``BarEvent`` in chronological order."""
+        ...
+
+    def live(
+        self,
+        *,
+        symbols: list[str],
+        asset_class: str,
+        native_timeframe: str,
+    ) -> Iterator[NativeEvent]:
+        """Live feed. Emits native ticks / bars that the resampler consumes.
+
+        Raises :class:`ProviderRegionBlocked` at *start-of-stream* if this
+        host is not permitted by the provider. Raises :class:`ProviderError`
+        for any other unrecoverable error (including mid-stream).
+        """
+        ...
+
+
+__all__ = [
+    "ProviderAdapter",
+    "ProviderCapabilities",
+    "ProviderError",
+    "ProviderRegionBlocked",
+]

--- a/backend/agents/investment_team/trading_service/providers/binance.py
+++ b/backend/agents/investment_team/trading_service/providers/binance.py
@@ -1,0 +1,204 @@
+"""Binance provider adapter — crypto primary default (free, keyless).
+
+Historical: REST ``/api/v3/klines`` (free, no auth).
+Live: public market-data websocket at ``wss://stream.binance.com:9443``
+(implementation in :mod:`binance_ws`; this file owns the adapter Protocol
+wiring and REST klines).
+
+See ``system_design/pr2_live_data_and_paper_cutover.md`` §2.2 / §13.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Iterator, List, Optional
+
+from ..data_stream.protocol import BarEvent
+from ..data_stream.resampler import NativeEvent
+from ..strategy.contract import Bar
+from .base import ProviderCapabilities, ProviderError
+
+logger = logging.getLogger(__name__)
+
+
+CAPABILITIES = ProviderCapabilities(
+    name="binance",
+    supports={"crypto"},
+    is_paid=False,
+    historical_timeframes={"1s", "1m", "5m", "15m", "30m", "1h", "4h", "1d"},
+    live_timeframes={"tick", "1s", "15s", "1m"},
+)
+
+
+# Binance's kline interval labels differ from ours for some values (e.g. ``1s``
+# is written as ``1s``, ``1m`` as ``1m``, etc.) — the mapping below is the
+# source of truth. "tick" is handled via the trade stream, not klines.
+_KLINE_INTERVAL_MAP = {
+    "1s": "1s",
+    "15s": "15s",  # only on WS, not REST; REST lookups rejected below
+    "1m": "1m",
+    "5m": "5m",
+    "15m": "15m",
+    "30m": "30m",
+    "1h": "1h",
+    "4h": "4h",
+    "1d": "1d",
+}
+
+_REST_UNSUPPORTED_TIMEFRAMES = {"15s"}  # 15s is WS-only per Binance docs
+
+
+class BinanceAdapter:
+    """Free, keyless Binance market-data adapter."""
+
+    capabilities = CAPABILITIES
+
+    def __init__(self, *, base_rest: Optional[str] = None, base_ws: Optional[str] = None) -> None:
+        self._rest = base_rest or os.environ.get("BINANCE_REST_URL", "https://api.binance.com")
+        self._ws = base_ws or os.environ.get("BINANCE_WS_URL", "wss://stream.binance.com:9443")
+
+    # ------------------------------------------------------------------
+
+    def smallest_available(self, asset_class: str, *, live: bool) -> Optional[str]:
+        if asset_class != "crypto":
+            return None
+        return "tick" if live else "1s"
+
+    # ------------------------------------------------------------------
+
+    def historical(
+        self,
+        *,
+        symbols: List[str],
+        asset_class: str,
+        start: str,
+        end: str,
+        timeframe: str,
+    ) -> Iterator[BarEvent]:
+        if asset_class != "crypto":
+            raise ValueError("binance adapter only serves asset_class='crypto'")
+        if timeframe in _REST_UNSUPPORTED_TIMEFRAMES:
+            raise ValueError(
+                f"binance historical endpoint does not support timeframe={timeframe!r}; "
+                "request the next-larger timeframe or use the live path with resampler"
+            )
+        if timeframe not in _KLINE_INTERVAL_MAP:
+            raise ValueError(
+                f"binance adapter cannot serve timeframe={timeframe!r}; "
+                f"supported: {sorted(self.capabilities.historical_timeframes)}"
+            )
+
+        # Interleaved by timestamp across symbols — the service expects bars
+        # in chronological order.
+        per_symbol: dict[str, List[BarEvent]] = {}
+        for symbol in symbols:
+            per_symbol[symbol] = list(
+                self._fetch_klines(symbol=symbol, interval=timeframe, start=start, end=end)
+            )
+        timeline: List[tuple[str, BarEvent]] = []
+        for sym, bars in per_symbol.items():
+            for b in bars:
+                timeline.append((b.bar.timestamp, b))
+        timeline.sort(key=lambda x: x[0])
+        for _, b in timeline:
+            yield b
+
+    def _fetch_klines(
+        self, *, symbol: str, interval: str, start: str, end: str
+    ) -> Iterator[BarEvent]:
+        import httpx  # local import keeps cold-start cheap
+
+        start_ms = _iso_to_ms(start)
+        end_ms = _iso_to_ms(end)
+        cursor = start_ms
+        url = f"{self._rest}/api/v3/klines"
+        with httpx.Client(timeout=30.0) as client:
+            while cursor < end_ms:
+                params = {
+                    "symbol": symbol.upper().replace("-", ""),
+                    "interval": interval,
+                    "startTime": cursor,
+                    "endTime": end_ms,
+                    "limit": 1000,
+                }
+                resp = client.get(url, params=params)
+                if resp.status_code == 451:  # regional block
+                    from .base import ProviderRegionBlocked
+
+                    raise ProviderRegionBlocked("binance REST returned HTTP 451 (region blocked)")
+                if resp.status_code != 200:
+                    raise ProviderError(f"binance REST error {resp.status_code}: {resp.text[:200]}")
+                data = resp.json()
+                if not data:
+                    break
+                for row in data:
+                    # row: [open_time, open, high, low, close, volume, close_time, ...]
+                    close_ms = int(row[6])
+                    yield BarEvent(
+                        bar=Bar(
+                            symbol=symbol,
+                            timestamp=_ms_to_iso(close_ms + 1),  # close-inclusive ISO label
+                            timeframe=interval,
+                            open=float(row[1]),
+                            high=float(row[2]),
+                            low=float(row[3]),
+                            close=float(row[4]),
+                            volume=float(row[5]),
+                        )
+                    )
+                # Advance cursor to avoid refetching the last bar.
+                next_cursor = int(data[-1][6]) + 1
+                if next_cursor <= cursor:
+                    break
+                cursor = next_cursor
+
+    # ------------------------------------------------------------------
+
+    def live(
+        self,
+        *,
+        symbols: List[str],
+        asset_class: str,
+        native_timeframe: str,
+    ) -> Iterator[NativeEvent]:
+        if asset_class != "crypto":
+            raise ValueError("binance adapter only serves asset_class='crypto'")
+        if native_timeframe not in self.capabilities.live_timeframes:
+            raise ValueError(f"binance live feed does not support timeframe={native_timeframe!r}")
+        from .binance_ws import run_binance_live
+
+        # Binance REST uses "BTCUSDT"; WS lowercases to "btcusdt". Normalise.
+        normalised = [s.upper().replace("-", "") for s in symbols]
+        yield from run_binance_live(
+            base_ws=self._ws,
+            symbols=normalised,
+            native_timeframe=native_timeframe,
+        )
+
+
+def build() -> BinanceAdapter:
+    return BinanceAdapter()
+
+
+def _iso_to_ms(iso: str) -> int:
+    from datetime import datetime, timezone
+
+    s = iso.replace("Z", "+00:00") if iso.endswith("Z") else iso
+    dt = (
+        datetime.fromisoformat(s)
+        if len(iso) > 10
+        else datetime.fromisoformat(iso + "T00:00:00+00:00")
+    )
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return int(dt.timestamp() * 1000)
+
+
+def _ms_to_iso(ms: int) -> str:
+    from datetime import datetime, timezone
+
+    return datetime.fromtimestamp(ms / 1000.0, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+__all__ = ["BinanceAdapter", "CAPABILITIES", "build"]

--- a/backend/agents/investment_team/trading_service/providers/binance_ws.py
+++ b/backend/agents/investment_team/trading_service/providers/binance_ws.py
@@ -1,0 +1,217 @@
+"""Binance websocket pump — async client → sync iterator bridge.
+
+The adapter Protocol requires a synchronous generator; ``websockets`` is
+async. This module runs an asyncio event loop in a background thread, the
+async coroutine pushes parsed :class:`NativeEvent` objects onto a
+``queue.Queue``, and the sync generator yields them.
+
+Split out from ``binance.py`` so the adapter file stays small and the
+pump's async plumbing is independently testable.
+
+Message shapes (see Binance WebSocket Market Streams docs):
+
+* ``@trade`` — single trade print:
+  ``{"e":"trade","T":1700000000000,"s":"BTCUSDT","p":"60000.1","q":"0.01", …}``
+* ``@kline_<tf>`` — candle updates; ``k.x=true`` when the candle closes:
+  ``{"e":"kline","k":{"t":..,"T":..,"o":..,"c":..,"h":..,"l":..,"v":..,"x":bool}}``
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import queue
+import threading
+from dataclasses import dataclass
+from typing import Iterator, List, Optional
+
+from ..data_stream.resampler import NativeBar, NativeEvent, NativeTick
+from .base import ProviderError, ProviderRegionBlocked
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Parsing — pure functions, unit-testable without any network
+# ---------------------------------------------------------------------------
+
+
+def parse_binance_trade(payload: dict) -> NativeTick:
+    """Convert a Binance ``@trade`` message to a :class:`NativeTick`.
+
+    Binance gives millisecond Unix timestamps; we emit ISO-8601 UTC.
+    """
+    import datetime as _dt
+
+    ts_ms = int(payload["T"])
+    return NativeTick(
+        timestamp=_dt.datetime.fromtimestamp(ts_ms / 1000.0, tz=_dt.timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        symbol=str(payload["s"]),
+        price=float(payload["p"]),
+        size=float(payload.get("q", 0.0)),
+    )
+
+
+def parse_binance_kline(payload: dict) -> Optional[NativeBar]:
+    """Return a :class:`NativeBar` iff the kline has closed, else ``None``.
+
+    Binance sends kline updates continuously; ``k.x == True`` flags the
+    final update for a given interval. We only emit on close so downstream
+    consumers (the resampler) never see a partial candle.
+    """
+    import datetime as _dt
+
+    k = payload.get("k") or {}
+    if not k.get("x"):
+        return None
+
+    close_ms = int(k["T"]) + 1  # Binance uses close-exclusive; shift +1ms
+    return NativeBar(
+        timestamp=_dt.datetime.fromtimestamp(close_ms / 1000.0, tz=_dt.timezone.utc)
+        .isoformat()
+        .replace("+00:00", "Z"),
+        symbol=str(k["s"]),
+        timeframe=str(k["i"]),
+        open=float(k["o"]),
+        high=float(k["h"]),
+        low=float(k["l"]),
+        close=float(k["c"]),
+        volume=float(k.get("v", 0.0)),
+    )
+
+
+def dispatch_binance_message(data: dict) -> Optional[NativeEvent]:
+    """Route a parsed JSON payload to the right converter, or None if ignorable."""
+    # Combined-stream messages wrap the payload under ``data``.
+    if "stream" in data and "data" in data:
+        payload = data["data"]
+    else:
+        payload = data
+
+    event_type = payload.get("e")
+    if event_type == "trade":
+        return parse_binance_trade(payload)
+    if event_type == "kline":
+        return parse_binance_kline(payload)
+    # Subscription acks, heartbeats, other noise — safe to ignore.
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Async pump running in a background thread
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _PumpState:
+    events: "queue.Queue[Optional[NativeEvent]]"
+    error: Optional[BaseException] = None
+    stop: threading.Event = None  # type: ignore[assignment]
+
+
+def _build_stream_url(base_ws: str, symbols: List[str], native_timeframe: str) -> str:
+    """Combined-streams URL for the given symbols at the given timeframe.
+
+    ``native_timeframe == "tick"`` selects the ``@trade`` channel; any other
+    value goes through ``@kline_<tf>``.
+    """
+    channel_suffix = "@trade" if native_timeframe == "tick" else f"@kline_{native_timeframe}"
+    streams = "/".join(f"{s.lower()}{channel_suffix}" for s in symbols)
+    return f"{base_ws}/stream?streams={streams}"
+
+
+async def _pump_coroutine(
+    *,
+    url: str,
+    state: _PumpState,
+) -> None:
+    """Open the WS, parse each message, enqueue NativeEvents."""
+    import websockets
+    from websockets.exceptions import InvalidStatus
+
+    try:
+        async with websockets.connect(url, open_timeout=10.0, ping_interval=20.0) as ws:
+            while not state.stop.is_set():
+                try:
+                    raw = await ws.recv()
+                except Exception as exc:  # connection closed / timeout
+                    state.error = ProviderError(f"binance ws recv failed: {exc}")
+                    break
+                try:
+                    data = json.loads(raw)
+                except json.JSONDecodeError:
+                    logger.warning("binance ws: non-JSON frame dropped")
+                    continue
+                event = dispatch_binance_message(data)
+                if event is not None:
+                    state.events.put(event)
+    except InvalidStatus as exc:
+        # HTTP upgrade rejected. 451 = region block; anything else is a
+        # generic provider error.
+        status_code = getattr(getattr(exc, "response", None), "status_code", None)
+        if status_code == 451:
+            state.error = ProviderRegionBlocked(
+                "binance websocket rejected connection with HTTP 451 (region blocked)"
+            )
+        else:
+            state.error = ProviderError(
+                f"binance websocket upgrade failed: HTTP {status_code or '???'}"
+            )
+    except Exception as exc:  # pragma: no cover - defensive
+        state.error = ProviderError(f"binance ws pump crashed: {exc}")
+    finally:
+        # Sentinel: wake the sync consumer and signal clean shutdown.
+        state.events.put(None)
+
+
+def run_binance_live(
+    *,
+    base_ws: str,
+    symbols: List[str],
+    native_timeframe: str,
+    max_queue: int = 1024,
+) -> Iterator[NativeEvent]:
+    """Synchronous live-feed iterator.
+
+    Starts an asyncio event loop in a background thread; yields parsed
+    events from the queue as they arrive. When the caller stops iterating
+    or the pump signals an error, the loop is terminated cleanly.
+
+    Raises :class:`ProviderRegionBlocked` if Binance rejects the
+    connection upgrade with HTTP 451 (geo-failover trigger). Raises
+    :class:`ProviderError` for any other terminal failure.
+    """
+    url = _build_stream_url(base_ws, symbols, native_timeframe)
+    state = _PumpState(events=queue.Queue(maxsize=max_queue), stop=threading.Event())
+
+    def _thread_target() -> None:
+        import asyncio
+
+        asyncio.run(_pump_coroutine(url=url, state=state))
+
+    thread = threading.Thread(target=_thread_target, name="binance-ws-pump", daemon=True)
+    thread.start()
+
+    try:
+        while True:
+            event = state.events.get()
+            if event is None:
+                # Pump signaled completion — propagate any stashed error.
+                if state.error is not None:
+                    raise state.error
+                return
+            yield event
+    finally:
+        state.stop.set()
+        # Drain up to a couple seconds waiting for the async pump to exit.
+        thread.join(timeout=2.0)
+
+
+__all__ = [
+    "dispatch_binance_message",
+    "parse_binance_kline",
+    "parse_binance_trade",
+    "run_binance_live",
+]

--- a/backend/agents/investment_team/trading_service/providers/coinbase.py
+++ b/backend/agents/investment_team/trading_service/providers/coinbase.py
@@ -1,0 +1,79 @@
+"""Coinbase Exchange provider adapter — crypto secondary default.
+
+Selected automatically when the Binance primary raises
+:class:`ProviderRegionBlocked` at session open (see registry's
+``resolve_live``). Free and keyless, like Binance, but with a narrower
+native-timeframe menu.
+
+REST: ``https://api.exchange.coinbase.com/products/{pair}/candles``.
+Live WS: ``wss://ws-feed.exchange.coinbase.com`` (``matches`` channel for
+ticks, ``ticker`` for quotes).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterator, List, Optional
+
+from ..data_stream.protocol import BarEvent
+from ..data_stream.resampler import NativeEvent
+from .base import ProviderCapabilities
+
+CAPABILITIES = ProviderCapabilities(
+    name="coinbase",
+    supports={"crypto"},
+    is_paid=False,
+    historical_timeframes={"1m", "5m", "15m", "1h", "6h", "1d"},
+    live_timeframes={"tick", "1m"},
+)
+
+
+class CoinbaseAdapter:
+    """Free, keyless Coinbase Exchange market-data adapter."""
+
+    capabilities = CAPABILITIES
+
+    def __init__(self, *, base_rest: Optional[str] = None, base_ws: Optional[str] = None) -> None:
+        self._rest = base_rest or os.environ.get(
+            "COINBASE_REST_URL", "https://api.exchange.coinbase.com"
+        )
+        self._ws = base_ws or os.environ.get(
+            "COINBASE_WS_URL", "wss://ws-feed.exchange.coinbase.com"
+        )
+
+    def smallest_available(self, asset_class: str, *, live: bool) -> Optional[str]:
+        if asset_class != "crypto":
+            return None
+        return "tick" if live else "1m"
+
+    def historical(
+        self,
+        *,
+        symbols: List[str],
+        asset_class: str,
+        start: str,
+        end: str,
+        timeframe: str,
+    ) -> Iterator[BarEvent]:
+        raise NotImplementedError(
+            "coinbase historical REST pump is not yet wired; it serves as a "
+            "geo-failover secondary for Binance at session open only"
+        )
+        yield  # pragma: no cover - generator typing marker
+
+    def live(
+        self,
+        *,
+        symbols: List[str],
+        asset_class: str,
+        native_timeframe: str,
+    ) -> Iterator[NativeEvent]:
+        raise NotImplementedError("coinbase live websocket pump is not yet wired")
+        yield  # pragma: no cover
+
+
+def build() -> CoinbaseAdapter:
+    return CoinbaseAdapter()
+
+
+__all__ = ["CAPABILITIES", "CoinbaseAdapter", "build"]

--- a/backend/agents/investment_team/trading_service/providers/databento.py
+++ b/backend/agents/investment_team/trading_service/providers/databento.py
@@ -1,0 +1,69 @@
+"""Databento provider adapter — paid alt (stocks, futures, options).
+
+Activated when ``DATABENTO_API_KEY`` is set. Institutional-grade historical
+and live data; useful when users need high-fidelity fill simulation.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterator, List, Optional
+
+from ..data_stream.protocol import BarEvent
+from ..data_stream.resampler import NativeEvent
+from .base import ProviderCapabilities
+
+CAPABILITIES = ProviderCapabilities(
+    name="databento",
+    supports={"equities"},  # PR 2 scope: equities only; futures/options later
+    is_paid=True,
+    historical_timeframes={"1s", "1m", "5m", "15m", "30m", "1h", "1d"},
+    live_timeframes={"tick", "1s", "1m"},
+)
+
+
+class DatabentoAdapter:
+    capabilities = CAPABILITIES
+
+    def __init__(self) -> None:
+        self._api_key = os.environ.get("DATABENTO_API_KEY")
+
+    def _require_auth(self) -> None:
+        if not self._api_key:
+            raise RuntimeError("databento adapter requires DATABENTO_API_KEY")
+
+    def smallest_available(self, asset_class: str, *, live: bool) -> Optional[str]:
+        if asset_class not in self.capabilities.supports:
+            return None
+        return "tick" if live else "1s"
+
+    def historical(
+        self,
+        *,
+        symbols: List[str],
+        asset_class: str,
+        start: str,
+        end: str,
+        timeframe: str,
+    ) -> Iterator[BarEvent]:
+        self._require_auth()
+        raise NotImplementedError("databento historical pump is not yet wired")
+        yield  # pragma: no cover
+
+    def live(
+        self,
+        *,
+        symbols: List[str],
+        asset_class: str,
+        native_timeframe: str,
+    ) -> Iterator[NativeEvent]:
+        self._require_auth()
+        raise NotImplementedError("databento live pump is not yet wired")
+        yield  # pragma: no cover
+
+
+def build() -> DatabentoAdapter:
+    return DatabentoAdapter()
+
+
+__all__ = ["CAPABILITIES", "DatabentoAdapter", "build"]

--- a/backend/agents/investment_team/trading_service/providers/oanda.py
+++ b/backend/agents/investment_team/trading_service/providers/oanda.py
@@ -1,0 +1,77 @@
+"""OANDA v20 provider adapter — FX default (free practice account).
+
+Requires ``OANDA_API_TOKEN`` and ``OANDA_ACCOUNT_ID`` (free practice-account
+signup). See ``system_design/pr2_live_data_and_paper_cutover.md`` §2.2.
+
+REST candles: ``GET /v3/instruments/{instrument}/candles``.
+Streaming prices: ``GET /v3/accounts/{accountID}/pricing/stream``.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterator, List, Optional
+
+from ..data_stream.protocol import BarEvent
+from ..data_stream.resampler import NativeEvent
+from .base import ProviderCapabilities
+
+CAPABILITIES = ProviderCapabilities(
+    name="oanda",
+    supports={"fx"},
+    is_paid=False,
+    historical_timeframes={"5s", "15s", "30s", "1m", "5m", "15m", "30m", "1h", "4h", "1d"},
+    live_timeframes={"tick"},
+)
+
+
+class OandaAdapter:
+    capabilities = CAPABILITIES
+
+    def __init__(self) -> None:
+        self._token = os.environ.get("OANDA_API_TOKEN")
+        self._account_id = os.environ.get("OANDA_ACCOUNT_ID")
+
+    def _require_auth(self) -> None:
+        if not self._token or not self._account_id:
+            raise RuntimeError(
+                "oanda adapter requires OANDA_API_TOKEN and OANDA_ACCOUNT_ID "
+                "(free practice signup at https://www.oanda.com/demo-account/). "
+                "FX paper trading cannot proceed without a configured FX provider."
+            )
+
+    def smallest_available(self, asset_class: str, *, live: bool) -> Optional[str]:
+        if asset_class != "fx":
+            return None
+        return "tick" if live else "5s"
+
+    def historical(
+        self,
+        *,
+        symbols: List[str],
+        asset_class: str,
+        start: str,
+        end: str,
+        timeframe: str,
+    ) -> Iterator[BarEvent]:
+        self._require_auth()
+        raise NotImplementedError("oanda historical REST pump is not yet wired")
+        yield  # pragma: no cover
+
+    def live(
+        self,
+        *,
+        symbols: List[str],
+        asset_class: str,
+        native_timeframe: str,
+    ) -> Iterator[NativeEvent]:
+        self._require_auth()
+        raise NotImplementedError("oanda pricing stream pump is not yet wired")
+        yield  # pragma: no cover
+
+
+def build() -> OandaAdapter:
+    return OandaAdapter()
+
+
+__all__ = ["CAPABILITIES", "OandaAdapter", "build"]

--- a/backend/agents/investment_team/trading_service/providers/polygon.py
+++ b/backend/agents/investment_team/trading_service/providers/polygon.py
@@ -1,0 +1,69 @@
+"""Polygon.io provider adapter — paid alt (stocks, options, crypto, forex).
+
+Activated when ``POLYGON_API_KEY`` is set. When active, the registry prefers
+Polygon over the free defaults for every asset class Polygon covers.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterator, List, Optional
+
+from ..data_stream.protocol import BarEvent
+from ..data_stream.resampler import NativeEvent
+from .base import ProviderCapabilities
+
+CAPABILITIES = ProviderCapabilities(
+    name="polygon",
+    supports={"crypto", "equities", "fx"},
+    is_paid=True,
+    historical_timeframes={"1s", "1m", "5m", "15m", "30m", "1h", "4h", "1d"},
+    live_timeframes={"tick", "1s", "1m"},
+)
+
+
+class PolygonAdapter:
+    capabilities = CAPABILITIES
+
+    def __init__(self) -> None:
+        self._api_key = os.environ.get("POLYGON_API_KEY")
+
+    def _require_auth(self) -> None:
+        if not self._api_key:
+            raise RuntimeError("polygon adapter requires POLYGON_API_KEY")
+
+    def smallest_available(self, asset_class: str, *, live: bool) -> Optional[str]:
+        if asset_class not in self.capabilities.supports:
+            return None
+        return "tick" if live else "1s"
+
+    def historical(
+        self,
+        *,
+        symbols: List[str],
+        asset_class: str,
+        start: str,
+        end: str,
+        timeframe: str,
+    ) -> Iterator[BarEvent]:
+        self._require_auth()
+        raise NotImplementedError("polygon historical REST pump is not yet wired")
+        yield  # pragma: no cover
+
+    def live(
+        self,
+        *,
+        symbols: List[str],
+        asset_class: str,
+        native_timeframe: str,
+    ) -> Iterator[NativeEvent]:
+        self._require_auth()
+        raise NotImplementedError("polygon live websocket pump is not yet wired")
+        yield  # pragma: no cover
+
+
+def build() -> PolygonAdapter:
+    return PolygonAdapter()
+
+
+__all__ = ["CAPABILITIES", "PolygonAdapter", "build"]

--- a/backend/agents/investment_team/trading_service/providers/registry.py
+++ b/backend/agents/investment_team/trading_service/providers/registry.py
@@ -175,20 +175,31 @@ class ProviderRegistry:
         direction: str,
         explicit: Optional[str],
     ) -> Optional[_Registration]:
-        # 1. Explicit wins.
+        # 1. Explicit (request-level) wins.
         if explicit is not None:
-            if explicit not in self._registrations:
-                raise KeyError(f"provider {explicit!r} is not registered")
-            reg = self._registrations[explicit]
-            if asset_class not in reg.capabilities.supports:
-                raise ValueError(
-                    f"provider {explicit!r} does not support asset_class={asset_class!r}"
-                )
-            if not _has_direction(reg, direction):
-                raise ValueError(f"provider {explicit!r} does not support direction={direction!r}")
-            return reg
+            return self._resolve_pinned(explicit, asset_class=asset_class, direction=direction)
 
-        # 2. Paid provider with API key configured.
+        # 2. Env-var override (operator-level). Documented as
+        #    INVESTMENT_LIVE_PROVIDER_{CRYPTO,EQUITIES,FX} for live streams and
+        #    INVESTMENT_HISTORICAL_PROVIDER_{...} for historical.
+        env_pinned = _env_override_for(asset_class=asset_class, direction=direction)
+        if env_pinned is not None:
+            # A misconfigured env var shouldn't wedge the server — log and fall
+            # through to paid/default selection if the pinned provider isn't
+            # usable.
+            try:
+                return self._resolve_pinned(
+                    env_pinned, asset_class=asset_class, direction=direction
+                )
+            except (KeyError, ValueError) as exc:
+                logger.warning(
+                    "env override %s=%r ignored: %s",
+                    _env_var_name(asset_class=asset_class, direction=direction),
+                    env_pinned,
+                    exc,
+                )
+
+        # 3. Paid provider with API key configured.
         for reg in self._registrations.values():
             if not reg.capabilities.is_paid:
                 continue
@@ -205,12 +216,12 @@ class ProviderRegistry:
                 )
                 return reg
 
-        # 3. Free default for this asset class.
+        # 4. Free default for this asset class.
         for reg in self._registrations.values():
             if asset_class in reg.default_for and _has_direction(reg, direction):
                 return reg
 
-        # 4. Any free provider that supports it (last-resort).
+        # 5. Any free provider that supports it (last-resort).
         for reg in self._registrations.values():
             if reg.capabilities.is_paid:
                 continue
@@ -218,6 +229,40 @@ class ProviderRegistry:
                 return reg
 
         return None
+
+    def _resolve_pinned(
+        self,
+        name: str,
+        *,
+        asset_class: str,
+        direction: str,
+    ) -> _Registration:
+        """Shared pin-resolution used by explicit and env-override paths."""
+        if name not in self._registrations:
+            raise KeyError(f"provider {name!r} is not registered")
+        reg = self._registrations[name]
+        if asset_class not in reg.capabilities.supports:
+            raise ValueError(f"provider {name!r} does not support asset_class={asset_class!r}")
+        if not _has_direction(reg, direction):
+            raise ValueError(f"provider {name!r} does not support direction={direction!r}")
+        return reg
+
+
+def _env_var_name(*, asset_class: str, direction: str) -> str:
+    """Return the env-var name that overrides selection for this combination."""
+    prefix = (
+        "INVESTMENT_LIVE_PROVIDER_" if direction == "live" else "INVESTMENT_HISTORICAL_PROVIDER_"
+    )
+    return f"{prefix}{asset_class.upper()}"
+
+
+def _env_override_for(*, asset_class: str, direction: str) -> Optional[str]:
+    """Read the ``INVESTMENT_{LIVE,HISTORICAL}_PROVIDER_*`` env var, if set."""
+    raw = os.environ.get(_env_var_name(asset_class=asset_class, direction=direction))
+    if raw is None:
+        return None
+    value = raw.strip()
+    return value or None
 
 
 def _has_direction(reg: _Registration, direction: str) -> bool:

--- a/backend/agents/investment_team/trading_service/providers/registry.py
+++ b/backend/agents/investment_team/trading_service/providers/registry.py
@@ -1,0 +1,244 @@
+"""Provider registry — free-first selection with paid overrides.
+
+Selection order for a given ``(asset_class, direction)``:
+
+1. **Explicit override** (request-level ``provider_id`` or env-var
+   ``INVESTMENT_LIVE_PROVIDER_*`` / ``INVESTMENT_HISTORICAL_PROVIDER_*``).
+2. **Paid provider with an API key configured**, ranked by registration order.
+3. **Free default** for that asset class.
+
+The Binance → Coinbase geo-failover is handled at session open by
+:func:`resolve_live` (see ``system_design/pr2_live_data_and_paper_cutover.md``
+§3.2 "Binance → Coinbase geo-failover").
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional
+
+from .base import ProviderAdapter, ProviderCapabilities, ProviderRegionBlocked
+
+logger = logging.getLogger(__name__)
+
+
+AdapterFactory = Callable[[], ProviderAdapter]
+
+
+@dataclass
+class _Registration:
+    factory: AdapterFactory
+    capabilities: ProviderCapabilities
+    #: Asset classes for which this adapter is the **free default** (if any).
+    default_for: List[str] = field(default_factory=list)
+    #: Secondary free default — used only when the primary adapter for the
+    #: same asset class raises :class:`ProviderRegionBlocked`. One secondary
+    #: per asset class at most; populated for Coinbase on ``crypto``.
+    secondary_for: List[str] = field(default_factory=list)
+    #: Name of env var whose presence indicates the user's configuration
+    #: enables this adapter's paid features (only meaningful when
+    #: ``capabilities.is_paid`` is True).
+    api_key_env: Optional[str] = None
+
+
+class ProviderRegistry:
+    """In-memory registry of provider adapters.
+
+    The default registry is constructed via :func:`build_default_registry`.
+    Tests construct their own registry with stub adapters.
+    """
+
+    def __init__(self) -> None:
+        self._registrations: Dict[str, _Registration] = {}
+        # Insertion order is preserved by dict in 3.7+; we rely on that for
+        # deterministic paid-provider ranking.
+
+    # ------------------------------------------------------------------
+    # Registration
+    # ------------------------------------------------------------------
+
+    def register(
+        self,
+        factory: AdapterFactory,
+        capabilities: ProviderCapabilities,
+        *,
+        default_for: Optional[List[str]] = None,
+        secondary_for: Optional[List[str]] = None,
+        api_key_env: Optional[str] = None,
+    ) -> None:
+        if capabilities.name in self._registrations:
+            raise ValueError(f"provider {capabilities.name!r} already registered")
+        self._registrations[capabilities.name] = _Registration(
+            factory=factory,
+            capabilities=capabilities,
+            default_for=list(default_for or []),
+            secondary_for=list(secondary_for or []),
+            api_key_env=api_key_env,
+        )
+
+    def names(self) -> List[str]:
+        return list(self._registrations.keys())
+
+    def get(self, name: str) -> ProviderAdapter:
+        if name not in self._registrations:
+            raise KeyError(f"provider {name!r} is not registered")
+        return self._registrations[name].factory()
+
+    def describe_all(self) -> List[Dict[str, object]]:
+        """Return a serializable snapshot for the ``GET /providers`` endpoint."""
+        out: List[Dict[str, object]] = []
+        for reg in self._registrations.values():
+            has_key = bool(reg.api_key_env and os.environ.get(reg.api_key_env))
+            out.append(
+                {
+                    "name": reg.capabilities.name,
+                    "supports": sorted(reg.capabilities.supports),
+                    "is_paid": reg.capabilities.is_paid,
+                    "has_key": has_key,
+                    "is_default_for": list(reg.default_for),
+                    "historical_timeframes": sorted(reg.capabilities.historical_timeframes),
+                    "live_timeframes": sorted(reg.capabilities.live_timeframes),
+                }
+            )
+        return out
+
+    # ------------------------------------------------------------------
+    # Selection
+    # ------------------------------------------------------------------
+
+    def resolve(
+        self,
+        *,
+        asset_class: str,
+        direction: str,
+        explicit: Optional[str] = None,
+    ) -> ProviderAdapter:
+        """Return the adapter chosen for ``(asset_class, direction)``.
+
+        ``direction`` is ``"historical"`` or ``"live"``. ``explicit`` wins
+        unconditionally if given; else paid providers with a configured key;
+        else the free default. Raises :class:`LookupError` if nothing matches.
+        """
+        if direction not in {"historical", "live"}:
+            raise ValueError("direction must be 'historical' or 'live'")
+        reg = self._pick(asset_class=asset_class, direction=direction, explicit=explicit)
+        if reg is None:
+            raise LookupError(
+                f"no provider available for asset_class={asset_class!r} direction={direction!r}"
+            )
+        return reg.factory()
+
+    def resolve_live(
+        self,
+        *,
+        asset_class: str,
+        explicit: Optional[str] = None,
+    ) -> "LiveResolution":
+        """Like :meth:`resolve` but with geo-failover support for crypto.
+
+        Returns both the **chosen** adapter and a fallback adapter (if any)
+        that the caller should try if the chosen one raises
+        :class:`ProviderRegionBlocked` *before the first bar is emitted*.
+        Only applies when ``direction="live"``.
+        """
+        primary_reg = self._pick(asset_class=asset_class, direction="live", explicit=explicit)
+        if primary_reg is None:
+            raise LookupError(
+                f"no provider available for asset_class={asset_class!r} direction='live'"
+            )
+
+        fallback_reg: Optional[_Registration] = None
+        if explicit is None:
+            # Only auto-failover when the user hasn't pinned a provider.
+            for reg in self._registrations.values():
+                if reg is primary_reg:
+                    continue
+                if asset_class in reg.secondary_for:
+                    fallback_reg = reg
+                    break
+
+        return LiveResolution(
+            primary=primary_reg.factory(),
+            primary_name=primary_reg.capabilities.name,
+            fallback=fallback_reg.factory() if fallback_reg else None,
+            fallback_name=fallback_reg.capabilities.name if fallback_reg else None,
+        )
+
+    # ------------------------------------------------------------------
+
+    def _pick(
+        self,
+        *,
+        asset_class: str,
+        direction: str,
+        explicit: Optional[str],
+    ) -> Optional[_Registration]:
+        # 1. Explicit wins.
+        if explicit is not None:
+            if explicit not in self._registrations:
+                raise KeyError(f"provider {explicit!r} is not registered")
+            reg = self._registrations[explicit]
+            if asset_class not in reg.capabilities.supports:
+                raise ValueError(
+                    f"provider {explicit!r} does not support asset_class={asset_class!r}"
+                )
+            if not _has_direction(reg, direction):
+                raise ValueError(f"provider {explicit!r} does not support direction={direction!r}")
+            return reg
+
+        # 2. Paid provider with API key configured.
+        for reg in self._registrations.values():
+            if not reg.capabilities.is_paid:
+                continue
+            if asset_class not in reg.capabilities.supports:
+                continue
+            if not _has_direction(reg, direction):
+                continue
+            if reg.api_key_env and os.environ.get(reg.api_key_env):
+                logger.debug(
+                    "registry selecting paid provider %s for %s/%s",
+                    reg.capabilities.name,
+                    asset_class,
+                    direction,
+                )
+                return reg
+
+        # 3. Free default for this asset class.
+        for reg in self._registrations.values():
+            if asset_class in reg.default_for and _has_direction(reg, direction):
+                return reg
+
+        # 4. Any free provider that supports it (last-resort).
+        for reg in self._registrations.values():
+            if reg.capabilities.is_paid:
+                continue
+            if asset_class in reg.capabilities.supports and _has_direction(reg, direction):
+                return reg
+
+        return None
+
+
+def _has_direction(reg: _Registration, direction: str) -> bool:
+    if direction == "historical":
+        return bool(reg.capabilities.historical_timeframes)
+    return bool(reg.capabilities.live_timeframes)
+
+
+@dataclass
+class LiveResolution:
+    """Result of :meth:`ProviderRegistry.resolve_live`."""
+
+    primary: ProviderAdapter
+    primary_name: str
+    fallback: Optional[ProviderAdapter] = None
+    fallback_name: Optional[str] = None
+
+
+__all__ = [
+    "AdapterFactory",
+    "LiveResolution",
+    "ProviderRegistry",
+    "ProviderRegionBlocked",
+]

--- a/backend/agents/investment_team/trading_service/providers/twelve_data.py
+++ b/backend/agents/investment_team/trading_service/providers/twelve_data.py
@@ -1,0 +1,77 @@
+"""Twelve Data provider adapter — paid alt (stocks, FX, crypto).
+
+Activated when ``TWELVE_DATA_API_KEY`` is set. A free tier exists but is
+rate-limited to 8 calls/minute, which is not usable for streaming; we only
+activate this adapter when the Pro (paid) plan key is present
+(``TWELVE_DATA_PLAN=pro``).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Iterator, List, Optional
+
+from ..data_stream.protocol import BarEvent
+from ..data_stream.resampler import NativeEvent
+from .base import ProviderCapabilities
+
+CAPABILITIES = ProviderCapabilities(
+    name="twelve_data",
+    supports={"crypto", "equities", "fx"},
+    is_paid=True,
+    historical_timeframes={"1m", "5m", "15m", "30m", "1h", "4h", "1d"},
+    live_timeframes={"1m"},  # no true tick stream on standard plans
+)
+
+
+class TwelveDataAdapter:
+    capabilities = CAPABILITIES
+
+    def __init__(self) -> None:
+        self._api_key = os.environ.get("TWELVE_DATA_API_KEY")
+        self._plan = os.environ.get("TWELVE_DATA_PLAN", "free").lower()
+
+    def _require_auth(self) -> None:
+        if not self._api_key:
+            raise RuntimeError("twelve_data adapter requires TWELVE_DATA_API_KEY")
+        if self._plan != "pro":
+            raise RuntimeError(
+                "twelve_data adapter only operates on the Pro plan "
+                "(TWELVE_DATA_PLAN=pro) due to free-tier rate limits"
+            )
+
+    def smallest_available(self, asset_class: str, *, live: bool) -> Optional[str]:
+        if asset_class not in self.capabilities.supports:
+            return None
+        return "1m"
+
+    def historical(
+        self,
+        *,
+        symbols: List[str],
+        asset_class: str,
+        start: str,
+        end: str,
+        timeframe: str,
+    ) -> Iterator[BarEvent]:
+        self._require_auth()
+        raise NotImplementedError("twelve_data historical pump is not yet wired")
+        yield  # pragma: no cover
+
+    def live(
+        self,
+        *,
+        symbols: List[str],
+        asset_class: str,
+        native_timeframe: str,
+    ) -> Iterator[NativeEvent]:
+        self._require_auth()
+        raise NotImplementedError("twelve_data live pump is not yet wired")
+        yield  # pragma: no cover
+
+
+def build() -> TwelveDataAdapter:
+    return TwelveDataAdapter()
+
+
+__all__ = ["CAPABILITIES", "TwelveDataAdapter", "build"]

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass, field
-from typing import Dict, Iterable, List, Optional
+from typing import Callable, Dict, Iterable, List, Optional
 
 from ..execution.risk_filter import RiskFilter, RiskLimits
 from ..models import BacktestConfig, TradeRecord
@@ -34,6 +34,10 @@ class TradingServiceResult:
     terminated_reason: Optional[str] = None
     lookahead_violation: bool = False
     error: Optional[str] = None
+    #: Orders the strategy tried to submit during a warm-up bar. These are
+    #: dropped as a belt-and-suspenders guard — strategies should check
+    #: ``ctx.is_warmup``. Populated only during paper-trade warm-up phase.
+    warmup_orders_dropped: int = 0
 
 
 class TradingService:
@@ -52,7 +56,19 @@ class TradingService:
 
     # ------------------------------------------------------------------
 
-    def run(self, stream: Iterable[StreamEvent]) -> TradingServiceResult:
+    def run(
+        self,
+        stream: Iterable[StreamEvent],
+        *,
+        on_trade: Optional[Callable[[TradeRecord], None]] = None,
+    ) -> TradingServiceResult:
+        """Run the strategy against ``stream``.
+
+        ``on_trade`` is invoked once per closed trade as they happen —
+        used by paper-trade mode to read the running fill count inside
+        its termination-check closure without peeking into service
+        internals.
+        """
         portfolio = Portfolio(initial_capital=self.config.initial_capital)
         order_book = OrderBook()
         fill_sim = FillSimulator(
@@ -94,47 +110,71 @@ class TradingService:
                     if not isinstance(event, BarEvent):
                         continue
                     cur_bar = event.bar
+                    is_warmup = event.is_warmup
 
-                    # 1) Expire day orders on date change.
-                    if prev_bar is not None and (cur_bar.timestamp[:10] != prev_bar.timestamp[:10]):
-                        order_book.expire_day_orders(cur_bar.timestamp)
+                    if not is_warmup:
+                        # 1) Expire day orders on date change.
+                        if prev_bar is not None and (
+                            cur_bar.timestamp[:10] != prev_bar.timestamp[:10]
+                        ):
+                            order_book.expire_day_orders(cur_bar.timestamp)
 
-                    # 2) Fill any orders from the previous iteration against
-                    #    *this* (current) bar. These were submitted by the
-                    #    strategy after seeing `prev_bar`.
-                    if pending_for_prev:
-                        for req in pending_for_prev:
-                            equity = portfolio.mark_to_market()
-                            order_book.submit(
-                                req, submitted_at=prev_bar.timestamp, submitted_equity=equity
+                        # 2) Fill any orders from the previous iteration against
+                        #    *this* (current) bar. These were submitted by the
+                        #    strategy after seeing `prev_bar`.
+                        if pending_for_prev:
+                            for req in pending_for_prev:
+                                equity = portfolio.mark_to_market()
+                                order_book.submit(
+                                    req,
+                                    submitted_at=prev_bar.timestamp,
+                                    submitted_equity=equity,
+                                )
+                            pending_for_prev = []
+
+                        outcome = fill_sim.process_bar(cur_bar)
+                        for fill in outcome.entry_fills + outcome.exit_fills:
+                            harness.send_fill(
+                                fill=fill.model_dump(mode="json"),
+                                state=self._state(portfolio),
                             )
-                        pending_for_prev = []
+                        result.trades.extend(outcome.closed_trades)
+                        if on_trade is not None:
+                            for trade in outcome.closed_trades:
+                                on_trade(trade)
 
-                    outcome = fill_sim.process_bar(cur_bar)
-                    for fill in outcome.entry_fills + outcome.exit_fills:
-                        harness.send_fill(
-                            fill=fill.model_dump(mode="json"), state=self._state(portfolio)
-                        )
-                    result.trades.extend(outcome.closed_trades)
-
-                    # 3) Drawdown circuit-breaker.
-                    portfolio.update_last_price(cur_bar.symbol, cur_bar.close)
-                    equity = portfolio.mark_to_market()
-                    dd = self._risk.check_drawdown(equity, portfolio.peak_equity)
-                    if dd.breached:
-                        result.terminated_reason = (
-                            f"max_drawdown breached "
-                            f"({dd.current_drawdown_pct:.1f}% >= {dd.limit_pct}%)"
-                        )
-                        break
+                        # 3) Drawdown circuit-breaker.
+                        portfolio.update_last_price(cur_bar.symbol, cur_bar.close)
+                        equity = portfolio.mark_to_market()
+                        dd = self._risk.check_drawdown(equity, portfolio.peak_equity)
+                        if dd.breached:
+                            result.terminated_reason = (
+                                f"max_drawdown breached "
+                                f"({dd.current_drawdown_pct:.1f}% >= {dd.limit_pct}%)"
+                            )
+                            break
 
                     # 4) Deliver the current bar to the strategy and collect
-                    #    any orders it submits in response.
+                    #    any orders it submits in response. Warm-up bars set
+                    #    ``ctx.is_warmup = True`` in the subprocess so the
+                    #    strategy can short-circuit order emission; we also
+                    #    drop any orders it emits anyway as a safety net.
                     resp = harness.send_bar(
                         bar=cur_bar.model_dump(mode="json"),
                         state=self._state(portfolio),
-                        is_warmup=False,
+                        is_warmup=is_warmup,
                     )
+
+                    if is_warmup:
+                        if resp.orders:
+                            result.warmup_orders_dropped += len(resp.orders)
+                            logger.info(
+                                "dropped %d order(s) submitted during warm-up bar",
+                                len(resp.orders),
+                            )
+                        # Cancels during warm-up are also no-ops (no live order book).
+                        prev_bar = cur_bar
+                        continue
 
                     # Map cancels.
                     for c in resp.cancels:


### PR DESCRIPTION
## Summary

Extends the unified Trading Service ([PR 1 #181](https://github.com/deepthought42/Khala-Agentic-AI-Teams/pull/181)) with:

- **Live market-data streaming** for paper trading via a pluggable provider registry (free-first defaults, paid alts via integrations).
- **Sub-daily backtests** through the same provider registry (e.g. `"15m"` via Binance REST klines).
- **One event loop, two modes**: `TradingService.run()` is unchanged for backtests; paper trading flows through the same code path by tagging warm-up bars.

Shipped behind `INVESTMENT_LIVE_PAPER_ENABLED=false` so existing deployments keep the legacy recent-OHLCV behavior until operators opt in.

Full spec at [`system_design/pr2_live_data_and_paper_cutover.md`](https://github.com/deepthought42/Khala-Agentic-AI-Teams/blob/claude/gifted-kalam/backend/agents/investment_team/system_design/pr2_live_data_and_paper_cutover.md).

## What's in this PR

| Area | File(s) |
|---|---|
| Resampler (tick/bar → target tf) | `trading_service/data_stream/resampler.py` |
| Provider Protocol + registry | `trading_service/providers/{base,registry}.py` |
| Provider adapters (7) | `trading_service/providers/{binance,binance_ws,coinbase,alpaca,oanda,polygon,databento,twelve_data}.py` |
| LiveStream (adapter → resampler → events) | `trading_service/data_stream/live_stream.py` |
| `ProviderHistoricalStream` | `trading_service/data_stream/provider_stream.py` |
| paper_trade mode + StopController | `trading_service/modes/paper_trade.py` |
| Sub-daily backtest path | `trading_service/modes/backtest.py` |
| Warm-up-aware service event loop | `trading_service/service.py`, `data_stream/protocol.py` |
| `PaperTradingSession` + API endpoints | `models.py`, `api/main.py` |

### Which providers actually stream today

- **Binance** — REST klines + websocket pump, **keyless**, works end-to-end.
- **Binance → Coinbase geo-failover** — wired at session open (HTTP 451 → fallback registry selection). Coinbase's own pump is the obvious next iteration.
- **Alpaca / OANDA / Polygon / Databento / Twelve Data** — correct capabilities registered; `live()` / `historical()` raise `NotImplementedError` with env-var pointers. One file per follow-up commit per the spec's merge order (§10).

### Resolved open questions from the spec (§11)

| # | Decision |
|---|---|
| D1 | Alpaca IEX as the free equities default; `provider_notes` flags the volume caveat |
| D2 | Binance → Coinbase geo-failover only at **session open**, not mid-session |
| D3 | OANDA practice signup is a documented first-run step (422 if token missing) |
| D4 | `POST /stop` is REST-only; SSE stays one-way |
| D5 | Warm-up default = **500 bars** |
| D6 | `min_fills < 20` warns (`warnings: ["min_fills_below_recommended"]`), doesn't reject |

## New API surface

- `POST /strategy-lab/paper-trade` — extended with `provider_id`, `min_fills`, `max_hours`, `warmup_bars`, `timeframe`. Returns **409** when a strategy already has an active live session.
- `POST /strategy-lab/paper-trade/{id}/stop` — idempotent user-stop.
- `GET /providers` — enumerate registered providers, capabilities, and `has_key` status. Useful for the UI.

## New env vars (all optional)

- `INVESTMENT_LIVE_PAPER_ENABLED` (default `false`) — gates the whole live path.
- `INVESTMENT_PAPER_WARMUP_BARS` / `INVESTMENT_PAPER_MIN_FILLS` / `INVESTMENT_PAPER_MAX_HOURS` — defaults.
- `INVESTMENT_LIVE_PROVIDER_{CRYPTO,EQUITIES,FX}` — override registry defaults.
- `BINANCE_WS_URL` / `COINBASE_WS_URL` — testable overrides.
- `ALPACA_API_KEY_ID` / `ALPACA_API_SECRET_KEY` / `ALPACA_PAID_FEED` — free IEX or paid SIP.
- `OANDA_API_TOKEN` / `OANDA_ACCOUNT_ID` — free practice account.
- `POLYGON_API_KEY`, `DATABENTO_API_KEY`, `TWELVE_DATA_API_KEY` — paid alts.

## Look-ahead safety

The PR 1 invariants are preserved:

- Strategy subprocess receives one `Bar` at a time; `ctx` has no `future_*` accessor.
- Fill simulator still peeks one bar forward **in the parent process** only; the subprocess never sees it.
- Resampler only emits a target-tf bar after observing a *later* native event — in-progress periods can't leak.
- Live warm-up bars are tagged `is_warmup=True`; the engine skips fill processing + drops any orders the strategy emits (belt-and-suspenders on top of strategies honoring `ctx.is_warmup`).
- Live bars with `ts < cutover_ts` are defensively dropped.

## Test plan

- [x] 51 new PR 2 tests green (resampler × 13, provider registry × 12, paper-trade × 8, sub-daily backtest × 5, Binance WS parsers × 10) + 3 original PR 1 tests still green.
- [x] `ruff check` clean on all touched files.
- [x] `ruff format` applied to all touched files.
- [x] Full investment_team suite: **198 passed, 2 xfailed** (the 2 pre-existing `test_strategy_lab_signal.py` failures are unrelated to this PR).
- [ ] Manual smoke: `INVESTMENT_LIVE_PAPER_ENABLED=true` against a real Binance WS connection (reviewer to validate in a staging env).
- [ ] UI integration: wire `GET /providers` into the Strategy Lab screen.

## What PR 3 still owes (for completeness)

Per the original "PR 1 of 3 / PR 2 of 3 / PR 3 of 3" sequencing:

- Retire legacy `TradeSimulationEngine` + `SandboxRunner` now that both modes share `TradingService`.
- Wire remaining provider pumps (Coinbase WS, Alpaca WS, OANDA stream).
- SSE progress stream `GET /strategy-lab/paper-trade/{id}/stream` (spec §6.1).
- Optional: intrabar fill simulation toggle (`FillSimulatorConfig.intrabar_fills`, spec §4.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)