### PR TITLE
Harden sandbox.compose.yml with resource/cap/read-only limits (#255)

### DIFF
--- a/docker/sandbox.compose.yml
+++ b/docker/sandbox.compose.yml
@@ -7,6 +7,14 @@
 #   - Dedicated port range 8200-8220 for team-sandbox services.
 #   - Same images as production (same Dockerfiles, same image tags) — no rebuild overhead.
 #
+# Security hardening (#255):
+#   - Every service drops all Linux capabilities (re-adding only the minimum each one
+#     genuinely needs), runs with `no-new-privileges`, a read-only root filesystem
+#     with tmpfs scratch space, and explicit CPU / memory / PID / file-descriptor caps.
+#   - Host port mappings are bound to 127.0.0.1 so sandboxes are only reachable from
+#     the local unified API; external callers must go through the API's auth layer.
+#     Service-to-service traffic still flows over the private `khala-sandbox` network.
+#
 # Usage (driven by backend/agents/agent_sandbox via `docker compose`):
 #   docker compose -f docker/sandbox.compose.yml up -d sandbox-postgres
 #   docker compose -f docker/sandbox.compose.yml up -d blogging-sandbox
@@ -32,11 +40,43 @@ x-sandbox-env-base: &sandbox-env-base
   AGENT_CACHE: /data/agents
   AGENT_CONSOLE_MODE: sandbox
 
+# Resource caps applied to every sandbox service.
+x-sandbox-limits: &sandbox-limits
+  deploy:
+    resources:
+      limits:
+        cpus: "1.0"
+        memory: 1g
+        pids: 512
+  pids_limit: 512
+  mem_limit: 1g
+  cpus: 1.0
+  ulimits:
+    nproc: 1024
+    nofile: 4096
+
+# Baseline hardening for the team sandbox services. Postgres has its own variant
+# below because its entrypoint needs a small set of re-added capabilities.
+x-sandbox-security: &sandbox-security
+  security_opt:
+    - "no-new-privileges:true"
+    - "seccomp=default"
+  cap_drop: [ALL]
+  read_only: true
+  tmpfs:
+    - /tmp
+    - /run
+
 services:
   # ---------------------------------------------------------------------------
   # Shared Postgres instance used by all sandboxes.
   # Lives on port 5433 (host) to avoid clashing with the prod postgres on 5432.
   # Each sandbox uses a distinct database name via POSTGRES_DB env.
+  #
+  # Capabilities: the official postgres image starts as root, chowns the data
+  # directory, and drops to the `postgres` user via gosu/setpriv. That flow
+  # needs CHOWN, SETUID, SETGID, FOWNER, and DAC_OVERRIDE — all other caps are
+  # dropped. tmpfs on /var/run/postgresql covers the unix socket and pidfile.
   # ---------------------------------------------------------------------------
   sandbox-postgres:
     image: postgres:18
@@ -46,7 +86,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in docker/.env before starting sandboxes}
       POSTGRES_DB: postgres
     ports:
-      - "5433:5432"
+      - "127.0.0.1:5433:5432"
     volumes:
       - sandbox_postgres_data:/var/lib/postgresql
       - ./postgres/init:/docker-entrypoint-initdb.d
@@ -58,6 +98,33 @@ services:
     networks:
       sandbox:
         aliases: [sandbox-postgres]
+    deploy:
+      resources:
+        limits:
+          cpus: "1.0"
+          memory: 1g
+          pids: 512
+    pids_limit: 512
+    mem_limit: 1g
+    cpus: 1.0
+    ulimits:
+      nproc: 1024
+      nofile: 4096
+    security_opt:
+      - "no-new-privileges:true"
+      - "seccomp=default"
+    cap_drop: [ALL]
+    cap_add:
+      - CHOWN
+      - SETUID
+      - SETGID
+      - FOWNER
+      - DAC_OVERRIDE
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /run
+      - /var/run/postgresql
 
   # ---------------------------------------------------------------------------
   # blogging-sandbox  (port 8200)
@@ -65,6 +132,7 @@ services:
   # session root lives inside this sandbox's own volume slice.
   # ---------------------------------------------------------------------------
   blogging-sandbox:
+    <<: [*sandbox-limits, *sandbox-security]
     image: khala-blogging-service
     build:
       context: ../backend
@@ -76,7 +144,7 @@ services:
       <<: *sandbox-env-base
       POSTGRES_DB: sandbox_blogging
     ports:
-      - "${BLOGGING_SANDBOX_PORT:-8200}:8090"
+      - "127.0.0.1:${BLOGGING_SANDBOX_PORT:-8200}:8090"
     volumes:
       - sandbox_agents_data:/data/agents
     networks:
@@ -88,10 +156,12 @@ services:
       timeout: 5s
       retries: 10
     restart: "no"
+
   # ---------------------------------------------------------------------------
   # software_engineering sandbox  (port 8201)
   # ---------------------------------------------------------------------------
   se-sandbox:
+    <<: [*sandbox-limits, *sandbox-security]
     image: khala-se-service
     build:
       context: ../backend
@@ -108,7 +178,7 @@ services:
       TEAM_PORT: "8091"
       SE_WORKSPACE_DIR: /data/agents/software_engineering_team/workspaces
     ports:
-      - "${SE_SANDBOX_PORT:-8201}:8091"
+      - "127.0.0.1:${SE_SANDBOX_PORT:-8201}:8091"
     volumes:
       - sandbox_agents_data:/data/agents
     networks:
@@ -125,6 +195,7 @@ services:
   # planning_v3 sandbox  (port 8202)
   # ---------------------------------------------------------------------------
   planning-v3-sandbox:
+    <<: [*sandbox-limits, *sandbox-security]
     image: khala-planning-v3-service
     build:
       context: ../backend
@@ -140,7 +211,7 @@ services:
       TEAM_NAME: planning_v3_team
       TEAM_PORT: "8102"
     ports:
-      - "${PLANNING_V3_SANDBOX_PORT:-8202}:8102"
+      - "127.0.0.1:${PLANNING_V3_SANDBOX_PORT:-8202}:8102"
     volumes:
       - sandbox_agents_data:/data/agents
     networks:
@@ -157,6 +228,7 @@ services:
   # branding sandbox  (port 8203)
   # ---------------------------------------------------------------------------
   branding-sandbox:
+    <<: [*sandbox-limits, *sandbox-security]
     image: khala-branding-service
     build:
       context: ../backend
@@ -172,7 +244,7 @@ services:
       TEAM_NAME: branding_team
       TEAM_PORT: "8096"
     ports:
-      - "${BRANDING_SANDBOX_PORT:-8203}:8096"
+      - "127.0.0.1:${BRANDING_SANDBOX_PORT:-8203}:8096"
     volumes:
       - sandbox_agents_data:/data/agents
     networks:


### PR DESCRIPTION
Addresses the principal-engineer security review: a runaway or compromised
agent in any team sandbox could previously fork-bomb the host, OOM siblings,
exhaust the shared agents volume, or bind to external interfaces.

Every team sandbox service and sandbox-postgres now declares:

- deploy.resources.limits (cpus 1.0, memory 1g, pids 512) plus the legacy
  top-level equivalents (mem_limit, cpus, pids_limit) for Compose
  versions that don't honour deploy outside swarm mode.
- ulimits nproc 1024 / nofile 4096.
- security_opt: no-new-privileges + seccomp=default.
- cap_drop [ALL]. Postgres re-adds the minimum its entrypoint needs
  (CHOWN, SETUID, SETGID, FOWNER, DAC_OVERRIDE) for chown + gosu.
- read_only rootfs with tmpfs on /tmp and /run (postgres also gets
  /var/run/postgresql for its socket + pidfile).
- Host port mappings bound to 127.0.0.1 so sandboxes are only reachable
  from the local unified API; service-to-service traffic still flows
  over the private khala-sandbox network.

Team service hardening is deduplicated via two YAML anchors
(x-sandbox-limits, x-sandbox-security); postgres uses an inline variant
because of its extra capability + tmpfs requirements.

Verified:
- docker compose -f docker/sandbox.compose.yml config parses cleanly and
  emits host_ip 127.0.0.1 on every published port and cap_drop/read_only
  on every service.
- agent_sandbox manager test suite (9 tests) still passes - the manager
  never touches these compose fields.

https://claude.ai/code/session_0144rNQALQFdBc81m4c7DW9m