### PR TITLE
docker: make temporal user override opt-in via TEMPORAL_USER

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -54,6 +54,14 @@ POSTGRES_PASSWORD_SANDBOX_BRANDING=
 # No extra vars needed; service uses POSTGRES_SEEDS=postgres, POSTGRES_USER=temporal, POSTGRES_PWD=temporal
 # For khala (unified API): connect to Temporal for SE team workflows
 TEMPORAL_ADDRESS=temporal:7233
+# Optional: override the UID:GID the temporal container runs as. Leave empty
+# (default) to use the image's `USER temporal` directive — required for
+# Docker / Docker Desktop / docker-userns-remap setups, where forcing a
+# numeric UID can produce:
+#   runc create failed: ... can't get final child's PID from pipe: EOF
+# Set to `1000:1000` for **rootless Podman** if you hit:
+#   unable to find user temporal: no matching entries in passwd file
+# TEMPORAL_USER=1000:1000
 # Optional: namespace (default "default"), task queue (default "software-engineering")
 # TEMPORAL_NAMESPACE=default
 # TEMPORAL_TASK_QUEUE=software-engineering

--- a/docker/README.md
+++ b/docker/README.md
@@ -35,12 +35,19 @@ This directory defines a **Docker Compose stack** that runs:
    podman compose -f docker/docker-compose.yml --env-file docker/.env up --build
    ```
 
-   > **Note (Podman / rootless runtimes):** The `temporal` service pins
-   > `user: "1000:1000"` because the `temporalio/auto-setup` image declares
-   > `USER temporal`, which some rootless OCI runtimes can't resolve and
-   > error out with `unable to find user temporal: no matching entries in
-   > passwd file`. The numeric form maps to the same identity the image
-   > already uses (UID/GID 1000) and is a no-op for daemon-mode Docker.
+   > **Note (Podman / rootless runtimes):** The `temporal` service exposes
+   > `user: "${TEMPORAL_USER:-}"`. The default (empty) lets the
+   > `temporalio/auto-setup` image use its built-in `USER temporal`
+   > directive — required for Docker / Docker Desktop / docker-userns-remap
+   > setups, where forcing a numeric UID can otherwise produce a generic
+   > `runc create failed: ... can't get final child's PID from pipe: EOF`
+   > because UID 1000 isn't always mappable through the user namespace.
+   > **Rootless Podman** users sometimes hit the opposite problem —
+   > `unable to find user temporal: no matching entries in passwd file` —
+   > because the runtime resolves the user before mounting the image
+   > rootfs. In that case, set `TEMPORAL_USER=1000:1000` in `docker/.env`;
+   > the numeric form maps to the same identity the image uses and skips
+   > the name lookup.
 
 3. **Access**
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -44,13 +44,19 @@ services:
     image: temporalio/auto-setup:1.24.2
     container_name: khala-stack-temporal
     # The auto-setup image declares `USER temporal` (UID/GID 1000) in its
-    # Dockerfile. Some OCI runtimes — most notably rootless Podman, but also
-    # Docker setups where the runtime resolves the user before mounting the
-    # image rootfs — fail that name lookup with:
+    # Dockerfile. Some OCI runtimes — most notably rootless Podman — fail the
+    # by-name lookup with:
     #   "unable to find user temporal: no matching entries in passwd file"
-    # Pinning to the numeric UID:GID skips the name lookup and starts the
-    # container as the same identity the image already uses.
-    user: "1000:1000"
+    # Numeric UID:GID skips the name lookup. We expose this as
+    # `TEMPORAL_USER` (default empty = use the image's USER directive) because
+    # forcing `user: "1000:1000"` on rootless Docker / docker-userns-remap /
+    # Docker Desktop setups instead triggers:
+    #   "runc create failed: unable to start container process:
+    #    can't get final child's PID from pipe: EOF: OCI runtime error"
+    # when UID 1000 isn't mappable through the user namespace. Podman users
+    # who hit the name-lookup error should set `TEMPORAL_USER=1000:1000` in
+    # docker/.env. See docker/README.md.
+    user: "${TEMPORAL_USER:-}"
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
## Summary

- Fixes `docker compose up` failing with `runc create failed: unable to start container process: can't get final child's PID from pipe: EOF: OCI runtime error`.
- PR #400 hard-coded `user: "1000:1000"` on the `temporal` service to work around a rootless-Podman name-lookup error and claimed it was a no-op for daemon-mode Docker. That assertion only holds on plain Docker + cgroup-v1; on rootless Docker / `docker-userns-remap` / Docker Desktop the explicit UID has to be mappable through the user namespace, and when it isn't, runc kills the container's init before it writes its PID — surfacing this very generic error.
- Makes the override **opt-in**: `user: "${TEMPORAL_USER:-}"` defaults to empty (the image's built-in `USER temporal` directive applies), and `TEMPORAL_USER=1000:1000` is documented for Podman users who hit the original name-lookup path.

## Why this is safe

`docker compose config` confirms the empty interpolation is stripped — no `user:` is sent to the engine, so the `temporalio/auto-setup:1.24.2` image runs as `temporal` (UID 1000) exactly as upstream intends. Setting `TEMPORAL_USER=1000:1000` in `docker/.env` reproduces the previous behaviour byte-for-byte.

## Test plan

- [ ] `docker compose -f docker/docker-compose.yml --env-file docker/.env up -d` brings up the temporal service on Docker / Docker Desktop without the runc EOF error.
- [ ] On rootless Podman, `TEMPORAL_USER=1000:1000 podman compose ... up -d` still avoids the `unable to find user temporal: no matching entries in passwd file` error.
- [ ] `docker compose config` renders no `user:` field for the `temporal` service when `TEMPORAL_USER` is unset, and renders `user: 1000:1000` when it is set.

https://claude.ai/code/session_01Qwnsfjq7iV7yHopZVsPWGM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qwnsfjq7iV7yHopZVsPWGM)_