### PR TITLE
shared_observability: stop logging endpoint=&lt;default&gt; when OTLP export is disabled

### DIFF
--- a/backend/agents/shared_observability/otel.py
+++ b/backend/agents/shared_observability/otel.py
@@ -126,9 +126,28 @@ def init_otel(
             "OpenTelemetry initialized: service=%s team=%s endpoint=%s",
             _service_name,
             team_key,
-            os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT", "<default>"),
+            _resolve_endpoint_for_log(),
         )
         return True
+
+
+def _resolve_endpoint_for_log() -> str:
+    """Render the configured OTLP endpoint for the init log line.
+
+    When no endpoint is set we skip exporter construction entirely (see
+    ``_otlp_endpoint_configured``), so logging ``<default>`` is misleading —
+    nothing is exported. Surface that explicitly so operators can tell at
+    a glance whether spans are leaving the process.
+    """
+    for var in (
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+    ):
+        value = os.environ.get(var, "").strip()
+        if value:
+            return value
+    return "<none; export disabled>"
 
 
 def _otlp_endpoint_configured() -> bool:

--- a/backend/agents/shared_observability/tests/test_otel.py
+++ b/backend/agents/shared_observability/tests/test_otel.py
@@ -53,6 +53,29 @@ def test_init_otel_reports_enabled() -> None:
     assert is_otel_enabled() is True
 
 
+def test_resolve_endpoint_for_log_reflects_export_state(monkeypatch) -> None:
+    """The init log must distinguish 'no exporter' from 'real endpoint'."""
+    from shared_observability.otel import _resolve_endpoint_for_log
+
+    for var in (
+        "OTEL_EXPORTER_OTLP_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+        "OTEL_EXPORTER_OTLP_METRICS_ENDPOINT",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+    rendered = _resolve_endpoint_for_log()
+    assert "<default>" not in rendered
+    assert "none" in rendered.lower()
+
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://collector:4318")
+    assert _resolve_endpoint_for_log() == "http://collector:4318"
+
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "http://traces:4318")
+    assert _resolve_endpoint_for_log() == "http://traces:4318"
+
+
 def test_get_tracer_and_meter_surface_is_usable() -> None:
     """Tracer and meter returned by the helpers must support the common API."""
     from shared_observability import get_meter, get_tracer


### PR DESCRIPTION
## Summary

- The `init_otel` log line read `endpoint=<default>` whenever no OTLP collector was configured, directly contradicting the preceding "OTLP endpoint not configured; spans will not be exported" message and making it hard to tell from logs whether spans were actually leaving the process.
- Render the configured endpoint via a small helper that returns the first set `OTEL_EXPORTER_OTLP{,_TRACES,_METRICS}_ENDPOINT`, or `<none; export disabled>` when none are set — so the log line matches the actual export state.
- Pin the new behaviour with a focused unit test in `shared_observability/tests/test_otel.py` so the misleading `<default>` placeholder cannot regress.

### Before

```
shared_observability.otel: OTLP endpoint not configured (OTEL_EXPORTER_OTLP_ENDPOINT unset); spans will not be exported.
shared_observability.otel: OpenTelemetry initialized: service=investment_team team=investment_team endpoint=<default>
```

### After

```
shared_observability.otel: OTLP endpoint not configured (OTEL_EXPORTER_OTLP_ENDPOINT unset); spans will not be exported.
shared_observability.otel: OpenTelemetry initialized: service=investment_team team=investment_team endpoint=<none; export disabled>
```

When `OTEL_EXPORTER_OTLP_ENDPOINT` (or the trace/metric-specific variants) is set, the log shows the actual URL, unchanged from before.

## Test plan

- [x] `ruff check` + `ruff format --check` clean for `agents/shared_observability/`.
- [x] Manually exercised `_resolve_endpoint_for_log` for unset, set, traces-only, and whitespace-only env states — all produce the expected strings.
- [ ] CI runs `pytest agents/shared_observability/tests/test_otel.py` (the new `test_resolve_endpoint_for_log_reflects_export_state` case is covered there).

## Out of scope

- Provisioning a real OTLP collector in `docker/docker-compose.yml` (no env var changes; default behaviour is still "no exporter, spans stay in-process").
- The unrelated `ModuleNotFoundError: No module named 'pyarrow'` crash-loop visible in the same investment_team logs — that's a separate dependency issue in `investment_team/market_data_cache/store.py` and should ship in its own PR.

https://claude.ai/code/session_019J5Cq1Ke5BBKScmxd59Tb7

---
_Generated by [Claude Code](https://claude.ai/code/session_019J5Cq1Ke5BBKScmxd59Tb7)_