### PR TITLE
llm_service: structured-output contract (fix founder spec parse failure + harden client)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,13 @@ All notable changes to this repository are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **`llm_service` structured-output contract:** new top-level `generate_text` / `generate_structured` entrypoints and a `complete_validated` helper that layers Pydantic validation + one schema-grounded self-correction retry on top of `complete_json`. New `LLMSchemaValidationError` carries `correction_attempts_used`; `LLMJsonParseError` gained the same optional field. A CI static check (`agents/llm_service/tests/test_no_markdown_in_structured.py`) prevents `*_PROMPT` constants with Markdown/prose bodies from being routed into JSON-only methods. Legacy `complete` / `complete_text` / `complete_json` / `chat_json_round` are unchanged and remain supported. See [FEATURE_SPEC_structured_output_contract.md](backend/agents/llm_service/FEATURE_SPEC_structured_output_contract.md).
+
 ### Fixed
 
+- **`user_agent_founder` spec generation:** the "Startup Founder Testing Persona" run no longer fails with `LLMJsonParseError` when the model returns Markdown. `FounderAgent.generate_spec` now bypasses the Strands / `chat_json_round` JSON-only transport and calls `LLMClient.complete` directly via a new `_call_text` helper. `FounderAgent.answer_question` migrated to `generate_structured` with a `FounderAnswer` Pydantic schema (canary for the new API); the bespoke regex/`json.loads` fallback was removed in favor of the self-correction guard.
 - **Ollama structured JSON:** responses with unescaped double quotes inside string values (common when the model cites snippets like `"Resource": "*"`) are parsed using a **`json-repair`** fallback in `OllamaLLMClient._extract_json`. Blog copy-editor prompt updated to require escaped or single-quoted inner quotes.
 
 ### Breaking changes

--- a/backend/agents/llm_service/README.md
+++ b/backend/agents/llm_service/README.md
@@ -20,6 +20,41 @@ text = client.complete(prompt, temperature=0.0, max_tokens=4096)
 max_ctx = client.get_max_context_tokens()
 ```
 
+## When to use which entrypoint
+
+New code should prefer the top-level helpers — they make the output contract
+explicit at the call site and eliminate the class of "Markdown prompt routed
+through a JSON parser" bugs that motivated
+[FEATURE_SPEC_structured_output_contract.md](FEATURE_SPEC_structured_output_contract.md).
+
+```python
+from llm_service import generate_text, generate_structured
+from pydantic import BaseModel
+
+# Free-form prose / Markdown / code — never JSON-parsed.
+spec_md = generate_text(prompt, system_prompt=PERSONA, agent_key="user_agent_founder")
+
+# Typed structured output — JSON mode + one self-correction retry applied automatically.
+class Answer(BaseModel):
+    selected_option_id: str
+    rationale: str
+
+answer = generate_structured(prompt, schema=Answer, agent_key="user_agent_founder")
+```
+
+Rule of thumb:
+
+| Use | When |
+|-----|------|
+| `generate_text` | The response is prose, Markdown, code, or any free-form text. |
+| `generate_structured` | The response must conform to a schema. Caller gets a validated Pydantic instance; single-shot parse/validation failures are auto-corrected once. |
+
+The legacy methods (`client.complete`, `client.complete_text`,
+`client.complete_json`, `client.chat_json_round`) remain fully supported for
+existing callers — no migration is required. See
+[FEATURE_SPEC_structured_output_contract.md](FEATURE_SPEC_structured_output_contract.md)
+for the design rationale and migration notes.
+
 ## Config (environment variables)
 
 | Variable | Meaning |

--- a/backend/agents/llm_service/__init__.py
+++ b/backend/agents/llm_service/__init__.py
@@ -9,6 +9,7 @@ and config (env vars, known context, per-agent defaults) are centralized here.
 from typing import TYPE_CHECKING, Any
 
 from . import config as _config
+from .api import generate_structured, generate_text
 from .clients import DummyLLMClient, OllamaLLMClient
 from .compaction import compact_text
 from .factory import _clear_client_cache_for_testing, get_client
@@ -19,11 +20,13 @@ from .interface import (
     LLMJsonParseError,
     LLMPermanentError,
     LLMRateLimitError,
+    LLMSchemaValidationError,
     LLMTemporaryError,
     LLMTruncatedError,
     LLMUnreachableAfterRetriesError,
 )
 from .strands_provider import _clear_strands_model_cache_for_testing, get_strands_model
+from .structured import complete_validated
 from .telemetry import get_recent_calls, get_usage_summary, record_llm_call
 from .tool_loop import complete_json_with_tool_loop
 from .util import call_llm_with_retries, extract_json_from_response
@@ -63,9 +66,12 @@ __all__ = [
     "_clear_client_cache_for_testing",
     "_clear_strands_model_cache_for_testing",
     "complete_json_with_tool_loop",
+    "complete_validated",
     "call_llm_with_retries",
     "compact_text",
     "extract_json_from_response",
+    "generate_structured",
+    "generate_text",
     "get_client",
     "get_strands_model",
     "get_llm_config_summary",
@@ -78,6 +84,7 @@ __all__ = [
     "LLMUnreachableAfterRetriesError",
     "LLMPermanentError",
     "LLMJsonParseError",
+    "LLMSchemaValidationError",
     "LLMTruncatedError",
     "OLLAMA_WEEKLY_LIMIT_MESSAGE",
     "OllamaLLMClient",

--- a/backend/agents/llm_service/api.py
+++ b/backend/agents/llm_service/api.py
@@ -1,0 +1,110 @@
+"""Public LLM entrypoints: ``generate_text`` and ``generate_structured``.
+
+Thin, opinionated wrappers over the existing :func:`llm_service.get_client`
+plumbing. The two functions make the contract explicit at every call site:
+
+- :func:`generate_text` — free-form string output. Never JSON-parsed.
+  Use for prose, Markdown, code, or any prompt that does not have a strict
+  response schema.
+- :func:`generate_structured` — Pydantic-typed structured output. Internally
+  enforces JSON mode (provider default) and applies the
+  :func:`llm_service.complete_validated` self-correction guard.
+
+Legacy methods (``complete``, ``complete_text``, ``complete_json``,
+``chat_json_round``) remain fully supported. This module is purely additive;
+new code is strongly encouraged to use these entrypoints instead.
+
+See :doc:`/backend/agents/llm_service/FEATURE_SPEC_structured_output_contract.md`.
+"""
+
+from __future__ import annotations
+
+from typing import TypeVar
+
+from pydantic import BaseModel
+
+from .factory import get_client
+from .structured import complete_validated
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def generate_text(
+    prompt: str,
+    *,
+    system_prompt: str | None = None,
+    temperature: float = 0.7,
+    agent_key: str | None = None,
+    think: bool = False,
+) -> str:
+    """Generate free-form text. The output is never JSON-parsed.
+
+    Use this for prose, Markdown, code, long-form answers, or any prompt whose
+    response does not have a strict schema.
+
+    Args:
+        prompt: The user prompt.
+        system_prompt: Optional system prompt.
+        temperature: Sampling temperature (default 0.7 for text generation).
+        agent_key: Per-agent config selector forwarded to ``get_client``.
+        think: Enable chain-of-thought / reasoning mode.
+
+    Returns:
+        Raw string response, stripped of leading/trailing whitespace.
+    """
+    client = get_client(agent_key=agent_key)
+    return str(
+        client.complete(
+            prompt,
+            system_prompt=system_prompt,
+            temperature=temperature,
+            think=think,
+        )
+    ).strip()
+
+
+def generate_structured(
+    prompt: str,
+    *,
+    schema: type[T],
+    system_prompt: str | None = None,
+    temperature: float = 0.0,
+    agent_key: str | None = None,
+    correction_attempts: int = 1,
+) -> T:
+    """Generate a typed structured response validated against ``schema``.
+
+    Internally delegates to :func:`llm_service.complete_validated`, which
+    provides one schema-grounded self-correction retry by default. JSON mode
+    is enforced implicitly inside the provider's ``complete_json``.
+
+    Args:
+        prompt: The user prompt. It should instruct the model to emit JSON.
+        schema: Pydantic ``BaseModel`` subclass the response must satisfy.
+        system_prompt: Optional system prompt.
+        temperature: Sampling temperature (default 0.0 for deterministic
+            structured output).
+        agent_key: Per-agent config selector forwarded to ``get_client``.
+        correction_attempts: Max corrective follow-up calls on parse /
+            validation failure (default 1; 0 opts out).
+
+    Returns:
+        An instance of ``schema`` validated against the final successful reply.
+
+    Raises:
+        LLMJsonParseError: Every attempt returned unparseable output.
+        LLMSchemaValidationError: Every attempt returned parseable JSON that
+            failed Pydantic validation.
+    """
+    client = get_client(agent_key=agent_key)
+    return complete_validated(
+        client,
+        prompt,
+        schema=schema,
+        system_prompt=system_prompt,
+        temperature=temperature,
+        correction_attempts=correction_attempts,
+    )
+
+
+__all__ = ["generate_structured", "generate_text"]

--- a/backend/agents/llm_service/interface.py
+++ b/backend/agents/llm_service/interface.py
@@ -57,10 +57,34 @@ class LLMJsonParseError(LLMPermanentError):
         *,
         error_kind: str = "json_parse",
         response_preview: str = "",
+        correction_attempts_used: int = 0,
     ):
         super().__init__(message)
         self.error_kind = error_kind
         self.response_preview = response_preview
+        self.correction_attempts_used = correction_attempts_used
+
+
+class LLMSchemaValidationError(LLMPermanentError):
+    """Raised when the LLM returned valid JSON that fails Pydantic schema validation.
+
+    Produced by the ``complete_validated`` helper after all corrective retries
+    have been exhausted. Wraps the underlying ``pydantic.ValidationError`` so
+    callers see a consistent ``LLMPermanentError`` subclass with the same
+    ``correction_attempts_used`` shape as ``LLMJsonParseError``.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        response_preview: str = "",
+        correction_attempts_used: int = 0,
+        cause: Optional[Exception] = None,
+    ):
+        super().__init__(message, cause=cause)
+        self.response_preview = response_preview
+        self.correction_attempts_used = correction_attempts_used
 
 
 class LLMTruncatedError(LLMError):

--- a/backend/agents/llm_service/structured.py
+++ b/backend/agents/llm_service/structured.py
@@ -1,0 +1,212 @@
+"""Structured-output helper: ``complete_validated``.
+
+Layers Pydantic schema validation + one self-correction retry on top of the
+already-parsed ``dict`` returned by :meth:`LLMClient.complete_json`. Designed
+to prevent single-shot ``LLMJsonParseError`` / ``pydantic.ValidationError``
+failures from wasting an entire run.
+
+Contract:
+
+- Does **not** call ``llm_service.util.extract_json_from_response``.
+  Provider clients handle JSON parsing internally and raise
+  :class:`LLMJsonParseError` on failure.
+- JSON mode is already enforced unconditionally inside ``complete_json``
+  (e.g. the Ollama client sets ``response_format={"type":"json_object"}``),
+  so this helper does not need to configure it.
+- On success after a correction, logs a single INFO line.
+  On terminal failure, logs a single WARNING and re-raises the last error
+  with ``correction_attempts_used`` populated.
+
+See :doc:`/backend/agents/llm_service/FEATURE_SPEC_structured_output_contract.md`
+for the motivating context (the ``user_agent_founder`` "Startup Founder Testing
+Persona" ``LLMJsonParseError``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from typing import Any, TypeVar
+
+from pydantic import BaseModel, ValidationError
+
+from .interface import LLMClient, LLMJsonParseError, LLMSchemaValidationError
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", bound=BaseModel)
+
+_CORRECTIVE_SUFFIX = (
+    "\n\n---\n"
+    "Your previous reply was rejected.\n"
+    "Error: {error}\n"
+    "Required JSON schema:\n{schema}\n"
+    "Re-emit ONLY a JSON object satisfying this schema — no prose, no markdown, "
+    "no code fences.\n"
+    "The previous reply (truncated) was:\n{preview}\n"
+)
+
+
+def _prompt_hash(prompt: str) -> str:
+    return hashlib.sha256(prompt.encode("utf-8")).hexdigest()[:12]
+
+
+def _build_corrective_prompt(
+    original_prompt: str,
+    *,
+    schema: type[BaseModel],
+    error_message: str,
+    preview: str,
+) -> str:
+    return original_prompt + _CORRECTIVE_SUFFIX.format(
+        error=error_message,
+        schema=json.dumps(schema.model_json_schema(), separators=(",", ":")),
+        preview=preview or "(empty)",
+    )
+
+
+def _truncate(text: str, *, limit: int = 500) -> str:
+    if len(text) <= limit:
+        return text
+    return text[:limit] + "…"
+
+
+def complete_validated(
+    client: LLMClient,
+    prompt: str,
+    *,
+    schema: type[T],
+    system_prompt: str | None = None,
+    temperature: float = 0.0,
+    correction_attempts: int = 1,
+    **kwargs: Any,
+) -> T:
+    """Call ``client.complete_json`` and validate the result against ``schema``.
+
+    On :class:`LLMJsonParseError` or :class:`pydantic.ValidationError`, performs
+    up to ``correction_attempts`` corrective follow-up calls. Each corrective
+    prompt is the original prompt with an appended block containing the error
+    message, the Pydantic schema, and the truncated previous reply.
+
+    Args:
+        client: The underlying :class:`LLMClient` (from ``llm_service.get_client``).
+        prompt: The user prompt.
+        schema: Pydantic ``BaseModel`` subclass the response must satisfy.
+        system_prompt: Optional system prompt forwarded to ``complete_json``.
+        temperature: Sampling temperature (default 0.0 for structured output).
+        correction_attempts: Max corrective follow-up calls (default 1).
+            ``0`` disables the retry and matches today's single-shot behavior.
+        **kwargs: Forwarded to ``client.complete_json``.
+
+    Returns:
+        An instance of ``schema`` validated against the final successful reply.
+
+    Raises:
+        LLMJsonParseError: The provider could not parse JSON on every attempt.
+            ``correction_attempts_used`` is set to the number of corrective
+            retries that also failed.
+        LLMSchemaValidationError: The provider returned valid JSON but every
+            attempt failed Pydantic validation.
+            ``correction_attempts_used`` is set analogously.
+    """
+    if correction_attempts < 0:
+        raise ValueError("correction_attempts must be >= 0")
+
+    current_prompt = prompt
+    last_parse_error: LLMJsonParseError | None = None
+    last_validation_error: ValidationError | None = None
+    last_validation_data: dict[str, Any] | None = None
+    attempts_used = 0
+
+    # Total call budget = 1 initial + correction_attempts follow-ups.
+    for attempt in range(correction_attempts + 1):
+        try:
+            data = client.complete_json(
+                current_prompt,
+                system_prompt=system_prompt,
+                temperature=temperature,
+                **kwargs,
+            )
+        except LLMJsonParseError as exc:
+            last_parse_error = exc
+            last_validation_error = None
+            last_validation_data = None
+            if attempt >= correction_attempts:
+                break
+            attempts_used = attempt + 1
+            current_prompt = _build_corrective_prompt(
+                prompt,
+                schema=schema,
+                error_message=str(exc),
+                preview=exc.response_preview or "",
+            )
+            continue
+
+        try:
+            validated = schema.model_validate(data)
+        except ValidationError as exc:
+            last_validation_error = exc
+            last_parse_error = None
+            last_validation_data = data if isinstance(data, dict) else None
+            if attempt >= correction_attempts:
+                break
+            attempts_used = attempt + 1
+            try:
+                preview = json.dumps(data, default=str)
+            except (TypeError, ValueError):
+                preview = repr(data)
+            current_prompt = _build_corrective_prompt(
+                prompt,
+                schema=schema,
+                error_message=str(exc),
+                preview=_truncate(preview),
+            )
+            continue
+
+        if attempts_used > 0:
+            logger.info(
+                "json_self_correction succeeded after %d retry (schema=%s, prompt_hash=%s)",
+                attempts_used,
+                schema.__name__,
+                _prompt_hash(prompt),
+            )
+        return validated
+
+    # Exhausted all attempts — log WARNING and re-raise the most recent failure.
+    if last_parse_error is not None:
+        preview_for_log = _truncate(last_parse_error.response_preview or "", limit=500)
+        logger.warning(
+            "json_self_correction failed terminally (schema=%s, prompt_hash=%s, "
+            "kind=parse, attempts_used=%d, preview=%r)",
+            schema.__name__,
+            _prompt_hash(prompt),
+            attempts_used,
+            preview_for_log,
+        )
+        last_parse_error.correction_attempts_used = attempts_used
+        raise last_parse_error
+
+    assert last_validation_error is not None  # one of the two paths must be set
+    try:
+        preview = json.dumps(last_validation_data, default=str)
+    except (TypeError, ValueError):
+        preview = repr(last_validation_data)
+    preview = _truncate(preview)
+    logger.warning(
+        "json_self_correction failed terminally (schema=%s, prompt_hash=%s, "
+        "kind=validation, attempts_used=%d, preview=%r)",
+        schema.__name__,
+        _prompt_hash(prompt),
+        attempts_used,
+        preview,
+    )
+    raise LLMSchemaValidationError(
+        f"Response failed Pydantic validation against {schema.__name__}: {last_validation_error}",
+        response_preview=preview,
+        correction_attempts_used=attempts_used,
+        cause=last_validation_error,
+    )
+
+
+__all__ = ["complete_validated"]

--- a/backend/agents/llm_service/tests/test_no_markdown_in_structured.py
+++ b/backend/agents/llm_service/tests/test_no_markdown_in_structured.py
@@ -38,7 +38,7 @@ from pathlib import Path
 # Configuration
 # ---------------------------------------------------------------------------
 
-AGENTS_ROOT = Path(__file__).resolve().parents[3]  # backend/agents/
+AGENTS_ROOT = Path(__file__).resolve().parents[2]  # backend/agents/
 
 TRIGGER_PHRASES = (
     "markdown",

--- a/backend/agents/llm_service/tests/test_no_markdown_in_structured.py
+++ b/backend/agents/llm_service/tests/test_no_markdown_in_structured.py
@@ -1,0 +1,240 @@
+"""Static check: Markdown / prose prompts must not be routed into JSON methods.
+
+Prevents recurrence of the Phase 1 failure — a prompt that asks for Markdown
+being passed into a JSON-only LLM method (``complete_json`` /
+``chat_json_round`` / ``generate_structured``). See
+:doc:`/backend/agents/llm_service/FEATURE_SPEC_structured_output_contract.md`.
+
+How it works
+------------
+
+1. Walks ``backend/agents/**/*.py`` and collects every module-level assignment
+   of the form ``FOO_PROMPT = "..."`` (including multi-part string
+   concatenation such as ``"...".join(...)`` of literal parts).
+2. Flags a prompt as **text-intent** if its body contains one of the trigger
+   phrases (``markdown``, ``prose``, ``as a document``) **and** does not also
+   contain a JSON-mode signal (``json object``, ``respond with a json``,
+   ``json schema``). The JSON-signal carve-out prevents false positives like
+   "respond with a JSON object (no markdown fencing)" in
+   :data:`user_agent_founder.agent.QUESTION_ANSWERING_PROMPT`.
+3. Scans every call site in the same module to ``complete_json`` /
+   ``chat_json_round`` / ``generate_structured`` and asserts its first
+   positional argument is not a text-intent prompt name.
+4. Violations that predate this check live in :data:`ALLOW_LIST` — each entry
+   must name a follow-up plan or issue. If ``ALLOW_LIST`` grows beyond a
+   handful, treat that as a signal that more migrations belong in the
+   structured-output contract plan.
+
+This is a best-effort AST heuristic, not a soundness proof. It catches the
+common footgun (named ``*_PROMPT`` constants) while staying CI-fast.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+AGENTS_ROOT = Path(__file__).resolve().parents[3]  # backend/agents/
+
+TRIGGER_PHRASES = (
+    "markdown",
+    "prose",
+    "as a document",
+    "as a markdown",
+    "markdown document",
+    "write the spec",
+)
+
+# If any of these substrings appear, the prompt is asking for JSON and the
+# ``markdown`` token is almost certainly a negation (e.g. "no markdown fencing").
+JSON_INTENT_MARKERS = (
+    "json object",
+    "json schema",
+    "respond with a json",
+    "return a json",
+    "emit only a json",
+    "a json object",
+    "json-decoded",
+)
+
+JSON_METHODS = {"complete_json", "chat_json_round", "generate_structured"}
+
+# Allow-list: (relative_path_from_agents_root, prompt_name). Each entry must
+# carry a trailing comment naming the follow-up. Keep this list short — more
+# than a handful is a signal that migration work belongs in the plan, not
+# the allow-list.
+ALLOW_LIST: set[tuple[str, str]] = set()
+
+
+# ---------------------------------------------------------------------------
+# AST helpers
+# ---------------------------------------------------------------------------
+
+
+def _literal_string(node: ast.AST) -> str | None:
+    """Return the string body of ``node`` if it is a (concatenated) string literal.
+
+    Handles bare ``Constant(str)`` and ``BinOp`` / ``JoinedStr`` concatenations
+    of string literals. Returns ``None`` for anything dynamic.
+    """
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    if isinstance(node, ast.JoinedStr):
+        parts: list[str] = []
+        for piece in node.values:
+            if isinstance(piece, ast.Constant) and isinstance(piece.value, str):
+                parts.append(piece.value)
+            else:
+                # f-string with dynamic interpolation — still mostly a literal
+                # for our heuristic, but we can't know the interpolated value.
+                # Treat the literal scaffolding as the body.
+                continue
+        return "".join(parts)
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.Add):
+        left = _literal_string(node.left)
+        right = _literal_string(node.right)
+        if left is not None and right is not None:
+            return left + right
+    return None
+
+
+def _is_text_intent(body: str) -> bool:
+    lower = body.lower()
+    has_trigger = any(phrase in lower for phrase in TRIGGER_PHRASES)
+    if not has_trigger:
+        return False
+    has_json_intent = any(marker in lower for marker in JSON_INTENT_MARKERS)
+    return not has_json_intent
+
+
+def _collect_text_intent_prompts(tree: ast.AST) -> set[str]:
+    """Return the set of ``*_PROMPT`` names whose literal body is text-intent."""
+    names: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        body = _literal_string(node.value)
+        if body is None or not _is_text_intent(body):
+            continue
+        for target in node.targets:
+            if isinstance(target, ast.Name) and target.id.endswith("_PROMPT"):
+                names.add(target.id)
+    return names
+
+
+def _collect_json_call_violations(
+    tree: ast.AST,
+    text_intent_names: set[str],
+) -> list[tuple[str, int]]:
+    """Return a list of (prompt_name, lineno) for offending call sites."""
+    violations: list[tuple[str, int]] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func_name: str | None = None
+        if isinstance(node.func, ast.Attribute):
+            func_name = node.func.attr
+        elif isinstance(node.func, ast.Name):
+            func_name = node.func.id
+        if func_name not in JSON_METHODS:
+            continue
+        # First positional arg OR ``prompt=`` kwarg.
+        candidate: ast.AST | None = None
+        if node.args:
+            candidate = node.args[0]
+        for kw in node.keywords:
+            if kw.arg == "prompt":
+                candidate = kw.value
+                break
+        if candidate is None:
+            continue
+        if isinstance(candidate, ast.Name) and candidate.id in text_intent_names:
+            violations.append((candidate.id, node.lineno))
+        elif isinstance(candidate, ast.Attribute) and candidate.attr in text_intent_names:
+            violations.append((candidate.attr, node.lineno))
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+def _iter_agent_py_files():
+    for path in AGENTS_ROOT.rglob("*.py"):
+        # Skip this test file and any obvious non-source locations.
+        if path == Path(__file__).resolve():
+            continue
+        parts = path.parts
+        if any(p in {"__pycache__", ".venv", "venv", "node_modules"} for p in parts):
+            continue
+        yield path
+
+
+def test_detector_catches_synthetic_violation():
+    """Sanity check: the AST walker flags a crafted text-intent-into-JSON call."""
+    source = '''
+MY_PROMPT = """
+Write a markdown document with three sections.
+No strict schema — just prose.
+"""
+
+def do_thing(client):
+    return client.complete_json(MY_PROMPT)
+'''
+    tree = ast.parse(source)
+    text_intent = _collect_text_intent_prompts(tree)
+    assert "MY_PROMPT" in text_intent
+    violations = _collect_json_call_violations(tree, text_intent)
+    assert violations == [("MY_PROMPT", 8)]
+
+
+def test_detector_respects_json_intent_carveout():
+    """A prompt that says 'no markdown fencing' while asking for JSON is safe."""
+    source = '''
+MY_PROMPT = """
+Respond with a JSON object (no markdown fencing):
+{ "ok": true }
+"""
+
+def do_thing(client):
+    return client.complete_json(MY_PROMPT)
+'''
+    tree = ast.parse(source)
+    text_intent = _collect_text_intent_prompts(tree)
+    assert "MY_PROMPT" not in text_intent
+
+
+def test_no_text_intent_prompt_passed_to_json_method():
+    offenders: list[str] = []
+    for path in _iter_agent_py_files():
+        try:
+            source = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        try:
+            tree = ast.parse(source, filename=str(path))
+        except SyntaxError:
+            continue
+        text_intent_names = _collect_text_intent_prompts(tree)
+        if not text_intent_names:
+            continue
+        rel = path.relative_to(AGENTS_ROOT).as_posix()
+        violations = _collect_json_call_violations(tree, text_intent_names)
+        for name, lineno in violations:
+            if (rel, name) in ALLOW_LIST:
+                continue
+            offenders.append(f"{rel}:{lineno}: {name} (text-intent prompt) routed into JSON method")
+
+    assert not offenders, (
+        "Text-intent prompts ('markdown', 'prose', etc. bodies) must not be passed to "
+        "complete_json / chat_json_round / generate_structured. "
+        "Use generate_text or client.complete() for free-form text, or rewrite the prompt "
+        "to demand strict JSON output. "
+        "If the flag is intentional, add an entry to ALLOW_LIST with a follow-up reference.\n"
+        + "\n".join(offenders)
+    )

--- a/backend/agents/llm_service/tests/test_structured_output.py
+++ b/backend/agents/llm_service/tests/test_structured_output.py
@@ -1,0 +1,205 @@
+"""Tests for ``llm_service.complete_validated`` (Phase 2 structured-output guard)."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+from llm_service.interface import (
+    LLMClient,
+    LLMJsonParseError,
+    LLMSchemaValidationError,
+)
+from llm_service.structured import complete_validated
+
+
+class FounderAnswer(BaseModel):
+    selected_option_id: str
+    other_text: str | None = None
+    rationale: str
+
+
+class _StubClient(LLMClient):
+    """Minimal LLMClient stub — routes ``complete_json`` through a user-supplied callable."""
+
+    def __init__(self, handler):
+        self._handler = handler
+        self.call_prompts: list[str] = []
+        self.call_system_prompts: list[str | None] = []
+
+    def complete_json(self, prompt, *, temperature=0.0, system_prompt=None, tools=None, think=False, **kwargs):
+        self.call_prompts.append(prompt)
+        self.call_system_prompts.append(system_prompt)
+        return self._handler(prompt, call_index=len(self.call_prompts) - 1)
+
+
+# ---------------------------------------------------------------------------
+# s2-tests-success — corrected parse after one retry
+# ---------------------------------------------------------------------------
+
+
+def test_complete_validated_succeeds_after_parse_error(caplog):
+    valid_payload = {
+        "selected_option_id": "opt-a",
+        "other_text": None,
+        "rationale": "because reasons",
+    }
+
+    def handler(prompt: str, *, call_index: int) -> dict[str, Any]:
+        if call_index == 0:
+            raise LLMJsonParseError(
+                "Non-JSON reply",
+                response_preview="# Markdown spec — not JSON",
+            )
+        return valid_payload
+
+    client = _StubClient(handler)
+
+    with caplog.at_level(logging.INFO, logger="llm_service.structured"):
+        result = complete_validated(
+            client,
+            "generate an answer",
+            schema=FounderAnswer,
+        )
+
+    assert isinstance(result, FounderAnswer)
+    assert result.selected_option_id == "opt-a"
+    assert len(client.call_prompts) == 2
+    # Corrective prompt must embed the error + schema + preview.
+    retry_prompt = client.call_prompts[1]
+    assert "Non-JSON reply" in retry_prompt
+    assert "# Markdown spec — not JSON" in retry_prompt
+    assert "selected_option_id" in retry_prompt  # schema embedded
+    # One INFO log confirming self-correction.
+    success_logs = [
+        r for r in caplog.records if "json_self_correction succeeded" in r.getMessage()
+    ]
+    assert len(success_logs) == 1
+    assert "FounderAnswer" in success_logs[0].getMessage()
+
+
+# ---------------------------------------------------------------------------
+# s2-tests-failure — parse errors on every attempt
+# ---------------------------------------------------------------------------
+
+
+def test_complete_validated_terminal_parse_failure_raises_with_attempts(caplog):
+    def handler(prompt: str, *, call_index: int) -> dict[str, Any]:
+        raise LLMJsonParseError(
+            f"bad json attempt {call_index}",
+            response_preview="# still markdown",
+        )
+
+    client = _StubClient(handler)
+
+    with caplog.at_level(logging.WARNING, logger="llm_service.structured"):
+        with pytest.raises(LLMJsonParseError) as excinfo:
+            complete_validated(client, "prompt", schema=FounderAnswer)
+
+    assert excinfo.value.correction_attempts_used == 1
+    assert len(client.call_prompts) == 2
+    warning_logs = [
+        r for r in caplog.records if "json_self_correction failed terminally" in r.getMessage()
+    ]
+    assert len(warning_logs) == 1
+    msg = warning_logs[0].getMessage()
+    assert "FounderAnswer" in msg
+    assert "attempts_used=1" in msg
+
+
+# ---------------------------------------------------------------------------
+# s2-tests-validation — parse ok on call 1 but missing required field; ok on call 2
+# ---------------------------------------------------------------------------
+
+
+def test_complete_validated_corrects_validation_error():
+    def handler(prompt: str, *, call_index: int) -> dict[str, Any]:
+        if call_index == 0:
+            # Missing required ``rationale`` field.
+            return {"selected_option_id": "opt-a"}
+        return {
+            "selected_option_id": "opt-a",
+            "other_text": None,
+            "rationale": "validated on retry",
+        }
+
+    client = _StubClient(handler)
+    result = complete_validated(client, "prompt", schema=FounderAnswer)
+
+    assert isinstance(result, FounderAnswer)
+    assert result.rationale == "validated on retry"
+    retry_prompt = client.call_prompts[1]
+    # The Pydantic validation error must be present in the corrective prompt.
+    assert "rationale" in retry_prompt
+    # Previous reply (truncated JSON) must be quoted back to the model.
+    assert "opt-a" in retry_prompt
+
+
+def test_complete_validated_terminal_validation_failure():
+    def handler(prompt: str, *, call_index: int) -> dict[str, Any]:
+        return {"selected_option_id": "opt-a"}  # always missing ``rationale``
+
+    client = _StubClient(handler)
+    with pytest.raises(LLMSchemaValidationError) as excinfo:
+        complete_validated(client, "prompt", schema=FounderAnswer)
+
+    assert excinfo.value.correction_attempts_used == 1
+    assert len(client.call_prompts) == 2
+    assert "FounderAnswer" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# s2-tests-no-extract-call — pin that extract_json_from_response is never called
+# ---------------------------------------------------------------------------
+
+
+def test_complete_validated_never_calls_extract_json_from_response(monkeypatch):
+    """The helper must operate on the parsed dict from complete_json — never raw text."""
+    import llm_service.util as util_module
+
+    def _sentinel(*args, **kwargs):
+        raise AssertionError("extract_json_from_response must not be called by complete_validated")
+
+    monkeypatch.setattr(util_module, "extract_json_from_response", _sentinel)
+
+    # Also patch the symbol on structured in case it imported by name (it does not today,
+    # but this makes the contract-pin bulletproof against future edits that add such an import).
+    import llm_service.structured as structured_module
+
+    if hasattr(structured_module, "extract_json_from_response"):
+        monkeypatch.setattr(
+            structured_module, "extract_json_from_response", _sentinel, raising=False
+        )
+
+    def handler(prompt: str, *, call_index: int) -> dict[str, Any]:
+        return {
+            "selected_option_id": "opt-a",
+            "other_text": None,
+            "rationale": "ok",
+        }
+
+    client = _StubClient(handler)
+    result = complete_validated(client, "prompt", schema=FounderAnswer)
+    assert isinstance(result, FounderAnswer)
+
+
+# ---------------------------------------------------------------------------
+# Additional invariants — opt-out and retry-budget honoring
+# ---------------------------------------------------------------------------
+
+
+def test_correction_attempts_zero_opts_out():
+    """correction_attempts=0 preserves today's single-shot behavior."""
+
+    def handler(prompt: str, *, call_index: int) -> dict[str, Any]:
+        raise LLMJsonParseError("single shot fails", response_preview="")
+
+    client = _StubClient(handler)
+    with pytest.raises(LLMJsonParseError) as excinfo:
+        complete_validated(client, "prompt", schema=FounderAnswer, correction_attempts=0)
+
+    assert excinfo.value.correction_attempts_used == 0
+    assert len(client.call_prompts) == 1

--- a/backend/agents/user_agent_founder/agent.py
+++ b/backend/agents/user_agent_founder/agent.py
@@ -6,12 +6,34 @@ through the lens of a bootstrapped founder building a task management service.
 
 from __future__ import annotations
 
-import json
 import logging
-import re
 from typing import Any
 
+from pydantic import BaseModel, Field
+
 logger = logging.getLogger(__name__)
+
+
+class FounderAnswer(BaseModel):
+    """Schema for a founder's answer to a question from the SE team.
+
+    Validated at the ``llm_service.generate_structured`` boundary; a single
+    schema-grounded self-correction retry is applied automatically before
+    the caller sees a failure.
+    """
+
+    selected_option_id: str = Field(
+        ...,
+        description="Chosen option id, or 'other' for a custom answer",
+    )
+    other_text: str | None = Field(
+        None,
+        description="Custom answer text when selected_option_id == 'other'",
+    )
+    rationale: str = Field(
+        ...,
+        description="Short explanation of the decision in founder-values terms",
+    )
 
 FOUNDER_SYSTEM_PROMPT = """\
 You are Alex Chen, a bootstrapped startup founder building a task management \
@@ -133,26 +155,6 @@ Respond with a JSON object (no markdown fencing):
 """
 
 
-def _parse_answer(raw: str) -> dict[str, Any]:
-    """Parse LLM answer JSON with fallback."""
-    cleaned = re.sub(r"^```(?:json)?\s*", "", raw.strip())
-    cleaned = re.sub(r"\s*```$", "", cleaned)
-    try:
-        parsed = json.loads(cleaned)
-        return {
-            "selected_option_id": parsed.get("selected_option_id", "other"),
-            "other_text": parsed.get("other_text"),
-            "rationale": parsed.get("rationale", ""),
-        }
-    except (json.JSONDecodeError, AttributeError):
-        logger.warning("Failed to parse answer JSON, using raw text as custom answer")
-        return {
-            "selected_option_id": "other",
-            "other_text": raw.strip(),
-            "rationale": "Could not parse structured response; using raw text.",
-        }
-
-
 class FounderAgent:
     """Simulates a budget-conscious, speed-first, UX-obsessed startup founder."""
 
@@ -195,12 +197,70 @@ class FounderAgent:
                     continue
                 raise
 
+    def _call_text(
+        self,
+        prompt: str,
+        *,
+        system_prompt: str | None = None,
+        max_retries: int = 3,
+    ) -> str:
+        """Invoke the LLM via a text-only path (bypasses Strands / JSON transport).
+
+        Use for prompts that expect Markdown or prose. The response is returned
+        verbatim and is never JSON-parsed. Mirrors ``_call``'s transient-error
+        retry/backoff so flaky-network behavior is unchanged.
+        """
+        import time as _time
+
+        from llm_service import get_client
+
+        client = get_client(agent_key="user_agent_founder")
+        for attempt in range(max_retries + 1):
+            try:
+                result = client.complete(
+                    prompt,
+                    system_prompt=system_prompt,
+                    temperature=0.7,
+                )
+                return str(result).strip()
+            except Exception as exc:
+                exc_text = str(exc).lower()
+                is_transient = any(k in exc_text for k in (
+                    "500", "502", "503", "504",
+                    "internal server error", "service unavailable",
+                    "timeout", "connection", "reset",
+                ))
+                if is_transient and attempt < max_retries:
+                    wait = 2 ** attempt * 5  # 5s, 10s, 20s
+                    logger.warning(
+                        "LLM call failed (attempt %d/%d), retrying in %ds: %s",
+                        attempt + 1, max_retries + 1, wait, str(exc)[:200],
+                    )
+                    _time.sleep(wait)
+                    continue
+                raise
+
     def generate_spec(self) -> str:
-        """Generate the TaskFlow product specification."""
-        return self._call(SPEC_GENERATION_PROMPT)
+        """Generate the TaskFlow product specification.
+
+        Returns raw Markdown. The response is never JSON-parsed downstream —
+        ``orchestrator.run_workflow`` stores ``spec_content`` verbatim and
+        POSTs it as a string body to ``/product-analysis/start-from-spec``.
+        Routed through ``_call_text`` (direct ``LLMClient.complete``) rather
+        than the Strands ``Agent`` to avoid the JSON-only transport rejecting
+        a Markdown reply.
+        """
+        return self._call_text(SPEC_GENERATION_PROMPT, system_prompt=FOUNDER_SYSTEM_PROMPT)
 
     def answer_question(self, question: dict[str, Any]) -> dict[str, Any]:
         """Answer a pending question from the SE team.
+
+        Delegates to :func:`llm_service.generate_structured` with the
+        :class:`FounderAnswer` schema, which enforces JSON-mode output and
+        applies one schema-grounded self-correction retry before failing.
+        The bespoke regex-stripping / ``json.loads`` fallback that lived here
+        previously is no longer needed — the guard covers both the parse
+        and validation failure modes.
 
         Args:
             question: Dict with keys: id, question_text, context, recommendation, options.
@@ -208,7 +268,14 @@ class FounderAgent:
 
         Returns:
             Dict with: selected_option_id, other_text (or None), rationale.
+
+        Raises:
+            LLMJsonParseError / LLMSchemaValidationError: surfaced only when
+            the corrective retry also fails. The orchestrator catches these
+            in its ``try`` block and records the question as unanswered.
         """
+        from llm_service import generate_structured
+
         options = question.get("options") or []
         options_lines = []
         for opt in options:
@@ -231,7 +298,13 @@ class FounderAgent:
             options_text=options_text,
         )
 
-        return _parse_answer(self._call(prompt))
+        answer = generate_structured(
+            prompt,
+            schema=FounderAnswer,
+            system_prompt=FOUNDER_SYSTEM_PROMPT,
+            agent_key="user_agent_founder",
+        )
+        return answer.model_dump()
 
     def chat(self, message: str, context: dict[str, Any]) -> str:
         """Respond to a user chat message in the founder persona."""

--- a/backend/agents/user_agent_founder/tests/test_agent_generate_spec.py
+++ b/backend/agents/user_agent_founder/tests/test_agent_generate_spec.py
@@ -1,0 +1,122 @@
+"""Regression test for the Phase 1 spec-generation routing fix.
+
+The "Startup Founder Testing Persona" run previously failed with
+``LLMJsonParseError`` because ``FounderAgent.generate_spec`` sent a Markdown
+prompt through the Strands ``Agent`` → ``chat_json_round`` path, which forces
+``response_format=json_object`` on the underlying Ollama client. After the fix,
+``generate_spec`` routes through ``FounderAgent._call_text`` which calls
+``LLMClient.complete`` directly (a text-only path — no JSON mode).
+
+This test pins that contract by:
+
+1. Asserting the Markdown preview from the failing run is returned unchanged.
+2. Asserting the Strands agent (and therefore ``chat_json_round``) is never
+   invoked for the spec-generation call.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+FAILING_RUN_PREVIEW = (
+    "# TaskFlow MVP Specification v0.1\n"
+    "**Author:** Alex Chen  \n"
+    "**Status:** Approved for Build  \n"
+    "**Target Ship Date:** 14 Days from Now  \n\n"
+    "---\n\n"
+    "## 1. Product Overview\n"
+    "TaskFlow is a real-time task management tool for small teams (2-10 people) "
+    "who are drowning in configuration overhead.\n"
+)
+
+
+def _make_agent_without_init(strands_agent_stub: object) -> object:
+    """Construct a FounderAgent without running ``__init__``.
+
+    Bypasses the real Strands ``Agent`` construction (which would need the
+    ``strands`` package and a live model). We still assign a canary object to
+    ``self._agent`` so the test can detect if anything accidentally routes
+    through the Strands path.
+    """
+    from user_agent_founder import agent as agent_module
+
+    founder = agent_module.FounderAgent.__new__(agent_module.FounderAgent)
+    founder._agent = strands_agent_stub
+    return founder
+
+
+def test_generate_spec_returns_markdown_unchanged(monkeypatch):
+    """generate_spec must return the raw Markdown reply verbatim."""
+    fake_client = MagicMock()
+    fake_client.complete.return_value = FAILING_RUN_PREVIEW
+    fake_client.chat_json_round = MagicMock(
+        side_effect=AssertionError("chat_json_round must not be called by generate_spec"),
+    )
+
+    # ``_call_text`` performs ``from llm_service import get_client`` at call
+    # time — patch the module attribute so the stub is returned.
+    import llm_service
+
+    monkeypatch.setattr(llm_service, "get_client", lambda agent_key=None: fake_client)
+
+    strands_agent_spy = MagicMock(
+        side_effect=AssertionError("Strands Agent must not be invoked by generate_spec"),
+    )
+    founder = _make_agent_without_init(strands_agent_spy)
+
+    result = founder.generate_spec()
+
+    assert result == FAILING_RUN_PREVIEW.strip()
+
+
+def test_generate_spec_bypasses_strands_json_transport(monkeypatch):
+    """The Strands agent (and hence chat_json_round) must never fire for spec generation."""
+    fake_client = MagicMock()
+    fake_client.complete.return_value = "# Some spec\n\nWith markdown body."
+    fake_client.chat_json_round = MagicMock(
+        side_effect=AssertionError("chat_json_round must not be called by generate_spec"),
+    )
+
+    import llm_service
+
+    monkeypatch.setattr(llm_service, "get_client", lambda agent_key=None: fake_client)
+
+    strands_agent_spy = MagicMock(
+        side_effect=AssertionError("Strands Agent must not be invoked by generate_spec"),
+    )
+    founder = _make_agent_without_init(strands_agent_spy)
+
+    founder.generate_spec()
+
+    # client.complete is the text-only path — must be hit exactly once.
+    fake_client.complete.assert_called_once()
+    call_kwargs = fake_client.complete.call_args.kwargs
+    # System prompt must be plumbed through so the founder persona is preserved
+    # now that we no longer rely on Strands' system_prompt wiring.
+    assert "system_prompt" in call_kwargs
+    assert call_kwargs["system_prompt"] is not None
+
+    # chat_json_round and the Strands agent must be untouched.
+    fake_client.chat_json_round.assert_not_called()
+    strands_agent_spy.assert_not_called()
+
+
+def test_generate_spec_uses_founder_system_prompt(monkeypatch):
+    """The founder persona's system prompt must be forwarded to client.complete."""
+    from user_agent_founder import agent as agent_module
+
+    fake_client = MagicMock()
+    fake_client.complete.return_value = "ok"
+
+    import llm_service
+
+    monkeypatch.setattr(llm_service, "get_client", lambda agent_key=None: fake_client)
+
+    founder = _make_agent_without_init(MagicMock())
+    founder.generate_spec()
+
+    call_kwargs = fake_client.complete.call_args.kwargs
+    assert call_kwargs["system_prompt"] == agent_module.FOUNDER_SYSTEM_PROMPT
+    # The user-facing prompt must still be the spec generation prompt.
+    sent_prompt = fake_client.complete.call_args.args[0]
+    assert sent_prompt == agent_module.SPEC_GENERATION_PROMPT


### PR DESCRIPTION
## Summary

Implements the three-part fix from [FEATURE_SPEC_structured_output_contract.md](backend/agents/llm_service/FEATURE_SPEC_structured_output_contract.md) (landed as docs-only in #182) to resolve the recurring `LLMJsonParseError` seen in the "Startup Founder Testing Persona" run, where a Markdown-asking prompt was routed through the Strands / `chat_json_round` JSON-only transport.

### Phase 1 — unblock the failing run
- `FounderAgent.generate_spec` routes through a new `_call_text` helper that calls `LLMClient.complete` directly, bypassing the Strands `Agent`. Markdown replies now survive unchanged.
- No edits under `graphs/lifecycle_graph.py` (dead code — confirmed no callers).
- Regression test pins both that the failing-run Markdown preview is returned verbatim and that `chat_json_round` / the Strands agent are never invoked for spec generation.

### Phase 2 — recover the class
- New `llm_service.complete_validated` layers Pydantic schema validation + one schema-grounded self-correction retry on top of `complete_json`'s already-parsed dict. Does **not** call `extract_json_from_response`.
- `LLMJsonParseError` gains an additive `correction_attempts_used` field; new `LLMSchemaValidationError(LLMPermanentError)` wraps terminal `pydantic.ValidationError` failures with the same shape and `.cause`.
- Emits one `INFO` line on self-correction success and one `WARNING` on terminal failure (schema name, prompt hash, truncated preview).

### Phase 3 — prevent recurrence
- New additive `llm_service.api` module exports `generate_text` (free-form; never JSON-parsed) and `generate_structured` (typed Pydantic output with Phase 2's guard baked in).
- Canary migration: `FounderAgent.answer_question` now uses `generate_structured` with a `FounderAnswer` Pydantic schema; the bespoke regex/`json.loads` fallback is deleted — the guard covers both parse and validation failure modes.
- `llm_service/README.md` gets a "When to use which" section pointing new callers at the two helpers.
- New CI static guard (`tests/test_no_markdown_in_structured.py`) AST-walks `agents/**/*.py`, flags `*_PROMPT` literals whose body is text-intent (`markdown` / `prose` / etc.) without a JSON-intent carve-out, and asserts none are routed into `complete_json` / `chat_json_round` / `generate_structured`. Allow-list is **empty** — the codebase is clean after Phase 1.

## Why

The original `LLMJsonParseError` was a prompt-asks-for-Markdown / transport-forces-JSON mismatch. Phase 1 fixes the active run; Phase 2 makes single-shot JSON failures self-heal for any caller; Phase 3 makes "I want text" vs "I want a typed object" an unambiguous choice at the call site, with a CI check preventing regressions.

## Reviewer notes

- **No provider-client changes.** `complete_json` still forces JSON mode implicitly via `response_format`; that's why Phase 2's helper layers on top rather than passing a `format=` kwarg.
- **No existing caller behavior changes.** Legacy `complete` / `complete_text` / `complete_json` / `chat_json_round` are untouched and fully supported.
- **Canary migration only** — `_parse_answer` was the single opportunistic migration. Bulk migration of other `complete_json` callers is explicitly out of scope, tracked separately.
- **Total call budget** for `complete_validated` is `1 + correction_attempts`. Default is 1 auto-correction; `correction_attempts=0` preserves today's single-shot behavior (test pins this).
- The diff touches 10 files (5 modified, 5 new) — all under `backend/agents/llm_service/`, `backend/agents/user_agent_founder/`, and a CHANGELOG entry.

## Test plan

- [x] `pytest agents/llm_service/tests/ agents/user_agent_founder/tests/` → 83/83 pass (excluding preexisting-on-main `test_strands_provider.py` collection error — unrelated).
- [x] `pytest agents/llm_service/tests/test_structured_output.py -v` → 6/6 (success-after-retry, terminal parse failure, validation re-ask, terminal validation failure, correction_attempts=0 opt-out, no-extract-call contract pin).
- [x] `pytest agents/llm_service/tests/test_no_markdown_in_structured.py -v` → 3/3 (detector positive + carve-out + repo-wide scan).
- [x] `pytest agents/user_agent_founder/tests/test_agent_generate_spec.py -v` → 3/3 (returns Markdown verbatim; Strands agent not invoked; founder system prompt forwarded).
- [x] `ruff check` clean across `agents/llm_service/` and `agents/user_agent_founder/`.
- [ ] Replay the originally failing "Startup Founder Testing Persona" run end-to-end against a live model (manual; acceptance gate per spec).

## Rollback

Each phase is independently revertable per the plan's rollback table. Revert this commit to fully restore the prior behavior; no DB / schema / config changes are involved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)