### PR TITLE
llm_service: deep-copy validation context per retry attempt

### DIFF
--- a/backend/agents/llm_service/structured.py
+++ b/backend/agents/llm_service/structured.py
@@ -24,6 +24,7 @@ Persona" ``LLMJsonParseError``).
 
 from __future__ import annotations
 
+import copy
 import hashlib
 import json
 import logging
@@ -150,7 +151,13 @@ def complete_validated(
             continue
 
         try:
-            validated = schema.model_validate(data, context=context)
+            # Deep-copy the context on every attempt so mutations performed by
+            # validators during a failed attempt (e.g. the sales outreach flow
+            # setting ``context["citations_stripped"] = True``) don't leak
+            # into the next retry and silently corrupt a clean payload.
+            # The caller's original ``context`` dict is never mutated either.
+            attempt_context = copy.deepcopy(context) if context is not None else None
+            validated = schema.model_validate(data, context=attempt_context)
         except ValidationError as exc:
             last_validation_error = exc
             last_parse_error = None

--- a/backend/agents/llm_service/tests/test_structured_output.py
+++ b/backend/agents/llm_service/tests/test_structured_output.py
@@ -30,7 +30,9 @@ class _StubClient(LLMClient):
         self.call_prompts: list[str] = []
         self.call_system_prompts: list[str | None] = []
 
-    def complete_json(self, prompt, *, temperature=0.0, system_prompt=None, tools=None, think=False, **kwargs):
+    def complete_json(
+        self, prompt, *, temperature=0.0, system_prompt=None, tools=None, think=False, **kwargs
+    ):
         self.call_prompts.append(prompt)
         self.call_system_prompts.append(system_prompt)
         return self._handler(prompt, call_index=len(self.call_prompts) - 1)
@@ -74,9 +76,7 @@ def test_complete_validated_succeeds_after_parse_error(caplog):
     assert "# Markdown spec — not JSON" in retry_prompt
     assert "selected_option_id" in retry_prompt  # schema embedded
     # One INFO log confirming self-correction.
-    success_logs = [
-        r for r in caplog.records if "json_self_correction succeeded" in r.getMessage()
-    ]
+    success_logs = [r for r in caplog.records if "json_self_correction succeeded" in r.getMessage()]
     assert len(success_logs) == 1
     assert "FounderAnswer" in success_logs[0].getMessage()
 
@@ -238,3 +238,60 @@ def test_context_is_forwarded_to_model_validate():
     client2 = _StubClient(handler)
     with pytest.raises(LLMSchemaValidationError):
         complete_validated(client2, "prompt", schema=ContextAwareModel, correction_attempts=0)
+
+
+def test_context_is_isolated_across_retry_attempts():
+    """Each retry attempt must see a pristine copy of the original context.
+
+    Regression: ``complete_validated`` used to pass the same mutable dict into
+    every ``schema.model_validate(data, context=...)`` call, so a validator
+    that mutated the context on a failed attempt (e.g. the sales outreach
+    flow setting ``context["citations_stripped"] = True``) would leak that
+    flag into the next retry and silently corrupt a clean payload.
+    """
+    from pydantic import ValidationInfo, field_validator, model_validator
+
+    class MutatingRetryModel(BaseModel):
+        value: str
+
+        @field_validator("value", mode="after")
+        @classmethod
+        def _record_marker(cls, v: str, info: ValidationInfo) -> str:
+            # Every call sets a flag on the context — simulating the sales
+            # outreach ``citations_stripped`` side-channel. If retries share
+            # state, attempt 2 sees ``was_marked=True`` and ``failed_first=True``
+            # set by attempt 1.
+            if info.context is not None:
+                info.context["was_marked"] = True
+            return v
+
+        @model_validator(mode="after")
+        def _fail_once_if_previously_marked(self, info: ValidationInfo):
+            if info.context is not None and info.context.get("failed_first"):
+                raise ValueError("context from a previous attempt leaked into this retry")
+            if info.context is not None:
+                info.context["failed_first"] = True
+            if self.value == "fail":
+                raise ValueError("initial attempt fails to trigger a retry")
+            return self
+
+    payloads = [{"value": "fail"}, {"value": "clean"}]
+
+    def handler(prompt: str, *, call_index: int) -> dict[str, Any]:
+        return payloads[call_index]
+
+    client = _StubClient(handler)
+    caller_context: dict[str, Any] = {"was_marked": False, "failed_first": False}
+
+    # With context isolation, the retry sees ``failed_first=False`` and
+    # ``_fail_once_if_previously_marked`` does not raise.
+    result = complete_validated(
+        client,
+        "prompt",
+        schema=MutatingRetryModel,
+        context=caller_context,
+        correction_attempts=1,
+    )
+    assert result.value == "clean"
+    # And the caller's context dict is never mutated.
+    assert caller_context == {"was_marked": False, "failed_first": False}


### PR DESCRIPTION
## Summary

Addresses the P1 [Codex review comment](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/pull/307#discussion_r3138657439) on the (now-merged) #307.

Codex flagged that `complete_validated` reused the same mutable `context` dict across every `schema.model_validate(data, context=...)` call. Validators are allowed to mutate that context — the sales outreach flow does exactly that, setting `context["citations_stripped"] = True` when an unverified citation URL is stripped — so a mutation from a failed attempt would leak into the retry and silently corrupt a clean payload (e.g. an otherwise-`high` variant getting downgraded to `"low"` even though the retry had no stripped citations).

## Fix

`backend/agents/llm_service/structured.py` — deep-copy `context` on every attempt before passing it into `model_validate`. The caller's original dict is never mutated either, which is a nicer contract for call sites that build context inline.

```python
attempt_context = copy.deepcopy(context) if context is not None else None
validated = schema.model_validate(data, context=attempt_context)
```

## Test plan

- [x] New regression `test_context_is_isolated_across_retry_attempts` in `test_structured_output.py`. It programs a Pydantic model whose validators mutate the context and whose `model_validator` raises if it sees a leaked flag from a previous attempt. Against the old (shared-context) code path the retry raises; against the fix the retry succeeds and the caller's context is pristine.
- [x] All 8 `test_structured_output` tests pass.
- [x] The 32 `sales_team` tests from #307 still pass unchanged.
- [x] `ruff check` + `ruff format --check` — clean.

## Why not just document "don't mutate context"?

The sales pod already relies on validator-mutation as a side channel (`citations_stripped`), and it's the natural Pydantic pattern for communicating between stacked validators. Locking down that capability retroactively would break #307. Deep-copy is the defensive alternative: mutations are allowed *within* an attempt, just isolated *across* attempts.

https://claude.ai/code/session_014aVVupQzK1N6vMDj6fkScN

---
_Generated by [Claude Code](https://claude.ai/code/session_014aVVupQzK1N6vMDj6fkScN)_