### PR TITLE
agent_provisioning: route /provision through V2 by default (closes #292)

### DIFF
--- a/backend/agents/agent_provisioning_team/api/main.py
+++ b/backend/agents/agent_provisioning_team/api/main.py
@@ -66,6 +66,31 @@ PROVISION_MAX_QUEUE_DEPTH = int(os.getenv("PROVISION_MAX_QUEUE_DEPTH", "32"))
 SHUTDOWN_GRACE_S = float(os.getenv("SHUTDOWN_GRACE_S", "30"))
 COMPENSATE_TIMEOUT_S = float(os.getenv("COMPENSATE_TIMEOUT_S", "15"))
 
+
+def _provision_thread_fallback() -> bool:
+    """Escape hatch: force the legacy thread path even when TEMPORAL_ADDRESS is set."""
+    return os.getenv("PROVISION_THREAD_FALLBACK", "").strip().lower() in ("1", "true", "yes")
+
+
+def _load_temporal_routing():
+    """Return (is_temporal_enabled_bool, start_workflow_callable). Any import
+    error degrades to the thread path so Temporal being half-installed never
+    breaks /provision."""
+    try:
+        from agent_provisioning_team.temporal.client import is_temporal_enabled
+        from agent_provisioning_team.temporal.start_workflow import start_provisioning_workflow
+
+        return bool(is_temporal_enabled()), start_provisioning_workflow
+    except ImportError:
+        return False, None
+
+
+def _temporal_active() -> bool:
+    """True when `/provision` should dispatch to Temporal (V2) instead of the thread pool."""
+    enabled, starter = _load_temporal_routing()
+    return enabled and starter is not None and not _provision_thread_fallback()
+
+
 _executor: Optional[ThreadPoolExecutor] = None
 _shutdown_event: threading.Event = threading.Event()
 _inflight: Dict[str, Future] = {}
@@ -152,9 +177,7 @@ async def _graceful_shutdown() -> None:
                 timeout=SHUTDOWN_GRACE_S,
             )
         except asyncio.TimeoutError:
-            logger.warning(
-                "Provisioning executor did not drain within %.1fs", SHUTDOWN_GRACE_S
-            )
+            logger.warning("Provisioning executor did not drain within %.1fs", SHUTDOWN_GRACE_S)
 
     try:
         active_jobs = list_jobs(running_only=True)
@@ -172,7 +195,8 @@ async def _graceful_shutdown() -> None:
         if t.is_alive():
             logger.warning(
                 "Compensate for agent=%s exceeded %.1fs; moving on",
-                agent_id, COMPENSATE_TIMEOUT_S,
+                agent_id,
+                COMPENSATE_TIMEOUT_S,
             )
 
     try:
@@ -286,18 +310,12 @@ def start_provisioning(request: ProvisionRequest) -> ProvisionJobResponse:
     """Start a new provisioning job."""
     # Check Temporal availability up front so we only apply thread-pool
     # backpressure to the thread path (Temporal has its own queueing).
-    temporal_enabled = False
-    start_temporal_workflow = None
-    try:
-        from agent_provisioning_team.temporal.client import is_temporal_enabled
-        from agent_provisioning_team.temporal.start_workflow import start_provisioning_workflow
+    enabled, start_temporal_workflow = _load_temporal_routing()
+    use_temporal = (
+        enabled and start_temporal_workflow is not None and not _provision_thread_fallback()
+    )
 
-        temporal_enabled = is_temporal_enabled()
-        start_temporal_workflow = start_provisioning_workflow
-    except ImportError:
-        pass
-
-    if not temporal_enabled:
+    if not use_temporal:
         _reject_if_saturated()
 
     job_id = str(uuid.uuid4())
@@ -308,12 +326,14 @@ def start_provisioning(request: ProvisionRequest) -> ProvisionJobResponse:
         access_tier=request.access_tier.value,
     )
 
-    if temporal_enabled:
+    if use_temporal:
         start_temporal_workflow(
             job_id,
             request.agent_id,
             request.manifest_path,
             request.access_tier.value,
+            skip_phases=None,
+            prior_results=None,
         )
         return ProvisionJobResponse(
             job_id=job_id,
@@ -466,21 +486,46 @@ def resume_provision_job(job_id: str) -> ProvisionJobResponse:
 
     from ..models import Phase
 
-    skip = {Phase(p) for p in completed if p in {ph.value for ph in Phase}}
+    phase_values = {ph.value for ph in Phase}
+    completed_values = [p for p in completed if p in phase_values]
+    access_tier_str = data.get("access_tier", "standard")
 
-    _reject_if_saturated()
+    enabled, start_temporal_workflow = _load_temporal_routing()
+    use_temporal = (
+        enabled and start_temporal_workflow is not None and not _provision_thread_fallback()
+    )
+
     update_job(job_id, status=JOB_STATUS_RUNNING, error=None)
 
+    if use_temporal:
+        start_temporal_workflow(
+            job_id,
+            agent_id,
+            manifest_path,
+            access_tier_str,
+            skip_phases=completed_values,
+            prior_results=phase_results,
+        )
+        return ProvisionJobResponse(
+            job_id=job_id,
+            status="running",
+            message="Job resumed (Temporal). Skipping completed phases.",
+        )
+
+    _reject_if_saturated()
+    skip = {Phase(p) for p in completed_values}
     _submit_provisioning_job(
         job_id,
         agent_id,
         manifest_path,
-        data.get("access_tier", "standard"),
+        access_tier_str,
         skip_phases=skip,
         prior_results=phase_results,
     )
 
-    return ProvisionJobResponse(job_id=job_id, status="running", message="Job resumed. Skipping completed phases.")
+    return ProvisionJobResponse(
+        job_id=job_id, status="running", message="Job resumed. Skipping completed phases."
+    )
 
 
 @app.post(
@@ -502,17 +547,40 @@ def restart_provision_job(job_id: str) -> ProvisionJobResponse:
     if not agent_id or not manifest_path:
         raise HTTPException(status_code=400, detail="Job is missing agent_id or manifest_path.")
 
-    _reject_if_saturated()
+    access_tier_str = data.get("access_tier", "standard")
+    enabled, start_temporal_workflow = _load_temporal_routing()
+    use_temporal = (
+        enabled and start_temporal_workflow is not None and not _provision_thread_fallback()
+    )
+
     store_reset_job(job_id)
 
+    if use_temporal:
+        start_temporal_workflow(
+            job_id,
+            agent_id,
+            manifest_path,
+            access_tier_str,
+            skip_phases=None,
+            prior_results=None,
+        )
+        return ProvisionJobResponse(
+            job_id=job_id,
+            status="running",
+            message="Job restarted (Temporal) from scratch.",
+        )
+
+    _reject_if_saturated()
     _submit_provisioning_job(
         job_id,
         agent_id,
         manifest_path,
-        data.get("access_tier", "standard"),
+        access_tier_str,
     )
 
-    return ProvisionJobResponse(job_id=job_id, status="running", message="Job restarted from scratch.")
+    return ProvisionJobResponse(
+        job_id=job_id, status="running", message="Job restarted from scratch."
+    )
 
 
 @app.delete(

--- a/backend/agents/agent_provisioning_team/api/main.py
+++ b/backend/agents/agent_provisioning_team/api/main.py
@@ -72,23 +72,19 @@ def _provision_thread_fallback() -> bool:
     return os.getenv("PROVISION_THREAD_FALLBACK", "").strip().lower() in ("1", "true", "yes")
 
 
-def _load_temporal_routing():
-    """Return (is_temporal_enabled_bool, start_workflow_callable). Any import
-    error degrades to the thread path so Temporal being half-installed never
-    breaks /provision."""
+def _temporal_starter():
+    """Return ``start_provisioning_workflow`` when /provision should dispatch
+    to Temporal (V2), else ``None``. Returns None on import error or when the
+    PROVISION_THREAD_FALLBACK escape hatch is set, so callers can branch on a
+    single value."""
+    if _provision_thread_fallback():
+        return None
     try:
         from agent_provisioning_team.temporal.client import is_temporal_enabled
         from agent_provisioning_team.temporal.start_workflow import start_provisioning_workflow
-
-        return bool(is_temporal_enabled()), start_provisioning_workflow
     except ImportError:
-        return False, None
-
-
-def _temporal_active() -> bool:
-    """True when `/provision` should dispatch to Temporal (V2) instead of the thread pool."""
-    enabled, starter = _load_temporal_routing()
-    return enabled and starter is not None and not _provision_thread_fallback()
+        return None
+    return start_provisioning_workflow if is_temporal_enabled() else None
 
 
 _executor: Optional[ThreadPoolExecutor] = None
@@ -308,14 +304,9 @@ def _run_provisioning_background(
 )
 def start_provisioning(request: ProvisionRequest) -> ProvisionJobResponse:
     """Start a new provisioning job."""
-    # Check Temporal availability up front so we only apply thread-pool
-    # backpressure to the thread path (Temporal has its own queueing).
-    enabled, start_temporal_workflow = _load_temporal_routing()
-    use_temporal = (
-        enabled and start_temporal_workflow is not None and not _provision_thread_fallback()
-    )
-
-    if not use_temporal:
+    # Apply thread-pool backpressure only on the thread path; Temporal has its own queueing.
+    starter = _temporal_starter()
+    if starter is None:
         _reject_if_saturated()
 
     job_id = str(uuid.uuid4())
@@ -326,8 +317,8 @@ def start_provisioning(request: ProvisionRequest) -> ProvisionJobResponse:
         access_tier=request.access_tier.value,
     )
 
-    if use_temporal:
-        start_temporal_workflow(
+    if starter is not None:
+        starter(
             job_id,
             request.agent_id,
             request.manifest_path,
@@ -490,15 +481,11 @@ def resume_provision_job(job_id: str) -> ProvisionJobResponse:
     completed_values = [p for p in completed if p in phase_values]
     access_tier_str = data.get("access_tier", "standard")
 
-    enabled, start_temporal_workflow = _load_temporal_routing()
-    use_temporal = (
-        enabled and start_temporal_workflow is not None and not _provision_thread_fallback()
-    )
-
+    starter = _temporal_starter()
     update_job(job_id, status=JOB_STATUS_RUNNING, error=None)
 
-    if use_temporal:
-        start_temporal_workflow(
+    if starter is not None:
+        starter(
             job_id,
             agent_id,
             manifest_path,
@@ -548,15 +535,11 @@ def restart_provision_job(job_id: str) -> ProvisionJobResponse:
         raise HTTPException(status_code=400, detail="Job is missing agent_id or manifest_path.")
 
     access_tier_str = data.get("access_tier", "standard")
-    enabled, start_temporal_workflow = _load_temporal_routing()
-    use_temporal = (
-        enabled and start_temporal_workflow is not None and not _provision_thread_fallback()
-    )
-
+    starter = _temporal_starter()
     store_reset_job(job_id)
 
-    if use_temporal:
-        start_temporal_workflow(
+    if starter is not None:
+        starter(
             job_id,
             agent_id,
             manifest_path,

--- a/backend/agents/agent_provisioning_team/temporal/__init__.py
+++ b/backend/agents/agent_provisioning_team/temporal/__init__.py
@@ -1,6 +1,50 @@
-"""Temporal workflows and worker for the Agent Provisioning team."""
+"""Temporal workflows and worker for the Agent Provisioning team.
 
+Follows shared_temporal Pattern A: exports ``WORKFLOWS``/``ACTIVITIES`` and
+self-boots a worker via ``start_team_worker`` when ``TEMPORAL_ADDRESS`` is
+set, so ``shared_temporal.teams_registry.start_all_team_workers`` picks up
+this team the same way it picks up every other team.
+"""
+
+from agent_provisioning_team.temporal.activities import (
+    audit_activity_v2,
+    compensate_activity_v2,
+    credentials_activity_v2,
+    deliver_activity_v2,
+    documentation_activity_v2,
+    provision_tool_activity,
+    run_provisioning_activity,
+    setup_activity_v2,
+)
 from agent_provisioning_team.temporal.client import is_temporal_enabled
 from agent_provisioning_team.temporal.constants import TASK_QUEUE
+from agent_provisioning_team.temporal.workflows import (
+    AgentProvisioningWorkflow,
+    AgentProvisioningWorkflowV2,
+)
 
-__all__ = ["is_temporal_enabled", "TASK_QUEUE"]
+WORKFLOWS = [AgentProvisioningWorkflow, AgentProvisioningWorkflowV2]
+ACTIVITIES = [
+    run_provisioning_activity,
+    setup_activity_v2,
+    credentials_activity_v2,
+    provision_tool_activity,
+    audit_activity_v2,
+    documentation_activity_v2,
+    deliver_activity_v2,
+    compensate_activity_v2,
+]
+
+from shared_temporal import start_team_worker  # noqa: E402
+
+if is_temporal_enabled():
+    start_team_worker("agent_provisioning", WORKFLOWS, ACTIVITIES, task_queue=TASK_QUEUE)
+
+__all__ = [
+    "is_temporal_enabled",
+    "TASK_QUEUE",
+    "WORKFLOWS",
+    "ACTIVITIES",
+    "AgentProvisioningWorkflow",
+    "AgentProvisioningWorkflowV2",
+]

--- a/backend/agents/agent_provisioning_team/temporal/activities.py
+++ b/backend/agents/agent_provisioning_team/temporal/activities.py
@@ -18,11 +18,13 @@ Two activity surfaces are exposed:
 from __future__ import annotations
 
 import logging
+from types import SimpleNamespace
 from typing import Any, Dict, List, Optional
 
 from temporalio import activity
 
 from agent_provisioning_team.models import AccessTier
+from agent_provisioning_team.shared import job_store as _js
 
 logger = logging.getLogger(__name__)
 
@@ -40,14 +42,9 @@ def run_provisioning_activity(
     access_tier_str: str,
 ) -> None:
     """Run the provisioning workflow. Converts access_tier_str to AccessTier."""
-    try:
-        from agent_provisioning_team.api.main import _run_provisioning_background
+    from agent_provisioning_team.api.main import _run_provisioning_background
 
-        access_tier = AccessTier(access_tier_str)
-        _run_provisioning_background(job_id, agent_id, manifest_path, access_tier)
-    except Exception:
-        logger.exception("Agent Provisioning activity failed for job %s", job_id)
-        raise
+    _run_provisioning_background(job_id, agent_id, manifest_path, AccessTier(access_tier_str))
 
 
 # ---------------------------------------------------------------------------
@@ -66,32 +63,24 @@ def _load_ctx(manifest_path: str, access_tier_str: str):
     return orch, manifest, access_tier
 
 
-def _update_job_safe(job_id: str, **fields: Any) -> None:
-    """Best-effort progress write. Must not fail the activity if job_store hiccups."""
+def _safe(fn_name: str, *args: Any, **kwargs: Any) -> None:
+    """Best-effort job_store call. A job_store hiccup must never fail the activity."""
     try:
-        from agent_provisioning_team.shared.job_store import update_job
-
-        update_job(job_id, **fields)
+        getattr(_js, fn_name)(*args, **kwargs)
     except Exception:
-        logger.exception("update_job failed for job=%s fields=%s", job_id, list(fields))
+        logger.exception("job_store.%s failed: args=%s kwargs=%s", fn_name, args, list(kwargs))
 
 
-def _mark_running_safe(job_id: str) -> None:
-    try:
-        from agent_provisioning_team.shared.job_store import mark_job_running
-
-        mark_job_running(job_id)
-    except Exception:
-        logger.exception("mark_job_running failed for job=%s", job_id)
-
-
-def _add_completed_phase_safe(job_id: str, phase: str, result: Dict[str, Any]) -> None:
-    try:
-        from agent_provisioning_team.shared.job_store import add_completed_phase
-
-        add_completed_phase(job_id, phase, result)
-    except Exception:
-        logger.exception("add_completed_phase failed for job=%s phase=%s", job_id, phase)
+def _restored(job_id: str, phase: str, progress: int) -> None:
+    """Common 'phase skipped, restored from prior_results' progress write."""
+    logger.info("Skipping %s for job=%s (restored from prior_results)", phase, job_id)
+    _safe(
+        "update_job",
+        job_id,
+        current_phase=phase,
+        progress=progress,
+        status_text=f"Restored {phase} from previous run",
+    )
 
 
 @activity.defn(name="agent_provisioning_setup")
@@ -105,23 +94,18 @@ def setup_activity_v2(
     from agent_provisioning_team.phases.setup import run_setup
     from agent_provisioning_team.shared.phase_state import restore_setup
 
-    _mark_running_safe(job_id)
+    _safe("mark_job_running", job_id)
 
     if prior_setup is not None:
         snap = restore_setup(prior_setup)
-        logger.info("Skipping setup for job=%s (restored from prior_results)", job_id)
-        _update_job_safe(
-            job_id,
-            current_phase="setup",
-            progress=15,
-            status_text="Restored setup from previous run",
-        )
+        _restored(job_id, "setup", 15)
         return {
             "success": snap.success,
             "environment": snap.environment.model_dump() if snap.environment else None,
         }
 
-    _update_job_safe(
+    _safe(
+        "update_job",
         job_id,
         current_phase="setup",
         progress=5,
@@ -143,8 +127,8 @@ def setup_activity_v2(
         "success": True,
         "environment": result.environment.model_dump() if result.environment else None,
     }
-    _add_completed_phase_safe(job_id, "setup", payload)
-    _update_job_safe(job_id, progress=15, status_text="Setup complete")
+    _safe("add_completed_phase", job_id, "setup", payload)
+    _safe("update_job", job_id, progress=15, status_text="Setup complete")
     return payload
 
 
@@ -162,19 +146,14 @@ def credentials_activity_v2(
 
     if prior_credentials is not None:
         snap = restore_credentials(prior_credentials)
-        logger.info("Skipping credential_generation for job=%s (restored)", job_id)
-        _update_job_safe(
-            job_id,
-            current_phase="credential_generation",
-            progress=30,
-            status_text="Restored credentials from previous run",
-        )
+        _restored(job_id, "credential_generation", 30)
         return {
             "success": snap.success,
             "credentials": {k: v.model_dump() for k, v in snap.credentials.items()},
         }
 
-    _update_job_safe(
+    _safe(
+        "update_job",
         job_id,
         current_phase="credential_generation",
         progress=20,
@@ -195,8 +174,8 @@ def credentials_activity_v2(
         "success": True,
         "credentials": {k: v.model_dump() for k, v in result.credentials.items()},
     }
-    _add_completed_phase_safe(job_id, "credential_generation", payload)
-    _update_job_safe(job_id, progress=30, status_text="Credentials generated")
+    _safe("add_completed_phase", job_id, "credential_generation", payload)
+    _safe("update_job", job_id, progress=30, status_text="Credentials generated")
     return payload
 
 
@@ -217,7 +196,8 @@ def provision_tool_activity(
     from agent_provisioning_team.shared.tool_agent_registry import build_default_tool_agents
     from agent_provisioning_team.shared.tool_manifest import load_manifest
 
-    _update_job_safe(
+    _safe(
+        "update_job",
         job_id,
         current_phase="account_provisioning",
         current_tool=tool_name,
@@ -265,16 +245,11 @@ def audit_activity_v2(
 
     if prior_audit is not None:
         result = restore_access_audit(prior_audit)
-        logger.info("Skipping access_audit for job=%s (restored)", job_id)
-        _update_job_safe(
-            job_id,
-            current_phase="access_audit",
-            progress=75,
-            status_text="Restored audit from previous run",
-        )
+        _restored(job_id, "access_audit", 75)
         return result.model_dump()
 
-    _update_job_safe(
+    _safe(
+        "update_job",
         job_id,
         current_phase="access_audit",
         progress=70,
@@ -292,8 +267,8 @@ def audit_activity_v2(
         provisioners=build_default_tool_agents(),
     )
     payload = result.model_dump()
-    _add_completed_phase_safe(job_id, "access_audit", payload)
-    _update_job_safe(job_id, progress=80, status_text="Access audit complete")
+    _safe("add_completed_phase", job_id, "access_audit", payload)
+    _safe("update_job", job_id, progress=80, status_text="Access audit complete")
     return payload
 
 
@@ -315,19 +290,14 @@ def documentation_activity_v2(
 
     if prior_documentation is not None:
         snap = restore_documentation(prior_documentation)
-        logger.info("Skipping documentation for job=%s (restored)", job_id)
-        _update_job_safe(
-            job_id,
-            current_phase="documentation",
-            progress=90,
-            status_text="Restored documentation from previous run",
-        )
+        _restored(job_id, "documentation", 90)
         return {
             "success": snap.success,
             "onboarding": snap.onboarding.model_dump() if snap.onboarding else None,
         }
 
-    _update_job_safe(
+    _safe(
+        "update_job",
         job_id,
         current_phase="documentation",
         progress=85,
@@ -350,8 +320,8 @@ def documentation_activity_v2(
         "success": result.success,
         "onboarding": result.onboarding.model_dump() if result.onboarding else None,
     }
-    _add_completed_phase_safe(job_id, "documentation", payload)
-    _update_job_safe(job_id, progress=92, status_text="Documentation complete")
+    _safe("add_completed_phase", job_id, "documentation", payload)
+    _safe("update_job", job_id, progress=92, status_text="Documentation complete")
     return payload
 
 
@@ -378,9 +348,9 @@ def deliver_activity_v2(
         redact_credentials_for_response,
         run_deliver,
     )
-    from agent_provisioning_team.shared.job_store import mark_job_completed, mark_job_failed
 
-    _update_job_safe(
+    _safe(
+        "update_job",
         job_id,
         current_phase="deliver",
         progress=95,
@@ -417,15 +387,9 @@ def deliver_activity_v2(
 
     if final.success:
         redacted = redact_credentials_for_response(final)
-        try:
-            mark_job_completed(job_id, result=redacted.model_dump())
-        except Exception:
-            logger.exception("mark_job_completed failed for job=%s", job_id)
+        _safe("mark_job_completed", job_id, result=redacted.model_dump())
     else:
-        try:
-            mark_job_failed(job_id, error=final.error or "Provisioning failed")
-        except Exception:
-            logger.exception("mark_job_failed failed for job=%s", job_id)
+        _safe("mark_job_failed", job_id, error=final.error or "Provisioning failed")
 
     return {"success": final.success, "error": final.error}
 
@@ -445,14 +409,12 @@ def compensate_activity_v2(
     from agent_provisioning_team.orchestrator import ProvisioningOrchestrator
 
     orch = ProvisioningOrchestrator()
-
-    class _R:  # noqa: D401 — local shim
-        def __init__(self, tool_name: str, provisioner_key: Optional[str]) -> None:
-            self.tool_name = tool_name
-            self.provisioner_key = provisioner_key
-            self.success = True
-
-    orch._compensate(
-        agent_id,
-        [_R(t.get("tool_name", ""), t.get("provisioner_key")) for t in succeeded_tools],
-    )
+    shims = [
+        SimpleNamespace(
+            tool_name=t.get("tool_name", ""),
+            provisioner_key=t.get("provisioner_key"),
+            success=True,
+        )
+        for t in succeeded_tools
+    ]
+    orch._compensate(agent_id, shims)

--- a/backend/agents/agent_provisioning_team/temporal/activities.py
+++ b/backend/agents/agent_provisioning_team/temporal/activities.py
@@ -3,12 +3,16 @@
 Two activity surfaces are exposed:
 
 * ``run_provisioning_activity`` — v1, single activity per workflow. Kept for
-  backwards compatibility with ``AgentProvisioningWorkflow``.
+  backwards compatibility with ``AgentProvisioningWorkflow`` so in-flight
+  runs can drain during a deploy.
 
 * The ``*_activity_v2`` family — fine-grained, per-phase activities used by
   ``AgentProvisioningWorkflowV2``. The per-tool provision step is its own
   activity (``provision_tool_activity``) so a workflow can fan out across
-  tools in parallel with independent retry/heartbeat policies.
+  tools in parallel with independent retry/heartbeat policies. Each v2
+  activity takes ``job_id`` as its first argument and writes phase/progress
+  updates back to ``job_store`` directly so ``GET /provision/status/{job_id}``
+  shows live progress without any signal plumbing.
 """
 
 from __future__ import annotations
@@ -62,14 +66,67 @@ def _load_ctx(manifest_path: str, access_tier_str: str):
     return orch, manifest, access_tier
 
 
+def _update_job_safe(job_id: str, **fields: Any) -> None:
+    """Best-effort progress write. Must not fail the activity if job_store hiccups."""
+    try:
+        from agent_provisioning_team.shared.job_store import update_job
+
+        update_job(job_id, **fields)
+    except Exception:
+        logger.exception("update_job failed for job=%s fields=%s", job_id, list(fields))
+
+
+def _mark_running_safe(job_id: str) -> None:
+    try:
+        from agent_provisioning_team.shared.job_store import mark_job_running
+
+        mark_job_running(job_id)
+    except Exception:
+        logger.exception("mark_job_running failed for job=%s", job_id)
+
+
+def _add_completed_phase_safe(job_id: str, phase: str, result: Dict[str, Any]) -> None:
+    try:
+        from agent_provisioning_team.shared.job_store import add_completed_phase
+
+        add_completed_phase(job_id, phase, result)
+    except Exception:
+        logger.exception("add_completed_phase failed for job=%s phase=%s", job_id, phase)
+
+
 @activity.defn(name="agent_provisioning_setup")
 def setup_activity_v2(
+    job_id: str,
     agent_id: str,
     manifest_path: str,
     access_tier_str: str,
+    prior_setup: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     from agent_provisioning_team.phases.setup import run_setup
+    from agent_provisioning_team.shared.phase_state import restore_setup
 
+    _mark_running_safe(job_id)
+
+    if prior_setup is not None:
+        snap = restore_setup(prior_setup)
+        logger.info("Skipping setup for job=%s (restored from prior_results)", job_id)
+        _update_job_safe(
+            job_id,
+            current_phase="setup",
+            progress=15,
+            status_text="Restored setup from previous run",
+        )
+        return {
+            "success": snap.success,
+            "environment": snap.environment.model_dump() if snap.environment else None,
+        }
+
+    _update_job_safe(
+        job_id,
+        current_phase="setup",
+        progress=5,
+        status_text="Creating Docker environment...",
+    )
     orch, manifest, access_tier = _load_ctx(manifest_path, access_tier_str)
     activity.heartbeat("setup")
     result = run_setup(
@@ -81,22 +138,48 @@ def setup_activity_v2(
     )
     if not result.success:
         raise RuntimeError(f"setup failed: {result.error}")
-    # Return a plain dict so it's JSON-serializable across the activity boundary.
-    return {
+
+    payload = {
         "success": True,
         "environment": result.environment.model_dump() if result.environment else None,
     }
+    _add_completed_phase_safe(job_id, "setup", payload)
+    _update_job_safe(job_id, progress=15, status_text="Setup complete")
+    return payload
 
 
 @activity.defn(name="agent_provisioning_credentials")
 def credentials_activity_v2(
+    job_id: str,
     agent_id: str,
     manifest_path: str,
+    prior_credentials: Optional[Dict[str, Any]] = None,
 ) -> Dict[str, Any]:
     from agent_provisioning_team.orchestrator import ProvisioningOrchestrator
     from agent_provisioning_team.phases.credential_generation import run_credential_generation
+    from agent_provisioning_team.shared.phase_state import restore_credentials
     from agent_provisioning_team.shared.tool_manifest import load_manifest
 
+    if prior_credentials is not None:
+        snap = restore_credentials(prior_credentials)
+        logger.info("Skipping credential_generation for job=%s (restored)", job_id)
+        _update_job_safe(
+            job_id,
+            current_phase="credential_generation",
+            progress=30,
+            status_text="Restored credentials from previous run",
+        )
+        return {
+            "success": snap.success,
+            "credentials": {k: v.model_dump() for k, v in snap.credentials.items()},
+        }
+
+    _update_job_safe(
+        job_id,
+        current_phase="credential_generation",
+        progress=20,
+        status_text="Generating credentials...",
+    )
     orch = ProvisioningOrchestrator()
     manifest = load_manifest(manifest_path)
     activity.heartbeat("credentials")
@@ -107,25 +190,40 @@ def credentials_activity_v2(
     )
     if not result.success:
         raise RuntimeError(f"credential generation failed: {result.error}")
-    return {
+
+    payload = {
         "success": True,
         "credentials": {k: v.model_dump() for k, v in result.credentials.items()},
     }
+    _add_completed_phase_safe(job_id, "credential_generation", payload)
+    _update_job_safe(job_id, progress=30, status_text="Credentials generated")
+    return payload
 
 
 @activity.defn(name="agent_provisioning_provision_tool")
 def provision_tool_activity(
+    job_id: str,
     agent_id: str,
     tool_name: str,
     manifest_path: str,
     access_tier_str: str,
     credentials_dump: Dict[str, Any],
+    tools_completed_so_far: int = 0,
+    tools_total: int = 0,
 ) -> Dict[str, Any]:
     """Provision a single tool — one activity per tool so fan-out is natural."""
     from agent_provisioning_team.models import GeneratedCredentials
     from agent_provisioning_team.phases.account_provisioning import _map_access_level_to_tier
     from agent_provisioning_team.shared.tool_agent_registry import build_default_tool_agents
     from agent_provisioning_team.shared.tool_manifest import load_manifest
+
+    _update_job_safe(
+        job_id,
+        current_phase="account_provisioning",
+        current_tool=tool_name,
+        tools_total=tools_total,
+        status_text=f"Provisioning {tool_name}...",
+    )
 
     manifest = load_manifest(manifest_path)
     tool = manifest.get_tool(tool_name)
@@ -148,6 +246,188 @@ def provision_tool_activity(
         access_tier=tier,
     )
     return result.model_dump()
+
+
+@activity.defn(name="agent_provisioning_audit")
+def audit_activity_v2(
+    job_id: str,
+    agent_id: str,
+    manifest_path: str,
+    access_tier_str: str,
+    tool_results_dump: List[Dict[str, Any]],
+    prior_audit: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    from agent_provisioning_team.models import ToolProvisionResult
+    from agent_provisioning_team.phases.access_audit import run_access_audit
+    from agent_provisioning_team.shared.phase_state import restore_access_audit
+    from agent_provisioning_team.shared.tool_agent_registry import build_default_tool_agents
+    from agent_provisioning_team.shared.tool_manifest import load_manifest
+
+    if prior_audit is not None:
+        result = restore_access_audit(prior_audit)
+        logger.info("Skipping access_audit for job=%s (restored)", job_id)
+        _update_job_safe(
+            job_id,
+            current_phase="access_audit",
+            progress=75,
+            status_text="Restored audit from previous run",
+        )
+        return result.model_dump()
+
+    _update_job_safe(
+        job_id,
+        current_phase="access_audit",
+        progress=70,
+        status_text="Auditing access permissions...",
+    )
+    manifest = load_manifest(manifest_path)
+    access_tier = AccessTier(access_tier_str)
+    tool_results = [ToolProvisionResult.model_validate(t) for t in tool_results_dump]
+    activity.heartbeat("access_audit")
+    result = run_access_audit(
+        agent_id=agent_id,
+        tool_results=tool_results,
+        access_tier=access_tier,
+        manifest=manifest,
+        provisioners=build_default_tool_agents(),
+    )
+    payload = result.model_dump()
+    _add_completed_phase_safe(job_id, "access_audit", payload)
+    _update_job_safe(job_id, progress=80, status_text="Access audit complete")
+    return payload
+
+
+@activity.defn(name="agent_provisioning_documentation")
+def documentation_activity_v2(
+    job_id: str,
+    agent_id: str,
+    manifest_path: str,
+    access_tier_str: str,
+    credentials_dump: Dict[str, Dict[str, Any]],
+    tool_results_dump: List[Dict[str, Any]],
+    workspace_path: str,
+    prior_documentation: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    from agent_provisioning_team.models import GeneratedCredentials, ToolProvisionResult
+    from agent_provisioning_team.phases.documentation import run_documentation
+    from agent_provisioning_team.shared.phase_state import restore_documentation
+    from agent_provisioning_team.shared.tool_manifest import load_manifest
+
+    if prior_documentation is not None:
+        snap = restore_documentation(prior_documentation)
+        logger.info("Skipping documentation for job=%s (restored)", job_id)
+        _update_job_safe(
+            job_id,
+            current_phase="documentation",
+            progress=90,
+            status_text="Restored documentation from previous run",
+        )
+        return {
+            "success": snap.success,
+            "onboarding": snap.onboarding.model_dump() if snap.onboarding else None,
+        }
+
+    _update_job_safe(
+        job_id,
+        current_phase="documentation",
+        progress=85,
+        status_text="Generating onboarding documentation...",
+    )
+    manifest = load_manifest(manifest_path)
+    access_tier = AccessTier(access_tier_str)
+    credentials = {k: GeneratedCredentials.model_validate(v) for k, v in credentials_dump.items()}
+    tool_results = [ToolProvisionResult.model_validate(t) for t in tool_results_dump]
+    activity.heartbeat("documentation")
+    result = run_documentation(
+        agent_id=agent_id,
+        manifest=manifest,
+        credentials=credentials,
+        tool_results=tool_results,
+        access_tier=access_tier,
+        workspace_path=workspace_path,
+    )
+    payload = {
+        "success": result.success,
+        "onboarding": result.onboarding.model_dump() if result.onboarding else None,
+    }
+    _add_completed_phase_safe(job_id, "documentation", payload)
+    _update_job_safe(job_id, progress=92, status_text="Documentation complete")
+    return payload
+
+
+@activity.defn(name="agent_provisioning_deliver")
+def deliver_activity_v2(
+    job_id: str,
+    agent_id: str,
+    environment_dump: Optional[Dict[str, Any]],
+    credentials_dump: Dict[str, Dict[str, Any]],
+    tool_results_dump: List[Dict[str, Any]],
+    audit_dump: Optional[Dict[str, Any]],
+    onboarding_dump: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    from agent_provisioning_team.models import (
+        AccessAuditResult,
+        EnvironmentInfo,
+        GeneratedCredentials,
+        OnboardingPacket,
+        ToolProvisionResult,
+    )
+    from agent_provisioning_team.orchestrator import ProvisioningOrchestrator
+    from agent_provisioning_team.phases.deliver import (
+        build_final_result,
+        redact_credentials_for_response,
+        run_deliver,
+    )
+    from agent_provisioning_team.shared.job_store import mark_job_completed, mark_job_failed
+
+    _update_job_safe(
+        job_id,
+        current_phase="deliver",
+        progress=95,
+        status_text="Finalizing provisioning...",
+    )
+
+    environment = EnvironmentInfo.model_validate(environment_dump) if environment_dump else None
+    credentials = {k: GeneratedCredentials.model_validate(v) for k, v in credentials_dump.items()}
+    tool_results = [ToolProvisionResult.model_validate(t) for t in tool_results_dump]
+    audit = AccessAuditResult.model_validate(audit_dump) if audit_dump else None
+    onboarding = OnboardingPacket.model_validate(onboarding_dump) if onboarding_dump else None
+
+    orch = ProvisioningOrchestrator()
+    activity.heartbeat("deliver")
+    deliver_result = run_deliver(
+        agent_id=agent_id,
+        environment=environment,
+        credentials=credentials,
+        tool_results=tool_results,
+        access_audit=audit,
+        onboarding=onboarding,
+        environment_store=orch.environment_store,
+    )
+
+    final = build_final_result(
+        agent_id=agent_id,
+        environment=environment,
+        credentials=credentials,
+        tool_results=tool_results,
+        access_audit=audit,
+        onboarding=onboarding,
+        deliver_result=deliver_result,
+    )
+
+    if final.success:
+        redacted = redact_credentials_for_response(final)
+        try:
+            mark_job_completed(job_id, result=redacted.model_dump())
+        except Exception:
+            logger.exception("mark_job_completed failed for job=%s", job_id)
+    else:
+        try:
+            mark_job_failed(job_id, error=final.error or "Provisioning failed")
+        except Exception:
+            logger.exception("mark_job_failed failed for job=%s", job_id)
+
+    return {"success": final.success, "error": final.error}
 
 
 @activity.defn(name="agent_provisioning_compensate")

--- a/backend/agents/agent_provisioning_team/temporal/start_workflow.py
+++ b/backend/agents/agent_provisioning_team/temporal/start_workflow.py
@@ -4,14 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from typing import Any
+from typing import Any, Optional
 
-from agent_provisioning_team.temporal.client import (
-    get_temporal_client,
-    get_temporal_loop,
-)
 from agent_provisioning_team.temporal.constants import TASK_QUEUE, WORKFLOW_ID_PREFIX
-from agent_provisioning_team.temporal.workflows import AgentProvisioningWorkflow
+from agent_provisioning_team.temporal.workflows import AgentProvisioningWorkflowV2
+from shared_temporal import get_temporal_client, get_temporal_loop
 
 logger = logging.getLogger(__name__)
 
@@ -34,18 +31,32 @@ def start_provisioning_workflow(
     agent_id: str,
     manifest_path: str,
     access_tier_str: str,
+    skip_phases: Optional[list[str]] = None,
+    prior_results: Optional[dict[str, Any]] = None,
 ) -> None:
-    """Start AgentProvisioningWorkflow for the given job."""
+    """Start ``AgentProvisioningWorkflowV2`` for the given job.
+
+    ``skip_phases`` (phase ``.value`` strings) and ``prior_results`` (dict
+    keyed by phase value with serialized phase output) are forwarded to
+    the workflow so ``/resume`` keeps parity with the thread path.
+    """
     client = get_temporal_client()
     if client is None:
         raise RuntimeError("Temporal client not available")
     workflow_id = f"{WORKFLOW_ID_PREFIX}{job_id}"
     _run_async(
         client.start_workflow(
-            AgentProvisioningWorkflow.run,
-            args=[job_id, agent_id, manifest_path, access_tier_str],
+            AgentProvisioningWorkflowV2.run,
+            args=[
+                job_id,
+                agent_id,
+                manifest_path,
+                access_tier_str,
+                list(skip_phases) if skip_phases else None,
+                dict(prior_results) if prior_results else None,
+            ],
             id=workflow_id,
             task_queue=TASK_QUEUE,
         )
     )
-    logger.info("Started AgentProvisioningWorkflow id=%s", workflow_id)
+    logger.info("Started AgentProvisioningWorkflowV2 id=%s", workflow_id)

--- a/backend/agents/agent_provisioning_team/temporal/worker.py
+++ b/backend/agents/agent_provisioning_team/temporal/worker.py
@@ -1,10 +1,14 @@
-"""Temporal worker for the Agent Provisioning team."""
+"""Temporal worker creation for the Agent Provisioning team.
+
+Worker startup is handled by ``shared_temporal.start_team_worker`` via the
+Pattern A auto-boot in ``agent_provisioning_team/temporal/__init__.py``.
+This module retains ``create_agent_provisioning_worker`` for tests and
+diagnostics that want to build a ``Worker`` instance directly.
+"""
 
 from __future__ import annotations
 
-import asyncio
 import logging
-import threading
 from concurrent.futures import ThreadPoolExecutor
 from typing import Optional
 
@@ -15,18 +19,16 @@ from temporalio.worker.workflow_sandbox import (
 )
 
 from agent_provisioning_team.temporal.activities import (
+    audit_activity_v2,
     compensate_activity_v2,
     credentials_activity_v2,
+    deliver_activity_v2,
+    documentation_activity_v2,
     provision_tool_activity,
     run_provisioning_activity,
     setup_activity_v2,
 )
-from agent_provisioning_team.temporal.client import (
-    connect_temporal_client,
-    is_temporal_enabled,
-    set_temporal_client,
-    set_temporal_loop,
-)
+from agent_provisioning_team.temporal.client import is_temporal_enabled
 from agent_provisioning_team.temporal.constants import TASK_QUEUE
 from agent_provisioning_team.temporal.workflows import (
     AgentProvisioningWorkflow,
@@ -35,7 +37,6 @@ from agent_provisioning_team.temporal.workflows import (
 
 logger = logging.getLogger(__name__)
 
-_worker_thread: Optional[threading.Thread] = None
 _activity_executor: Optional[ThreadPoolExecutor] = None
 
 
@@ -66,6 +67,9 @@ def create_agent_provisioning_worker(client: Optional[object] = None) -> Optiona
             setup_activity_v2,
             credentials_activity_v2,
             provision_tool_activity,
+            audit_activity_v2,
+            documentation_activity_v2,
+            deliver_activity_v2,
             compensate_activity_v2,
         ],
         activity_executor=_activity_executor,
@@ -74,50 +78,3 @@ def create_agent_provisioning_worker(client: Optional[object] = None) -> Optiona
     )
     logger.info("Agent Provisioning Temporal worker created for task queue %s", TASK_QUEUE)
     return worker
-
-
-async def _run_worker_async() -> None:
-    client = await connect_temporal_client()
-    if client is None:
-        return
-    set_temporal_client(client)
-    set_temporal_loop(asyncio.get_running_loop())
-    worker = create_agent_provisioning_worker(client)
-    if worker is None:
-        return
-    logger.info("Agent Provisioning Temporal worker starting")
-    await worker.run()
-
-
-def _worker_thread_target() -> None:
-    global _worker_thread
-    if not is_temporal_enabled():
-        return
-    loop = asyncio.new_event_loop()
-    asyncio.set_event_loop(loop)
-    try:
-        loop.run_until_complete(_run_worker_async())
-    except asyncio.CancelledError:
-        pass
-    except Exception as e:
-        logger.exception("Agent Provisioning Temporal worker failed: %s", e)
-    finally:
-        set_temporal_client(None)
-        set_temporal_loop(None)
-        loop.close()
-
-
-def start_agent_provisioning_temporal_worker_thread() -> bool:
-    global _worker_thread
-    if not is_temporal_enabled():
-        return False
-    if _worker_thread is not None and _worker_thread.is_alive():
-        return True
-    _worker_thread = threading.Thread(
-        target=_worker_thread_target,
-        name="agent-provisioning-temporal-worker",
-        daemon=True,
-    )
-    _worker_thread.start()
-    logger.info("Agent Provisioning Temporal worker thread started")
-    return True

--- a/backend/agents/agent_provisioning_team/temporal/workflows.py
+++ b/backend/agents/agent_provisioning_team/temporal/workflows.py
@@ -3,20 +3,23 @@
 Two workflows are exposed:
 
 * ``AgentProvisioningWorkflow`` — v1, delegates to a single activity. Kept
-  as the compatibility path for the current API.
+  registered so in-flight runs can drain during a deploy, but no longer
+  targeted by the default routing path.
 
 * ``AgentProvisioningWorkflowV2`` — v2, decomposes provisioning into
   per-phase activities and fans out tool provisioning in parallel via
   ``asyncio.gather``. Each tool activity has its own retry policy and
   heartbeat, so a flaky external tool can be retried independently
-  without re-doing the whole job. On any tool failure a compensation
-  activity is invoked to roll back partially-provisioned resources.
+  without re-doing the whole job. Accepts ``skip_phases`` /
+  ``prior_results`` on resume so completed phases are restored from the
+  job store instead of re-executed.
 """
 
 from __future__ import annotations
 
 import asyncio
 from datetime import timedelta
+from typing import Any
 
 from temporalio import workflow
 from temporalio.common import RetryPolicy
@@ -79,62 +82,112 @@ class AgentProvisioningWorkflowV2:
         agent_id: str,
         manifest_path: str,
         access_tier_str: str,
+        skip_phases: list[str] | None = None,
+        prior_results: dict[str, Any] | None = None,
     ) -> None:
+        skip = set(skip_phases or [])
+        prior = prior_results or {}
+
         # Phase 1: setup (Docker environment).
-        await workflow.execute_activity(
+        setup_prior = prior.get("setup") if "setup" in skip else None
+        setup_result = await workflow.execute_activity(
             _activities.setup_activity_v2,
-            args=[agent_id, manifest_path, access_tier_str],
+            args=[job_id, agent_id, manifest_path, access_tier_str, setup_prior],
             task_queue=TASK_QUEUE,
             schedule_to_close_timeout=PHASE_TIMEOUT,
             retry_policy=DEFAULT_RETRY_POLICY,
         )
+        environment_dump = setup_result.get("environment") if setup_result else None
 
         # Phase 2: credential generation.
+        creds_prior = (
+            prior.get("credential_generation") if "credential_generation" in skip else None
+        )
         creds_result = await workflow.execute_activity(
             _activities.credentials_activity_v2,
-            args=[agent_id, manifest_path],
+            args=[job_id, agent_id, manifest_path, creds_prior],
             task_queue=TASK_QUEUE,
             schedule_to_close_timeout=PHASE_TIMEOUT,
             retry_policy=DEFAULT_RETRY_POLICY,
         )
-        credentials_by_tool = creds_result["credentials"]
+        credentials_by_tool: dict[str, dict[str, Any]] = creds_result["credentials"]
 
-        # Phase 3: fan out per-tool provisioning.
+        # Phase 3: fan out per-tool provisioning (or restore from prior).
         manifest = load_manifest(manifest_path)
         tool_names = [t.name for t in manifest.tools]
 
-        async def _one(tool_name: str):
-            creds_dump = credentials_by_tool.get(tool_name, {})
-            return await workflow.execute_activity(
-                _activities.provision_tool_activity,
-                args=[agent_id, tool_name, manifest_path, access_tier_str, creds_dump],
-                task_queue=TASK_QUEUE,
-                start_to_close_timeout=TOOL_ACTIVITY_TIMEOUT,
-                heartbeat_timeout=TOOL_HEARTBEAT_TIMEOUT,
-                retry_policy=TOOL_RETRY_POLICY,
+        if "account_provisioning" in skip and prior.get("account_provisioning"):
+            # V1 mirrors whole-phase skip (no per-tool resume), so do the same here.
+            ap = prior["account_provisioning"]
+            tool_results_dump = list(ap.get("tool_results") or [])
+            succeeded: list[dict] = [
+                {
+                    "tool_name": r.get("tool_name"),
+                    "provisioner_key": r.get("provisioner_key"),
+                }
+                for r in tool_results_dump
+                if r.get("success")
+            ]
+            failures: list[str] = [
+                f"{r.get('tool_name')}: {r.get('error')}"
+                for r in tool_results_dump
+                if not r.get("success")
+            ]
+        else:
+            tools_total = len(tool_names)
+
+            async def _one(idx: int, tool_name: str) -> Any:
+                creds_dump = credentials_by_tool.get(tool_name, {})
+                return await workflow.execute_activity(
+                    _activities.provision_tool_activity,
+                    args=[
+                        job_id,
+                        agent_id,
+                        tool_name,
+                        manifest_path,
+                        access_tier_str,
+                        creds_dump,
+                        idx,
+                        tools_total,
+                    ],
+                    task_queue=TASK_QUEUE,
+                    start_to_close_timeout=TOOL_ACTIVITY_TIMEOUT,
+                    heartbeat_timeout=TOOL_HEARTBEAT_TIMEOUT,
+                    retry_policy=TOOL_RETRY_POLICY,
+                )
+
+            raw_results = await asyncio.gather(
+                *[_one(i, name) for i, name in enumerate(tool_names)],
+                return_exceptions=True,
             )
 
-        results = await asyncio.gather(
-            *[_one(name) for name in tool_names],
-            return_exceptions=True,
-        )
-
-        # Carry the registry key through with each success so compensation
-        # can look the provisioner back up (see #293).
-        succeeded: list[dict] = []
-        failures: list[str] = []
-        for name, res in zip(tool_names, results):
-            if isinstance(res, BaseException):
-                failures.append(f"{name}: {res}")
-            elif isinstance(res, dict) and res.get("success"):
-                succeeded.append(
-                    {
-                        "tool_name": res.get("tool_name", name),
-                        "provisioner_key": res.get("provisioner_key"),
-                    }
-                )
-            else:
-                failures.append(f"{name}: {res.get('error') if isinstance(res, dict) else 'unknown'}")
+            # Carry the registry key through with each success so compensation
+            # can look the provisioner back up (see #293).
+            succeeded = []
+            failures = []
+            tool_results_dump = []
+            for name, res in zip(tool_names, raw_results):
+                if isinstance(res, BaseException):
+                    failures.append(f"{name}: {res}")
+                    tool_results_dump.append(
+                        {"tool_name": name, "success": False, "error": str(res)}
+                    )
+                elif isinstance(res, dict) and res.get("success"):
+                    succeeded.append(
+                        {
+                            "tool_name": res.get("tool_name", name),
+                            "provisioner_key": res.get("provisioner_key"),
+                        }
+                    )
+                    tool_results_dump.append(res)
+                else:
+                    err = res.get("error") if isinstance(res, dict) else "unknown"
+                    failures.append(f"{name}: {err}")
+                    tool_results_dump.append(
+                        res
+                        if isinstance(res, dict)
+                        else {"tool_name": name, "success": False, "error": err}
+                    )
 
         if failures:
             # Compensation: roll back the ones that did succeed.
@@ -148,3 +201,53 @@ class AgentProvisioningWorkflowV2:
             raise RuntimeError(
                 f"Tool provisioning failed for agent {agent_id}: {'; '.join(failures)}"
             )
+
+        # Phase 4: access audit.
+        audit_prior = prior.get("access_audit") if "access_audit" in skip else None
+        audit_dump = await workflow.execute_activity(
+            _activities.audit_activity_v2,
+            args=[job_id, agent_id, manifest_path, access_tier_str, tool_results_dump, audit_prior],
+            task_queue=TASK_QUEUE,
+            schedule_to_close_timeout=PHASE_TIMEOUT,
+            retry_policy=DEFAULT_RETRY_POLICY,
+        )
+
+        # Phase 5: documentation.
+        workspace_path = "/workspace"
+        if environment_dump:
+            workspace_path = environment_dump.get("workspace_path") or "/workspace"
+        doc_prior = prior.get("documentation") if "documentation" in skip else None
+        doc_result = await workflow.execute_activity(
+            _activities.documentation_activity_v2,
+            args=[
+                job_id,
+                agent_id,
+                manifest_path,
+                access_tier_str,
+                credentials_by_tool,
+                tool_results_dump,
+                workspace_path,
+                doc_prior,
+            ],
+            task_queue=TASK_QUEUE,
+            schedule_to_close_timeout=PHASE_TIMEOUT,
+            retry_policy=DEFAULT_RETRY_POLICY,
+        )
+        onboarding_dump = doc_result.get("onboarding") if doc_result else None
+
+        # Phase 6: deliver + final job_store update.
+        await workflow.execute_activity(
+            _activities.deliver_activity_v2,
+            args=[
+                job_id,
+                agent_id,
+                environment_dump,
+                credentials_by_tool,
+                tool_results_dump,
+                audit_dump,
+                onboarding_dump,
+            ],
+            task_queue=TASK_QUEUE,
+            schedule_to_close_timeout=PHASE_TIMEOUT,
+            retry_policy=DEFAULT_RETRY_POLICY,
+        )

--- a/backend/agents/agent_provisioning_team/tests/test_temporal_integration.py
+++ b/backend/agents/agent_provisioning_team/tests/test_temporal_integration.py
@@ -1,0 +1,232 @@
+"""Temporal integration tests for the Agent Provisioning team.
+
+Covers routing, skip_phases/prior_results plumbing on /resume, the
+PROVISION_THREAD_FALLBACK escape hatch, progress writes from v2
+activities, and Pattern A exports. Mocks Temporal at the HTTP boundary
+rather than spinning up WorkflowEnvironment — matches the SE team's
+test_temporal_integration.py style and keeps the suite fast.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from fastapi.testclient import TestClient
+
+from agent_provisioning_team.api import main as api_main
+from agent_provisioning_team.api.main import app
+
+client = TestClient(app)
+
+
+@patch("agent_provisioning_team.api.main.create_job")
+@patch("agent_provisioning_team.temporal.start_workflow.start_provisioning_workflow")
+@patch("agent_provisioning_team.temporal.client.is_temporal_enabled", return_value=True)
+def test_provision_routes_to_v2_when_temporal_enabled(
+    mock_enabled: MagicMock,
+    mock_start: MagicMock,
+    mock_create_job: MagicMock,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("PROVISION_THREAD_FALLBACK", raising=False)
+    resp = client.post("/provision", json={"agent_id": "t-temporal-1"})
+
+    assert resp.status_code == 200
+    mock_start.assert_called_once()
+    args, kwargs = mock_start.call_args
+    # Positional: (job_id, agent_id, manifest_path, access_tier_str)
+    assert args[1] == "t-temporal-1"
+    assert args[3] == "standard"  # AccessTier.STANDARD.value, not the enum
+    assert kwargs.get("skip_phases") is None
+    assert kwargs.get("prior_results") is None
+
+
+@patch("agent_provisioning_team.api.main.update_job")
+@patch("agent_provisioning_team.api.main.get_job")
+@patch("agent_provisioning_team.temporal.start_workflow.start_provisioning_workflow")
+@patch("agent_provisioning_team.temporal.client.is_temporal_enabled", return_value=True)
+def test_resume_passes_skip_phases_and_prior_results(
+    mock_enabled: MagicMock,
+    mock_start: MagicMock,
+    mock_get_job: MagicMock,
+    mock_update_job: MagicMock,
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("PROVISION_THREAD_FALLBACK", raising=False)
+    mock_get_job.return_value = {
+        "job_id": "job-resume-1",
+        "agent_id": "a1",
+        "manifest_path": "default.yaml",
+        "access_tier": "standard",
+        "status": "failed",
+        "completed_phases": ["setup", "credential_generation"],
+        "phase_results": {
+            "setup": {"success": True, "environment": None},
+            "credential_generation": {"success": True, "credentials": {}},
+        },
+    }
+
+    resp = client.post("/provision/job/job-resume-1/resume")
+
+    assert resp.status_code == 200
+    mock_start.assert_called_once()
+    _, kwargs = mock_start.call_args
+    assert kwargs.get("skip_phases") == ["setup", "credential_generation"]
+    assert kwargs.get("prior_results") == {
+        "setup": {"success": True, "environment": None},
+        "credential_generation": {"success": True, "credentials": {}},
+    }
+
+
+def test_provision_falls_back_to_thread_path_when_flag_set(monkeypatch) -> None:
+    monkeypatch.setenv("PROVISION_THREAD_FALLBACK", "1")
+
+    with (
+        patch(
+            "agent_provisioning_team.temporal.client.is_temporal_enabled",
+            return_value=True,
+        ),
+        patch(
+            "agent_provisioning_team.temporal.start_workflow.start_provisioning_workflow"
+        ) as mock_start,
+        patch("agent_provisioning_team.api.main.create_job"),
+        patch("agent_provisioning_team.api.main._ensure_executor") as mock_ensure,
+    ):
+        mock_executor = MagicMock()
+        mock_ensure.return_value = mock_executor
+
+        resp = client.post("/provision", json={"agent_id": "t-fallback"})
+
+    assert resp.status_code == 200
+    # Fallback forces the thread path, so the Temporal starter must NOT be called.
+    mock_start.assert_not_called()
+    # And the executor must have received the submission.
+    assert mock_executor.submit.called
+    submitted_fn = mock_executor.submit.call_args[0][0]
+    assert submitted_fn is api_main._run_provisioning_background
+
+
+def test_setup_activity_v2_writes_progress_via_update_job() -> None:
+    """Invoking setup_activity_v2 directly should push phase + progress into job_store."""
+    from agent_provisioning_team.temporal import activities as t_acts
+
+    recorded_updates: list[dict] = []
+    recorded_running: list[str] = []
+    recorded_completed: list[tuple] = []
+
+    def fake_update(job_id, **fields):
+        recorded_updates.append({"job_id": job_id, **fields})
+
+    def fake_mark_running(job_id):
+        recorded_running.append(job_id)
+
+    def fake_add_completed(job_id, phase, result):
+        recorded_completed.append((job_id, phase, result))
+
+    class _FakeEnv:
+        def model_dump(self):
+            return {"container_id": "abc", "workspace_path": "/workspace"}
+
+    class _FakeSetupResult:
+        success = True
+        environment = _FakeEnv()
+        error = None
+
+    class _FakeManifest:
+        tools = []
+
+    class _FakeOrch:
+        environment_store = MagicMock()
+        tool_agents = {"docker_provisioner": MagicMock()}
+        credential_store = MagicMock()
+
+    with (
+        patch(
+            "agent_provisioning_team.shared.job_store.update_job",
+            side_effect=fake_update,
+        ),
+        patch(
+            "agent_provisioning_team.shared.job_store.mark_job_running",
+            side_effect=fake_mark_running,
+        ),
+        patch(
+            "agent_provisioning_team.shared.job_store.add_completed_phase",
+            side_effect=fake_add_completed,
+        ),
+        patch(
+            "agent_provisioning_team.phases.setup.run_setup",
+            return_value=_FakeSetupResult(),
+        ),
+        patch.object(
+            t_acts,
+            "_load_ctx",
+            return_value=(_FakeOrch(), _FakeManifest(), "standard"),
+        ),
+        # activity.heartbeat raises outside a live Temporal context; stub it.
+        patch("temporalio.activity.heartbeat"),
+    ):
+        payload = t_acts.setup_activity_v2("job-progress-1", "agent-1", "default.yaml", "standard")
+
+    assert payload["success"] is True
+    assert recorded_running == ["job-progress-1"]
+    assert any(
+        u.get("current_phase") == "setup" and u.get("progress") is not None
+        for u in recorded_updates
+    ), f"expected a setup/progress update, got {recorded_updates}"
+    assert recorded_completed and recorded_completed[0][1] == "setup"
+
+
+def test_setup_activity_v2_restores_prior_snapshot_without_running_setup() -> None:
+    """When prior_setup is passed, skip the real run_setup and return the restored payload."""
+    from agent_provisioning_team.temporal import activities as t_acts
+
+    recorded_updates: list[dict] = []
+
+    with (
+        patch(
+            "agent_provisioning_team.shared.job_store.update_job",
+            side_effect=lambda job_id, **f: recorded_updates.append({"job_id": job_id, **f}),
+        ),
+        patch(
+            "agent_provisioning_team.shared.job_store.mark_job_running",
+        ),
+        patch("agent_provisioning_team.phases.setup.run_setup") as real_setup,
+        patch.object(t_acts, "_load_ctx") as load_ctx,
+    ):
+        prior = {"success": True, "environment": None}
+        payload = t_acts.setup_activity_v2(
+            "job-resume", "agent-x", "default.yaml", "standard", prior_setup=prior
+        )
+
+    assert payload == {"success": True, "environment": None}
+    real_setup.assert_not_called()
+    load_ctx.assert_not_called()
+    assert any(u.get("status_text", "").startswith("Restored") for u in recorded_updates)
+
+
+def test_pattern_a_exports_workflows_and_activities() -> None:
+    import agent_provisioning_team.temporal as t
+    from agent_provisioning_team.temporal.activities import (
+        audit_activity_v2,
+        credentials_activity_v2,
+        deliver_activity_v2,
+        documentation_activity_v2,
+        provision_tool_activity,
+        setup_activity_v2,
+    )
+    from agent_provisioning_team.temporal.workflows import (
+        AgentProvisioningWorkflow,
+        AgentProvisioningWorkflowV2,
+    )
+
+    assert AgentProvisioningWorkflow in t.WORKFLOWS
+    assert AgentProvisioningWorkflowV2 in t.WORKFLOWS
+    for fn in (
+        setup_activity_v2,
+        credentials_activity_v2,
+        provision_tool_activity,
+        audit_activity_v2,
+        documentation_activity_v2,
+        deliver_activity_v2,
+    ):
+        assert fn in t.ACTIVITIES, f"{fn.__name__} missing from ACTIVITIES"

--- a/backend/agents/shared_temporal/teams_registry.py
+++ b/backend/agents/shared_temporal/teams_registry.py
@@ -31,6 +31,7 @@ TEAM_TEMPORAL_MODULES: dict[str, str] = {
     "agentic_team_provisioning": "agentic_team_provisioning.temporal",
     "deepthought": "deepthought.temporal",
     "coding_team": "coding_team.temporal",
+    "agent_provisioning": "agent_provisioning_team.temporal",
 }
 
 


### PR DESCRIPTION
Closes #292.

## Summary

- Extend `AgentProvisioningWorkflowV2` with `skip_phases` / `prior_results` so `/resume` and `/restart` reach parity with the V1 thread path (mirrors `orchestrator.run_workflow`'s whole-phase skip semantics).
- Close the V1/V2 feature gap by adding `audit_activity_v2`, `documentation_activity_v2`, `deliver_activity_v2` — V2 now runs all 6 phases instead of dropping the last 3, so flipping the default route doesn't regress output.
- Every v2 activity now takes `job_id` as its first argument and writes `current_phase` / `progress` / `status_text` directly to the job store via `update_job(...)`. `GET /provision/status/{job_id}` shows live progress on the Temporal path — no signal plumbing, matches SE team's pattern.
- `api/main.py` routes `/provision`, `/resume`, `/restart` through `start_provisioning_workflow` (V2) when `TEMPORAL_ADDRESS` is set. `PROVISION_THREAD_FALLBACK=1` forces the legacy thread path for rollback.
- Pattern A alignment: `temporal/__init__.py` exports `WORKFLOWS` / `ACTIVITIES` and self-boots via `start_team_worker` at import; `TEAM_TEMPORAL_MODULES` in `shared_temporal/teams_registry.py` now includes `agent_provisioning`. Removed the manual `start_agent_provisioning_temporal_worker_thread` bootstrap.

## Files

- `backend/agents/agent_provisioning_team/temporal/workflows.py` — V2 signature gains `skip_phases` / `prior_results`; SETUP → CREDENTIAL_GENERATION → ACCOUNT_PROVISIONING (fan-out) → ACCESS_AUDIT → DOCUMENTATION → DELIVER.
- `backend/agents/agent_provisioning_team/temporal/activities.py` — 3 new v2 activities; all v2 activities gain `job_id` + optional `prior_*` and call `update_job` / `mark_job_running` / `add_completed_phase` / `mark_job_completed`.
- `backend/agents/agent_provisioning_team/temporal/start_workflow.py` — always targets V2; forwards `skip_phases` / `prior_results`; uses `shared_temporal` client handle so the Pattern A worker and starter agree on the client.
- `backend/agents/agent_provisioning_team/temporal/__init__.py` — Pattern A exports + auto-boot.
- `backend/agents/agent_provisioning_team/temporal/worker.py` — removed manual `start_agent_provisioning_temporal_worker_thread`; `create_agent_provisioning_worker` retained for tests/diagnostics.
- `backend/agents/agent_provisioning_team/api/main.py` — `_load_temporal_routing()` + `_provision_thread_fallback()` + V2 routing for all three endpoints.
- `backend/agents/shared_temporal/teams_registry.py` — registers `agent_provisioning`.
- `backend/agents/agent_provisioning_team/tests/test_temporal_integration.py` — **new**, 6 cases.

## Test plan

- [x] `ruff check agents/agent_provisioning_team/ agents/shared_temporal/` — clean.
- [x] `ruff format --check` — clean for all touched files.
- [x] `pytest agents/agent_provisioning_team/tests/` — 111 passed (6 new + 105 existing, incl. `test_api.py` unchanged).
- [x] `test_provision_routes_to_v2_when_temporal_enabled` — `/provision` calls `start_provisioning_workflow` with `skip_phases=None, prior_results=None` when `is_temporal_enabled=True`.
- [x] `test_resume_passes_skip_phases_and_prior_results` — `/resume` forwards completed phases + phase results to V2.
- [x] `test_provision_falls_back_to_thread_path_when_flag_set` — `PROVISION_THREAD_FALLBACK=1` routes to the executor even when Temporal is on.
- [x] `test_setup_activity_v2_writes_progress_via_update_job` — direct activity invocation pushes `current_phase="setup"` + progress into `job_store`.
- [x] `test_setup_activity_v2_restores_prior_snapshot_without_running_setup` — `prior_setup` short-circuits the real `run_setup`.
- [x] `test_pattern_a_exports_workflows_and_activities` — `WORKFLOWS` / `ACTIVITIES` surface the 2 workflows + 8 activities.
- [ ] Local Temporal smoke against a running server (opt-in; documented in the plan's Verification section — not runnable in CI without a Temporal instance): kill the worker mid-run and confirm `/resume` skips completed phases; confirm `PROVISION_THREAD_FALLBACK=1` bypasses Temporal entirely.

## Non-goals (deferred)

- Per-tool skip/resume inside the ACCOUNT_PROVISIONING fan-out (V2 mirrors V1's whole-phase skip; per-tool granularity is out of scope).
- `run_idempotent` compensation-hook API (tracked separately in #295).
- Retiring the v1 `AgentProvisioningWorkflow` — kept registered so in-flight workflows can drain during deploy.

---
_Generated by [Claude Code](https://claude.ai/code/session_016cyboqB6i5zuddcDWEZG49)_