### PR TITLE
nutrition: SPEC-006 profile restriction normalization (flag-gated)

### DIFF
--- a/backend/agents/nutrition_meal_planning_team/agents/intake_profile_agent/agent.py
+++ b/backend/agents/nutrition_meal_planning_team/agents/intake_profile_agent/agent.py
@@ -15,7 +15,7 @@ from ...models import ClientProfile, ProfileUpdateRequest
 # Re-export the fallback merger under its historical private name so
 # the existing import surface stays stable. Pure-logic lives in
 # ``structural`` (no strands dependency) per SPEC-002 W4.
-from .restriction_hook import apply_resolver as _apply_resolver
+from .restriction_hook import apply_resolver
 from .structural import merge_profile_structural as _merge_profile_structural  # noqa: F401
 
 logger = logging.getLogger(__name__)
@@ -59,7 +59,7 @@ class IntakeProfileAgent:
         Merge current profile with update (if any), ask LLM to validate/complete, return ClientProfile.
         """
         profile = self._llm_merge(client_id, update, current_profile)
-        return _apply_resolver(profile)
+        return apply_resolver(profile)
 
     def _llm_merge(
         self,

--- a/backend/agents/nutrition_meal_planning_team/agents/intake_profile_agent/agent.py
+++ b/backend/agents/nutrition_meal_planning_team/agents/intake_profile_agent/agent.py
@@ -15,6 +15,7 @@ from ...models import ClientProfile, ProfileUpdateRequest
 # Re-export the fallback merger under its historical private name so
 # the existing import surface stays stable. Pure-logic lives in
 # ``structural`` (no strands dependency) per SPEC-002 W4.
+from .restriction_hook import apply_resolver as _apply_resolver
 from .structural import merge_profile_structural as _merge_profile_structural  # noqa: F401
 
 logger = logging.getLogger(__name__)
@@ -57,6 +58,15 @@ class IntakeProfileAgent:
         """
         Merge current profile with update (if any), ask LLM to validate/complete, return ClientProfile.
         """
+        profile = self._llm_merge(client_id, update, current_profile)
+        return _apply_resolver(profile)
+
+    def _llm_merge(
+        self,
+        client_id: str,
+        update: Optional[ProfileUpdateRequest],
+        current_profile: Optional[ClientProfile],
+    ) -> ClientProfile:
         current_dict: Dict[str, Any] = {}
         if current_profile:
             current_dict = current_profile.model_dump()

--- a/backend/agents/nutrition_meal_planning_team/agents/intake_profile_agent/restriction_hook.py
+++ b/backend/agents/nutrition_meal_planning_team/agents/intake_profile_agent/restriction_hook.py
@@ -14,17 +14,28 @@ from ...models import ClientProfile
 
 logger = logging.getLogger(__name__)
 
+_FLAG = "NUTRITION_RESTRICTION_RESOLVER"
+
+
+def is_resolver_enabled() -> bool:
+    """SPEC-006 feature-flag truth source.
+
+    Read at every call site so the env can flip without restarting
+    the process. Off by default until the rollout in spec §5 ramps.
+    """
+    return os.environ.get(_FLAG, "0") == "1"
+
 
 def apply_resolver(profile: ClientProfile) -> ClientProfile:
-    """Populate ``profile.restriction_resolution`` when
-    ``NUTRITION_RESTRICTION_RESOLVER=1`` is set.
+    """Populate ``profile.restriction_resolution`` when the SPEC-006
+    feature flag is on.
 
     Mutates the profile in place and returns it. Raw lists are
     untouched. On resolver failure, logs a warning and returns the
     profile with its existing (default) resolution so the user's
     write still persists.
     """
-    if os.environ.get("NUTRITION_RESTRICTION_RESOLVER", "0") != "1":
+    if not is_resolver_enabled():
         return profile
     try:
         from ...restriction_resolver import resolve_restrictions

--- a/backend/agents/nutrition_meal_planning_team/agents/intake_profile_agent/restriction_hook.py
+++ b/backend/agents/nutrition_meal_planning_team/agents/intake_profile_agent/restriction_hook.py
@@ -1,0 +1,41 @@
+"""SPEC-006 resolver hook, split out for testing without strands.
+
+Pure logic only. ``agent.py`` imports and applies this after both the
+LLM merge and the structural fallback, so tests can exercise it
+directly without the strands stack.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from ...models import ClientProfile
+
+logger = logging.getLogger(__name__)
+
+
+def apply_resolver(profile: ClientProfile) -> ClientProfile:
+    """Populate ``profile.restriction_resolution`` when
+    ``NUTRITION_RESTRICTION_RESOLVER=1`` is set.
+
+    Mutates the profile in place and returns it. Raw lists are
+    untouched. On resolver failure, logs a warning and returns the
+    profile with its existing (default) resolution so the user's
+    write still persists.
+    """
+    if os.environ.get("NUTRITION_RESTRICTION_RESOLVER", "0") != "1":
+        return profile
+    try:
+        from ...restriction_resolver import resolve_restrictions
+
+        profile.restriction_resolution = resolve_restrictions(
+            profile.allergies_and_intolerances or [],
+            profile.dietary_needs or [],
+        )
+    except Exception:
+        logger.warning(
+            "restriction resolver failed; leaving resolution untouched",
+            exc_info=True,
+        )
+    return profile

--- a/backend/agents/nutrition_meal_planning_team/api/main.py
+++ b/backend/agents/nutrition_meal_planning_team/api/main.py
@@ -28,6 +28,8 @@ from ..models import (
     MealPlanRequest,
     NutritionPlanRequest,
     ProfileUpdateRequest,
+    ResolveAmbiguousRequest,
+    RestrictionResolution,
 )
 from ..orchestrator.agent import NutritionMealPlanningOrchestrator
 from ..shared.job_store import (
@@ -230,6 +232,62 @@ def get_profile_completeness_route(client_id: str):
     response with ``no_profile`` in blockers.
     """
     return orchestrator.get_completeness(client_id)
+
+
+# --- SPEC-006: restriction resolution routes ----------------------------
+
+
+@app.get(
+    "/profile/{client_id}/restrictions",
+    response_model=RestrictionResolution,
+)
+def get_restrictions_route(client_id: str):
+    """SPEC-006: canonical tag resolution of the client's raw
+    ``allergies_and_intolerances`` and ``dietary_needs`` lists.
+
+    Returns the resolution stored on the profile. When the feature
+    flag was off at intake time, this is the empty default (equivalent
+    to ``RestrictionResolution()``).
+    """
+    try:
+        return orchestrator.get_restrictions(client_id)
+    except LookupError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+
+
+@app.post(
+    "/profile/{client_id}/restrictions/resolve-ambiguous",
+    response_model=RestrictionResolution,
+)
+def resolve_ambiguous_route(client_id: str, body: ResolveAmbiguousRequest):
+    """SPEC-006: user confirms a choice for an ambiguous restriction.
+
+    The chosen candidate is moved into ``resolved[]`` and persisted.
+    Subsequent reads no longer re-ask for the same ``raw``.
+    """
+    try:
+        return orchestrator.resolve_ambiguous(client_id, body)
+    except LookupError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@app.post(
+    "/profile/{client_id}/restrictions/reresolve",
+    response_model=RestrictionResolution,
+)
+def reresolve_restrictions_route(client_id: str):
+    """SPEC-006: force a re-run of the resolver against the current
+    KB version. Previously-confirmed resolutions are preserved.
+
+    Rate limiting is tracked as a follow-up (spec §4.5); v1 ships
+    unlimited.
+    """
+    try:
+        return orchestrator.reresolve_restrictions(client_id)
+    except LookupError as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
 
 
 def _run_nutrition_plan_job(job_id: str, body: NutritionPlanRequest) -> None:

--- a/backend/agents/nutrition_meal_planning_team/models.py
+++ b/backend/agents/nutrition_meal_planning_team/models.py
@@ -3,9 +3,14 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Set
 
 from pydantic import BaseModel, Field, field_validator
+
+# SPEC-006: import only the taxonomy enums. ``ingredient_kb.taxonomy`` is a
+# pure stdlib module, so this is cycle-safe. Never import from
+# ``ingredient_kb.catalog`` or ``parser`` here — those pull yaml + file I/O.
+from .ingredient_kb.taxonomy import AllergenTag, DietaryTag
 
 # SPEC-002 schema version. Bump when the ClientProfile shape changes
 # in a way downstream consumers must observe. Kept as a plain string
@@ -189,6 +194,75 @@ class GoalsInfo(BaseModel):
     notes: str = ""
 
 
+# --- Restriction resolution (SPEC-006) -----------------------------------
+
+
+class ResolvedRestriction(BaseModel):
+    """One user restriction string resolved to canonical tags."""
+
+    raw: str
+    allergen_tags: List[AllergenTag] = Field(default_factory=list)
+    dietary_tags_forbid: List[DietaryTag] = Field(default_factory=list)
+    dietary_tags_require: List[DietaryTag] = Field(default_factory=list)
+    matched_canonical_ids: List[str] = Field(default_factory=list)
+    confidence: float = 1.0
+    source: str = "user"  # "user" | "shorthand" | "clinician"
+    rule: str = "exact_alias"  # exact_alias|shorthand|category|negation|fuzzy
+    soft_constraint: Optional[str] = None  # e.g. "low_carb", "sodium_very_high"
+    note: str = ""
+
+
+class AmbiguousRestriction(BaseModel):
+    """A user input that mapped to multiple plausible resolutions.
+
+    SPEC-006 §4.3: e.g. ``"nuts"`` could mean peanut, tree_nut, or both.
+    The resolver never picks silently — it emits candidates and a
+    human-readable question. Default-strict: the strictest candidate's
+    tags are still exposed via ``RestrictionResolution.active_*`` so
+    SPEC-007 can fail-closed before the user confirms.
+    """
+
+    raw: str
+    candidates: List[ResolvedRestriction]  # len >= 2
+    question: str
+
+
+class RestrictionResolution(BaseModel):
+    """SPEC-006 §4.1 — canonical tag resolution of a profile's raw lists."""
+
+    resolved: List[ResolvedRestriction] = Field(default_factory=list)
+    ambiguous: List[AmbiguousRestriction] = Field(default_factory=list)
+    unresolved: List[str] = Field(default_factory=list)
+    kb_version: str = ""
+    resolved_at: Optional[str] = None
+
+    def active_allergen_tags(self) -> Set[AllergenTag]:
+        """Union of resolved allergen tags plus the strictest candidate
+        from each unresolved ambiguity (default-strict, spec §6.2)."""
+        out: Set[AllergenTag] = set()
+        for r in self.resolved:
+            out.update(r.allergen_tags)
+        for amb in self.ambiguous:
+            strictest: Set[AllergenTag] = set()
+            for cand in amb.candidates:
+                strictest.update(cand.allergen_tags)
+            out.update(strictest)
+        return out
+
+    def active_dietary_forbid(self) -> Set[DietaryTag]:
+        """Union of resolved dietary-forbid tags plus the strictest
+        candidate from each unresolved ambiguity (default-strict)."""
+        out: Set[DietaryTag] = set()
+        for r in self.resolved:
+            out.update(r.dietary_tags_forbid)
+        for amb in self.ambiguous:
+            strictest: Set[DietaryTag] = set()
+            for cand in amb.candidates:
+                strictest.update(cand.dietary_tags_forbid)
+            out.update(strictest)
+        return out
+
+
 class ClientProfile(BaseModel):
     """Single source of truth for nutritionist and meal planning agents."""
 
@@ -205,6 +279,10 @@ class ClientProfile(BaseModel):
     goals: GoalsInfo = Field(default_factory=GoalsInfo)
     biometrics: BiometricInfo = Field(default_factory=BiometricInfo)
     clinical: ClinicalInfo = Field(default_factory=ClinicalInfo)
+    # SPEC-006: canonical tag resolution of the raw restriction lists.
+    # Populated by the resolver at intake time when the feature flag is on;
+    # otherwise left as the empty default.
+    restriction_resolution: RestrictionResolution = Field(default_factory=RestrictionResolution)
     # Monotonic write counter; bumped by the store on every save.
     profile_version: int = 1
     # Data-model version. Migrations that reshape ClientProfile bump
@@ -351,6 +429,21 @@ class ProfileUpdateRequest(BaseModel):
     goals: Optional[GoalsInfo] = None
     biometrics: Optional[BiometricInfo] = None
     clinical: Optional[ClinicalInfo] = None
+
+
+# --- SPEC-006 request models --------------------------------------------
+
+
+class ResolveAmbiguousRequest(BaseModel):
+    """Body for POST /profile/{client_id}/restrictions/resolve-ambiguous.
+
+    ``raw`` identifies the ambiguity (must match an entry in
+    ``RestrictionResolution.ambiguous[*].raw``). ``chosen_candidate`` is
+    the candidate the user picked; it is moved into ``resolved[]``.
+    """
+
+    raw: str
+    chosen_candidate: ResolvedRestriction
 
 
 # --- SPEC-002 additive request/response models ---------------------------

--- a/backend/agents/nutrition_meal_planning_team/orchestrator/agent.py
+++ b/backend/agents/nutrition_meal_planning_team/orchestrator/agent.py
@@ -67,6 +67,24 @@ class SafetyInvariantError(RuntimeError):
 logger = logging.getLogger(__name__)
 
 
+def _candidate_signature(c) -> tuple:
+    """Substantive identity of a SPEC-006 candidate for membership tests.
+
+    Compares on the fields that would change downstream enforcement
+    (allergen + dietary tag sets, soft constraint, matched canonical
+    ids). Cosmetic fields (``raw``, ``rule``, ``confidence``,
+    ``source``, ``note``) are intentionally excluded so a UI that
+    round-trips the offered candidate doesn't drift on metadata.
+    """
+    return (
+        frozenset(c.allergen_tags),
+        frozenset(c.dietary_tags_forbid),
+        frozenset(c.dietary_tags_require),
+        c.soft_constraint,
+        frozenset(c.matched_canonical_ids),
+    )
+
+
 class NutritionMealPlanningOrchestrator:
     """
     Single entry point: load profile/history as needed, delegate to intake/nutritionist/meal_planning agents.
@@ -121,17 +139,28 @@ class NutritionMealPlanningOrchestrator:
 
     def resolve_ambiguous(self, client_id: str, req):
         """Promote a user-chosen candidate from ``ambiguous[]`` to
-        ``resolved[]`` and persist. Raises :class:`LookupError` if the
-        profile is missing; :class:`ValueError` if the raw doesn't
-        match any ambiguity.
+        ``resolved[]`` and persist.
+
+        Raises:
+            LookupError: profile missing.
+            ValueError: ``req.raw`` doesn't match any stored ambiguity,
+                or ``req.chosen_candidate`` doesn't match any of the
+                candidates the resolver offered for that ambiguity.
+                The latter check prevents a client from persisting an
+                arbitrary tag set under the guise of an answer.
         """
         profile = self._load_profile_or_404(client_id)
         rr = profile.restriction_resolution
-        remaining = [a for a in rr.ambiguous if a.raw != req.raw]
-        if len(remaining) == len(rr.ambiguous):
+        target = next((a for a in rr.ambiguous if a.raw == req.raw), None)
+        if target is None:
             raise ValueError(f"no ambiguous entry for raw={req.raw!r}")
+        chosen_sig = _candidate_signature(req.chosen_candidate)
+        if not any(_candidate_signature(c) == chosen_sig for c in target.candidates):
+            raise ValueError(
+                f"chosen_candidate is not one of the offered candidates for raw={req.raw!r}"
+            )
         chosen = req.chosen_candidate.model_copy(update={"raw": req.raw})
-        rr.ambiguous = remaining
+        rr.ambiguous = [a for a in rr.ambiguous if a.raw != req.raw]
         rr.resolved.append(chosen)
         profile.restriction_resolution = rr
         self.profile_store.save_profile(client_id, profile)
@@ -141,10 +170,18 @@ class NutritionMealPlanningOrchestrator:
         """Re-run the resolver against the current ``KB_VERSION`` and
         persist. Previously-confirmed resolutions are preserved
         (additive-only behavior, spec §4.4).
+
+        Honors the ``NUTRITION_RESTRICTION_RESOLVER`` flag: when the
+        feature is off the existing (likely empty) resolution is
+        returned untouched, so this endpoint can never quietly turn
+        the feature on for a single profile.
         """
+        from ..agents.intake_profile_agent.restriction_hook import is_resolver_enabled
         from ..restriction_resolver import resolve_restrictions
 
         profile = self._load_profile_or_404(client_id)
+        if not is_resolver_enabled():
+            return profile.restriction_resolution
         fresh = resolve_restrictions(
             profile.allergies_and_intolerances or [],
             profile.dietary_needs or [],

--- a/backend/agents/nutrition_meal_planning_team/orchestrator/agent.py
+++ b/backend/agents/nutrition_meal_planning_team/orchestrator/agent.py
@@ -109,12 +109,15 @@ class NutritionMealPlanningOrchestrator:
 
     # --- SPEC-006: restriction resolution routes -------------------------
 
-    def get_restrictions(self, client_id: str):
-        """Return the stored :class:`RestrictionResolution` for a client."""
+    def _load_profile_or_404(self, client_id: str) -> ClientProfile:
         profile = self.profile_store.get_profile(client_id)
         if profile is None:
             raise LookupError(f"profile not found: {client_id}")
-        return profile.restriction_resolution
+        return profile
+
+    def get_restrictions(self, client_id: str):
+        """Return the stored :class:`RestrictionResolution` for a client."""
+        return self._load_profile_or_404(client_id).restriction_resolution
 
     def resolve_ambiguous(self, client_id: str, req):
         """Promote a user-chosen candidate from ``ambiguous[]`` to
@@ -122,9 +125,7 @@ class NutritionMealPlanningOrchestrator:
         profile is missing; :class:`ValueError` if the raw doesn't
         match any ambiguity.
         """
-        profile = self.profile_store.get_profile(client_id)
-        if profile is None:
-            raise LookupError(f"profile not found: {client_id}")
+        profile = self._load_profile_or_404(client_id)
         rr = profile.restriction_resolution
         remaining = [a for a in rr.ambiguous if a.raw != req.raw]
         if len(remaining) == len(rr.ambiguous):
@@ -143,9 +144,7 @@ class NutritionMealPlanningOrchestrator:
         """
         from ..restriction_resolver import resolve_restrictions
 
-        profile = self.profile_store.get_profile(client_id)
-        if profile is None:
-            raise LookupError(f"profile not found: {client_id}")
+        profile = self._load_profile_or_404(client_id)
         fresh = resolve_restrictions(
             profile.allergies_and_intolerances or [],
             profile.dietary_needs or [],

--- a/backend/agents/nutrition_meal_planning_team/orchestrator/agent.py
+++ b/backend/agents/nutrition_meal_planning_team/orchestrator/agent.py
@@ -107,6 +107,67 @@ class NutritionMealPlanningOrchestrator:
         self.profile_store.save_profile(client_id, profile)
         return profile
 
+    # --- SPEC-006: restriction resolution routes -------------------------
+
+    def get_restrictions(self, client_id: str):
+        """Return the stored :class:`RestrictionResolution` for a client."""
+        profile = self.profile_store.get_profile(client_id)
+        if profile is None:
+            raise LookupError(f"profile not found: {client_id}")
+        return profile.restriction_resolution
+
+    def resolve_ambiguous(self, client_id: str, req):
+        """Promote a user-chosen candidate from ``ambiguous[]`` to
+        ``resolved[]`` and persist. Raises :class:`LookupError` if the
+        profile is missing; :class:`ValueError` if the raw doesn't
+        match any ambiguity.
+        """
+        profile = self.profile_store.get_profile(client_id)
+        if profile is None:
+            raise LookupError(f"profile not found: {client_id}")
+        rr = profile.restriction_resolution
+        remaining = [a for a in rr.ambiguous if a.raw != req.raw]
+        if len(remaining) == len(rr.ambiguous):
+            raise ValueError(f"no ambiguous entry for raw={req.raw!r}")
+        chosen = req.chosen_candidate.model_copy(update={"raw": req.raw})
+        rr.ambiguous = remaining
+        rr.resolved.append(chosen)
+        profile.restriction_resolution = rr
+        self.profile_store.save_profile(client_id, profile)
+        return rr
+
+    def reresolve_restrictions(self, client_id: str):
+        """Re-run the resolver against the current ``KB_VERSION`` and
+        persist. Previously-confirmed resolutions are preserved
+        (additive-only behavior, spec §4.4).
+        """
+        from ..restriction_resolver import resolve_restrictions
+
+        profile = self.profile_store.get_profile(client_id)
+        if profile is None:
+            raise LookupError(f"profile not found: {client_id}")
+        fresh = resolve_restrictions(
+            profile.allergies_and_intolerances or [],
+            profile.dietary_needs or [],
+        )
+        # Preserve prior user-confirmed resolutions: anything in the old
+        # ``resolved[]`` whose raw re-surfaces as ambiguous keeps the
+        # prior resolution. New raws flow through normally.
+        old_confirmed = {r.raw: r for r in profile.restriction_resolution.resolved}
+        kept_resolved = list(fresh.resolved)
+        kept_ambiguous = []
+        for amb in fresh.ambiguous:
+            prior = old_confirmed.get(amb.raw)
+            if prior is not None:
+                kept_resolved.append(prior)
+            else:
+                kept_ambiguous.append(amb)
+        fresh.resolved = kept_resolved
+        fresh.ambiguous = kept_ambiguous
+        profile.restriction_resolution = fresh
+        self.profile_store.save_profile(client_id, profile)
+        return fresh
+
     def _get_or_generate_nutrition_plan(self, profile: ClientProfile) -> NutritionPlan:
         """Return cached nutrition plan if inputs unchanged, otherwise rebuild.
 

--- a/backend/agents/nutrition_meal_planning_team/postgres/__init__.py
+++ b/backend/agents/nutrition_meal_planning_team/postgres/__init__.py
@@ -94,6 +94,19 @@ SCHEMA = TeamSchema(
         "ALTER TABLE nutrition_plans ADD COLUMN IF NOT EXISTS profile_cache_vector TEXT",
         """CREATE INDEX IF NOT EXISTS idx_nutrition_plans_cache_key
             ON nutrition_plans(client_id, calculator_version, profile_cache_vector)""",
+        # --- SPEC-006 additions (restriction resolution) ---
+        # ``restriction_resolution`` mirrors the RestrictionResolution
+        # field inside ``profile`` JSONB; the separate column exists only
+        # so future scanners can query without parsing the whole profile.
+        # ``restriction_resolver_kb_version`` is a denormalized index key
+        # for the SPEC-006 W9 background re-resolver (finds profiles with
+        # an older KB version).
+        "ALTER TABLE nutrition_profiles ADD COLUMN IF NOT EXISTS "
+        "restriction_resolution JSONB NOT NULL DEFAULT '{}'::jsonb",
+        "ALTER TABLE nutrition_profiles ADD COLUMN IF NOT EXISTS "
+        "restriction_resolver_kb_version TEXT",
+        """CREATE INDEX IF NOT EXISTS idx_nutrition_profiles_resolver_kb_version
+            ON nutrition_profiles(restriction_resolver_kb_version)""",
     ],
     table_names=[
         "nutrition_profiles",

--- a/backend/agents/nutrition_meal_planning_team/restriction_resolver/__init__.py
+++ b/backend/agents/nutrition_meal_planning_team/restriction_resolver/__init__.py
@@ -3,6 +3,6 @@
 Public entry point: :func:`resolve_restrictions`.
 """
 
-from .resolver import FUZZY_THRESHOLD, resolve_restrictions
+from .resolver import resolve_restrictions
 
-__all__ = ["FUZZY_THRESHOLD", "resolve_restrictions"]
+__all__ = ["resolve_restrictions"]

--- a/backend/agents/nutrition_meal_planning_team/restriction_resolver/__init__.py
+++ b/backend/agents/nutrition_meal_planning_team/restriction_resolver/__init__.py
@@ -1,0 +1,8 @@
+"""SPEC-006 profile-side restriction resolver.
+
+Public entry point: :func:`resolve_restrictions`.
+"""
+
+from .resolver import FUZZY_THRESHOLD, resolve_restrictions
+
+__all__ = ["FUZZY_THRESHOLD", "resolve_restrictions"]

--- a/backend/agents/nutrition_meal_planning_team/restriction_resolver/data/shorthand.yaml
+++ b/backend/agents/nutrition_meal_planning_team/restriction_resolver/data/shorthand.yaml
@@ -1,0 +1,67 @@
+# SPEC-006 shorthand table v1.
+#
+# Closed table. Every ``forbid_dietary`` value must exist in
+# ``ingredient_kb.taxonomy.DietaryTag``; every ``forbid_allergen``
+# must exist in ``AllergenTag``. The loader fails fast on unknowns;
+# the parity test (test_shorthand_against_taxonomy) enforces the
+# same invariant against the raw YAML to catch drift the loader
+# might mask.
+#
+# Synonyms are normalized through
+# ``ingredient_kb.normalizer.normalize`` before comparison, so
+# lowercase/whitespace/diacritics don't need to be covered here.
+#
+# Adding a row requires team-lead sign-off per spec §4.2.
+
+- name: vegan
+  synonyms: ["vegan", "plant-based", "plant based"]
+  forbid_dietary: [animal, dairy, egg, honey, gelatin]
+
+- name: vegetarian
+  synonyms: ["vegetarian", "veggie"]
+  forbid_dietary: [animal]
+  note: "allows dairy and eggs by default"
+
+- name: pescatarian
+  synonyms: ["pescatarian", "pescetarian"]
+  forbid_dietary: [animal]
+  note: "allows fish, shellfish, dairy, eggs"
+
+- name: gluten_free
+  # Note: we forbid BOTH the dietary ``gluten`` tag AND the
+  # allergen ``gluten`` + ``wheat`` tags. The taxonomy docstring
+  # explicitly treats gluten and wheat as separate allergens
+  # (spelt/barley/rye are gluten-bearing non-wheat); GF users need
+  # both blocked.
+  synonyms: ["gluten-free", "gluten free", "gf"]
+  forbid_dietary: [gluten]
+  forbid_allergen: [gluten, wheat]
+
+- name: dairy_free
+  synonyms: ["dairy-free", "dairy free", "lactose-free", "lactose free"]
+  forbid_dietary: [dairy]
+  forbid_allergen: [dairy]
+
+- name: paleo
+  synonyms: ["paleo", "paleolithic"]
+  forbid_dietary: [dairy, grain, legume]
+
+- name: halal
+  synonyms: ["halal"]
+  forbid_dietary: [alcohol]
+  note: "requires halal-certified meat preparation (not enforced in v1)"
+
+- name: kosher
+  synonyms: ["kosher"]
+  forbid_dietary: []
+  note: "requires kosher preparation (not enforced in v1)"
+
+- name: keto
+  synonyms: ["keto", "ketogenic"]
+  soft_constraint: low_carb
+  note: "advisory only; not enforced as forbid in v1"
+
+- name: low_sodium
+  synonyms: ["low-sodium", "low sodium", "low salt", "low-salt"]
+  soft_constraint: sodium_very_high
+  note: "maps to InteractionTag.sodium_very_high at SPEC-007 enforcement"

--- a/backend/agents/nutrition_meal_planning_team/restriction_resolver/metrics.py
+++ b/backend/agents/nutrition_meal_planning_team/restriction_resolver/metrics.py
@@ -1,0 +1,69 @@
+"""OTel counters for the SPEC-006 restriction resolver.
+
+Two instruments are emitted from the resolver:
+
+- ``nutrition.restriction.resolve`` — one point per input with
+  ``outcome`` ∈ {resolved, ambiguous, unresolved} and ``rule`` ∈
+  {exact_alias, shorthand, category, negation, fuzzy, unresolved}.
+- ``nutrition.restriction.shorthand_used`` — one point per shorthand
+  expansion, labelled with the shorthand ``name``.
+
+Both are lazily initialized so the resolver remains a pure function
+for call sites that haven't set up OTel (tests, direct imports).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_initialized = False
+_counter_resolve: Optional[Any] = None
+_counter_shorthand: Optional[Any] = None
+
+
+def _ensure_instruments() -> None:
+    global _initialized, _counter_resolve, _counter_shorthand
+    if _initialized:
+        return
+    _initialized = True
+    try:
+        from shared_observability import get_meter
+
+        meter = get_meter("khala.nutrition.restriction")
+        _counter_resolve = meter.create_counter(
+            "nutrition.restriction.resolve",
+            description="Count of restriction resolutions by outcome and rule",
+        )
+        _counter_shorthand = meter.create_counter(
+            "nutrition.restriction.shorthand_used",
+            description="Count of shorthand expansions by canonical name",
+        )
+    except Exception:
+        logger.debug("restriction resolver metrics init failed", exc_info=True)
+        _counter_resolve = None
+        _counter_shorthand = None
+
+
+def record_outcome(outcome: str, rule: str = "") -> None:
+    """Record one resolver outcome. No-op if OTel is unavailable."""
+    _ensure_instruments()
+    if _counter_resolve is None:
+        return
+    try:
+        _counter_resolve.add(1, {"outcome": outcome, "rule": rule})
+    except Exception:
+        logger.debug("restriction resolve counter add failed", exc_info=True)
+
+
+def record_shorthand(name: str) -> None:
+    """Record one shorthand expansion. No-op if OTel is unavailable."""
+    _ensure_instruments()
+    if _counter_shorthand is None:
+        return
+    try:
+        _counter_shorthand.add(1, {"name": name})
+    except Exception:
+        logger.debug("restriction shorthand counter add failed", exc_info=True)

--- a/backend/agents/nutrition_meal_planning_team/restriction_resolver/negation.py
+++ b/backend/agents/nutrition_meal_planning_team/restriction_resolver/negation.py
@@ -1,0 +1,54 @@
+"""Negation-pattern detection for restriction inputs.
+
+Users write ``"no cashews"`` / ``"avoid peanuts"`` / ``"gluten-free"``
+/ ``"without dairy"`` when they mean the same thing as the bare
+ingredient. The resolver runs negation detection first, strips the
+marker, and then routes the residue through the normal cascade. The
+original raw string is preserved on the resolved record.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+# Leading markers: ``no X``, ``avoid X``, ``without X``, ``free of X``.
+_LEADING = re.compile(
+    r"^\s*(no|avoid|without|free\s+of)\s+(?P<rest>.+?)\s*$",
+    re.IGNORECASE,
+)
+
+# Trailing markers: ``X-free``, ``X free``. Match only when ``free`` is
+# the last token so we don't strip from things like ``free-range eggs``.
+_TRAILING = re.compile(
+    r"^\s*(?P<rest>.+?)[\s-]+free\s*$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class Negation:
+    """Result of negation detection."""
+
+    is_negation: bool
+    stripped: str  # the payload with the marker removed (empty if none)
+    pattern: str = ""  # "leading" | "trailing" | ""
+
+
+def detect(raw: str) -> Negation:
+    """Return a :class:`Negation` describing whether ``raw`` is a
+    negated restriction and what the bare payload is.
+
+    ``stripped`` is untouched by normalization — the caller runs the
+    existing normalizer on it as part of the cascade. This keeps the
+    module dependency-free and easy to test.
+    """
+    if not raw or not raw.strip():
+        return Negation(is_negation=False, stripped="")
+    m = _LEADING.match(raw)
+    if m:
+        return Negation(is_negation=True, stripped=m.group("rest"), pattern="leading")
+    m = _TRAILING.match(raw)
+    if m:
+        return Negation(is_negation=True, stripped=m.group("rest"), pattern="trailing")
+    return Negation(is_negation=False, stripped=raw)

--- a/backend/agents/nutrition_meal_planning_team/restriction_resolver/resolver.py
+++ b/backend/agents/nutrition_meal_planning_team/restriction_resolver/resolver.py
@@ -90,7 +90,6 @@ def _mk_candidate(
     allergens: Tuple[AllergenTag, ...] = (),
     soft: Optional[str] = None,
     note: str = "",
-    rule: str = "category",
 ) -> ResolvedRestriction:
     return ResolvedRestriction(
         raw=raw,
@@ -99,7 +98,6 @@ def _mk_candidate(
         note=note,
         confidence=1.0,
         source="user",
-        rule=rule,
     )
 
 
@@ -112,8 +110,7 @@ def _build_ambiguity_table() -> Dict[str, _AmbiguityEntry]:
     table: Dict[str, _AmbiguityEntry] = {}
 
     # "nuts" / "nut" — both normalize to "nut"
-    nuts_key = normalize("nuts")
-    table[nuts_key] = _AmbiguityEntry(
+    table[normalize("nuts")] = _AmbiguityEntry(
         candidates=(
             _mk_candidate("nuts", allergens=(AllergenTag.peanut,)),
             _mk_candidate("nuts", allergens=(AllergenTag.tree_nut,)),
@@ -126,8 +123,7 @@ def _build_ambiguity_table() -> Dict[str, _AmbiguityEntry]:
     )
 
     # "seafood"
-    seafood_key = normalize("seafood")
-    table[seafood_key] = _AmbiguityEntry(
+    table[normalize("seafood")] = _AmbiguityEntry(
         candidates=(
             _mk_candidate("seafood", allergens=(AllergenTag.fish,)),
             _mk_candidate("seafood", allergens=(AllergenTag.shellfish,)),
@@ -141,25 +137,15 @@ def _build_ambiguity_table() -> Dict[str, _AmbiguityEntry]:
                 ),
             ),
         ),
-        question=("Does 'seafood' include all of fish, shellfish, and molluscs?"),
+        question="Does 'seafood' include all of fish, shellfish, and molluscs?",
     )
 
-    # "low-carb" / "low carb" — normalize drops nothing, so cover both
+    # "low-carb" / "low carb" — normalize keeps the hyphen, so cover both
     for label in ("low-carb", "low carb"):
         table[normalize(label)] = _AmbiguityEntry(
             candidates=(
-                _mk_candidate(
-                    label,
-                    soft="low_carb",
-                    note="advisory reduction only",
-                    rule="shorthand",
-                ),
-                _mk_candidate(
-                    label,
-                    soft="low_carb",
-                    note="keto-style hard restriction",
-                    rule="shorthand",
-                ),
+                _mk_candidate(label, soft="low_carb", note="advisory reduction only"),
+                _mk_candidate(label, soft="low_carb", note="keto-style hard restriction"),
             ),
             question="How strict is your low-carb preference?",
         )
@@ -167,14 +153,7 @@ def _build_ambiguity_table() -> Dict[str, _AmbiguityEntry]:
     return table
 
 
-_AMBIGUITY_TABLE: Optional[Dict[str, _AmbiguityEntry]] = None
-
-
-def _ambiguity_lookup(norm: str) -> Optional[_AmbiguityEntry]:
-    global _AMBIGUITY_TABLE
-    if _AMBIGUITY_TABLE is None:
-        _AMBIGUITY_TABLE = _build_ambiguity_table()
-    return _AMBIGUITY_TABLE.get(norm)
+_AMBIGUITY_TABLE: Dict[str, _AmbiguityEntry] = _build_ambiguity_table()
 
 
 def _cascade(
@@ -235,7 +214,7 @@ def _cascade(
         )
 
     # Rule 4: ambiguity table
-    amb = _ambiguity_lookup(norm)
+    amb = _AMBIGUITY_TABLE.get(norm)
     if amb is not None:
         return (
             None,

--- a/backend/agents/nutrition_meal_planning_team/restriction_resolver/resolver.py
+++ b/backend/agents/nutrition_meal_planning_team/restriction_resolver/resolver.py
@@ -1,0 +1,345 @@
+"""SPEC-006 restriction resolver.
+
+Pure function ``resolve_restrictions(allergies, dietary_needs)`` that
+turns user free-text lists into a :class:`RestrictionResolution` of
+canonical tag sets.
+
+Cascade (applied per input string, stop at first hit):
+
+1. **Exact alias** — ``ingredient_kb.alias_index.lookup`` returns
+   ``score == 1.0``. Produces a resolution with the catalog entry's
+   allergen + dietary tags and the matched canonical id.
+2. **Shorthand** — ``shorthand.yaml`` synonym hit (vegan, keto,
+   gluten-free, …).
+3. **Allergen category** — direct enum-name match (``tree nut``,
+   ``shellfish``, ``gluten``, etc.).
+4. **Ambiguity table** — curated entries with multiple plausible
+   resolutions (``nuts``, ``seafood``, ``low-carb``). Emits an
+   :class:`AmbiguousRestriction` the UI surfaces to the user. Default-
+   strict: ``RestrictionResolution.active_*`` unions every candidate's
+   tags so SPEC-007 can enforce pre-confirm.
+5. **Fuzzy alias** — ``alias_index.lookup`` score ≥
+   :data:`FUZZY_THRESHOLD` (0.85). The KB's own floor is 0.5 for
+   ingredient-parser use; restrictions need the tighter gate.
+6. **Unresolved** — falls into ``unresolved[]``.
+
+Negation (``"no X"`` / ``"X-free"`` / ``"avoid X"``) is a
+preprocessing step: the bare payload feeds the cascade; the raw
+string is preserved on the resolved record.
+
+No I/O, no LLM, no network. Safe to call from any layer.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Dict, List, Optional, Tuple
+
+from ..ingredient_kb.catalog import get_alias_index, get_catalog
+from ..ingredient_kb.normalizer import normalize
+from ..ingredient_kb.taxonomy import AllergenTag
+from ..ingredient_kb.version import KB_VERSION
+from ..models import (
+    AmbiguousRestriction,
+    ResolvedRestriction,
+    RestrictionResolution,
+)
+from . import metrics, negation, shorthand
+
+FUZZY_THRESHOLD = 0.85
+
+
+# Allergen-category direct names. Keys are already-normalized strings
+# (depluralized, lowercased). Variants with/without hyphens cover both
+# ``tree nut`` and ``tree-nut``.
+_ALLERGEN_CATEGORY: Dict[str, AllergenTag] = {
+    "peanut": AllergenTag.peanut,
+    "tree nut": AllergenTag.tree_nut,
+    "tree-nut": AllergenTag.tree_nut,
+    "treenut": AllergenTag.tree_nut,
+    "shellfish": AllergenTag.shellfish,
+    "gluten": AllergenTag.gluten,
+    "fish": AllergenTag.fish,
+    "dairy": AllergenTag.dairy,
+    "milk": AllergenTag.dairy,
+    "egg": AllergenTag.egg,
+    "soy": AllergenTag.soy,
+    "soya": AllergenTag.soy,
+    "wheat": AllergenTag.wheat,
+    "sesame": AllergenTag.sesame,
+    "mustard": AllergenTag.mustard,
+    "celery": AllergenTag.celery,
+    "sulfite": AllergenTag.sulfites,
+    "sulphite": AllergenTag.sulfites,
+    "lupin": AllergenTag.lupin,
+    "mollusc": AllergenTag.mollusc,
+    "mollusk": AllergenTag.mollusc,
+}
+
+
+@dataclass(frozen=True)
+class _AmbiguityEntry:
+    candidates: Tuple[ResolvedRestriction, ...]
+    question: str
+
+
+def _mk_candidate(
+    raw: str,
+    *,
+    allergens: Tuple[AllergenTag, ...] = (),
+    soft: Optional[str] = None,
+    note: str = "",
+    rule: str = "category",
+) -> ResolvedRestriction:
+    return ResolvedRestriction(
+        raw=raw,
+        allergen_tags=list(allergens),
+        soft_constraint=soft,
+        note=note,
+        confidence=1.0,
+        source="user",
+        rule=rule,
+    )
+
+
+def _build_ambiguity_table() -> Dict[str, _AmbiguityEntry]:
+    """Return ``{normalized_key: entry}``.
+
+    Keys are the *normalized* form of the raw input so the cascade can
+    look up in O(1) after normalizing once.
+    """
+    table: Dict[str, _AmbiguityEntry] = {}
+
+    # "nuts" / "nut" — both normalize to "nut"
+    nuts_key = normalize("nuts")
+    table[nuts_key] = _AmbiguityEntry(
+        candidates=(
+            _mk_candidate("nuts", allergens=(AllergenTag.peanut,)),
+            _mk_candidate("nuts", allergens=(AllergenTag.tree_nut,)),
+            _mk_candidate("nuts", allergens=(AllergenTag.peanut, AllergenTag.tree_nut)),
+        ),
+        question=(
+            "By 'nuts', do you mean peanuts, tree nuts, or both? "
+            "Peanuts and tree nuts are separate allergens."
+        ),
+    )
+
+    # "seafood"
+    seafood_key = normalize("seafood")
+    table[seafood_key] = _AmbiguityEntry(
+        candidates=(
+            _mk_candidate("seafood", allergens=(AllergenTag.fish,)),
+            _mk_candidate("seafood", allergens=(AllergenTag.shellfish,)),
+            _mk_candidate("seafood", allergens=(AllergenTag.mollusc,)),
+            _mk_candidate(
+                "seafood",
+                allergens=(
+                    AllergenTag.fish,
+                    AllergenTag.shellfish,
+                    AllergenTag.mollusc,
+                ),
+            ),
+        ),
+        question=("Does 'seafood' include all of fish, shellfish, and molluscs?"),
+    )
+
+    # "low-carb" / "low carb" — normalize drops nothing, so cover both
+    for label in ("low-carb", "low carb"):
+        table[normalize(label)] = _AmbiguityEntry(
+            candidates=(
+                _mk_candidate(
+                    label,
+                    soft="low_carb",
+                    note="advisory reduction only",
+                    rule="shorthand",
+                ),
+                _mk_candidate(
+                    label,
+                    soft="low_carb",
+                    note="keto-style hard restriction",
+                    rule="shorthand",
+                ),
+            ),
+            question="How strict is your low-carb preference?",
+        )
+
+    return table
+
+
+_AMBIGUITY_TABLE: Optional[Dict[str, _AmbiguityEntry]] = None
+
+
+def _ambiguity_lookup(norm: str) -> Optional[_AmbiguityEntry]:
+    global _AMBIGUITY_TABLE
+    if _AMBIGUITY_TABLE is None:
+        _AMBIGUITY_TABLE = _build_ambiguity_table()
+    return _AMBIGUITY_TABLE.get(norm)
+
+
+def _cascade(
+    raw: str, norm: str
+) -> Tuple[Optional[ResolvedRestriction], Optional[AmbiguousRestriction]]:
+    """Run rules 1–5 for a single normalized key. Returns
+    ``(resolved, ambiguous)`` — exactly one is non-None on success,
+    both None on a miss.
+    """
+    alias_index = get_alias_index()
+    catalog = get_catalog()
+    match = alias_index.lookup(norm)
+    if match is not None and match.score >= 1.0:
+        food = catalog[match.canonical_id]
+        return (
+            ResolvedRestriction(
+                raw=raw,
+                allergen_tags=list(food.allergen_tags),
+                dietary_tags_forbid=list(food.dietary_tags),
+                matched_canonical_ids=[match.canonical_id],
+                confidence=1.0,
+                source="user",
+                rule="exact_alias",
+            ),
+            None,
+        )
+
+    # Rule 2: shorthand
+    sh = shorthand.lookup(norm)
+    if sh is not None:
+        metrics.record_shorthand(sh.name)
+        return (
+            ResolvedRestriction(
+                raw=raw,
+                allergen_tags=list(sh.forbid_allergen),
+                dietary_tags_forbid=list(sh.forbid_dietary),
+                confidence=1.0,
+                source="shorthand",
+                rule="shorthand",
+                soft_constraint=sh.soft_constraint,
+                note=sh.note or "",
+            ),
+            None,
+        )
+
+    # Rule 3: allergen category
+    cat = _ALLERGEN_CATEGORY.get(norm)
+    if cat is not None:
+        return (
+            ResolvedRestriction(
+                raw=raw,
+                allergen_tags=[cat],
+                confidence=1.0,
+                source="user",
+                rule="category",
+            ),
+            None,
+        )
+
+    # Rule 4: ambiguity table
+    amb = _ambiguity_lookup(norm)
+    if amb is not None:
+        return (
+            None,
+            AmbiguousRestriction(
+                raw=raw,
+                candidates=list(amb.candidates),
+                question=amb.question,
+            ),
+        )
+
+    # Rule 5: fuzzy alias match
+    if match is not None and match.score >= FUZZY_THRESHOLD:
+        food = catalog[match.canonical_id]
+        return (
+            ResolvedRestriction(
+                raw=raw,
+                allergen_tags=list(food.allergen_tags),
+                dietary_tags_forbid=list(food.dietary_tags),
+                matched_canonical_ids=[match.canonical_id],
+                confidence=match.score,
+                source="user",
+                rule="fuzzy",
+            ),
+            None,
+        )
+
+    return None, None
+
+
+def _resolve_one(
+    raw: str,
+) -> Tuple[Optional[ResolvedRestriction], Optional[AmbiguousRestriction], Optional[str]]:
+    """Return ``(resolved, ambiguous, unresolved_raw)`` — exactly one
+    of the first two is non-None, or ``unresolved_raw`` is set.
+    """
+    if not raw or not raw.strip():
+        return None, None, None  # silently drop empty inputs
+
+    # First pass: run cascade on the raw as-is. Shorthand entries like
+    # ``"gluten-free"`` must win over negation-stripping to
+    # ``"gluten"``, since the shorthand is the more specific resolution.
+    norm = normalize(raw)
+    if norm:
+        resolved, ambiguous = _cascade(raw, norm)
+        if resolved is not None:
+            metrics.record_outcome("resolved", rule=resolved.rule)
+            return resolved, None, None
+        if ambiguous is not None:
+            metrics.record_outcome("ambiguous", rule="ambiguity_table")
+            return None, ambiguous, None
+
+    # Second pass: strip negation markers ("no X", "avoid X", "X-free")
+    # and retry the cascade on the bare payload. Raw is preserved.
+    neg = negation.detect(raw)
+    if neg.is_negation:
+        norm2 = normalize(neg.stripped)
+        if norm2:
+            resolved, ambiguous = _cascade(raw, norm2)
+            if resolved is not None:
+                metrics.record_outcome("resolved", rule=resolved.rule)
+                return resolved, None, None
+            if ambiguous is not None:
+                metrics.record_outcome("ambiguous", rule="ambiguity_table")
+                return None, ambiguous, None
+
+    # Rule 6: unresolved
+    metrics.record_outcome("unresolved", rule="unresolved")
+    return None, None, raw
+
+
+def resolve_restrictions(
+    allergies: List[str],
+    dietary_needs: List[str],
+) -> RestrictionResolution:
+    """Resolve raw restriction strings to canonical tag sets.
+
+    Both lists feed the same cascade — users mislabel routinely, so
+    divergent rules per list would surprise. Duplicate raw strings
+    across the lists are resolved once (first occurrence wins).
+    """
+    resolved: List[ResolvedRestriction] = []
+    ambiguous: List[AmbiguousRestriction] = []
+    unresolved: List[str] = []
+    seen: set[str] = set()
+
+    for raw in list(allergies or []) + list(dietary_needs or []):
+        if raw is None:
+            continue
+        key = (raw or "").strip().lower()
+        if not key or key in seen:
+            continue
+        seen.add(key)
+        r, a, u = _resolve_one(raw)
+        if r is not None:
+            resolved.append(r)
+        elif a is not None:
+            ambiguous.append(a)
+        elif u is not None:
+            unresolved.append(u)
+
+    return RestrictionResolution(
+        resolved=resolved,
+        ambiguous=ambiguous,
+        unresolved=unresolved,
+        kb_version=KB_VERSION,
+        resolved_at=datetime.now(tz=timezone.utc).isoformat(),
+    )

--- a/backend/agents/nutrition_meal_planning_team/restriction_resolver/shorthand.py
+++ b/backend/agents/nutrition_meal_planning_team/restriction_resolver/shorthand.py
@@ -38,23 +38,16 @@ class ShorthandEntry:
     synonyms: Tuple[str, ...] = field(default_factory=tuple)
 
 
-def _coerce_dietary(raw) -> Tuple[DietaryTag, ...]:
+def _coerce(raw, enum_cls):
+    """Map a list of YAML strings to enum members, raising
+    :class:`ShorthandError` on any unknown value.
+    """
     out = []
     for tag in raw or []:
         try:
-            out.append(DietaryTag(tag))
+            out.append(enum_cls(tag))
         except ValueError as exc:
-            raise ShorthandError(f"shorthand.yaml: unknown DietaryTag {tag!r}") from exc
-    return tuple(out)
-
-
-def _coerce_allergen(raw) -> Tuple[AllergenTag, ...]:
-    out = []
-    for tag in raw or []:
-        try:
-            out.append(AllergenTag(tag))
-        except ValueError as exc:
-            raise ShorthandError(f"shorthand.yaml: unknown AllergenTag {tag!r}") from exc
+            raise ShorthandError(f"shorthand.yaml: unknown {enum_cls.__name__} {tag!r}") from exc
     return tuple(out)
 
 
@@ -81,8 +74,8 @@ def get_shorthand_index() -> Dict[str, ShorthandEntry]:
             raise ShorthandError("shorthand.yaml entry missing 'name'")
         entry = ShorthandEntry(
             name=name,
-            forbid_dietary=_coerce_dietary(row.get("forbid_dietary")),
-            forbid_allergen=_coerce_allergen(row.get("forbid_allergen")),
+            forbid_dietary=_coerce(row.get("forbid_dietary"), DietaryTag),
+            forbid_allergen=_coerce(row.get("forbid_allergen"), AllergenTag),
             soft_constraint=row.get("soft_constraint"),
             note=row.get("note", ""),
             synonyms=tuple(row.get("synonyms") or ()),

--- a/backend/agents/nutrition_meal_planning_team/restriction_resolver/shorthand.py
+++ b/backend/agents/nutrition_meal_planning_team/restriction_resolver/shorthand.py
@@ -1,0 +1,113 @@
+"""Loader for the SPEC-006 shorthand table.
+
+``shorthand.yaml`` maps closed dietary-pattern names (``vegan``,
+``keto``, ``gluten-free``, …) to the canonical tag sets they expand
+to. The loader validates every tag against the SPEC-005 enums at
+import time, so an unknown string in YAML raises here rather than
+surfacing as a runtime mystery at resolution time.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+import yaml
+
+from ..ingredient_kb.normalizer import normalize
+from ..ingredient_kb.taxonomy import AllergenTag, DietaryTag
+
+_DATA_PATH = Path(__file__).resolve().parent / "data" / "shorthand.yaml"
+
+
+class ShorthandError(ValueError):
+    """Raised when ``shorthand.yaml`` fails validation."""
+
+
+@dataclass(frozen=True)
+class ShorthandEntry:
+    """One row of ``shorthand.yaml`` with tags coerced to enums."""
+
+    name: str
+    forbid_dietary: Tuple[DietaryTag, ...] = ()
+    forbid_allergen: Tuple[AllergenTag, ...] = ()
+    soft_constraint: Optional[str] = None
+    note: str = ""
+    synonyms: Tuple[str, ...] = field(default_factory=tuple)
+
+
+def _coerce_dietary(raw) -> Tuple[DietaryTag, ...]:
+    out = []
+    for tag in raw or []:
+        try:
+            out.append(DietaryTag(tag))
+        except ValueError as exc:
+            raise ShorthandError(f"shorthand.yaml: unknown DietaryTag {tag!r}") from exc
+    return tuple(out)
+
+
+def _coerce_allergen(raw) -> Tuple[AllergenTag, ...]:
+    out = []
+    for tag in raw or []:
+        try:
+            out.append(AllergenTag(tag))
+        except ValueError as exc:
+            raise ShorthandError(f"shorthand.yaml: unknown AllergenTag {tag!r}") from exc
+    return tuple(out)
+
+
+@lru_cache(maxsize=1)
+def get_shorthand_index() -> Dict[str, ShorthandEntry]:
+    """Return ``{normalized_synonym: ShorthandEntry}``.
+
+    Cached for the life of the process; the YAML is tiny and closed.
+    Raises :class:`ShorthandError` on duplicate synonyms or unknown tags.
+    """
+    if not _DATA_PATH.exists():
+        raise ShorthandError(f"shorthand.yaml missing at {_DATA_PATH}")
+    with _DATA_PATH.open("r", encoding="utf-8") as fh:
+        rows = yaml.safe_load(fh) or []
+    if not isinstance(rows, list):
+        raise ShorthandError("shorthand.yaml root must be a list")
+
+    index: Dict[str, ShorthandEntry] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            raise ShorthandError(f"shorthand.yaml entry must be a mapping: {row!r}")
+        name = row.get("name")
+        if not name:
+            raise ShorthandError("shorthand.yaml entry missing 'name'")
+        entry = ShorthandEntry(
+            name=name,
+            forbid_dietary=_coerce_dietary(row.get("forbid_dietary")),
+            forbid_allergen=_coerce_allergen(row.get("forbid_allergen")),
+            soft_constraint=row.get("soft_constraint"),
+            note=row.get("note", ""),
+            synonyms=tuple(row.get("synonyms") or ()),
+        )
+        synonyms = list(entry.synonyms) or [entry.name]
+        for raw_syn in synonyms:
+            key = normalize(raw_syn)
+            if not key:
+                continue
+            if key in index:
+                raise ShorthandError(
+                    f"shorthand.yaml: duplicate synonym {raw_syn!r} "
+                    f"(maps to both {index[key].name!r} and {entry.name!r})"
+                )
+            index[key] = entry
+    return index
+
+
+def lookup(raw_or_normalized: str) -> Optional[ShorthandEntry]:
+    """Return the shorthand entry for a string, or None.
+
+    Accepts either a raw user string (will be normalized) or an
+    already-normalized query.
+    """
+    key = normalize(raw_or_normalized)
+    if not key:
+        return None
+    return get_shorthand_index().get(key)

--- a/backend/agents/nutrition_meal_planning_team/restriction_resolver/tests/test_resolver_ambiguity.py
+++ b/backend/agents/nutrition_meal_planning_team/restriction_resolver/tests/test_resolver_ambiguity.py
@@ -1,0 +1,53 @@
+"""SPEC-006 §6.1 + §6.2 — ambiguous inputs and default-strict tags."""
+
+from nutrition_meal_planning_team.ingredient_kb.taxonomy import AllergenTag
+from nutrition_meal_planning_team.restriction_resolver import resolve_restrictions
+
+
+def _only_ambiguous(result):
+    assert result.resolved == []
+    assert result.unresolved == []
+    assert len(result.ambiguous) >= 1
+    return result.ambiguous
+
+
+def test_nuts_is_ambiguous_and_default_strict_includes_both():
+    r = resolve_restrictions(["nuts"], [])
+    amb = _only_ambiguous(r)
+    assert amb[0].raw == "nuts"
+    assert len(amb[0].candidates) >= 3
+    # Default-strict: active tags include both peanut AND tree_nut.
+    active = r.active_allergen_tags()
+    assert AllergenTag.peanut in active
+    assert AllergenTag.tree_nut in active
+
+
+def test_seafood_candidates_include_mollusc():
+    r = resolve_restrictions(["seafood"], [])
+    amb = _only_ambiguous(r)
+    # Strictest candidate (union) includes mollusc.
+    active = r.active_allergen_tags()
+    assert AllergenTag.fish in active
+    assert AllergenTag.shellfish in active
+    assert AllergenTag.mollusc in active
+    assert "molluscs" in amb[0].question.lower()
+
+
+def test_low_carb_is_ambiguous():
+    r = resolve_restrictions([], ["low-carb"])
+    amb = _only_ambiguous(r)
+    assert len(amb[0].candidates) == 2
+    # Both candidates carry the low_carb soft constraint.
+    assert all(c.soft_constraint == "low_carb" for c in amb[0].candidates)
+
+
+def test_resolving_ambiguous_after_the_fact_does_not_reprompt():
+    # Simulate the flow: initial resolve → ambiguous. After the user's
+    # chosen candidate is promoted into ``resolved[]`` (done by the API
+    # handler), re-running the resolver over the SAME raw list still
+    # yields the ambiguity (resolver is stateless); the promotion lives
+    # on the stored profile. This test pins the resolver's purity.
+    r1 = resolve_restrictions(["nuts"], [])
+    r2 = resolve_restrictions(["nuts"], [])
+    assert len(r1.ambiguous) == len(r2.ambiguous) == 1
+    assert r1.ambiguous[0].raw == r2.ambiguous[0].raw == "nuts"

--- a/backend/agents/nutrition_meal_planning_team/restriction_resolver/tests/test_resolver_exact.py
+++ b/backend/agents/nutrition_meal_planning_team/restriction_resolver/tests/test_resolver_exact.py
@@ -1,0 +1,49 @@
+"""SPEC-006 §6.1 — exact alias resolution."""
+
+from nutrition_meal_planning_team.ingredient_kb.taxonomy import AllergenTag
+from nutrition_meal_planning_team.restriction_resolver import resolve_restrictions
+
+
+def _only_resolved(result):
+    assert result.ambiguous == []
+    assert result.unresolved == []
+    return result.resolved
+
+
+def test_cashew_resolves_via_exact_alias():
+    r = resolve_restrictions(["cashew"], [])
+    resolved = _only_resolved(r)
+    assert len(resolved) == 1
+    entry = resolved[0]
+    assert entry.raw == "cashew"
+    assert entry.rule == "exact_alias"
+    assert entry.confidence == 1.0
+    assert AllergenTag.tree_nut in entry.allergen_tags
+    assert "cashew" in entry.matched_canonical_ids
+
+
+def test_almond_resolves_with_tree_nut():
+    r = resolve_restrictions(["almond"], [])
+    resolved = _only_resolved(r)
+    assert len(resolved) == 1
+    assert AllergenTag.tree_nut in resolved[0].allergen_tags
+    assert "almond" in resolved[0].matched_canonical_ids
+
+
+def test_peanut_resolves_with_peanut_allergen():
+    r = resolve_restrictions(["peanut"], [])
+    resolved = _only_resolved(r)
+    assert len(resolved) == 1
+    assert AllergenTag.peanut in resolved[0].allergen_tags
+    assert "peanut" in resolved[0].matched_canonical_ids
+
+
+def test_shellfish_category_match():
+    # "shellfish" is not a canonical food; it's an allergen category.
+    r = resolve_restrictions(["shellfish"], [])
+    resolved = _only_resolved(r)
+    assert len(resolved) == 1
+    entry = resolved[0]
+    assert entry.rule == "category"
+    assert entry.allergen_tags == [AllergenTag.shellfish]
+    assert entry.matched_canonical_ids == []

--- a/backend/agents/nutrition_meal_planning_team/restriction_resolver/tests/test_resolver_negation.py
+++ b/backend/agents/nutrition_meal_planning_team/restriction_resolver/tests/test_resolver_negation.py
@@ -1,0 +1,46 @@
+"""SPEC-006 §6.1 — negation-pattern handling."""
+
+from nutrition_meal_planning_team.ingredient_kb.taxonomy import AllergenTag
+from nutrition_meal_planning_team.restriction_resolver import resolve_restrictions
+
+
+def _only_resolved(result, n=1):
+    assert result.ambiguous == []
+    assert result.unresolved == []
+    assert len(result.resolved) == n
+    return result.resolved
+
+
+def test_no_cashews_preserves_raw_and_resolves_like_cashew():
+    r = resolve_restrictions(["no cashews"], [])
+    resolved = _only_resolved(r)
+    entry = resolved[0]
+    assert entry.raw == "no cashews"  # raw preserved
+    assert AllergenTag.tree_nut in entry.allergen_tags
+    assert "cashew" in entry.matched_canonical_ids
+
+
+def test_avoid_gluten_resolves_via_category():
+    r = resolve_restrictions(["avoid gluten"], [])
+    resolved = _only_resolved(r)
+    entry = resolved[0]
+    assert entry.raw == "avoid gluten"
+    assert entry.rule == "category"
+    assert entry.allergen_tags == [AllergenTag.gluten]
+
+
+def test_unknown_x_free_falls_through_to_unresolved():
+    r = resolve_restrictions(["xyznotathing-free"], [])
+    assert r.resolved == []
+    assert r.ambiguous == []
+    assert r.unresolved == ["xyznotathing-free"]
+
+
+def test_no_dairy_hits_shorthand_dairy_free():
+    # "no dairy" → negation strips to "dairy" → allergen category match.
+    # (Not the ``dairy_free`` shorthand since that synonym list is
+    # ``dairy-free`` / ``lactose-free``, not bare ``dairy``.) The
+    # outcome is still the same forbidden allergen.
+    r = resolve_restrictions(["no dairy"], [])
+    resolved = _only_resolved(r)
+    assert AllergenTag.dairy in resolved[0].allergen_tags

--- a/backend/agents/nutrition_meal_planning_team/restriction_resolver/tests/test_resolver_shorthand.py
+++ b/backend/agents/nutrition_meal_planning_team/restriction_resolver/tests/test_resolver_shorthand.py
@@ -1,0 +1,52 @@
+"""SPEC-006 §6.1 — shorthand expansions."""
+
+from nutrition_meal_planning_team.ingredient_kb.taxonomy import (
+    AllergenTag,
+    DietaryTag,
+)
+from nutrition_meal_planning_team.restriction_resolver import resolve_restrictions
+
+
+def _by_raw(result, raw):
+    for r in result.resolved:
+        if r.raw == raw:
+            return r
+    raise AssertionError(f"no resolved entry for raw={raw!r}")
+
+
+def test_vegan_expands_to_five_dietary_forbids():
+    r = resolve_restrictions([], ["vegan"])
+    entry = _by_raw(r, "vegan")
+    assert entry.rule == "shorthand"
+    assert entry.source == "shorthand"
+    forbid = set(entry.dietary_tags_forbid)
+    assert forbid == {
+        DietaryTag.animal,
+        DietaryTag.dairy,
+        DietaryTag.egg,
+        DietaryTag.honey,
+        DietaryTag.gelatin,
+    }
+
+
+def test_gluten_free_forbids_gluten_and_wheat_allergens():
+    r = resolve_restrictions(["gluten-free"], [])
+    entry = _by_raw(r, "gluten-free")
+    assert entry.rule == "shorthand"
+    assert DietaryTag.gluten in entry.dietary_tags_forbid
+    assert AllergenTag.gluten in entry.allergen_tags
+    assert AllergenTag.wheat in entry.allergen_tags
+
+
+def test_pescatarian_forbids_animal_only():
+    r = resolve_restrictions([], ["pescatarian"])
+    entry = _by_raw(r, "pescatarian")
+    assert entry.dietary_tags_forbid == [DietaryTag.animal]
+    assert "fish, shellfish" in entry.note
+
+
+def test_paleo_forbids_dairy_grain_legume():
+    r = resolve_restrictions([], ["paleo"])
+    entry = _by_raw(r, "paleo")
+    forbid = set(entry.dietary_tags_forbid)
+    assert forbid == {DietaryTag.dairy, DietaryTag.grain, DietaryTag.legume}

--- a/backend/agents/nutrition_meal_planning_team/restriction_resolver/tests/test_resolver_unresolved.py
+++ b/backend/agents/nutrition_meal_planning_team/restriction_resolver/tests/test_resolver_unresolved.py
@@ -1,0 +1,32 @@
+"""SPEC-006 §6.1 — unresolved fall-through."""
+
+from nutrition_meal_planning_team.restriction_resolver import resolve_restrictions
+
+
+def test_junk_input_lands_in_unresolved():
+    r = resolve_restrictions(["xyz-something-random"], [])
+    assert r.resolved == []
+    assert r.ambiguous == []
+    assert r.unresolved == ["xyz-something-random"]
+
+
+def test_empty_and_whitespace_inputs_are_dropped_silently():
+    r = resolve_restrictions(["", "   ", "\t"], ["", "  "])
+    assert r.resolved == []
+    assert r.ambiguous == []
+    assert r.unresolved == []
+
+
+def test_resolver_stamps_kb_version_and_timestamp():
+    r = resolve_restrictions(["vegan"], [])
+    assert r.kb_version  # non-empty
+    assert r.resolved_at  # ISO-ish
+    assert "T" in r.resolved_at  # datetime.isoformat()
+
+
+def test_unicode_diacritic_normalized():
+    # "gluten-frée" normalizes (strip accent) to "gluten-free", which
+    # is a shorthand synonym.
+    r = resolve_restrictions([], ["gluten-frée"])
+    assert len(r.resolved) == 1
+    assert r.resolved[0].rule == "shorthand"

--- a/backend/agents/nutrition_meal_planning_team/restriction_resolver/tests/test_shorthand_against_taxonomy.py
+++ b/backend/agents/nutrition_meal_planning_team/restriction_resolver/tests/test_shorthand_against_taxonomy.py
@@ -1,0 +1,68 @@
+"""SPEC-006 §6.3 — parity check: every tag in shorthand.yaml exists
+in the SPEC-005 enums.
+
+Parses the YAML directly (bypassing the loader) so that YAML drift
+the loader would mask still trips CI.
+"""
+
+from pathlib import Path
+
+import yaml
+
+from nutrition_meal_planning_team.ingredient_kb.taxonomy import (
+    AllergenTag,
+    DietaryTag,
+)
+
+_YAML_PATH = Path(__file__).resolve().parent.parent / "data" / "shorthand.yaml"
+
+
+def _load_rows():
+    with _YAML_PATH.open("r", encoding="utf-8") as fh:
+        rows = yaml.safe_load(fh) or []
+    assert isinstance(rows, list), "shorthand.yaml root must be a list"
+    return rows
+
+
+def test_every_forbid_dietary_tag_exists_in_enum():
+    known = {t.value for t in DietaryTag}
+    for row in _load_rows():
+        for tag in row.get("forbid_dietary") or []:
+            assert tag in known, (
+                f"shorthand.yaml: row {row.get('name')!r} has unknown DietaryTag {tag!r}"
+            )
+
+
+def test_every_forbid_allergen_tag_exists_in_enum():
+    known = {t.value for t in AllergenTag}
+    for row in _load_rows():
+        for tag in row.get("forbid_allergen") or []:
+            assert tag in known, (
+                f"shorthand.yaml: row {row.get('name')!r} has unknown AllergenTag {tag!r}"
+            )
+
+
+def test_no_duplicate_synonyms_across_rows():
+    from nutrition_meal_planning_team.ingredient_kb.normalizer import normalize
+
+    seen: dict[str, str] = {}
+    for row in _load_rows():
+        name = row.get("name")
+        for raw_syn in row.get("synonyms") or [name]:
+            key = normalize(raw_syn)
+            if not key:
+                continue
+            assert key not in seen, (
+                f"shorthand.yaml: synonym {raw_syn!r} duplicated across {seen[key]!r} and {name!r}"
+            )
+            seen[key] = name
+
+
+def test_every_synonym_normalizes_non_empty():
+    from nutrition_meal_planning_team.ingredient_kb.normalizer import normalize
+
+    for row in _load_rows():
+        for raw_syn in row.get("synonyms") or [row.get("name")]:
+            assert normalize(raw_syn), (
+                f"shorthand.yaml: synonym {raw_syn!r} in {row.get('name')!r} normalizes to empty"
+            )

--- a/backend/agents/nutrition_meal_planning_team/shared/client_profile_store.py
+++ b/backend/agents/nutrition_meal_planning_team/shared/client_profile_store.py
@@ -53,18 +53,30 @@ def get_profile(client_id: str) -> Optional[ClientProfile]:
 @timed_query(store=_STORE, op="save_profile")
 def save_profile(client_id: str, profile: ClientProfile) -> None:
     """Save client profile via upsert. Mutates ``profile.updated_at`` and
-    bumps ``profile_version`` as a side effect."""
+    bumps ``profile_version`` as a side effect.
+
+    SPEC-006: ``restriction_resolver_kb_version`` is a denormalized
+    index key mirroring ``profile.restriction_resolution.kb_version``.
+    The JSONB ``profile`` column remains the source of truth; this
+    column exists only so the background re-resolver can scan without
+    parsing every JSONB row.
+    """
     profile.client_id = client_id
     profile.updated_at = _now_iso()
     profile.profile_version = (profile.profile_version or 0) + 1
     ts = datetime.now(tz=timezone.utc)
+    rr = profile.restriction_resolution
+    kb_version = (rr.kb_version or None) if rr is not None else None
     with get_conn() as conn, conn.cursor() as cur:
         cur.execute(
-            "INSERT INTO nutrition_profiles (client_id, profile, updated_at) "
-            "VALUES (%s, %s, %s) "
+            "INSERT INTO nutrition_profiles "
+            "(client_id, profile, updated_at, restriction_resolver_kb_version) "
+            "VALUES (%s, %s, %s, %s) "
             "ON CONFLICT (client_id) DO UPDATE "
-            "SET profile = EXCLUDED.profile, updated_at = EXCLUDED.updated_at",
-            (client_id, Json(profile.model_dump()), ts),
+            "SET profile = EXCLUDED.profile, "
+            "    updated_at = EXCLUDED.updated_at, "
+            "    restriction_resolver_kb_version = EXCLUDED.restriction_resolver_kb_version",
+            (client_id, Json(profile.model_dump()), ts, kb_version),
         )
 
 

--- a/backend/agents/nutrition_meal_planning_team/tests/test_intake_agent_v2.py
+++ b/backend/agents/nutrition_meal_planning_team/tests/test_intake_agent_v2.py
@@ -128,3 +128,44 @@ def test_structural_merge_ed_flag_survives_no_update():
     merged = _merge_profile_structural("c1", existing, patch)
     assert merged.clinical.ed_history_flag is True
     assert merged.dietary_needs == ["vegan"]
+
+
+# --- SPEC-006: resolver hook ---------------------------------------------
+
+
+def test_apply_resolver_flag_off_is_noop(monkeypatch):
+    """When the flag is unset, ``apply_resolver`` returns the profile
+    untouched."""
+    from nutrition_meal_planning_team.agents.intake_profile_agent.restriction_hook import (
+        apply_resolver,
+    )
+
+    monkeypatch.delenv("NUTRITION_RESTRICTION_RESOLVER", raising=False)
+    p = ClientProfile(
+        client_id="c1",
+        allergies_and_intolerances=["cashew"],
+        dietary_needs=["vegan"],
+    )
+    out = apply_resolver(p)
+    assert out.restriction_resolution.resolved == []
+    assert out.restriction_resolution.kb_version == ""
+
+
+def test_apply_resolver_flag_on_populates_resolution(monkeypatch):
+    """When the flag is on, ``apply_resolver`` runs the cascade and
+    populates ``restriction_resolution`` from the raw lists.
+    """
+    from nutrition_meal_planning_team.agents.intake_profile_agent.restriction_hook import (
+        apply_resolver,
+    )
+
+    monkeypatch.setenv("NUTRITION_RESTRICTION_RESOLVER", "1")
+    p = ClientProfile(
+        client_id="c1",
+        allergies_and_intolerances=["cashew"],
+        dietary_needs=["vegan"],
+    )
+    out = apply_resolver(p)
+    raws = {r.raw for r in out.restriction_resolution.resolved}
+    assert raws == {"cashew", "vegan"}
+    assert out.restriction_resolution.kb_version  # non-empty

--- a/backend/agents/nutrition_meal_planning_team/tests/test_models_validators.py
+++ b/backend/agents/nutrition_meal_planning_team/tests/test_models_validators.py
@@ -215,3 +215,77 @@ def test_clinician_override_roundtrip():
     )
     assert r.overrides["bmi_floor"] == 19.5
     assert r.author == "dietitian-1234"
+
+
+# --- SPEC-006: restriction resolution model ------------------------------
+
+
+def test_client_profile_default_has_empty_restriction_resolution():
+    from nutrition_meal_planning_team.models import RestrictionResolution
+
+    p = ClientProfile(client_id="c")
+    assert isinstance(p.restriction_resolution, RestrictionResolution)
+    assert p.restriction_resolution.resolved == []
+    assert p.restriction_resolution.ambiguous == []
+    assert p.restriction_resolution.unresolved == []
+
+
+def test_restriction_resolution_active_allergen_union():
+    from nutrition_meal_planning_team.ingredient_kb.taxonomy import AllergenTag
+    from nutrition_meal_planning_team.models import (
+        AmbiguousRestriction,
+        ResolvedRestriction,
+        RestrictionResolution,
+    )
+
+    rr = RestrictionResolution(
+        resolved=[
+            ResolvedRestriction(
+                raw="cashew",
+                allergen_tags=[AllergenTag.tree_nut],
+                confidence=1.0,
+                rule="exact_alias",
+            )
+        ],
+        ambiguous=[
+            AmbiguousRestriction(
+                raw="nuts",
+                candidates=[
+                    ResolvedRestriction(raw="nuts", allergen_tags=[AllergenTag.peanut]),
+                    ResolvedRestriction(raw="nuts", allergen_tags=[AllergenTag.tree_nut]),
+                ],
+                question="?",
+            )
+        ],
+    )
+    active = rr.active_allergen_tags()
+    # Default-strict: union of resolved + strictest candidate tags.
+    assert AllergenTag.peanut in active
+    assert AllergenTag.tree_nut in active
+
+
+def test_client_profile_roundtrips_restriction_resolution_through_json():
+    from nutrition_meal_planning_team.ingredient_kb.taxonomy import DietaryTag
+    from nutrition_meal_planning_team.models import (
+        ResolvedRestriction,
+        RestrictionResolution,
+    )
+
+    rr = RestrictionResolution(
+        resolved=[
+            ResolvedRestriction(
+                raw="vegan",
+                dietary_tags_forbid=[DietaryTag.animal, DietaryTag.dairy],
+                source="shorthand",
+                rule="shorthand",
+                confidence=1.0,
+            )
+        ],
+        kb_version="1.0.0",
+        resolved_at="2026-04-23T00:00:00+00:00",
+    )
+    p = ClientProfile(client_id="c", restriction_resolution=rr)
+    p2 = ClientProfile.model_validate(p.model_dump())
+    assert p2.restriction_resolution.kb_version == "1.0.0"
+    assert p2.restriction_resolution.resolved[0].raw == "vegan"
+    assert DietaryTag.dairy in p2.restriction_resolution.resolved[0].dietary_tags_forbid

--- a/backend/agents/nutrition_meal_planning_team/tests/test_restrictions_api.py
+++ b/backend/agents/nutrition_meal_planning_team/tests/test_restrictions_api.py
@@ -155,3 +155,55 @@ def test_flag_off_leaves_resolution_empty(client, monkeypatch):
     assert data["ambiguous"] == []
     assert data["unresolved"] == []
     assert data["kb_version"] == ""
+
+
+def test_resolve_ambiguous_rejects_unoffered_candidate(client, flag_on):
+    """Ambiguity reviewer is the resolver, not the client. A chosen
+    candidate that doesn't match any of the offered ones for that raw
+    must be rejected so a malicious / buggy client can't persist a
+    weaker tag set under the guise of an answer.
+    """
+    client.put(
+        "/profile/sp_v1",
+        json={"allergies_and_intolerances": ["nuts"], "dietary_needs": []},
+    )
+    # nuts is offered with peanut / tree_nut / both. Submitting
+    # ``[dairy]`` is not among the offered candidates.
+    r = client.post(
+        "/profile/sp_v1/restrictions/resolve-ambiguous",
+        json={
+            "raw": "nuts",
+            "chosen_candidate": {
+                "raw": "nuts",
+                "allergen_tags": ["dairy"],
+                "confidence": 1.0,
+                "source": "user",
+                "rule": "category",
+            },
+        },
+    )
+    assert r.status_code == 400
+    # Profile state is unchanged.
+    after = client.get("/profile/sp_v1/restrictions").json()
+    assert len(after["ambiguous"]) == 1
+    assert all(e["raw"] != "nuts" for e in after["resolved"])
+
+
+def test_reresolve_is_noop_when_flag_off(client, monkeypatch):
+    """``POST .../reresolve`` must not quietly turn the resolver on
+    for a single profile when the rollout flag is off."""
+    monkeypatch.delenv("NUTRITION_RESTRICTION_RESOLVER", raising=False)
+    client.put(
+        "/profile/sp_v2",
+        json={
+            "allergies_and_intolerances": ["vegan", "cashew"],
+            "dietary_needs": [],
+        },
+    )
+    r = client.post("/profile/sp_v2/restrictions/reresolve")
+    assert r.status_code == 200
+    data = r.json()
+    # No resolution should have been written.
+    assert data["resolved"] == []
+    assert data["ambiguous"] == []
+    assert data["kb_version"] == ""

--- a/backend/agents/nutrition_meal_planning_team/tests/test_restrictions_api.py
+++ b/backend/agents/nutrition_meal_planning_team/tests/test_restrictions_api.py
@@ -1,0 +1,157 @@
+"""SPEC-006 integration tests: profile restriction endpoints.
+
+Uses Postgres via the same fixture pattern as ``test_api.py`` and
+``test_profile_biometrics.py``. The intake agent's LLM call falls
+through to the structural merge when no LLM is reachable (per
+``conftest.py``'s ``LLM_MAX_RETRIES=0``), so these tests do not need
+to mock strands — the resolver hook fires on the structural-fallback
+path just as it does on the LLM path.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+from shared_postgres import is_postgres_enabled
+
+_agents_dir = Path(__file__).resolve().parent.parent.parent
+if str(_agents_dir) not in __import__("sys").path:
+    __import__("sys").path.insert(0, str(_agents_dir))
+
+from nutrition_meal_planning_team.api.main import app  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not is_postgres_enabled(),
+    reason="SPEC-006 restriction endpoints require Postgres.",
+)
+
+
+@pytest.fixture
+def client():
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def flag_on(monkeypatch):
+    monkeypatch.setenv("NUTRITION_RESTRICTION_RESOLVER", "1")
+    yield
+
+
+# --- GET /restrictions ---------------------------------------------------
+
+
+def test_intake_resolves_on_write(client, flag_on):
+    client.put(
+        "/profile/sp1",
+        json={
+            "allergies_and_intolerances": ["cashew", "gluten-free"],
+            "dietary_needs": ["vegan"],
+        },
+    )
+    r = client.get("/profile/sp1/restrictions")
+    assert r.status_code == 200
+    data = r.json()
+    resolved_raws = {e["raw"] for e in data["resolved"]}
+    assert resolved_raws == {"cashew", "gluten-free", "vegan"}
+    assert data["ambiguous"] == []
+    assert data["unresolved"] == []
+    # KB version is stamped.
+    assert data["kb_version"]
+
+
+def test_ambiguous_nuts_surfaces_and_resolves(client, flag_on):
+    client.put(
+        "/profile/sp2",
+        json={"allergies_and_intolerances": ["nuts"], "dietary_needs": []},
+    )
+    r = client.get("/profile/sp2/restrictions")
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data["ambiguous"]) == 1
+    assert data["ambiguous"][0]["raw"] == "nuts"
+
+    # User picks the "both" candidate.
+    chosen = data["ambiguous"][0]["candidates"][-1]
+    r2 = client.post(
+        "/profile/sp2/restrictions/resolve-ambiguous",
+        json={"raw": "nuts", "chosen_candidate": chosen},
+    )
+    assert r2.status_code == 200
+    after = r2.json()
+    assert after["ambiguous"] == []
+    resolved_raws = [e["raw"] for e in after["resolved"]]
+    assert "nuts" in resolved_raws
+
+    # Subsequent GET does not re-ask.
+    r3 = client.get("/profile/sp2/restrictions")
+    assert r3.json()["ambiguous"] == []
+
+
+def test_resolve_ambiguous_returns_400_for_unknown_raw(client, flag_on):
+    client.put(
+        "/profile/sp3",
+        json={"allergies_and_intolerances": ["nuts"], "dietary_needs": []},
+    )
+    r = client.post(
+        "/profile/sp3/restrictions/resolve-ambiguous",
+        json={
+            "raw": "not-a-real-raw",
+            "chosen_candidate": {
+                "raw": "not-a-real-raw",
+                "allergen_tags": ["peanut"],
+                "confidence": 1.0,
+                "source": "user",
+                "rule": "category",
+            },
+        },
+    )
+    assert r.status_code == 400
+
+
+def test_get_restrictions_404_when_profile_missing(client, flag_on):
+    r = client.get("/profile/never-created/restrictions")
+    assert r.status_code == 404
+
+
+def test_reresolve_preserves_confirmed_choices(client, flag_on):
+    client.put(
+        "/profile/sp4",
+        json={"allergies_and_intolerances": ["nuts"], "dietary_needs": []},
+    )
+    data = client.get("/profile/sp4/restrictions").json()
+    chosen = data["ambiguous"][0]["candidates"][-1]
+    client.post(
+        "/profile/sp4/restrictions/resolve-ambiguous",
+        json={"raw": "nuts", "chosen_candidate": chosen},
+    )
+    # Confirmed. Re-resolve should keep the confirmation.
+    r = client.post("/profile/sp4/restrictions/reresolve")
+    assert r.status_code == 200
+    after = r.json()
+    # The user previously confirmed "nuts" so it should NOT reappear as
+    # ambiguous after re-resolve.
+    assert all(a["raw"] != "nuts" for a in after["ambiguous"])
+    assert any(e["raw"] == "nuts" for e in after["resolved"])
+
+
+def test_flag_off_leaves_resolution_empty(client, monkeypatch):
+    # Explicitly ensure the flag is off.
+    monkeypatch.delenv("NUTRITION_RESTRICTION_RESOLVER", raising=False)
+    client.put(
+        "/profile/sp5",
+        json={
+            "allergies_and_intolerances": ["vegan", "cashew"],
+            "dietary_needs": [],
+        },
+    )
+    r = client.get("/profile/sp5/restrictions")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["resolved"] == []
+    assert data["ambiguous"] == []
+    assert data["unresolved"] == []
+    assert data["kb_version"] == ""


### PR DESCRIPTION
Closes #211

## Summary

SPEC-006 resolves free-text `ClientProfile.allergies_and_intolerances` and `ClientProfile.dietary_needs` strings into canonical `AllergenTag` / `DietaryTag` sets at profile-save time, using the SPEC-005 ingredient KB + a new closed shorthand table. Raw fields are preserved; resolution is additive. This unblocks SPEC-007 (meal-plan guardrail enforcement), which today has no structured constraints to enforce against.

**This PR ships W1–W6 + W10** (P0/P1 backend) behind the `NUTRITION_RESTRICTION_RESOLVER` feature flag, **off by default**. W7–W11 are deferred to follow-ups (see below).

## What's in

- **Resolver (`backend/agents/nutrition_meal_planning_team/restriction_resolver/`)** — pure function `resolve_restrictions(allergies, dietary_needs) -> RestrictionResolution` implementing the 6-rule cascade: exact alias → shorthand → allergen category → ambiguity table → fuzzy (≥0.85) → unresolved. Negation patterns (`"no X"`, `"avoid X"`, `"X-free"`) are preprocessed; raw strings are preserved on the resolved record.
- **`shorthand.yaml` v1** — covers vegan, vegetarian, pescatarian, gluten-free (lists both `gluten` **and** `wheat` allergen tags per the taxonomy docstring), dairy-free, paleo, halal, kosher, keto (soft_constraint), low-sodium. Loader validates every tag against the SPEC-005 enums at import; CI parity test re-parses the YAML raw to catch drift the loader would mask.
- **Models** — `ResolvedRestriction`, `AmbiguousRestriction`, `RestrictionResolution` in `models.py`. `RestrictionResolution.active_allergen_tags()` / `active_dietary_forbid()` implement the default-strict contract: unresolved ambiguities still contribute their strictest candidate's tags so SPEC-007 can fail-closed pre-confirm.
- **Intake integration** — `restriction_hook.py` (split out following the SPEC-002 W4 pattern so tests import without `strands`). Fires on both the LLM-merge path and the structural-fallback path when the flag is on.
- **API endpoints** —
  - `GET  /profile/{client_id}/restrictions` → `RestrictionResolution`
  - `POST /profile/{client_id}/restrictions/resolve-ambiguous` — promotes a user-chosen candidate from `ambiguous[]` to `resolved[]`
  - `POST /profile/{client_id}/restrictions/reresolve` — re-runs against current KB, preserves prior user confirmations
- **Postgres** — additive `ALTER TABLE` statements adding `restriction_resolution JSONB` + denormalized `restriction_resolver_kb_version TEXT` column + index. The resolution is stored inside the existing `profile` JSONB (source of truth); the top-level column exists only as an index key for the W9 background re-resolver.
- **OTel counters** — `nutrition.restriction.resolve{outcome,rule}` and `nutrition.restriction.shorthand_used{name}` with bounded label cardinality.

## Deviations from the spec

- **No numbered SQL file.** The spec mentions `004_restriction_resolution.sql`; this team uses the idempotent `SCHEMA.statements` registration (matching SPEC-002 / SPEC-004 additions). Called out inline with comments.
- **Rate limiting on `/reresolve`** — spec §4.5 wants it; the team has no rate-limit infrastructure today. Deferred to W9, which needs it anyway for the background scanner.

## Deferred to follow-ups

- **W7 + W8 (Angular UI):** ambiguity cards with default-strict selection, resolved-chips view on profile + meal-plan pages, FE event for ambiguity-latency metric.
- **W9:** background `KB_VERSION` re-resolver + rate limiting.
- **W11:** `restriction_resolver/CHANGELOG.md` + docs for adding shorthand rows.
- **Observability extensions:** `unresolved_top_terms` (privacy-preserving count-min sketch) and `ambiguity_resolution_latency` (needs W7 FE event).

## Test plan

- [x] Unit tests pass: 24 resolver tests + 3 model tests + 2 intake hook tests (84 total across resolver/model/intake modules).
- [x] Ruff lint + format clean across the whole team directory.
- [ ] **CI / reviewer:** Postgres-backed integration tests in `tests/test_restrictions_api.py` (6 scenarios: intake resolves on write, ambiguous nuts flow, 400 on unknown raw, 404 on missing profile, reresolve preserves confirmations, flag-off leaves resolution empty).
- [ ] **Manual e2e (flag on):**
  ```
  export NUTRITION_RESTRICTION_RESOLVER=1
  curl -X PUT .../profile/test1 -d '{"allergies_and_intolerances":["nuts","cashew","gluten-free"],"dietary_needs":["vegan","low-carb"]}'
  curl .../profile/test1/restrictions | jq
  # resolved includes cashew, vegan, gluten-free; ambiguous includes nuts + low-carb
  curl -X POST .../profile/test1/restrictions/resolve-ambiguous -d '{"raw":"nuts","chosen_candidate":{...}}'
  ```
- [ ] **Flag-off regression:** unset the flag, re-run the PUT; `GET /restrictions` returns the empty default; no other behavior change.

https://claude.ai/code/session_01FHyt46XHsMipffafg5fUTU

---
_Generated by [Claude Code](https://claude.ai/code/session_01FHyt46XHsMipffafg5fUTU)_