### PR TITLE
branding: replace 8-tab brand preview with 5-step phase stepper

### DIFF
--- a/user-interface/src/app/components/brand-preview/brand-preview.component.html
+++ b/user-interface/src/app/components/brand-preview/brand-preview.component.html
@@ -18,21 +18,26 @@
         </span>
       </div>
     </div>
-    @if (hasOutput) {
-      <button class="save-btn" (click)="saveAsBrand.emit()">
-        <mat-icon>bookmark_add</mat-icon>
-        Save brand
-      </button>
-    }
-  </div>
-
-  <!-- Progress indicator -->
-  @if (hasMissionData && !hasOutput) {
-    <div class="progress-track">
-      <div class="progress-bar" [style.width]="completionPercent + '%'"></div>
+    <div class="header-actions">
+      @if (latestOutput?.brand_book?.content) {
+        <button
+          type="button"
+          class="brand-book-btn"
+          (click)="openBrandBook()"
+          data-testid="brand-book-btn"
+        >
+          <mat-icon>menu_book</mat-icon>
+          Brand Book
+        </button>
+      }
+      @if (hasOutput) {
+        <button type="button" class="save-btn" (click)="saveAsBrand.emit()">
+          <mat-icon>bookmark_add</mat-icon>
+          Save brand
+        </button>
+      }
     </div>
-    <div class="progress-label">{{ completionPercent }}% defined</div>
-  }
+  </div>
 
   <!-- Empty State -->
   @if (!hasContent) {
@@ -62,460 +67,419 @@
         </div>
       </div>
     </div>
-  } @else if (!hasOutput) {
-    <!-- Live Mission Preview -->
-    <div class="live-preview">
-      <!-- Foundation -->
-      @if (mission?.company_name && mission!.company_name !== 'TBD') {
-        <section class="preview-section" [@sectionEnter]>
-          <div class="section-header">
-            <div class="section-icon foundation-icon">
-              <mat-icon>domain</mat-icon>
+  } @else {
+    <!-- Phase stepper: spatial progress through the 5-phase pipeline. -->
+    <div class="phase-stepper" data-testid="phase-stepper">
+      @for (p of phases; track p.phase; let isLast = $last) {
+        <section
+          class="phase-step"
+          [class.phase-completed]="phaseStatus(p.phase) === 'completed'"
+          [class.phase-in-progress]="phaseStatus(p.phase) === 'in_progress'"
+          [class.phase-not-started]="phaseStatus(p.phase) === 'not_started'"
+          [class.phase-last]="isLast"
+          [attr.data-phase]="p.phase"
+        >
+          <div class="phase-rail">
+            <div class="phase-node">
+              <mat-icon>
+                {{ phaseStatus(p.phase) === 'completed' ? 'check' : p.icon }}
+              </mat-icon>
             </div>
-            <h3 class="section-label">Foundation</h3>
-          </div>
-          <div class="foundation-grid">
-            <div class="foundation-card">
-              <span class="field-label">Company</span>
-              <span class="field-value">{{ mission!.company_name }}</span>
-            </div>
-            @if (mission!.company_description && mission!.company_description !== 'To be discussed.') {
-              <div class="foundation-card full-width">
-                <span class="field-label">Description</span>
-                <span class="field-value">{{ mission!.company_description }}</span>
-              </div>
-            }
-            @if (mission!.target_audience && mission!.target_audience !== 'TBD') {
-              <div class="foundation-card">
-                <span class="field-label">Target audience</span>
-                <span class="field-value">{{ mission!.target_audience }}</span>
-              </div>
+            @if (!isLast) {
+              <div class="phase-connector"></div>
             }
           </div>
-        </section>
-      }
+          <div class="phase-body">
+            <header class="phase-header">
+              <h3 class="phase-label">{{ p.label }}</h3>
+              <span
+                class="phase-chip"
+                [class.chip-completed]="phaseStatus(p.phase) === 'completed'"
+                [class.chip-in-progress]="phaseStatus(p.phase) === 'in_progress'"
+                [class.chip-not-started]="phaseStatus(p.phase) === 'not_started'"
+              >
+                {{ phaseStatusLabel(p.phase) }}
+              </span>
+            </header>
 
-      <!-- Values & Differentiators -->
-      @if (missionValues.length > 0 || missionDifferentiators.length > 0) {
-        <section class="preview-section" [@sectionEnter]>
-          <div class="section-header">
-            <div class="section-icon values-icon">
-              <mat-icon>diamond</mat-icon>
-            </div>
-            <h3 class="section-label">Values &amp; Differentiators</h3>
-          </div>
-          @if (missionValues.length > 0) {
-            <div class="tag-group">
-              <span class="tag-group-label">Core values</span>
-              <div class="tag-row">
-                @for (v of missionValues; track v) {
-                  <span class="tag tag-value">{{ v }}</span>
-                }
-              </div>
-            </div>
-          }
-          @if (missionDifferentiators.length > 0) {
-            <div class="tag-group">
-              <span class="tag-group-label">Differentiators</span>
-              <div class="tag-row">
-                @for (d of missionDifferentiators; track d) {
-                  <span class="tag tag-diff">{{ d }}</span>
-                }
-              </div>
-            </div>
-          }
-        </section>
-      }
+            @if (phaseHasOutput(p.phase) || p.phase === 'strategic_core') {
+              <div class="phase-content" [@sectionEnter]>
+                @switch (p.phase) {
+                  @case ('strategic_core') {
+                    <!-- Strategic Core: mission foundation, values, codification -->
+                    @if (mission?.company_name && mission!.company_name !== 'TBD') {
+                      <div class="foundation-grid">
+                        <div class="foundation-card">
+                          <span class="field-label">Company</span>
+                          <span class="field-value">{{ mission!.company_name }}</span>
+                        </div>
+                        @if (mission!.company_description && mission!.company_description !== 'To be discussed.') {
+                          <div class="foundation-card full-width">
+                            <span class="field-label">Description</span>
+                            <span class="field-value">{{ mission!.company_description }}</span>
+                          </div>
+                        }
+                        @if (mission!.target_audience && mission!.target_audience !== 'TBD') {
+                          <div class="foundation-card">
+                            <span class="field-label">Target audience</span>
+                            <span class="field-value">{{ mission!.target_audience }}</span>
+                          </div>
+                        }
+                      </div>
+                    }
 
-      <!-- Voice -->
-      @if (mission?.desired_voice && mission!.desired_voice !== 'clear, confident, human') {
-        <section class="preview-section" [@sectionEnter]>
-          <div class="section-header">
-            <div class="section-icon voice-icon">
-              <mat-icon>record_voice_over</mat-icon>
-            </div>
-            <h3 class="section-label">Brand Voice</h3>
-          </div>
-          <div class="voice-card">
-            <p class="voice-text">{{ mission!.desired_voice }}</p>
-          </div>
-        </section>
-      }
+                    @if (missionValues.length > 0 || missionDifferentiators.length > 0) {
+                      <div class="subsection">
+                        @if (missionValues.length > 0) {
+                          <div class="tag-group">
+                            <span class="tag-group-label">Core values</span>
+                            <div class="tag-row">
+                              @for (v of missionValues; track v) {
+                                <span class="tag tag-value">{{ v }}</span>
+                              }
+                            </div>
+                          </div>
+                        }
+                        @if (missionDifferentiators.length > 0) {
+                          <div class="tag-group">
+                            <span class="tag-group-label">Differentiators</span>
+                            <div class="tag-row">
+                              @for (d of missionDifferentiators; track d) {
+                                <span class="tag tag-diff">{{ d }}</span>
+                              }
+                            </div>
+                          </div>
+                        }
+                      </div>
+                    }
 
-      <!-- Color Inspiration -->
-      @if (missionColorInspiration.length > 0) {
-        <section class="preview-section" [@sectionEnter]>
-          <div class="section-header">
-            <div class="section-icon color-icon">
-              <mat-icon>color_lens</mat-icon>
-            </div>
-            <h3 class="section-label">Color Inspiration</h3>
-          </div>
-          <div class="tag-row">
-            @for (c of missionColorInspiration; track c) {
-              <span class="tag tag-color">{{ c }}</span>
-            }
-          </div>
-        </section>
-      }
+                    @if (latestOutput?.mission_summary) {
+                      <div class="output-block">
+                        <h4 class="block-title">Summary</h4>
+                        <p class="block-text">{{ latestOutput!.mission_summary }}</p>
+                      </div>
+                    }
 
-      <!-- Color Palettes -->
-      @if (missionPalettes.length > 0) {
-        <section class="preview-section" [@sectionEnter]>
-          <div class="section-header">
-            <div class="section-icon palette-icon">
-              <mat-icon>palette</mat-icon>
-            </div>
-            <h3 class="section-label">Color Palettes</h3>
-          </div>
-          <div class="palettes-grid">
-            @for (palette of missionPalettes; track palette.name; let i = $index) {
-              <div class="palette-card" [class.palette-selected]="isPaletteSelected(i)">
-                <div class="palette-top">
-                  <span class="palette-name">{{ palette.name }}</span>
-                  @if (isPaletteSelected(i)) {
-                    <span class="selected-badge">
-                      <mat-icon>check</mat-icon>
-                      Selected
-                    </span>
+                    @if (latestOutput?.codification; as cod) {
+                      <div class="output-block">
+                        <h4 class="block-title">Positioning</h4>
+                        <p class="block-text">{{ cod.positioning_statement }}</p>
+                      </div>
+                      <div class="output-block">
+                        <h4 class="block-title">Brand promise</h4>
+                        <p class="block-text">{{ cod.brand_promise }}</p>
+                      </div>
+                      <div class="output-block">
+                        <h4 class="block-title">Narrative pillars</h4>
+                        <ul class="block-list">
+                          @for (pillar of cod.narrative_pillars; track pillar) {
+                            <li>{{ pillar }}</li>
+                          }
+                        </ul>
+                      </div>
+                    }
+
+                    @if (!hasMissionData && !latestOutput?.mission_summary && !latestOutput?.codification) {
+                      <p class="phase-empty">Start by describing your company, audience, and core values.</p>
+                    }
                   }
-                </div>
-                @if (palette.description) {
-                  <p class="palette-description">{{ palette.description }}</p>
-                }
-                <div class="swatch-strip">
-                  @for (color of palette.colors; track color) {
-                    <div class="swatch-block" [style.background]="parseColor(color)" [title]="color">
-                      <span class="swatch-hex">{{ color }}</span>
-                    </div>
+
+                  @case ('narrative_messaging') {
+                    @if (latestOutput?.writing_guidelines; as wg) {
+                      @if (mission?.desired_voice && mission!.desired_voice !== 'clear, confident, human') {
+                        <div class="voice-card">
+                          <p class="voice-text">{{ mission!.desired_voice }}</p>
+                        </div>
+                      }
+                      <div class="output-block">
+                        <h4 class="block-title">Voice principles</h4>
+                        <ul class="block-list">
+                          @for (v of wg.voice_principles; track v) {
+                            <li>{{ v }}</li>
+                          }
+                        </ul>
+                      </div>
+                      <div class="do-dont-grid">
+                        <div class="output-block do-block">
+                          <h4 class="block-title do-title">
+                            <mat-icon>check_circle</mat-icon>
+                            Do
+                          </h4>
+                          <ul class="block-list">
+                            @for (d of wg.style_dos; track d) {
+                              <li>{{ d }}</li>
+                            }
+                          </ul>
+                        </div>
+                        <div class="output-block dont-block">
+                          <h4 class="block-title dont-title">
+                            <mat-icon>cancel</mat-icon>
+                            Don't
+                          </h4>
+                          <ul class="block-list">
+                            @for (d of wg.style_donts; track d) {
+                              <li>{{ d }}</li>
+                            }
+                          </ul>
+                        </div>
+                      </div>
+                    }
                   }
-                </div>
-                @if (palette.sentiment) {
-                  <p class="palette-mood">{{ palette.sentiment }}</p>
+
+                  @case ('visual_identity') {
+                    @if (missionColorInspiration.length > 0) {
+                      <div class="subsection">
+                        <span class="tag-group-label">Color inspiration</span>
+                        <div class="tag-row">
+                          @for (c of missionColorInspiration; track c) {
+                            <span class="tag tag-color">{{ c }}</span>
+                          }
+                        </div>
+                      </div>
+                    }
+
+                    @if (missionPalettes.length > 0) {
+                      <div class="subsection">
+                        <span class="tag-group-label">Color palettes</span>
+                        <div class="palettes-grid">
+                          @for (palette of missionPalettes; track palette.name; let i = $index) {
+                            <div class="palette-card" [class.palette-selected]="isPaletteSelected(i)">
+                              <div class="palette-top">
+                                <span class="palette-name">{{ palette.name }}</span>
+                                @if (isPaletteSelected(i)) {
+                                  <span class="selected-badge">
+                                    <mat-icon>check</mat-icon>
+                                    Selected
+                                  </span>
+                                }
+                              </div>
+                              @if (palette.description) {
+                                <p class="palette-description">{{ palette.description }}</p>
+                              }
+                              <div class="swatch-strip">
+                                @for (color of palette.colors; track color) {
+                                  <div class="swatch-block" [style.background]="parseColor(color)" [title]="color">
+                                    <span class="swatch-hex">{{ color }}</span>
+                                  </div>
+                                }
+                              </div>
+                              @if (palette.sentiment) {
+                                <p class="palette-mood">{{ palette.sentiment }}</p>
+                              }
+                              <button
+                                type="button"
+                                class="palette-select-btn"
+                                [class.is-selected]="isPaletteSelected(i)"
+                                [disabled]="isPaletteSelected(i)"
+                                (click)="onSelectPalette(i)"
+                                data-testid="palette-select-btn"
+                              >
+                                <mat-icon>{{ isPaletteSelected(i) ? 'check' : 'radio_button_unchecked' }}</mat-icon>
+                                {{ isPaletteSelected(i) ? 'Selected' : 'Select this palette' }}
+                              </button>
+                            </div>
+                          }
+                        </div>
+                      </div>
+                    }
+
+                    @if (latestOutput?.mood_boards?.length) {
+                      <div class="subsection">
+                        <span class="tag-group-label">Moodboards</span>
+                        <div class="moodboard-grid">
+                          @for (mb of latestOutput!.mood_boards!; track mb.title) {
+                            <div class="moodboard-card">
+                              <h4 class="moodboard-title">{{ mb.title }}</h4>
+                              <div class="moodboard-detail">
+                                <span class="detail-label">Visual direction</span>
+                                <p>{{ mb.visual_direction }}</p>
+                              </div>
+                              @if (mb.color_story.length) {
+                                <div class="moodboard-colors">
+                                  @for (c of mb.color_story; track c) {
+                                    <div class="mini-swatch" [style.background]="parseColor(c)" [title]="c"></div>
+                                  }
+                                </div>
+                              }
+                              <div class="moodboard-detail">
+                                <span class="detail-label">Typography</span>
+                                <p>{{ mb.typography_direction }}</p>
+                              </div>
+                              @if (mb.image_style.length) {
+                                <div class="moodboard-detail">
+                                  <span class="detail-label">Image style</span>
+                                  <div class="tag-row compact">
+                                    @for (s of mb.image_style; track s) {
+                                      <span class="tag tag-muted">{{ s }}</span>
+                                    }
+                                  </div>
+                                </div>
+                              }
+                            </div>
+                          }
+                        </div>
+                      </div>
+                    }
+
+                    @if (latestOutput?.design_system; as ds) {
+                      <div class="subsection">
+                        <div class="output-block">
+                          <h4 class="block-title">Design principles</h4>
+                          <ul class="block-list">
+                            @for (pr of ds.design_principles; track pr) {
+                              <li>{{ pr }}</li>
+                            }
+                          </ul>
+                        </div>
+                        <div class="output-block">
+                          <h4 class="block-title">Foundation tokens</h4>
+                          <ul class="block-list">
+                            @for (t of ds.foundation_tokens; track t) {
+                              <li>{{ t }}</li>
+                            }
+                          </ul>
+                        </div>
+                        <div class="output-block">
+                          <h4 class="block-title">Component standards</h4>
+                          <ul class="block-list">
+                            @for (c of ds.component_standards; track c) {
+                              <li>{{ c }}</li>
+                            }
+                          </ul>
+                        </div>
+                      </div>
+                    }
+
+                    @if (mission?.visual_style || mission?.typography_preference || mission?.interface_density) {
+                      <div class="foundation-grid subsection">
+                        @if (mission!.visual_style) {
+                          <div class="foundation-card">
+                            <span class="field-label">Style</span>
+                            <span class="field-value">{{ mission!.visual_style }}</span>
+                          </div>
+                        }
+                        @if (mission!.typography_preference) {
+                          <div class="foundation-card">
+                            <span class="field-label">Typography</span>
+                            <span class="field-value">{{ mission!.typography_preference }}</span>
+                          </div>
+                        }
+                        @if (mission!.interface_density) {
+                          <div class="foundation-card">
+                            <span class="field-label">Layout density</span>
+                            <span class="field-value">{{ mission!.interface_density }}</span>
+                          </div>
+                        }
+                      </div>
+                    }
+                  }
+
+                  @case ('channel_activation') {
+                    @if (latestOutput?.creative_refinement; as cr) {
+                      @if (cr.phases.length) {
+                        <div class="output-block">
+                          <h4 class="block-title">Creative phases</h4>
+                          <ul class="block-list">
+                            @for (ph of cr.phases; track ph) {
+                              <li>{{ ph }}</li>
+                            }
+                          </ul>
+                        </div>
+                      }
+                      @if (cr.workshop_prompts.length) {
+                        <div class="output-block">
+                          <h4 class="block-title">Workshop prompts</h4>
+                          <ul class="block-list">
+                            @for (wp of cr.workshop_prompts; track wp) {
+                              <li>{{ wp }}</li>
+                            }
+                          </ul>
+                        </div>
+                      }
+                      @if (cr.decision_criteria.length) {
+                        <div class="output-block">
+                          <h4 class="block-title">Decision criteria</h4>
+                          <ul class="block-list">
+                            @for (dc of cr.decision_criteria; track dc) {
+                              <li>{{ dc }}</li>
+                            }
+                          </ul>
+                        </div>
+                      }
+                    }
+                    @if (latestOutput?.design_asset_result; as dar) {
+                      <div class="output-block">
+                        <h4 class="block-title">Design assets</h4>
+                        <p class="block-text">
+                          Request {{ dar.request_id }} · {{ dar.status }} · {{ dar.artifacts.length }} artifact(s)
+                        </p>
+                      </div>
+                    }
+                  }
+
+                  @case ('governance') {
+                    @if (latestOutput?.brand_guidelines?.length) {
+                      <div class="output-block">
+                        <h4 class="block-title">Brand guidelines</h4>
+                        <ul class="block-list">
+                          @for (g of latestOutput!.brand_guidelines; track g) {
+                            <li>{{ g }}</li>
+                          }
+                        </ul>
+                      </div>
+                    }
+                    @if (latestOutput?.wiki_backlog?.length) {
+                      <div class="output-block">
+                        <h4 class="block-title">Wiki backlog</h4>
+                        <ul class="block-list">
+                          @for (w of latestOutput!.wiki_backlog!; track w.title) {
+                            <li>
+                              <strong>{{ w.title }}</strong> — {{ w.summary }}
+                              <span class="wiki-meta">({{ w.update_cadence }})</span>
+                            </li>
+                          }
+                        </ul>
+                      </div>
+                    }
+                  }
                 }
               </div>
             }
-          </div>
-        </section>
-      }
-
-      <!-- Visual Style -->
-      @if (mission?.visual_style || mission?.interface_density) {
-        <section class="preview-section" [@sectionEnter]>
-          <div class="section-header">
-            <div class="section-icon style-icon">
-              <mat-icon>dashboard_customize</mat-icon>
-            </div>
-            <h3 class="section-label">Visual Style</h3>
-          </div>
-          <div class="foundation-grid">
-            @if (mission!.visual_style) {
-              <div class="foundation-card">
-                <span class="field-label">Style</span>
-                <span class="field-value">{{ mission!.visual_style }}</span>
-              </div>
-            }
-            @if (mission!.interface_density) {
-              <div class="foundation-card">
-                <span class="field-label">Layout density</span>
-                <span class="field-value">{{ mission!.interface_density }}</span>
-              </div>
-            }
-          </div>
-        </section>
-      }
-
-      <!-- Typography -->
-      @if (mission?.typography_preference) {
-        <section class="preview-section" [@sectionEnter]>
-          <div class="section-header">
-            <div class="section-icon type-icon">
-              <mat-icon>format_size</mat-icon>
-            </div>
-            <h3 class="section-label">Typography</h3>
-          </div>
-          <div class="voice-card">
-            <p class="voice-text">{{ mission!.typography_preference }}</p>
           </div>
         </section>
       }
     </div>
-  } @else {
-    <!-- Full Output — Tabbed View -->
-    <mat-tab-group class="output-tabs" animationDuration="200ms">
-      <mat-tab>
-        <ng-template mat-tab-label>
-          <mat-icon>summarize</mat-icon>
-          <span>Summary</span>
-        </ng-template>
-        <div class="tab-body">
-          @if (latestOutput?.mission_summary) {
-            <p class="summary-text">{{ latestOutput!.mission_summary }}</p>
-          } @else {
-            <div class="empty-tab">
-              <mat-icon>summarize</mat-icon>
-              <p>Your brand summary will be created during the strategic core phase, where your mission, positioning, and brand promise are defined.</p>
-            </div>
-          }
-        </div>
-      </mat-tab>
+  }
 
-      <mat-tab>
-        <ng-template mat-tab-label>
-          <mat-icon>hub</mat-icon>
-          <span>Codification</span>
-        </ng-template>
-        @if (latestOutput?.codification; as cod) {
-          <div class="tab-body">
-            <div class="output-block">
-              <h4 class="block-title">Positioning</h4>
-              <p class="block-text">{{ cod.positioning_statement }}</p>
-            </div>
-            <div class="output-block">
-              <h4 class="block-title">Brand promise</h4>
-              <p class="block-text">{{ cod.brand_promise }}</p>
-            </div>
-            <div class="output-block">
-              <h4 class="block-title">Narrative pillars</h4>
-              <ul class="block-list">
-                @for (p of cod.narrative_pillars; track p) {
-                  <li>{{ p }}</li>
-                }
-              </ul>
-            </div>
+  <!-- Brand Book overlay: viewer + download, triggered from the header action. -->
+  @if (brandBookOpen && latestOutput?.brand_book?.content; as content) {
+    <div
+      class="brand-book-overlay"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Brand book"
+      data-testid="brand-book-overlay"
+    >
+      <div class="brand-book-dialog">
+        <header class="brand-book-dialog-header">
+          <h3>Brand Book</h3>
+          <div class="brand-book-dialog-actions">
+            <button type="button" class="brand-book-download" (click)="downloadBrandBook()">
+              <mat-icon>download</mat-icon>
+              Download
+            </button>
+            <button
+              type="button"
+              class="brand-book-close"
+              (click)="closeBrandBook()"
+              aria-label="Close brand book"
+            >
+              <mat-icon>close</mat-icon>
+            </button>
           </div>
-        } @else {
-          <div class="tab-body">
-            <div class="empty-tab">
-              <mat-icon>hub</mat-icon>
-              <p>Brand codification — positioning, promise, and narrative pillars — will be generated during the strategic core phase.</p>
-            </div>
-          </div>
-        }
-      </mat-tab>
-
-      <mat-tab>
-        <ng-template mat-tab-label>
-          <mat-icon>dashboard</mat-icon>
-          <span>Moodboards</span>
-        </ng-template>
-        <div class="tab-body">
-          @if (latestOutput?.mood_boards?.length) {
-            <div class="moodboard-grid">
-              @for (mb of latestOutput!.mood_boards!; track mb.title) {
-                <div class="moodboard-card">
-                  <h4 class="moodboard-title">{{ mb.title }}</h4>
-                  <div class="moodboard-detail">
-                    <span class="detail-label">Visual direction</span>
-                    <p>{{ mb.visual_direction }}</p>
-                  </div>
-                  @if (mb.color_story.length) {
-                    <div class="moodboard-colors">
-                      @for (c of mb.color_story; track c) {
-                        <div class="mini-swatch" [style.background]="parseColor(c)" [title]="c"></div>
-                      }
-                    </div>
-                  }
-                  <div class="moodboard-detail">
-                    <span class="detail-label">Typography</span>
-                    <p>{{ mb.typography_direction }}</p>
-                  </div>
-                  @if (mb.image_style.length) {
-                    <div class="moodboard-detail">
-                      <span class="detail-label">Image style</span>
-                      <div class="tag-row compact">
-                        @for (s of mb.image_style; track s) {
-                          <span class="tag tag-muted">{{ s }}</span>
-                        }
-                      </div>
-                    </div>
-                  }
-                </div>
-              }
-            </div>
-          } @else {
-            <div class="empty-tab">
-              <mat-icon>dashboard</mat-icon>
-              <p>Moodboards with visual direction, color stories, and typography guidance will be created during the visual identity phase.</p>
-            </div>
-          }
-        </div>
-      </mat-tab>
-
-      <mat-tab>
-        <ng-template mat-tab-label>
-          <mat-icon>palette</mat-icon>
-          <span>Colors</span>
-        </ng-template>
-        <div class="tab-body">
-          @if (selectedPalette) {
-            <div class="palette-card palette-selected featured">
-              <div class="palette-top">
-                <span class="palette-name">{{ selectedPalette.name }}</span>
-                <span class="selected-badge">
-                  <mat-icon>check</mat-icon>
-                  Active
-                </span>
-              </div>
-              <div class="swatch-strip large">
-                @for (color of selectedPalette.colors; track color) {
-                  <div class="swatch-block" [style.background]="parseColor(color)" [title]="color">
-                    <span class="swatch-hex">{{ color }}</span>
-                  </div>
-                }
-              </div>
-              @if (selectedPalette.sentiment) {
-                <p class="palette-mood">{{ selectedPalette.sentiment }}</p>
-              }
-            </div>
-          }
-          @if (colorStories.length) {
-            <h4 class="block-title">Color stories</h4>
-            <div class="color-story-strip">
-              @for (c of colorStories; track c) {
-                <div class="story-swatch" [style.background]="parseColor(c)" [title]="c"></div>
-              }
-            </div>
-          } @else if (!selectedPalette) {
-            <div class="empty-tab">
-              <mat-icon>palette</mat-icon>
-              <p>Your color palette and color stories will be generated during the visual identity phase, alongside moodboards and typography.</p>
-            </div>
-          }
-        </div>
-      </mat-tab>
-
-      <mat-tab>
-        <ng-template mat-tab-label>
-          <mat-icon>edit_note</mat-icon>
-          <span>Writing</span>
-        </ng-template>
-        @if (latestOutput?.writing_guidelines; as wg) {
-          <div class="tab-body">
-            <div class="output-block">
-              <h4 class="block-title">Voice principles</h4>
-              <ul class="block-list">
-                @for (v of wg.voice_principles; track v) {
-                  <li>{{ v }}</li>
-                }
-              </ul>
-            </div>
-            <div class="do-dont-grid">
-              <div class="output-block do-block">
-                <h4 class="block-title do-title">
-                  <mat-icon>check_circle</mat-icon>
-                  Do
-                </h4>
-                <ul class="block-list">
-                  @for (d of wg.style_dos; track d) {
-                    <li>{{ d }}</li>
-                  }
-                </ul>
-              </div>
-              <div class="output-block dont-block">
-                <h4 class="block-title dont-title">
-                  <mat-icon>cancel</mat-icon>
-                  Don't
-                </h4>
-                <ul class="block-list">
-                  @for (d of wg.style_donts; track d) {
-                    <li>{{ d }}</li>
-                  }
-                </ul>
-              </div>
-            </div>
-          </div>
-        } @else {
-          <div class="tab-body">
-            <div class="empty-tab">
-              <mat-icon>edit_note</mat-icon>
-              <p>Voice principles and writing style guidelines will be crafted during the narrative and messaging phase.</p>
-            </div>
-          </div>
-        }
-      </mat-tab>
-
-      <mat-tab>
-        <ng-template mat-tab-label>
-          <mat-icon>design_services</mat-icon>
-          <span>Design</span>
-        </ng-template>
-        @if (latestOutput?.design_system; as ds) {
-          <div class="tab-body">
-            <div class="output-block">
-              <h4 class="block-title">Design principles</h4>
-              <ul class="block-list">
-                @for (p of ds.design_principles; track p) {
-                  <li>{{ p }}</li>
-                }
-              </ul>
-            </div>
-            <div class="output-block">
-              <h4 class="block-title">Foundation tokens</h4>
-              <ul class="block-list">
-                @for (t of ds.foundation_tokens; track t) {
-                  <li>{{ t }}</li>
-                }
-              </ul>
-            </div>
-            <div class="output-block">
-              <h4 class="block-title">Component standards</h4>
-              <ul class="block-list">
-                @for (c of ds.component_standards; track c) {
-                  <li>{{ c }}</li>
-                }
-              </ul>
-            </div>
-          </div>
-        } @else {
-          <div class="tab-body">
-            <div class="empty-tab">
-              <mat-icon>design_services</mat-icon>
-              <p>Design principles, tokens, and component standards will be defined during the visual identity phase.</p>
-            </div>
-          </div>
-        }
-      </mat-tab>
-
-      <mat-tab>
-        <ng-template mat-tab-label>
-          <mat-icon>menu_book</mat-icon>
-          <span>Guidelines</span>
-        </ng-template>
-        <div class="tab-body">
-          @if (latestOutput?.brand_guidelines?.length) {
-            <ul class="block-list">
-              @for (g of latestOutput!.brand_guidelines; track g) {
-                <li>{{ g }}</li>
-              }
-            </ul>
-          } @else {
-            <div class="empty-tab">
-              <mat-icon>menu_book</mat-icon>
-              <p>Brand guidelines covering usage rules and approval workflows will be produced during the governance phase.</p>
-            </div>
-          }
-        </div>
-      </mat-tab>
-
-      <mat-tab>
-        <ng-template mat-tab-label>
-          <mat-icon>auto_stories</mat-icon>
-          <span>Brand Book</span>
-        </ng-template>
-        @if (latestOutput?.brand_book?.content; as content) {
-          <div class="tab-body">
-            <div class="brand-book-prose">{{ content }}</div>
-          </div>
-        } @else {
-          <div class="tab-body">
-            <div class="empty-tab">
-              <mat-icon>auto_stories</mat-icon>
-              <p>The complete brand book will be compiled during the governance phase, bringing together all elements of your brand identity.</p>
-            </div>
-          </div>
-        }
-      </mat-tab>
-    </mat-tab-group>
+        </header>
+        <pre class="brand-book-prose">{{ content }}</pre>
+      </div>
+    </div>
   }
 </div>

--- a/user-interface/src/app/components/brand-preview/brand-preview.component.html
+++ b/user-interface/src/app/components/brand-preview/brand-preview.component.html
@@ -71,19 +71,19 @@
     <!-- Phase stepper: spatial progress through the 5-phase pipeline. -->
     <div class="phase-stepper" data-testid="phase-stepper">
       @for (p of phases; track p.phase; let isLast = $last) {
+        @let status = phaseStatus(p.phase);
+        @let hasContent = phaseHasOutput(p.phase) || p.phase === 'strategic_core';
         <section
           class="phase-step"
-          [class.phase-completed]="phaseStatus(p.phase) === 'completed'"
-          [class.phase-in-progress]="phaseStatus(p.phase) === 'in_progress'"
-          [class.phase-not-started]="phaseStatus(p.phase) === 'not_started'"
+          [class.phase-completed]="status === 'completed'"
+          [class.phase-in-progress]="status === 'in_progress'"
+          [class.phase-not-started]="status === 'not_started'"
           [class.phase-last]="isLast"
           [attr.data-phase]="p.phase"
         >
           <div class="phase-rail">
             <div class="phase-node">
-              <mat-icon>
-                {{ phaseStatus(p.phase) === 'completed' ? 'check' : p.icon }}
-              </mat-icon>
+              <mat-icon>{{ status === 'completed' ? 'check' : p.icon }}</mat-icon>
             </div>
             @if (!isLast) {
               <div class="phase-connector"></div>
@@ -94,15 +94,15 @@
               <h3 class="phase-label">{{ p.label }}</h3>
               <span
                 class="phase-chip"
-                [class.chip-completed]="phaseStatus(p.phase) === 'completed'"
-                [class.chip-in-progress]="phaseStatus(p.phase) === 'in_progress'"
-                [class.chip-not-started]="phaseStatus(p.phase) === 'not_started'"
+                [class.chip-completed]="status === 'completed'"
+                [class.chip-in-progress]="status === 'in_progress'"
+                [class.chip-not-started]="status === 'not_started'"
               >
                 {{ phaseStatusLabel(p.phase) }}
               </span>
             </header>
 
-            @if (phaseHasOutput(p.phase) || p.phase === 'strategic_core') {
+            @if (hasContent) {
               <div class="phase-content" [@sectionEnter]>
                 @switch (p.phase) {
                   @case ('strategic_core') {

--- a/user-interface/src/app/components/brand-preview/brand-preview.component.scss
+++ b/user-interface/src/app/components/brand-preview/brand-preview.component.scss
@@ -39,7 +39,6 @@ $radius-lg: 16px;
     border-color: $border-default;
   }
 
-  // Ambient glow at top
   &::before {
     content: '';
     position: absolute;
@@ -65,12 +64,20 @@ $radius-lg: 16px;
   padding: 16px 20px;
   border-bottom: 1px solid $border-subtle;
   flex-shrink: 0;
+  gap: 12px;
 }
 
 .header-left {
   display: flex;
   align-items: center;
   gap: 12px;
+  min-width: 0;
+}
+
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 
 .header-icon {
@@ -111,15 +118,13 @@ $radius-lg: 16px;
   }
 }
 
-.save-btn {
+.save-btn,
+.brand-book-btn {
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 8px 16px;
+  padding: 8px 14px;
   border-radius: $radius-sm;
-  border: 1px solid rgba($accent-blue, 0.3);
-  background: rgba($accent-blue, 0.08);
-  color: $accent-blue;
   font-size: 0.8125rem;
   font-weight: 500;
   cursor: pointer;
@@ -130,6 +135,12 @@ $radius-lg: 16px;
     width: 18px;
     height: 18px;
   }
+}
+
+.save-btn {
+  border: 1px solid rgba($accent-blue, 0.3);
+  background: rgba($accent-blue, 0.08);
+  color: $accent-blue;
 
   &:hover {
     background: rgba($accent-blue, 0.16);
@@ -138,30 +149,16 @@ $radius-lg: 16px;
   }
 }
 
-// ---------------------------------------------------------------------------
-// Progress bar
-// ---------------------------------------------------------------------------
+.brand-book-btn {
+  border: 1px solid rgba($accent-purple, 0.3);
+  background: rgba($accent-purple, 0.08);
+  color: $accent-purple;
 
-.progress-track {
-  height: 2px;
-  background: $border-subtle;
-  overflow: hidden;
-  flex-shrink: 0;
-}
-
-.progress-bar {
-  height: 100%;
-  background: linear-gradient(90deg, $accent-blue, $accent-purple);
-  border-radius: 1px;
-  transition: width 0.6s cubic-bezier(0.23, 1, 0.32, 1);
-}
-
-.progress-label {
-  padding: 6px 20px 0;
-  font-size: 0.6875rem;
-  color: $text-muted;
-  text-align: right;
-  flex-shrink: 0;
+  &:hover {
+    background: rgba($accent-purple, 0.16);
+    border-color: rgba($accent-purple, 0.5);
+    box-shadow: 0 0 16px rgba($accent-purple, 0.15);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -288,13 +285,13 @@ $radius-lg: 16px;
 }
 
 // ---------------------------------------------------------------------------
-// Live preview
+// Phase stepper (vertical)
 // ---------------------------------------------------------------------------
 
-.live-preview {
+.phase-stepper {
   flex: 1;
   overflow-y: auto;
-  padding: 16px 20px;
+  padding: 16px 20px 24px;
 
   &::-webkit-scrollbar {
     width: 4px;
@@ -314,33 +311,37 @@ $radius-lg: 16px;
   }
 }
 
-.preview-section {
-  margin-bottom: 20px;
-  padding-bottom: 20px;
-  border-bottom: 1px solid $border-subtle;
+.phase-step {
+  display: grid;
+  grid-template-columns: 32px 1fr;
+  gap: 14px;
+  position: relative;
 
-  &:last-child {
-    border-bottom: none;
-    margin-bottom: 0;
-    padding-bottom: 0;
+  &:not(.phase-last) {
+    padding-bottom: 20px;
   }
 }
 
-.section-header {
+.phase-rail {
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 10px;
-  margin-bottom: 12px;
+  position: relative;
 }
 
-.section-icon {
-  width: 28px;
-  height: 28px;
-  border-radius: 7px;
+.phase-node {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
   display: flex;
   align-items: center;
   justify-content: center;
+  border: 2px solid $border-default;
+  background: $surface-raised;
+  color: $text-muted;
+  transition: all 0.25s;
   flex-shrink: 0;
+  z-index: 2;
 
   mat-icon {
     font-size: 16px;
@@ -348,46 +349,109 @@ $radius-lg: 16px;
     height: 16px;
   }
 
-  &.foundation-icon {
-    background: rgba($accent-blue, 0.12);
-    mat-icon { color: $accent-blue; }
+  .phase-completed & {
+    border-color: $accent-green;
+    background: rgba($accent-green, 0.15);
+    color: $accent-green;
   }
-  &.values-icon {
-    background: rgba($accent-purple, 0.12);
-    mat-icon { color: $accent-purple; }
-  }
-  &.voice-icon {
-    background: rgba($accent-teal, 0.12);
-    mat-icon { color: $accent-teal; }
-  }
-  &.color-icon {
-    background: rgba($accent-amber, 0.12);
-    mat-icon { color: $accent-amber; }
-  }
-  &.palette-icon {
-    background: rgba($accent-rose, 0.12);
-    mat-icon { color: $accent-rose; }
-  }
-  &.style-icon {
-    background: rgba($accent-green, 0.12);
-    mat-icon { color: $accent-green; }
-  }
-  &.type-icon {
-    background: rgba($accent-blue, 0.12);
-    mat-icon { color: $accent-blue; }
+
+  .phase-in-progress & {
+    border-color: $accent-blue;
+    background: rgba($accent-blue, 0.15);
+    color: $accent-blue;
+    box-shadow: 0 0 0 3px rgba($accent-blue, 0.15);
   }
 }
 
-.section-label {
-  font-size: 0.75rem;
+.phase-connector {
+  flex: 1;
+  width: 2px;
+  background: $border-default;
+  margin-top: 4px;
+  min-height: 12px;
+
+  .phase-completed & {
+    background: rgba($accent-green, 0.4);
+  }
+}
+
+.phase-body {
+  min-width: 0;
+  padding-top: 4px;
+}
+
+.phase-header {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+}
+
+.phase-label {
+  font-size: 0.9375rem;
   font-weight: 600;
-  color: $text-secondary;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  color: $text-primary;
   margin: 0;
+  letter-spacing: -0.01em;
+
+  .phase-not-started & {
+    color: $text-secondary;
+  }
 }
 
+.phase-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 10px;
+  border-radius: 20px;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  border: 1px solid;
+
+  &.chip-completed {
+    color: $accent-green;
+    background: rgba($accent-green, 0.1);
+    border-color: rgba($accent-green, 0.3);
+  }
+
+  &.chip-in-progress {
+    color: $accent-blue;
+    background: rgba($accent-blue, 0.1);
+    border-color: rgba($accent-blue, 0.3);
+  }
+
+  &.chip-not-started {
+    color: $text-muted;
+    background: rgba(255, 255, 255, 0.04);
+    border-color: $border-default;
+  }
+}
+
+.phase-content {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.phase-empty {
+  font-size: 0.8125rem;
+  color: $text-muted;
+  margin: 0;
+  line-height: 1.5;
+}
+
+.subsection {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+// ---------------------------------------------------------------------------
 // Foundation cards
+// ---------------------------------------------------------------------------
+
 .foundation-grid {
   display: grid;
   grid-template-columns: 1fr;
@@ -427,7 +491,10 @@ $radius-lg: 16px;
   line-height: 1.5;
 }
 
+// ---------------------------------------------------------------------------
 // Tags
+// ---------------------------------------------------------------------------
+
 .tag-group {
   margin-bottom: 10px;
 
@@ -488,7 +555,10 @@ $radius-lg: 16px;
   }
 }
 
-// Voice card
+// ---------------------------------------------------------------------------
+// Voice
+// ---------------------------------------------------------------------------
+
 .voice-card {
   background: $surface-raised;
   border: 1px solid $border-subtle;
@@ -506,7 +576,7 @@ $radius-lg: 16px;
 }
 
 // ---------------------------------------------------------------------------
-// Palette cards (shared live + output)
+// Palette cards
 // ---------------------------------------------------------------------------
 
 .palettes-grid {
@@ -525,10 +595,6 @@ $radius-lg: 16px;
   &.palette-selected {
     border-color: rgba($accent-green, 0.4);
     background: rgba($accent-green, 0.04);
-  }
-
-  &.featured {
-    margin-bottom: 16px;
   }
 }
 
@@ -575,10 +641,6 @@ $radius-lg: 16px;
   gap: 4px;
   border-radius: $radius-sm;
   overflow: hidden;
-
-  &.large {
-    gap: 6px;
-  }
 }
 
 .swatch-block {
@@ -596,11 +658,6 @@ $radius-lg: 16px;
     .swatch-hex {
       opacity: 1;
     }
-  }
-
-  .large & {
-    height: 56px;
-    border-radius: $radius-sm;
   }
 }
 
@@ -630,77 +687,50 @@ $radius-lg: 16px;
   margin: 8px 0 0;
 }
 
-// ---------------------------------------------------------------------------
-// Output tabs
-// ---------------------------------------------------------------------------
+.palette-select-btn {
+  margin-top: 10px;
+  width: 100%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px 12px;
+  border-radius: $radius-sm;
+  border: 1px solid $border-default;
+  background: transparent;
+  color: $text-primary;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s;
 
-.output-tabs {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  overflow: hidden;
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
 
-  ::ng-deep {
-    .mat-mdc-tab-labels {
-      padding: 0 12px;
-      gap: 2px;
-    }
+  &:hover:not(:disabled) {
+    border-color: rgba($accent-blue, 0.4);
+    background: rgba($accent-blue, 0.06);
+    color: $accent-blue;
+  }
 
-    .mat-mdc-tab {
-      min-width: 0;
-      padding: 0 10px;
-      height: 40px;
-      font-size: 0.75rem;
-
-      .mdc-tab__text-label {
-        display: flex;
-        align-items: center;
-        gap: 4px;
-        letter-spacing: 0;
-      }
-
-      mat-icon {
-        font-size: 16px;
-        width: 16px;
-        height: 16px;
-      }
-    }
-
-    .mat-mdc-tab-body-wrapper {
-      flex: 1;
-      overflow: hidden;
-    }
-
-    .mat-mdc-tab-body-content {
-      overflow-y: auto;
-      &::-webkit-scrollbar {
-        width: 4px;
-      }
-      &::-webkit-scrollbar-thumb {
-        background: rgba(255, 255, 255, 0.08);
-        border-radius: 2px;
-      }
-    }
+  &.is-selected,
+  &:disabled {
+    border-color: rgba($accent-green, 0.4);
+    background: rgba($accent-green, 0.1);
+    color: $accent-green;
+    cursor: default;
   }
 }
 
-.tab-body {
-  padding: 16px 20px;
-}
-
-.summary-text {
-  font-size: 0.9375rem;
-  line-height: 1.7;
-  color: $text-primary;
-  margin: 0;
-}
+// ---------------------------------------------------------------------------
+// Output blocks
+// ---------------------------------------------------------------------------
 
 .output-block {
-  margin-bottom: 20px;
-
-  &:last-child {
-    margin-bottom: 0;
-  }
+  margin: 0;
 }
 
 .block-title {
@@ -741,7 +771,12 @@ $radius-lg: 16px;
   }
 }
 
-// Do / Don't grid
+.wiki-meta {
+  color: $text-muted;
+  font-size: 0.75rem;
+  margin-left: 4px;
+}
+
 .do-dont-grid {
   display: grid;
   grid-template-columns: 1fr 1fr;
@@ -780,7 +815,7 @@ $radius-lg: 16px;
   }
 }
 
-// Moodboard grid
+// Moodboards
 .moodboard-grid {
   display: flex;
   flex-direction: column;
@@ -844,56 +879,97 @@ $radius-lg: 16px;
   border: 1px solid $border-default;
 }
 
-// Color stories
-.color-story-strip {
+// ---------------------------------------------------------------------------
+// Brand book overlay
+// ---------------------------------------------------------------------------
+
+.brand-book-overlay {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(4px);
   display: flex;
-  gap: 4px;
-  flex-wrap: wrap;
-}
-
-.story-swatch {
-  width: 36px;
-  height: 36px;
-  border-radius: $radius-sm;
-  border: 1px solid $border-default;
-  transition: transform 0.15s;
-
-  &:hover {
-    transform: scale(1.1);
-  }
-}
-
-// Empty tab state
-.empty-tab {
-  display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  padding: 2rem 1rem;
-  text-align: center;
-  color: $text-muted;
+  padding: 24px;
+  z-index: 10;
+}
 
-  mat-icon {
-    font-size: 32px;
-    width: 32px;
-    height: 32px;
-    margin-bottom: 0.75rem;
-    opacity: 0.4;
-  }
+.brand-book-dialog {
+  background: $surface-base;
+  border: 1px solid $border-default;
+  border-radius: $radius-lg;
+  width: 100%;
+  max-width: 640px;
+  max-height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
+}
 
-  p {
-    font-size: 0.8125rem;
+.brand-book-dialog-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 20px;
+  border-bottom: 1px solid $border-subtle;
+  gap: 12px;
+
+  h3 {
     margin: 0;
-    max-width: 240px;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: $text-primary;
   }
 }
 
-// Brand book
+.brand-book-dialog-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.brand-book-download,
+.brand-book-close {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 6px 10px;
+  border-radius: $radius-sm;
+  background: transparent;
+  color: $text-secondary;
+  border: 1px solid transparent;
+  cursor: pointer;
+  font-size: 0.8125rem;
+  transition: all 0.2s;
+
+  mat-icon {
+    font-size: 16px;
+    width: 16px;
+    height: 16px;
+  }
+
+  &:hover {
+    border-color: $border-default;
+    color: $text-primary;
+  }
+}
+
+.brand-book-close {
+  padding: 6px;
+}
+
 .brand-book-prose {
   white-space: pre-wrap;
+  font-family: inherit;
   font-size: 0.8125rem;
   line-height: 1.7;
   color: $text-primary;
+  margin: 0;
+  padding: 20px;
+  overflow-y: auto;
+  flex: 1;
 }
 
 // ---------------------------------------------------------------------------
@@ -911,13 +987,10 @@ $radius-lg: 16px;
 
   .panel-header {
     padding: 12px 16px;
+    flex-wrap: wrap;
   }
 
-  .live-preview {
-    padding: 12px 16px;
-  }
-
-  .tab-body {
-    padding: 12px 16px;
+  .phase-stepper {
+    padding: 12px 14px 20px;
   }
 }

--- a/user-interface/src/app/components/brand-preview/brand-preview.component.spec.ts
+++ b/user-interface/src/app/components/brand-preview/brand-preview.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { BrandPreviewComponent } from './brand-preview.component';
+import type { BrandingTeamOutput } from '../../models';
 
 describe('BrandPreviewComponent', () => {
   let component: BrandPreviewComponent;
@@ -30,7 +31,7 @@ describe('BrandPreviewComponent', () => {
     expect(component.hasContent).toBe(false);
   });
 
-  it('should show live preview when mission has data but no output', () => {
+  it('should show the stepper when mission has data but no output', () => {
     component.latestOutput = null;
     component.mission = {
       company_name: 'Acme Corp',
@@ -42,9 +43,11 @@ describe('BrandPreviewComponent', () => {
     expect(component.hasOutput).toBe(false);
     expect(component.hasMissionData).toBe(true);
     expect(component.hasContent).toBe(true);
+    const stepper = fixture.nativeElement.querySelector('[data-testid="phase-stepper"]');
+    expect(stepper).not.toBeNull();
   });
 
-  it('should not show live preview for default TBD mission', () => {
+  it('should not show the stepper for default TBD mission', () => {
     component.latestOutput = null;
     component.mission = {
       company_name: 'TBD',
@@ -54,9 +57,11 @@ describe('BrandPreviewComponent', () => {
     fixture.detectChanges();
     expect(component.hasMissionData).toBe(false);
     expect(component.hasContent).toBe(false);
+    const stepper = fixture.nativeElement.querySelector('[data-testid="phase-stepper"]');
+    expect(stepper).toBeNull();
   });
 
-  it('should show full output tabs when latestOutput is set', () => {
+  it('should render all five pipeline phases when latestOutput is set', () => {
     component.latestOutput = {
       status: 'needs_human_decision',
       mission_summary: 'Test summary',
@@ -64,7 +69,130 @@ describe('BrandPreviewComponent', () => {
     };
     fixture.detectChanges();
     expect(component.hasOutput).toBe(true);
-    expect(component.hasContent).toBe(true);
+    const steps = fixture.nativeElement.querySelectorAll('.phase-step');
+    expect(steps.length).toBe(5);
+    const phases = Array.from(steps).map((el) => (el as HTMLElement).getAttribute('data-phase'));
+    expect(phases).toEqual([
+      'strategic_core',
+      'narrative_messaging',
+      'visual_identity',
+      'channel_activation',
+      'governance',
+    ]);
+  });
+
+  it('should no longer render the old progress bar', () => {
+    component.latestOutput = null;
+    component.mission = {
+      company_name: 'Acme Corp',
+      company_description: 'We build rockets',
+      target_audience: 'Humans',
+      values: ['focus'],
+    };
+    fixture.detectChanges();
+    const progressTrack = fixture.nativeElement.querySelector('.progress-track');
+    expect(progressTrack).toBeNull();
+  });
+
+  it('should reflect phase_gates in the status chips', () => {
+    component.latestOutput = {
+      status: 'in_progress',
+      mission_summary: 'Summary',
+      brand_guidelines: [],
+      phase_gates: [
+        { phase: 'strategic_core', status: 'approved' },
+        { phase: 'narrative_messaging', status: 'in_progress' },
+        { phase: 'visual_identity', status: 'not_started' },
+      ],
+    };
+    fixture.detectChanges();
+    expect(component.phaseStatus('strategic_core')).toBe('completed');
+    expect(component.phaseStatus('narrative_messaging')).toBe('in_progress');
+    expect(component.phaseStatus('visual_identity')).toBe('not_started');
+    expect(component.phaseStatus('channel_activation')).toBe('not_started');
+    const chips = fixture.nativeElement.querySelectorAll('.phase-chip');
+    expect(chips.length).toBe(5);
+    expect((chips[0] as HTMLElement).textContent?.trim()).toBe('Completed');
+    expect((chips[1] as HTMLElement).textContent?.trim()).toBe('In progress');
+    expect((chips[2] as HTMLElement).textContent?.trim()).toBe('Not started');
+  });
+
+  it('should fall back to content heuristic when phase_gates is absent', () => {
+    component.latestOutput = {
+      status: 'in_progress',
+      mission_summary: 'Summary',
+      codification: {
+        positioning_statement: 'p',
+        brand_promise: 'b',
+        brand_personality_traits: [],
+        narrative_pillars: [],
+      },
+      brand_guidelines: [],
+    };
+    fixture.detectChanges();
+    expect(component.phaseStatus('strategic_core')).toBe('completed');
+    expect(component.phaseStatus('narrative_messaging')).toBe('not_started');
+  });
+
+  it('should hide the brand-book button when no content is present', () => {
+    component.latestOutput = {
+      status: 'in_progress',
+      mission_summary: 'Summary',
+      brand_guidelines: [],
+    };
+    fixture.detectChanges();
+    const btn = fixture.nativeElement.querySelector('[data-testid="brand-book-btn"]');
+    expect(btn).toBeNull();
+  });
+
+  it('should show the brand-book button and open the overlay when content is present', () => {
+    component.latestOutput = {
+      status: 'complete',
+      mission_summary: 'Summary',
+      brand_guidelines: [],
+      brand_book: { content: '# Brand Book\n\nFull doc here.' },
+    };
+    fixture.detectChanges();
+    const btn = fixture.nativeElement.querySelector(
+      '[data-testid="brand-book-btn"]'
+    ) as HTMLButtonElement;
+    expect(btn).not.toBeNull();
+    btn.click();
+    fixture.detectChanges();
+    expect(component.brandBookOpen).toBe(true);
+    const overlay = fixture.nativeElement.querySelector(
+      '[data-testid="brand-book-overlay"]'
+    );
+    expect(overlay).not.toBeNull();
+    expect((overlay as HTMLElement).textContent).toContain('# Brand Book');
+  });
+
+  it('should emit selectPalette when a palette card button is clicked', () => {
+    const emitted: number[] = [];
+    component.selectPalette.subscribe((i) => emitted.push(i));
+    component.mission = {
+      company_name: 'Test',
+      company_description: 'Test',
+      target_audience: 'Test',
+      color_palettes: [
+        { name: 'Sunset', description: 'Warm', colors: ['orange'], sentiment: 'warm' },
+        { name: 'Ocean', description: 'Cool', colors: ['blue'], sentiment: 'cool' },
+      ],
+    };
+    // latestOutput needed to render visual_identity phase body (phase_gates
+    // absent → falls back to phaseHasOutput, which checks missionPalettes).
+    component.latestOutput = {
+      status: 'in_progress',
+      mission_summary: 'Summary',
+      brand_guidelines: [],
+    } as BrandingTeamOutput;
+    fixture.detectChanges();
+    const buttons = fixture.nativeElement.querySelectorAll(
+      '[data-testid="palette-select-btn"]'
+    );
+    expect(buttons.length).toBe(2);
+    (buttons[1] as HTMLButtonElement).click();
+    expect(emitted).toEqual([1]);
   });
 
   it('should detect selected palette from mission', () => {

--- a/user-interface/src/app/components/brand-preview/brand-preview.component.ts
+++ b/user-interface/src/app/components/brand-preview/brand-preview.component.ts
@@ -29,6 +29,12 @@ const PHASES: readonly PhaseSpec[] = [
   { phase: 'governance', label: 'Governance', icon: 'verified' },
 ];
 
+const STATUS_LABELS: Record<PhaseRenderStatus, string> = {
+  completed: 'Completed',
+  in_progress: 'In progress',
+  not_started: 'Not started',
+};
+
 @Component({
   selector: 'app-brand-preview',
   standalone: true,
@@ -58,14 +64,12 @@ export class BrandPreviewComponent {
 
   readonly phases = PHASES;
 
-  /** True when the brand-book overlay is visible. */
   brandBookOpen = false;
 
   get hasOutput(): boolean {
     return this.latestOutput != null;
   }
 
-  /** True when mission has at least basic info worth showing. */
   get hasMissionData(): boolean {
     const m = this.mission;
     if (!m) return false;
@@ -79,7 +83,6 @@ export class BrandPreviewComponent {
     );
   }
 
-  /** True when there is anything to display (mission or output). */
   get hasContent(): boolean {
     return this.hasOutput || this.hasMissionData;
   }
@@ -111,20 +114,6 @@ export class BrandPreviewComponent {
     return idx >= 0 && idx < palettes.length ? palettes[idx] : null;
   }
 
-  get colorStories(): string[] {
-    const out = this.latestOutput;
-    if (!out?.mood_boards?.length) {
-      return out?.design_system?.foundation_tokens ?? [];
-    }
-    const colors: string[] = [];
-    for (const mb of out.mood_boards) {
-      if (mb.color_story.length) {
-        colors.push(...mb.color_story);
-      }
-    }
-    return [...new Set(colors)];
-  }
-
   /** Return a CSS color for swatch display; supports hex or leaves as-is for names. */
   parseColor(token: string): string {
     const t = (token || '').trim();
@@ -146,30 +135,19 @@ export class BrandPreviewComponent {
    * back to `phaseHasOutput` when gates are absent (e.g. older fixtures).
    */
   phaseStatus(phase: BrandPhase): PhaseRenderStatus {
-    const gates = this.latestOutput?.phase_gates;
-    if (gates?.length) {
-      const gate = gates.find((g) => g.phase === phase);
-      if (gate) {
-        if (gate.status === 'approved') return 'completed';
-        if (gate.status === 'in_progress' || gate.status === 'pending_review') return 'in_progress';
-        return 'not_started';
-      }
+    const gate = this.latestOutput?.phase_gates?.find((g) => g.phase === phase);
+    if (gate) {
+      if (gate.status === 'approved') return 'completed';
+      if (gate.status === 'in_progress' || gate.status === 'pending_review') return 'in_progress';
+      return 'not_started';
     }
     return this.phaseHasOutput(phase) ? 'completed' : 'not_started';
   }
 
   phaseStatusLabel(phase: BrandPhase): string {
-    switch (this.phaseStatus(phase)) {
-      case 'completed':
-        return 'Completed';
-      case 'in_progress':
-        return 'In progress';
-      default:
-        return 'Not started';
-    }
+    return STATUS_LABELS[this.phaseStatus(phase)];
   }
 
-  /** True when backend output contains an artifact produced by this phase. */
   phaseHasOutput(phase: BrandPhase): boolean {
     const out = this.latestOutput;
     if (!out) return false;
@@ -199,7 +177,6 @@ export class BrandPreviewComponent {
     this.brandBookOpen = false;
   }
 
-  /** Trigger a browser download of the brand book Markdown. */
   downloadBrandBook(): void {
     const content = this.latestOutput?.brand_book?.content;
     if (!content) return;

--- a/user-interface/src/app/components/brand-preview/brand-preview.component.ts
+++ b/user-interface/src/app/components/brand-preview/brand-preview.component.ts
@@ -1,19 +1,39 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { trigger, transition, style, animate } from '@angular/animations';
 import { MatCardModule } from '@angular/material/card';
-import { MatTabsModule } from '@angular/material/tabs';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatChipsModule } from '@angular/material/chips';
-import type { BrandingMissionSnapshot, BrandingTeamOutput, ColorPalette } from '../../models';
+import type {
+  BrandingMissionSnapshot,
+  BrandingTeamOutput,
+  BrandPhase,
+  ColorPalette,
+} from '../../models';
+
+type PhaseRenderStatus = 'not_started' | 'in_progress' | 'completed';
+
+interface PhaseSpec {
+  phase: BrandPhase;
+  label: string;
+  icon: string;
+}
+
+/** Pipeline order mirrors backend `PHASE_ORDER` in graphs/shared.py. */
+const PHASES: readonly PhaseSpec[] = [
+  { phase: 'strategic_core', label: 'Strategic Core', icon: 'hub' },
+  { phase: 'narrative_messaging', label: 'Narrative', icon: 'edit_note' },
+  { phase: 'visual_identity', label: 'Visual', icon: 'palette' },
+  { phase: 'channel_activation', label: 'Channel', icon: 'campaign' },
+  { phase: 'governance', label: 'Governance', icon: 'verified' },
+];
 
 @Component({
   selector: 'app-brand-preview',
   standalone: true,
   imports: [
     MatCardModule,
-    MatTabsModule,
     MatExpansionModule,
     MatIconModule,
     MatButtonModule,
@@ -34,6 +54,12 @@ export class BrandPreviewComponent {
   @Input() mission: BrandingMissionSnapshot | null = null;
   @Input() latestOutput: BrandingTeamOutput | null = null;
   @Output() saveAsBrand = new EventEmitter<void>();
+  @Output() selectPalette = new EventEmitter<number>();
+
+  readonly phases = PHASES;
+
+  /** True when the brand-book overlay is visible. */
+  brandBookOpen = false;
 
   get hasOutput(): boolean {
     return this.latestOutput != null;
@@ -56,23 +82,6 @@ export class BrandPreviewComponent {
   /** True when there is anything to display (mission or output). */
   get hasContent(): boolean {
     return this.hasOutput || this.hasMissionData;
-  }
-
-  /** Rough percentage of mission fields that have meaningful data. */
-  get completionPercent(): number {
-    const m = this.mission;
-    if (!m) return 0;
-    let filled = 0;
-    const total = 8;
-    if (m.company_name && m.company_name !== 'TBD') filled++;
-    if (m.company_description && m.company_description !== 'To be discussed.') filled++;
-    if (m.target_audience && m.target_audience !== 'TBD') filled++;
-    if ((m.values?.length ?? 0) > 0) filled++;
-    if ((m.differentiators?.length ?? 0) > 0) filled++;
-    if (m.desired_voice && m.desired_voice !== 'clear, confident, human') filled++;
-    if ((m.color_palettes?.length ?? 0) > 0 || (m.color_inspiration?.length ?? 0) > 0) filled++;
-    if (m.visual_style || m.typography_preference) filled++;
-    return Math.round((filled / total) * 100);
   }
 
   get missionValues(): string[] {
@@ -126,5 +135,82 @@ export class BrandPreviewComponent {
 
   isPaletteSelected(index: number): boolean {
     return this.selectedPaletteIndex === index;
+  }
+
+  onSelectPalette(index: number): void {
+    this.selectPalette.emit(index);
+  }
+
+  /**
+   * Render status for a phase. Prefers the backend `phase_gates` signal; falls
+   * back to `phaseHasOutput` when gates are absent (e.g. older fixtures).
+   */
+  phaseStatus(phase: BrandPhase): PhaseRenderStatus {
+    const gates = this.latestOutput?.phase_gates;
+    if (gates?.length) {
+      const gate = gates.find((g) => g.phase === phase);
+      if (gate) {
+        if (gate.status === 'approved') return 'completed';
+        if (gate.status === 'in_progress' || gate.status === 'pending_review') return 'in_progress';
+        return 'not_started';
+      }
+    }
+    return this.phaseHasOutput(phase) ? 'completed' : 'not_started';
+  }
+
+  phaseStatusLabel(phase: BrandPhase): string {
+    switch (this.phaseStatus(phase)) {
+      case 'completed':
+        return 'Completed';
+      case 'in_progress':
+        return 'In progress';
+      default:
+        return 'Not started';
+    }
+  }
+
+  /** True when backend output contains an artifact produced by this phase. */
+  phaseHasOutput(phase: BrandPhase): boolean {
+    const out = this.latestOutput;
+    if (!out) return false;
+    switch (phase) {
+      case 'strategic_core':
+        return !!out.codification || !!out.mission_summary;
+      case 'narrative_messaging':
+        return !!out.writing_guidelines;
+      case 'visual_identity':
+        return (out.mood_boards?.length ?? 0) > 0 || !!out.design_system || this.missionPalettes.length > 0;
+      case 'channel_activation':
+        return !!out.creative_refinement || !!out.design_asset_result;
+      case 'governance':
+        return (out.brand_guidelines?.length ?? 0) > 0 || (out.wiki_backlog?.length ?? 0) > 0;
+      default:
+        return false;
+    }
+  }
+
+  openBrandBook(): void {
+    if (this.latestOutput?.brand_book?.content) {
+      this.brandBookOpen = true;
+    }
+  }
+
+  closeBrandBook(): void {
+    this.brandBookOpen = false;
+  }
+
+  /** Trigger a browser download of the brand book Markdown. */
+  downloadBrandBook(): void {
+    const content = this.latestOutput?.brand_book?.content;
+    if (!content) return;
+    const blob = new Blob([content], { type: 'text/markdown;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = 'brand-book.md';
+    document.body.appendChild(anchor);
+    anchor.click();
+    document.body.removeChild(anchor);
+    URL.revokeObjectURL(url);
   }
 }

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.html
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.html
@@ -65,6 +65,7 @@
                 [mission]="selectedBrand?.mission ?? conversationMission"
                 [latestOutput]="(($any(selectedBrand)?.latest_output ?? null) || conversationLatestOutput)"
                 (saveAsBrand)="onOpenSaveAsBrand()"
+                (selectPalette)="onSelectPalette($event)"
               />
             </mat-expansion-panel>
           } @else {
@@ -72,6 +73,7 @@
               [mission]="selectedBrand?.mission ?? conversationMission"
               [latestOutput]="(($any(selectedBrand)?.latest_output ?? null) || conversationLatestOutput)"
               (saveAsBrand)="onOpenSaveAsBrand()"
+              (selectPalette)="onSelectPalette($event)"
             />
           }
         </div>

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.spec.ts
@@ -297,6 +297,42 @@ describe('BrandingDashboardComponent', () => {
 
     expect(apiSpy.createClient).toHaveBeenCalledWith({ name: 'New' });
   });
+
+  it('onSelectPalette patches brands so syncBrandPreviewFromSelection does not revert the choice', () => {
+    const mission = {
+      company_name: 'Acme',
+      company_description: 'desc',
+      target_audience: 'devs',
+      color_palettes: [
+        { name: 'Sunset', description: '', colors: ['#f00'], sentiment: 'warm' },
+        { name: 'Ocean', description: '', colors: ['#00f'], sentiment: 'cool' },
+      ],
+    };
+    const brand: Brand = {
+      id: 'b-palette',
+      client_id: 'w1',
+      name: 'Acme',
+      status: 'draft',
+      mission,
+      version: 1,
+      history: [],
+      created_at: '',
+      updated_at: '',
+    };
+    component.brands = [brand];
+    component.selectedBrand = brand;
+
+    component.onSelectPalette(1);
+
+    expect(component.selectedBrand?.mission.selected_palette_index).toBe(1);
+    expect(component.brands[0].mission.selected_palette_index).toBe(1);
+
+    // Simulate a subsequent chat state update which calls
+    // syncBrandPreviewFromSelection → selectedBrand = brands.find(...).
+    // Without the brands patch, this would revert the choice.
+    (component as unknown as { syncBrandPreviewFromSelection: () => void }).syncBrandPreviewFromSelection();
+    expect(component.selectedBrand?.mission.selected_palette_index).toBe(1);
+  });
 });
 
 describe('BrandingDashboardComponent query-param restore', () => {

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
@@ -133,6 +133,25 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
     this.syncQueryParams();
   }
 
+  /**
+   * Handle a palette selection click from the brand preview. Optimistically
+   * updates the local mission so the UI reflects the choice immediately.
+   * TODO(#279): send the selection through the chat assistant so the backend
+   * persists it; the current palette-selection path runs via conversational
+   * intent rather than a dedicated REST endpoint.
+   */
+  onSelectPalette(index: number): void {
+    if (this.conversationMission) {
+      this.conversationMission = { ...this.conversationMission, selected_palette_index: index };
+    }
+    if (this.selectedBrand) {
+      this.selectedBrand = {
+        ...this.selectedBrand,
+        mission: { ...this.selectedBrand.mission, selected_palette_index: index },
+      };
+    }
+  }
+
   /** Handle auto-created brand from chat: refresh brands and select it. */
   onBrandAutoCreated(brandId: string): void {
     if (!this.selectedClient) return;

--- a/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
+++ b/user-interface/src/app/components/branding-dashboard/branding-dashboard.component.ts
@@ -145,10 +145,14 @@ export class BrandingDashboardComponent implements OnInit, OnDestroy {
       this.conversationMission = { ...this.conversationMission, selected_palette_index: index };
     }
     if (this.selectedBrand) {
-      this.selectedBrand = {
+      const updated: Brand = {
         ...this.selectedBrand,
         mission: { ...this.selectedBrand.mission, selected_palette_index: index },
       };
+      this.selectedBrand = updated;
+      // Also patch `brands` so syncBrandPreviewFromSelection() doesn't
+      // rehydrate selectedBrand from a stale entry and revert the choice.
+      this.brands = this.brands.map((b) => (b.id === updated.id ? updated : b));
     }
   }
 

--- a/user-interface/src/app/models/branding.model.ts
+++ b/user-interface/src/app/models/branding.model.ts
@@ -172,6 +172,23 @@ export interface BrandBook {
   sections?: Record<string, unknown>;
 }
 
+/** Sequential branding pipeline phases. Mirrors backend `BrandPhase` enum. */
+export type BrandPhase =
+  | 'strategic_core'
+  | 'narrative_messaging'
+  | 'visual_identity'
+  | 'channel_activation'
+  | 'governance'
+  | 'complete';
+
+/** Per-phase approval gate status. Mirrors backend `PhaseStatus`. */
+export type PhaseStatus = 'not_started' | 'in_progress' | 'pending_review' | 'approved';
+
+export interface PhaseGate {
+  phase: BrandPhase;
+  status: PhaseStatus;
+}
+
 /** Response from running the branding team for a brand. */
 export interface BrandingTeamOutput {
   status: string;
@@ -188,6 +205,8 @@ export interface BrandingTeamOutput {
   competitive_snapshot?: CompetitiveSnapshot | null;
   design_asset_result?: DesignAssetRequestResult | null;
   brand_book?: BrandBook | null;
+  current_phase?: BrandPhase;
+  phase_gates?: PhaseGate[];
 }
 
 export interface BrandingQuestion {


### PR DESCRIPTION
Closes #277.

## Summary

- Swap the tab-heavy brand preview for a vertical stepper that mirrors the backend `BrandPhase` pipeline (Strategic Core → Narrative → Visual → Channel → Governance). Each step renders its artifacts inline and shows a status chip (`Completed` / `In progress` / `Not started`) sourced from `phase_gates`, with a content-heuristic fallback for older fixtures.
- The "% defined" progress bar is gone — the stepper itself is the spatial progress indicator.
- Brand Book moved from an always-present tab to a header action that opens an overlay with viewer + Markdown download.
- Palette cards gained an explicit "Select this palette" button that emits a new `selectPalette` output; `branding-dashboard` optimistically updates the local mission. Full backend round-trip is deferred to #279, which owns palette selection.
- Extended `BrandingTeamOutput` TS model with `current_phase` and `phase_gates`; added matching `BrandPhase` / `PhaseStatus` / `PhaseGate` types.
- Pruned the old tab / progress-bar styles and added stepper, chip, palette-select, and overlay styles.

## Test plan

- [x] `npm run build` — clean production build (only pre-existing bundle-size warning remains).
- [x] `npx vitest run src/app/components/brand-preview src/app/components/branding-dashboard src/app/components/branding-chat src/app/services/branding-api` — 49/49 tests pass, including 7 new stepper/brand-book/palette specs.
- [ ] Manual smoke test in dev server at `/branding-workspace`: empty workspace shows 5 collapsed steps with `Not started` chips; no 8 tabs; no `% defined` bar; Brand Book button hidden.
- [ ] With a populated `latest_output` / `phase_gates`, each step expands inline with its artifacts and the chip reflects gate status.
- [ ] Brand Book button opens the overlay; Download triggers a `brand-book.md` file.
- [ ] Palette `Select this palette` click flips that card's button to `Selected` (disabled) and leaves the others clickable.

## Out of scope

- Backend palette-selection REST endpoint + full round-trip — #279.
- Chat vs. Form collapse into one progressive workflow — #278.
- CSV → `mat-chip-grid` inputs, workspace-switcher relocation, unified theme — #279.


---
_Generated by [Claude Code](https://claude.ai/code/session_017NKnVQQ1JW8duUvfrzb4gz)_