### PR TITLE
Sandbox Phase 2: agent-keyed lifecycle in agent_provisioning_team (#264)

### DIFF
--- a/backend/agents/agent_provisioning_team/sandbox/__init__.py
+++ b/backend/agents/agent_provisioning_team/sandbox/__init__.py
@@ -1,0 +1,23 @@
+"""Agent-keyed sandbox lifecycle for ``agent_provisioning_team`` (issue #264).
+
+Runs the unified ``khala-agent-sandbox`` image from Phase 1 (#263) as one
+ephemeral, hardened container per specialist agent under test. The unified
+API and Agent Console switch to this module in Phase 3 (#265).
+"""
+
+from .lifecycle import Lifecycle, UnknownAgentError
+from .state import (
+    SandboxHandle,
+    SandboxState,
+    SandboxStatus,
+    state_file_path,
+)
+
+__all__ = [
+    "Lifecycle",
+    "SandboxHandle",
+    "SandboxState",
+    "SandboxStatus",
+    "UnknownAgentError",
+    "state_file_path",
+]

--- a/backend/agents/agent_provisioning_team/sandbox/lifecycle.py
+++ b/backend/agents/agent_provisioning_team/sandbox/lifecycle.py
@@ -125,7 +125,13 @@ class Lifecycle:
                 return SandboxHandle.from_state(st)
 
     async def teardown(self, agent_id: str) -> None:
-        """Explicitly stop the sandbox for ``agent_id`` and evict from state."""
+        """Explicitly stop the sandbox for ``agent_id`` and evict from state.
+
+        State is only evicted after Docker confirms the container is gone:
+        ``stop_container`` raises :class:`DockerError` for real failures
+        (e.g. daemon unreachable), which we propagate so the caller (or the
+        reaper's next tick) can retry against a sandbox that is still alive.
+        """
         lock = self._locks.setdefault(agent_id, asyncio.Lock())
         async with lock:
             st = self._state.get(agent_id)
@@ -133,10 +139,7 @@ class Lifecycle:
                 return
             logger.info("Tearing down sandbox for %s", agent_id)
             if st.container_id:
-                try:
-                    await provisioner_mod.stop_container(st.container_id)
-                except provisioner_mod.DockerError as exc:
-                    logger.warning("teardown for %s reported non-zero: %s", agent_id, exc)
+                await provisioner_mod.stop_container(st.container_id)
             self._state.pop(agent_id, None)
             self._persist()
 
@@ -189,10 +192,15 @@ class Lifecycle:
             if st.status != SandboxStatus.WARM:
                 continue
             idle = (current - st.last_used_at).total_seconds()
-            if idle > threshold:
-                logger.info("Reaping idle sandbox %s (idle=%.0fs)", agent_id, idle)
+            if idle <= threshold:
+                continue
+            logger.info("Reaping idle sandbox %s (idle=%.0fs)", agent_id, idle)
+            try:
                 await self.teardown(agent_id)
-                torn_down.append(agent_id)
+            except provisioner_mod.DockerError:
+                logger.exception("Teardown failed for %s; will retry next tick", agent_id)
+                continue
+            torn_down.append(agent_id)
         return torn_down
 
     # ------------------------------------------------------------------

--- a/backend/agents/agent_provisioning_team/sandbox/lifecycle.py
+++ b/backend/agents/agent_provisioning_team/sandbox/lifecycle.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, timezone
 from pathlib import Path
 
 import httpx
@@ -90,7 +89,7 @@ class Lifecycle:
                 if await provisioner_mod.is_running(existing.container_id):
                     existing.last_used_at = now()
                     self._persist()
-                    return self._handle(existing)
+                    return SandboxHandle.from_state(existing)
                 logger.info(
                     "Sandbox for %s marked WARM but container %s is gone; re-provisioning",
                     agent_id,
@@ -98,14 +97,13 @@ class Lifecycle:
                 )
 
             container_name = provisioner_mod.container_name_for(agent_id)
-            # Sweep away any zombie container from a prior run that died before
-            # we could update state. Safe: `stop_container` is idempotent.
-            await self._best_effort_reap(container_name)
+            # Sweep any zombie container from a prior run. `docker rm -f` is
+            # idempotent against missing containers; timeouts are surfaced.
+            await provisioner_mod.stop_container(container_name)
 
             logger.info("Provisioning sandbox for %s (container %s)", agent_id, container_name)
             st = state_mod.new_state(agent_id=agent_id, team=team, container_name=container_name)
             self._state[agent_id] = st
-            self._persist()
 
             try:
                 container_id = await provisioner_mod.run_container(
@@ -114,27 +112,17 @@ class Lifecycle:
                 host_port = await provisioner_mod.inspect_host_port(container_id)
                 st.container_id = container_id
                 st.host_port = host_port
-                self._persist()
                 await self._wait_healthy(host_port)
                 st.status = SandboxStatus.WARM
-                st.error = None
                 st.last_used_at = now()
                 self._persist()
-                return self._handle(st)
+                return SandboxHandle.from_state(st)
             except Exception as exc:
                 logger.exception("Sandbox provisioning failed for %s", agent_id)
                 st.status = SandboxStatus.ERROR
                 st.error = str(exc)
                 self._persist()
-                return self._handle(st)
-
-    async def release(self, agent_id: str) -> None:
-        """Mark the sandbox as idle-eligible. Does not tear down — the reaper decides."""
-        st = self._state.get(agent_id)
-        if st is None:
-            return
-        st.last_used_at = now()
-        self._persist()
+                return SandboxHandle.from_state(st)
 
     async def teardown(self, agent_id: str) -> None:
         """Explicitly stop the sandbox for ``agent_id`` and evict from state."""
@@ -154,7 +142,7 @@ class Lifecycle:
 
     async def list_active(self) -> list[SandboxHandle]:
         """Return a handle for every sandbox currently tracked in state."""
-        return [self._handle(st) for st in list(self._state.values())]
+        return [SandboxHandle.from_state(st) for st in list(self._state.values())]
 
     async def note_activity(self, agent_id: str) -> None:
         """Bump ``last_used_at`` for ``agent_id``. Called after a successful invoke."""
@@ -231,36 +219,6 @@ class Lifecycle:
                     pass
                 await asyncio.sleep(backoff)
                 backoff = min(backoff * 1.5, 5.0)
-
-    async def _best_effort_reap(self, container_name: str) -> None:
-        """If a container with ``container_name`` exists from a prior run, remove it."""
-        try:
-            await provisioner_mod.stop_container(container_name)
-        except provisioner_mod.DockerError as exc:
-            logger.debug(
-                "best-effort reap of %s failed (likely already gone): %s", container_name, exc
-            )
-
-    def _handle(self, st: SandboxState) -> SandboxHandle:
-        idle = None
-        if st.last_used_at is not None:
-            idle = int((datetime.now(timezone.utc) - st.last_used_at).total_seconds())
-        url = None
-        if st.status == SandboxStatus.WARM and st.host_port is not None:
-            url = f"http://127.0.0.1:{st.host_port}"
-        return SandboxHandle(
-            agent_id=st.agent_id,
-            team=st.team,
-            status=st.status,
-            url=url,
-            container_name=st.container_name,
-            container_id=st.container_id,
-            host_port=st.host_port,
-            created_at=st.created_at,
-            last_used_at=st.last_used_at,
-            idle_seconds=idle,
-            error=st.error,
-        )
 
     def _persist(self) -> None:
         try:

--- a/backend/agents/agent_provisioning_team/sandbox/lifecycle.py
+++ b/backend/agents/agent_provisioning_team/sandbox/lifecycle.py
@@ -1,12 +1,17 @@
 """Per-agent sandbox lifecycle owner (issue #264, Phase 2).
 
-State machine per ``agent_id``::
+State machine per ``agent_id``:
 
-    COLD ──(acquire)──► WARMING ──(health OK)──► WARM
-                           │                       │
-                           │                       └──(teardown / idle)──► COLD
-                           │
-                           └──(run/health fail)────► ERROR ──► COLD
+.. mermaid::
+
+    stateDiagram-v2
+        [*] --> COLD
+        COLD --> WARMING: acquire
+        WARMING --> WARM: health OK
+        WARMING --> ERROR: run / health fail
+        WARM --> COLD: teardown / idle reap
+        ERROR --> COLD: teardown
+        COLD --> [*]
 
 Provisions the unified ``khala-agent-sandbox`` image from Phase 1 (#263) one
 container per specialist agent. Blocks Phases 3–5. Replaces — in parallel,

--- a/backend/agents/agent_provisioning_team/sandbox/lifecycle.py
+++ b/backend/agents/agent_provisioning_team/sandbox/lifecycle.py
@@ -1,0 +1,264 @@
+"""Per-agent sandbox lifecycle owner (issue #264, Phase 2).
+
+State machine per ``agent_id``::
+
+    COLD ──(acquire)──► WARMING ──(health OK)──► WARM
+                           │                       │
+                           │                       └──(teardown / idle)──► COLD
+                           │
+                           └──(run/health fail)────► ERROR ──► COLD
+
+Provisions the unified ``khala-agent-sandbox`` image from Phase 1 (#263) one
+container per specialist agent. Blocks Phases 3–5. Replaces — in parallel,
+without deleting — the per-team state machine in ``backend/agents/agent_sandbox``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+
+import httpx
+
+from . import provisioner as provisioner_mod
+from . import state as state_mod
+from .state import (
+    SandboxHandle,
+    SandboxState,
+    SandboxStatus,
+    boot_timeout_seconds,
+    idle_teardown_seconds,
+    now,
+    state_file_path,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class UnknownAgentError(ValueError):
+    """Raised when the requested ``agent_id`` has no manifest in the registry."""
+
+
+def _resolve_team(agent_id: str) -> str:
+    """Look up the agent's team via :mod:`agent_registry`.
+
+    Wrapped so tests can patch it without importing the whole registry.
+    """
+    from agent_registry import get_registry
+
+    manifest = get_registry().get(agent_id)
+    if manifest is None:
+        raise UnknownAgentError(f"No agent manifest for {agent_id!r}")
+    return manifest.team
+
+
+class Lifecycle:
+    """Per-process owner of agent-keyed sandboxes.
+
+    Mirrors the public shape of ``agent_sandbox.manager.SandboxManager`` but
+    rekeyed by ``agent_id`` and talking to ``docker run`` / ``docker inspect``
+    directly (Phase 2), not ``docker compose`` (legacy per-team path).
+    """
+
+    def __init__(self, *, state_file: Path | None = None) -> None:
+        self._state_file = state_file or state_file_path()
+        self._state: dict[str, SandboxState] = state_mod.load(self._state_file)
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def acquire(self, agent_id: str) -> SandboxHandle:
+        """Idempotently bring the sandbox for ``agent_id`` to WARM.
+
+        Raises :class:`UnknownAgentError` if the registry has no entry for
+        ``agent_id``.
+        """
+        team = _resolve_team(agent_id)
+        lock = self._locks.setdefault(agent_id, asyncio.Lock())
+        async with lock:
+            existing = self._state.get(agent_id)
+            if existing and existing.status == SandboxStatus.WARM and existing.container_id:
+                if await provisioner_mod.is_running(existing.container_id):
+                    existing.last_used_at = now()
+                    self._persist()
+                    return self._handle(existing)
+                logger.info(
+                    "Sandbox for %s marked WARM but container %s is gone; re-provisioning",
+                    agent_id,
+                    existing.container_id,
+                )
+
+            container_name = provisioner_mod.container_name_for(agent_id)
+            # Sweep away any zombie container from a prior run that died before
+            # we could update state. Safe: `stop_container` is idempotent.
+            await self._best_effort_reap(container_name)
+
+            logger.info("Provisioning sandbox for %s (container %s)", agent_id, container_name)
+            st = state_mod.new_state(agent_id=agent_id, team=team, container_name=container_name)
+            self._state[agent_id] = st
+            self._persist()
+
+            try:
+                container_id = await provisioner_mod.run_container(
+                    agent_id=agent_id, container_name=container_name
+                )
+                host_port = await provisioner_mod.inspect_host_port(container_id)
+                st.container_id = container_id
+                st.host_port = host_port
+                self._persist()
+                await self._wait_healthy(host_port)
+                st.status = SandboxStatus.WARM
+                st.error = None
+                st.last_used_at = now()
+                self._persist()
+                return self._handle(st)
+            except Exception as exc:
+                logger.exception("Sandbox provisioning failed for %s", agent_id)
+                st.status = SandboxStatus.ERROR
+                st.error = str(exc)
+                self._persist()
+                return self._handle(st)
+
+    async def release(self, agent_id: str) -> None:
+        """Mark the sandbox as idle-eligible. Does not tear down — the reaper decides."""
+        st = self._state.get(agent_id)
+        if st is None:
+            return
+        st.last_used_at = now()
+        self._persist()
+
+    async def teardown(self, agent_id: str) -> None:
+        """Explicitly stop the sandbox for ``agent_id`` and evict from state."""
+        lock = self._locks.setdefault(agent_id, asyncio.Lock())
+        async with lock:
+            st = self._state.get(agent_id)
+            if st is None:
+                return
+            logger.info("Tearing down sandbox for %s", agent_id)
+            if st.container_id:
+                try:
+                    await provisioner_mod.stop_container(st.container_id)
+                except provisioner_mod.DockerError as exc:
+                    logger.warning("teardown for %s reported non-zero: %s", agent_id, exc)
+            self._state.pop(agent_id, None)
+            self._persist()
+
+    async def list_active(self) -> list[SandboxHandle]:
+        """Return a handle for every sandbox currently tracked in state."""
+        return [self._handle(st) for st in list(self._state.values())]
+
+    async def note_activity(self, agent_id: str) -> None:
+        """Bump ``last_used_at`` for ``agent_id``. Called after a successful invoke."""
+        st = self._state.get(agent_id)
+        if st is None:
+            return
+        st.last_used_at = now()
+        self._persist()
+
+    # ------------------------------------------------------------------
+    # Idle reaper
+    # ------------------------------------------------------------------
+
+    async def run_idle_reaper(self, *, interval_s: int = 60) -> None:
+        """Background loop: tear down sandboxes idle for more than the threshold.
+
+        Threshold is :func:`state.idle_teardown_seconds` (default 5 min, env
+        ``AGENT_PROVISIONING_SANDBOX_IDLE_MINUTES``). Loop is cancellable.
+        """
+        threshold = idle_teardown_seconds()
+        logger.info(
+            "Agent sandbox idle reaper started (threshold %ds, check every %ds)",
+            threshold,
+            interval_s,
+        )
+        while True:
+            try:
+                await asyncio.sleep(interval_s)
+                await self.reap_once(threshold=threshold)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("idle reaper iteration failed; continuing")
+
+    async def reap_once(self, *, threshold: int) -> list[str]:
+        """Tear down every WARM sandbox idle longer than ``threshold`` seconds.
+
+        Returns the list of torn-down ``agent_id``s so callers (and tests) can
+        observe the effect without waiting a full reap interval.
+        """
+        torn_down: list[str] = []
+        current = now()
+        for agent_id, st in list(self._state.items()):
+            if st.status != SandboxStatus.WARM:
+                continue
+            idle = (current - st.last_used_at).total_seconds()
+            if idle > threshold:
+                logger.info("Reaping idle sandbox %s (idle=%.0fs)", agent_id, idle)
+                await self.teardown(agent_id)
+                torn_down.append(agent_id)
+        return torn_down
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    async def _wait_healthy(self, host_port: int) -> None:
+        deadline = boot_timeout_seconds()
+        url = f"http://127.0.0.1:{host_port}/health"
+        start = asyncio.get_event_loop().time()
+        backoff = 1.0
+        async with httpx.AsyncClient(timeout=httpx.Timeout(5.0)) as client:
+            while True:
+                elapsed = asyncio.get_event_loop().time() - start
+                if elapsed > deadline:
+                    raise RuntimeError(
+                        f"Sandbox on port {host_port} did not report healthy within {deadline}s"
+                    )
+                try:
+                    resp = await client.get(url)
+                    if resp.status_code == 200:
+                        return
+                except httpx.HTTPError:
+                    pass
+                await asyncio.sleep(backoff)
+                backoff = min(backoff * 1.5, 5.0)
+
+    async def _best_effort_reap(self, container_name: str) -> None:
+        """If a container with ``container_name`` exists from a prior run, remove it."""
+        try:
+            await provisioner_mod.stop_container(container_name)
+        except provisioner_mod.DockerError as exc:
+            logger.debug(
+                "best-effort reap of %s failed (likely already gone): %s", container_name, exc
+            )
+
+    def _handle(self, st: SandboxState) -> SandboxHandle:
+        idle = None
+        if st.last_used_at is not None:
+            idle = int((datetime.now(timezone.utc) - st.last_used_at).total_seconds())
+        url = None
+        if st.status == SandboxStatus.WARM and st.host_port is not None:
+            url = f"http://127.0.0.1:{st.host_port}"
+        return SandboxHandle(
+            agent_id=st.agent_id,
+            team=st.team,
+            status=st.status,
+            url=url,
+            container_name=st.container_name,
+            container_id=st.container_id,
+            host_port=st.host_port,
+            created_at=st.created_at,
+            last_used_at=st.last_used_at,
+            idle_seconds=idle,
+            error=st.error,
+        )
+
+    def _persist(self) -> None:
+        try:
+            state_mod.save(self._state_file, self._state)
+        except OSError as exc:
+            logger.warning("Could not persist sandbox state: %s", exc)

--- a/backend/agents/agent_provisioning_team/sandbox/provisioner.py
+++ b/backend/agents/agent_provisioning_team/sandbox/provisioner.py
@@ -15,6 +15,7 @@ unchanged for the non-sandbox provisioning path.
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 import os
 import re
@@ -51,14 +52,18 @@ def _fail(argv: list[str], rc: int, stderr: str) -> DockerError:
 
 
 def container_name_for(agent_id: str) -> str:
-    """Deterministic, DNS-safe container name for ``agent_id``.
+    """Deterministic, DNS-safe, collision-resistant container name for ``agent_id``.
 
-    Docker requires ``[a-zA-Z0-9][a-zA-Z0-9_.-]*`` — dots in agent ids like
-    ``blogging.planner`` are fine, but any other non-[A-Za-z0-9_.-] char is
-    replaced with ``-``.
+    Docker requires ``[a-zA-Z0-9][a-zA-Z0-9_.-]*``. The readable prefix is the
+    sanitised agent id (truncated); the 8-char sha1 suffix keeps the mapping
+    one-to-one so two ids that happen to sanitise the same way (e.g.
+    ``agent/1`` vs ``agent-1``) still get distinct container names — the
+    acquire-time zombie reap would otherwise tear down a sibling's live
+    container.
     """
-    safe = _CONTAINER_NAME_RE.sub("-", agent_id).strip("-")
-    return f"khala-sbx-{safe or 'agent'}"
+    safe = (_CONTAINER_NAME_RE.sub("-", agent_id).strip("-") or "agent")[:40]
+    digest = hashlib.sha1(agent_id.encode("utf-8")).hexdigest()[:8]
+    return f"khala-sbx-{safe}-{digest}"
 
 
 async def _exec(cmd: list[str], *, timeout_s: int = 30) -> tuple[int, str, str]:
@@ -175,9 +180,18 @@ async def is_running(container_id: str) -> bool:
 
 
 async def stop_container(container_id: str) -> None:
-    """Stop and remove ``container_id``. Idempotent; missing container is not an error.
+    """Stop and remove ``container_id``.
 
     ``docker rm -f`` stops running containers before removing them, so a single
-    call covers both the happy path and the zombie-container case.
+    call covers both the happy path and the zombie-container case. Missing
+    containers are treated as idempotent success; any other non-zero exit
+    (daemon unreachable, permissions, etc.) raises :class:`DockerError` so
+    callers don't silently evict state while the container is still alive.
     """
-    await _exec(["docker", "rm", "-f", container_id])
+    argv = ["docker", "rm", "-f", container_id]
+    rc, _, stderr = await _exec(argv)
+    if rc == 0:
+        return
+    if "no such container" in stderr.lower():
+        return
+    raise _fail(argv, rc, stderr)

--- a/backend/agents/agent_provisioning_team/sandbox/provisioner.py
+++ b/backend/agents/agent_provisioning_team/sandbox/provisioner.py
@@ -23,11 +23,9 @@ from .state import sandbox_image, sandbox_network
 
 logger = logging.getLogger(__name__)
 
-# Environment variables forwarded from the host into the sandbox container so
-# the loaded agent can reach Postgres / the LLM service the same way the
-# unified API does. Any secret listed here is readable inside the sandbox, so
-# this list is intentionally narrow. (Sandbox secret isolation is #257 — a
-# follow-up that splits secrets by agent/team.)
+# Host env vars forwarded into the sandbox so the loaded agent can reach
+# Postgres / the LLM service. Intentionally narrow — sandbox secret isolation
+# is #257.
 _FORWARDED_ENV = (
     "POSTGRES_HOST",
     "POSTGRES_PORT",
@@ -43,19 +41,13 @@ _FORWARDED_ENV = (
 
 _CONTAINER_NAME_RE = re.compile(r"[^a-zA-Z0-9_.-]+")
 
-_DOCKER_RUN_TIMEOUT_S = 60
-_DOCKER_INSPECT_TIMEOUT_S = 15
-_DOCKER_STOP_TIMEOUT_S = 30
-
 
 class DockerError(RuntimeError):
     """Raised when a docker CLI invocation exits non-zero."""
 
-    def __init__(self, command: list[str], exit_code: int, stderr: str) -> None:
-        self.command = command
-        self.exit_code = exit_code
-        self.stderr = stderr
-        super().__init__(f"docker failed (exit {exit_code}): {' '.join(command)}\n{stderr[:500]}")
+
+def _fail(argv: list[str], rc: int, stderr: str) -> DockerError:
+    return DockerError(f"docker failed (exit {rc}): {' '.join(argv)}\n{stderr[:500]}")
 
 
 def container_name_for(agent_id: str) -> str:
@@ -69,7 +61,7 @@ def container_name_for(agent_id: str) -> str:
     return f"khala-sbx-{safe or 'agent'}"
 
 
-async def _exec(cmd: list[str], *, timeout_s: int) -> tuple[int, str, str]:
+async def _exec(cmd: list[str], *, timeout_s: int = 30) -> tuple[int, str, str]:
     logger.debug("exec: %s", " ".join(cmd))
     proc = await asyncio.create_subprocess_exec(
         *cmd,
@@ -81,7 +73,7 @@ async def _exec(cmd: list[str], *, timeout_s: int) -> tuple[int, str, str]:
     except asyncio.TimeoutError:
         proc.kill()
         await proc.wait()
-        raise DockerError(cmd, -1, f"command timed out after {timeout_s}s") from None
+        raise DockerError(f"docker timed out after {timeout_s}s: {' '.join(cmd)}") from None
     return (
         proc.returncode or 0,
         stdout_b.decode("utf-8", errors="replace"),
@@ -106,10 +98,9 @@ def _build_run_argv(*, agent_id: str, container_name: str) -> list[str]:
         container_name,
         "--network",
         sandbox_network(),
-        # Publish only on loopback, Docker picks a free host port.
+        # `127.0.0.1::8090` binds to loopback only; Docker picks a free host port.
         "-p",
         "127.0.0.1::8090",
-        # Resource caps (#255).
         "--cpus=1.0",
         "--memory=1g",
         "--pids-limit=512",
@@ -117,17 +108,15 @@ def _build_run_argv(*, agent_id: str, container_name: str) -> list[str]:
         "nproc=1024",
         "--ulimit",
         "nofile=4096",
-        # Capability + syscall hardening (#255).
         "--security-opt=no-new-privileges:true",
         "--security-opt=seccomp=default",
         "--cap-drop=ALL",
-        # Read-only rootfs with tmpfs for the few paths the runtime writes.
         "--read-only",
         "--tmpfs",
         "/tmp",
         "--tmpfs",
         "/run",
-        # Which agent this sandbox is bound to (enforced by Phase 1 entrypoint).
+        # Phase 1 entrypoint binds the sandbox to exactly this agent id.
         "-e",
         f"SANDBOX_AGENT_ID={agent_id}",
     ]
@@ -147,12 +136,12 @@ async def run_container(agent_id: str, container_name: str) -> str:
     the container, not when uvicorn is listening.
     """
     argv = _build_run_argv(agent_id=agent_id, container_name=container_name)
-    rc, stdout, stderr = await _exec(argv, timeout_s=_DOCKER_RUN_TIMEOUT_S)
+    rc, stdout, stderr = await _exec(argv, timeout_s=60)
     if rc != 0:
-        raise DockerError(argv, rc, stderr or stdout)
-    container_id = stdout.strip().splitlines()[-1].strip() if stdout.strip() else ""
+        raise _fail(argv, rc, stderr or stdout)
+    container_id = stdout.strip()
     if not container_id:
-        raise DockerError(argv, rc, "docker run succeeded but printed no container id")
+        raise _fail(argv, rc, "docker run printed no container id")
     return container_id
 
 
@@ -165,12 +154,12 @@ async def inspect_host_port(container_id: str) -> int:
         '{{ (index (index .NetworkSettings.Ports "8090/tcp") 0).HostPort }}',
         container_id,
     ]
-    rc, stdout, stderr = await _exec(argv, timeout_s=_DOCKER_INSPECT_TIMEOUT_S)
+    rc, stdout, stderr = await _exec(argv)
     if rc != 0:
-        raise DockerError(argv, rc, stderr or stdout)
+        raise _fail(argv, rc, stderr or stdout)
     port_str = stdout.strip()
-    if not port_str or not port_str.isdigit():
-        raise DockerError(argv, rc, f"could not parse host port from {stdout!r}")
+    if not port_str.isdigit():
+        raise _fail(argv, rc, f"could not parse host port from {stdout!r}")
     return int(port_str)
 
 
@@ -179,23 +168,16 @@ async def is_running(container_id: str) -> bool:
 
     Missing / removed containers return False (not an error).
     """
-    argv = ["docker", "inspect", "--format", "{{.State.Running}}", container_id]
-    rc, stdout, stderr = await _exec(argv, timeout_s=_DOCKER_INSPECT_TIMEOUT_S)
-    if rc != 0:
-        # `docker inspect` exits non-zero for unknown containers; treat as not running.
-        logger.debug("is_running(%s) → not found: %s", container_id, stderr.strip())
-        return False
-    return stdout.strip().lower() == "true"
+    rc, stdout, _ = await _exec(
+        ["docker", "inspect", "--format", "{{.State.Running}}", container_id],
+    )
+    return rc == 0 and stdout.strip().lower() == "true"
 
 
 async def stop_container(container_id: str) -> None:
-    """Stop and remove ``container_id``. Idempotent; missing container is not an error."""
-    # `docker stop` triggers `--rm` from `run_container`, but we also fire `rm -f`
-    # afterward in case the container was started without `--rm` or is already stopped.
-    stop_argv = ["docker", "stop", "-t", "5", container_id]
-    rc, _, stderr = await _exec(stop_argv, timeout_s=_DOCKER_STOP_TIMEOUT_S)
-    if rc != 0:
-        # If the container is already gone that's fine; surface other failures.
-        logger.debug("docker stop %s → rc=%d stderr=%s", container_id, rc, stderr.strip())
-    rm_argv = ["docker", "rm", "-f", container_id]
-    await _exec(rm_argv, timeout_s=_DOCKER_STOP_TIMEOUT_S)
+    """Stop and remove ``container_id``. Idempotent; missing container is not an error.
+
+    ``docker rm -f`` stops running containers before removing them, so a single
+    call covers both the happy path and the zombie-container case.
+    """
+    await _exec(["docker", "rm", "-f", container_id])

--- a/backend/agents/agent_provisioning_team/sandbox/provisioner.py
+++ b/backend/agents/agent_provisioning_team/sandbox/provisioner.py
@@ -1,0 +1,201 @@
+"""Thin asyncio wrapper around ``docker run``/``docker inspect``/``docker rm``.
+
+Module-level coroutines (not a class) so tests can patch them cleanly via
+``patch("agent_provisioning_team.sandbox.provisioner.run_container", ...)``.
+Mirrors the shape of ``agent_sandbox/compose.py`` but talks to ``docker``
+directly rather than ``docker compose`` — Phase 2 runs one ephemeral
+container per agent, not a long-lived compose service.
+
+The hardening flags from issue #255 (cap-drop, read-only, security-opt,
+resource caps, loopback-bound ports) are assembled here rather than in the
+shared ``tool_agents/docker_provisioner.py`` so the existing tool stays
+unchanged for the non-sandbox provisioning path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+
+from .state import sandbox_image, sandbox_network
+
+logger = logging.getLogger(__name__)
+
+# Environment variables forwarded from the host into the sandbox container so
+# the loaded agent can reach Postgres / the LLM service the same way the
+# unified API does. Any secret listed here is readable inside the sandbox, so
+# this list is intentionally narrow. (Sandbox secret isolation is #257 — a
+# follow-up that splits secrets by agent/team.)
+_FORWARDED_ENV = (
+    "POSTGRES_HOST",
+    "POSTGRES_PORT",
+    "POSTGRES_USER",
+    "POSTGRES_PASSWORD",
+    "POSTGRES_DB",
+    "LLM_PROVIDER",
+    "LLM_BASE_URL",
+    "LLM_MODEL",
+    "OLLAMA_API_KEY",
+    "ANTHROPIC_API_KEY",
+)
+
+_CONTAINER_NAME_RE = re.compile(r"[^a-zA-Z0-9_.-]+")
+
+_DOCKER_RUN_TIMEOUT_S = 60
+_DOCKER_INSPECT_TIMEOUT_S = 15
+_DOCKER_STOP_TIMEOUT_S = 30
+
+
+class DockerError(RuntimeError):
+    """Raised when a docker CLI invocation exits non-zero."""
+
+    def __init__(self, command: list[str], exit_code: int, stderr: str) -> None:
+        self.command = command
+        self.exit_code = exit_code
+        self.stderr = stderr
+        super().__init__(f"docker failed (exit {exit_code}): {' '.join(command)}\n{stderr[:500]}")
+
+
+def container_name_for(agent_id: str) -> str:
+    """Deterministic, DNS-safe container name for ``agent_id``.
+
+    Docker requires ``[a-zA-Z0-9][a-zA-Z0-9_.-]*`` — dots in agent ids like
+    ``blogging.planner`` are fine, but any other non-[A-Za-z0-9_.-] char is
+    replaced with ``-``.
+    """
+    safe = _CONTAINER_NAME_RE.sub("-", agent_id).strip("-")
+    return f"khala-sbx-{safe or 'agent'}"
+
+
+async def _exec(cmd: list[str], *, timeout_s: int) -> tuple[int, str, str]:
+    logger.debug("exec: %s", " ".join(cmd))
+    proc = await asyncio.create_subprocess_exec(
+        *cmd,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    try:
+        stdout_b, stderr_b = await asyncio.wait_for(proc.communicate(), timeout=timeout_s)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        raise DockerError(cmd, -1, f"command timed out after {timeout_s}s") from None
+    return (
+        proc.returncode or 0,
+        stdout_b.decode("utf-8", errors="replace"),
+        stderr_b.decode("utf-8", errors="replace"),
+    )
+
+
+def _build_run_argv(*, agent_id: str, container_name: str) -> list[str]:
+    """Assemble the hardened ``docker run`` argument vector for a sandbox.
+
+    Kept as a pure function so tests can assert on the exact flags without
+    invoking subprocess.
+    """
+    argv: list[str] = [
+        "docker",
+        "run",
+        "-d",
+        "--rm",
+        "--name",
+        container_name,
+        "--hostname",
+        container_name,
+        "--network",
+        sandbox_network(),
+        # Publish only on loopback, Docker picks a free host port.
+        "-p",
+        "127.0.0.1::8090",
+        # Resource caps (#255).
+        "--cpus=1.0",
+        "--memory=1g",
+        "--pids-limit=512",
+        "--ulimit",
+        "nproc=1024",
+        "--ulimit",
+        "nofile=4096",
+        # Capability + syscall hardening (#255).
+        "--security-opt=no-new-privileges:true",
+        "--security-opt=seccomp=default",
+        "--cap-drop=ALL",
+        # Read-only rootfs with tmpfs for the few paths the runtime writes.
+        "--read-only",
+        "--tmpfs",
+        "/tmp",
+        "--tmpfs",
+        "/run",
+        # Which agent this sandbox is bound to (enforced by Phase 1 entrypoint).
+        "-e",
+        f"SANDBOX_AGENT_ID={agent_id}",
+    ]
+    for key in _FORWARDED_ENV:
+        value = os.environ.get(key)
+        if value is not None:
+            argv.extend(["-e", f"{key}={value}"])
+    argv.append(sandbox_image())
+    return argv
+
+
+async def run_container(agent_id: str, container_name: str) -> str:
+    """Start a hardened sandbox for ``agent_id`` and return its container id.
+
+    Caller is responsible for polling ``/health`` before treating the sandbox
+    as ready — this coroutine returns as soon as the Docker daemon accepts
+    the container, not when uvicorn is listening.
+    """
+    argv = _build_run_argv(agent_id=agent_id, container_name=container_name)
+    rc, stdout, stderr = await _exec(argv, timeout_s=_DOCKER_RUN_TIMEOUT_S)
+    if rc != 0:
+        raise DockerError(argv, rc, stderr or stdout)
+    container_id = stdout.strip().splitlines()[-1].strip() if stdout.strip() else ""
+    if not container_id:
+        raise DockerError(argv, rc, "docker run succeeded but printed no container id")
+    return container_id
+
+
+async def inspect_host_port(container_id: str) -> int:
+    """Resolve the host-side loopback port that maps to the sandbox's ``8090/tcp``."""
+    argv = [
+        "docker",
+        "inspect",
+        "--format",
+        '{{ (index (index .NetworkSettings.Ports "8090/tcp") 0).HostPort }}',
+        container_id,
+    ]
+    rc, stdout, stderr = await _exec(argv, timeout_s=_DOCKER_INSPECT_TIMEOUT_S)
+    if rc != 0:
+        raise DockerError(argv, rc, stderr or stdout)
+    port_str = stdout.strip()
+    if not port_str or not port_str.isdigit():
+        raise DockerError(argv, rc, f"could not parse host port from {stdout!r}")
+    return int(port_str)
+
+
+async def is_running(container_id: str) -> bool:
+    """Return True iff ``docker inspect`` reports the container as running.
+
+    Missing / removed containers return False (not an error).
+    """
+    argv = ["docker", "inspect", "--format", "{{.State.Running}}", container_id]
+    rc, stdout, stderr = await _exec(argv, timeout_s=_DOCKER_INSPECT_TIMEOUT_S)
+    if rc != 0:
+        # `docker inspect` exits non-zero for unknown containers; treat as not running.
+        logger.debug("is_running(%s) → not found: %s", container_id, stderr.strip())
+        return False
+    return stdout.strip().lower() == "true"
+
+
+async def stop_container(container_id: str) -> None:
+    """Stop and remove ``container_id``. Idempotent; missing container is not an error."""
+    # `docker stop` triggers `--rm` from `run_container`, but we also fire `rm -f`
+    # afterward in case the container was started without `--rm` or is already stopped.
+    stop_argv = ["docker", "stop", "-t", "5", container_id]
+    rc, _, stderr = await _exec(stop_argv, timeout_s=_DOCKER_STOP_TIMEOUT_S)
+    if rc != 0:
+        # If the container is already gone that's fine; surface other failures.
+        logger.debug("docker stop %s → rc=%d stderr=%s", container_id, rc, stderr.strip())
+    rm_argv = ["docker", "rm", "-f", container_id]
+    await _exec(rm_argv, timeout_s=_DOCKER_STOP_TIMEOUT_S)

--- a/backend/agents/agent_provisioning_team/sandbox/state.py
+++ b/backend/agents/agent_provisioning_team/sandbox/state.py
@@ -17,13 +17,10 @@ import os
 from datetime import datetime, timezone
 from enum import Enum
 from pathlib import Path
-from threading import Lock
 
 from pydantic import BaseModel, Field
 
 logger = logging.getLogger(__name__)
-
-_lock = Lock()
 
 
 class SandboxStatus(str, Enum):
@@ -50,7 +47,7 @@ class SandboxState(BaseModel):
 
 
 class SandboxHandle(BaseModel):
-    """Caller-facing view returned by ``Lifecycle.acquire()``."""
+    """Caller-facing view derived from :class:`SandboxState`."""
 
     agent_id: str
     team: str
@@ -67,6 +64,28 @@ class SandboxHandle(BaseModel):
     last_used_at: datetime | None = None
     idle_seconds: int | None = None
     error: str | None = None
+
+    @classmethod
+    def from_state(cls, st: SandboxState) -> SandboxHandle:
+        url = (
+            f"http://127.0.0.1:{st.host_port}"
+            if st.status == SandboxStatus.WARM and st.host_port is not None
+            else None
+        )
+        idle = int((now() - st.last_used_at).total_seconds()) if st.last_used_at else None
+        return cls(
+            agent_id=st.agent_id,
+            team=st.team,
+            status=st.status,
+            url=url,
+            container_name=st.container_name,
+            container_id=st.container_id,
+            host_port=st.host_port,
+            created_at=st.created_at,
+            last_used_at=st.last_used_at,
+            idle_seconds=idle,
+            error=st.error,
+        )
 
 
 def now() -> datetime:
@@ -100,17 +119,8 @@ def state_file_path() -> Path:
 
 
 def idle_teardown_seconds() -> int:
-    """Read ``AGENT_PROVISIONING_SANDBOX_IDLE_MINUTES`` (default 5) from the env.
-
-    Falls back to ``SANDBOX_IDLE_TEARDOWN_MINUTES`` for shared configuration
-    with the legacy per-team reaper; when neither is set, the per-agent
-    lifecycle reaps after 5 minutes (shorter than the per-team default of 15
-    because individual agent sandboxes are cheaper to churn).
-    """
-    raw = os.environ.get("AGENT_PROVISIONING_SANDBOX_IDLE_MINUTES")
-    if raw is None:
-        raw = os.environ.get("SANDBOX_IDLE_TEARDOWN_MINUTES", "5")
-    return int(raw) * 60
+    """Read ``AGENT_PROVISIONING_SANDBOX_IDLE_MINUTES`` (default 5) from the env."""
+    return int(os.environ.get("AGENT_PROVISIONING_SANDBOX_IDLE_MINUTES", "5")) * 60
 
 
 def boot_timeout_seconds() -> int:
@@ -128,37 +138,28 @@ def sandbox_network() -> str:
     return os.environ.get("AGENT_PROVISIONING_SANDBOX_NETWORK", "khala-sandbox")
 
 
-def _serialise(state: dict[str, SandboxState]) -> str:
-    return json.dumps(
-        {agent_id: s.model_dump(mode="json") for agent_id, s in state.items()},
-        indent=2,
-        sort_keys=True,
-    )
-
-
 def load(path: Path) -> dict[str, SandboxState]:
     """Load state from disk. Missing file → empty dict. Corrupt file → warn + empty."""
-    with _lock:
-        if not path.exists():
-            return {}
+    if not path.exists():
+        return {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as exc:
+        logger.warning("Could not load sandbox state from %s: %s", path, exc)
+        return {}
+    out: dict[str, SandboxState] = {}
+    for agent_id, entry in (raw or {}).items():
         try:
-            raw = json.loads(path.read_text(encoding="utf-8"))
-        except (json.JSONDecodeError, OSError) as exc:
-            logger.warning("Could not load sandbox state from %s: %s", path, exc)
-            return {}
-        out: dict[str, SandboxState] = {}
-        for agent_id, entry in (raw or {}).items():
-            try:
-                out[agent_id] = SandboxState.model_validate(entry)
-            except Exception as exc:
-                logger.warning("Dropping malformed sandbox state entry %s: %s", agent_id, exc)
-        return out
+            out[agent_id] = SandboxState.model_validate(entry)
+        except Exception as exc:
+            logger.warning("Dropping malformed sandbox state entry %s: %s", agent_id, exc)
+    return out
 
 
 def save(path: Path, state: dict[str, SandboxState]) -> None:
     """Atomically persist ``state`` to ``path`` (tmpfile + rename)."""
-    with _lock:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(path.suffix + ".tmp")
-        tmp.write_text(_serialise(state), encoding="utf-8")
-        os.replace(tmp, path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {agent_id: s.model_dump(mode="json") for agent_id, s in state.items()}
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    os.replace(tmp, path)

--- a/backend/agents/agent_provisioning_team/sandbox/state.py
+++ b/backend/agents/agent_provisioning_team/sandbox/state.py
@@ -1,0 +1,164 @@
+"""On-disk checkpoint for per-agent sandbox lifecycle state.
+
+Mirrors ``agent_sandbox/state.py`` but keyed by ``agent_id`` (not team) so the
+Phase 2 lifecycle owner can run one sandbox per specialist agent rather than
+one per team.
+
+Restart safety: if the unified API or the provisioning process restarts, the
+Lifecycle reloads the last-known state from disk and reconciles with
+``docker inspect`` on the next request.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from threading import Lock
+
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+_lock = Lock()
+
+
+class SandboxStatus(str, Enum):
+    """Lifecycle states for a per-agent sandbox."""
+
+    COLD = "cold"
+    WARMING = "warming"
+    WARM = "warm"
+    ERROR = "error"
+
+
+class SandboxState(BaseModel):
+    """Persistent state for one agent sandbox, checkpointed to JSON."""
+
+    agent_id: str
+    team: str
+    container_name: str
+    container_id: str | None = None
+    host_port: int | None = None
+    status: SandboxStatus
+    created_at: datetime
+    last_used_at: datetime
+    error: str | None = None
+
+
+class SandboxHandle(BaseModel):
+    """Caller-facing view returned by ``Lifecycle.acquire()``."""
+
+    agent_id: str
+    team: str
+    status: SandboxStatus
+    url: str | None = Field(
+        default=None,
+        description="Base URL of the sandbox service (e.g. http://127.0.0.1:55123). "
+        "None until the container is WARM.",
+    )
+    container_name: str
+    container_id: str | None = None
+    host_port: int | None = None
+    created_at: datetime | None = None
+    last_used_at: datetime | None = None
+    idle_seconds: int | None = None
+    error: str | None = None
+
+
+def now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def new_state(agent_id: str, team: str, container_name: str) -> SandboxState:
+    """Construct a freshly-WARMING state row for ``agent_id``."""
+    t = now()
+    return SandboxState(
+        agent_id=agent_id,
+        team=team,
+        container_name=container_name,
+        status=SandboxStatus.WARMING,
+        created_at=t,
+        last_used_at=t,
+    )
+
+
+def state_file_path() -> Path:
+    """Where to persist sandbox state across restarts.
+
+    Override with ``AGENT_PROVISIONING_SANDBOX_STATE_FILE``; otherwise defaults
+    to ``${AGENT_CACHE:-/tmp/agents}/agent_provisioning/sandboxes/state.json``.
+    """
+    override = os.environ.get("AGENT_PROVISIONING_SANDBOX_STATE_FILE")
+    if override:
+        return Path(override)
+    cache = os.environ.get("AGENT_CACHE", "/tmp/agents")
+    return Path(cache) / "agent_provisioning" / "sandboxes" / "state.json"
+
+
+def idle_teardown_seconds() -> int:
+    """Read ``AGENT_PROVISIONING_SANDBOX_IDLE_MINUTES`` (default 5) from the env.
+
+    Falls back to ``SANDBOX_IDLE_TEARDOWN_MINUTES`` for shared configuration
+    with the legacy per-team reaper; when neither is set, the per-agent
+    lifecycle reaps after 5 minutes (shorter than the per-team default of 15
+    because individual agent sandboxes are cheaper to churn).
+    """
+    raw = os.environ.get("AGENT_PROVISIONING_SANDBOX_IDLE_MINUTES")
+    if raw is None:
+        raw = os.environ.get("SANDBOX_IDLE_TEARDOWN_MINUTES", "5")
+    return int(raw) * 60
+
+
+def boot_timeout_seconds() -> int:
+    """How long to wait for a sandbox ``/health`` probe to succeed. Default 90s."""
+    return int(os.environ.get("AGENT_PROVISIONING_SANDBOX_BOOT_TIMEOUT_S", "90"))
+
+
+def sandbox_image() -> str:
+    """Image tag for the unified single-agent sandbox (Phase 1, issue #263)."""
+    return os.environ.get("AGENT_PROVISIONING_SANDBOX_IMAGE", "khala-agent-sandbox:latest")
+
+
+def sandbox_network() -> str:
+    """Docker bridge network already created by ``docker/sandbox.compose.yml``."""
+    return os.environ.get("AGENT_PROVISIONING_SANDBOX_NETWORK", "khala-sandbox")
+
+
+def _serialise(state: dict[str, SandboxState]) -> str:
+    return json.dumps(
+        {agent_id: s.model_dump(mode="json") for agent_id, s in state.items()},
+        indent=2,
+        sort_keys=True,
+    )
+
+
+def load(path: Path) -> dict[str, SandboxState]:
+    """Load state from disk. Missing file → empty dict. Corrupt file → warn + empty."""
+    with _lock:
+        if not path.exists():
+            return {}
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning("Could not load sandbox state from %s: %s", path, exc)
+            return {}
+        out: dict[str, SandboxState] = {}
+        for agent_id, entry in (raw or {}).items():
+            try:
+                out[agent_id] = SandboxState.model_validate(entry)
+            except Exception as exc:
+                logger.warning("Dropping malformed sandbox state entry %s: %s", agent_id, exc)
+        return out
+
+
+def save(path: Path, state: dict[str, SandboxState]) -> None:
+    """Atomically persist ``state`` to ``path`` (tmpfile + rename)."""
+    with _lock:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = path.with_suffix(path.suffix + ".tmp")
+        tmp.write_text(_serialise(state), encoding="utf-8")
+        os.replace(tmp, path)

--- a/backend/agents/agent_provisioning_team/tests/test_sandbox_lifecycle.py
+++ b/backend/agents/agent_provisioning_team/tests/test_sandbox_lifecycle.py
@@ -8,8 +8,10 @@ a real Docker daemon. Mirrors the pattern in
 from __future__ import annotations
 
 import asyncio
+from contextlib import ExitStack, contextmanager
 from datetime import timedelta
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -21,6 +23,7 @@ from agent_provisioning_team.sandbox import (
 )
 from agent_provisioning_team.sandbox import provisioner as provisioner_mod
 from agent_provisioning_team.sandbox.provisioner import _build_run_argv, container_name_for
+from agent_provisioning_team.sandbox.state import SandboxHandle, SandboxState, now
 
 
 def _lifecycle(tmp_path: Path) -> Lifecycle:
@@ -28,36 +31,47 @@ def _lifecycle(tmp_path: Path) -> Lifecycle:
 
 
 def _patched_registry(team: str = "blogging"):
-    """Return a patch context that stubs ``_resolve_team`` to avoid loading real YAML."""
     return patch(
         "agent_provisioning_team.sandbox.lifecycle._resolve_team",
         return_value=team,
     )
 
 
-def _patched_docker(
-    *,
-    container_id: str = "abc123",
-    host_port: int = 55123,
-    running: bool = False,
-):
-    """Bundle the default docker-mock patches used across tests."""
-    return (
-        patch.object(provisioner_mod, "run_container", new=AsyncMock(return_value=container_id)),
-        patch.object(provisioner_mod, "inspect_host_port", new=AsyncMock(return_value=host_port)),
-        patch.object(provisioner_mod, "is_running", new=AsyncMock(return_value=running)),
-        patch.object(provisioner_mod, "stop_container", new=AsyncMock()),
-        patch.object(Lifecycle, "_wait_healthy", new=AsyncMock()),
-    )
+@contextmanager
+def _patched_docker(*, container_id: str = "abc123", host_port: int = 55123, running: bool = False):
+    """Apply the five default docker-mock patches as a single context manager.
+
+    Yields a namespace whose attributes are the individual mocks so tests can
+    assert on call counts without unpacking a tuple in every `with` block.
+    """
+    with ExitStack() as stack:
+        yield SimpleNamespace(
+            run=stack.enter_context(
+                patch.object(
+                    provisioner_mod, "run_container", new=AsyncMock(return_value=container_id)
+                )
+            ),
+            port=stack.enter_context(
+                patch.object(
+                    provisioner_mod, "inspect_host_port", new=AsyncMock(return_value=host_port)
+                )
+            ),
+            running=stack.enter_context(
+                patch.object(provisioner_mod, "is_running", new=AsyncMock(return_value=running))
+            ),
+            stop=stack.enter_context(
+                patch.object(provisioner_mod, "stop_container", new=AsyncMock())
+            ),
+            wait=stack.enter_context(patch.object(Lifecycle, "_wait_healthy", new=AsyncMock())),
+        )
 
 
 @pytest.mark.asyncio
 async def test_acquire_cold_to_warm(tmp_path: Path) -> None:
     lc = _lifecycle(tmp_path)
-    run, port, running, stop, wait = _patched_docker()
-    with _patched_registry(), run as run_mock, port, running, stop, wait:
+    with _patched_registry(), _patched_docker() as d:
         handle = await lc.acquire("blogging.planner")
-    run_mock.assert_awaited_once()
+    d.run.assert_awaited_once()
     assert handle.status == SandboxStatus.WARM
     assert handle.url == "http://127.0.0.1:55123"
     assert handle.team == "blogging"
@@ -67,19 +81,10 @@ async def test_acquire_cold_to_warm(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_acquire_is_idempotent_when_already_warm(tmp_path: Path) -> None:
     lc = _lifecycle(tmp_path)
-    run, port, _, stop, wait = _patched_docker()
-    # Second acquire should see container still running and skip `run_container`.
-    with (
-        _patched_registry(),
-        run as run_mock,
-        port,
-        patch.object(provisioner_mod, "is_running", new=AsyncMock(return_value=True)),
-        stop,
-        wait,
-    ):
+    with _patched_registry(), _patched_docker(running=True) as d:
         first = await lc.acquire("blogging.planner")
         second = await lc.acquire("blogging.planner")
-    assert run_mock.await_count == 1
+    assert d.run.await_count == 1
     assert first.status == SandboxStatus.WARM
     assert second.status == SandboxStatus.WARM
     assert second.container_id == first.container_id
@@ -88,15 +93,8 @@ async def test_acquire_is_idempotent_when_already_warm(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_acquire_reports_error_on_health_timeout(tmp_path: Path) -> None:
     lc = _lifecycle(tmp_path)
-    run, port, running, stop, _ = _patched_docker()
-    with (
-        _patched_registry(),
-        run,
-        port,
-        running,
-        stop,
-        patch.object(Lifecycle, "_wait_healthy", new=AsyncMock(side_effect=RuntimeError("boom"))),
-    ):
+    with _patched_registry(), _patched_docker() as d:
+        d.wait.side_effect = RuntimeError("boom")
         handle = await lc.acquire("blogging.planner")
     assert handle.status == SandboxStatus.ERROR
     assert handle.error == "boom"
@@ -105,23 +103,13 @@ async def test_acquire_reports_error_on_health_timeout(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_acquire_reprovisions_when_container_vanished(tmp_path: Path) -> None:
     lc = _lifecycle(tmp_path)
-    run, port, running, stop, wait = _patched_docker()
-    # First warm; then on the second acquire, pretend the container is gone.
-    with _patched_registry(), run as run_mock, port, running, stop, wait:
+    with _patched_registry(), _patched_docker() as d1:
         await lc.acquire("blogging.planner")
-    with (
-        _patched_registry(),
-        patch.object(
-            provisioner_mod, "run_container", new=AsyncMock(return_value="xyz789")
-        ) as re_run,
-        patch.object(provisioner_mod, "inspect_host_port", new=AsyncMock(return_value=55999)),
-        patch.object(provisioner_mod, "is_running", new=AsyncMock(return_value=False)),
-        patch.object(provisioner_mod, "stop_container", new=AsyncMock()),
-        patch.object(Lifecycle, "_wait_healthy", new=AsyncMock()),
-    ):
+    assert d1.run.await_count == 1
+
+    with _patched_registry(), _patched_docker(container_id="xyz789", host_port=55999) as d2:
         handle = await lc.acquire("blogging.planner")
-    assert run_mock.await_count == 1
-    assert re_run.await_count == 1
+    assert d2.run.await_count == 1
     assert handle.container_id == "xyz789"
     assert handle.host_port == 55999
 
@@ -129,22 +117,19 @@ async def test_acquire_reprovisions_when_container_vanished(tmp_path: Path) -> N
 @pytest.mark.asyncio
 async def test_teardown_removes_state(tmp_path: Path) -> None:
     lc = _lifecycle(tmp_path)
-    run, port, running, stop, wait = _patched_docker()
-    with _patched_registry(), run, port, running, stop as stop_mock, wait:
+    with _patched_registry(), _patched_docker() as d:
         await lc.acquire("blogging.planner")
         await lc.teardown("blogging.planner")
-    stop_mock.assert_awaited()
+    d.stop.assert_awaited()
     assert await lc.list_active() == []
 
 
 @pytest.mark.asyncio
 async def test_note_activity_updates_last_used(tmp_path: Path) -> None:
     lc = _lifecycle(tmp_path)
-    run, port, running, stop, wait = _patched_docker()
-    with _patched_registry(), run, port, running, stop, wait:
+    with _patched_registry(), _patched_docker():
         await lc.acquire("blogging.planner")
     before = lc._state["blogging.planner"].last_used_at
-    # Rewind so any clock granularity doesn't make the comparison a no-op.
     lc._state["blogging.planner"].last_used_at = before - timedelta(seconds=60)
     await lc.note_activity("blogging.planner")
     after = lc._state["blogging.planner"].last_used_at
@@ -154,24 +139,21 @@ async def test_note_activity_updates_last_used(tmp_path: Path) -> None:
 @pytest.mark.asyncio
 async def test_reap_once_tears_down_idle(tmp_path: Path) -> None:
     lc = _lifecycle(tmp_path)
-    run, port, running, stop, wait = _patched_docker()
-    with _patched_registry(), run, port, running, stop as stop_mock, wait:
+    with _patched_registry(), _patched_docker() as d:
         await lc.acquire("blogging.planner")
-        # Fast-forward the last-used timestamp so the reaper sees the sandbox as idle.
         lc._state["blogging.planner"].last_used_at = lc._state[
             "blogging.planner"
         ].last_used_at - timedelta(minutes=30)
         reaped = await lc.reap_once(threshold=60)
     assert reaped == ["blogging.planner"]
-    stop_mock.assert_awaited()
+    d.stop.assert_awaited()
     assert "blogging.planner" not in lc._state
 
 
 @pytest.mark.asyncio
 async def test_reap_preserves_fresh_sandbox(tmp_path: Path) -> None:
     lc = _lifecycle(tmp_path)
-    run, port, running, stop, wait = _patched_docker()
-    with _patched_registry(), run, port, running, stop, wait:
+    with _patched_registry(), _patched_docker():
         await lc.acquire("blogging.planner")
         reaped = await lc.reap_once(threshold=3600)
     assert reaped == []
@@ -195,8 +177,7 @@ async def test_unknown_agent_raises_without_docker_call(tmp_path: Path) -> None:
 
 def test_state_persists_across_lifecycle_instances(tmp_path: Path) -> None:
     lc1 = _lifecycle(tmp_path)
-    run, port, running, stop, wait = _patched_docker()
-    with _patched_registry(), run, port, running, stop, wait:
+    with _patched_registry(), _patched_docker():
         asyncio.run(lc1.acquire("blogging.planner"))
     lc2 = _lifecycle(tmp_path)
     assert set(lc2._state) == {"blogging.planner"}
@@ -206,7 +187,6 @@ def test_state_persists_across_lifecycle_instances(tmp_path: Path) -> None:
 
 def test_build_run_argv_applies_hardening() -> None:
     argv = _build_run_argv(agent_id="blogging.planner", container_name="khala-sbx-blogging.planner")
-    # Acceptance criteria from issue #264 / #255.
     assert "--cap-drop=ALL" in argv
     assert "--read-only" in argv
     assert "--security-opt=no-new-privileges:true" in argv
@@ -214,16 +194,10 @@ def test_build_run_argv_applies_hardening() -> None:
     assert "--pids-limit=512" in argv
     assert "--memory=1g" in argv
     assert "--cpus=1.0" in argv
-    # Loopback-only port binding.
-    assert "-p" in argv
     p_index = argv.index("-p")
     assert argv[p_index + 1] == "127.0.0.1::8090"
-    # tmpfs for /tmp and /run (read-only root leaves no writable paths otherwise).
     assert argv.count("--tmpfs") == 2
-    # SANDBOX_AGENT_ID wiring for the Phase 1 entrypoint.
     assert any(a == "SANDBOX_AGENT_ID=blogging.planner" for a in argv)
-    # Attaches to the existing khala-sandbox bridge network.
-    assert "--network" in argv
     n_index = argv.index("--network")
     assert argv[n_index + 1] == "khala-sandbox"
 
@@ -237,33 +211,23 @@ def test_container_name_is_dns_safe() -> None:
 @pytest.mark.asyncio
 async def test_run_idle_reaper_is_cancellable(tmp_path: Path) -> None:
     lc = _lifecycle(tmp_path)
-
-    # Very short interval + reap_once stub — we just assert the loop honors cancel.
-    async def _fast_sleep(_):
-        return None
-
     with (
         patch(
             "agent_provisioning_team.sandbox.lifecycle.asyncio.sleep",
-            new=AsyncMock(side_effect=_fast_sleep),
+            new=AsyncMock(),
         ),
         patch.object(Lifecycle, "reap_once", new=AsyncMock(return_value=[])),
     ):
         task = asyncio.create_task(lc.run_idle_reaper(interval_s=0))
-        # Let it loop a few times then cancel.
         await asyncio.sleep(0)
         task.cancel()
         with pytest.raises(asyncio.CancelledError):
             await task
 
 
-def test_lifecycle_handle_carries_container_metadata(tmp_path: Path) -> None:
-    lc = _lifecycle(tmp_path)
-    # Directly seed a WARM entry and ensure _handle projects all fields.
-    from agent_provisioning_team.sandbox.state import SandboxState, now
-
+def test_handle_from_state_projects_url_and_idle() -> None:
     t = now()
-    st = SandboxState(
+    warm = SandboxState(
         agent_id="blogging.planner",
         team="blogging",
         container_name="khala-sbx-blogging.planner",
@@ -273,13 +237,13 @@ def test_lifecycle_handle_carries_container_metadata(tmp_path: Path) -> None:
         created_at=t,
         last_used_at=t,
     )
-    handle = lc._handle(st)
+    handle = SandboxHandle.from_state(warm)
     assert handle.url == "http://127.0.0.1:55123"
     assert handle.container_id == "abc123"
     assert handle.host_port == 55123
     assert handle.team == "blogging"
-    # COLD/ERROR statuses should not expose a URL.
-    st_cold = SandboxState(
+
+    cold = SandboxState(
         agent_id="x.y",
         team="blogging",
         container_name="khala-sbx-x.y",
@@ -287,7 +251,7 @@ def test_lifecycle_handle_carries_container_metadata(tmp_path: Path) -> None:
         created_at=t,
         last_used_at=t,
     )
-    assert lc._handle(st_cold).url is None
+    assert SandboxHandle.from_state(cold).url is None
 
 
 # --- tests for the small module-level helpers ------------------------------
@@ -302,15 +266,12 @@ def test_sandbox_image_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
     assert state_mod.sandbox_image() == "khala-agent-sandbox:latest"
 
 
-def test_idle_threshold_prefers_per_agent_env(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_idle_threshold_reads_per_agent_env(monkeypatch: pytest.MonkeyPatch) -> None:
     from agent_provisioning_team.sandbox import state as state_mod
 
     monkeypatch.setenv("AGENT_PROVISIONING_SANDBOX_IDLE_MINUTES", "2")
     assert state_mod.idle_teardown_seconds() == 120
     monkeypatch.delenv("AGENT_PROVISIONING_SANDBOX_IDLE_MINUTES")
-    monkeypatch.setenv("SANDBOX_IDLE_TEARDOWN_MINUTES", "10")
-    assert state_mod.idle_teardown_seconds() == 600
-    monkeypatch.delenv("SANDBOX_IDLE_TEARDOWN_MINUTES")
     assert state_mod.idle_teardown_seconds() == 300  # 5-minute default
 
 

--- a/backend/agents/agent_provisioning_team/tests/test_sandbox_lifecycle.py
+++ b/backend/agents/agent_provisioning_team/tests/test_sandbox_lifecycle.py
@@ -125,6 +125,20 @@ async def test_teardown_removes_state(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_teardown_preserves_state_when_docker_errors(tmp_path: Path) -> None:
+    # When `stop_container` raises a DockerError (daemon unreachable, etc.),
+    # state must NOT be evicted — we need the record to retry against the
+    # still-alive container on the next tick.
+    lc = _lifecycle(tmp_path)
+    with _patched_registry(), _patched_docker() as d:
+        await lc.acquire("blogging.planner")
+        d.stop.side_effect = provisioner_mod.DockerError("docker daemon unreachable")
+        with pytest.raises(provisioner_mod.DockerError):
+            await lc.teardown("blogging.planner")
+    assert "blogging.planner" in lc._state
+
+
+@pytest.mark.asyncio
 async def test_note_activity_updates_last_used(tmp_path: Path) -> None:
     lc = _lifecycle(tmp_path)
     with _patched_registry(), _patched_docker():
@@ -158,6 +172,33 @@ async def test_reap_preserves_fresh_sandbox(tmp_path: Path) -> None:
         reaped = await lc.reap_once(threshold=3600)
     assert reaped == []
     assert "blogging.planner" in lc._state
+
+
+@pytest.mark.asyncio
+async def test_reap_once_continues_after_teardown_failure(tmp_path: Path) -> None:
+    # If one sandbox's teardown hits a DockerError, the reaper should log and
+    # continue so sibling sandboxes still get reclaimed this tick.
+    lc = _lifecycle(tmp_path)
+    with _patched_registry(), _patched_docker() as d:
+        await lc.acquire("blogging.planner")
+        await lc.acquire("blogging.writer")
+        for aid in ("blogging.planner", "blogging.writer"):
+            lc._state[aid].last_used_at = lc._state[aid].last_used_at - timedelta(minutes=30)
+
+        # Fail the first teardown, succeed the second.
+        calls = {"n": 0}
+
+        async def flaky_stop(_container_id: str) -> None:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise provisioner_mod.DockerError("daemon blip")
+
+        d.stop.side_effect = flaky_stop
+        reaped = await lc.reap_once(threshold=60)
+
+    # Exactly one sandbox torn down; the other remains for the next tick.
+    assert len(reaped) == 1
+    assert len(lc._state) == 1
 
 
 @pytest.mark.asyncio
@@ -203,9 +244,45 @@ def test_build_run_argv_applies_hardening() -> None:
 
 
 def test_container_name_is_dns_safe() -> None:
-    assert container_name_for("blogging.planner") == "khala-sbx-blogging.planner"
-    assert container_name_for("weird agent/name!") == "khala-sbx-weird-agent-name"
-    assert container_name_for("") == "khala-sbx-agent"
+    name = container_name_for("blogging.planner")
+    assert name.startswith("khala-sbx-blogging.planner-")
+    # readable prefix + 8 lowercase-hex char digest suffix.
+    suffix = name.rsplit("-", 1)[1]
+    assert len(suffix) == 8
+    assert all(c in "0123456789abcdef" for c in suffix)
+    # Deterministic.
+    assert container_name_for("blogging.planner") == name
+    # Empty id still yields a valid container name.
+    assert container_name_for("").startswith("khala-sbx-agent-")
+
+
+@pytest.mark.asyncio
+async def test_stop_container_is_idempotent_on_missing_container() -> None:
+    with patch.object(
+        provisioner_mod,
+        "_exec",
+        new=AsyncMock(return_value=(1, "", "Error: No such container: abc")),
+    ):
+        await provisioner_mod.stop_container("abc")  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_stop_container_raises_on_real_failure() -> None:
+    with patch.object(
+        provisioner_mod,
+        "_exec",
+        new=AsyncMock(return_value=(1, "", "Cannot connect to the Docker daemon")),
+    ):
+        with pytest.raises(provisioner_mod.DockerError):
+            await provisioner_mod.stop_container("abc")
+
+
+def test_container_name_is_collision_resistant_under_sanitization() -> None:
+    # Two ids that sanitize to the same readable prefix still get distinct
+    # container names, so the acquire-time zombie reap cannot accidentally
+    # tear down another agent's live sandbox.
+    assert container_name_for("agent/1") != container_name_for("agent-1")
+    assert container_name_for("a b") != container_name_for("a-b")
 
 
 @pytest.mark.asyncio

--- a/backend/agents/agent_provisioning_team/tests/test_sandbox_lifecycle.py
+++ b/backend/agents/agent_provisioning_team/tests/test_sandbox_lifecycle.py
@@ -1,0 +1,323 @@
+"""Unit tests for the agent-keyed sandbox Lifecycle (issue #264, Phase 2).
+
+Docker CLI calls and the ``/health`` probe are patched so tests run without
+a real Docker daemon. Mirrors the pattern in
+``backend/agents/agent_sandbox/tests/test_manager.py``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from agent_provisioning_team.sandbox import (
+    Lifecycle,
+    SandboxStatus,
+    UnknownAgentError,
+)
+from agent_provisioning_team.sandbox import provisioner as provisioner_mod
+from agent_provisioning_team.sandbox.provisioner import _build_run_argv, container_name_for
+
+
+def _lifecycle(tmp_path: Path) -> Lifecycle:
+    return Lifecycle(state_file=tmp_path / "state.json")
+
+
+def _patched_registry(team: str = "blogging"):
+    """Return a patch context that stubs ``_resolve_team`` to avoid loading real YAML."""
+    return patch(
+        "agent_provisioning_team.sandbox.lifecycle._resolve_team",
+        return_value=team,
+    )
+
+
+def _patched_docker(
+    *,
+    container_id: str = "abc123",
+    host_port: int = 55123,
+    running: bool = False,
+):
+    """Bundle the default docker-mock patches used across tests."""
+    return (
+        patch.object(provisioner_mod, "run_container", new=AsyncMock(return_value=container_id)),
+        patch.object(provisioner_mod, "inspect_host_port", new=AsyncMock(return_value=host_port)),
+        patch.object(provisioner_mod, "is_running", new=AsyncMock(return_value=running)),
+        patch.object(provisioner_mod, "stop_container", new=AsyncMock()),
+        patch.object(Lifecycle, "_wait_healthy", new=AsyncMock()),
+    )
+
+
+@pytest.mark.asyncio
+async def test_acquire_cold_to_warm(tmp_path: Path) -> None:
+    lc = _lifecycle(tmp_path)
+    run, port, running, stop, wait = _patched_docker()
+    with _patched_registry(), run as run_mock, port, running, stop, wait:
+        handle = await lc.acquire("blogging.planner")
+    run_mock.assert_awaited_once()
+    assert handle.status == SandboxStatus.WARM
+    assert handle.url == "http://127.0.0.1:55123"
+    assert handle.team == "blogging"
+    assert handle.container_id == "abc123"
+
+
+@pytest.mark.asyncio
+async def test_acquire_is_idempotent_when_already_warm(tmp_path: Path) -> None:
+    lc = _lifecycle(tmp_path)
+    run, port, _, stop, wait = _patched_docker()
+    # Second acquire should see container still running and skip `run_container`.
+    with (
+        _patched_registry(),
+        run as run_mock,
+        port,
+        patch.object(provisioner_mod, "is_running", new=AsyncMock(return_value=True)),
+        stop,
+        wait,
+    ):
+        first = await lc.acquire("blogging.planner")
+        second = await lc.acquire("blogging.planner")
+    assert run_mock.await_count == 1
+    assert first.status == SandboxStatus.WARM
+    assert second.status == SandboxStatus.WARM
+    assert second.container_id == first.container_id
+
+
+@pytest.mark.asyncio
+async def test_acquire_reports_error_on_health_timeout(tmp_path: Path) -> None:
+    lc = _lifecycle(tmp_path)
+    run, port, running, stop, _ = _patched_docker()
+    with (
+        _patched_registry(),
+        run,
+        port,
+        running,
+        stop,
+        patch.object(Lifecycle, "_wait_healthy", new=AsyncMock(side_effect=RuntimeError("boom"))),
+    ):
+        handle = await lc.acquire("blogging.planner")
+    assert handle.status == SandboxStatus.ERROR
+    assert handle.error == "boom"
+
+
+@pytest.mark.asyncio
+async def test_acquire_reprovisions_when_container_vanished(tmp_path: Path) -> None:
+    lc = _lifecycle(tmp_path)
+    run, port, running, stop, wait = _patched_docker()
+    # First warm; then on the second acquire, pretend the container is gone.
+    with _patched_registry(), run as run_mock, port, running, stop, wait:
+        await lc.acquire("blogging.planner")
+    with (
+        _patched_registry(),
+        patch.object(
+            provisioner_mod, "run_container", new=AsyncMock(return_value="xyz789")
+        ) as re_run,
+        patch.object(provisioner_mod, "inspect_host_port", new=AsyncMock(return_value=55999)),
+        patch.object(provisioner_mod, "is_running", new=AsyncMock(return_value=False)),
+        patch.object(provisioner_mod, "stop_container", new=AsyncMock()),
+        patch.object(Lifecycle, "_wait_healthy", new=AsyncMock()),
+    ):
+        handle = await lc.acquire("blogging.planner")
+    assert run_mock.await_count == 1
+    assert re_run.await_count == 1
+    assert handle.container_id == "xyz789"
+    assert handle.host_port == 55999
+
+
+@pytest.mark.asyncio
+async def test_teardown_removes_state(tmp_path: Path) -> None:
+    lc = _lifecycle(tmp_path)
+    run, port, running, stop, wait = _patched_docker()
+    with _patched_registry(), run, port, running, stop as stop_mock, wait:
+        await lc.acquire("blogging.planner")
+        await lc.teardown("blogging.planner")
+    stop_mock.assert_awaited()
+    assert await lc.list_active() == []
+
+
+@pytest.mark.asyncio
+async def test_note_activity_updates_last_used(tmp_path: Path) -> None:
+    lc = _lifecycle(tmp_path)
+    run, port, running, stop, wait = _patched_docker()
+    with _patched_registry(), run, port, running, stop, wait:
+        await lc.acquire("blogging.planner")
+    before = lc._state["blogging.planner"].last_used_at
+    # Rewind so any clock granularity doesn't make the comparison a no-op.
+    lc._state["blogging.planner"].last_used_at = before - timedelta(seconds=60)
+    await lc.note_activity("blogging.planner")
+    after = lc._state["blogging.planner"].last_used_at
+    assert after > before - timedelta(seconds=60)
+
+
+@pytest.mark.asyncio
+async def test_reap_once_tears_down_idle(tmp_path: Path) -> None:
+    lc = _lifecycle(tmp_path)
+    run, port, running, stop, wait = _patched_docker()
+    with _patched_registry(), run, port, running, stop as stop_mock, wait:
+        await lc.acquire("blogging.planner")
+        # Fast-forward the last-used timestamp so the reaper sees the sandbox as idle.
+        lc._state["blogging.planner"].last_used_at = lc._state[
+            "blogging.planner"
+        ].last_used_at - timedelta(minutes=30)
+        reaped = await lc.reap_once(threshold=60)
+    assert reaped == ["blogging.planner"]
+    stop_mock.assert_awaited()
+    assert "blogging.planner" not in lc._state
+
+
+@pytest.mark.asyncio
+async def test_reap_preserves_fresh_sandbox(tmp_path: Path) -> None:
+    lc = _lifecycle(tmp_path)
+    run, port, running, stop, wait = _patched_docker()
+    with _patched_registry(), run, port, running, stop, wait:
+        await lc.acquire("blogging.planner")
+        reaped = await lc.reap_once(threshold=3600)
+    assert reaped == []
+    assert "blogging.planner" in lc._state
+
+
+@pytest.mark.asyncio
+async def test_unknown_agent_raises_without_docker_call(tmp_path: Path) -> None:
+    lc = _lifecycle(tmp_path)
+    with (
+        patch(
+            "agent_provisioning_team.sandbox.lifecycle._resolve_team",
+            side_effect=UnknownAgentError("No agent manifest for 'ghost.agent'"),
+        ),
+        patch.object(provisioner_mod, "run_container", new=AsyncMock()) as run_mock,
+    ):
+        with pytest.raises(UnknownAgentError):
+            await lc.acquire("ghost.agent")
+    run_mock.assert_not_awaited()
+
+
+def test_state_persists_across_lifecycle_instances(tmp_path: Path) -> None:
+    lc1 = _lifecycle(tmp_path)
+    run, port, running, stop, wait = _patched_docker()
+    with _patched_registry(), run, port, running, stop, wait:
+        asyncio.run(lc1.acquire("blogging.planner"))
+    lc2 = _lifecycle(tmp_path)
+    assert set(lc2._state) == {"blogging.planner"}
+    assert lc2._state["blogging.planner"].status == SandboxStatus.WARM
+    assert lc2._state["blogging.planner"].container_id == "abc123"
+
+
+def test_build_run_argv_applies_hardening() -> None:
+    argv = _build_run_argv(agent_id="blogging.planner", container_name="khala-sbx-blogging.planner")
+    # Acceptance criteria from issue #264 / #255.
+    assert "--cap-drop=ALL" in argv
+    assert "--read-only" in argv
+    assert "--security-opt=no-new-privileges:true" in argv
+    assert "--security-opt=seccomp=default" in argv
+    assert "--pids-limit=512" in argv
+    assert "--memory=1g" in argv
+    assert "--cpus=1.0" in argv
+    # Loopback-only port binding.
+    assert "-p" in argv
+    p_index = argv.index("-p")
+    assert argv[p_index + 1] == "127.0.0.1::8090"
+    # tmpfs for /tmp and /run (read-only root leaves no writable paths otherwise).
+    assert argv.count("--tmpfs") == 2
+    # SANDBOX_AGENT_ID wiring for the Phase 1 entrypoint.
+    assert any(a == "SANDBOX_AGENT_ID=blogging.planner" for a in argv)
+    # Attaches to the existing khala-sandbox bridge network.
+    assert "--network" in argv
+    n_index = argv.index("--network")
+    assert argv[n_index + 1] == "khala-sandbox"
+
+
+def test_container_name_is_dns_safe() -> None:
+    assert container_name_for("blogging.planner") == "khala-sbx-blogging.planner"
+    assert container_name_for("weird agent/name!") == "khala-sbx-weird-agent-name"
+    assert container_name_for("") == "khala-sbx-agent"
+
+
+@pytest.mark.asyncio
+async def test_run_idle_reaper_is_cancellable(tmp_path: Path) -> None:
+    lc = _lifecycle(tmp_path)
+
+    # Very short interval + reap_once stub — we just assert the loop honors cancel.
+    async def _fast_sleep(_):
+        return None
+
+    with (
+        patch(
+            "agent_provisioning_team.sandbox.lifecycle.asyncio.sleep",
+            new=AsyncMock(side_effect=_fast_sleep),
+        ),
+        patch.object(Lifecycle, "reap_once", new=AsyncMock(return_value=[])),
+    ):
+        task = asyncio.create_task(lc.run_idle_reaper(interval_s=0))
+        # Let it loop a few times then cancel.
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+def test_lifecycle_handle_carries_container_metadata(tmp_path: Path) -> None:
+    lc = _lifecycle(tmp_path)
+    # Directly seed a WARM entry and ensure _handle projects all fields.
+    from agent_provisioning_team.sandbox.state import SandboxState, now
+
+    t = now()
+    st = SandboxState(
+        agent_id="blogging.planner",
+        team="blogging",
+        container_name="khala-sbx-blogging.planner",
+        container_id="abc123",
+        host_port=55123,
+        status=SandboxStatus.WARM,
+        created_at=t,
+        last_used_at=t,
+    )
+    handle = lc._handle(st)
+    assert handle.url == "http://127.0.0.1:55123"
+    assert handle.container_id == "abc123"
+    assert handle.host_port == 55123
+    assert handle.team == "blogging"
+    # COLD/ERROR statuses should not expose a URL.
+    st_cold = SandboxState(
+        agent_id="x.y",
+        team="blogging",
+        container_name="khala-sbx-x.y",
+        status=SandboxStatus.COLD,
+        created_at=t,
+        last_used_at=t,
+    )
+    assert lc._handle(st_cold).url is None
+
+
+# --- tests for the small module-level helpers ------------------------------
+
+
+def test_sandbox_image_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_provisioning_team.sandbox import state as state_mod
+
+    monkeypatch.setenv("AGENT_PROVISIONING_SANDBOX_IMAGE", "my/custom:tag")
+    assert state_mod.sandbox_image() == "my/custom:tag"
+    monkeypatch.delenv("AGENT_PROVISIONING_SANDBOX_IMAGE")
+    assert state_mod.sandbox_image() == "khala-agent-sandbox:latest"
+
+
+def test_idle_threshold_prefers_per_agent_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_provisioning_team.sandbox import state as state_mod
+
+    monkeypatch.setenv("AGENT_PROVISIONING_SANDBOX_IDLE_MINUTES", "2")
+    assert state_mod.idle_teardown_seconds() == 120
+    monkeypatch.delenv("AGENT_PROVISIONING_SANDBOX_IDLE_MINUTES")
+    monkeypatch.setenv("SANDBOX_IDLE_TEARDOWN_MINUTES", "10")
+    assert state_mod.idle_teardown_seconds() == 600
+    monkeypatch.delenv("SANDBOX_IDLE_TEARDOWN_MINUTES")
+    assert state_mod.idle_teardown_seconds() == 300  # 5-minute default
+
+
+def test_state_file_path_uses_agent_cache(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    from agent_provisioning_team.sandbox import state as state_mod
+
+    monkeypatch.delenv("AGENT_PROVISIONING_SANDBOX_STATE_FILE", raising=False)
+    monkeypatch.setenv("AGENT_CACHE", str(tmp_path))
+    path = state_mod.state_file_path()
+    assert path == tmp_path / "agent_provisioning" / "sandboxes" / "state.json"


### PR DESCRIPTION
Runs the Phase 1 unified khala-agent-sandbox image from #263 as one
ephemeral, hardened container per specialist agent. Mirrors the
COLD → WARMING → WARM → ERROR state machine from agent_sandbox/manager.py
but rekeys by agent_id and talks to `docker run`/`docker inspect`
directly rather than `docker compose`.

Folds in #255 hardening on every `docker run`:
  --cpus=1.0 --memory=1g --pids-limit=512
  --ulimit nproc=1024 --ulimit nofile=4096
  --security-opt=no-new-privileges:true --security-opt=seccomp=default
  --cap-drop=ALL
  --read-only --tmpfs /tmp --tmpfs /run
  -p 127.0.0.1::8090  (loopback-only, Docker picks port)
  --network khala-sandbox

New package agents/agent_provisioning_team/sandbox/:
- state.py: Pydantic SandboxState/SandboxHandle, JSON checkpoint to
  $AGENT_CACHE/agent_provisioning/sandboxes/state.json, env overrides.
- provisioner.py: module-level async wrappers over docker run/inspect/stop
  with the hardening flags. Does not modify tool_agents/docker_provisioner.py.
- lifecycle.py: Lifecycle class with per-agent asyncio locks,
  acquire/release/teardown/note_activity, idle reaper (5-min default,
  env AGENT_PROVISIONING_SANDBOX_IDLE_MINUTES).
- __init__.py: public API re-exports.

Idle default shortened from 15 min (per-team) to 5 min (per-agent) since
individual agent sandboxes churn faster and are cheaper to re-provision.

17 new unit tests in tests/test_sandbox_lifecycle.py patch the docker CLI
and /health probe so nothing hits a real daemon. Covers: cold→warm,
idempotent reacquire, health-timeout error, container-vanished
reprovision, teardown, note_activity, idle reap, fresh-sandbox preserve,
unknown-agent-fast-fail, state rehydrate across instances, hardening-flag
assertions, container-name DNS safety, reaper cancellability, handle
projection, and env-var overrides.

Out of scope for this phase (tracked separately):
- Wiring Lifecycle into unified API routes — Phase 3 (#265).
- Agent Console Runner UI agent-keyed switch — Phase 4 (#266).
- Deleting agent_sandbox/ and sandbox.compose.yml — Phase 5 (#267).
- Cross-team end-to-end smoke tests — Phase 6 (#268).

https://claude.ai/code/session_01PGiwSimBevRa9koMaG7UoD