### PR TITLE
agent_provisioning: unify tool-provisioner scaffolding; close subprocess/path-traversal gaps

### DIFF
--- a/backend/agents/agent_provisioning_team/shared/tool_manifest.py
+++ b/backend/agents/agent_provisioning_team/shared/tool_manifest.py
@@ -12,8 +12,17 @@ Validation is layered:
 3. Manifest-level ``environment`` dict is checked against a
    secrets/metachar allowlist — manifests must not smuggle credentials
    through env vars.
+4. Filesystem paths in provisioner configs (``workspace_path``, ``init_repos``)
+   are checked for ``..`` traversal at manifest-parse time; the runtime
+   containment check against each provisioner's ``workspace_base`` lives in
+   :func:`assert_path_within_base`.
+
+The allowlist constants (``_ENV_*``) below are the single source of truth for
+any new provisioners that need to validate manifest-supplied env vars or
+shell-like strings.
 """
 
+import os
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Type
 
@@ -21,6 +30,60 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 DEFAULT_MANIFESTS_DIR = Path(__file__).parent.parent / "manifests"
+
+
+# ---------------------------------------------------------------------------
+# Filesystem path containment
+# ---------------------------------------------------------------------------
+
+
+def _reject_traversal_components(value: str, *, field: str) -> str:
+    """Reject path strings whose components include ``..``.
+
+    This runs at manifest-parse time — before any provisioner is instantiated
+    — and doesn't know the workspace base. Its job is to bar the trivial
+    escapes (``../../etc/passwd``). The runtime containment check against
+    the actual workspace base is :func:`assert_path_within_base`.
+    """
+    parts = Path(value).parts
+    if ".." in parts:
+        raise ValueError(f"{field} must not contain '..' traversal components: {value!r}")
+    return value
+
+
+def _reject_path_separators(value: str, *, field: str) -> str:
+    """Reject strings that are meant to be single flat segments (e.g. repo names)."""
+    if not value:
+        raise ValueError(f"{field} entry must be a non-empty string")
+    if ".." in Path(value).parts or value == "..":
+        raise ValueError(f"{field} entry must not traverse: {value!r}")
+    for bad in ("/", "\\", os.sep):
+        if bad in value:
+            raise ValueError(
+                f"{field} entry must be a flat name without path separators: {value!r}"
+            )
+    return value
+
+
+def assert_path_within_base(path: str, base: str) -> Path:
+    """Resolve ``path`` and assert it lives under ``base``; return the resolved Path.
+
+    Used by :class:`GitProvisionerTool._do_provision` as defence-in-depth after
+    manifest validation. The workspace base is only known at provisioner-
+    construction time, so this check cannot be expressed as a Pydantic
+    validator.
+
+    Raises:
+        ValueError: when the resolved ``path`` is not equal to, or a descendant
+        of, the resolved ``base``.
+    """
+    resolved = Path(path).resolve()
+    base_resolved = Path(base).resolve()
+    try:
+        resolved.relative_to(base_resolved)
+    except ValueError as e:
+        raise ValueError(f"path {path!r} escapes provisioner workspace base {base!r}") from e
+    return resolved
 
 
 # ---------------------------------------------------------------------------
@@ -47,6 +110,13 @@ class DockerProvisionerConfig(_ToolBaseConfig):
     init_command: Optional[str] = None
     environment: Dict[str, str] = Field(default_factory=dict)
 
+    @field_validator("workspace_path")
+    @classmethod
+    def _workspace_path(cls, v: Optional[str]) -> Optional[str]:
+        if v is None or v == "":
+            return v
+        return _reject_traversal_components(v, field="workspace_path")
+
 
 class PostgresProvisionerConfig(_ToolBaseConfig):
     database_prefix: str = "agent_"
@@ -67,6 +137,7 @@ class GitProvisionerConfig(_ToolBaseConfig):
     default_branch: str = "main"
     visibility: str = "private"
     generate_ssh_key: bool = False
+    workspace_path: Optional[str] = None
     init_repos: List[str] = Field(default_factory=list)
 
     @field_validator("visibility")
@@ -75,6 +146,18 @@ class GitProvisionerConfig(_ToolBaseConfig):
         if v not in {"private", "internal", "public"}:
             raise ValueError("visibility must be one of: private, internal, public")
         return v
+
+    @field_validator("workspace_path")
+    @classmethod
+    def _workspace_path(cls, v: Optional[str]) -> Optional[str]:
+        if v is None or v == "":
+            return v
+        return _reject_traversal_components(v, field="workspace_path")
+
+    @field_validator("init_repos")
+    @classmethod
+    def _init_repos(cls, v: List[str]) -> List[str]:
+        return [_reject_path_separators(r, field="init_repos") for r in v]
 
 
 class GenericProvisionerConfig(_ToolBaseConfig):
@@ -113,8 +196,16 @@ def validate_provisioner_config(provisioner: str, raw: Dict[str, Any]) -> Dict[s
 # ---------------------------------------------------------------------------
 
 _ENV_KEY_SECRET_SUBSTRINGS = (
-    "password", "passwd", "secret", "token", "api_key", "apikey",
-    "private_key", "privatekey", "credential", "auth",
+    "password",
+    "passwd",
+    "secret",
+    "token",
+    "api_key",
+    "apikey",
+    "private_key",
+    "privatekey",
+    "credential",
+    "auth",
 )
 _ENV_KEY_MAX_LEN = 128
 _ENV_VALUE_MAX_LEN = 4096
@@ -137,9 +228,7 @@ def validate_manifest_environment(env: Dict[str, str]) -> Dict[str, str]:
         if len(key) > _ENV_KEY_MAX_LEN:
             raise ValueError(f"Env key too long: {key[:32]}…")
         if not all(c.isupper() or c.isdigit() or c == "_" for c in key):
-            raise ValueError(
-                f"Env key '{key}' must be UPPER_SNAKE_CASE (A-Z, 0-9, _)"
-            )
+            raise ValueError(f"Env key '{key}' must be UPPER_SNAKE_CASE (A-Z, 0-9, _)")
         low = key.lower()
         if any(s in low for s in _ENV_KEY_SECRET_SUBSTRINGS):
             raise ValueError(
@@ -154,9 +243,7 @@ def validate_manifest_environment(env: Dict[str, str]) -> Dict[str, str]:
         if len(s) > _ENV_VALUE_MAX_LEN:
             raise ValueError(f"Env value for '{key}' exceeds {_ENV_VALUE_MAX_LEN} chars")
         if any(c in _ENV_METACHARS for c in s):
-            raise ValueError(
-                f"Env value for '{key}' contains disallowed shell metacharacters"
-            )
+            raise ValueError(f"Env value for '{key}' contains disallowed shell metacharacters")
         normalized[key] = s
     return normalized
 

--- a/backend/agents/agent_provisioning_team/tests/test_integration_matrix.py
+++ b/backend/agents/agent_provisioning_team/tests/test_integration_matrix.py
@@ -136,6 +136,30 @@ class TestManifestValidation:
         )
         assert m.get_tool("postgresql").config["database_prefix"] == "x_"
 
+    def test_workspace_path_traversal_rejected(self):
+        with pytest.raises(ValueError, match="traversal"):
+            validate_provisioner_config("git_provisioner", {"workspace_path": "../../etc"})
+        with pytest.raises(ValueError, match="traversal"):
+            validate_provisioner_config(
+                "docker_provisioner", {"workspace_path": "/workspace/../etc"}
+            )
+
+    def test_init_repo_name_traversal_rejected(self):
+        with pytest.raises(ValueError, match="traverse|path separators"):
+            validate_provisioner_config("git_provisioner", {"init_repos": ["../escape"]})
+        with pytest.raises(ValueError, match="path separators"):
+            validate_provisioner_config("git_provisioner", {"init_repos": ["nested/segment"]})
+
+    def test_workspace_path_accepts_clean_absolute(self):
+        # Regression guard: manifest-level rejection must not touch legitimate
+        # absolute workspace paths (used throughout the existing integration
+        # matrix and production manifests).
+        out = validate_provisioner_config(
+            "git_provisioner", {"workspace_path": "/tmp/ws", "init_repos": ["workspace"]}
+        )
+        assert out["workspace_path"] == "/tmp/ws"
+        assert out["init_repos"] == ["workspace"]
+
 
 # ---------------------------------------------------------------------------
 # ProvisionerStateStore
@@ -170,6 +194,90 @@ class TestProvisionerStateStore:
         assert s.delete("agent-1") is True
         assert s.delete("agent-1") is False
         assert s.get("agent-1") is None
+
+
+# ---------------------------------------------------------------------------
+# Unified provisioner scaffolding (BaseToolProvisioner.run_idempotent)
+# ---------------------------------------------------------------------------
+
+
+class TestProvisionerScaffolding:
+    """Covers the shared helper that owns idempotency + exception handling."""
+
+    def test_git_subprocess_timeout_is_surfaced_as_error_result(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Regression for the original bug: no timeout on `ssh-keygen` / `git init`
+        would hang the provisioning worker. With timeouts wired through
+        ``run_idempotent``, a ``subprocess.TimeoutExpired`` must become an
+        error ``ToolProvisionResult`` — not a raised exception.
+        """
+        import subprocess as _subprocess
+
+        from agent_provisioning_team.tool_agents.git_provisioner import GitProvisionerTool
+
+        tool = GitProvisionerTool(workspace_base=str(tmp_path))
+        # Point state store at tmp_path so the test is hermetic.
+        tool._state = ProvisionerStateStore("git_provisioner", storage_dir=tmp_path)
+
+        def _always_timeout(*args, **kwargs):  # noqa: ARG001
+            raise _subprocess.TimeoutExpired(cmd=args[0] if args else "git", timeout=30)
+
+        monkeypatch.setattr(_subprocess, "run", _always_timeout)
+
+        creds = GeneratedCredentials(tool_name="git")
+        result = tool.provision(
+            agent_id="agent-timeout",
+            config={"workspace_path": str(tmp_path / "ws"), "generate_ssh_key": True},
+            credentials=creds,
+            access_tier=AccessTier.STANDARD,
+        )
+        assert result.success is False
+        assert result.error is not None
+        assert "timed out" in result.error.lower()
+
+    def test_provisioner_idempotency_persists_across_instances(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """A fresh GenericProvisionerTool pointed at the same state dir must
+        see the prior agent's record and return ``reused: True`` — proves the
+        in-memory ``_provisioned`` dict was replaced with ``ProvisionerStateStore``.
+        """
+        from agent_provisioning_team.tool_agents.generic_provisioner import (
+            GenericProvisionerTool,
+        )
+
+        store_dir = tmp_path / "state"
+
+        tool_a = GenericProvisionerTool(tool_name="myservice")
+        tool_a._state = ProvisionerStateStore(
+            "generic_myservice_provisioner", storage_dir=store_dir
+        )
+        first = tool_a.provision(
+            agent_id="agent-1",
+            config={"permissions": ["read"]},
+            credentials=GeneratedCredentials(tool_name="myservice"),
+            access_tier=AccessTier.STANDARD,
+        )
+        assert first.success is True
+        assert first.details.get("reused") is not True
+
+        # Fresh instance — no in-memory handle — pointed at the same dir.
+        tool_b = GenericProvisionerTool(tool_name="myservice")
+        tool_b._state = ProvisionerStateStore(
+            "generic_myservice_provisioner", storage_dir=store_dir
+        )
+        second = tool_b.provision(
+            agent_id="agent-1",
+            config={"permissions": ["read"]},
+            credentials=GeneratedCredentials(tool_name="myservice"),
+            access_tier=AccessTier.STANDARD,
+        )
+        assert second.success is True
+        assert second.details.get("reused") is True
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/agent_provisioning_team/tool_agents/base.py
+++ b/backend/agents/agent_provisioning_team/tool_agents/base.py
@@ -4,8 +4,9 @@ Base interface for tool provisioner agents.
 All tool provisioners implement this protocol to ensure consistent behavior.
 """
 
+import subprocess
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Protocol, runtime_checkable
+from typing import Any, Callable, Dict, List, Optional, Protocol, Tuple, runtime_checkable
 
 from ..models import (
     AccessTier,
@@ -14,6 +15,7 @@ from ..models import (
     GeneratedCredentials,
     ToolProvisionResult,
 )
+from ..shared.provisioner_state import ProvisionerStateStore
 
 
 @runtime_checkable
@@ -132,6 +134,78 @@ class BaseToolProvisioner(ABC):
             success=False,
             error=error,
         )
+
+    def run_idempotent(
+        self,
+        agent_id: str,
+        *,
+        credentials: GeneratedCredentials,
+        create: Callable[[], Tuple[List[str], Dict[str, Any]]],
+        reuse: Optional[Callable[[Dict[str, Any]], List[str]]] = None,
+    ) -> ToolProvisionResult:
+        """Run ``create`` once per (provisioner, agent_id); reuse stored state on subsequent calls.
+
+        State lookup, short-circuit on prior success, uniform exception → error-result
+        translation, and persistence of the success payload all live here. Each
+        provisioner's ``create`` function does only the tool-specific work.
+
+        Contract:
+
+        * ``create()`` returns ``(permissions, details)``. ``details`` is both
+          returned in ``ToolProvisionResult.details`` and persisted as the
+          idempotency state payload. It may mutate ``credentials`` in place.
+        * ``reuse(stored_details)`` returns ``permissions`` for the cached
+          record. It may mutate ``credentials`` in place (e.g. to re-hydrate
+          ``credentials.extra`` from the stored payload). Defaults to reading
+          ``stored_details.get("permissions", [])``.
+        * Exceptions from infrastructure boundaries (missing binaries, subprocess
+          timeouts, permission errors) are caught and converted to error results.
+          Domain validation failures should ``return self._make_error_result(...)``
+          from inside ``create``.
+        """
+        state = self._state_store()
+        try:
+            existing = state.get(agent_id)
+            if existing is not None:
+                if reuse is not None:
+                    permissions = reuse(existing)
+                else:
+                    permissions = list(existing.get("permissions", []))
+                return self._make_success_result(
+                    credentials=credentials,
+                    permissions=permissions,
+                    details={**existing, "reused": True},
+                )
+
+            permissions, details = create()
+            state.put(agent_id, details)
+            return self._make_success_result(
+                credentials=credentials,
+                permissions=permissions,
+                details=details,
+            )
+        except FileNotFoundError as e:
+            return self._make_error_result(f"{self.tool_name}: required binary not found: {e}")
+        except subprocess.TimeoutExpired:
+            return self._make_error_result(f"{self.tool_name}: provisioning subprocess timed out")
+        except PermissionError as e:
+            return self._make_error_result(f"{self.tool_name}: permission denied: {e}")
+        except Exception as e:  # noqa: BLE001 — last-resort guard with explicit prior cases
+            return self._make_error_result(f"{self.tool_name} provisioning error: {e}")
+
+    def _state_store(self) -> ProvisionerStateStore:
+        """Return this provisioner's ``ProvisionerStateStore``, creating one on demand.
+
+        Subclasses may assign ``self._state`` eagerly in ``__init__`` to override
+        the storage directory or namespacing. When they don't, a default store
+        keyed on ``tool_name`` is lazily initialized here so ``run_idempotent``
+        always has somewhere to read/write.
+        """
+        store = getattr(self, "_state", None)
+        if store is None:
+            store = ProvisionerStateStore(f"{self.tool_name}_provisioner")
+            self._state = store
+        return store
 
     def _make_verification(
         self,

--- a/backend/agents/agent_provisioning_team/tool_agents/base.py
+++ b/backend/agents/agent_provisioning_team/tool_agents/base.py
@@ -15,7 +15,6 @@ from ..models import (
     GeneratedCredentials,
     ToolProvisionResult,
 )
-from ..shared.provisioner_state import ProvisionerStateStore
 
 
 @runtime_checkable
@@ -141,6 +140,7 @@ class BaseToolProvisioner(ABC):
         *,
         credentials: GeneratedCredentials,
         create: Callable[[], Tuple[List[str], Dict[str, Any]]],
+        hydrate_extras: Tuple[str, ...] = (),
         reuse: Optional[Callable[[Dict[str, Any]], List[str]]] = None,
     ) -> ToolProvisionResult:
         """Run ``create`` once per (provisioner, agent_id); reuse stored state on subsequent calls.
@@ -154,19 +154,30 @@ class BaseToolProvisioner(ABC):
         * ``create()`` returns ``(permissions, details)``. ``details`` is both
           returned in ``ToolProvisionResult.details`` and persisted as the
           idempotency state payload. It may mutate ``credentials`` in place.
-        * ``reuse(stored_details)`` returns ``permissions`` for the cached
-          record. It may mutate ``credentials`` in place (e.g. to re-hydrate
-          ``credentials.extra`` from the stored payload). Defaults to reading
-          ``stored_details.get("permissions", [])``.
+        * On the reuse path:
+          - ``hydrate_extras`` lists ``details`` keys whose stored values are
+            copied into ``credentials.extra`` via ``setdefault`` — the common
+            case ("restore what create populated"), so most provisioners don't
+            need a ``reuse`` callback.
+          - ``reuse(stored_details)`` is a full-control override: returns
+            ``permissions`` and may mutate ``credentials`` arbitrarily. Used
+            when the reuse path needs to consult live env (e.g. Postgres host
+            from env, not the stored value) or recompute permissions from the
+            current access tier.
+          - When neither is enough to derive permissions, the default is
+            ``stored_details.get("permissions", [])``.
         * Exceptions from infrastructure boundaries (missing binaries, subprocess
           timeouts, permission errors) are caught and converted to error results.
           Domain validation failures should ``return self._make_error_result(...)``
           from inside ``create``.
         """
-        state = self._state_store()
+        state = self._state
         try:
             existing = state.get(agent_id)
             if existing is not None:
+                for key in hydrate_extras:
+                    if key in existing:
+                        credentials.extra.setdefault(key, existing[key])
                 if reuse is not None:
                     permissions = reuse(existing)
                 else:
@@ -192,20 +203,6 @@ class BaseToolProvisioner(ABC):
             return self._make_error_result(f"{self.tool_name}: permission denied: {e}")
         except Exception as e:  # noqa: BLE001 — last-resort guard with explicit prior cases
             return self._make_error_result(f"{self.tool_name} provisioning error: {e}")
-
-    def _state_store(self) -> ProvisionerStateStore:
-        """Return this provisioner's ``ProvisionerStateStore``, creating one on demand.
-
-        Subclasses may assign ``self._state`` eagerly in ``__init__`` to override
-        the storage directory or namespacing. When they don't, a default store
-        keyed on ``tool_name`` is lazily initialized here so ``run_idempotent``
-        always has somewhere to read/write.
-        """
-        store = getattr(self, "_state", None)
-        if store is None:
-            store = ProvisionerStateStore(f"{self.tool_name}_provisioner")
-            self._state = store
-        return store
 
     def _make_verification(
         self,

--- a/backend/agents/agent_provisioning_team/tool_agents/docker_provisioner.py
+++ b/backend/agents/agent_provisioning_team/tool_agents/docker_provisioner.py
@@ -43,104 +43,89 @@ class DockerProvisionerTool(BaseToolProvisioner):
         access_tier: AccessTier,
     ) -> ToolProvisionResult:
         """Create and start a Docker container for the agent (idempotent)."""
-        # Idempotency: if we already have a running container for this
-        # agent, return the existing info instead of trying to create a
-        # second one (which would fail with "container name already in use").
-        existing = self._state.get(agent_id)
-        if existing:
-            permissions = get_permissions("docker", access_tier)
-            credentials.extra["container_id"] = existing.get("container_id", "")
-            credentials.extra["container_name"] = existing.get("container_name", "")
-            credentials.extra["workspace_path"] = existing.get("workspace_path", "")
-            return self._make_success_result(
-                credentials=credentials,
-                permissions=permissions,
-                details={**existing, "reused": True},
-            )
-        try:
-            container_name = f"agent-{agent_id}"
-            base_image = config.get("base_image", "python:3.11-slim")
-            workspace_path = config.get("workspace_path", f"{self.workspace_base}/{agent_id}")
-            ssh_port = config.get("ssh_port", self._allocate_port(agent_id))
+        return self.run_idempotent(
+            agent_id,
+            credentials=credentials,
+            create=lambda: self._do_provision(agent_id, config, credentials, access_tier),
+            reuse=lambda existing: self._on_reuse(existing, credentials, access_tier),
+        )
 
-            build_cmd = [
-                "docker",
-                "run",
-                "-d",
-                "--name",
-                container_name,
-                "--hostname",
-                container_name,
-                "-v",
-                f"{workspace_path}:/workspace",
-                "-w",
-                "/workspace",
-                "--restart",
-                "unless-stopped",
-            ]
+    def _do_provision(
+        self,
+        agent_id: str,
+        config: Dict[str, Any],
+        credentials: GeneratedCredentials,
+        access_tier: AccessTier,
+    ) -> Tuple[List[str], Dict[str, Any]]:
+        container_name = f"agent-{agent_id}"
+        base_image = config.get("base_image", "python:3.11-slim")
+        workspace_path = config.get("workspace_path", f"{self.workspace_base}/{agent_id}")
+        ssh_port = config.get("ssh_port", self._allocate_port(agent_id))
 
-            env_vars = config.get("environment", {})
-            for key, value in env_vars.items():
-                build_cmd.extend(["-e", f"{key}={value}"])
+        build_cmd = [
+            "docker",
+            "run",
+            "-d",
+            "--name",
+            container_name,
+            "--hostname",
+            container_name,
+            "-v",
+            f"{workspace_path}:/workspace",
+            "-w",
+            "/workspace",
+            "--restart",
+            "unless-stopped",
+        ]
 
-            if config.get("expose_ssh", False):
-                build_cmd.extend(["-p", f"{ssh_port}:22"])
+        env_vars = config.get("environment", {})
+        for key, value in env_vars.items():
+            build_cmd.extend(["-e", f"{key}={value}"])
 
-            build_cmd.append(base_image)
+        if config.get("expose_ssh", False):
+            build_cmd.extend(["-p", f"{ssh_port}:22"])
 
-            init_cmd = config.get("init_command", "tail -f /dev/null")
-            build_cmd.extend(["sh", "-c", init_cmd])
+        build_cmd.append(base_image)
 
-            result = subprocess.run(
-                build_cmd,
-                capture_output=True,
-                text=True,
-                timeout=120,
-            )
+        init_cmd = config.get("init_command", "tail -f /dev/null")
+        build_cmd.extend(["sh", "-c", init_cmd])
 
-            if result.returncode != 0:
-                return self._make_error_result(f"Docker run failed: {result.stderr}")
+        result = subprocess.run(
+            build_cmd,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
 
-            container_id = result.stdout.strip()[:12]
+        if result.returncode != 0:
+            raise RuntimeError(f"Docker run failed: {result.stderr}")
 
-            self._state.put(
-                agent_id,
-                {
-                    "container_id": container_id,
-                    "container_name": container_name,
-                    "ssh_port": ssh_port,
-                    "workspace_path": workspace_path,
-                    "status": "running",
-                },
-            )
+        container_id = result.stdout.strip()[:12]
+        permissions = get_permissions("docker", access_tier)
 
-            permissions = get_permissions("docker", access_tier)
+        credentials.extra["container_id"] = container_id
+        credentials.extra["container_name"] = container_name
+        credentials.extra["workspace_path"] = workspace_path
 
-            credentials.extra["container_id"] = container_id
-            credentials.extra["container_name"] = container_name
-            credentials.extra["workspace_path"] = workspace_path
+        details = {
+            "container_id": container_id,
+            "container_name": container_name,
+            "ssh_port": ssh_port,
+            "workspace_path": workspace_path,
+            "status": "running",
+        }
+        return permissions, details
 
-            return self._make_success_result(
-                credentials=credentials,
-                permissions=permissions,
-                details={
-                    "container_id": container_id,
-                    "container_name": container_name,
-                    "ssh_port": ssh_port,
-                    "workspace_path": workspace_path,
-                },
-            )
-
-        except FileNotFoundError:
-            return self._make_error_result(
-                "Docker CLI not found on PATH — install Docker or run inside a host with docker.sock mounted"
-            )
-        except subprocess.TimeoutExpired:
-            return self._make_error_result("Docker container creation timed out")
-        except PermissionError as e:
-            return self._make_error_result(f"Docker permission denied: {e}")
-        except Exception as e:  # noqa: BLE001 — last-resort guard with explicit prior cases
-            return self._make_error_result(f"Docker provisioning error: {str(e)}")
+    def _on_reuse(
+        self,
+        existing: Dict[str, Any],
+        credentials: GeneratedCredentials,
+        access_tier: AccessTier,
+    ) -> List[str]:
+        credentials.extra["container_id"] = existing.get("container_id", "")
+        credentials.extra["container_name"] = existing.get("container_name", "")
+        credentials.extra["workspace_path"] = existing.get("workspace_path", "")
+        return get_permissions("docker", access_tier)
 
     def verify_access(
         self,

--- a/backend/agents/agent_provisioning_team/tool_agents/docker_provisioner.py
+++ b/backend/agents/agent_provisioning_team/tool_agents/docker_provisioner.py
@@ -29,12 +29,6 @@ class DockerProvisionerTool(BaseToolProvisioner):
         # Persistent state: survives restarts, makes provision() idempotent.
         self._state = ProvisionerStateStore("docker_provisioner")
 
-    @property
-    def _containers(self) -> Dict[str, Dict[str, Any]]:
-        # Backwards-compat view over the persistent store for tests/callers
-        # that still read `_containers` directly.
-        return self._state.list_agents()
-
     def provision(
         self,
         agent_id: str,

--- a/backend/agents/agent_provisioning_team/tool_agents/generic_provisioner.py
+++ b/backend/agents/agent_provisioning_team/tool_agents/generic_provisioner.py
@@ -4,7 +4,7 @@ Generic provisioner tool agent template.
 Base implementation that can be extended for custom tools.
 """
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from ..models import (
     AccessTier,
@@ -13,6 +13,7 @@ from ..models import (
     GeneratedCredentials,
     ToolProvisionResult,
 )
+from ..shared.provisioner_state import ProvisionerStateStore
 from .base import BaseToolProvisioner
 
 
@@ -33,7 +34,9 @@ class GenericProvisionerTool(BaseToolProvisioner):
 
     def __init__(self, tool_name: str = "generic") -> None:
         self.tool_name = tool_name
-        self._provisioned: Dict[str, Dict[str, Any]] = {}
+        # Per-tool-name namespacing so two GenericProvisionerTool instances with
+        # different ``tool_name`` don't collide in the shared state dir.
+        self._state = ProvisionerStateStore(f"generic_{tool_name}_provisioner")
 
     def provision(
         self,
@@ -44,33 +47,44 @@ class GenericProvisionerTool(BaseToolProvisioner):
     ) -> ToolProvisionResult:
         """Provision access for the agent (generic implementation).
 
-        This stores the provisioning info but doesn't perform actual
-        external operations. Override this method for real integrations.
+        Stores the provisioning info but doesn't perform actual external
+        operations. Override this method for real integrations.
         """
-        try:
-            permissions = config.get("permissions", [access_tier.value])
+        return self.run_idempotent(
+            agent_id,
+            credentials=credentials,
+            create=lambda: self._do_provision(config, credentials, access_tier),
+            reuse=lambda existing: self._on_reuse(existing, credentials),
+        )
 
-            credentials.extra["tool_name"] = self.tool_name
-            credentials.extra["config"] = config
+    def _do_provision(
+        self,
+        config: Dict[str, Any],
+        credentials: GeneratedCredentials,
+        access_tier: AccessTier,
+    ) -> Tuple[List[str], Dict[str, Any]]:
+        permissions = config.get("permissions", [access_tier.value])
 
-            self._provisioned[agent_id] = {
-                "config": config,
-                "access_tier": access_tier.value,
-                "permissions": permissions,
-            }
+        credentials.extra["tool_name"] = self.tool_name
+        credentials.extra["config"] = config
 
-            return self._make_success_result(
-                credentials=credentials,
-                permissions=permissions,
-                details={
-                    "tool_name": self.tool_name,
-                    "access_tier": access_tier.value,
-                    "config_applied": True,
-                },
-            )
+        details = {
+            "tool_name": self.tool_name,
+            "access_tier": access_tier.value,
+            "config": config,
+            "config_applied": True,
+            "permissions": permissions,
+        }
+        return permissions, details
 
-        except Exception as e:
-            return self._make_error_result(f"Generic provisioning error: {str(e)}")
+    def _on_reuse(
+        self,
+        existing: Dict[str, Any],
+        credentials: GeneratedCredentials,
+    ) -> List[str]:
+        credentials.extra.setdefault("tool_name", existing.get("tool_name", self.tool_name))
+        credentials.extra.setdefault("config", existing.get("config", {}))
+        return list(existing.get("permissions", []))
 
     def verify_access(
         self,
@@ -78,7 +92,7 @@ class GenericProvisionerTool(BaseToolProvisioner):
         expected_tier: AccessTier,
     ) -> AccessVerification:
         """Verify access for the agent (generic implementation)."""
-        prov_info = self._provisioned.get(agent_id)
+        prov_info = self._state.get(agent_id)
 
         if not prov_info:
             return self._make_verification(
@@ -108,7 +122,7 @@ class GenericProvisionerTool(BaseToolProvisioner):
 
     def deprovision(self, agent_id: str) -> DeprovisionResult:
         """Remove agent access (generic implementation)."""
-        prov_info = self._provisioned.get(agent_id)
+        prov_info = self._state.get(agent_id)
 
         if not prov_info:
             return DeprovisionResult(
@@ -118,7 +132,7 @@ class GenericProvisionerTool(BaseToolProvisioner):
             )
 
         try:
-            del self._provisioned[agent_id]
+            self._state.delete(agent_id)
 
             return DeprovisionResult(
                 tool_name=self.tool_name,

--- a/backend/agents/agent_provisioning_team/tool_agents/generic_provisioner.py
+++ b/backend/agents/agent_provisioning_team/tool_agents/generic_provisioner.py
@@ -54,7 +54,7 @@ class GenericProvisionerTool(BaseToolProvisioner):
             agent_id,
             credentials=credentials,
             create=lambda: self._do_provision(config, credentials, access_tier),
-            reuse=lambda existing: self._on_reuse(existing, credentials),
+            hydrate_extras=("tool_name", "config"),
         )
 
     def _do_provision(
@@ -76,15 +76,6 @@ class GenericProvisionerTool(BaseToolProvisioner):
             "permissions": permissions,
         }
         return permissions, details
-
-    def _on_reuse(
-        self,
-        existing: Dict[str, Any],
-        credentials: GeneratedCredentials,
-    ) -> List[str]:
-        credentials.extra.setdefault("tool_name", existing.get("tool_name", self.tool_name))
-        credentials.extra.setdefault("config", existing.get("config", {}))
-        return list(existing.get("permissions", []))
 
     def verify_access(
         self,

--- a/backend/agents/agent_provisioning_team/tool_agents/git_provisioner.py
+++ b/backend/agents/agent_provisioning_team/tool_agents/git_provisioner.py
@@ -17,7 +17,14 @@ from ..models import (
     ToolProvisionResult,
 )
 from ..shared.access_policy import get_permissions
+from ..shared.provisioner_state import ProvisionerStateStore
+from ..shared.tool_manifest import assert_path_within_base
 from .base import BaseToolProvisioner
+
+# Every git subprocess gets bounded wall-clock; unbounded calls could hang the
+# provisioning worker if the git remote or filesystem stalled. Matches the
+# timeout style already used in docker_provisioner.py.
+_GIT_SUBPROCESS_TIMEOUT_S = 30
 
 
 class GitProvisionerTool(BaseToolProvisioner):
@@ -27,7 +34,7 @@ class GitProvisionerTool(BaseToolProvisioner):
 
     def __init__(self, workspace_base: str = "/workspace") -> None:
         self.workspace_base = workspace_base
-        self._provisioned: Dict[str, Dict[str, Any]] = {}
+        self._state = ProvisionerStateStore("git_provisioner")
 
     def provision(
         self,
@@ -37,27 +44,41 @@ class GitProvisionerTool(BaseToolProvisioner):
         access_tier: AccessTier,
     ) -> ToolProvisionResult:
         """Set up Git for the agent with optional SSH keys and repos."""
-        try:
-            workspace_path = config.get("workspace_path", f"{self.workspace_base}/{agent_id}")
-            init_repos = config.get("init_repos", ["workspace"])
-            generate_ssh_key = config.get("generate_ssh_key", True)
+        return self.run_idempotent(
+            agent_id,
+            credentials=credentials,
+            create=lambda: self._do_provision(agent_id, config, credentials, access_tier),
+            reuse=lambda existing: self._on_reuse(existing, credentials),
+        )
 
-            workspace = Path(workspace_path)
-            workspace.mkdir(parents=True, exist_ok=True)
+    def _do_provision(
+        self,
+        agent_id: str,
+        config: Dict[str, Any],
+        credentials: GeneratedCredentials,
+        access_tier: AccessTier,
+    ) -> Tuple[List[str], Dict[str, Any]]:
+        workspace_path = config.get("workspace_path", f"{self.workspace_base}/{agent_id}")
+        init_repos = config.get("init_repos", ["workspace"])
+        generate_ssh_key = config.get("generate_ssh_key", True)
 
-            ssh_dir = workspace / ".ssh"
-            ssh_dir.mkdir(mode=0o700, exist_ok=True)
+        # Defence-in-depth: manifest validation already rejects `..` paths, but
+        # the workspace_base (set at provisioner construction time) is only
+        # known here, so the containment check runs at provisioning time too.
+        workspace = assert_path_within_base(workspace_path, self.workspace_base)
+        workspace.mkdir(parents=True, exist_ok=True)
 
-            if generate_ssh_key:
-                private_key, public_key = self._generate_ssh_keypair(
-                    agent_id,
-                    ssh_dir,
-                )
-                credentials.ssh_private_key = private_key
-                credentials.ssh_public_key = public_key
+        ssh_dir = workspace / ".ssh"
+        ssh_dir.mkdir(mode=0o700, exist_ok=True)
 
-            git_config_path = workspace / ".gitconfig"
-            git_config_content = f"""[user]
+        if generate_ssh_key:
+            private_key, public_key = self._generate_ssh_keypair(agent_id, ssh_dir)
+            credentials.ssh_private_key = private_key
+            credentials.ssh_public_key = public_key
+
+        git_config_path = workspace / ".gitconfig"
+        git_config_path.write_text(
+            f"""[user]
     name = Agent {agent_id}
     email = agent-{agent_id}@provisioning.local
 [init]
@@ -66,39 +87,42 @@ class GitProvisionerTool(BaseToolProvisioner):
     autocrlf = input
     editor = vim
 """
-            git_config_path.write_text(git_config_content)
+        )
 
-            initialized_repos: List[str] = []
-            for repo_name in init_repos:
-                repo_path = workspace / repo_name
-                if self._init_repo(repo_path):
-                    initialized_repos.append(str(repo_path))
+        initialized_repos: List[str] = []
+        for repo_name in init_repos:
+            # Manifest validation also guards init_repos, but re-assert the
+            # flat-segment invariant here in case a caller bypasses manifest
+            # parsing.
+            assert_path_within_base(str(workspace / repo_name), str(workspace))
+            repo_path = workspace / repo_name
+            if self._init_repo(repo_path):
+                initialized_repos.append(str(repo_path))
 
-            permissions = get_permissions("git", access_tier)
+        permissions = get_permissions("git", access_tier)
 
-            credentials.extra["workspace_path"] = str(workspace)
-            credentials.extra["git_config"] = str(git_config_path)
-            credentials.extra["repos"] = initialized_repos
+        credentials.extra["workspace_path"] = str(workspace)
+        credentials.extra["git_config"] = str(git_config_path)
+        credentials.extra["repos"] = initialized_repos
 
-            self._provisioned[agent_id] = {
-                "workspace_path": str(workspace),
-                "repos": initialized_repos,
-                "ssh_key_path": str(ssh_dir / "id_ed25519") if generate_ssh_key else None,
-                "permissions": permissions,
-            }
+        details = {
+            "workspace_path": str(workspace),
+            "repos": initialized_repos,
+            "repos_initialized": initialized_repos,
+            "ssh_key_path": str(ssh_dir / "id_ed25519") if generate_ssh_key else None,
+            "ssh_key_generated": generate_ssh_key,
+            "permissions": permissions,
+        }
+        return permissions, details
 
-            return self._make_success_result(
-                credentials=credentials,
-                permissions=permissions,
-                details={
-                    "workspace_path": str(workspace),
-                    "repos_initialized": initialized_repos,
-                    "ssh_key_generated": generate_ssh_key,
-                },
-            )
-
-        except Exception as e:
-            return self._make_error_result(f"Git provisioning error: {str(e)}")
+    def _on_reuse(
+        self,
+        existing: Dict[str, Any],
+        credentials: GeneratedCredentials,
+    ) -> List[str]:
+        credentials.extra.setdefault("workspace_path", existing.get("workspace_path", ""))
+        credentials.extra.setdefault("repos", existing.get("repos", []))
+        return list(existing.get("permissions", []))
 
     def _generate_ssh_keypair(
         self,
@@ -128,6 +152,7 @@ class GitProvisionerTool(BaseToolProvisioner):
             ],
             check=True,
             capture_output=True,
+            timeout=_GIT_SUBPROCESS_TIMEOUT_S,
         )
 
         private_key_path.chmod(0o600)
@@ -152,6 +177,7 @@ class GitProvisionerTool(BaseToolProvisioner):
                 cwd=str(repo_path),
                 check=True,
                 capture_output=True,
+                timeout=_GIT_SUBPROCESS_TIMEOUT_S,
             )
 
             readme = repo_path / "README.md"
@@ -176,12 +202,14 @@ class GitProvisionerTool(BaseToolProvisioner):
                 cwd=str(repo_path),
                 check=True,
                 capture_output=True,
+                timeout=_GIT_SUBPROCESS_TIMEOUT_S,
             )
             subprocess.run(
                 ["git", "commit", "-m", "Initial commit"],
                 cwd=str(repo_path),
                 check=True,
                 capture_output=True,
+                timeout=_GIT_SUBPROCESS_TIMEOUT_S,
                 env={
                     **os.environ,
                     "GIT_AUTHOR_NAME": "Provisioner",
@@ -202,7 +230,7 @@ class GitProvisionerTool(BaseToolProvisioner):
         expected_tier: AccessTier,
     ) -> AccessVerification:
         """Verify Git access for the agent."""
-        prov_info = self._provisioned.get(agent_id)
+        prov_info = self._state.get(agent_id)
 
         if not prov_info:
             return self._make_verification(
@@ -237,7 +265,7 @@ class GitProvisionerTool(BaseToolProvisioner):
 
     def deprovision(self, agent_id: str) -> DeprovisionResult:
         """Clean up Git provisioning (removes SSH keys, keeps repos)."""
-        prov_info = self._provisioned.get(agent_id)
+        prov_info = self._state.get(agent_id)
 
         if not prov_info:
             return DeprovisionResult(
@@ -257,7 +285,7 @@ class GitProvisionerTool(BaseToolProvisioner):
                 if public_key.exists():
                     public_key.unlink()
 
-            del self._provisioned[agent_id]
+            self._state.delete(agent_id)
 
             return DeprovisionResult(
                 tool_name=self.tool_name,

--- a/backend/agents/agent_provisioning_team/tool_agents/git_provisioner.py
+++ b/backend/agents/agent_provisioning_team/tool_agents/git_provisioner.py
@@ -48,7 +48,7 @@ class GitProvisionerTool(BaseToolProvisioner):
             agent_id,
             credentials=credentials,
             create=lambda: self._do_provision(agent_id, config, credentials, access_tier),
-            reuse=lambda existing: self._on_reuse(existing, credentials),
+            hydrate_extras=("workspace_path", "repos"),
         )
 
     def _do_provision(
@@ -65,6 +65,8 @@ class GitProvisionerTool(BaseToolProvisioner):
         # Defence-in-depth: manifest validation already rejects `..` paths, but
         # the workspace_base (set at provisioner construction time) is only
         # known here, so the containment check runs at provisioning time too.
+        # ``init_repos`` entries are separator-free per manifest validation, so
+        # they don't need a second pass.
         workspace = assert_path_within_base(workspace_path, self.workspace_base)
         workspace.mkdir(parents=True, exist_ok=True)
 
@@ -91,10 +93,6 @@ class GitProvisionerTool(BaseToolProvisioner):
 
         initialized_repos: List[str] = []
         for repo_name in init_repos:
-            # Manifest validation also guards init_repos, but re-assert the
-            # flat-segment invariant here in case a caller bypasses manifest
-            # parsing.
-            assert_path_within_base(str(workspace / repo_name), str(workspace))
             repo_path = workspace / repo_name
             if self._init_repo(repo_path):
                 initialized_repos.append(str(repo_path))
@@ -114,15 +112,6 @@ class GitProvisionerTool(BaseToolProvisioner):
             "permissions": permissions,
         }
         return permissions, details
-
-    def _on_reuse(
-        self,
-        existing: Dict[str, Any],
-        credentials: GeneratedCredentials,
-    ) -> List[str]:
-        credentials.extra.setdefault("workspace_path", existing.get("workspace_path", ""))
-        credentials.extra.setdefault("repos", existing.get("repos", []))
-        return list(existing.get("permissions", []))
 
     def _generate_ssh_keypair(
         self,

--- a/backend/agents/agent_provisioning_team/tool_agents/postgres_provisioner.py
+++ b/backend/agents/agent_provisioning_team/tool_agents/postgres_provisioner.py
@@ -5,7 +5,7 @@ Creates databases and users with scoped permissions.
 """
 
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from ..models import (
     AccessTier,
@@ -74,96 +74,85 @@ class PostgresProvisionerTool(BaseToolProvisioner):
         if not HAS_PSYCOPG2:
             return self._make_error_result("psycopg2 is not installed")
 
-        # Idempotency: short-circuit if we already provisioned this agent.
-        existing = self._state.get(agent_id)
-        if existing:
-            permissions = existing.get("permissions", get_permissions("postgresql", access_tier))
-            credentials.extra.setdefault("database", existing["database"])
-            credentials.extra.setdefault("host", self.host)
-            credentials.extra.setdefault("port", self.port)
-            return self._make_success_result(
-                credentials=credentials,
-                permissions=permissions,
-                details={
-                    "database": existing["database"],
-                    "username": existing["username"],
-                    "host": self.host,
-                    "port": self.port,
-                    "reused": True,
-                },
+        return self.run_idempotent(
+            agent_id,
+            credentials=credentials,
+            create=lambda: self._do_provision(agent_id, config, credentials, access_tier),
+            reuse=lambda existing: self._on_reuse(existing, credentials, access_tier),
+        )
+
+    def _do_provision(
+        self,
+        agent_id: str,
+        config: Dict[str, Any],
+        credentials: GeneratedCredentials,
+        access_tier: AccessTier,
+    ) -> Tuple[List[str], Dict[str, Any]]:
+        db_prefix = config.get("database_prefix", "agent_")
+        db_name = f"{db_prefix}{agent_id}".replace("-", "_")[:63]
+        username = credentials.username or f"agent_{agent_id}".replace("-", "_")[:63]
+        password = credentials.password
+
+        if not password:
+            raise ValueError("No password provided in credentials")
+
+        conn = self._get_admin_connection()
+        conn.autocommit = True
+        cursor = conn.cursor()
+
+        try:
+            cursor.execute(
+                sql.SQL("CREATE USER {} WITH PASSWORD %s").format(sql.Identifier(username)),
+                [password],
+            )
+        except psycopg2.errors.DuplicateObject:
+            cursor.execute(
+                sql.SQL("ALTER USER {} WITH PASSWORD %s").format(sql.Identifier(username)),
+                [password],
             )
 
         try:
-            db_prefix = config.get("database_prefix", "agent_")
-            db_name = f"{db_prefix}{agent_id}".replace("-", "_")[:63]
-            username = credentials.username or f"agent_{agent_id}".replace("-", "_")[:63]
-            password = credentials.password
-
-            if not password:
-                return self._make_error_result("No password provided in credentials")
-
-            conn = self._get_admin_connection()
-            conn.autocommit = True
-            cursor = conn.cursor()
-
-            try:
-                cursor.execute(
-                    sql.SQL("CREATE USER {} WITH PASSWORD %s").format(sql.Identifier(username)),
-                    [password],
+            cursor.execute(
+                sql.SQL("CREATE DATABASE {} OWNER {}").format(
+                    sql.Identifier(db_name),
+                    sql.Identifier(username),
                 )
-            except psycopg2.errors.DuplicateObject:
-                cursor.execute(
-                    sql.SQL("ALTER USER {} WITH PASSWORD %s").format(sql.Identifier(username)),
-                    [password],
-                )
-
-            try:
-                cursor.execute(
-                    sql.SQL("CREATE DATABASE {} OWNER {}").format(
-                        sql.Identifier(db_name),
-                        sql.Identifier(username),
-                    )
-                )
-            except psycopg2.errors.DuplicateDatabase:
-                pass
-
-            permissions = get_permissions("postgresql", access_tier)
-            self._apply_permissions(cursor, db_name, username, permissions)
-
-            cursor.close()
-            conn.close()
-
-            connection_string = (
-                f"postgresql://{username}:{password}@{self.host}:{self.port}/{db_name}"
             )
+        except psycopg2.errors.DuplicateDatabase:
+            pass
 
-            credentials.connection_string = connection_string
-            credentials.extra["database"] = db_name
-            credentials.extra["host"] = self.host
-            credentials.extra["port"] = self.port
+        permissions = get_permissions("postgresql", access_tier)
+        self._apply_permissions(cursor, db_name, username, permissions)
 
-            self._state.put(
-                agent_id,
-                {
-                    "database": db_name,
-                    "username": username,
-                    "permissions": permissions,
-                },
-            )
+        cursor.close()
+        conn.close()
 
-            return self._make_success_result(
-                credentials=credentials,
-                permissions=permissions,
-                details={
-                    "database": db_name,
-                    "username": username,
-                    "host": self.host,
-                    "port": self.port,
-                },
-            )
+        connection_string = f"postgresql://{username}:{password}@{self.host}:{self.port}/{db_name}"
 
-        except Exception as e:
-            return self._make_error_result(f"PostgreSQL provisioning error: {str(e)}")
+        credentials.connection_string = connection_string
+        credentials.extra["database"] = db_name
+        credentials.extra["host"] = self.host
+        credentials.extra["port"] = self.port
+
+        details = {
+            "database": db_name,
+            "username": username,
+            "host": self.host,
+            "port": self.port,
+            "permissions": permissions,
+        }
+        return permissions, details
+
+    def _on_reuse(
+        self,
+        existing: Dict[str, Any],
+        credentials: GeneratedCredentials,
+        access_tier: AccessTier,
+    ) -> List[str]:
+        credentials.extra.setdefault("database", existing["database"])
+        credentials.extra.setdefault("host", self.host)
+        credentials.extra.setdefault("port", self.port)
+        return existing.get("permissions", get_permissions("postgresql", access_tier))
 
     def _apply_permissions(
         self,

--- a/backend/agents/agent_provisioning_team/tool_agents/postgres_provisioner.py
+++ b/backend/agents/agent_provisioning_team/tool_agents/postgres_provisioner.py
@@ -46,10 +46,6 @@ class PostgresProvisionerTool(BaseToolProvisioner):
         # Persistent idempotency store — survives process restarts.
         self._state = ProvisionerStateStore("postgres_provisioner")
 
-    @property
-    def _provisioned(self) -> Dict[str, Dict[str, Any]]:
-        return self._state.list_agents()
-
     def _get_admin_connection(self):
         """Get a connection with admin privileges."""
         if not HAS_PSYCOPG2:

--- a/backend/agents/agent_provisioning_team/tool_agents/redis_provisioner.py
+++ b/backend/agents/agent_provisioning_team/tool_agents/redis_provisioner.py
@@ -5,7 +5,7 @@ Sets up Redis ACL with key prefix restrictions.
 """
 
 import os
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from ..models import (
     AccessTier,
@@ -15,6 +15,7 @@ from ..models import (
     ToolProvisionResult,
 )
 from ..shared.access_policy import get_permissions, validate_permissions
+from ..shared.provisioner_state import ProvisionerStateStore
 from .base import BaseToolProvisioner
 
 try:
@@ -39,7 +40,7 @@ class RedisProvisionerTool(BaseToolProvisioner):
         self.host = host or os.environ.get("REDIS_HOST", "localhost")
         self.port = port or int(os.environ.get("REDIS_PORT", "6379"))
         self.admin_password = admin_password or os.environ.get("REDIS_PASSWORD")
-        self._provisioned: Dict[str, Dict[str, Any]] = {}
+        self._state = ProvisionerStateStore("redis_provisioner")
 
     def _get_admin_client(self):
         """Get a Redis client with admin privileges."""
@@ -64,58 +65,70 @@ class RedisProvisionerTool(BaseToolProvisioner):
         if not HAS_REDIS:
             return self._make_error_result("redis package is not installed")
 
+        return self.run_idempotent(
+            agent_id,
+            credentials=credentials,
+            create=lambda: self._do_provision(agent_id, config, credentials, access_tier),
+            reuse=lambda existing: self._on_reuse(existing, credentials),
+        )
+
+    def _do_provision(
+        self,
+        agent_id: str,
+        config: Dict[str, Any],
+        credentials: GeneratedCredentials,
+        access_tier: AccessTier,
+    ) -> Tuple[List[str], Dict[str, Any]]:
+        key_prefix = config.get("key_prefix", f"agent:{agent_id}:")
+        username = credentials.username or f"agent_{agent_id}".replace("-", "_")
+        password = credentials.password
+
+        if not password:
+            raise ValueError("No password provided in credentials")
+
+        client = self._get_admin_client()
+
+        permissions = get_permissions("redis", access_tier)
+        acl_rules = self._build_acl_rules(permissions, key_prefix)
+
         try:
-            key_prefix = config.get("key_prefix", f"agent:{agent_id}:")
-            username = credentials.username or f"agent_{agent_id}".replace("-", "_")
-            password = credentials.password
+            client.acl_deluser(username)
+        except redis.exceptions.ResponseError:
+            pass
 
-            if not password:
-                return self._make_error_result("No password provided in credentials")
+        client.acl_setuser(
+            username,
+            enabled=True,
+            passwords=[f"+{password}"],
+            keys=[f"{key_prefix}*"],
+            commands=acl_rules,
+        )
 
-            client = self._get_admin_client()
+        connection_url = f"redis://{username}:{password}@{self.host}:{self.port}"
 
-            permissions = get_permissions("redis", access_tier)
-            acl_rules = self._build_acl_rules(permissions, key_prefix)
+        credentials.connection_string = connection_url
+        credentials.extra["key_prefix"] = key_prefix
+        credentials.extra["host"] = self.host
+        credentials.extra["port"] = self.port
 
-            try:
-                client.acl_deluser(username)
-            except redis.exceptions.ResponseError:
-                pass
+        details = {
+            "username": username,
+            "key_prefix": key_prefix,
+            "host": self.host,
+            "port": self.port,
+            "permissions": permissions,
+        }
+        return permissions, details
 
-            client.acl_setuser(
-                username,
-                enabled=True,
-                passwords=[f"+{password}"],
-                keys=[f"{key_prefix}*"],
-                commands=acl_rules,
-            )
-
-            connection_url = f"redis://{username}:{password}@{self.host}:{self.port}"
-
-            credentials.connection_string = connection_url
-            credentials.extra["key_prefix"] = key_prefix
-            credentials.extra["host"] = self.host
-            credentials.extra["port"] = self.port
-
-            self._provisioned[agent_id] = {
-                "username": username,
-                "key_prefix": key_prefix,
-                "permissions": permissions,
-            }
-
-            return self._make_success_result(
-                credentials=credentials,
-                permissions=permissions,
-                details={
-                    "username": username,
-                    "key_prefix": key_prefix,
-                    "host": self.host,
-                    "port": self.port,
-                },
-            )
-
-        except Exception as e:
-            return self._make_error_result(f"Redis provisioning error: {str(e)}")
+    def _on_reuse(
+        self,
+        existing: Dict[str, Any],
+        credentials: GeneratedCredentials,
+    ) -> List[str]:
+        credentials.extra.setdefault("key_prefix", existing.get("key_prefix", ""))
+        credentials.extra.setdefault("host", self.host)
+        credentials.extra.setdefault("port", self.port)
+        return list(existing.get("permissions", []))
 
     def _build_acl_rules(
         self,
@@ -156,7 +169,7 @@ class RedisProvisionerTool(BaseToolProvisioner):
         expected_tier: AccessTier,
     ) -> AccessVerification:
         """Verify Redis ACL access for the agent."""
-        prov_info = self._provisioned.get(agent_id)
+        prov_info = self._state.get(agent_id)
 
         if not prov_info:
             return self._make_verification(
@@ -189,7 +202,7 @@ class RedisProvisionerTool(BaseToolProvisioner):
                 error="redis package is not installed",
             )
 
-        prov_info = self._provisioned.get(agent_id)
+        prov_info = self._state.get(agent_id)
         if not prov_info:
             return DeprovisionResult(
                 tool_name=self.tool_name,
@@ -206,7 +219,7 @@ class RedisProvisionerTool(BaseToolProvisioner):
             except redis.exceptions.ResponseError:
                 pass
 
-            del self._provisioned[agent_id]
+            self._state.delete(agent_id)
 
             return DeprovisionResult(
                 tool_name=self.tool_name,


### PR DESCRIPTION
## Summary

Closes #259.

A principal-engineer security review of `backend/agents/agent_provisioning_team/` flagged three problems this PR closes together:

1. **Path-traversal foothold.** `git_provisioner.py` piped manifest-supplied `workspace_path` and `init_repos[*]` straight into `Path(...).mkdir(parents=True, exist_ok=True)` with no containment check. Closed at two layers — Pydantic field validators on `DockerProvisionerConfig` / `GitProvisionerConfig` reject `..` and path separators at manifest-parse time, and `git_provisioner._do_provision` re-asserts runtime containment against `workspace_base` via a new `assert_path_within_base()` helper.
2. **Subprocess hangs.** `git_provisioner.py` made four `subprocess.run` calls (`ssh-keygen`, `git init`, `git add`, `git commit`) with no `timeout`. All now pass `timeout=_GIT_SUBPROCESS_TIMEOUT_S = 30`, matching the style already used in `docker_provisioner.py`.
3. **~90% boilerplate across five provisioners.** Each of `docker/postgres/git/redis/generic_provisioner.py` reimplemented the same idempotency-check → try/except → success/error wrapper. Three of them (git/redis/generic) used an in-memory `self._provisioned = {}` dict instead of `ProvisionerStateStore`, so their idempotency was silently lost on every process restart. A new `BaseToolProvisioner.run_idempotent(...)` in `tool_agents/base.py` owns state lookup, short-circuit on prior success, uniform exception→error-result translation, and persistence of the success payload; each provisioner's `provision()` collapses to a 5-line delegation, with tool-specific work in `_do_provision` / `_on_reuse`. git/redis/generic migrate to `ProvisionerStateStore` so idempotency now survives restarts.

## Deferred

The original issue also mentioned `run_idempotent` should own compensation-hook registration. No hook API exists today — the orchestrator's `_compensate()` walks `tool_results` and calls `deprovision()` directly, which works. Follow-up tracked in #295.

## Notable correction

The original issue claimed `docker_provisioner.py:62` was vulnerable to path traversal. It isn't — that path is only used as a `docker run -v` mount argument, never `mkdir`'d. Only `git_provisioner.py` had the runtime foothold. Manifest-level validation still guards both configs as defence-in-depth.

## Test plan

- [x] `ruff check` + `ruff format` — clean on all touched files.
- [x] `pytest agents/agent_provisioning_team/tests/` — **105 passed** (incl. 5 new tests):
  - `test_workspace_path_traversal_rejected` — git + docker configs reject `../../etc` / `/workspace/../etc`.
  - `test_init_repo_name_traversal_rejected` — git config rejects `../escape` and `nested/segment`.
  - `test_workspace_path_accepts_clean_absolute` — regression guard that legitimate absolute paths still pass.
  - `TestProvisionerScaffolding::test_git_subprocess_timeout_is_surfaced_as_error_result` — monkeypatches `subprocess.run` to raise `TimeoutExpired`; asserts `GitProvisionerTool.provision(...)` returns an error `ToolProvisionResult` with "timed out" in the message instead of hanging.
  - `TestProvisionerScaffolding::test_provisioner_idempotency_persists_across_instances` — provisions with one `GenericProvisionerTool`, then a fresh instance pointed at the same state dir sees `details["reused"] is True`. Proves the in-memory→state-store migration.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EeVVrmEoPkKQauuRD7BrrF)_