### PR TITLE
Simplify brand activity strip and store

### DIFF
--- a/user-interface/src/app/components/brand-activity-strip/brand-activity-strip.component.html
+++ b/user-interface/src/app/components/brand-activity-strip/brand-activity-strip.component.html
@@ -1,6 +1,6 @@
-@if (items.length > 0) {
+@if (items().length > 0) {
   <mat-chip-set class="brand-activity-strip" aria-label="Brand activity">
-    @for (a of items; track trackById($index, a)) {
+    @for (a of items(); track a.id) {
       <mat-chip
         [class]="chipClass(a)"
         [disabled]="false"
@@ -16,8 +16,6 @@
           <mat-icon matChipAvatar class="chip-icon chip-icon--failed">error</mat-icon>
         } @else if (a.status === 'cancelled') {
           <mat-icon matChipAvatar class="chip-icon chip-icon--cancelled">cancel</mat-icon>
-        } @else {
-          <mat-icon matChipAvatar class="chip-icon">{{ icon(a.kind) }}</mat-icon>
         }
         <span class="chip-label">{{ label(a) }}</span>
         @if (isRetryable(a)) {

--- a/user-interface/src/app/components/brand-activity-strip/brand-activity-strip.component.spec.ts
+++ b/user-interface/src/app/components/brand-activity-strip/brand-activity-strip.component.spec.ts
@@ -17,7 +17,7 @@ describe('BrandActivityStripComponent', () => {
     fixture = TestBed.createComponent(BrandActivityStripComponent);
     component = fixture.componentInstance;
     store = TestBed.inject(BrandActivityService);
-    component.brandId = 'b1';
+    fixture.componentRef.setInput('brandId', 'b1');
     fixture.detectChanges();
   });
 
@@ -25,15 +25,15 @@ describe('BrandActivityStripComponent', () => {
     store.start('run', 'b1');
     store.start('research', 'b-other');
     fixture.detectChanges();
-    expect(component.items.map((a) => a.brandId)).toEqual(['b1']);
+    expect(component.items().map((a) => a.brandId)).toEqual(['b1']);
   });
 
   it('label() describes running activities with phase and progress', () => {
     const activity = store.start('run', 'b1');
     store.update(activity.id, { status: 'running', phase: 'Visual Identity', progress: 60 });
     fixture.detectChanges();
-    expect(component.label(component.items[0])).toContain('Visual Identity');
-    expect(component.label(component.items[0])).toContain('60%');
+    expect(component.label(component.items()[0])).toContain('Visual Identity');
+    expect(component.label(component.items()[0])).toContain('60%');
   });
 
   it('isOpenable() is true only for completed activities', () => {
@@ -42,8 +42,8 @@ describe('BrandActivityStripComponent', () => {
     const failed = store.start('run', 'b1');
     store.update(failed.id, { status: 'failed' });
     fixture.detectChanges();
-    expect(component.isOpenable(component.items.find((a) => a.status === 'completed')!)).toBe(true);
-    expect(component.isOpenable(component.items.find((a) => a.status === 'failed')!)).toBe(false);
+    expect(component.isOpenable(component.items().find((a) => a.status === 'completed')!)).toBe(true);
+    expect(component.isOpenable(component.items().find((a) => a.status === 'failed')!)).toBe(false);
   });
 
   it('onOpen() emits only for completed activities', () => {
@@ -52,12 +52,12 @@ describe('BrandActivityStripComponent', () => {
     const running = store.start('run', 'b1');
     store.update(running.id, { status: 'running' });
     fixture.detectChanges();
-    component.onOpen(new Event('click'), component.items[0]);
+    component.onOpen(new Event('click'), component.items()[0]);
     expect(spy).not.toHaveBeenCalled();
 
     store.update(running.id, { status: 'completed' });
     fixture.detectChanges();
-    component.onOpen(new Event('click'), component.items[0]);
+    component.onOpen(new Event('click'), component.items()[0]);
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
@@ -67,7 +67,7 @@ describe('BrandActivityStripComponent', () => {
     const failed = store.start('run', 'b1');
     store.update(failed.id, { status: 'failed', error: 'boom' });
     fixture.detectChanges();
-    component.onRetry(new Event('click'), component.items[0]);
+    component.onRetry(new Event('click'), component.items()[0]);
     expect(spy).toHaveBeenCalledTimes(1);
   });
 
@@ -77,7 +77,7 @@ describe('BrandActivityStripComponent', () => {
     const done = store.start('run', 'b1');
     store.update(done.id, { status: 'completed' });
     fixture.detectChanges();
-    component.onDismiss(new Event('click'), component.items[0]);
+    component.onDismiss(new Event('click'), component.items()[0]);
     expect(spy).toHaveBeenCalledTimes(1);
   });
 });

--- a/user-interface/src/app/components/brand-activity-strip/brand-activity-strip.component.ts
+++ b/user-interface/src/app/components/brand-activity-strip/brand-activity-strip.component.ts
@@ -1,13 +1,13 @@
-import { Component, Input, OnChanges, OnDestroy, OnInit, SimpleChanges, inject, output } from '@angular/core';
+import { Component, inject, input, output } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
 import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule } from '@angular/material/chips';
 import { MatIconModule } from '@angular/material/icon';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
-import { Subject } from 'rxjs';
-import { switchMap, takeUntil } from 'rxjs/operators';
-import type { BrandActivity, BrandActivityKind } from '../../models';
+import { switchMap } from 'rxjs/operators';
+import type { BrandActivity, BrandActivityKind, BrandActivityStatus } from '../../models';
 import { BrandActivityService } from '../../services/brand-activity.service';
 
 const KIND_LABEL: Record<BrandActivityKind, string> = {
@@ -16,10 +16,15 @@ const KIND_LABEL: Record<BrandActivityKind, string> = {
   design: 'Design assets',
 };
 
-const KIND_ICON: Record<BrandActivityKind, string> = {
-  run: 'bolt',
-  research: 'travel_explore',
-  design: 'palette',
+const STATUS_SUFFIX: Record<BrandActivityStatus, (a: BrandActivity) => string> = {
+  queued: () => 'queued',
+  running: (a) =>
+    a.phase
+      ? `${a.phase}${a.progress != null ? ` · ${a.progress}%` : ''}`
+      : 'running',
+  completed: (a) => `completed${relative(a.completedAt)}`,
+  failed: () => 'failed',
+  cancelled: () => 'cancelled',
 };
 
 /**
@@ -43,76 +48,22 @@ const KIND_ICON: Record<BrandActivityKind, string> = {
   templateUrl: './brand-activity-strip.component.html',
   styleUrl: './brand-activity-strip.component.scss',
 })
-export class BrandActivityStripComponent implements OnInit, OnChanges, OnDestroy {
+export class BrandActivityStripComponent {
   private readonly activities = inject(BrandActivityService);
 
-  @Input({ required: true }) brandId!: string;
+  readonly brandId = input.required<string>();
 
   readonly retry = output<BrandActivity>();
   readonly open = output<BrandActivity>();
   readonly dismiss = output<BrandActivity>();
 
-  items: BrandActivity[] = [];
-
-  private readonly brandIdChanges = new Subject<string>();
-  private readonly destroy = new Subject<void>();
-
-  constructor() {
-    this.brandIdChanges
-      .pipe(
-        switchMap((id) => this.activities.forBrand(id)),
-        takeUntil(this.destroy)
-      )
-      .subscribe((list) => (this.items = list));
-  }
-
-  ngOnInit(): void {
-    if (this.brandId) {
-      this.brandIdChanges.next(this.brandId);
-    }
-  }
-
-  ngOnChanges(changes: SimpleChanges): void {
-    if (changes['brandId'] && !changes['brandId'].firstChange && this.brandId) {
-      this.brandIdChanges.next(this.brandId);
-    }
-  }
-
-  ngOnDestroy(): void {
-    this.destroy.next();
-    this.destroy.complete();
-  }
-
-  trackById(_: number, a: BrandActivity): string {
-    return a.id;
-  }
+  readonly items = toSignal(
+    toObservable(this.brandId).pipe(switchMap((id) => this.activities.forBrand(id))),
+    { initialValue: [] as BrandActivity[] }
+  );
 
   label(a: BrandActivity): string {
-    const base = KIND_LABEL[a.kind];
-    if (a.status === 'running' && a.phase) {
-      const percent = typeof a.progress === 'number' ? ` · ${a.progress}%` : '';
-      return `${base} · ${a.phase}${percent}`;
-    }
-    if (a.status === 'running') {
-      return `${base} · running`;
-    }
-    if (a.status === 'queued') {
-      return `${base} · queued`;
-    }
-    if (a.status === 'completed') {
-      return `${base} · completed${this.relative(a.completedAt)}`;
-    }
-    if (a.status === 'failed') {
-      return `${base} · failed`;
-    }
-    if (a.status === 'cancelled') {
-      return `${base} · cancelled`;
-    }
-    return base;
-  }
-
-  icon(kind: BrandActivityKind): string {
-    return KIND_ICON[kind];
+    return `${KIND_LABEL[a.kind]} · ${STATUS_SUFFIX[a.status](a)}`;
   }
 
   chipClass(a: BrandActivity): string {
@@ -151,17 +102,17 @@ export class BrandActivityStripComponent implements OnInit, OnChanges, OnDestroy
     event.stopPropagation();
     this.dismiss.emit(a);
   }
+}
 
-  private relative(iso?: string | null): string {
-    if (!iso) return '';
-    const then = Date.parse(iso);
-    if (Number.isNaN(then)) return '';
-    const diffMs = Date.now() - then;
-    if (diffMs < 60_000) return ' · just now';
-    const mins = Math.round(diffMs / 60_000);
-    if (mins < 60) return ` · ${mins}m ago`;
-    const hours = Math.round(mins / 60);
-    if (hours < 24) return ` · ${hours}h ago`;
-    return '';
-  }
+function relative(iso?: string | null): string {
+  if (!iso) return '';
+  const then = Date.parse(iso);
+  if (Number.isNaN(then)) return '';
+  const diffMs = Date.now() - then;
+  if (diffMs < 60_000) return ' · just now';
+  const mins = Math.round(diffMs / 60_000);
+  if (mins < 60) return ` · ${mins}m ago`;
+  const hours = Math.round(mins / 60);
+  if (hours < 24) return ` · ${hours}h ago`;
+  return '';
 }

--- a/user-interface/src/app/services/brand-activity.service.ts
+++ b/user-interface/src/app/services/brand-activity.service.ts
@@ -19,11 +19,9 @@ import type { BrandJobListItem, BrandJobStatus } from './branding-api.service';
 export class BrandActivityService {
   private readonly subject = new BehaviorSubject<BrandActivity[]>([]);
 
-  readonly activities$: Observable<BrandActivity[]> = this.subject.asObservable();
-
   /** Reactive view of activities for a single brand, sorted newest first. */
   forBrand(brandId: string): Observable<BrandActivity[]> {
-    return this.activities$.pipe(
+    return this.subject.pipe(
       map((list) =>
         list
           .filter((a) => a.brandId === brandId)
@@ -40,7 +38,7 @@ export class BrandActivityService {
   /** Create and return a new activity in `queued` state. */
   start(kind: BrandActivityKind, brandId: string, jobId?: string | null): BrandActivity {
     const activity: BrandActivity = {
-      id: this.generateId(),
+      id: crypto.randomUUID(),
       brandId,
       kind,
       status: 'queued',
@@ -66,11 +64,6 @@ export class BrandActivityService {
     this.subject.next(this.subject.getValue().filter((a) => a.id !== id));
   }
 
-  /** Drop every activity belonging to a brand (e.g. brand deleted). */
-  clearForBrand(brandId: string): void {
-    this.subject.next(this.subject.getValue().filter((a) => a.brandId !== brandId));
-  }
-
   /**
    * Seed the store with running jobs fetched from the backend on page load,
    * so a refresh during an in-flight run does not hide the chip. Jobs whose
@@ -87,7 +80,7 @@ export class BrandActivityService {
       const status = mapJobStatus(job.status);
       if (!runningLike.includes(status)) continue;
       additions.push({
-        id: this.generateId(),
+        id: crypto.randomUUID(),
         brandId: job.brand_id,
         kind: 'run',
         status,
@@ -111,13 +104,6 @@ export class BrandActivityService {
       error: status.error ?? null,
       completedAt: isTerminal ? status.updated_at ?? new Date().toISOString() : null,
     });
-  }
-
-  private generateId(): string {
-    if (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function') {
-      return crypto.randomUUID();
-    }
-    return `act-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
   }
 }
 


### PR DESCRIPTION
## Summary
Focused simplify pass on the branding activity work that landed in #282. No behaviour change — just less scaffolding.

**Strip component (-65 lines)**
- Replace `@Input` + `OnInit` + `OnChanges` + relay `Subject` + manual unsubscribe with a signal-based `input.required` fed through `toObservable`/`toSignal`.
- Collapse the 7-branch `label()` ladder into one format string plus a status → suffix map.
- Drop the dead `@else` template branch (every `BrandActivityStatus` matches an earlier case); remove the now-unused `icon()` method and `KIND_ICON` map.
- Use Angular 19's native `track a.id` and delete the `trackById` helper.

**Store (-20 lines)**
- Inline the unused public `activities$` observable into `forBrand`.
- Delete `clearForBrand` (never called).
- Replace the defensive `crypto.randomUUID` feature-detect with a direct call; Angular 19 targets environments where it is always present (Node ≥ 19, modern browsers, jsdom).

Net: **132 lines removed, 47 added** across 4 files.

## Context
This commit was originally pushed to the PR #282 branch but landed after that PR was merged, so it never made it to `main`. This PR re-opens it against the current `main`.

## Test plan
- [x] `ng lint` clean
- [x] `tsc --noEmit -p tsconfig.app.json` clean
- [x] `vitest run` — affected specs (branding-api, brand-activity, strip, dashboard) — 32/32 green
- [x] `ng build --configuration=development` succeeds
- [ ] Live browser smoke against Postgres + Branding API (same pre-existing limitation as #282 — not runnable in this sandbox)

https://claude.ai/code/session_01LBS6o1o9i1CWeEFihKBSJv