### PR TITLE
Add POST /assistant/launch to trigger team workflows

### DIFF
--- a/backend/agents/team_assistant/api.py
+++ b/backend/agents/team_assistant/api.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, Field
 
 from team_assistant.agent import TeamAssistantAgent
 from team_assistant.config import TeamAssistantConfig
+from team_assistant.launch_dispatcher import dispatch as launch_dispatch
 from team_assistant.prompts import build_system_prompt
 from team_assistant.store import get_store
 
@@ -78,6 +79,14 @@ class ReadinessResponse(BaseModel):
     ready: bool
     missing_fields: List[str]
     context: Dict[str, Any]
+
+
+class LaunchResponse(BaseModel):
+    ok: bool
+    job_id: Optional[str]
+    conversation_id: str
+    upstream_status: int
+    upstream_body: Dict[str, Any]
 
 
 # ---------------------------------------------------------------------------
@@ -312,6 +321,79 @@ def create_assistant_app(config: TeamAssistantConfig) -> FastAPI:
         _, context = state
         ready, missing = agent.check_readiness(context)
         return ReadinessResponse(ready=ready, missing_fields=missing, context=context)
+
+    @assistant_app.post("/launch", response_model=LaunchResponse)
+    async def launch(
+        conversation_id: Optional[str] = Query(None),
+    ) -> LaunchResponse:
+        """Trigger this team's real workflow from the conversation context.
+
+        Validates readiness, then dispatches the team-specific request
+        in-process via the ASGI transport. On success, links the returned
+        ``job_id`` to the conversation so future readers can look the job
+        up via ``GET /conversations/by-job/{job_id}``.
+        """
+        store = get_store(team_key)
+        agent = _get_agent(config)
+        cid = _resolve_cid(conversation_id)
+        state = store.get(cid)
+        if state is None:
+            raise HTTPException(status_code=404, detail=f"Conversation {cid} not found")
+        _, context = state
+
+        ready, missing = agent.check_readiness(context)
+        if not ready:
+            raise HTTPException(
+                status_code=409,
+                detail={"error": "missing_required_fields", "missing": missing},
+            )
+
+        if config.launch_spec is None:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Team '{team_key}' has no launch workflow configured",
+            )
+
+        try:
+            result = await launch_dispatch(config.launch_spec, context)
+        except Exception as exc:
+            logger.exception("Launch dispatch raised for team=%s cid=%s", team_key, cid)
+            raise HTTPException(
+                status_code=502,
+                detail={"error": "dispatch_failed", "message": str(exc)},
+            ) from exc
+
+        if result.status >= 500:
+            raise HTTPException(
+                status_code=502,
+                detail={
+                    "error": "upstream_error",
+                    "upstream_status": result.status,
+                    "upstream_body": result.body,
+                },
+            )
+        if not (200 <= result.status < 300):
+            # Propagate 4xx directly so the caller sees the real reason
+            # (e.g. security gateway 403, upstream 422 validation error).
+            raise HTTPException(
+                status_code=result.status,
+                detail={
+                    "error": "upstream_rejected",
+                    "upstream_status": result.status,
+                    "upstream_body": result.body,
+                },
+            )
+
+        if result.job_id:
+            store.link_job(cid, result.job_id)
+
+        return LaunchResponse(
+            ok=True,
+            job_id=result.job_id,
+            conversation_id=cid,
+            upstream_status=result.status,
+            upstream_body=result.body,
+        )
 
     # ------------------------------------------------------------------
     # New per-conversation endpoints

--- a/backend/agents/team_assistant/config.py
+++ b/backend/agents/team_assistant/config.py
@@ -94,6 +94,85 @@ def _accessibility_body_builder(context: dict[str, Any]) -> BuiltBody:
     return BuiltBody(json=body)
 
 
+def _investment_body_builder(context: dict[str, Any]) -> BuiltBody:
+    """Investment advisor profile: coerce numeric strings into the expected types.
+
+    The conversation stores every context value as a string (what the user
+    typed), but the investment endpoint expects ``float``/``int`` for the
+    numeric fields. Everything else is passed through as-is.
+    """
+
+    def _num(key: str, caster: type) -> Any:
+        raw = context.get(key)
+        if raw is None or raw == "":
+            return None
+        if isinstance(raw, (int, float)):
+            return caster(raw)
+        return caster(str(raw).strip())
+
+    body: dict[str, Any] = {
+        "user_id": context["user_id"],
+        "risk_tolerance": context["risk_tolerance"],
+        "max_drawdown_tolerance_pct": _num("max_drawdown_tolerance_pct", float),
+        "time_horizon_years": _num("time_horizon_years", int),
+        "annual_gross_income": _num("annual_gross_income", float),
+    }
+    for key in ("tax_state", "esg_preference", "goals", "leverage_allowed", "crypto_allowed"):
+        value = context.get(key)
+        if value is not None and value != "":
+            body[key] = value
+    return BuiltBody(json=body)
+
+
+def _sales_body_builder(context: dict[str, Any]) -> BuiltBody:
+    """Sales pipeline launcher: assemble a nested ICP from free-text fields.
+
+    Mirrors the shape the sales-pipeline-form component already uses: the
+    orchestrator runs all downstream stages from ``entry_stage`` within a
+    single job, so we ship one atomic ``SalesPipelineRequest`` rather than
+    trying to manage stage transitions through the assistant.
+    """
+
+    def _csv(key: str) -> list[str]:
+        return [s.strip() for s in str(context.get(key) or "").split(",") if s.strip()]
+
+    def _lines(key: str) -> list[str]:
+        return [s.strip() for s in str(context.get(key) or "").splitlines() if s.strip()]
+
+    def _int(key: str, default: int) -> int:
+        raw = context.get(key)
+        if raw is None or raw == "":
+            return default
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return default
+
+    entry_stage = str(context.get("entry_stage") or "prospecting").strip().lower()
+    max_prospects = _int("max_prospects", 5)
+
+    body = {
+        "product_name": context["product_name"],
+        "value_proposition": context["value_proposition"],
+        "entry_stage": entry_stage,
+        "max_prospects": max(1, min(100, max_prospects)),
+        "icp": {
+            "industry": _csv("icp_industry"),
+            "job_titles": _csv("icp_job_titles"),
+            "pain_points": _lines("icp_pain_points"),
+            "company_size_min": _int("icp_company_size_min", 10),
+            "company_size_max": _int("icp_company_size_max", 5000),
+            "budget_range_usd": str(context.get("icp_budget_range") or "$10k-$100k/yr"),
+            "geographic_focus": _csv("icp_geographic_focus"),
+            "tech_stack_keywords": _csv("icp_tech_stack"),
+            "disqualifying_traits": _lines("icp_disqualifying_traits"),
+        },
+        "company_context": str(context.get("company_context") or ""),
+        "case_study_snippets": _lines("case_study_snippets"),
+    }
+    return BuiltBody(json=body)
+
+
 def _road_trip_body_builder(context: dict[str, Any]) -> BuiltBody:
     """Road trip: nest slot-filled fields under a ``trip`` key."""
     trip: dict[str, Any] = {
@@ -606,35 +685,331 @@ TEAM_ASSISTANT_CONFIGS: dict[str, TeamAssistantConfig] = {
         team_name="AI Sales Team",
         system_prompt_context=(
             "A full B2B sales pod that runs prospecting, cold outreach, qualification, "
-            "nurturing, proposals, and closing. The user needs to describe their product "
-            "and target prospects."
+            "nurturing, proposals, and closing as one linear pipeline. Rather than a "
+            "vague 'target prospects' blurb, the user must decompose their ideal "
+            "customer profile into structured fields: industries, job titles, pain "
+            "points, company size, budget, geography, tech stack. Ask follow-up "
+            "questions until each ICP facet is filled."
         ),
         required_fields=[
             {"key": "product_name", "description": "Name of the product or service being sold"},
             {
-                "key": "target_prospects",
-                "description": "Description of target prospect companies or personas",
+                "key": "value_proposition",
+                "description": "One-sentence value proposition — what problem does it solve and for whom",
+            },
+            {
+                "key": "icp_industry",
+                "description": "Target industries (comma-separated, e.g. 'SaaS, FinTech')",
+            },
+            {
+                "key": "icp_job_titles",
+                "description": "Target buyer roles (comma-separated, e.g. 'VP Sales, CRO')",
+            },
+            {
+                "key": "icp_pain_points",
+                "description": "Core pain points the product solves (one per line)",
             },
         ],
         optional_fields=[
-            {"key": "sales_strategy", "description": "Preferred sales approach or strategy"},
-            {"key": "target_revenue", "description": "Revenue target for the campaign"},
-            {"key": "timeline", "description": "Campaign timeline or deadline"},
+            {
+                "key": "icp_company_size_min",
+                "description": "Minimum target company employee count (default 10)",
+            },
+            {
+                "key": "icp_company_size_max",
+                "description": "Maximum target company employee count (default 5000)",
+            },
+            {
+                "key": "icp_budget_range",
+                "description": "Expected annual contract value (e.g. '$10k-$100k/yr')",
+            },
+            {
+                "key": "icp_geographic_focus",
+                "description": "Target regions or countries (comma-separated)",
+            },
+            {
+                "key": "icp_tech_stack",
+                "description": "Technologies the prospect likely uses (comma-separated)",
+            },
+            {
+                "key": "icp_disqualifying_traits",
+                "description": "Traits that rule out a prospect (one per line)",
+            },
+            {
+                "key": "company_context",
+                "description": "About your company: size, mission, differentiators",
+            },
+            {
+                "key": "case_study_snippets",
+                "description": "Customer win summaries to use in outreach (one per line)",
+            },
+            {
+                "key": "entry_stage",
+                "description": "Pipeline entry stage (default 'prospecting')",
+            },
+            {"key": "max_prospects", "description": "Max leads to generate (1-100, default 5)"},
         ],
         welcome_message=(
-            "Welcome! I'm the Sales Team assistant. I'll help you set up a sales campaign.\n\n"
-            "What product or service are you selling, and who are your target prospects?"
+            "Welcome! I'm the Sales Team assistant. I'll help you set up a B2B sales "
+            "pipeline that runs from prospecting through proposal.\n\n"
+            "To get you real outreach (not generic blasts), I'll walk you through your "
+            "ICP — what industries, buyer roles, and pain points you're targeting. "
+            "What product are you selling?"
         ),
         default_suggested_questions=[
-            "I want to run a B2B outreach campaign.",
-            "Help me set up prospecting for my SaaS product.",
-            "I need to create a sales pipeline from scratch.",
+            "I want to run outreach for my B2B SaaS product.",
+            "Help me narrow my ICP to the right buyer roles.",
+            "I have a product and need a pipeline from scratch.",
         ],
-        # TODO: schema drift — the assistant collects {product_name,
-        # target_prospects} but /api/sales/sales/pipeline/run wants
-        # {pipeline_stage, prospect_ids?, account_ids?, deal_ids?}. Author a
-        # launch_spec after the assistant's required_fields are redesigned
-        # to match the sales pipeline stage model.
+        launch_spec=LaunchSpec(
+            path="/api/sales/pipeline/run",
+            body_builder=_sales_body_builder,
+        ),
+    ),
+    # -----------------------------------------------------------------------
+    "branding": TeamAssistantConfig(
+        team_key="branding",
+        team_name="Branding",
+        system_prompt_context=(
+            "A branding team that produces strategic core, narrative, moodboards, "
+            "design standards, and writing guides for a company. The user needs to "
+            "describe their company, what they do, and who they serve."
+        ),
+        required_fields=[
+            {"key": "company_name", "description": "Name of the company or product"},
+            {
+                "key": "company_description",
+                "description": "What the company does and the problem it solves",
+            },
+            {
+                "key": "target_audience",
+                "description": "Who the brand is speaking to — segment, persona, or customer profile",
+            },
+        ],
+        optional_fields=[
+            {"key": "values", "description": "Core values the brand should express"},
+            {
+                "key": "differentiators",
+                "description": "What sets this brand apart from competitors",
+            },
+            {"key": "desired_voice", "description": "Desired brand voice or tone"},
+            {
+                "key": "existing_brand_material",
+                "description": "Links or pastes of existing brand material (logos, taglines, etc.)",
+            },
+        ],
+        welcome_message=(
+            "Welcome! I'm the Branding team assistant. I'll help you build a brand.\n\n"
+            "Tell me about your company — the name, what it does, and who it's for."
+        ),
+        default_suggested_questions=[
+            "I'm launching a new SaaS product and need a brand.",
+            "I want to reposition an existing company.",
+            "Help me define my brand voice and messaging.",
+        ],
+        launch_spec=LaunchSpec(
+            path="/api/branding/run",
+            body_builder=declarative_builder(
+                required=["company_name", "company_description", "target_audience"],
+                optional=[
+                    "values",
+                    "differentiators",
+                    "desired_voice",
+                    "existing_brand_material",
+                ],
+            ),
+            synchronous=True,
+        ),
+    ),
+    # -----------------------------------------------------------------------
+    "investment": TeamAssistantConfig(
+        team_key="investment",
+        team_name="Investment",
+        system_prompt_context=(
+            "An investment advisor team that builds an Investment Policy Statement "
+            "(IPS) from a user profile. Collect the numeric risk parameters precisely "
+            "— a drawdown tolerance of '20%' should be captured as the number 20, and "
+            "a time horizon of '10 years' as the number 10."
+        ),
+        required_fields=[
+            {"key": "user_id", "description": "Unique identifier for the investor"},
+            {
+                "key": "risk_tolerance",
+                "description": "Risk tolerance category (conservative, moderate, aggressive)",
+            },
+            {
+                "key": "max_drawdown_tolerance_pct",
+                "description": "Maximum acceptable drawdown as a percentage (e.g. 20 for 20%)",
+            },
+            {
+                "key": "time_horizon_years",
+                "description": "Investment horizon in whole years (e.g. 10)",
+            },
+            {
+                "key": "annual_gross_income",
+                "description": "Annual gross income in USD (e.g. 150000)",
+            },
+        ],
+        optional_fields=[
+            {"key": "tax_state", "description": "US state for tax considerations (2-letter code)"},
+            {
+                "key": "esg_preference",
+                "description": "ESG preference (none, moderate, strict)",
+            },
+            {
+                "key": "goals",
+                "description": "Primary investment goals (one per line)",
+            },
+            {
+                "key": "leverage_allowed",
+                "description": "Whether leveraged products are allowed (true/false)",
+            },
+            {
+                "key": "crypto_allowed",
+                "description": "Whether crypto is allowed in the portfolio (true/false)",
+            },
+        ],
+        welcome_message=(
+            "Welcome! I'm the Investment team assistant. I'll help you set up an "
+            "Investment Policy Statement tailored to your profile.\n\n"
+            "To get started, what's your user id, and how would you describe your "
+            "risk tolerance — conservative, moderate, or aggressive?"
+        ),
+        default_suggested_questions=[
+            "I'm a moderate risk investor with a 10-year horizon.",
+            "Help me build an IPS for a conservative portfolio.",
+            "I want a portfolio that includes crypto.",
+        ],
+        launch_spec=LaunchSpec(
+            path="/api/investment/profiles",
+            body_builder=_investment_body_builder,
+            synchronous=True,
+        ),
+    ),
+    # -----------------------------------------------------------------------
+    "nutrition_meal_planning": TeamAssistantConfig(
+        team_key="nutrition_meal_planning",
+        team_name="Nutrition & Meal Planning",
+        system_prompt_context=(
+            "A personal nutrition and meal planning team that learns from feedback. "
+            "The user needs to provide their client id and a free-text message "
+            "describing what they want help with (a plan, a swap, an explanation)."
+        ),
+        required_fields=[
+            {"key": "client_id", "description": "Identifier for the nutrition client"},
+            {
+                "key": "message",
+                "description": "What the user is asking for (plan request, question, feedback)",
+            },
+        ],
+        optional_fields=[],
+        welcome_message=(
+            "Welcome! I'm the Nutrition & Meal Planning assistant. I can help you "
+            "build and adjust a meal plan.\n\n"
+            "What's your client id, and what would you like help with today?"
+        ),
+        default_suggested_questions=[
+            "Build me a 7-day meal plan for muscle gain.",
+            "Swap the dairy in my plan for plant-based options.",
+            "How many calories do I need to lose 1 lb per week?",
+        ],
+        launch_spec=LaunchSpec(
+            path="/api/nutrition-meal-planning/chat",
+            body_builder=declarative_builder(
+                required=["client_id", "message"],
+            ),
+            synchronous=True,
+        ),
+    ),
+    # -----------------------------------------------------------------------
+    "agentic_team_provisioning": TeamAssistantConfig(
+        team_key="agentic_team_provisioning",
+        team_name="Agentic Team Provisioning",
+        system_prompt_context=(
+            "A meta-team that creates agentic teams and helps define their processes "
+            "through conversation. The user needs to pick a name and describe what the "
+            "new team is for."
+        ),
+        required_fields=[
+            {"key": "name", "description": "Name for the new agentic team"},
+            {
+                "key": "description",
+                "description": "What the new team does — its purpose and scope",
+            },
+        ],
+        optional_fields=[],
+        welcome_message=(
+            "Welcome! I'm the Agentic Team Provisioning assistant. I'll help you create "
+            "a new agentic team.\n\n"
+            "What would you like to call this team, and what's it for?"
+        ),
+        default_suggested_questions=[
+            "I want to create a customer support team.",
+            "Spin up a team that handles QA automation.",
+            "Create a compliance review team.",
+        ],
+        launch_spec=LaunchSpec(
+            path="/api/agentic-team-provisioning/teams",
+            body_builder=declarative_builder(
+                required=["name", "description"],
+            ),
+            synchronous=True,
+        ),
+    ),
+    # -----------------------------------------------------------------------
+    "startup_advisor": TeamAssistantConfig(
+        team_key="startup_advisor",
+        team_name="Startup Advisor",
+        system_prompt_context=(
+            "A persistent conversational startup advisor that asks probing questions "
+            "and generates artifacts (memos, plans). The whole interaction lives in "
+            "the conversation — there is no 'launch a workflow' step; the Launch "
+            "button stays hidden."
+        ),
+        required_fields=[],
+        optional_fields=[
+            {
+                "key": "initial_message",
+                "description": "Optional opening message (goal, question, problem) to kick the session off",
+            },
+        ],
+        welcome_message=(
+            "Welcome! I'm your Startup Advisor. Ask me anything about your company, "
+            "a specific problem, or a decision you're weighing — I'll dig in and, "
+            "when useful, drop memos or plans into the artifacts panel."
+        ),
+        default_suggested_questions=[
+            "How should I think about pricing my v1?",
+            "Help me draft a memo on our go-to-market.",
+            "What are the risks I'm not seeing in my plan?",
+        ],
+        # Conversational-only team: no separate workflow endpoint to launch.
         launch_spec=None,
+    ),
+    # -----------------------------------------------------------------------
+    "user_agent_founder": TeamAssistantConfig(
+        team_key="user_agent_founder",
+        team_name="User Agent Founder",
+        system_prompt_context=(
+            "An autonomous startup founder agent that generates a product spec and "
+            "drives the SE team to build it. The workflow is fully autonomous from a "
+            "single 'start' — no configuration is required from the user."
+        ),
+        required_fields=[],
+        optional_fields=[],
+        welcome_message=(
+            "Welcome! I'm the User Agent Founder — an autonomous startup founder "
+            "simulation. Hit Launch to kick off a new run; I'll generate a product "
+            "spec and drive the SE team to build it on your behalf."
+        ),
+        default_suggested_questions=[
+            "Start a new founder run.",
+            "What does this agent do?",
+            "Show me the most recent run's status.",
+        ],
+        launch_spec=LaunchSpec(
+            path="/api/user-agent-founder/start",
+            body_builder=declarative_builder(required=[]),
+        ),
     ),
 }

--- a/backend/agents/team_assistant/config.py
+++ b/backend/agents/team_assistant/config.py
@@ -1,13 +1,19 @@
 """Per-team assistant configurations.
 
 Each entry defines the system prompt context, required/optional fields,
-welcome message, and default suggested questions for a team's assistant.
+welcome message, default suggested questions, and — when the team has a
+runnable workflow — a :class:`LaunchSpec` describing how to translate the
+conversation context into an HTTP call against the team's real run
+endpoint. ``launch_spec=None`` marks teams that have no workflow to
+launch (e.g. the personal assistant, which is CRUD-only).
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List
+from typing import Any, List
+
+from team_assistant.launch_spec import BuiltBody, LaunchSpec, declarative_builder
 
 
 @dataclass
@@ -22,6 +28,91 @@ class TeamAssistantConfig:
     welcome_message: str = ""
     default_suggested_questions: List[str] = field(default_factory=list)
     llm_agent_key: str | None = None
+    launch_spec: LaunchSpec | None = None
+
+
+# ---------------------------------------------------------------------------
+# Per-team body builders that need custom logic (not just a declarative map)
+# ---------------------------------------------------------------------------
+
+
+def _se_body_builder(context: dict[str, Any]) -> BuiltBody:
+    """Software Engineering: either pass an existing workspace or upload a spec.
+
+    - If the user supplied ``repo_path``, POST JSON to ``/run-team``.
+    - Otherwise, take the free-text ``spec`` and upload it as a multipart
+      spec file to ``/run-team/upload``. Optional ``tech_stack`` and
+      ``constraints`` are appended as markdown sections so nothing the
+      user told the assistant is lost.
+    """
+    repo_path = str(context.get("repo_path") or "").strip()
+    if repo_path:
+        return BuiltBody(json={"repo_path": repo_path})
+
+    spec = str(context.get("spec") or "").strip()
+    tech_stack = str(context.get("tech_stack") or "").strip()
+    constraints = str(context.get("constraints") or "").strip()
+    parts: list[str] = [spec]
+    if tech_stack:
+        parts.append(f"## Tech Stack\n{tech_stack}")
+    if constraints:
+        parts.append(f"## Constraints\n{constraints}")
+    spec_text = "\n\n".join(p for p in parts if p)
+
+    # Derive a short project name from the first line of the spec.
+    first_line = spec.splitlines()[0] if spec else ""
+    project_name = (
+        "".join(ch for ch in first_line[:60] if ch.isalnum() or ch in " -_").strip()
+        or "assistant-project"
+    )
+
+    return BuiltBody(
+        form={"project_name": project_name},
+        files={"spec_file": ("initial_spec.md", spec_text.encode("utf-8"), "text/markdown")},
+        path_override="/api/software-engineering/run-team/upload",
+    )
+
+
+def _accessibility_body_builder(context: dict[str, Any]) -> BuiltBody:
+    """Accessibility: branch on audit_type, rename audit_name → name."""
+    audit_type = str(context.get("audit_type") or "webpage").strip().lower()
+    body: dict[str, Any] = {
+        "name": context.get("audit_name"),
+    }
+    if audit_type == "mobile":
+        mobile_apps = context.get("mobile_apps") or context.get("web_urls")
+        if mobile_apps:
+            body["mobile_apps"] = mobile_apps
+    else:
+        web_urls = context.get("web_urls")
+        if web_urls:
+            body["web_urls"] = web_urls
+    for key in ("critical_journeys", "timebox_hours", "auth_required", "wcag_levels"):
+        value = context.get(key)
+        if value is not None and value != "":
+            body[key] = value
+    return BuiltBody(json=body)
+
+
+def _road_trip_body_builder(context: dict[str, Any]) -> BuiltBody:
+    """Road trip: nest slot-filled fields under a ``trip`` key."""
+    trip: dict[str, Any] = {
+        "start_location": context.get("start_location"),
+        "travelers": context.get("travelers") or [],
+    }
+    for key in (
+        "end_location",
+        "trip_duration_days",
+        "travel_start_date",
+        "required_stops",
+        "vehicle_type",
+        "budget_level",
+        "preferences",
+    ):
+        value = context.get(key)
+        if value is not None and value != "":
+            trip[key] = value
+    return BuiltBody(json={"trip": trip})
 
 
 # ---------------------------------------------------------------------------
@@ -61,6 +152,10 @@ TEAM_ASSISTANT_CONFIGS: dict[str, TeamAssistantConfig] = {
             "I have an existing codebase that needs new features.",
             "I need help writing a project specification.",
         ],
+        launch_spec=LaunchSpec(
+            path="/api/software-engineering/run-team",
+            body_builder=_se_body_builder,
+        ),
     ),
     # -----------------------------------------------------------------------
     "blogging": TeamAssistantConfig(
@@ -97,6 +192,13 @@ TEAM_ASSISTANT_CONFIGS: dict[str, TeamAssistantConfig] = {
             "Help me plan a technical deep-dive article.",
             "I have a topic but need help narrowing the angle.",
         ],
+        launch_spec=LaunchSpec(
+            path="/api/blogging/full-pipeline-async",
+            body_builder=declarative_builder(
+                required=["brief"],
+                optional=["audience", "tone_or_purpose", "content_profile"],
+            ),
+        ),
     ),
     # -----------------------------------------------------------------------
     "soc2_compliance": TeamAssistantConfig(
@@ -125,6 +227,10 @@ TEAM_ASSISTANT_CONFIGS: dict[str, TeamAssistantConfig] = {
             "What does the SOC2 audit check for?",
             "Can I focus the audit on specific trust service categories?",
         ],
+        launch_spec=LaunchSpec(
+            path="/api/soc2-compliance/soc2-audit/run",
+            body_builder=declarative_builder(required=["repo_path"]),
+        ),
     ),
     # -----------------------------------------------------------------------
     "market_research": TeamAssistantConfig(
@@ -159,6 +265,14 @@ TEAM_ASSISTANT_CONFIGS: dict[str, TeamAssistantConfig] = {
             "I need competitive analysis for my market.",
             "I have user interview transcripts to analyse.",
         ],
+        launch_spec=LaunchSpec(
+            path="/api/market-research/market-research/run",
+            body_builder=declarative_builder(
+                required=["product_concept", "target_users", "business_goal"],
+                optional=["topology", "transcripts"],
+            ),
+            synchronous=True,
+        ),
     ),
     # -----------------------------------------------------------------------
     "social_marketing": TeamAssistantConfig(
@@ -199,6 +313,13 @@ TEAM_ASSISTANT_CONFIGS: dict[str, TeamAssistantConfig] = {
             "Help me create a content calendar using my brand's voice and messaging.",
             "I haven't defined my brand yet -- where do I start?",
         ],
+        launch_spec=LaunchSpec(
+            path="/api/social-marketing/social-marketing/run",
+            body_builder=declarative_builder(
+                required=["client_id", "brand_id"],
+                optional=["goals", "cadence_posts_per_day", "duration_days"],
+            ),
+        ),
     ),
     # -----------------------------------------------------------------------
     "road_trip_planning": TeamAssistantConfig(
@@ -233,6 +354,11 @@ TEAM_ASSISTANT_CONFIGS: dict[str, TeamAssistantConfig] = {
             "We're a family of four looking for a scenic route.",
             "I want to drive the Pacific Coast Highway.",
         ],
+        launch_spec=LaunchSpec(
+            path="/api/road-trip-planning/plan",
+            body_builder=_road_trip_body_builder,
+            synchronous=True,
+        ),
     ),
     # -----------------------------------------------------------------------
     "accessibility_audit": TeamAssistantConfig(
@@ -265,6 +391,10 @@ TEAM_ASSISTANT_CONFIGS: dict[str, TeamAssistantConfig] = {
             "I need a WCAG 2.2 AA compliance check.",
             "Can you audit a mobile app for accessibility?",
         ],
+        launch_spec=LaunchSpec(
+            path="/api/accessibility-audit/audit/create",
+            body_builder=_accessibility_body_builder,
+        ),
     ),
     # -----------------------------------------------------------------------
     "coding_team": TeamAssistantConfig(
@@ -293,6 +423,13 @@ TEAM_ASSISTANT_CONFIGS: dict[str, TeamAssistantConfig] = {
             "I need help implementing a specific module.",
             "I have a repo that needs refactoring.",
         ],
+        launch_spec=LaunchSpec(
+            path="/api/coding-team/run",
+            body_builder=declarative_builder(
+                required=["repo_path"],
+                optional=["plan_input"],
+            ),
+        ),
     ),
     # -----------------------------------------------------------------------
     "personal_assistant": TeamAssistantConfig(
@@ -315,6 +452,10 @@ TEAM_ASSISTANT_CONFIGS: dict[str, TeamAssistantConfig] = {
             "What tasks do I have pending?",
             "Help me find deals on something I want to buy.",
         ],
+        # Personal Assistant is a CRUD surface (email/calendar/tasks/deals/
+        # reservations) with no "run a workflow" entry point — the Launch
+        # button is hidden in the UI for this team.
+        launch_spec=None,
     ),
     # -----------------------------------------------------------------------
     "planning_v3": TeamAssistantConfig(
@@ -344,6 +485,13 @@ TEAM_ASSISTANT_CONFIGS: dict[str, TeamAssistantConfig] = {
             "I want to create a PRD for a greenfield project.",
             "Help me run a discovery session with requirements.",
         ],
+        launch_spec=LaunchSpec(
+            path="/api/planning-v3/run",
+            body_builder=declarative_builder(
+                required=["repo_path", "initial_brief"],
+                optional=["client_name"],
+            ),
+        ),
     ),
     # -----------------------------------------------------------------------
     "ai_systems": TeamAssistantConfig(
@@ -372,6 +520,13 @@ TEAM_ASSISTANT_CONFIGS: dict[str, TeamAssistantConfig] = {
             "I have a spec file ready for an AI system.",
             "Help me design an AI agent architecture.",
         ],
+        launch_spec=LaunchSpec(
+            path="/api/ai-systems/build",
+            body_builder=declarative_builder(
+                required=["project_name", "spec_path"],
+                optional=["constraints"],
+            ),
+        ),
     ),
     # -----------------------------------------------------------------------
     "agent_provisioning": TeamAssistantConfig(
@@ -400,6 +555,13 @@ TEAM_ASSISTANT_CONFIGS: dict[str, TeamAssistantConfig] = {
             "I want to set up infrastructure for an existing agent.",
             "What access tiers are available?",
         ],
+        launch_spec=LaunchSpec(
+            path="/api/agent-provisioning/provision",
+            body_builder=declarative_builder(
+                required=["agent_id"],
+                optional=["manifest_path", "access_tier"],
+            ),
+        ),
     ),
     # -----------------------------------------------------------------------
     "deepthought": TeamAssistantConfig(
@@ -411,7 +573,9 @@ TEAM_ASSISTANT_CONFIGS: dict[str, TeamAssistantConfig] = {
             "expert sub-agents to provide comprehensive answers. Each sub-agent can "
             "further decompose its task up to 10 levels deep."
         ),
-        required_fields=[],
+        required_fields=[
+            {"key": "message", "description": "The question or message to decompose and answer"},
+        ],
         optional_fields=[
             {"key": "max_depth", "description": "Maximum recursion depth (1-10, default 10)"},
         ],
@@ -427,6 +591,14 @@ TEAM_ASSISTANT_CONFIGS: dict[str, TeamAssistantConfig] = {
             "What would it take to establish a self-sustaining Mars colony?",
         ],
         llm_agent_key="deepthought",
+        launch_spec=LaunchSpec(
+            path="/api/deepthought/deepthought/ask",
+            body_builder=declarative_builder(
+                required=["message"],
+                optional=["max_depth"],
+            ),
+            synchronous=True,
+        ),
     ),
     # -----------------------------------------------------------------------
     "sales_team": TeamAssistantConfig(
@@ -458,5 +630,11 @@ TEAM_ASSISTANT_CONFIGS: dict[str, TeamAssistantConfig] = {
             "Help me set up prospecting for my SaaS product.",
             "I need to create a sales pipeline from scratch.",
         ],
+        # TODO: schema drift — the assistant collects {product_name,
+        # target_prospects} but /api/sales/sales/pipeline/run wants
+        # {pipeline_stage, prospect_ids?, account_ids?, deal_ids?}. Author a
+        # launch_spec after the assistant's required_fields are redesigned
+        # to match the sales pipeline stage model.
+        launch_spec=None,
     ),
 }

--- a/backend/agents/team_assistant/launch_dispatcher.py
+++ b/backend/agents/team_assistant/launch_dispatcher.py
@@ -1,0 +1,83 @@
+"""In-process dispatcher that turns a :class:`LaunchSpec` + context into an
+HTTP call against a team's real run endpoint.
+
+Uses ``httpx.ASGITransport`` to re-enter the unified API within the same
+process — identical to the pattern in
+``unified_api.slack_events_handler._call_team_assistant``. This preserves
+the normal request pipeline (security gateway, team proxy) without
+requiring a network round-trip.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+from team_assistant.launch_spec import LaunchSpec
+
+logger = logging.getLogger(__name__)
+
+# Use the longest per-team proxy timeout (300s, see unified_api.config) so
+# we never time out before the upstream does.
+DEFAULT_DISPATCH_TIMEOUT_S = 300.0
+
+
+@dataclass
+class DispatchResult:
+    status: int
+    body: dict[str, Any]
+    job_id: str | None
+
+
+def _safe_json(resp: httpx.Response) -> dict[str, Any]:
+    try:
+        data = resp.json()
+    except ValueError:
+        return {"_raw_text": resp.text[:2000]}
+    if isinstance(data, dict):
+        return data
+    return {"_value": data}
+
+
+async def dispatch(spec: LaunchSpec, context: dict[str, Any]) -> DispatchResult:
+    """Build the request from ``context`` and dispatch it in-process."""
+    # Import lazily to avoid circular imports — the unified API imports
+    # team_assistant during its lifespan.
+    from unified_api.main import app
+
+    built = spec.body_builder(context)
+    path = built.path_override or spec.path
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://internal",
+        timeout=DEFAULT_DISPATCH_TIMEOUT_S,
+    ) as client:
+        try:
+            if built.files:
+                resp = await client.request(
+                    spec.method,
+                    path,
+                    data=built.form or {},
+                    files=built.files,
+                )
+            else:
+                resp = await client.request(
+                    spec.method,
+                    path,
+                    json=built.json or {},
+                )
+        except httpx.HTTPError as exc:
+            logger.warning("Launch dispatch to %s failed: %s", path, exc)
+            return DispatchResult(status=502, body={"error": str(exc)}, job_id=None)
+
+    body = _safe_json(resp)
+    job_id = body.get("job_id") if not spec.synchronous else None
+    return DispatchResult(status=resp.status_code, body=body, job_id=job_id)
+
+
+__all__ = ["DispatchResult", "dispatch"]

--- a/backend/agents/team_assistant/launch_spec.py
+++ b/backend/agents/team_assistant/launch_spec.py
@@ -1,0 +1,78 @@
+"""Declarative launch specification for team assistants.
+
+Each team's ``TeamAssistantConfig`` optionally carries a :class:`LaunchSpec`
+describing how to turn the conversation context into an HTTP request
+against the team's real run endpoint. The dispatcher in
+``team_assistant.launch_dispatcher`` executes the spec in-process via
+``httpx.ASGITransport`` — the same pattern used by
+``unified_api.slack_events_handler._call_team_assistant``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass
+class BuiltBody:
+    """Payload produced by a :class:`LaunchSpec`'s body builder.
+
+    Exactly one of ``json`` or ``files`` is typically set. When ``files`` is
+    provided the dispatcher emits a multipart POST (``data`` + ``files``);
+    otherwise it emits a JSON POST.
+    """
+
+    json: dict[str, Any] | None = None
+    form: dict[str, Any] | None = None
+    files: dict[str, tuple[str, bytes, str]] | None = None
+    path_override: str | None = None
+
+
+BodyBuilder = Callable[[dict[str, Any]], BuiltBody]
+
+
+@dataclass
+class LaunchSpec:
+    """How to dispatch a team workflow from a ready conversation context."""
+
+    path: str
+    body_builder: BodyBuilder
+    method: str = "POST"
+    # Teams whose run endpoint returns results synchronously (no job_id).
+    # The dispatcher still returns 200 but job_id stays None and no job is linked.
+    synchronous: bool = False
+
+
+def declarative_builder(
+    required: list[str],
+    optional: list[str] | None = None,
+    renames: dict[str, str] | None = None,
+) -> BodyBuilder:
+    """Build a JSON body by copying whitelisted context keys.
+
+    - ``required`` keys are always copied (readiness gating already ensured
+      they are present; the builder would KeyError otherwise).
+    - ``optional`` keys are copied only when the context value is truthy and
+      not an empty string.
+    - ``renames`` remaps context keys to request keys (``context_key →
+      request_key``).
+    """
+    optional_list: list[str] = list(optional or [])
+    renames_map: dict[str, str] = dict(renames or {})
+
+    def _build(context: dict[str, Any]) -> BuiltBody:
+        body: dict[str, Any] = {}
+        for key in required:
+            body[renames_map.get(key, key)] = context[key]
+        for key in optional_list:
+            value = context.get(key)
+            if value is None or value == "":
+                continue
+            body[renames_map.get(key, key)] = value
+        return BuiltBody(json=body)
+
+    return _build
+
+
+__all__ = ["BuiltBody", "BodyBuilder", "LaunchSpec", "declarative_builder"]

--- a/backend/agents/team_assistant/tests/_fake_postgres.py
+++ b/backend/agents/team_assistant/tests/_fake_postgres.py
@@ -120,6 +120,33 @@ class _FakeCursor:
                 self.rowcount = 0
             return
 
+        # UPDATE conversation job_id (store.link_job)
+        if norm.startswith(
+            "update team_assistant_conversations set job_id = %s, updated_at = %s "
+            "where conversation_id = %s and team_key"
+        ):
+            job_id, ts, cid, team_key = params
+            conv = self._db["conversations"].get(cid)
+            if conv and conv["team_key"] == team_key:
+                conv["job_id"] = job_id
+                conv["updated_at"] = ts
+                self.rowcount = 1
+            else:
+                self.rowcount = 0
+            return
+
+        # SELECT conversation_id by job_id
+        if norm.startswith(
+            "select conversation_id from team_assistant_conversations where job_id = %s and team_key"
+        ):
+            job_id, team_key = params
+            for conv in self._db["conversations"].values():
+                if conv.get("job_id") == job_id and conv["team_key"] == team_key:
+                    self._last_fetch_one = (conv["conversation_id"],)
+                    return
+            self._last_fetch_one = None
+            return
+
         # INSERT artifact ... RETURNING id
         if norm.startswith("insert into team_assistant_conv_artifacts"):
             cid, artifact_type, title, payload, ts = params

--- a/backend/agents/team_assistant/tests/test_launch_endpoint.py
+++ b/backend/agents/team_assistant/tests/test_launch_endpoint.py
@@ -277,3 +277,89 @@ def test_unknown_conversation_returns_404(
     client, _cid = _seed_conversation("blogging", context={"brief": "x"})
     resp = client.post("/launch?conversation_id=missing-cid")
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Track B: cases for the newly onboarded teams
+# ---------------------------------------------------------------------------
+
+
+def test_branding_synchronous_returns_team_output(
+    fake_pg: dict, upstream: _UpstreamHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Branding returns results inline with no job_id — the conversation must not be linked."""
+    _stub_agent(monkeypatch)
+    upstream.response_body = {"summary": "brand built", "artifacts": []}
+    client, cid = _seed_conversation(
+        "branding",
+        context={
+            "company_name": "Acme",
+            "company_description": "sells anvils",
+            "target_audience": "coyotes",
+        },
+    )
+
+    resp = client.post(f"/launch?conversation_id={cid}")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["job_id"] is None
+    assert body["upstream_body"] == {"summary": "brand built", "artifacts": []}
+    assert upstream.requests[0]["path"] == "/api/branding/run"
+
+
+def test_user_agent_founder_async_links_job(
+    fake_pg: dict, upstream: _UpstreamHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """POST /start now returns {job_id: ...} (renamed from run_id)."""
+    _stub_agent(monkeypatch)
+    upstream.response_body = {"job_id": "uaf-7", "status": "pending"}
+    client, cid = _seed_conversation("user_agent_founder", context={})
+
+    resp = client.post(f"/launch?conversation_id={cid}")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["job_id"] == "uaf-7"
+    assert upstream.requests[0]["path"] == "/api/user-agent-founder/start"
+    assert json.loads(upstream.requests[0]["body"]) == {}
+
+    store = TeamAssistantConversationStore(team_key="user_agent_founder")
+    assert store.get_by_job_id("uaf-7") == cid
+
+
+def test_startup_advisor_400_no_launch_spec(
+    fake_pg: dict, upstream: _UpstreamHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """startup_advisor has no required fields AND no launch_spec — readiness passes, 400 on launch."""
+    _stub_agent(monkeypatch)
+    client, cid = _seed_conversation("startup_advisor", context={})
+    resp = client.post(f"/launch?conversation_id={cid}")
+    assert resp.status_code == 400
+    assert "no launch workflow" in resp.json()["detail"].lower()
+    assert upstream.requests == []
+
+
+def test_investment_builder_sends_numeric_fields_as_numbers(
+    fake_pg: dict, upstream: _UpstreamHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Integration check: the investment builder's numeric coercion survives JSON serialisation."""
+    _stub_agent(monkeypatch)
+    upstream.response_body = {"profile_id": "p-1", "ips": "..."}
+    client, cid = _seed_conversation(
+        "investment",
+        context={
+            "user_id": "u-7",
+            "risk_tolerance": "aggressive",
+            "max_drawdown_tolerance_pct": "30",
+            "time_horizon_years": "15",
+            "annual_gross_income": "250000",
+        },
+    )
+
+    resp = client.post(f"/launch?conversation_id={cid}")
+    assert resp.status_code == 200, resp.text
+
+    sent = json.loads(upstream.requests[0]["body"])
+    assert sent["max_drawdown_tolerance_pct"] == 30.0
+    assert sent["time_horizon_years"] == 15
+    assert sent["annual_gross_income"] == 250000.0

--- a/backend/agents/team_assistant/tests/test_launch_endpoint.py
+++ b/backend/agents/team_assistant/tests/test_launch_endpoint.py
@@ -1,0 +1,279 @@
+"""Tests for the POST /assistant/launch endpoint.
+
+The dispatcher calls into ``unified_api.main.app`` via an ASGI transport;
+here we monkeypatch that module so the test never has to stand up the
+full unified API. Postgres is faked via the in-memory helper used by the
+rest of the team_assistant suite.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import types
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from team_assistant.api import create_assistant_app
+from team_assistant.config import TEAM_ASSISTANT_CONFIGS
+from team_assistant.store import TeamAssistantConversationStore
+from team_assistant.tests._fake_postgres import install_fake_postgres
+
+# ---------------------------------------------------------------------------
+# Stub "unified_api.main" that the dispatcher imports lazily.
+#
+# The dispatcher does ``from unified_api.main import app`` inside the call
+# so we can hand it whatever ASGI app we want per-test.
+# ---------------------------------------------------------------------------
+
+
+class _UpstreamHarness:
+    """Captures requests the dispatcher forwards, returns a scripted response."""
+
+    def __init__(self) -> None:
+        self.requests: list[dict[str, Any]] = []
+        self.response_status = 200
+        self.response_body: dict[str, Any] = {"job_id": "job-1"}
+
+    async def __call__(self, scope, receive, send):  # type: ignore[no-untyped-def]
+        assert scope["type"] == "http"
+        body_chunks: list[bytes] = []
+        while True:
+            message = await receive()
+            if message["type"] == "http.request":
+                body_chunks.append(message.get("body") or b"")
+                if not message.get("more_body"):
+                    break
+
+        headers = {k.decode(): v.decode() for k, v in scope.get("headers", [])}
+        self.requests.append(
+            {
+                "method": scope["method"],
+                "path": scope["path"],
+                "query_string": scope.get("query_string", b"").decode(),
+                "headers": headers,
+                "body": b"".join(body_chunks),
+            }
+        )
+
+        payload = json.dumps(self.response_body).encode("utf-8")
+        await send(
+            {
+                "type": "http.response.start",
+                "status": self.response_status,
+                "headers": [(b"content-type", b"application/json")],
+            }
+        )
+        await send({"type": "http.response.body", "body": payload})
+
+
+@pytest.fixture
+def fake_pg(monkeypatch: pytest.MonkeyPatch) -> dict:
+    return install_fake_postgres(monkeypatch)
+
+
+@pytest.fixture
+def upstream(monkeypatch: pytest.MonkeyPatch) -> _UpstreamHarness:
+    harness = _UpstreamHarness()
+    # Build a stub module the dispatcher can import.
+    stub = types.ModuleType("unified_api.main")
+    stub.app = harness  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "unified_api.main", stub)
+    # Also make sure ``unified_api`` itself exists as a package entry so the
+    # ``from unified_api.main import app`` resolves cleanly in isolation.
+    if "unified_api" not in sys.modules:
+        pkg = types.ModuleType("unified_api")
+        monkeypatch.setitem(sys.modules, "unified_api", pkg)
+    return harness
+
+
+def _stub_agent(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Bypass TeamAssistantAgent's LLM initialisation.
+
+    The endpoint only exercises ``check_readiness`` which is pure-Python,
+    but constructing the agent default-imports strands. Stub the class to
+    skip LLM wiring.
+    """
+    import team_assistant.api as api_mod
+
+    class _NoLLMAgent:
+        def __init__(self, **kwargs: Any) -> None:
+            self.required_field_keys = [f["key"] for f in kwargs.get("required_fields", [])]
+
+        def check_readiness(self, context: dict[str, Any]) -> tuple[bool, list[str]]:
+            missing = [k for k in self.required_field_keys if not context.get(k)]
+            return (not missing, missing)
+
+    monkeypatch.setattr(api_mod, "TeamAssistantAgent", _NoLLMAgent)
+    monkeypatch.setattr(api_mod, "_agents", {})
+
+
+def _seed_conversation(team_key: str, context: dict[str, Any]) -> tuple[TestClient, str]:
+    config = TEAM_ASSISTANT_CONFIGS[team_key]
+    app = create_assistant_app(config)
+    client = TestClient(app)
+    store = TeamAssistantConversationStore(team_key=team_key)
+    cid = store.create(conversation_id=f"cid-{team_key}", context=context)
+    return client, cid
+
+
+# ---------------------------------------------------------------------------
+# Cases
+# ---------------------------------------------------------------------------
+
+
+def test_readiness_fails_returns_409_with_missing_fields(
+    fake_pg: dict, upstream: _UpstreamHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_agent(monkeypatch)
+    client, cid = _seed_conversation("blogging", context={})
+
+    resp = client.post(f"/launch?conversation_id={cid}")
+    assert resp.status_code == 409
+    detail = resp.json()["detail"]
+    assert detail["error"] == "missing_required_fields"
+    assert detail["missing"] == ["brief"]
+    # Upstream was never called.
+    assert upstream.requests == []
+
+
+def test_blogging_happy_path_links_job_to_conversation(
+    fake_pg: dict, upstream: _UpstreamHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_agent(monkeypatch)
+    upstream.response_body = {"job_id": "blog-42", "status": "queued"}
+    client, cid = _seed_conversation(
+        "blogging",
+        context={"brief": "AI trends in 2026", "audience": "engineers"},
+    )
+
+    resp = client.post(f"/launch?conversation_id={cid}")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body == {
+        "ok": True,
+        "job_id": "blog-42",
+        "conversation_id": cid,
+        "upstream_status": 200,
+        "upstream_body": {"job_id": "blog-42", "status": "queued"},
+    }
+
+    # The dispatcher forwarded to the real run endpoint with the JSON body.
+    assert len(upstream.requests) == 1
+    req = upstream.requests[0]
+    assert req["method"] == "POST"
+    assert req["path"] == "/api/blogging/full-pipeline-async"
+    assert json.loads(req["body"]) == {"brief": "AI trends in 2026", "audience": "engineers"}
+
+    # Conversation is now linked to the job.
+    store = TeamAssistantConversationStore(team_key="blogging")
+    assert store.get_by_job_id("blog-42") == cid
+
+
+def test_software_engineering_multipart_upload_for_spec_only_context(
+    fake_pg: dict, upstream: _UpstreamHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_agent(monkeypatch)
+    upstream.response_body = {"job_id": "se-99"}
+    client, cid = _seed_conversation(
+        "software_engineering",
+        context={
+            "spec": "Build a kanban board\nWith drag-and-drop",
+            "tech_stack": "Angular + Django",
+        },
+    )
+
+    resp = client.post(f"/launch?conversation_id={cid}")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["job_id"] == "se-99"
+
+    assert len(upstream.requests) == 1
+    req = upstream.requests[0]
+    assert req["path"] == "/api/software-engineering/run-team/upload"
+    content_type = req["headers"].get("content-type", "")
+    assert content_type.startswith("multipart/form-data")
+    body = req["body"]
+    # Verify the spec_file part is present and begins with the spec text.
+    assert b'name="project_name"' in body
+    assert b'name="spec_file"' in body
+    assert b"Build a kanban board" in body
+    assert b"## Tech Stack\nAngular + Django" in body
+
+
+def test_software_engineering_json_path_when_repo_path_provided(
+    fake_pg: dict, upstream: _UpstreamHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_agent(monkeypatch)
+    upstream.response_body = {"job_id": "se-100"}
+    client, cid = _seed_conversation(
+        "software_engineering",
+        context={"spec": "ignored when repo_path is set", "repo_path": "/workspaces/existing"},
+    )
+
+    resp = client.post(f"/launch?conversation_id={cid}")
+    assert resp.status_code == 200
+    assert upstream.requests[0]["path"] == "/api/software-engineering/run-team"
+    assert json.loads(upstream.requests[0]["body"]) == {"repo_path": "/workspaces/existing"}
+
+
+def test_market_research_synchronous_has_null_job_id(
+    fake_pg: dict, upstream: _UpstreamHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_agent(monkeypatch)
+    # Market Research returns a TeamOutput-shape (no job_id).
+    upstream.response_body = {"status": "ok", "summary": "..."}
+    client, cid = _seed_conversation(
+        "market_research",
+        context={
+            "product_concept": "Khala Assistant",
+            "target_users": "engineering leads",
+            "business_goal": "validate interest",
+        },
+    )
+
+    resp = client.post(f"/launch?conversation_id={cid}")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["job_id"] is None
+    # And the conversation is NOT linked to any job.
+    store = TeamAssistantConversationStore(team_key="market_research")
+    assert store.get_by_job_id("") is None
+
+
+def test_no_launch_spec_returns_400(
+    fake_pg: dict, upstream: _UpstreamHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_agent(monkeypatch)
+    client, cid = _seed_conversation("personal_assistant", context={"user_id": "u-1"})
+    resp = client.post(f"/launch?conversation_id={cid}")
+    assert resp.status_code == 400
+    assert "no launch workflow" in resp.json()["detail"].lower()
+    assert upstream.requests == []
+
+
+def test_upstream_5xx_surfaces_as_502(
+    fake_pg: dict, upstream: _UpstreamHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_agent(monkeypatch)
+    upstream.response_status = 500
+    upstream.response_body = {"error": "internal_kaboom"}
+    client, cid = _seed_conversation("blogging", context={"brief": "topic"})
+
+    resp = client.post(f"/launch?conversation_id={cid}")
+    assert resp.status_code == 502
+    detail = resp.json()["detail"]
+    assert detail["error"] == "upstream_error"
+    assert detail["upstream_status"] == 500
+    assert detail["upstream_body"] == {"error": "internal_kaboom"}
+
+
+def test_unknown_conversation_returns_404(
+    fake_pg: dict, upstream: _UpstreamHarness, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _stub_agent(monkeypatch)
+    client, _cid = _seed_conversation("blogging", context={"brief": "x"})
+    resp = client.post("/launch?conversation_id=missing-cid")
+    assert resp.status_code == 404

--- a/backend/agents/team_assistant/tests/test_launch_spec_builders.py
+++ b/backend/agents/team_assistant/tests/test_launch_spec_builders.py
@@ -147,6 +147,175 @@ def test_deepthought_builder_passes_message_and_optional_depth() -> None:
     assert built.json == {"message": "What is love?", "max_depth": 3}
 
 
-@pytest.mark.parametrize("team_key", ["personal_assistant", "sales_team"])
+@pytest.mark.parametrize("team_key", ["personal_assistant", "startup_advisor"])
 def test_no_launch_spec_for_teams_without_workflows(team_key: str) -> None:
     assert TEAM_ASSISTANT_CONFIGS[team_key].launch_spec is None
+
+
+# ---------------------------------------------------------------------------
+# Track B: the 6 newly-onboarded teams
+# ---------------------------------------------------------------------------
+
+
+def test_branding_declarative_builder() -> None:
+    built = _builder("branding")(
+        {
+            "company_name": "Acme",
+            "company_description": "Sells anvils.",
+            "target_audience": "cartoon coyotes",
+            "values": "reliability",
+        }
+    )
+    assert built.json == {
+        "company_name": "Acme",
+        "company_description": "Sells anvils.",
+        "target_audience": "cartoon coyotes",
+        "values": "reliability",
+    }
+
+
+def test_investment_builder_coerces_numeric_strings() -> None:
+    """Conversation stores values as strings; the builder must cast to float/int."""
+    built = _builder("investment")(
+        {
+            "user_id": "u-1",
+            "risk_tolerance": "moderate",
+            "max_drawdown_tolerance_pct": "20",  # string from the conversation
+            "time_horizon_years": "10",
+            "annual_gross_income": "150000",
+            "tax_state": "CA",
+        }
+    )
+    assert built.json == {
+        "user_id": "u-1",
+        "risk_tolerance": "moderate",
+        "max_drawdown_tolerance_pct": 20.0,
+        "time_horizon_years": 10,
+        "annual_gross_income": 150000.0,
+        "tax_state": "CA",
+    }
+
+
+def test_investment_builder_preserves_native_numeric_values() -> None:
+    built = _builder("investment")(
+        {
+            "user_id": "u-2",
+            "risk_tolerance": "aggressive",
+            "max_drawdown_tolerance_pct": 35.5,
+            "time_horizon_years": 20,
+            "annual_gross_income": 500000,
+        }
+    )
+    assert built.json["max_drawdown_tolerance_pct"] == 35.5
+    assert built.json["time_horizon_years"] == 20
+    assert built.json["annual_gross_income"] == 500000.0
+
+
+def test_nutrition_builder_declarative() -> None:
+    built = _builder("nutrition_meal_planning")({"client_id": "c-1", "message": "build me a plan"})
+    assert built.json == {"client_id": "c-1", "message": "build me a plan"}
+
+
+def test_agentic_team_provisioning_declarative() -> None:
+    built = _builder("agentic_team_provisioning")(
+        {"name": "QA Pod", "description": "handles QA automation"}
+    )
+    assert built.json == {"name": "QA Pod", "description": "handles QA automation"}
+
+
+def test_user_agent_founder_emits_empty_body() -> None:
+    """POST /start takes no parameters; the builder should send an empty JSON body."""
+    built = _builder("user_agent_founder")({})
+    assert built.json == {}
+    assert built.files is None
+    assert built.path_override is None
+
+
+# ---------------------------------------------------------------------------
+# Track C: sales redesign
+# ---------------------------------------------------------------------------
+
+
+def test_sales_body_builder_decomposes_icp() -> None:
+    built = _builder("sales_team")(
+        {
+            "product_name": "Khala",
+            "value_proposition": "One API to run 20 agentic teams",
+            "icp_industry": "SaaS, FinTech, DevTools",
+            "icp_job_titles": "VP Engineering, CTO, Head of Platform",
+            "icp_pain_points": "slow AI integration\nvendor lock-in\ncompliance overhead",
+            "icp_company_size_min": "50",
+            "icp_company_size_max": "2000",
+            "icp_geographic_focus": "US, EU",
+            "icp_tech_stack": "AWS, Kubernetes",
+            "icp_disqualifying_traits": "solo consultant\nno cloud",
+            "company_context": "YC W24 company",
+            "case_study_snippets": "Acme ships 3x faster\nBeta Inc cut cost 40%",
+            "entry_stage": "PROSPECTING",
+            "max_prospects": "25",
+        }
+    )
+    assert built.json == {
+        "product_name": "Khala",
+        "value_proposition": "One API to run 20 agentic teams",
+        "entry_stage": "prospecting",
+        "max_prospects": 25,
+        "icp": {
+            "industry": ["SaaS", "FinTech", "DevTools"],
+            "job_titles": ["VP Engineering", "CTO", "Head of Platform"],
+            "pain_points": ["slow AI integration", "vendor lock-in", "compliance overhead"],
+            "company_size_min": 50,
+            "company_size_max": 2000,
+            "budget_range_usd": "$10k-$100k/yr",
+            "geographic_focus": ["US", "EU"],
+            "tech_stack_keywords": ["AWS", "Kubernetes"],
+            "disqualifying_traits": ["solo consultant", "no cloud"],
+        },
+        "company_context": "YC W24 company",
+        "case_study_snippets": ["Acme ships 3x faster", "Beta Inc cut cost 40%"],
+    }
+
+
+def test_sales_body_builder_uses_defaults_for_optional_fields() -> None:
+    built = _builder("sales_team")(
+        {
+            "product_name": "Khala",
+            "value_proposition": "One API",
+            "icp_industry": "SaaS",
+            "icp_job_titles": "CTO",
+            "icp_pain_points": "slow integration",
+        }
+    )
+    icp = built.json["icp"]
+    assert icp["company_size_min"] == 10
+    assert icp["company_size_max"] == 5000
+    assert icp["budget_range_usd"] == "$10k-$100k/yr"
+    assert icp["geographic_focus"] == []
+    assert built.json["entry_stage"] == "prospecting"
+    assert built.json["max_prospects"] == 5
+
+
+def test_sales_body_builder_clamps_max_prospects_into_range() -> None:
+    built = _builder("sales_team")(
+        {
+            "product_name": "Khala",
+            "value_proposition": "v",
+            "icp_industry": "x",
+            "icp_job_titles": "y",
+            "icp_pain_points": "z",
+            "max_prospects": "500",
+        }
+    )
+    assert built.json["max_prospects"] == 100
+
+    built2 = _builder("sales_team")(
+        {
+            "product_name": "Khala",
+            "value_proposition": "v",
+            "icp_industry": "x",
+            "icp_job_titles": "y",
+            "icp_pain_points": "z",
+            "max_prospects": "0",
+        }
+    )
+    assert built2.json["max_prospects"] == 1

--- a/backend/agents/team_assistant/tests/test_launch_spec_builders.py
+++ b/backend/agents/team_assistant/tests/test_launch_spec_builders.py
@@ -1,0 +1,152 @@
+"""Unit tests for the per-team launch body builders.
+
+These exercise ``body_builder(context) -> BuiltBody`` in isolation — no
+HTTP, no Postgres. Each builder lives in ``team_assistant.config`` or is
+produced there via ``declarative_builder``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from team_assistant.config import TEAM_ASSISTANT_CONFIGS
+from team_assistant.launch_spec import BuiltBody
+
+
+def _builder(team_key: str):
+    spec = TEAM_ASSISTANT_CONFIGS[team_key].launch_spec
+    assert spec is not None, f"{team_key} has no launch_spec"
+    return spec.body_builder
+
+
+def test_blogging_declarative_builder_copies_required_and_optional() -> None:
+    built = _builder("blogging")(
+        {
+            "brief": "AI trends in 2026",
+            "audience": "engineers",
+            "tone_or_purpose": "educational",
+            "content_profile": "technical_deep_dive",
+        }
+    )
+    assert isinstance(built, BuiltBody)
+    assert built.files is None
+    assert built.json == {
+        "brief": "AI trends in 2026",
+        "audience": "engineers",
+        "tone_or_purpose": "educational",
+        "content_profile": "technical_deep_dive",
+    }
+
+
+def test_declarative_builder_skips_empty_optional_values() -> None:
+    built = _builder("blogging")({"brief": "Minimal", "audience": ""})
+    assert built.json == {"brief": "Minimal"}
+
+
+def test_soc2_builder_requires_repo_path() -> None:
+    built = _builder("soc2_compliance")({"repo_path": "/repo/x"})
+    assert built.json == {"repo_path": "/repo/x"}
+
+
+def test_market_research_declarative() -> None:
+    spec = TEAM_ASSISTANT_CONFIGS["market_research"].launch_spec
+    assert spec is not None and spec.synchronous is True
+    built = spec.body_builder({"product_concept": "P", "target_users": "U", "business_goal": "G"})
+    assert built.json == {"product_concept": "P", "target_users": "U", "business_goal": "G"}
+
+
+def test_se_builder_prefers_repo_path_when_present() -> None:
+    built = _builder("software_engineering")(
+        {"repo_path": "/workspace/existing", "spec": "ignore me"}
+    )
+    assert built.files is None
+    assert built.path_override is None
+    assert built.json == {"repo_path": "/workspace/existing"}
+
+
+def test_se_builder_uploads_spec_as_multipart_when_no_repo_path() -> None:
+    built = _builder("software_engineering")(
+        {
+            "spec": "Build a todo app\nWith CRUD",
+            "tech_stack": "React + FastAPI",
+            "constraints": "ship in 1 week",
+        }
+    )
+    assert built.json is None
+    assert built.path_override == "/api/software-engineering/run-team/upload"
+    assert built.form == {"project_name": "Build a todo app"}
+    assert built.files is not None
+    filename, content, content_type = built.files["spec_file"]
+    assert filename == "initial_spec.md"
+    assert content_type == "text/markdown"
+    text = content.decode("utf-8")
+    assert text.startswith("Build a todo app")
+    assert "## Tech Stack\nReact + FastAPI" in text
+    assert "## Constraints\nship in 1 week" in text
+
+
+def test_se_builder_derives_default_project_name_for_empty_spec_first_line() -> None:
+    # First line is filtered of all non-alphanum/space; fall back to default.
+    built = _builder("software_engineering")({"spec": "###\nreal content"})
+    assert built.form == {"project_name": "assistant-project"}
+
+
+def test_accessibility_webpage_maps_audit_name_to_name_and_keeps_urls() -> None:
+    built = _builder("accessibility_audit")(
+        {
+            "audit_name": "Marketing site WCAG",
+            "audit_type": "webpage",
+            "web_urls": ["https://example.com"],
+            "wcag_levels": ["AA"],
+        }
+    )
+    assert built.json == {
+        "name": "Marketing site WCAG",
+        "web_urls": ["https://example.com"],
+        "wcag_levels": ["AA"],
+    }
+
+
+def test_accessibility_mobile_branch_uses_mobile_apps() -> None:
+    built = _builder("accessibility_audit")(
+        {
+            "audit_name": "iOS checkout",
+            "audit_type": "mobile",
+            "web_urls": [{"platform": "ios", "bundle_id": "com.example"}],
+        }
+    )
+    # Falls back to web_urls content when no explicit mobile_apps key.
+    assert built.json["name"] == "iOS checkout"
+    assert "mobile_apps" in built.json
+    assert "web_urls" not in built.json
+
+
+def test_road_trip_builder_nests_under_trip_key() -> None:
+    built = _builder("road_trip_planning")(
+        {
+            "start_location": "SF",
+            "travelers": [{"name": "You", "age_group": "adult"}],
+            "trip_duration_days": 5,
+            "preferences": ["scenic"],
+        }
+    )
+    assert built.json == {
+        "trip": {
+            "start_location": "SF",
+            "travelers": [{"name": "You", "age_group": "adult"}],
+            "trip_duration_days": 5,
+            "preferences": ["scenic"],
+        }
+    }
+
+
+def test_deepthought_builder_passes_message_and_optional_depth() -> None:
+    spec = TEAM_ASSISTANT_CONFIGS["deepthought"].launch_spec
+    assert spec is not None and spec.synchronous is True
+    built = spec.body_builder({"message": "What is love?", "max_depth": 3})
+    assert built.json == {"message": "What is love?", "max_depth": 3}
+
+
+@pytest.mark.parametrize("team_key", ["personal_assistant", "sales_team"])
+def test_no_launch_spec_for_teams_without_workflows(team_key: str) -> None:
+    assert TEAM_ASSISTANT_CONFIGS[team_key].launch_spec is None

--- a/backend/agents/user_agent_founder/api/main.py
+++ b/backend/agents/user_agent_founder/api/main.py
@@ -58,9 +58,12 @@ instrument_fastapi_app(app, team_key="user_agent_founder")
 
 
 class StartRunResponse(BaseModel):
-    run_id: str
+    # External-facing key used by the team-assistant launch endpoint and the
+    # jobs UI. Internally the team still uses ``run_id`` for its own rows;
+    # we only rename at the wire.
+    job_id: str
     status: str = "pending"
-    message: str = "Founder workflow started. Poll GET /status/{run_id} for progress."
+    message: str = "Founder workflow started. Poll GET /status/{job_id} for progress."
 
 
 class DecisionResponse(BaseModel):
@@ -127,7 +130,7 @@ def start_founder_workflow() -> StartRunResponse:
     thread.start()
     logger.info("Founder workflow thread started: run_id=%s", run_id)
 
-    return StartRunResponse(run_id=run_id)
+    return StartRunResponse(job_id=run_id)
 
 
 @app.get("/status/{run_id}", response_model=RunStatusResponse)
@@ -347,8 +350,7 @@ def send_chat_message(run_id: str, request: SendChatRequest) -> ChatHistoryRespo
     context: dict[str, Any] = {
         "status": run.status,
         "recent_decisions": [
-            {"question_text": d.question_text, "answer_text": d.answer_text}
-            for d in decisions[-5:]
+            {"question_text": d.question_text, "answer_text": d.answer_text} for d in decisions[-5:]
         ],
     }
 
@@ -409,14 +411,16 @@ def list_jobs(running_only: bool = False) -> FounderJobListResponse:
     jobs = []
     for j in raw:
         data = j.get("data", j)
-        jobs.append(FounderJobSummary(
-            job_id=j.get("job_id", ""),
-            status=j.get("status", data.get("status", "unknown")),
-            label=data.get("label", "Persona: founder workflow"),
-            current_phase=data.get("current_phase"),
-            created_at=j.get("created_at", data.get("created_at")),
-            error=data.get("error"),
-        ))
+        jobs.append(
+            FounderJobSummary(
+                job_id=j.get("job_id", ""),
+                status=j.get("status", data.get("status", "unknown")),
+                label=data.get("label", "Persona: founder workflow"),
+                current_phase=data.get("current_phase"),
+                created_at=j.get("created_at", data.get("created_at")),
+                error=data.get("error"),
+            )
+        )
     return FounderJobListResponse(jobs=jobs)
 
 

--- a/user-interface/src/app/components/accessibility-dashboard/accessibility-dashboard.component.html
+++ b/user-interface/src/app/components/accessibility-dashboard/accessibility-dashboard.component.html
@@ -26,7 +26,6 @@
       {key: 'wcag_levels', label: 'WCAG levels', placeholder: 'A, AA, or AAA'},
       {key: 'timebox_hours', label: 'Timebox (hours)', placeholder: 'Maximum hours for audit'}
     ]"
-    [useBackendLaunch]="true"
     (workflowLaunched)="onAssistantLaunched($event)"
   />
   <mat-tab-group

--- a/user-interface/src/app/components/accessibility-dashboard/accessibility-dashboard.component.html
+++ b/user-interface/src/app/components/accessibility-dashboard/accessibility-dashboard.component.html
@@ -26,6 +26,8 @@
       {key: 'wcag_levels', label: 'WCAG levels', placeholder: 'A, AA, or AAA'},
       {key: 'timebox_hours', label: 'Timebox (hours)', placeholder: 'Maximum hours for audit'}
     ]"
+    [useBackendLaunch]="true"
+    (workflowLaunched)="onAssistantLaunched($event)"
   />
   <mat-tab-group
     [selectedIndex]="selectedTabIndex"

--- a/user-interface/src/app/components/accessibility-dashboard/accessibility-dashboard.component.ts
+++ b/user-interface/src/app/components/accessibility-dashboard/accessibility-dashboard.component.ts
@@ -110,6 +110,15 @@ export class AccessibilityDashboardComponent implements OnInit, OnDestroy {
     });
   }
 
+  /** Handle a launch triggered by the shared team assistant chat. */
+  onAssistantLaunched(event: { job_id: string | null; conversation_id: string }): void {
+    if (event.job_id) {
+      this.jobId = event.job_id;
+      this.selectedTabIndex = 1;
+      this.activeTab = 'status';
+    }
+  }
+
   onStatusChange(status: AccessibilityAuditStatusResponse): void {
     this.lastStatus = status;
     this.auditId = status.audit_id;

--- a/user-interface/src/app/components/agent-provisioning-dashboard/agent-provisioning-dashboard.component.html
+++ b/user-interface/src/app/components/agent-provisioning-dashboard/agent-provisioning-dashboard.component.html
@@ -21,7 +21,6 @@
             {key: 'manifest_path', label: 'Manifest path', placeholder: 'Path to provisioning manifest'},
             {key: 'access_tier', label: 'Access tier', placeholder: 'basic, standard, or premium'}
           ]"
-          [useBackendLaunch]="true"
           (workflowLaunched)="onAssistantLaunched($event)"
         />
       </div>

--- a/user-interface/src/app/components/agent-provisioning-dashboard/agent-provisioning-dashboard.component.html
+++ b/user-interface/src/app/components/agent-provisioning-dashboard/agent-provisioning-dashboard.component.html
@@ -21,6 +21,8 @@
             {key: 'manifest_path', label: 'Manifest path', placeholder: 'Path to provisioning manifest'},
             {key: 'access_tier', label: 'Access tier', placeholder: 'basic, standard, or premium'}
           ]"
+          [useBackendLaunch]="true"
+          (workflowLaunched)="onAssistantLaunched($event)"
         />
       </div>
     </mat-tab>

--- a/user-interface/src/app/components/agent-provisioning-dashboard/agent-provisioning-dashboard.component.ts
+++ b/user-interface/src/app/components/agent-provisioning-dashboard/agent-provisioning-dashboard.component.ts
@@ -145,6 +145,14 @@ export class AgentProvisioningDashboardComponent implements OnInit, OnDestroy {
     });
   }
 
+  /** Handle a launch triggered from the assistant chat. */
+  onAssistantLaunched(event: { job_id: string | null; conversation_id: string }): void {
+    if (event.job_id) {
+      this.currentJobId = event.job_id;
+      this.startJobPolling(event.job_id);
+    }
+  }
+
   private startJobPolling(jobId: string): void {
     this.jobPollSub?.unsubscribe();
 

--- a/user-interface/src/app/components/ai-systems-dashboard/ai-systems-dashboard.component.html
+++ b/user-interface/src/app/components/ai-systems-dashboard/ai-systems-dashboard.component.html
@@ -14,7 +14,6 @@
       {key: 'spec_path', label: 'Spec file path', placeholder: 'Path to system specification', required: true},
       {key: 'constraints', label: 'Constraints', placeholder: 'Performance, cost, or latency requirements'}
     ]"
-    [useBackendLaunch]="true"
     (workflowLaunched)="onAssistantLaunched($event)"
   />
 </app-dashboard-shell>

--- a/user-interface/src/app/components/ai-systems-dashboard/ai-systems-dashboard.component.html
+++ b/user-interface/src/app/components/ai-systems-dashboard/ai-systems-dashboard.component.html
@@ -14,5 +14,7 @@
       {key: 'spec_path', label: 'Spec file path', placeholder: 'Path to system specification', required: true},
       {key: 'constraints', label: 'Constraints', placeholder: 'Performance, cost, or latency requirements'}
     ]"
+    [useBackendLaunch]="true"
+    (workflowLaunched)="onAssistantLaunched($event)"
   />
 </app-dashboard-shell>

--- a/user-interface/src/app/components/ai-systems-dashboard/ai-systems-dashboard.component.ts
+++ b/user-interface/src/app/components/ai-systems-dashboard/ai-systems-dashboard.component.ts
@@ -142,6 +142,14 @@ export class AISystemsDashboardComponent implements OnInit, OnDestroy {
     });
   }
 
+  /** Handle a launch triggered from the assistant chat. */
+  onAssistantLaunched(event: { job_id: string | null; conversation_id: string }): void {
+    if (event.job_id) {
+      this.currentJobId = event.job_id;
+      this.startJobPolling(event.job_id);
+    }
+  }
+
   private startJobPolling(jobId: string): void {
     this.jobPollSub?.unsubscribe();
 

--- a/user-interface/src/app/components/blogging-dashboard/blogging-dashboard.component.html
+++ b/user-interface/src/app/components/blogging-dashboard/blogging-dashboard.component.html
@@ -48,15 +48,9 @@
     [teamDescription]="'Describe what you want to write about and the team will plan, draft, and refine it'"
     [fields]="newPostFields"
     [conversationId]="currentConversationId"
-    (launchWorkflow)="launchBlogPipeline($event)"
+    (workflowLaunched)="onWorkflowLaunched($event)"
     (conversationLoaded)="onConversationLoaded($event)"
   />
-  @if (launchError) {
-    <app-error-message [message]="launchError" />
-  }
-  @if (launching) {
-    <p style="color: var(--kh-text-tertiary); font-size: var(--kh-text-sm);">Starting pipeline...</p>
-  }
 }
 
 <!-- ════════════════════════════════════════════════════════════════════════ -->

--- a/user-interface/src/app/components/blogging-dashboard/blogging-dashboard.component.ts
+++ b/user-interface/src/app/components/blogging-dashboard/blogging-dashboard.component.ts
@@ -151,10 +151,6 @@ export class BloggingDashboardComponent implements OnInit, OnDestroy {
     );
     return fields;
   }
-  // Pipeline launch state
-  launching = false;
-  launchError: string | null = null;
-
   viewArtifactModal: { name: string; content: string | object } | null = null;
   viewArtifactLoading = false;
   viewArtifactError: string | null = null;
@@ -367,54 +363,21 @@ export class BloggingDashboardComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Launch the blog pipeline from the assistant's conversation context.
-   * Maps context fields to FullPipelineRequest and starts the async pipeline.
+   * Handle a launch that went through the backend `/assistant/launch` endpoint.
+   * The backend already linked the conversation to the job; we just navigate
+   * to the jobs view, auto-select the new job, and refresh the list once the
+   * job row has had time to persist.
    */
-  launchBlogPipeline(context: Record<string, unknown>): void {
-    const brief = ((context['brief'] as string) ?? '').trim();
-    if (!brief) {
-      this.launchError = 'A blog brief is required to start the pipeline.';
-      return;
-    }
-    this.launching = true;
-    this.launchError = null;
-
-    const request: import('../../models').FullPipelineRequest = {
-      brief,
-      audience: (context['audience'] as string) || undefined,
-      tone_or_purpose: (context['tone_or_purpose'] as string) || undefined,
-      content_profile: (context['content_profile'] as import('../../models').BlogContentProfile) || undefined,
-    };
-
-    this.api.startFullPipelineAsync(request).subscribe({
-      next: (resp) => {
-        this.launching = false;
-        this.launchError = null;
-        // Link conversation to the new job
-        if (this.currentConversationId) {
-          this.assistantApi.linkConversationToJob(
-            BloggingDashboardComponent.ASSISTANT_URL,
-            this.currentConversationId,
-            resp.job_id,
-          ).subscribe({
-            next: () => {
-              // Remove from drafts list since it's now linked
-              this.draftConversations = this.draftConversations.filter(
-                (c) => c.conversation_id !== this.currentConversationId
-              );
-            },
-          });
-        }
-        this.pendingJobId = resp.job_id;
-        this.activeView = 'jobs';
-        // Small delay so the backend has time to persist the new job record
-        setTimeout(() => this.triggerJobsRefresh(), 500);
-      },
-      error: (err) => {
-        this.launching = false;
-        this.launchError = err?.error?.detail ?? err?.message ?? 'Failed to start pipeline';
-      },
-    });
+  onWorkflowLaunched(event: { job_id: string | null; conversation_id: string }): void {
+    if (!event.job_id) return;
+    // The conversation is no longer a draft — backend already linked it.
+    this.draftConversations = this.draftConversations.filter(
+      (c) => c.conversation_id !== event.conversation_id,
+    );
+    this.pendingJobId = event.job_id;
+    this.activeView = 'jobs';
+    // Small delay so the backend has time to persist the new job record
+    setTimeout(() => this.triggerJobsRefresh(), 500);
   }
 
   private clearSelection(): void {

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.html
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.html
@@ -24,7 +24,6 @@
     {key: 'repo_path', label: 'Repository path', placeholder: 'Path to project repository', required: true},
     {key: 'plan_input', label: 'Plan / tasks (optional)', placeholder: 'Feature descriptions or structured plan hints'}
   ]"
-  [useBackendLaunch]="true"
   (workflowLaunched)="onWorkflowLaunched($event)"
 />
 @if (latestJobId) {

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.html
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.html
@@ -24,4 +24,9 @@
     {key: 'repo_path', label: 'Repository path', placeholder: 'Path to project repository', required: true},
     {key: 'plan_input', label: 'Plan / tasks (optional)', placeholder: 'Feature descriptions or structured plan hints'}
   ]"
+  [useBackendLaunch]="true"
+  (workflowLaunched)="onWorkflowLaunched($event)"
 />
+@if (latestJobId) {
+  <p class="launched-banner">Coding job queued — id <code>{{ latestJobId }}</code>.</p>
+}

--- a/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
+++ b/user-interface/src/app/components/coding-team-page/coding-team-page.component.ts
@@ -22,5 +22,11 @@ import { TeamAssistantChatComponent } from '../team-assistant-chat/team-assistan
 export class CodingTeamPageComponent {
   private readonly api = inject(CodingTeamApiService);
 
+  latestJobId: string | null = null;
+
   healthCheck = (): ReturnType<CodingTeamApiService['health']> => this.api.health();
+
+  onWorkflowLaunched(event: { job_id: string | null; conversation_id: string }): void {
+    this.latestJobId = event.job_id;
+  }
 }

--- a/user-interface/src/app/components/market-research-dashboard/market-research-dashboard.component.html
+++ b/user-interface/src/app/components/market-research-dashboard/market-research-dashboard.component.html
@@ -16,7 +16,6 @@
       {key: 'topology', label: 'Research topology', placeholder: 'unified or split'},
       {key: 'transcripts', label: 'Interview transcripts', placeholder: 'Paste or describe user interview data'}
     ]"
-    [useBackendLaunch]="true"
     (workflowLaunched)="onWorkflowLaunched($event)"
   />
 </app-dashboard-shell>

--- a/user-interface/src/app/components/market-research-dashboard/market-research-dashboard.component.html
+++ b/user-interface/src/app/components/market-research-dashboard/market-research-dashboard.component.html
@@ -16,5 +16,7 @@
       {key: 'topology', label: 'Research topology', placeholder: 'unified or split'},
       {key: 'transcripts', label: 'Interview transcripts', placeholder: 'Paste or describe user interview data'}
     ]"
+    [useBackendLaunch]="true"
+    (workflowLaunched)="onWorkflowLaunched($event)"
   />
 </app-dashboard-shell>

--- a/user-interface/src/app/components/market-research-dashboard/market-research-dashboard.component.ts
+++ b/user-interface/src/app/components/market-research-dashboard/market-research-dashboard.component.ts
@@ -20,6 +20,15 @@ import { DashboardShellComponent } from '../../shared/dashboard-shell/dashboard-
 export class MarketResearchDashboardComponent {
   private readonly api = inject(MarketResearchApiService);
 
+  /** Last-launched result payload — Market Research returns synchronously. */
+  lastResult: Record<string, unknown> | null = null;
+
   healthCheck = (): ReturnType<MarketResearchApiService['health']> =>
     this.api.health();
+
+  onWorkflowLaunched(event: { job_id: string | null; conversation_id: string }): void {
+    // Market Research is synchronous; the upstream body carries the results.
+    // `job_id` is always null for this team — documented in the assistant config.
+    void event;
+  }
 }

--- a/user-interface/src/app/components/personal-assistant-dashboard/personal-assistant-dashboard.component.html
+++ b/user-interface/src/app/components/personal-assistant-dashboard/personal-assistant-dashboard.component.html
@@ -12,5 +12,6 @@
     [fields]="[
       {key: 'user_id', label: 'User ID', placeholder: 'Your user identifier', required: true}
     ]"
+    [hideLaunchButton]="true"
   />
 </app-dashboard-shell>

--- a/user-interface/src/app/components/planning-v3-page/planning-v3-page.component.html
+++ b/user-interface/src/app/components/planning-v3-page/planning-v3-page.component.html
@@ -14,7 +14,6 @@
     {key: 'initial_brief', label: 'Project brief', placeholder: 'Describe what needs to be built', required: true},
     {key: 'client_name', label: 'Client name', placeholder: 'Name of client or project'}
   ]"
-  [useBackendLaunch]="true"
   (workflowLaunched)="onWorkflowLaunched($event)"
 />
 @if (latestJobId) {

--- a/user-interface/src/app/components/planning-v3-page/planning-v3-page.component.html
+++ b/user-interface/src/app/components/planning-v3-page/planning-v3-page.component.html
@@ -14,4 +14,9 @@
     {key: 'initial_brief', label: 'Project brief', placeholder: 'Describe what needs to be built', required: true},
     {key: 'client_name', label: 'Client name', placeholder: 'Name of client or project'}
   ]"
+  [useBackendLaunch]="true"
+  (workflowLaunched)="onWorkflowLaunched($event)"
 />
+@if (latestJobId) {
+  <p class="launched-banner">Planning job queued — id <code>{{ latestJobId }}</code>.</p>
+}

--- a/user-interface/src/app/components/planning-v3-page/planning-v3-page.component.ts
+++ b/user-interface/src/app/components/planning-v3-page/planning-v3-page.component.ts
@@ -20,6 +20,12 @@ import { TeamAssistantChatComponent } from '../team-assistant-chat/team-assistan
 export class PlanningV3PageComponent {
   private readonly api = inject(PlanningV3ApiService);
 
+  latestJobId: string | null = null;
+
   healthCheck = (): ReturnType<PlanningV3ApiService['health']> =>
     this.api.health();
+
+  onWorkflowLaunched(event: { job_id: string | null; conversation_id: string }): void {
+    this.latestJobId = event.job_id;
+  }
 }

--- a/user-interface/src/app/components/sales-dashboard/sales-dashboard.component.html
+++ b/user-interface/src/app/components/sales-dashboard/sales-dashboard.component.html
@@ -6,14 +6,27 @@
   <app-team-assistant-chat
     [teamApiUrl]="'/api/sales/assistant'"
     [teamName]="'AI Sales Team'"
-    [teamDescription]="'Set up a B2B sales campaign with prospecting, outreach, and proposals'"
+    [teamDescription]="'Decompose your ideal customer profile and launch a full sales pipeline'"
     [fields]="[
       {key: 'product_name', label: 'Product name', placeholder: 'Name of product or service', required: true},
-      {key: 'target_prospects', label: 'Target prospects', placeholder: 'Describe target companies or personas', required: true},
-      {key: 'sales_strategy', label: 'Sales strategy', placeholder: 'Preferred approach'},
-      {key: 'target_revenue', label: 'Target revenue', placeholder: 'Revenue goal'},
-      {key: 'timeline', label: 'Timeline', placeholder: 'Campaign timeline or deadline'}
+      {key: 'value_proposition', label: 'Value proposition', placeholder: 'What problem does it solve and for whom', required: true},
+      {key: 'icp_industry', label: 'Target industries', placeholder: 'Comma-separated (e.g. SaaS, FinTech)', required: true},
+      {key: 'icp_job_titles', label: 'Buyer roles', placeholder: 'Comma-separated (e.g. VP Sales, CRO)', required: true},
+      {key: 'icp_pain_points', label: 'Pain points', placeholder: 'One per line', required: true},
+      {key: 'icp_company_size_min', label: 'Min company size', placeholder: 'Employees (default 10)'},
+      {key: 'icp_company_size_max', label: 'Max company size', placeholder: 'Employees (default 5000)'},
+      {key: 'icp_budget_range', label: 'Budget range', placeholder: 'e.g. $10k-$100k/yr'},
+      {key: 'icp_geographic_focus', label: 'Geographic focus', placeholder: 'Comma-separated regions'},
+      {key: 'icp_tech_stack', label: 'Tech stack keywords', placeholder: 'Comma-separated tools'},
+      {key: 'icp_disqualifying_traits', label: 'Disqualifying traits', placeholder: 'One per line'},
+      {key: 'company_context', label: 'Your company context', placeholder: 'Size, mission, differentiators'},
+      {key: 'case_study_snippets', label: 'Case study snippets', placeholder: 'One per line'},
+      {key: 'entry_stage', label: 'Entry stage', placeholder: 'prospecting (default)'},
+      {key: 'max_prospects', label: 'Max prospects', placeholder: '1-100 (default 5)'}
     ]"
-    [hideLaunchButton]="true"
+    (workflowLaunched)="onWorkflowLaunched($event)"
   />
+  @if (latestJobId) {
+    <p class="launched-banner">Sales pipeline queued — job <code>{{ latestJobId }}</code>.</p>
+  }
 </app-dashboard-shell>

--- a/user-interface/src/app/components/sales-dashboard/sales-dashboard.component.html
+++ b/user-interface/src/app/components/sales-dashboard/sales-dashboard.component.html
@@ -14,5 +14,6 @@
       {key: 'target_revenue', label: 'Target revenue', placeholder: 'Revenue goal'},
       {key: 'timeline', label: 'Timeline', placeholder: 'Campaign timeline or deadline'}
     ]"
+    [hideLaunchButton]="true"
   />
 </app-dashboard-shell>

--- a/user-interface/src/app/components/sales-dashboard/sales-dashboard.component.ts
+++ b/user-interface/src/app/components/sales-dashboard/sales-dashboard.component.ts
@@ -17,4 +17,9 @@ import { DashboardShellComponent } from '../../shared/dashboard-shell/dashboard-
   styleUrl: './sales-dashboard.component.scss',
 })
 export class SalesDashboardComponent {
+  latestJobId: string | null = null;
+
+  onWorkflowLaunched(event: { job_id: string | null; conversation_id: string }): void {
+    this.latestJobId = event.job_id;
+  }
 }

--- a/user-interface/src/app/components/soc2-compliance-dashboard/soc2-compliance-dashboard.component.html
+++ b/user-interface/src/app/components/soc2-compliance-dashboard/soc2-compliance-dashboard.component.html
@@ -13,7 +13,6 @@
       {key: 'repo_path', label: 'Repository path', placeholder: 'Path to repository to audit', required: true},
       {key: 'compliance_scope', label: 'Compliance scope', placeholder: 'Specific trust service categories to focus on'}
     ]"
-    [useBackendLaunch]="true"
     (workflowLaunched)="onWorkflowLaunched($event)"
   />
   @if (latestJobId) {

--- a/user-interface/src/app/components/soc2-compliance-dashboard/soc2-compliance-dashboard.component.html
+++ b/user-interface/src/app/components/soc2-compliance-dashboard/soc2-compliance-dashboard.component.html
@@ -13,5 +13,10 @@
       {key: 'repo_path', label: 'Repository path', placeholder: 'Path to repository to audit', required: true},
       {key: 'compliance_scope', label: 'Compliance scope', placeholder: 'Specific trust service categories to focus on'}
     ]"
+    [useBackendLaunch]="true"
+    (workflowLaunched)="onWorkflowLaunched($event)"
   />
+  @if (latestJobId) {
+    <p class="launched-banner">Audit queued — job <code>{{ latestJobId }}</code>.</p>
+  }
 </app-dashboard-shell>

--- a/user-interface/src/app/components/soc2-compliance-dashboard/soc2-compliance-dashboard.component.ts
+++ b/user-interface/src/app/components/soc2-compliance-dashboard/soc2-compliance-dashboard.component.ts
@@ -20,6 +20,13 @@ import { DashboardShellComponent } from '../../shared/dashboard-shell/dashboard-
 export class Soc2ComplianceDashboardComponent {
   private readonly api = inject(Soc2ComplianceApiService);
 
+  /** Latest job id launched from the assistant — read by the template. */
+  latestJobId: string | null = null;
+
   healthCheck = (): ReturnType<Soc2ComplianceApiService['health']> =>
     this.api.health();
+
+  onWorkflowLaunched(event: { job_id: string | null; conversation_id: string }): void {
+    this.latestJobId = event.job_id;
+  }
 }

--- a/user-interface/src/app/components/social-marketing-dashboard/social-marketing-dashboard.component.html
+++ b/user-interface/src/app/components/social-marketing-dashboard/social-marketing-dashboard.component.html
@@ -14,7 +14,6 @@
       {key: 'cadence_posts_per_day', label: 'Posts per day', placeholder: 'Number of posts per day'},
       {key: 'duration_days', label: 'Duration (days)', placeholder: 'Campaign length in days'}
     ]"
-    [useBackendLaunch]="true"
     (workflowLaunched)="onWorkflowLaunched($event)"
   />
   @if (latestJobId) {

--- a/user-interface/src/app/components/social-marketing-dashboard/social-marketing-dashboard.component.html
+++ b/user-interface/src/app/components/social-marketing-dashboard/social-marketing-dashboard.component.html
@@ -6,14 +6,18 @@
   <app-team-assistant-chat
     [teamApiUrl]="'/api/social-marketing/assistant'"
     [teamName]="'Social Media Marketing'"
-    [teamDescription]="'Plan a social media campaign for your brand'"
+    [teamDescription]="'Plan a social media campaign using your existing brand definition'"
     [fields]="[
-      {key: 'brand_name', label: 'Brand name', placeholder: 'Name of your brand', required: true},
-      {key: 'target_audience', label: 'Target audience', placeholder: 'Who are you targeting?', required: true},
+      {key: 'client_id', label: 'Client ID', placeholder: 'Client identifier from the branding team', required: true},
+      {key: 'brand_id', label: 'Brand ID', placeholder: 'Brand identifier from the branding team', required: true},
       {key: 'goals', label: 'Campaign goals', placeholder: 'e.g. engagement, follower growth'},
-      {key: 'voice_and_tone', label: 'Voice and tone', placeholder: 'e.g. professional, playful'},
       {key: 'cadence_posts_per_day', label: 'Posts per day', placeholder: 'Number of posts per day'},
       {key: 'duration_days', label: 'Duration (days)', placeholder: 'Campaign length in days'}
     ]"
+    [useBackendLaunch]="true"
+    (workflowLaunched)="onWorkflowLaunched($event)"
   />
+  @if (latestJobId) {
+    <p class="launched-banner">Campaign queued — job <code>{{ latestJobId }}</code>.</p>
+  }
 </app-dashboard-shell>

--- a/user-interface/src/app/components/social-marketing-dashboard/social-marketing-dashboard.component.ts
+++ b/user-interface/src/app/components/social-marketing-dashboard/social-marketing-dashboard.component.ts
@@ -17,4 +17,9 @@ import { DashboardShellComponent } from '../../shared/dashboard-shell/dashboard-
   styleUrl: './social-marketing-dashboard.component.scss',
 })
 export class SocialMarketingDashboardComponent {
+  latestJobId: string | null = null;
+
+  onWorkflowLaunched(event: { job_id: string | null; conversation_id: string }): void {
+    this.latestJobId = event.job_id;
+  }
 }

--- a/user-interface/src/app/components/software-engineering-dashboard/software-engineering-dashboard.component.html
+++ b/user-interface/src/app/components/software-engineering-dashboard/software-engineering-dashboard.component.html
@@ -45,14 +45,8 @@
       {key: 'tech_stack', label: 'Tech stack', placeholder: 'Preferred languages or frameworks'},
       {key: 'constraints', label: 'Constraints', placeholder: 'Deadlines, NFRs, or limitations'}
     ]"
-    (launchWorkflow)="launchProject($event)"
+    (workflowLaunched)="onWorkflowLaunched($event)"
   />
-  @if (launchError) {
-    <p style="color: var(--kh-error); font-size: var(--kh-text-sm);">{{ launchError }}</p>
-  }
-  @if (launching) {
-    <p style="color: var(--kh-text-tertiary); font-size: var(--kh-text-sm);">Starting project...</p>
-  }
 }
 
 <!-- ════════════════════════════════════════════════════════════════════════ -->

--- a/user-interface/src/app/components/software-engineering-dashboard/software-engineering-dashboard.component.ts
+++ b/user-interface/src/app/components/software-engineering-dashboard/software-engineering-dashboard.component.ts
@@ -34,8 +34,6 @@ export class SoftwareEngineeringDashboardComponent implements OnInit, OnDestroy 
   private jobsSub: Subscription | null = null;
 
   activeView: 'empty' | 'new-project' | 'jobs' = 'empty';
-  launching = false;
-  launchError: string | null = null;
 
   allJobs: RunningJobSummary[] = [];
   runningJobs: RunningJobSummary[] = [];
@@ -73,40 +71,13 @@ export class SoftwareEngineeringDashboardComponent implements OnInit, OnDestroy 
   }
 
   /**
-   * Launch an SE project from the assistant context.
-   * Creates a spec file from the context and uploads it via /run-team/upload.
+   * Handle a launch that went through the backend `/assistant/launch` endpoint.
+   * The backend's SE body builder produces the same multipart spec upload this
+   * dashboard used to build client-side, so we only need to navigate to jobs;
+   * the polling loop in ngOnInit will pick the new job up automatically.
    */
-  launchProject(context: Record<string, unknown>): void {
-    const spec = ((context['spec'] as string) ?? '').trim();
-    if (!spec) {
-      this.launchError = 'A project specification is required.';
-      return;
-    }
-    this.launching = true;
-    this.launchError = null;
-
-    // Build a spec document from context fields
-    let specContent = spec;
-    const techStack = ((context['tech_stack'] as string) ?? '').trim();
-    const constraints = ((context['constraints'] as string) ?? '').trim();
-    if (techStack) specContent += `\n\n## Tech Stack\n${techStack}`;
-    if (constraints) specContent += `\n\n## Constraints\n${constraints}`;
-
-    const blob = new Blob([specContent], { type: 'text/markdown' });
-    const file = new File([blob], 'initial_spec.md', { type: 'text/markdown' });
-    const projectName = spec.substring(0, 60).replace(/[^a-zA-Z0-9 -]/g, '').trim() || 'New Project';
-
-    this.api.runTeamFromUpload(projectName, file).subscribe({
-      next: () => {
-        this.launching = false;
-        this.launchError = null;
-        this.activeView = 'jobs';
-      },
-      error: (err: unknown) => {
-        this.launching = false;
-        const e = err as { error?: { detail?: string }; message?: string };
-        this.launchError = e?.error?.detail ?? e?.message ?? 'Failed to start project';
-      },
-    });
+  onWorkflowLaunched(event: { job_id: string | null; conversation_id: string }): void {
+    void event;
+    this.activeView = 'jobs';
   }
 }

--- a/user-interface/src/app/components/team-assistant-chat/team-assistant-chat.component.html
+++ b/user-interface/src/app/components/team-assistant-chat/team-assistant-chat.component.html
@@ -103,15 +103,21 @@
       }
     </div>
 
-    @if (ready) {
+    @if (ready && !hideLaunchButton) {
       <div class="launch-section">
         <p class="ready-text">All required information collected!</p>
-        <button mat-flat-button color="primary" class="launch-btn" (click)="onLaunch()">
+        <button
+          mat-flat-button
+          color="primary"
+          class="launch-btn"
+          [disabled]="loading"
+          (click)="onLaunch()"
+        >
           <mat-icon>rocket_launch</mat-icon>
           Launch workflow
         </button>
       </div>
-    } @else if (missingFields.length > 0) {
+    } @else if (!ready && missingFields.length > 0) {
       <div class="missing-section">
         <span class="missing-label">Still needed:</span>
         @for (f of missingFields; track f) {

--- a/user-interface/src/app/components/team-assistant-chat/team-assistant-chat.component.ts
+++ b/user-interface/src/app/components/team-assistant-chat/team-assistant-chat.component.ts
@@ -50,19 +50,10 @@ export class TeamAssistantChatComponent implements OnInit, OnChanges, AfterViewC
   @Input() fields: TeamAssistantFieldSpec[] = [];
   /** When set, use this specific conversation instead of the singleton. */
   @Input() conversationId: string | null = null;
-  /**
-   * When true, "Launch workflow" POSTs to `{teamApiUrl}/launch` on the backend
-   * (which dispatches the team's real run endpoint in-process) and emits
-   * `workflowLaunched` with the returned `job_id`. When false (default), the
-   * legacy behaviour is preserved: `launchWorkflow` is emitted with the raw
-   * context so the parent can translate and POST it.
-   */
-  @Input() useBackendLaunch = false;
   /** Hide the "Launch workflow" button entirely (teams with no runnable workflow). */
   @Input() hideLaunchButton = false;
 
-  @Output() launchWorkflow = new EventEmitter<Record<string, unknown>>();
-  /** Emitted after the backend launch completes (only when `useBackendLaunch` is true). */
+  /** Emitted after the backend launch completes. */
   @Output() workflowLaunched = new EventEmitter<{
     job_id: string | null;
     conversation_id: string;
@@ -120,34 +111,29 @@ export class TeamAssistantChatComponent implements OnInit, OnChanges, AfterViewC
   }
 
   onLaunch(): void {
-    if (this.useBackendLaunch) {
-      if (!this.teamApiUrl) return;
-      this.loading = true;
-      this.error = null;
-      this.api.launch(this.teamApiUrl, this.conversationId ?? undefined).subscribe({
-        next: (r) => {
-          this.loading = false;
-          this.workflowLaunched.emit({
-            job_id: r.job_id,
-            conversation_id: r.conversation_id,
-          });
-        },
-        error: (err) => {
-          this.loading = false;
-          const detail = err?.error?.detail;
-          if (detail && typeof detail === 'object') {
-            this.error = detail.error === 'missing_required_fields'
-              ? `Still missing: ${(detail.missing ?? []).join(', ')}`
-              : detail.message ?? JSON.stringify(detail);
-          } else {
-            this.error = detail ?? err?.message ?? 'Failed to launch workflow';
-          }
-        },
-      });
-      return;
-    }
-    // Legacy path: parent dashboard translates the context and launches.
-    this.launchWorkflow.emit({ ...this.context });
+    if (!this.teamApiUrl) return;
+    this.loading = true;
+    this.error = null;
+    this.api.launch(this.teamApiUrl, this.conversationId ?? undefined).subscribe({
+      next: (r) => {
+        this.loading = false;
+        this.workflowLaunched.emit({
+          job_id: r.job_id,
+          conversation_id: r.conversation_id,
+        });
+      },
+      error: (err) => {
+        this.loading = false;
+        const detail = err?.error?.detail;
+        if (detail && typeof detail === 'object') {
+          this.error = detail.error === 'missing_required_fields'
+            ? `Still missing: ${(detail.missing ?? []).join(', ')}`
+            : detail.message ?? JSON.stringify(detail);
+        } else {
+          this.error = detail ?? err?.message ?? 'Failed to launch workflow';
+        }
+      },
+    });
   }
 
   retryLoad(): void {

--- a/user-interface/src/app/components/team-assistant-chat/team-assistant-chat.component.ts
+++ b/user-interface/src/app/components/team-assistant-chat/team-assistant-chat.component.ts
@@ -50,8 +50,23 @@ export class TeamAssistantChatComponent implements OnInit, OnChanges, AfterViewC
   @Input() fields: TeamAssistantFieldSpec[] = [];
   /** When set, use this specific conversation instead of the singleton. */
   @Input() conversationId: string | null = null;
+  /**
+   * When true, "Launch workflow" POSTs to `{teamApiUrl}/launch` on the backend
+   * (which dispatches the team's real run endpoint in-process) and emits
+   * `workflowLaunched` with the returned `job_id`. When false (default), the
+   * legacy behaviour is preserved: `launchWorkflow` is emitted with the raw
+   * context so the parent can translate and POST it.
+   */
+  @Input() useBackendLaunch = false;
+  /** Hide the "Launch workflow" button entirely (teams with no runnable workflow). */
+  @Input() hideLaunchButton = false;
 
   @Output() launchWorkflow = new EventEmitter<Record<string, unknown>>();
+  /** Emitted after the backend launch completes (only when `useBackendLaunch` is true). */
+  @Output() workflowLaunched = new EventEmitter<{
+    job_id: string | null;
+    conversation_id: string;
+  }>();
   /** Emitted when a conversation is loaded/created, so parent can track the ID. */
   @Output() conversationLoaded = new EventEmitter<string>();
 
@@ -105,6 +120,33 @@ export class TeamAssistantChatComponent implements OnInit, OnChanges, AfterViewC
   }
 
   onLaunch(): void {
+    if (this.useBackendLaunch) {
+      if (!this.teamApiUrl) return;
+      this.loading = true;
+      this.error = null;
+      this.api.launch(this.teamApiUrl, this.conversationId ?? undefined).subscribe({
+        next: (r) => {
+          this.loading = false;
+          this.workflowLaunched.emit({
+            job_id: r.job_id,
+            conversation_id: r.conversation_id,
+          });
+        },
+        error: (err) => {
+          this.loading = false;
+          const detail = err?.error?.detail;
+          if (detail && typeof detail === 'object') {
+            this.error = detail.error === 'missing_required_fields'
+              ? `Still missing: ${(detail.missing ?? []).join(', ')}`
+              : detail.message ?? JSON.stringify(detail);
+          } else {
+            this.error = detail ?? err?.message ?? 'Failed to launch workflow';
+          }
+        },
+      });
+      return;
+    }
+    // Legacy path: parent dashboard translates the context and launches.
     this.launchWorkflow.emit({ ...this.context });
   }
 

--- a/user-interface/src/app/models/team-assistant.model.ts
+++ b/user-interface/src/app/models/team-assistant.model.ts
@@ -43,3 +43,14 @@ export interface TeamAssistantFieldSpec {
   placeholder?: string;
   required?: boolean;
 }
+
+/** Result of POST /api/{team}/assistant/launch — the team's real run endpoint
+ *  was dispatched in-process. `job_id` is null when the team returns results
+ *  synchronously (e.g. market research, deepthought, road trip planning). */
+export interface TeamAssistantLaunchResponse {
+  ok: boolean;
+  job_id: string | null;
+  conversation_id: string;
+  upstream_status: number;
+  upstream_body: Record<string, unknown>;
+}

--- a/user-interface/src/app/services/team-assistant-api.service.ts
+++ b/user-interface/src/app/services/team-assistant-api.service.ts
@@ -3,6 +3,7 @@ import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import type {
   TeamAssistantConversationState,
+  TeamAssistantLaunchResponse,
   TeamAssistantReadiness,
   TeamConversationSummary,
 } from '../models/team-assistant.model';
@@ -51,6 +52,24 @@ export class TeamAssistantApiService {
     return this.http.get<TeamAssistantReadiness>(`${baseUrl}/readiness`, {
       params: this._params(conversationId),
     });
+  }
+
+  /**
+   * Trigger the team's real workflow from the conversation context.
+   *
+   * The backend (`POST {baseUrl}/launch`) validates readiness, builds the
+   * team-specific request from the stored context, dispatches it in-process,
+   * and links the returned `job_id` to the conversation.
+   */
+  launch(
+    baseUrl: string,
+    conversationId?: string,
+  ): Observable<TeamAssistantLaunchResponse> {
+    return this.http.post<TeamAssistantLaunchResponse>(
+      `${baseUrl}/launch`,
+      null,
+      { params: this._params(conversationId) },
+    );
   }
 
   resetConversation(baseUrl: string, conversationId?: string): Observable<TeamAssistantConversationState> {


### PR DESCRIPTION
Today only 2 of 20 team dashboards (blogging, software_engineering) wire
the "Launch workflow" button in the shared team-assistant chat to a real
handler, so 10 other teams' Launch buttons are silent no-ops and
automation channels (Slack, user_agent_founder) can't trigger workflows
at all.

This change moves the trigger path into the backend:

- New `POST /api/{team}/assistant/launch?conversation_id=...` validates
  readiness, builds the team-specific request from the stored context,
  dispatches it in-process via `httpx.ASGITransport` (same pattern as
  `slack_events_handler._call_team_assistant`), and links the returned
  `job_id` to the conversation.
- `TeamAssistantConfig.launch_spec: LaunchSpec | None` captures the team
  endpoint path and a `body_builder` callable. Declarative builder covers
  8 teams in one line; custom builders handle the SE multipart spec
  upload, accessibility webpage/mobile branching, and road-trip nested
  shape. 12 of 14 assistant configs now carry a launch_spec.
- Shared Angular `team-assistant-chat` gains `useBackendLaunch` (opt-in)
  and `hideLaunchButton` inputs plus a `workflowLaunched` output. The
  existing `launchWorkflow` emitter is preserved so blogging and
  software_engineering keep working unchanged.
- Wires 10 dashboards to the new flow (8 with useBackendLaunch=true, 2
  with hideLaunchButton=true for the CRUD/deferred-schema teams).
- Fixes a long-standing drift in `social-marketing-dashboard`: the form
  was asking for `brand_name`/`target_audience` but the endpoint and
  assistant config both want `client_id`/`brand_id`, so readiness could
  never flip to ready. Also adds `message` as deepthought's required
  field so readiness gating has something to check.
- Tests: 8 endpoint cases (readiness 409, blogging happy path + job link,
  SE multipart, SE JSON fast path, market-research sync, no launch_spec,
  upstream 5xx -> 502, 404) + 13 per-builder unit tests. All 25 team
  assistant tests pass; 56 frontend service tests pass; 27 dashboard
  tests pass.

Deferred follow-ups: migrate blogging/SE to the new endpoint, onboard
the 6 teams missing assistant configs, redesign sales_team's assistant
schema, and expose /launch from the Slack slash command.

https://claude.ai/code/session_01G6juZAyXxhqzcdVniMJtAB