### PR TITLE
agent_provisioning: plumb provisioner_key through compensation (closes #293)

### DIFF
--- a/backend/agents/agent_provisioning_team/api/main.py
+++ b/backend/agents/agent_provisioning_team/api/main.py
@@ -125,6 +125,10 @@ def _submit_provisioning_job(job_id: str, *args: Any, **kwargs: Any) -> None:
 
 def _safe_compensate(agent_id: str) -> None:
     try:
+        # Passes [] so the orchestrator only runs the tail (docker teardown,
+        # credential delete, env cleanup). Per-tool rollback on SIGTERM isn't
+        # wired up from here — per-job tool_results aren't plumbed through
+        # job_store today. Tracked alongside #258/#293; out of scope for #293.
         orchestrator._compensate(agent_id, [])  # noqa: SLF001
     except Exception:
         logger.exception("Compensate raised for agent=%s", agent_id)

--- a/backend/agents/agent_provisioning_team/models.py
+++ b/backend/agents/agent_provisioning_team/models.py
@@ -83,6 +83,11 @@ class ToolProvisionResult(BaseModel):
     permissions: List[str] = Field(default_factory=list)
     error: Optional[str] = None
     details: Dict[str, Any] = Field(default_factory=dict)
+    # Registry key of the provisioner that produced this result (e.g.
+    # "postgres_provisioner"). Used by ProvisioningOrchestrator._compensate()
+    # to look the provisioner back up for rollback. Optional/None for
+    # backward compatibility with results serialized before #293.
+    provisioner_key: Optional[str] = None
 
 
 class AccessVerification(BaseModel):

--- a/backend/agents/agent_provisioning_team/orchestrator.py
+++ b/backend/agents/agent_provisioning_team/orchestrator.py
@@ -314,15 +314,33 @@ class ProvisioningOrchestrator:
         Docker environment, and removes encrypted credentials so a failed
         run doesn't leak resources or secrets to disk.
         """
-        succeeded = [r.tool_name for r in tool_results if getattr(r, "success", False)]
-        for tool_name in succeeded:
-            provisioner = self.tool_agents.get(f"{tool_name}_provisioner")
+        # Look each successfully-provisioned tool back up by its registry key
+        # (stamped onto the result in run_account_provisioning). Prior to #293
+        # this used f"{r.tool_name}_provisioner", which silently missed for
+        # provisioners whose class `tool_name` differs from the registry stem
+        # (e.g. PostgresProvisionerTool.tool_name == "postgresql" vs key
+        # "postgres_provisioner"), leaking accounts + encrypted credentials.
+        for r in tool_results:
+            if not getattr(r, "success", False):
+                continue
+            key = getattr(r, "provisioner_key", None)
+            if not key:
+                logger.warning(
+                    "Compensation: tool_result for %s has no provisioner_key; "
+                    "skipping rollback (stale result pre-#293).",
+                    getattr(r, "tool_name", "?"),
+                )
+                continue
+            provisioner = self.tool_agents.get(key)
             if provisioner is None:
+                logger.warning(
+                    "Compensation: no provisioner registered for key=%s", key
+                )
                 continue
             try:
                 provisioner.deprovision(agent_id)
             except Exception:  # noqa: BLE001 — best-effort cleanup
-                logger.exception("Compensation: deprovision failed for %s", tool_name)
+                logger.exception("Compensation: deprovision failed for %s", key)
 
         docker = self.tool_agents.get("docker_provisioner")
         if docker is not None:

--- a/backend/agents/agent_provisioning_team/phases/account_provisioning.py
+++ b/backend/agents/agent_provisioning_team/phases/account_provisioning.py
@@ -71,6 +71,7 @@ def run_account_provisioning(
                     tool_name=tool_name,
                     success=False,
                     error=f"Unknown provisioner: {provisioner_name}",
+                    provisioner_key=provisioner_name,
                 )
             )
             continue
@@ -82,6 +83,7 @@ def run_account_provisioning(
                     tool_name=tool_name,
                     success=False,
                     error=f"No credentials generated for {tool_name}",
+                    provisioner_key=provisioner_name,
                 )
             )
             continue
@@ -97,6 +99,10 @@ def run_account_provisioning(
                 access_tier=tool_tier,
             )
 
+            # Stamp the registry key so _compensate() can look the provisioner
+            # back up by key rather than by the fragile class attribute
+            # `tool_name` (see #293).
+            result.provisioner_key = provisioner_name
             tool_results.append(result)
 
             if result.success:
@@ -109,6 +115,7 @@ def run_account_provisioning(
                     tool_name=tool_name,
                     success=False,
                     error=str(e),
+                    provisioner_key=provisioner_name,
                 )
             )
 

--- a/backend/agents/agent_provisioning_team/shared/tool_agent_registry.py
+++ b/backend/agents/agent_provisioning_team/shared/tool_agent_registry.py
@@ -21,7 +21,13 @@ from ..tool_agents.redis_provisioner import RedisProvisionerTool
 def build_default_tool_agents() -> Dict[str, ToolProvisionerInterface]:
     """Build the default set of tool provisioner agents.
 
-    Keys MUST match the `provisioner` field used by tool manifests.
+    Keys MUST match the `provisioner` field used by tool manifests. They are
+    also the canonical identifier stamped onto
+    ``ToolProvisionResult.provisioner_key`` by ``run_account_provisioning``
+    and consumed by ``ProvisioningOrchestrator._compensate()`` to look a
+    provisioner back up for rollback. Do not rename a key here without
+    updating any manifests, persisted results, and call sites that store or
+    match on it (see #293).
     """
     return {
         "docker_provisioner": DockerProvisionerTool(),

--- a/backend/agents/agent_provisioning_team/temporal/activities.py
+++ b/backend/agents/agent_provisioning_team/temporal/activities.py
@@ -14,7 +14,7 @@ Two activity surfaces are exposed:
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from temporalio import activity
 
@@ -153,17 +153,26 @@ def provision_tool_activity(
 @activity.defn(name="agent_provisioning_compensate")
 def compensate_activity_v2(
     agent_id: str,
-    succeeded_tools: List[str],
+    succeeded_tools: List[Dict[str, Any]],
 ) -> None:
-    """Roll back a partially-provisioned agent (best effort)."""
+    """Roll back a partially-provisioned agent (best effort).
+
+    ``succeeded_tools`` entries are dicts with ``tool_name`` and
+    ``provisioner_key`` (registry key, e.g. ``"postgres_provisioner"``).
+    Post-#293 the orchestrator looks provisioners back up by the registry
+    key, not by a class attribute derived from ``tool_name``.
+    """
     from agent_provisioning_team.orchestrator import ProvisioningOrchestrator
 
     orch = ProvisioningOrchestrator()
-    # Reuse the orchestrator's compensation path by synthesizing minimal
-    # tool_results with success=True for the ones that completed.
+
     class _R:  # noqa: D401 — local shim
-        def __init__(self, name: str) -> None:
-            self.tool_name = name
+        def __init__(self, tool_name: str, provisioner_key: Optional[str]) -> None:
+            self.tool_name = tool_name
+            self.provisioner_key = provisioner_key
             self.success = True
 
-    orch._compensate(agent_id, [_R(t) for t in succeeded_tools])
+    orch._compensate(
+        agent_id,
+        [_R(t.get("tool_name", ""), t.get("provisioner_key")) for t in succeeded_tools],
+    )

--- a/backend/agents/agent_provisioning_team/temporal/workflows.py
+++ b/backend/agents/agent_provisioning_team/temporal/workflows.py
@@ -119,13 +119,20 @@ class AgentProvisioningWorkflowV2:
             return_exceptions=True,
         )
 
-        succeeded: list[str] = []
+        # Carry the registry key through with each success so compensation
+        # can look the provisioner back up (see #293).
+        succeeded: list[dict] = []
         failures: list[str] = []
         for name, res in zip(tool_names, results):
             if isinstance(res, BaseException):
                 failures.append(f"{name}: {res}")
             elif isinstance(res, dict) and res.get("success"):
-                succeeded.append(name)
+                succeeded.append(
+                    {
+                        "tool_name": res.get("tool_name", name),
+                        "provisioner_key": res.get("provisioner_key"),
+                    }
+                )
             else:
                 failures.append(f"{name}: {res.get('error') if isinstance(res, dict) else 'unknown'}")
 

--- a/backend/agents/agent_provisioning_team/tests/test_integration_matrix.py
+++ b/backend/agents/agent_provisioning_team/tests/test_integration_matrix.py
@@ -322,14 +322,6 @@ tools:
 
 
 class TestOrchestratorCompensation:
-    @pytest.mark.xfail(
-        strict=True,
-        reason=(
-            "orchestrator._compensate lookup uses `{tool_name}_provisioner` but tool_name "
-            "is the class attribute (e.g. 'postgresql') which does not match the registry "
-            "stem ('postgres_provisioner'). Tracked in issue #293."
-        ),
-    )
     def test_compensation_deprovisions_successful_tools(self, tmp_path, monkeypatch):
         # Fake tool agents: toola succeeds, toolb fails.
         pg = _FakeProvisioner("toola")
@@ -374,6 +366,87 @@ class TestOrchestratorCompensation:
         assert "agent-1" in pg.deprovisioned
         # Docker teardown too.
         assert "agent-1" in docker.deprovisioned
+
+    def test_compensation_when_tool_name_differs_from_registry_key(self, tmp_path, monkeypatch):
+        """Regression test for #293.
+
+        The production `PostgresProvisionerTool` has
+        ``tool_name = "postgresql"`` while its registry key is
+        ``"postgres_provisioner"``. Before #293 the orchestrator looked up
+        the provisioner as ``f"{tool_name}_provisioner"`` which silently
+        missed for this exact case, leaking the DB account + encrypted
+        credential file. This test simulates that mismatch with a fake
+        provisioner whose ``tool_name`` does NOT match its registry key and
+        asserts compensation still rolls it back.
+        """
+        # tool_name intentionally mismatched with registry stem.
+        pg_like = _FakeProvisioner("postgresql")
+        redis_ = _FakeProvisioner("redis", fail=True)
+        docker = _FakeProvisioner("docker")
+
+        fake_agents: Dict[str, Any] = {
+            "postgres_provisioner": pg_like,
+            "redis_provisioner": redis_,
+            "docker_provisioner": docker,
+            "git_provisioner": _FakeProvisioner("git"),
+            "generic_provisioner": _FakeProvisioner("generic"),
+        }
+
+        from agent_provisioning_team import orchestrator as orch_mod
+
+        def _fake_run_setup(**kwargs):
+            return SetupResult(
+                success=True,
+                environment=EnvironmentInfo(
+                    container_id="c1",
+                    container_name="c1",
+                    workspace_path="/tmp/ws",
+                    status="running",
+                ),
+            )
+
+        monkeypatch.setattr(orch_mod, "run_setup", _fake_run_setup)
+
+        manifest = _write_manifest(tmp_path)
+        orch = ProvisioningOrchestrator(tool_agents=fake_agents)
+        result = orch.run_workflow(
+            agent_id="agent-2",
+            manifest_path=manifest,
+            access_tier=AccessTier.STANDARD,
+        )
+
+        assert result.success is False
+        assert result.current_phase == Phase.ACCOUNT_PROVISIONING
+        # The postgres-like provisioner (registered under
+        # "postgres_provisioner" but exposing tool_name="postgresql") must
+        # still be deprovisioned — lookup must use the registry key.
+        assert "agent-2" in pg_like.deprovisioned, (
+            "Compensation dropped a provisioner whose tool_name differs from "
+            "its registry key — the #293 regression."
+        )
+        assert "agent-2" in docker.deprovisioned
+
+    def test_every_default_provisioner_has_registry_key_roundtrip(self):
+        """Cheap invariant: every default provisioner's registry key round-trips.
+
+        Catches future drift where someone adds a provisioner whose registry
+        key isn't exactly what downstream code stamps onto
+        ``ToolProvisionResult.provisioner_key``.
+        """
+        from agent_provisioning_team.shared.tool_agent_registry import (
+            build_default_tool_agents,
+        )
+
+        registry = build_default_tool_agents()
+        for key, prov in registry.items():
+            result = ToolProvisionResult(
+                tool_name=prov.tool_name,
+                success=True,
+                provisioner_key=key,
+            )
+            assert result.provisioner_key in registry, (
+                f"Registry key {key!r} not round-trippable via ToolProvisionResult.provisioner_key"
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes a silent credential/resource leak in `ProvisioningOrchestrator._compensate()`. The lookup used `f"{r.tool_name}_provisioner"`, but `tool_name` is the provisioner **class attribute** (e.g. `PostgresProvisionerTool.tool_name == "postgresql"`) — which does not match the registry key (`"postgres_provisioner"`). For Postgres specifically, compensation silently skipped deprovision, leaving the database, role, and encrypted credential file live on disk when an account-provisioning phase partially succeeded and then failed. This also re-exposed the same bug on the SIGTERM shutdown path wired up in #258.

## Approach (Option A from the issue)

Plumb the registry key through as `provisioner_key` on `ToolProvisionResult`, stamp it at the site where the result is produced, and have `_compensate()` use it directly. Keep a warn-and-skip fallback for stale serialized results; do not re-introduce the old class-attribute-derived lookup.

## Changes

- **`models.py`** — `ToolProvisionResult` gains optional `provisioner_key: Optional[str] = None` (back-compat with all existing serialized payloads).
- **`phases/account_provisioning.py`** — stamp `provisioner_key = provisioner_name` on every `ToolProvisionResult` the phase produces (the registry key is already in scope).
- **`orchestrator.py`** — `_compensate()` rewritten to look up provisioners via `provisioner_key`. Stale results (no key) warn-and-skip rather than silently guessing; missing-registry-key also warn-skipped. Tail (docker teardown, credential delete, env cleanup) unchanged.
- **`temporal/activities.py`** + **`temporal/workflows.py`** — `compensate_activity_v2` now takes `List[Dict]` so both `tool_name` and `provisioner_key` travel with each succeeded tool; `AgentProvisioningWorkflowV2` builds those dicts from the per-tool activity return dumps.
- **`tests/test_integration_matrix.py`**:
  - Removed `@pytest.mark.xfail(strict=True, ...#293)` from `test_compensation_deprovisions_successful_tools`.
  - Added `test_compensation_when_tool_name_differs_from_registry_key` — regression test that simulates the postgresql/postgres_provisioner mismatch.
  - Added `test_every_default_provisioner_has_registry_key_roundtrip` — cheap invariant that every default provisioner's registry key round-trips via `ToolProvisionResult.provisioner_key`.
- **`api/main.py`** — commented the pre-existing `_safe_compensate([])` limitation on the SIGTERM lifespan path (per-tool rollback there is not wired up; tracked as a separate #258/#293 follow-up).
- **`shared/tool_agent_registry.py`** — docstring note that registry keys are also the canonical identifier stamped onto `ToolProvisionResult.provisioner_key`.

## Test plan

- [x] `ruff check backend/agents/agent_provisioning_team` — clean.
- [x] `pytest backend/agents/agent_provisioning_team/tests` — 100/100 passing, including:
  - the previously-xfail `test_compensation_deprovisions_successful_tools`,
  - the new `test_compensation_when_tool_name_differs_from_registry_key`,
  - the new `test_every_default_provisioner_has_registry_key_roundtrip`.
- [ ] Operator sanity: drain any in-flight Temporal workflows before deploy — activity outputs queued pre-upgrade will deserialize with `provisioner_key=None` and fall through the warn-skip branch (safe, but rolling will log warnings once).

## Risks / callouts

- `ToolProvisionResult` is serialized via `model_dump()` into job rows and Temporal activity returns; the new field is `Optional[str]` with default `None`, so legacy payloads deserialize unchanged.
- Downstream consumers that match on `tool_name` (`phases/deliver.redact_credentials_for_response`, `phases/documentation`, `phases/access_audit`) are unaffected — we only added a field.
- The `api/main.py:_safe_compensate` SIGTERM path still passes `[]` and therefore doesn't perform per-tool rollback. That was the state before this PR and is explicitly out of scope for #293; a comment now flags it for the next person.

Closes #293

---
_Generated by [Claude Code](https://claude.ai/code/session_017PvZDk1sQQVNGros1ve2Z6)_