### PR TITLE
Testing Personas: delete FounderAgent singleton and heartbeat Phase 1 spec generation

### DIFF
--- a/backend/agents/user_agent_founder/agent.py
+++ b/backend/agents/user_agent_founder/agent.py
@@ -380,17 +380,3 @@ class FounderAgent:
             message=message,
         )
         return self._call(prompt)
-
-
-# ---------------------------------------------------------------------------
-# Singleton
-# ---------------------------------------------------------------------------
-
-_agent: FounderAgent | None = None
-
-
-def get_founder_agent() -> FounderAgent:
-    global _agent
-    if _agent is None:
-        _agent = FounderAgent()
-    return _agent

--- a/backend/agents/user_agent_founder/api/main.py
+++ b/backend/agents/user_agent_founder/api/main.py
@@ -13,7 +13,7 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
 from shared_observability import init_otel, instrument_fastapi_app
-from user_agent_founder.agent import get_founder_agent
+from user_agent_founder.agent import FounderAgent
 from user_agent_founder.orchestrator import run_workflow
 from user_agent_founder.postgres import SCHEMA as USER_AGENT_FOUNDER_POSTGRES_SCHEMA
 from user_agent_founder.store import get_founder_store
@@ -118,7 +118,7 @@ def start_founder_workflow() -> StartRunResponse:
     4. Trigger the full SE team build pipeline
     """
     store = get_founder_store()
-    agent = get_founder_agent()
+    agent = FounderAgent()
     run_id = store.create_run()
 
     thread = threading.Thread(
@@ -355,7 +355,7 @@ def send_chat_message(run_id: str, request: SendChatRequest) -> ChatHistoryRespo
     }
 
     # Get persona response
-    agent = get_founder_agent()
+    agent = FounderAgent()
     try:
         response = agent.chat(request.message, context)
     except Exception as exc:

--- a/backend/agents/user_agent_founder/orchestrator.py
+++ b/backend/agents/user_agent_founder/orchestrator.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 import os
+import threading
 import time
 from typing import Any
 
@@ -54,6 +55,36 @@ def _heartbeat(run_id: str) -> None:
         _job_client.heartbeat(run_id)
     except Exception:
         pass
+
+
+# Interval between spec-generation heartbeats. Module-level so tests can shorten it.
+SPEC_HEARTBEAT_INTERVAL = float(os.environ.get("FOUNDER_SPEC_HEARTBEAT_SECONDS", "30"))
+
+
+def _generate_spec_with_heartbeat(agent: FounderAgent, run_id: str) -> str:
+    """Run agent.generate_spec() while a background thread heartbeats the job.
+
+    Spec generation commonly takes 60-180s; without this, the centralised
+    job-service stale-job monitor reaps the run as dead even though Phases 2
+    and 3 still succeed.
+    """
+    stop = threading.Event()
+
+    def _beat() -> None:
+        while not stop.wait(SPEC_HEARTBEAT_INTERVAL):
+            _heartbeat(run_id)
+
+    hb_thread = threading.Thread(
+        target=_beat,
+        name=f"founder-spec-hb-{run_id[:12]}",
+        daemon=True,
+    )
+    hb_thread.start()
+    try:
+        return agent.generate_spec()
+    finally:
+        stop.set()
+        hb_thread.join(timeout=1)
 
 
 def _answer_pending_questions(
@@ -365,7 +396,7 @@ def run_workflow(run_id: str, store: FounderRunStore, agent: FounderAgent) -> No
         store.update_run(run_id, status="generating_spec")
         _sync_job_status(run_id, "running", phase="generating_spec")
         store.add_chat_message(run_id, "system", "Generating product specification...", "status_update")
-        spec_content = agent.generate_spec()
+        spec_content = _generate_spec_with_heartbeat(agent, run_id)
         store.update_run(run_id, spec_content=spec_content)
         logger.info("Spec generated for run %s (%d chars)", run_id, len(spec_content))
         store.add_chat_message(

--- a/backend/agents/user_agent_founder/tests/test_agent_no_singleton.py
+++ b/backend/agents/user_agent_founder/tests/test_agent_no_singleton.py
@@ -1,0 +1,69 @@
+"""Regression test for #262: FounderAgent must not share state across runs.
+
+Before the fix, ``get_founder_agent()`` cached a module-level ``FounderAgent``
+whose embedded ``strands.Agent`` kept conversation history. Two concurrent
+persona runs would silently contaminate each other's rationales.
+
+These tests pin the new contract:
+
+1. The module no longer exposes ``get_founder_agent`` — callers must construct
+   ``FounderAgent()`` per run.
+2. Each ``FounderAgent()`` instance owns an independent embedded Strands agent.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def test_get_founder_agent_is_removed():
+    """The legacy singleton accessor must no longer exist."""
+    from user_agent_founder import agent as agent_module
+
+    assert not hasattr(agent_module, "get_founder_agent"), (
+        "get_founder_agent singleton accessor must be removed (see #262)"
+    )
+    assert not hasattr(agent_module, "_agent"), (
+        "_agent module-level cache must be removed (see #262)"
+    )
+
+
+def test_founder_agent_instances_are_independent(monkeypatch):
+    """Two FounderAgent() calls must produce instances with distinct Strands agents."""
+    import strands
+
+    import llm_service
+
+    # Each call to strands.Agent(...) returns a fresh MagicMock so instance
+    # identity is observable.
+    monkeypatch.setattr(strands, "Agent", lambda **kwargs: MagicMock(name="StrandsAgentStub"))
+    monkeypatch.setattr(
+        llm_service, "get_strands_model", lambda team_key: MagicMock(name="ModelStub")
+    )
+
+    from user_agent_founder.agent import FounderAgent
+
+    a1 = FounderAgent()
+    a2 = FounderAgent()
+
+    assert a1 is not a2, "FounderAgent() must return a fresh instance per call"
+    assert a1._agent is not a2._agent, (
+        "Embedded strands.Agent must be independent per FounderAgent instance "
+        "(otherwise concurrent runs share conversation history — see #262)"
+    )
+
+
+def test_api_main_imports_class_not_singleton():
+    """The API module must import FounderAgent directly, not a singleton accessor."""
+    from user_agent_founder.api import main as api_main
+
+    assert hasattr(api_main, "FounderAgent"), "api.main must import the FounderAgent class directly"
+    assert not hasattr(api_main, "get_founder_agent"), (
+        "api.main must not keep a reference to the removed singleton accessor"
+    )
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/backend/agents/user_agent_founder/tests/test_orchestrator_spec_heartbeat.py
+++ b/backend/agents/user_agent_founder/tests/test_orchestrator_spec_heartbeat.py
@@ -1,0 +1,96 @@
+"""Regression test for #262: Phase 1 spec generation must emit heartbeats.
+
+Before the fix, ``orchestrator.run_workflow`` called ``agent.generate_spec()``
+synchronously with no heartbeat. Slow LLM providers pushed the run past the
+stale-job monitor's threshold (typically 60-120s), causing the Jobs Dashboard
+and the store to flip to ``failed`` even when Phases 2 & 3 later succeeded.
+
+The fix wraps ``generate_spec()`` in a daemon thread that fires
+``_heartbeat(run_id)`` every ``SPEC_HEARTBEAT_INTERVAL`` seconds. These tests
+pin the behaviour.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def test_heartbeat_fires_during_slow_generate_spec(monkeypatch):
+    """A slow generate_spec must produce multiple heartbeats while blocked."""
+    from user_agent_founder import orchestrator
+
+    heartbeat_calls: list[str] = []
+    monkeypatch.setattr(orchestrator, "_heartbeat", lambda run_id: heartbeat_calls.append(run_id))
+    monkeypatch.setattr(orchestrator, "SPEC_HEARTBEAT_INTERVAL", 0.1)
+
+    agent = MagicMock()
+
+    def slow_spec() -> str:
+        time.sleep(0.55)
+        return "# Spec body"
+
+    agent.generate_spec = slow_spec
+
+    result = orchestrator._generate_spec_with_heartbeat(agent, "run-abc-123456")
+
+    assert result == "# Spec body"
+    # With interval=0.1s and a 0.55s sleep, we expect ~5 heartbeats.
+    # Assert >=2 to tolerate scheduler jitter while still proving the loop ran.
+    assert len(heartbeat_calls) >= 2, (
+        f"Expected multiple heartbeats during slow generate_spec; got {len(heartbeat_calls)}"
+    )
+    assert all(rid == "run-abc-123456" for rid in heartbeat_calls)
+
+
+def test_heartbeat_thread_stops_after_generate_spec_returns(monkeypatch):
+    """The heartbeat thread must terminate once generate_spec returns."""
+    from user_agent_founder import orchestrator
+
+    monkeypatch.setattr(orchestrator, "_heartbeat", lambda run_id: None)
+    monkeypatch.setattr(orchestrator, "SPEC_HEARTBEAT_INTERVAL", 0.05)
+
+    agent = MagicMock()
+    agent.generate_spec = lambda: "spec"
+
+    before_threads = {t.name for t in threading.enumerate()}
+    orchestrator._generate_spec_with_heartbeat(agent, "run-xyz-987654")
+
+    # Give the daemon a beat to exit via the stop event + join(timeout=1).
+    time.sleep(0.1)
+    after_threads = {t.name for t in threading.enumerate()}
+
+    leaked = {n for n in (after_threads - before_threads) if n.startswith("founder-spec-hb-")}
+    assert not leaked, f"Heartbeat thread leaked after generate_spec returned: {leaked}"
+
+
+def test_heartbeat_thread_stops_when_generate_spec_raises(monkeypatch):
+    """Exceptions from generate_spec must still stop the heartbeat thread."""
+    from user_agent_founder import orchestrator
+
+    monkeypatch.setattr(orchestrator, "_heartbeat", lambda run_id: None)
+    monkeypatch.setattr(orchestrator, "SPEC_HEARTBEAT_INTERVAL", 0.05)
+
+    agent = MagicMock()
+
+    def boom() -> str:
+        raise RuntimeError("LLM blew up")
+
+    agent.generate_spec = boom
+
+    before_threads = {t.name for t in threading.enumerate()}
+    with pytest.raises(RuntimeError, match="LLM blew up"):
+        orchestrator._generate_spec_with_heartbeat(agent, "run-boom-1")
+
+    time.sleep(0.1)
+    after_threads = {t.name for t in threading.enumerate()}
+
+    leaked = {n for n in (after_threads - before_threads) if n.startswith("founder-spec-hb-")}
+    assert not leaked, f"Heartbeat thread leaked after exception: {leaked}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## Summary

Fixes two tightly-coupled bugs in `user_agent_founder` (Testing Personas), both called out in #262.

- **Shared-state corruption across concurrent runs.** `get_founder_agent()` cached a module-level `FounderAgent` whose embedded `strands.Agent` kept conversation history. Overlapping persona runs (dashboard polls every 15s) silently inherited each other's context, producing plausible-looking but contaminated rationales persisted to `user_agent_founder_decisions`. Fix: delete the singleton; construct `FounderAgent()` per call at both entry points (`POST /start`, `POST /runs/{run_id}/chat`).
- **Phase 1 spec generation had no heartbeat.** `agent.generate_spec()` routinely blocks 60–180s on slow LLM providers; the centralised job service's stale-job monitor reaped the run as dead while Phases 2 & 3 still succeeded — a false-negative `failed`. Fix: wrap the call in a daemon thread that fires the existing `_heartbeat(run_id)` every `SPEC_HEARTBEAT_INTERVAL` seconds (default 30, env-overridable via `FOUNDER_SPEC_HEARTBEAT_SECONDS`). Pattern modelled on `backend/agents/blogging/shared/run_pipeline_job.py:187`. Extracted into `_generate_spec_with_heartbeat()` so it's unit-testable without the full `run_workflow`.

Closes #262.

## Files changed

- `backend/agents/user_agent_founder/agent.py` — remove singleton block.
- `backend/agents/user_agent_founder/api/main.py` — import `FounderAgent`; construct per call at lines 121, 358.
- `backend/agents/user_agent_founder/orchestrator.py` — add `threading` import; new `_generate_spec_with_heartbeat()` helper; Phase 1 routes through it.
- `backend/agents/user_agent_founder/tests/test_agent_no_singleton.py` *(new, 3 tests)*
- `backend/agents/user_agent_founder/tests/test_orchestrator_spec_heartbeat.py` *(new, 3 tests)*

Net: +200 / −18 LOC (most of the adds are tests).

## Test plan

- [x] `pytest backend/agents/user_agent_founder/tests/` — 38 passed (32 pre-existing + 6 new).
- [x] `ruff check` clean on all modified files.
- [x] `ruff format --check` clean on the new test files. (Pre-existing format drift in `agent.py`/`orchestrator.py` exists on `main` too — left untouched to avoid churning unrelated lines.)
- [ ] Manual smoke: launch 3 concurrent `POST /api/user-agent-founder/start`, assert each run's `user_agent_founder_decisions` references only its own question IDs (no cross-contamination).
- [ ] Manual smoke: monkey-patch `generate_spec` with `time.sleep(150)`, launch a run, confirm Jobs Dashboard never flips to `failed` during Phase 1.

https://claude.ai/code/session_01NmjW9uwXKkfL9pdh3yQMau