### PR TITLE
investment_team: make Strategy Lab resilient to per-cycle errors (closes #305)

### DIFF
--- a/backend/agents/investment_team/api/main.py
+++ b/backend/agents/investment_team/api/main.py
@@ -216,6 +216,15 @@ def _now() -> str:
 # Strategy Lab run tracking models
 # ---------------------------------------------------------------------------
 
+# All terminal statuses a strategy lab run can land in. Kept local to this
+# module because "completed_with_errors" is a lab-specific concept and the
+# shared job_service_client constants don't know about it. Used by the SSE
+# stream short-circuit, status reconciliation, and restart gating so a
+# freshly-introduced terminal state can't silently diverge.
+STRATEGY_LAB_TERMINAL_STATUSES: frozenset[str] = frozenset(
+    {"completed", "completed_with_errors", "failed", "cancelled", "interrupted"}
+)
+
 
 class StrategyLabRunStartResponse(BaseModel):
     """Returned immediately when a strategy lab batch is started."""
@@ -2135,8 +2144,12 @@ def restart_strategy_lab_run(run_id: str) -> StrategyLabRunStartResponse:
         state = _active_runs.get(run_id)
     if not state:
         state = _load_run_from_job_service(run_id)
+    # "completed_with_errors" is a terminal outcome of the same workflow as
+    # "completed" and must be restartable. Extend the shared set locally
+    # rather than leaking a lab-specific status into job_service_client.
+    _lab_restartable = RESTARTABLE_STATUSES | {"completed_with_errors"}
     try:
-        validate_job_for_action(state, run_id, RESTARTABLE_STATUSES, "restarted")
+        validate_job_for_action(state, run_id, _lab_restartable, "restarted")
     except ValueError as exc:
         code = 404 if "not found" in str(exc) else 400
         raise HTTPException(status_code=code, detail=str(exc)) from exc
@@ -2224,7 +2237,7 @@ def list_strategy_lab_runs() -> ActiveRunsResponse:
     updated to match — this handles external cancellation via the generic
     job proxy or the Jobs Dashboard.
     """
-    _TERMINAL = {"completed", "failed", "cancelled", "interrupted"}
+    _TERMINAL = STRATEGY_LAB_TERMINAL_STATUSES
 
     try:
         client = _get_lab_run_job_client()
@@ -2279,7 +2292,7 @@ def list_strategy_lab_runs() -> ActiveRunsResponse:
 )
 def get_strategy_lab_run_status(run_id: str) -> StrategyLabRunStatusResponse:
     """Snapshot of a single run's progress. Use for polling when SSE is unavailable."""
-    _TERMINAL = {"completed", "failed", "cancelled", "interrupted"}
+    _TERMINAL = STRATEGY_LAB_TERMINAL_STATUSES
 
     with _lock:
         state = _active_runs.get(run_id)
@@ -2337,7 +2350,7 @@ async def stream_strategy_lab_run(run_id: str) -> StreamingResponse:
         return f"data: {json_module.dumps(data, default=str)}\n\n"
 
     # If the run is already terminal, send snapshot + done immediately.
-    if state.get("status") in ("completed", "failed"):
+    if state.get("status") in STRATEGY_LAB_TERMINAL_STATUSES:
 
         async def _terminal_gen():
             yield _sse_line(

--- a/backend/agents/investment_team/api/main.py
+++ b/backend/agents/investment_team/api/main.py
@@ -244,6 +244,10 @@ class StrategyLabRunStatusResponse(BaseModel):
     total_cycles: int
     completed_cycles: int = 0
     skipped_cycles: int = 0
+    # Non-fatal per-cycle failures: run keeps going, but these are surfaced
+    # to the UI so users can see that something went wrong during generation.
+    errored_cycles: int = 0
+    errored_details: List[Dict[str, Any]] = Field(default_factory=list)
     current_cycle: Optional[StrategyLabCycleProgress] = None
     completed_record_ids: List[str] = Field(default_factory=list)
     error: Optional[str] = None
@@ -278,6 +282,8 @@ def _run_state_to_response(state: Dict[str, Any]) -> StrategyLabRunStatusRespons
         total_cycles=state["total_cycles"],
         completed_cycles=state.get("completed_cycles", 0),
         skipped_cycles=state.get("skipped_cycles", 0),
+        errored_cycles=state.get("errored_cycles", 0),
+        errored_details=state.get("errored_details", []),
         current_cycle=StrategyLabCycleProgress(**cc) if cc else None,
         completed_record_ids=state.get("completed_record_ids", []),
         error=state.get("error"),
@@ -1533,11 +1539,19 @@ def _strategy_lab_worker(
             # persisted counter with only the new-since-resume count, making
             # /strategy-lab/jobs and UI progress move backward.
             skipped: int = int(_run_state_snapshot.get("skipped_cycles") or 0)
+            # Carry forward errored count on resume (same reasoning as skipped).
+            errored: int = int(_run_state_snapshot.get("errored_cycles") or 0)
+            errored_details: List[Dict[str, Any]] = list(
+                _run_state_snapshot.get("errored_details") or []
+            )
         completed_indices: set[int] = set(range(start_cycle_offset))
         completed_batches = start_batch_idx
         primary_tracker = orchestrator.convergence_tracker
         run_failed = False
         run_cancelled = False
+        # Bound memory for errored_details — enough for operators to diagnose
+        # without letting a pathological run balloon the state dict.
+        _ERRORED_DETAILS_MAX = 50
 
         for batch_idx in range(start_batch_idx, batch_count):
             if run_failed or run_cancelled:
@@ -1559,7 +1573,24 @@ def _strategy_lab_worker(
 
             # Refresh the signal-intelligence brief at the start of every batch so the
             # next batch's strategies are informed by every prior batch's results.
-            precomputed_brief, signal_brief_storage = _compute_signal_brief()
+            # Belt-and-suspenders: _compute_signal_brief already catches expected
+            # failures, but an unexpected raise here must not kill the whole run.
+            try:
+                precomputed_brief, signal_brief_storage = _compute_signal_brief()
+            except Exception as exc:
+                logger.exception(
+                    "Signal brief computation raised unexpectedly at batch %d", batch_num
+                )
+                precomputed_brief = None
+                signal_brief_storage = {
+                    "skipped": True,
+                    "skipped_reason": "brief_failed",
+                    "error": str(exc)[:500],
+                }
+                _publish(
+                    "batch_warning",
+                    {"batch_index": batch_num, "reason": "signal_brief_failed"},
+                )
 
             # Wave-based parallel execution within this batch.
             # Cycle indices are global (1-based across the whole run): for batch B
@@ -1676,16 +1707,33 @@ def _strategy_lab_worker(
                                 _publish("error", {"detail": f"Cycle {cn} failed: {exc}"})
                                 run_failed = True
                         except Exception as exc:
-                            logger.exception("Strategy lab cycle %d/%d failed", cn, total_cycles)
+                            logger.exception("Strategy lab cycle %d/%d errored", cn, total_cycles)
+                            errored += 1
+                            if len(errored_details) < _ERRORED_DETAILS_MAX:
+                                errored_details.append(
+                                    {
+                                        "cycle_index": cn,
+                                        "batch_index": batch_num,
+                                        "error": str(exc)[:500],
+                                        "exception_type": type(exc).__name__,
+                                    }
+                                )
                             _update_run(
                                 {
-                                    "status": "failed",
-                                    "error": f"Cycle {cn} failed: {exc}",
+                                    "errored_cycles": errored,
+                                    "errored_details": errored_details,
                                     "current_cycle": None,
                                 }
                             )
-                            _publish("error", {"detail": f"Cycle {cn} failed: {exc}"})
-                            run_failed = True
+                            _publish(
+                                "cycle_errored",
+                                {
+                                    "cycle_index": cn,
+                                    "batch_index": batch_num,
+                                    "reason": type(exc).__name__,
+                                    "error": str(exc)[:500],
+                                },
+                            )
 
                 # Merge wave results into the primary convergence tracker in
                 # deterministic cycle-index order so that stall/diversity
@@ -1703,7 +1751,40 @@ def _strategy_lab_worker(
                     # touches ``_trial_count``.
                     cycle_orch = wave_orchestrators.get(_idx)
                     if cycle_orch is not None:
-                        primary_tracker.merge_from(cycle_orch.convergence_tracker)
+                        try:
+                            primary_tracker.merge_from(cycle_orch.convergence_tracker)
+                        except Exception as exc:
+                            logger.exception(
+                                "Strategy lab tracker merge failed for cycle %d/%d",
+                                _idx + 1,
+                                total_cycles,
+                            )
+                            errored += 1
+                            if len(errored_details) < _ERRORED_DETAILS_MAX:
+                                errored_details.append(
+                                    {
+                                        "cycle_index": _idx + 1,
+                                        "batch_index": batch_num,
+                                        "error": str(exc)[:500],
+                                        "exception_type": type(exc).__name__,
+                                        "reason": "tracker_merge_failed",
+                                    }
+                                )
+                            _update_run(
+                                {
+                                    "errored_cycles": errored,
+                                    "errored_details": errored_details,
+                                }
+                            )
+                            _publish(
+                                "cycle_errored",
+                                {
+                                    "cycle_index": _idx + 1,
+                                    "batch_index": batch_num,
+                                    "reason": "tracker_merge_failed",
+                                    "error": str(exc)[:500],
+                                },
+                            )
 
                 # Check for external cancellation between waves
                 if not run_failed and _is_run_cancelled():
@@ -1740,14 +1821,26 @@ def _strategy_lab_worker(
         )
         if skipped:
             msg += f" ({skipped} skipped due to unavailable market data)"
+        if errored:
+            msg += f" ({errored} cycle(s) errored)"
 
-        _update_run({"status": "completed", "current_cycle": None, "current_batch": None})
+        terminal_status = "completed_with_errors" if errored else "completed"
+        _update_run(
+            {
+                "status": terminal_status,
+                "current_cycle": None,
+                "current_batch": None,
+            }
+        )
         _publish(
             "complete",
             {
                 "message": msg,
+                "status": terminal_status,
                 "completed_count": len(completed_ids),
                 "skipped_count": skipped,
+                "errored_count": errored,
+                "errored_details": errored_details,
                 "completed_batches": completed_batches,
                 "total_batches": batch_count,
             },
@@ -1758,13 +1851,20 @@ def _strategy_lab_worker(
         _update_run({"status": "failed", "error": str(exc)[:500], "current_cycle": None})
         _publish("error", {"detail": str(exc)[:500]})
     finally:
-        # Schedule cleanup of _active_runs entry after 5 minutes
+        # Schedule cleanup of _active_runs entry. Catastrophic worker-level
+        # failures ("failed") get a longer window so UI polls that arrive
+        # after SSE disconnect still see the terminal status and error text.
+        with _lock:
+            final_state = _active_runs.get(run_id)
+        final_status = (final_state or {}).get("status")
+        cleanup_delay = 900.0 if final_status == "failed" else 300.0
+
         def _cleanup() -> None:
             with _lock:
                 _active_runs.pop(run_id, None)
             cleanup_job(run_id)
 
-        timer = threading.Timer(300.0, _cleanup)
+        timer = threading.Timer(cleanup_delay, _cleanup)
         timer.daemon = True
         timer.start()
 
@@ -1804,6 +1904,8 @@ def run_strategy_lab(request: RunStrategyLabRequest) -> StrategyLabRunStartRespo
         "total_cycles": total_cycles,
         "completed_cycles": 0,
         "skipped_cycles": 0,
+        "errored_cycles": 0,
+        "errored_details": [],
         "current_cycle": None,
         "completed_record_ids": [],
         "error": None,
@@ -1990,6 +2092,8 @@ def resume_strategy_lab_run(run_id: str) -> StrategyLabRunStartResponse:
         "completed_cycles": completed_cycles,
         "contiguous_cycles": contiguous_cycles,
         "skipped_cycles": state.get("skipped_cycles", 0),
+        "errored_cycles": state.get("errored_cycles", 0),
+        "errored_details": state.get("errored_details", []),
         "current_cycle": None,
         "completed_record_ids": state.get("completed_record_ids", []),
         "error": None,
@@ -2058,6 +2162,8 @@ def restart_strategy_lab_run(run_id: str) -> StrategyLabRunStartResponse:
         "total_cycles": total_cycles,
         "completed_cycles": 0,
         "skipped_cycles": 0,
+        "errored_cycles": 0,
+        "errored_details": [],
         "current_cycle": None,
         "completed_record_ids": [],
         "error": None,

--- a/backend/agents/investment_team/strategy_lab/quality_gates/convergence_tracker.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/convergence_tracker.py
@@ -7,11 +7,14 @@ Modeled on the blogging team's FeedbackTracker
 from __future__ import annotations
 
 import hashlib
+import logging
 from collections import Counter
 from typing import List, Optional, Set
 
 from ...models import StrategySpec
 from .models import QualityGateResult
+
+logger = logging.getLogger(__name__)
 
 
 class ConvergenceTracker:
@@ -183,6 +186,12 @@ class ConvergenceTracker:
         baseline = other._trial_count_at_snapshot
         delta = other._trial_count - baseline
         if delta < 0:
+            logger.warning(
+                "ConvergenceTracker.merge_from: snapshot trial_count (%d) is below "
+                "its baseline (%d); refusing to apply negative delta",
+                other._trial_count,
+                baseline,
+            )
             raise ValueError(
                 f"snapshot trial_count ({other._trial_count}) is below its "
                 f"baseline ({baseline}); merge_from expects monotonic increments"

--- a/backend/agents/investment_team/tests/test_strategy_lab_batches.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_batches.py
@@ -514,3 +514,61 @@ def test_merge_from_failure_does_not_halt_run(
     assert state["errored_cycles"] == 1
     assert state["completed_batches"] == 1
     assert state["errored_details"][0].get("reason") == "tracker_merge_failed"
+
+
+def test_restart_accepts_completed_with_errors(
+    empty_lab_state: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """completed_with_errors is a terminal outcome of the same workflow as
+    completed; restart must accept it (reviewer P2)."""
+    from fastapi.testclient import TestClient
+
+    # Seed a run that is already in the new terminal state.
+    request = RunStrategyLabRequest(batch_size=1, batch_count=1)
+    run_id = "run-test-restart-cwe"
+    _seed_run_state(run_id, request)
+    lab_main._active_runs[run_id]["status"] = "completed_with_errors"
+
+    # Stub the worker thread so restart doesn't actually run the pipeline.
+    started: List[str] = []
+
+    class _FakeThread:
+        def __init__(self, *_a: Any, **kw: Any) -> None:
+            started.append(kw.get("name", ""))
+
+        def start(self) -> None:
+            pass
+
+    monkeypatch.setattr(lab_main.threading, "Thread", _FakeThread)
+    monkeypatch.setattr(lab_main, "_persist_run_state", lambda *a, **kw: None)
+
+    client = TestClient(lab_main.app)
+    resp = client.post(f"/strategy-lab/runs/{run_id}/restart")
+    # Before the fix this returned 400 ("job not restartable").
+    assert resp.status_code == 200, resp.text
+    assert started, "restart should have dispatched the worker thread"
+
+
+def test_sse_stream_short_circuits_completed_with_errors(
+    empty_lab_state: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """SSE endpoint must treat completed_with_errors as terminal so reconnecting
+    clients get snapshot + done instead of hanging in 'running' (reviewer P1)."""
+    from fastapi.testclient import TestClient
+
+    request = RunStrategyLabRequest(batch_size=1, batch_count=1)
+    run_id = "run-test-sse-cwe"
+    _seed_run_state(run_id, request)
+    lab_main._active_runs[run_id]["status"] = "completed_with_errors"
+    lab_main._active_runs[run_id]["errored_cycles"] = 1
+
+    monkeypatch.setattr(lab_main, "_persist_run_state", lambda *a, **kw: None)
+
+    client = TestClient(lab_main.app)
+    with client.stream("GET", f"/strategy-lab/runs/{run_id}/stream") as resp:
+        assert resp.status_code == 200
+        body = b"".join(resp.iter_bytes())
+    text = body.decode()
+    # Must contain both the snapshot and the terminal done event.
+    assert '"type": "snapshot"' in text
+    assert '"type": "done"' in text

--- a/backend/agents/investment_team/tests/test_strategy_lab_batches.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_batches.py
@@ -379,3 +379,138 @@ def test_parallel_wave_merges_trial_counts_into_primary_tracker(
     for cycle_orch in instances[1:]:
         # Snapshot started at baseline 0, was incremented trials_per_cycle.
         assert cycle_orch.convergence_tracker.trial_count == trials_per_cycle
+
+
+# ---------------------------------------------------------------------------
+# Resilience: per-cycle exceptions no longer halt the whole run.
+# ---------------------------------------------------------------------------
+
+
+class _NoopTracker:
+    """Minimal tracker stub shared by the resilience tests."""
+
+    def snapshot(self) -> "_NoopTracker":
+        return _NoopTracker()
+
+    def record(self, *_a: Any, **_kw: Any) -> None:
+        pass
+
+    def merge_from(self, *_a: Any, **_kw: Any) -> None:
+        pass
+
+
+def test_unexpected_cycle_exception_does_not_halt_run(
+    empty_lab_state: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A single cycle raising an unexpected error must be surfaced as an errored
+    cycle and the remaining batches must still run to completion."""
+
+    call_counter = {"n": 0}
+
+    class _OneBadCycleOrchestrator:
+        _counter = 0
+
+        def __init__(self, convergence_tracker: Any = None) -> None:
+            self.convergence_tracker = _NoopTracker()
+
+        def run_cycle(
+            self,
+            prior_records: List[StrategyLabRecord],
+            config: BacktestConfig,
+            signal_brief: Any = None,
+            on_phase: Any = None,
+            exclude_asset_classes: Any = None,
+        ) -> StrategyLabRecord:
+            call_counter["n"] += 1
+            # Fail cycle #2 with a totally unexpected exception.
+            if call_counter["n"] == 2:
+                raise RuntimeError("boom — downstream provider exploded")
+            type(self)._counter += 1
+            return _make_record(type(self)._counter, config)
+
+    monkeypatch.setattr(lab_main, "StrategyLabOrchestrator", _OneBadCycleOrchestrator)
+    monkeypatch.setattr(lab_main, "ConvergenceTracker", _NoopTracker)
+    monkeypatch.setattr(lab_main, "_strategy_lab_signal_expert_enabled", lambda: False)
+    monkeypatch.setattr(lab_main, "_persist_run_state", lambda *a, **kw: None)
+
+    request = RunStrategyLabRequest(
+        batch_size=2,
+        batch_count=3,
+        max_parallel=1,
+        paper_trading_enabled=False,
+    )
+    run_id = "run-test-errored"
+    _seed_run_state(run_id, request)
+
+    _strategy_lab_worker(run_id, request)
+
+    state = lab_main._active_runs[run_id]
+    # Pre-fix regression: status would be "failed" and the loop would have
+    # broken after batch 1 (~1 completed cycle). Post-fix: run continues.
+    assert state["status"] == "completed_with_errors", state
+    assert state["completed_cycles"] == 5  # 6 total - 1 errored
+    assert state["errored_cycles"] == 1
+    assert state["completed_batches"] == 3
+    assert len(state["errored_details"]) == 1
+    detail = state["errored_details"][0]
+    assert detail["cycle_index"] == 2
+    assert detail["batch_index"] == 1
+    assert detail["exception_type"] == "RuntimeError"
+    assert "boom" in detail["error"]
+
+
+def test_merge_from_failure_does_not_halt_run(
+    empty_lab_state: None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If primary_tracker.merge_from raises (e.g. negative trial delta), the run
+    must still complete — only that cycle's merge is dropped."""
+
+    class _MergeFailingTracker(_NoopTracker):
+        calls = {"merge": 0}
+
+        def merge_from(self, *_a: Any, **_kw: Any) -> None:
+            _MergeFailingTracker.calls["merge"] += 1
+            # Second merge blows up; the run must still keep going.
+            if _MergeFailingTracker.calls["merge"] == 2:
+                raise ValueError("synthetic negative delta")
+
+    class _Orch:
+        _counter = 0
+
+        def __init__(self, convergence_tracker: Any = None) -> None:
+            self.convergence_tracker = _MergeFailingTracker()
+
+        def run_cycle(
+            self,
+            prior_records: List[StrategyLabRecord],
+            config: BacktestConfig,
+            signal_brief: Any = None,
+            on_phase: Any = None,
+            exclude_asset_classes: Any = None,
+        ) -> StrategyLabRecord:
+            type(self)._counter += 1
+            return _make_record(type(self)._counter, config)
+
+    monkeypatch.setattr(lab_main, "StrategyLabOrchestrator", _Orch)
+    monkeypatch.setattr(lab_main, "ConvergenceTracker", _MergeFailingTracker)
+    monkeypatch.setattr(lab_main, "_strategy_lab_signal_expert_enabled", lambda: False)
+    monkeypatch.setattr(lab_main, "_persist_run_state", lambda *a, **kw: None)
+
+    request = RunStrategyLabRequest(
+        batch_size=3,
+        batch_count=1,
+        max_parallel=1,
+        paper_trading_enabled=False,
+    )
+    run_id = "run-test-merge-fail"
+    _seed_run_state(run_id, request)
+
+    _strategy_lab_worker(run_id, request)
+
+    state = lab_main._active_runs[run_id]
+    # All 3 cycles produced records; one merge failed but that's non-fatal.
+    assert state["status"] == "completed_with_errors", state
+    assert state["completed_cycles"] == 3
+    assert state["errored_cycles"] == 1
+    assert state["completed_batches"] == 1
+    assert state["errored_details"][0].get("reason") == "tracker_merge_failed"

--- a/user-interface/src/app/components/strategy-lab/strategy-lab.component.html
+++ b/user-interface/src/app/components/strategy-lab/strategy-lab.component.html
@@ -86,6 +86,17 @@
     </div>
   }
 
+  <!-- Non-fatal completion warning -->
+  @if (completionWarning) {
+    <div class="warning-banner">
+      <mat-icon>warning_amber</mat-icon>
+      <span>{{ completionWarning }}</span>
+      <button mat-icon-button (click)="completionWarning = null" aria-label="Dismiss warning">
+        <mat-icon>close</mat-icon>
+      </button>
+    </div>
+  }
+
   <!-- In-progress tracking -->
   @if (running && runStatus) {
     <div class="in-progress-section">
@@ -100,6 +111,11 @@
         </span>
         @if (runStatus.skipped_cycles) {
           <span class="skipped-badge">{{ runStatus.skipped_cycles }} skipped</span>
+        }
+        @if (runStatus.errored_cycles) {
+          <span class="errored-badge" [matTooltip]="erroredTooltip()">
+            {{ runStatus.errored_cycles }} errored
+          </span>
         }
         <span class="status-badge status-running">Running</span>
       </div>

--- a/user-interface/src/app/components/strategy-lab/strategy-lab.component.scss
+++ b/user-interface/src/app/components/strategy-lab/strategy-lab.component.scss
@@ -92,6 +92,31 @@
   }
 }
 
+// ── Non-fatal warning banner (completed_with_errors, batch warnings) ────────
+
+.warning-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75rem 1rem;
+  background: var(--kh-warning-subtle, #fff7e0);
+  color: var(--kh-warning, #8a6d00);
+  border-radius: var(--kh-radius-md);
+  margin-bottom: 1.25rem;
+  font-size: 0.9rem;
+
+  mat-icon {
+    flex-shrink: 0;
+    font-size: 1.2rem;
+    width: 1.2rem;
+    height: 1.2rem;
+  }
+
+  button {
+    margin-left: auto;
+  }
+}
+
 // ── Summary chips ─────────────────────────────────────────────────────────────
 
 .summary-row {
@@ -692,6 +717,17 @@
   background: var(--kh-warning-subtle);
   color: var(--kh-warning);
   font-weight: 500;
+}
+
+.errored-badge {
+  font-size: var(--kh-text-xs);
+  padding: 2px 8px;
+  border-radius: var(--kh-radius-full);
+  background: var(--kh-error-subtle);
+  color: var(--kh-error);
+  font-weight: 500;
+  cursor: help;
+  white-space: pre-line;
 }
 
 .status-badge {

--- a/user-interface/src/app/components/strategy-lab/strategy-lab.component.ts
+++ b/user-interface/src/app/components/strategy-lab/strategy-lab.component.ts
@@ -100,6 +100,8 @@ export class StrategyLabComponent implements OnInit, OnDestroy {
   loading = false;
   clearingAll = false;
   error: string | null = null;
+  /** Non-fatal warning banner shown when a run finishes with errored/skipped cycles. */
+  completionWarning: string | null = null;
   /** Lab record id currently being deleted (disables actions on that card). */
   deletingLabRecordId: string | null = null;
 
@@ -252,6 +254,8 @@ export class StrategyLabComponent implements OnInit, OnDestroy {
         status: event['status'] ?? this.runStatus.status,
         completed_cycles: event['completed_cycles'] ?? this.runStatus.completed_cycles,
         skipped_cycles: event['skipped_cycles'] ?? this.runStatus.skipped_cycles,
+        errored_cycles: event['errored_cycles'] ?? this.runStatus.errored_cycles,
+        errored_details: event['errored_details'] ?? this.runStatus.errored_details,
         current_cycle: event['current_cycle'] ?? this.runStatus.current_cycle,
         completed_record_ids: event['completed_record_ids'] ?? this.runStatus.completed_record_ids,
         error: event['error'] ?? this.runStatus.error,
@@ -322,7 +326,37 @@ export class StrategyLabComponent implements OnInit, OnDestroy {
       this.runStatus.current_cycle = undefined;
     }
 
+    if (event.type === 'cycle_errored' && this.runStatus) {
+      this.runStatus.errored_cycles = (this.runStatus.errored_cycles ?? 0) + 1;
+      const detail = {
+        cycle_index: (event['cycle_index'] as number) ?? 0,
+        batch_index: event['batch_index'] as number | undefined,
+        error: (event['error'] as string) || '',
+        exception_type: event['reason'] as string | undefined,
+      };
+      const existing = this.runStatus.errored_details ?? [];
+      this.runStatus.errored_details = [...existing, detail].slice(-50);
+      this.runStatus.current_cycle = undefined;
+    }
+
+    if (event.type === 'batch_warning') {
+      // Non-fatal pre-batch issue (e.g. signal-brief failure). Surface as a
+      // gentle warning; the run is still progressing.
+      this.completionWarning =
+        (event['reason'] as string) === 'signal_brief_failed'
+          ? 'Signal brief unavailable for a batch; strategies continued without it.'
+          : (event['reason'] as string) || 'A non-fatal warning occurred during a batch.';
+    }
+
     if (event.type === 'complete') {
+      const erroredCount = (event['errored_count'] as number) ?? this.runStatus?.errored_cycles ?? 0;
+      const skippedCount = (event['skipped_count'] as number) ?? this.runStatus?.skipped_cycles ?? 0;
+      if (erroredCount > 0 || (event['status'] as string) === 'completed_with_errors') {
+        const parts: string[] = [];
+        if (erroredCount > 0) parts.push(`${erroredCount} cycle(s) errored`);
+        if (skippedCount > 0) parts.push(`${skippedCount} cycle(s) skipped`);
+        this.completionWarning = `Run finished with ${parts.join(' and ')}. See details below.`;
+      }
       this.onRunComplete();
     }
 
@@ -394,6 +428,7 @@ export class StrategyLabComponent implements OnInit, OnDestroy {
 
     this.running = true;
     this.error = null;
+    this.completionWarning = null;
     this.api.runStrategyLab({ batch_size: batchSize, batch_count: batchCount }).subscribe({
       next: (res) => {
         this.activeRunId = res.run_id;
@@ -404,6 +439,8 @@ export class StrategyLabComponent implements OnInit, OnDestroy {
           total_cycles: res.total_cycles,
           completed_cycles: 0,
           skipped_cycles: 0,
+          errored_cycles: 0,
+          errored_details: [],
           completed_record_ids: [],
           batch_size: batchSize,
           batch_count: batchCount,
@@ -547,6 +584,16 @@ export class StrategyLabComponent implements OnInit, OnDestroy {
   progressPercent(): number {
     if (!this.runStatus || this.runStatus.total_cycles === 0) return 0;
     return Math.round((this.runStatus.completed_cycles / this.runStatus.total_cycles) * 100);
+  }
+
+  /** Short multi-line tooltip summarizing recent errored cycles for hover. */
+  erroredTooltip(): string {
+    const details = this.runStatus?.errored_details ?? [];
+    if (!details.length) return '';
+    return details
+      .slice(-10)
+      .map((d) => `#${d.cycle_index}${d.batch_index ? ` (batch ${d.batch_index})` : ''}: ${d.error}`)
+      .join('\n');
   }
 
   // ---------------------------------------------------------------------------

--- a/user-interface/src/app/models/investment.model.ts
+++ b/user-interface/src/app/models/investment.model.ts
@@ -575,13 +575,24 @@ export interface StrategyLabCycleProgress {
   is_winning?: boolean;
 }
 
+export interface StrategyLabErroredDetail {
+  cycle_index: number;
+  batch_index?: number;
+  error: string;
+  exception_type?: string;
+  reason?: string;
+}
+
 export interface StrategyLabRunStatus {
   run_id: string;
-  status: 'running' | 'completed' | 'failed';
+  status: 'running' | 'completed' | 'completed_with_errors' | 'failed' | 'cancelled';
   started_at: string;
   total_cycles: number;
   completed_cycles: number;
   skipped_cycles: number;
+  /** Non-fatal per-cycle failures — run kept going but user should see the count. */
+  errored_cycles?: number;
+  errored_details?: StrategyLabErroredDetail[];
   current_cycle?: StrategyLabCycleProgress;
   completed_record_ids: string[];
   error?: string;
@@ -625,8 +636,10 @@ export interface StrategyLabStreamEvent {
     | 'progress'
     | 'cycle_complete'
     | 'cycle_skipped'
+    | 'cycle_errored'
     | 'batch_start'
     | 'batch_complete'
+    | 'batch_warning'
     | 'complete'
     | 'error'
     | 'done';


### PR DESCRIPTION
## Summary

- Unexpected per-cycle exceptions no longer halt the whole Strategy Lab run — they're counted as `errored_cycles` with per-cycle detail, the batch loop keeps going, and the run ends in a new `completed_with_errors` terminal status.
- Guards added around `primary_tracker.merge_from` and `_compute_signal_brief` so a single bad snapshot or brief can't poison an entire run.
- UI surfaces a red "N errored" badge with hover detail and a dismissible warning banner when a run finishes with errors or skips.

Closes #305.

## Changes

**Backend** (`backend/agents/investment_team/api/main.py`)
- `_strategy_lab_worker`: generic per-cycle `Exception` now increments `errored_cycles` / appends to `errored_details` / emits a new `cycle_errored` SSE event instead of marking the run `failed`.
- Guarded `merge_from` call site (issue #269 landing point) — tracker-merge failures surface as `cycle_errored` with `reason: tracker_merge_failed`.
- Belt-and-suspenders `try/except` around `_compute_signal_brief()`; emits a `batch_warning` on unexpected raise.
- Terminal status selection: `completed` / `completed_with_errors` (new) / `cancelled` / `failed`. `failed` is reserved for catastrophic worker-level errors.
- Cleanup timer bumped to 15 min for `failed` runs so UI polls after SSE disconnect still see the terminal error.
- `StrategyLabRunStatusResponse` gains `errored_cycles` + `errored_details`; seeded in initial / resume / restart state dicts.

**Convergence tracker** (`strategy_lab/quality_gates/convergence_tracker.py`)
- `merge_from` logs a warning with both trial counts before raising `ValueError` on negative delta, making the root cause visible.

**Frontend** (`user-interface/src/app/components/strategy-lab/`)
- `StrategyLabRunStatus` status union extended with `completed_with_errors` / `cancelled`; new `errored_cycles` + `errored_details` fields; `cycle_errored` / `batch_warning` event types added.
- Red "N errored" badge with per-cycle tooltip; dismissible yellow warning banner.

**Tests**
- `test_strategy_lab_batches.py` gains two resilience cases — unexpected cycle exception and `merge_from` failure — both assert the run still completes and surfaces accurate counters.

## Test plan

- [x] `pytest agents/investment_team/tests/` — 355 passed, 1 skipped
- [x] `ruff check` + `ruff format --check` on touched files — clean
- [ ] Manual UI smoke test of a small multi-batch run (happy path) to confirm no regression in existing badges.
- [ ] Manual fault-injection run (monkey-patched orchestrator that fails every Nth cycle) to confirm the red badge, warning banner, and `completed_with_errors` status render as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)