### PR TITLE
ui: redesign integrations page with responsive grid + expandable cards

### DIFF
--- a/user-interface/src/app/components/integrations-dashboard/integrations-dashboard.component.html
+++ b/user-interface/src/app/components/integrations-dashboard/integrations-dashboard.component.html
@@ -1,491 +1,589 @@
-<h1>Integrations</h1>
-<p>Connect external services to receive agent notifications and updates.</p>
+<div class="integrations-page">
 
-  <mat-card class="google-browser-card">
-    @if (googleBrowserLoading) {
-      <mat-card-content>
-        <div class="loading-wrap">
-          <mat-spinner diameter="36"></mat-spinner>
-        </div>
-      </mat-card-content>
-    } @else {
-      <mat-card-header>
-        <div mat-card-avatar class="google-browser-avatar" aria-hidden="true">
-          <mat-icon>account_circle</mat-icon>
-        </div>
-        <mat-card-title>Google account (browser sign-in)</mat-card-title>
-        <mat-card-subtitle>
-          One Fernet-encrypted Gmail / Google login for <strong>every</strong> integration that uses
-          <strong>Sign in with Google</strong> in a real browser (e.g. Medium). Stored only in Postgres
-          (<code>encrypted_integration_credentials</code>) when the API runs with <code>POSTGRES_HOST</code>
-          (e.g. Docker Compose). Not available in local API dev without Postgres — passwords are never written to
-          SQLite.
-        </mat-card-subtitle>
-      </mat-card-header>
-      <mat-card-content>
-        @if (googleBrowserError) {
-          <div class="status-banner error-banner">
-            <mat-icon>error_outline</mat-icon>
-            <span>{{ googleBrowserError }}</span>
+  <header class="integrations-hero">
+    <div class="integrations-hero__copy">
+      <h1>Integrations</h1>
+      <p>Connect external services so your agents can sign in, post updates, and pull metrics on your behalf.</p>
+    </div>
+
+    <div class="integrations-hero__stats" role="status" aria-live="polite">
+      <div class="stat-pill">
+        <span class="stat-pill__value">{{ connectedCount }}<span class="stat-pill__divider">/</span>{{ totalIntegrations }}</span>
+        <span class="stat-pill__label">Connected</span>
+      </div>
+      <div class="stat-pill stat-pill--muted">
+        <span class="stat-pill__value">{{ totalIntegrations - connectedCount }}</span>
+        <span class="stat-pill__label">Pending setup</span>
+      </div>
+    </div>
+  </header>
+
+  <div class="integrations-grid">
+
+    <!-- ─────────────────────────────────────────────────────────────── -->
+    <!-- Google account (browser sign-in)                               -->
+    <!-- ─────────────────────────────────────────────────────────────── -->
+    <article
+      class="integration-card"
+      [class.integration-card--expanded]="expanded === 'google'"
+      [attr.aria-busy]="googleBrowserLoading || null"
+    >
+      <header class="integration-card__head">
+        <div class="integration-card__brand">
+          <div class="integration-card__icon integration-card__icon--google" aria-hidden="true">
+            <mat-icon>account_circle</mat-icon>
           </div>
-        }
-        @if (!googleBrowserStorageAvailable) {
-          <div class="status-banner info-banner" role="status">
-            <mat-icon>info</mat-icon>
-            <span>
-              This feature is disabled: the API is not using PostgreSQL (<code>POSTGRES_HOST</code>). Run the stack with
-              Docker (or otherwise set <code>POSTGRES_HOST</code>) to save encrypted Google sign-in credentials.
+          <div class="integration-card__title-block">
+            <h2 class="integration-card__title">Google account</h2>
+            <p class="integration-card__tag">Shared browser sign-in</p>
+          </div>
+        </div>
+
+        <div class="integration-card__status">
+          @if (googleBrowserLoading) {
+            <mat-spinner diameter="20" class="integration-card__spinner"></mat-spinner>
+          } @else if (!googleBrowserStorageAvailable) {
+            <span class="status-chip status-chip--info" title="Postgres required">
+              <mat-icon aria-hidden="true">info</mat-icon>
+              Unavailable
             </span>
-          </div>
-        }
-        @if (googleBrowserSuccess) {
-          <div class="status-banner success-banner">
-            <mat-icon>check_circle_outline</mat-icon>
-            <span>{{ googleBrowserSuccess }}</span>
-          </div>
-        }
-        <div class="readiness-item inline-readiness">
-          <span class="readiness-label">Status</span>
-          <span class="readiness-value" [class.ready]="googleBrowserLoginConfigured">
-            @if (googleBrowserLoginConfigured) { Credentials saved } @else { Not configured }
-          </span>
+          } @else if (googleBrowserLoginConfigured) {
+            <span class="status-chip status-chip--success">
+              <mat-icon aria-hidden="true">check_circle</mat-icon>
+              Saved
+            </span>
+          } @else {
+            <span class="status-chip status-chip--neutral">Not configured</span>
+          }
         </div>
-        <div class="form-row">
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>Google email</mat-label>
-            <input
-              matInput
-              type="email"
-              [(ngModel)]="googleAccountEmail"
-              autocomplete="username"
-              [disabled]="!googleBrowserStorageAvailable"
-            />
-          </mat-form-field>
-        </div>
-        <div class="form-row">
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>Google password</mat-label>
-            <input
-              matInput
-              type="password"
-              [(ngModel)]="googleAccountPassword"
-              autocomplete="new-password"
-              [disabled]="!googleBrowserStorageAvailable"
-            />
-          </mat-form-field>
-        </div>
-        <div class="form-row medium-browser-cred-actions">
+      </header>
+
+      <p class="integration-card__summary">
+        One Fernet-encrypted Gmail / Google login that every <strong>Sign in with Google</strong> integration
+        (Medium, etc.) reuses. Stored only when <code>POSTGRES_HOST</code> is set; never written to SQLite.
+      </p>
+
+      <div class="integration-card__actions">
+        <button
+          type="button"
+          class="kh-btn-primary"
+          mat-flat-button
+          (click)="toggleExpanded('google')"
+          [disabled]="googleBrowserLoading"
+        >
+          <mat-icon>{{ expanded === 'google' ? 'expand_less' : 'tune' }}</mat-icon>
+          {{ expanded === 'google' ? 'Hide settings' : (googleBrowserLoginConfigured ? 'Manage' : 'Configure') }}
+        </button>
+
+        @if (googleBrowserLoginConfigured) {
           <button
-            mat-raised-button
-            color="primary"
             type="button"
-            (click)="saveGoogleBrowserLoginCredentials()"
-            [disabled]="
-              savingGoogleBrowserCredentials ||
-              !googleBrowserStorageAvailable ||
-              !googleAccountEmail.trim() ||
-              !googleAccountPassword
-            "
-          >
-            @if (savingGoogleBrowserCredentials) { Saving… } @else { Save encrypted credentials }
-          </button>
-          <button
             mat-stroked-button
             color="warn"
-            type="button"
             (click)="clearGoogleBrowserLoginCredentials()"
-            [disabled]="
-              clearingGoogleBrowserCredentials ||
-              !googleBrowserStorageAvailable ||
-              !googleBrowserLoginConfigured
-            "
+            [disabled]="clearingGoogleBrowserCredentials || !googleBrowserStorageAvailable"
           >
-            @if (clearingGoogleBrowserCredentials) { Clearing… } @else { Clear credentials }
+            @if (clearingGoogleBrowserCredentials) { Clearing… } @else { Disconnect }
           </button>
-        </div>
-      </mat-card-content>
-    }
-  </mat-card>
-
-  <mat-card class="slack-card">
-    @if (loadingSlack) {
-      <mat-card-content>
-        <div class="loading-wrap">
-          <mat-spinner diameter="36"></mat-spinner>
-        </div>
-      </mat-card-content>
-    } @else {
-    <mat-card-header>
-      <div mat-card-avatar class="slack-avatar">
-        <svg viewBox="0 0 122.8 122.8" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-          <path d="M25.8 77.6a12.9 12.9 0 0 1-12.9 12.9A12.9 12.9 0 0 1 0 77.6a12.9 12.9 0 0 1 12.9-12.9h12.9v12.9z" fill="#E01E5A"/>
-          <path d="M32.3 77.6a12.9 12.9 0 0 1 12.9-12.9 12.9 12.9 0 0 1 12.9 12.9v32.3a12.9 12.9 0 0 1-12.9 12.9 12.9 12.9 0 0 1-12.9-12.9V77.6z" fill="#E01E5A"/>
-          <path d="M45.2 25.8A12.9 12.9 0 0 1 32.3 12.9 12.9 12.9 0 0 1 45.2 0a12.9 12.9 0 0 1 12.9 12.9v12.9H45.2z" fill="#36C5F0"/>
-          <path d="M45.2 32.3a12.9 12.9 0 0 1 12.9 12.9 12.9 12.9 0 0 1-12.9 12.9H12.9A12.9 12.9 0 0 1 0 45.2a12.9 12.9 0 0 1 12.9-12.9h32.3z" fill="#36C5F0"/>
-          <path d="M97 45.2a12.9 12.9 0 0 1 12.9-12.9 12.9 12.9 0 0 1 12.9 12.9 12.9 12.9 0 0 1-12.9 12.9H97V45.2z" fill="#2EB67D"/>
-          <path d="M90.5 45.2a12.9 12.9 0 0 1-12.9 12.9 12.9 12.9 0 0 1-12.9-12.9V12.9A12.9 12.9 0 0 1 77.6 0a12.9 12.9 0 0 1 12.9 12.9v32.3z" fill="#2EB67D"/>
-          <path d="M77.6 97a12.9 12.9 0 0 1 12.9 12.9 12.9 12.9 0 0 1-12.9 12.9 12.9 12.9 0 0 1-12.9-12.9V97h12.9z" fill="#ECB22E"/>
-          <path d="M77.6 90.5a12.9 12.9 0 0 1-12.9-12.9 12.9 12.9 0 0 1 12.9-12.9h32.3a12.9 12.9 0 0 1 12.9 12.9 12.9 12.9 0 0 1-12.9 12.9H77.6z" fill="#ECB22E"/>
-        </svg>
+        }
       </div>
-      <mat-card-title>Slack</mat-card-title>
-      <mat-card-subtitle>Post agent notifications to your Slack workspace.</mat-card-subtitle>
-    </mat-card-header>
 
-    <mat-card-content>
-
-      @if (error) {
-        <div class="status-banner error-banner">
-          <mat-icon>error_outline</mat-icon>
-          <span>{{ error }}</span>
-        </div>
-      }
-      @if (success) {
-        <div class="status-banner success-banner">
-          <mat-icon>check_circle_outline</mat-icon>
-          <span>{{ success }}</span>
-        </div>
-      }
-
-      <!-- ──────────────────────────────────────────── -->
-      <!-- CONNECTED STATE                              -->
-      <!-- ──────────────────────────────────────────── -->
-      @if (oauthConnected) {
-        <div class="connected-state">
-          <div class="connected-badge">
-            <mat-icon class="connected-icon">verified</mat-icon>
-            <div class="connected-text">
-              <span class="connected-label">Connected</span>
-              @if (teamName) {
-                <span class="team-name">{{ teamName }}</span>
-              }
+      @if (expanded === 'google') {
+        <div class="integration-card__body">
+          @if (googleBrowserError) {
+            <div class="status-banner status-banner--error">
+              <mat-icon aria-hidden="true">error_outline</mat-icon>
+              <span>{{ googleBrowserError }}</span>
             </div>
-            <button
-              mat-stroked-button
-              color="warn"
-              class="disconnect-btn"
-              (click)="disconnectSlack()"
-              [disabled]="disconnecting || saving"
-            >
-              @if (disconnecting) { Disconnecting… } @else { Disconnect }
-            </button>
-          </div>
+          }
+          @if (!googleBrowserStorageAvailable) {
+            <div class="status-banner status-banner--info">
+              <mat-icon aria-hidden="true">info</mat-icon>
+              <span>
+                The API is not running with PostgreSQL. Start the stack via Docker (or set
+                <code>POSTGRES_HOST</code>) to save encrypted Google credentials.
+              </span>
+            </div>
+          }
+          @if (googleBrowserSuccess) {
+            <div class="status-banner status-banner--success">
+              <mat-icon aria-hidden="true">check_circle_outline</mat-icon>
+              <span>{{ googleBrowserSuccess }}</span>
+            </div>
+          }
 
-          <mat-divider class="section-divider"></mat-divider>
-
-          <div class="form-row">
-            <mat-slide-toggle [(ngModel)]="slackEnabled" color="primary">
-              Enable notifications
-            </mat-slide-toggle>
-          </div>
-
-          <div class="form-row">
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>Default channel</mat-label>
-              <input matInput [(ngModel)]="defaultChannel" placeholder="#engineering or C0ABC123DEF" />
-              <mat-hint>The channel your bot will post to. Invite the bot to the channel first.</mat-hint>
+          <div class="form-grid form-grid--two">
+            <mat-form-field appearance="outline">
+              <mat-label>Google email</mat-label>
+              <input
+                matInput
+                type="email"
+                [(ngModel)]="googleAccountEmail"
+                autocomplete="username"
+                [disabled]="!googleBrowserStorageAvailable"
+              />
+            </mat-form-field>
+            <mat-form-field appearance="outline">
+              <mat-label>Google password</mat-label>
+              <input
+                matInput
+                type="password"
+                [(ngModel)]="googleAccountPassword"
+                autocomplete="new-password"
+                [disabled]="!googleBrowserStorageAvailable"
+              />
             </mat-form-field>
           </div>
 
-          <div class="form-row">
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>Channel display name (optional)</mat-label>
-              <input matInput [(ngModel)]="channelDisplayName" placeholder="#engineering" />
-              <mat-hint>Label shown in this UI only.</mat-hint>
-            </mat-form-field>
-          </div>
-
-          <div class="form-row toggles">
-            <mat-slide-toggle [(ngModel)]="notifyOpenQuestions" color="primary">
-              Notify on open questions
-            </mat-slide-toggle>
-            <mat-slide-toggle [(ngModel)]="notifyPaResponses" color="primary">
-              Notify on Personal Assistant responses
-            </mat-slide-toggle>
-          </div>
-
-          <div class="form-row">
+          <div class="form-actions">
             <button
-              mat-raised-button
+              mat-flat-button
               color="primary"
-              (click)="saveSettings()"
-              [disabled]="saving || disconnecting"
+              type="button"
+              (click)="saveGoogleBrowserLoginCredentials()"
+              [disabled]="
+                savingGoogleBrowserCredentials ||
+                !googleBrowserStorageAvailable ||
+                !googleAccountEmail.trim() ||
+                !googleAccountPassword
+              "
             >
-              @if (saving) { Saving… } @else { Save settings }
+              @if (savingGoogleBrowserCredentials) { Saving… } @else { Save encrypted credentials }
             </button>
           </div>
         </div>
       }
+    </article>
 
-      <!-- ──────────────────────────────────────────── -->
-      <!-- NOT CONNECTED STATE                          -->
-      <!-- ──────────────────────────────────────────── -->
-      @if (!oauthConnected) {
-        <div class="not-connected-state">
-
-          <!-- App credentials -->
-          <p class="section-label">App credentials</p>
-          <p class="connect-description">
-            Enter your Slack app's Client ID and Client Secret, then click <strong>Add to Slack</strong>
-            to authorize access to your workspace.
-          </p>
-
-          <div class="form-row">
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>Client ID</mat-label>
-              <input matInput [(ngModel)]="clientId" placeholder="1234567890.9876543210" autocomplete="off" />
-              @if (clientIdConfigured && !clientId) {
-                <mat-hint align="end">Configured ✓</mat-hint>
-              }
-              <mat-hint>Found on your Slack app's Basic Information page.</mat-hint>
-            </mat-form-field>
+    <!-- ─────────────────────────────────────────────────────────────── -->
+    <!-- Slack                                                          -->
+    <!-- ─────────────────────────────────────────────────────────────── -->
+    <article
+      class="integration-card"
+      [class.integration-card--expanded]="expanded === 'slack'"
+      [attr.aria-busy]="loadingSlack || null"
+    >
+      <header class="integration-card__head">
+        <div class="integration-card__brand">
+          <div class="integration-card__icon integration-card__icon--slack" aria-hidden="true">
+            <svg viewBox="0 0 122.8 122.8" xmlns="http://www.w3.org/2000/svg">
+              <path d="M25.8 77.6a12.9 12.9 0 0 1-12.9 12.9A12.9 12.9 0 0 1 0 77.6a12.9 12.9 0 0 1 12.9-12.9h12.9v12.9z" fill="#E01E5A"/>
+              <path d="M32.3 77.6a12.9 12.9 0 0 1 12.9-12.9 12.9 12.9 0 0 1 12.9 12.9v32.3a12.9 12.9 0 0 1-12.9 12.9 12.9 12.9 0 0 1-12.9-12.9V77.6z" fill="#E01E5A"/>
+              <path d="M45.2 25.8A12.9 12.9 0 0 1 32.3 12.9 12.9 12.9 0 0 1 45.2 0a12.9 12.9 0 0 1 12.9 12.9v12.9H45.2z" fill="#36C5F0"/>
+              <path d="M45.2 32.3a12.9 12.9 0 0 1 12.9 12.9 12.9 12.9 0 0 1-12.9 12.9H12.9A12.9 12.9 0 0 1 0 45.2a12.9 12.9 0 0 1 12.9-12.9h32.3z" fill="#36C5F0"/>
+              <path d="M97 45.2a12.9 12.9 0 0 1 12.9-12.9 12.9 12.9 0 0 1 12.9 12.9 12.9 12.9 0 0 1-12.9 12.9H97V45.2z" fill="#2EB67D"/>
+              <path d="M90.5 45.2a12.9 12.9 0 0 1-12.9 12.9 12.9 12.9 0 0 1-12.9-12.9V12.9A12.9 12.9 0 0 1 77.6 0a12.9 12.9 0 0 1 12.9 12.9v32.3z" fill="#2EB67D"/>
+              <path d="M77.6 97a12.9 12.9 0 0 1 12.9 12.9 12.9 12.9 0 0 1-12.9 12.9 12.9 12.9 0 0 1-12.9-12.9V97h12.9z" fill="#ECB22E"/>
+              <path d="M77.6 90.5a12.9 12.9 0 0 1-12.9-12.9 12.9 12.9 0 0 1 12.9-12.9h32.3a12.9 12.9 0 0 1 12.9 12.9 12.9 12.9 0 0 1-12.9 12.9H77.6z" fill="#ECB22E"/>
+            </svg>
           </div>
-
-          <div class="form-row">
-            <mat-form-field appearance="outline" class="full-width">
-              <mat-label>Client Secret</mat-label>
-              <input matInput [(ngModel)]="clientSecret" type="password" placeholder="••••••••••••••••••••••••••••••••" autocomplete="new-password" />
-              <mat-hint>Required for OAuth. Never returned by the API after saving.</mat-hint>
-            </mat-form-field>
-          </div>
-
-          <div class="form-row">
-            <button
-              class="slack-connect-btn"
-              (click)="connectWithSlack()"
-              [disabled]="connecting"
-            >
-              @if (connecting) {
-                <span>Redirecting…</span>
+          <div class="integration-card__title-block">
+            <h2 class="integration-card__title">Slack</h2>
+            <p class="integration-card__tag">
+              @if (oauthConnected && teamName) {
+                {{ teamName }} workspace
               } @else {
-                <svg viewBox="0 0 122.8 122.8" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="btn-slack-logo">
-                  <path d="M25.8 77.6a12.9 12.9 0 0 1-12.9 12.9A12.9 12.9 0 0 1 0 77.6a12.9 12.9 0 0 1 12.9-12.9h12.9v12.9z" fill="#E01E5A"/>
-                  <path d="M32.3 77.6a12.9 12.9 0 0 1 12.9-12.9 12.9 12.9 0 0 1 12.9 12.9v32.3a12.9 12.9 0 0 1-12.9 12.9 12.9 12.9 0 0 1-12.9-12.9V77.6z" fill="#E01E5A"/>
-                  <path d="M45.2 25.8A12.9 12.9 0 0 1 32.3 12.9 12.9 12.9 0 0 1 45.2 0a12.9 12.9 0 0 1 12.9 12.9v12.9H45.2z" fill="#36C5F0"/>
-                  <path d="M45.2 32.3a12.9 12.9 0 0 1 12.9 12.9 12.9 12.9 0 0 1-12.9 12.9H12.9A12.9 12.9 0 0 1 0 45.2a12.9 12.9 0 0 1 12.9-12.9h32.3z" fill="#36C5F0"/>
-                  <path d="M97 45.2a12.9 12.9 0 0 1 12.9-12.9 12.9 12.9 0 0 1 12.9 12.9 12.9 12.9 0 0 1-12.9 12.9H97V45.2z" fill="#2EB67D"/>
-                  <path d="M90.5 45.2a12.9 12.9 0 0 1-12.9 12.9 12.9 12.9 0 0 1-12.9-12.9V12.9A12.9 12.9 0 0 1 77.6 0a12.9 12.9 0 0 1 12.9 12.9v32.3z" fill="#2EB67D"/>
-                  <path d="M77.6 97a12.9 12.9 0 0 1 12.9 12.9 12.9 12.9 0 0 1-12.9 12.9 12.9 12.9 0 0 1-12.9-12.9V97h12.9z" fill="#ECB22E"/>
-                  <path d="M77.6 90.5a12.9 12.9 0 0 1-12.9-12.9 12.9 12.9 0 0 1 12.9-12.9h32.3a12.9 12.9 0 0 1 12.9 12.9 12.9 12.9 0 0 1-12.9 12.9H77.6z" fill="#ECB22E"/>
-                </svg>
-                <span>Add to Slack</span>
+                Agent notifications
               }
+            </p>
+          </div>
+        </div>
+
+        <div class="integration-card__status">
+          @if (loadingSlack) {
+            <mat-spinner diameter="20" class="integration-card__spinner"></mat-spinner>
+          } @else if (oauthConnected) {
+            <span class="status-chip status-chip--success">
+              <mat-icon aria-hidden="true">verified</mat-icon>
+              Connected
+            </span>
+          } @else {
+            <span class="status-chip status-chip--neutral">Not connected</span>
+          }
+        </div>
+      </header>
+
+      <p class="integration-card__summary">
+        Post agent updates, open questions, and Personal Assistant replies straight to your Slack channels.
+      </p>
+
+      <div class="integration-card__actions">
+        <button
+          type="button"
+          mat-flat-button
+          color="primary"
+          (click)="toggleExpanded('slack')"
+          [disabled]="loadingSlack"
+        >
+          <mat-icon>{{ expanded === 'slack' ? 'expand_less' : 'tune' }}</mat-icon>
+          {{ expanded === 'slack' ? 'Hide settings' : (oauthConnected ? 'Manage' : 'Configure') }}
+        </button>
+
+        @if (oauthConnected) {
+          <button
+            type="button"
+            mat-stroked-button
+            color="warn"
+            (click)="disconnectSlack()"
+            [disabled]="disconnecting || saving"
+          >
+            @if (disconnecting) { Disconnecting… } @else { Disconnect }
+          </button>
+        }
+      </div>
+
+      @if (expanded === 'slack') {
+        <div class="integration-card__body">
+          @if (error) {
+            <div class="status-banner status-banner--error">
+              <mat-icon aria-hidden="true">error_outline</mat-icon>
+              <span>{{ error }}</span>
+            </div>
+          }
+          @if (success) {
+            <div class="status-banner status-banner--success">
+              <mat-icon aria-hidden="true">check_circle_outline</mat-icon>
+              <span>{{ success }}</span>
+            </div>
+          }
+
+          @if (oauthConnected) {
+            <!-- ── CONNECTED — settings ─────────────────────────────── -->
+            <div class="connected-summary">
+              <mat-icon class="connected-summary__icon" aria-hidden="true">verified</mat-icon>
+              <div class="connected-summary__text">
+                <span class="connected-summary__label">Connected to</span>
+                @if (teamName) { <span class="connected-summary__name">{{ teamName }}</span> }
+              </div>
+            </div>
+
+            <div class="form-grid form-grid--two">
+              <mat-form-field appearance="outline">
+                <mat-label>Default channel</mat-label>
+                <input matInput [(ngModel)]="defaultChannel" placeholder="#engineering or C0ABC123DEF" />
+                <mat-hint>Invite the bot to the channel first.</mat-hint>
+              </mat-form-field>
+              <mat-form-field appearance="outline">
+                <mat-label>Channel display name (optional)</mat-label>
+                <input matInput [(ngModel)]="channelDisplayName" placeholder="#engineering" />
+                <mat-hint>Label shown in this UI only.</mat-hint>
+              </mat-form-field>
+            </div>
+
+            <div class="setting-row">
+              <mat-slide-toggle [(ngModel)]="slackEnabled" color="primary">
+                Enable notifications
+              </mat-slide-toggle>
+              <mat-slide-toggle [(ngModel)]="notifyOpenQuestions" color="primary">
+                Notify on open questions
+              </mat-slide-toggle>
+              <mat-slide-toggle [(ngModel)]="notifyPaResponses" color="primary">
+                Notify on Personal Assistant replies
+              </mat-slide-toggle>
+            </div>
+
+            <div class="form-actions">
+              <button
+                mat-flat-button
+                color="primary"
+                (click)="saveSettings()"
+                [disabled]="saving || disconnecting"
+              >
+                @if (saving) { Saving… } @else { Save settings }
+              </button>
+            </div>
+          } @else {
+            <!-- ── NOT CONNECTED — OAuth setup ──────────────────────── -->
+            <p class="form-hint">
+              Enter your Slack app's <strong>Client ID</strong> and <strong>Client Secret</strong>, then
+              authorize Khala to post into your workspace.
+            </p>
+
+            <div class="form-grid form-grid--two">
+              <mat-form-field appearance="outline">
+                <mat-label>Client ID</mat-label>
+                <input matInput [(ngModel)]="clientId" placeholder="1234567890.9876543210" autocomplete="off" />
+                @if (clientIdConfigured && !clientId) {
+                  <mat-hint align="end">Saved ✓</mat-hint>
+                }
+                <mat-hint>Slack app → Basic Information.</mat-hint>
+              </mat-form-field>
+              <mat-form-field appearance="outline">
+                <mat-label>Client Secret</mat-label>
+                <input matInput [(ngModel)]="clientSecret" type="password" placeholder="••••••••••••••••" autocomplete="new-password" />
+                <mat-hint>Never returned by the API after saving.</mat-hint>
+              </mat-form-field>
+            </div>
+
+            <div class="form-actions">
+              <button
+                type="button"
+                class="slack-connect-btn"
+                (click)="connectWithSlack()"
+                [disabled]="connecting"
+              >
+                @if (connecting) {
+                  <span>Redirecting…</span>
+                } @else {
+                  <svg viewBox="0 0 122.8 122.8" xmlns="http://www.w3.org/2000/svg" aria-hidden="true" class="slack-connect-btn__logo">
+                    <path d="M25.8 77.6a12.9 12.9 0 0 1-12.9 12.9A12.9 12.9 0 0 1 0 77.6a12.9 12.9 0 0 1 12.9-12.9h12.9v12.9z" fill="#E01E5A"/>
+                    <path d="M32.3 77.6a12.9 12.9 0 0 1 12.9-12.9 12.9 12.9 0 0 1 12.9 12.9v32.3a12.9 12.9 0 0 1-12.9 12.9 12.9 12.9 0 0 1-12.9-12.9V77.6z" fill="#E01E5A"/>
+                    <path d="M45.2 25.8A12.9 12.9 0 0 1 32.3 12.9 12.9 12.9 0 0 1 45.2 0a12.9 12.9 0 0 1 12.9 12.9v12.9H45.2z" fill="#36C5F0"/>
+                    <path d="M45.2 32.3a12.9 12.9 0 0 1 12.9 12.9 12.9 12.9 0 0 1-12.9 12.9H12.9A12.9 12.9 0 0 1 0 45.2a12.9 12.9 0 0 1 12.9-12.9h32.3z" fill="#36C5F0"/>
+                    <path d="M97 45.2a12.9 12.9 0 0 1 12.9-12.9 12.9 12.9 0 0 1 12.9 12.9 12.9 12.9 0 0 1-12.9 12.9H97V45.2z" fill="#2EB67D"/>
+                    <path d="M90.5 45.2a12.9 12.9 0 0 1-12.9 12.9 12.9 12.9 0 0 1-12.9-12.9V12.9A12.9 12.9 0 0 1 77.6 0a12.9 12.9 0 0 1 12.9 12.9v32.3z" fill="#2EB67D"/>
+                    <path d="M77.6 97a12.9 12.9 0 0 1 12.9 12.9 12.9 12.9 0 0 1-12.9 12.9 12.9 12.9 0 0 1-12.9-12.9V97h12.9z" fill="#ECB22E"/>
+                    <path d="M77.6 90.5a12.9 12.9 0 0 1-12.9-12.9 12.9 12.9 0 0 1 12.9-12.9h32.3a12.9 12.9 0 0 1 12.9 12.9 12.9 12.9 0 0 1-12.9 12.9H77.6z" fill="#ECB22E"/>
+                  </svg>
+                  <span>Add to Slack</span>
+                }
+              </button>
+            </div>
+
+            <button mat-button class="advanced-toggle" (click)="showAdvanced = !showAdvanced">
+              <mat-icon>{{ showAdvanced ? 'expand_less' : 'expand_more' }}</mat-icon>
+              Advanced — configure manually with a webhook or bot token
             </button>
+
+            @if (showAdvanced) {
+              <div class="advanced-section">
+                <p class="form-hint">
+                  Use this if you prefer an Incoming Webhook or want to paste a bot token directly.
+                </p>
+
+                <div class="setting-row">
+                  <mat-slide-toggle [(ngModel)]="slackEnabled" color="primary">
+                    Enable Slack integration
+                  </mat-slide-toggle>
+                </div>
+
+                <div class="setting-row">
+                  <span class="setting-row__label">Delivery mode</span>
+                  <mat-radio-group [(ngModel)]="mode" aria-label="Slack mode">
+                    <mat-radio-button value="webhook">Incoming Webhook</mat-radio-button>
+                    <mat-radio-button value="bot">Bot token</mat-radio-button>
+                  </mat-radio-group>
+                </div>
+
+                @if (mode === 'webhook') {
+                  <div class="form-grid">
+                    <mat-form-field appearance="outline">
+                      <mat-label>Webhook URL</mat-label>
+                      <input matInput [(ngModel)]="webhookUrl" type="url" placeholder="https://hooks.slack.com/services/..." />
+                      <mat-hint>Create an Incoming Webhook in your Slack app and paste the URL.</mat-hint>
+                      @if (webhookConfigured && !webhookUrl) {
+                        <mat-hint align="end">Saved ✓</mat-hint>
+                      }
+                    </mat-form-field>
+                  </div>
+                }
+
+                @if (mode === 'bot') {
+                  <div class="form-grid form-grid--two">
+                    <mat-form-field appearance="outline">
+                      <mat-label>Bot token</mat-label>
+                      <input matInput [(ngModel)]="botToken" type="password" placeholder="xoxb-..." />
+                      @if (botTokenConfigured && !botToken) {
+                        <mat-hint align="end">Saved ✓</mat-hint>
+                      }
+                    </mat-form-field>
+                    <mat-form-field appearance="outline">
+                      <mat-label>Default channel</mat-label>
+                      <input matInput [(ngModel)]="defaultChannel" placeholder="#engineering or C123..." />
+                      <mat-hint>Used for all bot-mode notifications.</mat-hint>
+                    </mat-form-field>
+                  </div>
+                }
+
+                <div class="form-grid form-grid--two">
+                  <mat-form-field appearance="outline">
+                    <mat-label>Channel display name (optional)</mat-label>
+                    <input matInput [(ngModel)]="channelDisplayName" placeholder="#engineering" />
+                  </mat-form-field>
+                </div>
+
+                <div class="setting-row">
+                  <mat-slide-toggle [(ngModel)]="notifyOpenQuestions" color="primary">
+                    Notify on open questions
+                  </mat-slide-toggle>
+                  <mat-slide-toggle [(ngModel)]="notifyPaResponses" color="primary">
+                    Notify on Personal Assistant replies
+                  </mat-slide-toggle>
+                </div>
+
+                <div class="form-actions">
+                  <button mat-flat-button color="primary" (click)="saveAdvanced()" [disabled]="saving">
+                    @if (saving) { Saving… } @else { Save advanced settings }
+                  </button>
+                </div>
+              </div>
+            }
+          }
+        </div>
+      }
+    </article>
+
+    <!-- ─────────────────────────────────────────────────────────────── -->
+    <!-- Medium                                                         -->
+    <!-- ─────────────────────────────────────────────────────────────── -->
+    <article
+      class="integration-card"
+      [class.integration-card--expanded]="expanded === 'medium'"
+      [attr.aria-busy]="mediumLoading || null"
+    >
+      <header class="integration-card__head">
+        <div class="integration-card__brand">
+          <div class="integration-card__icon integration-card__icon--medium" aria-hidden="true">M</div>
+          <div class="integration-card__title-block">
+            <h2 class="integration-card__title">Medium</h2>
+            <p class="integration-card__tag">Stats &amp; publication</p>
+          </div>
+        </div>
+
+        <div class="integration-card__status">
+          @if (mediumLoading) {
+            <mat-spinner diameter="20" class="integration-card__spinner"></mat-spinner>
+          } @else if (mediumReadyForStats) {
+            <span class="status-chip status-chip--success">
+              <mat-icon aria-hidden="true">check_circle</mat-icon>
+              Ready
+            </span>
+          } @else if (mediumEnabled) {
+            <span class="status-chip status-chip--warning">
+              <mat-icon aria-hidden="true">pending</mat-icon>
+              Action needed
+            </span>
+          } @else {
+            <span class="status-chip status-chip--neutral">Disabled</span>
+          }
+        </div>
+      </header>
+
+      <p class="integration-card__summary">
+        Pull <strong>Medium statistics</strong> via a Playwright session. With Google sign-in, it reuses the
+        shared Google credentials above — no separate password needed.
+      </p>
+
+      <div class="integration-card__actions">
+        <button
+          type="button"
+          mat-flat-button
+          color="primary"
+          (click)="toggleExpanded('medium')"
+          [disabled]="mediumLoading"
+        >
+          <mat-icon>{{ expanded === 'medium' ? 'expand_less' : 'tune' }}</mat-icon>
+          {{ expanded === 'medium' ? 'Hide settings' : 'Configure' }}
+        </button>
+      </div>
+
+      @if (expanded === 'medium') {
+        <div class="integration-card__body">
+          @if (mediumError) {
+            <div class="status-banner status-banner--error">
+              <mat-icon aria-hidden="true">error_outline</mat-icon>
+              <span>{{ mediumError }}</span>
+            </div>
+          }
+          @if (mediumSuccess) {
+            <div class="status-banner status-banner--success">
+              <mat-icon aria-hidden="true">check_circle_outline</mat-icon>
+              <span>{{ mediumSuccess }}</span>
+            </div>
+          }
+
+          <div class="setting-row">
+            <mat-slide-toggle [(ngModel)]="mediumEnabled" color="primary">
+              Enable Medium integration
+            </mat-slide-toggle>
           </div>
 
-          <!-- Advanced / manual section -->
-          <mat-divider class="section-divider"></mat-divider>
+          <div class="readiness-grid">
+            <div class="readiness-tile" [class.readiness-tile--ready]="mediumIdentityReady">
+              <span class="readiness-tile__label">Identity</span>
+              <span class="readiness-tile__value">
+                @if (mediumIdentityReady) { Ready } @else { Pending }
+              </span>
+            </div>
+            <div class="readiness-tile" [class.readiness-tile--ready]="googleBrowserLoginConfigured">
+              <span class="readiness-tile__label">Shared Google login</span>
+              <span class="readiness-tile__value">
+                @if (googleBrowserLoginConfigured) { Saved } @else { None }
+              </span>
+            </div>
+            <div class="readiness-tile" [class.readiness-tile--ready]="mediumSessionConfigured">
+              <span class="readiness-tile__label">Browser session</span>
+              <span class="readiness-tile__value">
+                @if (mediumSessionConfigured) { Ready } @else { Missing }
+              </span>
+            </div>
+            <div class="readiness-tile" [class.readiness-tile--ready]="mediumReadyForStats">
+              <span class="readiness-tile__label">Stats run</span>
+              <span class="readiness-tile__value">
+                @if (mediumReadyForStats) { Ready } @else { Not ready }
+              </span>
+            </div>
+          </div>
 
-          <button mat-button class="advanced-toggle" (click)="showAdvanced = !showAdvanced">
-            <mat-icon>{{ showAdvanced ? 'expand_less' : 'expand_more' }}</mat-icon>
-            Advanced: configure manually
-          </button>
+          <div class="setting-row">
+            <span class="setting-row__label">Identity provider you use on Medium</span>
+            <mat-radio-group [(ngModel)]="mediumProvider" aria-label="Medium OAuth provider">
+              <mat-radio-button value="google">Google</mat-radio-button>
+              <mat-radio-button value="apple">Apple</mat-radio-button>
+              <mat-radio-button value="facebook">Facebook</mat-radio-button>
+              <mat-radio-button value="twitter">X (Twitter)</mat-radio-button>
+            </mat-radio-group>
+          </div>
 
-          @if (showAdvanced) {
-            <div class="advanced-section">
-              <p class="advanced-hint">
-                Use this if you prefer an Incoming Webhook or want to paste a bot token directly.
+          @if (mediumProvider !== 'google') {
+            <div class="status-banner status-banner--info">
+              <mat-icon aria-hidden="true">info</mat-icon>
+              <span>
+                {{ mediumProviderLabel }} selected. Browser automation is oriented around Google sign-in —
+                pick Google if you use “Continue with Google” on Medium.
+              </span>
+            </div>
+          }
+
+          @if (mediumEnabled && mediumProvider === 'google') {
+            <div class="subsection">
+              <h3 class="subsection__title">Capture Medium browser session</h3>
+              <p class="form-hint">
+                Uses the shared Google credentials at the top. Run <code>playwright install chromium</code> on
+                the API host once. Stats can also auto-sign-in if the session file goes missing.
               </p>
-
-              <div class="form-row">
-                <mat-slide-toggle [(ngModel)]="slackEnabled" color="primary">
-                  Enable Slack integration
-                </mat-slide-toggle>
-              </div>
-
-              <div class="form-row">
-                <span class="mode-label">Delivery mode</span>
-                <mat-radio-group [(ngModel)]="mode" aria-label="Slack mode">
-                  <mat-radio-button value="webhook">Incoming Webhook</mat-radio-button>
-                  <mat-radio-button value="bot">Bot token (chat.postMessage)</mat-radio-button>
-                </mat-radio-group>
-              </div>
-
-              @if (mode === 'webhook') {
-                <div class="form-row">
-                  <mat-form-field appearance="outline" class="full-width">
-                    <mat-label>Webhook URL</mat-label>
-                    <input matInput [(ngModel)]="webhookUrl" type="url" placeholder="https://hooks.slack.com/services/..." />
-                    <mat-hint>Create an Incoming Webhook in your Slack app and paste the URL here.</mat-hint>
-                    @if (webhookConfigured && !webhookUrl) {
-                      <mat-hint align="end">Webhook configured ✓</mat-hint>
-                    }
-                  </mat-form-field>
-                </div>
-              }
-
-              @if (mode === 'bot') {
-                <div class="form-row">
-                  <mat-form-field appearance="outline" class="full-width">
-                    <mat-label>Bot token</mat-label>
-                    <input matInput [(ngModel)]="botToken" type="password" placeholder="xoxb-..." />
-                    @if (botTokenConfigured && !botToken) {
-                      <mat-hint align="end">Token configured ✓</mat-hint>
-                    }
-                  </mat-form-field>
-                </div>
-                <div class="form-row">
-                  <mat-form-field appearance="outline" class="full-width">
-                    <mat-label>Default channel</mat-label>
-                    <input matInput [(ngModel)]="defaultChannel" placeholder="#engineering or C123..." />
-                    <mat-hint>Used for all Slack notifications in bot mode.</mat-hint>
-                  </mat-form-field>
-                </div>
-              }
-
-              <div class="form-row">
-                <mat-form-field appearance="outline" class="full-width">
-                  <mat-label>Channel display name (optional)</mat-label>
-                  <input matInput [(ngModel)]="channelDisplayName" placeholder="#engineering" />
-                  <mat-hint>Display label only.</mat-hint>
-                </mat-form-field>
-              </div>
-
-              <div class="form-row toggles">
-                <mat-slide-toggle [(ngModel)]="notifyOpenQuestions" color="primary">
-                  Notify on open questions
-                </mat-slide-toggle>
-                <mat-slide-toggle [(ngModel)]="notifyPaResponses" color="primary">
-                  Notify on Personal Assistant responses
-                </mat-slide-toggle>
-              </div>
-
-              <div class="form-row">
-                <button mat-raised-button color="primary" (click)="saveAdvanced()" [disabled]="saving">
-                  @if (saving) { Saving… } @else { Save }
+              <div class="form-actions">
+                <button
+                  mat-stroked-button
+                  color="primary"
+                  type="button"
+                  (click)="runMediumBrowserLogin()"
+                  [disabled]="mediumBrowserLoginRunning || mediumSaving || !googleBrowserLoginConfigured"
+                >
+                  @if (mediumBrowserLoginRunning) {
+                    Signing in via browser…
+                  } @else {
+                    Capture session now
+                  }
                 </button>
               </div>
             </div>
           }
-        </div>
-      }
 
-    </mat-card-content>
-    }
-  </mat-card>
-
-  <mat-card class="medium-card">
-    @if (mediumLoading) {
-      <mat-card-content>
-        <div class="loading-wrap">
-          <mat-spinner diameter="36"></mat-spinner>
-        </div>
-      </mat-card-content>
-    } @else {
-      <mat-card-header>
-        <div mat-card-avatar class="medium-avatar" aria-hidden="true">M</div>
-        <mat-card-title>Medium</mat-card-title>
-        <mat-card-subtitle>
-          Blogging <strong>Medium statistics</strong> use a Playwright <code>storage_state</code> on disk. With
-          <strong>Google</strong> as your Medium provider, use the shared Google credentials at the top of this page
-          and capture a browser session below.
-        </mat-card-subtitle>
-      </mat-card-header>
-      <mat-card-content>
-        @if (mediumError) {
-          <div class="status-banner error-banner">
-            <mat-icon>error_outline</mat-icon>
-            <span>{{ mediumError }}</span>
-          </div>
-        }
-        @if (mediumSuccess) {
-          <div class="status-banner success-banner">
-            <mat-icon>check_circle_outline</mat-icon>
-            <span>{{ mediumSuccess }}</span>
-          </div>
-        }
-
-        <div class="form-row">
-          <mat-slide-toggle [(ngModel)]="mediumEnabled" color="primary">
-            Enable Medium integration
-          </mat-slide-toggle>
-        </div>
-
-        <div class="medium-readiness-grid">
-          <div class="readiness-item">
-            <span class="readiness-label">Identity</span>
-            <span class="readiness-value" [class.ready]="mediumIdentityReady">
-              @if (mediumIdentityReady) { Ready } @else { Pending }
-            </span>
-          </div>
-          <div class="readiness-item">
-            <span class="readiness-label">Shared Google login</span>
-            <span class="readiness-value" [class.ready]="googleBrowserLoginConfigured">
-              @if (googleBrowserLoginConfigured) { Saved } @else { None }
-            </span>
-          </div>
-          <div class="readiness-item">
-            <span class="readiness-label">Browser session</span>
-            <span class="readiness-value" [class.ready]="mediumSessionConfigured">
-              @if (mediumSessionConfigured) { Ready } @else { Missing }
-            </span>
-          </div>
-          <div class="readiness-item">
-            <span class="readiness-label">Stats run readiness</span>
-            <span class="readiness-value" [class.ready]="mediumReadyForStats">
-              @if (mediumReadyForStats) { Ready } @else { Not ready }
-            </span>
-          </div>
-        </div>
-
-        <div class="form-row">
-          <span class="mode-label">Identity provider you use on Medium</span>
-          <mat-radio-group [(ngModel)]="mediumProvider" aria-label="Medium OAuth provider">
-            <mat-radio-button value="google">Google</mat-radio-button>
-            <mat-radio-button value="apple">Apple</mat-radio-button>
-            <mat-radio-button value="facebook">Facebook</mat-radio-button>
-            <mat-radio-button value="twitter">X (Twitter)</mat-radio-button>
-          </mat-radio-group>
-        </div>
-
-        @if (mediumProvider !== 'google') {
-          <div class="status-banner">
-            <mat-icon>info</mat-icon>
-            <span>
-              {{ mediumProviderLabel }} selected. Browser automation for Medium is oriented around Google sign-in; pick
-              Google if you use “Continue with Google” on Medium.
-            </span>
-          </div>
-        }
-
-        @if (mediumEnabled && mediumProvider === 'google') {
-          <mat-divider class="section-divider"></mat-divider>
-          <h3 class="medium-section-title">Medium session (Playwright)</h3>
-          <p class="connect-description">
-            Uses the <strong>shared Google credentials</strong> at the top of this page. Run
-            <code>playwright install chromium</code> on the API host. Capture once to write
-            <code>storage_state</code>; stats can also auto-sign-in if the session file is missing.
-          </p>
-          <div class="form-row medium-browser-cred-actions">
+          <div class="form-actions form-actions--justify">
             <button
-              mat-stroked-button
+              mat-flat-button
               color="primary"
               type="button"
-              (click)="runMediumBrowserLogin()"
-              [disabled]="mediumBrowserLoginRunning || mediumSaving || !googleBrowserLoginConfigured"
+              (click)="saveMediumSettings()"
+              [disabled]="mediumSaving"
             >
-              @if (mediumBrowserLoginRunning) {
-                Signing in via browser…
-              } @else {
-                Capture Medium session (browser)
-              }
+              @if (mediumSaving) { Saving… } @else { Save Medium settings }
             </button>
           </div>
-        }
-
-        <mat-divider class="section-divider"></mat-divider>
-
-        <div class="form-row">
-          <button
-            mat-raised-button
-            color="primary"
-            type="button"
-            (click)="saveMediumSettings()"
-            [disabled]="mediumSaving"
-          >
-            @if (mediumSaving) { Saving… } @else { Save Medium settings }
-          </button>
         </div>
-      </mat-card-content>
-    }
-  </mat-card>
+      }
+    </article>
+
+  </div>
+</div>

--- a/user-interface/src/app/components/integrations-dashboard/integrations-dashboard.component.scss
+++ b/user-interface/src/app/components/integrations-dashboard/integrations-dashboard.component.scss
@@ -1,207 +1,478 @@
-.google-browser-card,
-.slack-card,
-.medium-card {
-  max-width: 680px;
-  margin-top: 1rem;
+// ============================================================================
+// Integrations Dashboard — Modern grid layout, full-width, dark + amber.
+// ============================================================================
+
+:host {
+  display: block;
+  padding: var(--kh-space-8) var(--kh-space-8) var(--kh-space-12);
+  max-width: 1440px;
+  margin: 0 auto;
 }
 
-.google-browser-avatar {
+// ── Hero ────────────────────────────────────────────────────────────────────
+.integrations-hero {
   display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--kh-space-6);
+  flex-wrap: wrap;
+  margin-bottom: var(--kh-space-8);
+  padding-bottom: var(--kh-space-6);
+  border-bottom: 1px solid var(--kh-border-subtle);
+
+  &__copy {
+    h1 {
+      margin: 0 0 var(--kh-space-2);
+    }
+    p {
+      margin: 0;
+      max-width: 60ch;
+      color: var(--kh-text-tertiary);
+      font-size: var(--kh-text-md);
+    }
+  }
+
+  &__stats {
+    display: flex;
+    gap: var(--kh-space-3);
+  }
+}
+
+.stat-pill {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: var(--kh-space-3) var(--kh-space-5);
+  border-radius: var(--kh-radius-lg);
+  background: var(--kh-accent-muted);
+  border: 1px solid var(--kh-accent-subtle);
+  min-width: 132px;
+
+  &--muted {
+    background: var(--kh-glass);
+    border-color: var(--kh-border-subtle);
+
+    .stat-pill__value {
+      color: var(--kh-text-primary);
+    }
+  }
+
+  &__value {
+    font-size: 1.5rem;
+    font-weight: 700;
+    line-height: 1.1;
+    color: var(--kh-accent);
+    font-feature-settings: 'tnum' 1;
+  }
+
+  &__divider {
+    color: var(--kh-text-muted);
+    font-weight: 500;
+    margin: 0 0.15em;
+  }
+
+  &__label {
+    font-size: var(--kh-text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--kh-text-tertiary);
+  }
+}
+
+// ── Grid ────────────────────────────────────────────────────────────────────
+.integrations-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(420px, 1fr));
+  gap: var(--kh-space-6);
+  align-items: start;
+}
+
+// ── Card ────────────────────────────────────────────────────────────────────
+.integration-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--kh-space-4);
+  padding: var(--kh-space-6);
+  background: var(--kh-surface-2);
+  border: 1px solid var(--kh-border-subtle);
+  border-radius: var(--kh-radius-lg);
+  transition: border-color var(--kh-transition), box-shadow var(--kh-transition), background var(--kh-transition);
+  position: relative;
+
+  &:hover {
+    border-color: var(--kh-border);
+  }
+
+  &--expanded {
+    grid-column: 1 / -1;
+    background: var(--kh-surface-2);
+    border-color: var(--kh-border);
+    box-shadow: var(--kh-shadow-md);
+  }
+
+  &__head {
+    display: flex;
+    align-items: center;
+    gap: var(--kh-space-4);
+    justify-content: space-between;
+  }
+
+  &__brand {
+    display: flex;
+    align-items: center;
+    gap: var(--kh-space-3);
+    min-width: 0;
+  }
+
+  &__title-block {
+    min-width: 0;
+  }
+
+  &__title {
+    font-size: var(--kh-text-lg);
+    margin: 0;
+    line-height: 1.2;
+    color: var(--kh-text-primary);
+  }
+
+  &__tag {
+    margin: 2px 0 0;
+    font-size: var(--kh-text-sm);
+    color: var(--kh-text-tertiary);
+    line-height: 1.2;
+  }
+
+  &__icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 44px;
+    height: 44px;
+    flex-shrink: 0;
+    border-radius: var(--kh-radius-md);
+    box-shadow: var(--kh-shadow-sm);
+
+    mat-icon {
+      font-size: 26px;
+      width: 26px;
+      height: 26px;
+    }
+
+    svg {
+      width: 26px;
+      height: 26px;
+    }
+
+    &--google {
+      background: linear-gradient(135deg, rgba(66, 133, 244, 0.25), rgba(66, 133, 244, 0.10));
+      color: #8ab4f8;
+      border: 1px solid rgba(66, 133, 244, 0.30);
+    }
+
+    &--slack {
+      background: #fff;
+      border: 1px solid var(--kh-border-subtle);
+    }
+
+    &--medium {
+      background: #000;
+      color: #fff;
+      font-weight: 700;
+      font-size: 1.25rem;
+      border: 1px solid var(--kh-border);
+    }
+  }
+
+  &__status {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+
+  &__spinner {
+    --mdc-circular-progress-active-indicator-color: var(--kh-accent);
+  }
+
+  &__summary {
+    margin: 0;
+    color: var(--kh-text-secondary);
+    font-size: var(--kh-text-sm);
+    line-height: 1.55;
+
+    code {
+      background: var(--kh-glass);
+      border: 1px solid var(--kh-border-subtle);
+      border-radius: var(--kh-radius-sm);
+      padding: 0.1em 0.4em;
+      font-size: 0.85em;
+      color: var(--kh-text-primary);
+    }
+  }
+
+  &__actions {
+    display: flex;
+    gap: var(--kh-space-2);
+    flex-wrap: wrap;
+  }
+
+  &__body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--kh-space-4);
+    margin-top: var(--kh-space-2);
+    padding-top: var(--kh-space-5);
+    border-top: 1px solid var(--kh-border-subtle);
+    animation: fade-in 0.18s ease;
+  }
+}
+
+@keyframes fade-in {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+// ── Status chips ────────────────────────────────────────────────────────────
+.status-chip {
+  display: inline-flex;
   align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  border-radius: 8px;
-  background: rgba(66, 133, 244, 0.2);
-  color: #8ab4f8;
+  gap: 0.35rem;
+  padding: 0.3rem 0.65rem;
+  border-radius: var(--kh-radius-full);
+  font-size: var(--kh-text-xs);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  border: 1px solid transparent;
+  white-space: nowrap;
 
   mat-icon {
-    font-size: 26px;
-    width: 26px;
-    height: 26px;
+    font-size: 14px;
+    width: 14px;
+    height: 14px;
+  }
+
+  &--success {
+    background: var(--kh-success-subtle);
+    color: var(--kh-success);
+    border-color: rgba(74, 222, 128, 0.30);
+  }
+
+  &--warning {
+    background: var(--kh-warning-subtle);
+    color: var(--kh-warning);
+    border-color: rgba(251, 191, 36, 0.30);
+  }
+
+  &--info {
+    background: var(--kh-info-subtle);
+    color: var(--kh-info);
+    border-color: rgba(147, 197, 253, 0.30);
+  }
+
+  &--neutral {
+    background: var(--kh-glass);
+    color: var(--kh-text-tertiary);
+    border-color: var(--kh-border-subtle);
   }
 }
 
-.inline-readiness {
-  margin-bottom: 0.75rem;
-  padding: 0.5rem 0.65rem;
-  border-radius: 8px;
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  background: rgba(148, 163, 184, 0.08);
-}
-
-.medium-avatar {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  border-radius: 8px;
-  background: #000;
-  color: #fff;
-  font-weight: 700;
-  font-size: 1.1rem;
-  letter-spacing: -0.02em;
-}
-
-.medium-section-title {
-  margin: 0.75rem 0 0.25rem;
-  font-size: 1rem;
-  font-weight: 600;
-}
-
-.medium-browser-cred-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.5rem;
-  align-items: center;
-}
-
-.medium-readiness-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 0.6rem;
-  margin: 0.8rem 0 1rem;
-}
-
-.readiness-item {
-  border: 1px solid rgba(148, 163, 184, 0.28);
-  background: rgba(148, 163, 184, 0.08);
-  border-radius: 10px;
-  padding: 0.6rem 0.7rem;
-}
-
-.readiness-label {
-  display: block;
-  font-size: 0.74rem;
-  color: #8b949e;
-  margin-bottom: 0.25rem;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-
-.readiness-value {
-  font-size: 0.92rem;
-  font-weight: 600;
-  color: #d29922;
-}
-
-.readiness-value.ready {
-  color: #3fb950;
-}
-
-// ── Loading ────────────────────────────────────────────────────────────────
-.loading-wrap {
-  display: flex;
-  justify-content: center;
-  padding: 3rem 0;
-}
-
-// ── Card avatar: Slack logo ────────────────────────────────────────────────
-.slack-avatar {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 40px;
-  height: 40px;
-  border-radius: 8px;
-  background: #fff;
-  box-shadow: 0 1px 3px rgba(0, 0, 0, .15);
-
-  svg {
-    width: 26px;
-    height: 26px;
-  }
-}
-
-// ── Status banners ─────────────────────────────────────────────────────────
+// ── Status banners (inside expanded body) ───────────────────────────────────
 .status-banner {
   display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.75rem 1rem;
-  border-radius: 6px;
-  margin-bottom: 1.25rem;
-  font-size: 0.9rem;
-  background: rgba(148, 163, 184, 0.12);
-  color: #c9d1d9;
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  align-items: flex-start;
+  gap: var(--kh-space-2);
+  padding: var(--kh-space-3) var(--kh-space-4);
+  border-radius: var(--kh-radius-md);
+  font-size: var(--kh-text-sm);
+  background: var(--kh-glass);
+  border: 1px solid var(--kh-border-subtle);
+  color: var(--kh-text-secondary);
 
   mat-icon {
     flex-shrink: 0;
-    font-size: 1.2rem;
-    width: 1.2rem;
-    height: 1.2rem;
+    font-size: 18px;
+    width: 18px;
+    height: 18px;
+    margin-top: 1px;
+  }
+
+  &--error {
+    background: var(--kh-error-subtle);
+    border-color: rgba(248, 113, 113, 0.32);
+    color: #fecaca;
+  }
+
+  &--success {
+    background: var(--kh-success-subtle);
+    border-color: rgba(74, 222, 128, 0.32);
+    color: #bbf7d0;
+  }
+
+  &--info {
+    background: var(--kh-info-subtle);
+    border-color: rgba(147, 197, 253, 0.32);
+    color: #dbeafe;
+  }
+
+  code {
+    background: rgba(0, 0, 0, 0.4);
+    padding: 0.05em 0.35em;
+    border-radius: 4px;
+    font-size: 0.85em;
   }
 }
 
-.error-banner {
-  background: rgba(248, 113, 113, 0.14);
-  color: #fecaca;
-  border: 1px solid rgba(248, 113, 113, 0.28);
-}
-
-.success-banner {
-  background: rgba(63, 185, 80, 0.16);
-  color: #bbf7d0;
-  border: 1px solid rgba(63, 185, 80, 0.28);
-}
-
-.info-banner {
-  background: rgba(96, 165, 250, 0.12);
-  color: #bfdbfe;
-  border: 1px solid rgba(96, 165, 250, 0.28);
-}
-
-// ── Connected state ────────────────────────────────────────────────────────
-.connected-badge {
+// ── Connected summary (Slack connected card body) ──────────────────────────
+.connected-summary {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
-  padding: 0.875rem 1rem;
-  background: rgba(63, 185, 80, 0.12);
-  border: 1px solid rgba(63, 185, 80, 0.32);
-  border-radius: 8px;
-  margin-bottom: 1.25rem;
+  gap: var(--kh-space-3);
+  padding: var(--kh-space-3) var(--kh-space-4);
+  background: var(--kh-success-subtle);
+  border: 1px solid rgba(74, 222, 128, 0.32);
+  border-radius: var(--kh-radius-md);
+
+  &__icon {
+    color: var(--kh-success);
+    font-size: 22px;
+    width: 22px;
+    height: 22px;
+  }
+
+  &__text {
+    display: flex;
+    align-items: center;
+    gap: var(--kh-space-2);
+    flex-wrap: wrap;
+  }
+
+  &__label {
+    color: var(--kh-text-secondary);
+    font-size: var(--kh-text-sm);
+  }
+
+  &__name {
+    font-weight: 600;
+    color: var(--kh-text-primary);
+  }
 }
 
-.connected-icon {
-  color: #3fb950;
-  font-size: 1.6rem;
-  width: 1.6rem;
-  height: 1.6rem;
+// ── Form layout ─────────────────────────────────────────────────────────────
+.form-grid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--kh-space-3) var(--kh-space-4);
+
+  &--two {
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  }
+
+  mat-form-field {
+    width: 100%;
+  }
 }
 
-.connected-text {
+.form-actions {
   display: flex;
-  flex-direction: column;
-  flex: 1;
+  gap: var(--kh-space-3);
+  flex-wrap: wrap;
+  align-items: center;
+
+  &--justify {
+    justify-content: flex-end;
+  }
 }
 
-.connected-label {
-  font-weight: 600;
-  font-size: 0.95rem;
-  color: #bbf7d0;
-}
-
-.team-name {
-  font-size: 0.85rem;
-  color: #86efac;
-}
-
-.disconnect-btn {
-  margin-left: auto;
-  flex-shrink: 0;
-}
-
-// ── Not-connected state ────────────────────────────────────────────────────
-.connect-description {
-  color: #9ca3af;
-  margin-bottom: 1.5rem;
+.form-hint {
+  margin: 0;
+  font-size: var(--kh-text-sm);
+  color: var(--kh-text-tertiary);
   line-height: 1.6;
 }
 
-// The "Add to Slack" button matches Slack's brand button guidelines
+// ── Setting rows (toggles, radio groups) ────────────────────────────────────
+.setting-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--kh-space-3) var(--kh-space-6);
+  align-items: center;
+  padding: var(--kh-space-3) var(--kh-space-4);
+  border-radius: var(--kh-radius-md);
+  background: var(--kh-glass);
+  border: 1px solid var(--kh-border-subtle);
+
+  &__label {
+    font-size: var(--kh-text-sm);
+    color: var(--kh-text-secondary);
+    font-weight: 500;
+    margin-right: var(--kh-space-2);
+  }
+
+  mat-radio-group {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--kh-space-4);
+  }
+}
+
+// ── Readiness grid (Medium) ─────────────────────────────────────────────────
+.readiness-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: var(--kh-space-3);
+}
+
+.readiness-tile {
+  padding: var(--kh-space-3) var(--kh-space-4);
+  background: var(--kh-glass);
+  border: 1px solid var(--kh-border-subtle);
+  border-radius: var(--kh-radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  position: relative;
+
+  &__label {
+    font-size: var(--kh-text-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: var(--kh-text-muted);
+  }
+
+  &__value {
+    font-size: var(--kh-text-md);
+    font-weight: 600;
+    color: var(--kh-warning);
+  }
+
+  &--ready {
+    background: var(--kh-success-subtle);
+    border-color: rgba(74, 222, 128, 0.30);
+
+    .readiness-tile__value {
+      color: var(--kh-success);
+    }
+  }
+}
+
+// ── Subsection (inset block) ────────────────────────────────────────────────
+.subsection {
+  padding: var(--kh-space-4);
+  background: var(--kh-surface-1);
+  border: 1px solid var(--kh-border-subtle);
+  border-radius: var(--kh-radius-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--kh-space-3);
+
+  &__title {
+    margin: 0;
+    font-size: var(--kh-text-md);
+    font-weight: 600;
+    color: var(--kh-text-primary);
+  }
+}
+
+// ── Slack brand button ──────────────────────────────────────────────────────
 .slack-connect-btn {
   display: inline-flex;
   align-items: center;
@@ -209,39 +480,36 @@
   padding: 0 1.25rem;
   height: 44px;
   border: none;
-  border-radius: 4px;
-  background: #4a154b;   // Slack aubergine
+  border-radius: var(--kh-radius-md);
+  background: #4a154b;
   color: #fff;
-  font-size: 0.95rem;
+  font-size: var(--kh-text-md);
   font-weight: 600;
   cursor: pointer;
-  transition: background 0.15s ease;
+  transition: background var(--kh-transition), transform var(--kh-transition);
 
   &:hover:not(:disabled) {
     background: #611f69;
+    transform: translateY(-1px);
   }
 
   &:disabled {
     opacity: 0.55;
     cursor: not-allowed;
   }
+
+  &__logo {
+    width: 20px;
+    height: 20px;
+    flex-shrink: 0;
+  }
 }
 
-.btn-slack-logo {
-  width: 20px;
-  height: 20px;
-  flex-shrink: 0;
-}
-
-// ── Divider ────────────────────────────────────────────────────────────────
-.section-divider {
-  margin: 1.5rem 0;
-}
-
-// ── Advanced section ───────────────────────────────────────────────────────
+// ── Advanced toggle ─────────────────────────────────────────────────────────
 .advanced-toggle {
-  color: #9ca3af;
-  font-size: 0.875rem;
+  align-self: flex-start;
+  color: var(--kh-text-tertiary) !important;
+  font-size: var(--kh-text-sm);
   text-transform: none;
   letter-spacing: 0;
 
@@ -254,46 +522,40 @@
 }
 
 .advanced-section {
-  margin-top: 0.75rem;
-  padding: 1rem;
-  background: rgba(148, 163, 184, 0.06);
-  border: 1px solid rgba(148, 163, 184, 0.18);
-  border-radius: 6px;
-}
-
-.advanced-hint {
-  font-size: 0.85rem;
-  color: #9ca3af;
-  margin-bottom: 1rem;
-}
-
-// ── Shared form rows ───────────────────────────────────────────────────────
-.form-row {
-  margin-bottom: 1rem;
-
-  &:last-of-type {
-    margin-bottom: 0;
-  }
-}
-
-.mode-label {
-  display: block;
-  margin-bottom: 0.5rem;
-  font-weight: 500;
-}
-
-mat-radio-group {
-  display: flex;
-  gap: 1rem;
-  flex-wrap: wrap;
-}
-
-.toggles {
   display: flex;
   flex-direction: column;
-  gap: 0.5rem;
+  gap: var(--kh-space-4);
+  padding: var(--kh-space-4);
+  background: var(--kh-surface-1);
+  border: 1px solid var(--kh-border-subtle);
+  border-radius: var(--kh-radius-md);
+  animation: fade-in 0.18s ease;
 }
 
-.full-width {
-  width: 100%;
+// ── Responsive ──────────────────────────────────────────────────────────────
+@media (max-width: 720px) {
+  :host {
+    padding: var(--kh-space-5) var(--kh-space-4) var(--kh-space-10);
+  }
+
+  .integrations-hero {
+    align-items: flex-start;
+
+    &__stats {
+      width: 100%;
+    }
+  }
+
+  .stat-pill {
+    flex: 1;
+    min-width: 0;
+  }
+
+  .integrations-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .integration-card {
+    padding: var(--kh-space-5);
+  }
 }

--- a/user-interface/src/app/components/integrations-dashboard/integrations-dashboard.component.ts
+++ b/user-interface/src/app/components/integrations-dashboard/integrations-dashboard.component.ts
@@ -24,6 +24,8 @@ import type {
 
 const SLACK_WEBHOOK_PREFIX = 'https://hooks.slack.com/';
 
+type IntegrationKey = 'google' | 'slack' | 'medium';
+
 @Component({
   selector: 'app-integrations-dashboard',
   standalone: true,
@@ -53,6 +55,23 @@ export class IntegrationsDashboardComponent implements OnInit {
   disconnecting = false;
   error: string | null = null;
   success: string | null = null;
+
+  /** Which integration card is currently expanded inline. Only one at a time. */
+  expanded: IntegrationKey | null = null;
+
+  toggleExpanded(key: IntegrationKey): void {
+    this.expanded = this.expanded === key ? null : key;
+  }
+
+  readonly totalIntegrations = 3;
+
+  get connectedCount(): number {
+    let n = 0;
+    if (this.googleBrowserLoginConfigured) n += 1;
+    if (this.oauthConnected) n += 1;
+    if (this.mediumReadyForStats) n += 1;
+    return n;
+  }
 
   // OAuth connection state
   oauthConnected = false;
@@ -94,17 +113,21 @@ export class IntegrationsDashboardComponent implements OnInit {
         this.success = team
           ? `Connected to "${team}" workspace successfully.`
           : 'Slack connected successfully.';
+        this.expanded = 'slack';
         this.loadSlackConfig();
       } else if (params['slack_error']) {
         const errCode = params['slack_error'];
         this.error = this.friendlySlackOAuthError(errCode);
+        this.expanded = 'slack';
       }
       if (params['medium_google_connected']) {
         this.mediumSuccess = 'Google account linked for Medium workflow.';
+        this.expanded = 'medium';
         this.loadMediumConfig();
       }
       if (params['medium_error']) {
         this.mediumError = this.friendlyMediumOAuthError(String(params['medium_error']));
+        this.expanded = 'medium';
       }
     });
   }


### PR DESCRIPTION
## Summary

The previous Integrations page stacked three full-width Material cards (capped at 680px) on top of each other, wasting horizontal space and pushing every form below the fold. This rebuilds the layout around the rest of the Khala UI's design language (`--kh-*` tokens, layered dark surfaces, amber accent).

**What changed**

- **Hero header** — title, one-line description, and a stat pill summary (`X/3 Connected`, pending count) so users see status at a glance.
- **Responsive grid** — integration tiles flow in `repeat(auto-fill, minmax(420px, 1fr))`, so wide screens show 2-3 tiles per row instead of one stacked column.
- **Expandable tiles** — each card collapsed by default with brand icon, status chip (Saved / Connected / Action needed / Not configured), one-sentence summary and a single Configure / Manage CTA. Clicking expands the card to full row width with the inline form.
- **Side-by-side form grids** — email + password, Client ID + Client Secret, bot token + default channel are now `grid-template-columns: repeat(auto-fit, minmax(240px, 1fr))` so wide layouts use the available width; on narrow screens they collapse to one column.
- **Setting rows** — toggles (enable, notify open questions, notify PA replies) wrap horizontally inside a subtle glass row instead of stacking.
- **Status chips and banners** rebuilt against the existing `--kh-success / --kh-warning / --kh-error / --kh-info` tokens.
- **Auto-expand on OAuth callback** — `slack_connected` / `medium_google_connected` (and their error variants) auto-open the relevant card so the success/error banner is visible.

**Design tokens used**: `--kh-surface-1/2`, `--kh-border-subtle`, `--kh-radius-md/lg`, `--kh-accent`, `--kh-glass`, `--kh-success-subtle`, `--kh-warning-subtle`, `--kh-info-subtle`, `--kh-shadow-md`, `--kh-text-*`, `--kh-space-*`.

## Test plan

- [x] `npx ng build --configuration=production` — succeeds (only the unrelated, pre-existing initial-bundle budget warning).
- [x] `npx vitest run src/app/components/integrations-dashboard` — 8/8 green (component-state tests untouched by the template rewrite).
- [ ] Manual: open `/integrations` and confirm:
  - [ ] Cards render in a multi-column grid on a wide viewport (>= ~1200px).
  - [ ] Clicking Configure expands the tile to full width and shows the form.
  - [ ] Form fields appear side-by-side (email + password, Client ID + Client Secret).
  - [ ] Toggles stack inline horizontally.
  - [ ] Slack OAuth round-trip: connecting auto-expands the Slack tile and shows the success banner.
  - [ ] Stat pill at top reflects the connected count (0–3) accurately as integrations come online.
  - [ ] Below ~720px the grid collapses to a single column without overflow.

https://claude.ai/code/session_01NDTieMjmjUoCPXsP2j1ATq

---
_Generated by [Claude Code](https://claude.ai/code/session_01NDTieMjmjUoCPXsP2j1ATq)_