### PR TITLE
Branding: per-brand activity strip and split-button generate (#276)

### DIFF
--- a/user-interface/src/app/components/brand-activity-strip/brand-activity-strip.component.html
+++ b/user-interface/src/app/components/brand-activity-strip/brand-activity-strip.component.html
@@ -1,0 +1,49 @@
+@if (items.length > 0) {
+  <mat-chip-set class="brand-activity-strip" aria-label="Brand activity">
+    @for (a of items; track trackById($index, a)) {
+      <mat-chip
+        [class]="chipClass(a)"
+        [disabled]="false"
+        [matTooltip]="a.error || ''"
+        [matTooltipDisabled]="!a.error"
+        (click)="onOpen($event, a)"
+      >
+        @if (a.status === 'running' || a.status === 'queued') {
+          <mat-spinner matChipAvatar diameter="16" strokeWidth="2" />
+        } @else if (a.status === 'completed') {
+          <mat-icon matChipAvatar class="chip-icon chip-icon--completed">check_circle</mat-icon>
+        } @else if (a.status === 'failed') {
+          <mat-icon matChipAvatar class="chip-icon chip-icon--failed">error</mat-icon>
+        } @else if (a.status === 'cancelled') {
+          <mat-icon matChipAvatar class="chip-icon chip-icon--cancelled">cancel</mat-icon>
+        } @else {
+          <mat-icon matChipAvatar class="chip-icon">{{ icon(a.kind) }}</mat-icon>
+        }
+        <span class="chip-label">{{ label(a) }}</span>
+        @if (isRetryable(a)) {
+          <button
+            matChipTrailingIcon
+            mat-icon-button
+            type="button"
+            aria-label="Retry"
+            matTooltip="Retry"
+            (click)="onRetry($event, a)"
+          >
+            <mat-icon>refresh</mat-icon>
+          </button>
+        }
+        @if (isDismissable(a)) {
+          <button
+            matChipRemove
+            mat-icon-button
+            type="button"
+            aria-label="Dismiss"
+            (click)="onDismiss($event, a)"
+          >
+            <mat-icon>close</mat-icon>
+          </button>
+        }
+      </mat-chip>
+    }
+  </mat-chip-set>
+}

--- a/user-interface/src/app/components/brand-activity-strip/brand-activity-strip.component.scss
+++ b/user-interface/src/app/components/brand-activity-strip/brand-activity-strip.component.scss
@@ -1,0 +1,50 @@
+:host {
+  display: block;
+}
+
+.brand-activity-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.activity-chip {
+  --mdc-chip-container-height: 28px;
+  font-size: 12px;
+
+  .chip-label {
+    margin: 0 2px;
+  }
+
+  .chip-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
+
+  .chip-icon--completed {
+    color: var(--mat-sys-tertiary, #2e7d32);
+  }
+
+  .chip-icon--failed {
+    color: var(--mat-sys-error, #c62828);
+  }
+
+  .chip-icon--cancelled {
+    color: var(--mat-sys-outline, #6b6b6b);
+  }
+}
+
+.activity-chip--completed {
+  cursor: pointer;
+}
+
+.activity-chip--failed {
+  background-color: rgba(198, 40, 40, 0.08);
+}
+
+.activity-chip--running,
+.activity-chip--queued {
+  background-color: rgba(25, 118, 210, 0.08);
+}

--- a/user-interface/src/app/components/brand-activity-strip/brand-activity-strip.component.spec.ts
+++ b/user-interface/src/app/components/brand-activity-strip/brand-activity-strip.component.spec.ts
@@ -1,0 +1,83 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { BrandActivityStripComponent } from './brand-activity-strip.component';
+import { BrandActivityService } from '../../services/brand-activity.service';
+
+describe('BrandActivityStripComponent', () => {
+  let fixture: ComponentFixture<BrandActivityStripComponent>;
+  let component: BrandActivityStripComponent;
+  let store: BrandActivityService;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BrandActivityStripComponent, NoopAnimationsModule],
+      providers: [BrandActivityService],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BrandActivityStripComponent);
+    component = fixture.componentInstance;
+    store = TestBed.inject(BrandActivityService);
+    component.brandId = 'b1';
+    fixture.detectChanges();
+  });
+
+  it('subscribes to the activity store for the given brand', () => {
+    store.start('run', 'b1');
+    store.start('research', 'b-other');
+    fixture.detectChanges();
+    expect(component.items.map((a) => a.brandId)).toEqual(['b1']);
+  });
+
+  it('label() describes running activities with phase and progress', () => {
+    const activity = store.start('run', 'b1');
+    store.update(activity.id, { status: 'running', phase: 'Visual Identity', progress: 60 });
+    fixture.detectChanges();
+    expect(component.label(component.items[0])).toContain('Visual Identity');
+    expect(component.label(component.items[0])).toContain('60%');
+  });
+
+  it('isOpenable() is true only for completed activities', () => {
+    const completed = store.start('run', 'b1');
+    store.update(completed.id, { status: 'completed' });
+    const failed = store.start('run', 'b1');
+    store.update(failed.id, { status: 'failed' });
+    fixture.detectChanges();
+    expect(component.isOpenable(component.items.find((a) => a.status === 'completed')!)).toBe(true);
+    expect(component.isOpenable(component.items.find((a) => a.status === 'failed')!)).toBe(false);
+  });
+
+  it('onOpen() emits only for completed activities', () => {
+    const spy = vi.fn();
+    component.open.subscribe(spy);
+    const running = store.start('run', 'b1');
+    store.update(running.id, { status: 'running' });
+    fixture.detectChanges();
+    component.onOpen(new Event('click'), component.items[0]);
+    expect(spy).not.toHaveBeenCalled();
+
+    store.update(running.id, { status: 'completed' });
+    fixture.detectChanges();
+    component.onOpen(new Event('click'), component.items[0]);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('onRetry() emits for failed activities', () => {
+    const spy = vi.fn();
+    component.retry.subscribe(spy);
+    const failed = store.start('run', 'b1');
+    store.update(failed.id, { status: 'failed', error: 'boom' });
+    fixture.detectChanges();
+    component.onRetry(new Event('click'), component.items[0]);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it('onDismiss() emits for any terminal activity', () => {
+    const spy = vi.fn();
+    component.dismiss.subscribe(spy);
+    const done = store.start('run', 'b1');
+    store.update(done.id, { status: 'completed' });
+    fixture.detectChanges();
+    component.onDismiss(new Event('click'), component.items[0]);
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/user-interface/src/app/components/brand-activity-strip/brand-activity-strip.component.ts
+++ b/user-interface/src/app/components/brand-activity-strip/brand-activity-strip.component.ts
@@ -1,0 +1,167 @@
+import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges, inject, output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { MatButtonModule } from '@angular/material/button';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatIconModule } from '@angular/material/icon';
+import { MatTooltipModule } from '@angular/material/tooltip';
+import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { Subject } from 'rxjs';
+import { switchMap, takeUntil } from 'rxjs/operators';
+import type { BrandActivity, BrandActivityKind } from '../../models';
+import { BrandActivityService } from '../../services/brand-activity.service';
+
+const KIND_LABEL: Record<BrandActivityKind, string> = {
+  run: 'Run',
+  research: 'Market research',
+  design: 'Design assets',
+};
+
+const KIND_ICON: Record<BrandActivityKind, string> = {
+  run: 'bolt',
+  research: 'travel_explore',
+  design: 'palette',
+};
+
+/**
+ * Compact per-brand activity strip. Renders a `mat-chip` for every pending,
+ * running, or recently-finished generate action against a single brand, with
+ * retry on failure and "open artifacts" on completion. Data comes from
+ * {@link BrandActivityService}; the parent handles the actual retry / open
+ * behaviour via the `(retry)` and `(open)` outputs.
+ */
+@Component({
+  selector: 'app-brand-activity-strip',
+  standalone: true,
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatChipsModule,
+    MatIconModule,
+    MatTooltipModule,
+    MatProgressSpinnerModule,
+  ],
+  templateUrl: './brand-activity-strip.component.html',
+  styleUrl: './brand-activity-strip.component.scss',
+})
+export class BrandActivityStripComponent implements OnInit, OnChanges, OnDestroy {
+  private readonly activities = inject(BrandActivityService);
+
+  @Input({ required: true }) brandId!: string;
+
+  readonly retry = output<BrandActivity>();
+  readonly open = output<BrandActivity>();
+  readonly dismiss = output<BrandActivity>();
+
+  items: BrandActivity[] = [];
+
+  private readonly brandIdChanges = new Subject<string>();
+  private readonly destroy = new Subject<void>();
+
+  constructor() {
+    this.brandIdChanges
+      .pipe(
+        switchMap((id) => this.activities.forBrand(id)),
+        takeUntil(this.destroy)
+      )
+      .subscribe((list) => (this.items = list));
+  }
+
+  ngOnInit(): void {
+    if (this.brandId) {
+      this.brandIdChanges.next(this.brandId);
+    }
+  }
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (changes['brandId'] && !changes['brandId'].firstChange && this.brandId) {
+      this.brandIdChanges.next(this.brandId);
+    }
+  }
+
+  ngOnDestroy(): void {
+    this.destroy.next();
+    this.destroy.complete();
+  }
+
+  trackById(_: number, a: BrandActivity): string {
+    return a.id;
+  }
+
+  label(a: BrandActivity): string {
+    const base = KIND_LABEL[a.kind];
+    if (a.status === 'running' && a.phase) {
+      const percent = typeof a.progress === 'number' ? ` · ${a.progress}%` : '';
+      return `${base} · ${a.phase}${percent}`;
+    }
+    if (a.status === 'running') {
+      return `${base} · running`;
+    }
+    if (a.status === 'queued') {
+      return `${base} · queued`;
+    }
+    if (a.status === 'completed') {
+      return `${base} · completed${this.relative(a.completedAt)}`;
+    }
+    if (a.status === 'failed') {
+      return `${base} · failed`;
+    }
+    if (a.status === 'cancelled') {
+      return `${base} · cancelled`;
+    }
+    return base;
+  }
+
+  icon(kind: BrandActivityKind): string {
+    return KIND_ICON[kind];
+  }
+
+  chipClass(a: BrandActivity): string {
+    return `activity-chip activity-chip--${a.status}`;
+  }
+
+  /** Completed chips are clickable to jump to artifacts; running chips aren't. */
+  isOpenable(a: BrandActivity): boolean {
+    return a.status === 'completed';
+  }
+
+  isRetryable(a: BrandActivity): boolean {
+    return a.status === 'failed' || a.status === 'cancelled';
+  }
+
+  isDismissable(a: BrandActivity): boolean {
+    return (
+      a.status === 'completed' ||
+      a.status === 'failed' ||
+      a.status === 'cancelled'
+    );
+  }
+
+  onOpen(event: Event, a: BrandActivity): void {
+    if (!this.isOpenable(a)) return;
+    event.stopPropagation();
+    this.open.emit(a);
+  }
+
+  onRetry(event: Event, a: BrandActivity): void {
+    event.stopPropagation();
+    this.retry.emit(a);
+  }
+
+  onDismiss(event: Event, a: BrandActivity): void {
+    event.stopPropagation();
+    this.dismiss.emit(a);
+  }
+
+  private relative(iso?: string | null): string {
+    if (!iso) return '';
+    const then = Date.parse(iso);
+    if (Number.isNaN(then)) return '';
+    const diffMs = Date.now() - then;
+    if (diffMs < 60_000) return ' · just now';
+    const mins = Math.round(diffMs / 60_000);
+    if (mins < 60) return ` · ${mins}m ago`;
+    const hours = Math.round(mins / 60);
+    if (hours < 24) return ` · ${hours}h ago`;
+    return '';
+  }
+}

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.html
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.html
@@ -193,18 +193,56 @@
                     [class.brand-item--highlight]="highlightedBrandId === b.id"
                     [attr.data-brand-id]="b.id"
                   >
-                    <strong>{{ b.name }}</strong> ({{ b.status }}, v{{ b.version }})
-                    <span class="brand-actions">
-                      <button mat-stroked-button type="button" [disabled]="brandFormBusy" (click)="runBrand(b)">
-                        Run
-                      </button>
-                      <button mat-stroked-button type="button" [disabled]="brandFormBusy" (click)="requestMarketResearchForBrand(b)">
-                        Market Research
-                      </button>
-                      <button mat-stroked-button type="button" [disabled]="brandFormBusy" (click)="requestDesignAssetsForBrand(b)">
-                        Design Assets
-                      </button>
-                    </span>
+                    <div class="brand-item__header">
+                      <strong>{{ b.name }}</strong> ({{ b.status }}, v{{ b.version }})
+                      <span class="brand-actions">
+                        <span class="split-button">
+                          <button
+                            mat-stroked-button
+                            type="button"
+                            class="split-button__primary"
+                            (click)="runBrand(b)"
+                            [disabled]="isGenerating(b.id)"
+                          >
+                            <mat-icon>bolt</mat-icon>
+                            Generate
+                          </button>
+                          <button
+                            mat-stroked-button
+                            type="button"
+                            class="split-button__menu"
+                            [matMenuTriggerFor]="generateMenu"
+                            [disabled]="isGenerating(b.id)"
+                            aria-label="Generate options"
+                          >
+                            <mat-icon>arrow_drop_down</mat-icon>
+                          </button>
+                        </span>
+                        <mat-menu #generateMenu="matMenu" xPosition="before">
+                          <button mat-menu-item type="button" (click)="runBrand(b)">
+                            <mat-icon>bolt</mat-icon>
+                            <span class="menu-item__title">Run full pipeline</span>
+                            <span class="menu-item__subtitle">Strategic core through governance (5-phase)</span>
+                          </button>
+                          <button mat-menu-item type="button" (click)="requestMarketResearchForBrand(b)">
+                            <mat-icon>travel_explore</mat-icon>
+                            <span class="menu-item__title">Market research only</span>
+                            <span class="menu-item__subtitle">Competitor and audience analysis</span>
+                          </button>
+                          <button mat-menu-item type="button" (click)="requestDesignAssetsForBrand(b)">
+                            <mat-icon>palette</mat-icon>
+                            <span class="menu-item__title">Design assets only</span>
+                            <span class="menu-item__subtitle">Palettes, typography, moodboards</span>
+                          </button>
+                        </mat-menu>
+                      </span>
+                    </div>
+                    <app-brand-activity-strip
+                      [brandId]="b.id"
+                      (open)="onActivityOpen($event)"
+                      (retry)="onActivityRetry(b, $event)"
+                      (dismiss)="onActivityDismiss($event)"
+                    />
                   </li>
                 }
               </ul>

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.scss
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.scss
@@ -239,13 +239,20 @@ mat-card {
 
 .brand-item {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 12px;
-  padding: 8px 0;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+  padding: 10px 0;
   border-bottom: 1px solid #eee;
   border-radius: 4px;
   transition: background 0.3s ease;
+}
+
+.brand-item__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 12px;
 }
 
 .brand-item--highlight {
@@ -256,6 +263,35 @@ mat-card {
   display: flex;
   gap: 8px;
   margin-left: auto;
+}
+
+.split-button {
+  display: inline-flex;
+  align-items: stretch;
+
+  .split-button__primary {
+    border-top-right-radius: 0;
+    border-bottom-right-radius: 0;
+    margin-right: -1px;
+  }
+
+  .split-button__menu {
+    border-top-left-radius: 0;
+    border-bottom-left-radius: 0;
+    min-width: 36px;
+    padding: 0 4px;
+  }
+}
+
+.menu-item__title {
+  display: block;
+  font-weight: 500;
+}
+
+.menu-item__subtitle {
+  display: block;
+  font-size: 0.8rem;
+  color: rgba(0, 0, 0, 0.6);
 }
 
 .action-message {

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.spec.ts
@@ -1,11 +1,13 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { of, throwError } from 'rxjs';
+import { Subject, of, throwError } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ActivatedRoute } from '@angular/router';
 import { vi } from 'vitest';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { BrandingApiService } from '../../services/branding-api.service';
+import { BrandingApiService, type BrandJobStatus } from '../../services/branding-api.service';
+import { BrandActivityService } from '../../services/brand-activity.service';
 import { BrandingDashboardComponent } from './branding-dashboard.component';
+import type { Brand } from '../../models';
 
 const fakeRoute = { snapshot: { queryParamMap: { get: () => null } } };
 
@@ -22,6 +24,11 @@ describe('BrandingDashboardComponent', () => {
     createBrand: ReturnType<typeof vi.fn>;
     getBrand: ReturnType<typeof vi.fn>;
     createConversation: ReturnType<typeof vi.fn>;
+    submitRun: ReturnType<typeof vi.fn>;
+    observeJob: ReturnType<typeof vi.fn>;
+    listJobs: ReturnType<typeof vi.fn>;
+    requestMarketResearch: ReturnType<typeof vi.fn>;
+    requestDesignAssets: ReturnType<typeof vi.fn>;
   };
   let snackBarSpy: { open: ReturnType<typeof vi.fn> };
 
@@ -40,6 +47,11 @@ describe('BrandingDashboardComponent', () => {
       createBrand: vi.fn(),
       getBrand: vi.fn(),
       createConversation: vi.fn().mockReturnValue(of(emptyConversationState)),
+      submitRun: vi.fn(),
+      observeJob: vi.fn(),
+      listJobs: vi.fn().mockReturnValue(of([])),
+      requestMarketResearch: vi.fn(),
+      requestDesignAssets: vi.fn(),
     };
     await TestBed.configureTestingModule({
       imports: [BrandingDashboardComponent, NoopAnimationsModule],
@@ -118,6 +130,122 @@ describe('BrandingDashboardComponent', () => {
     component.selectBrandForChat(brand);
     expect(component.selectedBrand).toEqual(brand);
     expect(component.activeConversationId).toBe('conv-123');
+  });
+
+  it('runBrand submits, tracks the job, and updates the activity chip', () => {
+    const brand: Brand = {
+      id: 'b1',
+      client_id: 'w1',
+      name: 'B',
+      status: 'draft',
+      conversation_id: null,
+      mission: {} as any,
+      version: 1,
+      history: [],
+      created_at: '',
+      updated_at: '',
+    };
+    component.selectedClient = { id: 'w1', name: 'My brands', created_at: '', updated_at: '' };
+    component.brands = [brand];
+    const statusSubject = new Subject<BrandJobStatus>();
+    apiSpy.submitRun.mockReturnValue(of({ job_id: 'j1', status: 'queued' }));
+    apiSpy.observeJob.mockReturnValue(statusSubject.asObservable());
+    apiSpy.getBrand.mockReturnValue(of(brand));
+
+    component.runBrand(brand);
+
+    const store = TestBed.inject(BrandActivityService);
+    const running = store.snapshot().find((a) => a.brandId === 'b1');
+    expect(running).toBeTruthy();
+    expect(running!.jobId).toBe('j1');
+    expect(component.isGenerating('b1')).toBe(true);
+
+    statusSubject.next({ job_id: 'j1', status: 'running', current_phase: 'Visual Identity' });
+    const mid = store.snapshot().find((a) => a.id === running!.id);
+    expect(mid!.status).toBe('running');
+    expect(mid!.phase).toBe('Visual Identity');
+
+    statusSubject.next({ job_id: 'j1', status: 'completed', updated_at: '2026-04-22T10:00:00Z' });
+    statusSubject.complete();
+    const final = store.snapshot().find((a) => a.id === running!.id);
+    expect(final!.status).toBe('completed');
+    expect(component.isGenerating('b1')).toBe(false);
+    expect(apiSpy.getBrand).toHaveBeenCalledWith('w1', 'b1');
+  });
+
+  it('runBrand failure pushes a failed activity and exposes the error', () => {
+    const brand: Brand = {
+      id: 'b1', client_id: 'w1', name: 'B', status: 'draft',
+      mission: {} as any, version: 1, history: [], created_at: '', updated_at: '',
+    };
+    component.selectedClient = { id: 'w1', name: 'My brands', created_at: '', updated_at: '' };
+    component.brands = [brand];
+    apiSpy.submitRun.mockReturnValue(throwError(() => ({ error: { detail: 'nope' } })));
+
+    component.runBrand(brand);
+
+    const store = TestBed.inject(BrandActivityService);
+    const activity = store.snapshot().find((a) => a.brandId === 'b1');
+    expect(activity!.status).toBe('failed');
+    expect(activity!.error).toBe('nope');
+  });
+
+  it('requestMarketResearchForBrand pushes a research activity', () => {
+    const brand: Brand = {
+      id: 'b1', client_id: 'w1', name: 'B', status: 'draft',
+      mission: {} as any, version: 1, history: [], created_at: '', updated_at: '',
+    };
+    component.selectedClient = { id: 'w1', name: 'My brands', created_at: '', updated_at: '' };
+    apiSpy.requestMarketResearch.mockReturnValue(
+      of({ summary: 'S', similar_brands: [], insights: [], source: 'x' })
+    );
+
+    component.requestMarketResearchForBrand(brand);
+
+    const store = TestBed.inject(BrandActivityService);
+    const activity = store.snapshot().find((a) => a.brandId === 'b1');
+    expect(activity!.kind).toBe('research');
+    expect(activity!.status).toBe('completed');
+  });
+
+  it('onActivityRetry removes the old chip and re-fires the same kind', () => {
+    const brand: Brand = {
+      id: 'b1', client_id: 'w1', name: 'B', status: 'draft',
+      mission: {} as any, version: 1, history: [], created_at: '', updated_at: '',
+    };
+    component.selectedClient = { id: 'w1', name: 'My brands', created_at: '', updated_at: '' };
+    apiSpy.requestDesignAssets.mockReturnValue(of({ request_id: 'r1', status: 'pending', artifacts: [] }));
+    const store = TestBed.inject(BrandActivityService);
+    const failed = store.start('design', 'b1');
+    store.update(failed.id, { status: 'failed', error: 'prev failure' });
+
+    component.onActivityRetry(brand, store.snapshot()[0]);
+
+    expect(apiSpy.requestDesignAssets).toHaveBeenCalledWith('w1', 'b1');
+    const snap = store.snapshot();
+    expect(snap).toHaveLength(1);
+    expect(snap[0].id).not.toBe(failed.id);
+    expect(snap[0].status).toBe('completed');
+  });
+
+  it('selectClient hydrates running jobs for the workspace', () => {
+    const brand: Brand = {
+      id: 'b1', client_id: 'w1', name: 'B', status: 'draft',
+      mission: {} as any, version: 1, history: [], created_at: '', updated_at: '',
+    };
+    apiSpy.listBrands.mockReturnValue(of([brand]));
+    apiSpy.listJobs.mockReturnValue(
+      of([{ job_id: 'hydrated', status: 'running', brand_id: 'b1' }])
+    );
+    apiSpy.observeJob.mockReturnValue(new Subject().asObservable());
+
+    component.selectClient({ id: 'w1', name: 'My brands', created_at: '', updated_at: '' });
+
+    expect(apiSpy.listJobs).toHaveBeenCalledWith(true);
+    const store = TestBed.inject(BrandActivityService);
+    const hydrated = store.snapshot().find((a) => a.jobId === 'hydrated');
+    expect(hydrated).toBeTruthy();
+    expect(hydrated!.brandId).toBe('b1');
   });
 });
 

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
@@ -24,7 +24,6 @@ import { BrandActivityStripComponent } from '../brand-activity-strip/brand-activ
 import type {
   Brand,
   BrandActivity,
-  BrandActivityKind,
   BrandingMissionSnapshot,
   BrandingQuestion,
   BrandingSessionResponse,
@@ -641,7 +640,7 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
   }
 
   onActivityOpen(activity: BrandActivity): void {
-    this.openActivityArtifacts(activity.brandId, activity.kind);
+    this.openActivityArtifacts(activity.brandId);
   }
 
   onActivityRetry(brand: Brand, activity: BrandActivity): void {
@@ -668,7 +667,7 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
    * the Chat tab (which hosts the preview panel) — precise per-phase anchoring
    * will arrive with the phase stepper in #277.
    */
-  private openActivityArtifacts(brandId: string, _kind?: BrandActivityKind): void {
+  private openActivityArtifacts(brandId: string): void {
     const brand = this.brands.find((b) => b.id === brandId);
     if (brand) {
       this.resumeOrStartBrand(brand);

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
@@ -14,13 +14,17 @@ import { MatMenuModule } from '@angular/material/menu';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { BrandingApiService } from '../../services/branding-api.service';
+import { BrandActivityService } from '../../services/brand-activity.service';
 import { LoadingSpinnerComponent } from '../../shared/loading-spinner/loading-spinner.component';
 import { ErrorMessageComponent } from '../../shared/error-message/error-message.component';
 import { HealthIndicatorComponent } from '../health-indicator/health-indicator.component';
 import { BrandingChatComponent } from '../branding-chat/branding-chat.component';
 import { BrandPreviewComponent } from '../brand-preview/brand-preview.component';
+import { BrandActivityStripComponent } from '../brand-activity-strip/brand-activity-strip.component';
 import type {
   Brand,
+  BrandActivity,
+  BrandActivityKind,
   BrandingMissionSnapshot,
   BrandingQuestion,
   BrandingSessionResponse,
@@ -56,6 +60,7 @@ const WORKSPACE_CLIENT_NAME = 'My brands';
     HealthIndicatorComponent,
     BrandingChatComponent,
     BrandPreviewComponent,
+    BrandActivityStripComponent,
   ],
   templateUrl: './branding-dashboard.component.html',
   styleUrl: './branding-dashboard.component.scss',
@@ -67,6 +72,9 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
   private readonly breakpoint = inject(BreakpointObserver);
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
+  private readonly activityStore = inject(BrandActivityService);
+  /** Per-activity-id polling subscriptions so we can clean up on destroy. */
+  private readonly activityPolls = new Map<string, Subscription>();
 
   @ViewChild('brandListWrap') private brandListWrap?: ElementRef<HTMLElement>;
 
@@ -343,6 +351,7 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
         this.brands = list;
         this.applyDefaultBrandSelection();
         this.syncBrandPreviewFromSelection();
+        this.hydrateRunningJobs();
         this.loading = false;
       },
       error: () => {
@@ -505,59 +514,190 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
     });
   }
 
+  /**
+   * True when this brand currently has a running or queued activity of any
+   * kind. Disables the split-button so users can't double-fire pipelines for
+   * the same brand.
+   */
+  isGenerating(brandId: string): boolean {
+    return this.activityStore
+      .snapshot()
+      .some(
+        (a) => a.brandId === brandId && (a.status === 'running' || a.status === 'queued')
+      );
+  }
+
   runBrand(brand: Brand): void {
     if (!this.selectedClient) return;
-    this.brandFormBusy = true;
+    const activity = this.activityStore.start('run', brand.id);
     this.brandActionMessage = null;
-    this.api.runBrand(this.selectedClient.id, brand.id).subscribe({
-      next: () => {
-        this.brandActionMessage = 'Brand run completed. Output saved to brand version.';
-        this.brandFormBusy = false;
-        this.snackBar.open(this.brandActionMessage, 'Dismiss', { duration: 5000 });
-        this.api.getBrand(this.selectedClient!.id, brand.id).subscribe({
-          next: (updated) => {
-            this.brands = this.brands.map((b) => (b.id === brand.id ? updated : b));
-            this.selectedBrand = this.selectedBrand?.id === brand.id ? updated : this.selectedBrand;
-          },
+    const clientId = this.selectedClient.id;
+    this.api.submitRun(clientId, brand.id).subscribe({
+      next: (submission) => {
+        this.activityStore.update(activity.id, {
+          jobId: submission.job_id,
+          status: 'queued',
         });
+        this.trackRunActivity(clientId, brand, activity.id, submission.job_id);
       },
       error: (err) => {
-        this.error = err?.error?.detail ?? err?.message ?? 'Run failed';
-        this.brandFormBusy = false;
+        this.finishActivityWithError(activity.id, err, 'Run failed');
       },
     });
   }
 
   requestMarketResearchForBrand(brand: Brand): void {
     if (!this.selectedClient) return;
-    this.brandFormBusy = true;
+    const activity = this.activityStore.start('research', brand.id);
+    this.activityStore.update(activity.id, { status: 'running' });
     this.brandActionMessage = null;
     this.api.requestMarketResearch(this.selectedClient.id, brand.id).subscribe({
       next: (snapshot) => {
+        this.activityStore.update(activity.id, {
+          status: 'completed',
+          completedAt: new Date().toISOString(),
+        });
         this.brandActionMessage = `Market research: ${snapshot.summary.slice(0, 80)}...`;
-        this.brandFormBusy = false;
         this.snackBar.open(this.brandActionMessage, 'Dismiss', { duration: 6000 });
       },
       error: (err) => {
-        this.error = err?.error?.detail ?? err?.message ?? 'Market research request failed';
-        this.brandFormBusy = false;
+        this.finishActivityWithError(activity.id, err, 'Market research request failed');
       },
     });
   }
 
   requestDesignAssetsForBrand(brand: Brand): void {
     if (!this.selectedClient) return;
-    this.brandFormBusy = true;
+    const activity = this.activityStore.start('design', brand.id);
+    this.activityStore.update(activity.id, { status: 'running' });
     this.brandActionMessage = null;
     this.api.requestDesignAssets(this.selectedClient.id, brand.id).subscribe({
       next: (result) => {
+        this.activityStore.update(activity.id, {
+          status: 'completed',
+          completedAt: new Date().toISOString(),
+        });
         this.brandActionMessage = `Design request ${result.request_id} (${result.status}).`;
-        this.brandFormBusy = false;
         this.snackBar.open(this.brandActionMessage, 'Dismiss', { duration: 5000 });
       },
       error: (err) => {
-        this.error = err?.error?.detail ?? err?.message ?? 'Design assets request failed';
-        this.brandFormBusy = false;
+        this.finishActivityWithError(activity.id, err, 'Design assets request failed');
+      },
+    });
+  }
+
+  /**
+   * Subscribe to `observeJob` and mirror each status poll onto the matching
+   * activity chip. On terminal success, refresh the brand so the preview panel
+   * reflects the new output.
+   */
+  private trackRunActivity(clientId: string, brand: Brand, activityId: string, jobId: string): void {
+    this.activityPolls.get(activityId)?.unsubscribe();
+    const sub = this.api.observeJob(jobId).subscribe({
+      next: (status) => {
+        this.activityStore.applyJobStatus(activityId, status);
+        if (status.status === 'completed') {
+          this.api.getBrand(clientId, brand.id).subscribe({
+            next: (updated) => {
+              this.brands = this.brands.map((b) => (b.id === brand.id ? updated : b));
+              if (this.selectedBrand?.id === brand.id) {
+                this.selectedBrand = updated;
+                this.conversationLatestOutput =
+                  (updated.latest_output as BrandingTeamOutput | null) ?? null;
+              }
+              this.snackBar.open(
+                `Brand "${brand.name}" run completed.`,
+                'View',
+                { duration: 5000 }
+              ).onAction().subscribe(() => this.openActivityArtifacts(brand.id));
+            },
+          });
+        } else if (status.status === 'failed' || status.status === 'cancelled') {
+          this.snackBar.open(
+            status.error || `Brand run ${status.status}.`,
+            'Dismiss',
+            { duration: 6000 }
+          );
+        }
+      },
+      error: (err) => this.finishActivityWithError(activityId, err, 'Run failed'),
+      complete: () => {
+        this.activityPolls.delete(activityId);
+      },
+    });
+    this.activityPolls.set(activityId, sub);
+  }
+
+  private finishActivityWithError(activityId: string, err: unknown, fallback: string): void {
+    const message = (err as { error?: { detail?: string }; message?: string })?.error?.detail
+      ?? (err as { message?: string })?.message
+      ?? fallback;
+    this.activityStore.update(activityId, {
+      status: 'failed',
+      error: message,
+      completedAt: new Date().toISOString(),
+    });
+    this.snackBar.open(message, 'Dismiss', { duration: 6000 });
+  }
+
+  onActivityOpen(activity: BrandActivity): void {
+    this.openActivityArtifacts(activity.brandId, activity.kind);
+  }
+
+  onActivityRetry(brand: Brand, activity: BrandActivity): void {
+    this.activityStore.remove(activity.id);
+    switch (activity.kind) {
+      case 'run':
+        this.runBrand(brand);
+        break;
+      case 'research':
+        this.requestMarketResearchForBrand(brand);
+        break;
+      case 'design':
+        this.requestDesignAssetsForBrand(brand);
+        break;
+    }
+  }
+
+  onActivityDismiss(activity: BrandActivity): void {
+    this.activityStore.remove(activity.id);
+  }
+
+  /**
+   * Jump to the brand preview. Today this selects the brand and switches to
+   * the Chat tab (which hosts the preview panel) — precise per-phase anchoring
+   * will arrive with the phase stepper in #277.
+   */
+  private openActivityArtifacts(brandId: string, _kind?: BrandActivityKind): void {
+    const brand = this.brands.find((b) => b.id === brandId);
+    if (brand) {
+      this.resumeOrStartBrand(brand);
+    }
+    this.selectedTabIndex = 0;
+  }
+
+  /**
+   * Fetch in-flight jobs for the current workspace and seed the activity
+   * strip so a page reload mid-run does not hide the chip.
+   */
+  private hydrateRunningJobs(): void {
+    if (!this.brands.length) return;
+    const knownBrandIds = new Set(this.brands.map((b) => b.id));
+    this.api.listJobs(true).subscribe({
+      next: (jobs) => {
+        const before = new Set(this.activityStore.snapshot().map((a) => a.id));
+        this.activityStore.hydrateFromJobs(jobs, knownBrandIds);
+        for (const activity of this.activityStore.snapshot()) {
+          if (before.has(activity.id)) continue;
+          if (activity.kind !== 'run' || !activity.jobId) continue;
+          const brand = this.brands.find((b) => b.id === activity.brandId);
+          const clientId = this.selectedClient?.id;
+          if (!brand || !clientId) continue;
+          this.trackRunActivity(clientId, brand, activity.id, activity.jobId);
+        }
+      },
+      error: () => {
+        /* Silent: hydration is best-effort. */
       },
     });
   }
@@ -574,6 +714,10 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
   ngOnDestroy(): void {
     this.pollSub?.unsubscribe();
     this.layoutSub?.unsubscribe();
+    for (const sub of this.activityPolls.values()) {
+      sub.unsubscribe();
+    }
+    this.activityPolls.clear();
   }
 
   startSession(): void {

--- a/user-interface/src/app/models/branding.model.ts
+++ b/user-interface/src/app/models/branding.model.ts
@@ -248,3 +248,41 @@ export interface ConversationSummary {
   updated_at: string;
   message_count: number;
 }
+
+/**
+ * Which generate action an activity represents. These map onto the Form-tab
+ * split-button menu ("Run full pipeline", "Market research only", "Design
+ * assets only") and the section the user jumps to when opening a completed
+ * chip.
+ */
+export type BrandActivityKind = 'run' | 'research' | 'design';
+
+export type BrandActivityStatus =
+  | 'queued'
+  | 'running'
+  | 'completed'
+  | 'failed'
+  | 'cancelled';
+
+/**
+ * A single in-flight or recently-finished job against a brand. Shown as a
+ * status chip under each brand row. `jobId` is set for async runs (where the
+ * backend returns a job id); synchronous requests (market research, design
+ * assets) track only in the client.
+ */
+export interface BrandActivity {
+  /** Client-generated id so we can update/retry a specific chip. */
+  id: string;
+  brandId: string;
+  kind: BrandActivityKind;
+  status: BrandActivityStatus;
+  /** Present when `kind === 'run'` and the backend accepted the submission. */
+  jobId?: string | null;
+  /** Human-readable phase label emitted by the backend, e.g. "Visual Identity". */
+  phase?: string | null;
+  /** Optional numeric progress; 0-100 if the backend reports it. */
+  progress?: number | null;
+  error?: string | null;
+  startedAt: string;
+  completedAt?: string | null;
+}

--- a/user-interface/src/app/services/brand-activity.service.spec.ts
+++ b/user-interface/src/app/services/brand-activity.service.spec.ts
@@ -1,0 +1,100 @@
+import { firstValueFrom } from 'rxjs';
+import { first } from 'rxjs/operators';
+import { BrandActivityService } from './brand-activity.service';
+import type { BrandJobListItem, BrandJobStatus } from './branding-api.service';
+
+describe('BrandActivityService', () => {
+  let service: BrandActivityService;
+
+  beforeEach(() => {
+    service = new BrandActivityService();
+  });
+
+  it('start() creates an activity in queued state and emits it on forBrand()', async () => {
+    const activity = service.start('run', 'b1');
+    expect(activity.status).toBe('queued');
+    expect(activity.brandId).toBe('b1');
+    const list = await firstValueFrom(service.forBrand('b1').pipe(first()));
+    expect(list.map((a) => a.id)).toEqual([activity.id]);
+  });
+
+  it('update() merges patches without touching identity fields', () => {
+    const a = service.start('run', 'b1');
+    service.update(a.id, { status: 'running', phase: 'Visual Identity' });
+    const [after] = service.snapshot();
+    expect(after.status).toBe('running');
+    expect(after.phase).toBe('Visual Identity');
+    expect(after.id).toBe(a.id);
+    expect(after.brandId).toBe('b1');
+    expect(after.kind).toBe('run');
+  });
+
+  it('remove() drops the activity', () => {
+    const a = service.start('run', 'b1');
+    service.remove(a.id);
+    expect(service.snapshot()).toHaveLength(0);
+  });
+
+  it('forBrand() isolates activities by brand and sorts newest first', async () => {
+    const a1 = service.start('run', 'b1');
+    // Force distinct timestamps so sort is deterministic.
+    service.update(a1.id, { startedAt: '2020-01-01T00:00:00Z' });
+    const a2 = service.start('research', 'b1');
+    service.update(a2.id, { startedAt: '2020-01-02T00:00:00Z' });
+    service.start('run', 'b2');
+    const list = await firstValueFrom(service.forBrand('b1').pipe(first()));
+    expect(list.map((a) => a.id)).toEqual([a2.id, a1.id]);
+  });
+
+  it('applyJobStatus() maps running -> running and preserves phase/progress', () => {
+    const a = service.start('run', 'b1');
+    const poll: BrandJobStatus = {
+      job_id: 'j1',
+      status: 'running',
+      current_phase: 'Visual Identity',
+      progress: 42,
+    };
+    service.applyJobStatus(a.id, poll);
+    const [after] = service.snapshot();
+    expect(after.status).toBe('running');
+    expect(after.phase).toBe('Visual Identity');
+    expect(after.progress).toBe(42);
+    expect(after.completedAt).toBeNull();
+  });
+
+  it('applyJobStatus() marks completed with a completedAt timestamp', () => {
+    const a = service.start('run', 'b1');
+    service.applyJobStatus(a.id, {
+      job_id: 'j1',
+      status: 'completed',
+      updated_at: '2026-04-22T12:00:00Z',
+    });
+    const [after] = service.snapshot();
+    expect(after.status).toBe('completed');
+    expect(after.completedAt).toBe('2026-04-22T12:00:00Z');
+  });
+
+  it('hydrateFromJobs() adopts running jobs for known brands', () => {
+    const jobs: BrandJobListItem[] = [
+      { job_id: 'j1', status: 'running', brand_id: 'b1', created_at: '2026-04-22T10:00:00Z' },
+      { job_id: 'j2', status: 'running', brand_id: 'b-other' }, // wrong workspace
+      { job_id: 'j3', status: 'completed', brand_id: 'b1' }, // terminal
+    ];
+    service.hydrateFromJobs(jobs, new Set(['b1']));
+    const snap = service.snapshot();
+    expect(snap).toHaveLength(1);
+    expect(snap[0].jobId).toBe('j1');
+    expect(snap[0].kind).toBe('run');
+    expect(snap[0].status).toBe('running');
+  });
+
+  it('hydrateFromJobs() does not duplicate an already-tracked job', () => {
+    const a = service.start('run', 'b1', 'j1');
+    service.update(a.id, { status: 'running' });
+    service.hydrateFromJobs(
+      [{ job_id: 'j1', status: 'running', brand_id: 'b1' }],
+      new Set(['b1'])
+    );
+    expect(service.snapshot()).toHaveLength(1);
+  });
+});

--- a/user-interface/src/app/services/brand-activity.service.ts
+++ b/user-interface/src/app/services/brand-activity.service.ts
@@ -1,0 +1,137 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import type {
+  BrandActivity,
+  BrandActivityKind,
+  BrandActivityStatus,
+} from '../models';
+import type { BrandJobListItem, BrandJobStatus } from './branding-api.service';
+
+/**
+ * Client-side activity store for the per-brand activity strip. Holds a flat
+ * list of {@link BrandActivity} entries; callers filter per brand at the
+ * render edge. State is in-memory only — a page reload rehydrates running
+ * entries from `GET /branding/jobs?running_only=true` and drops finished
+ * chips.
+ */
+@Injectable({ providedIn: 'root' })
+export class BrandActivityService {
+  private readonly subject = new BehaviorSubject<BrandActivity[]>([]);
+
+  readonly activities$: Observable<BrandActivity[]> = this.subject.asObservable();
+
+  /** Reactive view of activities for a single brand, sorted newest first. */
+  forBrand(brandId: string): Observable<BrandActivity[]> {
+    return this.activities$.pipe(
+      map((list) =>
+        list
+          .filter((a) => a.brandId === brandId)
+          .sort((a, b) => b.startedAt.localeCompare(a.startedAt))
+      )
+    );
+  }
+
+  /** Current snapshot; used by the dashboard for imperative retry/open flows. */
+  snapshot(): BrandActivity[] {
+    return this.subject.getValue();
+  }
+
+  /** Create and return a new activity in `queued` state. */
+  start(kind: BrandActivityKind, brandId: string, jobId?: string | null): BrandActivity {
+    const activity: BrandActivity = {
+      id: this.generateId(),
+      brandId,
+      kind,
+      status: 'queued',
+      jobId: jobId ?? null,
+      startedAt: new Date().toISOString(),
+    };
+    this.subject.next([...this.subject.getValue(), activity]);
+    return activity;
+  }
+
+  /** Merge a partial patch into an existing activity. No-op if the id is gone. */
+  update(id: string, patch: Partial<Omit<BrandActivity, 'id' | 'brandId' | 'kind'>>): void {
+    const list = this.subject.getValue();
+    const idx = list.findIndex((a) => a.id === id);
+    if (idx === -1) return;
+    const merged: BrandActivity = { ...list[idx], ...patch };
+    const next = list.slice();
+    next[idx] = merged;
+    this.subject.next(next);
+  }
+
+  remove(id: string): void {
+    this.subject.next(this.subject.getValue().filter((a) => a.id !== id));
+  }
+
+  /** Drop every activity belonging to a brand (e.g. brand deleted). */
+  clearForBrand(brandId: string): void {
+    this.subject.next(this.subject.getValue().filter((a) => a.brandId !== brandId));
+  }
+
+  /**
+   * Seed the store with running jobs fetched from the backend on page load,
+   * so a refresh during an in-flight run does not hide the chip. Jobs whose
+   * brand is not in `knownBrandIds` are ignored — they belong to a different
+   * workspace.
+   */
+  hydrateFromJobs(jobs: BrandJobListItem[], knownBrandIds: Set<string>): void {
+    const runningLike: BrandActivityStatus[] = ['queued', 'running'];
+    const existing = new Set(this.subject.getValue().map((a) => a.jobId).filter((j): j is string => !!j));
+    const additions: BrandActivity[] = [];
+    for (const job of jobs) {
+      if (!job.brand_id || !knownBrandIds.has(job.brand_id)) continue;
+      if (existing.has(job.job_id)) continue;
+      const status = mapJobStatus(job.status);
+      if (!runningLike.includes(status)) continue;
+      additions.push({
+        id: this.generateId(),
+        brandId: job.brand_id,
+        kind: 'run',
+        status,
+        jobId: job.job_id,
+        startedAt: job.created_at ?? new Date().toISOString(),
+      });
+    }
+    if (additions.length) {
+      this.subject.next([...this.subject.getValue(), ...additions]);
+    }
+  }
+
+  /** Apply a polled job status to the matching activity chip. */
+  applyJobStatus(activityId: string, status: BrandJobStatus): void {
+    const mapped = mapJobStatus(status.status);
+    const isTerminal = mapped === 'completed' || mapped === 'failed' || mapped === 'cancelled';
+    this.update(activityId, {
+      status: mapped,
+      phase: status.current_phase ?? null,
+      progress: status.progress ?? null,
+      error: status.error ?? null,
+      completedAt: isTerminal ? status.updated_at ?? new Date().toISOString() : null,
+    });
+  }
+
+  private generateId(): string {
+    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
+      return crypto.randomUUID();
+    }
+    return `act-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+  }
+}
+
+function mapJobStatus(status: string): BrandActivityStatus {
+  switch (status) {
+    case 'completed':
+      return 'completed';
+    case 'failed':
+      return 'failed';
+    case 'cancelled':
+      return 'cancelled';
+    case 'running':
+      return 'running';
+    default:
+      return 'queued';
+  }
+}

--- a/user-interface/src/app/services/branding-api.service.spec.ts
+++ b/user-interface/src/app/services/branding-api.service.spec.ts
@@ -59,4 +59,30 @@ describe('BrandingApiService', () => {
       answered_questions: [],
     });
   });
+
+  it('listJobs(true) hits /branding/jobs?running_only=true', () => {
+    const payload = { jobs: [{ job_id: 'j1', status: 'running', brand_id: 'b1' }] };
+    service.listJobs(true).subscribe((jobs) => {
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0].job_id).toBe('j1');
+    });
+    const req = httpMock.expectOne(`${baseUrl}/branding/jobs?running_only=true`);
+    expect(req.request.method).toBe('GET');
+    req.flush(payload);
+  });
+
+  it('observeJob emits intermediate running status before terminal', () => {
+    const received: string[] = [];
+    const sub = service.observeJob('j1').subscribe({
+      next: (status) => received.push(status.status),
+    });
+
+    const first = httpMock.expectOne(`${baseUrl}/branding/status/j1`);
+    first.flush({ job_id: 'j1', status: 'running', current_phase: 'Visual Identity' });
+
+    // Intermediate status reached the subscriber; no second poll yet (timer).
+    expect(received).toEqual(['running']);
+
+    sub.unsubscribe();
+  });
 });

--- a/user-interface/src/app/services/branding-api.service.ts
+++ b/user-interface/src/app/services/branding-api.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, inject } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, EMPTY, of, throwError, timer } from 'rxjs';
-import { expand, first, switchMap } from 'rxjs/operators';
+import { expand, first, map, switchMap } from 'rxjs/operators';
 import { environment } from '../../environments/environment';
 import type {
   Brand,
@@ -21,17 +21,36 @@ import type {
   HealthResponse,
 } from '../models';
 
-interface BrandJobSubmission {
+export interface BrandJobSubmission {
   job_id: string;
   status: string;
 }
 
-interface BrandJobStatus {
+export interface BrandJobStatus {
   job_id: string;
   status: string;
+  client_id?: string | null;
+  brand_id?: string | null;
   current_phase?: string | null;
+  progress?: number | null;
   result?: BrandingTeamOutput | null;
   error?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+export interface BrandJobListItem {
+  job_id: string;
+  status: string;
+  client_id?: string | null;
+  brand_id?: string | null;
+  created_at?: string | null;
+  updated_at?: string | null;
+}
+
+/** A job status is terminal when no further polls will change it. */
+export function isTerminalJobStatus(status: string): boolean {
+  return status === 'completed' || status === 'failed' || status === 'cancelled';
 }
 
 const BRANDING_POLL_INTERVAL_MS = 2000;
@@ -100,17 +119,31 @@ export class BrandingApiService {
     return this.http.get<BrandJobStatus>(`${this.baseUrl}/branding/status/${jobId}`);
   }
 
-  private pollJob(jobId: string): Observable<BrandingTeamOutput> {
+  /**
+   * Poll a branding job and emit every status update — including intermediate
+   * phase transitions — until a terminal status. Used by the per-brand activity
+   * strip; unlike `runBrand`, this does not collapse to just the final result.
+   */
+  observeJob(jobId: string): Observable<BrandJobStatus> {
     const poll$ = this.getJobStatus(jobId);
     return poll$.pipe(
       expand((job) =>
-        job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled'
+        isTerminalJobStatus(job.status)
           ? EMPTY
           : timer(BRANDING_POLL_INTERVAL_MS).pipe(switchMap(() => poll$))
-      ),
-      first((job) =>
-        job.status === 'completed' || job.status === 'failed' || job.status === 'cancelled'
-      ),
+      )
+    );
+  }
+
+  /** List branding jobs; pass `runningOnly=true` to hydrate the activity strip on mount. */
+  listJobs(runningOnly = false): Observable<BrandJobListItem[]> {
+    const url = `${this.baseUrl}/branding/jobs${runningOnly ? '?running_only=true' : ''}`;
+    return this.http.get<{ jobs: BrandJobListItem[] }>(url).pipe(map((r) => r.jobs));
+  }
+
+  private pollJob(jobId: string): Observable<BrandingTeamOutput> {
+    return this.observeJob(jobId).pipe(
+      first((job) => isTerminalJobStatus(job.status)),
       switchMap((job) =>
         job.status === 'completed' && job.result
           ? of(job.result)


### PR DESCRIPTION
## Summary
Closes #276.

Each brand row on the Branding **Form** tab now surfaces its async work as live status chips instead of an opaque toast, and the three anonymous buttons (`Run`, `Market Research`, `Design Assets`) collapse into a single **Generate** split-button with a labelled menu. Intermediate run phases, failures with retry, and hydrated in-flight jobs after a page reload are all visible without leaving the tab.

- `BrandingApiService`: new `observeJob()` emits every status poll (not just the terminal result) and `listJobs(runningOnly)` for hydration.
- `BrandActivityService`: in-memory per-brand activity store with `start`/`update`/`remove`, per-brand `forBrand()` streams, and `hydrateFromJobs()`.
- `brand-activity-strip` standalone component: `mat-chip` per activity with spinner, completed / failed / cancelled icons, tooltip for error, and retry + dismiss affordances.
- Dashboard: split-button + `mat-menu` replace the three buttons; per-activity tracking replaces the global `brandFormBusy` lock for run / research / design; `selectClient` hydrates in-flight runs; opening a completed chip jumps to the Chat tab preview pane.

Per the issue discussion, precise per-phase anchoring for the "open completed chip" action is deferred to follow up with #277 (phase stepper). For now, opening a completed chip selects the brand and switches to the preview tab.

## Test plan
- [x] `vitest run` — full UI suite, 290 tests green (32 new/updated across `BrandActivityService`, `BrandingApiService`, `BrandActivityStripComponent`, `BrandingDashboardComponent`)
- [x] `tsc --noEmit -p tsconfig.app.json` — clean
- [x] `ng build --configuration=development` — clean
- [ ] **Not run in this sandbox** — live browser smoke test against Postgres + Branding API:
  - [ ] Kick off a full pipeline; chip cycles Queued → Running (phase progression) → Completed
  - [ ] Start market-research + design-assets for different brands concurrently; per-brand activity chips tracked independently
  - [ ] Induce a failure; chip shows error tooltip and retry restarts the same action
  - [ ] Reload mid-run; `GET /branding/jobs?running_only=true` hydration repopulates the chip
  - [ ] Click completed chip; navigates to Chat tab with brand selected and preview populated

https://claude.ai/code/session_01LBS6o1o9i1CWeEFihKBSJv