### PR TITLE
docs: replace ASCII architecture diagram with Mermaid on GH Pages

### DIFF
--- a/backend/agents/accessibility_audit_team/README.md
+++ b/backend/agents/accessibility_audit_team/README.md
@@ -17,22 +17,32 @@ Identify accessibility issues and frame them in two ways:
 
 ## Architecture
 
-```
-                    ┌──────────────────────┐
-                    │  AccessibilityProgram │
-                    │       Lead (APL)      │
-                    └──────────┬───────────┘
-                               │
-           ┌───────────────────┼───────────────────┐
-           │                   │                   │
-    ┌──────▼──────┐     ┌──────▼──────┐     ┌──────▼──────┐
-    │   Lane A    │     │   Lane B    │     │   Quality   │
-    │  Coverage   │     │ Credibility │     │    Layer    │
-    ├─────────────┤     ├─────────────┤     ├─────────────┤
-    │ WAS (Web)   │────▶│ ATS (AT)    │────▶│ QCR (QA)    │
-    │ MAS (Mobile)│     │ SLMS (Stds) │     │ RA (Remed)  │
-    └─────────────┘     │ REE (Evid)  │     └─────────────┘
-                        └─────────────┘
+```mermaid
+flowchart TB
+    APL["Accessibility Program Lead (APL)"]
+
+    subgraph LaneA["Lane A: Coverage"]
+        WAS["WAS (Web)"]
+        MAS["MAS (Mobile)"]
+    end
+
+    subgraph LaneB["Lane B: Credibility"]
+        ATS["ATS (AT)"]
+        SLMS["SLMS (Stds)"]
+        REE["REE (Evid)"]
+    end
+
+    subgraph Quality["Quality Layer"]
+        QCR["QCR (QA)"]
+        RA["RA (Remed)"]
+    end
+
+    APL --> LaneA
+    APL --> LaneB
+    APL --> Quality
+
+    WAS --> ATS
+    ATS --> QCR
 ```
 
 ### Specialist Agents (8 Core)
@@ -58,19 +68,12 @@ Identify accessibility issues and frame them in two ways:
 
 ## Workflow Phases
 
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                                                                      │
-│  ┌─────────┐   ┌───────────┐   ┌──────────────┐   ┌───────────┐    │
-│  │ Intake  │ → │ Discovery │ → │ Verification │ → │  Report   │    │
-│  │ (APL)   │   │ (WAS/MAS) │   │ (ATS/SLMS)   │   │ Packaging │    │
-│  └─────────┘   └───────────┘   └──────────────┘   └───────────┘    │
-│                                                          │          │
-│                                                    ┌─────▼─────┐    │
-│                                                    │  Retest   │◄───┤
-│                                                    │ (Optional)│    │
-│                                                    └───────────┘    │
-└─────────────────────────────────────────────────────────────────────┘
+```mermaid
+flowchart LR
+    Intake["Intake<br/>(APL)"] --> Discovery["Discovery<br/>(WAS/MAS)"]
+    Discovery --> Verification["Verification<br/>(ATS/SLMS)"]
+    Verification --> Report["Report<br/>Packaging"]
+    Report --> Retest["Retest<br/>(Optional)"]
 ```
 
 ### Phase 0: Intake

--- a/backend/agents/agent_sandbox/README.md
+++ b/backend/agents/agent_sandbox/README.md
@@ -17,15 +17,14 @@ Used by `backend/unified_api/routes/sandboxes.py`
 
 ## State machine
 
-```
-           ensure_warm                    health OK
-   COLD ─────────────────► WARMING ──────────────────► WARM
-                               │                         │
-                               │                         │ idle > threshold
-                               │                         ▼
-                               │                        COLD
-                               │
-                               └── health fail ──► ERROR ──► COLD
+```mermaid
+stateDiagram-v2
+    [*] --> COLD
+    COLD --> WARMING: ensure_warm
+    WARMING --> WARM: health OK
+    WARMING --> ERROR: health fail
+    WARM --> COLD: idle > threshold
+    ERROR --> COLD
 ```
 
 ## Adding a new team

--- a/backend/agents/personal_assistant_team/README.md
+++ b/backend/agents/personal_assistant_team/README.md
@@ -4,31 +4,19 @@ A comprehensive personal assistant agent team that manages email, calendars, tas
 
 ## Architecture
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                    PersonalAssistantOrchestrator                │
-│              (Intent Classification & Request Routing)          │
-└─────────────────────────┬───────────────────────────────────────┘
-                          │
-    ┌─────────────────────┼─────────────────────┐
-    │                     │                     │
-    ▼                     ▼                     ▼
-┌─────────┐         ┌─────────┐          ┌─────────┐
-│ Email   │         │Calendar │          │  Task   │
-│ Agent   │         │ Agent   │          │ Agent   │
-└─────────┘         └─────────┘          └─────────┘
-    │                     │                     │
-    ▼                     ▼                     ▼
-┌─────────┐         ┌─────────┐          ┌─────────┐
-│  Deal   │         │Reserv.  │          │  Doc    │
-│ Finder  │         │ Agent   │          │Generator│
-└─────────┘         └─────────┘          └─────────┘
-                          │
-                          ▼
-                    ┌───────────┐
-                    │User Profile│
-                    │   Agent    │
-                    └───────────┘
+```mermaid
+flowchart TB
+    ORCH["PersonalAssistantOrchestrator<br/>(Intent Classification & Request Routing)"]
+
+    ORCH --> EMAIL["Email Agent"]
+    ORCH --> CAL["Calendar Agent"]
+    ORCH --> TASK["Task Agent"]
+
+    EMAIL --> DEAL["Deal Finder"]
+    CAL --> RES["Reservation Agent"]
+    TASK --> DOC["Doc Generator"]
+
+    RES --> PROFILE["User Profile Agent"]
 ```
 
 ## Features

--- a/backend/agents/user_agent_founder/system_design/FEATURE_SPEC_testing_personas.md
+++ b/backend/agents/user_agent_founder/system_design/FEATURE_SPEC_testing_personas.md
@@ -37,36 +37,39 @@ This spec extends the feature so a user can:
 
 ### Testing Personas dashboard (`/persona-testing`)
 
-```
-Testing Personas
-─────────────────────────────────────────────────
-  [ Start Test ]              [ + Create Persona ]
+```mermaid
+flowchart TB
+    Header["Testing Personas"]
+    Actions["[ Start Test ]  |  [ + Create Persona ]"]
 
-  Personas
-  ┌─────────────────┐  ┌─────────────────┐
-  │ Startup Founder │  │ My QA Persona   │
-  │ (builtin)       │  │ (custom)        │
-  │  Edit disabled  │  │  Edit / Delete  │
-  │  [Duplicate]    │  │                 │
-  └─────────────────┘  └─────────────────┘
+    subgraph Personas["Personas"]
+        Builtin["Startup Founder<br/>(builtin)<br/>Edit disabled<br/>[Duplicate]"]
+        Custom["My QA Persona<br/>(custom)<br/>Edit / Delete"]
+    end
 
-  Running tests   (polled every 15s)
-  …
+    Running["Running tests (polled every 15s)"]
+    Completed["Completed tests"]
 
-  Completed tests
-  …
+    Header --> Actions
+    Actions --> Personas
+    Personas --> Running
+    Running --> Completed
 ```
 
 ### Start Test dialog
 
-```
-Start Test
-────────────────────────────────────
-Persona         [ Startup Founder ▼ ]  (required)
-Target team     [ Software Engineering ▼ ]  (required)
-Project name    [ taskflow-mvp           ]  (optional; default = slugified persona name + "-mvp")
+```mermaid
+flowchart TB
+    Title["Start Test"]
+    Persona["Persona: [ Startup Founder &#9662; ] (required)"]
+    Team["Target team: [ Software Engineering &#9662; ] (required)"]
+    Project["Project name: [ taskflow-mvp ]<br/>(optional; default = slugified persona name + '-mvp')"]
+    Buttons["[ Cancel ]  [ Start Test ]"]
 
-                        [ Cancel ]  [ Start Test ]
+    Title --> Persona
+    Persona --> Team
+    Team --> Project
+    Project --> Buttons
 ```
 
 Clicking **Start Test** → `POST /api/user-agent-founder/start` with `{persona_id, target_team_key, project_name}` → navigate to `/persona-testing/audit/:runId` (existing audit panel, unchanged).

--- a/docs/index.html
+++ b/docs/index.html
@@ -239,26 +239,96 @@
     </p>
   </div>
 
-  <div class="arch-diagram">
-    <pre class="ascii" aria-hidden="true">
-          ┌──────────┐
-  you ─▶  │   UI     │  ─▶  /api/&lt;team&gt;
-          └──────────┘            │
-                                  ▼
-                      ┌──────────────────────┐
-                      │   Unified API        │  ← optional security pre-scan
-                      │   FastAPI gateway    │
-                      └──────────┬───────────┘
-                                 │ mounts
-            ┌────────┬───────────┼───────────┬────────┐
-            ▼        ▼           ▼           ▼        ▼
-         🛠 Core    💼 Biz     ✍ Content   🧘 Personal  …
-            │
-            ├─ threads (default)
-            └─ Temporal workflows (opt-in, set TEMPORAL_ADDRESS)
-                                 │
-                   shared: Postgres · AGENT_CACHE · LLM client
-    </pre>
+  <div class="arch-diagram" aria-label="Khala system topology: UI and clients call a single FastAPI gateway that mounts every specialist team and runs them as threads or Temporal workflows over shared Postgres, AGENT_CACHE, and LLM client">
+    <div class="mermaid">
+flowchart TB
+  user([you / client])
+  ui["Angular UI"]
+  gw["Unified API<br/>FastAPI gateway<br/><i>optional security pre-scan</i>"]
+
+  subgraph teams ["mounted teams · /api/[slug]"]
+    direction LR
+    core["🛠 Core dev"]
+    biz["💼 Biz"]
+    content["✍ Content"]
+    personal["🧘 Personal"]
+    more["…"]
+  end
+
+  subgraph runtime ["execution runtime"]
+    direction LR
+    threads["threads<br/><i>default</i>"]
+    temporal["Temporal workflows<br/><i>opt-in · TEMPORAL_ADDRESS</i>"]
+  end
+
+  shared[("shared · Postgres · AGENT_CACHE · LLM client")]
+
+  user --> ui --> gw
+  gw --> core
+  gw --> biz
+  gw --> content
+  gw --> personal
+  gw --> more
+  teams --> threads
+  teams --> temporal
+  threads --> shared
+  temporal --> shared
+
+  classDef gw fill:#140a2e,stroke:#5ef0ff,stroke-width:1.5px,color:#ece7ff
+  classDef team fill:#0d0622,stroke:#8b5cff,stroke-width:1px,color:#ece7ff
+  classDef rt fill:#0d0622,stroke:#ffd36b,stroke-width:1px,color:#ece7ff
+  classDef shared fill:#140a2e,stroke:#ff5cd4,stroke-width:1.5px,color:#ece7ff
+  class gw gw
+  class core,biz,content,personal,more team
+  class threads,temporal rt
+  class shared shared
+    </div>
+  </div>
+
+  <div class="arch-diagram" aria-label="Software engineering team four phase pipeline: discovery to design to execution with parallel backend and frontend workers to integration and release">
+    <p class="arch-caption">SE team pipeline — one spec in, a deployable system out.</p>
+    <div class="mermaid">
+flowchart LR
+  spec["initial_spec.md"]
+
+  subgraph d1 ["1 · Discovery"]
+    parse["LLM spec parse"]
+    plan["Planning v2/v3<br/>(6-phase)"]
+    parse --> plan
+  end
+
+  subgraph d2 ["2 · Design"]
+    tl["Tech Lead"]
+    arch["Architecture Expert"]
+    master["master_plan.md"]
+    tl --> master
+    arch --> master
+  end
+
+  subgraph d3 ["3 · Execution"]
+    direction TB
+    prefix["Prefix queue<br/>git + DevOps"]
+    be["Backend worker<br/>generate → lint → build → review → QA"]
+    fe["Frontend worker<br/>generate → lint → build → review → QA"]
+    prefix --> be
+    prefix --> fe
+  end
+
+  subgraph d4 ["4 · Integration"]
+    integ["Integration Agent<br/>(contract check)"]
+    devops["DevOps trigger"]
+    sec["Final security pass"]
+    docs["Docs update"]
+    integ --> devops --> sec --> docs
+  end
+
+  spec --> d1 --> d2 --> d3 --> d4
+
+  classDef phase fill:#0d0622,stroke:#8b5cff,stroke-width:1px,color:#ece7ff
+  classDef node fill:#140a2e,stroke:#5ef0ff,stroke-width:1px,color:#ece7ff
+  class d1,d2,d3,d4 phase
+  class spec,parse,plan,tl,arch,master,prefix,be,fe,integ,devops,sec,docs node
+    </div>
   </div>
 
   <div class="adr-list">
@@ -770,6 +840,28 @@ nvm use &amp;&amp; npm ci &amp;&amp; npm start
 }
 </script>
 
+<script type="module">
+  import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10.9.1/dist/mermaid.esm.min.mjs';
+  mermaid.initialize({
+    startOnLoad: true,
+    theme: 'base',
+    securityLevel: 'strict',
+    fontFamily: "'JetBrains Mono', 'Space Mono', ui-monospace, monospace",
+    themeVariables: {
+      background: '#07030f',
+      primaryColor: '#140a2e',
+      primaryTextColor: '#ece7ff',
+      primaryBorderColor: '#8b5cff',
+      lineColor: '#8b5cff',
+      secondaryColor: '#0d0622',
+      tertiaryColor: '#0d0622',
+      clusterBkg: '#07030f',
+      clusterBorder: 'rgba(146, 104, 255, 0.4)',
+      edgeLabelBackground: '#0d0622',
+      textColor: '#ece7ff'
+    }
+  });
+</script>
 <script src="app.js"></script>
 </body>
 </html>

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -629,22 +629,35 @@ strong { font-weight: 600; color: var(--ink); }
 
 /* ============ ARCHITECTURE ============ */
 .arch-diagram {
-  margin: 0 0 72px;
+  margin: 0 0 32px;
   padding: 28px;
   background: rgba(7, 3, 15, 0.6);
   border: 1px solid var(--border);
   border-radius: 16px;
   overflow-x: auto;
 }
-.ascii {
+.arch-diagram .mermaid {
+  display: flex;
+  justify-content: center;
   font-family: var(--font-mono);
-  font-size: clamp(0.75rem, 0.95vw, 0.88rem);
-  line-height: 1.5;
-  color: var(--ink-dim);
+  color: var(--ink);
   margin: 0;
-  white-space: pre;
+  min-height: 60px;
 }
-.ascii::selection { background: var(--violet); color: var(--ink); }
+.arch-diagram .mermaid svg {
+  max-width: 100%;
+  height: auto;
+}
+.arch-caption {
+  margin: 0 0 16px;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ink-soft);
+  text-align: center;
+}
+.arch-diagram:last-of-type { margin-bottom: 72px; }
 
 .adr-list {
   display: grid;


### PR DESCRIPTION
Drop the box-drawing ASCII art from the landing page Architecture section
and render two Mermaid flowcharts instead: the system topology (UI →
Unified API → mounted teams → threads|Temporal → shared stores) and the
SE team's 4-phase pipeline. Mermaid is loaded from jsDelivr as an ES
module and themed to the Psionic palette so diagrams sit naturally
inside the existing .arch-diagram card.

https://claude.ai/code/session_016UNDvZy2w94qJrC8XfTRvH