### PR TITLE
docker: pin temporal service to UID:GID 1000:1000

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -35,6 +35,13 @@ This directory defines a **Docker Compose stack** that runs:
    podman compose -f docker/docker-compose.yml --env-file docker/.env up --build
    ```
 
+   > **Note (Podman / rootless runtimes):** The `temporal` service pins
+   > `user: "1000:1000"` because the `temporalio/auto-setup` image declares
+   > `USER temporal`, which some rootless OCI runtimes can't resolve and
+   > error out with `unable to find user temporal: no matching entries in
+   > passwd file`. The numeric form maps to the same identity the image
+   > already uses (UID/GID 1000) and is a no-op for daemon-mode Docker.
+
 3. **Access**
 
    | Service        | URL                         |

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -43,6 +43,14 @@ services:
   temporal:
     image: temporalio/auto-setup:1.24.2
     container_name: khala-stack-temporal
+    # The auto-setup image declares `USER temporal` (UID/GID 1000) in its
+    # Dockerfile. Some OCI runtimes — most notably rootless Podman, but also
+    # Docker setups where the runtime resolves the user before mounting the
+    # image rootfs — fail that name lookup with:
+    #   "unable to find user temporal: no matching entries in passwd file"
+    # Pinning to the numeric UID:GID skips the name lookup and starts the
+    # container as the same identity the image already uses.
+    user: "1000:1000"
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Fixes `docker compose up` failing with:

```
Error response from daemon: unable to find user temporal: no matching entries in passwd file
Error: executing /usr/libexec/docker/cli-plugins/docker-compose -f docker/docker-compose.yml --env-file docker/.env up -d: exit status 1
```

The `temporalio/auto-setup:1.24.2` image declares `USER temporal` (UID/GID 1000, per [temporalio/docker-builds `server.Dockerfile`](https://github.com/temporalio/docker-builds/blob/main/server.Dockerfile): `addgroup -g 1000 temporal && adduser -u 1000 -G temporal -D temporal`). Some OCI runtimes — notably rootless Podman, which `docker/README.md` already documents as a supported way to run this stack — fail the by-name lookup during user-namespace setup and emit the error above before the container ever starts.

Pinning the service to `user: "1000:1000"` skips the username lookup and starts the container as the same identity the image already uses. It's a no-op for daemon-mode Docker.

- `docker/docker-compose.yml`: add `user: "1000:1000"` to the `temporal` service with an inline comment explaining the failure mode.
- `docker/README.md`: short note in the Podman section pointing at this pin.

## Test plan

- [ ] `docker compose -f docker/docker-compose.yml --env-file docker/.env up -d temporal` brings the container up cleanly under daemon Docker.
- [ ] Same command under rootless `podman compose` no longer errors with `unable to find user temporal`.
- [ ] Temporal UI at http://localhost:8080 loads after the stack is up.
- [ ] `docker logs khala-stack-temporal` shows auto-setup completing and the server listening on `:7233`.

https://claude.ai/code/session_01Pn6cXURECgfLEJktHFkaxJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pn6cXURECgfLEJktHFkaxJ)_