### PR TITLE
user_agent_founder: collapse poll loops behind TargetTeamAdapter (#261)

### DIFF
--- a/backend/agents/user_agent_founder/api/main.py
+++ b/backend/agents/user_agent_founder/api/main.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import logging
-import os
 import threading
 from contextlib import asynccontextmanager
 from typing import Any, Optional
@@ -16,7 +15,8 @@ from shared_observability import init_otel, instrument_fastapi_app
 from user_agent_founder.agent import FounderAgent
 from user_agent_founder.orchestrator import run_workflow
 from user_agent_founder.postgres import SCHEMA as USER_AGENT_FOUNDER_POSTGRES_SCHEMA
-from user_agent_founder.store import get_founder_store
+from user_agent_founder.store import DEFAULT_TARGET_TEAM_KEY, get_founder_store
+from user_agent_founder.targets import get_adapter
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +57,13 @@ instrument_fastapi_app(app, team_key="user_agent_founder")
 # ---------------------------------------------------------------------------
 
 
+class StartRunRequest(BaseModel):
+    target_team_key: str = Field(
+        default=DEFAULT_TARGET_TEAM_KEY,
+        description="Which target team this persona run drives. Must be a key in targets.ADAPTERS.",
+    )
+
+
 class StartRunResponse(BaseModel):
     # External-facing key used by the team-assistant launch endpoint and the
     # jobs UI. Internally the team still uses ``run_id`` for its own rows;
@@ -82,6 +89,7 @@ class RunStatusResponse(BaseModel):
     analysis_job_id: Optional[str] = None
     spec_content: Optional[str] = None
     repo_path: Optional[str] = None
+    target_team_key: str = DEFAULT_TARGET_TEAM_KEY
     created_at: str
     updated_at: str
     error: Optional[str] = None
@@ -93,6 +101,7 @@ class RunSummaryResponse(BaseModel):
     status: str
     se_job_id: Optional[str] = None
     analysis_job_id: Optional[str] = None
+    target_team_key: str = DEFAULT_TARGET_TEAM_KEY
     created_at: str
     updated_at: str
     error: Optional[str] = None
@@ -128,9 +137,12 @@ def _dispatch_founder_run(run_id: str) -> str:
 
     store = get_founder_store()
     agent = FounderAgent()
+    run = store.get_run(run_id)
+    team_key = (run.target_team_key if run is not None else None) or DEFAULT_TARGET_TEAM_KEY
+    adapter = get_adapter(team_key)
     thread = threading.Thread(
         target=run_workflow,
-        args=(run_id, store, agent),
+        args=(run_id, store, agent, adapter),
         name=f"founder-workflow-{run_id[:8]}",
         daemon=True,
     )
@@ -140,22 +152,30 @@ def _dispatch_founder_run(run_id: str) -> str:
 
 
 @app.post("/start", response_model=StartRunResponse)
-def start_founder_workflow() -> StartRunResponse:
+def start_founder_workflow(request: StartRunRequest | None = None) -> StartRunResponse:
     """Kick off the autonomous founder workflow.
 
     The agent will:
     1. Generate a task management product spec
-    2. Submit it to the SE team for product analysis
-    3. Answer all SE team questions autonomously
-    4. Trigger the full SE team build pipeline
+    2. Submit it to the target team for product analysis
+    3. Answer all target-team questions autonomously
+    4. Trigger the full target-team build pipeline
 
     The run is registered with the centralized job service **before**
     dispatch so it appears in the Jobs Dashboard immediately.
     """
     from user_agent_founder.shared import job_store
 
+    target_team_key = request.target_team_key if request else DEFAULT_TARGET_TEAM_KEY
+    # Validate up-front so an unknown key returns 400 instead of crashing the
+    # background dispatch thread later.
+    try:
+        get_adapter(target_team_key)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
     store = get_founder_store()
-    run_id = store.create_run()
+    run_id = store.create_run(target_team_key=target_team_key)
 
     job_store.create_job(
         run_id,
@@ -197,6 +217,7 @@ def get_run_status(run_id: str) -> RunStatusResponse:
         analysis_job_id=run.analysis_job_id,
         spec_content=run.spec_content,
         repo_path=run.repo_path,
+        target_team_key=run.target_team_key,
         created_at=run.created_at,
         updated_at=run.updated_at,
         error=run.error,
@@ -226,6 +247,7 @@ def list_runs() -> RunListResponse:
                 status=r.status,
                 se_job_id=r.se_job_id,
                 analysis_job_id=r.analysis_job_id,
+                target_team_key=r.target_team_key,
                 created_at=r.created_at,
                 updated_at=r.updated_at,
                 error=r.error,
@@ -294,11 +316,6 @@ class RunArtifactsResponse(BaseModel):
     spec_content: Optional[str] = None
 
 
-UNIFIED_API_BASE = os.environ.get("UNIFIED_API_BASE_URL", "http://localhost:8080")
-SE_PREFIX = "/api/software-engineering"
-_HTTP_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
-
-
 @app.get("/personas", response_model=PersonaListResponse)
 def list_personas() -> PersonaListResponse:
     """Return the list of available project personas for SE team testing."""
@@ -322,8 +339,9 @@ def list_personas() -> PersonaListResponse:
 def get_run_artifacts(run_id: str) -> RunArtifactsResponse:
     """Get artifacts produced during a persona test run.
 
-    Proxies to the SE team job status to retrieve task results,
-    task states, and other pipeline outputs.
+    Proxies to the target-team job status (resolved via the run's
+    ``target_team_key``) to retrieve task results, task states, and
+    other pipeline outputs.
     """
     store = get_founder_store()
     run = store.get_run(run_id)
@@ -333,15 +351,21 @@ def get_run_artifacts(run_id: str) -> RunArtifactsResponse:
     se_job_status: dict[str, Any] | None = None
     if run.se_job_id:
         try:
-            with httpx.Client() as client:
-                resp = client.get(
-                    f"{UNIFIED_API_BASE}{SE_PREFIX}/run-team/{run.se_job_id}",
-                    timeout=_HTTP_TIMEOUT,
-                )
-                if resp.status_code < 400:
-                    se_job_status = resp.json()
-        except httpx.HTTPError:
-            logger.warning("Failed to fetch SE job status for %s", run.se_job_id)
+            adapter = get_adapter(run.target_team_key)
+        except ValueError:
+            logger.warning(
+                "Unknown target_team_key %r on run %s; cannot fetch artifacts",
+                run.target_team_key,
+                run.run_id,
+            )
+        else:
+            try:
+                with httpx.Client() as client:
+                    payload = adapter.poll_build(client, run.se_job_id)
+                if not payload.get("_poll_error"):
+                    se_job_status = payload
+            except httpx.HTTPError:
+                logger.warning("Failed to fetch target-team job status for %s", run.se_job_id)
 
     return RunArtifactsResponse(
         run_id=run.run_id,

--- a/backend/agents/user_agent_founder/orchestrator.py
+++ b/backend/agents/user_agent_founder/orchestrator.py
@@ -1,7 +1,10 @@
 """Background workflow orchestrator for the founder agent.
 
-Runs the full lifecycle: spec generation -> product analysis -> SE team execution,
+Runs the full lifecycle: spec generation -> product analysis -> team build,
 answering all questions autonomously through the founder persona.
+
+Team-specific HTTP coupling lives in ``user_agent_founder.targets``;
+the orchestrator only knows the ``TargetTeamAdapter`` Protocol shape.
 """
 
 from __future__ import annotations
@@ -10,7 +13,7 @@ import logging
 import os
 import threading
 import time
-from typing import Any
+from typing import Any, Callable
 
 import httpx
 
@@ -18,13 +21,11 @@ from job_service_client import JobServiceClient
 from llm_service import LLMJsonParseError, LLMSchemaValidationError
 from user_agent_founder.agent import FounderAgent
 from user_agent_founder.store import FounderRunStore
+from user_agent_founder.targets import StartFailed, TargetTeamAdapter, get_adapter
 
 logger = logging.getLogger(__name__)
 
 _job_client = JobServiceClient(team="user_agent_founder")
-
-UNIFIED_API_BASE = os.environ.get("UNIFIED_API_BASE_URL", "http://localhost:8080")
-SE_PREFIX = "/api/software-engineering"
 
 ANALYSIS_POLL_INTERVAL = int(os.environ.get("FOUNDER_ANALYSIS_POLL_SECONDS", "15"))
 EXECUTION_POLL_INTERVAL = int(os.environ.get("FOUNDER_EXECUTION_POLL_SECONDS", "30"))
@@ -32,13 +33,6 @@ MAX_POLL_ATTEMPTS = int(os.environ.get("FOUNDER_MAX_POLL_ATTEMPTS", "480"))  # ~
 MAX_ANSWER_RETRIES = int(os.environ.get("FOUNDER_MAX_ANSWER_RETRIES", "2"))
 ANSWER_POST_RETRIES = 3
 ANSWER_POST_BACKOFF_BASE = 2  # seconds
-
-# httpx timeout: generous because SE team operations can be slow
-HTTP_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
-
-
-def _se_url(path: str) -> str:
-    return f"{UNIFIED_API_BASE}{SE_PREFIX}{path}"
 
 
 def _sync_job_status(run_id: str, status: str, *, phase: str = "", error: str = "") -> None:
@@ -88,17 +82,18 @@ def _generate_spec_with_heartbeat(agent: FounderAgent, run_id: str) -> str:
 
 
 def _answer_pending_questions(
-    client: httpx.Client,
     agent: FounderAgent,
     store: FounderRunStore,
     run_id: str,
     job_id: str,
     questions: list[dict[str, Any]],
-    endpoint_prefix: str,
+    submit_fn: Callable[[list[dict[str, Any]]], None],
 ) -> bool:
     """Use the founder agent to answer all pending questions and submit them.
 
-    Returns True if answers were successfully submitted, False on failure.
+    ``submit_fn`` posts the answers (e.g. ``adapter.submit_analysis_answers``
+    bound to ``client`` and ``job_id``). Returns True if answers were
+    successfully submitted, False on failure.
     """
     answerable = [q for q in questions if q.get("id")]
     if not answerable:
@@ -155,32 +150,175 @@ def _answer_pending_questions(
 
     # Submit with retry + backoff for transient failures
     for attempt in range(ANSWER_POST_RETRIES):
-        resp = client.post(
-            _se_url(f"{endpoint_prefix}/{job_id}/answers"),
-            json={"answers": answers},
-            timeout=HTTP_TIMEOUT,
-        )
-        if resp.status_code < 400:
+        try:
+            submit_fn(answers)
+        except httpx.HTTPStatusError as exc:
+            logger.warning(
+                "Answer submission attempt %d/%d failed for job %s: %s %s",
+                attempt + 1,
+                ANSWER_POST_RETRIES,
+                job_id,
+                exc.response.status_code,
+                exc.response.text[:500],
+            )
+        except Exception:
+            logger.exception(
+                "Answer submission attempt %d/%d crashed for job %s",
+                attempt + 1,
+                ANSWER_POST_RETRIES,
+                job_id,
+            )
+        else:
             logger.info("Successfully submitted %d answers for job %s", len(answers), job_id)
             return True
-        logger.warning(
-            "Answer submission attempt %d/%d failed for job %s: %s %s",
-            attempt + 1,
-            ANSWER_POST_RETRIES,
-            job_id,
-            resp.status_code,
-            resp.text[:500],
-        )
         if attempt < ANSWER_POST_RETRIES - 1:
             time.sleep(ANSWER_POST_BACKOFF_BASE ** (attempt + 1))
 
     store.add_chat_message(
         run_id=run_id,
         role="system",
-        content=f"Failed to submit answers to SE team after {ANSWER_POST_RETRIES} attempts.",
+        content=f"Failed to submit answers to target team after {ANSWER_POST_RETRIES} attempts.",
         message_type="status_update",
     )
     return False
+
+
+def _run_phase(
+    *,
+    client: httpx.Client,
+    agent: FounderAgent,
+    store: FounderRunStore,
+    run_id: str,
+    phase: str,
+    poll_interval: int,
+    start_fn: Callable[[], str],
+    poll_fn: Callable[[str], dict[str, Any]],
+    submit_answers_fn: Callable[[str, list[dict[str, Any]]], None],
+    on_started: Callable[[str], None],
+    existing_job_id: str | None,
+    questions_status: str,
+    failure_label: str,
+) -> tuple[bool, dict[str, Any] | None]:
+    """Run one start + poll + answer phase against a target-team adapter.
+
+    Returns ``(ok, final_status_data)``. ``ok=False`` means the phase
+    failed/cancelled/timed out and the run row has already been marked
+    ``failed``; the caller should abort. ``final_status_data`` is the
+    last status payload returned by ``poll_fn`` on success.
+
+    All four terminal states (completed / failed / cancelled / timeout)
+    are handled in this single helper, eliminating the historic
+    asymmetry where the analysis phase ignored ``cancelled`` and burned
+    ~4 hours of polling before timing out.
+    """
+    submit_phase_status = f"submitting_{phase}"
+    polling_phase_status = f"polling_{phase}"
+
+    if existing_job_id is None:
+        store.update_run(run_id, status=submit_phase_status)
+        _sync_job_status(run_id, "running", phase=submit_phase_status)
+        try:
+            job_id = start_fn()
+        except StartFailed as exc:
+            err = f"Failed to start {phase}: {exc}"
+            store.update_run(run_id, status="failed", error=err)
+            _sync_job_status(run_id, "failed", error=f"Failed to start {phase}")
+            return False, None
+        on_started(job_id)
+        store.update_run(run_id, status=polling_phase_status)
+        _sync_job_status(run_id, "running", phase=polling_phase_status)
+        logger.info("%s started: job_id=%s", failure_label, job_id)
+        store.add_chat_message(
+            run_id, "system", f"{failure_label} started (job: {job_id})", "status_update"
+        )
+    else:
+        job_id = existing_job_id
+        store.update_run(run_id, status=polling_phase_status, error=None)
+        _sync_job_status(run_id, "running", phase=polling_phase_status)
+        logger.info("Resuming %s poll: job_id=%s", failure_label, job_id)
+        store.add_chat_message(
+            run_id,
+            "system",
+            f"Resuming {failure_label} poll (job: {job_id})",
+            "status_update",
+        )
+
+    failed_question_sets: dict[frozenset[str], int] = {}
+
+    for _ in range(MAX_POLL_ATTEMPTS):
+        time.sleep(poll_interval)
+        _heartbeat(run_id)
+
+        status_data = poll_fn(job_id)
+        if status_data.get("_poll_error"):
+            logger.warning("%s poll error: %s", failure_label, status_data.get("_poll_error"))
+            continue
+        status = status_data.get("status", "")
+
+        # Answer pending questions
+        if status_data.get("waiting_for_answers") and status_data.get("pending_questions"):
+            pending = status_data["pending_questions"]
+            qset = frozenset(q.get("id", "") for q in pending)
+            prior_failures = failed_question_sets.get(qset, 0)
+
+            if prior_failures > MAX_ANSWER_RETRIES:
+                err = (
+                    f"Answer submission failed {prior_failures} times "
+                    f"for {phase} questions. Aborting."
+                )
+                logger.error(err)
+                store.update_run(run_id, status="failed", error=err)
+                _sync_job_status(run_id, "failed", error=err)
+                store.add_chat_message(run_id, "system", err, "status_update")
+                return False, None
+
+            store.update_run(run_id, status=questions_status)
+            store.add_chat_message(
+                run_id,
+                "system",
+                f"Target team has {len(pending)} question(s) during {phase}.",
+                "question_received",
+                metadata={"question_ids": list(qset)},
+            )
+            success = _answer_pending_questions(
+                agent,
+                store,
+                run_id,
+                job_id,
+                pending,
+                lambda answers, _jid=job_id: submit_answers_fn(_jid, answers),
+            )
+            if not success:
+                failed_question_sets[qset] = prior_failures + 1
+                logger.warning(
+                    "Answer attempt %d failed for %s questions",
+                    prior_failures + 1,
+                    phase,
+                )
+            continue
+
+        if status == "completed":
+            return True, status_data
+
+        if status == "failed":
+            err = f"{failure_label} failed: {status_data.get('error', 'unknown')}"
+            store.update_run(run_id, status="failed", error=err)
+            _sync_job_status(run_id, "failed", error=f"{failure_label} failed")
+            store.add_chat_message(run_id, "system", err, "status_update")
+            return False, None
+
+        if status == "cancelled":
+            err = f"{failure_label} was cancelled"
+            store.update_run(run_id, status="failed", error=err)
+            _sync_job_status(run_id, "failed", error=f"{failure_label} cancelled")
+            store.add_chat_message(run_id, "system", f"{err}.", "status_update")
+            return False, None
+
+    err = f"{failure_label} timed out"
+    store.update_run(run_id, status="failed", error=err)
+    _sync_job_status(run_id, "failed", error=err)
+    store.add_chat_message(run_id, "system", f"{err}.", "status_update")
+    return False, None
 
 
 def _run_product_analysis(
@@ -189,274 +327,100 @@ def _run_product_analysis(
     store: FounderRunStore,
     run_id: str,
     spec_content: str,
+    adapter: TargetTeamAdapter,
+    project_name: str,
     *,
     existing_job_id: str | None = None,
 ) -> str | None:
-    """Submit spec for product analysis and poll until complete. Returns repo_path or None.
+    """Submit spec for product analysis and poll until complete. Returns repo_path or None."""
 
-    If ``existing_job_id`` is supplied (resume path), the submit step is
-    skipped and polling resumes against that analysis job.
-    """
-    if existing_job_id is None:
-        store.update_run(run_id, status="submitting_analysis")
-        _sync_job_status(run_id, "running", phase="submitting_analysis")
+    def _on_started(job_id: str) -> None:
+        store.update_run(run_id, analysis_job_id=job_id)
 
-        resp = client.post(
-            _se_url("/product-analysis/start-from-spec"),
-            json={"project_name": f"user-agent-founder-{run_id}", "spec_content": spec_content},
-            timeout=HTTP_TIMEOUT,
-        )
-        if resp.status_code >= 400:
-            store.update_run(
-                run_id,
-                status="failed",
-                error=f"Failed to start analysis: {resp.status_code} {resp.text[:500]}",
-            )
-            _sync_job_status(run_id, "failed", error="Failed to start analysis")
-            return None
+    ok, status_data = _run_phase(
+        client=client,
+        agent=agent,
+        store=store,
+        run_id=run_id,
+        phase="analysis",
+        poll_interval=ANALYSIS_POLL_INTERVAL,
+        start_fn=lambda: adapter.start_from_spec(client, project_name, spec_content),
+        poll_fn=lambda jid: adapter.poll_analysis(client, jid),
+        submit_answers_fn=lambda jid, answers: adapter.submit_analysis_answers(
+            client, jid, answers
+        ),
+        on_started=_on_started,
+        existing_job_id=existing_job_id,
+        questions_status="answering_analysis_questions",
+        failure_label="Product analysis",
+    )
+    if not ok or status_data is None:
+        return None
 
-        data = resp.json()
-        analysis_job_id = data.get("job_id")
-        store.update_run(run_id, analysis_job_id=analysis_job_id, status="polling_analysis")
-        _sync_job_status(run_id, "running", phase="polling_analysis")
-        logger.info("Product analysis started: job_id=%s", analysis_job_id)
-        store.add_chat_message(
-            run_id, "system", f"Product analysis started (job: {analysis_job_id})", "status_update"
-        )
-    else:
-        analysis_job_id = existing_job_id
-        store.update_run(run_id, status="polling_analysis", error=None)
-        _sync_job_status(run_id, "running", phase="polling_analysis")
-        logger.info("Resuming product analysis poll: job_id=%s", analysis_job_id)
-        store.add_chat_message(
-            run_id,
-            "system",
-            f"Resuming product analysis poll (job: {analysis_job_id})",
-            "status_update",
-        )
-
-    failed_question_sets: dict[frozenset[str], int] = {}  # qset -> attempt count
-
-    for _ in range(MAX_POLL_ATTEMPTS):
-        time.sleep(ANALYSIS_POLL_INTERVAL)
-        _heartbeat(run_id)
-
-        resp = client.get(
-            _se_url(f"/product-analysis/status/{analysis_job_id}"),
-            timeout=HTTP_TIMEOUT,
-        )
-        if resp.status_code >= 400:
-            logger.warning("Analysis poll error: %s", resp.status_code)
-            continue
-
-        status_data = resp.json()
-        status = status_data.get("status", "")
-
-        # Answer pending questions
-        if status_data.get("waiting_for_answers") and status_data.get("pending_questions"):
-            pending = status_data["pending_questions"]
-            qset = frozenset(q.get("id", "") for q in pending)
-            prior_failures = failed_question_sets.get(qset, 0)
-
-            if prior_failures > MAX_ANSWER_RETRIES:
-                err = f"Answer submission failed {prior_failures} times for analysis questions. Aborting."
-                logger.error(err)
-                store.update_run(run_id, status="failed", error=err)
-                _sync_job_status(run_id, "failed", error=err)
-                store.add_chat_message(run_id, "system", err, "status_update")
-                return None
-
-            store.update_run(run_id, status="answering_analysis_questions")
-            store.add_chat_message(
-                run_id,
-                "system",
-                f"SE team has {len(pending)} question(s) during analysis.",
-                "question_received",
-                metadata={"question_ids": list(qset)},
-            )
-            success = _answer_pending_questions(
-                client,
-                agent,
-                store,
-                run_id,
-                analysis_job_id,
-                pending,
-                "/product-analysis",
-            )
-            if not success:
-                failed_question_sets[qset] = prior_failures + 1
-                logger.warning(
-                    "Answer attempt %d failed for analysis questions", prior_failures + 1
-                )
-            continue
-
-        if status == "completed":
-            repo_path = status_data.get("repo_path")
-            store.update_run(run_id, repo_path=repo_path)
-            logger.info("Product analysis completed: repo_path=%s", repo_path)
-            store.add_chat_message(
-                run_id,
-                "system",
-                "Analysis complete. Starting SE team build.",
-                "status_update",
-            )
-            return repo_path
-
-        if status == "failed":
-            err = f"Product analysis failed: {status_data.get('error', 'unknown')}"
-            store.update_run(run_id, status="failed", error=err)
-            _sync_job_status(run_id, "failed", error="Product analysis failed")
-            store.add_chat_message(run_id, "system", err, "status_update")
-            return None
-
-    store.update_run(run_id, status="failed", error="Product analysis timed out")
-    _sync_job_status(run_id, "failed", error="Product analysis timed out")
-    store.add_chat_message(run_id, "system", "Product analysis timed out.", "status_update")
-    return None
+    repo_path = status_data.get("repo_path")
+    store.update_run(run_id, repo_path=repo_path)
+    logger.info("Product analysis completed: repo_path=%s", repo_path)
+    store.add_chat_message(
+        run_id,
+        "system",
+        "Analysis complete. Starting target-team build.",
+        "status_update",
+    )
+    return repo_path
 
 
-def _run_se_team(
+def _run_target_team(
     client: httpx.Client,
     agent: FounderAgent,
     store: FounderRunStore,
     run_id: str,
     repo_path: str,
+    adapter: TargetTeamAdapter,
     *,
     existing_job_id: str | None = None,
 ) -> bool:
-    """Start the SE team build and poll until complete. Returns True on success.
+    """Start the target-team build and poll until complete. Returns True on success."""
 
-    If ``existing_job_id`` is supplied (resume path), the submit step is
-    skipped and polling resumes against that SE job.
-    """
-    if existing_job_id is None:
-        store.update_run(run_id, status="submitting_build")
-        _sync_job_status(run_id, "running", phase="submitting_build")
+    def _on_started(job_id: str) -> None:
+        store.update_run(run_id, se_job_id=job_id)
 
-        resp = client.post(
-            _se_url("/run-team"),
-            json={"repo_path": repo_path},
-            timeout=HTTP_TIMEOUT,
-        )
-        if resp.status_code >= 400:
-            store.update_run(
-                run_id,
-                status="failed",
-                error=f"Failed to start SE team: {resp.status_code} {resp.text[:500]}",
-            )
-            _sync_job_status(run_id, "failed", error="Failed to start SE team")
-            return False
-
-        data = resp.json()
-        se_job_id = data.get("job_id")
-        store.update_run(run_id, se_job_id=se_job_id, status="polling_build")
-        _sync_job_status(run_id, "running", phase="polling_build")
-        logger.info("SE team build started: job_id=%s", se_job_id)
-        store.add_chat_message(
-            run_id, "system", f"SE team build started (job: {se_job_id})", "status_update"
-        )
-    else:
-        se_job_id = existing_job_id
-        store.update_run(run_id, status="polling_build", error=None)
-        _sync_job_status(run_id, "running", phase="polling_build")
-        logger.info("Resuming SE team build poll: job_id=%s", se_job_id)
-        store.add_chat_message(
-            run_id,
-            "system",
-            f"Resuming SE team build poll (job: {se_job_id})",
-            "status_update",
-        )
-
-    failed_question_sets: dict[frozenset[str], int] = {}
-
-    for _ in range(MAX_POLL_ATTEMPTS):
-        time.sleep(EXECUTION_POLL_INTERVAL)
-        _heartbeat(run_id)
-
-        resp = client.get(
-            _se_url(f"/run-team/{se_job_id}"),
-            timeout=HTTP_TIMEOUT,
-        )
-        if resp.status_code >= 400:
-            logger.warning("Build poll error: %s", resp.status_code)
-            continue
-
-        status_data = resp.json()
-        status = status_data.get("status", "")
-
-        # Answer pending questions
-        if status_data.get("waiting_for_answers") and status_data.get("pending_questions"):
-            pending = status_data["pending_questions"]
-            qset = frozenset(q.get("id", "") for q in pending)
-            prior_failures = failed_question_sets.get(qset, 0)
-
-            if prior_failures > MAX_ANSWER_RETRIES:
-                err = f"Answer submission failed {prior_failures} times for build questions. Aborting."
-                logger.error(err)
-                store.update_run(run_id, status="failed", error=err)
-                _sync_job_status(run_id, "failed", error=err)
-                store.add_chat_message(run_id, "system", err, "status_update")
-                return False
-
-            store.update_run(run_id, status="answering_build_questions")
-            store.add_chat_message(
-                run_id,
-                "system",
-                f"SE team has {len(pending)} question(s) during build.",
-                "question_received",
-                metadata={"question_ids": list(qset)},
-            )
-            success = _answer_pending_questions(
-                client,
-                agent,
-                store,
-                run_id,
-                se_job_id,
-                pending,
-                "/run-team",
-            )
-            if not success:
-                failed_question_sets[qset] = prior_failures + 1
-                logger.warning("Answer attempt %d failed for build questions", prior_failures + 1)
-            continue
-
-        if status == "completed":
-            logger.info("SE team build completed for run %s", run_id)
-            store.add_chat_message(
-                run_id, "system", "Build completed successfully.", "status_update"
-            )
-            return True
-
-        if status == "failed":
-            err = f"SE team build failed: {status_data.get('error', 'unknown')}"
-            store.update_run(run_id, status="failed", error=err)
-            _sync_job_status(run_id, "failed", error="SE team build failed")
-            store.add_chat_message(run_id, "system", err, "status_update")
-            return False
-
-        if status == "cancelled":
-            store.update_run(run_id, status="failed", error="SE team build was cancelled")
-            _sync_job_status(run_id, "failed", error="SE team build cancelled")
-            store.add_chat_message(
-                run_id, "system", "SE team build was cancelled.", "status_update"
-            )
-            return False
-
-    store.update_run(run_id, status="failed", error="SE team build timed out")
-    _sync_job_status(run_id, "failed", error="SE team build timed out")
-    store.add_chat_message(run_id, "system", "SE team build timed out.", "status_update")
-    return False
+    ok, _status_data = _run_phase(
+        client=client,
+        agent=agent,
+        store=store,
+        run_id=run_id,
+        phase="build",
+        poll_interval=EXECUTION_POLL_INTERVAL,
+        start_fn=lambda: adapter.start_build(client, repo_path),
+        poll_fn=lambda jid: adapter.poll_build(client, jid),
+        submit_answers_fn=lambda jid, answers: adapter.submit_build_answers(client, jid, answers),
+        on_started=_on_started,
+        existing_job_id=existing_job_id,
+        questions_status="answering_build_questions",
+        failure_label=f"{adapter.display_name} build",
+    )
+    if ok:
+        logger.info("%s build completed for run %s", adapter.display_name, run_id)
+        store.add_chat_message(run_id, "system", "Build completed successfully.", "status_update")
+    return ok
 
 
-def run_workflow(run_id: str, store: FounderRunStore, agent: FounderAgent) -> None:
+def run_workflow(
+    run_id: str,
+    store: FounderRunStore,
+    agent: FounderAgent,
+    adapter: TargetTeamAdapter | None = None,
+) -> None:
     """Execute the full founder workflow: spec -> analysis -> build.
 
+    ``adapter`` defaults to the team recorded on the run row's
+    ``target_team_key`` column (or the default if the column is empty).
     Re-entrant for the resume path: phases whose checkpoint columns are
     already populated on the run row are short-circuited so a `/resume`
     call does not re-pay the cost of completed phases (LLM spec gen,
     multi-hour analysis poll, etc.).
 
-    This function is designed to run in a background thread.
+    Designed to run in a background thread.
     """
     logger.info("Starting founder workflow: run_id=%s", run_id)
 
@@ -465,6 +429,12 @@ def run_workflow(run_id: str, store: FounderRunStore, agent: FounderAgent) -> No
         # the resume-short-circuit lookup gets caught by the failure handler
         # below rather than escaping the worker thread silently.
         run = store.get_run(run_id)
+
+        if adapter is None:
+            team_key = getattr(run, "target_team_key", None) or "software_engineering"
+            adapter = get_adapter(team_key)
+
+        project_name = f"user-agent-founder-{run_id}"
 
         # Phase 1: Generate the product spec (skip if already done)
         if run is not None and run.spec_content:
@@ -492,7 +462,8 @@ def run_workflow(run_id: str, store: FounderRunStore, agent: FounderAgent) -> No
             store.add_chat_message(
                 run_id,
                 "assistant",
-                f"Product spec generated ({len(spec_content)} chars). Submitting to SE team for analysis.",
+                f"Product spec generated ({len(spec_content)} chars). "
+                f"Submitting to {adapter.display_name} for analysis.",
                 "status_update",
             )
 
@@ -519,18 +490,21 @@ def run_workflow(run_id: str, store: FounderRunStore, agent: FounderAgent) -> No
                     store,
                     run_id,
                     spec_content,
+                    adapter,
+                    project_name,
                     existing_job_id=run.analysis_job_id if run is not None else None,
                 )
                 if repo_path is None:
                     return  # status already set to failed
 
-            # Phase 3: SE team build (skip submit if se_job_id stored)
-            success = _run_se_team(
+            # Phase 3: target-team build (skip submit if se_job_id stored)
+            success = _run_target_team(
                 client,
                 agent,
                 store,
                 run_id,
                 repo_path,
+                adapter,
                 existing_job_id=run.se_job_id if run is not None else None,
             )
             if success:

--- a/backend/agents/user_agent_founder/postgres/__init__.py
+++ b/backend/agents/user_agent_founder/postgres/__init__.py
@@ -13,16 +13,22 @@ SCHEMA = TeamSchema(
     database=None,
     statements=[
         """CREATE TABLE IF NOT EXISTS user_agent_founder_runs (
-            run_id          TEXT PRIMARY KEY,
-            status          TEXT NOT NULL DEFAULT 'pending',
-            se_job_id       TEXT,
-            analysis_job_id TEXT,
-            spec_content    TEXT,
-            repo_path       TEXT,
-            created_at      TIMESTAMPTZ NOT NULL,
-            updated_at      TIMESTAMPTZ NOT NULL,
-            error           TEXT
+            run_id           TEXT PRIMARY KEY,
+            status           TEXT NOT NULL DEFAULT 'pending',
+            se_job_id        TEXT,
+            analysis_job_id  TEXT,
+            spec_content     TEXT,
+            repo_path        TEXT,
+            target_team_key  TEXT NOT NULL DEFAULT 'software_engineering',
+            created_at       TIMESTAMPTZ NOT NULL,
+            updated_at       TIMESTAMPTZ NOT NULL,
+            error            TEXT
         )""",
+        # Idempotent migration for existing deployments where the table
+        # was created before this column existed.
+        """ALTER TABLE user_agent_founder_runs
+            ADD COLUMN IF NOT EXISTS target_team_key TEXT
+            NOT NULL DEFAULT 'software_engineering'""",
         """CREATE TABLE IF NOT EXISTS user_agent_founder_decisions (
             id             BIGSERIAL PRIMARY KEY,
             run_id         TEXT NOT NULL,

--- a/backend/agents/user_agent_founder/store.py
+++ b/backend/agents/user_agent_founder/store.py
@@ -41,9 +41,12 @@ _UPDATE_ALLOWED_COLUMNS = frozenset(
         "analysis_job_id",
         "spec_content",
         "repo_path",
+        "target_team_key",
         "error",
     }
 )
+
+DEFAULT_TARGET_TEAM_KEY = "software_engineering"
 
 
 def _row_ts(value: Any) -> str:
@@ -65,6 +68,7 @@ class StoredRun:
     analysis_job_id: str | None
     spec_content: str | None
     repo_path: str | None
+    target_team_key: str
     created_at: str
     updated_at: str
     error: str | None
@@ -100,6 +104,7 @@ def _row_to_run(row: dict[str, Any]) -> StoredRun:
         analysis_job_id=row["analysis_job_id"],
         spec_content=row["spec_content"],
         repo_path=row["repo_path"],
+        target_team_key=row.get("target_team_key") or DEFAULT_TARGET_TEAM_KEY,
         created_at=_row_ts(row["created_at"]),
         updated_at=_row_ts(row["updated_at"]),
         error=row["error"],
@@ -120,14 +125,15 @@ class FounderRunStore:
         pass
 
     @timed_query(store=_STORE, op="create_run")
-    def create_run(self) -> str:
+    def create_run(self, target_team_key: str = DEFAULT_TARGET_TEAM_KEY) -> str:
         run_id = str(uuid4())
         now = datetime.now(tz=timezone.utc)
         with get_conn() as conn, conn.cursor() as cur:
             cur.execute(
                 "INSERT INTO user_agent_founder_runs "
-                "(run_id, status, created_at, updated_at) VALUES (%s, %s, %s, %s)",
-                (run_id, "pending", now, now),
+                "(run_id, status, target_team_key, created_at, updated_at) "
+                "VALUES (%s, %s, %s, %s, %s)",
+                (run_id, "pending", target_team_key, now, now),
             )
         return run_id
 
@@ -136,7 +142,7 @@ class FounderRunStore:
         with get_conn() as conn, conn.cursor(row_factory=dict_row) as cur:
             cur.execute(
                 "SELECT run_id, status, se_job_id, analysis_job_id, spec_content, "
-                "repo_path, created_at, updated_at, error "
+                "repo_path, target_team_key, created_at, updated_at, error "
                 "FROM user_agent_founder_runs WHERE run_id = %s",
                 (run_id,),
             )
@@ -223,7 +229,7 @@ class FounderRunStore:
         with get_conn() as conn, conn.cursor(row_factory=dict_row) as cur:
             cur.execute(
                 "SELECT run_id, status, se_job_id, analysis_job_id, spec_content, "
-                "repo_path, created_at, updated_at, error "
+                "repo_path, target_team_key, created_at, updated_at, error "
                 "FROM user_agent_founder_runs ORDER BY created_at DESC"
             )
             return [_row_to_run(r) for r in cur.fetchall()]

--- a/backend/agents/user_agent_founder/targets/__init__.py
+++ b/backend/agents/user_agent_founder/targets/__init__.py
@@ -1,0 +1,39 @@
+"""Target-team adapter registry.
+
+The founder orchestrator looks up the adapter for a run by
+``target_team_key``; each adapter satisfies the
+``TargetTeamAdapter`` Protocol from ``base.py``.
+"""
+
+from __future__ import annotations
+
+from user_agent_founder.targets.base import StartFailed, TargetTeamAdapter
+from user_agent_founder.targets.software_engineering import SoftwareEngineeringAdapter
+
+DEFAULT_TARGET_TEAM_KEY = "software_engineering"
+
+ADAPTERS: dict[str, type[TargetTeamAdapter]] = {
+    DEFAULT_TARGET_TEAM_KEY: SoftwareEngineeringAdapter,
+}
+
+
+def get_adapter(team_key: str) -> TargetTeamAdapter:
+    """Return a fresh adapter instance for ``team_key``.
+
+    Raises ``ValueError`` for an unknown team — the registry is the
+    single source of truth for which teams the persona framework can
+    drive.
+    """
+    if team_key not in ADAPTERS:
+        raise ValueError(f"Team {team_key!r} does not support persona testing")
+    return ADAPTERS[team_key]()
+
+
+__all__ = [
+    "ADAPTERS",
+    "DEFAULT_TARGET_TEAM_KEY",
+    "SoftwareEngineeringAdapter",
+    "StartFailed",
+    "TargetTeamAdapter",
+    "get_adapter",
+]

--- a/backend/agents/user_agent_founder/targets/base.py
+++ b/backend/agents/user_agent_founder/targets/base.py
@@ -1,0 +1,46 @@
+"""TargetTeamAdapter Protocol.
+
+Lifts team-specific HTTP coupling out of the founder orchestrator. Each
+adapter wraps a target team's start/poll/answer endpoints behind the
+same shape, so the orchestrator can drive any registered team without
+hardcoding URLs. Defined verbatim in
+``system_design/FEATURE_SPEC_testing_personas.md`` §4.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol, runtime_checkable
+
+import httpx
+
+
+class StartFailed(RuntimeError):
+    """Raised by an adapter's ``start_*`` method when the target team's
+    submit endpoint returns an HTTP error.
+
+    Lives in ``base.py`` so the orchestrator can catch a single
+    adapter-agnostic exception without reaching into a specific
+    adapter's internals.
+    """
+
+    def __init__(self, status_code: int, body: str) -> None:
+        super().__init__(f"{status_code} {body[:500]}")
+        self.status_code = status_code
+        self.body = body
+
+
+@runtime_checkable
+class TargetTeamAdapter(Protocol):
+    team_key: str
+    display_name: str
+
+    def start_from_spec(self, client: httpx.Client, project_name: str, spec: str) -> str: ...
+    def poll_analysis(self, client: httpx.Client, job_id: str) -> dict[str, Any]: ...
+    def submit_analysis_answers(
+        self, client: httpx.Client, job_id: str, answers: list[dict[str, Any]]
+    ) -> None: ...
+    def start_build(self, client: httpx.Client, repo_path: str) -> str: ...
+    def poll_build(self, client: httpx.Client, job_id: str) -> dict[str, Any]: ...
+    def submit_build_answers(
+        self, client: httpx.Client, job_id: str, answers: list[dict[str, Any]]
+    ) -> None: ...

--- a/backend/agents/user_agent_founder/targets/software_engineering.py
+++ b/backend/agents/user_agent_founder/targets/software_engineering.py
@@ -1,0 +1,91 @@
+"""SoftwareEngineeringAdapter — wraps the SE team's start/poll/answer endpoints."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import httpx
+
+from user_agent_founder.targets.base import StartFailed
+
+UNIFIED_API_BASE = os.environ.get("UNIFIED_API_BASE_URL", "http://localhost:8080")
+SE_PREFIX = "/api/software-engineering"
+
+HTTP_TIMEOUT = httpx.Timeout(30.0, connect=10.0)
+
+
+class SoftwareEngineeringAdapter:
+    """Adapter for the Software Engineering team.
+
+    Wraps the existing endpoints under ``/api/software-engineering`` —
+    no SE-side changes required.
+    """
+
+    team_key = "software_engineering"
+    display_name = "Software Engineering"
+
+    def _url(self, path: str) -> str:
+        return f"{UNIFIED_API_BASE}{SE_PREFIX}{path}"
+
+    # ── Phase 2: product analysis ─────────────────────────────────────
+
+    def start_from_spec(self, client: httpx.Client, project_name: str, spec: str) -> str:
+        resp = client.post(
+            self._url("/product-analysis/start-from-spec"),
+            json={"project_name": project_name, "spec_content": spec},
+            timeout=HTTP_TIMEOUT,
+        )
+        if resp.status_code >= 400:
+            raise StartFailed(resp.status_code, resp.text)
+        return resp.json().get("job_id", "")
+
+    def poll_analysis(self, client: httpx.Client, job_id: str) -> dict[str, Any]:
+        resp = client.get(
+            self._url(f"/product-analysis/status/{job_id}"),
+            timeout=HTTP_TIMEOUT,
+        )
+        if resp.status_code >= 400:
+            return {"_poll_error": resp.status_code}
+        return resp.json()
+
+    def submit_analysis_answers(
+        self, client: httpx.Client, job_id: str, answers: list[dict[str, Any]]
+    ) -> None:
+        resp = client.post(
+            self._url(f"/product-analysis/{job_id}/answers"),
+            json={"answers": answers},
+            timeout=HTTP_TIMEOUT,
+        )
+        resp.raise_for_status()
+
+    # ── Phase 3: build ────────────────────────────────────────────────
+
+    def start_build(self, client: httpx.Client, repo_path: str) -> str:
+        resp = client.post(
+            self._url("/run-team"),
+            json={"repo_path": repo_path},
+            timeout=HTTP_TIMEOUT,
+        )
+        if resp.status_code >= 400:
+            raise StartFailed(resp.status_code, resp.text)
+        return resp.json().get("job_id", "")
+
+    def poll_build(self, client: httpx.Client, job_id: str) -> dict[str, Any]:
+        resp = client.get(
+            self._url(f"/run-team/{job_id}"),
+            timeout=HTTP_TIMEOUT,
+        )
+        if resp.status_code >= 400:
+            return {"_poll_error": resp.status_code}
+        return resp.json()
+
+    def submit_build_answers(
+        self, client: httpx.Client, job_id: str, answers: list[dict[str, Any]]
+    ) -> None:
+        resp = client.post(
+            self._url(f"/run-team/{job_id}/answers"),
+            json={"answers": answers},
+            timeout=HTTP_TIMEOUT,
+        )
+        resp.raise_for_status()

--- a/backend/agents/user_agent_founder/temporal/__init__.py
+++ b/backend/agents/user_agent_founder/temporal/__init__.py
@@ -24,6 +24,8 @@ def run_pipeline_activity(run_id: str) -> dict[str, Any]:
 
     store = get_founder_store()
     agent = FounderAgent()
+    # run_workflow resolves the adapter from the run row's target_team_key
+    # when none is supplied — keeps this boundary thin.
     run_workflow(run_id, store, agent)
     return {"run_id": run_id}
 

--- a/backend/agents/user_agent_founder/tests/test_adapter_se.py
+++ b/backend/agents/user_agent_founder/tests/test_adapter_se.py
@@ -1,0 +1,328 @@
+"""Contract tests for ``SoftwareEngineeringAdapter`` and the registry.
+
+Locks three things:
+1. The adapter satisfies the ``TargetTeamAdapter`` Protocol shape.
+2. URL construction matches the SE team's actual endpoint paths so the
+   refactor doesn't silently drift from the contract.
+3. The orchestrator handles ``status="cancelled"`` symmetrically across
+   both phases — historically the analysis phase ignored cancellation
+   and burned ~4h of polling.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Reusable test doubles (mirror test_orchestrator_resume.py shapes)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeRun:
+    run_id: str
+    status: str = "running"
+    se_job_id: str | None = None
+    analysis_job_id: str | None = None
+    spec_content: str | None = None
+    repo_path: str | None = None
+    target_team_key: str = "software_engineering"
+    created_at: str = "2026-04-25T00:00:00+00:00"
+    updated_at: str = "2026-04-25T00:00:00+00:00"
+    error: str | None = None
+
+
+class _FakeStore:
+    def __init__(self, run: _FakeRun) -> None:
+        self._run = run
+        self.update_calls: list[dict[str, Any]] = []
+        self.chat_messages: list[dict[str, Any]] = []
+
+    def get_run(self, run_id: str) -> _FakeRun | None:
+        return self._run if self._run.run_id == run_id else None
+
+    def update_run(self, run_id: str, **fields: Any) -> bool:
+        self.update_calls.append({"run_id": run_id, **fields})
+        for k, v in fields.items():
+            setattr(self._run, k, v)
+        return True
+
+    def add_chat_message(
+        self,
+        run_id: str,
+        role: str,
+        content: str,
+        message_type: str = "",
+        *,
+        metadata: Any = None,
+    ) -> None:
+        self.chat_messages.append(
+            {"run_id": run_id, "role": role, "content": content, "type": message_type}
+        )
+
+    def add_decision(self, **fields: Any) -> None:
+        pass
+
+
+class _FakeResponse:
+    def __init__(
+        self, status_code: int = 200, json_data: dict | None = None, text: str = ""
+    ) -> None:
+        self.status_code = status_code
+        self._json = json_data or {}
+        self.text = text
+
+    def json(self) -> dict:
+        return self._json
+
+    def raise_for_status(self) -> None:
+        if self.status_code >= 400:
+            import httpx
+
+            raise httpx.HTTPStatusError(
+                f"{self.status_code}", request=MagicMock(), response=MagicMock(self)
+            )
+
+
+class _FakeHttpxClient:
+    """Records every POST/GET; returns scripted responses keyed by URL substring."""
+
+    def __init__(
+        self,
+        post_responses: dict[str, _FakeResponse] | None = None,
+        get_responses: dict[str, list[_FakeResponse]] | None = None,
+    ) -> None:
+        self.post_responses = post_responses or {}
+        self.get_responses = get_responses or {}
+        self._get_indices: dict[str, int] = {}
+        self.posts: list[dict[str, Any]] = []
+        self.gets: list[dict[str, Any]] = []
+
+    def __enter__(self) -> "_FakeHttpxClient":
+        return self
+
+    def __exit__(self, *exc: Any) -> None:
+        return None
+
+    def post(self, url: str, *, json: dict | None = None, timeout: Any = None) -> _FakeResponse:
+        self.posts.append({"url": url, "json": json})
+        for needle, resp in self.post_responses.items():
+            if needle in url:
+                return resp
+        return _FakeResponse(200, {"job_id": "default-job"})
+
+    def get(self, url: str, *, timeout: Any = None) -> _FakeResponse:
+        self.gets.append({"url": url})
+        for needle, queue in self.get_responses.items():
+            if needle in url:
+                idx = self._get_indices.get(needle, 0)
+                if idx >= len(queue):
+                    return queue[-1]
+                self._get_indices[needle] = idx + 1
+                return queue[idx]
+        return _FakeResponse(200, {"status": "completed"})
+
+
+@pytest.fixture
+def stub_orchestrator_io(monkeypatch):
+    from user_agent_founder import orchestrator
+
+    monkeypatch.setattr(orchestrator.time, "sleep", lambda _s: None)
+    monkeypatch.setattr(orchestrator, "ANALYSIS_POLL_INTERVAL", 0)
+    monkeypatch.setattr(orchestrator, "EXECUTION_POLL_INTERVAL", 0)
+    monkeypatch.setattr(orchestrator, "SPEC_HEARTBEAT_INTERVAL", 0.01)
+    monkeypatch.setattr(orchestrator, "_sync_job_status", lambda *a, **kw: None)
+    monkeypatch.setattr(orchestrator, "_heartbeat", lambda _rid: None)
+    return orchestrator
+
+
+# ---------------------------------------------------------------------------
+# Protocol contract
+# ---------------------------------------------------------------------------
+
+
+def test_software_engineering_adapter_satisfies_protocol():
+    from user_agent_founder.targets import SoftwareEngineeringAdapter, TargetTeamAdapter
+
+    adapter = SoftwareEngineeringAdapter()
+    # ``TargetTeamAdapter`` is ``runtime_checkable`` so this is a real
+    # structural check, not just a type-hint formality.
+    assert isinstance(adapter, TargetTeamAdapter)
+    assert adapter.team_key == "software_engineering"
+    assert adapter.display_name
+
+
+def test_registry_returns_fresh_instance_per_call():
+    from user_agent_founder.targets import get_adapter
+
+    a = get_adapter("software_engineering")
+    b = get_adapter("software_engineering")
+    assert a is not b  # fresh instance, no cross-run state leakage
+    assert type(a) is type(b)
+
+
+def test_registry_rejects_unknown_team():
+    from user_agent_founder.targets import get_adapter
+
+    with pytest.raises(ValueError, match="does not support persona testing"):
+        get_adapter("nonexistent_team")
+
+
+# ---------------------------------------------------------------------------
+# URL construction — locks the SE-side contract
+# ---------------------------------------------------------------------------
+
+
+def test_start_from_spec_hits_correct_endpoint():
+    from user_agent_founder.targets import SoftwareEngineeringAdapter
+
+    adapter = SoftwareEngineeringAdapter()
+    fake = _FakeHttpxClient(
+        post_responses={
+            "/product-analysis/start-from-spec": _FakeResponse(200, {"job_id": "a-1"}),
+        }
+    )
+    job_id = adapter.start_from_spec(fake, "proj", "# spec body")
+    assert job_id == "a-1"
+    assert fake.posts[0]["url"].endswith(
+        "/api/software-engineering/product-analysis/start-from-spec"
+    )
+    assert fake.posts[0]["json"] == {"project_name": "proj", "spec_content": "# spec body"}
+
+
+def test_start_from_spec_raises_on_http_error():
+    from user_agent_founder.targets import SoftwareEngineeringAdapter, StartFailed
+
+    adapter = SoftwareEngineeringAdapter()
+    fake = _FakeHttpxClient(
+        post_responses={
+            "/product-analysis/start-from-spec": _FakeResponse(500, {}, text="boom"),
+        }
+    )
+    with pytest.raises(StartFailed) as excinfo:
+        adapter.start_from_spec(fake, "proj", "spec")
+    assert excinfo.value.status_code == 500
+
+
+def test_start_build_hits_correct_endpoint():
+    from user_agent_founder.targets import SoftwareEngineeringAdapter
+
+    adapter = SoftwareEngineeringAdapter()
+    fake = _FakeHttpxClient(post_responses={"/run-team": _FakeResponse(200, {"job_id": "se-9"})})
+    job_id = adapter.start_build(fake, "/repos/x")
+    assert job_id == "se-9"
+    assert fake.posts[0]["url"].endswith("/api/software-engineering/run-team")
+    assert fake.posts[0]["json"] == {"repo_path": "/repos/x"}
+
+
+def test_poll_methods_return_dict_and_signal_http_errors():
+    from user_agent_founder.targets import SoftwareEngineeringAdapter
+
+    adapter = SoftwareEngineeringAdapter()
+    fake = _FakeHttpxClient(
+        get_responses={
+            "/product-analysis/status/job-1": [_FakeResponse(200, {"status": "running"})],
+            "/run-team/job-2": [_FakeResponse(503, {})],
+        }
+    )
+    assert adapter.poll_analysis(fake, "job-1") == {"status": "running"}
+    payload = adapter.poll_build(fake, "job-2")
+    assert payload.get("_poll_error") == 503
+
+
+def test_submit_answers_post_to_correct_endpoints():
+    from user_agent_founder.targets import SoftwareEngineeringAdapter
+
+    adapter = SoftwareEngineeringAdapter()
+    fake = _FakeHttpxClient(
+        post_responses={
+            "/product-analysis/job-1/answers": _FakeResponse(200),
+            "/run-team/job-2/answers": _FakeResponse(200),
+        }
+    )
+    answers = [{"question_id": "q1", "selected_option_id": "a"}]
+    adapter.submit_analysis_answers(fake, "job-1", answers)
+    adapter.submit_build_answers(fake, "job-2", answers)
+    urls = [p["url"] for p in fake.posts]
+    assert any(u.endswith("/api/software-engineering/product-analysis/job-1/answers") for u in urls)
+    assert any(u.endswith("/api/software-engineering/run-team/job-2/answers") for u in urls)
+
+
+# ---------------------------------------------------------------------------
+# Symmetric cancellation handling — the bug this issue fixes
+# ---------------------------------------------------------------------------
+
+
+def _install_httpx(monkeypatch, orchestrator, fake_client) -> None:
+    monkeypatch.setattr(orchestrator.httpx, "Client", lambda *a, **kw: fake_client)
+
+
+def test_analysis_phase_aborts_on_cancelled_status(stub_orchestrator_io, monkeypatch):
+    """Pre-fix: the analysis poll ignored ``cancelled`` and burned ~4h
+    of MAX_POLL_ATTEMPTS before timing out. After this refactor, both
+    phases share one helper that handles ``cancelled`` in one place."""
+    from user_agent_founder.targets import SoftwareEngineeringAdapter
+
+    orchestrator = stub_orchestrator_io
+    run = _FakeRun(run_id="run-cancel-analysis")
+    store = _FakeStore(run)
+    agent = MagicMock()
+    agent.generate_spec.return_value = "# spec"
+
+    fake = _FakeHttpxClient(
+        post_responses={
+            "/product-analysis/start-from-spec": _FakeResponse(200, {"job_id": "a-1"}),
+        },
+        get_responses={
+            # Single cancelled response — the loop must abort within one tick,
+            # not consume MAX_POLL_ATTEMPTS.
+            "/product-analysis/status/": [_FakeResponse(200, {"status": "cancelled"})],
+        },
+    )
+    _install_httpx(monkeypatch, orchestrator, fake)
+
+    orchestrator.run_workflow("run-cancel-analysis", store, agent, SoftwareEngineeringAdapter())
+
+    assert run.status == "failed"
+    assert run.error and "cancelled" in run.error.lower()
+    # Critically: SE build was never started — cancel aborted Phase 2.
+    assert not any("/run-team" in p["url"] for p in fake.posts)
+    # And we polled at most a couple of times, not hundreds.
+    analysis_polls = [g for g in fake.gets if "/product-analysis/status/" in g["url"]]
+    assert len(analysis_polls) <= 3, (
+        f"Expected analysis poll to abort on cancelled, got {len(analysis_polls)} polls"
+    )
+
+
+def test_build_phase_aborts_on_cancelled_status(stub_orchestrator_io, monkeypatch):
+    """Regression: the build phase already handled cancelled — keep it that way."""
+    from user_agent_founder.targets import SoftwareEngineeringAdapter
+
+    orchestrator = stub_orchestrator_io
+    run = _FakeRun(
+        run_id="run-cancel-build",
+        spec_content="# spec",
+        analysis_job_id="a-1",
+        repo_path="/repos/run-cancel-build",
+    )
+    store = _FakeStore(run)
+    agent = MagicMock()
+
+    fake = _FakeHttpxClient(
+        post_responses={"/run-team": _FakeResponse(200, {"job_id": "se-1"})},
+        get_responses={"/run-team/": [_FakeResponse(200, {"status": "cancelled"})]},
+    )
+    _install_httpx(monkeypatch, orchestrator, fake)
+
+    orchestrator.run_workflow("run-cancel-build", store, agent, SoftwareEngineeringAdapter())
+
+    assert run.status == "failed"
+    assert run.error and "cancelled" in run.error.lower()
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/backend/agents/user_agent_founder/tests/test_jobs_endpoints.py
+++ b/backend/agents/user_agent_founder/tests/test_jobs_endpoints.py
@@ -153,6 +153,27 @@ def test_start_creates_job_and_dispatches(fake_job_store, fake_store, fake_dispa
         )
     ]
     assert fake_job_store.jobs["run-123"]["status"] == "running"
+    # Default target_team_key is recorded on create_run.
+    fake_store.create_run.assert_called_once_with(target_team_key="software_engineering")
+
+
+def test_start_passes_explicit_target_team_key_through(fake_job_store, fake_store, fake_dispatch):
+    from user_agent_founder.api.main import StartRunRequest, start_founder_workflow
+
+    resp = start_founder_workflow(StartRunRequest(target_team_key="software_engineering"))
+
+    assert resp.job_id == "run-123"
+    fake_store.create_run.assert_called_once_with(target_team_key="software_engineering")
+
+
+def test_start_rejects_unknown_target_team_key(fake_job_store, fake_store, fake_dispatch):
+    from user_agent_founder.api.main import StartRunRequest, start_founder_workflow
+
+    with pytest.raises(HTTPException) as excinfo:
+        start_founder_workflow(StartRunRequest(target_team_key="not_a_real_team"))
+    assert excinfo.value.status_code == 400
+    # No dispatch when validation rejects the request.
+    assert fake_dispatch == []
 
 
 def test_start_marks_job_failed_when_dispatch_raises(fake_job_store, fake_store, monkeypatch):

--- a/backend/agents/user_agent_founder/tests/test_orchestrator_resume.py
+++ b/backend/agents/user_agent_founder/tests/test_orchestrator_resume.py
@@ -32,6 +32,7 @@ class _FakeRun:
     analysis_job_id: str | None = None
     spec_content: str | None = None
     repo_path: str | None = None
+    target_team_key: str = "software_engineering"
     created_at: str = "2026-04-25T00:00:00+00:00"
     updated_at: str = "2026-04-25T00:00:00+00:00"
     error: str | None = None

--- a/backend/agents/user_agent_founder/tests/test_store.py
+++ b/backend/agents/user_agent_founder/tests/test_store.py
@@ -43,7 +43,7 @@ class _FakeCursor:
 
         # INSERT into runs
         if sql_l.startswith("insert into user_agent_founder_runs"):
-            run_id, status, created_at, updated_at = params
+            run_id, status, target_team_key, created_at, updated_at = params
             self._db["runs"][run_id] = {
                 "run_id": run_id,
                 "status": status,
@@ -51,6 +51,7 @@ class _FakeCursor:
                 "analysis_job_id": None,
                 "spec_content": None,
                 "repo_path": None,
+                "target_team_key": target_team_key,
                 "created_at": created_at,
                 "updated_at": updated_at,
                 "error": None,
@@ -171,8 +172,27 @@ def test_create_run_returns_uuid_and_inserts_pending_row(store, fake_pg):
     assert row["status"] == "pending"
     assert row["se_job_id"] is None
     assert row["spec_content"] is None
+    assert row["target_team_key"] == "software_engineering"
     assert isinstance(row["created_at"], datetime)
     assert row["created_at"].tzinfo is timezone.utc
+
+
+def test_create_run_persists_explicit_target_team_key(store, fake_pg):
+    run_id = store.create_run(target_team_key="some_other_team")
+    assert fake_pg["runs"][run_id]["target_team_key"] == "some_other_team"
+
+
+def test_get_run_exposes_target_team_key(store):
+    run_id = store.create_run(target_team_key="software_engineering")
+    run = store.get_run(run_id)
+    assert run is not None
+    assert run.target_team_key == "software_engineering"
+
+
+def test_update_run_can_change_target_team_key(store, fake_pg):
+    run_id = store.create_run()
+    assert store.update_run(run_id, target_team_key="new_team") is True
+    assert fake_pg["runs"][run_id]["target_team_key"] == "new_team"
 
 
 def test_get_run_returns_stored_run_dataclass(store):


### PR DESCRIPTION
Closes #261.

## Summary

- Lifts SE-specific HTTP coupling out of `user_agent_founder/orchestrator.py` into a new `targets/` package implementing the `TargetTeamAdapter` Protocol from `FEATURE_SPEC_testing_personas.md` §4.
- Collapses the duplicate `_run_product_analysis` and `_run_se_team` loops into a single `_run_phase` helper. All four terminal states (`completed` / `failed` / `cancelled` / timeout) are now handled in one place.
- **Bug fix:** the analysis phase used to ignore `status="cancelled"` and burn ~4h of `MAX_POLL_ATTEMPTS × ANALYSIS_POLL_INTERVAL` before timing out. Both phases now share one cancellation check.
- Adds a `target_team_key` column to `user_agent_founder_runs` (defaulting to `software_engineering`); `get_run_artifacts` resolves the adapter from this column instead of hardcoding the SE prefix.
- `grep '/api/software-engineering\|/product-analysis\|/run-team' orchestrator.py api/main.py` now returns 0 hits — every SE URL lives in `targets/software_engineering.py`.

## What changed

| File | Change |
|---|---|
| `targets/base.py` | new — `TargetTeamAdapter` Protocol + `StartFailed` |
| `targets/software_engineering.py` | new — `SoftwareEngineeringAdapter` wraps existing SE endpoints |
| `targets/__init__.py` | new — `ADAPTERS` registry + `get_adapter()` |
| `orchestrator.py` | single `_run_phase` helper; `run_workflow` accepts `adapter`; SE URLs gone |
| `api/main.py` | new `StartRunRequest` body w/ `target_team_key`; `get_run_artifacts` uses adapter; SE_PREFIX removed |
| `store.py` + `postgres/__init__.py` | `target_team_key` column (default `software_engineering`) + idempotent ALTER |
| `tests/test_adapter_se.py` | new — Protocol contract, URL construction, **cancelled-on-analysis regression test** |
| `tests/test_orchestrator_resume.py`, `test_jobs_endpoints.py`, `test_store.py` | round-trip + dispatch coverage for the new column |

## Test plan

- [x] `pytest backend/agents/user_agent_founder/tests/` — 77 passed (10 new in `test_adapter_se.py`).
- [x] New regression test asserts the analysis phase aborts within ≤3 polls on `status="cancelled"` (would loop ~480× before this PR).
- [x] `ruff check` + `ruff format --check` clean.
- [ ] End-to-end smoke against the unified API + Postgres (start run → completed → `GET /runs/{id}/artifacts`).

Plan: `/root/.claude/plans/write-plan-for-261-serialized-meerkat.md`

https://claude.ai/code/session_01YBpA6HvVAMhdyw2PfV9u5y

---
_Generated by [Claude Code](https://claude.ai/code/session_01YBpA6HvVAMhdyw2PfV9u5y)_