### PR TITLE
investment_team: wire walk-forward + AcceptanceGate into Strategy Lab orchestrator (#247)

### DIFF
--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -12,10 +12,25 @@ Pipeline:
 from __future__ import annotations
 
 import logging
+import os
 import uuid
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
+from ..execution.benchmarks import benchmark_for_strategy, build_60_40_equity
+from ..execution.metrics import (
+    bootstrap_sharpe_ci,
+    build_equity_curve_from_trades,
+    compute_deflated_sharpe,
+    summarize_return_moments,
+)
+from ..execution.regimes import regime_comparison, vix_quartile_subwindows
+from ..execution.walk_forward import (
+    build_purged_walk_forward,
+    filter_trades_in_fold_training,
+    filter_trades_in_range,
+    max_hold_days_from_trades,
+)
 from ..market_data_service import MarketDataService, OHLCVBar
 from ..models import (
     BacktestConfig,
@@ -33,6 +48,7 @@ from .agents.alignment import TradeAlignmentAgent, TradeAlignmentReport
 from .agents.analysis import AnalysisAgent
 from .agents.ideation import IdeationAgent
 from .agents.refinement import RefinementAgent
+from .quality_gates.acceptance_gate import AcceptanceGate, summarize_acceptance_reason
 from .quality_gates.backtest_anomaly import BacktestAnomalyDetector
 from .quality_gates.code_safety import CodeSafetyChecker
 from .quality_gates.convergence_tracker import ConvergenceTracker
@@ -50,6 +66,10 @@ MAX_CODE_REFINEMENT_ROUNDS = 50
 # through the sandbox for a fresh backtest. The cap prevents runaway loops
 # when the agent cannot converge.
 MAX_ALIGNMENT_ROUNDS = 10
+# Legacy single-window acceptance threshold. Issue #247 replaced this with
+# the composite ``AcceptanceGate`` (OOS DSR + IS→OOS degradation + OOS trade
+# count + regime beats); ``WINNING_THRESHOLD`` is now only consulted as a
+# fallback when ``BacktestConfig.walk_forward_enabled`` is False.
 WINNING_THRESHOLD = 8.0
 
 
@@ -69,6 +89,7 @@ class StrategyLabOrchestrator:
         self.strategy_validator = StrategySpecValidator()
         self.code_safety_checker = CodeSafetyChecker()
         self.anomaly_detector = BacktestAnomalyDetector()
+        self.acceptance_gate = AcceptanceGate()
         self.convergence_tracker = convergence_tracker or ConvergenceTracker()
         self.market_data_service = MarketDataService()
 
@@ -328,7 +349,9 @@ class StrategyLabOrchestrator:
                 trades, config.initial_capital, config.start_date, config.end_date
             )
 
-            anomaly_gates = self.anomaly_detector.check(metrics, trades)
+            anomaly_gates = self.anomaly_detector.check(
+                metrics, trades, dsr_aware=config.walk_forward_enabled
+            )
             for g in anomaly_gates:
                 g.refinement_round = round_num
             all_gate_results.extend(anomaly_gates)
@@ -574,7 +597,9 @@ class StrategyLabOrchestrator:
                 # fix could introduce zero-trade or implausible-return
                 # output that bypasses quality gates and still flows into
                 # analysis and the win/loss classification.
-                anomaly_gates = self.anomaly_detector.check(new_metrics, new_trades)
+                anomaly_gates = self.anomaly_detector.check(
+                    new_metrics, new_trades, dsr_aware=config.walk_forward_enabled
+                )
                 for g in anomaly_gates:
                     g.refinement_round = align_round
                     g.gate_name = f"alignment_{g.gate_name}"
@@ -617,6 +642,72 @@ class StrategyLabOrchestrator:
         alignment_rounds = len(alignment_attempts)
         trades_aligned = bool(alignment_reports and alignment_reports[-1].aligned)
 
+        # ── Phase 2.6: TRIAL COUNTING (issue #247) ────────────────────
+        # Every refinement round on the same window contributes to the
+        # multiple-testing burden the Deflated Sharpe Ratio corrects for.
+        # Increment by ``len(refinement_attempts) + 1`` so the first
+        # round (which has no recorded "attempt") still counts.
+        self.convergence_tracker.increment_trials(max(1, len(refinement_attempts) + 1))
+
+        # ── Phase 2.7: WALK-FORWARD + ACCEPTANCE GATE (issue #247) ────
+        # Replaces the legacy ``WINNING_THRESHOLD`` annualized-return scalar
+        # with a composite OOS gate evaluated on purged, embargoed K-fold
+        # walk-forward diagnostics. Skipped when walk-forward is disabled
+        # (legacy fallback) or there is no successful execution to evaluate.
+        acceptance_results: List[QualityGateResult] = []
+        acceptance_reason: Optional[str] = None
+        if (
+            execution_succeeded
+            and trades
+            and market_data is not None
+            and config.walk_forward_enabled
+        ):
+            try:
+                emit("backtesting", {"sub_phase": "walk_forward_started"})
+                metrics = self._evaluate_walk_forward(spec, market_data, config, trades, metrics)
+                acceptance_results = self.acceptance_gate.check(
+                    metrics,
+                    config,
+                    n_trials=self.convergence_tracker.trial_count,
+                )
+                all_gate_results.extend(acceptance_results)
+                acceptance_reason = summarize_acceptance_reason(acceptance_results)
+                metrics = metrics.model_copy(
+                    update={
+                        "n_trials_when_accepted": self.convergence_tracker.trial_count,
+                        "acceptance_reason": acceptance_reason,
+                    }
+                )
+                emit(
+                    "backtesting",
+                    {
+                        "sub_phase": "walk_forward_completed",
+                        "deflated_sharpe": metrics.deflated_sharpe,
+                        "oos_sharpe": metrics.oos_sharpe,
+                        "is_oos_degradation_pct": metrics.is_oos_degradation_pct,
+                        "oos_trade_count": metrics.oos_trade_count,
+                        "n_trials": self.convergence_tracker.trial_count,
+                        "acceptance_reason": acceptance_reason,
+                    },
+                )
+            except Exception:
+                logger.exception(
+                    "Walk-forward evaluation failed for %s; falling back to "
+                    "legacy single-window acceptance",
+                    spec.strategy_id,
+                )
+                acceptance_results = []
+                acceptance_reason = None
+
+        # ── Resolve is_winning ────────────────────────────────────────
+        # Walk-forward path: composite gate is authoritative.
+        # Legacy path (walk_forward_enabled=False or evaluation failed):
+        # fall back to the historical annualized-return threshold.
+        if acceptance_results:
+            is_winning = execution_succeeded and all(r.passed for r in acceptance_results)
+        else:
+            is_winning = execution_succeeded and metrics.annualized_return_pct > WINNING_THRESHOLD
+
         # ── Phase 3: ANALYSIS ─────────────────────────────────────────
         narrative = ""
         if execution_succeeded and trades:
@@ -629,12 +720,10 @@ class StrategyLabOrchestrator:
                 narrative = self.analysis_agent.run(
                     spec, metrics, trades, rationale, on_sub_phase=_on_analysis_sub
                 )
-                is_w = metrics.annualized_return_pct > WINNING_THRESHOLD
-                emit("analyzing", {"sub_phase": "completed", "is_winning": is_w})
+                emit("analyzing", {"sub_phase": "completed", "is_winning": is_winning})
             except Exception:
                 logger.exception("Analysis agent failed for %s", spec.strategy_id)
-                is_w = metrics.annualized_return_pct > WINNING_THRESHOLD
-                label = "winning" if is_w else "losing"
+                label = "winning" if is_winning else "losing"
                 narrative = (
                     f"Auto-summary: {spec.asset_class} strategy ({label}) with "
                     f"annualized return {metrics.annualized_return_pct:.1f}%. "
@@ -649,7 +738,6 @@ class StrategyLabOrchestrator:
 
         # ── Phase 4: RECORD ───────────────────────────────────────────
         now_iso = datetime.now(timezone.utc).isoformat()
-        is_winning = execution_succeeded and metrics.annualized_return_pct > WINNING_THRESHOLD
 
         backtest_id = f"bt-{uuid.uuid4().hex[:8]}"
         backtest_record = BacktestRecord(
@@ -781,3 +869,282 @@ class StrategyLabOrchestrator:
         except Exception:
             logger.exception("Market data fetch failed for %s", spec.asset_class)
             return None
+
+    # ------------------------------------------------------------------
+    # Issue #247 — walk-forward + acceptance-gate helpers
+    # ------------------------------------------------------------------
+
+    def _evaluate_walk_forward(
+        self,
+        spec: StrategySpec,
+        market_data: Dict[str, List[OHLCVBar]],
+        config: BacktestConfig,
+        trades: List[TradeRecord],
+        metrics: BacktestResult,
+    ) -> BacktestResult:
+        """Compute walk-forward IS/OOS diagnostics and populate the new
+        ``BacktestResult`` fields the ``AcceptanceGate`` consumes.
+
+        The strategy code is fixed for a cycle (no per-fold refit), so we
+        partition the existing full-window trade ledger by ``exit_date`` into
+        IS/OOS buckets per fold rather than re-running the strategy K times.
+        Mathematically equivalent for OOS metrics and K× cheaper.
+        """
+        purge_hold_days = max_hold_days_from_trades(trades)
+        embargo = config.embargo_days if config.embargo_days > 0 else purge_hold_days
+        folds = build_purged_walk_forward(
+            config.start_date,
+            config.end_date,
+            k_folds=config.n_folds,
+            embargo_days=embargo,
+            purge_hold_days=purge_hold_days,
+        )
+
+        fold_results: List[Dict[str, Any]] = []
+        per_fold_oos_sharpe: List[float] = []
+        per_fold_is_sharpe: List[float] = []
+        oos_trade_count_total = 0
+        all_oos_trades: List[TradeRecord] = []
+        for fold in folds:
+            oos_trades = filter_trades_in_range(trades, fold.test_start, fold.test_end)
+            is_trades = filter_trades_in_fold_training(trades, fold)
+
+            test_start_str = fold.test_start.isoformat()
+            test_end_str = fold.test_end.isoformat()
+
+            oos_metrics = compute_metrics(
+                oos_trades, config.initial_capital, test_start_str, test_end_str
+            )
+            # IS metrics span the full original window minus the fold's
+            # purge/embargo cushion; use the full window for the date span
+            # (the trade list is already filtered).
+            is_metrics = compute_metrics(
+                is_trades,
+                config.initial_capital,
+                config.start_date,
+                config.end_date,
+            )
+
+            per_fold_oos_sharpe.append(oos_metrics.sharpe_ratio)
+            if is_trades:
+                per_fold_is_sharpe.append(is_metrics.sharpe_ratio)
+            oos_trade_count_total += len(oos_trades)
+            all_oos_trades.extend(oos_trades)
+
+            fold_results.append(
+                {
+                    "fold_index": fold.fold_index,
+                    "test_start": test_start_str,
+                    "test_end": test_end_str,
+                    "oos_sharpe": oos_metrics.sharpe_ratio,
+                    "is_sharpe": is_metrics.sharpe_ratio,
+                    "oos_trade_count": len(oos_trades),
+                    "is_trade_count": len(is_trades),
+                }
+            )
+
+        oos_sharpe = (
+            sum(per_fold_oos_sharpe) / len(per_fold_oos_sharpe) if per_fold_oos_sharpe else 0.0
+        )
+        is_sharpe = sum(per_fold_is_sharpe) / len(per_fold_is_sharpe) if per_fold_is_sharpe else 0.0
+        denom = max(abs(is_sharpe), 1e-9)
+        is_oos_degradation_pct = max(0.0, 100.0 * (is_sharpe - oos_sharpe) / denom)
+
+        # Pooled OOS daily-return series for DSR + bootstrap CI. Uses the
+        # same equity-curve construction the metrics engine uses, so the
+        # series is consistent with the per-fold OOS Sharpes.
+        oos_returns = self._daily_returns_from_trades(
+            all_oos_trades, config.initial_capital, config.start_date, config.end_date
+        )
+        skew, kurt = summarize_return_moments(oos_returns)
+        deflated_sharpe = compute_deflated_sharpe(
+            oos_sharpe,
+            n_trials=self.convergence_tracker.trial_count,
+            n_obs=len(oos_returns),
+            skew=skew,
+            kurtosis=kurt,
+        )
+        sharpe_ci_low, sharpe_ci_high = bootstrap_sharpe_ci(oos_returns, seed=0)
+
+        regime_results = self._evaluate_regimes(spec, market_data, config, trades)
+
+        return metrics.model_copy(
+            update={
+                "deflated_sharpe": round(deflated_sharpe, 4),
+                "sharpe_ci_low": sharpe_ci_low,
+                "sharpe_ci_high": sharpe_ci_high,
+                "is_sharpe": round(is_sharpe, 4),
+                "oos_sharpe": round(oos_sharpe, 4),
+                "is_oos_degradation_pct": round(is_oos_degradation_pct, 2),
+                "oos_trade_count": oos_trade_count_total,
+                "regime_results": regime_results,
+                "fold_results": fold_results,
+            }
+        )
+
+    @staticmethod
+    def _daily_returns_from_trades(
+        trades: Sequence[TradeRecord],
+        initial_capital: float,
+        start_date: str,
+        end_date: str,
+    ) -> List[float]:
+        """Daily simple returns from the equity curve implied by the trades."""
+        curve = build_equity_curve_from_trades(
+            trades, initial_capital, start_date=start_date, end_date=end_date
+        )
+        if len(curve.equity) < 2:
+            return []
+        out: List[float] = []
+        for i in range(1, len(curve.equity)):
+            prev = curve.equity[i - 1]
+            if prev <= 0:
+                out.append(0.0)
+            else:
+                out.append((curve.equity[i] - prev) / prev)
+        return out
+
+    def _evaluate_regimes(
+        self,
+        spec: StrategySpec,
+        market_data: Dict[str, List[OHLCVBar]],
+        config: BacktestConfig,
+        trades: List[TradeRecord],
+    ) -> List[Dict[str, Any]]:
+        """Per-regime strategy-vs-benchmark comparison for the acceptance gate.
+
+        Builds a daily strategy return series from the trade ledger, a
+        benchmark return series from the configured composition (defaults to
+        a 60/40 SPY+AGG blend; falls back to a single-symbol benchmark when
+        the blend cannot be assembled), aligns by length, then partitions
+        into VIX-quartile sub-windows. Returns a list of four dicts shaped
+        for ``AcceptanceGate``.
+        """
+        try:
+            curve = build_equity_curve_from_trades(
+                trades,
+                config.initial_capital,
+                start_date=config.start_date,
+                end_date=config.end_date,
+            )
+            if len(curve.equity) < 2:
+                return []
+            strategy_returns = self._equity_to_returns(curve.equity)
+
+            bench_dates, bench_equity = self._build_benchmark_equity(spec, market_data, config)
+            if len(bench_equity) < 2:
+                return []
+            benchmark_returns = self._equity_to_returns(bench_equity)
+
+            n = min(len(strategy_returns), len(benchmark_returns))
+            strategy_returns = strategy_returns[:n]
+            benchmark_returns = benchmark_returns[:n]
+            aligned_dates = list(bench_dates[: n + 1])  # equity has n+1 points; returns has n
+
+            subwindows = vix_quartile_subwindows(
+                aligned_dates,
+                benchmark_returns,
+                vix_provider=self._resolve_vix_provider(),
+            )
+            return regime_comparison(strategy_returns, benchmark_returns, subwindows)
+        except Exception:
+            logger.exception("Regime evaluation failed for %s", spec.strategy_id)
+            return []
+
+    @staticmethod
+    def _equity_to_returns(equity: Sequence[float]) -> List[float]:
+        out: List[float] = []
+        for i in range(1, len(equity)):
+            prev = equity[i - 1]
+            if prev <= 0:
+                out.append(0.0)
+            else:
+                out.append((equity[i] - prev) / prev)
+        return out
+
+    def _build_benchmark_equity(
+        self,
+        spec: StrategySpec,
+        market_data: Dict[str, List[OHLCVBar]],
+        config: BacktestConfig,
+    ) -> Tuple[List[Any], List[float]]:
+        """Return ``(dates, equity)`` for the configured benchmark composition.
+
+        ``benchmark_composition="60_40"`` blends SPY and AGG closes via
+        :func:`build_60_40_equity`; any other value falls back to the
+        asset-class default benchmark from :func:`benchmark_for_strategy`.
+        Both paths normalize closes into an equity series scaled by
+        ``config.initial_capital``.
+        """
+        composition = (config.benchmark_composition or "").strip().lower()
+        if composition == "60_40":
+            try:
+                blend = self.market_data_service.fetch_multi_symbol_range(
+                    symbols=["SPY", "AGG"],
+                    asset_class="stocks",
+                    start_date=config.start_date,
+                    end_date=config.end_date,
+                )
+            except Exception:
+                logger.exception("60/40 benchmark fetch failed; falling back to single-symbol")
+                blend = None
+            if blend and "SPY" in blend and "AGG" in blend and blend["SPY"] and blend["AGG"]:
+                spy_bars = blend["SPY"]
+                agg_bars = blend["AGG"]
+                spy_dates = [self._parse_bar_date(b.date) for b in spy_bars]
+                spy_equity = self._closes_to_equity(
+                    [b.close for b in spy_bars], config.initial_capital
+                )
+                agg_equity = self._closes_to_equity(
+                    [b.close for b in agg_bars], config.initial_capital
+                )
+                blended = build_60_40_equity(
+                    spy_equity, agg_equity, initial_capital=config.initial_capital
+                )
+                n = min(len(spy_dates), len(blended))
+                return spy_dates[:n], blended[:n]
+
+        # Single-symbol fallback
+        bench_symbol = benchmark_for_strategy(spec)
+        try:
+            single = self.market_data_service.fetch_multi_symbol_range(
+                symbols=[bench_symbol],
+                asset_class=spec.asset_class,
+                start_date=config.start_date,
+                end_date=config.end_date,
+            )
+        except Exception:
+            logger.exception("Single-symbol benchmark fetch failed for %s", bench_symbol)
+            single = None
+        if single and bench_symbol in single and single[bench_symbol]:
+            bars = single[bench_symbol]
+            dates = [self._parse_bar_date(b.date) for b in bars]
+            equity = self._closes_to_equity([b.close for b in bars], config.initial_capital)
+            n = min(len(dates), len(equity))
+            return dates[:n], equity[:n]
+        return [], []
+
+    @staticmethod
+    def _closes_to_equity(closes: Sequence[float], initial_capital: float) -> List[float]:
+        if not closes or closes[0] <= 0:
+            return []
+        scale = initial_capital / closes[0]
+        return [c * scale for c in closes]
+
+    @staticmethod
+    def _parse_bar_date(d: str) -> Any:
+        from datetime import date
+
+        return date.fromisoformat(d[:10])
+
+    @staticmethod
+    def _resolve_vix_provider() -> Optional[Callable[[Sequence[Any]], List[float]]]:
+        """Return a VIX provider callable when ``STRATEGY_LAB_VIX_SOURCE`` is
+        set, otherwise None so :func:`vix_quartile_subwindows` falls back to
+        realized-vol on the benchmark series. Production deployments can
+        wire in a Yahoo ``^VIX`` fetcher here without touching callers."""
+        source = os.environ.get("STRATEGY_LAB_VIX_SOURCE", "").strip().lower()
+        if not source:
+            return None
+        # Hook point for production providers; unset → realized-vol fallback.
+        return None

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -656,6 +656,7 @@ class StrategyLabOrchestrator:
         # (legacy fallback) or there is no successful execution to evaluate.
         acceptance_results: List[QualityGateResult] = []
         acceptance_reason: Optional[str] = None
+        walk_forward_failed = False
         if (
             execution_succeeded
             and trades
@@ -698,13 +699,36 @@ class StrategyLabOrchestrator:
                 )
                 acceptance_results = []
                 acceptance_reason = None
+                walk_forward_failed = True
 
         # ── Resolve is_winning ────────────────────────────────────────
         # Walk-forward path: composite gate is authoritative.
-        # Legacy path (walk_forward_enabled=False or evaluation failed):
-        # fall back to the historical annualized-return threshold.
+        # Walk-forward fallback: anomaly checks during refinement ran with
+        # ``dsr_aware=True``, which downgraded the ``Sharpe > 5.0`` flag
+        # from critical to warning on the assumption that the OOS DSR
+        # would adjudicate. With AcceptanceGate unavailable, re-run the
+        # anomaly checks with ``dsr_aware=False`` and reject if any
+        # critical fires — otherwise an obvious overfit could still be
+        # marked winning on annualized return alone.
+        # Legacy path (``walk_forward_enabled=False``): unchanged
+        # ``WINNING_THRESHOLD`` comparison; the refinement loop already
+        # ran with ``dsr_aware=False`` so no re-check is needed.
         if acceptance_results:
             is_winning = execution_succeeded and all(r.passed for r in acceptance_results)
+        elif walk_forward_failed and execution_succeeded:
+            fallback_anomalies = self.anomaly_detector.check(metrics, trades, dsr_aware=False)
+            fallback_criticals = [
+                g for g in fallback_anomalies if not g.passed and g.severity == "critical"
+            ]
+            is_winning = (
+                metrics.annualized_return_pct > WINNING_THRESHOLD and not fallback_criticals
+            )
+            if fallback_criticals:
+                # Surface the upgraded severities so the persisted
+                # gate-result history reflects the true rejection reason.
+                for g in fallback_anomalies:
+                    g.gate_name = f"fallback_{g.gate_name}"
+                all_gate_results.extend(fallback_anomalies)
         else:
             is_winning = execution_succeeded and metrics.annualized_return_pct > WINNING_THRESHOLD
 
@@ -915,19 +939,36 @@ class StrategyLabOrchestrator:
             oos_metrics = compute_metrics(
                 oos_trades, config.initial_capital, test_start_str, test_end_str
             )
-            # IS metrics span the full original window minus the fold's
-            # purge/embargo cushion; use the full window for the date span
-            # (the trade list is already filtered).
-            is_metrics = compute_metrics(
-                is_trades,
-                config.initial_capital,
-                config.start_date,
-                config.end_date,
-            )
+            # IS Sharpe is computed per training segment (a fold may have up
+            # to two disjoint segments — pre-test and post-test) and then
+            # trade-count-weighted. Spanning the full backtest window would
+            # include the test+purge+embargo gap as flat zero-return days
+            # and dilute the Sharpe, materially understating IS→OOS
+            # degradation.
+            is_segment_sharpes: List[Tuple[float, int]] = []
+            for tr in fold.train_ranges:
+                seg_trades = filter_trades_in_range(is_trades, tr.start, tr.end)
+                if not seg_trades:
+                    continue
+                seg_metrics = compute_metrics(
+                    seg_trades,
+                    config.initial_capital,
+                    tr.start.isoformat(),
+                    tr.end.isoformat(),
+                )
+                is_segment_sharpes.append((seg_metrics.sharpe_ratio, len(seg_trades)))
+
+            if is_segment_sharpes:
+                total_w = sum(w for _, w in is_segment_sharpes)
+                fold_is_sharpe = (
+                    sum(s * w for s, w in is_segment_sharpes) / total_w if total_w else 0.0
+                )
+            else:
+                fold_is_sharpe = 0.0
 
             per_fold_oos_sharpe.append(oos_metrics.sharpe_ratio)
             if is_trades:
-                per_fold_is_sharpe.append(is_metrics.sharpe_ratio)
+                per_fold_is_sharpe.append(fold_is_sharpe)
             oos_trade_count_total += len(oos_trades)
             all_oos_trades.extend(oos_trades)
 
@@ -937,7 +978,7 @@ class StrategyLabOrchestrator:
                     "test_start": test_start_str,
                     "test_end": test_end_str,
                     "oos_sharpe": oos_metrics.sharpe_ratio,
-                    "is_sharpe": is_metrics.sharpe_ratio,
+                    "is_sharpe": fold_is_sharpe,
                     "oos_trade_count": len(oos_trades),
                     "is_trade_count": len(is_trades),
                 }

--- a/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
@@ -19,12 +19,20 @@ class BacktestAnomalyDetector:
         trades: List[TradeRecord],
         *,
         mode: str = "backtest",
+        dsr_aware: bool = False,
     ) -> List[QualityGateResult]:
         """Run anomaly checks.
 
         ``mode="backtest"`` (default) runs the full gate set; ``mode="paper"``
         relaxes gates that assume a multi-year backtest window so short
         paper-trading sessions don't false-trigger on "too few trades".
+
+        ``dsr_aware`` (default False) is set by the Strategy Lab orchestrator
+        when walk-forward + ``AcceptanceGate`` is wired in: the OOS Deflated
+        Sharpe Ratio is then the authoritative overfitting check, so the
+        ``Sharpe > 5.0`` single-window flag is downgraded from critical to
+        warning — it still surfaces in the gate result list but no longer
+        forces a refinement-loop rewrite when the OOS DSR clears the gate.
         """
         results: List[QualityGateResult] = []
 
@@ -98,26 +106,32 @@ class BacktestAnomalyDetector:
             )
 
         # 5b. Sharpe ratio thresholds.
-        # Issue #247: the walk-forward + AcceptanceGate + DSR gate is the
-        # eventual authoritative overfitting check, but until it is wired
-        # into StrategyLabOrchestrator (step 8), the orchestrator only
-        # refines/rejects on ``severity == "critical"`` gate failures. Keep
-        # Sharpe > 5.0 at critical severity so clearly-overfit strategies
-        # still trigger refinement on the single-window path; the Sharpe > 3
-        # band remains a warning. Once AcceptanceGate is invoked from the
-        # orchestrator this gate can be revisited.
+        # Issue #247: when the orchestrator runs walk-forward and invokes
+        # ``AcceptanceGate`` on the OOS Deflated Sharpe, that gate is the
+        # authoritative overfitting check — so we downgrade the single-window
+        # ``Sharpe > 5.0`` flag from critical to warning under ``dsr_aware``
+        # to avoid double-rejecting (and to avoid forcing a refinement rewrite
+        # on a strategy whose IS Sharpe is high but OOS DSR clears the gate).
+        # Without ``dsr_aware`` the orchestrator only sees the single window,
+        # so a Sharpe > 5.0 stays critical to trigger refinement.
         if metrics.sharpe_ratio > 5.0:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
                     passed=False,
-                    severity="critical",
+                    severity="warning" if dsr_aware else "critical",
                     details=(
                         f"Sharpe ratio {metrics.sharpe_ratio:.2f} exceeds 5.0 — "
                         "almost certainly indicates look-ahead bias or a "
-                        "calculation artifact. When walk-forward is available, "
-                        "AcceptanceGate's OOS Deflated Sharpe is the more "
-                        "precise overfitting check."
+                        "calculation artifact. "
+                        + (
+                            "AcceptanceGate's OOS Deflated Sharpe is the "
+                            "authoritative overfitting check on this run."
+                            if dsr_aware
+                            else "When walk-forward is available, "
+                            "AcceptanceGate's OOS Deflated Sharpe is the more "
+                            "precise overfitting check."
+                        )
                     ),
                 )
             )

--- a/backend/agents/investment_team/tests/test_backtest_anomaly_dsr_aware.py
+++ b/backend/agents/investment_team/tests/test_backtest_anomaly_dsr_aware.py
@@ -1,0 +1,98 @@
+"""Regression for ``BacktestAnomalyDetector(dsr_aware=...)`` (issue #247).
+
+When walk-forward + ``AcceptanceGate`` is wired into the orchestrator (step 8
+of issue #247), the OOS Deflated Sharpe is the authoritative overfitting
+check, so the legacy ``Sharpe > 5.0`` single-window flag must downgrade from
+critical to warning to avoid double-rejecting the same strategy. The flag is
+preserved (it still surfaces in the gate result list and feeds into the
+gate-history persistence) but it no longer forces a refinement-loop rewrite.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from investment_team.models import BacktestResult, TradeRecord
+from investment_team.strategy_lab.quality_gates.backtest_anomaly import (
+    BacktestAnomalyDetector,
+)
+
+
+def _trades(n: int = 12) -> List[TradeRecord]:
+    out: List[TradeRecord] = []
+    cum = 0.0
+    for i in range(n):
+        net = 25.0 if i % 2 == 0 else -10.0
+        cum += net
+        out.append(
+            TradeRecord(
+                trade_num=i + 1,
+                entry_date=f"2023-01-{(i % 28) + 1:02d}",
+                exit_date=f"2023-02-{(i % 28) + 1:02d}",
+                symbol="AAPL" if i % 2 == 0 else "MSFT",
+                side="long" if i % 3 != 0 else "short",
+                entry_price=100.0,
+                exit_price=100.0 + net / 10.0,
+                shares=10.0,
+                position_value=1000.0,
+                gross_pnl=net,
+                net_pnl=net,
+                return_pct=net / 1000.0 * 100,
+                hold_days=20,  # multi-day holds — clears the avg-hold gate
+                outcome="win" if net > 0 else "loss",
+                cumulative_pnl=cum,
+            )
+        )
+    return out
+
+
+def _high_sharpe_metrics() -> BacktestResult:
+    return BacktestResult(
+        total_return_pct=80.0,
+        annualized_return_pct=60.0,
+        volatility_pct=8.0,
+        sharpe_ratio=6.5,  # above the > 5.0 threshold
+        max_drawdown_pct=4.0,
+        win_rate_pct=60.0,
+        profit_factor=2.4,
+    )
+
+
+def test_sharpe_above_5_is_critical_by_default():
+    """Without ``dsr_aware``, ``Sharpe > 5.0`` stays critical so the
+    single-window orchestrator path triggers refinement."""
+    detector = BacktestAnomalyDetector()
+    results = detector.check(_high_sharpe_metrics(), _trades())
+    sharpe_failures = [r for r in results if not r.passed and "Sharpe ratio" in r.details]
+    assert len(sharpe_failures) == 1
+    assert sharpe_failures[0].severity == "critical"
+
+
+def test_sharpe_above_5_downgrades_to_warning_when_dsr_aware():
+    """With ``dsr_aware=True`` the same metrics produce a *warning*, not a
+    critical — AcceptanceGate's OOS DSR is the authoritative check on this
+    run."""
+    detector = BacktestAnomalyDetector()
+    results = detector.check(_high_sharpe_metrics(), _trades(), dsr_aware=True)
+    sharpe_failures = [r for r in results if not r.passed and "Sharpe ratio" in r.details]
+    assert len(sharpe_failures) == 1
+    assert sharpe_failures[0].severity == "warning"
+    assert "AcceptanceGate" in sharpe_failures[0].details
+
+
+def test_dsr_aware_does_not_affect_other_critical_gates():
+    """``dsr_aware`` only re-classifies the Sharpe band; other critical gates
+    (zero trades, sub-1d holds, win-rate > 95%) stay critical."""
+    metrics = BacktestResult(
+        total_return_pct=10.0,
+        annualized_return_pct=12.0,
+        volatility_pct=8.0,
+        sharpe_ratio=1.2,
+        max_drawdown_pct=4.0,
+        win_rate_pct=98.0,  # > 95 → critical
+        profit_factor=1.4,
+    )
+    detector = BacktestAnomalyDetector()
+    results = detector.check(metrics, _trades(), dsr_aware=True)
+    critical = [r for r in results if not r.passed and r.severity == "critical"]
+    assert any("Win rate" in r.details for r in critical)

--- a/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
@@ -433,3 +433,152 @@ def test_closes_to_equity_scales_to_initial_capital():
     out = StrategyLabOrchestrator._closes_to_equity([10.0, 11.0, 12.0], 100_000.0)
     assert out[0] == pytest.approx(100_000.0)
     assert out[-1] == pytest.approx(100_000.0 * 12.0 / 10.0)
+
+
+# ---------------------------------------------------------------------------
+# Review-comment fixes — IS Sharpe per training segment
+# ---------------------------------------------------------------------------
+
+
+def test_is_sharpe_uses_training_segments_not_full_span():
+    """Per-fold IS Sharpe must be computed on the actual training date
+    ranges. If we used ``config.start_date``/``config.end_date`` instead,
+    the test+purge+embargo gap would show up as flat zero-return days and
+    dilute the Sharpe — materially understating IS→OOS degradation.
+
+    This test compares two scenarios with identical OOS trades but very
+    different IS trade distributions (front-loaded vs back-loaded). The
+    full-span computation would yield similar IS Sharpes for both because
+    the gaps dominate; the per-segment computation produces visibly
+    different IS Sharpes.
+    """
+    orch = _orchestrator(_StubMarketDataService())
+    config = _config(walk_forward_enabled=True, n_folds=5)
+    base_metrics = BacktestResult(
+        total_return_pct=5.0,
+        annualized_return_pct=6.0,
+        volatility_pct=8.0,
+        sharpe_ratio=1.0,
+        max_drawdown_pct=4.0,
+        win_rate_pct=55.0,
+        profit_factor=1.4,
+    )
+
+    # Two trades per month, evenly distributed → at least one IS trade per
+    # fold's training segments.
+    trades = _trades_across_year(n_per_month=4, base_pnl=80.0)
+    market_data = {"AAPL": _stub_bars("AAPL")}
+    result = orch._evaluate_walk_forward(_spec(), market_data, config, trades, base_metrics)
+
+    # Per-fold IS Sharpe must come from the segment computation: when
+    # ``is_trade_count > 0``, the recorded ``is_sharpe`` should not be
+    # zero except by genuine flat-return coincidence. With four winning-
+    # losing alternations per month and 5 folds, at least one fold should
+    # produce a strictly nonzero IS Sharpe under the per-segment fix.
+    nonzero_is_sharpes = [
+        fr["is_sharpe"]
+        for fr in (result.fold_results or [])
+        if fr.get("is_trade_count", 0) > 0 and fr.get("is_sharpe", 0.0) != 0.0
+    ]
+    assert nonzero_is_sharpes, (
+        "Per-fold IS Sharpe should be nonzero for at least one fold once we "
+        "compute on training segments instead of the full backtest span."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Review-comment fixes — walk-forward fallback re-checks anomalies
+# ---------------------------------------------------------------------------
+
+
+def test_walk_forward_fallback_rejects_overfit_via_anomaly_recheck(monkeypatch):
+    """When walk-forward evaluation raises and we fall back to the legacy
+    threshold path, the orchestrator must re-run anomaly checks with
+    ``dsr_aware=False`` so a downgraded ``Sharpe > 5`` flag becomes
+    critical again — preventing an obvious overfit from being marked
+    winning on annualized return alone."""
+
+    from investment_team.models import StrategyLabRecord
+    from investment_team.strategy_lab.agents.alignment import TradeAlignmentReport
+
+    orch = _orchestrator(_StubMarketDataService())
+
+    # Force walk-forward to raise so we exercise the fallback path.
+    def _raise(*args, **kwargs):
+        raise RuntimeError("walk-forward fold construction failed (synthetic)")
+
+    monkeypatch.setattr(orch, "_evaluate_walk_forward", _raise)
+
+    # Stub the agents that would otherwise call the LLM.
+    spec_dict = {
+        "asset_class": "stocks",
+        "hypothesis": "h",
+        "signal_definition": "s",
+        "entry_rules": ["e"],
+        "exit_rules": ["x"],
+        "sizing_rules": [],
+        "risk_limits": {},
+        "speculative": False,
+    }
+    overfit_code = "from contract import Strategy\n\nclass S(Strategy):\n    def on_bar(self, ctx, bar):\n        pass\n"
+    monkeypatch.setattr(
+        orch.ideation_agent, "run", lambda **kw: (spec_dict, overfit_code, "rationale")
+    )
+    monkeypatch.setattr(
+        orch.refinement_agent, "run", lambda **kw: ({"changes_made": "x"}, overfit_code)
+    )
+    monkeypatch.setattr(
+        orch.alignment_agent, "run", lambda **kw: TradeAlignmentReport(aligned=True, rationale="ok")
+    )
+    monkeypatch.setattr(orch.analysis_agent, "run", lambda *a, **k: "narrative")
+    monkeypatch.setattr(
+        orch, "_fetch_market_data", lambda spec, config: {"AAPL": _stub_bars("AAPL")}
+    )
+
+    # Synthesize an "overfit" backtest: high Sharpe (>5) and high
+    # annualized return (>WINNING_THRESHOLD). With dsr_aware=False the
+    # Sharpe>5 critical is what we expect to upgrade severity on
+    # fallback.
+    overfit_result = BacktestResult(
+        total_return_pct=80.0,
+        annualized_return_pct=60.0,
+        volatility_pct=8.0,
+        sharpe_ratio=6.5,
+        max_drawdown_pct=4.0,
+        win_rate_pct=60.0,
+        profit_factor=2.4,
+    )
+    overfit_trades = _trades_across_year(n_per_month=4, base_pnl=80.0)
+
+    class _StubExecResult:
+        def __init__(self):
+            self.success = True
+            self.trades = overfit_trades
+            self.execution_time_seconds = 0.01
+            self.error_type = None
+            self.stderr = ""
+
+    monkeypatch.setattr(
+        "investment_team.strategy_lab.orchestrator.run_strategy_code",
+        lambda *a, **k: _StubExecResult(),
+    )
+    monkeypatch.setattr(
+        "investment_team.strategy_lab.orchestrator.compute_metrics",
+        lambda *a, **k: overfit_result,
+    )
+
+    config = _config(walk_forward_enabled=True)
+    record: StrategyLabRecord = orch.run_cycle(prior_records=[], config=config)
+
+    # The fallback path must reject this on the upgraded Sharpe>5 critical
+    # even though annualized return clears WINNING_THRESHOLD.
+    assert record.is_winning is False
+    # The persisted gate-result history reflects the upgraded severity so
+    # downstream consumers can audit the rejection reason.
+    fallback_gates = [
+        g for g in record.quality_gate_results if g.get("gate_name", "").startswith("fallback_")
+    ]
+    assert any(
+        g.get("severity") == "critical" and "Sharpe ratio" in g.get("details", "")
+        for g in fallback_gates
+    )

--- a/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
@@ -1,0 +1,435 @@
+"""Orchestrator wiring tests for issue #247 — walk-forward + acceptance gate.
+
+The lower-level building blocks (fold construction, DSR, bootstrap CI, regime
+sub-windows, the acceptance gate itself) have their own dedicated test files.
+This file exercises the wiring inside :class:`StrategyLabOrchestrator`:
+
+- :meth:`_evaluate_walk_forward` populates every new ``BacktestResult`` field
+  the acceptance gate consumes.
+- :meth:`_daily_returns_from_trades` and :meth:`_equity_to_returns` produce
+  sensible series for the DSR / regime helpers.
+- :meth:`_build_benchmark_equity` blends 60/40 SPY+AGG when the market-data
+  service returns both, and falls back to a single-symbol benchmark when the
+  blend cannot be assembled.
+- The trial counter monotonically deflates DSR for an unchanged raw Sharpe.
+
+The full ``run_cycle`` is not exercised here; the alignment-loop and ideation
+agents are covered in ``test_strategy_lab_alignment.py``.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from investment_team.execution.metrics import compute_deflated_sharpe
+from investment_team.market_data_service import OHLCVBar
+from investment_team.models import BacktestConfig, BacktestResult, StrategySpec, TradeRecord
+from investment_team.strategy_lab.orchestrator import StrategyLabOrchestrator
+from investment_team.strategy_lab.quality_gates.acceptance_gate import AcceptanceGate
+from investment_team.strategy_lab.quality_gates.convergence_tracker import ConvergenceTracker
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _spec() -> StrategySpec:
+    return StrategySpec(
+        strategy_id="strat-wf-test",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="hyp",
+        signal_definition="sig",
+        entry_rules=["enter on signal"],
+        exit_rules=["exit on opposite"],
+        sizing_rules=["fixed size"],
+        risk_limits={},
+        speculative=False,
+        strategy_code="from contract import Strategy\n\nclass S(Strategy):\n    def on_bar(self, ctx, bar):\n        pass\n",
+    )
+
+
+def _config(**overrides: Any) -> BacktestConfig:
+    base: Dict[str, Any] = dict(
+        start_date="2022-01-03",
+        end_date="2022-12-30",
+        initial_capital=100_000.0,
+    )
+    base.update(overrides)
+    return BacktestConfig(**base)
+
+
+def _mk_trade(
+    *,
+    entry: str,
+    exit_: str,
+    net: float,
+    symbol: str = "AAPL",
+    hold: int = 5,
+) -> TradeRecord:
+    return TradeRecord(
+        trade_num=1,
+        entry_date=entry,
+        exit_date=exit_,
+        symbol=symbol,
+        side="long" if net >= 0 else "short",
+        entry_price=100.0,
+        exit_price=100.0 + net / 10.0,
+        shares=10.0,
+        position_value=1000.0,
+        gross_pnl=net,
+        net_pnl=net,
+        return_pct=net / 1000.0 * 100,
+        hold_days=hold,
+        outcome="win" if net > 0 else "loss",
+        cumulative_pnl=net,
+    )
+
+
+def _trades_across_year(n_per_month: int = 4, base_pnl: float = 50.0) -> List[TradeRecord]:
+    """Spread roughly ``n_per_month`` winning trades across the calendar so that
+    every walk-forward fold gets a handful of OOS observations."""
+    out: List[TradeRecord] = []
+    cum = 0.0
+    for month in range(1, 13):
+        for j in range(n_per_month):
+            day = (j * 7) + 3  # 3, 10, 17, 24
+            entry = date(2022, month, day)
+            exit_ = entry + timedelta(days=5)
+            net = base_pnl if (month + j) % 2 == 0 else -base_pnl * 0.6
+            cum += net
+            out.append(
+                TradeRecord(
+                    trade_num=len(out) + 1,
+                    entry_date=entry.isoformat(),
+                    exit_date=exit_.isoformat(),
+                    symbol="AAPL",
+                    side="long",
+                    entry_price=100.0,
+                    exit_price=100.0 + net / 10.0,
+                    shares=10.0,
+                    position_value=1000.0,
+                    gross_pnl=net,
+                    net_pnl=net,
+                    return_pct=net / 1000.0 * 100,
+                    hold_days=5,
+                    outcome="win" if net > 0 else "loss",
+                    cumulative_pnl=cum,
+                )
+            )
+    return out
+
+
+def _stub_bars(symbol: str, *, drift: float = 0.0003, n: int = 250) -> List[OHLCVBar]:
+    """Synthetic OHLCV bars starting 2022-01-03; price drifts at ``drift`` per day."""
+    bars: List[OHLCVBar] = []
+    d = date(2022, 1, 3)
+    price = 100.0
+    while len(bars) < n:
+        if d.weekday() < 5:
+            bars.append(
+                OHLCVBar(
+                    date=d.isoformat(),
+                    open=price,
+                    high=price * 1.005,
+                    low=price * 0.995,
+                    close=price,
+                    volume=1_000_000,
+                )
+            )
+            price *= 1.0 + drift
+        d += timedelta(days=1)
+    return bars
+
+
+class _StubMarketDataService:
+    """Returns canned SPY/AGG bars for the 60/40 blend; no network access."""
+
+    def __init__(self, *, has_spy: bool = True, has_agg: bool = True) -> None:
+        self.has_spy = has_spy
+        self.has_agg = has_agg
+        self.calls: List[Dict[str, Any]] = []
+
+    def fetch_multi_symbol_range(
+        self,
+        *,
+        symbols: List[str],
+        asset_class: str,
+        start_date: str,
+        end_date: str,
+    ) -> Dict[str, List[OHLCVBar]]:
+        self.calls.append(
+            {
+                "symbols": list(symbols),
+                "asset_class": asset_class,
+                "start_date": start_date,
+                "end_date": end_date,
+            }
+        )
+        out: Dict[str, List[OHLCVBar]] = {}
+        for s in symbols:
+            if s == "SPY" and self.has_spy:
+                out[s] = _stub_bars("SPY", drift=0.0004)
+            elif s == "AGG" and self.has_agg:
+                out[s] = _stub_bars("AGG", drift=0.0001)
+            elif s not in {"SPY", "AGG"}:
+                out[s] = _stub_bars(s, drift=0.0002)
+        return out
+
+
+def _orchestrator(
+    market_data_service: Optional[_StubMarketDataService] = None,
+) -> StrategyLabOrchestrator:
+    orch = StrategyLabOrchestrator()
+    if market_data_service is not None:
+        orch.market_data_service = market_data_service  # type: ignore[assignment]
+    return orch
+
+
+# ---------------------------------------------------------------------------
+# _evaluate_walk_forward
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_walk_forward_populates_oos_fields():
+    """All new BacktestResult fields are set; fold count matches config."""
+    orch = _orchestrator(_StubMarketDataService())
+    config = _config(walk_forward_enabled=True, n_folds=5)
+    trades = _trades_across_year(n_per_month=4)
+    base_metrics = BacktestResult(
+        total_return_pct=10.0,
+        annualized_return_pct=12.0,
+        volatility_pct=8.0,
+        sharpe_ratio=1.0,
+        max_drawdown_pct=4.0,
+        win_rate_pct=55.0,
+        profit_factor=1.4,
+    )
+    market_data = {"AAPL": _stub_bars("AAPL")}
+
+    result = orch._evaluate_walk_forward(_spec(), market_data, config, trades, base_metrics)
+
+    assert result.deflated_sharpe is not None
+    assert 0.0 <= result.deflated_sharpe <= 1.0
+    assert result.oos_sharpe is not None
+    assert result.is_sharpe is not None
+    assert result.is_oos_degradation_pct is not None
+    assert result.is_oos_degradation_pct >= 0.0  # clamped to non-negative
+    assert result.oos_trade_count is not None
+    assert result.oos_trade_count > 0
+    assert result.fold_results is not None and len(result.fold_results) == 5
+    # Per-fold dicts carry the keys the persistence layer expects.
+    for fr in result.fold_results:
+        assert {
+            "fold_index",
+            "test_start",
+            "test_end",
+            "oos_sharpe",
+            "is_sharpe",
+            "oos_trade_count",
+        } <= set(fr.keys())
+    # Bootstrap CI populated (may collapse to (0, 0) on tiny series; we just
+    # confirm the fields are not None).
+    assert result.sharpe_ci_low is not None
+    assert result.sharpe_ci_high is not None
+    # Regime evaluation ran and produced four entries (matching REGIME_LABELS).
+    assert result.regime_results is not None and len(result.regime_results) == 4
+    for rr in result.regime_results:
+        assert "beat_benchmark" in rr
+
+
+def test_evaluate_walk_forward_with_empty_trades_does_not_crash():
+    """Empty trade list still yields a populated BacktestResult; OOS fields
+    fall back to neutral values rather than raising."""
+    orch = _orchestrator(_StubMarketDataService())
+    config = _config(walk_forward_enabled=True, n_folds=5)
+    trades: List[TradeRecord] = []
+    base_metrics = BacktestResult(
+        total_return_pct=0.0,
+        annualized_return_pct=0.0,
+        volatility_pct=0.0,
+        sharpe_ratio=0.0,
+        max_drawdown_pct=0.0,
+        win_rate_pct=0.0,
+        profit_factor=0.0,
+    )
+
+    result = orch._evaluate_walk_forward(_spec(), {}, config, trades, base_metrics)
+
+    # At raw Sharpe = 0 and ``n_trials = 0``, DSR collapses to the
+    # Probabilistic Sharpe Ratio against a zero benchmark, which is 0.5 —
+    # not 0.0. We assert the field is populated and bounded; the gate
+    # rejects it via the dsr_threshold default of 1.0.
+    assert result.deflated_sharpe is not None
+    assert 0.0 <= result.deflated_sharpe <= 1.0
+    assert result.oos_sharpe == 0.0
+    assert result.oos_trade_count == 0
+    assert result.fold_results is not None and len(result.fold_results) == 5
+
+
+def test_evaluate_walk_forward_falls_back_when_60_40_unavailable():
+    """When SPY+AGG are unavailable, regime evaluation falls back to the
+    single-symbol benchmark path. The overall walk-forward call must still
+    return a populated result."""
+    stub = _StubMarketDataService(has_agg=False)
+    orch = _orchestrator(stub)
+    config = _config(walk_forward_enabled=True, n_folds=5, benchmark_composition="60_40")
+    trades = _trades_across_year()
+    base_metrics = BacktestResult(
+        total_return_pct=5.0,
+        annualized_return_pct=6.0,
+        volatility_pct=8.0,
+        sharpe_ratio=0.7,
+        max_drawdown_pct=3.0,
+        win_rate_pct=52.0,
+        profit_factor=1.2,
+    )
+
+    result = orch._evaluate_walk_forward(
+        _spec(), {"AAPL": _stub_bars("AAPL")}, config, trades, base_metrics
+    )
+
+    assert result.deflated_sharpe is not None
+    # Fallback path may surface zero-length regime results when neither blend
+    # nor single-symbol resolve; we accept either an empty list or four
+    # entries — the gate handles missing data via its own warning result.
+    assert result.regime_results is not None
+    assert len(result.regime_results) in (0, 4)
+
+
+# ---------------------------------------------------------------------------
+# Trial counter deflates DSR
+# ---------------------------------------------------------------------------
+
+
+def test_trial_count_deflates_dsr_for_identical_raw_sharpe():
+    """For a fixed raw Sharpe and observation count, increasing ``n_trials``
+    must not increase the DSR. This is the multiple-testing correction the
+    issue calls out."""
+    sharpe = 1.5
+    n_obs = 250
+    dsr_one = compute_deflated_sharpe(sharpe, n_trials=1, n_obs=n_obs, skew=0.0, kurtosis=3.0)
+    dsr_fifty = compute_deflated_sharpe(sharpe, n_trials=50, n_obs=n_obs, skew=0.0, kurtosis=3.0)
+    assert 0.0 <= dsr_fifty <= dsr_one <= 1.0
+    assert dsr_one - dsr_fifty > 0.05  # meaningful (not just floating-point noise)
+
+
+def test_increment_trials_on_orchestrator_tracker_is_visible_to_dsr():
+    """The orchestrator's convergence tracker exposes ``trial_count`` via the
+    same property the walk-forward helper feeds to ``compute_deflated_sharpe``.
+    This guards against a future refactor accidentally bypassing the counter.
+    """
+    tracker = ConvergenceTracker()
+    orch = StrategyLabOrchestrator(convergence_tracker=tracker)
+    assert orch.convergence_tracker.trial_count == 0
+    orch.convergence_tracker.increment_trials(3)
+    orch.convergence_tracker.increment_trials(2)
+    assert orch.convergence_tracker.trial_count == 5
+
+
+# ---------------------------------------------------------------------------
+# Acceptance gate drives is_winning end-to-end (composition test)
+# ---------------------------------------------------------------------------
+
+
+def test_acceptance_gate_passes_winning_walk_forward_result():
+    """A walk-forward result that clears all four sub-criteria produces an
+    all-passing gate result; the orchestrator's ``is_winning`` rule treats
+    that as a win."""
+    cfg = _config(
+        walk_forward_enabled=True,
+        dsr_threshold=0.5,
+        max_is_oos_degradation_pct=40.0,
+        min_oos_trades=10,
+    )
+    res = BacktestResult(
+        total_return_pct=12.0,
+        annualized_return_pct=14.0,
+        volatility_pct=9.0,
+        sharpe_ratio=1.4,
+        max_drawdown_pct=5.0,
+        win_rate_pct=58.0,
+        profit_factor=1.6,
+        deflated_sharpe=0.8,
+        oos_sharpe=1.2,
+        is_sharpe=1.3,
+        is_oos_degradation_pct=10.0,
+        oos_trade_count=40,
+        regime_results=[
+            {"regime": "vix_q1", "beat_benchmark": True},
+            {"regime": "vix_q2", "beat_benchmark": True},
+            {"regime": "vix_q3", "beat_benchmark": False},
+            {"regime": "vix_q4", "beat_benchmark": False},
+        ],
+    )
+    results = AcceptanceGate().check(res, cfg, n_trials=10)
+    assert all(r.passed for r in results)
+    assert (True and all(r.passed for r in results)) is True  # the orchestrator's rule
+
+
+def test_acceptance_gate_rejects_overfit_pattern():
+    """High IS Sharpe + collapsed OOS Sharpe + insufficient regime breadth
+    must trip multiple sub-criteria, so the orchestrator marks the cycle
+    as not-winning."""
+    cfg = _config(
+        walk_forward_enabled=True,
+        dsr_threshold=0.9,
+        max_is_oos_degradation_pct=30.0,
+        min_oos_trades=30,
+    )
+    res = BacktestResult(
+        total_return_pct=18.0,
+        annualized_return_pct=22.0,
+        volatility_pct=11.0,
+        sharpe_ratio=2.5,  # IS-only sharpe (the headline single-window number)
+        max_drawdown_pct=6.0,
+        win_rate_pct=63.0,
+        profit_factor=1.9,
+        deflated_sharpe=0.3,  # low — overfit suspicion
+        oos_sharpe=0.4,
+        is_sharpe=2.5,
+        is_oos_degradation_pct=84.0,  # huge IS→OOS gap
+        oos_trade_count=12,  # below min_oos_trades
+        regime_results=[
+            {"regime": "vix_q1", "beat_benchmark": False},
+            {"regime": "vix_q2", "beat_benchmark": False},
+            {"regime": "vix_q3", "beat_benchmark": False},
+            {"regime": "vix_q4", "beat_benchmark": False},
+        ],
+    )
+    results = AcceptanceGate().check(res, cfg, n_trials=50)
+    assert not all(r.passed for r in results)
+    failed_reasons = [r.details for r in results if not r.passed]
+    # Each of the four sub-criteria fails on this fixture.
+    assert len(failed_reasons) == 4
+
+
+# ---------------------------------------------------------------------------
+# Helper purity: _daily_returns_from_trades and _equity_to_returns
+# ---------------------------------------------------------------------------
+
+
+def test_daily_returns_from_trades_handles_empty_input():
+    """Returns an empty list rather than raising on an empty trade ledger."""
+    out = StrategyLabOrchestrator._daily_returns_from_trades(
+        [], 100_000.0, "2022-01-03", "2022-12-30"
+    )
+    assert out == [] or all(r == 0.0 for r in out)
+
+
+def test_equity_to_returns_skips_zero_or_negative_prev():
+    """Zero/negative previous equity yields a 0.0 return at that step (no
+    ZeroDivisionError, no NaN)."""
+    out = StrategyLabOrchestrator._equity_to_returns([100.0, 0.0, 50.0])
+    assert len(out) == 2
+    assert out[0] == pytest.approx(-1.0)
+    assert out[1] == 0.0
+
+
+def test_closes_to_equity_scales_to_initial_capital():
+    out = StrategyLabOrchestrator._closes_to_equity([10.0, 11.0, 12.0], 100_000.0)
+    assert out[0] == pytest.approx(100_000.0)
+    assert out[-1] == pytest.approx(100_000.0 * 12.0 / 10.0)


### PR DESCRIPTION
## Summary

Closes step 8 of #247 — wires the walk-forward + Deflated Sharpe + AcceptanceGate scaffolding (already shipped in steps 1–7) into `StrategyLabOrchestrator`. Replaces the legacy `WINNING_THRESHOLD = 8.0` annualized-return scalar with a composite OOS acceptance gate evaluated on purged, embargoed K-fold walk-forward diagnostics.

- **Trial counting (Phase 2.6).** Increments `convergence_tracker.increment_trials(...)` once per cycle so DSR's multiple-testing correction sees every refinement round across every prior strategy on the same window.
- **Walk-forward (Phase 2.7).** New `_evaluate_walk_forward` partitions the cycle's trades by `exit_date` into IS/OOS buckets per fold (K× cheaper than re-running the strategy K times against sliced market data — equivalent for fixed-per-cycle LLM strategies), aggregates per-fold IS/OOS Sharpes, computes DSR + stationary-block bootstrap CI on the pooled OOS series, and runs regime evaluation against a 60/40 SPY+AGG benchmark (single-symbol fallback when the blend is unavailable).
- **AcceptanceGate is authoritative.** `is_winning = all(r.passed for r in acceptance_results)` when walk-forward ran; `WINNING_THRESHOLD` stays as a documented fallback for `walk_forward_enabled=False`.
- **`BacktestAnomalyDetector(dsr_aware=...)`.** New kwarg downgrades the `Sharpe > 5.0` single-window flag from critical → warning so the OOS DSR isn't double-counted as an overfit veto. Threaded through both orchestrator call sites.

Out of scope (per the issue): Combinatorial Purged CV, White's Reality Check, per-fold strategy refit.

## Files

- `backend/agents/investment_team/strategy_lab/orchestrator.py` — primary wiring (imports, constructor, Phase 2.6/2.7 insertion, `is_winning` rule, four new private helpers).
- `backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py` — `dsr_aware` kwarg + comment update at lines 100–108.
- `backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py` — new (10 tests).
- `backend/agents/investment_team/tests/test_backtest_anomaly_dsr_aware.py` — new (3 tests).

## Test plan

- [x] `pytest agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py` (10 passed)
- [x] `pytest agents/investment_team/tests/test_backtest_anomaly_dsr_aware.py` (3 passed)
- [x] `pytest agents/investment_team/tests/test_strategy_lab_alignment.py agents/investment_team/tests/test_strategy_lab_resume.py agents/investment_team/tests/test_strategy_lab_batches.py agents/investment_team/tests/test_strategy_lab_signal.py` (29 passed — orchestrator regression)
- [x] `pytest agents/investment_team/tests/test_walk_forward.py agents/investment_team/tests/test_acceptance_gate.py agents/investment_team/tests/test_deflated_sharpe.py agents/investment_team/tests/test_convergence_tracker.py agents/investment_team/tests/test_regimes.py` (84 passed — building blocks unchanged)
- [x] `pytest agents/investment_team/tests/` (370 passed, 1 skipped, 0 failed)
- [x] `ruff check agents/investment_team/` (all clean)
- [x] `ruff format --check` on the four touched files (clean)

https://claude.ai/code/session_012eHj2PzUWXycwU8tgzcCHx

---
_Generated by [Claude Code](https://claude.ai/code/session_012eHj2PzUWXycwU8tgzcCHx)_