### PR TITLE
Fix two review issues from #238: social_marketing llm_model_name + sync result visibility

### DIFF
--- a/backend/agents/team_assistant/config.py
+++ b/backend/agents/team_assistant/config.py
@@ -10,10 +10,16 @@ launch (e.g. the personal assistant, which is CRUD-only).
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from typing import Any, List
 
 from team_assistant.launch_spec import BuiltBody, LaunchSpec, declarative_builder
+
+# Fallback when neither the conversation context nor the LLM_MODEL env var
+# supplies a model name. Matches docker/.env.example so local dev works
+# out of the box.
+_DEFAULT_LLM_MODEL = "qwen3.5:397b-cloud"
 
 
 @dataclass
@@ -71,6 +77,32 @@ def _se_body_builder(context: dict[str, Any]) -> BuiltBody:
         files={"spec_file": ("initial_spec.md", spec_text.encode("utf-8"), "text/markdown")},
         path_override="/api/software-engineering/run-team/upload",
     )
+
+
+def _social_marketing_body_builder(context: dict[str, Any]) -> BuiltBody:
+    """Social Marketing: always inject ``llm_model_name``.
+
+    The upstream ``RunMarketingTeamRequest`` makes ``llm_model_name``
+    required, so a launch that forgets it fails validation with 422. We
+    resolve it in priority order: conversation context → ``LLM_MODEL``
+    env var → bundled default. The rest of the fields are copied
+    declaratively, same as before.
+    """
+    llm_model_name = (
+        str(context.get("llm_model_name") or "").strip()
+        or os.environ.get("LLM_MODEL", "").strip()
+        or _DEFAULT_LLM_MODEL
+    )
+    body: dict[str, Any] = {
+        "client_id": context["client_id"],
+        "brand_id": context["brand_id"],
+        "llm_model_name": llm_model_name,
+    }
+    for key in ("goals", "cadence_posts_per_day", "duration_days"):
+        value = context.get(key)
+        if value is not None and value != "":
+            body[key] = value
+    return BuiltBody(json=body)
 
 
 def _accessibility_body_builder(context: dict[str, Any]) -> BuiltBody:
@@ -376,6 +408,10 @@ TEAM_ASSISTANT_CONFIGS: dict[str, TeamAssistantConfig] = {
             },
             {"key": "cadence_posts_per_day", "description": "Number of posts per day"},
             {"key": "duration_days", "description": "Campaign duration in days"},
+            {
+                "key": "llm_model_name",
+                "description": "Override the LLM model (defaults to LLM_MODEL env var)",
+            },
         ],
         welcome_message=(
             "Welcome! I'm your Social Media Marketing assistant. I help plan campaigns that "
@@ -394,10 +430,7 @@ TEAM_ASSISTANT_CONFIGS: dict[str, TeamAssistantConfig] = {
         ],
         launch_spec=LaunchSpec(
             path="/api/social-marketing/social-marketing/run",
-            body_builder=declarative_builder(
-                required=["client_id", "brand_id"],
-                optional=["goals", "cadence_posts_per_day", "duration_days"],
-            ),
+            body_builder=_social_marketing_body_builder,
         ),
     ),
     # -----------------------------------------------------------------------

--- a/backend/agents/team_assistant/tests/test_launch_endpoint.py
+++ b/backend/agents/team_assistant/tests/test_launch_endpoint.py
@@ -238,9 +238,35 @@ def test_market_research_synchronous_has_null_job_id(
     body = resp.json()
     assert body["ok"] is True
     assert body["job_id"] is None
+    # The full upstream body is surfaced so the dashboard can render it,
+    # since there's no job to poll for synchronous teams.
+    assert body["upstream_body"] == {"status": "ok", "summary": "..."}
     # And the conversation is NOT linked to any job.
     store = TeamAssistantConversationStore(team_key="market_research")
     assert store.get_by_job_id("") is None
+
+
+def test_social_marketing_launch_injects_llm_model_name(
+    fake_pg: dict,
+    upstream: _UpstreamHarness,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Regression: upstream requires llm_model_name; assistant must supply it."""
+    _stub_agent(monkeypatch)
+    monkeypatch.setenv("LLM_MODEL", "llama3.1")
+    upstream.response_body = {"job_id": "sm-1", "status": "queued", "message": "ok"}
+    client, cid = _seed_conversation(
+        "social_marketing",
+        context={"client_id": "client-a", "brand_id": "brand-b"},
+    )
+
+    resp = client.post(f"/launch?conversation_id={cid}")
+    assert resp.status_code == 200, resp.text
+
+    sent = json.loads(upstream.requests[0]["body"])
+    assert sent["client_id"] == "client-a"
+    assert sent["brand_id"] == "brand-b"
+    assert sent["llm_model_name"] == "llama3.1"
 
 
 def test_no_launch_spec_returns_400(

--- a/backend/agents/team_assistant/tests/test_launch_spec_builders.py
+++ b/backend/agents/team_assistant/tests/test_launch_spec_builders.py
@@ -236,6 +236,49 @@ def test_user_agent_founder_emits_empty_body() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_social_marketing_builder_injects_llm_model_from_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the user didn't pick a model, fall back to LLM_MODEL env var."""
+    monkeypatch.setenv("LLM_MODEL", "llama3.1")
+    built = _builder("social_marketing")(
+        {
+            "client_id": "c-1",
+            "brand_id": "b-1",
+            "goals": ["engagement"],
+        }
+    )
+    assert built.json == {
+        "client_id": "c-1",
+        "brand_id": "b-1",
+        "llm_model_name": "llama3.1",
+        "goals": ["engagement"],
+    }
+
+
+def test_social_marketing_builder_prefers_context_value_over_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LLM_MODEL", "llama3.1")
+    built = _builder("social_marketing")(
+        {
+            "client_id": "c-1",
+            "brand_id": "b-1",
+            "llm_model_name": "mistral",
+        }
+    )
+    assert built.json["llm_model_name"] == "mistral"
+
+
+def test_social_marketing_builder_uses_hardcoded_default_when_env_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No context value, no env var → bundled docker/.env.example default."""
+    monkeypatch.delenv("LLM_MODEL", raising=False)
+    built = _builder("social_marketing")({"client_id": "c-1", "brand_id": "b-1"})
+    assert built.json["llm_model_name"] == "qwen3.5:397b-cloud"
+
+
 def test_sales_body_builder_decomposes_icp() -> None:
     built = _builder("sales_team")(
         {

--- a/user-interface/src/app/components/market-research-dashboard/market-research-dashboard.component.html
+++ b/user-interface/src/app/components/market-research-dashboard/market-research-dashboard.component.html
@@ -18,4 +18,16 @@
     ]"
     (workflowLaunched)="onWorkflowLaunched($event)"
   />
+  @if (lastResult) {
+    <section class="mr-result">
+      <header class="mr-result-header">
+        <h3>Research result</h3>
+        <button mat-stroked-button type="button" (click)="clearResult()">
+          <mat-icon>close</mat-icon>
+          Clear
+        </button>
+      </header>
+      <pre class="mr-result-body">{{ lastResultJson }}</pre>
+    </section>
+  }
 </app-dashboard-shell>

--- a/user-interface/src/app/components/market-research-dashboard/market-research-dashboard.component.ts
+++ b/user-interface/src/app/components/market-research-dashboard/market-research-dashboard.component.ts
@@ -1,4 +1,5 @@
 import { Component, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { MarketResearchApiService } from '../../services/market-research-api.service';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -9,6 +10,7 @@ import { DashboardShellComponent } from '../../shared/dashboard-shell/dashboard-
   selector: 'app-market-research-dashboard',
   standalone: true,
   imports: [
+    CommonModule,
     DashboardShellComponent,
     MatButtonModule,
     MatIconModule,
@@ -20,15 +22,33 @@ import { DashboardShellComponent } from '../../shared/dashboard-shell/dashboard-
 export class MarketResearchDashboardComponent {
   private readonly api = inject(MarketResearchApiService);
 
-  /** Last-launched result payload — Market Research returns synchronously. */
+  /** Last-launched result payload. Market Research is synchronous — the
+   * upstream body is the ``TeamOutput`` returned inline by /market-research/run. */
   lastResult: Record<string, unknown> | null = null;
+  /** Pretty-printed JSON for display; derived from ``lastResult``. */
+  lastResultJson = '';
 
   healthCheck = (): ReturnType<MarketResearchApiService['health']> =>
     this.api.health();
 
-  onWorkflowLaunched(event: { job_id: string | null; conversation_id: string }): void {
-    // Market Research is synchronous; the upstream body carries the results.
-    // `job_id` is always null for this team — documented in the assistant config.
-    void event;
+  onWorkflowLaunched(event: {
+    job_id: string | null;
+    conversation_id: string;
+    upstream_status: number;
+    upstream_body: Record<string, unknown>;
+  }): void {
+    // Market Research returns its TeamOutput inline with no job_id. Surface
+    // the body so the run isn't invisible to the user.
+    this.lastResult = event.upstream_body;
+    try {
+      this.lastResultJson = JSON.stringify(event.upstream_body, null, 2);
+    } catch {
+      this.lastResultJson = String(event.upstream_body);
+    }
+  }
+
+  clearResult(): void {
+    this.lastResult = null;
+    this.lastResultJson = '';
   }
 }

--- a/user-interface/src/app/components/social-marketing-dashboard/social-marketing-dashboard.component.html
+++ b/user-interface/src/app/components/social-marketing-dashboard/social-marketing-dashboard.component.html
@@ -12,7 +12,8 @@
       {key: 'brand_id', label: 'Brand ID', placeholder: 'Brand identifier from the branding team', required: true},
       {key: 'goals', label: 'Campaign goals', placeholder: 'e.g. engagement, follower growth'},
       {key: 'cadence_posts_per_day', label: 'Posts per day', placeholder: 'Number of posts per day'},
-      {key: 'duration_days', label: 'Duration (days)', placeholder: 'Campaign length in days'}
+      {key: 'duration_days', label: 'Duration (days)', placeholder: 'Campaign length in days'},
+      {key: 'llm_model_name', label: 'LLM model', placeholder: 'Override the LLM_MODEL env default'}
     ]"
     (workflowLaunched)="onWorkflowLaunched($event)"
   />

--- a/user-interface/src/app/components/team-assistant-chat/team-assistant-chat.component.ts
+++ b/user-interface/src/app/components/team-assistant-chat/team-assistant-chat.component.ts
@@ -53,10 +53,19 @@ export class TeamAssistantChatComponent implements OnInit, OnChanges, AfterViewC
   /** Hide the "Launch workflow" button entirely (teams with no runnable workflow). */
   @Input() hideLaunchButton = false;
 
-  /** Emitted after the backend launch completes. */
+  /**
+   * Emitted after the backend launch completes. For async teams, consumers
+   * typically read ``job_id`` and navigate to a jobs view. For synchronous
+   * teams (market_research, branding, nutrition, deepthought, road_trip,
+   * agentic_team_provisioning, investment), ``job_id`` is ``null`` and the
+   * actual results are carried in ``upstream_body`` — dashboards that
+   * embed a sync team should read that directly.
+   */
   @Output() workflowLaunched = new EventEmitter<{
     job_id: string | null;
     conversation_id: string;
+    upstream_status: number;
+    upstream_body: Record<string, unknown>;
   }>();
   /** Emitted when a conversation is loaded/created, so parent can track the ID. */
   @Output() conversationLoaded = new EventEmitter<string>();
@@ -120,6 +129,8 @@ export class TeamAssistantChatComponent implements OnInit, OnChanges, AfterViewC
         this.workflowLaunched.emit({
           job_id: r.job_id,
           conversation_id: r.conversation_id,
+          upstream_status: r.upstream_status,
+          upstream_body: r.upstream_body,
         });
       },
       error: (err) => {


### PR DESCRIPTION
Follow-up to #238 — the PR was merged before these two Codex review fixes landed, so this PR re-opens them against `main`.

## Summary

**P1 — social_marketing launch would 422 before a job was created.** `RunMarketingTeamRequest.llm_model_name` is required, but the declarative launch_spec in #238 never set it. Replaced with `_social_marketing_body_builder` that resolves `llm_model_name` in priority order: conversation context → `LLM_MODEL` env var → `qwen3.5:397b-cloud` (docker/.env.example default). Exposed the field in `optional_fields` and the `social-marketing-dashboard` `[fields]` so a user can override it.

**P2 — market_research Launch button looked like a no-op.** Market Research is synchronous — it returns its `TeamOutput` inline rather than queuing a job. The dashboard's `onWorkflowLaunched` handler discarded the event, so a successful run left no visible trace. Extended the shared `team-assistant-chat` `workflowLaunched` `EventEmitter` to also carry `upstream_status` + `upstream_body`, then wired the market-research dashboard to pretty-print the returned `TeamOutput` in a dismissible panel. Same pattern is now available to every synchronous team.

## Test plan

- [x] `python3 -m pytest backend/agents/team_assistant/tests/ -q` — 42 passed (up from 38 on main)
- [x] `python3 -m ruff check backend/agents/team_assistant/` — clean
- [x] `tsc --noEmit -p tsconfig.app.json` — clean
- [x] `vitest run src/app/components/market-research-dashboard src/app/components/social-marketing-dashboard src/app/components/team-assistant-chat src/app/services` — 59 passed
- [ ] Manual smoke: open `/social-marketing`, fill in client_id + brand_id, click Launch — POST `/api/social-marketing/social-marketing/run` fires with `llm_model_name` set (422 no longer returned).
- [ ] Manual smoke: open `/market-research`, fill in product_concept + target_users + business_goal, click Launch — the `TeamOutput` JSON appears in a result panel below the chat.

## Codex threads addressed

- https://github.com/brandonkindred/Khala-Agentic-AI-Teams/pull/238#discussion_r3107417411 (P1)
- https://github.com/brandonkindred/Khala-Agentic-AI-Teams/pull/238#discussion_r3107417413 (P2)

https://claude.ai/code/session_01G6juZAyXxhqzcdVniMJtAB