### PR TITLE
SPEC-015 W5: pantry API endpoints (#322)

### DIFF
--- a/backend/agents/nutrition_meal_planning_team/api/main.py
+++ b/backend/agents/nutrition_meal_planning_team/api/main.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import logging
+import os
 import threading
 from contextlib import asynccontextmanager
-from typing import Optional
+from typing import List, Optional
 from uuid import uuid4
 
-from fastapi import FastAPI, HTTPException
+from fastapi import Depends, FastAPI, HTTPException, Query
 from fastapi.middleware.cors import CORSMiddleware
 
 from shared_observability import init_otel, instrument_fastapi_app
@@ -27,11 +28,20 @@ from ..models import (
     MealHistoryResponse,
     MealPlanRequest,
     NutritionPlanRequest,
+    PantryItemCreate,
+    PantryItemOut,
+    PantryItemPatch,
     ProfileUpdateRequest,
     ResolveAmbiguousRequest,
     RestrictionResolution,
 )
 from ..orchestrator.agent import NutritionMealPlanningOrchestrator
+from ..pantry import (
+    InvalidQuantity,
+    PantryItem,
+    PantryItemNotFound,
+    get_pantry_store,
+)
 from ..shared.job_store import (
     JOB_STATUS_COMPLETED,
     JOB_STATUS_FAILED,
@@ -435,3 +445,158 @@ def get_history_meals_route(client_id: Optional[str] = None):
     if not client_id:
         raise HTTPException(status_code=400, detail="client_id required")
     return orchestrator.get_meal_history(client_id)
+
+
+# --- SPEC-015 §4.4: pantry routes (NUTRITION_PANTRY) ---------------------
+
+_PANTRY_FLAG = "NUTRITION_PANTRY"
+
+
+def is_pantry_enabled() -> bool:
+    """Feature-flag truth source. Read on every call so tests can toggle."""
+    return os.environ.get(_PANTRY_FLAG, "0") == "1"
+
+
+def require_pantry_flag() -> None:
+    """Gate routes behind ``NUTRITION_PANTRY``. Returns 404 when flag is off
+    so the surface looks absent rather than forbidden."""
+    if not is_pantry_enabled():
+        raise HTTPException(status_code=404, detail="Not Found")
+
+
+def _item_to_out(item: PantryItem) -> PantryItemOut:
+    return PantryItemOut(
+        client_id=item.client_id,
+        canonical_id=item.canonical_id,
+        quantity_grams=item.quantity_grams,
+        display_qty=item.display_qty,
+        display_unit=item.display_unit,
+        expires_on=item.expires_on,
+        notes=item.notes,
+        added_at=item.added_at,
+        updated_at=item.updated_at,
+    )
+
+
+@app.get(
+    "/pantry/{client_id}",
+    response_model=List[PantryItemOut],
+    dependencies=[Depends(require_pantry_flag)],
+)
+def get_pantry_route(
+    client_id: str,
+    sort: str = Query("expiring", pattern="^(expiring|name|added_desc)$"),
+):
+    """List pantry items for a client. Sort modes: expiring (default), name, added_desc."""
+    store = get_pantry_store()
+    items = store.list_items(client_id, sort=sort)  # type: ignore[arg-type]
+    return [_item_to_out(i) for i in items]
+
+
+@app.post(
+    "/pantry/{client_id}/items",
+    response_model=PantryItemOut,
+    dependencies=[Depends(require_pantry_flag)],
+)
+def post_pantry_item_route(client_id: str, body: PantryItemCreate):
+    """Add or increment a pantry item. Server derives ``quantity_grams`` from
+    ``display_qty`` + ``display_unit``. When ``raw_name`` is given, the
+    ingredient parser resolves it to a canonical id."""
+    # Lazy-import to avoid loading the KB yaml / alias index at module import.
+    from ..ingredient_kb.errors import UnknownUnitError
+    from ..ingredient_kb.parser import parse_ingredient
+    from ..ingredient_kb.units import convert_to_grams, get_unit
+
+    canonical_id = body.canonical_id
+    if canonical_id is None:
+        parsed = parse_ingredient(body.raw_name or "")
+        if parsed.canonical_id is None:
+            raise HTTPException(
+                status_code=422,
+                detail={
+                    "reason": "unresolved_ingredient",
+                    "raw_name": body.raw_name,
+                    "reasons": list(parsed.reasons),
+                },
+            )
+        canonical_id = parsed.canonical_id
+
+    try:
+        unit = get_unit(body.display_unit)
+    except UnknownUnitError as e:
+        raise HTTPException(
+            status_code=422,
+            detail={"reason": "unknown_unit", "display_unit": body.display_unit, "error": str(e)},
+        ) from e
+
+    grams = convert_to_grams(qty=body.display_qty, unit=unit, canonical_id=canonical_id)
+    if grams is None:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "reason": "unconvertible_quantity",
+                "canonical_id": canonical_id,
+                "display_unit": body.display_unit,
+            },
+        )
+
+    store = get_pantry_store()
+    try:
+        item = store.add_or_increment_item(
+            client_id,
+            canonical_id,
+            quantity_grams=grams,
+            display_qty=body.display_qty,
+            display_unit=body.display_unit,
+            expires_on=body.expires_on,
+            notes=body.notes,
+        )
+    except InvalidQuantity as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    return _item_to_out(item)
+
+
+@app.put(
+    "/pantry/{client_id}/items/{canonical_id}",
+    response_model=PantryItemOut,
+    dependencies=[Depends(require_pantry_flag)],
+)
+def put_pantry_item_route(client_id: str, canonical_id: str, body: PantryItemPatch):
+    """Patch an existing pantry item. Omitted fields are untouched; explicit
+    ``null`` clears a nullable column."""
+    fields = body.model_dump(exclude_unset=True)
+    store = get_pantry_store()
+    try:
+        item = store.update_item(client_id, canonical_id, **fields)
+    except PantryItemNotFound as e:
+        raise HTTPException(status_code=404, detail=str(e)) from e
+    except InvalidQuantity as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    return _item_to_out(item)
+
+
+@app.delete(
+    "/pantry/{client_id}/items/{canonical_id}",
+    dependencies=[Depends(require_pantry_flag)],
+)
+def delete_pantry_item_route(client_id: str, canonical_id: str):
+    """Remove a pantry item. 404 when the row doesn't exist."""
+    store = get_pantry_store()
+    if not store.delete_item(client_id, canonical_id):
+        raise HTTPException(status_code=404, detail="pantry item not found")
+    return {"deleted": True, "client_id": client_id, "canonical_id": canonical_id}
+
+
+@app.get(
+    "/pantry/{client_id}/expiring",
+    response_model=List[PantryItemOut],
+    dependencies=[Depends(require_pantry_flag)],
+)
+def get_pantry_expiring_route(client_id: str, days: int = 3):
+    """Items expiring within ``days`` of today (already-expired items included)."""
+    store = get_pantry_store()
+    try:
+        items = store.list_expiring(client_id, days=days)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    return [_item_to_out(i) for i in items]

--- a/backend/agents/nutrition_meal_planning_team/api/main.py
+++ b/backend/agents/nutrition_meal_planning_team/api/main.py
@@ -506,6 +506,16 @@ def post_pantry_item_route(client_id: str, body: PantryItemCreate):
     from ..ingredient_kb.errors import UnknownUnitError
     from ..ingredient_kb.parser import parse_ingredient
     from ..ingredient_kb.units import convert_to_grams, get_unit
+    from ..shared.client_profile_store import get_profile
+
+    # ``nutrition_pantry.client_id`` FKs into ``nutrition_profiles``; check
+    # here so unknown clients surface as a clean 404 rather than a 500 from
+    # a Postgres IntegrityError downstream.
+    if get_profile(client_id) is None:
+        raise HTTPException(
+            status_code=404,
+            detail={"reason": "client_profile_not_found", "client_id": client_id},
+        )
 
     canonical_id = body.canonical_id
     if canonical_id is None:

--- a/backend/agents/nutrition_meal_planning_team/models.py
+++ b/backend/agents/nutrition_meal_planning_team/models.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
+from datetime import date
 from enum import Enum
 from typing import Any, Dict, List, Optional, Set
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 # SPEC-006: import only the taxonomy enums. ``ingredient_kb.taxonomy`` is a
 # pure stdlib module, so this is cycle-safe. Never import from
@@ -652,3 +653,59 @@ class ChatResponse(BaseModel):
     nutrition_plan: Optional[NutritionPlan] = None
     meal_suggestions: List[MealRecommendationWithId] = Field(default_factory=list)
     feedback_recorded: bool = False
+
+
+# SPEC-015 §4.4 — pantry API (W5) ------------------------------------------
+
+
+class PantryItemCreate(BaseModel):
+    """POST /pantry/{client_id}/items body.
+
+    Exactly one of ``canonical_id`` or ``raw_name`` must be supplied.
+    ``quantity_grams`` is derived server-side from ``display_qty`` +
+    ``display_unit`` via ``ingredient_kb.units.convert_to_grams``.
+    """
+
+    canonical_id: Optional[str] = None
+    raw_name: Optional[str] = None
+    display_qty: float
+    display_unit: str
+    expires_on: Optional[date] = None
+    notes: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _exactly_one_identity(self) -> "PantryItemCreate":
+        has_cid = bool(self.canonical_id and self.canonical_id.strip())
+        has_raw = bool(self.raw_name and self.raw_name.strip())
+        if has_cid == has_raw:
+            raise ValueError("exactly one of canonical_id or raw_name is required")
+        return self
+
+
+class PantryItemPatch(BaseModel):
+    """PUT /pantry/{client_id}/items/{canonical_id} body.
+
+    Omitted fields are left untouched. Explicit ``null`` clears a
+    nullable column. ``quantity_grams`` is NOT NULL in the schema, so
+    ``null`` there is ignored by the store.
+    """
+
+    quantity_grams: Optional[float] = None
+    display_qty: Optional[float] = None
+    display_unit: Optional[str] = None
+    expires_on: Optional[date] = None
+    notes: Optional[str] = None
+
+
+class PantryItemOut(BaseModel):
+    """Wire response shape for a pantry item."""
+
+    client_id: str
+    canonical_id: str
+    quantity_grams: float
+    display_qty: Optional[float] = None
+    display_unit: Optional[str] = None
+    expires_on: Optional[date] = None
+    notes: str = ""
+    added_at: str = ""
+    updated_at: str = ""

--- a/backend/agents/nutrition_meal_planning_team/models.py
+++ b/backend/agents/nutrition_meal_planning_team/models.py
@@ -675,10 +675,15 @@ class PantryItemCreate(BaseModel):
 
     @model_validator(mode="after")
     def _exactly_one_identity(self) -> "PantryItemCreate":
-        has_cid = bool(self.canonical_id and self.canonical_id.strip())
-        has_raw = bool(self.raw_name and self.raw_name.strip())
-        if has_cid == has_raw:
+        # Normalize blank / whitespace-only strings to ``None`` so the route
+        # can branch on ``is None`` alone (and so blank canonical ids never
+        # reach the store).
+        cid = (self.canonical_id or "").strip() or None
+        raw = (self.raw_name or "").strip() or None
+        if (cid is None) == (raw is None):
             raise ValueError("exactly one of canonical_id or raw_name is required")
+        self.canonical_id = cid
+        self.raw_name = raw
         return self
 
 

--- a/backend/agents/nutrition_meal_planning_team/tests/test_api_pantry.py
+++ b/backend/agents/nutrition_meal_planning_team/tests/test_api_pantry.py
@@ -1,0 +1,393 @@
+"""API tests for SPEC-015 W5 pantry endpoints.
+
+Covers the feature-flag gate, wire-contract semantics
+(XOR identity, server-side gram derivation, increment-on-duplicate,
+sentinel-based PUT), and per-route error mapping.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from pathlib import Path
+
+import pytest
+
+from shared_postgres import is_postgres_enabled
+
+# Ensure agents dir is on path for direct invocation.
+_agents_dir = Path(__file__).resolve().parent.parent.parent
+if str(_agents_dir) not in __import__("sys").path:
+    __import__("sys").path.insert(0, str(_agents_dir))
+
+from fastapi.testclient import TestClient  # noqa: E402
+
+from nutrition_meal_planning_team.api.main import app  # noqa: E402
+from nutrition_meal_planning_team.models import ClientProfile  # noqa: E402
+from nutrition_meal_planning_team.shared.client_profile_store import save_profile  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not is_postgres_enabled(),
+    reason="Pantry API requires Postgres (set POSTGRES_HOST).",
+)
+
+
+@pytest.fixture
+def client():
+    # Context-manage to run Starlette lifespan (schema registration).
+    with TestClient(app) as c:
+        yield c
+
+
+@pytest.fixture
+def client_id() -> str:
+    """Insert a profile so the pantry FK constraint is satisfied."""
+    cid = "pantry-api-client"
+    save_profile(cid, ClientProfile(client_id=cid))
+    return cid
+
+
+@pytest.fixture
+def pantry_on(monkeypatch):
+    """Enable the NUTRITION_PANTRY flag for happy-path tests."""
+    monkeypatch.setenv("NUTRITION_PANTRY", "1")
+    yield
+
+
+# --- Flag gating (one per route) ----------------------------------------
+
+
+def _flag_off(monkeypatch):
+    monkeypatch.delenv("NUTRITION_PANTRY", raising=False)
+
+
+def test_flag_off_get_list_returns_404(client, client_id, monkeypatch):
+    _flag_off(monkeypatch)
+    r = client.get(f"/pantry/{client_id}")
+    assert r.status_code == 404
+
+
+def test_flag_off_post_returns_404(client, client_id, monkeypatch):
+    _flag_off(monkeypatch)
+    r = client.post(
+        f"/pantry/{client_id}/items",
+        json={"canonical_id": "olive_oil", "display_qty": 1, "display_unit": "g"},
+    )
+    assert r.status_code == 404
+
+
+def test_flag_off_put_returns_404(client, client_id, monkeypatch):
+    _flag_off(monkeypatch)
+    r = client.put(
+        f"/pantry/{client_id}/items/olive_oil",
+        json={"quantity_grams": 10},
+    )
+    assert r.status_code == 404
+
+
+def test_flag_off_delete_returns_404(client, client_id, monkeypatch):
+    _flag_off(monkeypatch)
+    r = client.delete(f"/pantry/{client_id}/items/olive_oil")
+    assert r.status_code == 404
+
+
+def test_flag_off_expiring_returns_404(client, client_id, monkeypatch):
+    _flag_off(monkeypatch)
+    r = client.get(f"/pantry/{client_id}/expiring")
+    assert r.status_code == 404
+
+
+# --- POST happy paths --------------------------------------------------
+
+
+def test_post_with_canonical_id_creates_item(client, client_id, pantry_on):
+    r = client.post(
+        f"/pantry/{client_id}/items",
+        json={
+            "canonical_id": "olive_oil",
+            "display_qty": 500,
+            "display_unit": "g",
+            "notes": "kitchen cabinet",
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["canonical_id"] == "olive_oil"
+    assert body["quantity_grams"] == 500.0
+    assert body["display_qty"] == 500.0
+    assert body["display_unit"] == "g"
+    assert body["notes"] == "kitchen cabinet"
+
+
+def test_post_with_raw_name_resolves_and_creates(client, client_id, pantry_on):
+    r = client.post(
+        f"/pantry/{client_id}/items",
+        json={"raw_name": "olive oil", "display_qty": 100, "display_unit": "g"},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["canonical_id"] == "olive_oil"
+    assert body["quantity_grams"] == 100.0
+
+
+def test_post_existing_canonical_id_increments(client, client_id, pantry_on):
+    first = client.post(
+        f"/pantry/{client_id}/items",
+        json={"canonical_id": "olive_oil", "display_qty": 100, "display_unit": "g"},
+    )
+    assert first.status_code == 200, first.text
+    assert first.json()["quantity_grams"] == 100.0
+
+    second = client.post(
+        f"/pantry/{client_id}/items",
+        json={"canonical_id": "olive_oil", "display_qty": 250, "display_unit": "g"},
+    )
+    assert second.status_code == 200, second.text
+    assert second.json()["quantity_grams"] == 350.0
+
+    listed = client.get(f"/pantry/{client_id}")
+    assert listed.status_code == 200
+    items = listed.json()
+    assert len(items) == 1
+    assert items[0]["canonical_id"] == "olive_oil"
+    assert items[0]["quantity_grams"] == 350.0
+
+
+# --- POST error paths --------------------------------------------------
+
+
+def test_post_raw_name_unresolved_returns_422(client, client_id, pantry_on):
+    r = client.post(
+        f"/pantry/{client_id}/items",
+        json={"raw_name": "xyzzynotafood", "display_qty": 1, "display_unit": "g"},
+    )
+    assert r.status_code == 422
+    assert r.json()["detail"]["reason"] == "unresolved_ingredient"
+
+
+def test_post_unknown_unit_returns_422(client, client_id, pantry_on):
+    r = client.post(
+        f"/pantry/{client_id}/items",
+        json={"canonical_id": "olive_oil", "display_qty": 1, "display_unit": "bogusunit"},
+    )
+    assert r.status_code == 422
+    assert r.json()["detail"]["reason"] == "unknown_unit"
+
+
+def test_post_unconvertible_quantity_returns_422(client, client_id, pantry_on):
+    # ``butter`` has ``count_to_mass`` but no ``volume_to_mass`` density,
+    # so a volume unit like ``cup`` cannot be converted to grams.
+    r = client.post(
+        f"/pantry/{client_id}/items",
+        json={"canonical_id": "butter", "display_qty": 1, "display_unit": "cup"},
+    )
+    assert r.status_code == 422
+    assert r.json()["detail"]["reason"] == "unconvertible_quantity"
+
+
+def test_post_xor_both_set_returns_422(client, client_id, pantry_on):
+    r = client.post(
+        f"/pantry/{client_id}/items",
+        json={
+            "canonical_id": "olive_oil",
+            "raw_name": "olive oil",
+            "display_qty": 1,
+            "display_unit": "g",
+        },
+    )
+    assert r.status_code == 422
+
+
+def test_post_xor_neither_set_returns_422(client, client_id, pantry_on):
+    r = client.post(
+        f"/pantry/{client_id}/items",
+        json={"display_qty": 1, "display_unit": "g"},
+    )
+    assert r.status_code == 422
+
+
+def test_post_invalid_quantity_returns_400(client, client_id, pantry_on):
+    # display_qty=0 → grams=0 → store rejects with InvalidQuantity → 400.
+    r = client.post(
+        f"/pantry/{client_id}/items",
+        json={"canonical_id": "olive_oil", "display_qty": 0, "display_unit": "g"},
+    )
+    assert r.status_code == 400
+
+
+# --- PUT ----------------------------------------------------------------
+
+
+def test_put_partial_update_preserves_other_fields(client, client_id, pantry_on):
+    client.post(
+        f"/pantry/{client_id}/items",
+        json={
+            "canonical_id": "olive_oil",
+            "display_qty": 500,
+            "display_unit": "g",
+            "notes": "original notes",
+        },
+    ).raise_for_status()
+
+    r = client.put(
+        f"/pantry/{client_id}/items/olive_oil",
+        json={"quantity_grams": 999.0},
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["quantity_grams"] == 999.0
+    # Untouched fields preserved (omitted from body ⇒ store's _UNSET sentinel).
+    assert body["display_qty"] == 500.0
+    assert body["display_unit"] == "g"
+    assert body["notes"] == "original notes"
+
+
+def test_put_explicit_null_clears_nullable_field(client, client_id, pantry_on):
+    today = date.today()
+    client.post(
+        f"/pantry/{client_id}/items",
+        json={
+            "canonical_id": "olive_oil",
+            "display_qty": 500,
+            "display_unit": "g",
+            "expires_on": today.isoformat(),
+        },
+    ).raise_for_status()
+
+    r = client.put(
+        f"/pantry/{client_id}/items/olive_oil",
+        json={"expires_on": None},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["expires_on"] is None
+
+
+def test_put_missing_item_returns_404(client, client_id, pantry_on):
+    r = client.put(
+        f"/pantry/{client_id}/items/does_not_exist",
+        json={"quantity_grams": 10},
+    )
+    assert r.status_code == 404
+
+
+def test_put_invalid_quantity_returns_400(client, client_id, pantry_on):
+    client.post(
+        f"/pantry/{client_id}/items",
+        json={"canonical_id": "olive_oil", "display_qty": 500, "display_unit": "g"},
+    ).raise_for_status()
+
+    r = client.put(
+        f"/pantry/{client_id}/items/olive_oil",
+        json={"quantity_grams": -1.0},
+    )
+    assert r.status_code == 400
+
+
+# --- DELETE -------------------------------------------------------------
+
+
+def test_delete_removes_item(client, client_id, pantry_on):
+    client.post(
+        f"/pantry/{client_id}/items",
+        json={"canonical_id": "olive_oil", "display_qty": 500, "display_unit": "g"},
+    ).raise_for_status()
+
+    r = client.delete(f"/pantry/{client_id}/items/olive_oil")
+    assert r.status_code == 200
+    assert r.json() == {"deleted": True, "client_id": client_id, "canonical_id": "olive_oil"}
+
+    listed = client.get(f"/pantry/{client_id}")
+    assert listed.status_code == 200
+    assert listed.json() == []
+
+
+def test_delete_absent_returns_404(client, client_id, pantry_on):
+    r = client.delete(f"/pantry/{client_id}/items/olive_oil")
+    assert r.status_code == 404
+
+
+# --- GET list + sort ---------------------------------------------------
+
+
+def _post_item(client, client_id, canonical_id: str, expires_on=None) -> None:
+    body = {"canonical_id": canonical_id, "display_qty": 100, "display_unit": "g"}
+    if expires_on is not None:
+        body["expires_on"] = expires_on.isoformat()
+    client.post(f"/pantry/{client_id}/items", json=body).raise_for_status()
+
+
+def test_get_list_default_sort_expiring_nulls_last(client, client_id, pantry_on):
+    today = date.today()
+    _post_item(client, client_id, "olive_oil", expires_on=today + timedelta(days=7))
+    _post_item(client, client_id, "butter", expires_on=today + timedelta(days=2))
+    _post_item(client, client_id, "rice_white_raw", expires_on=None)
+
+    r = client.get(f"/pantry/{client_id}")
+    assert r.status_code == 200
+    ids = [row["canonical_id"] for row in r.json()]
+    assert ids == ["butter", "olive_oil", "rice_white_raw"]
+
+
+def test_get_list_sort_name(client, client_id, pantry_on):
+    for cid in ("olive_oil", "butter", "rice_white_raw"):
+        _post_item(client, client_id, cid)
+    r = client.get(f"/pantry/{client_id}", params={"sort": "name"})
+    assert r.status_code == 200
+    ids = [row["canonical_id"] for row in r.json()]
+    assert ids == sorted(ids)
+
+
+def test_get_list_sort_added_desc(client, client_id, pantry_on):
+    import time
+
+    _post_item(client, client_id, "olive_oil")
+    time.sleep(0.01)
+    _post_item(client, client_id, "butter")
+    time.sleep(0.01)
+    _post_item(client, client_id, "rice_white_raw")
+
+    r = client.get(f"/pantry/{client_id}", params={"sort": "added_desc"})
+    assert r.status_code == 200
+    ids = [row["canonical_id"] for row in r.json()]
+    assert ids[0] == "rice_white_raw"
+    assert ids[-1] == "olive_oil"
+
+
+def test_get_list_invalid_sort_returns_422(client, client_id, pantry_on):
+    r = client.get(f"/pantry/{client_id}", params={"sort": "bogus"})
+    assert r.status_code == 422
+
+
+# --- GET expiring ------------------------------------------------------
+
+
+def test_expiring_default_days_filters_to_near_term(client, client_id, pantry_on):
+    today = date.today()
+    _post_item(client, client_id, "olive_oil", expires_on=today + timedelta(days=2))
+    _post_item(client, client_id, "butter", expires_on=today + timedelta(days=10))
+
+    r = client.get(f"/pantry/{client_id}/expiring")
+    assert r.status_code == 200
+    ids = [row["canonical_id"] for row in r.json()]
+    assert ids == ["olive_oil"]
+
+
+def test_expiring_custom_days_broadens_window(client, client_id, pantry_on):
+    today = date.today()
+    _post_item(client, client_id, "olive_oil", expires_on=today + timedelta(days=2))
+    _post_item(client, client_id, "butter", expires_on=today + timedelta(days=10))
+
+    r = client.get(f"/pantry/{client_id}/expiring", params={"days": 14})
+    assert r.status_code == 200
+    ids = sorted(row["canonical_id"] for row in r.json())
+    assert ids == ["butter", "olive_oil"]
+
+
+def test_expiring_negative_days_returns_400(client, client_id, pantry_on):
+    r = client.get(f"/pantry/{client_id}/expiring", params={"days": -1})
+    assert r.status_code == 400
+
+
+def test_expiring_empty_pantry_returns_empty_list(client, client_id, pantry_on):
+    r = client.get(f"/pantry/{client_id}/expiring")
+    assert r.status_code == 200
+    assert r.json() == []

--- a/backend/agents/nutrition_meal_planning_team/tests/test_api_pantry.py
+++ b/backend/agents/nutrition_meal_planning_team/tests/test_api_pantry.py
@@ -214,6 +214,32 @@ def test_post_invalid_quantity_returns_400(client, client_id, pantry_on):
     assert r.status_code == 400
 
 
+def test_post_whitespace_canonical_id_falls_through_to_raw_name(client, client_id, pantry_on):
+    # Whitespace-only ``canonical_id`` must not bypass ``raw_name`` resolution;
+    # the validator normalizes blank strings to ``None``.
+    r = client.post(
+        f"/pantry/{client_id}/items",
+        json={
+            "canonical_id": "   ",
+            "raw_name": "olive oil",
+            "display_qty": 100,
+            "display_unit": "g",
+        },
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["canonical_id"] == "olive_oil"
+
+
+def test_post_unknown_client_returns_404(client, pantry_on):
+    # No profile seeded ⇒ FK would fail. Route pre-checks and 404s cleanly.
+    r = client.post(
+        "/pantry/ghost-client/items",
+        json={"canonical_id": "olive_oil", "display_qty": 100, "display_unit": "g"},
+    )
+    assert r.status_code == 404
+    assert r.json()["detail"]["reason"] == "client_profile_not_found"
+
+
 # --- PUT ----------------------------------------------------------------
 
 


### PR DESCRIPTION
Closes #322.

## Summary

Add the five pantry API routes behind the `NUTRITION_PANTRY` feature flag (404 when off) so follow-up SPEC-015 work (bulk import #323, near-expiry hints #324, UI #325–#328, benchmarks #330, observability #329) can proceed in parallel.

Wire contract mirrors **SPEC-015 §4.4** exactly: POST accepts `{canonical_id OR raw_name, display_qty, display_unit, expires_on?, notes?}` and the server derives `quantity_grams` via `ingredient_kb.convert_to_grams` — `quantity_grams` is never on the wire. PUT uses `model_dump(exclude_unset=True)` so the store's `_UNSET` sentinel preserves untouched fields while explicit `null` clears nullable columns.

## Changes

- **`backend/agents/nutrition_meal_planning_team/models.py`** — add `PantryItemCreate` (with `@model_validator` XOR on `canonical_id`/`raw_name`), `PantryItemPatch`, `PantryItemOut`.
- **`backend/agents/nutrition_meal_planning_team/api/main.py`** — add 5 routes, `NUTRITION_PANTRY` feature-flag helpers, and a `require_pantry_flag` dependency that returns 404 when the flag is off.
- **`backend/agents/nutrition_meal_planning_team/tests/test_api_pantry.py`** — new, 28 tests covering flag gating, POST happy paths + increment, all 5 error branches (unresolved ingredient, unknown unit, unconvertible quantity, XOR violations, invalid quantity), PUT partial / explicit-null / 404 / 400, DELETE success + 404, all three sort modes + invalid-sort 422, and the expiring endpoint.

## Error mapping

| Condition | HTTP |
|---|---|
| Flag off (any route) | 404 |
| `raw_name` with `parsed.canonical_id is None` | 422 `reason=unresolved_ingredient` |
| `display_unit` not in `units.yaml` | 422 `reason=unknown_unit` |
| `convert_to_grams` returns `None` | 422 `reason=unconvertible_quantity` |
| `canonical_id` XOR `raw_name` violated | 422 (Pydantic) |
| Invalid `sort` param | 422 (Query pattern) |
| `store.InvalidQuantity` (grams ≤ 0) | 400 |
| `store.PantryItemNotFound` on PUT | 404 |
| `delete_item` returned `False` | 404 |
| `list_expiring` negative `days` | 400 |

## Test plan

- [x] `NUTRITION_PANTRY=1 pytest agents/nutrition_meal_planning_team/tests/test_api_pantry.py` — 28 passed
- [x] Without `NUTRITION_PANTRY` set — same 28 passed (flag-off paths exercise the 404 dependency; happy paths set `pantry_on` via `monkeypatch`)
- [x] `ruff check` + `ruff format --check` — clean
- [x] Broader nutrition suite — no regressions from this PR (5 pre-existing `test_agents.py` failures are unrelated Strands env issues present on `main`)

https://claude.ai/code/session_01PCCWkoyFfoKwBwcNAjd2iY

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCCWkoyFfoKwBwcNAjd2iY)_