### PR TITLE
investment_team: merge per-cycle ConvergenceTracker trial counts (closes #269)

### DIFF
--- a/backend/agents/investment_team/api/main.py
+++ b/backend/agents/investment_team/api/main.py
@@ -1574,6 +1574,11 @@ def _strategy_lab_worker(
                 remaining = remaining[max_parallel:]
 
                 wave_futures: Dict[Any, int] = {}
+                # Issue #269 — retain each cycle's orchestrator so the wave
+                # can merge its post-run ``convergence_tracker`` back into
+                # ``primary_tracker`` below. Keyed by 0-based cycle index
+                # for O(1) lookup during the deterministic merge loop.
+                wave_orchestrators: Dict[int, "StrategyLabOrchestrator"] = {}
                 with ThreadPoolExecutor(
                     max_workers=len(wave_indices), thread_name_prefix="strat-lab"
                 ) as pool:
@@ -1595,6 +1600,7 @@ def _strategy_lab_worker(
                         cycle_orchestrator = StrategyLabOrchestrator(
                             convergence_tracker=primary_tracker.snapshot(),
                         )
+                        wave_orchestrators[i] = cycle_orchestrator
                         future = pool.submit(
                             _run_one_strategy_lab_cycle,
                             config,
@@ -1691,6 +1697,13 @@ def _strategy_lab_worker(
                         for g in record.quality_gate_results
                     ]
                     primary_tracker.record(record.strategy, gate_results)
+                    # Issue #269 — fold the cycle-local trial-count delta
+                    # back into the primary. Diversity state was already
+                    # merged via ``record()`` above, so ``merge_from`` only
+                    # touches ``_trial_count``.
+                    cycle_orch = wave_orchestrators.get(_idx)
+                    if cycle_orch is not None:
+                        primary_tracker.merge_from(cycle_orch.convergence_tracker)
 
                 # Check for external cancellation between waves
                 if not run_failed and _is_run_cancelled():

--- a/backend/agents/investment_team/strategy_lab/quality_gates/convergence_tracker.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/convergence_tracker.py
@@ -34,6 +34,11 @@ class ConvergenceTracker:
         # loop completes; ``record()`` does not touch this so parallel cycle
         # snapshots can keep their accounting independent of diversity state.
         self._trial_count: int = 0
+        # Issue #269 — baseline captured inside ``snapshot()`` so that
+        # ``merge_from`` folds only the delta accumulated during the cycle
+        # back into the primary, avoiding double-counting the pre-snapshot
+        # trial total. Zero on directly-constructed instances.
+        self._trial_count_at_snapshot: int = 0
 
     # ------------------------------------------------------------------
     # Recording
@@ -154,7 +159,35 @@ class ConvergenceTracker:
         clone._failure_modes = Counter(self._failure_modes)
         clone._asset_class_history = list(self._asset_class_history)
         clone._trial_count = self._trial_count
+        clone._trial_count_at_snapshot = self._trial_count
         return clone
+
+    def merge_from(self, other: "ConvergenceTracker") -> None:
+        """Fold a cycle snapshot's trial-count delta back into this tracker.
+
+        Called at parallel-batch wave completion so the primary tracker
+        accumulates the refinement rounds each cycle observed on its own
+        snapshot. Without this, DSR deflation during concurrent waves
+        sees only prior-wave trials and under-deflates by the current
+        wave's sibling increments.
+
+        Only ``_trial_count`` is merged. Diversity state (signatures,
+        asset-class history, failure-mode counters) flows back via the
+        wave-completion ``record()`` loop in the orchestration layer;
+        merging it here would double-count.
+
+        The delta is computed against ``other._trial_count_at_snapshot``
+        (captured in ``snapshot()``), so ``self`` need not equal the
+        baseline at merge time.
+        """
+        baseline = other._trial_count_at_snapshot
+        delta = other._trial_count - baseline
+        if delta < 0:
+            raise ValueError(
+                f"snapshot trial_count ({other._trial_count}) is below its "
+                f"baseline ({baseline}); merge_from expects monotonic increments"
+            )
+        self._trial_count += delta
 
     # ------------------------------------------------------------------
     # Internals

--- a/backend/agents/investment_team/tests/test_convergence_tracker.py
+++ b/backend/agents/investment_team/tests/test_convergence_tracker.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from collections import Counter
+
 import pytest
 
 from investment_team.models import StrategySpec
@@ -88,3 +90,134 @@ def test_snapshot_preserves_diversity_state():
     # Diversity directives should see the same history.
     assert snap._asset_class_history == ["crypto", "stocks"]
     assert len(snap._signatures) == 2
+
+
+# ----------------------------------------------------------------------
+# Issue #269 — merge_from parallel-wave trial-count fold-back
+# ----------------------------------------------------------------------
+
+
+def test_merge_from_adds_cycle_delta_not_full_count():
+    primary = ConvergenceTracker()
+    primary.increment_trials(2)
+    snap = primary.snapshot()  # baseline captured at 2
+    snap.increment_trials(5)  # cycle did 5 refinement rounds
+
+    primary.merge_from(snap)
+
+    # 2 (pre-wave) + 5 (delta), not 2 + 7 which would double-count the baseline.
+    assert primary.trial_count == 7
+
+
+def test_merge_from_on_fresh_primary_adds_full_trial_count():
+    # Issue #269 AC: primary.merge_from(snapshot_with_5_trials) → trial_count += 5
+    # when the baseline is 0 (freshly constructed primary).
+    primary = ConvergenceTracker()
+    snap = primary.snapshot()
+    snap.increment_trials(5)
+
+    primary.merge_from(snap)
+    assert primary.trial_count == 5
+
+
+def test_merge_from_does_not_touch_diversity_state():
+    # Diversity merging is the wave-completion ``record()`` loop's job;
+    # merge_from must stay out of it to avoid double-counting.
+    primary = ConvergenceTracker()
+    primary.record(_mk_spec("stocks"), [_passing_gate()])
+
+    pre_signatures = list(primary._signatures)
+    pre_history = list(primary._asset_class_history)
+    pre_failures = Counter(primary._failure_modes)
+
+    snap = primary.snapshot()
+    snap.record(_mk_spec("crypto"), [_passing_gate()])  # cycle adds diversity
+    snap.increment_trials(3)
+
+    primary.merge_from(snap)
+
+    assert primary._signatures == pre_signatures
+    assert primary._asset_class_history == pre_history
+    assert primary._failure_modes == pre_failures
+    assert primary.trial_count == 3  # delta only
+
+
+def test_merge_from_multiple_snapshots_accumulate_like_a_parallel_wave():
+    # Mirrors the orchestration call pattern: one primary, N sibling
+    # snapshots built at the same time, each does K refinement rounds, all
+    # merged back at wave end.
+    primary = ConvergenceTracker()
+    snaps = [primary.snapshot() for _ in range(3)]
+    for s in snaps:
+        s.increment_trials(4)
+
+    for s in snaps:
+        primary.merge_from(s)
+
+    assert primary.trial_count == 12
+
+
+def test_merge_from_rejects_shrinking_snapshot():
+    primary = ConvergenceTracker()
+    primary.increment_trials(10)
+    snap = primary.snapshot()
+    # Manually corrupt trial_count below the captured baseline.
+    snap._trial_count = 3
+
+    with pytest.raises(ValueError, match="monotonic"):
+        primary.merge_from(snap)
+
+
+def test_merge_from_directly_constructed_tracker_uses_zero_baseline():
+    # A tracker built without snapshot() has ``_trial_count_at_snapshot = 0``;
+    # merge_from folds its full trial_count. Useful for tests that construct
+    # synthetic trackers directly.
+    primary = ConvergenceTracker()
+    other = ConvergenceTracker()
+    other.increment_trials(8)
+
+    primary.merge_from(other)
+    assert primary.trial_count == 8
+
+
+def test_merge_from_lowers_dsr_on_subsequent_cycle():
+    """Issue #269 AC: DSR regression — after a parallel-batch wave merges
+    sibling trial counts into the primary, DSR computed on a subsequent
+    cycle at the same raw Sharpe is strictly lower than the pre-merge DSR.
+
+    This is the end-to-end motivation for the fix: merge_from propagates
+    trial counts into the primary so that n_trials passed to
+    ``compute_deflated_sharpe`` reflects all sibling work, not just prior
+    waves."""
+    from investment_team.execution.metrics import compute_deflated_sharpe
+
+    sharpe = 1.5
+    n_obs = 252
+
+    # Pre-merge: primary sits at whatever trial_count prior waves produced
+    # (simulated here as a modest baseline). DSR on the next cycle sees
+    # n_trials = primary.trial_count + 1 (this cycle).
+    primary = ConvergenceTracker()
+    primary.increment_trials(5)  # prior waves
+    dsr_pre_merge = compute_deflated_sharpe(
+        sharpe=sharpe, n_trials=primary.trial_count + 1, n_obs=n_obs
+    )
+
+    # Simulate a parallel wave of 3 sibling cycles, each doing 30 refinement
+    # rounds on its own snapshot. Without merge_from these 90 trials would
+    # be invisible to DSR on the next cycle.
+    snaps = [primary.snapshot() for _ in range(3)]
+    for s in snaps:
+        s.increment_trials(30)
+    for s in snaps:
+        primary.merge_from(s)
+
+    assert primary.trial_count == 5 + 3 * 30  # merge_from landed the delta
+    dsr_post_merge = compute_deflated_sharpe(
+        sharpe=sharpe, n_trials=primary.trial_count + 1, n_obs=n_obs
+    )
+
+    assert dsr_post_merge < dsr_pre_merge, (
+        "Expected post-merge DSR to deflate further once sibling trial "
+        f"counts are visible; got pre={dsr_pre_merge:.6f} post={dsr_post_merge:.6f}"
+    )

--- a/backend/agents/investment_team/tests/test_strategy_lab_batches.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_batches.py
@@ -154,6 +154,11 @@ def test_multi_batch_run_completes_all_cycles_and_learns_from_priors(
         def record(self, *_a: Any, **_kw: Any) -> None:
             pass
 
+        def merge_from(self, *_a: Any, **_kw: Any) -> None:
+            # Issue #269 — wave-completion loop now calls merge_from on the
+            # primary for each cycle snapshot; stub is a no-op.
+            pass
+
     monkeypatch.setattr(lab_main, "StrategyLabOrchestrator", _StubOrchestrator)
     monkeypatch.setattr(lab_main, "ConvergenceTracker", _StubTracker)
     monkeypatch.setattr(lab_main, "_strategy_lab_signal_expert_enabled", lambda: False)
@@ -236,6 +241,11 @@ def test_signal_brief_regenerates_once_per_batch(
         def record(self, *_a: Any, **_kw: Any) -> None:
             pass
 
+        def merge_from(self, *_a: Any, **_kw: Any) -> None:
+            # Issue #269 — wave-completion loop now calls merge_from on the
+            # primary for each cycle snapshot; stub is a no-op.
+            pass
+
     class _StubOrchestrator:
         _counter = 0
 
@@ -293,3 +303,79 @@ def test_total_cycles_is_batch_size_times_batch_count(empty_lab_state: None) -> 
         RunStrategyLabRequest(batch_count=0)
     with pytest.raises(Exception):
         RunStrategyLabRequest(batch_count=lab_main._MAX_BATCH_COUNT + 1)
+
+
+def test_parallel_wave_merges_trial_counts_into_primary_tracker(
+    empty_lab_state: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Issue #269 — after a parallel wave completes, the primary tracker's
+    trial_count must equal the sum of per-cycle refinement rounds, not just
+    the primary's snapshot-time value (which would stay at 0)."""
+
+    # Each cycle simulates this many refinement rounds on its own snapshot.
+    trials_per_cycle = 7
+
+    instances: List["_CapturingOrchestrator"] = []
+
+    class _CapturingOrchestrator:
+        """Passes ``convergence_tracker`` through unchanged so the real
+        ``ConvergenceTracker.merge_from`` path is exercised end-to-end.
+        The first instance receives the primary tracker; subsequent
+        instances receive snapshots built at wave submission time."""
+
+        _counter = 0
+
+        def __init__(self, convergence_tracker: Any = None) -> None:
+            self.convergence_tracker = convergence_tracker
+            instances.append(self)
+
+        def run_cycle(
+            self,
+            prior_records: List[StrategyLabRecord],
+            config: BacktestConfig,
+            signal_brief: Any = None,
+            on_phase: Any = None,
+            exclude_asset_classes: Any = None,
+        ) -> StrategyLabRecord:
+            # Simulate refinement-loop trial increments on the cycle snapshot.
+            if self.convergence_tracker is not None:
+                self.convergence_tracker.increment_trials(trials_per_cycle)
+            type(self)._counter += 1
+            return _make_record(type(self)._counter, config)
+
+    monkeypatch.setattr(lab_main, "StrategyLabOrchestrator", _CapturingOrchestrator)
+    # NB: intentionally do NOT monkeypatch ConvergenceTracker — we want the
+    # real class so merge_from is exercised end-to-end.
+    monkeypatch.setattr(lab_main, "_strategy_lab_signal_expert_enabled", lambda: False)
+    monkeypatch.setattr(lab_main, "_persist_run_state", lambda *a, **kw: None)
+
+    request = RunStrategyLabRequest(
+        batch_size=3,
+        batch_count=1,
+        max_parallel=3,  # truly parallel wave
+        paper_trading_enabled=False,
+    )
+    run_id = "run-test-parallel-merge"
+    _seed_run_state(run_id, request)
+
+    _strategy_lab_worker(run_id, request)
+
+    state = lab_main._active_runs[run_id]
+    assert state["status"] == "completed", state
+
+    # The first constructed orchestrator holds the primary tracker
+    # (constructed with a fresh ConvergenceTracker at worker entry).
+    assert len(instances) == 1 + 3  # primary + one per cycle
+    primary_tracker = instances[0].convergence_tracker
+    assert primary_tracker is not None
+
+    # Before the fix: primary_tracker.trial_count == 0 (snapshots incremented
+    # their own copies and were discarded). After the fix: 3 cycles × 7 =
+    # 21 trials merged back into the primary.
+    assert primary_tracker.trial_count == 3 * trials_per_cycle
+
+    # Sanity: each cycle's snapshot tracker also still shows its own count
+    # (merge_from does not mutate the snapshot).
+    for cycle_orch in instances[1:]:
+        # Snapshot started at baseline 0, was incremented trials_per_cycle.
+        assert cycle_orch.convergence_tracker.trial_count == trials_per_cycle


### PR DESCRIPTION
## Summary

- Adds `ConvergenceTracker.merge_from(other)` + a `_trial_count_at_snapshot` baseline captured inside `snapshot()` so parallel cycle snapshots can fold their trial-count delta back into the primary tracker without double-counting.
- Wires `primary_tracker.merge_from(cycle_orch.convergence_tracker)` into the Strategy Lab wave-completion loop in `backend/agents/investment_team/api/main.py`, right after the existing deterministic `primary_tracker.record(...)` call per cycle.
- Only `_trial_count` is merged. Signatures, failure-mode counters, and asset-class history still flow through the existing `record()` path to avoid double-counting.

## Context

Follow-up to #247 (purged walk-forward + Deflated Sharpe). When a wave runs N cycles in parallel, each cycle increments `_trial_count` on its own `primary_tracker.snapshot()`. Those increments were previously discarded at wave completion, so DSR on subsequent cycles within the same batch was deflated against a stale `trial_count` (it saw prior waves but not siblings in the current wave) — a meaningful multiple-testing correction gap right where the deflation should bite hardest.

Closes #269.

## Test plan

- [x] `pytest agents/investment_team/tests/test_convergence_tracker.py` — 14 passed (7 new tests covering delta arithmetic, fresh-primary full-count, multi-snapshot wave accumulation, diversity-state untouched, negative-delta rejection, direct (non-snapshot) tracker merge, DSR regression)
- [x] `pytest agents/investment_team/tests/test_strategy_lab_batches.py` — 4 passed, including a new `test_parallel_wave_merges_trial_counts_into_primary_tracker` that runs a true parallel wave (`max_parallel=3`) end-to-end through `_strategy_lab_worker` and asserts `primary.trial_count == 3 × per_cycle_trials`
- [x] Full `pytest agents/investment_team/tests/` — 353 passed, 1 skipped
- [x] `ruff check` + `ruff format --check` clean across `investment_team/`

https://claude.ai/code/session_01WRoiheTGY8BLdEYGU3wFeH

---
_Generated by [Claude Code](https://claude.ai/code/session_01WRoiheTGY8BLdEYGU3wFeH)_