### PR TITLE
Enforce payload size and execution-time limits on the agent invoke path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,9 @@ Environment variables for LLM: `LLM_PROVIDER`, `LLM_BASE_URL`, `LLM_MODEL`
 | `SOCIAL_MARKETING_WINNING_POSTS_TOP_K` | Max exemplars retrieved from the social marketing Winning Posts Bank per concept run (default `5`). |
 | `SOCIAL_MARKETING_WINNING_POSTS_RERANK_ENABLED` | Enable LLM rerank stage in the Winning Posts Bank retrieval (default `true`; set to `false` to disable). |
 | `SOCIAL_MARKETING_WINNING_POSTS_INGEST_THRESHOLD` | Engagement-score cutoff (0..1) above which performance observations are auto-promoted into the Winning Posts Bank (default `0.7`). |
+| `AGENT_INVOKE_MAX_PAYLOAD_BYTES` | Hard cap on request body for `POST /api/agents/{id}/invoke` and the sandbox shim (default `1048576` = 1 MiB; overflow returns 413 without spinning up a sandbox). |
+| `AGENT_INVOKE_MAX_OUTPUT_BYTES` | Hard cap on agent response body; oversized outputs are truncated with `truncated: true` on the envelope (default `1048576` = 1 MiB). Applies inside the shim and on the proxy's re-serialize path. |
+| `AGENT_EXEC_TIMEOUT_S` | Default per-agent execution timeout (`asyncio.wait_for`) inside the sandbox; overflow returns 504 with `timeout_hit: true` (default `60`). Per-agent override via `invoke.timeout_seconds` in the manifest. |
 
 **Blogging pipeline:** `research → planning (ContentPlan) → writer → gates`; `POST /research-and-review` runs research + the same planning step. See `backend/agents/blogging/README.md` and repo `CHANGELOG.md`.
 

--- a/backend/agents/agent_registry/models.py
+++ b/backend/agents/agent_registry/models.py
@@ -26,6 +26,11 @@ class InvokeSpec(BaseModel):
     path: str | None = None
     workflow: str | None = None
     callable_ref: str | None = None
+    timeout_seconds: float | None = Field(
+        default=None,
+        description="Per-agent execution timeout inside the sandbox. "
+        "Falls back to AGENT_EXEC_TIMEOUT_S (default 60s).",
+    )
 
 
 class SandboxSpec(BaseModel):

--- a/backend/agents/shared_agent_invoke/limits.py
+++ b/backend/agents/shared_agent_invoke/limits.py
@@ -1,0 +1,80 @@
+"""Size and timeout limits for the agent invoke path.
+
+Shared by the unified API proxy (``unified_api/routes/agents.py``) and the
+sandbox shim (``shared_agent_invoke/shim.py``) so both enforcement points use
+the same defaults and env-var overrides. See GitHub issue #256.
+
+Three axes are bounded:
+
+* Request body size — hard cap, returns HTTP 413 on overflow.
+* Execution time — wrapped in ``asyncio.wait_for``, returns HTTP 504.
+* Response body size — serialised output is truncated with a flag.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from fastapi import HTTPException, Request
+
+DEFAULT_MAX_PAYLOAD_BYTES = 1 * 1024 * 1024  # 1 MiB
+DEFAULT_MAX_OUTPUT_BYTES = 1 * 1024 * 1024  # 1 MiB
+DEFAULT_EXEC_TIMEOUT_S = 60.0
+
+
+def max_payload_bytes() -> int:
+    return int(os.getenv("AGENT_INVOKE_MAX_PAYLOAD_BYTES", str(DEFAULT_MAX_PAYLOAD_BYTES)))
+
+
+def max_output_bytes() -> int:
+    return int(os.getenv("AGENT_INVOKE_MAX_OUTPUT_BYTES", str(DEFAULT_MAX_OUTPUT_BYTES)))
+
+
+def default_exec_timeout_s() -> float:
+    return float(os.getenv("AGENT_EXEC_TIMEOUT_S", str(DEFAULT_EXEC_TIMEOUT_S)))
+
+
+async def read_json_capped(request: Request, *, max_bytes: int) -> Any:
+    """Read the request body with a hard size cap.
+
+    Returns ``{}`` for empty or malformed JSON (preserving the existing
+    silent-fallback contract of the invoke path). Raises ``HTTPException(413)``
+    if the body exceeds ``max_bytes`` — the streaming loop short-circuits as
+    soon as the cap is hit, so large payloads do not materialise in memory.
+    """
+    cl = request.headers.get("content-length")
+    if cl is not None and cl.isdigit() and int(cl) > max_bytes:
+        raise HTTPException(status_code=413, detail=f"Payload exceeds {max_bytes} bytes")
+    buf = bytearray()
+    async for chunk in request.stream():
+        if not chunk:
+            continue
+        buf.extend(chunk)
+        if len(buf) > max_bytes:
+            raise HTTPException(status_code=413, detail=f"Payload exceeds {max_bytes} bytes")
+    if not buf:
+        return {}
+    try:
+        return json.loads(bytes(buf))
+    except (ValueError, json.JSONDecodeError):
+        return {}
+
+
+def cap_output(value: Any, *, max_bytes: int) -> tuple[Any, bool]:
+    """Return ``(value, False)`` if the serialised size fits, else a truncation envelope."""
+    try:
+        serialized = json.dumps(value, default=str)
+    except (TypeError, ValueError):
+        serialized = repr(value)
+    if len(serialized) <= max_bytes:
+        return value, False
+    return (
+        {
+            "__truncated__": True,
+            "preview": serialized[:max_bytes],
+            "original_size": len(serialized),
+        },
+        True,
+    )

--- a/backend/agents/shared_agent_invoke/shim.py
+++ b/backend/agents/shared_agent_invoke/shim.py
@@ -13,6 +13,7 @@ manifest and dispatches.
 
 from __future__ import annotations
 
+import asyncio
 import io
 import logging
 import time
@@ -24,6 +25,13 @@ from fastapi import FastAPI, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from .dispatch import AgentNotRunnableError, invoke_entrypoint
+from .limits import (
+    cap_output,
+    default_exec_timeout_s,
+    max_output_bytes,
+    max_payload_bytes,
+    read_json_capped,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -36,6 +44,8 @@ class InvokeEnvelope(BaseModel):
     trace_id: str
     logs_tail: list[str] = Field(default_factory=list)
     error: str | None = None
+    truncated: bool = False
+    timeout_hit: bool = False
 
 
 def mount_invoke_shim(app: FastAPI) -> None:
@@ -60,10 +70,7 @@ def mount_invoke_shim(app: FastAPI) -> None:
                 detail=f"Agent {agent_id} requires live integrations and is not runnable in the sandbox.",
             )
 
-        try:
-            body: Any = await request.json()
-        except Exception:
-            body = {}
+        body: Any = await read_json_capped(request, max_bytes=max_payload_bytes())
 
         trace_id = str(uuid.uuid4())
         logs_tail: list[str] = []
@@ -75,9 +82,14 @@ def mount_invoke_shim(app: FastAPI) -> None:
         error: str | None = None
         output: Any | None = None
         dispatch_error: AgentNotRunnableError | None = None
+        timeout_hit = False
+        timeout_s = _resolve_exec_timeout(manifest)
         try:
             with redirect_stdout(stdout_buf), redirect_stderr(stderr_buf):
-                output = await invoke_entrypoint(manifest.source.entrypoint, body)
+                output = await asyncio.wait_for(
+                    invoke_entrypoint(manifest.source.entrypoint, body),
+                    timeout=timeout_s,
+                )
         except AgentNotRunnableError as exc:
             # Config / deployment problem — bad entrypoint, missing symbol,
             # non-zero-arg constructor. Defer the raise until after `finally`
@@ -86,6 +98,10 @@ def mount_invoke_shim(app: FastAPI) -> None:
             dispatch_error = exc
         except HTTPException:
             raise
+        except asyncio.TimeoutError:
+            logger.warning("agent %s exceeded execution timeout (%.1fs)", agent_id, timeout_s)
+            error = f"AgentExecutionTimeout: exceeded {timeout_s:.1f}s"
+            timeout_hit = True
         except Exception as exc:
             # User-space exception raised by the agent itself — surface it
             # with logs via a 422 so the caller can still render the envelope.
@@ -115,16 +131,31 @@ def mount_invoke_shim(app: FastAPI) -> None:
             )
             raise HTTPException(status_code=500, detail=envelope.model_dump())
 
+        capped_output, truncated = cap_output(_jsonable(output), max_bytes=max_output_bytes())
         envelope = InvokeEnvelope(
-            output=_jsonable(output),
+            output=capped_output,
             duration_ms=duration_ms,
             trace_id=trace_id,
             logs_tail=logs_tail[-50:],
             error=error,
+            truncated=truncated,
+            timeout_hit=timeout_hit,
         )
+        if timeout_hit:
+            raise HTTPException(status_code=504, detail=envelope.model_dump())
         if error:
             raise HTTPException(status_code=422, detail=envelope.model_dump())
         return envelope
+
+
+def _resolve_exec_timeout(manifest: Any) -> float:
+    """Per-agent timeout override from ``manifest.invoke.timeout_seconds`` if set."""
+    invoke = getattr(manifest, "invoke", None)
+    if invoke is not None:
+        override = getattr(invoke, "timeout_seconds", None)
+        if override is not None and override > 0:
+            return float(override)
+    return default_exec_timeout_s()
 
 
 def _jsonable(value: Any) -> Any:

--- a/backend/agents/shared_agent_invoke/tests/test_shim.py
+++ b/backend/agents/shared_agent_invoke/tests/test_shim.py
@@ -47,8 +47,28 @@ def client(tmp_path: Path):
         def run(self, body):
             raise RuntimeError("user-space failure")
 
+    class SleepAgent:
+        async def run(self, body):
+            import asyncio
+
+            await asyncio.sleep(10)
+            return {"never": "returned"}
+
+    class BigAgent:
+        def run(self, body):
+            # Deliberately larger than the default 1 MiB output cap so tests
+            # that tune AGENT_INVOKE_MAX_OUTPUT_BYTES downward trip truncation.
+            return {"blob": "x" * (2 * 1024 * 1024)}
+
+    class SentinelAgent:
+        def run(self, body):
+            raise AssertionError("SentinelAgent must never be invoked")
+
     runnable_mod.GoodAgent = GoodAgent
     runnable_mod.RaisingAgent = RaisingAgent
+    runnable_mod.SleepAgent = SleepAgent
+    runnable_mod.BigAgent = BigAgent
+    runnable_mod.SentinelAgent = SentinelAgent
     sys.modules["_shim_test_runnable"] = runnable_mod
 
     _write_manifest(
@@ -102,6 +122,61 @@ def client(tmp_path: Path):
         tags: [requires-live-integration]
         source:
           entrypoint: _shim_test_runnable:GoodAgent
+        """,
+    )
+    _write_manifest(
+        tmp_path,
+        "sleeper.yaml",
+        """
+        schema_version: 1
+        id: blogging.sleeper
+        team: blogging
+        name: Sleeper
+        summary: never returns in time
+        source:
+          entrypoint: _shim_test_runnable:SleepAgent
+        """,
+    )
+    _write_manifest(
+        tmp_path,
+        "sleeper_override.yaml",
+        """
+        schema_version: 1
+        id: blogging.sleeper_override
+        team: blogging
+        name: Sleeper with per-manifest override
+        summary: sleeps long, but manifest caps it low
+        invoke:
+          kind: http
+          timeout_seconds: 0.2
+        source:
+          entrypoint: _shim_test_runnable:SleepAgent
+        """,
+    )
+    _write_manifest(
+        tmp_path,
+        "big.yaml",
+        """
+        schema_version: 1
+        id: blogging.big
+        team: blogging
+        name: Big
+        summary: returns oversized output
+        source:
+          entrypoint: _shim_test_runnable:BigAgent
+        """,
+    )
+    _write_manifest(
+        tmp_path,
+        "sentinel.yaml",
+        """
+        schema_version: 1
+        id: blogging.sentinel
+        team: blogging
+        name: Sentinel
+        summary: must not run
+        source:
+          entrypoint: _shim_test_runnable:SentinelAgent
         """,
     )
 
@@ -168,3 +243,57 @@ def test_requires_live_integration_returns_409(client: TestClient) -> None:
 def test_unknown_agent_returns_404(client: TestClient) -> None:
     resp = client.post("/_agents/does.not.exist/invoke", json={})
     assert resp.status_code == 404
+
+
+def test_oversized_body_returns_413(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Cap to 1 KiB so the test doesn't allocate megabytes.
+    monkeypatch.setenv("AGENT_INVOKE_MAX_PAYLOAD_BYTES", "1024")
+    payload = "x" * 4096  # 4 KiB — well over the cap
+    resp = client.post(
+        "/_agents/blogging.sentinel/invoke",
+        content=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 413
+    # Sentinel agent raises AssertionError if called — absence of 500 proves
+    # the cap short-circuits before dispatch.
+
+
+def test_timeout_returns_504_with_envelope(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("AGENT_EXEC_TIMEOUT_S", "0.1")
+    resp = client.post("/_agents/blogging.sleeper/invoke", json={})
+    assert resp.status_code == 504
+    detail = resp.json()["detail"]
+    assert detail["timeout_hit"] is True
+    assert detail["error"].startswith("AgentExecutionTimeout:")
+    assert "trace_id" in detail
+
+
+def test_oversized_output_sets_truncated_flag(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Cap at 10 KiB — BigAgent returns ~2 MiB.
+    monkeypatch.setenv("AGENT_INVOKE_MAX_OUTPUT_BYTES", "10240")
+    resp = client.post("/_agents/blogging.big/invoke", json={})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["truncated"] is True
+    assert body["error"] is None
+    assert body["output"]["__truncated__"] is True
+    assert body["output"]["original_size"] > 10240
+    assert len(body["output"]["preview"]) == 10240
+
+
+def test_per_manifest_timeout_overrides_env_default(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Env default is very generous; manifest override pins it to 0.2s.
+    monkeypatch.setenv("AGENT_EXEC_TIMEOUT_S", "60")
+    resp = client.post("/_agents/blogging.sleeper_override/invoke", json={})
+    assert resp.status_code == 504
+    detail = resp.json()["detail"]
+    assert detail["timeout_hit"] is True
+    # Timeout message reflects the manifest's 0.2s override, not the env 60s.
+    assert "0.2s" in detail["error"]

--- a/backend/unified_api/routes/agents.py
+++ b/backend/unified_api/routes/agents.py
@@ -43,6 +43,11 @@ from agent_provisioning_team.sandbox import (
 )
 from agent_registry import AgentDetail, AgentSummary, TeamGroup, get_registry
 from agent_registry.schema_resolver import SchemaResolutionError, resolve_schema
+from shared_agent_invoke.limits import (
+    max_output_bytes,
+    max_payload_bytes,
+    read_json_capped,
+)
 from unified_api.config import TEAM_CONFIGS
 
 logger = logging.getLogger(__name__)
@@ -143,6 +148,11 @@ async def invoke_agent(
             ),
         )
 
+    # Cap the request body *before* spinning up a sandbox — a 2 GB payload
+    # must not tie up Docker or proxy memory. `read_json_capped` raises 413
+    # on overflow and returns {} on empty/malformed JSON.
+    body = await read_json_capped(request, max_bytes=max_payload_bytes())
+
     try:
         handle = await acquire(agent_id)
     except Exception as exc:  # Docker/daemon/infra problems
@@ -172,10 +182,10 @@ async def invoke_agent(
             },
         )
 
-    try:
-        body = await request.json()
-    except Exception:
-        body = {}
+    # Outer transport timeout on the proxy → sandbox hop. The inner
+    # per-agent execution timeout (enforced via asyncio.wait_for inside the
+    # shim) is strictly shorter, so the shim always gets to surface a 504
+    # envelope before this fires.
     timeout_s = TEAM_CONFIGS.get(manifest.team).timeout_seconds if manifest.team in TEAM_CONFIGS else 120.0
     target = f"{handle.url}/_agents/{agent_id}/invoke"
     try:
@@ -187,6 +197,23 @@ async def invoke_agent(
 
     # Update idle tracker only on a real response (any status — the user still engaged with it).
     await note_activity(agent_id)
+
+    # Cap the upstream response body. A runaway sandbox that returns 10 GB
+    # should not blow up the proxy or the UI — surface a 502 with a preview.
+    raw_len = len(upstream.content)
+    cap = max_output_bytes()
+    if raw_len > cap:
+        logger.warning("upstream response for %s exceeded %d bytes (got %d)", agent_id, cap, raw_len)
+        return JSONResponse(
+            status_code=502,
+            content={
+                "error": f"Upstream response exceeds {cap} bytes",
+                "truncated": True,
+                "original_size": raw_len,
+                "preview": upstream.content[:cap].decode("utf-8", errors="replace"),
+                "sandbox": {"agent_id": agent_id, "url": handle.url},
+            },
+        )
 
     content: Any
     try:

--- a/backend/unified_api/tests/test_agents_route.py
+++ b/backend/unified_api/tests/test_agents_route.py
@@ -139,3 +139,24 @@ def test_schema_input_404_when_missing_ref(client: TestClient) -> None:
 def test_schema_output_404_when_missing_ref(client: TestClient) -> None:
     resp = client.get("/api/agents/blogging.planner/schema/output")
     assert resp.status_code == 404
+
+
+def test_invoke_oversized_body_returns_413_without_acquiring_sandbox(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Regression for issue #256: the payload cap must fire before any sandbox work."""
+    import unified_api.routes.agents as agents_route_mod
+
+    async def _fail_acquire(agent_id: str):  # pragma: no cover — must not run
+        raise AssertionError(f"acquire({agent_id!r}) must not be called on oversized body")
+
+    monkeypatch.setattr(agents_route_mod, "acquire", _fail_acquire)
+    monkeypatch.setenv("AGENT_INVOKE_MAX_PAYLOAD_BYTES", "1024")
+
+    payload = "x" * 4096
+    resp = client.post(
+        "/api/agents/blogging.planner/invoke",
+        content=payload,
+        headers={"Content-Type": "application/json"},
+    )
+    assert resp.status_code == 413


### PR DESCRIPTION
Closes #256.

## Summary

Caps three axes of resource consumption at the invoke boundary — request body, agent execution time, and response body — with env-var defaults and a per-manifest override for the execution timeout. A single 10 GB request or a hung agent can no longer tie up the warm sandbox or blow up proxy memory.

### What changed

- **New `backend/agents/shared_agent_invoke/limits.py`** — shared helpers (`read_json_capped`, `cap_output`, env-var readers). `read_json_capped` streams the body and short-circuits at the cap, so oversized payloads never materialise in memory.
- **Shim (`shim.py`)** — wraps dispatch in `asyncio.wait_for()`; returns **504** with `timeout_hit: true` on overflow. Adds `truncated` / `timeout_hit` fields to `InvokeEnvelope`. Output piped through `cap_output` with `truncated: true` flag when it exceeds the cap.
- **Proxy (`routes/agents.py`)** — caps the body *before* `acquire()` so oversized payloads return **413** without warming a sandbox. Caps the upstream response on re-serialize (**502** with preview + `original_size`).
- **Manifest schema** — `InvokeSpec.timeout_seconds` added as an optional per-agent override; falls back to `AGENT_EXEC_TIMEOUT_S` (60s default).
- **CLAUDE.md** — three new env vars documented: `AGENT_INVOKE_MAX_PAYLOAD_BYTES`, `AGENT_INVOKE_MAX_OUTPUT_BYTES`, `AGENT_EXEC_TIMEOUT_S`.

### Defaults

| Axis | Default | Env override |
|---|---|---|
| Request body | 1 MiB | `AGENT_INVOKE_MAX_PAYLOAD_BYTES` |
| Execution time | 60 s | `AGENT_EXEC_TIMEOUT_S` (or `invoke.timeout_seconds` in the manifest) |
| Response body | 1 MiB | `AGENT_INVOKE_MAX_OUTPUT_BYTES` |

## Test plan

- [x] `pytest agents/shared_agent_invoke/ agents/agent_registry/ unified_api/tests/test_agents_route.py unified_api/tests/test_sandboxes_route.py` — 49 passed locally
- [x] Ruff lint + format check clean on all touched files
- [ ] CI: full backend pytest + ruff
- [ ] Manual: `curl -X POST …/api/agents/blogging.planner/invoke --data-binary @2MB.json` returns 413 in <100 ms, no sandbox warmed
- [ ] Manual: `AGENT_EXEC_TIMEOUT_S=2` + a sleep-10 agent returns 504 with `timeout_hit: true`
- [ ] Smoke: run one real agent via the Agent Console Runner UI and confirm the happy path is unchanged

### New tests

- `test_oversized_body_returns_413` — sentinel agent that would raise if invoked; payload cap fires first
- `test_timeout_returns_504_with_envelope` — sleep-10 agent + 0.1s env timeout
- `test_oversized_output_sets_truncated_flag` — agent returning 2 MiB with a 10 KiB cap
- `test_per_manifest_timeout_overrides_env_default` — 60s env, 0.2s manifest override; asserts manifest wins
- `test_invoke_oversized_body_returns_413_without_acquiring_sandbox` — proxy-layer test that asserts `acquire()` is never called

https://claude.ai/code/session_01MBPtRVQ3QLV7UUVmgXVjyf

---
_Generated by [Claude Code](https://claude.ai/code/session_01MBPtRVQ3QLV7UUVmgXVjyf)_