### PR TITLE
Isolate sandbox secrets and add per-team Postgres roles

### DIFF
--- a/backend/agent_sandbox_runtime/entrypoint.py
+++ b/backend/agent_sandbox_runtime/entrypoint.py
@@ -16,9 +16,11 @@ Invariants:
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import os
 import sys
+from pathlib import Path
 
 import uvicorn
 from fastapi import FastAPI
@@ -38,7 +40,47 @@ EXIT_REGISTRY_LOAD_ERROR = 4
 _INVOKE_PATH_PREFIX = "/_agents/"
 
 
+def _load_sandbox_secrets() -> None:
+    """Read ``KEY=VALUE`` pairs from ``SANDBOX_SECRETS_FILE`` into ``os.environ``.
+
+    The provisioner bind-mounts a 0400 file at ``/run/secrets/sandbox-env``
+    and sets ``SANDBOX_SECRETS_FILE`` pointing at it — so agent-consumed libs
+    (``ollama``, ``shared_postgres``, etc.) keep reading creds from the env
+    while the container's startup env (as seen by ``docker inspect`` /
+    ``docker exec env``) stays free of them.
+
+    After a successful load we unlink the in-sandbox view so agent code can't
+    ``cat /run/secrets/sandbox-env``. The host-side file is cleaned up by the
+    lifecycle when the container is torn down.
+
+    No-op when the env marker is unset or the file is missing; keeps unit
+    tests and non-sandbox invocations working unchanged.
+    """
+    path_str = os.environ.get("SANDBOX_SECRETS_FILE")
+    if not path_str:
+        return
+    path = Path(path_str)
+    if not path.exists():
+        return
+    loaded = 0
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if not key:
+            continue
+        os.environ[key] = value
+        loaded += 1
+    log.info("Loaded %d sandbox secrets", loaded)
+    # Bind-mounted read-only view can't always be unlinked; best-effort.
+    with contextlib.suppress(OSError):
+        path.unlink()
+
+
 def _build_app() -> FastAPI:
+    _load_sandbox_secrets()
     agent_id = os.environ.get("SANDBOX_AGENT_ID")
     if not agent_id:
         log.error("FATAL: SANDBOX_AGENT_ID env var is required")
@@ -90,10 +132,7 @@ def _build_app() -> FastAPI:
                 return JSONResponse(
                     status_code=404,
                     content={
-                        "detail": (
-                            f"Sandbox is bound to {bound_agent_id!r}; "
-                            f"refusing invoke for {requested_id!r}."
-                        ),
+                        "detail": (f"Sandbox is bound to {bound_agent_id!r}; refusing invoke for {requested_id!r}."),
                     },
                 )
         return await call_next(request)

--- a/backend/agent_sandbox_runtime/tests/test_entrypoint.py
+++ b/backend/agent_sandbox_runtime/tests/test_entrypoint.py
@@ -10,6 +10,9 @@ Covers:
 
 from __future__ import annotations
 
+import os
+from pathlib import Path
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -103,3 +106,63 @@ def test_invoke_cross_team_agent_is_rejected(monkeypatch: pytest.MonkeyPatch) ->
 
     resp = client.post("/_agents/branding.creative_director/invoke", json={})
     assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Sandbox secrets loader (issue #257)
+# ---------------------------------------------------------------------------
+
+
+def test_secrets_loader_populates_environ_and_unlinks(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Loader reads KEY=VALUE pairs into ``os.environ`` and unlinks the file."""
+    from agent_sandbox_runtime.entrypoint import _load_sandbox_secrets
+
+    secrets = tmp_path / "sandbox-env"
+    secrets.write_text(
+        "\n".join(
+            [
+                "OLLAMA_API_KEY=ollama-xyz",
+                "POSTGRES_PASSWORD=pg-xyz",
+                "# comment line",
+                "",
+                "POSTGRES_USER=sandbox_blogging",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("SANDBOX_SECRETS_FILE", str(secrets))
+    # Make sure these aren't pre-set in the test process.
+    for key in ("OLLAMA_API_KEY", "POSTGRES_PASSWORD", "POSTGRES_USER"):
+        monkeypatch.delenv(key, raising=False)
+
+    _load_sandbox_secrets()
+
+    assert os.environ["OLLAMA_API_KEY"] == "ollama-xyz"
+    assert os.environ["POSTGRES_PASSWORD"] == "pg-xyz"
+    assert os.environ["POSTGRES_USER"] == "sandbox_blogging"
+    # After loading, the in-sandbox view is unlinked so agent code can't cat it.
+    assert not secrets.exists()
+
+
+def test_secrets_loader_noop_when_env_marker_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No ``SANDBOX_SECRETS_FILE`` set → loader is a silent no-op.
+
+    This keeps unit tests (and non-sandbox invocations) working unchanged.
+    """
+    from agent_sandbox_runtime.entrypoint import _load_sandbox_secrets
+
+    monkeypatch.delenv("SANDBOX_SECRETS_FILE", raising=False)
+    # Must not raise.
+    _load_sandbox_secrets()
+
+
+def test_secrets_loader_noop_when_file_missing(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``SANDBOX_SECRETS_FILE`` pointing at a nonexistent file is a no-op too.
+
+    Guards against races where the file was already unlinked by a prior call.
+    """
+    from agent_sandbox_runtime.entrypoint import _load_sandbox_secrets
+
+    monkeypatch.setenv("SANDBOX_SECRETS_FILE", str(tmp_path / "does-not-exist"))
+    _load_sandbox_secrets()

--- a/backend/agents/agent_provisioning_team/sandbox/lifecycle.py
+++ b/backend/agents/agent_provisioning_team/sandbox/lifecycle.py
@@ -99,6 +99,10 @@ class Lifecycle:
             # Sweep any zombie container from a prior run. `docker rm -f` is
             # idempotent against missing containers; timeouts are surfaced.
             await provisioner_mod.stop_container(container_name)
+            # And any stale secrets file the previous sandbox may have left
+            # behind before the host process died — run_container will write
+            # a fresh one.
+            provisioner_mod.cleanup_secrets_file(container_name)
 
             logger.info("Provisioning sandbox for %s (container %s)", agent_id, container_name)
             st = state_mod.new_state(agent_id=agent_id, team=team, container_name=container_name)
@@ -106,7 +110,7 @@ class Lifecycle:
 
             try:
                 container_id = await provisioner_mod.run_container(
-                    agent_id=agent_id, container_name=container_name
+                    agent_id=agent_id, container_name=container_name, team=team
                 )
                 host_port = await provisioner_mod.inspect_host_port(container_id)
                 st.container_id = container_id
@@ -164,6 +168,10 @@ class Lifecycle:
             logger.info("Tearing down sandbox for %s", agent_id)
             if st.container_id:
                 await provisioner_mod.stop_container(st.container_id)
+            # Secrets file is keyed by container_name; clean it up after the
+            # container is confirmed gone so we don't leave 0400 files on the
+            # host when an agent never runs again.
+            provisioner_mod.cleanup_secrets_file(st.container_name)
             self._state.pop(agent_id, None)
             self._persist()
 

--- a/backend/agents/agent_provisioning_team/sandbox/provisioner.py
+++ b/backend/agents/agent_provisioning_team/sandbox/provisioner.py
@@ -17,26 +17,26 @@ import hashlib
 import logging
 import os
 import re
+from pathlib import Path
 
 from .state import sandbox_image, sandbox_network
 
 logger = logging.getLogger(__name__)
 
-# Host env vars forwarded into the sandbox so the loaded agent can reach
-# Postgres / the LLM service. Intentionally narrow — sandbox secret isolation
-# is #257.
+# Non-sensitive host env vars forwarded into the sandbox via `-e KEY=VALUE`.
+# Secrets (POSTGRES_USER/PASSWORD/DB, *_API_KEY) are NEVER on this path — they
+# flow through a 0400 bind-mounted file the in-sandbox loader reads once at
+# startup. See `_write_sandbox_secrets_file` and issue #257.
 _FORWARDED_ENV = (
     "POSTGRES_HOST",
     "POSTGRES_PORT",
-    "POSTGRES_USER",
-    "POSTGRES_PASSWORD",
-    "POSTGRES_DB",
     "LLM_PROVIDER",
     "LLM_BASE_URL",
     "LLM_MODEL",
-    "OLLAMA_API_KEY",
-    "ANTHROPIC_API_KEY",
 )
+
+# In-sandbox path where the per-sandbox secrets file is bind-mounted read-only.
+_SANDBOX_SECRETS_TARGET = "/run/secrets/sandbox-env"
 
 _CONTAINER_NAME_RE = re.compile(r"[^a-zA-Z0-9_.-]+")
 
@@ -47,6 +47,91 @@ class DockerError(RuntimeError):
 
 def _fail(argv: list[str], rc: int, stderr: str) -> DockerError:
     return DockerError(f"docker failed (exit {rc}): {' '.join(argv)}\n{stderr[:500]}")
+
+
+def _secrets_host_path(container_name: str) -> Path:
+    """Deterministic host path for a sandbox's 0400 secrets file.
+
+    Keyed off ``container_name`` so teardown can clean it up without needing to
+    remember the path separately. Lives under ``AGENT_CACHE`` for parity with
+    the rest of the provisioning state.
+    """
+    cache = os.environ.get("AGENT_CACHE", "/tmp/agents")
+    return Path(cache) / "agent_provisioning" / "sandboxes" / "secrets" / f"{container_name}.env"
+
+
+def _team_postgres_credentials(team: str) -> tuple[str | None, str | None, str | None]:
+    """Resolve team-scoped ``(user, password, db)`` for a sandbox's Postgres creds.
+
+    Reads ``POSTGRES_PASSWORD_SANDBOX_<TEAM>`` and uses the convention
+    ``sandbox_<team>`` for both role and database. If the team-scoped password
+    is unset, falls back to the global ``POSTGRES_USER`` / ``POSTGRES_PASSWORD``
+    / ``POSTGRES_DB`` with a warning so local dev keeps working when per-team
+    roles haven't been provisioned yet.
+    """
+    env_key = f"POSTGRES_PASSWORD_SANDBOX_{team.upper()}"
+    password = os.environ.get(env_key)
+    if password:
+        return (f"sandbox_{team}", password, f"sandbox_{team}")
+    logger.warning(
+        "No %s set; sandbox for team %r will fall back to the global "
+        "POSTGRES_USER/PASSWORD/DB. See docker/README.md § Per-team Postgres "
+        "isolation.",
+        env_key,
+        team,
+    )
+    return (
+        os.environ.get("POSTGRES_USER"),
+        os.environ.get("POSTGRES_PASSWORD"),
+        os.environ.get("POSTGRES_DB"),
+    )
+
+
+def _write_sandbox_secrets_file(container_name: str, team: str) -> Path:
+    """Atomically write a 0400 ``KEY=VALUE`` file with the sandbox's secrets.
+
+    The file is bind-mounted read-only at :data:`_SANDBOX_SECRETS_TARGET` in
+    the sandbox, where the entrypoint loader reads it into ``os.environ`` and
+    unlinks the in-sandbox view. Values absent from the host environment are
+    simply omitted — the loader treats missing keys as no-ops.
+    """
+    pg_user, pg_pass, pg_db = _team_postgres_credentials(team)
+    values: dict[str, str] = {}
+    if pg_user is not None:
+        values["POSTGRES_USER"] = pg_user
+    if pg_pass is not None:
+        values["POSTGRES_PASSWORD"] = pg_pass
+    if pg_db is not None:
+        values["POSTGRES_DB"] = pg_db
+    for key in ("OLLAMA_API_KEY", "ANTHROPIC_API_KEY"):
+        v = os.environ.get(key)
+        if v is not None:
+            values[key] = v
+
+    path = _secrets_host_path(container_name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = "".join(f"{k}={v}\n" for k, v in values.items())
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(body, encoding="utf-8")
+    os.chmod(tmp, 0o400)
+    os.replace(tmp, path)
+    return path
+
+
+def cleanup_secrets_file(container_name: str) -> None:
+    """Remove the host-side sandbox secrets file for ``container_name``.
+
+    Idempotent: missing-file is treated as success. Called from the lifecycle
+    after ``docker rm -f`` succeeds and before provisioning a fresh sandbox
+    so stale creds don't linger if the host process was killed between
+    sandbox teardowns.
+    """
+    try:
+        _secrets_host_path(container_name).unlink()
+    except FileNotFoundError:
+        return
+    except OSError as exc:
+        logger.warning("Could not remove sandbox secrets file for %s: %s", container_name, exc)
 
 
 def container_name_for(agent_id: str) -> str:
@@ -84,11 +169,18 @@ async def _exec(cmd: list[str], *, timeout_s: int = 30) -> tuple[int, str, str]:
     )
 
 
-def _build_run_argv(*, agent_id: str, container_name: str) -> list[str]:
+def _build_run_argv(
+    *,
+    agent_id: str,
+    container_name: str,
+    secrets_host_path: Path | None = None,
+) -> list[str]:
     """Assemble the hardened ``docker run`` argument vector for a sandbox.
 
     Kept as a pure function so tests can assert on the exact flags without
-    invoking subprocess.
+    invoking subprocess. When ``secrets_host_path`` is provided, the file is
+    bind-mounted read-only at :data:`_SANDBOX_SECRETS_TARGET` and the sandbox
+    is told where to find it via ``SANDBOX_SECRETS_FILE``.
     """
     argv: list[str] = [
         "docker",
@@ -127,6 +219,15 @@ def _build_run_argv(*, agent_id: str, container_name: str) -> list[str]:
         value = os.environ.get(key)
         if value is not None:
             argv.extend(["-e", f"{key}={value}"])
+    if secrets_host_path is not None:
+        argv.extend(
+            [
+                "--mount",
+                f"type=bind,source={secrets_host_path},target={_SANDBOX_SECRETS_TARGET},readonly",
+                "-e",
+                f"SANDBOX_SECRETS_FILE={_SANDBOX_SECRETS_TARGET}",
+            ]
+        )
     argv.append(sandbox_image())
     return argv
 
@@ -148,20 +249,35 @@ async def ensure_network() -> None:
         raise _fail(argv, rc2, stderr or stdout)
 
 
-async def run_container(agent_id: str, container_name: str) -> str:
+async def run_container(agent_id: str, container_name: str, team: str) -> str:
     """Start a hardened sandbox for ``agent_id`` and return its container id.
+
+    Writes a per-sandbox 0400 secrets file (team-scoped Postgres creds +
+    any ``*_API_KEY`` values present on the host) and bind-mounts it read-only
+    into the container — secrets are never passed via ``-e`` flags.
 
     Caller is responsible for polling ``/health`` before treating the sandbox
     as ready — this coroutine returns as soon as the Docker daemon accepts
     the container, not when uvicorn is listening.
     """
     await ensure_network()
-    argv = _build_run_argv(agent_id=agent_id, container_name=container_name)
-    rc, stdout, stderr = await _exec(argv, timeout_s=60)
+    secrets_host_path = _write_sandbox_secrets_file(container_name, team)
+    argv = _build_run_argv(
+        agent_id=agent_id,
+        container_name=container_name,
+        secrets_host_path=secrets_host_path,
+    )
+    try:
+        rc, stdout, stderr = await _exec(argv, timeout_s=60)
+    except DockerError:
+        cleanup_secrets_file(container_name)
+        raise
     if rc != 0:
+        cleanup_secrets_file(container_name)
         raise _fail(argv, rc, stderr or stdout)
     container_id = stdout.strip()
     if not container_id:
+        cleanup_secrets_file(container_name)
         raise _fail(argv, rc, "docker run printed no container id")
     return container_id
 

--- a/backend/agents/agent_provisioning_team/tests/test_sandbox_lifecycle.py
+++ b/backend/agents/agent_provisioning_team/tests/test_sandbox_lifecycle.py
@@ -275,6 +275,149 @@ def test_build_run_argv_applies_hardening() -> None:
     assert argv[n_index + 1] == "khala-sandbox"
 
 
+def test_build_run_argv_excludes_secret_env_flags(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #257: secrets must never reach the sandbox via ``-e``.
+
+    With a secrets bind-mount path supplied, ``_build_run_argv`` must carry the
+    mount + the ``SANDBOX_SECRETS_FILE`` pointer, and must NOT emit any ``-e``
+    entry whose value matches a host secret.
+    """
+    monkeypatch.setenv("OLLAMA_API_KEY", "ollama-secret-xyz")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "pg-secret-xyz")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "ant-secret-xyz")
+
+    argv = _build_run_argv(
+        agent_id="blogging.planner",
+        container_name="khala-sbx-blogging.planner",
+        secrets_host_path=Path("/tmp/secrets/blogging.env"),
+    )
+
+    joined = " ".join(argv)
+    for secret in ("ollama-secret-xyz", "pg-secret-xyz", "ant-secret-xyz"):
+        assert secret not in joined, f"{secret!r} leaked into docker run argv"
+    # Bind-mount + pointer env are present.
+    assert any(
+        a.startswith("type=bind,source=/tmp/secrets/blogging.env,target=/run/secrets/sandbox-env")
+        for a in argv
+    )
+    assert "SANDBOX_SECRETS_FILE=/run/secrets/sandbox-env" in argv
+
+
+def test_build_run_argv_without_secrets_skips_mount() -> None:
+    """The bind-mount flags only appear when the caller supplies a path.
+
+    Tests that don't care about secrets (e.g. the hardening assertions above)
+    still get a clean argv.
+    """
+    argv = _build_run_argv(
+        agent_id="blogging.planner",
+        container_name="khala-sbx-blogging.planner",
+    )
+    assert not any("sandbox-env" in a for a in argv)
+    assert not any(a.startswith("SANDBOX_SECRETS_FILE=") for a in argv)
+
+
+def test_write_sandbox_secrets_file_per_team_creds(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Per-team password var wins over the global POSTGRES_* creds."""
+    monkeypatch.setenv("AGENT_CACHE", str(tmp_path))
+    monkeypatch.setenv("POSTGRES_USER", "global_user")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "global_pw")
+    monkeypatch.setenv("POSTGRES_DB", "global_db")
+    monkeypatch.setenv("POSTGRES_PASSWORD_SANDBOX_BLOGGING", "team-pw-xyz")
+    monkeypatch.setenv("OLLAMA_API_KEY", "ollama-xyz")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    path = provisioner_mod._write_sandbox_secrets_file("khala-sbx-blog", "blogging")
+    assert path.exists()
+    # Permissions: 0400 — read-only for the owning process, no group/other.
+    assert (path.stat().st_mode & 0o777) == 0o400
+    body = path.read_text(encoding="utf-8")
+    assert "POSTGRES_USER=sandbox_blogging\n" in body
+    assert "POSTGRES_PASSWORD=team-pw-xyz\n" in body
+    assert "POSTGRES_DB=sandbox_blogging\n" in body
+    assert "OLLAMA_API_KEY=ollama-xyz\n" in body
+    # Values not in the host env must not appear with an empty RHS.
+    assert "ANTHROPIC_API_KEY" not in body
+    # Global creds must NOT leak when the per-team var is set.
+    assert "global_user" not in body
+    assert "global_pw" not in body
+    assert "global_db" not in body
+
+
+def test_write_sandbox_secrets_file_falls_back_to_global(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """No team-scoped password → warn and fall back to global POSTGRES_* creds."""
+    monkeypatch.setenv("AGENT_CACHE", str(tmp_path))
+    monkeypatch.setenv("POSTGRES_USER", "global_user")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "global_pw")
+    monkeypatch.setenv("POSTGRES_DB", "global_db")
+    monkeypatch.delenv("POSTGRES_PASSWORD_SANDBOX_BRANDING", raising=False)
+
+    with caplog.at_level("WARNING", logger="agent_provisioning_team.sandbox.provisioner"):
+        path = provisioner_mod._write_sandbox_secrets_file("khala-sbx-brand", "branding")
+
+    body = path.read_text(encoding="utf-8")
+    assert "POSTGRES_USER=global_user\n" in body
+    assert "POSTGRES_PASSWORD=global_pw\n" in body
+    assert "POSTGRES_DB=global_db\n" in body
+    assert any("POSTGRES_PASSWORD_SANDBOX_BRANDING" in record.message for record in caplog.records)
+
+
+def test_cleanup_secrets_file_removes_host_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``cleanup_secrets_file`` unlinks the host-side tmpfile; missing file is a no-op."""
+    monkeypatch.setenv("AGENT_CACHE", str(tmp_path))
+    monkeypatch.setenv("POSTGRES_PASSWORD_SANDBOX_BLOGGING", "x")
+    path = provisioner_mod._write_sandbox_secrets_file("khala-sbx-blog", "blogging")
+    assert path.exists()
+
+    provisioner_mod.cleanup_secrets_file("khala-sbx-blog")
+    assert not path.exists()
+    # Idempotent: second call on the same name is a no-op.
+    provisioner_mod.cleanup_secrets_file("khala-sbx-blog")
+
+
+@pytest.mark.asyncio
+async def test_run_container_writes_and_mounts_secrets_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The public ``run_container`` path must write a 0400 secrets file and
+    mount it into the sandbox; on docker failure it must clean up."""
+    monkeypatch.setenv("AGENT_CACHE", str(tmp_path))
+    monkeypatch.setenv("POSTGRES_PASSWORD_SANDBOX_BLOGGING", "team-pw")
+
+    captured_argv: list[list[str]] = []
+
+    async def fake_exec(cmd: list[str], *, timeout_s: int = 30):
+        captured_argv.append(cmd)
+        return 0, "abc123\n", ""
+
+    async def fake_network() -> None:
+        return None
+
+    monkeypatch.setattr(provisioner_mod, "_exec", fake_exec)
+    monkeypatch.setattr(provisioner_mod, "ensure_network", fake_network)
+
+    container_id = await provisioner_mod.run_container(
+        agent_id="blogging.planner", container_name="khala-sbx-blog", team="blogging"
+    )
+    assert container_id == "abc123"
+
+    # The argv passed to docker carries the bind-mount spec.
+    argv = captured_argv[-1]
+    mount_specs = [a for a in argv if a.startswith("type=bind,source=")]
+    assert len(mount_specs) == 1
+    secrets_path = Path(mount_specs[0].split("source=", 1)[1].split(",", 1)[0])
+    assert secrets_path.exists()
+    assert (secrets_path.stat().st_mode & 0o777) == 0o400
+
+
 def test_container_name_is_dns_safe() -> None:
     name = container_name_for("blogging.planner")
     assert name.startswith("khala-sbx-blogging.planner-")

--- a/docker/.env.example
+++ b/docker/.env.example
@@ -34,6 +34,21 @@ POSTGRES_PASSWORD=postgres
 POSTGRES_DB=postgres
 
 # ---------------------------------------------------------------------------
+# Per-team sandbox Postgres roles (issue #257)
+# ---------------------------------------------------------------------------
+# Set one password per currently-wired team. On first Postgres boot,
+# docker/postgres/init/04-create-sandbox-team-roles.sh creates a
+# sandbox_<team> role + database for each value that's set. The Agent Console
+# runner writes these into each sandbox's 0400 secrets file so a sandbox for
+# a blogging agent can only reach the blogging database. Leave blank to fall
+# back to the global POSTGRES_* creds for that team (dev convenience).
+# See docker/README.md § Per-team Postgres isolation.
+POSTGRES_PASSWORD_SANDBOX_BLOGGING=
+POSTGRES_PASSWORD_SANDBOX_SOFTWARE_ENGINEERING=
+POSTGRES_PASSWORD_SANDBOX_PLANNING_V3=
+POSTGRES_PASSWORD_SANDBOX_BRANDING=
+
+# ---------------------------------------------------------------------------
 # Temporal (uses temporal/temporal database and user created by init script)
 # ---------------------------------------------------------------------------
 # No extra vars needed; service uses POSTGRES_SEEDS=postgres, POSTGRES_USER=temporal, POSTGRES_PWD=temporal

--- a/docker/README.md
+++ b/docker/README.md
@@ -130,6 +130,42 @@ On **macOS** with Podman Machine, container memory is capped by the machine’s 
 
 When running in this stack, the **khala** service uses the **stack’s Postgres** (database `khala`, user `khala`) via **POSTGRES_HOST=postgres**. The container does not start its own PostgreSQL. The init script in `docker/postgres/init/` creates the `khala` database and user on first run.
 
+### Per-team Postgres isolation (Agent Console sandboxes)
+
+Agent Console sandboxes run one container per agent, hardened with `--cap-drop=ALL`, `--read-only`, and loopback-bound ports. They receive Postgres credentials **scoped to their team's database**, so an agent from the `blogging` team cannot read `branding` or `software_engineering` data even if it tries.
+
+- `docker/postgres/init/04-create-sandbox-team-roles.sh` creates one `sandbox_<team>` role + database per currently-wired team (blogging, software_engineering, planning_v3, branding) on first Postgres boot.
+- Passwords come from `POSTGRES_PASSWORD_SANDBOX_<TEAM>` env vars in `.env`. Leave any of them blank to skip that team — the provisioner falls back to the global `POSTGRES_*` creds in that case (dev convenience).
+- Only runs on **first** Postgres boot (`/docker-entrypoint-initdb.d` is skipped once the data directory is populated). To add teams later, `psql` into the running instance and replay the relevant `CREATE USER`/`CREATE DATABASE`/`GRANT` statements by hand.
+
+Verify isolation with:
+
+```bash
+docker exec khala-stack-postgres psql -U postgres -c '\du' | grep sandbox_
+docker exec khala-stack-postgres psql -U postgres -c '\l'  | grep sandbox_
+
+# A blogging-team role must not be able to connect to another team's DB:
+docker exec -e PGPASSWORD=$POSTGRES_PASSWORD_SANDBOX_BLOGGING \
+  khala-stack-postgres psql -U sandbox_blogging -d sandbox_software_engineering -c '\dt'
+# Expected: permission denied for database "sandbox_software_engineering"
+```
+
+### Sandbox secrets
+
+Sandbox containers **never** receive `OLLAMA_API_KEY`, `ANTHROPIC_API_KEY`, or the per-team `POSTGRES_*` credentials via `docker run -e` flags — so they don't appear in `docker inspect` and aren't visible via `docker exec <sandbox> env`.
+
+The provisioner (`backend/agents/agent_provisioning_team/sandbox/provisioner.py`) writes each sandbox's secrets to a per-container `KEY=VALUE` file under `$AGENT_CACHE/agent_provisioning/sandboxes/secrets/<container>.env` on the host, `chmod 0400`, and bind-mounts it read-only at `/run/secrets/sandbox-env`. The in-sandbox entrypoint reads the file into `os.environ` and unlinks the in-sandbox view; the host file is cleaned up when the sandbox is torn down.
+
+Verify after a run:
+
+```bash
+sandbox=$(docker ps --format '{{.Names}}' | grep khala-sbx- | head -1)
+docker exec "$sandbox" env | grep -E 'OLLAMA|POSTGRES_PASSWORD|ANTHROPIC'
+# Expected: (no output)
+docker inspect "$sandbox" | jq '.[0].Config.Env' | grep -E 'OLLAMA|POSTGRES_PASSWORD|ANTHROPIC'
+# Expected: (no match)
+```
+
 ## Observability (Prometheus + Grafana)
 
 The stack ships with a Prometheus server and Grafana instance pre-wired.

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,6 +14,14 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-postgres}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-postgres}
       POSTGRES_DB: ${POSTGRES_DB:-postgres}
+      # Per-team sandbox roles (issue #257). Consumed by
+      # postgres/init/04-create-sandbox-team-roles.sh on first boot. Unset
+      # values skip that team's role; provisioner falls back to the global
+      # POSTGRES_* creds for sandboxes in that team.
+      POSTGRES_PASSWORD_SANDBOX_BLOGGING: ${POSTGRES_PASSWORD_SANDBOX_BLOGGING:-}
+      POSTGRES_PASSWORD_SANDBOX_SOFTWARE_ENGINEERING: ${POSTGRES_PASSWORD_SANDBOX_SOFTWARE_ENGINEERING:-}
+      POSTGRES_PASSWORD_SANDBOX_PLANNING_V3: ${POSTGRES_PASSWORD_SANDBOX_PLANNING_V3:-}
+      POSTGRES_PASSWORD_SANDBOX_BRANDING: ${POSTGRES_PASSWORD_SANDBOX_BRANDING:-}
     ports:
       - "5432:5432"
     volumes:

--- a/docker/postgres/init/04-create-sandbox-team-roles.sh
+++ b/docker/postgres/init/04-create-sandbox-team-roles.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+set -e
+# Per-team sandbox Postgres roles and databases (issue #257).
+#
+# Creates one (role, database) pair per currently-wired team so that sandboxes
+# for agents in team X receive credentials that can only reach team X's data.
+# Passwords come from POSTGRES_PASSWORD_SANDBOX_<TEAM> env vars plumbed into
+# the postgres service via docker-compose.yml. If a var is unset we skip that
+# team with a warning — the provisioner falls back to the global POSTGRES_*
+# creds in that case, keeping local dev working without per-team setup.
+#
+# Verification (after the stack is up):
+#   docker exec khala-stack-postgres psql -U postgres -c '\du' | grep sandbox_
+#   docker exec khala-stack-postgres psql -U postgres -c '\l'  | grep sandbox_
+#   docker exec -e PGPASSWORD=$POSTGRES_PASSWORD_SANDBOX_BLOGGING \
+#     khala-stack-postgres psql -U sandbox_blogging -d sandbox_software_engineering -c '\dt'
+#   # Expected: permission denied to connect to database "sandbox_software_engineering"
+
+create_team_role() {
+  local team="$1"
+  local password_var="POSTGRES_PASSWORD_SANDBOX_${team^^}"
+  local password="${!password_var:-}"
+  if [ -z "$password" ]; then
+    echo "WARN: $password_var is unset; skipping sandbox_${team} role/database" >&2
+    return 0
+  fi
+  # Escape single quotes for the SQL string literal — passwords with special
+  # characters would otherwise break the CREATE USER statement.
+  local escaped
+  escaped=$(printf '%s' "$password" | sed "s/'/''/g")
+  psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<SQL
+CREATE USER "sandbox_${team}" WITH PASSWORD '${escaped}';
+CREATE DATABASE "sandbox_${team}" OWNER "sandbox_${team}";
+REVOKE ALL ON DATABASE "sandbox_${team}" FROM PUBLIC;
+GRANT CONNECT ON DATABASE "sandbox_${team}" TO "sandbox_${team}";
+SQL
+}
+
+for team in blogging software_engineering planning_v3 branding; do
+  create_team_role "$team"
+done


### PR DESCRIPTION
Closes #257

## Summary

Agent Console sandboxes no longer receive `OLLAMA_API_KEY`, `ANTHROPIC_API_KEY`, or per-team `POSTGRES_*` credentials via `docker run -e` — so they don't appear in `docker inspect` and aren't visible via `docker exec <sandbox> env`. Secrets flow through a per-sandbox 0400 bind-mounted file that the in-sandbox entrypoint reads into `os.environ` once and then unlinks. Postgres first-boot init now creates one `sandbox_<team>` role + database per currently-wired team with `CONNECT` granted only on that team's own DB, so an agent in team A can't reach team B's data even at the credential layer.

Sandbox **containers remain per-agent** (one container per `agent_id`); the per-team scoping applies only to the Postgres credentials each sandbox's secrets file carries, since agents within a team legitimately share their team's data store.

## What changed

- **`backend/agents/agent_provisioning_team/sandbox/provisioner.py`**
  - Split `_FORWARDED_ENV` into non-sensitive forwards (`POSTGRES_HOST`, `POSTGRES_PORT`, `LLM_PROVIDER`, `LLM_BASE_URL`, `LLM_MODEL`) vs. secrets — the latter are never on the `-e` path.
  - New `_write_sandbox_secrets_file(container_name, team)` atomically writes a 0400 `KEY=VALUE` file under `$AGENT_CACHE/agent_provisioning/sandboxes/secrets/`.
  - New `_team_postgres_credentials(team)` resolves `sandbox_<team>` user/db with the `POSTGRES_PASSWORD_SANDBOX_<TEAM>` password; falls back to global `POSTGRES_*` with a warning for dev convenience.
  - `_build_run_argv` gains an optional `secrets_host_path` — when set, adds the `--mount …target=/run/secrets/sandbox-env,readonly` and `SANDBOX_SECRETS_FILE` pointer.
  - `run_container(agent_id, container_name, team)` writes the secrets file, bind-mounts it, and cleans up on docker failure.
  - New `cleanup_secrets_file(container_name)` — idempotent unlink.
- **`backend/agents/agent_provisioning_team/sandbox/lifecycle.py`**
  - Passes `team` through to `run_container`, sweeps stale secrets files before re-provisioning, and cleans them up on teardown.
- **`backend/agent_sandbox_runtime/entrypoint.py`**
  - New `_load_sandbox_secrets()` reads `SANDBOX_SECRETS_FILE` into `os.environ` before the FastAPI app starts, then unlinks the in-sandbox view. No-op when unset / file missing, so non-sandbox invocations (unit tests) keep working.
- **`docker/postgres/init/04-create-sandbox-team-roles.sh`** — new. Creates `sandbox_<team>` role + DB for blogging, software_engineering, planning_v3, branding on first Postgres boot. `REVOKE ALL … FROM PUBLIC`, `GRANT CONNECT` only to the team's own role. Skips teams whose `POSTGRES_PASSWORD_SANDBOX_<TEAM>` is unset with a warning.
- **`docker/docker-compose.yml`** — plumbs the four new `POSTGRES_PASSWORD_SANDBOX_*` env vars into the `postgres` service so the init script can read them.
- **`docker/.env.example`** — documents the four new vars and their semantics.
- **`docker/README.md`** — two new sections: *Per-team Postgres isolation* and *Sandbox secrets*, each with copy-pasteable verification commands.

## Test plan

- [x] `pytest backend/agents/agent_provisioning_team/tests/test_sandbox_lifecycle.py backend/agent_sandbox_runtime/tests/` — 40 passed (9 new tests covering: argv excludes secret `-e` flags, bind-mount spec is correct, secrets file is 0400 with the right keys, per-team creds win over globals, global fallback warns, cleanup is idempotent, `run_container` end-to-end, loader populates env + unlinks, loader is no-op when unset/missing).
- [x] `pytest backend/agents/agent_provisioning_team/tests/ --ignore=…/test_integration_matrix.py` — 72 passed. (`test_integration_matrix.py::test_compensation_deprovisions_successful_tools` fails both before and after this PR — pre-existing, unrelated.)
- [x] `ruff check` + `ruff format --check` on all touched files — clean.
- [ ] End-to-end (requires docker daemon): bring the stack up, invoke an Agent Console runner, and verify `docker exec <sandbox> env | grep -E 'OLLAMA|POSTGRES_PASSWORD|ANTHROPIC'` returns nothing and `docker inspect` shows no secret env entries. Commands are in `docker/README.md § Sandbox secrets`.
- [ ] End-to-end per-team Postgres: `docker exec -e PGPASSWORD=$POSTGRES_PASSWORD_SANDBOX_BLOGGING khala-stack-postgres psql -U sandbox_blogging -d sandbox_software_engineering -c '\dt'` should fail with "permission denied".

## Deliberately out of scope (follow-ups)

- Per-team Ollama credential scoping (forward-proxy / short-lived tokens) — issue's Phase 3.
- Migrating the team microservices (blogging-service, se-service, etc.) in `docker-compose.yml` off env-var secrets onto the same mechanism — user opted for "sandbox runtime only" in this PR.

https://claude.ai/code/session_01MpUBXEd5SUzPWx2PPVDAPF

---
_Generated by [Claude Code](https://claude.ai/code/session_01MpUBXEd5SUzPWx2PPVDAPF)_