### PR TITLE
Security gateway: scope path-traversal rules to URL-layer only (#241)

### DIFF
--- a/backend/unified_api/security/agent.py
+++ b/backend/unified_api/security/agent.py
@@ -4,6 +4,13 @@ Rule-based security agent for the API gateway.
 Scans request method, path, query string, headers, and body for patterns
 indicating malicious, destructive, or security-compromising content.
 Returns (passed, findings) where findings are human-readable messages.
+
+Each rule declares which request parts it applies to via a scope set.
+Path-traversal patterns are scoped to URL-layer inputs (path, query string,
+headers) because request bodies in this system are primarily free-form
+content destined for storage or LLM prompts, not filesystem path handling —
+so scanning bodies for ``../`` produces false positives without blocking any
+real attack vector.
 """
 
 from __future__ import annotations
@@ -13,32 +20,50 @@ import re
 # Type alias for scan result
 ScanResult = tuple[bool, list[str]]
 
+# Scope identifiers for per-rule request-part targeting.
+_SCOPE_PATH = "path"
+_SCOPE_QUERY = "query_string"
+_SCOPE_HEADERS = "headers"
+_SCOPE_BODY = "body"
 
-def _normalize_inputs(
-    method: str,
+_URL_SCOPES: frozenset[str] = frozenset({_SCOPE_PATH, _SCOPE_QUERY, _SCOPE_HEADERS})
+_ALL_SCOPES: frozenset[str] = _URL_SCOPES | {_SCOPE_BODY}
+
+# Fixed order used when joining per-scope strings into a rule's haystack.
+_SCOPE_ORDER: tuple[str, ...] = (_SCOPE_PATH, _SCOPE_QUERY, _SCOPE_HEADERS, _SCOPE_BODY)
+
+
+def _normalize_parts(
     path: str,
     query_string: bytes,
     headers: list[tuple[bytes, bytes]],
     body_bytes: bytes,
-) -> str:
-    """Build a single string from all request parts for scanning. UTF-8 decode with replace."""
-    parts = [method or "", path or ""]
-    if query_string:
-        parts.append(query_string.decode("utf-8", errors="replace"))
-    for k, v in headers or []:
-        parts.append(k.decode("utf-8", errors="replace") + " " + v.decode("utf-8", errors="replace"))
-    if body_bytes:
-        parts.append(body_bytes.decode("utf-8", errors="replace"))
-    return "\n".join(parts).lower()
+) -> dict[str, str]:
+    """Return a per-scope dict of lowercased, UTF-8-decoded request parts."""
+    header_blob = " ".join(
+        k.decode("utf-8", errors="replace") + " " + v.decode("utf-8", errors="replace") for k, v in headers or []
+    )
+    return {
+        _SCOPE_PATH: (path or "").lower(),
+        _SCOPE_QUERY: query_string.decode("utf-8", errors="replace").lower() if query_string else "",
+        _SCOPE_HEADERS: header_blob.lower(),
+        _SCOPE_BODY: body_bytes.decode("utf-8", errors="replace").lower() if body_bytes else "",
+    }
 
 
-# Rules: (pattern, message). Pattern is compiled regex or we use re.escape for literal.
-# Messages are human-readable findings for the 403 response.
-_RULES: list[tuple[re.Pattern[str], str]] = []
+# Rules: (pattern, message, scopes). Scopes declare which request parts each
+# rule applies to; unlisted parts are skipped for that rule.
+_RULES: list[tuple[re.Pattern[str], str, frozenset[str]]] = []
 
 
-def _add_rule(pattern: str, message: str, flags: int = re.IGNORECASE) -> None:
-    _RULES.append((re.compile(pattern, flags), message))
+def _add_rule(
+    pattern: str,
+    message: str,
+    *,
+    scopes: frozenset[str] = _ALL_SCOPES,
+    flags: int = re.IGNORECASE,
+) -> None:
+    _RULES.append((re.compile(pattern, flags), message, scopes))
 
 
 # Destructive / dangerous commands
@@ -55,12 +80,12 @@ _add_rule(r"\$\(rm\s+", "Command substitution with rm detected.")
 _add_rule(r"`rm\s+", "Backtick command with rm detected.")
 _add_rule(r"&\s*&\s*del\s+", "Shell/command chaining with del detected.")
 
-# Path traversal
-_add_rule(r"\.\./", "Path traversal sequence (e.g. '..') detected.")
-_add_rule(r"\.\.\\", "Path traversal sequence (e.g. '..\\') detected.")
-_add_rule(r"%2e%2e%2f", "Path traversal sequence (encoded) detected.")
-_add_rule(r"%2e%2e/", "Path traversal sequence (encoded) detected.")
-_add_rule(r"\.\.%2f", "Path traversal sequence (encoded) detected.")
+# Path traversal — URL-layer only; bodies are free-form content.
+_add_rule(r"\.\./", "Path traversal sequence (e.g. '..') detected.", scopes=_URL_SCOPES)
+_add_rule(r"\.\.\\", "Path traversal sequence (e.g. '..\\') detected.", scopes=_URL_SCOPES)
+_add_rule(r"%2e%2e%2f", "Path traversal sequence (encoded) detected.", scopes=_URL_SCOPES)
+_add_rule(r"%2e%2e/", "Path traversal sequence (encoded) detected.", scopes=_URL_SCOPES)
+_add_rule(r"\.\.%2f", "Path traversal sequence (encoded) detected.", scopes=_URL_SCOPES)
 
 # Prompt / instruction override
 _add_rule(r"ignore\s+(all\s+)?previous\s+instructions", "Prompt or instruction override phrase detected.")
@@ -88,7 +113,8 @@ def scan(
     Scan request for malicious, destructive, or security-compromising content.
 
     Args:
-        method: HTTP method (e.g. GET, POST).
+        method: HTTP method (e.g. GET, POST). Unused for pattern matching —
+            kept in the signature for API stability and future rule options.
         path: Request path (e.g. /api/blogging/full-pipeline).
         query_string: Raw query string bytes.
         headers: ASGI headers list of (name, value) bytes.
@@ -98,11 +124,10 @@ def scan(
         (passed, findings). passed is True if no issues; otherwise False with
         a non-empty list of human-readable finding messages.
     """
-    text = _normalize_inputs(method, path, query_string, headers, body_bytes)
-    findings: list[str] = []
-    for pattern, message in _RULES:
-        if pattern.search(text):
-            findings.append(message)
-            # Return on first match (plan: "return (False, findings) on first rule match")
-            return (False, findings)
+    del method  # method is not scanned; no rule meaningfully matches GET/POST.
+    parts = _normalize_parts(path, query_string, headers, body_bytes)
+    for pattern, message, scopes in _RULES:
+        haystack = "\n".join(parts[name] for name in _SCOPE_ORDER if name in scopes)
+        if pattern.search(haystack):
+            return (False, [message])
     return (True, [])

--- a/backend/unified_api/tests/test_security_agent.py
+++ b/backend/unified_api/tests/test_security_agent.py
@@ -51,15 +51,14 @@ def test_agent_destructive_rm_rf_returns_findings():
     assert "rm" in findings[0].lower() or "destructive" in findings[0].lower()
 
 
-def test_agent_path_traversal_returns_findings():
-    """Path or body with '../' returns (False, findings) with path traversal message."""
-    body = b'{"path": "../../../etc/passwd"}'
+def test_agent_path_traversal_in_url_path_returns_findings():
+    """A '../' sequence in the request path is flagged with a path-traversal message."""
     passed, findings = scan(
-        "POST",
-        "/api/blogging/jobs/123/artifacts/outline.md",
+        "GET",
+        "/api/blogging/jobs/../../etc/passwd",
         b"",
         [],
-        body,
+        b"",
     )
     assert passed is False
     assert len(findings) >= 1
@@ -77,6 +76,73 @@ def test_agent_path_traversal_in_path():
     )
     assert passed is False
     assert len(findings) >= 1
+
+
+def test_agent_path_traversal_in_query_string_returns_findings():
+    """A '../' sequence in the query string is flagged."""
+    passed, findings = scan(
+        "GET",
+        "/api/blogging/jobs/123/artifact",
+        b"file=../../etc/passwd",
+        [],
+        b"",
+    )
+    assert passed is False
+    assert len(findings) >= 1
+    assert "path" in findings[0].lower() or "traversal" in findings[0].lower()
+
+
+def test_agent_path_traversal_in_body_is_ignored():
+    """
+    '../' and '..\\\\' appearing only inside a request body must NOT be flagged.
+
+    Bodies in this system are free-form content (LLM specs, blog drafts, code
+    snippets) and frequently contain benign path-ish substrings. Path-traversal
+    rules are a URL/filesystem-layer defense; scanning bodies for '../' just
+    produces false positives.
+    """
+    body = (
+        b'{"spec": "Open a terminal and run `cd ../foo` to reach the project, '
+        b'or on Windows navigate to C:\\\\temp\\\\..\\\\bar for the equivalent."}'
+    )
+    passed, findings = scan(
+        "POST",
+        "/api/software-engineering/product-analysis/start-from-spec",
+        b"",
+        _headers(("content-type", "application/json")),
+        body,
+    )
+    assert passed is True
+    assert findings == []
+
+
+def test_agent_path_traversal_in_body_with_encoded_form_is_ignored():
+    """Encoded path-traversal sequences (%2e%2e%2f, ..%2f) in a body are not flagged."""
+    body = b'{"note": "example of an encoded sequence: %2e%2e%2f and ..%2f"}'
+    passed, findings = scan(
+        "POST",
+        "/api/blogging/full-pipeline",
+        b"",
+        _headers(("content-type", "application/json")),
+        body,
+    )
+    assert passed is True
+    assert findings == []
+
+
+def test_agent_body_still_scanned_for_non_traversal_rules():
+    """Non-traversal rules (e.g. destructive shell commands) must still scan bodies."""
+    body = b'{"spec": "Then run rm -rf / on the target."}'
+    passed, findings = scan(
+        "POST",
+        "/api/software-engineering/product-analysis/start-from-spec",
+        b"",
+        _headers(("content-type", "application/json")),
+        body,
+    )
+    assert passed is False
+    assert len(findings) >= 1
+    assert "rm" in findings[0].lower() or "destructive" in findings[0].lower()
 
 
 def test_agent_prompt_injection_returns_findings():


### PR DESCRIPTION
Closes #241.

## Summary

- Path-traversal patterns (`../`, `..\`, `%2e%2e%2f`, `%2e%2e/`, `..%2f`) now scan only URL-layer inputs (`path`, `query_string`, `headers`) — **not** the request body.
- All other rules (destructive shell commands, SQL injection, script injection, prompt-override) keep scanning every part including the body.
- `_RULES` entries carry a `scopes: frozenset[str]` alongside pattern + message; `scan()` builds a per-rule haystack by joining only the parts the rule declares. Public `scan()` signature is unchanged, so the middleware and all existing callers are untouched.

## Why

Bodies in this system are free-form content — LLM specs, blog drafts, code snippets that routinely contain benign path-ish substrings like Windows paths in code fences. Legitimate inter-service calls (e.g. Founder Testing Persona → `/api/software-engineering/product-analysis/start-from-spec`) were 403'ing on harmless content. Path traversal is a URL/filesystem-layer attack; nothing in this codebase routes request bodies through filesystem path handlers, so body scans add no defense-in-depth — just false positives. Destructive shell / SQL / script / prompt-injection rules still scan bodies because those payloads can reach LLM prompts, stored content, or rendered HTML.

## Files changed

- `backend/unified_api/security/agent.py` — scope constants (`_URL_SCOPES`, `_ALL_SCOPES`), 3-tuple rule shape, per-scope normalization dict, scoped haystack in `scan()`.
- `backend/unified_api/tests/test_security_agent.py` — migrated the body-based path-traversal assertion to URL-path; added: body-level `../` and `..\` are ignored, encoded body traversal is ignored, non-traversal rules (e.g. `rm -rf`) still scan bodies, and query-string traversal is flagged.

## Test plan

- [x] `pytest unified_api/tests/test_security_agent.py unified_api/tests/test_security_gateway_middleware.py` — 16/16 passed.
- [x] `ruff check` + `ruff format --check` on both changed files — clean.
- [ ] (Reviewer, optional) POST a spec containing `cd ../foo` in a code block to `/api/software-engineering/product-analysis/start-from-spec` — expect non-403.

https://claude.ai/code/session_01BFfHWCUyjeqRtFkoFLAGVj