### PR TITLE
investment_team: PendingOrder fields + OrderBook primitives (#384)

### DIFF
--- a/backend/agents/investment_team/execution/bar_safety.py
+++ b/backend/agents/investment_team/execution/bar_safety.py
@@ -9,14 +9,65 @@ future engine refactor that accidentally fills an order against the same
 bar on which it was submitted surfaces as a hard error instead of silently
 producing inflated backtest results.
 
-``BarSafetyAssertion`` is intentionally tiny: a timestamp comparison gated
-on an ``enabled`` flag.  The ``TradingService`` catches ``LookAheadError``
-and flips ``TradingServiceResult.lookahead_violation`` so the same
-classification that the subprocess harness emits also applies when the
-violation originates in the fill simulator.
+``BarSafetyAssertion`` is intentionally tiny: a chronological timestamp
+comparison gated on an ``enabled`` flag.  The ``TradingService`` catches
+``LookAheadError`` and flips ``TradingServiceResult.lookahead_violation``
+so the same classification that the subprocess harness emits also applies
+when the violation originates in the fill simulator.
 """
 
 from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Optional
+
+_COMPACT_OFFSET_RE = re.compile(r"([+-])(\d{2})(\d{2})$")
+
+
+def _normalize_ts(ts: str) -> str:
+    """Best-effort ISO 8601 input normaliser used as both a pre-parse step
+    (so ``datetime.fromisoformat`` accepts variants Python < 3.11 doesn't)
+    and the fallback string-compare value for unparseable inputs.
+    """
+    if not isinstance(ts, str):
+        return ts
+    if ts.endswith("Z"):
+        return ts[:-1] + "+00:00"
+    m = _COMPACT_OFFSET_RE.search(ts)
+    if m:
+        return ts[: m.start()] + f"{m.group(1)}{m.group(2)}:{m.group(3)}"
+    return ts
+
+
+def _try_parse_ts(ts: str) -> Optional[datetime]:
+    if not isinstance(ts, str):
+        return None
+    try:
+        return datetime.fromisoformat(_normalize_ts(ts))
+    except ValueError:
+        return None
+
+
+def _ts_le(a: str, b: str) -> bool:
+    """True iff ``a`` is chronologically ``<=`` ``b``.
+
+    Parses both as ISO 8601 datetimes when possible and compares them
+    chronologically — so equivalent instants in different timezone offsets
+    or formats (e.g. ``2024-01-02T10:00:00Z`` vs
+    ``2024-01-02T10:00:00+00:00``) compare equal instead of being ordered
+    by raw ASCII string ordering.
+
+    Falls back to normalised string comparison when one side fails to
+    parse, or when one side is naive and the other is timezone-aware
+    (Python raises ``TypeError`` on mixed-awareness datetime comparisons).
+    """
+    a_dt = _try_parse_ts(a)
+    b_dt = _try_parse_ts(b)
+    if a_dt is not None and b_dt is not None:
+        if (a_dt.tzinfo is None) == (b_dt.tzinfo is None):
+            return a_dt <= b_dt
+    return _normalize_ts(a) <= _normalize_ts(b)
 
 
 class LookAheadError(RuntimeError):
@@ -40,11 +91,14 @@ class LookAheadError(RuntimeError):
 class BarSafetyAssertion:
     """Stateless guard that enforces strict ``fill_bar > submitted_at``.
 
-    ISO-8601 timestamps compare correctly as plain strings for both daily
-    (``YYYY-MM-DD``) and intraday (``YYYY-MM-DDTHH:MM:SS``) formats, so the
-    check is a single lexicographic comparison.  When ``enabled=False`` the
-    assertion becomes a no-op — used only by tests that deliberately
-    construct pathological traces to verify the assertion fires when enabled.
+    Comparison is *chronological* — equivalent instants in different ISO 8601
+    encodings (``Z`` suffix vs ``+00:00``, compact ``+0000`` vs
+    ``+00:00``, equivalent offsets like ``+05:30`` vs ``+00:00``) are
+    treated as equal and correctly trip the guard. ``YYYY-MM-DD`` and
+    ``YYYY-MM-DDTHH:MM:SS`` (naive) inputs still compare lexicographically
+    via the fallback path. When ``enabled=False`` the assertion becomes a
+    no-op — used only by tests that deliberately construct pathological
+    traces to verify the assertion fires when enabled.
     """
 
     def __init__(self, *, enabled: bool = True) -> None:
@@ -63,7 +117,11 @@ class BarSafetyAssertion:
             # Missing metadata would make the comparison meaningless; skip
             # rather than false-positive on records predating this field.
             return
-        if fill_bar_timestamp <= submitted_at:
+        # ``fill_bar_timestamp <= submitted_at`` chronologically — i.e. the
+        # fill bar isn't *strictly* after the submission bar. Equivalent
+        # instants in different formats trip this branch (the canonical
+        # same-bar fill case) instead of falsely passing on ASCII ordering.
+        if _ts_le(fill_bar_timestamp, submitted_at):
             raise LookAheadError(
                 order_id=order_id,
                 submitted_at=submitted_at,

--- a/backend/agents/investment_team/tests/test_bar_safety.py
+++ b/backend/agents/investment_team/tests/test_bar_safety.py
@@ -96,6 +96,52 @@ def test_assertion_skips_blank_metadata() -> None:
     )
 
 
+def test_assertion_treats_z_and_offset_as_same_instant() -> None:
+    """``2024-01-02T10:00:00Z`` and ``2024-01-02T10:00:00+00:00`` are the
+    same instant. Lexicographic ASCII compare would see ``Z > +00:00``
+    (because ``Z`` 0x5A > ``+`` 0x2B) and falsely allow a same-bar fill;
+    chronological compare correctly trips the guard.
+    """
+    with pytest.raises(LookAheadError):
+        BarSafetyAssertion().check_fill(
+            order_id="o1",
+            submitted_at="2024-01-02T10:00:00+00:00",
+            fill_bar_timestamp="2024-01-02T10:00:00Z",
+        )
+    # And the other direction.
+    with pytest.raises(LookAheadError):
+        BarSafetyAssertion().check_fill(
+            order_id="o2",
+            submitted_at="2024-01-02T10:00:00Z",
+            fill_bar_timestamp="2024-01-02T10:00:00+00:00",
+        )
+
+
+def test_assertion_handles_compact_utc_offset() -> None:
+    """Same-instant compact-offset (``+0000``) vs colon-form (``+00:00``)
+    must not slip past the guard.
+    """
+    with pytest.raises(LookAheadError):
+        BarSafetyAssertion().check_fill(
+            order_id="o1",
+            submitted_at="2024-01-02T10:00:00+00:00",
+            fill_bar_timestamp="2024-01-02T10:00:00+0000",
+        )
+
+
+def test_assertion_treats_equivalent_offsets_as_same_instant() -> None:
+    """``2024-01-02T15:30:00+05:30`` is the same instant as
+    ``2024-01-02T10:00:00+00:00`` — chronological compare correctly trips
+    the guard regardless of which offset the caller used.
+    """
+    with pytest.raises(LookAheadError):
+        BarSafetyAssertion().check_fill(
+            order_id="o1",
+            submitted_at="2024-01-02T10:00:00+00:00",
+            fill_bar_timestamp="2024-01-02T15:30:00+05:30",
+        )
+
+
 # ---------------------------------------------------------------------------
 # Integration — FillSimulator with a pathological OrderBook
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -240,9 +240,10 @@ def test_requeue_normalizes_z_suffix_timestamp() -> None:
         new_submitted_at="2024-01-02T10:00:00Z",
     )
     assert po.remaining_qty == 4.0
-    # ``requeue`` canonicalises tz-aware timestamps to UTC ``+00:00`` form
-    # so all downstream consumers see a consistent string.
-    assert po.submitted_at == "2024-01-02T10:00:00+00:00"
+    # ``requeue`` stores the caller-supplied timestamp verbatim — the
+    # downstream look-ahead guard does its own chronological compare so we
+    # don't need to mangle the stored format.
+    assert po.submitted_at == "2024-01-02T10:00:00Z"
 
     # And the other direction: existing has Z suffix, new has +00:00 — also
     # not a regression.
@@ -2078,62 +2079,10 @@ def test_requeue_rejects_non_numeric_remaining_qty(bad_qty) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Timestamp canonicalisation: ``requeue`` normalises tz-aware values to UTC
-# ``+00:00`` form so the look-ahead guard in ``execution/bar_safety.py``
-# (which compares bar timestamps to ``po.submitted_at`` lexicographically)
-# doesn't false-reject mixed-offset traces.
+# Compact UTC offsets (``+0000`` / ``-0500``) are valid ISO 8601 but Python
+# 3.10's ``datetime.fromisoformat`` rejects them; ``_normalize_ts`` rewrites
+# them before parse so the regression check works correctly.
 # ---------------------------------------------------------------------------
-
-
-def test_requeue_canonicalizes_tz_aware_timestamp_to_utc() -> None:
-    """A non-UTC offset gets rewritten to the equivalent UTC instant."""
-    book = OrderBook()
-    po = book.submit(
-        _base(qty=10.0),
-        submitted_at="2024-01-02T05:00:00+00:00",
-        submitted_equity=100_000.0,
-    )
-    # 10:30 IST = 05:00 UTC (same instant); after canonicalisation the
-    # stored string is in UTC form regardless of caller-side offset.
-    book.requeue(
-        po.order_id,
-        new_remaining_qty=4.0,
-        new_submitted_at="2024-01-02T10:30:00+05:30",
-    )
-    assert po.submitted_at == "2024-01-02T05:00:00+00:00"
-
-
-def test_requeue_canonicalizes_compact_offset() -> None:
-    """``+0000`` (no colon) is a valid ISO 8601 offset that Python 3.10's
-    ``datetime.fromisoformat`` rejects; ``_normalize_ts`` rewrites it
-    before parse, and ``_canonicalize_ts`` then re-emits in canonical form.
-    """
-    book = OrderBook()
-    po = book.submit(
-        _base(qty=10.0),
-        submitted_at="2024-01-02T05:00:00+00:00",
-        submitted_equity=100_000.0,
-    )
-    book.requeue(
-        po.order_id,
-        new_remaining_qty=3.0,
-        new_submitted_at="2024-01-02T05:00:00+0000",
-    )
-    assert po.submitted_at == "2024-01-02T05:00:00+00:00"
-
-
-def test_requeue_does_not_canonicalize_naive_date_string() -> None:
-    """Naive (date-only / no-offset) inputs round-trip unchanged so existing
-    callers using simple date strings aren't mangled into datetime form.
-    """
-    book = OrderBook()
-    po = book.submit(
-        _base(qty=10.0),
-        submitted_at="2024-01-02",
-        submitted_equity=100_000.0,
-    )
-    book.requeue(po.order_id, new_remaining_qty=4.0, new_submitted_at="2024-01-03")
-    assert po.submitted_at == "2024-01-03"
 
 
 def test_requeue_handles_compact_offset_in_regression_check() -> None:

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -9,6 +9,8 @@ stop) can rely on it.
 
 from __future__ import annotations
 
+from datetime import datetime
+
 import pytest
 
 from investment_team.trading_service.engine.order_book import (
@@ -1554,6 +1556,92 @@ def test_filled_parent_evicted_when_only_child_terminal_fills() -> None:
             parent_order_id=parent.order_id,
             oco_group_id="g2",
         )
+
+
+def test_book_contains_membership_test() -> None:
+    """``order_id in book`` exposes pending membership for iteration patterns
+    (notably ``FillSimulator.process_bar``) that snapshot ``pending_for_symbol``
+    and need to skip orders cascade-cancelled mid-loop.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    assert po.order_id in book
+    assert "o-bogus" not in book
+    book.cancel(po.order_id)
+    assert po.order_id not in book
+
+
+def test_submit_attached_rejects_symbol_mismatch() -> None:
+    """A child must trade the same symbol as its parent. A typo would
+    otherwise route the child under the wrong symbol while still tagged
+    with the parent / OCO ids.
+    """
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0, symbol="AAA"),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    with pytest.raises(ValueError, match="does not match parent"):
+        book.submit_attached(
+            _base(qty=10.0, symbol="BBB", order_type=OrderType.LIMIT, limit_price=110.0),
+            submitted_at="2024-01-03",
+            submitted_equity=100_000.0,
+            parent_order_id=parent.order_id,
+            oco_group_id="g1",
+        )
+    assert book.children_of(parent.order_id) == []
+
+
+def test_submit_attached_accepts_matching_symbol_after_parent_filled() -> None:
+    """Symbol validation must work even after the parent has been removed
+    via ``remove(was_filled=True)`` — the parent's symbol stays cached in
+    ``_known_top_level_order_ids`` so post-fill activation can verify.
+    """
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0, symbol="AAA"),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    book.remove(parent.order_id, was_filled=True)
+    book.submit_attached(  # matching symbol — accepted
+        _base(qty=10.0, symbol="AAA", order_type=OrderType.LIMIT, limit_price=110.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    with pytest.raises(ValueError, match="does not match parent"):
+        book.submit_attached(
+            _base(qty=10.0, symbol="BBB", order_type=OrderType.STOP, stop_price=95.0),
+            submitted_at="2024-01-03",
+            submitted_equity=100_000.0,
+            parent_order_id=parent.order_id,
+            oco_group_id="g2",
+        )
+
+
+def test_requeue_rejects_non_string_submitted_at() -> None:
+    """``new_submitted_at`` must be a string. A non-string would otherwise
+    fall through to a raw ``<`` comparison and raise an unhelpful
+    ``TypeError``; reject up front with a controlled message.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    for bad in (None, 123, 1.5, datetime(2024, 1, 5)):
+        with pytest.raises(TypeError, match="must be a str"):
+            book.requeue(po.order_id, new_remaining_qty=5.0, new_submitted_at=bad)
+    # State unchanged.
+    assert po.remaining_qty == 10.0
 
 
 def test_no_auto_evict_while_parent_still_pending() -> None:

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -1,0 +1,333 @@
+"""Unit tests for ``OrderBook`` and ``PendingOrder`` extensions added in
+Trading 5/5 Step 2 (issue #384).
+
+Step 2 is purely additive plumbing. No engine or service caller wires up the
+new methods yet — these tests exercise the data-layer contract directly so
+later steps (#386 partial-fill requeue, #389 bracket / OCO, #390 trailing
+stop) can rely on it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from investment_team.trading_service.engine.order_book import (
+    OrderBook,
+    PendingOrder,
+)
+from investment_team.trading_service.strategy.contract import (
+    OrderRequest,
+    OrderSide,
+    OrderType,
+    UnsupportedOrderFeatureError,
+)
+
+
+def _base(**overrides) -> OrderRequest:
+    """Minimal ``OrderRequest`` mirroring the helper in ``test_contract_gates``."""
+    kwargs = {
+        "client_order_id": "x",
+        "symbol": "AAA",
+        "side": OrderSide.LONG,
+        "qty": 10.0,
+        "order_type": OrderType.MARKET,
+    }
+    kwargs.update(overrides)
+    return OrderRequest(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# PendingOrder field initialization
+# ---------------------------------------------------------------------------
+
+
+def test_submit_initializes_partial_fill_fields() -> None:
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    assert isinstance(po, PendingOrder)
+    assert po.original_qty == 10.0
+    assert po.remaining_qty == 10.0
+    assert po.cumulative_filled_qty == 0.0
+    assert po.twap_slices_remaining is None
+    assert po.effective_stop_price is None
+    assert po.trailing_water is None
+    assert po.armed is True
+    assert po.rejection_reason is None
+
+
+# ---------------------------------------------------------------------------
+# Submit → requeue → remove cycle
+# ---------------------------------------------------------------------------
+
+
+def test_submit_requeue_remove_cycle() -> None:
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    order_id = po.order_id
+
+    requeued = book.requeue(
+        order_id,
+        new_remaining_qty=4.0,
+        new_submitted_at="2024-01-03",
+    )
+    assert requeued is po  # same object, mutated in place
+    assert requeued.remaining_qty == 4.0
+    assert requeued.submitted_at == "2024-01-03"
+    assert requeued.original_qty == 10.0  # immutable
+
+    removed = book.remove(order_id)
+    assert removed is po
+    assert book.all_pending() == []
+    assert book.pending_for_symbol("AAA") == []
+
+
+# ---------------------------------------------------------------------------
+# requeue refreshes submitted_at and rejects regression
+# ---------------------------------------------------------------------------
+
+
+def test_requeue_refreshes_submitted_at() -> None:
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    book.requeue(po.order_id, new_remaining_qty=5.0, new_submitted_at="2024-01-05")
+    assert po.submitted_at == "2024-01-05"
+
+
+def test_requeue_stale_timestamp_raises() -> None:
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-05",
+        submitted_equity=100_000.0,
+    )
+    with pytest.raises(AssertionError, match="must not regress"):
+        book.requeue(
+            po.order_id,
+            new_remaining_qty=5.0,
+            new_submitted_at="2024-01-04",
+        )
+
+
+def test_requeue_same_timestamp_allowed() -> None:
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    # Equal timestamps are fine — the bar-safety guard fires only on strict
+    # look-ahead, and intra-bar partial fills may legitimately requeue on the
+    # same bar boundary before the simulator advances.
+    book.requeue(po.order_id, new_remaining_qty=3.0, new_submitted_at="2024-01-02")
+    assert po.remaining_qty == 3.0
+
+
+def test_requeue_twap_slices_passthrough() -> None:
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=12.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    book.requeue(
+        po.order_id,
+        new_remaining_qty=8.0,
+        new_submitted_at="2024-01-03",
+        twap_slices_remaining=2,
+    )
+    assert po.twap_slices_remaining == 2
+
+    book.requeue(
+        po.order_id,
+        new_remaining_qty=4.0,
+        new_submitted_at="2024-01-04",
+    )
+    assert po.twap_slices_remaining is None
+
+
+# ---------------------------------------------------------------------------
+# OCO sibling cancellation
+# ---------------------------------------------------------------------------
+
+
+def test_oco_cancel_siblings_cancels_only_siblings() -> None:
+    book = OrderBook()
+
+    parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+
+    sibling_a = book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    sibling_b = book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.STOP, stop_price=95.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    unrelated = book.submit_attached(
+        _base(qty=5.0, symbol="BBB", order_type=OrderType.LIMIT, limit_price=55.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id="other",
+        oco_group_id="g2",
+    )
+
+    cancelled = book.oco_cancel_siblings("g1", except_order_id=sibling_a.order_id)
+    assert cancelled == [sibling_b.order_id]
+
+    pending_ids = {po.order_id for po in book.all_pending()}
+    assert pending_ids == {parent.order_id, sibling_a.order_id, unrelated.order_id}
+    # Symbol index also stays consistent.
+    assert book.pending_for_symbol("BBB") == [unrelated]
+
+
+def test_oco_cancel_siblings_empty_when_no_match() -> None:
+    book = OrderBook()
+    book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    assert book.oco_cancel_siblings("nonexistent", except_order_id="o0") == []
+
+
+# ---------------------------------------------------------------------------
+# children_of
+# ---------------------------------------------------------------------------
+
+
+def test_children_of_returns_only_direct_children() -> None:
+    book = OrderBook()
+
+    parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    child_a = book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    child_b = book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.STOP, stop_price=95.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    # Unrelated parent + child.
+    other_parent = book.submit(
+        _base(qty=5.0, symbol="BBB"),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    book.submit_attached(
+        _base(qty=5.0, symbol="BBB", order_type=OrderType.LIMIT, limit_price=55.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=other_parent.order_id,
+        oco_group_id="g2",
+    )
+
+    children = book.children_of(parent.order_id)
+    assert {c.order_id for c in children} == {child_a.order_id, child_b.order_id}
+
+
+def test_children_of_returns_empty_for_unknown_parent() -> None:
+    book = OrderBook()
+    book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    assert book.children_of("nope") == []
+
+
+# ---------------------------------------------------------------------------
+# submit_attached bypasses validate_prices but still indexes by symbol
+# ---------------------------------------------------------------------------
+
+
+def test_submit_attached_skips_risk_gates() -> None:
+    """``submit_attached`` must accept a request with ``parent_order_id`` /
+    ``oco_group_id`` set even though calling ``validate_prices()`` directly on
+    the same payload still raises (the gate is owned by the strategy-side
+    service path; engine-side bracket materialization owns its own correctness).
+    """
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+
+    # Independent proof that the gate is real on the strategy path.
+    gated = OrderRequest(
+        client_order_id="child",
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=10.0,
+        order_type=OrderType.LIMIT,
+        limit_price=110.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    with pytest.raises(UnsupportedOrderFeatureError):
+        gated.validate_prices()
+
+    # submit_attached must not raise on the same payload shape.
+    child = book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    assert child.request.parent_order_id == parent.order_id
+    assert child.request.oco_group_id == "g1"
+    assert child.original_qty == 10.0
+    assert child.remaining_qty == 10.0
+
+
+def test_submit_attached_indexes_by_symbol() -> None:
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    child = book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    assert child in book.pending_for_symbol("AAA")
+    # Removing the child also clears the symbol index entry.
+    book.remove(child.order_id)
+    assert child not in book.pending_for_symbol("AAA")

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -112,7 +112,8 @@ def test_requeue_stale_timestamp_raises() -> None:
         submitted_at="2024-01-05",
         submitted_equity=100_000.0,
     )
-    with pytest.raises(AssertionError, match="must not regress"):
+    # Use ValueError (not assert) so the guard survives ``python -O``.
+    with pytest.raises(ValueError, match="must not regress"):
         book.requeue(
             po.order_id,
             new_remaining_qty=5.0,
@@ -193,7 +194,11 @@ def test_oco_cancel_siblings_cancels_only_siblings() -> None:
         oco_group_id="g2",
     )
 
-    cancelled = book.oco_cancel_siblings("g1", except_order_id=sibling_a.order_id)
+    cancelled = book.oco_cancel_siblings(
+        "g1",
+        except_order_id=sibling_a.order_id,
+        parent_order_id=parent.order_id,
+    )
     assert cancelled == [sibling_b.order_id]
 
     pending_ids = {po.order_id for po in book.all_pending()}
@@ -209,7 +214,79 @@ def test_oco_cancel_siblings_empty_when_no_match() -> None:
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
     )
-    assert book.oco_cancel_siblings("nonexistent", except_order_id="o0") == []
+    assert (
+        book.oco_cancel_siblings(
+            "nonexistent",
+            except_order_id="o0",
+            parent_order_id="o0",
+        )
+        == []
+    )
+
+
+def test_oco_cancel_siblings_does_not_cross_brackets() -> None:
+    """Two independent brackets that reuse the same ``oco_group_id`` (e.g. a
+    caller picks ``"oco-1"`` for every bracket) must not cross-cancel each
+    other's protective legs. Scoping by ``parent_order_id`` enforces this.
+    """
+    book = OrderBook()
+
+    parent_a = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    parent_b = book.submit(
+        _base(qty=10.0, symbol="BBB"),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+
+    a_tp = book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent_a.order_id,
+        oco_group_id="g-shared",
+    )
+    a_sl = book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.STOP, stop_price=95.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent_a.order_id,
+        oco_group_id="g-shared",
+    )
+    b_tp = book.submit_attached(
+        _base(qty=10.0, symbol="BBB", order_type=OrderType.LIMIT, limit_price=210.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent_b.order_id,
+        oco_group_id="g-shared",
+    )
+    b_sl = book.submit_attached(
+        _base(qty=10.0, symbol="BBB", order_type=OrderType.STOP, stop_price=195.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent_b.order_id,
+        oco_group_id="g-shared",
+    )
+
+    # A's take-profit fills → cancel A's stop, leave B untouched.
+    cancelled = book.oco_cancel_siblings(
+        "g-shared",
+        except_order_id=a_tp.order_id,
+        parent_order_id=parent_a.order_id,
+    )
+    assert cancelled == [a_sl.order_id]
+
+    pending_ids = {po.order_id for po in book.all_pending()}
+    assert pending_ids == {
+        parent_a.order_id,
+        parent_b.order_id,
+        a_tp.order_id,
+        b_tp.order_id,
+        b_sl.order_id,
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -456,6 +456,11 @@ def test_oco_cancel_siblings_cancels_only_siblings() -> None:
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
     )
+    other_parent = book.submit(
+        _base(qty=5.0, symbol="BBB"),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
 
     sibling_a = book.submit_attached(
         _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
@@ -475,7 +480,7 @@ def test_oco_cancel_siblings_cancels_only_siblings() -> None:
         _base(qty=5.0, symbol="BBB", order_type=OrderType.LIMIT, limit_price=55.0),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
-        parent_order_id="other",
+        parent_order_id=other_parent.order_id,
         oco_group_id="g2",
     )
 
@@ -487,9 +492,17 @@ def test_oco_cancel_siblings_cancels_only_siblings() -> None:
     assert cancelled == [sibling_b.order_id]
 
     pending_ids = {po.order_id for po in book.all_pending()}
-    assert pending_ids == {parent.order_id, sibling_a.order_id, unrelated.order_id}
+    assert pending_ids == {
+        parent.order_id,
+        other_parent.order_id,
+        sibling_a.order_id,
+        unrelated.order_id,
+    }
     # Symbol index also stays consistent.
-    assert book.pending_for_symbol("BBB") == [unrelated]
+    assert {po.order_id for po in book.pending_for_symbol("BBB")} == {
+        other_parent.order_id,
+        unrelated.order_id,
+    }
 
 
 def test_oco_cancel_siblings_empty_when_no_match() -> None:
@@ -870,3 +883,94 @@ def test_submit_attached_rejects_bad_oco_group_id(bad_group) -> None:
             oco_group_id=bad_group,
         )
     assert len(book.all_pending()) == 1
+
+
+# ---------------------------------------------------------------------------
+# submit_attached parent linkage. A typo / stale id would otherwise create an
+# orphan child that the simulator treats as a standalone order.
+# ---------------------------------------------------------------------------
+
+
+def test_submit_attached_rejects_unknown_parent_order_id() -> None:
+    """An ``parent_order_id`` that was never allocated by this book is a
+    bracket plumbing bug — reject loudly so the orphan child can't slip into
+    the book and execute as a standalone entry/exit.
+    """
+    book = OrderBook()
+    with pytest.raises(ValueError, match="not a known order id"):
+        book.submit_attached(
+            _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+            submitted_at="2024-01-03",
+            submitted_equity=100_000.0,
+            parent_order_id="o-typo",
+            oco_group_id="g1",
+        )
+    assert book.all_pending() == []
+
+
+def test_submit_attached_accepts_parent_after_removal() -> None:
+    """Typical bracket flow: parent fills, gets removed from ``_pending``,
+    children are then submitted to materialize the protective legs. Validation
+    must accept the parent's id even though it's no longer in ``_pending``.
+    """
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    book.remove(parent.order_id)
+    assert parent not in book.all_pending()
+
+    child = book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    assert child.request.parent_order_id == parent.order_id
+
+
+# ---------------------------------------------------------------------------
+# DAY-TIF expiry uses the immutable ``original_submitted_at`` anchor so a
+# partially-filled-and-requeued DAY order still expires at the end of its
+# original session, not the day after the last partial fill.
+# ---------------------------------------------------------------------------
+
+
+def test_expire_day_orders_uses_original_submitted_at() -> None:
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0, tif=TimeInForce.DAY),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    # Partial fill bumps ``submitted_at`` to D+1 so the look-ahead guard still
+    # holds, but the original submission date is preserved separately.
+    book.requeue(po.order_id, new_remaining_qty=4.0, new_submitted_at="2024-01-03")
+    assert po.submitted_at == "2024-01-03"
+    assert po.original_submitted_at == "2024-01-02"
+
+    # On D+1 (2024-01-03) the order should expire — it was originally a DAY
+    # order submitted on 2024-01-02, so it must not survive into 2024-01-03's
+    # session.
+    expired = book.expire_day_orders("2024-01-03")
+    assert expired == [po]
+    assert po not in book.all_pending()
+
+
+def test_expire_day_orders_keeps_order_on_original_day() -> None:
+    """Sanity: a DAY order shouldn't expire on the same date it was submitted,
+    even after a same-day requeue.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0, tif=TimeInForce.DAY),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    # Same-day requeue (the look-ahead guard allows equal timestamps).
+    book.requeue(po.order_id, new_remaining_qty=5.0, new_submitted_at="2024-01-02")
+    assert book.expire_day_orders("2024-01-02") == []
+    assert po in book.all_pending()

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -137,6 +137,42 @@ def test_requeue_same_timestamp_allowed() -> None:
     assert po.remaining_qty == 3.0
 
 
+def test_requeue_normalizes_z_suffix_timestamp() -> None:
+    """``…Z`` and ``…+00:00`` are equivalent ISO 8601 representations of the
+    same instant; lexicographic comparison would falsely reject ``…Z`` as
+    earlier than ``…+00:00`` (because ``Z`` < ``+`` in ASCII). The regression
+    guard normalises both sides before comparing.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02T10:00:00+00:00",
+        submitted_equity=100_000.0,
+    )
+    # Same instant, just expressed with the Z suffix.
+    book.requeue(
+        po.order_id,
+        new_remaining_qty=4.0,
+        new_submitted_at="2024-01-02T10:00:00Z",
+    )
+    assert po.remaining_qty == 4.0
+    assert po.submitted_at == "2024-01-02T10:00:00Z"
+
+    # And the other direction: existing has Z suffix, new has +00:00 — also
+    # not a regression.
+    po2 = book.submit(
+        _base(qty=5.0, symbol="BBB"),
+        submitted_at="2024-01-02T10:00:00Z",
+        submitted_equity=100_000.0,
+    )
+    book.requeue(
+        po2.order_id,
+        new_remaining_qty=2.0,
+        new_submitted_at="2024-01-02T10:00:00+00:00",
+    )
+    assert po2.remaining_qty == 2.0
+
+
 def test_requeue_twap_slices_passthrough() -> None:
     book = OrderBook()
     po = book.submit(
@@ -961,6 +997,52 @@ def test_submit_attached_accepts_parent_after_removal() -> None:
         oco_group_id="g1",
     )
     assert child.request.parent_order_id == parent.order_id
+
+
+def test_submit_attached_rejects_cancelled_parent() -> None:
+    """A cancelled top-level order never opened, so attaching protective
+    children to it would be a bug. ``cancel()`` must remove the parent's id
+    from the eligible-parent set so subsequent ``submit_attached`` fails.
+    """
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    assert book.cancel(parent.order_id) is True
+
+    with pytest.raises(ValueError, match="not a known top-level order id"):
+        book.submit_attached(
+            _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+            submitted_at="2024-01-03",
+            submitted_equity=100_000.0,
+            parent_order_id=parent.order_id,
+            oco_group_id="g1",
+        )
+
+
+def test_submit_attached_rejects_expired_parent() -> None:
+    """Same lifecycle rule as cancel: a DAY order expired without filling
+    is not eligible to be a bracket parent.
+    """
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0, tif=TimeInForce.DAY),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    expired = book.expire_day_orders("2024-01-03")
+    assert expired == [parent]
+
+    with pytest.raises(ValueError, match="not a known top-level order id"):
+        book.submit_attached(
+            _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+            submitted_at="2024-01-03",
+            submitted_equity=100_000.0,
+            parent_order_id=parent.order_id,
+            oco_group_id="g1",
+        )
 
 
 def test_submit_attached_rejects_attached_child_as_parent() -> None:

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -505,21 +505,52 @@ def test_oco_cancel_siblings_cancels_only_siblings() -> None:
     }
 
 
-def test_oco_cancel_siblings_empty_when_no_match() -> None:
+def test_oco_cancel_siblings_rejects_stale_except_order_id() -> None:
+    """A stale ``except_order_id`` (not currently pending) would otherwise
+    fall through and let the cancellation loop nuke every leg in the group,
+    leaving the bracket unprotected. Reject explicitly.
+    """
     book = OrderBook()
     book.submit(
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
     )
-    assert (
+    with pytest.raises(ValueError, match="is not currently pending"):
         book.oco_cancel_siblings(
-            "nonexistent",
-            except_order_id="o0",
-            parent_order_id="o0",
+            "g1",
+            except_order_id="o-stale",
+            parent_order_id="o-stale",
         )
-        == []
+
+
+def test_oco_cancel_siblings_rejects_mismatched_except_leg() -> None:
+    """``except_order_id`` is currently pending, but its (group, parent) tuple
+    doesn't match the requested cancellation scope — reject so a typo can't
+    silently clear an unrelated bracket.
+    """
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
     )
+    sibling = book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    # except_order_id is real and pending, but with mismatched group / parent.
+    with pytest.raises(ValueError, match="does not belong to"):
+        book.oco_cancel_siblings(
+            "different-group",
+            except_order_id=sibling.order_id,
+            parent_order_id=parent.order_id,
+        )
+    # Nothing got cancelled.
+    assert sibling in book.all_pending()
 
 
 @pytest.mark.parametrize("arg", ["oco_group_id", "except_order_id", "parent_order_id"])
@@ -897,7 +928,7 @@ def test_submit_attached_rejects_unknown_parent_order_id() -> None:
     the book and execute as a standalone entry/exit.
     """
     book = OrderBook()
-    with pytest.raises(ValueError, match="not a known order id"):
+    with pytest.raises(ValueError, match="not a known top-level order id"):
         book.submit_attached(
             _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
             submitted_at="2024-01-03",
@@ -930,6 +961,121 @@ def test_submit_attached_accepts_parent_after_removal() -> None:
         oco_group_id="g1",
     )
     assert child.request.parent_order_id == parent.order_id
+
+
+def test_submit_attached_rejects_attached_child_as_parent() -> None:
+    """Multi-level bracket trees (``parent → child → grandchild``) are not
+    supported by this API. Only ids allocated by ``submit()`` (top-level
+    orders) are eligible parents — attached children must not be promoted
+    into parents themselves, otherwise ``children_of`` traversal and OCO
+    cancellation semantics break.
+    """
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    child = book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    # The child has a real, valid order_id, but attempting to use it as a
+    # parent for another submit_attached must fail.
+    with pytest.raises(ValueError, match="not a known top-level order id"):
+        book.submit_attached(
+            _base(qty=5.0, order_type=OrderType.STOP, stop_price=95.0),
+            submitted_at="2024-01-04",
+            submitted_equity=100_000.0,
+            parent_order_id=child.order_id,
+            oco_group_id="g2",
+        )
+    # Grandchild was not queued.
+    assert book.children_of(child.order_id) == []
+
+
+# ---------------------------------------------------------------------------
+# prune_known_top_level_order_ids — operators of long-running services should
+# call this periodically to bound memory growth in ``_known_top_level_order_ids``.
+# ---------------------------------------------------------------------------
+
+
+def test_prune_keeps_active_parents() -> None:
+    """A top-level order that's still pending — or that has at least one
+    pending child — must be preserved by prune so the next bracket
+    materialization still validates correctly.
+    """
+    book = OrderBook()
+    pending_parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    parent_with_child = book.submit(
+        _base(qty=5.0, symbol="BBB"),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    # Remove the parent but keep its child pending — parent_id is still
+    # referenced by an active leg, so prune must keep it.
+    book.submit_attached(
+        _base(qty=5.0, symbol="BBB", order_type=OrderType.LIMIT, limit_price=55.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent_with_child.order_id,
+        oco_group_id="g2",
+    )
+    book.remove(parent_with_child.order_id)
+
+    pruned = book.prune_known_top_level_order_ids()
+    assert pruned == 0
+    # Both parent ids still admit new children.
+    book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        submitted_at="2024-01-04",
+        submitted_equity=100_000.0,
+        parent_order_id=pending_parent.order_id,
+        oco_group_id="g1",
+    )
+    book.submit_attached(
+        _base(qty=5.0, symbol="BBB", order_type=OrderType.STOP, stop_price=45.0),
+        submitted_at="2024-01-04",
+        submitted_equity=100_000.0,
+        parent_order_id=parent_with_child.order_id,
+        oco_group_id="g3",
+    )
+
+
+def test_prune_evicts_fully_resolved_parents() -> None:
+    """A top-level order whose entry has been removed *and* has no remaining
+    pending children is fully resolved — its id is safe to evict, and
+    subsequent ``submit_attached`` calls referencing it correctly fail.
+    """
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    book.remove(parent.order_id)
+    assert book.children_of(parent.order_id) == []
+
+    pruned = book.prune_known_top_level_order_ids()
+    assert pruned == 1
+
+    # Submitting a child against the pruned parent now fails — the bracket is
+    # fully resolved.
+    with pytest.raises(ValueError, match="not a known top-level order id"):
+        book.submit_attached(
+            _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+            submitted_at="2024-01-04",
+            submitted_equity=100_000.0,
+            parent_order_id=parent.order_id,
+            oco_group_id="g1",
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -1455,6 +1455,136 @@ def test_remove_filled_does_not_cascade_to_pending_children() -> None:
     assert pending_ids == {child_a.order_id, child_b.order_id}
 
 
+# ---------------------------------------------------------------------------
+# Auto-eviction of filled-parent ids once the bracket is fully resolved.
+# Without this, ``_known_top_level_order_ids`` would only ever shrink on
+# cancel/expire/non-fill paths, so long-running services would accumulate
+# every filled parent forever even after their brackets fully closed out.
+# ---------------------------------------------------------------------------
+
+
+def test_filled_parent_remains_eligible_while_children_pending() -> None:
+    """The filled parent must stay in the eligible-parent set as long as at
+    least one of its protective legs is still pending — otherwise the
+    bracket flow can't add late children (e.g. a re-armed stop) to it.
+    """
+    book = OrderBook()
+    parent, child_a, child_b = _bracket_with_two_children(book)
+    book.remove(parent.order_id, was_filled=True)  # entry fills
+    # Both children still pending — parent stays eligible.
+    book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.STOP, stop_price=90.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g2",
+    )
+    # Cancel one of the original children — parent still has b + the new
+    # leg pending, so still eligible.
+    book.cancel(child_a.order_id)
+    book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=120.0),
+        submitted_at="2024-01-04",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g3",
+    )
+
+
+def test_filled_parent_auto_evicted_when_last_child_resolves() -> None:
+    """Once the parent's last pending child is removed (filled or cancelled),
+    the parent's id is auto-evicted from ``_known_top_level_order_ids``
+    so subsequent ``submit_attached`` calls referencing the resolved
+    bracket correctly fail.
+    """
+    book = OrderBook()
+    parent, child_a, child_b = _bracket_with_two_children(book)
+    book.remove(parent.order_id, was_filled=True)  # entry fills
+
+    # Resolve child_a via terminal-fill requeue.
+    book.requeue(child_a.order_id, new_remaining_qty=0.0, new_submitted_at="2024-01-03")
+    # Parent still eligible — child_b is pending.
+    book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.STOP, stop_price=90.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g4",
+    )
+    # Now cancel both remaining children.
+    pending_children = book.children_of(parent.order_id)
+    for child in pending_children:
+        book.cancel(child.order_id)
+    # Last child gone → parent auto-evicted. New submit_attached fails.
+    with pytest.raises(ValueError, match="not a known top-level order id"):
+        book.submit_attached(
+            _base(qty=10.0, order_type=OrderType.STOP, stop_price=85.0),
+            submitted_at="2024-01-04",
+            submitted_equity=100_000.0,
+            parent_order_id=parent.order_id,
+            oco_group_id="g5",
+        )
+
+
+def test_filled_parent_evicted_when_only_child_terminal_fills() -> None:
+    """The eviction also fires when the *last* child is removed via the
+    terminal-fill ``requeue(0)`` path (not just via cancel) — exercises
+    the ``remove(was_filled=True)`` branch on the child.
+    """
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    child = book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    book.remove(parent.order_id, was_filled=True)
+    book.requeue(child.order_id, new_remaining_qty=0.0, new_submitted_at="2024-01-03")
+    with pytest.raises(ValueError, match="not a known top-level order id"):
+        book.submit_attached(
+            _base(qty=10.0, order_type=OrderType.STOP, stop_price=95.0),
+            submitted_at="2024-01-04",
+            submitted_equity=100_000.0,
+            parent_order_id=parent.order_id,
+            oco_group_id="g2",
+        )
+
+
+def test_no_auto_evict_while_parent_still_pending() -> None:
+    """Auto-evict must only fire after the parent itself is gone from
+    ``_pending``. Removing a child while the parent is still live should
+    leave the parent eligible (so additional children can attach).
+    """
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    child = book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    book.cancel(child.order_id)
+    # Parent is still pending → still eligible. Submit a new child.
+    book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.STOP, stop_price=95.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g2",
+    )
+
+
 def test_cancel_only_cancels_direct_children_of_target() -> None:
     """Cascade is scoped to the cancelled parent's *own* children — an
     unrelated bracket shouldn't be touched.

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -1696,3 +1696,70 @@ def test_cancel_only_cancels_direct_children_of_target() -> None:
     assert pending_ids == {parent_b.order_id, child_b.order_id}
     assert child_a1 not in book.all_pending()
     assert child_a2 not in book.all_pending()
+
+
+# ---------------------------------------------------------------------------
+# Pre-armed bracket children: submit_attached sets ``armed=False`` while
+# the parent is still pending so the simulator's fill loop skips the child
+# until the bracket materializer (#389) flips it on after the parent fills.
+# Children submitted *after* the parent fills (post-fill bracket activation)
+# are armed immediately.
+# ---------------------------------------------------------------------------
+
+
+def test_submit_attached_disarmed_when_parent_still_pending() -> None:
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    child = book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    assert child.armed is False
+    # Parent itself is always armed — it's the entry.
+    assert parent.armed is True
+
+
+def test_submit_attached_armed_when_parent_already_filled() -> None:
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    book.remove(parent.order_id, was_filled=True)  # entry fills
+    child = book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    assert child.armed is True
+
+
+def test_submit_attached_rejects_market_child() -> None:
+    """Market children would fire on the next bar, defeating the protective-
+    leg semantic. ``submit_attached`` must reject ``OrderType.MARKET``.
+    """
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    with pytest.raises(ValueError, match="not MARKET"):
+        book.submit_attached(
+            _base(qty=10.0, order_type=OrderType.MARKET),
+            submitted_at="2024-01-03",
+            submitted_equity=100_000.0,
+            parent_order_id=parent.order_id,
+            oco_group_id="g1",
+        )
+    assert book.children_of(parent.order_id) == []

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -181,10 +181,14 @@ def test_requeue_keeps_cumulative_filled_consistent() -> None:
     assert po.cumulative_filled_qty == 9.0
     assert po.original_qty == po.cumulative_filled_qty + po.remaining_qty
 
-    # Fully filled — remainder collapses to zero.
+    # Fully filled — remainder collapses to zero. The PendingOrder reference
+    # still holds the terminal state for the caller to read, but it is removed
+    # from the book so the simulator can't double-fill it.
     book.requeue(po.order_id, new_remaining_qty=0.0, new_submitted_at="2024-01-05")
     assert po.cumulative_filled_qty == 10.0
     assert po.remaining_qty == 0.0
+    assert po not in book.all_pending()
+    assert po not in book.pending_for_symbol("AAA")
 
 
 def test_requeue_rejects_negative_remaining_qty() -> None:
@@ -263,6 +267,37 @@ def test_requeue_unknown_order_id_raises_keyerror() -> None:
     )
     with pytest.raises(KeyError, match="not in the book"):
         book.requeue("o-bogus", new_remaining_qty=5.0, new_submitted_at="2024-01-03")
+
+
+def test_requeue_zero_remainder_removes_order_from_book() -> None:
+    """``requeue(..., new_remaining_qty=0)`` is the terminal step of a partial-fill
+    sequence. The order must be removed from ``_pending`` and from the symbol
+    index so downstream consumers (notably ``FillSimulator``, which sizes from
+    ``req.qty`` rather than ``remaining_qty``) cannot double-fill it. The
+    returned reference still carries the terminal state for the caller.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    # First a real partial fill — order remains in the book.
+    book.requeue(po.order_id, new_remaining_qty=4.0, new_submitted_at="2024-01-03")
+    assert po in book.all_pending()
+    assert po in book.pending_for_symbol("AAA")
+
+    returned = book.requeue(po.order_id, new_remaining_qty=0.0, new_submitted_at="2024-01-04")
+    # Caller still gets the PendingOrder reference with terminal state.
+    assert returned is po
+    assert po.remaining_qty == 0.0
+    assert po.cumulative_filled_qty == po.original_qty == 10.0
+    # But it is no longer queued for further fills.
+    assert po not in book.all_pending()
+    assert po not in book.pending_for_symbol("AAA")
+    # And the next requeue raises (book no longer holds the id).
+    with pytest.raises(KeyError, match="not in the book"):
+        book.requeue(po.order_id, new_remaining_qty=0.0, new_submitted_at="2024-01-05")
 
 
 # ---------------------------------------------------------------------------
@@ -598,3 +633,42 @@ def test_submit_attached_rejects_ioc_child() -> None:
             oco_group_id="g1",
         )
     assert book.children_of(parent.order_id) == []
+
+
+# ---------------------------------------------------------------------------
+# parent_order_id / oco_group_id type validation. Pydantic's
+# ``model_copy(update=...)`` does not validate update values, so a non-string
+# id would be stored silently and break later string-based lookups
+# (``children_of`` / ``oco_cancel_siblings`` compare with ``==``).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_parent", [123, None, "", 1.5])
+def test_submit_attached_rejects_bad_parent_order_id(bad_parent) -> None:
+    book = OrderBook()
+    _bracket_parent(book)
+    with pytest.raises(TypeError, match="parent_order_id must be a non-empty str"):
+        book.submit_attached(
+            _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+            submitted_at="2024-01-03",
+            submitted_equity=100_000.0,
+            parent_order_id=bad_parent,
+            oco_group_id="g1",
+        )
+    # Nothing got queued — only the bracket parent remains.
+    assert len(book.all_pending()) == 1
+
+
+@pytest.mark.parametrize("bad_group", [123, None, "", 1.5])
+def test_submit_attached_rejects_bad_oco_group_id(bad_group) -> None:
+    book = OrderBook()
+    parent = _bracket_parent(book)
+    with pytest.raises(TypeError, match="oco_group_id must be a non-empty str"):
+        book.submit_attached(
+            _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+            submitted_at="2024-01-03",
+            submitted_equity=100_000.0,
+            parent_order_id=parent.order_id,
+            oco_group_id=bad_group,
+        )
+    assert len(book.all_pending()) == 1

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -240,7 +240,9 @@ def test_requeue_normalizes_z_suffix_timestamp() -> None:
         new_submitted_at="2024-01-02T10:00:00Z",
     )
     assert po.remaining_qty == 4.0
-    assert po.submitted_at == "2024-01-02T10:00:00Z"
+    # ``requeue`` canonicalises tz-aware timestamps to UTC ``+00:00`` form
+    # so all downstream consumers see a consistent string.
+    assert po.submitted_at == "2024-01-02T10:00:00+00:00"
 
     # And the other direction: existing has Z suffix, new has +00:00 — also
     # not a regression.
@@ -2073,3 +2075,108 @@ def test_requeue_rejects_non_numeric_remaining_qty(bad_qty) -> None:
         book.requeue(po.order_id, new_remaining_qty=bad_qty, new_submitted_at="2024-01-03")
     # State unchanged.
     assert po.remaining_qty == 10.0
+
+
+# ---------------------------------------------------------------------------
+# Timestamp canonicalisation: ``requeue`` normalises tz-aware values to UTC
+# ``+00:00`` form so the look-ahead guard in ``execution/bar_safety.py``
+# (which compares bar timestamps to ``po.submitted_at`` lexicographically)
+# doesn't false-reject mixed-offset traces.
+# ---------------------------------------------------------------------------
+
+
+def test_requeue_canonicalizes_tz_aware_timestamp_to_utc() -> None:
+    """A non-UTC offset gets rewritten to the equivalent UTC instant."""
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02T05:00:00+00:00",
+        submitted_equity=100_000.0,
+    )
+    # 10:30 IST = 05:00 UTC (same instant); after canonicalisation the
+    # stored string is in UTC form regardless of caller-side offset.
+    book.requeue(
+        po.order_id,
+        new_remaining_qty=4.0,
+        new_submitted_at="2024-01-02T10:30:00+05:30",
+    )
+    assert po.submitted_at == "2024-01-02T05:00:00+00:00"
+
+
+def test_requeue_canonicalizes_compact_offset() -> None:
+    """``+0000`` (no colon) is a valid ISO 8601 offset that Python 3.10's
+    ``datetime.fromisoformat`` rejects; ``_normalize_ts`` rewrites it
+    before parse, and ``_canonicalize_ts`` then re-emits in canonical form.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02T05:00:00+00:00",
+        submitted_equity=100_000.0,
+    )
+    book.requeue(
+        po.order_id,
+        new_remaining_qty=3.0,
+        new_submitted_at="2024-01-02T05:00:00+0000",
+    )
+    assert po.submitted_at == "2024-01-02T05:00:00+00:00"
+
+
+def test_requeue_does_not_canonicalize_naive_date_string() -> None:
+    """Naive (date-only / no-offset) inputs round-trip unchanged so existing
+    callers using simple date strings aren't mangled into datetime form.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    book.requeue(po.order_id, new_remaining_qty=4.0, new_submitted_at="2024-01-03")
+    assert po.submitted_at == "2024-01-03"
+
+
+def test_requeue_handles_compact_offset_in_regression_check() -> None:
+    """A compact-offset timestamp must compare correctly against an
+    already-stored equivalent ``+00:00``-form timestamp — same instant
+    must not raise as a regression.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02T10:00:00+00:00",
+        submitted_equity=100_000.0,
+    )
+    # Same instant in compact form — must not raise.
+    book.requeue(
+        po.order_id,
+        new_remaining_qty=4.0,
+        new_submitted_at="2024-01-02T10:00:00+0000",
+    )
+    assert po.remaining_qty == 4.0
+
+
+def test_submit_attached_market_rejection_message_lists_supported_types() -> None:
+    """The MARKET-rejection message must point callers at types that are
+    actually supported (``LIMIT`` / ``STOP``) — not at ``STOP_LIMIT``
+    (doesn't exist) or ``TRAILING_STOP`` (still gated until #390).
+    """
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0, side=OrderSide.LONG),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+        expect_brackets=True,
+    )
+    with pytest.raises(ValueError) as excinfo:
+        book.submit_attached(
+            _base(qty=10.0, side=OrderSide.SHORT, order_type=OrderType.MARKET),
+            submitted_at="2024-01-03",
+            submitted_equity=100_000.0,
+            parent_order_id=parent.order_id,
+            oco_group_id="g1",
+        )
+    msg = str(excinfo.value)
+    assert "LIMIT or STOP" in msg
+    # Make sure we're not pointing callers at non-existent or gated types.
+    assert "STOP_LIMIT" not in msg

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -14,7 +14,7 @@ from datetime import datetime
 import pytest
 
 from investment_team.trading_service.engine.order_book import (
-    FILL_QTY_EPSILON,
+    FILL_QTY_REL_TOL,
     OrderBook,
     PendingOrder,
 )
@@ -501,14 +501,15 @@ def test_requeue_zero_remainder_removes_order_from_book() -> None:
         book.requeue(po.order_id, new_remaining_qty=0.0, new_submitted_at="2024-01-05")
 
 
-@pytest.mark.parametrize("residual", [1e-15, 1e-12, FILL_QTY_EPSILON / 2])
+@pytest.mark.parametrize("residual", [1e-15, 1e-14, 1e-13])
 def test_requeue_clamps_tiny_positive_residual_to_zero(residual) -> None:
     """Float math in upstream sizing (``prev_remaining - filled``) can produce
-    sub-epsilon remainders that aren't exactly 0. Without clamping, those
-    orders linger in the book and can be re-filled by the simulator. Verify
-    that any value with absolute magnitude below FILL_QTY_EPSILON is treated
-    as a terminal fill: the order is removed and ``cumulative_filled_qty``
-    equals ``original_qty``.
+    sub-ULP remainders that aren't exactly 0. Without clamping, those
+    orders linger in the book and can be re-filled by the simulator.
+
+    For ``original_qty=10``, the relative threshold is
+    ``10 * 1e-12 = 1e-11``, so values like ``1e-15`` / ``1e-14`` / ``1e-13``
+    are all comfortably below ULP-level error and get clamped.
     """
     book = OrderBook()
     po = book.submit(
@@ -524,11 +525,11 @@ def test_requeue_clamps_tiny_positive_residual_to_zero(residual) -> None:
     assert po not in book.pending_for_symbol("AAA")
 
 
-@pytest.mark.parametrize("residual", [-1e-15, -FILL_QTY_EPSILON / 2])
+@pytest.mark.parametrize("residual", [-1e-15, -1e-14, -1e-13])
 def test_requeue_clamps_tiny_negative_residual_to_zero(residual) -> None:
     """Tiny negatives from accumulated float error are physically zero and
     shouldn't trip the ``< 0`` rejection. They should clamp the same way
-    positive sub-epsilon residuals do.
+    positive sub-tolerance residuals do.
     """
     book = OrderBook()
     po = book.submit(
@@ -543,9 +544,11 @@ def test_requeue_clamps_tiny_negative_residual_to_zero(residual) -> None:
     assert po not in book.all_pending()
 
 
-def test_requeue_preserves_remainder_above_epsilon() -> None:
-    """A remainder safely above FILL_QTY_EPSILON should not be clamped — the
-    order stays in the book with the requested partial-fill remainder.
+def test_requeue_preserves_remainder_above_relative_threshold() -> None:
+    """A remainder safely above the relative tolerance threshold should not
+    be clamped. For ``original_qty=10``, the threshold is ``1e-11``; a
+    remainder of ``1e-7`` is six orders of magnitude above it and clearly
+    a real partial fill, not float noise.
     """
     book = OrderBook()
     po = book.submit(
@@ -554,15 +557,15 @@ def test_requeue_preserves_remainder_above_epsilon() -> None:
         submitted_equity=100_000.0,
         expect_brackets=True,
     )
-    above = FILL_QTY_EPSILON * 100  # 1e-7 — well above the clamp tolerance
+    above = 10.0 * FILL_QTY_REL_TOL * 1_000_000  # 1e-5 — well above the clamp
     book.requeue(po.order_id, new_remaining_qty=above, new_submitted_at="2024-01-03")
     assert po.remaining_qty == above
     assert po.cumulative_filled_qty == 10.0 - above
     assert po in book.all_pending()
 
 
-def test_requeue_rejects_negative_above_epsilon() -> None:
-    """The clamp only swallows sub-epsilon negatives. A genuinely negative
+def test_requeue_rejects_negative_above_relative_threshold() -> None:
+    """The clamp only swallows sub-tolerance negatives. A genuinely negative
     remainder still gets rejected by the strict ``< 0`` guard.
     """
     book = OrderBook()
@@ -575,10 +578,35 @@ def test_requeue_rejects_negative_above_epsilon() -> None:
     with pytest.raises(ValueError, match="must be >= 0"):
         book.requeue(
             po.order_id,
-            new_remaining_qty=-FILL_QTY_EPSILON * 1000,  # -1e-6, well past the clamp
+            new_remaining_qty=-1e-6,  # well past the relative-tolerance clamp
             new_submitted_at="2024-01-03",
         )
     assert po.remaining_qty == 10.0  # unchanged
+
+
+def test_requeue_does_not_clamp_legitimate_small_remainder() -> None:
+    """For a legitimately small order (e.g. fractional-token venue where
+    every quantity is sub-1e-9 in absolute terms), a remainder that would
+    be below the *absolute* sub-epsilon threshold of an earlier
+    implementation must NOT be clamped if it's still a meaningful fraction
+    of the order's own size. The clamp is *relative* to ``original_qty``.
+
+    Regression test for the reviewer's concern that an absolute
+    ``FILL_QTY_EPSILON`` threshold over-clamped real partial fills on
+    small orders.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=1e-8),  # legitimate fractional-token amount
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+        expect_brackets=True,
+    )
+    # 5e-10 is 5% of the original 1e-8 — a meaningful partial-fill
+    # remainder, NOT ULP noise. Must not be clamped.
+    book.requeue(po.order_id, new_remaining_qty=5e-10, new_submitted_at="2024-01-03")
+    assert po.remaining_qty == 5e-10
+    assert po in book.all_pending()
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -1383,3 +1383,98 @@ def test_requeue_falls_back_to_string_compare_for_unparseable_ts() -> None:
     # And same lexicographic ordering forward — accepted.
     book.requeue(po.order_id, new_remaining_qty=4.0, new_submitted_at="bar-2024-01-03")
     assert po.remaining_qty == 4.0
+
+
+# ---------------------------------------------------------------------------
+# Cascade-cancel attached children when a top-level parent leaves the book
+# without filling. Covers cancel() and remove(was_filled=False); the
+# expire_day_orders cascade is exercised separately above.
+# ---------------------------------------------------------------------------
+
+
+def _bracket_with_two_children(book: OrderBook):
+    parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    child_a = book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    child_b = book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.STOP, stop_price=95.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    return parent, child_a, child_b
+
+
+def test_cancel_cascades_to_pending_children() -> None:
+    """``cancel()`` on a top-level parent must cascade-cancel its attached
+    children. Otherwise an orphan TP / SL leg would still execute as a
+    standalone order even though the entry was cancelled.
+    """
+    book = OrderBook()
+    parent, child_a, child_b = _bracket_with_two_children(book)
+    assert book.cancel(parent.order_id) is True
+    # Parent and both children gone.
+    assert book.all_pending() == []
+    assert child_a not in book.all_pending()
+    assert child_b not in book.all_pending()
+
+
+def test_remove_unfilled_cascades_to_pending_children() -> None:
+    """``remove(was_filled=False)`` on a top-level parent must cascade for
+    the same reason as ``cancel()``: a non-filled removal (risk-rejection,
+    insufficient capital, manual cleanup) leaves no entry, so the
+    protective legs are orphans.
+    """
+    book = OrderBook()
+    parent, child_a, child_b = _bracket_with_two_children(book)
+    book.remove(parent.order_id)  # default was_filled=False
+    assert book.all_pending() == []
+    assert child_a not in book.all_pending()
+    assert child_b not in book.all_pending()
+
+
+def test_remove_filled_does_not_cascade_to_pending_children() -> None:
+    """``remove(was_filled=True)`` is the terminal-fill path. The parent
+    just opened, so its bracket children should *stay* live to protect the
+    new position. Cascade must not fire here.
+    """
+    book = OrderBook()
+    parent, child_a, child_b = _bracket_with_two_children(book)
+    book.remove(parent.order_id, was_filled=True)
+    pending_ids = {po.order_id for po in book.all_pending()}
+    assert pending_ids == {child_a.order_id, child_b.order_id}
+
+
+def test_cancel_only_cancels_direct_children_of_target() -> None:
+    """Cascade is scoped to the cancelled parent's *own* children — an
+    unrelated bracket shouldn't be touched.
+    """
+    book = OrderBook()
+    parent_a, child_a1, child_a2 = _bracket_with_two_children(book)
+    parent_b = book.submit(
+        _base(qty=5.0, symbol="BBB"),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    child_b = book.submit_attached(
+        _base(qty=5.0, symbol="BBB", order_type=OrderType.LIMIT, limit_price=55.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+        parent_order_id=parent_b.order_id,
+        oco_group_id="g2",
+    )
+    book.cancel(parent_a.order_id)
+    pending_ids = {po.order_id for po in book.all_pending()}
+    assert pending_ids == {parent_b.order_id, child_b.order_id}
+    assert child_a1 not in book.all_pending()
+    assert child_a2 not in book.all_pending()

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -19,6 +19,7 @@ from investment_team.trading_service.strategy.contract import (
     OrderRequest,
     OrderSide,
     OrderType,
+    TimeInForce,
     UnsupportedOrderFeatureError,
 )
 
@@ -224,6 +225,44 @@ def test_requeue_rejects_growing_remaining_qty() -> None:
     # And a value larger than original_qty is also rejected.
     with pytest.raises(ValueError, match="must not exceed current remaining_qty"):
         book.requeue(po.order_id, new_remaining_qty=11.0, new_submitted_at="2024-01-04")
+
+
+def test_requeue_rejects_nan_and_inf_remaining_qty() -> None:
+    """``NaN`` passes both ``< 0`` and ``> current`` checks vacuously, so an
+    explicit finite-check is needed to keep ``nan``/``inf`` out of fill state.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+
+    with pytest.raises(ValueError, match="must be finite"):
+        book.requeue(po.order_id, new_remaining_qty=float("nan"), new_submitted_at="2024-01-03")
+    with pytest.raises(ValueError, match="must be finite"):
+        book.requeue(po.order_id, new_remaining_qty=float("inf"), new_submitted_at="2024-01-03")
+    with pytest.raises(ValueError, match="must be finite"):
+        book.requeue(po.order_id, new_remaining_qty=float("-inf"), new_submitted_at="2024-01-03")
+
+    # State preserved — the rejected calls leave remaining/cumulative fields untouched.
+    assert po.remaining_qty == 10.0
+    assert po.cumulative_filled_qty == 0.0
+
+
+def test_requeue_unknown_order_id_raises_keyerror() -> None:
+    """A stale/missing id is a partial-fill bug, not an idempotent removal —
+    raise loudly with a clear message rather than silently no-op like
+    ``cancel`` / ``remove`` do.
+    """
+    book = OrderBook()
+    book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    with pytest.raises(KeyError, match="not in the book"):
+        book.requeue("o-bogus", new_remaining_qty=5.0, new_submitted_at="2024-01-03")
 
 
 # ---------------------------------------------------------------------------
@@ -476,3 +515,86 @@ def test_submit_attached_indexes_by_symbol() -> None:
     # Removing the child also clears the symbol index entry.
     book.remove(child.order_id)
     assert child not in book.pending_for_symbol("AAA")
+
+
+# ---------------------------------------------------------------------------
+# submit_attached re-runs *every* validate_prices() gate except the
+# parent_order_id / oco_group_id ones — i.e. malformed children (LIMIT
+# without limit_price, STOP without stop_price) and unsupported types
+# (TRAILING_STOP, IOC/FOK) must still be rejected at submission time so we
+# never queue an order that would crash the simulator later.
+# ---------------------------------------------------------------------------
+
+
+def _bracket_parent(book: OrderBook):
+    return book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+
+
+def test_submit_attached_rejects_limit_child_without_price() -> None:
+    book = OrderBook()
+    parent = _bracket_parent(book)
+    with pytest.raises(ValueError, match="limit order requires limit_price"):
+        book.submit_attached(
+            _base(qty=10.0, order_type=OrderType.LIMIT),  # limit_price missing
+            submitted_at="2024-01-03",
+            submitted_equity=100_000.0,
+            parent_order_id=parent.order_id,
+            oco_group_id="g1",
+        )
+    # Nothing got queued.
+    assert book.children_of(parent.order_id) == []
+
+
+def test_submit_attached_rejects_stop_child_without_price() -> None:
+    book = OrderBook()
+    parent = _bracket_parent(book)
+    with pytest.raises(ValueError, match="stop order requires stop_price"):
+        book.submit_attached(
+            _base(qty=10.0, order_type=OrderType.STOP),  # stop_price missing
+            submitted_at="2024-01-03",
+            submitted_equity=100_000.0,
+            parent_order_id=parent.order_id,
+            oco_group_id="g1",
+        )
+    assert book.children_of(parent.order_id) == []
+
+
+def test_submit_attached_rejects_trailing_stop_child() -> None:
+    """TRAILING_STOP is gated until #390 ships — the gate must still fire on
+    bracket children even though strategy-level submit was bypassed.
+    """
+    book = OrderBook()
+    parent = _bracket_parent(book)
+    with pytest.raises(UnsupportedOrderFeatureError, match="#390"):
+        book.submit_attached(
+            _base(qty=10.0, order_type=OrderType.TRAILING_STOP, stop_price=95.0),
+            submitted_at="2024-01-03",
+            submitted_equity=100_000.0,
+            parent_order_id=parent.order_id,
+            oco_group_id="g1",
+        )
+    assert book.children_of(parent.order_id) == []
+
+
+def test_submit_attached_rejects_ioc_child() -> None:
+    """IOC/FOK are gated until #388 ships — same as above."""
+    book = OrderBook()
+    parent = _bracket_parent(book)
+    with pytest.raises(UnsupportedOrderFeatureError, match="#388"):
+        book.submit_attached(
+            _base(
+                qty=10.0,
+                order_type=OrderType.LIMIT,
+                limit_price=110.0,
+                tif=TimeInForce.IOC,
+            ),
+            submitted_at="2024-01-03",
+            submitted_equity=100_000.0,
+            parent_order_id=parent.order_id,
+            oco_group_id="g1",
+        )
+    assert book.children_of(parent.order_id) == []

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -106,7 +106,7 @@ def test_remove_default_evicts_top_level_id() -> None:
 
     with pytest.raises(ValueError, match="not a known top-level order id"):
         book.submit_attached(
-            _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+            _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
             submitted_at="2024-01-03",
             submitted_equity=100_000.0,
             parent_order_id=parent.order_id,
@@ -127,7 +127,7 @@ def test_remove_with_was_filled_preserves_top_level_id() -> None:
     book.remove(parent.order_id, was_filled=True)
 
     child = book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
@@ -574,21 +574,27 @@ def test_oco_cancel_siblings_cancels_only_siblings() -> None:
     )
 
     sibling_a = book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
         oco_group_id="g1",
     )
     sibling_b = book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.STOP, stop_price=95.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.STOP, stop_price=95.0),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
         oco_group_id="g1",
     )
     unrelated = book.submit_attached(
-        _base(qty=5.0, symbol="BBB", order_type=OrderType.LIMIT, limit_price=55.0),
+        _base(
+            side=OrderSide.SHORT,
+            qty=5.0,
+            symbol="BBB",
+            order_type=OrderType.LIMIT,
+            limit_price=55.0,
+        ),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=other_parent.order_id,
@@ -647,7 +653,7 @@ def test_oco_cancel_siblings_rejects_mismatched_except_leg() -> None:
         submitted_equity=100_000.0,
     )
     sibling = book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
@@ -680,7 +686,7 @@ def test_oco_cancel_siblings_rejects_bad_id_args(arg, bad_value) -> None:
         submitted_equity=100_000.0,
     )
     sibling = book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
@@ -721,28 +727,40 @@ def test_oco_cancel_siblings_does_not_cross_brackets() -> None:
     )
 
     a_tp = book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=parent_a.order_id,
         oco_group_id="g-shared",
     )
     a_sl = book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.STOP, stop_price=95.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.STOP, stop_price=95.0),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=parent_a.order_id,
         oco_group_id="g-shared",
     )
     b_tp = book.submit_attached(
-        _base(qty=10.0, symbol="BBB", order_type=OrderType.LIMIT, limit_price=210.0),
+        _base(
+            side=OrderSide.SHORT,
+            qty=10.0,
+            symbol="BBB",
+            order_type=OrderType.LIMIT,
+            limit_price=210.0,
+        ),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=parent_b.order_id,
         oco_group_id="g-shared",
     )
     b_sl = book.submit_attached(
-        _base(qty=10.0, symbol="BBB", order_type=OrderType.STOP, stop_price=195.0),
+        _base(
+            side=OrderSide.SHORT,
+            qty=10.0,
+            symbol="BBB",
+            order_type=OrderType.STOP,
+            stop_price=195.0,
+        ),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=parent_b.order_id,
@@ -781,14 +799,14 @@ def test_children_of_returns_only_direct_children() -> None:
         submitted_equity=100_000.0,
     )
     child_a = book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
         oco_group_id="g1",
     )
     child_b = book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.STOP, stop_price=95.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.STOP, stop_price=95.0),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
@@ -801,7 +819,13 @@ def test_children_of_returns_only_direct_children() -> None:
         submitted_equity=100_000.0,
     )
     book.submit_attached(
-        _base(qty=5.0, symbol="BBB", order_type=OrderType.LIMIT, limit_price=55.0),
+        _base(
+            side=OrderSide.SHORT,
+            qty=5.0,
+            symbol="BBB",
+            order_type=OrderType.LIMIT,
+            limit_price=55.0,
+        ),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=other_parent.order_id,
@@ -873,7 +897,7 @@ def test_submit_attached_skips_risk_gates() -> None:
 
     # submit_attached must not raise on the same payload shape.
     child = book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
@@ -893,7 +917,7 @@ def test_submit_attached_indexes_by_symbol() -> None:
         submitted_equity=100_000.0,
     )
     child = book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
@@ -927,7 +951,9 @@ def test_submit_attached_rejects_limit_child_without_price() -> None:
     parent = _bracket_parent(book)
     with pytest.raises(ValueError, match="limit order requires limit_price"):
         book.submit_attached(
-            _base(qty=10.0, order_type=OrderType.LIMIT),  # limit_price missing
+            _base(
+                side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT
+            ),  # limit_price missing
             submitted_at="2024-01-03",
             submitted_equity=100_000.0,
             parent_order_id=parent.order_id,
@@ -942,7 +968,7 @@ def test_submit_attached_rejects_stop_child_without_price() -> None:
     parent = _bracket_parent(book)
     with pytest.raises(ValueError, match="stop order requires stop_price"):
         book.submit_attached(
-            _base(qty=10.0, order_type=OrderType.STOP),  # stop_price missing
+            _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.STOP),  # stop_price missing
             submitted_at="2024-01-03",
             submitted_equity=100_000.0,
             parent_order_id=parent.order_id,
@@ -959,7 +985,9 @@ def test_submit_attached_rejects_trailing_stop_child() -> None:
     parent = _bracket_parent(book)
     with pytest.raises(UnsupportedOrderFeatureError, match="#390"):
         book.submit_attached(
-            _base(qty=10.0, order_type=OrderType.TRAILING_STOP, stop_price=95.0),
+            _base(
+                side=OrderSide.SHORT, qty=10.0, order_type=OrderType.TRAILING_STOP, stop_price=95.0
+            ),
             submitted_at="2024-01-03",
             submitted_equity=100_000.0,
             parent_order_id=parent.order_id,
@@ -976,6 +1004,7 @@ def test_submit_attached_rejects_ioc_child() -> None:
         book.submit_attached(
             _base(
                 qty=10.0,
+                side=OrderSide.SHORT,
                 order_type=OrderType.LIMIT,
                 limit_price=110.0,
                 tif=TimeInForce.IOC,
@@ -1002,7 +1031,7 @@ def test_submit_attached_rejects_bad_parent_order_id(bad_parent) -> None:
     _bracket_parent(book)
     with pytest.raises(TypeError, match="parent_order_id must be a non-empty str"):
         book.submit_attached(
-            _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+            _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
             submitted_at="2024-01-03",
             submitted_equity=100_000.0,
             parent_order_id=bad_parent,
@@ -1018,7 +1047,7 @@ def test_submit_attached_rejects_bad_oco_group_id(bad_group) -> None:
     parent = _bracket_parent(book)
     with pytest.raises(TypeError, match="oco_group_id must be a non-empty str"):
         book.submit_attached(
-            _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+            _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
             submitted_at="2024-01-03",
             submitted_equity=100_000.0,
             parent_order_id=parent.order_id,
@@ -1041,7 +1070,7 @@ def test_submit_attached_rejects_unknown_parent_order_id() -> None:
     book = OrderBook()
     with pytest.raises(ValueError, match="not a known top-level order id"):
         book.submit_attached(
-            _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+            _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
             submitted_at="2024-01-03",
             submitted_equity=100_000.0,
             parent_order_id="o-typo",
@@ -1067,7 +1096,7 @@ def test_submit_attached_accepts_parent_after_removal() -> None:
     assert parent not in book.all_pending()
 
     child = book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
@@ -1091,7 +1120,7 @@ def test_submit_attached_rejects_cancelled_parent() -> None:
 
     with pytest.raises(ValueError, match="not a known top-level order id"):
         book.submit_attached(
-            _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+            _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
             submitted_at="2024-01-03",
             submitted_equity=100_000.0,
             parent_order_id=parent.order_id,
@@ -1114,7 +1143,7 @@ def test_submit_attached_rejects_expired_parent() -> None:
 
     with pytest.raises(ValueError, match="not a known top-level order id"):
         book.submit_attached(
-            _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+            _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
             submitted_at="2024-01-03",
             submitted_equity=100_000.0,
             parent_order_id=parent.order_id,
@@ -1136,7 +1165,7 @@ def test_submit_attached_rejects_attached_child_as_parent() -> None:
         submitted_equity=100_000.0,
     )
     child = book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
@@ -1146,7 +1175,7 @@ def test_submit_attached_rejects_attached_child_as_parent() -> None:
     # parent for another submit_attached must fail.
     with pytest.raises(ValueError, match="not a known top-level order id"):
         book.submit_attached(
-            _base(qty=5.0, order_type=OrderType.STOP, stop_price=95.0),
+            _base(side=OrderSide.SHORT, qty=5.0, order_type=OrderType.STOP, stop_price=95.0),
             submitted_at="2024-01-04",
             submitted_equity=100_000.0,
             parent_order_id=child.order_id,
@@ -1181,7 +1210,13 @@ def test_prune_keeps_active_parents() -> None:
     # Remove the parent but keep its child pending — parent_id is still
     # referenced by an active leg, so prune must keep it.
     book.submit_attached(
-        _base(qty=5.0, symbol="BBB", order_type=OrderType.LIMIT, limit_price=55.0),
+        _base(
+            side=OrderSide.SHORT,
+            qty=5.0,
+            symbol="BBB",
+            order_type=OrderType.LIMIT,
+            limit_price=55.0,
+        ),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=parent_with_child.order_id,
@@ -1195,14 +1230,16 @@ def test_prune_keeps_active_parents() -> None:
     assert pruned == 0
     # Both parent ids still admit new children.
     book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
         submitted_at="2024-01-04",
         submitted_equity=100_000.0,
         parent_order_id=pending_parent.order_id,
         oco_group_id="g1",
     )
     book.submit_attached(
-        _base(qty=5.0, symbol="BBB", order_type=OrderType.STOP, stop_price=45.0),
+        _base(
+            side=OrderSide.SHORT, qty=5.0, symbol="BBB", order_type=OrderType.STOP, stop_price=45.0
+        ),
         submitted_at="2024-01-04",
         submitted_equity=100_000.0,
         parent_order_id=parent_with_child.order_id,
@@ -1233,7 +1270,7 @@ def test_prune_evicts_fully_resolved_parents() -> None:
     # fully resolved.
     with pytest.raises(ValueError, match="not a known top-level order id"):
         book.submit_attached(
-            _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+            _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
             submitted_at="2024-01-04",
             submitted_equity=100_000.0,
             parent_order_id=parent.order_id,
@@ -1300,14 +1337,14 @@ def test_expire_day_orders_cascades_to_pending_children() -> None:
     # Children submitted while the parent is still pending (preventive
     # bracket pattern). Use GTC so the children themselves don't expire.
     child_a = book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
         oco_group_id="g1",
     )
     child_b = book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.STOP, stop_price=95.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.STOP, stop_price=95.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
@@ -1401,14 +1438,14 @@ def _bracket_with_two_children(book: OrderBook):
         submitted_equity=100_000.0,
     )
     child_a = book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
         oco_group_id="g1",
     )
     child_b = book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.STOP, stop_price=95.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.STOP, stop_price=95.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
@@ -1475,7 +1512,7 @@ def test_filled_parent_remains_eligible_while_children_pending() -> None:
     book.remove(parent.order_id, was_filled=True)  # entry fills
     # Both children still pending — parent stays eligible.
     book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.STOP, stop_price=90.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.STOP, stop_price=90.0),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
@@ -1485,7 +1522,7 @@ def test_filled_parent_remains_eligible_while_children_pending() -> None:
     # leg pending, so still eligible.
     book.cancel(child_a.order_id)
     book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=120.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=120.0),
         submitted_at="2024-01-04",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
@@ -1507,7 +1544,7 @@ def test_filled_parent_auto_evicted_when_last_child_resolves() -> None:
     book.requeue(child_a.order_id, new_remaining_qty=0.0, new_submitted_at="2024-01-03")
     # Parent still eligible — child_b is pending.
     book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.STOP, stop_price=90.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.STOP, stop_price=90.0),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
@@ -1520,7 +1557,7 @@ def test_filled_parent_auto_evicted_when_last_child_resolves() -> None:
     # Last child gone → parent auto-evicted. New submit_attached fails.
     with pytest.raises(ValueError, match="not a known top-level order id"):
         book.submit_attached(
-            _base(qty=10.0, order_type=OrderType.STOP, stop_price=85.0),
+            _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.STOP, stop_price=85.0),
             submitted_at="2024-01-04",
             submitted_equity=100_000.0,
             parent_order_id=parent.order_id,
@@ -1540,7 +1577,7 @@ def test_filled_parent_evicted_when_only_child_terminal_fills() -> None:
         submitted_equity=100_000.0,
     )
     child = book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
@@ -1550,7 +1587,7 @@ def test_filled_parent_evicted_when_only_child_terminal_fills() -> None:
     book.requeue(child.order_id, new_remaining_qty=0.0, new_submitted_at="2024-01-03")
     with pytest.raises(ValueError, match="not a known top-level order id"):
         book.submit_attached(
-            _base(qty=10.0, order_type=OrderType.STOP, stop_price=95.0),
+            _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.STOP, stop_price=95.0),
             submitted_at="2024-01-04",
             submitted_equity=100_000.0,
             parent_order_id=parent.order_id,
@@ -1588,7 +1625,13 @@ def test_submit_attached_rejects_symbol_mismatch() -> None:
     )
     with pytest.raises(ValueError, match="does not match parent"):
         book.submit_attached(
-            _base(qty=10.0, symbol="BBB", order_type=OrderType.LIMIT, limit_price=110.0),
+            _base(
+                side=OrderSide.SHORT,
+                qty=10.0,
+                symbol="BBB",
+                order_type=OrderType.LIMIT,
+                limit_price=110.0,
+            ),
             submitted_at="2024-01-03",
             submitted_equity=100_000.0,
             parent_order_id=parent.order_id,
@@ -1610,7 +1653,13 @@ def test_submit_attached_accepts_matching_symbol_after_parent_filled() -> None:
     )
     book.remove(parent.order_id, was_filled=True)
     book.submit_attached(  # matching symbol — accepted
-        _base(qty=10.0, symbol="AAA", order_type=OrderType.LIMIT, limit_price=110.0),
+        _base(
+            side=OrderSide.SHORT,
+            qty=10.0,
+            symbol="AAA",
+            order_type=OrderType.LIMIT,
+            limit_price=110.0,
+        ),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
@@ -1618,7 +1667,13 @@ def test_submit_attached_accepts_matching_symbol_after_parent_filled() -> None:
     )
     with pytest.raises(ValueError, match="does not match parent"):
         book.submit_attached(
-            _base(qty=10.0, symbol="BBB", order_type=OrderType.STOP, stop_price=95.0),
+            _base(
+                side=OrderSide.SHORT,
+                qty=10.0,
+                symbol="BBB",
+                order_type=OrderType.STOP,
+                stop_price=95.0,
+            ),
             submitted_at="2024-01-03",
             submitted_equity=100_000.0,
             parent_order_id=parent.order_id,
@@ -1656,7 +1711,7 @@ def test_no_auto_evict_while_parent_still_pending() -> None:
         submitted_equity=100_000.0,
     )
     child = book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
@@ -1665,7 +1720,7 @@ def test_no_auto_evict_while_parent_still_pending() -> None:
     book.cancel(child.order_id)
     # Parent is still pending → still eligible. Submit a new child.
     book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.STOP, stop_price=95.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.STOP, stop_price=95.0),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
@@ -1685,7 +1740,13 @@ def test_cancel_only_cancels_direct_children_of_target() -> None:
         submitted_equity=100_000.0,
     )
     child_b = book.submit_attached(
-        _base(qty=5.0, symbol="BBB", order_type=OrderType.LIMIT, limit_price=55.0),
+        _base(
+            side=OrderSide.SHORT,
+            qty=5.0,
+            symbol="BBB",
+            order_type=OrderType.LIMIT,
+            limit_price=55.0,
+        ),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
         parent_order_id=parent_b.order_id,
@@ -1715,7 +1776,7 @@ def test_submit_attached_disarmed_when_parent_still_pending() -> None:
         submitted_equity=100_000.0,
     )
     child = book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
@@ -1735,7 +1796,7 @@ def test_submit_attached_armed_when_parent_already_filled() -> None:
     )
     book.remove(parent.order_id, was_filled=True)  # entry fills
     child = book.submit_attached(
-        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
         submitted_at="2024-01-03",
         submitted_equity=100_000.0,
         parent_order_id=parent.order_id,
@@ -1756,10 +1817,126 @@ def test_submit_attached_rejects_market_child() -> None:
     )
     with pytest.raises(ValueError, match="not MARKET"):
         book.submit_attached(
-            _base(qty=10.0, order_type=OrderType.MARKET),
+            _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.MARKET),
             submitted_at="2024-01-03",
             submitted_equity=100_000.0,
             parent_order_id=parent.order_id,
             oco_group_id="g1",
         )
     assert book.children_of(parent.order_id) == []
+
+
+# ---------------------------------------------------------------------------
+# Bracket children must take the opposite side from the parent — protective
+# legs close out the parent's position. A same-side child would be silently
+# dropped by the simulator's same-side path, leaving the bracket unprotected.
+# ---------------------------------------------------------------------------
+
+
+def test_submit_attached_rejects_same_side_long_child() -> None:
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0, side=OrderSide.LONG),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    with pytest.raises(ValueError, match="must be opposite parent"):
+        book.submit_attached(
+            _base(side=OrderSide.LONG, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+            submitted_at="2024-01-03",
+            submitted_equity=100_000.0,
+            parent_order_id=parent.order_id,
+            oco_group_id="g1",
+        )
+    assert book.children_of(parent.order_id) == []
+
+
+def test_submit_attached_rejects_same_side_short_child() -> None:
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0, side=OrderSide.SHORT),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    with pytest.raises(ValueError, match="must be opposite parent"):
+        book.submit_attached(
+            _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.STOP, stop_price=110.0),
+            submitted_at="2024-01-03",
+            submitted_equity=100_000.0,
+            parent_order_id=parent.order_id,
+            oco_group_id="g1",
+        )
+
+
+def test_submit_attached_accepts_short_child_for_long_parent() -> None:
+    """Sanity: a LONG entry with a SHORT take-profit (protective leg) is
+    the canonical bracket and must succeed.
+    """
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0, side=OrderSide.LONG),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    child = book.submit_attached(
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    assert child.request.side == OrderSide.SHORT
+
+
+# ---------------------------------------------------------------------------
+# requeue's terminal-fill path forwards ``was_filled`` to ``remove()`` so
+# future callers (e.g. partial-fill on exits in #386) can opt out of the
+# eligible-parent registration.
+# ---------------------------------------------------------------------------
+
+
+def test_requeue_terminal_fill_default_was_filled_preserves_eligibility() -> None:
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    # Default ``was_filled=True`` (entry-style).
+    book.requeue(po.order_id, new_remaining_qty=0.0, new_submitted_at="2024-01-03")
+    # Parent's id is still eligible — bracket children can be activated.
+    book.submit_attached(
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        submitted_at="2024-01-04",
+        submitted_equity=100_000.0,
+        parent_order_id=po.order_id,
+        oco_group_id="g1",
+    )
+
+
+def test_requeue_terminal_fill_was_filled_false_evicts() -> None:
+    """A future caller handling a non-entry partial fill (e.g. an exit
+    closing out a position) passes ``was_filled=False`` so the order's id
+    is NOT registered as a future bracket parent.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    book.requeue(
+        po.order_id,
+        new_remaining_qty=0.0,
+        new_submitted_at="2024-01-03",
+        was_filled=False,
+    )
+    # Now the id is no longer eligible to receive bracket children.
+    with pytest.raises(ValueError, match="not a known top-level order id"):
+        book.submit_attached(
+            _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+            submitted_at="2024-01-04",
+            submitted_equity=100_000.0,
+            parent_order_id=po.order_id,
+            oco_group_id="g1",
+        )

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -158,6 +158,74 @@ def test_requeue_twap_slices_passthrough() -> None:
     assert po.twap_slices_remaining is None
 
 
+def test_requeue_keeps_cumulative_filled_consistent() -> None:
+    """``requeue`` must update ``cumulative_filled_qty`` so the invariant
+    ``original_qty == cumulative_filled_qty + remaining_qty`` holds after each
+    partial-fill remainder. Otherwise downstream Fill / analytics readers see
+    stale fill progress.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    assert po.cumulative_filled_qty == 0.0
+
+    book.requeue(po.order_id, new_remaining_qty=6.0, new_submitted_at="2024-01-03")
+    assert po.cumulative_filled_qty == 4.0
+    assert po.original_qty == po.cumulative_filled_qty + po.remaining_qty
+
+    book.requeue(po.order_id, new_remaining_qty=1.0, new_submitted_at="2024-01-04")
+    assert po.cumulative_filled_qty == 9.0
+    assert po.original_qty == po.cumulative_filled_qty + po.remaining_qty
+
+    # Fully filled — remainder collapses to zero.
+    book.requeue(po.order_id, new_remaining_qty=0.0, new_submitted_at="2024-01-05")
+    assert po.cumulative_filled_qty == 10.0
+    assert po.remaining_qty == 0.0
+
+
+def test_requeue_rejects_negative_remaining_qty() -> None:
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    with pytest.raises(ValueError, match="must be >= 0"):
+        book.requeue(po.order_id, new_remaining_qty=-1.0, new_submitted_at="2024-01-03")
+    # State unchanged.
+    assert po.remaining_qty == 10.0
+    assert po.cumulative_filled_qty == 0.0
+
+
+def test_requeue_rejects_growing_remaining_qty() -> None:
+    """A partial fill can only shrink the remainder. Growing it (e.g. an off-by-one
+    or stale state in the caller) would imply a negative fill, which has no
+    execution semantics.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    # First a real partial fill.
+    book.requeue(po.order_id, new_remaining_qty=4.0, new_submitted_at="2024-01-03")
+
+    # Trying to grow back to 6.0 is rejected even though it's still <= original_qty.
+    with pytest.raises(ValueError, match="must not exceed current remaining_qty"):
+        book.requeue(po.order_id, new_remaining_qty=6.0, new_submitted_at="2024-01-04")
+    # State preserved from the legitimate partial fill.
+    assert po.remaining_qty == 4.0
+    assert po.cumulative_filled_qty == 6.0
+
+    # And a value larger than original_qty is also rejected.
+    with pytest.raises(ValueError, match="must not exceed current remaining_qty"):
+        book.requeue(po.order_id, new_remaining_qty=11.0, new_submitted_at="2024-01-04")
+
+
 # ---------------------------------------------------------------------------
 # OCO sibling cancellation
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -61,6 +61,79 @@ def test_submit_initializes_partial_fill_fields() -> None:
     assert po.rejection_reason is None
 
 
+def test_submit_rejects_request_with_parent_order_id() -> None:
+    """Defense in depth — strategy-side ``validate_prices()`` already rejects
+    these fields, but ``submit()`` is the gateway that registers an id as an
+    eligible bracket parent. Refusing child-shaped requests here prevents an
+    internal caller that bypasses ``validate_prices`` from smuggling an
+    attached order into the eligible-parent set.
+    """
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    bad_request = _base(qty=5.0).model_copy(update={"parent_order_id": parent.order_id})
+    with pytest.raises(ValueError, match="must not receive a request with parent_order_id"):
+        book.submit(bad_request, submitted_at="2024-01-03", submitted_equity=100_000.0)
+
+
+def test_submit_rejects_request_with_oco_group_id() -> None:
+    book = OrderBook()
+    bad_request = _base(qty=10.0).model_copy(update={"oco_group_id": "g1"})
+    with pytest.raises(ValueError, match="must not receive a request with parent_order_id"):
+        book.submit(bad_request, submitted_at="2024-01-02", submitted_equity=100_000.0)
+    assert book.all_pending() == []
+
+
+def test_remove_default_evicts_top_level_id() -> None:
+    """``remove(was_filled=False)`` (default) is the safe path used for risk-
+    rejection / insufficient-capital paths in ``fill_simulator``: the parent
+    never opened, so its id must be evicted from the eligible-parent set so
+    a later ``submit_attached`` doesn't attach children to a non-existent
+    entry. Distinct from ``requeue(0)`` which uses ``was_filled=True``.
+    """
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    book.remove(parent.order_id)  # default was_filled=False — non-fill path
+
+    with pytest.raises(ValueError, match="not a known top-level order id"):
+        book.submit_attached(
+            _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+            submitted_at="2024-01-03",
+            submitted_equity=100_000.0,
+            parent_order_id=parent.order_id,
+            oco_group_id="g1",
+        )
+
+
+def test_remove_with_was_filled_preserves_top_level_id() -> None:
+    """``remove(was_filled=True)`` is the terminal-fill path — keeps the id
+    eligible so bracket children can still be activated against it.
+    """
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    book.remove(parent.order_id, was_filled=True)
+
+    child = book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    assert child.request.parent_order_id == parent.order_id
+
+
 # ---------------------------------------------------------------------------
 # Submit → requeue → remove cycle
 # ---------------------------------------------------------------------------
@@ -986,7 +1059,9 @@ def test_submit_attached_accepts_parent_after_removal() -> None:
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
     )
-    book.remove(parent.order_id)
+    # Simulate the terminal-fill removal path used by ``requeue(0)``;
+    # ``was_filled=True`` keeps the parent eligible for bracket children.
+    book.remove(parent.order_id, was_filled=True)
     assert parent not in book.all_pending()
 
     child = book.submit_attached(
@@ -1110,7 +1185,9 @@ def test_prune_keeps_active_parents() -> None:
         parent_order_id=parent_with_child.order_id,
         oco_group_id="g2",
     )
-    book.remove(parent_with_child.order_id)
+    # Filled parent (was_filled=True) — keeps the id in the eligible-parent
+    # set so the still-pending child can later be referenced.
+    book.remove(parent_with_child.order_id, was_filled=True)
 
     pruned = book.prune_known_top_level_order_ids()
     assert pruned == 0
@@ -1142,7 +1219,9 @@ def test_prune_evicts_fully_resolved_parents() -> None:
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
     )
-    book.remove(parent.order_id)
+    # Filled-parent removal: keeps the id in the eligible-parent set so
+    # ``prune_known_top_level_order_ids`` is the natural eviction path.
+    book.remove(parent.order_id, was_filled=True)
     assert book.children_of(parent.order_id) == []
 
     pruned = book.prune_known_top_level_order_ids()
@@ -1202,3 +1281,105 @@ def test_expire_day_orders_keeps_order_on_original_day() -> None:
     book.requeue(po.order_id, new_remaining_qty=5.0, new_submitted_at="2024-01-02")
     assert book.expire_day_orders("2024-01-02") == []
     assert po in book.all_pending()
+
+
+def test_expire_day_orders_cascades_to_pending_children() -> None:
+    """When a top-level DAY order expires unfilled, any already-pending
+    attached children must also be cancelled — otherwise the orphan
+    protective legs would execute as standalone orders without the parent
+    entry having ever opened.
+    """
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0, tif=TimeInForce.DAY),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    # Children submitted while the parent is still pending (preventive
+    # bracket pattern). Use GTC so the children themselves don't expire.
+    child_a = book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    child_b = book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.STOP, stop_price=95.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    # Parent expires at end-of-session — children must be cascaded out.
+    expired = book.expire_day_orders("2024-01-03")
+    assert expired == [parent]
+    assert book.all_pending() == []
+    assert child_a not in book.all_pending()
+    assert child_b not in book.all_pending()
+
+
+# ---------------------------------------------------------------------------
+# requeue uses datetime-aware timestamp comparison so equivalent ISO 8601
+# instants in different timezone offsets don't trip the regression guard.
+# ---------------------------------------------------------------------------
+
+
+def test_requeue_treats_equivalent_offsets_as_equal() -> None:
+    """``2024-01-02T10:00:00+05:30`` and ``2024-01-02T04:30:00+00:00`` are the
+    same instant. Lexicographic string compare would falsely reject the
+    second as a regression (``+`` ASCII < ``+05:30`` literally is fine, but
+    the time portion sorts ``04:`` before ``10:``). Datetime parsing fixes
+    this.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02T10:00:00+05:30",
+        submitted_equity=100_000.0,
+    )
+    # Same instant in UTC offset — must not raise.
+    book.requeue(
+        po.order_id,
+        new_remaining_qty=4.0,
+        new_submitted_at="2024-01-02T04:30:00+00:00",
+    )
+    assert po.remaining_qty == 4.0
+
+
+def test_requeue_rejects_strictly_earlier_instant_across_offsets() -> None:
+    """Datetime-aware compare still rejects a genuinely earlier instant
+    expressed in a different offset.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02T10:00:00+00:00",
+        submitted_equity=100_000.0,
+    )
+    # 09:00 IST = 03:30 UTC, which is before 10:00 UTC → regression.
+    with pytest.raises(ValueError, match="must not regress"):
+        book.requeue(
+            po.order_id,
+            new_remaining_qty=5.0,
+            new_submitted_at="2024-01-02T09:00:00+05:30",
+        )
+
+
+def test_requeue_falls_back_to_string_compare_for_unparseable_ts() -> None:
+    """When a timestamp doesn't parse as ISO 8601, the regression guard
+    falls back to normalised string comparison so callers using non-ISO
+    formats aren't silently accepted in either direction.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="bar-2024-01-02",  # not ISO 8601
+        submitted_equity=100_000.0,
+    )
+    # Lexicographically earlier — should still raise via string fallback.
+    with pytest.raises(ValueError, match="must not regress"):
+        book.requeue(po.order_id, new_remaining_qty=5.0, new_submitted_at="bar-2024-01-01")
+    # And same lexicographic ordering forward — accepted.
+    book.requeue(po.order_id, new_remaining_qty=4.0, new_submitted_at="bar-2024-01-03")
+    assert po.remaining_qty == 4.0

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -301,6 +301,25 @@ def test_requeue_rejects_nan_and_inf_remaining_qty() -> None:
     assert po.cumulative_filled_qty == 0.0
 
 
+@pytest.mark.parametrize("bad_qty", [True, False])
+def test_requeue_rejects_bool_remaining_qty(bad_qty) -> None:
+    """``bool`` is a subclass of ``int`` in Python, so ``True``/``False`` would
+    otherwise pass ``math.isfinite`` and the range checks and silently land in
+    ``remaining_qty`` as ``1``/``0``. Reject them explicitly.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    with pytest.raises(ValueError, match="must be a real number, got bool"):
+        book.requeue(po.order_id, new_remaining_qty=bad_qty, new_submitted_at="2024-01-03")
+    # State unchanged.
+    assert po.remaining_qty == 10.0
+    assert po.cumulative_filled_qty == 0.0
+
+
 def test_requeue_unknown_order_id_raises_keyerror() -> None:
     """A stale/missing id is a partial-fill bug, not an idempotent removal —
     raise loudly with a clear message rather than silently no-op like
@@ -411,6 +430,44 @@ def test_oco_cancel_siblings_empty_when_no_match() -> None:
         )
         == []
     )
+
+
+@pytest.mark.parametrize("arg", ["oco_group_id", "except_order_id", "parent_order_id"])
+@pytest.mark.parametrize("bad_value", [None, "", 123, 1.5])
+def test_oco_cancel_siblings_rejects_bad_id_args(arg, bad_value) -> None:
+    """``OrderRequest`` stores ``oco_group_id``/``parent_order_id`` as
+    ``Optional[str]`` defaulting to ``None``, so calling
+    ``oco_cancel_siblings`` with ``None`` (or any non-string) for either id
+    would equality-match every ordinary parent order in the book and nuke
+    unrelated orders. Reject all three id args defensively.
+    """
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    sibling = book.submit_attached(
+        _base(qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    kwargs: dict = {
+        "oco_group_id": "g1",
+        "except_order_id": sibling.order_id,
+        "parent_order_id": parent.order_id,
+    }
+    kwargs[arg] = bad_value
+    with pytest.raises(TypeError, match=f"{arg} must be a non-empty str"):
+        book.oco_cancel_siblings(
+            kwargs.pop("oco_group_id"),
+            except_order_id=kwargs["except_order_id"],
+            parent_order_id=kwargs["parent_order_id"],
+        )
+    # Nothing got cancelled — both pending orders are still in the book.
+    assert {po.order_id for po in book.all_pending()} == {parent.order_id, sibling.order_id}
 
 
 def test_oco_cancel_siblings_does_not_cross_brackets() -> None:

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -51,6 +51,7 @@ def test_submit_initializes_partial_fill_fields() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     assert isinstance(po, PendingOrder)
     assert po.original_qty == 10.0
@@ -75,6 +76,7 @@ def test_submit_rejects_request_with_parent_order_id() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     bad_request = _base(qty=5.0).model_copy(update={"parent_order_id": parent.order_id})
     with pytest.raises(ValueError, match="must not receive a request with parent_order_id"):
@@ -101,6 +103,7 @@ def test_remove_default_evicts_top_level_id() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     book.remove(parent.order_id)  # default was_filled=False — non-fill path
 
@@ -123,6 +126,7 @@ def test_remove_with_was_filled_preserves_top_level_id() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     book.remove(parent.order_id, was_filled=True)
 
@@ -147,6 +151,7 @@ def test_submit_requeue_remove_cycle() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     order_id = po.order_id
 
@@ -177,6 +182,7 @@ def test_requeue_refreshes_submitted_at() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     book.requeue(po.order_id, new_remaining_qty=5.0, new_submitted_at="2024-01-05")
     assert po.submitted_at == "2024-01-05"
@@ -188,6 +194,7 @@ def test_requeue_stale_timestamp_raises() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-05",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     # Use ValueError (not assert) so the guard survives ``python -O``.
     with pytest.raises(ValueError, match="must not regress"):
@@ -204,6 +211,7 @@ def test_requeue_same_timestamp_allowed() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     # Equal timestamps are fine — the bar-safety guard fires only on strict
     # look-ahead, and intra-bar partial fills may legitimately requeue on the
@@ -223,6 +231,7 @@ def test_requeue_normalizes_z_suffix_timestamp() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02T10:00:00+00:00",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     # Same instant, just expressed with the Z suffix.
     book.requeue(
@@ -239,6 +248,7 @@ def test_requeue_normalizes_z_suffix_timestamp() -> None:
         _base(qty=5.0, symbol="BBB"),
         submitted_at="2024-01-02T10:00:00Z",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     book.requeue(
         po2.order_id,
@@ -254,6 +264,7 @@ def test_requeue_twap_slices_passthrough() -> None:
         _base(qty=12.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     book.requeue(
         po.order_id,
@@ -280,6 +291,7 @@ def test_requeue_accepts_zero_twap_slices() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     book.requeue(
         po.order_id,
@@ -302,6 +314,7 @@ def test_requeue_rejects_bad_twap_slices(bad_slices) -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     with pytest.raises(
         ValueError, match="twap_slices_remaining must be a non-negative int or None"
@@ -329,6 +342,7 @@ def test_requeue_keeps_cumulative_filled_consistent() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     assert po.cumulative_filled_qty == 0.0
 
@@ -356,6 +370,7 @@ def test_requeue_rejects_negative_remaining_qty() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     with pytest.raises(ValueError, match="must be >= 0"):
         book.requeue(po.order_id, new_remaining_qty=-1.0, new_submitted_at="2024-01-03")
@@ -374,6 +389,7 @@ def test_requeue_rejects_growing_remaining_qty() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     # First a real partial fill.
     book.requeue(po.order_id, new_remaining_qty=4.0, new_submitted_at="2024-01-03")
@@ -399,6 +415,7 @@ def test_requeue_rejects_nan_and_inf_remaining_qty() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
 
     with pytest.raises(ValueError, match="must be finite"):
@@ -424,6 +441,7 @@ def test_requeue_rejects_bool_remaining_qty(bad_qty) -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     with pytest.raises(ValueError, match="must be a real number, got bool"):
         book.requeue(po.order_id, new_remaining_qty=bad_qty, new_submitted_at="2024-01-03")
@@ -442,6 +460,7 @@ def test_requeue_unknown_order_id_raises_keyerror() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     with pytest.raises(KeyError, match="not in the book"):
         book.requeue("o-bogus", new_remaining_qty=5.0, new_submitted_at="2024-01-03")
@@ -459,6 +478,7 @@ def test_requeue_zero_remainder_removes_order_from_book() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     # First a real partial fill — order remains in the book.
     book.requeue(po.order_id, new_remaining_qty=4.0, new_submitted_at="2024-01-03")
@@ -492,6 +512,7 @@ def test_requeue_clamps_tiny_positive_residual_to_zero(residual) -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     book.requeue(po.order_id, new_remaining_qty=residual, new_submitted_at="2024-01-03")
     assert po.remaining_qty == 0.0
@@ -511,6 +532,7 @@ def test_requeue_clamps_tiny_negative_residual_to_zero(residual) -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     book.requeue(po.order_id, new_remaining_qty=residual, new_submitted_at="2024-01-03")
     assert po.remaining_qty == 0.0
@@ -527,6 +549,7 @@ def test_requeue_preserves_remainder_above_epsilon() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     above = FILL_QTY_EPSILON * 100  # 1e-7 — well above the clamp tolerance
     book.requeue(po.order_id, new_remaining_qty=above, new_submitted_at="2024-01-03")
@@ -544,6 +567,7 @@ def test_requeue_rejects_negative_above_epsilon() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     with pytest.raises(ValueError, match="must be >= 0"):
         book.requeue(
@@ -566,11 +590,13 @@ def test_oco_cancel_siblings_cancels_only_siblings() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     other_parent = book.submit(
         _base(qty=5.0, symbol="BBB"),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
 
     sibling_a = book.submit_attached(
@@ -632,6 +658,7 @@ def test_oco_cancel_siblings_rejects_stale_except_order_id() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     with pytest.raises(ValueError, match="is not currently pending"):
         book.oco_cancel_siblings(
@@ -651,6 +678,7 @@ def test_oco_cancel_siblings_rejects_mismatched_except_leg() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     sibling = book.submit_attached(
         _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
@@ -684,6 +712,7 @@ def test_oco_cancel_siblings_rejects_bad_id_args(arg, bad_value) -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     sibling = book.submit_attached(
         _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
@@ -719,11 +748,13 @@ def test_oco_cancel_siblings_does_not_cross_brackets() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     parent_b = book.submit(
         _base(qty=10.0, symbol="BBB"),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
 
     a_tp = book.submit_attached(
@@ -797,6 +828,7 @@ def test_children_of_returns_only_direct_children() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     child_a = book.submit_attached(
         _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
@@ -817,6 +849,7 @@ def test_children_of_returns_only_direct_children() -> None:
         _base(qty=5.0, symbol="BBB"),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     book.submit_attached(
         _base(
@@ -842,6 +875,7 @@ def test_children_of_returns_empty_for_unknown_parent() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     assert book.children_of("nope") == []
 
@@ -858,6 +892,7 @@ def test_children_of_rejects_bad_parent_id(bad_parent) -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     with pytest.raises(TypeError, match="parent_order_id must be a non-empty str"):
         book.children_of(bad_parent)
@@ -879,6 +914,7 @@ def test_submit_attached_skips_risk_gates() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
 
     # Independent proof that the gate is real on the strategy path.
@@ -915,6 +951,7 @@ def test_submit_attached_indexes_by_symbol() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     child = book.submit_attached(
         _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
@@ -943,6 +980,7 @@ def _bracket_parent(book: OrderBook):
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
 
 
@@ -1089,6 +1127,7 @@ def test_submit_attached_accepts_parent_after_removal() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     # Simulate the terminal-fill removal path used by ``requeue(0)``;
     # ``was_filled=True`` keeps the parent eligible for bracket children.
@@ -1115,6 +1154,7 @@ def test_submit_attached_rejects_cancelled_parent() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     assert book.cancel(parent.order_id) is True
 
@@ -1137,6 +1177,7 @@ def test_submit_attached_rejects_expired_parent() -> None:
         _base(qty=10.0, tif=TimeInForce.DAY),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     expired = book.expire_day_orders("2024-01-03")
     assert expired == [parent]
@@ -1163,6 +1204,7 @@ def test_submit_attached_rejects_attached_child_as_parent() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     child = book.submit_attached(
         _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
@@ -1201,11 +1243,13 @@ def test_prune_keeps_active_parents() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     parent_with_child = book.submit(
         _base(qty=5.0, symbol="BBB"),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     # Remove the parent but keep its child pending — parent_id is still
     # referenced by an active leg, so prune must keep it.
@@ -1257,6 +1301,7 @@ def test_prune_evicts_fully_resolved_parents() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     # Filled-parent removal: keeps the id in the eligible-parent set so
     # ``prune_known_top_level_order_ids`` is the natural eviction path.
@@ -1291,6 +1336,7 @@ def test_expire_day_orders_uses_original_submitted_at() -> None:
         _base(qty=10.0, tif=TimeInForce.DAY),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     # Partial fill bumps ``submitted_at`` to D+1 so the look-ahead guard still
     # holds, but the original submission date is preserved separately.
@@ -1315,6 +1361,7 @@ def test_expire_day_orders_keeps_order_on_original_day() -> None:
         _base(qty=10.0, tif=TimeInForce.DAY),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     # Same-day requeue (the look-ahead guard allows equal timestamps).
     book.requeue(po.order_id, new_remaining_qty=5.0, new_submitted_at="2024-01-02")
@@ -1333,6 +1380,7 @@ def test_expire_day_orders_cascades_to_pending_children() -> None:
         _base(qty=10.0, tif=TimeInForce.DAY),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     # Children submitted while the parent is still pending (preventive
     # bracket pattern). Use GTC so the children themselves don't expire.
@@ -1376,6 +1424,7 @@ def test_requeue_treats_equivalent_offsets_as_equal() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02T10:00:00+05:30",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     # Same instant in UTC offset — must not raise.
     book.requeue(
@@ -1395,6 +1444,7 @@ def test_requeue_rejects_strictly_earlier_instant_across_offsets() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02T10:00:00+00:00",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     # 09:00 IST = 03:30 UTC, which is before 10:00 UTC → regression.
     with pytest.raises(ValueError, match="must not regress"):
@@ -1436,6 +1486,7 @@ def _bracket_with_two_children(book: OrderBook):
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     child_a = book.submit_attached(
         _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
@@ -1575,6 +1626,7 @@ def test_filled_parent_evicted_when_only_child_terminal_fills() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     child = book.submit_attached(
         _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
@@ -1605,6 +1657,7 @@ def test_book_contains_membership_test() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     assert po.order_id in book
     assert "o-bogus" not in book
@@ -1622,6 +1675,7 @@ def test_submit_attached_rejects_symbol_mismatch() -> None:
         _base(qty=10.0, symbol="AAA"),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     with pytest.raises(ValueError, match="does not match parent"):
         book.submit_attached(
@@ -1650,6 +1704,7 @@ def test_submit_attached_accepts_matching_symbol_after_parent_filled() -> None:
         _base(qty=10.0, symbol="AAA"),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     book.remove(parent.order_id, was_filled=True)
     book.submit_attached(  # matching symbol — accepted
@@ -1691,6 +1746,7 @@ def test_requeue_rejects_non_string_submitted_at() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     for bad in (None, 123, 1.5, datetime(2024, 1, 5)):
         with pytest.raises(TypeError, match="must be a str"):
@@ -1709,6 +1765,7 @@ def test_no_auto_evict_while_parent_still_pending() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     child = book.submit_attached(
         _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
@@ -1738,6 +1795,7 @@ def test_cancel_only_cancels_direct_children_of_target() -> None:
         _base(qty=5.0, symbol="BBB"),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     child_b = book.submit_attached(
         _base(
@@ -1774,6 +1832,7 @@ def test_submit_attached_disarmed_when_parent_still_pending() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     child = book.submit_attached(
         _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
@@ -1793,6 +1852,7 @@ def test_submit_attached_armed_when_parent_already_filled() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     book.remove(parent.order_id, was_filled=True)  # entry fills
     child = book.submit_attached(
@@ -1814,6 +1874,7 @@ def test_submit_attached_rejects_market_child() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     with pytest.raises(ValueError, match="not MARKET"):
         book.submit_attached(
@@ -1839,6 +1900,7 @@ def test_submit_attached_rejects_same_side_long_child() -> None:
         _base(qty=10.0, side=OrderSide.LONG),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     with pytest.raises(ValueError, match="must be opposite parent"):
         book.submit_attached(
@@ -1857,6 +1919,7 @@ def test_submit_attached_rejects_same_side_short_child() -> None:
         _base(qty=10.0, side=OrderSide.SHORT),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     with pytest.raises(ValueError, match="must be opposite parent"):
         book.submit_attached(
@@ -1877,6 +1940,7 @@ def test_submit_attached_accepts_short_child_for_long_parent() -> None:
         _base(qty=10.0, side=OrderSide.LONG),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     child = book.submit_attached(
         _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
@@ -1901,6 +1965,7 @@ def test_requeue_terminal_fill_default_was_filled_preserves_eligibility() -> Non
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     # Default ``was_filled=True`` (entry-style).
     book.requeue(po.order_id, new_remaining_qty=0.0, new_submitted_at="2024-01-03")
@@ -1924,6 +1989,7 @@ def test_requeue_terminal_fill_was_filled_false_evicts() -> None:
         _base(qty=10.0),
         submitted_at="2024-01-02",
         submitted_equity=100_000.0,
+        expect_brackets=True,
     )
     book.requeue(
         po.order_id,
@@ -1940,3 +2006,70 @@ def test_requeue_terminal_fill_was_filled_false_evicts() -> None:
             parent_order_id=po.order_id,
             oco_group_id="g1",
         )
+
+
+# ---------------------------------------------------------------------------
+# expect_brackets opt-in: only orders submitted with ``expect_brackets=True``
+# register in ``_known_top_level_order_ids``. Non-bracket strategies pay no
+# memory cost, and stale-id reuse drops to near-zero since the set only
+# contains parents the strategy has explicitly declared bracket intent for.
+# ---------------------------------------------------------------------------
+
+
+def test_submit_default_does_not_register_eligible_parent() -> None:
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+        # expect_brackets omitted → defaults to False
+    )
+    # ``submit_attached`` correctly fails: the strategy didn't declare bracket
+    # intent at submission time, so the parent's id was never registered.
+    with pytest.raises(ValueError, match="not a known top-level order id"):
+        book.submit_attached(
+            _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+            submitted_at="2024-01-03",
+            submitted_equity=100_000.0,
+            parent_order_id=parent.order_id,
+            oco_group_id="g1",
+        )
+
+
+def test_submit_with_expect_brackets_registers_eligible_parent() -> None:
+    book = OrderBook()
+    parent = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+        expect_brackets=True,
+    )
+    # Now ``submit_attached`` succeeds — the strategy declared bracket intent.
+    child = book.submit_attached(
+        _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    assert child.request.parent_order_id == parent.order_id
+
+
+# ---------------------------------------------------------------------------
+# requeue rejects non-numeric ``new_remaining_qty`` with a structured
+# ``TypeError`` rather than letting ``math.isfinite`` raise its own.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad_qty", ["10", b"10", None, [10.0], object()])
+def test_requeue_rejects_non_numeric_remaining_qty(bad_qty) -> None:
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    with pytest.raises(TypeError, match="must be int or float"):
+        book.requeue(po.order_id, new_remaining_qty=bad_qty, new_submitted_at="2024-01-03")
+    # State unchanged.
+    assert po.remaining_qty == 10.0

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import pytest
 
 from investment_team.trading_service.engine.order_book import (
+    FILL_QTY_EPSILON,
     OrderBook,
     PendingOrder,
 )
@@ -366,6 +367,82 @@ def test_requeue_zero_remainder_removes_order_from_book() -> None:
         book.requeue(po.order_id, new_remaining_qty=0.0, new_submitted_at="2024-01-05")
 
 
+@pytest.mark.parametrize("residual", [1e-15, 1e-12, FILL_QTY_EPSILON / 2])
+def test_requeue_clamps_tiny_positive_residual_to_zero(residual) -> None:
+    """Float math in upstream sizing (``prev_remaining - filled``) can produce
+    sub-epsilon remainders that aren't exactly 0. Without clamping, those
+    orders linger in the book and can be re-filled by the simulator. Verify
+    that any value with absolute magnitude below FILL_QTY_EPSILON is treated
+    as a terminal fill: the order is removed and ``cumulative_filled_qty``
+    equals ``original_qty``.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    book.requeue(po.order_id, new_remaining_qty=residual, new_submitted_at="2024-01-03")
+    assert po.remaining_qty == 0.0
+    assert po.cumulative_filled_qty == 10.0
+    assert po not in book.all_pending()
+    assert po not in book.pending_for_symbol("AAA")
+
+
+@pytest.mark.parametrize("residual", [-1e-15, -FILL_QTY_EPSILON / 2])
+def test_requeue_clamps_tiny_negative_residual_to_zero(residual) -> None:
+    """Tiny negatives from accumulated float error are physically zero and
+    shouldn't trip the ``< 0`` rejection. They should clamp the same way
+    positive sub-epsilon residuals do.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    book.requeue(po.order_id, new_remaining_qty=residual, new_submitted_at="2024-01-03")
+    assert po.remaining_qty == 0.0
+    assert po.cumulative_filled_qty == 10.0
+    assert po not in book.all_pending()
+
+
+def test_requeue_preserves_remainder_above_epsilon() -> None:
+    """A remainder safely above FILL_QTY_EPSILON should not be clamped — the
+    order stays in the book with the requested partial-fill remainder.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    above = FILL_QTY_EPSILON * 100  # 1e-7 — well above the clamp tolerance
+    book.requeue(po.order_id, new_remaining_qty=above, new_submitted_at="2024-01-03")
+    assert po.remaining_qty == above
+    assert po.cumulative_filled_qty == 10.0 - above
+    assert po in book.all_pending()
+
+
+def test_requeue_rejects_negative_above_epsilon() -> None:
+    """The clamp only swallows sub-epsilon negatives. A genuinely negative
+    remainder still gets rejected by the strict ``< 0`` guard.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    with pytest.raises(ValueError, match="must be >= 0"):
+        book.requeue(
+            po.order_id,
+            new_remaining_qty=-FILL_QTY_EPSILON * 1000,  # -1e-6, well past the clamp
+            new_submitted_at="2024-01-03",
+        )
+    assert po.remaining_qty == 10.0  # unchanged
+
+
 # ---------------------------------------------------------------------------
 # OCO sibling cancellation
 # ---------------------------------------------------------------------------
@@ -588,6 +665,23 @@ def test_children_of_returns_empty_for_unknown_parent() -> None:
         submitted_equity=100_000.0,
     )
     assert book.children_of("nope") == []
+
+
+@pytest.mark.parametrize("bad_parent", [None, "", 123, 1.5])
+def test_children_of_rejects_bad_parent_id(bad_parent) -> None:
+    """``OrderRequest.parent_order_id`` defaults to ``None`` for top-level
+    orders, so calling ``children_of(None)`` would equality-match every
+    top-level order and cause callers to apply child-order logic
+    (cancellation, etc.) to unrelated entries. Reject defensively.
+    """
+    book = OrderBook()
+    book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    with pytest.raises(TypeError, match="parent_order_id must be a non-empty str"):
+        book.children_of(bad_parent)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -159,6 +159,53 @@ def test_requeue_twap_slices_passthrough() -> None:
     assert po.twap_slices_remaining is None
 
 
+def test_requeue_accepts_zero_twap_slices() -> None:
+    """``twap_slices_remaining=0`` is the terminal slice marker — TWAP just
+    drained — and must be accepted alongside ``None`` and positive ints.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    book.requeue(
+        po.order_id,
+        new_remaining_qty=4.0,
+        new_submitted_at="2024-01-03",
+        twap_slices_remaining=0,
+    )
+    assert po.twap_slices_remaining == 0
+
+
+@pytest.mark.parametrize("bad_slices", [-1, 1.5, "two", True, False])
+def test_requeue_rejects_bad_twap_slices(bad_slices) -> None:
+    """Negative, float, str, and bool values are all caller bugs. Bools are
+    rejected explicitly because ``isinstance(True, int)`` is True in Python
+    and silently accepting ``True``/``False`` as slice counts hides confusion
+    in the caller.
+    """
+    book = OrderBook()
+    po = book.submit(
+        _base(qty=10.0),
+        submitted_at="2024-01-02",
+        submitted_equity=100_000.0,
+    )
+    with pytest.raises(
+        ValueError, match="twap_slices_remaining must be a non-negative int or None"
+    ):
+        book.requeue(
+            po.order_id,
+            new_remaining_qty=4.0,
+            new_submitted_at="2024-01-03",
+            twap_slices_remaining=bad_slices,
+        )
+    # State unchanged — rejected calls leave the order intact.
+    assert po.remaining_qty == 10.0
+    assert po.cumulative_filled_qty == 0.0
+    assert po.twap_slices_remaining is None
+
+
 def test_requeue_keeps_cumulative_filled_consistent() -> None:
     """``requeue`` must update ``cumulative_filled_qty`` so the invariant
     ``original_qty == cumulative_filled_qty + remaining_qty`` holds after each

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -90,6 +90,13 @@ class FillSimulator:
         pending = list(self.order_book.pending_for_symbol(bar.symbol))
 
         for po in pending:
+            # The snapshot can go stale mid-loop: e.g. a parent rejected via
+            # the risk-gate or insufficient-capital paths cascade-cancels its
+            # bracket children, which may already be in this snapshot. Skip
+            # any order that's no longer in the book so cascade-removed
+            # children can't slip through and fill on the same bar.
+            if po.order_id not in self.order_book:
+                continue
             req = po.request
             # Determine whether this bar triggered the order and at what
             # terms (price, partial-fill fraction, adverse-selection

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -97,6 +97,13 @@ class FillSimulator:
             # children can't slip through and fill on the same bar.
             if po.order_id not in self.order_book:
                 continue
+            # Pre-armed bracket children (submitted while the parent is still
+            # pending) sit in the book with ``armed=False`` until the bracket
+            # materializer (#389) flips them on after the parent fills.
+            # Skipping them here keeps protective legs from firing as
+            # standalone orders before the entry has actually opened.
+            if not po.armed:
+                continue
             req = po.request
             # Determine whether this bar triggered the order and at what
             # terms (price, partial-fill fraction, adverse-selection

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -128,9 +128,11 @@ class FillSimulator:
                 self.portfolio.open(pos)
                 fill = self.portfolio.make_entry_fill(pos)
                 entry_fills.append(fill)
-                # Entry filled — keep the parent's id in the eligible-parent
-                # set so bracket / OCO children can later be activated against
-                # it via ``OrderBook.submit_attached`` (see #389).
+                # Entry filled — keep this id in the eligible-parent set so
+                # bracket / OCO children can later be activated against it via
+                # ``OrderBook.submit_attached`` (see #389). Only entries qualify
+                # as bracket parents; exit fills below intentionally use the
+                # default ``was_filled=False``.
                 self.order_book.remove(po.order_id, was_filled=True)
             elif has_position:
                 # Exit path: order closes out the open position. We only
@@ -164,12 +166,15 @@ class FillSimulator:
                         reason="exit",
                     )
                 )
-                # Exit filled — fill (not a non-fill removal). ``was_filled``
-                # only affects how ``remove`` treats the *eligible-parent set*
-                # used by ``OrderBook.submit_attached``; passing ``True`` here
-                # is the right semantic because this is a fill, even though
-                # exit orders rarely have brackets attached after-the-fact.
-                self.order_book.remove(po.order_id, was_filled=True)
+                # Exit filled — close out the position. We pass the default
+                # ``was_filled=False`` here even though this *is* a fill,
+                # because ``was_filled=True`` is specifically for entries that
+                # may later carry bracket children. Exits don't open positions
+                # and so are never valid bracket parents — keeping their ids
+                # in ``_known_top_level_order_ids`` would let a later
+                # ``submit_attached`` accept the wrong order as a parent and
+                # mis-scope protective legs.
+                self.order_book.remove(po.order_id)
 
         return FillOutcome(
             entry_fills=entry_fills,

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -128,7 +128,10 @@ class FillSimulator:
                 self.portfolio.open(pos)
                 fill = self.portfolio.make_entry_fill(pos)
                 entry_fills.append(fill)
-                self.order_book.remove(po.order_id)
+                # Entry filled — keep the parent's id in the eligible-parent
+                # set so bracket / OCO children can later be activated against
+                # it via ``OrderBook.submit_attached`` (see #389).
+                self.order_book.remove(po.order_id, was_filled=True)
             elif has_position:
                 # Exit path: order closes out the open position. We only
                 # support full-qty exits in PR 1 (matches legacy behavior at
@@ -161,7 +164,12 @@ class FillSimulator:
                         reason="exit",
                     )
                 )
-                self.order_book.remove(po.order_id)
+                # Exit filled — fill (not a non-fill removal). ``was_filled``
+                # only affects how ``remove`` treats the *eligible-parent set*
+                # used by ``OrderBook.submit_attached``; passing ``True`` here
+                # is the right semantic because this is a fill, even though
+                # exit orders rarely have brackets attached after-the-fact.
+                self.order_book.remove(po.order_id, was_filled=True)
 
         return FillOutcome(
             entry_fills=entry_fills,

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -164,12 +164,32 @@ class OrderBook:
                 f"submit_attached child symbol {request.symbol!r} does not match parent "
                 f"{parent_order_id!r} symbol {parent_symbol!r}"
             )
+        # Bracket / OCO children are protective legs. ``MARKET`` order types
+        # would fire on the very next bar and execute as a standalone position
+        # change rather than acting as a take-profit / stop-loss leg, which
+        # breaks bracket semantics. Forbid them here so callers get a clear
+        # error rather than an unintended fill.
+        if request.order_type == OrderType.MARKET:
+            raise ValueError(
+                "submit_attached child must be LIMIT / STOP / STOP_LIMIT / TRAILING_STOP, "
+                "not MARKET — market children would fire immediately on the next bar "
+                "instead of acting as protective legs"
+            )
         attached_request = request.model_copy(
             update={"parent_order_id": parent_order_id, "oco_group_id": oco_group_id}
         )
         attached_request.model_copy(
             update={"parent_order_id": None, "oco_group_id": None}
         ).validate_prices()
+
+        # Pre-armed bracket children: a child submitted while its parent is
+        # still pending must not fire before the entry actually opens.
+        # ``armed=False`` keeps it in the book but invisible to the simulator's
+        # fill loop. Children submitted after the parent has filled (post-fill
+        # bracket activation, the typical flow) are armed immediately. The
+        # transition False → True for pre-armed children when the parent
+        # eventually fills is the bracket materializer's job (#389).
+        armed = parent_order_id not in self._pending
 
         self._next_id += 1
         order_id = f"o{self._next_id}"
@@ -181,6 +201,7 @@ class OrderBook:
             original_submitted_at=submitted_at,
             original_qty=attached_request.qty,
             remaining_qty=attached_request.qty,
+            armed=armed,
         )
         self._pending[order_id] = po
         # Note: do NOT add ``order_id`` to ``_known_top_level_order_ids`` —

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -187,40 +187,56 @@ class OrderBook:
         ids = self._by_symbol.get(po.request.symbol)
         if ids and order_id in ids:
             ids.remove(order_id)
-        # Cancelled top-level orders are no longer eligible parents — their
-        # entry never produced (or won't produce any further) live exposure,
-        # so attaching protective children would be a bug. Cascade-cancel
-        # any pending children so we don't leave orphan protective legs in
-        # the book without a live entry.
         if po.request.parent_order_id is None:
+            # Cancelled top-level: ineligible to parent further children +
+            # cascade to any pending TP / SL legs.
             self._known_top_level_order_ids.discard(order_id)
             self._cascade_cancel_children(order_id)
+        else:
+            # Cancelled child: the parent's bracket may now be fully
+            # resolved (no pending children, parent already filled), in
+            # which case the parent's id can be reclaimed from the
+            # eligible-parent set.
+            self._maybe_evict_resolved_parent(po.request.parent_order_id)
         return True
 
     def remove(self, order_id: str, *, was_filled: bool = False) -> Optional[PendingOrder]:
         """Drop an order from the book.
 
-        Pass ``was_filled=True`` *only* when the removal represents a real
-        terminal fill (used by ``requeue(... new_remaining_qty=0)`` and
-        ``FillSimulator``'s entry / exit fill paths). In that case the
-        order's id is preserved in ``_known_top_level_order_ids`` so
-        bracket children can still be activated against it.
+        Pass ``was_filled=True`` *only* when the removal represents a fill of
+        an order that may carry bracket children — i.e. an *entry* fill
+        (terminal-fill ``requeue(... new_remaining_qty=0)`` or
+        ``FillSimulator``'s entry path). In that case the id is preserved in
+        ``_known_top_level_order_ids`` so children can be activated against
+        the now-filled parent. *Exit* fills don't qualify as bracket parents
+        and should leave ``was_filled`` at its default.
 
         The default ``was_filled=False`` is the safe choice for every other
         removal path (risk-gate rejection, insufficient capital, sibling
-        cancellation, expiry cascade, manual removal). It evicts a top-level
-        parent's id from the eligible-parent set *and* cascade-cancels any
-        pending children so non-fill removals don't leave orphan bracket
-        legs in the book.
+        cancellation, expiry cascade, manual removal, exit fills). It evicts
+        a top-level order's id from the eligible-parent set *and*
+        cascade-cancels any pending children so non-eligible removals don't
+        leave orphan bracket legs in the book.
+
+        For child removals, both branches notify
+        ``_maybe_evict_resolved_parent`` so a filled parent's id is reclaimed
+        from the eligible-parent set automatically once its bracket is
+        fully resolved (no pending entry, no pending children).
         """
         po = self._pending.pop(order_id, None)
-        if po is not None:
-            ids = self._by_symbol.get(po.request.symbol)
-            if ids and order_id in ids:
-                ids.remove(order_id)
-            if not was_filled and po.request.parent_order_id is None:
+        if po is None:
+            return None
+        ids = self._by_symbol.get(po.request.symbol)
+        if ids and order_id in ids:
+            ids.remove(order_id)
+        if po.request.parent_order_id is None:
+            if not was_filled:
                 self._known_top_level_order_ids.discard(order_id)
                 self._cascade_cancel_children(order_id)
+        else:
+            # Removed child: a previously-filled parent may now have no
+            # remaining live legs and can be evicted automatically.
+            self._maybe_evict_resolved_parent(po.request.parent_order_id)
         return po
 
     def _cascade_cancel_children(self, parent_id: str) -> None:
@@ -234,6 +250,25 @@ class OrderBook:
         """
         for child in self.children_of(parent_id):
             self.remove(child.order_id)
+
+    def _maybe_evict_resolved_parent(self, parent_id: str) -> None:
+        """Auto-evict a filled-parent id from ``_known_top_level_order_ids``
+        once its bracket is fully resolved.
+
+        A filled parent stays in the eligible-parent set only because future
+        ``submit_attached`` calls might still add protective children to it.
+        Once the parent itself is no longer pending *and* none of its
+        children remain pending either, the bracket is done — keeping the id
+        around just leaks memory and lets stale ids get reused. This hook
+        runs whenever a child is removed (via ``cancel`` or ``remove``) and
+        is a no-op when the parent is still pending or still has live
+        children.
+        """
+        if parent_id in self._pending:
+            return
+        if any(po.request.parent_order_id == parent_id for po in self._pending.values()):
+            return
+        self._known_top_level_order_ids.discard(parent_id)
 
     def pending_for_symbol(self, symbol: str) -> List[PendingOrder]:
         return [self._pending[oid] for oid in self._by_symbol.get(symbol, [])]

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -22,7 +22,14 @@ class PendingOrder:
     request: OrderRequest
     submitted_at: str  # timestamp of the bar on which this was accepted
     submitted_equity: float  # for audit / risk-recheck if needed
+    original_qty: float = 0.0  # immutable, set at submit (overridden by submit())
     rejection_reason: Optional[str] = None  # set if the book rejects at submit-time
+    cumulative_filled_qty: float = 0.0
+    remaining_qty: float = 0.0  # initialized to request.qty in submit()
+    twap_slices_remaining: Optional[int] = None
+    effective_stop_price: Optional[float] = None  # live trailing stop (Step 8 / #390)
+    trailing_water: Optional[float] = None  # running high (LONG) / low (SHORT); Step 8
+    armed: bool = True
 
 
 @dataclass
@@ -48,9 +55,42 @@ class OrderBook:
             request=request,
             submitted_at=submitted_at,
             submitted_equity=submitted_equity,
+            original_qty=request.qty,
+            remaining_qty=request.qty,
         )
         self._pending[order_id] = po
         self._by_symbol.setdefault(request.symbol, []).append(order_id)
+        return po
+
+    def submit_attached(
+        self,
+        request: OrderRequest,
+        *,
+        submitted_at: str,
+        submitted_equity: float,
+        parent_order_id: str,
+        oco_group_id: str,
+    ) -> PendingOrder:
+        """Submit a bracket / OCO child without re-running the strategy-side
+        ``validate_prices()`` gate. The parent order has already been risk-gated
+        at submit time; the engine-side materializer (Step 7 / #389) is
+        responsible for shape correctness of the attached leg.
+        """
+        self._next_id += 1
+        order_id = f"o{self._next_id}"
+        attached_request = request.model_copy(
+            update={"parent_order_id": parent_order_id, "oco_group_id": oco_group_id}
+        )
+        po = PendingOrder(
+            order_id=order_id,
+            request=attached_request,
+            submitted_at=submitted_at,
+            submitted_equity=submitted_equity,
+            original_qty=attached_request.qty,
+            remaining_qty=attached_request.qty,
+        )
+        self._pending[order_id] = po
+        self._by_symbol.setdefault(attached_request.symbol, []).append(order_id)
         return po
 
     def cancel(self, order_id: str) -> bool:
@@ -75,6 +115,57 @@ class OrderBook:
 
     def all_pending(self) -> List[PendingOrder]:
         return list(self._pending.values())
+
+    # ------------------------------------------------------------------
+    # Partial-fill requeue + bracket / OCO traversal (Trading 5/5 Step 2).
+    # No engine or service caller wires these up in Step 2 — they exist for
+    # Steps 4 / 7 / 8 (#386 / #389 / #390) to call.
+    # ------------------------------------------------------------------
+
+    def requeue(
+        self,
+        order_id: str,
+        *,
+        new_remaining_qty: float,
+        new_submitted_at: str,
+        twap_slices_remaining: Optional[int] = None,
+    ) -> PendingOrder:
+        """Single mutation point for a partial-fill remainder. Refreshes
+        ``submitted_at`` so the look-ahead guard in
+        ``execution/bar_safety.py`` still holds on the next bar.
+        """
+        po = self._pending[order_id]
+        assert new_submitted_at >= po.submitted_at, (
+            f"requeue submitted_at must not regress: "
+            f"old={po.submitted_at!r} new={new_submitted_at!r}"
+        )
+        po.submitted_at = new_submitted_at
+        po.remaining_qty = new_remaining_qty
+        po.twap_slices_remaining = twap_slices_remaining
+        return po
+
+    def oco_cancel_siblings(
+        self,
+        oco_group_id: str,
+        *,
+        except_order_id: str,
+    ) -> List[str]:
+        """Remove every pending order tagged with ``oco_group_id`` other than
+        ``except_order_id``. Returns the list of cancelled order ids.
+        """
+        cancelled: List[str] = []
+        for oid in list(self._pending.keys()):
+            po = self._pending[oid]
+            if po.request.oco_group_id == oco_group_id and oid != except_order_id:
+                self.remove(oid)
+                cancelled.append(oid)
+        return cancelled
+
+    def children_of(self, parent_order_id: str) -> List[PendingOrder]:
+        """Direct children of ``parent_order_id`` (no recursion)."""
+        return [
+            po for po in self._pending.values() if po.request.parent_order_id == parent_order_id
+        ]
 
     # ------------------------------------------------------------------
     # TIF expiry — callers pass the current bar timestamp; day orders

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import math
 import re
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Dict, List, NamedTuple, Optional
 
 from ..strategy.contract import OrderRequest, OrderSide, OrderType, TimeInForce
@@ -461,14 +461,15 @@ class OrderBook:
                 f"requeue twap_slices_remaining must be a non-negative int or None, "
                 f"got {twap_slices_remaining!r}"
             )
-        # Canonicalise before storing so equivalent instants in different
-        # input formats (``Z`` vs ``+00:00`` vs ``+0000`` vs ``+05:30``)
-        # persist as the same string, and so the look-ahead guard in
-        # ``execution/bar_safety.py`` (which compares bar timestamps to
-        # ``po.submitted_at`` lexicographically) doesn't false-reject
-        # mixed-offset traces. Naive date-only inputs are returned
-        # unchanged so existing tests using ``"2024-01-02"`` aren't mangled.
-        po.submitted_at = _canonicalize_ts(new_submitted_at)
+        # Store ``new_submitted_at`` verbatim. The downstream look-ahead
+        # guard in ``execution/bar_safety.py`` does its own chronological
+        # parse-and-compare, so we don't need to canonicalise here —
+        # canonicalising would create a different format from the bar
+        # timestamps the guard compares against (``Z``-suffixed bars vs
+        # canonical ``+00:00`` storage), reintroducing the same lexicographic
+        # mis-comparison this PR's chronological-compare path is designed to
+        # fix.
+        po.submitted_at = new_submitted_at
         po.remaining_qty = new_remaining_qty
         po.cumulative_filled_qty = po.original_qty - new_remaining_qty
         po.twap_slices_remaining = twap_slices_remaining
@@ -667,26 +668,6 @@ def _try_parse_ts(ts: str) -> Optional[datetime]:
         return datetime.fromisoformat(_normalize_ts(ts))
     except ValueError:
         return None
-
-
-def _canonicalize_ts(ts: str) -> str:
-    """Re-emit a timestamp in a canonical ISO 8601 form so equivalent
-    instants in different input formats persist as the same string. UTC
-    is the canonical zone for tz-aware values; tz-naive inputs (e.g.
-    date-only ``"2024-01-02"`` strings used by the existing tests) are
-    returned unchanged so we don't mangle them into ``"2024-01-02T00:00:00"``.
-
-    Used by ``OrderBook.requeue`` to keep ``po.submitted_at`` in a
-    consistent format that the look-ahead guard in
-    ``execution/bar_safety.py`` can compare against bar timestamps with
-    plain string ``<=``.
-    """
-    if not isinstance(ts, str):
-        return ts
-    dt = _try_parse_ts(ts)
-    if dt is None or dt.tzinfo is None:
-        return ts
-    return dt.astimezone(timezone.utc).isoformat()
 
 
 def _ts_lt(new_ts: str, existing_ts: str) -> bool:

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -53,11 +53,18 @@ class OrderBook:
     _pending: Dict[str, PendingOrder] = field(default_factory=dict)
     # Parallel index by symbol/side so fill_simulator doesn't have to scan.
     _by_symbol: Dict[str, List[str]] = field(default_factory=dict)
-    # All-time set of allocated order ids — used by ``submit_attached`` to
-    # reject children whose parent_order_id was never issued, while still
-    # allowing children of a since-removed parent (typical bracket flow:
-    # parent fills, gets removed, children activate).
-    _known_order_ids: Set[str] = field(default_factory=set)
+    # All-time set of *top-level* order ids (those allocated by ``submit``).
+    # Used by ``submit_attached`` to reject children whose ``parent_order_id``
+    # was never a real top-level order — including the case where a caller
+    # accidentally passes another attached order's id, which would create a
+    # multi-level bracket tree (``parent → child → grandchild``) that this
+    # API does not support. Tracked separately from attached ids so that
+    # ``submit_attached`` cannot promote a child into a parent.
+    #
+    # Memory: this set grows monotonically with the number of top-level
+    # orders submitted (children are *not* added). Long-running services
+    # should call :meth:`prune_known_top_level_order_ids` periodically.
+    _known_top_level_order_ids: Set[str] = field(default_factory=set)
 
     # ------------------------------------------------------------------
 
@@ -80,7 +87,7 @@ class OrderBook:
             remaining_qty=request.qty,
         )
         self._pending[order_id] = po
-        self._known_order_ids.add(order_id)
+        self._known_top_level_order_ids.add(order_id)
         self._by_symbol.setdefault(request.symbol, []).append(order_id)
         return po
 
@@ -113,14 +120,18 @@ class OrderBook:
             raise TypeError(
                 f"submit_attached oco_group_id must be a non-empty str, got {oco_group_id!r}"
             )
-        # Reject orphan children whose parent_order_id was never allocated by
-        # this book. We check the all-time set, not just _pending, so a child
-        # submitted after the parent fills (typical bracket activation flow)
-        # still works.
-        if parent_order_id not in self._known_order_ids:
+        # Reject orphan children whose parent_order_id was never allocated as
+        # a *top-level* order by this book. We check the all-time set rather
+        # than ``_pending`` so a child submitted after the parent fills (the
+        # typical bracket activation flow) still works. Children of children
+        # are forbidden so the API stays as flat parent/child legs — multi-
+        # level bracket trees would break ``children_of`` traversal and OCO
+        # cancellation semantics.
+        if parent_order_id not in self._known_top_level_order_ids:
             raise ValueError(
-                f"submit_attached parent_order_id {parent_order_id!r} is not a known order id; "
-                f"submit the parent through OrderBook.submit() first"
+                f"submit_attached parent_order_id {parent_order_id!r} is not a known "
+                f"top-level order id; submit the parent through OrderBook.submit() first "
+                f"(attached children may not themselves be parents of further children)"
             )
         attached_request = request.model_copy(
             update={"parent_order_id": parent_order_id, "oco_group_id": oco_group_id}
@@ -141,7 +152,8 @@ class OrderBook:
             remaining_qty=attached_request.qty,
         )
         self._pending[order_id] = po
-        self._known_order_ids.add(order_id)
+        # Note: do NOT add ``order_id`` to ``_known_top_level_order_ids`` —
+        # attached children must not be eligible as future parents.
         self._by_symbol.setdefault(attached_request.symbol, []).append(order_id)
         return po
 
@@ -277,6 +289,14 @@ class OrderBook:
         with default ``None``, so calling with ``None`` here would
         equality-match every ordinary parent order in the book and nuke
         unrelated orders. Reject defensively.
+
+        Ordering contract: the caller must pass ``except_order_id`` *while
+        the surviving leg is still in the book*, before finalizing it
+        (e.g., before a terminal-fill ``requeue(... new_remaining_qty=0)``
+        auto-removes it). The method validates that ``except_order_id`` is
+        currently pending and matches the ``(oco_group_id, parent_order_id)``
+        tuple — otherwise a stale or mistyped value would slip through and
+        cancel *every* leg in the group, leaving the bracket unprotected.
         """
         for name, value in (
             ("oco_group_id", oco_group_id),
@@ -287,6 +307,22 @@ class OrderBook:
                 raise TypeError(
                     f"oco_cancel_siblings {name} must be a non-empty str, got {value!r}"
                 )
+        survivor = self._pending.get(except_order_id)
+        if survivor is None:
+            raise ValueError(
+                f"oco_cancel_siblings except_order_id {except_order_id!r} is not currently "
+                f"pending; cancel siblings before removing the surviving leg from the book"
+            )
+        if (
+            survivor.request.oco_group_id != oco_group_id
+            or survivor.request.parent_order_id != parent_order_id
+        ):
+            raise ValueError(
+                f"oco_cancel_siblings except_order_id {except_order_id!r} does not belong to "
+                f"the ({oco_group_id!r}, {parent_order_id!r}) bracket "
+                f"(actual: oco_group_id={survivor.request.oco_group_id!r}, "
+                f"parent_order_id={survivor.request.parent_order_id!r})"
+            )
         cancelled: List[str] = []
         for oid in list(self._pending.keys()):
             po = self._pending[oid]
@@ -314,6 +350,32 @@ class OrderBook:
         return [
             po for po in self._pending.values() if po.request.parent_order_id == parent_order_id
         ]
+
+    def prune_known_top_level_order_ids(self) -> int:
+        """Reclaim memory from ``_known_top_level_order_ids``.
+
+        Removes any id whose top-level order is no longer in ``_pending``
+        AND has no children currently in ``_pending``. Subsequent
+        ``submit_attached`` calls referencing those ids will fail —
+        correctly, because the bracket is fully resolved.
+
+        Long-running services (paper-trade, live) should call this
+        periodically to bound memory; it's a no-op for single-shot
+        backtests where the OrderBook is discarded after the run.
+
+        Returns the number of ids pruned.
+        """
+        # Active ids = currently-pending top-level orders + parents
+        # referenced by any pending child.
+        active: set[str] = set()
+        for po in self._pending.values():
+            if po.request.parent_order_id is None:
+                active.add(po.order_id)
+            else:
+                active.add(po.request.parent_order_id)
+        pruned = self._known_top_level_order_ids - active
+        self._known_top_level_order_ids -= pruned
+        return len(pruned)
 
     # ------------------------------------------------------------------
     # TIF expiry — callers pass the current bar timestamp; day orders

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -135,10 +135,11 @@ class OrderBook:
         ``execution/bar_safety.py`` still holds on the next bar.
         """
         po = self._pending[order_id]
-        assert new_submitted_at >= po.submitted_at, (
-            f"requeue submitted_at must not regress: "
-            f"old={po.submitted_at!r} new={new_submitted_at!r}"
-        )
+        if new_submitted_at < po.submitted_at:
+            raise ValueError(
+                f"requeue submitted_at must not regress: "
+                f"old={po.submitted_at!r} new={new_submitted_at!r}"
+            )
         po.submitted_at = new_submitted_at
         po.remaining_qty = new_remaining_qty
         po.twap_slices_remaining = twap_slices_remaining
@@ -149,14 +150,24 @@ class OrderBook:
         oco_group_id: str,
         *,
         except_order_id: str,
+        parent_order_id: str,
     ) -> List[str]:
-        """Remove every pending order tagged with ``oco_group_id`` other than
+        """Remove every pending order tagged with ``oco_group_id`` whose
+        ``parent_order_id`` matches the surviving leg's parent, other than
         ``except_order_id``. Returns the list of cancelled order ids.
+
+        Scoping by ``parent_order_id`` prevents two independent brackets that
+        happen to reuse the same ``oco_group_id`` from cross-cancelling each
+        other's protective legs.
         """
         cancelled: List[str] = []
         for oid in list(self._pending.keys()):
             po = self._pending[oid]
-            if po.request.oco_group_id == oco_group_id and oid != except_order_id:
+            if (
+                po.request.oco_group_id == oco_group_id
+                and po.request.parent_order_id == parent_order_id
+                and oid != except_order_id
+            ):
                 self.remove(oid)
                 cancelled.append(oid)
         return cancelled

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Dict, List, Optional, Set
+from typing import Dict, List, Optional
 
 from ..strategy.contract import OrderRequest, OrderSide, OrderType, TimeInForce
 
@@ -54,27 +54,25 @@ class OrderBook:
     _pending: Dict[str, PendingOrder] = field(default_factory=dict)
     # Parallel index by symbol/side so fill_simulator doesn't have to scan.
     _by_symbol: Dict[str, List[str]] = field(default_factory=dict)
-    # Set of *eligible-parent* top-level order ids. Used by
+    # Map of *eligible-parent* top-level order id → symbol. Used by
     # ``submit_attached`` to reject children whose ``parent_order_id`` is not
-    # a real top-level order eligible to carry brackets:
+    # a real top-level order eligible to carry brackets, and to verify the
+    # child's symbol matches the parent's. Lifecycle:
     #
-    # - Added on ``submit()`` (top-level entries).
+    # - Inserted on ``submit()`` (top-level entries).
     # - Discarded on ``cancel()`` and ``expire_day_orders()`` for top-level
     #   orders (cancelled / expired parents never opened, so attaching
     #   protective children to them would be a bug).
-    # - Preserved on ``remove()`` (the terminal-fill path used by
-    #   ``requeue(... new_remaining_qty=0)``): a *filled* parent is the
-    #   normal case where bracket children are activated *after* the entry
-    #   fills and is removed.
+    # - Preserved on ``remove(was_filled=True)`` (the terminal-fill path
+    #   used by ``requeue(... new_remaining_qty=0)`` and the simulator's
+    #   entry-fill path): a filled entry is the normal case where bracket
+    #   children are activated *after* the entry fills and is removed.
+    # - Auto-evicted by ``_maybe_evict_resolved_parent`` once a filled
+    #   parent has no remaining pending children.
     #
     # ``submit_attached`` is never inserted here, so an attached child can
     # never be promoted into a parent (multi-level bracket trees rejected).
-    #
-    # Growth is bounded by lifecycle: cancel/expire prune in O(1) per call.
-    # Filled parents only stay in the set until the operator decides to call
-    # :meth:`prune_known_top_level_order_ids`, which evicts ids whose entry
-    # is gone *and* whose children have all resolved.
-    _known_top_level_order_ids: Set[str] = field(default_factory=set)
+    _known_top_level_order_ids: Dict[str, str] = field(default_factory=dict)
 
     # ------------------------------------------------------------------
 
@@ -110,7 +108,7 @@ class OrderBook:
             remaining_qty=request.qty,
         )
         self._pending[order_id] = po
-        self._known_top_level_order_ids.add(order_id)
+        self._known_top_level_order_ids[order_id] = request.symbol
         self._by_symbol.setdefault(request.symbol, []).append(order_id)
         return po
 
@@ -150,11 +148,21 @@ class OrderBook:
         # are forbidden so the API stays as flat parent/child legs — multi-
         # level bracket trees would break ``children_of`` traversal and OCO
         # cancellation semantics.
-        if parent_order_id not in self._known_top_level_order_ids:
+        parent_symbol = self._known_top_level_order_ids.get(parent_order_id)
+        if parent_symbol is None:
             raise ValueError(
                 f"submit_attached parent_order_id {parent_order_id!r} is not a known "
                 f"top-level order id; submit the parent through OrderBook.submit() first "
                 f"(attached children may not themselves be parents of further children)"
+            )
+        # Bracket children must trade the same symbol as the parent. A typo
+        # (parent on AAA, child on BBB) would otherwise be accepted and then
+        # routed under the child's symbol while still tagged with the parent /
+        # OCO ids — corrupting bracket scoping and producing unrelated fills.
+        if request.symbol != parent_symbol:
+            raise ValueError(
+                f"submit_attached child symbol {request.symbol!r} does not match parent "
+                f"{parent_order_id!r} symbol {parent_symbol!r}"
             )
         attached_request = request.model_copy(
             update={"parent_order_id": parent_order_id, "oco_group_id": oco_group_id}
@@ -190,7 +198,7 @@ class OrderBook:
         if po.request.parent_order_id is None:
             # Cancelled top-level: ineligible to parent further children +
             # cascade to any pending TP / SL legs.
-            self._known_top_level_order_ids.discard(order_id)
+            self._known_top_level_order_ids.pop(order_id, None)
             self._cascade_cancel_children(order_id)
         else:
             # Cancelled child: the parent's bracket may now be fully
@@ -231,7 +239,7 @@ class OrderBook:
             ids.remove(order_id)
         if po.request.parent_order_id is None:
             if not was_filled:
-                self._known_top_level_order_ids.discard(order_id)
+                self._known_top_level_order_ids.pop(order_id, None)
                 self._cascade_cancel_children(order_id)
         else:
             # Removed child: a previously-filled parent may now have no
@@ -268,13 +276,22 @@ class OrderBook:
             return
         if any(po.request.parent_order_id == parent_id for po in self._pending.values()):
             return
-        self._known_top_level_order_ids.discard(parent_id)
+        self._known_top_level_order_ids.pop(parent_id, None)
 
     def pending_for_symbol(self, symbol: str) -> List[PendingOrder]:
         return [self._pending[oid] for oid in self._by_symbol.get(symbol, [])]
 
     def all_pending(self) -> List[PendingOrder]:
         return list(self._pending.values())
+
+    def __contains__(self, order_id: object) -> bool:
+        """``order_id in book`` — true iff the id is currently pending.
+
+        Useful in iteration patterns (e.g. ``FillSimulator.process_bar``)
+        that snapshot ``pending_for_symbol`` and need to skip orders that
+        have been cascade-cancelled or otherwise removed mid-loop.
+        """
+        return order_id in self._pending
 
     # ------------------------------------------------------------------
     # Partial-fill requeue + bracket / OCO traversal (Trading 5/5 Step 2).
@@ -319,6 +336,11 @@ class OrderBook:
             )
         if not math.isfinite(new_remaining_qty):
             raise ValueError(f"requeue new_remaining_qty must be finite, got {new_remaining_qty!r}")
+        if not isinstance(new_submitted_at, str):
+            raise TypeError(
+                f"requeue new_submitted_at must be a str, "
+                f"got {type(new_submitted_at).__name__} {new_submitted_at!r}"
+            )
         # Compare both sides as parsed datetimes when possible, falling back
         # to normalised string compare when one side isn't ISO 8601. Otherwise
         # equivalent ISO 8601 instants in different timezone offsets (e.g.
@@ -475,9 +497,10 @@ class OrderBook:
                 active.add(po.order_id)
             else:
                 active.add(po.request.parent_order_id)
-        pruned = self._known_top_level_order_ids - active
-        self._known_top_level_order_ids -= pruned
-        return len(pruned)
+        prunable = [oid for oid in self._known_top_level_order_ids if oid not in active]
+        for oid in prunable:
+            self._known_top_level_order_ids.pop(oid, None)
+        return len(prunable)
 
     # ------------------------------------------------------------------
     # TIF expiry — callers pass the current bar timestamp; day orders

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -84,6 +84,14 @@ class OrderBook:
         ``validate_prices`` on a clone with parent/OCO cleared so we don't
         re-fire the very gates this method is meant to bypass.
         """
+        if not isinstance(parent_order_id, str) or not parent_order_id:
+            raise TypeError(
+                f"submit_attached parent_order_id must be a non-empty str, got {parent_order_id!r}"
+            )
+        if not isinstance(oco_group_id, str) or not oco_group_id:
+            raise TypeError(
+                f"submit_attached oco_group_id must be a non-empty str, got {oco_group_id!r}"
+            )
         attached_request = request.model_copy(
             update={"parent_order_id": parent_order_id, "oco_group_id": oco_group_id}
         )
@@ -179,6 +187,12 @@ class OrderBook:
         po.remaining_qty = new_remaining_qty
         po.cumulative_filled_qty = po.original_qty - new_remaining_qty
         po.twap_slices_remaining = twap_slices_remaining
+        if new_remaining_qty == 0:
+            # Fully filled — drop from the book so downstream consumers (notably
+            # FillSimulator, which still sizes from req.qty) can't re-fill it.
+            # The returned PendingOrder reference still holds the final terminal
+            # state for the caller to read.
+            self.remove(order_id)
         return po
 
     def oco_cancel_siblings(

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Set
 
 from ..strategy.contract import OrderRequest, OrderSide, OrderType, TimeInForce
 
@@ -30,8 +30,13 @@ FILL_QTY_EPSILON = 1e-9
 class PendingOrder:
     order_id: str
     request: OrderRequest
-    submitted_at: str  # timestamp of the bar on which this was accepted
+    submitted_at: str  # bar timestamp anchor for the look-ahead guard; advanced
+    # by ``OrderBook.requeue`` so the simulator doesn't re-fill on the same bar.
     submitted_equity: float  # for audit / risk-recheck if needed
+    original_submitted_at: str = ""  # immutable original submission timestamp
+    # — used by ``expire_day_orders`` so a partially-filled-and-requeued DAY
+    # order still expires at the end of its original session, not the day after
+    # the last partial fill. Set in ``submit`` / ``submit_attached``.
     original_qty: float = 0.0  # immutable, set at submit (overridden by submit())
     rejection_reason: Optional[str] = None  # set if the book rejects at submit-time
     cumulative_filled_qty: float = 0.0
@@ -48,6 +53,11 @@ class OrderBook:
     _pending: Dict[str, PendingOrder] = field(default_factory=dict)
     # Parallel index by symbol/side so fill_simulator doesn't have to scan.
     _by_symbol: Dict[str, List[str]] = field(default_factory=dict)
+    # All-time set of allocated order ids — used by ``submit_attached`` to
+    # reject children whose parent_order_id was never issued, while still
+    # allowing children of a since-removed parent (typical bracket flow:
+    # parent fills, gets removed, children activate).
+    _known_order_ids: Set[str] = field(default_factory=set)
 
     # ------------------------------------------------------------------
 
@@ -65,10 +75,12 @@ class OrderBook:
             request=request,
             submitted_at=submitted_at,
             submitted_equity=submitted_equity,
+            original_submitted_at=submitted_at,
             original_qty=request.qty,
             remaining_qty=request.qty,
         )
         self._pending[order_id] = po
+        self._known_order_ids.add(order_id)
         self._by_symbol.setdefault(request.symbol, []).append(order_id)
         return po
 
@@ -101,6 +113,15 @@ class OrderBook:
             raise TypeError(
                 f"submit_attached oco_group_id must be a non-empty str, got {oco_group_id!r}"
             )
+        # Reject orphan children whose parent_order_id was never allocated by
+        # this book. We check the all-time set, not just _pending, so a child
+        # submitted after the parent fills (typical bracket activation flow)
+        # still works.
+        if parent_order_id not in self._known_order_ids:
+            raise ValueError(
+                f"submit_attached parent_order_id {parent_order_id!r} is not a known order id; "
+                f"submit the parent through OrderBook.submit() first"
+            )
         attached_request = request.model_copy(
             update={"parent_order_id": parent_order_id, "oco_group_id": oco_group_id}
         )
@@ -115,10 +136,12 @@ class OrderBook:
             request=attached_request,
             submitted_at=submitted_at,
             submitted_equity=submitted_equity,
+            original_submitted_at=submitted_at,
             original_qty=attached_request.qty,
             remaining_qty=attached_request.qty,
         )
         self._pending[order_id] = po
+        self._known_order_ids.add(order_id)
         self._by_symbol.setdefault(attached_request.symbol, []).append(order_id)
         return po
 
@@ -303,8 +326,14 @@ class OrderBook:
             po = self._pending[oid]
             if po.request.tif != TimeInForce.DAY:
                 continue
+            # Anchor the expiry decision on ``original_submitted_at`` (immutable)
+            # rather than ``submitted_at`` (which ``requeue`` advances on every
+            # partial fill). Otherwise a DAY order partially filled on day D and
+            # requeued to D+1 would only expire on D+2 — surviving an extra
+            # session and breaking TIF semantics.
+            anchor = po.original_submitted_at or po.submitted_at
             # Compare date prefix only so intraday timestamps also work.
-            if _date_only(po.submitted_at) < _date_only(current_date):
+            if _date_only(anchor) < _date_only(current_date):
                 expired.append(po)
                 self.remove(oid)
         return expired

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -53,17 +53,26 @@ class OrderBook:
     _pending: Dict[str, PendingOrder] = field(default_factory=dict)
     # Parallel index by symbol/side so fill_simulator doesn't have to scan.
     _by_symbol: Dict[str, List[str]] = field(default_factory=dict)
-    # All-time set of *top-level* order ids (those allocated by ``submit``).
-    # Used by ``submit_attached`` to reject children whose ``parent_order_id``
-    # was never a real top-level order — including the case where a caller
-    # accidentally passes another attached order's id, which would create a
-    # multi-level bracket tree (``parent → child → grandchild``) that this
-    # API does not support. Tracked separately from attached ids so that
-    # ``submit_attached`` cannot promote a child into a parent.
+    # Set of *eligible-parent* top-level order ids. Used by
+    # ``submit_attached`` to reject children whose ``parent_order_id`` is not
+    # a real top-level order eligible to carry brackets:
     #
-    # Memory: this set grows monotonically with the number of top-level
-    # orders submitted (children are *not* added). Long-running services
-    # should call :meth:`prune_known_top_level_order_ids` periodically.
+    # - Added on ``submit()`` (top-level entries).
+    # - Discarded on ``cancel()`` and ``expire_day_orders()`` for top-level
+    #   orders (cancelled / expired parents never opened, so attaching
+    #   protective children to them would be a bug).
+    # - Preserved on ``remove()`` (the terminal-fill path used by
+    #   ``requeue(... new_remaining_qty=0)``): a *filled* parent is the
+    #   normal case where bracket children are activated *after* the entry
+    #   fills and is removed.
+    #
+    # ``submit_attached`` is never inserted here, so an attached child can
+    # never be promoted into a parent (multi-level bracket trees rejected).
+    #
+    # Growth is bounded by lifecycle: cancel/expire prune in O(1) per call.
+    # Filled parents only stay in the set until the operator decides to call
+    # :meth:`prune_known_top_level_order_ids`, which evicts ids whose entry
+    # is gone *and* whose children have all resolved.
     _known_top_level_order_ids: Set[str] = field(default_factory=set)
 
     # ------------------------------------------------------------------
@@ -164,6 +173,13 @@ class OrderBook:
         ids = self._by_symbol.get(po.request.symbol)
         if ids and order_id in ids:
             ids.remove(order_id)
+        # Cancelled top-level orders are no longer eligible parents — their
+        # entry never produced (or won't produce any further) live exposure,
+        # so attaching protective children would be a bug. Use ``remove()``
+        # for the *fill* removal path so the parent stays in the set and
+        # bracket children can still be activated.
+        if po.request.parent_order_id is None:
+            self._known_top_level_order_ids.discard(order_id)
         return True
 
     def remove(self, order_id: str) -> Optional[PendingOrder]:
@@ -223,7 +239,10 @@ class OrderBook:
             )
         if not math.isfinite(new_remaining_qty):
             raise ValueError(f"requeue new_remaining_qty must be finite, got {new_remaining_qty!r}")
-        if new_submitted_at < po.submitted_at:
+        # Normalise both sides of the regression check before comparing so
+        # equivalent ISO 8601 instants in different formats (e.g. ``…Z`` vs
+        # ``…+00:00``) don't trip a false rejection.
+        if _normalize_ts(new_submitted_at) < _normalize_ts(po.submitted_at):
             raise ValueError(
                 f"requeue submitted_at must not regress: "
                 f"old={po.submitted_at!r} new={new_submitted_at!r}"
@@ -398,11 +417,32 @@ class OrderBook:
             if _date_only(anchor) < _date_only(current_date):
                 expired.append(po)
                 self.remove(oid)
+                # Same lifecycle rule as ``cancel``: an expired top-level
+                # order never opened (or finished its session unfilled), so
+                # it should not accept new bracket children afterwards.
+                if po.request.parent_order_id is None:
+                    self._known_top_level_order_ids.discard(oid)
         return expired
 
 
 def _date_only(ts: str) -> str:
     return (ts or "")[:10]
+
+
+def _normalize_ts(ts: str) -> str:
+    """Best-effort ISO 8601 normalisation for lexicographic comparison.
+
+    Maps a trailing ``Z`` (UTC zulu suffix) to ``+00:00`` so two equivalent
+    representations of the same instant compare equal as strings. Anything
+    else is returned unchanged — this is a defensive nudge, not a full ISO
+    parser; mixed timezone offsets / locale formats are still the caller's
+    responsibility.
+    """
+    if not isinstance(ts, str):
+        return ts
+    if ts.endswith("Z"):
+        return ts[:-1] + "+00:00"
+    return ts
 
 
 # Convenience re-exports to make ``from .order_book import *`` unambiguous.

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -10,6 +10,7 @@ them (or they expire by TIF, or the strategy cancels them).
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
@@ -71,16 +72,27 @@ class OrderBook:
         parent_order_id: str,
         oco_group_id: str,
     ) -> PendingOrder:
-        """Submit a bracket / OCO child without re-running the strategy-side
-        ``validate_prices()`` gate. The parent order has already been risk-gated
-        at submit time; the engine-side materializer (Step 7 / #389) is
-        responsible for shape correctness of the attached leg.
+        """Submit a bracket / OCO child.
+
+        The point of this entry is to allow ``parent_order_id`` /
+        ``oco_group_id`` to be set on the queued order — the strategy-side
+        ``validate_prices()`` gate refuses both fields outright (they are
+        engine-internal). All *other* runtime-support gates and shape-consistency
+        checks (LIMIT requires ``limit_price``, STOP requires ``stop_price``,
+        no TRAILING_STOP / IOC / FOK / unfilled_policy until their respective
+        steps ship, no nested attachments) still apply; we re-run
+        ``validate_prices`` on a clone with parent/OCO cleared so we don't
+        re-fire the very gates this method is meant to bypass.
         """
-        self._next_id += 1
-        order_id = f"o{self._next_id}"
         attached_request = request.model_copy(
             update={"parent_order_id": parent_order_id, "oco_group_id": oco_group_id}
         )
+        attached_request.model_copy(
+            update={"parent_order_id": None, "oco_group_id": None}
+        ).validate_prices()
+
+        self._next_id += 1
+        order_id = f"o{self._next_id}"
         po = PendingOrder(
             order_id=order_id,
             request=attached_request,
@@ -141,7 +153,16 @@ class OrderBook:
         A partial fill can only shrink the remainder; growing it would imply a
         negative fill, and a negative remainder has no execution semantics.
         """
-        po = self._pending[order_id]
+        po = self._pending.get(order_id)
+        if po is None:
+            # Explicit raise (not silent no-op) — partial-fill flow should never
+            # call requeue on an order that's already been removed/cancelled, so
+            # surface the bug rather than masking it. Unlike ``cancel``/``remove``,
+            # which are idempotent removals, ``requeue`` represents an active fill
+            # update against an order the caller believes is still pending.
+            raise KeyError(f"requeue: order_id {order_id!r} is not in the book")
+        if not math.isfinite(new_remaining_qty):
+            raise ValueError(f"requeue new_remaining_qty must be finite, got {new_remaining_qty!r}")
         if new_submitted_at < po.submitted_at:
             raise ValueError(
                 f"requeue submitted_at must not regress: "

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -66,12 +66,15 @@ class OrderBook:
     _pending: Dict[str, PendingOrder] = field(default_factory=dict)
     # Parallel index by symbol/side so fill_simulator doesn't have to scan.
     _by_symbol: Dict[str, List[str]] = field(default_factory=dict)
-    # Map of *eligible-parent* top-level order id → symbol. Used by
+    # Map of *eligible-parent* top-level order id → (symbol, side). Used by
     # ``submit_attached`` to reject children whose ``parent_order_id`` is not
-    # a real top-level order eligible to carry brackets, and to verify the
-    # child's symbol matches the parent's. Lifecycle:
+    # a real top-level order eligible to carry brackets, to verify the child's
+    # symbol matches, and to verify the child takes the opposite side.
+    # Lifecycle:
     #
-    # - Inserted on ``submit()`` (top-level entries).
+    # - Inserted by ``submit()`` *only when the caller passes*
+    #   ``expect_brackets=True`` (strategies that don't use brackets pay no
+    #   memory cost — non-bracket entries never enter this set).
     # - Discarded on ``cancel()`` and ``expire_day_orders()`` for top-level
     #   orders (cancelled / expired parents never opened, so attaching
     #   protective children to them would be a bug).
@@ -94,7 +97,19 @@ class OrderBook:
         *,
         submitted_at: str,
         submitted_equity: float,
+        expect_brackets: bool = False,
     ) -> PendingOrder:
+        """Submit a top-level order to the book.
+
+        ``expect_brackets`` (default ``False``) is the strategy's declaration
+        that one or more bracket / OCO children may be attached against this
+        order's id later via :meth:`submit_attached`. Only when ``True`` does
+        the order's id register in ``_known_top_level_order_ids`` — the
+        eligible-parent set ``submit_attached`` validates against. Non-
+        bracket strategies (the majority) get *zero* memory overhead from
+        the eligible-parent tracking; bracket strategies opt in explicitly,
+        which also makes intent visible at the call site.
+        """
         # Defense in depth — strategy-side ``validate_prices()`` already rejects
         # both fields, but ``submit()`` is the gateway that registers an id as
         # an *eligible bracket parent*. Refusing child-shaped requests here
@@ -120,9 +135,10 @@ class OrderBook:
             remaining_qty=request.qty,
         )
         self._pending[order_id] = po
-        self._known_top_level_order_ids[order_id] = _TopLevelMeta(
-            symbol=request.symbol, side=request.side
-        )
+        if expect_brackets:
+            self._known_top_level_order_ids[order_id] = _TopLevelMeta(
+                symbol=request.symbol, side=request.side
+            )
         self._by_symbol.setdefault(request.symbol, []).append(order_id)
         return po
 
@@ -389,6 +405,15 @@ class OrderBook:
         if isinstance(new_remaining_qty, bool):
             raise ValueError(
                 f"requeue new_remaining_qty must be a real number, got bool {new_remaining_qty!r}"
+            )
+        # Type-check before ``math.isfinite`` so non-numeric inputs (e.g. a
+        # malformed caller passing a string) raise a structured ``TypeError``
+        # with a clear message instead of the raw ``TypeError`` ``math``
+        # produces from inside its C implementation.
+        if not isinstance(new_remaining_qty, (int, float)):
+            raise TypeError(
+                f"requeue new_remaining_qty must be int or float, "
+                f"got {type(new_remaining_qty).__name__} {new_remaining_qty!r}"
             )
         if not math.isfinite(new_remaining_qty):
             raise ValueError(f"requeue new_remaining_qty must be finite, got {new_remaining_qty!r}")

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -189,24 +189,29 @@ class OrderBook:
             ids.remove(order_id)
         # Cancelled top-level orders are no longer eligible parents — their
         # entry never produced (or won't produce any further) live exposure,
-        # so attaching protective children would be a bug.
+        # so attaching protective children would be a bug. Cascade-cancel
+        # any pending children so we don't leave orphan protective legs in
+        # the book without a live entry.
         if po.request.parent_order_id is None:
             self._known_top_level_order_ids.discard(order_id)
+            self._cascade_cancel_children(order_id)
         return True
 
     def remove(self, order_id: str, *, was_filled: bool = False) -> Optional[PendingOrder]:
         """Drop an order from the book.
 
         Pass ``was_filled=True`` *only* when the removal represents a real
-        terminal fill (used by ``requeue(... new_remaining_qty=0)``). In that
-        case the order's id is preserved in ``_known_top_level_order_ids`` so
+        terminal fill (used by ``requeue(... new_remaining_qty=0)`` and
+        ``FillSimulator``'s entry / exit fill paths). In that case the
+        order's id is preserved in ``_known_top_level_order_ids`` so
         bracket children can still be activated against it.
 
         The default ``was_filled=False`` is the safe choice for every other
         removal path (risk-gate rejection, insufficient capital, sibling
-        cancellation, expiry cascade, etc.) — those must evict the parent's
-        id from the eligible-parent set so subsequent ``submit_attached``
-        calls don't accidentally attach children to a never-opened entry.
+        cancellation, expiry cascade, manual removal). It evicts a top-level
+        parent's id from the eligible-parent set *and* cascade-cancels any
+        pending children so non-fill removals don't leave orphan bracket
+        legs in the book.
         """
         po = self._pending.pop(order_id, None)
         if po is not None:
@@ -215,7 +220,20 @@ class OrderBook:
                 ids.remove(order_id)
             if not was_filled and po.request.parent_order_id is None:
                 self._known_top_level_order_ids.discard(order_id)
+                self._cascade_cancel_children(order_id)
         return po
+
+    def _cascade_cancel_children(self, parent_id: str) -> None:
+        """Remove every pending child of ``parent_id`` (non-recursive).
+
+        Called by ``cancel`` and by ``remove(was_filled=False)`` on top-level
+        orders to keep orphan protective legs (TP / SL) out of the book when
+        the entry never opens. ``children_of`` only returns *direct*
+        children, so ``submit_attached``'s flat-bracket invariant means we
+        don't recurse.
+        """
+        for child in self.children_of(parent_id):
+            self.remove(child.order_id)
 
     def pending_for_symbol(self, symbol: str) -> List[PendingOrder]:
         return [self._pending[oid] for oid in self._by_symbol.get(symbol, [])]
@@ -433,9 +451,10 @@ class OrderBook:
 
     def expire_day_orders(self, current_date: str) -> List[PendingOrder]:
         """Expire DAY-TIF orders whose original submission date is strictly
-        earlier than ``current_date``. When the expired order is a top-level
-        bracket parent, also cascade-cancel any children currently pending so
-        we don't leave orphan protective legs in the book without an entry.
+        earlier than ``current_date``. Top-level expirations cascade-cancel
+        any pending attached children via ``remove()``'s default
+        (``was_filled=False``) lifecycle path so we don't leave orphan
+        protective legs in the book.
         """
         expired: List[PendingOrder] = []
         for oid in list(self._pending.keys()):
@@ -454,14 +473,8 @@ class OrderBook:
             # Compare date prefix only so intraday timestamps also work.
             if _date_only(anchor) < _date_only(current_date):
                 expired.append(po)
-                # Cascade to attached children *before* removing the parent so
-                # orphan bracket legs don't linger after the entry expired
-                # without filling. Only relevant for top-level orders since
-                # only they have children. ``remove()`` defaults to evicting
-                # the id from ``_known_top_level_order_ids`` (was_filled=False).
-                if po.request.parent_order_id is None:
-                    for child in self.children_of(oid):
-                        self.remove(child.order_id)
+                # ``remove(was_filled=False)`` evicts the parent from the
+                # eligible-parent set *and* cascades to any pending children.
                 self.remove(oid)
         return expired
 

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -169,6 +169,14 @@ class OrderBook:
             # which are idempotent removals, ``requeue`` represents an active fill
             # update against an order the caller believes is still pending.
             raise KeyError(f"requeue: order_id {order_id!r} is not in the book")
+        # ``bool`` is a subclass of ``int`` (and therefore numeric) in Python,
+        # so ``True``/``False`` would otherwise pass the finite + range checks
+        # and silently land in ``remaining_qty`` as 1/0. That corrupts fill
+        # accounting downstream, so reject explicitly.
+        if isinstance(new_remaining_qty, bool):
+            raise ValueError(
+                f"requeue new_remaining_qty must be a real number, got bool {new_remaining_qty!r}"
+            )
         if not math.isfinite(new_remaining_qty):
             raise ValueError(f"requeue new_remaining_qty must be finite, got {new_remaining_qty!r}")
         if new_submitted_at < po.submitted_at:
@@ -223,7 +231,22 @@ class OrderBook:
         Scoping by ``parent_order_id`` prevents two independent brackets that
         happen to reuse the same ``oco_group_id`` from cross-cancelling each
         other's protective legs.
+
+        All three id arguments must be non-empty strings. ``OrderRequest``
+        stores ``oco_group_id`` and ``parent_order_id`` as ``Optional[str]``
+        with default ``None``, so calling with ``None`` here would
+        equality-match every ordinary parent order in the book and nuke
+        unrelated orders. Reject defensively.
         """
+        for name, value in (
+            ("oco_group_id", oco_group_id),
+            ("except_order_id", except_order_id),
+            ("parent_order_id", parent_order_id),
+        ):
+            if not isinstance(value, str) or not value:
+                raise TypeError(
+                    f"oco_cancel_siblings {name} must be a non-empty str, got {value!r}"
+                )
         cancelled: List[str] = []
         for oid in list(self._pending.keys()):
             po = self._pending[oid]

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Dict, List, Optional, Set
 
 from ..strategy.contract import OrderRequest, OrderSide, OrderType, TimeInForce
@@ -84,6 +85,19 @@ class OrderBook:
         submitted_at: str,
         submitted_equity: float,
     ) -> PendingOrder:
+        # Defense in depth — strategy-side ``validate_prices()`` already rejects
+        # both fields, but ``submit()`` is the gateway that registers an id as
+        # an *eligible bracket parent*. Refusing child-shaped requests here
+        # prevents an internal caller that bypasses ``validate_prices`` from
+        # smuggling an attached order into the eligible-parent set and creating
+        # multi-level bracket trees.
+        if request.parent_order_id is not None or request.oco_group_id is not None:
+            raise ValueError(
+                f"submit() must not receive a request with parent_order_id or "
+                f"oco_group_id set (got parent_order_id={request.parent_order_id!r}, "
+                f"oco_group_id={request.oco_group_id!r}); use submit_attached() "
+                f"for bracket / OCO children"
+            )
         self._next_id += 1
         order_id = f"o{self._next_id}"
         po = PendingOrder(
@@ -175,19 +189,32 @@ class OrderBook:
             ids.remove(order_id)
         # Cancelled top-level orders are no longer eligible parents — their
         # entry never produced (or won't produce any further) live exposure,
-        # so attaching protective children would be a bug. Use ``remove()``
-        # for the *fill* removal path so the parent stays in the set and
-        # bracket children can still be activated.
+        # so attaching protective children would be a bug.
         if po.request.parent_order_id is None:
             self._known_top_level_order_ids.discard(order_id)
         return True
 
-    def remove(self, order_id: str) -> Optional[PendingOrder]:
+    def remove(self, order_id: str, *, was_filled: bool = False) -> Optional[PendingOrder]:
+        """Drop an order from the book.
+
+        Pass ``was_filled=True`` *only* when the removal represents a real
+        terminal fill (used by ``requeue(... new_remaining_qty=0)``). In that
+        case the order's id is preserved in ``_known_top_level_order_ids`` so
+        bracket children can still be activated against it.
+
+        The default ``was_filled=False`` is the safe choice for every other
+        removal path (risk-gate rejection, insufficient capital, sibling
+        cancellation, expiry cascade, etc.) — those must evict the parent's
+        id from the eligible-parent set so subsequent ``submit_attached``
+        calls don't accidentally attach children to a never-opened entry.
+        """
         po = self._pending.pop(order_id, None)
         if po is not None:
             ids = self._by_symbol.get(po.request.symbol)
             if ids and order_id in ids:
                 ids.remove(order_id)
+            if not was_filled and po.request.parent_order_id is None:
+                self._known_top_level_order_ids.discard(order_id)
         return po
 
     def pending_for_symbol(self, symbol: str) -> List[PendingOrder]:
@@ -239,10 +266,11 @@ class OrderBook:
             )
         if not math.isfinite(new_remaining_qty):
             raise ValueError(f"requeue new_remaining_qty must be finite, got {new_remaining_qty!r}")
-        # Normalise both sides of the regression check before comparing so
-        # equivalent ISO 8601 instants in different formats (e.g. ``…Z`` vs
-        # ``…+00:00``) don't trip a false rejection.
-        if _normalize_ts(new_submitted_at) < _normalize_ts(po.submitted_at):
+        # Compare both sides as parsed datetimes when possible, falling back
+        # to normalised string compare when one side isn't ISO 8601. Otherwise
+        # equivalent ISO 8601 instants in different timezone offsets (e.g.
+        # ``+05:30`` vs ``+00:00``) would falsely reject as a regression.
+        if _ts_lt(new_submitted_at, po.submitted_at):
             raise ValueError(
                 f"requeue submitted_at must not regress: "
                 f"old={po.submitted_at!r} new={new_submitted_at!r}"
@@ -283,9 +311,11 @@ class OrderBook:
         if new_remaining_qty == 0:
             # Fully filled — drop from the book so downstream consumers (notably
             # FillSimulator, which still sizes from req.qty) can't re-fill it.
+            # ``was_filled=True`` keeps the id in ``_known_top_level_order_ids``
+            # so bracket children can still be activated against this parent.
             # The returned PendingOrder reference still holds the final terminal
             # state for the caller to read.
-            self.remove(order_id)
+            self.remove(order_id, was_filled=True)
         return po
 
     def oco_cancel_siblings(
@@ -402,9 +432,17 @@ class OrderBook:
     # ------------------------------------------------------------------
 
     def expire_day_orders(self, current_date: str) -> List[PendingOrder]:
+        """Expire DAY-TIF orders whose original submission date is strictly
+        earlier than ``current_date``. When the expired order is a top-level
+        bracket parent, also cascade-cancel any children currently pending so
+        we don't leave orphan protective legs in the book without an entry.
+        """
         expired: List[PendingOrder] = []
         for oid in list(self._pending.keys()):
-            po = self._pending[oid]
+            po = self._pending.get(oid)
+            if po is None:
+                # Already cascade-cancelled by an earlier parent in this loop.
+                continue
             if po.request.tif != TimeInForce.DAY:
                 continue
             # Anchor the expiry decision on ``original_submitted_at`` (immutable)
@@ -416,12 +454,15 @@ class OrderBook:
             # Compare date prefix only so intraday timestamps also work.
             if _date_only(anchor) < _date_only(current_date):
                 expired.append(po)
-                self.remove(oid)
-                # Same lifecycle rule as ``cancel``: an expired top-level
-                # order never opened (or finished its session unfilled), so
-                # it should not accept new bracket children afterwards.
+                # Cascade to attached children *before* removing the parent so
+                # orphan bracket legs don't linger after the entry expired
+                # without filling. Only relevant for top-level orders since
+                # only they have children. ``remove()`` defaults to evicting
+                # the id from ``_known_top_level_order_ids`` (was_filled=False).
                 if po.request.parent_order_id is None:
-                    self._known_top_level_order_ids.discard(oid)
+                    for child in self.children_of(oid):
+                        self.remove(child.order_id)
+                self.remove(oid)
         return expired
 
 
@@ -430,19 +471,48 @@ def _date_only(ts: str) -> str:
 
 
 def _normalize_ts(ts: str) -> str:
-    """Best-effort ISO 8601 normalisation for lexicographic comparison.
-
-    Maps a trailing ``Z`` (UTC zulu suffix) to ``+00:00`` so two equivalent
-    representations of the same instant compare equal as strings. Anything
-    else is returned unchanged — this is a defensive nudge, not a full ISO
-    parser; mixed timezone offsets / locale formats are still the caller's
-    responsibility.
+    """Map a trailing ``Z`` (UTC zulu suffix) to ``+00:00``. Used as both a
+    pre-parse normaliser (so ``datetime.fromisoformat`` accepts the Z form on
+    Python < 3.11) and the fallback string compare for unparseable inputs.
     """
     if not isinstance(ts, str):
         return ts
     if ts.endswith("Z"):
         return ts[:-1] + "+00:00"
     return ts
+
+
+def _try_parse_ts(ts: str) -> Optional[datetime]:
+    """Best-effort ISO 8601 parse. Returns ``None`` if the value isn't a
+    string or doesn't parse cleanly — callers fall back to string compare.
+    """
+    if not isinstance(ts, str):
+        return None
+    try:
+        return datetime.fromisoformat(_normalize_ts(ts))
+    except ValueError:
+        return None
+
+
+def _ts_lt(new_ts: str, existing_ts: str) -> bool:
+    """True iff ``new_ts`` is *strictly* earlier than ``existing_ts``.
+
+    Parses both as ISO 8601 datetimes when possible and compares them
+    chronologically — so equivalent instants in different timezone offsets
+    (e.g. ``2024-01-02T10:00:00+05:30`` vs ``2024-01-02T04:30:00+00:00``)
+    correctly compare equal instead of being rejected as a regression by
+    raw string ordering.
+
+    Falls back to normalised string comparison when one side fails to
+    parse, or when one side is naive and the other is timezone-aware
+    (Python raises ``TypeError`` on mixed-awareness datetime comparisons).
+    """
+    new_dt = _try_parse_ts(new_ts)
+    existing_dt = _try_parse_ts(existing_ts)
+    if new_dt is not None and existing_dt is not None:
+        if (new_dt.tzinfo is None) == (existing_dt.tzinfo is None):
+            return new_dt < existing_dt
+    return _normalize_ts(new_ts) < _normalize_ts(existing_ts)
 
 
 # Convenience re-exports to make ``from .order_book import *`` unambiguous.

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -132,7 +132,14 @@ class OrderBook:
     ) -> PendingOrder:
         """Single mutation point for a partial-fill remainder. Refreshes
         ``submitted_at`` so the look-ahead guard in
-        ``execution/bar_safety.py`` still holds on the next bar.
+        ``execution/bar_safety.py`` still holds on the next bar, and keeps
+        ``cumulative_filled_qty`` consistent with
+        ``original_qty - remaining_qty`` so downstream readers (Fill records,
+        backtest analytics) see correct partial-fill progress.
+
+        Bounds: ``new_remaining_qty`` must be in ``[0, current remaining_qty]``.
+        A partial fill can only shrink the remainder; growing it would imply a
+        negative fill, and a negative remainder has no execution semantics.
         """
         po = self._pending[order_id]
         if new_submitted_at < po.submitted_at:
@@ -140,8 +147,16 @@ class OrderBook:
                 f"requeue submitted_at must not regress: "
                 f"old={po.submitted_at!r} new={new_submitted_at!r}"
             )
+        if new_remaining_qty < 0:
+            raise ValueError(f"requeue new_remaining_qty must be >= 0, got {new_remaining_qty!r}")
+        if new_remaining_qty > po.remaining_qty:
+            raise ValueError(
+                f"requeue new_remaining_qty must not exceed current remaining_qty: "
+                f"current={po.remaining_qty!r} new={new_remaining_qty!r}"
+            )
         po.submitted_at = new_submitted_at
         po.remaining_qty = new_remaining_qty
+        po.cumulative_filled_qty = po.original_qty - new_remaining_qty
         po.twap_slices_remaining = twap_slices_remaining
         return po
 

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -11,8 +11,9 @@ them (or they expire by TIF, or the strategy cancels them).
 from __future__ import annotations
 
 import math
+import re
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Dict, List, NamedTuple, Optional
 
 from ..strategy.contract import OrderRequest, OrderSide, OrderType, TimeInForce
@@ -212,9 +213,9 @@ class OrderBook:
         # error rather than an unintended fill.
         if request.order_type == OrderType.MARKET:
             raise ValueError(
-                "submit_attached child must be LIMIT / STOP / STOP_LIMIT / TRAILING_STOP, "
-                "not MARKET — market children would fire immediately on the next bar "
-                "instead of acting as protective legs"
+                "submit_attached child must be LIMIT or STOP, not MARKET — market "
+                "children would fire immediately on the next bar instead of acting as "
+                "protective legs (TRAILING_STOP is gated until #390 / Step 8 lands)"
             )
         attached_request = request.model_copy(
             update={"parent_order_id": parent_order_id, "oco_group_id": oco_group_id}
@@ -460,7 +461,14 @@ class OrderBook:
                 f"requeue twap_slices_remaining must be a non-negative int or None, "
                 f"got {twap_slices_remaining!r}"
             )
-        po.submitted_at = new_submitted_at
+        # Canonicalise before storing so equivalent instants in different
+        # input formats (``Z`` vs ``+00:00`` vs ``+0000`` vs ``+05:30``)
+        # persist as the same string, and so the look-ahead guard in
+        # ``execution/bar_safety.py`` (which compares bar timestamps to
+        # ``po.submitted_at`` lexicographically) doesn't false-reject
+        # mixed-offset traces. Naive date-only inputs are returned
+        # unchanged so existing tests using ``"2024-01-02"`` aren't mangled.
+        po.submitted_at = _canonicalize_ts(new_submitted_at)
         po.remaining_qty = new_remaining_qty
         po.cumulative_filled_qty = po.original_qty - new_remaining_qty
         po.twap_slices_remaining = twap_slices_remaining
@@ -622,15 +630,30 @@ def _date_only(ts: str) -> str:
     return (ts or "")[:10]
 
 
+_COMPACT_OFFSET_RE = re.compile(r"([+-])(\d{2})(\d{2})$")
+
+
 def _normalize_ts(ts: str) -> str:
-    """Map a trailing ``Z`` (UTC zulu suffix) to ``+00:00``. Used as both a
-    pre-parse normaliser (so ``datetime.fromisoformat`` accepts the Z form on
-    Python < 3.11) and the fallback string compare for unparseable inputs.
+    """Best-effort ISO 8601 input normaliser used as both a pre-parse step
+    (so ``datetime.fromisoformat`` accepts variants Python < 3.11 doesn't)
+    and the fallback string-compare value for unparseable inputs.
+
+    Handles two non-canonical forms:
+
+    - Trailing ``Z`` (UTC zulu suffix) → ``+00:00``.
+    - Compact offsets ``±HHMM`` (no colon) → ``±HH:MM``. Without this,
+      values like ``+0000`` or ``+0530`` fail ``fromisoformat`` on Python
+      3.10 and force ``_ts_lt`` into the lexicographic fallback.
+
+    Anything else is returned unchanged.
     """
     if not isinstance(ts, str):
         return ts
     if ts.endswith("Z"):
         return ts[:-1] + "+00:00"
+    m = _COMPACT_OFFSET_RE.search(ts)
+    if m:
+        return ts[: m.start()] + f"{m.group(1)}{m.group(2)}:{m.group(3)}"
     return ts
 
 
@@ -644,6 +667,26 @@ def _try_parse_ts(ts: str) -> Optional[datetime]:
         return datetime.fromisoformat(_normalize_ts(ts))
     except ValueError:
         return None
+
+
+def _canonicalize_ts(ts: str) -> str:
+    """Re-emit a timestamp in a canonical ISO 8601 form so equivalent
+    instants in different input formats persist as the same string. UTC
+    is the canonical zone for tz-aware values; tz-naive inputs (e.g.
+    date-only ``"2024-01-02"`` strings used by the existing tests) are
+    returned unchanged so we don't mangle them into ``"2024-01-02T00:00:00"``.
+
+    Used by ``OrderBook.requeue`` to keep ``po.submitted_at`` in a
+    consistent format that the look-ahead guard in
+    ``execution/bar_safety.py`` can compare against bar timestamps with
+    plain string ``<=``.
+    """
+    if not isinstance(ts, str):
+        return ts
+    dt = _try_parse_ts(ts)
+    if dt is None or dt.tzinfo is None:
+        return ts
+    return dt.astimezone(timezone.utc).isoformat()
 
 
 def _ts_lt(new_ts: str, existing_ts: str) -> bool:

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -13,9 +13,21 @@ from __future__ import annotations
 import math
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List, NamedTuple, Optional
 
 from ..strategy.contract import OrderRequest, OrderSide, OrderType, TimeInForce
+
+
+class _TopLevelMeta(NamedTuple):
+    """Metadata cached for an eligible bracket-parent id: its symbol and side
+    so ``submit_attached`` can validate that bracket children share the
+    parent's symbol and take the opposite side (protective legs close out
+    the parent's position).
+    """
+
+    symbol: str
+    side: OrderSide
+
 
 # Tolerance below which a partial-fill remainder is treated as a terminal
 # zero. Float math in upstream sizing (typically ``prev_remaining - filled``
@@ -72,7 +84,7 @@ class OrderBook:
     #
     # ``submit_attached`` is never inserted here, so an attached child can
     # never be promoted into a parent (multi-level bracket trees rejected).
-    _known_top_level_order_ids: Dict[str, str] = field(default_factory=dict)
+    _known_top_level_order_ids: Dict[str, _TopLevelMeta] = field(default_factory=dict)
 
     # ------------------------------------------------------------------
 
@@ -108,7 +120,9 @@ class OrderBook:
             remaining_qty=request.qty,
         )
         self._pending[order_id] = po
-        self._known_top_level_order_ids[order_id] = request.symbol
+        self._known_top_level_order_ids[order_id] = _TopLevelMeta(
+            symbol=request.symbol, side=request.side
+        )
         self._by_symbol.setdefault(request.symbol, []).append(order_id)
         return po
 
@@ -148,8 +162,8 @@ class OrderBook:
         # are forbidden so the API stays as flat parent/child legs — multi-
         # level bracket trees would break ``children_of`` traversal and OCO
         # cancellation semantics.
-        parent_symbol = self._known_top_level_order_ids.get(parent_order_id)
-        if parent_symbol is None:
+        parent_meta = self._known_top_level_order_ids.get(parent_order_id)
+        if parent_meta is None:
             raise ValueError(
                 f"submit_attached parent_order_id {parent_order_id!r} is not a known "
                 f"top-level order id; submit the parent through OrderBook.submit() first "
@@ -159,10 +173,21 @@ class OrderBook:
         # (parent on AAA, child on BBB) would otherwise be accepted and then
         # routed under the child's symbol while still tagged with the parent /
         # OCO ids — corrupting bracket scoping and producing unrelated fills.
-        if request.symbol != parent_symbol:
+        if request.symbol != parent_meta.symbol:
             raise ValueError(
                 f"submit_attached child symbol {request.symbol!r} does not match parent "
-                f"{parent_order_id!r} symbol {parent_symbol!r}"
+                f"{parent_order_id!r} symbol {parent_meta.symbol!r}"
+            )
+        # Protective legs close out the parent's position, so they must take
+        # the *opposite* side. Otherwise the simulator's same-side path would
+        # silently drop the order at fill time (treating it as an attempted
+        # add-on), leaving the bracket leg unprotected and the position
+        # exposed to runaway moves.
+        if request.side == parent_meta.side:
+            raise ValueError(
+                f"submit_attached child side {request.side.value!r} must be opposite "
+                f"parent {parent_order_id!r} side {parent_meta.side.value!r} — "
+                f"protective legs close out the parent's position"
             )
         # Bracket / OCO children are protective legs. ``MARKET`` order types
         # would fire on the very next bar and execute as a standalone position
@@ -327,6 +352,7 @@ class OrderBook:
         new_remaining_qty: float,
         new_submitted_at: str,
         twap_slices_remaining: Optional[int] = None,
+        was_filled: bool = True,
     ) -> PendingOrder:
         """Single mutation point for a partial-fill remainder. Refreshes
         ``submitted_at`` so the look-ahead guard in
@@ -338,6 +364,15 @@ class OrderBook:
         Bounds: ``new_remaining_qty`` must be in ``[0, current remaining_qty]``.
         A partial fill can only shrink the remainder; growing it would imply a
         negative fill, and a negative remainder has no execution semantics.
+
+        ``was_filled`` (default ``True``) is forwarded to ``remove()`` when the
+        remainder collapses to zero (terminal fill). Default reflects the
+        primary use case — a partial-fill remainder being completed on a
+        top-level entry, which should preserve the parent's id in the
+        eligible-parent set for bracket activation. Future callers (e.g.
+        the partial-fill simulator in #386) that handle non-entry
+        partial-fills (such as exits) should pass ``was_filled=False`` so
+        those ids are *not* registered as eligible bracket parents.
         """
         po = self._pending.get(order_id)
         if po is None:
@@ -407,11 +442,11 @@ class OrderBook:
         if new_remaining_qty == 0:
             # Fully filled — drop from the book so downstream consumers (notably
             # FillSimulator, which still sizes from req.qty) can't re-fill it.
-            # ``was_filled=True`` keeps the id in ``_known_top_level_order_ids``
-            # so bracket children can still be activated against this parent.
-            # The returned PendingOrder reference still holds the final terminal
-            # state for the caller to read.
-            self.remove(order_id, was_filled=True)
+            # ``was_filled`` is forwarded so an entry-style terminal fill
+            # (default ``True``) preserves the parent's id for bracket
+            # activation, while exit-style partial fills (caller passes
+            # ``False``) correctly evict from the eligible-parent set.
+            self.remove(order_id, was_filled=was_filled)
         return po
 
     def oco_cancel_siblings(

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -30,14 +30,17 @@ class _TopLevelMeta(NamedTuple):
     side: OrderSide
 
 
-# Tolerance below which a partial-fill remainder is treated as a terminal
-# zero. Float math in upstream sizing (typically ``prev_remaining - filled``
-# in the partial-fill path) can produce sub-epsilon residuals that aren't
-# exactly 0; without this clamp those orders would linger in the book
-# instead of being removed and the simulator could re-fill them. 1e-9 sits
-# safely below any meaningful trading quantity (fractional-share venues
-# generally don't go past 6 decimal places).
-FILL_QTY_EPSILON = 1e-9
+# Relative tolerance for the float-math residual clamp in
+# ``OrderBook.requeue``. A remainder smaller than
+# ``po.original_qty * FILL_QTY_REL_TOL`` is treated as exactly 0 because
+# that's well below ULP-level error for the upstream sizing operands
+# (machine epsilon ≈ 2.2e-16; even after dozens of sequential subtractions
+# on operands of size N, accumulated ULP stays well under N * 1e-13).
+# A *relative* threshold avoids over-clamping legitimately small orders
+# (fractional-token / per-pip-quote venues, etc.) — a sub-epsilon-sized
+# absolute residual that's a meaningful fraction of an even smaller order
+# is real, not noise.
+FILL_QTY_REL_TOL = 1e-12
 
 
 @dataclass
@@ -432,13 +435,18 @@ class OrderBook:
                 f"requeue submitted_at must not regress: "
                 f"old={po.submitted_at!r} new={new_submitted_at!r}"
             )
-        # Clamp sub-epsilon residuals (positive *or* negative) to exactly zero
-        # before the bounds checks so that a tiny remainder produced by float
-        # math (e.g. ``prev - filled`` accumulating ULP error) is treated as a
-        # terminal fill rather than lingering in the book. This also keeps the
-        # ``< 0`` check below from rejecting tiny negatives that are physically
-        # zero.
-        if abs(new_remaining_qty) < FILL_QTY_EPSILON:
+        # Clamp sub-epsilon residuals (positive *or* negative) to exactly
+        # zero before the bounds checks so that a tiny remainder produced by
+        # float math (e.g. ``prev - filled`` accumulating ULP error) is
+        # treated as a terminal fill rather than lingering in the book. The
+        # threshold is *relative* to the order's own size so legitimately
+        # small orders (e.g. fractional-token venues where every quantity
+        # is sub-epsilon in absolute terms) don't have real partial-fill
+        # remainders silently swallowed. ``original_qty <= 0`` falls into
+        # the ``threshold == 0`` branch and never clamps — we never produce
+        # a zero-qty top-level order in normal flow, but be defensive.
+        clamp_threshold = po.original_qty * FILL_QTY_REL_TOL
+        if clamp_threshold > 0 and abs(new_remaining_qty) < clamp_threshold:
             new_remaining_qty = 0.0
         if new_remaining_qty < 0:
             raise ValueError(f"requeue new_remaining_qty must be >= 0, got {new_remaining_qty!r}")

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -183,6 +183,20 @@ class OrderBook:
                 f"requeue new_remaining_qty must not exceed current remaining_qty: "
                 f"current={po.remaining_qty!r} new={new_remaining_qty!r}"
             )
+        # TWAP slice counters are discrete and non-negative. ``bool`` is a
+        # subclass of ``int`` in Python, so we reject it explicitly to avoid
+        # ``True``/``False`` being silently accepted as 1/0 — TWAP scheduling
+        # treats slice counts as integers and a bool there indicates caller
+        # confusion.
+        if twap_slices_remaining is not None and (
+            isinstance(twap_slices_remaining, bool)
+            or not isinstance(twap_slices_remaining, int)
+            or twap_slices_remaining < 0
+        ):
+            raise ValueError(
+                f"requeue twap_slices_remaining must be a non-negative int or None, "
+                f"got {twap_slices_remaining!r}"
+            )
         po.submitted_at = new_submitted_at
         po.remaining_qty = new_remaining_qty
         po.cumulative_filled_qty = po.original_qty - new_remaining_qty

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -16,6 +16,15 @@ from typing import Dict, List, Optional
 
 from ..strategy.contract import OrderRequest, OrderSide, OrderType, TimeInForce
 
+# Tolerance below which a partial-fill remainder is treated as a terminal
+# zero. Float math in upstream sizing (typically ``prev_remaining - filled``
+# in the partial-fill path) can produce sub-epsilon residuals that aren't
+# exactly 0; without this clamp those orders would linger in the book
+# instead of being removed and the simulator could re-fill them. 1e-9 sits
+# safely below any meaningful trading quantity (fractional-share venues
+# generally don't go past 6 decimal places).
+FILL_QTY_EPSILON = 1e-9
+
 
 @dataclass
 class PendingOrder:
@@ -184,6 +193,14 @@ class OrderBook:
                 f"requeue submitted_at must not regress: "
                 f"old={po.submitted_at!r} new={new_submitted_at!r}"
             )
+        # Clamp sub-epsilon residuals (positive *or* negative) to exactly zero
+        # before the bounds checks so that a tiny remainder produced by float
+        # math (e.g. ``prev - filled`` accumulating ULP error) is treated as a
+        # terminal fill rather than lingering in the book. This also keeps the
+        # ``< 0`` check below from rejecting tiny negatives that are physically
+        # zero.
+        if abs(new_remaining_qty) < FILL_QTY_EPSILON:
+            new_remaining_qty = 0.0
         if new_remaining_qty < 0:
             raise ValueError(f"requeue new_remaining_qty must be >= 0, got {new_remaining_qty!r}")
         if new_remaining_qty > po.remaining_qty:
@@ -260,7 +277,17 @@ class OrderBook:
         return cancelled
 
     def children_of(self, parent_order_id: str) -> List[PendingOrder]:
-        """Direct children of ``parent_order_id`` (no recursion)."""
+        """Direct children of ``parent_order_id`` (no recursion).
+
+        Requires a non-empty string. ``OrderRequest.parent_order_id`` defaults
+        to ``None`` for non-bracket orders, so calling with ``None`` would
+        equality-match every top-level order in the book and cause callers to
+        treat unrelated entries as bracket children.
+        """
+        if not isinstance(parent_order_id, str) or not parent_order_id:
+            raise TypeError(
+                f"children_of parent_order_id must be a non-empty str, got {parent_order_id!r}"
+            )
         return [
             po for po in self._pending.values() if po.request.parent_order_id == parent_order_id
         ]


### PR DESCRIPTION
## Summary

Step 2 of Trading 5/5 (parent #379). Pure-additive plumbing — no engine, harness, or service caller is wired up yet. Sets the stage for Steps 3–8 (#385–#390).

- **`PendingOrder`** gains `original_qty`, `cumulative_filled_qty`, `remaining_qty`, `twap_slices_remaining`, `effective_stop_price`, `trailing_water`, `armed`.
- **`OrderBook`** gains:
  - `submit_attached(...)` — submits a bracket / OCO child without re-running the strategy-side `validate_prices()` gate (the parent was already gated; engine-side bracket materializer in #389 owns shape correctness of the leg).
  - `requeue(order_id, *, new_remaining_qty, new_submitted_at, twap_slices_remaining=None)` — single mutation point for partial-fill remainder; refreshes `submitted_at` and `assert new_submitted_at >= old.submitted_at` so the look-ahead guard at `execution/bar_safety.py:66` still holds.
  - `oco_cancel_siblings(oco_group_id, *, except_order_id)` — returns the cancelled order ids.
  - `children_of(parent_order_id)` — direct children only.

## Files

- `backend/agents/investment_team/trading_service/engine/order_book.py`
- `backend/agents/investment_team/tests/test_order_book.py` (new — 12 tests)

## Test plan

- [x] `pytest agents/investment_team/tests/test_order_book.py -v` — 12 / 12 pass.
- [x] `pytest agents/investment_team/tests/` — 491 pass, 10 pre-existing skips, no regressions.
- [x] `ruff check` + `ruff format --check` clean on both modified files.

Closes #384.

https://claude.ai/code/session_01VcLee3SSmmwUK4wrC4Dde7

---
_Generated by [Claude Code](https://claude.ai/code/session_01VcLee3SSmmwUK4wrC4Dde7)_