### PR TITLE
agent_provisioning: per-tool compensation-hook registration API

### DIFF
--- a/backend/agents/agent_provisioning_team/orchestrator.py
+++ b/backend/agents/agent_provisioning_team/orchestrator.py
@@ -337,10 +337,38 @@ class ProvisioningOrchestrator:
                     "Compensation: no provisioner registered for key=%s", key
                 )
                 continue
+            # Prefer persisted per-step compensations when the provisioner
+            # registered any during `_do_provision`: replay in LIFO order,
+            # then drop the whole state row. Provisioners that register
+            # nothing keep the legacy whole-tool `deprovision()` fallback.
+            records: List[Any] = []
             try:
-                provisioner.deprovision(agent_id)
-            except Exception:  # noqa: BLE001 — best-effort cleanup
-                logger.exception("Compensation: deprovision failed for %s", key)
+                records = list(provisioner.list_compensations(agent_id))
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "Compensation: could not read records for %s; falling back to deprovision",
+                    key,
+                )
+            if records:
+                for rec in reversed(records):
+                    try:
+                        provisioner.replay_compensation(agent_id, rec.kind, rec.payload)
+                    except Exception:  # noqa: BLE001 — best-effort cleanup
+                        logger.exception(
+                            "Compensation: replay failed kind=%s for %s", rec.kind, key
+                        )
+                try:
+                    provisioner.clear_compensations(agent_id)
+                    provisioner._state.delete(agent_id)
+                except Exception:  # noqa: BLE001
+                    logger.exception(
+                        "Compensation: post-replay state cleanup failed for %s", key
+                    )
+            else:
+                try:
+                    provisioner.deprovision(agent_id)
+                except Exception:  # noqa: BLE001 — best-effort cleanup
+                    logger.exception("Compensation: deprovision failed for %s", key)
 
         docker = self.tool_agents.get("docker_provisioner")
         if docker is not None:

--- a/backend/agents/agent_provisioning_team/shared/provisioner_state.py
+++ b/backend/agents/agent_provisioning_team/shared/provisioner_state.py
@@ -9,6 +9,17 @@ This module gives every provisioner a single tiny JSON-backed store, keyed
 by ``(provisioner, agent_id, resource_name)``, with file locking so two
 concurrent processes can't corrupt it. Use ``get_or_create`` to make a
 provisioner step idempotent.
+
+On-disk schema (legacy flat rows are migrated transparently on load):
+
+    {
+      "agent-uuid": {
+        "details": {...},            # what `put(agent_id, details)` stores
+        "compensations": [           # LIFO rollback records from run_idempotent
+          {"kind": "...", "payload": {...}, "created_at": 1.0}
+        ]
+      }
+    }
 """
 
 from __future__ import annotations
@@ -16,16 +27,72 @@ from __future__ import annotations
 import json
 import os
 import tempfile
+import time
 from contextlib import contextmanager
+from dataclasses import dataclass, field
 from pathlib import Path
 from threading import Lock
-from typing import Any, Callable, Dict, Iterator, Optional
+from typing import Any, Callable, Dict, Iterator, List, Optional
 
 DEFAULT_STATE_DIR = Path(
     os.environ.get("AGENT_CACHE", ".agent_cache")
 ) / "agent_provisioning_team" / "provisioner_state"
 
 _PROCESS_LOCK = Lock()
+
+
+@dataclass(frozen=True)
+class CompensationRecord:
+    """Serializable per-step rollback record.
+
+    Provisioners register these from inside ``create(...)`` as each
+    side effect lands, so that a later failure (including a full process
+    crash) can replay the rollback in LIFO order. ``payload`` must be
+    JSON-serializable; this is enforced at construction time.
+    """
+
+    kind: str
+    payload: Dict[str, Any]
+    created_at: float = field(default_factory=time.time)
+
+    def __post_init__(self) -> None:
+        # Fail fast on non-serializable payloads (lambdas, objects) — we
+        # want the error at registration time, not at recovery time when
+        # the original stack frame is long gone.
+        try:
+            json.dumps(self.payload)
+        except (TypeError, ValueError) as e:
+            raise ValueError(
+                f"CompensationRecord payload is not JSON-serializable: {e}"
+            ) from e
+
+    def to_json(self) -> Dict[str, Any]:
+        return {"kind": self.kind, "payload": self.payload, "created_at": self.created_at}
+
+    @classmethod
+    def from_json(cls, data: Dict[str, Any]) -> "CompensationRecord":
+        return cls(
+            kind=data["kind"],
+            payload=dict(data.get("payload") or {}),
+            created_at=float(data.get("created_at") or time.time()),
+        )
+
+
+def _as_row(raw: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Normalize an on-disk entry into the nested schema.
+
+    Legacy rows were flat (``{<details>}``); new rows are
+    ``{"details": {...}, "compensations": [...]}``. We detect legacy rows
+    by the absence of a ``"details"`` key and rewrite on read so every
+    downstream caller sees the nested shape.
+    """
+    if raw is None:
+        return {"details": {}, "compensations": []}
+    if "details" in raw and isinstance(raw["details"], dict):
+        comps = raw.get("compensations") or []
+        return {"details": raw["details"], "compensations": list(comps)}
+    # Legacy flat row — treat the whole thing as details.
+    return {"details": dict(raw), "compensations": []}
 
 
 class ProvisionerStateStore:
@@ -49,9 +116,11 @@ class ProvisionerStateStore:
         if not self.path.exists():
             return {}
         try:
-            return json.loads(self.path.read_text(encoding="utf-8")) or {}
+            raw = json.loads(self.path.read_text(encoding="utf-8")) or {}
         except (OSError, json.JSONDecodeError):
             return {}
+        # Migrate legacy flat rows on read so every in-memory view is nested.
+        return {agent_id: _as_row(row) for agent_id, row in raw.items()}
 
     def _save(self, data: Dict[str, Dict[str, Any]]) -> None:
         # Atomic write: tempfile → fsync → rename.
@@ -84,11 +153,18 @@ class ProvisionerStateStore:
 
     # ---- Public API ----
     def get(self, agent_id: str) -> Optional[Dict[str, Any]]:
-        return self._load().get(agent_id)
+        """Return the flat details dict for ``agent_id`` (backwards-compatible)."""
+        row = self._load().get(agent_id)
+        if row is None:
+            return None
+        return dict(row["details"]) if row["details"] else None
 
     def put(self, agent_id: str, value: Dict[str, Any]) -> None:
+        """Persist details for ``agent_id``; preserves any existing compensations."""
         with self._locked() as data:
-            data[agent_id] = value
+            existing = data.get(agent_id) or {"details": {}, "compensations": []}
+            existing["details"] = dict(value)
+            data[agent_id] = existing
 
     def delete(self, agent_id: str) -> bool:
         with self._locked() as data:
@@ -98,22 +174,53 @@ class ProvisionerStateStore:
             return False
 
     def list_agents(self) -> Dict[str, Dict[str, Any]]:
-        return dict(self._load())
+        """Return every agent's flat details dict (legacy shape preserved)."""
+        return {aid: dict(row["details"]) for aid, row in self._load().items() if row["details"]}
 
     def get_or_create(
         self,
         agent_id: str,
         creator: Callable[[], Dict[str, Any]],
     ) -> Dict[str, Any]:
-        """Return existing record for agent, or run ``creator`` and store it.
+        """Return existing details for agent, or run ``creator`` and store them.
 
         ``creator`` is invoked at most once per (provisioner, agent_id) and
         is the place where the actual side-effecting resource creation
-        happens. If ``creator`` raises, nothing is persisted.
+        happens. If ``creator`` raises, nothing is persisted. Any existing
+        compensation records for the agent are preserved across this call.
         """
         with self._locked() as data:
-            if agent_id in data:
-                return data[agent_id]
+            existing = data.get(agent_id)
+            if existing is not None and existing["details"]:
+                return dict(existing["details"])
             value = creator()
-            data[agent_id] = value
+            row = existing or {"details": {}, "compensations": []}
+            row["details"] = dict(value)
+            data[agent_id] = row
             return value
+
+    # ---- Compensation records ----
+    def add_compensation(self, agent_id: str, record: CompensationRecord) -> None:
+        """Append a compensation record for ``agent_id`` (write-through)."""
+        with self._locked() as data:
+            row = data.get(agent_id) or {"details": {}, "compensations": []}
+            comps: List[Dict[str, Any]] = list(row.get("compensations") or [])
+            comps.append(record.to_json())
+            row["compensations"] = comps
+            data[agent_id] = row
+
+    def list_compensations(self, agent_id: str) -> List[CompensationRecord]:
+        """Return the compensation records for ``agent_id`` in registration order."""
+        row = self._load().get(agent_id)
+        if row is None:
+            return []
+        return [CompensationRecord.from_json(c) for c in row.get("compensations") or []]
+
+    def clear_compensations(self, agent_id: str) -> None:
+        """Remove all compensation records for ``agent_id``; keep details intact."""
+        with self._locked() as data:
+            row = data.get(agent_id)
+            if row is None:
+                return
+            row["compensations"] = []
+            data[agent_id] = row

--- a/backend/agents/agent_provisioning_team/tests/test_integration_matrix.py
+++ b/backend/agents/agent_provisioning_team/tests/test_integration_matrix.py
@@ -17,8 +17,9 @@ touches Docker / Postgres / Temporal.
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Tuple
 
 import pytest
 
@@ -41,7 +42,10 @@ from agent_provisioning_team.shared.credential_store import (
     CredentialStoreConfigError,
 )
 from agent_provisioning_team.shared.llm_client import LLMClient, sanitize_prompt_var
-from agent_provisioning_team.shared.provisioner_state import ProvisionerStateStore
+from agent_provisioning_team.shared.provisioner_state import (
+    CompensationRecord,
+    ProvisionerStateStore,
+)
 from agent_provisioning_team.shared.tool_manifest import (
     ToolManifest,
     validate_manifest_environment,
@@ -54,6 +58,22 @@ from agent_provisioning_team.tool_agents.base import BaseToolProvisioner
 # ---------------------------------------------------------------------------
 
 
+class _FakeState:
+    """Minimal stand-in for ProvisionerStateStore on ``_FakeProvisioner``.
+
+    The orchestrator's compensation path calls ``provisioner._state.delete``
+    after replaying persisted records; the fake tracks that here so tests
+    can assert the row was cleaned up without hitting the filesystem.
+    """
+
+    def __init__(self) -> None:
+        self.deleted: List[str] = []
+
+    def delete(self, agent_id: str) -> bool:
+        self.deleted.append(agent_id)
+        return True
+
+
 class _FakeProvisioner(BaseToolProvisioner):
     """In-memory provisioner that records calls; can be told to fail."""
 
@@ -62,6 +82,9 @@ class _FakeProvisioner(BaseToolProvisioner):
         self.fail = fail
         self.provisioned: List[str] = []
         self.deprovisioned: List[str] = []
+        self.replays: List[Tuple[str, Dict[str, Any]]] = []
+        self._seeded_comps: Dict[str, List[CompensationRecord]] = {}
+        self._state = _FakeState()
 
     def provision(self, agent_id, config, credentials, access_tier):
         if self.fail:
@@ -83,6 +106,19 @@ class _FakeProvisioner(BaseToolProvisioner):
     def deprovision(self, agent_id):
         self.deprovisioned.append(agent_id)
         return DeprovisionResult(tool_name=self.tool_name, success=True)
+
+    # ---- Compensation-hook overrides (bypass real state store) ----
+    def seed_compensations(self, agent_id: str, records: List[CompensationRecord]) -> None:
+        self._seeded_comps[agent_id] = list(records)
+
+    def list_compensations(self, agent_id):
+        return list(self._seeded_comps.get(agent_id, []))
+
+    def clear_compensations(self, agent_id):
+        self._seeded_comps.pop(agent_id, None)
+
+    def replay_compensation(self, agent_id, kind, payload):
+        self.replays.append((kind, payload))
 
 
 # ---------------------------------------------------------------------------
@@ -534,6 +570,68 @@ class TestOrchestratorCompensation:
         )
         assert "agent-2" in docker.deprovisioned
 
+    def test_compensation_replays_registered_hooks_instead_of_deprovision(
+        self, tmp_path, monkeypatch
+    ):
+        """When a provisioner has persisted compensations the orchestrator
+        must replay them (LIFO) and **not** fall through to ``deprovision``.
+        """
+        pg = _FakeProvisioner("toola")
+        redis_ = _FakeProvisioner("toolb", fail=True)
+        docker = _FakeProvisioner("docker")
+
+        # Pre-seed two compensations on the tool that will succeed.
+        pg.seed_compensations(
+            "agent-r1",
+            [
+                CompensationRecord(kind="postgres.drop_role", payload={"username": "u1"}),
+                CompensationRecord(kind="postgres.drop_database", payload={"database": "d1"}),
+            ],
+        )
+
+        fake_agents: Dict[str, Any] = {
+            "postgres_provisioner": pg,
+            "redis_provisioner": redis_,
+            "docker_provisioner": docker,
+            "git_provisioner": _FakeProvisioner("git"),
+            "generic_provisioner": _FakeProvisioner("generic"),
+        }
+
+        from agent_provisioning_team import orchestrator as orch_mod
+
+        def _fake_run_setup(**kwargs):
+            return SetupResult(
+                success=True,
+                environment=EnvironmentInfo(
+                    container_id="c1",
+                    container_name="c1",
+                    workspace_path="/tmp/ws",
+                    status="running",
+                ),
+            )
+
+        monkeypatch.setattr(orch_mod, "run_setup", _fake_run_setup)
+
+        manifest = _write_manifest(tmp_path)
+        orch = ProvisioningOrchestrator(tool_agents=fake_agents)
+        result = orch.run_workflow(
+            agent_id="agent-r1",
+            manifest_path=manifest,
+            access_tier=AccessTier.STANDARD,
+        )
+        assert result.success is False
+
+        # Replays happened in LIFO order (drop_database registered second,
+        # replayed first) — so drop_database precedes drop_role.
+        assert [kind for kind, _ in pg.replays] == [
+            "postgres.drop_database",
+            "postgres.drop_role",
+        ]
+        # Legacy `deprovision` path was NOT taken for the compensated provisioner.
+        assert "agent-r1" not in pg.deprovisioned
+        # State row was dropped after replay.
+        assert "agent-r1" in pg._state.deleted
+
     def test_every_default_provisioner_has_registry_key_roundtrip(self):
         """Cheap invariant: every default provisioner's registry key round-trips.
 
@@ -585,3 +683,152 @@ class TestPhaseSnapshotRestore:
 
         with pytest.raises(Exception):
             restore_setup({"success": "maybe"})  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Compensation-hook registration (issue #295)
+# ---------------------------------------------------------------------------
+
+
+class _RegisteringProvisioner(BaseToolProvisioner):
+    """Minimal provisioner whose ``create`` closure registers N compensations.
+
+    Uses a real ``ProvisionerStateStore`` pointed at a caller-supplied dir so
+    tests can exercise the write-through persistence path end-to-end.
+    """
+
+    tool_name = "demo"
+
+    def __init__(self, storage_dir: Path, kinds: List[str], fail_at_end: bool = True) -> None:
+        self._state = ProvisionerStateStore("demo_provisioner", storage_dir=storage_dir)
+        self.kinds = kinds
+        self.fail_at_end = fail_at_end
+        self.replayed: List[Tuple[str, Dict[str, Any]]] = []
+
+    def provision(self, agent_id, config, credentials, access_tier):
+        def _create(register):
+            for i, kind in enumerate(self.kinds):
+                register(kind, {"i": i, "name": kind})
+            if self.fail_at_end:
+                raise RuntimeError("boom")
+            return [], {"n": len(self.kinds)}
+
+        return self.run_idempotent(agent_id, credentials=credentials, create=_create)
+
+    def verify_access(self, agent_id, expected_tier):
+        return self._make_verification(
+            passed=True, expected_tier=expected_tier, actual_permissions=[]
+        )
+
+    def deprovision(self, agent_id):
+        return DeprovisionResult(tool_name=self.tool_name, success=True)
+
+    def replay_compensation(self, agent_id, kind, payload):
+        self.replayed.append((kind, payload))
+
+
+class TestCompensationRegistration:
+    def test_registrations_persist_and_replay_in_lifo_order(self, tmp_path: Path):
+        """Register three compensations then raise from inside create.
+
+        - ``run_idempotent`` must convert the raise to an error result.
+        - The three records must be persisted write-through (a fresh store
+          instance pointed at the same dir sees them).
+        - Replaying them in reverse order walks ``["c", "b", "a"]``.
+        """
+        prov = _RegisteringProvisioner(tmp_path, kinds=["a", "b", "c"], fail_at_end=True)
+        result = prov.provision(
+            agent_id="agent-1",
+            config={},
+            credentials=GeneratedCredentials(tool_name="demo"),
+            access_tier=AccessTier.STANDARD,
+        )
+        assert result.success is False
+        assert result.error is not None and "boom" in result.error
+
+        # Fresh store instance — records survived the exception.
+        fresh = ProvisionerStateStore("demo_provisioner", storage_dir=tmp_path)
+        records = fresh.list_compensations("agent-1")
+        assert [r.kind for r in records] == ["a", "b", "c"]
+        # Payloads roundtripped cleanly.
+        assert records[0].payload == {"i": 0, "name": "a"}
+
+        # LIFO replay walks reverse order.
+        for rec in reversed(records):
+            prov.replay_compensation("agent-1", rec.kind, rec.payload)
+        assert [k for k, _ in prov.replayed] == ["c", "b", "a"]
+
+        # After a successful replay the caller clears the list.
+        fresh.clear_compensations("agent-1")
+        assert fresh.list_compensations("agent-1") == []
+
+    def test_cold_start_replay_via_orchestrator(self, tmp_path: Path, monkeypatch):
+        """A fresh provisioner instance loaded from disk must be able to
+        replay compensations registered by a prior (now-gone) instance.
+        """
+        # First instance registers; process "dies" (discarded).
+        first = _RegisteringProvisioner(tmp_path, kinds=["x1", "x2"], fail_at_end=True)
+        first.provision(
+            agent_id="agent-cold",
+            config={},
+            credentials=GeneratedCredentials(tool_name="demo"),
+            access_tier=AccessTier.STANDARD,
+        )
+
+        # Fresh instance — reads from the same storage dir.
+        second = _RegisteringProvisioner(tmp_path, kinds=["x1", "x2"], fail_at_end=False)
+
+        # Simulate the orchestrator's replay path inline (we don't need the
+        # full workflow: this is the core behaviour we're proving).
+        records = second.list_compensations("agent-cold")
+        assert [r.kind for r in records] == ["x1", "x2"]
+        for rec in reversed(records):
+            second.replay_compensation("agent-cold", rec.kind, rec.payload)
+        second.clear_compensations("agent-cold")
+        second._state.delete("agent-cold")
+
+        assert [k for k, _ in second.replayed] == ["x2", "x1"]
+        assert second.list_compensations("agent-cold") == []
+        assert second._state.get("agent-cold") is None
+
+    def test_record_rejects_non_json_payload(self):
+        with pytest.raises(ValueError, match="JSON-serializable"):
+            CompensationRecord(kind="x", payload={"f": lambda: None})  # type: ignore[dict-item]
+
+    def test_store_migrates_legacy_flat_rows_on_read(self, tmp_path: Path):
+        """Legacy on-disk rows (``{"agent-x": {<details>}}``) must be
+        transparently readable after the nested-schema migration.
+        """
+        # Hand-write a legacy flat file the store will see on _load.
+        storage = tmp_path / "state"
+        storage.mkdir()
+        legacy = {"agent-x": {"database": "db1", "username": "u1"}}
+        (storage / "demo_provisioner.json").write_text(json.dumps(legacy), encoding="utf-8")
+
+        store = ProvisionerStateStore("demo_provisioner", storage_dir=storage)
+        assert store.get("agent-x") == {"database": "db1", "username": "u1"}
+        assert store.list_compensations("agent-x") == []
+
+        # Adding a compensation now must preserve the pre-existing details.
+        store.add_compensation(
+            "agent-x", CompensationRecord(kind="demo.cleanup", payload={"k": "v"})
+        )
+        assert store.get("agent-x") == {"database": "db1", "username": "u1"}
+        comps = store.list_compensations("agent-x")
+        assert [c.kind for c in comps] == ["demo.cleanup"]
+
+    def test_put_preserves_existing_compensations(self, tmp_path: Path):
+        store = ProvisionerStateStore("demo_provisioner", storage_dir=tmp_path)
+        store.add_compensation("a1", CompensationRecord(kind="k1", payload={}))
+        store.put("a1", {"database": "db"})
+        # Both survive the round-trip.
+        assert store.get("a1") == {"database": "db"}
+        assert [c.kind for c in store.list_compensations("a1")] == ["k1"]
+
+    def test_delete_drops_whole_row(self, tmp_path: Path):
+        store = ProvisionerStateStore("demo_provisioner", storage_dir=tmp_path)
+        store.put("a1", {"database": "db"})
+        store.add_compensation("a1", CompensationRecord(kind="k1", payload={}))
+        assert store.delete("a1") is True
+        assert store.get("a1") is None
+        assert store.list_compensations("a1") == []

--- a/backend/agents/agent_provisioning_team/tool_agents/base.py
+++ b/backend/agents/agent_provisioning_team/tool_agents/base.py
@@ -4,6 +4,7 @@ Base interface for tool provisioner agents.
 All tool provisioners implement this protocol to ensure consistent behavior.
 """
 
+import logging
 import subprocess
 from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, List, Optional, Protocol, Tuple, runtime_checkable
@@ -15,6 +16,16 @@ from ..models import (
     GeneratedCredentials,
     ToolProvisionResult,
 )
+from ..shared.provisioner_state import CompensationRecord
+
+logger = logging.getLogger(__name__)
+
+# Callable passed into ``create(...)`` so provisioners can register per-step
+# rollbacks as each side effect lands. ``kind`` is a stable, provisioner-
+# namespaced string (e.g. ``"postgres.drop_database"``); ``payload`` must be
+# JSON-serializable — the record is persisted write-through so a crash
+# mid-provision can still be replayed on cold start.
+CompensationRegistrar = Callable[[str, Dict[str, Any]], None]
 
 
 @runtime_checkable
@@ -139,7 +150,7 @@ class BaseToolProvisioner(ABC):
         agent_id: str,
         *,
         credentials: GeneratedCredentials,
-        create: Callable[[], Tuple[List[str], Dict[str, Any]]],
+        create: Callable[[CompensationRegistrar], Tuple[List[str], Dict[str, Any]]],
         hydrate_extras: Tuple[str, ...] = (),
         reuse: Optional[Callable[[Dict[str, Any]], List[str]]] = None,
     ) -> ToolProvisionResult:
@@ -151,9 +162,17 @@ class BaseToolProvisioner(ABC):
 
         Contract:
 
-        * ``create()`` returns ``(permissions, details)``. ``details`` is both
-          returned in ``ToolProvisionResult.details`` and persisted as the
-          idempotency state payload. It may mutate ``credentials`` in place.
+        * ``create(register_compensation)`` returns ``(permissions, details)``.
+          ``details`` is both returned in ``ToolProvisionResult.details`` and
+          persisted as the idempotency state payload. It may mutate
+          ``credentials`` in place.
+        * ``register_compensation(kind, payload)`` records a LIFO rollback
+          step, persisted write-through. Provisioners should call it *after*
+          each destructive side effect lands (e.g. after ``CREATE DATABASE``
+          succeeds, register ``"postgres.drop_database"``). On failure the
+          orchestrator replays these in reverse via
+          :meth:`replay_compensation`; provisioners that register nothing
+          keep the legacy :meth:`deprovision` fallback.
         * On the reuse path:
           - ``hydrate_extras`` lists ``details`` keys whose stored values are
             copied into ``credentials.extra`` via ``setdefault`` — the common
@@ -168,10 +187,15 @@ class BaseToolProvisioner(ABC):
             ``stored_details.get("permissions", [])``.
         * Exceptions from infrastructure boundaries (missing binaries, subprocess
           timeouts, permission errors) are caught and converted to error results.
-          Domain validation failures should ``return self._make_error_result(...)``
-          from inside ``create``.
+          Compensation records already registered before the exception remain
+          persisted for the orchestrator to replay. Domain validation failures
+          should ``return self._make_error_result(...)`` from inside ``create``.
         """
         state = self._state
+
+        def _register(kind: str, payload: Dict[str, Any]) -> None:
+            state.add_compensation(agent_id, CompensationRecord(kind=kind, payload=payload))
+
         try:
             existing = state.get(agent_id)
             if existing is not None:
@@ -188,7 +212,7 @@ class BaseToolProvisioner(ABC):
                     details={**existing, "reused": True},
                 )
 
-            permissions, details = create()
+            permissions, details = create(_register)
             state.put(agent_id, details)
             return self._make_success_result(
                 credentials=credentials,
@@ -203,6 +227,36 @@ class BaseToolProvisioner(ABC):
             return self._make_error_result(f"{self.tool_name}: permission denied: {e}")
         except Exception as e:  # noqa: BLE001 — last-resort guard with explicit prior cases
             return self._make_error_result(f"{self.tool_name} provisioning error: {e}")
+
+    # ---- Compensation hooks ---------------------------------------------
+    def list_compensations(self, agent_id: str) -> List[CompensationRecord]:
+        """Return compensation records registered for ``agent_id``."""
+        return self._state.list_compensations(agent_id)
+
+    def clear_compensations(self, agent_id: str) -> None:
+        """Clear compensation records for ``agent_id`` (leaves details intact)."""
+        self._state.clear_compensations(agent_id)
+
+    def replay_compensation(
+        self,
+        agent_id: str,
+        kind: str,
+        payload: Dict[str, Any],
+    ) -> None:
+        """Dispatch a single compensation record back to live infrastructure.
+
+        Default: log a warning and skip. Provisioners that register
+        compensations in ``create(...)`` must override this to map each
+        ``kind`` back to the corresponding cleanup (e.g.
+        ``"postgres.drop_database"`` → terminate sessions + ``DROP DATABASE``).
+        """
+        logger.warning(
+            "%s: no replay handler for compensation kind=%r (agent=%s, payload keys=%s); skipping",
+            self.tool_name,
+            kind,
+            agent_id,
+            sorted(payload.keys()),
+        )
 
     def _make_verification(
         self,

--- a/backend/agents/agent_provisioning_team/tool_agents/docker_provisioner.py
+++ b/backend/agents/agent_provisioning_team/tool_agents/docker_provisioner.py
@@ -40,7 +40,9 @@ class DockerProvisionerTool(BaseToolProvisioner):
         return self.run_idempotent(
             agent_id,
             credentials=credentials,
-            create=lambda: self._do_provision(agent_id, config, credentials, access_tier),
+            create=lambda _register: self._do_provision(
+                agent_id, config, credentials, access_tier
+            ),
             reuse=lambda existing: self._on_reuse(existing, credentials, access_tier),
         )
 

--- a/backend/agents/agent_provisioning_team/tool_agents/generic_provisioner.py
+++ b/backend/agents/agent_provisioning_team/tool_agents/generic_provisioner.py
@@ -53,7 +53,7 @@ class GenericProvisionerTool(BaseToolProvisioner):
         return self.run_idempotent(
             agent_id,
             credentials=credentials,
-            create=lambda: self._do_provision(config, credentials, access_tier),
+            create=lambda _register: self._do_provision(config, credentials, access_tier),
             hydrate_extras=("tool_name", "config"),
         )
 

--- a/backend/agents/agent_provisioning_team/tool_agents/git_provisioner.py
+++ b/backend/agents/agent_provisioning_team/tool_agents/git_provisioner.py
@@ -47,7 +47,9 @@ class GitProvisionerTool(BaseToolProvisioner):
         return self.run_idempotent(
             agent_id,
             credentials=credentials,
-            create=lambda: self._do_provision(agent_id, config, credentials, access_tier),
+            create=lambda _register: self._do_provision(
+                agent_id, config, credentials, access_tier
+            ),
             hydrate_extras=("workspace_path", "repos"),
         )
 

--- a/backend/agents/agent_provisioning_team/tool_agents/postgres_provisioner.py
+++ b/backend/agents/agent_provisioning_team/tool_agents/postgres_provisioner.py
@@ -16,7 +16,7 @@ from ..models import (
 )
 from ..shared.access_policy import get_permissions, validate_permissions
 from ..shared.provisioner_state import ProvisionerStateStore
-from .base import BaseToolProvisioner
+from .base import BaseToolProvisioner, CompensationRegistrar
 
 try:
     import psycopg2
@@ -73,7 +73,9 @@ class PostgresProvisionerTool(BaseToolProvisioner):
         return self.run_idempotent(
             agent_id,
             credentials=credentials,
-            create=lambda: self._do_provision(agent_id, config, credentials, access_tier),
+            create=lambda register_compensation: self._do_provision(
+                agent_id, config, credentials, access_tier, register_compensation
+            ),
             reuse=lambda existing: self._on_reuse(existing, credentials, access_tier),
         )
 
@@ -83,6 +85,7 @@ class PostgresProvisionerTool(BaseToolProvisioner):
         config: Dict[str, Any],
         credentials: GeneratedCredentials,
         access_tier: AccessTier,
+        register_compensation: CompensationRegistrar,
     ) -> Tuple[List[str], Dict[str, Any]]:
         db_prefix = config.get("database_prefix", "agent_")
         db_name = f"{db_prefix}{agent_id}".replace("-", "_")[:63]
@@ -96,17 +99,23 @@ class PostgresProvisionerTool(BaseToolProvisioner):
         conn.autocommit = True
         cursor = conn.cursor()
 
+        role_existed = False
         try:
             cursor.execute(
                 sql.SQL("CREATE USER {} WITH PASSWORD %s").format(sql.Identifier(username)),
                 [password],
             )
         except psycopg2.errors.DuplicateObject:
+            role_existed = True
             cursor.execute(
                 sql.SQL("ALTER USER {} WITH PASSWORD %s").format(sql.Identifier(username)),
                 [password],
             )
+        if not role_existed:
+            # We created the role, so we own the rollback for it.
+            register_compensation("postgres.drop_role", {"username": username})
 
+        db_existed = False
         try:
             cursor.execute(
                 sql.SQL("CREATE DATABASE {} OWNER {}").format(
@@ -115,7 +124,11 @@ class PostgresProvisionerTool(BaseToolProvisioner):
                 )
             )
         except psycopg2.errors.DuplicateDatabase:
-            pass
+            db_existed = True
+        if not db_existed:
+            # Registered second so LIFO replay drops the DB before the role
+            # (the DB is owned by the role — required ordering).
+            register_compensation("postgres.drop_database", {"database": db_name})
 
         permissions = get_permissions("postgresql", access_tier)
         self._apply_permissions(cursor, db_name, username, permissions)
@@ -237,19 +250,8 @@ class PostgresProvisionerTool(BaseToolProvisioner):
             db_name = prov_info["database"]
             username = prov_info["username"]
 
-            cursor.execute(
-                sql.SQL("""
-                    SELECT pg_terminate_backend(pg_stat_activity.pid)
-                    FROM pg_stat_activity
-                    WHERE pg_stat_activity.datname = %s
-                    AND pid <> pg_backend_pid()
-                """),
-                [db_name],
-            )
-
-            cursor.execute(sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(db_name)))
-
-            cursor.execute(sql.SQL("DROP USER IF EXISTS {}").format(sql.Identifier(username)))
+            self._drop_database(cursor, db_name)
+            self._drop_role(cursor, username)
 
             cursor.close()
             conn.close()
@@ -271,3 +273,55 @@ class PostgresProvisionerTool(BaseToolProvisioner):
                 success=False,
                 error=str(e),
             )
+
+    def replay_compensation(
+        self,
+        agent_id: str,
+        kind: str,
+        payload: Dict[str, Any],
+    ) -> None:
+        """Map a persisted compensation record back to live SQL.
+
+        Kinds (in LIFO order, matching registration):
+
+        * ``postgres.drop_database`` → terminate sessions + ``DROP DATABASE IF EXISTS``
+        * ``postgres.drop_role``     → ``DROP USER IF EXISTS``
+
+        Orchestrator iterates compensations in reverse, so the DB is always
+        dropped before the role that owns it.
+        """
+        if not HAS_PSYCOPG2:
+            raise RuntimeError("psycopg2 is not installed")
+
+        conn = self._get_admin_connection()
+        conn.autocommit = True
+        try:
+            cursor = conn.cursor()
+            try:
+                if kind == "postgres.drop_database":
+                    self._drop_database(cursor, payload["database"])
+                elif kind == "postgres.drop_role":
+                    self._drop_role(cursor, payload["username"])
+                else:
+                    super().replay_compensation(agent_id, kind, payload)
+            finally:
+                cursor.close()
+        finally:
+            conn.close()
+
+    def _drop_database(self, cursor, db_name: str) -> None:
+        cursor.execute(
+            sql.SQL(
+                """
+                SELECT pg_terminate_backend(pg_stat_activity.pid)
+                FROM pg_stat_activity
+                WHERE pg_stat_activity.datname = %s
+                AND pid <> pg_backend_pid()
+                """
+            ),
+            [db_name],
+        )
+        cursor.execute(sql.SQL("DROP DATABASE IF EXISTS {}").format(sql.Identifier(db_name)))
+
+    def _drop_role(self, cursor, username: str) -> None:
+        cursor.execute(sql.SQL("DROP USER IF EXISTS {}").format(sql.Identifier(username)))

--- a/backend/agents/agent_provisioning_team/tool_agents/redis_provisioner.py
+++ b/backend/agents/agent_provisioning_team/tool_agents/redis_provisioner.py
@@ -68,7 +68,9 @@ class RedisProvisionerTool(BaseToolProvisioner):
         return self.run_idempotent(
             agent_id,
             credentials=credentials,
-            create=lambda: self._do_provision(agent_id, config, credentials, access_tier),
+            create=lambda _register: self._do_provision(
+                agent_id, config, credentials, access_tier
+            ),
             reuse=lambda existing: self._on_reuse(existing, credentials),
         )
 


### PR DESCRIPTION
Closes #295.

Follow-up from #259. The orchestrator's compensation path previously called each provisioner's whole-tool `deprovision(agent_id)`, which forced a single entry point to unwind N side effects and had no way to recover from a crash *inside* `_do_provision` — the state file was never written, so on restart we had orphaned resources (postgres roles, docker containers, ssh keys) with nothing pointing at them.

## Summary

- Provisioners can now register per-step compensations via a registrar passed into `create(...)` inside `run_idempotent`. Records are JSON-serializable (`kind` + `payload`), persisted **write-through** in the same state file as the details payload.
- `orchestrator._compensate` replays persisted records in **LIFO order** — either in-process (exception during provision) or on cold start (process dies mid-provision, fresh instance reads records on restart).
- Provisioners that register nothing keep the legacy `deprovision()` fallback unchanged.
- Plumbing + **Postgres** ships in this PR; Docker / Redis / Git / Generic get the signature bump only and migrate in a follow-up.

## Files changed

- `shared/provisioner_state.py` — `CompensationRecord` dataclass (JSON-payload validated at construction), nested schema (`{"details": ..., "compensations": [...]}`) with transparent migration of legacy flat rows, new `add_/list_/clear_compensations`.
- `tool_agents/base.py` — `run_idempotent`'s `create` callback receives a `register_compensation(kind, payload)` registrar; default `replay_compensation` logs + skips unknown kinds; `list_compensations` / `clear_compensations` passthroughs.
- `orchestrator.py` — `_compensate` prefers persisted records (LIFO replay → clear → delete state row); falls back to `deprovision()` when none registered.
- `tool_agents/postgres_provisioner.py` — registers `postgres.drop_role` after role creation, then `postgres.drop_database` after DB creation. LIFO replay guarantees DB-drop precedes role-drop (DB is owned by role). Shared `_drop_database` / `_drop_role` helpers reused by `replay_compensation` and `deprovision`.
- `tool_agents/{docker,redis,git,generic}_provisioner.py` — signature bump only (`create(_register)`), deferred to follow-up PR.

## Test plan

- [x] `pytest agents/agent_provisioning_team/tests/test_integration_matrix.py` — **37/37 pass**, including:
  - 6 new `TestCompensationRegistration` cases: LIFO ordering, cold-start replay from disk, non-JSON payload rejection, legacy schema migration, `put` preserves compensations, `delete` drops whole row.
  - 1 new orchestrator case `test_compensation_replays_registered_hooks_instead_of_deprovision`: seeded provisioner gets replays in LIFO, not `deprovision`.
  - Existing `test_compensation_deprovisions_successful_tools` still exercises the no-compensation fallback path.
- [x] `ruff check agents/ unified_api/` — clean.
- [ ] Manual cold-start verification with Postgres running (per repo CLAUDE.md envs):
  1. Inject a temporary `raise RuntimeError(...)` in `postgres_provisioner._do_provision` after `CREATE DATABASE`.
  2. Run provisioning; observe `$AGENT_CACHE/agent_provisioning_team/provisioner_state/postgres_provisioner.json` contains `compensations` with `drop_database` + `drop_role`.
  3. Re-run provisioning; orchestrator replays in LIFO (DB first, then role), cleans the store, fresh run succeeds.
  4. Remove the injected failure.

## Follow-up

A separate issue will migrate the remaining provisioners:
- Docker → `docker.rm_container`
- Redis → `redis.acl_deluser`
- Git → `git.unlink_ssh_key` (only when `generate_ssh_key=True`; do **not** register repo creation — `git.deprovision` preserves repos by design)

https://claude.ai/code/session_01L6xJe196HAt224qB5gfMQq

---
_Generated by [Claude Code](https://claude.ai/code/session_01L6xJe196HAt224qB5gfMQq)_