### PR TITLE
SPEC-007 W1: guardrail/ scaffolding (#333)

### DIFF
--- a/backend/agents/nutrition_meal_planning_team/guardrail/__init__.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/__init__.py
@@ -1,0 +1,41 @@
+"""SPEC-007 guardrail pipeline — Phase 0 scaffolding.
+
+W1 ships only the public surface area. ``check_recommendation`` is a
+stub that raises ``NotImplementedError`` until W2 lands ``checker.py``.
+
+Behaviour is gated by the ``NUTRITION_GUARDRAIL`` env var (off by
+default), mirroring the SPEC-006 ``NUTRITION_RESTRICTION_RESOLVER``
+pattern.
+"""
+
+from __future__ import annotations
+
+import os
+
+from .errors import GuardrailError, GuardrailNotImplementedError
+from .version import GUARDRAIL_VERSION
+from .violations import GuardrailResult, Severity, Violation, ViolationReason
+
+_FLAG = "NUTRITION_GUARDRAIL"
+
+
+def is_guardrail_enabled() -> bool:
+    """Read at every call site so env can flip without restart."""
+    return os.environ.get(_FLAG, "0") == "1"
+
+
+def check_recommendation(profile, rec):
+    """SPEC-007 entrypoint. Stub until W2 implements ``checker.py``."""
+    raise GuardrailNotImplementedError("check_recommendation is implemented in SPEC-007 W2")
+
+
+__all__ = [
+    "GUARDRAIL_VERSION",
+    "GuardrailError",
+    "GuardrailResult",
+    "Severity",
+    "Violation",
+    "ViolationReason",
+    "check_recommendation",
+    "is_guardrail_enabled",
+]

--- a/backend/agents/nutrition_meal_planning_team/guardrail/errors.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/errors.py
@@ -1,0 +1,11 @@
+"""Error types for the SPEC-007 guardrail pipeline."""
+
+from __future__ import annotations
+
+
+class GuardrailError(Exception):
+    """Base for guardrail failures."""
+
+
+class GuardrailNotImplementedError(GuardrailError, NotImplementedError):
+    """W1 scaffolding stub — replaced by W2 ``checker.check_recommendation``."""

--- a/backend/agents/nutrition_meal_planning_team/guardrail/tests/__init__.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/tests/__init__.py
@@ -1,0 +1,1 @@
+"""SPEC-007 guardrail tests."""

--- a/backend/agents/nutrition_meal_planning_team/guardrail/tests/test_smoke_import.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/tests/test_smoke_import.py
@@ -1,0 +1,87 @@
+"""SPEC-007 W1 smoke test — exercise every acceptance criterion.
+
+Pure-Python; no fixtures, no Postgres, no LLM.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+
+def test_public_surface_imports() -> None:
+    from agents.nutrition_meal_planning_team.guardrail import (  # noqa: F401
+        GUARDRAIL_VERSION,
+        GuardrailResult,
+        Severity,
+        Violation,
+        ViolationReason,
+        check_recommendation,
+        is_guardrail_enabled,
+    )
+
+
+def test_guardrail_version() -> None:
+    from agents.nutrition_meal_planning_team.guardrail import GUARDRAIL_VERSION
+
+    assert GUARDRAIL_VERSION == "1.0.0"
+
+
+def test_check_recommendation_is_stub() -> None:
+    from agents.nutrition_meal_planning_team.guardrail import check_recommendation
+
+    with pytest.raises(NotImplementedError):
+        check_recommendation(None, None)
+
+
+def test_violation_is_frozen() -> None:
+    from agents.nutrition_meal_planning_team.guardrail import (
+        Severity,
+        Violation,
+        ViolationReason,
+    )
+
+    v = Violation(
+        reason=ViolationReason.allergen,
+        ingredient_raw="peanut butter",
+        canonical_id=None,
+        tag="peanut",
+        detail="contains peanut",
+        severity=Severity.hard_reject,
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        v.detail = "mutated"  # type: ignore[misc]
+
+
+def test_guardrail_result_is_frozen() -> None:
+    from agents.nutrition_meal_planning_team.guardrail import GuardrailResult
+
+    r = GuardrailResult(
+        passed=True,
+        violations=(),
+        flags=(),
+        parsed_ingredients=(),
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        r.passed = False  # type: ignore[misc]
+
+
+def test_violation_reason_is_str_enum() -> None:
+    from agents.nutrition_meal_planning_team.guardrail import ViolationReason
+
+    assert ViolationReason.allergen.value == "allergen"
+    assert isinstance(ViolationReason.allergen, str)
+
+
+def test_feature_flag_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agents.nutrition_meal_planning_team.guardrail import is_guardrail_enabled
+
+    monkeypatch.delenv("NUTRITION_GUARDRAIL", raising=False)
+    assert is_guardrail_enabled() is False
+
+    monkeypatch.setenv("NUTRITION_GUARDRAIL", "1")
+    assert is_guardrail_enabled() is True
+
+    monkeypatch.setenv("NUTRITION_GUARDRAIL", "0")
+    assert is_guardrail_enabled() is False

--- a/backend/agents/nutrition_meal_planning_team/guardrail/version.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/version.py
@@ -1,0 +1,8 @@
+"""SPEC-007 guardrail version.
+
+Bumping invalidates cached guardrail decisions and triggers replay (W12).
+"""
+
+from __future__ import annotations
+
+GUARDRAIL_VERSION = "1.0.0"

--- a/backend/agents/nutrition_meal_planning_team/guardrail/violations.py
+++ b/backend/agents/nutrition_meal_planning_team/guardrail/violations.py
@@ -1,0 +1,62 @@
+"""SPEC-007 §4.3 public types — violation reasons, severity, and result.
+
+Pure data. No I/O, no LLM. Frozen dataclasses so a ``GuardrailResult``
+is safe to hash, log, and replay deterministically.
+
+The spec calls ``ViolationReason`` a ``StrEnum``; on Python 3.10 we use
+the team's ``(str, Enum)`` idiom (see ``ingredient_kb.taxonomy``), which
+is ``isinstance`` of ``str`` and behaves identically for our needs.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from ..ingredient_kb.types import ParsedIngredient
+
+
+class Severity(str, Enum):
+    """Whether a violation blocks the recommendation or just decorates it."""
+
+    hard_reject = "hard_reject"
+    flag = "flag"
+
+
+class ViolationReason(str, Enum):
+    """Why the guardrail rejected or flagged a recommendation."""
+
+    allergen = "allergen"
+    dietary_forbid = "dietary_forbid"
+    unresolved_ingredient = "unresolved_ingredient"
+    interaction_hard = "interaction_hard"
+    interaction_flag = "interaction_flag"
+
+
+@dataclass(frozen=True)
+class Violation:
+    """One reason a recommendation failed (or was flagged by) the guardrail."""
+
+    reason: ViolationReason
+    ingredient_raw: str
+    canonical_id: Optional[str]
+    tag: Optional[str]
+    detail: str
+    severity: Severity
+
+
+@dataclass(frozen=True)
+class GuardrailResult:
+    """Outcome of ``check_recommendation``.
+
+    ``violations`` are ``hard_reject`` entries that block the rec;
+    ``flags`` are non-blocking ``flag`` entries surfaced in the UI.
+    ``parsed_ingredients`` is reused by ADR-003 callers.
+    """
+
+    passed: bool
+    violations: tuple[Violation, ...]
+    flags: tuple[Violation, ...]
+    parsed_ingredients: tuple[ParsedIngredient, ...]


### PR DESCRIPTION
Closes #333. Phase 0 foundation for [SPEC-007](../blob/main/system_design/specs/SPEC-007-nutrition-guardrail-pipeline.md) — the deterministic, pure-Python meal-recommendation guardrail. Lands the public surface area so W2–W14 can build on it incrementally.

## Summary

- New package `backend/agents/nutrition_meal_planning_team/guardrail/`:
  - `version.py` — `GUARDRAIL_VERSION = "1.0.0"`.
  - `violations.py` — frozen dataclasses `Violation` and `GuardrailResult`; `ViolationReason` and `Severity` enums.
  - `errors.py` — `GuardrailError` base + `GuardrailNotImplementedError`.
  - `__init__.py` — re-exports the public types, defines `is_guardrail_enabled()` (env var `NUTRITION_GUARDRAIL`, off by default), and provides a `check_recommendation` stub that raises `NotImplementedError` until W2 lands `checker.py`.
  - `tests/test_smoke_import.py` — covers all four W1 acceptance criteria.

## Notable design choices

- **`(str, Enum)` instead of `StrEnum`.** The issue text says "`ViolationReason` is a `StrEnum`," but the repo targets Python 3.10 (`backend/pyproject.toml:2`, `target-version = "py310"`) and `enum.StrEnum` is 3.11+. Used the established team idiom from `ingredient_kb/taxonomy.py` (`AllergenTag(str, Enum)`); the smoke test asserts `isinstance(ViolationReason.allergen, str)` to nail down the contract.
- **`ParsedIngredient` imported under `TYPE_CHECKING`.** Keeps the guardrail package independent of `ingredient_kb/__init__.py`'s yaml-loading side effects. With `from __future__ import annotations` the dataclass field annotation works fine as a forward reference.
- **Feature flag mirrors SPEC-006.** `is_guardrail_enabled()` follows the exact pattern from `agents/intake_profile_agent/restriction_hook.py` (read at every call site so the env can flip without restarting the process).

## Files NOT touched

`checker.py`, `interactions.py`, `regeneration.py`, `data/interactions.yaml` are listed in spec §4.2 but belong to W2/W3/W4/W5 — not pre-created here.

## Test plan

- [x] `ruff check` and `ruff format --check` pass on the new package.
- [x] `pytest agents/nutrition_meal_planning_team/guardrail/tests/test_smoke_import.py -v` — 7/7 pass.
- [x] Manual: `from agents.nutrition_meal_planning_team.guardrail import check_recommendation, GUARDRAIL_VERSION` succeeds; `GUARDRAIL_VERSION == "1.0.0"`; calling the stub raises `NotImplementedError`.
- [x] Manual: `is_guardrail_enabled()` is `False` by default and `True` when `NUTRITION_GUARDRAIL=1`.

Marked draft because W2 (#334) will replace the `check_recommendation` stub with the real checker; rest of the W1 surface area is final.

https://claude.ai/code/session_01P2KwzWJb9F2equbmtpzrev

---
_Generated by [Claude Code](https://claude.ai/code/session_01P2KwzWJb9F2equbmtpzrev)_