### PR TITLE
ui: move Road Trip Planning into a new Travel sidebar category

### DIFF
--- a/user-interface/src/app/models/navigation.model.ts
+++ b/user-interface/src/app/models/navigation.model.ts
@@ -84,7 +84,13 @@ export const NAV_GROUPS: NavGroup[] = [
     items: [
       { id: 'personal-assistant', label: 'Personal Assistant', icon: 'smart_toy', route: '/personal-assistant', group: 'personal' },
       { id: 'nutrition', label: 'Nutritionist', icon: 'restaurant_menu', route: '/nutrition', group: 'personal' },
-      { id: 'road-trip-planning', label: 'Road Trip Planning', icon: 'directions_car', route: '/road-trip-planning', group: 'personal' },
+    ],
+  },
+  {
+    key: 'travel',
+    label: 'Travel',
+    items: [
+      { id: 'road-trip-planning', label: 'Road Trip Planning', icon: 'directions_car', route: '/road-trip-planning', group: 'travel' },
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Removes `road-trip-planning` from the **Personal** sidebar group (which now contains only Personal Assistant and Nutritionist).
- Adds a new top-level **Travel** group in `NAV_GROUPS` and places Road Trip Planning under it (`group: 'travel'`).

Single-file change in `user-interface/src/app/models/navigation.model.ts`. Route, component, and API service are unchanged — only the sidebar grouping moves.

## Test plan
- [ ] `npm start` and confirm the sidebar now shows a **Travel** category with Road Trip Planning, and that Personal no longer lists it.
- [ ] Click into Road Trip Planning and confirm `/road-trip-planning` still loads the dashboard.
- [ ] `npm test` to make sure no nav-related specs regressed.

https://claude.ai/code/session_01SEK9xTH3qJYb87FPhCrtrY

---
_Generated by [Claude Code](https://claude.ai/code/session_01SEK9xTH3qJYb87FPhCrtrY)_