### PR TITLE
Address PR #271 review comments for issue #247

### DIFF
--- a/backend/agents/investment_team/execution/regimes.py
+++ b/backend/agents/investment_team/execution/regimes.py
@@ -72,7 +72,10 @@ def realized_vol_quartile_subwindows(
     downstream consumers can iterate a fixed schema.
     """
     n = len(returns)
-    if n <= window:
+    # Index ``window-1`` is the first position whose trailing slice is fully
+    # populated, so we need ``n >= window`` — not ``n > window`` — before
+    # classifying anything.
+    if n < window:
         return [(label, []) for label in REGIME_LABELS]
 
     rolling = _rolling_std(returns, window=window)
@@ -122,9 +125,10 @@ def vix_quartile_subwindows(
     if len(vix_levels) != len(dates):
         raise ValueError(f"vix_provider returned {len(vix_levels)} values, expected {len(dates)}")
     # Match realized-vol semantics: the first ``window-1`` indices are
-    # unassigned (equivalent to "insufficient prior data" in the RV path).
+    # unassigned (equivalent to "insufficient prior data" in the RV path),
+    # but index ``window-1`` itself is classifiable when ``n >= window``.
     n = len(vix_levels)
-    if n <= window:
+    if n < window:
         return [(label, []) for label in REGIME_LABELS]
 
     populated_slice = vix_levels[window - 1 :]

--- a/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
@@ -98,21 +98,26 @@ class BacktestAnomalyDetector:
             )
 
         # 5b. Sharpe ratio thresholds.
-        # Issue #247: DSR (on walk-forward OOS) is now the authoritative
-        # overfitting signal, applied by AcceptanceGate. The raw-Sharpe bands
-        # remain as a cheap warning-level sanity check for single-window paths
-        # and legacy callers that don't populate deflated_sharpe.
+        # Issue #247: the walk-forward + AcceptanceGate + DSR gate is the
+        # eventual authoritative overfitting check, but until it is wired
+        # into StrategyLabOrchestrator (step 8), the orchestrator only
+        # refines/rejects on ``severity == "critical"`` gate failures. Keep
+        # Sharpe > 5.0 at critical severity so clearly-overfit strategies
+        # still trigger refinement on the single-window path; the Sharpe > 3
+        # band remains a warning. Once AcceptanceGate is invoked from the
+        # orchestrator this gate can be revisited.
         if metrics.sharpe_ratio > 5.0:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
                     passed=False,
-                    severity="warning",
+                    severity="critical",
                     details=(
                         f"Sharpe ratio {metrics.sharpe_ratio:.2f} exceeds 5.0 — "
-                        "possible look-ahead bias or calculation artifact. "
-                        "When available, AcceptanceGate's OOS Deflated Sharpe "
-                        "is the authoritative overfitting check."
+                        "almost certainly indicates look-ahead bias or a "
+                        "calculation artifact. When walk-forward is available, "
+                        "AcceptanceGate's OOS Deflated Sharpe is the more "
+                        "precise overfitting check."
                     ),
                 )
             )

--- a/backend/agents/investment_team/tests/test_regimes.py
+++ b/backend/agents/investment_team/tests/test_regimes.py
@@ -42,10 +42,20 @@ def test_realized_vol_buckets_partition_eligible_indices():
     assert len(all_idx) == 252 - 20
 
 
-def test_realized_vol_empty_bucket_list_when_series_too_short():
+def test_realized_vol_empty_bucket_list_when_series_shorter_than_window():
     subs = realized_vol_quartile_subwindows([0.01, 0.02, 0.03], window=21)
     assert [label for label, _ in subs] == list(REGIME_LABELS)
     assert all(len(idx) == 0 for _, idx in subs)
+
+
+def test_realized_vol_classifies_minimum_valid_window():
+    # A series of exactly ``window`` observations has one fully-populated
+    # trailing-std value at index ``window-1``. The regime classifier must
+    # assign that index rather than dropping it (PR #271 review: off-by-one).
+    returns = [0.01 * i for i in range(21)]
+    subs = dict(realized_vol_quartile_subwindows(returns, window=21))
+    all_idx = sorted(i for idx in subs.values() for i in idx)
+    assert all_idx == [20]
 
 
 def test_realized_vol_calmer_regime_gets_lower_bucket():
@@ -92,6 +102,18 @@ def test_vix_quartile_uses_provider_output():
     assert max(subs["vix_q4"]) == 99
     # Lowest quartile should contain the earliest eligible indices.
     assert min(subs["vix_q1"]) == 20
+
+
+def test_vix_quartile_classifies_minimum_valid_window():
+    # Same off-by-one fix applies to the VIX path.
+    dates = [date(2022, 1, 3) + timedelta(days=i) for i in range(21)]
+
+    def provider(ds):
+        return [float(i) for i in range(len(ds))]
+
+    subs = dict(vix_quartile_subwindows(dates, [0.0] * 21, vix_provider=provider, window=21))
+    all_idx = sorted(i for idx in subs.values() for i in idx)
+    assert all_idx == [20]
 
 
 def test_vix_provider_length_mismatch_raises():


### PR DESCRIPTION
Addresses the two Codex review comments that landed on #271 after that PR was merged.

## Summary

- **P1** (`backtest_anomaly.py`): restore `severity="critical"` on the Sharpe > 5 anomaly. `StrategyLabOrchestrator` only refines/rejects on `severity=="critical"` gate failures, and `AcceptanceGate` (the DSR check) isn't invoked from the orchestrator yet (that's step 8 of #247). Downgrading to `"warning"` removed the only blocking overfitting check on the single-window path — a regression until walk-forward wiring ships.
- **P2** (`regimes.py`): fix off-by-one in the window-length guard. `n <= window` rejected `n == window` series from classification, but index `window-1` has a fully populated trailing slice and should be classifiable. Changed to `n < window` in both `realized_vol_quartile_subwindows` and `vix_quartile_subwindows`; added boundary tests.

Original review comments:
- https://github.com/brandonkindred/Khala-Agentic-AI-Teams/pull/271#discussion_r3120803591
- https://github.com/brandonkindred/Khala-Agentic-AI-Teams/pull/271#discussion_r3120803594

## Test plan

- [x] `pytest agents/investment_team/tests/test_regimes.py` — 17 tests (2 new boundary-case tests added)
- [x] `pytest agents/investment_team/tests/test_acceptance_gate.py` — 11 tests
- [x] Full issue #247 test set (walk-forward, DSR, tracker, regimes, acceptance gate, golden snapshots) — 135 tests pass
- [x] `ruff check` + `ruff format --check` clean

https://claude.ai/code/session_01VRbDWnzjKEmVms2b8FopEu