### PR TITLE
user-interface: Road Trip Planning dashboard with conversational slot-filling

### DIFF
--- a/user-interface/src/app/app.routes.ts
+++ b/user-interface/src/app/app.routes.ts
@@ -26,6 +26,7 @@ import { PlanningArtifactDetailComponent } from './components/planning-artifact-
 import { PersonaTestingDashboardComponent } from './components/persona-testing-dashboard/persona-testing-dashboard.component';
 import { PersonaTestAuditPanelComponent } from './components/persona-test-audit-panel/persona-test-audit-panel.component';
 import { DeepthoughtDashboardComponent } from './components/deepthought-dashboard/deepthought-dashboard.component';
+import { RoadTripPlanningDashboardComponent } from './components/road-trip-planning-dashboard/road-trip-planning-dashboard.component';
 
 export const routes: Routes = [
   {
@@ -64,6 +65,7 @@ export const routes: Routes = [
       { path: 'persona-testing', component: PersonaTestingDashboardComponent, data: { breadcrumb: 'Persona Testing', title: 'Persona Testing' } },
       { path: 'persona-testing/audit/:runId', component: PersonaTestAuditPanelComponent, data: { breadcrumb: 'Audit', title: 'Persona Test Audit' } },
       { path: 'deepthought', component: DeepthoughtDashboardComponent, data: { breadcrumb: 'Deepthought', title: 'Deepthought' } },
+      { path: 'road-trip-planning', component: RoadTripPlanningDashboardComponent, data: { breadcrumb: 'Road Trip Planning', title: 'Road Trip Planning' } },
     ],
   },
   { path: '**', redirectTo: '/dashboard' },

--- a/user-interface/src/app/components/road-trip-planning-dashboard/road-trip-planning-dashboard.component.html
+++ b/user-interface/src/app/components/road-trip-planning-dashboard/road-trip-planning-dashboard.component.html
@@ -151,7 +151,6 @@
                       (keydown.enter)="saveEdit()"
                       (keydown.escape)="cancelEdit()"
                       [attr.aria-label]="'Edit ' + field.label"
-                      autofocus
                     />
                     <button mat-icon-button (click)="saveEdit()" aria-label="Save">
                       <mat-icon>check</mat-icon>

--- a/user-interface/src/app/components/road-trip-planning-dashboard/road-trip-planning-dashboard.component.html
+++ b/user-interface/src/app/components/road-trip-planning-dashboard/road-trip-planning-dashboard.component.html
@@ -1,0 +1,426 @@
+<app-dashboard-shell
+  title="Road Trip Planning"
+  subtitle="Chat with the planning team. Tell them where you want to go, who's coming, and what you care about — they'll build a day-by-day itinerary and rework it anytime plans change."
+  icon="directions_car"
+  healthLabel="Road Trip API"
+  [healthCheck]="getHealth"
+>
+  <ng-container dashboardActions>
+    <button
+      mat-stroked-button
+      (click)="onRestart()"
+      class="header-button"
+      aria-label="Start a new trip"
+    >
+      <mat-icon>refresh</mat-icon>
+      New trip
+    </button>
+    <button
+      mat-flat-button
+      color="primary"
+      class="header-button"
+      [disabled]="!readyToPlan() || planning"
+      (click)="generateItinerary()"
+      [attr.aria-label]="itinerary ? 'Re-plan itinerary' : 'Generate itinerary'"
+    >
+      <mat-icon>{{ itinerary ? 'autorenew' : 'auto_awesome' }}</mat-icon>
+      {{ itinerary ? (dirtyRePlan ? 'Re-plan' : 'Re-plan (no changes)') : 'Generate itinerary' }}
+    </button>
+  </ng-container>
+
+  <div class="rt-layout">
+    <!-- ============================== CHAT ============================== -->
+    <mat-card class="chat-card">
+      <mat-card-content>
+        <div class="messages-container" #messagesContainer role="log" aria-live="polite">
+          @for (msg of messages; track $index) {
+            <div
+              class="message"
+              [class.user]="msg.role === 'user'"
+              [class.assistant]="msg.role === 'assistant'"
+            >
+              <div class="message-content" [innerHTML]="formatMessage(msg.content)"></div>
+              @if (msg.timestamp) {
+                <div class="message-time">{{ formatTime(msg.timestamp) }}</div>
+              }
+            </div>
+          }
+
+          @if (sending || planning) {
+            <div class="message assistant typing">
+              <div class="typing-indicator">
+                <span></span><span></span><span></span>
+              </div>
+              @if (planningStep) {
+                <div class="planning-step">
+                  <mat-icon>group_work</mat-icon>
+                  {{ planningStep }}
+                </div>
+              }
+            </div>
+          }
+        </div>
+
+        <form [formGroup]="form" (ngSubmit)="onSubmit()" class="input-form" autocomplete="off">
+          <mat-form-field appearance="outline" class="message-input">
+            <mat-label>
+              @if (pendingSlot) {
+                Answering: {{ labelForSlot(pendingSlot) }}
+              } @else {
+                Tell me about your trip, or what to change…
+              }
+            </mat-label>
+            <input
+              matInput
+              formControlName="message"
+              [attr.aria-label]="'Message input'"
+              (keydown.enter)="$event.preventDefault(); onSubmit()"
+            />
+          </mat-form-field>
+          <button
+            mat-fab
+            color="primary"
+            type="submit"
+            [disabled]="form.invalid || sending"
+            aria-label="Send message"
+          >
+            <mat-icon>send</mat-icon>
+          </button>
+        </form>
+
+        @if (lastQuickReplies() && lastQuickReplies()!.length > 0) {
+          <div class="quick-replies">
+            @for (chip of lastQuickReplies(); track chip) {
+              <button
+                mat-stroked-button
+                class="quick-reply-chip"
+                (click)="onQuickReply(chip)"
+                [disabled]="sending || planning"
+              >
+                {{ chip }}
+              </button>
+            }
+          </div>
+        }
+
+        @if (error) {
+          <div class="error-banner" role="alert">
+            <mat-icon>error_outline</mat-icon>
+            <span>{{ error }}</span>
+            <button mat-stroked-button (click)="generateItinerary()" [disabled]="!readyToPlan() || planning">
+              Retry
+            </button>
+          </div>
+        }
+      </mat-card-content>
+    </mat-card>
+
+    <!-- ============================== RIGHT PANEL ============================== -->
+    <div class="rt-sidebar">
+      <!-- Trip context -->
+      <mat-card class="context-card">
+        <mat-card-header>
+          <mat-icon mat-card-avatar>luggage</mat-icon>
+          <mat-card-title>Trip so far</mat-card-title>
+          <mat-card-subtitle>
+            @if (readyToPlan()) {
+              Ready to plan — click Generate above
+            } @else {
+              Missing: {{ missingLabels().join(', ') }}
+            }
+          </mat-card-subtitle>
+        </mat-card-header>
+
+        <mat-card-content>
+          <div class="context-grid">
+            @for (field of contextFields(); track field.key) {
+              <div class="context-row" [class.empty]="!field.displayValue">
+                <span class="context-label">
+                  {{ field.label }}
+                  @if (field.required) {
+                    <span class="required-dot" aria-label="required">*</span>
+                  }
+                </span>
+
+                @if (editingKey === field.key) {
+                  <div class="context-edit">
+                    <input
+                      class="context-edit-input"
+                      [value]="editingValue"
+                      (input)="editingValue = $any($event.target).value"
+                      (keydown.enter)="saveEdit()"
+                      (keydown.escape)="cancelEdit()"
+                      [attr.aria-label]="'Edit ' + field.label"
+                      autofocus
+                    />
+                    <button mat-icon-button (click)="saveEdit()" aria-label="Save">
+                      <mat-icon>check</mat-icon>
+                    </button>
+                    <button mat-icon-button (click)="cancelEdit()" aria-label="Cancel">
+                      <mat-icon>close</mat-icon>
+                    </button>
+                  </div>
+                } @else {
+                  <div class="context-value-row">
+                    <span class="context-value">
+                      {{ field.displayValue ?? '—' }}
+                    </span>
+                    <button
+                      mat-icon-button
+                      class="context-edit-btn"
+                      (click)="startEdit(field.key)"
+                      [attr.aria-label]="'Edit ' + field.label"
+                    >
+                      <mat-icon>edit</mat-icon>
+                    </button>
+                  </div>
+                }
+              </div>
+            }
+          </div>
+
+          @if (trip.required_stops.length > 0) {
+            <div class="chip-group">
+              <span class="chip-label">Stops</span>
+              <div class="chip-list">
+                @for (stop of trip.required_stops; track stop) {
+                  <span class="rt-chip removable">
+                    {{ stop }}
+                    <button
+                      mat-icon-button
+                      (click)="removeStop(stop)"
+                      [attr.aria-label]="'Remove ' + stop"
+                    >
+                      <mat-icon>close</mat-icon>
+                    </button>
+                  </span>
+                }
+              </div>
+            </div>
+          }
+
+          @if (trip.preferences.length > 0) {
+            <div class="chip-group">
+              <span class="chip-label">Preferences</span>
+              <div class="chip-list">
+                @for (pref of trip.preferences; track pref) {
+                  <span class="rt-chip removable subtle">
+                    {{ pref }}
+                    <button
+                      mat-icon-button
+                      (click)="removePreference(pref)"
+                      [attr.aria-label]="'Remove preference'"
+                    >
+                      <mat-icon>close</mat-icon>
+                    </button>
+                  </span>
+                }
+              </div>
+            </div>
+          }
+
+          @if (dirtyRePlan && itinerary) {
+            <div class="replan-hint">
+              <mat-icon>sync</mat-icon>
+              <span>Trip changed since the current itinerary was built. Re-plan to refresh.</span>
+            </div>
+          }
+        </mat-card-content>
+      </mat-card>
+
+      <!-- Itinerary -->
+      @if (itinerary) {
+        <mat-card class="itinerary-card">
+          <mat-card-header>
+            <mat-icon mat-card-avatar>map</mat-icon>
+            <mat-card-title>{{ itinerary.title || 'Your itinerary' }}</mat-card-title>
+            <mat-card-subtitle>
+              {{ itinerary.total_days }} day{{ itinerary.total_days === 1 ? '' : 's' }}
+              @if (itinerary.total_driving_miles) {
+                · {{ itinerary.total_driving_miles | number:'1.0-0' }} mi total
+              }
+              @if (itinerary.budget_estimate) {
+                · Est. {{ itinerary.budget_estimate }}
+              }
+            </mat-card-subtitle>
+          </mat-card-header>
+
+          <mat-card-content>
+            <mat-tab-group class="itinerary-tabs" animationDuration="150ms">
+              <mat-tab label="Overview">
+                <div class="tab-body">
+                  @if (itinerary.overview) {
+                    <p class="overview-text">{{ itinerary.overview }}</p>
+                  }
+                  @if (itinerary.traveler_highlights) {
+                    <p class="overview-text subtle">{{ itinerary.traveler_highlights }}</p>
+                  }
+
+                  @if (itinerary.route_summary.length > 0) {
+                    <h4>Route</h4>
+                    <ol class="route-list">
+                      @for (leg of itinerary.route_summary; track leg) {
+                        <li>{{ leg }}</li>
+                      }
+                    </ol>
+                  }
+
+                  @if (itinerary.travel_tips.length > 0) {
+                    <h4>Travel tips</h4>
+                    <ul class="tip-list">
+                      @for (tip of itinerary.travel_tips; track tip) {
+                        <li>{{ tip }}</li>
+                      }
+                    </ul>
+                  }
+
+                  @if (itinerary.packing_suggestions.length > 0) {
+                    <h4>Packing</h4>
+                    <div class="chip-list">
+                      @for (item of itinerary.packing_suggestions; track item) {
+                        <span class="rt-chip subtle">{{ item }}</span>
+                      }
+                    </div>
+                  }
+                </div>
+              </mat-tab>
+
+              @for (day of itinerary.days; track day.day_number) {
+                <mat-tab [label]="'Day ' + day.day_number">
+                  <div class="tab-body">
+                    <div class="day-head">
+                      <div>
+                        <h3 class="day-title">Day {{ day.day_number }} · {{ day.location }}</h3>
+                        @if (day.date) {
+                          <p class="day-date">{{ day.date }}</p>
+                        }
+                      </div>
+                      @if (dayBadge(day)) {
+                        <span class="day-badge" aria-label="driving distance">
+                          <mat-icon>directions_car</mat-icon>
+                          {{ dayBadge(day) }}
+                        </span>
+                      }
+                    </div>
+
+                    @if (day.driving_from) {
+                      <p class="drive-from">From {{ day.driving_from }}{{ day.driving_notes ? ' · ' + day.driving_notes : '' }}</p>
+                    }
+
+                    @if (day.day_summary) {
+                      <p class="day-summary">{{ day.day_summary }}</p>
+                    }
+
+                    @if (day.morning_activities.length > 0) {
+                      <h4>Morning</h4>
+                      <ul class="activity-list">
+                        @for (act of day.morning_activities; track act.name) {
+                          <li>
+                            <strong>{{ act.name }}</strong>
+                            @if (act.description) { — {{ act.description }} }
+                          </li>
+                        }
+                      </ul>
+                    }
+
+                    @if (day.afternoon_activities.length > 0) {
+                      <h4>Afternoon</h4>
+                      <ul class="activity-list">
+                        @for (act of day.afternoon_activities; track act.name) {
+                          <li>
+                            <strong>{{ act.name }}</strong>
+                            @if (act.description) { — {{ act.description }} }
+                          </li>
+                        }
+                      </ul>
+                    }
+
+                    @if (day.evening_activities.length > 0) {
+                      <h4>Evening</h4>
+                      <ul class="activity-list">
+                        @for (act of day.evening_activities; track act.name) {
+                          <li>
+                            <strong>{{ act.name }}</strong>
+                            @if (act.description) { — {{ act.description }} }
+                          </li>
+                        }
+                      </ul>
+                    }
+
+                    @if (day.meals.length > 0) {
+                      <h4>Meals</h4>
+                      <ul class="activity-list">
+                        @for (meal of day.meals; track meal.name) {
+                          <li>
+                            <strong>{{ meal.name }}</strong>
+                            @if (meal.description) { — {{ meal.description }} }
+                          </li>
+                        }
+                      </ul>
+                    }
+
+                    @if (day.accommodation) {
+                      <h4>Stay</h4>
+                      <p class="accommodation">
+                        <strong>{{ day.accommodation.name }}</strong>
+                        @if (day.accommodation.accommodation_type) {
+                          · {{ day.accommodation.accommodation_type }}
+                        }
+                        @if (day.accommodation.approximate_cost_per_night) {
+                          · {{ day.accommodation.approximate_cost_per_night }}/night
+                        }
+                      </p>
+                      @if (day.accommodation.booking_tips) {
+                        <p class="accommodation-tip">{{ day.accommodation.booking_tips }}</p>
+                      }
+                    }
+
+                    @if (day.day_tips.length > 0) {
+                      <ul class="tip-list">
+                        @for (tip of day.day_tips; track tip) {
+                          <li>{{ tip }}</li>
+                        }
+                      </ul>
+                    }
+
+                    <div class="day-footer">
+                      <button
+                        mat-stroked-button
+                        (click)="reworkDay(day)"
+                        class="rework-btn"
+                      >
+                        <mat-icon>edit_note</mat-icon>
+                        Rework this day in chat
+                      </button>
+                    </div>
+                  </div>
+                </mat-tab>
+              }
+            </mat-tab-group>
+          </mat-card-content>
+        </mat-card>
+      }
+
+      @if (previousItineraries.length > 0) {
+        <mat-card class="history-card">
+          <mat-card-header>
+            <mat-icon mat-card-avatar>history</mat-icon>
+            <mat-card-title>Previous plans</mat-card-title>
+            <mat-card-subtitle>Your last {{ previousItineraries.length }} itinerary
+              {{ previousItineraries.length === 1 ? 'version' : 'versions' }}</mat-card-subtitle>
+          </mat-card-header>
+          <mat-card-content>
+            <ul class="history-list">
+              @for (prev of previousItineraries; track $index) {
+                <li>
+                  <span class="history-title">{{ prev.title || 'Untitled trip' }}</span>
+                  <span class="history-meta">{{ prev.total_days }} days</span>
+                </li>
+              }
+            </ul>
+          </mat-card-content>
+        </mat-card>
+      }
+    </div>
+  </div>
+</app-dashboard-shell>

--- a/user-interface/src/app/components/road-trip-planning-dashboard/road-trip-planning-dashboard.component.scss
+++ b/user-interface/src/app/components/road-trip-planning-dashboard/road-trip-planning-dashboard.component.scss
@@ -1,0 +1,541 @@
+// Road Trip Planning dashboard — matches the visual language of Startup
+// Advisor, with trip-specific flourishes (amber accents, route tabs).
+
+.header-button {
+  margin-left: 0.5rem;
+
+  mat-icon {
+    margin-right: 6px;
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    vertical-align: middle;
+  }
+}
+
+.rt-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(320px, 1fr);
+  gap: 1rem;
+  align-items: start;
+}
+
+// --------------------------------------------------------------------------
+// Chat
+// --------------------------------------------------------------------------
+
+.chat-card {
+  background: #161b22;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+}
+
+.messages-container {
+  height: 560px;
+  overflow-y: auto;
+  padding: 1rem;
+  background: #0d1117;
+  border-radius: 8px;
+  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+
+  &::-webkit-scrollbar { width: 6px; }
+  &::-webkit-scrollbar-track { background: transparent; }
+  &::-webkit-scrollbar-thumb {
+    background: rgba(255, 255, 255, 0.1);
+    border-radius: 3px;
+    &:hover { background: rgba(255, 255, 255, 0.15); }
+  }
+}
+
+.message {
+  max-width: 80%;
+  padding: 12px 16px;
+  border-radius: 16px;
+  line-height: 1.5;
+
+  &.user {
+    align-self: flex-end;
+    background: linear-gradient(135deg, #f59e0b 0%, #d97706 100%);
+    color: #1a1207;
+    border-bottom-right-radius: 4px;
+
+    ::ng-deep strong { color: #1a1207; }
+
+    .message-time { color: rgba(26, 18, 7, 0.6); }
+  }
+
+  &.assistant {
+    align-self: flex-start;
+    background: #21262d;
+    color: #f0f6fc;
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    border-bottom-left-radius: 4px;
+
+    ::ng-deep strong { color: #fde68a; font-weight: 600; }
+  }
+
+  &.typing {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+}
+
+.message-content {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.message-time {
+  font-size: 0.72rem;
+  color: #8b949e;
+  margin-top: 6px;
+}
+
+.typing-indicator {
+  display: flex;
+  gap: 4px;
+  padding: 4px 0;
+
+  span {
+    width: 8px;
+    height: 8px;
+    background: #fbbf24;
+    border-radius: 50%;
+    animation: bounce 1.4s infinite ease-in-out;
+
+    &:nth-child(1) { animation-delay: 0s; }
+    &:nth-child(2) { animation-delay: 0.2s; }
+    &:nth-child(3) { animation-delay: 0.4s; }
+  }
+}
+
+.planning-step {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #d4d4d8;
+  font-size: 0.85rem;
+
+  mat-icon {
+    color: #fbbf24;
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+  }
+}
+
+@keyframes bounce {
+  0%, 80%, 100% { transform: translateY(0); }
+  40% { transform: translateY(-6px); }
+}
+
+.input-form {
+  display: flex;
+  gap: 12px;
+  align-items: flex-start;
+
+  .message-input { flex: 1; }
+  button[mat-fab] { margin-top: 4px; }
+}
+
+.quick-replies {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+}
+
+.quick-reply-chip {
+  font-size: 0.82rem;
+  border-color: rgba(251, 191, 36, 0.25);
+  color: #fde68a;
+
+  &:hover:not([disabled]) {
+    background: rgba(251, 191, 36, 0.08);
+    border-color: #fbbf24;
+  }
+}
+
+.error-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-top: 12px;
+  padding: 10px 14px;
+  background: rgba(248, 81, 73, 0.08);
+  border: 1px solid rgba(248, 81, 73, 0.3);
+  border-radius: 10px;
+  color: #fca5a5;
+  font-size: 0.88rem;
+
+  mat-icon {
+    color: #f87171;
+    font-size: 20px;
+    width: 20px;
+    height: 20px;
+  }
+
+  button {
+    margin-left: auto;
+  }
+}
+
+// --------------------------------------------------------------------------
+// Sidebar
+// --------------------------------------------------------------------------
+
+.rt-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.context-card,
+.itinerary-card,
+.history-card {
+  border-radius: 12px;
+}
+
+.context-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+}
+
+.context-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+
+  &:last-child { border-bottom: none; }
+  &.empty .context-value { color: #6b7280; font-style: italic; }
+}
+
+.context-label {
+  font-size: 0.7rem;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.required-dot {
+  color: #fbbf24;
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
+.context-value-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 4px;
+
+  .context-edit-btn {
+    opacity: 0;
+    transition: opacity 0.15s;
+    width: 28px;
+    height: 28px;
+
+    mat-icon {
+      font-size: 16px;
+      width: 16px;
+      height: 16px;
+      color: #8b949e;
+    }
+  }
+
+  &:hover .context-edit-btn { opacity: 1; }
+}
+
+.context-value {
+  font-size: 0.9rem;
+  color: #d4dde7;
+}
+
+.context-edit {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.context-edit-input {
+  flex: 1;
+  background: #0d1117;
+  border: 1px solid rgba(251, 191, 36, 0.4);
+  border-radius: 6px;
+  color: #f0f6fc;
+  padding: 6px 10px;
+  font-size: 0.88rem;
+  outline: none;
+
+  &:focus { border-color: #fbbf24; }
+}
+
+.chip-group {
+  margin-top: 0.9rem;
+
+  .chip-label {
+    font-size: 0.7rem;
+    color: #8b949e;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 600;
+    display: block;
+    margin-bottom: 0.4rem;
+  }
+}
+
+.chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.rt-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  background: rgba(251, 191, 36, 0.14);
+  color: #fde68a;
+  border: 1px solid rgba(251, 191, 36, 0.25);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.82rem;
+  line-height: 1.2;
+
+  &.subtle {
+    background: rgba(255, 255, 255, 0.05);
+    color: #c9d1d9;
+    border-color: rgba(255, 255, 255, 0.1);
+  }
+
+  &.removable {
+    padding-right: 2px;
+    button {
+      width: 20px;
+      height: 20px;
+      line-height: 20px;
+
+      mat-icon {
+        font-size: 14px;
+        width: 14px;
+        height: 14px;
+      }
+    }
+  }
+}
+
+.replan-hint {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  margin-top: 0.9rem;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: rgba(251, 191, 36, 0.08);
+  border: 1px solid rgba(251, 191, 36, 0.18);
+  font-size: 0.82rem;
+  color: #fde68a;
+  line-height: 1.4;
+
+  mat-icon {
+    color: #fbbf24;
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+    margin-top: 1px;
+  }
+}
+
+// --------------------------------------------------------------------------
+// Itinerary
+// --------------------------------------------------------------------------
+
+.itinerary-tabs {
+  ::ng-deep .mat-mdc-tab-header {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  }
+}
+
+.tab-body {
+  padding: 1rem 0.25rem 0.5rem;
+
+  h3, h4 {
+    margin: 1rem 0 0.5rem;
+    color: #f0f6fc;
+    letter-spacing: -0.01em;
+  }
+
+  h3 { font-size: 1.05rem; }
+  h4 {
+    font-size: 0.82rem;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #fde68a;
+    font-weight: 600;
+  }
+
+  p {
+    margin: 0 0 0.5rem;
+    color: #c9d1d9;
+    line-height: 1.5;
+    font-size: 0.9rem;
+
+    &.subtle { color: #8b949e; font-style: italic; }
+  }
+}
+
+.overview-text {
+  font-size: 0.92rem;
+  line-height: 1.55;
+}
+
+.route-list,
+.activity-list,
+.tip-list {
+  margin: 0 0 0.75rem 0;
+  padding-left: 1.25rem;
+
+  li {
+    color: #c9d1d9;
+    font-size: 0.88rem;
+    line-height: 1.5;
+    margin-bottom: 0.35rem;
+
+    strong { color: #f0f6fc; }
+  }
+}
+
+.day-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 0.5rem;
+}
+
+.day-title {
+  margin: 0;
+}
+
+.day-date {
+  color: #8b949e;
+  font-size: 0.8rem;
+  margin: 0.2rem 0 0;
+}
+
+.day-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: rgba(251, 191, 36, 0.12);
+  color: #fde68a;
+  border: 1px solid rgba(251, 191, 36, 0.25);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.78rem;
+  white-space: nowrap;
+
+  mat-icon {
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
+  }
+}
+
+.drive-from {
+  font-size: 0.82rem !important;
+  color: #8b949e !important;
+}
+
+.day-summary {
+  font-size: 0.92rem !important;
+  color: #d4dde7 !important;
+  font-style: italic;
+}
+
+.accommodation { margin-bottom: 0.25rem; }
+
+.accommodation-tip {
+  font-size: 0.82rem !important;
+  color: #8b949e !important;
+}
+
+.day-footer {
+  margin-top: 1rem;
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.rework-btn {
+  font-size: 0.82rem;
+  border-color: rgba(251, 191, 36, 0.25);
+  color: #fde68a;
+
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+    margin-right: 4px;
+  }
+
+  &:hover {
+    background: rgba(251, 191, 36, 0.08);
+    border-color: #fbbf24;
+  }
+}
+
+// --------------------------------------------------------------------------
+// History
+// --------------------------------------------------------------------------
+
+.history-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+
+  li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0.5rem 0;
+    border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+    font-size: 0.85rem;
+
+    &:last-child { border-bottom: none; }
+  }
+}
+
+.history-title {
+  color: #d4dde7;
+}
+
+.history-meta {
+  color: #8b949e;
+  font-size: 0.78rem;
+}
+
+// --------------------------------------------------------------------------
+// Responsive
+// --------------------------------------------------------------------------
+
+@media (max-width: 1100px) {
+  .rt-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .messages-container {
+    height: 440px;
+  }
+}

--- a/user-interface/src/app/components/road-trip-planning-dashboard/road-trip-planning-dashboard.component.ts
+++ b/user-interface/src/app/components/road-trip-planning-dashboard/road-trip-planning-dashboard.component.ts
@@ -1,0 +1,500 @@
+import {
+  AfterViewChecked,
+  Component,
+  ElementRef,
+  OnDestroy,
+  OnInit,
+  ViewChild,
+  inject,
+} from '@angular/core';
+import { DecimalPipe } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatTabsModule } from '@angular/material/tabs';
+import { Subject, takeUntil } from 'rxjs';
+
+import { DashboardShellComponent } from '../../shared/dashboard-shell/dashboard-shell.component';
+import { RoadTripPlanningApiService } from '../../services/road-trip-planning-api.service';
+import type {
+  ChatMessage,
+  DayPlan,
+  PlanJob,
+  TripContextField,
+  TripItinerary,
+  TripRequest,
+  TripSlotKey,
+} from '../../models';
+import {
+  CONTEXT_SCHEMA,
+  assistantMessage,
+  detectIntent,
+  displayValueFor,
+  freshTrip,
+  initialGreeting,
+  isSlotEmpty,
+  parseSlotValue,
+  pickNextSlot,
+  promptForSlot,
+  readinessSummary,
+  userMessage,
+} from './trip-slot-filler';
+
+const STORAGE_KEY = 'khala.roadTripPlanning.session.v1';
+
+/**
+ * Road Trip Planning — conversational planner dashboard.
+ *
+ * Two-panel layout (chat + trip context / itinerary) with client-side
+ * slot-filling chat driving a one-shot backend pipeline. Session state
+ * is persisted to localStorage so refreshes preserve work.
+ */
+@Component({
+  selector: 'app-road-trip-planning-dashboard',
+  standalone: true,
+  imports: [
+    DecimalPipe,
+    ReactiveFormsModule,
+    MatCardModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatButtonModule,
+    MatIconModule,
+    MatChipsModule,
+    MatSnackBarModule,
+    MatTabsModule,
+    DashboardShellComponent,
+  ],
+  templateUrl: './road-trip-planning-dashboard.component.html',
+  styleUrl: './road-trip-planning-dashboard.component.scss',
+})
+export class RoadTripPlanningDashboardComponent implements OnInit, AfterViewChecked, OnDestroy {
+  @ViewChild('messagesContainer') messagesContainer?: ElementRef<HTMLDivElement>;
+
+  private readonly api = inject(RoadTripPlanningApiService);
+  private readonly fb = inject(FormBuilder);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly destroy$ = new Subject<void>();
+
+  // --- Conversational state ---
+  messages: ChatMessage[] = [];
+  trip: TripRequest = freshTrip();
+  pendingSlot: TripSlotKey | null = null;
+
+  // --- Itinerary state ---
+  itinerary: TripItinerary | null = null;
+  previousItineraries: TripItinerary[] = [];
+  dirtyRePlan = false;
+
+  // --- UI state ---
+  sending = false;
+  planning = false;
+  planningStep: string | null = null;
+  error: string | null = null;
+  editingKey: TripSlotKey | null = null;
+  editingValue = '';
+
+  readonly contextSchema = CONTEXT_SCHEMA;
+
+  readonly form = this.fb.nonNullable.group({
+    message: ['', [Validators.required, Validators.minLength(1)]],
+  });
+
+  readonly getHealth = () => this.api.getHealth();
+
+  ngOnInit(): void {
+    const restored = this.loadSession();
+    if (restored) {
+      this.trip = restored.trip;
+      this.messages = restored.messages;
+      this.pendingSlot = restored.pendingSlot;
+      this.itinerary = restored.itinerary;
+      this.previousItineraries = restored.previousItineraries;
+      this.dirtyRePlan = restored.dirtyRePlan;
+    } else {
+      this.startFreshConversation();
+    }
+  }
+
+  ngAfterViewChecked(): void {
+    this.scrollToBottom();
+  }
+
+  ngOnDestroy(): void {
+    this.destroy$.next();
+    this.destroy$.complete();
+  }
+
+  // -------------------------------------------------------------------------
+  // Conversation
+  // -------------------------------------------------------------------------
+
+  onSubmit(): void {
+    if (this.form.invalid || this.sending) return;
+    const text = this.form.getRawValue().message.trim();
+    if (!text) return;
+    this.form.reset({ message: '' });
+    this.handleUserMessage(text);
+  }
+
+  onQuickReply(reply: string): void {
+    if (this.sending) return;
+    this.handleUserMessage(reply);
+  }
+
+  onRestart(): void {
+    this.snackBar.open('Started a new trip', 'OK', { duration: 2000 });
+    this.startFreshConversation();
+    this.persistSession();
+  }
+
+  private startFreshConversation(): void {
+    this.trip = freshTrip();
+    this.itinerary = null;
+    this.previousItineraries = [];
+    this.dirtyRePlan = false;
+    this.pendingSlot = 'start_location';
+    this.messages = [initialGreeting(), promptForSlot('start_location')];
+  }
+
+  private handleUserMessage(text: string): void {
+    this.messages = [...this.messages, userMessage(text)];
+    const intent = detectIntent(text, this.pendingSlot);
+
+    switch (intent.kind) {
+      case 'restart':
+        this.onRestart();
+        return;
+
+      case 'plan_now':
+        this.respond(this.readyToPlan() ? 'Great — kicking off the plan now.' : this.missingFieldsMessage());
+        if (this.readyToPlan()) this.generateItinerary();
+        break;
+
+      case 'fill':
+        this.applySlotFill(intent.slot, intent.rawValue);
+        break;
+
+      case 'add_stop':
+        this.trip = { ...this.trip, required_stops: [...this.trip.required_stops, intent.value] };
+        this.dirtyRePlan = this.itinerary !== null;
+        this.respond(`Added **${intent.value}** to your stops.`);
+        break;
+
+      case 'remove_stop': {
+        const before = this.trip.required_stops.length;
+        this.trip = {
+          ...this.trip,
+          required_stops: this.trip.required_stops.filter(
+            (s) => s.toLowerCase() !== intent.value.toLowerCase(),
+          ),
+        };
+        this.dirtyRePlan = this.itinerary !== null && before !== this.trip.required_stops.length;
+        this.respond(
+          before === this.trip.required_stops.length
+            ? `I couldn't find **${intent.value}** in your stops, so nothing changed.`
+            : `Removed **${intent.value}** from your stops.`,
+        );
+        break;
+      }
+
+      case 'add_preference':
+        this.trip = { ...this.trip, preferences: [...this.trip.preferences, text] };
+        this.dirtyRePlan = this.itinerary !== null;
+        this.respond(`Got it — I'll factor that into the plan.`);
+        break;
+
+      case 'clear_preferences':
+        this.trip = { ...this.trip, preferences: [] };
+        this.respond('Cleared your preferences.');
+        break;
+
+      case 'unknown':
+      default:
+        this.respond(
+          "I didn't quite catch that — can you tell me a bit more? (Or click one of the quick replies.)",
+        );
+        break;
+    }
+
+    this.advanceSlot();
+    this.persistSession();
+  }
+
+  private applySlotFill(slot: TripSlotKey, raw: string): void {
+    const next = parseSlotValue(slot, raw, this.trip);
+    const changed = JSON.stringify(next) !== JSON.stringify(this.trip);
+    this.trip = next;
+    this.dirtyRePlan = this.itinerary !== null && changed;
+
+    const display = displayValueFor(slot, next);
+    const pretty = labelFor(slot);
+    if (display) {
+      this.respond(`Noted **${pretty}**: ${display}.`);
+    } else {
+      this.respond(`I couldn't parse a value for **${pretty}** — want to try again?`);
+      this.pendingSlot = slot;
+      return;
+    }
+    this.pendingSlot = null;
+  }
+
+  private advanceSlot(): void {
+    // If we're already in the middle of a slot, don't advance.
+    if (this.pendingSlot) return;
+    const next = pickNextSlot(this.trip);
+    if (next && isSlotEmpty(this.trip, next)) {
+      this.pendingSlot = next;
+      this.messages = [...this.messages, promptForSlot(next)];
+    } else if (this.readyToPlan() && !this.itinerary) {
+      this.messages = [
+        ...this.messages,
+        assistantMessage("I've got enough to start planning. Click **Generate Itinerary** on the right whenever you're ready."),
+      ];
+    } else if (this.readyToPlan() && this.itinerary && this.dirtyRePlan) {
+      this.messages = [
+        ...this.messages,
+        assistantMessage('Your trip changed — hit **Re-plan** on the right to rebuild the itinerary.'),
+      ];
+    }
+  }
+
+  private respond(content: string, chips?: string[]): void {
+    this.messages = [...this.messages, assistantMessage(content, chips)];
+  }
+
+  // -------------------------------------------------------------------------
+  // Planning (async job + poll)
+  // -------------------------------------------------------------------------
+
+  generateItinerary(): void {
+    if (!this.readyToPlan() || this.planning) return;
+
+    this.planning = true;
+    this.error = null;
+    this.planningStep = 'Submitting plan…';
+    this.respond('Dispatching the planning team — this usually takes 30–90 seconds.');
+
+    let stepIndex = 0;
+    const steps = [
+      'Traveler Profiler is synthesising the group…',
+      'Route Planner is mapping the ordered stops…',
+      'Activities Expert is picking things to do…',
+      'Logistics Agent is finding places to stay…',
+      'Itinerary Composer is assembling the day-by-day plan…',
+    ];
+
+    this.api
+      .planAndPoll({ trip: this.trip }, 2500)
+      .pipe(takeUntil(this.destroy$))
+      .subscribe({
+        next: (job: PlanJob) => {
+          if (job.status === 'running' || job.status === 'pending') {
+            this.planningStep = steps[Math.min(stepIndex, steps.length - 1)];
+            stepIndex += 1;
+          }
+          if (job.status === 'completed' && job.result) {
+            this.onPlanCompleted(job.result);
+          }
+          if (job.status === 'failed') {
+            this.onPlanFailed(job.error ?? 'Unknown error');
+          }
+        },
+        error: (err) => {
+          this.onPlanFailed(err?.error?.detail ?? err?.message ?? 'Planning request failed');
+        },
+      });
+  }
+
+  private onPlanCompleted(itinerary: TripItinerary): void {
+    if (this.itinerary) {
+      this.previousItineraries = [this.itinerary, ...this.previousItineraries].slice(0, 3);
+    }
+    this.itinerary = itinerary;
+    this.dirtyRePlan = false;
+    this.planning = false;
+    this.planningStep = null;
+    this.respond(
+      `Your **${itinerary.total_days}-day** itinerary is ready — ${itinerary.title}. Scroll the right panel to review it, or tell me what to change.`,
+      ['Make day 1 more relaxed', 'Add a rest day', 'Find cheaper stays'],
+    );
+    this.persistSession();
+  }
+
+  private onPlanFailed(detail: string): void {
+    this.planning = false;
+    this.planningStep = null;
+    this.error = detail;
+    this.respond(`Planning hit an error: ${detail}. You can try again when ready.`);
+    this.persistSession();
+  }
+
+  // -------------------------------------------------------------------------
+  // Direct context editing (pencil icons on the trip panel)
+  // -------------------------------------------------------------------------
+
+  startEdit(key: TripSlotKey): void {
+    this.editingKey = key;
+    this.editingValue = displayValueFor(key, this.trip) ?? '';
+  }
+
+  cancelEdit(): void {
+    this.editingKey = null;
+    this.editingValue = '';
+  }
+
+  saveEdit(): void {
+    if (!this.editingKey) return;
+    const key = this.editingKey;
+    const value = this.editingValue.trim();
+    this.editingKey = null;
+    this.editingValue = '';
+    if (!value) return;
+
+    const next = parseSlotValue(key, value, this.trip);
+    const changed = JSON.stringify(next) !== JSON.stringify(this.trip);
+    this.trip = next;
+    if (changed) {
+      this.dirtyRePlan = this.itinerary !== null;
+      this.snackBar.open(`Updated ${labelFor(key).toLowerCase()}`, 'OK', { duration: 1800 });
+    }
+    this.persistSession();
+  }
+
+  removeStop(stop: string): void {
+    this.trip = {
+      ...this.trip,
+      required_stops: this.trip.required_stops.filter((s) => s !== stop),
+    };
+    this.dirtyRePlan = this.itinerary !== null;
+    this.persistSession();
+  }
+
+  removePreference(pref: string): void {
+    this.trip = {
+      ...this.trip,
+      preferences: this.trip.preferences.filter((p) => p !== pref),
+    };
+    this.dirtyRePlan = this.itinerary !== null;
+    this.persistSession();
+  }
+
+  // -------------------------------------------------------------------------
+  // Day-card "rework this day" shortcut
+  // -------------------------------------------------------------------------
+
+  reworkDay(day: DayPlan): void {
+    const prompt = `Can you rework Day ${day.day_number} in ${day.location}? `;
+    this.form.reset({ message: prompt });
+    // Focus-the-chat intent — just scroll the messages area.
+    this.scrollToBottom();
+  }
+
+  // -------------------------------------------------------------------------
+  // Helpers for the template
+  // -------------------------------------------------------------------------
+
+  contextFields(): TripContextField[] {
+    return this.contextSchema.map((s) => ({
+      key: s.key,
+      label: s.label,
+      displayValue: displayValueFor(s.key, this.trip),
+      required: s.required,
+    }));
+  }
+
+  readyToPlan(): boolean {
+    return readinessSummary(this.trip).ready;
+  }
+
+  missingLabels(): string[] {
+    return readinessSummary(this.trip).missing.map((k) => labelFor(k));
+  }
+
+  private missingFieldsMessage(): string {
+    const missing = this.missingLabels();
+    if (missing.length === 0) return 'Looks ready to me!';
+    return `I still need: ${missing.join(', ')}. Tell me any of them and we'll keep going.`;
+  }
+
+  lastQuickReplies(): string[] | undefined {
+    const last = this.messages[this.messages.length - 1];
+    return last?.role === 'assistant' ? last.quickReplies : undefined;
+  }
+
+  formatTime(ts: string): string {
+    if (!ts) return '';
+    try {
+      return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    } catch {
+      return '';
+    }
+  }
+
+  formatMessage(content: string): string {
+    // Tiny inline markdown: only **bold** (safe, no HTML injection risk from agents).
+    const escaped = content
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+    return escaped.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
+  }
+
+  dayBadge(day: DayPlan): string {
+    const dist = day.driving_distance_miles;
+    if (dist == null) return '';
+    const hours = day.driving_time_hours ? `${day.driving_time_hours.toFixed(1)} hr` : '';
+    return `${Math.round(dist)} mi${hours ? ` · ${hours}` : ''}`;
+  }
+
+  labelForSlot(key: TripSlotKey): string {
+    return labelFor(key);
+  }
+
+  // -------------------------------------------------------------------------
+  // Persistence
+  // -------------------------------------------------------------------------
+
+  private persistSession(): void {
+    try {
+      const state = {
+        trip: this.trip,
+        messages: this.messages,
+        pendingSlot: this.pendingSlot,
+        itinerary: this.itinerary,
+        previousItineraries: this.previousItineraries,
+        dirtyRePlan: this.dirtyRePlan,
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch {
+      // Quota / private browsing — silently ignore.
+    }
+  }
+
+  private loadSession() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return null;
+      const parsed = JSON.parse(raw);
+      if (!parsed?.trip || !Array.isArray(parsed.messages)) return null;
+      return parsed;
+    } catch {
+      return null;
+    }
+  }
+
+  private scrollToBottom(): void {
+    const el = this.messagesContainer?.nativeElement;
+    if (el) el.scrollTop = el.scrollHeight;
+  }
+}
+
+function labelFor(key: TripSlotKey): string {
+  const entry = CONTEXT_SCHEMA.find((f) => f.key === key);
+  return entry?.label ?? key;
+}

--- a/user-interface/src/app/components/road-trip-planning-dashboard/road-trip-planning-dashboard.component.ts
+++ b/user-interface/src/app/components/road-trip-planning-dashboard/road-trip-planning-dashboard.component.ts
@@ -85,6 +85,8 @@ export class RoadTripPlanningDashboardComponent implements OnInit, AfterViewChec
   messages: ChatMessage[] = [];
   trip: TripRequest = freshTrip();
   pendingSlot: TripSlotKey | null = null;
+  /** Slots the user has explicitly opted out of ("skip for now", "flexible", "I'm done"). */
+  declinedSlots = new Set<TripSlotKey>();
 
   // --- Itinerary state ---
   itinerary: TripItinerary | null = null;
@@ -116,6 +118,7 @@ export class RoadTripPlanningDashboardComponent implements OnInit, AfterViewChec
       this.itinerary = restored.itinerary;
       this.previousItineraries = restored.previousItineraries;
       this.dirtyRePlan = restored.dirtyRePlan;
+      this.declinedSlots = new Set(restored.declinedSlots ?? []);
     } else {
       this.startFreshConversation();
     }
@@ -158,6 +161,7 @@ export class RoadTripPlanningDashboardComponent implements OnInit, AfterViewChec
     this.itinerary = null;
     this.previousItineraries = [];
     this.dirtyRePlan = false;
+    this.declinedSlots = new Set();
     this.pendingSlot = 'start_location';
     this.messages = [initialGreeting(), promptForSlot('start_location')];
   }
@@ -227,27 +231,41 @@ export class RoadTripPlanningDashboardComponent implements OnInit, AfterViewChec
   }
 
   private applySlotFill(slot: TripSlotKey, raw: string): void {
-    const next = parseSlotValue(slot, raw, this.trip);
-    const changed = JSON.stringify(next) !== JSON.stringify(this.trip);
-    this.trip = next;
-    this.dirtyRePlan = this.itinerary !== null && changed;
-
-    const display = displayValueFor(slot, next);
+    const result = parseSlotValue(slot, raw, this.trip);
     const pretty = labelFor(slot);
-    if (display) {
-      this.respond(`Noted **${pretty}**: ${display}.`);
-    } else {
+
+    // User explicitly opted out of this optional field ("skip", "flexible",
+    // "I'm done"). Mark it declined so advanceSlot() doesn't ask again.
+    if (result.declined) {
+      this.declinedSlots.add(slot);
+      this.pendingSlot = null;
+      this.respond(`Got it — we'll leave **${pretty}** open for now.`);
+      return;
+    }
+
+    // Parser rejected the text (couldn't find a number, unparseable date,
+    // empty traveler list, etc.). Re-prompt rather than storing garbage.
+    if (!result.accepted) {
       this.respond(`I couldn't parse a value for **${pretty}** — want to try again?`);
       this.pendingSlot = slot;
       return;
     }
+
+    const changed = JSON.stringify(result.trip) !== JSON.stringify(this.trip);
+    this.trip = result.trip;
+    this.dirtyRePlan = this.itinerary !== null && changed;
+    // A fresh answer supersedes any prior decline of the same slot.
+    this.declinedSlots.delete(slot);
+
+    const display = displayValueFor(slot, result.trip);
+    this.respond(display ? `Noted **${pretty}**: ${display}.` : `Got it — **${pretty}** updated.`);
     this.pendingSlot = null;
   }
 
   private advanceSlot(): void {
     // If we're already in the middle of a slot, don't advance.
     if (this.pendingSlot) return;
-    const next = pickNextSlot(this.trip);
+    const next = pickNextSlot(this.trip, this.declinedSlots);
     if (next && isSlotEmpty(this.trip, next)) {
       this.pendingSlot = next;
       this.messages = [...this.messages, promptForSlot(next)];
@@ -356,11 +374,25 @@ export class RoadTripPlanningDashboardComponent implements OnInit, AfterViewChec
     this.editingValue = '';
     if (!value) return;
 
-    const next = parseSlotValue(key, value, this.trip);
-    const changed = JSON.stringify(next) !== JSON.stringify(this.trip);
-    this.trip = next;
-    if (changed) {
-      this.dirtyRePlan = this.itinerary !== null;
+    const result = parseSlotValue(key, value, this.trip);
+    if (!result.accepted && !result.declined) {
+      this.snackBar.open(
+        `Couldn't parse "${value}" for ${labelFor(key).toLowerCase()}`,
+        'OK',
+        { duration: 2500 },
+      );
+      return;
+    }
+
+    const changed = JSON.stringify(result.trip) !== JSON.stringify(this.trip);
+    this.trip = result.trip;
+    if (result.declined) {
+      this.declinedSlots.add(key);
+    } else {
+      this.declinedSlots.delete(key);
+    }
+    if (changed || result.declined) {
+      this.dirtyRePlan = this.itinerary !== null && changed;
       this.snackBar.open(`Updated ${labelFor(key).toLowerCase()}`, 'OK', { duration: 1800 });
     }
     this.persistSession();
@@ -469,6 +501,8 @@ export class RoadTripPlanningDashboardComponent implements OnInit, AfterViewChec
         itinerary: this.itinerary,
         previousItineraries: this.previousItineraries,
         dirtyRePlan: this.dirtyRePlan,
+        // Sets don't survive JSON.stringify — serialise to an array.
+        declinedSlots: Array.from(this.declinedSlots),
       };
       localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
     } catch {

--- a/user-interface/src/app/components/road-trip-planning-dashboard/trip-slot-filler.ts
+++ b/user-interface/src/app/components/road-trip-planning-dashboard/trip-slot-filler.ts
@@ -1,0 +1,425 @@
+/**
+ * Client-side conversational slot filler for the Road Trip Planning team.
+ *
+ * The backend exposes a one-shot planner — there is no chat endpoint.
+ * This module provides the rule-based conversational layer: given the
+ * current trip context and a free-text user message, it infers which
+ * slot is being updated, applies the edit, and decides what to ask next.
+ *
+ * Kept as pure functions so the dashboard component stays thin and so
+ * the logic is easy to unit-test.
+ */
+
+import type {
+  AgeGroup,
+  BudgetLevel,
+  ChatMessage,
+  Traveler,
+  TripRequest,
+  TripSlotKey,
+  VehicleType,
+} from '../../models';
+import { DEFAULT_TRIP, REQUIRED_SLOTS, TRIP_CONTEXT_SCHEMA } from '../../models';
+
+// ---------------------------------------------------------------------------
+// Intent detection
+// ---------------------------------------------------------------------------
+
+export type SlotIntent =
+  | { kind: 'fill'; slot: TripSlotKey; rawValue: string }
+  | { kind: 'add_stop'; value: string }
+  | { kind: 'remove_stop'; value: string }
+  | { kind: 'add_traveler'; traveler: Partial<Traveler> }
+  | { kind: 'remove_traveler'; name: string }
+  | { kind: 'add_preference'; value: string }
+  | { kind: 'clear_preferences' }
+  | { kind: 'restart' }
+  | { kind: 'plan_now' }
+  | { kind: 'unknown' };
+
+/** Detect the user's intent from a free-text message + the pending slot. */
+export function detectIntent(message: string, pendingSlot: TripSlotKey | null): SlotIntent {
+  const text = message.trim();
+  const lower = text.toLowerCase();
+
+  if (/^(start over|restart|reset|clear( all)?)\b/.test(lower)) {
+    return { kind: 'restart' };
+  }
+  if (/^(plan|plan it|plan now|generate|go|build( it)?|make( the)? trip)\b/.test(lower)) {
+    return { kind: 'plan_now' };
+  }
+
+  // Explicit "add/remove a stop" verbs anywhere in the message.
+  const addStop = lower.match(/\b(?:add|include|stop (?:in|at)|visit|also (?:go|stop|visit))\s+(?:a\s+stop\s+(?:at|in)\s+)?([^.,]+?)(?:\s+(?:to|on|in)\s+(?:the\s+)?(?:trip|route|itinerary))?\s*$/);
+  if (addStop && !pendingSlot) {
+    const v = addStop[1].replace(/^as (a|an) (stop|visit)/i, '').trim();
+    if (v) return { kind: 'add_stop', value: titleCasePlace(v) };
+  }
+  const removeStop = lower.match(/\b(?:skip|drop|remove|cancel)\s+(?:the\s+)?(?:stop\s+(?:at|in)\s+)?([^.,]+)$/);
+  if (removeStop) {
+    const v = removeStop[1].trim();
+    if (v && !['dates', 'date', 'everything', 'all of it'].includes(v)) {
+      return { kind: 'remove_stop', value: titleCasePlace(v) };
+    }
+  }
+
+  // Preferences / style vocabulary
+  const prefMatch = lower.match(/\b(?:prefer|i want|we want|more|less|avoid|no|stick to)\s+(.+)$/);
+  if (prefMatch && !pendingSlot) {
+    return { kind: 'add_preference', value: text };
+  }
+
+  // If a slot is pending, treat the message as the answer to that slot.
+  if (pendingSlot) {
+    return { kind: 'fill', slot: pendingSlot, rawValue: text };
+  }
+
+  // Heuristic guesses when nothing is pending.
+  if (/\b\d+\s*(days?|nights?|weeks?)\b/.test(lower)) {
+    return { kind: 'fill', slot: 'trip_duration_days', rawValue: text };
+  }
+  if (/\b(rv|suv|van|motorcycle|car)\b/.test(lower) && !/\bcar(eful|ry)/.test(lower)) {
+    return { kind: 'fill', slot: 'vehicle_type', rawValue: text };
+  }
+  if (/\b(budget|moderate|mid-?range|luxury|cheap|fancy)\b/.test(lower)) {
+    return { kind: 'fill', slot: 'budget_level', rawValue: text };
+  }
+  return { kind: 'unknown' };
+}
+
+// ---------------------------------------------------------------------------
+// Value parsers
+// ---------------------------------------------------------------------------
+
+export function parseSlotValue(
+  slot: TripSlotKey,
+  raw: string,
+  current: TripRequest,
+): TripRequest {
+  const value = raw.trim();
+  const trip: TripRequest = { ...current };
+  switch (slot) {
+    case 'start_location':
+      trip.start_location = titleCasePlace(value);
+      break;
+    case 'end_location':
+      trip.end_location = /^(same|round ?trip|back|loop|no|none)/i.test(value)
+        ? null
+        : titleCasePlace(value);
+      break;
+    case 'trip_duration_days': {
+      const m = value.match(/(\d+)\s*(day|night|week)?/i);
+      if (m) {
+        const n = parseInt(m[1], 10);
+        const unit = (m[2] || 'day').toLowerCase();
+        trip.trip_duration_days = unit.startsWith('week') ? n * 7 : n;
+      }
+      break;
+    }
+    case 'travel_start_date':
+      trip.travel_start_date = parseDate(value);
+      break;
+    case 'travelers':
+      trip.travelers = parseTravelers(value);
+      break;
+    case 'required_stops':
+      trip.required_stops = value
+        .split(/[,;]|\band\b/)
+        .map((s) => titleCasePlace(s.trim()))
+        .filter(Boolean);
+      break;
+    case 'vehicle_type':
+      trip.vehicle_type = parseVehicle(value);
+      break;
+    case 'budget_level':
+      trip.budget_level = parseBudget(value);
+      break;
+    case 'preferences':
+      if (value && !/^(none|skip|no)$/i.test(value)) {
+        trip.preferences = [...trip.preferences, value];
+      }
+      break;
+  }
+  return trip;
+}
+
+function titleCasePlace(s: string): string {
+  return s
+    .trim()
+    .replace(/\s+/g, ' ')
+    .split(' ')
+    .map((w) => (w.length <= 2 ? w.toUpperCase() : w.charAt(0).toUpperCase() + w.slice(1)))
+    .join(' ');
+}
+
+function parseDate(value: string): string | null {
+  if (!value) return null;
+  // Accept ISO or natural-ish dates — Date.parse is lenient enough here.
+  const t = Date.parse(value);
+  if (!Number.isNaN(t)) {
+    return new Date(t).toISOString().slice(0, 10);
+  }
+  return null;
+}
+
+function parseVehicle(value: string): VehicleType {
+  const v = value.toLowerCase();
+  if (v.includes('rv') || v.includes('motorhome')) return 'rv';
+  if (v.includes('suv')) return 'suv';
+  if (v.includes('van')) return 'van';
+  if (v.includes('motor') || v.includes('bike')) return 'motorcycle';
+  return 'car';
+}
+
+function parseBudget(value: string): BudgetLevel {
+  const v = value.toLowerCase();
+  if (v.includes('lux') || v.includes('fancy') || v.includes('splurge')) return 'luxury';
+  if (v.includes('cheap') || v.includes('budget') || v.includes('shoestring')) return 'budget';
+  return 'moderate';
+}
+
+function parseTravelers(value: string): Traveler[] {
+  // "2 adults and 1 kid" / "me and my partner" / "Sarah (vegetarian) + Jake (hiker)"
+  const travelers: Traveler[] = [];
+  const parts = value.split(/,|;|\band\b|\+/i).map((p) => p.trim()).filter(Boolean);
+
+  for (const part of parts) {
+    const countMatch = part.match(/^(\d+)\s*(adults?|kids?|child(?:ren)?|teens?|seniors?)/i);
+    if (countMatch) {
+      const n = parseInt(countMatch[1], 10);
+      const group = countMatch[2].toLowerCase();
+      const ageGroup: AgeGroup = group.startsWith('kid') || group.startsWith('child')
+        ? 'child'
+        : group.startsWith('teen')
+          ? 'teen'
+          : group.startsWith('senior')
+            ? 'senior'
+            : 'adult';
+      for (let i = 0; i < n; i++) {
+        travelers.push(makeTraveler('', ageGroup));
+      }
+      continue;
+    }
+
+    // "Sarah (vegetarian, hiker)" style
+    const parenMatch = part.match(/^([^\s(]+)\s*\(([^)]+)\)/);
+    if (parenMatch) {
+      const name = parenMatch[1].replace(/^(me|myself)$/i, 'You');
+      const traits = parenMatch[2].split(/[,/]/).map((t) => t.trim()).filter(Boolean);
+      const needs = traits.filter((t) =>
+        /vegetarian|vegan|wheelchair|pet|allergy|allergic|mobility|kosher|halal|gluten/i.test(t),
+      );
+      const interests = traits.filter((t) => !needs.includes(t));
+      travelers.push({
+        name,
+        age_group: 'adult',
+        interests,
+        needs,
+        notes: '',
+      });
+      continue;
+    }
+
+    // Bare name or pronoun
+    if (/^(me|myself|i)$/i.test(part)) {
+      travelers.push(makeTraveler('You', 'adult'));
+    } else if (/^(my )?(wife|husband|partner|spouse|girlfriend|boyfriend)/i.test(part)) {
+      travelers.push(makeTraveler('Partner', 'adult'));
+    } else if (part.length > 0 && part.length < 60) {
+      travelers.push(makeTraveler(titleCasePlace(part), 'adult'));
+    }
+  }
+
+  // Failsafe — if nothing parsed, record a single anonymous adult so the
+  // trip passes backend validation.
+  if (travelers.length === 0 && value.length > 0) {
+    travelers.push(makeTraveler('', 'adult'));
+  }
+  return travelers;
+}
+
+function makeTraveler(name: string, ageGroup: AgeGroup): Traveler {
+  return { name, age_group: ageGroup, interests: [], needs: [], notes: '' };
+}
+
+// ---------------------------------------------------------------------------
+// Conversation orchestration
+// ---------------------------------------------------------------------------
+
+const SLOT_PROMPTS: Record<TripSlotKey, { question: string; chips?: string[] }> = {
+  start_location: {
+    question: "Great — where are you starting from? (a city, address, or landmark works)",
+  },
+  end_location: {
+    question: "Where do you want to end up? If it's a round trip, just say 'round trip.'",
+    chips: ['Round trip', 'Still deciding'],
+  },
+  trip_duration_days: {
+    question: 'How long do you have for this trip?',
+    chips: ['3 days', '1 week', '10 days', '2 weeks'],
+  },
+  travel_start_date: {
+    question: 'When do you want to leave? (a date, or "flexible" is fine)',
+    chips: ['Flexible'],
+  },
+  travelers: {
+    question:
+      "Who's coming along? You can describe them freely — e.g. \"2 adults and a kid\" or \"Sarah (hiker), Jake (foodie)\".",
+  },
+  required_stops: {
+    question: 'Any must-see stops along the way? Comma-separated is fine.',
+    chips: ['None specific', 'Skip for now'],
+  },
+  vehicle_type: {
+    question: 'What are you driving?',
+    chips: ['Car', 'SUV', 'RV', 'Van', 'Motorcycle'],
+  },
+  budget_level: {
+    question: 'What feels like the right budget vibe?',
+    chips: ['Budget', 'Moderate', 'Luxury'],
+  },
+  preferences: {
+    question: 'Any preferences I should know? (scenic routes, avoid highways, pet-friendly, etc.)',
+    chips: ['Scenic routes', 'Avoid highways', 'Pet-friendly', "I'm done"],
+  },
+};
+
+const GREETING: ChatMessage = {
+  role: 'assistant',
+  content:
+    "Hi! I'm your road trip planner. Tell me a bit about the trip and I'll put together a day-by-day itinerary — and re-work it anytime you change your mind.",
+  timestamp: new Date().toISOString(),
+  quickReplies: ['Start from scratch', 'Surprise me'],
+};
+
+/** Pick the next slot to ask about, preferring required then useful fields. */
+export function pickNextSlot(trip: TripRequest): TripSlotKey | null {
+  for (const key of REQUIRED_SLOTS) {
+    if (isSlotEmpty(trip, key)) return key;
+  }
+  const order: TripSlotKey[] = [
+    'trip_duration_days',
+    'travel_start_date',
+    'end_location',
+    'required_stops',
+    'vehicle_type',
+    'budget_level',
+    'preferences',
+  ];
+  for (const key of order) {
+    if (isSlotEmpty(trip, key)) return key;
+  }
+  return null;
+}
+
+export function isSlotEmpty(trip: TripRequest, slot: TripSlotKey): boolean {
+  switch (slot) {
+    case 'start_location':
+      return !trip.start_location;
+    case 'end_location':
+      return trip.end_location === null && trip.start_location === '';
+    case 'trip_duration_days':
+      return trip.trip_duration_days === null;
+    case 'travel_start_date':
+      return trip.travel_start_date === null;
+    case 'travelers':
+      return trip.travelers.length === 0;
+    case 'required_stops':
+      return trip.required_stops.length === 0;
+    case 'vehicle_type':
+      return trip.vehicle_type === 'car' && !trip.start_location;
+    case 'budget_level':
+      return false; // always has a default — don't nag
+    case 'preferences':
+      return trip.preferences.length === 0;
+  }
+}
+
+export function assistantMessage(text: string, chips?: string[]): ChatMessage {
+  return {
+    role: 'assistant',
+    content: text,
+    timestamp: new Date().toISOString(),
+    quickReplies: chips,
+  };
+}
+
+export function userMessage(text: string): ChatMessage {
+  return { role: 'user', content: text, timestamp: new Date().toISOString() };
+}
+
+export function promptForSlot(slot: TripSlotKey): ChatMessage {
+  const p = SLOT_PROMPTS[slot];
+  return assistantMessage(p.question, p.chips);
+}
+
+export function initialGreeting(): ChatMessage {
+  return { ...GREETING, timestamp: new Date().toISOString() };
+}
+
+export function freshTrip(): TripRequest {
+  return {
+    ...DEFAULT_TRIP,
+    required_stops: [],
+    travelers: [],
+    preferences: [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Readability helpers for the context panel
+// ---------------------------------------------------------------------------
+
+export function readinessSummary(trip: TripRequest): {
+  ready: boolean;
+  missing: TripSlotKey[];
+} {
+  const missing = REQUIRED_SLOTS.filter((k) => isSlotEmpty(trip, k));
+  return { ready: missing.length === 0, missing: [...missing] };
+}
+
+export function displayValueFor(slot: TripSlotKey, trip: TripRequest): string | null {
+  switch (slot) {
+    case 'start_location':
+      return trip.start_location || null;
+    case 'end_location':
+      return trip.end_location ?? (trip.start_location ? 'Round trip' : null);
+    case 'trip_duration_days':
+      return trip.trip_duration_days ? `${trip.trip_duration_days} days` : null;
+    case 'travel_start_date':
+      return trip.travel_start_date;
+    case 'travelers':
+      if (trip.travelers.length === 0) return null;
+      return summariseTravelers(trip.travelers);
+    case 'required_stops':
+      return trip.required_stops.length === 0 ? null : trip.required_stops.join(', ');
+    case 'vehicle_type':
+      return capitalise(trip.vehicle_type);
+    case 'budget_level':
+      return capitalise(trip.budget_level);
+    case 'preferences':
+      return trip.preferences.length === 0 ? null : trip.preferences.join('; ');
+  }
+}
+
+function summariseTravelers(travelers: Traveler[]): string {
+  const byGroup: Record<string, number> = {};
+  let named = 0;
+  for (const t of travelers) {
+    if (t.name && t.name !== 'You' && t.name !== 'Partner') named += 1;
+    byGroup[t.age_group] = (byGroup[t.age_group] ?? 0) + 1;
+  }
+  const parts = Object.entries(byGroup).map(([g, n]) =>
+    n === 1 ? `1 ${g}` : `${n} ${g}s`,
+  );
+  if (named > 0) {
+    parts.push(`${named} named`);
+  }
+  return parts.join(', ');
+}
+
+function capitalise(s: string): string {
+  return s.length ? s.charAt(0).toUpperCase() + s.slice(1) : s;
+}
+
+export const CONTEXT_SCHEMA = TRIP_CONTEXT_SCHEMA;

--- a/user-interface/src/app/components/road-trip-planning-dashboard/trip-slot-filler.ts
+++ b/user-interface/src/app/components/road-trip-planning-dashboard/trip-slot-filler.ts
@@ -91,56 +91,120 @@ export function detectIntent(message: string, pendingSlot: TripSlotKey | null): 
 // Value parsers
 // ---------------------------------------------------------------------------
 
+/**
+ * Outcome of trying to parse a user answer into a slot.
+ *
+ * - `accepted` — we stored a real value and should move on.
+ * - `declined` — user explicitly opted out (e.g. "skip for now", "flexible",
+ *   "I'm done"). The slot stays empty and the picker won't ask again.
+ * - neither  — answer was unintelligible; caller should re-prompt.
+ */
+export interface ParseResult {
+  trip: TripRequest;
+  accepted: boolean;
+  declined: boolean;
+}
+
+/**
+ * Per-slot matcher for "I'd rather skip this" phrases. Keyed separately
+ * from the parsers so the decline vocabulary can evolve independently.
+ */
+function isDeclineForSlot(slot: TripSlotKey, raw: string): boolean {
+  const v = raw.trim().toLowerCase();
+  if (!v) return false;
+  switch (slot) {
+    case 'end_location':
+      return /^(round ?trip|same|back|loop|no|none|still deciding|not sure|don'?t know)\b/.test(v);
+    case 'trip_duration_days':
+      return /^(flexible|not sure|don'?t know|tbd|whatever|we'?ll see)\b/.test(v);
+    case 'travel_start_date':
+      return /^(flexible|not sure|don'?t know|tbd|whenever|we'?ll see)\b/.test(v);
+    case 'required_stops':
+      return /^(none(\s+specific|\s+in\s+particular|\s+yet)?|skip(\s+for\s+now)?|no(\s+specific(\s+stops)?)?|nothing|not\s+sure|we'?ll\s+see)\b/.test(v);
+    case 'preferences':
+      return /^(i'?m\s+done|done|we'?re\s+good|that'?s\s+all|that'?s it|nothing( else)?|no( more| thanks)?|skip|none)\b/.test(v);
+    case 'start_location':
+    case 'travelers':
+    case 'vehicle_type':
+    case 'budget_level':
+      return false; // required (or always has a default) — never decline
+  }
+}
+
 export function parseSlotValue(
   slot: TripSlotKey,
   raw: string,
   current: TripRequest,
-): TripRequest {
+): ParseResult {
   const value = raw.trim();
   const trip: TripRequest = { ...current };
+
+  // Decline phrases short-circuit the parser for every slot where they
+  // apply. This is what keeps "None specific" from becoming a literal stop
+  // and "I'm done" from becoming a preference string.
+  if (isDeclineForSlot(slot, value)) {
+    return { trip, accepted: false, declined: true };
+  }
+
   switch (slot) {
     case 'start_location':
+      if (!value) return { trip, accepted: false, declined: false };
       trip.start_location = titleCasePlace(value);
-      break;
+      return { trip, accepted: true, declined: false };
+
     case 'end_location':
-      trip.end_location = /^(same|round ?trip|back|loop|no|none)/i.test(value)
-        ? null
-        : titleCasePlace(value);
-      break;
+      // Decline cases ("round trip" etc.) are handled above; any remaining
+      // value is a real destination.
+      if (!value) return { trip, accepted: false, declined: false };
+      trip.end_location = titleCasePlace(value);
+      return { trip, accepted: true, declined: false };
+
     case 'trip_duration_days': {
       const m = value.match(/(\d+)\s*(day|night|week)?/i);
-      if (m) {
-        const n = parseInt(m[1], 10);
-        const unit = (m[2] || 'day').toLowerCase();
-        trip.trip_duration_days = unit.startsWith('week') ? n * 7 : n;
-      }
-      break;
+      if (!m) return { trip, accepted: false, declined: false };
+      const n = parseInt(m[1], 10);
+      const unit = (m[2] || 'day').toLowerCase();
+      trip.trip_duration_days = unit.startsWith('week') ? n * 7 : n;
+      return { trip, accepted: true, declined: false };
     }
-    case 'travel_start_date':
-      trip.travel_start_date = parseDate(value);
-      break;
-    case 'travelers':
-      trip.travelers = parseTravelers(value);
-      break;
-    case 'required_stops':
-      trip.required_stops = value
+
+    case 'travel_start_date': {
+      const d = parseDate(value);
+      if (d === null) return { trip, accepted: false, declined: false };
+      trip.travel_start_date = d;
+      return { trip, accepted: true, declined: false };
+    }
+
+    case 'travelers': {
+      const parsed = parseTravelers(value);
+      if (parsed.length === 0) return { trip, accepted: false, declined: false };
+      trip.travelers = parsed;
+      return { trip, accepted: true, declined: false };
+    }
+
+    case 'required_stops': {
+      const stops = value
         .split(/[,;]|\band\b/)
         .map((s) => titleCasePlace(s.trim()))
         .filter(Boolean);
-      break;
+      if (stops.length === 0) return { trip, accepted: false, declined: false };
+      trip.required_stops = stops;
+      return { trip, accepted: true, declined: false };
+    }
+
     case 'vehicle_type':
       trip.vehicle_type = parseVehicle(value);
-      break;
+      return { trip, accepted: true, declined: false };
+
     case 'budget_level':
       trip.budget_level = parseBudget(value);
-      break;
+      return { trip, accepted: true, declined: false };
+
     case 'preferences':
-      if (value && !/^(none|skip|no)$/i.test(value)) {
-        trip.preferences = [...trip.preferences, value];
-      }
-      break;
+      if (!value) return { trip, accepted: false, declined: false };
+      trip.preferences = [...trip.preferences, value];
+      return { trip, accepted: true, declined: false };
   }
-  return trip;
 }
 
 function titleCasePlace(s: string): string {
@@ -292,10 +356,18 @@ const GREETING: ChatMessage = {
   quickReplies: ['Start from scratch', 'Surprise me'],
 };
 
-/** Pick the next slot to ask about, preferring required then useful fields. */
-export function pickNextSlot(trip: TripRequest): TripSlotKey | null {
+/**
+ * Pick the next slot to ask about, preferring required then useful fields.
+ * Slots the user has explicitly declined are skipped so the chat doesn't
+ * loop on answered-but-empty optional fields.
+ */
+export function pickNextSlot(
+  trip: TripRequest,
+  declined: ReadonlySet<TripSlotKey> = new Set(),
+): TripSlotKey | null {
+  const isAskable = (key: TripSlotKey) => isSlotEmpty(trip, key) && !declined.has(key);
   for (const key of REQUIRED_SLOTS) {
-    if (isSlotEmpty(trip, key)) return key;
+    if (isAskable(key)) return key;
   }
   const order: TripSlotKey[] = [
     'trip_duration_days',
@@ -307,7 +379,7 @@ export function pickNextSlot(trip: TripRequest): TripSlotKey | null {
     'preferences',
   ];
   for (const key of order) {
-    if (isSlotEmpty(trip, key)) return key;
+    if (isAskable(key)) return key;
   }
   return null;
 }
@@ -317,7 +389,7 @@ export function isSlotEmpty(trip: TripRequest, slot: TripSlotKey): boolean {
     case 'start_location':
       return !trip.start_location;
     case 'end_location':
-      return trip.end_location === null && trip.start_location === '';
+      return trip.end_location === null;
     case 'trip_duration_days':
       return trip.trip_duration_days === null;
     case 'travel_start_date':
@@ -327,7 +399,7 @@ export function isSlotEmpty(trip: TripRequest, slot: TripSlotKey): boolean {
     case 'required_stops':
       return trip.required_stops.length === 0;
     case 'vehicle_type':
-      return trip.vehicle_type === 'car' && !trip.start_location;
+      return trip.vehicle_type === 'car';
     case 'budget_level':
       return false; // always has a default — don't nag
     case 'preferences':

--- a/user-interface/src/app/models/index.ts
+++ b/user-interface/src/app/models/index.ts
@@ -21,3 +21,4 @@ export * from './startup-advisor.model';
 export * from './agentic-team.model';
 export * from './team-assistant.model';
 export * from './persona-testing.model';
+export * from './road-trip-planning.model';

--- a/user-interface/src/app/models/navigation.model.ts
+++ b/user-interface/src/app/models/navigation.model.ts
@@ -85,6 +85,7 @@ export const NAV_GROUPS: NavGroup[] = [
     items: [
       { id: 'personal-assistant', label: 'Personal Assistant', icon: 'smart_toy', route: '/personal-assistant', group: 'personal' },
       { id: 'nutrition', label: 'Nutritionist', icon: 'restaurant_menu', route: '/nutrition', group: 'personal' },
+      { id: 'road-trip-planning', label: 'Road Trip Planning', icon: 'directions_car', route: '/road-trip-planning', group: 'personal' },
     ],
   },
   {

--- a/user-interface/src/app/models/road-trip-planning.model.ts
+++ b/user-interface/src/app/models/road-trip-planning.model.ts
@@ -1,0 +1,196 @@
+/**
+ * Models for the Road Trip Planning team UI.
+ *
+ * Mirrors backend/agents/road_trip_planning_team/models.py on the request
+ * and itinerary side. Adds frontend-only types for the client-orchestrated
+ * chat (slot filling) and async job polling.
+ */
+
+// ---------------------------------------------------------------------------
+// Backend wire types (mirror Pydantic models)
+// ---------------------------------------------------------------------------
+
+export type AgeGroup = 'child' | 'teen' | 'adult' | 'senior';
+export type BudgetLevel = 'budget' | 'moderate' | 'luxury';
+export type VehicleType = 'car' | 'suv' | 'rv' | 'motorcycle' | 'van';
+
+export interface Traveler {
+  name: string;
+  age_group: AgeGroup;
+  interests: string[];
+  needs: string[];
+  notes: string;
+}
+
+export interface TripRequest {
+  start_location: string;
+  required_stops: string[];
+  end_location: string | null;
+  travelers: Traveler[];
+  trip_duration_days: number | null;
+  budget_level: BudgetLevel;
+  travel_start_date: string | null;
+  vehicle_type: VehicleType;
+  preferences: string[];
+}
+
+export interface PlanTripRequestBody {
+  trip: TripRequest;
+}
+
+export interface Activity {
+  name: string;
+  description: string;
+  duration_hours: number | null;
+  activity_type: string;
+  address: string | null;
+  tips: string[];
+  good_for: string[];
+  approximate_cost: string | null;
+}
+
+export interface Accommodation {
+  name: string;
+  accommodation_type: string;
+  address: string | null;
+  approximate_cost_per_night: string | null;
+  amenities: string[];
+  booking_tips: string;
+}
+
+export interface DayPlan {
+  day_number: number;
+  date: string | null;
+  location: string;
+  driving_from: string | null;
+  driving_distance_miles: number | null;
+  driving_time_hours: number | null;
+  driving_notes: string;
+  morning_activities: Activity[];
+  afternoon_activities: Activity[];
+  evening_activities: Activity[];
+  meals: Activity[];
+  accommodation: Accommodation | null;
+  day_summary: string;
+  day_tips: string[];
+}
+
+export interface TripItinerary {
+  title: string;
+  overview: string;
+  total_days: number;
+  total_driving_miles: number | null;
+  route_summary: string[];
+  traveler_highlights: string;
+  days: DayPlan[];
+  travel_tips: string[];
+  packing_suggestions: string[];
+  budget_estimate: string;
+  generated_at: string | null;
+}
+
+export interface PlanTripResponse {
+  itinerary: TripItinerary;
+}
+
+// Async job wire types (GET /jobs/{id})
+export type JobStatus = 'pending' | 'running' | 'completed' | 'failed';
+
+export interface PlanJobSubmission {
+  job_id: string;
+  status: JobStatus;
+}
+
+export interface PlanJob {
+  job_id: string;
+  status: JobStatus;
+  result?: TripItinerary;
+  error?: string | null;
+  request?: PlanTripRequestBody;
+  created_at?: string;
+  updated_at?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Client-side chat + slot-filling types
+// ---------------------------------------------------------------------------
+
+export type ChatRole = 'user' | 'assistant' | 'system';
+
+export interface ChatMessage {
+  role: ChatRole;
+  content: string;
+  timestamp: string;
+  /** Quick-action chips the assistant offers after this message. */
+  quickReplies?: string[];
+}
+
+/** Canonical keys the slot filler targets, in the order it asks for them. */
+export type TripSlotKey =
+  | 'start_location'
+  | 'end_location'
+  | 'trip_duration_days'
+  | 'travel_start_date'
+  | 'travelers'
+  | 'required_stops'
+  | 'vehicle_type'
+  | 'budget_level'
+  | 'preferences';
+
+/** A single entry in the side-panel "Trip so far" view. */
+export interface TripContextField {
+  key: TripSlotKey;
+  label: string;
+  /** Display-ready value, or `null` when the slot is still empty. */
+  displayValue: string | null;
+  required: boolean;
+}
+
+/** Persisted snapshot stored in localStorage so refreshes don't wipe work. */
+export interface RoadTripSessionState {
+  trip: TripRequest;
+  messages: ChatMessage[];
+  /** Slot the assistant is currently awaiting an answer for. */
+  pendingSlot: TripSlotKey | null;
+  /** Most recent itinerary (if generated). */
+  itinerary: TripItinerary | null;
+  /** Up to 3 previous itineraries so the user can diff / revert after a re-plan. */
+  previousItineraries: TripItinerary[];
+  /** True when the trip context has changed since `itinerary` was produced. */
+  dirtyRePlan: boolean;
+}
+
+export const DEFAULT_TRIP: TripRequest = {
+  start_location: '',
+  required_stops: [],
+  end_location: null,
+  travelers: [],
+  trip_duration_days: null,
+  budget_level: 'moderate',
+  travel_start_date: null,
+  vehicle_type: 'car',
+  preferences: [],
+};
+
+/** Order + labels for the context panel. */
+export const TRIP_CONTEXT_SCHEMA: ReadonlyArray<{
+  key: TripSlotKey;
+  label: string;
+  required: boolean;
+}> = [
+  { key: 'start_location', label: 'Start', required: true },
+  { key: 'end_location', label: 'End', required: false },
+  { key: 'trip_duration_days', label: 'Duration', required: false },
+  { key: 'travel_start_date', label: 'Start date', required: false },
+  { key: 'travelers', label: 'Travelers', required: true },
+  { key: 'required_stops', label: 'Stops', required: false },
+  { key: 'vehicle_type', label: 'Vehicle', required: false },
+  { key: 'budget_level', label: 'Budget', required: false },
+  { key: 'preferences', label: 'Preferences', required: false },
+];
+
+/** Minimum slots that must be filled before the /plan call is valid. */
+export const REQUIRED_SLOTS: ReadonlyArray<TripSlotKey> = [
+  'start_location',
+  'travelers',
+];

--- a/user-interface/src/app/models/road-trip-planning.model.ts
+++ b/user-interface/src/app/models/road-trip-planning.model.ts
@@ -173,11 +173,11 @@ export const DEFAULT_TRIP: TripRequest = {
 };
 
 /** Order + labels for the context panel. */
-export const TRIP_CONTEXT_SCHEMA: ReadonlyArray<{
+export const TRIP_CONTEXT_SCHEMA: readonly {
   key: TripSlotKey;
   label: string;
   required: boolean;
-}> = [
+}[] = [
   { key: 'start_location', label: 'Start', required: true },
   { key: 'end_location', label: 'End', required: false },
   { key: 'trip_duration_days', label: 'Duration', required: false },
@@ -190,7 +190,7 @@ export const TRIP_CONTEXT_SCHEMA: ReadonlyArray<{
 ];
 
 /** Minimum slots that must be filled before the /plan call is valid. */
-export const REQUIRED_SLOTS: ReadonlyArray<TripSlotKey> = [
+export const REQUIRED_SLOTS: readonly TripSlotKey[] = [
   'start_location',
   'travelers',
 ];

--- a/user-interface/src/app/models/road-trip-planning.model.ts
+++ b/user-interface/src/app/models/road-trip-planning.model.ts
@@ -158,6 +158,12 @@ export interface RoadTripSessionState {
   previousItineraries: TripItinerary[];
   /** True when the trip context has changed since `itinerary` was produced. */
   dirtyRePlan: boolean;
+  /**
+   * Slot keys the user has explicitly declined (e.g. "skip for now",
+   * "flexible", "I'm done"). These are skipped by the slot picker so
+   * the chat doesn't re-ask a question the user already dismissed.
+   */
+  declinedSlots: TripSlotKey[];
 }
 
 export const DEFAULT_TRIP: TripRequest = {

--- a/user-interface/src/app/services/road-trip-planning-api.service.ts
+++ b/user-interface/src/app/services/road-trip-planning-api.service.ts
@@ -1,0 +1,78 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable, Subject, timer } from 'rxjs';
+import { switchMap, takeWhile, tap } from 'rxjs/operators';
+import { environment } from '../../environments/environment';
+import type {
+  PlanJob,
+  PlanJobSubmission,
+  PlanTripRequestBody,
+  TripItinerary,
+} from '../models';
+
+/**
+ * API client for the Road Trip Planning team.
+ *
+ * Backend exposes a one-shot planner (no conversational endpoint) —
+ * this service wraps the async flow into a single observable stream
+ * that emits every job poll until the job reaches a terminal state.
+ */
+@Injectable({ providedIn: 'root' })
+export class RoadTripPlanningApiService {
+  private readonly http = inject(HttpClient);
+  private readonly baseUrl = environment.roadTripPlanningApiUrl;
+
+  /** Health check for the team's API. */
+  getHealth(): Observable<{ status?: string }> {
+    return this.http.get<{ status?: string }>(`${this.baseUrl}/health`);
+  }
+
+  /** Submit an async planning job. Returns immediately with a job_id. */
+  submitPlanJob(body: PlanTripRequestBody): Observable<PlanJobSubmission> {
+    return this.http.post<PlanJobSubmission>(`${this.baseUrl}/plan/async`, body);
+  }
+
+  /** Single poll of a job's status. */
+  getJob(jobId: string): Observable<PlanJob> {
+    return this.http.get<PlanJob>(`${this.baseUrl}/jobs/${jobId}`);
+  }
+
+  /**
+   * Submit a plan job and emit every poll result until it completes or
+   * fails. The final emission is the terminal `PlanJob` (status `completed`
+   * or `failed`). Terminates the subscription on terminal status.
+   *
+   * @param body       Plan request
+   * @param pollMs     Poll interval (default 2000ms)
+   * @param onSubmit   Optional hook fired once with the submission id.
+   */
+  planAndPoll(
+    body: PlanTripRequestBody,
+    pollMs = 2000,
+    onSubmit?: (submission: PlanJobSubmission) => void,
+  ): Observable<PlanJob> {
+    const submission$ = new Subject<PlanJobSubmission>();
+    const stream$ = this.submitPlanJob(body).pipe(
+      tap((submission) => {
+        onSubmit?.(submission);
+        submission$.next(submission);
+        submission$.complete();
+      }),
+      switchMap((submission) =>
+        timer(0, pollMs).pipe(
+          switchMap(() => this.getJob(submission.job_id)),
+          takeWhile((job) => job.status !== 'completed' && job.status !== 'failed', true),
+        ),
+      ),
+    );
+    return stream$;
+  }
+
+  /**
+   * One-shot synchronous planning. Kept for callers that want a blocking
+   * call (not used by the dashboard, but handy for integration/tests).
+   */
+  planSync(body: PlanTripRequestBody): Observable<{ itinerary: TripItinerary }> {
+    return this.http.post<{ itinerary: TripItinerary }>(`${this.baseUrl}/plan`, body);
+  }
+}

--- a/user-interface/src/environments/environment.prod.ts
+++ b/user-interface/src/environments/environment.prod.ts
@@ -25,4 +25,5 @@ export const environment = {
   startupAdvisorApiUrl: `${apiBase}/api/startup-advisor`,
   personaTestingApiUrl: `${apiBase}/api/user-agent-founder`,
   deepthoughtApiUrl: `${apiBase}/api/deepthought`,
+  roadTripPlanningApiUrl: `${apiBase}/api/road-trip-planning`,
 };

--- a/user-interface/src/environments/environment.ts
+++ b/user-interface/src/environments/environment.ts
@@ -26,5 +26,6 @@ export const environment = {
   startupAdvisorApiUrl: `${apiBase}/api/startup-advisor`,
   personaTestingApiUrl: `${apiBase}/api/user-agent-founder`,
   deepthoughtApiUrl: `${apiBase}/api/deepthought`,
+  roadTripPlanningApiUrl: `${apiBase}/api/road-trip-planning`,
 };
 


### PR DESCRIPTION
## Summary

Adds a new **Road Trip Planning** page in the Angular UI that lets a user chat with the planning team to build a day-by-day itinerary — and course-correct anytime plans change.

- **New route:** `/road-trip-planning`
- **New left-nav entry:** *Personal → Road Trip Planning* (icon: `directions_car`)
- **Wraps the existing backend** (`/api/road-trip-planning`) — no backend changes

## Why

The Road Trip Planning team has been mounted in the Unified API for a while but had no UI. The backend exposes a one-shot planning pipeline (`POST /plan/async` → poll `GET /jobs/{id}`), so the UI needed to provide the conversational layer itself. This PR adds a client-orchestrated slot-filling chat that drives that pipeline and makes re-planning frictionless.

## What changed

**New files**
- `components/road-trip-planning-dashboard/` — two-panel dashboard (chat + trip context/itinerary) matching the Startup Advisor visual language
- `components/road-trip-planning-dashboard/trip-slot-filler.ts` — pure-function conversational layer (intent detection, free-text → slot parsing, next-question picker). Kept as pure functions so the component stays thin and the logic is easy to unit-test
- `services/road-trip-planning-api.service.ts` — wraps submit-and-poll into a single `planAndPoll()` observable that emits job status until terminal
- `models/road-trip-planning.model.ts` — wire types (mirror backend Pydantic) plus client-only chat + session types

**Updated files**
- `app.routes.ts` — new `/road-trip-planning` route
- `models/navigation.model.ts` — new nav item in the Personal group
- `models/index.ts` — barrel export
- `environments/environment.ts` + `environment.prod.ts` — added `roadTripPlanningApiUrl`

## UX highlights

- **Chat-driven slot filling**: assistant asks one question at a time, accepts free-text (\"2 adults and a kid\", \"a week-ish\", \"Sarah (hiker), Jake (foodie)\"), live-updates the right-hand trip context panel so the user watches the plan assemble.
- **Three course-correction paths** — all available at any time:
  - Type the change in chat (\"skip Portland, add Yosemite instead\")
  - Edit the trip context directly (pencil icon on hover for each field; stops and preferences are removable chips)
  - \"Rework this day in chat\" shortcut on each day card
- **Agent progress surfaced** during the ~60s planning job: \"Traveler Profiler is synthesising…\" → \"Route Planner is mapping…\" → etc. (mirrors the real 5-agent pipeline)
- **Previous plans** drawer keeps the last 3 itineraries so a user can compare/revert after a re-plan
- **Session persists** through refreshes via localStorage

## Accessibility

- `role=\"log\"` + `aria-live=\"polite\"` on the chat messages container
- Aria labels on all icon buttons (send, edit, close, save, cancel)
- Visible focus states; keyboard Enter sends, Escape cancels inline edit
- Responsive: collapses to a single column below 1100px

## Test plan

- [ ] `npm ci && npm run build` in `user-interface/` — clean build (verified locally)
- [ ] Navigate to *Personal → Road Trip Planning* from the sidebar — page loads
- [ ] Walk through the chat: answer start location, travelers, duration — trip context panel updates live
- [ ] Click **Generate Itinerary** — progress steps cycle, itinerary renders in tabs
- [ ] Type \"skip Portland\" or \"add Yosemite\" — context updates, **Re-plan** becomes active
- [ ] Edit a field directly via the pencil icon — context updates without going through chat
- [ ] Refresh the page — session (messages, context, itinerary) restored from localStorage
- [ ] Click **New trip** — state resets

🤖 Generated with [Claude Code](https://claude.com/claude-code)