### PR TITLE
Tolerate tiny OHLC floating-point drift in market data validation

### DIFF
--- a/backend/agents/investment_team/execution/data_quality.py
+++ b/backend/agents/investment_team/execution/data_quality.py
@@ -515,11 +515,18 @@ def _ohlc_violation(bar: OHLCVBar) -> bool:
     if not all(math.isfinite(v) for v in (o, h, ll, c)):
         # Already counted by the NaN check; do not double-count.
         return False
-    if h < ll:
+
+    # Vendors can emit tiny floating-point drift (e.g., high a few ULPs below
+    # open/close). Treat invariants with a relative tolerance so we only flag
+    # materially broken bars.
+    scale = max(1.0, abs(o), abs(h), abs(ll), abs(c))
+    eps = 1e-9 * scale
+
+    if h + eps < ll:
         return True
-    if h < max(o, c):
+    if h + eps < max(o, c):
         return True
-    if ll > min(o, c):
+    if ll - eps > min(o, c):
         return True
     return False
 


### PR DESCRIPTION
### Motivation
- Prevent spurious `ohlc_violations` that arise from tiny floating-point rounding drift in provider feeds which cause strategy-lab/backtest preflight runs to fail despite data being materially correct.

### Description
- Replace exact OHLC comparisons in `_ohlc_violation` with a small relative tolerance by computing `scale = max(1.0, abs(o), abs(h), abs(ll), abs(c))` and `eps = 1e-9 * scale` and applying `eps` to the three invariant checks. 
- Preserve existing NaN/negative checks so genuinely corrupted bars still fail the validator.
- Change is confined to `backend/agents/investment_team/execution/data_quality.py` and keeps all other rule logic unchanged.

### Testing
- Ran `pytest -q backend/agents/investment_team/tests/test_data_quality.py` and all tests passed (`27 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f51f840734832e9def4f3c37bfe270)