### PR TITLE
user_agent_founder: resume short-circuits already-completed phases (#347)

### DIFF
--- a/backend/agents/user_agent_founder/api/main.py
+++ b/backend/agents/user_agent_founder/api/main.py
@@ -561,7 +561,18 @@ def restart_job(job_id: str) -> StartRunResponse:
     job_store.reset_job(job_id)
     job_store.update_job(job_id, status=job_store.JOB_STATUS_RUNNING, current_phase="starting")
     store = get_founder_store()
-    store.update_run(job_id, status="pending", error=None)
+    # Clear every checkpoint column so the orchestrator's resume short-circuit
+    # (which keys off non-NULL spec_content / analysis_job_id / repo_path /
+    # se_job_id) cannot turn a restart into a stale replay.
+    store.update_run(
+        job_id,
+        status="pending",
+        error=None,
+        spec_content=None,
+        analysis_job_id=None,
+        repo_path=None,
+        se_job_id=None,
+    )
 
     try:
         mode = _dispatch_founder_run(job_id)

--- a/backend/agents/user_agent_founder/orchestrator.py
+++ b/backend/agents/user_agent_founder/orchestrator.py
@@ -137,7 +137,10 @@ def _answer_pending_questions(
             role="assistant",
             content=f"Q: {q.get('question_text', '')}\nA: {answer_text}\nRationale: {rationale}",
             message_type="answer_given",
-            metadata={"question_id": q["id"], "selected_option_id": result.get("selected_option_id")},
+            metadata={
+                "question_id": q["id"],
+                "selected_option_id": result.get("selected_option_id"),
+            },
         )
         answer_payload: dict[str, Any] = {
             "question_id": q["id"],
@@ -186,31 +189,51 @@ def _run_product_analysis(
     store: FounderRunStore,
     run_id: str,
     spec_content: str,
+    *,
+    existing_job_id: str | None = None,
 ) -> str | None:
-    """Submit spec for product analysis and poll until complete. Returns repo_path or None."""
-    store.update_run(run_id, status="submitting_analysis")
-    _sync_job_status(run_id, "running", phase="submitting_analysis")
+    """Submit spec for product analysis and poll until complete. Returns repo_path or None.
 
-    resp = client.post(
-        _se_url("/product-analysis/start-from-spec"),
-        json={"project_name": f"user-agent-founder-{run_id}", "spec_content": spec_content},
-        timeout=HTTP_TIMEOUT,
-    )
-    if resp.status_code >= 400:
-        store.update_run(
-            run_id,
-            status="failed",
-            error=f"Failed to start analysis: {resp.status_code} {resp.text[:500]}",
+    If ``existing_job_id`` is supplied (resume path), the submit step is
+    skipped and polling resumes against that analysis job.
+    """
+    if existing_job_id is None:
+        store.update_run(run_id, status="submitting_analysis")
+        _sync_job_status(run_id, "running", phase="submitting_analysis")
+
+        resp = client.post(
+            _se_url("/product-analysis/start-from-spec"),
+            json={"project_name": f"user-agent-founder-{run_id}", "spec_content": spec_content},
+            timeout=HTTP_TIMEOUT,
         )
-        _sync_job_status(run_id, "failed", error="Failed to start analysis")
-        return None
+        if resp.status_code >= 400:
+            store.update_run(
+                run_id,
+                status="failed",
+                error=f"Failed to start analysis: {resp.status_code} {resp.text[:500]}",
+            )
+            _sync_job_status(run_id, "failed", error="Failed to start analysis")
+            return None
 
-    data = resp.json()
-    analysis_job_id = data.get("job_id")
-    store.update_run(run_id, analysis_job_id=analysis_job_id, status="polling_analysis")
-    _sync_job_status(run_id, "running", phase="polling_analysis")
-    logger.info("Product analysis started: job_id=%s", analysis_job_id)
-    store.add_chat_message(run_id, "system", f"Product analysis started (job: {analysis_job_id})", "status_update")
+        data = resp.json()
+        analysis_job_id = data.get("job_id")
+        store.update_run(run_id, analysis_job_id=analysis_job_id, status="polling_analysis")
+        _sync_job_status(run_id, "running", phase="polling_analysis")
+        logger.info("Product analysis started: job_id=%s", analysis_job_id)
+        store.add_chat_message(
+            run_id, "system", f"Product analysis started (job: {analysis_job_id})", "status_update"
+        )
+    else:
+        analysis_job_id = existing_job_id
+        store.update_run(run_id, status="polling_analysis", error=None)
+        _sync_job_status(run_id, "running", phase="polling_analysis")
+        logger.info("Resuming product analysis poll: job_id=%s", analysis_job_id)
+        store.add_chat_message(
+            run_id,
+            "system",
+            f"Resuming product analysis poll (job: {analysis_job_id})",
+            "status_update",
+        )
 
     failed_question_sets: dict[frozenset[str], int] = {}  # qset -> attempt count
 
@@ -245,15 +268,26 @@ def _run_product_analysis(
 
             store.update_run(run_id, status="answering_analysis_questions")
             store.add_chat_message(
-                run_id, "system", f"SE team has {len(pending)} question(s) during analysis.",
-                "question_received", metadata={"question_ids": list(qset)},
+                run_id,
+                "system",
+                f"SE team has {len(pending)} question(s) during analysis.",
+                "question_received",
+                metadata={"question_ids": list(qset)},
             )
             success = _answer_pending_questions(
-                client, agent, store, run_id, analysis_job_id, pending, "/product-analysis",
+                client,
+                agent,
+                store,
+                run_id,
+                analysis_job_id,
+                pending,
+                "/product-analysis",
             )
             if not success:
                 failed_question_sets[qset] = prior_failures + 1
-                logger.warning("Answer attempt %d failed for analysis questions", prior_failures + 1)
+                logger.warning(
+                    "Answer attempt %d failed for analysis questions", prior_failures + 1
+                )
             continue
 
         if status == "completed":
@@ -261,7 +295,10 @@ def _run_product_analysis(
             store.update_run(run_id, repo_path=repo_path)
             logger.info("Product analysis completed: repo_path=%s", repo_path)
             store.add_chat_message(
-                run_id, "system", "Analysis complete. Starting SE team build.", "status_update",
+                run_id,
+                "system",
+                "Analysis complete. Starting SE team build.",
+                "status_update",
             )
             return repo_path
 
@@ -284,31 +321,51 @@ def _run_se_team(
     store: FounderRunStore,
     run_id: str,
     repo_path: str,
+    *,
+    existing_job_id: str | None = None,
 ) -> bool:
-    """Start the SE team build and poll until complete. Returns True on success."""
-    store.update_run(run_id, status="submitting_build")
-    _sync_job_status(run_id, "running", phase="submitting_build")
+    """Start the SE team build and poll until complete. Returns True on success.
 
-    resp = client.post(
-        _se_url("/run-team"),
-        json={"repo_path": repo_path},
-        timeout=HTTP_TIMEOUT,
-    )
-    if resp.status_code >= 400:
-        store.update_run(
-            run_id,
-            status="failed",
-            error=f"Failed to start SE team: {resp.status_code} {resp.text[:500]}",
+    If ``existing_job_id`` is supplied (resume path), the submit step is
+    skipped and polling resumes against that SE job.
+    """
+    if existing_job_id is None:
+        store.update_run(run_id, status="submitting_build")
+        _sync_job_status(run_id, "running", phase="submitting_build")
+
+        resp = client.post(
+            _se_url("/run-team"),
+            json={"repo_path": repo_path},
+            timeout=HTTP_TIMEOUT,
         )
-        _sync_job_status(run_id, "failed", error="Failed to start SE team")
-        return False
+        if resp.status_code >= 400:
+            store.update_run(
+                run_id,
+                status="failed",
+                error=f"Failed to start SE team: {resp.status_code} {resp.text[:500]}",
+            )
+            _sync_job_status(run_id, "failed", error="Failed to start SE team")
+            return False
 
-    data = resp.json()
-    se_job_id = data.get("job_id")
-    store.update_run(run_id, se_job_id=se_job_id, status="polling_build")
-    _sync_job_status(run_id, "running", phase="polling_build")
-    logger.info("SE team build started: job_id=%s", se_job_id)
-    store.add_chat_message(run_id, "system", f"SE team build started (job: {se_job_id})", "status_update")
+        data = resp.json()
+        se_job_id = data.get("job_id")
+        store.update_run(run_id, se_job_id=se_job_id, status="polling_build")
+        _sync_job_status(run_id, "running", phase="polling_build")
+        logger.info("SE team build started: job_id=%s", se_job_id)
+        store.add_chat_message(
+            run_id, "system", f"SE team build started (job: {se_job_id})", "status_update"
+        )
+    else:
+        se_job_id = existing_job_id
+        store.update_run(run_id, status="polling_build", error=None)
+        _sync_job_status(run_id, "running", phase="polling_build")
+        logger.info("Resuming SE team build poll: job_id=%s", se_job_id)
+        store.add_chat_message(
+            run_id,
+            "system",
+            f"Resuming SE team build poll (job: {se_job_id})",
+            "status_update",
+        )
 
     failed_question_sets: dict[frozenset[str], int] = {}
 
@@ -343,11 +400,20 @@ def _run_se_team(
 
             store.update_run(run_id, status="answering_build_questions")
             store.add_chat_message(
-                run_id, "system", f"SE team has {len(pending)} question(s) during build.",
-                "question_received", metadata={"question_ids": list(qset)},
+                run_id,
+                "system",
+                f"SE team has {len(pending)} question(s) during build.",
+                "question_received",
+                metadata={"question_ids": list(qset)},
             )
             success = _answer_pending_questions(
-                client, agent, store, run_id, se_job_id, pending, "/run-team",
+                client,
+                agent,
+                store,
+                run_id,
+                se_job_id,
+                pending,
+                "/run-team",
             )
             if not success:
                 failed_question_sets[qset] = prior_failures + 1
@@ -356,7 +422,9 @@ def _run_se_team(
 
         if status == "completed":
             logger.info("SE team build completed for run %s", run_id)
-            store.add_chat_message(run_id, "system", "Build completed successfully.", "status_update")
+            store.add_chat_message(
+                run_id, "system", "Build completed successfully.", "status_update"
+            )
             return True
 
         if status == "failed":
@@ -369,7 +437,9 @@ def _run_se_team(
         if status == "cancelled":
             store.update_run(run_id, status="failed", error="SE team build was cancelled")
             _sync_job_status(run_id, "failed", error="SE team build cancelled")
-            store.add_chat_message(run_id, "system", "SE team build was cancelled.", "status_update")
+            store.add_chat_message(
+                run_id, "system", "SE team build was cancelled.", "status_update"
+            )
             return False
 
     store.update_run(run_id, status="failed", error="SE team build timed out")
@@ -381,32 +451,85 @@ def _run_se_team(
 def run_workflow(run_id: str, store: FounderRunStore, agent: FounderAgent) -> None:
     """Execute the full founder workflow: spec -> analysis -> build.
 
+    Re-entrant for the resume path: phases whose checkpoint columns are
+    already populated on the run row are short-circuited so a `/resume`
+    call does not re-pay the cost of completed phases (LLM spec gen,
+    multi-hour analysis poll, etc.).
+
     This function is designed to run in a background thread.
     """
     logger.info("Starting founder workflow: run_id=%s", run_id)
 
+    run = store.get_run(run_id)
+
     try:
-        # Phase 1: Generate the product spec
-        store.update_run(run_id, status="generating_spec")
-        _sync_job_status(run_id, "running", phase="generating_spec")
-        store.add_chat_message(run_id, "system", "Generating product specification...", "status_update")
-        spec_content = _generate_spec_with_heartbeat(agent, run_id)
-        store.update_run(run_id, spec_content=spec_content)
-        logger.info("Spec generated for run %s (%d chars)", run_id, len(spec_content))
-        store.add_chat_message(
-            run_id, "assistant",
-            f"Product spec generated ({len(spec_content)} chars). Submitting to SE team for analysis.",
-            "status_update",
-        )
+        # Phase 1: Generate the product spec (skip if already done)
+        if run is not None and run.spec_content:
+            spec_content = run.spec_content
+            logger.info(
+                "Resuming run %s past Phase 1 (spec already generated, %d chars)",
+                run_id,
+                len(spec_content),
+            )
+            store.add_chat_message(
+                run_id,
+                "system",
+                "Resuming with existing spec.",
+                "status_update",
+            )
+        else:
+            store.update_run(run_id, status="generating_spec")
+            _sync_job_status(run_id, "running", phase="generating_spec")
+            store.add_chat_message(
+                run_id, "system", "Generating product specification...", "status_update"
+            )
+            spec_content = _generate_spec_with_heartbeat(agent, run_id)
+            store.update_run(run_id, spec_content=spec_content)
+            logger.info("Spec generated for run %s (%d chars)", run_id, len(spec_content))
+            store.add_chat_message(
+                run_id,
+                "assistant",
+                f"Product spec generated ({len(spec_content)} chars). Submitting to SE team for analysis.",
+                "status_update",
+            )
 
         with httpx.Client() as client:
-            # Phase 2: Product analysis
-            repo_path = _run_product_analysis(client, agent, store, run_id, spec_content)
-            if repo_path is None:
-                return  # status already set to failed
+            # Phase 2: Product analysis (skip entirely if repo_path stored;
+            # skip submit only if analysis_job_id stored without repo_path)
+            if run is not None and run.repo_path:
+                repo_path: str | None = run.repo_path
+                logger.info(
+                    "Resuming run %s past Phase 2 (analysis already complete, repo_path=%s)",
+                    run_id,
+                    repo_path,
+                )
+                store.add_chat_message(
+                    run_id,
+                    "system",
+                    "Resuming with existing analysis output.",
+                    "status_update",
+                )
+            else:
+                repo_path = _run_product_analysis(
+                    client,
+                    agent,
+                    store,
+                    run_id,
+                    spec_content,
+                    existing_job_id=run.analysis_job_id if run is not None else None,
+                )
+                if repo_path is None:
+                    return  # status already set to failed
 
-            # Phase 3: SE team build
-            success = _run_se_team(client, agent, store, run_id, repo_path)
+            # Phase 3: SE team build (skip submit if se_job_id stored)
+            success = _run_se_team(
+                client,
+                agent,
+                store,
+                run_id,
+                repo_path,
+                existing_job_id=run.se_job_id if run is not None else None,
+            )
             if success:
                 store.update_run(run_id, status="completed")
                 _sync_job_status(run_id, "completed", phase="completed")
@@ -416,4 +539,6 @@ def run_workflow(run_id: str, store: FounderRunStore, agent: FounderAgent) -> No
         logger.exception("Founder workflow crashed: run_id=%s", run_id)
         store.update_run(run_id, status="failed", error=str(exc)[:1000])
         _sync_job_status(run_id, "failed", error=str(exc)[:500])
-        store.add_chat_message(run_id, "system", f"Workflow failed: {str(exc)[:500]}", "status_update")
+        store.add_chat_message(
+            run_id, "system", f"Workflow failed: {str(exc)[:500]}", "status_update"
+        )

--- a/backend/agents/user_agent_founder/orchestrator.py
+++ b/backend/agents/user_agent_founder/orchestrator.py
@@ -460,9 +460,12 @@ def run_workflow(run_id: str, store: FounderRunStore, agent: FounderAgent) -> No
     """
     logger.info("Starting founder workflow: run_id=%s", run_id)
 
-    run = store.get_run(run_id)
-
     try:
+        # Read the run row inside the try so a transient store outage during
+        # the resume-short-circuit lookup gets caught by the failure handler
+        # below rather than escaping the worker thread silently.
+        run = store.get_run(run_id)
+
         # Phase 1: Generate the product spec (skip if already done)
         if run is not None and run.spec_content:
             spec_content = run.spec_content

--- a/backend/agents/user_agent_founder/tests/test_jobs_endpoints.py
+++ b/backend/agents/user_agent_founder/tests/test_jobs_endpoints.py
@@ -219,7 +219,9 @@ def test_resume_mirrors_dispatch_failure_into_founder_store(
 
     fake_job_store.create_job("run-bad", status="failed", error="boom")
     monkeypatch.setattr(
-        api_main, "_dispatch_founder_run", lambda _run_id: (_ for _ in ()).throw(RuntimeError("no worker"))
+        api_main,
+        "_dispatch_founder_run",
+        lambda _run_id: (_ for _ in ()).throw(RuntimeError("no worker")),
     )
 
     with pytest.raises(HTTPException) as excinfo:
@@ -262,6 +264,26 @@ def test_restart_resets_and_redispatches_completed_job(fake_job_store, fake_stor
     assert fake_job_store.jobs["run-done"]["status"] == "running"
 
 
+def test_restart_clears_founder_store_checkpoint_columns(fake_job_store, fake_store, fake_dispatch):
+    """Restart must NULL every column the resume short-circuit reads, otherwise
+    a restarted run skips spec/analysis or polls a stale SE job id (#347)."""
+    from user_agent_founder.api.main import restart_job
+
+    fake_job_store.create_job("run-done", status="completed", error=None)
+
+    restart_job("run-done")
+
+    fake_store.update_run.assert_any_call(
+        "run-done",
+        status="pending",
+        error=None,
+        spec_content=None,
+        analysis_job_id=None,
+        repo_path=None,
+        se_job_id=None,
+    )
+
+
 def test_restart_mirrors_dispatch_failure_into_founder_store(
     fake_job_store, fake_store, monkeypatch
 ):
@@ -271,7 +293,9 @@ def test_restart_mirrors_dispatch_failure_into_founder_store(
 
     fake_job_store.create_job("run-done", status="completed", error=None)
     monkeypatch.setattr(
-        api_main, "_dispatch_founder_run", lambda _run_id: (_ for _ in ()).throw(RuntimeError("no worker"))
+        api_main,
+        "_dispatch_founder_run",
+        lambda _run_id: (_ for _ in ()).throw(RuntimeError("no worker")),
     )
 
     with pytest.raises(HTTPException) as excinfo:

--- a/backend/agents/user_agent_founder/tests/test_orchestrator_resume.py
+++ b/backend/agents/user_agent_founder/tests/test_orchestrator_resume.py
@@ -1,0 +1,367 @@
+"""Tests for the resume-short-circuit logic in ``run_workflow`` (#347).
+
+PR #310 added ``POST /api/persona-testing/job/{id}/resume`` which simply
+re-dispatches the workflow. Without these tests, ``run_workflow`` would
+re-run every phase from the start regardless of which checkpoint columns
+(``spec_content``, ``analysis_job_id``, ``repo_path``, ``se_job_id``) are
+already populated on the run row — wasting an LLM spec call and a
+multi-hour analysis poll on every resume.
+
+Each test stubs the network (``httpx.Client``) and the founder store so
+we can assert which orchestrator branches fire.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeRun:
+    run_id: str
+    status: str = "running"
+    se_job_id: str | None = None
+    analysis_job_id: str | None = None
+    spec_content: str | None = None
+    repo_path: str | None = None
+    created_at: str = "2026-04-25T00:00:00+00:00"
+    updated_at: str = "2026-04-25T00:00:00+00:00"
+    error: str | None = None
+
+
+class FakeFounderStore:
+    """In-memory stand-in for ``FounderRunStore``.
+
+    Only implements the surface ``run_workflow`` actually calls.
+    """
+
+    def __init__(self, run: _FakeRun) -> None:
+        self._run = run
+        self.update_calls: list[dict[str, Any]] = []
+        self.chat_messages: list[dict[str, Any]] = []
+        self.decisions: list[dict[str, Any]] = []
+
+    def get_run(self, run_id: str) -> _FakeRun | None:
+        return self._run if self._run.run_id == run_id else None
+
+    def update_run(self, run_id: str, **fields: Any) -> bool:
+        self.update_calls.append({"run_id": run_id, **fields})
+        for k, v in fields.items():
+            setattr(self._run, k, v)
+        return True
+
+    def add_chat_message(
+        self,
+        run_id: str,
+        role: str,
+        content: str,
+        message_type: str = "",
+        *,
+        metadata: Any = None,
+    ) -> None:
+        self.chat_messages.append(
+            {"run_id": run_id, "role": role, "content": content, "type": message_type}
+        )
+
+    def add_decision(self, **fields: Any) -> None:
+        self.decisions.append(fields)
+
+
+class _FakeResponse:
+    def __init__(
+        self, status_code: int = 200, json_data: dict | None = None, text: str = ""
+    ) -> None:
+        self.status_code = status_code
+        self._json = json_data or {}
+        self.text = text
+
+    def json(self) -> dict:
+        return self._json
+
+
+class FakeHttpxClient:
+    """Records every POST/GET; returns scripted responses keyed by URL substring."""
+
+    def __init__(
+        self,
+        post_responses: dict[str, _FakeResponse] | None = None,
+        get_responses: dict[str, list[_FakeResponse]] | None = None,
+    ) -> None:
+        self.post_responses = post_responses or {}
+        # GET responses keyed by URL substring -> list of sequential responses
+        self.get_responses = get_responses or {}
+        self._get_indices: dict[str, int] = {}
+        self.posts: list[dict[str, Any]] = []
+        self.gets: list[dict[str, Any]] = []
+
+    def __enter__(self) -> "FakeHttpxClient":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        return None
+
+    def post(self, url: str, *, json: dict | None = None, timeout: Any = None) -> _FakeResponse:
+        self.posts.append({"url": url, "json": json})
+        for needle, resp in self.post_responses.items():
+            if needle in url:
+                return resp
+        return _FakeResponse(200, {"job_id": "default-job"})
+
+    def get(self, url: str, *, timeout: Any = None) -> _FakeResponse:
+        self.gets.append({"url": url})
+        for needle, queue in self.get_responses.items():
+            if needle in url:
+                idx = self._get_indices.get(needle, 0)
+                if idx >= len(queue):
+                    return queue[-1]
+                self._get_indices[needle] = idx + 1
+                return queue[idx]
+        return _FakeResponse(200, {"status": "completed"})
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def stub_orchestrator_io(monkeypatch):
+    """Neutralise sleeps + side-effecting helpers; isolate orchestrator under test."""
+    from user_agent_founder import orchestrator
+
+    monkeypatch.setattr(orchestrator.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(orchestrator, "ANALYSIS_POLL_INTERVAL", 0)
+    monkeypatch.setattr(orchestrator, "EXECUTION_POLL_INTERVAL", 0)
+    monkeypatch.setattr(orchestrator, "SPEC_HEARTBEAT_INTERVAL", 0.01)
+    monkeypatch.setattr(orchestrator, "_sync_job_status", lambda *a, **kw: None)
+    monkeypatch.setattr(orchestrator, "_heartbeat", lambda _rid: None)
+    return orchestrator
+
+
+def _install_httpx(monkeypatch, orchestrator, fake_client: FakeHttpxClient) -> None:
+    monkeypatch.setattr(orchestrator.httpx, "Client", lambda *a, **kw: fake_client)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_run_runs_all_phases(stub_orchestrator_io, monkeypatch):
+    """Regression: empty checkpoints -> spec gen + analysis submit + build submit all fire."""
+    orchestrator = stub_orchestrator_io
+    run = _FakeRun(run_id="run-fresh")
+    store = FakeFounderStore(run)
+    agent = MagicMock()
+    agent.generate_spec.return_value = "# Generated spec body"
+
+    fake = FakeHttpxClient(
+        post_responses={
+            "/product-analysis/start-from-spec": _FakeResponse(200, {"job_id": "analysis-1"}),
+            "/run-team": _FakeResponse(200, {"job_id": "se-1"}),
+        },
+        get_responses={
+            "/product-analysis/status/": [
+                _FakeResponse(200, {"status": "completed", "repo_path": "/repos/run-fresh"}),
+            ],
+            "/run-team/": [
+                _FakeResponse(200, {"status": "completed"}),
+            ],
+        },
+    )
+    _install_httpx(monkeypatch, orchestrator, fake)
+
+    orchestrator.run_workflow("run-fresh", store, agent)
+
+    assert agent.generate_spec.call_count == 1
+    assert any("/product-analysis/start-from-spec" in p["url"] for p in fake.posts)
+    assert any(
+        "/run-team" in p["url"] and "json" in p and p["json"] == {"repo_path": "/repos/run-fresh"}
+        for p in fake.posts
+    )
+    assert run.status == "completed"
+
+
+def test_resume_skips_phase1_when_spec_content_present(stub_orchestrator_io, monkeypatch):
+    """spec_content set but nothing else -> no LLM call; analysis POST fires."""
+    orchestrator = stub_orchestrator_io
+    run = _FakeRun(run_id="run-1", spec_content="# pre-existing spec")
+    store = FakeFounderStore(run)
+    agent = MagicMock()
+
+    fake = FakeHttpxClient(
+        post_responses={
+            "/product-analysis/start-from-spec": _FakeResponse(200, {"job_id": "analysis-1"}),
+            "/run-team": _FakeResponse(200, {"job_id": "se-1"}),
+        },
+        get_responses={
+            "/product-analysis/status/": [
+                _FakeResponse(200, {"status": "completed", "repo_path": "/repos/run-1"}),
+            ],
+            "/run-team/": [
+                _FakeResponse(200, {"status": "completed"}),
+            ],
+        },
+    )
+    _install_httpx(monkeypatch, orchestrator, fake)
+
+    orchestrator.run_workflow("run-1", store, agent)
+
+    agent.generate_spec.assert_not_called()
+    assert any("/product-analysis/start-from-spec" in p["url"] for p in fake.posts)
+    assert run.status == "completed"
+
+
+def test_resume_skips_phase2_submit_when_analysis_job_id_present(stub_orchestrator_io, monkeypatch):
+    """analysis_job_id set, repo_path empty -> no /start-from-spec POST; poll uses existing id."""
+    orchestrator = stub_orchestrator_io
+    run = _FakeRun(
+        run_id="run-2",
+        spec_content="# spec",
+        analysis_job_id="prior-analysis-42",
+    )
+    store = FakeFounderStore(run)
+    agent = MagicMock()
+
+    fake = FakeHttpxClient(
+        post_responses={
+            "/run-team": _FakeResponse(200, {"job_id": "se-1"}),
+        },
+        get_responses={
+            "/product-analysis/status/": [
+                _FakeResponse(200, {"status": "completed", "repo_path": "/repos/run-2"}),
+            ],
+            "/run-team/": [
+                _FakeResponse(200, {"status": "completed"}),
+            ],
+        },
+    )
+    _install_httpx(monkeypatch, orchestrator, fake)
+
+    orchestrator.run_workflow("run-2", store, agent)
+
+    agent.generate_spec.assert_not_called()
+    assert not any("/product-analysis/start-from-spec" in p["url"] for p in fake.posts), (
+        "Expected no analysis submit POST on resume with analysis_job_id set"
+    )
+    # First analysis GET hits the existing id (not a fresh one).
+    analysis_gets = [g for g in fake.gets if "/product-analysis/status/" in g["url"]]
+    assert analysis_gets, "Expected at least one analysis status GET"
+    assert "prior-analysis-42" in analysis_gets[0]["url"]
+
+
+def test_resume_skips_phase2_entirely_when_repo_path_present(stub_orchestrator_io, monkeypatch):
+    """spec_content + repo_path set -> _run_product_analysis is not invoked; SE submit fires."""
+    orchestrator = stub_orchestrator_io
+    run = _FakeRun(
+        run_id="run-3",
+        spec_content="# spec",
+        analysis_job_id="prior-analysis",
+        repo_path="/repos/run-3",
+    )
+    store = FakeFounderStore(run)
+    agent = MagicMock()
+
+    fake = FakeHttpxClient(
+        post_responses={
+            "/run-team": _FakeResponse(200, {"job_id": "se-1"}),
+        },
+        get_responses={
+            "/run-team/": [
+                _FakeResponse(200, {"status": "completed"}),
+            ],
+        },
+    )
+    _install_httpx(monkeypatch, orchestrator, fake)
+
+    orchestrator.run_workflow("run-3", store, agent)
+
+    agent.generate_spec.assert_not_called()
+    assert not any("/product-analysis" in g["url"] for g in fake.gets), (
+        "Expected no analysis status polls when repo_path already set"
+    )
+    assert not any("/product-analysis" in p["url"] for p in fake.posts)
+    se_posts = [p for p in fake.posts if "/run-team" in p["url"]]
+    assert se_posts and se_posts[0]["json"] == {"repo_path": "/repos/run-3"}
+
+
+def test_resume_skips_phase3_submit_when_se_job_id_present(stub_orchestrator_io, monkeypatch):
+    """All checkpoints set incl. se_job_id -> no /run-team POST; poll uses existing id."""
+    orchestrator = stub_orchestrator_io
+    run = _FakeRun(
+        run_id="run-4",
+        spec_content="# spec",
+        analysis_job_id="prior-analysis",
+        repo_path="/repos/run-4",
+        se_job_id="prior-se-99",
+    )
+    store = FakeFounderStore(run)
+    agent = MagicMock()
+
+    fake = FakeHttpxClient(
+        get_responses={
+            "/run-team/": [
+                _FakeResponse(200, {"status": "completed"}),
+            ],
+        },
+    )
+    _install_httpx(monkeypatch, orchestrator, fake)
+
+    orchestrator.run_workflow("run-4", store, agent)
+
+    assert not any("/run-team" in p["url"] for p in fake.posts), (
+        "Expected no SE-team submit POST on resume with se_job_id set"
+    )
+    se_gets = [g for g in fake.gets if "/run-team/" in g["url"]]
+    assert se_gets, "Expected at least one SE-team status GET"
+    assert "prior-se-99" in se_gets[0]["url"]
+    assert run.status == "completed"
+
+
+def test_resume_with_existing_analysis_job_succeeds_to_completion(
+    stub_orchestrator_io, monkeypatch
+):
+    """Happy path: resume mid-Phase-2; analysis returns completed; Phase 3 then runs."""
+    orchestrator = stub_orchestrator_io
+    run = _FakeRun(
+        run_id="run-5",
+        spec_content="# spec",
+        analysis_job_id="prior-analysis-77",
+    )
+    store = FakeFounderStore(run)
+    agent = MagicMock()
+
+    fake = FakeHttpxClient(
+        post_responses={
+            "/run-team": _FakeResponse(200, {"job_id": "se-new"}),
+        },
+        get_responses={
+            "/product-analysis/status/": [
+                _FakeResponse(200, {"status": "running"}),
+                _FakeResponse(200, {"status": "completed", "repo_path": "/repos/run-5"}),
+            ],
+            "/run-team/": [
+                _FakeResponse(200, {"status": "completed"}),
+            ],
+        },
+    )
+    _install_httpx(monkeypatch, orchestrator, fake)
+
+    orchestrator.run_workflow("run-5", store, agent)
+
+    agent.generate_spec.assert_not_called()
+    se_posts = [p for p in fake.posts if "/run-team" in p["url"]]
+    assert se_posts and se_posts[0]["json"] == {"repo_path": "/repos/run-5"}
+    assert run.status == "completed"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/backend/agents/user_agent_founder/tests/test_orchestrator_resume.py
+++ b/backend/agents/user_agent_founder/tests/test_orchestrator_resume.py
@@ -363,5 +363,31 @@ def test_resume_with_existing_analysis_job_succeeds_to_completion(
     assert run.status == "completed"
 
 
+def test_get_run_failure_is_caught_and_reported_as_failed(stub_orchestrator_io):
+    """A transient store outage at the entry-time lookup must not escape the
+    worker thread silently; the failure handler must mirror status to the
+    founder store + job service so the UI doesn't see the run stuck."""
+    orchestrator = stub_orchestrator_io
+    store = MagicMock()
+    store.get_run.side_effect = RuntimeError("postgres outage")
+    agent = MagicMock()
+
+    # Must not raise — exceptions in the worker thread are handled internally.
+    orchestrator.run_workflow("run-boom", store, agent)
+
+    # Failure path was hit: status flipped to "failed" + a chat message added.
+    failed_calls = [
+        c
+        for c in store.update_run.call_args_list
+        if c.kwargs.get("status") == "failed" and "postgres outage" in (c.kwargs.get("error") or "")
+    ]
+    assert failed_calls, (
+        f"Expected update_run(..., status='failed', error=...) on get_run failure; "
+        f"got {store.update_run.call_args_list}"
+    )
+    failure_msgs = [c for c in store.add_chat_message.call_args_list if "postgres outage" in str(c)]
+    assert failure_msgs, "Expected a system chat message reporting the failure"
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #347.

## Problem

`POST /api/persona-testing/job/{id}/resume` (added in #310) re-dispatches `run_workflow` from the very beginning. For a `failed` run that died in Phase 3 (SE-team build), this re-runs spec generation (LLM call) and product analysis (~4h poll loop) even though `spec_content`, `analysis_job_id`, and `repo_path` are already on the `user_agent_founder_runs` row.

## Change

`run_workflow` now reads the run row at entry and skips phases whose checkpoint columns are populated:

| `spec_content` | `analysis_job_id` | `repo_path` | `se_job_id` | What happens on resume |
|---|---|---|---|---|
| ∅ | ∅ | ∅ | ∅ | All three phases run (regression baseline) |
| ✓ | ∅ | ∅ | ∅ | Skip Phase 1; submit + poll Phase 2; submit + poll Phase 3 |
| ✓ | ✓ | ∅ | ∅ | Skip Phase 1; **poll only** Phase 2 against existing analysis job; submit + poll Phase 3 |
| ✓ | ✓ | ✓ | ∅ | Skip Phases 1 & 2; submit + poll Phase 3 |
| ✓ | ✓ | ✓ | ✓ | Skip Phases 1 & 2; **poll only** Phase 3 against existing SE job |

Achieved by:

- Adding an `existing_job_id` kwarg to `_run_product_analysis` and `_run_se_team` (`backend/agents/user_agent_founder/orchestrator.py`). When supplied, each function bypasses its submit block and enters the poll loop with the existing job id.
- Wrapping `run_workflow`'s phase calls in `if run.<checkpoint>: skip` guards using the existing `FounderRunStore.get_run` API.

No schema, API, or UI changes — `POST /job/{id}/resume` already triggers re-dispatch; the orchestrator just gets smarter about what to skip.

## Tests

New `backend/agents/user_agent_founder/tests/test_orchestrator_resume.py` (6 cases) using a stubbed `httpx.Client` and an in-memory `FakeFounderStore` to assert which network calls fire on each resume scenario.

```
$ .venv/bin/python -m pytest agents/user_agent_founder/tests/
============================== 60 passed in 3.68s ==============================
```

Lint clean on the two modified files.

## Test plan

- [x] `pytest agents/user_agent_founder/tests/test_orchestrator_resume.py` — 6 passed
- [x] `pytest agents/user_agent_founder/tests/` — 60 passed (no regressions)
- [x] `ruff check` + `ruff format --check` clean on modified files
- [ ] Manual smoke (Postgres up, no Temporal):
  1. Start a Testing Personas run; let it pass Phase 1 + Phase 2; kill the API mid-Phase-3 polling.
  2. Restart the API; click Resume on the row.
  3. Confirm logs show `Resuming run … past Phase 2 (analysis already complete)` and the next request is a `GET /api/software-engineering/run-team/{se_job_id}` against the same SE job, not a `POST /run-team`.

## Out of scope

- Pause (closed in #319 as `not_planned`).
- Mid-phase resume tokens — only phase boundaries are short-circuited.
- Backfilling resume short-circuit to blogging / investment / other teams.

https://claude.ai/code/session_01We7BdQCkJFHxZPfBVaRZSA

---
_Generated by [Claude Code](https://claude.ai/code/session_01We7BdQCkJFHxZPfBVaRZSA)_