### PR TITLE
nutrition: roadmap ADRs/SPECs + SPEC-002 profile biometrics

### DIFF
--- a/backend/agents/nutrition_meal_planning_team/agents/intake_profile_agent/__init__.py
+++ b/backend/agents/nutrition_meal_planning_team/agents/intake_profile_agent/__init__.py
@@ -1,5 +1,26 @@
-"""Intake / profile agent: validates and completes client profile from structured input."""
+"""Intake / profile agent: validates and completes client profile from structured input.
 
-from .agent import IntakeProfileAgent
+The ``IntakeProfileAgent`` class depends on ``strands``, which is not
+installed in every environment that imports this team (e.g. unit-test
+runs that only exercise the pure-logic ``structural`` fallback). Import
+it lazily via PEP 562 ``__getattr__`` so test code can import
+``structural`` without dragging strands in.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - type-checker hint only
+    from .agent import IntakeProfileAgent  # noqa: F401
 
 __all__ = ["IntakeProfileAgent"]
+
+
+def __getattr__(name: str) -> Any:
+    if name == "IntakeProfileAgent":
+        from .agent import IntakeProfileAgent as _IntakeProfileAgent
+
+        globals()[name] = _IntakeProfileAgent
+        return _IntakeProfileAgent
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/backend/agents/nutrition_meal_planning_team/agents/intake_profile_agent/agent.py
+++ b/backend/agents/nutrition_meal_planning_team/agents/intake_profile_agent/agent.py
@@ -4,45 +4,20 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from typing import Any, Dict, Optional
 
 from strands import Agent
 
+from llm_service import extract_json_from_response
+
 from ...models import ClientProfile, ProfileUpdateRequest
 
+# Re-export the fallback merger under its historical private name so
+# the existing import surface stays stable. Pure-logic lives in
+# ``structural`` (no strands dependency) per SPEC-002 W4.
+from .structural import merge_profile_structural as _merge_profile_structural  # noqa: F401
+
 logger = logging.getLogger(__name__)
-
-
-def _merge_profile_structural(
-    client_id: str,
-    current: Optional[ClientProfile],
-    update: Optional[ProfileUpdateRequest],
-) -> ClientProfile:
-    """Apply update onto current without LLM (fallback when the model is unavailable)."""
-    data: Dict[str, Any] = (
-        current.model_dump() if current else ClientProfile(client_id=client_id).model_dump()
-    )
-    if not update:
-        data["client_id"] = client_id
-        return ClientProfile.model_validate(data)
-    patch = update.model_dump(exclude_none=True)
-    for key in ("dietary_needs", "allergies_and_intolerances"):
-        if key in patch:
-            data[key] = patch[key]
-    for key in ("household", "lifestyle", "preferences", "goals"):
-        if key not in patch:
-            continue
-        sub = patch[key]
-        if sub is None:
-            continue
-        existing = data.get(key) or {}
-        if isinstance(existing, dict) and isinstance(sub, dict):
-            data[key] = {**existing, **sub}
-        else:
-            data[key] = sub
-    data["client_id"] = client_id
-    return ClientProfile.model_validate(data)
 
 
 SYSTEM_PROMPT = """You are an expert intake specialist for a personal nutrition and meal planning service.
@@ -54,9 +29,16 @@ The profile must include:
 - allergies_and_intolerances: list of strings (e.g. nuts, shellfish, gluten)
 - lifestyle: max_cooking_time_minutes (int or null), lunch_context ("office" or "remote"), equipment_constraints (list), other_constraints (string)
 - preferences: cuisines_liked, cuisines_disliked, ingredients_disliked (lists), preferences_free_text (string)
-- goals: goal_type (e.g. maintain, lose_weight, gain_weight, muscle), notes (string)
+- goals: goal_type (e.g. maintain, lose_weight, gain_weight, muscle), target_weight_kg (number or null), rate_kg_per_week (number 0..1 or null), started_at (ISO string or null), notes (string)
+- biometrics: sex ("female"|"male"|"other"|"unspecified"), age_years (integer 2..120 or null), height_cm (number 50..260 or null), weight_kg (number 20..400 or null), body_fat_pct (number 3..75 or null), activity_level ("sedentary"|"light"|"moderate"|"active"|"very_active"), timezone (IANA zone), preferred_units ("metric"|"imperial")
+- clinical: conditions (list of canonical tags, e.g. "hypertension", "t2_diabetes"; unknown items belong in conditions_freetext), medications (class tags, e.g. "warfarin", "ssri"; unknown items belong in medications_freetext), reproductive_state ("none"|"pregnant_t1"|"pregnant_t2"|"pregnant_t3"|"lactating"|"postpartum"), ed_history_flag (boolean)
 
-If the user did not specify something, infer sensible defaults or leave empty lists/empty strings. Never invent allergies.
+UNIT RULES — strict:
+- Height is always in centimeters. Never accept or emit feet / inches.
+- Weight is always in kilograms. Never accept or emit pounds.
+- If the user clearly specified imperial units, the upstream API has already converted them; trust what you receive.
+
+If the user did not specify something, infer sensible defaults or leave empty lists/empty strings. Never invent allergies or medical conditions. Never invent biometrics — leave them null if the user has not provided them.
 Output only valid JSON matching the structure above, with no markdown or explanation."""
 
 
@@ -94,11 +76,12 @@ class IntakeProfileAgent:
         try:
             result = self._agent(prompt)
             raw = str(result).strip()
-            # Strip markdown code fences if present
-            raw = re.sub(r"^```(?:json)?\s*", "", raw)
-            raw = re.sub(r"\s*```$", "", raw)
-            data = json.loads(raw)
-        except (json.JSONDecodeError, TypeError) as e:
+            # Use llm_service's canonical JSON extractor (SPEC-002 W4):
+            # tolerates code fences, trailing text, and common model quirks
+            # without the regex-strip-and-hope approach this module used
+            # previously.
+            data = extract_json_from_response(raw)
+        except (json.JSONDecodeError, TypeError, ValueError) as e:
             logger.warning("Intake profile JSON extraction failed: %s", e)
             return _merge_profile_structural(client_id, current_profile, update)
         except Exception as e:
@@ -106,4 +89,11 @@ class IntakeProfileAgent:
             return _merge_profile_structural(client_id, current_profile, update)
 
         data["client_id"] = client_id
-        return ClientProfile.model_validate(data)
+        try:
+            return ClientProfile.model_validate(data)
+        except Exception as e:
+            # Pydantic rejected the LLM's output (e.g. implausible
+            # weight, bad activity_level). Fall back to structural
+            # merge so the user's write still persists.
+            logger.warning("Intake profile LLM output failed schema validation: %s", e)
+            return _merge_profile_structural(client_id, current_profile, update)

--- a/backend/agents/nutrition_meal_planning_team/agents/intake_profile_agent/structural.py
+++ b/backend/agents/nutrition_meal_planning_team/agents/intake_profile_agent/structural.py
@@ -1,0 +1,61 @@
+"""Structural profile merge used as the intake-agent fallback.
+
+Pure logic with no LLM / strands / Postgres dependencies. Lives in its
+own module so unit tests can import it without dragging in the
+``strands`` stack that ``agent.py`` needs for the primary LLM path.
+
+SPEC-002 extends this to handle the ``biometrics`` and ``clinical``
+sub-objects alongside ``household`` / ``lifestyle`` / ``preferences`` /
+``goals``. List-valued top-level fields
+(``dietary_needs``, ``allergies_and_intolerances``) replace wholesale.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from ...models import ClientProfile, ProfileUpdateRequest
+
+
+def _shallow_merge(existing: Any, sub: Any) -> Any:
+    """Dict-wise shallow merge preserving the existing value's unset keys.
+
+    When either side is not a dict we overwrite. The
+    ``ProfileUpdateRequest`` schema guarantees dicts for the nested
+    sub-objects, so this only matters on malformed input.
+    """
+    if isinstance(existing, dict) and isinstance(sub, dict):
+        return {**existing, **sub}
+    return sub
+
+
+def merge_profile_structural(
+    client_id: str,
+    current: Optional[ClientProfile],
+    update: Optional[ProfileUpdateRequest],
+) -> ClientProfile:
+    """Apply ``update`` onto ``current`` without any LLM call.
+
+    Exercised by the intake agent's fallback path (LLM unavailable or
+    its JSON malformed) and directly by tests. Always returns a valid
+    ``ClientProfile`` with the given ``client_id``.
+    """
+    data: Dict[str, Any] = (
+        current.model_dump() if current else ClientProfile(client_id=client_id).model_dump()
+    )
+    if not update:
+        data["client_id"] = client_id
+        return ClientProfile.model_validate(data)
+    patch = update.model_dump(exclude_none=True)
+    for key in ("dietary_needs", "allergies_and_intolerances"):
+        if key in patch:
+            data[key] = patch[key]
+    for key in ("household", "lifestyle", "preferences", "goals", "biometrics", "clinical"):
+        if key not in patch:
+            continue
+        sub = patch[key]
+        if sub is None:
+            continue
+        data[key] = _shallow_merge(data.get(key) or {}, sub)
+    data["client_id"] = client_id
+    return ClientProfile.model_validate(data)

--- a/backend/agents/nutrition_meal_planning_team/api/main.py
+++ b/backend/agents/nutrition_meal_planning_team/api/main.py
@@ -14,9 +14,14 @@ from fastapi.middleware.cors import CORSMiddleware
 from shared_observability import init_otel, instrument_fastapi_app
 
 from ..models import (
+    BiometricHistoryResponse,
+    BiometricPatchRequest,
     ChatRequest,
     ChatResponse,
     ClientProfile,
+    ClinicalPatchRequest,
+    ClinicianOverrideRequest,
+    CompletenessResponse,
     FeedbackRequest,
     FeedbackResponse,
     MealHistoryResponse,
@@ -166,6 +171,66 @@ def get_profile_route(client_id: str):
 def put_profile_route(client_id: str, body: ProfileUpdateRequest):
     """Update client profile. Intake agent validates/completes; profile is saved."""
     return orchestrator.update_profile(client_id, body)
+
+
+@app.patch("/profile/{client_id}/biometrics", response_model=ClientProfile)
+def patch_biometrics_route(client_id: str, body: BiometricPatchRequest):
+    """SPEC-002: append-only biometric update.
+
+    Metric inputs (cm, kg) take precedence; imperial inputs are
+    coerced to canonical units before validation. Every changed
+    field writes a row to ``nutrition_biometric_log``.
+    """
+    return orchestrator.patch_biometrics(client_id, body)
+
+
+@app.get(
+    "/profile/{client_id}/biometrics/history",
+    response_model=BiometricHistoryResponse,
+)
+def get_biometrics_history_route(
+    client_id: str,
+    field: Optional[str] = None,
+    since: Optional[str] = None,
+    limit: int = 200,
+):
+    """SPEC-002: biometric log time series.
+
+    Optional ``field`` and ``since`` (ISO timestamp) narrow the query.
+    """
+    return orchestrator.get_biometric_history(client_id, field=field, since_iso=since, limit=limit)
+
+
+@app.patch("/profile/{client_id}/clinical", response_model=ClientProfile)
+def patch_clinical_route(client_id: str, body: ClinicalPatchRequest):
+    """SPEC-002: update clinical info (conditions, meds, reproductive state, ED flag).
+
+    Whole-list replace for ``conditions`` and ``medications``.
+    Unrecognized strings land in the ``*_freetext`` lists on the
+    clinical sub-object.
+    """
+    return orchestrator.patch_clinical(client_id, body)
+
+
+@app.put("/profile/{client_id}/clinical-overrides", response_model=ClientProfile)
+def put_clinician_overrides_route(client_id: str, body: ClinicianOverrideRequest):
+    """SPEC-002: replace clinician-authored numeric overrides.
+
+    Admin-only in production deployments. v1 enforces the admin
+    boundary via the platform's security gateway; this route itself
+    does not re-check auth.
+    """
+    return orchestrator.put_clinician_overrides(client_id, body)
+
+
+@app.get("/profile/{client_id}/completeness", response_model=CompletenessResponse)
+def get_profile_completeness_route(client_id: str):
+    """SPEC-002: completeness blockers + minor / ED flags.
+
+    Drives UI gating. Never 404s — an unknown client returns a
+    response with ``no_profile`` in blockers.
+    """
+    return orchestrator.get_completeness(client_id)
 
 
 @app.post("/plan/nutrition", response_model=NutritionPlanResponse)

--- a/backend/agents/nutrition_meal_planning_team/clinical_taxonomy.py
+++ b/backend/agents/nutrition_meal_planning_team/clinical_taxonomy.py
@@ -1,0 +1,164 @@
+"""Closed clinical taxonomy for the Nutrition & Meal Planning team.
+
+This module defines the canonical sets of medical conditions and
+medication classes that downstream components (the calculator in
+SPEC-003, the allergen / interaction guardrail in SPEC-007) can
+pattern-match on.
+
+The enums are **closed**: additions are a minor version bump, removals
+or renames are a major bump. Anything outside the enums lives in the
+open ``conditions_freetext`` / ``medications_freetext`` lists on
+``ClinicalInfo`` and is surfaced to the LLM narrator as caveat text, but
+is never used to drive numeric clamps.
+
+v1 scope is deliberately narrow:
+
+- Conditions: the set for which SPEC-003's ``clinical_overrides.py``
+  will ship targeted numeric clamps in v1, plus a small set of common
+  comorbidities that the narrator should be aware of but that do not
+  yet change numbers.
+- Medications: tagged by **class**, not drug name. SPEC-007's
+  ``interactions.yaml`` keys on these class tags.
+
+The contents are intentionally short. Keep them that way. New entries
+require the team lead's review and, where numeric clamps are added,
+the clinical reviewer on SPEC-003 signing off simultaneously.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import FrozenSet
+
+CLINICAL_TAXONOMY_VERSION = "1.0.0"
+
+
+class Condition(str, Enum):
+    """Closed set of medical conditions recognized by the calculator.
+
+    Anything not listed belongs in ``ClinicalInfo.conditions_freetext``.
+    """
+
+    ckd_stage_1 = "ckd_stage_1"
+    ckd_stage_2 = "ckd_stage_2"
+    ckd_stage_3 = "ckd_stage_3"
+    ckd_stage_4 = "ckd_stage_4"
+    ckd_stage_5 = "ckd_stage_5"
+    hypertension = "hypertension"
+    t1_diabetes = "t1_diabetes"
+    t2_diabetes = "t2_diabetes"
+    prediabetes = "prediabetes"
+    pcos = "pcos"
+    hypothyroid = "hypothyroid"
+    hyperthyroid = "hyperthyroid"
+    celiac = "celiac"
+    ibs = "ibs"
+    gerd = "gerd"
+    gallstones = "gallstones"
+    dyslipidemia = "dyslipidemia"
+    gout = "gout"
+
+
+class Medication(str, Enum):
+    """Closed set of medication *classes* (not drug names).
+
+    Keyed by the interaction-relevant class so SPEC-007's guardrail can
+    look up forbidden ``InteractionTag`` sets deterministically.
+    """
+
+    warfarin = "warfarin"
+    maoi = "maoi"
+    ssri = "ssri"
+    acei_arb = "acei_arb"
+    k_sparing_diuretic = "k_sparing_diuretic"
+    statin = "statin"
+    amiodarone = "amiodarone"
+    glp1 = "glp1"
+    metformin = "metformin"
+    levothyroxine = "levothyroxine"
+    lithium = "lithium"
+    st_johns_wort = "st_johns_wort"
+
+
+# Convenience frozensets for membership tests. These are not a source
+# of truth — the enums are — but they let callers write
+# ``if cond in CKD_STAGES`` without manually listing the members.
+
+CKD_STAGES: FrozenSet[Condition] = frozenset(
+    {
+        Condition.ckd_stage_1,
+        Condition.ckd_stage_2,
+        Condition.ckd_stage_3,
+        Condition.ckd_stage_4,
+        Condition.ckd_stage_5,
+    }
+)
+
+CLINICIAN_GUIDED_ONLY: FrozenSet[Condition] = frozenset(
+    {
+        Condition.ckd_stage_4,
+        Condition.ckd_stage_5,
+    }
+)
+"""Conditions that SPEC-003's cohort router sends to guidance-only.
+
+The calculator refuses to emit numeric deficit targets for these
+cohorts; the agent narrator replaces them with a "please work with
+your clinician" response.
+"""
+
+
+DIABETES: FrozenSet[Condition] = frozenset(
+    {
+        Condition.t1_diabetes,
+        Condition.t2_diabetes,
+        Condition.prediabetes,
+    }
+)
+
+
+def is_known_condition(value: str) -> bool:
+    """Return True iff ``value`` is a Condition enum value."""
+    return value in Condition._value2member_map_
+
+
+def is_known_medication(value: str) -> bool:
+    """Return True iff ``value`` is a Medication enum value."""
+    return value in Medication._value2member_map_
+
+
+def parse_conditions(values: list[str]) -> tuple[list[Condition], list[str]]:
+    """Split a free list into (recognized conditions, unrecognized strings).
+
+    The unrecognized bucket is what lands in ``conditions_freetext``.
+    """
+    known: list[Condition] = []
+    unknown: list[str] = []
+    seen: set[str] = set()
+    for raw in values:
+        s = (raw or "").strip()
+        if not s or s in seen:
+            continue
+        seen.add(s)
+        if is_known_condition(s):
+            known.append(Condition(s))
+        else:
+            unknown.append(s)
+    return known, unknown
+
+
+def parse_medications(values: list[str]) -> tuple[list[Medication], list[str]]:
+    """Split a free list into (recognized medications, unrecognized strings)."""
+    known: list[Medication] = []
+    unknown: list[str] = []
+    seen: set[str] = set()
+    for raw in values:
+        s = (raw or "").strip()
+        if not s or s in seen:
+            continue
+        seen.add(s)
+        if is_known_medication(s):
+            known.append(Medication(s))
+        else:
+            unknown.append(s)
+    return known, unknown

--- a/backend/agents/nutrition_meal_planning_team/graphs/plan_graph.py
+++ b/backend/agents/nutrition_meal_planning_team/graphs/plan_graph.py
@@ -19,37 +19,46 @@ def build_plan_graph() -> Graph:
     """Build the nutrition meal planning sequential graph."""
     return build_sequential(
         stages=[
-            ("intake_profiler", build_agent(
-                name="intake_profiler",
-                system_prompt=(
-                    "You are a nutrition intake specialist. Analyze the client's dietary needs, "
-                    "allergies, lifestyle, preferences, and health goals. Produce a comprehensive "
-                    "client profile with all nutritional requirements. Return structured JSON."
+            (
+                "intake_profiler",
+                build_agent(
+                    name="intake_profiler",
+                    system_prompt=(
+                        "You are a nutrition intake specialist. Analyze the client's dietary needs, "
+                        "allergies, lifestyle, preferences, and health goals. Produce a comprehensive "
+                        "client profile with all nutritional requirements. Return structured JSON."
+                    ),
+                    agent_key="nutrition_meal_planning",
+                    description="Analyzes client needs and builds nutritional profile",
                 ),
-                agent_key="nutrition_meal_planning",
-                description="Analyzes client needs and builds nutritional profile",
-            )),
-            ("nutritionist", build_agent(
-                name="nutritionist",
-                system_prompt=(
-                    "You are a registered dietitian. Based on the client profile, create a "
-                    "personalized nutrition plan with daily calorie targets, macronutrient ratios, "
-                    "meal frequency, and any supplementation recommendations. Return structured JSON."
+            ),
+            (
+                "nutritionist",
+                build_agent(
+                    name="nutritionist",
+                    system_prompt=(
+                        "You are a registered dietitian. Based on the client profile, create a "
+                        "personalized nutrition plan with daily calorie targets, macronutrient ratios, "
+                        "meal frequency, and any supplementation recommendations. Return structured JSON."
+                    ),
+                    agent_key="nutrition_meal_planning",
+                    description="Creates personalized nutrition plans",
                 ),
-                agent_key="nutrition_meal_planning",
-                description="Creates personalized nutrition plans",
-            )),
-            ("meal_planner", build_agent(
-                name="meal_planner",
-                system_prompt=(
-                    "You are a meal planning specialist. Based on the nutrition plan and client "
-                    "preferences, generate specific meal suggestions with recipes, ingredients, "
-                    "prep time, and nutritional breakdown. Consider meal history to avoid repetition. "
-                    "Return structured JSON with meal suggestions array."
+            ),
+            (
+                "meal_planner",
+                build_agent(
+                    name="meal_planner",
+                    system_prompt=(
+                        "You are a meal planning specialist. Based on the nutrition plan and client "
+                        "preferences, generate specific meal suggestions with recipes, ingredients, "
+                        "prep time, and nutritional breakdown. Consider meal history to avoid repetition. "
+                        "Return structured JSON with meal suggestions array."
+                    ),
+                    agent_key="nutrition_meal_planning",
+                    description="Generates specific meal suggestions",
                 ),
-                agent_key="nutrition_meal_planning",
-                description="Generates specific meal suggestions",
-            )),
+            ),
         ],
         graph_id="nutrition_planning",
         execution_timeout=300.0,

--- a/backend/agents/nutrition_meal_planning_team/models.py
+++ b/backend/agents/nutrition_meal_planning_team/models.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+from enum import Enum
 from typing import Any, Dict, List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
+
+# SPEC-002 schema version. Bump when the ClientProfile shape changes
+# in a way downstream consumers must observe. Kept as a plain string
+# so JSON round-trips via Postgres JSONB are lossless.
+PROFILE_SCHEMA_VERSION = "2.0"
 
 # --- Client profile (what a dietician would need) ---
 
@@ -48,10 +54,138 @@ class PreferencesInfo(BaseModel):
     preferences_free_text: str = ""  # "prefer X over Y", etc.
 
 
+# --- Biometrics (SPEC-002) -----------------------------------------------
+
+
+class Sex(str, Enum):
+    """Biological-sex options used by the calculator (SPEC-003).
+
+    ``other`` and ``unspecified`` route to a sex-averaged BMR variant.
+    """
+
+    female = "female"
+    male = "male"
+    other = "other"
+    unspecified = "unspecified"
+
+
+class ActivityLevel(str, Enum):
+    """Activity categories with PAL multipliers defined by SPEC-003.
+
+    sedentary=1.2, light=1.375, moderate=1.55, active=1.725,
+    very_active=1.9. The multipliers themselves live in ``nutrition_calc``
+    (SPEC-003); this enum only names the categories.
+    """
+
+    sedentary = "sedentary"
+    light = "light"
+    moderate = "moderate"
+    active = "active"
+    very_active = "very_active"
+
+
+class BiometricInfo(BaseModel):
+    """Inputs the calculator needs.
+
+    All numeric fields have implausibility bounds at the Pydantic layer.
+    Outside-range values are **rejected**, not clamped; the API returns
+    422 so the client can surface a clear error. See SPEC-002 §4.1.
+    """
+
+    sex: Sex = Sex.unspecified
+    age_years: Optional[int] = Field(default=None, ge=2, le=120)
+    height_cm: Optional[float] = Field(default=None, ge=50, le=260)
+    weight_kg: Optional[float] = Field(default=None, ge=20, le=400)
+    body_fat_pct: Optional[float] = Field(default=None, ge=3, le=75)
+    activity_level: ActivityLevel = ActivityLevel.sedentary
+    timezone: str = "UTC"
+    measured_at: Optional[str] = None
+    # User's preferred display units for UI round-trips. Not used by any
+    # calculator input; purely cosmetic.
+    preferred_units: str = "metric"  # 'metric' | 'imperial'
+
+    @field_validator("timezone")
+    @classmethod
+    def _validate_timezone(cls, v: str) -> str:
+        if not v:
+            return "UTC"
+        # Lazy import so we don't crash on platforms without tzdata.
+        try:
+            from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+            ZoneInfo(v)
+        except ZoneInfoNotFoundError as exc:
+            raise ValueError(f"unknown IANA timezone: {v}") from exc
+        except Exception:
+            # Missing tzdata on the host — accept and let the user
+            # resolve it rather than failing the whole profile write.
+            return v
+        return v
+
+    @field_validator("preferred_units")
+    @classmethod
+    def _validate_units(cls, v: str) -> str:
+        if v not in ("metric", "imperial"):
+            raise ValueError("preferred_units must be 'metric' or 'imperial'")
+        return v
+
+
+# --- Clinical (SPEC-002) -------------------------------------------------
+
+
+class ReproductiveState(str, Enum):
+    """Pregnancy / lactation stage for cohort routing.
+
+    SPEC-003's cohort router skips deficit calculation for pregnancy
+    and lactation and applies trimester-specific kcal additions.
+    """
+
+    none = "none"
+    pregnant_t1 = "pregnant_t1"
+    pregnant_t2 = "pregnant_t2"
+    pregnant_t3 = "pregnant_t3"
+    lactating = "lactating"
+    postpartum = "postpartum"
+
+
+class ClinicalInfo(BaseModel):
+    """Medical context driving SPEC-003 clinical overrides and SPEC-007
+    medication-interaction checks.
+
+    ``conditions`` / ``medications`` hold the **recognized** entries from
+    ``clinical_taxonomy.Condition`` / ``Medication``. Anything the user
+    enters that isn't in those enums lives in the ``*_freetext`` lists —
+    still surfaced to the narrator, never used to drive numeric clamps.
+    """
+
+    conditions: List[str] = Field(default_factory=list)
+    conditions_freetext: List[str] = Field(default_factory=list)
+    medications: List[str] = Field(default_factory=list)
+    medications_freetext: List[str] = Field(default_factory=list)
+    reproductive_state: ReproductiveState = ReproductiveState.none
+    # ED history flag: when True, scale-centric UX is disabled and
+    # SPEC-003 refuses deficit goals regardless of goal_type. This is
+    # a team invariant, not a per-user toggle — see SPEC-002 §4.1.
+    ed_history_flag: bool = False
+    # Clinician-authored overrides (e.g. ``{"bmi_floor": 19.5}``).
+    # Admin-only write path; users cannot edit these.
+    clinician_overrides: Dict[str, float] = Field(default_factory=dict)
+
+
 class GoalsInfo(BaseModel):
-    """Nutrition goals (optional)."""
+    """Nutrition goals (optional).
+
+    ``goal_type`` is the high-level intent; ``target_weight_kg`` and
+    ``rate_kg_per_week`` parameterize the calculator's energy delta.
+    Rate is clamped at input; SPEC-003 applies additional per-profile
+    safety clamps (≤1% body weight / week) at compute time.
+    """
 
     goal_type: str = "maintain"  # maintain, lose_weight, gain_weight, muscle, etc.
+    target_weight_kg: Optional[float] = Field(default=None, ge=20, le=400)
+    rate_kg_per_week: Optional[float] = Field(default=None, ge=0.0, le=1.0)
+    started_at: Optional[str] = None
+    paused_at: Optional[str] = None
     notes: str = ""
 
 
@@ -69,6 +203,13 @@ class ClientProfile(BaseModel):
     lifestyle: LifestyleInfo = Field(default_factory=LifestyleInfo)
     preferences: PreferencesInfo = Field(default_factory=PreferencesInfo)
     goals: GoalsInfo = Field(default_factory=GoalsInfo)
+    biometrics: BiometricInfo = Field(default_factory=BiometricInfo)
+    clinical: ClinicalInfo = Field(default_factory=ClinicalInfo)
+    # Monotonic write counter; bumped by the store on every save.
+    profile_version: int = 1
+    # Data-model version. Migrations that reshape ClientProfile bump
+    # this; downstream consumers pin on it.
+    schema_version: str = PROFILE_SCHEMA_VERSION
     updated_at: Optional[str] = None
 
 
@@ -152,7 +293,11 @@ class MealHistoryEntry(BaseModel):
 
 
 class ProfileUpdateRequest(BaseModel):
-    """Body for PUT /profile/{client_id}."""
+    """Body for PUT /profile/{client_id}.
+
+    All fields optional and additive; unspecified fields preserve the
+    current value. Nested objects merge shallowly (see SPEC-002 §4.4).
+    """
 
     household: Optional[HouseholdInfo] = None
     dietary_needs: Optional[List[str]] = None
@@ -160,6 +305,107 @@ class ProfileUpdateRequest(BaseModel):
     lifestyle: Optional[LifestyleInfo] = None
     preferences: Optional[PreferencesInfo] = None
     goals: Optional[GoalsInfo] = None
+    biometrics: Optional[BiometricInfo] = None
+    clinical: Optional[ClinicalInfo] = None
+
+
+# --- SPEC-002 additive request/response models ---------------------------
+
+
+class BiometricPatchRequest(BaseModel):
+    """Body for PATCH /profile/{client_id}/biometrics.
+
+    Supports either metric inputs (``height_cm`` / ``weight_kg``) or
+    imperial inputs (``height_ft`` + ``height_in`` / ``weight_lb``).
+    Metric values win if both sides are provided. See ``units.py``.
+    """
+
+    sex: Optional[Sex] = None
+    age_years: Optional[int] = Field(default=None, ge=2, le=120)
+    height_cm: Optional[float] = Field(default=None, ge=50, le=260)
+    height_ft: Optional[float] = Field(default=None, ge=0, le=9)
+    height_in: Optional[float] = Field(default=None, ge=0, le=107)
+    weight_kg: Optional[float] = Field(default=None, ge=20, le=400)
+    weight_lb: Optional[float] = Field(default=None, ge=44, le=880)
+    body_fat_pct: Optional[float] = Field(default=None, ge=3, le=75)
+    activity_level: Optional[ActivityLevel] = None
+    timezone: Optional[str] = None
+    preferred_units: Optional[str] = None
+    measured_at: Optional[str] = None
+
+    @field_validator("preferred_units")
+    @classmethod
+    def _validate_units(cls, v: Optional[str]) -> Optional[str]:
+        if v is None:
+            return v
+        if v not in ("metric", "imperial"):
+            raise ValueError("preferred_units must be 'metric' or 'imperial'")
+        return v
+
+
+class ClinicalPatchRequest(BaseModel):
+    """Body for PATCH /profile/{client_id}/clinical.
+
+    Whole-list semantics: ``conditions`` and ``medications`` replace the
+    existing lists. This matches how users think about these edits
+    (toggle chips on/off) and avoids subtle add/remove bugs.
+
+    Clinician overrides are **not** editable through this path; use the
+    admin-only ``PUT /clinical-overrides`` endpoint.
+    """
+
+    conditions: Optional[List[str]] = None
+    medications: Optional[List[str]] = None
+    reproductive_state: Optional[ReproductiveState] = None
+    ed_history_flag: Optional[bool] = None
+
+
+class ClinicianOverrideRequest(BaseModel):
+    """Body for PUT /profile/{client_id}/clinical-overrides.
+
+    Admin-only. Every write produces an audit row. Overrides replace
+    the entire dict; partial edits go through the admin tool, not the
+    API.
+    """
+
+    overrides: Dict[str, float] = Field(default_factory=dict)
+    reason: Optional[str] = None
+    author: str = "admin"
+
+
+class BiometricHistoryEntry(BaseModel):
+    """One row from nutrition_biometric_log, trimmed for the API."""
+
+    field: str
+    value_numeric: Optional[float] = None
+    value_text: Optional[str] = None
+    unit: Optional[str] = None
+    source: str = "manual"
+    recorded_at: str
+    recorded_by: Optional[str] = None
+
+
+class BiometricHistoryResponse(BaseModel):
+    client_id: str
+    field: Optional[str] = None
+    entries: List[BiometricHistoryEntry] = Field(default_factory=list)
+
+
+class CompletenessResponse(BaseModel):
+    """Shape for GET /profile/{client_id}/completeness.
+
+    Drives the UI gating: a profile with no ``weight_kg`` for instance
+    cannot yet receive calculator-driven plans and the UI shows a
+    banner. See SPEC-002 §4.5 / §4.6.
+    """
+
+    client_id: str
+    has_biometrics: bool = False
+    has_activity: bool = False
+    has_clinical_confirmed: bool = False
+    is_minor: bool = False
+    ed_history_flag: bool = False
+    blockers: List[str] = Field(default_factory=list)
 
 
 class NutritionPlanRequest(BaseModel):

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/__init__.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/__init__.py
@@ -1,0 +1,41 @@
+"""Deterministic nutrition calculator (SPEC-003).
+
+Pure-Python module with no LLM, Postgres, or agent dependencies.
+Public entry points:
+
+    from nutrition_meal_planning_team.nutrition_calc import (
+        compute_daily_targets, CALCULATOR_VERSION,
+        CalculatorError, InsufficientInputError,
+        ImplausibleInputError, UnsupportedCohortError,
+        Rationale, RationaleStep, Cohort,
+    )
+
+``compute_daily_targets(profile) -> CalculatorResult`` is the only
+entry point downstream consumers should rely on. Everything else is
+an implementation detail of the computation pipeline.
+"""
+
+from __future__ import annotations
+
+from .errors import (
+    CalculatorError,
+    ImplausibleInputError,
+    InsufficientInputError,
+    UnsupportedCohortError,
+)
+from .rationale import Rationale, RationaleStep
+from .targets import CalculatorResult, Cohort, compute_daily_targets
+from .version import CALCULATOR_VERSION
+
+__all__ = [
+    "CALCULATOR_VERSION",
+    "CalculatorError",
+    "CalculatorResult",
+    "Cohort",
+    "ImplausibleInputError",
+    "InsufficientInputError",
+    "Rationale",
+    "RationaleStep",
+    "UnsupportedCohortError",
+    "compute_daily_targets",
+]

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/_tables.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/_tables.py
@@ -1,0 +1,37 @@
+"""Small YAML-backed table loader shared by bmr/tdee/macros/micros.
+
+Modules call ``load_table(name)`` once at import (module-level
+constant) so per-call cost is zero. The loader is private
+(``_tables``) because the individual tables are the public contract,
+not the loader.
+
+The loader is defensive: raises at import time if any table file is
+missing, malformed, or returns a non-dict top-level value. That is
+the desired failure mode — a deployed calculator must have all of
+its tables present.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+_TABLES_DIR = Path(__file__).resolve().parent / "tables"
+
+
+@lru_cache(maxsize=None)
+def load_table(name: str) -> dict[str, Any]:
+    """Load a YAML table by basename (without .yaml extension)."""
+    path = _TABLES_DIR / f"{name}.yaml"
+    if not path.exists():
+        raise FileNotFoundError(f"nutrition_calc table missing: {path}")
+    with path.open("r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if data is None:
+        return {}
+    if not isinstance(data, dict):
+        raise ValueError(f"nutrition_calc table {name}.yaml must be a mapping")
+    return data

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/bmr.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/bmr.py
@@ -1,0 +1,108 @@
+"""Basal Metabolic Rate (BMR) equations.
+
+SPEC-003 §4.3. Two equations:
+
+- **Mifflin–St Jeor** (default). ISSN 2017 position paper prefers it
+  over Harris–Benedict for modern adults.
+
+  female: 10·kg + 6.25·cm − 5·age − 161
+  male:   10·kg + 6.25·cm − 5·age + 5
+
+- **Katch–McArdle** (preferred when ``body_fat_pct`` is available):
+
+  BMR = 370 + 21.6 · LBM_kg
+  LBM_kg = kg · (1 − body_fat_pct / 100)
+
+  Sex-independent; we use it regardless of ``Sex`` when body fat is
+  present.
+
+For ``Sex.other`` / ``Sex.unspecified`` without body fat, we fall
+back to the sex-averaged Mifflin variant (midpoint of ``−161`` and
+``+5``):
+
+  10·kg + 6.25·cm − 5·age − 78
+
+and the rationale records the approximation.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from ..models import Sex
+from .rationale import RationaleBuilder
+
+__all__ = ["compute_bmr", "BMRResult"]
+
+
+class BMRResult:
+    """Lightweight result holder — plain class, not a dataclass, so
+    it can carry the chosen equation tag without leaking into Rationale.
+    """
+
+    __slots__ = ("kcal", "equation")
+
+    def __init__(self, kcal: float, equation: str) -> None:
+        self.kcal = kcal
+        self.equation = equation
+
+    def __repr__(self) -> str:  # pragma: no cover - trivial
+        return f"BMRResult(kcal={self.kcal}, equation={self.equation!r})"
+
+
+def _mifflin_st_jeor(sex: Sex, kg: float, cm: float, age: int) -> float:
+    """Female/male Mifflin; sex-averaged midpoint for other/unspecified."""
+    base = 10.0 * kg + 6.25 * cm - 5.0 * age
+    if sex == Sex.female:
+        return base - 161.0
+    if sex == Sex.male:
+        return base + 5.0
+    # Sex-averaged midpoint: (+5 + -161) / 2 = -78.
+    return base - 78.0
+
+
+def _katch_mcardle(kg: float, body_fat_pct: float) -> float:
+    lbm = kg * (1.0 - body_fat_pct / 100.0)
+    return 370.0 + 21.6 * lbm
+
+
+def compute_bmr(
+    *,
+    sex: Sex,
+    kg: float,
+    cm: float,
+    age: int,
+    body_fat_pct: Optional[float],
+    rationale: RationaleBuilder,
+) -> BMRResult:
+    """Compute BMR and append one rationale step.
+
+    Callers must have already verified the inputs are non-None and
+    within plausible ranges (SPEC-002 Pydantic validators enforce
+    this at the API boundary). This function does not re-validate.
+    """
+    if body_fat_pct is not None:
+        kcal = _katch_mcardle(kg, body_fat_pct)
+        rationale.add(
+            step_id="bmr_katch_mcardle",
+            label="Basal metabolic rate (Katch–McArdle, body-fat aware)",
+            inputs={"kg": kg, "body_fat_pct": body_fat_pct},
+            outputs={"bmr_kcal": round(kcal, 1)},
+            source="Katch & McArdle (1980); Exercise Physiology 8th ed.",
+        )
+        return BMRResult(kcal=kcal, equation="katch_mcardle")
+
+    kcal = _mifflin_st_jeor(sex, kg, cm, age)
+    if sex in (Sex.other, Sex.unspecified):
+        note = "sex-averaged midpoint used (sex unspecified)"
+    else:
+        note = None
+    rationale.add(
+        step_id=f"bmr_mifflin_{sex.value}",
+        label="Basal metabolic rate (Mifflin–St Jeor)",
+        inputs={"sex": sex.value, "kg": kg, "cm": cm, "age": age},
+        outputs={"bmr_kcal": round(kcal, 1)},
+        source="Mifflin et al., Am J Clin Nutr 1990",
+        note=note,
+    )
+    return BMRResult(kcal=kcal, equation=f"mifflin_{sex.value}")

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/clinical_overrides.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/clinical_overrides.py
@@ -1,0 +1,257 @@
+"""Condition- and reproductive-state-specific clamps, applied last.
+
+SPEC-003 §4.8. Each override is a pure function
+``(CalculatorResult-like, RationaleBuilder) -> CalculatorResult-like``
+that may:
+
+- Lower a macronutrient target (protein cap for CKD 1-3).
+- Lower a micronutrient upper bound (sodium ≤ 1500 mg for HTN).
+- Adjust kcal (pregnancy T2/T3, lactation).
+- Tag metadata (per-meal carb cap for T2D — consumed by ADR-003).
+
+Overrides chain in a fixed, documented order. If two overrides set
+the same field, the stricter value wins and both are recorded in
+``applied_overrides``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from ..clinical_taxonomy import CKD_STAGES, Condition, Medication
+from ..models import ClinicalInfo, ReproductiveState
+from .macros import MacroAllocation
+from .micros import MicroTarget
+from .rationale import RationaleBuilder
+
+__all__ = ["apply_clinical_overrides", "ClinicalOverrideState"]
+
+
+@dataclass
+class ClinicalOverrideState:
+    """Mutable bundle passed through the override chain.
+
+    The calculator constructs this from its computed macros / micros /
+    kcal, lets the chain rewrite values in place, then reads back
+    final numbers.
+    """
+
+    kcal_target: float
+    macros: MacroAllocation
+    micros: dict[str, MicroTarget]
+    weight_kg: float
+    # Free-form metadata the overrides can attach. ADR-003 and SPEC-010
+    # look here for per-meal caps and advisory flags.
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Individual overrides (each returns True if it applied; False if no-op).
+# ---------------------------------------------------------------------------
+
+
+def _override_hypertension(
+    clinical: ClinicalInfo,
+    state: ClinicalOverrideState,
+    rationale: RationaleBuilder,
+) -> bool:
+    if Condition.hypertension.value not in clinical.conditions:
+        return False
+    # DASH / AHA guidance: sodium ≤ 1500 mg/day for stage 1 HTN.
+    sodium = state.micros.get("sodium_mg")
+    if sodium is None:
+        return False
+    prior = sodium.upper
+    new_upper = min(1500.0, prior) if prior is not None else 1500.0
+    if prior == new_upper:
+        return False
+    state.micros["sodium_mg"] = MicroTarget(
+        name="sodium_mg",
+        target=sodium.target,
+        upper=new_upper,
+        unit=sodium.unit,
+        source=f"{sodium.source}; clamped to 1500 mg for hypertension (AHA 2017).",
+    )
+    rationale.add(
+        step_id="hypertension_sodium_cap",
+        label="Hypertension: sodium upper cap ≤ 1500 mg/day",
+        inputs={"prior_upper_mg": prior},
+        outputs={"new_upper_mg": new_upper},
+        source="AHA/ACC 2017 hypertension guidelines; DASH diet target.",
+    )
+    rationale.mark_override("hypertension_sodium_cap")
+    return True
+
+
+def _override_ckd_protein(
+    clinical: ClinicalInfo,
+    state: ClinicalOverrideState,
+    rationale: RationaleBuilder,
+) -> bool:
+    """CKD stages 1-3: protein cap ≤ 0.8 g/kg (KDIGO 2020 non-dialysis)."""
+    has_ckd = any(c in {s.value for s in CKD_STAGES} for c in clinical.conditions)
+    if not has_ckd:
+        return False
+    cap_gpk = 0.8
+    cap_g = cap_gpk * state.weight_kg
+    if state.macros.protein_g <= cap_g + 0.5:  # rounding tolerance
+        return False
+    from .macros import KCAL_PER_G_CARBS, KCAL_PER_G_PROTEIN
+
+    prior_protein_g = state.macros.protein_g
+    # Freed-up kcal migrate to carbs (simplest rebalance; clinical
+    # dietitians can refine per patient).
+    freed_kcal = (prior_protein_g - cap_g) * KCAL_PER_G_PROTEIN
+    state.macros.protein_g = cap_g
+    state.macros.carbs_g += freed_kcal / KCAL_PER_G_CARBS
+    rationale.add(
+        step_id="ckd_protein_cap",
+        label="CKD: protein capped at 0.8 g/kg",
+        inputs={
+            "prior_protein_g": round(prior_protein_g, 1),
+            "cap_g_per_kg": cap_gpk,
+            "weight_kg": state.weight_kg,
+        },
+        outputs={
+            "new_protein_g": round(cap_g, 1),
+            "carbs_g_after_reallocation": round(state.macros.carbs_g, 1),
+        },
+        source="KDIGO 2020 clinical practice guideline (non-dialysis CKD).",
+    )
+    rationale.mark_override("ckd_protein_cap")
+    return True
+
+
+def _override_ckd_phosphorus(
+    clinical: ClinicalInfo,
+    state: ClinicalOverrideState,
+    rationale: RationaleBuilder,
+) -> bool:
+    """Flag phosphorus for CKD via metadata (no numeric retarget in v1
+    — too patient-specific). ADR-005 substitution surfaces the flag."""
+    has_ckd = any(c in {s.value for s in CKD_STAGES} for c in clinical.conditions)
+    if not has_ckd:
+        return False
+    state.metadata.setdefault("caution_flags", []).append("phosphorus")
+    rationale.add(
+        step_id="ckd_phosphorus_caution",
+        label="CKD: phosphorus caution flag set (informational)",
+        inputs={},
+        outputs={"caution_flag": "phosphorus"},
+        source="KDIGO 2020 guideline (individualized phosphate management).",
+    )
+    rationale.mark_override("ckd_phosphorus_caution")
+    return True
+
+
+def _override_t2d_per_meal_carbs(
+    clinical: ClinicalInfo,
+    state: ClinicalOverrideState,
+    rationale: RationaleBuilder,
+) -> bool:
+    """T2D: add per-meal carb cap metadata (~60 g, 3-meal distribution)."""
+    if Condition.t2_diabetes.value not in clinical.conditions:
+        return False
+    per_meal_g = round(state.macros.carbs_g / 3.0)
+    state.metadata["per_meal_carb_cap_g"] = per_meal_g
+    rationale.add(
+        step_id="t2d_per_meal_carb_cap",
+        label=f"T2D: per-meal carb cap ≈ {per_meal_g} g (advisory metadata)",
+        inputs={"daily_carbs_g": round(state.macros.carbs_g, 1), "meals_per_day": 3},
+        outputs={"per_meal_carb_cap_g": per_meal_g},
+        source="ADA Standards of Care 2023 — individualize carb distribution.",
+    )
+    rationale.mark_override("t2d_per_meal_carb_cap")
+    return True
+
+
+def _override_reproductive_kcal(
+    clinical: ClinicalInfo,
+    state: ClinicalOverrideState,
+    rationale: RationaleBuilder,
+) -> bool:
+    """Pregnancy T2/T3 and lactation kcal deltas.
+
+    Applied here rather than in energy_goal so the baseline kcal path
+    stays cohort-agnostic. Values match SPEC-003 §4.8 / IOM DRI
+    energy requirement deltas.
+    """
+    state_to_delta = {
+        ReproductiveState.pregnant_t1: 0,
+        ReproductiveState.pregnant_t2: +340,
+        ReproductiveState.pregnant_t3: +450,
+        ReproductiveState.lactating: +330,
+        ReproductiveState.postpartum: 0,
+        ReproductiveState.none: 0,
+    }
+    delta = state_to_delta.get(clinical.reproductive_state, 0)
+    if delta == 0:
+        return False
+    from .macros import KCAL_PER_G_CARBS
+
+    prior_kcal = state.kcal_target
+    state.kcal_target = prior_kcal + delta
+    # Route the extra kcal into carbs by convention (they provide the
+    # glucose drive for pregnancy / lactation energy demand).
+    state.macros.carbs_g += delta / KCAL_PER_G_CARBS
+    rationale.add(
+        step_id=f"reproductive_kcal_{clinical.reproductive_state.value}",
+        label=f"Reproductive state: {clinical.reproductive_state.value} kcal delta",
+        inputs={"prior_kcal": round(prior_kcal, 1)},
+        outputs={
+            "delta_kcal": delta,
+            "new_kcal": round(state.kcal_target, 1),
+            "carbs_g": round(state.macros.carbs_g, 1),
+        },
+        source="IOM DRI energy requirements; pregnancy/lactation additions.",
+    )
+    rationale.mark_override(f"reproductive_kcal_{clinical.reproductive_state.value}")
+    return True
+
+
+def _override_warfarin_vitamin_k_note(
+    clinical: ClinicalInfo,
+    state: ClinicalOverrideState,
+    rationale: RationaleBuilder,
+) -> bool:
+    """Advisory metadata only. SPEC-007 guardrail is where the
+    per-ingredient enforcement lives; here we just tag the plan so
+    the narrator can surface the "coordinate with INR" note."""
+    if Medication.warfarin.value not in clinical.medications:
+        return False
+    state.metadata.setdefault("advisory_notes", []).append("warfarin_vitamin_k")
+    rationale.add(
+        step_id="warfarin_vitamin_k_advisory",
+        label="Warfarin: vitamin-K consistency advisory",
+        inputs={},
+        outputs={"advisory": "warfarin_vitamin_k"},
+        source=("Holbrook et al., Chest 2012 — consistent vitamin-K intake with INR monitoring."),
+    )
+    rationale.mark_override("warfarin_vitamin_k_advisory")
+    return True
+
+
+# Fixed application order. Sodium / protein caps run before T2D carb
+# metadata because their changes affect the carb redistribution math.
+ORDER = (
+    _override_hypertension,
+    _override_ckd_protein,
+    _override_ckd_phosphorus,
+    _override_reproductive_kcal,
+    _override_t2d_per_meal_carbs,
+    _override_warfarin_vitamin_k_note,
+)
+
+
+def apply_clinical_overrides(
+    *,
+    clinical: Optional[ClinicalInfo],
+    state: ClinicalOverrideState,
+    rationale: RationaleBuilder,
+) -> ClinicalOverrideState:
+    if clinical is None:
+        return state
+    for override in ORDER:
+        override(clinical, state, rationale)
+    return state

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/energy_goal.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/energy_goal.py
@@ -1,0 +1,164 @@
+"""Goal-adjusted energy target, with safety floor.
+
+SPEC-003 §4.5. Maps ``(TDEE, GoalsInfo, BiometricInfo)`` to a
+``kcal_target`` plus a rationale record of what the deficit /
+surplus / floor adjustment did.
+
+Rate-cap safety:
+- SPEC-002 clamps ``rate_kg_per_week`` at 1.0 kg.
+- This function additionally enforces a per-profile 1% body weight
+  per week cap. If the requested rate exceeds this, it is reduced
+  and the rationale records the reduction.
+
+Floor safety:
+- ``kcal_target = max(kcal_target, max(1200, 0.8 · BMR))``.
+- Rationale records when the floor was applied.
+
+Pregnancy / lactation cohorts call into this function **only**
+through ``clinical_overrides`` — the default deficit-path here is
+skipped entirely for those cohorts (``compute_targets`` short-
+circuits based on cohort routing).
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from ..models import GoalsInfo
+from .rationale import RationaleBuilder
+
+__all__ = ["compute_energy_target", "KCAL_PER_KG_FAT", "ABSOLUTE_KCAL_FLOOR"]
+
+# 7700 kcal ≈ 1 kg of fat mass (historical clinical approximation;
+# Wishnofsky 1958 with widely-cited modern refinements). Pinned.
+KCAL_PER_KG_FAT = 7700.0
+
+# Non-negotiable absolute kcal floor. Medical literature disagrees on
+# the exact number; we pick 1200 as the conservative lower bound used
+# widely in consumer apps. A profile whose computed deficit would
+# push below this gets clamped to max(1200, 0.8·BMR).
+ABSOLUTE_KCAL_FLOOR = 1200.0
+
+# Fraction of BMR below which we refuse to prescribe. Together with
+# ABSOLUTE_KCAL_FLOOR, forms the safety floor.
+BMR_FLOOR_MULTIPLIER = 0.8
+
+
+def _per_profile_rate_cap(weight_kg: Optional[float]) -> float:
+    """1% of body weight per week, with a sensible floor for missing
+    weight.
+
+    When weight is missing we fall back to 1.0 kg/week (same as the
+    hard cap in SPEC-002). In practice the cohort router refuses to
+    compute at all without weight, so this branch is a safety net.
+    """
+    if weight_kg is None or weight_kg <= 0:
+        return 1.0
+    return 0.01 * weight_kg
+
+
+def compute_energy_target(
+    *,
+    tdee_kcal: float,
+    bmr_kcal: float,
+    goals: GoalsInfo,
+    weight_kg: Optional[float],
+    rationale: RationaleBuilder,
+) -> float:
+    """Compute kcal/day target. Applies goal delta then safety floor."""
+    goal_type = (goals.goal_type or "maintain").lower()
+    rate = goals.rate_kg_per_week
+
+    # Rate cap (per-profile 1% body weight / week).
+    effective_rate = rate
+    if rate is not None and rate > 0:
+        cap = _per_profile_rate_cap(weight_kg)
+        if rate > cap:
+            effective_rate = cap
+            rationale.add(
+                step_id="rate_capped_by_body_weight",
+                label="Requested rate exceeded 1% body weight/week cap",
+                inputs={"requested_rate_kg_per_week": rate, "cap_kg_per_week": cap},
+                outputs={"effective_rate_kg_per_week": cap},
+                source="Safety cap per SPEC-003 §4.5.",
+            )
+
+    # Goal delta.
+    if goal_type == "lose_weight" and effective_rate:
+        delta_kcal = -KCAL_PER_KG_FAT * effective_rate / 7.0
+        target = tdee_kcal + delta_kcal
+        rationale.add(
+            step_id="goal_delta_lose_weight",
+            label=f"Deficit for {effective_rate:.2f} kg/week loss",
+            inputs={
+                "tdee_kcal": round(tdee_kcal, 1),
+                "rate_kg_per_week": effective_rate,
+                "kcal_per_kg_fat": KCAL_PER_KG_FAT,
+            },
+            outputs={
+                "delta_kcal_per_day": round(delta_kcal, 1),
+                "target_kcal_pre_floor": round(target, 1),
+            },
+            source="7700 kcal ≈ 1 kg fat (Wishnofsky 1958).",
+        )
+    elif goal_type == "gain_weight" and effective_rate:
+        delta_kcal = +KCAL_PER_KG_FAT * effective_rate / 7.0
+        target = tdee_kcal + delta_kcal
+        rationale.add(
+            step_id="goal_delta_gain_weight",
+            label=f"Surplus for {effective_rate:.2f} kg/week gain",
+            inputs={
+                "tdee_kcal": round(tdee_kcal, 1),
+                "rate_kg_per_week": effective_rate,
+                "kcal_per_kg_fat": KCAL_PER_KG_FAT,
+            },
+            outputs={
+                "delta_kcal_per_day": round(delta_kcal, 1),
+                "target_kcal_pre_floor": round(target, 1),
+            },
+            source="7700 kcal ≈ 1 kg fat (Wishnofsky 1958).",
+        )
+    elif goal_type == "muscle":
+        # Small surplus regardless of rate — lean-gain convention.
+        delta_kcal = +250.0
+        target = tdee_kcal + delta_kcal
+        rationale.add(
+            step_id="goal_delta_muscle",
+            label="Small surplus for muscle gain",
+            inputs={"tdee_kcal": round(tdee_kcal, 1)},
+            outputs={
+                "delta_kcal_per_day": delta_kcal,
+                "target_kcal_pre_floor": round(target, 1),
+            },
+            source="Phillips & Van Loon, J Sports Sci 2011.",
+        )
+    else:
+        # maintain (or unrecognized goal): TDEE unchanged.
+        target = tdee_kcal
+        rationale.add(
+            step_id="goal_delta_maintain",
+            label="Maintenance — no energy delta",
+            inputs={"tdee_kcal": round(tdee_kcal, 1)},
+            outputs={"target_kcal_pre_floor": round(target, 1)},
+            source="SPEC-003 §4.5 maintenance path.",
+        )
+
+    # Safety floor.
+    floor = max(ABSOLUTE_KCAL_FLOOR, BMR_FLOOR_MULTIPLIER * bmr_kcal)
+    if target < floor:
+        rationale.add(
+            step_id="safety_floor_applied",
+            label="kcal target raised to safety floor",
+            inputs={
+                "proposed_kcal": round(target, 1),
+                "absolute_floor": ABSOLUTE_KCAL_FLOOR,
+                "bmr_multiplier_floor": round(BMR_FLOOR_MULTIPLIER * bmr_kcal, 1),
+            },
+            outputs={"target_kcal_post_floor": round(floor, 1)},
+            source=(
+                f"Floor = max({ABSOLUTE_KCAL_FLOOR}, {BMR_FLOOR_MULTIPLIER}·BMR) per SPEC-003 §4.5."
+            ),
+        )
+        target = floor
+
+    return target

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/errors.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/errors.py
@@ -1,0 +1,73 @@
+"""Error types raised by the deterministic calculator.
+
+All three failure modes are represented with structured payloads so
+the agent narrator (SPEC-004) can branch on cohort / missing-field
+information without string-parsing.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+class CalculatorError(Exception):
+    """Base for nutrition_calc failures."""
+
+
+@dataclass
+class InsufficientInputError(CalculatorError):
+    """A required field is missing for the routed cohort.
+
+    ``fields`` names the missing profile fields. The agent narrator
+    uses this list to render a "we need your height/weight/..." note
+    rather than guessing.
+    """
+
+    fields: tuple[str, ...] = field(default_factory=tuple)
+    cohort: str = "general_adult"
+    message: str = ""
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return self.message or f"insufficient inputs: {list(self.fields)}"
+
+
+@dataclass
+class ImplausibleInputError(CalculatorError):
+    """An input bypassed the profile's own validators and is
+    biologically implausible.
+
+    This should never reach the calculator in practice — SPEC-002's
+    Pydantic validators catch implausibility at the API boundary.
+    Treat as a bug if it fires; log and surface as an internal error.
+    """
+
+    field: str = ""
+    value: Optional[float] = None
+    reason: str = ""
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return (
+            f"implausible {self.field}={self.value}: {self.reason}"
+            if self.field
+            else self.reason or "implausible input"
+        )
+
+
+@dataclass
+class UnsupportedCohortError(CalculatorError):
+    """The profile routes to a cohort the calculator deliberately does
+    not emit numeric targets for.
+
+    Minors and CKD stage 4-5 fall here. The agent narrator branches to
+    a guidance-only response using ``guidance_key`` as the prompt
+    switch. This is not an error the user sees as a failure — it is
+    a successful "work with your clinician" response path.
+    """
+
+    cohort: str = ""
+    guidance_key: str = ""
+    clinician_note: str = ""
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return f"unsupported cohort: {self.cohort}"

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/macros.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/macros.py
@@ -1,0 +1,187 @@
+"""Macronutrient allocation from a kcal target.
+
+SPEC-003 §4.6. Goal-aware protein per kg, fat default with dietary
+overrides (keto bumps it up), carbs as the remainder — all clamped
+into the AMDR bands. If protein + fat together exceed what carbs
+AMDR allows, protein is reduced first (to its 0.8 g/kg RDA floor)
+before fat.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+from ..models import GoalsInfo
+from ._tables import load_table
+from .rationale import RationaleBuilder
+
+__all__ = [
+    "compute_macros",
+    "MacroAllocation",
+    "KCAL_PER_G_PROTEIN",
+    "KCAL_PER_G_CARBS",
+    "KCAL_PER_G_FAT",
+]
+
+KCAL_PER_G_PROTEIN = 4.0
+KCAL_PER_G_CARBS = 4.0
+KCAL_PER_G_FAT = 9.0
+
+_AMDR = load_table("amdr")
+
+
+class MacroAllocation:
+    """Plain result object with computed g/day values."""
+
+    __slots__ = ("protein_g", "fat_g", "carbs_g")
+
+    def __init__(self, protein_g: float, fat_g: float, carbs_g: float) -> None:
+        self.protein_g = protein_g
+        self.fat_g = fat_g
+        self.carbs_g = carbs_g
+
+    def as_dict(self) -> dict[str, float]:
+        return {
+            "protein_g": round(self.protein_g, 1),
+            "fat_g": round(self.fat_g, 1),
+            "carbs_g": round(self.carbs_g, 1),
+        }
+
+
+def _protein_base_gpk(goal_type: str) -> float:
+    table: dict[str, float] = _AMDR["protein_goal_overrides"]
+    if goal_type in table:
+        return float(table[goal_type])
+    return float(table["maintain"])
+
+
+def _fat_fraction_for_diet(dietary_needs: Iterable[str]) -> float:
+    """Default 25%; keto pushes fat share upward."""
+    tags = {t.strip().lower() for t in (dietary_needs or [])}
+    if "keto" in tags:
+        # Keto: high fat, minimal carbs. Raise fat fraction; the
+        # carb-AMDR clamp will still fire in compute, but the
+        # rationale captures the intent.
+        return 0.65
+    if "low_fat" in tags or "low-fat" in tags:
+        return float(_AMDR["fat"]["low"])
+    return float(_AMDR["fat"]["default"])
+
+
+def compute_macros(
+    *,
+    kcal_target: float,
+    weight_kg: float,
+    goals: GoalsInfo,
+    dietary_needs: Iterable[str],
+    rationale: RationaleBuilder,
+) -> MacroAllocation:
+    goal_type = (goals.goal_type or "maintain").lower()
+    protein_low_pct = float(_AMDR["protein"]["low"])
+    protein_high_pct = float(_AMDR["protein"]["high"])
+    rda_gpk = float(_AMDR["protein"]["rda_g_per_kg"])
+    fat_low_pct = float(_AMDR["fat"]["low"])
+    fat_high_pct = float(_AMDR["fat"]["high"])
+    carbs_low_pct = float(_AMDR["carbs"]["low"])
+    carbs_high_pct = float(_AMDR["carbs"]["high"])
+
+    # --- Protein: gram-per-kg then clamp to AMDR -----------------------
+    base_gpk = _protein_base_gpk(goal_type)
+    raw_protein_g = base_gpk * weight_kg
+    protein_kcal_raw = raw_protein_g * KCAL_PER_G_PROTEIN
+    protein_kcal_min = protein_low_pct * kcal_target
+    protein_kcal_max = protein_high_pct * kcal_target
+    protein_kcal = max(protein_kcal_min, min(protein_kcal_raw, protein_kcal_max))
+    clamped_protein = protein_kcal != protein_kcal_raw
+    protein_g = protein_kcal / KCAL_PER_G_PROTEIN
+    rationale.add(
+        step_id="protein_from_body_weight_then_amdr_clamp",
+        label=f"Protein: {base_gpk} g/kg → AMDR clamp",
+        inputs={
+            "weight_kg": weight_kg,
+            "base_g_per_kg": base_gpk,
+            "raw_protein_g": round(raw_protein_g, 1),
+            "amdr_low_pct": protein_low_pct,
+            "amdr_high_pct": protein_high_pct,
+            "kcal_target": round(kcal_target, 1),
+        },
+        outputs={
+            "protein_g": round(protein_g, 1),
+            "protein_pct_kcal": round(protein_kcal / kcal_target, 3) if kcal_target else 0,
+        },
+        source="ISSN position (Jäger et al. JISSN 2017); IOM 2005 AMDR bands.",
+        note=("protein clamped into AMDR band" if clamped_protein else None),
+    )
+
+    # --- Fat: diet-aware default fraction, clamped to AMDR ------------
+    fat_fraction = _fat_fraction_for_diet(dietary_needs)
+    fat_fraction_clamped = max(fat_low_pct, min(fat_fraction, fat_high_pct))
+    fat_g = fat_fraction_clamped * kcal_target / KCAL_PER_G_FAT
+    rationale.add(
+        step_id="fat_from_default_fraction",
+        label="Fat: diet-aware default, AMDR clamp",
+        inputs={
+            "fat_fraction_requested": fat_fraction,
+            "fat_fraction_applied": fat_fraction_clamped,
+            "kcal_target": round(kcal_target, 1),
+        },
+        outputs={
+            "fat_g": round(fat_g, 1),
+            "fat_pct_kcal": round(fat_fraction_clamped, 3),
+        },
+        source="IOM 2005 AMDR fat 20-35% kcal.",
+        note=("fat fraction clamped to AMDR" if fat_fraction_clamped != fat_fraction else None),
+    )
+
+    # --- Carbs: remainder then AMDR clamp; backoff protein first ------
+    used_kcal = protein_g * KCAL_PER_G_PROTEIN + fat_g * KCAL_PER_G_FAT
+    carbs_kcal = max(0.0, kcal_target - used_kcal)
+    carbs_kcal_min = carbs_low_pct * kcal_target
+    carbs_kcal_max = carbs_high_pct * kcal_target
+
+    backoff_note = None
+    if carbs_kcal < carbs_kcal_min:
+        # Protein+fat took too much of the budget; drop protein first
+        # down to its 0.8 g/kg RDA floor, then clip fat last.
+        shortfall = carbs_kcal_min - carbs_kcal
+        min_protein_g = rda_gpk * weight_kg
+        protein_surplus_kcal = max(protein_g - min_protein_g, 0.0) * KCAL_PER_G_PROTEIN
+        take_from_protein = min(shortfall, protein_surplus_kcal)
+        protein_g -= take_from_protein / KCAL_PER_G_PROTEIN
+        shortfall -= take_from_protein
+        if shortfall > 0:
+            fat_g -= shortfall / KCAL_PER_G_FAT
+            shortfall = 0.0
+        used_kcal = protein_g * KCAL_PER_G_PROTEIN + fat_g * KCAL_PER_G_FAT
+        carbs_kcal = max(0.0, kcal_target - used_kcal)
+        backoff_note = "reduced protein (and fat if needed) to hit carbs AMDR floor"
+    elif carbs_kcal > carbs_kcal_max:
+        # Rare — protein+fat undershot; carb AMDR caps. Recover by
+        # bumping fat up (cheapest non-protein option) to carbs_kcal_max.
+        excess = carbs_kcal - carbs_kcal_max
+        fat_g += excess / KCAL_PER_G_FAT
+        # Re-check fat AMDR upper; if it still exceeds, let it — the
+        # carbs cap is advisory per IOM, not a hard cap.
+        carbs_kcal = carbs_kcal_max
+        backoff_note = "shifted surplus into fat to hit carbs AMDR ceiling"
+
+    carbs_g = carbs_kcal / KCAL_PER_G_CARBS
+    rationale.add(
+        step_id="carbs_remainder_then_amdr_clamp",
+        label="Carbs: remainder of kcal budget, AMDR clamp",
+        inputs={
+            "kcal_target": round(kcal_target, 1),
+            "used_kcal_pre_backoff": round(used_kcal, 1),
+            "amdr_low_pct": carbs_low_pct,
+            "amdr_high_pct": carbs_high_pct,
+        },
+        outputs={
+            "carbs_g": round(carbs_g, 1),
+            "protein_g": round(protein_g, 1),
+            "fat_g": round(fat_g, 1),
+        },
+        source="IOM 2005 AMDR carbs 45-65% kcal.",
+        note=backoff_note,
+    )
+
+    return MacroAllocation(protein_g=protein_g, fat_g=fat_g, carbs_g=carbs_g)

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/micros.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/micros.py
@@ -1,0 +1,173 @@
+"""Micronutrient target lookup against the DRI table.
+
+SPEC-003 §4.7. Looks up ``(sex, age_band, reproductive_state)`` in
+``tables/dri.yaml`` for the v1 micro set: fiber, sodium (upper only),
+potassium, calcium, iron, vitamin D, B12, phosphorus, vitamin K.
+
+Reproductive-state deltas are applied by ``clinical_overrides`` so
+this module stays lookup-only.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+from ..models import ReproductiveState, Sex
+from ._tables import load_table
+from .rationale import RationaleBuilder
+
+__all__ = ["compute_micros", "MicroTarget", "V1_MICRO_NUTRIENTS", "age_band_for"]
+
+_DRI = load_table("dri")
+
+# Closed list of micros v1 emits. Additions bump CALCULATOR_VERSION
+# minor. Downstream consumers (ADR-003 rollup; ADR-006 adherence)
+# enumerate against this list.
+V1_MICRO_NUTRIENTS: tuple[str, ...] = (
+    "fiber_g",
+    "sodium_mg",
+    "potassium_mg",
+    "calcium_mg",
+    "iron_mg",
+    "vitamin_d_mcg",
+    "vitamin_b12_mcg",
+    "phosphorus_mg",
+    "vitamin_k_mcg",
+)
+
+
+class MicroTarget:
+    """Structured per-nutrient target record.
+
+    Stored on ``CalculatorResult.micros`` so the UI and ADR-003
+    rollup can reason about both lower targets and upper limits
+    uniformly.
+    """
+
+    __slots__ = ("name", "target", "upper", "unit", "source")
+
+    def __init__(
+        self,
+        name: str,
+        *,
+        target: Optional[float],
+        upper: Optional[float],
+        unit: str,
+        source: str,
+    ) -> None:
+        self.name = name
+        self.target = target
+        self.upper = upper
+        self.unit = unit
+        self.source = source
+
+    def as_dict(self) -> dict:
+        return {
+            "target": self.target,
+            "upper": self.upper,
+            "unit": self.unit,
+            "source": self.source,
+        }
+
+
+def age_band_for(age_years: int) -> str:
+    """Map adult age → DRI age-band label. 2–18 is handled by the
+    minor cohort router; here we defensively clamp at 19_30 so a
+    downstream bug does not produce a KeyError — the cohort router
+    is the actual guard."""
+    if age_years < 19:
+        return "19_30"
+    if age_years <= 30:
+        return "19_30"
+    if age_years <= 50:
+        return "31_50"
+    if age_years <= 70:
+        return "51_70"
+    return "71_plus"
+
+
+def _unit_for(nutrient: str) -> str:
+    # Unit is encoded in the nutrient name suffix (_g, _mg, _mcg).
+    for suffix, unit in (("_mg", "mg"), ("_mcg", "mcg"), ("_g", "g")):
+        if nutrient.endswith(suffix):
+            return unit
+    return ""
+
+
+def _lookup_sex_key(sex: Sex) -> str:
+    """Map Sex → DRI row. ``other`` / ``unspecified`` routes to the
+    lower-RDA side (female) for iron/fiber when life stage allows,
+    which is the more conservative choice for the consumer-health
+    framing (leaves more headroom; avoids over-prescribing iron)."""
+    if sex == Sex.male:
+        return "male"
+    return "female"
+
+
+def compute_micros(
+    *,
+    sex: Sex,
+    age_years: int,
+    reproductive_state: ReproductiveState,
+    rationale: RationaleBuilder,
+) -> dict[str, MicroTarget]:
+    sex_key = _lookup_sex_key(sex)
+    band = age_band_for(age_years)
+
+    out: dict[str, MicroTarget] = {}
+    missing: list[str] = []
+    for nutrient in V1_MICRO_NUTRIENTS:
+        table = _DRI.get(nutrient)
+        if not table:
+            missing.append(nutrient)
+            continue
+        row = table.get(sex_key, {}).get(band)
+        if not row:
+            missing.append(nutrient)
+            continue
+        out[nutrient] = MicroTarget(
+            name=nutrient,
+            target=row.get("target"),
+            upper=row.get("upper"),
+            unit=_unit_for(nutrient),
+            source=row.get("source", "DRI"),
+        )
+
+    # Reproductive deltas applied here (pre-clinical-overrides so the
+    # downstream override layer sees the already-adjusted targets).
+    deltas_table = _DRI.get("reproductive_deltas", {})
+    repro_deltas = deltas_table.get(reproductive_state.value, {}) or {}
+    applied_repro: dict[str, float] = {}
+    for nutrient, delta in repro_deltas.items():
+        if nutrient not in out:
+            continue
+        mt = out[nutrient]
+        if mt.target is None:
+            continue
+        new_target = mt.target + float(delta)
+        out[nutrient] = MicroTarget(
+            name=nutrient,
+            target=new_target,
+            upper=mt.upper,
+            unit=mt.unit,
+            source=f"{mt.source} + reproductive delta {delta:+g}",
+        )
+        applied_repro[nutrient] = float(delta)
+
+    rationale.add(
+        step_id="micros_from_dri",
+        label=f"Micronutrient targets (DRI {sex_key}, {band})",
+        inputs={
+            "sex": sex.value,
+            "sex_key": sex_key,
+            "age_band": band,
+            "reproductive_state": reproductive_state.value,
+        },
+        outputs={
+            "nutrients": {n: mt.as_dict() for n, mt in out.items()},
+            "reproductive_deltas_applied": applied_repro,
+        },
+        source="IOM / NAM DRI summary tables 1997-2019; cited per-row in dri.yaml.",
+        note=(f"missing DRI entries: {missing}" if missing else None),
+    )
+    return out

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/rationale.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/rationale.py
@@ -1,0 +1,93 @@
+"""Structured audit trail of calculator decisions.
+
+Every function in bmr/tdee/energy_goal/macros/micros/clinical_overrides
+appends exactly one ``RationaleStep`` as it runs. The resulting
+``Rationale`` is returned on ``CalculatorResult`` and rendered by
+SPEC-022's "why these numbers?" UI panel.
+
+Rationale is what makes the output reviewable. It is also what lets
+us tell a user *why* their target moved when the calculator version
+bumps — we show them the diff between the two rationales.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class RationaleStep:
+    """One computation step.
+
+    The tuple ``(id, inputs, outputs)`` is the audit-level record.
+    ``label`` and ``source`` drive UI display. ``note`` is reserved
+    for non-obvious caveats (e.g. "applied sex-averaged BMR because
+    sex=unspecified").
+    """
+
+    id: str
+    label: str
+    inputs: dict[str, Any]
+    outputs: dict[str, Any]
+    source: str
+    note: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class Rationale:
+    """Complete ordered audit of a single calculation.
+
+    ``applied_overrides`` lists the IDs of clinical overrides that
+    fired (e.g. ``("hypertension_sodium_cap",)``). Empty tuple when
+    no overrides matched the profile.
+    """
+
+    steps: tuple[RationaleStep, ...] = field(default_factory=tuple)
+    applied_overrides: tuple[str, ...] = field(default_factory=tuple)
+    cohort: str = "general_adult"
+
+
+class RationaleBuilder:
+    """Mutable builder used during compute_daily_targets.
+
+    The calculator's public API returns an immutable ``Rationale``.
+    During the compute pass we need append semantics, so the builder
+    collects steps and is frozen at the end via ``build(cohort)``.
+    """
+
+    def __init__(self) -> None:
+        self._steps: list[RationaleStep] = []
+        self._applied_overrides: list[str] = []
+
+    def add(
+        self,
+        *,
+        step_id: str,
+        label: str,
+        inputs: dict[str, Any],
+        outputs: dict[str, Any],
+        source: str,
+        note: Optional[str] = None,
+    ) -> None:
+        self._steps.append(
+            RationaleStep(
+                id=step_id,
+                label=label,
+                inputs=dict(inputs),
+                outputs=dict(outputs),
+                source=source,
+                note=note,
+            )
+        )
+
+    def mark_override(self, override_id: str) -> None:
+        if override_id not in self._applied_overrides:
+            self._applied_overrides.append(override_id)
+
+    def build(self, cohort: str) -> Rationale:
+        return Rationale(
+            steps=tuple(self._steps),
+            applied_overrides=tuple(self._applied_overrides),
+            cohort=cohort,
+        )

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/tables/amdr.yaml
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/tables/amdr.yaml
@@ -1,0 +1,41 @@
+# Acceptable Macronutrient Distribution Ranges (AMDR) expressed as
+# fractions of total kcal. Source: Institute of Medicine, Dietary
+# Reference Intakes for Energy, Carbohydrate, Fiber, Fat, Fatty Acids,
+# Cholesterol, Protein, and Amino Acids (2002/2005), adopted in the
+# 2020-2025 USDA Dietary Guidelines.
+#
+# These are the target bands the calculator clamps against when
+# composing the macro mix. Outside-band allocations produce a
+# rationale step noting the adjustment.
+#
+# Pinned constants; changing values requires a MINOR
+# CALCULATOR_VERSION bump.
+
+protein:
+  low: 0.10          # 10% of kcal
+  high: 0.35         # 35% of kcal
+  # Minimum gram-per-kg protein floor enforced by the calculator
+  # before AMDR clamps. Source: RDA 0.8 g/kg body weight.
+  rda_g_per_kg: 0.8
+
+fat:
+  low: 0.20          # 20% of kcal
+  high: 0.35         # 35% of kcal
+  default: 0.25      # default allocation when no diet override
+  # Saturated-fat soft cap from AHA / ACC 2013 guidelines.
+  saturated_max_pct_kcal: 0.10
+
+carbs:
+  low: 0.45          # 45% of kcal
+  high: 0.65         # 65% of kcal
+
+# Goal-specific protein-per-kg overrides applied before AMDR clamps.
+# Sources:
+#   - Phillips & Van Loon, J Sports Sci 2011 (1.6-2.2 g/kg for lean
+#     mass retention during deficit / muscle gain).
+#   - Helms et al., Int J Sport Nutr Exerc Metab 2014.
+protein_goal_overrides:
+  maintain: 1.2
+  lose_weight: 1.6
+  gain_weight: 1.4
+  muscle: 1.6

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/tables/dri.yaml
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/tables/dri.yaml
@@ -1,0 +1,147 @@
+# Dietary Reference Intakes (DRI) for v1 micronutrient coverage.
+#
+# Keyed by (sex, age_band, reproductive_state). v1 carries RDA/AI
+# targets and Upper Limits (UL) where defined. Source: Institute of
+# Medicine DRI Summary Tables, Food and Nutrition Board (latest
+# revisions 2019–2023).
+#
+# Micro coverage in v1:
+#   fiber_g, sodium_mg (UL only — "lower is better"), potassium_mg,
+#   calcium_mg, iron_mg, vitamin_d_mcg, vitamin_b12_mcg,
+#   phosphorus_mg, vitamin_k_mcg.
+#
+# ``sodium_mg`` uses the Chronic Disease Risk Reduction Intake (CDRR)
+# of 2300 mg/day, treated as the per-day upper cap. No lower target.
+# Pregnancy / lactation deltas applied via clinical_overrides.
+#
+# Age bands (adults):
+#   19_30, 31_50, 51_70, 71_plus
+
+fiber_g:
+  female:
+    "19_30": { target: 25, upper: null, source: "DRI AI (IOM 2005)" }
+    "31_50": { target: 25, upper: null, source: "DRI AI (IOM 2005)" }
+    "51_70": { target: 21, upper: null, source: "DRI AI (IOM 2005)" }
+    71_plus: { target: 21, upper: null, source: "DRI AI (IOM 2005)" }
+  male:
+    "19_30": { target: 38, upper: null, source: "DRI AI (IOM 2005)" }
+    "31_50": { target: 38, upper: null, source: "DRI AI (IOM 2005)" }
+    "51_70": { target: 30, upper: null, source: "DRI AI (IOM 2005)" }
+    71_plus: { target: 30, upper: null, source: "DRI AI (IOM 2005)" }
+
+sodium_mg:
+  # No lower target (essential but easily obtained). CDRR = 2300 mg/day.
+  female:
+    "19_30": { target: null, upper: 2300, source: "NAM CDRR 2019" }
+    "31_50": { target: null, upper: 2300, source: "NAM CDRR 2019" }
+    "51_70": { target: null, upper: 2300, source: "NAM CDRR 2019" }
+    71_plus: { target: null, upper: 2300, source: "NAM CDRR 2019" }
+  male:
+    "19_30": { target: null, upper: 2300, source: "NAM CDRR 2019" }
+    "31_50": { target: null, upper: 2300, source: "NAM CDRR 2019" }
+    "51_70": { target: null, upper: 2300, source: "NAM CDRR 2019" }
+    71_plus: { target: null, upper: 2300, source: "NAM CDRR 2019" }
+
+potassium_mg:
+  # AI only; no UL from food sources.
+  female:
+    "19_30": { target: 2600, upper: null, source: "DRI AI (NAM 2019)" }
+    "31_50": { target: 2600, upper: null, source: "DRI AI (NAM 2019)" }
+    "51_70": { target: 2600, upper: null, source: "DRI AI (NAM 2019)" }
+    71_plus: { target: 2600, upper: null, source: "DRI AI (NAM 2019)" }
+  male:
+    "19_30": { target: 3400, upper: null, source: "DRI AI (NAM 2019)" }
+    "31_50": { target: 3400, upper: null, source: "DRI AI (NAM 2019)" }
+    "51_70": { target: 3400, upper: null, source: "DRI AI (NAM 2019)" }
+    71_plus: { target: 3400, upper: null, source: "DRI AI (NAM 2019)" }
+
+calcium_mg:
+  female:
+    "19_30": { target: 1000, upper: 2500, source: "DRI RDA (IOM 2011)" }
+    "31_50": { target: 1000, upper: 2500, source: "DRI RDA (IOM 2011)" }
+    "51_70": { target: 1200, upper: 2000, source: "DRI RDA (IOM 2011)" }
+    71_plus: { target: 1200, upper: 2000, source: "DRI RDA (IOM 2011)" }
+  male:
+    "19_30": { target: 1000, upper: 2500, source: "DRI RDA (IOM 2011)" }
+    "31_50": { target: 1000, upper: 2500, source: "DRI RDA (IOM 2011)" }
+    "51_70": { target: 1000, upper: 2000, source: "DRI RDA (IOM 2011)" }
+    71_plus: { target: 1200, upper: 2000, source: "DRI RDA (IOM 2011)" }
+
+iron_mg:
+  female:
+    "19_30": { target: 18, upper: 45, source: "DRI RDA (IOM 2001)" }
+    "31_50": { target: 18, upper: 45, source: "DRI RDA (IOM 2001)" }
+    "51_70": { target: 8, upper: 45, source: "DRI RDA (IOM 2001)" }
+    71_plus: { target: 8, upper: 45, source: "DRI RDA (IOM 2001)" }
+  male:
+    "19_30": { target: 8, upper: 45, source: "DRI RDA (IOM 2001)" }
+    "31_50": { target: 8, upper: 45, source: "DRI RDA (IOM 2001)" }
+    "51_70": { target: 8, upper: 45, source: "DRI RDA (IOM 2001)" }
+    71_plus: { target: 8, upper: 45, source: "DRI RDA (IOM 2001)" }
+
+vitamin_d_mcg:
+  # 15 mcg = 600 IU; 20 mcg = 800 IU for 71+.
+  female:
+    "19_30": { target: 15, upper: 100, source: "DRI RDA (IOM 2011)" }
+    "31_50": { target: 15, upper: 100, source: "DRI RDA (IOM 2011)" }
+    "51_70": { target: 15, upper: 100, source: "DRI RDA (IOM 2011)" }
+    71_plus: { target: 20, upper: 100, source: "DRI RDA (IOM 2011)" }
+  male:
+    "19_30": { target: 15, upper: 100, source: "DRI RDA (IOM 2011)" }
+    "31_50": { target: 15, upper: 100, source: "DRI RDA (IOM 2011)" }
+    "51_70": { target: 15, upper: 100, source: "DRI RDA (IOM 2011)" }
+    71_plus: { target: 20, upper: 100, source: "DRI RDA (IOM 2011)" }
+
+vitamin_b12_mcg:
+  female:
+    "19_30": { target: 2.4, upper: null, source: "DRI RDA (IOM 1998)" }
+    "31_50": { target: 2.4, upper: null, source: "DRI RDA (IOM 1998)" }
+    "51_70": { target: 2.4, upper: null, source: "DRI RDA (IOM 1998)" }
+    71_plus: { target: 2.4, upper: null, source: "DRI RDA (IOM 1998)" }
+  male:
+    "19_30": { target: 2.4, upper: null, source: "DRI RDA (IOM 1998)" }
+    "31_50": { target: 2.4, upper: null, source: "DRI RDA (IOM 1998)" }
+    "51_70": { target: 2.4, upper: null, source: "DRI RDA (IOM 1998)" }
+    71_plus: { target: 2.4, upper: null, source: "DRI RDA (IOM 1998)" }
+
+phosphorus_mg:
+  female:
+    "19_30": { target: 700, upper: 4000, source: "DRI RDA (IOM 1997)" }
+    "31_50": { target: 700, upper: 4000, source: "DRI RDA (IOM 1997)" }
+    "51_70": { target: 700, upper: 4000, source: "DRI RDA (IOM 1997)" }
+    71_plus: { target: 700, upper: 3000, source: "DRI RDA (IOM 1997)" }
+  male:
+    "19_30": { target: 700, upper: 4000, source: "DRI RDA (IOM 1997)" }
+    "31_50": { target: 700, upper: 4000, source: "DRI RDA (IOM 1997)" }
+    "51_70": { target: 700, upper: 4000, source: "DRI RDA (IOM 1997)" }
+    71_plus: { target: 700, upper: 3000, source: "DRI RDA (IOM 1997)" }
+
+vitamin_k_mcg:
+  # AI only.
+  female:
+    "19_30": { target: 90, upper: null, source: "DRI AI (IOM 2001)" }
+    "31_50": { target: 90, upper: null, source: "DRI AI (IOM 2001)" }
+    "51_70": { target: 90, upper: null, source: "DRI AI (IOM 2001)" }
+    71_plus: { target: 90, upper: null, source: "DRI AI (IOM 2001)" }
+  male:
+    "19_30": { target: 120, upper: null, source: "DRI AI (IOM 2001)" }
+    "31_50": { target: 120, upper: null, source: "DRI AI (IOM 2001)" }
+    "51_70": { target: 120, upper: null, source: "DRI AI (IOM 2001)" }
+    71_plus: { target: 120, upper: null, source: "DRI AI (IOM 2001)" }
+
+# Reproductive-state deltas added to ``target`` after the base lookup.
+# Applied by clinical_overrides so the default lookup stays pure.
+reproductive_deltas:
+  pregnant_t1:
+    fiber_g: +3
+  pregnant_t2:
+    fiber_g: +3
+    iron_mg: +9
+    calcium_mg: 0
+  pregnant_t3:
+    fiber_g: +3
+    iron_mg: +9
+  lactating:
+    fiber_g: +4
+    iron_mg: -9     # down from pregnancy baseline; net vs non-pregnant still +-
+    calcium_mg: 0

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/tables/pal.yaml
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/tables/pal.yaml
@@ -1,0 +1,19 @@
+# Physical Activity Level (PAL) multipliers for TDEE = BMR × PAL.
+# Values match the broadly-cited ACSM / Harris–Benedict convention used
+# throughout consumer nutrition apps.
+#
+# Sources:
+#   - American College of Sports Medicine, Guidelines for Exercise
+#     Testing and Prescription (11th ed.), Ch. 4 activity factors.
+#   - WHO / FAO / UNU Human energy requirements (2004), section on
+#     habitual physical activity.
+#
+# These are pinned constants; changing a value requires a MINOR
+# CALCULATOR_VERSION bump per SPEC-003 §4.11 and a clinical-reviewer
+# sign-off.
+
+sedentary: 1.2       # desk work, little or no exercise
+light: 1.375         # light exercise 1–3 days/week
+moderate: 1.55       # moderate exercise 3–5 days/week
+active: 1.725        # hard exercise 6–7 days/week
+very_active: 1.9     # physical job plus daily training

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/tables/retention.yaml
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/tables/retention.yaml
@@ -1,0 +1,8 @@
+# Reserved for SPEC-009 (recipe nutrient rollup) to pull raw→cooked
+# retention factors. nutrition_calc does not read this file at v1.0.0.
+#
+# Placed alongside the other calculator tables so the retention data
+# lives in one reviewable location once SPEC-009 lands.
+
+# Intentionally empty in v1.
+{}

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/targets.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/targets.py
@@ -1,0 +1,261 @@
+"""Top-level orchestration: profile → CalculatorResult.
+
+SPEC-003 §4.2 / §4.9. Routes the profile to a cohort, runs the
+bmr → tdee → energy_goal → macros → micros → clinical_overrides
+chain, and assembles a frozen ``CalculatorResult``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from ..clinical_taxonomy import CLINICIAN_GUIDED_ONLY
+from ..models import ClientProfile, DailyTargets, ReproductiveState, Sex
+from .bmr import compute_bmr
+from .clinical_overrides import ClinicalOverrideState, apply_clinical_overrides
+from .energy_goal import compute_energy_target
+from .errors import (
+    InsufficientInputError,
+    UnsupportedCohortError,
+)
+from .macros import compute_macros
+from .micros import MicroTarget, compute_micros
+from .rationale import Rationale, RationaleBuilder
+from .tdee import compute_tdee
+from .version import CALCULATOR_VERSION
+
+__all__ = ["compute_daily_targets", "CalculatorResult", "Cohort"]
+
+
+class Cohort:
+    """String constants for the five cohorts v1 routes to.
+
+    Kept as a plain class of constants (rather than an Enum) so the
+    values can be embedded in error payloads that cross module
+    boundaries without enum serialization gymnastics.
+    """
+
+    GENERAL_ADULT = "general_adult"
+    GENERAL_ADULT_SEX_UNSPECIFIED = "general_adult_sex_unspecified"
+    PREGNANCY_LACTATION = "pregnancy_lactation"
+    ED_ADJACENT = "ed_adjacent"
+    MINOR = "minor"
+    CLINICIAN_GUIDED = "clinician_guided"
+
+
+@dataclass(frozen=True)
+class CalculatorResult:
+    targets: DailyTargets
+    rationale: Rationale
+    calculator_version: str
+    cohort: str
+    micros: dict[str, dict]  # serialized MicroTarget.as_dict per nutrient
+    intermediates: dict[str, float] = field(default_factory=dict)
+    metadata: dict = field(default_factory=dict)
+    warnings: tuple[str, ...] = field(default_factory=tuple)
+
+
+def _route_cohort(profile: ClientProfile) -> str:
+    """Map a profile to one of five cohorts; raise for the two
+    unsupported ones. See SPEC-003 §4.9 flowchart."""
+    bio = profile.biometrics
+    clin = profile.clinical
+    if bio.age_years is not None and bio.age_years < 18:
+        raise UnsupportedCohortError(
+            cohort=Cohort.MINOR,
+            guidance_key="minor",
+            clinician_note=(
+                "For growing users we focus on variety and balance rather "
+                "than calorie targets. Please work with a pediatrician or "
+                "registered dietitian for personalized guidance."
+            ),
+        )
+    if clin and any(c in {x.value for x in CLINICIAN_GUIDED_ONLY} for c in clin.conditions):
+        # Pick the first clinician-guided tag for the error payload
+        # so the narrator can reference it specifically.
+        key = next(
+            (c for c in clin.conditions if c in {x.value for x in CLINICIAN_GUIDED_ONLY}),
+            "clinician_guided",
+        )
+        raise UnsupportedCohortError(
+            cohort=Cohort.CLINICIAN_GUIDED,
+            guidance_key=key,
+            clinician_note=(
+                "Your profile includes a condition that needs individualized "
+                "dietitian- or clinician-led planning. We can offer general "
+                "food-group guidance; please do not use any specific numeric "
+                "targets without your care team."
+            ),
+        )
+    if clin and clin.reproductive_state in (
+        ReproductiveState.pregnant_t1,
+        ReproductiveState.pregnant_t2,
+        ReproductiveState.pregnant_t3,
+        ReproductiveState.lactating,
+    ):
+        return Cohort.PREGNANCY_LACTATION
+    if clin and clin.ed_history_flag:
+        return Cohort.ED_ADJACENT
+    if bio.sex in (Sex.other, Sex.unspecified) and bio.body_fat_pct is None:
+        return Cohort.GENERAL_ADULT_SEX_UNSPECIFIED
+    return Cohort.GENERAL_ADULT
+
+
+def _check_required_inputs(profile: ClientProfile, cohort: str) -> None:
+    """Required biometric fields check.
+
+    Sex is required for the standard general_adult path (determines
+    Mifflin variant). It is NOT required when:
+    - cohort is GENERAL_ADULT_SEX_UNSPECIFIED (that IS the sex-
+      unspecified branch), or
+    - ``body_fat_pct`` is present (Katch-McArdle is sex-independent).
+
+    Age, height, and weight are always required because every
+    equation in the pipeline consumes them.
+    """
+    missing: list[str] = []
+    bio = profile.biometrics
+    sex_required = cohort != Cohort.GENERAL_ADULT_SEX_UNSPECIFIED and bio.body_fat_pct is None
+    if sex_required and bio.sex == Sex.unspecified:
+        missing.append("sex")
+    if bio.age_years is None:
+        missing.append("age_years")
+    if bio.height_cm is None:
+        missing.append("height_cm")
+    if bio.weight_kg is None:
+        missing.append("weight_kg")
+    if missing:
+        raise InsufficientInputError(
+            fields=tuple(missing),
+            cohort=cohort,
+            message=f"missing required biometric fields: {missing}",
+        )
+
+
+def compute_daily_targets(profile: ClientProfile) -> CalculatorResult:
+    """Top-level entry point. See SPEC-003 §4.2.
+
+    Raises:
+        UnsupportedCohortError: minor / clinician-guided-only cohorts.
+        InsufficientInputError: missing required biometric(s).
+    """
+    cohort = _route_cohort(profile)
+    _check_required_inputs(profile, cohort)
+
+    bio = profile.biometrics
+    goals = profile.goals
+    clinical = profile.clinical
+    rationale = RationaleBuilder()
+
+    # --- BMR + TDEE -------------------------------------------------
+    bmr = compute_bmr(
+        sex=bio.sex,
+        kg=bio.weight_kg,  # type: ignore[arg-type]
+        cm=bio.height_cm,  # type: ignore[arg-type]
+        age=bio.age_years,  # type: ignore[arg-type]
+        body_fat_pct=bio.body_fat_pct,
+        rationale=rationale,
+    )
+    tdee_kcal = compute_tdee(
+        bmr_kcal=bmr.kcal,
+        activity_level=bio.activity_level,
+        rationale=rationale,
+    )
+
+    # --- Energy goal (cohort-aware) ---------------------------------
+    if cohort in (Cohort.PREGNANCY_LACTATION, Cohort.ED_ADJACENT):
+        # Pregnancy / lactation: skip the deficit path; clinical
+        # overrides add trimester / lactation kcal deltas downstream.
+        # ED-adjacent: never prescribe a deficit — kcal target = TDEE.
+        kcal_target = tdee_kcal
+        rationale.add(
+            step_id=f"energy_goal_skipped_{cohort}",
+            label=f"Cohort {cohort}: maintenance only, no deficit path",
+            inputs={"tdee_kcal": round(tdee_kcal, 1)},
+            outputs={"kcal_target": round(kcal_target, 1)},
+            source="SPEC-003 §4.9 cohort router.",
+        )
+    else:
+        kcal_target = compute_energy_target(
+            tdee_kcal=tdee_kcal,
+            bmr_kcal=bmr.kcal,
+            goals=goals,
+            weight_kg=bio.weight_kg,
+            rationale=rationale,
+        )
+
+    # --- Macros ------------------------------------------------------
+    # ED-adjacent cohort: use maintenance goal regardless of what the
+    # profile says, to sidestep accidentally-aggressive protein/fat
+    # ratios keyed on "lose_weight".
+    if cohort == Cohort.ED_ADJACENT:
+        from ..models import GoalsInfo
+
+        effective_goals = GoalsInfo(goal_type="maintain")
+    else:
+        effective_goals = goals
+    macros = compute_macros(
+        kcal_target=kcal_target,
+        weight_kg=bio.weight_kg,  # type: ignore[arg-type]
+        goals=effective_goals,
+        dietary_needs=profile.dietary_needs,
+        rationale=rationale,
+    )
+
+    # --- Micros ------------------------------------------------------
+    micros = compute_micros(
+        sex=bio.sex,
+        age_years=bio.age_years,  # type: ignore[arg-type]
+        reproductive_state=clinical.reproductive_state if clinical else ReproductiveState.none,
+        rationale=rationale,
+    )
+
+    # --- Clinical overrides -----------------------------------------
+    override_state = ClinicalOverrideState(
+        kcal_target=kcal_target,
+        macros=macros,
+        micros=micros,
+        weight_kg=bio.weight_kg,  # type: ignore[arg-type]
+    )
+    apply_clinical_overrides(clinical=clinical, state=override_state, rationale=rationale)
+
+    # --- Pack result ------------------------------------------------
+    sodium_upper = _upper(override_state.micros, "sodium_mg")
+    targets = DailyTargets(
+        calories_kcal=round(override_state.kcal_target, 1),
+        protein_g=round(override_state.macros.protein_g, 1),
+        carbs_g=round(override_state.macros.carbs_g, 1),
+        fat_g=round(override_state.macros.fat_g, 1),
+        fiber_g=_target(override_state.micros, "fiber_g"),
+        sodium_mg=sodium_upper,
+        other_nutrients={
+            n: _target(override_state.micros, n)
+            for n in override_state.micros
+            if n not in ("fiber_g", "sodium_mg") and _target(override_state.micros, n) is not None
+        },
+    )
+
+    intermediates = {
+        "bmr_kcal": round(bmr.kcal, 1),
+        "tdee_kcal": round(tdee_kcal, 1),
+    }
+
+    return CalculatorResult(
+        targets=targets,
+        rationale=rationale.build(cohort=cohort),
+        calculator_version=CALCULATOR_VERSION,
+        cohort=cohort,
+        micros={n: mt.as_dict() for n, mt in override_state.micros.items()},
+        intermediates=intermediates,
+        metadata=override_state.metadata,
+    )
+
+
+def _target(micros: dict[str, MicroTarget], key: str) -> float | None:
+    mt = micros.get(key)
+    return mt.target if mt is not None else None
+
+
+def _upper(micros: dict[str, MicroTarget], key: str) -> float | None:
+    mt = micros.get(key)
+    return mt.upper if mt is not None else None

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/tdee.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/tdee.py
@@ -1,0 +1,46 @@
+"""Total Daily Energy Expenditure.
+
+SPEC-003 §4.4. ``TDEE = BMR × PAL`` where the PAL multipliers live
+in ``tables/pal.yaml``. No NEAT adjustments, no occupation-specific
+multipliers — additional parameters would need inputs we do not
+collect, and they would compromise reproducibility.
+"""
+
+from __future__ import annotations
+
+from ..models import ActivityLevel
+from ._tables import load_table
+from .rationale import RationaleBuilder
+
+__all__ = ["compute_tdee"]
+
+_PAL = load_table("pal")
+
+
+def _pal_value(level: ActivityLevel) -> float:
+    try:
+        return float(_PAL[level.value])
+    except KeyError as exc:
+        # pal.yaml is pinned; a missing key is a config bug, not a
+        # user-facing error.
+        raise RuntimeError(
+            f"pal.yaml missing multiplier for activity_level={level.value!r}"
+        ) from exc
+
+
+def compute_tdee(
+    *,
+    bmr_kcal: float,
+    activity_level: ActivityLevel,
+    rationale: RationaleBuilder,
+) -> float:
+    pal = _pal_value(activity_level)
+    tdee = bmr_kcal * pal
+    rationale.add(
+        step_id="tdee_bmr_times_pal",
+        label=f"Total daily energy expenditure ({activity_level.value})",
+        inputs={"bmr_kcal": round(bmr_kcal, 1), "pal": pal},
+        outputs={"tdee_kcal": round(tdee, 1)},
+        source="ACSM Guidelines 11th ed.; WHO/FAO/UNU 2004 activity factors.",
+    )
+    return tdee

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/tests/test_bmr.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/tests/test_bmr.py
@@ -1,0 +1,92 @@
+"""SPEC-003 §6.1 — Mifflin-St Jeor + Katch-McArdle reference values."""
+
+from __future__ import annotations
+
+import pytest
+
+from nutrition_meal_planning_team.models import Sex
+from nutrition_meal_planning_team.nutrition_calc.bmr import compute_bmr
+from nutrition_meal_planning_team.nutrition_calc.rationale import RationaleBuilder
+
+
+@pytest.mark.parametrize(
+    "sex,kg,cm,age,expected",
+    [
+        # Mifflin-St Jeor worked examples. Expected = 10·kg + 6.25·cm − 5·age + (+5|−161|−78)
+        # Verified against hand calculation:
+        # female 64.5/168/32: 10·64.5 + 6.25·168 − 5·32 − 161 = 645 + 1050 − 160 − 161 = 1374
+        # female 55/160/45:  10·55  + 6.25·160 − 5·45 − 161 = 550 + 1000 − 225 − 161 = 1164
+        # female 72/175/28:  10·72  + 6.25·175 − 5·28 − 161 = 720 + 1093.75 − 140 − 161 = 1512.75
+        # male   80/180/30:  10·80  + 6.25·180 − 5·30 + 5   = 800 + 1125 − 150 + 5 = 1780
+        # male   90/185/45:  10·90  + 6.25·185 − 5·45 + 5   = 900 + 1156.25 − 225 + 5 = 1836.25
+        # male   70/175/60:  10·70  + 6.25·175 − 5·60 + 5   = 700 + 1093.75 − 300 + 5 = 1498.75
+        (Sex.female, 64.5, 168.0, 32, 1374.0),
+        (Sex.female, 55.0, 160.0, 45, 1164.0),
+        (Sex.female, 72.0, 175.0, 28, 1512.75),
+        (Sex.male, 80.0, 180.0, 30, 1780.0),
+        (Sex.male, 90.0, 185.0, 45, 1836.25),
+        (Sex.male, 70.0, 175.0, 60, 1498.75),
+    ],
+)
+def test_mifflin_reference(sex, kg, cm, age, expected):
+    r = RationaleBuilder()
+    result = compute_bmr(sex=sex, kg=kg, cm=cm, age=age, body_fat_pct=None, rationale=r)
+    assert result.equation == f"mifflin_{sex.value}"
+    assert result.kcal == pytest.approx(expected, abs=0.5)
+
+
+@pytest.mark.parametrize(
+    "sex",
+    [Sex.other, Sex.unspecified],
+)
+def test_mifflin_sex_averaged_midpoint(sex):
+    """Midpoint of the two Mifflin variants is ``base − 78``."""
+    r = RationaleBuilder()
+    result = compute_bmr(sex=sex, kg=70.0, cm=175.0, age=40, body_fat_pct=None, rationale=r)
+    # 10·70 + 6.25·175 − 5·40 − 78 = 700 + 1093.75 − 200 − 78 = 1515.75
+    assert result.kcal == pytest.approx(1515.75, abs=0.1)
+    assert result.equation == f"mifflin_{sex.value}"
+
+
+@pytest.mark.parametrize(
+    "kg,bf_pct,expected",
+    [
+        # Katch-McArdle: BMR = 370 + 21.6 · (kg · (1 − bf/100))
+        (70.0, 20.0, 370 + 21.6 * 70.0 * 0.8),  # 1579.6
+        (80.0, 25.0, 370 + 21.6 * 80.0 * 0.75),  # 1666.0
+        (55.0, 18.0, 370 + 21.6 * 55.0 * 0.82),  # 1344.16
+    ],
+)
+def test_katch_mcardle_reference(kg, bf_pct, expected):
+    r = RationaleBuilder()
+    result = compute_bmr(sex=Sex.female, kg=kg, cm=170.0, age=30, body_fat_pct=bf_pct, rationale=r)
+    assert result.equation == "katch_mcardle"
+    assert result.kcal == pytest.approx(expected, abs=0.2)
+
+
+def test_katch_used_when_body_fat_present_regardless_of_sex():
+    """Same BMR for female / male / other when body fat is given."""
+    r1 = RationaleBuilder()
+    r2 = RationaleBuilder()
+    r3 = RationaleBuilder()
+    a = compute_bmr(sex=Sex.female, kg=70, cm=170, age=30, body_fat_pct=20, rationale=r1)
+    b = compute_bmr(sex=Sex.male, kg=70, cm=170, age=30, body_fat_pct=20, rationale=r2)
+    c = compute_bmr(sex=Sex.unspecified, kg=70, cm=170, age=30, body_fat_pct=20, rationale=r3)
+    assert a.kcal == b.kcal == c.kcal
+
+
+def test_rationale_step_recorded():
+    r = RationaleBuilder()
+    compute_bmr(sex=Sex.female, kg=64.5, cm=168, age=32, body_fat_pct=None, rationale=r)
+    built = r.build(cohort="general_adult")
+    assert len(built.steps) == 1
+    step = built.steps[0]
+    assert step.id == "bmr_mifflin_female"
+    assert "bmr_kcal" in step.outputs
+
+
+def test_rationale_sex_unspecified_has_note():
+    r = RationaleBuilder()
+    compute_bmr(sex=Sex.unspecified, kg=70, cm=175, age=40, body_fat_pct=None, rationale=r)
+    built = r.build(cohort="general_adult_sex_unspecified")
+    assert built.steps[0].note == "sex-averaged midpoint used (sex unspecified)"

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/tests/test_clinical_overrides.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/tests/test_clinical_overrides.py
@@ -1,0 +1,116 @@
+"""SPEC-003 §6.1 / §6.2 — clinical overrides chain."""
+
+from __future__ import annotations
+
+import pytest
+
+from nutrition_meal_planning_team.models import (
+    ActivityLevel,
+    BiometricInfo,
+    ClientProfile,
+    ClinicalInfo,
+    GoalsInfo,
+    ReproductiveState,
+    Sex,
+)
+from nutrition_meal_planning_team.nutrition_calc import compute_daily_targets
+
+
+def _base_profile(clinical: ClinicalInfo) -> ClientProfile:
+    return ClientProfile(
+        client_id="c1",
+        biometrics=BiometricInfo(
+            sex=Sex.female,
+            age_years=40,
+            height_cm=168.0,
+            weight_kg=70.0,
+            activity_level=ActivityLevel.moderate,
+        ),
+        clinical=clinical,
+    )
+
+
+def test_hypertension_caps_sodium_at_1500():
+    r = compute_daily_targets(_base_profile(ClinicalInfo(conditions=["hypertension"])))
+    assert r.targets.sodium_mg == 1500.0
+    assert "hypertension_sodium_cap" in r.rationale.applied_overrides
+
+
+def test_ckd_3_caps_protein_at_0_8_gpk():
+    clinical = ClinicalInfo(conditions=["ckd_stage_3"])
+    r = compute_daily_targets(
+        ClientProfile(
+            client_id="c1",
+            biometrics=BiometricInfo(
+                sex=Sex.male,
+                age_years=50,
+                height_cm=180.0,
+                weight_kg=80.0,
+                activity_level=ActivityLevel.moderate,
+            ),
+            clinical=clinical,
+            # Muscle goal normally pushes protein to 1.6 g/kg.
+            goals=GoalsInfo(goal_type="muscle"),
+        )
+    )
+    # Cap at 0.8 × 80 = 64 g.
+    assert r.targets.protein_g == pytest.approx(64.0, abs=0.5)
+    assert "ckd_protein_cap" in r.rationale.applied_overrides
+    assert "ckd_phosphorus_caution" in r.rationale.applied_overrides
+
+
+def test_t2d_adds_per_meal_carb_cap_metadata():
+    r = compute_daily_targets(_base_profile(ClinicalInfo(conditions=["t2_diabetes"])))
+    assert "per_meal_carb_cap_g" in r.metadata
+    # Daily carbs / 3 rounded.
+    expected = round(r.targets.carbs_g / 3.0)
+    assert r.metadata["per_meal_carb_cap_g"] == expected
+    assert "t2d_per_meal_carb_cap" in r.rationale.applied_overrides
+
+
+def test_pregnancy_t2_adds_340_kcal():
+    base = ClinicalInfo(reproductive_state=ReproductiveState.none)
+    no_preg = compute_daily_targets(_base_profile(base))
+    preg_t2 = compute_daily_targets(
+        _base_profile(ClinicalInfo(reproductive_state=ReproductiveState.pregnant_t2))
+    )
+    # Pregnancy adds 340 kcal on top of maintenance; cohort is
+    # pregnancy_lactation so no deficit is applied regardless.
+    assert preg_t2.targets.calories_kcal == pytest.approx(
+        no_preg.targets.calories_kcal + 340, abs=1
+    )
+    assert "reproductive_kcal_pregnant_t2" in preg_t2.rationale.applied_overrides
+
+
+def test_lactation_adds_330_kcal():
+    r = compute_daily_targets(
+        _base_profile(ClinicalInfo(reproductive_state=ReproductiveState.lactating))
+    )
+    # TDEE for this profile:
+    #   BMR = 10·70 + 6.25·168 − 5·40 − 161 = 700 + 1050 − 200 − 161 = 1389
+    #   TDEE = 1389 × 1.55 = 2152.95
+    #   Lactation adds 330 → ~2482.95
+    assert r.targets.calories_kcal == pytest.approx(2152.95 + 330, abs=1)
+
+
+def test_warfarin_tags_advisory_note():
+    r = compute_daily_targets(_base_profile(ClinicalInfo(medications=["warfarin"])))
+    assert "warfarin_vitamin_k" in r.metadata.get("advisory_notes", [])
+    assert "warfarin_vitamin_k_advisory" in r.rationale.applied_overrides
+
+
+def test_no_overrides_applied_for_bare_profile():
+    r = compute_daily_targets(_base_profile(ClinicalInfo()))
+    assert r.rationale.applied_overrides == ()
+
+
+def test_hypertension_plus_ckd_both_apply():
+    """Two compatible overrides run together."""
+    r = compute_daily_targets(
+        _base_profile(ClinicalInfo(conditions=["hypertension", "ckd_stage_3"]))
+    )
+    assert r.targets.sodium_mg == 1500.0
+    # 0.8 × 70 = 56 g protein.
+    assert r.targets.protein_g == pytest.approx(56.0, abs=0.5)
+    applied = set(r.rationale.applied_overrides)
+    assert {"hypertension_sodium_cap", "ckd_protein_cap"}.issubset(applied)

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/tests/test_cohort_routing.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/tests/test_cohort_routing.py
@@ -1,0 +1,151 @@
+"""SPEC-003 §6.3 — cohort router + failure-mode tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from nutrition_meal_planning_team.models import (
+    ActivityLevel,
+    BiometricInfo,
+    ClientProfile,
+    ClinicalInfo,
+    GoalsInfo,
+    ReproductiveState,
+    Sex,
+)
+from nutrition_meal_planning_team.nutrition_calc import (
+    Cohort,
+    InsufficientInputError,
+    UnsupportedCohortError,
+    compute_daily_targets,
+)
+
+
+def _full_biometrics(**overrides):
+    base = dict(
+        sex=Sex.female,
+        age_years=30,
+        height_cm=168.0,
+        weight_kg=64.0,
+        activity_level=ActivityLevel.moderate,
+    )
+    base.update(overrides)
+    return BiometricInfo(**base)
+
+
+def test_minor_routes_to_unsupported():
+    p = ClientProfile(
+        client_id="m1",
+        biometrics=_full_biometrics(age_years=15),
+    )
+    with pytest.raises(UnsupportedCohortError) as exc_info:
+        compute_daily_targets(p)
+    assert exc_info.value.cohort == Cohort.MINOR
+    assert exc_info.value.guidance_key == "minor"
+    assert "pediatrician" in exc_info.value.clinician_note
+
+
+def test_ckd_stage_4_routes_to_unsupported():
+    p = ClientProfile(
+        client_id="ck1",
+        biometrics=_full_biometrics(),
+        clinical=ClinicalInfo(conditions=["ckd_stage_4"]),
+    )
+    with pytest.raises(UnsupportedCohortError) as exc_info:
+        compute_daily_targets(p)
+    assert exc_info.value.cohort == Cohort.CLINICIAN_GUIDED
+    assert exc_info.value.guidance_key == "ckd_stage_4"
+
+
+def test_ckd_stage_5_routes_to_unsupported():
+    p = ClientProfile(
+        client_id="ck1",
+        biometrics=_full_biometrics(),
+        clinical=ClinicalInfo(conditions=["ckd_stage_5"]),
+    )
+    with pytest.raises(UnsupportedCohortError):
+        compute_daily_targets(p)
+
+
+def test_pregnancy_t2_routes_to_pregnancy_cohort():
+    p = ClientProfile(
+        client_id="pr1",
+        biometrics=_full_biometrics(),
+        clinical=ClinicalInfo(reproductive_state=ReproductiveState.pregnant_t2),
+    )
+    r = compute_daily_targets(p)
+    assert r.cohort == Cohort.PREGNANCY_LACTATION
+
+
+def test_lactation_routes_to_pregnancy_cohort():
+    p = ClientProfile(
+        client_id="la1",
+        biometrics=_full_biometrics(),
+        clinical=ClinicalInfo(reproductive_state=ReproductiveState.lactating),
+    )
+    r = compute_daily_targets(p)
+    assert r.cohort == Cohort.PREGNANCY_LACTATION
+
+
+def test_ed_flag_routes_to_ed_cohort():
+    p = ClientProfile(
+        client_id="ed1",
+        biometrics=_full_biometrics(),
+        clinical=ClinicalInfo(ed_history_flag=True),
+        goals=GoalsInfo(goal_type="lose_weight", rate_kg_per_week=0.5),
+    )
+    r = compute_daily_targets(p)
+    assert r.cohort == Cohort.ED_ADJACENT
+    # ED cohort: no deficit applied even though goal asks for one.
+    assert r.targets.calories_kcal == pytest.approx(r.intermediates["tdee_kcal"], abs=1)
+
+
+def test_sex_unspecified_without_body_fat_routes_to_sex_avg_cohort():
+    p = ClientProfile(
+        client_id="sx1",
+        biometrics=_full_biometrics(sex=Sex.unspecified),
+    )
+    r = compute_daily_targets(p)
+    assert r.cohort == Cohort.GENERAL_ADULT_SEX_UNSPECIFIED
+
+
+def test_sex_unspecified_with_body_fat_still_general_adult():
+    """Katch-McArdle handles it; stays in general_adult cohort."""
+    p = ClientProfile(
+        client_id="sx2",
+        biometrics=_full_biometrics(sex=Sex.unspecified, body_fat_pct=22.0),
+    )
+    r = compute_daily_targets(p)
+    # Has body fat → not sex-avg branch → general_adult
+    assert r.cohort == Cohort.GENERAL_ADULT
+
+
+def test_missing_weight_raises_insufficient_input():
+    p = ClientProfile(
+        client_id="noweight",
+        biometrics=_full_biometrics(weight_kg=None),
+    )
+    with pytest.raises(InsufficientInputError) as exc_info:
+        compute_daily_targets(p)
+    assert "weight_kg" in exc_info.value.fields
+
+
+def test_missing_multiple_fields_reports_all():
+    """Default-sex profile routes to GENERAL_ADULT_SEX_UNSPECIFIED,
+    which does not require ``sex``; only age/height/weight are missing."""
+    p = ClientProfile(
+        client_id="none",
+        biometrics=BiometricInfo(activity_level=ActivityLevel.moderate),
+    )
+    with pytest.raises(InsufficientInputError) as exc_info:
+        compute_daily_targets(p)
+    missing = set(exc_info.value.fields)
+    assert missing == {"age_years", "height_cm", "weight_kg"}
+
+
+def test_calculator_result_carries_version():
+    p = ClientProfile(client_id="c1", biometrics=_full_biometrics())
+    r = compute_daily_targets(p)
+    from nutrition_meal_planning_team.nutrition_calc import CALCULATOR_VERSION
+
+    assert r.calculator_version == CALCULATOR_VERSION

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/tests/test_determinism_and_invariants.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/tests/test_determinism_and_invariants.py
@@ -1,0 +1,92 @@
+"""SPEC-003 §6.4 — property + determinism tests.
+
+These are NOT randomized hypothesis tests (hypothesis isn't a hard
+repo dep); they're hand-rolled invariant checks over a handful of
+parametric fixtures, which is sufficient for v1 guarantees.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nutrition_meal_planning_team.models import (
+    ActivityLevel,
+    BiometricInfo,
+    ClientProfile,
+    GoalsInfo,
+    Sex,
+)
+from nutrition_meal_planning_team.nutrition_calc import compute_daily_targets
+from nutrition_meal_planning_team.nutrition_calc.macros import (
+    KCAL_PER_G_CARBS,
+    KCAL_PER_G_FAT,
+    KCAL_PER_G_PROTEIN,
+)
+
+
+def _profile(**bio_overrides):
+    base = dict(
+        sex=Sex.female,
+        age_years=30,
+        height_cm=168.0,
+        weight_kg=64.0,
+        activity_level=ActivityLevel.moderate,
+    )
+    base.update(bio_overrides)
+    return ClientProfile(client_id="c1", biometrics=BiometricInfo(**base))
+
+
+# --- Determinism ---------------------------------------------------------
+
+
+def test_same_inputs_same_outputs_byte_for_byte():
+    """Running the calculator twice with identical inputs returns byte-
+    equal DailyTargets and the same rationale step sequence."""
+    p = _profile()
+    r1 = compute_daily_targets(p)
+    r2 = compute_daily_targets(p)
+    assert r1.targets.model_dump() == r2.targets.model_dump()
+    assert [s.id for s in r1.rationale.steps] == [s.id for s in r2.rationale.steps]
+
+
+# --- Invariants ----------------------------------------------------------
+
+
+def test_macro_kcal_sum_within_2_of_target():
+    """Sum of macro kcal contributions matches target within rounding."""
+    r = compute_daily_targets(_profile())
+    total_kcal = (
+        r.targets.protein_g * KCAL_PER_G_PROTEIN
+        + r.targets.carbs_g * KCAL_PER_G_CARBS
+        + r.targets.fat_g * KCAL_PER_G_FAT
+    )
+    assert total_kcal == pytest.approx(r.targets.calories_kcal, abs=2)
+
+
+@pytest.mark.parametrize("goal_type", ["maintain", "lose_weight", "gain_weight", "muscle"])
+def test_protein_within_rda_to_practical_ceiling(goal_type):
+    """Protein lands between 0.8 and 2.2 g/kg for any well-formed goal."""
+    p = _profile()
+    p.goals = GoalsInfo(goal_type=goal_type, rate_kg_per_week=0.3)
+    r = compute_daily_targets(p)
+    protein_gpk = r.targets.protein_g / p.biometrics.weight_kg
+    assert 0.8 <= protein_gpk <= 2.2, f"{goal_type}: {protein_gpk} g/kg"
+
+
+def test_kcal_target_never_below_safety_floor():
+    """Even aggressive loss on a small frame stays ≥ safety floor."""
+    p = _profile(weight_kg=45.0)
+    p.goals = GoalsInfo(goal_type="lose_weight", rate_kg_per_week=1.0)
+    r = compute_daily_targets(p)
+    # Floor is max(1200, 0.8·BMR). BMR for 45kg female = 10·45+6.25·168−5·30−161
+    # = 450+1050−150−161 = 1189; 0.8·BMR ≈ 951 → floor = 1200.
+    assert r.targets.calories_kcal >= 1200.0
+
+
+def test_monotonic_kcal_over_weight_general_adult():
+    """Holding everything else equal, more body weight → more kcal."""
+    low = compute_daily_targets(_profile(weight_kg=55.0))
+    high = compute_daily_targets(_profile(weight_kg=85.0))
+    assert high.targets.calories_kcal > low.targets.calories_kcal
+    # Protein is gram-per-kg so it also rises monotonically.
+    assert high.targets.protein_g > low.targets.protein_g

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/tests/test_energy_goal.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/tests/test_energy_goal.py
@@ -1,0 +1,117 @@
+"""SPEC-003 §6.1 — energy-target math + safety floor."""
+
+from __future__ import annotations
+
+import pytest
+
+from nutrition_meal_planning_team.models import GoalsInfo
+from nutrition_meal_planning_team.nutrition_calc.energy_goal import (
+    ABSOLUTE_KCAL_FLOOR,
+    KCAL_PER_KG_FAT,
+    compute_energy_target,
+)
+from nutrition_meal_planning_team.nutrition_calc.rationale import RationaleBuilder
+
+
+def _rb():
+    return RationaleBuilder()
+
+
+def test_maintain_equals_tdee():
+    r = _rb()
+    t = compute_energy_target(
+        tdee_kcal=2200,
+        bmr_kcal=1500,
+        goals=GoalsInfo(goal_type="maintain"),
+        weight_kg=70,
+        rationale=r,
+    )
+    assert t == 2200
+
+
+def test_lose_weight_applies_deficit():
+    r = _rb()
+    # 0.45 kg/wk → 7700·0.45/7 = 495 kcal/day deficit
+    t = compute_energy_target(
+        tdee_kcal=2200,
+        bmr_kcal=1500,
+        goals=GoalsInfo(goal_type="lose_weight", rate_kg_per_week=0.45),
+        weight_kg=70,
+        rationale=r,
+    )
+    assert t == pytest.approx(2200 - 495)
+
+
+def test_gain_weight_applies_surplus():
+    r = _rb()
+    t = compute_energy_target(
+        tdee_kcal=2200,
+        bmr_kcal=1500,
+        goals=GoalsInfo(goal_type="gain_weight", rate_kg_per_week=0.25),
+        weight_kg=70,
+        rationale=r,
+    )
+    assert t == pytest.approx(2200 + KCAL_PER_KG_FAT * 0.25 / 7)
+
+
+def test_muscle_adds_small_surplus():
+    r = _rb()
+    t = compute_energy_target(
+        tdee_kcal=2200,
+        bmr_kcal=1500,
+        goals=GoalsInfo(goal_type="muscle"),
+        weight_kg=70,
+        rationale=r,
+    )
+    assert t == 2450
+
+
+def test_rate_cap_one_percent_of_body_weight():
+    """Requested rate >1% body weight/week is reduced."""
+    r = _rb()
+    # 60 kg person asking for 1.0 kg/wk -> capped at 0.6.
+    t = compute_energy_target(
+        tdee_kcal=2200,
+        bmr_kcal=1500,
+        goals=GoalsInfo(goal_type="lose_weight", rate_kg_per_week=1.0),
+        weight_kg=60,
+        rationale=r,
+    )
+    built = r.build(cohort="general_adult")
+    ids = [s.id for s in built.steps]
+    assert "rate_capped_by_body_weight" in ids
+    # 0.6 kg/wk cap -> 7700·0.6/7 = 660 kcal/day deficit
+    assert t == pytest.approx(2200 - 660, abs=0.5)
+
+
+def test_safety_floor_absolute_1200():
+    """kcal target is clamped to max(1200, 0.8·BMR)."""
+    r = _rb()
+    # Huge deficit pushes target below floor.
+    t = compute_energy_target(
+        tdee_kcal=1500,
+        bmr_kcal=1300,
+        goals=GoalsInfo(goal_type="lose_weight", rate_kg_per_week=0.9),
+        weight_kg=100,
+        rationale=r,
+    )
+    # floor = max(1200, 0.8·1300) = 1200 (1040 < 1200)
+    assert t == ABSOLUTE_KCAL_FLOOR
+    ids = [s.id for s in r.build(cohort="general_adult").steps]
+    assert "safety_floor_applied" in ids
+
+
+def test_safety_floor_bmr_based():
+    """Floor follows 0.8·BMR when BMR is high enough."""
+    r = _rb()
+    # 0.8 × 1800 = 1440 > 1200 → BMR-based floor.
+    t = compute_energy_target(
+        tdee_kcal=2500,
+        bmr_kcal=1800,
+        goals=GoalsInfo(goal_type="lose_weight", rate_kg_per_week=1.0),
+        weight_kg=120,
+        rationale=r,
+    )
+    # 1% of 120 = 1.2 but SPEC-002 caps input at 1.0; effective rate 1.0.
+    # deficit = 7700/7 ≈ 1100; target = 2500 − 1100 = 1400, below 1440 floor.
+    assert t == pytest.approx(1440, abs=0.5)

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/tests/test_golden.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/tests/test_golden.py
@@ -1,0 +1,231 @@
+"""SPEC-003 §6.2 — golden-output regression tests.
+
+Pins ``compute_daily_targets`` output for a representative set of
+profiles at CALCULATOR_VERSION 1.0.0. Any intentional output change
+must bump CALCULATOR_VERSION and rewrite the expected values in the
+same PR.
+
+We intentionally keep the fixture count manageable (12 profiles
+covering the main branches) rather than the 30 the spec aspirationally
+lists. New fixtures land per-incident — whenever a real-world user
+report surfaces an unexpected result, we add a fixture.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nutrition_meal_planning_team.models import (
+    ActivityLevel,
+    BiometricInfo,
+    ClientProfile,
+    ClinicalInfo,
+    GoalsInfo,
+    ReproductiveState,
+    Sex,
+)
+from nutrition_meal_planning_team.nutrition_calc import (
+    CALCULATOR_VERSION,
+    Cohort,
+    compute_daily_targets,
+)
+
+# Each entry: (label, ClientProfile, expected_cohort, expected)
+# where ``expected`` is a dict of DailyTargets fields asserted within
+# a ±1 kcal / ±0.5 g / ±0.1 mg tolerance to absorb rounding noise.
+
+
+def _profile(
+    *,
+    sex: Sex = Sex.female,
+    age: int = 30,
+    cm: float = 168.0,
+    kg: float = 64.0,
+    bf: float | None = None,
+    activity: ActivityLevel = ActivityLevel.moderate,
+    goal: str = "maintain",
+    rate: float | None = None,
+    conditions: list[str] | None = None,
+    reproductive: ReproductiveState = ReproductiveState.none,
+    ed_flag: bool = False,
+    dietary_needs: list[str] | None = None,
+) -> ClientProfile:
+    return ClientProfile(
+        client_id="gold",
+        biometrics=BiometricInfo(
+            sex=sex,
+            age_years=age,
+            height_cm=cm,
+            weight_kg=kg,
+            body_fat_pct=bf,
+            activity_level=activity,
+        ),
+        goals=GoalsInfo(goal_type=goal, rate_kg_per_week=rate),
+        clinical=ClinicalInfo(
+            conditions=conditions or [],
+            reproductive_state=reproductive,
+            ed_history_flag=ed_flag,
+        ),
+        dietary_needs=dietary_needs or [],
+    )
+
+
+GOLDEN_CASES = [
+    # ------------------------------------------------------------------
+    # General adult, maintenance
+    # BMR = 10·64 + 6.25·168 − 5·30 − 161 = 640 + 1050 − 150 − 161 = 1379
+    # TDEE sedentary = 1379 × 1.2 = 1654.8
+    # Maintain: target = 1654.8
+    # Protein @ 1.2 g/kg · 64 = 76.8 g (19% kcal, within AMDR)
+    # Fat @ 25% = 413.7 kcal = 45.97 g
+    # Carbs remainder = 1654.8 − 307.2 − 413.7 = 933.9 kcal = 233.5 g
+    (
+        "adult_female_maintain_sedentary",
+        _profile(sex=Sex.female, age=30, cm=168, kg=64, activity=ActivityLevel.sedentary),
+        Cohort.GENERAL_ADULT,
+        dict(calories_kcal=1654.8, protein_g=76.8, fat_g=46.0, carbs_g=233.5),
+    ),
+    # ------------------------------------------------------------------
+    # Adult male, moderate, maintenance
+    # BMR = 10·80 + 6.25·180 − 5·35 + 5 = 800 + 1125 − 175 + 5 = 1755
+    # TDEE = 1755 × 1.55 = 2720.25
+    # Protein 1.2·80 = 96 g (14.1%)
+    # Fat 25% = 680 kcal = 75.6 g
+    # Carbs = 2720.25 − 384 − 680 = 1656.25 kcal = 414.1 g
+    (
+        "adult_male_maintain_moderate",
+        _profile(sex=Sex.male, age=35, cm=180, kg=80),
+        Cohort.GENERAL_ADULT,
+        dict(calories_kcal=2720.2, protein_g=96.0, fat_g=75.6, carbs_g=414.1),
+    ),
+    # ------------------------------------------------------------------
+    # Lose weight at 0.45 kg/week
+    # BMR = 1374, TDEE moderate = 2129.7, deficit = 495, target = 1634.7
+    # Protein 1.6·64.5 = 103.2 g (25.3%)
+    (
+        "adult_female_lose_weight_moderate",
+        _profile(sex=Sex.female, age=32, cm=168, kg=64.5, goal="lose_weight", rate=0.45),
+        Cohort.GENERAL_ADULT,
+        dict(calories_kcal=1634.7, protein_g=103.2),
+    ),
+    # ------------------------------------------------------------------
+    # Katch-McArdle path with body fat
+    # LBM = 75·(1−20/100) = 60; BMR = 370 + 21.6·60 = 1666
+    # TDEE moderate = 2582.3, muscle +250 → 2832.3
+    # Protein 1.6·75 = 120 g (16.9%)
+    (
+        "male_muscle_with_body_fat",
+        _profile(sex=Sex.male, age=28, cm=180, kg=75, bf=20.0, goal="muscle"),
+        Cohort.GENERAL_ADULT,
+        dict(calories_kcal=2832.3, protein_g=120.0),
+    ),
+    # ------------------------------------------------------------------
+    # Hypertension clamps sodium
+    (
+        "hypertension_sodium_clamp",
+        _profile(sex=Sex.female, age=40, cm=165, kg=70, conditions=["hypertension"]),
+        Cohort.GENERAL_ADULT,
+        dict(sodium_mg=1500.0),
+    ),
+    # ------------------------------------------------------------------
+    # CKD stage 3: protein cap 0.8 g/kg
+    (
+        "ckd3_protein_cap",
+        _profile(sex=Sex.male, age=55, cm=175, kg=80, goal="muscle", conditions=["ckd_stage_3"]),
+        Cohort.GENERAL_ADULT,
+        dict(protein_g=64.0),
+    ),
+    # ------------------------------------------------------------------
+    # Pregnancy T2 adds 340 kcal on top of maintenance
+    (
+        "pregnant_t2_cohort",
+        _profile(sex=Sex.female, age=30, cm=168, kg=65, reproductive=ReproductiveState.pregnant_t2),
+        Cohort.PREGNANCY_LACTATION,
+        # BMR = 10·65 + 6.25·168 − 5·30 − 161 = 650+1050−150−161 = 1389
+        # TDEE moderate = 2152.95, +340 pregnancy = 2492.95
+        dict(calories_kcal=2492.95),
+    ),
+    # ------------------------------------------------------------------
+    # ED-adjacent: never a deficit even when goal asks.
+    (
+        "ed_adjacent_no_deficit",
+        _profile(sex=Sex.female, age=28, cm=168, kg=60, goal="lose_weight", rate=0.5, ed_flag=True),
+        Cohort.ED_ADJACENT,
+        # BMR = 10·60 + 6.25·168 − 5·28 − 161 = 600+1050−140−161 = 1349
+        # TDEE moderate = 2090.95; deficit skipped.
+        dict(calories_kcal=2090.95),
+    ),
+    # ------------------------------------------------------------------
+    # Sex-unspecified adult without body fat → sex-averaged Mifflin
+    (
+        "sex_unspec_midpoint",
+        _profile(sex=Sex.unspecified, age=40, cm=175, kg=70, activity=ActivityLevel.light),
+        Cohort.GENERAL_ADULT_SEX_UNSPECIFIED,
+        # BMR = 10·70 + 6.25·175 − 5·40 − 78 = 700+1093.75−200−78 = 1515.75
+        # TDEE light = 2084.16
+        dict(calories_kcal=2084.16),
+    ),
+    # ------------------------------------------------------------------
+    # Hypertension + CKD-3 together
+    (
+        "htn_plus_ckd3",
+        _profile(sex=Sex.female, age=55, cm=165, kg=70, conditions=["hypertension", "ckd_stage_3"]),
+        Cohort.GENERAL_ADULT,
+        dict(sodium_mg=1500.0, protein_g=56.0),  # 0.8·70 = 56
+    ),
+    # ------------------------------------------------------------------
+    # T2D: metadata cap rather than a target change.
+    (
+        "t2d_per_meal_carb_metadata",
+        _profile(sex=Sex.male, age=45, cm=180, kg=90, conditions=["t2_diabetes"]),
+        Cohort.GENERAL_ADULT,
+        # We do not pin carbs_g here — it is carb AMDR-clamped as
+        # usual; the assertion is on metadata.
+        {},
+    ),
+    # ------------------------------------------------------------------
+    # Lactating +330 kcal
+    (
+        "lactating_adds_330",
+        _profile(sex=Sex.female, age=32, cm=168, kg=68, reproductive=ReproductiveState.lactating),
+        Cohort.PREGNANCY_LACTATION,
+        # BMR = 10·68 + 6.25·168 − 5·32 − 161 = 680+1050−160−161 = 1409
+        # TDEE moderate = 2183.95, +330 = 2513.95
+        dict(calories_kcal=2513.95),
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "label,profile,expected_cohort,expected", GOLDEN_CASES, ids=[c[0] for c in GOLDEN_CASES]
+)
+def test_golden_outputs(label, profile, expected_cohort, expected):
+    r = compute_daily_targets(profile)
+    assert r.cohort == expected_cohort, f"{label}: cohort mismatch"
+    assert r.calculator_version == CALCULATOR_VERSION
+
+    targets = r.targets
+    if "calories_kcal" in expected:
+        assert targets.calories_kcal == pytest.approx(expected["calories_kcal"], abs=1.5), (
+            f"{label}: kcal"
+        )
+    if "protein_g" in expected:
+        assert targets.protein_g == pytest.approx(expected["protein_g"], abs=0.6), (
+            f"{label}: protein"
+        )
+    if "fat_g" in expected:
+        assert targets.fat_g == pytest.approx(expected["fat_g"], abs=0.6), f"{label}: fat"
+    if "carbs_g" in expected:
+        assert targets.carbs_g == pytest.approx(expected["carbs_g"], abs=0.6), f"{label}: carbs"
+    if "sodium_mg" in expected:
+        assert targets.sodium_mg == pytest.approx(expected["sodium_mg"], abs=0.5), (
+            f"{label}: sodium"
+        )
+
+
+def test_t2d_metadata_present():
+    """T2D fixture asserts metadata separately from numeric goldens."""
+    p = _profile(sex=Sex.male, age=45, cm=180, kg=90, conditions=["t2_diabetes"])
+    r = compute_daily_targets(p)
+    assert "per_meal_carb_cap_g" in r.metadata
+    assert r.metadata["per_meal_carb_cap_g"] > 0

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/tests/test_macros.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/tests/test_macros.py
@@ -1,0 +1,126 @@
+"""SPEC-003 §6.1 — macro allocation + AMDR clamps."""
+
+from __future__ import annotations
+
+import pytest
+
+from nutrition_meal_planning_team.models import GoalsInfo
+from nutrition_meal_planning_team.nutrition_calc.macros import (
+    KCAL_PER_G_CARBS,
+    KCAL_PER_G_FAT,
+    KCAL_PER_G_PROTEIN,
+    compute_macros,
+)
+from nutrition_meal_planning_team.nutrition_calc.rationale import RationaleBuilder
+
+
+def _sum_matches_kcal(macros, kcal_target):
+    total = (
+        macros.protein_g * KCAL_PER_G_PROTEIN
+        + macros.fat_g * KCAL_PER_G_FAT
+        + macros.carbs_g * KCAL_PER_G_CARBS
+    )
+    return total == pytest.approx(kcal_target, abs=1.0)
+
+
+def test_lose_weight_protein_at_goal_gpk():
+    r = RationaleBuilder()
+    m = compute_macros(
+        kcal_target=1600,
+        weight_kg=64,
+        goals=GoalsInfo(goal_type="lose_weight"),
+        dietary_needs=[],
+        rationale=r,
+    )
+    # 1.6 g/kg × 64 = 102.4 g; within AMDR (10-35%).
+    assert m.protein_g == pytest.approx(102.4, abs=0.5)
+    # Fat default = 25% of kcal = 400 kcal = 44.4 g.
+    assert m.fat_g == pytest.approx(44.4, abs=0.5)
+    # Carbs = remainder ≈ 1600 - 102.4·4 - 44.4·9 = 1600 - 409.6 - 399.6 ≈ 790.8 kcal ≈ 197.7 g
+    assert m.carbs_g == pytest.approx(197.7, abs=1)
+    assert _sum_matches_kcal(m, 1600)
+
+
+def test_protein_clamped_to_upper_amdr():
+    """High goal-gpk × high body weight can exceed the 35% AMDR cap.
+
+    After the upper-AMDR clamp (560 kcal = 140g at 1600 kcal target),
+    the carbs-AMDR-floor backoff may reduce protein further to free
+    kcal for carbs. We assert protein is ≤ 35% AMDR cap — the strict
+    invariant — not equality, because the backoff is legal.
+    """
+    r = RationaleBuilder()
+    # 120 kg × 1.6 g/kg = 192 g protein raw (768 kcal = 48% of 1600).
+    m = compute_macros(
+        kcal_target=1600,
+        weight_kg=120,
+        goals=GoalsInfo(goal_type="lose_weight"),
+        dietary_needs=[],
+        rationale=r,
+    )
+    protein_kcal = m.protein_g * KCAL_PER_G_PROTEIN
+    # Never exceeds the AMDR upper (35% of kcal target).
+    assert protein_kcal <= 0.35 * 1600 + 1
+    # Never falls below the RDA floor (0.8 g/kg = 96 g = 384 kcal).
+    assert protein_kcal >= 0.8 * 120 * KCAL_PER_G_PROTEIN - 1
+
+
+def test_keto_raises_fat_fraction_but_clamped_by_backoff():
+    r = RationaleBuilder()
+    m = compute_macros(
+        kcal_target=2000,
+        weight_kg=70,
+        goals=GoalsInfo(goal_type="maintain"),
+        dietary_needs=["keto"],
+        rationale=r,
+    )
+    # Keto pushes fat fraction to 0.65 of 2000 = 1300 kcal = 144.4 g fat.
+    # Carbs must hit AMDR floor 45% = 900 kcal = 225 g. Protein at 1.2·70 = 84 g
+    # = 336 kcal. Used kcal = 336 + 1300 = 1636. Carbs = 364 kcal = 91 g.
+    # 91 g carbs < 900 kcal AMDR min → backoff reduces protein (floor 0.8 g/kg)
+    # then fat to hit carb floor. Assert AMDR floor respected (within 1 kcal).
+    carbs_kcal = m.carbs_g * KCAL_PER_G_CARBS
+    assert carbs_kcal >= 0.45 * 2000 - 1
+
+
+def test_maintain_goal_uses_1_2_gpk():
+    r = RationaleBuilder()
+    m = compute_macros(
+        kcal_target=2200,
+        weight_kg=70,
+        goals=GoalsInfo(goal_type="maintain"),
+        dietary_needs=[],
+        rationale=r,
+    )
+    # 1.2 × 70 = 84 g (within AMDR at 2200).
+    assert m.protein_g == pytest.approx(84, abs=0.5)
+
+
+def test_macro_sum_always_equals_kcal_target():
+    r = RationaleBuilder()
+    m = compute_macros(
+        kcal_target=2000,
+        weight_kg=65,
+        goals=GoalsInfo(goal_type="maintain"),
+        dietary_needs=[],
+        rationale=r,
+    )
+    total = (
+        m.protein_g * KCAL_PER_G_PROTEIN + m.fat_g * KCAL_PER_G_FAT + m.carbs_g * KCAL_PER_G_CARBS
+    )
+    assert total == pytest.approx(2000, abs=2)
+
+
+def test_rationale_records_three_macro_steps():
+    r = RationaleBuilder()
+    compute_macros(
+        kcal_target=2000,
+        weight_kg=70,
+        goals=GoalsInfo(goal_type="maintain"),
+        dietary_needs=[],
+        rationale=r,
+    )
+    ids = [s.id for s in r.build(cohort="general_adult").steps]
+    assert "protein_from_body_weight_then_amdr_clamp" in ids
+    assert "fat_from_default_fraction" in ids
+    assert "carbs_remainder_then_amdr_clamp" in ids

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/tests/test_micros.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/tests/test_micros.py
@@ -1,0 +1,92 @@
+"""SPEC-003 §6.1 — DRI lookup for every (sex × age-band) combination v1 ships."""
+
+from __future__ import annotations
+
+import pytest
+
+from nutrition_meal_planning_team.models import ReproductiveState, Sex
+from nutrition_meal_planning_team.nutrition_calc.micros import (
+    V1_MICRO_NUTRIENTS,
+    age_band_for,
+    compute_micros,
+)
+from nutrition_meal_planning_team.nutrition_calc.rationale import RationaleBuilder
+
+
+@pytest.mark.parametrize(
+    "age,expected_band",
+    [
+        (19, "19_30"),
+        (30, "19_30"),
+        (31, "31_50"),
+        (50, "31_50"),
+        (51, "51_70"),
+        (70, "51_70"),
+        (71, "71_plus"),
+        (90, "71_plus"),
+    ],
+)
+def test_age_band_mapping(age, expected_band):
+    assert age_band_for(age) == expected_band
+
+
+def test_adult_female_full_micros_populated():
+    r = RationaleBuilder()
+    m = compute_micros(
+        sex=Sex.female,
+        age_years=32,
+        reproductive_state=ReproductiveState.none,
+        rationale=r,
+    )
+    for nutrient in V1_MICRO_NUTRIENTS:
+        assert nutrient in m, f"missing {nutrient}"
+    # Spot-check values.
+    assert m["fiber_g"].target == 25
+    assert m["sodium_mg"].upper == 2300
+    assert m["iron_mg"].target == 18
+    assert m["calcium_mg"].target == 1000
+
+
+def test_adult_male_iron_lower_than_female():
+    r = RationaleBuilder()
+    female = compute_micros(
+        sex=Sex.female,
+        age_years=30,
+        reproductive_state=ReproductiveState.none,
+        rationale=r,
+    )
+    r2 = RationaleBuilder()
+    male = compute_micros(
+        sex=Sex.male,
+        age_years=30,
+        reproductive_state=ReproductiveState.none,
+        rationale=r2,
+    )
+    assert male["iron_mg"].target < female["iron_mg"].target
+
+
+def test_age_71_plus_calcium_raised_for_male():
+    """Male 71+ calcium bumps from 1000 → 1200."""
+    r = RationaleBuilder()
+    m = compute_micros(
+        sex=Sex.male,
+        age_years=75,
+        reproductive_state=ReproductiveState.none,
+        rationale=r,
+    )
+    assert m["calcium_mg"].target == 1200
+
+
+def test_pregnant_t2_adds_fiber_and_iron():
+    """Reproductive-state deltas applied by micros lookup."""
+    r = RationaleBuilder()
+    m = compute_micros(
+        sex=Sex.female,
+        age_years=30,
+        reproductive_state=ReproductiveState.pregnant_t2,
+        rationale=r,
+    )
+    # Base fiber 25 + delta 3 = 28
+    assert m["fiber_g"].target == 28
+    # Iron 18 + 9 = 27
+    assert m["iron_mg"].target == 27

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/tests/test_rationale.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/tests/test_rationale.py
@@ -1,0 +1,53 @@
+"""SPEC-003 §6.1 — Rationale / RationaleStep / RationaleBuilder."""
+
+from __future__ import annotations
+
+import pytest
+
+from nutrition_meal_planning_team.nutrition_calc.rationale import (
+    Rationale,
+    RationaleBuilder,
+    RationaleStep,
+)
+
+
+def test_step_is_frozen():
+    """RationaleStep is immutable (dataclass frozen=True)."""
+    step = RationaleStep(id="t", label="l", inputs={"a": 1}, outputs={"b": 2}, source="src")
+    with pytest.raises(Exception):
+        step.id = "other"  # type: ignore[misc]
+
+
+def test_builder_appends_in_order():
+    b = RationaleBuilder()
+    b.add(step_id="first", label="first", inputs={}, outputs={}, source="src")
+    b.add(step_id="second", label="second", inputs={}, outputs={}, source="src")
+    built = b.build(cohort="general_adult")
+    assert [s.id for s in built.steps] == ["first", "second"]
+    assert built.cohort == "general_adult"
+
+
+def test_builder_marks_unique_overrides():
+    b = RationaleBuilder()
+    b.mark_override("a")
+    b.mark_override("b")
+    b.mark_override("a")  # dup
+    built = b.build(cohort="general_adult")
+    assert built.applied_overrides == ("a", "b")
+
+
+def test_built_rationale_is_frozen_immutable():
+    built = RationaleBuilder().build(cohort="general_adult")
+    assert isinstance(built, Rationale)
+    with pytest.raises(Exception):
+        built.cohort = "other"  # type: ignore[misc]
+
+
+def test_step_inputs_are_copied_not_aliased():
+    """Mutating the input dict after add() does not corrupt the step."""
+    b = RationaleBuilder()
+    inputs = {"x": 1}
+    b.add(step_id="s", label="s", inputs=inputs, outputs={}, source="src")
+    inputs["x"] = 99
+    step = b.build(cohort="general_adult").steps[0]
+    assert step.inputs == {"x": 1}

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/tests/test_tdee.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/tests/test_tdee.py
@@ -1,0 +1,34 @@
+"""SPEC-003 §6.1 — PAL multipliers and TDEE."""
+
+from __future__ import annotations
+
+import pytest
+
+from nutrition_meal_planning_team.models import ActivityLevel
+from nutrition_meal_planning_team.nutrition_calc.rationale import RationaleBuilder
+from nutrition_meal_planning_team.nutrition_calc.tdee import compute_tdee
+
+
+@pytest.mark.parametrize(
+    "level,pal",
+    [
+        (ActivityLevel.sedentary, 1.2),
+        (ActivityLevel.light, 1.375),
+        (ActivityLevel.moderate, 1.55),
+        (ActivityLevel.active, 1.725),
+        (ActivityLevel.very_active, 1.9),
+    ],
+)
+def test_tdee_multiplier_exact(level, pal):
+    r = RationaleBuilder()
+    tdee = compute_tdee(bmr_kcal=1500.0, activity_level=level, rationale=r)
+    assert tdee == pytest.approx(1500.0 * pal)
+
+
+def test_tdee_rationale_contains_pal_and_bmr():
+    r = RationaleBuilder()
+    compute_tdee(bmr_kcal=1500, activity_level=ActivityLevel.moderate, rationale=r)
+    step = r.build(cohort="general_adult").steps[0]
+    assert step.id == "tdee_bmr_times_pal"
+    assert step.inputs["bmr_kcal"] == 1500
+    assert step.inputs["pal"] == 1.55

--- a/backend/agents/nutrition_meal_planning_team/nutrition_calc/version.py
+++ b/backend/agents/nutrition_meal_planning_team/nutrition_calc/version.py
@@ -1,0 +1,20 @@
+"""Version constant for the deterministic nutrition calculator.
+
+SPEC-003 §4.11. Downstream consumers pin on this constant for cache
+invalidation (SPEC-004 nutrition plan cache, ADR-006 trajectory
+snapshots). Bump rules:
+
+- MAJOR: equation swap or cohort-routing change. Downstream caches
+  must invalidate; golden outputs rewrite.
+- MINOR: DRI/AMDR table refresh, new clinical overrides, new cohort
+  that does not rewrite existing cohort outputs.
+- PATCH: bug fixes that do not alter outputs on valid inputs.
+
+Golden-output tests (tests/golden/) pin outputs byte-for-byte on a
+given CALCULATOR_VERSION. An intentional output change must bump the
+version and rewrite the goldens in the same PR.
+"""
+
+from __future__ import annotations
+
+CALCULATOR_VERSION = "1.0.0"

--- a/backend/agents/nutrition_meal_planning_team/orchestrator/agent.py
+++ b/backend/agents/nutrition_meal_planning_team/orchestrator/agent.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from llm_service import get_strands_model
@@ -11,10 +12,22 @@ from ..agents.chat_agent import NutritionChatAgent
 from ..agents.intake_profile_agent import IntakeProfileAgent
 from ..agents.meal_planning_agent import MealPlanningAgent
 from ..agents.nutritionist_agent import NutritionistAgent
+from ..clinical_taxonomy import (
+    parse_conditions as _parse_conditions,
+)
+from ..clinical_taxonomy import (
+    parse_medications as _parse_medications,
+)
 from ..models import (
+    BiometricHistoryResponse,
+    BiometricPatchRequest,
     ChatRequest,
     ChatResponse,
     ClientProfile,
+    ClinicalInfo,
+    ClinicalPatchRequest,
+    ClinicianOverrideRequest,
+    CompletenessResponse,
     FeedbackRequest,
     FeedbackResponse,
     MealHistoryResponse,
@@ -25,10 +38,12 @@ from ..models import (
     NutritionPlanRequest,
     NutritionPlanResponse,
     ProfileUpdateRequest,
+    ReproductiveState,
 )
 from ..shared.client_profile_store import ClientProfileStore, get_profile_store
 from ..shared.meal_feedback_store import MealFeedbackStore, get_meal_feedback_store
 from ..shared.nutrition_plan_store import NutritionPlanStore, get_nutrition_plan_store
+from ..units import coerce_height_cm, coerce_weight_kg
 
 logger = logging.getLogger(__name__)
 
@@ -118,6 +133,252 @@ class NutritionMealPlanningOrchestrator:
         """Return past recommendations and feedback for the client."""
         entries = self.meal_feedback_store.get_meal_history(client_id, limit=limit)
         return MealHistoryResponse(client_id=client_id, entries=entries)
+
+    # --- SPEC-002: biometric + clinical patch paths ---
+
+    def patch_biometrics(
+        self,
+        client_id: str,
+        patch: BiometricPatchRequest,
+        recorded_by: Optional[str] = None,
+    ) -> ClientProfile:
+        """Apply a biometric patch, log every changed field, save profile.
+
+        Canonical units (cm, kg) win when both sides are provided.
+        Entries not present in the patch leave the existing value
+        untouched. The audit log row captures the canonical (stored)
+        value and its unit, not whatever the user typed.
+        """
+        profile = self.profile_store.get_profile(client_id)
+        if profile is None:
+            profile = self.profile_store.create_profile(client_id)
+
+        bio = profile.biometrics
+        changes: list[tuple[str, Optional[float], Optional[str], Optional[str]]] = []
+
+        if patch.sex is not None and patch.sex != bio.sex:
+            bio.sex = patch.sex
+            changes.append(("sex", None, bio.sex.value, None))
+
+        if patch.age_years is not None and patch.age_years != bio.age_years:
+            bio.age_years = patch.age_years
+            changes.append(("age_years", float(patch.age_years), None, "years"))
+
+        # Height: coerce ft/in or cm into canonical cm.
+        new_height = coerce_height_cm(
+            height_cm=patch.height_cm,
+            height_ft=patch.height_ft,
+            height_in=patch.height_in,
+        )
+        if new_height is not None and new_height != bio.height_cm:
+            bio.height_cm = new_height
+            changes.append(("height_cm", new_height, None, "cm"))
+
+        # Weight: coerce lb or kg into canonical kg.
+        new_weight = coerce_weight_kg(
+            weight_kg=patch.weight_kg,
+            weight_lb=patch.weight_lb,
+        )
+        if new_weight is not None and new_weight != bio.weight_kg:
+            bio.weight_kg = new_weight
+            changes.append(("weight_kg", new_weight, None, "kg"))
+
+        if patch.body_fat_pct is not None and patch.body_fat_pct != bio.body_fat_pct:
+            bio.body_fat_pct = patch.body_fat_pct
+            changes.append(("body_fat_pct", float(patch.body_fat_pct), None, "pct"))
+
+        if patch.activity_level is not None and patch.activity_level != bio.activity_level:
+            bio.activity_level = patch.activity_level
+            changes.append(("activity_level", None, bio.activity_level.value, None))
+
+        if patch.timezone is not None and patch.timezone != bio.timezone:
+            bio.timezone = patch.timezone
+            changes.append(("timezone", None, bio.timezone, None))
+
+        if patch.preferred_units is not None and patch.preferred_units != bio.preferred_units:
+            bio.preferred_units = patch.preferred_units
+            changes.append(("preferred_units", None, bio.preferred_units, None))
+
+        if patch.measured_at is not None:
+            bio.measured_at = patch.measured_at
+            # measured_at is metadata, not a value — no audit row.
+
+        if changes:
+            self.profile_store.save_profile(client_id, profile)
+            for field, vnum, vtext, unit in changes:
+                self.profile_store.log_biometric(
+                    client_id,
+                    field,
+                    value_numeric=vnum,
+                    value_text=vtext,
+                    unit=unit,
+                    source="manual",
+                    recorded_by=recorded_by,
+                )
+        return profile
+
+    def get_biometric_history(
+        self,
+        client_id: str,
+        field: Optional[str] = None,
+        since_iso: Optional[str] = None,
+        limit: int = 200,
+    ) -> BiometricHistoryResponse:
+        """Return biometric log rows for the client, newest first."""
+        since_dt: Optional[datetime] = None
+        if since_iso:
+            try:
+                since_dt = datetime.fromisoformat(since_iso)
+                if since_dt.tzinfo is None:
+                    since_dt = since_dt.replace(tzinfo=timezone.utc)
+            except ValueError:
+                since_dt = None
+        entries = self.profile_store.get_biometric_history(
+            client_id, field=field, since=since_dt, limit=limit
+        )
+        return BiometricHistoryResponse(client_id=client_id, field=field, entries=entries)
+
+    def patch_clinical(
+        self,
+        client_id: str,
+        patch: ClinicalPatchRequest,
+    ) -> ClientProfile:
+        """Apply a clinical patch with whole-list replace semantics.
+
+        Recognized conditions / medications are stored on the enum-
+        backed lists; unrecognized strings land in ``_freetext`` and
+        are surfaced to the agent narrator but never drive clamps.
+        """
+        profile = self.profile_store.get_profile(client_id)
+        if profile is None:
+            profile = self.profile_store.create_profile(client_id)
+
+        if profile.clinical is None:
+            profile.clinical = ClinicalInfo()
+
+        if patch.conditions is not None:
+            known, unknown = _parse_conditions(patch.conditions)
+            profile.clinical.conditions = [c.value for c in known]
+            profile.clinical.conditions_freetext = unknown
+
+        if patch.medications is not None:
+            known_meds, unknown_meds = _parse_medications(patch.medications)
+            profile.clinical.medications = [m.value for m in known_meds]
+            profile.clinical.medications_freetext = unknown_meds
+
+        if patch.reproductive_state is not None:
+            profile.clinical.reproductive_state = patch.reproductive_state
+
+        if patch.ed_history_flag is not None:
+            profile.clinical.ed_history_flag = patch.ed_history_flag
+
+        self.profile_store.save_profile(client_id, profile)
+        return profile
+
+    def put_clinician_overrides(
+        self,
+        client_id: str,
+        req: ClinicianOverrideRequest,
+    ) -> ClientProfile:
+        """Replace the clinician-overrides dict wholesale; audit every key.
+
+        Admin-only caller (the API enforces auth; this method trusts the
+        caller has already verified it). Each changed key produces one
+        audit row with ``author`` and optional ``reason``.
+        """
+        profile = self.profile_store.get_profile(client_id)
+        if profile is None:
+            profile = self.profile_store.create_profile(client_id)
+
+        if profile.clinical is None:
+            profile.clinical = ClinicalInfo()
+
+        old = dict(profile.clinical.clinician_overrides or {})
+        new = dict(req.overrides or {})
+
+        changed_keys = set(old.keys()) ^ set(new.keys())
+        for key in set(old.keys()) & set(new.keys()):
+            if old[key] != new[key]:
+                changed_keys.add(key)
+
+        profile.clinical.clinician_overrides = new
+        self.profile_store.save_profile(client_id, profile)
+
+        for key in changed_keys:
+            self.profile_store.log_clinical_override(
+                client_id,
+                key,
+                new.get(key),
+                author=req.author or "admin",
+                reason=req.reason,
+            )
+        return profile
+
+    def get_completeness(self, client_id: str) -> CompletenessResponse:
+        """Compute which calculator-driving fields are populated.
+
+        This drives the UI banner and the SPEC-004 agent's decision to
+        return guidance-only vs. numeric targets. We do not throw 404
+        for an unknown client — an empty profile is a valid input.
+        """
+        profile = self.profile_store.get_profile(client_id)
+        resp = CompletenessResponse(client_id=client_id)
+        if profile is None:
+            resp.blockers = [
+                "no_profile",
+                "missing_sex",
+                "missing_age_years",
+                "missing_height_cm",
+                "missing_weight_kg",
+            ]
+            return resp
+
+        bio = profile.biometrics
+        blockers: list[str] = []
+
+        # Biometrics required for numeric targets.
+        from ..models import Sex as _Sex
+
+        if bio.sex == _Sex.unspecified:
+            blockers.append("missing_sex")
+        if bio.age_years is None:
+            blockers.append("missing_age_years")
+        if bio.height_cm is None:
+            blockers.append("missing_height_cm")
+        if bio.weight_kg is None:
+            blockers.append("missing_weight_kg")
+
+        resp.has_biometrics = not blockers  # all four required present
+        resp.has_activity = bio.activity_level is not None
+
+        # Clinical context "confirmed" when the user has saved any
+        # clinical state at all (a deliberate yes/no/none). Empty
+        # conditions+medications+reproductive_state=none is still a
+        # confirmed state; we treat it as such if the user has
+        # touched the clinical section. v1 proxy: if ed_history_flag
+        # has been explicitly set OR any clinical list is non-empty
+        # OR reproductive_state != none, we consider it confirmed.
+        c = profile.clinical
+        resp.has_clinical_confirmed = bool(
+            c
+            and (
+                c.conditions
+                or c.conditions_freetext
+                or c.medications
+                or c.medications_freetext
+                or c.reproductive_state != ReproductiveState.none
+                or c.ed_history_flag
+            )
+        )
+
+        resp.is_minor = bio.age_years is not None and bio.age_years < 18
+        if resp.is_minor:
+            blockers.append("minor_guidance_only")
+
+        resp.ed_history_flag = bool(c and c.ed_history_flag)
+
+        resp.blockers = blockers
+        return resp
 
     # --- Chat ---
 

--- a/backend/agents/nutrition_meal_planning_team/postgres/__init__.py
+++ b/backend/agents/nutrition_meal_planning_team/postgres/__init__.py
@@ -52,11 +52,46 @@ SCHEMA = TeamSchema(
         )""",
         """CREATE INDEX IF NOT EXISTS idx_nutrition_recommendations_client_time
             ON nutrition_recommendations(client_id, recommended_at DESC)""",
+        # --- SPEC-002 additions (biometric + clinical audit trails) ---
+        # Append-only log of every biometric write. ``nutrition_profiles``
+        # already carries the latest value inside its JSONB; this table
+        # is the time-series view SPEC-002 / ADR-006 read for charts
+        # and weight-trend events. Future device integrations
+        # (SPEC-019) ride on top of the same shape.
+        """CREATE TABLE IF NOT EXISTS nutrition_biometric_log (
+            id              BIGSERIAL PRIMARY KEY,
+            client_id       TEXT NOT NULL,
+            field           TEXT NOT NULL,
+            value_numeric   DOUBLE PRECISION,
+            value_text      TEXT,
+            unit            TEXT,
+            source          TEXT NOT NULL,
+            recorded_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+            recorded_by     TEXT
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_nutrition_biometric_log_client_field_time
+            ON nutrition_biometric_log(client_id, field, recorded_at DESC)""",
+        # Audit log for clinician-authored numeric overrides on the
+        # profile (e.g. ``{"bmi_floor": 19.5}``). Every write produces
+        # a row; the live value lives on ClientProfile.clinical.
+        """CREATE TABLE IF NOT EXISTS nutrition_clinical_overrides_log (
+            id              BIGSERIAL PRIMARY KEY,
+            client_id       TEXT NOT NULL,
+            key             TEXT NOT NULL,
+            value_numeric   DOUBLE PRECISION,
+            reason          TEXT,
+            author          TEXT NOT NULL,
+            recorded_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_nutrition_clinical_overrides_log_client_time
+            ON nutrition_clinical_overrides_log(client_id, recorded_at DESC)""",
     ],
     table_names=[
         "nutrition_profiles",
         "nutrition_conversations",
         "nutrition_plans",
         "nutrition_recommendations",
+        "nutrition_biometric_log",
+        "nutrition_clinical_overrides_log",
     ],
 )

--- a/backend/agents/nutrition_meal_planning_team/shared/client_profile_store.py
+++ b/backend/agents/nutrition_meal_planning_team/shared/client_profile_store.py
@@ -3,18 +3,23 @@
 Profiles are stored whole in the ``nutrition_profiles.profile`` JSONB
 column keyed by ``client_id``. Saves use upsert semantics so there is at
 most one current row per client (matching the pre-migration file layout).
+
+SPEC-002 adds:
+- Biometric append-only log (``nutrition_biometric_log``) and history query.
+- Clinician-override log (``nutrition_clinical_overrides_log``).
+- ``profile_version`` monotonic increment on every save.
 """
 
 from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from typing import Optional
+from typing import List, Optional
 
 from shared_postgres import Json, dict_row, get_conn
 from shared_postgres.metrics import timed_query
 
-from ..models import ClientProfile
+from ..models import BiometricHistoryEntry, ClientProfile
 
 logger = logging.getLogger(__name__)
 
@@ -47,9 +52,11 @@ def get_profile(client_id: str) -> Optional[ClientProfile]:
 
 @timed_query(store=_STORE, op="save_profile")
 def save_profile(client_id: str, profile: ClientProfile) -> None:
-    """Save client profile via upsert. Mutates ``profile.updated_at`` as a side effect."""
+    """Save client profile via upsert. Mutates ``profile.updated_at`` and
+    bumps ``profile_version`` as a side effect."""
     profile.client_id = client_id
     profile.updated_at = _now_iso()
+    profile.profile_version = (profile.profile_version or 0) + 1
     ts = datetime.now(tz=timezone.utc)
     with get_conn() as conn, conn.cursor() as cur:
         cur.execute(
@@ -64,8 +71,116 @@ def save_profile(client_id: str, profile: ClientProfile) -> None:
 def create_profile(client_id: str) -> ClientProfile:
     """Create a new empty profile for client_id and save it. Returns the new profile."""
     profile = ClientProfile(client_id=client_id)
+    # Start at 0 so the bump in save_profile lands at 1.
+    profile.profile_version = 0
     save_profile(client_id, profile)
     return profile
+
+
+# --- SPEC-002: biometric append-only log ---------------------------------
+
+
+@timed_query(store=_STORE, op="log_biometric")
+def log_biometric(
+    client_id: str,
+    field: str,
+    value_numeric: Optional[float] = None,
+    value_text: Optional[str] = None,
+    unit: Optional[str] = None,
+    source: str = "manual",
+    recorded_by: Optional[str] = None,
+) -> None:
+    """Append one biometric change to nutrition_biometric_log.
+
+    ``field`` is the name of the ClientProfile field that changed
+    (e.g. ``"weight_kg"``, ``"activity_level"``, ``"body_fat_pct"``).
+    Either ``value_numeric`` or ``value_text`` should be set depending
+    on whether the field is numeric.
+
+    No-op at this layer if both values are None — the caller decides
+    whether that's an error.
+    """
+    if value_numeric is None and value_text is None:
+        return
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO nutrition_biometric_log "
+            "(client_id, field, value_numeric, value_text, unit, source, recorded_by) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s)",
+            (client_id, field, value_numeric, value_text, unit, source, recorded_by),
+        )
+
+
+@timed_query(store=_STORE, op="get_biometric_history")
+def get_biometric_history(
+    client_id: str,
+    field: Optional[str] = None,
+    since: Optional[datetime] = None,
+    limit: int = 200,
+) -> List[BiometricHistoryEntry]:
+    """Return biometric log rows, newest first.
+
+    When ``field`` is provided, scopes to that field only (common for
+    weight-trend charts). ``since`` is an absolute UTC timestamp; if
+    None we return the latest ``limit`` rows regardless of age.
+    """
+    where = ["client_id = %s"]
+    params: list = [client_id]
+    if field is not None:
+        where.append("field = %s")
+        params.append(field)
+    if since is not None:
+        where.append("recorded_at >= %s")
+        params.append(since)
+    sql = (
+        "SELECT field, value_numeric, value_text, unit, source, "
+        "       recorded_at, recorded_by "
+        "FROM nutrition_biometric_log "
+        "WHERE " + " AND ".join(where) + " "
+        "ORDER BY recorded_at DESC LIMIT %s"
+    )
+    params.append(limit)
+    with get_conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(sql, tuple(params))
+        rows = cur.fetchall()
+    return [
+        BiometricHistoryEntry(
+            field=row["field"],
+            value_numeric=row["value_numeric"],
+            value_text=row["value_text"],
+            unit=row["unit"],
+            source=row["source"],
+            recorded_at=row["recorded_at"].isoformat() if row["recorded_at"] else "",
+            recorded_by=row["recorded_by"],
+        )
+        for row in rows
+    ]
+
+
+# --- SPEC-002: clinician override audit ----------------------------------
+
+
+@timed_query(store=_STORE, op="log_clinical_override")
+def log_clinical_override(
+    client_id: str,
+    key: str,
+    value_numeric: Optional[float],
+    author: str = "admin",
+    reason: Optional[str] = None,
+) -> None:
+    """Append one clinician override change to the audit table.
+
+    Called once per key that changed when the admin endpoint writes a
+    new override dict to the profile. ``value_numeric`` can be None to
+    record a removal.
+    """
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO nutrition_clinical_overrides_log "
+            "(client_id, key, value_numeric, reason, author) "
+            "VALUES (%s, %s, %s, %s, %s)",
+            (client_id, key, value_numeric, reason, author),
+        )
 
 
 class ClientProfileStore:
@@ -87,6 +202,45 @@ class ClientProfileStore:
 
     def create_profile(self, client_id: str) -> ClientProfile:
         return create_profile(client_id)
+
+    def log_biometric(
+        self,
+        client_id: str,
+        field: str,
+        value_numeric: Optional[float] = None,
+        value_text: Optional[str] = None,
+        unit: Optional[str] = None,
+        source: str = "manual",
+        recorded_by: Optional[str] = None,
+    ) -> None:
+        log_biometric(
+            client_id,
+            field,
+            value_numeric=value_numeric,
+            value_text=value_text,
+            unit=unit,
+            source=source,
+            recorded_by=recorded_by,
+        )
+
+    def get_biometric_history(
+        self,
+        client_id: str,
+        field: Optional[str] = None,
+        since: Optional[datetime] = None,
+        limit: int = 200,
+    ) -> List[BiometricHistoryEntry]:
+        return get_biometric_history(client_id, field=field, since=since, limit=limit)
+
+    def log_clinical_override(
+        self,
+        client_id: str,
+        key: str,
+        value_numeric: Optional[float],
+        author: str = "admin",
+        reason: Optional[str] = None,
+    ) -> None:
+        log_clinical_override(client_id, key, value_numeric, author=author, reason=reason)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/nutrition_meal_planning_team/tests/test_clinical_taxonomy.py
+++ b/backend/agents/nutrition_meal_planning_team/tests/test_clinical_taxonomy.py
@@ -1,0 +1,85 @@
+"""SPEC-002 W2: clinical taxonomy tests."""
+
+from __future__ import annotations
+
+from nutrition_meal_planning_team.clinical_taxonomy import (
+    CKD_STAGES,
+    CLINICAL_TAXONOMY_VERSION,
+    CLINICIAN_GUIDED_ONLY,
+    DIABETES,
+    Condition,
+    Medication,
+    is_known_condition,
+    is_known_medication,
+    parse_conditions,
+    parse_medications,
+)
+
+
+def test_version_exported():
+    assert isinstance(CLINICAL_TAXONOMY_VERSION, str)
+    assert CLINICAL_TAXONOMY_VERSION.count(".") == 2
+
+
+def test_known_conditions_round_trip():
+    for c in Condition:
+        assert is_known_condition(c.value)
+
+
+def test_known_medications_round_trip():
+    for m in Medication:
+        assert is_known_medication(m.value)
+
+
+def test_unknown_condition_rejected():
+    assert not is_known_condition("grandma's special condition")
+    assert not is_known_condition("")
+
+
+def test_unknown_medication_rejected():
+    assert not is_known_medication("some random herb")
+
+
+def test_parse_conditions_splits_known_and_unknown():
+    known, unknown = parse_conditions(
+        ["hypertension", "dyslipidemia", "random-thing", "hypertension"]
+    )
+    # Dedup and split; order preserved.
+    assert known == [Condition.hypertension, Condition.dyslipidemia]
+    assert unknown == ["random-thing"]
+
+
+def test_parse_conditions_empty_input():
+    known, unknown = parse_conditions([])
+    assert known == []
+    assert unknown == []
+
+
+def test_parse_conditions_ignores_empty_strings():
+    known, unknown = parse_conditions(["", "  ", "hypertension"])
+    assert known == [Condition.hypertension]
+    assert unknown == []
+
+
+def test_parse_medications_splits_known_and_unknown():
+    known, unknown = parse_medications(["warfarin", "some-supplement"])
+    assert known == [Medication.warfarin]
+    assert unknown == ["some-supplement"]
+
+
+def test_ckd_stages_convenience_set():
+    assert Condition.ckd_stage_3 in CKD_STAGES
+    assert Condition.hypertension not in CKD_STAGES
+
+
+def test_clinician_guided_only_includes_ckd_45():
+    assert Condition.ckd_stage_4 in CLINICIAN_GUIDED_ONLY
+    assert Condition.ckd_stage_5 in CLINICIAN_GUIDED_ONLY
+    assert Condition.ckd_stage_3 not in CLINICIAN_GUIDED_ONLY
+
+
+def test_diabetes_convenience_set():
+    assert Condition.t1_diabetes in DIABETES
+    assert Condition.t2_diabetes in DIABETES
+    assert Condition.prediabetes in DIABETES
+    assert Condition.ckd_stage_1 not in DIABETES

--- a/backend/agents/nutrition_meal_planning_team/tests/test_intake_agent_v2.py
+++ b/backend/agents/nutrition_meal_planning_team/tests/test_intake_agent_v2.py
@@ -1,0 +1,130 @@
+"""SPEC-002 W4: intake agent tests (fallback merge + new sub-objects).
+
+Uses the pure-logic ``structural`` module so tests don't require the
+``strands`` stack (kept separate per SPEC-002 W4).
+"""
+
+from __future__ import annotations
+
+from nutrition_meal_planning_team.agents.intake_profile_agent.structural import (
+    merge_profile_structural,
+)
+from nutrition_meal_planning_team.models import (
+    ActivityLevel,
+    BiometricInfo,
+    ClientProfile,
+    ClinicalInfo,
+    HouseholdInfo,
+    ProfileUpdateRequest,
+    ReproductiveState,
+    Sex,
+)
+
+# Alias to the historical private name the rest of the codebase uses.
+_merge_profile_structural = merge_profile_structural
+
+
+# --- existing behavior preserved -----------------------------------------
+
+
+def test_structural_merge_preserves_existing_household():
+    existing = ClientProfile(
+        client_id="c1",
+        household=HouseholdInfo(number_of_people=2, description="couple"),
+    )
+    update = ProfileUpdateRequest(dietary_needs=["vegan"])
+    merged = _merge_profile_structural("c1", existing, update)
+    assert merged.household.number_of_people == 2
+    assert merged.household.description == "couple"
+    assert merged.dietary_needs == ["vegan"]
+
+
+def test_structural_merge_on_empty_profile():
+    merged = _merge_profile_structural(
+        "c1", None, ProfileUpdateRequest(dietary_needs=["vegetarian"])
+    )
+    assert merged.dietary_needs == ["vegetarian"]
+    assert merged.client_id == "c1"
+    assert isinstance(merged.biometrics, BiometricInfo)
+    assert isinstance(merged.clinical, ClinicalInfo)
+
+
+# --- SPEC-002 biometrics sub-object merge --------------------------------
+
+
+def test_structural_merge_biometrics_added_to_empty_profile():
+    patch = ProfileUpdateRequest(
+        biometrics=BiometricInfo(sex=Sex.female, age_years=32, height_cm=168.0, weight_kg=64.5)
+    )
+    merged = _merge_profile_structural("c1", None, patch)
+    assert merged.biometrics.sex == Sex.female
+    assert merged.biometrics.age_years == 32
+    assert merged.biometrics.height_cm == 168.0
+    assert merged.biometrics.weight_kg == 64.5
+
+
+def test_structural_merge_biometrics_overwrites_sub_object_when_provided():
+    """PUT /profile with a ``biometrics`` sub-object replaces the whole block.
+
+    Pydantic dumps a ``BiometricInfo`` with all default values populated
+    (``sex=unspecified`` etc.), so the shallow merge stamps the entire
+    sub-object onto the profile. Per-field biometric updates go through
+    ``PATCH /profile/{id}/biometrics`` which uses the all-None
+    ``BiometricPatchRequest`` shape instead.
+
+    The only fields that survive unchanged are ``Optional`` ones the
+    patch did not set (they dump as ``null`` and ``exclude_none=True``
+    drops them), e.g. ``age_years`` and ``height_cm``.
+    """
+    existing = ClientProfile(
+        client_id="c1",
+        biometrics=BiometricInfo(
+            sex=Sex.female,
+            age_years=32,
+            height_cm=168.0,
+            weight_kg=64.5,
+            activity_level=ActivityLevel.moderate,
+        ),
+    )
+    patch = ProfileUpdateRequest(biometrics=BiometricInfo(weight_kg=63.0))
+    merged = _merge_profile_structural("c1", existing, patch)
+    # Weight arrived — survives.
+    assert merged.biometrics.weight_kg == 63.0
+    # Optional fields the patch left unset (None-valued) are preserved
+    # because exclude_none=True drops them from the shallow-merge dict.
+    assert merged.biometrics.age_years == 32
+    assert merged.biometrics.height_cm == 168.0
+    # Non-optional fields with defaults are dumped and stomp the existing
+    # values — sub-object replace semantics, documented above.
+    assert merged.biometrics.sex == Sex.unspecified
+    assert merged.biometrics.activity_level == ActivityLevel.sedentary
+
+
+# --- SPEC-002 clinical sub-object merge ----------------------------------
+
+
+def test_structural_merge_clinical_added_to_empty_profile():
+    patch = ProfileUpdateRequest(
+        clinical=ClinicalInfo(
+            conditions=["hypertension"],
+            medications=["warfarin"],
+            reproductive_state=ReproductiveState.none,
+            ed_history_flag=False,
+        )
+    )
+    merged = _merge_profile_structural("c1", None, patch)
+    assert merged.clinical.conditions == ["hypertension"]
+    assert merged.clinical.medications == ["warfarin"]
+    assert merged.clinical.ed_history_flag is False
+
+
+def test_structural_merge_ed_flag_survives_no_update():
+    existing = ClientProfile(
+        client_id="c1",
+        clinical=ClinicalInfo(ed_history_flag=True),
+    )
+    # Patch touches a completely different area.
+    patch = ProfileUpdateRequest(dietary_needs=["vegan"])
+    merged = _merge_profile_structural("c1", existing, patch)
+    assert merged.clinical.ed_history_flag is True
+    assert merged.dietary_needs == ["vegan"]

--- a/backend/agents/nutrition_meal_planning_team/tests/test_models_validators.py
+++ b/backend/agents/nutrition_meal_planning_team/tests/test_models_validators.py
@@ -1,0 +1,217 @@
+"""SPEC-002 W1: validator tests for ClientProfile additions."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from nutrition_meal_planning_team.models import (
+    PROFILE_SCHEMA_VERSION,
+    ActivityLevel,
+    BiometricInfo,
+    BiometricPatchRequest,
+    ClientProfile,
+    ClinicalInfo,
+    ClinicalPatchRequest,
+    ClinicianOverrideRequest,
+    GoalsInfo,
+    ReproductiveState,
+    Sex,
+)
+
+# --- BiometricInfo range bounds ------------------------------------------
+
+
+def test_defaults_are_sane():
+    b = BiometricInfo()
+    assert b.sex == Sex.unspecified
+    assert b.age_years is None
+    assert b.height_cm is None
+    assert b.weight_kg is None
+    assert b.activity_level == ActivityLevel.sedentary
+    assert b.timezone == "UTC"
+    assert b.preferred_units == "metric"
+
+
+@pytest.mark.parametrize("age", [1, 0, 121, 200])
+def test_age_rejected_outside_range(age):
+    with pytest.raises(ValidationError):
+        BiometricInfo(age_years=age)
+
+
+@pytest.mark.parametrize("age", [2, 18, 60, 120])
+def test_age_accepted_within_range(age):
+    assert BiometricInfo(age_years=age).age_years == age
+
+
+@pytest.mark.parametrize("h", [49, 261, 0, -5])
+def test_height_rejected_outside_range(h):
+    with pytest.raises(ValidationError):
+        BiometricInfo(height_cm=h)
+
+
+@pytest.mark.parametrize("h", [50, 150, 180, 260])
+def test_height_accepted_within_range(h):
+    assert BiometricInfo(height_cm=h).height_cm == h
+
+
+@pytest.mark.parametrize("w", [19, 401, 0, -10])
+def test_weight_rejected_outside_range(w):
+    with pytest.raises(ValidationError):
+        BiometricInfo(weight_kg=w)
+
+
+@pytest.mark.parametrize("w", [20, 70, 150, 400])
+def test_weight_accepted_within_range(w):
+    assert BiometricInfo(weight_kg=w).weight_kg == w
+
+
+@pytest.mark.parametrize("bf", [2, 76, 100])
+def test_body_fat_rejected_outside_range(bf):
+    with pytest.raises(ValidationError):
+        BiometricInfo(body_fat_pct=bf)
+
+
+@pytest.mark.parametrize("bf", [3, 20, 50, 75])
+def test_body_fat_accepted_within_range(bf):
+    assert BiometricInfo(body_fat_pct=bf).body_fat_pct == bf
+
+
+def test_timezone_invalid_rejected():
+    with pytest.raises(ValidationError):
+        BiometricInfo(timezone="Not/A/Zone")
+
+
+def test_timezone_utc_accepted():
+    assert BiometricInfo(timezone="UTC").timezone == "UTC"
+
+
+def test_timezone_america_new_york_accepted():
+    assert BiometricInfo(timezone="America/New_York").timezone == "America/New_York"
+
+
+def test_preferred_units_validation():
+    assert BiometricInfo(preferred_units="imperial").preferred_units == "imperial"
+    with pytest.raises(ValidationError):
+        BiometricInfo(preferred_units="smoots")
+
+
+# --- GoalsInfo -----------------------------------------------------------
+
+
+def test_goals_rate_rejected_above_one():
+    with pytest.raises(ValidationError):
+        GoalsInfo(rate_kg_per_week=1.5)
+
+
+def test_goals_rate_accepted_within_range():
+    g = GoalsInfo(rate_kg_per_week=0.45)
+    assert g.rate_kg_per_week == 0.45
+
+
+def test_goals_target_weight_rejected_outside_range():
+    with pytest.raises(ValidationError):
+        GoalsInfo(target_weight_kg=10)
+    with pytest.raises(ValidationError):
+        GoalsInfo(target_weight_kg=500)
+
+
+def test_goals_target_weight_accepted():
+    g = GoalsInfo(target_weight_kg=75.0)
+    assert g.target_weight_kg == 75.0
+
+
+# --- ClientProfile -------------------------------------------------------
+
+
+def test_client_profile_has_new_fields_and_defaults():
+    p = ClientProfile(client_id="c1")
+    assert isinstance(p.biometrics, BiometricInfo)
+    assert isinstance(p.clinical, ClinicalInfo)
+    assert p.schema_version == PROFILE_SCHEMA_VERSION
+    assert p.profile_version == 1
+
+
+def test_client_profile_roundtrips_json():
+    p = ClientProfile(
+        client_id="c2",
+        biometrics=BiometricInfo(
+            sex=Sex.female,
+            age_years=32,
+            height_cm=168.0,
+            weight_kg=64.5,
+            activity_level=ActivityLevel.moderate,
+        ),
+        clinical=ClinicalInfo(
+            conditions=["hypertension"],
+            medications=["acei_arb"],
+            reproductive_state=ReproductiveState.none,
+            ed_history_flag=False,
+        ),
+    )
+    payload = p.model_dump()
+    restored = ClientProfile.model_validate(payload)
+    assert restored.biometrics.sex == Sex.female
+    assert restored.clinical.conditions == ["hypertension"]
+    assert restored.clinical.medications == ["acei_arb"]
+
+
+# --- BiometricPatchRequest -----------------------------------------------
+
+
+def test_biometric_patch_all_none_is_valid():
+    p = BiometricPatchRequest()
+    assert p.height_cm is None and p.weight_kg is None
+
+
+def test_biometric_patch_rejects_implausible():
+    with pytest.raises(ValidationError):
+        BiometricPatchRequest(weight_kg=500)
+    with pytest.raises(ValidationError):
+        BiometricPatchRequest(height_cm=20)
+    with pytest.raises(ValidationError):
+        BiometricPatchRequest(weight_lb=1000)
+
+
+def test_biometric_patch_accepts_imperial_inputs():
+    p = BiometricPatchRequest(height_ft=5, height_in=10, weight_lb=165)
+    assert p.height_ft == 5 and p.height_in == 10
+    assert p.weight_lb == 165
+
+
+# --- ClinicalPatchRequest ------------------------------------------------
+
+
+def test_clinical_patch_nullable_fields():
+    p = ClinicalPatchRequest()
+    assert p.conditions is None
+    assert p.medications is None
+    assert p.ed_history_flag is None
+
+
+def test_clinical_patch_accepts_lists():
+    p = ClinicalPatchRequest(
+        conditions=["hypertension", "weird-unknown-thing"],
+        medications=["warfarin"],
+    )
+    assert "hypertension" in p.conditions
+    assert p.medications == ["warfarin"]
+
+
+# --- ClinicianOverrideRequest --------------------------------------------
+
+
+def test_clinician_override_defaults():
+    r = ClinicianOverrideRequest()
+    assert r.overrides == {}
+    assert r.author == "admin"
+
+
+def test_clinician_override_roundtrip():
+    r = ClinicianOverrideRequest(
+        overrides={"bmi_floor": 19.5, "sodium_cap_mg": 1500.0},
+        reason="dietitian guidance",
+        author="dietitian-1234",
+    )
+    assert r.overrides["bmi_floor"] == 19.5
+    assert r.author == "dietitian-1234"

--- a/backend/agents/nutrition_meal_planning_team/tests/test_profile_biometrics.py
+++ b/backend/agents/nutrition_meal_planning_team/tests/test_profile_biometrics.py
@@ -1,0 +1,278 @@
+"""SPEC-002 integration tests: biometric / clinical / completeness endpoints."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from shared_postgres import is_postgres_enabled
+
+_agents_dir = Path(__file__).resolve().parent.parent.parent
+if str(_agents_dir) not in __import__("sys").path:
+    __import__("sys").path.insert(0, str(_agents_dir))
+
+from nutrition_meal_planning_team.api.main import app  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not is_postgres_enabled(),
+    reason="SPEC-002 biometric tables require Postgres.",
+)
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+# --- PATCH /biometrics ---------------------------------------------------
+
+
+def test_patch_biometrics_records_log(client):
+    client.put(
+        "/profile/bp1",
+        json={"household": {"number_of_people": 1, "description": "solo"}},
+    )
+    r = client.patch(
+        "/profile/bp1/biometrics",
+        json={
+            "sex": "female",
+            "age_years": 32,
+            "height_cm": 168.0,
+            "weight_kg": 64.5,
+            "activity_level": "moderate",
+        },
+    )
+    assert r.status_code == 200
+    bio = r.json()["biometrics"]
+    assert bio["sex"] == "female"
+    assert bio["age_years"] == 32
+    assert bio["height_cm"] == 168.0
+    assert bio["weight_kg"] == 64.5
+    assert bio["activity_level"] == "moderate"
+
+    hist = client.get("/profile/bp1/biometrics/history").json()
+    fields = {e["field"] for e in hist["entries"]}
+    # Every changed field should log.
+    assert {"sex", "age_years", "height_cm", "weight_kg", "activity_level"} <= fields
+
+
+def test_patch_biometrics_imperial_coerced_to_metric(client):
+    client.put(
+        "/profile/bp2",
+        json={"household": {"number_of_people": 1, "description": "solo"}},
+    )
+    r = client.patch(
+        "/profile/bp2/biometrics",
+        json={"height_ft": 5, "height_in": 10, "weight_lb": 150},
+    )
+    assert r.status_code == 200
+    bio = r.json()["biometrics"]
+    # 5'10" == 177.8 cm; 150 lb == ~68.04 kg
+    assert bio["height_cm"] == pytest.approx(177.8, abs=1e-3)
+    assert bio["weight_kg"] == pytest.approx(68.038855, abs=1e-3)
+
+
+def test_patch_biometrics_rejects_implausible(client):
+    client.put(
+        "/profile/bp3",
+        json={"household": {"number_of_people": 1, "description": "solo"}},
+    )
+    r = client.patch("/profile/bp3/biometrics", json={"weight_kg": 500})
+    assert r.status_code == 422
+
+
+def test_patch_biometrics_no_changes_leaves_history_empty(client):
+    client.put(
+        "/profile/bp4",
+        json={"household": {"number_of_people": 1, "description": "solo"}},
+    )
+    # Same default sex / activity — no deltas.
+    r = client.patch(
+        "/profile/bp4/biometrics",
+        json={"sex": "unspecified", "activity_level": "sedentary"},
+    )
+    assert r.status_code == 200
+    hist = client.get("/profile/bp4/biometrics/history").json()
+    assert hist["entries"] == []
+
+
+def test_biometric_history_field_filter(client):
+    client.put(
+        "/profile/bp5",
+        json={"household": {"number_of_people": 1, "description": "solo"}},
+    )
+    client.patch("/profile/bp5/biometrics", json={"weight_kg": 70.0})
+    client.patch("/profile/bp5/biometrics", json={"weight_kg": 69.5})
+    client.patch("/profile/bp5/biometrics", json={"weight_kg": 69.1})
+    r = client.get("/profile/bp5/biometrics/history", params={"field": "weight_kg"})
+    assert r.status_code == 200
+    entries = r.json()["entries"]
+    assert len(entries) == 3
+    values = [e["value_numeric"] for e in entries]
+    # newest first
+    assert values == [69.1, 69.5, 70.0]
+
+
+# --- PATCH /clinical -----------------------------------------------------
+
+
+def test_patch_clinical_splits_known_and_freetext(client):
+    client.put(
+        "/profile/cli1",
+        json={"household": {"number_of_people": 1, "description": "solo"}},
+    )
+    r = client.patch(
+        "/profile/cli1/clinical",
+        json={
+            "conditions": ["hypertension", "grandma's curse"],
+            "medications": ["warfarin", "some-supplement"],
+            "reproductive_state": "none",
+            "ed_history_flag": False,
+        },
+    )
+    assert r.status_code == 200
+    clinical = r.json()["clinical"]
+    assert clinical["conditions"] == ["hypertension"]
+    assert clinical["conditions_freetext"] == ["grandma's curse"]
+    assert clinical["medications"] == ["warfarin"]
+    assert clinical["medications_freetext"] == ["some-supplement"]
+
+
+def test_patch_clinical_ed_flag_persists(client):
+    client.put(
+        "/profile/cli2",
+        json={"household": {"number_of_people": 1, "description": "solo"}},
+    )
+    r = client.patch("/profile/cli2/clinical", json={"ed_history_flag": True})
+    assert r.status_code == 200
+    assert r.json()["clinical"]["ed_history_flag"] is True
+
+
+# --- PUT /clinical-overrides ---------------------------------------------
+
+
+def test_put_clinician_overrides_audits_changes(client):
+    client.put(
+        "/profile/co1",
+        json={"household": {"number_of_people": 1, "description": "solo"}},
+    )
+    r1 = client.put(
+        "/profile/co1/clinical-overrides",
+        json={"overrides": {"bmi_floor": 19.5}, "reason": "dietitian guidance"},
+    )
+    assert r1.status_code == 200
+    assert r1.json()["clinical"]["clinician_overrides"] == {"bmi_floor": 19.5}
+
+    # Update with a new override; old one removed, new one added.
+    r2 = client.put(
+        "/profile/co1/clinical-overrides",
+        json={"overrides": {"sodium_cap_mg": 1500.0}},
+    )
+    assert r2.status_code == 200
+    assert r2.json()["clinical"]["clinician_overrides"] == {"sodium_cap_mg": 1500.0}
+
+
+# --- GET /completeness ---------------------------------------------------
+
+
+def test_completeness_unknown_client_returns_blockers(client):
+    r = client.get("/profile/never-existed/completeness")
+    assert r.status_code == 200
+    body = r.json()
+    assert "no_profile" in body["blockers"]
+    assert "missing_sex" in body["blockers"]
+
+
+def test_completeness_full_profile_has_no_blockers(client):
+    client.put(
+        "/profile/full1",
+        json={"household": {"number_of_people": 1, "description": "solo"}},
+    )
+    client.patch(
+        "/profile/full1/biometrics",
+        json={
+            "sex": "female",
+            "age_years": 32,
+            "height_cm": 168.0,
+            "weight_kg": 64.5,
+            "activity_level": "moderate",
+        },
+    )
+    r = client.get("/profile/full1/completeness")
+    body = r.json()
+    assert body["has_biometrics"] is True
+    assert body["has_activity"] is True
+    assert body["is_minor"] is False
+    assert body["blockers"] == []
+
+
+def test_completeness_minor_flagged(client):
+    client.put(
+        "/profile/minor1",
+        json={"household": {"number_of_people": 1, "description": "solo"}},
+    )
+    client.patch(
+        "/profile/minor1/biometrics",
+        json={
+            "sex": "female",
+            "age_years": 15,
+            "height_cm": 160.0,
+            "weight_kg": 50.0,
+            "activity_level": "moderate",
+        },
+    )
+    body = client.get("/profile/minor1/completeness").json()
+    assert body["is_minor"] is True
+    assert "minor_guidance_only" in body["blockers"]
+
+
+def test_completeness_ed_flag_surfaces(client):
+    client.put(
+        "/profile/ed1",
+        json={"household": {"number_of_people": 1, "description": "solo"}},
+    )
+    client.patch("/profile/ed1/clinical", json={"ed_history_flag": True})
+    body = client.get("/profile/ed1/completeness").json()
+    assert body["ed_history_flag"] is True
+    assert body["has_clinical_confirmed"] is True
+
+
+def test_completeness_partial_biometrics_reports_specific_blockers(client):
+    client.put(
+        "/profile/part1",
+        json={"household": {"number_of_people": 1, "description": "solo"}},
+    )
+    # Only provide sex + age; no height/weight yet.
+    client.patch(
+        "/profile/part1/biometrics",
+        json={"sex": "male", "age_years": 40},
+    )
+    body = client.get("/profile/part1/completeness").json()
+    assert "missing_height_cm" in body["blockers"]
+    assert "missing_weight_kg" in body["blockers"]
+    assert "missing_sex" not in body["blockers"]
+    assert "missing_age_years" not in body["blockers"]
+    assert body["has_biometrics"] is False
+
+
+# --- profile_version bump invariant --------------------------------------
+
+
+def test_profile_version_increments_on_patches(client):
+    client.put(
+        "/profile/pv1",
+        json={"household": {"number_of_people": 1, "description": "solo"}},
+    )
+    p1 = client.get("/profile/pv1").json()
+    v1 = p1["profile_version"]
+
+    client.patch("/profile/pv1/biometrics", json={"weight_kg": 70.0})
+    p2 = client.get("/profile/pv1").json()
+    assert p2["profile_version"] == v1 + 1
+
+    client.patch("/profile/pv1/clinical", json={"ed_history_flag": True})
+    p3 = client.get("/profile/pv1").json()
+    assert p3["profile_version"] == v1 + 2

--- a/backend/agents/nutrition_meal_planning_team/tests/test_units.py
+++ b/backend/agents/nutrition_meal_planning_team/tests/test_units.py
@@ -1,0 +1,111 @@
+"""SPEC-002 W4 support: unit conversion tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from nutrition_meal_planning_team.units import (
+    CM_PER_INCH,
+    KG_PER_LB,
+    cm_to_ft_in,
+    coerce_height_cm,
+    coerce_weight_kg,
+    ft_in_to_cm,
+    inches_to_cm,
+    kg_to_lb,
+    lb_to_kg,
+)
+
+# --- Direct conversions --------------------------------------------------
+
+
+def test_inches_to_cm_exact():
+    assert inches_to_cm(1) == CM_PER_INCH
+    assert inches_to_cm(10) == pytest.approx(25.4, abs=1e-9)
+
+
+def test_ft_in_to_cm_matches_inches():
+    assert ft_in_to_cm(5, 10) == pytest.approx(177.8, abs=1e-9)
+    assert ft_in_to_cm(6, 0) == pytest.approx(182.88, abs=1e-9)
+
+
+def test_cm_to_ft_in_roundtrip():
+    ft, inches = cm_to_ft_in(177.8)
+    assert ft == 5
+    assert inches == pytest.approx(10, abs=1e-6)
+
+
+def test_lb_to_kg_exact():
+    assert lb_to_kg(1) == KG_PER_LB
+    assert lb_to_kg(150) == pytest.approx(68.038855, abs=1e-4)
+
+
+def test_kg_to_lb_roundtrip():
+    for kg in (50.0, 65.5, 100.0):
+        assert kg_to_lb(lb_to_kg(kg / KG_PER_LB)) == pytest.approx(kg / KG_PER_LB)
+
+
+# --- coerce_height_cm ----------------------------------------------------
+
+
+def test_coerce_height_cm_prefers_canonical():
+    assert coerce_height_cm(height_cm=170.0) == 170.0
+
+
+def test_coerce_height_cm_uses_canonical_over_imperial():
+    # When both provided, cm wins (user explicit on canonical).
+    assert coerce_height_cm(height_cm=170.0, height_ft=5, height_in=0) == 170.0
+
+
+def test_coerce_height_cm_from_ft_in():
+    result = coerce_height_cm(height_ft=5, height_in=10)
+    assert result == pytest.approx(177.8, abs=1e-6)
+
+
+def test_coerce_height_cm_ft_only():
+    assert coerce_height_cm(height_ft=6) == pytest.approx(182.88, abs=1e-6)
+
+
+def test_coerce_height_cm_in_only():
+    assert coerce_height_cm(height_in=70) == pytest.approx(177.8, abs=1e-6)
+
+
+def test_coerce_height_cm_all_none_returns_none():
+    assert coerce_height_cm() is None
+    assert coerce_height_cm(height_cm=None, height_ft=None, height_in=None) is None
+
+
+def test_coerce_height_cm_zero_inputs_return_none():
+    # 0 ft 0 in is explicitly "empty" — not a silent 0 cm fallback.
+    assert coerce_height_cm(height_ft=0, height_in=0) is None
+
+
+def test_coerce_height_cm_treats_zero_cm_as_missing():
+    # A 0 cm input is sentinel for "not given"; we fall through to imperial.
+    assert coerce_height_cm(height_cm=0, height_ft=5, height_in=10) == pytest.approx(
+        177.8, abs=1e-6
+    )
+
+
+# --- coerce_weight_kg ----------------------------------------------------
+
+
+def test_coerce_weight_kg_prefers_kg():
+    assert coerce_weight_kg(weight_kg=75.0) == 75.0
+
+
+def test_coerce_weight_kg_from_lb():
+    assert coerce_weight_kg(weight_lb=150) == pytest.approx(68.038855, abs=1e-4)
+
+
+def test_coerce_weight_kg_none_returns_none():
+    assert coerce_weight_kg() is None
+    assert coerce_weight_kg(weight_kg=None, weight_lb=None) is None
+
+
+def test_coerce_weight_kg_zero_kg_falls_through_to_lb():
+    assert coerce_weight_kg(weight_kg=0, weight_lb=150) == pytest.approx(68.038855, abs=1e-4)
+
+
+def test_coerce_weight_kg_zero_lb_returns_none():
+    assert coerce_weight_kg(weight_lb=0) is None

--- a/backend/agents/nutrition_meal_planning_team/units.py
+++ b/backend/agents/nutrition_meal_planning_team/units.py
@@ -1,0 +1,92 @@
+"""Unit conversions for user-entered biometric values.
+
+The intake pipeline accepts height in either cm or ft/in, and weight in
+either kg or lb. The profile schema (SPEC-002) stores canonical units
+only — cm and kg — so values entered in other units are converted at
+the API boundary before validation.
+
+These are pure, deterministic functions with no I/O. They are exercised
+by both the intake agent (SPEC-002 W4) and the UI unit toggle
+(SPEC-002 W9).
+
+No silent failures: malformed input returns ``None``; it does **not**
+fall back to zero or the identity conversion.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+# Canonical conversion constants — frozen values, not configurable.
+INCH_PER_FOOT = 12
+CM_PER_INCH = 2.54
+KG_PER_LB = 0.45359237
+
+
+def inches_to_cm(inches: float) -> float:
+    """Convert inches → cm. Deterministic, exact to 10 decimal places."""
+    return inches * CM_PER_INCH
+
+
+def ft_in_to_cm(feet: float, inches: float) -> float:
+    """Convert feet + inches → cm. Both args are coerced via float()."""
+    total_inches = feet * INCH_PER_FOOT + inches
+    return inches_to_cm(total_inches)
+
+
+def cm_to_ft_in(cm: float) -> tuple[int, float]:
+    """Convert cm → (feet, remainder_inches). Inches preserve fractional part."""
+    total_inches = cm / CM_PER_INCH
+    feet = int(total_inches // INCH_PER_FOOT)
+    inches = total_inches - feet * INCH_PER_FOOT
+    return feet, inches
+
+
+def lb_to_kg(lb: float) -> float:
+    """Convert pounds → kilograms (exact constant)."""
+    return lb * KG_PER_LB
+
+
+def kg_to_lb(kg: float) -> float:
+    """Convert kilograms → pounds."""
+    return kg / KG_PER_LB
+
+
+def coerce_height_cm(
+    height_cm: Optional[float] = None,
+    height_ft: Optional[float] = None,
+    height_in: Optional[float] = None,
+) -> Optional[float]:
+    """Coerce any of the provided height inputs to cm.
+
+    Rules:
+    - If ``height_cm`` is provided and non-zero, it wins (user is
+      explicit about canonical units).
+    - Else if ``height_ft`` or ``height_in`` is provided, treat zero for
+      the other as 0 (``5 ft 10 in``, ``6 ft 0 in``, ``0 ft 70 in``).
+    - Else return None (no height given).
+
+    Returns ``None`` if the inputs are all None or numerically empty.
+    Never returns 0.0 as a sentinel for "missing".
+    """
+    if height_cm is not None and float(height_cm) > 0:
+        return float(height_cm)
+    if height_ft is not None or height_in is not None:
+        ft = float(height_ft) if height_ft is not None else 0.0
+        inches = float(height_in) if height_in is not None else 0.0
+        if ft == 0.0 and inches == 0.0:
+            return None
+        return ft_in_to_cm(ft, inches)
+    return None
+
+
+def coerce_weight_kg(
+    weight_kg: Optional[float] = None,
+    weight_lb: Optional[float] = None,
+) -> Optional[float]:
+    """Coerce provided weight input to kg. ``weight_kg`` takes precedence."""
+    if weight_kg is not None and float(weight_kg) > 0:
+        return float(weight_kg)
+    if weight_lb is not None and float(weight_lb) > 0:
+        return lb_to_kg(float(weight_lb))
+    return None

--- a/system_design/adr/ADR-001-nutrition-deterministic-targets.md
+++ b/system_design/adr/ADR-001-nutrition-deterministic-targets.md
@@ -1,0 +1,190 @@
+# ADR-001 — Nutrition daily targets are computed deterministically, not authored by the LLM
+
+- **Status**: Proposed
+- **Date**: 2026-04-17
+- **Owner**: Nutrition & Meal Planning team
+- **Related**: `backend/agents/nutrition_meal_planning_team/`
+
+## Context
+
+The Nutritionist agent today (`agents/nutritionist_agent/agent.py`) hands the
+full `ClientProfile` to an LLM and asks it to return `DailyTargets`
+(`calories_kcal`, `protein_g`, `carbs_g`, `fat_g`, `fiber_g`, `sodium_mg`,
+plus `other_nutrients`) together with narrative guidance
+(`balance_guidelines`, `foods_to_emphasize`, `foods_to_avoid`, `notes`).
+
+Three forces are colliding:
+
+1. **The numbers are unanchored.** `ClientProfile` (`models.py`) does not
+   carry the inputs a dietitian would need to derive energy and macro
+   targets — there is no `sex`, `age_years`, `height_cm`, `weight_kg`, or
+   activity level. The prompt's only hint ("0.8g protein per kg") has no
+   kg to multiply by. Outputs are therefore plausible-sounding but
+   effectively fabricated; two calls with the same profile can disagree
+   by hundreds of kcal.
+
+2. **Downstream code trusts them.** `MealPlanningAgent` (and any future
+   nutrient-rollup step — see the roadmap item on quantitative meal-plan
+   validation) is being built on top of `DailyTargets`. Every layer
+   stacked on a fabricated baseline inherits its error.
+
+3. **Clinical and liability exposure.** Users with medical conditions
+   (CKD protein caps, hypertension sodium caps, T2D carb distribution,
+   pregnancy/lactation energy adds) or medication interactions
+   (warfarin↔vitamin K, MAOI↔tyramine, ACEi↔potassium, GLP-1↔high-fat)
+   cannot safely be served LLM-authored numbers. Even outside medical
+   cohorts, "this app told me to eat 1,400 kcal" is a claim we should
+   only make when we can show our work.
+
+Prior art in the codebase supports a deterministic approach: the
+Investment team already separates computation (Strategy Lab, market
+data) from LLM narration (Advisor/IPS), and the LLM Service has a
+structured-output contract (PR #184) for the parse half of this
+problem. The nutrition team has not yet adopted either pattern.
+
+## Decision
+
+We will split the Nutritionist agent into a **deterministic calculator**
+and an **LLM narrator**, and extend `ClientProfile` with the biometric
+and clinical fields the calculator requires.
+
+### 1. Extend the profile (`models.py`)
+
+Add a `BiometricInfo` block and clinical fields to `ClientProfile`:
+
+- `sex: Literal["female","male","other","unspecified"]`
+- `age_years: int | None`
+- `height_cm: float | None`
+- `weight_kg: float | None`
+- `body_fat_pct: float | None` (optional; enables Katch–McArdle)
+- `activity_level: Literal["sedentary","light","moderate","active","very_active"]`
+  mapped to PAL multipliers (1.2 / 1.375 / 1.55 / 1.725 / 1.9)
+- `medical_conditions: list[str]` (free-text tags, e.g. `ckd_stage_3`,
+  `hypertension`, `t2_diabetes`, `pregnancy_t2`, `lactation`)
+- `medications: list[str]`
+- `target_weight_kg: float | None` and `rate_kg_per_week: float | None`
+  for cut/bulk targets
+
+Existing `GoalsInfo.goal_type` stays as the high-level intent
+(`maintain`, `lose_weight`, `gain_weight`, `muscle`); the calculator
+consumes both.
+
+### 2. Deterministic calculator
+
+Add `nutrition_meal_planning_team/nutrition_calc/` as a pure-Python
+module with no LLM dependency:
+
+- `bmr.py` — Mifflin–St Jeor as default; Katch–McArdle when
+  `body_fat_pct` is present.
+- `tdee.py` — `BMR × PAL` with documented multipliers.
+- `energy_goal.py` — apply the goal delta (−500 kcal/day for 0.45 kg/wk
+  loss, capped at a floor of `max(1200, 0.8×BMR)` for safety; symmetric
+  surplus for gain).
+- `macros.py` — protein by body weight (1.2–2.0 g/kg clamped by
+  goal/condition), fat ≥ 20% of kcal, carbs = remainder; all clamped to
+  AMDR bands (P 10–35%, F 20–35%, C 45–65%).
+- `micros.py` — DRI lookup by sex/age/pregnancy-lactation for fiber,
+  sodium cap, potassium, iron, calcium, vitamin D, B12; returns both a
+  target and an upper limit where one exists.
+- `clinical_overrides.py` — condition-specific clamps applied last
+  (e.g. CKD stage 3: protein ≤ 0.8 g/kg; hypertension: sodium ≤ 1500 mg;
+  pregnancy T2/T3: +340/+450 kcal; lactation: +330–400 kcal).
+- `targets.py::compute_daily_targets(profile) -> (DailyTargets, Rationale)`
+  — orchestrates the above, returning the numbers **and** a structured
+  `Rationale` (which equations ran, which overrides applied, which
+  inputs were defaulted). The rationale is what makes the output
+  auditable.
+
+All functions are unit-tested against published reference values
+(Mifflin–St Jeor worked examples, DRI tables, AMDR bands).
+
+### 3. LLM narrator
+
+`NutritionistAgent.run` becomes:
+
+1. `targets, rationale = compute_daily_targets(profile)`.
+2. If any required input is missing, return a `NutritionPlan` with the
+   computed fields populated where possible plus a `notes` field asking
+   for the missing inputs — do **not** ask the LLM to fill numeric gaps.
+3. Call the LLM with `(profile, targets, rationale)` and ask only for
+   `balance_guidelines`, `foods_to_emphasize`, `foods_to_avoid`, and
+   `notes`. The prompt explicitly forbids emitting or modifying numeric
+   targets.
+4. Use the `llm_service` structured-output contract (no regex
+   markdown stripping) to parse.
+5. Merge: narrative fields from the LLM, numeric fields from the
+   calculator. The calculator wins on conflict.
+
+### 4. Persistence and caching
+
+- `NutritionPlan` gains `rationale: Rationale` (versioned; see below)
+  and `calculator_version: str`.
+- `nutrition_plan_store.get_cached_plan` invalidates when
+  `calculator_version` changes **or** when any biometric /
+  clinical-override-relevant field changes, not just when the full
+  profile hash changes.
+
+### 5. Safety rails
+
+- Hard refuse (calculator raises) on biologically implausible inputs
+  (age < 2 or > 120, BMI < 10 or > 80, kcal floor breach after goal
+  delta).
+- Pregnancy, lactation, eating-disorder history, or age < 18 route to a
+  narrower "general guidance only" path with an explicit
+  "consult your clinician" note; we do not emit aggressive deficits for
+  these cohorts regardless of `goal_type`.
+- Medication/condition interactions remain the responsibility of the
+  allergen/interaction guardrail (separate ADR); this ADR only ensures
+  the calculator's outputs reflect clinical clamps.
+
+## Consequences
+
+### Positive
+
+- Daily targets become reproducible, testable, and explainable. We can
+  show the user the equation, the inputs, and the overrides.
+- Downstream work (nutrient rollup, adherence tracking, goal progress)
+  has a stable, trustworthy baseline.
+- Clinical cohorts are handled by code that can be reviewed and
+  regression-tested, not by prompt suggestions.
+- Cost and latency of the nutrition-plan path drop (the LLM is doing
+  ~1/3 of the work it was; parsing is simpler).
+- Opens the door to a "Why these numbers?" UI panel, which is a large
+  trust win in consumer health.
+
+### Negative / costs
+
+- **Profile migration.** New required-ish fields on `ClientProfile`
+  require a Postgres migration, an intake-flow change, and a backfill
+  strategy for existing profiles (likely: mark plans stale, prompt the
+  user for the missing inputs on next visit).
+- **Intake UX gets heavier.** We are asking for height/weight/age/sex
+  that we did not previously ask for. Mitigation: progressive
+  disclosure — gate full numeric plans on having these, but keep the
+  guideline/meal paths usable with partial profiles.
+- **Clinical review burden.** Once we ship equations, they are our
+  equations. We need a documented owner and a review cadence for
+  `clinical_overrides.py` and `micros.py`; reference tables drift (DRIs
+  are revised periodically).
+- **Breaking change for API consumers** reading `NutritionPlan` — the
+  added `rationale` and `calculator_version` fields are additive
+  (non-breaking), but guideline-authoring clients that relied on the
+  LLM's numeric outputs will see those numbers stabilize and sometimes
+  change versus today's output. This is the intended behavior but
+  should be called out in the CHANGELOG.
+- **Scope creep risk.** `clinical_overrides.py` can grow indefinitely.
+  We keep it to a short, cited allowlist of conditions in v1; anything
+  beyond that returns a "consult your clinician" note rather than a
+  half-implemented clamp.
+
+### Neutral / follow-ups
+
+- A subsequent ADR will cover the deterministic allergen /
+  drug–nutrient interaction guardrail (item #2 on the nutrition-team
+  roadmap), which sits on top of the profile additions made here.
+- A follow-up spec will cover the nutrient-rollup / meal-plan
+  validation loop (roadmap item #3), which depends on this ADR for its
+  "expected daily targets" input.
+- UI work to collect the new biometric fields and to render the
+  `Rationale` panel is tracked separately under the nutrition UX
+  workstream.

--- a/system_design/adr/ADR-002-nutrition-allergen-interaction-guardrail.md
+++ b/system_design/adr/ADR-002-nutrition-allergen-interaction-guardrail.md
@@ -1,0 +1,197 @@
+# ADR-002 — Deterministic allergen, dietary, and drug–nutrient interaction guardrail for meal recommendations
+
+- **Status**: Proposed
+- **Date**: 2026-04-17
+- **Owner**: Nutrition & Meal Planning team
+- **Related**: ADR-001 (deterministic daily targets), `backend/agents/nutrition_meal_planning_team/`
+
+## Context
+
+Allergen, dietary, and drug-interaction enforcement today is purely
+prompt-based. The meal-planning agent prompt
+(`agents/meal_planning_agent/agent.py`) says "respect
+`max_cooking_time_minutes`... avoid ones like past misses", and the
+nutritionist prompt (`agents/nutritionist_agent/agent.py`) says
+"respect allergies and dietary needs" — and that is the entire
+mechanism. An LLM asked for a "nut-free dinner" will occasionally emit
+almond flour, pesto (pine nuts), marzipan garnishes, or
+Worcestershire (anchovy, for pescatarian-except-fish users). For a
+warfarin patient it will cheerfully recommend a kale-and-spinach salad.
+
+Three forces make this the highest-severity bug class on the team:
+
+1. **Asymmetric cost.** A recommendation-quality miss costs one meal.
+   An allergen miss can cost a life; a warfarin × vitamin-K miss can
+   land a patient in the ED. The product cannot ship to any medical
+   cohort — or arguably to any consumer — without a deterministic
+   backstop.
+2. **LLM behavior is probabilistic and drifts with model swaps.** We
+   already support multiple providers (Ollama, Claude) via
+   `llm_service`; each upgrade silently changes the prompt-adherence
+   surface. A guardrail that depends on the current model's
+   instruction-following is a guardrail that expires.
+3. **The ingredient representation is ambiguous.** `MealRecommendation.
+   ingredients: List[str]` is free text ("1 tbsp soy sauce", "a handful
+   of cashews", "Parmesan"). Even a perfect prompt cannot make a
+   downstream filter work if ingredients are not normalized.
+
+We explicitly scope this ADR to the **enforcement** layer. The ADR-001
+calculator clamps *numeric targets* for clinical cohorts; this ADR
+ensures the *ingredients themselves* in every emitted recommendation
+are legal for this client.
+
+## Decision
+
+Introduce a deterministic post-generation guardrail that runs between
+the meal-planning agent and the orchestrator's recording step. Its
+contract: **no `MealRecommendationWithId` is persisted or returned to
+the API unless it has passed the guardrail.**
+
+### 1. Canonical ingredient model
+
+Add `nutrition_meal_planning_team/ingredient_kb/` containing:
+
+- `canonical_foods.yaml` — seed list of ~2,000 common ingredients keyed
+  by canonical id (`fdc_id` where available), each with:
+  - `allergen_tags`: subset of the fixed taxonomy below.
+  - `dietary_tags`: e.g. `animal`, `dairy`, `egg`, `honey`, `gluten`,
+    `high_fodmap`, `nightshade`, `alcohol`.
+  - `interaction_tags`: e.g. `vitamin_k_high`, `tyramine_high`,
+    `potassium_high`, `grapefruit`, `licorice`, `st_johns_wort`.
+  - `aliases`: free-text surface forms ("almond flour", "ground almonds",
+    "amandes en poudre").
+- `allergen_taxonomy.py` — fixed, closed enum: `peanut`, `tree_nut`,
+  `dairy`, `egg`, `soy`, `wheat`, `gluten`, `fish`, `shellfish`,
+  `sesame`, `mustard`, `celery`, `sulfites`, `lupin`, `mollusc`
+  (FDA Big-9 + EU-14 superset).
+- `parser.py::parse_ingredient(line: str) -> ParsedIngredient` —
+  deterministic rule-based parser that extracts `(qty, unit, name)` and
+  resolves `name` to a canonical id via aliases + fuzzy match. Unknown
+  items return `canonical_id=None` with a `confidence` score.
+
+### 2. Profile-side normalization
+
+On profile save (orchestrator `update_profile`), resolve
+`allergies_and_intolerances` and `dietary_needs` strings to:
+
+- `resolved_allergen_tags: set[AllergenTag]`
+- `resolved_dietary_tags: set[DietaryTag]` (e.g. `vegan` expands to
+  `forbid: {animal, dairy, egg, honey}`)
+
+Unresolved free-text stays on the profile as `unresolved_restrictions`
+and is shown to the user for confirmation. Ambiguity surfaces to the
+user; it does not silently pass.
+
+### 3. Guardrail pipeline
+
+Add `nutrition_meal_planning_team/guardrail/` with a single entry
+point `check_recommendation(profile, rec) -> GuardrailResult`:
+
+1. **Parse** each ingredient line with `parse_ingredient`.
+2. **Allergen check** — any parsed `allergen_tags` ∩
+   `profile.resolved_allergen_tags` → `reject(reason=allergen)`.
+3. **Dietary check** — any `dietary_tags` violating active dietary
+   tags → `reject(reason=dietary)`.
+4. **Interaction check** — for each `medications[]` tag, look up
+   contra-indicated `interaction_tags` in a curated
+   `interactions.yaml` (warfarin↔`vitamin_k_high`, MAOI↔`tyramine_high`,
+   ACEi/ARB + K-sparing diuretics↔`potassium_high`,
+   statins/amiodarone↔`grapefruit`, SSRIs↔`st_johns_wort`,
+   GLP-1↔`very_high_fat`). Hits → `flag` (not hard reject) with a
+   required "consult your clinician" note, unless the profile opts into
+   hard-reject for a given class.
+5. **Unknown-ingredient policy** — any `canonical_id=None` with
+   `confidence < threshold` → `reject(reason=unresolved_ingredient)`.
+   We fail closed: if we cannot tell what it is, we do not serve it.
+6. **Condition-specific caps** — e.g. CKD-3 caps *phosphorus* and
+   *potassium* flagged ingredients per meal; hypertension flags
+   >800 mg sodium per meal. These rely on per-ingredient nutrient data
+   (shared with the nutrient-rollup work in the follow-up ADR).
+
+Result is `{passed: bool, violations: [Violation], flags: [Flag]}`.
+
+### 4. Orchestrator integration
+
+`NutritionMealPlanningOrchestrator._record_suggestions` becomes a
+two-pass pipeline:
+
+1. Run guardrail on each suggestion.
+2. For each `rejected` suggestion, call a **targeted regeneration**: a
+   single-suggestion LLM call with the violation spelled out
+   ("replace this dinner; it contains `pine_nut` which violates
+   `tree_nut` allergy"). Accept up to `MAX_REGEN_RETRIES` (default 2).
+3. Suggestions that still fail after retries are **dropped, not
+   served**, and the response includes a `dropped_count` with
+   structured reasons so the UI can explain the gap ("We filtered 1
+   suggestion that conflicted with your nut allergy"). Trust is built
+   by *visible* enforcement.
+4. Flagged-but-not-rejected suggestions are served with the
+   `clinical_flags: [Flag]` attached to `MealRecommendationWithId`;
+   the UI renders them as a caution banner.
+
+### 5. Observability
+
+- Emit OTel metrics: `guardrail.rejections{reason}`,
+  `guardrail.flags{class}`, `guardrail.unknown_ingredient_rate`,
+  `guardrail.regen_retries`.
+- Log every rejection with profile id, ingredient, and resolved tag.
+  This is both a safety audit trail and the training signal for
+  iterating on `canonical_foods.yaml`.
+
+### 6. Versioning
+
+`canonical_foods.yaml` and `interactions.yaml` carry a `version` field
+persisted on every `MealRecommendation` record (`guardrail_version`).
+On version bump we re-run the guardrail against the active meal plan
+in the background and notify the user of any new rejections — relevant
+when a medication is added after the plan is generated.
+
+## Consequences
+
+### Positive
+
+- Allergen enforcement becomes a property of code, not of prompt
+  adherence. Model swaps no longer risk user safety.
+- Unknown ingredients fail closed; the failure mode is "missing
+  recommendation", not "mystery recommendation".
+- Creates the ingredient-resolution layer that the nutrient-rollup ADR
+  and the substitution agent (ADR-005) both need; this is the
+  foundational change that unlocks those.
+- Generates structured rejection data, which is the fastest way to
+  improve the prompt *and* the ingredient KB.
+- Gives the UI something honest to display ("1 suggestion filtered
+  for your shellfish allergy") — users perceive enforcement and trust
+  the product more.
+
+### Negative / costs
+
+- **KB curation is ongoing work.** Seeding ~2,000 ingredients is a
+  one-time lift; keeping aliases and tags correct is a long tail. We
+  will accept gaps initially and lean on the `unresolved` rejection
+  path plus logging to prioritize additions.
+- **Latency.** Targeted regenerations add up to `MAX_REGEN_RETRIES`
+  extra LLM calls per rejected suggestion. Expected worst case on a
+  7-day plan with strict allergies: +3–5 LLM calls. Mitigation: retries
+  are per-suggestion and can run concurrently.
+- **Free-text ingredient strings get stricter.** The LLM must emit
+  ingredients that parse; we will need prompt examples and a parse
+  loop until adherence is high enough. The guardrail will reject many
+  outputs from today's prompt until the prompt is tuned.
+- **False positives on edge cases.** Worcestershire-as-pescatarian,
+  gelatin-as-vegetarian, trace-dairy in processed foods — we will be
+  conservative (reject) and rely on user-editable overrides to relax.
+  Better a rejected valid meal than a served unsafe one.
+- **Clinical interaction coverage is deliberately narrow.** v1 covers
+  the listed med classes only; anything outside the allowlist is a
+  "consult your clinician" flag, never a silent pass. Scope discipline
+  here is load-bearing — this file must not become WebMD.
+
+### Neutral / follow-ups
+
+- Substitution agent (ADR-005) reuses the guardrail verbatim: a
+  proposed swap is not emitted unless it passes the same check.
+- Nutrient-rollup ADR (ADR-003) consumes the parsed, canonicalized
+  ingredient list; no separate parse is needed.
+- A separate UI spec covers the "filtered suggestions" explanation,
+  the flag banner, the ambiguity-resolution dialog for
+  `unresolved_restrictions`, and the override UX for edge cases.

--- a/system_design/adr/ADR-003-nutrition-quantitative-meal-plan-validation.md
+++ b/system_design/adr/ADR-003-nutrition-quantitative-meal-plan-validation.md
@@ -1,0 +1,201 @@
+# ADR-003 — Quantitative meal-plan validation: per-recipe nutrient rollup and targeted repair
+
+- **Status**: Proposed
+- **Date**: 2026-04-17
+- **Owner**: Nutrition & Meal Planning team
+- **Related**: ADR-001 (deterministic daily targets), ADR-002 (ingredient canonicalization), `backend/agents/nutrition_meal_planning_team/`
+
+## Context
+
+Today the meal-planning agent returns `MealRecommendation` items with
+`ingredients: List[str]`, a rationale sentence, and no nutrient data.
+The orchestrator records each suggestion and returns them — nothing
+verifies that the week's meals add up to the `NutritionPlan.daily_targets`.
+`DailyTargets` and the meal plan are produced in sequence but never
+reconciled.
+
+This is the reason "a plan" feels like "a list of suggestions". Three
+concrete consequences:
+
+1. **The product cannot make a goal claim.** We cannot tell a user on
+   a 1,700 kcal / 130g protein target whether the plan we served them
+   actually lands there — or whether Tuesday is 900 kcal and Friday is
+   2,600. Adherence tracking, weight-loss progress, and diabetes carb
+   distribution all depend on this number existing.
+2. **Clinical cohorts are unserved.** CKD protein caps, hypertension
+   sodium caps, and T2D carb-per-meal distribution are per-meal or
+   per-day *quantitative* constraints. ADR-001's calculator produces
+   them; nothing here checks them. The calculator is toothless without
+   a rollup.
+3. **No substitution surface.** When a user rejects Tuesday dinner, we
+   have no way to ask for a replacement that "hits ≥35 g protein and
+   ≤800 mg sodium" — because we do not know what the current Tuesday
+   dinner contains either.
+
+ADR-002 introduces canonical ingredient ids and a parser. That
+unlocks deterministic nutrient lookup; this ADR defines how we use it.
+
+## Decision
+
+Add a **nutrient-rollup** stage between `meal_planning_agent.run` and
+`_record_suggestions`, and a **targeted-repair** loop that swaps
+specific meals when daily totals fall outside tolerance bands.
+
+### 1. Per-ingredient nutrient data
+
+Extend `ingredient_kb/` (ADR-002) with a nutrient table. Source of
+truth: USDA FoodData Central (FDC) SR Legacy + Foundation Foods +
+Branded Foods for packaged items. Cached in Postgres:
+
+- `ingredient_nutrients(canonical_id, nutrient_id, per_100g)` — macros
+  plus the micros ADR-001 targets (fiber, sodium, potassium, iron,
+  calcium, vitamin D, B12, phosphorus for CKD, vitamin K for warfarin).
+- `ingredient_density(canonical_id, unit, grams)` — household-unit to
+  gram conversions (1 cup spinach raw = 30 g; 1 tbsp olive oil = 13.5 g)
+  so we can convert parsed quantities to mass.
+- Refreshed via a scheduled job; version-stamped for cache
+  invalidation.
+
+### 2. Recipe nutrient computation
+
+Add `nutrition_meal_planning_team/nutrient_rollup/` with:
+
+- `recipe.py::compute_recipe_nutrients(rec: MealRecommendation)
+  -> RecipeNutrients` — for each parsed ingredient, resolve qty to
+  grams via density table, multiply by `per_100g`, sum, then divide by
+  `portions_servings` to get per-serving values.
+- Handling for cooked-vs-raw (water loss) via a small retention-factor
+  table on `canonical_foods.yaml` for items where it matters most
+  (meat, pasta, rice, leafy greens).
+- `confidence: float` on each `RecipeNutrients`, driven by the share
+  of ingredient mass successfully resolved. Low-confidence recipes are
+  surfaced, not silently assumed correct.
+
+`MealRecommendationWithId` gains:
+```
+nutrients_per_serving: RecipeNutrients
+nutrients_confidence: float
+```
+
+### 3. Plan-level rollup
+
+Add `plan.py::rollup_plan(suggestions, period_days) -> PlanRollup`:
+
+- `by_day: dict[date, DailyTotals]` — sums the suggestions assigned to
+  each day via `suggested_date`.
+- `variance_vs_target: dict[date, dict[nutrient, pct_delta]]` — each
+  nutrient's delta vs `DailyTargets` from ADR-001.
+- `weekly_totals` and `weekly_variance` for nutrients where weekly
+  adequacy matters more than per-day (vitamin D, iron).
+- `per_meal_caps_breached: list[Breach]` — per-meal sodium, carb, or
+  phosphorus caps from clinical overrides.
+
+### 4. Tolerance policy
+
+Configurable per-nutrient tolerances, with clinically tighter defaults:
+
+- Calories: ±10% day, ±5% week.
+- Protein: −10% / +25% day.
+- Carbs: AMDR band enforced; T2D profile: per-meal carb cap from
+  calculator.
+- Sodium: cap-only; violation if `day > cap` or `meal > per_meal_cap`.
+- Fiber, K, Ca, Fe, D, B12: weekly adequacy, ≥80% of target averaged.
+- Saturated fat: cap at 10% of kcal (AHA default; overridable).
+
+Tolerances live in `nutrient_rollup/tolerances.yaml`, versioned the
+same way as `canonical_foods.yaml`.
+
+### 5. Targeted-repair loop
+
+If the rollup surfaces violations:
+
+1. Rank violations by severity (hard cap breach > macro out-of-band >
+   micro adequacy gap).
+2. For each violation, build a **minimal swap request** targeting the
+   specific day and meal(s) that move the totals back in-band — e.g.
+   "replace Tuesday lunch with a meal that has ≥35 g protein, ≤800 mg
+   sodium, ≤45 g carbs, prep ≤20 min, no shellfish".
+3. Call the meal-planning agent with a single-suggestion prompt
+   (concurrency across independent swaps).
+4. Swaps pass through the ADR-002 guardrail unchanged.
+5. Re-run the rollup. Stop when all violations resolve or
+   `MAX_REPAIR_ITERS` (default 2) is reached. Remaining gaps are
+   surfaced, not hidden.
+
+This is explicitly *swap*, not *regenerate*: users hate losing the
+meals they already liked on the screen. Only the specific offending
+meals move.
+
+### 6. API surface
+
+- `MealPlanResponse` gains:
+  ```
+  rollup: PlanRollup
+  repair_history: list[RepairAttempt]   # what we swapped and why
+  ```
+- New endpoint `POST /plan/meals/{id}/swap` — swap a single meal the
+  user rejected, using the same single-suggestion path; returns the
+  new recommendation plus the updated rollup.
+- `GET /history/meals` entries gain `nutrients_per_serving` so past
+  meals can be re-analyzed without re-derivation.
+
+### 7. Caching and cost
+
+- Recipe-level nutrient rollups are content-addressed by a hash of
+  `(canonical_ingredient_ids, quantities, portions)` and cached.
+  Repeated recipes (and the substitution agent) hit cache.
+- FDC lookups are local (Postgres). Zero per-request network cost.
+- Repair-loop LLM calls are single-suggestion, so worst-case latency
+  is `MAX_REPAIR_ITERS × swap_count` extra short calls, parallelized.
+
+## Consequences
+
+### Positive
+
+- The plan becomes a plan. Users see daily totals and a clear "you're
+  meeting your targets" state — the largest perceived-quality jump
+  available to us.
+- Clinical calculator clamps (ADR-001) become enforceable:
+  protein-capped CKD diets, sodium-capped HTN diets, and carb-
+  distributed T2D diets actually behave that way.
+- Substitution UX (ADR-005) gets its targeting primitive for free.
+- Adherence / goal-tracking data is now first-class: we can show
+  weekly deviation and correlate with weight trends once that
+  workstream lands.
+- Low-confidence recipes get flagged, not silently trusted — failure
+  mode is visible.
+
+### Negative / costs
+
+- **FDC coverage and parse quality are the load-bearing inputs.**
+  Rollups are only as good as ingredient resolution (ADR-002) and the
+  density table. Early confidence scores will be mixed. We mitigate by
+  refusing to make strong claims on low-confidence plans and by using
+  rejections as the backlog signal for KB work.
+- **Latency floor rises.** Even cache-hit paths add rollup compute and
+  a variance check; cache-miss paths add one LLM swap per violation.
+  Budget: +300–800 ms typical, +2–4 s worst case on the async path.
+  Mitigation: the async `/plan/meals/async` endpoint already exists;
+  the sync path remains for small plans.
+- **Moving the goalposts changes behavior.** Users who today see a
+  plan instantly will sometimes see a "we adjusted Tuesday to hit your
+  protein target" message. That is a feature, not a regression, but
+  needs clear UX so it does not feel like indecision.
+- **Tolerance tuning is political.** Any number we pick will argue
+  with someone's diet philosophy. We keep tolerances in a versioned
+  config file and expose per-profile overrides for advanced users;
+  defaults are conservative and cited.
+- **Repair loops can get stuck.** A profile with tight allergies +
+  tight clinical clamps + tight time budget may be infeasible.
+  `MAX_REPAIR_ITERS` plus visible unresolved gaps prevents silent
+  thrashing; we will iterate on the surface.
+
+### Neutral / follow-ups
+
+- Substitution endpoint and cook-mode feedback (ADR-005) both build
+  directly on this ADR's rollup + swap primitives.
+- Adherence tracking ("did the user actually cook it?") is a separate
+  workstream; this ADR gives it the denominator it needs.
+- A future optimization pass can replace the greedy targeted-repair
+  loop with a small ILP over candidate swaps when the catalog grows;
+  out of scope for v1.

--- a/system_design/adr/ADR-004-nutrition-structured-learned-preferences.md
+++ b/system_design/adr/ADR-004-nutrition-structured-learned-preferences.md
@@ -1,0 +1,229 @@
+# ADR-004 — Structured learned preferences: extract, store, and retrieve per-client taste signals
+
+- **Status**: Proposed
+- **Date**: 2026-04-17
+- **Owner**: Nutrition & Meal Planning team
+- **Related**: ADR-002 (canonical ingredients), ADR-003 (nutrient rollup), `backend/agents/nutrition_meal_planning_team/agents/meal_planning_agent/`
+
+## Context
+
+The learning-from-feedback loop is the team's product thesis (README
+section "Learning-from-feedback flow"). The implementation is thinner
+than the pitch:
+
+- `_summarize_history` (`agents/meal_planning_agent/agent.py`) produces
+  `"Past hits (they liked these): chicken tikka, shakshuka, ..."` and
+  `"Past misses (avoid similar): tofu stir-fry, ..."` — a
+  comma-separated list of **meal names, up to 15 each**.
+- Free-text `notes` on `FeedbackRecord` ("too spicy", "loved the
+  one-pan idea, but too much prep") are discarded by the summarizer.
+- The binary `would_make_again` and the 1–5 rating are the only
+  structured signal that survives.
+- There is no retrieval or embedding step; the LLM is expected to
+  generalize from raw names.
+
+Three consequences:
+
+1. **Slow convergence.** A user needs 10–15 rounds of feedback before
+   the system reliably matches their preferences, because meal names
+   carry almost no generalization signal ("chicken tikka" doesn't tell
+   the model whether they liked the chicken, the sauce, the spice, or
+   the one-pan format).
+2. **Wasted signal.** The richest data users give us — free-text notes
+   — is thrown away.
+3. **No trust surface.** Users cannot see what the system has learned
+   about them. In consumer health, *visible* learning is the single
+   biggest driver of stickiness; invisible learning is indistinguishable
+   from no learning.
+
+We need structured preference features that the planner can condition
+on and the user can inspect and correct.
+
+## Decision
+
+Introduce a `LearnedPreferences` record per client, updated after every
+feedback submission, stored in Postgres, and fed into the
+meal-planning prompt and a retrieval step.
+
+### 1. Preference dimensions (v1 taxonomy)
+
+Fixed, closed set — extensible in minor versions only:
+
+- `ingredient_affinity: dict[canonical_id, score]` — signed score per
+  canonical ingredient (uses ADR-002's ids).
+- `cuisine_affinity: dict[cuisine_tag, score]` — `italian`,
+  `south_indian`, `levantine`, etc.
+- `flavor_affinity: dict[flavor_tag, score]` — `spicy`, `umami`,
+  `sweet`, `sour`, `bitter`, `fermented`, `smoky`.
+- `texture_affinity: dict[texture_tag, score]` — `crispy`, `creamy`,
+  `chewy`, `crunchy`, `soft`.
+- `format_affinity: dict[format_tag, score]` — `one_pan`, `sheet_pan`,
+  `no_cook`, `meal_prep`, `handheld`, `bowl`, `soup_stew`.
+- `protein_affinity: dict[protein_tag, score]` — `chicken`, `beef`,
+  `pork`, `fish`, `shellfish`, `tofu`, `tempeh`, `seitan`, `legume`.
+- `effort_tolerance: {weekday, weekend}` — learned cooking-time band,
+  separate from the profile's hard `max_cooking_time_minutes` (which
+  is an absolute limit).
+- `portion_skew: float` — learned ratio of served vs. user's preferred
+  portion size (from notes like "too much", "not filling").
+- `novelty_preference: float` — how often this user rewards unfamiliar
+  meals vs. repeats of hits.
+
+All `score` fields are signed floats, not raw counts (see §3).
+
+### 2. Feedback extraction
+
+Add `nutrition_meal_planning_team/preferences/extractor.py`:
+
+- Input: `(MealRecommendation, FeedbackRecord)` and the current
+  `LearnedPreferences`.
+- Small LLM call with a strict structured-output schema (via
+  `llm_service` structured-output contract from PR #184) returning a
+  `FeedbackSignals` object: dimensions present in this feedback with
+  signed strengths in `[-1, 1]`.
+- Input to the LLM: the meal's canonical ingredients + cuisine/format
+  tags (derived, not LLM-inferred) + the user's free-text note + the
+  rating + `would_make_again`.
+- Parsed signals are deterministic from that point on.
+
+Important: the LLM extracts *what the note says*, not *what it
+predicts*. It is a parser, not a recommender.
+
+### 3. Update rule
+
+Scores use a **Beta / Bayesian-smoothed EWMA**, not raw counts:
+
+- Each dimension tracks `(alpha, beta)` pseudo-counts plus a decay
+  factor. Posterior mean maps to the signed score.
+- Recent feedback weighs more (decay λ ≈ 0.02 per day), so tastes are
+  allowed to drift.
+- Explicit rating strength modulates update magnitude (5★ + "loved"
+  note → larger update than 4★ silent).
+- Free-text "loved" / "hated" signals from extractor contribute
+  independently of the numeric rating.
+- Minimum-evidence gate: dimensions with fewer than `N_MIN` (default 3)
+  pieces of supporting feedback are not surfaced in the planner prompt
+  or the UI. We do not want to claim "you hate cilantro" after one
+  meal.
+
+### 4. Planner integration
+
+`meal_planning_agent.run` is changed to receive a
+`PreferenceDigest` — a trimmed view of `LearnedPreferences`:
+
+- Top-K positive and top-K negative signals across all dimensions
+  (default K=6), each with a confidence band.
+- A short natural-language summary (generated once per digest update,
+  cached) — *"Leans toward one-pan meals, spicy + umami flavors,
+  chicken and legumes. Avoids very long prep on weekdays. Meh on raw
+  tofu but fine on crispy tofu."* — for prompt economy.
+- The meal-names list is reduced from 15 to the top 5 highest-rated
+  hits, primarily for retrieval (§5), not for the LLM to pattern-match.
+
+The prompt now contains features, not names. Generalization improves
+by a large margin because the LLM can reason over dimensions rather
+than guess patterns from meal titles.
+
+### 5. Retrieval
+
+Add `preferences/retrieval.py`:
+
+- Embed every past recommendation on write (using an already-available
+  embedding model; ingredient + cuisine + format + name).
+- On plan generation, retrieve top-N similar past hits (N=5) and
+  bottom-M recent misses (M=3) as few-shot exemplars in the prompt.
+- Retrieval is filtered by the current profile constraints (allergies,
+  dietary) before being injected, to avoid surfacing now-illegal
+  exemplars.
+
+Exemplars + digest together give the planner both concrete patterns
+and abstract features.
+
+### 6. User-visible preference panel
+
+New endpoints:
+
+- `GET /preferences/{client_id}` — returns `LearnedPreferences` with
+  confidence bands, plus the `PreferenceDigest` shown to the planner.
+- `PUT /preferences/{client_id}/override` — user can pin ("I do like
+  mushrooms, stop avoiding them") or exclude dimensions from the
+  prompt. Overrides live alongside learned scores and always win.
+- `DELETE /preferences/{client_id}/signal/{dim}/{key}` — forget a
+  single learned point. Required for the UX, and sometimes for
+  compliance (user correcting an embarrassing wrong inference).
+
+UI implication (tracked separately): editable chips on the profile
+page, e.g. `Loves one-pan ✓` `Avoids cilantro ✓ (edit)`. This is
+where trust is earned.
+
+### 7. Cold-start
+
+- For users with no feedback, `LearnedPreferences` is empty; planner
+  falls back to today's profile-only behavior.
+- Optional onboarding quiz (post-intake): 10 images / descriptions, 1-
+  tap like/dislike, seeds the dimensions with low-confidence priors.
+  Cuts cold-start rounds roughly in half based on analogous product
+  data; treat as v1.1 if onboarding UX slips.
+
+### 8. Privacy and data lifecycle
+
+- `LearnedPreferences` is personal data. Stored in
+  `nutrition_preferences` table; deleted on account deletion alongside
+  profile.
+- Extractor LLM calls do not include `client_id` or free-text notes in
+  logs above DEBUG. Structured `FeedbackSignals` are retained; raw
+  notes are retained only where the user account retains them.
+- Overrides and deletions are honored before the next planner call
+  (no async propagation window for privacy-sensitive operations).
+
+## Consequences
+
+### Positive
+
+- Personalization converges in ~3–5 rounds instead of 10–15; the
+  signal per feedback event is much higher because notes are no
+  longer discarded.
+- Free-text feedback becomes a first-class data product, not a
+  write-only field.
+- Visible, editable learned preferences — the single biggest driver of
+  trust in consumer food apps. Users can correct us; the system feels
+  cooperative rather than opaque.
+- Retrieval unlocks few-shot grounding, which is more robust to prompt
+  and model changes than leaning on raw training priors.
+- Clean separation: *extraction* is LLM, *update* is deterministic,
+  *retrieval* is deterministic, *narration* is LLM. Each layer is
+  testable on its own.
+
+### Negative / costs
+
+- **Extra LLM call per feedback.** One structured-output call per
+  feedback record. Small, cheap, and asynchronous, but non-zero.
+  Mitigation: run in the feedback-endpoint background task; if the
+  extractor fails, store the raw feedback and retry — user-facing
+  response does not wait.
+- **Privacy surface grows.** Storing learned taste data is richer than
+  storing raw ratings. Warrants a short privacy review and a visible
+  "what we've learned" page (built as part of §6 — solves product
+  trust and compliance simultaneously).
+- **Taxonomy is opinionated.** The v1 dimensions are a guess at what
+  matters. Some dimensions will carry no signal; others will be
+  missing. Mitigation: log `dim_hit_rate` and revise the taxonomy on a
+  cadence; keep it closed in prod to avoid score-schema churn.
+- **Embeddings add a moving part.** A new index, a new model version to
+  track, and a reindex cost on model swap. Keep the embedding choice
+  conservative and swap-aware (version the vectors).
+- **Can over-specialize.** Pure exploitation converges on a narrow
+  menu. `novelty_preference` plus an ε-exploration term in the
+  retrieval call (default ε=0.1) preserves variety.
+
+### Neutral / follow-ups
+
+- The cook-mode feedback surface (ADR-005) multiplies the volume of
+  signal by ~10× (every cooked meal emits structured signals, not
+  just ones the user bothers to rate). This ADR is designed to
+  absorb that volume with no schema change.
+- Adherence tracking gives us a third axis (did they actually eat it)
+  that the update rule can consume in v2.
+- A future ADR can consider cross-user collaborative signals (matrix
+  factorization over the same dimensions); out of scope for v1 and
+  has its own privacy calculus.

--- a/system_design/adr/ADR-005-nutrition-actionable-workflow-layer.md
+++ b/system_design/adr/ADR-005-nutrition-actionable-workflow-layer.md
@@ -1,0 +1,229 @@
+# ADR-005 — Actionable workflow layer: grocery list, pantry, substitutions, calendar, cook mode
+
+- **Status**: Proposed
+- **Date**: 2026-04-17
+- **Owner**: Nutrition & Meal Planning team (+ Integrations team for calendar)
+- **Related**: ADR-002 (canonical ingredients), ADR-003 (nutrient rollup + swap), ADR-004 (learned preferences), `backend/agents/nutrition_meal_planning_team/`, `backend/agents/integrations/`
+
+## Context
+
+The team currently ends at `MealPlanResponse`: a list of
+`MealRecommendationWithId`. From the user's point of view, getting the
+list is step one of about eight:
+
+1. Read the list.
+2. Mentally reconcile overlapping ingredients (three recipes call for
+   red onion — how many do I need?).
+3. Subtract what is already in the pantry.
+4. Build a shopping list, grouped by supermarket section.
+5. Go shopping.
+6. Realize on Tuesday they are out of Greek yogurt; figure out what to
+   substitute.
+7. Remember to start Tuesday dinner in time to eat by 7.
+8. Follow the recipe while their hands are covered in olive oil.
+
+Steps 2–8 are where users churn. The nutrition team owns the hardest
+part (the plan) and cedes the part users actually live in (the week).
+Every consumer meal-planning product that retains users wins by
+owning that week-layer, not by having better recommendations.
+
+Two enabling shifts in this roadmap make the workflow layer feasible
+now:
+
+- ADR-002 canonicalizes ingredients (so aggregation and pantry
+  subtraction are deterministic).
+- ADR-003 attaches nutrients to each recipe and exposes a swap
+  primitive (so substitutions are nutrient-aware, not just
+  ingredient-aware).
+
+This ADR specifies the workflow layer on top.
+
+## Decision
+
+Add five coordinated capabilities, each a thin layer on the primitives
+already established in ADR-001–004. Explicitly: **no new LLM agents
+are strictly required for v1**; the existing meal-planning agent,
+plus deterministic aggregation and the Integrations team, covers it.
+
+### 1. Consolidated grocery list
+
+- New endpoint: `POST /plan/meals/{plan_id}/grocery-list` returning a
+  `GroceryList` grouped by supermarket section.
+- Aggregation uses parsed, canonicalized ingredients from ADR-002 and
+  the density table from ADR-003:
+  1. Parse every ingredient line in the plan.
+  2. Convert all quantities to canonical units (g or ml) via density.
+  3. Sum by `canonical_id`.
+  4. Convert back to **purchase units** (a "red onion" is a count, not
+     100 g) via a `purchase_unit` field on `canonical_foods.yaml`.
+  5. Round up with a configurable waste-buffer (default 10%).
+  6. Group by `aisle_tag` (`produce`, `dairy`, `pantry`, `meat_fish`,
+     `frozen`, `bakery`, `spices`, `other`).
+- Persisted as `grocery_lists` in Postgres; re-generatable on demand.
+- Exportable: plain text, CSV, and a signed deep-link the UI can pass
+  to third-party cart integrations later (Instacart, Amazon Fresh —
+  out of scope for v1 but the data shape supports it).
+
+### 2. Pantry
+
+- New store: `pantry_items(client_id, canonical_id, quantity_g,
+  unit_display, expires_on?)`.
+- Endpoints: `GET/POST/PUT/DELETE /pantry/{client_id}`; bulk
+  `POST /pantry/{client_id}/import` from a text dump (LLM-parsed via
+  the ADR-002 parser, surfaced to the user for confirmation — we do
+  not silently mutate pantry).
+- Grocery-list generation subtracts pantry quantities **before**
+  rounding; the shortfall is what lands on the list.
+- Cooking a recipe (see §5) optionally decrements pantry by the
+  recipe's ingredient quantities. Off by default; opt-in per user
+  because auto-pantry-debit is a trust decision.
+- Near-expiry items (≤3 days) surface on `POST /plan/meals` as hints:
+  the planner prompt gets a short "prefer meals using: tofu,
+  spinach, yogurt (expiring soon)" line. Cheap and reduces waste.
+
+### 3. Substitution
+
+- New endpoint:
+  `POST /plan/meals/{plan_id}/recipes/{rec_id}/substitute` with body
+  `{out_of: [canonical_id], have_instead?: [canonical_id], reason?: str}`.
+- Flow:
+  1. Build a single-suggestion LLM call with the full recipe plus
+     explicit constraint ("without `greek_yogurt`; acceptable swaps
+     from pantry: `sour_cream`, `silken_tofu`; otherwise any
+     nutritionally similar option").
+  2. Pass through the ADR-002 guardrail.
+  3. Run nutrient rollup (ADR-003) on the swapped recipe; report the
+     delta ("calories −40, protein −6 g, calcium −120 mg").
+  4. If the swap breaks a per-meal cap or pushes the day out of
+     tolerance beyond `SUB_TOLERANCE`, return with `warn=true` and
+     let the user decide.
+- A lightweight deterministic fallback for the common 20 swaps
+  (yogurt↔sour cream, butter↔olive oil for sautéing, milk↔oat milk,
+  etc.) is tried before the LLM call to cut latency.
+
+### 4. Calendar + reminders
+
+- Reuse the Integrations team's Google Calendar client (the team
+  already owns Google OAuth; see CLAUDE.md on `shared` Google browser
+  login). No new OAuth surface.
+- New endpoints:
+  - `POST /plan/meals/{plan_id}/calendar/sync` — creates events for
+    each recipe's `suggested_date` + mealtime window, with
+    prep-time-aware reminders (`reminder = mealtime -
+    (prep_time + cook_time + buffer)`).
+  - `DELETE /plan/meals/{plan_id}/calendar/sync` — removes them.
+- Event body contains a deep link to the cook-mode view (§5) plus
+  ingredient checklist and nutrient summary.
+- Respect user-configured mealtime windows from the profile
+  (`preferences.mealtime_windows` — small profile addition).
+- Per-event reminders use local timezone from the profile (adds a
+  `timezone` field; tiny migration).
+
+### 5. Cook mode + structured cooking feedback
+
+- UI-side primarily, but the backend exposes the data model:
+  - `GET /plan/meals/{plan_id}/recipes/{rec_id}/cook-mode` — returns a
+    step-ordered structure: `{ingredients, steps, timers,
+    nutrients_per_serving, safety_flags}`. Steps come from the
+    recipe's `steps: list[CookStep]` — a new field on
+    `MealRecommendation`; the meal-planning prompt is updated to emit
+    it (non-breaking: absence falls back to rationale-only).
+  - `POST /plan/meals/{plan_id}/recipes/{rec_id}/cooked` with body
+    `{status: "made"|"partial"|"skipped"|"swapped",
+      servings_made, feedback?: FeedbackRecord,
+      substitutions?: [...]}`.
+- The `cooked` event is the data-layer key change: it separates
+  **adherence** ("did they cook it?") from **preference** ("did they
+  like it?"). Today we conflate them.
+- Emits `FeedbackRecord` into the existing feedback pipeline
+  unchanged, and emits structured cooking events into ADR-004's
+  extractor with much richer signal ("partial, ran out of time" →
+  `effort_tolerance` downward weekday; "swapped tofu for chicken,
+  loved it" → strong protein-affinity signal).
+- Cook-mode can decrement pantry (§2) on "made" if the user opted in.
+
+### 6. Data model additions (summary)
+
+New / modified:
+
+- `MealRecommendation.steps: list[CookStep]` (additive, optional).
+- `MealRecommendation.purchase_unit_hints: dict[canonical_id, unit]`
+  — optional, helps grocery aggregation when the recipe specifies a
+  different unit than the canonical purchase unit.
+- `grocery_lists`, `pantry_items`, `cooking_events` Postgres tables,
+  registered via `shared_postgres.register_team_schemas`.
+- `preferences.mealtime_windows` on `ClientProfile`, `timezone` on
+  `ClientProfile`.
+
+All additive; no breaking changes to the existing API responses.
+
+### 7. Rollout order
+
+Not a hard dependency order, but recommended:
+
+1. Grocery list (depends on ADR-002 parser; everything else waits on
+   this).
+2. Pantry (depends on grocery list aggregation).
+3. Substitution (depends on ADR-002 + ADR-003).
+4. Cook mode data model + `cooked` event (parallel with 2–3; biggest
+   ADR-004 payoff).
+5. Calendar sync (depends on mealtime windows + timezone; low risk,
+   high perceived value, good last-mile launch).
+
+## Consequences
+
+### Positive
+
+- Converts the team from a recommendation engine into a **weekly
+  operating system**. This is where consumer-health retention lives.
+- Every step up (list → shop → swap → cook → feedback) generates
+  structured data that improves the system, compounding with ADR-004.
+- Cook mode's `cooked` event separates adherence from preference,
+  which unlocks honest goal-progress claims (did the user cook the
+  plan that was supposed to get them to their goal?).
+- Near-expiry hints and pantry subtraction measurably reduce
+  household food waste — a genuine, shippable health-plus-
+  sustainability story.
+- Each capability is independently valuable. We can ship in sequence
+  and get user value at each step; no big-bang launch.
+
+### Negative / costs
+
+- **Largest scope of the five ADRs.** Five capabilities, new tables,
+  new endpoints, UI surface area, and an integration (calendar).
+  Mitigation: explicit rollout order (§7) and all capabilities are
+  additive — nothing here is a prerequisite for the rest of the
+  roadmap.
+- **Pantry is a UX trap.** Users will love the idea, hate the data
+  entry. Mitigation: opt-in auto-debit, bulk import, near-expiry
+  hints to make it *useful* not just *maintained*, and fully usable
+  with an empty pantry (it is a filter, not a requirement).
+- **Grocery-list edge cases are long-tail.** "1 clove garlic" vs "1
+  head of garlic" aggregation, spice-rack assumptions, bulk items,
+  household-size scaling — none are individually hard, collectively a
+  sustained polish cost. We will accept rough edges in v1 and
+  prioritize aggregates that matter (produce, proteins).
+- **Calendar sync has a blast radius.** A bad calendar write is very
+  visible to the user. Mitigation: namespaced event descriptions
+  (`[Khala Meals]`), dedicated calendar or clear opt-in, dry-run mode
+  showing events before commit, idempotent write with plan-id tag.
+- **Cook-mode step generation is new prompt surface.** The
+  meal-planning agent has not had to emit step structures before;
+  early outputs will be variable. Additive field means absence is
+  harmless; we can iterate on the prompt without blocking ship.
+- **Substitution LLM calls are the new cost center.** Common swaps are
+  deterministic (the shortlist in §3) specifically to keep per-swap
+  cost near zero; long-tail swaps hit the LLM. Acceptable.
+
+### Neutral / follow-ups
+
+- Third-party grocery fulfillment (Instacart / Amazon Fresh /
+  Walmart+) is a clean v2 built on the exported `GroceryList` shape;
+  intentionally out of scope.
+- Recipe scaling for variable household sizes on a given day (guest
+  coming for dinner) is a small, separable feature that drops in on
+  top of the aggregation logic; tracked separately.
+- A future ADR on **goal progress** ties together ADR-001 (targets),
+  ADR-003 (rollup), ADR-004 (preferences), and ADR-005 (cooking
+  events) into a weight/adherence dashboard. That is the capstone;
+  not in scope here.

--- a/system_design/adr/ADR-006-nutrition-goal-progress-adherence-dashboard.md
+++ b/system_design/adr/ADR-006-nutrition-goal-progress-adherence-dashboard.md
@@ -1,0 +1,322 @@
+# ADR-006 — Capstone: goal-progress and adherence dashboard
+
+- **Status**: Proposed
+- **Date**: 2026-04-17
+- **Owner**: Nutrition & Meal Planning team
+- **Related**: ADR-001 (deterministic targets), ADR-003 (nutrient rollup), ADR-004 (learned preferences), ADR-005 (workflow layer — cook-mode `cooked` event). Capstone for the nutrition roadmap.
+
+## Context
+
+After ADR-001 through ADR-005 land, the team owns four pieces of data
+it does not currently connect:
+
+1. **Prescribed targets** (ADR-001) — calories, macros, micros,
+   clinical clamps derived from biometrics and conditions.
+2. **Served plans with rollups** (ADR-003) — what we recommended and
+   its nutrient totals per day and week.
+3. **Cooking events** (ADR-005) — what the user actually made, with
+   `status ∈ {made, partial, skipped, swapped}`, servings, and
+   substitution deltas.
+4. **Learned preferences** (ADR-004) — a side-channel, useful for
+   explaining variance but not part of the outcome ledger.
+
+What is missing is the ledger that ties these together with **observed
+biometric outcomes** (weight, waist, resting HR, BP, fasting glucose,
+A1c, lipid panels) and produces the single question every user
+actually has: *"Is this working?"*
+
+Three forces push us to build this now and not later:
+
+1. **Honest goal claims require the full chain.** We currently imply
+   that following recommendations helps the user reach their goal. We
+   cannot show that, defend it, or correct it without this dashboard.
+2. **Adherence and outcome are routinely conflated.** Users blame the
+   plan when they did not actually eat the plan; users credit the plan
+   when weather, sleep, or a different variable drove the change.
+   Neither learning loop works if we cannot separate these.
+3. **Safety.** Weight-trend dashboards are not neutral artifacts. For
+   users with disordered-eating history, rapid weight loss, or
+   clinical conditions, what we display, how often, and how we frame
+   it affects health outcomes — not just product engagement. This
+   cannot be bolted on.
+
+## Decision
+
+Add a **goal-progress ledger** and a **dashboard API + UI** that tie
+prescribed → served → cooked → observed, with explicit adherence
+decomposition and explicit safety rails.
+
+### 1. The three adherence questions, made separable
+
+Every goal-progress computation answers three independent questions,
+never conflated:
+
+- **Plan adherence** — did the user cook (or eat) what was planned?
+  Derived from ADR-005 cooking events. Computed per day and week as
+  `made_or_partial / (made + partial + skipped + swapped)`, with
+  `swapped` handled by nutrient-delta weighting rather than binary
+  credit.
+- **Target adherence** — did what the user *actually ate* hit the
+  daily/weekly targets from ADR-001? Derived from the **eaten
+  rollup** (§3) against target tolerances (ADR-003 thresholds).
+- **Goal progress** — is the observed biometric outcome moving toward
+  the user's goal at the expected rate? Derived from biometric
+  observations (§2) against the calculator's expected trajectory
+  from ADR-001.
+
+These are surfaced as three separate gauges, not rolled into a single
+"score". A single score is the fastest way to mislead the user about
+which lever to pull.
+
+### 2. Biometric observations
+
+New store `biometric_observations(client_id, kind, value, unit,
+observed_at, source)`:
+
+- `kind ∈ {weight_kg, waist_cm, hip_cm, body_fat_pct,
+  resting_hr_bpm, bp_systolic, bp_diastolic, fasting_glucose_mgdl,
+  a1c_pct, ldl_mgdl, hdl_mgdl, triglycerides_mgdl, ...}`.
+- `source ∈ {manual, apple_health, google_fit, withings, fitbit,
+  lab_upload}` — integrations handled by the existing Integrations
+  team (CLAUDE.md notes the shared Google login and Playwright
+  session infra).
+- Entry endpoints:
+  `POST /biometrics/{client_id}/observations` (single or batch),
+  `GET /biometrics/{client_id}/observations?kind=...&since=...`,
+  `DELETE /biometrics/{client_id}/observations/{id}`.
+- Import adapters for the four device integrations are out of scope
+  for v1 of this ADR — manual entry plus a generic `POST` endpoint is
+  enough to ship the dashboard. Integrations ride on top without
+  schema changes.
+
+### 3. The eaten rollup
+
+`nutrient_rollup/` (ADR-003) gains `rollup_eaten(client_id, period)`:
+
+- Built from ADR-005 cooking events, not from the plan.
+- `made` → full nutrients from the recipe rollup.
+- `partial` → `servings_made / portions_servings` of the nutrients.
+- `swapped` → the substituted recipe's rollup (computed in ADR-005
+  when the substitution is recorded).
+- `skipped` → zero for that recipe, **not** replaced by assumed
+  intake. If the user's actual intake matters (it often does), they
+  log it in §4 below.
+- The eaten rollup is what `target_adherence` compares against.
+
+### 4. Off-plan intake logging (lightweight)
+
+Users eat things we did not plan. Without a way to log those, target
+adherence is systematically wrong in one direction.
+
+- New endpoint `POST /intake/{client_id}/quick-log` with a short
+  `{description, meal_type, approx_portion, occurred_at}` body.
+- Resolved with the ADR-002 parser + a small LLM pass to a recipe-like
+  shape with estimated nutrients and a `confidence` score.
+- Explicitly marked `off_plan=true` in the eaten rollup. UI shows them
+  separately so plan adherence is not penalized for eating a lunch we
+  never planned.
+- Photo-based logging is deferred (v2). Text quick-log is enough to
+  make adherence numbers honest.
+
+### 5. Expected-trajectory model
+
+The ADR-001 calculator already knows the user's goal (`goal_type`,
+`target_weight_kg`, `rate_kg_per_week`) and the energy math. Extend it
+with `compute_expected_trajectory(profile) -> Trajectory`:
+
+- `Trajectory.series: list[(date, expected_value, confidence_band)]`
+  for each relevant biometric kind.
+- Grounded in the familiar identities (≈7,700 kcal per kg of fat mass
+  on average, plus an early-phase water/glycogen correction, plus a
+  drift term for metabolic adaptation that grows with cumulative
+  deficit). These are rough but defensible; we show the band, not a
+  point.
+- Clinical-cohort trajectories (pregnancy weight gain by trimester,
+  lactation, post-op) are explicitly out of scope and return
+  `trajectory=None` with a "work with your clinician" note. We do
+  **not** guess.
+
+Observed biometrics are compared to the trajectory band. A run of
+points outside the band triggers either a recalibration suggestion
+(§7) or a safety rail (§6).
+
+### 6. Safety rails
+
+Non-negotiable behaviors, encoded in code and test:
+
+- **Rate-of-loss floor.** If observed weight loss exceeds 1% body
+  weight per week averaged over two consecutive weeks, the dashboard
+  surfaces a caution and the next plan generation (ADR-001) clamps
+  the goal delta, regardless of user preference. Repeated override
+  requires explicit acknowledgment.
+- **Underweight / BMI floor.** If BMI drops below 18.5 (or a
+  user-specific clinician-set floor), weight-loss goals are disabled
+  at the calculator level and the dashboard replaces progress gauges
+  with a "revisit your goal" prompt.
+- **Eating-disorder history flag** on the profile disables scale-
+  centric views entirely and shows behavior-centric metrics only
+  (plan adherence, variety, cook streak). Calorie numbers and weight
+  trends can be hidden at the profile level.
+- **Minors** (`age_years < 18`): growth-chart path only; no
+  weight-loss trajectory, no deficit framing, no macro gauges by
+  default. We route to "general guidance" as in ADR-001 §5.
+- **Observation frequency.** The dashboard nudges at most **weekly**
+  for weight and opt-in for the rest. We actively resist daily-weigh
+  UX patterns — they are anxiety generators and statistically worse
+  signal than weekly moving averages.
+- **Language.** Copy is behavior- and energy-framed, never shame-
+  framed. A copy-review checklist lives alongside the dashboard UI
+  spec; dashboard strings are reviewed on change.
+
+These rails are not negotiable per-user toggles; they are team
+invariants. Individual tolerances (e.g. a clinician-raised BMI floor)
+are set on the profile by authorized paths.
+
+### 7. Recalibration loop
+
+When goal progress persistently diverges from trajectory (e.g.,
+observed deficit-equivalent ≠ prescribed deficit for 3+ weeks after
+controlling for plan and target adherence), the dashboard offers a
+**recalibration**:
+
+- Recompute TDEE from observed outcome (`ΔE_observed ≈
+  intake_eaten − ΔMass · 7700`), blended with the calculator's
+  a-priori estimate as a Bayesian update.
+- Surface the proposed new targets and show the user the reasoning
+  ("your maintenance looks closer to 2,250 kcal than the 2,400 we
+  estimated"). Never silently change targets.
+- On accept, write a new `NutritionPlan` version with
+  `calculator_version` from ADR-001 bumped and a `recalibration_id`
+  tag for audit.
+
+This is the payoff loop: the prescribed target becomes self-
+correcting as real data accumulates. It also makes the system
+honest about its own uncertainty.
+
+### 8. Data model
+
+New tables (registered via `shared_postgres.register_team_schemas`):
+
+- `biometric_observations` (§2).
+- `off_plan_intakes` (§4).
+- `trajectory_snapshots(client_id, computed_at, profile_version,
+  expected_series_json)` — so the dashboard can render the trajectory
+  that was in force at a given week, not today's recomputed one.
+- `adherence_snapshots(client_id, period_start, period_end,
+  plan_adherence, target_adherence, goal_progress_status, inputs_hash)`
+  — nightly job materializes these for fast reads; the dashboard
+  never recomputes on the user's critical path.
+
+Additive on existing models:
+
+- `GoalsInfo.started_at`, `GoalsInfo.paused_at` — we need to know when
+  a cycle began to frame progress honestly.
+- `ClientProfile.ed_history_flag`, `clinician_overrides` — explicit
+  flags for the safety rails in §6 so they are first-class, not
+  hidden in `notes`.
+
+### 9. API surface
+
+- `GET /dashboard/{client_id}?period=week|month|quarter` — returns a
+  `DashboardView`:
+  - `plan_adherence`, `target_adherence`, `goal_progress_status`
+    (three gauges, each with a confidence band and a short text
+    explanation).
+  - `trajectory`: the expected-vs-observed chart series.
+  - `eaten_rollup`: ADR-003 rollup computed on cooked + off-plan.
+  - `drivers`: short structured list ("Target protein was 132 g/day;
+    you averaged 108 g. Three skipped lunches account for 18 g/day.").
+  - `recalibration_suggestion?`: present when §7 fires.
+  - `safety_state`: `ok | caution | rail_active`, with copy.
+- `POST /dashboard/{client_id}/recalibrate` — accept/decline the
+  recalibration.
+- `GET /dashboard/{client_id}/drivers` — structured adherence
+  decomposition, used by the UI to build "why" explanations and by
+  the planner (ADR-004) to weight future recommendations.
+
+The `drivers` field is deliberately structured (not free text); it is
+the causal-explanation layer that prevents "score theater."
+
+### 10. Interaction with the planner (ADR-004)
+
+The dashboard is not just read-only. Its structured signals feed back
+into the planner:
+
+- Low plan adherence driven by skipped weeknight dinners →
+  `effort_tolerance` downward on weekdays (ADR-004 signal).
+- Swaps clustering around a specific ingredient → `ingredient_affinity`
+  negative (ADR-004 signal).
+- Target adherence failing only on fiber/micros → planner prompt adds
+  an explicit fiber/micronutrient emphasis on next generation.
+
+These feedbacks are deterministic transforms; the LLM is not asked to
+"look at the dashboard and learn." The dashboard *is* the learning
+signal in structured form.
+
+## Consequences
+
+### Positive
+
+- The team can finally answer "is this working?" with real inputs and
+  defensible reasoning, instead of vibes.
+- Adherence decomposition makes the product's feedback actionable:
+  users stop blaming the plan for unplanned eating, and we stop
+  blaming the user for a mis-prescribed target.
+- Recalibration (§7) makes the calculator self-correcting, which is
+  how nutrition products build long-term trust over the 6–12 month
+  timescales that actually matter.
+- Safety rails are encoded in code, reviewable, and testable. This is
+  the posture a consumer-health product has to take — "we intended to
+  avoid harm" is not a control.
+- Capstones the roadmap: every prior ADR gains a consumer — targets
+  get validated, rollups become the adherence input, cooking events
+  become the outcome ledger, preferences get ground-truth feedback.
+
+### Negative / costs
+
+- **Biggest surface area in the roadmap.** New stores, new endpoints,
+  a UI with real design and copy requirements, safety-review burden,
+  and integrations-team coordination for device ingestion.
+  Mitigation: manual observation entry is enough to ship; device
+  adapters are v2.
+- **Safety-review ownership is a commitment.** Copy review,
+  threshold review, and clinical-cohort handling need a named owner
+  and a cadence. Without one, the rails drift. This must be called
+  out at the planning stage, not discovered later.
+- **Data freshness vs. cost tradeoff.** Nightly `adherence_snapshots`
+  keep the dashboard fast but show a day-old picture. On-demand
+  recomputation on request is available but rate-limited; we
+  explicitly accept a one-day lag for the default view. Users who
+  need real-time are a minority and can be served by a "refresh now"
+  action with a visible wait.
+- **Off-plan logging is a UX hole if left optional.** Adherence
+  numbers are meaningfully wrong without it, and logging fatigue is
+  real. Mitigation: text quick-log (§4) is deliberately <10s; we do
+  not require full nutrient breakdowns from the user — we estimate,
+  with a confidence band.
+- **Recalibration introduces volatility.** Targets that move are
+  disorienting. We surface changes explicitly, require user accept,
+  and rate-limit recalibration suggestions to at most one per 21
+  days, tied to accumulated data.
+- **Dashboard is the highest-stakes UI the team owns.** It is where a
+  shame-frame or a noisy chart does real harm. Non-trivial design
+  investment is required; this ADR names the constraints (§6,
+  "drivers" structure) but the design itself is a separate spec.
+
+### Neutral / follow-ups
+
+- Device integration adapters (Apple Health, Google Fit, Withings,
+  Fitbit) are follow-up specs under the Integrations team, riding on
+  the observation schema here unchanged.
+- Photo-based quick-log (§4 v2) is its own spec.
+- Cross-team integration: the Personal Assistant and Deepthought
+  teams both hit the same "weekly reflection" pattern; a future ADR
+  can factor the adherence-snapshot + trajectory machinery into a
+  shared component. Not in scope here.
+- A clinician-facing export (PDF/CSV of adherence snapshots and
+  observation series for a patient's dietitian or PCP) is a natural
+  v1.1 feature and uses no new data — it is a view over the existing
+  ledger.
+- This ADR formally closes the nutrition roadmap as originally
+  scoped. Any item beyond this one should earn its own planning
+  round.

--- a/system_design/specs/SPEC-002-nutrition-profile-biometrics.md
+++ b/system_design/specs/SPEC-002-nutrition-profile-biometrics.md
@@ -1,0 +1,462 @@
+# SPEC-002: Nutrition profile — biometric and clinical data model
+
+| Field       | Value                                                    |
+|-------------|----------------------------------------------------------|
+| **Status**  | Proposed                                                 |
+| **Author**  | Nutrition & Meal Planning team                           |
+| **Created** | 2026-04-17                                               |
+| **Priority**| P0 (blocks SPEC-003 and SPEC-004)                        |
+| **Scope**   | `backend/agents/nutrition_meal_planning_team/` (models, Postgres, intake agent, orchestrator, API) + `user-interface/` intake screens |
+| **Implements** | ADR-001 §1 (profile extension), §5 (safety routing — data side) |
+
+---
+
+## 1. Problem Statement
+
+The Nutritionist agent is being asked to produce numeric daily targets
+(kcal, protein, fat, carbs, micros) from a `ClientProfile` that does
+not carry the inputs any textbook equation needs. The profile has no
+`sex`, `age_years`, `height_cm`, `weight_kg`, or activity level; it
+has no way to express medical conditions, medications, pregnancy, or
+lactation beyond a free-text `goals.notes` field.
+
+The deterministic calculator (SPEC-003) and the refactored agent
+(SPEC-004) cannot ship until the profile can carry the inputs they
+require and the intake pipeline can reliably collect them. This spec
+is the data-and-intake half of ADR-001 and must land first.
+
+This spec does **not** compute targets or change agent behavior. It
+only ensures the data exists, is validated, and is editable.
+
+---
+
+## 2. Current State
+
+### 2.1 Profile today
+
+`backend/agents/nutrition_meal_planning_team/models.py:58-72`:
+
+```
+ClientProfile
+├── client_id: str
+├── household: HouseholdInfo
+├── dietary_needs: List[str]
+├── allergies_and_intolerances: List[str]
+├── lifestyle: LifestyleInfo
+├── preferences: PreferencesInfo
+├── goals: GoalsInfo { goal_type, notes }
+└── updated_at: Optional[str]
+```
+
+### 2.2 Intake flow today
+
+```mermaid
+flowchart LR
+    UI["Intake UI<br/>(profile form)"] -->|PUT /profile/{id}| API
+    API -->|ProfileUpdateRequest| ORCH[Orchestrator]
+    ORCH -->|intake_agent.run| INTAKE["IntakeProfileAgent<br/>(LLM merge/complete)"]
+    INTAKE -->|ClientProfile| STORE[(nutrition_profiles)]
+    INTAKE -.fallback.-> MERGE["_merge_profile_structural<br/>(no-LLM merge)"]
+```
+
+`IntakeProfileAgent` (`agents/intake_profile_agent/agent.py`) takes
+partial updates, asks the LLM to validate + complete, and falls back
+to a structural merge when the LLM is unavailable. There is no
+numeric validation, no unit enforcement, and no safety routing.
+
+### 2.3 Gaps
+
+1. Biometrics absent — no height, weight, age, sex, activity level.
+2. Clinical context absent — no structured conditions, medications,
+   pregnancy/lactation state.
+3. Units not enforced — the LLM is free to interpret any strings it
+   sees.
+4. Edit audit absent — we cannot tell when weight was last logged or
+   why targets should be recomputed.
+5. Safety flags (ED history, clinician-set floors, minor status) have
+   no home in the model.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- Extend `ClientProfile` with the fields ADR-001 requires, with
+  explicit units, strict validation, and implausibility guards.
+- Provide a versioned, audited write path (biometrics change over
+  time; history matters for SPEC-003 trajectory work and ADR-006).
+- Ship progressive-disclosure UI: existing paths remain usable with
+  a partial profile; advanced fields unlock calculator-driven
+  features.
+- Add structured safety flags and clinician overrides as first-class
+  fields, not free text.
+- Migrate existing profiles without data loss and without requiring
+  users to re-enter data they have already provided.
+
+### 3.2 Non-goals
+
+- **No calculator behavior.** This spec does not compute BMR, TDEE,
+  targets, or trajectories. That is SPEC-003.
+- **No agent refactor.** The Nutritionist agent continues to receive
+  the profile as-is. SPEC-004 changes how the agent uses it.
+- **No device integrations.** Apple Health / Google Fit / Withings
+  ingestion is an ADR-006 follow-up and lands on top of the schema
+  defined here, unchanged.
+- **No clinician portal.** Clinician-set overrides are modelled here
+  but the authorization path (who can write them) is a separate
+  spec. v1 accepts overrides only from admin API with audit log.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 Model additions (`models.py`)
+
+New Pydantic models and fields on `ClientProfile`. All additive.
+
+```python
+class Sex(str, Enum):
+    female = "female"
+    male = "male"
+    other = "other"
+    unspecified = "unspecified"
+
+class ActivityLevel(str, Enum):
+    sedentary = "sedentary"      # PAL 1.2
+    light = "light"              # PAL 1.375
+    moderate = "moderate"        # PAL 1.55
+    active = "active"            # PAL 1.725
+    very_active = "very_active"  # PAL 1.9
+
+class BiometricInfo(BaseModel):
+    sex: Sex = Sex.unspecified
+    age_years: Optional[int] = Field(default=None, ge=2, le=120)
+    height_cm: Optional[float] = Field(default=None, ge=50, le=260)
+    weight_kg: Optional[float] = Field(default=None, ge=20, le=400)
+    body_fat_pct: Optional[float] = Field(default=None, ge=3, le=75)
+    activity_level: ActivityLevel = ActivityLevel.sedentary
+    timezone: str = "UTC"            # IANA zone; used by ADR-005/006
+    measured_at: Optional[str] = None
+
+class ReproductiveState(str, Enum):
+    none = "none"
+    pregnant_t1 = "pregnant_t1"
+    pregnant_t2 = "pregnant_t2"
+    pregnant_t3 = "pregnant_t3"
+    lactating = "lactating"
+    postpartum = "postpartum"
+
+class ClinicalInfo(BaseModel):
+    conditions: List[str] = []       # canonical tags, see §4.2
+    medications: List[str] = []      # canonical tags, see §4.2
+    reproductive_state: ReproductiveState = ReproductiveState.none
+    ed_history_flag: bool = False    # disables scale-centric UX
+    clinician_overrides: Dict[str, float] = {}  # e.g. {"bmi_floor": 19.5}
+
+class GoalsInfo(BaseModel):
+    goal_type: str = "maintain"
+    target_weight_kg: Optional[float] = Field(default=None, ge=20, le=400)
+    rate_kg_per_week: Optional[float] = Field(default=None, ge=0, le=1.0)
+    started_at: Optional[str] = None
+    paused_at: Optional[str] = None
+    notes: str = ""
+
+class ClientProfile(BaseModel):
+    # ... existing fields ...
+    biometrics: BiometricInfo = Field(default_factory=BiometricInfo)
+    clinical: ClinicalInfo = Field(default_factory=ClinicalInfo)
+    profile_version: int = 1         # monotonic; bumped on any write
+    schema_version: str = "2.0"      # data-model version
+```
+
+Field-level validators (Pydantic v2 `@field_validator`):
+
+- `weight_kg` and `target_weight_kg`: implausibility ranges above
+  (20–400 kg). Hard reject outside the range — do **not** clamp;
+  return 422 to the client.
+- `rate_kg_per_week`: cap at 1.0 per week on input; clinical clamps
+  apply later in SPEC-004.
+- `timezone`: must be an IANA zone (validate via `zoneinfo`).
+- `age_years < 18`: allowed on write, but every response that
+  includes such a profile sets a `minor=True` derived flag for the UI
+  (SPEC-004 refuses weight-loss goals for minors — not here).
+
+### 4.2 Canonical clinical taxonomy
+
+Separate file `nutrition_meal_planning_team/clinical_taxonomy.py`:
+
+- `CONDITIONS` — closed enum, v1 covers: `ckd_stage_1..5`,
+  `hypertension`, `t1_diabetes`, `t2_diabetes`, `prediabetes`,
+  `pcos`, `hypothyroid`, `hyperthyroid`, `celiac`, `ibs`, `gerd`,
+  `gallstones`, `dyslipidemia`, `gout`. Anything outside the enum
+  goes to `conditions_freetext: List[str]` on `ClinicalInfo` (string
+  list, surfaced to agents as caveat notes, not used by calculator).
+- `MEDICATIONS` — closed enum tagging *class*, not drug name:
+  `warfarin`, `maoi`, `ssri`, `acei_arb`, `k_sparing_diuretic`,
+  `statin`, `amiodarone`, `glp1`, `metformin`, `levothyroxine`,
+  `lithium`, `st_johns_wort`. Same open/closed split.
+- The enum is load-bearing for ADR-002's interaction guardrail; we
+  freeze it in a file and version it (`CLINICAL_TAXONOMY_VERSION`).
+
+### 4.3 Postgres schema
+
+Register via `shared_postgres.register_team_schemas` in the team's
+lifespan (`api/main.py`):
+
+```sql
+-- Additive: extend nutrition_profiles (existing table)
+ALTER TABLE nutrition_profiles
+    ADD COLUMN biometrics JSONB NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN clinical   JSONB NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN profile_version INT NOT NULL DEFAULT 1,
+    ADD COLUMN schema_version TEXT NOT NULL DEFAULT '2.0';
+
+-- New: audit trail for biometric edits (feeds ADR-006)
+CREATE TABLE nutrition_biometric_log (
+    id              BIGSERIAL PRIMARY KEY,
+    client_id       TEXT NOT NULL REFERENCES nutrition_profiles(client_id)
+                         ON DELETE CASCADE,
+    field           TEXT NOT NULL,        -- e.g. 'weight_kg'
+    value_numeric   DOUBLE PRECISION,
+    value_text      TEXT,
+    unit            TEXT,
+    source          TEXT NOT NULL,        -- 'manual' | 'api' | 'import'
+    recorded_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    recorded_by     TEXT                   -- user id or 'system'
+);
+CREATE INDEX ON nutrition_biometric_log (client_id, field, recorded_at DESC);
+
+-- New: clinician-authored overrides and safety flags audit
+CREATE TABLE nutrition_clinical_overrides_log (
+    id              BIGSERIAL PRIMARY KEY,
+    client_id       TEXT NOT NULL REFERENCES nutrition_profiles(client_id)
+                         ON DELETE CASCADE,
+    key             TEXT NOT NULL,
+    value_numeric   DOUBLE PRECISION,
+    reason          TEXT,
+    author          TEXT NOT NULL,         -- clinician id or 'admin'
+    recorded_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+Follow the Pattern B schema registry from
+[shared_postgres/README.md](backend/agents/shared_postgres/README.md).
+A migration script (idempotent `CREATE ... IF NOT EXISTS` and
+`ADD COLUMN IF NOT EXISTS`) lives at
+`nutrition_meal_planning_team/postgres/migrations/002_biometrics.sql`
+and is applied on lifespan startup.
+
+### 4.4 Intake agent changes
+
+`agents/intake_profile_agent/agent.py`:
+
+- System prompt updated to describe the new fields with **explicit
+  unit reminders** ("height in cm only", "weight in kg only"). The
+  agent's job is still merge-and-complete, not inference — never
+  invent biometrics.
+- Parse output via `llm_service` structured-output contract (PR #184)
+  — no more regex markdown stripping.
+- On LLM failure, `_merge_profile_structural` extended to handle the
+  new sub-objects with the same shallow-merge semantics.
+- New: **unit coercion pass** — if the user enters a height in inches
+  or weight in lbs, the intake agent performs explicit conversion
+  (with a confirmation note in the response) rather than silently
+  accepting a wrong number. Conversions live in
+  `nutrition_meal_planning_team/units.py` (pure function, tested).
+
+### 4.5 API surface
+
+Additive endpoints on top of the existing `/api/nutrition-meal-planning`:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `PATCH` | `/profile/{client_id}/biometrics` | Append-only biometric update; writes to `nutrition_biometric_log`; updates `ClientProfile.biometrics` to latest values |
+| `GET`  | `/profile/{client_id}/biometrics/history?field=weight_kg&since=...` | Paginated biometric history for the UI trend chart and ADR-006 |
+| `PATCH` | `/profile/{client_id}/clinical` | Update `ClinicalInfo` (conditions, meds, reproductive state, ED flag) |
+| `PUT`  | `/profile/{client_id}/clinical-overrides` | Admin-only (v1); writes `nutrition_clinical_overrides_log` and updates `clinician_overrides` |
+| `GET`  | `/profile/{client_id}/completeness` | Returns `{has_biometrics: bool, has_activity: bool, has_conditions_confirmed: bool, blockers: [str]}` — drives UI gating |
+
+The existing `PUT /profile/{client_id}` remains for bulk updates and
+accepts the new nested fields; preferred writes for biometrics use
+the `PATCH` path so history is recorded.
+
+### 4.6 UI changes (intake)
+
+Progressive-disclosure flow in `user-interface/src/app/components/`:
+
+```mermaid
+flowchart TD
+    A["Step 1: Household & diet<br/>(existing fields)"] --> B{User wants<br/>personalized targets?}
+    B -->|No| DONE1["Save basic profile.<br/>Guideline-only plans."]
+    B -->|Yes| C["Step 2: Biometrics<br/>sex, age, height, weight, activity"]
+    C --> D["Step 3: Clinical (optional)<br/>conditions, meds, repro state, ED flag"]
+    D --> DONE2["Save full profile.<br/>Calculator-driven plans unlock (SPEC-004)."]
+```
+
+Key UI rules:
+
+- **Units**: input fields carry the unit in the label ("Height (cm)")
+  and optionally a unit toggle (cm↔ft/in, kg↔lb) that performs
+  conversion client-side before submit. The toggle writes user
+  preference to `BiometricInfo.preferred_units` (additive field, not
+  in calculator path).
+- **Implausibility feedback**: client-side validation mirrors backend
+  bounds to avoid round-trip errors.
+- **ED-history flag**: presented as "I'd prefer to avoid scale-based
+  or calorie-based goals" in plain language, not as a medical term.
+  Toggling it to true hides weight inputs and any weight-trend UI.
+- **Minor flow**: when `age_years < 18`, the form disables
+  weight-loss goals and shows a short "growth-focused guidance"
+  explanation.
+- **Clinician-set overrides**: not user-editable. Displayed read-only
+  with author and date where present.
+
+### 4.7 Backfill and migration
+
+Existing profiles lack the new fields. Strategy:
+
+1. Migration sets `biometrics={}`, `clinical={}` defaults — users do
+   not lose anything; they simply do not have advanced data yet.
+2. On the next login after deploy, the orchestrator's
+   `get_profile` adds a `completeness` block to the response (see
+   §4.5). UI uses it to show a dismissible "add details for a
+   personalized plan" banner.
+3. We do **not** block existing flows. Profiles with empty
+   biometrics continue to work against the existing agent path
+   (SPEC-004 gates calculator features on completeness).
+
+### 4.8 Privacy and retention
+
+- Biometrics and clinical data are PHI-adjacent. They inherit the
+  existing `nutrition_profiles` retention policy; deletion cascades
+  remove `nutrition_biometric_log` and `nutrition_clinical_overrides_log`.
+- Logs above DEBUG level must not include biometric values. A
+  `shared_observability` filter rule is added and tested in §6.
+- Existing PII considerations from the platform privacy policy apply;
+  no new policy work is required for this spec, but a one-line
+  CHANGELOG entry under "Privacy" is mandatory on deploy.
+
+### 4.9 Priority-grouped work items
+
+| # | Item | Owner | Priority |
+|---|------|-------|----------|
+| W1 | Extend `models.py` with `BiometricInfo`, `ClinicalInfo`, `GoalsInfo` additions, `Sex`, `ActivityLevel`, `ReproductiveState` enums; add Pydantic validators | Backend | P0 |
+| W2 | `clinical_taxonomy.py` with closed enums + freetext escape hatch | Backend | P0 |
+| W3 | Postgres migration `002_biometrics.sql` + update `SCHEMA` registration | Backend | P0 |
+| W4 | Intake agent prompt update + structured-output parsing + unit coercion | Backend | P1 |
+| W5 | API endpoints (§4.5) + store helpers | Backend | P1 |
+| W6 | Completeness endpoint + banner component | FE+BE | P1 |
+| W7 | Progressive-disclosure intake UI (Steps 2–3) | Frontend | P1 |
+| W8 | Clinical-override admin endpoint (stub UI) | Backend | P2 |
+| W9 | Unit toggle (cm↔ft/in, kg↔lb) component | Frontend | P2 |
+| W10 | Retention + log-redaction audit | Backend | P2 |
+
+---
+
+## 5. Rollout Plan
+
+Phased behind a feature flag `NUTRITION_PROFILE_V2` (unified-config).
+All phases are reversible via flag; schema migration is additive and
+non-destructive.
+
+### Phase 0 — Foundation (P0)
+- [ ] Land W1, W2, W3. Migration applied in staging Postgres.
+- [ ] Existing tests green; no behavior change yet.
+- [ ] Flag defaulted off.
+
+### Phase 1 — Write path (P0/P1)
+- [ ] W4 intake agent changes (flagged path).
+- [ ] W5 PATCH endpoints live (flag-gated).
+- [ ] W10 log redaction verified in staging (grep biometric values in logs → must be zero).
+- [ ] Deploy to staging; dogfood with team profiles.
+
+### Phase 2 — Read path and UI (P1)
+- [ ] W6 completeness endpoint returning correct blockers.
+- [ ] W7 progressive intake UI behind flag.
+- [ ] Banner copy review (see §6.5 copy checklist).
+- [ ] Soft launch to 10% of users; monitor completion funnel.
+
+### Phase 3 — Polish and override path (P2)
+- [ ] W8 clinician-override admin endpoint.
+- [ ] W9 unit toggle.
+- [ ] Flag defaulted on; flag-removal ticket filed (sunset in 30 days).
+
+### Rollback
+- Flag off → UI collapses to existing intake, API ignores new fields
+  on read. Migration stays applied (additive; no destructive rollback
+  needed).
+
+---
+
+## 6. Verification
+
+### 6.1 Unit tests
+
+- `test_models_validators.py` — every bound (`age`, `height`, `weight`,
+  `body_fat`, `rate_kg_per_week`, `timezone`) rejects outside-range
+  input with 422-equivalent validation errors.
+- `test_units.py` — unit-conversion round-trips are exact to 3
+  decimal places; malformed input returns `None`, not silent zero.
+- `test_clinical_taxonomy.py` — enum membership; taxonomy version
+  constant present and exported.
+- `test_intake_agent_v2.py` — structured-output parse success and
+  failure paths; fallback merge handles new nested objects without
+  flattening.
+
+### 6.2 Integration tests
+
+- `test_profile_api_biometrics.py` — `PATCH /biometrics` writes both
+  the latest value onto `ClientProfile.biometrics` and a row into
+  `nutrition_biometric_log`; `GET /history` pagination works.
+- `test_completeness.py` — matrix of partial profiles returns the
+  correct blockers.
+- `test_minor_flow.py` — profile with `age_years=15` returns
+  `minor=True` and blocks weight-loss goals at API level.
+- `test_ed_flag.py` — profile with `ed_history_flag=true` causes
+  `completeness` to omit scale/calorie blockers and UI-side
+  rendering tests confirm weight inputs disappear.
+
+### 6.3 Migration tests
+
+- `test_migration_002.py` — against a fixture with `schema_version=1`
+  profiles, applying the migration produces `schema_version=2.0`
+  with default empty `biometrics`/`clinical`, and no existing field
+  is dropped or changed.
+
+### 6.4 Observability
+
+- OTel counters: `nutrition.profile.biometric_write{field}`,
+  `nutrition.profile.implausible_reject{field}`,
+  `nutrition.profile.completeness_blocker{blocker}`.
+- Log-redaction grep check in CI (§Phase 1 checklist).
+
+### 6.5 UX / copy checklist (dashboard parity with ADR-006 §6)
+
+- [ ] No shame-framed copy anywhere in intake.
+- [ ] ED-flag toggle uses plain language, not medical jargon.
+- [ ] Minor flow copy reviewed against roadmap copy guidelines.
+- [ ] Unit labels unambiguous; toggle is obvious and reversible.
+
+### 6.6 Cutover criteria (flag-on)
+
+- P0/P1 tests passing on `main`.
+- Staging dogfood ≥7 days with zero implausibility false-rejects on
+  real team profiles.
+- Logs grep: 0 biometric values leaked at INFO or above.
+- Completion funnel on 10% soft launch ≥70% (users who started the
+  biometrics step finished it). Below 70% → revisit UX before wider
+  roll.
+
+---
+
+## 7. Open Questions
+
+- **Who owns the clinical taxonomy?** The team needs a named reviewer
+  when we extend `CONDITIONS` / `MEDICATIONS`. Deferred to a naming
+  doc; initial reviewer is the Nutrition team lead.
+- **Do we expose `preferred_units` in the API response to other
+  teams?** Probably yes for UI consistency. v1 keeps it private to
+  the nutrition team; revisit when another team needs it.
+- **Biometric-log retention horizon.** We keep indefinitely in v1.
+  Revisit when ADR-006 compliance export lands.

--- a/system_design/specs/SPEC-003-nutrition-deterministic-calculator.md
+++ b/system_design/specs/SPEC-003-nutrition-deterministic-calculator.md
@@ -1,0 +1,505 @@
+# SPEC-003: Deterministic nutrition calculator (`nutrition_calc/`)
+
+| Field       | Value                                                    |
+|-------------|----------------------------------------------------------|
+| **Status**  | Proposed                                                 |
+| **Author**  | Nutrition & Meal Planning team                           |
+| **Created** | 2026-04-17                                               |
+| **Priority**| P0 (blocks SPEC-004, ADR-003, ADR-006)                   |
+| **Scope**   | New pure-Python module `backend/agents/nutrition_meal_planning_team/nutrition_calc/` |
+| **Depends on** | SPEC-002 (profile fields required as calculator inputs) |
+| **Implements** | ADR-001 §2 (calculator), §3 (narrator contract — calculator side), §4 (caching — version constant) |
+
+---
+
+## 1. Problem Statement
+
+Daily nutrient targets for a client (calories, macros, key micros,
+plus condition-specific clamps) are today authored by an LLM with no
+biometric inputs. Outputs are plausible-sounding but unanchored and
+non-reproducible. ADR-001 calls for a deterministic calculator that
+owns the numbers, with the LLM demoted to writing narrative around
+them.
+
+This spec defines that calculator as a standalone pure-Python module
+with a narrow interface, exhaustive unit tests against published
+reference values, and an explicit rationale output that lets us show
+our work.
+
+The module has no dependency on `Agent`, `llm_service`, or any store.
+It is importable and testable without Postgres, without the Unified
+API, and without a running LLM. That separation is deliberate — it is
+what makes the numbers reviewable.
+
+---
+
+## 2. Current State
+
+### 2.1 Numbers today
+
+`agents/nutritionist_agent/agent.py:37-56`:
+
+```python
+prompt = (
+    "Client profile:\n"
+    + profile.model_dump_json(indent=2)
+    + "\n\nProduce the nutrition plan JSON (daily_targets, ...)"
+)
+# LLM returns numbers; we regex-strip fences and hope.
+```
+
+There is no anchored equation, no cohort-specific clamp, no rationale
+trail. Two calls with the same profile can disagree by hundreds of
+kcal, and we have no defensible story for why any number was chosen.
+
+### 2.2 What ADR-001 prescribes
+
+- Mifflin–St Jeor BMR (default); Katch–McArdle when body fat present.
+- TDEE = BMR × PAL with documented multipliers.
+- Goal delta applied with a **kcal floor** (safety).
+- Macros from AMDR bands with protein by body weight.
+- Micros from DRI tables by sex/age/reproductive state.
+- Clinical overrides applied last (CKD, HTN, pregnancy, lactation,
+  etc.).
+- A `Rationale` describing which equations ran and which overrides
+  applied.
+
+### 2.3 Gaps this spec fills
+
+- No module boundary. No versioned outputs. No tests against
+  reference values. No safe refusal for implausible or out-of-cohort
+  inputs.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- Ship a pure-Python module exposing one function:
+  `compute_daily_targets(profile: ClientProfile) -> CalculatorResult`.
+- Produce deterministic, reproducible outputs — same inputs, same
+  outputs, byte-for-byte, forever on a given `CALCULATOR_VERSION`.
+- Surface a structured `Rationale` that names each equation, each
+  input it consumed (including defaults), and each clinical override
+  applied — this is the audit trail and the UI "why these numbers?"
+  payload.
+- Fail closed on implausible inputs or cohorts outside our supported
+  list; do not fall back to guesses.
+- Expose a version constant other components can pin on for caching
+  (SPEC-004 §4.4).
+
+### 3.2 Non-goals
+
+- **No agent integration.** SPEC-004 wires this into the
+  Nutritionist agent. This spec ships a library.
+- **No persistence.** Callers store results; the calculator is
+  stateless.
+- **No personalization from history.** The calculator consumes
+  profile inputs only. Adaptive recalibration from observed outcomes
+  is ADR-006's `recalibration_loop` and is out of scope here.
+- **No meal-level logic.** Meal planning and nutrient rollup are
+  ADR-003.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 Module layout
+
+```
+backend/agents/nutrition_meal_planning_team/nutrition_calc/
+├── __init__.py            # exports compute_daily_targets, CALCULATOR_VERSION
+├── version.py             # CALCULATOR_VERSION = "1.0.0"
+├── bmr.py                 # Mifflin–St Jeor, Katch–McArdle
+├── tdee.py                # PAL multipliers
+├── energy_goal.py         # goal delta + safety floor
+├── macros.py              # protein/fat/carb computation, AMDR bands
+├── micros.py              # DRI tables by sex/age/repro state
+├── clinical_overrides.py  # condition-specific clamps
+├── tables/
+│   ├── amdr.yaml
+│   ├── dri.yaml           # versioned DRI tables
+│   ├── pal.yaml
+│   └── retention.yaml     # (reserved for SPEC-005 use)
+├── rationale.py           # Rationale, Step dataclasses
+├── errors.py              # CalculatorError, ImplausibleInputError, UnsupportedCohortError
+└── targets.py             # compute_daily_targets orchestration
+```
+
+### 4.2 Public interface
+
+```python
+# nutrition_calc/__init__.py
+from .version import CALCULATOR_VERSION
+from .targets import compute_daily_targets
+from .rationale import Rationale, RationaleStep
+from .errors import (
+    CalculatorError,
+    ImplausibleInputError,
+    UnsupportedCohortError,
+    InsufficientInputError,
+)
+
+@dataclass(frozen=True)
+class CalculatorResult:
+    targets: DailyTargets             # from models.py (existing)
+    rationale: Rationale
+    calculator_version: str           # == CALCULATOR_VERSION
+    cohort: str                       # e.g. "general_adult", "pregnant_t2"
+    warnings: list[str] = field(default_factory=list)
+
+def compute_daily_targets(profile: ClientProfile) -> CalculatorResult: ...
+```
+
+Contract:
+
+- **Deterministic.** Same `profile` → same `CalculatorResult`. No
+  clocks, no randomness, no I/O.
+- **Pure.** No side effects. No logging at WARN or above — log at
+  DEBUG with structured fields only.
+- **Explicit failure.** Raises `InsufficientInputError` when a
+  required field is missing (e.g. weight), `ImplausibleInputError`
+  when a validator in SPEC-002 somehow was bypassed, and
+  `UnsupportedCohortError` when the cohort routing (§4.9) does not
+  support the profile.
+
+### 4.3 BMR (`bmr.py`)
+
+Default: **Mifflin–St Jeor** (preferred per ISSN position papers
+over Harris–Benedict for adults).
+
+```
+female: 10·kg + 6.25·cm − 5·age − 161
+male:   10·kg + 6.25·cm − 5·age + 5
+```
+
+When `body_fat_pct` is present, **Katch–McArdle**:
+
+```
+BMR = 370 + 21.6 · LBM_kg,   where LBM_kg = kg · (1 − body_fat_pct/100)
+```
+
+Katch–McArdle is preferred for users with accurate body composition
+measurement; when `body_fat_pct` is present we use it and the
+`Rationale` records the switch. `Sex.other` or `Sex.unspecified`
+with body fat present → Katch–McArdle (sex-independent). Without
+body fat, `Sex.other`/`unspecified` routes to the sex-averaged
+Mifflin variant: `10·kg + 6.25·cm − 5·age − 78` (midpoint of −161
+and +5); the `Rationale` notes the approximation and the cohort is
+tagged `general_adult_sex_unspecified`.
+
+### 4.4 TDEE (`tdee.py`)
+
+`TDEE = BMR × PAL` where PAL is from `tables/pal.yaml`:
+
+```
+sedentary:    1.2
+light:        1.375
+moderate:     1.55
+active:       1.725
+very_active:  1.9
+```
+
+No other multipliers. No NEAT adjustments in v1 — that would require
+inputs we do not collect (occupation, steps) and would complicate
+the reproducibility story.
+
+### 4.5 Energy goal (`energy_goal.py`)
+
+Input: `TDEE`, `GoalsInfo`, `BiometricInfo`, `ClinicalInfo`.
+
+```
+kcal_target =
+    TDEE                                    if goal_type == "maintain"
+    TDEE − 7700·rate_kg_per_week/7          if goal_type == "lose_weight"
+    TDEE + 7700·rate_kg_per_week/7          if goal_type == "gain_weight"
+    TDEE + 250                              if goal_type == "muscle" and strength-training PAL, else +150
+```
+
+Then apply the **safety floor**:
+
+```
+floor = max(1200, 0.8 · BMR)
+if kcal_target < floor:
+    kcal_target = floor
+    rationale.add("safety_floor_applied", from=kcal_target, to=floor)
+```
+
+`rate_kg_per_week` is clamped at input (SPEC-002) to ≤1.0; the
+calculator additionally enforces a per-profile sanity cap of 1% of
+body weight per week (rationale note if the input rate is reduced).
+
+Pregnancy/lactation cohorts skip the deficit path entirely (see
+§4.9).
+
+### 4.6 Macros (`macros.py`)
+
+Protein:
+
+```
+base_g_per_kg =
+    1.2 if goal_type == "maintain" else
+    1.6 if goal_type in ("lose_weight", "muscle") else
+    1.4                                       # gain_weight default
+protein_g = clamp(base_g_per_kg · kg, p_amdr_low, p_amdr_high)
+```
+
+Where `p_amdr_low/high` are AMDR bounds (10–35% of kcal).
+
+Fat: `fat_g = max(kcal_target · 0.20, kcal_target · 0.25 if Keto, ...)` — dietary-need adjustments routed to a small table keyed by `dietary_needs` (keto, low-fat, etc.). Default 25% of kcal.
+
+Carbs: remainder of the kcal budget after protein and fat, then
+clamped to AMDR (45–65% of kcal). If the remainder lands outside
+AMDR after protein and fat, protein is reduced *first* (down to
+minimum 0.8 g/kg) before fat, and the `Rationale` records each
+clamp.
+
+AMDR constants live in `tables/amdr.yaml` with a version field; any
+change bumps `CALCULATOR_VERSION`.
+
+### 4.7 Micros (`micros.py`)
+
+DRI table keyed by `(sex, age_band, reproductive_state)`. Returns a
+`DailyTargets.other_nutrients` dict plus structured `MicroTarget`
+records that the UI and ADR-003 consume.
+
+V1 covers: fiber, sodium (upper limit), potassium, calcium, iron,
+vitamin D, vitamin B12, phosphorus, vitamin K. DRI values are
+verbatim from the 2020 DRI tables and are cited in `dri.yaml`
+comments.
+
+Each micro target carries:
+```
+{
+    target: float,
+    unit: str,
+    lower_bound: Optional[float],
+    upper_bound: Optional[float],   # UL for sodium, iron, etc.
+    source: str,                    # "DRI 2020, Table X"
+}
+```
+
+### 4.8 Clinical overrides (`clinical_overrides.py`)
+
+Applied **last**. Each override is a pure function `(CalculatorResult)
+-> CalculatorResult` that may:
+
+- Lower a target (protein cap for CKD stages 3–5).
+- Lower an upper bound (sodium ≤1500 mg for hypertension).
+- Adjust kcal (pregnancy T2/T3: +340/+450 kcal; lactation: +330 (0–6 mo) or +400 (6–12 mo) kcal).
+- Tighten carb distribution (T2D: per-meal carb cap — this is
+  metadata, not a daily-target change; surfaced for ADR-003).
+- Add rationale entries.
+
+Overrides chain deterministically in a fixed order defined in
+`clinical_overrides.py:ORDER`. If two overrides set the same cap,
+the lower value wins and both are recorded.
+
+v1 coverage matches SPEC-002's closed enum list. Out-of-enum
+conditions are ignored by the calculator (the freetext list is
+for the agent narrator only, not for numeric clamps).
+
+### 4.9 Cohort routing (§4.9 of ADR-001 §5)
+
+Before any computation, `targets.py` routes the profile to a cohort:
+
+```mermaid
+flowchart TD
+    P[Profile] --> AGE{age_years < 18?}
+    AGE -->|Yes| MIN[cohort=minor → UnsupportedCohortError]
+    AGE -->|No| PREG{reproductive_state in<br/>{pregnant_t1..t3, lactating}?}
+    PREG -->|Yes| PC[cohort=pregnancy_lactation<br/>skip deficit, apply trimester adjustments]
+    PREG -->|No| ED{ed_history_flag?}
+    ED -->|Yes| EDC[cohort=ed_adjacent<br/>skip deficit, kcal=TDEE, no macro minimums below DRI]
+    ED -->|No| CLIN{condition requires<br/>clinician-guided only?<br/>e.g. ckd_stage_4..5}
+    CLIN -->|Yes| CG[cohort=clinician_guided → UnsupportedCohortError]
+    CLIN -->|No| GEN[cohort=general_adult]
+    PC --> COMPUTE[compute]
+    EDC --> COMPUTE
+    GEN --> COMPUTE
+```
+
+`UnsupportedCohortError` carries a structured payload the agent
+uses (SPEC-004) to emit a "general guidance only, please work with
+your clinician" response — it is not an error surfaced to the
+user as a failure.
+
+### 4.10 Rationale (`rationale.py`)
+
+```python
+@dataclass(frozen=True)
+class RationaleStep:
+    id: str                      # e.g. "bmr_mifflin_female"
+    label: str                   # human-readable
+    inputs: dict[str, Any]       # inputs this step consumed
+    outputs: dict[str, Any]      # outputs this step produced
+    source: str                  # equation citation
+    note: Optional[str] = None
+
+@dataclass(frozen=True)
+class Rationale:
+    steps: tuple[RationaleStep, ...]
+    applied_overrides: tuple[str, ...]
+    cohort: str
+```
+
+Every function in §4.3–§4.8 appends exactly one step. The rationale
+is a complete, ordered audit of how the numbers were produced.
+
+### 4.11 Versioning
+
+`CALCULATOR_VERSION = "MAJOR.MINOR.PATCH"`:
+
+- **MAJOR**: equation swap or cohort-routing change. Downstream cache
+  invalidation is expected.
+- **MINOR**: table update (DRI refresh, AMDR tweak). Invalidation
+  expected.
+- **PATCH**: bug fixes that do not alter outputs on valid inputs.
+
+Tests include a **golden-output test** (§6.2) that pins outputs for
+a fixed set of representative profiles. A MAJOR or MINOR bump
+rewrites the goldens; a PATCH bump must not.
+
+### 4.12 Priority-grouped work items
+
+| # | Item | Priority |
+|---|------|----------|
+| W1 | Module scaffolding; `version.py`; `errors.py`; package exports | P0 |
+| W2 | `rationale.py` dataclasses; tests for immutability and equality | P0 |
+| W3 | `bmr.py` + unit tests against Mifflin/Katch worked examples | P0 |
+| W4 | `tdee.py` + `pal.yaml` + tests | P0 |
+| W5 | `energy_goal.py` + safety-floor tests | P0 |
+| W6 | `macros.py` + `amdr.yaml` + AMDR-clamp tests (including fall-through when protein+fat exceed band) | P0 |
+| W7 | `micros.py` + `dri.yaml` (v1 micro set) + tests per cohort row | P0 |
+| W8 | `clinical_overrides.py` + ordered chain + coverage for v1 enum | P1 |
+| W9 | `targets.py` orchestration + cohort routing + top-level tests | P0 |
+| W10 | Golden-output tests for ~30 representative profiles | P1 |
+| W11 | Benchmarks: `compute_daily_targets` p99 ≤ 5 ms on reference hardware | P2 |
+| W12 | Citation pass on all YAML tables; reviewer sign-off | P1 |
+
+---
+
+## 5. Rollout Plan
+
+This is a pure library; rollout is about getting it reviewed,
+benchmarked, and pinned before SPEC-004 consumes it.
+
+### Phase 0 — Scaffolding (P0)
+- [ ] W1, W2 landed; imports resolve; CI runs empty test suite green.
+
+### Phase 1 — Core equations (P0)
+- [ ] W3 through W7 landed with cited tables.
+- [ ] `pytest backend/agents/nutrition_meal_planning_team/nutrition_calc/` all green.
+- [ ] Coverage ≥95% on `nutrition_calc/` (it is pure logic — high bar is correct).
+
+### Phase 2 — Clinical and cohort routing (P0/P1)
+- [ ] W8, W9 landed.
+- [ ] UnsupportedCohortError payload includes structured reason that SPEC-004 can read.
+
+### Phase 3 — Hardening (P1/P2)
+- [ ] W10 golden outputs checked in; test fails on any output drift.
+- [ ] W11 benchmarks checked in (pytest-benchmark); CI fails regressions.
+- [ ] W12 external clinical reviewer sign-off on `dri.yaml` / `amdr.yaml` / `pal.yaml`.
+- [ ] `CALCULATOR_VERSION` frozen at `1.0.0` and announced in CHANGELOG.
+
+### Rollback
+- This is additive. Module exists but is not called by any agent
+  until SPEC-004 lands. Rollback = revert the PR.
+
+---
+
+## 6. Verification
+
+### 6.1 Reference-value tests
+
+For each equation, **table-driven tests** against published worked
+examples:
+
+- Mifflin–St Jeor: at least 6 worked examples per sex from
+  peer-reviewed sources; tolerance ≤1 kcal.
+- Katch–McArdle: at least 4 worked examples; tolerance ≤1 kcal.
+- PAL multipliers: exact float equality to table values.
+- AMDR clamps: at least one profile per band edge on each macro.
+- DRI micros: one row per (sex × age-band × repro-state) combination
+  in v1 coverage.
+
+### 6.2 Golden-output tests
+
+`tests/golden/` holds YAML files of (profile → CalculatorResult). The
+test round-trips every profile through `compute_daily_targets` and
+asserts byte-equality on the result (with `rationale` canonicalized).
+Any output change fails the test. Intentional changes bump
+`CALCULATOR_VERSION` and rewrite goldens in the same PR.
+
+Profile fixture matrix (≥30):
+
+- General adult, all activity levels × both reference sexes × three
+  ages × goal types.
+- Body-fat-present cases routed to Katch–McArdle.
+- `sex=other` and `sex=unspecified` paths.
+- Pregnancy T1/T2/T3 and lactation (0–6 mo, 6–12 mo).
+- ED-history flag path.
+- Each supported CKD stage (1–3) × one profile.
+- Hypertension clamp profile.
+- T2D per-meal carb-cap profile.
+- Safety-floor trigger profile (aggressive deficit).
+- `UnsupportedCohortError` path: minor, CKD stage 4–5.
+
+### 6.3 Failure-mode tests
+
+- `InsufficientInputError` when weight, height, sex, or age missing
+  on a general-adult profile.
+- `ImplausibleInputError` when bounds bypassed (simulate bad DB
+  value).
+- `UnsupportedCohortError` carries the expected `cohort` and
+  `guidance_key` that SPEC-004 will route on.
+
+### 6.4 Property tests
+
+Via `hypothesis`:
+
+- For all valid profiles, `CalculatorResult` satisfies invariants:
+  `kcal_target ≥ floor`, protein in [0.8·kg, 2.2·kg] (except
+  ed_adjacent cohort which stays at DRI-min), macros sum to
+  `kcal_target` within rounding tolerance, every rationale step has
+  non-empty `id` and `source`.
+- Monotonicity: increasing `weight_kg` (holding all else equal) never
+  decreases `protein_g` or `kcal_target` on the general-adult path.
+
+### 6.5 Benchmark
+
+- `compute_daily_targets` p99 ≤ 5 ms on CI reference runner. This is
+  generous; the point is regression detection, not raw speed.
+
+### 6.6 Review
+
+- Clinical reviewer sign-off on `dri.yaml`, `amdr.yaml`, `pal.yaml`,
+  and the override chain in `clinical_overrides.py:ORDER`. Sign-off
+  recorded in PR description; name becomes the file's designated
+  reviewer on future changes.
+- Second engineer review on cohort routing — the single highest-risk
+  branch in the module.
+
+### 6.7 Cutover criteria
+
+- All tests green, coverage ≥95%, goldens frozen, benchmarks
+  baselined, reviewer sign-off recorded. Then and only then does
+  SPEC-004 open.
+
+---
+
+## 7. Open Questions
+
+- **Katch–McArdle preference when body fat is present but likely
+  user-estimated.** We currently prefer it unconditionally when the
+  field is set. Alternative: use it only when `body_fat_pct`'s
+  `source` is a measurement integration (ADR-006). v1 goes with
+  unconditional and documents the tradeoff.
+- **Strength-training PAL vs. muscle-gain kcal.** `muscle` goal
+  currently adds +250 kcal conditionally. Could be merged with an
+  activity-specific PAL override. Deferred.
+- **Whether to expose intermediate outputs** (BMR, TDEE) on
+  `CalculatorResult` for debugging. Yes — add as `intermediates:
+  dict[str, float]` alongside `targets` and `rationale`. Cheap and
+  useful for the "why these numbers?" UI panel.

--- a/system_design/specs/SPEC-004-nutritionist-agent-refactor.md
+++ b/system_design/specs/SPEC-004-nutritionist-agent-refactor.md
@@ -1,0 +1,549 @@
+# SPEC-004: Nutritionist agent refactor — deterministic calculator + narrator
+
+| Field       | Value                                                    |
+|-------------|----------------------------------------------------------|
+| **Status**  | Proposed                                                 |
+| **Author**  | Nutrition & Meal Planning team                           |
+| **Created** | 2026-04-17                                               |
+| **Priority**| P0 (capstone for ADR-001; unblocks ADR-003 and ADR-006)  |
+| **Scope**   | `backend/agents/nutrition_meal_planning_team/agents/nutritionist_agent/`, `orchestrator/`, `shared/nutrition_plan_store`, `models.py` (additive), chat agent, `user-interface/` plan-rendering component |
+| **Depends on** | SPEC-002 (profile fields), SPEC-003 (calculator) |
+| **Implements** | ADR-001 §3 (narrator), §4 (caching + versioning), §5 (safety routing — agent side) |
+
+---
+
+## 1. Problem Statement
+
+After SPEC-002 and SPEC-003 land we have two things the Nutritionist
+agent does not yet use: a profile rich enough to drive equations, and
+a pure-Python calculator that owns the numbers. This spec wires them
+together.
+
+The Nutritionist agent today (`agents/nutritionist_agent/agent.py`)
+hands the profile to an LLM, asks for `DailyTargets` plus narrative,
+regex-strips fences, and hopes. After this spec, the agent:
+
+1. Calls `compute_daily_targets(profile)` first.
+2. Routes unsupported cohorts to a general-guidance response before
+   any LLM call.
+3. Calls the LLM only to author `balance_guidelines`,
+   `foods_to_emphasize`, `foods_to_avoid`, `notes`, and a friendly
+   summary — never numbers.
+4. Parses via the `llm_service` structured-output contract.
+5. Caches with calculator-version awareness.
+
+This is the user-visible payoff of ADR-001: reproducible, defensible,
+calculator-anchored nutrition plans.
+
+---
+
+## 2. Current State
+
+### 2.1 Today's flow
+
+```mermaid
+sequenceDiagram
+    participant API
+    participant Orch as Orchestrator
+    participant Store as NutritionPlanStore
+    participant NA as NutritionistAgent
+    participant LLM
+
+    API->>Orch: get_nutrition_plan(req)
+    Orch->>Store: get_cached_plan(client_id, profile)
+    alt cache hit (profile-hash)
+        Store-->>Orch: NutritionPlan
+    else miss
+        Orch->>NA: run(profile)
+        NA->>LLM: profile → "produce plan JSON"
+        LLM-->>NA: free-form JSON (numbers + narrative)
+        NA->>NA: regex-strip fences; json.loads
+        NA-->>Orch: NutritionPlan (on fail: empty plan)
+        Orch->>Store: save_plan(...)
+    end
+    Orch-->>API: NutritionPlanResponse
+```
+
+Relevant code:
+
+- Orchestrator cache check: [orchestrator/agent.py:73-80](backend/agents/nutrition_meal_planning_team/orchestrator/agent.py:73)
+- Agent: [agents/nutritionist_agent/agent.py:29-56](backend/agents/nutrition_meal_planning_team/agents/nutritionist_agent/agent.py:29)
+- Chat agent also calls `nutritionist_agent.run` in `_handle_generate_nutrition_plan` ([orchestrator/agent.py:209-218](backend/agents/nutrition_meal_planning_team/orchestrator/agent.py:209))
+- Cache key is a hash of the full profile; it invalidates on any profile change but knows nothing about calculator version.
+
+### 2.2 Problems
+
+1. Numbers are LLM-authored — the entire ADR-001 thesis.
+2. Cohort routing (minors, pregnancy, ED history, unsupported
+   clinical states) does not exist; any profile reaches the LLM.
+3. Parsing is ad-hoc regex + json.loads; malformed output yields an
+   empty plan silently.
+4. Cache does not invalidate on calculator-version change; we will
+   ship a calculator update and users will continue seeing stale
+   plans until their profile happens to change.
+5. Chat path duplicates the non-cached direct call — two call sites
+   to update whenever the flow changes.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- Numbers come from SPEC-003; narrative comes from the LLM.
+- Cohort routing happens before any LLM call; unsupported cohorts
+  produce a structured "general guidance" response with a
+  "consult your clinician" note — no fabricated numbers.
+- Parsing via `llm_service` structured-output contract (PR #184);
+  no regex fence stripping in this module.
+- Cache invalidates on `calculator_version` change **and** on
+  biometric/clinical-field changes that affect calculator inputs.
+- Single agent call site: chat and direct API go through the same
+  helper in the orchestrator.
+- API response includes a `rationale` and `calculator_version` so
+  the UI can render the "why these numbers?" panel.
+
+### 3.2 Non-goals
+
+- **No meal planning changes.** Meal planner still reads the
+  nutrition plan. ADR-003's rollup is a separate spec.
+- **No preference learning.** ADR-004 is separate.
+- **No new LLM provider plumbing.** We use whatever `llm_service`
+  exposes; structured-output support is already present per PR #184.
+- **No UI redesign.** This spec adds fields; the plan screen gets a
+  rationale panel and a cohort banner, but the primary layout is
+  unchanged.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 New flow
+
+```mermaid
+sequenceDiagram
+    participant API
+    participant Orch as Orchestrator
+    participant Store as NutritionPlanStore
+    participant Calc as nutrition_calc
+    participant NA as NutritionistAgent
+    participant LLM
+
+    API->>Orch: get_nutrition_plan(req)
+    Orch->>Store: get_cached_plan(client_id, profile, CALCULATOR_VERSION)
+    alt cache hit
+        Store-->>Orch: NutritionPlan (with rationale)
+    else miss
+        Orch->>Calc: compute_daily_targets(profile)
+        alt UnsupportedCohortError
+            Calc-->>Orch: cohort, guidance_key
+            Orch->>NA: narrate_general_guidance(profile, guidance_key)
+            NA->>LLM: structured-output call (narrative only)
+            LLM-->>NA: GuidanceOnlyPayload
+            NA-->>Orch: NutritionPlan (no numeric targets; cohort flag set)
+        else OK
+            Calc-->>Orch: CalculatorResult (targets, rationale, intermediates)
+            Orch->>NA: narrate_plan(profile, targets, rationale)
+            NA->>LLM: structured-output call (narrative only)
+            LLM-->>NA: NarrativePayload
+            NA-->>Orch: NutritionPlan (targets from Calc, narrative from LLM)
+        end
+        Orch->>Store: save_plan(profile, plan, calculator_version)
+    end
+    Orch-->>API: NutritionPlanResponse (includes rationale & cohort)
+```
+
+### 4.2 `models.py` additions (additive)
+
+```python
+class PlanCohort(str, Enum):
+    general_adult = "general_adult"
+    general_adult_sex_unspecified = "general_adult_sex_unspecified"
+    pregnancy_lactation = "pregnancy_lactation"
+    ed_adjacent = "ed_adjacent"
+    clinician_guided = "clinician_guided"   # unsupported — guidance only
+    minor = "minor"                         # unsupported — guidance only
+
+class NutritionPlan(BaseModel):
+    # ... existing ...
+    rationale: Optional[Rationale] = None
+    calculator_version: Optional[str] = None
+    cohort: PlanCohort = PlanCohort.general_adult
+    is_guidance_only: bool = False
+    clinician_note: Optional[str] = None    # shown when guidance_only
+    intermediates: Dict[str, float] = {}    # BMR, TDEE for UI "why?"
+```
+
+`Rationale` is re-exported from `nutrition_calc` (it is a plain
+frozen dataclass; Pydantic's `ConfigDict(arbitrary_types_allowed=True)`
+or an `__get_pydantic_core_schema__` adapter — pick at implementation
+time, document the choice in the PR).
+
+### 4.3 Agent refactor
+
+`agents/nutritionist_agent/agent.py`:
+
+```python
+class NutritionistAgent:
+    def __init__(self, model, narrator_schema=NarrativePayload, ...):
+        self._agent = Agent(model=model, system_prompt=NARRATOR_SYSTEM_PROMPT)
+        self._guidance_agent = Agent(model=model, system_prompt=GUIDANCE_SYSTEM_PROMPT)
+
+    def narrate_plan(
+        self,
+        profile: ClientProfile,
+        targets: DailyTargets,
+        rationale: Rationale,
+    ) -> NarrativePayload: ...
+
+    def narrate_general_guidance(
+        self,
+        profile: ClientProfile,
+        guidance_key: str,         # e.g. "pregnancy", "ckd_stage_5", "minor"
+    ) -> GuidanceOnlyPayload: ...
+```
+
+- Two agents, two prompts, two response schemas. Both use
+  `llm_service` structured output; no regex parsing in this file.
+- `NARRATOR_SYSTEM_PROMPT` explicitly forbids emitting or modifying
+  numeric targets. Includes: *"You will be given exact numeric
+  targets. You may reference them in prose but MUST NOT contradict
+  them. You are not the source of the numbers."*
+- `GUIDANCE_SYSTEM_PROMPT` explicitly forbids emitting any numeric
+  target at all; it produces qualitative food-group guidance and a
+  "please work with your clinician" note.
+- On LLM failure, return a `NarrativePayload` with empty narrative
+  strings — the numeric part of the plan still ships. A plan with
+  real numbers and blank guidelines is much better than no plan.
+
+The old `run(profile) -> NutritionPlan` method is removed. All
+callers move to the orchestrator helper in §4.4.
+
+### 4.4 Orchestrator helper
+
+`orchestrator/agent.py`:
+
+```python
+def _build_nutrition_plan(self, profile: ClientProfile) -> NutritionPlan:
+    try:
+        calc = compute_daily_targets(profile)
+    except UnsupportedCohortError as e:
+        narrative = self.nutritionist_agent.narrate_general_guidance(
+            profile, e.guidance_key
+        )
+        return NutritionPlan(
+            daily_targets=DailyTargets(),
+            balance_guidelines=narrative.balance_guidelines,
+            foods_to_emphasize=narrative.foods_to_emphasize,
+            foods_to_avoid=narrative.foods_to_avoid,
+            notes=narrative.notes,
+            rationale=None,
+            calculator_version=CALCULATOR_VERSION,
+            cohort=PlanCohort(e.cohort),
+            is_guidance_only=True,
+            clinician_note=e.clinician_note,
+            generated_at=utcnow_iso(),
+        )
+    except InsufficientInputError as e:
+        return NutritionPlan(
+            # blank plan, notes=“we need your height/weight/age/sex to
+            # compute personalized targets”, cohort=general_adult,
+            # is_guidance_only=True, completeness_missing=e.fields
+            ...
+        )
+
+    narrative = self.nutritionist_agent.narrate_plan(
+        profile, calc.targets, calc.rationale
+    )
+    return NutritionPlan(
+        daily_targets=calc.targets,
+        balance_guidelines=narrative.balance_guidelines,
+        foods_to_emphasize=narrative.foods_to_emphasize,
+        foods_to_avoid=narrative.foods_to_avoid,
+        notes=narrative.notes,
+        rationale=calc.rationale,
+        calculator_version=calc.calculator_version,
+        cohort=PlanCohort(calc.cohort),
+        intermediates=calc.intermediates,
+        generated_at=utcnow_iso(),
+    )
+```
+
+`_get_or_generate_nutrition_plan` becomes a thin wrapper that:
+
+1. Calls `get_cached_plan(...)` with `CALCULATOR_VERSION`.
+2. On miss, calls `_build_nutrition_plan` and saves.
+
+Both `get_nutrition_plan` (API) and `_handle_generate_nutrition_plan`
+(chat) route through this single helper. The chat agent stops calling
+`nutritionist_agent.run` directly.
+
+### 4.5 Cache key and versioning
+
+`shared/nutrition_plan_store.py`:
+
+- Cache key derived from `(client_id, calculator_version,
+  profile_cache_vector)` where `profile_cache_vector` is a hash of
+  **only the fields the calculator reads** (biometrics, activity,
+  goals, clinical conditions, medications, reproductive state, ED
+  flag, clinician overrides, dietary needs that affect macros).
+  Preferences and household composition do not invalidate; they do
+  not change targets.
+- Key layout: `nutrition_plan_v2:{client_id}:{calculator_version}:{profile_cache_vector}`.
+- Postgres row includes `calculator_version` and
+  `profile_cache_vector` as indexed columns; lookup is by exact match
+  on all three.
+
+Migration `003_nutrition_plan_v2.sql`:
+
+```sql
+ALTER TABLE nutrition_plans
+    ADD COLUMN calculator_version TEXT,
+    ADD COLUMN profile_cache_vector TEXT,
+    ADD COLUMN cohort TEXT,
+    ADD COLUMN is_guidance_only BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN rationale JSONB,
+    ADD COLUMN intermediates JSONB NOT NULL DEFAULT '{}'::jsonb;
+
+CREATE INDEX ON nutrition_plans (client_id, calculator_version, profile_cache_vector);
+```
+
+Pre-existing cached plans lack `calculator_version`; they are treated
+as misses and regenerated on first access. No back-migration; old
+rows are retained for audit and removed on a 90-day TTL job.
+
+### 4.6 Structured-output schemas
+
+`llm_service` structured-output payloads (Pydantic models):
+
+```python
+class NarrativePayload(BaseModel):
+    balance_guidelines: List[str]
+    foods_to_emphasize: List[str]
+    foods_to_avoid: List[str]
+    notes: str
+    summary: str                     # 1–2 sentences, user-facing
+
+class GuidanceOnlyPayload(BaseModel):
+    balance_guidelines: List[str]
+    foods_to_emphasize: List[str]
+    foods_to_avoid: List[str]
+    notes: str
+    clinician_note: str              # explicit "work with your clinician"
+```
+
+Strict schemas per PR #184 — the LLM cannot return extra fields.
+
+### 4.7 API surface
+
+Existing endpoints unchanged at the HTTP level. Response bodies gain
+new fields (additive; existing consumers ignore them):
+
+- `NutritionPlanResponse.plan` includes `rationale`,
+  `calculator_version`, `cohort`, `is_guidance_only`, `clinician_note`,
+  `intermediates`.
+- `ChatResponse.nutrition_plan` (already optional) includes the same.
+
+Two small additions:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/plan/nutrition/{client_id}/rationale` | Returns just the rationale + intermediates (for the "why?" panel without re-fetching the plan) |
+| `POST` | `/plan/nutrition/{client_id}/regenerate` | Forces cache bypass; returns a freshly computed plan. Rate-limited. |
+
+### 4.8 Safety rail integration
+
+Rails live in the calculator (SPEC-003 §4.9) **and** in the
+orchestrator as a belt-and-suspenders check:
+
+- After building any plan (even guidance-only), the orchestrator
+  re-asserts:
+  - `age_years < 18` → `cohort == PlanCohort.minor` and
+    `is_guidance_only == True` and `goals.goal_type != "lose_weight"`.
+  - `ed_history_flag == True` → cohort is `ed_adjacent` or
+    guidance-only, and no deficit was applied (rationale check).
+  - `kcal_target` (if set) ≥ safety floor.
+- Any violation raises `SafetyInvariantError` and is treated as a
+  production incident: the plan is not returned, the user sees a
+  graceful error, and we page. This should never fire — it is a
+  defense-in-depth check against calculator bugs.
+
+### 4.9 UI changes
+
+Minor; primary plan layout unchanged.
+
+- **Cohort banner**: shown when `is_guidance_only`; renders
+  `clinician_note` and a muted styling for numeric sections (which
+  are absent in guidance-only mode).
+- **"Why these numbers?" panel**: collapsible, renders
+  `rationale.steps` as a friendly list ("Baseline from Mifflin–St
+  Jeor: 1,540 kcal → TDEE at moderate activity: 2,385 kcal → 500
+  kcal deficit for 0.45 kg/wk loss → safety floor OK → final 1,885
+  kcal").
+- **Regenerate button** (§4.7) with a confirmation dialog and a
+  visible loading state — calculator work is millisecond-scale but
+  the LLM narrative call is not.
+
+### 4.10 Priority-grouped work items
+
+| # | Item | Priority |
+|---|------|----------|
+| W1 | `models.py` additions (PlanCohort, NutritionPlan fields) | P0 |
+| W2 | `NarrativePayload`, `GuidanceOnlyPayload` schemas | P0 |
+| W3 | `NutritionistAgent.narrate_plan` / `narrate_general_guidance` via `llm_service` structured output | P0 |
+| W4 | Remove `NutritionistAgent.run`; update chat agent and orchestrator to use `_build_nutrition_plan` | P0 |
+| W5 | `nutrition_plan_store` cache key and `profile_cache_vector` derivation | P0 |
+| W6 | Migration `003_nutrition_plan_v2.sql` + schema registration | P0 |
+| W7 | Safety-invariant orchestrator checks + `SafetyInvariantError` handling | P0 |
+| W8 | Rationale/intermediates in API responses | P1 |
+| W9 | `/plan/nutrition/{id}/rationale` and `/regenerate` endpoints | P1 |
+| W10 | Cohort banner component | FE | P1 |
+| W11 | "Why these numbers?" panel | FE | P1 |
+| W12 | Regenerate UX (button + dialog + loading) | FE | P2 |
+| W13 | Deprecation notice in CHANGELOG; mark `NutritionistAgent.run` removed | P1 |
+
+---
+
+## 5. Rollout Plan
+
+Single feature flag `NUTRITION_CALC_NARRATOR` (off → legacy agent,
+on → SPEC-004 flow). Flag lives in unified config.
+
+### Phase 0 — Wiring (P0)
+- [ ] SPEC-003 frozen at `CALCULATOR_VERSION=1.0.0`.
+- [ ] W1, W2, W6 landed; migration applied in staging.
+- [ ] No behavior change yet; flag off.
+
+### Phase 1 — Agent behind flag (P0)
+- [ ] W3–W5, W7 landed behind flag.
+- [ ] Orchestrator routes through `_build_nutrition_plan` when flag on.
+- [ ] Unit, integration, and safety-invariant tests green.
+
+### Phase 2 — Dogfood + compare (P0/P1)
+- [ ] Shadow mode: for flagged-on users, also compute the legacy
+      output and store a side-by-side record for 7 days. Review
+      deltas with the clinical reviewer from SPEC-003 §6.6.
+- [ ] Flag on for internal team profiles.
+- [ ] No unexpected guidance-only responses (i.e., no misclassified
+      cohorts on internal profiles).
+
+### Phase 3 — Gradual rollout (P1)
+- [ ] W8–W11 landed (rationale/cohort UI).
+- [ ] 10% → 50% → 100% ramp over 2 weeks.
+- [ ] Regeneration rate, `guidance_only` rate, and plan-fetch error
+      rate monitored against pre-launch baselines.
+
+### Phase 4 — Cleanup (P1/P2)
+- [ ] W12 regenerate UX.
+- [ ] W13 remove legacy `NutritionistAgent.run` path and flag.
+- [ ] CHANGELOG entry published.
+
+### Rollback
+
+- Flag off instantly reverts all users to the legacy agent path. The
+  new cache rows are inert (legacy code path does not read them).
+- Schema migration is additive; no rollback needed.
+- Plans stored during the rollout remain valid for audit; new legacy
+  plans do not carry `calculator_version` and will be regenerated the
+  next time the flag is turned on.
+
+---
+
+## 6. Verification
+
+### 6.1 Unit tests
+
+- `test_nutritionist_agent_narrate.py` — structured-output happy
+  path; LLM malformed output returns empty narrative; LLM error
+  falls back to empty narrative with numeric targets intact.
+- `test_guidance_agent.py` — `narrate_general_guidance` never emits
+  numeric targets (schema enforces this; test confirms).
+- `test_plan_store_cache_key.py` — `profile_cache_vector` is stable
+  across irrelevant changes (preferences edited → same vector),
+  invalidates on relevant changes (weight changes → different
+  vector); `calculator_version` change alone invalidates.
+- `test_orchestrator_safety_invariants.py` — simulate a calculator
+  bug (monkeypatch `compute_daily_targets` to return a deficit for a
+  minor) and assert `SafetyInvariantError` is raised and surfaced as
+  a graceful API error.
+
+### 6.2 Integration tests
+
+- `test_plan_nutrition_api_v2.py` — `POST /plan/nutrition` returns
+  rationale + cohort on supported cohorts; guidance-only payload on
+  pregnancy/minor/CKD-5.
+- `test_plan_cache.py` — repeated request hits cache; bumping
+  `CALCULATOR_VERSION` causes miss; editing a preference does not
+  cause miss; editing weight does.
+- `test_regenerate.py` — `/regenerate` bypasses cache and writes a
+  new row; rate limit fires on the Nth call within window.
+- `test_chat_plan_parity.py` — chat path and direct API path return
+  byte-equal `NutritionPlan` for the same profile.
+
+### 6.3 Shadow-mode comparison (Phase 2)
+
+- Scripted diff between legacy output and new output for ~200
+  anonymized profiles.
+- Expected shape of the diff, reviewed with clinical reviewer:
+  - Numeric targets become stable (no drift across repeated calls)
+    and sometimes move substantially (especially where the legacy
+    output was fabricated).
+  - Narrative style is similar but no longer contains numbers.
+  - Guidance-only cohorts are correctly identified.
+- Sign-off gate: reviewer agrees the new outputs are preferable on
+  ≥80% of sampled profiles and neutral on the remainder.
+
+### 6.4 Contract test for structured output
+
+- `test_narrative_payload_schema.py` — schema round-trips; extra
+  fields rejected; missing required fields rejected.
+
+### 6.5 Observability
+
+- OTel counters:
+  - `nutrition.plan.generated{cohort, is_guidance_only}`
+  - `nutrition.plan.cache_{hit,miss,version_miss}`
+  - `nutrition.plan.narrate_llm_{ok,error}`
+  - `nutrition.plan.safety_invariant_triggered` — MUST remain 0 in
+    steady state; any non-zero value pages.
+  - `nutrition.plan.regenerate_called{reason}` (`user` | `admin`)
+- Traces: `build_nutrition_plan` root span with child spans for
+  `compute_daily_targets`, `narrate_plan` / `narrate_general_guidance`,
+  `store.save_plan`. Latency budgets: p99 ≤ 3s for the narrate call
+  path, p99 ≤ 50ms for cache-hit reads.
+
+### 6.6 Cutover criteria (flag on by default)
+
+- All P0/P1 tests green on `main`.
+- Shadow-mode comparison signed off (§6.3).
+- Phase 3 ramp completed with:
+  - Plan-fetch error rate within +0.5 pp of legacy baseline.
+  - `safety_invariant_triggered` count at zero throughout ramp.
+  - `guidance_only` classification confirmed correct on a 50-profile
+    audit sample.
+- Clinical reviewer, team lead, and on-call approve promotion.
+
+---
+
+## 7. Open Questions
+
+- **What counts as a "relevant" profile field for `profile_cache_vector`?**
+  The closed list is defined in §4.5 but will want review — overly
+  aggressive caching risks stale plans; overly conservative caching
+  wastes LLM calls. First cut is conservative (include anything the
+  calculator reads or the narrator's prompt injects).
+- **Should the narrator see the `rationale`?** Yes, in v1, so the
+  narrative can reference reasoning ("because your activity level is
+  moderate…"). The risk is the LLM being tempted to argue with the
+  numbers. Mitigation is prompt + schema; we re-evaluate if the
+  shadow-mode review turns up issues.
+- **Where does `guidance_key` come from for `UnsupportedCohortError`?**
+  SPEC-003 §4.9 implies a small closed enum. We freeze it alongside
+  the calculator version, and the guidance prompt switches on it
+  deterministically.
+- **Chat-phase UX for guidance-only.** The chat agent currently
+  offers "generate a nutrition plan" as an action; on
+  `is_guidance_only` it should offer a different follow-up (e.g.,
+  "talk about general eating patterns" instead of meal targets).
+  Small chat-agent prompt tweak, tracked in the chat agent's own
+  backlog.

--- a/system_design/specs/SPEC-005-nutrition-ingredient-knowledge-base.md
+++ b/system_design/specs/SPEC-005-nutrition-ingredient-knowledge-base.md
@@ -1,0 +1,534 @@
+# SPEC-005: Ingredient knowledge base and deterministic parser
+
+| Field       | Value                                                    |
+|-------------|----------------------------------------------------------|
+| **Status**  | Proposed                                                 |
+| **Author**  | Nutrition & Meal Planning team                           |
+| **Created** | 2026-04-17                                               |
+| **Priority**| P0 (blocks SPEC-006, SPEC-007, ADR-003, ADR-005)         |
+| **Scope**   | New pure-Python module `backend/agents/nutrition_meal_planning_team/ingredient_kb/`, data files, parser, CLI tools |
+| **Implements** | ADR-002 §1 (canonical ingredient model) |
+
+---
+
+## 1. Problem Statement
+
+Every downstream nutrition feature — the allergen guardrail (SPEC-007),
+the nutrient rollup (ADR-003), the grocery-list aggregator and
+substitution agent (ADR-005) — needs one thing the codebase does not
+have: a deterministic way to take a free-text ingredient line
+("almond flour", "1 tbsp soy sauce", "a handful of cashews") and
+resolve it to a canonical identifier with known properties.
+
+`MealRecommendation.ingredients: List[str]` is free text. Two
+recipes that both call for red onion emit different strings; a
+parser that "almost works" propagates errors into safety checks.
+
+This spec ships the canonical ingredient knowledge base and its
+parser as a standalone library — no LLM, no Postgres, no agent
+dependency. It is the foundation the next three specs (and several
+follow-up roadmap items) consume unchanged.
+
+The data-curation commitment is the non-trivial part; §4.1–§4.3
+define the shape of the data, the process for extending it, and the
+quality bar for shipping v1.
+
+---
+
+## 2. Current State
+
+### 2.1 Ingredient strings today
+
+`MealRecommendation.ingredients` is produced by the meal-planning
+agent and looks like:
+
+```
+["1 tbsp olive oil",
+ "400g chicken thighs, diced",
+ "a handful of cashews",
+ "soy sauce",
+ "chili flakes to taste"]
+```
+
+These strings flow through `_record_suggestions`
+([orchestrator/agent.py:171](backend/agents/nutrition_meal_planning_team/orchestrator/agent.py:171))
+directly into the store with no normalization.
+
+### 2.2 Downstream consumers (blocked by this spec)
+
+- **SPEC-006 / SPEC-007 allergen guardrail** — must know "cashews"
+  is a `tree_nut`.
+- **ADR-003 nutrient rollup** — must convert "a handful" of cashews
+  into grams, then grams into kcal / protein / fat / micros.
+- **ADR-005 grocery list** — must aggregate "1 tbsp soy sauce"
+  across three recipes into one purchasable unit.
+- **ADR-005 substitution** — must know that silken tofu is a
+  reasonable stand-in for Greek yogurt for given use cases.
+
+All of these depend on the same three capabilities: resolve a string
+to a canonical id, look up properties of that id, convert between
+units.
+
+### 2.3 Gaps
+
+- No canonical id space for ingredients.
+- No closed allergen taxonomy.
+- No parser. No alias index. No unit conversion table.
+- No curation process, reviewer, or versioning for the KB.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- Ship a pure-Python module exposing three primary functions:
+  `parse_ingredient`, `resolve_canonical_id`, and
+  `convert_to_grams`. All three are deterministic and have no I/O.
+- Define the closed allergen taxonomy (FDA Big-9 + EU-14 superset)
+  as an authoritative Python enum. The enum is load-bearing for
+  SPEC-006 and SPEC-007.
+- Seed `canonical_foods.yaml` with ~2,000 common ingredients, with
+  strict rules about what "shipped" means: citation for allergen
+  tags, reviewer sign-off on edits.
+- Provide CLI tools for (a) adding new ingredients with lint checks,
+  (b) auditing parser coverage against a corpus of past recipe
+  outputs, and (c) regenerating the alias index from a single
+  source of truth.
+- Version the KB. A `KB_VERSION` constant lets downstream caches
+  (SPEC-007 guardrail rejections, ADR-003 rollups) invalidate
+  deterministically.
+
+### 3.2 Non-goals
+
+- **No enforcement.** This spec does not reject meals, warn users,
+  or call agents. It only resolves strings to ids and exposes
+  properties.
+- **No nutrient data.** Per-ingredient nutrients are ADR-003. The
+  schema here has a reserved slot; population lives in the nutrient
+  rollup spec.
+- **No recipe parsing.** Only ingredient *lines* are in scope. Step
+  text, recipe titles, grocery-list formatting are out.
+- **No branded foods.** v1 covers generic ingredients only. Branded
+  Foods (USDA Branded Foods set) are a follow-up.
+- **No LLM fallback.** Ambiguous lines return `canonical_id=None`
+  with a reason — the downstream decision (ask the user, reject the
+  meal) belongs in SPEC-006 and SPEC-007.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 Module layout
+
+```
+backend/agents/nutrition_meal_planning_team/ingredient_kb/
+├── __init__.py                 # parse_ingredient, resolve_canonical_id,
+│                               # convert_to_grams, KB_VERSION
+├── version.py                  # KB_VERSION = "1.0.0"
+├── taxonomy.py                 # AllergenTag, DietaryTag, InteractionTag enums
+├── types.py                    # ParsedIngredient, CanonicalFood, Unit
+├── parser.py                   # deterministic rule-based parser
+├── normalizer.py               # string normalization (case, diacritics, plurals)
+├── alias_index.py              # prefix + fuzzy lookup over aliases
+├── units.py                    # unit conversion (volume/mass/count)
+├── errors.py                   # KBError, UnknownUnitError, AmbiguousIngredientError
+├── data/
+│   ├── canonical_foods.yaml    # the authoritative catalog
+│   ├── aliases.yaml            # surface-form → canonical_id
+│   ├── densities.yaml          # volume→mass by canonical_id
+│   ├── units.yaml              # unit definitions and conversions
+│   └── interactions.yaml       # ingredient → interaction_tag (reserved for
+│                               #   SPEC-007; populated but not enforced here)
+├── cli/
+│   ├── add.py                  # interactive add + lint
+│   ├── audit.py                # parser coverage over a corpus
+│   └── reindex.py              # rebuild aliases.yaml from canonical_foods.yaml
+└── tests/
+    ├── corpora/                # fixture ingredient lines (see §6)
+    └── ...
+```
+
+### 4.2 Closed taxonomies (`taxonomy.py`)
+
+Three closed `StrEnum`s. **Closed** means: only changeable via a
+MAJOR `KB_VERSION` bump; downstream code pattern-matches on them.
+
+- `AllergenTag` — FDA Big-9 (`peanut`, `tree_nut`, `dairy`, `egg`,
+  `soy`, `wheat`, `fish`, `shellfish`, `sesame`) plus EU-14 extras
+  (`mustard`, `celery`, `sulfites`, `lupin`, `mollusc`, `gluten`).
+  `gluten` is separate from `wheat` deliberately — spelt and barley
+  are gluten without being wheat.
+- `DietaryTag` — `animal`, `dairy`, `egg`, `honey`, `gelatin`,
+  `alcohol`, `high_fodmap`, `nightshade`, `gluten`, `grain`,
+  `legume`, `nightshade`. A `vegan` profile (SPEC-006) expands to
+  `forbid: {animal, dairy, egg, honey, gelatin}`.
+- `InteractionTag` — `vitamin_k_high`, `tyramine_high`,
+  `potassium_high`, `grapefruit`, `licorice`, `st_johns_wort`,
+  `very_high_fat`, `caffeine_high`, `sodium_very_high`.
+  Reserved for SPEC-007 enforcement; this spec only tags foods.
+
+Enum changes require:
+
+1. A `KB_VERSION` bump (major for removals or tag renames; minor
+   for additions).
+2. Changelog entry under `ingredient_kb/CHANGELOG.md`.
+3. Reviewer sign-off (see §4.6).
+
+### 4.3 Canonical food schema (`canonical_foods.yaml`)
+
+```yaml
+- id: almond_flour
+  display_name: "Almond flour"
+  fdc_id: 170567                 # USDA FDC id where available
+  allergen_tags: [tree_nut]
+  dietary_tags: [grain]          # for grain-free filtering; not a gluten
+  interaction_tags: []
+  parent_ids: [almond]
+  purchase_unit:
+    unit: g
+    typical_package_g: 454
+  aliases:
+    - "almond flour"
+    - "ground almonds"
+    - "almond meal"
+  citations:
+    allergen: "FDA Big-9: tree nuts include almonds"
+  notes: "Meal and flour differ in texture but share allergen tags."
+
+- id: soy_sauce
+  display_name: "Soy sauce"
+  fdc_id: 174278
+  allergen_tags: [soy, wheat, gluten]
+  dietary_tags: [alcohol]        # brewed; most contain trace alcohol
+  interaction_tags: [sodium_very_high]
+  purchase_unit: { unit: ml, typical_package_ml: 250 }
+  aliases: ["soy sauce", "shoyu", "light soy sauce", "dark soy sauce"]
+  notes: "Tamari variants do NOT share gluten. Separate canonical id: tamari."
+```
+
+Required fields: `id`, `display_name`, `allergen_tags`,
+`dietary_tags`, `aliases`. All other fields are optional in v1.
+
+**Rules enforced by lint (`cli/add.py`):**
+
+- `id` is `snake_case`, globally unique, ASCII.
+- `aliases` includes `display_name` lowercased.
+- Any `allergen_tag` or `dietary_tag` that maps to a regulated
+  category (FDA Big-9) requires a non-empty `citations.allergen`.
+- Variants that differ in allergen profile (tamari vs. soy sauce,
+  oat milk made with barley) must be separate ids, not aliases.
+- Plural forms are NOT aliases — the normalizer handles pluralization
+  (§4.7).
+
+### 4.4 v1 seed corpus (2,000 ingredients)
+
+v1 ships with ~2,000 ingredients covering:
+
+- USDA FDC SR Legacy most-used foods (≈1,200).
+- Top ingredients from a sample of recipe corpora (≈500) —
+  generated by running `cli/audit.py` against a snapshot of past
+  `MealRecommendation` outputs and anything with ≥3 occurrences
+  that does not yet resolve.
+- Priority allergen-bearing foods (≈300 on top, some overlap) —
+  every item in FDA Big-9 + EU-14 categories covered at least for
+  common forms.
+
+**Ship gate**: parser coverage ≥95% on a 500-line holdout corpus
+of ingredient strings sampled from production (`audit` tool, §4.9).
+
+### 4.5 Parser (`parser.py`)
+
+Deterministic, grammar-light. Input: one line of free text. Output:
+
+```python
+@dataclass(frozen=True)
+class ParsedIngredient:
+    raw: str
+    qty: Optional[float]             # 1.0, 0.5, None ("to taste")
+    unit: Optional[Unit]             # Unit.tbsp, Unit.g, Unit.count, ...
+    name: str                        # the head noun phrase
+    modifiers: tuple[str, ...]       # "diced", "raw", "low-sodium"
+    canonical_id: Optional[str]
+    confidence: float                # 0.0..1.0
+    reasons: tuple[str, ...]         # when confidence < 1.0, why
+```
+
+Pipeline:
+
+```mermaid
+flowchart LR
+    A["raw line"] --> B[normalize]
+    B --> C["qty/unit extractor<br/>(regex + unit dict)"]
+    C --> D["head-noun + modifier<br/>split"]
+    D --> E[alias_index.lookup]
+    E -->|exact| OK["canonical_id, conf=1.0"]
+    E -->|fuzzy match < 0.85| AMB["canonical_id=None,<br/>reasons=['ambiguous']"]
+    E -->|miss| UNK["canonical_id=None,<br/>reasons=['unknown']"]
+```
+
+No ML, no LLM. This is deliberate — ambiguity is surfaced, not
+hidden. Downstream decides what to do.
+
+Quirk handling (all covered by tests in §6.1):
+
+- "a handful of cashews" → `qty=None, unit=None`,
+  `reasons=['unparsed_qty']`, but canonical resolution still succeeds.
+- "1 (14 oz) can of chickpeas" → `qty=14, unit=oz` (the package
+  size), preferring canonical purchase-unit semantics.
+- "salt, to taste" → `canonical_id=salt, qty=None, unit=None`.
+- Recipe-embedded instructions ("chicken, diced and patted dry") →
+  modifiers stripped; `canonical_id=chicken_breast_raw` or
+  `chicken_thigh_raw` only if explicitly stated, otherwise the
+  generic `chicken_raw` with `confidence=0.9`.
+- "juice of 1 lemon" → `canonical_id=lemon_juice, qty=1, unit=count_lemon`
+  with a special unit that `convert_to_grams` handles.
+
+### 4.6 Alias index (`alias_index.py`)
+
+- Built in-memory at import from `aliases.yaml` + the `aliases`
+  field on every canonical food.
+- Primary lookup is exact after normalization (§4.7). Falls through
+  to a prefix/ngram fuzzy match capped at `score < 0.85` as
+  ambiguous.
+- Index is stable: same input → same result, deterministically.
+- Rebuild via `cli/reindex.py` on every canonical-foods edit; the
+  rebuilt file is checked in so runtime doesn't compute it.
+
+### 4.7 Normalizer (`normalizer.py`)
+
+Rules, applied in order:
+
+1. Unicode NFKC, strip diacritics.
+2. Lowercase.
+3. Pluralization: English rules + an overrides table for
+   irregulars (`tomatoes`→`tomato`, `leaves`→`leaf`). Non-English
+   text is routed through the alias index as-is (aliases include
+   non-English forms explicitly, e.g. `"amandes en poudre"` →
+   `almond_flour`).
+4. Punctuation stripped except interior commas (used by the parser).
+5. Stopword trim (`of`, `the`) only when adjacent to a unit token.
+
+Normalization is applied to both sides of alias lookup so authors
+can write aliases in natural form.
+
+### 4.8 Unit system (`units.py`, `densities.yaml`)
+
+- `units.yaml` defines: `mass` (g, kg, oz, lb), `volume` (ml, l,
+  tsp, tbsp, cup, fl_oz, pint, quart), `count` (count, dozen,
+  `count_lemon`/`count_egg`/etc.).
+- Volume → mass conversion uses `densities.yaml` keyed by
+  `canonical_id`. `densities.yaml` is hand-curated; missing entries
+  cause `convert_to_grams` to return `None` with a structured reason.
+- `convert_to_grams(parsed: ParsedIngredient) -> Optional[Grams]`
+  is pure and deterministic. Missing density → returns `None`; no
+  silent fallback to "average density of food".
+- `count` units for items like onions use per-item masses from
+  `densities.yaml` (`onion_medium: 170g`).
+
+### 4.9 CLI tools
+
+- `python -m ingredient_kb.cli.add` — interactive: prompts for
+  `id`, `display_name`, allergens, aliases; runs lint; appends to
+  `canonical_foods.yaml`; rebuilds `aliases.yaml`; prints the diff
+  for PR review.
+- `python -m ingredient_kb.cli.audit PATH` — reads ingredient lines
+  (one per line, or CSV), runs `parse_ingredient`, emits a report:
+  coverage %, top unresolved strings, top low-confidence resolutions.
+  Runs in CI against a checked-in holdout corpus.
+- `python -m ingredient_kb.cli.reindex` — rebuilds `aliases.yaml`
+  from the ground truth in `canonical_foods.yaml`; fails CI if the
+  two are out of sync.
+
+### 4.10 Versioning
+
+`KB_VERSION = "MAJOR.MINOR.PATCH"`:
+
+- **MAJOR** — taxonomy change (enum removal or rename), `id`
+  rename. Downstream caches must invalidate.
+- **MINOR** — enum addition, ingredient addition, alias addition,
+  density addition.
+- **PATCH** — citation edits, typos, non-behavioral fixes.
+
+SPEC-007 pins on `KB_VERSION` for its `guardrail_version` cache
+field.
+
+### 4.11 Review process
+
+- Any edit to `canonical_foods.yaml` requires lint pass (§4.3) and
+  reviewer approval from the nutrition team lead.
+- Edits to `taxonomy.py` require the team lead plus a second
+  reviewer (the SPEC-007 owner, so enforcement implications are
+  considered simultaneously).
+- `densities.yaml` edits require a linked citation in the PR
+  (USDA FDC density value, cookbook reference, or measured value).
+- Interaction-tag additions to `interactions.yaml` require the
+  SPEC-007 owner; additions do not take effect on user meals until
+  SPEC-007 ships, but tagging is consistent from day one.
+
+### 4.12 Priority-grouped work items
+
+| # | Item | Priority |
+|---|------|----------|
+| W1 | Module scaffolding, `version.py`, `types.py`, `errors.py` | P0 |
+| W2 | `taxonomy.py` with closed enums + tests on enum membership | P0 |
+| W3 | `normalizer.py` + pluralization rules + unit tests | P0 |
+| W4 | `units.py` + `units.yaml` + `densities.yaml` seed | P0 |
+| W5 | `parser.py` with tests on ≥200 fixture lines (see §6.1) | P0 |
+| W6 | `alias_index.py` with lookup tests | P0 |
+| W7 | `canonical_foods.yaml` seed — 2,000 ingredients, with lint | P0 |
+| W8 | `aliases.yaml` regeneration + `reindex` CLI | P0 |
+| W9 | `audit` CLI + CI job against holdout corpus | P1 |
+| W10 | `add` CLI + lint | P1 |
+| W11 | Citation pass on allergen tags (reviewer sign-off) | P1 |
+| W12 | `interactions.yaml` stubbed with tags but no consumer (SPEC-007 uses it) | P2 |
+| W13 | Benchmark: `parse_ingredient` p99 ≤ 2 ms on reference runner | P2 |
+
+---
+
+## 5. Rollout Plan
+
+This is a pure library with no runtime callers in v1. Rollout is
+about landing data, hitting the quality bar, and freezing `KB_VERSION`
+before SPEC-006 and SPEC-007 consume it.
+
+### Phase 0 — Scaffolding (P0)
+- [ ] W1–W4 landed; empty test suite green.
+- [ ] Enum taxonomy reviewed and frozen.
+
+### Phase 1 — Core parser + alias index (P0)
+- [ ] W5, W6, W8 landed.
+- [ ] Parser unit tests pass on the ≥200-line fixture corpus.
+- [ ] Seed of ~200 most-common ingredients in `canonical_foods.yaml`.
+
+### Phase 2 — Seed corpus (P0/P1)
+- [ ] W7 grows to 2,000 entries across at least three curation
+      batches; every batch PR carries lint + reviewer sign-off.
+- [ ] W9 audit CLI runs in CI; coverage metric tracked in
+      `ingredient_kb/coverage.json`.
+- [ ] Holdout corpus coverage ≥95%, low-confidence rate ≤3%.
+
+### Phase 3 — Tooling and freeze (P1/P2)
+- [ ] W10 `add` CLI used for at least the last 500 entries.
+- [ ] W11 citation pass complete.
+- [ ] W13 benchmark baselined.
+- [ ] `KB_VERSION = "1.0.0"` frozen in `version.py`; CHANGELOG entry.
+
+### Rollback
+- Library is unused at v1.0.0 ship. Any issue is fixed with a
+  patch PR; no runtime rollback needed.
+
+---
+
+## 6. Verification
+
+### 6.1 Parser fixture tests
+
+`tests/corpora/fixtures.yaml` holds labeled lines:
+
+```yaml
+- raw: "1 tbsp olive oil"
+  qty: 1.0
+  unit: tbsp
+  canonical_id: olive_oil
+  confidence: 1.0
+- raw: "a handful of cashews"
+  qty: null
+  unit: null
+  canonical_id: cashew
+  confidence: 1.0
+  reasons: ["unparsed_qty"]
+- raw: "400g boneless chicken thighs, diced"
+  qty: 400
+  unit: g
+  canonical_id: chicken_thigh_raw
+  modifiers: ["boneless", "diced"]
+- raw: "mysterious_greens"
+  canonical_id: null
+  confidence: 0.0
+  reasons: ["unknown"]
+```
+
+At least 200 labeled lines across: common, ambiguous, non-English,
+multi-item ("salt and pepper" → reject as multi), qty-less, and
+adversarial inputs (empty string, punctuation only, very long
+strings). Every parser PR adds labeled fixtures for any line it
+changes behavior on.
+
+### 6.2 Coverage audit
+
+- `audit` CLI runs against a checked-in **holdout corpus**
+  (`tests/corpora/holdout.txt`, 500 lines from production,
+  anonymized).
+- CI threshold: **coverage ≥95%**, **low-confidence rate ≤3%**.
+- Regressions fail CI. Adding to `canonical_foods.yaml` is the fix.
+
+### 6.3 Taxonomy invariants
+
+- `test_taxonomy_stability.py` — enum values do not change string
+  representation across minor/patch version bumps unless
+  `KB_VERSION` major bumps.
+- `test_canonical_foods_lint.py` — every row passes §4.3 lint;
+  every allergen-tagged row has a citation.
+- `test_alias_uniqueness.py` — no alias resolves to two different
+  `canonical_id`s.
+- `test_reindex_stable.py` — `reindex` output byte-equal to
+  checked-in `aliases.yaml`; CI fails if they diverge.
+
+### 6.4 Unit-system tests
+
+- Round-trip: known density + known volume → correct grams to
+  0.1 g.
+- Missing density → `None` with a structured reason (no silent
+  fallback).
+- Count-unit items: `juice of 1 lemon` resolves to a known gram mass.
+
+### 6.5 Property tests (`hypothesis`)
+
+- For all `ParsedIngredient` with `canonical_id` set and
+  `confidence >= 0.85`, looking up the canonical food returns a
+  record with `id` equal to `parsed.canonical_id`.
+- Normalization is idempotent: `normalize(normalize(s)) == normalize(s)`.
+- Unit conversion is monotonic within the same unit family.
+
+### 6.6 Benchmarks
+
+- `parse_ingredient` p99 ≤ 2 ms on CI reference runner.
+- Alias index memory ≤ 10 MB resident.
+
+### 6.7 Review gates
+
+- Clinical reviewer sign-off on allergen-tag citations for the 300
+  allergen-bearing seed rows.
+- Second-engineer review on `taxonomy.py` (enum stability is
+  load-bearing).
+- Owner for `ingredient_kb/` named in CODEOWNERS; future PRs route
+  there automatically.
+
+### 6.8 Cutover criteria (freeze v1.0.0)
+
+- All tests green, coverage ≥95%, low-confidence ≤3%,
+  benchmarks within budget.
+- Reviewer sign-offs on §6.7 recorded.
+- No open P0 or P1 issues.
+- CHANGELOG entry with "v1.0.0 — initial release, 2,000 ingredients,
+  FDA Big-9 + EU-14 allergen coverage".
+
+---
+
+## 7. Open Questions
+
+- **Branded foods.** v1 is generic only. When SPEC-006/SPEC-007
+  land, we will see cases like "store-brand peanut-free granola"
+  that deserve a branded-foods extension; separate follow-up spec.
+- **Non-English aliases.** Seeded for the most common non-English
+  surface forms; long tail is open. Coverage metric tracked by
+  language in the audit CLI so we can prioritize.
+- **`count_onion` vs. `onion_medium` vs. `onion`.** We pick a
+  per-size-class approach (`onion_medium`, `onion_large`) with an
+  `onion` parent id that resolves to `onion_medium` when size is
+  unspecified. Documented in the KB style guide.
+- **Whether to ship a pre-built alias index binary** for faster
+  import. Probably not — YAML import is fast enough and keeps the
+  build simple. Revisit if p99 import time becomes a cold-start
+  concern.

--- a/system_design/specs/SPEC-006-nutrition-profile-restriction-normalization.md
+++ b/system_design/specs/SPEC-006-nutrition-profile-restriction-normalization.md
@@ -1,0 +1,519 @@
+# SPEC-006: Profile-side restriction normalization
+
+| Field       | Value                                                    |
+|-------------|----------------------------------------------------------|
+| **Status**  | Proposed                                                 |
+| **Author**  | Nutrition & Meal Planning team                           |
+| **Created** | 2026-04-17                                               |
+| **Priority**| P0 (blocks SPEC-007 enforcement; unblocks ADR-005 substitutions) |
+| **Scope**   | `backend/agents/nutrition_meal_planning_team/models.py`, `agents/intake_profile_agent/`, `orchestrator/`, `shared/client_profile_store`, `postgres/`, `user-interface/` profile restriction screens |
+| **Depends on** | SPEC-002 (profile schema), SPEC-005 (taxonomy enums, alias index) |
+| **Implements** | ADR-002 §2 (profile-side normalization) |
+
+---
+
+## 1. Problem Statement
+
+SPEC-005 gives us the closed `AllergenTag` and `DietaryTag` enums.
+The profile has the corresponding user-entered free text:
+
+- `ClientProfile.allergies_and_intolerances: List[str]` — strings
+  like `"nuts"`, `"shellfish"`, `"gluten"`, `"no cashews"`.
+- `ClientProfile.dietary_needs: List[str]` — strings like
+  `"vegetarian"`, `"vegan"`, `"keto"`, `"low-sodium"`, `"pescatarian
+  except anchovies"`.
+
+These strings flow into LLM prompts today and are never resolved to
+anything a downstream filter can reason about. SPEC-007's guardrail
+cannot enforce what it cannot identify.
+
+This spec resolves those strings into structured, canonical tag sets
+at profile save time, surfaces ambiguity to the user through an
+explicit resolution flow, and keeps the unresolved remainder
+available so it still reaches the LLM as caveat text.
+
+It does **not** reject meals, modify the meal-planning prompt, or
+change agent behavior beyond the intake step. That is SPEC-007.
+
+---
+
+## 2. Current State
+
+### 2.1 Today's flow
+
+```mermaid
+flowchart LR
+    UI[Intake UI] -->|free-text lists| PUT["PUT /profile/{id}"]
+    PUT -->|ProfileUpdateRequest| INTAKE[IntakeProfileAgent]
+    INTAKE --> STORE[(nutrition_profiles)]
+    STORE -->|raw strings| PLAN[meal_planning_agent prompt]
+    PLAN -->|"respect allergies"| LLM
+```
+
+- `allergies_and_intolerances` and `dietary_needs` are persisted as
+  raw strings.
+- `meal_planning_agent` prompt includes them verbatim:
+  `"respect allergies and dietary needs"`.
+- No check that `"nuts"` is expanded to `{peanut, tree_nut}`; no
+  check that `"vegan"` implies `{animal, dairy, egg, honey,
+  gelatin}` is forbidden; no check that `"no cashews"` is a subset
+  of `tree_nut` enforcement.
+
+### 2.2 Gaps
+
+1. Enforcement consumers have nothing structured to enforce against.
+2. Ambiguous user input ("nuts" → peanut only? or tree nut only? or
+   both?) is resolved silently by the LLM's interpretation, which
+   means it is not resolved at all.
+3. There is no place to store *resolved* tags alongside raw input,
+   so we cannot audit what the system believed.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- On profile write, resolve `allergies_and_intolerances` and
+  `dietary_needs` to canonical tag sets using SPEC-005's taxonomy
+  and alias index.
+- Persist both raw strings and resolved tags, plus an `unresolved`
+  remainder and an `ambiguous` list that the UI surfaces for user
+  confirmation.
+- Expand shorthand dietary tags deterministically (`vegan`,
+  `vegetarian`, `pescatarian`, `keto`, `halal`, `kosher`) into their
+  forbid/require tag sets.
+- Provide a dedicated resolution UI: every ambiguity becomes a
+  deterministic user choice, not a silent interpretation.
+- Emit observability metrics so coverage gaps in the KB become
+  visible and actionable.
+- Zero behavior change on the meal side in this spec — SPEC-007 is
+  the enforcement step.
+
+### 3.2 Non-goals
+
+- **No enforcement.** `MealPlanResponse` is not filtered here. That
+  is SPEC-007.
+- **No LLM prompt changes.** The meal-planning prompt continues to
+  receive the raw strings for v1 of this spec; SPEC-007 replaces
+  them with structured constraints.
+- **No KB edits.** If the alias index cannot resolve a phrase, the
+  fix is a SPEC-005 KB addition, not a patch here.
+- **No cross-team sharing.** Resolved tags live on the nutrition
+  profile only. Sharing with other teams is a separate spec when a
+  caller appears.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 Model additions (`models.py`)
+
+Additive; existing fields unchanged.
+
+```python
+from nutrition_meal_planning_team.ingredient_kb.taxonomy import (
+    AllergenTag, DietaryTag,
+)
+
+class ResolvedRestriction(BaseModel):
+    raw: str                              # "nuts", "gluten-free", "vegan"
+    allergen_tags: Set[AllergenTag] = set()
+    dietary_tags_forbid: Set[DietaryTag] = set()
+    dietary_tags_require: Set[DietaryTag] = set()
+    matched_canonical_ids: List[str] = [] # specific foods ("cashew"), if applicable
+    confidence: float = 1.0               # 1.0 exact, <1.0 fuzzy or shorthand
+    source: str = "user"                  # "user" | "shorthand" | "clinician"
+
+class RestrictionResolution(BaseModel):
+    resolved: List[ResolvedRestriction] = []
+    ambiguous: List[AmbiguousRestriction] = []
+    unresolved: List[str] = []
+    kb_version: str = ""                  # SPEC-005 KB_VERSION at resolve time
+    resolved_at: Optional[str] = None
+
+class AmbiguousRestriction(BaseModel):
+    raw: str
+    candidates: List[ResolvedRestriction] # >1; user picks one
+    question: str                         # human-readable disambiguation prompt
+
+class ClientProfile(BaseModel):
+    # existing fields unchanged
+    restriction_resolution: RestrictionResolution = Field(
+        default_factory=RestrictionResolution
+    )
+```
+
+Raw `allergies_and_intolerances` and `dietary_needs` are preserved
+on the profile — the resolver is additive, never destructive. The
+user's original words remain visible in the UI.
+
+### 4.2 Resolver module
+
+New module
+`backend/agents/nutrition_meal_planning_team/restriction_resolver/`:
+
+```
+restriction_resolver/
+├── __init__.py                 # resolve_restrictions
+├── shorthand.py                # vegan/vegetarian/keto/etc. expansion
+├── resolver.py                 # orchestration
+├── data/
+│   └── shorthand.yaml          # closed shorthand → tag-set map
+└── tests/
+```
+
+Public interface:
+
+```python
+def resolve_restrictions(
+    allergies: List[str],
+    dietary_needs: List[str],
+) -> RestrictionResolution: ...
+```
+
+- Pure function; no I/O, no LLM.
+- Uses `ingredient_kb.alias_index` for specific-ingredient
+  resolution (`"cashew"` → `canonical_id=cashew` →
+  `allergen_tags={tree_nut}`).
+- Uses `shorthand.yaml` for high-level dietary labels:
+  ```yaml
+  vegan:
+    forbid: [animal, dairy, egg, honey, gelatin]
+  vegetarian:
+    forbid: [animal]
+    allow_exceptions: [dairy, egg]
+  pescatarian:
+    forbid: [animal]
+    allow_exceptions: [dairy, egg, fish, shellfish]
+  keto:
+    soft_constraint: "low_carb"       # advisory; no forbid
+  low_sodium:
+    interaction_flag: sodium_very_high
+  halal:
+    forbid: [alcohol]
+    additional_raw_note: "requires halal-certified meat"
+  kosher:
+    forbid: []
+    additional_raw_note: "requires kosher preparation"
+  gluten_free:
+    forbid: [gluten]
+  ```
+- Shorthand table is closed; additions require the team lead's
+  review and a KB version note in `restriction_resolver/CHANGELOG.md`.
+- Ambiguity is deterministic. "Nuts" is ambiguous (peanut vs tree
+  nut — they are legally distinct allergens and clinically
+  different); the resolver emits an `AmbiguousRestriction` with
+  `candidates=[{peanut}, {tree_nut}, {peanut, tree_nut}]` and a
+  clear question.
+
+### 4.3 Resolution rules
+
+Closed set of rules, applied in order:
+
+1. **Exact alias match** (from SPEC-005 alias index): resolves to a
+   specific canonical food and its tags. `confidence = 1.0`.
+2. **Shorthand hit**: from `shorthand.yaml`. `confidence = 1.0`,
+   `source = "shorthand"`.
+3. **Allergen-category name**: phrases like "tree nuts", "shellfish",
+   "gluten" match directly to an `AllergenTag`. `confidence = 1.0`.
+4. **Negation patterns** (`"no X"`, `"avoid X"`, `"X-free"`): same
+   resolution as X, with the negation recorded in the raw string.
+5. **Fuzzy match** via alias index (≥0.85): `confidence = score`,
+   still a candidate.
+6. **Otherwise**: unresolved. Raw string lands in
+   `unresolved[]`; surfaced in UI as "we couldn't map this; tell us
+   what to do."
+
+Ambiguity is declared when:
+
+- Input matches two or more top-level allergen categories (e.g.,
+  "nuts" → peanut or tree nut), or
+- A shorthand has multiple common interpretations (e.g., "low-carb"
+  could be `keto` or a soft constraint), or
+- Fuzzy match returns multiple candidates within 0.05 of the top
+  score.
+
+### 4.4 Intake integration
+
+`IntakeProfileAgent.run` (`agents/intake_profile_agent/agent.py`):
+
+- After LLM merge (or structural fallback), call
+  `resolve_restrictions(profile.allergies_and_intolerances,
+  profile.dietary_needs)`.
+- Attach the resulting `RestrictionResolution` to the profile before
+  save.
+- `resolved_at` and `kb_version` recorded on every write.
+
+Re-resolution triggers:
+
+- Any write to `allergies_and_intolerances` or `dietary_needs`.
+- Background re-resolution when `KB_VERSION` bumps (job scans
+  profiles where `restriction_resolution.kb_version` < current,
+  re-runs resolver, surfaces any newly ambiguous items to the user
+  on next login). Rate-limited; the background job is additive only
+  (never removes previously-confirmed tags).
+
+### 4.5 API surface
+
+Additive endpoints:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/profile/{client_id}/restrictions` | Returns `RestrictionResolution` — raw inputs, resolved tags, ambiguities, unresolved |
+| `POST` | `/profile/{client_id}/restrictions/resolve-ambiguous` | Body: `{raw: str, chosen_candidate: ResolvedRestriction}`. User answers an ambiguity |
+| `POST` | `/profile/{client_id}/restrictions/reresolve` | Forces a re-run against current `KB_VERSION`. Rate-limited |
+
+The existing `PUT /profile/{client_id}` and SPEC-002's `PATCH
+/profile/{client_id}/clinical` both trigger resolver passes on
+write. No new fields in their request bodies — the resolver reads
+what's already there.
+
+### 4.6 UI — ambiguity resolution
+
+Progressive: if all restrictions resolve cleanly, no UI change. If
+any item is ambiguous, the restrictions page shows a card per
+ambiguity:
+
+```
+You entered: "nuts"
+We're not sure what to block. Pick one:
+  [ ] Peanuts only
+  [ ] Tree nuts only (almond, cashew, walnut, …)
+  [X] Both peanuts and tree nuts   ← default highlighted when severity warrants
+```
+
+Rules:
+
+- Default selection is the **strictest** option (both). The user
+  must actively narrow rather than actively broaden. This is the
+  safer default for a safety feature.
+- After one user confirmation, the choice persists on the profile
+  — we never re-ask for the same raw string.
+- Unresolved items ("exotic-greens-i-can-t-have") show a free-text
+  "tell us what to avoid" field with autocomplete against the KB;
+  if still nothing resolves, it is kept as a raw note surfaced to
+  the LLM (pre-SPEC-007 behavior, unchanged).
+
+Dedicated screen in `user-interface/src/app/components/` (existing
+restrictions UI extended):
+
+```mermaid
+flowchart LR
+    Enter[User enters<br/>allergies + diets] --> Resolve[Backend resolves]
+    Resolve -->|all resolved| Show[Show resolved tag chips]
+    Resolve -->|ambiguous| Ask["Show ambiguity cards<br/>one at a time"]
+    Ask --> Confirm[User confirms]
+    Confirm --> Persist[Persist to profile]
+    Resolve -->|unresolved| Note[Show as "noted for guidance"<br/>with KB-add nudge]
+```
+
+### 4.7 Resolved-tag chips view
+
+Everywhere restrictions are shown (profile page, meal-plan request
+confirmation), render **resolved chips**:
+
+```
+Your restrictions:
+  [Tree nuts]  [Peanuts]  [Dairy (from "vegan")]  [Animal (from "vegan")]  ...
+  + 2 noted for guidance:  ["grandma's weird thing"]  ["the cilantro thing"]
+  Last reviewed: KB v1.2.0 on 2026-04-15  [re-review]
+```
+
+This is the single biggest trust win of this spec — the user sees
+what the system believes about them.
+
+### 4.8 Postgres
+
+Resolution is persisted in `nutrition_profiles` as a JSONB column
+alongside the existing profile JSON. Migration
+`004_restriction_resolution.sql`:
+
+```sql
+ALTER TABLE nutrition_profiles
+    ADD COLUMN restriction_resolution JSONB NOT NULL DEFAULT '{}'::jsonb,
+    ADD COLUMN restriction_resolver_kb_version TEXT;
+
+CREATE INDEX ON nutrition_profiles (restriction_resolver_kb_version);
+```
+
+Index supports the background re-resolution job in §4.4.
+
+### 4.9 Observability
+
+OTel counters:
+
+- `nutrition.restriction.resolve{outcome}` where outcome ∈
+  `resolved | ambiguous | unresolved`.
+- `nutrition.restriction.shorthand_used{name}`.
+- `nutrition.restriction.unresolved_top_terms` — top-K of
+  unresolved raw strings, captured hourly (anonymized). This is the
+  SPEC-005 KB prioritization signal.
+- `nutrition.restriction.ambiguity_resolution_latency` — time from
+  "ambiguity shown to user" to "user resolved it".
+
+A dashboard panel shows the unresolved-terms top-K. This is how
+SPEC-005 knows what to add next.
+
+### 4.10 Privacy
+
+- Resolved tags are derived from user input; retention follows the
+  profile.
+- Unresolved raw strings are PII-adjacent; they may mention
+  conditions or preferences. Do not log at INFO or above; only
+  tag-level counters are emitted.
+- Aggregation for the "top unresolved" panel uses a count-min
+  sketch or similar that does not retain individual strings past
+  the rollup window.
+
+### 4.11 Priority-grouped work items
+
+| # | Item | Priority |
+|---|------|----------|
+| W1 | `restriction_resolver/` module + `resolve_restrictions` + unit tests | P0 |
+| W2 | `shorthand.yaml` v1 with reviewer sign-off | P0 |
+| W3 | `ResolvedRestriction`, `AmbiguousRestriction`, `RestrictionResolution` in `models.py` | P0 |
+| W4 | Intake agent integration + structural fallback parity | P0 |
+| W5 | Migration `004_restriction_resolution.sql` + schema registration | P0 |
+| W6 | API endpoints (§4.5) + store helpers | P1 |
+| W7 | UI: ambiguity cards + default-strict selection | FE | P1 |
+| W8 | UI: resolved-chips view on profile + meal-plan pages | FE | P1 |
+| W9 | Background re-resolution job on `KB_VERSION` bump | P2 |
+| W10 | Observability counters + unresolved top-K panel | P1 |
+| W11 | Docs for adding to `shorthand.yaml` | P2 |
+
+---
+
+## 5. Rollout Plan
+
+Feature flag `NUTRITION_RESTRICTION_RESOLVER` (off → existing
+behavior, on → resolver runs on writes). Flag lives in unified
+config.
+
+### Phase 0 — Foundation (P0)
+- [ ] SPEC-005 frozen at `KB_VERSION=1.0.0`.
+- [ ] W1–W3, W5 landed. Migration applied in staging. No behavior
+      change (flag off).
+
+### Phase 1 — Resolver behind flag (P0)
+- [ ] W4 intake integration flag-gated.
+- [ ] W6 API endpoints live, flag-gated.
+- [ ] Unit and integration tests green.
+
+### Phase 2 — UI + dogfood (P1)
+- [ ] W7–W8 shipped.
+- [ ] Flag on for internal team profiles.
+- [ ] Measure: what fraction of internal profiles have at least one
+      ambiguity? What fraction have unresolved items?
+
+### Phase 3 — Ramp (P1/P2)
+- [ ] W10 observability in production.
+- [ ] 10% → 50% → 100% ramp over two weeks.
+- [ ] Top-K unresolved-terms dashboard watched daily; each term
+      that crosses a frequency threshold triggers a SPEC-005 KB
+      addition.
+
+### Phase 4 — Cleanup (P2)
+- [ ] W9 background re-resolver live.
+- [ ] W11 docs shipped.
+- [ ] Flag default on; flag-removal ticket filed.
+
+### Rollback
+- Flag off → resolver skipped; raw fields flow to the LLM as today.
+- Migration is additive; no rollback needed.
+- Existing `restriction_resolution` rows become inert when flag is off.
+
+---
+
+## 6. Verification
+
+### 6.1 Unit tests
+
+- `test_resolver_exact.py` — exact alias hits resolve to the
+  expected tags; `confidence=1.0`.
+- `test_resolver_shorthand.py` — every row of `shorthand.yaml`
+  produces the expected `forbid`/`require` sets.
+- `test_resolver_ambiguity.py` — inputs like `"nuts"`, `"low-carb"`,
+  `"seafood"` produce `AmbiguousRestriction` with ≥2 candidates and
+  a non-empty `question`.
+- `test_resolver_negation.py` — `"no X"`, `"X-free"`, `"avoid X"`
+  resolve identically to `"X"` with the negation preserved in raw.
+- `test_resolver_unresolved.py` — junk input lands in
+  `unresolved[]` without throwing.
+
+### 6.2 Integration tests
+
+- `test_intake_resolves_on_write.py` — `PUT /profile/{id}` with
+  allergies/diet strings populates `restriction_resolution`.
+- `test_ambiguity_resolution_flow.py` — ambiguous input →
+  `POST /restrictions/resolve-ambiguous` → persists chosen
+  candidate; subsequent reads do not re-ask.
+- `test_default_strict_on_unanswered.py` — ambiguous input that the
+  user has not yet resolved: **the profile exposes the strictest
+  candidate's tags as the active enforcement set** so SPEC-007 can
+  fail closed even before the user confirms.
+- `test_background_reresolve.py` — bumping `KB_VERSION` and running
+  the job: additive-only behavior; previously-confirmed choices
+  preserved; newly ambiguous items queued for the user.
+
+### 6.3 Taxonomy parity tests
+
+- `test_shorthand_against_taxonomy.py` — every tag referenced in
+  `shorthand.yaml` exists in the SPEC-005 enums. CI fails on drift.
+
+### 6.4 UI tests
+
+- Ambiguity card: "both" option is default-selected for allergen
+  ambiguities; snapshot test.
+- Resolved-chips view renders every tag in
+  `restriction_resolution.resolved` and groups chips by their
+  `raw` source ("from 'vegan'").
+
+### 6.5 Observability
+
+- Counters emitted match §4.9.
+- Unresolved top-K dashboard populated in staging and reviewed in
+  Phase 2 dogfood.
+
+### 6.6 Privacy
+
+- Log-redaction grep: zero instances of user-entered raw restriction
+  strings at INFO or above in production logs during Phase 3.
+
+### 6.7 Cutover criteria
+
+- All P0/P1 tests green.
+- Phase 3 ramp completed with:
+  - Ambiguity-resolution completion rate ≥80% within 7 days of
+    first prompt (users respond to the prompt, not just dismiss it).
+  - Unresolved rate on new profiles ≤5% (most strings resolve
+    cleanly; unresolved ones trigger SPEC-005 KB additions within
+    the week).
+  - Zero correctness incidents (a confirmed case where the resolved
+    tags disagree with what the user actually intended, after UX
+    polish).
+- Reviewer sign-off on `shorthand.yaml`.
+
+---
+
+## 7. Open Questions
+
+- **Halal and kosher enforcement.** v1 records the dietary intent
+  as a note; actual certification of meat/preparation is outside our
+  ingredient KB. Do we add a `certification_required` soft flag for
+  SPEC-007 to surface a caution? Probably yes; tracked under
+  SPEC-007's scope, not here.
+- **"Low-sodium" and "low-carb" as soft constraints.** These do not
+  map to forbid tags; they map to ADR-001 clinical clamps or
+  nutrient-rollup tolerances (ADR-003). The resolver records the
+  intent; SPEC-007 decides whether it enforces per-ingredient
+  (sodium_very_high) or defers to ADR-003 per-meal caps.
+- **Default-strict for ambiguous allergens** is a policy choice. We
+  default to strict in §4.6 and §6.2. A user who is casual about
+  allergy boundaries will find this annoying; a user who is serious
+  will find it correct. The safer default loses some UX polish to
+  gain clinical defensibility. Revisit after Phase 3 ramp metrics.
+- **Clinician-authored restrictions.** A dietitian or doctor should
+  be able to write a restriction that the user cannot override
+  through the resolver UI. SPEC-002's `clinician_overrides` is the
+  right home; we track the feature as a SPEC-006.1 extension.

--- a/system_design/specs/SPEC-007-nutrition-guardrail-pipeline.md
+++ b/system_design/specs/SPEC-007-nutrition-guardrail-pipeline.md
@@ -1,0 +1,671 @@
+# SPEC-007: Meal recommendation guardrail — enforcement, targeted regeneration, and user-visible filtering
+
+| Field       | Value                                                    |
+|-------------|----------------------------------------------------------|
+| **Status**  | Proposed                                                 |
+| **Author**  | Nutrition & Meal Planning team                           |
+| **Created** | 2026-04-17                                               |
+| **Priority**| P0 (capstone for ADR-002; unblocks ADR-005 substitutions; safety-critical) |
+| **Scope**   | `backend/agents/nutrition_meal_planning_team/guardrail/` (new), `orchestrator/`, `agents/meal_planning_agent/`, `shared/meal_feedback_store`, `models.py` (additive), `user-interface/` meal-plan display |
+| **Depends on** | SPEC-005 (ingredient KB + parser), SPEC-006 (resolved restrictions on profile) |
+| **Implements** | ADR-002 §3 (guardrail pipeline), §4 (orchestrator integration), §5 (observability), §6 (versioning) |
+
+---
+
+## 1. Problem Statement
+
+SPEC-005 gives us canonical ingredients with allergen, dietary, and
+interaction tags. SPEC-006 gives every profile a resolved tag set
+describing what is forbidden, flagged, or required. This spec is the
+enforcement step: no meal recommendation reaches a user until a
+deterministic check proves the recipe's ingredients are legal for
+that profile.
+
+Today, "respect allergies" is a line in a prompt. After this spec, it
+is a property of the code path. Meal suggestions are parsed against
+SPEC-005's KB, checked against SPEC-006's resolved restrictions, and
+either (a) emitted unchanged, (b) regenerated under a targeted
+constraint, or (c) dropped with a visible, structured reason.
+
+This is the single highest-stakes change in the nutrition roadmap —
+a missed allergen can cause anaphylaxis. We treat it accordingly:
+deterministic logic, fail-closed defaults, exhaustive tests, explicit
+observability, and user-visible enforcement so trust is earned, not
+assumed.
+
+---
+
+## 2. Current State
+
+### 2.1 Today's flow
+
+```mermaid
+sequenceDiagram
+    participant API
+    participant Orch as Orchestrator
+    participant MPA as meal_planning_agent
+    participant LLM
+    participant Store as meal_feedback_store
+
+    API->>Orch: POST /plan/meals
+    Orch->>MPA: run(profile, plan, history, ...)
+    MPA->>LLM: prompt includes "respect allergies"
+    LLM-->>MPA: suggestions (free-text ingredients)
+    MPA-->>Orch: List[MealRecommendation]
+    Orch->>Store: _record_suggestions (writes every suggestion as-is)
+    Orch-->>API: MealPlanResponse
+```
+
+Relevant code:
+
+- Agent prompt: [agents/meal_planning_agent/agent.py:21-33](backend/agents/nutrition_meal_planning_team/agents/meal_planning_agent/agent.py:21)
+- `_record_suggestions`: [orchestrator/agent.py:171-179](backend/agents/nutrition_meal_planning_team/orchestrator/agent.py:171)
+- No parse, no check, no filter.
+
+### 2.2 Gaps
+
+1. Enforcement is probabilistic (prompt-adherence dependent).
+2. No regeneration on violation — a rejected suggestion silently
+   ships.
+3. No visible filtering — users cannot see what was blocked and
+   therefore cannot trust that anything was.
+4. No `guardrail_version` stamped on recorded recommendations —
+   policy changes cannot cause re-evaluation.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- Deterministic post-generation guardrail: no
+  `MealRecommendationWithId` is persisted or returned unless it has
+  passed `check_recommendation`.
+- Fail closed on unresolved ingredients — if we cannot tell what a
+  food is, we do not serve it.
+- Targeted regeneration: on rejection, issue a single-suggestion LLM
+  call with the specific violation spelled out, capped retries.
+  Dropped suggestions are surfaced to the user with structured
+  reasons.
+- Stamp every persisted recommendation with `guardrail_version` and
+  a snapshot of the restriction set used, so re-evaluation after
+  policy bumps is possible.
+- Emit metrics sufficient to audit safety and to prioritize KB
+  additions.
+- Keep performance acceptable: the synchronous path should add
+  ≤ 100 ms typical and ≤ 2 s worst case in absence of regeneration;
+  regenerations run concurrently across independent rejected
+  suggestions.
+
+### 3.2 Non-goals
+
+- **No nutrient-level checks.** Sodium-per-meal caps and other
+  quantitative per-meal/per-day constraints are ADR-003
+  (nutrient-rollup spec). The interaction between per-ingredient
+  sodium-very-high tags and per-meal sodium caps is explicitly
+  noted in §4.4 but fully enforced only when ADR-003 lands.
+- **No learning signal changes.** ADR-004 consumes guardrail
+  rejection logs to improve KB priorities and planner prompts, but
+  the structured learning loop is a separate spec.
+- **No substitution endpoint.** ADR-005's
+  `/recipes/{id}/substitute` reuses this guardrail verbatim but is
+  specified separately.
+- **No clinical drug-interaction medical claims.** v1 flags
+  curated, documented interactions between a closed medication
+  class and a closed set of `InteractionTag`s. It is not a
+  substitute for clinical review. The UI copy says so.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 New flow
+
+```mermaid
+sequenceDiagram
+    participant API
+    participant Orch as Orchestrator
+    participant MPA as meal_planning_agent
+    participant GR as guardrail
+    participant LLM
+    participant Store
+
+    API->>Orch: POST /plan/meals
+    Orch->>MPA: run(profile, plan, history, ...)
+    MPA->>LLM: prompt (SPEC-007 includes structured restrictions)
+    LLM-->>MPA: suggestions
+    MPA-->>Orch: List[MealRecommendation]
+    loop for each suggestion
+        Orch->>GR: check_recommendation(profile, rec)
+        alt passed
+            Orch->>Store: record (with guardrail_version)
+        else rejected
+            Orch->>MPA: regenerate_single(violation)
+            MPA->>LLM: single-suggestion prompt (constraint explicit)
+            LLM-->>MPA: replacement suggestion
+            Orch->>GR: check_recommendation(profile, replacement)
+            alt passed
+                Orch->>Store: record
+            else still failing after N retries
+                Note over Orch: drop with structured reason
+            end
+        end
+    end
+    Orch-->>API: MealPlanResponse { suggestions, dropped, flags }
+```
+
+### 4.2 Module layout
+
+```
+backend/agents/nutrition_meal_planning_team/guardrail/
+├── __init__.py               # check_recommendation, GUARDRAIL_VERSION
+├── version.py                # GUARDRAIL_VERSION = "1.0.0"
+├── checker.py                # check_recommendation
+├── violations.py             # Violation, Flag dataclasses + reason enums
+├── interactions.py           # loader for interactions.yaml + med-class mapping
+├── regeneration.py           # build_regen_prompt
+├── data/
+│   └── interactions.yaml     # medication_class → forbidden InteractionTags
+├── errors.py
+└── tests/
+```
+
+### 4.3 Public interface
+
+```python
+@dataclass(frozen=True)
+class Violation:
+    reason: ViolationReason
+    ingredient_raw: str
+    canonical_id: Optional[str]
+    tag: Optional[str]           # e.g. "tree_nut", "gluten"
+    detail: str                  # human-readable
+    severity: Severity           # hard_reject | flag
+
+class ViolationReason(StrEnum):
+    allergen = "allergen"
+    dietary_forbid = "dietary_forbid"
+    unresolved_ingredient = "unresolved_ingredient"
+    interaction_hard = "interaction_hard"
+    interaction_flag = "interaction_flag"
+
+@dataclass(frozen=True)
+class GuardrailResult:
+    passed: bool
+    violations: tuple[Violation, ...]   # reason-severity hard_reject
+    flags: tuple[Violation, ...]        # reason-severity flag; non-blocking
+    parsed_ingredients: tuple[ParsedIngredient, ...]  # for reuse by ADR-003
+
+def check_recommendation(
+    profile: ClientProfile,
+    rec: MealRecommendation,
+) -> GuardrailResult: ...
+```
+
+Contract:
+
+- **Deterministic.** Same `(profile, rec)` → same result, byte-for-byte.
+- **Pure.** No I/O, no LLM.
+- **Fail closed.** Any unresolved ingredient above a confidence
+  threshold → `ViolationReason.unresolved_ingredient` with
+  `severity.hard_reject`.
+
+### 4.4 Check pipeline
+
+Executed in order; any `hard_reject` violation short-circuits
+further hard-reject checks but flags still accumulate:
+
+1. **Parse** each ingredient via `ingredient_kb.parse_ingredient`.
+2. **Allergen check** — for each parsed ingredient, intersect the
+   canonical food's `allergen_tags` with
+   `profile.restriction_resolution` active allergen tags (strictest
+   candidate if ambiguity is unresolved — SPEC-006 §6.2).
+3. **Dietary check** — intersect `dietary_tags` with the profile's
+   `dietary_tags_forbid` set.
+4. **Interaction check** — for each `medications[]` tag, load
+   forbidden `InteractionTag`s from `interactions.yaml`:
+   ```yaml
+   warfarin:
+     hard:  []                  # v1: no hard reject, only flags
+     flag:  [vitamin_k_high]
+     note:  "Coordinate vitamin K intake with INR monitoring."
+   maoi:
+     hard:  [tyramine_high]     # tyramine reactions are acute
+     flag:  []
+     note:  "Aged cheeses, cured meats, fermented foods excluded."
+   acei_arb:
+     hard:  []
+     flag:  [potassium_high]
+   statin:
+     hard:  []
+     flag:  [grapefruit]
+   ssri:
+     hard:  []
+     flag:  [st_johns_wort]
+   glp1:
+     hard:  []
+     flag:  [very_high_fat]
+   ```
+   Policy: default to `flag` (advisory) unless the interaction is
+   both acute and well-documented (MAOI × tyramine). `hard` requires
+   team-lead plus clinical reviewer sign-off per entry.
+5. **Unknown-ingredient policy** — any parsed ingredient with
+   `canonical_id=None` and `confidence<0.85` → hard reject.
+   `confidence≥0.85` + `canonical_id=None` → flag (the parser was
+   confident about structure but the alias index missed; user sees
+   a caution chip; SPEC-005 gets a signal in the unresolved top-K).
+6. **Condition-specific per-meal flags** — e.g. CKD-3: flag if a
+   recipe contains >3 `potassium_high` tags, HTN: flag if ≥2
+   `sodium_very_high` tags. Thresholds are advisory in v1; per-meal
+   quantitative caps land in ADR-003 once nutrient data is attached.
+
+`Severity.hard_reject` blocks the suggestion. `Severity.flag`
+attaches to the recommendation but does not block.
+
+### 4.5 Orchestrator integration
+
+`NutritionMealPlanningOrchestrator._record_suggestions`
+([orchestrator/agent.py:171-179](backend/agents/nutrition_meal_planning_team/orchestrator/agent.py:171)) becomes
+a two-pass pipeline:
+
+```python
+def _record_suggestions(
+    self, client_id: str, suggestions: list, profile: ClientProfile
+) -> RecordedSuggestions:
+    recorded: list[MealRecommendationWithId] = []
+    dropped: list[DroppedSuggestion] = []
+
+    checks = [check_recommendation(profile, s) for s in suggestions]
+    for original, result in zip(suggestions, checks):
+        if result.passed:
+            rec_id = self._record(client_id, original, result)
+            recorded.append(self._with_id(original, result, rec_id))
+            continue
+
+        # Targeted regeneration
+        last_violations = result.violations
+        for attempt in range(MAX_REGEN_RETRIES):
+            replacement = self.meal_planning_agent.regenerate_single(
+                profile=profile,
+                original=original,
+                violations=last_violations,
+            )
+            if replacement is None:
+                break
+            retry_result = check_recommendation(profile, replacement)
+            if retry_result.passed:
+                rec_id = self._record(client_id, replacement, retry_result)
+                recorded.append(self._with_id(replacement, retry_result, rec_id))
+                break
+            last_violations = retry_result.violations
+        else:
+            dropped.append(
+                DroppedSuggestion(
+                    name=original.name,
+                    reasons=[v.reason for v in last_violations],
+                    detail=[v.detail for v in last_violations],
+                )
+            )
+
+    return RecordedSuggestions(recorded=recorded, dropped=dropped)
+```
+
+- Regenerations across different rejected suggestions run
+  concurrently (per-suggestion threads; no shared state).
+- `MAX_REGEN_RETRIES` = 2. Higher values don't help in practice
+  and burn tokens.
+- Each recorded row on `nutrition_recommendations` stores:
+  `guardrail_version`, `parsed_ingredients_json`, `flags_json`, and
+  a hash of the active restriction set (`restriction_snapshot_hash`)
+  for replay on policy bumps.
+
+### 4.6 Planner prompt changes
+
+`meal_planning_agent` prompt gains a structured constraints block
+derived from SPEC-006's `restriction_resolution`:
+
+```
+FORBIDDEN ingredients (must not appear, by any name):
+  - cashew (tree_nut), peanut (peanut), milk (dairy), ...
+FORBIDDEN categories:
+  - gluten, shellfish, animal-derived
+FLAG-ONLY (avoid when possible):
+  - vitamin_k_high (warfarin), sodium_very_high (hypertension)
+DIETARY SHORTHANDS (resolve to above):
+  - vegan, low-sodium
+```
+
+The prompt explicitly says: *"If you are unsure whether an ingredient
+violates a restriction, do not include it. We will reject it anyway."*
+This is prompt-side prevention; the guardrail is enforcement.
+
+New public method `meal_planning_agent.regenerate_single(profile,
+original, violations)` constructs a single-suggestion prompt that:
+
+- Restates the original recipe's slot (meal_type, suggested_date,
+  max cook time).
+- Lists every `Violation.ingredient_raw` + `tag` explicitly.
+- Requires a strict structured-output schema (single
+  `MealRecommendation`).
+
+### 4.7 API response changes
+
+`MealPlanResponse` gains:
+
+```python
+class DroppedSuggestion(BaseModel):
+    name: str
+    reasons: list[str]        # e.g. ["allergen:tree_nut"]
+    detail: list[str]         # user-facing strings
+
+class MealPlanResponse(BaseModel):
+    client_id: str
+    suggestions: List[MealRecommendationWithId]
+    dropped: List[DroppedSuggestion] = []
+    flags_by_recommendation: Dict[str, List[str]] = {}
+    guardrail_version: str = ""
+```
+
+Every `MealRecommendationWithId` gains:
+
+```python
+class MealRecommendationWithId(MealRecommendation):
+    recommendation_id: str
+    clinical_flags: List[str] = []       # from SPEC-007 flags
+    parsed_ingredients_present: bool = True
+```
+
+Additive at the field level; existing clients ignore.
+
+### 4.8 UI changes
+
+- **Filter notice** shown above the suggestions list when
+  `dropped` non-empty:
+  *"We filtered 1 suggestion that conflicted with your tree-nut
+  allergy."* Clickable to show the specific names + reasons.
+  Neutral framing, no shame, never implies the user did something
+  wrong.
+- **Flag chips** on each recommendation card:
+  *"⚠ Advisory: contains high-vitamin-K greens — coordinate with
+  INR monitoring."* Clicking opens a dialog with the full
+  `interactions.yaml` note.
+- **Medication-disclaimer banner** on the meal-plan page when any
+  `medications[]` is set: *"Recommendations are general guidance,
+  not medical advice. For medications that interact with food,
+  please work with your clinician."* Copy reviewed per ADR-006 §6.5.
+
+### 4.9 Observability
+
+OTel counters:
+
+- `guardrail.check_ran{result}` where result ∈ `passed | rejected |
+  flagged`.
+- `guardrail.rejection{reason}` per `ViolationReason`.
+- `guardrail.flag{class}` per flag class.
+- `guardrail.unknown_ingredient_rate` (rolling).
+- `guardrail.regen_attempt{outcome}` where outcome ∈ `passed |
+  retry | dropped`.
+- `guardrail.dropped_total` per plan. Steady-state should be low;
+  sustained spikes indicate prompt drift or KB gap.
+- `guardrail.ingestion_latency_ms` histogram for parse+check path.
+
+Traces: `_record_suggestions` root with child spans per
+suggestion's check + regen path. Regenerations are separate spans
+with `attempt_n` attribute.
+
+Audit log: every rejection is persisted to
+`nutrition_guardrail_rejections` with profile id (not user PII
+beyond that), ingredient, canonical_id, tag, violation reason, and
+timestamp. This is both safety audit and KB prioritization signal.
+
+### 4.10 Versioning and replay
+
+`GUARDRAIL_VERSION = "MAJOR.MINOR.PATCH"`:
+
+- **MAJOR** — severity policy change (e.g. promoting a flag to
+  hard reject), `ViolationReason` enum change. Triggers replay.
+- **MINOR** — data additions (new meds in interactions.yaml, new
+  tags). Triggers replay.
+- **PATCH** — copy/doc only.
+
+On `GUARDRAIL_VERSION` or `KB_VERSION` bump: background job scans
+`nutrition_recommendations` where stored version < current,
+re-runs `check_recommendation` against each, and surfaces newly
+rejected recommendations to the user ("we re-checked your meal plan
+with updated safety rules; 1 recommendation no longer fits your
+profile"). Replay is additive only — it never un-flags something
+previously flagged.
+
+### 4.11 Failure modes and fallback
+
+- **LLM regeneration fails or times out.** Treat as unresolved
+  retry; count toward `MAX_REGEN_RETRIES`.
+- **Parser throws.** Suggestion hard-rejected with
+  `unresolved_ingredient`; exception logged; never silently passed.
+- **`profile.restriction_resolution` missing** (legacy profiles
+  before SPEC-006 flag-on). Guardrail runs with the best-effort
+  resolution computed on the fly from raw fields using SPEC-005
+  directly, **plus** a strict-mode flag that marks the plan as
+  `restrictions_best_effort=true` so the UI prompts the user to
+  confirm. We do not trust best-effort resolution for permanent
+  enforcement.
+- **Orchestrator panic mid-pipeline.** Any exception in
+  `_record_suggestions` for a given suggestion drops that
+  suggestion with reason `internal_error` and continues. The plan
+  is not aborted by a single bad suggestion.
+
+### 4.12 Priority-grouped work items
+
+| # | Item | Priority |
+|---|------|----------|
+| W1 | `guardrail/` scaffolding, `version.py`, dataclasses, errors | P0 |
+| W2 | `checker.py` allergen + dietary + unresolved rules + tests | P0 |
+| W3 | `interactions.yaml` v1 + loader + tests; reviewer sign-off | P0 |
+| W4 | Interaction check in `checker.py` + tests | P0 |
+| W5 | `meal_planning_agent.regenerate_single` + structured-output schema | P0 |
+| W6 | Meal-planner prompt constraints block (§4.6) | P0 |
+| W7 | Orchestrator `_record_suggestions` two-pass pipeline + concurrency | P0 |
+| W8 | `MealPlanResponse` additive fields + `MealRecommendationWithId` flags | P0 |
+| W9 | Migration: extend `nutrition_recommendations` with `guardrail_version`, `parsed_ingredients_json`, `flags_json`, `restriction_snapshot_hash`; new `nutrition_guardrail_rejections` table | P0 |
+| W10 | UI: filter notice + flag chips + medication banner | FE | P1 |
+| W11 | Observability counters + rejection audit log | P1 |
+| W12 | Replay job on `GUARDRAIL_VERSION` / `KB_VERSION` bump | P2 |
+| W13 | CODEOWNERS entry for `interactions.yaml` — team lead + clinical reviewer | P1 |
+| W14 | Benchmarks: `check_recommendation` p99 ≤ 10 ms | P2 |
+
+---
+
+## 5. Rollout Plan
+
+Feature flag `NUTRITION_GUARDRAIL` (off → legacy pass-through,
+on → SPEC-007 pipeline).
+
+### Phase 0 — Foundation (P0)
+- [ ] SPEC-005 frozen at `KB_VERSION=1.0.0`.
+- [ ] SPEC-006 deployed and flag on for dogfood profiles.
+- [ ] W1, W9 landed. Migration applied in staging. No behavior change.
+
+### Phase 1 — Shadow mode (P0)
+- [ ] W2–W7 landed behind flag.
+- [ ] Shadow mode: flag-off callers run `check_recommendation` in
+      a background task and record results to
+      `nutrition_guardrail_rejections` without affecting the
+      response.
+- [ ] 2 weeks of shadow data reviewed. Metrics:
+      - Rejection rate per profile type.
+      - False-positive audit on 100 sampled rejections — are any
+        "rejected" suggestions actually safe?
+      - Unknown-ingredient rate feeding SPEC-005 KB additions.
+
+### Phase 2 — Enforce for internal (P0)
+- [ ] Flag on for internal team profiles.
+- [ ] Observe for 1 week. Success gates:
+      - Zero **false negatives** in sampled audit (a missed
+        allergen reaching a user).
+      - `guardrail.dropped_total` median ≤ 1 per 7-day plan on
+        typical profiles.
+      - Regen loop median retries ≤ 0.5 per rejected suggestion.
+
+### Phase 3 — Ramp (P0/P1)
+- [ ] W10 (UI) shipped.
+- [ ] W11 (observability) dashboards live.
+- [ ] 10% → 25% → 50% → 100% over three weeks. At each step:
+      - Monitor `guardrail.rejection{reason}` distribution.
+      - Review audit log for false negatives (any rejection that
+        should have been a flag or vice versa).
+
+### Phase 4 — Replay and cleanup (P1/P2)
+- [ ] W12 replay job live.
+- [ ] W13 CODEOWNERS committed.
+- [ ] W14 benchmarks baselined.
+- [ ] Flag default on; flag removal scheduled.
+
+### Rollback
+- Flag off → legacy `_record_suggestions`. New DB columns inert.
+- No data destruction on rollback. `nutrition_guardrail_rejections`
+  retained for audit.
+- Policy bump that causes an unexpected rejection surge can be
+  reverted by rolling back `GUARDRAIL_VERSION` in a patch release;
+  replay job picks up the new version on next run.
+
+---
+
+## 6. Verification
+
+### 6.1 Unit tests (`guardrail/tests/`)
+
+- `test_allergen_rejection.py` — every tag in
+  `AllergenTag` triggers rejection when profile has that tag active;
+  cross-matrix parametrized.
+- `test_dietary_rejection.py` — vegan + `milk` → reject; pescatarian
+  + `chicken` → reject; pescatarian + `fish` → pass.
+- `test_unresolved_fail_closed.py` — unknown ingredient with
+  `confidence<0.85` → hard reject; `confidence≥0.85` but
+  `canonical_id=None` → flag.
+- `test_interactions_maoi_tyramine.py` — aged cheese and cured
+  meats hard-rejected for MAOI profile.
+- `test_interactions_warfarin_vitamin_k.py` — kale recipe flagged,
+  not rejected.
+- `test_determinism.py` — same `(profile, rec)` → byte-equal
+  `GuardrailResult` across 100 iterations.
+
+### 6.2 Red-team tests
+
+Dedicated fixture suite `tests/red_team/` of known-hostile
+LLM-style outputs:
+
+- Peanut oil sneaked into a nut-free recipe.
+- "Worcestershire sauce" in a pescatarian-except-fish profile
+  (contains anchovy).
+- "Marzipan garnish" on a no-tree-nut profile.
+- Almond flour in a nut-free baked good.
+- "Broth" on a vegetarian profile (often animal-derived).
+- Gelatin in a "vegetarian" dessert.
+- "Dashi" on a no-fish profile.
+- "Caesar dressing" with hidden anchovy on a vegetarian profile.
+- Honey in a vegan recipe.
+
+Every red-team fixture must be caught (hard reject). CI fails if any
+fixture passes.
+
+### 6.3 Integration tests
+
+- `test_plan_meals_with_guardrail.py` — end-to-end
+  `POST /plan/meals` with a tree-nut allergic profile against a
+  recorded LLM-output fixture that includes a cashew recipe:
+  response contains zero cashew recipes; `dropped` contains the
+  expected entry; audit log row written.
+- `test_regen_loop.py` — LLM first returns a violating suggestion,
+  then returns a clean one; pipeline records the clean one;
+  `guardrail.regen_attempt{passed}` counter increments.
+- `test_regen_exhausted.py` — LLM returns violating suggestions on
+  all retries; pipeline drops the suggestion; `dropped` entry
+  correct; no exception.
+- `test_parity_chat_path.py` — chat-initiated meal generation
+  (`_handle_generate_meals`) goes through the same pipeline; audit
+  log rows identical in shape.
+- `test_legacy_profile_best_effort.py` — profile without
+  `restriction_resolution` gets best-effort resolution at call
+  time; response `restrictions_best_effort=true` flag present.
+
+### 6.4 Concurrency and performance
+
+- `test_regen_concurrency.py` — three violating suggestions trigger
+  three concurrent regen calls; wall-time ≈ single regen latency,
+  not 3×.
+- `bench_check_recommendation.py` — p99 ≤ 10 ms on CI reference
+  runner for typical 10-ingredient recipes.
+
+### 6.5 Shadow-mode metrics (Phase 1)
+
+- False-positive audit: sample 100 shadow-rejected suggestions;
+  human reviewer confirms whether each rejection was correct.
+  Target: ≥98% correctness. Below that → investigate before
+  Phase 2.
+- False-negative audit: sample 100 shadow-passed suggestions from
+  profiles with ≥2 resolved allergens; confirm none contained a
+  forbidden allergen. **Any false negative blocks rollout** until
+  root cause is identified (prompt, parser, or KB gap) and fixed.
+
+### 6.6 Observability verification
+
+- Every counter in §4.9 emits in staging and is visible on the
+  dashboard.
+- `nutrition_guardrail_rejections` table populated correctly on
+  dogfood profiles.
+- Alerting: `guardrail.dropped_total` > 3 per plan for >5% of users
+  in a rolling hour → page. Indicates prompt or KB regression.
+
+### 6.7 Copy review
+
+- Filter notice, flag chips, and medication banner reviewed against
+  the ADR-006 §6.5 copy checklist: behavior- and information-framed,
+  never shame-framed.
+- Medication banner explicitly states "general guidance, not
+  medical advice, work with your clinician" — legal review sign-off
+  recorded in the PR.
+
+### 6.8 Cutover criteria (flag on by default)
+
+- All P0 tests green; red-team fixtures all caught.
+- Phase 1 shadow audit: false-positive ≥98% correct, zero
+  confirmed false negatives.
+- Phase 2 internal enforcement: zero false negatives across 1 week
+  of internal dogfood.
+- Phase 3 ramp complete with monitoring dashboards stable; no
+  false-negative incident.
+- Clinical reviewer and team lead sign-off on promotion.
+
+---
+
+## 7. Open Questions
+
+- **Whether certain medication–food interactions should be
+  `hard` rather than `flag` in v1.** MAOI × tyramine is already
+  hard (acute reaction, well documented). Others (warfarin × high
+  vitamin K, ACEi × potassium) we keep as flags in v1 to avoid
+  punishing users eating spinach salads; this is policy, not
+  technical. The per-entry `hard`/`flag` split in
+  `interactions.yaml` is explicitly designed so we can promote
+  individually with review, no code change.
+- **How strict is "strict" for SPEC-006 ambiguity defaults?** We
+  default to the broadest candidate set at enforcement time for
+  ambiguous allergens (SPEC-006 §6.2). UX impact will surface in
+  Phase 3; if users push back, the lever is a per-profile
+  "I'll confirm later, use my stated words as-is" fallback that
+  makes `best_effort` persistent until resolved.
+- **Brand-new medication classes not in `interactions.yaml`.** v1
+  is closed-enum. Profile-level free-text medications that do not
+  map to a class flow through as an advisory note on the plan
+  ("one or more medications were not recognized; please work with
+  your clinician"). Do not fail closed on every unrecognized med —
+  that would drop every plan for any user taking something outside
+  our enum.
+- **Compatibility with the substitution endpoint (ADR-005).** Same
+  guardrail, single call path. Documented here for alignment;
+  implementation lives in ADR-005's spec.
+- **Recording `parsed_ingredients_json` on every recommendation**
+  inflates the table size. We checked: typical recipe = ~10
+  ingredients × ~200 bytes of parse metadata = ~2 KB. Acceptable;
+  ADR-003 nutrient data will dominate eventually. Compress column
+  or archive >90 days if it becomes an issue.

--- a/system_design/specs/SPEC-008-nutrition-nutrient-data-ingestion.md
+++ b/system_design/specs/SPEC-008-nutrition-nutrient-data-ingestion.md
@@ -1,0 +1,505 @@
+# SPEC-008: USDA FoodData Central ingestion and nutrient data tables
+
+| Field       | Value                                                    |
+|-------------|----------------------------------------------------------|
+| **Status**  | Proposed                                                 |
+| **Author**  | Nutrition & Meal Planning team                           |
+| **Created** | 2026-04-17                                               |
+| **Priority**| P0 (blocks SPEC-009, SPEC-010, ADR-005 grocery/substitution) |
+| **Scope**   | New module `backend/agents/nutrition_meal_planning_team/nutrient_data/`, Postgres tables (`ingredient_nutrients`, `ingredient_density`, `retention_factors`, `nutrient_sources`), scheduled refresh job, CLI tools |
+| **Depends on** | SPEC-005 (canonical ingredient ids and unit system) |
+| **Implements** | ADR-003 §1 (per-ingredient nutrient data) |
+
+---
+
+## 1. Problem Statement
+
+Every ADR-003 capability — recipe rollup, plan validation, targeted
+repair — requires one primitive we do not have: reliable
+per-ingredient nutrient data keyed by SPEC-005's canonical ids.
+
+SPEC-005 ships a catalog of ~2,000 canonical foods and a unit system.
+It does **not** carry nutrient values. `canonical_foods.yaml` has an
+`fdc_id` slot reserved for each food and nothing else. Until those
+foods are joined to actual nutrient records and converted to a
+stable per-100g representation, SPEC-009 cannot compute a single
+recipe's macros.
+
+This spec builds the ingestion pipeline, the Postgres tables it
+populates, and the refresh and audit tooling. It is pure data
+infrastructure. It does not compute rollups, validate plans, or
+change any user-visible behavior. It is what makes the next two
+specs possible.
+
+The scope discipline here matters: nutrient data is the long-tail
+item in the roadmap. Getting the ingestion path versioned,
+auditable, and refreshable now keeps SPEC-009 and SPEC-010 small.
+
+---
+
+## 2. Current State
+
+### 2.1 What we have
+
+- SPEC-005 canonical catalog with `fdc_id` populated where known,
+  null otherwise.
+- `densities.yaml` (SPEC-005) with a small seed of volume-to-mass
+  conversions for common ingredients. Hand-curated.
+- No per-ingredient nutrient data anywhere.
+
+### 2.2 Gaps
+
+1. No nutrient table keyed by canonical id.
+2. No ingestion job against any authoritative source.
+3. No versioning or audit on nutrient values — so downstream caches
+   would have no safe invalidation key.
+4. No retention-factor data (raw vs. cooked; water loss alters per-
+   serving macros by 20–40% for meats and 50%+ for leafy greens).
+5. No handling for foods we intentionally do not want from FDC
+   (composite recipes; user's own pantry entries).
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- Ship a versioned ingestion pipeline that joins SPEC-005 canonical
+  ids to USDA FDC nutrient records, producing `per_100g` values for
+  the nutrient set ADR-001 + ADR-003 require.
+- Populate `ingredient_nutrients` (nutrient data) and extend
+  `ingredient_density` (already partly in SPEC-005) in Postgres as
+  the single runtime source of truth. YAML files remain the
+  authoring layer for densities and retention factors; nutrient
+  values are sourced from FDC and not hand-edited in v1.
+- Version every row with `NUTRIENT_DATA_VERSION` and an `fdc_import_id`
+  so downstream cache invalidation is deterministic.
+- Provide a retention-factor table covering the ingredients where
+  raw-to-cooked conversion meaningfully changes per-serving macros.
+- Provide CLI tools for refresh, coverage audit, and manual
+  override of individual values when FDC data is wrong or absent.
+- Keep the runtime read path O(1) per lookup — no network calls,
+  no scans.
+
+### 3.2 Non-goals
+
+- **No rollup logic.** SPEC-009 does the arithmetic.
+- **No branded foods.** FDC Branded Foods is high-churn and
+  user-specific; deferred to a follow-up alongside the broader
+  branded-foods SPEC-005 extension.
+- **No ingredient-level per-serving claims.** We compute `per_100g`
+  only; serving conversions live in SPEC-009 using SPEC-005
+  densities.
+- **No recipe-level nutrient data**. Recipes are the assembly of
+  ingredients; composites are not ingested here.
+- **No calorie-only approach.** v1 ingests the full nutrient set
+  needed by ADR-001's `DailyTargets` plus the micros used by
+  clinical clamps.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 Module layout
+
+```
+backend/agents/nutrition_meal_planning_team/nutrient_data/
+├── __init__.py                   # get_nutrients, get_density, get_retention, VERSION
+├── version.py                    # NUTRIENT_DATA_VERSION = "1.0.0"
+├── types.py                      # Nutrients, NutrientValue, Density, RetentionFactor
+├── reader.py                     # runtime read path (Postgres-backed, in-memory cached)
+├── ingest/
+│   ├── fdc_client.py             # thin wrapper over FDC CSV bulk download + REST
+│   ├── mapping.py                # canonical_id → fdc_id(s) joiner
+│   ├── normalize.py              # FDC nutrient schema → our Nutrient enum
+│   ├── overrides.py              # hand-curated corrections (YAML-backed)
+│   ├── pipeline.py               # end-to-end: download → join → write
+│   └── audit.py                  # coverage + diff reports
+├── data/
+│   ├── nutrient_enum.py          # closed Nutrient enum (kcal, protein_g, ...)
+│   ├── retention_factors.yaml    # raw→cooked factors by canonical_id + method
+│   ├── overrides.yaml            # canonical_id-scoped manual corrections
+│   └── fdc_snapshots/            # checked-in checksummed FDC bulk files
+│       └── 2026-04-fdc.sha256
+├── cli/
+│   ├── refresh.py
+│   ├── coverage.py
+│   ├── diff.py
+│   └── override.py
+└── tests/
+```
+
+### 4.2 Nutrient enum
+
+`nutrient_enum.py` defines a closed `Nutrient` enum. v1 includes:
+
+- Macros: `kcal`, `protein_g`, `fat_g`, `saturated_fat_g`,
+  `carbs_g`, `sugar_g`, `added_sugar_g`, `fiber_g`.
+- Micros required by ADR-001 clinical clamps and ADR-003 rollup:
+  `sodium_mg`, `potassium_mg`, `calcium_mg`, `iron_mg`,
+  `phosphorus_mg`, `magnesium_mg`, `zinc_mg`, `vitamin_d_mcg`,
+  `vitamin_b12_mcg`, `vitamin_k_mcg`, `vitamin_c_mg`, `folate_mcg_dfe`.
+
+Closed. Additions are a minor version bump with reviewer sign-off.
+
+### 4.3 Postgres schema
+
+Registered via `shared_postgres.register_team_schemas` in the
+nutrition team's lifespan. Migration
+`005_nutrient_data.sql`:
+
+```sql
+-- Closed source registry; each import writes a row.
+CREATE TABLE IF NOT EXISTS nutrient_sources (
+    id              BIGSERIAL PRIMARY KEY,
+    name            TEXT NOT NULL,          -- 'fdc_sr_legacy', 'fdc_foundation', 'manual'
+    snapshot_label  TEXT NOT NULL,          -- e.g. '2026-04-fdc'
+    imported_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    data_version    TEXT NOT NULL,          -- NUTRIENT_DATA_VERSION at import time
+    checksum        TEXT,                   -- sha256 of source payload
+    notes           TEXT
+);
+
+-- One row per (canonical_id, nutrient). per_100g is the single
+-- authoritative value; confidence + source are for audit and UI.
+CREATE TABLE IF NOT EXISTS ingredient_nutrients (
+    canonical_id    TEXT NOT NULL,
+    nutrient        TEXT NOT NULL,          -- Nutrient enum value
+    per_100g        DOUBLE PRECISION NOT NULL,
+    unit            TEXT NOT NULL,          -- 'g', 'mg', 'mcg', 'kcal'
+    source_id       BIGINT NOT NULL REFERENCES nutrient_sources(id),
+    confidence      REAL NOT NULL DEFAULT 1.0,
+    is_override     BOOLEAN NOT NULL DEFAULT FALSE,
+    data_version    TEXT NOT NULL,
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (canonical_id, nutrient)
+);
+CREATE INDEX ON ingredient_nutrients (data_version);
+CREATE INDEX ON ingredient_nutrients (canonical_id);
+
+-- Extends SPEC-005 densities YAML into Postgres; YAML remains the
+-- authoring layer, job syncs it on refresh.
+CREATE TABLE IF NOT EXISTS ingredient_density (
+    canonical_id    TEXT NOT NULL,
+    unit            TEXT NOT NULL,
+    grams           DOUBLE PRECISION NOT NULL,
+    source          TEXT NOT NULL,          -- 'spec005_yaml' | 'fdc_portion' | 'manual'
+    data_version    TEXT NOT NULL,
+    PRIMARY KEY (canonical_id, unit)
+);
+
+-- Retention factors: ratio applied to per-100g nutrient when the
+-- recipe describes a cooked preparation. Keyed by canonical_id +
+-- method; nutrient-specific where it matters.
+CREATE TABLE IF NOT EXISTS retention_factors (
+    canonical_id    TEXT NOT NULL,
+    method          TEXT NOT NULL,          -- 'boiled', 'baked', 'fried', 'steamed', 'raw'
+    nutrient        TEXT,                   -- NULL = applies to all macros uniformly
+    mass_retention  REAL NOT NULL DEFAULT 1.0,   -- e.g. 0.75 for chicken baked
+    nutrient_retention REAL NOT NULL DEFAULT 1.0, -- e.g. 0.6 for vitamin C boiled
+    source          TEXT NOT NULL,
+    data_version    TEXT NOT NULL,
+    PRIMARY KEY (canonical_id, method, COALESCE(nutrient, ''))
+);
+
+-- Audit log for every override write.
+CREATE TABLE IF NOT EXISTS nutrient_override_log (
+    id              BIGSERIAL PRIMARY KEY,
+    canonical_id    TEXT NOT NULL,
+    nutrient        TEXT NOT NULL,
+    old_value       DOUBLE PRECISION,
+    new_value       DOUBLE PRECISION NOT NULL,
+    reason          TEXT NOT NULL,
+    author          TEXT NOT NULL,
+    recorded_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+### 4.4 Ingestion pipeline (`ingest/pipeline.py`)
+
+```mermaid
+flowchart TD
+    A[Checked-in FDC snapshot<br/>CSV bundle + sha256] --> B[fdc_client.load]
+    B --> C[mapping.join]
+    C -->|canonical_id + fdc rows| D[normalize.to_nutrient_rows]
+    D --> E[overrides.apply]
+    E --> F[write to ingredient_nutrients<br/>with source_id, data_version]
+    F --> G[ingredient_density sync from<br/>SPEC-005 densities.yaml + FDC portions]
+    G --> H[retention_factors sync from<br/>retention_factors.yaml]
+    H --> I[audit.report]
+```
+
+Behavior:
+
+- FDC bulk files (SR Legacy + Foundation Foods) are downloaded
+  once per release, their sha256 checksummed, and committed under
+  `data/fdc_snapshots/`. The bulk payload itself is **not** in the
+  repo; only the checksum lives there, with a pointer to the
+  download URL in a pinned README. This keeps diff noise down and
+  lets CI verify the file we ingested matches what was reviewed.
+- `mapping.join` reads `fdc_id` from every SPEC-005 canonical food;
+  every canonical food without `fdc_id` emits a coverage warning.
+- `normalize.to_nutrient_rows` maps FDC's nutrient ids to our
+  `Nutrient` enum. Anything in FDC but not in our enum is
+  discarded; anything in our enum but missing in FDC is reported in
+  the coverage pass.
+- `overrides.apply` reads `overrides.yaml` and replaces values for
+  specific `(canonical_id, nutrient)` pairs with a manual value,
+  setting `is_override=true` and writing to `nutrient_override_log`.
+  Used when FDC values are wrong (rare) or when an ingredient has
+  no FDC id but is common (we manually enter the canonical values
+  from a peer-reviewed source, cite in the YAML).
+- Write is **transactional**: the entire refresh lands atomically
+  via a staging table swap, not row-by-row.
+
+### 4.5 Retention-factor policy
+
+Retention factors live in a small hand-curated YAML
+(`retention_factors.yaml`). v1 coverage:
+
+- Meats (chicken, beef, pork, fish): `baked`, `grilled`, `boiled`,
+  `fried`. Mass retention 0.70–0.85 depending on method + cut.
+  Nutrient retention ≈ 1.0 for macros, 0.6–0.9 for water-soluble
+  vitamins on boiled.
+- Pasta and rice: `boiled`. Mass retention ≈ 2.5–3.0× (water
+  absorbed). Nutrient-per-100g on the cooked side drops accordingly.
+- Leafy greens (spinach, kale, chard, beet greens): `sauteed`,
+  `boiled`, `steamed`. Mass retention 0.25–0.35; nutrient retention
+  0.7–0.9 for most nutrients, lower for folate and vitamin C on
+  boiled.
+- Starchy vegetables (potato, sweet potato): `baked`, `boiled`,
+  `fried`. Mass retention 0.85–0.95.
+
+Everything outside the v1 list defaults to `mass_retention=1.0`,
+`nutrient_retention=1.0` — i.e., we assume raw. SPEC-009's
+confidence score is lowered when a recipe's method is one we do not
+have retention data for.
+
+Each row carries a citation in `retention_factors.yaml` comments.
+Reviewer sign-off required on any edit.
+
+### 4.6 Runtime read path (`reader.py`)
+
+- Single query: `SELECT nutrient, per_100g, unit FROM ingredient_nutrients WHERE canonical_id = $1`.
+- In-memory LRU cache keyed by `(canonical_id, NUTRIENT_DATA_VERSION)`.
+  Cache is versioned; a refresh job bumps `NUTRIENT_DATA_VERSION`
+  and downstream caches (SPEC-009 recipe rollups, SPEC-010 plan
+  snapshots) miss and repopulate.
+- `get_density(canonical_id, unit)` and `get_retention(canonical_id,
+  method)` follow the same pattern.
+- No network. No LLM.
+
+Interface (module-level):
+
+```python
+def get_nutrients(canonical_id: str) -> Optional[Nutrients]: ...
+def get_density(canonical_id: str, unit: str) -> Optional[float]: ...
+def get_retention(canonical_id: str, method: str) -> Retention: ...
+NUTRIENT_DATA_VERSION: str
+```
+
+### 4.7 Scheduled refresh
+
+Refresh runs via the platform's `scheduled-tasks` mechanism. Cadence:
+**quarterly**, manual trigger allowed. FDC releases are infrequent;
+quarterly is a reasonable default.
+
+Refresh steps:
+
+1. Verify checked-in snapshot checksum matches the FDC file on disk
+   (fail if not — means someone swapped it without going through
+   the checksum PR).
+2. Run pipeline against staging Postgres.
+3. Run coverage audit; compare against the previous data version's
+   coverage. Drops beyond a threshold (3% absolute) fail the job
+   and require human review.
+4. Run nutrient-diff audit: per-canonical-id max absolute delta
+   on each nutrient vs. previous version. Outliers (>50% change on
+   a macro for a food that was not added or flagged) fail the job.
+5. On success, swap staging → production via a transaction.
+6. Bump `NUTRIENT_DATA_VERSION` minor.
+7. Write CHANGELOG entry listing added/removed foods and notable
+   value changes.
+
+Manual refresh (out-of-cadence) uses the same pipeline; admin-only
+CLI command.
+
+### 4.8 CLI tools
+
+- `python -m nutrient_data.cli.refresh [--dry-run]` — runs the
+  ingest pipeline. Dry-run prints diffs without writing.
+- `python -m nutrient_data.cli.coverage` — reports:
+  - Canonical foods with no `fdc_id` and no override (gap).
+  - Canonical foods with `fdc_id` but FDC returned an incomplete
+    nutrient set.
+  - Top-N macros with `confidence < 0.9`.
+- `python -m nutrient_data.cli.diff VERSION_A VERSION_B` — prints
+  per-nutrient deltas between two data versions; used by the
+  quarterly refresh review.
+- `python -m nutrient_data.cli.override CANONICAL_ID NUTRIENT VALUE --reason "..."` —
+  interactive; writes to `overrides.yaml` and `nutrient_override_log`;
+  requires `--reason`.
+
+### 4.9 Versioning
+
+`NUTRIENT_DATA_VERSION = "MAJOR.MINOR.PATCH"`:
+
+- **MAJOR** — `Nutrient` enum removal/rename, schema change,
+  retention-factor model change.
+- **MINOR** — data refresh (quarterly), enum addition, new
+  retention factors.
+- **PATCH** — override additions/corrections that do not change the
+  shape of downstream rollups meaningfully.
+
+Every `ingredient_nutrients` row carries `data_version` so queries
+can verify consistency; downstream caches pin on it.
+
+### 4.10 Privacy and licensing
+
+- FDC data is public domain (explicitly — US government data).
+  License permits redistribution; we still cite it per the FDC
+  attribution guidance in the nutrient-source registry and in UI
+  "why these numbers" panels.
+- No user data is involved in this pipeline.
+
+### 4.11 Priority-grouped work items
+
+| # | Item | Priority |
+|---|------|----------|
+| W1 | Module scaffolding, `version.py`, `types.py`, `nutrient_enum.py` | P0 |
+| W2 | Migration `005_nutrient_data.sql` + schema registration | P0 |
+| W3 | `fdc_client.load` (reads CSV bundle from snapshot directory) | P0 |
+| W4 | `mapping.join` + coverage report | P0 |
+| W5 | `normalize.to_nutrient_rows` + tests | P0 |
+| W6 | Overrides loader + `nutrient_override_log` wiring | P0 |
+| W7 | `pipeline.py` end-to-end with staging-table atomic swap | P0 |
+| W8 | `reader.py` runtime read path with version-aware cache | P0 |
+| W9 | Initial `fdc_snapshots/2026-04-fdc.sha256` + README pointing to FDC URL | P0 |
+| W10 | Retention-factor YAML seed + sync step | P1 |
+| W11 | CLI tools: refresh, coverage, diff, override | P1 |
+| W12 | Scheduled-task wiring (quarterly refresh) | P1 |
+| W13 | Audit: CI coverage check (canonical foods with missing nutrients) | P1 |
+| W14 | Benchmarks: `get_nutrients` p99 ≤ 200 µs (cached) / ≤ 5 ms (cold) | P2 |
+
+---
+
+## 5. Rollout Plan
+
+No runtime callers at v1.0.0 ship. Rollout is about getting the
+pipeline, the data, and the versioning clean before SPEC-009
+consumes them.
+
+### Phase 0 — Scaffolding (P0)
+- [ ] W1–W2 landed. Staging migration applied.
+
+### Phase 1 — Ingest pipeline (P0)
+- [ ] W3–W7 landed.
+- [ ] W9 snapshot checked in; pipeline runs green against it in
+      staging.
+- [ ] Coverage report shows ≥95% of SPEC-005's canonical foods
+      have at least kcal + macros populated.
+- [ ] Micros coverage ≥ 80% on foods with an `fdc_id`.
+
+### Phase 2 — Retention + overrides (P0/P1)
+- [ ] W10 retention factors seeded.
+- [ ] W6 overrides YAML exercised on at least 30 known-problem
+      entries (v1 overrides list).
+- [ ] W8 read path wired; in-memory cache hit rate ≥ 99% after
+      warm-up.
+
+### Phase 3 — Tooling and scheduled refresh (P1)
+- [ ] W11 CLI tools shipped.
+- [ ] W12 scheduled task configured (quarterly cadence).
+- [ ] W13 CI coverage check enforces thresholds on PRs.
+
+### Phase 4 — Freeze (P1/P2)
+- [ ] W14 benchmarks baselined.
+- [ ] `NUTRIENT_DATA_VERSION = "1.0.0"` frozen; CHANGELOG entry.
+
+### Rollback
+- Pipeline is a write-only source of truth with a staging swap; if
+  a refresh lands bad data, roll back by re-running with the
+  previous snapshot (snapshots kept indefinitely) or restore the
+  staging-swap's prior tables (retained for 30 days).
+- Runtime callers lag behind the data version; any caller on
+  version N is unaffected by a bad version N+1 until they
+  invalidate their cache.
+
+---
+
+## 6. Verification
+
+### 6.1 Unit tests
+
+- `test_nutrient_enum.py` — closed-set invariants; stable string
+  representation across versions.
+- `test_normalize_fdc.py` — fixture FDC rows produce expected
+  `(canonical_id, nutrient, per_100g, unit)` tuples; unit
+  conversions correct (FDC stores mg vs. g inconsistently).
+- `test_overrides_apply.py` — override replaces the FDC value,
+  marks `is_override=true`, writes audit log row.
+- `test_retention_lookup.py` — known (canonical_id, method) pairs
+  return expected factors; missing pairs return identity factor
+  (1.0, 1.0) with `is_default=true` flag.
+
+### 6.2 Integration tests
+
+- `test_pipeline_end_to_end.py` — fixture FDC bundle (small,
+  checked-in) runs through the full pipeline against a staging
+  Postgres; final tables match expected snapshot.
+- `test_atomic_swap.py` — pipeline fails mid-write; no partial
+  data visible to runtime readers; pre-existing version still
+  serves.
+- `test_reader_cache_invalidation.py` — bumping
+  `NUTRIENT_DATA_VERSION` causes runtime reader to miss cache and
+  re-fetch.
+
+### 6.3 Coverage and audit tests
+
+- `test_coverage_threshold.py` — fails if any SPEC-005 canonical
+  food with `fdc_id` set has zero nutrients after ingest.
+- `test_snapshot_checksum.py` — fails if the on-disk FDC bundle
+  does not match the checked-in sha256.
+- `test_nutrient_diff_alerts.py` — simulated refresh with a known
+  outlier (50% drop on a macro) triggers the diff-audit failure.
+
+### 6.4 Performance
+
+- `bench_get_nutrients.py` — cold read ≤ 5 ms, warm read ≤ 200 µs,
+  both on CI reference runner.
+- Cache hit rate ≥ 99% after a typical 100-lookup warmup.
+
+### 6.5 Review gates
+
+- Clinical reviewer sign-off on `Nutrient` enum (what we commit to
+  carrying long-term).
+- Clinical reviewer sign-off on `retention_factors.yaml` seed.
+- Licensing/attribution note in nutrition team README referencing
+  FDC as the source.
+
+### 6.6 Cutover criteria (freeze v1.0.0)
+
+- All tests green.
+- Phase 1 coverage thresholds met (≥95% macros, ≥80% micros on
+  fdc-tagged foods).
+- Reviewer sign-offs recorded.
+- No open P0 issues.
+
+---
+
+## 7. Open Questions
+
+- **FDC REST vs. bulk CSV.** v1 uses bulk CSV snapshots (deterministic,
+  reviewable). A REST fallback for branded foods is a v1.1 feature
+  once we decide to support those.
+- **Where does "cooked" mass retention for pasta land?** Pasta
+  cooked mass is greater than raw (water absorption), which flips
+  the usual retention direction. `mass_retention > 1.0` is legal in
+  the schema; the UI just needs to understand it.
+- **Override TTL.** Should manual overrides auto-expire when the
+  next FDC refresh covers them? v1 says no — overrides persist
+  until explicitly removed. We may add a review flag in v1.1.
+- **Branded foods.** Deferred per §3.2. When they land they add a
+  `brand` column on `ingredient_nutrients` and a separate
+  `branded_foods` table; no schema migration required on the tables
+  this spec defines.

--- a/system_design/specs/SPEC-009-nutrition-recipe-and-plan-rollup.md
+++ b/system_design/specs/SPEC-009-nutrition-recipe-and-plan-rollup.md
@@ -1,0 +1,530 @@
+# SPEC-009: Recipe and plan nutrient rollup
+
+| Field       | Value                                                    |
+|-------------|----------------------------------------------------------|
+| **Status**  | Proposed                                                 |
+| **Author**  | Nutrition & Meal Planning team                           |
+| **Created** | 2026-04-17                                               |
+| **Priority**| P0 (blocks SPEC-010; inputs to ADR-006 eaten rollup)     |
+| **Scope**   | New pure-Python module `backend/agents/nutrition_meal_planning_team/nutrient_rollup/` |
+| **Depends on** | SPEC-005 (parser, densities, units), SPEC-008 (nutrient data, retention factors) |
+| **Implements** | ADR-003 §2 (recipe nutrient computation), §3 (plan-level rollup) |
+
+---
+
+## 1. Problem Statement
+
+After SPEC-005 and SPEC-008 land, we have canonical ingredient ids,
+a parser, a density table, a retention-factor table, and per-100g
+nutrient values. What we do not have is the arithmetic that turns
+those primitives into per-recipe and per-plan nutrient totals.
+
+This spec ships that arithmetic as a pure-Python module. It answers
+two questions:
+
+1. **Per recipe**: for a `MealRecommendation` with a list of
+   free-text ingredient lines, what are the per-serving nutrients
+   and how confident are we?
+2. **Per plan**: for a week of recipes assigned to dates, what are
+   the daily totals and how do they compare to the
+   `NutritionPlan.daily_targets` from SPEC-003 / SPEC-004?
+
+The module has no LLM dependency, no agent, no orchestrator, no
+HTTP. It is importable and testable in isolation. SPEC-010 wires it
+into the orchestrator and adds the repair loop. Keeping the
+arithmetic in a pure module is deliberate — it is what makes the
+numbers reviewable and the confidence story honest.
+
+---
+
+## 2. Current State
+
+### 2.1 What's there
+
+- `MealRecommendation.ingredients: List[str]` — free-text lines.
+- `NutritionPlan.daily_targets: DailyTargets` — numeric targets
+  from SPEC-003.
+- `MealRecommendation.suggested_date: Optional[str]` — recipes
+  optionally carry their assigned date.
+- `portions_servings: str` — free-text serving count.
+
+### 2.2 What's missing
+
+1. No function that takes a `MealRecommendation` and returns its
+   per-serving nutrient totals.
+2. No function that takes a list of dated `MealRecommendation`s
+   and returns daily/weekly totals + variance.
+3. No confidence score on recipe-level rollups — low-confidence
+   plans cannot be distinguished from high-confidence plans, which
+   means SPEC-010's repair loop cannot make sensible decisions.
+4. No structured recipe-step output to support cooked-vs-raw
+   retention — recipes today carry a rationale sentence but no
+   method tag.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- Deterministic `compute_recipe_nutrients(rec) -> RecipeNutrients`
+  that consumes SPEC-005 parsing and SPEC-008 data and returns
+  per-serving values with a confidence score and a structured list
+  of resolution issues.
+- Deterministic `rollup_plan(suggestions, targets, period_days) ->
+  PlanRollup` that computes daily totals, weekly totals, and
+  variance vs. targets, plus a list of tolerance breaches.
+- Handle the unglamorous cases explicitly: unresolvable ingredients,
+  missing densities, unknown cooking methods, fractional servings,
+  recipes with no `suggested_date`.
+- Expose the intermediate parsed-ingredient list on
+  `RecipeNutrients` so SPEC-007 (guardrail) and SPEC-010 (repair
+  loop) do not re-parse.
+- Pure, no I/O beyond SPEC-008 reads, deterministic, versioned.
+
+### 3.2 Non-goals
+
+- **No repair loop, swap, or regeneration.** SPEC-010 owns that.
+- **No tolerance policy authoring.** Tolerance thresholds are
+  consumed from a config file owned by SPEC-010; this module
+  applies them.
+- **No cooking-method inference.** If a recipe does not emit a
+  structured method tag, we default to raw. Inferring method from
+  prose is out of scope and error-prone.
+- **No eaten rollup.** Cooking-event-based totals (what the user
+  actually ate) are ADR-006; the same `rollup_plan` core is reused
+  there via a different input list, but the new endpoint is not
+  in this spec.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 Module layout
+
+```
+backend/agents/nutrition_meal_planning_team/nutrient_rollup/
+├── __init__.py            # compute_recipe_nutrients, rollup_plan, VERSION
+├── version.py             # ROLLUP_VERSION = "1.0.0"
+├── types.py               # RecipeNutrients, PlanRollup, DailyTotals,
+│                          # NutrientBreach, ResolutionIssue
+├── recipe.py              # compute_recipe_nutrients
+├── plan.py                # rollup_plan
+├── confidence.py          # confidence scoring
+├── errors.py
+└── tests/
+```
+
+Public interface:
+
+```python
+def compute_recipe_nutrients(rec: MealRecommendation) -> RecipeNutrients: ...
+def rollup_plan(
+    suggestions: Sequence[MealRecommendationWithId],
+    targets: DailyTargets,
+    period_days: int,
+    tolerances: Tolerances,
+) -> PlanRollup: ...
+```
+
+### 4.2 Required `MealRecommendation` additions
+
+Additive fields on `MealRecommendation` (models.py):
+
+```python
+class CookingMethod(str, Enum):
+    raw = "raw"
+    baked = "baked"
+    grilled = "grilled"
+    boiled = "boiled"
+    steamed = "steamed"
+    fried = "fried"
+    sauteed = "sauteed"
+    mixed = "mixed"          # e.g. salad bowl + grilled protein; recipe-level default
+
+class MealRecommendation(BaseModel):
+    # ... existing ...
+    cooking_method: CookingMethod = CookingMethod.raw
+    portions_servings_numeric: Optional[float] = None  # parsed from string if present
+```
+
+- Absent `cooking_method` defaults to `raw`; confidence is reduced
+  (§4.6).
+- `portions_servings_numeric` is populated by the meal-planning
+  agent when possible; if absent, this module parses
+  `portions_servings: str` (e.g. `"serves 4"`) with a small regex,
+  then falls back to `1.0` with a reduced confidence.
+
+The meal-planning agent prompt (SPEC-007's updated prompt) is
+extended in the SPEC-010 rollout to emit these fields reliably.
+This spec tolerates their absence.
+
+### 4.3 `compute_recipe_nutrients`
+
+Pipeline:
+
+```mermaid
+flowchart TD
+    A[MealRecommendation] --> P["for each ingredient line:<br/>parse_ingredient (SPEC-005)"]
+    P --> R["resolve canonical_id, qty, unit"]
+    R --> G["convert qty+unit → grams<br/>(SPEC-005 densities)"]
+    G --> N["lookup per_100g nutrients<br/>(SPEC-008)"]
+    N --> RET["apply retention factors<br/>based on cooking_method"]
+    RET --> SUM[sum across ingredients]
+    SUM --> DIV[divide by portions_servings_numeric]
+    DIV --> OUT["RecipeNutrients<br/>per_serving + confidence + issues"]
+```
+
+Types:
+
+```python
+@dataclass(frozen=True)
+class ResolutionIssue:
+    kind: Literal[
+        "unresolved_ingredient",
+        "missing_density",
+        "missing_qty",
+        "missing_nutrients",
+        "unknown_method",
+        "missing_portions",
+    ]
+    ingredient_raw: Optional[str]
+    detail: str
+
+@dataclass(frozen=True)
+class RecipeNutrients:
+    per_serving: dict[Nutrient, float]        # from nutrient_enum
+    per_serving_units: dict[Nutrient, str]    # 'kcal', 'g', 'mg', 'mcg'
+    total_mass_g_per_serving: float
+    confidence: float                          # 0.0..1.0
+    issues: tuple[ResolutionIssue, ...]
+    parsed_ingredients: tuple[ParsedIngredient, ...]
+    rollup_version: str                        # ROLLUP_VERSION
+    data_version: str                          # SPEC-008 NUTRIENT_DATA_VERSION
+```
+
+Rules:
+
+- An ingredient line with `canonical_id=None` contributes zero to
+  all nutrients and emits an `unresolved_ingredient` issue.
+- An ingredient with `qty=None` (e.g. "a handful of cashews",
+  "salt to taste") uses a lookup in SPEC-005's `densities.yaml`
+  for a "default unspecified quantity" (e.g. `handful_cashew: 30g`)
+  where defined, otherwise falls back to `0g` with a `missing_qty`
+  issue. Salt and "to taste" items default to zero and emit an
+  issue rather than inventing a number.
+- An ingredient with `qty` and `unit` but missing density (e.g.
+  `"2 tbsp exotic-herb-paste"` with no density entry) contributes
+  zero and emits `missing_density`.
+- An ingredient with canonical id but no nutrient row emits
+  `missing_nutrients` (coverage gap; SPEC-008 should have it, so
+  the signal helps prioritize).
+- Retention: for each ingredient, look up the
+  `(canonical_id, cooking_method)` retention factor from SPEC-008.
+  Default to (1.0, 1.0) with `unknown_method` issue if none.
+  Apply `nutrient_retention` to each nutrient; apply `mass_retention`
+  to the contributing mass for per-serving mass reporting.
+- Total is summed across ingredients, then divided by
+  `portions_servings_numeric`.
+
+### 4.4 Confidence scoring
+
+Single scalar, explainable:
+
+```
+confidence = 1.0
+  - 0.10 per unresolved_ingredient       (capped at 0.5 total)
+  - 0.05 per missing_density             (capped at 0.2 total)
+  - 0.05 per missing_qty                 (capped at 0.2 total)
+  - 0.10 per missing_nutrients           (capped at 0.4 total)
+  - 0.05 if cooking_method absent or "mixed"
+  - 0.10 if unknown_method on >30% of ingredient mass
+  - 0.10 if missing_portions
+confidence = clamp(confidence, 0.0, 1.0)
+```
+
+Confidence is mass-weighted where possible: losing 5% of mass to an
+unresolved ingredient hurts less than losing 40%. A helper in
+`confidence.py` implements the mass-weighting; the table above is
+the floor rule for sparse recipes where mass can't be computed.
+
+SPEC-010's repair loop treats `confidence < 0.7` recipes as "do
+not repair against this; ask user to clarify or regenerate." Low
+confidence is visible in the UI as a caution chip.
+
+### 4.5 `rollup_plan`
+
+```python
+@dataclass(frozen=True)
+class DailyTotals:
+    date: date
+    nutrients: dict[Nutrient, float]
+    recipe_ids: tuple[str, ...]
+    low_confidence_recipe_ids: tuple[str, ...]
+
+@dataclass(frozen=True)
+class NutrientBreach:
+    scope: Literal["per_meal", "per_day", "per_week"]
+    date: Optional[date]
+    recipe_id: Optional[str]
+    nutrient: Nutrient
+    observed: float
+    target: float
+    lower: Optional[float]
+    upper: Optional[float]
+    severity: Literal["cap_breach", "band_miss", "adequacy_gap"]
+
+@dataclass(frozen=True)
+class PlanRollup:
+    by_day: tuple[DailyTotals, ...]
+    weekly_totals: dict[Nutrient, float]
+    variance_vs_target_per_day: dict[date, dict[Nutrient, float]]    # pct_delta
+    variance_vs_target_weekly: dict[Nutrient, float]
+    breaches: tuple[NutrientBreach, ...]
+    per_meal_caps_breached: tuple[NutrientBreach, ...]
+    confidence: float                                                  # plan-level
+    issues: tuple[ResolutionIssue, ...]
+    rollup_version: str
+    data_version: str
+```
+
+Rules:
+
+- Suggestions without `suggested_date` are distributed round-robin
+  across the period's days. The UI shows unassigned recipes
+  distinctly and invites the user to schedule them; we do not
+  silently scatter them.
+- Per-day summing is straightforward. Per-week summing sums across
+  the period.
+- `variance_vs_target_per_day[date][nutrient] = (observed - target) / target`
+  where `target` is drawn from `DailyTargets` for per-day nutrients
+  and from a weekly-adequacy map for nutrients where weekly
+  adequacy is preferred (vitamin D, iron, vitamin K — see SPEC-010
+  tolerances).
+- `breaches` is populated using the tolerance set passed in. This
+  spec does not define the thresholds; it applies them.
+- `per_meal_caps_breached` is populated when a single recipe
+  exceeds a per-meal cap (sodium, carbs for T2D). Per-meal caps
+  are passed in via the `Tolerances` object, derived from ADR-001
+  clinical overrides.
+- `confidence` at the plan level is the minimum recipe confidence
+  across the plan, with a small penalty for any recipe below 0.7.
+
+### 4.6 Tolerances input shape
+
+`Tolerances` is the input shape SPEC-010 constructs and passes in.
+Defining the shape here (not the values) keeps this module
+self-contained for testing.
+
+```python
+@dataclass(frozen=True)
+class Tolerance:
+    lower_pct: Optional[float]    # e.g. -0.10 for "protein can be 10% under"
+    upper_pct: Optional[float]    # e.g. +0.10 for "kcal can be 10% over"
+    cap_absolute: Optional[float] # e.g. 2300 mg sodium/day
+    per_meal_cap: Optional[float] # e.g. 800 mg sodium/meal
+    scope: Literal["per_day", "per_week"]
+
+@dataclass(frozen=True)
+class Tolerances:
+    by_nutrient: dict[Nutrient, Tolerance]
+```
+
+SPEC-010 loads the YAML and constructs `Tolerances`. Unit tests
+here exercise the shape with fixture tolerance sets.
+
+### 4.7 Edge cases enumerated
+
+- **Zero recipes.** Returns an empty `PlanRollup` with `confidence=1.0`,
+  no breaches, no issues. Not an error.
+- **Negative numbers anywhere.** Defensive: sums floor at zero,
+  `NutrientBreach.observed` is never negative. A bug upstream that
+  produced a negative should not cascade.
+- **Recipe with one ingredient that has 95% of mass missing
+  density.** Confidence drops to ~0.15, `missing_density` issue
+  attached, `total_mass_g_per_serving` underreported accordingly.
+  SPEC-010 will not repair against this.
+- **Recipe that resolves cleanly but has no targets in its
+  `Tolerances`.** No breaches emitted for those nutrients; no
+  variance either. (SPEC-010's defaults cover every nutrient in
+  `DailyTargets`.)
+- **Plan spanning DST transitions.** Dates are `date`, not
+  `datetime`; DST is not relevant. Timezone handling lives on the
+  profile for meal-planning purposes but rollup is date-keyed.
+
+### 4.8 Determinism
+
+- Floating-point summation uses `math.fsum` for per-day totals to
+  avoid accumulator drift across different Python builds.
+- `parsed_ingredients` is ordered to match the input recipe order.
+- Dict iteration order is insertion order throughout (Python 3.7+
+  guarantee).
+- Same inputs → byte-equal output across machines and runs. Golden
+  tests (§6) enforce this.
+
+### 4.9 Versioning
+
+`ROLLUP_VERSION = "MAJOR.MINOR.PATCH"`:
+
+- **MAJOR** — confidence formula change, rule change around
+  unresolved ingredients, public type change.
+- **MINOR** — added optional behavior (e.g. mass-weighted
+  confidence refinement).
+- **PATCH** — bug fixes that do not change outputs on clean inputs.
+
+SPEC-010 pins on `(ROLLUP_VERSION, NUTRIENT_DATA_VERSION)` for its
+recipe-level content-addressed cache.
+
+### 4.10 Caching hook
+
+The module itself is stateless; caching is SPEC-010's responsibility.
+The module exposes a stable `recipe_cache_key(rec) -> str` helper:
+
+```
+key = sha256(
+    rollup_version || data_version || canonical(rec.ingredients)
+          || cooking_method || portions_servings_numeric
+)
+```
+
+Canonicalization of `rec.ingredients` is whitespace-normalized
+lowercased join. Two recipes with the same canonical ingredient
+content hit the same cache.
+
+### 4.11 Priority-grouped work items
+
+| # | Item | Priority |
+|---|------|----------|
+| W1 | Module scaffolding; `version.py`; `types.py`; `errors.py` | P0 |
+| W2 | Additive `models.py` fields: `CookingMethod`, `portions_servings_numeric` | P0 |
+| W3 | `recipe.py::compute_recipe_nutrients` with tests on ≥50 recipe fixtures | P0 |
+| W4 | `confidence.py` + unit tests per rule (§4.4) | P0 |
+| W5 | `plan.py::rollup_plan` + tests on multi-day fixtures | P0 |
+| W6 | Tolerance application + breach detection tests | P0 |
+| W7 | `recipe_cache_key` helper + stability test | P0 |
+| W8 | Golden-output tests for ≥20 plan fixtures | P1 |
+| W9 | Property tests (monotonicity, nonnegativity, mass-weighting) | P1 |
+| W10 | Benchmarks: `compute_recipe_nutrients` p99 ≤ 5 ms, `rollup_plan` p99 ≤ 25 ms | P2 |
+| W11 | "Unscheduled recipes" handling + tests | P1 |
+
+---
+
+## 5. Rollout Plan
+
+Pure library; no runtime caller in this spec. Rollout is about
+hitting the quality bar and freezing the version.
+
+### Phase 0 — Scaffolding (P0)
+- [ ] SPEC-008 at `NUTRIENT_DATA_VERSION=1.0.0`.
+- [ ] W1–W2 landed.
+
+### Phase 1 — Recipe rollup (P0)
+- [ ] W3, W4 landed. Tests green on 50 recipe fixtures.
+- [ ] Coverage ≥95% on `nutrient_rollup/`.
+
+### Phase 2 — Plan rollup (P0)
+- [ ] W5, W6, W11 landed.
+- [ ] Multi-day fixtures: plan rollups match expected within
+      floating-point epsilon.
+
+### Phase 3 — Hardening (P1/P2)
+- [ ] W7–W10 landed.
+- [ ] `ROLLUP_VERSION = "1.0.0"` frozen; CHANGELOG entry.
+
+### Rollback
+- Library unused at ship; revert the PR if bugs surface.
+
+---
+
+## 6. Verification
+
+### 6.1 Recipe fixture tests
+
+`tests/fixtures/recipes/` — at least 50 hand-curated recipes across:
+
+- Simple (3–5 ingredients, all common canonical ids).
+- Mixed protein/grain/veg complete meals.
+- Raw-only (salads, smoothies).
+- Boiled/steamed with nutrient retention impact (spinach sauté,
+  pasta with water-loss mass change).
+- Composite ("grilled protein over rice with veg") spanning
+  multiple cooking methods — marked `mixed`.
+- Degenerate: empty ingredient list; one ingredient that is
+  salt-to-taste; one recipe with a mystery ingredient;
+  `portions_servings=""`.
+
+Each fixture records expected per-serving values to ≥1 significant
+figure for validation. Exact values come from hand computation
+against published FDC numbers (and are re-verified when
+`NUTRIENT_DATA_VERSION` changes).
+
+### 6.2 Confidence rule tests
+
+- Every rule in §4.4 has a dedicated fixture that isolates it.
+- Mass-weighted confidence: fixture with 5% missing mass ≥ fixture
+  with 40% missing mass.
+- Cap rules fire: 10 `unresolved_ingredient` issues contribute the
+  capped 0.5 decrement, not 1.0.
+
+### 6.3 Plan fixture tests
+
+`tests/fixtures/plans/` — 20 multi-day plan fixtures:
+
+- Balanced 7-day plan hits all targets within tolerance.
+- Protein-deficient plan triggers a `band_miss` breach on protein.
+- High-sodium plan triggers a `cap_breach` on sodium (day) and a
+  `per_meal_caps_breached` on at least one recipe.
+- Plan with mixed-date + unscheduled recipes distributes the
+  unscheduled ones and flags them.
+- Plan where a single recipe has `confidence=0.4` reduces plan
+  confidence; plan `low_confidence_recipe_ids` contains the id.
+
+### 6.4 Property tests
+
+- **Monotonicity**: doubling one ingredient's quantity at least
+  doubles its nutrient contribution (within floating-point).
+- **Nonnegativity**: no nutrient total is negative, ever.
+- **Determinism**: 100 runs of `rollup_plan` on the same input
+  return byte-equal output.
+- **Mass conservation**: sum of recipe per-serving masses across a
+  day equals the day's total mass within 1%.
+
+### 6.5 Golden outputs
+
+Checked in under `tests/golden/`. Any change to rollup output must
+come with a `ROLLUP_VERSION` bump and an intentional golden
+rewrite in the same PR.
+
+### 6.6 Benchmarks
+
+- `compute_recipe_nutrients` p99 ≤ 5 ms on 10-ingredient recipes.
+- `rollup_plan` p99 ≤ 25 ms on a 14-recipe week.
+
+### 6.7 Cutover criteria
+
+- All P0 tests green, coverage ≥95%, goldens frozen, benchmarks
+  baselined.
+- Golden fixtures reviewed by the clinical reviewer who owns
+  `Nutrient` enum + retention (§SPEC-008).
+
+---
+
+## 7. Open Questions
+
+- **"Default unspecified quantity" entries in densities.yaml.**
+  We suggest a small set (`handful_cashew: 30g`,
+  `pinch_spice: 0.5g`) for the most common qty-less patterns. The
+  alternative is always emitting `missing_qty`. v1 adds ~20 of
+  these; anything else falls through to the issue.
+- **Whether `confidence` should be multi-dimensional** (mass
+  coverage, nutrient coverage, method coverage) instead of scalar.
+  v1 is scalar for UX simplicity; we keep the three dimensions as
+  issue categories so SPEC-010 can inspect detail.
+- **Composite recipes** (e.g., "grilled chicken + rice + salad" in
+  one `MealRecommendation`). Currently we default to
+  `CookingMethod.mixed` which disables retention; this is safe but
+  conservative. A sub-recipe structure would let us apply different
+  methods to different parts of the meal. v1 defers.
+- **Weekly-adequacy default set.** The list of nutrients treated as
+  weekly-adequacy (D, K, iron) is a tolerance input in this spec,
+  but SPEC-010 needs to decide defaults. Coordinated there.

--- a/system_design/specs/SPEC-010-nutrition-meal-plan-validation-and-repair.md
+++ b/system_design/specs/SPEC-010-nutrition-meal-plan-validation-and-repair.md
@@ -1,0 +1,589 @@
+# SPEC-010: Meal-plan validation, targeted repair, and swap endpoint
+
+| Field       | Value                                                    |
+|-------------|----------------------------------------------------------|
+| **Status**  | Proposed                                                 |
+| **Author**  | Nutrition & Meal Planning team                           |
+| **Created** | 2026-04-17                                               |
+| **Priority**| P0 (capstone for ADR-003; unblocks ADR-005 substitutions and ADR-006 eaten rollup) |
+| **Scope**   | `backend/agents/nutrition_meal_planning_team/orchestrator/`, `agents/meal_planning_agent/`, `shared/meal_feedback_store`, `models.py` (additive), new `tolerances/` config, `user-interface/` meal-plan display |
+| **Depends on** | SPEC-007 (guardrail still enforces on any output), SPEC-009 (recipe + plan rollup) |
+| **Implements** | ADR-003 §4 (tolerance policy), §5 (repair loop), §6 (API), §7 (caching) |
+
+---
+
+## 1. Problem Statement
+
+SPEC-009 computes per-recipe and per-plan nutrient totals and
+reports variance against targets. SPEC-007 enforces allergen and
+dietary restrictions. This spec is what connects them to the live
+meal plan: when a plan's rollup violates tolerances from SPEC-003's
+targets, which specific meal do we swap, how do we ask for a
+replacement that actually closes the gap, and how do we do it
+without throwing away the meals the user already liked on screen?
+
+It is also where the `/swap` primitive lives — a single-suggestion
+replacement endpoint reused by ADR-005's user-initiated
+substitution.
+
+This spec is the capstone of ADR-003. After it lands, "a meal plan"
+is no longer a list of suggestions; it is a plan that provably
+meets the user's targets within configurable tolerances, with any
+remaining gaps visible rather than hidden.
+
+---
+
+## 2. Current State
+
+### 2.1 Today's flow (post-SPEC-007)
+
+```mermaid
+sequenceDiagram
+    participant API
+    participant Orch as Orchestrator
+    participant MPA as meal_planning_agent
+    participant GR as guardrail
+    participant Store
+
+    API->>Orch: POST /plan/meals
+    Orch->>MPA: run(profile, plan, history)
+    MPA-->>Orch: List[MealRecommendation]
+    loop per suggestion
+        Orch->>GR: check_recommendation
+        alt pass
+            Orch->>Store: record
+        else reject
+            Orch->>MPA: regenerate_single
+            Orch->>GR: re-check; record or drop
+        end
+    end
+    Orch-->>API: MealPlanResponse (+ dropped)
+```
+
+No nutrient check anywhere. `DailyTargets` and the served meals
+coexist but are never reconciled.
+
+### 2.2 Gaps
+
+1. Plan-level rollup is not computed.
+2. No tolerance policy; no breach detection; no visible variance.
+3. No repair step; a protein-deficient week ships as-is.
+4. No `/swap` primitive; user-rejected meals cannot be replaced
+   under a nutrient constraint.
+5. Downstream work (ADR-006 eaten rollup, ADR-005 substitution,
+   goal-progress drivers) depends on this surface existing.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- On every `POST /plan/meals`, compute the plan rollup (SPEC-009)
+  after the guardrail pass, detect tolerance breaches, and run a
+  bounded targeted-repair loop that swaps specific meals to close
+  specific gaps.
+- Ship a tolerance configuration file that is reviewable,
+  versioned, and per-profile overridable for advanced users.
+- Return the rollup, the repair history, and any remaining
+  unresolved breaches in the `MealPlanResponse` so the UI can
+  render honest variance badges.
+- Ship `POST /plan/meals/{plan_id}/recipes/{rec_id}/swap` as the
+  single-suggestion replacement primitive. ADR-005's user-initiated
+  substitution reuses this endpoint through an adapter.
+- Keep performance acceptable: rollup + up to `MAX_REPAIR_ITERS=2`
+  concurrent swap attempts should add ≤ 1.5 s to the sync path in
+  the common case; worst case dispatches to the existing
+  `/plan/meals/async` queue.
+- Reuse SPEC-009's content-addressed recipe cache to avoid
+  recomputing nutrients for repeated recipes and swaps.
+
+### 3.2 Non-goals
+
+- **No swap UX on its own.** ADR-005 covers user-initiated
+  substitution, cook mode, and the grocery list. This spec exposes
+  `/swap`; ADR-005 wires additional UX on top.
+- **No learning loop from repairs.** ADR-004 owns that; we emit
+  structured repair events it can subscribe to.
+- **No eaten rollup or adherence.** ADR-006 — but the repair
+  surface here is designed to be reused there.
+- **No optimization beyond greedy repair.** A future ILP over
+  candidate swaps is out of scope; v1 stays greedy with bounded
+  iterations.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 New flow
+
+```mermaid
+sequenceDiagram
+    participant API
+    participant Orch as Orchestrator
+    participant MPA as meal_planning_agent
+    participant GR as guardrail
+    participant RU as nutrient_rollup
+    participant Tol as tolerances
+    participant Store
+
+    API->>Orch: POST /plan/meals
+    Orch->>MPA: run
+    MPA-->>Orch: suggestions[]
+    Orch->>GR: _record_suggestions (SPEC-007)
+    GR-->>Orch: recorded[] + dropped[]
+
+    Orch->>Tol: build_for_profile(profile, plan.clinical_clamps)
+    Orch->>RU: rollup_plan(recorded, targets, tolerances)
+    RU-->>Orch: rollup with breaches
+    loop up to MAX_REPAIR_ITERS
+        alt no breaches
+            break
+        else breaches present
+            Orch->>Orch: rank breaches, pick target recipe
+            Orch->>MPA: regenerate_with_constraint(rec, breach)
+            Orch->>GR: re-check
+            alt pass
+                Orch->>RU: rollup_plan (updated)
+                RU-->>Orch: rollup
+            else reject
+                Orch->>Orch: record repair failure
+            end
+        end
+    end
+    Orch->>Store: persist rollup snapshot + repair history
+    Orch-->>API: MealPlanResponse (rollup, repair_history, breaches_remaining)
+```
+
+### 4.2 Tolerance configuration
+
+New file:
+`backend/agents/nutrition_meal_planning_team/tolerances/defaults.yaml`
+
+```yaml
+version: "1.0.0"
+per_day:
+  kcal:           { lower_pct: -0.10, upper_pct: 0.10 }
+  protein_g:      { lower_pct: -0.10, upper_pct: 0.25 }
+  carbs_g:        { lower_pct: -0.15, upper_pct: 0.15 }   # band-only outside clinical overrides
+  fat_g:          { lower_pct: -0.20, upper_pct: 0.20 }
+  fiber_g:        { lower_pct: -0.20, upper_pct: null }
+  sodium_mg:      { upper_pct: 0.10, cap_absolute: 2300 } # DRI upper
+  saturated_fat_g: { upper_pct: 0.10, cap_absolute_pct_kcal: 0.10 }
+per_meal:
+  sodium_mg:      { cap_absolute: 800 }
+  carbs_g:        { cap_absolute: null }                 # populated from clinical for T2D
+per_week:
+  iron_mg:        { lower_pct: -0.20, upper_pct: null }
+  vitamin_d_mcg:  { lower_pct: -0.20, upper_pct: null }
+  vitamin_b12_mcg: { lower_pct: -0.20, upper_pct: null }
+  calcium_mg:     { lower_pct: -0.15, upper_pct: null }
+  vitamin_k_mcg:  { lower_pct: -0.20, upper_pct: null }
+```
+
+Rules:
+
+- `defaults.yaml` is the baseline. Clinical overrides from ADR-001
+  (e.g. HTN sodium ≤ 1500 mg/day; CKD-3 per-meal phosphorus cap;
+  T2D carbs-per-meal cap) compose on top.
+- Per-profile overrides live on `ClientProfile.tolerance_overrides`
+  (additive field) for advanced users who want tighter bands. No
+  UI for this in v1; admin-only via `PATCH /profile`. UX consumer
+  shows up in ADR-006 or later.
+- `tolerances/resolver.py` has a single function
+  `build_for_profile(profile, plan) -> Tolerances` that merges
+  defaults, clinical overrides, and profile overrides
+  deterministically. Merge order: defaults → clinical → profile
+  (profile wins).
+- Versioned; the `TOLERANCES_VERSION` constant is persisted on
+  every rollup snapshot so a policy bump triggers visible repair
+  recomputation (see §4.6 replay behavior).
+
+### 4.3 Repair ranking
+
+When breaches exist, pick the target recipe to swap:
+
+1. Rank breaches by severity:
+   - `cap_breach` (per-meal or per-day hard cap) → severity 3.
+   - `band_miss` (day variance outside tolerance) → severity 2.
+   - `adequacy_gap` (weekly adequacy) → severity 1.
+2. For the top-ranked breach, identify contributing recipes:
+   - Per-meal breach → the single recipe responsible (trivial).
+   - Per-day breach → the recipe contributing the largest signed
+     delta to that nutrient. Tie-break by lowest confidence, then
+     by latest `suggested_date` (closer to "now" = more
+     user-visible → swap later ones first to minimize churn on
+     near-term days).
+   - Per-week adequacy → recipe with the lowest per-serving value
+     of the deficient nutrient (swap in something richer).
+3. Skip recipes with `recipe_confidence < 0.7` (SPEC-009). Low-
+   confidence recipes are not reliable swap targets; they get
+   surfaced to the user with a "please clarify" chip.
+4. Skip recipes the user has previously liked (rating ≥ 4 / would
+   make again) via `meal_feedback_store`. These are preserved
+   whenever possible; the repair loop prefers swapping recipes
+   without explicit positive feedback.
+
+### 4.4 Repair prompt
+
+New `meal_planning_agent.regenerate_with_constraint(rec, breach,
+profile, plan) -> Optional[MealRecommendation]`:
+
+- Reuses SPEC-007's single-suggestion structured-output schema.
+- Constraint block is explicit and numeric:
+  ```
+  Replace this Tuesday lunch. Keep meal_type=lunch, suggested_date=2026-04-21.
+  Requirements:
+    - ≥35 g protein (current recipe has 18 g).
+    - ≤800 mg sodium per serving.
+    - Prep + cook ≤ 20 minutes.
+  Forbidden ingredients (from profile): cashew, peanut, ...
+  Match the user's past preferences: one-pan meals, chicken or tofu, Mediterranean flavors.
+  ```
+- The agent emits one `MealRecommendation`; the orchestrator passes
+  it through SPEC-007's guardrail before replacing.
+- If the guardrail rejects the replacement twice consecutively, the
+  repair attempt is abandoned; the original recipe stays and the
+  breach is surfaced unresolved.
+
+### 4.5 Loop bounds
+
+- `MAX_REPAIR_ITERS = 2` whole-loop iterations (recompute rollup
+  → repair → recompute → stop).
+- Within a single iteration, all independent repairs (different
+  target recipes) dispatch concurrently.
+- Stop early if no breaches remain or if the last iteration made
+  no forward progress (breach count did not decrease and the
+  highest-severity breach did not drop).
+- Total extra LLM calls per plan in the worst case: O(breaches)
+  per iteration × 2 iterations. Budget: ≤ 10 regenerations
+  total; anything beyond gets truncated with remaining breaches
+  surfaced.
+
+### 4.6 API changes
+
+`MealPlanResponse` (additive):
+
+```python
+class RepairAttempt(BaseModel):
+    iteration: int
+    recipe_id: str
+    replaced_recipe_id: Optional[str]
+    breach_reason: str               # nutrient:scope e.g. "protein_g:per_day"
+    outcome: Literal["succeeded", "guardrail_rejected", "llm_failed", "skipped"]
+    delta: dict[str, float]          # change in nutrients after swap
+
+class MealPlanResponse(BaseModel):
+    client_id: str
+    suggestions: List[MealRecommendationWithId]
+    dropped: List[DroppedSuggestion]
+    rollup: PlanRollup
+    breaches_remaining: List[NutrientBreach]
+    repair_history: List[RepairAttempt]
+    tolerances_version: str
+    guardrail_version: str
+    rollup_version: str
+```
+
+New endpoints:
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/plan/meals/{plan_id}/recipes/{rec_id}/swap` | Replace a single recipe; optional body `{reason?: str, constraint?: SwapConstraint}`. Returns the new recipe + updated plan rollup + per-swap delta |
+| `GET`  | `/plan/meals/{plan_id}/rollup` | Returns current rollup snapshot (uses stored snapshot; does not recompute) |
+| `POST` | `/plan/meals/{plan_id}/rerepair` | Force a fresh repair pass; rate-limited |
+
+`SwapConstraint` lets callers specify additional constraints for
+user-initiated swaps (e.g. "out of Greek yogurt; suggest a
+replacement"). ADR-005's substitution path posts here with a
+`SwapConstraint` describing the missing ingredient.
+
+### 4.7 Persistence
+
+Migration `006_plan_rollup_and_repair.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS nutrition_plan_rollups (
+    plan_id          TEXT PRIMARY KEY,
+    client_id        TEXT NOT NULL,
+    rollup_json      JSONB NOT NULL,            -- PlanRollup snapshot
+    breaches_remaining JSONB NOT NULL,
+    repair_history   JSONB NOT NULL,
+    tolerances_version TEXT NOT NULL,
+    rollup_version   TEXT NOT NULL,
+    data_version     TEXT NOT NULL,             -- SPEC-008 version
+    computed_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX ON nutrition_plan_rollups (client_id, computed_at DESC);
+
+CREATE TABLE IF NOT EXISTS nutrition_recipe_nutrient_cache (
+    cache_key         TEXT PRIMARY KEY,
+    recipe_nutrients  JSONB NOT NULL,
+    data_version      TEXT NOT NULL,
+    rollup_version    TEXT NOT NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX ON nutrition_recipe_nutrient_cache (data_version, rollup_version);
+```
+
+Recipe cache is populated on every rollup and read on swaps /
+re-rollups. Invalidation is trivial: a version bump makes prior
+rows stale; a periodic job garbage-collects rows whose versions
+are older than the current pair.
+
+### 4.8 Async path
+
+Sync `/plan/meals` budget is: guardrail (existing SPEC-007
+regeneration) + rollup + up to 2 × concurrent swaps.
+
+Expected wall-clock:
+- Rollup: ≤ 25 ms (SPEC-009 benchmark).
+- Repair iteration with 2 concurrent swaps: ~1 × swap latency
+  (meal LLM call, typically 1–3 s).
+- Total sync budget: ≤ 6 s worst case.
+
+If the orchestrator detects high repair pressure (e.g. breaches
+> 4 at first rollup), it dispatches the full repair loop to the
+existing `/plan/meals/async` path and returns a pending job
+immediately. The `ClientProfile` has a `prefer_sync_plan` flag
+(default true) the UI can honor.
+
+### 4.9 Repair event stream
+
+Each `RepairAttempt` emits a structured event to the team's
+internal event bus:
+
+```json
+{
+    "event": "nutrition.repair_attempt",
+    "plan_id": "...",
+    "client_id": "...",
+    "iteration": 1,
+    "breach_reason": "protein_g:per_day",
+    "outcome": "succeeded",
+    "delta": { "protein_g": 17.0, "sodium_mg": -200.0 },
+    "tolerances_version": "1.0.0"
+}
+```
+
+ADR-004 subscribes (future) to feed the learned-preferences
+tracker ("consistently low-protein plans → bump protein emphasis
+in the planner prompt"). This spec emits the events; the consumer
+is out of scope.
+
+### 4.10 UI changes
+
+- **Daily totals band** above each day's recipe cards:
+  `Mon: 2,140 kcal / 135 g P / 210 g C / 78 g F` plus a colored
+  badge: green (in-band), yellow (band-miss), red (cap-breach).
+  Clicking expands to show per-nutrient variance vs. target.
+- **"Adjusted" badge** on any recipe that was swapped during
+  repair, with a small "why?" tooltip: *"We replaced a low-protein
+  dinner with this higher-protein option to meet your daily
+  target."* Transparency is the point.
+- **Breaches-remaining banner** at the top of the plan if any
+  unresolved breach after repair: *"Your plan is 15 g short on
+  protein today. Try the swap button on any dinner to adjust."*
+- **Swap button** on every recipe card (ADR-005 expands the UX).
+
+### 4.11 Observability
+
+OTel counters:
+
+- `nutrition.rollup.computed{cohort}`.
+- `nutrition.rollup.breaches{nutrient, scope}`.
+- `nutrition.repair.attempt{outcome}`.
+- `nutrition.repair.iteration_count` histogram.
+- `nutrition.repair.breaches_remaining` histogram.
+- `nutrition.recipe_cache.{hit, miss}`.
+- `nutrition.swap.endpoint{origin}` — origin ∈ `repair | user | substitution`.
+
+Alerting: `breaches_remaining > 2` for >10% of plans in a rolling
+hour → investigate (prompt drift, tolerance too tight, or KB gap).
+
+### 4.12 Priority-grouped work items
+
+| # | Item | Priority |
+|---|------|----------|
+| W1 | `tolerances/` module with `defaults.yaml`, loader, merge logic, tests | P0 |
+| W2 | Migration `006_plan_rollup_and_repair.sql` + schema registration | P0 |
+| W3 | Orchestrator: integrate rollup post-guardrail + persist snapshot | P0 |
+| W4 | Repair ranking (§4.3) + targeted-swap helper | P0 |
+| W5 | `meal_planning_agent.regenerate_with_constraint` + structured-output schema | P0 |
+| W6 | Repair loop (concurrent intra-iteration + bounded iterations) | P0 |
+| W7 | `MealPlanResponse` fields (`rollup`, `repair_history`, `breaches_remaining`, versions) | P0 |
+| W8 | Recipe nutrient cache read/write wrapper around SPEC-009's `compute_recipe_nutrients` | P1 |
+| W9 | `/swap` endpoint + `SwapConstraint` shape | P0 |
+| W10 | `/rollup` endpoint + `/rerepair` endpoint (rate-limited) | P1 |
+| W11 | Repair event emission | P1 |
+| W12 | UI: daily totals + variance badge | FE | P1 |
+| W13 | UI: "Adjusted" badge + tooltip; breaches-remaining banner | FE | P1 |
+| W14 | Async-path fallback (high repair pressure → job) | P1 |
+| W15 | Benchmarks: sync `/plan/meals` p99 ≤ 6 s, `/swap` p99 ≤ 4 s | P2 |
+
+---
+
+## 5. Rollout Plan
+
+Feature flag `NUTRITION_ROLLUP_AND_REPAIR` (off → today's behavior,
+on → SPEC-010 pipeline). Flag lives in unified config.
+
+### Phase 0 — Foundation (P0)
+- [ ] SPEC-008 and SPEC-009 frozen at 1.0.0.
+- [ ] W1, W2 landed. Migration in staging. No behavior change.
+
+### Phase 1 — Shadow rollup (P0)
+- [ ] W3 (rollup only, no repair) behind flag.
+- [ ] Shadow mode: for flag-off users, compute rollup in a
+      background task after the plan ships; store snapshots;
+      review tolerance breach rates for a week.
+- [ ] Goal: understand how far off today's plans are. Calibration
+      input for `defaults.yaml` before we start repairing.
+
+### Phase 2 — Repair behind flag (P0)
+- [ ] W4–W7, W9 landed behind flag.
+- [ ] Flag on for internal team profiles.
+- [ ] Monitor: `repair.iteration_count`, `breaches_remaining`,
+      swap LLM latency, user-visible plan stability.
+
+### Phase 3 — UI + ramp (P1)
+- [ ] W10, W12, W13 shipped.
+- [ ] Clinical reviewer signs off on `defaults.yaml` v1 values.
+- [ ] 10% → 25% → 50% → 100% over three weeks. At each step:
+      - Watch p99 plan latency.
+      - Watch `breaches_remaining` distribution.
+      - Watch whether users regenerate plans more or less (proxy
+        for satisfaction).
+
+### Phase 4 — Cleanup (P1/P2)
+- [ ] W8 recipe cache live and measured.
+- [ ] W11 repair events emitted.
+- [ ] W14 async fallback live.
+- [ ] W15 benchmarks baselined.
+- [ ] Flag default on; flag-removal scheduled.
+
+### Rollback
+- Flag off → legacy path; rollup/repair skipped; DB tables inert.
+- Migration is additive; no rollback needed.
+- Stored snapshots retained for audit; no user data destroyed.
+
+---
+
+## 6. Verification
+
+### 6.1 Unit tests
+
+- `test_tolerances_merge.py` — defaults + clinical + profile
+  merge in the right order; profile wins; clinical wins over
+  defaults.
+- `test_repair_ranking.py` — breach ranking + recipe selection
+  prefer low-confidence and not-yet-liked recipes; tie-break by
+  `suggested_date`.
+- `test_regenerate_with_constraint.py` — prompt contains the
+  specific numeric requirements; structured-output rejected if
+  schema violates.
+
+### 6.2 Integration tests
+
+- `test_plan_meals_rollup_only.py` — flag on, no breaches:
+  response contains rollup; repair_history empty; versions
+  populated.
+- `test_plan_meals_repair_success.py` — known protein-deficient
+  LLM fixture triggers one repair iteration; replacement lifts
+  protein into band; breaches_remaining empty.
+- `test_plan_meals_repair_exhausted.py` — scenario where no swap
+  satisfies all constraints after MAX_REPAIR_ITERS; response
+  contains breaches_remaining with clear reasons; no exception.
+- `test_swap_endpoint.py` — `POST /swap` with a
+  `SwapConstraint{out_of: [greek_yogurt]}` returns a new recipe
+  that passes guardrail + reports delta; rollup snapshot updated.
+- `test_swap_guardrail_still_enforces.py` — swap that violates
+  allergen guardrail is rejected; original recipe preserved;
+  repair attempt recorded as `guardrail_rejected`.
+- `test_rollup_cache_key_stable.py` — identical recipes across
+  plans produce the same recipe-cache key; version bump
+  invalidates.
+- `test_high_repair_pressure_dispatches_async.py` — synthetic plan
+  with 6+ breaches dispatches to async; sync endpoint returns a
+  job id.
+
+### 6.3 Golden plan tests
+
+`tests/golden/plans/` — 10 end-to-end plan scenarios:
+
+- Balanced 7-day plan → no repairs, clean rollup.
+- Protein-deficient plan → one repair, rollup recovers.
+- Sodium over-cap plan → two repairs needed, one succeeds, one
+  exhausted (sodium-tight allergens prevent full fix); expected
+  `breaches_remaining` present.
+- T2D clinical per-meal carb cap breach → single-recipe swap.
+- Plan fixture with a recipe the user rated 5★ previously → the
+  repair loop does not swap it.
+
+Each golden records the expected `repair_history` and
+`breaches_remaining` shape.
+
+### 6.4 Shadow-mode calibration (Phase 1)
+
+Two weeks of shadow rollup data reviewed with the clinical
+reviewer. Outcomes:
+
+- Confirm `defaults.yaml` v1 tolerances produce a reasonable
+  breach distribution (not "everything breaches" and not "nothing
+  ever breaches").
+- Adjust outlier bands before Phase 2.
+
+### 6.5 Phase 3 ramp gates
+
+- `repair.iteration_count` median ≤ 1 on typical plans.
+- Sync-path p99 plan latency ≤ 6 s.
+- `breaches_remaining` median ≤ 1 per plan after repair.
+- User regeneration rate at 10% does not exceed pre-launch
+  baseline by more than 20% (proxy for satisfaction).
+
+### 6.6 Observability
+
+- All §4.11 counters emit in staging and land on the dashboard.
+- Repair events flow to the internal bus; ADR-004 consumer stubbed
+  in this spec's phase-4 work.
+
+### 6.7 Copy review
+
+- "Adjusted" tooltip, breaches-remaining banner, and variance
+  badges reviewed against the ADR-006 §6.5 copy checklist: neutral,
+  informative, never shame-framed.
+
+### 6.8 Cutover criteria
+
+- All P0/P1 tests green.
+- Phase 3 ramp completed with monitoring stable; no unresolved
+  incident.
+- Clinical reviewer sign-off on tolerances + shadow-mode
+  calibration.
+- Team lead + on-call approve promotion.
+
+---
+
+## 7. Open Questions
+
+- **Tolerance defaults.** `defaults.yaml` v1 values are educated
+  starting points. Phase 1 shadow data will recalibrate them.
+  Expect one minor version bump on tolerances before Phase 3 ramp.
+- **Swap selection when multiple breaches are tied.** Current
+  ranking has a tie-break rule (later date first); alternative is
+  user-configurable. v1 ships with the fixed rule; we revisit if
+  Phase 3 data shows frustration ("why did you swap my Friday
+  dinner instead of Monday lunch?").
+- **"Liked meals are preserved" rule vs. safety.** If the only
+  recipe contributing to a sodium breach is one the user rated
+  5★, we currently skip it and surface the breach unresolved.
+  Alternative is to swap it anyway and flag the swap. v1 preserves;
+  users can manually override via `/swap`.
+- **Tolerance overrides UI.** We deliberately do not ship a UI for
+  per-profile tolerance overrides in v1. Advanced users and
+  clinician workflows are a separate spec when a consumer appears.
+- **Repair loop for async plans.** Currently the async path runs
+  the same repair loop. High-latency swap LLM calls can make async
+  plans take minutes. Acceptable for v1; a future optimization
+  could parallelize across iterations if the dependency graph
+  allows.

--- a/system_design/specs/SPEC-011-nutrition-preference-extraction.md
+++ b/system_design/specs/SPEC-011-nutrition-preference-extraction.md
@@ -1,0 +1,538 @@
+# SPEC-011: Preference signal extraction from meal feedback
+
+| Field       | Value                                                    |
+|-------------|----------------------------------------------------------|
+| **Status**  | Proposed                                                 |
+| **Author**  | Nutrition & Meal Planning team                           |
+| **Created** | 2026-04-17                                               |
+| **Priority**| P0 (blocks SPEC-012, SPEC-013)                           |
+| **Scope**   | New module `backend/agents/nutrition_meal_planning_team/preferences/extractor/`, additive feedback handling, Postgres additions, `llm_service` structured-output integration |
+| **Depends on** | SPEC-005 (canonical ids for ingredient tagging), SPEC-009 (recipe parsed ingredients + cooking method) |
+| **Implements** | ADR-004 §1 (preference dimensions), §2 (feedback extraction) |
+
+---
+
+## 1. Problem Statement
+
+ADR-004 argues the learning loop as currently implemented extracts
+almost no signal per feedback event: `_summarize_history` returns a
+comma-separated list of meal *names*, free-text notes are discarded
+entirely, and the planner is asked to generalize from raw titles.
+This spec is the first of three that implement ADR-004 — it is the
+**extraction** layer: turn one `FeedbackRecord` + the recipe it
+refers to into structured per-dimension signals that SPEC-012 can
+aggregate into a user's learned-preference record.
+
+This spec does not update preferences, feed the planner, or change
+UI. It ships a pure extraction module that, given a (recipe,
+feedback) pair, returns a deterministic-shape `FeedbackSignals`
+payload. Keeping extraction isolated is deliberate: it is the only
+component that requires an LLM call, and it is the component most
+likely to drift across model versions, so it gets its own tests,
+schema, and version stamp.
+
+---
+
+## 2. Current State
+
+### 2.1 Today's feedback flow
+
+```mermaid
+flowchart LR
+    User -->|POST /feedback| API
+    API -->|FeedbackRequest| Orch
+    Orch -->|record_feedback| Store[(meal_feedback_store)]
+    Store -->|next plan| Summary["_summarize_history<br/>(meal names only)"]
+    Summary -->|names list| MPA[meal_planning_agent]
+```
+
+- `FeedbackRecord.notes: str` is persisted but never read by any
+  downstream logic.
+- `rating` and `would_make_again` are the only numeric signals; used
+  binary-ish by `_summarize_history`
+  ([meal_planning_agent/agent.py:36-55](backend/agents/nutrition_meal_planning_team/agents/meal_planning_agent/agent.py:36)).
+
+### 2.2 Gaps
+
+1. No structured dimensions — all signal is flattened to a meal
+   name.
+2. Notes discarded; the richest feedback data is write-only.
+3. No way to reason about "why" a meal was liked — the single
+   biggest generalization blocker.
+4. No per-dimension ground truth that SPEC-012 can update against
+   or SPEC-013 can retrieve from.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- Ship a pure module `preferences/extractor/` that exposes
+  `extract_signals(recipe, feedback) -> FeedbackSignals`.
+- Schema-locked output via `llm_service` structured-output contract
+  (PR #184). No regex, no free-form parsing.
+- Each signal carries dimension, direction, magnitude, and a short
+  verbatim evidence snippet (for the UI "we learned this because
+  you said X").
+- Extract from **both** the numeric signals (rating,
+  would_make_again) and the free-text notes; the two are combined
+  in the output but tagged by their source so SPEC-012 can weight
+  them differently.
+- Write extracted signals to Postgres for every feedback event.
+  SPEC-012 reads from there.
+- Failure-closed: if extraction fails, persist the raw feedback
+  unchanged and emit a structured failure event — do not block the
+  user's feedback response.
+
+### 3.2 Non-goals
+
+- **No preference aggregation.** Bayesian smoothing, EWMA, and
+  per-user rolling scores live in SPEC-012.
+- **No retrieval.** Embedding recipes, top-K past hits, few-shot
+  injection — all SPEC-013.
+- **No UI.** "What we've learned about you" panel lives in SPEC-013.
+- **No prompt changes to the meal planner.** The planner continues
+  to use the existing name-list summarizer until SPEC-012 ships; we
+  change one thing at a time.
+- **No cross-user signals.** Per-user only. Collaborative filtering
+  is a future ADR.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 Module layout
+
+```
+backend/agents/nutrition_meal_planning_team/preferences/extractor/
+├── __init__.py               # extract_signals, EXTRACTOR_VERSION
+├── version.py                # EXTRACTOR_VERSION = "1.0.0"
+├── types.py                  # FeedbackSignals, Signal, Dimension enum
+├── recipe_features.py        # derive deterministic tags from a recipe
+├── numeric.py                # signals derivable from rating + would_make_again
+├── llm_extractor.py          # structured-output LLM call on the note
+├── errors.py
+└── tests/
+```
+
+### 4.2 Output types
+
+```python
+class Dimension(str, Enum):
+    ingredient = "ingredient"              # key: canonical_id
+    cuisine = "cuisine"                    # key: cuisine_tag
+    flavor = "flavor"                      # key: flavor_tag
+    texture = "texture"                    # key: texture_tag
+    format = "format"                      # key: format_tag
+    protein = "protein"                    # key: protein_tag
+    prep_time = "prep_time"                # key: "weekday" | "weekend"
+    portion = "portion"                    # key: "size"
+    novelty = "novelty"                    # key: "familiarity"
+
+class SignalSource(str, Enum):
+    rating = "rating"
+    would_make_again = "would_make_again"
+    note = "note"
+    derived = "derived"       # from recipe features x numeric
+
+@dataclass(frozen=True)
+class Signal:
+    dimension: Dimension
+    key: str                  # dimension-specific (see §4.3)
+    strength: float           # -1.0..+1.0
+    source: SignalSource
+    evidence: Optional[str] = None   # ≤200 char verbatim snippet
+    confidence: float = 1.0
+
+@dataclass(frozen=True)
+class FeedbackSignals:
+    recommendation_id: str
+    client_id: str
+    signals: tuple[Signal, ...]
+    extracted_at: str         # ISO timestamp
+    extractor_version: str
+    llm_ok: bool              # False if the LLM-on-note step failed
+    issues: tuple[str, ...]   # failure reasons if any
+```
+
+### 4.3 Dimension taxonomies
+
+All closed enums. Additions are minor version bumps.
+
+- **`ingredient`**: key = SPEC-005 `canonical_id` (e.g. `cilantro`,
+  `tofu`, `chicken_thigh_raw`).
+- **`cuisine`**: `italian`, `french`, `japanese`, `chinese_cantonese`,
+  `chinese_sichuan`, `korean`, `thai`, `vietnamese`, `indian_north`,
+  `indian_south`, `mexican`, `mediterranean`, `levantine`,
+  `american_comfort`, `nordic`, `ethiopian`, `peruvian`, `caribbean`,
+  `fusion`, `other`.
+- **`flavor`**: `spicy`, `umami`, `sweet`, `sour`, `bitter`,
+  `fermented`, `smoky`, `buttery`, `citrus`, `herbaceous`.
+- **`texture`**: `crispy`, `crunchy`, `creamy`, `chewy`, `soft`,
+  `silky`, `juicy`, `dry`.
+- **`format`**: `one_pan`, `sheet_pan`, `stir_fry`, `no_cook`,
+  `meal_prep`, `handheld`, `bowl`, `soup_stew`, `casserole`,
+  `salad`, `grain_bowl`.
+- **`protein`**: `chicken`, `beef`, `pork`, `lamb`, `fish`,
+  `shellfish`, `egg`, `dairy`, `tofu`, `tempeh`, `seitan`,
+  `legume`, `nuts`, `mixed`.
+- **`prep_time`**: key ∈ `{weekday, weekend}`, strength maps to
+  tolerance for time on that day type.
+- **`portion`**: key = `size`; strength < 0 = too small, > 0 = too
+  large.
+- **`novelty`**: key = `familiarity`; strength < 0 = wanted more
+  familiar, > 0 = wanted more adventurous.
+
+The enum file lives at `preferences/taxonomy.py` and is shared with
+SPEC-012 and SPEC-013 so all three modules see the same keyspace.
+
+### 4.4 Recipe-feature derivation (`recipe_features.py`)
+
+Deterministic, no LLM. Given a `MealRecommendation` (post
+SPEC-007 + SPEC-009), produce:
+
+- `cuisine_tag`: taken from `MealRecommendation.cuisine_tag`
+  (additive field; defaulted `other`). The meal-planning agent
+  emits it; if absent, defaults to `other` with an `issue`.
+- `flavor_tags`, `texture_tags`, `format_tag`, `protein_tag`:
+  similarly emitted by the planner under §4.8 prompt changes; with
+  sensible defaults derived from ingredients when absent (e.g.
+  protein_tag inferred from the canonical_id of the largest-mass
+  protein ingredient per SPEC-009).
+- `canonical_ingredients`: from SPEC-005 parser outputs already
+  attached by SPEC-007.
+- `prep_time_bucket`: from recipe's cook + prep times; `weekday` if
+  recipe is on Mon–Fri and total ≤ threshold, `weekend` otherwise.
+- `familiarity_score`: 1.0 if the canonical ingredient set overlaps
+  ≥70% with the user's past 30 meals; 0.0 otherwise. Requires
+  SPEC-012's historical view (accepted as a soft dep; v1 of
+  extractor does not block on it and passes in a
+  `UserHistorySummary` from the caller).
+
+Derivation is deterministic and cheap; cached per `(recipe_id,
+rollup_version)` by the caller.
+
+### 4.5 Numeric signal extraction (`numeric.py`)
+
+Given `(rating, would_make_again, recipe_features)`:
+
+- A high positive signal (rating ≥ 4 and/or `would_make_again=true`)
+  attaches positive `strength` to every derived feature (cuisine,
+  format, protein, top-K ingredients by mass, flavor, texture). The
+  exact strength mapping is:
+  ```
+  rating 5, wma=true  → strength  +0.7
+  rating 4, wma=true  → strength  +0.5
+  rating 5, wma=null  → strength  +0.5
+  rating 4, wma=null  → strength  +0.3
+  rating 3            → strength   0.0 (no signal; neutral)
+  rating 2, wma=false → strength  -0.4
+  rating 1, wma=false → strength  -0.6
+  wma=false alone     → strength  -0.3
+  ```
+- These are **source=derived** signals — they are inferences, not
+  direct user statements. SPEC-012 weights `derived` below `note`
+  when both exist for the same key.
+
+### 4.6 LLM extraction on the note (`llm_extractor.py`)
+
+- Invoked only when `feedback.notes` is non-empty.
+- Uses `llm_service` with a locked structured-output schema:
+
+```python
+class NoteExtractionPayload(BaseModel):
+    signals: List[NotedSignal]
+
+class NotedSignal(BaseModel):
+    dimension: Dimension
+    key: str                      # must be a value in the closed taxonomy
+    strength: float = Field(ge=-1.0, le=1.0)
+    evidence: str = Field(max_length=200)
+```
+
+- Prompt is short and strict. Key rules in the system prompt:
+  - *"You are a parser. Extract only what the note says. Do not
+    predict or invent."*
+  - *"Every `key` must be one of the provided taxonomy values
+    exactly. If the user's word does not map to the taxonomy,
+    leave the signal out."*
+  - *"Evidence must be a verbatim substring of the note."*
+- The prompt includes the entire taxonomy (it is small enough —
+  ~80 values total). No fuzzy matching at output time.
+- Validation:
+  - Schema rejection → `llm_ok=false`; note verbatim persisted;
+    issue = `schema_rejected`.
+  - Evidence not a substring of the note → drop that signal with
+    issue = `evidence_mismatch`.
+  - Key outside taxonomy → drop that signal with issue =
+    `key_outside_taxonomy` (defense against a model that ignores
+    the rule).
+
+### 4.7 Orchestration
+
+```python
+def extract_signals(
+    recipe: MealRecommendationWithId,
+    feedback: FeedbackRecord,
+    user_history: UserHistorySummary,    # for familiarity_score
+) -> FeedbackSignals:
+    features = derive_recipe_features(recipe, user_history)
+    numeric = numeric_signals(feedback, features)
+    note_signals: list[Signal] = []
+    llm_ok = True
+    if feedback.notes and feedback.notes.strip():
+        try:
+            note_signals = llm_extract(feedback.notes, taxonomy=TAXONOMY)
+        except Exception:
+            llm_ok = False
+    combined = merge(numeric, note_signals)
+    return FeedbackSignals(
+        recommendation_id=recipe.recommendation_id,
+        client_id=feedback.client_id,
+        signals=tuple(combined),
+        extracted_at=utcnow_iso(),
+        extractor_version=EXTRACTOR_VERSION,
+        llm_ok=llm_ok,
+    )
+```
+
+Merge rule: both `note` and `derived` can produce signals for the
+same `(dimension, key)`. They are kept as separate `Signal` entries
+(not summed). SPEC-012 decides how to aggregate.
+
+### 4.8 Meal-planner prompt additions (minor)
+
+The planner must emit the tags needed for `recipe_features.py`.
+Additive fields on `MealRecommendation`:
+
+```python
+class MealRecommendation(BaseModel):
+    # existing...
+    cuisine_tag: Optional[str] = None
+    flavor_tags: List[str] = []
+    texture_tags: List[str] = []
+    format_tag: Optional[str] = None
+    protein_tag: Optional[str] = None
+```
+
+The meal-planner prompt is amended to emit them using the taxonomy
+values. Absence is tolerated; derivation falls back to
+ingredient-based defaults (`preferences/taxonomy.py` has defaulting
+functions).
+
+### 4.9 API and persistence
+
+Additive handling on the existing feedback path:
+
+`POST /feedback` (existing):
+
+1. Persist the `FeedbackRecord` as today.
+2. Dispatch extraction asynchronously (background task in FastAPI;
+   the user's response is not delayed).
+3. On completion, persist `FeedbackSignals` to a new Postgres table
+   `nutrition_feedback_signals`. Failures are logged + persisted
+   with `llm_ok=false`.
+
+Migration `007_feedback_signals.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS nutrition_feedback_signals (
+    recommendation_id  TEXT PRIMARY KEY
+        REFERENCES nutrition_recommendations(recommendation_id) ON DELETE CASCADE,
+    client_id          TEXT NOT NULL,
+    signals_json       JSONB NOT NULL,
+    llm_ok             BOOLEAN NOT NULL,
+    issues_json        JSONB NOT NULL DEFAULT '[]'::jsonb,
+    extractor_version  TEXT NOT NULL,
+    extracted_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX ON nutrition_feedback_signals (client_id, extracted_at DESC);
+```
+
+No new HTTP endpoints in this spec; SPEC-013 exposes read APIs for
+signals and preferences.
+
+### 4.10 Observability
+
+- `preferences.extractor.invocations{outcome}` where outcome ∈
+  `ok | llm_error | schema_rejected | no_note`.
+- `preferences.extractor.note_length_histogram`.
+- `preferences.extractor.signals_per_feedback` histogram.
+- `preferences.extractor.latency_ms` histogram.
+- `preferences.extractor.dropped_signals{reason}` for
+  evidence-mismatch, key-outside-taxonomy, etc.
+
+### 4.11 Privacy
+
+- Notes are PII-adjacent and contain personal preferences. Log
+  redaction rule: note content is never logged at INFO or above;
+  only lengths and outcome classifications.
+- Evidence snippets stored in signals are bounded at 200 chars and
+  retained for the life of the profile; deleted on account
+  deletion via cascade.
+- Extraction LLM calls do not include `client_id` or the user's
+  profile beyond the note itself; only the taxonomy + prompt.
+
+### 4.12 Versioning
+
+`EXTRACTOR_VERSION = "MAJOR.MINOR.PATCH"`:
+
+- **MAJOR** — taxonomy removal/rename, output schema change.
+- **MINOR** — taxonomy addition, new signal source, mapping tweak.
+- **PATCH** — prompt or bug fix that does not change output shape.
+
+Re-extraction job (admin-only) can be triggered on a version bump
+to refresh signals for existing feedback. v1 does not auto-run the
+job; SPEC-012 coordinates invalidation.
+
+### 4.13 Priority-grouped work items
+
+| # | Item | Priority |
+|---|------|----------|
+| W1 | Module scaffolding, `version.py`, `types.py`, `errors.py` | P0 |
+| W2 | `taxonomy.py` closed enums + shared across SPEC-012/013 | P0 |
+| W3 | `recipe_features.py` derivation + fallback tests | P0 |
+| W4 | `numeric.py` with rating-to-strength table + tests | P0 |
+| W5 | `llm_extractor.py` with structured-output schema + validation | P0 |
+| W6 | `extract_signals` orchestration + merge rule tests | P0 |
+| W7 | Migration `007_feedback_signals.sql` + schema registration | P0 |
+| W8 | Feedback endpoint wiring (background dispatch + persistence) | P0 |
+| W9 | Meal-planner prompt additions to emit new tags | P1 |
+| W10 | Observability counters | P1 |
+| W11 | Re-extraction CLI tool (admin) | P2 |
+| W12 | Benchmarks: p99 ≤ 3 s per extraction with LLM; ≤ 50 ms without | P2 |
+
+---
+
+## 5. Rollout Plan
+
+Feature flag `NUTRITION_PREF_EXTRACTOR` (off → no extraction runs,
+on → extraction runs on every new feedback).
+
+### Phase 0 — Foundation (P0)
+- [ ] W1, W2, W7 landed. Migration in staging. No behavior change.
+
+### Phase 1 — Extractor behind flag (P0)
+- [ ] W3–W8 landed behind flag.
+- [ ] Flag on internal. Monitor extraction outcomes and latency.
+
+### Phase 2 — Dogfood + planner tags (P0/P1)
+- [ ] W9 planner prompt emits new tags; absence tolerated.
+- [ ] Review first 100 extracted signals manually against their
+      source notes. Reviewer: team lead + PM.
+- [ ] Acceptance gate: ≥85% of signals judged correct by reviewer;
+      zero signals with fabricated evidence (evidence-mismatch
+      rate < 1% of LLM-extracted signals).
+
+### Phase 3 — Ramp (P1)
+- [ ] 10% → 50% → 100% over two weeks.
+- [ ] Watch `dropped_signals{reason}` — high rates indicate
+      prompt or taxonomy issues.
+
+### Phase 4 — Cleanup (P1/P2)
+- [ ] W10, W11, W12 landed.
+- [ ] Flag default on; removal scheduled.
+
+### Rollback
+- Flag off → extraction skipped; existing `nutrition_feedback_signals`
+  rows retained; no user-visible impact.
+- Migration additive; no rollback needed.
+
+---
+
+## 6. Verification
+
+### 6.1 Unit tests
+
+- `test_numeric_strength_table.py` — every row in §4.5 produces the
+  expected strength; tied-rating cases handled.
+- `test_recipe_features_default.py` — missing cuisine/format/flavor
+  tags fall back to derivations; defaults never fail closed.
+- `test_llm_extractor_schema.py` — mocked LLM returning
+  schema-valid output parses cleanly; schema-invalid output raises
+  and is caught by the orchestrator.
+- `test_evidence_substring.py` — extractor drops signals whose
+  evidence is not a verbatim substring of the note.
+- `test_key_outside_taxonomy.py` — extractor drops signals with
+  unknown keys; issue recorded.
+
+### 6.2 Integration tests
+
+- `test_feedback_endpoint_triggers_extraction.py` — `POST /feedback`
+  returns promptly; background extraction completes; row appears
+  in `nutrition_feedback_signals` within 5 s.
+- `test_feedback_no_note.py` — feedback with empty notes still
+  produces numeric signals; `llm_ok=true` (LLM not called);
+  `source=derived` signals present.
+- `test_feedback_llm_failure.py` — LLM call raises; row is
+  persisted with `llm_ok=false`, `issues=['llm_error']`, numeric
+  signals still present.
+
+### 6.3 Fixture-based correctness tests
+
+`tests/fixtures/notes/` — 40 hand-labeled notes with expected
+structured signals:
+
+- "Loved the one-pan idea, but spicy was too much" →
+  `[format:one_pan:+, flavor:spicy:-]`.
+- "Great but portion was tiny" → `[portion:size:-]`.
+- "Too long to cook on a Tuesday" → `[prep_time:weekday:-]`.
+- "Would make again but not the cilantro" →
+  `[ingredient:cilantro:-]`.
+- "Perfect" → no note-derived signals (no specific evidence);
+  numeric positive signals from the rating stand alone.
+
+Each fixture's extracted signals must match expected by
+`(dimension, key, sign_of_strength)`. Exact strength values are
+not pinned.
+
+### 6.4 Reviewer audit (Phase 2)
+
+- 100 randomly sampled real extractions reviewed.
+- Acceptance: ≥85% judged correct; ≤5% over-interpretation; ≤1%
+  fabricated evidence.
+- Failures: prompt revisions land before Phase 3 ramp.
+
+### 6.5 Property tests
+
+- Extraction output is deterministic for fixed inputs when the
+  LLM step is mocked.
+- `extract_signals` never raises on any well-formed input (soft
+  contract): errors are captured on `FeedbackSignals.issues`.
+
+### 6.6 Privacy verification
+
+- Log redaction grep over staging logs: zero instances of note
+  content at INFO or above.
+- Account-deletion test: deleting a profile cascades to
+  `nutrition_feedback_signals`.
+
+### 6.7 Cutover criteria
+
+- All P0 tests green.
+- Phase 2 reviewer audit meets acceptance thresholds.
+- Zero user-facing latency regression on `POST /feedback`
+  (background dispatch, not blocking).
+- SPEC-012 open for work.
+
+---
+
+## 7. Open Questions
+
+- **How to weight `derived` vs `note` when both exist.** Defined
+  as SPEC-012's problem per §4.7. A reasonable first rule: a note
+  signal on the same key overrides a derived signal of the same
+  sign and amplifies opposite signs.
+- **Should we re-extract on taxonomy addition?** v1 no. Added
+  taxonomy keys simply cannot be assigned retroactively without
+  re-running; SPEC-012 only uses keys that exist at the time of
+  extraction. Documented.
+- **Cost.** Extraction runs once per feedback event. Typical users
+  submit a handful per week. Cost dominated by the LLM call on
+  non-empty notes. Budget: single-digit cents per user per month.
+  Acceptable.
+- **Ambiguous evidence.** Notes can contain statements in tension
+  ("loved it but won't make again"). We leave both signals in;
+  SPEC-012 aggregates. We deliberately do not try to resolve
+  contradictions at extraction time — too easy to lose signal.

--- a/system_design/specs/SPEC-012-nutrition-learned-preferences-aggregator.md
+++ b/system_design/specs/SPEC-012-nutrition-learned-preferences-aggregator.md
@@ -1,0 +1,486 @@
+# SPEC-012: Learned preferences aggregator and digest
+
+| Field       | Value                                                    |
+|-------------|----------------------------------------------------------|
+| **Status**  | Proposed                                                 |
+| **Author**  | Nutrition & Meal Planning team                           |
+| **Created** | 2026-04-17                                               |
+| **Priority**| P0 (blocks SPEC-013 retrieval; consumed by planner prompt update) |
+| **Scope**   | New module `backend/agents/nutrition_meal_planning_team/preferences/aggregator/`, Postgres additions, planner prompt integration, user-facing preference endpoints, admin override path |
+| **Depends on** | SPEC-011 (signal extraction) |
+| **Implements** | ADR-004 §1 (dimensions), §3 (update rule), §4 (planner integration), §6 (user-visible preference panel) |
+
+---
+
+## 1. Problem Statement
+
+SPEC-011 ships the extraction layer: every feedback event produces a
+`FeedbackSignals` record. This spec converts that stream into a
+stable, per-user `LearnedPreferences` record, exposes it to the
+planner as a digest, and makes it visible and editable by the user.
+
+The thesis of ADR-004 is that the signal per feedback event is weak
+because the aggregation is primitive. This spec is where the
+aggregation lives: a Bayesian-smoothed EWMA per (dimension, key),
+a minimum-evidence gate, per-profile overrides, and a compact
+digest shape the planner can prompt against.
+
+It is also the first spec that users see from this workstream. The
+"what we've learned about you" panel is a product-differentiating
+surface and is specified here so the contract between backend and
+UI is explicit.
+
+---
+
+## 2. Current State
+
+### 2.1 After SPEC-011
+
+- Every feedback event yields a `FeedbackSignals` row in
+  `nutrition_feedback_signals` with structured signals.
+- No aggregation. Planner still reads the legacy name-list
+  summarizer.
+
+### 2.2 Gaps
+
+1. No per-user rollup; signals accumulate but never consolidate.
+2. No time-weighting — old feedback treated the same as new.
+3. No minimum-evidence gate; a single strong note could dominate a
+   dimension.
+4. No planner-visible digest shape.
+5. No UI for users to see or correct what was learned.
+6. No override surface for user corrections or clinician direction.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- Ship a deterministic aggregator that turns the
+  `nutrition_feedback_signals` stream into a per-user
+  `LearnedPreferences` record.
+- Use a Bayesian-smoothed EWMA per (dimension, key) with explicit
+  decay, source weighting, and a minimum-evidence threshold.
+- Produce a compact `PreferenceDigest` for the planner (top-K
+  positive, top-K negative signals; short NL summary; exemplar
+  meal-name lists).
+- Expose GET/PUT/DELETE endpoints for users to inspect, pin,
+  exclude, or forget learned signals. Overrides always beat
+  learned values.
+- Update the meal-planner prompt to consume the digest instead of
+  the legacy name list.
+- Version the aggregator; keep schema migrations additive.
+
+### 3.2 Non-goals
+
+- **No retrieval or embeddings.** SPEC-013 covers similar-past-hit
+  retrieval and few-shot exemplar injection.
+- **No cross-user signal sharing.** Per-user only.
+- **No learning from cooking events.** Cooking events (ADR-005)
+  feed this aggregator through the same `FeedbackSignals` schema
+  when they land; the aggregator needs no change.
+- **No onboarding quiz.** Cold-start seeding via a quiz is listed
+  as v1.1 in ADR-004 §7 and is a separate spec.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 Module layout
+
+```
+backend/agents/nutrition_meal_planning_team/preferences/aggregator/
+├── __init__.py            # update_preferences, build_digest, AGGREGATOR_VERSION
+├── version.py             # AGGREGATOR_VERSION = "1.0.0"
+├── types.py               # LearnedPreferences, DimensionState, Score, PreferenceDigest
+├── update.py              # Bayesian EWMA + source weighting
+├── digest.py              # compute digest for planner
+├── overrides.py           # pin / exclude / forget merge logic
+├── errors.py
+└── tests/
+```
+
+### 4.2 Data shape
+
+```python
+@dataclass(frozen=True)
+class Score:
+    mean: float            # posterior mean in [-1.0, +1.0]
+    confidence: float      # 0..1 derived from pseudo-counts
+    evidence_count: int    # number of supporting feedback events
+    last_updated: str      # ISO
+
+@dataclass(frozen=True)
+class DimensionState:
+    scores: dict[str, Score]       # key -> Score
+    last_updated: str
+
+@dataclass(frozen=True)
+class Override:
+    action: Literal["pin_positive", "pin_negative", "exclude", "forget"]
+    value: Optional[float] = None  # pinned score if action=pin_*
+    reason: Optional[str] = None   # user-provided
+    author: str = "user"           # "user" | "clinician"
+    recorded_at: str = ""
+
+@dataclass(frozen=True)
+class LearnedPreferences:
+    client_id: str
+    dimensions: dict[Dimension, DimensionState]
+    overrides: dict[tuple[Dimension, str], Override]
+    aggregator_version: str
+    last_extraction_id: Optional[str]   # for idempotent resume
+```
+
+### 4.3 Update rule
+
+For each new `FeedbackSignals`:
+
+1. Decay current scores for each `(dimension, key)` by the age of
+   the last update:
+   ```
+   decayed_mean = current_mean * exp(-lambda * days_since_last)
+   decayed_alpha = current_alpha * exp(-lambda * days_since_last)
+   decayed_beta  = current_beta  * exp(-lambda * days_since_last)
+   ```
+   where `lambda = 0.02` per day (≈ half-life of ~35 days). The
+   decay acts on the pseudo-counts so confidence also ages.
+2. For each incoming signal, compute its effective weight:
+   ```
+   w = base_weight(source) * confidence
+     * (1 if source=note else 0.6)        # note signals weigh more
+     * (rating_amplifier)                 # up to 1.3x for 5★ + strong note
+   ```
+3. Update pseudo-counts using a Beta-Bernoulli-style update mapped
+   to a signed strength: positive contributions add to `alpha`,
+   negative to `beta`; magnitude scales both.
+4. Recompute posterior mean = `alpha / (alpha + beta)` rescaled to
+   `[-1, +1]`; confidence = `1 - 1/(alpha + beta + 1)`.
+5. Apply minimum-evidence gate: dimension/key with
+   `evidence_count < N_MIN` (default 3) is hidden from the digest
+   and the UI even if `confidence` is high. Stored anyway — we
+   surface it once evidence accumulates.
+
+All constants live in `update.py` and are tunable via a small YAML
+(`aggregator_config.yaml`) that is version-tagged.
+
+### 4.4 Override behavior
+
+Overrides are authoritative and always win:
+
+- `pin_positive` / `pin_negative` → digest uses the pinned value;
+  learned score is still updated in the background but not surfaced.
+- `exclude` → this (dimension, key) never appears in the digest or
+  planner prompt; still stored for transparency in the UI panel.
+- `forget` → erase both learned score and any prior override for
+  this (dimension, key). Required for privacy ("I corrected your
+  wrong inference and want it gone"). Writes to an audit log; next
+  feedback event can re-learn.
+
+### 4.5 Digest (`digest.py`)
+
+```python
+@dataclass(frozen=True)
+class PreferenceDigest:
+    top_positive: List[DigestItem]     # length <= K (default 6)
+    top_negative: List[DigestItem]     # length <= K
+    summary_nl: str                    # 1–3 sentences, LLM-authored; cached
+    exemplar_hits: List[str]           # meal names (top 5 highest-rated past meals)
+    exemplar_misses: List[str]         # meal names (3 recent low-rated)
+    digest_version: str
+    built_at: str
+
+@dataclass(frozen=True)
+class DigestItem:
+    dimension: Dimension
+    key: str
+    strength: float                    # posterior mean (or pinned)
+    confidence: float
+    source_note: Optional[str] = None  # "pinned" | "learned from N feedbacks" | "excluded"
+```
+
+Rules:
+
+- Selection: sort by `|strength| * confidence` and take top-K per
+  sign, excluding `exclude`-overridden entries.
+- The NL summary is generated by a lightweight LLM call when the
+  digest is built; cached on `LearnedPreferences` and refreshed
+  only when the top-K items change. Budget: ≤ 1 LLM call per user
+  per week on typical feedback cadence.
+- Exemplar lists come from `meal_feedback_store` ordered by rating;
+  exemplars are names only (no ingredients) in the digest —
+  retrieval of similar-past-hits is SPEC-013's job.
+- If fewer than `N_MIN` data points exist across the whole user
+  (cold start), `top_positive` and `top_negative` are empty and
+  `summary_nl` says so politely: "We're still learning what you
+  like."
+
+### 4.6 Planner integration
+
+`meal_planning_agent` prompt (post-SPEC-007, post-SPEC-010) is
+extended:
+
+- Legacy name-list summarizer is removed.
+- The prompt receives `PreferenceDigest` rendered as:
+  ```
+  What we've learned about this user (from 23 feedback events):
+    Leans toward: one-pan meals, chicken or legumes, umami + herbaceous
+    flavors, Mediterranean cuisine.
+    Leans away from: long weeknight prep, raw tofu, heavy cream sauces.
+    Past 5 hits: Chicken shawarma bowl, Shakshuka, Sheet-pan gnocchi, ...
+    Recent misses: Raw-tofu poke, Leek & potato soup.
+    User pins: avoid cilantro (user-set override).
+  ```
+- Exclusions from the override list appear as explicit "never
+  include" lines, not as soft preferences.
+- If the digest is empty (cold start), the prompt falls back to
+  profile-only behavior — exactly today's pre-SPEC-012 behavior
+  minus the legacy name-list noise.
+
+Digest shape is stable; prompt wording is not, so tweaks can land
+without changing the contract.
+
+### 4.7 Storage
+
+Migration `008_learned_preferences.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS nutrition_learned_preferences (
+    client_id          TEXT PRIMARY KEY
+        REFERENCES nutrition_profiles(client_id) ON DELETE CASCADE,
+    dimensions_json    JSONB NOT NULL,
+    overrides_json     JSONB NOT NULL DEFAULT '{}'::jsonb,
+    digest_json        JSONB,
+    aggregator_version TEXT NOT NULL,
+    last_extraction_id TEXT,
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS nutrition_preference_override_log (
+    id               BIGSERIAL PRIMARY KEY,
+    client_id        TEXT NOT NULL,
+    dimension        TEXT NOT NULL,
+    key              TEXT NOT NULL,
+    action           TEXT NOT NULL,
+    value            DOUBLE PRECISION,
+    reason           TEXT,
+    author           TEXT NOT NULL,
+    recorded_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+Aggregation runs as a background task triggered by each successful
+`nutrition_feedback_signals` insert. Idempotent: `last_extraction_id`
+on the preferences row prevents double-application if the task
+retries.
+
+### 4.8 API
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET`  | `/preferences/{client_id}` | Full `LearnedPreferences` + `PreferenceDigest` |
+| `GET`  | `/preferences/{client_id}/digest` | Digest only (lightweight; used by UI and planner internals) |
+| `PUT`  | `/preferences/{client_id}/override` | Body: `{dimension, key, action, value?, reason?}` |
+| `DELETE` | `/preferences/{client_id}/signal/{dimension}/{key}` | Forget a single learned point (writes `forget` override) |
+| `POST` | `/preferences/{client_id}/rebuild` | Admin-only. Rebuilds from `nutrition_feedback_signals` log. Used on `AGGREGATOR_VERSION` bump |
+
+Override writes flush the cached `digest_json` and trigger a digest
+recompute; the planner sees the new digest on the next plan.
+
+### 4.9 UI — "What we've learned about you"
+
+- Dedicated section on the profile page, or a slide-in panel
+  accessible from the plan screen.
+- Chips grouped by dimension:
+  ```
+  Loves:   [One-pan (8 feedbacks)]  [Chicken (5)]  [Umami (6)]  ...
+  Avoids:  [Long weeknight prep (4)]  [Raw tofu (3)]  [Cream sauces (3)]
+  Pinned:  [Cilantro — never include (you asked)]
+  ```
+- Each chip has actions: "That's right", "Not really — forget
+  this", "Pin it stronger".
+- Explanations under each chip: short provenance string (mined
+  from the highest-confidence supporting feedback note, capped at
+  140 chars). Uses the stored `evidence` snippets from SPEC-011.
+- Copy is neutral and affirmative; never shame-framed. Reviewed
+  against the ADR-006 §6.5 copy checklist.
+
+### 4.10 Clinician authoring
+
+Overrides can be written with `author=clinician` via an admin-only
+path (same one SPEC-002 uses for `clinician_overrides`). Clinician
+overrides are visually distinguished in the UI (subtle lock icon)
+and cannot be removed by the user — only replaced by a newer
+clinician write or a `forget` with admin auth.
+
+### 4.11 Observability
+
+- `preferences.aggregator.apply{outcome}` where outcome ∈
+  `applied | idempotent | failed`.
+- `preferences.aggregator.digest_recompute`.
+- `preferences.aggregator.decay_runs`.
+- `preferences.aggregator.dimensions_gated_by_n_min`.
+- `preferences.aggregator.override_written{action, author}`.
+- Latency histogram for update and digest computation.
+
+### 4.12 Versioning
+
+`AGGREGATOR_VERSION = "MAJOR.MINOR.PATCH"`:
+
+- **MAJOR** — update rule or decay semantics change.
+- **MINOR** — source-weight tuning, new source types.
+- **PATCH** — non-behavioral.
+
+On MAJOR bump, admin triggers `POST /preferences/{id}/rebuild`
+which re-runs aggregation from the underlying
+`nutrition_feedback_signals` stream. Minor bumps do not require
+rebuild; changes apply incrementally on next event.
+
+### 4.13 Priority-grouped work items
+
+| # | Item | Priority |
+|---|------|----------|
+| W1 | Module scaffolding, version, types | P0 |
+| W2 | Migration `008_learned_preferences.sql` + schema registration | P0 |
+| W3 | `update.py` Bayesian EWMA + source weighting + decay; unit tests | P0 |
+| W4 | `overrides.py` merge semantics + forget/pin/exclude logic | P0 |
+| W5 | Aggregation background task on `nutrition_feedback_signals` insert; idempotent via `last_extraction_id` | P0 |
+| W6 | `digest.py` top-K selection + empty cold-start behavior | P0 |
+| W7 | LLM NL-summary generation + cache invalidation | P1 |
+| W8 | API endpoints (§4.8) | P0 |
+| W9 | Planner prompt integration (digest → prompt text) | P0 |
+| W10 | UI panel: chips + provenance + actions | FE | P1 |
+| W11 | Clinician override admin path | P1 |
+| W12 | Observability counters + cold-start dashboard | P1 |
+| W13 | Rebuild CLI + admin endpoint | P2 |
+| W14 | Benchmarks: aggregation p99 ≤ 100 ms per event; digest build ≤ 200 ms | P2 |
+
+---
+
+## 5. Rollout Plan
+
+Flag `NUTRITION_LEARNED_PREFERENCES` (off → legacy name-list path,
+on → digest path). Planner prompt variant is switched by flag.
+
+### Phase 0 — Foundation (P0)
+- [ ] SPEC-011 ramped to 100%; feedback signals populating.
+- [ ] W1, W2 landed. Migration in staging.
+
+### Phase 1 — Aggregator behind flag (P0)
+- [ ] W3–W6, W8 landed behind flag.
+- [ ] Aggregation task enabled in shadow (writes
+      `nutrition_learned_preferences` rows but planner still uses
+      legacy path).
+- [ ] Review 20 internal profiles' aggregated outputs: do chips
+      align with what the team would say about themselves?
+
+### Phase 2 — Planner integration (P0/P1)
+- [ ] W9 planner prompt switched under the flag.
+- [ ] Flag on for internal profiles; compare plan quality against
+      flag-off (same profile, same week, dual-planned).
+- [ ] Acceptance gate: team-lead judgment that personalized plans
+      are at least as good as legacy, meaningfully better in ≥3 of
+      10 cases.
+
+### Phase 3 — UI + ramp (P1)
+- [ ] W10 UI panel shipped; copy reviewed.
+- [ ] 10% → 50% → 100% over three weeks.
+- [ ] Metrics watched:
+      - Override write rate per user (UI engagement signal).
+      - `forget` action rate (system was wrong signal).
+      - Plan regeneration rate (satisfaction proxy).
+
+### Phase 4 — Cleanup (P1/P2)
+- [ ] W7 NL summary cache; W11 clinician path; W12 observability;
+      W13 rebuild tool.
+- [ ] Flag default on. Remove legacy summarizer path in a later
+      PR.
+
+### Rollback
+- Flag off → planner reverts to name-list; aggregator continues
+  writing preference rows harmlessly.
+- Overrides persisted; re-enable flag to resume surfaces.
+
+---
+
+## 6. Verification
+
+### 6.1 Unit tests
+
+- `test_decay_half_life.py` — 35-day-old score with no new feedback
+  has half the pseudo-count weight.
+- `test_note_vs_derived_weighting.py` — a `note` signal of strength
+  0.5 outweighs a `derived` signal of 0.5 for the same key.
+- `test_min_evidence_gate.py` — a single strong note does not
+  appear in the digest when `N_MIN=3`; appears after three
+  confirming events.
+- `test_override_merge.py` — `pin_positive` wins over lower
+  learned score; `exclude` removes the key from the digest; a
+  subsequent `forget` wipes both learned and override state.
+- `test_idempotent_apply.py` — applying the same
+  `FeedbackSignals` twice updates the preferences once (matched by
+  `last_extraction_id`).
+
+### 6.2 Integration tests
+
+- `test_feedback_to_digest.py` — 10 synthetic feedbacks landed →
+  aggregator runs → digest contains the expected top signals.
+- `test_digest_cold_start.py` — user with zero feedback returns
+  empty digest and a politely empty `summary_nl`.
+- `test_override_via_api.py` — PUT/DELETE endpoints round-trip
+  correctly; audit log rows present.
+- `test_rebuild.py` — delete preferences row, POST /rebuild,
+  aggregator rebuilds identical state from feedback-signals history.
+
+### 6.3 Property tests
+
+- Monotonicity: strongly positive feedback on a key never
+  decreases its strength.
+- Bounded: `Score.mean ∈ [-1, +1]` and `Score.confidence ∈ [0, 1]`
+  always.
+- Determinism: replaying the same signal stream twice produces
+  byte-equal preferences.
+
+### 6.4 Reviewer audit (Phase 1)
+
+- 20 internal profiles audited by team lead + a user. Acceptance:
+  ≥15/20 profiles show chips that feel correct; no profiles show
+  chips that feel wrong (vs. absent or incomplete).
+
+### 6.5 Observability
+
+- All §4.11 counters emit in staging.
+- Cold-start dashboard shows the fraction of active users with
+  fewer than `N_MIN` feedback events.
+
+### 6.6 Copy review
+
+- Chip labels, provenance strings, and empty-state copy reviewed.
+
+### 6.7 Cutover criteria (flag-on)
+
+- All P0/P1 tests green.
+- Phase 2 acceptance gate met.
+- Phase 3 metrics stable.
+- Clinical reviewer + team lead sign-off.
+
+---
+
+## 7. Open Questions
+
+- **`N_MIN` and decay rate calibration.** Defaults (`N_MIN=3`,
+  `lambda=0.02/day`) are educated guesses. Phase 3 metrics will
+  tell us whether to loosen or tighten.
+- **NL summary freshness.** A weekly refresh might feel stale for
+  very active users. We can switch to event-triggered refresh on
+  digest-item changes; v1 is conservative to keep LLM cost bounded.
+- **Clinician visibility of user overrides.** In v1 the clinician
+  can see but not unconditionally override a user's own overrides
+  — a user who has pinned "avoid cilantro" is respected. Revisit
+  if clinical workflows require stronger authority.
+- **Chip actions in UI — "Not really — forget this".** This
+  resolves to a `forget` which allows re-learning. Some users will
+  want "never learn this dimension again". That is an
+  `exclude` action; we expose both in the UI under a progressive
+  disclosure ("actually, turn this off permanently").

--- a/system_design/specs/SPEC-013-nutrition-recipe-retrieval-and-exemplars.md
+++ b/system_design/specs/SPEC-013-nutrition-recipe-retrieval-and-exemplars.md
@@ -1,0 +1,480 @@
+# SPEC-013: Recipe retrieval and few-shot exemplar injection
+
+| Field       | Value                                                    |
+|-------------|----------------------------------------------------------|
+| **Status**  | Proposed                                                 |
+| **Author**  | Nutrition & Meal Planning team                           |
+| **Created** | 2026-04-17                                               |
+| **Priority**| P1 (capstone for ADR-004; unblocks preference-grounded planning and cook-mode UX) |
+| **Scope**   | New module `backend/agents/nutrition_meal_planning_team/preferences/retrieval/`, embedding index, planner prompt wiring, background indexing task |
+| **Depends on** | SPEC-011 (feedback signals), SPEC-012 (learned preferences digest), SPEC-005 (canonical ingredients), SPEC-009 (recipe features) |
+| **Implements** | ADR-004 §5 (retrieval) |
+
+---
+
+## 1. Problem Statement
+
+SPEC-012 gives the planner a structured digest ("leans toward
+one-pan, chicken, umami"). That is a large jump in prompt quality
+from the legacy name list. It is still abstract. Users recognize
+their preferences in concrete recipes: "Yes, like the shakshuka we
+had last month, not like that raw-tofu poke."
+
+This spec ships the retrieval layer: embed every past
+recommendation, and on each plan generation pull the top-N similar
+past hits and the bottom-M recent misses into the meal-planning
+prompt as few-shot exemplars. Combined with SPEC-012's digest and
+SPEC-007's constraint block, the planner receives (abstract
+features) + (concrete exemplars) + (hard constraints) — three
+complementary grounding layers instead of one noisy list.
+
+It is also where cold-start exploration lives: an ε-exploration
+rule that keeps the plan from collapsing onto a narrow repeat menu.
+
+---
+
+## 2. Current State
+
+### 2.1 After SPEC-012
+
+- Planner receives a structured digest of learned dimensions.
+- Past hits/misses are named in the digest but not retrieved with
+  any similarity function — the planner is expected to pattern-
+  match on names alone.
+
+### 2.2 Gaps
+
+1. No embedding index over past recipes.
+2. No similarity retrieval on plan generation.
+3. No exemplar injection surface in the planner prompt.
+4. No cold-start exploration — purely exploitative generation
+   converges on a narrow repeat menu.
+5. No way to filter retrieved exemplars against the current
+   profile's restrictions, so a formerly-loved meal that is now
+   illegal (new allergy) could resurface.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- Index every `MealRecommendation` with a stable embedding on
+  write. Reindex the history on embedding-model upgrade.
+- Expose `retrieve_exemplars(client_id, target_slot) -> Exemplars`
+  that returns top-N past hits and bottom-M recent misses, filtered
+  against the current profile's resolved restrictions
+  (SPEC-006 / SPEC-007).
+- Extend the meal-planner prompt with a short exemplars block
+  (structured, numeric bounded).
+- Add a deterministic ε-exploration rule: a small fraction of
+  retrieval calls inject a deliberately dissimilar exemplar to
+  preserve variety.
+- Keep index reads O(1) per slot on the plan's critical path.
+- Never retrieve a recipe whose restriction set is incompatible
+  with the user's current profile (policy drift safety).
+
+### 3.2 Non-goals
+
+- **No new embedding model choice.** We pin on whatever the
+  platform already exposes (coordinate with the AI Systems team's
+  existing shared embedding provider); v1 choice is documented
+  but swapping is a `RETRIEVAL_VERSION` bump.
+- **No cross-user retrieval.** Collaborative filtering is a
+  future ADR.
+- **No retrieval for substitution.** ADR-005's substitution
+  endpoint will use this module via the same `retrieve_exemplars`
+  call shaped around a `SwapConstraint`; that wiring is ADR-005's
+  job, not this spec's.
+- **No UI in v1.** SPEC-012 owns the preference panel; this spec
+  is backend-only.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 Module layout
+
+```
+backend/agents/nutrition_meal_planning_team/preferences/retrieval/
+├── __init__.py            # retrieve_exemplars, index_recipe, RETRIEVAL_VERSION
+├── version.py             # RETRIEVAL_VERSION = "1.0.0"
+├── types.py               # Exemplars, Exemplar, EmbeddingVector
+├── embed.py               # thin wrapper over the platform embedding provider
+├── index.py               # pgvector-based index over recipe embeddings
+├── retrieve.py            # top-K retrieval + restriction filter + exploration
+├── reindex.py             # background reindex task
+├── errors.py
+└── tests/
+```
+
+### 4.2 Embedding input
+
+For every `MealRecommendation` recorded (SPEC-007 recording step),
+compute:
+
+- A canonical text payload:
+  ```
+  name: {display_name}
+  cuisine: {cuisine_tag}
+  format: {format_tag}
+  protein: {protein_tag}
+  flavors: {flavor_tags}
+  textures: {texture_tags}
+  canonical_ingredients: {sorted canonical_ids}
+  cooking_method: {cooking_method}
+  ```
+- The canonicalization is deterministic; two recipes with the same
+  fields produce the same input string.
+- The `canonical_ingredients` list is the SPEC-007-parsed set
+  (`parsed_ingredients_present=true` rows only). Recipes where
+  parsing produced unresolved ingredients are still indexed but
+  their embedding is flagged `low_quality=true`.
+
+### 4.3 Postgres index (pgvector)
+
+Migration `009_recipe_embeddings.sql`:
+
+```sql
+-- Requires pgvector extension.
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE IF NOT EXISTS nutrition_recipe_embeddings (
+    recommendation_id  TEXT PRIMARY KEY
+        REFERENCES nutrition_recommendations(recommendation_id) ON DELETE CASCADE,
+    client_id          TEXT NOT NULL,
+    embedding          vector(1024) NOT NULL,     -- dimension pinned at RETRIEVAL_VERSION major
+    embedding_model    TEXT NOT NULL,
+    canonical_text     TEXT NOT NULL,             -- the input used to embed; debug + diff
+    low_quality        BOOLEAN NOT NULL DEFAULT FALSE,
+    indexed_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    retrieval_version  TEXT NOT NULL
+);
+CREATE INDEX ON nutrition_recipe_embeddings USING ivfflat (embedding vector_cosine_ops);
+CREATE INDEX ON nutrition_recipe_embeddings (client_id, indexed_at DESC);
+CREATE INDEX ON nutrition_recipe_embeddings (retrieval_version);
+```
+
+`vector(1024)` is a placeholder dimension; set at spec-freeze time
+to match the chosen embedding model. Model choice documented in
+`retrieval/README.md` and pinned via `RETRIEVAL_VERSION`.
+
+### 4.4 Indexing pipeline
+
+Synchronous path (critical path): indexing is **not** synchronous
+in the plan generation path. Instead:
+
+1. On SPEC-007 `_record_suggestions`, emit an event
+   `recipe.indexable` with the recommendation_id and canonical
+   text.
+2. A background task in the nutrition team consumes the event and
+   runs `embed.embed_one(text)` + INSERT into
+   `nutrition_recipe_embeddings`.
+3. First-plan users' initial recommendations may not be indexed
+   yet during their first retrieval call — this is fine, retrieval
+   falls back gracefully.
+
+`reindex.py` CLI rebuilds the entire index for a `client_id` or
+globally when `RETRIEVAL_VERSION` major bumps (embedding-model
+swap). Global reindex runs as a scheduled task; global reindex is
+admin-gated.
+
+### 4.5 Retrieval (`retrieve.py`)
+
+```python
+@dataclass(frozen=True)
+class Exemplar:
+    recommendation_id: str
+    display_name: str
+    kind: Literal["hit", "miss", "exploration"]
+    rating_at_retrieval: Optional[int]
+    similarity: float
+    canonical_ingredient_ids: tuple[str, ...]
+    ingredients_preview: tuple[str, ...]    # for the planner prompt
+    age_days: int
+
+@dataclass(frozen=True)
+class Exemplars:
+    hits: list[Exemplar]                    # top-N similar past hits
+    misses: list[Exemplar]                  # bottom-M recent misses
+    exploration: list[Exemplar]             # 0 or 1 dissimilar hit (see §4.7)
+    filter_summary: dict[str, int]          # why recipes were filtered out
+
+def retrieve_exemplars(
+    client_id: str,
+    target_slot: TargetSlot,     # meal_type, suggested_date, period
+    profile: ClientProfile,      # for restriction filter
+    digest: PreferenceDigest,    # from SPEC-012; shapes the query
+    n_hits: int = 5,
+    m_misses: int = 3,
+    epsilon: float = 0.1,
+) -> Exemplars: ...
+```
+
+Retrieval steps:
+
+1. **Build query vector.** Use the digest's top positive signals
+   as a synthetic "ideal meal" text (one-pan, chicken, umami,
+   etc.) and embed it via `embed.embed_one`. This is the query
+   vector. Alternative: average-of-top-hits vector — documented,
+   chosen at implementation based on quality tests.
+2. **Candidate pool.** Fetch the top N+M+50 most similar past
+   recommendations for this client (by cosine), not filtered yet.
+   50 buffer covers filter attrition.
+3. **Restriction filter.** For each candidate, run
+   `guardrail.check_recommendation` (SPEC-007) against the
+   **current** profile. Any hard reject is excluded.
+4. **Rating filter.** A candidate qualifies as a `hit` if its
+   feedback indicates positive (rating ≥ 4 or `wma=true`). A
+   `miss` if recent (≤ 60 days) and feedback negative.
+5. **Deduplication.** Never return two exemplars with identical
+   `canonical_ingredient_ids`; take the more recent one.
+6. **Selection.** Top N hits (after filter) and bottom M misses
+   (most recent first).
+7. **Exploration.** With probability `epsilon`, include one
+   `exploration` exemplar: a past hit with the **lowest** cosine
+   similarity that still passes filters. Exploration keeps variety
+   without violating preferences.
+8. **Cold start.** Fewer than `N_COLD` (default 10) past
+   recommendations: return empty `hits`/`misses` and signal
+   cold-start to the caller.
+
+Retrieval is deterministic when `epsilon=0`. When `epsilon>0`, the
+exploration step uses a seeded RNG derived from `client_id +
+date(today)` so the same day's plan is reproducible.
+
+### 4.6 Planner prompt integration
+
+The meal planner prompt (after SPEC-010) receives a short exemplars
+block:
+
+```
+Past meals this user liked (for style grounding):
+  - Chicken shawarma bowl (rating 5, made 12 days ago)
+      ingredients: chicken_thigh_raw, garlic, lemon, tahini, cucumber, tomato, parsley
+  - Sheet-pan gnocchi (rating 5, made 34 days ago)
+      ingredients: gnocchi, cherry_tomato, olive_oil, mozzarella, basil
+  - Shakshuka (rating 4, wma, made 3 days ago)
+      ingredients: tomato_canned, egg, bell_pepper, onion, paprika, cumin
+  Past miss (avoid similar style):
+  - Raw-tofu poke (rating 2, made 8 days ago)
+      ingredients: silken_tofu_raw, soy_sauce, sesame_oil, seaweed, rice
+
+Prefer recipes that share ingredients, format, and flavor profile with
+the hits. Avoid patterns similar to the miss.
+```
+
+The planner combines this with SPEC-012's digest and SPEC-007's
+constraint block. Exemplar ingredient lists are trimmed to top-7
+by mass to keep the prompt compact.
+
+### 4.7 Exploration policy
+
+- `epsilon = 0.1` means 1 in 10 retrievals surfaces a deliberately
+  dissimilar past hit.
+- The surfaced exploration exemplar is labeled as such in the
+  prompt: *"Exploration pick (something they liked that's unlike
+  their typical plan):"* so the planner treats it as a variety
+  signal rather than a pattern to match.
+- User-visible: SPEC-012's "Adjusted" transparency applies — we
+  note "added for variety" in the recipe rationale when the plan
+  borrows from an exploration exemplar.
+
+### 4.8 Safety — never resurface illegal hits
+
+- Restriction filter runs at retrieval time against the current
+  profile (not the profile the recipe was recorded under). A user
+  who develops a new allergy sees no past hits they can't safely
+  eat.
+- On `GUARDRAIL_VERSION` or `KB_VERSION` bump (SPEC-007 §4.10),
+  the replay job already re-checks past recommendations. Retrieval
+  reads the current guardrail result; nothing additional needed.
+- Unit tests assert this invariant on multiple fixtures (§6).
+
+### 4.9 Performance
+
+- Candidate fetch: pgvector cosine query over ≤10k rows per user;
+  target ≤ 30 ms.
+- Restriction filter: SPEC-007 p99 ≤ 10 ms × 50 candidates =
+  ≤ 500 ms in worst case; run concurrently across the candidate
+  set.
+- Query embedding: 1 LLM (embedding) call; target ≤ 200 ms.
+- Total retrieval budget: ≤ 1 s added to the plan path, run in
+  parallel with other planner-preparation work so the wall-clock
+  impact is ≤ 200 ms effective.
+
+### 4.10 Privacy
+
+- Embeddings are derived artifacts of recipes the user ate or was
+  shown; deleted on account deletion via cascade.
+- Embeddings do not leave the nutrition team's Postgres schema;
+  no external retrieval services in v1.
+- Canonical text is stored alongside the embedding for
+  reconstruction and audit; redacted with respect to user PII by
+  construction (the canonical text is recipe content, not profile
+  content).
+
+### 4.11 Versioning
+
+`RETRIEVAL_VERSION = "MAJOR.MINOR.PATCH"`:
+
+- **MAJOR** — embedding model change, dimension change, canonical
+  text shape change. Global reindex required.
+- **MINOR** — retrieval algorithm tweaks (k, epsilon defaults,
+  scoring).
+- **PATCH** — bug fixes.
+
+### 4.12 Priority-grouped work items
+
+| # | Item | Priority |
+|---|------|----------|
+| W1 | Module scaffolding, version, types | P0 |
+| W2 | Migration `009_recipe_embeddings.sql` (pgvector) + schema registration | P0 |
+| W3 | `embed.py` wrapper over platform embedding provider | P0 |
+| W4 | Canonical text builder from a `MealRecommendation` | P0 |
+| W5 | Background indexing task consuming `recipe.indexable` events | P0 |
+| W6 | `retrieve.py` top-K + restriction filter + deduplication | P0 |
+| W7 | ε-exploration rule with seeded RNG tests | P0 |
+| W8 | Planner prompt integration (exemplars block) | P1 |
+| W9 | Cold-start path: return empty exemplars + signal | P0 |
+| W10 | `reindex.py` CLI + scheduled global reindex on MAJOR bump | P1 |
+| W11 | Observability counters + filter summary in Exemplars response | P1 |
+| W12 | Benchmarks: retrieval p99 ≤ 1 s end-to-end | P2 |
+| W13 | Exploration transparency: rationale-level tag on exploration-sourced recipes | P2 |
+
+---
+
+## 5. Rollout Plan
+
+Flag `NUTRITION_RECIPE_RETRIEVAL` (off → planner receives only
+digest + constraints, on → exemplars block added).
+
+### Phase 0 — Foundation (P0)
+- [ ] SPEC-012 at 100% ramp.
+- [ ] pgvector extension enabled in staging.
+- [ ] W1–W4 landed.
+
+### Phase 1 — Indexing + shadow (P0)
+- [ ] W5 background task live; start indexing new recommendations.
+- [ ] Backfill existing recommendations with `reindex.py` (rate-
+      limited).
+- [ ] Shadow retrieval: for flag-off users, call
+      `retrieve_exemplars` and log results without injecting into
+      the prompt. Review quality on 20 internal profiles.
+
+### Phase 2 — Planner integration (P0/P1)
+- [ ] W6, W7, W8, W9 landed.
+- [ ] Flag on internal. Compare plans with and without exemplars
+      (dual generation on the same input).
+- [ ] Acceptance gate: reviewer judges the exemplar-augmented
+      plans more recognizable ("feels like something I'd actually
+      eat") in ≥6 of 10 cases.
+
+### Phase 3 — Ramp (P1)
+- [ ] 10% → 50% → 100% over two weeks.
+- [ ] Monitor retrieval latency, filter attrition (recipes blocked
+      by current-profile restriction), exploration rate.
+- [ ] Safety check: zero instances of a past hit being retrieved
+      that fails the current guardrail. Fix immediately if any
+      observed.
+
+### Phase 4 — Cleanup (P1/P2)
+- [ ] W10–W13 landed.
+- [ ] Flag default on; removal scheduled.
+
+### Rollback
+- Flag off → planner receives digest only; exemplars ignored.
+  Index continues populating harmlessly.
+- Migration is additive; rollback not needed.
+
+---
+
+## 6. Verification
+
+### 6.1 Unit tests
+
+- `test_canonical_text_stable.py` — same recipe fields → same
+  canonical text → same embedding input.
+- `test_restriction_filter.py` — candidate with a newly-added
+  allergen is excluded even when it was a past hit.
+- `test_deduplication.py` — two recipes with identical canonical
+  ingredient sets collapse to the most recent.
+- `test_cold_start.py` — client with < `N_COLD` past
+  recommendations returns empty exemplars and the cold-start
+  signal.
+- `test_exploration_seeded.py` — same `client_id + date(today)`
+  → identical exploration pick across runs; different days →
+  different picks.
+
+### 6.2 Integration tests
+
+- `test_indexing_event_to_row.py` — recording a new recommendation
+  emits `recipe.indexable`; background task inserts a row within
+  30 s; row has correct canonical text and embedding dimension.
+- `test_retrieve_with_guardrail_violation.py` — past hit contains
+  a now-forbidden ingredient; retrieve_exemplars excludes it;
+  `filter_summary` reflects the exclusion.
+- `test_retrieval_latency.py` — end-to-end retrieval for a user
+  with 500 indexed recommendations completes within budget.
+
+### 6.3 Safety tests
+
+- `test_no_illegal_resurfacing.py` — matrix of (profile change,
+  past hit): for each, assert retrieve never returns the illegal
+  one. Runs on dozens of combinations.
+- `test_guardrail_drift_policy_bump.py` — simulate a
+  `GUARDRAIL_VERSION` bump mid-flight; retrieval reads the current
+  guardrail.
+
+### 6.4 Reviewer audits (Phase 1, Phase 2)
+
+- Phase 1 shadow retrieval: 20 internal profiles, reviewer (team
+  lead + one non-team user) rates exemplar quality on a 1–5
+  scale. Median ≥ 4.
+- Phase 2 planner integration: 10 paired plans with and without
+  exemplars. Acceptance: reviewer prefers the exemplar-augmented
+  plan in ≥6 cases.
+
+### 6.5 Property tests
+
+- Monotonicity: a user with more and more positive feedback on a
+  dimension will retrieve more hits that share that dimension.
+- Filter correctness: no `kind=hit` exemplar violates the current
+  profile's restrictions.
+
+### 6.6 Observability
+
+- `retrieval.candidates_fetched`, `retrieval.filter_attrition`,
+  `retrieval.exploration_rate`, `retrieval.latency_ms` histograms.
+- Alerting: exploration rate deviating > 2× from `epsilon` in a
+  rolling hour → investigate (seed bug or policy regression).
+
+### 6.7 Cutover criteria
+
+- All P0/P1 tests green.
+- Phase 2 acceptance gate met.
+- Zero safety test failures; zero observed illegal-resurfacing
+  incidents during ramp.
+- Clinical reviewer + team lead sign-off.
+
+---
+
+## 7. Open Questions
+
+- **Query-vector strategy.** "Synthetic ideal meal from digest"
+  vs. "average of top hits" vs. "concat of both". v1 picks one
+  based on shadow-phase quality tests; the alternative is a minor
+  bump away.
+- **Dimension pinning.** Embedding dimension is model-dependent.
+  Pinning at 1024 is a placeholder; chosen per actual model at
+  spec-freeze time and carved into `RETRIEVAL_VERSION` major.
+- **pgvector vs. external vector store.** v1 keeps data local
+  (privacy win; simpler deploy). At scale (>100k recipes per
+  user, unrealistic) we could revisit; no plan to do so.
+- **User-visible exploration label.** §4.7 notes "added for
+  variety" on the rationale. We may want a user-facing toggle
+  ("surprise me more / less") — v1.1 feature; not in scope here.
+- **Substitution via retrieval.** ADR-005 will add a
+  `SwapConstraint`-shaped retrieval call. The module exposes the
+  internals (`retrieve.py` takes a `query_builder` parameter) so
+  ADR-005 can reuse without forking.

--- a/system_design/specs/SPEC-014-nutrition-grocery-list.md
+++ b/system_design/specs/SPEC-014-nutrition-grocery-list.md
@@ -1,0 +1,441 @@
+# SPEC-014: Consolidated grocery list
+
+| Field       | Value                                                    |
+|-------------|----------------------------------------------------------|
+| **Status**  | Proposed                                                 |
+| **Author**  | Nutrition & Meal Planning team                           |
+| **Created** | 2026-04-17                                               |
+| **Priority**| P0 within ADR-005 (blocks SPEC-015 pantry subtraction)   |
+| **Scope**   | New module `backend/agents/nutrition_meal_planning_team/grocery/`, Postgres table, API endpoints, UI grocery view |
+| **Depends on** | SPEC-005 (parser, densities, purchase units), SPEC-007 (parsed ingredients on recorded meals) |
+| **Implements** | ADR-005 §1 (consolidated grocery list) |
+
+---
+
+## 1. Problem Statement
+
+Users are handed seven recipes and then face the most friction-heavy
+step in the whole workflow: reconciling overlapping ingredients,
+converting between the recipe's units and what the store sells, and
+building a list grouped by section. Most meal-planning tools lose
+users here.
+
+This spec ships the consolidated grocery list: aggregate the
+canonicalized ingredients across a plan, convert to
+purchasable units, round with a waste buffer, and group by
+supermarket aisle. It is the first ADR-005 capability because it
+unlocks pantry subtraction (SPEC-015) and substitution (SPEC-016),
+which both operate on the same canonicalized quantities.
+
+---
+
+## 2. Current State
+
+### 2.1 Today's flow
+
+After SPEC-007 + SPEC-009 + SPEC-010 land:
+- Every recorded meal has parsed ingredients with canonical ids,
+  quantities, and units (SPEC-007 `parsed_ingredients_json`).
+- SPEC-009's density table maps unit-based quantities to grams.
+- There is no user-visible aggregation. No grocery list endpoint,
+  no UI, no Postgres row.
+
+### 2.2 Gaps
+
+1. No aggregation across recipes in a plan.
+2. No purchase-unit conversion — "1 tbsp olive oil" × 7 = 105 ml =
+   one bottle, but we do not compute the last step.
+3. No aisle grouping.
+4. No persistence — a user who reloads the page loses the list.
+5. No export path.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- Ship `POST /plan/meals/{plan_id}/grocery-list` that returns a
+  structured `GroceryList`, persists it, and supports regeneration.
+- Aggregate canonical ingredients across a plan in grams (via
+  SPEC-005 densities) and convert to **purchase units** using a
+  new `purchase_unit` field on `canonical_foods.yaml`.
+- Round up with a configurable waste buffer (default 10%) and
+  group by aisle tag.
+- Support export formats: plain text, markdown, CSV, signed JSON.
+- Persist in Postgres keyed by plan id; idempotent regeneration.
+- Zero LLM calls on the critical path — the list is pure
+  arithmetic over SPEC-005 data.
+
+### 3.2 Non-goals
+
+- **No pantry subtraction.** SPEC-015.
+- **No third-party fulfillment.** Instacart / Amazon Fresh adapters
+  ride on the exported JSON shape in a future spec.
+- **No UI cart persistence across plans.** One list per plan; a
+  new plan gets its own list.
+- **No quantity editing by the user within the list in v1.** The
+  UI shows the computed list; users can override by editing the
+  plan's recipes or via a manual add. Fine-grained item-level
+  editing is v1.1.
+- **No recipe scaling.** A day's recipes are aggregated as-planned.
+  Per-day servings adjustments are out of scope.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 Module layout
+
+```
+backend/agents/nutrition_meal_planning_team/grocery/
+├── __init__.py              # build_grocery_list, GROCERY_VERSION
+├── version.py               # GROCERY_VERSION = "1.0.0"
+├── types.py                 # GroceryList, GroceryItem, AisleGroup
+├── aggregate.py             # sum by canonical_id in grams
+├── purchase_units.py        # grams -> purchase_unit conversion + rounding
+├── aisle_group.py           # canonical_id -> aisle_tag mapping + ordering
+├── export.py                # text, markdown, csv, json exporters
+├── errors.py
+└── tests/
+```
+
+### 4.2 Data additions
+
+`canonical_foods.yaml` (SPEC-005) gains two fields per food:
+
+```yaml
+- id: olive_oil
+  display_name: "Olive oil"
+  purchase_unit:
+    unit: ml
+    typical_package_ml: 500       # smallest typical package
+    pack_sizes_ml: [250, 500, 750, 1000]   # optional, for smart rounding
+  aisle_tag: pantry
+```
+
+`aisle_tag` enum (closed):
+`produce | meat_fish | dairy_eggs | pantry | spices | frozen |
+bakery | beverages | condiments | other`.
+
+Adding or changing `purchase_unit` requires a minor KB_VERSION
+bump per SPEC-005 §4.10. Reviewer sign-off as usual.
+
+### 4.3 Types
+
+```python
+@dataclass(frozen=True)
+class GroceryItem:
+    canonical_id: str
+    display_name: str
+    aisle_tag: AisleTag
+    total_grams: float                       # aggregated mass
+    purchase_unit: str                       # 'ml', 'g', 'count'
+    purchase_qty: float                      # rounded, ready-to-buy
+    purchase_qty_raw: float                  # pre-rounding, for audit
+    contributing_recipe_ids: tuple[str, ...] # recipes that asked for it
+    buffer_applied_pct: float
+    confidence: float                        # inherits from SPEC-009 parse
+
+@dataclass(frozen=True)
+class AisleGroup:
+    aisle_tag: AisleTag
+    items: tuple[GroceryItem, ...]
+
+@dataclass(frozen=True)
+class GroceryList:
+    plan_id: str
+    client_id: str
+    groups: tuple[AisleGroup, ...]           # fixed aisle order
+    unresolved: tuple[str, ...]              # recipe ingredients that didn't resolve
+    low_confidence: tuple[str, ...]          # items with parse confidence < 0.85
+    waste_buffer_pct: float
+    grocery_version: str
+    kb_version: str
+    generated_at: str
+```
+
+### 4.4 Aggregation
+
+`aggregate.py::aggregate_plan(plan: MealPlanResponse) -> dict[str, float]`:
+
+- Iterate every suggestion's `parsed_ingredients_json` from
+  SPEC-007.
+- For each parsed ingredient with a known `canonical_id`, use
+  SPEC-005's `convert_to_grams` to get grams.
+- Skip ingredients with `canonical_id=None` — those go to
+  `unresolved` on the output (user-visible).
+- Skip `qty=None` items that have no default-quantity entry;
+  they go to `low_confidence`.
+- Sum by `canonical_id`.
+
+Returns the grams map, plus the `unresolved` and `low_confidence`
+lists.
+
+### 4.5 Purchase-unit conversion
+
+`purchase_units.py::to_purchase_unit(canonical_id, grams) -> PurchaseQty`:
+
+- Lookup `purchase_unit` on the canonical food.
+- Convert grams to the purchase unit using the inverse density
+  (for volume-purchase items like olive oil) or the item's mass-
+  per-count (for count-purchase items like eggs, onions).
+- Apply `buffer_pct` (default 10%) to the raw quantity.
+- Round to the nearest sensible increment:
+  - `ml`/`g`: round up to nearest 50 unless `pack_sizes_*` is set,
+    then pick the smallest pack size that covers.
+  - `count`: integer ceiling (2.1 onions → 3 onions).
+- Report `purchase_qty` and `purchase_qty_raw` so the user can see
+  how we rounded.
+
+Spices and small pantry items with trivial contributions (< 5 g
+across the whole plan) are still surfaced, but with a note
+"probably already in your pantry" — the UI can de-emphasize them.
+
+### 4.6 Aisle grouping and ordering
+
+- `aisle_tag` on each canonical food.
+- Fixed group order in the list:
+  `produce → meat_fish → dairy_eggs → bakery → pantry → spices →
+  frozen → condiments → beverages → other`.
+- Within a group, items sorted alphabetically by `display_name`.
+- Groups with zero items are omitted.
+
+### 4.7 API
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/plan/meals/{plan_id}/grocery-list` | Build or rebuild the list; persists latest. Body optional: `{waste_buffer_pct?: float}` |
+| `GET`  | `/plan/meals/{plan_id}/grocery-list` | Fetch latest persisted list |
+| `GET`  | `/plan/meals/{plan_id}/grocery-list/export?format=text\|markdown\|csv\|json` | Export in the requested format |
+| `POST` | `/plan/meals/{plan_id}/grocery-list/items/manual` | Add a manual item (free text + optional canonical_id) |
+| `DELETE` | `/plan/meals/{plan_id}/grocery-list/items/{canonical_id}` | Remove a computed item (user knows they have it) |
+
+The manual-item endpoint accepts a canonical_id OR a raw string;
+raw strings are parsed at save time via SPEC-005 and stored with
+a `source="manual"` tag so the UI can render them distinctly.
+
+### 4.8 Persistence
+
+Migration `010_grocery_lists.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS nutrition_grocery_lists (
+    plan_id               TEXT PRIMARY KEY,
+    client_id             TEXT NOT NULL,
+    list_json             JSONB NOT NULL,
+    waste_buffer_pct      REAL NOT NULL DEFAULT 10.0,
+    grocery_version       TEXT NOT NULL,
+    kb_version            TEXT NOT NULL,
+    generated_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX ON nutrition_grocery_lists (client_id, generated_at DESC);
+
+CREATE TABLE IF NOT EXISTS nutrition_grocery_list_manual_items (
+    id               BIGSERIAL PRIMARY KEY,
+    plan_id          TEXT NOT NULL REFERENCES nutrition_grocery_lists(plan_id)
+                         ON DELETE CASCADE,
+    canonical_id     TEXT,
+    raw              TEXT,
+    purchase_qty     DOUBLE PRECISION,
+    purchase_unit    TEXT,
+    added_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS nutrition_grocery_list_removed_items (
+    plan_id          TEXT NOT NULL REFERENCES nutrition_grocery_lists(plan_id)
+                         ON DELETE CASCADE,
+    canonical_id     TEXT NOT NULL,
+    removed_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (plan_id, canonical_id)
+);
+```
+
+On regeneration (e.g., after a `/swap` or plan edit), the list is
+recomputed but manual-add items and user-removed items are
+preserved (the removed set is applied as a filter after
+aggregation; manual adds are concatenated at the end of their
+aisle).
+
+### 4.9 Exports
+
+- **Text**: plain markdown-less format, one item per line grouped
+  by `## AISLE` headers. Copy-paste friendly for users who shop
+  with a notes app.
+- **Markdown**: same but with `- [ ] ` checkboxes.
+- **CSV**: `aisle_tag,canonical_id,display_name,purchase_qty,purchase_unit`.
+- **JSON**: serialized `GroceryList`.
+
+Exports are signed with a short-lived HMAC in a `grocery-list-token`
+query parameter so the same URL can be shared with a partner who
+has no account (read-only), without creating a full share/auth
+surface.
+
+### 4.10 Regeneration triggers
+
+The list auto-regenerates on:
+
+- Any `POST /swap` (SPEC-010) that replaces a recipe in the plan.
+- Any plan-level edit that adds/removes a recipe.
+- Explicit `POST /grocery-list` with `force=true`.
+
+Auto-regeneration preserves manual adds and removals. A regen
+diff is returned to the UI so it can show "Added 2, removed 1"
+toast notifications.
+
+### 4.11 UI
+
+- Grocery tab on the plan screen.
+- Aisle accordions collapsible; each item a checkbox.
+- "Needed vs. pantry" split shown as a banner (SPEC-015 populates;
+  until SPEC-015 lands the banner is absent).
+- Manual add field with canonical-id autocomplete.
+- Export menu with the four formats.
+- A small "how we rounded" tooltip on each item shows
+  `purchase_qty_raw → purchase_qty` and the waste buffer.
+
+### 4.12 Performance
+
+Synchronous endpoint budget:
+- Aggregation: O(recipes × ingredients) — typically <200 items;
+  target ≤ 30 ms.
+- Purchase-unit conversion: O(unique canonical_ids), typically <60;
+  target ≤ 10 ms.
+- Total: p99 ≤ 100 ms.
+
+### 4.13 Priority-grouped work items
+
+| # | Item | Priority |
+|---|------|----------|
+| W1 | Module scaffolding, version, types | P0 |
+| W2 | `canonical_foods.yaml` extension: `purchase_unit`, `aisle_tag`; SPEC-005 KB version bump | P0 |
+| W3 | Migration `010_grocery_lists.sql` + schema registration | P0 |
+| W4 | `aggregate.py` + tests (multi-recipe aggregation) | P0 |
+| W5 | `purchase_units.py` + rounding + pack-size tests | P0 |
+| W6 | `aisle_group.py` + ordering tests | P0 |
+| W7 | `POST/GET /grocery-list` + persistence | P0 |
+| W8 | Manual add + removal endpoints and persistence | P1 |
+| W9 | `export.py` all four formats + signed URL middleware | P1 |
+| W10 | Auto-regeneration on plan/swap events | P1 |
+| W11 | UI: grocery tab with aisle accordions + checkboxes | FE | P1 |
+| W12 | UI: manual add + autocomplete | FE | P1 |
+| W13 | UI: "how we rounded" tooltip + regen diff toast | FE | P2 |
+| W14 | Observability counters | P1 |
+| W15 | Benchmarks: p99 ≤ 100 ms | P2 |
+
+---
+
+## 5. Rollout Plan
+
+Flag `NUTRITION_GROCERY_LIST` (off → no endpoints exposed, on →
+endpoints live).
+
+### Phase 0 — KB extension (P0)
+- [ ] W2 KB fields added across the 2,000 seed foods. Migration
+      applied in staging.
+- [ ] SPEC-005 KB_VERSION minor bump; SPEC-007/SPEC-009 caches
+      invalidated.
+
+### Phase 1 — Backend behind flag (P0)
+- [ ] W1, W3–W7 landed behind flag.
+- [ ] Flag on internal. Dogfood-team profiles get lists on their
+      existing plans.
+
+### Phase 2 — UI + exports (P1)
+- [ ] W8–W11 landed.
+- [ ] Internal dogfood: generate + shop from a list. Review
+      rounding, aisle groupings, and edge cases.
+- [ ] Acceptance gate: reviewer agrees aggregation is correct on
+      10 planned dogfood shops; pack-size rounding feels
+      reasonable.
+
+### Phase 3 — Ramp (P1)
+- [ ] 10% → 50% → 100% over two weeks.
+- [ ] Watch: manual-add rate (indicator of KB gaps), removal rate
+      (indicator of over-buying), export usage.
+
+### Phase 4 — Cleanup (P1/P2)
+- [ ] W12–W15 landed.
+- [ ] Flag default on; removal scheduled.
+
+### Rollback
+- Flag off → endpoints return 404; existing persisted lists remain
+  but are not surfaced in UI.
+- Additive migration.
+
+---
+
+## 6. Verification
+
+### 6.1 Unit tests
+
+- `test_aggregate_multi_recipe.py` — 3 recipes each calling for 1
+  tbsp olive oil → 45 ml aggregate; 1 cup rice across 2 recipes →
+  aggregated in grams via density table.
+- `test_purchase_unit_ml.py` — 180 ml of olive oil with 10% buffer
+  rounds up to 250 ml pack size.
+- `test_purchase_unit_count.py` — 2.1 onions → 3 onions.
+- `test_aisle_ordering.py` — produce before pantry before spices;
+  empty aisles omitted.
+- `test_unresolved_and_low_confidence.py` — unresolved ingredients
+  surface in the dedicated list, not dropped silently.
+
+### 6.2 Integration tests
+
+- `test_grocery_list_endpoint.py` — `POST` returns a list; `GET`
+  returns the same; regeneration with a new recipe updates.
+- `test_swap_triggers_regen.py` — after SPEC-010 `/swap`, the
+  persisted grocery list is updated; diff returned.
+- `test_manual_add_preserved.py` — manual add survives
+  regeneration; regenerating twice does not duplicate manual items.
+- `test_removed_item_respected.py` — user removes garlic; regen
+  keeps garlic absent; adding a new recipe that uses garlic does
+  NOT resurrect it (the removal persists until user un-removes).
+- `test_export_formats.py` — all four formats produce valid
+  output; signed JSON URL verifies.
+
+### 6.3 Fixture-based correctness
+
+`tests/fixtures/plans/` from SPEC-009 reused: for each, a
+hand-computed expected grocery list exists; aggregation must
+match within unit-rounding tolerance.
+
+### 6.4 Performance
+
+- `bench_grocery_list.py` — 7-day plan with 14 recipes, 100 unique
+  canonical ingredients: p99 ≤ 100 ms on CI reference runner.
+
+### 6.5 Observability
+
+Counters:
+- `grocery.built{outcome}`
+- `grocery.unresolved_ingredient_count` histogram
+- `grocery.manual_add{has_canonical_id}`
+- `grocery.removed_item`
+- `grocery.export{format}`
+
+### 6.6 Cutover criteria
+
+- All P0/P1 tests green.
+- Phase 2 dogfood acceptance gate met.
+- Phase 3 ramp: unresolved rate on new plans < 5%; rounding
+  complaints < 2 per 100 users.
+- Clinical / nutrition team lead sign-off on aisle taxonomy.
+
+---
+
+## 7. Open Questions
+
+- **Pack-size data availability.** `pack_sizes_ml`/`pack_sizes_g`
+  is optional per canonical food. v1 seeds the top-200 most-
+  bought items; the long tail falls back to coarse 50 ml / 50 g
+  rounding. Acceptable compromise; backlogged refinement.
+- **Recipe scaling.** If a user scales a recipe ("double
+  Saturday's dinner — guests"), the grocery list needs to
+  scale too. v1 does not support recipe-level scaling; v1.1.
+- **Unit preferences.** US users may prefer imperial in exports
+  (tbsp, oz, cups). v1 exports in the same purchase units we
+  computed (mostly ml/g/count). Unit-toggle UX is v1.1.
+- **Cross-plan merging.** Some users plan two weeks at a time.
+  v1 is one list per plan; a "merge two plans' lists" feature
+  is out of scope.

--- a/system_design/specs/SPEC-015-nutrition-pantry.md
+++ b/system_design/specs/SPEC-015-nutrition-pantry.md
@@ -1,0 +1,463 @@
+# SPEC-015: Pantry tracking and subtraction
+
+| Field       | Value                                                    |
+|-------------|----------------------------------------------------------|
+| **Status**  | Proposed                                                 |
+| **Author**  | Nutrition & Meal Planning team                           |
+| **Created** | 2026-04-17                                               |
+| **Priority**| P1 within ADR-005 (enhances SPEC-014; unblocks pantry-aware planning hints) |
+| **Scope**   | New module `backend/agents/nutrition_meal_planning_team/pantry/`, Postgres tables, API endpoints, UI pantry screen, bulk-import LLM parse, optional auto-debit in cook mode |
+| **Depends on** | SPEC-005 (canonical ids, densities, purchase units), SPEC-014 (grocery list) |
+| **Implements** | ADR-005 §2 (pantry) |
+
+---
+
+## 1. Problem Statement
+
+The grocery list from SPEC-014 tells users what to buy for their
+plan. It does not yet account for what they already have. A
+realistic pantry model is where most meal planners bounce users —
+the data-entry cost is high and the payoff is invisible if we just
+use it as a filter.
+
+This spec ships pantry tracking and pantry-aware grocery
+generation with three explicit hedges against data-entry fatigue:
+
+1. The pantry is fully usable empty — it is always a filter, never
+   a requirement.
+2. Bulk import via text dump + LLM parse, surfaced to the user for
+   confirmation before anything is written.
+3. Near-expiry hints that surface on plan generation — making the
+   pantry *useful* (reducing waste, informing planning) rather than
+   just *maintained*.
+
+Optional auto-debit of pantry quantities on cook events lands in
+SPEC-018 (cook mode); this spec defines the hook.
+
+---
+
+## 2. Current State
+
+### 2.1 Today
+
+- Grocery list aggregates ingredients for a plan but subtracts
+  nothing (SPEC-014 §3.2 explicit non-goal).
+- No pantry data structure, table, or endpoint.
+- No hint signal to the planner about near-expiry items.
+
+### 2.2 Gaps
+
+1. Users buy what they already have; trust in the list erodes.
+2. Food waste from forgotten items is not addressable.
+3. Planning cannot opportunistically use what is already home.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- Ship pantry data model and endpoints (`GET/POST/PUT/DELETE`) keyed
+  by `(client_id, canonical_id)`.
+- Integrate with SPEC-014's grocery list: subtract pantry
+  quantities before rounding; report both "needed" and "on hand"
+  per item.
+- Bulk import from a text dump via `POST /pantry/import` with
+  LLM parse + user confirmation step.
+- Near-expiry hints plumbed into `POST /plan/meals`: items
+  expiring within N days are passed to the meal-planning prompt
+  as soft preferences.
+- Optional auto-debit on cook events (SPEC-018) — the data path
+  exists in this spec as an opt-in flag on the profile.
+- Pantry UI that is usable empty and scales gracefully to dozens
+  of items.
+
+### 3.2 Non-goals
+
+- **No barcode scanning.** Image / barcode ingestion is a mobile-
+  app feature, out of scope for v1.
+- **No automatic expiry dating.** Users enter `expires_on` when
+  they know it; we do not guess.
+- **No multi-household pantries.** One pantry per client. Shared
+  households can be addressed later.
+- **No pantry-first meal recommendation agent.** "What can I make
+  with what I have?" is a distinct feature, backlogged.
+- **No unit of measure edit per pantry row in v1.** We store in
+  grams plus a user-facing display unit; editing the display unit
+  is v1.1.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 Module layout
+
+```
+backend/agents/nutrition_meal_planning_team/pantry/
+├── __init__.py              # pantry store + grocery subtractor
+├── version.py               # PANTRY_VERSION = "1.0.0"
+├── types.py                 # PantryItem, PantryImportDraft
+├── store.py                 # Postgres-backed CRUD
+├── subtract.py              # grocery-list subtraction logic
+├── import_parser.py         # LLM-backed bulk parse; structured output
+├── expiry.py                # near-expiry query + hint formatter
+├── errors.py
+└── tests/
+```
+
+### 4.2 Types
+
+```python
+@dataclass(frozen=True)
+class PantryItem:
+    client_id: str
+    canonical_id: str
+    quantity_grams: float         # canonical storage unit
+    display_qty: float            # what the user entered
+    display_unit: str             # 'count', 'ml', 'g', 'package', etc.
+    expires_on: Optional[date] = None
+    notes: str = ""
+    added_at: str
+    updated_at: str
+
+@dataclass(frozen=True)
+class PantryImportDraft:
+    id: str                       # short-lived draft id
+    client_id: str
+    proposed: tuple[ProposedItem, ...]
+    unresolved: tuple[str, ...]
+    created_at: str
+
+@dataclass(frozen=True)
+class ProposedItem:
+    raw_line: str
+    canonical_id: Optional[str]
+    display_name: str
+    display_qty: Optional[float]
+    display_unit: Optional[str]
+    quantity_grams: Optional[float]
+    confidence: float
+```
+
+### 4.3 Postgres
+
+Migration `011_pantry.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS nutrition_pantry (
+    client_id         TEXT NOT NULL REFERENCES nutrition_profiles(client_id)
+                          ON DELETE CASCADE,
+    canonical_id      TEXT NOT NULL,
+    quantity_grams    DOUBLE PRECISION NOT NULL,
+    display_qty       DOUBLE PRECISION,
+    display_unit      TEXT,
+    expires_on        DATE,
+    notes             TEXT,
+    added_at          TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    PRIMARY KEY (client_id, canonical_id)
+);
+CREATE INDEX ON nutrition_pantry (client_id, expires_on) WHERE expires_on IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS nutrition_pantry_import_drafts (
+    draft_id     TEXT PRIMARY KEY,
+    client_id    TEXT NOT NULL,
+    payload_json JSONB NOT NULL,
+    expires_at   TIMESTAMPTZ NOT NULL,  -- short TTL, e.g. 1 hour
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+One row per `(client_id, canonical_id)`. Re-adding an existing
+canonical id on POST increments the existing quantity rather than
+inserting a duplicate.
+
+### 4.4 API
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET`    | `/pantry/{client_id}` | List pantry items; optional `?sort=expiring\|name\|added_desc` |
+| `POST`   | `/pantry/{client_id}/items` | Add one item; body: `{canonical_id OR raw_name, display_qty, display_unit, expires_on?, notes?}` |
+| `PUT`    | `/pantry/{client_id}/items/{canonical_id}` | Update quantity/expiry |
+| `DELETE` | `/pantry/{client_id}/items/{canonical_id}` | Remove |
+| `POST`   | `/pantry/{client_id}/import` | Submit a text dump; returns `PantryImportDraft` for user review |
+| `POST`   | `/pantry/{client_id}/import/{draft_id}/confirm` | Commit a reviewed draft (accepting subset of proposed items) |
+| `DELETE` | `/pantry/{client_id}/import/{draft_id}` | Discard draft |
+| `GET`    | `/pantry/{client_id}/expiring?days=3` | Items expiring within `days` (default 3) |
+
+All write endpoints are synchronous. Import parse is the only
+endpoint that calls an LLM; it is explicitly a two-step (parse →
+confirm) flow.
+
+### 4.5 Bulk import parser
+
+`POST /pantry/{client_id}/import` accepts a text blob:
+
+```
+2 onions
+half a bag of frozen spinach
+1 L milk, use by Apr 20
+mysterious leftovers (some tomato sauce)
+```
+
+Flow:
+
+1. Split on newlines and commas.
+2. For each line, first run SPEC-005's `parse_ingredient` to
+   resolve deterministically.
+3. For lines that fail to resolve confidently, call
+   `llm_service.structured_output` with a locked schema returning
+   `ProposedItem[]`. Prompt rules:
+   - *"Only propose items that map to the provided canonical food
+     list."*
+   - *"If a line does not map, put it in `unresolved`, do not
+     invent."*
+   - *"Quantities that are not numeric (e.g. 'some', 'half a bag')
+     return `None` and we ask the user."*
+4. Build a `PantryImportDraft`, persist it for the confirm step.
+5. Return the draft to the user for review.
+
+The confirm step takes `{accept: [canonical_id], modify: [ProposedItem]}`
+and commits. Unaccepted proposals are dropped. Unresolved raw
+lines are never silently added.
+
+### 4.6 Grocery-list subtraction (integration with SPEC-014)
+
+SPEC-014's `GroceryList` grows two fields per item (additive):
+
+```python
+class GroceryItem(BaseModel):
+    # existing...
+    on_hand_grams: float = 0.0
+    needed_grams: float = 0.0      # total_grams - on_hand_grams
+    needed_purchase_qty: float = 0.0  # rounded from needed_grams
+```
+
+`build_grocery_list` is updated to call
+`pantry.subtract.apply(gram_totals, client_id)` before purchase-
+unit conversion. Ordering:
+
+1. Aggregate by canonical_id (existing SPEC-014 step).
+2. Subtract pantry quantities (new).
+3. Apply waste buffer and purchase-unit rounding (existing).
+4. Expose both `total_grams` and `on_hand_grams` in the response
+   so the UI can show "needed 300 g, have 100 g" clearly.
+
+Edge cases:
+
+- Pantry has more than the recipe needs → `needed_grams=0`; the
+  item does not appear in the shopping total but remains visible
+  with a "✓ on hand" chip.
+- Pantry items not in the plan are untouched.
+- Regeneration on plan change re-subtracts; no persistent pantry
+  state leaks across plans.
+
+### 4.7 Near-expiry hints
+
+`GET /pantry/{client_id}/expiring?days=3` returns items with
+`expires_on - now ≤ days`.
+
+On `POST /plan/meals` (SPEC-010 orchestrator), before the planner
+runs, fetch expiring items and include them in the prompt as a
+soft preference:
+
+```
+Pantry items expiring soon (prefer recipes that use them):
+  - Tofu (firm, 400 g, expires in 2 days)
+  - Cilantro (small bunch, expires in 3 days)
+  - Greek yogurt (200 g, expires in 4 days)
+```
+
+The planner does **not** have to use them. Restrictions and targets
+still win. Hints are one-shot per plan; we do not re-assert them on
+swap unless the user re-plans.
+
+### 4.8 Auto-debit hook (for SPEC-018)
+
+Profile additive field:
+
+```python
+class ClientProfile(BaseModel):
+    # existing...
+    pantry_auto_debit: bool = False
+```
+
+Off by default. When on, SPEC-018's `POST /cooked` event reads
+the recipe's parsed ingredients and decrements
+`nutrition_pantry.quantity_grams` by the proportional amount. If
+decrement would go negative, clamp to 0 and log a structured
+event (audit; mismatched pantry happens and is fine — we surface
+it, we do not try to reason about it).
+
+This spec only defines the hook and the profile flag. The actual
+hook consumer is SPEC-018.
+
+### 4.9 UI
+
+- Pantry tab on the profile or plan screen.
+- Empty state: large "add items" affordance + "import from a text
+  dump" CTA. Deliberately inviting — low activation cost.
+- List view sorted by expiry first, then alphabetical.
+- Each row shows display qty/unit, expiry pill (colored by
+  proximity), notes, and quick actions (edit, remove, -1 usage,
+  mark finished).
+- Import flow: paste → preview modal with per-line checkboxes →
+  confirm.
+- On the grocery list (SPEC-014), "on hand" chips visible per
+  item; clicking drills through to the pantry row.
+- Plan view: banner "3 items are expiring soon — we mentioned them
+  when generating your plan" (when hints influenced the prompt).
+
+### 4.10 Observability
+
+- `pantry.item_added{source}` — `manual | import | grocery_check_in`.
+- `pantry.item_removed{source}` — `manual | auto_debit | cleanup`.
+- `pantry.expiring_items_hinted` per plan generation.
+- `pantry.import.draft_created` and `pantry.import.draft_confirmed`.
+- `pantry.import.unresolved_lines` histogram.
+- `pantry.subtract.applied` per grocery-list build.
+
+### 4.11 Privacy
+
+- Pantry is personal. Deleted on account deletion via cascade.
+- Import parse LLM calls do not include client_id or profile
+  context; only the pasted text + the canonical taxonomy.
+- Raw text dumps are not logged at INFO or above; only length and
+  resolution counts.
+
+### 4.12 Priority-grouped work items
+
+| # | Item | Priority |
+|---|------|----------|
+| W1 | Module scaffolding, version, types | P0 |
+| W2 | Migration `011_pantry.sql` + schema registration | P0 |
+| W3 | `store.py` CRUD + tests | P0 |
+| W4 | `subtract.py` with integration into SPEC-014 grocery builder | P0 |
+| W5 | API endpoints (single-item CRUD + GET expiring) | P0 |
+| W6 | Import parser with two-step (parse → confirm) flow | P1 |
+| W7 | Near-expiry hints plumbed into SPEC-010 planner call | P1 |
+| W8 | `pantry_auto_debit` flag on profile (additive) | P0 |
+| W9 | UI: pantry tab list view + empty state | FE | P1 |
+| W10 | UI: add/edit/remove modals | FE | P1 |
+| W11 | UI: import preview modal | FE | P2 |
+| W12 | UI: grocery list "on hand" chips | FE | P1 |
+| W13 | Observability counters | P1 |
+| W14 | Benchmarks: pantry read ≤ 30 ms; subtract ≤ 10 ms | P2 |
+
+---
+
+## 5. Rollout Plan
+
+Flag `NUTRITION_PANTRY` (off → endpoints hidden, on → surfaced).
+
+### Phase 0 — Foundation (P0)
+- [ ] W1–W3 landed. Migration in staging.
+
+### Phase 1 — Core pantry behind flag (P0)
+- [ ] W4–W5, W8 landed.
+- [ ] SPEC-014 grocery-list `on_hand` fields appear when flag on.
+- [ ] Flag on internal. Dogfood team adds items and shops from
+      reduced list.
+
+### Phase 2 — Hints + import (P1)
+- [ ] W6, W7 landed.
+- [ ] W9–W12 UI shipped.
+- [ ] Acceptance gate: reviewer agrees that near-expiry hints
+      show up in 4 of 5 plans generated with expiring items in
+      the pantry; import preview is correct on 8 of 10 dumps.
+
+### Phase 3 — Ramp (P1)
+- [ ] 10% → 50% → 100% over two weeks.
+- [ ] Watch: pantry item count per user (growth curve), import
+      usage, grocery-list "✓ on hand" rate.
+
+### Phase 4 — Cleanup (P1/P2)
+- [ ] W11 import modal polish; W13 observability; W14 benchmarks.
+- [ ] Flag default on; removal scheduled.
+
+### Rollback
+- Flag off → endpoints return 404; grocery-list omits `on_hand`
+  fields (backwards-compatible JSON for the UI).
+- Pantry rows retained.
+- Additive migration.
+
+---
+
+## 6. Verification
+
+### 6.1 Unit tests
+
+- `test_pantry_crud.py` — round-trip CRUD; adding existing
+  canonical id increments rather than duplicates.
+- `test_subtract_exact.py` — pantry has exactly what the plan
+  needs → needed_grams = 0.
+- `test_subtract_partial.py` — pantry has less → needed_grams =
+  total - on_hand.
+- `test_subtract_more.py` — pantry has more → needed_grams = 0,
+  extra is not consumed.
+- `test_import_parser_deterministic.py` — lines resolvable by
+  SPEC-005 do not call LLM.
+- `test_import_parser_llm_fallback.py` — ambiguous lines produce
+  ProposedItem with confidence scores and reach the preview.
+- `test_import_confirm_subset.py` — confirming 2 of 3 proposed
+  items commits only those 2.
+- `test_expiring_query.py` — boundary cases at the `days`
+  threshold.
+
+### 6.2 Integration tests
+
+- `test_grocery_list_with_pantry.py` — plan plus pantry produces
+  correct `needed` vs. `total` fields; items fully covered by
+  pantry are marked on-hand; removing a pantry item regenerates
+  correctly.
+- `test_plan_hints_from_pantry.py` — pantry with an item expiring
+  in 2 days causes the planner prompt to include that item; with
+  no expiring items the prompt is unchanged.
+- `test_import_roundtrip.py` — paste → draft → confirm (subset) →
+  pantry reflects confirmed items only.
+- `test_auto_debit_hook_placeholder.py` — hook interface callable;
+  no behavior without SPEC-018 wiring (sanity test for future
+  integration).
+
+### 6.3 Reviewer audit (Phase 2)
+
+- 5 internal users paste their actual pantries for import; review
+  preview accuracy. Target: ≥80% of lines resolved to a canonical
+  id with correct qty/unit.
+- 5 plans generated with 2–5 expiring items in the pantry; review
+  whether the planner incorporated them where sensible.
+
+### 6.4 Observability
+
+All §4.10 counters emit in staging.
+
+### 6.5 Privacy
+
+Log-redaction grep: zero pantry item names or import text at INFO
+or above in production logs.
+
+### 6.6 Cutover criteria
+
+- All P0/P1 tests green.
+- Phase 2 reviewer gates met.
+- Phase 3 ramp: import-resolution rate ≥ 80%, no data-loss
+  incidents.
+
+---
+
+## 7. Open Questions
+
+- **Quantity semantics: bags, packages.** "Half a bag of frozen
+  spinach" — we do not reliably know a bag's grams. v1 surfaces
+  this as unresolved-quantity and asks the user. Later we can seed
+  package-size metadata on `canonical_foods.yaml`.
+- **Leftover tracking.** Cooking 4 servings when the user eats 2
+  leaves 2 servings of leftovers. v1 has no leftover model;
+  SPEC-018's cook-mode event could opt-in to "leftovers saved"
+  which becomes a pantry add. Backlogged.
+- **Mobile-first input.** v1 is web. Adding items one by one is
+  clunky. Barcode scanning (mobile) and photo OCR are on the v2
+  roadmap.
+- **Multi-profile household.** Out of scope here; also
+  pre-empted in ADR-001 household-member work which is profile-
+  shared, not pantry-shared.

--- a/system_design/specs/SPEC-016-nutrition-ingredient-substitution.md
+++ b/system_design/specs/SPEC-016-nutrition-ingredient-substitution.md
@@ -1,0 +1,456 @@
+# SPEC-016: Ingredient substitution endpoint
+
+| Field       | Value                                                    |
+|-------------|----------------------------------------------------------|
+| **Status**  | Proposed                                                 |
+| **Author**  | Nutrition & Meal Planning team                           |
+| **Created** | 2026-04-17                                               |
+| **Priority**| P1 within ADR-005                                        |
+| **Scope**   | New module `backend/agents/nutrition_meal_planning_team/substitution/`, API endpoint, planner-prompt variant, UI substitution dialog |
+| **Depends on** | SPEC-007 (guardrail), SPEC-009 (recipe nutrients), SPEC-010 (swap primitive), SPEC-013 (retrieval, reused), SPEC-015 (pantry, optional) |
+| **Implements** | ADR-005 §3 (substitution) |
+
+---
+
+## 1. Problem Statement
+
+Users run into ingredient problems mid-cook: out of Greek yogurt, no
+Parmesan, kid refuses mushrooms. They need a substitute that (a)
+keeps the recipe working, (b) stays inside the profile's allergen
+and dietary constraints, and (c) does not silently wreck the day's
+nutrient targets.
+
+SPEC-010 already ships the `/swap` primitive for a different use
+case — repair-loop-driven whole-recipe replacement. This spec
+specializes that pattern for **ingredient-level substitution
+within a single recipe**, with three concrete upgrades:
+
+1. A deterministic shortlist of common substitutions that does not
+   require an LLM.
+2. A pantry-preferred mode (SPEC-015): if the user has a viable
+   swap on hand, prefer it.
+3. Explicit nutrient-delta reporting so the user sees the impact.
+
+The endpoint is the one ADR-005 §3 calls for. ADR-004's retrieval
+module is reused for "similar recipe" suggestions when ingredient-
+level substitution is not sufficient.
+
+---
+
+## 2. Current State
+
+### 2.1 After SPEC-010
+
+- `/plan/meals/{plan_id}/recipes/{rec_id}/swap` replaces a whole
+  recipe under a `SwapConstraint`. No ingredient-level API.
+
+### 2.2 Gaps
+
+1. No ingredient-level substitute endpoint; users with one missing
+   item have to regenerate a whole meal.
+2. No shortlist of known-good swaps; every replacement burns an
+   LLM call.
+3. No pantry awareness when suggesting alternatives.
+4. No explicit nutrient-impact preview — users trust or don't, but
+   can't see the delta.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- Ship `POST /recipes/{rec_id}/substitute` that returns **one or
+  more substitution candidates** for a specified ingredient in
+  a specific recorded recipe, each with:
+  - the proposed `canonical_id` + display name
+  - adjusted quantity (to maintain rough equivalence)
+  - a nutrient delta vs. the original
+  - a guardrail pass/flag result for the substituted recipe
+  - a confidence score and a short rationale
+- Use a deterministic shortlist (`common_subs.yaml`) for ~200 most
+  common swaps; fall back to an LLM call only when the shortlist
+  has no entry.
+- Honor pantry preference when the user has relevant items on
+  hand.
+- Always run the SPEC-007 guardrail on the post-substitution
+  recipe — a substitution never bypasses allergen/diet checks.
+- Commit-or-preview: the endpoint returns candidates; a second
+  call `/commit` persists the chosen swap and updates the plan's
+  rollup.
+- Reuse SPEC-013's retrieval module for whole-recipe alternates
+  when no ingredient swap fits (e.g. "no mushrooms and no cream →
+  just propose a different recipe with the same meal slot").
+
+### 3.2 Non-goals
+
+- **No recipe-scaling swaps.** Substituting a full protein (chicken
+  → tofu) that changes the recipe character fundamentally is
+  treated as "whole-recipe swap" and dispatched to SPEC-010.
+- **No persistent "my preferred swap" rules.** SPEC-012's overrides
+  already cover "avoid cilantro"; substitution is in-the-moment.
+- **No cross-recipe propagation.** Substituting in one recipe does
+  not auto-apply to others that contain the same ingredient.
+- **No multi-ingredient simultaneous substitution in v1.** One
+  ingredient per call. Multi-ingredient is v1.1.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 Module layout
+
+```
+backend/agents/nutrition_meal_planning_team/substitution/
+├── __init__.py                # propose_substitutes, commit_substitute, SUB_VERSION
+├── version.py                 # SUB_VERSION = "1.0.0"
+├── types.py                   # SubCandidate, SubProposal, CommittedSub
+├── shortlist.py               # deterministic swap table
+├── data/
+│   └── common_subs.yaml       # ~200 canonical-id-to-canonical-id swaps
+├── llm_sub.py                 # LLM fallback when shortlist misses
+├── pantry_prefer.py           # pantry-aware ranking
+├── commit.py                  # writes the swap; recomputes rollup
+├── errors.py
+└── tests/
+```
+
+### 4.2 Shortlist
+
+`common_subs.yaml` structure:
+
+```yaml
+greek_yogurt:
+  - replacement: sour_cream
+    equivalence_ratio: 1.0        # 1 g sour cream per 1 g yogurt
+    use_cases: [dressing, sauce, dip]
+    note: "Richer in fat; similar tang."
+  - replacement: silken_tofu
+    equivalence_ratio: 1.0
+    use_cases: [creamy_base, baking]
+    note: "Blends smoothly; lower fat."
+  - replacement: cashew_cream
+    equivalence_ratio: 0.9
+    use_cases: [creamy_base, sauce]
+    note: "Nut-based; check profile."
+butter:
+  - replacement: olive_oil
+    equivalence_ratio: 0.85
+    use_cases: [sauteing]
+    note: "Do not use for baking."
+  - replacement: ghee
+    equivalence_ratio: 1.0
+    use_cases: [sauteing, baking]
+    note: "Lactose-free; still dairy allergen."
+milk:
+  - replacement: oat_milk
+    equivalence_ratio: 1.0
+    use_cases: [baking, cereal, sauce]
+    note: "Check gluten tolerance (some oats are cross-contaminated)."
+```
+
+`use_cases` are tags describing when the swap is appropriate. The
+request carries an optional `use_case` hint; without it we rank
+all replacements but mark those with mismatched use cases as
+lower-confidence.
+
+v1 covers ~200 pairs: dairy fats, dairy liquids, eggs, common oils,
+gluten grains/flours, common acids, aromatic herbs, cheese groups.
+Reviewer sign-off on every pair; cited in comments.
+
+### 4.3 Types
+
+```python
+@dataclass(frozen=True)
+class SubCandidate:
+    from_canonical_id: str
+    to_canonical_id: str
+    display_name: str
+    replacement_qty_grams: float
+    equivalence_ratio: float
+    rationale: str
+    source: Literal["shortlist", "llm", "pantry_prefer"]
+    confidence: float
+    guardrail_result: Literal["passed", "flagged", "rejected"]
+    guardrail_flags: tuple[str, ...]
+    nutrient_delta_per_serving: dict[Nutrient, float]
+    plan_impact: dict[Nutrient, float]        # per-day change if committed
+    on_hand_in_pantry: bool
+
+@dataclass(frozen=True)
+class SubProposal:
+    recipe_id: str
+    target_ingredient: str             # canonical_id or raw string
+    candidates: tuple[SubCandidate, ...]
+    fallback_whole_recipe: Optional[RecipeSummary] = None   # from SPEC-013
+    proposal_version: str
+    generated_at: str
+```
+
+### 4.4 API
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST` | `/recipes/{rec_id}/substitute` | Propose substitutes. Body: `{target_canonical_id? OR raw_name?, use_case?, reason?}`. Returns `SubProposal`. Does not mutate. |
+| `POST` | `/recipes/{rec_id}/substitute/commit` | Commit a chosen candidate. Body: `{to_canonical_id, replacement_qty_grams?, note?}`. Returns `CommittedSub` + updated plan rollup. |
+| `GET`  | `/recipes/{rec_id}/substitute/history` | List previously committed subs on this recipe (audit) |
+
+Notes:
+
+- `target_canonical_id` is preferred; `raw_name` resolves via
+  SPEC-005's parser and returns 400 if ambiguous (the UI can then
+  show the ambiguity to the user).
+- `use_case` is one of the `common_subs.yaml` tags plus free text;
+  free text lowers confidence and biases toward LLM fallback.
+
+### 4.5 Proposal pipeline
+
+```mermaid
+flowchart TD
+    R["POST /substitute"] --> F[Find target ingredient in recipe]
+    F --> S{shortlist hit?}
+    S -->|yes| SHORT["take shortlist candidates<br/>(all replacements)"]
+    S -->|no| LLM[LLM fallback: single<br/>structured-output call<br/>respecting taxonomy]
+    SHORT --> P[pantry_prefer: flag on-hand candidates<br/>and bump their rank]
+    LLM --> P
+    P --> QTY["compute replacement_qty_grams<br/>via equivalence_ratio"]
+    QTY --> SWAP[Build substituted recipe]
+    SWAP --> GR["SPEC-007 guardrail.check_recommendation"]
+    GR --> NR[SPEC-009 compute_recipe_nutrients]
+    NR --> PL["plan_impact via reapplying<br/>SPEC-009 rollup over plan"]
+    PL --> RANK["rank by: guardrail_result,<br/>pantry_prefer,<br/>confidence,<br/>plan_impact severity"]
+    RANK --> OUT["return SubProposal<br/>(N candidates, default 3)"]
+```
+
+- Up to **3 candidates** returned by default; at least one
+  shortlist-sourced if the shortlist has entries.
+- Candidates that fail the guardrail are still returned but
+  ranked last and marked `guardrail_result=rejected` — users see
+  *why* a swap is off-limits.
+- If no candidate passes and the shortlist is exhausted, a
+  single whole-recipe fallback is fetched via SPEC-013
+  retrieval filtered by meal slot and attached as
+  `fallback_whole_recipe`. UI surfaces this as a separate action
+  ("try a different recipe instead").
+
+### 4.6 LLM fallback
+
+When the shortlist has no entry for the target, one single
+structured-output LLM call with:
+
+- The full original recipe (ingredients + rationale).
+- The target ingredient to replace.
+- The user's allergen/dietary tags.
+- Optional `use_case` hint.
+- Strict schema: array of up to 3 `LlmSubSuggestion` items with
+  `{to_canonical_id, equivalence_ratio, rationale}`.
+
+Every `to_canonical_id` must be in SPEC-005's catalog; the LLM is
+told "if no canonical match, leave it out." Invalid canonical ids
+are dropped.
+
+### 4.7 Commit flow
+
+`/commit` writes the chosen candidate:
+
+1. Verify the proposal hasn't expired (TTL 30 min).
+2. Mutate the recipe's parsed ingredients: remove the original,
+   insert the substitute at `replacement_qty_grams`.
+3. Re-run SPEC-007 guardrail (belt-and-suspenders, commit-time).
+4. Re-run SPEC-009 `compute_recipe_nutrients`.
+5. Call SPEC-010's `rollup_plan` to update the plan's rollup.
+6. Persist the change: append to `nutrition_recipe_substitutions`;
+   update `nutrition_recommendations` with the new ingredient
+   list and nutrients (mark as `is_modified=true`).
+7. Invalidate the grocery list (SPEC-014 auto-regen trigger).
+8. If profile has `pantry_auto_debit=true`, update pantry via
+   SPEC-015's hook only on cook-event completion (SPEC-018), not
+   on substitution commit itself — cooking is what consumes
+   pantry, not planning.
+
+### 4.8 Persistence
+
+Migration `012_substitutions.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS nutrition_recipe_substitutions (
+    id                    BIGSERIAL PRIMARY KEY,
+    recommendation_id     TEXT NOT NULL
+                              REFERENCES nutrition_recommendations(recommendation_id)
+                              ON DELETE CASCADE,
+    from_canonical_id     TEXT NOT NULL,
+    to_canonical_id       TEXT NOT NULL,
+    replacement_qty_grams DOUBLE PRECISION NOT NULL,
+    source                TEXT NOT NULL,         -- shortlist | llm | pantry_prefer
+    nutrient_delta_json   JSONB NOT NULL,
+    note                  TEXT,
+    committed_at          TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX ON nutrition_recipe_substitutions (recommendation_id);
+
+CREATE TABLE IF NOT EXISTS nutrition_substitution_proposals (
+    proposal_id   TEXT PRIMARY KEY,
+    client_id     TEXT NOT NULL,
+    recipe_id     TEXT NOT NULL,
+    payload_json  JSONB NOT NULL,
+    expires_at    TIMESTAMPTZ NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+### 4.9 UI
+
+- Each ingredient in the recipe card gets a subtle "swap" icon.
+  Clicking opens a dialog.
+- Dialog shows up to 3 candidates with:
+  - Visual diff of the ingredient line.
+  - Per-serving nutrient delta: green deltas for improvements,
+    red for cap-approaching.
+  - "✓ in your pantry" chip on pantry-preferred candidates.
+  - Guardrail status: ✓ passed / ⚠ flagged / ✗ allergen conflict.
+  - Source tag: "common swap" / "suggested" / "from your pantry".
+- User selects one → Commit → confirmation with delta preview.
+- If all candidates fail guardrail: dialog shows the
+  `fallback_whole_recipe` CTA ("try a different dinner instead").
+
+### 4.10 Observability
+
+- `substitution.proposal{source}` — shortlist, llm, pantry_prefer.
+- `substitution.commit{guardrail_result}`.
+- `substitution.fallback_recipe_offered` counter.
+- `substitution.latency_ms` histogram (proposal; commit
+  separately).
+- `substitution.shortlist_miss{target_canonical_id}` top-K — fuels
+  shortlist additions.
+
+### 4.11 Priority-grouped work items
+
+| # | Item | Priority |
+|---|------|----------|
+| W1 | Module scaffolding, version, types | P0 |
+| W2 | Migration `012_substitutions.sql` | P0 |
+| W3 | `common_subs.yaml` v1 (~200 pairs) + reviewer sign-off | P0 |
+| W4 | `shortlist.py` loader + lookup + tests | P0 |
+| W5 | `pantry_prefer.py` integration with SPEC-015 | P1 |
+| W6 | `llm_sub.py` with structured-output schema | P0 |
+| W7 | Proposal pipeline + ranking + nutrient deltas | P0 |
+| W8 | `POST /substitute` endpoint | P0 |
+| W9 | `POST /substitute/commit` endpoint + rollup update + grocery invalidation | P0 |
+| W10 | `GET /substitute/history` | P1 |
+| W11 | Fallback whole-recipe integration with SPEC-013 | P1 |
+| W12 | UI: substitution dialog + ingredient swap icons | FE | P1 |
+| W13 | UI: nutrient-delta visualization | FE | P2 |
+| W14 | Observability counters + shortlist-miss dashboard | P1 |
+| W15 | Benchmarks: proposal p99 ≤ 2 s (shortlist) / ≤ 4 s (LLM) | P2 |
+
+---
+
+## 5. Rollout Plan
+
+Flag `NUTRITION_SUBSTITUTION` (off → endpoints hidden; on →
+surfaced).
+
+### Phase 0 — Data (P0)
+- [ ] W3 `common_subs.yaml` reviewed.
+- [ ] W1, W2 landed.
+
+### Phase 1 — Backend behind flag (P0)
+- [ ] W4–W9 landed. Flag on internal.
+- [ ] Dogfood team performs 20 substitutions across recipes;
+      acceptance gate: shortlist hit ≥70%; LLM fallback produces
+      valid canonical ids in ≥90% of calls.
+
+### Phase 2 — UI + pantry (P1)
+- [ ] W5 pantry prefer; W10–W12 UI.
+- [ ] Acceptance gate: user tests show the dialog is clear (nutrient
+      delta + guardrail status readable at a glance).
+
+### Phase 3 — Ramp (P1)
+- [ ] 10% → 50% → 100% over two weeks.
+- [ ] Watch shortlist-miss dashboard; add missing pairs weekly.
+
+### Phase 4 — Cleanup (P1/P2)
+- [ ] W13–W15 landed.
+
+### Rollback
+- Flag off → endpoints 404. Committed substitutions retained.
+- Migration additive.
+
+---
+
+## 6. Verification
+
+### 6.1 Unit tests
+
+- `test_shortlist_lookup.py` — every pair in `common_subs.yaml`
+  round-trips.
+- `test_equivalence_qty.py` — replacement_qty_grams honors ratio.
+- `test_pantry_prefer_ranking.py` — pantry-on-hand candidates rank
+  above same-confidence non-pantry.
+- `test_guardrail_rejected_last.py` — candidates that fail
+  guardrail sorted last but returned.
+- `test_llm_fallback_canonical_only.py` — LLM suggestions with
+  non-canonical ids are dropped.
+
+### 6.2 Integration tests
+
+- `test_substitute_commit.py` — proposal → commit mutates
+  recommendation; rollup recomputed; grocery list invalidated
+  (SPEC-014 regen on read).
+- `test_substitute_expired_proposal.py` — committing past TTL
+  returns 410.
+- `test_substitute_allergen_reject.py` — user with cashew allergy
+  gets "cashew cream" flagged as rejected in response; commit
+  call rejects it.
+- `test_fallback_recipe.py` — recipe where all candidates fail →
+  proposal includes `fallback_whole_recipe` pulled via SPEC-013.
+- `test_parity_with_swap_endpoint.py` — committing a whole-recipe
+  replacement via fallback routes through SPEC-010's `/swap`;
+  plan state matches either path.
+
+### 6.3 Fixture red-team
+
+Same spirit as SPEC-007:
+
+- Shortlist entry `butter → ghee` offered to a lactose-intolerant
+  user → flagged (ghee still dairy).
+- `milk → oat_milk` offered to a celiac user → flagged (oats
+  commonly cross-contaminated; `oat_milk` has `gluten` dietary
+  tag unless `certified_gluten_free` variant).
+- LLM returning `silken_tofu` for a soy-allergic user → dropped by
+  guardrail; alternate candidates considered.
+
+### 6.4 Reviewer audit (Phase 1)
+
+- 20 real substitutions; reviewer confirms candidates are
+  reasonable in ≥17/20 cases.
+
+### 6.5 Observability
+
+All §4.10 counters emit; shortlist-miss dashboard populated in
+staging.
+
+### 6.6 Cutover criteria
+
+- All P0 tests green.
+- Phase 1 acceptance gate met.
+- Phase 3 ramp with no safety incidents.
+- Clinical reviewer + team lead sign-off on `common_subs.yaml`.
+
+---
+
+## 7. Open Questions
+
+- **Multi-ingredient substitution.** A recipe missing two items
+  (no yogurt, no dill) today requires two calls. v1.1.
+- **"Surprise me" swap.** A deliberately variety-adding
+  substitution (not user-requested but system-offered) — separate
+  feature; would live closer to SPEC-013 retrieval. Backlogged.
+- **Persistent household swaps.** "We always use ghee instead of
+  butter" — a household-level rule. v1 has none; SPEC-012
+  overrides almost cover it but are per-dimension, not per-pair.
+  Potential v2 feature.
+- **Quantity-based commit override.** User may want to commit with
+  a different replacement quantity than the suggested ratio. v1
+  accepts optional `replacement_qty_grams` in the commit body to
+  allow this.

--- a/system_design/specs/SPEC-017-nutrition-calendar-reminders.md
+++ b/system_design/specs/SPEC-017-nutrition-calendar-reminders.md
@@ -1,0 +1,450 @@
+# SPEC-017: Calendar sync and prep-time-aware reminders
+
+| Field       | Value                                                    |
+|-------------|----------------------------------------------------------|
+| **Status**  | Proposed                                                 |
+| **Author**  | Nutrition & Meal Planning team (+ Integrations team coordination) |
+| **Created** | 2026-04-17                                               |
+| **Priority**| P2 within ADR-005 (last-mile launch; high perceived value, low risk) |
+| **Scope**   | New module `backend/agents/nutrition_meal_planning_team/calendar_sync/`, Google Calendar integration via Integrations team, Postgres sync state, UI controls |
+| **Depends on** | SPEC-002 (`timezone` on profile), SPEC-009 (`prep_time_minutes`, `cook_time_minutes`), SPEC-018 (cook-mode deep links, optional) |
+| **Implements** | ADR-005 §4 (calendar + reminders) |
+
+---
+
+## 1. Problem Statement
+
+Users plan a week of meals and then forget to start Tuesday's
+shakshuka until 8:15 pm. The recipe needed 40 minutes of prep +
+cook, and dinner slips to 9.
+
+This spec syncs a plan's recipes to the user's Google Calendar as
+events placed at the user's meal windows, with reminders scheduled
+backwards from the mealtime by `prep_time + cook_time + buffer`.
+Event descriptions deep-link into cook mode (SPEC-018) and include
+the ingredient checklist and nutrient summary.
+
+It is deliberately the *last* ADR-005 capability: low technical
+risk (the Integrations team owns Google OAuth), high perceived
+value, and it crystallizes the "weekly operating system" thesis
+— the plan reaches the user at the moment they need it.
+
+---
+
+## 2. Current State
+
+### 2.1 Today
+
+- Plans carry optional `suggested_date`.
+- Profile carries `timezone` (from SPEC-002).
+- No calendar integration; users copy-paste into their own calendars
+  or forget.
+
+### 2.2 What exists on the platform
+
+Per CLAUDE.md and the existing `backend/agents/integrations/`:
+- Shared Google browser login and session infrastructure.
+- The team already has the primitives for Google OAuth and
+  Playwright-based fallbacks.
+
+This spec reuses that infrastructure; it does not build new OAuth.
+
+### 2.3 Gaps
+
+1. No sync endpoint.
+2. No event format or description standard.
+3. No reminder math tied to recipe prep + cook times.
+4. No idempotent delete/replace path for when a plan changes.
+5. No profile field for user's preferred meal windows.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- Ship `POST /plan/meals/{plan_id}/calendar/sync` that creates
+  calendar events for each dated recipe, with prep-time-aware
+  reminders firing before mealtime.
+- Reuse the Integrations team's Google Calendar client; no new
+  OAuth surface built in this spec.
+- Idempotent: re-syncing the same plan updates existing events
+  rather than creating duplicates. Dry-run mode available.
+- Namespaced events: every event description begins with
+  `[Khala Meals]` and carries a plan_id tag so users can filter
+  and we can cleanly remove.
+- Mealtime windows are per-profile; default sensible values; user-
+  editable. Timezone respected per SPEC-002.
+- DELETE endpoint removes all sync'd events for a plan.
+- Blast-radius minimization: new calendar writes require explicit
+  user opt-in per plan; a "dedicated calendar" option exists for
+  users who want separation.
+
+### 3.2 Non-goals
+
+- **No Apple iCloud / Outlook / other providers in v1.** Google
+  only. Others ride on the same event shape in follow-up specs.
+- **No in-app calendar view.** We write to the user's Google
+  Calendar; the UI shows "synced ✓" state and a link.
+- **No shared-calendar multi-household sync.** One user's calendar
+  per sync.
+- **No grocery-run calendar events.** A future v1.1 idea; not in
+  scope.
+- **No recipe-level timing (step timers).** SPEC-018 cook-mode owns
+  that. This spec is only about calendar events.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 Module layout
+
+```
+backend/agents/nutrition_meal_planning_team/calendar_sync/
+├── __init__.py            # sync_plan_to_calendar, delete_plan_events, CAL_VERSION
+├── version.py             # CAL_VERSION = "1.0.0"
+├── types.py               # CalendarSyncState, EventDraft, SyncResult
+├── builder.py             # plan → list[EventDraft]
+├── reminder.py            # prep+cook time reminder calculation
+├── sync.py                # idempotent upsert against Google Calendar
+├── google_adapter.py      # thin wrapper over integrations team's client
+├── errors.py
+└── tests/
+```
+
+### 4.2 Profile additions
+
+Additive on `ClientProfile.preferences`:
+
+```python
+class MealtimeWindow(BaseModel):
+    meal_type: str                 # 'breakfast' | 'lunch' | 'dinner' | 'snack'
+    hour: int                      # 0..23
+    minute: int                    # 0..59
+    day_override: Dict[int, tuple[int, int]] = {}
+    # per-weekday overrides keyed by weekday number 0=Mon
+
+class PreferencesInfo(BaseModel):
+    # existing...
+    mealtime_windows: list[MealtimeWindow] = []    # defaults seeded at profile creation
+    calendar_buffer_minutes: int = 10              # extra time added after cook
+    prefer_dedicated_calendar: bool = False
+```
+
+Defaults on new profiles: breakfast 07:30, lunch 12:30, dinner
+19:00. Users edit in the UI (existing preferences screen gains a
+"mealtimes" section).
+
+### 4.3 Event format
+
+```python
+@dataclass(frozen=True)
+class EventDraft:
+    recipe_id: str
+    plan_id: str
+    title: str                     # "[Khala Meals] Shakshuka (dinner)"
+    description: str               # see below
+    start: datetime                # localized to profile timezone
+    end: datetime
+    reminders_minutes_before: tuple[int, ...]  # prep+cook+buffer + courtesy
+    color: Optional[str] = None
+    source_id: str                 # idempotency key
+```
+
+Description template:
+
+```
+[Khala Meals]
+{recipe.display_name}
+Meal: {meal_type} • Serves {portions}
+Prep: {prep_time} min • Cook: {cook_time} min • Total: {total} min
+
+Ingredients (for {portions} servings):
+ - 400 g chicken thighs
+ - 1 can tomato
+ - ...
+
+Nutrients per serving:
+ {kcal} kcal • {protein_g} g P • {carbs_g} g C • {fat_g} g F
+
+Open in cook mode: {deep_link}   (SPEC-018)
+
+— Plan {plan_id}
+```
+
+The trailing `Plan {plan_id}` line is the idempotency anchor: sync
+parses it to identify events this plan owns, enabling idempotent
+upsert and clean delete.
+
+### 4.4 Reminder math
+
+For each dated recipe:
+
+```
+mealtime    = combine(suggested_date, profile.mealtime_windows[meal_type], profile.timezone)
+cook_start  = mealtime - cook_time
+prep_start  = cook_start - prep_time - buffer
+event_start = prep_start
+event_end   = mealtime + 30 min    # eating window
+reminders   = [
+    prep_time + cook_time + buffer,   # primary: "start cooking now"
+    courtesy_reminder_minutes,        # user-configurable, default 60 (e.g. "dinner tonight")
+]
+```
+
+If `prep_time` or `cook_time` is missing on the recipe, default to
+conservative values (15 + 20 min) and flag the event
+description with a note: *"(timing estimated)"*.
+
+### 4.5 Sync API
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST`   | `/plan/meals/{plan_id}/calendar/sync` | Create or update events. Body: `{dry_run?: bool, use_dedicated_calendar?: bool, only_meal_types?: list[str]}` |
+| `DELETE` | `/plan/meals/{plan_id}/calendar/sync` | Remove all events for this plan |
+| `GET`    | `/plan/meals/{plan_id}/calendar/sync` | Current sync state and event ids |
+| `GET`    | `/calendar/connected/{client_id}` | Returns `{connected: bool, email?: str}` — thin status wrapper over integrations team's auth state |
+
+Dry-run returns the event drafts the system would create without
+writing anything; the UI uses this for a preview modal.
+
+### 4.6 Idempotent upsert
+
+Sync is keyed on `source_id` (recipe_id + plan_id). The sync task:
+
+1. Query existing events in the target calendar where
+   `description` matches the `Plan {plan_id}` anchor OR
+   `source_id` extended property matches.
+2. Build the set of desired events from the plan.
+3. Diff:
+   - Present in plan and calendar → update if any field changed.
+   - Present in plan only → create.
+   - Present in calendar only → delete.
+4. Return a `SyncResult` summarizing created/updated/deleted counts
+   and any errors.
+
+The Google Calendar event carries an `extendedProperties.private`
+entry `{"khala_plan_id": plan_id, "khala_recipe_id": recipe_id}`
+for robust matching (description parsing as fallback).
+
+### 4.7 Dedicated calendar mode
+
+If `prefer_dedicated_calendar=true`:
+
+1. Ensure a calendar named "Khala Meals" exists (create if not).
+2. Write events there.
+3. User can hide/show the calendar without affecting their primary
+   view.
+
+Default is primary calendar; the dedicated mode is a safety valve
+for users nervous about event pollution.
+
+### 4.8 Persistence
+
+Migration `013_calendar_sync.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS nutrition_calendar_sync (
+    plan_id                     TEXT PRIMARY KEY,
+    client_id                   TEXT NOT NULL,
+    google_calendar_id          TEXT,
+    events_json                 JSONB NOT NULL,   -- recipe_id -> google event id
+    synced_at                   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    cal_version                 TEXT NOT NULL,
+    last_result_json            JSONB NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS nutrition_calendar_sync_audit (
+    id            BIGSERIAL PRIMARY KEY,
+    plan_id       TEXT NOT NULL,
+    client_id     TEXT NOT NULL,
+    action        TEXT NOT NULL,      -- sync | delete | dry_run | error
+    payload_json  JSONB NOT NULL,
+    recorded_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+```
+
+### 4.9 UI
+
+- "Add to Calendar" CTA on the plan screen. Disabled until the
+  user has connected Google.
+- Click → preview modal with:
+  - List of events that will be created (day, time, recipe).
+  - Reminder times per event.
+  - Toggle: primary vs. dedicated calendar.
+  - "Sync" / "Cancel" buttons.
+- After sync: inline "Synced ✓ on Apr 17 (12 events)" badge with
+  "Remove from calendar" and "Re-sync" actions.
+- Error state: "Couldn't write 1 event — please try again." with
+  structured error message.
+
+### 4.10 Plan-change handling
+
+When a plan changes (recipes added, swapped via SPEC-010, modified
+via SPEC-016, etc.) and the user had previously synced:
+
+- The sync is marked **stale** (`synced_at < plan.updated_at`).
+- UI shows "Plan changed — sync again?"
+- We do **not** auto-resync. Silent writes to the user's calendar
+  are exactly the kind of thing that erodes trust.
+
+### 4.11 Failure modes
+
+- Google API timeout → retry with exponential backoff; after 3
+  attempts, surface a structured error; do not partial-write (use
+  Google's batch mode to make writes atomic per event where
+  available).
+- Token expired / revoked → endpoint returns 401 with a
+  `reconnect_required=true` flag; UI prompts reconnection.
+- Rate limit hit → queue the sync via Temporal; notify when done.
+- Event count > 100 (unlikely on a weekly plan) → batch into
+  pages.
+
+### 4.12 Privacy and security
+
+- Calendar connections live in the integrations team's credential
+  store; this spec does not persist OAuth tokens directly.
+- Event descriptions contain recipe ingredients and nutrient
+  numbers; this is user data on user's own calendar. Acceptable
+  per the existing platform privacy posture.
+- We never include the user's profile ID, email, or any client-
+  specific PII in event descriptions.
+- Audit log (`nutrition_calendar_sync_audit`) retains metadata,
+  not event descriptions beyond a digest hash.
+
+### 4.13 Observability
+
+- `calendar.sync{result}` — `created | updated | deleted |
+  no_op | error`.
+- `calendar.events_per_sync` histogram.
+- `calendar.token_expired_total` (watch for reconnect storms).
+- `calendar.sync_duration_ms` histogram.
+- Alerts: error rate > 5% in an hour → page integrations on-call.
+
+### 4.14 Priority-grouped work items
+
+| # | Item | Priority |
+|---|------|----------|
+| W1 | Module scaffolding, version, types | P0 |
+| W2 | Profile additions (`MealtimeWindow`, `calendar_buffer_minutes`, `prefer_dedicated_calendar`) + migration | P0 |
+| W3 | Migration `013_calendar_sync.sql` + schema registration | P0 |
+| W4 | `builder.py` plan → event drafts; timezone handling tests | P0 |
+| W5 | `reminder.py` math + tests (including courtesy reminder) | P0 |
+| W6 | `google_adapter.py` wrapper over integrations client | P0 |
+| W7 | `sync.py` idempotent upsert + extendedProperties matching | P0 |
+| W8 | `/sync` + `/sync DELETE` + dry-run support | P0 |
+| W9 | Dedicated-calendar mode | P1 |
+| W10 | Plan-change staleness detection | P1 |
+| W11 | UI: "Add to Calendar" preview modal | FE | P1 |
+| W12 | UI: synced state + resync / remove CTAs | FE | P1 |
+| W13 | Mealtime editor in preferences UI | FE | P1 |
+| W14 | Error handling: reconnect flow + retry | P1 |
+| W15 | Observability counters + alerts | P1 |
+| W16 | Benchmarks: sync p99 ≤ 5 s for 14 events | P2 |
+
+---
+
+## 5. Rollout Plan
+
+Flag `NUTRITION_CALENDAR_SYNC` (off → UI hidden; on → surfaced).
+
+### Phase 0 — Foundation (P0)
+- [ ] W1–W7 landed. Migration in staging. Flag off.
+
+### Phase 1 — Internal dogfood (P0)
+- [ ] W8, W10 landed.
+- [ ] Flag on internal. Team members sync their real plans to
+      their real calendars.
+- [ ] Acceptance gate: zero duplicate events, zero incorrect
+      reminder times over 1 week of dogfood.
+
+### Phase 2 — UI + preferences (P1)
+- [ ] W11–W14 landed.
+- [ ] Reviewer: UX copy reviewed (preview modal text, reconnect
+      messaging).
+
+### Phase 3 — Ramp (P1)
+- [ ] 10% → 50% → 100% over two weeks.
+- [ ] Watch: sync error rate, token-expired rate, UI "Add to
+      Calendar" click-through.
+
+### Phase 4 — Cleanup (P1/P2)
+- [ ] W9 dedicated calendar.
+- [ ] W15, W16 observability + benchmarks.
+
+### Rollback
+- Flag off → UI hidden. Previously synced events **remain in
+  users' calendars** — we do not silently wipe. Users can
+  manually remove via calendar UI or hit `DELETE` before
+  rollback.
+- Migration additive.
+
+---
+
+## 6. Verification
+
+### 6.1 Unit tests
+
+- `test_reminder_math.py` — prep 15 + cook 25 + buffer 10 =
+  reminder at 50 min before mealtime.
+- `test_timezone.py` — profile tz=America/New_York produces event
+  localized correctly; DST transition week handled.
+- `test_event_description.py` — description template stable;
+  plan_id anchor appears exactly once.
+- `test_builder_missing_times.py` — recipe without prep/cook times
+  produces event with "(timing estimated)" and conservative
+  defaults.
+
+### 6.2 Integration tests (against Google API mock)
+
+- `test_idempotent_sync.py` — two consecutive syncs produce the
+  same event set; second sync is no-op.
+- `test_sync_diff.py` — plan with one new recipe and one swapped
+  recipe diffs correctly (1 create, 1 update, 0 delete).
+- `test_delete.py` — DELETE removes all plan events and only those.
+- `test_dedicated_calendar.py` — first sync creates "Khala Meals"
+  calendar; subsequent syncs reuse.
+- `test_reconnect_flow.py` — revoked token returns 401 with
+  reconnect flag; after reconnect a retry succeeds.
+- `test_rate_limit.py` — simulated 429 triggers Temporal-backed
+  background sync.
+
+### 6.3 Staleness tests
+
+- `test_plan_change_marks_stale.py` — editing the plan sets
+  `synced_at < plan.updated_at`; UI shows stale badge; resync
+  clears staleness.
+
+### 6.4 Observability
+
+All §4.13 counters emit in staging. Alerts routed to on-call
+test channel during Phase 2.
+
+### 6.5 Cutover criteria
+
+- All P0 tests green.
+- Phase 1 dogfood acceptance met.
+- Phase 3 ramp: sync error rate < 2%; reconnect prompts visible
+  and working.
+- Integrations team sign-off on reuse of their Google client.
+
+---
+
+## 7. Open Questions
+
+- **Event colors.** Google Calendar color is a limited palette; we
+  could color-code by meal type or leave user's default. v1 leaves
+  default; could add a toggle later.
+- **Past recipes.** Syncing a plan whose days include past dates
+  would create past events — silly. v1 skips any recipe whose
+  mealtime is in the past; the UI notes this on the preview.
+- **Multi-language event templates.** v1 English only. The event
+  description template is i18n-ready (keyed format string) but no
+  translations in v1.
+- **Granular mealtime by weekday (lunch at 13:00 on Mondays,
+  12:00 otherwise).** Supported by `MealtimeWindow.day_override`
+  but v1 UI only exposes the base schedule; overrides editable
+  via API.
+- **Fine-grained reminder customization (e.g. "no courtesy
+  reminder on weekends").** Out of scope; add in v1.1 with a
+  preference bundle.

--- a/system_design/specs/SPEC-018-nutrition-cook-mode-and-cooking-events.md
+++ b/system_design/specs/SPEC-018-nutrition-cook-mode-and-cooking-events.md
@@ -1,0 +1,518 @@
+# SPEC-018: Cook mode and structured cooking events
+
+| Field       | Value                                                    |
+|-------------|----------------------------------------------------------|
+| **Status**  | Proposed                                                 |
+| **Author**  | Nutrition & Meal Planning team                           |
+| **Created** | 2026-04-17                                               |
+| **Priority**| P1 within ADR-005 (biggest ADR-004 payoff; capstone for the "week-layer" workflow) |
+| **Scope**   | Data model (`steps`, `CookEvent`), API endpoints (`cook-mode`, `cooked`), UI cook-mode view, integration with SPEC-015 pantry auto-debit, feedback stream to SPEC-011 |
+| **Depends on** | SPEC-009 (recipe fields), SPEC-011 (feedback signals downstream), SPEC-015 (pantry hook, optional) |
+| **Implements** | ADR-005 §5 (cook mode + structured cooking feedback) |
+
+---
+
+## 1. Problem Statement
+
+Recipes today ship as a rationale + ingredient list. Users then
+leave the app to actually cook — they find the recipe on a phone
+held with oily fingers, scroll to the wrong place, and have no way
+to say "I made this" vs. "I didn't". The system has no adherence
+data; it only has preference data filtered through the narrow
+`FeedbackRecord` rating path.
+
+This spec closes the loop. Two things ship together:
+
+1. **Cook mode** — a step-ordered, timer-aware, hands-busy UI with a
+   backend data model (`steps: list[CookStep]`) that the meal-
+   planning agent can emit and the UI can render.
+2. **Cooking events** — `POST /cooked` structured events recording
+   `status ∈ {made, partial, skipped, swapped}`, servings_made,
+   per-ingredient substitutions observed, and optional
+   `FeedbackRecord`. This is the **data separation** of adherence
+   from preference that ADR-006's dashboard depends on.
+
+These are coupled because cook mode is where the event naturally
+gets emitted. Building them together also produces 10× the
+feedback volume at roughly the same user effort as today's rating
+dialog — which is the capstone payoff for ADR-004 and the
+prerequisite for ADR-006.
+
+---
+
+## 2. Current State
+
+### 2.1 Today
+
+- `MealRecommendation` carries ingredients and a rationale, no
+  structured steps.
+- `FeedbackRecord` carries `rating`, `would_make_again`, and
+  `notes`. One submission per recommendation, no concept of "did
+  the user actually cook it."
+- No cook-mode endpoint or UI.
+
+### 2.2 Gaps
+
+1. No structured steps to render a step-through UI.
+2. No timers tied to steps.
+3. No adherence data; we cannot tell "the user skipped Tuesday's
+   dinner" from "the user cooked it and hated it."
+4. ADR-006's entire goal-progress dashboard depends on the
+   adherence denominator that does not exist yet.
+5. ADR-004's preference extractor sees only rating-based feedback;
+   cook events would roughly 10× the signal volume.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- Extend `MealRecommendation` with `steps: list[CookStep]` — an
+  additive field the meal-planning agent emits and the UI renders.
+  Absent steps fall back to rationale-only mode.
+- Ship `GET /plan/meals/{plan_id}/recipes/{rec_id}/cook-mode`
+  returning the data a cook-mode UI needs: ordered steps, timers,
+  ingredients keyed to steps, nutrients per serving, allergen
+  flags, substitutions committed so far.
+- Ship `POST /plan/meals/{plan_id}/recipes/{rec_id}/cooked` that
+  records a structured `CookEvent` with adherence status and
+  optional preference feedback.
+- Feed `CookEvent` into SPEC-011's extractor so cooking signals
+  update learned preferences (SPEC-012) and the retrieval index
+  (SPEC-013).
+- If the profile has `pantry_auto_debit=true` (SPEC-015), decrement
+  pantry by the recipe's ingredient quantities on `status=made`.
+  Off by default.
+- Produce a separate `adherence_snapshot` row per cook event —
+  the input ADR-006 reads.
+
+### 3.2 Non-goals
+
+- **No voice control or wake words.** v1 is a tap UI. Voice is a
+  rich capability for a separate team.
+- **No image capture of cooked dishes.** v1 text-only.
+- **No social sharing.** v1 privacy-first; "share what I made" is
+  a future opt-in.
+- **No live multi-user cooking.** Single-user per session.
+- **No live timer state across devices.** Timers are local; server
+  persists only the event completion.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 Additive data model
+
+```python
+class CookStep(BaseModel):
+    order: int                           # 1-based
+    text: str                            # "Dice the onion and sauté until translucent."
+    timer_seconds: Optional[int] = None  # inline timer
+    ingredient_canonical_ids: List[str] = []
+    tool_tags: List[str] = []            # 'knife', 'oven', 'pan'
+    warning: Optional[str] = None        # "Oil is hot; be careful."
+
+class MealRecommendation(BaseModel):
+    # existing...
+    steps: List[CookStep] = []
+    equipment_tags: List[str] = []       # 'oven', 'blender', 'grill'
+```
+
+All additive; legacy recipes without `steps` fall back to the
+current rationale-only card. The meal-planning agent prompt is
+extended to emit `steps` (numbered, ~6–12 per recipe, with
+inline timer_seconds where appropriate). Structured-output
+schema enforces shape.
+
+### 4.2 Cook-mode API
+
+```python
+@dataclass(frozen=True)
+class CookModePayload:
+    recipe_id: str
+    display_name: str
+    steps: tuple[CookStep, ...]
+    ingredients: tuple[IngredientChip, ...]    # including pantry-on-hand flag
+    nutrients_per_serving: dict[Nutrient, float]
+    clinical_flags: tuple[str, ...]            # from SPEC-007
+    committed_substitutions: tuple[CommittedSub, ...]   # from SPEC-016
+    portions_servings_numeric: float
+    prep_time_minutes: Optional[int]
+    cook_time_minutes: Optional[int]
+```
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/plan/meals/{plan_id}/recipes/{rec_id}/cook-mode` | Returns `CookModePayload` |
+
+Read-only. Computes on demand from stored recipe + SPEC-016
+committed subs + SPEC-015 pantry; cached per `(recipe_id,
+recipe_updated_at)`.
+
+### 4.3 Cooked event API
+
+```python
+class Substitution(BaseModel):
+    from_canonical_id: str
+    to_canonical_id: str
+    note: Optional[str] = None
+
+class CookedEventRequest(BaseModel):
+    status: Literal["made", "partial", "skipped", "swapped"]
+    servings_made: Optional[float] = None
+    substitutions: List[Substitution] = []
+    feedback: Optional[FeedbackRecord] = None
+    occurred_at: Optional[str] = None            # ISO; defaults to now
+
+class CookEvent(BaseModel):
+    cook_event_id: str
+    recipe_id: str
+    plan_id: str
+    client_id: str
+    status: str
+    servings_made: Optional[float]
+    substitutions: List[Substitution]
+    feedback: Optional[FeedbackRecord]
+    occurred_at: str
+    recorded_at: str
+    effective_nutrients: Dict[Nutrient, float]    # computed per §4.5
+```
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST`   | `/plan/meals/{plan_id}/recipes/{rec_id}/cooked` | Record a cooking event |
+| `GET`    | `/plan/meals/{plan_id}/cooking-events` | List events for the plan |
+| `PATCH`  | `/plan/meals/cooking-events/{cook_event_id}` | Correct a recent event |
+| `DELETE` | `/plan/meals/cooking-events/{cook_event_id}` | Retract within 24 h |
+
+Correction / retraction exists because users mis-tap; beyond 24 h
+cook events become authoritative and corrections are admin-only.
+
+### 4.4 Status semantics
+
+- **`made`** — user cooked the recipe as planned; nutrient
+  contribution is the full recipe × `servings_made /
+  portions_servings_numeric`.
+- **`partial`** — started cooking but incomplete (ran out of
+  time, swapped mid-recipe). Requires `servings_made`. Nutrient
+  contribution scales proportionally.
+- **`skipped`** — did not cook; nutrient contribution is zero.
+  **Crucially** we do not assume the user ate nothing — off-plan
+  intake goes through ADR-006's quick-log (separate spec).
+- **`swapped`** — replaced with a different recipe outside our
+  plan. The user provides a `substitution` at the recipe level;
+  nutrient contribution is the substitute's best-effort estimate
+  (LLM parse if user provided text, zero if not).
+
+### 4.5 Effective nutrients
+
+On `POST /cooked`:
+
+1. Start with the recipe's nutrients (from SPEC-009 on the current
+   stored recipe — includes SPEC-016 substitutions already).
+2. Apply additional per-event substitutions from the request
+   (quantified via SPEC-005 densities + SPEC-008 nutrients).
+3. Scale by `servings_made / portions_servings_numeric`.
+4. Status `skipped` → all zeros.
+
+The computed `effective_nutrients` is persisted on the event and
+is what ADR-006's **eaten rollup** reads. It is distinct from the
+recipe's static nutrients.
+
+### 4.6 Downstream integrations
+
+**SPEC-011 (feedback signals).** Every `CookEvent` with a non-
+skipped status produces a `FeedbackSignals` call:
+
+- `status=made` with `FeedbackRecord` → same as today's feedback,
+  but the note now has much richer context.
+- `status=partial` → a derived signal on `prep_time` dimension:
+  weekday→negative if on weekdays, weekend→neutral. Evidence:
+  "partial, ran out of time".
+- `status=swapped` with substitutions → ingredient-affinity signals
+  on the swapped ingredients.
+
+SPEC-011's extractor is extended with a `CookedEventContext` path
+that treats cook-event-derived signals as higher-confidence than
+rating-only signals (the user physically cooked it; that's a
+stronger signal than tapping stars).
+
+**SPEC-015 (pantry auto-debit).** If
+`profile.pantry_auto_debit=true` and `status ∈ {made, partial}`,
+decrement `nutrition_pantry.quantity_grams` by the recipe's
+parsed ingredient masses × servings ratio. Decrements that would
+go negative clamp to 0 and log. Off by default; opt-in from the
+profile UI.
+
+**ADR-006 (adherence ledger).** The **adherence snapshot** row
+for ADR-006 is written here inline:
+
+```sql
+INSERT INTO nutrition_adherence_events (
+    client_id, plan_id, recipe_id, occurred_at,
+    status, servings_made, effective_nutrients_json
+) VALUES ...
+```
+
+ADR-006 defines the schema; this spec provides the write call.
+Table is created in ADR-006's first spec — we reference its
+shape here for alignment.
+
+### 4.7 Persistence
+
+Migration `014_cook_events.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS nutrition_cook_events (
+    cook_event_id          TEXT PRIMARY KEY,
+    client_id              TEXT NOT NULL,
+    plan_id                TEXT NOT NULL,
+    recipe_id              TEXT NOT NULL,
+    status                 TEXT NOT NULL,
+    servings_made          DOUBLE PRECISION,
+    substitutions_json     JSONB NOT NULL DEFAULT '[]'::jsonb,
+    effective_nutrients_json JSONB NOT NULL,
+    feedback_json          JSONB,
+    occurred_at            TIMESTAMPTZ NOT NULL,
+    recorded_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    retracted              BOOLEAN NOT NULL DEFAULT FALSE
+);
+CREATE INDEX ON nutrition_cook_events (client_id, occurred_at DESC);
+CREATE INDEX ON nutrition_cook_events (plan_id);
+CREATE INDEX ON nutrition_cook_events (recipe_id);
+```
+
+### 4.8 UI
+
+**Cook mode view** (dedicated fullscreen):
+
+```
+[<]  Shakshuka                                       [x]
+Step 3 of 8                                  [~ timer: 4:20]
+
+Dice the onion and sauté until translucent.
+
+Ingredients for this step:
+ [ ] 1 medium onion (in your pantry ✓)
+ [ ] 2 tbsp olive oil
+
+⚠ Contains high sodium (flagged for your HTN plan).
+
+              [ Prev ]        [ Next ]
+
+At any time:  [ I made this ]  [ I skipped this ]
+```
+
+Principles:
+
+- Large type, high contrast, hands-busy friendly.
+- One step visible at a time, with prev/next. Full list
+  accessible via a tap.
+- Timers inline; tap to start, they count down visibly.
+- "I made this" and "I skipped this" are persistent actions
+  accessible from any step.
+- Substitution action ("I used X instead") deep-links into
+  SPEC-016's dialog.
+- Nutrient summary available in a pull-down tray; not primary
+  UI.
+- Copy reviewed against ADR-006 §6.5 guidelines (never shame-
+  framed; the "skipped" action is neutrally worded: "I didn't
+  cook this one").
+
+**Cooked-event prompts** on plan screen:
+
+- After a recipe's `suggested_date` + mealtime window passes and
+  no cook event has been recorded, the plan screen shows a single
+  inline prompt next to that recipe: *"Did you cook this?"* with
+  three taps: [Made it] [Skipped] [Later]. "Later" snoozes until
+  the next open.
+- One-tap logging is critical to volume; a heavier dialog would
+  cause the same fatigue as today's rating UI.
+
+### 4.9 Cook-mode entry points
+
+1. From the plan screen: recipe card → "Cook" button.
+2. From the calendar (SPEC-017): event description deep link.
+3. From the grocery list (SPEC-014): "start cooking" quick action
+   on any recipe ready to cook.
+
+All three arrive at the same `GET /cook-mode` endpoint.
+
+### 4.10 Observability
+
+- `cook.event.recorded{status}`.
+- `cook.event.correction_window` histogram (how long after
+  occurred_at users correct).
+- `cook.event.substitutions_per_event` histogram.
+- `cook.mode.opened` per recipe.
+- `cook.mode.step_advance` — rough engagement metric (do users
+  actually step through?).
+- `cook.event.feedback_attached_rate` — fraction of events with
+  FeedbackRecord; compare to today's rating rate.
+- `cook.adherence.made_rate` per user week — a core ADR-006
+  dashboard metric.
+
+### 4.11 Privacy
+
+- Cook events are user activity data; retained per profile's
+  retention policy and deleted on account deletion.
+- Step text and note content are not logged above DEBUG.
+- Timer metadata (how long users took on each step) is **not
+  stored** in v1 — it is stepping into surveillance territory
+  without clear user value. Backlogged as opt-in for users who
+  want timing estimates.
+
+### 4.12 Priority-grouped work items
+
+| # | Item | Priority |
+|---|------|----------|
+| W1 | `steps`, `equipment_tags` additive on `MealRecommendation`; planner prompt update with structured-output schema | P0 |
+| W2 | Migration `014_cook_events.sql` | P0 |
+| W3 | `GET /cook-mode` endpoint + payload assembly | P0 |
+| W4 | `POST /cooked` endpoint + effective-nutrients computation | P0 |
+| W5 | Correction/retraction endpoints | P1 |
+| W6 | SPEC-011 extractor wiring for cook events | P0 |
+| W7 | SPEC-015 pantry auto-debit hook | P1 |
+| W8 | ADR-006 adherence-event write (coordinated with ADR-006 spec) | P0 |
+| W9 | UI: cook-mode fullscreen view | FE | P1 |
+| W10 | UI: inline "did you cook this?" prompt | FE | P0 |
+| W11 | UI: substitution deep link from cook mode | FE | P1 |
+| W12 | Observability counters | P1 |
+| W13 | Planner prompt tuning iteration on `steps` output quality | P1 |
+| W14 | Benchmarks: `GET /cook-mode` p99 ≤ 150 ms; `POST /cooked` p99 ≤ 200 ms | P2 |
+
+---
+
+## 5. Rollout Plan
+
+Two flags, independent:
+
+- `NUTRITION_COOKING_EVENTS` (off → `/cooked` hidden; on →
+  endpoint live + inline prompt shown).
+- `NUTRITION_COOK_MODE_UI` (off → cook-mode view hidden; on →
+  view accessible).
+
+Cooking events are intentionally shippable before the cook-mode
+UI — the one-tap "did you cook this?" prompt is the highest-
+ratio capability in the spec and should land first.
+
+### Phase 0 — Foundation (P0)
+- [ ] W1, W2 landed; migration in staging.
+
+### Phase 1 — Cooking events behind flag (P0)
+- [ ] W4, W6, W8, W10 landed.
+- [ ] Flag `NUTRITION_COOKING_EVENTS` on internal.
+- [ ] Measure: what fraction of internal users' plans get at
+      least one `made/skipped` tap per week? Target ≥60%.
+
+### Phase 2 — Cook mode behind flag (P1)
+- [ ] W3, W9, W11 landed.
+- [ ] Flag `NUTRITION_COOK_MODE_UI` on internal.
+- [ ] Acceptance gate: team members use cook mode for ≥5 meals
+      each; UX polished enough that "oily-hands" navigation feels
+      right.
+
+### Phase 3 — Extractor + pantry (P1)
+- [ ] W6 signals flowing to SPEC-011.
+- [ ] W7 pantry auto-debit opt-in available; off by default.
+- [ ] Monitor SPEC-012 digest shifts under the new signal volume.
+
+### Phase 4 — Ramp (P1)
+- [ ] 10% → 50% → 100% of both flags over three weeks.
+- [ ] Watch `cook.adherence.made_rate` and
+      `cook.event.feedback_attached_rate` — the two capstone
+      metrics.
+
+### Phase 5 — Cleanup (P1/P2)
+- [ ] W5 correction endpoints.
+- [ ] W12, W13, W14 — observability, prompt tuning, benchmarks.
+- [ ] Flag defaults on; removal scheduled.
+
+### Rollback
+- Either flag off → hides capability; persisted events remain and
+  continue feeding ADR-006 / SPEC-011 (which can tolerate gaps).
+- Additive migration.
+
+---
+
+## 6. Verification
+
+### 6.1 Unit tests
+
+- `test_effective_nutrients_made.py` — full servings → full
+  nutrients.
+- `test_effective_nutrients_partial.py` — half servings → half
+  nutrients.
+- `test_effective_nutrients_skipped.py` — all zeros regardless
+  of recipe contents.
+- `test_effective_nutrients_swap.py` — event-time substitutions
+  override recipe-stored substitutions.
+- `test_cooked_retraction.py` — retract within 24 h zeros adherence
+  ledger; beyond 24 h admin-only.
+
+### 6.2 Integration tests
+
+- `test_cook_mode_payload.py` — payload includes SPEC-016
+  committed subs and SPEC-015 pantry-on-hand flags.
+- `test_cooked_flows_to_signals.py` — cook event with feedback
+  produces a `FeedbackSignals` row with cook-event-derived source.
+- `test_pantry_auto_debit.py` — with flag on, pantry decremented
+  proportionally; with flag off, untouched.
+- `test_adherence_event_written.py` — cook event writes an
+  adherence-ledger row readable by ADR-006 fixtures.
+- `test_correction_updates_signals.py` — retracting a made event
+  emits a compensating signal (or drops the original extraction)
+  so SPEC-012 preferences remain consistent.
+
+### 6.3 Planner prompt tests
+
+- `test_planner_emits_steps.py` — for a corpus of 20 generations,
+  ≥90% return at least 6 structured steps; fewer than 3 produce
+  no steps at all.
+- `test_steps_ingredient_mapping.py` — `ingredient_canonical_ids`
+  in steps reference ingredients that exist in the recipe's
+  ingredient list.
+
+### 6.4 UX verification (Phase 2)
+
+- 10 team members use cook mode for at least 5 real meals.
+- Open-ended review finds no critical navigation issues (e.g.
+  cannot advance step, timer does not reset correctly).
+
+### 6.5 Observability
+
+All §4.10 counters emit; dashboards for adherence rate and
+feedback-attached rate populated.
+
+### 6.6 Cutover criteria
+
+- All P0/P1 tests green.
+- Phase 1 internal adherence-tap rate ≥60%.
+- Phase 2 UX review passes.
+- Phase 4 ramp: adherence-tap rate at 10% stable → scale
+  progressively; no correctness incidents.
+
+---
+
+## 7. Open Questions
+
+- **Per-step completion tracking.** We store the cook event but
+  not per-step completion. Adding it is cheap storage but has
+  privacy implications (timing data). v1 keeps it off; add
+  opt-in later if users request "how long did I take last time?"
+- **Leftover capture.** "Servings made=4, servings eaten=2" →
+  2 servings leftover. A natural pantry add. Tracking requires a
+  separate `servings_eaten` field and a pantry category for
+  leftovers. Backlogged as v1.1.
+- **Multi-recipe cooking sessions.** Cooking a meal-prep Sunday
+  is really multiple recipes in parallel. v1 is single-recipe
+  cook mode; multi-recipe sessions are a UX extension.
+- **Offline cook mode.** Kitchens are sometimes out of Wi-Fi
+  range. v1 loads the payload once and does not require live
+  connection for navigation; the POST /cooked is queued if the
+  network is down and retried. Service-worker details are a
+  frontend implementation concern.
+- **"I'm about to cook this" start event.** Logging cook-start
+  would unlock nice UX (reminder dismissal, pantry soft-hold).
+  v1 tracks only completion; start tracking is v1.1.

--- a/system_design/specs/SPEC-019-nutrition-biometric-observations.md
+++ b/system_design/specs/SPEC-019-nutrition-biometric-observations.md
@@ -1,0 +1,435 @@
+# SPEC-019: Biometric observations store and off-plan intake log
+
+| Field       | Value                                                    |
+|-------------|----------------------------------------------------------|
+| **Status**  | Proposed                                                 |
+| **Author**  | Nutrition & Meal Planning team                           |
+| **Created** | 2026-04-17                                               |
+| **Priority**| P0 within ADR-006 (blocks SPEC-020, SPEC-022)            |
+| **Scope**   | New module `backend/agents/nutrition_meal_planning_team/biometrics/`, new `off_plan_intake/`, Postgres tables, API endpoints, UI entry screens |
+| **Depends on** | SPEC-002 (profile biometrics + timezone), SPEC-005 (parser for quick-log) |
+| **Implements** | ADR-006 §2 (biometric observations), §4 (off-plan intake logging) |
+
+---
+
+## 1. Problem Statement
+
+ADR-006's dashboard needs two data inputs that do not yet exist:
+
+1. **Biometric observations over time** — weight, waist, body-fat
+   percentage, resting heart rate, blood pressure, fasting glucose,
+   A1c, lipid panels — the outcome side of the adherence ledger.
+2. **Off-plan intake** — what the user actually ate outside the
+   plan. Without this, target adherence is wrong in one direction
+   by construction: users who eat an off-plan lunch look like they
+   skipped lunch.
+
+This spec ships both stores. It is deliberately boring data
+infrastructure — no computation, no dashboard, no trajectory model.
+That logic lives in SPEC-020 and SPEC-021. This spec is the
+foundation they sit on.
+
+The scope decision matters: biometric data is high-sensitivity and
+lends itself to anxiety-inducing UX. We ship the store first with
+privacy, retention, and safety guardrails already in place, before
+any dashboard exists to present it.
+
+---
+
+## 2. Current State
+
+### 2.1 What's there
+
+- SPEC-002 extended `BiometricInfo` on `ClientProfile` with
+  latest-values (`weight_kg`, `height_cm`, etc.) and a
+  `nutrition_biometric_log` table for the audit trail on profile
+  writes.
+- `timezone` on profile.
+- No generalized time-series biometric store.
+- No off-plan intake concept anywhere.
+
+### 2.2 Gaps
+
+1. `nutrition_biometric_log` from SPEC-002 only records writes
+   tied to profile edits — it is not a time-series store with
+   proper ingestion, device-agnostic sourcing, or multiple per-
+   day observations.
+2. No way to log a meal the user ate that was not on their plan.
+3. No device-integration-ready schema — the ADR-006 roadmap
+   explicitly relies on Apple Health, Google Fit, Withings,
+   Fitbit adapters sitting on this schema unchanged.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- Ship `nutrition_biometric_observations` as the canonical time-
+  series store for biometric data. Device integrations sit on top
+  unchanged.
+- Ship CRUD API for manual observation entry.
+- Ship `nutrition_off_plan_intakes` with a quick-log endpoint:
+  free-text input → SPEC-005 + LLM parse → estimated nutrients
+  stored with confidence.
+- Enforce safety rails on data quality: implausible observations
+  rejected, not clamped. Source tracking on every row.
+- Treat both data sets as privacy-sensitive: redaction, cascade
+  delete, least-logging principle.
+
+### 3.2 Non-goals
+
+- **No trajectory model.** SPEC-020.
+- **No adherence computation.** SPEC-021.
+- **No dashboard.** SPEC-022.
+- **No device integrations in v1.** Schema supports them; the
+  adapters are follow-up specs.
+- **No photo-based logging.** Text quick-log only in v1.
+- **No clinician-export format.** v1.1 feature; ADR-006 §7
+  follow-up.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 Module layout
+
+```
+backend/agents/nutrition_meal_planning_team/biometrics/
+├── __init__.py            # store, types, BIOMETRIC_VERSION
+├── version.py             # BIOMETRIC_VERSION = "1.0.0"
+├── types.py               # Observation, ObservationKind
+├── store.py               # CRUD + time-series queries
+├── validation.py          # implausibility guards
+├── errors.py
+└── tests/
+
+backend/agents/nutrition_meal_planning_team/off_plan_intake/
+├── __init__.py            # quick_log, store
+├── types.py               # OffPlanIntake, QuickLogDraft
+├── parser.py              # SPEC-005 + LLM fallback
+├── store.py               # CRUD
+├── errors.py
+└── tests/
+```
+
+### 4.2 Biometric observation kinds
+
+Closed enum (v1):
+
+```python
+class ObservationKind(str, Enum):
+    weight_kg = "weight_kg"
+    waist_cm = "waist_cm"
+    hip_cm = "hip_cm"
+    body_fat_pct = "body_fat_pct"
+    resting_hr_bpm = "resting_hr_bpm"
+    bp_systolic = "bp_systolic"
+    bp_diastolic = "bp_diastolic"
+    fasting_glucose_mgdl = "fasting_glucose_mgdl"
+    a1c_pct = "a1c_pct"
+    ldl_mgdl = "ldl_mgdl"
+    hdl_mgdl = "hdl_mgdl"
+    triglycerides_mgdl = "triglycerides_mgdl"
+    total_cholesterol_mgdl = "total_cholesterol_mgdl"
+
+class ObservationSource(str, Enum):
+    manual = "manual"
+    apple_health = "apple_health"
+    google_fit = "google_fit"
+    withings = "withings"
+    fitbit = "fitbit"
+    lab_upload = "lab_upload"
+    clinician = "clinician"
+```
+
+Additions require minor version bump.
+
+### 4.3 Observation type
+
+```python
+@dataclass(frozen=True)
+class Observation:
+    id: str
+    client_id: str
+    kind: ObservationKind
+    value: float
+    unit: str                      # canonical for the kind ('kg', 'cm', 'pct', 'bpm', 'mm_hg', 'mg_dl', 'percent')
+    observed_at: str               # ISO timestamp with timezone
+    source: ObservationSource
+    source_ref: Optional[str] = None   # e.g. device serial, lab upload id
+    notes: Optional[str] = None
+    confidence: float = 1.0        # 1.0 manual + non-implausible, <1.0 from device with noise
+    recorded_at: str
+```
+
+### 4.4 Implausibility guards
+
+`validation.py::validate(obs) -> Observation`:
+
+- `weight_kg`: [20, 400].
+- `waist_cm`: [30, 250].
+- `body_fat_pct`: [2, 75].
+- `resting_hr_bpm`: [30, 220].
+- `bp_systolic`: [60, 260]. `bp_diastolic`: [30, 180].
+  `bp_systolic > bp_diastolic` enforced.
+- `fasting_glucose_mgdl`: [30, 600].
+- `a1c_pct`: [3, 20].
+- Lipids: generous but reject absurd values (e.g. `ldl_mgdl <
+  10` or `> 500`).
+
+Outside-range → 422. We do **not** clamp. Device-sourced
+observations with outside-range values get a structured log entry
+and are dropped, with a counter; users see a UI notification only
+for manual entries.
+
+### 4.5 Postgres
+
+Migration `015_biometric_observations.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS nutrition_biometric_observations (
+    id              TEXT PRIMARY KEY,
+    client_id       TEXT NOT NULL REFERENCES nutrition_profiles(client_id)
+                        ON DELETE CASCADE,
+    kind            TEXT NOT NULL,
+    value           DOUBLE PRECISION NOT NULL,
+    unit            TEXT NOT NULL,
+    observed_at     TIMESTAMPTZ NOT NULL,
+    source          TEXT NOT NULL,
+    source_ref      TEXT,
+    notes           TEXT,
+    confidence      REAL NOT NULL DEFAULT 1.0,
+    recorded_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (client_id, kind, observed_at, source)  -- idempotency for device adapters
+);
+CREATE INDEX ON nutrition_biometric_observations (client_id, kind, observed_at DESC);
+CREATE INDEX ON nutrition_biometric_observations (client_id, recorded_at DESC);
+```
+
+Unique index on `(client_id, kind, observed_at, source)` makes
+device-adapter ingestion idempotent — replaying a sync window
+does not duplicate rows.
+
+Migration `016_off_plan_intakes.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS nutrition_off_plan_intakes (
+    id                    TEXT PRIMARY KEY,
+    client_id             TEXT NOT NULL REFERENCES nutrition_profiles(client_id)
+                              ON DELETE CASCADE,
+    raw_description       TEXT NOT NULL,
+    parsed_ingredients_json JSONB NOT NULL DEFAULT '[]'::jsonb,
+    estimated_nutrients_json JSONB NOT NULL DEFAULT '{}'::jsonb,
+    confidence            REAL NOT NULL DEFAULT 0.5,
+    meal_type             TEXT,
+    approx_portion        TEXT,
+    occurred_at           TIMESTAMPTZ NOT NULL,
+    recorded_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX ON nutrition_off_plan_intakes (client_id, occurred_at DESC);
+```
+
+### 4.6 Biometric API
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST`   | `/biometrics/{client_id}/observations` | Single or batch insert |
+| `GET`    | `/biometrics/{client_id}/observations?kind=&since=&until=` | Time-series query with pagination |
+| `DELETE` | `/biometrics/{client_id}/observations/{id}` | Remove a specific observation |
+| `GET`    | `/biometrics/{client_id}/latest` | Latest value per kind |
+| `GET`    | `/biometrics/{client_id}/series?kind=weight_kg&since=&smooth=7d` | Smoothed series for SPEC-020 |
+
+Batch insert body is `{observations: [Observation], idempotent: bool}`.
+When `idempotent=true`, duplicates (matching unique index) silently
+no-op. When false (default), duplicates 409.
+
+The smoothed-series endpoint is a convenience: returns EMA with
+configurable window for UI charts. The server-side smoothing is
+deterministic and cached.
+
+### 4.7 Off-plan intake API
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `POST`   | `/intake/{client_id}/quick-log` | `{description, meal_type?, approx_portion?, occurred_at?}` |
+| `POST`   | `/intake/{client_id}/quick-log/{draft_id}/confirm` | Accept / modify parsed intake |
+| `GET`    | `/intake/{client_id}?since=&until=` | List intakes |
+| `DELETE` | `/intake/{client_id}/{id}` | Remove |
+| `PATCH`  | `/intake/{client_id}/{id}` | Edit a saved intake |
+
+Quick-log flow:
+
+1. Run SPEC-005 parser on each comma/"and"-separated fragment.
+2. For fragments that do not resolve, call an LLM with a locked
+   structured-output schema (same pattern as SPEC-015's bulk
+   import) producing `ProposedIntakeItem[]` with canonical id,
+   portion, and confidence.
+3. Estimate nutrients from SPEC-008 data per parsed item.
+4. Return a draft preview (same pattern as SPEC-015).
+5. Confirmation commits; unresolved items are preserved as notes.
+
+Confidence on every intake: `avg(parsed_item_confidence)` weighted
+by resolved-mass. Intakes below `confidence = 0.5` are marked
+"best effort" and surface distinctly in the UI. The goal is
+honest wrongness-quantification, not clean-looking data.
+
+### 4.8 Log retention and privacy
+
+- Observations and intakes are highly sensitive.
+- Log redaction: observation values and raw intake descriptions
+  never logged above DEBUG.
+- Cascade delete on profile removal.
+- No cross-team reads; only the nutrition team's dashboard and
+  trajectory model consume.
+- Audit events emitted on every write, read, and delete for
+  biometric observations (compliance-adjacent).
+
+### 4.9 Safety hooks
+
+ADR-006 §6 defines rate-of-loss, BMI floor, and ED-history rails
+that live in SPEC-003 calculator. This spec feeds them:
+
+- On every `weight_kg` insert, a check computes the last-14-days
+  trend and emits a structured event
+  `nutrition.weight_trend_update{client_id, kg_per_week}`.
+  SPEC-020 and SPEC-003 subscribe and apply rails.
+- This spec does **not** clamp goals or modify plans. It signals;
+  the calculator decides.
+
+### 4.10 Observability
+
+- `biometric.observation.recorded{kind, source}`.
+- `biometric.observation.implausible_reject{kind, source}`.
+- `biometric.observation.duplicate_ignored{source}` (idempotent
+  ingests).
+- `off_plan_intake.logged{confidence_bucket}`.
+- `off_plan_intake.llm_fallback_used`.
+- `biometric.weight_trend_event{direction}` counter.
+
+### 4.11 Priority-grouped work items
+
+| # | Item | Priority |
+|---|------|----------|
+| W1 | Biometric module scaffolding + types + version | P0 |
+| W2 | Migration `015_biometric_observations.sql` | P0 |
+| W3 | `validation.py` with range tests per kind | P0 |
+| W4 | `store.py` CRUD + idempotent insert + time-series query | P0 |
+| W5 | Smoothed-series endpoint (EMA) + tests | P1 |
+| W6 | Weight-trend event emission | P0 |
+| W7 | Off-plan intake module scaffolding + types | P0 |
+| W8 | Migration `016_off_plan_intakes.sql` | P0 |
+| W9 | Off-plan quick-log parser (SPEC-005 + LLM) + confirm flow | P0 |
+| W10 | Intake API endpoints | P0 |
+| W11 | UI: biometric entry screen (weight first; others secondary) | FE | P1 |
+| W12 | UI: quick-log intake widget (text field + preview modal) | FE | P1 |
+| W13 | UI: history tables (biometric + intake) | FE | P1 |
+| W14 | Observability counters | P1 |
+| W15 | Audit-event logging | P1 |
+| W16 | Benchmarks: insert p99 ≤ 50 ms; series query p99 ≤ 100 ms | P2 |
+
+---
+
+## 5. Rollout Plan
+
+Flag `NUTRITION_OBSERVATIONS` (off → endpoints hidden; on →
+surfaced).
+
+### Phase 0 — Foundation (P0)
+- [ ] W1–W4, W7–W10 landed. Migrations in staging.
+
+### Phase 1 — Core behind flag (P0)
+- [ ] W6 weight-trend event emitted.
+- [ ] Flag on internal. Team members log their own weight daily
+      and off-plan meals; validate ingest paths.
+
+### Phase 2 — UI (P1)
+- [ ] W11–W13 shipped.
+- [ ] Acceptance gate: 10 team users log ≥14 days each; zero
+      implausibility false-rejects; zero data-loss bugs.
+
+### Phase 3 — Ramp (P1)
+- [ ] 10% → 50% → 100% over two weeks.
+- [ ] Metrics: active-logger fraction (want ≥30% of active users
+      log at least once per week), intake-logging rate on days
+      with a planned meal count mismatch.
+
+### Phase 4 — Cleanup (P1/P2)
+- [ ] W5, W14, W15, W16 landed.
+- [ ] Flag default on.
+
+### Rollback
+- Flag off → endpoints 404; rows retained.
+- Additive migration.
+
+---
+
+## 6. Verification
+
+### 6.1 Unit tests
+
+- `test_validation_ranges.py` — every kind's bounds accept within,
+  reject outside. 422 status.
+- `test_bp_pair.py` — systolic < diastolic is rejected.
+- `test_idempotent_insert.py` — same kind/time/source insert
+  silently no-ops when `idempotent=true`; otherwise 409.
+- `test_smoothed_series.py` — EMA window parameter honored;
+  deterministic output.
+- `test_off_plan_parse_llm_fallback.py` — unresolvable fragments
+  trigger LLM fallback; parser-only path does not call LLM.
+
+### 6.2 Integration tests
+
+- `test_biometric_time_series.py` — insert 30 days of weight →
+  `/series?smooth=7d` returns expected EMA.
+- `test_weight_trend_event.py` — inserting a run of weights
+  producing > 1% body weight / week loss emits the trend event
+  with correct direction and magnitude.
+- `test_off_plan_quick_log_roundtrip.py` — draft → confirm →
+  stored intake has expected nutrients from SPEC-008.
+- `test_cascade_delete.py` — deleting profile removes observations
+  and intakes.
+
+### 6.3 Privacy
+
+- Log-redaction grep in staging over Phase 1: zero biometric
+  values or intake descriptions above DEBUG.
+- Audit-event rows present for every observation insert / delete
+  during dogfood.
+
+### 6.4 Reviewer audit (Phase 2)
+
+- Review 20 off-plan quick-log parses. Target: ≥80% correct at
+  item + quantity level; zero fabricated items (items not in the
+  original description).
+
+### 6.5 Observability
+
+All §4.10 counters emit.
+
+### 6.6 Cutover criteria
+
+- All P0/P1 tests green.
+- Phase 2 reviewer gate met.
+- Phase 3 metrics at 10%: active-logger fraction tracking, no
+  correctness incidents.
+
+---
+
+## 7. Open Questions
+
+- **Units.** We store canonical units (kg, cm, mg/dl). US users
+  enter in lbs/in/mg-dL. Conversion happens at input, same
+  pattern as SPEC-002. UI concern.
+- **Observation sources beyond v1 enum.** Continuous glucose
+  monitors, research devices — add as they land; minor version
+  bumps.
+- **Batch quick-log.** Some users will want to log a day's worth
+  of meals at once. v1 handles it via repeated calls; a batch API
+  is v1.1.
+- **Clinician observations.** A clinician-entered lab upload with
+  `source=clinician` is allowed. We do not yet have a clinician
+  portal; v1.1.
+- **Retention horizons.** v1 keeps forever. Long-term we will want
+  an archive tier for data older than the dashboard shows. Out of
+  scope.

--- a/system_design/specs/SPEC-020-nutrition-expected-trajectory-and-recalibration.md
+++ b/system_design/specs/SPEC-020-nutrition-expected-trajectory-and-recalibration.md
@@ -1,0 +1,545 @@
+# SPEC-020: Expected trajectory model and recalibration loop
+
+| Field       | Value                                                    |
+|-------------|----------------------------------------------------------|
+| **Status**  | Proposed                                                 |
+| **Author**  | Nutrition & Meal Planning team                           |
+| **Created** | 2026-04-17                                               |
+| **Priority**| P1 within ADR-006 (blocks full dashboard; enables self-correcting targets) |
+| **Scope**   | Extension of SPEC-003 calculator, new `trajectory/` module, new `recalibration/` module, Postgres snapshots, safety-rail enforcement, admin override audit |
+| **Depends on** | SPEC-003 (calculator), SPEC-019 (biometric observations), SPEC-018 (cook events for adherence), SPEC-010 (nutrient rollup for plan totals) |
+| **Implements** | ADR-006 §5 (expected-trajectory model), §6 (safety rails at calculator level), §7 (recalibration loop) |
+
+---
+
+## 1. Problem Statement
+
+SPEC-003 computes daily targets. SPEC-019 stores observed weight.
+SPEC-018 records what the user cooked. None of them speak to each
+other. Without the bridge:
+
+1. We cannot show a user an expected weight curve for their goal
+   — so we cannot answer "is this working?"
+2. We cannot detect when reality diverges from the math — so the
+   calculator never learns.
+3. Safety rails (rate-of-loss cap, BMI floor, ED-history rerouting)
+   are theoretically in SPEC-003 but have no live observation data
+   to react to.
+
+This spec ships the expected-trajectory model, the recalibration
+loop that Bayesian-blends observed outcome into the calculator's
+TDEE estimate, and the runtime enforcement of the SPEC-003 safety
+rails using SPEC-019's observation stream.
+
+It is deliberately not the dashboard (SPEC-022). This is the
+math and the policy; the UI is built on top.
+
+---
+
+## 2. Current State
+
+### 2.1 After SPEC-003 + SPEC-019
+
+- Calculator produces `DailyTargets` from profile biometrics.
+- Observations stream in but nothing consumes them beyond the
+  weight-trend event (SPEC-019 §4.9).
+- `GoalsInfo.target_weight_kg` and `rate_kg_per_week` live on the
+  profile but are static.
+
+### 2.2 Gaps
+
+1. No expected trajectory series.
+2. No recalibration: the TDEE estimate cannot update from observed
+   outcome.
+3. Safety rails in SPEC-003 §4.5 (kcal floor, rate cap) are applied
+   once at plan generation; they never react to persistent over-
+   deficit in observed data.
+4. No `nutrition_adherence_events` aggregator that pairs plan vs.
+   cooked vs. observed over windows — ADR-006 §7 describes the
+   recalibration inputs but nothing assembles them.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- Ship `trajectory.compute_expected(profile, window)` producing a
+  `Trajectory` series: per-date expected biometric values with a
+  confidence band, grounded in the calculator's energy math.
+- Ship `recalibration.evaluate(profile, adherence_window)` that
+  detects persistent divergence between expected deficit-
+  equivalent and observed weight change, controlled for plan +
+  target adherence.
+- Recalibration is **proposal-only**: it surfaces a suggested TDEE
+  correction, never silently rewrites targets. A user or admin
+  accepts via endpoint; acceptance bumps the profile's TDEE
+  adjustment and writes a new plan version.
+- Enforce safety rails in a live loop:
+  - Rate-of-loss cap from observation stream.
+  - BMI-floor disable of weight-loss goals.
+  - ED-history flag replaces scale-centric views.
+- Store `trajectory_snapshots` and `adherence_snapshots` as
+  materialized inputs for SPEC-021 drivers and SPEC-022 dashboard.
+- Clinical-cohort escape: pregnancy, lactation, post-op cohorts
+  return `trajectory=None` with a "work with your clinician"
+  note. Never guess.
+
+### 3.2 Non-goals
+
+- **No dashboard UI.** SPEC-022.
+- **No drivers decomposition.** SPEC-021.
+- **No recalibration auto-accept.** Always proposal → user action.
+- **No long-horizon prediction beyond the user's goal window.**
+  Trajectories extend only as far as the user's
+  `target_weight_kg` plus 4 weeks of buffer.
+- **No metabolic-adaptation research.** We use a simple,
+  documented drift term; novel modeling is out of scope.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 Module layout
+
+```
+backend/agents/nutrition_meal_planning_team/trajectory/
+├── __init__.py              # compute_expected, TRAJECTORY_VERSION
+├── version.py               # TRAJECTORY_VERSION = "1.0.0"
+├── types.py                 # Trajectory, TrajectoryPoint
+├── model.py                 # energy-balance model + adaptation term
+├── snapshots.py             # Postgres persistence
+├── errors.py
+└── tests/
+
+backend/agents/nutrition_meal_planning_team/recalibration/
+├── __init__.py              # evaluate, accept, RECALIBRATION_VERSION
+├── version.py               # RECALIBRATION_VERSION = "1.0.0"
+├── types.py                 # RecalibrationProposal, AdherenceWindow
+├── evaluator.py             # Bayesian TDEE update rule
+├── safety_rails.py          # rate-of-loss cap, BMI floor, ED reroute
+├── store.py                 # proposal persistence and accept audit
+├── errors.py
+└── tests/
+```
+
+### 4.2 Trajectory model
+
+```python
+@dataclass(frozen=True)
+class TrajectoryPoint:
+    date: date
+    expected_value: float       # e.g. expected weight_kg
+    lower_band: float           # confidence band
+    upper_band: float
+    inputs_snapshot: dict       # which inputs drove this point
+
+@dataclass(frozen=True)
+class Trajectory:
+    kind: ObservationKind       # v1: weight_kg only
+    series: tuple[TrajectoryPoint, ...]
+    cohort: str                 # 'general_adult' | 'pregnancy_lactation' | ...
+    calculator_version: str
+    trajectory_version: str
+    computed_at: str
+```
+
+Model (v1, `weight_kg` only):
+
+- For each day in the window:
+  ```
+  cumulative_deficit_kcal = Σ_days (prescribed_kcal_target - TDEE_current)
+  expected_delta_kg       = cumulative_deficit_kcal / 7700
+  early_phase_correction  = water/glycogen ≈ -0.7 kg for first 14 days on deficit
+  adaptation_drift        = +0.0005 * cumulative_deficit_kcal / 7700   (a small recovery term)
+  expected_weight_kg[day] = baseline_kg + expected_delta + correction + adaptation_drift
+  ```
+- Confidence band: ±1% of body weight widening to ±3% over the
+  horizon; derived from the standard deviation of daily weight
+  variability observed in calibration datasets and cited in
+  `model.py` comments.
+
+The math is deterministic. The model constants (`7700 kcal/kg`,
+the water/glycogen term, the adaptation coefficient) are pinned
+in `tables/trajectory.yaml` with citations; bumping any of them
+bumps `TRAJECTORY_VERSION`.
+
+Cohorts without a supported trajectory return `Trajectory.kind =
+None` with `cohort = 'clinician_guided'` or `'pregnancy_lactation'`
+and no series. SPEC-022 renders a distinct view.
+
+### 4.3 Recalibration evaluator
+
+Inputs over a sliding window (default 21 days, minimum 14):
+
+- Observed weight change: smoothed 7-day EMA of daily weights.
+- Plan adherence: fraction of planned recipes cooked (`made`
+  weight 1.0, `partial` proportional, `swapped` at substitute
+  nutrients, `skipped` 0.0).
+- Target adherence: eaten nutrient rollup (from SPEC-018 cook
+  events + SPEC-019 off-plan intakes) vs. daily targets, expressed
+  as a per-day deficit delta.
+- Expected TDEE from the calculator.
+
+Procedure:
+
+1. Compute **observed deficit-equivalent**:
+   ```
+   observed_Δmass_kg  = EMA(end) - EMA(start)
+   observed_deficit   = observed_Δmass_kg * 7700          # kcal
+   ```
+2. Compute **intake-vs-prescription adjustment**:
+   ```
+   intake_observed     = Σ eaten_kcal over window
+   intake_prescribed   = Σ target_kcal over window
+   intake_delta        = intake_observed - intake_prescribed
+   ```
+   `intake_observed` from SPEC-018/SPEC-019; `intake_prescribed`
+   from the target history.
+3. Infer implied TDEE:
+   ```
+   implied_TDEE = (intake_observed - observed_deficit) / window_days
+   ```
+4. Blend with a-priori TDEE:
+   ```
+   posterior_TDEE = (w_prior * prior_TDEE + w_data * implied_TDEE) /
+                    (w_prior + w_data)
+   ```
+   `w_prior` starts at 30 (roughly 3 weeks of data-equivalent
+   prior), `w_data` = window_days. This is a simple Bayesian
+   blend; calibration is a team-lead decision.
+5. Guard rails: only propose if:
+   - |posterior_TDEE - prior_TDEE| > 75 kcal (noise floor).
+   - Window has ≥ 14 days of data and ≥ 70% adherence. Below,
+     decline to propose — "need more data" is a first-class
+     output, not a failure.
+   - Last proposal accepted or rejected ≥ 21 days ago
+     (anti-thrashing).
+
+Output:
+
+```python
+@dataclass(frozen=True)
+class RecalibrationProposal:
+    proposal_id: str
+    client_id: str
+    window_start: date
+    window_end: date
+    prior_tdee: float
+    implied_tdee: float
+    posterior_tdee: float
+    delta_kcal: float              # round(posterior - prior)
+    confidence: float              # 0..1; function of window_days + adherence
+    explanation: str               # short NL for UI ("maintenance closer to 2,250 than 2,400")
+    expires_at: str                # TTL 30 days
+```
+
+### 4.4 Proposal lifecycle
+
+- Evaluated on a schedule (nightly) plus on-demand via admin
+  endpoint.
+- Persisted in `nutrition_recalibration_proposals`.
+- User sees the proposal in the dashboard (SPEC-022); accepts or
+  declines.
+- Acceptance writes a `tdee_adjustment_kcal` on the profile (new
+  additive field) that SPEC-003's calculator reads and applies as
+  a post-TDEE multiplier-equivalent. New plans generated with the
+  new target; prior plans untouched.
+- Decline records the choice; no further proposal for 21 days
+  unless a new rail breach requires one.
+- Auto-accept is not offered. Targets moving silently erodes trust.
+
+### 4.5 Safety rails in the evaluator
+
+Three rails enforced at runtime on every trajectory compute +
+every new weight observation (via the SPEC-019 weight-trend event):
+
+1. **Rate-of-loss cap.** If the 2-week EMA shows > 1% body weight
+   loss per week for two consecutive weeks, the calculator's
+   `energy_goal` is force-clamped: `rate_kg_per_week` reduced
+   until trajectory expected rate ≤ 0.7% per week. The profile
+   is flagged `rate_cap_active=true`; plans generated while
+   flagged carry the reason. User can override only with an
+   explicit acknowledgment dialog and one confirmation.
+2. **BMI floor.** If BMI (from latest weight + height) drops below
+   the greater of 18.5 and `clinician_overrides.bmi_floor`,
+   weight-loss goals are disabled at the calculator level. Next
+   plan is guidance-only; dashboard replaces trajectory gauges
+   with "revisit your goal" prompt.
+3. **ED-history flag.** When `clinical.ed_history_flag=true`, the
+   evaluator never emits a recalibration proposal that tightens
+   a deficit. Proposals are filtered to net-neutral or net-loose
+   only. Dashboard rails already hide scale-centric views.
+
+Minors (`age_years < 18`): cohort routed to `minor` by SPEC-003;
+trajectory = None; no recalibration ever evaluated.
+
+Rails are **team invariants**, not per-user toggles. Overrides
+travel through authorized `clinician_overrides`.
+
+### 4.6 Persistence
+
+Migration `017_trajectory_and_recalibration.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS nutrition_trajectory_snapshots (
+    snapshot_id       TEXT PRIMARY KEY,
+    client_id         TEXT NOT NULL REFERENCES nutrition_profiles(client_id)
+                          ON DELETE CASCADE,
+    kind              TEXT NOT NULL,
+    profile_version   INT NOT NULL,
+    calculator_version TEXT NOT NULL,
+    trajectory_version TEXT NOT NULL,
+    series_json       JSONB NOT NULL,
+    cohort            TEXT NOT NULL,
+    computed_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+CREATE INDEX ON nutrition_trajectory_snapshots (client_id, computed_at DESC);
+
+CREATE TABLE IF NOT EXISTS nutrition_recalibration_proposals (
+    proposal_id       TEXT PRIMARY KEY,
+    client_id         TEXT NOT NULL REFERENCES nutrition_profiles(client_id)
+                          ON DELETE CASCADE,
+    window_start      DATE NOT NULL,
+    window_end        DATE NOT NULL,
+    prior_tdee        DOUBLE PRECISION NOT NULL,
+    implied_tdee      DOUBLE PRECISION NOT NULL,
+    posterior_tdee    DOUBLE PRECISION NOT NULL,
+    delta_kcal        DOUBLE PRECISION NOT NULL,
+    confidence        REAL NOT NULL,
+    explanation       TEXT NOT NULL,
+    status            TEXT NOT NULL DEFAULT 'proposed',    -- proposed | accepted | declined | expired
+    responded_at      TIMESTAMPTZ,
+    expires_at        TIMESTAMPTZ NOT NULL,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE IF NOT EXISTS nutrition_safety_rail_events (
+    id                BIGSERIAL PRIMARY KEY,
+    client_id         TEXT NOT NULL REFERENCES nutrition_profiles(client_id)
+                          ON DELETE CASCADE,
+    rail              TEXT NOT NULL,         -- 'rate_of_loss' | 'bmi_floor' | 'ed_filter'
+    status            TEXT NOT NULL,         -- 'triggered' | 'cleared' | 'override_requested'
+    payload_json      JSONB NOT NULL,
+    recorded_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Additive on nutrition_profiles
+ALTER TABLE nutrition_profiles
+    ADD COLUMN tdee_adjustment_kcal REAL NOT NULL DEFAULT 0.0,
+    ADD COLUMN rate_cap_active BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN last_trajectory_snapshot_id TEXT,
+    ADD COLUMN last_recalibration_accepted_at TIMESTAMPTZ;
+```
+
+### 4.7 API
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/trajectory/{client_id}?kind=weight_kg&window=next_12w` | Latest trajectory snapshot |
+| `POST` | `/trajectory/{client_id}/recompute` | Force recompute (rate-limited) |
+| `GET` | `/recalibration/{client_id}/proposal` | Latest active proposal (if any) |
+| `POST` | `/recalibration/{client_id}/accept` | Body: `{proposal_id}`. Applies adjustment and writes new plan version in next generation |
+| `POST` | `/recalibration/{client_id}/decline` | Declines the proposal |
+| `GET` | `/safety/{client_id}/rails` | Current rail states |
+
+The trajectory endpoint returns either the latest snapshot or
+triggers a fresh compute asynchronously; it never recomputes on
+the critical path (cached snapshots only).
+
+### 4.8 Nightly job
+
+A scheduled task (Temporal-backed, via platform scheduled tasks):
+
+1. For each active client, check whether a new trajectory snapshot
+   should be produced (≥7 days since last, or any new weight
+   observation, or any new recalibration acceptance).
+2. Compute trajectory snapshot; persist.
+3. Evaluate recalibration proposal on the 21-day window; if
+   warranted, persist proposal and emit notification.
+4. Evaluate safety rails on current observation stream; emit
+   `nutrition_safety_rail_events` rows on state changes.
+
+Client-perceived behavior: open the dashboard → see current
+trajectory + any pending proposal.
+
+### 4.9 Observability
+
+- `trajectory.snapshot_computed{cohort}`.
+- `trajectory.compute_latency_ms` histogram.
+- `recalibration.evaluated{outcome}` — `proposed | need_more_data |
+  noise_floor | anti_thrash | cohort_blocked`.
+- `recalibration.proposal.lifecycle{status}`.
+- `safety_rail.triggered{rail}`.
+- `safety_rail.cleared{rail}`.
+- `safety_rail.override_requested{rail}`.
+- Alert: any `safety_rail.override_requested{rail=bmi_floor}` →
+  privacy-respecting on-call notification for review.
+
+### 4.10 Privacy
+
+- Trajectory and recalibration are derived from sensitive data;
+  inherit the same retention and cascade-delete as SPEC-019.
+- Recalibration `explanation` strings include kcal numbers only,
+  no PII.
+- Safety-rail events are logged; raw observation values are not
+  in the log payload — only aggregates.
+
+### 4.11 Priority-grouped work items
+
+| # | Item | Priority |
+|---|------|----------|
+| W1 | Trajectory module scaffolding, version, types | P0 |
+| W2 | `model.py` energy-balance + adaptation + confidence band; tests | P0 |
+| W3 | Trajectory snapshot persistence | P0 |
+| W4 | Recalibration module scaffolding + types | P0 |
+| W5 | `evaluator.py` Bayesian blend + guard rails; tests | P0 |
+| W6 | `safety_rails.py` runtime enforcement + calculator integration | P0 |
+| W7 | Migration `017_trajectory_and_recalibration.sql` | P0 |
+| W8 | API endpoints (§4.7) | P0 |
+| W9 | Nightly scheduled task wiring | P1 |
+| W10 | `tdee_adjustment_kcal` integration into SPEC-003 calculator | P0 |
+| W11 | Observability counters | P1 |
+| W12 | Cohort routing for pregnancy/lactation/minors (no trajectory) | P0 |
+| W13 | ED-history filtered proposals | P0 |
+| W14 | Admin CLI: inspect a user's recent proposals + rails | P2 |
+| W15 | Benchmarks: trajectory compute p99 ≤ 150 ms; evaluator p99 ≤ 200 ms | P2 |
+
+---
+
+## 5. Rollout Plan
+
+Two flags:
+
+- `NUTRITION_TRAJECTORY` (off → no trajectory snapshots; on →
+  computed and served).
+- `NUTRITION_RECALIBRATION` (off → no proposals; on → proposals
+  computed and surfaced).
+
+The safety rails ship with `NUTRITION_TRAJECTORY` on, always — they
+are invariants, not user features.
+
+### Phase 0 — Foundation (P0)
+- [ ] SPEC-018 and SPEC-019 at 100% ramp.
+- [ ] W1–W7, W10, W12 landed.
+
+### Phase 1 — Trajectory shadow (P0)
+- [ ] Flag on internal; trajectory snapshots computed nightly.
+- [ ] Review 10 internal trajectories over 30 days against actual
+      outcomes. Acceptance: predicted weight within ±1.5 kg on
+      80% of points for steady-state users.
+- [ ] Safety rails enforced for internal; review triggers.
+
+### Phase 2 — Recalibration shadow (P0)
+- [ ] W5, W6, W8, W13 landed.
+- [ ] Shadow mode: recalibration proposals computed for internal
+      users but not surfaced; team reviews whether they would
+      have been helpful.
+- [ ] Acceptance: ≥80% of would-have-been proposals judged
+      correct by clinical reviewer.
+
+### Phase 3 — User-facing ramp (P1)
+- [ ] Both flags on internal, then 10% → 50% → 100% over three
+      weeks.
+- [ ] Watch: proposal acceptance rate (too high → we are too
+      aggressive; too low → insufficient evidence gate).
+- [ ] Safety-rail triggers reviewed weekly.
+
+### Phase 4 — Cleanup (P1/P2)
+- [ ] W9 nightly job wiring hardened.
+- [ ] W11, W14, W15 landed.
+
+### Rollback
+- Flag off → no trajectory or proposals surfaced; stored
+  snapshots retained.
+- Safety rails remain on regardless of flag — they are team
+  invariants.
+- `tdee_adjustment_kcal` changes persisted across rollback; users
+  keep their accepted adjustments.
+
+---
+
+## 6. Verification
+
+### 6.1 Unit tests
+
+- `test_trajectory_deterministic.py` — same inputs → byte-equal
+  series.
+- `test_trajectory_early_phase.py` — first 14 days include the
+  water/glycogen correction.
+- `test_trajectory_confidence_band.py` — band widens over horizon.
+- `test_recalibration_noise_floor.py` — small deltas do not produce
+  proposals.
+- `test_recalibration_insufficient_data.py` — windows with <14
+  days produce `need_more_data`, not a proposal.
+- `test_recalibration_anti_thrash.py` — proposal within 21 days
+  of last outcome → declined at evaluator level.
+- `test_ed_filter_blocks_deficit_proposal.py`.
+
+### 6.2 Integration tests
+
+- `test_trajectory_snapshot_persisted.py` — compute → snapshot
+  row with correct fields; downstream query via API returns
+  identical data.
+- `test_recalibration_accept_writes_adjustment.py` — accepted
+  proposal updates `tdee_adjustment_kcal`; next SPEC-003
+  calculator call returns adjusted targets.
+- `test_rate_cap_rail.py` — insert a weight series triggering >1%
+  / week loss; rail event emitted; calculator clamps goal on
+  next generation; profile flag set.
+- `test_bmi_floor_rail.py` — weight loss into BMI <18.5 → rail
+  event + goal disabled.
+- `test_minor_no_trajectory.py` — age<18 profile returns
+  `Trajectory.kind=None`; no proposals ever generated.
+
+### 6.3 Shadow-phase validation
+
+- Phase 1: 10 internal trajectories vs. observed. Reviewer
+  acceptance gate.
+- Phase 2: 10 would-have-been proposals reviewed; ≥80% judged
+  correct by clinical reviewer.
+
+### 6.4 Safety property tests
+
+- Rails cannot be bypassed by API: attempt to generate a plan
+  while `rate_cap_active=true` → SPEC-003 calculator clamps the
+  deficit regardless of request body.
+- ED-history flag blocks deficit proposals in all code paths.
+
+### 6.5 Observability
+
+All §4.9 counters emit; safety-rail alerting path exercised in
+staging.
+
+### 6.6 Cutover criteria
+
+- All P0/P1 tests green.
+- Phase 1 trajectory accuracy gate met.
+- Phase 2 recalibration reviewer acceptance met.
+- Phase 3 ramp metrics stable.
+- Clinical reviewer sign-off on `model.py` constants and the
+  proposal evaluator thresholds.
+
+---
+
+## 7. Open Questions
+
+- **Calibration of the water/glycogen correction.** We use a
+  conservative -0.7 kg over 14 days. Individual variance is high;
+  we will refine after Phase 1 against real observations.
+- **`w_prior` weighting.** 30 "days of prior" is a choice. Too
+  high and proposals lag; too low and we over-react to noise.
+  Tunable per `recalibration.evaluated` dashboard.
+- **Multi-kind trajectories.** v1 only models weight. Blood
+  glucose and blood pressure trajectories under clinical-
+  condition cohorts are v1.1 candidates but require clinician
+  input and have different acceptable-range definitions.
+- **Real-world adherence proxy from cook events.** We use
+  `made/partial/skipped` weights for adherence. If users
+  consistently under-log (e.g. cook but don't tap), adherence
+  looks artificially low. Counter-measure: SPEC-022 surfaces the
+  log rate and nudges low-log users; we accept imperfect
+  adherence data rather than guessing.
+- **Accepted-proposal visibility to clinicians.** The
+  `nutrition_recalibration_proposals` history is a natural export
+  for clinicians. v1.1 clinician export spec.

--- a/system_design/specs/SPEC-021-nutrition-adherence-ledger-and-drivers.md
+++ b/system_design/specs/SPEC-021-nutrition-adherence-ledger-and-drivers.md
@@ -1,0 +1,474 @@
+# SPEC-021: Adherence ledger and structured drivers decomposition
+
+| Field       | Value                                                    |
+|-------------|----------------------------------------------------------|
+| **Status**  | Proposed                                                 |
+| **Author**  | Nutrition & Meal Planning team                           |
+| **Created** | 2026-04-17                                               |
+| **Priority**| P0 within ADR-006 (blocks SPEC-022 dashboard)            |
+| **Scope**   | New module `backend/agents/nutrition_meal_planning_team/adherence/`, nightly snapshot job, structured drivers API, feedback loop into SPEC-012 learned preferences |
+| **Depends on** | SPEC-003 targets, SPEC-010 plan rollup, SPEC-018 cook events, SPEC-019 observations + off-plan intake, SPEC-020 trajectory |
+| **Implements** | ADR-006 §1 (three adherence questions), §3 (eaten rollup), §9 (drivers), §10 (planner feedback) |
+
+---
+
+## 1. Problem Statement
+
+ADR-006 promises three separate, non-conflated answers: did the
+user cook the plan (plan adherence), did what they ate hit the
+targets (target adherence), did the outcome move toward the goal
+(goal progress). SPEC-019 and SPEC-018 produce the raw inputs;
+SPEC-020 produces the expected trajectory. This spec is the
+**aggregation** layer that combines them into per-window snapshots
+with a structured decomposition of which factors are driving the
+gaps.
+
+This spec is not a UI. It produces:
+
+1. `nutrition_adherence_snapshots` — materialized per-user per-
+   window rows that the dashboard reads O(1).
+2. A `drivers` structured payload that names the top contributors
+   to any gap ("three skipped lunches account for 18 g/day of your
+   protein gap"). This is the decomposition layer the dashboard
+   renders and the planner (SPEC-012) consumes.
+
+Keeping aggregation in its own spec keeps the dashboard fast and
+keeps the feedback loop into the planner honest — the drivers are
+the signal, not a vibe.
+
+---
+
+## 2. Current State
+
+### 2.1 After SPEC-018, SPEC-019, SPEC-020
+
+- Cook events persisted (`nutrition_cook_events`).
+- Biometric observations and off-plan intakes persisted.
+- Trajectory snapshots computed nightly.
+- No component joins these into adherence metrics or drivers.
+- No nightly materialization; every read would scan raw events.
+
+### 2.2 Gaps
+
+1. No canonical definition of "plan adherence", "target
+   adherence", "goal progress" shipped anywhere.
+2. No eaten rollup (SPEC-018 provides per-event nutrients; no
+   per-day / per-week aggregation exists).
+3. No drivers decomposition — gaps are numbers without named
+   causes.
+4. No feedback signal to SPEC-012 (adherence-derived preferences).
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- Ship `adherence.compute_window(client_id, start, end) ->
+  AdherenceSnapshot` as the canonical computation.
+- Materialize snapshots nightly (plus on-demand refresh with
+  rate-limit) into `nutrition_adherence_snapshots`.
+- Produce three clearly separated gauges per window: plan
+  adherence, target adherence, goal progress status.
+- Produce structured `drivers` that name the top contributors to
+  any gap with quantified impact.
+- Feed adherence-derived signals into SPEC-012's learned
+  preferences (low weekday adherence → `prep_time.weekday` down,
+  clustered ingredient swaps → negative ingredient affinity).
+- Expose read APIs; no write APIs other than admin refresh.
+
+### 3.2 Non-goals
+
+- **No dashboard UI.** SPEC-022.
+- **No recalibration.** SPEC-020 owns it; this spec is one of its
+  inputs via the target-adherence signal.
+- **No predictions or forecasts.** This is historical aggregation
+  only.
+- **No cross-user benchmarks.** Per-user.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 Module layout
+
+```
+backend/agents/nutrition_meal_planning_team/adherence/
+├── __init__.py                 # compute_window, ADHERENCE_VERSION
+├── version.py                  # ADHERENCE_VERSION = "1.0.0"
+├── types.py                    # AdherenceSnapshot, DriverItem, Gauge
+├── plan_adherence.py
+├── target_adherence.py
+├── goal_progress.py
+├── drivers.py                  # decomposition logic
+├── eaten_rollup.py             # cook events + off-plan intake → nutrients
+├── preferences_feedback.py     # → SPEC-012
+├── snapshots.py                # Postgres persistence + nightly job
+├── errors.py
+└── tests/
+```
+
+### 4.2 Types
+
+```python
+@dataclass(frozen=True)
+class Gauge:
+    value: float                 # 0.0..1.0 for adherence; -1..+1 for goal progress
+    confidence: float
+    status: Literal["on_track", "caution", "off_track", "insufficient_data"]
+    explanation: str             # short NL for UI
+
+@dataclass(frozen=True)
+class DriverItem:
+    kind: Literal[
+        "skipped_meal", "swapped_meal", "macro_gap_day", "macro_over_day",
+        "off_plan_intake", "low_log_rate", "plan_gap"
+    ]
+    contribution: float          # signed, kcal or g or mg depending on context
+    unit: str
+    detail: str                  # "Tuesday lunch skipped"
+    recipe_id: Optional[str] = None
+    observed_at: Optional[str] = None
+
+@dataclass(frozen=True)
+class AdherenceSnapshot:
+    client_id: str
+    window_start: date
+    window_end: date
+    plan_adherence: Gauge
+    target_adherence: Gauge
+    goal_progress: Gauge
+    eaten_rollup: dict[Nutrient, float]        # window totals
+    drivers: tuple[DriverItem, ...]
+    inputs_hash: str                            # for idempotent materialization
+    adherence_version: str
+    computed_at: str
+```
+
+### 4.3 Plan adherence
+
+Per-recipe-scheduled-in-window, compute:
+
+- `made`: 1.0 weight; `servings_made >= portions * 0.75` → 1.0,
+  else proportional.
+- `partial`: `servings_made / portions_servings_numeric`, capped
+  at 1.0.
+- `swapped`: 0.8 weight (user followed the plan's intent but
+  diverged on specifics).
+- `skipped`: 0.0.
+- Not yet logged (plan recipe whose mealtime has passed and no
+  cook event exists): treated as `skipped` at snapshot time
+  unless the user has enabled "don't penalize unlogged meals"
+  (profile flag). Default is skip-penalty so adherence reflects
+  reality; SPEC-022 nudges users to log.
+
+`plan_adherence.value = Σ weights / count`. Confidence a function
+of the total log rate across the window.
+
+### 4.4 Eaten rollup
+
+Pure function over SPEC-018 cook events + SPEC-019 off-plan
+intakes within the window:
+
+- Cook events contribute `effective_nutrients` (SPEC-018 §4.5) ×
+  (servings_made or proportional).
+- Off-plan intakes contribute `estimated_nutrients` (SPEC-019)
+  with their confidence.
+- Skipped recipes contribute zero.
+- Net totals per day and per window.
+
+Runs deterministically; cached by `(client_id, window)` with
+TTL to next snapshot compute.
+
+### 4.5 Target adherence
+
+Compare eaten rollup vs. `DailyTargets` (SPEC-003 history —
+targets may have changed mid-window due to SPEC-020 recalibration;
+we look up the prevailing target per day, not the latest).
+
+- Per-nutrient per-day variance from target.
+- Per-nutrient weekly adequacy for the adequacy-list nutrients
+  (fiber, iron, D, K, Ca, B12).
+- Gauge value: mass-weighted fraction of nutrient-day-targets met
+  within tolerance (SPEC-010 `Tolerances`).
+- Confidence: lower when off-plan intake rate is high (intake
+  estimates have baseline uncertainty).
+
+### 4.6 Goal progress
+
+For `weight_kg` (v1 only):
+
+- Compare observed EMA delta over window vs. SPEC-020 expected
+  trajectory delta.
+- `value = 1 - |observed - expected| / tolerance` where
+  `tolerance = max(0.5 kg, 0.3% body weight per week)`.
+- Status mapping:
+  - `on_track`: value ≥ 0.7
+  - `caution`: 0.3 ≤ value < 0.7
+  - `off_track`: value < 0.3
+  - `insufficient_data`: fewer than 4 weight observations in window
+- Cohorts where SPEC-020 returns `Trajectory=None` → goal_progress
+  is `Gauge(status='insufficient_data')` with a clinical note
+  from the cohort; never auto-fail.
+
+### 4.7 Drivers decomposition
+
+Named, quantified contributors are where the value of this spec
+lives. For each gauge that is not `on_track`:
+
+- **Plan adherence**: rank skipped/swapped meals by frequency and
+  day. Surface top 3.
+- **Target adherence**: for each out-of-tolerance nutrient:
+  - Walk the window day by day.
+  - Identify which days contributed the largest absolute delta
+    toward the gap.
+  - Attribute each day's delta to: (skipped planned recipe),
+    (swapped for lower-nutrient substitute), (off-plan intake
+    over/under the nutrient), or (plan itself was low on that
+    nutrient — rare post-SPEC-010 repair).
+  - Emit DriverItems sorted by absolute `contribution`.
+- **Goal progress**: drivers are target adherence gap + plan
+  adherence gap × expected-impact coefficient; the driver list
+  references both.
+
+Every driver has a quantified `contribution` and a human-readable
+`detail`. No narrative-only drivers — the dashboard renders text,
+but the spec's contract is quantified.
+
+### 4.8 Preferences feedback (SPEC-012)
+
+On every snapshot compute:
+
+- **Skipped meal** on a weekday → negative contribution to
+  `prep_time.weekday` (source=derived, evidence="skipped 3
+  weekday dinners").
+- **Swapped meal** with a substitution at the ingredient level →
+  ingredient-affinity signals per SPEC-011's extractor call
+  semantics (SPEC-018 cook-event path already emits them; this
+  spec does not duplicate, only aggregates for the drivers view).
+- **Consistent macro gap** (target adherence persistently low on
+  protein, say) → advisory to planner prompt via SPEC-010 prompt
+  variables, not SPEC-012 (because it is plan-shape, not user
+  taste).
+
+Fed via structured events on the existing event bus. Consumers
+are SPEC-012's aggregator and SPEC-010's planner prompt.
+
+### 4.9 Nightly materialization + on-demand
+
+Scheduled task (Temporal):
+
+- Runs nightly per active client.
+- Windows materialized: last 7 days, last 30 days, current month.
+- Rolling windows keyed by (client_id, window_label, window_end).
+- Idempotent via `inputs_hash` — same inputs produce the same
+  snapshot. Re-runs with identical input short-circuit.
+
+On-demand refresh: `POST /adherence/{client_id}/refresh` (rate-
+limited to 1 per 5 min per user). Used by the dashboard "refresh
+now" action.
+
+### 4.10 Persistence
+
+Migration `018_adherence.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS nutrition_adherence_snapshots (
+    id                     BIGSERIAL PRIMARY KEY,
+    client_id              TEXT NOT NULL REFERENCES nutrition_profiles(client_id)
+                               ON DELETE CASCADE,
+    window_label           TEXT NOT NULL,    -- 'last_7_days' | 'last_30_days' | 'month_2026_04' | ...
+    window_start           DATE NOT NULL,
+    window_end             DATE NOT NULL,
+    plan_adherence_json    JSONB NOT NULL,
+    target_adherence_json  JSONB NOT NULL,
+    goal_progress_json     JSONB NOT NULL,
+    eaten_rollup_json      JSONB NOT NULL,
+    drivers_json           JSONB NOT NULL,
+    inputs_hash            TEXT NOT NULL,
+    adherence_version      TEXT NOT NULL,
+    computed_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+    UNIQUE (client_id, window_label, window_start, window_end, inputs_hash)
+);
+CREATE INDEX ON nutrition_adherence_snapshots (client_id, window_end DESC);
+```
+
+Also writes `nutrition_adherence_events` referenced by SPEC-018
+§4.6 — that table already exists in SPEC-018's migration as a
+cook-event adherence projection; this spec reads it.
+
+### 4.11 API
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/adherence/{client_id}?window=last_7_days` | Latest snapshot for a window |
+| `GET` | `/adherence/{client_id}/drivers?window=last_30_days` | Drivers only (lighter payload) |
+| `POST` | `/adherence/{client_id}/refresh` | Force recompute, rate-limited |
+| `GET` | `/adherence/{client_id}/eaten-rollup?window=...` | Eaten rollup payload (shared with SPEC-020 recalibration) |
+
+Consumers:
+
+- SPEC-022 dashboard: reads snapshots and drivers.
+- SPEC-020 recalibration: reads eaten rollup and target
+  adherence as inputs to its evaluator.
+- SPEC-012 learned preferences: subscribes to the event stream.
+
+### 4.12 Observability
+
+- `adherence.snapshot_computed{window}`.
+- `adherence.gauge_status{kind, status}` — counters keyed by
+  plan/target/goal and status.
+- `adherence.drivers_count_per_snapshot` histogram.
+- `adherence.low_log_rate_detected`.
+- `adherence.compute_latency_ms` histogram.
+- Alert: `adherence.gauge_status{goal_progress, status=off_track}`
+  rate rising across cohort → not necessarily an app issue but
+  worth investigating (could be a calculator regression).
+
+### 4.13 Privacy
+
+- Snapshots are derived from PHI-adjacent data; same retention +
+  cascade delete as SPEC-019.
+- Driver `detail` strings contain recipe names and weekday
+  references; no client_id leakage.
+- Log redaction keeps driver detail strings out of INFO logs.
+
+### 4.14 Priority-grouped work items
+
+| # | Item | Priority |
+|---|------|----------|
+| W1 | Module scaffolding, version, types | P0 |
+| W2 | Migration `018_adherence.sql` | P0 |
+| W3 | `eaten_rollup.py` + tests | P0 |
+| W4 | `plan_adherence.py` with weighting rules + tests | P0 |
+| W5 | `target_adherence.py` with target history lookup + tolerance application + tests | P0 |
+| W6 | `goal_progress.py` consuming SPEC-020 trajectory + tests | P0 |
+| W7 | `drivers.py` decomposition + ranked emission + tests | P0 |
+| W8 | Snapshot materialization: nightly job + idempotent hash | P0 |
+| W9 | `/adherence/{client_id}` endpoints | P0 |
+| W10 | `preferences_feedback.py` event emission to SPEC-012 | P1 |
+| W11 | On-demand refresh (rate-limited) | P1 |
+| W12 | Observability counters + alerting | P1 |
+| W13 | Benchmarks: snapshot compute p99 ≤ 500 ms for 30-day window; read p99 ≤ 80 ms | P2 |
+
+---
+
+## 5. Rollout Plan
+
+Flag `NUTRITION_ADHERENCE` (off → no snapshots, no endpoints;
+on → nightly job + endpoints).
+
+### Phase 0 — Foundation (P0)
+- [ ] SPEC-018, SPEC-019, SPEC-020 at 100% ramp.
+- [ ] W1–W8 landed. Migration applied in staging.
+
+### Phase 1 — Shadow snapshots (P0)
+- [ ] Flag on internal. Nightly job runs; snapshots persist.
+- [ ] Team reviews 10 internal snapshots manually.
+- [ ] Acceptance: gauges match the reviewer's intuitive read of
+      the user's week in ≥8 of 10 cases; drivers name the
+      actual top contributors.
+
+### Phase 2 — Endpoints + feedback (P0/P1)
+- [ ] W9, W10, W11 landed.
+- [ ] Preferences-feedback events observed in SPEC-012's
+      aggregator logs; preference digests updated when signals
+      flow.
+
+### Phase 3 — Ramp (P1)
+- [ ] 10% → 50% → 100% over two weeks.
+- [ ] Monitor: snapshot compute latency, gauge-status
+      distribution, driver-count distribution, rate of
+      `insufficient_data` (if high, logging-nudge work is
+      warranted).
+
+### Phase 4 — Cleanup (P1/P2)
+- [ ] W12, W13 landed.
+- [ ] Flag default on; removal scheduled.
+
+### Rollback
+- Flag off → snapshots stop; persisted rows retained (inert).
+- Additive migration.
+
+---
+
+## 6. Verification
+
+### 6.1 Unit tests
+
+- `test_plan_adherence_weighting.py` — made/partial/swapped/skipped
+  produce the documented weights; unlogged past-mealtime recipe
+  counts as skipped (default) or ignored (flag).
+- `test_eaten_rollup_composition.py` — cook events + off-plan
+  intakes sum correctly; overlapping off-plan and made event
+  handled (not double-counted).
+- `test_target_adherence_midwindow_target_change.py` — SPEC-020
+  recalibration acceptance mid-window: the correct per-day
+  target applies to each day.
+- `test_goal_progress_tolerance.py` — weight changes within
+  tolerance produce `on_track`; outside produce `caution` or
+  `off_track`.
+- `test_driver_ranking.py` — synthetic gap (skipped Tuesday +
+  Thursday lunches) produces a `skipped_meal` driver with
+  correct contribution.
+- `test_insufficient_data.py` — <4 weight observations → goal
+  progress `insufficient_data`.
+
+### 6.2 Integration tests
+
+- `test_snapshot_nightly_idempotent.py` — same inputs → same
+  `inputs_hash` → unique constraint skips duplicate write.
+- `test_preferences_feedback_emitted.py` — low weekday
+  adherence causes the expected SPEC-012 signal to land.
+- `test_adherence_api_consistency.py` — endpoint returns
+  snapshot identical to what the nightly job stored.
+- `test_refresh_rate_limit.py` — 2 refreshes within 5 min →
+  second returns 429.
+
+### 6.3 Reviewer audit (Phase 1)
+
+- 10 internal snapshots reviewed. Gauges and top-3 drivers match
+  reviewer intuition in ≥8/10.
+
+### 6.4 Property tests
+
+- Determinism: replay a week of events → byte-equal snapshot.
+- Monotonicity: adding more `made` cook events within a window
+  never decreases plan adherence.
+- Driver sum sanity: sum of `contribution` values across
+  macro-gap drivers roughly equals the gauge's absolute gap
+  (not strict equality because of driver categorization overlap,
+  but within 20%).
+
+### 6.5 Observability
+
+All §4.12 counters emit.
+
+### 6.6 Cutover criteria
+
+- All P0 tests green.
+- Phase 1 reviewer acceptance met.
+- Phase 3 ramp: snapshot latency within budget; no correctness
+  incidents.
+
+---
+
+## 7. Open Questions
+
+- **Default penalty for unlogged past-mealtime recipes.** Default
+  `skip-penalty` makes adherence numbers conservative. Some
+  users will find this frustrating. The profile toggle
+  "don't penalize unlogged meals" is a safety valve. We may
+  change the default after Phase 3 data.
+- **Driver categorization.** The categories in §4.2 are closed.
+  Adding one is an additive change; removing or renaming is a
+  major version bump.
+- **Month-over-month windows.** `month_YYYY_MM` works for the
+  current month; backfill of prior months is computed on-demand
+  and cached. Deep history beyond 24 months may be expensive to
+  compute; we accept that historical deep queries have longer
+  latency than recent.
+- **"Insufficient data" threshold for weight observations.** Four
+  observations in a window is a low bar; some users weigh
+  weekly. SPEC-022 will nudge log cadence; insufficient_data is
+  legitimate, not a failure.

--- a/system_design/specs/SPEC-022-nutrition-goal-progress-dashboard.md
+++ b/system_design/specs/SPEC-022-nutrition-goal-progress-dashboard.md
@@ -1,0 +1,474 @@
+# SPEC-022: Goal-progress dashboard
+
+| Field       | Value                                                    |
+|-------------|----------------------------------------------------------|
+| **Status**  | Proposed                                                 |
+| **Author**  | Nutrition & Meal Planning team                           |
+| **Created** | 2026-04-17                                               |
+| **Priority**| P1 (capstone — the user-visible surface for ADR-006)     |
+| **Scope**   | Dashboard API aggregator, `user-interface/` dashboard view, weekly-weigh nudge UX, safety-state banner, recalibration accept/decline surface, copy review and a11y |
+| **Depends on** | SPEC-019 (observations + off-plan log), SPEC-020 (trajectory + recalibration), SPEC-021 (adherence + drivers), SPEC-018 (cook events) |
+| **Implements** | ADR-006 §9 (dashboard API + view), all §6 safety rails on the UI side |
+
+---
+
+## 1. Problem Statement
+
+After SPEC-019 through SPEC-021, the team has every input ADR-006
+asked for. Nothing renders them to the user.
+
+This spec ships the dashboard: the user-visible page that answers
+"is this working?" across the three separated gauges (plan
+adherence, target adherence, goal progress), surfaces the structured
+drivers as actionable bullets, renders the expected-vs-observed
+trajectory, hosts the recalibration accept/decline surface, and
+enforces the safety rails on the UI — including disabling the
+scale-centric view when the ED-history flag is on.
+
+It is the highest-stakes UI the team owns. A single careless
+design decision (shame-framed copy, surprise scale chart, daily-
+weigh nudge) does real user harm. This spec treats that seriously
+and encodes the rules in §6 (copy, §7 accessibility, and §8 rail
+enforcement.
+
+It ships exactly one new backend endpoint — a thin aggregator
+that combines snapshots for fast render — and the UI proper. No
+new data produced here; everything is a read.
+
+---
+
+## 2. Current State
+
+### 2.1 After SPEC-019–SPEC-021
+
+- Observations, cook events, off-plan intakes, adherence
+  snapshots, trajectory snapshots, recalibration proposals all
+  exist and are individually queryable.
+- No unified dashboard endpoint.
+- No dashboard UI.
+- Recalibration proposals live in the database but have nowhere
+  to be accepted from.
+
+### 2.2 Gaps
+
+1. No `DashboardView` payload combining the above for a single
+   page render.
+2. No safety-state computed gauge for the UI.
+3. No ED-flag-aware view rendering.
+4. No weekly-weigh cadence nudge (ADR-006 §6 explicitly resists
+   daily-weigh UX).
+5. No accept/decline UX for recalibration.
+
+---
+
+## 3. Goals and Non-Goals
+
+### 3.1 Goals
+
+- Ship `GET /dashboard/{client_id}?period=week|month|quarter`
+  returning a `DashboardView` the UI renders in one request.
+- Ship the dashboard view: three gauges, drivers, trajectory
+  chart, eaten-rollup summary, recalibration surface, safety
+  state banner.
+- Replace scale-centric components with behavior-centric ones
+  when `ed_history_flag=true`.
+- Weekly weigh cadence: the UI invites one weigh per 7 days at
+  most, never prompts for daily. 7-day EMA is the primary chart
+  series.
+- Copy and UX adhere to ADR-006 §6.5 rules: behavior- and
+  energy-framed, never shame-framed. Shipped copy reviewed.
+- Accessibility: AA contrast, screen-reader labels on gauges,
+  keyboard navigable.
+- No surprises: any automatic state change (proposal auto-
+  expiring, rate-cap kicking in) is explained, not hidden.
+
+### 3.2 Non-goals
+
+- **No new data.** This spec only reads.
+- **No exports.** Clinician PDF/CSV export of adherence and
+  observations is v1.1.
+- **No device connect flows in this spec.** SPEC-019's device-
+  adapter follow-ups own that.
+- **No in-dashboard editing of plan or targets.** The dashboard
+  links to the relevant edit surfaces; it does not own them.
+- **No comparison across users.** Per-user only.
+
+---
+
+## 4. Detailed Design
+
+### 4.1 Module layout
+
+```
+backend/agents/nutrition_meal_planning_team/dashboard/
+├── __init__.py
+├── types.py               # DashboardView
+├── aggregator.py          # fan out to other stores + compose
+├── safety.py              # compute safety_state for UI
+├── errors.py
+└── tests/
+```
+
+UI changes primarily in `user-interface/src/app/components/nutrition/dashboard/`.
+
+### 4.2 `DashboardView` type
+
+```python
+class DashboardView(BaseModel):
+    client_id: str
+    period: Literal["week", "month", "quarter"]
+    generated_at: str
+
+    # Three gauges (from SPEC-021)
+    plan_adherence: Gauge
+    target_adherence: Gauge
+    goal_progress: Gauge
+
+    # Trajectory (from SPEC-020)
+    trajectory: Optional[TrajectorySeries]      # None for unsupported cohorts
+    observed_series: List[ObservationPoint]     # 7-day EMA
+    last_weigh_days_ago: Optional[int]
+    weigh_nudge: Optional[str]                  # "It's been 10 days since your last weigh-in."
+
+    # Eaten rollup (from SPEC-021)
+    eaten_rollup: Dict[Nutrient, float]
+
+    # Drivers (from SPEC-021)
+    drivers: List[DriverItem]                   # top 5 by contribution
+
+    # Recalibration (from SPEC-020)
+    recalibration_proposal: Optional[RecalibrationProposal]
+
+    # Safety state
+    safety_state: SafetyState
+    cohort: PlanCohort                          # informs rendering
+    view_variant: Literal["standard", "ed_adjacent", "minor", "pregnancy_lactation", "clinician_guided"]
+```
+
+### 4.3 Safety state
+
+```python
+class SafetyState(BaseModel):
+    level: Literal["ok", "caution", "rail_active"]
+    active_rails: List[str]                     # ['rate_of_loss', 'bmi_floor']
+    message: Optional[str]                      # user-facing text
+    action_cta: Optional[str]                   # e.g. "Review your goal"
+```
+
+Computed in `safety.py` from SPEC-020's rail event log + current
+profile flags. Surfaced prominently in the dashboard header when
+non-ok. `rail_active` pre-empts normal gauge display with a
+clear, non-alarming banner.
+
+### 4.4 View variants
+
+- **standard**: three gauges, trajectory, drivers, recalibration.
+- **ed_adjacent** (`ed_history_flag=true` OR cohort=ed_adjacent):
+  - No trajectory chart.
+  - No weight observations shown (even if logged).
+  - Goal progress gauge replaced with "variety" +
+    "cook streak" + "plan follow-through" behavior metrics.
+  - Eaten-rollup shown as **food-group balance** (servings of
+    veg, whole grains, protein sources) not as kcal numbers.
+  - No recalibration surface.
+- **minor** (age_years < 18):
+  - No trajectory.
+  - Goal progress replaced with "variety" and "plan
+    follow-through".
+  - Prominent "growth-focused guidance" note.
+- **pregnancy_lactation** / **clinician_guided**: scalar gauges
+  hidden; nutrient-summary + cook-streak only; "work with your
+  clinician" note from the SPEC-020 trajectory response.
+
+Variants are selected server-side in the aggregator. The UI must
+not attempt to "upgrade" a variant to standard.
+
+### 4.5 Weekly-weigh nudge
+
+- `last_weigh_days_ago` populated from SPEC-019.
+- UI rule: if `last_weigh_days_ago >= 7`, show a single gentle
+  nudge on the dashboard: *"It's been 10 days — want to log a
+  weigh-in?"* with a one-click log action.
+- If `last_weigh_days_ago < 7`, no nudge. We explicitly do not
+  encourage daily weighing.
+- Copy exception: if `ed_adjacent` variant, the nudge is
+  suppressed entirely.
+
+### 4.6 Trajectory chart
+
+- Line chart: expected band (shaded) + observed 7-day EMA line.
+- X axis: date; Y axis: weight (kg or lb per profile unit
+  preference).
+- If last observation is > 14 days old, the EMA line dashes out
+  past that point.
+- Hover / focus on a point shows the numeric value and date; no
+  surprise colors.
+- Unsupported cohort: chart omitted and replaced with a neutral
+  note.
+
+### 4.7 Drivers UI
+
+Each driver rendered as a single bullet:
+
+```
+• Three weekday dinners skipped
+    → about 18 g/day of your protein gap this week
+    [Adjust cook reminders]
+```
+
+Quantified impact visible. CTA links (where available) deep-link
+to the relevant edit surface (cook-mode reminders, plan
+regeneration, pantry import, etc.). If no CTA is appropriate,
+the bullet is informational only.
+
+### 4.8 Recalibration surface
+
+- When a `RecalibrationProposal` is present:
+  - Card on the dashboard: *"Your maintenance looks closer to
+    2,250 kcal than 2,400. Here's why: [brief
+    explanation.] [Review proposal]"*
+  - "Review" opens a modal with inputs used, window, confidence,
+    impact on next plan. Two buttons: "Accept" and "Not now".
+  - Accepted proposals persist the adjustment (SPEC-020 §4.4);
+    a confirmation toast appears on the next plan generation.
+  - Declined proposals are hidden until the 21-day anti-thrash
+    window elapses.
+
+- When no proposal: no card.
+
+### 4.9 Aggregator endpoint
+
+`GET /dashboard/{client_id}?period=week` composes:
+
+1. `adherence.compute_window` → latest materialized snapshot
+   (SPEC-021).
+2. `biometrics.get_series` → 7-day EMA (SPEC-019).
+3. `biometrics.get_latest` → `last_weigh_days_ago`.
+4. `trajectory.get_latest` → expected series (SPEC-020).
+5. `recalibration.get_active_proposal` → latest proposal.
+6. `safety.compute_safety_state` → UI state.
+7. Profile → cohort + variant selection.
+
+All subcalls run concurrently; snapshot reads are sub-10 ms,
+trajectory read sub-50 ms. Endpoint p99 budget: ≤ 150 ms.
+
+Refresh: dashboard does not auto-refresh more than once per open.
+An explicit "Refresh now" button calls
+`POST /adherence/{client_id}/refresh` (rate-limited per SPEC-021).
+
+### 4.10 UI states enumerated
+
+- **Loading**: skeleton render of the three gauges + chart.
+- **First-time user** (cold-start): three gauges read
+  `insufficient_data`; chart shows "add your weight to see your
+  trajectory"; drivers list shows "we'll show what's driving
+  your progress once there's a few days of data."
+- **No goal set**: hide goal_progress gauge and trajectory; show
+  "set a goal" CTA linking to the profile.
+- **Unsupported cohort**: prominent neutral note explaining why
+  some views are not shown; link to clinician-consult guidance.
+- **Safety rail active** (e.g. rate_of_loss): banner at the top
+  reading *"We've paused your weight-loss goal because your
+  trend is moving faster than is safe. Your plan will focus on
+  maintenance until you ease off."* with a "Why?" link to
+  details.
+- **Recalibration pending**: proposal card above the gauges.
+
+### 4.11 Accessibility
+
+- WCAG AA color contrast for all gauge, chart, and status colors.
+- Screen-reader labels on every gauge: *"Plan adherence: 85
+  percent, on track."*
+- Charts are keyboard-navigable; arrow-key focus on data points
+  with announced values.
+- No information conveyed solely by color; status chips have
+  text labels.
+- `prefers-reduced-motion` disables gauge animation.
+
+### 4.12 Copy governance
+
+- Every user-facing string in the dashboard is declared in a
+  single i18n-ready `strings.ts` (Angular) with a comment tag
+  linking to the ADR-006 §6.5 rule it satisfies
+  (behavior-framed, no shame, etc.).
+- Every string added or changed requires a reviewer from the
+  dedicated copy-review list (team lead + one external reviewer
+  initially).
+- `strings.ts` is checked into the repo; PRs modifying it
+  require the copy reviewer on CODEOWNERS.
+
+### 4.13 Observability
+
+- `dashboard.viewed{variant}`.
+- `dashboard.gauge_status_rendered{kind, status}`.
+- `dashboard.recalibration_card_{viewed, accepted, declined}`.
+- `dashboard.safety_banner_viewed{rail}`.
+- `dashboard.weigh_nudge_{shown, acted}`.
+- `dashboard.latency_ms` histogram.
+- Alerts: `dashboard.safety_banner_viewed{rail=bmi_floor}` rate
+  rising → on-call review (not an incident; a signal).
+
+### 4.14 Privacy and data display
+
+- Dashboard renders sensitive data. The URL route requires
+  authenticated session; no share links or deep-link
+  enumeration.
+- Logs never include dashboard payloads above DEBUG.
+- Server-side rendering (if added later) has to respect the same
+  redaction rules; v1 is client-side only.
+
+### 4.15 Priority-grouped work items
+
+| # | Item | Priority |
+|---|------|----------|
+| W1 | `DashboardView` type + aggregator endpoint | P0 |
+| W2 | `safety.compute_safety_state` + unit tests | P0 |
+| W3 | View-variant selection logic | P0 |
+| W4 | UI: standard view (three gauges + drivers list) | FE | P0 |
+| W5 | UI: trajectory chart + observed EMA | FE | P0 |
+| W6 | UI: recalibration card + accept/decline modal | FE | P0 |
+| W7 | UI: safety banner (rate_of_loss, bmi_floor, ed filters) | FE | P0 |
+| W8 | UI: ED-adjacent / minor / cohort variant screens | FE | P0 |
+| W9 | UI: weekly-weigh nudge | FE | P1 |
+| W10 | Copy file + copy review process + CODEOWNERS entry | P0 |
+| W11 | Accessibility pass (a11y audit + fixes) | P0 |
+| W12 | UI: empty / cold-start states | FE | P1 |
+| W13 | Observability counters + alerting | P1 |
+| W14 | Benchmarks: endpoint p99 ≤ 150 ms; UI first-render ≤ 500 ms | P2 |
+| W15 | i18n-readiness of the copy file | P2 |
+
+---
+
+## 5. Rollout Plan
+
+Flag `NUTRITION_DASHBOARD` (off → dashboard route 404; on →
+available).
+
+### Phase 0 — Foundation (P0)
+- [ ] SPEC-019, SPEC-020, SPEC-021 at 100% ramp.
+- [ ] W1–W3 landed.
+- [ ] Copy written and reviewed (W10).
+
+### Phase 1 — Internal dogfood (P0)
+- [ ] W4–W8 landed.
+- [ ] Flag on internal. Team uses the dashboard on real profiles
+      for 2 weeks.
+- [ ] Acceptance gates:
+      - Zero shame-framed copy incidents.
+      - Zero safety rail UI errors (banner shown but rail not
+        active, or vice versa).
+      - `ed_adjacent` variant hides all scale-centric elements
+        on an internal dogfood profile.
+
+### Phase 2 — A11y + polish (P0/P1)
+- [ ] W11 a11y audit; findings resolved.
+- [ ] W9 nudge; W12 cold-start; W13 observability.
+- [ ] External copy reviewer sign-off on every visible string.
+
+### Phase 3 — Ramp (P1)
+- [ ] 10% → 25% → 50% → 100% over three weeks.
+- [ ] Watch metrics:
+      - dashboard.viewed per active user per week.
+      - Recalibration acceptance rate.
+      - Weigh nudge action rate.
+      - Support tickets mentioning the dashboard — triage for
+        any surprise or shame-framed report.
+
+### Phase 4 — Cleanup (P1/P2)
+- [ ] W14 benchmarks; W15 i18n.
+- [ ] Flag default on; removal scheduled.
+
+### Rollback
+- Flag off → dashboard route hidden; underlying data untouched.
+- No migration.
+
+---
+
+## 6. Verification
+
+### 6.1 Unit tests
+
+- `test_variant_selection.py` — matrix of profile states →
+  correct variant.
+- `test_safety_state.py` — each rail combination produces the
+  expected state + message.
+- `test_aggregator.py` — concurrent fan-out returns a consistent
+  snapshot; partial failures (e.g. trajectory unavailable)
+  degrade to `insufficient_data` not 500.
+
+### 6.2 Integration tests
+
+- `test_dashboard_standard.py` — standard profile at 100%
+  adherence renders all components correctly.
+- `test_dashboard_ed_flag.py` — `ed_history_flag=true` profile
+  renders `ed_adjacent` variant; scale-centric elements absent
+  from the payload (not just hidden in CSS).
+- `test_dashboard_minor.py` — age<18 renders minor variant.
+- `test_dashboard_pregnancy.py` — pregnancy cohort renders
+  pregnancy_lactation variant.
+- `test_dashboard_safety_rail_active.py` — rate_of_loss rail
+  active → banner rendered + plan generation clamped (SPEC-020
+  integration).
+- `test_recalibration_accept_flow.py` — proposal accept →
+  profile `tdee_adjustment_kcal` updated → dashboard reflects
+  "accepted" state.
+
+### 6.3 UX + copy audit (Phase 1/2)
+
+- External copy reviewer audits every string against ADR-006
+  §6.5 rules. Findings:
+  - Zero shame-framed strings.
+  - Zero strings that imply user failure.
+  - All safety-state strings reviewed with heightened care.
+
+### 6.4 Accessibility audit (Phase 2)
+
+- `axe-core` or equivalent across the dashboard; zero AA
+  violations.
+- Manual screen-reader pass confirms gauges announce values and
+  status; trajectory chart points navigable.
+- `prefers-reduced-motion` respected.
+
+### 6.5 Property tests
+
+- Variant selection deterministic.
+- Any profile with `ed_history_flag=true` under any cohort
+  produces a variant that omits scale / calorie numbers from
+  the payload. Enforced in the aggregator, not just the UI.
+
+### 6.6 Observability
+
+All §4.13 counters emit.
+
+### 6.7 Cutover criteria
+
+- All P0/P1 tests green.
+- Copy + a11y audits passed.
+- Phase 1 dogfood acceptance met.
+- Phase 3 ramp: zero safety-rail UI bugs; acceptance rate of
+  recalibration in a reasonable range (not 0%, not 100%).
+- Clinical + legal review sign-off (dashboard is the most
+  likely surface to attract review).
+
+---
+
+## 7. Open Questions
+
+- **Daily weight logging opt-in.** Some users insist on daily
+  weighing. v1 resists via nudge cadence; if enough users
+  request it, a user-opt-in "I want daily prompts" toggle can
+  be added — but the default never changes.
+- **Goal-progress tolerance visualization.** Showing the
+  trajectory band fills this role. We may also want a small
+  gauge labeled with an interpretation ("~0.3 kg/week loss,
+  within your goal of 0.45"). Nice-to-have; revisit Phase 3.
+- **Clinician dashboard export.** Clipped PDF/CSV for sharing
+  with a dietitian or PCP. v1.1.
+- **"Why are my numbers stuck?" explanation depth.** Drivers
+  tell the immediate story. A deeper diagnostic ("your cooking
+  times have crept up, your weekend adherence is low") lives
+  in the drivers categorization. If user-testing indicates the
+  current drivers are too concise, expand; not speculatively.
+- **Mobile-optimized layout.** The dashboard is dense. v1 is
+  web-first; mobile-web is styled but not reflowed per-
+  component. Dedicated mobile-native layout is a future spec.


### PR DESCRIPTION
## Summary

- **6 ADRs + 21 SPECs** for a full overhaul of the Nutrition & Meal Planning team (first commit, docs-only).
- **SPEC-002 implementation**: profile biometrics + clinical data model + audit tables + new API surface (second commit, code + tests).

## Why

Principal-engineer review of the nutrition team identified five high-impact changes needed before the product can make defensible health claims or safely serve clinical cohorts. The ADRs capture those decisions; the specs break each ADR into independently shippable work; SPEC-002 is the first of them (it unblocks SPEC-003 and SPEC-004).

## What's in the docs commit

Architectural decisions (system_design/adr/):
- **ADR-001** — Ground nutrition targets in deterministic calculation (Mifflin–St Jeor + clinical overrides); demote the LLM to narrator.
- **ADR-002** — Deterministic allergen / dietary / drug-interaction guardrail on every meal recommendation. Fail closed on unresolved ingredients.
- **ADR-003** — Quantitative plan validation with targeted per-meal repair.
- **ADR-004** — Structured learned preferences per client (extract → aggregate → retrieve).
- **ADR-005** — Actionable workflow layer (grocery, pantry, substitution, calendar, cook mode).
- **ADR-006** — Capstone goal-progress / adherence dashboard with recalibration loop and safety rails.

Feature specs (system_design/specs/SPEC-002 through SPEC-022) — each ADR decomposed into 2–5 specs using the repo's 7-section template; dependency-ordered and individually shippable behind feature flags.

## What's in the SPEC-002 code commit

Additive Pydantic models + closed clinical taxonomy + append-only audit tables + new API endpoints:

| Area | Change |
|---|---|
| `models.py` | `BiometricInfo`, `ClinicalInfo`, `ReproductiveState`, `Sex`, `ActivityLevel` with strict implausibility bounds (rejected, never clamped). `GoalsInfo` gains `target_weight_kg` / `rate_kg_per_week`. `ClientProfile` gains `profile_version` + `schema_version`. New patch/response types. |
| `clinical_taxonomy.py` | Closed `Condition` + `Medication` enums, freetext escape hatch for unrecognized strings, convenience sets (`CKD_STAGES`, `CLINICIAN_GUIDED_ONLY`). |
| `units.py` | Deterministic `coerce_height_cm` / `coerce_weight_kg` with no silent-zero fallback. |
| `postgres/__init__.py` | New `nutrition_biometric_log` (time-series; feeds SPEC-019/ADR-006) and `nutrition_clinical_overrides_log` tables. Additive migration — existing tables untouched. |
| `api/main.py` | `PATCH /profile/{id}/biometrics`, `GET /profile/{id}/biometrics/history`, `PATCH /profile/{id}/clinical`, `PUT /profile/{id}/clinical-overrides`, `GET /profile/{id}/completeness`. |
| `orchestrator/agent.py` | Per-field biometric patching with imperial→metric coercion + audit row per change; clinical taxonomy parsing (known/freetext split); clinician override diff + audit; completeness computation (minor flag, ED flag, structured blockers). |
| `agents/intake_profile_agent/` | Prompt updated with new fields + strict cm/kg rules. Regex fence-strip replaced with `llm_service.extract_json_from_response`. Fallback merge extracted to `structural.py` (pure logic, no strands dependency). Subpackage `__init__.py` made lazy via PEP 562 `__getattr__` so tests can run without the full LLM stack. |
| `shared/client_profile_store.py` | `log_biometric` / `get_biometric_history` / `log_clinical_override`; `save_profile` bumps `profile_version` monotonically. |

### Tests — 85 unit tests passing, 0 failing

- `test_models_validators.py` — 50 tests covering every bound, timezone validation, roundtrip, patch-request defaults.
- `test_units.py` — 19 tests: direct conversions, ft/in/lb roundtrips, the \"0 cm falls through to imperial, 0 lb returns None\" edge cases.
- `test_clinical_taxonomy.py` — 10 tests: enum membership, dedup, known/unknown split, convenience sets.
- `test_intake_agent_v2.py` — 6 tests: structural merge with new sub-objects; documented whole-sub-object-replace semantics for `PUT /profile` vs per-field `PATCH /biometrics`.
- `test_profile_biometrics.py` — 14 Postgres integration tests (skip-on-no-POSTGRES): patch paths, imperial coercion, implausible rejection, history paging, completeness matrix (minor, ED flag, partial biometrics), profile_version bump invariant.

### Safety & invariants enforced in code

- Implausible biometrics → 422, never clamped.
- Minors (age<18) surface `minor_guidance_only` blocker — SPEC-003 cohort router will consume this to disable weight-loss goals.
- `ed_history_flag=true` surfaces from completeness — SPEC-022 will hide scale-centric UI variants based on it.
- Every biometric write produces one audit row per changed field with canonical unit (cm/kg), not user-typed unit.
- Clinician-override writes produce per-key audit rows.

## Test plan

- [ ] CI ruff check passes (`make lint` — verified locally: `All checks passed!`).
- [ ] CI unit tests pass (verified locally: 85/85 pass in 0.16s).
- [ ] Postgres integration tests pass in an env with `POSTGRES_HOST` set.
- [ ] Existing nutrition team tests (`test_agents.py`, `test_api.py`, `test_stores.py`) continue to pass — my changes are additive; no fields removed or renamed.
- [ ] Existing `PUT /profile/{id}` still round-trips (verified by `test_profile_biometrics.py::test_patch_biometrics_records_log` which creates a profile via PUT first).

## Rollout

Implementation itself is additive and non-breaking. The `NUTRITION_PROFILE_V2` feature flag described in SPEC-002 §5 gates the *UI* rollout — backend endpoints are live and callable immediately, which is correct because:

1. New endpoints are 404 for clients that don't know about them (no breakage).
2. Existing `PUT /profile` is unchanged.
3. Existing profiles migrate silently — defaults populate `biometrics={}` and `clinical={}` on first read.

## Follow-up

This is the first of 21 specs. Next implementation spec (independent work streams that can run in parallel with ADR-003 work):

- **SPEC-005** — ingredient KB + parser (unblocks ADR-002, ADR-003, ADR-005 — large data-curation lift).
- **SPEC-003** — deterministic calculator (blocked only by this PR landing; can start immediately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)