### PR TITLE
Branding: unify Workspace/Brand/Version into one persistent selector

### DIFF
--- a/user-interface/src/app/components/branding-dashboard/branding-context-selector/branding-context-selector.component.html
+++ b/user-interface/src/app/components/branding-dashboard/branding-context-selector/branding-context-selector.component.html
@@ -27,7 +27,7 @@
       <span>Reload workspaces</span>
     </button>
     <mat-divider />
-    <div class="ctx-add-workspace" (click)="$event.stopPropagation()" (keydown)="$event.stopPropagation()">
+    <div class="ctx-add-workspace">
       <mat-form-field appearance="outline" class="ctx-add-workspace__field" subscriptSizing="dynamic">
         <mat-label>Add workspace</mat-label>
         <input

--- a/user-interface/src/app/components/branding-dashboard/branding-context-selector/branding-context-selector.component.html
+++ b/user-interface/src/app/components/branding-dashboard/branding-context-selector/branding-context-selector.component.html
@@ -1,0 +1,85 @@
+<div class="brand-context-bar" role="group" aria-label="Brand context">
+  <mat-form-field appearance="outline" class="ctx-field ctx-workspace">
+    <mat-label>Workspace</mat-label>
+    <mat-select
+      [value]="selectedClient?.id ?? null"
+      (selectionChange)="onClientSelect($event.value)"
+      aria-label="Workspace"
+    >
+      @for (c of clients; track c.id) {
+        <mat-option [value]="c.id">{{ c.name }}</mat-option>
+      }
+    </mat-select>
+  </mat-form-field>
+
+  <button
+    mat-icon-button
+    type="button"
+    class="ctx-workspace-menu"
+    [matMenuTriggerFor]="workspaceMenu"
+    aria-label="Workspace actions"
+  >
+    <mat-icon>more_vert</mat-icon>
+  </button>
+  <mat-menu #workspaceMenu="matMenu">
+    <button mat-menu-item type="button" (click)="reloadClients.emit()">
+      <mat-icon>refresh</mat-icon>
+      <span>Reload workspaces</span>
+    </button>
+    <mat-divider />
+    <div class="ctx-add-workspace" (click)="$event.stopPropagation()" (keydown)="$event.stopPropagation()">
+      <mat-form-field appearance="outline" class="ctx-add-workspace__field" subscriptSizing="dynamic">
+        <mat-label>Add workspace</mat-label>
+        <input
+          matInput
+          type="text"
+          name="ctx-new-workspace"
+          [(ngModel)]="newWorkspaceName"
+          (keydown.enter)="submitNewWorkspace()"
+          placeholder="Workspace name"
+        />
+      </mat-form-field>
+      <button
+        mat-stroked-button
+        color="primary"
+        type="button"
+        [disabled]="!newWorkspaceName.trim()"
+        (click)="submitNewWorkspace()"
+      >
+        Add
+      </button>
+    </div>
+  </mat-menu>
+
+  <mat-form-field appearance="outline" class="ctx-field ctx-brand">
+    <mat-label>Brand</mat-label>
+    <mat-select
+      [value]="selectedBrand?.id ?? null"
+      [disabled]="brands.length === 0"
+      (selectionChange)="onBrandSelect($event.value)"
+      aria-label="Brand"
+    >
+      @for (b of brands; track b.id) {
+        <mat-option [value]="b.id">{{ b.name }} · v{{ b.version }} · {{ b.status }}</mat-option>
+      }
+    </mat-select>
+  </mat-form-field>
+
+  <div class="ctx-version" aria-label="Brand version">
+    <span class="ctx-version__label">Version</span>
+    <span class="ctx-version__value">{{ selectedBrand ? 'v' + selectedBrand.version : '—' }}</span>
+  </div>
+
+  <span class="ctx-spacer"></span>
+
+  <button
+    mat-stroked-button
+    color="primary"
+    type="button"
+    class="ctx-new-brand"
+    (click)="newBrandRequest.emit()"
+  >
+    <mat-icon>add</mat-icon>
+    New brand
+  </button>
+</div>

--- a/user-interface/src/app/components/branding-dashboard/branding-context-selector/branding-context-selector.component.scss
+++ b/user-interface/src/app/components/branding-dashboard/branding-context-selector/branding-context-selector.component.scss
@@ -1,0 +1,96 @@
+:host {
+  display: block;
+  margin-bottom: 12px;
+}
+
+.brand-context-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px 12px;
+  padding: 10px 14px;
+  border: 1px solid var(--mat-sys-outline-variant, #e0e0e0);
+  border-radius: 8px;
+  background: var(--mat-sys-surface-container-low, #fafafa);
+}
+
+.ctx-field {
+  margin: 0;
+
+  ::ng-deep .mat-mdc-form-field-subscript-wrapper {
+    display: none;
+  }
+}
+
+.ctx-workspace {
+  min-width: 180px;
+}
+
+.ctx-workspace-menu {
+  margin-left: -4px;
+}
+
+.ctx-brand {
+  min-width: 240px;
+  flex: 1 1 240px;
+}
+
+.ctx-version {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 6px;
+  padding: 0 10px;
+  font-size: 0.9rem;
+  color: var(--mat-sys-on-surface-variant, #555);
+}
+
+.ctx-version__label {
+  font-size: 0.7rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.ctx-version__value {
+  font-weight: 500;
+  color: var(--mat-sys-on-surface, #1c1c1c);
+}
+
+.ctx-spacer {
+  flex: 1 1 auto;
+}
+
+.ctx-new-brand {
+  white-space: nowrap;
+
+  mat-icon {
+    margin-right: 4px;
+  }
+}
+
+.ctx-add-workspace {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 16px 12px;
+  min-width: 280px;
+}
+
+.ctx-add-workspace__field {
+  flex: 1 1 auto;
+}
+
+@media (max-width: 600px) {
+  .brand-context-bar {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .ctx-spacer {
+    display: none;
+  }
+
+  .ctx-version {
+    padding: 0;
+  }
+}

--- a/user-interface/src/app/components/branding-dashboard/branding-context-selector/branding-context-selector.component.spec.ts
+++ b/user-interface/src/app/components/branding-dashboard/branding-context-selector/branding-context-selector.component.spec.ts
@@ -1,0 +1,129 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { vi } from 'vitest';
+import { BrandingContextSelectorComponent } from './branding-context-selector.component';
+import type { Brand, Client } from '../../../models';
+
+const client = (id: string, name = `Workspace ${id}`): Client => ({
+  id,
+  name,
+  created_at: '',
+  updated_at: '',
+});
+
+const brand = (id: string, version = 1): Brand => ({
+  id,
+  client_id: 'w1',
+  name: `Brand ${id}`,
+  status: 'draft',
+  mission: {} as Brand['mission'],
+  version,
+  history: [],
+  created_at: '',
+  updated_at: '',
+});
+
+describe('BrandingContextSelectorComponent', () => {
+  let component: BrandingContextSelectorComponent;
+  let fixture: ComponentFixture<BrandingContextSelectorComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BrandingContextSelectorComponent, NoopAnimationsModule],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(BrandingContextSelectorComponent);
+    component = fixture.componentInstance;
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('emits clientChange with the full Client when a new workspace id is selected', () => {
+    const c1 = client('w1');
+    const c2 = client('w2');
+    component.clients = [c1, c2];
+    component.selectedClient = c1;
+    const spy = vi.fn();
+    component.clientChange.subscribe(spy);
+
+    component.onClientSelect('w2');
+
+    expect(spy).toHaveBeenCalledWith(c2);
+  });
+
+  it('does not emit clientChange when the selected workspace is unchanged', () => {
+    const c1 = client('w1');
+    component.clients = [c1];
+    component.selectedClient = c1;
+    const spy = vi.fn();
+    component.clientChange.subscribe(spy);
+
+    component.onClientSelect('w1');
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+
+  it('emits brandChange with the full Brand when a new brand id is selected', () => {
+    const b1 = brand('b1');
+    const b2 = brand('b2', 3);
+    component.brands = [b1, b2];
+    component.selectedBrand = b1;
+    const spy = vi.fn();
+    component.brandChange.subscribe(spy);
+
+    component.onBrandSelect('b2');
+
+    expect(spy).toHaveBeenCalledWith(b2);
+  });
+
+  it('disables the brand select when there are no brands', () => {
+    component.brands = [];
+    fixture.detectChanges();
+    const brandSelect = fixture.nativeElement.querySelector('.ctx-brand mat-select');
+    expect(brandSelect?.getAttribute('aria-disabled')).toBe('true');
+  });
+
+  it('renders Version "—" when no brand selected and "v{n}" when one is', () => {
+    component.selectedBrand = null;
+    fixture.detectChanges();
+    const empty = fixture.nativeElement.querySelector('.ctx-version__value');
+    expect(empty.textContent.trim()).toBe('—');
+
+    component.selectedBrand = brand('b1', 7);
+    fixture.detectChanges();
+    const filled = fixture.nativeElement.querySelector('.ctx-version__value');
+    expect(filled.textContent.trim()).toBe('v7');
+  });
+
+  it('emits newBrandRequest when the New brand button is clicked', () => {
+    fixture.detectChanges();
+    const spy = vi.fn();
+    component.newBrandRequest.subscribe(spy);
+    const button: HTMLButtonElement | null = fixture.nativeElement.querySelector('.ctx-new-brand');
+    button?.click();
+    expect(spy).toHaveBeenCalled();
+  });
+
+  it('submitNewWorkspace emits trimmed name and clears the field', () => {
+    component.newWorkspaceName = '  My new workspace  ';
+    const spy = vi.fn();
+    component.addClient.subscribe(spy);
+
+    component.submitNewWorkspace();
+
+    expect(spy).toHaveBeenCalledWith('My new workspace');
+    expect(component.newWorkspaceName).toBe('');
+  });
+
+  it('submitNewWorkspace ignores empty input', () => {
+    component.newWorkspaceName = '   ';
+    const spy = vi.fn();
+    component.addClient.subscribe(spy);
+
+    component.submitNewWorkspace();
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/user-interface/src/app/components/branding-dashboard/branding-context-selector/branding-context-selector.component.ts
+++ b/user-interface/src/app/components/branding-dashboard/branding-context-selector/branding-context-selector.component.ts
@@ -1,0 +1,58 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatSelectModule } from '@angular/material/select';
+import type { Brand, Client } from '../../../models';
+
+@Component({
+  selector: 'app-branding-context-selector',
+  standalone: true,
+  imports: [
+    FormsModule,
+    MatButtonModule,
+    MatDividerModule,
+    MatFormFieldModule,
+    MatIconModule,
+    MatInputModule,
+    MatMenuModule,
+    MatSelectModule,
+  ],
+  templateUrl: './branding-context-selector.component.html',
+  styleUrl: './branding-context-selector.component.scss',
+})
+export class BrandingContextSelectorComponent {
+  @Input() clients: Client[] = [];
+  @Input() selectedClient: Client | null = null;
+  @Input() brands: Brand[] = [];
+  @Input() selectedBrand: Brand | null = null;
+
+  @Output() clientChange = new EventEmitter<Client>();
+  @Output() brandChange = new EventEmitter<Brand>();
+  @Output() newBrandRequest = new EventEmitter<void>();
+  @Output() reloadClients = new EventEmitter<void>();
+  @Output() addClient = new EventEmitter<string>();
+
+  newWorkspaceName = '';
+
+  onClientSelect(id: string): void {
+    const match = this.clients.find((c) => c.id === id);
+    if (match && match.id !== this.selectedClient?.id) this.clientChange.emit(match);
+  }
+
+  onBrandSelect(id: string): void {
+    const match = this.brands.find((b) => b.id === id);
+    if (match && match.id !== this.selectedBrand?.id) this.brandChange.emit(match);
+  }
+
+  submitNewWorkspace(): void {
+    const name = this.newWorkspaceName.trim();
+    if (!name) return;
+    this.addClient.emit(name);
+    this.newWorkspaceName = '';
+  }
+}

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.html
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.html
@@ -7,6 +7,18 @@
   <app-health-indicator [healthCheck]="healthCheck" label="Branding API" />
 </div>
 
+<app-branding-context-selector
+  [clients]="clients"
+  [selectedClient]="selectedClient"
+  [brands]="brands"
+  [selectedBrand]="selectedBrand"
+  (clientChange)="onWorkspaceChange($event)"
+  (brandChange)="onBrandChange($event)"
+  (newBrandRequest)="openFormTabForNewBrand()"
+  (reloadClients)="loadClients()"
+  (addClient)="onAddClientFromSelector($event)"
+/>
+
 @if (loading) {
   <app-loading-spinner message="Loading branding workspace..." />
 }
@@ -26,57 +38,6 @@
       <span class="tab-label">Chat</span>
     </ng-template>
     <div class="chat-view">
-      <div
-        class="current-brand-bar"
-        aria-live="polite"
-        [attr.aria-label]="
-          selectedBrand
-            ? 'Current brand: ' + selectedBrand.name + ', version ' + selectedBrand.version
-            : 'No brand selected'
-        "
-      >
-        @if (selectedBrand) {
-          <div class="current-brand-bar__main">
-            <span class="current-brand-bar__label">Current brand</span>
-            <span class="current-brand-bar__value">
-              {{ selectedBrand.name }} · v{{ selectedBrand.version }} · {{ selectedBrand.status }}
-            </span>
-            @if (brands.length > 1) {
-              <button mat-stroked-button type="button" [matMenuTriggerFor]="brandMenu">Change brand</button>
-              <mat-menu #brandMenu="matMenu">
-                @for (b of brands; track b.id) {
-                  <button mat-menu-item type="button" (click)="selectBrandForChat(b)">
-                    {{ b.name }} · v{{ b.version }} · {{ b.status }}
-                  </button>
-                }
-              </mat-menu>
-            }
-            <button mat-stroked-button color="primary" type="button" (click)="startFreshConversation()">
-              New brand
-            </button>
-          </div>
-        } @else if (brands.length > 0) {
-          <div class="current-brand-bar__main">
-            <span class="current-brand-bar__empty">Pick a brand to scope the assistant.</span>
-            <button mat-stroked-button type="button" [matMenuTriggerFor]="brandMenuEmpty">Select brand</button>
-            <mat-menu #brandMenuEmpty="matMenu">
-              @for (b of brands; track b.id) {
-                <button mat-menu-item type="button" (click)="selectBrandForChat(b)">
-                  {{ b.name }} · v{{ b.version }} · {{ b.status }}
-                </button>
-              }
-            </mat-menu>
-          </div>
-        } @else {
-          <div class="current-brand-bar__main current-brand-bar__main--empty">
-            <span class="current-brand-bar__empty">No brands yet.</span>
-            <button mat-stroked-button color="primary" type="button" (click)="openFormTabForNewBrand()">
-              Create brand
-            </button>
-          </div>
-        }
-      </div>
-
       <div class="split-panel">
         <div class="panel chat-panel">
           <div class="chat-toolbar">
@@ -112,27 +73,6 @@
               [latestOutput]="(($any(selectedBrand)?.latest_output ?? null) || conversationLatestOutput)"
               (saveAsBrand)="onOpenSaveAsBrand()"
             />
-          }
-          @if (brands.length > 0) {
-            <mat-card class="history-card">
-              <mat-card-header>
-                <mat-card-title>Quick switch</mat-card-title>
-                <mat-card-subtitle>Jump between saved brands for this workspace</mat-card-subtitle>
-              </mat-card-header>
-              <mat-card-content>
-                <div class="history-list">
-                  @for (brand of brands; track brand.id) {
-                    <button
-                      mat-stroked-button
-                      [color]="selectedBrand?.id === brand.id ? 'primary' : undefined"
-                      (click)="startNewBrandConversation(brand)"
-                    >
-                      {{ brand.name }} (v{{ brand.version }})
-                    </button>
-                  }
-                </div>
-              </mat-card-content>
-            </mat-card>
           }
         </div>
       </div>
@@ -185,69 +125,67 @@
                 </button>
               </form>
             }
-            <div #brandListWrap class="brand-list-wrap">
-              <ul class="brand-list">
-                @for (b of brands; track b.id) {
-                  <li
-                    class="brand-item"
-                    [class.brand-item--highlight]="highlightedBrandId === b.id"
-                    [attr.data-brand-id]="b.id"
-                  >
-                    <div class="brand-item__header">
-                      <strong>{{ b.name }}</strong> ({{ b.status }}, v{{ b.version }})
-                      <span class="brand-actions">
-                        <span class="split-button">
-                          <button
-                            mat-stroked-button
-                            type="button"
-                            class="split-button__primary"
-                            (click)="runBrand(b)"
-                            [disabled]="isGenerating(b.id)"
-                          >
-                            <mat-icon>bolt</mat-icon>
-                            Generate
-                          </button>
-                          <button
-                            mat-stroked-button
-                            type="button"
-                            class="split-button__menu"
-                            [matMenuTriggerFor]="generateMenu"
-                            [disabled]="isGenerating(b.id)"
-                            aria-label="Generate options"
-                          >
-                            <mat-icon>arrow_drop_down</mat-icon>
-                          </button>
-                        </span>
-                        <mat-menu #generateMenu="matMenu" xPosition="before">
-                          <button mat-menu-item type="button" (click)="runBrand(b)">
-                            <mat-icon>bolt</mat-icon>
-                            <span class="menu-item__title">Run full pipeline</span>
-                            <span class="menu-item__subtitle">Strategic core through governance (5-phase)</span>
-                          </button>
-                          <button mat-menu-item type="button" (click)="requestMarketResearchForBrand(b)">
-                            <mat-icon>travel_explore</mat-icon>
-                            <span class="menu-item__title">Market research only</span>
-                            <span class="menu-item__subtitle">Competitor and audience analysis</span>
-                          </button>
-                          <button mat-menu-item type="button" (click)="requestDesignAssetsForBrand(b)">
-                            <mat-icon>palette</mat-icon>
-                            <span class="menu-item__title">Design assets only</span>
-                            <span class="menu-item__subtitle">Palettes, typography, moodboards</span>
-                          </button>
-                        </mat-menu>
-                      </span>
-                    </div>
-                    <app-brand-activity-strip
-                      [brandId]="b.id"
-                      (open)="onActivityOpen($event)"
-                      (retry)="onActivityRetry(b, $event)"
-                      (dismiss)="onActivityDismiss($event)"
-                    />
-                  </li>
-                }
-              </ul>
-            </div>
-            @if (brands.length === 0 && !showCreateBrand) {
+            @if (selectedBrand) {
+              <div
+                class="selected-brand-actions"
+                [class.brand-item--highlight]="highlightedBrandId === selectedBrand.id"
+                [attr.data-brand-id]="selectedBrand.id"
+              >
+                <div class="brand-item__header">
+                  <strong>{{ selectedBrand.name }}</strong>
+                  <span class="brand-meta">({{ selectedBrand.status }}, v{{ selectedBrand.version }})</span>
+                  <span class="brand-actions">
+                    <span class="split-button">
+                      <button
+                        mat-stroked-button
+                        type="button"
+                        class="split-button__primary"
+                        (click)="runBrand(selectedBrand)"
+                        [disabled]="isGenerating(selectedBrand.id)"
+                      >
+                        <mat-icon>bolt</mat-icon>
+                        Generate
+                      </button>
+                      <button
+                        mat-stroked-button
+                        type="button"
+                        class="split-button__menu"
+                        [matMenuTriggerFor]="generateMenu"
+                        [disabled]="isGenerating(selectedBrand.id)"
+                        aria-label="Generate options"
+                      >
+                        <mat-icon>arrow_drop_down</mat-icon>
+                      </button>
+                    </span>
+                    <mat-menu #generateMenu="matMenu" xPosition="before">
+                      <button mat-menu-item type="button" (click)="runBrand(selectedBrand)">
+                        <mat-icon>bolt</mat-icon>
+                        <span class="menu-item__title">Run full pipeline</span>
+                        <span class="menu-item__subtitle">Strategic core through governance (5-phase)</span>
+                      </button>
+                      <button mat-menu-item type="button" (click)="requestMarketResearchForBrand(selectedBrand)">
+                        <mat-icon>travel_explore</mat-icon>
+                        <span class="menu-item__title">Market research only</span>
+                        <span class="menu-item__subtitle">Competitor and audience analysis</span>
+                      </button>
+                      <button mat-menu-item type="button" (click)="requestDesignAssetsForBrand(selectedBrand)">
+                        <mat-icon>palette</mat-icon>
+                        <span class="menu-item__title">Design assets only</span>
+                        <span class="menu-item__subtitle">Palettes, typography, moodboards</span>
+                      </button>
+                    </mat-menu>
+                  </span>
+                </div>
+                <app-brand-activity-strip
+                  [brandId]="selectedBrand.id"
+                  (open)="onActivityOpen($event)"
+                  (retry)="onActivityRetry(selectedBrand, $event)"
+                  (dismiss)="onActivityDismiss($event)"
+                />
+              </div>
+            } @else if (brands.length > 0) {
+              <p class="hint">Select a brand from the context switcher above to run workflows.</p>
+            } @else if (!showCreateBrand) {
               <p>No brands yet. Use <strong>New brand</strong> to add one.</p>
             }
             @if (brandActionMessage) {
@@ -256,37 +194,6 @@
           } @else if (!loading && !clientLoadError) {
             <p>Preparing workspace…</p>
           }
-
-          <mat-expansion-panel class="advanced-workspace-panel">
-            <mat-expansion-panel-header>
-              <mat-panel-title>Advanced</mat-panel-title>
-              <mat-panel-description>Optional: extra workspace entries (rarely needed)</mat-panel-description>
-            </mat-expansion-panel-header>
-            <div class="agency-actions">
-              <button mat-stroked-button type="button" color="primary" (click)="loadClients()">Reload workspaces</button>
-              <span class="new-client-row">
-                <input type="text" [(ngModel)]="newClientName" placeholder="Additional workspace name" class="client-name-input" />
-                <button mat-stroked-button type="button" (click)="createClient()" [disabled]="!newClientName.trim() || brandFormBusy">
-                  Add workspace
-                </button>
-              </span>
-            </div>
-            @if (clients.length > 0) {
-              <p class="client-list-label">Switch workspace:</p>
-              <div class="client-list">
-                @for (c of clients; track c.id) {
-                  <button
-                    mat-stroked-button
-                    type="button"
-                    [color]="selectedClient?.id === c.id ? 'primary' : null"
-                    (click)="selectClient(c)"
-                  >
-                    {{ c.name }}
-                  </button>
-                }
-              </div>
-            }
-          </mat-expansion-panel>
         </mat-card-content>
       </mat-card>
 

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.scss
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.scss
@@ -10,42 +10,6 @@
   line-height: 1.5;
 }
 
-.current-brand-bar {
-  margin-bottom: 12px;
-  padding: 12px 14px;
-  border: 1px solid var(--mat-sys-outline-variant, #e0e0e0);
-  border-radius: 8px;
-  background: var(--mat-sys-surface-container-low, #fafafa);
-}
-
-.current-brand-bar__main {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 10px 16px;
-}
-
-.current-brand-bar__main--empty {
-  justify-content: flex-start;
-}
-
-.current-brand-bar__label {
-  font-size: 0.75rem;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--mat-sys-on-surface-variant, #666);
-  width: 100%;
-}
-
-.current-brand-bar__value {
-  font-weight: 500;
-}
-
-.current-brand-bar__empty {
-  color: var(--mat-sys-on-surface-variant, #555);
-}
-
 .chat-view {
   padding: 0;
 }
@@ -80,20 +44,6 @@
   .split-panel {
     grid-template-columns: 1fr;
     min-height: auto;
-  }
-
-  /* Narrow: brand context → chat → preview → lists */
-  .chat-view {
-    display: flex;
-    flex-direction: column;
-  }
-
-  .current-brand-bar {
-    order: 0;
-  }
-
-  .split-panel {
-    order: 1;
   }
 }
 
@@ -179,10 +129,6 @@ mat-card {
   width: 100%;
 }
 
-.advanced-workspace-panel {
-  margin-top: 16px;
-}
-
 .agency-actions {
   display: flex;
   flex-wrap: wrap;
@@ -204,24 +150,6 @@ mat-card {
   min-width: 180px;
 }
 
-.client-list-label,
-.brands-label {
-  margin-top: 12px;
-  margin-bottom: 8px;
-  font-weight: 500;
-}
-
-.client-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-bottom: 12px;
-}
-
-.brand-list-wrap {
-  margin-top: 8px;
-}
-
 .new-brand-form {
   display: grid;
   gap: 12px;
@@ -231,19 +159,14 @@ mat-card {
   border-radius: 8px;
 }
 
-.brand-list {
-  list-style: none;
-  padding: 0;
-  margin: 12px 0 0;
-}
-
-.brand-item {
+.selected-brand-actions {
   display: flex;
   flex-direction: column;
   align-items: stretch;
   gap: 6px;
-  padding: 10px 0;
-  border-bottom: 1px solid #eee;
+  padding: 12px 0;
+  margin-top: 12px;
+  border-top: 1px solid #eee;
   border-radius: 4px;
   transition: background 0.3s ease;
 }
@@ -255,8 +178,19 @@ mat-card {
   gap: 12px;
 }
 
+.brand-meta {
+  color: var(--mat-sys-on-surface-variant, #666);
+  font-size: 0.9rem;
+}
+
 .brand-item--highlight {
   background: rgba(88, 166, 255, 0.12);
+}
+
+.hint {
+  margin-top: 12px;
+  color: var(--mat-sys-on-surface-variant, #666);
+  font-style: italic;
 }
 
 .brand-actions {

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { Subject, of, throwError } from 'rxjs';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { vi } from 'vitest';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { BrandingApiService, type BrandJobStatus } from '../../services/branding-api.service';
@@ -10,6 +10,9 @@ import { BrandingDashboardComponent } from './branding-dashboard.component';
 import type { Brand } from '../../models';
 
 const fakeRoute = { snapshot: { queryParamMap: { get: () => null } } };
+const fakeRouteWith = (params: Record<string, string | null>) => ({
+  snapshot: { queryParamMap: { get: (k: string) => params[k] ?? null } },
+});
 
 const workspaceClient = { id: 'w1', name: 'My brands', created_at: '2020-01-01', updated_at: '2020-01-01' };
 
@@ -31,6 +34,7 @@ describe('BrandingDashboardComponent', () => {
     requestDesignAssets: ReturnType<typeof vi.fn>;
   };
   let snackBarSpy: { open: ReturnType<typeof vi.fn> };
+  let routerSpy: { navigate: ReturnType<typeof vi.fn> };
 
   beforeEach(async () => {
     snackBarSpy = {
@@ -38,6 +42,7 @@ describe('BrandingDashboardComponent', () => {
         onAction: () => ({ subscribe: vi.fn() }),
       }),
     };
+    routerSpy = { navigate: vi.fn().mockResolvedValue(true) };
     const emptyConversationState = { conversation_id: 'c1', messages: [], mission: null, latest_output: null, suggested_questions: [] };
     apiSpy = {
       health: vi.fn().mockReturnValue(of({ status: 'ok' })),
@@ -59,6 +64,7 @@ describe('BrandingDashboardComponent', () => {
         { provide: BrandingApiService, useValue: apiSpy },
         { provide: MatSnackBar, useValue: snackBarSpy },
         { provide: ActivatedRoute, useValue: fakeRoute },
+        { provide: Router, useValue: routerSpy },
       ],
     }).compileComponents();
 
@@ -247,6 +253,135 @@ describe('BrandingDashboardComponent', () => {
     expect(hydrated).toBeTruthy();
     expect(hydrated!.brandId).toBe('b1');
   });
+
+  it('selectClient writes workspaceId to the URL via syncQueryParams', () => {
+    const client = { id: 'w1', name: 'My brands', created_at: '', updated_at: '' };
+    apiSpy.listBrands.mockReturnValue(of([]));
+    routerSpy.navigate.mockClear();
+
+    component.selectClient(client);
+
+    expect(routerSpy.navigate).toHaveBeenCalled();
+    const lastCall = routerSpy.navigate.mock.calls[routerSpy.navigate.mock.calls.length - 1];
+    expect(lastCall[1].queryParams.workspaceId).toBe('w1');
+  });
+
+  it('onWorkspaceChange delegates to selectClient', () => {
+    const client = { id: 'w2', name: 'Other', created_at: '', updated_at: '' };
+    apiSpy.listBrands.mockReturnValue(of([]));
+
+    component.onWorkspaceChange(client);
+
+    expect(component.selectedClient).toEqual(client);
+    expect(apiSpy.listBrands).toHaveBeenCalledWith('w2');
+  });
+
+  it('onBrandChange resumes the brand and sets activeConversationId', () => {
+    const brand: Brand = {
+      id: 'b1', client_id: 'w1', name: 'B', status: 'draft',
+      conversation_id: 'conv-7', mission: {} as any, version: 1, history: [],
+      created_at: '', updated_at: '',
+    };
+
+    component.onBrandChange(brand);
+
+    expect(component.selectedBrand).toEqual(brand);
+    expect(component.activeConversationId).toBe('conv-7');
+  });
+
+  it('onAddClientFromSelector creates the workspace via createClient', () => {
+    apiSpy.createClient.mockReturnValue(of({ id: 'wN', name: 'New', created_at: '', updated_at: '' }));
+    apiSpy.listClients.mockReturnValue(of([{ id: 'wN', name: 'New', created_at: '', updated_at: '' }]));
+
+    component.onAddClientFromSelector('New');
+
+    expect(apiSpy.createClient).toHaveBeenCalledWith({ name: 'New' });
+  });
+});
+
+describe('BrandingDashboardComponent query-param restore', () => {
+  it('restores selected workspace from ?workspaceId on init', async () => {
+    const w1 = { id: 'w1', name: 'WS1', created_at: '', updated_at: '' };
+    const w2 = { id: 'w2', name: 'WS2', created_at: '', updated_at: '' };
+    const snackBar = { open: vi.fn().mockReturnValue({ onAction: () => ({ subscribe: vi.fn() }) }) };
+    const router = { navigate: vi.fn().mockResolvedValue(true) };
+    const api = {
+      health: vi.fn().mockReturnValue(of({ status: 'ok' })),
+      listClients: vi.fn().mockReturnValue(of([w1, w2])),
+      listBrands: vi.fn().mockReturnValue(of([])),
+      createClient: vi.fn(),
+      createBrand: vi.fn(),
+      getBrand: vi.fn(),
+      createConversation: vi.fn().mockReturnValue(of({ conversation_id: 'c1', messages: [], mission: null, latest_output: null, suggested_questions: [] })),
+      submitRun: vi.fn(),
+      observeJob: vi.fn(),
+      listJobs: vi.fn().mockReturnValue(of([])),
+      requestMarketResearch: vi.fn(),
+      requestDesignAssets: vi.fn(),
+    };
+
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [BrandingDashboardComponent, NoopAnimationsModule],
+      providers: [
+        { provide: BrandingApiService, useValue: api },
+        { provide: MatSnackBar, useValue: snackBar },
+        { provide: ActivatedRoute, useValue: fakeRouteWith({ workspaceId: 'w2' }) },
+        { provide: Router, useValue: router },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(BrandingDashboardComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.selectedClient?.id).toBe('w2');
+  });
+
+  it('restores selected brand from ?brandId on init', async () => {
+    const w1 = { id: 'w1', name: 'WS1', created_at: '', updated_at: '' };
+    const b1: Brand = {
+      id: 'b1', client_id: 'w1', name: 'B1', status: 'draft',
+      mission: {} as any, version: 1, history: [], created_at: '', updated_at: '',
+    };
+    const b2: Brand = {
+      id: 'b2', client_id: 'w1', name: 'B2', status: 'draft',
+      mission: {} as any, version: 2, history: [], created_at: '', updated_at: '',
+    };
+    const snackBar = { open: vi.fn().mockReturnValue({ onAction: () => ({ subscribe: vi.fn() }) }) };
+    const router = { navigate: vi.fn().mockResolvedValue(true) };
+    const api = {
+      health: vi.fn().mockReturnValue(of({ status: 'ok' })),
+      listClients: vi.fn().mockReturnValue(of([w1])),
+      listBrands: vi.fn().mockReturnValue(of([b1, b2])),
+      createClient: vi.fn(),
+      createBrand: vi.fn(),
+      getBrand: vi.fn(),
+      createConversation: vi.fn().mockReturnValue(of({ conversation_id: 'c1', messages: [], mission: null, latest_output: null, suggested_questions: [] })),
+      submitRun: vi.fn(),
+      observeJob: vi.fn(),
+      listJobs: vi.fn().mockReturnValue(of([])),
+      requestMarketResearch: vi.fn(),
+      requestDesignAssets: vi.fn(),
+    };
+
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [BrandingDashboardComponent, NoopAnimationsModule],
+      providers: [
+        { provide: BrandingApiService, useValue: api },
+        { provide: MatSnackBar, useValue: snackBar },
+        { provide: ActivatedRoute, useValue: fakeRouteWith({ brandId: 'b1' }) },
+        { provide: Router, useValue: router },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(BrandingDashboardComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(fixture.componentInstance.selectedBrand?.id).toBe('b1');
+  });
 });
 
 describe('BrandingDashboardComponent workspace bootstrap', () => {
@@ -274,6 +409,7 @@ describe('BrandingDashboardComponent workspace bootstrap', () => {
         { provide: BrandingApiService, useValue: api },
         { provide: MatSnackBar, useValue: snackBar },
         { provide: ActivatedRoute, useValue: fakeRoute },
+        { provide: Router, useValue: { navigate: vi.fn().mockResolvedValue(true) } },
       ],
     }).compileComponents();
 

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, OnDestroy, OnInit, ViewChild, inject } from '@angular/core';
+import { Component, OnDestroy, OnInit, inject } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
 import { BreakpointObserver } from '@angular/cdk/layout';
 import { FormBuilder, FormsModule, ReactiveFormsModule, Validators } from '@angular/forms';
@@ -21,6 +21,7 @@ import { HealthIndicatorComponent } from '../health-indicator/health-indicator.c
 import { BrandingChatComponent } from '../branding-chat/branding-chat.component';
 import { BrandPreviewComponent } from '../brand-preview/brand-preview.component';
 import { BrandActivityStripComponent } from '../brand-activity-strip/brand-activity-strip.component';
+import { BrandingContextSelectorComponent } from './branding-context-selector/branding-context-selector.component';
 import type {
   Brand,
   BrandActivity,
@@ -60,6 +61,7 @@ const WORKSPACE_CLIENT_NAME = 'My brands';
     BrandingChatComponent,
     BrandPreviewComponent,
     BrandActivityStripComponent,
+    BrandingContextSelectorComponent,
   ],
   templateUrl: './branding-dashboard.component.html',
   styleUrl: './branding-dashboard.component.scss',
@@ -74,8 +76,6 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
   private readonly activityStore = inject(BrandActivityService);
   /** Per-activity-id polling subscriptions so we can clean up on destroy. */
   private readonly activityPolls = new Map<string, Subscription>();
-
-  @ViewChild('brandListWrap') private brandListWrap?: ElementRef<HTMLElement>;
 
   /** Narrow layout: collapsible brand preview panel. */
   isCompactLayout = false;
@@ -156,6 +156,7 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
   /** Keep URL query params in sync so the user can bookmark / deep-link back. */
   private syncQueryParams(): void {
     const params: Record<string, string> = {};
+    if (this.selectedClient?.id) params['workspaceId'] = this.selectedClient.id;
     if (this.activeConversationId) params['conversationId'] = this.activeConversationId;
     if (this.selectedBrand?.id) params['brandId'] = this.selectedBrand.id;
     this.router.navigate([], {
@@ -164,6 +165,19 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
       queryParamsHandling: 'replace',
       replaceUrl: true,
     });
+  }
+
+  onWorkspaceChange(client: Client): void {
+    this.selectClient(client);
+  }
+
+  onBrandChange(brand: Brand): void {
+    this.resumeOrStartBrand(brand);
+  }
+
+  onAddClientFromSelector(name: string): void {
+    this.newClientName = name;
+    this.createClient();
   }
 
   onOpenSaveAsBrand(): void {
@@ -264,14 +278,16 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
     });
   }
 
-  /** Conversation/brand IDs from URL query params, used to restore state on page load. */
+  /** Conversation/brand/workspace IDs from URL query params, used to restore state on page load. */
   private pendingConversationId: string | null = null;
   private pendingBrandId: string | null = null;
+  private pendingWorkspaceId: string | null = null;
 
   ngOnInit(): void {
     const snap = this.route.snapshot.queryParamMap;
     this.pendingConversationId = snap.get('conversationId');
     this.pendingBrandId = snap.get('brandId');
+    this.pendingWorkspaceId = snap.get('workspaceId');
     this.ensureWorkspaceClient();
     this.layoutSub = this.breakpoint.observe('(max-width: 900px)').subscribe((state) => {
       this.isCompactLayout = state.matches;
@@ -312,7 +328,12 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
         } else {
           this.clients = list;
           if (!this.selectedClient) {
-            this.selectClient(list[0]);
+            const target =
+              (this.pendingWorkspaceId &&
+                list.find((c) => c.id === this.pendingWorkspaceId)) ||
+              list[0];
+            this.pendingWorkspaceId = null;
+            this.selectClient(target);
           } else {
             this.loading = false;
           }
@@ -345,6 +366,7 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
     this.selectedBrand = null;
     this.brands = [];
     this.brandActionMessage = null;
+    this.syncQueryParams();
     this.api.listBrands(client.id).subscribe({
       next: (list) => {
         this.brands = list;
@@ -414,18 +436,13 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
     this.resumeOrStartBrand(brand);
   }
 
-  startNewBrandConversation(brand: Brand): void {
-    this.resumeOrStartBrand(brand);
-  }
-
   openFormTabForNewBrand(): void {
     this.selectedTabIndex = 1;
     this.showCreateBrand = true;
   }
 
   private scrollBrandRowIntoView(brandId: string): void {
-    const root = this.brandListWrap?.nativeElement;
-    const el = root?.querySelector(`[data-brand-id="${brandId}"]`);
+    const el = document.querySelector(`[data-brand-id="${brandId}"]`);
     el?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
   }
 
@@ -494,7 +511,7 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
         setTimeout(() => {
           this.highlightedBrandId = null;
         }, 2500);
-        this.startNewBrandConversation(brand);
+        this.resumeOrStartBrand(brand);
         this.selectedTabIndex = 0;
         const ref = this.snackBar.open(
           `Brand “${brand.name}” created. Chat is scoped to this brand.`,


### PR DESCRIPTION
Closes #275.

## Summary

Collapses the three duplicated brand-selection UIs in the branding dashboard — sticky "current brand" bar (Chat tab), "quick switch" card (preview panel), and per-brand list (Form tab) — plus the Advanced workspace expansion panel into a single persistent `Workspace / Brand / Version` selector rendered once above `<mat-tab-group>`. Chat, Form, and Preview tabs all read from this single source of truth.

This is the foundational issue in the branding UX cleanup epic (unblocks #277, #278, #279).

## Changes

- **New** `BrandingContextSelectorComponent` (`branding-dashboard/branding-context-selector/`) — presentational, standalone. `<mat-select>` for Workspace and Brand, read-only Version badge, "+ New brand" button, overflow menu hosting Reload workspaces / Add workspace.
- **Dashboard template** (`branding-dashboard.component.html`):
  - Inserted the selector above the tab group.
  - Removed the sticky `.current-brand-bar` block (Chat tab).
  - Removed the `.history-card` quick-switch card (preview panel).
  - Reduced the Form tab brand list to a single "selected brand actions" panel scoped to `selectedBrand` (Generate split-button + activity strip preserved).
  - Removed the Advanced workspace `<mat-expansion-panel>`.
- **Dashboard TS** (`branding-dashboard.component.ts`):
  - New handlers: `onWorkspaceChange`, `onBrandChange`, `onAddClientFromSelector`.
  - `syncQueryParams` now writes `workspaceId` alongside `brandId` and `conversationId`.
  - `selectClient` calls `syncQueryParams` so workspace switches show in the URL.
  - `ngOnInit` reads `pendingWorkspaceId` from `?workspaceId=…`; `ensureWorkspaceClient` honours it on first hydrate.
  - Deleted `startNewBrandConversation` (only caller now uses `resumeOrStartBrand` directly), `#brandListWrap` `ViewChild`, unused `ElementRef`/`ViewChild` imports.
- **SCSS** — removed orphan `.current-brand-bar*`, `.advanced-workspace-panel`, `.client-list*`, `.brand-list-wrap`, `.brand-list`, `.brand-item` rules; added `.selected-brand-actions`, `.brand-meta`, `.hint`.
- **Tests**:
  - 9 new specs in `branding-context-selector.component.spec.ts`.
  - 5 new specs + `Router` stub in `branding-dashboard.component.spec.ts` (selectClient writes workspaceId, onWorkspaceChange/onBrandChange/onAddClientFromSelector handlers, query-param restore for `workspaceId` and `brandId`).

Net: 8 files changed, +622 / −260.

## Acceptance criteria

- [x] One brand selector component, rendered once at the dashboard level.
- [x] Chat, Form, and Preview tabs all react to selector changes (no local brand state in children).
- [x] Workspace switcher promoted out of the Advanced panel into this selector.
- [x] Removed the redundant "quick switch" card from the preview panel.
- [x] Removed the in-tab brand list from the Form tab (reduced to single selected-brand action panel).
- [x] Query-param deep linking continues to work; extended with `workspaceId`.

## Test plan

- [x] `npm test` — 305/305 pass (29 in branding dashboard + selector).
- [x] `npm run build` — production build succeeds (preexisting bundle-size warning unaffected).
- [ ] Manual: open `/branding-dashboard`, switch brands/workspaces from selector, verify Chat/Form/Preview all react.
- [ ] Manual: deep-link with `?workspaceId=…&brandId=…&conversationId=…`, reload, verify all three restore.
- [ ] Manual: tab through the selector — `aria-label`s announce Workspace / Brand / Version.

https://claude.ai/code/session_018LbCgrTGDgVy57SAxFFGfo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y9pM6eahteD73rweiMB1jC)_