### PR TITLE
[Trading 5/5 — Step 6] IOC / FOK time-in-force pre-check in fill_simulator (#388)

### DIFF
--- a/backend/agents/investment_team/tests/test_contract_gates.py
+++ b/backend/agents/investment_team/tests/test_contract_gates.py
@@ -43,24 +43,12 @@ def test_trailing_stop_is_gated_until_step_8():
         req.validate_prices()
 
 
-def test_ioc_is_gated_until_step_6():
-    req = _base(tif=TimeInForce.IOC)
-    with pytest.raises(NotImplementedError, match="#388"):
-        req.validate_prices()
-
-
-def test_fok_is_gated_until_step_6():
-    req = _base(tif=TimeInForce.FOK)
-    with pytest.raises(NotImplementedError, match="#388"):
-        req.validate_prices()
-
-
 def test_gates_raise_unsupported_order_feature_subclass():
     """The gates must raise the dedicated subclass, not bare
     ``NotImplementedError``, so streaming_harness only re-classifies real
     gate violations as ``unsupported_feature`` (and lets unrelated
     ``NotImplementedError`` from strategy code stay as ``runtime_error``)."""
-    req = _base(tif=TimeInForce.IOC)
+    req = _base(order_type=OrderType.TRAILING_STOP, stop_price=10.0)
     with pytest.raises(UnsupportedOrderFeatureError):
         req.validate_prices()
 
@@ -95,6 +83,13 @@ def test_default_market_order_still_validates():
     _base(order_type=OrderType.LIMIT, limit_price=100.0).validate_prices()
     _base(order_type=OrderType.STOP, stop_price=105.0).validate_prices()
     _base(tif=TimeInForce.GTC).validate_prices()
+    # IOC/FOK are runtime-supported as of #388 (Step 6) — the blanket
+    # submission-time gate is gone; only the shape-consistency check
+    # ("IOC/FOK only valid with market or limit orders") remains live.
+    _base(tif=TimeInForce.IOC).validate_prices()
+    _base(tif=TimeInForce.FOK).validate_prices()
+    _base(tif=TimeInForce.IOC, order_type=OrderType.LIMIT, limit_price=100.0).validate_prices()
+    _base(tif=TimeInForce.FOK, order_type=OrderType.LIMIT, limit_price=100.0).validate_prices()
 
 
 def test_unfilled_policies_validate_post_step_5():

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -1001,8 +1001,8 @@ def test_submit_attached_indexes_by_symbol() -> None:
 # submit_attached re-runs *every* validate_prices() gate except the
 # parent_order_id / oco_group_id ones — i.e. malformed children (LIMIT
 # without limit_price, STOP without stop_price) and unsupported types
-# (TRAILING_STOP, IOC/FOK) must still be rejected at submission time so we
-# never queue an order that would crash the simulator later.
+# (TRAILING_STOP) must still be rejected at submission time so we never
+# queue an order that would crash the simulator later.
 # ---------------------------------------------------------------------------
 
 
@@ -1056,27 +1056,6 @@ def test_submit_attached_rejects_trailing_stop_child() -> None:
         book.submit_attached(
             _base(
                 side=OrderSide.SHORT, qty=10.0, order_type=OrderType.TRAILING_STOP, stop_price=95.0
-            ),
-            submitted_at="2024-01-03",
-            submitted_equity=100_000.0,
-            parent_order_id=parent.order_id,
-            oco_group_id="g1",
-        )
-    assert book.children_of(parent.order_id) == []
-
-
-def test_submit_attached_rejects_ioc_child() -> None:
-    """IOC/FOK are gated until #388 ships — same as above."""
-    book = OrderBook()
-    parent = _bracket_parent(book)
-    with pytest.raises(UnsupportedOrderFeatureError, match="#388"):
-        book.submit_attached(
-            _base(
-                qty=10.0,
-                side=OrderSide.SHORT,
-                order_type=OrderType.LIMIT,
-                limit_price=110.0,
-                tif=TimeInForce.IOC,
             ),
             submitted_at="2024-01-03",
             submitted_equity=100_000.0,

--- a/backend/agents/investment_team/tests/test_tif.py
+++ b/backend/agents/investment_team/tests/test_tif.py
@@ -210,3 +210,51 @@ def test_ioc_overrides_requeue_next_bar_policy() -> None:
     assert outcome.entry_fills[0].fill_kind == FillKind.PARTIAL
     # No requeue despite REQUEUE_NEXT_BAR — IOC dominates.
     assert order_book.all_pending() == []
+
+
+def test_no_trigger_ioc_same_side_addon_drops_silently() -> None:
+    """A same-side IOC LIMIT add-on against an already-open position must be
+    silently suppressed (no Fill emitted) — same as the triggered same-side
+    add-on path. Without this guard, the no-trigger IOC/FOK branch would
+    emit a synthetic REJECTED Fill and route it as an exit fill, even
+    though the order was never going to fill regardless of TIF.
+    """
+    sim, order_book, portfolio = _make_simulator()
+
+    # Open a LONG position via a clean, fully-absorbed entry.
+    order_book.submit(
+        _entry_order(2_000),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+    )
+    sim.process_bar(_bar("2024-01-02", price=100.0, volume=10_000_000))
+    assert portfolio.positions["AAA"].qty == pytest.approx(2_000.0, rel=1e-9)
+
+    # Submit a same-side (LONG) IOC LIMIT add-on with a price that won't
+    # cross on the next bar (limit far below the bar's range).
+    order_book.submit(
+        OrderRequest(
+            client_order_id="addon-1",
+            symbol="AAA",
+            side=OrderSide.LONG,
+            qty=500,
+            order_type=OrderType.LIMIT,
+            limit_price=50.0,
+            tif=TimeInForce.IOC,
+        ),
+        submitted_at="2024-01-02",
+        submitted_equity=10_000_000.0,
+    )
+
+    outcome = sim.process_bar(_bar("2024-01-03", price=100.0, volume=10_000_000))
+
+    # No synthetic REJECTED fill — same-side suppression wins on both
+    # the triggered and no-trigger paths.
+    assert outcome.entry_fills == []
+    assert outcome.exit_fills == []
+    # Add-on order silently removed; the original position is untouched.
+    addon_pending = [
+        po for po in order_book.all_pending() if po.request.client_order_id == "addon-1"
+    ]
+    assert addon_pending == []
+    assert portfolio.positions["AAA"].qty == pytest.approx(2_000.0, rel=1e-9)

--- a/backend/agents/investment_team/tests/test_tif.py
+++ b/backend/agents/investment_team/tests/test_tif.py
@@ -1,0 +1,212 @@
+"""IOC / FOK time-in-force runtime support in the fill simulator (#388).
+
+The ``TimeInForce`` enum (DAY/GTC/IOC/FOK) was added to the contract in
+Step 1 of #379 but the engine raised ``UnsupportedOrderFeatureError``
+for ``IOC`` and ``FOK`` until this step. With #388 those gates are
+lifted and the simulator honours the two non-default TIFs:
+
+- **FOK** rejects on this bar if the bar can't fully absorb the order
+  (participation-cap clip OR exit-side ``pos.qty`` shortfall).
+- **IOC** lets whatever this bar can absorb through, emits a PARTIAL
+  fill, then cancels the remainder regardless of ``unfilled_policy``.
+
+DAY/GTC behaviour and golden parity must remain unchanged.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from investment_team.execution.bar_safety import BarSafetyAssertion
+from investment_team.execution.risk_filter import RiskFilter, RiskLimits
+from investment_team.trading_service.engine.execution_model import (
+    RealisticExecutionModel,
+)
+from investment_team.trading_service.engine.fill_simulator import (
+    FillSimulator,
+    FillSimulatorConfig,
+)
+from investment_team.trading_service.engine.order_book import OrderBook
+from investment_team.trading_service.engine.portfolio import Portfolio
+from investment_team.trading_service.strategy.contract import (
+    Bar,
+    FillKind,
+    OrderRequest,
+    OrderSide,
+    OrderType,
+    TimeInForce,
+    UnfilledPolicy,
+)
+
+
+def _bar(ts: str, *, price: float = 100.0, volume: float = 1_000_000.0) -> Bar:
+    return Bar(
+        symbol="AAA",
+        timestamp=ts,
+        timeframe="1d",
+        open=price,
+        high=price + 1,
+        low=price - 1,
+        close=price,
+        volume=volume,
+    )
+
+
+def _make_simulator(
+    initial_capital: float = 10_000_000.0,
+) -> tuple[FillSimulator, OrderBook, Portfolio]:
+    portfolio = Portfolio(initial_capital=initial_capital)
+    order_book = OrderBook()
+    sim = FillSimulator(
+        portfolio=portfolio,
+        order_book=order_book,
+        risk_filter=RiskFilter(RiskLimits(max_position_pct=100, max_gross_leverage=10.0)),
+        config=FillSimulatorConfig(slippage_bps=0.0, transaction_cost_bps=0.0),
+        bar_safety=BarSafetyAssertion(),
+        # Pin to the production cap so fixed bar/qty math below stays
+        # stable if the default ever changes.
+        execution_model=RealisticExecutionModel(participation_cap=0.10),
+    )
+    return sim, order_book, portfolio
+
+
+def _entry_order(
+    qty: float,
+    *,
+    tif: TimeInForce = TimeInForce.DAY,
+    policy: UnfilledPolicy | None = None,
+) -> OrderRequest:
+    return OrderRequest(
+        client_order_id="entry-1",
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=qty,
+        order_type=OrderType.MARKET,
+        tif=tif,
+        unfilled_policy=policy,
+    )
+
+
+# Participation math reminder (default cap = 0.10):
+#   raw_participation = req.qty * ref_price / (bar.volume * bar.close)
+#   if raw_participation <= cap: qty_fraction = 1.0
+#   else:                        qty_fraction = cap / raw_participation
+#
+# At price=100, volume=10_000  → bar_dollar_volume=1_000_000, capacity=100_000
+#                                notional → 1_000 shares ⇒ qty=2_000 → 50% partial.
+# At price=100, volume=10_000_000 → bar_dollar_volume=1e9, capacity=1e8 notional
+#                                   → fully absorbs qty=2_000 ⇒ qty_fraction=1.0.
+
+
+def test_fok_low_adv_emits_rejected_fill_and_no_position() -> None:
+    """FOK + low-ADV bar → single REJECTED Fill, no Position created, no requeue.
+
+    Acceptance bullet 1 of #388.
+    """
+    sim, order_book, portfolio = _make_simulator()
+    order_book.submit(
+        _entry_order(2_000, tif=TimeInForce.FOK),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+    )
+
+    outcome = sim.process_bar(_bar("2024-01-02", price=100.0, volume=10_000))
+
+    assert len(outcome.entry_fills) == 1
+    fill = outcome.entry_fills[0]
+    assert fill.fill_kind == FillKind.REJECTED
+    assert fill.qty == 0.0
+    assert fill.unfilled_qty == pytest.approx(2_000.0, rel=1e-9)
+    assert fill.cumulative_filled_qty == 0.0
+    # No money math: no position, no risk-gate side effect, no exit fill.
+    assert "AAA" not in portfolio.positions
+    assert outcome.exit_fills == []
+    # Order removed from the book — no requeue.
+    assert order_book.all_pending() == []
+
+    # Belt-and-braces: a follow-up bar (even one that could fully absorb)
+    # produces nothing because the FOK was already cancelled.
+    follow_up = sim.process_bar(_bar("2024-01-03", price=100.0, volume=10_000_000))
+    assert follow_up.entry_fills == []
+    assert follow_up.exit_fills == []
+
+
+def test_fok_full_absorption_emits_full_fill() -> None:
+    """FOK + bar that can fully absorb → ``fill_kind=FULL``.
+
+    Acceptance bullet 2 of #388.
+    """
+    sim, order_book, portfolio = _make_simulator()
+    order_book.submit(
+        _entry_order(2_000, tif=TimeInForce.FOK),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+    )
+
+    outcome = sim.process_bar(_bar("2024-01-02", price=100.0, volume=10_000_000))
+
+    assert len(outcome.entry_fills) == 1
+    fill = outcome.entry_fills[0]
+    assert fill.fill_kind == FillKind.FULL
+    assert fill.qty == pytest.approx(2_000.0, rel=1e-9)
+    assert fill.unfilled_qty == pytest.approx(0.0, abs=1e-9)
+    assert "AAA" in portfolio.positions
+    assert portfolio.positions["AAA"].qty == pytest.approx(2_000.0, rel=1e-9)
+    # FOK fully filled → order removed (the standard full-fill path).
+    assert order_book.all_pending() == []
+
+
+def test_ioc_low_adv_emits_partial_then_removes_order() -> None:
+    """IOC + low-ADV bar → PARTIAL fill with ``unfilled_qty>0``; the order
+    is then removed and the next bar sees no pending order.
+
+    Acceptance bullet 3 of #388.
+    """
+    sim, order_book, portfolio = _make_simulator()
+    order_book.submit(
+        _entry_order(2_000, tif=TimeInForce.IOC),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+    )
+
+    outcome = sim.process_bar(_bar("2024-01-02", price=100.0, volume=10_000))
+
+    # PARTIAL fill emitted exactly as it would be for DAY/DROP — IOC only
+    # changes the *remainder* handling, not the Fill payload.
+    assert len(outcome.entry_fills) == 1
+    fill = outcome.entry_fills[0]
+    assert fill.fill_kind == FillKind.PARTIAL
+    assert fill.qty == pytest.approx(1_000.0, rel=1e-9)
+    assert fill.unfilled_qty == pytest.approx(1_000.0, rel=1e-9)
+    assert fill.cumulative_filled_qty == pytest.approx(1_000.0, rel=1e-9)
+
+    # Position opened with the partial qty.
+    assert "AAA" in portfolio.positions
+    assert portfolio.positions["AAA"].qty == pytest.approx(1_000.0, rel=1e-9)
+
+    # IOC: remainder cancelled — no continuation across bars.
+    assert order_book.all_pending() == []
+
+    follow_up = sim.process_bar(_bar("2024-01-03", price=100.0, volume=10_000_000))
+    assert follow_up.entry_fills == []
+
+
+def test_ioc_overrides_requeue_next_bar_policy() -> None:
+    """IOC + ``REQUEUE_NEXT_BAR`` → IOC overrides; no requeue.
+
+    Acceptance bullet 4 of #388. The strategy's ``unfilled_policy`` is
+    ignored for IOC; the engine forces a same-bar cancel of the
+    remainder.
+    """
+    sim, order_book, _portfolio = _make_simulator()
+    order_book.submit(
+        _entry_order(2_000, tif=TimeInForce.IOC, policy=UnfilledPolicy.REQUEUE_NEXT_BAR),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+    )
+
+    outcome = sim.process_bar(_bar("2024-01-02", price=100.0, volume=10_000))
+
+    assert outcome.entry_fills[0].fill_kind == FillKind.PARTIAL
+    # No requeue despite REQUEUE_NEXT_BAR — IOC dominates.
+    assert order_book.all_pending() == []

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -166,7 +166,23 @@ class FillSimulator:
                 # outcome, then drop. Reference price is unavailable
                 # here (terms is None), so report the bar's close as a
                 # cosmetic price field — no money math is performed.
+                #
+                # Same-side add-on against an open position is suppressed
+                # exactly as it is on the triggered path (silent remove,
+                # no Fill emitted) so behaviour stays symmetric. IOC/FOK
+                # still demands cancel-this-bar — the order is removed
+                # so it doesn't linger as a stealth DAY/GTC — but no
+                # synthetic Fill is emitted, matching the triggered
+                # same-side suppression at the dispatch site below.
+                is_same_side_addon = (
+                    existing_pos is not None
+                    and not is_partial_entry_continuation
+                    and req.side == existing_pos.side
+                )
                 if req.tif in (TimeInForce.IOC, TimeInForce.FOK):
+                    if is_same_side_addon:
+                        self.order_book.remove(po.order_id)
+                        continue
                     dp = 4 if bar.close < 10 else 2
                     rejected = Fill(
                         order_id=po.order_id,

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -24,7 +24,7 @@ from typing import List, Optional
 from ...execution.bar_safety import BarSafetyAssertion
 from ...execution.risk_filter import RiskFilter
 from ...models import TradeRecord
-from ..strategy.contract import Bar, Fill, FillKind, OrderSide, UnfilledPolicy
+from ..strategy.contract import Bar, Fill, FillKind, OrderSide, TimeInForce, UnfilledPolicy
 from .execution_model import ExecutionModel, FillTerms, OptimisticExecutionModel
 from .order_book import OrderBook, PendingOrder
 from .portfolio import Portfolio, Position
@@ -136,6 +136,21 @@ class FillSimulator:
                     self.order_book.remove(po.order_id)
                     continue
 
+            # Routing flags computed up-front so the IOC/FOK reject
+            # branches below can place their REJECTED Fill into the
+            # correct outcome list without re-deriving the dispatch.
+            is_partial_entry_continuation = (
+                existing_pos is not None
+                and existing_pos.entry_order_id == po.order_id
+                and po.cumulative_filled_qty > 0
+            )
+            is_entry = (
+                not is_partial_entry_continuation
+                and existing_pos is None
+                and req.side in (OrderSide.LONG, OrderSide.SHORT)
+            )
+            is_entry_side = is_entry or is_partial_entry_continuation
+
             # Determine whether this bar triggered the order and at what
             # terms (price, partial-fill fraction, adverse-selection
             # haircut). The execution model encapsulates the (model-
@@ -143,6 +158,32 @@ class FillSimulator:
             # owned below.
             terms = self.execution_model.compute_fill_terms(req, bar, next_bar)
             if terms is None:
+                # IOC / FOK semantics demand cancel-on-this-bar when the
+                # order doesn't trigger (e.g. a LIMIT IOC whose limit
+                # price didn't cross). Without this branch they would
+                # silently behave like DAY/GTC and stay alive across
+                # bars. Emit a REJECTED Fill so the strategy sees the
+                # outcome, then drop. Reference price is unavailable
+                # here (terms is None), so report the bar's close as a
+                # cosmetic price field — no money math is performed.
+                if req.tif in (TimeInForce.IOC, TimeInForce.FOK):
+                    dp = 4 if bar.close < 10 else 2
+                    rejected = Fill(
+                        order_id=po.order_id,
+                        client_order_id=req.client_order_id,
+                        symbol=req.symbol,
+                        side=req.side,
+                        qty=0.0,
+                        price=round(bar.close, dp),
+                        timestamp=bar.timestamp,
+                        reason=f"rejected_{req.tif.value}_no_trigger",
+                        fill_kind=FillKind.REJECTED,
+                        unfilled_qty=po.remaining_qty,
+                        cumulative_filled_qty=po.cumulative_filled_qty,
+                    )
+                    (entry_fills if is_entry_side else exit_fills).append(rejected)
+                    self.order_book.remove(po.order_id)
+                    continue
                 # ``TWAP_N`` orders consume a slice on every elapsed bar,
                 # not only on bars where the execution model triggers a
                 # fill. Without this, a ``LIMIT``/``STOP`` TWAP order
@@ -178,26 +219,48 @@ class FillSimulator:
                 fill_bar_timestamp=bar.timestamp,
             )
 
-            # ``existing_pos`` already fetched above for the stale-
-            # continuation guard; reuse it. Within a single iteration
-            # of this loop no other order has run, so portfolio state
-            # hasn't changed since the early lookup.
-
-            # Partial-entry continuation (#386): a requeued partial entry has
-            # ``cumulative_filled_qty > 0`` and an existing position whose
-            # ``entry_order_id`` matches this pending order. Without this
-            # branch the requeued order would hit the same-side-as-position
-            # guard below and get silently removed.
-            is_partial_entry_continuation = (
+            # FOK pre-check (before money math): a FOK order must fill its
+            # entire requested qty on this bar or reject outright. Two
+            # ways the bar can fail it:
+            #   (a) participation cap clips ``terms.qty_fraction`` < 1.0.
+            #   (b) on the exit path, the strategy asked for more shares
+            #       than the position currently holds — ``_fill_exit``
+            #       would otherwise clip via ``min(target_qty, pos.qty)``
+            #       and produce a PARTIAL despite ``qty_fraction == 1.0``.
+            # Same-side add-ons against an open position fall through to
+            # the existing silent suppression below; FOK doesn't change
+            # that path because the order never had a chance to fill.
+            if req.tif == TimeInForce.FOK and not (
                 existing_pos is not None
-                and existing_pos.entry_order_id == po.order_id
-                and po.cumulative_filled_qty > 0
-            )
-            is_entry = (
-                not is_partial_entry_continuation
-                and existing_pos is None
-                and req.side in (OrderSide.LONG, OrderSide.SHORT)
-            )
+                and not is_partial_entry_continuation
+                and req.side == existing_pos.side
+            ):
+                fok_partial = terms.qty_fraction < 1.0
+                if (
+                    not is_entry_side
+                    and existing_pos is not None
+                    and req.side != existing_pos.side
+                    and po.remaining_qty > existing_pos.qty
+                ):
+                    fok_partial = True
+                if fok_partial:
+                    dp = 4 if terms.reference_price < 10 else 2
+                    rejected = Fill(
+                        order_id=po.order_id,
+                        client_order_id=req.client_order_id,
+                        symbol=req.symbol,
+                        side=req.side,
+                        qty=0.0,
+                        price=round(terms.reference_price, dp),
+                        timestamp=bar.timestamp,
+                        reason="rejected_fok_partial",
+                        fill_kind=FillKind.REJECTED,
+                        unfilled_qty=req.qty,
+                        cumulative_filled_qty=po.cumulative_filled_qty,
+                    )
+                    (entry_fills if is_entry_side else exit_fills).append(rejected)
+                    self.order_book.remove(po.order_id)
+                    continue
 
             if is_partial_entry_continuation:
                 fill = self._continue_entry(po, bar, terms)
@@ -586,6 +649,14 @@ class FillSimulator:
         (``_fill_entry`` with ``filled_qty <= 0``) the caller passes
         ``False`` since no position has opened.
         """
+        # IOC override: the order's remainder is cancelled regardless of
+        # ``unfilled_policy`` (#388). The partial Fill that triggered
+        # this handler is already on the wire with ``fill_kind=PARTIAL``
+        # and ``unfilled_qty>0`` — the override only affects requeue vs
+        # drop, not the Fill itself.
+        if po.request.tif == TimeInForce.IOC and unfilled > 0:
+            self.order_book.remove(po.order_id, was_filled=was_filled)
+            return
         policy = po.request.unfilled_policy or UnfilledPolicy.DROP
         if unfilled > 0 and policy == UnfilledPolicy.REQUEUE_NEXT_BAR:
             self.order_book.requeue(
@@ -808,6 +879,13 @@ class FillSimulator:
         at fill-time, not submission), so accepting TWAP_N for any order
         means honoring it on both sides.
         """
+        # IOC override: the order's remainder is cancelled regardless of
+        # ``unfilled_policy`` (#388). Symmetric with the entry-side
+        # handler — the partial exit Fill is already emitted with
+        # ``fill_kind=PARTIAL`` so the strategy sees the unfilled qty.
+        if po.request.tif == TimeInForce.IOC and unfilled > 0:
+            self.order_book.remove(po.order_id)
+            return
         policy = po.request.unfilled_policy or UnfilledPolicy.DROP
         if unfilled > 0 and policy == UnfilledPolicy.REQUEUE_NEXT_BAR:
             self.order_book.requeue(

--- a/backend/agents/investment_team/trading_service/strategy/contract.py
+++ b/backend/agents/investment_team/trading_service/strategy/contract.py
@@ -161,11 +161,6 @@ class OrderRequest(BaseModel):
                 "trailing_stop is not yet supported by the execution engine; "
                 "see #390 (Trading 5/5 Step 8) for runtime support"
             )
-        if self.tif in (TimeInForce.IOC, TimeInForce.FOK):
-            raise UnsupportedOrderFeatureError(
-                f"{self.tif.value} time-in-force is not yet supported by the execution engine; "
-                "see #388 (Trading 5/5 Step 6) for runtime support"
-            )
         if self.attached_stop_loss is not None or self.attached_take_profit is not None:
             raise UnsupportedOrderFeatureError(
                 "attached_stop_loss / attached_take_profit are not yet materialized "


### PR DESCRIPTION
Closes #388.

## Summary

Lifts the runtime gate on `tif=IOC|FOK` and teaches the fill simulator
to honour both:

- **FOK pre-check (before money math).** If the bar can't fully absorb
  the order — either `terms.qty_fraction < 1.0`, or on the exit side
  `req.qty > pos.qty` — emit `Fill(fill_kind=REJECTED, qty=0,
  unfilled_qty=req.qty)` with `reason="rejected_fok_partial"`,
  `order_book.remove`, no money math, no requeue. FOK orders that *can*
  fully fill go through the existing FULL path unchanged.
- **IOC remainder override.** When an IOC order has any unfilled
  remainder after the bar's fill attempt, the remainder is cancelled
  regardless of `unfilled_policy` (including `REQUEUE_NEXT_BAR`). The
  partial Fill itself still emits with `fill_kind=PARTIAL` and
  `unfilled_qty>0` so the strategy sees what filled. Implemented at the
  top of `_handle_entry_remainder` and `_handle_exit_remainder` so
  every code path that reaches a remainder decision (zero-fill initial,
  zero-fill continuation, partial fill) is covered.
- **No-trigger IOC/FOK (LIMIT).** A LIMIT IOC/FOK that doesn't cross
  on this bar is cancelled with a REJECTED Fill
  (`reason="rejected_<tif>_no_trigger"`) so it doesn't silently behave
  like DAY/GTC.
- **Same-side add-on path** falls through to the existing silent
  suppression in `process_bar` — FOK doesn't change that path because
  the order never had a chance to fill regardless of TIF.

The contract-level `IOC/FOK is not yet supported` gate at
`OrderRequest.validate_prices` is removed; the shape-consistency check
("IOC/FOK only valid with market or limit orders") stays. The
matching tests in `test_contract_gates.py` and `test_order_book.py`
are deleted, and `test_default_market_order_still_validates` is
extended to cover `IOC` and `FOK` (MARKET + LIMIT).

DAY/GTC behaviour and golden parity are unchanged.

## Files

- `backend/agents/investment_team/trading_service/strategy/contract.py`
  — drop the IOC/FOK gate.
- `backend/agents/investment_team/trading_service/engine/fill_simulator.py`
  — `TimeInForce` import, FOK pre-check + IOC no-trigger + IOC remainder
  override.
- `backend/agents/investment_team/tests/test_contract_gates.py` — drop
  obsolete gate tests; extend the IOC/FOK validates-OK coverage.
- `backend/agents/investment_team/tests/test_order_book.py` — drop the
  obsolete `test_submit_attached_rejects_ioc_child`; refresh the
  block comment.
- `backend/agents/investment_team/tests/test_tif.py` — **new**, four
  tests covering the issue's acceptance bullets.

## Test plan

- [x] `pytest agents/investment_team/tests/test_tif.py` — 4/4 pass
- [x] `pytest agents/investment_team/tests/test_partial_fills.py` —
      DAY/GTC paths unchanged (31/31 pass)
- [x] `pytest agents/investment_team/tests/test_contract_gates.py` —
      surviving gates still fire (8/8 pass)
- [x] `pytest agents/investment_team/tests/test_order_book.py` — pass
- [x] `pytest agents/investment_team/tests/golden/` — golden parity
      preserved
- [x] `ruff check` + `ruff format --check` clean on all modified files

https://claude.ai/code/session_01CRhzGsmX77q9YRYeaQHUiw

---
_Generated by [Claude Code](https://claude.ai/code/session_01CRhzGsmX77q9YRYeaQHUiw)_