### PR TITLE
Sandbox re-architecture — Phase 4: Agent Console Runner UI is agent-keyed (#266)

### DIFF
--- a/user-interface/src/app/components/agent-console/agent-runner/agent-runner.component.ts
+++ b/user-interface/src/app/components/agent-console/agent-runner/agent-runner.component.ts
@@ -195,7 +195,7 @@ export class AgentRunnerComponent implements OnInit, OnDestroy {
         this.loadSamples(id);
         this.loadSavedInputs(id);
         this.loadInputSchema(id);
-        this.startSandboxPolling(detail.manifest.team);
+        this.startSandboxPolling(id);
       },
       error: (err) => {
         console.error('Failed to load agent detail', err);
@@ -357,24 +357,24 @@ export class AgentRunnerComponent implements OnInit, OnDestroy {
   // Sandbox lifecycle
   // ---------------------------------------------------------------
 
-  private startSandboxPolling(team: string): void {
+  private startSandboxPolling(agentId: string): void {
     this.sandboxPollSub?.unsubscribe();
-    this.runner.getSandbox(team).subscribe({
+    this.runner.getSandbox(agentId).subscribe({
       next: (handle) => this.sandbox.set(handle),
       error: () => this.sandbox.set(null),
     });
     this.sandboxPollSub = interval(5000).subscribe(() => {
-      this.runner.getSandbox(team).subscribe({
+      this.runner.getSandbox(agentId).subscribe({
         next: (handle) => this.sandbox.set(handle),
       });
     });
   }
 
   warmSandbox(): void {
-    const team = this.selectedAgent()?.manifest.team;
-    if (!team) return;
+    const agentId = this.selectedAgentId();
+    if (!agentId) return;
     this.sandboxPolling.set(true);
-    this.runner.ensureWarm(team).subscribe({
+    this.runner.ensureWarm(agentId).subscribe({
       next: (handle) => {
         this.sandbox.set(handle);
         this.sandboxPolling.set(false);
@@ -387,10 +387,11 @@ export class AgentRunnerComponent implements OnInit, OnDestroy {
   }
 
   tearDownSandbox(): void {
-    const team = this.selectedAgent()?.manifest.team;
-    if (!team) return;
-    if (!confirm(`Tear down the ${team} sandbox?`)) return;
-    this.runner.teardown(team).subscribe({
+    const agentId = this.selectedAgentId();
+    if (!agentId) return;
+    const label = this.selectedAgent()?.manifest.name ?? agentId;
+    if (!confirm(`Tear down the ${label} sandbox?`)) return;
+    this.runner.teardown(agentId).subscribe({
       next: () => {
         this.sandbox.set({ ...(this.sandbox() as SandboxHandle), status: 'cold', url: null });
       },
@@ -468,7 +469,7 @@ export class AgentRunnerComponent implements OnInit, OnDestroy {
           logs_tail: record.logs_tail,
           error: record.error,
           sandbox: record.sandbox_url
-            ? { team: record.team, url: record.sandbox_url }
+            ? { agent_id: record.agent_id, url: record.sandbox_url }
             : undefined,
         });
         this.lastError.set(null);

--- a/user-interface/src/app/models/agent-runner.model.ts
+++ b/user-interface/src/app/models/agent-runner.model.ts
@@ -5,6 +5,7 @@
 export type SandboxStatus = 'cold' | 'warming' | 'warm' | 'error';
 
 export interface SandboxHandle {
+  agent_id: string;
   team: string;
   status: SandboxStatus;
   url: string | null;
@@ -23,11 +24,11 @@ export interface InvokeEnvelope {
   trace_id: string;
   logs_tail: string[];
   error?: string | null;
-  sandbox?: { team: string; url: string | null };
+  sandbox?: { agent_id: string; url: string | null };
 }
 
 export interface InvokeWarmingResponse {
   status: SandboxStatus;
   message: string;
-  sandbox: { team: string; status: SandboxStatus };
+  sandbox: { agent_id: string; status: SandboxStatus };
 }

--- a/user-interface/src/app/services/agent-runner-api.service.ts
+++ b/user-interface/src/app/services/agent-runner-api.service.ts
@@ -36,17 +36,20 @@ export class AgentRunnerApiService {
     return this.http.get<SandboxHandle[]>(this.sandboxesUrl);
   }
 
-  ensureWarm(team: string): Observable<SandboxHandle> {
-    return this.http.post<SandboxHandle>(`${this.sandboxesUrl}/${encodeURIComponent(team)}`, {});
+  ensureWarm(agentId: string): Observable<SandboxHandle> {
+    return this.http.post<SandboxHandle>(
+      `${this.sandboxesUrl}/${encodeURIComponent(agentId)}/warm`,
+      {},
+    );
   }
 
-  getSandbox(team: string): Observable<SandboxHandle> {
-    return this.http.get<SandboxHandle>(`${this.sandboxesUrl}/${encodeURIComponent(team)}`);
+  getSandbox(agentId: string): Observable<SandboxHandle> {
+    return this.http.get<SandboxHandle>(`${this.sandboxesUrl}/${encodeURIComponent(agentId)}`);
   }
 
-  teardown(team: string): Observable<{ team: string; status: string }> {
-    return this.http.delete<{ team: string; status: string }>(
-      `${this.sandboxesUrl}/${encodeURIComponent(team)}`,
+  teardown(agentId: string): Observable<{ agent_id: string; status: string }> {
+    return this.http.delete<{ agent_id: string; status: string }>(
+      `${this.sandboxesUrl}/${encodeURIComponent(agentId)}`,
     );
   }
 


### PR DESCRIPTION
Closes #266.

## Summary
- Phase 4 of the sandbox re-architecture: Agent Console Runner UI now keys on `agent_id` instead of `team`, matching the Phase 3 agent-keyed backend routes (`/api/agents/sandboxes/{agent_id}`, `POST …/{agent_id}/warm`, `DELETE …/{agent_id}`).
- Two agents in the same team (e.g. `blogging.planner` and `blogging.writer`) now get distinct sandboxes.
- `SandboxHandle`, `InvokeEnvelope.sandbox`, and `InvokeWarmingResponse.sandbox` interfaces updated to expose `agent_id`; `onHistoryLoadRun` rebuilds the envelope from `record.agent_id`.
- Teardown confirmation uses the agent's display name (`manifest.name`) instead of the team slug.

## Files changed
- `user-interface/src/app/services/agent-runner-api.service.ts`
- `user-interface/src/app/components/agent-console/agent-runner/agent-runner.component.ts`
- `user-interface/src/app/models/agent-runner.model.ts`

No backend changes. No existing sandbox-related spec files to update.

## Test plan
- [x] `npm run build` — succeeds (pre-existing bundle-size warning unchanged)
- [x] `npm test` — 290/290 tests pass across 89 files
- [ ] Manual smoke: Agent Console → Runner → select `blogging.planner` → sandbox chip transitions `cold → warming → warm`; Run invokes successfully
- [ ] Warm `blogging.planner` then switch to `blogging.writer`; `GET /api/agents/sandboxes` returns **two distinct** entries keyed by `agent_id`
- [ ] Select `blogging.publication` (tagged `requires-live-integration`) → Run button remains disabled with the "Not runnable in sandbox" explainer
- [ ] Teardown flow: click "Tear down" → confirm prompt shows the agent's display name → chip returns to `cold`

https://claude.ai/code/session_0163hn5XnkXHPPbFKsL9om1Z

---
_Generated by [Claude Code](https://claude.ai/code/session_0163hn5XnkXHPPbFKsL9om1Z)_