### PR TITLE
Instrument TradingService order lifecycle diagnostics (#409)

### DIFF
--- a/backend/agents/investment_team/tests/test_trading_service.py
+++ b/backend/agents/investment_team/tests/test_trading_service.py
@@ -29,6 +29,7 @@ from investment_team.trading_service.data_stream.protocol import BarEvent, EndOf
 from investment_team.trading_service.engine.order_book import OrderBook
 from investment_team.trading_service.modes.backtest import run_backtest
 from investment_team.trading_service.service import (
+    _MAX_ORDER_EVENTS,
     TradingService,
     _increment_rejection,
     _record_event,
@@ -258,13 +259,13 @@ def test_trading_service_surfaces_lookahead_violation() -> None:
     assert diagnostics.summary
 
 
-def test_zero_trade_result_gets_unknown_diagnostics_until_order_counters_are_instrumented() -> None:
-    """A no-op strategy gets a deterministic #408 zero-trade category."""
+def test_zero_trade_result_gets_no_orders_emitted_category() -> None:
+    """A no-op strategy lands in NO_ORDERS_EMITTED with zeroed counters (#409)."""
     market_data: Dict[str, List[OHLCVBar]] = {}
     _uptrend_then_down_bars(market_data)
 
     strategy = StrategySpec(
-        strategy_id="strat-noop-408",
+        strategy_id="strat-noop-409",
         authored_by="tests",
         asset_class="equity",
         hypothesis="no-op",
@@ -279,10 +280,14 @@ def test_zero_trade_result_gets_unknown_diagnostics_until_order_counters_are_ins
     assert run.service_result.error is None, run.service_result.error
     assert not run.trades
     diagnostics = run.service_result.execution_diagnostics
-    assert diagnostics.zero_trade_category == "UNKNOWN_ZERO_TRADE_PATH"
+    assert diagnostics.zero_trade_category == "NO_ORDERS_EMITTED"
     assert diagnostics.closed_trades == 0
+    assert diagnostics.orders_emitted == 0
+    assert diagnostics.orders_accepted == 0
+    assert diagnostics.orders_rejected == 0
+    assert diagnostics.orders_unfilled == 0
+    assert diagnostics.last_order_events == []
     assert diagnostics.bars_processed == run.service_result.bars_processed
-    assert "not instrumented yet" in diagnostics.summary
 
 
 def test_warmup_only_order_result_gets_warmup_diagnostics() -> None:
@@ -380,6 +385,384 @@ def test_execution_diagnostic_helpers_cap_events_and_count_rejections() -> None:
         "malformed_request": 2,
         "unknown": 1,
     }
+
+
+# ---------------------------------------------------------------------------
+# Issue #409 — TradingService order lifecycle diagnostics
+# ---------------------------------------------------------------------------
+
+
+_UNSUPPORTED_FEATURE_STRATEGY_CODE = textwrap.dedent('''\
+    """Strategy that bypasses ``submit_order``'s subprocess-side validation
+    to exercise the parent's ``UnsupportedOrderFeatureError`` rejection
+    path. Sets ``parent_order_id``, which still raises in the parent's
+    ``OrderRequest.validate_prices`` until #389 lands.
+    """
+    from contract import Strategy
+
+
+    class UnsupportedFeatureStrategy(Strategy):
+        _emitted = False
+
+        def on_bar(self, ctx, bar):
+            if self._emitted:
+                return
+            self._emitted = True
+            ctx._next_client_order_id += 1
+            cid = f"c{ctx._next_client_order_id}"
+            ctx._emit({
+                "kind": "order",
+                "payload": {
+                    "client_order_id": cid,
+                    "symbol": bar.symbol,
+                    "side": "long",
+                    "qty": 1.0,
+                    "order_type": "market",
+                    "tif": "day",
+                    "parent_order_id": "fake-parent",
+                },
+            })
+''')
+
+
+_MALFORMED_ORDER_STRATEGY_CODE = textwrap.dedent('''\
+    """Strategy that bypasses ``submit_order`` and emits a payload missing
+    required fields, exercising the parent's malformed-request rejection.
+    """
+    from contract import Strategy
+
+
+    class MalformedOrderStrategy(Strategy):
+        _emitted = False
+
+        def on_bar(self, ctx, bar):
+            if self._emitted:
+                return
+            self._emitted = True
+            # Missing client_order_id, symbol, side, qty — Pydantic must reject.
+            ctx._emit({"kind": "order", "payload": {"order_type": "market"}})
+''')
+
+
+_UNREACHABLE_LIMIT_STRATEGY_CODE = textwrap.dedent('''\
+    """Strategy that submits a single DAY limit order with an unreachable
+    price on the first bar so it survives the next bar's fill check and
+    is expired on the date roll-over.
+    """
+    from contract import OrderSide, OrderType, Strategy
+
+
+    class UnreachableLimitStrategy(Strategy):
+        _emitted = False
+
+        def on_bar(self, ctx, bar):
+            if self._emitted:
+                return
+            self._emitted = True
+            ctx.submit_order(
+                symbol=bar.symbol,
+                side=OrderSide.LONG,
+                qty=1,
+                order_type=OrderType.LIMIT,
+                limit_price=0.01,  # far below market — never fills
+                tif="day",
+                reason="day_expiry_probe",
+            )
+''')
+
+
+_LATE_MARKET_ORDER_STRATEGY_CODE = textwrap.dedent('''\
+    """Strategy that submits a market order on every bar so the very
+    last bar's order has no successor bar to fill against, exercising
+    the end-of-stream unfilled path.
+    """
+    from contract import OrderSide, OrderType, Strategy
+
+
+    class LateMarketStrategy(Strategy):
+        def on_bar(self, ctx, bar):
+            if ctx.position(bar.symbol) is not None:
+                return
+            ctx.submit_order(
+                symbol=bar.symbol,
+                side=OrderSide.LONG,
+                qty=1,
+                order_type=OrderType.MARKET,
+                reason="late_emit",
+            )
+''')
+
+
+_NOISY_ORDER_STRATEGY_CODE = textwrap.dedent('''\
+    """Strategy that emits a fresh long order every bar (each bar gets a
+    rejected order because there's already a position). Used to overflow
+    the 20-event ``last_order_events`` cap.
+    """
+    from contract import OrderSide, OrderType, Strategy
+
+
+    class NoisyOrderStrategy(Strategy):
+        def on_bar(self, ctx, bar):
+            ctx.submit_order(
+                symbol=bar.symbol,
+                side=OrderSide.LONG,
+                qty=1,
+                order_type=OrderType.MARKET,
+                reason="noise",
+            )
+''')
+
+
+def _two_day_bars() -> List[BarEvent]:
+    """Two bars on consecutive trading dates, both well above any limit at $0.01.
+
+    Used by the DAY-expiry test: bar 0 lets the strategy emit; bar 1 is on
+    the same day so the limit order fails to fill; bar 2 is on day 2 and
+    fires ``expire_day_orders``.
+    """
+    return [
+        BarEvent(
+            bar=Bar(
+                symbol="AAA",
+                timestamp="2024-01-02",
+                open=100.0,
+                high=101.0,
+                low=99.0,
+                close=100.0,
+                volume=1_000_000,
+            ),
+            is_warmup=False,
+        ),
+        BarEvent(
+            bar=Bar(
+                symbol="AAA",
+                timestamp="2024-01-02T16:00:00",
+                open=100.0,
+                high=101.0,
+                low=99.0,
+                close=100.0,
+                volume=1_000_000,
+            ),
+            is_warmup=False,
+        ),
+        BarEvent(
+            bar=Bar(
+                symbol="AAA",
+                timestamp="2024-01-03",
+                open=100.0,
+                high=101.0,
+                low=99.0,
+                close=100.0,
+                volume=1_000_000,
+            ),
+            is_warmup=False,
+        ),
+        EndOfStreamEvent(),
+    ]
+
+
+def test_diagnostics_emitted_and_accepted_counts_round_trip() -> None:
+    """SMA round-trip: 2 emits, 2 accepts, 1 exit-emit, no rejections."""
+    market_data: Dict[str, List[OHLCVBar]] = {}
+    _uptrend_then_down_bars(market_data)
+
+    strategy = StrategySpec(
+        strategy_id="strat-409-sma",
+        authored_by="tests",
+        asset_class="equity",
+        hypothesis="round-trip",
+        signal_definition="sma",
+        entry_rules=["close > sma(5)"],
+        exit_rules=["close < sma(5)"],
+        strategy_code=_SMA_STRATEGY_CODE,
+    )
+
+    run = run_backtest(strategy=strategy, config=_config(), market_data=market_data)
+    diagnostics = run.service_result.execution_diagnostics
+
+    assert run.service_result.error is None, run.service_result.error
+    # SMA(5) crossover emits one long entry then one opposite-side close.
+    assert diagnostics.orders_emitted == 2
+    assert diagnostics.orders_accepted == 2
+    assert diagnostics.orders_rejected == 0
+    assert diagnostics.orders_unfilled == 0
+    assert diagnostics.exits_emitted == 1
+    # ``entries_filled`` is owned by #410 (FillSimulator) and must stay 0
+    # at this layer until that issue lands.
+    assert diagnostics.entries_filled == 0
+    # Capped well under the limit for this fixture.
+    assert len(diagnostics.last_order_events) <= _MAX_ORDER_EVENTS
+    event_types = [e.event_type for e in diagnostics.last_order_events]
+    assert "emitted" in event_types
+    assert "accepted" in event_types
+
+
+def test_diagnostics_unsupported_feature_records_rejection() -> None:
+    """``parent_order_id`` is gated until #389; counts as unsupported_feature."""
+    market_data: Dict[str, List[OHLCVBar]] = {}
+    _uptrend_then_down_bars(market_data)
+
+    strategy = StrategySpec(
+        strategy_id="strat-409-unsupported",
+        authored_by="tests",
+        asset_class="equity",
+        hypothesis="unsupported feature",
+        signal_definition="parent_order_id",
+        entry_rules=[],
+        exit_rules=[],
+        strategy_code=_UNSUPPORTED_FEATURE_STRATEGY_CODE,
+    )
+
+    run = run_backtest(strategy=strategy, config=_config(), market_data=market_data)
+    diagnostics = run.service_result.execution_diagnostics
+
+    # The unsupported feature aborts the run via StrategyRuntimeError, so
+    # error is set and the unknown category preserves the abort signal.
+    assert run.service_result.error is not None
+    assert "unsupported" in run.service_result.error.lower()
+    assert diagnostics.zero_trade_category == "UNKNOWN_ZERO_TRADE_PATH"
+    # Counters captured before the abort still record the rejection.
+    assert diagnostics.orders_emitted == 1
+    assert diagnostics.orders_rejected == 1
+    assert diagnostics.orders_rejection_reasons == {"unsupported_feature": 1}
+    rejected_events = [e for e in diagnostics.last_order_events if e.event_type == "rejected"]
+    assert len(rejected_events) == 1
+    assert rejected_events[0].reason == "unsupported_feature"
+
+
+def test_diagnostics_malformed_order_records_rejection_and_continues() -> None:
+    """A bad payload is rejected as malformed_request without aborting the run."""
+    market_data: Dict[str, List[OHLCVBar]] = {}
+    _uptrend_then_down_bars(market_data)
+
+    strategy = StrategySpec(
+        strategy_id="strat-409-malformed",
+        authored_by="tests",
+        asset_class="equity",
+        hypothesis="malformed payload",
+        signal_definition="missing fields",
+        entry_rules=[],
+        exit_rules=[],
+        strategy_code=_MALFORMED_ORDER_STRATEGY_CODE,
+    )
+
+    run = run_backtest(strategy=strategy, config=_config(), market_data=market_data)
+    diagnostics = run.service_result.execution_diagnostics
+
+    # Run completes despite the malformed order (matching pre-#409 behavior).
+    assert run.service_result.error is None, run.service_result.error
+    assert diagnostics.orders_emitted == 1
+    assert diagnostics.orders_accepted == 0
+    assert diagnostics.orders_rejected == 1
+    assert diagnostics.orders_rejection_reasons == {"malformed_request": 1}
+    assert diagnostics.zero_trade_category == "ORDERS_REJECTED"
+    rejected_events = [e for e in diagnostics.last_order_events if e.event_type == "rejected"]
+    assert len(rejected_events) == 1
+    assert rejected_events[0].reason == "malformed_request"
+
+
+def test_diagnostics_day_order_expiry_records_unfilled() -> None:
+    """A DAY limit at an unreachable price expires on the next-day bar."""
+    service = TradingService(strategy_code=_UNREACHABLE_LIMIT_STRATEGY_CODE, config=_config())
+
+    result = service.run(_two_day_bars())
+    diagnostics = result.execution_diagnostics
+
+    assert result.error is None, result.error
+    assert diagnostics.orders_emitted == 1
+    assert diagnostics.orders_accepted == 1
+    assert diagnostics.orders_unfilled >= 1
+    unfilled_events = [e for e in diagnostics.last_order_events if e.event_type == "unfilled"]
+    reasons = {e.reason for e in unfilled_events}
+    assert "day_expired" in reasons
+    assert diagnostics.zero_trade_category == "ORDERS_UNFILLED"
+
+
+def test_diagnostics_end_of_stream_unfilled_recorded() -> None:
+    """An order emitted on the last bar has no next bar; counts as unfilled."""
+    market_data: Dict[str, List[OHLCVBar]] = {}
+    # 5 bars is enough; LateMarketStrategy emits on every bar but only
+    # the *first* survives unmatched to the end (subsequent emissions are
+    # short-circuited once a position opens). With no future bar after
+    # the last bar, the queued order falls into the end-of-stream sink.
+    _uptrend_then_down_bars(market_data)
+    market_data["AAA"] = market_data["AAA"][:1]
+
+    strategy = StrategySpec(
+        strategy_id="strat-409-eos",
+        authored_by="tests",
+        asset_class="equity",
+        hypothesis="end-of-stream",
+        signal_definition="late market",
+        entry_rules=[],
+        exit_rules=[],
+        strategy_code=_LATE_MARKET_ORDER_STRATEGY_CODE,
+    )
+
+    run = run_backtest(strategy=strategy, config=_config(), market_data=market_data)
+    diagnostics = run.service_result.execution_diagnostics
+
+    assert run.service_result.error is None, run.service_result.error
+    assert diagnostics.orders_emitted >= 1
+    assert diagnostics.orders_unfilled >= 1
+    unfilled_events = [e for e in diagnostics.last_order_events if e.event_type == "unfilled"]
+    reasons = {e.reason for e in unfilled_events}
+    assert "end_of_stream" in reasons
+
+
+def test_diagnostics_warmup_dropped_emits_lifecycle_event() -> None:
+    """Warm-up orders increment the counter *and* surface a lifecycle event."""
+    service = TradingService(strategy_code=_WARMUP_ORDER_STRATEGY_CODE, config=_config())
+    stream = [
+        BarEvent(
+            bar=Bar(
+                symbol="AAA",
+                timestamp="2024-01-01",
+                open=100.0,
+                high=101.0,
+                low=99.0,
+                close=100.0,
+                volume=1_000_000,
+            ),
+            is_warmup=True,
+        ),
+        EndOfStreamEvent(),
+    ]
+
+    result = service.run(stream)
+    diagnostics = result.execution_diagnostics
+
+    assert result.error is None, result.error
+    assert diagnostics.warmup_orders_dropped == 1
+    warmup_events = [e for e in diagnostics.last_order_events if e.event_type == "warmup_dropped"]
+    assert len(warmup_events) == 1
+    assert warmup_events[0].symbol == "AAA"
+    # Warm-up emissions never reach the post-warmup ``orders_emitted`` counter.
+    assert diagnostics.orders_emitted == 0
+
+
+def test_diagnostics_last_order_events_capped_at_twenty() -> None:
+    """A noisy strategy emits >20 orders; ``last_order_events`` stays at 20."""
+    market_data: Dict[str, List[OHLCVBar]] = {}
+    _uptrend_then_down_bars(market_data)
+
+    strategy = StrategySpec(
+        strategy_id="strat-409-noisy",
+        authored_by="tests",
+        asset_class="equity",
+        hypothesis="noisy",
+        signal_definition="emit every bar",
+        entry_rules=[],
+        exit_rules=[],
+        strategy_code=_NOISY_ORDER_STRATEGY_CODE,
+    )
+
+    run = run_backtest(strategy=strategy, config=_config(), market_data=market_data)
+    diagnostics = run.service_result.execution_diagnostics
+
+    # 30 bars of fixture × at least one event per bar > 20.
+    assert diagnostics.orders_emitted >= 25
+    assert len(diagnostics.last_order_events) == _MAX_ORDER_EVENTS
 
 
 def test_run_backtest_without_strategy_code_raises() -> None:

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -124,18 +124,65 @@ def _finalize_diagnostics(result: TradingServiceResult) -> TradingServiceResult:
             f"Backtest closed {diagnostics.closed_trades} trade(s) "
             f"across {diagnostics.bars_processed} post-warmup bar(s)."
         )
-    elif diagnostics.warmup_orders_dropped > 0:
+        return result
+
+    # An aborted run (subprocess crash, look-ahead violation, etc.) doesn't
+    # let the lifecycle counters speak for the strategy's intent — preserve
+    # the unknown category so callers don't misread a partial counter set
+    # as a clean zero-trade signal. Refinement-loop callers see the
+    # ``error``/``lookahead_violation`` fields on ``TradingServiceResult``
+    # for the actual failure mode.
+    if result.error is not None:
+        diagnostics.zero_trade_category = "UNKNOWN_ZERO_TRADE_PATH"
+        diagnostics.summary = f"Backtest aborted before completion: {result.error}"
+        return result
+
+    # Zero-trade categorisation. Counters populated by the run loop drive the
+    # category; the precedence below mirrors the order in which the failure
+    # would manifest along the strategy → submit → fill path.
+    if diagnostics.orders_emitted == 0 and diagnostics.warmup_orders_dropped > 0:
         diagnostics.zero_trade_category = "ONLY_WARMUP_ORDERS"
         diagnostics.summary = (
             f"Backtest closed zero trades; dropped {diagnostics.warmup_orders_dropped} "
             f"warm-up order(s) across {diagnostics.bars_processed} post-warmup bar(s)."
         )
+    elif diagnostics.orders_emitted == 0:
+        diagnostics.zero_trade_category = "NO_ORDERS_EMITTED"
+        diagnostics.summary = (
+            f"Backtest closed zero trades; strategy emitted no orders across "
+            f"{diagnostics.bars_processed} post-warmup bar(s)."
+        )
+    elif diagnostics.orders_rejected > 0 and diagnostics.orders_accepted == 0:
+        reasons = ", ".join(
+            f"{k}={v}" for k, v in sorted(diagnostics.orders_rejection_reasons.items())
+        )
+        diagnostics.zero_trade_category = "ORDERS_REJECTED"
+        diagnostics.summary = (
+            f"Backtest closed zero trades; all {diagnostics.orders_rejected} emitted "
+            f"order(s) were rejected ({reasons or 'unknown'})."
+        )
+    elif diagnostics.orders_unfilled > 0 and diagnostics.entries_filled == 0:
+        diagnostics.zero_trade_category = "ORDERS_UNFILLED"
+        diagnostics.summary = (
+            f"Backtest closed zero trades; {diagnostics.orders_unfilled} order(s) "
+            "left unfilled with no entry fills recorded."
+        )
+    elif diagnostics.entries_filled > 0 and diagnostics.exits_emitted == 0:
+        diagnostics.zero_trade_category = "ENTRY_WITH_NO_EXIT"
+        diagnostics.summary = (
+            f"Backtest closed zero trades; {diagnostics.entries_filled} entr(ies) "
+            "filled but the strategy never emitted an exit order."
+        )
     else:
         diagnostics.zero_trade_category = "UNKNOWN_ZERO_TRADE_PATH"
         diagnostics.summary = (
             f"Backtest closed zero trades across {diagnostics.bars_processed} "
-            "post-warmup bar(s). "
-            "Full order lifecycle counters are not instrumented yet."
+            f"post-warmup bar(s); counters: emitted={diagnostics.orders_emitted}, "
+            f"accepted={diagnostics.orders_accepted}, "
+            f"rejected={diagnostics.orders_rejected}, "
+            f"unfilled={diagnostics.orders_unfilled}, "
+            f"entries_filled={diagnostics.entries_filled}, "
+            f"exits_emitted={diagnostics.exits_emitted}."
         )
 
     return result
@@ -266,7 +313,19 @@ class TradingService:
                         if prev_bar is not None and (
                             cur_bar.timestamp[:10] != prev_bar.timestamp[:10]
                         ):
-                            order_book.expire_day_orders(cur_bar.timestamp)
+                            expired = order_book.expire_day_orders(cur_bar.timestamp)
+                            if expired:
+                                result.execution_diagnostics.orders_unfilled += len(expired)
+                                for ex in expired:
+                                    _record_event(
+                                        result.execution_diagnostics,
+                                        "unfilled",
+                                        timestamp=cur_bar.timestamp,
+                                        symbol=ex.request.symbol,
+                                        side=ex.request.side.value,
+                                        order_type=ex.request.order_type.value,
+                                        reason="day_expired",
+                                    )
 
                         # 2) Fill any orders from the previous iteration against
                         #    *this* (current) bar. These were submitted by the
@@ -288,6 +347,15 @@ class TradingService:
                                     req,
                                     submitted_at=prev_bar.timestamp,
                                     submitted_equity=equity,
+                                )
+                                result.execution_diagnostics.orders_accepted += 1
+                                _record_event(
+                                    result.execution_diagnostics,
+                                    "accepted",
+                                    timestamp=prev_bar.timestamp,
+                                    symbol=req.symbol,
+                                    side=req.side.value,
+                                    order_type=req.order_type.value,
                                 )
                             pending_for_prev = []
 
@@ -337,6 +405,15 @@ class TradingService:
                                 "dropped %d order(s) submitted during warm-up bar",
                                 len(resp.orders),
                             )
+                            for o in resp.orders:
+                                _record_event(
+                                    result.execution_diagnostics,
+                                    "warmup_dropped",
+                                    timestamp=cur_bar.timestamp,
+                                    symbol=o.get("symbol"),
+                                    side=o.get("side"),
+                                    order_type=o.get("order_type"),
+                                )
                         # Cancels during warm-up are also no-ops (no live order book).
                         prev_bar = cur_bar
                         continue
@@ -350,10 +427,27 @@ class TradingService:
                     # Orders submitted now are evaluated against the *next*
                     # bar (look-ahead-safe).
                     for o in resp.orders:
+                        result.execution_diagnostics.orders_emitted += 1
+                        _record_event(
+                            result.execution_diagnostics,
+                            "emitted",
+                            timestamp=cur_bar.timestamp,
+                            symbol=o.get("symbol"),
+                            side=o.get("side"),
+                            order_type=o.get("order_type"),
+                        )
                         try:
                             req = OrderRequest(**o)
                             req.validate_prices()
                             pending_for_prev.append(req)
+                            # An opposite-side order against an existing open
+                            # position is the strategy's exit intent. Counted
+                            # here (parent-side, before fill) so the diagnostic
+                            # reflects emission, not execution; #410 owns the
+                            # fill-side ``exit_filled`` event.
+                            held = portfolio.positions.get(req.symbol)
+                            if held is not None and held.side != req.side:
+                                result.execution_diagnostics.exits_emitted += 1
                         except UnsupportedOrderFeatureError as exc:
                             # Runtime-support gates from validate_prices ("feature
                             # ships in a later step of #379") must terminate the
@@ -364,12 +458,36 @@ class TradingService:
                             # subclass keeps unrelated ``NotImplementedError``s
                             # from strategy code in the generic catch below.
                             # See #383.
+                            _increment_rejection(
+                                result.execution_diagnostics, "unsupported_feature"
+                            )
+                            _record_event(
+                                result.execution_diagnostics,
+                                "rejected",
+                                timestamp=cur_bar.timestamp,
+                                symbol=o.get("symbol"),
+                                side=o.get("side"),
+                                order_type=o.get("order_type"),
+                                reason="unsupported_feature",
+                                detail=str(exc),
+                            )
                             raise StrategyRuntimeError(
                                 f"strategy emitted an unsupported order: {exc}",
                                 etype="unsupported_feature",
                             ) from exc
                         except Exception as exc:  # malformed request from strategy
                             logger.warning("dropping malformed order from strategy: %s", exc)
+                            _increment_rejection(result.execution_diagnostics, "malformed_request")
+                            _record_event(
+                                result.execution_diagnostics,
+                                "rejected",
+                                timestamp=cur_bar.timestamp,
+                                symbol=o.get("symbol"),
+                                side=o.get("side"),
+                                order_type=o.get("order_type"),
+                                reason="malformed_request",
+                                detail=str(exc),
+                            )
 
                     prev_bar = cur_bar
 
@@ -381,6 +499,18 @@ class TradingService:
                         "%d orders queued at end-of-stream with no next bar; dropped",
                         len(pending_for_prev),
                     )
+                    result.execution_diagnostics.orders_unfilled += len(pending_for_prev)
+                    last_ts = prev_bar.timestamp if prev_bar is not None else None
+                    for req in pending_for_prev:
+                        _record_event(
+                            result.execution_diagnostics,
+                            "unfilled",
+                            timestamp=last_ts,
+                            symbol=req.symbol,
+                            side=req.side.value,
+                            order_type=req.order_type.value,
+                            reason="end_of_stream",
+                        )
 
                 harness.send_end()
             except LookAheadError as exc:


### PR DESCRIPTION
## Summary

Closes the foundational sub-issue of #404. Wires the previously-stubbed
`BacktestExecutionDiagnostics` counters and `OrderLifecycleEvent`s
into `TradingService.run` so zero-trade backtests carry a structured
explanation of *why* — not just a generic "no trades produced".

The data model (`BacktestExecutionDiagnostics`, `OrderLifecycleEvent`,
`ZeroTradeCategory`, plus `_record_event` / `_increment_rejection`
helpers) was already in place from #408; this PR populates them.
Sub-issues #410–#414 layer on top.

### What's instrumented in `service.py`

| Counter / event | Trigger |
|---|---|
| `orders_emitted` + `emitted` event | Every non-warmup order the strategy submits |
| `orders_accepted` + `accepted` event | Each `OrderRequest` that survives parse + `validate_prices` and reaches `order_book.submit` |
| `orders_rejected` (`malformed_request`) + `rejected` event | Pydantic / shape failures from the strategy payload |
| `orders_rejected` (`unsupported_feature`) + `rejected` event | `UnsupportedOrderFeatureError` from `validate_prices` (recorded before re-raise) |
| `warmup_dropped` event | Each warm-up order (counter was already wired) |
| `orders_unfilled` (`day_expired`) + `unfilled` event | Each order returned by `order_book.expire_day_orders` on date roll-over |
| `orders_unfilled` (`end_of_stream`) + `unfilled` event | Orders queued for "next bar" when the stream ends |
| `exits_emitted` | Strategy submits an opposite-side order against an existing open position (parent-side detection; `exit_filled` from the fill simulator is #410's job) |

`last_order_events` stays capped at `_MAX_ORDER_EVENTS = 20` (already
enforced in `_record_event`).

### Zero-trade categorisation

`_finalize_diagnostics` now picks a real category from the counters:
`NO_ORDERS_EMITTED` / `ONLY_WARMUP_ORDERS` / `ORDERS_REJECTED` /
`ORDERS_UNFILLED` / `ENTRY_WITH_NO_EXIT`. Aborted runs (subprocess
crash, look-ahead violation, etc.) keep `UNKNOWN_ZERO_TRADE_PATH` so a
partial counter set isn't misread as a clean zero-trade signal — the
real failure is on `TradingServiceResult.error` /
`lookahead_violation`.

Existing execution behavior is unchanged — only diagnostics state moves.

### Out of scope (next sub-issues)

- `entries_filled` / `exit_filled` events from FillSimulator → #410
- `BacktestResult.execution_diagnostics` plumbing → #411
- `StrategyRunResult.diagnostics` plumbing → #412
- `BacktestAnomalyDetector` consuming the envelope → #413
- Refinement-prompt usage → #414

## Test plan

- [x] `pytest agents/investment_team/tests/test_trading_service.py` — 23 tests pass (7 new lifecycle-diagnostic tests + the existing no-op test updated to assert `NO_ORDERS_EMITTED`)
- [x] `pytest test_execution_diagnostics_models.py test_partial_fills.py test_order_book.py test_backtest_endpoint.py test_backtest_anomaly_dsr_aware.py` — 157 passed
- [x] `ruff check` and `ruff format --check` clean on touched files
- [ ] Manual Strategy Lab smoke run on a known zero-trade fixture to confirm the new `summary` text is more informative than "not instrumented yet"

Closes #409.

https://claude.ai/code/session_01VR7VqebWwtiAfttbTPSfDc

---
_Generated by [Claude Code](https://claude.ai/code/session_01VR7VqebWwtiAfttbTPSfDc)_