### PR TITLE
[Trading 5/5 — Step 4] Partial-fill emission + REQUEUE_NEXT_BAR + partial-exit accounting (#386)

### DIFF
--- a/backend/agents/investment_team/tests/test_paper_trade.py
+++ b/backend/agents/investment_team/tests/test_paper_trade.py
@@ -133,6 +133,11 @@ class _StubProvider:
 
 
 def _hist_bar(ts: str, close: float, symbol: str = "BTC") -> BarEvent:
+    # ``volume`` must be large enough that the strategy's qty=1 order doesn't
+    # hit the realistic execution model's 10% participation cap on either
+    # entry or exit. Pre-#386 exits ignored the cap, so an arbitrary
+    # placeholder (1.0) worked; post-#386 the cap applies symmetrically and
+    # tiny-volume bars clip a qty=1 fill into a qty=0.1 partial.
     return BarEvent(
         bar=Bar(
             symbol=symbol,
@@ -142,7 +147,7 @@ def _hist_bar(ts: str, close: float, symbol: str = "BTC") -> BarEvent:
             high=close,
             low=close,
             close=close,
-            volume=1.0,
+            volume=1_000_000.0,
         )
     )
 
@@ -156,7 +161,7 @@ def _native_bar(close_ts: str, close: float, symbol: str = "BTC", tf: str = "1m"
         high=close,
         low=close,
         close=close,
-        volume=1.0,
+        volume=1_000_000.0,
     )
 
 

--- a/backend/agents/investment_team/tests/test_partial_fills.py
+++ b/backend/agents/investment_team/tests/test_partial_fills.py
@@ -605,3 +605,118 @@ def test_capital_is_conserved_across_fragmented_round_trip() -> None:
 
     # Zero-cost flat round-trip: capital must equal initial.
     assert portfolio.capital == pytest.approx(initial, rel=1e-9)
+
+
+def test_over_ask_exit_total_unfilled_capped_at_cap_clipped_only() -> None:
+    """When an over-ask exit gets requeued, the never-fillable portion
+    must not accumulate into ``total_unfilled_qty`` on every bar — only
+    the participation-cap-clipped slice does.
+
+    Regression for a Codex P2 review note on PR #417: the previous
+    ``pos.total_unfilled_qty += unfilled`` (with ``unfilled`` measured
+    from the request) added the same ghost over-ask amount each bar, so
+    a 2000-share exit against a 1000-share position could report > 2000
+    unfilled in the final ``TradeRecord``.
+    """
+    sim, order_book, portfolio = _make_simulator()
+    order_book.submit(
+        _entry_order(1_000),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+    )
+    sim.process_bar(_bar("2024-01-02", price=100.0, volume=10_000_000))
+
+    order_book.submit(
+        _exit_order(2_000, policy=UnfilledPolicy.REQUEUE_NEXT_BAR),
+        submitted_at="2024-01-02",
+        submitted_equity=10_000_000.0,
+    )
+    # Bar 1: cap-clipped: fillable=min(2000, 1000)=1000, qty_fraction=0.5,
+    # filled=500, cap_clipped=500. pos.qty=500.
+    bar1 = sim.process_bar(_bar("2024-01-03", price=100.0, volume=10_000))
+    assert bar1.closed_trades == []
+    # Bar 2: high volume, fillable=min(remaining, pos.qty)=500, filled=500.
+    # cap_clipped=0. Position closes.
+    bar2 = sim.process_bar(_bar("2024-01-04", price=100.0, volume=10_000_000))
+    assert len(bar2.closed_trades) == 1
+    record = bar2.closed_trades[0]
+    # total_unfilled_qty must reflect cap-clipped slices only (500), not
+    # the carried over-ask amount times each requeue (which would have
+    # given 1500 + 1000 = 2500 under the old behavior).
+    assert record.total_unfilled_qty == pytest.approx(500.0, rel=1e-9)
+    assert record.shares == pytest.approx(1_000.0, rel=1e-9)
+
+
+def test_multi_bar_exit_records_weighted_bid_price() -> None:
+    """A multi-bar partial exit reports a qty-weighted ``exit_bid_price``
+    on the TradeRecord (mirroring the weighted ``exit_price``), not just
+    the closing bar's reference.
+
+    Regression for a Codex P2 review note on PR #417: leaving
+    ``exit_bid_price`` anchored to the final bar mismatched the two
+    fields and skewed slippage diagnostics on multi-slice exits.
+    """
+    sim, order_book, portfolio = _make_simulator()
+    order_book.submit(
+        _entry_order(2_000),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+    )
+    sim.process_bar(_bar("2024-01-02", price=100.0, volume=10_000_000))
+
+    order_book.submit(
+        _exit_order(2_000, policy=UnfilledPolicy.REQUEUE_NEXT_BAR),
+        submitted_at="2024-01-02",
+        submitted_equity=10_000_000.0,
+    )
+    # Bar 1: cap-clipped 50% partial @ ref=110 → 1000 shares.
+    sim.process_bar(_bar("2024-01-03", price=110.0, volume=10_000))
+    # Bar 2: full close @ ref=120 → 1000 shares.
+    bar2 = sim.process_bar(_bar("2024-01-04", price=120.0, volume=10_000_000))
+
+    assert len(bar2.closed_trades) == 1
+    record = bar2.closed_trades[0]
+    # Weighted bid = (1000 * 110 + 1000 * 120) / 2000 = 115 — matching the
+    # weighted exit_price (since slippage is zero in this test).
+    assert record.exit_bid_price == pytest.approx(115.0, rel=1e-9)
+    assert record.exit_price == pytest.approx(115.0, rel=1e-9)
+
+
+def test_multi_bar_entry_records_weighted_entry_bid_price() -> None:
+    """A multi-bar partial entry continuation reports a qty-weighted
+    ``entry_bid_price`` on the TradeRecord (mirroring the weighted
+    ``entry_price``), not the first slice's reference.
+
+    Regression for a Codex P2 review note on PR #417: ``Portfolio.extend``
+    used to update ``entry_price`` to a weighted average but leave
+    ``entry_bid_price`` anchored at the first slice, skewing entry-side
+    slippage metrics on fragmented entries.
+    """
+    sim, order_book, portfolio = _make_simulator()
+
+    # Bar 1: partial fill @ ref=100, cap forces 50% → 1000 shares filled.
+    order_book.submit(
+        _entry_order(2_000, policy=UnfilledPolicy.REQUEUE_NEXT_BAR),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+    )
+    sim.process_bar(_bar("2024-01-02", price=100.0, volume=10_000))
+    # Bar 2: full continuation @ ref=110.
+    sim.process_bar(_bar("2024-01-03", price=110.0, volume=10_000_000))
+
+    pos = portfolio.positions["AAA"]
+    # Weighted entry bid = (1000 * 100 + 1000 * 110) / 2000 = 105 — same as
+    # weighted entry_price since slippage is zero.
+    assert pos.entry_bid_price == pytest.approx(105.0, rel=1e-9)
+    assert pos.entry_price == pytest.approx(105.0, rel=1e-9)
+
+    # Close cleanly at the same weighted price; TradeRecord propagates
+    # the weighted entry bid.
+    order_book.submit(
+        _exit_order(2_000),
+        submitted_at="2024-01-03",
+        submitted_equity=10_000_000.0,
+    )
+    bar3 = sim.process_bar(_bar("2024-01-04", price=120.0, volume=10_000_000))
+    assert len(bar3.closed_trades) == 1
+    assert bar3.closed_trades[0].entry_bid_price == pytest.approx(105.0, rel=1e-9)

--- a/backend/agents/investment_team/tests/test_partial_fills.py
+++ b/backend/agents/investment_team/tests/test_partial_fills.py
@@ -1,0 +1,272 @@
+"""Partial-fill emission tests for the streaming fill simulator (#386).
+
+Covers the five acceptance bullets from the issue:
+
+1. ``RealisticExecutionModel`` + low ADV → entry returns
+   ``Fill(fill_kind=PARTIAL, unfilled_qty>0)``.
+2. ``REQUEUE_NEXT_BAR`` → two consecutive entry fills sum to the original
+   qty; the resulting ``TradeRecord`` carries
+   ``partial_fill_count=2`` and ``participation_clipped=True``.
+3. ``DROP`` policy preserves the silent-remainder behavior end-to-end
+   (the partial Fill is still emitted, but the remainder is not requeued).
+4. Bar-safety guard does not fire on a requeued order's next-bar fill —
+   ``OrderBook.requeue`` advances ``submitted_at`` to the fill bar so the
+   next bar is strictly later.
+5. Partial exit: position qty is decremented across multiple bars,
+   ``TradeRecord`` is emitted only on the closing bar, and
+   ``TradeRecord.exit_price`` equals the qty-weighted average exit price.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from investment_team.execution.bar_safety import BarSafetyAssertion
+from investment_team.execution.risk_filter import RiskFilter, RiskLimits
+from investment_team.trading_service.engine.execution_model import RealisticExecutionModel
+from investment_team.trading_service.engine.fill_simulator import (
+    FillSimulator,
+    FillSimulatorConfig,
+)
+from investment_team.trading_service.engine.order_book import OrderBook
+from investment_team.trading_service.engine.portfolio import Portfolio
+from investment_team.trading_service.strategy.contract import (
+    Bar,
+    FillKind,
+    OrderRequest,
+    OrderSide,
+    OrderType,
+    TimeInForce,
+    UnfilledPolicy,
+)
+
+
+def _bar(ts: str, *, price: float = 100.0, volume: float = 1_000_000.0) -> Bar:
+    return Bar(
+        symbol="AAA",
+        timestamp=ts,
+        timeframe="1d",
+        open=price,
+        high=price + 1,
+        low=price - 1,
+        close=price,
+        volume=volume,
+    )
+
+
+def _make_simulator(
+    initial_capital: float = 10_000_000.0,
+) -> tuple[FillSimulator, OrderBook, Portfolio]:
+    portfolio = Portfolio(initial_capital=initial_capital)
+    order_book = OrderBook()
+    sim = FillSimulator(
+        portfolio=portfolio,
+        order_book=order_book,
+        risk_filter=RiskFilter(RiskLimits(max_position_pct=100, max_gross_leverage=10.0)),
+        config=FillSimulatorConfig(slippage_bps=0.0, transaction_cost_bps=0.0),
+        bar_safety=BarSafetyAssertion(),
+        # Default 0.10 cap is what production uses — pin explicitly here so
+        # the math in this test file doesn't drift if the default changes.
+        execution_model=RealisticExecutionModel(participation_cap=0.10),
+    )
+    return sim, order_book, portfolio
+
+
+def _entry_order(qty: float, *, policy: UnfilledPolicy | None = None) -> OrderRequest:
+    return OrderRequest(
+        client_order_id="entry-1",
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=qty,
+        order_type=OrderType.MARKET,
+        tif=TimeInForce.DAY,
+        unfilled_policy=policy,
+    )
+
+
+def _exit_order(qty: float, *, policy: UnfilledPolicy | None = None) -> OrderRequest:
+    return OrderRequest(
+        client_order_id="exit-1",
+        symbol="AAA",
+        side=OrderSide.SHORT,
+        qty=qty,
+        order_type=OrderType.MARKET,
+        tif=TimeInForce.DAY,
+        unfilled_policy=policy,
+    )
+
+
+# Participation math reminder (default cap = 0.10):
+#   raw_participation = req.qty * ref_price / (bar.volume * bar.close)
+#   if raw_participation <= cap: qty_fraction = 1.0
+#   else:                        qty_fraction = cap / raw_participation
+#
+# To force a 50% partial: raw_participation = 0.20.
+# At price=100, volume=10_000, bar_dollar_volume = 1_000_000.
+# An order of qty=2_000 has notional = 200_000 → raw_participation = 0.20
+# → qty_fraction = 0.5 → fills 1_000, leaves 1_000 unfilled.
+
+
+def test_realistic_low_adv_emits_partial_entry_fill() -> None:
+    """Single oversized order against a low-ADV bar emits a PARTIAL fill.
+
+    No silent-drop: the engine must annotate the Fill with ``fill_kind``,
+    ``unfilled_qty``, and ``cumulative_filled_qty`` so the strategy sees
+    what actually filled.
+    """
+    sim, order_book, portfolio = _make_simulator()
+    order_book.submit(
+        _entry_order(2_000),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+    )
+
+    outcome = sim.process_bar(_bar("2024-01-02", price=100.0, volume=10_000))
+
+    assert len(outcome.entry_fills) == 1
+    fill = outcome.entry_fills[0]
+    assert fill.fill_kind == FillKind.PARTIAL
+    assert fill.qty == pytest.approx(1_000.0, rel=1e-9)
+    assert fill.unfilled_qty == pytest.approx(1_000.0, rel=1e-9)
+    assert fill.cumulative_filled_qty == pytest.approx(1_000.0, rel=1e-9)
+
+    pos = portfolio.positions["AAA"]
+    assert pos.original_qty == 2_000
+    assert pos.qty == pytest.approx(1_000.0, rel=1e-9)
+    assert pos.participation_clipped is True
+    assert pos.total_unfilled_qty == pytest.approx(1_000.0, rel=1e-9)
+    assert pos.partial_fill_count == 1
+
+
+def test_requeue_next_bar_two_partials_sum_to_original() -> None:
+    """Two-bar entry fill + clean exit produces a TradeRecord with
+    ``partial_fill_count=2`` and ``participation_clipped=True``.
+    """
+    sim, order_book, portfolio = _make_simulator()
+    order_book.submit(
+        _entry_order(2_000, policy=UnfilledPolicy.REQUEUE_NEXT_BAR),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+    )
+
+    # Bar 1: low volume → 50% partial fill, remainder requeued.
+    bar1 = sim.process_bar(_bar("2024-01-02", price=100.0, volume=10_000))
+    assert bar1.entry_fills[0].fill_kind == FillKind.PARTIAL
+    assert "entry-1" in {po.request.client_order_id for po in order_book.all_pending()}, (
+        "remainder should remain pending after a REQUEUE_NEXT_BAR partial"
+    )
+
+    # Bar 2: high volume → remainder fills cleanly.
+    bar2 = sim.process_bar(_bar("2024-01-03", price=100.0, volume=10_000_000))
+    assert len(bar2.entry_fills) == 1
+    final_entry = bar2.entry_fills[0]
+    assert final_entry.fill_kind == FillKind.FULL
+    assert final_entry.cumulative_filled_qty == pytest.approx(2_000.0, rel=1e-9)
+    pos = portfolio.positions["AAA"]
+    assert pos.qty == pytest.approx(2_000.0, rel=1e-9)
+    assert pos.partial_fill_count == 2
+
+    # Bar 3: clean full exit on a high-volume bar.
+    order_book.submit(
+        _exit_order(2_000),
+        submitted_at="2024-01-03",
+        submitted_equity=10_000_000.0,
+    )
+    bar3 = sim.process_bar(_bar("2024-01-04", price=105.0, volume=10_000_000))
+
+    assert len(bar3.closed_trades) == 1
+    record = bar3.closed_trades[0]
+    assert record.partial_fill_count == 2
+    assert record.participation_clipped is True
+    assert record.total_unfilled_qty == pytest.approx(1_000.0, rel=1e-9)
+    assert record.shares == pytest.approx(2_000.0, rel=1e-9)
+
+
+def test_drop_policy_emits_partial_fill_but_does_not_requeue() -> None:
+    """Under ``DROP`` the partial Fill is still emitted (no silent-drop) but
+    the remainder is removed from the book — no next-bar continuation."""
+    sim, order_book, _ = _make_simulator()
+    order_book.submit(
+        _entry_order(2_000, policy=UnfilledPolicy.DROP),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+    )
+
+    outcome = sim.process_bar(_bar("2024-01-02", price=100.0, volume=10_000))
+    assert outcome.entry_fills[0].fill_kind == FillKind.PARTIAL
+    assert outcome.entry_fills[0].unfilled_qty == pytest.approx(1_000.0, rel=1e-9)
+    # Remainder dropped, not requeued.
+    assert order_book.all_pending() == []
+
+
+def test_requeued_order_passes_bar_safety() -> None:
+    """The requeue path must advance ``submitted_at`` to the fill bar so the
+    bar-safety guard (which compares ``submitted_at < fill_bar.timestamp``)
+    keeps holding on the next-bar continuation."""
+    sim, order_book, _ = _make_simulator()
+    order_book.submit(
+        _entry_order(2_000, policy=UnfilledPolicy.REQUEUE_NEXT_BAR),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+    )
+
+    sim.process_bar(_bar("2024-01-02", price=100.0, volume=10_000))
+
+    pending = order_book.all_pending()
+    assert len(pending) == 1
+    # ``OrderBook.requeue`` rewrites ``submitted_at`` to the fill bar.
+    assert pending[0].submitted_at == "2024-01-02"
+    assert pending[0].cumulative_filled_qty == pytest.approx(1_000.0, rel=1e-9)
+
+    # The next-bar continuation must not raise LookAheadError despite the
+    # original ``submitted_at`` being two bars in the past.
+    outcome = sim.process_bar(_bar("2024-01-03", price=100.0, volume=10_000_000))
+    assert outcome.entry_fills[0].fill_kind == FillKind.FULL
+
+
+def test_partial_exit_records_weighted_avg_price() -> None:
+    """Exit clipped across two bars → TradeRecord only on the closing bar
+    and ``exit_price`` is the qty-weighted average of the two fills."""
+    sim, order_book, portfolio = _make_simulator()
+
+    # Open a clean position first via a high-volume entry bar.
+    order_book.submit(
+        _entry_order(2_000),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+    )
+    sim.process_bar(_bar("2024-01-02", price=100.0, volume=10_000_000))
+    pos = portfolio.positions["AAA"]
+    assert pos.qty == pytest.approx(2_000.0, rel=1e-9)
+    assert pos.participation_clipped is False
+
+    # Submit the closing order. The next bar's volume forces a 50% partial
+    # exit; the bar after fills the rest.
+    order_book.submit(
+        _exit_order(2_000, policy=UnfilledPolicy.REQUEUE_NEXT_BAR),
+        submitted_at="2024-01-02",
+        submitted_equity=10_000_000.0,
+    )
+
+    bar1 = sim.process_bar(_bar("2024-01-03", price=110.0, volume=10_000))
+    assert len(bar1.closed_trades) == 0, "no TradeRecord until the position is fully closed"
+    assert len(bar1.exit_fills) == 1
+    assert bar1.exit_fills[0].fill_kind == FillKind.PARTIAL
+    assert bar1.exit_fills[0].qty == pytest.approx(1_000.0, rel=1e-9)
+
+    # Position partially closed but still open.
+    assert "AAA" in portfolio.positions
+    assert portfolio.positions["AAA"].qty == pytest.approx(1_000.0, rel=1e-9)
+
+    bar2 = sim.process_bar(_bar("2024-01-04", price=120.0, volume=10_000_000))
+    assert len(bar2.closed_trades) == 1
+    record = bar2.closed_trades[0]
+    # Weighted-avg exit: (1000 * 110 + 1000 * 120) / 2000 = 115
+    assert record.exit_price == pytest.approx(115.0, rel=1e-9)
+    assert record.shares == pytest.approx(2_000.0, rel=1e-9)
+    assert record.participation_clipped is True
+    # ``partial_fill_count`` only tracks entry-side pieces; this entry was a
+    # single full fill.
+    assert record.partial_fill_count == 1
+    # Position fully closed.
+    assert "AAA" not in portfolio.positions

--- a/backend/agents/investment_team/tests/test_partial_fills.py
+++ b/backend/agents/investment_team/tests/test_partial_fills.py
@@ -495,3 +495,113 @@ def test_over_ask_exit_reports_truncated_remainder_as_unfilled() -> None:
     assert len(bar2.closed_trades) == 1
     assert bar2.closed_trades[0].shares == pytest.approx(500.0, rel=1e-9)
     assert "AAA" not in portfolio.positions
+
+
+def test_continuation_rejection_preserves_parent_eligible_for_brackets() -> None:
+    """When a continuation slice is rejected (risk gate or capital), the
+    parent's id must stay registered in ``OrderBook``'s eligible-parent
+    set so a later ``submit_attached`` against that parent still works.
+
+    Regression for a Codex P1 review note on PR #417: removing the parent
+    with the default ``was_filled=False`` evicted it from the eligible set
+    even though the first slice had already opened exposure, breaking
+    bracket-attachment flows for requeued entries that terminate on
+    continuation rejection.
+    """
+    portfolio = Portfolio(initial_capital=1_000_000.0)
+    order_book = OrderBook()
+    sim = FillSimulator(
+        portfolio=portfolio,
+        order_book=order_book,
+        risk_filter=RiskFilter(
+            RiskLimits(
+                max_position_pct=100,
+                max_symbol_concentration_pct=15,
+                max_gross_leverage=10.0,
+            )
+        ),
+        config=FillSimulatorConfig(slippage_bps=0.0, transaction_cost_bps=0.0),
+        bar_safety=BarSafetyAssertion(),
+        execution_model=RealisticExecutionModel(participation_cap=0.10),
+    )
+
+    # First slice fits the 15% cap, the post-extend full size (20%) doesn't.
+    parent = order_book.submit(
+        OrderRequest(
+            client_order_id="parent-1",
+            symbol="AAA",
+            side=OrderSide.LONG,
+            qty=2_000,
+            order_type=OrderType.MARKET,
+            tif=TimeInForce.DAY,
+            unfilled_policy=UnfilledPolicy.REQUEUE_NEXT_BAR,
+        ),
+        submitted_at="2024-01-01",
+        submitted_equity=1_000_000.0,
+        expect_brackets=True,
+    )
+    parent_id = parent.order_id
+
+    sim.process_bar(_bar("2024-01-02", price=100.0, volume=10_000))
+    sim.process_bar(_bar("2024-01-03", price=100.0, volume=10_000_000))
+    # Continuation rejected; first-slice position remains.
+    assert portfolio.positions["AAA"].qty == pytest.approx(1_000.0, rel=1e-9)
+    assert order_book.all_pending() == []
+
+    # The parent should still be eligible for bracket attachment — this
+    # call must not raise.
+    order_book.submit_attached(
+        OrderRequest(
+            client_order_id="bracket-1",
+            symbol="AAA",
+            side=OrderSide.SHORT,
+            qty=1_000,
+            order_type=OrderType.STOP,
+            stop_price=95.0,
+            tif=TimeInForce.GTC,
+        ),
+        submitted_at="2024-01-03",
+        submitted_equity=1_000_000.0,
+        parent_order_id=parent_id,
+        oco_group_id="bracket-group-1",
+    )
+
+
+def test_capital_is_conserved_across_fragmented_round_trip() -> None:
+    """A multi-slice entry + multi-slice exit at the same price must
+    return capital exactly to its starting value (zero costs, zero
+    slippage). Per-slice rounding inside ``extend`` / ``partial_close``
+    used to introduce cumulative cash drift on fragmented fills.
+
+    Regression for two Codex P2 review notes on PR #417.
+    """
+    sim, order_book, portfolio = _make_simulator()
+    initial = portfolio.capital
+
+    # Entry: REQUEUE_NEXT_BAR with cap forcing ≥ 2 partials. Sub-$10 price
+    # so fill_price is rounded to 4 decimals (multiplier with integer qty
+    # produces the same notional whether or not we round per-slice, but
+    # we still want to assert no drift creeps in).
+    order_book.submit(
+        _entry_order(2_000, policy=UnfilledPolicy.REQUEUE_NEXT_BAR),
+        submitted_at="2024-01-01",
+        submitted_equity=initial,
+    )
+    # Bar 1: cap forces ~50% fill, remainder requeued.
+    sim.process_bar(_bar("2024-01-02", price=5.1234, volume=200_000))
+    # Bar 2: high volume, remainder fills.
+    sim.process_bar(_bar("2024-01-03", price=5.1234, volume=200_000_000))
+    assert portfolio.positions["AAA"].qty == pytest.approx(2_000.0, rel=1e-9)
+
+    # Exit at the *same* price via REQUEUE_NEXT_BAR — same fragmentation.
+    order_book.submit(
+        _exit_order(2_000, policy=UnfilledPolicy.REQUEUE_NEXT_BAR),
+        submitted_at="2024-01-03",
+        submitted_equity=initial,
+    )
+    sim.process_bar(_bar("2024-01-04", price=5.1234, volume=200_000))
+    sim.process_bar(_bar("2024-01-05", price=5.1234, volume=200_000_000))
+    assert "AAA" not in portfolio.positions
+
+    # Zero-cost flat round-trip: capital must equal initial.
+    assert portfolio.capital == pytest.approx(initial, rel=1e-9)

--- a/backend/agents/investment_team/tests/test_partial_fills.py
+++ b/backend/agents/investment_team/tests/test_partial_fills.py
@@ -270,3 +270,48 @@ def test_partial_exit_records_weighted_avg_price() -> None:
     assert record.partial_fill_count == 1
     # Position fully closed.
     assert "AAA" not in portfolio.positions
+
+
+def test_exit_does_not_overfill_when_entry_continuation_grows_position() -> None:
+    """Same-bar entry continuation + exit must not over-close.
+
+    Regression for a Codex review note on PR #417: when a partial entry
+    is requeued and its remainder fills on the same bar an exit fires
+    against, ``_fill_exit`` must size the fill from
+    ``min(po.remaining_qty, pos.qty)`` — not from ``pos.qty`` alone —
+    or the exit will close newly-added shares the strategy never asked
+    to unwind.
+    """
+    sim, order_book, portfolio = _make_simulator()
+
+    # Bar 1 (low volume): partial entry → pos.qty=1000, remainder=1000 requeued.
+    order_book.submit(
+        _entry_order(2_000, policy=UnfilledPolicy.REQUEUE_NEXT_BAR),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+    )
+    sim.process_bar(_bar("2024-01-02", price=100.0, volume=10_000))
+    assert portfolio.positions["AAA"].qty == pytest.approx(1_000.0, rel=1e-9)
+
+    # The strategy sees pos.qty=1000 and submits an exit for that qty —
+    # *before* the entry remainder fills next bar.
+    order_book.submit(
+        _exit_order(1_000),
+        submitted_at="2024-01-02",
+        submitted_equity=10_000_000.0,
+    )
+
+    # Bar 2 (high volume): entry continuation grows the position to 2000,
+    # then the exit fires. The exit must respect the strategy's req.qty
+    # (1000), not balloon to the new pos.qty (2000).
+    bar2 = sim.process_bar(_bar("2024-01-03", price=100.0, volume=10_000_000))
+
+    # Exit fill should be exactly the strategy's requested 1000.
+    assert len(bar2.exit_fills) == 1
+    assert bar2.exit_fills[0].qty == pytest.approx(1_000.0, rel=1e-9)
+    # Position remains open with the entry continuation's added shares —
+    # not silently emptied to zero.
+    assert "AAA" in portfolio.positions
+    assert portfolio.positions["AAA"].qty == pytest.approx(1_000.0, rel=1e-9)
+    # No TradeRecord yet — only original_qty exits trigger one.
+    assert len(bar2.closed_trades) == 0

--- a/backend/agents/investment_team/tests/test_partial_fills.py
+++ b/backend/agents/investment_team/tests/test_partial_fills.py
@@ -23,7 +23,10 @@ import pytest
 
 from investment_team.execution.bar_safety import BarSafetyAssertion
 from investment_team.execution.risk_filter import RiskFilter, RiskLimits
-from investment_team.trading_service.engine.execution_model import RealisticExecutionModel
+from investment_team.trading_service.engine.execution_model import (
+    FillTerms,
+    RealisticExecutionModel,
+)
 from investment_team.trading_service.engine.fill_simulator import (
     FillSimulator,
     FillSimulatorConfig,
@@ -720,3 +723,144 @@ def test_multi_bar_entry_records_weighted_entry_bid_price() -> None:
     bar3 = sim.process_bar(_bar("2024-01-04", price=120.0, volume=10_000_000))
     assert len(bar3.closed_trades) == 1
     assert bar3.closed_trades[0].entry_bid_price == pytest.approx(105.0, rel=1e-9)
+
+
+class _ScriptedFractionModel:
+    """Test stub: returns a per-bar ``qty_fraction`` keyed by bar timestamp.
+
+    Lets us drive ``_fill_entry`` / ``_continue_entry`` into the
+    ``filled_qty <= 0`` zero-fraction branch deterministically — the
+    realistic model can't actually return ``qty_fraction = 0`` from any
+    legitimate input, so the only way to test that branch's policy
+    handling is with a controlled stub.
+    """
+
+    name = "scripted-fraction"
+
+    def __init__(self, fractions: dict[str, float]) -> None:
+        self._fractions = fractions
+
+    def compute_fill_terms(self, req, bar, next_bar):
+        ref = bar.open
+        return FillTerms(
+            reference_price=ref,
+            qty_fraction=self._fractions.get(bar.timestamp, 1.0),
+            extra_slip_bps=0.0,
+        )
+
+
+def test_zero_fraction_continuation_honors_requeue_policy() -> None:
+    """A continuation slice that returns ``qty_fraction = 0`` (e.g.
+    transient no-liquidity bar under a custom execution model) must
+    honor ``UnfilledPolicy.REQUEUE_NEXT_BAR`` and re-queue the
+    remainder for the next bar instead of permanently dropping it.
+
+    Regression for a Codex P2 review note on PR #417: the previous
+    branch unconditionally called ``order_book.remove`` and ignored
+    the policy.
+    """
+    portfolio = Portfolio(initial_capital=10_000_000.0)
+    order_book = OrderBook()
+    sim = FillSimulator(
+        portfolio=portfolio,
+        order_book=order_book,
+        risk_filter=RiskFilter(RiskLimits(max_position_pct=100, max_gross_leverage=10.0)),
+        config=FillSimulatorConfig(slippage_bps=0.0, transaction_cost_bps=0.0),
+        bar_safety=BarSafetyAssertion(),
+        execution_model=_ScriptedFractionModel(
+            {
+                "2024-01-02": 0.5,  # bar 1: 50% partial
+                "2024-01-03": 0.0,  # bar 2: no liquidity
+                "2024-01-04": 1.0,  # bar 3: recovers, fills the rest
+            }
+        ),
+    )
+
+    order_book.submit(
+        _entry_order(2_000, policy=UnfilledPolicy.REQUEUE_NEXT_BAR),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+    )
+    # Bar 1: 50% partial → pos.qty=1000, requeue 1000.
+    sim.process_bar(_bar("2024-01-02", price=100.0))
+    assert portfolio.positions["AAA"].qty == pytest.approx(1_000.0, rel=1e-9)
+
+    # Bar 2: zero-fraction → emit REJECTED Fill, but order must still
+    # be in the book (REQUEUE policy honored).
+    bar2 = sim.process_bar(_bar("2024-01-03", price=100.0))
+    assert len(bar2.entry_fills) == 1
+    assert bar2.entry_fills[0].fill_kind == FillKind.REJECTED
+    assert order_book.all_pending(), "REQUEUE_NEXT_BAR must keep the remainder pending"
+
+    # Bar 3: recovers → continuation fills the remaining 1000.
+    bar3 = sim.process_bar(_bar("2024-01-04", price=100.0))
+    assert len(bar3.entry_fills) == 1
+    assert bar3.entry_fills[0].fill_kind == FillKind.FULL
+    assert portfolio.positions["AAA"].qty == pytest.approx(2_000.0, rel=1e-9)
+
+
+def test_zero_fraction_continuation_drop_keeps_parent_eligible() -> None:
+    """When a zero-fraction continuation hits a non-REQUEUE policy
+    (DROP) and the order is removed, the parent must stay registered
+    in ``OrderBook``'s eligible-parent set — its first slice already
+    opened a position, so subsequent ``submit_attached`` calls must
+    still work.
+
+    Regression for a Codex P2 review note on PR #417: the previous
+    branch called ``order_book.remove`` with the default
+    ``was_filled=False`` and evicted the parent.
+    """
+    portfolio = Portfolio(initial_capital=10_000_000.0)
+    order_book = OrderBook()
+    sim = FillSimulator(
+        portfolio=portfolio,
+        order_book=order_book,
+        risk_filter=RiskFilter(RiskLimits(max_position_pct=100, max_gross_leverage=10.0)),
+        config=FillSimulatorConfig(slippage_bps=0.0, transaction_cost_bps=0.0),
+        bar_safety=BarSafetyAssertion(),
+        execution_model=_ScriptedFractionModel(
+            {
+                "2024-01-02": 0.5,  # bar 1: 50% partial
+                "2024-01-03": 0.0,  # bar 2: zero-fraction continuation
+            }
+        ),
+    )
+
+    parent = order_book.submit(
+        OrderRequest(
+            client_order_id="parent-1",
+            symbol="AAA",
+            side=OrderSide.LONG,
+            qty=2_000,
+            order_type=OrderType.MARKET,
+            tif=TimeInForce.DAY,
+            unfilled_policy=UnfilledPolicy.DROP,
+        ),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+        expect_brackets=True,
+    )
+
+    sim.process_bar(_bar("2024-01-02", price=100.0))
+    sim.process_bar(_bar("2024-01-03", price=100.0))
+
+    # Continuation dropped under DROP policy; first-slice position remains.
+    assert portfolio.positions["AAA"].qty == pytest.approx(1_000.0, rel=1e-9)
+    assert order_book.all_pending() == []
+
+    # Parent must still be eligible for bracket attachment.
+    order_book.submit_attached(
+        OrderRequest(
+            client_order_id="bracket-stop",
+            symbol="AAA",
+            side=OrderSide.SHORT,
+            qty=1_000,
+            order_type=OrderType.STOP,
+            stop_price=95.0,
+            tif=TimeInForce.GTC,
+        ),
+        submitted_at="2024-01-03",
+        submitted_equity=10_000_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="bracket-group-1",
+    )

--- a/backend/agents/investment_team/tests/test_partial_fills.py
+++ b/backend/agents/investment_team/tests/test_partial_fills.py
@@ -131,7 +131,10 @@ def test_realistic_low_adv_emits_partial_entry_fill() -> None:
     assert fill.cumulative_filled_qty == pytest.approx(1_000.0, rel=1e-9)
 
     pos = portfolio.positions["AAA"]
-    assert pos.original_qty == 2_000
+    # ``original_qty`` tracks cumulative *entry-filled* qty, not the
+    # strategy's request — so a DROP / REJECT path leaves it at what's
+    # actually held, which is what subsequent exits will close against.
+    assert pos.original_qty == pytest.approx(1_000.0, rel=1e-9)
     assert pos.qty == pytest.approx(1_000.0, rel=1e-9)
     assert pos.participation_clipped is True
     assert pos.total_unfilled_qty == pytest.approx(1_000.0, rel=1e-9)
@@ -315,3 +318,131 @@ def test_exit_does_not_overfill_when_entry_continuation_grows_position() -> None
     assert portfolio.positions["AAA"].qty == pytest.approx(1_000.0, rel=1e-9)
     # No TradeRecord yet — only original_qty exits trigger one.
     assert len(bar2.closed_trades) == 0
+
+
+def test_dropped_entry_remainder_does_not_strand_position() -> None:
+    """A partial entry with ``DROP`` followed by an exit for the held qty
+    must close the position cleanly.
+
+    Regression for a Codex review note on PR #417: ``Position.is_closed``
+    compares cumulative exits against ``original_qty``. If ``original_qty``
+    were pinned to the strategy's *request* (2000) instead of the
+    actually-filled qty (1000), exiting the held shares would leave the
+    position stranded with ``qty=0`` and no ``TradeRecord``.
+    """
+    sim, order_book, portfolio = _make_simulator()
+
+    # Bar 1: partial entry under DROP → pos.qty=1000, remainder=1000 dropped.
+    order_book.submit(
+        _entry_order(2_000, policy=UnfilledPolicy.DROP),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+    )
+    sim.process_bar(_bar("2024-01-02", price=100.0, volume=10_000))
+    assert order_book.all_pending() == [], "DROP must remove the remainder from the book"
+    pos = portfolio.positions["AAA"]
+    assert pos.qty == pytest.approx(1_000.0, rel=1e-9)
+    assert pos.original_qty == pytest.approx(1_000.0, rel=1e-9), (
+        "original_qty must reflect actually-held qty, not the abandoned request"
+    )
+
+    # Bar 2: exit the held qty (1000). Position must close cleanly.
+    order_book.submit(
+        _exit_order(1_000),
+        submitted_at="2024-01-02",
+        submitted_equity=10_000_000.0,
+    )
+    bar2 = sim.process_bar(_bar("2024-01-03", price=110.0, volume=10_000_000))
+    assert len(bar2.closed_trades) == 1
+    assert bar2.closed_trades[0].shares == pytest.approx(1_000.0, rel=1e-9)
+    assert "AAA" not in portfolio.positions, "position must be popped on full close"
+
+
+def test_partial_unwind_exit_reports_full_fill_kind() -> None:
+    """Strategy requests qty < pos.qty (partial unwind) and the exit fills
+    fully against high volume — ``Fill.fill_kind`` must be ``FULL`` (the
+    exit *order* completed) even though the position is still open.
+
+    Regression for a Codex P2 review note: ``fill_kind`` describes the
+    exit order's completeness, not the position's closure state.
+    """
+    sim, order_book, portfolio = _make_simulator()
+
+    # Open a 2000-qty position cleanly.
+    order_book.submit(
+        _entry_order(2_000),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+    )
+    sim.process_bar(_bar("2024-01-02", price=100.0, volume=10_000_000))
+    assert portfolio.positions["AAA"].qty == pytest.approx(2_000.0, rel=1e-9)
+
+    # Partial unwind: exit only 500 of the 2000.
+    order_book.submit(
+        _exit_order(500),
+        submitted_at="2024-01-02",
+        submitted_equity=10_000_000.0,
+    )
+    bar2 = sim.process_bar(_bar("2024-01-03", price=110.0, volume=10_000_000))
+
+    assert len(bar2.exit_fills) == 1
+    fill = bar2.exit_fills[0]
+    # Order filled to its requested size — must be FULL, not PARTIAL.
+    assert fill.fill_kind == FillKind.FULL
+    assert fill.unfilled_qty == pytest.approx(0.0, abs=1e-9)
+    assert fill.qty == pytest.approx(500.0, rel=1e-9)
+    # Position still open with residual exposure — no TradeRecord yet.
+    assert len(bar2.closed_trades) == 0
+    assert portfolio.positions["AAA"].qty == pytest.approx(1_500.0, rel=1e-9)
+
+
+def test_risk_gate_re_applied_on_entry_continuation() -> None:
+    """A continuation slice must re-check the risk gate. If the limits no
+    longer admit the post-extend exposure, the continuation is rejected
+    even though the original entry's first slice fit at submit time.
+
+    Regression for a Codex P1 review note: ``can_enter`` was being
+    skipped on continuations, letting later slices breach
+    leverage / concentration limits set after the initial fill.
+    """
+    portfolio = Portfolio(initial_capital=1_000_000.0)
+    order_book = OrderBook()
+    # Tight concentration cap: a fully-filled 2000-share order at ~$100
+    # = $200k notional = 20% of equity. ``max_symbol_concentration_pct``
+    # at 15% admits the first 1000-share slice (10%) but rejects the
+    # post-extend total (20%).
+    sim = FillSimulator(
+        portfolio=portfolio,
+        order_book=order_book,
+        risk_filter=RiskFilter(
+            RiskLimits(
+                max_position_pct=100,
+                max_symbol_concentration_pct=15,
+                max_gross_leverage=10.0,
+            )
+        ),
+        config=FillSimulatorConfig(slippage_bps=0.0, transaction_cost_bps=0.0),
+        bar_safety=BarSafetyAssertion(),
+        execution_model=RealisticExecutionModel(participation_cap=0.10),
+    )
+
+    # First slice (1000 shares × $100 ≈ 10% concentration) fits. Remainder
+    # would push to 20% concentration, breaching max_position_pct=15.
+    order_book.submit(
+        _entry_order(2_000, policy=UnfilledPolicy.REQUEUE_NEXT_BAR),
+        submitted_at="2024-01-01",
+        submitted_equity=1_000_000.0,
+    )
+    bar1 = sim.process_bar(_bar("2024-01-02", price=100.0, volume=10_000))
+    assert len(bar1.entry_fills) == 1
+    assert bar1.entry_fills[0].fill_kind == FillKind.PARTIAL
+    assert portfolio.positions["AAA"].qty == pytest.approx(1_000.0, rel=1e-9)
+
+    # Bar 2: high volume would otherwise let the continuation fully fill,
+    # but the risk gate rejects it.
+    bar2 = sim.process_bar(_bar("2024-01-03", price=100.0, volume=10_000_000))
+    assert bar2.entry_fills == [], "continuation must be rejected by risk gate"
+    # Position keeps its first-slice qty; the rejected continuation is
+    # removed from the book without growing exposure.
+    assert portfolio.positions["AAA"].qty == pytest.approx(1_000.0, rel=1e-9)
+    assert order_book.all_pending() == []

--- a/backend/agents/investment_team/tests/test_partial_fills.py
+++ b/backend/agents/investment_team/tests/test_partial_fills.py
@@ -446,3 +446,52 @@ def test_risk_gate_re_applied_on_entry_continuation() -> None:
     # removed from the book without growing exposure.
     assert portfolio.positions["AAA"].qty == pytest.approx(1_000.0, rel=1e-9)
     assert order_book.all_pending() == []
+
+
+def test_over_ask_exit_reports_truncated_remainder_as_unfilled() -> None:
+    """An exit order requesting more shares than the position holds must
+    report the not-fillable portion as ``unfilled_qty`` — silently
+    truncating to the live position size and reporting ``unfilled_qty=0``
+    would mislabel the order as fully complete.
+
+    Regression for a Codex P2 review note on PR #417.
+    """
+    sim, order_book, portfolio = _make_simulator()
+
+    # Open a 500-qty position via a DROP-partial entry (req=2000, fills 500,
+    # remainder dropped). Position now has qty=500, original_qty=500.
+    order_book.submit(
+        _entry_order(2_000, policy=UnfilledPolicy.DROP),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+    )
+    # raw_part = (2000 * 100) / (5000 * 100) = 0.4 → qty_fraction = 0.25
+    # → filled_qty = 2000 * 0.25 = 500.
+    sim.process_bar(_bar("2024-01-02", price=100.0, volume=5_000))
+    assert portfolio.positions["AAA"].qty == pytest.approx(500.0, rel=1e-9)
+    assert portfolio.positions["AAA"].original_qty == pytest.approx(500.0, rel=1e-9)
+
+    # Strategy mistakenly asks to exit 1000 (more than held).
+    order_book.submit(
+        _exit_order(1_000),
+        submitted_at="2024-01-02",
+        submitted_equity=10_000_000.0,
+    )
+    bar2 = sim.process_bar(_bar("2024-01-03", price=110.0, volume=10_000_000))
+
+    # The actual close fills 500 (everything that exists), but the order
+    # asked for 1000 → ``unfilled_qty=500`` reflects what the strategy still
+    # wanted that could never execute.
+    assert len(bar2.exit_fills) == 1
+    fill = bar2.exit_fills[0]
+    assert fill.qty == pytest.approx(500.0, rel=1e-9)
+    assert fill.unfilled_qty == pytest.approx(500.0, rel=1e-9)
+    assert fill.fill_kind == FillKind.PARTIAL
+    # Per-order monotonic cumulative — *this exit order's* fills, not the
+    # position-wide cumulative_exit_qty.
+    assert fill.cumulative_filled_qty == pytest.approx(500.0, rel=1e-9)
+    # Position is fully closed (we exited everything that was held); the
+    # TradeRecord captures the actual round-trip.
+    assert len(bar2.closed_trades) == 1
+    assert bar2.closed_trades[0].shares == pytest.approx(500.0, rel=1e-9)
+    assert "AAA" not in portfolio.positions

--- a/backend/agents/investment_team/tests/test_subdaily_backtest.py
+++ b/backend/agents/investment_team/tests/test_subdaily_backtest.py
@@ -90,7 +90,7 @@ def _bar(ts: str, close: float, symbol: str = "BTC", tf: str = "15m") -> BarEven
             high=close + 0.1,
             low=close - 0.2,
             close=close,
-            volume=1.0,
+            volume=1_000_000.0,
         )
     )
 
@@ -217,7 +217,7 @@ def test_legacy_market_data_path_still_works() -> None:
                 high=101.0,
                 low=99.0,
                 close=100.5,
-                volume=1.0,
+                volume=1_000_000.0,
             )
         ]
     }

--- a/backend/agents/investment_team/tests/test_trading_service.py
+++ b/backend/agents/investment_team/tests/test_trading_service.py
@@ -305,7 +305,10 @@ def test_default_unfilled_policy_gated_by_flag(
     if flag_on:
         monkeypatch.setenv("TRADING_PARTIAL_FILL_DEFAULTS_ENABLED", "true")
     else:
-        monkeypatch.delenv("TRADING_PARTIAL_FILL_DEFAULTS_ENABLED", raising=False)
+        # Step 4 (#386) flipped the default to ``true`` once the engine
+        # started consuming the policy. Pin to ``false`` explicitly so the
+        # flag-off semantics stay testable without depending on the default.
+        monkeypatch.setenv("TRADING_PARTIAL_FILL_DEFAULTS_ENABLED", "false")
 
     captured = _capture_submitted_orders(monkeypatch)
 
@@ -356,9 +359,9 @@ def test_run_backtest_passes_requeue_default_to_service(monkeypatch) -> None:
         assert req.unfilled_policy == UnfilledPolicy.REQUEUE_NEXT_BAR
 
 
-def test_partial_fill_defaults_flag_default_is_off(monkeypatch) -> None:
-    """With the env var unset, the helper reports ``False`` (opt-in semantics)."""
+def test_partial_fill_defaults_flag_default_is_on(monkeypatch) -> None:
+    """With the env var unset, the helper reports ``True`` (Step 4 default)."""
     monkeypatch.delenv("TRADING_PARTIAL_FILL_DEFAULTS_ENABLED", raising=False)
     from investment_team.trading_service.service import _partial_fill_defaults_enabled
 
-    assert _partial_fill_defaults_enabled() is False
+    assert _partial_fill_defaults_enabled() is True

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -367,7 +367,12 @@ class FillSimulator:
         )
         if not gate.allowed:
             logger.info("risk gate rejected entry continuation for %s: %s", req.symbol, gate.reason)
-            self.order_book.remove(po.order_id)
+            # ``was_filled=True`` — the parent already opened a position on
+            # the first slice (we wouldn't be in ``_continue_entry`` otherwise).
+            # Removing with the default ``False`` would evict the parent id
+            # from ``OrderBook``'s eligible-parent set and break any later
+            # ``submit_attached`` call against this parent.
+            self.order_book.remove(po.order_id, was_filled=True)
             return None
 
         # Capital check against the *additional* notional only — the existing
@@ -380,7 +385,10 @@ class FillSimulator:
                 additional_notional,
                 self.portfolio.capital,
             )
-            self.order_book.remove(po.order_id)
+            # Same reasoning as the risk-gate branch above — preserve the
+            # parent's eligible-parent registration since the first slice
+            # already filled.
+            self.order_book.remove(po.order_id, was_filled=True)
             return None
 
         pos = self.portfolio.extend(req.symbol, filled_qty, fill_price)

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -24,7 +24,7 @@ from typing import List, Optional
 from ...execution.bar_safety import BarSafetyAssertion
 from ...execution.risk_filter import RiskFilter
 from ...models import TradeRecord
-from ..strategy.contract import Bar, Fill, OrderSide
+from ..strategy.contract import Bar, Fill, FillKind, OrderSide, UnfilledPolicy
 from .execution_model import ExecutionModel, FillTerms, OptimisticExecutionModel
 from .order_book import OrderBook, PendingOrder
 from .portfolio import Portfolio, Position
@@ -122,41 +122,36 @@ class FillSimulator:
                 fill_bar_timestamp=bar.timestamp,
             )
 
-            has_position = bar.symbol in self.portfolio.positions
+            existing_pos = self.portfolio.positions.get(bar.symbol)
+            # Partial-entry continuation (#386): a requeued partial entry has
+            # ``cumulative_filled_qty > 0`` and an existing position whose
+            # ``entry_order_id`` matches this pending order. Without this
+            # branch the requeued order would hit the same-side-as-position
+            # guard below and get silently removed.
+            is_partial_entry_continuation = (
+                existing_pos is not None
+                and existing_pos.entry_order_id == po.order_id
+                and po.cumulative_filled_qty > 0
+            )
             is_entry = (
-                not has_position
+                not is_partial_entry_continuation
+                and existing_pos is None
                 and req.side in (OrderSide.LONG, OrderSide.SHORT)
-                and (
-                    # Treat an order as an entry when there's no open position and
-                    # the request direction would create one. Exit requests from
-                    # strategies are expressed as an opposite-side order on a
-                    # symbol where a position is already open.
-                    not has_position
-                )
             )
 
-            if is_entry:
-                pos = self._fill_entry(po, bar, terms)
-                if pos is None:
-                    continue
-                self.portfolio.open(pos)
-                fill = self.portfolio.make_entry_fill(pos)
-                entry_fills.append(fill)
-                # Entry filled — keep this id in the eligible-parent set so
-                # bracket / OCO children can later be activated against it via
-                # ``OrderBook.submit_attached`` (see #389). Only entries qualify
-                # as bracket parents; exit fills below intentionally use the
-                # default ``was_filled=False``.
-                self.order_book.remove(po.order_id, was_filled=True)
-            elif has_position:
-                # Exit path: order closes out the open position. We only
-                # support full-qty exits in PR 1 (matches legacy behavior at
-                # trade_simulator.py:560-565). Partial-fill caps from the
-                # execution model apply only to entries — exits always
-                # close the position fully.
-                pos = self.portfolio.positions[bar.symbol]
+            if is_partial_entry_continuation:
+                fill = self._continue_entry(po, bar, terms)
+                if fill is not None:
+                    entry_fills.append(fill)
+            elif is_entry:
+                fill = self._fill_entry(po, bar, terms)
+                if fill is not None:
+                    entry_fills.append(fill)
+            else:
+                # Has open position. Either an exit (opposite side) or a
+                # same-side add-on we currently don't support.
+                pos = existing_pos
                 if req.side == pos.side:
-                    # Ignoring same-side add-ons in PR 1 — log and leave.
                     logger.debug(
                         "ignoring same-side order %s for already-open %s position",
                         po.order_id,
@@ -164,31 +159,11 @@ class FillSimulator:
                     )
                     self.order_book.remove(po.order_id)
                     continue
-                trade = self._fill_exit(po, bar, terms)
-                if trade is None:
-                    continue
-                closed.append(trade)
-                exit_fills.append(
-                    Fill(
-                        order_id=po.order_id,
-                        client_order_id=req.client_order_id,
-                        symbol=bar.symbol,
-                        side=req.side,
-                        qty=pos.qty,
-                        price=trade.exit_price,
-                        timestamp=bar.timestamp,
-                        reason="exit",
-                    )
-                )
-                # Exit filled — close out the position. We pass the default
-                # ``was_filled=False`` here even though this *is* a fill,
-                # because ``was_filled=True`` is specifically for entries that
-                # may later carry bracket children. Exits don't open positions
-                # and so are never valid bracket parents — keeping their ids
-                # in ``_known_top_level_order_ids`` would let a later
-                # ``submit_attached`` accept the wrong order as a parent and
-                # mis-scope protective legs.
-                self.order_book.remove(po.order_id)
+                exit_fill, trade = self._fill_exit(po, bar, terms)
+                if exit_fill is not None:
+                    exit_fills.append(exit_fill)
+                if trade is not None:
+                    closed.append(trade)
 
         return FillOutcome(
             entry_fills=entry_fills,
@@ -226,20 +201,44 @@ class FillSimulator:
         po: PendingOrder,
         bar: Bar,
         terms: FillTerms,
-    ) -> Optional[Position]:
+    ) -> Optional[Fill]:
+        """First fill against an entry order. Opens the Position.
+
+        Returns the entry ``Fill`` (full or partial), or ``None`` when the
+        order was rejected (risk gate, insufficient capital, zero qty).
+        Side effect: drives ``portfolio.open`` and either ``order_book.remove``
+        or ``order_book.requeue`` based on the order's ``unfilled_policy``.
+        """
         req = po.request
         ref_price = terms.reference_price
-        # Apply the execution model's partial-fill cap (1.0 = full).
-        # Fractions below 1.0 mean the bar's dollar volume couldn't absorb
-        # the full request; the remainder is dropped, not re-quoted.
-        qty = req.qty * max(0.0, min(1.0, terms.qty_fraction))
-        if qty <= 0:
+        # ``po.remaining_qty`` is the same as ``req.qty`` on first fill
+        # (set by ``OrderBook.submit``). Reading from the pending order keeps
+        # the path uniform with ``_continue_entry``.
+        requested_qty = po.remaining_qty
+        qty_fraction = max(0.0, min(1.0, terms.qty_fraction))
+        filled_qty = requested_qty * qty_fraction
+        unfilled = requested_qty - filled_qty
+        dp = 4 if ref_price < 10 else 2
+
+        if filled_qty <= 0:
+            # No silent drop: emit a REJECTED Fill so the strategy sees the
+            # outcome, then remove the order.
             self.order_book.remove(po.order_id)
-            return None
-        # Vol-target sizing is not re-run here — strategies own sizing via
-        # ``ctx.submit_order(qty=...)``. The risk filter still caps via
-        # ``can_enter``, which mirrors the legacy engine's behavior.
-        notional = qty * ref_price
+            return Fill(
+                order_id=po.order_id,
+                client_order_id=req.client_order_id,
+                symbol=req.symbol,
+                side=req.side,
+                qty=0.0,
+                price=round(ref_price, dp),
+                timestamp=bar.timestamp,
+                reason="rejected_no_liquidity",
+                fill_kind=FillKind.REJECTED,
+                unfilled_qty=requested_qty,
+                cumulative_filled_qty=po.cumulative_filled_qty,
+            )
+
+        notional = filled_qty * ref_price
         equity = self.portfolio.mark_to_market()
         gate = self.risk.can_enter(req.symbol, notional, equity, self.portfolio.positions)
         if not gate.allowed:
@@ -257,54 +256,237 @@ class FillSimulator:
             return None
 
         slip_long_entry, _, slip_short_entry, _ = self._slippage_multipliers(terms.extra_slip_bps)
-        dp = 4 if ref_price < 10 else 2
         if req.side == OrderSide.LONG:
             fill_price = round(ref_price * slip_long_entry, dp)
         else:
             fill_price = round(ref_price * slip_short_entry, dp)
 
-        return Position(
+        is_partial = unfilled > 0
+        pos = Position(
             symbol=req.symbol,
             side=req.side,
-            qty=qty,
+            qty=filled_qty,
             entry_price=fill_price,
             entry_bid_price=round(ref_price, dp),
             entry_timestamp=bar.timestamp,
             entry_order_id=po.order_id,
             entry_client_order_id=req.client_order_id,
             entry_order_type=req.order_type.value,
+            original_qty=req.qty,
+            participation_clipped=is_partial,
+            total_unfilled_qty=unfilled,
+            # Counts the number of fill events on the entry side: initial
+            # fill = 1, every ``REQUEUE_NEXT_BAR`` continuation += 1. Exit
+            # slices don't bump this counter (see ``Position.reduce``).
+            partial_fill_count=1,
         )
+        self.portfolio.open(pos)
+        self._handle_entry_remainder(po, bar, unfilled)
+
+        return Fill(
+            order_id=po.order_id,
+            client_order_id=req.client_order_id,
+            symbol=pos.symbol,
+            side=pos.side,
+            qty=filled_qty,
+            price=fill_price,
+            timestamp=bar.timestamp,
+            reason="entry",
+            fill_kind=FillKind.PARTIAL if is_partial else FillKind.FULL,
+            unfilled_qty=unfilled,
+            cumulative_filled_qty=filled_qty,
+        )
+
+    def _continue_entry(
+        self,
+        po: PendingOrder,
+        bar: Bar,
+        terms: FillTerms,
+    ) -> Optional[Fill]:
+        """Apply a follow-on entry fill against an already-open position.
+
+        Used when ``REQUEUE_NEXT_BAR`` requeued an entry's partial-fill
+        remainder and the next bar's terms now allow more of it through.
+        """
+        req = po.request
+        ref_price = terms.reference_price
+        requested_qty = po.remaining_qty
+        qty_fraction = max(0.0, min(1.0, terms.qty_fraction))
+        filled_qty = requested_qty * qty_fraction
+        unfilled = requested_qty - filled_qty
+        dp = 4 if ref_price < 10 else 2
+
+        if filled_qty <= 0:
+            # Zero-fraction continuation — drop the order; further requeue
+            # would just defer the same outcome. Emit a REJECTED Fill on the
+            # remainder so the strategy sees the abandonment.
+            self.order_book.remove(po.order_id)
+            return Fill(
+                order_id=po.order_id,
+                client_order_id=req.client_order_id,
+                symbol=req.symbol,
+                side=req.side,
+                qty=0.0,
+                price=round(ref_price, dp),
+                timestamp=bar.timestamp,
+                reason="rejected_no_liquidity",
+                fill_kind=FillKind.REJECTED,
+                unfilled_qty=requested_qty,
+                cumulative_filled_qty=po.cumulative_filled_qty,
+            )
+
+        slip_long_entry, _, slip_short_entry, _ = self._slippage_multipliers(terms.extra_slip_bps)
+        if req.side == OrderSide.LONG:
+            fill_price = round(ref_price * slip_long_entry, dp)
+        else:
+            fill_price = round(ref_price * slip_short_entry, dp)
+
+        # Capital and risk checks against the *additional* notional only.
+        additional_notional = filled_qty * fill_price
+        if self.portfolio.capital < additional_notional:
+            logger.info(
+                "insufficient capital for %s entry continuation: need %.2f, have %.2f",
+                req.symbol,
+                additional_notional,
+                self.portfolio.capital,
+            )
+            self.order_book.remove(po.order_id)
+            return None
+
+        pos = self.portfolio.extend(req.symbol, filled_qty, fill_price)
+        is_partial = unfilled > 0
+        if is_partial:
+            pos.participation_clipped = True
+        pos.total_unfilled_qty += unfilled
+        pos.partial_fill_count += 1
+
+        self._handle_entry_remainder(po, bar, unfilled)
+
+        return Fill(
+            order_id=po.order_id,
+            client_order_id=req.client_order_id,
+            symbol=pos.symbol,
+            side=pos.side,
+            qty=filled_qty,
+            price=fill_price,
+            timestamp=bar.timestamp,
+            reason="entry",
+            fill_kind=FillKind.PARTIAL if is_partial else FillKind.FULL,
+            unfilled_qty=unfilled,
+            cumulative_filled_qty=pos.qty,
+        )
+
+    def _handle_entry_remainder(
+        self,
+        po: PendingOrder,
+        bar: Bar,
+        unfilled: float,
+    ) -> None:
+        """Decide whether to requeue or remove an entry order's remainder."""
+        policy = po.request.unfilled_policy or UnfilledPolicy.DROP
+        if unfilled > 0 and policy == UnfilledPolicy.REQUEUE_NEXT_BAR:
+            self.order_book.requeue(
+                po.order_id,
+                new_remaining_qty=unfilled,
+                new_submitted_at=bar.timestamp,
+                was_filled=True,
+            )
+            return
+        # TWAP_N is wired in #387; until then it falls through to DROP.
+        # Entries that fully fill or get DROPped both end here. ``was_filled=True``
+        # keeps the parent id eligible for bracket activation (#389).
+        self.order_book.remove(po.order_id, was_filled=True)
 
     def _fill_exit(
         self,
         po: PendingOrder,
         bar: Bar,
         terms: FillTerms,
-    ) -> Optional[TradeRecord]:
+    ) -> tuple[Optional[Fill], Optional[TradeRecord]]:
+        """Close (or partially close) the open position.
+
+        Returns ``(exit_fill, trade_record)``. ``trade_record`` is ``None``
+        until the position is fully closed (after partial exits, every
+        intermediate bar still emits an exit ``Fill`` but no record).
+        """
+        req = po.request
         pos = self.portfolio.positions[bar.symbol]
         ref_price = terms.reference_price
         dp = 4 if ref_price < 10 else 2
         _, slip_long_exit, _, slip_short_exit = self._slippage_multipliers(terms.extra_slip_bps)
-        # Apply slippage against the position's original direction.
         if pos.side == OrderSide.LONG:
             exit_price = round(ref_price * slip_long_exit, dp)
         else:
             exit_price = round(ref_price * slip_short_exit, dp)
 
-        # Realized P&L — matches trade_simulator._close_position math.
+        requested_exit_qty = po.remaining_qty if po.cumulative_filled_qty > 0 else pos.qty
+        qty_fraction = max(0.0, min(1.0, terms.qty_fraction))
+        filled_qty = requested_exit_qty * qty_fraction
+        unfilled = requested_exit_qty - filled_qty
+
+        if filled_qty <= 0:
+            # No liquidity for any exit slice on this bar. Decide whether to
+            # try again next bar or abandon the order; emit a REJECTED Fill
+            # either way so the strategy sees the outcome.
+            self._handle_exit_remainder(po, bar, unfilled)
+            rejected = Fill(
+                order_id=po.order_id,
+                client_order_id=req.client_order_id,
+                symbol=pos.symbol,
+                side=req.side,
+                qty=0.0,
+                price=round(ref_price, dp),
+                timestamp=bar.timestamp,
+                reason="rejected_no_liquidity",
+                fill_kind=FillKind.REJECTED,
+                unfilled_qty=requested_exit_qty,
+                cumulative_filled_qty=pos.cumulative_exit_qty,
+            )
+            return rejected, None
+
+        self.portfolio.partial_close(bar.symbol, filled_qty, exit_price)
+        if unfilled > 0:
+            pos.participation_clipped = True
+            pos.total_unfilled_qty += unfilled
+
+        is_closed = pos.is_closed
+        exit_fill = Fill(
+            order_id=po.order_id,
+            client_order_id=req.client_order_id,
+            symbol=pos.symbol,
+            side=req.side,
+            qty=filled_qty,
+            price=exit_price,
+            timestamp=bar.timestamp,
+            reason="exit",
+            fill_kind=FillKind.FULL if is_closed else FillKind.PARTIAL,
+            unfilled_qty=unfilled,
+            cumulative_filled_qty=pos.cumulative_exit_qty,
+        )
+
+        if not is_closed:
+            self._handle_exit_remainder(po, bar, unfilled)
+            return exit_fill, None
+
+        # Position fully closed — build the TradeRecord using the qty-weighted
+        # avg exit price across all partial exits so cumulative P&L is honest.
+        final_exit_price = pos.weighted_avg_exit_price
         cost_mult = self.config.transaction_cost_bps / 10_000.0
-        entry_notional = pos.entry_price * pos.qty
-        exit_notional = exit_price * pos.qty
+        entry_notional = pos.entry_price * pos.original_qty
+        exit_notional = final_exit_price * pos.original_qty
         if pos.side == OrderSide.LONG:
-            gross = (exit_price - pos.entry_price) * pos.qty
+            gross = (final_exit_price - pos.entry_price) * pos.original_qty
         else:
-            gross = (pos.entry_price - exit_price) * pos.qty
+            gross = (pos.entry_price - final_exit_price) * pos.original_qty
         tx_costs = (entry_notional + exit_notional) * cost_mult
         net = round(gross - tx_costs, 2)
 
         self._trade_num += 1
         self.portfolio.record_pnl(net)
-        self.portfolio.close(bar.symbol, exit_price)
+        # ``partial_close`` already credited cash for every slice; this terminal
+        # ``close`` just pops the position (pos.qty is ~0 by now).
+        self.portfolio.close(bar.symbol, final_exit_price)
+        self.order_book.remove(po.order_id)
 
         hold_days = _date_diff(pos.entry_timestamp, bar.timestamp)
         record = TradeRecord(
@@ -314,8 +496,8 @@ class FillSimulator:
             symbol=pos.symbol,
             side=pos.side.value,
             entry_price=pos.entry_price,
-            exit_price=exit_price,
-            shares=pos.qty,
+            exit_price=final_exit_price,
+            shares=pos.original_qty,
             position_value=round(entry_notional, 2),
             gross_pnl=round(gross, 2),
             net_pnl=net,
@@ -326,11 +508,37 @@ class FillSimulator:
             entry_bid_price=pos.entry_bid_price,
             entry_fill_price=pos.entry_price,
             exit_bid_price=round(ref_price, dp),
-            exit_fill_price=exit_price,
+            exit_fill_price=final_exit_price,
             entry_order_type=pos.entry_order_type,
             exit_order_type=po.request.order_type.value,
+            participation_clipped=pos.participation_clipped,
+            partial_fill_count=pos.partial_fill_count,
+            total_unfilled_qty=pos.total_unfilled_qty,
         )
-        return record
+        return exit_fill, record
+
+    def _handle_exit_remainder(
+        self,
+        po: PendingOrder,
+        bar: Bar,
+        unfilled: float,
+    ) -> None:
+        """Decide whether to requeue or remove an exit order's remainder.
+
+        Exit orders are never bracket parents (they don't open positions),
+        so ``was_filled=False`` is correct for both branches — see the
+        docstring at ``order_book.OrderBook.requeue``.
+        """
+        policy = po.request.unfilled_policy or UnfilledPolicy.DROP
+        if unfilled > 0 and policy == UnfilledPolicy.REQUEUE_NEXT_BAR:
+            self.order_book.requeue(
+                po.order_id,
+                new_remaining_qty=unfilled,
+                new_submitted_at=bar.timestamp,
+                was_filled=False,
+            )
+            return
+        self.order_book.remove(po.order_id)
 
 
 def _date_diff(t1: str, t2: str) -> int:

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -391,7 +391,7 @@ class FillSimulator:
             self.order_book.remove(po.order_id, was_filled=True)
             return None
 
-        pos = self.portfolio.extend(req.symbol, filled_qty, fill_price)
+        pos = self.portfolio.extend(req.symbol, filled_qty, fill_price, ref_price)
         # ``original_qty`` mirrors the cumulative entry-filled qty; bump it
         # so ``is_closed`` (compares ``cumulative_exit_qty`` to it) and
         # ``TradeRecord.shares`` reflect the actually-held position.
@@ -505,10 +505,20 @@ class FillSimulator:
             )
             return rejected, None
 
-        self.portfolio.partial_close(bar.symbol, filled_qty, exit_price)
-        if unfilled > 0:
+        self.portfolio.partial_close(bar.symbol, filled_qty, exit_price, ref_price)
+        # Only the participation-cap-clipped portion (``fillable_qty -
+        # filled_qty``) accumulates into ``pos.total_unfilled_qty`` — the
+        # over-ask portion (``po.remaining_qty - fillable_qty``) is a
+        # property of the strategy's request size relative to the live
+        # position, not a bar-level liquidity event, and the same ghost
+        # over-ask would re-appear on every requeued slice. Adding it
+        # bar-after-bar inflated ``TradeRecord.total_unfilled_qty`` past
+        # the original_qty (e.g. a 2000-share over-ask against a
+        # 1000-share position could report > 2000 unfilled).
+        cap_clipped = fillable_qty - filled_qty
+        if cap_clipped > 0:
             pos.participation_clipped = True
-            pos.total_unfilled_qty += unfilled
+            pos.total_unfilled_qty += cap_clipped
 
         is_closed = pos.is_closed
         # ``fill_kind`` reports completeness of *this exit order*, not
@@ -579,7 +589,11 @@ class FillSimulator:
             cumulative_pnl=self.portfolio.cumulative_pnl,
             entry_bid_price=pos.entry_bid_price,
             entry_fill_price=pos.entry_price,
-            exit_bid_price=round(ref_price, dp),
+            # Use the qty-weighted exit bid across all partial-exit slices
+            # so the reference price stays coherent with the weighted
+            # ``exit_price``. For single-bar full closes this collapses to
+            # the bar's own ref price (matches legacy behavior).
+            exit_bid_price=round(pos.weighted_avg_exit_bid_price, dp),
             exit_fill_price=final_exit_price,
             entry_order_type=pos.entry_order_type,
             exit_order_type=po.request.order_type.value,

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -222,8 +222,13 @@ class FillSimulator:
 
         if filled_qty <= 0:
             # No silent drop: emit a REJECTED Fill so the strategy sees the
-            # outcome, then remove the order.
-            self.order_book.remove(po.order_id)
+            # outcome. Route through ``_handle_entry_remainder`` so the
+            # order's ``unfilled_policy`` is honored — REQUEUE_NEXT_BAR
+            # gives the next bar a chance to recover instead of permanently
+            # dropping after a single no-liquidity bar. ``was_filled=False``
+            # because no position has opened yet (initial slice rejected),
+            # so the parent shouldn't remain registered as bracket-eligible.
+            self._handle_entry_remainder(po, bar, requested_qty, was_filled=False)
             return Fill(
                 order_id=po.order_id,
                 client_order_id=req.client_order_id,
@@ -324,10 +329,15 @@ class FillSimulator:
         dp = 4 if ref_price < 10 else 2
 
         if filled_qty <= 0:
-            # Zero-fraction continuation — drop the order; further requeue
-            # would just defer the same outcome. Emit a REJECTED Fill on the
-            # remainder so the strategy sees the abandonment.
-            self.order_book.remove(po.order_id)
+            # Zero-fraction continuation — route through
+            # ``_handle_entry_remainder`` so the order's
+            # ``unfilled_policy`` is honored (e.g. ``REQUEUE_NEXT_BAR``
+            # gives the next bar a chance to recover; previously this
+            # branch unconditionally dropped, ignoring the policy).
+            # ``was_filled=True`` because the parent's first slice
+            # already opened a position — preserves bracket-attachment
+            # eligibility on the eventual ``remove`` path.
+            self._handle_entry_remainder(po, bar, requested_qty, was_filled=True)
             return Fill(
                 order_id=po.order_id,
                 client_order_id=req.client_order_id,
@@ -427,21 +437,32 @@ class FillSimulator:
         po: PendingOrder,
         bar: Bar,
         unfilled: float,
+        *,
+        was_filled: bool = True,
     ) -> None:
-        """Decide whether to requeue or remove an entry order's remainder."""
+        """Decide whether to requeue or remove an entry order's remainder.
+
+        ``was_filled`` controls whether the parent stays registered in
+        ``OrderBook``'s eligible-parent set (only consequential when the
+        order was submitted with ``expect_brackets=True``). The default
+        ``True`` is correct for the typical path where at least one slice
+        already filled — including the no-liquidity *continuation* case,
+        because the partial entry that triggered the continuation has
+        already opened a position. For the no-liquidity *initial* case
+        (``_fill_entry`` with ``filled_qty <= 0``) the caller passes
+        ``False`` since no position has opened.
+        """
         policy = po.request.unfilled_policy or UnfilledPolicy.DROP
         if unfilled > 0 and policy == UnfilledPolicy.REQUEUE_NEXT_BAR:
             self.order_book.requeue(
                 po.order_id,
                 new_remaining_qty=unfilled,
                 new_submitted_at=bar.timestamp,
-                was_filled=True,
+                was_filled=was_filled,
             )
             return
         # TWAP_N is wired in #387; until then it falls through to DROP.
-        # Entries that fully fill or get DROPped both end here. ``was_filled=True``
-        # keeps the parent id eligible for bracket activation (#389).
-        self.order_book.remove(po.order_id, was_filled=True)
+        self.order_book.remove(po.order_id, was_filled=was_filled)
 
     def _fill_exit(
         self,

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -465,10 +465,17 @@ class FillSimulator:
         # position past what the strategy saw at submission time — without
         # this min() the exit could close newly-added shares the strategy
         # never intended to unwind.
-        requested_exit_qty = min(po.remaining_qty, pos.qty)
+        fillable_qty = min(po.remaining_qty, pos.qty)
         qty_fraction = max(0.0, min(1.0, terms.qty_fraction))
-        filled_qty = requested_exit_qty * qty_fraction
-        unfilled = requested_exit_qty - filled_qty
+        filled_qty = fillable_qty * qty_fraction
+        # Compute ``unfilled`` against the *order's* remaining request, not
+        # against ``fillable_qty``. If the strategy asked for more shares
+        # than are currently open (e.g. after a dropped partial entry), the
+        # not-fillable portion is real unfilled work from the strategy's
+        # perspective — reporting it as ``unfilled_qty=0`` would mislabel a
+        # truncated execution as fully complete and break resubmission /
+        # exposure-reconciliation logic.
+        unfilled = po.remaining_qty - filled_qty
 
         if filled_qty <= 0:
             # No liquidity for any exit slice on this bar. Decide whether to
@@ -485,8 +492,8 @@ class FillSimulator:
                 timestamp=bar.timestamp,
                 reason="rejected_no_liquidity",
                 fill_kind=FillKind.REJECTED,
-                unfilled_qty=requested_exit_qty,
-                cumulative_filled_qty=pos.cumulative_exit_qty,
+                unfilled_qty=po.remaining_qty,
+                cumulative_filled_qty=po.cumulative_filled_qty,
             )
             return rejected, None
 
@@ -513,7 +520,12 @@ class FillSimulator:
             reason="exit",
             fill_kind=FillKind.FULL if unfilled <= 0 else FillKind.PARTIAL,
             unfilled_qty=unfilled,
-            cumulative_filled_qty=pos.cumulative_exit_qty,
+            # Per-order cumulative exit fills (monotonic across all slices
+            # of *this* exit order). ``pos.cumulative_exit_qty`` is
+            # position-wide across multiple exit orders, which would let an
+            # independent later exit emit a value larger than its own
+            # requested qty — breaking per-order fill accounting.
+            cumulative_filled_qty=po.cumulative_filled_qty + filled_qty,
         )
 
         if not is_closed:

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -419,7 +419,15 @@ class FillSimulator:
         else:
             exit_price = round(ref_price * slip_short_exit, dp)
 
-        requested_exit_qty = po.remaining_qty if po.cumulative_filled_qty > 0 else pos.qty
+        # Bound the exit fill by both the strategy's requested qty
+        # (``po.remaining_qty``, which OrderBook.submit pins to ``req.qty``
+        # on first slice and the requeue path shrinks on partial slices) and
+        # the position's currently-open qty. The position cap matters when
+        # an entry continuation runs earlier in the same bar and grows the
+        # position past what the strategy saw at submission time — without
+        # this min() the exit could close newly-added shares the strategy
+        # never intended to unwind.
+        requested_exit_qty = min(po.remaining_qty, pos.qty)
         qty_fraction = max(0.0, min(1.0, terms.qty_fraction))
         filled_qty = requested_exit_qty * qty_fraction
         unfilled = requested_exit_qty - filled_qty

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -272,7 +272,14 @@ class FillSimulator:
             entry_order_id=po.order_id,
             entry_client_order_id=req.client_order_id,
             entry_order_type=req.order_type.value,
-            original_qty=req.qty,
+            # ``original_qty`` tracks the cumulative entry-filled qty (the
+            # qty we expect to exit to fully close), *not* the strategy's
+            # original request. Initialized to this slice's filled qty;
+            # ``_continue_entry`` bumps it on each follow-on fill. When the
+            # entry order is removed (DROP / full fill) ``original_qty``
+            # naturally settles at the actually-held qty so a subsequent
+            # exit for that qty hits ``is_closed``.
+            original_qty=filled_qty,
             participation_clipped=is_partial,
             total_unfilled_qty=unfilled,
             # Counts the number of fill events on the entry side: initial
@@ -341,7 +348,30 @@ class FillSimulator:
         else:
             fill_price = round(ref_price * slip_short_entry, dp)
 
-        # Capital and risk checks against the *additional* notional only.
+        # Re-apply the risk gate on every continuation slice. Exposure can
+        # have grown between bars (mark-to-market on other positions, fresh
+        # entries on different symbols) so an originally-approved order
+        # still needs to fit current limits before adding more shares to the
+        # position. Exclude this symbol's existing position from the snapshot
+        # so ``max_open_positions`` doesn't trip on our own presence, and
+        # pass the post-extend full notional so leverage / concentration
+        # checks see the exposure that *will* exist after this fill.
+        existing_pos = self.portfolio.positions[req.symbol]
+        post_extend_notional = (existing_pos.qty + filled_qty) * fill_price
+        positions_excluding_self = {
+            s: p for s, p in self.portfolio.positions.items() if s != req.symbol
+        }
+        equity = self.portfolio.mark_to_market()
+        gate = self.risk.can_enter(
+            req.symbol, post_extend_notional, equity, positions_excluding_self
+        )
+        if not gate.allowed:
+            logger.info("risk gate rejected entry continuation for %s: %s", req.symbol, gate.reason)
+            self.order_book.remove(po.order_id)
+            return None
+
+        # Capital check against the *additional* notional only — the existing
+        # position's capital is already deducted.
         additional_notional = filled_qty * fill_price
         if self.portfolio.capital < additional_notional:
             logger.info(
@@ -354,6 +384,10 @@ class FillSimulator:
             return None
 
         pos = self.portfolio.extend(req.symbol, filled_qty, fill_price)
+        # ``original_qty`` mirrors the cumulative entry-filled qty; bump it
+        # so ``is_closed`` (compares ``cumulative_exit_qty`` to it) and
+        # ``TradeRecord.shares`` reflect the actually-held position.
+        pos.original_qty += filled_qty
         is_partial = unfilled > 0
         if is_partial:
             pos.participation_clipped = True
@@ -373,7 +407,11 @@ class FillSimulator:
             reason="entry",
             fill_kind=FillKind.PARTIAL if is_partial else FillKind.FULL,
             unfilled_qty=unfilled,
-            cumulative_filled_qty=pos.qty,
+            # Per-order cumulative entry fills (monotonic across all slices
+            # of *this* order). Reading from ``po.cumulative_filled_qty``
+            # plus the current slice keeps the value monotonic even if
+            # interim exits have shrunk ``pos.qty``.
+            cumulative_filled_qty=po.cumulative_filled_qty + filled_qty,
         )
 
     def _handle_entry_remainder(
@@ -458,6 +496,12 @@ class FillSimulator:
             pos.total_unfilled_qty += unfilled
 
         is_closed = pos.is_closed
+        # ``fill_kind`` reports completeness of *this exit order*, not
+        # closure of the position: a strategy that intentionally requests a
+        # partial unwind (req.qty < pos.qty) gets a ``FULL`` exit Fill
+        # while the position keeps residual exposure. Conflating the two
+        # would mislabel partial-unwind fills as ``PARTIAL`` even when the
+        # order filled to its requested size.
         exit_fill = Fill(
             order_id=po.order_id,
             client_order_id=req.client_order_id,
@@ -467,7 +511,7 @@ class FillSimulator:
             price=exit_price,
             timestamp=bar.timestamp,
             reason="exit",
-            fill_kind=FillKind.FULL if is_closed else FillKind.PARTIAL,
+            fill_kind=FillKind.FULL if unfilled <= 0 else FillKind.PARTIAL,
             unfilled_qty=unfilled,
             cumulative_filled_qty=pos.cumulative_exit_qty,
         )

--- a/backend/agents/investment_team/trading_service/engine/portfolio.py
+++ b/backend/agents/investment_team/trading_service/engine/portfolio.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
 from ..strategy.contract import Fill, OrderSide
+from .order_book import FILL_QTY_REL_TOL
 
 
 @dataclass
@@ -29,9 +30,49 @@ class Position:
     entry_client_order_id: str
     entry_order_type: str = "market"
 
+    # Partial-fill accounting (#386). ``original_qty`` is the qty the strategy
+    # asked for; ``qty`` is the *currently open* qty (decreases on partial
+    # exits). The cumulative-exit fields drive the weighted-average exit price
+    # used when the final ``TradeRecord`` is emitted.
+    original_qty: float = 0.0
+    cumulative_exit_qty: float = 0.0
+    weighted_exit_price_sum: float = 0.0
+    partial_fill_count: int = 0
+    participation_clipped: bool = False
+    total_unfilled_qty: float = 0.0
+
     @property
     def position_value(self) -> float:
         return self.entry_price * self.qty
+
+    def reduce(self, qty: float, exit_price: float) -> None:
+        """Apply a partial exit: shrink ``qty`` and accumulate weighted exit.
+
+        ``partial_fill_count`` is intentionally not bumped here — it counts
+        the number of fills the *entry* side required (initial + each
+        ``REQUEUE_NEXT_BAR`` continuation). Exit-side slice count is
+        captured implicitly via ``cumulative_exit_qty`` /
+        ``weighted_exit_price_sum``.
+        """
+        self.cumulative_exit_qty += qty
+        self.weighted_exit_price_sum += qty * exit_price
+        self.qty -= qty
+
+    @property
+    def is_closed(self) -> bool:
+        # FP-safe terminal check: a sub-ULP residual on ``cumulative_exit_qty``
+        # vs ``original_qty`` shouldn't keep a position open. Reuse the same
+        # relative tolerance ``OrderBook.requeue`` uses for remainder clamping
+        # so the two terminal-fill checks agree.
+        if self.original_qty <= 0:
+            return False
+        return self.cumulative_exit_qty + self.original_qty * FILL_QTY_REL_TOL >= self.original_qty
+
+    @property
+    def weighted_avg_exit_price(self) -> float:
+        if self.cumulative_exit_qty <= 0:
+            return 0.0
+        return self.weighted_exit_price_sum / self.cumulative_exit_qty
 
 
 @dataclass
@@ -58,16 +99,54 @@ class Portfolio:
     def open(self, position: Position) -> None:
         if position.symbol in self.positions:
             raise ValueError(f"position already open for {position.symbol}")
+        # Pin ``original_qty`` to the first-fill qty when the caller didn't set
+        # it. The fill simulator builds Position objects with the strategy's
+        # requested qty in ``original_qty`` and the actually-filled qty in
+        # ``qty``; this fallback keeps direct callers (tests, legacy paths)
+        # working without forcing them to set both fields.
+        if position.original_qty == 0.0:
+            position.original_qty = position.qty
         self.capital -= position.position_value
         self.positions[position.symbol] = position
+
+    def extend(self, symbol: str, additional_qty: float, fill_price: float) -> Position:
+        """Apply a follow-on entry fill to an already-open position.
+
+        Used by the partial-fill simulator (#386) when a requeued partial
+        entry's remainder fills on a later bar. ``entry_price`` becomes the
+        qty-weighted average across all entry partials so downstream P&L
+        math (``position_value``, gross/net in TradeRecord) stays correct.
+        """
+        pos = self.positions[symbol]
+        old_notional = pos.entry_price * pos.qty
+        new_qty = pos.qty + additional_qty
+        pos.entry_price = (old_notional + additional_qty * fill_price) / new_qty
+        pos.qty = new_qty
+        self.capital -= round(additional_qty * fill_price, 2)
+        return pos
+
+    def partial_close(self, symbol: str, exit_qty: float, exit_price: float) -> Optional[Position]:
+        """Apply a partial exit: shrink position qty, credit cash, keep open.
+
+        The position remains in ``self.positions``; ``close()`` is called
+        separately by the fill simulator once ``pos.is_closed``.
+        """
+        pos = self.positions.get(symbol)
+        if pos is None:
+            return None
+        pos.reduce(exit_qty, exit_price)
+        self.capital += round(exit_qty * exit_price, 2)
+        return pos
 
     def close(self, symbol: str, exit_price: float) -> Optional[Position]:
         pos = self.positions.pop(symbol, None)
         if pos is None:
             return None
-        # Cash returned uses the exit fill price × original qty. Realized P&L
-        # is owned by the FillSimulator so it can apply slippage / fees; the
-        # Portfolio just moves cash.
+        # Cash returned uses the exit fill price × current open qty. Realized
+        # P&L is owned by the FillSimulator so it can apply slippage / fees;
+        # the Portfolio just moves cash. When ``partial_close`` already
+        # credited earlier slices, ``pos.qty`` is the residual being closed
+        # here so the cash math stays balanced across the lifecycle.
         self.capital += round(pos.qty * exit_price, 2)
         return pos
 

--- a/backend/agents/investment_team/trading_service/engine/portfolio.py
+++ b/backend/agents/investment_team/trading_service/engine/portfolio.py
@@ -122,7 +122,12 @@ class Portfolio:
         new_qty = pos.qty + additional_qty
         pos.entry_price = (old_notional + additional_qty * fill_price) / new_qty
         pos.qty = new_qty
-        self.capital -= round(additional_qty * fill_price, 2)
+        # Don't round per-slice — fragmented partial fills would let the
+        # rounding error accumulate. ``Portfolio.open`` is also raw; the only
+        # rounding happens at terminal ``close()`` (consistent with legacy
+        # single-shot behavior). This keeps zero-cost flat round-trips
+        # cash-conservative even across hundreds of partials.
+        self.capital -= additional_qty * fill_price
         return pos
 
     def partial_close(self, symbol: str, exit_qty: float, exit_price: float) -> Optional[Position]:
@@ -135,7 +140,11 @@ class Portfolio:
         if pos is None:
             return None
         pos.reduce(exit_qty, exit_price)
-        self.capital += round(exit_qty * exit_price, 2)
+        # See ``extend`` — no per-slice rounding. The terminal ``close()``
+        # rounds once on the residual (which is ~0 by then, so a no-op),
+        # matching the legacy single-shot behavior without introducing
+        # cumulative drift on multi-slice exits.
+        self.capital += exit_qty * exit_price
         return pos
 
     def close(self, symbol: str, exit_price: float) -> Optional[Position]:

--- a/backend/agents/investment_team/trading_service/engine/portfolio.py
+++ b/backend/agents/investment_team/trading_service/engine/portfolio.py
@@ -37,6 +37,13 @@ class Position:
     original_qty: float = 0.0
     cumulative_exit_qty: float = 0.0
     weighted_exit_price_sum: float = 0.0
+    # Weighted exit *bid* price (the pre-slippage reference price used on
+    # each exit slice). Mirrors ``weighted_exit_price_sum`` so multi-bar
+    # partial exits can report a coherent weighted ``exit_bid_price`` on
+    # the final TradeRecord — without this, ``exit_price`` (weighted) and
+    # ``exit_bid_price`` (only the closing bar) get mismatched and skew
+    # slippage diagnostics.
+    weighted_exit_bid_sum: float = 0.0
     partial_fill_count: int = 0
     participation_clipped: bool = False
     total_unfilled_qty: float = 0.0
@@ -45,7 +52,7 @@ class Position:
     def position_value(self) -> float:
         return self.entry_price * self.qty
 
-    def reduce(self, qty: float, exit_price: float) -> None:
+    def reduce(self, qty: float, exit_price: float, exit_bid_price: float = 0.0) -> None:
         """Apply a partial exit: shrink ``qty`` and accumulate weighted exit.
 
         ``partial_fill_count`` is intentionally not bumped here — it counts
@@ -53,9 +60,15 @@ class Position:
         ``REQUEUE_NEXT_BAR`` continuation). Exit-side slice count is
         captured implicitly via ``cumulative_exit_qty`` /
         ``weighted_exit_price_sum``.
+
+        ``exit_bid_price`` defaults to ``0.0`` for legacy / direct callers
+        that don't track a reference price; the fill simulator always
+        passes the bar's pre-slippage reference price so multi-bar
+        partial exits accumulate a true weighted bid average.
         """
         self.cumulative_exit_qty += qty
         self.weighted_exit_price_sum += qty * exit_price
+        self.weighted_exit_bid_sum += qty * exit_bid_price
         self.qty -= qty
 
     @property
@@ -73,6 +86,12 @@ class Position:
         if self.cumulative_exit_qty <= 0:
             return 0.0
         return self.weighted_exit_price_sum / self.cumulative_exit_qty
+
+    @property
+    def weighted_avg_exit_bid_price(self) -> float:
+        if self.cumulative_exit_qty <= 0:
+            return 0.0
+        return self.weighted_exit_bid_sum / self.cumulative_exit_qty
 
 
 @dataclass
@@ -109,18 +128,35 @@ class Portfolio:
         self.capital -= position.position_value
         self.positions[position.symbol] = position
 
-    def extend(self, symbol: str, additional_qty: float, fill_price: float) -> Position:
+    def extend(
+        self,
+        symbol: str,
+        additional_qty: float,
+        fill_price: float,
+        fill_bid_price: float | None = None,
+    ) -> Position:
         """Apply a follow-on entry fill to an already-open position.
 
         Used by the partial-fill simulator (#386) when a requeued partial
         entry's remainder fills on a later bar. ``entry_price`` becomes the
         qty-weighted average across all entry partials so downstream P&L
         math (``position_value``, gross/net in TradeRecord) stays correct.
+
+        ``fill_bid_price`` is the pre-slippage reference price for this
+        slice. When provided, ``entry_bid_price`` is also updated to a
+        qty-weighted average so it stays coherent with the weighted
+        ``entry_price`` (otherwise the trade record would mix weighted
+        fill pricing with a stale first-slice reference, skewing entry-
+        side slippage diagnostics). Defaults to ``None`` for legacy
+        callers; the fill simulator always passes the bar's reference.
         """
         pos = self.positions[symbol]
         old_notional = pos.entry_price * pos.qty
         new_qty = pos.qty + additional_qty
         pos.entry_price = (old_notional + additional_qty * fill_price) / new_qty
+        if fill_bid_price is not None:
+            old_bid_notional = pos.entry_bid_price * pos.qty
+            pos.entry_bid_price = (old_bid_notional + additional_qty * fill_bid_price) / new_qty
         pos.qty = new_qty
         # Don't round per-slice — fragmented partial fills would let the
         # rounding error accumulate. ``Portfolio.open`` is also raw; the only
@@ -130,16 +166,27 @@ class Portfolio:
         self.capital -= additional_qty * fill_price
         return pos
 
-    def partial_close(self, symbol: str, exit_qty: float, exit_price: float) -> Optional[Position]:
+    def partial_close(
+        self,
+        symbol: str,
+        exit_qty: float,
+        exit_price: float,
+        exit_bid_price: float = 0.0,
+    ) -> Optional[Position]:
         """Apply a partial exit: shrink position qty, credit cash, keep open.
 
         The position remains in ``self.positions``; ``close()`` is called
         separately by the fill simulator once ``pos.is_closed``.
+
+        ``exit_bid_price`` is the bar's pre-slippage reference; when
+        provided it accumulates into the weighted exit-bid average so the
+        final TradeRecord's ``exit_bid_price`` is coherent with the
+        weighted ``exit_price`` across multi-bar partial exits.
         """
         pos = self.positions.get(symbol)
         if pos is None:
             return None
-        pos.reduce(exit_qty, exit_price)
+        pos.reduce(exit_qty, exit_price, exit_bid_price)
         # See ``extend`` — no per-slice rounding. The terminal ``close()``
         # rounds once on the residual (which is ~0 by then, so a no-op),
         # matching the legacy single-shot behavior without introducing

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -39,12 +39,12 @@ logger = logging.getLogger(__name__)
 def _partial_fill_defaults_enabled() -> bool:
     """Whether parent-side application of ``default_unfilled_policy`` is on.
 
-    Off by default — Step 3 of #379 ships the wiring; Steps 4+ make the
-    downstream engine actually act on the policy. With the flag off, the
-    service ignores ``default_unfilled_policy`` entirely (acts as DROP
-    regardless), preserving today's byte-identical behavior.
+    On by default since #386 (Step 4) wired ``REQUEUE_NEXT_BAR`` into
+    ``FillSimulator``. Set ``TRADING_PARTIAL_FILL_DEFAULTS_ENABLED=false``
+    to fall back to the pre-Step-4 behavior (silent drop of partial-fill
+    remainders) — useful for parity comparisons against legacy snapshots.
     """
-    return os.environ.get("TRADING_PARTIAL_FILL_DEFAULTS_ENABLED", "false").lower() in {
+    return os.environ.get("TRADING_PARTIAL_FILL_DEFAULTS_ENABLED", "true").lower() in {
         "true",
         "1",
         "yes",


### PR DESCRIPTION
Closes #386. First behavior-changing commit in the Trading 5/5 chain (#379).

## Summary

Replaces the silent-drop site in `FillSimulator` with truthful partial-fill emission, adds cumulative-exit accounting on `Position`, wires `REQUEUE_NEXT_BAR` through to `OrderBook.requeue` (already implemented in #384), and flips the Step-3 feature flag (`TRADING_PARTIAL_FILL_DEFAULTS_ENABLED`) default to `true`.

**Backtest mode default change:** prior behavior was *silent drop* of partial-fill remainders. After this PR backtests default to **`REQUEUE_NEXT_BAR`** — partial-fill remainders are re-quoted on the next bar with a refreshed `submitted_at` (so bar-safety still holds). Strategies that explicitly set `unfilled_policy` are unaffected. Paper-trade mode default remains `DROP`.

**Env flag flip:** `TRADING_PARTIAL_FILL_DEFAULTS_ENABLED` default flipped from `false` to `true`. Pin to `false` to fall back to pre-Step-4 behavior for parity comparisons against legacy snapshots.

## Engine changes

- `Position` gains `original_qty` / `cumulative_exit_qty` / `weighted_exit_price_sum` / `partial_fill_count` / `participation_clipped` / `total_unfilled_qty` plus `reduce()`, `is_closed`, `weighted_avg_exit_price`.
- `Portfolio` gains `extend()` (partial-entry continuation; qty-weighted entry-price update) and `partial_close()` (partial exit; reduces qty, credits cash, keeps position open). `open()` auto-pins `original_qty` when unset.
- `FillSimulator.process_bar` adds a third routing branch — a requeued partial entry is matched to its existing `Position` via `entry_order_id` so it accumulates into that position instead of falling through the same-side exit guard.
- `_fill_entry` / `_continue_entry` / `_fill_exit` now emit `Fill(fill_kind=PARTIAL|FULL|REJECTED)` with `unfilled_qty` and `cumulative_filled_qty` populated. `_fill_exit` only constructs `TradeRecord` when the position is fully closed, using the qty-weighted average exit price across all partial exits.
- `_handle_entry_remainder` / `_handle_exit_remainder` centralize the requeue-vs-remove decision based on `po.request.unfilled_policy`. Exit requeues correctly pass `was_filled=False` (exits are never bracket parents).

## Tests

- **New** `tests/test_partial_fills.py` — 5 cases:
  1. `RealisticExecutionModel` + low ADV → entry returns `Fill(fill_kind=PARTIAL, unfilled_qty>0)`.
  2. `REQUEUE_NEXT_BAR`: two consecutive entry fills sum to the original qty; resulting `TradeRecord.partial_fill_count == 2`, `participation_clipped == True`, `total_unfilled_qty` matches.
  3. `DROP` policy: partial Fill is still emitted (no silent-drop), but the remainder is removed from the book — no next-bar continuation.
  4. Bar-safety guard does not fire on a requeued order's next-bar fill (`OrderBook.requeue` advances `submitted_at`).
  5. Partial exit: position qty decremented across two bars; `TradeRecord` only emitted on the closing bar; `exit_price` equals the qty-weighted avg.
- `test_trading_service.py` — flag-off case now pins the env var explicitly (default is now `true`); `test_partial_fill_defaults_flag_default_is_off` renamed to `_is_on` with inverted assertion.
- `test_paper_trade.py` / `test_subdaily_backtest.py` — bumped placeholder bar volume from `1.0` to `1_000_000` so the realistic execution model's 10% participation cap doesn't clip `qty=1` fills (pre-#386 exits ignored the cap, so `volume=1.0` used to work).

## Acceptance criteria (from issue)

- [x] All 5 new tests pass.
- [x] Golden parity preserved on `OptimisticExecutionModel + DROP + no attachments`: `tests/golden/test_simulator_invariants.py` (4 tests) and `tests/golden/test_reference_strategies.py` (3 tests) pass byte-identical against existing snapshots.
- [x] No silent-drop path remains in `fill_simulator.py` — every `qty <= 0` branch now emits `Fill(fill_kind=REJECTED)` before `remove()`.
- [x] PR description notes the backtest mode default change (above).

## Test plan

- [ ] CI: ruff check + format
- [ ] CI: investment-team test suite (613 passed locally, 90s)
- [ ] CI: golden parity suite (`tests/golden/`) byte-identical
- [ ] Spot-check on `claude/select-next-issue-19tJy`: `pytest agents/investment_team/tests/test_partial_fills.py -v` → 5/5 pass

https://claude.ai/code/session_01NLMimP9CVtpnSDp2C1iPVj

---
_Generated by [Claude Code](https://claude.ai/code/session_01NLMimP9CVtpnSDp2C1iPVj)_