### PR TITLE
product_delivery: persistent backlog + ProductOwnerAgent (#243 phase 1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,11 @@ backend/
     llm_service/             # Centralized LLM client (Ollama, Claude)
     agent_registry/          # Agent Console catalog: loads per-agent YAML manifests, serves /api/agents
     agent_console/           # Agent Console Phase 3: Postgres-backed saved inputs, run history, diff, pruner
+    product_delivery/        # Phase 1 of the persistent Product Delivery Loop (#243): Postgres-backed
+                             # backlog (products → initiatives → epics → stories → tasks + acceptance
+                             # criteria + feedback_items), ProductOwnerAgent (WSJF/RICE), routes under
+                             # /api/product-delivery. In-process module mounted by unified_api (not a
+                             # proxy team). Sprints/releases/UI ship in follow-up issues.
     shared_agent_invoke/     # Invoke shim mounted inside the sandbox image; exposes POST /_agents/{id}/invoke
     integrations/            # Shared integration contracts (Google login, Medium, etc.)
     artifact_registry/       # Shared artifact persistence

--- a/backend/agents/product_delivery/README.md
+++ b/backend/agents/product_delivery/README.md
@@ -1,0 +1,101 @@
+# Product Delivery (Phase 1)
+
+Persistent product backlog + Product Owner grooming. Phase 1 of issue
+[#243](https://github.com/brandonkindred/khala-agentic-ai-teams/issues/243)
+("SE team: persistent Product Delivery Loop"), recommendation #1 from
+the Principal-Engineer SDLC review.
+
+## What lands in this PR
+
+- Postgres schema (`product_delivery_*` tables) registered via
+  `shared_postgres` Pattern B at unified-API startup.
+- `ProductDeliveryStore` — stateless DAL mirroring `agent_console.store`.
+- `ProductOwnerAgent` — ranks stories with **WSJF** or **RICE**. The
+  agent only asks the LLM for *scoring inputs*; the score itself is
+  computed by the deterministic functions in `scoring.py`, so a
+  re-groom over the same backlog produces stable, auditable numbers.
+- Routes under `/api/product-delivery` (mounted in-process by the
+  unified API; this team is **not** a proxy team).
+
+## What's deferred to follow-up issues
+
+- `sprints` + `releases` tables and the sprint-planner phase that gates
+  the existing SE Discovery → Design → Execution → Integration pipeline
+  (so `POST /api/software-engineering/run-team` can accept `{sprint_id}`
+  instead of a fresh spec every time).
+- `ReleaseManagerAgent` + release-notes generation hooked into
+  Integration.
+- Agent Console "Backlog" and "Sprints" tabs (Angular).
+- `ARCHITECTURE.md` "Product Delivery Loop" section (lands with the SE
+  pipeline integration above).
+
+## Schema
+
+```
+products
+  └── initiatives
+        └── epics
+              └── stories ── tasks
+                          ── acceptance_criteria
+feedback_items   (linked_story_id NULL when not yet triaged)
+```
+
+Every row carries:
+
+- `id TEXT PRIMARY KEY` — UUID4 hex assigned by the store.
+- `author TEXT NOT NULL` — handle from
+  `agent_console.author.resolve_author()`. When real auth lands we can
+  migrate both `agent_console` and `product_delivery` rows to user ids
+  in a single pass.
+- `created_at` / `updated_at TIMESTAMPTZ`.
+
+`status` is a free-form `TEXT` column (no Postgres `ENUM`) so adding a
+state like `"in_sprint"` later is a no-op.
+
+## API surface
+
+```
+POST   /api/product-delivery/products
+GET    /api/product-delivery/products
+GET    /api/product-delivery/products/{id}/backlog          (nested tree)
+
+POST   /api/product-delivery/initiatives
+POST   /api/product-delivery/epics
+POST   /api/product-delivery/stories
+POST   /api/product-delivery/tasks
+POST   /api/product-delivery/acceptance-criteria
+
+PATCH  /api/product-delivery/{kind}/{id}/status
+PATCH  /api/product-delivery/{kind}/{id}/scores
+
+POST   /api/product-delivery/groom                          (WSJF or RICE)
+POST   /api/product-delivery/feedback
+GET    /api/product-delivery/feedback?product_id=…&status=open
+```
+
+## Local smoke test
+
+```bash
+docker compose -f docker/docker-compose.yml up -d postgres job-service
+export POSTGRES_HOST=localhost POSTGRES_PORT=5432 \
+       POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres POSTGRES_DB=postgres \
+       JOB_SERVICE_URL=http://localhost:8085
+cd backend && make run
+
+curl -sX POST localhost:8080/api/product-delivery/products \
+  -H 'content-type: application/json' \
+  -d '{"name":"Demo","description":"smoke","vision":"ship it"}'
+
+# Then create initiative → epic → story → groom.
+psql -h localhost -U postgres -c "\dt product_delivery_*"
+```
+
+## Testing
+
+- `tests/test_scoring.py` — pure-function unit tests for WSJF / RICE.
+- `tests/test_product_owner_agent.py` — agent with stubbed LLM client.
+- `tests/test_api.py` — FastAPI routes with the store overridden via
+  `app.dependency_overrides`-style monkeypatch on `get_store`.
+- `tests/test_store.py` — integration tests against a live Postgres,
+  auto-skipped when `POSTGRES_HOST` is unset (matches the agent_console
+  pattern).

--- a/backend/agents/product_delivery/__init__.py
+++ b/backend/agents/product_delivery/__init__.py
@@ -29,6 +29,7 @@ from product_delivery.models import (
 )
 from product_delivery.scoring import rice_score, wsjf_score
 from product_delivery.store import (
+    CrossProductFeedbackLink,
     ProductDeliveryStorageUnavailable,
     ProductDeliveryStore,
     UnknownProductDeliveryEntity,
@@ -38,6 +39,7 @@ from product_delivery.store import (
 __all__ = [
     "AcceptanceCriterion",
     "BacklogTree",
+    "CrossProductFeedbackLink",
     "Epic",
     "FeedbackItem",
     "GroomRequest",

--- a/backend/agents/product_delivery/__init__.py
+++ b/backend/agents/product_delivery/__init__.py
@@ -1,0 +1,57 @@
+"""Product Delivery — persistent backlog, grooming, and feedback intake.
+
+Phase 1 of issue #243 (Principal-Engineer SDLC review, recommendation #1).
+The team owns a product hierarchy that survives across SE jobs:
+
+* Postgres-backed ``products → initiatives → epics → stories → tasks``
+  plus ``acceptance_criteria`` and ``feedback_items``.
+* :class:`ProductOwnerAgent` ranks the backlog with WSJF and RICE.
+* CRUD + grooming routes live under ``/api/product-delivery`` (mounted
+  in-process by ``unified_api``; this team is *not* a proxy team).
+
+Sprints, releases, the SE pipeline integration, the ReleaseManagerAgent,
+and the Agent Console UI tabs ship in follow-up issues.
+"""
+
+from product_delivery.author import resolve_author
+from product_delivery.models import (
+    AcceptanceCriterion,
+    BacklogTree,
+    Epic,
+    FeedbackItem,
+    GroomRequest,
+    GroomResult,
+    Initiative,
+    Product,
+    RankedBacklogItem,
+    Story,
+    Task,
+)
+from product_delivery.scoring import rice_score, wsjf_score
+from product_delivery.store import (
+    ProductDeliveryStorageUnavailable,
+    ProductDeliveryStore,
+    UnknownProductDeliveryEntity,
+    get_store,
+)
+
+__all__ = [
+    "AcceptanceCriterion",
+    "BacklogTree",
+    "Epic",
+    "FeedbackItem",
+    "GroomRequest",
+    "GroomResult",
+    "Initiative",
+    "Product",
+    "ProductDeliveryStorageUnavailable",
+    "ProductDeliveryStore",
+    "RankedBacklogItem",
+    "Story",
+    "Task",
+    "UnknownProductDeliveryEntity",
+    "get_store",
+    "resolve_author",
+    "rice_score",
+    "wsjf_score",
+]

--- a/backend/agents/product_delivery/author.py
+++ b/backend/agents/product_delivery/author.py
@@ -1,0 +1,13 @@
+"""Stable author handle for product_delivery rows.
+
+Re-exports :func:`agent_console.author.resolve_author` so every persisted
+row in this team carries the same handle the Agent Console writes to its
+own tables (see ``agent_console_runs.author``). When auth lands, a
+single migration can map both teams' rows to user ids in lockstep.
+"""
+
+from __future__ import annotations
+
+from agent_console.author import resolve_author
+
+__all__ = ["resolve_author"]

--- a/backend/agents/product_delivery/models.py
+++ b/backend/agents/product_delivery/models.py
@@ -79,7 +79,8 @@ PositiveFiniteEstimate = Annotated[
 
 
 def _reject_blank_str(value: str) -> str:
-    """``AfterValidator``: reject whitespace-only strings.
+    """``AfterValidator``: reject whitespace-only strings AND
+    normalise leading/trailing whitespace.
 
     Pydantic's ``min_length=1`` accepts ``"   "`` because it counts the
     spaces. Without this, a whitespace-only ``status``/``name``/``title``
@@ -87,10 +88,17 @@ def _reject_blank_str(value: str) -> str:
     helpers, and surfaced as a raw ``ValueError`` → 500 because the
     domain-exception handler doesn't map ``ValueError``. Reject up
     front so clients get a 422 with a clear "may not be blank" message.
+
+    Also returns the *stripped* value: Codex flagged that accidental
+    inputs like ``"open "`` would otherwise be persisted as a distinct
+    state and miss exact-match filters such as ``GET /feedback?status=open``.
+    Normalising on the way in (rather than only at filter time) keeps
+    API/store/projection paths consistent.
     """
-    if not value.strip():
+    stripped = value.strip()
+    if not stripped:
         raise ValueError("must not be blank or whitespace-only")
-    return value
+    return stripped
 
 
 # Status string bounds shared by every create payload + StatusUpdate so

--- a/backend/agents/product_delivery/models.py
+++ b/backend/agents/product_delivery/models.py
@@ -30,11 +30,30 @@ def _finite_or_none(value: float | None) -> float | None:
     if value is None:
         return None
     if not math.isfinite(value):
-        raise ValueError("score must be a finite number (NaN / Infinity not allowed)")
+        raise ValueError("value must be a finite number (NaN / Infinity not allowed)")
     return value
 
 
 FiniteScore = Annotated[float | None, AfterValidator(_finite_or_none)]
+
+
+def _positive_finite_or_none(value: float | None) -> float | None:
+    """Like ``_finite_or_none`` but also rejects values ≤ 0.
+
+    Used by ``estimate_points``: zero / negative values silently inflate
+    WSJF/RICE priority (denominators clamp to 1), and ``Infinity``
+    passes ``gt=0`` but is non-finite. ``None`` still means "unestimated".
+    """
+    if value is None:
+        return None
+    if not math.isfinite(value):
+        raise ValueError("estimate_points must be a finite positive number")
+    if value <= 0:
+        raise ValueError("estimate_points must be > 0")
+    return value
+
+
+PositiveFiniteEstimate = Annotated[float | None, AfterValidator(_positive_finite_or_none)]
 
 # ---------------------------------------------------------------------------
 # Backlog entities
@@ -135,11 +154,11 @@ class StoryCreate(BaseModel):
     title: str = Field(..., min_length=1, max_length=200)
     user_story: str = ""
     status: str = "proposed"
-    # Strictly positive: zero / negative effort silently inflates WSJF
-    # (job_size <= 0 clamps to 1) and RICE (effort <= 0 clamps to 1),
-    # which would let bad input bubble misleading priorities into the
-    # ranking. Reject at the API boundary instead.
-    estimate_points: float | None = Field(default=None, gt=0)
+    # Strictly positive AND finite: zero / negative effort silently
+    # inflates WSJF (job_size <= 0 clamps to 1) and RICE (effort <= 0
+    # clamps to 1), and Infinity would pass `gt=0` but propagate as
+    # non-finite into scoring fallbacks. Reject at the API boundary.
+    estimate_points: PositiveFiniteEstimate = None
 
 
 class TaskCreate(BaseModel):

--- a/backend/agents/product_delivery/models.py
+++ b/backend/agents/product_delivery/models.py
@@ -238,7 +238,9 @@ class GroomRequest(BaseModel):
         default=True,
         description=(
             "When True (default), persist the computed scores back onto each "
-            "story / epic / initiative row. Set to False for what-if scoring."
+            "scored **story** row. Epic and initiative rows are not updated by "
+            "grooming today — those scores are set explicitly via "
+            "PATCH /{kind}/{id}/scores. Set to False for what-if scoring."
         ),
     )
 

--- a/backend/agents/product_delivery/models.py
+++ b/backend/agents/product_delivery/models.py
@@ -14,10 +14,27 @@ The principal differences are:
 
 from __future__ import annotations
 
+import math
 from datetime import datetime
-from typing import Any, Literal
+from typing import Annotated, Any, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import AfterValidator, BaseModel, Field
+
+
+def _finite_or_none(value: float | None) -> float | None:
+    """Reject NaN / ±Infinity. Pydantic happily coerces ``"NaN"`` / ``"Infinity"``
+    on plain ``float`` fields; non-finite scores break Starlette's JSON
+    encoder downstream and corrupt persisted ranking data, so we refuse
+    them at the boundary.
+    """
+    if value is None:
+        return None
+    if not math.isfinite(value):
+        raise ValueError("score must be a finite number (NaN / Infinity not allowed)")
+    return value
+
+
+FiniteScore = Annotated[float | None, AfterValidator(_finite_or_none)]
 
 # ---------------------------------------------------------------------------
 # Backlog entities
@@ -156,8 +173,8 @@ class StatusUpdate(BaseModel):
 class ScoreUpdate(BaseModel):
     """PATCH body for setting scores on initiatives/epics/stories."""
 
-    wsjf_score: float | None = None
-    rice_score: float | None = None
+    wsjf_score: FiniteScore = None
+    rice_score: FiniteScore = None
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/product_delivery/models.py
+++ b/backend/agents/product_delivery/models.py
@@ -78,11 +78,42 @@ PositiveFiniteEstimate = Annotated[
 ]
 
 
+def _reject_blank_str(value: str) -> str:
+    """``AfterValidator``: reject whitespace-only strings.
+
+    Pydantic's ``min_length=1`` accepts ``"   "`` because it counts the
+    spaces. Without this, a whitespace-only ``status``/``name``/``title``
+    passed Pydantic, hit the store layer's stricter ``_validate_*``
+    helpers, and surfaced as a raw ``ValueError`` → 500 because the
+    domain-exception handler doesn't map ``ValueError``. Reject up
+    front so clients get a 422 with a clear "may not be blank" message.
+    """
+    if not value.strip():
+        raise ValueError("must not be blank or whitespace-only")
+    return value
+
+
 # Status string bounds shared by every create payload + StatusUpdate so
 # the create and patch contracts can't drift apart (Codex caught a case
 # where Create accepted unbounded strings while StatusUpdate enforced
-# 1..40 chars).
-StatusStr = Annotated[str, Field(min_length=1, max_length=40)]
+# 1..40 chars). The ``AfterValidator`` also rejects whitespace-only
+# values so they trip the API's 422 path instead of the store's
+# unmapped 500 path.
+StatusStr = Annotated[
+    str,
+    Field(min_length=1, max_length=40),
+    AfterValidator(_reject_blank_str),
+]
+
+# Title/name string bound — matches the store's ``_validate_title``
+# helper so blank/whitespace and oversized titles fail validation at
+# the API boundary (422), not at the store (500). Used by every
+# ``*Create.title`` field plus ``ProductCreate.name``.
+TitleStr = Annotated[
+    str,
+    Field(min_length=1, max_length=200),
+    AfterValidator(_reject_blank_str),
+]
 
 # ---------------------------------------------------------------------------
 # Backlog entities
@@ -159,28 +190,28 @@ class FeedbackItem(_AuditedRow):
 
 
 class ProductCreate(BaseModel):
-    name: str = Field(..., min_length=1, max_length=200)
+    name: TitleStr
     description: str = ""
     vision: str = ""
 
 
 class InitiativeCreate(BaseModel):
     product_id: str
-    title: str = Field(..., min_length=1, max_length=200)
+    title: TitleStr
     summary: str = ""
     status: StatusStr = "proposed"
 
 
 class EpicCreate(BaseModel):
     initiative_id: str
-    title: str = Field(..., min_length=1, max_length=200)
+    title: TitleStr
     summary: str = ""
     status: StatusStr = "proposed"
 
 
 class StoryCreate(BaseModel):
     epic_id: str
-    title: str = Field(..., min_length=1, max_length=200)
+    title: TitleStr
     user_story: str = ""
     status: StatusStr = "proposed"
     # Strictly positive AND finite: zero / negative effort silently
@@ -192,7 +223,7 @@ class StoryCreate(BaseModel):
 
 class TaskCreate(BaseModel):
     story_id: str
-    title: str = Field(..., min_length=1, max_length=200)
+    title: TitleStr
     description: str = ""
     status: StatusStr = "todo"
     owner: str | None = None

--- a/backend/agents/product_delivery/models.py
+++ b/backend/agents/product_delivery/models.py
@@ -78,22 +78,37 @@ PositiveFiniteEstimate = Annotated[
 ]
 
 
+def _strip_and_bound(*, max_len: int) -> Any:
+    """Build an ``AfterValidator`` that strips, rejects blank, then
+    enforces the max length on the *trimmed* value.
+
+    Codex flagged that putting ``Field(max_length=N)`` *before* the
+    ``AfterValidator`` strips makes Pydantic compare the raw length —
+    so ``"x" * N + " "`` (N+1 chars, but trims to N) gets rejected at
+    the API while the store's stripped value is accepted, drifting
+    the two contracts. Doing both checks inside one validator keeps
+    them aligned.
+    """
+
+    def _validate(value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("must not be blank or whitespace-only")
+        if len(stripped) > max_len:
+            raise ValueError(f"must be at most {max_len} chars after trimming; got {len(stripped)}")
+        return stripped
+
+    return AfterValidator(_validate)
+
+
 def _reject_blank_str(value: str) -> str:
     """``AfterValidator``: reject whitespace-only strings AND
     normalise leading/trailing whitespace.
 
-    Pydantic's ``min_length=1`` accepts ``"   "`` because it counts the
-    spaces. Without this, a whitespace-only ``status``/``name``/``title``
-    passed Pydantic, hit the store layer's stricter ``_validate_*``
-    helpers, and surfaced as a raw ``ValueError`` → 500 because the
-    domain-exception handler doesn't map ``ValueError``. Reject up
-    front so clients get a 422 with a clear "may not be blank" message.
-
-    Also returns the *stripped* value: Codex flagged that accidental
-    inputs like ``"open "`` would otherwise be persisted as a distinct
-    state and miss exact-match filters such as ``GET /feedback?status=open``.
-    Normalising on the way in (rather than only at filter time) keeps
-    API/store/projection paths consistent.
+    Used by fields that don't have a max-length cap (e.g. acceptance
+    criterion ``text``). Bounded fields use ``_strip_and_bound`` instead
+    so Pydantic can't reject a value at the API that the store would
+    accept after trimming.
     """
     stripped = value.strip()
     if not stripped:
@@ -101,26 +116,30 @@ def _reject_blank_str(value: str) -> str:
     return stripped
 
 
-# Status string bounds shared by every create payload + StatusUpdate so
+# Status string bound shared by every create payload + StatusUpdate so
 # the create and patch contracts can't drift apart (Codex caught a case
 # where Create accepted unbounded strings while StatusUpdate enforced
-# 1..40 chars). The ``AfterValidator`` also rejects whitespace-only
-# values so they trip the API's 422 path instead of the store's
-# unmapped 500 path.
+# 1..40 chars). The ``min_length=1`` on Field rejects empty strings
+# fast (no surprise traceback for the AfterValidator); the actual
+# whitespace + max-length checks run inside ``_strip_and_bound`` AFTER
+# stripping so accidental trailing spaces don't trip the boundary
+# while leaving the equivalent trimmed value valid in the store.
 StatusStr = Annotated[
     str,
-    Field(min_length=1, max_length=40),
-    AfterValidator(_reject_blank_str),
+    Field(min_length=1),
+    _strip_and_bound(max_len=40),
 ]
 
 # Title/name string bound — matches the store's ``_validate_title``
 # helper so blank/whitespace and oversized titles fail validation at
 # the API boundary (422), not at the store (500). Used by every
-# ``*Create.title`` field plus ``ProductCreate.name``.
+# ``*Create.title`` field plus ``ProductCreate.name``. Same length-
+# after-strip ordering as ``StatusStr`` so trailing-whitespace inputs
+# don't drift between the API and the store.
 TitleStr = Annotated[
     str,
-    Field(min_length=1, max_length=200),
-    AfterValidator(_reject_blank_str),
+    Field(min_length=1),
+    _strip_and_bound(max_len=200),
 ]
 
 # ---------------------------------------------------------------------------
@@ -252,7 +271,7 @@ class FeedbackItemCreate(BaseModel):
     # `source` is used for triage and reporting (e.g. "support",
     # "sales-call", "bug-tracker"). A blank value would break source
     # filtering and degrade the provenance trail, so reject up front.
-    source: Annotated[str, Field(min_length=1, max_length=120), AfterValidator(_reject_blank_str)]
+    source: Annotated[str, Field(min_length=1), _strip_and_bound(max_len=120)]
     raw_payload: dict[str, Any] = Field(default_factory=dict)
     severity: str = "normal"
     linked_story_id: str | None = None

--- a/backend/agents/product_delivery/models.py
+++ b/backend/agents/product_delivery/models.py
@@ -18,14 +18,27 @@ import math
 from datetime import datetime
 from typing import Annotated, Any, Literal
 
-from pydantic import AfterValidator, BaseModel, Field
+from pydantic import AfterValidator, BaseModel, BeforeValidator, Field
+
+
+def _reject_bool(value: Any) -> Any:
+    """``BeforeValidator``: reject JSON booleans before float coercion.
+
+    Pydantic's default ``float`` coercion accepts JSON booleans
+    (``true → 1.0``, ``false → 0.0``). For score / estimate fields that
+    silently mutates ranking data with non-numeric semantics, so we
+    refuse booleans up front. ``isinstance(True, int)`` is True, hence
+    the explicit ``bool`` check.
+    """
+    if isinstance(value, bool):
+        raise ValueError("must be a number, not a boolean")
+    return value
 
 
 def _finite_or_none(value: float | None) -> float | None:
-    """Reject NaN / ±Infinity. Pydantic happily coerces ``"NaN"`` / ``"Infinity"``
-    on plain ``float`` fields; non-finite scores break Starlette's JSON
-    encoder downstream and corrupt persisted ranking data, so we refuse
-    them at the boundary.
+    """``AfterValidator``: reject NaN / ±Infinity. Booleans are blocked
+    earlier by ``_reject_bool``. Non-finite scores break Starlette's
+    JSON encoder downstream and corrupt persisted ranking data.
     """
     if value is None:
         return None
@@ -34,15 +47,20 @@ def _finite_or_none(value: float | None) -> float | None:
     return value
 
 
-FiniteScore = Annotated[float | None, AfterValidator(_finite_or_none)]
+FiniteScore = Annotated[
+    float | None,
+    BeforeValidator(_reject_bool),
+    AfterValidator(_finite_or_none),
+]
 
 
 def _positive_finite_or_none(value: float | None) -> float | None:
-    """Like ``_finite_or_none`` but also rejects values ≤ 0.
+    """``AfterValidator``: like ``_finite_or_none`` but also rejects ≤ 0.
 
     Used by ``estimate_points``: zero / negative values silently inflate
     WSJF/RICE priority (denominators clamp to 1), and ``Infinity``
-    passes ``gt=0`` but is non-finite. ``None`` still means "unestimated".
+    passes ``gt=0`` but is non-finite. ``None`` still means
+    "unestimated"; booleans are blocked by ``_reject_bool`` upstream.
     """
     if value is None:
         return None
@@ -53,7 +71,11 @@ def _positive_finite_or_none(value: float | None) -> float | None:
     return value
 
 
-PositiveFiniteEstimate = Annotated[float | None, AfterValidator(_positive_finite_or_none)]
+PositiveFiniteEstimate = Annotated[
+    float | None,
+    BeforeValidator(_reject_bool),
+    AfterValidator(_positive_finite_or_none),
+]
 
 
 # Status string bounds shared by every create payload + StatusUpdate so

--- a/backend/agents/product_delivery/models.py
+++ b/backend/agents/product_delivery/models.py
@@ -1,0 +1,220 @@
+"""Pydantic models for the Product Delivery team.
+
+Shape mirrors :mod:`software_engineering_team.shared.models` (Initiative
+→ Epic → StoryPlan → TaskPlan) so the SE Tech Lead can later persist its
+``PlanningHierarchy`` directly into these tables without translation.
+The principal differences are:
+
+* every entity has a stable ``id`` allocated by the store (UUID4 hex);
+* every entity carries an ``author`` handle and audit timestamps;
+* status is a free-form ``str`` (no Postgres ENUM) so adding a state
+  doesn't require a migration — matches the convention in
+  ``agent_console_runs.status`` and ``branding`` jobs.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+# ---------------------------------------------------------------------------
+# Backlog entities
+# ---------------------------------------------------------------------------
+
+
+class _AuditedRow(BaseModel):
+    """Common fields written by the store for every backlog row."""
+
+    id: str
+    author: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class Product(_AuditedRow):
+    name: str
+    description: str = ""
+    vision: str = ""
+
+
+class _ScoredRow(_AuditedRow):
+    title: str
+    summary: str = ""
+    status: str = "proposed"
+    wsjf_score: float | None = None
+    rice_score: float | None = None
+
+
+class Initiative(_ScoredRow):
+    product_id: str
+
+
+class Epic(_ScoredRow):
+    initiative_id: str
+
+
+class Story(_AuditedRow):
+    epic_id: str
+    title: str
+    user_story: str = ""
+    status: str = "proposed"
+    wsjf_score: float | None = None
+    rice_score: float | None = None
+    estimate_points: float | None = None
+
+
+class Task(_AuditedRow):
+    story_id: str
+    title: str
+    description: str = ""
+    status: str = "todo"
+    owner: str | None = None
+
+
+class AcceptanceCriterion(_AuditedRow):
+    story_id: str
+    text: str
+    satisfied: bool = False
+
+
+class FeedbackItem(_AuditedRow):
+    product_id: str
+    source: str
+    raw_payload: dict[str, Any] = Field(default_factory=dict)
+    severity: str = "normal"
+    status: str = "open"
+    linked_story_id: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# Create / update payloads
+# ---------------------------------------------------------------------------
+
+
+class ProductCreate(BaseModel):
+    name: str = Field(..., min_length=1, max_length=200)
+    description: str = ""
+    vision: str = ""
+
+
+class InitiativeCreate(BaseModel):
+    product_id: str
+    title: str = Field(..., min_length=1, max_length=200)
+    summary: str = ""
+    status: str = "proposed"
+
+
+class EpicCreate(BaseModel):
+    initiative_id: str
+    title: str = Field(..., min_length=1, max_length=200)
+    summary: str = ""
+    status: str = "proposed"
+
+
+class StoryCreate(BaseModel):
+    epic_id: str
+    title: str = Field(..., min_length=1, max_length=200)
+    user_story: str = ""
+    status: str = "proposed"
+    estimate_points: float | None = None
+
+
+class TaskCreate(BaseModel):
+    story_id: str
+    title: str = Field(..., min_length=1, max_length=200)
+    description: str = ""
+    status: str = "todo"
+    owner: str | None = None
+
+
+class AcceptanceCriterionCreate(BaseModel):
+    story_id: str
+    text: str = Field(..., min_length=1)
+    satisfied: bool = False
+
+
+class FeedbackItemCreate(BaseModel):
+    product_id: str
+    source: str = Field(..., min_length=1, max_length=120)
+    raw_payload: dict[str, Any] = Field(default_factory=dict)
+    severity: str = "normal"
+    linked_story_id: str | None = None
+
+
+class StatusUpdate(BaseModel):
+    """PATCH body for status transitions on any backlog entity."""
+
+    status: str = Field(..., min_length=1, max_length=40)
+
+
+class ScoreUpdate(BaseModel):
+    """PATCH body for setting scores on initiatives/epics/stories."""
+
+    wsjf_score: float | None = None
+    rice_score: float | None = None
+
+
+# ---------------------------------------------------------------------------
+# Read projections
+# ---------------------------------------------------------------------------
+
+
+class StoryNode(Story):
+    """Story with nested tasks + acceptance criteria for the tree view."""
+
+    tasks: list[Task] = Field(default_factory=list)
+    acceptance_criteria: list[AcceptanceCriterion] = Field(default_factory=list)
+
+
+class EpicNode(Epic):
+    stories: list[StoryNode] = Field(default_factory=list)
+
+
+class InitiativeNode(Initiative):
+    epics: list[EpicNode] = Field(default_factory=list)
+
+
+class BacklogTree(BaseModel):
+    """Full nested backlog projection used by ``GET /products/{id}/backlog``."""
+
+    product: Product
+    initiatives: list[InitiativeNode] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Grooming
+# ---------------------------------------------------------------------------
+
+
+GroomMethod = Literal["wsjf", "rice"]
+
+
+class GroomRequest(BaseModel):
+    product_id: str
+    method: GroomMethod = "wsjf"
+    persist: bool = Field(
+        default=True,
+        description=(
+            "When True (default), persist the computed scores back onto each "
+            "story / epic / initiative row. Set to False for what-if scoring."
+        ),
+    )
+
+
+class RankedBacklogItem(BaseModel):
+    kind: Literal["initiative", "epic", "story"]
+    id: str
+    title: str
+    score: float
+    wsjf_score: float | None = None
+    rice_score: float | None = None
+    rationale: str = ""
+
+
+class GroomResult(BaseModel):
+    product_id: str
+    method: GroomMethod
+    ranked: list[RankedBacklogItem] = Field(default_factory=list)
+    rationale: str = ""

--- a/backend/agents/product_delivery/models.py
+++ b/backend/agents/product_delivery/models.py
@@ -231,13 +231,20 @@ class TaskCreate(BaseModel):
 
 class AcceptanceCriterionCreate(BaseModel):
     story_id: str
-    text: str = Field(..., min_length=1)
+    # Wrapped in `_reject_blank_str` so whitespace-only text (`'   '`,
+    # `'\t'`) doesn't slip past `min_length=1` and persist a
+    # semantically empty acceptance criterion that breaks the
+    # satisfied/total ratio operators read from the backlog tree.
+    text: Annotated[str, Field(min_length=1), AfterValidator(_reject_blank_str)]
     satisfied: bool = False
 
 
 class FeedbackItemCreate(BaseModel):
     product_id: str
-    source: str = Field(..., min_length=1, max_length=120)
+    # `source` is used for triage and reporting (e.g. "support",
+    # "sales-call", "bug-tracker"). A blank value would break source
+    # filtering and degrade the provenance trail, so reject up front.
+    source: Annotated[str, Field(min_length=1, max_length=120), AfterValidator(_reject_blank_str)]
     raw_payload: dict[str, Any] = Field(default_factory=dict)
     severity: str = "normal"
     linked_story_id: str | None = None

--- a/backend/agents/product_delivery/models.py
+++ b/backend/agents/product_delivery/models.py
@@ -55,6 +55,13 @@ def _positive_finite_or_none(value: float | None) -> float | None:
 
 PositiveFiniteEstimate = Annotated[float | None, AfterValidator(_positive_finite_or_none)]
 
+
+# Status string bounds shared by every create payload + StatusUpdate so
+# the create and patch contracts can't drift apart (Codex caught a case
+# where Create accepted unbounded strings while StatusUpdate enforced
+# 1..40 chars).
+StatusStr = Annotated[str, Field(min_length=1, max_length=40)]
+
 # ---------------------------------------------------------------------------
 # Backlog entities
 # ---------------------------------------------------------------------------
@@ -78,7 +85,7 @@ class Product(_AuditedRow):
 class _ScoredRow(_AuditedRow):
     title: str
     summary: str = ""
-    status: str = "proposed"
+    status: StatusStr = "proposed"
     wsjf_score: float | None = None
     rice_score: float | None = None
 
@@ -95,7 +102,7 @@ class Story(_AuditedRow):
     epic_id: str
     title: str
     user_story: str = ""
-    status: str = "proposed"
+    status: StatusStr = "proposed"
     wsjf_score: float | None = None
     rice_score: float | None = None
     estimate_points: float | None = None
@@ -105,7 +112,7 @@ class Task(_AuditedRow):
     story_id: str
     title: str
     description: str = ""
-    status: str = "todo"
+    status: StatusStr = "todo"
     owner: str | None = None
 
 
@@ -120,7 +127,7 @@ class FeedbackItem(_AuditedRow):
     source: str
     raw_payload: dict[str, Any] = Field(default_factory=dict)
     severity: str = "normal"
-    status: str = "open"
+    status: StatusStr = "open"
     linked_story_id: str | None = None
 
 
@@ -139,21 +146,21 @@ class InitiativeCreate(BaseModel):
     product_id: str
     title: str = Field(..., min_length=1, max_length=200)
     summary: str = ""
-    status: str = "proposed"
+    status: StatusStr = "proposed"
 
 
 class EpicCreate(BaseModel):
     initiative_id: str
     title: str = Field(..., min_length=1, max_length=200)
     summary: str = ""
-    status: str = "proposed"
+    status: StatusStr = "proposed"
 
 
 class StoryCreate(BaseModel):
     epic_id: str
     title: str = Field(..., min_length=1, max_length=200)
     user_story: str = ""
-    status: str = "proposed"
+    status: StatusStr = "proposed"
     # Strictly positive AND finite: zero / negative effort silently
     # inflates WSJF (job_size <= 0 clamps to 1) and RICE (effort <= 0
     # clamps to 1), and Infinity would pass `gt=0` but propagate as
@@ -165,7 +172,7 @@ class TaskCreate(BaseModel):
     story_id: str
     title: str = Field(..., min_length=1, max_length=200)
     description: str = ""
-    status: str = "todo"
+    status: StatusStr = "todo"
     owner: str | None = None
 
 
@@ -186,7 +193,7 @@ class FeedbackItemCreate(BaseModel):
 class StatusUpdate(BaseModel):
     """PATCH body for status transitions on any backlog entity."""
 
-    status: str = Field(..., min_length=1, max_length=40)
+    status: StatusStr
 
 
 class ScoreUpdate(BaseModel):

--- a/backend/agents/product_delivery/models.py
+++ b/backend/agents/product_delivery/models.py
@@ -118,7 +118,11 @@ class StoryCreate(BaseModel):
     title: str = Field(..., min_length=1, max_length=200)
     user_story: str = ""
     status: str = "proposed"
-    estimate_points: float | None = None
+    # Strictly positive: zero / negative effort silently inflates WSJF
+    # (job_size <= 0 clamps to 1) and RICE (effort <= 0 clamps to 1),
+    # which would let bad input bubble misleading priorities into the
+    # ranking. Reject at the API boundary instead.
+    estimate_points: float | None = Field(default=None, gt=0)
 
 
 class TaskCreate(BaseModel):

--- a/backend/agents/product_delivery/postgres/__init__.py
+++ b/backend/agents/product_delivery/postgres/__init__.py
@@ -1,0 +1,139 @@
+"""Postgres schema for the Product Delivery team.
+
+Pure data module — importing it has no side effects. DDL runs when the
+unified API lifespan calls
+``shared_postgres.register_team_schemas(SCHEMA)``.
+
+Schema shape (Phase 1 of issue #243):
+
+    products
+      └── initiatives
+            └── epics
+                  └── stories
+                        ├── tasks
+                        └── acceptance_criteria
+    feedback_items   (optionally linked to a story)
+
+Sprints / releases ship in the follow-up — they belong on this same
+schema and will be added as additional ``CREATE TABLE IF NOT EXISTS``
+statements (no destructive migration required).
+"""
+
+from __future__ import annotations
+
+from shared_postgres import TeamSchema
+
+SCHEMA: TeamSchema = TeamSchema(
+    team="product_delivery",
+    database=None,
+    statements=[
+        # -----------------------------------------------------------------
+        # Products — top-level container.
+        # -----------------------------------------------------------------
+        """CREATE TABLE IF NOT EXISTS product_delivery_products (
+            id          TEXT PRIMARY KEY,
+            name        TEXT NOT NULL,
+            description TEXT NOT NULL DEFAULT '',
+            vision      TEXT NOT NULL DEFAULT '',
+            author      TEXT NOT NULL,
+            created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )""",
+        # -----------------------------------------------------------------
+        # Initiatives → Epics → Stories → (Tasks | AC).
+        # -----------------------------------------------------------------
+        """CREATE TABLE IF NOT EXISTS product_delivery_initiatives (
+            id          TEXT PRIMARY KEY,
+            product_id  TEXT NOT NULL REFERENCES product_delivery_products(id) ON DELETE CASCADE,
+            title       TEXT NOT NULL,
+            summary     TEXT NOT NULL DEFAULT '',
+            status      TEXT NOT NULL DEFAULT 'proposed',
+            wsjf_score  DOUBLE PRECISION,
+            rice_score  DOUBLE PRECISION,
+            author      TEXT NOT NULL,
+            created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_pd_initiatives_product
+            ON product_delivery_initiatives(product_id)""",
+        """CREATE TABLE IF NOT EXISTS product_delivery_epics (
+            id            TEXT PRIMARY KEY,
+            initiative_id TEXT NOT NULL REFERENCES product_delivery_initiatives(id) ON DELETE CASCADE,
+            title         TEXT NOT NULL,
+            summary       TEXT NOT NULL DEFAULT '',
+            status        TEXT NOT NULL DEFAULT 'proposed',
+            wsjf_score    DOUBLE PRECISION,
+            rice_score    DOUBLE PRECISION,
+            author        TEXT NOT NULL,
+            created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_pd_epics_initiative
+            ON product_delivery_epics(initiative_id)""",
+        """CREATE TABLE IF NOT EXISTS product_delivery_stories (
+            id              TEXT PRIMARY KEY,
+            epic_id         TEXT NOT NULL REFERENCES product_delivery_epics(id) ON DELETE CASCADE,
+            title           TEXT NOT NULL,
+            user_story      TEXT NOT NULL DEFAULT '',
+            status          TEXT NOT NULL DEFAULT 'proposed',
+            wsjf_score      DOUBLE PRECISION,
+            rice_score      DOUBLE PRECISION,
+            estimate_points DOUBLE PRECISION,
+            author          TEXT NOT NULL,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_pd_stories_epic
+            ON product_delivery_stories(epic_id)""",
+        """CREATE TABLE IF NOT EXISTS product_delivery_tasks (
+            id          TEXT PRIMARY KEY,
+            story_id    TEXT NOT NULL REFERENCES product_delivery_stories(id) ON DELETE CASCADE,
+            title       TEXT NOT NULL,
+            description TEXT NOT NULL DEFAULT '',
+            status      TEXT NOT NULL DEFAULT 'todo',
+            owner       TEXT,
+            author      TEXT NOT NULL,
+            created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_pd_tasks_story
+            ON product_delivery_tasks(story_id)""",
+        """CREATE TABLE IF NOT EXISTS product_delivery_acceptance_criteria (
+            id         TEXT PRIMARY KEY,
+            story_id   TEXT NOT NULL REFERENCES product_delivery_stories(id) ON DELETE CASCADE,
+            text       TEXT NOT NULL,
+            satisfied  BOOLEAN NOT NULL DEFAULT FALSE,
+            author     TEXT NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_pd_ac_story
+            ON product_delivery_acceptance_criteria(story_id)""",
+        # -----------------------------------------------------------------
+        # Feedback intake — the seed for next sprint's grooming.
+        # -----------------------------------------------------------------
+        """CREATE TABLE IF NOT EXISTS product_delivery_feedback_items (
+            id               TEXT PRIMARY KEY,
+            product_id       TEXT NOT NULL REFERENCES product_delivery_products(id) ON DELETE CASCADE,
+            source           TEXT NOT NULL,
+            raw_payload      JSONB NOT NULL DEFAULT '{}'::jsonb,
+            severity         TEXT NOT NULL DEFAULT 'normal',
+            status           TEXT NOT NULL DEFAULT 'open',
+            linked_story_id  TEXT REFERENCES product_delivery_stories(id) ON DELETE SET NULL,
+            author           TEXT NOT NULL,
+            created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_pd_feedback_product_status
+            ON product_delivery_feedback_items(product_id, status)""",
+    ],
+    table_names=[
+        "product_delivery_acceptance_criteria",
+        "product_delivery_tasks",
+        "product_delivery_stories",
+        "product_delivery_epics",
+        "product_delivery_initiatives",
+        "product_delivery_feedback_items",
+        "product_delivery_products",
+    ],
+)

--- a/backend/agents/product_delivery/product_owner_agent/__init__.py
+++ b/backend/agents/product_delivery/product_owner_agent/__init__.py
@@ -1,0 +1,5 @@
+"""Product Owner agent — ranks the product backlog with WSJF or RICE."""
+
+from product_delivery.product_owner_agent.agent import ProductOwnerAgent
+
+__all__ = ["ProductOwnerAgent"]

--- a/backend/agents/product_delivery/product_owner_agent/agent.py
+++ b/backend/agents/product_delivery/product_owner_agent/agent.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 from typing import Any, Protocol
 
 from product_delivery.models import (
@@ -37,17 +38,28 @@ logger = logging.getLogger(__name__)
 
 
 def _to_float(value: Any, fallback: float) -> float:
-    """Coerce an LLM-supplied value to ``float`` with a typed fallback.
+    """Coerce an LLM-supplied value to a finite ``float`` with a typed fallback.
 
     Models routinely emit explicit ``null`` for fields they're unsure
     about (especially the denominator-shaped ones like ``job_size`` and
     ``effort``). ``float(None)`` raises ``TypeError`` and the outer
     handler skips the whole story — so we'd silently drop items from
     the ranking. Treat ``None`` (and missing) the same as the fallback.
+
+    Models also occasionally emit ``"NaN"`` or ``"Infinity"`` for fields
+    they refuse to commit to. ``float()`` accepts both, but non-finite
+    scores break Starlette's JSON encoder downstream and corrupt
+    persisted ranking data — so we treat them the same as ``None`` and
+    fall back, not raise. The outer ``try`` only catches malformed
+    values that genuinely can't be coerced; a finite fallback is the
+    safer default for a lossy LLM input.
     """
     if value is None:
         return float(fallback)
-    return float(value)
+    coerced = float(value)
+    if not math.isfinite(coerced):
+        return float(fallback)
+    return coerced
 
 
 class _LLMLike(Protocol):

--- a/backend/agents/product_delivery/product_owner_agent/agent.py
+++ b/backend/agents/product_delivery/product_owner_agent/agent.py
@@ -269,7 +269,19 @@ class ProductOwnerAgent:
                 ranked.append(_fallback(story, _MISSING_RATIONALE))
                 continue
 
-            inputs = raw.get("inputs") if isinstance(raw.get("inputs"), dict) else {}
+            inputs = raw.get("inputs")
+            if not isinstance(inputs, dict):
+                # `inputs` missing or non-object (e.g. `null`, list, string).
+                # Treating an empty dict here would silently produce a
+                # zero score and persist it, overwriting any existing
+                # real score on the row. Route through the malformed
+                # fallback so the synthetic zero stays visible-only.
+                logger.warning(
+                    "ProductOwnerAgent: non-dict inputs for story %s; including with score=0",
+                    story.id,
+                )
+                ranked.append(_fallback(story, _MALFORMED_RATIONALE))
+                continue
             try:
                 score, wsjf_value, rice_value = _score_for(method, inputs, story)
             except (TypeError, ValueError):

--- a/backend/agents/product_delivery/product_owner_agent/agent.py
+++ b/backend/agents/product_delivery/product_owner_agent/agent.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import json
 import logging
 import math
+import os
 from typing import Any, Callable, Protocol
 
 from product_delivery.models import (
@@ -38,6 +39,35 @@ logger = logging.getLogger(__name__)
 
 _MISSING_RATIONALE = "LLM did not score this story; needs manual review."
 _MALFORMED_RATIONALE = "LLM emitted malformed scoring inputs; needs manual review."
+_BACKLOG_TOO_LARGE_RATIONALE = (
+    "Backlog exceeded grooming prompt cap; story deferred to a later run."
+)
+
+
+def _max_stories_per_groom() -> int:
+    """Per-call cap on stories serialised into the grooming prompt.
+
+    A single LLM call has a hard context-window ceiling; serialising
+    every story in a multi-thousand-item production backlog would
+    either be silently truncated by the provider or fail the call
+    outright (which the route maps to 503, blocking *all* prioritisation
+    until the backlog shrinks). We cap at ``PRODUCT_DELIVERY_GROOM_MAX_STORIES``
+    (default 200) and surface the deferred stories in the result with
+    ``score=0`` + a "deferred" rationale so they don't disappear from
+    the planning view.
+    """
+    raw = os.environ.get("PRODUCT_DELIVERY_GROOM_MAX_STORIES")
+    if not raw:
+        return 200
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning(
+            "PRODUCT_DELIVERY_GROOM_MAX_STORIES=%r is not an int; using default 200",
+            raw,
+        )
+        return 200
+    return max(1, value)
 
 
 class LLMScoringUnavailable(RuntimeError):
@@ -51,10 +81,14 @@ class LLMScoringUnavailable(RuntimeError):
 def _to_float(value: Any, fallback: float) -> float:
     """Coerce an LLM-supplied value to a finite ``float`` with a typed fallback.
 
-    Handles three lossy LLM behaviours:
+    Handles four lossy LLM behaviours:
 
     * explicit ``null`` → returns the fallback (``float(None)`` would
       otherwise raise ``TypeError`` and skip the whole story);
+    * JSON booleans (``true``/``false``) → propagates ``TypeError``
+      so the caller surfaces the story as malformed;
+      ``float(True)`` would otherwise silently produce ``1.0`` and
+      let a confused LLM rank everything identically;
     * non-finite ``"NaN"`` / ``"Infinity"`` → returns the fallback
       (those would later break Starlette's JSON encoder if persisted);
     * malformed strings → propagates ``ValueError``/``TypeError`` for
@@ -62,6 +96,11 @@ def _to_float(value: Any, fallback: float) -> float:
     """
     if value is None:
         return float(fallback)
+    if isinstance(value, bool):
+        # `isinstance(True, int)` is True, so `float(True)` returns 1.0
+        # without raising. Reject explicitly so the malformed fallback
+        # in `_compute_ranked` fires instead of silently scoring.
+        raise TypeError("LLM scoring input must be a number, not a boolean")
     coerced = float(value)
     if not math.isfinite(coerced):
         return float(fallback)
@@ -98,6 +137,26 @@ def _score_for(
         )
     )
     return rice, None, rice
+
+
+def _fallback_item(story: Story, method: GroomMethod, rationale: str) -> RankedBacklogItem:
+    """Synthetic ``score=0`` row for a story we couldn't score this run.
+
+    Surfaced in the ranked list so downstream planning sees the gap;
+    *not* persisted so existing scores on the row stay intact. Used for
+    three branches: the LLM omitted the story, the LLM emitted
+    malformed inputs for it, and the backlog was too large to fit in
+    one prompt so the story was deferred.
+    """
+    return RankedBacklogItem(
+        kind="story",
+        id=story.id,
+        title=story.title,
+        score=0.0,
+        wsjf_score=0.0 if method == "wsjf" else None,
+        rice_score=0.0 if method == "rice" else None,
+        rationale=rationale,
+    )
 
 
 def _index_payload(payload: Any) -> dict[str, dict[str, Any]]:
@@ -191,8 +250,31 @@ class ProductOwnerAgent:
                 rationale="No stories under this product yet.",
             )
 
-        scoring_payload = self._call_llm(method, stories)
-        ranked, persist_rows = self._compute_ranked(method, stories, scoring_payload)
+        # Cap stories sent to the LLM to bound prompt size — production
+        # backlogs can exceed the model context window. The deferred
+        # tail is still surfaced in the result (score=0 + deferred
+        # rationale) so callers see them; they just aren't scored this
+        # run. Order matters: we keep the oldest stories (already
+        # ``ORDER BY created_at`` from the store) so the cap is
+        # deterministic and operators can predict which stories will be
+        # scored on the next call after a backlog edit.
+        cap = _max_stories_per_groom()
+        if len(stories) > cap:
+            logger.warning(
+                "ProductOwnerAgent: backlog has %d stories; grooming first %d, deferring rest",
+                len(stories),
+                cap,
+            )
+            scored_stories = stories[:cap]
+            deferred_stories = stories[cap:]
+        else:
+            scored_stories = stories
+            deferred_stories = []
+
+        scoring_payload = self._call_llm(method, scored_stories)
+        ranked, persist_rows = self._compute_ranked(method, scored_stories, scoring_payload)
+        for deferred in deferred_stories:
+            ranked.append(_fallback_item(deferred, method, _BACKLOG_TOO_LARGE_RATIONALE))
 
         # Report the actual *persisted* count (not just `len(persist_rows)`):
         # if rows were deleted between ranking and persistence, fewer
@@ -209,6 +291,14 @@ class ProductOwnerAgent:
         total = len(stories)
         if persisted == total:
             rationale = f"Scored {persisted} stories using {method.upper()}."
+        elif deferred_stories:
+            rationale = (
+                f"Scored {persisted}/{total} stories using {method.upper()}; "
+                f"{len(deferred_stories)} deferred (backlog exceeded "
+                f"grooming cap of {cap}); "
+                f"{total - persisted - len(deferred_stories)} surfaced with "
+                f"score=0 for manual review."
+            )
         else:
             rationale = (
                 f"Scored {persisted}/{total} stories using {method.upper()}; "
@@ -280,20 +370,6 @@ class ProductOwnerAgent:
         ranked: list[RankedBacklogItem] = []
         persist_rows: list[tuple[str, float | None, float | None]] = []
 
-        def _fallback(story: Story, rationale: str) -> RankedBacklogItem:
-            """Synthetic row for a story we couldn't score. Surfaced so
-            downstream planning sees the gap; not persisted, so existing
-            scores on the row stay intact."""
-            return RankedBacklogItem(
-                kind="story",
-                id=story.id,
-                title=story.title,
-                score=0.0,
-                wsjf_score=0.0 if method == "wsjf" else None,
-                rice_score=0.0 if method == "rice" else None,
-                rationale=rationale,
-            )
-
         for story in stories:
             raw = payload_by_id.get(story.id)
             if raw is None:
@@ -301,7 +377,7 @@ class ProductOwnerAgent:
                     "ProductOwnerAgent: story %s missing from LLM output; including with score=0",
                     story.id,
                 )
-                ranked.append(_fallback(story, _MISSING_RATIONALE))
+                ranked.append(_fallback_item(story, method, _MISSING_RATIONALE))
                 continue
 
             inputs = raw.get("inputs")
@@ -315,21 +391,21 @@ class ProductOwnerAgent:
                     "ProductOwnerAgent: empty/non-dict inputs for story %s; including with score=0",
                     story.id,
                 )
-                ranked.append(_fallback(story, _MALFORMED_RATIONALE))
+                ranked.append(_fallback_item(story, method, _MALFORMED_RATIONALE))
                 continue
             try:
                 score, wsjf_value, rice_value = _score_for(method, inputs, story)
             except (TypeError, ValueError, OverflowError):
-                # Malformed inputs (un-coerceable strings, integers too
-                # large for the float64 range, etc.). Surface the story
-                # with score=0 + a malformed-inputs rationale rather
-                # than dropping it silently — downstream planning would
-                # otherwise lose this work item entirely.
+                # Malformed inputs (un-coerceable strings, booleans,
+                # integers too large for the float64 range, etc.).
+                # Surface the story with score=0 + a malformed-inputs
+                # rationale rather than dropping it silently — downstream
+                # planning would otherwise lose this work item entirely.
                 logger.warning(
                     "ProductOwnerAgent: malformed inputs for story %s; including with score=0",
                     story.id,
                 )
-                ranked.append(_fallback(story, _MALFORMED_RATIONALE))
+                ranked.append(_fallback_item(story, method, _MALFORMED_RATIONALE))
                 continue
 
             ranked.append(

--- a/backend/agents/product_delivery/product_owner_agent/agent.py
+++ b/backend/agents/product_delivery/product_owner_agent/agent.py
@@ -37,6 +37,7 @@ from product_delivery.store import ProductDeliveryStore
 logger = logging.getLogger(__name__)
 
 _MISSING_RATIONALE = "LLM did not score this story; needs manual review."
+_MALFORMED_RATIONALE = "LLM emitted malformed scoring inputs; needs manual review."
 
 
 def _to_float(value: Any, fallback: float) -> float:
@@ -218,6 +219,20 @@ class ProductOwnerAgent:
         ranked: list[RankedBacklogItem] = []
         persist_rows: list[tuple[str, float | None, float | None]] = []
 
+        def _fallback(story: Story, rationale: str) -> RankedBacklogItem:
+            """Synthetic row for a story we couldn't score. Surfaced so
+            downstream planning sees the gap; not persisted, so existing
+            scores on the row stay intact."""
+            return RankedBacklogItem(
+                kind="story",
+                id=story.id,
+                title=story.title,
+                score=0.0,
+                wsjf_score=0.0 if method == "wsjf" else None,
+                rice_score=0.0 if method == "rice" else None,
+                rationale=rationale,
+            )
+
         for story in stories:
             raw = payload_by_id.get(story.id)
             if raw is None:
@@ -225,27 +240,22 @@ class ProductOwnerAgent:
                     "ProductOwnerAgent: story %s missing from LLM output; including with score=0",
                     story.id,
                 )
-                ranked.append(
-                    RankedBacklogItem(
-                        kind="story",
-                        id=story.id,
-                        title=story.title,
-                        score=0.0,
-                        wsjf_score=0.0 if method == "wsjf" else None,
-                        rice_score=0.0 if method == "rice" else None,
-                        rationale=_MISSING_RATIONALE,
-                    )
-                )
+                ranked.append(_fallback(story, _MISSING_RATIONALE))
                 continue
 
             inputs = raw.get("inputs") if isinstance(raw.get("inputs"), dict) else {}
             try:
                 score, wsjf_value, rice_value = _score_for(method, inputs, story)
             except (TypeError, ValueError):
+                # Malformed inputs (un-coerceable strings, etc.). Surface
+                # the story with score=0 + a malformed-inputs rationale
+                # rather than dropping it silently — downstream planning
+                # would otherwise lose this work item entirely.
                 logger.warning(
-                    "ProductOwnerAgent: malformed inputs for story %s; skipping",
+                    "ProductOwnerAgent: malformed inputs for story %s; including with score=0",
                     story.id,
                 )
+                ranked.append(_fallback(story, _MALFORMED_RATIONALE))
                 continue
 
             ranked.append(

--- a/backend/agents/product_delivery/product_owner_agent/agent.py
+++ b/backend/agents/product_delivery/product_owner_agent/agent.py
@@ -140,6 +140,7 @@ class ProductOwnerAgent:
         by_id = {s.id: s for s in stories}
         ranked: list[RankedBacklogItem] = []
         persist_rows: list[tuple[str, float | None, float | None]] = []
+        seen_ids: set[str] = set()
         items = payload.get("items") if isinstance(payload, dict) else None
         if not isinstance(items, list):
             items = []
@@ -150,6 +151,16 @@ class ProductOwnerAgent:
             sid = raw.get("id")
             story = by_id.get(sid) if isinstance(sid, str) else None
             if story is None:
+                continue
+            # Models occasionally repeat the same id (truncation + retry,
+            # confused JSON). Take the first occurrence and warn on the
+            # rest so persisted scores stay deterministic instead of
+            # depending on whichever copy lands last.
+            if story.id in seen_ids:
+                logger.warning(
+                    "ProductOwnerAgent: duplicate story id %s in LLM payload; ignoring repeat",
+                    story.id,
+                )
                 continue
             inputs = raw.get("inputs") if isinstance(raw.get("inputs"), dict) else {}
             rationale = str(raw.get("rationale") or "")
@@ -192,6 +203,7 @@ class ProductOwnerAgent:
                 )
                 continue
 
+            seen_ids.add(story.id)
             ranked.append(
                 RankedBacklogItem(
                     kind="story",
@@ -204,4 +216,29 @@ class ProductOwnerAgent:
                 )
             )
             persist_rows.append((story.id, wsjf_value, rice_value))
+
+        # Cover any stories the LLM omitted (truncation, skipped uncertain
+        # items). Surface them in the response with score=0 + a rationale
+        # so downstream planning sees them and can re-groom or hand-score
+        # them — silently dropping is the failure mode flagged by review.
+        for story in stories:
+            if story.id in seen_ids:
+                continue
+            logger.warning(
+                "ProductOwnerAgent: story %s missing from LLM output; including with score=0",
+                story.id,
+            )
+            ranked.append(
+                RankedBacklogItem(
+                    kind="story",
+                    id=story.id,
+                    title=story.title,
+                    score=0.0,
+                    wsjf_score=0.0 if method == "wsjf" else None,
+                    rice_score=0.0 if method == "rice" else None,
+                    rationale="LLM did not score this story; needs manual review.",
+                )
+            )
+            # Don't persist a 0 — leave the row's existing scores intact.
+            seen_ids.add(story.id)
         return ranked, persist_rows

--- a/backend/agents/product_delivery/product_owner_agent/agent.py
+++ b/backend/agents/product_delivery/product_owner_agent/agent.py
@@ -212,31 +212,47 @@ def _trim_to_prompt_budget(
 
     Story-count caps don't protect against a small backlog with very
     long ``user_story`` fields (Codex flagged this in PR #369). We
-    accumulate the JSON payload story-by-story and stop adding once
-    the next story would push us past the budget.
+    accumulate the indented JSON payload story-by-story and stop
+    adding once the next story would push us past the budget.
+
+    The byte estimate matches what ``_call_llm`` actually serialises
+    (via ``_serialised_list_size`` below — same ``indent=2``,
+    same separators), so the trimmer can't undercount and let an
+    indented prompt overrun the budget.
 
     Returns ``(scored, deferred)`` so deferred stories can surface in
     the result with the same ``_BACKLOG_TOO_LARGE_RATIONALE`` as the
-    story-count cap. Always keeps at least one story so a single
-    pathological story doesn't drop the entire run to "0 scored".
-    Length budget includes the ``[`` / ``]`` / `, ` JSON list overhead
-    (rough proxy: 2 + (n-1)*2 bytes; conservative for our purposes).
+    story-count cap. If even the *first* story exceeds the budget on
+    its own, it's deferred too — a pathological single story
+    should not break the budget contract and 503 the call. The result
+    in that case is ``([], [oversize])``: the route surfaces every
+    story as deferred, planner sees the gap, no LLM call made.
     """
     if not stories:
         return [], []
     kept: list[Story] = []
-    used = 2  # the enclosing `[]`
     for story in stories:
-        # Recompute the payload byte cost incrementally — `json.dumps`
-        # of one dict is cheap and avoids re-serialising the whole
-        # accumulator every iteration.
-        item_bytes = len(json.dumps(_story_payload(story)).encode("utf-8"))
-        sep_bytes = 2 if kept else 0  # `, ` between items
-        if kept and used + sep_bytes + item_bytes > byte_budget:
+        # Recompute the indented size with this story added. Slightly
+        # more expensive than incremental delta tracking, but matches
+        # `_call_llm`'s `json.dumps(..., indent=2)` exactly so the
+        # budget can't drift if the indent ever changes.
+        candidate = kept + [story]
+        if _serialised_list_size(candidate) > byte_budget:
             break
         kept.append(story)
-        used += sep_bytes + item_bytes
     return kept, stories[len(kept) :]
+
+
+def _serialised_list_size(stories: list[Story]) -> int:
+    """Byte size of the JSON list `_call_llm` will actually send.
+
+    Mirrors ``json.dumps([...], indent=2)`` exactly — including the
+    enclosing ``[`` / ``]``, the `,\\n  ` separators between items,
+    and the per-key indentation — so ``_trim_to_prompt_budget`` can't
+    undercount the payload by measuring with compact formatting and
+    let the prompt still overrun the budget.
+    """
+    return len(json.dumps([_story_payload(s) for s in stories], indent=2).encode("utf-8"))
 
 
 def _fallback_item(story: Story, method: GroomMethod, rationale: str) -> RankedBacklogItem:
@@ -396,8 +412,18 @@ class ProductOwnerAgent:
                 len(deferred_stories),
             )
 
-        scoring_payload = self._call_llm(method, scored_stories)
-        ranked, persist_rows = self._compute_ranked(method, scored_stories, scoring_payload)
+        if scored_stories:
+            scoring_payload = self._call_llm(method, scored_stories)
+            ranked, persist_rows = self._compute_ranked(method, scored_stories, scoring_payload)
+        else:
+            # Every candidate story was deferred (e.g. the only story
+            # in the backlog has a `user_story` field longer than the
+            # byte budget). Skip the LLM call entirely — sending an
+            # empty list would either produce useless 0-score output
+            # or 503 the call. Surface every story as deferred so the
+            # planner sees the gap.
+            ranked = []
+            persist_rows = []
         for deferred in deferred_stories:
             ranked.append(_fallback_item(deferred, method, _BACKLOG_TOO_LARGE_RATIONALE))
 

--- a/backend/agents/product_delivery/product_owner_agent/agent.py
+++ b/backend/agents/product_delivery/product_owner_agent/agent.py
@@ -39,9 +39,10 @@ logger = logging.getLogger(__name__)
 
 _MISSING_RATIONALE = "LLM did not score this story; needs manual review."
 _MALFORMED_RATIONALE = "LLM emitted malformed scoring inputs; needs manual review."
-_BACKLOG_TOO_LARGE_RATIONALE = (
-    "Backlog exceeded grooming prompt cap; story deferred to a later run."
-)
+# `cause` is filled in per-deferral so operators can see which cap fired
+# (story count vs. prompt-byte budget) and tune the right env var. Codex
+# flagged that conflating the two pointed at the wrong control.
+_BACKLOG_TOO_LARGE_RATIONALE = "Story deferred to a later run: {cause}."
 
 
 def _max_stories_per_groom() -> int:
@@ -208,29 +209,32 @@ def _select_grooming_window(stories: list[Story], cap: int) -> tuple[list[Story]
 def _trim_to_prompt_budget(
     stories: list[Story], byte_budget: int
 ) -> tuple[list[Story], list[Story]]:
-    """Trim ``stories`` from the tail until the JSON payload fits in ``byte_budget``.
+    """Trim ``stories`` so the JSON payload fits in ``byte_budget``.
 
     Story-count caps don't protect against a small backlog with very
     long ``user_story`` fields (Codex flagged this in PR #369). We
-    accumulate the indented JSON payload story-by-story and stop
-    adding once the next story would push us past the budget.
+    accumulate the indented JSON payload story-by-story; if a story
+    would push us past the budget, we *skip that one* and try the
+    next — a single oversize story shouldn't block scoring of every
+    later (potentially small) story. Codex flagged the previous
+    "break on first overflow" version because in sustained large
+    backlogs a single pathological item could permanently defer the
+    rest of the tail across runs.
 
     The byte estimate matches what ``_call_llm`` actually serialises
-    (via ``_serialised_list_size`` below — same ``indent=2``,
-    same separators), so the trimmer can't undercount and let an
-    indented prompt overrun the budget.
+    (via ``_serialised_list_size`` below — same ``indent=2``, same
+    separators), so the trimmer can't undercount and let an indented
+    prompt overrun the budget.
 
     Returns ``(scored, deferred)`` so deferred stories can surface in
-    the result with the same ``_BACKLOG_TOO_LARGE_RATIONALE`` as the
-    story-count cap. If even the *first* story exceeds the budget on
-    its own, it's deferred too — a pathological single story
-    should not break the budget contract and 503 the call. The result
-    in that case is ``([], [oversize])``: the route surfaces every
-    story as deferred, planner sees the gap, no LLM call made.
+    the result with the byte-budget rationale. ``scored`` may be
+    empty (every candidate too large); the caller skips the LLM
+    altogether in that case.
     """
     if not stories:
         return [], []
     kept: list[Story] = []
+    deferred: list[Story] = []
     for story in stories:
         # Recompute the indented size with this story added. Slightly
         # more expensive than incremental delta tracking, but matches
@@ -238,9 +242,10 @@ def _trim_to_prompt_budget(
         # budget can't drift if the indent ever changes.
         candidate = kept + [story]
         if _serialised_list_size(candidate) > byte_budget:
-            break
+            deferred.append(story)
+            continue
         kept.append(story)
-    return kept, stories[len(kept) :]
+    return kept, deferred
 
 
 def _serialised_list_size(stories: list[Story]) -> int:
@@ -399,17 +404,23 @@ class ProductOwnerAgent:
         #      context). Trims from the tail of the size-sorted slice
         #      until the JSON fits.
         cap = _max_stories_per_groom()
-        scored_stories, deferred_stories = _select_grooming_window(stories, cap)
-        scored_stories, byte_deferred = _trim_to_prompt_budget(
-            scored_stories, _max_prompt_bytes_per_groom()
-        )
-        deferred_stories.extend(byte_deferred)
-        if deferred_stories:
+        prompt_bytes_cap = _max_prompt_bytes_per_groom()
+        scored_stories, count_deferred = _select_grooming_window(stories, cap)
+        scored_stories, byte_deferred = _trim_to_prompt_budget(scored_stories, prompt_bytes_cap)
+        # Track the deferral cause separately so the rationale points
+        # operators at the right control to tune (story-count cap vs.
+        # prompt-byte budget) — Codex flagged that conflating the two
+        # mis-diagnoses the failure in production.
+        deferred_total = len(count_deferred) + len(byte_deferred)
+        if deferred_total:
             logger.warning(
-                "ProductOwnerAgent: backlog has %d stories; grooming %d, deferring %d",
+                "ProductOwnerAgent: backlog has %d stories; grooming %d, deferring "
+                "%d (%d count-cap, %d byte-budget)",
                 len(stories),
                 len(scored_stories),
-                len(deferred_stories),
+                deferred_total,
+                len(count_deferred),
+                len(byte_deferred),
             )
 
         if scored_stories:
@@ -424,8 +435,27 @@ class ProductOwnerAgent:
             # planner sees the gap.
             ranked = []
             persist_rows = []
-        for deferred in deferred_stories:
-            ranked.append(_fallback_item(deferred, method, _BACKLOG_TOO_LARGE_RATIONALE))
+        # Distinct rationale per cause so operators can tell at a
+        # glance which cap fired — the message reads cleanly when
+        # both fire (rare) and stays accurate when only one does.
+        for deferred in count_deferred:
+            ranked.append(
+                _fallback_item(
+                    deferred,
+                    method,
+                    _BACKLOG_TOO_LARGE_RATIONALE.format(cause=f"story-count cap of {cap} exceeded"),
+                )
+            )
+        for deferred in byte_deferred:
+            ranked.append(
+                _fallback_item(
+                    deferred,
+                    method,
+                    _BACKLOG_TOO_LARGE_RATIONALE.format(
+                        cause=f"prompt-byte budget of {prompt_bytes_cap} exceeded"
+                    ),
+                )
+            )
 
         # Report the actual *persisted* count (not just `len(persist_rows)`):
         # if rows were deleted between ranking and persistence, fewer
@@ -442,12 +472,15 @@ class ProductOwnerAgent:
         total = len(stories)
         if persisted == total:
             rationale = f"Scored {persisted} stories using {method.upper()}."
-        elif deferred_stories:
+        elif deferred_total:
+            # Both causes get name-checked in the summary so an
+            # operator reading the result knows which control to tune.
             rationale = (
                 f"Scored {persisted}/{total} stories using {method.upper()}; "
-                f"{len(deferred_stories)} deferred (backlog exceeded "
-                f"grooming cap of {cap}); "
-                f"{total - persisted - len(deferred_stories)} surfaced with "
+                f"{deferred_total} deferred ({len(count_deferred)} story-count "
+                f"cap of {cap}, {len(byte_deferred)} prompt-byte budget "
+                f"of {prompt_bytes_cap}); "
+                f"{total - persisted - deferred_total} surfaced with "
                 f"score=0 for manual review."
             )
         else:

--- a/backend/agents/product_delivery/product_owner_agent/agent.py
+++ b/backend/agents/product_delivery/product_owner_agent/agent.py
@@ -36,23 +36,20 @@ from product_delivery.store import ProductDeliveryStore
 
 logger = logging.getLogger(__name__)
 
+_MISSING_RATIONALE = "LLM did not score this story; needs manual review."
+
 
 def _to_float(value: Any, fallback: float) -> float:
     """Coerce an LLM-supplied value to a finite ``float`` with a typed fallback.
 
-    Models routinely emit explicit ``null`` for fields they're unsure
-    about (especially the denominator-shaped ones like ``job_size`` and
-    ``effort``). ``float(None)`` raises ``TypeError`` and the outer
-    handler skips the whole story — so we'd silently drop items from
-    the ranking. Treat ``None`` (and missing) the same as the fallback.
+    Handles three lossy LLM behaviours:
 
-    Models also occasionally emit ``"NaN"`` or ``"Infinity"`` for fields
-    they refuse to commit to. ``float()`` accepts both, but non-finite
-    scores break Starlette's JSON encoder downstream and corrupt
-    persisted ranking data — so we treat them the same as ``None`` and
-    fall back, not raise. The outer ``try`` only catches malformed
-    values that genuinely can't be coerced; a finite fallback is the
-    safer default for a lossy LLM input.
+    * explicit ``null`` → returns the fallback (``float(None)`` would
+      otherwise raise ``TypeError`` and skip the whole story);
+    * non-finite ``"NaN"`` / ``"Infinity"`` → returns the fallback
+      (those would later break Starlette's JSON encoder if persisted);
+    * malformed strings → propagates ``ValueError``/``TypeError`` for
+      the caller's exception handler to log + skip.
     """
     if value is None:
         return float(fallback)
@@ -60,6 +57,65 @@ def _to_float(value: Any, fallback: float) -> float:
     if not math.isfinite(coerced):
         return float(fallback)
     return coerced
+
+
+def _score_for(
+    method: GroomMethod, inputs: dict[str, Any], story: Story
+) -> tuple[float, float | None, float | None]:
+    """Compute (score, wsjf_value, rice_value) for one story.
+
+    Centralises the WSJF/RICE branching so the loop in ``_compute_ranked``
+    doesn't have to. The two unused per-method values stay ``None`` so
+    ``RankedBacklogItem`` and ``persist_rows`` keep their typed shape.
+    """
+    if method == "wsjf":
+        wsjf = wsjf_score(
+            WSJFInputs(
+                user_business_value=_to_float(inputs.get("user_business_value"), 0.0),
+                time_criticality=_to_float(inputs.get("time_criticality"), 0.0),
+                risk_reduction_or_opportunity_enablement=_to_float(
+                    inputs.get("risk_reduction_or_opportunity_enablement"), 0.0
+                ),
+                job_size=_to_float(inputs.get("job_size"), story.estimate_points or 1.0),
+            )
+        )
+        return wsjf, wsjf, None
+    rice = rice_score(
+        RICEInputs(
+            reach=_to_float(inputs.get("reach"), 0.0),
+            impact=_to_float(inputs.get("impact"), 0.0),
+            confidence=_to_float(inputs.get("confidence"), 0.0),
+            effort=_to_float(inputs.get("effort"), (story.estimate_points or 4.0) / 4.0),
+        )
+    )
+    return rice, None, rice
+
+
+def _index_payload(payload: Any) -> dict[str, dict[str, Any]]:
+    """Build ``{story_id: raw_item}`` from the LLM response.
+
+    Filters out non-dict items + items without a string id, and warns on
+    duplicate ids (first occurrence wins so persisted scores stay
+    deterministic instead of depending on which copy lands last).
+    """
+    items = payload.get("items") if isinstance(payload, dict) else None
+    if not isinstance(items, list):
+        return {}
+    indexed: dict[str, dict[str, Any]] = {}
+    for raw in items:
+        if not isinstance(raw, dict):
+            continue
+        sid = raw.get("id")
+        if not isinstance(sid, str):
+            continue
+        if sid in indexed:
+            logger.warning(
+                "ProductOwnerAgent: duplicate story id %s in LLM payload; ignoring repeat",
+                sid,
+            )
+            continue
+        indexed[sid] = raw
+    return indexed
 
 
 class _LLMLike(Protocol):
@@ -149,65 +205,42 @@ class ProductOwnerAgent:
         stories: list[Story],
         payload: dict[str, Any],
     ) -> tuple[list[RankedBacklogItem], list[tuple[str, float | None, float | None]]]:
-        by_id = {s.id: s for s in stories}
+        """Build the ranked list + the persist payload.
+
+        Iterates ``stories`` (each id seen once, no dedup needed) and
+        looks up the LLM's scoring inputs by id. Stories the LLM
+        omitted get a synthetic ``score=0`` row with a manual-review
+        rationale so downstream planning never silently loses work;
+        synthetic rows are *not* persisted (the existing scores on the
+        row stay intact).
+        """
+        payload_by_id = _index_payload(payload)
         ranked: list[RankedBacklogItem] = []
         persist_rows: list[tuple[str, float | None, float | None]] = []
-        seen_ids: set[str] = set()
-        items = payload.get("items") if isinstance(payload, dict) else None
-        if not isinstance(items, list):
-            items = []
 
-        for raw in items:
-            if not isinstance(raw, dict):
-                continue
-            sid = raw.get("id")
-            story = by_id.get(sid) if isinstance(sid, str) else None
-            if story is None:
-                continue
-            # Models occasionally repeat the same id (truncation + retry,
-            # confused JSON). Take the first occurrence and warn on the
-            # rest so persisted scores stay deterministic instead of
-            # depending on whichever copy lands last.
-            if story.id in seen_ids:
+        for story in stories:
+            raw = payload_by_id.get(story.id)
+            if raw is None:
                 logger.warning(
-                    "ProductOwnerAgent: duplicate story id %s in LLM payload; ignoring repeat",
+                    "ProductOwnerAgent: story %s missing from LLM output; including with score=0",
                     story.id,
                 )
+                ranked.append(
+                    RankedBacklogItem(
+                        kind="story",
+                        id=story.id,
+                        title=story.title,
+                        score=0.0,
+                        wsjf_score=0.0 if method == "wsjf" else None,
+                        rice_score=0.0 if method == "rice" else None,
+                        rationale=_MISSING_RATIONALE,
+                    )
+                )
                 continue
-            inputs = raw.get("inputs") if isinstance(raw.get("inputs"), dict) else {}
-            rationale = str(raw.get("rationale") or "")
 
-            wsjf_value: float | None = None
-            rice_value: float | None = None
+            inputs = raw.get("inputs") if isinstance(raw.get("inputs"), dict) else {}
             try:
-                if method == "wsjf":
-                    wsjf_value = wsjf_score(
-                        WSJFInputs(
-                            user_business_value=_to_float(inputs.get("user_business_value"), 0.0),
-                            time_criticality=_to_float(inputs.get("time_criticality"), 0.0),
-                            risk_reduction_or_opportunity_enablement=_to_float(
-                                inputs.get("risk_reduction_or_opportunity_enablement"), 0.0
-                            ),
-                            job_size=_to_float(
-                                inputs.get("job_size"),
-                                story.estimate_points or 1.0,
-                            ),
-                        )
-                    )
-                    score = wsjf_value
-                else:
-                    rice_value = rice_score(
-                        RICEInputs(
-                            reach=_to_float(inputs.get("reach"), 0.0),
-                            impact=_to_float(inputs.get("impact"), 0.0),
-                            confidence=_to_float(inputs.get("confidence"), 0.0),
-                            effort=_to_float(
-                                inputs.get("effort"),
-                                (story.estimate_points or 4.0) / 4.0,
-                            ),
-                        )
-                    )
-                    score = rice_value
+                score, wsjf_value, rice_value = _score_for(method, inputs, story)
             except (TypeError, ValueError):
                 logger.warning(
                     "ProductOwnerAgent: malformed inputs for story %s; skipping",
@@ -215,7 +248,6 @@ class ProductOwnerAgent:
                 )
                 continue
 
-            seen_ids.add(story.id)
             ranked.append(
                 RankedBacklogItem(
                     kind="story",
@@ -224,33 +256,9 @@ class ProductOwnerAgent:
                     score=score,
                     wsjf_score=wsjf_value,
                     rice_score=rice_value,
-                    rationale=rationale,
+                    rationale=str(raw.get("rationale") or ""),
                 )
             )
             persist_rows.append((story.id, wsjf_value, rice_value))
 
-        # Cover any stories the LLM omitted (truncation, skipped uncertain
-        # items). Surface them in the response with score=0 + a rationale
-        # so downstream planning sees them and can re-groom or hand-score
-        # them — silently dropping is the failure mode flagged by review.
-        for story in stories:
-            if story.id in seen_ids:
-                continue
-            logger.warning(
-                "ProductOwnerAgent: story %s missing from LLM output; including with score=0",
-                story.id,
-            )
-            ranked.append(
-                RankedBacklogItem(
-                    kind="story",
-                    id=story.id,
-                    title=story.title,
-                    score=0.0,
-                    wsjf_score=0.0 if method == "wsjf" else None,
-                    rice_score=0.0 if method == "rice" else None,
-                    rationale="LLM did not score this story; needs manual review.",
-                )
-            )
-            # Don't persist a 0 — leave the row's existing scores intact.
-            seen_ids.add(story.id)
         return ranked, persist_rows

--- a/backend/agents/product_delivery/product_owner_agent/agent.py
+++ b/backend/agents/product_delivery/product_owner_agent/agent.py
@@ -36,6 +36,20 @@ from product_delivery.store import ProductDeliveryStore
 logger = logging.getLogger(__name__)
 
 
+def _to_float(value: Any, fallback: float) -> float:
+    """Coerce an LLM-supplied value to ``float`` with a typed fallback.
+
+    Models routinely emit explicit ``null`` for fields they're unsure
+    about (especially the denominator-shaped ones like ``job_size`` and
+    ``effort``). ``float(None)`` raises ``TypeError`` and the outer
+    handler skips the whole story — so we'd silently drop items from
+    the ranking. Treat ``None`` (and missing) the same as the fallback.
+    """
+    if value is None:
+        return float(fallback)
+    return float(value)
+
+
 class _LLMLike(Protocol):
     def complete_json(
         self,
@@ -146,16 +160,14 @@ class ProductOwnerAgent:
                 if method == "wsjf":
                     wsjf_value = wsjf_score(
                         WSJFInputs(
-                            user_business_value=float(inputs.get("user_business_value", 0)),
-                            time_criticality=float(inputs.get("time_criticality", 0)),
-                            risk_reduction_or_opportunity_enablement=float(
-                                inputs.get("risk_reduction_or_opportunity_enablement", 0)
+                            user_business_value=_to_float(inputs.get("user_business_value"), 0.0),
+                            time_criticality=_to_float(inputs.get("time_criticality"), 0.0),
+                            risk_reduction_or_opportunity_enablement=_to_float(
+                                inputs.get("risk_reduction_or_opportunity_enablement"), 0.0
                             ),
-                            job_size=float(
-                                inputs.get(
-                                    "job_size",
-                                    story.estimate_points or 1.0,
-                                )
+                            job_size=_to_float(
+                                inputs.get("job_size"),
+                                story.estimate_points or 1.0,
                             ),
                         )
                     )
@@ -163,14 +175,12 @@ class ProductOwnerAgent:
                 else:
                     rice_value = rice_score(
                         RICEInputs(
-                            reach=float(inputs.get("reach", 0)),
-                            impact=float(inputs.get("impact", 0)),
-                            confidence=float(inputs.get("confidence", 0)),
-                            effort=float(
-                                inputs.get(
-                                    "effort",
-                                    (story.estimate_points or 4.0) / 4.0,
-                                )
+                            reach=_to_float(inputs.get("reach"), 0.0),
+                            impact=_to_float(inputs.get("impact"), 0.0),
+                            confidence=_to_float(inputs.get("confidence"), 0.0),
+                            effort=_to_float(
+                                inputs.get("effort"),
+                                (story.estimate_points or 4.0) / 4.0,
                             ),
                         )
                     )

--- a/backend/agents/product_delivery/product_owner_agent/agent.py
+++ b/backend/agents/product_delivery/product_owner_agent/agent.py
@@ -305,25 +305,26 @@ class ProductOwnerAgent:
                 continue
 
             inputs = raw.get("inputs")
-            if not isinstance(inputs, dict):
-                # `inputs` missing or non-object (e.g. `null`, list, string).
-                # Treating an empty dict here would silently produce a
-                # zero score and persist it, overwriting any existing
-                # real score on the row. Route through the malformed
+            if not isinstance(inputs, dict) or not inputs:
+                # `inputs` missing, non-object (e.g. `null`, list, string),
+                # OR an empty dict. An empty dict would otherwise score
+                # to a synthetic 0.0 and overwrite any real persisted
+                # score on the row. Route through the malformed
                 # fallback so the synthetic zero stays visible-only.
                 logger.warning(
-                    "ProductOwnerAgent: non-dict inputs for story %s; including with score=0",
+                    "ProductOwnerAgent: empty/non-dict inputs for story %s; including with score=0",
                     story.id,
                 )
                 ranked.append(_fallback(story, _MALFORMED_RATIONALE))
                 continue
             try:
                 score, wsjf_value, rice_value = _score_for(method, inputs, story)
-            except (TypeError, ValueError):
-                # Malformed inputs (un-coerceable strings, etc.). Surface
-                # the story with score=0 + a malformed-inputs rationale
-                # rather than dropping it silently — downstream planning
-                # would otherwise lose this work item entirely.
+            except (TypeError, ValueError, OverflowError):
+                # Malformed inputs (un-coerceable strings, integers too
+                # large for the float64 range, etc.). Surface the story
+                # with score=0 + a malformed-inputs rationale rather
+                # than dropping it silently — downstream planning would
+                # otherwise lose this work item entirely.
                 logger.warning(
                     "ProductOwnerAgent: malformed inputs for story %s; including with score=0",
                     story.id,

--- a/backend/agents/product_delivery/product_owner_agent/agent.py
+++ b/backend/agents/product_delivery/product_owner_agent/agent.py
@@ -1,0 +1,197 @@
+"""ProductOwnerAgent — ranks a product's backlog.
+
+Flow:
+
+1. Pull every story under ``product_id`` from the store.
+2. Ask the LLM to produce *scoring inputs* (never the score itself; see
+   :mod:`product_delivery.product_owner_agent.prompts`).
+3. Compute WSJF or RICE scores deterministically via
+   :mod:`product_delivery.scoring`.
+4. Optionally persist the scores back onto each story row.
+5. Return a ranked :class:`GroomResult`.
+
+Tests inject a stub ``llm_client`` (any object with a ``complete_json``
+method). In production we use ``llm_service.get_client("product_owner")``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Protocol
+
+from product_delivery.models import (
+    GroomMethod,
+    GroomResult,
+    RankedBacklogItem,
+    Story,
+)
+from product_delivery.product_owner_agent.prompts import (
+    SYSTEM_PROMPT,
+    build_user_prompt,
+)
+from product_delivery.scoring import RICEInputs, WSJFInputs, rice_score, wsjf_score
+from product_delivery.store import ProductDeliveryStore
+
+logger = logging.getLogger(__name__)
+
+
+class _LLMLike(Protocol):
+    def complete_json(
+        self,
+        prompt: str,
+        *,
+        temperature: float = ...,
+        system_prompt: str | None = ...,
+        **kwargs: Any,
+    ) -> dict[str, Any]: ...
+
+
+class ProductOwnerAgent:
+    """Stateless: depends on a store + an LLM client only."""
+
+    def __init__(
+        self,
+        store: ProductDeliveryStore,
+        llm_client: _LLMLike,
+    ) -> None:
+        self._store = store
+        self._llm = llm_client
+
+    def groom(
+        self,
+        *,
+        product_id: str,
+        method: GroomMethod = "wsjf",
+        persist: bool = True,
+    ) -> GroomResult:
+        stories = self._store.list_stories_for_product(product_id)
+        if not stories:
+            return GroomResult(
+                product_id=product_id,
+                method=method,
+                ranked=[],
+                rationale="No stories under this product yet.",
+            )
+
+        scoring_payload = self._call_llm(method, stories)
+        ranked, persist_rows = self._compute_ranked(method, stories, scoring_payload)
+
+        if persist and persist_rows:
+            self._store.bulk_update_story_scores(persist_rows)
+
+        ranked.sort(key=lambda r: r.score, reverse=True)
+        return GroomResult(
+            product_id=product_id,
+            method=method,
+            ranked=ranked,
+            rationale=f"Scored {len(ranked)} stories using {method.upper()}.",
+        )
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _call_llm(self, method: GroomMethod, stories: list[Story]) -> dict[str, Any]:
+        stories_payload = json.dumps(
+            [
+                {
+                    "id": s.id,
+                    "title": s.title,
+                    "user_story": s.user_story,
+                    "estimate_points": s.estimate_points,
+                    "status": s.status,
+                }
+                for s in stories
+            ],
+            indent=2,
+        )
+        prompt = build_user_prompt(method, stories_payload)
+        try:
+            return self._llm.complete_json(
+                prompt,
+                temperature=0.0,
+                system_prompt=SYSTEM_PROMPT,
+            )
+        except Exception:
+            logger.exception("ProductOwnerAgent: LLM call failed; returning unscored backlog")
+            return {"items": []}
+
+    def _compute_ranked(
+        self,
+        method: GroomMethod,
+        stories: list[Story],
+        payload: dict[str, Any],
+    ) -> tuple[list[RankedBacklogItem], list[tuple[str, float | None, float | None]]]:
+        by_id = {s.id: s for s in stories}
+        ranked: list[RankedBacklogItem] = []
+        persist_rows: list[tuple[str, float | None, float | None]] = []
+        items = payload.get("items") if isinstance(payload, dict) else None
+        if not isinstance(items, list):
+            items = []
+
+        for raw in items:
+            if not isinstance(raw, dict):
+                continue
+            sid = raw.get("id")
+            story = by_id.get(sid) if isinstance(sid, str) else None
+            if story is None:
+                continue
+            inputs = raw.get("inputs") if isinstance(raw.get("inputs"), dict) else {}
+            rationale = str(raw.get("rationale") or "")
+
+            wsjf_value: float | None = None
+            rice_value: float | None = None
+            try:
+                if method == "wsjf":
+                    wsjf_value = wsjf_score(
+                        WSJFInputs(
+                            user_business_value=float(inputs.get("user_business_value", 0)),
+                            time_criticality=float(inputs.get("time_criticality", 0)),
+                            risk_reduction_or_opportunity_enablement=float(
+                                inputs.get("risk_reduction_or_opportunity_enablement", 0)
+                            ),
+                            job_size=float(
+                                inputs.get(
+                                    "job_size",
+                                    story.estimate_points or 1.0,
+                                )
+                            ),
+                        )
+                    )
+                    score = wsjf_value
+                else:
+                    rice_value = rice_score(
+                        RICEInputs(
+                            reach=float(inputs.get("reach", 0)),
+                            impact=float(inputs.get("impact", 0)),
+                            confidence=float(inputs.get("confidence", 0)),
+                            effort=float(
+                                inputs.get(
+                                    "effort",
+                                    (story.estimate_points or 4.0) / 4.0,
+                                )
+                            ),
+                        )
+                    )
+                    score = rice_value
+            except (TypeError, ValueError):
+                logger.warning(
+                    "ProductOwnerAgent: malformed inputs for story %s; skipping",
+                    story.id,
+                )
+                continue
+
+            ranked.append(
+                RankedBacklogItem(
+                    kind="story",
+                    id=story.id,
+                    title=story.title,
+                    score=score,
+                    wsjf_score=wsjf_value,
+                    rice_score=rice_value,
+                    rationale=rationale,
+                )
+            )
+            persist_rows.append((story.id, wsjf_value, rice_value))
+        return ranked, persist_rows

--- a/backend/agents/product_delivery/product_owner_agent/agent.py
+++ b/backend/agents/product_delivery/product_owner_agent/agent.py
@@ -56,18 +56,47 @@ def _max_stories_per_groom() -> int:
     ``score=0`` + a "deferred" rationale so they don't disappear from
     the planning view.
     """
-    raw = os.environ.get("PRODUCT_DELIVERY_GROOM_MAX_STORIES")
+    return _env_int("PRODUCT_DELIVERY_GROOM_MAX_STORIES", default=200, minimum=1)
+
+
+def _max_prompt_bytes_per_groom() -> int:
+    """Per-call byte budget for the grooming prompt's stories payload.
+
+    Story-count alone isn't sufficient: a small backlog with very long
+    ``user_story`` fields can still overrun the model context (Codex
+    flagged this in PR #369). We trim from the *tail* of the candidate
+    slice once the JSON-serialized payload exceeds this budget; the
+    trimmed stories surface with the same "deferred" rationale as the
+    story-count cap, so deferred work stays visible to the planner.
+
+    Default 65_536 bytes (~16k tokens worst case) — well under the
+    smallest model context budgets we use. Override with
+    ``PRODUCT_DELIVERY_GROOM_MAX_PROMPT_BYTES``.
+    """
+    return _env_int("PRODUCT_DELIVERY_GROOM_MAX_PROMPT_BYTES", default=65_536, minimum=1_024)
+
+
+def _env_int(name: str, *, default: int, minimum: int) -> int:
+    """Parse an int env var with a default + lower bound.
+
+    Centralises the "missing → default; non-int → warn + default;
+    below minimum → clamp" pattern shared by the two grooming cap
+    knobs above. Returns >= ``minimum`` always.
+    """
+    raw = os.environ.get(name)
     if not raw:
-        return 200
+        return default
     try:
         value = int(raw)
     except ValueError:
         logger.warning(
-            "PRODUCT_DELIVERY_GROOM_MAX_STORIES=%r is not an int; using default 200",
+            "%s=%r is not an int; using default %d",
+            name,
             raw,
+            default,
         )
-        return 200
-    return max(1, value)
+        return default
+    return max(minimum, value)
 
 
 class LLMScoringUnavailable(RuntimeError):
@@ -139,6 +168,77 @@ def _score_for(
     return rice, None, rice
 
 
+def _story_payload(story: Story) -> dict[str, Any]:
+    """The serialised shape sent to the LLM for one story.
+
+    Centralised so ``_call_llm`` and ``_trim_to_prompt_budget`` agree
+    on what's in the prompt — otherwise the byte budget would underestimate.
+    """
+    return {
+        "id": story.id,
+        "title": story.title,
+        "user_story": story.user_story,
+        "estimate_points": story.estimate_points,
+        "status": story.status,
+    }
+
+
+def _select_grooming_window(stories: list[Story], cap: int) -> tuple[list[Story], list[Story]]:
+    """Pick up to ``cap`` stories to groom, return ``(scored, deferred)``.
+
+    Sorted by ``updated_at`` ascending so the *least-recently-touched*
+    stories are scored first. After grooming persists their new scores,
+    each scored story's ``updated_at`` jumps to "now" and naturally
+    cycles to the *end* of the next run's window. This rotates the cap
+    across the backlog instead of permanently starving newer stories
+    (which the original "oldest by `created_at`" slice would do for
+    sustained large backlogs — Codex flagged this in PR #369).
+
+    Stable sort within ``updated_at`` ties means stories with identical
+    timestamps stay in their original (creation) order, so the cap
+    selection is deterministic across runs as long as the backlog
+    doesn't change.
+    """
+    if len(stories) <= cap:
+        return list(stories), []
+    by_freshness = sorted(stories, key=lambda s: s.updated_at)
+    return by_freshness[:cap], by_freshness[cap:]
+
+
+def _trim_to_prompt_budget(
+    stories: list[Story], byte_budget: int
+) -> tuple[list[Story], list[Story]]:
+    """Trim ``stories`` from the tail until the JSON payload fits in ``byte_budget``.
+
+    Story-count caps don't protect against a small backlog with very
+    long ``user_story`` fields (Codex flagged this in PR #369). We
+    accumulate the JSON payload story-by-story and stop adding once
+    the next story would push us past the budget.
+
+    Returns ``(scored, deferred)`` so deferred stories can surface in
+    the result with the same ``_BACKLOG_TOO_LARGE_RATIONALE`` as the
+    story-count cap. Always keeps at least one story so a single
+    pathological story doesn't drop the entire run to "0 scored".
+    Length budget includes the ``[`` / ``]`` / `, ` JSON list overhead
+    (rough proxy: 2 + (n-1)*2 bytes; conservative for our purposes).
+    """
+    if not stories:
+        return [], []
+    kept: list[Story] = []
+    used = 2  # the enclosing `[]`
+    for story in stories:
+        # Recompute the payload byte cost incrementally — `json.dumps`
+        # of one dict is cheap and avoids re-serialising the whole
+        # accumulator every iteration.
+        item_bytes = len(json.dumps(_story_payload(story)).encode("utf-8"))
+        sep_bytes = 2 if kept else 0  # `, ` between items
+        if kept and used + sep_bytes + item_bytes > byte_budget:
+            break
+        kept.append(story)
+        used += sep_bytes + item_bytes
+    return kept, stories[len(kept) :]
+
+
 def _fallback_item(story: Story, method: GroomMethod, rationale: str) -> RankedBacklogItem:
     """Synthetic ``score=0`` row for a story we couldn't score this run.
 
@@ -162,13 +262,31 @@ def _fallback_item(story: Story, method: GroomMethod, rationale: str) -> RankedB
 def _index_payload(payload: Any) -> dict[str, dict[str, Any]]:
     """Build ``{story_id: raw_item}`` from the LLM response.
 
-    Filters out non-dict items + items without a string id, and warns on
-    duplicate ids (first occurrence wins so persisted scores stay
-    deterministic instead of depending on which copy lands last).
+    Raises :class:`LLMScoringUnavailable` (→ 503 at the route) when the
+    envelope itself is malformed — a non-dict response or a response
+    without a list-typed ``items`` key indicates a provider/schema
+    regression and is *not* equivalent to "the LLM scored zero
+    stories". Returning a 200 with every story zero-scored would mask
+    that regression as normal output and silently de-prioritise the
+    whole backlog, so we surface it as a retryable failure instead.
+
+    Per-item issues (non-dict entries, missing/non-string ids) are
+    still tolerated: those are filtered out and the rest of the items
+    proceed through the missing-fallback path. Duplicate ids keep the
+    first occurrence so persisted scores stay deterministic instead
+    of depending on which copy lands last.
     """
-    items = payload.get("items") if isinstance(payload, dict) else None
+    if not isinstance(payload, dict):
+        raise LLMScoringUnavailable(
+            f"LLM returned a non-object envelope ({type(payload).__name__}); "
+            "expected an object with an 'items' list."
+        )
+    items = payload.get("items")
     if not isinstance(items, list):
-        return {}
+        raise LLMScoringUnavailable(
+            "LLM envelope missing or non-list 'items' field; "
+            "treating as a transient provider/schema failure."
+        )
     indexed: dict[str, dict[str, Any]] = {}
     for raw in items:
         if not isinstance(raw, dict):
@@ -254,22 +372,29 @@ class ProductOwnerAgent:
         # backlogs can exceed the model context window. The deferred
         # tail is still surfaced in the result (score=0 + deferred
         # rationale) so callers see them; they just aren't scored this
-        # run. Order matters: we keep the oldest stories (already
-        # ``ORDER BY created_at`` from the store) so the cap is
-        # deterministic and operators can predict which stories will be
-        # scored on the next call after a backlog edit.
+        # run.
+        #
+        # Two-stage cap:
+        #   1. Story count (oldest-`updated_at` first so each run
+        #      rotates the window — see `_select_grooming_window` —
+        #      newer stories aren't permanently starved).
+        #   2. Serialized-payload byte budget (so a small backlog with
+        #      verbose `user_story` fields can't still overrun model
+        #      context). Trims from the tail of the size-sorted slice
+        #      until the JSON fits.
         cap = _max_stories_per_groom()
-        if len(stories) > cap:
+        scored_stories, deferred_stories = _select_grooming_window(stories, cap)
+        scored_stories, byte_deferred = _trim_to_prompt_budget(
+            scored_stories, _max_prompt_bytes_per_groom()
+        )
+        deferred_stories.extend(byte_deferred)
+        if deferred_stories:
             logger.warning(
-                "ProductOwnerAgent: backlog has %d stories; grooming first %d, deferring rest",
+                "ProductOwnerAgent: backlog has %d stories; grooming %d, deferring %d",
                 len(stories),
-                cap,
+                len(scored_stories),
+                len(deferred_stories),
             )
-            scored_stories = stories[:cap]
-            deferred_stories = stories[cap:]
-        else:
-            scored_stories = stories
-            deferred_stories = []
 
         scoring_payload = self._call_llm(method, scored_stories)
         ranked, persist_rows = self._compute_ranked(method, scored_stories, scoring_payload)
@@ -316,17 +441,12 @@ class ProductOwnerAgent:
     # ------------------------------------------------------------------
 
     def _call_llm(self, method: GroomMethod, stories: list[Story]) -> dict[str, Any]:
+        # Use the shared `_story_payload` helper so the byte-budget
+        # estimate in `_trim_to_prompt_budget` matches what's actually
+        # serialised here. Otherwise an indent-2 difference would
+        # silently let the prompt overrun the budget.
         stories_payload = json.dumps(
-            [
-                {
-                    "id": s.id,
-                    "title": s.title,
-                    "user_story": s.user_story,
-                    "estimate_points": s.estimate_points,
-                    "status": s.status,
-                }
-                for s in stories
-            ],
+            [_story_payload(s) for s in stories],
             indent=2,
         )
         prompt = build_user_prompt(method, stories_payload)

--- a/backend/agents/product_delivery/product_owner_agent/agent.py
+++ b/backend/agents/product_delivery/product_owner_agent/agent.py
@@ -40,6 +40,14 @@ _MISSING_RATIONALE = "LLM did not score this story; needs manual review."
 _MALFORMED_RATIONALE = "LLM emitted malformed scoring inputs; needs manual review."
 
 
+class LLMScoringUnavailable(RuntimeError):
+    """The LLM call inside grooming failed end-to-end (transport, parse,
+    or model error). The route maps this to 503 so callers can retry —
+    a 200 with all-fallback zero-scores would silently de-prioritise
+    the entire backlog during a transient outage.
+    """
+
+
 def _to_float(value: Any, fallback: float) -> float:
     """Coerce an LLM-supplied value to a finite ``float`` with a typed fallback.
 
@@ -164,11 +172,24 @@ class ProductOwnerAgent:
             self._store.bulk_update_story_scores(persist_rows)
 
         ranked.sort(key=lambda r: r.score, reverse=True)
+        # Report the actual scored count (= persist_rows length) — not
+        # `len(ranked)`, which also includes synthetic fallback rows for
+        # missing/malformed LLM outputs. Otherwise downstream automation
+        # that parses the rationale overcounts scoring success.
+        scored = len(persist_rows)
+        total = len(stories)
+        if scored == total:
+            rationale = f"Scored {scored} stories using {method.upper()}."
+        else:
+            rationale = (
+                f"Scored {scored}/{total} stories using {method.upper()}; "
+                f"{total - scored} surfaced with score=0 for manual review."
+            )
         return GroomResult(
             product_id=product_id,
             method=method,
             ranked=ranked,
-            rationale=f"Scored {len(ranked)} stories using {method.upper()}.",
+            rationale=rationale,
         )
 
     # ------------------------------------------------------------------
@@ -196,9 +217,14 @@ class ProductOwnerAgent:
                 temperature=0.0,
                 system_prompt=SYSTEM_PROMPT,
             )
-        except Exception:
-            logger.exception("ProductOwnerAgent: LLM call failed; returning unscored backlog")
-            return {"items": []}
+        except Exception as exc:
+            # End-to-end LLM failure (network, model, JSON parse). Convert
+            # to a typed domain error so the route can return 503 and
+            # callers retry, instead of returning 200 with every story
+            # zero-scored. Per-story missing/malformed payloads are still
+            # handled gracefully downstream in `_compute_ranked`.
+            logger.exception("ProductOwnerAgent: LLM call failed; surfacing as 503")
+            raise LLMScoringUnavailable(f"LLM scoring call failed: {exc}") from exc
 
     def _compute_ranked(
         self,

--- a/backend/agents/product_delivery/product_owner_agent/agent.py
+++ b/backend/agents/product_delivery/product_owner_agent/agent.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 import json
 import logging
 import math
-from typing import Any, Protocol
+from typing import Any, Callable, Protocol
 
 from product_delivery.models import (
     GroomMethod,
@@ -139,15 +139,37 @@ class _LLMLike(Protocol):
 
 
 class ProductOwnerAgent:
-    """Stateless: depends on a store + an LLM client only."""
+    """Stateless: depends on a store + an LLM client (or factory).
+
+    Accepting a *factory* (not a pre-built client) lets the agent
+    short-circuit on an empty backlog without ever touching the LLM
+    stack — important because the route can't safely "pre-check"
+    emptiness without racing concurrent writes. We bootstrap the
+    client lazily on the first call to ``_call_llm``.
+
+    For ergonomic tests, callers may pass a pre-built ``llm_client``
+    instead; it gets wrapped in a constant factory so the lazy path
+    behaves the same way. Exactly one of the two arguments must be set.
+    """
 
     def __init__(
         self,
         store: ProductDeliveryStore,
-        llm_client: _LLMLike,
+        llm_client: _LLMLike | None = None,
+        *,
+        llm_factory: Callable[[], _LLMLike] | None = None,
     ) -> None:
+        if (llm_client is None) == (llm_factory is None):
+            raise TypeError("ProductOwnerAgent: pass exactly one of llm_client or llm_factory")
         self._store = store
-        self._llm = llm_client
+        if llm_factory is not None:
+            self._llm_factory = llm_factory
+            self._llm: _LLMLike | None = None
+        else:
+            # Pre-built client — store it directly so `_call_llm` skips
+            # the bootstrap branch.
+            self._llm_factory = lambda: llm_client  # type: ignore[return-value,assignment]
+            self._llm = llm_client
 
     def groom(
         self,
@@ -156,6 +178,10 @@ class ProductOwnerAgent:
         method: GroomMethod = "wsjf",
         persist: bool = True,
     ) -> GroomResult:
+        # Single read of the backlog — no second `list_stories_for_product`
+        # call elsewhere. The route doesn't pre-check emptiness either,
+        # so there's no race window between an empty-check and the actual
+        # iteration.
         stories = self._store.list_stories_for_product(product_id)
         if not stories:
             return GroomResult(
@@ -168,22 +194,25 @@ class ProductOwnerAgent:
         scoring_payload = self._call_llm(method, stories)
         ranked, persist_rows = self._compute_ranked(method, stories, scoring_payload)
 
+        # Report the actual *persisted* count (not just `len(persist_rows)`):
+        # if rows were deleted between ranking and persistence, fewer
+        # scores landed than we attempted, and downstream automation
+        # parsing the rationale should see that.
+        persisted = 0
         if persist and persist_rows:
-            self._store.bulk_update_story_scores(persist_rows)
+            persisted = self._store.bulk_update_story_scores(persist_rows)
+        elif not persist:
+            # Caller explicitly opted out — report attempted scoring.
+            persisted = len(persist_rows)
 
         ranked.sort(key=lambda r: r.score, reverse=True)
-        # Report the actual scored count (= persist_rows length) — not
-        # `len(ranked)`, which also includes synthetic fallback rows for
-        # missing/malformed LLM outputs. Otherwise downstream automation
-        # that parses the rationale overcounts scoring success.
-        scored = len(persist_rows)
         total = len(stories)
-        if scored == total:
-            rationale = f"Scored {scored} stories using {method.upper()}."
+        if persisted == total:
+            rationale = f"Scored {persisted} stories using {method.upper()}."
         else:
             rationale = (
-                f"Scored {scored}/{total} stories using {method.upper()}; "
-                f"{total - scored} surfaced with score=0 for manual review."
+                f"Scored {persisted}/{total} stories using {method.upper()}; "
+                f"{total - persisted} surfaced with score=0 for manual review."
             )
         return GroomResult(
             product_id=product_id,
@@ -212,6 +241,12 @@ class ProductOwnerAgent:
         )
         prompt = build_user_prompt(method, stories_payload)
         try:
+            if self._llm is None:
+                # Lazy bootstrap: factory failures (missing credentials,
+                # broken provider plugin, etc.) get the same 503 mapping
+                # as LLM-call failures. Empty-backlog grooming never
+                # reaches here, so it's safe to defer.
+                self._llm = self._llm_factory()
             return self._llm.complete_json(
                 prompt,
                 temperature=0.0,

--- a/backend/agents/product_delivery/product_owner_agent/agent.py
+++ b/backend/agents/product_delivery/product_owner_agent/agent.py
@@ -172,8 +172,8 @@ def _score_for(
 def _story_payload(story: Story) -> dict[str, Any]:
     """The serialised shape sent to the LLM for one story.
 
-    Centralised so ``_call_llm`` and ``_trim_to_prompt_budget`` agree
-    on what's in the prompt — otherwise the byte budget would underestimate.
+    Centralised so ``_call_llm`` and ``_full_prompt_size`` agree on
+    what's in the prompt — otherwise the byte budget would underestimate.
     """
     return {
         "id": story.id,
@@ -184,80 +184,70 @@ def _story_payload(story: Story) -> dict[str, Any]:
     }
 
 
-def _select_grooming_window(stories: list[Story], cap: int) -> tuple[list[Story], list[Story]]:
-    """Pick up to ``cap`` stories to groom, return ``(scored, deferred)``.
+def _full_prompt_size(method: GroomMethod, stories: list[Story]) -> int:
+    """Byte size of the *full* prompt `_call_llm` will actually send.
 
-    Sorted by ``updated_at`` ascending so the *least-recently-touched*
-    stories are scored first. After grooming persists their new scores,
-    each scored story's ``updated_at`` jumps to "now" and naturally
-    cycles to the *end* of the next run's window. This rotates the cap
-    across the backlog instead of permanently starving newer stories
-    (which the original "oldest by `created_at`" slice would do for
-    sustained large backlogs — Codex flagged this in PR #369).
+    Codex flagged that the previous size estimate measured only the
+    JSON list of stories, ignoring ``SYSTEM_PROMPT`` and the
+    instruction text in ``build_user_prompt``. Near the byte budget
+    that meant a payload could pass the trimmer and still overrun
+    model context inside ``_call_llm``, turning what should be a
+    deferred-story result into a 503 grooming failure.
 
-    Stable sort within ``updated_at`` ties means stories with identical
-    timestamps stay in their original (creation) order, so the cap
-    selection is deterministic across runs as long as the backlog
-    doesn't change.
+    This now sums:
+      * the system prompt bytes (``SYSTEM_PROMPT``),
+      * the full user prompt as ``build_user_prompt(method, …)``
+        renders it — including the instruction wrapper and the
+        ``json.dumps(..., indent=2)`` payload — so the budget reflects
+        what actually crosses the wire to the model.
     """
-    if len(stories) <= cap:
-        return list(stories), []
-    by_freshness = sorted(stories, key=lambda s: s.updated_at)
-    return by_freshness[:cap], by_freshness[cap:]
+    stories_payload = json.dumps([_story_payload(s) for s in stories], indent=2)
+    user_prompt = build_user_prompt(method, stories_payload)
+    return len(SYSTEM_PROMPT.encode("utf-8")) + len(user_prompt.encode("utf-8"))
 
 
-def _trim_to_prompt_budget(
-    stories: list[Story], byte_budget: int
-) -> tuple[list[Story], list[Story]]:
-    """Trim ``stories`` so the JSON payload fits in ``byte_budget``.
+def _select_grooming_candidates(
+    method: GroomMethod, stories: list[Story], *, cap: int, byte_budget: int
+) -> tuple[list[Story], list[Story], list[Story]]:
+    """Pick up to ``cap`` stories that fit in ``byte_budget``.
 
-    Story-count caps don't protect against a small backlog with very
-    long ``user_story`` fields (Codex flagged this in PR #369). We
-    accumulate the indented JSON payload story-by-story; if a story
-    would push us past the budget, we *skip that one* and try the
-    next — a single oversize story shouldn't block scoring of every
-    later (potentially small) story. Codex flagged the previous
-    "break on first overflow" version because in sustained large
-    backlogs a single pathological item could permanently defer the
-    rest of the tail across runs.
+    Returns ``(scored, count_deferred, byte_deferred)``. Codex flagged
+    a starvation case in the previous two-stage selection: when
+    ``cap=1`` and the oldest candidate is always over the byte budget,
+    the trim returned ``scored=[]`` every run, the oldest story's
+    ``updated_at`` never advanced, and newer stories that would fit
+    were permanently deferred for count-cap reasons even though there
+    was prompt room for them. The fix folds the two stages into one
+    pass so byte-deferred stories don't consume cap slots:
 
-    The byte estimate matches what ``_call_llm`` actually serialises
-    (via ``_serialised_list_size`` below — same ``indent=2``, same
-    separators), so the trimmer can't undercount and let an indented
-    prompt overrun the budget.
+      * sort by ``updated_at`` ascending (oldest-touched first);
+      * for each story, if it'd push the prompt past ``byte_budget``,
+        defer it as **byte_deferred** — it does *not* count against
+        ``cap``;
+      * else, if we already have ``cap`` kept, defer the rest as
+        **count_deferred** — still surfaced with the count-cap
+        rationale so an operator knows which control to tune;
+      * else, keep it.
 
-    Returns ``(scored, deferred)`` so deferred stories can surface in
-    the result with the byte-budget rationale. ``scored`` may be
-    empty (every candidate too large); the caller skips the LLM
-    altogether in that case.
+    Stable sort within ``updated_at`` ties keeps selection
+    deterministic across runs.
     """
     if not stories:
-        return [], []
-    kept: list[Story] = []
-    deferred: list[Story] = []
-    for story in stories:
-        # Recompute the indented size with this story added. Slightly
-        # more expensive than incremental delta tracking, but matches
-        # `_call_llm`'s `json.dumps(..., indent=2)` exactly so the
-        # budget can't drift if the indent ever changes.
-        candidate = kept + [story]
-        if _serialised_list_size(candidate) > byte_budget:
-            deferred.append(story)
+        return [], [], []
+    by_freshness = sorted(stories, key=lambda s: s.updated_at)
+    scored: list[Story] = []
+    count_deferred: list[Story] = []
+    byte_deferred: list[Story] = []
+    for story in by_freshness:
+        if len(scored) >= cap:
+            count_deferred.append(story)
             continue
-        kept.append(story)
-    return kept, deferred
-
-
-def _serialised_list_size(stories: list[Story]) -> int:
-    """Byte size of the JSON list `_call_llm` will actually send.
-
-    Mirrors ``json.dumps([...], indent=2)`` exactly — including the
-    enclosing ``[`` / ``]``, the `,\\n  ` separators between items,
-    and the per-key indentation — so ``_trim_to_prompt_budget`` can't
-    undercount the payload by measuring with compact formatting and
-    let the prompt still overrun the budget.
-    """
-    return len(json.dumps([_story_payload(s) for s in stories], indent=2).encode("utf-8"))
+        candidate = scored + [story]
+        if _full_prompt_size(method, candidate) > byte_budget:
+            byte_deferred.append(story)
+            continue
+        scored.append(story)
+    return scored, count_deferred, byte_deferred
 
 
 def _fallback_item(story: Story, method: GroomMethod, rationale: str) -> RankedBacklogItem:
@@ -395,18 +385,21 @@ class ProductOwnerAgent:
         # rationale) so callers see them; they just aren't scored this
         # run.
         #
-        # Two-stage cap:
-        #   1. Story count (oldest-`updated_at` first so each run
-        #      rotates the window — see `_select_grooming_window` —
-        #      newer stories aren't permanently starved).
-        #   2. Serialized-payload byte budget (so a small backlog with
-        #      verbose `user_story` fields can't still overrun model
-        #      context). Trims from the tail of the size-sorted slice
-        #      until the JSON fits.
+        # Combined cap + byte-budget selection:
+        # Codex flagged a starvation case where the two-stage version
+        # (count cap first, then byte trim) could leave `scored_stories`
+        # empty forever under cap=1 + an oldest oversize story —
+        # `updated_at` never advanced, the oversize story stayed at the
+        # front of the freshness queue, and newer stories that would
+        # actually fit were permanently deferred. `_select_grooming_candidates`
+        # iterates the freshness-sorted list once and only consumes a
+        # cap slot when a story is *actually kept*, so a byte-deferral
+        # rolls forward to the next candidate instead of blocking the run.
         cap = _max_stories_per_groom()
         prompt_bytes_cap = _max_prompt_bytes_per_groom()
-        scored_stories, count_deferred = _select_grooming_window(stories, cap)
-        scored_stories, byte_deferred = _trim_to_prompt_budget(scored_stories, prompt_bytes_cap)
+        scored_stories, count_deferred, byte_deferred = _select_grooming_candidates(
+            method, stories, cap=cap, byte_budget=prompt_bytes_cap
+        )
         # Track the deferral cause separately so the rationale points
         # operators at the right control to tune (story-count cap vs.
         # prompt-byte budget) — Codex flagged that conflating the two
@@ -501,7 +494,7 @@ class ProductOwnerAgent:
 
     def _call_llm(self, method: GroomMethod, stories: list[Story]) -> dict[str, Any]:
         # Use the shared `_story_payload` helper so the byte-budget
-        # estimate in `_trim_to_prompt_budget` matches what's actually
+        # estimate in `_full_prompt_size` matches what's actually
         # serialised here. Otherwise an indent-2 difference would
         # silently let the prompt overrun the budget.
         stories_payload = json.dumps(

--- a/backend/agents/product_delivery/product_owner_agent/prompts.py
+++ b/backend/agents/product_delivery/product_owner_agent/prompts.py
@@ -1,0 +1,57 @@
+"""Prompt templates for the ProductOwnerAgent.
+
+The agent asks the model for *scoring inputs* (cost-of-delay components,
+RICE components) — never for the score itself. Scores are computed by
+the deterministic functions in :mod:`product_delivery.scoring` so a
+re-groom over the same backlog produces consistent, auditable numbers.
+"""
+
+from __future__ import annotations
+
+SYSTEM_PROMPT = (
+    "You are an experienced Product Owner. You estimate the value, urgency, "
+    "and effort of stories so that the deterministic WSJF / RICE formulas "
+    "below can rank them. You never invent the final score — you only "
+    "produce the inputs the formulas consume."
+)
+
+
+WSJF_INSTRUCTIONS = """
+For each story, return WSJF input components on a 1..10 scale (10 = highest):
+
+- user_business_value: customer or business value if shipped today
+- time_criticality: how quickly this loses value if delayed (regulation,
+  market window, dependency)
+- risk_reduction_or_opportunity_enablement: how much it de-risks future
+  work or unlocks new capability
+- job_size: relative effort (1 = trivial, 10 = multi-sprint epic). Use
+  the story's estimate_points if present; otherwise infer from scope.
+
+Also include a one-sentence rationale.
+"""
+
+
+RICE_INSTRUCTIONS = """
+For each story, return RICE input components:
+
+- reach: people impacted per quarter (raw count, e.g. 5000)
+- impact: 0.25 (minimal) | 0.5 (low) | 1 (medium) | 2 (high) | 3 (massive)
+- confidence: 0..1 (0.5 = medium confidence). Lower this when the value
+  estimate relies on speculation.
+- effort: person-months (use estimate_points / 4 if estimate present,
+  else infer)
+
+Also include a one-sentence rationale.
+"""
+
+
+def build_user_prompt(method: str, stories_payload: str) -> str:
+    instructions = WSJF_INSTRUCTIONS if method == "wsjf" else RICE_INSTRUCTIONS
+    return (
+        f"Score the following backlog stories using {method.upper()}.\n"
+        f"{instructions}\n"
+        "Respond as a JSON object with the shape:\n"
+        '  {"items": [{"id": "<story_id>", "inputs": {...}, "rationale": "..."}]}\n\n'
+        "Only include stories present in the input. Do not invent ids.\n\n"
+        f"Stories:\n{stories_payload}"
+    )

--- a/backend/agents/product_delivery/scoring.py
+++ b/backend/agents/product_delivery/scoring.py
@@ -11,13 +11,38 @@ Both formulas are well-established product-prioritisation heuristics:
   ``confidence`` is a 0..1 multiplier (60% → 0.6). Effort of zero is
   treated as 1 for the same reason as WSJF.
 
-Each function returns a ``float`` rounded to four decimals so the
-persisted ``DOUBLE PRECISION`` column is stable across re-grooms.
+Each function returns a finite ``float`` rounded to four decimals so the
+persisted ``DOUBLE PRECISION`` column is stable across re-grooms. If
+arithmetic on caller-supplied finite inputs would overflow (e.g. very
+large ``reach * impact`` in RICE), the result is clamped to a finite
+sentinel (``sys.float_info.max``) before rounding rather than returned
+as ``inf`` — non-finite scores break Starlette's JSON encoder when
+serialised back through ``/backlog`` or ``/groom``.
 """
 
 from __future__ import annotations
 
+import math
+import sys
 from dataclasses import dataclass
+
+_FINITE_MAX = sys.float_info.max
+
+
+def _finite_round(value: float) -> float:
+    """Round to 4 dp; clamp ``±inf`` to ``±sys.float_info.max`` first.
+
+    Always returns a finite float, so persistence and JSON serialisation
+    downstream can't trip on a non-finite score.
+    """
+    if not math.isfinite(value):
+        # NaN propagates through arithmetic too; treat it like +inf so
+        # the caller still gets a deterministic finite number.
+        if math.isnan(value) or value > 0:
+            value = _FINITE_MAX
+        else:
+            value = -_FINITE_MAX
+    return round(value, 4)
 
 
 @dataclass(frozen=True)
@@ -44,7 +69,7 @@ def wsjf_score(inputs: WSJFInputs) -> float:
         + max(0.0, inputs.risk_reduction_or_opportunity_enablement)
     )
     job_size = inputs.job_size if inputs.job_size > 0 else 1.0
-    return round(cost_of_delay / job_size, 4)
+    return _finite_round(cost_of_delay / job_size)
 
 
 def rice_score(inputs: RICEInputs) -> float:
@@ -55,7 +80,4 @@ def rice_score(inputs: RICEInputs) -> float:
     """
     confidence = min(1.0, max(0.0, inputs.confidence))
     effort = inputs.effort if inputs.effort > 0 else 1.0
-    return round(
-        (max(0.0, inputs.reach) * max(0.0, inputs.impact) * confidence) / effort,
-        4,
-    )
+    return _finite_round((max(0.0, inputs.reach) * max(0.0, inputs.impact) * confidence) / effort)

--- a/backend/agents/product_delivery/scoring.py
+++ b/backend/agents/product_delivery/scoring.py
@@ -1,0 +1,61 @@
+"""WSJF and RICE scoring — pure functions, no I/O.
+
+Both formulas are well-established product-prioritisation heuristics:
+
+* **WSJF** (SAFe): ``Cost of Delay / Job Size`` where Cost of Delay is
+  ``user_business_value + time_criticality + risk_reduction_or_opportunity_enablement``.
+  Higher is better. Job size of zero is treated as 1 to avoid division by
+  zero; callers should guard against missing estimates upstream.
+
+* **RICE** (Intercom): ``(reach * impact * confidence) / effort``.
+  ``confidence`` is a 0..1 multiplier (60% → 0.6). Effort of zero is
+  treated as 1 for the same reason as WSJF.
+
+Each function returns a ``float`` rounded to four decimals so the
+persisted ``DOUBLE PRECISION`` column is stable across re-grooms.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class WSJFInputs:
+    user_business_value: float
+    time_criticality: float
+    risk_reduction_or_opportunity_enablement: float
+    job_size: float
+
+
+@dataclass(frozen=True)
+class RICEInputs:
+    reach: float
+    impact: float
+    confidence: float
+    effort: float
+
+
+def wsjf_score(inputs: WSJFInputs) -> float:
+    """Cost of Delay divided by Job Size. Higher is better."""
+    cost_of_delay = (
+        max(0.0, inputs.user_business_value)
+        + max(0.0, inputs.time_criticality)
+        + max(0.0, inputs.risk_reduction_or_opportunity_enablement)
+    )
+    job_size = inputs.job_size if inputs.job_size > 0 else 1.0
+    return round(cost_of_delay / job_size, 4)
+
+
+def rice_score(inputs: RICEInputs) -> float:
+    """(reach * impact * confidence) / effort. Higher is better.
+
+    ``confidence`` is expected as a 0..1 multiplier; values outside that
+    range are clamped so a stray "60" doesn't blow up the score by 100x.
+    """
+    confidence = min(1.0, max(0.0, inputs.confidence))
+    effort = inputs.effort if inputs.effort > 0 else 1.0
+    return round(
+        (max(0.0, inputs.reach) * max(0.0, inputs.impact) * confidence) / effort,
+        4,
+    )

--- a/backend/agents/product_delivery/store.py
+++ b/backend/agents/product_delivery/store.py
@@ -393,6 +393,14 @@ class ProductDeliveryStore:
 
     @timed_query(store=_STORE, op="get_backlog_tree")
     def get_backlog_tree(self, product_id: str) -> BacklogTree | None:
+        """Nested backlog projection for a single product.
+
+        Five queries total — one per level of the hierarchy plus the
+        product row — instead of N+1 fan-out. Children are bucketed by
+        parent id in Python and the tree is assembled in a single pass.
+        Cost is O(rows), not O(stories) round trips, so a product with
+        a few hundred stories no longer thrashes the connection pool.
+        """
         product = self.get_product(product_id)
         if product is None:
             return None
@@ -405,51 +413,85 @@ class ProductDeliveryStore:
                 (product_id,),
             )
             initiatives_raw = cur.fetchall()
-            initiatives: list[InitiativeNode] = []
-            for irow in initiatives_raw:
+            if not initiatives_raw:
+                return BacklogTree(product=product, initiatives=[])
+            initiative_ids = [i["id"] for i in initiatives_raw]
+
+            cur.execute(
+                """SELECT id, initiative_id, title, summary, status, wsjf_score, rice_score,
+                          author, created_at, updated_at
+                   FROM product_delivery_epics
+                   WHERE initiative_id = ANY(%s)
+                   ORDER BY created_at""",
+                (initiative_ids,),
+            )
+            epics_raw = cur.fetchall()
+            epic_ids = [e["id"] for e in epics_raw]
+
+            stories_raw: list[dict[str, Any]] = []
+            tasks_raw: list[dict[str, Any]] = []
+            acs_raw: list[dict[str, Any]] = []
+            if epic_ids:
                 cur.execute(
-                    """SELECT id, initiative_id, title, summary, status, wsjf_score, rice_score,
-                              author, created_at, updated_at
-                       FROM product_delivery_epics WHERE initiative_id = %s
+                    """SELECT id, epic_id, title, user_story, status, wsjf_score, rice_score,
+                              estimate_points, author, created_at, updated_at
+                       FROM product_delivery_stories
+                       WHERE epic_id = ANY(%s)
                        ORDER BY created_at""",
-                    (irow["id"],),
+                    (epic_ids,),
                 )
-                epics_raw = cur.fetchall()
-                epics: list[EpicNode] = []
-                for erow in epics_raw:
+                stories_raw = cur.fetchall()
+                story_ids = [s["id"] for s in stories_raw]
+                if story_ids:
                     cur.execute(
-                        """SELECT id, epic_id, title, user_story, status, wsjf_score, rice_score,
-                                  estimate_points, author, created_at, updated_at
-                           FROM product_delivery_stories WHERE epic_id = %s
+                        """SELECT id, story_id, title, description, status, owner,
+                                  author, created_at, updated_at
+                           FROM product_delivery_tasks
+                           WHERE story_id = ANY(%s)
                            ORDER BY created_at""",
-                        (erow["id"],),
+                        (story_ids,),
                     )
-                    stories_raw = cur.fetchall()
-                    stories: list[StoryNode] = []
-                    for srow in stories_raw:
-                        cur.execute(
-                            """SELECT id, story_id, title, description, status, owner,
-                                      author, created_at, updated_at
-                               FROM product_delivery_tasks WHERE story_id = %s
-                               ORDER BY created_at""",
-                            (srow["id"],),
-                        )
-                        tasks = [Task.model_validate(t) for t in cur.fetchall()]
-                        cur.execute(
-                            """SELECT id, story_id, text, satisfied, author,
-                                      created_at, updated_at
-                               FROM product_delivery_acceptance_criteria
-                               WHERE story_id = %s ORDER BY created_at""",
-                            (srow["id"],),
-                        )
-                        acs = [AcceptanceCriterion.model_validate(a) for a in cur.fetchall()]
-                        stories.append(
-                            StoryNode.model_validate(
-                                {**srow, "tasks": tasks, "acceptance_criteria": acs}
-                            )
-                        )
-                    epics.append(EpicNode.model_validate({**erow, "stories": stories}))
-                initiatives.append(InitiativeNode.model_validate({**irow, "epics": epics}))
+                    tasks_raw = cur.fetchall()
+                    cur.execute(
+                        """SELECT id, story_id, text, satisfied, author,
+                                  created_at, updated_at
+                           FROM product_delivery_acceptance_criteria
+                           WHERE story_id = ANY(%s)
+                           ORDER BY created_at""",
+                        (story_ids,),
+                    )
+                    acs_raw = cur.fetchall()
+
+        # Bucket children by parent id, preserving fetch order (which is
+        # already created_at thanks to the ORDER BY above).
+        tasks_by_story: dict[str, list[Task]] = {}
+        for t in tasks_raw:
+            tasks_by_story.setdefault(t["story_id"], []).append(Task.model_validate(t))
+        acs_by_story: dict[str, list[AcceptanceCriterion]] = {}
+        for a in acs_raw:
+            acs_by_story.setdefault(a["story_id"], []).append(AcceptanceCriterion.model_validate(a))
+        stories_by_epic: dict[str, list[StoryNode]] = {}
+        for srow in stories_raw:
+            stories_by_epic.setdefault(srow["epic_id"], []).append(
+                StoryNode.model_validate(
+                    {
+                        **srow,
+                        "tasks": tasks_by_story.get(srow["id"], []),
+                        "acceptance_criteria": acs_by_story.get(srow["id"], []),
+                    }
+                )
+            )
+        epics_by_initiative: dict[str, list[EpicNode]] = {}
+        for erow in epics_raw:
+            epics_by_initiative.setdefault(erow["initiative_id"], []).append(
+                EpicNode.model_validate({**erow, "stories": stories_by_epic.get(erow["id"], [])})
+            )
+        initiatives = [
+            InitiativeNode.model_validate(
+                {**irow, "epics": epics_by_initiative.get(irow["id"], [])}
+            )
+            for irow in initiatives_raw
+        ]
         return BacklogTree(product=product, initiatives=initiatives)
 
     @timed_query(store=_STORE, op="list_stories_for_product")

--- a/backend/agents/product_delivery/store.py
+++ b/backend/agents/product_delivery/store.py
@@ -169,6 +169,22 @@ _FEEDBACK_COLS = (
 _T = TypeVar("_T", bound=BaseModel)
 
 
+def _begin_repeatable_read(cur: Any) -> None:
+    """Pin the current transaction to ``REPEATABLE READ`` snapshot isolation.
+
+    psycopg3 in non-autocommit mode auto-begins a transaction on the
+    first statement; ``SET TRANSACTION ISOLATION LEVEL …`` issued before
+    any data-touching statement applies to that transaction. Used by
+    the multi-statement read methods (``get_backlog_tree``,
+    ``list_stories_for_product``, ``list_feedback``) so an existence
+    check + the matching read see the same snapshot — under the
+    default ``READ COMMITTED`` each statement gets its own snapshot
+    and a concurrent delete between them can return ``200 []`` for a
+    product that no longer exists.
+    """
+    cur.execute("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+
+
 def _bucket_by(rows: list[dict[str, Any]], key: str, model: type[_T]) -> dict[str, list[_T]]:
     """Group raw row dicts by `parent_id` and validate them through ``model``.
 
@@ -278,7 +294,7 @@ class ProductDeliveryStore:
             product_id=product_id,
             title=title,
             summary=summary,
-            status=status,
+            status=_validate_status(status),
             author=author,
         )
 
@@ -291,7 +307,7 @@ class ProductDeliveryStore:
             initiative_id=initiative_id,
             title=title,
             summary=summary,
-            status=status,
+            status=_validate_status(status),
             author=author,
         )
 
@@ -332,7 +348,7 @@ class ProductDeliveryStore:
             story_id=story_id,
             title=title,
             description=description,
-            status=status,
+            status=_validate_status(status),
             owner=owner,
             author=author,
         )
@@ -452,16 +468,28 @@ class ProductDeliveryStore:
     def get_backlog_tree(self, product_id: str) -> BacklogTree | None:
         """Nested backlog projection for a single product.
 
-        Five queries total — one per level of the hierarchy plus the
-        product row — instead of N+1 fan-out. Children are bucketed by
-        parent id in Python and the tree is assembled in a single pass.
-        Cost is O(rows), not O(stories) round trips, so a product with
-        a few hundred stories no longer thrashes the connection pool.
+        Five queries total — product row + one per level of the hierarchy
+        — instead of N+1 fan-out. Children are bucketed by parent id in
+        Python and the tree is assembled in a single pass. Cost is
+        O(rows), not O(stories) round trips, so a product with a few
+        hundred stories no longer thrashes the connection pool.
+
+        All five SELECTs run inside a single ``REPEATABLE READ``
+        transaction so the projection comes from one consistent snapshot
+        — otherwise concurrent writes between the per-level fetches
+        could yield stale product metadata next to vanished children
+        (or vice versa).
         """
-        product = self.get_product(product_id)
-        if product is None:
-            return None
         with self._conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+            _begin_repeatable_read(cur)
+            cur.execute(
+                f"SELECT {_PRODUCT_COLS} FROM product_delivery_products WHERE id = %s",
+                (product_id,),
+            )
+            product_row = cur.fetchone()
+            if product_row is None:
+                return None
+            product = Product.model_validate(product_row)
             cur.execute(
                 f"""SELECT {_INITIATIVE_COLS}
                    FROM product_delivery_initiatives WHERE product_id = %s
@@ -547,11 +575,14 @@ class ProductDeliveryStore:
         """Flat list of every story under a product. Used by the grooming agent.
 
         Raises ``UnknownProductDeliveryEntity`` if the product doesn't
-        exist (the existence check + the story SELECT run in a single
-        connection so concurrent deletes can't make the route return
-        ``200 []`` for a missing product).
+        exist. The existence check + the story SELECT run inside a
+        single ``REPEATABLE READ`` transaction so they observe the same
+        snapshot — under the default ``READ COMMITTED`` a concurrent
+        delete between the two statements could otherwise return
+        ``200 []`` for a missing product.
         """
         with self._conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+            _begin_repeatable_read(cur)
             cur.execute(
                 "SELECT 1 FROM product_delivery_products WHERE id = %s",
                 (product_id,),
@@ -674,9 +705,11 @@ class ProductDeliveryStore:
         """List feedback items under a product.
 
         Raises ``UnknownProductDeliveryEntity`` when the product doesn't
-        exist — the existence check + the feedback SELECT run in a
-        single connection so a concurrent delete can't make the route
-        return ``200 []`` for a missing product.
+        exist. The existence check + the feedback SELECT run inside a
+        single ``REPEATABLE READ`` transaction so they observe the same
+        snapshot — under the default ``READ COMMITTED`` a concurrent
+        delete between the two statements could otherwise return
+        ``200 []`` for a missing product.
         """
         sql = f"SELECT {_FEEDBACK_COLS} FROM product_delivery_feedback_items WHERE product_id = %s"
         params: list[Any] = [product_id]
@@ -685,6 +718,7 @@ class ProductDeliveryStore:
             params.append(status)
         sql += " ORDER BY created_at DESC"
         with self._conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+            _begin_repeatable_read(cur)
             cur.execute(
                 "SELECT 1 FROM product_delivery_products WHERE id = %s",
                 (product_id,),

--- a/backend/agents/product_delivery/store.py
+++ b/backend/agents/product_delivery/store.py
@@ -36,6 +36,7 @@ from datetime import datetime, timezone
 from typing import Any, Iterable, TypeVar
 from uuid import uuid4
 
+import psycopg
 from psycopg import errors as psycopg_errors
 from psycopg.rows import dict_row
 from psycopg.types.json import Json
@@ -121,29 +122,70 @@ _STATUS_MAX_LEN = 40
 _TITLE_MAX_LEN = 200
 
 
-def _validate_status(value: str) -> str:
-    # `not value.strip()` rejects whitespace-only strings (`'   '`,
-    # `'\t'`) that pass the length check but represent semantically
-    # empty workflow states. Without this they'd persist and propagate
-    # through backlog + feedback projections as if they were valid
-    # statuses.
-    if not value or not value.strip() or len(value) > _STATUS_MAX_LEN:
-        raise ValueError(f"status must be 1..{_STATUS_MAX_LEN} non-blank chars; got {len(value)}")
-    return value
+def _validate_status(value: Any) -> str:
+    # `isinstance(value, str)` first: non-route callers handing in a
+    # non-string (int, dict, None) used to trip ``len(value)`` with a
+    # raw ``TypeError`` that fell past the route's exception map and
+    # surfaced as 500. Surface a domain ``ValueError`` instead so the
+    # route translates it cleanly to 422.
+    #
+    # Then strip+normalise: the API-side `_reject_blank_str` now
+    # *strips* leading/trailing whitespace too, so accidental inputs
+    # like ``"open "`` no longer become a distinct persisted state
+    # that misses exact-match filters (``GET /feedback?status=open``).
+    if not isinstance(value, str):
+        raise ValueError(f"status must be a string; got {type(value).__name__}")
+    stripped = value.strip()
+    if not stripped or len(stripped) > _STATUS_MAX_LEN:
+        raise ValueError(
+            f"status must be 1..{_STATUS_MAX_LEN} non-blank chars; got {len(stripped)}"
+        )
+    return stripped
 
 
-def _validate_title(value: str, *, label: str = "title") -> str:
+def _validate_title(value: Any, *, label: str = "title") -> str:
     """Mirror the API-level ``min_length=1, max_length=200`` bound.
 
     Used by ``create_product`` / ``create_initiative`` / ``create_epic``
     / ``create_story`` / ``create_task`` so internal callers (the
     ProductOwnerAgent, future workflow code, etc.) can't bypass route
     validation and persist empty / oversized / whitespace-only titles
-    that the HTTP contract rejects.
+    that the HTTP contract rejects. Strips leading/trailing whitespace
+    so ``"S "`` and ``"S"`` don't diverge between API and store paths.
     """
-    if not value or not value.strip() or len(value) > _TITLE_MAX_LEN:
-        raise ValueError(f"{label} must be 1..{_TITLE_MAX_LEN} non-blank chars; got {len(value)}")
-    return value
+    if not isinstance(value, str):
+        raise ValueError(f"{label} must be a string; got {type(value).__name__}")
+    stripped = value.strip()
+    if not stripped or len(stripped) > _TITLE_MAX_LEN:
+        raise ValueError(
+            f"{label} must be 1..{_TITLE_MAX_LEN} non-blank chars; got {len(stripped)}"
+        )
+    return stripped
+
+
+def _validate_text(value: Any, *, label: str, max_len: int | None = None) -> str:
+    """Generic non-blank string validator used by feedback ``source`` /
+    acceptance-criterion ``text``.
+
+    Matches the API-side ``_reject_blank_str`` contract: rejects empty,
+    rejects non-strings (so non-route callers handing in ``None`` or
+    a dict don't trigger ``TypeError`` past the route's exception map),
+    rejects whitespace-only, and strips leading/trailing whitespace
+    on the way out. ``max_len`` mirrors the API ``Field(max_length=…)``
+    when set; ``None`` means "no upper bound" (acceptance-criterion
+    text is unbounded at the API).
+    """
+    if not isinstance(value, str):
+        raise ValueError(f"{label} must be a string; got {type(value).__name__}")
+    stripped = value.strip()
+    if not stripped:
+        raise ValueError(f"{label} must not be blank or whitespace-only")
+    if max_len is not None and len(stripped) > max_len:
+        raise ValueError(f"{label} must be at most {max_len} chars; got {len(stripped)}")
+    return stripped
+
+
+_FEEDBACK_SOURCE_MAX_LEN = 120
 
 
 def _validate_optional_finite_score(value: float | None, *, label: str) -> float | None:
@@ -387,10 +429,13 @@ class ProductDeliveryStore:
     def create_acceptance_criterion(
         self, *, story_id: str, text: str, satisfied: bool, author: str
     ) -> AcceptanceCriterion:
+        # Mirror the API-side `_reject_blank_str` so non-route callers
+        # can't persist whitespace-only criteria that would inflate
+        # criterion counts and undermine the satisfied/total ratio.
         return self._insert(
             "ac",
             story_id=story_id,
-            text=text,
+            text=_validate_text(text, label="text"),
             satisfied=satisfied,
             author=author,
         )
@@ -652,6 +697,17 @@ class ProductDeliveryStore:
         # The INSERT is also wrapped in a FK-violation handler so a
         # concurrent delete between validation and insert surfaces as
         # 404, not a raw 500.
+        #
+        # Mirror the API-side validators so non-route callers can't
+        # bypass the HTTP contract:
+        #   * `source` — `min_length=1, max_length=120, non-blank`
+        #   * `raw_payload` — must be a dict (it's serialised as JSONB,
+        #     and `FeedbackItem.raw_payload: dict[str, Any]` will fail
+        #     model-validate on a non-dict, but only *after* the row is
+        #     committed — a 500 with a poisoned row already in the DB).
+        source = _validate_text(source, label="source", max_len=_FEEDBACK_SOURCE_MAX_LEN)
+        if not isinstance(raw_payload, dict):
+            raise ValueError(f"raw_payload must be a dict; got {type(raw_payload).__name__}")
         now = _now()
         fid = _new_id()
         try:
@@ -801,9 +857,15 @@ class _SafeConn:
 
     # psycopg query-time exceptions that mean "infra is broken"
     # (transport down, schema not deployed, pool poisoned). Each maps
-    # naturally to 503 — clients should retry. Specific subclasses are
-    # listed before broader bases so the isinstance check below picks
-    # the most precise mapping in the log line.
+    # naturally to 503 — clients should retry. Order matters only for
+    # the diagnostic log line (the most-specific match wins via the
+    # ``type(exc).__name__`` we record).
+    #
+    # Also includes the *base classes* ``OperationalError`` and
+    # ``InterfaceError`` so that transport-layer failures raised
+    # without a SQLSTATE-derived subclass (e.g. raw socket-closed
+    # errors from psycopg) still map to 503 instead of falling
+    # through as 500.
     _INFRA_EXC_TYPES = (
         psycopg_errors.UndefinedTable,
         psycopg_errors.UndefinedColumn,
@@ -813,6 +875,8 @@ class _SafeConn:
         psycopg_errors.ConnectionException,
         psycopg_errors.ConnectionFailure,
         psycopg_errors.SqlclientUnableToEstablishSqlconnection,
+        psycopg.OperationalError,
+        psycopg.InterfaceError,
     )
 
     def __init__(self) -> None:
@@ -832,14 +896,23 @@ class _SafeConn:
         if self._cm is None:
             return False
         # Always let the pool's CM tear down (commit/rollback, return
-        # connection) — we're going to *replace* the exception, not
-        # suppress it.
+        # connection). If teardown itself raises (e.g. connection lost
+        # during commit on a write path), we *must* let the caller see
+        # it — silently logging would let a route report 200 on a
+        # write that never committed. Translate it to
+        # ``ProductDeliveryStorageUnavailable`` so the route returns
+        # 503 (retryable) rather than the previous "log + return False"
+        # which lost the failure entirely.
         try:
             self._cm.__exit__(exc_type, exc, tb)
-        except Exception:  # pragma: no cover — pool teardown failures
-            # Don't lose the original error if pool teardown also
-            # raises; just log and continue to the translation step.
-            logger.warning("ProductDeliveryStore: pool teardown raised", exc_info=True)
+        except Exception as teardown_exc:  # pragma: no cover — infra paths
+            logger.warning(
+                "ProductDeliveryStore: pool teardown raised %s; mapping to "
+                "ProductDeliveryStorageUnavailable so caller doesn't report success",
+                type(teardown_exc).__name__,
+                exc_info=True,
+            )
+            raise ProductDeliveryStorageUnavailable(str(teardown_exc)) from teardown_exc
         # Translate infra-class exceptions to ProductDeliveryStorageUnavailable
         # so the route handler returns 503. Domain exceptions raised
         # by the store itself (``UnknownProductDeliveryEntity``,

--- a/backend/agents/product_delivery/store.py
+++ b/backend/agents/product_delivery/store.py
@@ -55,6 +55,16 @@ class UnknownProductDeliveryEntity(LookupError):
     """A foreign-key target (product/initiative/epic/story) does not exist."""
 
 
+class CrossProductFeedbackLink(ValueError):
+    """A feedback item tried to link to a story under a different product.
+
+    The schema's two FKs (``product_id`` and ``linked_story_id``) cannot
+    enforce this on their own — the story is reachable only via
+    ``epic → initiative → product``. We validate at the store layer so
+    triage stays scoped to the right product.
+    """
+
+
 class ProductDeliveryStore:
     """Stateless DAL. Construct once per process; pool is shared."""
 
@@ -478,6 +488,29 @@ class ProductDeliveryStore:
         fid = _new_id()
         try:
             with self._conn() as conn, conn.cursor() as cur:
+                # When linked_story_id is set, verify the story is under the
+                # same product as the feedback item (story → epic → initiative
+                # → product). Done inside the same transaction so a concurrent
+                # delete of the linking chain can't slip a stale row past us.
+                if linked_story_id is not None:
+                    cur.execute(
+                        """SELECT i.product_id
+                           FROM product_delivery_stories s
+                           JOIN product_delivery_epics e ON e.id = s.epic_id
+                           JOIN product_delivery_initiatives i ON i.id = e.initiative_id
+                           WHERE s.id = %s""",
+                        (linked_story_id,),
+                    )
+                    row = cur.fetchone()
+                    if row is None:
+                        raise UnknownProductDeliveryEntity(
+                            f"story {linked_story_id!r} does not exist"
+                        )
+                    if row[0] != product_id:
+                        raise CrossProductFeedbackLink(
+                            f"story {linked_story_id!r} belongs to product "
+                            f"{row[0]!r}, not {product_id!r}"
+                        )
                 cur.execute(
                     """INSERT INTO product_delivery_feedback_items
                           (id, product_id, source, raw_payload, severity, status,

--- a/backend/agents/product_delivery/store.py
+++ b/backend/agents/product_delivery/store.py
@@ -116,6 +116,14 @@ _STORY_COLS = (
     f"id, epic_id, title, user_story, status, wsjf_score, rice_score, "
     f"estimate_points, {_AUDIT_COLS}"
 )
+# Same projection as ``_STORY_COLS`` but every column qualified with the
+# ``s.`` alias for the ``list_stories_for_product`` JOIN. Maintained
+# explicitly (rather than via string rewriting) so substring matches
+# inside identifiers like ``epic_id`` can't corrupt the SQL.
+_STORY_COLS_ALIASED = (
+    "s.id, s.epic_id, s.title, s.user_story, s.status, s.wsjf_score, "
+    "s.rice_score, s.estimate_points, s.author, s.created_at, s.updated_at"
+)
 _TASK_COLS = f"id, story_id, title, description, status, owner, {_AUDIT_COLS}"
 _AC_COLS = f"id, story_id, text, satisfied, {_AUDIT_COLS}"
 _FEEDBACK_COLS = (
@@ -483,7 +491,7 @@ class ProductDeliveryStore:
         """Flat list of every story under a product. Used by the grooming agent."""
         with self._conn() as conn, conn.cursor(row_factory=dict_row) as cur:
             cur.execute(
-                f"""SELECT {_STORY_COLS.replace("id, ", "s.id, ")}
+                f"""SELECT {_STORY_COLS_ALIASED}
                    FROM product_delivery_stories s
                    JOIN product_delivery_epics e ON e.id = s.epic_id
                    JOIN product_delivery_initiatives i ON i.id = e.initiative_id
@@ -512,48 +520,61 @@ class ProductDeliveryStore:
         # don't go through `_insert` because feedback_items needs the
         # validation-then-insert sequence inside one transaction (so a
         # concurrent delete of the linking chain can't slip past us).
+        # The INSERT is also wrapped in a FK-violation handler so a
+        # concurrent delete between validation and insert surfaces as
+        # 404, not a raw 500.
         now = _now()
         fid = _new_id()
-        with self._conn() as conn, conn.cursor() as cur:
-            cur.execute(
-                "SELECT 1 FROM product_delivery_products WHERE id = %s",
-                (product_id,),
-            )
-            if cur.fetchone() is None:
-                raise UnknownProductDeliveryEntity(f"product {product_id!r} does not exist")
-            if linked_story_id is not None:
+        try:
+            with self._conn() as conn, conn.cursor() as cur:
                 cur.execute(
-                    """SELECT i.product_id
-                       FROM product_delivery_stories s
-                       JOIN product_delivery_epics e ON e.id = s.epic_id
-                       JOIN product_delivery_initiatives i ON i.id = e.initiative_id
-                       WHERE s.id = %s""",
-                    (linked_story_id,),
+                    "SELECT 1 FROM product_delivery_products WHERE id = %s",
+                    (product_id,),
                 )
-                row = cur.fetchone()
-                if row is None:
-                    raise UnknownProductDeliveryEntity(f"story {linked_story_id!r} does not exist")
-                if row[0] != product_id:
-                    raise CrossProductFeedbackLink(
-                        f"story {linked_story_id!r} belongs to product "
-                        f"{row[0]!r}, not {product_id!r}"
+                if cur.fetchone() is None:
+                    raise UnknownProductDeliveryEntity(f"product {product_id!r} does not exist")
+                if linked_story_id is not None:
+                    cur.execute(
+                        """SELECT i.product_id
+                           FROM product_delivery_stories s
+                           JOIN product_delivery_epics e ON e.id = s.epic_id
+                           JOIN product_delivery_initiatives i ON i.id = e.initiative_id
+                           WHERE s.id = %s""",
+                        (linked_story_id,),
                     )
-            cur.execute(
-                f"""INSERT INTO product_delivery_feedback_items ({_FEEDBACK_COLS})
-                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
-                (
-                    fid,
-                    product_id,
-                    source,
-                    Json(raw_payload),
-                    severity,
-                    "open",
-                    linked_story_id,
-                    author,
-                    now,
-                    now,
-                ),
-            )
+                    row = cur.fetchone()
+                    if row is None:
+                        raise UnknownProductDeliveryEntity(
+                            f"story {linked_story_id!r} does not exist"
+                        )
+                    if row[0] != product_id:
+                        raise CrossProductFeedbackLink(
+                            f"story {linked_story_id!r} belongs to product "
+                            f"{row[0]!r}, not {product_id!r}"
+                        )
+                cur.execute(
+                    f"""INSERT INTO product_delivery_feedback_items ({_FEEDBACK_COLS})
+                       VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+                    (
+                        fid,
+                        product_id,
+                        source,
+                        Json(raw_payload),
+                        severity,
+                        "open",
+                        linked_story_id,
+                        author,
+                        now,
+                        now,
+                    ),
+                )
+        except psycopg_errors.ForeignKeyViolation as exc:
+            # Race: a concurrent caller deleted the product or story
+            # between the validation SELECT and our INSERT. Surface as
+            # the same 404 the eager validation would have produced.
+            raise UnknownProductDeliveryEntity(
+                f"product or story for feedback item disappeared mid-write: {exc}"
+            ) from exc
         return FeedbackItem(
             id=fid,
             product_id=product_id,

--- a/backend/agents/product_delivery/store.py
+++ b/backend/agents/product_delivery/store.py
@@ -772,8 +772,8 @@ class ProductDeliveryStore:
 
 class _SafeConn:
     """Context manager wrapper around ``shared_postgres.get_conn`` that
-    surfaces connection-acquisition failures as
-    :class:`ProductDeliveryStorageUnavailable`.
+    surfaces both connection-acquisition *and* query-time infra
+    failures as :class:`ProductDeliveryStorageUnavailable`.
 
     ``get_conn()`` returns a context manager, but the real connection
     isn't acquired until ``__enter__`` runs (the pool's ``connection()``
@@ -784,12 +784,36 @@ class _SafeConn:
     driver errors, bypassing the route-level 503 mapping and producing
     unhandled 500s.
 
-    This wrapper re-raises any exception from either ``__enter__`` or
-    the underlying CM creation as ``ProductDeliveryStorageUnavailable``
-    so the route's exception handler maps it cleanly to 503 every time.
-    Exit semantics are unchanged — the pool's CM still commits on clean
-    exit, rolls back on exception, and returns the connection to the pool.
+    Codex also flagged that ``cur.execute(...)`` errors raised *inside*
+    the body — most importantly ``UndefinedTable`` when schema
+    registration applied only partially, plus ``OperationalError``
+    when the connection drops mid-query — bypass the same 503 mapping.
+    ``__exit__`` translates those infra errors to
+    ``ProductDeliveryStorageUnavailable`` too, while leaving the store's
+    own typed domain exceptions (``UnknownProductDeliveryEntity``,
+    ``CrossProductFeedbackLink``, ``ForeignKeyViolation``) and
+    ``ValueError`` from the validator helpers untouched.
+
+    Exit semantics are otherwise unchanged — the pool's CM still
+    commits on clean exit, rolls back on exception, and returns the
+    connection to the pool.
     """
+
+    # psycopg query-time exceptions that mean "infra is broken"
+    # (transport down, schema not deployed, pool poisoned). Each maps
+    # naturally to 503 — clients should retry. Specific subclasses are
+    # listed before broader bases so the isinstance check below picks
+    # the most precise mapping in the log line.
+    _INFRA_EXC_TYPES = (
+        psycopg_errors.UndefinedTable,
+        psycopg_errors.UndefinedColumn,
+        psycopg_errors.UndefinedObject,
+        psycopg_errors.AdminShutdown,
+        psycopg_errors.CrashShutdown,
+        psycopg_errors.ConnectionException,
+        psycopg_errors.ConnectionFailure,
+        psycopg_errors.SqlclientUnableToEstablishSqlconnection,
+    )
 
     def __init__(self) -> None:
         self._cm: Any | None = None
@@ -807,7 +831,34 @@ class _SafeConn:
     def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> Any:
         if self._cm is None:
             return False
-        return self._cm.__exit__(exc_type, exc, tb)
+        # Always let the pool's CM tear down (commit/rollback, return
+        # connection) — we're going to *replace* the exception, not
+        # suppress it.
+        try:
+            self._cm.__exit__(exc_type, exc, tb)
+        except Exception:  # pragma: no cover — pool teardown failures
+            # Don't lose the original error if pool teardown also
+            # raises; just log and continue to the translation step.
+            logger.warning("ProductDeliveryStore: pool teardown raised", exc_info=True)
+        # Translate infra-class exceptions to ProductDeliveryStorageUnavailable
+        # so the route handler returns 503. Domain exceptions raised
+        # by the store itself (``UnknownProductDeliveryEntity``,
+        # ``CrossProductFeedbackLink``) and ``ValueError`` from the
+        # validator helpers, plus ``ForeignKeyViolation`` (translated
+        # by callers to ``UnknownProductDeliveryEntity``), all flow
+        # through unchanged.
+        if exc is not None and isinstance(exc, self._INFRA_EXC_TYPES):
+            logger.warning(
+                "ProductDeliveryStore: infra error %s raised inside connection; "
+                "mapping to ProductDeliveryStorageUnavailable",
+                type(exc).__name__,
+            )
+            raise ProductDeliveryStorageUnavailable(str(exc)) from exc
+        # Returning False (or None) lets the original exception, if
+        # any, propagate; returning True would suppress it. Never
+        # suppress — every store method needs the caller to see real
+        # failures.
+        return False
 
 
 def _now() -> datetime:

--- a/backend/agents/product_delivery/store.py
+++ b/backend/agents/product_delivery/store.py
@@ -530,6 +530,16 @@ class ProductDeliveryStore:
         fid = _new_id()
         try:
             with self._conn() as conn, conn.cursor() as cur:
+                # Validate the product first so a bad product_id always
+                # surfaces as 404 (unknown), even when a valid story id
+                # is also supplied. Otherwise the cross-product check
+                # below would misclassify "unknown product" as 400.
+                cur.execute(
+                    "SELECT 1 FROM product_delivery_products WHERE id = %s",
+                    (product_id,),
+                )
+                if cur.fetchone() is None:
+                    raise UnknownProductDeliveryEntity(f"product {product_id!r} does not exist")
                 # When linked_story_id is set, verify the story is under the
                 # same product as the feedback item (story → epic → initiative
                 # → product). Done inside the same transaction so a concurrent

--- a/backend/agents/product_delivery/store.py
+++ b/backend/agents/product_delivery/store.py
@@ -1,0 +1,567 @@
+"""Postgres data-access layer for the Product Delivery team.
+
+Mirrors :mod:`agent_console.store` in shape:
+
+* stateless class — pool lives in ``shared_postgres``;
+* one public method per operation, decorated with ``@timed_query``;
+* methods translate Postgres errors into typed domain exceptions;
+* :func:`get_store` returns a process-wide singleton via ``lru_cache``.
+
+The store does not manage transactions across operations; each method is
+its own transaction (``shared_postgres.get_conn`` commits on clean exit,
+rolls back on error). Multi-row writes that need atomicity (e.g. the
+grooming endpoint persisting scores for many stories) call the store
+inside an explicit transaction at the route layer.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from functools import lru_cache
+from typing import Any, Iterable
+from uuid import uuid4
+
+from psycopg import errors as psycopg_errors
+from psycopg.rows import dict_row
+from psycopg.types.json import Json
+
+from shared_postgres import get_conn, is_postgres_enabled
+from shared_postgres.metrics import timed_query
+
+from .models import (
+    AcceptanceCriterion,
+    BacklogTree,
+    Epic,
+    EpicNode,
+    FeedbackItem,
+    Initiative,
+    InitiativeNode,
+    Product,
+    Story,
+    StoryNode,
+    Task,
+)
+
+logger = logging.getLogger(__name__)
+_STORE = "product_delivery"
+
+
+class ProductDeliveryStorageUnavailable(RuntimeError):
+    """Postgres isn't configured, unreachable, or the pool is shut down."""
+
+
+class UnknownProductDeliveryEntity(LookupError):
+    """A foreign-key target (product/initiative/epic/story) does not exist."""
+
+
+class ProductDeliveryStore:
+    """Stateless DAL. Construct once per process; pool is shared."""
+
+    # ------------------------------------------------------------------
+    # Products
+    # ------------------------------------------------------------------
+
+    @timed_query(store=_STORE, op="create_product")
+    def create_product(self, *, name: str, description: str, vision: str, author: str) -> Product:
+        now = _now()
+        pid = _new_id()
+        with self._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                """INSERT INTO product_delivery_products
+                      (id, name, description, vision, author, created_at, updated_at)
+                   VALUES (%s, %s, %s, %s, %s, %s, %s)""",
+                (pid, name, description, vision, author, now, now),
+            )
+        return Product(
+            id=pid,
+            name=name,
+            description=description,
+            vision=vision,
+            author=author,
+            created_at=now,
+            updated_at=now,
+        )
+
+    @timed_query(store=_STORE, op="list_products")
+    def list_products(self) -> list[Product]:
+        with self._conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                """SELECT id, name, description, vision, author, created_at, updated_at
+                   FROM product_delivery_products
+                   ORDER BY created_at DESC"""
+            )
+            return [Product.model_validate(row) for row in cur.fetchall()]
+
+    @timed_query(store=_STORE, op="get_product")
+    def get_product(self, product_id: str) -> Product | None:
+        with self._conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                """SELECT id, name, description, vision, author, created_at, updated_at
+                   FROM product_delivery_products WHERE id = %s""",
+                (product_id,),
+            )
+            row = cur.fetchone()
+            return Product.model_validate(row) if row else None
+
+    # ------------------------------------------------------------------
+    # Initiatives / Epics / Stories — uniform CRUD via _create_scored.
+    # ------------------------------------------------------------------
+
+    @timed_query(store=_STORE, op="create_initiative")
+    def create_initiative(
+        self,
+        *,
+        product_id: str,
+        title: str,
+        summary: str,
+        status: str,
+        author: str,
+    ) -> Initiative:
+        now = _now()
+        iid = _new_id()
+        try:
+            with self._conn() as conn, conn.cursor() as cur:
+                cur.execute(
+                    """INSERT INTO product_delivery_initiatives
+                          (id, product_id, title, summary, status, author,
+                           created_at, updated_at)
+                       VALUES (%s, %s, %s, %s, %s, %s, %s, %s)""",
+                    (iid, product_id, title, summary, status, author, now, now),
+                )
+        except psycopg_errors.ForeignKeyViolation as exc:
+            raise UnknownProductDeliveryEntity(f"product {product_id!r} does not exist") from exc
+        return Initiative(
+            id=iid,
+            product_id=product_id,
+            title=title,
+            summary=summary,
+            status=status,
+            author=author,
+            created_at=now,
+            updated_at=now,
+        )
+
+    @timed_query(store=_STORE, op="create_epic")
+    def create_epic(
+        self,
+        *,
+        initiative_id: str,
+        title: str,
+        summary: str,
+        status: str,
+        author: str,
+    ) -> Epic:
+        now = _now()
+        eid = _new_id()
+        try:
+            with self._conn() as conn, conn.cursor() as cur:
+                cur.execute(
+                    """INSERT INTO product_delivery_epics
+                          (id, initiative_id, title, summary, status, author,
+                           created_at, updated_at)
+                       VALUES (%s, %s, %s, %s, %s, %s, %s, %s)""",
+                    (eid, initiative_id, title, summary, status, author, now, now),
+                )
+        except psycopg_errors.ForeignKeyViolation as exc:
+            raise UnknownProductDeliveryEntity(
+                f"initiative {initiative_id!r} does not exist"
+            ) from exc
+        return Epic(
+            id=eid,
+            initiative_id=initiative_id,
+            title=title,
+            summary=summary,
+            status=status,
+            author=author,
+            created_at=now,
+            updated_at=now,
+        )
+
+    @timed_query(store=_STORE, op="create_story")
+    def create_story(
+        self,
+        *,
+        epic_id: str,
+        title: str,
+        user_story: str,
+        status: str,
+        estimate_points: float | None,
+        author: str,
+    ) -> Story:
+        now = _now()
+        sid = _new_id()
+        try:
+            with self._conn() as conn, conn.cursor() as cur:
+                cur.execute(
+                    """INSERT INTO product_delivery_stories
+                          (id, epic_id, title, user_story, status,
+                           estimate_points, author, created_at, updated_at)
+                       VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+                    (
+                        sid,
+                        epic_id,
+                        title,
+                        user_story,
+                        status,
+                        estimate_points,
+                        author,
+                        now,
+                        now,
+                    ),
+                )
+        except psycopg_errors.ForeignKeyViolation as exc:
+            raise UnknownProductDeliveryEntity(f"epic {epic_id!r} does not exist") from exc
+        return Story(
+            id=sid,
+            epic_id=epic_id,
+            title=title,
+            user_story=user_story,
+            status=status,
+            estimate_points=estimate_points,
+            author=author,
+            created_at=now,
+            updated_at=now,
+        )
+
+    @timed_query(store=_STORE, op="create_task")
+    def create_task(
+        self,
+        *,
+        story_id: str,
+        title: str,
+        description: str,
+        status: str,
+        owner: str | None,
+        author: str,
+    ) -> Task:
+        now = _now()
+        tid = _new_id()
+        try:
+            with self._conn() as conn, conn.cursor() as cur:
+                cur.execute(
+                    """INSERT INTO product_delivery_tasks
+                          (id, story_id, title, description, status, owner,
+                           author, created_at, updated_at)
+                       VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+                    (tid, story_id, title, description, status, owner, author, now, now),
+                )
+        except psycopg_errors.ForeignKeyViolation as exc:
+            raise UnknownProductDeliveryEntity(f"story {story_id!r} does not exist") from exc
+        return Task(
+            id=tid,
+            story_id=story_id,
+            title=title,
+            description=description,
+            status=status,
+            owner=owner,
+            author=author,
+            created_at=now,
+            updated_at=now,
+        )
+
+    @timed_query(store=_STORE, op="create_acceptance_criterion")
+    def create_acceptance_criterion(
+        self,
+        *,
+        story_id: str,
+        text: str,
+        satisfied: bool,
+        author: str,
+    ) -> AcceptanceCriterion:
+        now = _now()
+        aid = _new_id()
+        try:
+            with self._conn() as conn, conn.cursor() as cur:
+                cur.execute(
+                    """INSERT INTO product_delivery_acceptance_criteria
+                          (id, story_id, text, satisfied, author,
+                           created_at, updated_at)
+                       VALUES (%s, %s, %s, %s, %s, %s, %s)""",
+                    (aid, story_id, text, satisfied, author, now, now),
+                )
+        except psycopg_errors.ForeignKeyViolation as exc:
+            raise UnknownProductDeliveryEntity(f"story {story_id!r} does not exist") from exc
+        return AcceptanceCriterion(
+            id=aid,
+            story_id=story_id,
+            text=text,
+            satisfied=satisfied,
+            author=author,
+            created_at=now,
+            updated_at=now,
+        )
+
+    # ------------------------------------------------------------------
+    # Status / score updates — generic helpers keep route code small.
+    # ------------------------------------------------------------------
+
+    _SCORED_TABLES = {
+        "initiative": "product_delivery_initiatives",
+        "epic": "product_delivery_epics",
+        "story": "product_delivery_stories",
+    }
+    _STATUS_TABLES = {
+        **_SCORED_TABLES,
+        "task": "product_delivery_tasks",
+    }
+
+    @timed_query(store=_STORE, op="update_status")
+    def update_status(self, *, kind: str, entity_id: str, status: str) -> bool:
+        table = self._STATUS_TABLES.get(kind)
+        if table is None:
+            raise ValueError(f"unknown kind for status update: {kind!r}")
+        with self._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                f"UPDATE {table} SET status = %s, updated_at = %s WHERE id = %s",
+                (status, _now(), entity_id),
+            )
+            return cur.rowcount > 0
+
+    @timed_query(store=_STORE, op="update_scores")
+    def update_scores(
+        self,
+        *,
+        kind: str,
+        entity_id: str,
+        wsjf_score: float | None,
+        rice_score: float | None,
+    ) -> bool:
+        table = self._SCORED_TABLES.get(kind)
+        if table is None:
+            raise ValueError(f"unknown kind for score update: {kind!r}")
+        sets: list[str] = []
+        params: list[Any] = []
+        if wsjf_score is not None:
+            sets.append("wsjf_score = %s")
+            params.append(wsjf_score)
+        if rice_score is not None:
+            sets.append("rice_score = %s")
+            params.append(rice_score)
+        if not sets:
+            return False
+        sets.append("updated_at = %s")
+        params.append(_now())
+        params.append(entity_id)
+        with self._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                f"UPDATE {table} SET {', '.join(sets)} WHERE id = %s",
+                params,
+            )
+            return cur.rowcount > 0
+
+    def bulk_update_story_scores(
+        self,
+        rows: Iterable[tuple[str, float | None, float | None]],
+    ) -> int:
+        """Persist a batch of (story_id, wsjf, rice) updates in one transaction.
+
+        Returns the number of rows actually updated. Used by the grooming
+        route so a re-groom is atomic from the client's perspective.
+        """
+        rows_list = list(rows)
+        if not rows_list:
+            return 0
+        now = _now()
+        with self._conn() as conn, conn.cursor() as cur:
+            updated = 0
+            for sid, wsjf, rice in rows_list:
+                cur.execute(
+                    """UPDATE product_delivery_stories
+                       SET wsjf_score = COALESCE(%s, wsjf_score),
+                           rice_score = COALESCE(%s, rice_score),
+                           updated_at = %s
+                       WHERE id = %s""",
+                    (wsjf, rice, now, sid),
+                )
+                updated += cur.rowcount
+            return updated
+
+    # ------------------------------------------------------------------
+    # Backlog read — single-product nested tree.
+    # ------------------------------------------------------------------
+
+    @timed_query(store=_STORE, op="get_backlog_tree")
+    def get_backlog_tree(self, product_id: str) -> BacklogTree | None:
+        product = self.get_product(product_id)
+        if product is None:
+            return None
+        with self._conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                """SELECT id, product_id, title, summary, status, wsjf_score, rice_score,
+                          author, created_at, updated_at
+                   FROM product_delivery_initiatives WHERE product_id = %s
+                   ORDER BY created_at""",
+                (product_id,),
+            )
+            initiatives_raw = cur.fetchall()
+            initiatives: list[InitiativeNode] = []
+            for irow in initiatives_raw:
+                cur.execute(
+                    """SELECT id, initiative_id, title, summary, status, wsjf_score, rice_score,
+                              author, created_at, updated_at
+                       FROM product_delivery_epics WHERE initiative_id = %s
+                       ORDER BY created_at""",
+                    (irow["id"],),
+                )
+                epics_raw = cur.fetchall()
+                epics: list[EpicNode] = []
+                for erow in epics_raw:
+                    cur.execute(
+                        """SELECT id, epic_id, title, user_story, status, wsjf_score, rice_score,
+                                  estimate_points, author, created_at, updated_at
+                           FROM product_delivery_stories WHERE epic_id = %s
+                           ORDER BY created_at""",
+                        (erow["id"],),
+                    )
+                    stories_raw = cur.fetchall()
+                    stories: list[StoryNode] = []
+                    for srow in stories_raw:
+                        cur.execute(
+                            """SELECT id, story_id, title, description, status, owner,
+                                      author, created_at, updated_at
+                               FROM product_delivery_tasks WHERE story_id = %s
+                               ORDER BY created_at""",
+                            (srow["id"],),
+                        )
+                        tasks = [Task.model_validate(t) for t in cur.fetchall()]
+                        cur.execute(
+                            """SELECT id, story_id, text, satisfied, author,
+                                      created_at, updated_at
+                               FROM product_delivery_acceptance_criteria
+                               WHERE story_id = %s ORDER BY created_at""",
+                            (srow["id"],),
+                        )
+                        acs = [AcceptanceCriterion.model_validate(a) for a in cur.fetchall()]
+                        stories.append(
+                            StoryNode.model_validate(
+                                {**srow, "tasks": tasks, "acceptance_criteria": acs}
+                            )
+                        )
+                    epics.append(EpicNode.model_validate({**erow, "stories": stories}))
+                initiatives.append(InitiativeNode.model_validate({**irow, "epics": epics}))
+        return BacklogTree(product=product, initiatives=initiatives)
+
+    @timed_query(store=_STORE, op="list_stories_for_product")
+    def list_stories_for_product(self, product_id: str) -> list[Story]:
+        """Flat list of every story under a product. Used by the grooming agent."""
+        with self._conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                """SELECT s.id, s.epic_id, s.title, s.user_story, s.status,
+                          s.wsjf_score, s.rice_score, s.estimate_points,
+                          s.author, s.created_at, s.updated_at
+                   FROM product_delivery_stories s
+                   JOIN product_delivery_epics e ON e.id = s.epic_id
+                   JOIN product_delivery_initiatives i ON i.id = e.initiative_id
+                   WHERE i.product_id = %s
+                   ORDER BY s.created_at""",
+                (product_id,),
+            )
+            return [Story.model_validate(row) for row in cur.fetchall()]
+
+    # ------------------------------------------------------------------
+    # Feedback
+    # ------------------------------------------------------------------
+
+    @timed_query(store=_STORE, op="create_feedback_item")
+    def create_feedback_item(
+        self,
+        *,
+        product_id: str,
+        source: str,
+        raw_payload: dict[str, Any],
+        severity: str,
+        linked_story_id: str | None,
+        author: str,
+    ) -> FeedbackItem:
+        now = _now()
+        fid = _new_id()
+        try:
+            with self._conn() as conn, conn.cursor() as cur:
+                cur.execute(
+                    """INSERT INTO product_delivery_feedback_items
+                          (id, product_id, source, raw_payload, severity, status,
+                           linked_story_id, author, created_at, updated_at)
+                       VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+                    (
+                        fid,
+                        product_id,
+                        source,
+                        Json(raw_payload),
+                        severity,
+                        "open",
+                        linked_story_id,
+                        author,
+                        now,
+                        now,
+                    ),
+                )
+        except psycopg_errors.ForeignKeyViolation as exc:
+            raise UnknownProductDeliveryEntity(f"product {product_id!r} does not exist") from exc
+        return FeedbackItem(
+            id=fid,
+            product_id=product_id,
+            source=source,
+            raw_payload=raw_payload,
+            severity=severity,
+            status="open",
+            linked_story_id=linked_story_id,
+            author=author,
+            created_at=now,
+            updated_at=now,
+        )
+
+    @timed_query(store=_STORE, op="list_feedback")
+    def list_feedback(
+        self,
+        product_id: str,
+        *,
+        status: str | None = None,
+    ) -> list[FeedbackItem]:
+        with self._conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+            if status is None:
+                cur.execute(
+                    """SELECT id, product_id, source, raw_payload, severity, status,
+                              linked_story_id, author, created_at, updated_at
+                       FROM product_delivery_feedback_items
+                       WHERE product_id = %s
+                       ORDER BY created_at DESC""",
+                    (product_id,),
+                )
+            else:
+                cur.execute(
+                    """SELECT id, product_id, source, raw_payload, severity, status,
+                              linked_story_id, author, created_at, updated_at
+                       FROM product_delivery_feedback_items
+                       WHERE product_id = %s AND status = %s
+                       ORDER BY created_at DESC""",
+                    (product_id, status),
+                )
+            return [FeedbackItem.model_validate(row) for row in cur.fetchall()]
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _conn(self):
+        if not is_postgres_enabled():
+            raise ProductDeliveryStorageUnavailable(
+                "POSTGRES_HOST is not configured; product_delivery storage is unavailable."
+            )
+        try:
+            return get_conn()
+        except Exception as exc:  # pragma: no cover — infra paths
+            raise ProductDeliveryStorageUnavailable(str(exc)) from exc
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+def _new_id() -> str:
+    return uuid4().hex
+
+
+@lru_cache(maxsize=1)
+def get_store() -> ProductDeliveryStore:
+    return ProductDeliveryStore()

--- a/backend/agents/product_delivery/store.py
+++ b/backend/agents/product_delivery/store.py
@@ -29,6 +29,7 @@ Internal layout:
 from __future__ import annotations
 
 import logging
+import math
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -106,6 +107,40 @@ _ROW_SPECS: dict[str, _RowSpec] = {
 
 _STATUS_KINDS = frozenset({"initiative", "epic", "story", "task"})
 _SCORED_KINDS = frozenset({"initiative", "epic", "story"})
+
+# Status string bound (matches ``models.StatusStr``) — store-level
+# enforcement so non-route callers can't slip overlong statuses past
+# the API validator and break read-side projection later.
+_STATUS_MAX_LEN = 40
+
+
+def _validate_status(value: str) -> str:
+    if not value or len(value) > _STATUS_MAX_LEN:
+        raise ValueError(f"status must be 1..{_STATUS_MAX_LEN} chars; got {len(value)}")
+    return value
+
+
+def _validate_optional_finite_score(value: float | None, *, label: str) -> float | None:
+    """Mirror ``models.FiniteScore`` at the store layer for non-route callers."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError(f"{label} must be a number, not a boolean")
+    if not math.isfinite(value):
+        raise ValueError(f"{label} must be a finite number")
+    return float(value)
+
+
+def _validate_estimate_points(value: float | None) -> float | None:
+    """Mirror ``models.PositiveFiniteEstimate`` at the store layer."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError("estimate_points must be a number, not a boolean")
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError("estimate_points must be a finite positive number")
+    return float(value)
+
 
 _AUDIT_COLS = "author, created_at, updated_at"
 _PRODUCT_COLS = f"id, name, description, vision, {_AUDIT_COLS}"
@@ -276,8 +311,8 @@ class ProductDeliveryStore:
             epic_id=epic_id,
             title=title,
             user_story=user_story,
-            status=status,
-            estimate_points=estimate_points,
+            status=_validate_status(status),
+            estimate_points=_validate_estimate_points(estimate_points),
             author=author,
         )
 
@@ -322,6 +357,10 @@ class ProductDeliveryStore:
     def update_status(self, *, kind: str, entity_id: str, status: str) -> bool:
         if kind not in _STATUS_KINDS:
             raise ValueError(f"unknown kind for status update: {kind!r}")
+        # Mirror the API-level `StatusStr` bound here so non-route
+        # callers can't slip overlong/empty statuses into the row and
+        # break read-side projection later.
+        status = _validate_status(status)
         table = _ROW_SPECS[kind].table
         with self._conn() as conn, conn.cursor() as cur:
             cur.execute(
@@ -341,6 +380,12 @@ class ProductDeliveryStore:
     ) -> bool:
         if kind not in _SCORED_KINDS:
             raise ValueError(f"unknown kind for score update: {kind!r}")
+        # Store-level guard against NaN/±Infinity/booleans — mirrors
+        # `models.FiniteScore` so non-route callers can't write
+        # non-finite values that later break JSON serialisation or
+        # corrupt persisted ranking data.
+        wsjf_score = _validate_optional_finite_score(wsjf_score, label="wsjf_score")
+        rice_score = _validate_optional_finite_score(rice_score, label="rice_score")
         table = _ROW_SPECS[kind].table
         sets: list[str] = []
         params: list[Any] = []
@@ -362,6 +407,7 @@ class ProductDeliveryStore:
             )
             return cur.rowcount > 0
 
+    @timed_query(store=_STORE, op="bulk_update_story_scores")
     def bulk_update_story_scores(
         self,
         rows: Iterable[tuple[str, float | None, float | None]],
@@ -371,11 +417,21 @@ class ProductDeliveryStore:
         Uses ``executemany`` so the whole batch ships in a single
         client/server round trip. Returns the number of rows actually
         updated (psycopg's ``rowcount`` after ``executemany`` is the
-        sum of per-statement row counts).
+        sum of per-statement row counts). Validates each per-row score
+        the same way ``update_scores`` does.
         """
         rows_list = list(rows)
         if not rows_list:
             return 0
+        validated: list[tuple[str, float | None, float | None]] = []
+        for sid, w, r in rows_list:
+            validated.append(
+                (
+                    sid,
+                    _validate_optional_finite_score(w, label="wsjf_score"),
+                    _validate_optional_finite_score(r, label="rice_score"),
+                )
+            )
         now = _now()
         with self._conn() as conn, conn.cursor() as cur:
             cur.executemany(
@@ -384,7 +440,7 @@ class ProductDeliveryStore:
                        rice_score = COALESCE(%s, rice_score),
                        updated_at = %s
                    WHERE id = %s""",
-                [(w, r, now, sid) for sid, w, r in rows_list],
+                [(w, r, now, sid) for sid, w, r in validated],
             )
             return cur.rowcount
 
@@ -488,8 +544,20 @@ class ProductDeliveryStore:
 
     @timed_query(store=_STORE, op="list_stories_for_product")
     def list_stories_for_product(self, product_id: str) -> list[Story]:
-        """Flat list of every story under a product. Used by the grooming agent."""
+        """Flat list of every story under a product. Used by the grooming agent.
+
+        Raises ``UnknownProductDeliveryEntity`` if the product doesn't
+        exist (the existence check + the story SELECT run in a single
+        connection so concurrent deletes can't make the route return
+        ``200 []`` for a missing product).
+        """
         with self._conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                "SELECT 1 FROM product_delivery_products WHERE id = %s",
+                (product_id,),
+            )
+            if cur.fetchone() is None:
+                raise UnknownProductDeliveryEntity(f"unknown product: {product_id}")
             cur.execute(
                 f"""SELECT {_STORY_COLS_ALIASED}
                    FROM product_delivery_stories s
@@ -603,6 +671,13 @@ class ProductDeliveryStore:
         *,
         status: str | None = None,
     ) -> list[FeedbackItem]:
+        """List feedback items under a product.
+
+        Raises ``UnknownProductDeliveryEntity`` when the product doesn't
+        exist — the existence check + the feedback SELECT run in a
+        single connection so a concurrent delete can't make the route
+        return ``200 []`` for a missing product.
+        """
         sql = f"SELECT {_FEEDBACK_COLS} FROM product_delivery_feedback_items WHERE product_id = %s"
         params: list[Any] = [product_id]
         if status is not None:
@@ -610,6 +685,12 @@ class ProductDeliveryStore:
             params.append(status)
         sql += " ORDER BY created_at DESC"
         with self._conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                "SELECT 1 FROM product_delivery_products WHERE id = %s",
+                (product_id,),
+            )
+            if cur.fetchone() is None:
+                raise UnknownProductDeliveryEntity(f"unknown product: {product_id}")
             cur.execute(sql, params)
             return [FeedbackItem.model_validate(row) for row in cur.fetchall()]
 

--- a/backend/agents/product_delivery/store.py
+++ b/backend/agents/product_delivery/store.py
@@ -572,8 +572,16 @@ class ProductDeliveryStore:
             # Race: a concurrent caller deleted the product or story
             # between the validation SELECT and our INSERT. Surface as
             # the same 404 the eager validation would have produced.
+            # Don't leak the raw psycopg/SQL detail to the HTTP client —
+            # `from exc` keeps the cause chained for server logs.
+            logger.warning(
+                "create_feedback_item: FK race for product=%s story=%s: %s",
+                product_id,
+                linked_story_id,
+                exc,
+            )
             raise UnknownProductDeliveryEntity(
-                f"product or story for feedback item disappeared mid-write: {exc}"
+                "product or linked story disappeared mid-write"
             ) from exc
         return FeedbackItem(
             id=fid,

--- a/backend/agents/product_delivery/store.py
+++ b/backend/agents/product_delivery/store.py
@@ -114,9 +114,35 @@ _SCORED_KINDS = frozenset({"initiative", "epic", "story"})
 _STATUS_MAX_LEN = 40
 
 
+# Title bound — matches every ``*Create.title``/``ProductCreate.name``
+# Pydantic field on the API side. Store-level mirror so non-route
+# callers can't slip empty/oversized identifiers past validation and
+# break read-side projection later.
+_TITLE_MAX_LEN = 200
+
+
 def _validate_status(value: str) -> str:
-    if not value or len(value) > _STATUS_MAX_LEN:
-        raise ValueError(f"status must be 1..{_STATUS_MAX_LEN} chars; got {len(value)}")
+    # `not value.strip()` rejects whitespace-only strings (`'   '`,
+    # `'\t'`) that pass the length check but represent semantically
+    # empty workflow states. Without this they'd persist and propagate
+    # through backlog + feedback projections as if they were valid
+    # statuses.
+    if not value or not value.strip() or len(value) > _STATUS_MAX_LEN:
+        raise ValueError(f"status must be 1..{_STATUS_MAX_LEN} non-blank chars; got {len(value)}")
+    return value
+
+
+def _validate_title(value: str, *, label: str = "title") -> str:
+    """Mirror the API-level ``min_length=1, max_length=200`` bound.
+
+    Used by ``create_product`` / ``create_initiative`` / ``create_epic``
+    / ``create_story`` / ``create_task`` so internal callers (the
+    ProductOwnerAgent, future workflow code, etc.) can't bypass route
+    validation and persist empty / oversized / whitespace-only titles
+    that the HTTP contract rejects.
+    """
+    if not value or not value.strip() or len(value) > _TITLE_MAX_LEN:
+        raise ValueError(f"{label} must be 1..{_TITLE_MAX_LEN} non-blank chars; got {len(value)}")
     return value
 
 
@@ -243,6 +269,10 @@ class ProductDeliveryStore:
 
     @timed_query(store=_STORE, op="create_product")
     def create_product(self, *, name: str, description: str, vision: str, author: str) -> Product:
+        # Mirror `ProductCreate(name=Field(min_length=1, max_length=200))`
+        # so non-route callers can't persist empty / oversized names
+        # that the HTTP contract rejects.
+        name = _validate_title(name, label="name")
         now = _now()
         pid = _new_id()
         with self._conn() as conn, conn.cursor() as cur:
@@ -292,7 +322,7 @@ class ProductDeliveryStore:
         return self._insert(
             "initiative",
             product_id=product_id,
-            title=title,
+            title=_validate_title(title),
             summary=summary,
             status=_validate_status(status),
             author=author,
@@ -305,7 +335,7 @@ class ProductDeliveryStore:
         return self._insert(
             "epic",
             initiative_id=initiative_id,
-            title=title,
+            title=_validate_title(title),
             summary=summary,
             status=_validate_status(status),
             author=author,
@@ -325,7 +355,7 @@ class ProductDeliveryStore:
         return self._insert(
             "story",
             epic_id=epic_id,
-            title=title,
+            title=_validate_title(title),
             user_story=user_story,
             status=_validate_status(status),
             estimate_points=_validate_estimate_points(estimate_points),
@@ -346,7 +376,7 @@ class ProductDeliveryStore:
         return self._insert(
             "task",
             story_id=story_id,
-            title=title,
+            title=_validate_title(title),
             description=description,
             status=_validate_status(status),
             owner=owner,
@@ -737,10 +767,47 @@ class ProductDeliveryStore:
             raise ProductDeliveryStorageUnavailable(
                 "POSTGRES_HOST is not configured; product_delivery storage is unavailable."
             )
+        return _SafeConn()
+
+
+class _SafeConn:
+    """Context manager wrapper around ``shared_postgres.get_conn`` that
+    surfaces connection-acquisition failures as
+    :class:`ProductDeliveryStorageUnavailable`.
+
+    ``get_conn()`` returns a context manager, but the real connection
+    isn't acquired until ``__enter__`` runs (the pool's ``connection()``
+    method blocks waiting for a free slot, then opens the socket if
+    needed). If the pool times out or the driver raises, the original
+    ``_conn`` only caught errors at *creation* of that context manager
+    — the ``__enter__`` exceptions surfaced as raw ``PoolTimeout`` /
+    driver errors, bypassing the route-level 503 mapping and producing
+    unhandled 500s.
+
+    This wrapper re-raises any exception from either ``__enter__`` or
+    the underlying CM creation as ``ProductDeliveryStorageUnavailable``
+    so the route's exception handler maps it cleanly to 503 every time.
+    Exit semantics are unchanged — the pool's CM still commits on clean
+    exit, rolls back on exception, and returns the connection to the pool.
+    """
+
+    def __init__(self) -> None:
+        self._cm: Any | None = None
+
+    def __enter__(self) -> Any:
         try:
-            return get_conn()
+            self._cm = get_conn()
+            return self._cm.__enter__()
+        except ProductDeliveryStorageUnavailable:
+            raise
         except Exception as exc:  # pragma: no cover — infra paths
+            self._cm = None
             raise ProductDeliveryStorageUnavailable(str(exc)) from exc
+
+    def __exit__(self, exc_type: Any, exc: Any, tb: Any) -> Any:
+        if self._cm is None:
+            return False
+        return self._cm.__exit__(exc_type, exc, tb)
 
 
 def _now() -> datetime:

--- a/backend/agents/product_delivery/store.py
+++ b/backend/agents/product_delivery/store.py
@@ -5,26 +5,40 @@ Mirrors :mod:`agent_console.store` in shape:
 * stateless class — pool lives in ``shared_postgres``;
 * one public method per operation, decorated with ``@timed_query``;
 * methods translate Postgres errors into typed domain exceptions;
-* :func:`get_store` returns a process-wide singleton via ``lru_cache``.
+* :func:`get_store` returns the process-wide singleton.
 
 The store does not manage transactions across operations; each method is
 its own transaction (``shared_postgres.get_conn`` commits on clean exit,
 rolls back on error). Multi-row writes that need atomicity (e.g. the
 grooming endpoint persisting scores for many stories) call the store
 inside an explicit transaction at the route layer.
+
+Internal layout:
+
+* ``_ROW_SPECS`` is the single source of truth for "what kind of row is
+  this": the table name, the parent FK label used in error messages,
+  and the Pydantic model used to project a row dict back to a typed
+  return value. Both the create-shim methods and the status / score
+  update methods key off it.
+
+* ``_*_COLS`` constants hold each table's projection column list once,
+  so a typo can't drop a column from one query while leaving another
+  query's projection intact.
 """
 
 from __future__ import annotations
 
 import logging
+from collections import defaultdict
+from dataclasses import dataclass
 from datetime import datetime, timezone
-from functools import lru_cache
-from typing import Any, Iterable
+from typing import Any, Iterable, TypeVar
 from uuid import uuid4
 
 from psycopg import errors as psycopg_errors
 from psycopg.rows import dict_row
 from psycopg.types.json import Json
+from pydantic import BaseModel
 
 from shared_postgres import get_conn, is_postgres_enabled
 from shared_postgres.metrics import timed_query
@@ -47,6 +61,11 @@ logger = logging.getLogger(__name__)
 _STORE = "product_delivery"
 
 
+# ---------------------------------------------------------------------------
+# Domain exceptions
+# ---------------------------------------------------------------------------
+
+
 class ProductDeliveryStorageUnavailable(RuntimeError):
     """Postgres isn't configured, unreachable, or the pool is shut down."""
 
@@ -65,8 +84,99 @@ class CrossProductFeedbackLink(ValueError):
     """
 
 
+# ---------------------------------------------------------------------------
+# Row specs + per-table column constants — single source of truth.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _RowSpec:
+    table: str
+    model: type[BaseModel]
+    parent_fk: str  # human label for FK-violation errors
+
+
+_ROW_SPECS: dict[str, _RowSpec] = {
+    "initiative": _RowSpec("product_delivery_initiatives", Initiative, "product"),
+    "epic": _RowSpec("product_delivery_epics", Epic, "initiative"),
+    "story": _RowSpec("product_delivery_stories", Story, "epic"),
+    "task": _RowSpec("product_delivery_tasks", Task, "story"),
+    "ac": _RowSpec("product_delivery_acceptance_criteria", AcceptanceCriterion, "story"),
+}
+
+_STATUS_KINDS = frozenset({"initiative", "epic", "story", "task"})
+_SCORED_KINDS = frozenset({"initiative", "epic", "story"})
+
+_AUDIT_COLS = "author, created_at, updated_at"
+_PRODUCT_COLS = f"id, name, description, vision, {_AUDIT_COLS}"
+_SCORED_HEAD = "title, summary, status, wsjf_score, rice_score"
+_INITIATIVE_COLS = f"id, product_id, {_SCORED_HEAD}, {_AUDIT_COLS}"
+_EPIC_COLS = f"id, initiative_id, {_SCORED_HEAD}, {_AUDIT_COLS}"
+_STORY_COLS = (
+    f"id, epic_id, title, user_story, status, wsjf_score, rice_score, "
+    f"estimate_points, {_AUDIT_COLS}"
+)
+_TASK_COLS = f"id, story_id, title, description, status, owner, {_AUDIT_COLS}"
+_AC_COLS = f"id, story_id, text, satisfied, {_AUDIT_COLS}"
+_FEEDBACK_COLS = (
+    f"id, product_id, source, raw_payload, severity, status, linked_story_id, {_AUDIT_COLS}"
+)
+
+
+_T = TypeVar("_T", bound=BaseModel)
+
+
+def _bucket_by(rows: list[dict[str, Any]], key: str, model: type[_T]) -> dict[str, list[_T]]:
+    """Group raw row dicts by `parent_id` and validate them through ``model``.
+
+    Used by ``get_backlog_tree`` to assemble the nested tree from the
+    flat per-level fetches without a per-parent SQL query.
+    """
+    buckets: defaultdict[str, list[_T]] = defaultdict(list)
+    for row in rows:
+        buckets[row[key]].append(model.model_validate(row))
+    return buckets
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+
 class ProductDeliveryStore:
     """Stateless DAL. Construct once per process; pool is shared."""
+
+    # ------------------------------------------------------------------
+    # Generic insert — used by all create_* shims below.
+    # ------------------------------------------------------------------
+
+    def _insert(self, kind: str, **fields: Any) -> Any:
+        """INSERT a row and return the validated Pydantic model.
+
+        Auto-fills ``id`` (if not supplied), ``created_at``, ``updated_at``.
+        Translates a foreign-key violation into ``UnknownProductDeliveryEntity``
+        with the parent label from :data:`_ROW_SPECS`.
+        """
+        spec = _ROW_SPECS[kind]
+        now = _now()
+        fields.setdefault("id", _new_id())
+        fields.setdefault("author", fields.get("author"))  # required by callers
+        fields["created_at"] = now
+        fields["updated_at"] = now
+        cols = ", ".join(fields)
+        placeholders = ", ".join(["%s"] * len(fields))
+        # Adapt JSONB-typed columns. Currently only `raw_payload` on
+        # feedback_items needs it; future kinds add their key to this set.
+        adapted = {k: (Json(v) if k == "raw_payload" else v) for k, v in fields.items()}
+        try:
+            with self._conn() as conn, conn.cursor() as cur:
+                cur.execute(
+                    f"INSERT INTO {spec.table} ({cols}) VALUES ({placeholders})",
+                    list(adapted.values()),
+                )
+        except psycopg_errors.ForeignKeyViolation as exc:
+            raise UnknownProductDeliveryEntity(f"{spec.parent_fk} does not exist") from exc
+        return spec.model.model_validate(fields)
 
     # ------------------------------------------------------------------
     # Products
@@ -78,8 +188,7 @@ class ProductDeliveryStore:
         pid = _new_id()
         with self._conn() as conn, conn.cursor() as cur:
             cur.execute(
-                """INSERT INTO product_delivery_products
-                      (id, name, description, vision, author, created_at, updated_at)
+                f"""INSERT INTO product_delivery_products ({_PRODUCT_COLS})
                    VALUES (%s, %s, %s, %s, %s, %s, %s)""",
                 (pid, name, description, vision, author, now, now),
             )
@@ -97,9 +206,7 @@ class ProductDeliveryStore:
     def list_products(self) -> list[Product]:
         with self._conn() as conn, conn.cursor(row_factory=dict_row) as cur:
             cur.execute(
-                """SELECT id, name, description, vision, author, created_at, updated_at
-                   FROM product_delivery_products
-                   ORDER BY created_at DESC"""
+                f"SELECT {_PRODUCT_COLS} FROM product_delivery_products ORDER BY created_at DESC"
             )
             return [Product.model_validate(row) for row in cur.fetchall()]
 
@@ -107,85 +214,42 @@ class ProductDeliveryStore:
     def get_product(self, product_id: str) -> Product | None:
         with self._conn() as conn, conn.cursor(row_factory=dict_row) as cur:
             cur.execute(
-                """SELECT id, name, description, vision, author, created_at, updated_at
-                   FROM product_delivery_products WHERE id = %s""",
+                f"SELECT {_PRODUCT_COLS} FROM product_delivery_products WHERE id = %s",
                 (product_id,),
             )
             row = cur.fetchone()
             return Product.model_validate(row) if row else None
 
     # ------------------------------------------------------------------
-    # Initiatives / Epics / Stories — uniform CRUD via _create_scored.
+    # Initiatives / Epics / Stories / Tasks / Acceptance criteria —
+    # thin shims over `_insert`. Public signatures are unchanged so the
+    # route layer and tests stay identical.
     # ------------------------------------------------------------------
 
     @timed_query(store=_STORE, op="create_initiative")
     def create_initiative(
-        self,
-        *,
-        product_id: str,
-        title: str,
-        summary: str,
-        status: str,
-        author: str,
+        self, *, product_id: str, title: str, summary: str, status: str, author: str
     ) -> Initiative:
-        now = _now()
-        iid = _new_id()
-        try:
-            with self._conn() as conn, conn.cursor() as cur:
-                cur.execute(
-                    """INSERT INTO product_delivery_initiatives
-                          (id, product_id, title, summary, status, author,
-                           created_at, updated_at)
-                       VALUES (%s, %s, %s, %s, %s, %s, %s, %s)""",
-                    (iid, product_id, title, summary, status, author, now, now),
-                )
-        except psycopg_errors.ForeignKeyViolation as exc:
-            raise UnknownProductDeliveryEntity(f"product {product_id!r} does not exist") from exc
-        return Initiative(
-            id=iid,
+        return self._insert(
+            "initiative",
             product_id=product_id,
             title=title,
             summary=summary,
             status=status,
             author=author,
-            created_at=now,
-            updated_at=now,
         )
 
     @timed_query(store=_STORE, op="create_epic")
     def create_epic(
-        self,
-        *,
-        initiative_id: str,
-        title: str,
-        summary: str,
-        status: str,
-        author: str,
+        self, *, initiative_id: str, title: str, summary: str, status: str, author: str
     ) -> Epic:
-        now = _now()
-        eid = _new_id()
-        try:
-            with self._conn() as conn, conn.cursor() as cur:
-                cur.execute(
-                    """INSERT INTO product_delivery_epics
-                          (id, initiative_id, title, summary, status, author,
-                           created_at, updated_at)
-                       VALUES (%s, %s, %s, %s, %s, %s, %s, %s)""",
-                    (eid, initiative_id, title, summary, status, author, now, now),
-                )
-        except psycopg_errors.ForeignKeyViolation as exc:
-            raise UnknownProductDeliveryEntity(
-                f"initiative {initiative_id!r} does not exist"
-            ) from exc
-        return Epic(
-            id=eid,
+        return self._insert(
+            "epic",
             initiative_id=initiative_id,
             title=title,
             summary=summary,
             status=status,
             author=author,
-            created_at=now,
-            updated_at=now,
         )
 
     @timed_query(store=_STORE, op="create_story")
@@ -199,39 +263,14 @@ class ProductDeliveryStore:
         estimate_points: float | None,
         author: str,
     ) -> Story:
-        now = _now()
-        sid = _new_id()
-        try:
-            with self._conn() as conn, conn.cursor() as cur:
-                cur.execute(
-                    """INSERT INTO product_delivery_stories
-                          (id, epic_id, title, user_story, status,
-                           estimate_points, author, created_at, updated_at)
-                       VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)""",
-                    (
-                        sid,
-                        epic_id,
-                        title,
-                        user_story,
-                        status,
-                        estimate_points,
-                        author,
-                        now,
-                        now,
-                    ),
-                )
-        except psycopg_errors.ForeignKeyViolation as exc:
-            raise UnknownProductDeliveryEntity(f"epic {epic_id!r} does not exist") from exc
-        return Story(
-            id=sid,
+        return self._insert(
+            "story",
             epic_id=epic_id,
             title=title,
             user_story=user_story,
             status=status,
             estimate_points=estimate_points,
             author=author,
-            created_at=now,
-            updated_at=now,
         )
 
     @timed_query(store=_STORE, op="create_task")
@@ -245,82 +284,37 @@ class ProductDeliveryStore:
         owner: str | None,
         author: str,
     ) -> Task:
-        now = _now()
-        tid = _new_id()
-        try:
-            with self._conn() as conn, conn.cursor() as cur:
-                cur.execute(
-                    """INSERT INTO product_delivery_tasks
-                          (id, story_id, title, description, status, owner,
-                           author, created_at, updated_at)
-                       VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)""",
-                    (tid, story_id, title, description, status, owner, author, now, now),
-                )
-        except psycopg_errors.ForeignKeyViolation as exc:
-            raise UnknownProductDeliveryEntity(f"story {story_id!r} does not exist") from exc
-        return Task(
-            id=tid,
+        return self._insert(
+            "task",
             story_id=story_id,
             title=title,
             description=description,
             status=status,
             owner=owner,
             author=author,
-            created_at=now,
-            updated_at=now,
         )
 
     @timed_query(store=_STORE, op="create_acceptance_criterion")
     def create_acceptance_criterion(
-        self,
-        *,
-        story_id: str,
-        text: str,
-        satisfied: bool,
-        author: str,
+        self, *, story_id: str, text: str, satisfied: bool, author: str
     ) -> AcceptanceCriterion:
-        now = _now()
-        aid = _new_id()
-        try:
-            with self._conn() as conn, conn.cursor() as cur:
-                cur.execute(
-                    """INSERT INTO product_delivery_acceptance_criteria
-                          (id, story_id, text, satisfied, author,
-                           created_at, updated_at)
-                       VALUES (%s, %s, %s, %s, %s, %s, %s)""",
-                    (aid, story_id, text, satisfied, author, now, now),
-                )
-        except psycopg_errors.ForeignKeyViolation as exc:
-            raise UnknownProductDeliveryEntity(f"story {story_id!r} does not exist") from exc
-        return AcceptanceCriterion(
-            id=aid,
+        return self._insert(
+            "ac",
             story_id=story_id,
             text=text,
             satisfied=satisfied,
             author=author,
-            created_at=now,
-            updated_at=now,
         )
 
     # ------------------------------------------------------------------
-    # Status / score updates — generic helpers keep route code small.
+    # Status / score updates.
     # ------------------------------------------------------------------
-
-    _SCORED_TABLES = {
-        "initiative": "product_delivery_initiatives",
-        "epic": "product_delivery_epics",
-        "story": "product_delivery_stories",
-    }
-    _STATUS_TABLES = {
-        **_SCORED_TABLES,
-        "task": "product_delivery_tasks",
-    }
 
     @timed_query(store=_STORE, op="update_status")
     def update_status(self, *, kind: str, entity_id: str, status: str) -> bool:
-        table = self._STATUS_TABLES.get(kind)
-        if table is None:
+        if kind not in _STATUS_KINDS:
             raise ValueError(f"unknown kind for status update: {kind!r}")
+        table = _ROW_SPECS[kind].table
         with self._conn() as conn, conn.cursor() as cur:
             cur.execute(
                 f"UPDATE {table} SET status = %s, updated_at = %s WHERE id = %s",
@@ -337,9 +331,9 @@ class ProductDeliveryStore:
         wsjf_score: float | None,
         rice_score: float | None,
     ) -> bool:
-        table = self._SCORED_TABLES.get(kind)
-        if table is None:
+        if kind not in _SCORED_KINDS:
             raise ValueError(f"unknown kind for score update: {kind!r}")
+        table = _ROW_SPECS[kind].table
         sets: list[str] = []
         params: list[Any] = []
         if wsjf_score is not None:
@@ -366,26 +360,25 @@ class ProductDeliveryStore:
     ) -> int:
         """Persist a batch of (story_id, wsjf, rice) updates in one transaction.
 
-        Returns the number of rows actually updated. Used by the grooming
-        route so a re-groom is atomic from the client's perspective.
+        Uses ``executemany`` so the whole batch ships in a single
+        client/server round trip. Returns the number of rows actually
+        updated (psycopg's ``rowcount`` after ``executemany`` is the
+        sum of per-statement row counts).
         """
         rows_list = list(rows)
         if not rows_list:
             return 0
         now = _now()
         with self._conn() as conn, conn.cursor() as cur:
-            updated = 0
-            for sid, wsjf, rice in rows_list:
-                cur.execute(
-                    """UPDATE product_delivery_stories
-                       SET wsjf_score = COALESCE(%s, wsjf_score),
-                           rice_score = COALESCE(%s, rice_score),
-                           updated_at = %s
-                       WHERE id = %s""",
-                    (wsjf, rice, now, sid),
-                )
-                updated += cur.rowcount
-            return updated
+            cur.executemany(
+                """UPDATE product_delivery_stories
+                   SET wsjf_score = COALESCE(%s, wsjf_score),
+                       rice_score = COALESCE(%s, rice_score),
+                       updated_at = %s
+                   WHERE id = %s""",
+                [(w, r, now, sid) for sid, w, r in rows_list],
+            )
+            return cur.rowcount
 
     # ------------------------------------------------------------------
     # Backlog read — single-product nested tree.
@@ -406,8 +399,7 @@ class ProductDeliveryStore:
             return None
         with self._conn() as conn, conn.cursor(row_factory=dict_row) as cur:
             cur.execute(
-                """SELECT id, product_id, title, summary, status, wsjf_score, rice_score,
-                          author, created_at, updated_at
+                f"""SELECT {_INITIATIVE_COLS}
                    FROM product_delivery_initiatives WHERE product_id = %s
                    ORDER BY created_at""",
                 (product_id,),
@@ -418,8 +410,7 @@ class ProductDeliveryStore:
             initiative_ids = [i["id"] for i in initiatives_raw]
 
             cur.execute(
-                """SELECT id, initiative_id, title, summary, status, wsjf_score, rice_score,
-                          author, created_at, updated_at
+                f"""SELECT {_EPIC_COLS}
                    FROM product_delivery_epics
                    WHERE initiative_id = ANY(%s)
                    ORDER BY created_at""",
@@ -433,8 +424,7 @@ class ProductDeliveryStore:
             acs_raw: list[dict[str, Any]] = []
             if epic_ids:
                 cur.execute(
-                    """SELECT id, epic_id, title, user_story, status, wsjf_score, rice_score,
-                              estimate_points, author, created_at, updated_at
+                    f"""SELECT {_STORY_COLS}
                        FROM product_delivery_stories
                        WHERE epic_id = ANY(%s)
                        ORDER BY created_at""",
@@ -444,8 +434,7 @@ class ProductDeliveryStore:
                 story_ids = [s["id"] for s in stories_raw]
                 if story_ids:
                     cur.execute(
-                        """SELECT id, story_id, title, description, status, owner,
-                                  author, created_at, updated_at
+                        f"""SELECT {_TASK_COLS}
                            FROM product_delivery_tasks
                            WHERE story_id = ANY(%s)
                            ORDER BY created_at""",
@@ -453,8 +442,7 @@ class ProductDeliveryStore:
                     )
                     tasks_raw = cur.fetchall()
                     cur.execute(
-                        """SELECT id, story_id, text, satisfied, author,
-                                  created_at, updated_at
+                        f"""SELECT {_AC_COLS}
                            FROM product_delivery_acceptance_criteria
                            WHERE story_id = ANY(%s)
                            ORDER BY created_at""",
@@ -464,15 +452,11 @@ class ProductDeliveryStore:
 
         # Bucket children by parent id, preserving fetch order (which is
         # already created_at thanks to the ORDER BY above).
-        tasks_by_story: dict[str, list[Task]] = {}
-        for t in tasks_raw:
-            tasks_by_story.setdefault(t["story_id"], []).append(Task.model_validate(t))
-        acs_by_story: dict[str, list[AcceptanceCriterion]] = {}
-        for a in acs_raw:
-            acs_by_story.setdefault(a["story_id"], []).append(AcceptanceCriterion.model_validate(a))
-        stories_by_epic: dict[str, list[StoryNode]] = {}
+        tasks_by_story = _bucket_by(tasks_raw, "story_id", Task)
+        acs_by_story = _bucket_by(acs_raw, "story_id", AcceptanceCriterion)
+        stories_by_epic: defaultdict[str, list[StoryNode]] = defaultdict(list)
         for srow in stories_raw:
-            stories_by_epic.setdefault(srow["epic_id"], []).append(
+            stories_by_epic[srow["epic_id"]].append(
                 StoryNode.model_validate(
                     {
                         **srow,
@@ -481,9 +465,9 @@ class ProductDeliveryStore:
                     }
                 )
             )
-        epics_by_initiative: dict[str, list[EpicNode]] = {}
+        epics_by_initiative: defaultdict[str, list[EpicNode]] = defaultdict(list)
         for erow in epics_raw:
-            epics_by_initiative.setdefault(erow["initiative_id"], []).append(
+            epics_by_initiative[erow["initiative_id"]].append(
                 EpicNode.model_validate({**erow, "stories": stories_by_epic.get(erow["id"], [])})
             )
         initiatives = [
@@ -499,9 +483,7 @@ class ProductDeliveryStore:
         """Flat list of every story under a product. Used by the grooming agent."""
         with self._conn() as conn, conn.cursor(row_factory=dict_row) as cur:
             cur.execute(
-                """SELECT s.id, s.epic_id, s.title, s.user_story, s.status,
-                          s.wsjf_score, s.rice_score, s.estimate_points,
-                          s.author, s.created_at, s.updated_at
+                f"""SELECT {_STORY_COLS.replace("id, ", "s.id, ")}
                    FROM product_delivery_stories s
                    JOIN product_delivery_epics e ON e.id = s.epic_id
                    JOIN product_delivery_initiatives i ON i.id = e.initiative_id
@@ -526,63 +508,52 @@ class ProductDeliveryStore:
         linked_story_id: str | None,
         author: str,
     ) -> FeedbackItem:
+        # Validate product + cross-product linkage first, then insert. We
+        # don't go through `_insert` because feedback_items needs the
+        # validation-then-insert sequence inside one transaction (so a
+        # concurrent delete of the linking chain can't slip past us).
         now = _now()
         fid = _new_id()
-        try:
-            with self._conn() as conn, conn.cursor() as cur:
-                # Validate the product first so a bad product_id always
-                # surfaces as 404 (unknown), even when a valid story id
-                # is also supplied. Otherwise the cross-product check
-                # below would misclassify "unknown product" as 400.
+        with self._conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT 1 FROM product_delivery_products WHERE id = %s",
+                (product_id,),
+            )
+            if cur.fetchone() is None:
+                raise UnknownProductDeliveryEntity(f"product {product_id!r} does not exist")
+            if linked_story_id is not None:
                 cur.execute(
-                    "SELECT 1 FROM product_delivery_products WHERE id = %s",
-                    (product_id,),
+                    """SELECT i.product_id
+                       FROM product_delivery_stories s
+                       JOIN product_delivery_epics e ON e.id = s.epic_id
+                       JOIN product_delivery_initiatives i ON i.id = e.initiative_id
+                       WHERE s.id = %s""",
+                    (linked_story_id,),
                 )
-                if cur.fetchone() is None:
-                    raise UnknownProductDeliveryEntity(f"product {product_id!r} does not exist")
-                # When linked_story_id is set, verify the story is under the
-                # same product as the feedback item (story → epic → initiative
-                # → product). Done inside the same transaction so a concurrent
-                # delete of the linking chain can't slip a stale row past us.
-                if linked_story_id is not None:
-                    cur.execute(
-                        """SELECT i.product_id
-                           FROM product_delivery_stories s
-                           JOIN product_delivery_epics e ON e.id = s.epic_id
-                           JOIN product_delivery_initiatives i ON i.id = e.initiative_id
-                           WHERE s.id = %s""",
-                        (linked_story_id,),
+                row = cur.fetchone()
+                if row is None:
+                    raise UnknownProductDeliveryEntity(f"story {linked_story_id!r} does not exist")
+                if row[0] != product_id:
+                    raise CrossProductFeedbackLink(
+                        f"story {linked_story_id!r} belongs to product "
+                        f"{row[0]!r}, not {product_id!r}"
                     )
-                    row = cur.fetchone()
-                    if row is None:
-                        raise UnknownProductDeliveryEntity(
-                            f"story {linked_story_id!r} does not exist"
-                        )
-                    if row[0] != product_id:
-                        raise CrossProductFeedbackLink(
-                            f"story {linked_story_id!r} belongs to product "
-                            f"{row[0]!r}, not {product_id!r}"
-                        )
-                cur.execute(
-                    """INSERT INTO product_delivery_feedback_items
-                          (id, product_id, source, raw_payload, severity, status,
-                           linked_story_id, author, created_at, updated_at)
-                       VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
-                    (
-                        fid,
-                        product_id,
-                        source,
-                        Json(raw_payload),
-                        severity,
-                        "open",
-                        linked_story_id,
-                        author,
-                        now,
-                        now,
-                    ),
-                )
-        except psycopg_errors.ForeignKeyViolation as exc:
-            raise UnknownProductDeliveryEntity(f"product {product_id!r} does not exist") from exc
+            cur.execute(
+                f"""INSERT INTO product_delivery_feedback_items ({_FEEDBACK_COLS})
+                   VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)""",
+                (
+                    fid,
+                    product_id,
+                    source,
+                    Json(raw_payload),
+                    severity,
+                    "open",
+                    linked_story_id,
+                    author,
+                    now,
+                    now,
+                ),
+            )
         return FeedbackItem(
             id=fid,
             product_id=product_id,
@@ -603,25 +574,14 @@ class ProductDeliveryStore:
         *,
         status: str | None = None,
     ) -> list[FeedbackItem]:
+        sql = f"SELECT {_FEEDBACK_COLS} FROM product_delivery_feedback_items WHERE product_id = %s"
+        params: list[Any] = [product_id]
+        if status is not None:
+            sql += " AND status = %s"
+            params.append(status)
+        sql += " ORDER BY created_at DESC"
         with self._conn() as conn, conn.cursor(row_factory=dict_row) as cur:
-            if status is None:
-                cur.execute(
-                    """SELECT id, product_id, source, raw_payload, severity, status,
-                              linked_story_id, author, created_at, updated_at
-                       FROM product_delivery_feedback_items
-                       WHERE product_id = %s
-                       ORDER BY created_at DESC""",
-                    (product_id,),
-                )
-            else:
-                cur.execute(
-                    """SELECT id, product_id, source, raw_payload, severity, status,
-                              linked_story_id, author, created_at, updated_at
-                       FROM product_delivery_feedback_items
-                       WHERE product_id = %s AND status = %s
-                       ORDER BY created_at DESC""",
-                    (product_id, status),
-                )
+            cur.execute(sql, params)
             return [FeedbackItem.model_validate(row) for row in cur.fetchall()]
 
     # ------------------------------------------------------------------
@@ -647,6 +607,12 @@ def _new_id() -> str:
     return uuid4().hex
 
 
-@lru_cache(maxsize=1)
+# Process-wide singleton. The store has no constructor side effects and
+# the connection pool lives in ``shared_postgres``, so a module-level
+# instance is sufficient — no `lru_cache` dance, no `cache_clear()`
+# calls in tests.
+_STORE_INSTANCE = ProductDeliveryStore()
+
+
 def get_store() -> ProductDeliveryStore:
-    return ProductDeliveryStore()
+    return _STORE_INSTANCE

--- a/backend/agents/product_delivery/store.py
+++ b/backend/agents/product_delivery/store.py
@@ -796,12 +796,20 @@ class ProductDeliveryStore:
         snapshot — under the default ``READ COMMITTED`` a concurrent
         delete between the two statements could otherwise return
         ``200 []`` for a missing product.
+
+        ``status`` is normalised through ``_validate_status`` (strip +
+        non-blank + length bound) before the SQL filter so a query like
+        ``GET /feedback?status=open%20`` (trailing space) matches stored
+        rows whose status was likewise normalised on write. Without this,
+        the filter did exact matching against the raw query input and
+        returned an empty list even when matching rows existed —
+        Codex flagged this as a triage-view false-negative.
         """
         sql = f"SELECT {_FEEDBACK_COLS} FROM product_delivery_feedback_items WHERE product_id = %s"
         params: list[Any] = [product_id]
         if status is not None:
             sql += " AND status = %s"
-            params.append(status)
+            params.append(_validate_status(status))
         sql += " ORDER BY created_at DESC"
         with self._conn() as conn, conn.cursor(row_factory=dict_row) as cur:
             _begin_repeatable_read(cur)

--- a/backend/agents/product_delivery/tests/test_api.py
+++ b/backend/agents/product_delivery/tests/test_api.py
@@ -325,10 +325,23 @@ class _FakeStore:
         linked_story_id: str | None,
         author: str,
     ) -> FeedbackItem:
-        from product_delivery.store import UnknownProductDeliveryEntity
+        from product_delivery.store import (
+            CrossProductFeedbackLink,
+            UnknownProductDeliveryEntity,
+        )
 
         if product_id not in self.products:
             raise UnknownProductDeliveryEntity(f"product {product_id!r} does not exist")
+        if linked_story_id is not None:
+            story = self.stories.get(linked_story_id)
+            if story is None:
+                raise UnknownProductDeliveryEntity(f"story {linked_story_id!r} does not exist")
+            owning_product = self.initiatives[self.epics[story.epic_id].initiative_id].product_id
+            if owning_product != product_id:
+                raise CrossProductFeedbackLink(
+                    f"story {linked_story_id!r} belongs to product "
+                    f"{owning_product!r}, not {product_id!r}"
+                )
         fid = self._id()
         now = _now()
         f = FeedbackItem(
@@ -493,6 +506,85 @@ def test_feedback_create_and_list_filters_by_status(client: TestClient) -> None:
         params={"product_id": pid, "status": "closed"},
     ).json()
     assert listed_closed == []
+
+
+def test_feedback_rejects_cross_product_story_link(client: TestClient) -> None:
+    # Two products, each with one story. Linking a feedback item for
+    # product A to a story that lives under product B must be rejected.
+    pid_a = client.post("/api/product-delivery/products", json={"name": "A"}).json()["id"]
+    pid_b = client.post("/api/product-delivery/products", json={"name": "B"}).json()["id"]
+    iid_b = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid_b, "title": "I"},
+    ).json()["id"]
+    eid_b = client.post(
+        "/api/product-delivery/epics",
+        json={"initiative_id": iid_b, "title": "E"},
+    ).json()["id"]
+    sid_b = client.post(
+        "/api/product-delivery/stories",
+        json={"epic_id": eid_b, "title": "S"},
+    ).json()["id"]
+
+    resp = client.post(
+        "/api/product-delivery/feedback",
+        json={
+            "product_id": pid_a,
+            "source": "qa",
+            "linked_story_id": sid_b,
+        },
+    )
+    assert resp.status_code == 400
+    assert "belongs to product" in resp.json()["detail"]
+
+
+def test_feedback_accepts_same_product_story_link(client: TestClient) -> None:
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    iid = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": "I"},
+    ).json()["id"]
+    eid = client.post(
+        "/api/product-delivery/epics",
+        json={"initiative_id": iid, "title": "E"},
+    ).json()["id"]
+    sid = client.post(
+        "/api/product-delivery/stories",
+        json={"epic_id": eid, "title": "S"},
+    ).json()["id"]
+
+    resp = client.post(
+        "/api/product-delivery/feedback",
+        json={"product_id": pid, "source": "qa", "linked_story_id": sid},
+    )
+    assert resp.status_code == 200
+    assert resp.json()["linked_story_id"] == sid
+
+
+def test_groom_returns_503_when_storage_unavailable(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Simulate a Postgres outage hitting `store.get_product` (the failure
+    # path covered by the P1 review comment). The route must return 503,
+    # not 500, so clients can retry the same way they do for the
+    # CRUD endpoints.
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+
+    from unified_api.routes import product_delivery as router_module
+
+    from product_delivery.store import ProductDeliveryStorageUnavailable
+
+    def _boom(_self, _product_id):  # type: ignore[no-untyped-def]
+        raise ProductDeliveryStorageUnavailable("postgres is down")
+
+    monkeypatch.setattr(router_module.get_store().__class__, "get_product", _boom)
+
+    resp = client.post(
+        "/api/product-delivery/groom",
+        json={"product_id": pid, "method": "wsjf"},
+    )
+    assert resp.status_code == 503
+    assert "postgres is down" in resp.json()["detail"]
 
 
 def test_groom_unknown_product_returns_404(client: TestClient) -> None:

--- a/backend/agents/product_delivery/tests/test_api.py
+++ b/backend/agents/product_delivery/tests/test_api.py
@@ -479,6 +479,35 @@ def test_status_patch_404_for_unknown_id(client: TestClient) -> None:
     assert r.status_code == 404
 
 
+def test_score_patch_rejects_non_finite_values(client: TestClient) -> None:
+    # NaN / ±Infinity must be rejected at validation: persisting them
+    # would later break Starlette's JSON encoder when /backlog or /groom
+    # serialize the row, manifesting as a 500 long after the bad write.
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    iid = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": "I"},
+    ).json()["id"]
+
+    for bad in ("NaN", "Infinity", "-Infinity"):
+        # Send the value as a string so Pydantic's float coercion is exercised.
+        # FastAPI / requests serializes Python floats correctly, but JSON
+        # itself doesn't allow NaN — strings reach Pydantic intact.
+        r = client.post(
+            f"/api/product-delivery/initiative/{iid}/scores",
+            content=f'{{"wsjf_score": "{bad}"}}',
+            headers={"content-type": "application/json"},
+        )
+        # POST → 405 (we declared PATCH); use PATCH with the same content.
+        r = client.request(
+            "PATCH",
+            f"/api/product-delivery/initiative/{iid}/scores",
+            content=f'{{"wsjf_score": "{bad}"}}',
+            headers={"content-type": "application/json"},
+        )
+        assert r.status_code == 422, f"value={bad!r} should be rejected"
+
+
 def test_score_patch_empty_body_returns_400(client: TestClient) -> None:
     # Empty (or all-null) score payload is a client error, not a 404 —
     # otherwise clients can't tell "you sent nothing" from "the entity
@@ -535,6 +564,44 @@ def test_story_create_rejects_non_positive_estimate_points(client: TestClient) -
         json={"epic_id": eid, "title": "S", "estimate_points": None},
     )
     assert r.status_code == 200
+
+
+def test_groom_returns_503_when_llm_client_bootstrap_fails(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # `get_client("product_owner")` can fail on misconfigured provider
+    # / missing credentials. The route must surface that as 503 (not a
+    # bare 500) so clients see the same "transient infra" signal they
+    # do for a Postgres outage.
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+
+    import sys
+    import types
+
+    stub_module = types.ModuleType("llm_service")
+
+    def _boom(*args: Any, **kwargs: Any) -> Any:
+        raise RuntimeError("OLLAMA_API_KEY missing")
+
+    stub_module.get_client = _boom  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "llm_service", stub_module)
+
+    resp = client.post(
+        "/api/product-delivery/groom",
+        json={"product_id": pid, "method": "wsjf"},
+    )
+    assert resp.status_code == 503
+    assert "LLM client unavailable" in resp.json()["detail"]
+    assert "OLLAMA_API_KEY missing" in resp.json()["detail"]
+
+
+def test_feedback_list_404_for_unknown_product(client: TestClient) -> None:
+    # Match the 404 semantics of /backlog, /groom, and feedback POST
+    # when the product doesn't exist. Otherwise clients can't
+    # distinguish "no feedback yet" from "you sent the wrong id".
+    r = client.get("/api/product-delivery/feedback", params={"product_id": "ghost"})
+    assert r.status_code == 404
+    assert "ghost" in r.json()["detail"]
 
 
 def test_feedback_unknown_product_with_valid_story_returns_404(client: TestClient) -> None:

--- a/backend/agents/product_delivery/tests/test_api.py
+++ b/backend/agents/product_delivery/tests/test_api.py
@@ -558,6 +558,28 @@ def test_story_create_accepts_none_estimate_points(client: TestClient) -> None:
     assert r.status_code == 200
 
 
+@pytest.mark.parametrize("bad", ["Infinity", "-Infinity", "NaN"])
+def test_story_create_rejects_non_finite_estimate_points(client: TestClient, bad: str) -> None:
+    # Infinity passes `gt=0` but is non-finite; later it would propagate
+    # into WSJF `job_size` / RICE `effort` and serialise as null/invalid.
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    iid = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": "I"},
+    ).json()["id"]
+    eid = client.post(
+        "/api/product-delivery/epics",
+        json={"initiative_id": iid, "title": "E"},
+    ).json()["id"]
+    r = client.request(
+        "POST",
+        "/api/product-delivery/stories",
+        content=(f'{{"epic_id": "{eid}", "title": "S", "estimate_points": "{bad}"}}'),
+        headers={"content-type": "application/json"},
+    )
+    assert r.status_code == 422
+
+
 def test_groom_returns_503_when_llm_client_bootstrap_fails(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/agents/product_delivery/tests/test_api.py
+++ b/backend/agents/product_delivery/tests/test_api.py
@@ -626,8 +626,21 @@ def test_groom_returns_503_when_llm_client_bootstrap_fails(
     # `get_client("product_owner")` can fail on misconfigured provider
     # / missing credentials. The route must surface that as 503 (not a
     # bare 500) so clients see the same "transient infra" signal they
-    # do for a Postgres outage.
+    # do for a Postgres outage. We need a non-empty backlog here —
+    # an empty backlog short-circuits before the LLM bootstrap.
     pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    iid = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": "I"},
+    ).json()["id"]
+    eid = client.post(
+        "/api/product-delivery/epics",
+        json={"initiative_id": iid, "title": "E"},
+    ).json()["id"]
+    client.post(
+        "/api/product-delivery/stories",
+        json={"epic_id": eid, "title": "S", "estimate_points": 5},
+    )
 
     import sys
     import types
@@ -803,6 +816,76 @@ def test_groom_unknown_product_returns_404(client: TestClient) -> None:
         json={"product_id": "nope", "method": "wsjf"},
     )
     assert resp.status_code == 404
+
+
+def test_groom_empty_backlog_does_not_bootstrap_llm(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Empty backlog short-circuits to GroomResult(ranked=[]) without any
+    # LLM call. Even if `get_client` would raise, the route must return
+    # 200 — otherwise newly-created products with zero stories 503
+    # whenever the LLM provider is down.
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+
+    import sys
+    import types
+
+    stub_module = types.ModuleType("llm_service")
+    calls: list[tuple] = []
+
+    def _boom(*args, **kwargs):
+        calls.append((args, kwargs))
+        raise RuntimeError("LLM provider down")
+
+    stub_module.get_client = _boom  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "llm_service", stub_module)
+
+    resp = client.post(
+        "/api/product-delivery/groom",
+        json={"product_id": pid, "method": "wsjf"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ranked"] == []
+    # `get_client` must not have been called for the empty-backlog path.
+    assert calls == []
+
+
+def test_groom_returns_503_when_llm_service_import_fails(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Module-level import errors (missing strands/ollama, broken plugin)
+    # must surface as 503, the same way `get_client` failures do — the
+    # route's error contract is "transient infra problem, retry".
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    iid = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": "I"},
+    ).json()["id"]
+    eid = client.post(
+        "/api/product-delivery/epics",
+        json={"initiative_id": iid, "title": "E"},
+    ).json()["id"]
+    client.post(
+        "/api/product-delivery/stories",
+        json={"epic_id": eid, "title": "S", "estimate_points": 5},
+    )
+
+    import sys
+
+    # Make `from llm_service import get_client` fail at import time.
+    class _BoomModule:
+        def __getattr__(self, name):
+            raise ImportError(f"llm_service plugin broken: {name}")
+
+    monkeypatch.setitem(sys.modules, "llm_service", _BoomModule())
+
+    resp = client.post(
+        "/api/product-delivery/groom",
+        json={"product_id": pid, "method": "wsjf"},
+    )
+    assert resp.status_code == 503
+    assert "LLM client unavailable" in resp.json()["detail"]
 
 
 def test_groom_uses_stubbed_llm_and_returns_ranked_result(

--- a/backend/agents/product_delivery/tests/test_api.py
+++ b/backend/agents/product_delivery/tests/test_api.py
@@ -607,6 +607,52 @@ def test_initiative_create_rejects_out_of_bounds_status(
     assert r.status_code == 422
 
 
+@pytest.mark.parametrize("blank", [" ", "   ", "\t", "\n", " \t\n "])
+def test_product_create_rejects_whitespace_only_name(client: TestClient, blank: str) -> None:
+    """Whitespace-only `name` must 422 at the API, not 500 at the store.
+
+    Codex flagged that ``min_length=1`` accepts ``"   "`` because it
+    counts the spaces; the value then hit the store's ``_validate_title``
+    helper, which raises ``ValueError`` — and ``ValueError`` isn't in
+    the domain-exception map, so clients saw a 500 instead of a 4xx.
+    """
+    r = client.post("/api/product-delivery/products", json={"name": blank})
+    assert r.status_code == 422
+
+
+@pytest.mark.parametrize("blank", [" ", "   ", "\t", "\n"])
+def test_initiative_create_rejects_whitespace_only_title(client: TestClient, blank: str) -> None:
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    r = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": blank},
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.parametrize("blank", [" ", "   ", "\t"])
+def test_initiative_create_rejects_whitespace_only_status(client: TestClient, blank: str) -> None:
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    r = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": "I", "status": blank},
+    )
+    assert r.status_code == 422
+
+
+def test_status_patch_rejects_whitespace_only_status(client: TestClient) -> None:
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    iid = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": "I"},
+    ).json()["id"]
+    r = client.patch(
+        f"/api/product-delivery/initiative/{iid}/status",
+        json={"status": "   "},
+    )
+    assert r.status_code == 422
+
+
 def test_story_create_accepts_none_estimate_points(client: TestClient) -> None:
     """``None`` is the legitimate "unestimated" value — must still be accepted."""
     pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]

--- a/backend/agents/product_delivery/tests/test_api.py
+++ b/backend/agents/product_delivery/tests/test_api.py
@@ -291,6 +291,12 @@ class _FakeStore:
         return BacklogTree(product=p, initiatives=i_nodes)
 
     def list_stories_for_product(self, product_id: str) -> list[Story]:
+        # Mirror the real store's transactional contract: an unknown
+        # product raises `UnknownProductDeliveryEntity` (→ 404 via the
+        # global handler) so a concurrent delete can't slip past as
+        # `200 []`.
+        if product_id not in self.products:
+            raise UnknownProductDeliveryEntity(f"unknown product: {product_id}")
         epic_ids = {
             e.id
             for e in self.epics.values()
@@ -335,6 +341,11 @@ class _FakeStore:
         )
 
     def list_feedback(self, product_id: str, *, status: str | None = None) -> list[FeedbackItem]:
+        # Mirror the real store: unknown product raises 404 inside the
+        # same transaction as the SELECT, so concurrent deletes don't
+        # turn a 404 into `200 []`.
+        if product_id not in self.products:
+            raise UnknownProductDeliveryEntity(f"unknown product: {product_id}")
         out = [f for f in self.feedback.values() if f.product_id == product_id]
         if status is not None:
             out = [f for f in out if f.status == status]
@@ -466,6 +477,41 @@ def test_status_patch_404_for_unknown_id(client: TestClient) -> None:
         json={"status": "done"},
     )
     assert r.status_code == 404
+
+
+@pytest.mark.parametrize("bad", [True, False])
+def test_score_patch_rejects_boolean_values(client: TestClient, bad: bool) -> None:
+    # Pydantic's default `float` coercion accepts JSON booleans
+    # (`true → 1.0`, `false → 0.0`). The validator now rejects them
+    # so PATCH /scores can't silently mutate ranking data.
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    iid = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": "I"},
+    ).json()["id"]
+    r = client.patch(
+        f"/api/product-delivery/initiative/{iid}/scores",
+        json={"wsjf_score": bad},
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.parametrize("bad", [True, False])
+def test_story_create_rejects_boolean_estimate_points(client: TestClient, bad: bool) -> None:
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    iid = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": "I"},
+    ).json()["id"]
+    eid = client.post(
+        "/api/product-delivery/epics",
+        json={"initiative_id": iid, "title": "E"},
+    ).json()["id"]
+    r = client.post(
+        "/api/product-delivery/stories",
+        json={"epic_id": eid, "title": "S", "estimate_points": bad},
+    )
+    assert r.status_code == 422
 
 
 @pytest.mark.parametrize("bad", ["NaN", "Infinity", "-Infinity"])
@@ -809,10 +855,11 @@ def test_feedback_accepts_same_product_story_link(client: TestClient) -> None:
 def test_groom_returns_503_when_storage_unavailable(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # Simulate a Postgres outage hitting `store.get_product` (the failure
-    # path covered by the P1 review comment). The route must return 503,
-    # not 500, so clients can retry the same way they do for the
-    # CRUD endpoints.
+    # Simulate a Postgres outage hitting the agent's
+    # `store.list_stories_for_product` call (the new TOCTTOU-safe
+    # entry point that combines product-existence + story-listing).
+    # The route must return 503, not 500, so clients can retry the
+    # same way they do for the other persistence endpoints.
     pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
 
     from unified_api.routes import product_delivery as router_module
@@ -822,7 +869,7 @@ def test_groom_returns_503_when_storage_unavailable(
     def _boom(_self, _product_id):  # type: ignore[no-untyped-def]
         raise ProductDeliveryStorageUnavailable("postgres is down")
 
-    monkeypatch.setattr(router_module.get_store().__class__, "get_product", _boom)
+    monkeypatch.setattr(router_module.get_store().__class__, "list_stories_for_product", _boom)
 
     resp = client.post(
         "/api/product-delivery/groom",

--- a/backend/agents/product_delivery/tests/test_api.py
+++ b/backend/agents/product_delivery/tests/test_api.py
@@ -479,6 +479,95 @@ def test_status_patch_404_for_unknown_id(client: TestClient) -> None:
     assert r.status_code == 404
 
 
+def test_score_patch_empty_body_returns_400(client: TestClient) -> None:
+    # Empty (or all-null) score payload is a client error, not a 404 —
+    # otherwise clients can't tell "you sent nothing" from "the entity
+    # doesn't exist" and may incorrectly trigger a create/retry flow.
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    iid = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": "I"},
+    ).json()["id"]
+
+    r = client.patch(f"/api/product-delivery/initiative/{iid}/scores", json={})
+    assert r.status_code == 400
+    assert "wsjf_score" in r.json()["detail"]
+
+    r = client.patch(
+        f"/api/product-delivery/initiative/{iid}/scores",
+        json={"wsjf_score": None, "rice_score": None},
+    )
+    assert r.status_code == 400
+
+
+def test_score_patch_404_for_unknown_id_with_real_payload(client: TestClient) -> None:
+    # Sanity check: a well-formed payload against an unknown id is still 404.
+    r = client.patch(
+        "/api/product-delivery/initiative/missing/scores",
+        json={"wsjf_score": 1.0},
+    )
+    assert r.status_code == 404
+
+
+def test_story_create_rejects_non_positive_estimate_points(client: TestClient) -> None:
+    # Negative / zero estimates would feed into WSJF/RICE denominators
+    # which clamp to 1, silently inflating priority. Reject at the API.
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    iid = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": "I"},
+    ).json()["id"]
+    eid = client.post(
+        "/api/product-delivery/epics",
+        json={"initiative_id": iid, "title": "E"},
+    ).json()["id"]
+
+    for bad in (0, -3.5):
+        r = client.post(
+            "/api/product-delivery/stories",
+            json={"epic_id": eid, "title": "S", "estimate_points": bad},
+        )
+        assert r.status_code == 422, f"estimate_points={bad} should be rejected"
+
+    # None is still allowed (means "unestimated").
+    r = client.post(
+        "/api/product-delivery/stories",
+        json={"epic_id": eid, "title": "S", "estimate_points": None},
+    )
+    assert r.status_code == 200
+
+
+def test_feedback_unknown_product_with_valid_story_returns_404(client: TestClient) -> None:
+    # When both product_id and linked_story_id are supplied and the
+    # product doesn't exist, the route must return 404 (unknown product),
+    # not 400 (cross-product link). Otherwise clients misclassify the
+    # error and may trigger the wrong recovery flow.
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    iid = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": "I"},
+    ).json()["id"]
+    eid = client.post(
+        "/api/product-delivery/epics",
+        json={"initiative_id": iid, "title": "E"},
+    ).json()["id"]
+    sid = client.post(
+        "/api/product-delivery/stories",
+        json={"epic_id": eid, "title": "S"},
+    ).json()["id"]
+
+    r = client.post(
+        "/api/product-delivery/feedback",
+        json={
+            "product_id": "ghost-product",
+            "source": "qa",
+            "linked_story_id": sid,
+        },
+    )
+    assert r.status_code == 404
+    assert "ghost-product" in r.json()["detail"]
+
+
 def test_feedback_create_and_list_filters_by_status(client: TestClient) -> None:
     pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
     client.post(

--- a/backend/agents/product_delivery/tests/test_api.py
+++ b/backend/agents/product_delivery/tests/test_api.py
@@ -539,6 +539,28 @@ def test_story_create_rejects_non_positive_estimate_points(client: TestClient, b
     assert r.status_code == 422
 
 
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("status", ""),  # empty
+        ("status", "x" * 41),  # over the 40-char cap
+    ],
+    ids=["empty", "over-cap"],
+)
+def test_initiative_create_rejects_out_of_bounds_status(
+    client: TestClient, field: str, value: str
+) -> None:
+    # Codex flagged that Create payloads accepted unbounded `status`
+    # while StatusUpdate enforced 1..40. Now both go through the same
+    # `StatusStr` annotated alias, so create + patch agree.
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    r = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": "I", field: value},
+    )
+    assert r.status_code == 422
+
+
 def test_story_create_accepts_none_estimate_points(client: TestClient) -> None:
     """``None`` is the legitimate "unestimated" value — must still be accepted."""
     pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
@@ -658,7 +680,7 @@ def test_groom_returns_503_when_llm_client_bootstrap_fails(
         json={"product_id": pid, "method": "wsjf"},
     )
     assert resp.status_code == 503
-    assert "LLM client unavailable" in resp.json()["detail"]
+    assert "LLM scoring call failed" in resp.json()["detail"]
     assert "OLLAMA_API_KEY missing" in resp.json()["detail"]
 
 
@@ -885,7 +907,7 @@ def test_groom_returns_503_when_llm_service_import_fails(
         json={"product_id": pid, "method": "wsjf"},
     )
     assert resp.status_code == 503
-    assert "LLM client unavailable" in resp.json()["detail"]
+    assert "LLM scoring call failed" in resp.json()["detail"]
 
 
 def test_groom_uses_stubbed_llm_and_returns_ranked_result(

--- a/backend/agents/product_delivery/tests/test_api.py
+++ b/backend/agents/product_delivery/tests/test_api.py
@@ -580,6 +580,46 @@ def test_story_create_rejects_non_finite_estimate_points(client: TestClient, bad
     assert r.status_code == 422
 
 
+def test_groom_returns_503_when_llm_call_fails(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # End-to-end LLM call failure (model unreachable, JSON parse blew up)
+    # must propagate as 503 — same shape as a Postgres outage — so
+    # callers retry instead of accepting a 200 with all-zero scores.
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    iid = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": "I"},
+    ).json()["id"]
+    eid = client.post(
+        "/api/product-delivery/epics",
+        json={"initiative_id": iid, "title": "E"},
+    ).json()["id"]
+    client.post(
+        "/api/product-delivery/stories",
+        json={"epic_id": eid, "title": "S", "estimate_points": 5},
+    )
+
+    import sys
+    import types
+
+    stub_module = types.ModuleType("llm_service")
+
+    class _BoomClient:
+        def complete_json(self, *a: Any, **kw: Any) -> dict[str, Any]:
+            raise RuntimeError("model unreachable")
+
+    stub_module.get_client = lambda *a, **kw: _BoomClient()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "llm_service", stub_module)
+
+    resp = client.post(
+        "/api/product-delivery/groom",
+        json={"product_id": pid, "method": "wsjf"},
+    )
+    assert resp.status_code == 503
+    assert "LLM scoring call failed" in resp.json()["detail"]
+
+
 def test_groom_returns_503_when_llm_client_bootstrap_fails(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/backend/agents/product_delivery/tests/test_api.py
+++ b/backend/agents/product_delivery/tests/test_api.py
@@ -343,12 +343,17 @@ class _FakeStore:
     def list_feedback(self, product_id: str, *, status: str | None = None) -> list[FeedbackItem]:
         # Mirror the real store: unknown product raises 404 inside the
         # same transaction as the SELECT, so concurrent deletes don't
-        # turn a 404 into `200 []`.
+        # turn a 404 into `200 []`. Also normalise the status filter
+        # the same way the real store does so the in-memory fake stays
+        # in lockstep with the API contract.
+        from product_delivery.store import _validate_status
+
         if product_id not in self.products:
             raise UnknownProductDeliveryEntity(f"unknown product: {product_id}")
         out = [f for f in self.feedback.values() if f.product_id == product_id]
         if status is not None:
-            out = [f for f in out if f.status == status]
+            normalised = _validate_status(status)
+            out = [f for f in out if f.status == normalised]
         return out
 
 
@@ -653,6 +658,48 @@ def test_status_patch_rejects_whitespace_only_status(client: TestClient) -> None
     assert r.status_code == 422
 
 
+def test_status_with_trailing_whitespace_is_accepted_after_trim(client: TestClient) -> None:
+    """Codex-flagged ordering bug: ``StatusStr`` used to apply ``max_length=40``
+    *before* the AfterValidator stripped whitespace, so a 40-char status
+    plus a trailing space (41 chars total, but trims to 40) was rejected
+    by the API while the store accepted the trimmed value. With the
+    validator applied first, both paths agree.
+    """
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    # 40-char status + trailing space = 41 chars raw, 40 after trim
+    status_with_trailing_space = "a" * 40 + " "
+    r = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": "I", "status": status_with_trailing_space},
+    )
+    assert r.status_code == 200, r.text
+    # And the persisted value is the trimmed form, not the raw input.
+    assert r.json()["status"] == "a" * 40
+
+
+def test_title_with_trailing_whitespace_is_accepted_after_trim(client: TestClient) -> None:
+    """Same length-after-trim contract for ``TitleStr``."""
+    title_with_trailing_space = "T" * 200 + " "
+    r = client.post(
+        "/api/product-delivery/products",
+        json={"name": title_with_trailing_space},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["name"] == "T" * 200
+
+
+def test_status_overlong_after_trim_still_rejected(client: TestClient) -> None:
+    """Defence-in-depth: 41 chars after stripping must still be 422
+    (the trim doesn't bypass the cap, just moves the cap behind it).
+    """
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    r = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": "I", "status": "a" * 41},
+    )
+    assert r.status_code == 422
+
+
 @pytest.mark.parametrize("blank", [" ", "   ", "\t", "\n"])
 def test_acceptance_criterion_create_rejects_whitespace_only_text(
     client: TestClient, blank: str
@@ -884,6 +931,36 @@ def test_feedback_create_and_list_filters_by_status(client: TestClient) -> None:
         params={"product_id": pid, "status": "closed"},
     ).json()
     assert listed_closed == []
+
+
+@pytest.mark.parametrize("filter_value", ["open ", " open", "  open  ", "open\t", "\nopen"])
+def test_feedback_status_filter_normalised_before_query(
+    client: TestClient, filter_value: str
+) -> None:
+    """Codex flagged: feedback statuses are normalised on write but the
+    read filter used the raw query input, so ``status=open%20`` returned
+    an empty list even when ``open`` rows existed. The store now strips
+    the filter through the same ``_validate_status`` helper used on
+    write, so the API/store contract holds.
+    """
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    client.post(
+        "/api/product-delivery/feedback",
+        json={
+            "product_id": pid,
+            "source": "user-survey",
+            "raw_payload": {},
+            "severity": "low",
+        },
+    )
+    listed = client.get(
+        "/api/product-delivery/feedback",
+        params={"product_id": pid, "status": filter_value},
+    )
+    assert listed.status_code == 200, listed.text
+    assert len(listed.json()) == 1, (
+        f"filter_value={filter_value!r} should match the persisted 'open' status"
+    )
 
 
 def test_feedback_rejects_cross_product_story_link(client: TestClient) -> None:

--- a/backend/agents/product_delivery/tests/test_api.py
+++ b/backend/agents/product_delivery/tests/test_api.py
@@ -1,0 +1,572 @@
+"""API tests for the product_delivery router.
+
+Routes are exercised through a FastAPI ``TestClient`` against a minimal
+app that mounts only the product_delivery router. The store is replaced
+with an in-memory fake via ``monkeypatch`` so these tests do not require
+Postgres.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from product_delivery.models import (
+    AcceptanceCriterion,
+    BacklogTree,
+    Epic,
+    EpicNode,
+    FeedbackItem,
+    Initiative,
+    InitiativeNode,
+    Product,
+    Story,
+    StoryNode,
+    Task,
+)
+
+
+def _now() -> datetime:
+    return datetime.now(tz=timezone.utc)
+
+
+class _FakeStore:
+    """In-memory implementation of the subset of ProductDeliveryStore the API uses."""
+
+    def __init__(self) -> None:
+        self.products: dict[str, Product] = {}
+        self.initiatives: dict[str, Initiative] = {}
+        self.epics: dict[str, Epic] = {}
+        self.stories: dict[str, Story] = {}
+        self.tasks: dict[str, Task] = {}
+        self.acs: dict[str, AcceptanceCriterion] = {}
+        self.feedback: dict[str, FeedbackItem] = {}
+        self._next = 0
+
+    def _id(self) -> str:
+        self._next += 1
+        return f"id{self._next}"
+
+    # products ----------------------------------------------------------
+
+    def create_product(self, *, name: str, description: str, vision: str, author: str) -> Product:
+        pid = self._id()
+        now = _now()
+        product = Product(
+            id=pid,
+            name=name,
+            description=description,
+            vision=vision,
+            author=author,
+            created_at=now,
+            updated_at=now,
+        )
+        self.products[pid] = product
+        return product
+
+    def list_products(self) -> list[Product]:
+        return list(self.products.values())
+
+    def get_product(self, product_id: str) -> Product | None:
+        return self.products.get(product_id)
+
+    # initiatives / epics / stories / tasks / ac ------------------------
+
+    def create_initiative(
+        self,
+        *,
+        product_id: str,
+        title: str,
+        summary: str,
+        status: str,
+        author: str,
+    ) -> Initiative:
+        from product_delivery.store import UnknownProductDeliveryEntity
+
+        if product_id not in self.products:
+            raise UnknownProductDeliveryEntity(f"product {product_id!r} does not exist")
+        iid = self._id()
+        now = _now()
+        i = Initiative(
+            id=iid,
+            product_id=product_id,
+            title=title,
+            summary=summary,
+            status=status,
+            author=author,
+            created_at=now,
+            updated_at=now,
+        )
+        self.initiatives[iid] = i
+        return i
+
+    def create_epic(
+        self,
+        *,
+        initiative_id: str,
+        title: str,
+        summary: str,
+        status: str,
+        author: str,
+    ) -> Epic:
+        from product_delivery.store import UnknownProductDeliveryEntity
+
+        if initiative_id not in self.initiatives:
+            raise UnknownProductDeliveryEntity(f"initiative {initiative_id!r} does not exist")
+        eid = self._id()
+        now = _now()
+        e = Epic(
+            id=eid,
+            initiative_id=initiative_id,
+            title=title,
+            summary=summary,
+            status=status,
+            author=author,
+            created_at=now,
+            updated_at=now,
+        )
+        self.epics[eid] = e
+        return e
+
+    def create_story(
+        self,
+        *,
+        epic_id: str,
+        title: str,
+        user_story: str,
+        status: str,
+        estimate_points: float | None,
+        author: str,
+    ) -> Story:
+        from product_delivery.store import UnknownProductDeliveryEntity
+
+        if epic_id not in self.epics:
+            raise UnknownProductDeliveryEntity(f"epic {epic_id!r} does not exist")
+        sid = self._id()
+        now = _now()
+        s = Story(
+            id=sid,
+            epic_id=epic_id,
+            title=title,
+            user_story=user_story,
+            status=status,
+            estimate_points=estimate_points,
+            author=author,
+            created_at=now,
+            updated_at=now,
+        )
+        self.stories[sid] = s
+        return s
+
+    def create_task(
+        self,
+        *,
+        story_id: str,
+        title: str,
+        description: str,
+        status: str,
+        owner: str | None,
+        author: str,
+    ) -> Task:
+        from product_delivery.store import UnknownProductDeliveryEntity
+
+        if story_id not in self.stories:
+            raise UnknownProductDeliveryEntity(f"story {story_id!r} does not exist")
+        tid = self._id()
+        now = _now()
+        t = Task(
+            id=tid,
+            story_id=story_id,
+            title=title,
+            description=description,
+            status=status,
+            owner=owner,
+            author=author,
+            created_at=now,
+            updated_at=now,
+        )
+        self.tasks[tid] = t
+        return t
+
+    def create_acceptance_criterion(
+        self, *, story_id: str, text: str, satisfied: bool, author: str
+    ) -> AcceptanceCriterion:
+        from product_delivery.store import UnknownProductDeliveryEntity
+
+        if story_id not in self.stories:
+            raise UnknownProductDeliveryEntity(f"story {story_id!r} does not exist")
+        aid = self._id()
+        now = _now()
+        ac = AcceptanceCriterion(
+            id=aid,
+            story_id=story_id,
+            text=text,
+            satisfied=satisfied,
+            author=author,
+            created_at=now,
+            updated_at=now,
+        )
+        self.acs[aid] = ac
+        return ac
+
+    # status / score updates -------------------------------------------
+
+    _kinds = {
+        "initiative": "initiatives",
+        "epic": "epics",
+        "story": "stories",
+        "task": "tasks",
+    }
+
+    def update_status(self, *, kind: str, entity_id: str, status: str) -> bool:
+        attr = self._kinds.get(kind)
+        if attr is None:
+            raise ValueError(kind)
+        bag = getattr(self, attr)
+        if entity_id not in bag:
+            return False
+        existing = bag[entity_id]
+        bag[entity_id] = existing.model_copy(update={"status": status, "updated_at": _now()})
+        return True
+
+    def update_scores(
+        self,
+        *,
+        kind: str,
+        entity_id: str,
+        wsjf_score: float | None,
+        rice_score: float | None,
+    ) -> bool:
+        if wsjf_score is None and rice_score is None:
+            return False
+        attr = self._kinds.get(kind)
+        if attr is None:
+            raise ValueError(kind)
+        bag = getattr(self, attr)
+        if entity_id not in bag:
+            return False
+        update: dict[str, Any] = {"updated_at": _now()}
+        if wsjf_score is not None:
+            update["wsjf_score"] = wsjf_score
+        if rice_score is not None:
+            update["rice_score"] = rice_score
+        bag[entity_id] = bag[entity_id].model_copy(update=update)
+        return True
+
+    # backlog tree -----------------------------------------------------
+
+    def get_backlog_tree(self, product_id: str) -> BacklogTree | None:
+        p = self.products.get(product_id)
+        if p is None:
+            return None
+        i_nodes: list[InitiativeNode] = []
+        for i in self.initiatives.values():
+            if i.product_id != product_id:
+                continue
+            e_nodes: list[EpicNode] = []
+            for e in self.epics.values():
+                if e.initiative_id != i.id:
+                    continue
+                s_nodes: list[StoryNode] = []
+                for s in self.stories.values():
+                    if s.epic_id != e.id:
+                        continue
+                    s_nodes.append(
+                        StoryNode.model_validate(
+                            {
+                                **s.model_dump(),
+                                "tasks": [t for t in self.tasks.values() if t.story_id == s.id],
+                                "acceptance_criteria": [
+                                    a for a in self.acs.values() if a.story_id == s.id
+                                ],
+                            }
+                        )
+                    )
+                e_nodes.append(EpicNode.model_validate({**e.model_dump(), "stories": s_nodes}))
+            i_nodes.append(InitiativeNode.model_validate({**i.model_dump(), "epics": e_nodes}))
+        return BacklogTree(product=p, initiatives=i_nodes)
+
+    def list_stories_for_product(self, product_id: str) -> list[Story]:
+        epic_ids = {
+            e.id
+            for e in self.epics.values()
+            if e.initiative_id
+            in {i.id for i in self.initiatives.values() if i.product_id == product_id}
+        }
+        return [s for s in self.stories.values() if s.epic_id in epic_ids]
+
+    def bulk_update_story_scores(self, rows: list[tuple[str, float | None, float | None]]) -> int:
+        n = 0
+        for sid, w, r in rows:
+            if sid not in self.stories:
+                continue
+            update: dict[str, Any] = {"updated_at": _now()}
+            if w is not None:
+                update["wsjf_score"] = w
+            if r is not None:
+                update["rice_score"] = r
+            self.stories[sid] = self.stories[sid].model_copy(update=update)
+            n += 1
+        return n
+
+    # feedback ---------------------------------------------------------
+
+    def create_feedback_item(
+        self,
+        *,
+        product_id: str,
+        source: str,
+        raw_payload: dict[str, Any],
+        severity: str,
+        linked_story_id: str | None,
+        author: str,
+    ) -> FeedbackItem:
+        from product_delivery.store import UnknownProductDeliveryEntity
+
+        if product_id not in self.products:
+            raise UnknownProductDeliveryEntity(f"product {product_id!r} does not exist")
+        fid = self._id()
+        now = _now()
+        f = FeedbackItem(
+            id=fid,
+            product_id=product_id,
+            source=source,
+            raw_payload=raw_payload,
+            severity=severity,
+            status="open",
+            linked_story_id=linked_story_id,
+            author=author,
+            created_at=now,
+            updated_at=now,
+        )
+        self.feedback[fid] = f
+        return f
+
+    def list_feedback(self, product_id: str, *, status: str | None = None) -> list[FeedbackItem]:
+        out = [f for f in self.feedback.values() if f.product_id == product_id]
+        if status is not None:
+            out = [f for f in out if f.status == status]
+        return out
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    from unified_api.routes import product_delivery as router_module
+
+    fake = _FakeStore()
+    monkeypatch.setattr(router_module, "get_store", lambda: fake)
+    monkeypatch.setattr(router_module, "resolve_author", lambda: "tester")
+
+    app = FastAPI()
+    app.include_router(router_module.router)
+    test_client = TestClient(app)
+    test_client.fake_store = fake  # type: ignore[attr-defined]
+    return test_client
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_create_and_list_products(client: TestClient) -> None:
+    resp = client.post(
+        "/api/product-delivery/products",
+        json={"name": "Demo", "description": "d", "vision": "v"},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["name"] == "Demo"
+    assert body["author"] == "tester"
+    assert body["id"]
+
+    listed = client.get("/api/product-delivery/products").json()
+    assert len(listed) == 1
+    assert listed[0]["id"] == body["id"]
+
+
+def test_full_hierarchy_creation_and_backlog_tree(client: TestClient) -> None:
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    iid = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": "I"},
+    ).json()["id"]
+    eid = client.post(
+        "/api/product-delivery/epics",
+        json={"initiative_id": iid, "title": "E"},
+    ).json()["id"]
+    sid = client.post(
+        "/api/product-delivery/stories",
+        json={"epic_id": eid, "title": "S", "estimate_points": 5},
+    ).json()["id"]
+    client.post(
+        "/api/product-delivery/tasks",
+        json={"story_id": sid, "title": "T", "owner": "alice"},
+    )
+    client.post(
+        "/api/product-delivery/acceptance-criteria",
+        json={"story_id": sid, "text": "must work"},
+    )
+
+    tree = client.get(f"/api/product-delivery/products/{pid}/backlog").json()
+    assert tree["product"]["id"] == pid
+    assert tree["initiatives"][0]["id"] == iid
+    epic = tree["initiatives"][0]["epics"][0]
+    assert epic["id"] == eid
+    story = epic["stories"][0]
+    assert story["id"] == sid
+    assert story["estimate_points"] == 5
+    assert len(story["tasks"]) == 1
+    assert len(story["acceptance_criteria"]) == 1
+
+
+def test_initiative_create_404_when_product_missing(client: TestClient) -> None:
+    resp = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": "missing", "title": "x"},
+    )
+    assert resp.status_code == 404
+
+
+def test_status_and_score_patches_apply(client: TestClient) -> None:
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    iid = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": "I"},
+    ).json()["id"]
+
+    r = client.patch(
+        f"/api/product-delivery/initiative/{iid}/status",
+        json={"status": "in_sprint"},
+    )
+    assert r.status_code == 200
+    assert r.json()["status"] == "in_sprint"
+
+    r = client.patch(
+        f"/api/product-delivery/initiative/{iid}/scores",
+        json={"wsjf_score": 12.5, "rice_score": 80.0},
+    )
+    assert r.status_code == 200
+
+    fake = client.fake_store  # type: ignore[attr-defined]
+    assert fake.initiatives[iid].status == "in_sprint"
+    assert fake.initiatives[iid].wsjf_score == 12.5
+    assert fake.initiatives[iid].rice_score == 80.0
+
+
+def test_status_patch_404_for_unknown_id(client: TestClient) -> None:
+    r = client.patch(
+        "/api/product-delivery/story/missing/status",
+        json={"status": "done"},
+    )
+    assert r.status_code == 404
+
+
+def test_feedback_create_and_list_filters_by_status(client: TestClient) -> None:
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    client.post(
+        "/api/product-delivery/feedback",
+        json={
+            "product_id": pid,
+            "source": "user-survey",
+            "raw_payload": {"note": "love it"},
+            "severity": "low",
+        },
+    )
+
+    listed = client.get("/api/product-delivery/feedback", params={"product_id": pid}).json()
+    assert len(listed) == 1
+    assert listed[0]["status"] == "open"
+
+    listed_open = client.get(
+        "/api/product-delivery/feedback",
+        params={"product_id": pid, "status": "open"},
+    ).json()
+    assert len(listed_open) == 1
+
+    listed_closed = client.get(
+        "/api/product-delivery/feedback",
+        params={"product_id": pid, "status": "closed"},
+    ).json()
+    assert listed_closed == []
+
+
+def test_groom_unknown_product_returns_404(client: TestClient) -> None:
+    resp = client.post(
+        "/api/product-delivery/groom",
+        json={"product_id": "nope", "method": "wsjf"},
+    )
+    assert resp.status_code == 404
+
+
+def test_groom_uses_stubbed_llm_and_returns_ranked_result(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Stub the llm_service module before the route's lazy import runs, so the
+    # test doesn't pull in strands / ollama just to swap out get_client.
+    import sys
+    import types
+
+    stub_module = types.ModuleType("llm_service")
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    iid = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": "I"},
+    ).json()["id"]
+    eid = client.post(
+        "/api/product-delivery/epics",
+        json={"initiative_id": iid, "title": "E"},
+    ).json()["id"]
+    sid_a = client.post(
+        "/api/product-delivery/stories",
+        json={"epic_id": eid, "title": "low", "estimate_points": 5},
+    ).json()["id"]
+    sid_b = client.post(
+        "/api/product-delivery/stories",
+        json={"epic_id": eid, "title": "high", "estimate_points": 5},
+    ).json()["id"]
+
+    class _Stub:
+        def complete_json(self, prompt: str, **_: Any) -> dict[str, Any]:
+            return {
+                "items": [
+                    {
+                        "id": sid_a,
+                        "inputs": {
+                            "user_business_value": 1,
+                            "time_criticality": 1,
+                            "risk_reduction_or_opportunity_enablement": 1,
+                            "job_size": 5,
+                        },
+                        "rationale": "low",
+                    },
+                    {
+                        "id": sid_b,
+                        "inputs": {
+                            "user_business_value": 9,
+                            "time_criticality": 9,
+                            "risk_reduction_or_opportunity_enablement": 9,
+                            "job_size": 5,
+                        },
+                        "rationale": "high",
+                    },
+                ]
+            }
+
+    stub_module.get_client = lambda *a, **kw: _Stub()  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "llm_service", stub_module)
+
+    resp = client.post(
+        "/api/product-delivery/groom",
+        json={"product_id": pid, "method": "wsjf", "persist": True},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["product_id"] == pid
+    assert [r["id"] for r in body["ranked"]] == [sid_b, sid_a]
+    # persistence ran on the fake
+    assert client.fake_store.stories[sid_b].wsjf_score == body["ranked"][0]["score"]  # type: ignore[attr-defined]

--- a/backend/agents/product_delivery/tests/test_api.py
+++ b/backend/agents/product_delivery/tests/test_api.py
@@ -8,8 +8,9 @@ Postgres.
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 from fastapi import FastAPI
@@ -28,45 +29,101 @@ from product_delivery.models import (
     StoryNode,
     Task,
 )
+from product_delivery.store import (
+    CrossProductFeedbackLink,
+    UnknownProductDeliveryEntity,
+)
 
 
 def _now() -> datetime:
     return datetime.now(tz=timezone.utc)
 
 
-class _FakeStore:
-    """In-memory implementation of the subset of ProductDeliveryStore the API uses."""
+# ---------------------------------------------------------------------------
+# Fake store — kind-driven CRUD over per-bucket dicts.
+# ---------------------------------------------------------------------------
 
-    def __init__(self) -> None:
-        self.products: dict[str, Product] = {}
-        self.initiatives: dict[str, Initiative] = {}
-        self.epics: dict[str, Epic] = {}
-        self.stories: dict[str, Story] = {}
-        self.tasks: dict[str, Task] = {}
-        self.acs: dict[str, AcceptanceCriterion] = {}
-        self.feedback: dict[str, FeedbackItem] = {}
-        self._next = 0
+
+@dataclass(frozen=True)
+class _Kind:
+    """Metadata table mirroring the real store's ``_ROW_SPECS``.
+
+    ``model`` is the Pydantic class returned from create. ``bucket`` is
+    the attribute name of the in-memory dict that holds rows of this
+    kind. ``parent_kind`` (when set) names the kind whose dict is
+    consulted for FK validation; ``parent_field`` is the field name on
+    the row that holds the parent's id.
+    """
+
+    model: type
+    bucket: str
+    parent_kind: str | None = None
+    parent_field: str | None = None
+    fk_label: str | None = None
+
+
+_KINDS: dict[str, _Kind] = {
+    "product": _Kind(Product, "products"),
+    "initiative": _Kind(Initiative, "initiatives", "product", "product_id", "product"),
+    "epic": _Kind(Epic, "epics", "initiative", "initiative_id", "initiative"),
+    "story": _Kind(Story, "stories", "epic", "epic_id", "epic"),
+    "task": _Kind(Task, "tasks", "story", "story_id", "story"),
+    "ac": _Kind(AcceptanceCriterion, "acs", "story", "story_id", "story"),
+    "feedback": _Kind(FeedbackItem, "feedback"),
+}
+
+
+@dataclass
+class _FakeStore:
+    """In-memory subset of ``ProductDeliveryStore`` used by the API tests.
+
+    Kind-driven: every CRUD method is a thin shim over ``_insert`` /
+    ``_update`` that consults :data:`_KINDS` for the bucket attribute,
+    parent FK, and Pydantic model. Mirrors the real store's
+    ``_ROW_SPECS`` pattern so the two stay in lockstep.
+    """
+
+    products: dict[str, Product] = field(default_factory=dict)
+    initiatives: dict[str, Initiative] = field(default_factory=dict)
+    epics: dict[str, Epic] = field(default_factory=dict)
+    stories: dict[str, Story] = field(default_factory=dict)
+    tasks: dict[str, Task] = field(default_factory=dict)
+    acs: dict[str, AcceptanceCriterion] = field(default_factory=dict)
+    feedback: dict[str, FeedbackItem] = field(default_factory=dict)
+    _next: ClassVar[int] = 0
 
     def _id(self) -> str:
-        self._next += 1
-        return f"id{self._next}"
+        type(self)._next += 1
+        return f"id{type(self)._next}"
 
-    # products ----------------------------------------------------------
+    # ------------------------------------------------------------------
+    # Generic create — used by every public create_* shim.
+    # ------------------------------------------------------------------
+
+    def _insert(self, kind: str, **fields: Any) -> Any:
+        meta = _KINDS[kind]
+        if meta.parent_kind:
+            parent_bucket = getattr(self, _KINDS[meta.parent_kind].bucket)
+            if fields[meta.parent_field] not in parent_bucket:  # type: ignore[index]
+                raise UnknownProductDeliveryEntity(
+                    f"{meta.fk_label} {fields[meta.parent_field]!r} does not exist"  # type: ignore[index]
+                )
+        now = _now()
+        fields["id"] = self._id()
+        fields["created_at"] = now
+        fields["updated_at"] = now
+        row = meta.model(**fields)
+        getattr(self, meta.bucket)[row.id] = row
+        return row
+
+    # ------------------------------------------------------------------
+    # Public store API — thin shims, signatures match ProductDeliveryStore.
+    # ------------------------------------------------------------------
 
     def create_product(self, *, name: str, description: str, vision: str, author: str) -> Product:
-        pid = self._id()
-        now = _now()
-        product = Product(
-            id=pid,
-            name=name,
-            description=description,
-            vision=vision,
-            author=author,
-            created_at=now,
-            updated_at=now,
+        return self._insert(
+            "product", name=name, description=description, vision=vision, author=author
         )
-        self.products[pid] = product
-        return product
 
     def list_products(self) -> list[Product]:
         return list(self.products.values())
@@ -74,63 +131,29 @@ class _FakeStore:
     def get_product(self, product_id: str) -> Product | None:
         return self.products.get(product_id)
 
-    # initiatives / epics / stories / tasks / ac ------------------------
-
     def create_initiative(
-        self,
-        *,
-        product_id: str,
-        title: str,
-        summary: str,
-        status: str,
-        author: str,
+        self, *, product_id: str, title: str, summary: str, status: str, author: str
     ) -> Initiative:
-        from product_delivery.store import UnknownProductDeliveryEntity
-
-        if product_id not in self.products:
-            raise UnknownProductDeliveryEntity(f"product {product_id!r} does not exist")
-        iid = self._id()
-        now = _now()
-        i = Initiative(
-            id=iid,
+        return self._insert(
+            "initiative",
             product_id=product_id,
             title=title,
             summary=summary,
             status=status,
             author=author,
-            created_at=now,
-            updated_at=now,
         )
-        self.initiatives[iid] = i
-        return i
 
     def create_epic(
-        self,
-        *,
-        initiative_id: str,
-        title: str,
-        summary: str,
-        status: str,
-        author: str,
+        self, *, initiative_id: str, title: str, summary: str, status: str, author: str
     ) -> Epic:
-        from product_delivery.store import UnknownProductDeliveryEntity
-
-        if initiative_id not in self.initiatives:
-            raise UnknownProductDeliveryEntity(f"initiative {initiative_id!r} does not exist")
-        eid = self._id()
-        now = _now()
-        e = Epic(
-            id=eid,
+        return self._insert(
+            "epic",
             initiative_id=initiative_id,
             title=title,
             summary=summary,
             status=status,
             author=author,
-            created_at=now,
-            updated_at=now,
         )
-        self.epics[eid] = e
-        return e
 
     def create_story(
         self,
@@ -142,25 +165,15 @@ class _FakeStore:
         estimate_points: float | None,
         author: str,
     ) -> Story:
-        from product_delivery.store import UnknownProductDeliveryEntity
-
-        if epic_id not in self.epics:
-            raise UnknownProductDeliveryEntity(f"epic {epic_id!r} does not exist")
-        sid = self._id()
-        now = _now()
-        s = Story(
-            id=sid,
+        return self._insert(
+            "story",
             epic_id=epic_id,
             title=title,
             user_story=user_story,
             status=status,
             estimate_points=estimate_points,
             author=author,
-            created_at=now,
-            updated_at=now,
         )
-        self.stories[sid] = s
-        return s
 
     def create_task(
         self,
@@ -172,50 +185,24 @@ class _FakeStore:
         owner: str | None,
         author: str,
     ) -> Task:
-        from product_delivery.store import UnknownProductDeliveryEntity
-
-        if story_id not in self.stories:
-            raise UnknownProductDeliveryEntity(f"story {story_id!r} does not exist")
-        tid = self._id()
-        now = _now()
-        t = Task(
-            id=tid,
+        return self._insert(
+            "task",
             story_id=story_id,
             title=title,
             description=description,
             status=status,
             owner=owner,
             author=author,
-            created_at=now,
-            updated_at=now,
         )
-        self.tasks[tid] = t
-        return t
 
     def create_acceptance_criterion(
         self, *, story_id: str, text: str, satisfied: bool, author: str
     ) -> AcceptanceCriterion:
-        from product_delivery.store import UnknownProductDeliveryEntity
-
-        if story_id not in self.stories:
-            raise UnknownProductDeliveryEntity(f"story {story_id!r} does not exist")
-        aid = self._id()
-        now = _now()
-        ac = AcceptanceCriterion(
-            id=aid,
-            story_id=story_id,
-            text=text,
-            satisfied=satisfied,
-            author=author,
-            created_at=now,
-            updated_at=now,
-        )
-        self.acs[aid] = ac
-        return ac
+        return self._insert("ac", story_id=story_id, text=text, satisfied=satisfied, author=author)
 
     # status / score updates -------------------------------------------
 
-    _kinds = {
+    _UPDATE_KINDS: ClassVar[dict[str, str]] = {
         "initiative": "initiatives",
         "epic": "epics",
         "story": "stories",
@@ -223,14 +210,13 @@ class _FakeStore:
     }
 
     def update_status(self, *, kind: str, entity_id: str, status: str) -> bool:
-        attr = self._kinds.get(kind)
-        if attr is None:
+        bucket_name = self._UPDATE_KINDS.get(kind)
+        if bucket_name is None:
             raise ValueError(kind)
-        bag = getattr(self, attr)
+        bag = getattr(self, bucket_name)
         if entity_id not in bag:
             return False
-        existing = bag[entity_id]
-        bag[entity_id] = existing.model_copy(update={"status": status, "updated_at": _now()})
+        bag[entity_id] = bag[entity_id].model_copy(update={"status": status, "updated_at": _now()})
         return True
 
     def update_scores(
@@ -243,10 +229,10 @@ class _FakeStore:
     ) -> bool:
         if wsjf_score is None and rice_score is None:
             return False
-        attr = self._kinds.get(kind)
-        if attr is None:
+        bucket_name = self._UPDATE_KINDS.get(kind)
+        if bucket_name is None:
             raise ValueError(kind)
-        bag = getattr(self, attr)
+        bag = getattr(self, bucket_name)
         if entity_id not in bag:
             return False
         update: dict[str, Any] = {"updated_at": _now()}
@@ -256,6 +242,20 @@ class _FakeStore:
             update["rice_score"] = rice_score
         bag[entity_id] = bag[entity_id].model_copy(update=update)
         return True
+
+    def bulk_update_story_scores(self, rows: list[tuple[str, float | None, float | None]]) -> int:
+        n = 0
+        for sid, w, r in rows:
+            if sid not in self.stories:
+                continue
+            update: dict[str, Any] = {"updated_at": _now()}
+            if w is not None:
+                update["wsjf_score"] = w
+            if r is not None:
+                update["rice_score"] = r
+            self.stories[sid] = self.stories[sid].model_copy(update=update)
+            n += 1
+        return n
 
     # backlog tree -----------------------------------------------------
 
@@ -299,20 +299,6 @@ class _FakeStore:
         }
         return [s for s in self.stories.values() if s.epic_id in epic_ids]
 
-    def bulk_update_story_scores(self, rows: list[tuple[str, float | None, float | None]]) -> int:
-        n = 0
-        for sid, w, r in rows:
-            if sid not in self.stories:
-                continue
-            update: dict[str, Any] = {"updated_at": _now()}
-            if w is not None:
-                update["wsjf_score"] = w
-            if r is not None:
-                update["rice_score"] = r
-            self.stories[sid] = self.stories[sid].model_copy(update=update)
-            n += 1
-        return n
-
     # feedback ---------------------------------------------------------
 
     def create_feedback_item(
@@ -325,11 +311,6 @@ class _FakeStore:
         linked_story_id: str | None,
         author: str,
     ) -> FeedbackItem:
-        from product_delivery.store import (
-            CrossProductFeedbackLink,
-            UnknownProductDeliveryEntity,
-        )
-
         if product_id not in self.products:
             raise UnknownProductDeliveryEntity(f"product {product_id!r} does not exist")
         if linked_story_id is not None:
@@ -342,10 +323,8 @@ class _FakeStore:
                     f"story {linked_story_id!r} belongs to product "
                     f"{owning_product!r}, not {product_id!r}"
                 )
-        fid = self._id()
-        now = _now()
-        f = FeedbackItem(
-            id=fid,
+        return self._insert(
+            "feedback",
             product_id=product_id,
             source=source,
             raw_payload=raw_payload,
@@ -353,11 +332,7 @@ class _FakeStore:
             status="open",
             linked_story_id=linked_story_id,
             author=author,
-            created_at=now,
-            updated_at=now,
         )
-        self.feedback[fid] = f
-        return f
 
     def list_feedback(self, product_id: str, *, status: str | None = None) -> list[FeedbackItem]:
         out = [f for f in self.feedback.values() if f.product_id == product_id]
@@ -366,8 +341,16 @@ class _FakeStore:
         return out
 
 
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
 @pytest.fixture
-def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+def client_and_store(monkeypatch: pytest.MonkeyPatch) -> tuple[TestClient, _FakeStore]:
+    """Yield (TestClient, fake_store) so tests can assert on either side
+    without the runtime ``client.fake_store = …`` monkey-attr hack.
+    """
     from unified_api.routes import product_delivery as router_module
 
     fake = _FakeStore()
@@ -376,9 +359,13 @@ def client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
 
     app = FastAPI()
     app.include_router(router_module.router)
-    test_client = TestClient(app)
-    test_client.fake_store = fake  # type: ignore[attr-defined]
-    return test_client
+    router_module.register_pd_exception_handlers(app)
+    return TestClient(app), fake
+
+
+@pytest.fixture
+def client(client_and_store: tuple[TestClient, _FakeStore]) -> TestClient:
+    return client_and_store[0]
 
 
 # ---------------------------------------------------------------------------
@@ -445,7 +432,10 @@ def test_initiative_create_404_when_product_missing(client: TestClient) -> None:
     assert resp.status_code == 404
 
 
-def test_status_and_score_patches_apply(client: TestClient) -> None:
+def test_status_and_score_patches_apply(
+    client_and_store: tuple[TestClient, _FakeStore],
+) -> None:
+    client, fake = client_and_store
     pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
     iid = client.post(
         "/api/product-delivery/initiatives",
@@ -465,7 +455,6 @@ def test_status_and_score_patches_apply(client: TestClient) -> None:
     )
     assert r.status_code == 200
 
-    fake = client.fake_store  # type: ignore[attr-defined]
     assert fake.initiatives[iid].status == "in_sprint"
     assert fake.initiatives[iid].wsjf_score == 12.5
     assert fake.initiatives[iid].rice_score == 80.0
@@ -479,7 +468,8 @@ def test_status_patch_404_for_unknown_id(client: TestClient) -> None:
     assert r.status_code == 404
 
 
-def test_score_patch_rejects_non_finite_values(client: TestClient) -> None:
+@pytest.mark.parametrize("bad", ["NaN", "Infinity", "-Infinity"])
+def test_score_patch_rejects_non_finite_values(client: TestClient, bad: str) -> None:
     # NaN / ±Infinity must be rejected at validation: persisting them
     # would later break Starlette's JSON encoder when /backlog or /groom
     # serialize the row, manifesting as a 500 long after the bad write.
@@ -488,27 +478,23 @@ def test_score_patch_rejects_non_finite_values(client: TestClient) -> None:
         "/api/product-delivery/initiatives",
         json={"product_id": pid, "title": "I"},
     ).json()["id"]
-
-    for bad in ("NaN", "Infinity", "-Infinity"):
-        # Send the value as a string so Pydantic's float coercion is exercised.
-        # FastAPI / requests serializes Python floats correctly, but JSON
-        # itself doesn't allow NaN — strings reach Pydantic intact.
-        r = client.post(
-            f"/api/product-delivery/initiative/{iid}/scores",
-            content=f'{{"wsjf_score": "{bad}"}}',
-            headers={"content-type": "application/json"},
-        )
-        # POST → 405 (we declared PATCH); use PATCH with the same content.
-        r = client.request(
-            "PATCH",
-            f"/api/product-delivery/initiative/{iid}/scores",
-            content=f'{{"wsjf_score": "{bad}"}}',
-            headers={"content-type": "application/json"},
-        )
-        assert r.status_code == 422, f"value={bad!r} should be rejected"
+    # JSON itself doesn't allow NaN / Infinity tokens, so send them as
+    # strings to exercise Pydantic's float coercion.
+    r = client.request(
+        "PATCH",
+        f"/api/product-delivery/initiative/{iid}/scores",
+        content=f'{{"wsjf_score": "{bad}"}}',
+        headers={"content-type": "application/json"},
+    )
+    assert r.status_code == 422
 
 
-def test_score_patch_empty_body_returns_400(client: TestClient) -> None:
+@pytest.mark.parametrize(
+    "body",
+    [{}, {"wsjf_score": None, "rice_score": None}],
+    ids=["empty", "explicit-nulls"],
+)
+def test_score_patch_empty_body_returns_400(client: TestClient, body: dict[str, Any]) -> None:
     # Empty (or all-null) score payload is a client error, not a 404 —
     # otherwise clients can't tell "you sent nothing" from "the entity
     # doesn't exist" and may incorrectly trigger a create/retry flow.
@@ -518,15 +504,9 @@ def test_score_patch_empty_body_returns_400(client: TestClient) -> None:
         json={"product_id": pid, "title": "I"},
     ).json()["id"]
 
-    r = client.patch(f"/api/product-delivery/initiative/{iid}/scores", json={})
+    r = client.patch(f"/api/product-delivery/initiative/{iid}/scores", json=body)
     assert r.status_code == 400
     assert "wsjf_score" in r.json()["detail"]
-
-    r = client.patch(
-        f"/api/product-delivery/initiative/{iid}/scores",
-        json={"wsjf_score": None, "rice_score": None},
-    )
-    assert r.status_code == 400
 
 
 def test_score_patch_404_for_unknown_id_with_real_payload(client: TestClient) -> None:
@@ -538,7 +518,8 @@ def test_score_patch_404_for_unknown_id_with_real_payload(client: TestClient) ->
     assert r.status_code == 404
 
 
-def test_story_create_rejects_non_positive_estimate_points(client: TestClient) -> None:
+@pytest.mark.parametrize("bad", [0, -3.5])
+def test_story_create_rejects_non_positive_estimate_points(client: TestClient, bad: float) -> None:
     # Negative / zero estimates would feed into WSJF/RICE denominators
     # which clamp to 1, silently inflating priority. Reject at the API.
     pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
@@ -551,14 +532,25 @@ def test_story_create_rejects_non_positive_estimate_points(client: TestClient) -
         json={"initiative_id": iid, "title": "E"},
     ).json()["id"]
 
-    for bad in (0, -3.5):
-        r = client.post(
-            "/api/product-delivery/stories",
-            json={"epic_id": eid, "title": "S", "estimate_points": bad},
-        )
-        assert r.status_code == 422, f"estimate_points={bad} should be rejected"
+    r = client.post(
+        "/api/product-delivery/stories",
+        json={"epic_id": eid, "title": "S", "estimate_points": bad},
+    )
+    assert r.status_code == 422
 
-    # None is still allowed (means "unestimated").
+
+def test_story_create_accepts_none_estimate_points(client: TestClient) -> None:
+    """``None`` is the legitimate "unestimated" value — must still be accepted."""
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    iid = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": "I"},
+    ).json()["id"]
+    eid = client.post(
+        "/api/product-delivery/epics",
+        json={"initiative_id": iid, "title": "E"},
+    ).json()["id"]
+
     r = client.post(
         "/api/product-delivery/stories",
         json={"epic_id": eid, "title": "S", "estimate_points": None},
@@ -752,13 +744,15 @@ def test_groom_unknown_product_returns_404(client: TestClient) -> None:
 
 
 def test_groom_uses_stubbed_llm_and_returns_ranked_result(
-    client: TestClient, monkeypatch: pytest.MonkeyPatch
+    client_and_store: tuple[TestClient, _FakeStore],
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     # Stub the llm_service module before the route's lazy import runs, so the
     # test doesn't pull in strands / ollama just to swap out get_client.
     import sys
     import types
 
+    client, fake = client_and_store
     stub_module = types.ModuleType("llm_service")
     pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
     iid = client.post(
@@ -817,4 +811,4 @@ def test_groom_uses_stubbed_llm_and_returns_ranked_result(
     assert body["product_id"] == pid
     assert [r["id"] for r in body["ranked"]] == [sid_b, sid_a]
     # persistence ran on the fake
-    assert client.fake_store.stories[sid_b].wsjf_score == body["ranked"][0]["score"]  # type: ignore[attr-defined]
+    assert fake.stories[sid_b].wsjf_score == body["ranked"][0]["score"]

--- a/backend/agents/product_delivery/tests/test_api.py
+++ b/backend/agents/product_delivery/tests/test_api.py
@@ -653,6 +653,47 @@ def test_status_patch_rejects_whitespace_only_status(client: TestClient) -> None
     assert r.status_code == 422
 
 
+@pytest.mark.parametrize("blank", [" ", "   ", "\t", "\n"])
+def test_acceptance_criterion_create_rejects_whitespace_only_text(
+    client: TestClient, blank: str
+) -> None:
+    """Whitespace-only acceptance-criterion text degrades the satisfied/total ratio.
+
+    Codex flagged that ``min_length=1`` lets ``'   '`` through, which
+    persists a meaningless criterion. Now rejected at the API boundary
+    via the shared ``_reject_blank_str`` validator.
+    """
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    iid = client.post(
+        "/api/product-delivery/initiatives",
+        json={"product_id": pid, "title": "I"},
+    ).json()["id"]
+    eid = client.post(
+        "/api/product-delivery/epics",
+        json={"initiative_id": iid, "title": "E"},
+    ).json()["id"]
+    sid = client.post(
+        "/api/product-delivery/stories",
+        json={"epic_id": eid, "title": "S"},
+    ).json()["id"]
+    r = client.post(
+        "/api/product-delivery/acceptance-criteria",
+        json={"story_id": sid, "text": blank},
+    )
+    assert r.status_code == 422
+
+
+@pytest.mark.parametrize("blank", [" ", "   ", "\t", "\n"])
+def test_feedback_create_rejects_whitespace_only_source(client: TestClient, blank: str) -> None:
+    """Blank ``source`` would corrupt feedback provenance / triage filters."""
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    r = client.post(
+        "/api/product-delivery/feedback",
+        json={"product_id": pid, "source": blank, "raw_payload": {"k": "v"}},
+    )
+    assert r.status_code == 422
+
+
 def test_story_create_accepts_none_estimate_points(client: TestClient) -> None:
     """``None`` is the legitimate "unestimated" value — must still be accepted."""
     pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]

--- a/backend/agents/product_delivery/tests/test_product_owner_agent.py
+++ b/backend/agents/product_delivery/tests/test_product_owner_agent.py
@@ -29,14 +29,20 @@ class _StubLLM:
 
 
 class _FakeStore:
-    """In-memory subset of ``ProductDeliveryStore`` used by the agent."""
+    """In-memory subset of ``ProductDeliveryStore`` used by the agent.
 
-    def __init__(self, stories: list[Story]) -> None:
-        self._stories = stories
+    Stories are keyed by ``product_id`` so tests can put two products
+    side by side and assert that ``list_stories_for_product`` only
+    returns the stories scoped to the requested product (i.e. catches
+    a regression that would leak the agent across product boundaries).
+    """
+
+    def __init__(self, stories_by_product: dict[str, list[Story]]) -> None:
+        self._stories_by_product = stories_by_product
         self.persisted: list[tuple[str, float | None, float | None]] = []
 
     def list_stories_for_product(self, product_id: str) -> list[Story]:
-        return [s for s in self._stories if s.id.startswith(product_id) or True]
+        return list(self._stories_by_product.get(product_id, []))
 
     def bulk_update_story_scores(
         self,
@@ -45,6 +51,11 @@ class _FakeStore:
         rows = list(rows)
         self.persisted.extend(rows)
         return len(rows)
+
+
+def _fake_store(*, stories: list[Story], product_id: str = "prod-x") -> _FakeStore:
+    """Most tests use a single product; this keeps the call sites short."""
+    return _FakeStore({product_id: stories})
 
 
 def _story(sid: str, *, title: str = "do thing", points: float | None = 5.0) -> Story:
@@ -92,10 +103,10 @@ def test_groom_wsjf_ranks_and_persists_scores() -> None:
             ]
         }
     )
-    store = _FakeStore(stories)
+    store = _fake_store(stories=stories)
     agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
 
-    result = agent.groom(product_id="anything", method="wsjf", persist=True)
+    result = agent.groom(product_id="prod-x", method="wsjf", persist=True)
 
     # Sorted descending by score: s2 (4.0) then s1 (2.0)
     assert [r.id for r in result.ranked] == ["s2", "s1"]
@@ -121,9 +132,9 @@ def test_groom_rice_uses_estimate_points_when_effort_missing() -> None:
             ]
         }
     )
-    store = _FakeStore(stories)
+    store = _fake_store(stories=stories)
     agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
-    result = agent.groom(product_id="x", method="rice", persist=False)
+    result = agent.groom(product_id="prod-x", method="rice", persist=False)
     # effort defaults to estimate_points / 4 = 2.0 → score 500
     assert result.ranked[0].score == 500.0
     assert store.persisted == []
@@ -148,17 +159,17 @@ def test_groom_skips_unknown_story_ids() -> None:
             ]
         }
     )
-    store = _FakeStore(stories)
+    store = _fake_store(stories=stories)
     agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
-    result = agent.groom(product_id="x", method="wsjf", persist=False)
+    result = agent.groom(product_id="prod-x", method="wsjf", persist=False)
     assert [r.id for r in result.ranked] == ["real"]
 
 
 def test_groom_returns_empty_when_backlog_empty() -> None:
-    store = _FakeStore([])
+    store = _fake_store(stories=[])
     llm = _StubLLM(payload={"items": []})
     agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
-    result = agent.groom(product_id="x", method="wsjf")
+    result = agent.groom(product_id="prod-x", method="wsjf")
     assert result.ranked == []
     # LLM should not have been called when backlog is empty
     assert llm.calls == []
@@ -170,9 +181,9 @@ def test_groom_handles_llm_exception_gracefully() -> None:
             raise RuntimeError("model unreachable")
 
     stories = [_story("s1")]
-    store = _FakeStore(stories)
+    store = _fake_store(stories=stories)
     agent = ProductOwnerAgent(store=store, llm_client=_BoomLLM())  # type: ignore[arg-type]
-    result = agent.groom(product_id="x", method="wsjf")
+    result = agent.groom(product_id="prod-x", method="wsjf")
     assert result.ranked == []
 
 
@@ -197,9 +208,9 @@ def test_groom_wsjf_treats_null_job_size_as_estimate_points_fallback() -> None:
             ]
         }
     )
-    store = _FakeStore(stories)
+    store = _fake_store(stories=stories)
     agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
-    result = agent.groom(product_id="x", method="wsjf", persist=False)
+    result = agent.groom(product_id="prod-x", method="wsjf", persist=False)
     # cost_of_delay = 12; job_size falls back to estimate_points (4) → 3.0
     assert len(result.ranked) == 1
     assert result.ranked[0].score == 3.0
@@ -223,9 +234,9 @@ def test_groom_rice_treats_null_effort_as_estimate_points_fallback() -> None:
             ]
         }
     )
-    store = _FakeStore(stories)
+    store = _fake_store(stories=stories)
     agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
-    result = agent.groom(product_id="x", method="rice", persist=False)
+    result = agent.groom(product_id="prod-x", method="rice", persist=False)
     # effort falls back to estimate_points / 4 = 2.0 → score 500
     assert len(result.ranked) == 1
     assert result.ranked[0].score == 500.0
@@ -250,9 +261,47 @@ def test_groom_wsjf_treats_null_value_components_as_zero() -> None:
             ]
         }
     )
-    store = _FakeStore(stories)
+    store = _fake_store(stories=stories)
     agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
-    result = agent.groom(product_id="x", method="wsjf", persist=False)
+    result = agent.groom(product_id="prod-x", method="wsjf", persist=False)
     # cost_of_delay = 0 → score 0
     assert len(result.ranked) == 1
     assert result.ranked[0].score == 0.0
+
+
+def test_groom_only_sees_stories_under_requested_product() -> None:
+    # Two products with disjoint stories. The agent must only score the
+    # stories under the requested product — a regression to the old
+    # `or True` predicate (or any other cross-product leak in the real
+    # store's JOIN) would surface stories from the wrong product here.
+    a_only = [_story("s-a")]
+    b_only = [_story("s-b")]
+    store = _FakeStore({"prod-a": a_only, "prod-b": b_only})
+
+    inputs = {
+        "user_business_value": 1,
+        "time_criticality": 1,
+        "risk_reduction_or_opportunity_enablement": 1,
+        "job_size": 3,
+    }
+    llm = _StubLLM(
+        payload={
+            "items": [
+                {"id": "s-a", "inputs": inputs, "rationale": ""},
+                {"id": "s-b", "inputs": inputs, "rationale": ""},
+            ]
+        }
+    )
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+
+    result_a = agent.groom(product_id="prod-a", method="wsjf", persist=False)
+    assert [r.id for r in result_a.ranked] == ["s-a"]
+
+    result_b = agent.groom(product_id="prod-b", method="wsjf", persist=False)
+    assert [r.id for r in result_b.ranked] == ["s-b"]
+
+    # An unknown product id has no stories and the LLM is never called.
+    pre_calls = len(llm.calls)
+    result_missing = agent.groom(product_id="prod-missing", method="wsjf")
+    assert result_missing.ranked == []
+    assert len(llm.calls) == pre_calls

--- a/backend/agents/product_delivery/tests/test_product_owner_agent.py
+++ b/backend/agents/product_delivery/tests/test_product_owner_agent.py
@@ -819,3 +819,38 @@ def test_groom_trims_by_byte_budget_when_user_stories_are_large(
     assert '"id": "s1"' in prompt
     assert '"id": "s2"' not in prompt
     assert '"id": "s3"' not in prompt
+
+
+def test_groom_defers_pathological_oversize_only_story(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A single story larger than the budget must be deferred, not break it.
+
+    Codex flagged that the previous trim kept the first story
+    unconditionally — so a backlog of one pathological story would
+    overrun the budget contract and 503 the whole call. With the fix,
+    that story surfaces as deferred and the LLM is never invoked
+    (no point sending an empty list).
+    """
+    monkeypatch.setenv("PRODUCT_DELIVERY_GROOM_MAX_PROMPT_BYTES", "256")  # tiny budget
+    huge = _story("huge")
+    object.__setattr__(huge, "user_story", "x" * 4_000)  # alone > 256 bytes
+
+    llm = _StubLLM(payload={"items": []})  # never expected to be called
+    store = _fake_store(stories=[huge])
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="prod-x", method="wsjf", persist=True)
+
+    # Single story surfaces in the result so planner sees the gap.
+    assert len(result.ranked) == 1
+    assert result.ranked[0].id == "huge"
+    assert result.ranked[0].score == 0.0
+    assert "deferred" in result.ranked[0].rationale.lower()
+
+    # Nothing persisted (synthetic zero must not overwrite an existing
+    # score on the row).
+    assert store.persisted == []
+
+    # And, crucially, the LLM was never called — sending an empty
+    # list would either 503 the call or produce useless 0-score output.
+    assert llm.calls == []

--- a/backend/agents/product_delivery/tests/test_product_owner_agent.py
+++ b/backend/agents/product_delivery/tests/test_product_owner_agent.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from typing import Any
 
+import pytest
+
 from product_delivery.models import Story
 from product_delivery.product_owner_agent import ProductOwnerAgent
 
@@ -567,3 +569,108 @@ def test_groom_deduplicates_repeated_story_ids() -> None:
     assert result.ranked[0].rationale == "first"
     # Persistence wrote exactly one row.
     assert store.persisted == [("s1", 3.0, None)]
+
+
+@pytest.mark.parametrize("bad_value", [True, False])
+def test_groom_rejects_boolean_llm_inputs_as_malformed(bad_value: bool) -> None:
+    """`_to_float` must reject JSON booleans before they silently become 1.0/0.0.
+
+    Without this guard a confused LLM emitting booleans for any of the
+    WSJF/RICE inputs would skew rankings (every story scored as
+    ``cost_of_delay=1`` or ``=0``); we want those stories surfaced as
+    malformed so a human can re-rank them, not persisted.
+    """
+    stories = [_story("s1")]
+    llm = _StubLLM(
+        payload={
+            "items": [
+                {
+                    "id": "s1",
+                    "inputs": {
+                        "user_business_value": bad_value,
+                        "time_criticality": 4,
+                        "risk_reduction_or_opportunity_enablement": 0,
+                        "job_size": 4,
+                    },
+                }
+            ]
+        }
+    )
+    store = _fake_store(stories=stories)
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="prod-x", method="wsjf", persist=True)
+
+    assert len(result.ranked) == 1
+    assert result.ranked[0].score == 0.0
+    assert "malformed" in result.ranked[0].rationale.lower()
+    # Synthetic 0.0 must not be persisted — the existing score on the
+    # row stays intact.
+    assert store.persisted == []
+
+
+def test_groom_caps_prompt_size_and_defers_overflow_stories(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Backlogs over the cap must defer the tail rather than 503 the whole run.
+
+    The first ``cap`` stories are scored; the rest surface as score=0
+    with a "deferred" rationale and are never sent to the LLM. The LLM
+    must see exactly the capped slice (so prompt size is bounded).
+    """
+    monkeypatch.setenv("PRODUCT_DELIVERY_GROOM_MAX_STORIES", "2")
+    stories = [_story(f"s{i}") for i in range(5)]
+    llm = _StubLLM(
+        payload={
+            "items": [
+                {
+                    "id": "s0",
+                    "inputs": {
+                        "user_business_value": 8,
+                        "time_criticality": 4,
+                        "risk_reduction_or_opportunity_enablement": 0,
+                        "job_size": 4,
+                    },
+                },
+                {
+                    "id": "s1",
+                    "inputs": {
+                        "user_business_value": 4,
+                        "time_criticality": 2,
+                        "risk_reduction_or_opportunity_enablement": 0,
+                        "job_size": 4,
+                    },
+                },
+            ]
+        }
+    )
+    store = _fake_store(stories=stories)
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="prod-x", method="wsjf", persist=True)
+
+    # All five stories surface in the result so deferred work isn't
+    # invisible to the planner.
+    assert len(result.ranked) == 5
+    by_id = {item.id: item for item in result.ranked}
+
+    # The two scored stories carry real scores + were persisted.
+    assert by_id["s0"].score == 3.0
+    assert by_id["s1"].score == 1.5
+    assert {r[0] for r in store.persisted} == {"s0", "s1"}
+
+    # The deferred tail surfaces with score=0 + a "deferred" rationale
+    # and was never persisted.
+    for sid in ("s2", "s3", "s4"):
+        item = by_id[sid]
+        assert item.score == 0.0
+        assert "deferred" in item.rationale.lower()
+
+    # And, crucially, the LLM only saw the capped slice.
+    assert len(llm.calls) == 1
+    prompt = llm.calls[0]["prompt"]
+    assert '"id": "s0"' in prompt
+    assert '"id": "s1"' in prompt
+    for omitted in ("s2", "s3", "s4"):
+        assert f'"id": "{omitted}"' not in prompt
+
+    # And the rationale calls out the deferral so an operator notices.
+    assert "deferred" in result.rationale.lower()

--- a/backend/agents/product_delivery/tests/test_product_owner_agent.py
+++ b/backend/agents/product_delivery/tests/test_product_owner_agent.py
@@ -274,6 +274,42 @@ def test_groom_wsjf_treats_null_value_components_as_zero() -> None:
     assert result.ranked[0].score == 0.0
 
 
+def test_groom_treats_non_finite_inputs_as_fallback() -> None:
+    # Models occasionally emit `"NaN"` or `"Infinity"` for fields they
+    # refuse to commit to. `float("NaN")` succeeds but propagates into
+    # `RankedBacklogItem.score`, breaking JSON serialization downstream.
+    # `_to_float` must fall back the same way it does for None.
+    stories = [_story("s1", points=4.0)]
+    llm = _StubLLM(
+        payload={
+            "items": [
+                {
+                    "id": "s1",
+                    "inputs": {
+                        "user_business_value": 6,
+                        "time_criticality": 4,
+                        "risk_reduction_or_opportunity_enablement": 2,
+                        # Non-finite denominator — must fall back to
+                        # estimate_points (4) rather than become inf.
+                        "job_size": float("inf"),
+                    },
+                    "rationale": "",
+                }
+            ]
+        }
+    )
+    store = _fake_store(stories=stories)
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="prod-x", method="wsjf", persist=False)
+    assert len(result.ranked) == 1
+    # cost_of_delay = 12; job_size falls back to estimate_points (4) → 3.0.
+    assert result.ranked[0].score == 3.0
+    # And the score is finite for the JSON encoder downstream.
+    import math
+
+    assert math.isfinite(result.ranked[0].score)
+
+
 def test_groom_only_sees_stories_under_requested_product() -> None:
     # Two products with disjoint stories. The agent must only score the
     # stories under the requested product — a regression to the old

--- a/backend/agents/product_delivery/tests/test_product_owner_agent.py
+++ b/backend/agents/product_delivery/tests/test_product_owner_agent.py
@@ -315,6 +315,34 @@ def test_groom_treats_non_finite_inputs_as_fallback() -> None:
     assert math.isfinite(result.ranked[0].score)
 
 
+def test_groom_surfaces_non_dict_inputs_with_score_zero_no_persist() -> None:
+    # When the LLM returns `inputs: null` (or a list/string), the
+    # agent must NOT silently substitute `{}` and persist a synthetic
+    # zero — that would overwrite the row's existing real score.
+    # Route through the malformed fallback (visible-only, no persist).
+    stories = [_story("s1")]
+    llm = _StubLLM(
+        payload={
+            "items": [
+                {
+                    "id": "s1",
+                    "inputs": None,  # non-dict — must trigger fallback
+                    "rationale": "model gave up",
+                }
+            ]
+        }
+    )
+    store = _fake_store(stories=stories)
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="prod-x", method="wsjf", persist=True)
+    assert len(result.ranked) == 1
+    assert result.ranked[0].id == "s1"
+    assert result.ranked[0].score == 0.0
+    assert "malformed" in result.ranked[0].rationale.lower()
+    # Critical: synthetic row must NOT be persisted.
+    assert store.persisted == []
+
+
 def test_groom_surfaces_malformed_inputs_with_score_zero() -> None:
     # When an LLM returns un-coerceable values (e.g. a list where a
     # number is expected), the agent must still surface the story in

--- a/backend/agents/product_delivery/tests/test_product_owner_agent.py
+++ b/backend/agents/product_delivery/tests/test_product_owner_agent.py
@@ -310,6 +310,39 @@ def test_groom_treats_non_finite_inputs_as_fallback() -> None:
     assert math.isfinite(result.ranked[0].score)
 
 
+def test_groom_surfaces_malformed_inputs_with_score_zero() -> None:
+    # When an LLM returns un-coerceable values (e.g. a list where a
+    # number is expected), the agent must still surface the story in
+    # ``GroomResult.ranked`` with score=0 + a malformed-inputs rationale.
+    # Dropping it silently is the failure mode flagged by review.
+    stories = [_story("s1")]
+    llm = _StubLLM(
+        payload={
+            "items": [
+                {
+                    "id": "s1",
+                    "inputs": {
+                        "user_business_value": ["not", "a", "number"],
+                        "time_criticality": 1,
+                        "risk_reduction_or_opportunity_enablement": 1,
+                        "job_size": 3,
+                    },
+                    "rationale": "broken",
+                }
+            ]
+        }
+    )
+    store = _fake_store(stories=stories)
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="prod-x", method="wsjf", persist=True)
+    assert len(result.ranked) == 1
+    assert result.ranked[0].id == "s1"
+    assert result.ranked[0].score == 0.0
+    assert "malformed" in result.ranked[0].rationale.lower()
+    # Synthetic row → no persistence (existing scores stay intact).
+    assert store.persisted == []
+
+
 def test_groom_only_sees_stories_under_requested_product() -> None:
     # Two products with disjoint stories. The agent must only score the
     # stories under the requested product — a regression to the old

--- a/backend/agents/product_delivery/tests/test_product_owner_agent.py
+++ b/backend/agents/product_delivery/tests/test_product_owner_agent.py
@@ -854,3 +854,109 @@ def test_groom_defers_pathological_oversize_only_story(
     # And, crucially, the LLM was never called — sending an empty
     # list would either 503 the call or produce useless 0-score output.
     assert llm.calls == []
+
+
+def test_groom_keeps_trimming_past_oversize_story(monkeypatch: pytest.MonkeyPatch) -> None:
+    """An oversize story in the middle must not block scoring of later small ones.
+
+    Codex flagged that the previous "break on first overflow"
+    behaviour deferred *every* story after the first oversize one,
+    so a single pathological item could permanently starve the rest
+    of the backlog. With the new continue-past-overflow trimmer, the
+    oversize story is deferred individually and later small stories
+    are still scored.
+    """
+    monkeypatch.setenv("PRODUCT_DELIVERY_GROOM_MAX_PROMPT_BYTES", "1024")
+    small_a = _story("small_a")
+    huge = _story("huge")
+    object.__setattr__(huge, "user_story", "x" * 4_000)
+    small_b = _story("small_b")
+
+    llm = _StubLLM(
+        payload={
+            "items": [
+                {
+                    "id": "small_a",
+                    "inputs": {
+                        "user_business_value": 8,
+                        "time_criticality": 4,
+                        "risk_reduction_or_opportunity_enablement": 0,
+                        "job_size": 4,
+                    },
+                },
+                {
+                    "id": "small_b",
+                    "inputs": {
+                        "user_business_value": 6,
+                        "time_criticality": 2,
+                        "risk_reduction_or_opportunity_enablement": 0,
+                        "job_size": 4,
+                    },
+                },
+            ]
+        }
+    )
+    store = _fake_store(stories=[small_a, huge, small_b])
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="prod-x", method="wsjf", persist=True)
+
+    assert len(result.ranked) == 3
+    by_id = {item.id: item for item in result.ranked}
+    # Both small stories scored, the huge one deferred.
+    assert by_id["small_a"].score == 3.0
+    assert by_id["small_b"].score == 2.0
+    assert by_id["huge"].score == 0.0
+    assert "deferred" in by_id["huge"].rationale.lower()
+    # Rationale must call out the byte-budget cause specifically so an
+    # operator knows which env var to tune.
+    assert "prompt-byte budget" in by_id["huge"].rationale.lower()
+    # Both small stories were scored AND persisted.
+    assert {r[0] for r in store.persisted} == {"small_a", "small_b"}
+    # LLM only saw the two small stories.
+    assert len(llm.calls) == 1
+    prompt = llm.calls[0]["prompt"]
+    assert '"id": "small_a"' in prompt
+    assert '"id": "small_b"' in prompt
+    assert '"id": "huge"' not in prompt
+
+
+def test_groom_rationale_distinguishes_count_cap_vs_byte_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Operators reading the rationale must be able to tell which control fired.
+
+    Codex flagged that the previous "backlog exceeded grooming cap"
+    text always blamed the count cap, even when the byte budget
+    triggered the deferral. Verify both paths are name-checked
+    individually.
+    """
+    monkeypatch.setenv("PRODUCT_DELIVERY_GROOM_MAX_STORIES", "1")
+    monkeypatch.setenv("PRODUCT_DELIVERY_GROOM_MAX_PROMPT_BYTES", "65536")
+    s1 = _story("s1")
+    s2 = _story("s2")
+    llm = _StubLLM(
+        payload={
+            "items": [
+                {
+                    "id": "s1",
+                    "inputs": {
+                        "user_business_value": 8,
+                        "time_criticality": 4,
+                        "risk_reduction_or_opportunity_enablement": 0,
+                        "job_size": 4,
+                    },
+                }
+            ]
+        }
+    )
+    store = _fake_store(stories=[s1, s2])
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="prod-x", method="wsjf", persist=True)
+
+    by_id = {item.id: item for item in result.ranked}
+    # s2 was deferred for *count-cap* reasons (cap=1, 2 stories).
+    assert "story-count cap" in by_id["s2"].rationale.lower()
+    # And the overall result rationale must call out the count-cap
+    # bucket so operators tune `PRODUCT_DELIVERY_GROOM_MAX_STORIES`,
+    # not the byte budget.
+    assert "story-count" in result.rationale.lower()

--- a/backend/agents/product_delivery/tests/test_product_owner_agent.py
+++ b/backend/agents/product_delivery/tests/test_product_owner_agent.py
@@ -184,7 +184,12 @@ def test_groom_handles_llm_exception_gracefully() -> None:
     store = _fake_store(stories=stories)
     agent = ProductOwnerAgent(store=store, llm_client=_BoomLLM())  # type: ignore[arg-type]
     result = agent.groom(product_id="prod-x", method="wsjf")
-    assert result.ranked == []
+    # LLM exception → empty payload → missing-stories pass surfaces
+    # every backlog story with score=0 + a manual-review rationale so
+    # downstream planning doesn't silently lose work.
+    assert [r.id for r in result.ranked] == ["s1"]
+    assert result.ranked[0].score == 0.0
+    assert "manual review" in result.ranked[0].rationale
 
 
 def test_groom_wsjf_treats_null_job_size_as_estimate_points_fallback() -> None:
@@ -305,3 +310,82 @@ def test_groom_only_sees_stories_under_requested_product() -> None:
     result_missing = agent.groom(product_id="prod-missing", method="wsjf")
     assert result_missing.ranked == []
     assert len(llm.calls) == pre_calls
+
+
+def test_groom_includes_stories_omitted_by_llm_with_score_zero() -> None:
+    # Models truncate or skip uncertain items. The agent must still
+    # surface every backlog story so downstream planning doesn't silently
+    # lose work; the omitted ones are flagged for manual review and not
+    # persisted (their existing scores stay intact).
+    stories = [_story("scored", title="alpha"), _story("missed", title="beta")]
+    llm = _StubLLM(
+        payload={
+            "items": [
+                {
+                    "id": "scored",
+                    "inputs": {
+                        "user_business_value": 5,
+                        "time_criticality": 3,
+                        "risk_reduction_or_opportunity_enablement": 1,
+                        "job_size": 3,
+                    },
+                    "rationale": "covered",
+                }
+            ]
+        }
+    )
+    store = _fake_store(stories=stories)
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="prod-x", method="wsjf", persist=True)
+
+    by_id = {r.id: r for r in result.ranked}
+    assert set(by_id) == {"scored", "missed"}
+    assert by_id["scored"].score == 3.0
+    assert by_id["missed"].score == 0.0
+    assert "manual review" in by_id["missed"].rationale
+    # Persistence covers only the LLM-scored stories — never overwrites
+    # the missed story's existing score with a synthetic zero.
+    assert {r[0] for r in store.persisted} == {"scored"}
+
+
+def test_groom_deduplicates_repeated_story_ids() -> None:
+    # Repeated id in the LLM payload — agent must keep the first scoring
+    # and ignore the rest so persisted scores stay deterministic.
+    stories = [_story("s1")]
+    llm = _StubLLM(
+        payload={
+            "items": [
+                {
+                    "id": "s1",
+                    "inputs": {
+                        "user_business_value": 8,
+                        "time_criticality": 4,
+                        "risk_reduction_or_opportunity_enablement": 0,
+                        "job_size": 4,
+                    },
+                    "rationale": "first",
+                },
+                {
+                    "id": "s1",
+                    "inputs": {
+                        "user_business_value": 1,
+                        "time_criticality": 1,
+                        "risk_reduction_or_opportunity_enablement": 0,
+                        "job_size": 4,
+                    },
+                    "rationale": "second",
+                },
+            ]
+        }
+    )
+    store = _fake_store(stories=stories)
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="prod-x", method="wsjf", persist=True)
+
+    assert len(result.ranked) == 1
+    assert result.ranked[0].id == "s1"
+    # First payload wins → cost_of_delay=12 / job_size=4 = 3.0
+    assert result.ranked[0].score == 3.0
+    assert result.ranked[0].rationale == "first"
+    # Persistence wrote exactly one row.
+    assert store.persisted == [("s1", 3.0, None)]

--- a/backend/agents/product_delivery/tests/test_product_owner_agent.py
+++ b/backend/agents/product_delivery/tests/test_product_owner_agent.py
@@ -376,6 +376,36 @@ def test_groom_surfaces_malformed_inputs_with_score_zero() -> None:
     assert store.persisted == []
 
 
+def test_groom_rationale_uses_actual_persisted_count() -> None:
+    # If `bulk_update_story_scores` reports fewer rows updated than we
+    # tried to score (e.g. concurrent delete), the rationale must
+    # reflect that — it's the signal downstream automation parses to
+    # measure grooming success.
+    stories = [_story("s1"), _story("s2")]
+    inputs = {
+        "user_business_value": 1,
+        "time_criticality": 1,
+        "risk_reduction_or_opportunity_enablement": 1,
+        "job_size": 3,
+    }
+    llm = _StubLLM(
+        payload={
+            "items": [
+                {"id": "s1", "inputs": inputs, "rationale": "ok"},
+                {"id": "s2", "inputs": inputs, "rationale": "ok"},
+            ]
+        }
+    )
+    store = _fake_store(stories=stories)
+    # Stub bulk_update_story_scores to claim only one row landed (the
+    # other was deleted between ranking and persistence).
+    store.bulk_update_story_scores = lambda rows: 1  # type: ignore[assignment]
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="prod-x", method="wsjf", persist=True)
+    assert "Scored 1/2" in result.rationale
+    assert "manual review" in result.rationale.lower()
+
+
 def test_groom_only_sees_stories_under_requested_product() -> None:
     # Two products with disjoint stories. The agent must only score the
     # stories under the requested product — a regression to the old

--- a/backend/agents/product_delivery/tests/test_product_owner_agent.py
+++ b/backend/agents/product_delivery/tests/test_product_owner_agent.py
@@ -175,7 +175,17 @@ def test_groom_returns_empty_when_backlog_empty() -> None:
     assert llm.calls == []
 
 
-def test_groom_handles_llm_exception_gracefully() -> None:
+def test_groom_raises_llm_unavailable_on_end_to_end_llm_failure() -> None:
+    # End-to-end LLM failure (transport / model / parse) must surface as
+    # `LLMScoringUnavailable` so the route can return 503 and callers
+    # retry. Returning 200 with every story zero-scored would silently
+    # de-prioritise the backlog during a transient outage. (Per-story
+    # missing/malformed payloads are handled gracefully via the
+    # fallback path — see `test_groom_includes_stories_omitted_by_llm`.)
+    import pytest as _pytest
+
+    from product_delivery.product_owner_agent.agent import LLMScoringUnavailable
+
     class _BoomLLM:
         def complete_json(self, *a: Any, **kw: Any) -> dict[str, Any]:
             raise RuntimeError("model unreachable")
@@ -183,13 +193,8 @@ def test_groom_handles_llm_exception_gracefully() -> None:
     stories = [_story("s1")]
     store = _fake_store(stories=stories)
     agent = ProductOwnerAgent(store=store, llm_client=_BoomLLM())  # type: ignore[arg-type]
-    result = agent.groom(product_id="prod-x", method="wsjf")
-    # LLM exception → empty payload → missing-stories pass surfaces
-    # every backlog story with score=0 + a manual-review rationale so
-    # downstream planning doesn't silently lose work.
-    assert [r.id for r in result.ranked] == ["s1"]
-    assert result.ranked[0].score == 0.0
-    assert "manual review" in result.ranked[0].rationale
+    with _pytest.raises(LLMScoringUnavailable):
+        agent.groom(product_id="prod-x", method="wsjf")
 
 
 def test_groom_wsjf_treats_null_job_size_as_estimate_points_fallback() -> None:

--- a/backend/agents/product_delivery/tests/test_product_owner_agent.py
+++ b/backend/agents/product_delivery/tests/test_product_owner_agent.py
@@ -1,0 +1,176 @@
+"""Unit tests for :class:`ProductOwnerAgent` with a stub LLM client."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+from product_delivery.models import Story
+from product_delivery.product_owner_agent import ProductOwnerAgent
+
+
+class _StubLLM:
+    """Returns a canned ``complete_json`` response."""
+
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+        self.calls: list[dict[str, Any]] = []
+
+    def complete_json(
+        self,
+        prompt: str,
+        *,
+        temperature: float = 0.0,
+        system_prompt: str | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        self.calls.append({"prompt": prompt, "system_prompt": system_prompt})
+        return self.payload
+
+
+class _FakeStore:
+    """In-memory subset of ``ProductDeliveryStore`` used by the agent."""
+
+    def __init__(self, stories: list[Story]) -> None:
+        self._stories = stories
+        self.persisted: list[tuple[str, float | None, float | None]] = []
+
+    def list_stories_for_product(self, product_id: str) -> list[Story]:
+        return [s for s in self._stories if s.id.startswith(product_id) or True]
+
+    def bulk_update_story_scores(
+        self,
+        rows: list[tuple[str, float | None, float | None]],
+    ) -> int:
+        rows = list(rows)
+        self.persisted.extend(rows)
+        return len(rows)
+
+
+def _story(sid: str, *, title: str = "do thing", points: float | None = 5.0) -> Story:
+    now = datetime.now(tz=timezone.utc)
+    return Story(
+        id=sid,
+        epic_id="epic1",
+        title=title,
+        user_story="",
+        status="proposed",
+        wsjf_score=None,
+        rice_score=None,
+        estimate_points=points,
+        author="tester",
+        created_at=now,
+        updated_at=now,
+    )
+
+
+def test_groom_wsjf_ranks_and_persists_scores() -> None:
+    stories = [_story("s1", title="alpha"), _story("s2", title="beta")]
+    llm = _StubLLM(
+        payload={
+            "items": [
+                {
+                    "id": "s1",
+                    "inputs": {
+                        "user_business_value": 5,
+                        "time_criticality": 3,
+                        "risk_reduction_or_opportunity_enablement": 2,
+                        "job_size": 5,
+                    },
+                    "rationale": "important",
+                },
+                {
+                    "id": "s2",
+                    "inputs": {
+                        "user_business_value": 9,
+                        "time_criticality": 6,
+                        "risk_reduction_or_opportunity_enablement": 5,
+                        "job_size": 5,
+                    },
+                    "rationale": "critical",
+                },
+            ]
+        }
+    )
+    store = _FakeStore(stories)
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+
+    result = agent.groom(product_id="anything", method="wsjf", persist=True)
+
+    # Sorted descending by score: s2 (4.0) then s1 (2.0)
+    assert [r.id for r in result.ranked] == ["s2", "s1"]
+    assert result.ranked[0].score == 4.0
+    assert result.ranked[1].score == 2.0
+    # persistence ran
+    assert {r[0] for r in store.persisted} == {"s1", "s2"}
+    # LLM was called exactly once with the system prompt set
+    assert len(llm.calls) == 1
+    assert llm.calls[0]["system_prompt"]
+
+
+def test_groom_rice_uses_estimate_points_when_effort_missing() -> None:
+    stories = [_story("s1", points=8.0)]
+    llm = _StubLLM(
+        payload={
+            "items": [
+                {
+                    "id": "s1",
+                    "inputs": {"reach": 1000, "impact": 1, "confidence": 1},
+                    "rationale": "",
+                }
+            ]
+        }
+    )
+    store = _FakeStore(stories)
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="x", method="rice", persist=False)
+    # effort defaults to estimate_points / 4 = 2.0 → score 500
+    assert result.ranked[0].score == 500.0
+    assert store.persisted == []
+
+
+def test_groom_skips_unknown_story_ids() -> None:
+    stories = [_story("real")]
+    llm = _StubLLM(
+        payload={
+            "items": [
+                {"id": "ghost", "inputs": {}, "rationale": ""},
+                {
+                    "id": "real",
+                    "inputs": {
+                        "user_business_value": 1,
+                        "time_criticality": 1,
+                        "risk_reduction_or_opportunity_enablement": 1,
+                        "job_size": 3,
+                    },
+                    "rationale": "",
+                },
+            ]
+        }
+    )
+    store = _FakeStore(stories)
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="x", method="wsjf", persist=False)
+    assert [r.id for r in result.ranked] == ["real"]
+
+
+def test_groom_returns_empty_when_backlog_empty() -> None:
+    store = _FakeStore([])
+    llm = _StubLLM(payload={"items": []})
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="x", method="wsjf")
+    assert result.ranked == []
+    # LLM should not have been called when backlog is empty
+    assert llm.calls == []
+
+
+def test_groom_handles_llm_exception_gracefully() -> None:
+    class _BoomLLM:
+        def complete_json(self, *a: Any, **kw: Any) -> dict[str, Any]:
+            raise RuntimeError("model unreachable")
+
+    stories = [_story("s1")]
+    store = _FakeStore(stories)
+    agent = ProductOwnerAgent(store=store, llm_client=_BoomLLM())  # type: ignore[arg-type]
+    result = agent.groom(product_id="x", method="wsjf")
+    assert result.ranked == []

--- a/backend/agents/product_delivery/tests/test_product_owner_agent.py
+++ b/backend/agents/product_delivery/tests/test_product_owner_agent.py
@@ -406,6 +406,52 @@ def test_groom_rationale_uses_actual_persisted_count() -> None:
     assert "manual review" in result.rationale.lower()
 
 
+def test_groom_treats_empty_inputs_dict_as_malformed_no_persist() -> None:
+    # Codex flagged: an empty `{}` for `inputs` was scored to 0 and
+    # persisted, overwriting any existing real score on the row. Now
+    # the agent treats empty-dict same as None — fallback row visible
+    # but never persisted.
+    stories = [_story("s1")]
+    llm = _StubLLM(payload={"items": [{"id": "s1", "inputs": {}, "rationale": "x"}]})
+    store = _fake_store(stories=stories)
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="prod-x", method="wsjf", persist=True)
+    assert len(result.ranked) == 1
+    assert result.ranked[0].score == 0.0
+    assert "malformed" in result.ranked[0].rationale.lower()
+    assert store.persisted == []
+
+
+def test_groom_handles_overflow_error_in_inputs() -> None:
+    # `_to_float` can raise `OverflowError` for huge JSON integers
+    # (e.g. an LLM emitting `reach: 10**400`). The agent must still
+    # surface the story via the malformed fallback rather than 500.
+    stories = [_story("s1")]
+    llm = _StubLLM(
+        payload={
+            "items": [
+                {
+                    "id": "s1",
+                    "inputs": {
+                        "reach": 10**400,  # int well outside float64
+                        "impact": 1,
+                        "confidence": 1,
+                        "effort": 1,
+                    },
+                    "rationale": "huge",
+                }
+            ]
+        }
+    )
+    store = _fake_store(stories=stories)
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="prod-x", method="rice", persist=True)
+    assert len(result.ranked) == 1
+    assert result.ranked[0].score == 0.0
+    assert "malformed" in result.ranked[0].rationale.lower()
+    assert store.persisted == []
+
+
 def test_groom_only_sees_stories_under_requested_product() -> None:
     # Two products with disjoint stories. The agent must only score the
     # stories under the requested product — a regression to the old

--- a/backend/agents/product_delivery/tests/test_product_owner_agent.py
+++ b/backend/agents/product_delivery/tests/test_product_owner_agent.py
@@ -674,3 +674,148 @@ def test_groom_caps_prompt_size_and_defers_overflow_stories(
 
     # And the rationale calls out the deferral so an operator notices.
     assert "deferred" in result.rationale.lower()
+
+
+@pytest.mark.parametrize(
+    "bad_envelope",
+    [
+        # Codex flagged: a 200 with all stories zero-scored masks
+        # provider/schema regressions as normal output. These shapes
+        # must trip `LLMScoringUnavailable` so the route returns 503
+        # and callers retry.
+        {"items": "not a list"},
+        {"items": None},
+        {"results": [{"id": "s1", "inputs": {}}]},  # wrong key
+        "definitely not a dict",
+        ["lists are not envelopes"],
+        42,
+    ],
+)
+def test_groom_raises_503_on_malformed_llm_envelope(bad_envelope: Any) -> None:
+    from product_delivery.product_owner_agent.agent import LLMScoringUnavailable
+
+    stories = [_story("s1")]
+    llm = _StubLLM(payload=bad_envelope)  # type: ignore[arg-type]
+    store = _fake_store(stories=stories)
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    with pytest.raises(LLMScoringUnavailable):
+        agent.groom(product_id="prod-x", method="wsjf", persist=True)
+    # No persistence on failure — the existing scores stay intact.
+    assert store.persisted == []
+
+
+def test_groom_grooming_window_rotates_by_updated_at(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Cap selection must prefer least-recently-updated stories.
+
+    If grooming always took ``stories[:cap]`` (creation order) every
+    run, newer stories would be permanently starved in sustained large
+    backlogs. The rotation by ``updated_at`` means scored stories'
+    ``updated_at`` jumps to "now" on persist and they cycle to the
+    end of the next run's window.
+    """
+    from datetime import timedelta
+
+    monkeypatch.setenv("PRODUCT_DELIVERY_GROOM_MAX_STORIES", "1")
+    base = datetime.now(tz=timezone.utc)
+
+    # Two stories — `recent` was just touched, `stale` hasn't been
+    # updated in a week. The rotation must pick `stale` for grooming
+    # this run, not `recent` (which would be the first by id).
+    recent = _story("recent")
+    stale = _story("stale")
+    object.__setattr__(recent, "updated_at", base)
+    object.__setattr__(stale, "updated_at", base - timedelta(days=7))
+
+    llm = _StubLLM(
+        payload={
+            "items": [
+                {
+                    "id": "stale",
+                    "inputs": {
+                        "user_business_value": 8,
+                        "time_criticality": 4,
+                        "risk_reduction_or_opportunity_enablement": 0,
+                        "job_size": 4,
+                    },
+                }
+            ]
+        }
+    )
+    store = _fake_store(stories=[recent, stale])  # creation-order: recent first
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="prod-x", method="wsjf", persist=True)
+
+    assert len(result.ranked) == 2
+    # Stale was scored, recent was deferred — opposite of creation order.
+    by_id = {item.id: item for item in result.ranked}
+    assert by_id["stale"].score == 3.0
+    assert by_id["recent"].score == 0.0
+    assert "deferred" in by_id["recent"].rationale.lower()
+
+    # And the LLM only saw the stale story.
+    assert len(llm.calls) == 1
+    prompt = llm.calls[0]["prompt"]
+    assert '"id": "stale"' in prompt
+    assert '"id": "recent"' not in prompt
+
+    # Persistence covers only the scored story.
+    assert {r[0] for r in store.persisted} == {"stale"}
+
+
+def test_groom_trims_by_byte_budget_when_user_stories_are_large(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Story-count cap alone doesn't protect against verbose ``user_story`` fields.
+
+    A small backlog with multi-KB ``user_story`` text can still overrun
+    model context. Set a small byte budget and verify that stories
+    beyond what fits get deferred (even when count < cap), and the
+    LLM only sees the trimmed slice.
+    """
+    monkeypatch.setenv("PRODUCT_DELIVERY_GROOM_MAX_STORIES", "100")  # well above story count
+    monkeypatch.setenv("PRODUCT_DELIVERY_GROOM_MAX_PROMPT_BYTES", "1024")  # tight budget
+
+    # Three stories with ~600-char `user_story` each, so two fit and
+    # one overflows the 1 KiB budget.
+    big_text = "x" * 600
+    stories = []
+    for sid in ("s1", "s2", "s3"):
+        story = _story(sid)
+        object.__setattr__(story, "user_story", big_text)
+        stories.append(story)
+
+    llm = _StubLLM(
+        payload={
+            "items": [
+                {
+                    "id": "s1",
+                    "inputs": {
+                        "user_business_value": 8,
+                        "time_criticality": 4,
+                        "risk_reduction_or_opportunity_enablement": 0,
+                        "job_size": 4,
+                    },
+                },
+            ]
+        }
+    )
+    store = _fake_store(stories=stories)
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="prod-x", method="wsjf", persist=True)
+
+    # All three surface in result so no work disappears.
+    assert len(result.ranked) == 3
+    by_id = {item.id: item for item in result.ranked}
+
+    # First story scored, the other two deferred for byte-budget reasons
+    # (the second wouldn't fit either since 2 * 600 > 1024 budget).
+    assert by_id["s1"].score == 3.0
+    for sid in ("s2", "s3"):
+        assert by_id[sid].score == 0.0
+        assert "deferred" in by_id[sid].rationale.lower()
+
+    # LLM only saw the slice that fit in the byte budget.
+    prompt = llm.calls[0]["prompt"]
+    assert '"id": "s1"' in prompt
+    assert '"id": "s2"' not in prompt
+    assert '"id": "s3"' not in prompt

--- a/backend/agents/product_delivery/tests/test_product_owner_agent.py
+++ b/backend/agents/product_delivery/tests/test_product_owner_agent.py
@@ -174,3 +174,85 @@ def test_groom_handles_llm_exception_gracefully() -> None:
     agent = ProductOwnerAgent(store=store, llm_client=_BoomLLM())  # type: ignore[arg-type]
     result = agent.groom(product_id="x", method="wsjf")
     assert result.ranked == []
+
+
+def test_groom_wsjf_treats_null_job_size_as_estimate_points_fallback() -> None:
+    # The model occasionally emits explicit `null` for job_size when it
+    # can't size a story. Without normalization, float(None) trips the
+    # exception handler and silently drops the story from the ranking.
+    stories = [_story("s1", points=4.0)]
+    llm = _StubLLM(
+        payload={
+            "items": [
+                {
+                    "id": "s1",
+                    "inputs": {
+                        "user_business_value": 6,
+                        "time_criticality": 4,
+                        "risk_reduction_or_opportunity_enablement": 2,
+                        "job_size": None,
+                    },
+                    "rationale": "",
+                }
+            ]
+        }
+    )
+    store = _FakeStore(stories)
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="x", method="wsjf", persist=False)
+    # cost_of_delay = 12; job_size falls back to estimate_points (4) → 3.0
+    assert len(result.ranked) == 1
+    assert result.ranked[0].score == 3.0
+
+
+def test_groom_rice_treats_null_effort_as_estimate_points_fallback() -> None:
+    stories = [_story("s1", points=8.0)]
+    llm = _StubLLM(
+        payload={
+            "items": [
+                {
+                    "id": "s1",
+                    "inputs": {
+                        "reach": 1000,
+                        "impact": 1,
+                        "confidence": 1,
+                        "effort": None,
+                    },
+                    "rationale": "",
+                }
+            ]
+        }
+    )
+    store = _FakeStore(stories)
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="x", method="rice", persist=False)
+    # effort falls back to estimate_points / 4 = 2.0 → score 500
+    assert len(result.ranked) == 1
+    assert result.ranked[0].score == 500.0
+
+
+def test_groom_wsjf_treats_null_value_components_as_zero() -> None:
+    # All non-denominator inputs default to 0 when the model emits null.
+    stories = [_story("s1", points=2.0)]
+    llm = _StubLLM(
+        payload={
+            "items": [
+                {
+                    "id": "s1",
+                    "inputs": {
+                        "user_business_value": None,
+                        "time_criticality": None,
+                        "risk_reduction_or_opportunity_enablement": None,
+                        "job_size": 4,
+                    },
+                    "rationale": "",
+                }
+            ]
+        }
+    )
+    store = _FakeStore(stories)
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="x", method="wsjf", persist=False)
+    # cost_of_delay = 0 → score 0
+    assert len(result.ranked) == 1
+    assert result.ranked[0].score == 0.0

--- a/backend/agents/product_delivery/tests/test_product_owner_agent.py
+++ b/backend/agents/product_delivery/tests/test_product_owner_agent.py
@@ -768,15 +768,19 @@ def test_groom_trims_by_byte_budget_when_user_stories_are_large(
     """Story-count cap alone doesn't protect against verbose ``user_story`` fields.
 
     A small backlog with multi-KB ``user_story`` text can still overrun
-    model context. Set a small byte budget and verify that stories
+    model context. Set a tight byte budget and verify that stories
     beyond what fits get deferred (even when count < cap), and the
     LLM only sees the trimmed slice.
+
+    Budget includes the SYSTEM_PROMPT + build_user_prompt wrapper
+    (~1020 bytes) per Codex's "include wrapper bytes" fix; the test
+    sizes its budget above that floor.
     """
     monkeypatch.setenv("PRODUCT_DELIVERY_GROOM_MAX_STORIES", "100")  # well above story count
-    monkeypatch.setenv("PRODUCT_DELIVERY_GROOM_MAX_PROMPT_BYTES", "1024")  # tight budget
+    # Wrapper is ~1020 bytes; 2048 leaves ~1028 bytes for stories.
+    # One ~600-char user_story (+ ~80 bytes JSON overhead) fits, two don't.
+    monkeypatch.setenv("PRODUCT_DELIVERY_GROOM_MAX_PROMPT_BYTES", "2048")
 
-    # Three stories with ~600-char `user_story` each, so two fit and
-    # one overflows the 1 KiB budget.
     big_text = "x" * 600
     stories = []
     for sid in ("s1", "s2", "s3"):
@@ -866,7 +870,10 @@ def test_groom_keeps_trimming_past_oversize_story(monkeypatch: pytest.MonkeyPatc
     oversize story is deferred individually and later small stories
     are still scored.
     """
-    monkeypatch.setenv("PRODUCT_DELIVERY_GROOM_MAX_PROMPT_BYTES", "1024")
+    # Wrapper alone is ~1020 bytes; 2048 leaves ~1028 bytes for stories.
+    # Two small stories with default-length user_story easily fit; the
+    # 4_000-char huge story doesn't.
+    monkeypatch.setenv("PRODUCT_DELIVERY_GROOM_MAX_PROMPT_BYTES", "2048")
     small_a = _story("small_a")
     huge = _story("huge")
     object.__setattr__(huge, "user_story", "x" * 4_000)
@@ -960,3 +967,96 @@ def test_groom_rationale_distinguishes_count_cap_vs_byte_budget(
     # bucket so operators tune `PRODUCT_DELIVERY_GROOM_MAX_STORIES`,
     # not the byte budget.
     assert "story-count" in result.rationale.lower()
+
+
+def test_groom_byte_deferred_oldest_story_does_not_starve_newer_ones(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex-flagged starvation case: cap=1 + oldest story too large.
+
+    Previously the two-stage selection put the oversize-oldest story
+    in the cap window first, the byte-budget trim then dropped it,
+    and ``scored_stories`` came back empty. ``updated_at`` for that
+    story never advanced, so it stayed at the front of the freshness
+    queue forever and newer (potentially small) stories were
+    permanently deferred even though there was prompt room. The
+    combined `_select_grooming_candidates` only consumes a cap slot
+    when a story is *actually kept*, so byte-deferrals roll forward
+    to the next candidate.
+    """
+    from datetime import timedelta
+
+    monkeypatch.setenv("PRODUCT_DELIVERY_GROOM_MAX_STORIES", "1")
+    monkeypatch.setenv("PRODUCT_DELIVERY_GROOM_MAX_PROMPT_BYTES", "2048")
+    base = datetime.now(tz=timezone.utc)
+
+    # Oldest story is huge (won't fit byte budget). Newer one is small
+    # (would fit). Under the old two-stage selection, the huge story
+    # consumed the only cap slot and the small story was permanently
+    # count-deferred; the rotation never advanced because the huge
+    # story's `updated_at` stayed pinned at one week ago.
+    huge_old = _story("huge_old")
+    object.__setattr__(huge_old, "user_story", "x" * 4_000)
+    object.__setattr__(huge_old, "updated_at", base - timedelta(days=7))
+    small_new = _story("small_new")
+    object.__setattr__(small_new, "updated_at", base)
+
+    llm = _StubLLM(
+        payload={
+            "items": [
+                {
+                    "id": "small_new",
+                    "inputs": {
+                        "user_business_value": 8,
+                        "time_criticality": 4,
+                        "risk_reduction_or_opportunity_enablement": 0,
+                        "job_size": 4,
+                    },
+                }
+            ]
+        }
+    )
+    store = _fake_store(stories=[huge_old, small_new])
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="prod-x", method="wsjf", persist=True)
+
+    by_id = {item.id: item for item in result.ranked}
+    # The byte-deferred huge story did NOT consume the cap slot — the
+    # newer small story still got scored.
+    assert by_id["small_new"].score == 3.0
+    assert by_id["huge_old"].score == 0.0
+    # The huge story is byte-deferred, not count-deferred — operators
+    # should know which control to tune.
+    assert "prompt-byte budget" in by_id["huge_old"].rationale.lower()
+    # Persistence covers the small story.
+    assert {r[0] for r in store.persisted} == {"small_new"}
+
+
+def test_groom_503_when_byte_budget_smaller_than_prompt_wrapper(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Codex-flagged: budget that ignores wrapper bytes was undercounting.
+
+    Set the byte budget to the env-var minimum (1024) — even smaller
+    than the SYSTEM_PROMPT + build_user_prompt wrapper alone. Every
+    story's ``_full_prompt_size`` exceeds the budget, so all stories
+    are byte-deferred and the LLM is never invoked. Without the
+    wrapper-aware fix, the trimmer would have undercounted and the
+    actual model call would have overrun context with no warning.
+    """
+    monkeypatch.setenv(
+        "PRODUCT_DELIVERY_GROOM_MAX_PROMPT_BYTES", "1024"
+    )  # below ~1020-byte wrapper
+    stories = [_story("s1"), _story("s2")]
+    llm = _StubLLM(payload={"items": []})
+    store = _fake_store(stories=stories)
+    agent = ProductOwnerAgent(store=store, llm_client=llm)  # type: ignore[arg-type]
+    result = agent.groom(product_id="prod-x", method="wsjf", persist=True)
+
+    # Both stories surface as deferred (LLM never called).
+    assert len(result.ranked) == 2
+    for item in result.ranked:
+        assert item.score == 0.0
+        assert "prompt-byte budget" in item.rationale.lower()
+    assert llm.calls == []
+    assert store.persisted == []

--- a/backend/agents/product_delivery/tests/test_scoring.py
+++ b/backend/agents/product_delivery/tests/test_scoring.py
@@ -101,3 +101,40 @@ def test_rice_zero_effort_treated_as_one() -> None:
 def test_rice_negative_reach_floors_at_zero() -> None:
     score = rice_score(RICEInputs(reach=-50, impact=1, confidence=1, effort=2))
     assert score == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Finite-output guarantees
+# ---------------------------------------------------------------------------
+
+
+def test_wsjf_overflow_clamps_to_finite_max() -> None:
+    """Caller-supplied finite inputs that overflow during arithmetic must
+    not return ``inf`` — Starlette's JSON encoder rejects non-finite
+    floats and would raise during response serialisation otherwise.
+    """
+    import math
+    import sys
+
+    # cost_of_delay = 3 × max ≈ ±inf when summed; result must be finite.
+    huge = sys.float_info.max
+    score = wsjf_score(
+        WSJFInputs(
+            user_business_value=huge,
+            time_criticality=huge,
+            risk_reduction_or_opportunity_enablement=huge,
+            job_size=1.0,
+        )
+    )
+    assert math.isfinite(score)
+    assert score == pytest.approx(sys.float_info.max)
+
+
+def test_rice_overflow_clamps_to_finite_max() -> None:
+    import math
+    import sys
+
+    huge = sys.float_info.max
+    score = rice_score(RICEInputs(reach=huge, impact=huge, confidence=1.0, effort=1.0))
+    assert math.isfinite(score)
+    assert score == pytest.approx(sys.float_info.max)

--- a/backend/agents/product_delivery/tests/test_scoring.py
+++ b/backend/agents/product_delivery/tests/test_scoring.py
@@ -1,0 +1,103 @@
+"""Unit tests for the WSJF and RICE scoring functions."""
+
+from __future__ import annotations
+
+import pytest
+
+from product_delivery.scoring import (
+    RICEInputs,
+    WSJFInputs,
+    rice_score,
+    wsjf_score,
+)
+
+# ---------------------------------------------------------------------------
+# WSJF
+# ---------------------------------------------------------------------------
+
+
+def test_wsjf_basic_division() -> None:
+    score = wsjf_score(
+        WSJFInputs(
+            user_business_value=8,
+            time_criticality=5,
+            risk_reduction_or_opportunity_enablement=2,
+            job_size=5,
+        )
+    )
+    # Cost of delay = 15, job size 5 → 3.0
+    assert score == pytest.approx(3.0)
+
+
+def test_wsjf_zero_job_size_treated_as_one() -> None:
+    score = wsjf_score(
+        WSJFInputs(
+            user_business_value=4,
+            time_criticality=2,
+            risk_reduction_or_opportunity_enablement=1,
+            job_size=0,
+        )
+    )
+    assert score == pytest.approx(7.0)
+
+
+def test_wsjf_negative_components_floor_at_zero() -> None:
+    score = wsjf_score(
+        WSJFInputs(
+            user_business_value=-3,
+            time_criticality=4,
+            risk_reduction_or_opportunity_enablement=1,
+            job_size=5,
+        )
+    )
+    # value clamps to 0 → cost of delay 5 / 5 = 1.0
+    assert score == pytest.approx(1.0)
+
+
+def test_wsjf_rounded_to_four_dp() -> None:
+    score = wsjf_score(
+        WSJFInputs(
+            user_business_value=1,
+            time_criticality=1,
+            risk_reduction_or_opportunity_enablement=1,
+            job_size=3,
+        )
+    )
+    # 3 / 3 = 1.0 — but check rounding contract holds for an awkward case
+    score2 = wsjf_score(
+        WSJFInputs(
+            user_business_value=1,
+            time_criticality=1,
+            risk_reduction_or_opportunity_enablement=0,
+            job_size=3,
+        )
+    )
+    assert score == pytest.approx(1.0)
+    assert score2 == pytest.approx(round(2 / 3, 4))
+
+
+# ---------------------------------------------------------------------------
+# RICE
+# ---------------------------------------------------------------------------
+
+
+def test_rice_basic_formula() -> None:
+    # (1000 * 2 * 0.8) / 4 = 400.0
+    score = rice_score(RICEInputs(reach=1000, impact=2, confidence=0.8, effort=4))
+    assert score == pytest.approx(400.0)
+
+
+def test_rice_confidence_clamped_above_one() -> None:
+    score = rice_score(RICEInputs(reach=100, impact=1, confidence=60, effort=5))
+    # confidence clamps to 1.0 → (100 * 1 * 1) / 5 = 20.0 (not 1200)
+    assert score == pytest.approx(20.0)
+
+
+def test_rice_zero_effort_treated_as_one() -> None:
+    score = rice_score(RICEInputs(reach=10, impact=1, confidence=1, effort=0))
+    assert score == pytest.approx(10.0)
+
+
+def test_rice_negative_reach_floors_at_zero() -> None:
+    score = rice_score(RICEInputs(reach=-50, impact=1, confidence=1, effort=2))
+    assert score == pytest.approx(0.0)

--- a/backend/agents/product_delivery/tests/test_store.py
+++ b/backend/agents/product_delivery/tests/test_store.py
@@ -10,6 +10,7 @@ import pytest
 
 from product_delivery.postgres import SCHEMA
 from product_delivery.store import (
+    CrossProductFeedbackLink,
     ProductDeliveryStore,
     UnknownProductDeliveryEntity,
     get_store,
@@ -154,3 +155,33 @@ def test_feedback_round_trip_and_status_filter() -> None:
 
     closed = store.list_feedback(p.id, status="closed")
     assert closed == []
+
+
+def test_feedback_rejects_cross_product_story_link() -> None:
+    store = _store()
+    p_a = store.create_product(name="A", description="", vision="", author="alice")
+    p_b = store.create_product(name="B", description="", vision="", author="alice")
+    i_b = store.create_initiative(
+        product_id=p_b.id, title="I", summary="", status="proposed", author="alice"
+    )
+    e_b = store.create_epic(
+        initiative_id=i_b.id, title="E", summary="", status="proposed", author="alice"
+    )
+    s_b = store.create_story(
+        epic_id=e_b.id,
+        title="S",
+        user_story="",
+        status="proposed",
+        estimate_points=None,
+        author="alice",
+    )
+
+    with pytest.raises(CrossProductFeedbackLink):
+        store.create_feedback_item(
+            product_id=p_a.id,
+            source="qa",
+            raw_payload={},
+            severity="normal",
+            linked_story_id=s_b.id,
+            author="alice",
+        )

--- a/backend/agents/product_delivery/tests/test_store.py
+++ b/backend/agents/product_delivery/tests/test_store.py
@@ -157,6 +157,72 @@ def test_feedback_round_trip_and_status_filter() -> None:
     assert closed == []
 
 
+def test_get_backlog_tree_batches_child_reads() -> None:
+    # Regression for the N+1 fan-out: with two epics, four stories, and
+    # a task + AC per story, the request should hit the DB exactly five
+    # times (product, initiatives, epics, stories, tasks, ACs) — not
+    # 1 + 1 + (1 per epic) + (1 per story) * 2.
+    store = _store()
+    p = store.create_product(name="P", description="", vision="", author="alice")
+    i = store.create_initiative(
+        product_id=p.id, title="I", summary="", status="proposed", author="alice"
+    )
+    epic_ids: list[str] = []
+    story_ids: list[str] = []
+    for n in range(2):
+        e = store.create_epic(
+            initiative_id=i.id,
+            title=f"E{n}",
+            summary="",
+            status="proposed",
+            author="alice",
+        )
+        epic_ids.append(e.id)
+        for k in range(2):
+            s = store.create_story(
+                epic_id=e.id,
+                title=f"S{n}-{k}",
+                user_story="",
+                status="proposed",
+                estimate_points=None,
+                author="alice",
+            )
+            story_ids.append(s.id)
+            store.create_task(
+                story_id=s.id,
+                title="T",
+                description="",
+                status="todo",
+                owner=None,
+                author="alice",
+            )
+            store.create_acceptance_criterion(
+                story_id=s.id, text="must work", satisfied=False, author="alice"
+            )
+
+    tree = store.get_backlog_tree(p.id)
+    assert tree is not None
+    assert tree.product.id == p.id
+    flat_epic_ids = [e.id for e in tree.initiatives[0].epics]
+    flat_story_ids = [s.id for e in tree.initiatives[0].epics for s in e.stories]
+    assert sorted(flat_epic_ids) == sorted(epic_ids)
+    assert sorted(flat_story_ids) == sorted(story_ids)
+    # Every story has its task + AC attached (no cross-leakage from the
+    # bucketing pass).
+    for e in tree.initiatives[0].epics:
+        for s in e.stories:
+            assert len(s.tasks) == 1
+            assert len(s.acceptance_criteria) == 1
+
+
+def test_get_backlog_tree_returns_empty_initiatives_for_product_without_any() -> None:
+    store = _store()
+    p = store.create_product(name="P", description="", vision="", author="alice")
+    tree = store.get_backlog_tree(p.id)
+    assert tree is not None
+    assert tree.initiatives == []
+
+
 def test_feedback_rejects_cross_product_story_link() -> None:
     store = _store()
     p_a = store.create_product(name="A", description="", vision="", author="alice")

--- a/backend/agents/product_delivery/tests/test_store.py
+++ b/backend/agents/product_delivery/tests/test_store.py
@@ -1,0 +1,156 @@
+"""Integration tests for :class:`ProductDeliveryStore` against live Postgres.
+
+Skipped automatically when ``POSTGRES_HOST`` is unset (matches the
+pattern used by ``agent_console`` / ``shared_postgres`` tests).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from product_delivery.postgres import SCHEMA
+from product_delivery.store import (
+    ProductDeliveryStore,
+    UnknownProductDeliveryEntity,
+    get_store,
+)
+from shared_postgres import is_postgres_enabled, register_team_schemas
+from shared_postgres.testing import truncate_team_tables
+
+pytestmark = pytest.mark.skipif(
+    not is_postgres_enabled(),
+    reason="POSTGRES_HOST not set; skipping live-Postgres store tests",
+)
+
+
+@pytest.fixture(autouse=True)
+def _provision_schema() -> None:
+    register_team_schemas(SCHEMA)
+    truncate_team_tables(SCHEMA)
+    get_store.cache_clear()
+
+
+def _store() -> ProductDeliveryStore:
+    return get_store()
+
+
+def test_create_product_round_trip() -> None:
+    store = _store()
+    p = store.create_product(name="P", description="d", vision="v", author="alice")
+    assert p.author == "alice"
+    again = store.get_product(p.id)
+    assert again is not None
+    assert again.name == "P"
+
+
+def test_full_hierarchy_creation_and_backlog_tree() -> None:
+    store = _store()
+    p = store.create_product(name="P", description="", vision="", author="alice")
+    i = store.create_initiative(
+        product_id=p.id, title="I", summary="", status="proposed", author="alice"
+    )
+    e = store.create_epic(
+        initiative_id=i.id, title="E", summary="", status="proposed", author="alice"
+    )
+    s = store.create_story(
+        epic_id=e.id,
+        title="S",
+        user_story="",
+        status="proposed",
+        estimate_points=5,
+        author="alice",
+    )
+    store.create_task(
+        story_id=s.id,
+        title="T",
+        description="",
+        status="todo",
+        owner=None,
+        author="alice",
+    )
+    store.create_acceptance_criterion(
+        story_id=s.id, text="must work", satisfied=False, author="alice"
+    )
+
+    tree = store.get_backlog_tree(p.id)
+    assert tree is not None
+    assert tree.product.id == p.id
+    assert tree.initiatives[0].id == i.id
+    epic = tree.initiatives[0].epics[0]
+    assert epic.id == e.id
+    story = epic.stories[0]
+    assert story.id == s.id
+    assert len(story.tasks) == 1
+    assert len(story.acceptance_criteria) == 1
+
+
+def test_initiative_create_raises_when_product_missing() -> None:
+    store = _store()
+    with pytest.raises(UnknownProductDeliveryEntity):
+        store.create_initiative(
+            product_id="missing",
+            title="x",
+            summary="",
+            status="proposed",
+            author="alice",
+        )
+
+
+def test_status_and_score_updates() -> None:
+    store = _store()
+    p = store.create_product(name="P", description="", vision="", author="alice")
+    i = store.create_initiative(
+        product_id=p.id, title="I", summary="", status="proposed", author="alice"
+    )
+    assert store.update_status(kind="initiative", entity_id=i.id, status="in_sprint")
+    assert store.update_scores(kind="initiative", entity_id=i.id, wsjf_score=12.5, rice_score=80.0)
+    tree = store.get_backlog_tree(p.id)
+    assert tree is not None
+    assert tree.initiatives[0].status == "in_sprint"
+    assert tree.initiatives[0].wsjf_score == 12.5
+    assert tree.initiatives[0].rice_score == 80.0
+
+
+def test_bulk_update_story_scores_only_persists_specified_columns() -> None:
+    store = _store()
+    p = store.create_product(name="P", description="", vision="", author="alice")
+    i = store.create_initiative(
+        product_id=p.id, title="I", summary="", status="proposed", author="alice"
+    )
+    e = store.create_epic(
+        initiative_id=i.id, title="E", summary="", status="proposed", author="alice"
+    )
+    s = store.create_story(
+        epic_id=e.id,
+        title="S",
+        user_story="",
+        status="proposed",
+        estimate_points=None,
+        author="alice",
+    )
+
+    n = store.bulk_update_story_scores([(s.id, 4.2, None)])
+    assert n == 1
+
+    flat = store.list_stories_for_product(p.id)
+    assert flat[0].wsjf_score == 4.2
+    assert flat[0].rice_score is None
+
+
+def test_feedback_round_trip_and_status_filter() -> None:
+    store = _store()
+    p = store.create_product(name="P", description="", vision="", author="alice")
+    f = store.create_feedback_item(
+        product_id=p.id,
+        source="bug-tracker",
+        raw_payload={"issue": 123},
+        severity="high",
+        linked_story_id=None,
+        author="alice",
+    )
+    open_items = store.list_feedback(p.id, status="open")
+    assert len(open_items) == 1
+    assert open_items[0].id == f.id
+
+    closed = store.list_feedback(p.id, status="closed")
+    assert closed == []

--- a/backend/agents/product_delivery/tests/test_store.py
+++ b/backend/agents/product_delivery/tests/test_store.py
@@ -28,7 +28,6 @@ pytestmark = pytest.mark.skipif(
 def _provision_schema() -> None:
     register_team_schemas(SCHEMA)
     truncate_team_tables(SCHEMA)
-    get_store.cache_clear()
 
 
 def _store() -> ProductDeliveryStore:

--- a/backend/agents/product_delivery/tests/test_store_validators.py
+++ b/backend/agents/product_delivery/tests/test_store_validators.py
@@ -1,0 +1,156 @@
+"""Unit tests for the store-level validators in :mod:`product_delivery.store`.
+
+These cover the "pre-insert validation" contract — the real store
+validates status / scores / estimates **before** the SQL INSERT/UPDATE
+runs, so a non-route caller can't bypass the API-level Pydantic guards
+and persist invalid rows. Postgres-backed integration tests live in
+``test_store.py`` and are skipped when ``POSTGRES_HOST`` is unset; the
+checks here run unconditionally because they don't need a live DB.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from product_delivery.store import (
+    ProductDeliveryStorageUnavailable,
+    ProductDeliveryStore,
+    _validate_estimate_points,
+    _validate_optional_finite_score,
+    _validate_status,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_status",
+    [
+        "",
+        "x" * 41,
+        "y" * 200,
+    ],
+)
+def test_validate_status_rejects_out_of_bounds(bad_status: str) -> None:
+    with pytest.raises(ValueError, match="status must"):
+        _validate_status(bad_status)
+
+
+def test_validate_status_accepts_typical_values() -> None:
+    for ok in ("proposed", "in-progress", "x", "x" * 40):
+        assert _validate_status(ok) == ok
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [True, False, math.nan, math.inf, -math.inf],
+)
+def test_validate_optional_finite_score_rejects_invalid(bad_value: object) -> None:
+    with pytest.raises(ValueError):
+        _validate_optional_finite_score(bad_value, label="wsjf_score")  # type: ignore[arg-type]
+
+
+def test_validate_optional_finite_score_accepts_none_and_finite() -> None:
+    assert _validate_optional_finite_score(None, label="wsjf_score") is None
+    assert _validate_optional_finite_score(0.0, label="wsjf_score") == 0.0
+    assert _validate_optional_finite_score(-3.5, label="rice_score") == -3.5
+
+
+@pytest.mark.parametrize(
+    "bad_value",
+    [True, False, 0.0, -1.0, math.nan, math.inf, -math.inf],
+)
+def test_validate_estimate_points_rejects_invalid(bad_value: object) -> None:
+    with pytest.raises(ValueError):
+        _validate_estimate_points(bad_value)  # type: ignore[arg-type]
+
+
+def test_validate_estimate_points_accepts_none_and_positive() -> None:
+    assert _validate_estimate_points(None) is None
+    assert _validate_estimate_points(1.0) == 1.0
+    assert _validate_estimate_points(0.5) == 0.5
+
+
+# ---------------------------------------------------------------------------
+# create_*: status must validate BEFORE the INSERT runs.
+#
+# Without the fix, an out-of-bounds status would reach the SQL INSERT
+# and (if Postgres were available) persist before the post-insert
+# Pydantic validation raised. We assert that the validator fires first
+# by calling the create methods on a real ``ProductDeliveryStore``
+# without Postgres configured: a ``ValueError`` from the validator must
+# beat the ``ProductDeliveryStorageUnavailable`` from ``_conn``.
+# ---------------------------------------------------------------------------
+
+
+def _store(monkeypatch: pytest.MonkeyPatch) -> ProductDeliveryStore:
+    # Belt-and-suspenders: even if the test runner has POSTGRES_HOST
+    # set, force the storage-unavailable path so the test isolates the
+    # validator's "raises before SQL" guarantee.
+    monkeypatch.delenv("POSTGRES_HOST", raising=False)
+    return ProductDeliveryStore()
+
+
+def test_create_initiative_validates_status_before_insert(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(monkeypatch)
+    with pytest.raises(ValueError, match="status must"):
+        store.create_initiative(
+            product_id="p1",
+            title="I",
+            summary="",
+            status="x" * 200,
+            author="tester",
+        )
+
+
+def test_create_epic_validates_status_before_insert(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(monkeypatch)
+    with pytest.raises(ValueError, match="status must"):
+        store.create_epic(
+            initiative_id="i1",
+            title="E",
+            summary="",
+            status="x" * 200,
+            author="tester",
+        )
+
+
+def test_create_task_validates_status_before_insert(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(monkeypatch)
+    with pytest.raises(ValueError, match="status must"):
+        store.create_task(
+            story_id="s1",
+            title="T",
+            description="",
+            status="x" * 200,
+            owner=None,
+            author="tester",
+        )
+
+
+def test_create_initiative_storage_unavailable_for_valid_input(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sanity check: with POSTGRES_HOST unset, a *valid* status must
+    surface ``ProductDeliveryStorageUnavailable`` (i.e. the validator
+    didn't reject the input — it passed the guard and only the missing
+    DB stops the call)."""
+    store = _store(monkeypatch)
+    with pytest.raises(ProductDeliveryStorageUnavailable):
+        store.create_initiative(
+            product_id="p1",
+            title="I",
+            summary="",
+            status="proposed",
+            author="tester",
+        )

--- a/backend/agents/product_delivery/tests/test_store_validators.py
+++ b/backend/agents/product_delivery/tests/test_store_validators.py
@@ -20,6 +20,7 @@ from product_delivery.store import (
     _validate_estimate_points,
     _validate_optional_finite_score,
     _validate_status,
+    _validate_text,
     _validate_title,
 )
 
@@ -252,3 +253,58 @@ def test_create_methods_validate_title_before_insert(
         )
     with pytest.raises(ValueError, match="title must"):
         call()
+
+
+# ---------------------------------------------------------------------------
+# Status validator: non-string inputs and whitespace normalisation.
+# Both flagged as P3 by Codex.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", [None, 123, 4.5, [], {}, True, False])
+def test_validate_status_rejects_non_string_inputs(bad: object) -> None:
+    """Non-route callers handing in non-strings must surface a domain
+    `ValueError`, not a raw `TypeError` from `len()`."""
+    with pytest.raises(ValueError, match="status must be a string"):
+        _validate_status(bad)  # type: ignore[arg-type]
+
+
+def test_validate_status_strips_leading_trailing_whitespace() -> None:
+    # `"open "` and `"open"` must not become distinct persisted states.
+    assert _validate_status("open ") == "open"
+    assert _validate_status("  open  ") == "open"
+    assert _validate_status("\topen\n") == "open"
+
+
+def test_validate_title_rejects_non_string_inputs() -> None:
+    with pytest.raises(ValueError, match="title must be a string"):
+        _validate_title(None)  # type: ignore[arg-type]
+
+
+def test_validate_title_strips_whitespace() -> None:
+    assert _validate_title("  My Title  ") == "My Title"
+
+
+# ---------------------------------------------------------------------------
+# Generic text validator (acceptance-criterion text, feedback source).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", ["", "   ", "\t", "\n"])
+def test_validate_text_rejects_blank(bad: str) -> None:
+    with pytest.raises(ValueError, match="must not be blank"):
+        _validate_text(bad, label="text")
+
+
+def test_validate_text_rejects_oversized_when_max_len_set() -> None:
+    with pytest.raises(ValueError, match="must be at most 10 chars"):
+        _validate_text("x" * 11, label="text", max_len=10)
+
+
+def test_validate_text_rejects_non_string() -> None:
+    with pytest.raises(ValueError, match="must be a string"):
+        _validate_text(None, label="text")  # type: ignore[arg-type]
+
+
+def test_validate_text_strips_whitespace() -> None:
+    assert _validate_text("  ok  ", label="text") == "ok"

--- a/backend/agents/product_delivery/tests/test_store_validators.py
+++ b/backend/agents/product_delivery/tests/test_store_validators.py
@@ -276,9 +276,15 @@ def test_validate_status_strips_leading_trailing_whitespace() -> None:
     assert _validate_status("\topen\n") == "open"
 
 
-def test_validate_title_rejects_non_string_inputs() -> None:
+@pytest.mark.parametrize("bad", [None, 123, 4.5, [], {}, True, False])
+def test_validate_title_rejects_non_string_inputs(bad: object) -> None:
+    """Non-route callers handing in non-strings must surface a domain
+    `ValueError`, not a raw `TypeError` from `len()` — same contract
+    as `_validate_status`. Internal callers (the ProductOwnerAgent,
+    future workflow code, etc.) can't bypass the explicit validation
+    path with non-strings."""
     with pytest.raises(ValueError, match="title must be a string"):
-        _validate_title(None)  # type: ignore[arg-type]
+        _validate_title(bad)  # type: ignore[arg-type]
 
 
 def test_validate_title_strips_whitespace() -> None:

--- a/backend/agents/product_delivery/tests/test_store_validators.py
+++ b/backend/agents/product_delivery/tests/test_store_validators.py
@@ -20,6 +20,7 @@ from product_delivery.store import (
     _validate_estimate_points,
     _validate_optional_finite_score,
     _validate_status,
+    _validate_title,
 )
 
 # ---------------------------------------------------------------------------
@@ -154,3 +155,100 @@ def test_create_initiative_storage_unavailable_for_valid_input(
             status="proposed",
             author="tester",
         )
+
+
+# ---------------------------------------------------------------------------
+# Whitespace-only status (Codex P3): _validate_status must reject `'   '`
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("blank_status", [" ", "   ", "\t", "\n", " \t \n "])
+def test_validate_status_rejects_whitespace_only(blank_status: str) -> None:
+    with pytest.raises(ValueError, match="status must"):
+        _validate_status(blank_status)
+
+
+# ---------------------------------------------------------------------------
+# Title validator (Codex P3): mirrors API-level min_length=1, max_length=200
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_title",
+    [
+        "",
+        " ",
+        "   ",
+        "\t",
+        "x" * 201,
+    ],
+)
+def test_validate_title_rejects_invalid(bad_title: str) -> None:
+    with pytest.raises(ValueError, match="title must"):
+        _validate_title(bad_title)
+
+
+def test_validate_title_accepts_typical_values() -> None:
+    for ok in ("A", "A short title", "x" * 200):
+        assert _validate_title(ok) == ok
+
+
+def test_validate_title_uses_label_in_error() -> None:
+    # `_validate_title` is reused as `_validate_title(name, label="name")`
+    # in `create_product`, so the error must reflect the field name for
+    # operators reading the rejection message.
+    with pytest.raises(ValueError, match="name must"):
+        _validate_title("", label="name")
+
+
+# ---------------------------------------------------------------------------
+# create_*: title (and product name) must validate BEFORE the INSERT runs.
+# Mirror of the status guards above.
+# ---------------------------------------------------------------------------
+
+
+def test_create_product_validates_name_before_insert(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(monkeypatch)
+    with pytest.raises(ValueError, match="name must"):
+        store.create_product(name="", description="", vision="", author="tester")
+
+
+def test_create_product_rejects_oversized_name_before_insert(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(monkeypatch)
+    with pytest.raises(ValueError, match="name must"):
+        store.create_product(name="x" * 201, description="", vision="", author="tester")
+
+
+@pytest.mark.parametrize("kind", ["initiative", "epic", "story", "task"])
+def test_create_methods_validate_title_before_insert(
+    kind: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    store = _store(monkeypatch)
+    common = {"author": "tester"}
+    if kind == "initiative":
+        call = lambda: store.create_initiative(  # noqa: E731
+            product_id="p1", title="", summary="", status="proposed", **common
+        )
+    elif kind == "epic":
+        call = lambda: store.create_epic(  # noqa: E731
+            initiative_id="i1", title="", summary="", status="proposed", **common
+        )
+    elif kind == "story":
+        call = lambda: store.create_story(  # noqa: E731
+            epic_id="e1",
+            title="",
+            user_story="",
+            status="proposed",
+            estimate_points=None,
+            **common,
+        )
+    else:
+        call = lambda: store.create_task(  # noqa: E731
+            story_id="s1", title="", description="", status="todo", owner=None, **common
+        )
+    with pytest.raises(ValueError, match="title must"):
+        call()

--- a/backend/agents/shared_postgres/registry.py
+++ b/backend/agents/shared_postgres/registry.py
@@ -34,6 +34,7 @@ TEAM_POSTGRES_MODULES: dict[str, str] = {
     "agentic_team_provisioning": "agentic_team_provisioning.postgres",
     "blogging": "blogging.postgres",
     "nutrition_meal_planning": "nutrition_meal_planning_team.postgres",
+    "product_delivery": "product_delivery.postgres",
 }
 
 

--- a/backend/unified_api/config.py
+++ b/backend/unified_api/config.py
@@ -21,6 +21,12 @@ class TeamConfig:
     cell: str = "default"
     # Per-team proxy timeout in seconds. Long-running teams (SE pipeline) get higher timeouts.
     timeout_seconds: float = 60.0
+    # When True, this team is mounted in-process by the unified API
+    # (e.g. via ``app.include_router(...)``) rather than running in its
+    # own container. Proxy registration is skipped for these teams, but
+    # the security gateway still scans their prefix and discovery surfaces
+    # (``/teams``, ``/health``, ``/``) report them as live.
+    in_process: bool = False
 
 
 # Default port for the unified API server
@@ -224,10 +230,11 @@ TEAM_CONFIGS: dict[str, TeamConfig] = {
         timeout_seconds=120.0,
     ),
     # In-process module (not a proxy team): the unified API mounts the
-    # product_delivery router directly. Listed here with enabled=False so
-    # `_register_proxy_routes` skips proxy registration but the security
-    # gateway middleware still picks up the prefix in
-    # `_get_team_prefixes()` and scans request bodies.
+    # product_delivery router directly via `app.include_router(...)`.
+    # `in_process=True` so `_register_proxy_routes` skips proxy
+    # registration but the security gateway middleware picks up the
+    # prefix in `_get_team_prefixes()` and discovery surfaces report
+    # the team as live (`/teams`, `/health`, `/` show enabled=true).
     "product_delivery": TeamConfig(
         name="Product Delivery",
         prefix="/api/product-delivery",
@@ -235,10 +242,10 @@ TEAM_CONFIGS: dict[str, TeamConfig] = {
             "Persistent product backlog (products → initiatives → epics → stories → tasks), "
             "WSJF/RICE grooming, and feedback intake. In-process module mounted on the unified API."
         ),
-        enabled=False,
         tags=["product-delivery", "backlog", "grooming"],
         cell="core_dev",
         timeout_seconds=60.0,
+        in_process=True,
     ),
 }
 

--- a/backend/unified_api/config.py
+++ b/backend/unified_api/config.py
@@ -223,6 +223,23 @@ TEAM_CONFIGS: dict[str, TeamConfig] = {
         cell="core_dev",
         timeout_seconds=120.0,
     ),
+    # In-process module (not a proxy team): the unified API mounts the
+    # product_delivery router directly. Listed here with enabled=False so
+    # `_register_proxy_routes` skips proxy registration but the security
+    # gateway middleware still picks up the prefix in
+    # `_get_team_prefixes()` and scans request bodies.
+    "product_delivery": TeamConfig(
+        name="Product Delivery",
+        prefix="/api/product-delivery",
+        description=(
+            "Persistent product backlog (products → initiatives → epics → stories → tasks), "
+            "WSJF/RICE grooming, and feedback intake. In-process module mounted on the unified API."
+        ),
+        enabled=False,
+        tags=["product-delivery", "backlog", "grooming"],
+        cell="core_dev",
+        timeout_seconds=60.0,
+    ),
 }
 
 

--- a/backend/unified_api/main.py
+++ b/backend/unified_api/main.py
@@ -124,6 +124,11 @@ _registered_teams: dict[str, bool] = {}
 # Track upstream liveness per team (updated by background health checker).
 _team_liveness: dict[str, str] = {}  # team_key -> "healthy" | "unhealthy" | "unknown"
 
+# In-process teams whose Postgres schema registration failed at startup.
+# Health reports these as "unhealthy" so operators see the broken
+# persistence instead of a green light beside endpoints that 503.
+_in_process_schema_failures: set[str] = set()
+
 # Background health check interval in seconds.
 _HEALTH_CHECK_INTERVAL = int(os.getenv("HEALTH_CHECK_INTERVAL", "30"))
 
@@ -246,6 +251,10 @@ async def lifespan(app: FastAPI):
         register_team_schemas(PRODUCT_DELIVERY_SCHEMA)
     except Exception:
         logger.exception("product_delivery postgres schema registration failed")
+        # Surface the failure through `/health` — the team is still
+        # mounted (so /docs and discovery work) but every persistence
+        # call will 503, so health must reflect that.
+        _in_process_schema_failures.add("product_delivery")
 
     # 1. Mount team assistant conversational sub-apps (before proxy routes).
     try:
@@ -437,9 +446,12 @@ async def health() -> UnifiedHealthResponse:
         registered = _registered_teams.get(key, False)
         liveness = _team_liveness.get(key, "unknown")
         if config.in_process:
-            # No upstream container — health rides on the unified API
-            # process itself, which is up if we're answering this call.
-            status = "healthy"
+            # No upstream container, but the in-process router still
+            # depends on Postgres for product_delivery / agent_console.
+            # If schema registration failed at startup, persistence calls
+            # will 503 — surface that here instead of always reporting
+            # "healthy".
+            status = "unhealthy" if key in _in_process_schema_failures else "healthy"
         elif registered and liveness == "healthy":
             status = "healthy"
         elif registered and liveness == "unknown":

--- a/backend/unified_api/main.py
+++ b/backend/unified_api/main.py
@@ -176,7 +176,7 @@ async def _health_check_loop() -> None:
                 for team_key in list(_in_process_schema_failures):
                     try:
                         await loop.run_in_executor(
-                            _PROBE_EXECUTOR,
+                            _get_probe_executor(),
                             _retry_in_process_schema_registration,
                             team_key,
                         )
@@ -388,11 +388,13 @@ async def lifespan(app: FastAPI):
         logger.warning("shared_postgres close_pool failed", exc_info=True)
 
     # Shut down the dedicated health-probe executor so worker threads
-    # don't outlive the app — important under reload / test processes
-    # that recreate app state. ``cancel_futures=True`` drops queued
-    # work; in-flight DB pings finish naturally because they were
-    # already capped by the inner connection timeout.
-    _PROBE_EXECUTOR.shutdown(wait=False, cancel_futures=True)
+    # don't outlive the app. The shutdown helper also clears the
+    # module-level slot so the next lifespan startup (under reload /
+    # test harnesses that recreate app state in-process) sees a fresh
+    # executor on first probe via `_get_probe_executor()`. Codex
+    # flagged that the previous "shutdown but never recreate" pattern
+    # silently broke probe + schema retry on subsequent app starts.
+    _shutdown_probe_executor()
 
     logger.info("Shutting down Unified API Server...")
 
@@ -526,8 +528,38 @@ async def root() -> ApiInfoResponse:
 #   2. Cap the connection-acquisition wait via psycopg's own timeout
 #      knob (`pool.connection(timeout=…)`) so the worker itself can't
 #      block longer than the budget — the thread always exits cleanly.
-_PROBE_EXECUTOR = futures.ThreadPoolExecutor(max_workers=2, thread_name_prefix="pd-health-probe")
 _PROBE_DB_TIMEOUT_S = 1.5
+# The probe executor is created lazily via `_get_probe_executor()` so
+# that lifespan teardown (which calls `.shutdown()`) doesn't strand a
+# subsequent app start with a dead executor — Codex flagged that
+# tests / reload harnesses that recreate app state in-process were
+# left with no way to schedule probe or retry work after the first
+# shutdown. ``_get_probe_executor`` recreates it on demand.
+_PROBE_EXECUTOR: futures.ThreadPoolExecutor | None = None
+
+
+def _get_probe_executor() -> futures.ThreadPoolExecutor:
+    """Lazily create or recreate the dedicated probe executor.
+
+    Codex flagged that the previous module-level executor was shut
+    down on lifespan exit but never recreated. In-process restarts
+    (test harnesses, ``uvicorn --reload``) would then schedule probe
+    work onto a closed executor and silently fail. With this lazy
+    accessor every probe / retry call enters with a live executor —
+    or creates a fresh one if the previous lifespan tore it down.
+    """
+    global _PROBE_EXECUTOR
+    if _PROBE_EXECUTOR is None or getattr(_PROBE_EXECUTOR, "_shutdown", False):
+        _PROBE_EXECUTOR = futures.ThreadPoolExecutor(max_workers=2, thread_name_prefix="pd-health-probe")
+    return _PROBE_EXECUTOR
+
+
+def _shutdown_probe_executor() -> None:
+    """Shut down the probe executor and clear the slot for re-creation."""
+    global _PROBE_EXECUTOR
+    if _PROBE_EXECUTOR is not None:
+        _PROBE_EXECUTOR.shutdown(wait=False, cancel_futures=True)
+        _PROBE_EXECUTOR = None
 
 
 async def _probe_postgres_live() -> bool:
@@ -571,7 +603,7 @@ async def _probe_postgres_live() -> bool:
         # cleanup is guaranteed by the inner timeout; this is just
         # belt-and-suspenders for the await side.
         return await asyncio.wait_for(
-            loop.run_in_executor(_PROBE_EXECUTOR, _ping),
+            loop.run_in_executor(_get_probe_executor(), _ping),
             timeout=_PROBE_DB_TIMEOUT_S + 0.5,
         )
     except asyncio.TimeoutError:
@@ -588,6 +620,74 @@ def _is_postgres_enabled_cached() -> bool:
     to drop in-process teams to ``unavailable`` rather than ``unhealthy``.
     """
     return bool(os.environ.get("POSTGRES_HOST", "").strip())
+
+
+def _expected_tables_for(team_key: str) -> list[str]:
+    """Return the list of tables an in-process team is expected to own.
+
+    Sourced from each team's ``TeamSchema.table_names`` so this stays
+    in lockstep with the schema-registry truth, no separate list.
+    """
+    if team_key == "product_delivery":
+        from product_delivery.postgres import SCHEMA as PRODUCT_DELIVERY_SCHEMA
+
+        return list(PRODUCT_DELIVERY_SCHEMA.table_names)
+    # Other in-process teams (agent_console, team_assistant, …) don't
+    # currently surface table-presence checks in /health. Add cases
+    # here as they adopt the pattern.
+    return []
+
+
+async def _verify_in_process_schema_present(team_key: str) -> bool:
+    """Check that the team's expected tables still exist in Postgres.
+
+    Codex flagged that ``SELECT 1`` alone proves connectivity but
+    *not* that the team's schema is intact — a manual ``DROP TABLE``,
+    a botched migration, or a database swap could leave product-delivery
+    endpoints returning storage errors while ``/health`` stayed green.
+    We re-confirm the table set every time this branch fires; if any
+    expected table is missing, the team flips to ``unhealthy`` and is
+    added back to ``_in_process_schema_failures`` so the background
+    loop's retry path attempts re-registration.
+
+    Runs the synchronous psycopg query inside the dedicated probe
+    executor (same pool as ``_probe_postgres_live`` and the schema
+    retry) so it can't starve the default ``to_thread`` executor.
+    """
+    expected = _expected_tables_for(team_key)
+    if not expected:
+        # No declared tables → nothing to verify. Treat as healthy
+        # (e.g. a future in-process team that doesn't own any tables).
+        return True
+
+    def _check() -> bool:
+        from shared_postgres import client as _pg_client
+        from shared_postgres import is_postgres_enabled
+
+        if not is_postgres_enabled():
+            return False
+        try:
+            pool = _pg_client._get_or_create_pool()
+            with pool.connection(timeout=_PROBE_DB_TIMEOUT_S) as conn, conn.cursor() as cur:
+                # `to_regclass` returns NULL for missing tables — fast,
+                # one round-trip, and it doesn't lock anything.
+                placeholders = ", ".join(["to_regclass(%s) IS NOT NULL"] * len(expected))
+                cur.execute(f"SELECT {placeholders}", expected)
+                row = cur.fetchone()
+                return row is not None and all(row)
+        except Exception:
+            return False
+
+    loop = asyncio.get_running_loop()
+    try:
+        return await asyncio.wait_for(
+            loop.run_in_executor(_get_probe_executor(), _check),
+            timeout=_PROBE_DB_TIMEOUT_S + 0.5,
+        )
+    except asyncio.TimeoutError:
+        return False
+    except Exception:
+        return False
 
 
 def _retry_in_process_schema_registration(team_key: str) -> bool:
@@ -696,7 +796,27 @@ async def health() -> UnifiedHealthResponse:
             else:
                 if db_live is None:
                     db_live = await _probe_postgres_live()
-                status = "healthy" if db_live else "unhealthy"
+                if not db_live:
+                    status = "unhealthy"
+                else:
+                    # `SELECT 1` proves connectivity — but Codex
+                    # flagged that it doesn't prove the team's tables
+                    # are still present (a manual `DROP TABLE`,
+                    # botched migration, or DB swap can leave
+                    # endpoints 503-ing while /health stayed green).
+                    # Verify the team's expected tables exist; if any
+                    # are missing, mark the team unhealthy and queue
+                    # a background-loop retry to re-register.
+                    if await _verify_in_process_schema_present(key):
+                        status = "healthy"
+                    else:
+                        logger.warning(
+                            "%s: Postgres reachable but expected tables missing; "
+                            "marking unhealthy and queueing schema retry",
+                            key,
+                        )
+                        _in_process_schema_failures.add(key)
+                        status = "unhealthy"
         elif registered and liveness == "healthy":
             status = "healthy"
         elif registered and liveness == "unknown":

--- a/backend/unified_api/main.py
+++ b/backend/unified_api/main.py
@@ -160,6 +160,12 @@ def _register_proxy_routes(app: FastAPI) -> dict[str, bool]:
     enabled = get_enabled_teams()
 
     for team_key, config in enabled.items():
+        # In-process teams are served by `app.include_router(...)`; no
+        # upstream container, so no proxy. They still count as
+        # "registered" for discovery purposes since the route is live.
+        if config.in_process:
+            results[team_key] = True
+            continue
         env_var = TEAM_SERVICE_URL_ENVS.get(team_key)
         url = (os.environ.get(env_var, "").strip() if env_var else "") if env_var else ""
         if not url:
@@ -424,7 +430,11 @@ async def health() -> UnifiedHealthResponse:
     for key, config in TEAM_CONFIGS.items():
         registered = _registered_teams.get(key, False)
         liveness = _team_liveness.get(key, "unknown")
-        if registered and liveness == "healthy":
+        if config.in_process:
+            # No upstream container — health rides on the unified API
+            # process itself, which is up if we're answering this call.
+            status = "healthy"
+        elif registered and liveness == "healthy":
             status = "healthy"
         elif registered and liveness == "unknown":
             status = "healthy"  # Not yet checked — assume healthy

--- a/backend/unified_api/main.py
+++ b/backend/unified_api/main.py
@@ -422,12 +422,6 @@ from unified_api.routes.analytics import router as analytics_router
 from unified_api.routes.integrations import router as integrations_router
 from unified_api.routes.llm_tools import router as llm_tools_router
 from unified_api.routes.llm_usage import router as llm_usage_router
-from unified_api.routes.product_delivery import (
-    register_pd_exception_handlers,
-)
-from unified_api.routes.product_delivery import (
-    router as product_delivery_router,
-)
 from unified_api.routes.sandboxes import router as sandboxes_router
 
 app.include_router(integrations_router)
@@ -440,8 +434,16 @@ app.include_router(agent_console_saved_inputs_router)
 app.include_router(agent_console_diff_router)
 # Honor the in-process team's `enabled` flag: an operator that disables
 # the team via TEAM_CONFIGS expects /api/product-delivery/* to stop
-# answering, not just disappear from /teams.
+# answering, not just disappear from /teams. Gate the *import* too —
+# Codex flagged that an unconditional import can take down unified_api
+# at startup with an import-time failure (missing transitive dep,
+# broken module, etc.) even when the team is disabled. With the gate,
+# disabling product_delivery in config skips the module graph
+# entirely.
 if TEAM_CONFIGS["product_delivery"].enabled:
+    from unified_api.routes.product_delivery import register_pd_exception_handlers
+    from unified_api.routes.product_delivery import router as product_delivery_router
+
     app.include_router(product_delivery_router)
     register_pd_exception_handlers(app)
 
@@ -557,19 +559,38 @@ def _retry_in_process_schema_registration(team_key: str) -> bool:
     Called from `/health` when the live DB probe succeeds for a team
     that was added to `_in_process_schema_failures` at startup —
     typically because Postgres wasn't reachable when the lifespan
-    fired but is reachable now. `register_team_schemas` is idempotent,
-    so re-running on a recovered DB simply applies any DDL the startup
-    attempt missed and clears the failure flag so subsequent /health
-    calls report `healthy` without a process restart.
+    fired but is reachable now. Uses `ensure_team_schema` (rather than
+    the boolean `register_team_schemas` wrapper) so we can detect
+    *partial* DDL — that helper logs-and-skips per-statement errors
+    and would otherwise return success after applying only some
+    statements, flipping `/health` to `healthy` while required tables
+    or indexes are still missing. We only clear the failure flag when
+    `applied == total`.
+
+    Synchronous (DDL is sync); the caller wraps this in
+    ``asyncio.to_thread`` so it doesn't block the event loop.
     """
     try:
         if team_key == "product_delivery":
             from product_delivery.postgres import SCHEMA as PRODUCT_DELIVERY_SCHEMA
-            from shared_postgres import register_team_schemas
+            from shared_postgres import ensure_team_schema
 
-            register_team_schemas(PRODUCT_DELIVERY_SCHEMA)
+            applied = ensure_team_schema(PRODUCT_DELIVERY_SCHEMA)
+            total = len(PRODUCT_DELIVERY_SCHEMA.statements)
+            if applied < total:
+                logger.warning(
+                    "product_delivery retry: %d/%d DDL statements applied; "
+                    "still unhealthy (some required tables or indexes are missing)",
+                    applied,
+                    total,
+                )
+                return False
             _in_process_schema_failures.discard(team_key)
-            logger.info("product_delivery: schema re-registration succeeded; clearing health flag")
+            logger.info(
+                "product_delivery: schema re-registration succeeded (%d/%d); clearing health flag",
+                applied,
+                total,
+            )
             return True
         # Other in-process teams (agent_console, team_assistant, etc.)
         # don't currently track their schema-failure flag through this
@@ -627,7 +648,10 @@ async def health() -> UnifiedHealthResponse:
                 # probe + retry both fail.
                 if db_live is None:
                     db_live = await _probe_postgres_live()
-                if db_live and _retry_in_process_schema_registration(key):
+                if db_live and await asyncio.to_thread(_retry_in_process_schema_registration, key):
+                    # DDL is synchronous; offloaded to a worker so the
+                    # event loop isn't blocked while pg processes
+                    # CREATE TABLE / CREATE INDEX during recovery.
                     status = "healthy"
                 else:
                     status = "unhealthy"

--- a/backend/unified_api/main.py
+++ b/backend/unified_api/main.py
@@ -468,31 +468,76 @@ async def root() -> ApiInfoResponse:
     )
 
 
+async def _probe_postgres_live() -> bool:
+    """Run ``SELECT 1`` against the shared pool with a short timeout.
+
+    Used by the in-process team health branch so a runtime Postgres
+    outage (pool exhausted, host unreachable, FK chain broken) flips
+    those teams to ``unhealthy`` immediately instead of leaving the
+    startup-time success result frozen until the next process restart.
+    Anything that doesn't return a ``True`` quickly is treated as a
+    fail — better to flap to "unhealthy" briefly than miss a real
+    outage. Runs the sync psycopg call inside ``to_thread`` so the
+    event loop isn't blocked on a slow connect.
+    """
+
+    def _ping() -> bool:
+        from shared_postgres import get_conn, is_postgres_enabled
+
+        if not is_postgres_enabled():
+            return False
+        try:
+            with get_conn() as conn, conn.cursor() as cur:
+                cur.execute("SELECT 1")
+                row = cur.fetchone()
+                return row is not None and row[0] == 1
+        except Exception:
+            return False
+
+    try:
+        return await asyncio.wait_for(asyncio.to_thread(_ping), timeout=2.0)
+    except asyncio.TimeoutError:
+        return False
+    except Exception:
+        return False
+
+
 @app.get("/health", response_model=UnifiedHealthResponse, tags=["health"])
 async def health() -> UnifiedHealthResponse:
     """Unified health check — reports proxy registration and upstream liveness per team."""
     teams = []
     all_healthy = True
+    # Lazily probe the live DB only if at least one in-process team
+    # would otherwise report `healthy` — avoids paying the round trip
+    # when every in-process team is already disabled or has a startup
+    # schema failure recorded.
+    db_live: bool | None = None
     for key, config in TEAM_CONFIGS.items():
         registered = _registered_teams.get(key, False)
         liveness = _team_liveness.get(key, "unknown")
         if config.in_process:
             # No upstream container, but the in-process router still
             # depends on Postgres for product_delivery / agent_console.
-            # Three states matter:
+            # Four states matter:
             #   * disabled → routes are unmounted; report "unavailable"
             #     so operators don't see a green light beside a route
             #     that 404s.
-            #   * schema registration failed → persistence calls will
-            #     503; report "unhealthy".
-            #   * otherwise the route is live and the unified API
-            #     process itself is up → "healthy".
+            #   * schema registration failed at startup → persistence
+            #     calls will 503; report "unhealthy".
+            #   * runtime DB probe fails → endpoints are actively
+            #     returning 503; report "unhealthy" (this catches
+            #     post-startup outages — pool death, host reboot, etc.
+            #     — that the startup-time failure set wouldn't).
+            #   * otherwise the route is live and Postgres is reachable
+            #     → "healthy".
             if not config.enabled:
                 status = "unavailable"
             elif key in _in_process_schema_failures:
                 status = "unhealthy"
             else:
-                status = "healthy"
+                if db_live is None:
+                    db_live = await _probe_postgres_live()
+                status = "healthy" if db_live else "unhealthy"
         elif registered and liveness == "healthy":
             status = "healthy"
         elif registered and liveness == "unknown":

--- a/backend/unified_api/main.py
+++ b/backend/unified_api/main.py
@@ -233,6 +233,14 @@ async def lifespan(app: FastAPI):
     except Exception:
         logger.exception("agent_console postgres schema registration failed")
 
+    try:
+        from product_delivery.postgres import SCHEMA as PRODUCT_DELIVERY_SCHEMA
+        from shared_postgres import register_team_schemas
+
+        register_team_schemas(PRODUCT_DELIVERY_SCHEMA)
+    except Exception:
+        logger.exception("product_delivery postgres schema registration failed")
+
     # 1. Mount team assistant conversational sub-apps (before proxy routes).
     try:
         from team_assistant.api import create_assistant_app
@@ -367,6 +375,7 @@ from unified_api.routes.analytics import router as analytics_router
 from unified_api.routes.integrations import router as integrations_router
 from unified_api.routes.llm_tools import router as llm_tools_router
 from unified_api.routes.llm_usage import router as llm_usage_router
+from unified_api.routes.product_delivery import router as product_delivery_router
 from unified_api.routes.sandboxes import router as sandboxes_router
 
 app.include_router(integrations_router)
@@ -377,6 +386,7 @@ app.include_router(agents_router)
 app.include_router(sandboxes_router)
 app.include_router(agent_console_saved_inputs_router)
 app.include_router(agent_console_diff_router)
+app.include_router(product_delivery_router)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/unified_api/main.py
+++ b/backend/unified_api/main.py
@@ -145,7 +145,15 @@ async def _check_team_health(team_key: str, service_url: str) -> str:
 
 
 async def _health_check_loop() -> None:
-    """Periodically probe all registered teams' health endpoints."""
+    """Periodically probe all registered teams' health endpoints.
+
+    Also retries schema registration for in-process teams whose startup
+    DDL failed — Codex flagged that doing this from `/health` makes the
+    handler mutate state on every probe (no throttling, no isolation).
+    Running it here gives both: a natural cooldown via the loop interval
+    and a dedicated executor (`_PROBE_EXECUTOR`) instead of the default
+    threadpool.
+    """
     while True:
         await asyncio.sleep(_HEALTH_CHECK_INTERVAL)
         for team_key in list(_registered_teams.keys()):
@@ -156,6 +164,28 @@ async def _health_check_loop() -> None:
             if url:
                 status = await _check_team_health(team_key, url)
                 _team_liveness[team_key] = status
+        # Background schema retries for in-process teams that failed at
+        # startup. The interval (default 30s) is the cooldown — no
+        # tighter retry loop, no per-/health-call execution. Runs in
+        # the dedicated `_PROBE_EXECUTOR` so DDL doesn't compete with
+        # other `to_thread` work in the default executor.
+        if _in_process_schema_failures:
+            db_live = await _probe_postgres_live()
+            if db_live:
+                loop = asyncio.get_running_loop()
+                for team_key in list(_in_process_schema_failures):
+                    try:
+                        await loop.run_in_executor(
+                            _PROBE_EXECUTOR,
+                            _retry_in_process_schema_registration,
+                            team_key,
+                        )
+                    except Exception:
+                        logger.warning(
+                            "Background schema retry failed for %s",
+                            team_key,
+                            exc_info=True,
+                        )
 
 
 def _register_proxy_routes(app: FastAPI) -> dict[str, bool]:
@@ -356,6 +386,13 @@ async def lifespan(app: FastAPI):
         close_pool()
     except Exception:
         logger.warning("shared_postgres close_pool failed", exc_info=True)
+
+    # Shut down the dedicated health-probe executor so worker threads
+    # don't outlive the app — important under reload / test processes
+    # that recreate app state. ``cancel_futures=True`` drops queued
+    # work; in-flight DB pings finish naturally because they were
+    # already capped by the inner connection timeout.
+    _PROBE_EXECUTOR.shutdown(wait=False, cancel_futures=True)
 
     logger.info("Shutting down Unified API Server...")
 
@@ -604,7 +641,15 @@ def _retry_in_process_schema_registration(team_key: str) -> bool:
 
 @app.get("/health", response_model=UnifiedHealthResponse, tags=["health"])
 async def health() -> UnifiedHealthResponse:
-    """Unified health check — reports proxy registration and upstream liveness per team."""
+    """Unified health check — reports proxy registration and upstream liveness per team.
+
+    Read-only: Codex flagged that triggering DDL retries from a public
+    GET endpoint is operationally surprising and lets every health
+    probe (load balancer, monitoring) repeatedly attempt
+    `CREATE TABLE/INDEX`. Schema retries now run on a throttled
+    background task (`_health_check_loop`) so this handler only reads
+    state — no DDL, no `_retry_in_process_schema_registration`.
+    """
     teams = []
     all_healthy = True
     # Lazily probe the live DB only if at least one in-process team
@@ -615,46 +660,39 @@ async def health() -> UnifiedHealthResponse:
     for key, config in TEAM_CONFIGS.items():
         registered = _registered_teams.get(key, False)
         liveness = _team_liveness.get(key, "unknown")
+        # Tracks whether `unavailable` here is *intentional* (the
+        # in-process Postgres-disabled case) or *misconfigured* (proxy
+        # team without a service URL). Only the misconfigured case
+        # should flip overall health to `degraded` — Codex flagged
+        # that the previous "any unavailable degrades" rule masked
+        # real proxy misconfigurations and the new "no unavailable
+        # degrades" rule overcorrected.
+        intentionally_unavailable = False
         if config.in_process:
             # No upstream container, but the in-process router still
             # depends on Postgres for product_delivery / agent_console.
             # Four states matter:
             #   * disabled → routes are unmounted; report "unavailable"
-            #     so operators don't see a green light beside a route
-            #     that 404s.
-            #   * schema registration failed at startup → persistence
-            #     calls will 503; report "unhealthy".
-            #   * runtime DB probe fails → endpoints are actively
-            #     returning 503; report "unhealthy" (this catches
-            #     post-startup outages — pool death, host reboot, etc.
-            #     — that the startup-time failure set wouldn't).
-            #   * otherwise the route is live and Postgres is reachable
-            #     → "healthy".
-            if not config.enabled:
+            #     (intentional — operator opt-out via TEAM_CONFIGS).
+            #   * Postgres not configured → "unavailable" (intentional —
+            #     the env explicitly opted out by not setting
+            #     `POSTGRES_HOST`).
+            #   * schema registration failed at startup AND the
+            #     background retry hasn't healed it yet → "unhealthy"
+            #     (broken).
+            #   * runtime DB probe fails → "unhealthy" (active outage).
+            #   * otherwise → "healthy".
+            if not config.enabled or not _is_postgres_enabled_cached():
+                # Either operator opt-out (config-disabled team) or
+                # env opt-out (no `POSTGRES_HOST`). Both are
+                # intentional and should not flip overall health.
                 status = "unavailable"
-            elif not _is_postgres_enabled_cached():
-                # Postgres intentionally not configured for this env.
-                # The team is mounted but every persistence call will
-                # 503; report `unavailable` so the unified API doesn't
-                # report degraded for an opt-out feature.
-                status = "unavailable"
+                intentionally_unavailable = True
             elif key in _in_process_schema_failures:
-                # Startup-time failure recorded. Don't immediately
-                # short-circuit to "unhealthy" — Postgres may have
-                # come back since startup. Probe live, and if it
-                # succeeds, retry the schema registration (idempotent)
-                # so the team can self-heal between startup and the
-                # next process restart. Only stay "unhealthy" if the
-                # probe + retry both fail.
-                if db_live is None:
-                    db_live = await _probe_postgres_live()
-                if db_live and await asyncio.to_thread(_retry_in_process_schema_registration, key):
-                    # DDL is synchronous; offloaded to a worker so the
-                    # event loop isn't blocked while pg processes
-                    # CREATE TABLE / CREATE INDEX during recovery.
-                    status = "healthy"
-                else:
-                    status = "unhealthy"
+                # Background loop may have already cleared this; if
+                # we're still in the set, persistence is still broken.
+                # Read-only: don't trigger a retry from this handler.
+                status = "unhealthy"
             else:
                 if db_live is None:
                     db_live = await _probe_postgres_live()
@@ -666,14 +704,11 @@ async def health() -> UnifiedHealthResponse:
         elif registered:
             status = "unhealthy"
         else:
+            # Proxy team that isn't registered — typically because its
+            # service URL is missing. That's a deployment misconfig,
+            # not an opt-out, so it should degrade overall health.
             status = "unavailable"
-        # Only `unhealthy` flips the overall status to `degraded`.
-        # `unavailable` means a team is intentionally not deployed in
-        # this environment (in-process team without `POSTGRES_HOST`
-        # set, or proxy team without a service URL); flagging the
-        # whole API degraded for an opt-out feature would trip
-        # readiness probes for deployments that don't use it yet.
-        if config.enabled and status == "unhealthy":
+        if config.enabled and (status == "unhealthy" or (status == "unavailable" and not intentionally_unavailable)):
             all_healthy = False
         teams.append(TeamHealth(name=config.name, prefix=config.prefix, status=status, enabled=config.enabled))
     return UnifiedHealthResponse(

--- a/backend/unified_api/main.py
+++ b/backend/unified_api/main.py
@@ -517,13 +517,17 @@ async def list_teams() -> dict[str, Any]:
     teams = {}
     for key, config in TEAM_CONFIGS.items():
         registered = _registered_teams.get(key, False)
+        # In-process teams piggy-back on the unified API's `/docs` —
+        # they don't expose a `/api/<team>/docs` endpoint themselves,
+        # so don't advertise one (it would 404).
+        per_team_docs = registered and not config.in_process
         teams[key] = {
             "name": config.name,
             "prefix": config.prefix,
             "description": config.description,
             "registered": registered,
             "enabled": config.enabled,
-            "docs_url": f"{config.prefix}/docs" if registered else None,
+            "docs_url": f"{config.prefix}/docs" if per_team_docs else None,
         }
     return {"teams": teams}
 

--- a/backend/unified_api/main.py
+++ b/backend/unified_api/main.py
@@ -14,6 +14,7 @@ import asyncio
 import logging
 import os
 import sys
+from concurrent import futures
 from contextlib import asynccontextmanager
 from pathlib import Path
 from typing import Any
@@ -276,9 +277,13 @@ async def lifespan(app: FastAPI):
                     _in_process_schema_failures.add("product_delivery")
             else:
                 # Postgres disabled → every persistence call will 503.
-                # Mark unhealthy so /health doesn't disagree with the route.
+                # Don't add to `_in_process_schema_failures` (which
+                # tracks broken state, not opt-out): the health handler
+                # sees `is_postgres_enabled()` is False and reports
+                # `unavailable` instead of `unhealthy`, so the unified
+                # API doesn't flag overall health degraded for an
+                # intentionally-undeployed feature.
                 logger.warning("product_delivery: Postgres disabled; persistence endpoints will return 503")
-                _in_process_schema_failures.add("product_delivery")
         except Exception:
             logger.exception("product_delivery postgres schema registration failed")
             _in_process_schema_failures.add("product_delivery")
@@ -468,6 +473,24 @@ async def root() -> ApiInfoResponse:
     )
 
 
+# Dedicated, bounded executor for the `/health` Postgres probe.
+# Codex flagged that `asyncio.to_thread` cannot interrupt the underlying
+# psycopg call on `wait_for` timeout: under a Postgres outage every
+# probe leaves a worker blocked in `pool.connection()` until the pool's
+# own timeout elapses, which can quickly exhaust the default executor
+# (and starve every other `to_thread`-using path in the app — file
+# I/O, integrations, etc.).
+#
+# Two-pronged fix:
+#   1. Run the probe in its own small executor so a flooded /health
+#      can't drag down unrelated work.
+#   2. Cap the connection-acquisition wait via psycopg's own timeout
+#      knob (`pool.connection(timeout=…)`) so the worker itself can't
+#      block longer than the budget — the thread always exits cleanly.
+_PROBE_EXECUTOR = futures.ThreadPoolExecutor(max_workers=2, thread_name_prefix="pd-health-probe")
+_PROBE_DB_TIMEOUT_S = 1.5
+
+
 async def _probe_postgres_live() -> bool:
     """Run ``SELECT 1`` against the shared pool with a short timeout.
 
@@ -475,30 +498,86 @@ async def _probe_postgres_live() -> bool:
     outage (pool exhausted, host unreachable, FK chain broken) flips
     those teams to ``unhealthy`` immediately instead of leaving the
     startup-time success result frozen until the next process restart.
-    Anything that doesn't return a ``True`` quickly is treated as a
-    fail — better to flap to "unhealthy" briefly than miss a real
-    outage. Runs the sync psycopg call inside ``to_thread`` so the
-    event loop isn't blocked on a slow connect.
+    Anything that doesn't return ``True`` quickly is treated as a
+    fail — better to flap to ``unhealthy`` briefly than miss a real
+    outage. Runs in a dedicated 2-worker executor with an inner
+    psycopg-level timeout so a stalled DB can't accumulate orphaned
+    workers in the default threadpool.
     """
 
     def _ping() -> bool:
-        from shared_postgres import get_conn, is_postgres_enabled
+        from shared_postgres import client as _pg_client
+        from shared_postgres import is_postgres_enabled
 
         if not is_postgres_enabled():
             return False
         try:
-            with get_conn() as conn, conn.cursor() as cur:
+            # Bound the connection acquisition itself so the worker
+            # thread can't block longer than `_PROBE_DB_TIMEOUT_S`. We
+            # reach through `client._get_or_create_pool` (rather than
+            # `get_conn()`) because the public helper doesn't expose a
+            # timeout knob today and the probe must be hard-bounded.
+            pool = _pg_client._get_or_create_pool()
+            with pool.connection(timeout=_PROBE_DB_TIMEOUT_S) as conn, conn.cursor() as cur:
                 cur.execute("SELECT 1")
                 row = cur.fetchone()
                 return row is not None and row[0] == 1
         except Exception:
             return False
 
+    loop = asyncio.get_running_loop()
     try:
-        return await asyncio.wait_for(asyncio.to_thread(_ping), timeout=2.0)
+        # Outer wait_for gives the await an upper bound even if the
+        # inner psycopg timeout fires later than expected. Worker
+        # cleanup is guaranteed by the inner timeout; this is just
+        # belt-and-suspenders for the await side.
+        return await asyncio.wait_for(
+            loop.run_in_executor(_PROBE_EXECUTOR, _ping),
+            timeout=_PROBE_DB_TIMEOUT_S + 0.5,
+        )
     except asyncio.TimeoutError:
         return False
     except Exception:
+        return False
+
+
+def _is_postgres_enabled_cached() -> bool:
+    """``shared_postgres.is_postgres_enabled()`` without the import dance.
+
+    Just reads the env var directly so the health handler doesn't pay
+    an import on every call. Postgres-disabled environments use this
+    to drop in-process teams to ``unavailable`` rather than ``unhealthy``.
+    """
+    return bool(os.environ.get("POSTGRES_HOST", "").strip())
+
+
+def _retry_in_process_schema_registration(team_key: str) -> bool:
+    """Re-run schema registration for a team after a transient outage.
+
+    Called from `/health` when the live DB probe succeeds for a team
+    that was added to `_in_process_schema_failures` at startup —
+    typically because Postgres wasn't reachable when the lifespan
+    fired but is reachable now. `register_team_schemas` is idempotent,
+    so re-running on a recovered DB simply applies any DDL the startup
+    attempt missed and clears the failure flag so subsequent /health
+    calls report `healthy` without a process restart.
+    """
+    try:
+        if team_key == "product_delivery":
+            from product_delivery.postgres import SCHEMA as PRODUCT_DELIVERY_SCHEMA
+            from shared_postgres import register_team_schemas
+
+            register_team_schemas(PRODUCT_DELIVERY_SCHEMA)
+            _in_process_schema_failures.discard(team_key)
+            logger.info("product_delivery: schema re-registration succeeded; clearing health flag")
+            return True
+        # Other in-process teams (agent_console, team_assistant, etc.)
+        # don't currently track their schema-failure flag through this
+        # set, so there's nothing to retry. Add cases here as they
+        # adopt the pattern.
+        return False
+    except Exception:
+        logger.warning("Schema re-registration retry failed for %s", team_key, exc_info=True)
         return False
 
 
@@ -532,8 +611,26 @@ async def health() -> UnifiedHealthResponse:
             #     → "healthy".
             if not config.enabled:
                 status = "unavailable"
+            elif not _is_postgres_enabled_cached():
+                # Postgres intentionally not configured for this env.
+                # The team is mounted but every persistence call will
+                # 503; report `unavailable` so the unified API doesn't
+                # report degraded for an opt-out feature.
+                status = "unavailable"
             elif key in _in_process_schema_failures:
-                status = "unhealthy"
+                # Startup-time failure recorded. Don't immediately
+                # short-circuit to "unhealthy" — Postgres may have
+                # come back since startup. Probe live, and if it
+                # succeeds, retry the schema registration (idempotent)
+                # so the team can self-heal between startup and the
+                # next process restart. Only stay "unhealthy" if the
+                # probe + retry both fail.
+                if db_live is None:
+                    db_live = await _probe_postgres_live()
+                if db_live and _retry_in_process_schema_registration(key):
+                    status = "healthy"
+                else:
+                    status = "unhealthy"
             else:
                 if db_live is None:
                     db_live = await _probe_postgres_live()
@@ -546,7 +643,13 @@ async def health() -> UnifiedHealthResponse:
             status = "unhealthy"
         else:
             status = "unavailable"
-        if config.enabled and status in ("unavailable", "unhealthy"):
+        # Only `unhealthy` flips the overall status to `degraded`.
+        # `unavailable` means a team is intentionally not deployed in
+        # this environment (in-process team without `POSTGRES_HOST`
+        # set, or proxy team without a service URL); flagging the
+        # whole API degraded for an opt-out feature would trip
+        # readiness probes for deployments that don't use it yet.
+        if config.enabled and status == "unhealthy":
             all_healthy = False
         teams.append(TeamHealth(name=config.name, prefix=config.prefix, status=status, enabled=config.enabled))
     return UnifiedHealthResponse(

--- a/backend/unified_api/main.py
+++ b/backend/unified_api/main.py
@@ -217,6 +217,12 @@ async def lifespan(app: FastAPI):
     global _registered_teams
     logger.info("Starting Unified API Server...")
 
+    # Reset stale failure markers from a previous lifespan run (e.g.
+    # uvicorn `--reload`, in-process test fixtures that boot the app
+    # multiple times). Without this, a transient Postgres outage on the
+    # first boot would mark the team unhealthy forever.
+    _in_process_schema_failures.clear()
+
     # 0. Register Postgres schemas for modules that run in-process here
     #    (unified_api itself + the team_assistant conversation store that we
     #    mount as sub-apps). No-op when POSTGRES_HOST is unset.
@@ -246,14 +252,30 @@ async def lifespan(app: FastAPI):
 
     try:
         from product_delivery.postgres import SCHEMA as PRODUCT_DELIVERY_SCHEMA
-        from shared_postgres import register_team_schemas
+        from shared_postgres import ensure_team_schema, is_postgres_enabled
 
-        register_team_schemas(PRODUCT_DELIVERY_SCHEMA)
+        # Use `ensure_team_schema` directly (rather than the
+        # `register_team_schemas` boolean wrapper) so we can detect
+        # partial DDL: if a single CREATE/ALTER statement fails it's
+        # logged-and-skipped and `applied < total` — the team's still
+        # mounted but its persistence is broken.
+        if is_postgres_enabled():
+            applied = ensure_team_schema(PRODUCT_DELIVERY_SCHEMA)
+            total = len(PRODUCT_DELIVERY_SCHEMA.statements)
+            if applied < total:
+                logger.warning(
+                    "product_delivery: %d/%d DDL statements applied; marking unhealthy",
+                    applied,
+                    total,
+                )
+                _in_process_schema_failures.add("product_delivery")
+        else:
+            # Postgres disabled → every persistence call will 503.
+            # Mark unhealthy so /health doesn't disagree with the route.
+            logger.warning("product_delivery: Postgres disabled; persistence endpoints will return 503")
+            _in_process_schema_failures.add("product_delivery")
     except Exception:
         logger.exception("product_delivery postgres schema registration failed")
-        # Surface the failure through `/health` — the team is still
-        # mounted (so /docs and discovery work) but every persistence
-        # call will 503, so health must reflect that.
         _in_process_schema_failures.add("product_delivery")
 
     # 1. Mount team assistant conversational sub-apps (before proxy routes).
@@ -406,8 +428,12 @@ app.include_router(agents_router)
 app.include_router(sandboxes_router)
 app.include_router(agent_console_saved_inputs_router)
 app.include_router(agent_console_diff_router)
-app.include_router(product_delivery_router)
-register_pd_exception_handlers(app)
+# Honor the in-process team's `enabled` flag: an operator that disables
+# the team via TEAM_CONFIGS expects /api/product-delivery/* to stop
+# answering, not just disappear from /teams.
+if TEAM_CONFIGS["product_delivery"].enabled:
+    app.include_router(product_delivery_router)
+    register_pd_exception_handlers(app)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/unified_api/main.py
+++ b/backend/unified_api/main.py
@@ -381,7 +381,12 @@ from unified_api.routes.analytics import router as analytics_router
 from unified_api.routes.integrations import router as integrations_router
 from unified_api.routes.llm_tools import router as llm_tools_router
 from unified_api.routes.llm_usage import router as llm_usage_router
-from unified_api.routes.product_delivery import router as product_delivery_router
+from unified_api.routes.product_delivery import (
+    register_pd_exception_handlers,
+)
+from unified_api.routes.product_delivery import (
+    router as product_delivery_router,
+)
 from unified_api.routes.sandboxes import router as sandboxes_router
 
 app.include_router(integrations_router)
@@ -393,6 +398,7 @@ app.include_router(sandboxes_router)
 app.include_router(agent_console_saved_inputs_router)
 app.include_router(agent_console_diff_router)
 app.include_router(product_delivery_router)
+register_pd_exception_handlers(app)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/unified_api/main.py
+++ b/backend/unified_api/main.py
@@ -250,33 +250,38 @@ async def lifespan(app: FastAPI):
     except Exception:
         logger.exception("agent_console postgres schema registration failed")
 
-    try:
-        from product_delivery.postgres import SCHEMA as PRODUCT_DELIVERY_SCHEMA
-        from shared_postgres import ensure_team_schema, is_postgres_enabled
+    # Gate the entire product_delivery startup block on the team's
+    # `enabled` flag. Disabling the team must also disable its startup
+    # side effects (schema DDL, failure logs, health markers) — not
+    # just the routes.
+    if TEAM_CONFIGS["product_delivery"].enabled:
+        try:
+            from product_delivery.postgres import SCHEMA as PRODUCT_DELIVERY_SCHEMA
+            from shared_postgres import ensure_team_schema, is_postgres_enabled
 
-        # Use `ensure_team_schema` directly (rather than the
-        # `register_team_schemas` boolean wrapper) so we can detect
-        # partial DDL: if a single CREATE/ALTER statement fails it's
-        # logged-and-skipped and `applied < total` — the team's still
-        # mounted but its persistence is broken.
-        if is_postgres_enabled():
-            applied = ensure_team_schema(PRODUCT_DELIVERY_SCHEMA)
-            total = len(PRODUCT_DELIVERY_SCHEMA.statements)
-            if applied < total:
-                logger.warning(
-                    "product_delivery: %d/%d DDL statements applied; marking unhealthy",
-                    applied,
-                    total,
-                )
+            # Use `ensure_team_schema` directly (rather than the
+            # `register_team_schemas` boolean wrapper) so we can detect
+            # partial DDL: if a single CREATE/ALTER statement fails it's
+            # logged-and-skipped and `applied < total` — the team's still
+            # mounted but its persistence is broken.
+            if is_postgres_enabled():
+                applied = ensure_team_schema(PRODUCT_DELIVERY_SCHEMA)
+                total = len(PRODUCT_DELIVERY_SCHEMA.statements)
+                if applied < total:
+                    logger.warning(
+                        "product_delivery: %d/%d DDL statements applied; marking unhealthy",
+                        applied,
+                        total,
+                    )
+                    _in_process_schema_failures.add("product_delivery")
+            else:
+                # Postgres disabled → every persistence call will 503.
+                # Mark unhealthy so /health doesn't disagree with the route.
+                logger.warning("product_delivery: Postgres disabled; persistence endpoints will return 503")
                 _in_process_schema_failures.add("product_delivery")
-        else:
-            # Postgres disabled → every persistence call will 503.
-            # Mark unhealthy so /health doesn't disagree with the route.
-            logger.warning("product_delivery: Postgres disabled; persistence endpoints will return 503")
+        except Exception:
+            logger.exception("product_delivery postgres schema registration failed")
             _in_process_schema_failures.add("product_delivery")
-    except Exception:
-        logger.exception("product_delivery postgres schema registration failed")
-        _in_process_schema_failures.add("product_delivery")
 
     # 1. Mount team assistant conversational sub-apps (before proxy routes).
     try:
@@ -474,10 +479,20 @@ async def health() -> UnifiedHealthResponse:
         if config.in_process:
             # No upstream container, but the in-process router still
             # depends on Postgres for product_delivery / agent_console.
-            # If schema registration failed at startup, persistence calls
-            # will 503 — surface that here instead of always reporting
-            # "healthy".
-            status = "unhealthy" if key in _in_process_schema_failures else "healthy"
+            # Three states matter:
+            #   * disabled → routes are unmounted; report "unavailable"
+            #     so operators don't see a green light beside a route
+            #     that 404s.
+            #   * schema registration failed → persistence calls will
+            #     503; report "unhealthy".
+            #   * otherwise the route is live and the unified API
+            #     process itself is up → "healthy".
+            if not config.enabled:
+                status = "unavailable"
+            elif key in _in_process_schema_failures:
+                status = "unhealthy"
+            else:
+                status = "healthy"
         elif registered and liveness == "healthy":
             status = "healthy"
         elif registered and liveness == "unknown":

--- a/backend/unified_api/main.py
+++ b/backend/unified_api/main.py
@@ -133,6 +133,14 @@ _in_process_schema_failures: set[str] = set()
 # Background health check interval in seconds.
 _HEALTH_CHECK_INTERVAL = int(os.getenv("HEALTH_CHECK_INTERVAL", "30"))
 
+# Per-team schema retry budget inside `_health_check_loop`. Codex
+# flagged that an unbounded `await loop.run_in_executor(...)` could let
+# one stalled DDL attempt block every other team's liveness update —
+# exactly during the outages where timely health refresh matters most.
+# The timeout cancels the *await*; the worker thread is independently
+# bounded by the pool-connection timeout, so it always cleans up.
+_SCHEMA_RETRY_TIMEOUT_S = float(os.getenv("SCHEMA_RETRY_TIMEOUT_S", "10"))
+
 
 async def _check_team_health(team_key: str, service_url: str) -> str:
     """Probe a team's /health endpoint. Returns 'healthy' or 'unhealthy'."""
@@ -174,11 +182,30 @@ async def _health_check_loop() -> None:
             if db_live:
                 loop = asyncio.get_running_loop()
                 for team_key in list(_in_process_schema_failures):
+                    # Bound each retry with `wait_for`. Codex flagged that
+                    # awaiting the executor directly meant a single stalled
+                    # DDL attempt (lock contention, slow connection
+                    # acquisition during the same outage that caused the
+                    # initial failure) could stall the loop and stale every
+                    # other team's liveness update — exactly the moment
+                    # operators need timely health refresh. The timeout
+                    # cancels the await; the worker thread itself is bounded
+                    # by the inner pool-connection timeout so it cleans up.
                     try:
-                        await loop.run_in_executor(
-                            _get_probe_executor(),
-                            _retry_in_process_schema_registration,
+                        await asyncio.wait_for(
+                            loop.run_in_executor(
+                                _get_probe_executor(),
+                                _retry_in_process_schema_registration,
+                                team_key,
+                            ),
+                            timeout=_SCHEMA_RETRY_TIMEOUT_S,
+                        )
+                    except asyncio.TimeoutError:
+                        logger.warning(
+                            "Background schema retry for %s exceeded %.1fs; "
+                            "leaving team in failure set for next loop pass",
                             team_key,
+                            _SCHEMA_RETRY_TIMEOUT_S,
                         )
                     except Exception:
                         logger.warning(

--- a/backend/unified_api/routes/product_delivery.py
+++ b/backend/unified_api/routes/product_delivery.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, HTTPException
 from product_delivery import (
     AcceptanceCriterion,
     BacklogTree,
+    CrossProductFeedbackLink,
     Epic,
     FeedbackItem,
     GroomRequest,
@@ -215,19 +216,19 @@ def patch_scores(kind: _ScoredKind, entity_id: str, body: ScoreUpdate) -> dict[s
 def groom(body: GroomRequest) -> GroomResult:
     try:
         store = get_store()
+        if store.get_product(body.product_id) is None:
+            raise HTTPException(status_code=404, detail=f"unknown product: {body.product_id}")
+
+        from llm_service import get_client  # noqa: PLC0415 — lazy: tests stub via override
+
+        agent = ProductOwnerAgent(store=store, llm_client=get_client("product_owner"))
+        return agent.groom(
+            product_id=body.product_id,
+            method=body.method,
+            persist=body.persist,
+        )
     except ProductDeliveryStorageUnavailable as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
-    if store.get_product(body.product_id) is None:
-        raise HTTPException(status_code=404, detail=f"unknown product: {body.product_id}")
-
-    from llm_service import get_client  # noqa: PLC0415 — lazy: tests stub via override
-
-    agent = ProductOwnerAgent(store=store, llm_client=get_client("product_owner"))
-    return agent.groom(
-        product_id=body.product_id,
-        method=body.method,
-        persist=body.persist,
-    )
 
 
 # ---------------------------------------------------------------------------
@@ -246,6 +247,8 @@ def create_feedback(body: FeedbackItemCreate) -> FeedbackItem:
             linked_story_id=body.linked_story_id,
             author=resolve_author(),
         )
+    except CrossProductFeedbackLink as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     except UnknownProductDeliveryEntity as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
     except ProductDeliveryStorageUnavailable as exc:

--- a/backend/unified_api/routes/product_delivery.py
+++ b/backend/unified_api/routes/product_delivery.py
@@ -226,7 +226,21 @@ def groom(body: GroomRequest) -> GroomResult:
 
         from llm_service import get_client  # noqa: PLC0415 — lazy: tests stub via override
 
-        agent = ProductOwnerAgent(store=store, llm_client=get_client("product_owner"))
+        # `get_client` can raise on misconfigured provider, missing
+        # credentials, or import-time failures inside the LLM stack.
+        # Surface those as 503 (same shape as a Postgres outage) so
+        # clients see a consistent "transient infrastructure" signal
+        # instead of a 500 from a bare exception.
+        try:
+            llm_client = get_client("product_owner")
+        except Exception as exc:
+            logger.exception("ProductOwnerAgent: LLM client bootstrap failed")
+            raise HTTPException(
+                status_code=503,
+                detail=f"LLM client unavailable: {exc}",
+            ) from exc
+
+        agent = ProductOwnerAgent(store=store, llm_client=llm_client)
         return agent.groom(
             product_id=body.product_id,
             method=body.method,
@@ -266,6 +280,11 @@ def list_feedback(
     status: str | None = None,
 ) -> list[FeedbackItem]:
     try:
-        return get_store().list_feedback(product_id, status=status)
+        store = get_store()
+        # Match the 404 semantics of /backlog, /groom, and feedback POST:
+        # an unknown product is a hard error, not "no feedback yet".
+        if store.get_product(product_id) is None:
+            raise HTTPException(status_code=404, detail=f"unknown product: {product_id}")
+        return store.list_feedback(product_id, status=status)
     except ProductDeliveryStorageUnavailable as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc

--- a/backend/unified_api/routes/product_delivery.py
+++ b/backend/unified_api/routes/product_delivery.py
@@ -215,13 +215,26 @@ def groom(body: GroomRequest) -> GroomResult:
     if store.get_product(body.product_id) is None:
         raise HTTPException(status_code=404, detail=f"unknown product: {body.product_id}")
 
-    from llm_service import get_client  # noqa: PLC0415 — lazy: tests stub via override
+    # Defer LLM client bootstrap until we actually need it: a product
+    # with no stories short-circuits to an empty `GroomResult` without
+    # any LLM call, so we shouldn't fail with 503 here when the LLM
+    # provider is down. The agent itself does the empty-backlog check.
+    if not store.list_stories_for_product(body.product_id):
+        agent = ProductOwnerAgent(store=store, llm_client=_NullLLMClient())
+        return agent.groom(
+            product_id=body.product_id,
+            method=body.method,
+            persist=body.persist,
+        )
 
-    # `get_client` can raise on misconfigured provider, missing credentials,
-    # or import-time failures inside the LLM stack. Surface those as 503
-    # (same shape as a Postgres outage) so clients see a consistent
-    # "transient infrastructure" signal instead of a bare 500.
+    # `get_client` (and the `llm_service` import itself) can raise on
+    # misconfigured provider, missing credentials, or module/dependency
+    # import-time failures. Surface all of those as 503 (same shape as a
+    # Postgres outage) so clients see a consistent "transient
+    # infrastructure" signal instead of a bare 500.
     try:
+        from llm_service import get_client  # noqa: PLC0415 — lazy: tests stub via override
+
         llm_client = get_client("product_owner")
     except Exception as exc:
         logger.exception("ProductOwnerAgent: LLM client bootstrap failed")
@@ -236,6 +249,20 @@ def groom(body: GroomRequest) -> GroomResult:
         method=body.method,
         persist=body.persist,
     )
+
+
+class _NullLLMClient:
+    """Sentinel client used only when the backlog is empty.
+
+    The agent never calls ``complete_json`` on the empty-backlog path
+    (it short-circuits to ``GroomResult(ranked=[])`` before any LLM
+    interaction), so this sentinel is just a typing-stable placeholder
+    that lets us avoid bootstrapping the real client when the LLM
+    provider is unavailable.
+    """
+
+    def complete_json(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
+        raise RuntimeError("_NullLLMClient.complete_json should never be called — empty backlog short-circuit only")
 
 
 # ---------------------------------------------------------------------------

--- a/backend/unified_api/routes/product_delivery.py
+++ b/backend/unified_api/routes/product_delivery.py
@@ -190,6 +190,14 @@ def patch_status(kind: _StatusKind, entity_id: str, body: StatusUpdate) -> dict[
 
 @router.patch("/{kind}/{entity_id}/scores")
 def patch_scores(kind: _ScoredKind, entity_id: str, body: ScoreUpdate) -> dict[str, Any]:
+    # Distinguish "bad request" from "not found" so clients can branch
+    # correctly on retry / create flows. An empty body is a 400 even if
+    # the entity exists; an unknown id is a 404.
+    if body.wsjf_score is None and body.rice_score is None:
+        raise HTTPException(
+            status_code=400,
+            detail="at least one of wsjf_score / rice_score must be supplied",
+        )
     try:
         ok = get_store().update_scores(
             kind=kind,
@@ -200,10 +208,7 @@ def patch_scores(kind: _ScoredKind, entity_id: str, body: ScoreUpdate) -> dict[s
     except ProductDeliveryStorageUnavailable as exc:
         raise HTTPException(status_code=503, detail=str(exc)) from exc
     if not ok:
-        raise HTTPException(
-            status_code=404,
-            detail=f"unknown {kind} or no score fields supplied: {entity_id}",
-        )
+        raise HTTPException(status_code=404, detail=f"unknown {kind}: {entity_id}")
     return {"ok": True, "kind": kind, "id": entity_id}
 
 

--- a/backend/unified_api/routes/product_delivery.py
+++ b/backend/unified_api/routes/product_delivery.py
@@ -209,60 +209,41 @@ def patch_scores(kind: _ScoredKind, entity_id: str, body: ScoreUpdate) -> dict[s
 # ---------------------------------------------------------------------------
 
 
+def _llm_client_factory() -> Any:
+    """Bootstrap the LLM client lazily.
+
+    Both the import and the ``get_client`` call can fail (missing strands
+    plugin, bad credentials, broken provider). Wrapping them in a single
+    callable lets the agent invoke it only when the backlog is non-empty,
+    and lets the agent's existing ``LLMScoringUnavailable`` path handle
+    failures without an extra try/except in the route. Tests stub by
+    monkeypatching ``sys.modules['llm_service']``.
+    """
+    from llm_service import get_client  # noqa: PLC0415 — tests stub via sys.modules
+
+    return get_client("product_owner")
+
+
 @router.post("/groom", response_model=GroomResult)
 def groom(body: GroomRequest) -> GroomResult:
     store = get_store()
     if store.get_product(body.product_id) is None:
         raise HTTPException(status_code=404, detail=f"unknown product: {body.product_id}")
 
-    # Defer LLM client bootstrap until we actually need it: a product
-    # with no stories short-circuits to an empty `GroomResult` without
-    # any LLM call, so we shouldn't fail with 503 here when the LLM
-    # provider is down. The agent itself does the empty-backlog check.
-    if not store.list_stories_for_product(body.product_id):
-        agent = ProductOwnerAgent(store=store, llm_client=_NullLLMClient())
-        return agent.groom(
-            product_id=body.product_id,
-            method=body.method,
-            persist=body.persist,
-        )
-
-    # `get_client` (and the `llm_service` import itself) can raise on
-    # misconfigured provider, missing credentials, or module/dependency
-    # import-time failures. Surface all of those as 503 (same shape as a
-    # Postgres outage) so clients see a consistent "transient
-    # infrastructure" signal instead of a bare 500.
-    try:
-        from llm_service import get_client  # noqa: PLC0415 — lazy: tests stub via override
-
-        llm_client = get_client("product_owner")
-    except Exception as exc:
-        logger.exception("ProductOwnerAgent: LLM client bootstrap failed")
-        raise HTTPException(
-            status_code=503,
-            detail=f"LLM client unavailable: {exc}",
-        ) from exc
-
-    agent = ProductOwnerAgent(store=store, llm_client=llm_client)
+    # The agent owns the empty-backlog short-circuit AND lazy LLM
+    # bootstrap, so:
+    #   * we don't double-scan the backlog (no pre-check + agent re-read);
+    #   * there's no race where a story lands between a pre-check and
+    #     the agent's read;
+    #   * an empty backlog never touches the LLM stack.
+    # Factory failures and call failures both surface as
+    # `LLMScoringUnavailable`, mapped to 503 by the global handler.
+    agent = ProductOwnerAgent(store=store, llm_factory=_llm_client_factory)
     return agent.groom(
         product_id=body.product_id,
         method=body.method,
         persist=body.persist,
     )
-
-
-class _NullLLMClient:
-    """Sentinel client used only when the backlog is empty.
-
-    The agent never calls ``complete_json`` on the empty-backlog path
-    (it short-circuits to ``GroomResult(ranked=[])`` before any LLM
-    interaction), so this sentinel is just a typing-stable placeholder
-    that lets us avoid bootstrapping the real client when the LLM
-    provider is unavailable.
-    """
-
-    def complete_json(self, *_args: Any, **_kwargs: Any) -> dict[str, Any]:  # pragma: no cover
-        raise RuntimeError("_NullLLMClient.complete_json should never be called — empty backlog short-circuit only")
 
 
 # ---------------------------------------------------------------------------

--- a/backend/unified_api/routes/product_delivery.py
+++ b/backend/unified_api/routes/product_delivery.py
@@ -49,6 +49,7 @@ from product_delivery.models import (
     TaskCreate,
 )
 from product_delivery.product_owner_agent import ProductOwnerAgent
+from product_delivery.product_owner_agent.agent import LLMScoringUnavailable
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +67,9 @@ _EXC_STATUS: dict[type[Exception], int] = {
     CrossProductFeedbackLink: 400,
     UnknownProductDeliveryEntity: 404,
     ProductDeliveryStorageUnavailable: 503,
+    # LLM transport/model/parse failures during /groom — clients retry
+    # the same way they do for a Postgres outage.
+    LLMScoringUnavailable: 503,
 }
 
 

--- a/backend/unified_api/routes/product_delivery.py
+++ b/backend/unified_api/routes/product_delivery.py
@@ -4,6 +4,12 @@ Phase 1 of issue #243. Mounted under ``/api/product-delivery`` directly
 on the unified API (this is an in-process module, not a proxy team).
 Sprint planning, releases, and the SE-pipeline integration ship in
 follow-up issues.
+
+Domain exceptions raised by ``product_delivery.store`` are mapped to
+HTTP statuses by the app-level handlers registered via
+:func:`register_pd_exception_handlers`. Routes therefore call the store
+directly and let the handlers translate failures — no per-route
+try/except chains.
 """
 
 from __future__ import annotations
@@ -11,7 +17,8 @@ from __future__ import annotations
 import logging
 from typing import Any, Literal
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
 
 from product_delivery import (
     AcceptanceCriterion,
@@ -49,37 +56,50 @@ router = APIRouter(prefix="/api/product-delivery", tags=["product-delivery"])
 
 
 # ---------------------------------------------------------------------------
+# Exception handlers — registered on the FastAPI app, not the router
+# (APIRouter doesn't support exception_handler). The mapping is the single
+# source of truth for status codes; tests register it the same way.
+# ---------------------------------------------------------------------------
+
+
+_EXC_STATUS: dict[type[Exception], int] = {
+    CrossProductFeedbackLink: 400,
+    UnknownProductDeliveryEntity: 404,
+    ProductDeliveryStorageUnavailable: 503,
+}
+
+
+def register_pd_exception_handlers(app: FastAPI) -> None:
+    for exc_cls, status_code in _EXC_STATUS.items():
+
+        @app.exception_handler(exc_cls)
+        async def _handler(_req: Request, exc: Exception, _s: int = status_code) -> JSONResponse:
+            return JSONResponse({"detail": str(exc)}, status_code=_s)
+
+
+# ---------------------------------------------------------------------------
 # Products
 # ---------------------------------------------------------------------------
 
 
 @router.post("/products", response_model=Product)
 def create_product(body: ProductCreate) -> Product:
-    try:
-        return get_store().create_product(
-            name=body.name,
-            description=body.description,
-            vision=body.vision,
-            author=resolve_author(),
-        )
-    except ProductDeliveryStorageUnavailable as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return get_store().create_product(
+        name=body.name,
+        description=body.description,
+        vision=body.vision,
+        author=resolve_author(),
+    )
 
 
 @router.get("/products", response_model=list[Product])
 def list_products() -> list[Product]:
-    try:
-        return get_store().list_products()
-    except ProductDeliveryStorageUnavailable as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return get_store().list_products()
 
 
 @router.get("/products/{product_id}/backlog", response_model=BacklogTree)
 def get_backlog(product_id: str) -> BacklogTree:
-    try:
-        tree = get_store().get_backlog_tree(product_id)
-    except ProductDeliveryStorageUnavailable as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    tree = get_store().get_backlog_tree(product_id)
     if tree is None:
         raise HTTPException(status_code=404, detail=f"unknown product: {product_id}")
     return tree
@@ -92,85 +112,60 @@ def get_backlog(product_id: str) -> BacklogTree:
 
 @router.post("/initiatives", response_model=Initiative)
 def create_initiative(body: InitiativeCreate) -> Initiative:
-    try:
-        return get_store().create_initiative(
-            product_id=body.product_id,
-            title=body.title,
-            summary=body.summary,
-            status=body.status,
-            author=resolve_author(),
-        )
-    except UnknownProductDeliveryEntity as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except ProductDeliveryStorageUnavailable as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return get_store().create_initiative(
+        product_id=body.product_id,
+        title=body.title,
+        summary=body.summary,
+        status=body.status,
+        author=resolve_author(),
+    )
 
 
 @router.post("/epics", response_model=Epic)
 def create_epic(body: EpicCreate) -> Epic:
-    try:
-        return get_store().create_epic(
-            initiative_id=body.initiative_id,
-            title=body.title,
-            summary=body.summary,
-            status=body.status,
-            author=resolve_author(),
-        )
-    except UnknownProductDeliveryEntity as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except ProductDeliveryStorageUnavailable as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return get_store().create_epic(
+        initiative_id=body.initiative_id,
+        title=body.title,
+        summary=body.summary,
+        status=body.status,
+        author=resolve_author(),
+    )
 
 
 @router.post("/stories", response_model=Story)
 def create_story(body: StoryCreate) -> Story:
-    try:
-        return get_store().create_story(
-            epic_id=body.epic_id,
-            title=body.title,
-            user_story=body.user_story,
-            status=body.status,
-            estimate_points=body.estimate_points,
-            author=resolve_author(),
-        )
-    except UnknownProductDeliveryEntity as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except ProductDeliveryStorageUnavailable as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return get_store().create_story(
+        epic_id=body.epic_id,
+        title=body.title,
+        user_story=body.user_story,
+        status=body.status,
+        estimate_points=body.estimate_points,
+        author=resolve_author(),
+    )
 
 
 @router.post("/tasks", response_model=Task)
 def create_task(body: TaskCreate) -> Task:
-    try:
-        return get_store().create_task(
-            story_id=body.story_id,
-            title=body.title,
-            description=body.description,
-            status=body.status,
-            owner=body.owner,
-            author=resolve_author(),
-        )
-    except UnknownProductDeliveryEntity as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except ProductDeliveryStorageUnavailable as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return get_store().create_task(
+        story_id=body.story_id,
+        title=body.title,
+        description=body.description,
+        status=body.status,
+        owner=body.owner,
+        author=resolve_author(),
+    )
 
 
 @router.post("/acceptance-criteria", response_model=AcceptanceCriterion)
 def create_acceptance_criterion(
     body: AcceptanceCriterionCreate,
 ) -> AcceptanceCriterion:
-    try:
-        return get_store().create_acceptance_criterion(
-            story_id=body.story_id,
-            text=body.text,
-            satisfied=body.satisfied,
-            author=resolve_author(),
-        )
-    except UnknownProductDeliveryEntity as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except ProductDeliveryStorageUnavailable as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return get_store().create_acceptance_criterion(
+        story_id=body.story_id,
+        text=body.text,
+        satisfied=body.satisfied,
+        author=resolve_author(),
+    )
 
 
 _StatusKind = Literal["initiative", "epic", "story", "task"]
@@ -179,11 +174,7 @@ _ScoredKind = Literal["initiative", "epic", "story"]
 
 @router.patch("/{kind}/{entity_id}/status")
 def patch_status(kind: _StatusKind, entity_id: str, body: StatusUpdate) -> dict[str, Any]:
-    try:
-        ok = get_store().update_status(kind=kind, entity_id=entity_id, status=body.status)
-    except ProductDeliveryStorageUnavailable as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
-    if not ok:
+    if not get_store().update_status(kind=kind, entity_id=entity_id, status=body.status):
         raise HTTPException(status_code=404, detail=f"unknown {kind}: {entity_id}")
     return {"ok": True, "kind": kind, "id": entity_id, "status": body.status}
 
@@ -198,15 +189,12 @@ def patch_scores(kind: _ScoredKind, entity_id: str, body: ScoreUpdate) -> dict[s
             status_code=400,
             detail="at least one of wsjf_score / rice_score must be supplied",
         )
-    try:
-        ok = get_store().update_scores(
-            kind=kind,
-            entity_id=entity_id,
-            wsjf_score=body.wsjf_score,
-            rice_score=body.rice_score,
-        )
-    except ProductDeliveryStorageUnavailable as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    ok = get_store().update_scores(
+        kind=kind,
+        entity_id=entity_id,
+        wsjf_score=body.wsjf_score,
+        rice_score=body.rice_score,
+    )
     if not ok:
         raise HTTPException(status_code=404, detail=f"unknown {kind}: {entity_id}")
     return {"ok": True, "kind": kind, "id": entity_id}
@@ -219,35 +207,31 @@ def patch_scores(kind: _ScoredKind, entity_id: str, body: ScoreUpdate) -> dict[s
 
 @router.post("/groom", response_model=GroomResult)
 def groom(body: GroomRequest) -> GroomResult:
+    store = get_store()
+    if store.get_product(body.product_id) is None:
+        raise HTTPException(status_code=404, detail=f"unknown product: {body.product_id}")
+
+    from llm_service import get_client  # noqa: PLC0415 — lazy: tests stub via override
+
+    # `get_client` can raise on misconfigured provider, missing credentials,
+    # or import-time failures inside the LLM stack. Surface those as 503
+    # (same shape as a Postgres outage) so clients see a consistent
+    # "transient infrastructure" signal instead of a bare 500.
     try:
-        store = get_store()
-        if store.get_product(body.product_id) is None:
-            raise HTTPException(status_code=404, detail=f"unknown product: {body.product_id}")
+        llm_client = get_client("product_owner")
+    except Exception as exc:
+        logger.exception("ProductOwnerAgent: LLM client bootstrap failed")
+        raise HTTPException(
+            status_code=503,
+            detail=f"LLM client unavailable: {exc}",
+        ) from exc
 
-        from llm_service import get_client  # noqa: PLC0415 — lazy: tests stub via override
-
-        # `get_client` can raise on misconfigured provider, missing
-        # credentials, or import-time failures inside the LLM stack.
-        # Surface those as 503 (same shape as a Postgres outage) so
-        # clients see a consistent "transient infrastructure" signal
-        # instead of a 500 from a bare exception.
-        try:
-            llm_client = get_client("product_owner")
-        except Exception as exc:
-            logger.exception("ProductOwnerAgent: LLM client bootstrap failed")
-            raise HTTPException(
-                status_code=503,
-                detail=f"LLM client unavailable: {exc}",
-            ) from exc
-
-        agent = ProductOwnerAgent(store=store, llm_client=llm_client)
-        return agent.groom(
-            product_id=body.product_id,
-            method=body.method,
-            persist=body.persist,
-        )
-    except ProductDeliveryStorageUnavailable as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    agent = ProductOwnerAgent(store=store, llm_client=llm_client)
+    return agent.groom(
+        product_id=body.product_id,
+        method=body.method,
+        persist=body.persist,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -257,21 +241,14 @@ def groom(body: GroomRequest) -> GroomResult:
 
 @router.post("/feedback", response_model=FeedbackItem)
 def create_feedback(body: FeedbackItemCreate) -> FeedbackItem:
-    try:
-        return get_store().create_feedback_item(
-            product_id=body.product_id,
-            source=body.source,
-            raw_payload=body.raw_payload,
-            severity=body.severity,
-            linked_story_id=body.linked_story_id,
-            author=resolve_author(),
-        )
-    except CrossProductFeedbackLink as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-    except UnknownProductDeliveryEntity as exc:
-        raise HTTPException(status_code=404, detail=str(exc)) from exc
-    except ProductDeliveryStorageUnavailable as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    return get_store().create_feedback_item(
+        product_id=body.product_id,
+        source=body.source,
+        raw_payload=body.raw_payload,
+        severity=body.severity,
+        linked_story_id=body.linked_story_id,
+        author=resolve_author(),
+    )
 
 
 @router.get("/feedback", response_model=list[FeedbackItem])
@@ -279,12 +256,9 @@ def list_feedback(
     product_id: str,
     status: str | None = None,
 ) -> list[FeedbackItem]:
-    try:
-        store = get_store()
-        # Match the 404 semantics of /backlog, /groom, and feedback POST:
-        # an unknown product is a hard error, not "no feedback yet".
-        if store.get_product(product_id) is None:
-            raise HTTPException(status_code=404, detail=f"unknown product: {product_id}")
-        return store.list_feedback(product_id, status=status)
-    except ProductDeliveryStorageUnavailable as exc:
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    store = get_store()
+    # Match the 404 semantics of /backlog, /groom, and feedback POST:
+    # an unknown product is a hard error, not "no feedback yet".
+    if store.get_product(product_id) is None:
+        raise HTTPException(status_code=404, detail=f"unknown product: {product_id}")
+    return store.list_feedback(product_id, status=status)

--- a/backend/unified_api/routes/product_delivery.py
+++ b/backend/unified_api/routes/product_delivery.py
@@ -227,16 +227,13 @@ def _llm_client_factory() -> Any:
 @router.post("/groom", response_model=GroomResult)
 def groom(body: GroomRequest) -> GroomResult:
     store = get_store()
-    if store.get_product(body.product_id) is None:
-        raise HTTPException(status_code=404, detail=f"unknown product: {body.product_id}")
-
-    # The agent owns the empty-backlog short-circuit AND lazy LLM
-    # bootstrap, so:
-    #   * we don't double-scan the backlog (no pre-check + agent re-read);
-    #   * there's no race where a story lands between a pre-check and
-    #     the agent's read;
-    #   * an empty backlog never touches the LLM stack.
-    # Factory failures and call failures both surface as
+    # No standalone existence check here — `agent.groom` calls
+    # `store.list_stories_for_product`, which raises
+    # `UnknownProductDeliveryEntity` (mapped to 404 by the global
+    # handler) inside a single transaction with the product-existence
+    # SELECT. So a concurrent delete can't slip past as `200 []`.
+    #
+    # Factory failures and LLM call failures both surface as
     # `LLMScoringUnavailable`, mapped to 503 by the global handler.
     agent = ProductOwnerAgent(store=store, llm_factory=_llm_client_factory)
     return agent.groom(
@@ -268,9 +265,8 @@ def list_feedback(
     product_id: str,
     status: str | None = None,
 ) -> list[FeedbackItem]:
-    store = get_store()
-    # Match the 404 semantics of /backlog, /groom, and feedback POST:
-    # an unknown product is a hard error, not "no feedback yet".
-    if store.get_product(product_id) is None:
-        raise HTTPException(status_code=404, detail=f"unknown product: {product_id}")
-    return store.list_feedback(product_id, status=status)
+    # `store.list_feedback` checks product existence in the same
+    # transaction as the SELECT and raises `UnknownProductDeliveryEntity`
+    # (→ 404) when the product is missing — no TOCTTOU window where a
+    # concurrent delete could turn a 404 into a `200 []`.
+    return get_store().list_feedback(product_id, status=status)

--- a/backend/unified_api/routes/product_delivery.py
+++ b/backend/unified_api/routes/product_delivery.py
@@ -1,0 +1,263 @@
+"""Product Delivery — backlog CRUD, grooming, feedback intake.
+
+Phase 1 of issue #243. Mounted under ``/api/product-delivery`` directly
+on the unified API (this is an in-process module, not a proxy team).
+Sprint planning, releases, and the SE-pipeline integration ship in
+follow-up issues.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal
+
+from fastapi import APIRouter, HTTPException
+
+from product_delivery import (
+    AcceptanceCriterion,
+    BacklogTree,
+    Epic,
+    FeedbackItem,
+    GroomRequest,
+    GroomResult,
+    Initiative,
+    Product,
+    ProductDeliveryStorageUnavailable,
+    Story,
+    Task,
+    UnknownProductDeliveryEntity,
+    get_store,
+    resolve_author,
+)
+from product_delivery.models import (
+    AcceptanceCriterionCreate,
+    EpicCreate,
+    FeedbackItemCreate,
+    InitiativeCreate,
+    ProductCreate,
+    ScoreUpdate,
+    StatusUpdate,
+    StoryCreate,
+    TaskCreate,
+)
+from product_delivery.product_owner_agent import ProductOwnerAgent
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/product-delivery", tags=["product-delivery"])
+
+
+# ---------------------------------------------------------------------------
+# Products
+# ---------------------------------------------------------------------------
+
+
+@router.post("/products", response_model=Product)
+def create_product(body: ProductCreate) -> Product:
+    try:
+        return get_store().create_product(
+            name=body.name,
+            description=body.description,
+            vision=body.vision,
+            author=resolve_author(),
+        )
+    except ProductDeliveryStorageUnavailable as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+@router.get("/products", response_model=list[Product])
+def list_products() -> list[Product]:
+    try:
+        return get_store().list_products()
+    except ProductDeliveryStorageUnavailable as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+@router.get("/products/{product_id}/backlog", response_model=BacklogTree)
+def get_backlog(product_id: str) -> BacklogTree:
+    try:
+        tree = get_store().get_backlog_tree(product_id)
+    except ProductDeliveryStorageUnavailable as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    if tree is None:
+        raise HTTPException(status_code=404, detail=f"unknown product: {product_id}")
+    return tree
+
+
+# ---------------------------------------------------------------------------
+# Backlog hierarchy CRUD
+# ---------------------------------------------------------------------------
+
+
+@router.post("/initiatives", response_model=Initiative)
+def create_initiative(body: InitiativeCreate) -> Initiative:
+    try:
+        return get_store().create_initiative(
+            product_id=body.product_id,
+            title=body.title,
+            summary=body.summary,
+            status=body.status,
+            author=resolve_author(),
+        )
+    except UnknownProductDeliveryEntity as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ProductDeliveryStorageUnavailable as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+@router.post("/epics", response_model=Epic)
+def create_epic(body: EpicCreate) -> Epic:
+    try:
+        return get_store().create_epic(
+            initiative_id=body.initiative_id,
+            title=body.title,
+            summary=body.summary,
+            status=body.status,
+            author=resolve_author(),
+        )
+    except UnknownProductDeliveryEntity as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ProductDeliveryStorageUnavailable as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+@router.post("/stories", response_model=Story)
+def create_story(body: StoryCreate) -> Story:
+    try:
+        return get_store().create_story(
+            epic_id=body.epic_id,
+            title=body.title,
+            user_story=body.user_story,
+            status=body.status,
+            estimate_points=body.estimate_points,
+            author=resolve_author(),
+        )
+    except UnknownProductDeliveryEntity as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ProductDeliveryStorageUnavailable as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+@router.post("/tasks", response_model=Task)
+def create_task(body: TaskCreate) -> Task:
+    try:
+        return get_store().create_task(
+            story_id=body.story_id,
+            title=body.title,
+            description=body.description,
+            status=body.status,
+            owner=body.owner,
+            author=resolve_author(),
+        )
+    except UnknownProductDeliveryEntity as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ProductDeliveryStorageUnavailable as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+@router.post("/acceptance-criteria", response_model=AcceptanceCriterion)
+def create_acceptance_criterion(
+    body: AcceptanceCriterionCreate,
+) -> AcceptanceCriterion:
+    try:
+        return get_store().create_acceptance_criterion(
+            story_id=body.story_id,
+            text=body.text,
+            satisfied=body.satisfied,
+            author=resolve_author(),
+        )
+    except UnknownProductDeliveryEntity as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ProductDeliveryStorageUnavailable as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+_StatusKind = Literal["initiative", "epic", "story", "task"]
+_ScoredKind = Literal["initiative", "epic", "story"]
+
+
+@router.patch("/{kind}/{entity_id}/status")
+def patch_status(kind: _StatusKind, entity_id: str, body: StatusUpdate) -> dict[str, Any]:
+    try:
+        ok = get_store().update_status(kind=kind, entity_id=entity_id, status=body.status)
+    except ProductDeliveryStorageUnavailable as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    if not ok:
+        raise HTTPException(status_code=404, detail=f"unknown {kind}: {entity_id}")
+    return {"ok": True, "kind": kind, "id": entity_id, "status": body.status}
+
+
+@router.patch("/{kind}/{entity_id}/scores")
+def patch_scores(kind: _ScoredKind, entity_id: str, body: ScoreUpdate) -> dict[str, Any]:
+    try:
+        ok = get_store().update_scores(
+            kind=kind,
+            entity_id=entity_id,
+            wsjf_score=body.wsjf_score,
+            rice_score=body.rice_score,
+        )
+    except ProductDeliveryStorageUnavailable as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    if not ok:
+        raise HTTPException(
+            status_code=404,
+            detail=f"unknown {kind} or no score fields supplied: {entity_id}",
+        )
+    return {"ok": True, "kind": kind, "id": entity_id}
+
+
+# ---------------------------------------------------------------------------
+# Grooming
+# ---------------------------------------------------------------------------
+
+
+@router.post("/groom", response_model=GroomResult)
+def groom(body: GroomRequest) -> GroomResult:
+    try:
+        store = get_store()
+    except ProductDeliveryStorageUnavailable as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    if store.get_product(body.product_id) is None:
+        raise HTTPException(status_code=404, detail=f"unknown product: {body.product_id}")
+
+    from llm_service import get_client  # noqa: PLC0415 — lazy: tests stub via override
+
+    agent = ProductOwnerAgent(store=store, llm_client=get_client("product_owner"))
+    return agent.groom(
+        product_id=body.product_id,
+        method=body.method,
+        persist=body.persist,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Feedback intake
+# ---------------------------------------------------------------------------
+
+
+@router.post("/feedback", response_model=FeedbackItem)
+def create_feedback(body: FeedbackItemCreate) -> FeedbackItem:
+    try:
+        return get_store().create_feedback_item(
+            product_id=body.product_id,
+            source=body.source,
+            raw_payload=body.raw_payload,
+            severity=body.severity,
+            linked_story_id=body.linked_story_id,
+            author=resolve_author(),
+        )
+    except UnknownProductDeliveryEntity as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except ProductDeliveryStorageUnavailable as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+@router.get("/feedback", response_model=list[FeedbackItem])
+def list_feedback(
+    product_id: str,
+    status: str | None = None,
+) -> list[FeedbackItem]:
+    try:
+        return get_store().list_feedback(product_id, status=status)
+    except ProductDeliveryStorageUnavailable as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc

--- a/backend/unified_api/tests/test_config.py
+++ b/backend/unified_api/tests/test_config.py
@@ -105,16 +105,20 @@ def test_blogging_team_config_structure():
 def test_product_delivery_listed_for_security_gateway_scanning():
     """product_delivery is an in-process module mounted by unified_api.
 
-    It must appear in TEAM_CONFIGS so the security gateway middleware's
-    `_get_team_prefixes()` includes `/api/product-delivery` and scans
-    bodies. It is `enabled=False` so `_register_proxy_routes` skips
-    proxy registration (there is no separate container to forward to).
+    Marked `in_process=True` (and `enabled=True`) so:
+
+    * `_get_team_prefixes()` includes `/api/product-delivery` and the
+      security gateway middleware scans bodies.
+    * `_register_proxy_routes` skips proxy registration (no container).
+    * Discovery surfaces (`/teams`, `/health`, `/`) report it as live
+      because the in-process router actually serves the route.
     """
     from unified_api.middleware.security_gateway import _get_team_prefixes
 
     cfg = TEAM_CONFIGS["product_delivery"]
     assert cfg.prefix == "/api/product-delivery"
-    assert cfg.enabled is False
+    assert cfg.enabled is True
+    assert cfg.in_process is True
     assert "/api/product-delivery" in _get_team_prefixes()
 
 

--- a/backend/unified_api/tests/test_config.py
+++ b/backend/unified_api/tests/test_config.py
@@ -102,6 +102,22 @@ def test_blogging_team_config_structure():
     assert "blogging" in cfg.tags
 
 
+def test_product_delivery_listed_for_security_gateway_scanning():
+    """product_delivery is an in-process module mounted by unified_api.
+
+    It must appear in TEAM_CONFIGS so the security gateway middleware's
+    `_get_team_prefixes()` includes `/api/product-delivery` and scans
+    bodies. It is `enabled=False` so `_register_proxy_routes` skips
+    proxy registration (there is no separate container to forward to).
+    """
+    from unified_api.middleware.security_gateway import _get_team_prefixes
+
+    cfg = TEAM_CONFIGS["product_delivery"]
+    assert cfg.prefix == "/api/product-delivery"
+    assert cfg.enabled is False
+    assert "/api/product-delivery" in _get_team_prefixes()
+
+
 def test_software_engineering_team_config_structure():
     """Software engineering team config has correct prefix."""
     cfg = TEAM_CONFIGS["software_engineering"]

--- a/backend/unified_api/tests/test_sandboxes_route.py
+++ b/backend/unified_api/tests/test_sandboxes_route.py
@@ -117,5 +117,3 @@ def test_status_reconciles_vanished_container(client: TestClient, monkeypatch) -
     resp = client.get("/api/agents/sandboxes/blogging.planner")
     assert resp.status_code == 200
     assert resp.json()["status"] == SandboxStatus.COLD
-
-


### PR DESCRIPTION
First vertical slice of issue #243 ("SE team: persistent Product Delivery Loop") — recommendation #1 from the Principal-Engineer SDLC review. Lands the foundation (Postgres-backed backlog + Product Owner grooming + standalone API) and explicitly defers sprint/release/UI work to follow-up issues so this PR stays reviewable.

## Summary

- New in-process team `backend/agents/product_delivery/` mounted under `/api/product-delivery` by the unified API (not a proxy team).
- Postgres schema (`product_delivery_*` tables) registered via `shared_postgres` Pattern B at unified-API startup. Schema mirrors the SE Tech Lead's Initiative → Epic → Story → Task hierarchy so the SE team can later persist its `PlanningHierarchy` directly.
- `ProductOwnerAgent` ranks stories with **WSJF** or **RICE**. The agent only asks the LLM for *scoring inputs*; the scores themselves are computed by the deterministic functions in `scoring.py`, so a re-groom over the same backlog produces stable, auditable numbers.
- Every row is tagged with the shared `agent_console.author.resolve_author()` handle so we can migrate to real auth alongside the agent_console rows.

## What landed

- `product_delivery/postgres/__init__.py` — `SCHEMA: TeamSchema` for `products`, `initiatives`, `epics`, `stories`, `tasks`, `acceptance_criteria`, `feedback_items`.
- `product_delivery/models.py` — Pydantic models + nested-tree projections.
- `product_delivery/store.py` — `ProductDeliveryStore` mirroring `agent_console.store` (stateless, `@timed_query`, typed domain exceptions).
- `product_delivery/scoring.py` — pure WSJF / RICE functions, rounded to four decimals.
- `product_delivery/product_owner_agent/` — `ProductOwnerAgent` + prompts.
- `unified_api/routes/product_delivery.py` — APIRouter mounted in the unified API (CRUD for the full hierarchy, PATCH for status/scores, `POST /groom`, feedback intake + listing).
- `unified_api/main.py` — schema registered in the existing lifespan alongside `agent_console`.
- `shared_postgres/registry.py` — `product_delivery` added so CLI/test harnesses can register the schema directly.
- `CLAUDE.md` + `backend/agents/product_delivery/README.md`.

## API surface

```
POST   /api/product-delivery/products
GET    /api/product-delivery/products
GET    /api/product-delivery/products/{id}/backlog          (nested tree)

POST   /api/product-delivery/initiatives | epics | stories | tasks | acceptance-criteria
PATCH  /api/product-delivery/{kind}/{id}/status
PATCH  /api/product-delivery/{kind}/{id}/scores

POST   /api/product-delivery/groom                          (WSJF or RICE)
POST   /api/product-delivery/feedback
GET    /api/product-delivery/feedback?product_id=…&status=open
```

## Deferred to follow-up issues (will be filed alongside this PR)

- Sprint planner + `sprints` / `releases` tables — wire `POST /api/software-engineering/run-team` to accept `{sprint_id}` and pull scope from the backlog; planning cache scoped per sprint.
- `ReleaseManagerAgent` + release notes hooked into Integration; writes `plan/releases/<version>.md` and opens a `feedback_items` bucket for the new release.
- Agent Console "Backlog" + "Sprints" tabs (Angular) mirroring agent_console Phase 3 patterns.
- `ARCHITECTURE.md` "Product Delivery Loop" section — lands with the SE-pipeline integration above.

## Test plan

- [x] `ruff check` + `ruff format --check` clean across new + modified files.
- [x] `pytest agents/product_delivery/tests/` — 21 unit tests pass (scoring, agent with stub LLM, API with in-memory fake store).
- [x] Store integration tests skip without `POSTGRES_HOST` (matches the agent_console pattern). `pytest -m integration` will exercise them in CI.
- [x] Existing `agent_console` unit tests still pass after the unified_api lifespan / router edits.
- [ ] Manual smoke against a live Postgres:
  ```bash
  docker compose -f docker/docker-compose.yml up -d postgres job-service
  export POSTGRES_HOST=localhost POSTGRES_PORT=5432 POSTGRES_USER=postgres POSTGRES_PASSWORD=postgres POSTGRES_DB=postgres JOB_SERVICE_URL=http://localhost:8085
  cd backend && make run
  psql -h localhost -U postgres -c "\dt product_delivery_*"   # 7 tables expected
  curl -sX POST localhost:8080/api/product-delivery/products -H 'content-type: application/json' -d '{"name":"Demo"}'
  ```

Closes a vertical slice of #243; remaining acceptance criteria tracked in the follow-up issues.

https://claude.ai/code/session_01Es8icBkjUT21zuPruVVaxb

---
_Generated by [Claude Code](https://claude.ai/code/session_01Es8icBkjUT21zuPruVVaxb)_