### PR TITLE
investment_team: zero-trade execution diagnostic models (#407)

### DIFF
--- a/backend/agents/investment_team/models.py
+++ b/backend/agents/investment_team/models.py
@@ -410,6 +410,91 @@ def get_fee_defaults(asset_class: str) -> dict[str, float]:
     )
 
 
+# Issue #407 / parent #404 — zero-trade execution diagnostics envelope.
+# Producers (issues #408–#410) populate counters and recent lifecycle events;
+# the anomaly detector (issue #413) classifies the run with ``ZeroTradeCategory``;
+# the refinement prompt (issue #414) consumes the envelope.
+
+
+class ZeroTradeCategory(str, Enum):
+    """Deterministic classification of why a backtest produced zero closed trades.
+
+    ``None`` on ``BacktestExecutionDiagnostics.zero_trade_category`` means the
+    run was not zero-trade.
+    """
+
+    NO_ORDERS_EMITTED = "no_orders_emitted"
+    ORDERS_REJECTED = "orders_rejected"
+    ORDERS_UNFILLED = "orders_unfilled"
+    ENTRY_WITH_NO_EXIT = "entry_with_no_exit"
+    ONLY_WARMUP_ORDERS = "only_warmup_orders"
+
+
+class OrderLifecycleEventType(str, Enum):
+    EMITTED = "emitted"
+    ACCEPTED = "accepted"
+    REJECTED = "rejected"
+    UNFILLED = "unfilled"
+    WARMUP_DROPPED = "warmup_dropped"
+    ENTRY_FILLED = "entry_filled"
+    EXIT_FILLED = "exit_filled"
+
+
+class OrderLifecycleEvent(BaseModel):
+    event_type: OrderLifecycleEventType
+    timestamp: str
+    symbol: Optional[str] = None
+    order_id: Optional[str] = None
+    side: Optional[str] = None
+    order_type: Optional[str] = None
+    quantity: Optional[float] = None
+    price: Optional[float] = None
+    reason: Optional[str] = None
+
+
+class OpenPositionDiagnostic(BaseModel):
+    symbol: str
+    quantity: float
+    entry_price: float
+    entry_date: str
+    bars_held: Optional[int] = None
+    unrealized_pnl: Optional[float] = None
+
+
+MAX_RECENT_ORDER_EVENTS: int = 50
+
+
+class BacktestExecutionDiagnostics(BaseModel):
+    """Structured execution diagnostics attached to a ``BacktestResult``.
+
+    Counters default to ``0`` and collections default empty so a producer can
+    construct the envelope once and increment in place. ``last_order_events``
+    is capped at :data:`MAX_RECENT_ORDER_EVENTS` (the tail is preserved).
+    """
+
+    bars_processed: int = 0
+    orders_emitted: int = 0
+    orders_accepted: int = 0
+    orders_rejected: int = 0
+    orders_unfilled: int = 0
+    warmup_orders_dropped: int = 0
+    entries_filled: int = 0
+    exits_emitted: int = 0
+    closed_trades: int = 0
+    orders_rejection_reasons: Dict[str, int] = Field(default_factory=dict)
+    last_order_events: List[OrderLifecycleEvent] = Field(default_factory=list)
+    open_positions_at_end: List[OpenPositionDiagnostic] = Field(default_factory=list)
+    zero_trade_category: Optional[ZeroTradeCategory] = None
+    summary: Optional[str] = None
+
+    @field_validator("last_order_events")
+    @classmethod
+    def _cap_last_order_events(cls, v: List[OrderLifecycleEvent]) -> List[OrderLifecycleEvent]:
+        if len(v) > MAX_RECENT_ORDER_EVENTS:
+            return v[-MAX_RECENT_ORDER_EVENTS:]
+        return v
+
+
 class BacktestResult(BaseModel):
     total_return_pct: float
     annualized_return_pct: float
@@ -449,6 +534,10 @@ class BacktestResult(BaseModel):
     acceptance_reason: Optional[str] = None
     regime_results: Optional[List[Dict[str, Any]]] = None
     fold_results: Optional[List[Dict[str, Any]]] = None
+    # Issue #407 / #404 — zero-trade execution diagnostics envelope. ``None`` on
+    # legacy persisted rows and on backtests that pre-date the producer wiring
+    # in issues #408–#410.
+    execution_diagnostics: Optional[BacktestExecutionDiagnostics] = None
 
 
 class TradeRecord(BaseModel):

--- a/backend/agents/investment_team/tests/test_execution_diagnostics_models.py
+++ b/backend/agents/investment_team/tests/test_execution_diagnostics_models.py
@@ -1,0 +1,153 @@
+"""Model tests for the zero-trade execution diagnostics envelope (issue #407).
+
+Pure Pydantic model coverage. The producers and the anomaly-detector
+consumer are wired up in subsequent issues (#408–#414); this test file
+exercises only the typed shapes and the backwards-compat guarantees on
+``BacktestResult``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from investment_team.models import (
+    MAX_RECENT_ORDER_EVENTS,
+    BacktestExecutionDiagnostics,
+    BacktestResult,
+    OpenPositionDiagnostic,
+    OrderLifecycleEvent,
+    OrderLifecycleEventType,
+    ZeroTradeCategory,
+)
+
+
+def _required_backtest_kwargs() -> dict:
+    return dict(
+        total_return_pct=12.0,
+        annualized_return_pct=10.0,
+        volatility_pct=8.0,
+        sharpe_ratio=1.2,
+        max_drawdown_pct=4.0,
+        win_rate_pct=55.0,
+        profit_factor=1.6,
+    )
+
+
+def test_order_lifecycle_event_round_trip():
+    event = OrderLifecycleEvent(
+        event_type=OrderLifecycleEventType.REJECTED,
+        timestamp="2026-04-01T13:30:00Z",
+        symbol="AAPL",
+        order_id="o-1",
+        side="buy",
+        order_type="market",
+        quantity=10.0,
+        price=170.5,
+        reason="risk_filter:position_size",
+    )
+    payload = event.model_dump()
+    restored = OrderLifecycleEvent.model_validate(payload)
+    assert restored == event
+    assert restored.event_type is OrderLifecycleEventType.REJECTED
+
+
+def test_open_position_diagnostic_round_trip():
+    pos = OpenPositionDiagnostic(
+        symbol="MSFT",
+        quantity=5.0,
+        entry_price=420.10,
+        entry_date="2026-03-15",
+        bars_held=12,
+        unrealized_pnl=-3.25,
+    )
+    restored = OpenPositionDiagnostic.model_validate(pos.model_dump())
+    assert restored == pos
+
+
+def test_backtest_execution_diagnostics_defaults_are_zero_and_empty():
+    diag = BacktestExecutionDiagnostics()
+    assert diag.bars_processed == 0
+    assert diag.orders_emitted == 0
+    assert diag.orders_accepted == 0
+    assert diag.orders_rejected == 0
+    assert diag.orders_unfilled == 0
+    assert diag.warmup_orders_dropped == 0
+    assert diag.entries_filled == 0
+    assert diag.exits_emitted == 0
+    assert diag.closed_trades == 0
+    assert diag.orders_rejection_reasons == {}
+    assert diag.last_order_events == []
+    assert diag.open_positions_at_end == []
+    assert diag.zero_trade_category is None
+    assert diag.summary is None
+
+
+def test_last_order_events_caps_to_max_and_keeps_tail():
+    overflow = MAX_RECENT_ORDER_EVENTS + 7
+    events = [
+        OrderLifecycleEvent(
+            event_type=OrderLifecycleEventType.EMITTED,
+            timestamp=f"2026-04-01T00:00:{i % 60:02d}Z",
+            order_id=f"o-{i}",
+        )
+        for i in range(overflow)
+    ]
+    diag = BacktestExecutionDiagnostics(last_order_events=events)
+    assert len(diag.last_order_events) == MAX_RECENT_ORDER_EVENTS
+    # Tail is preserved — the very last input event must survive.
+    assert diag.last_order_events[-1].order_id == f"o-{overflow - 1}"
+    # And the truncation drops the head.
+    assert diag.last_order_events[0].order_id == f"o-{overflow - MAX_RECENT_ORDER_EVENTS}"
+
+
+def test_zero_trade_category_parses_known_values_and_rejects_unknown():
+    assert ZeroTradeCategory("orders_rejected") is ZeroTradeCategory.ORDERS_REJECTED
+    assert ZeroTradeCategory("entry_with_no_exit") is ZeroTradeCategory.ENTRY_WITH_NO_EXIT
+    with pytest.raises(ValueError):
+        ZeroTradeCategory("not_a_real_category")
+
+
+def test_backtest_result_constructs_without_execution_diagnostics():
+    result = BacktestResult(**_required_backtest_kwargs())
+    assert result.execution_diagnostics is None
+
+
+def test_backtest_result_deserializes_legacy_row_without_field():
+    # Legacy persisted rows predate issue #407 and have no
+    # ``execution_diagnostics`` key. ``model_validate`` must accept them and
+    # default the field to ``None``. Acceptance criterion of #407.
+    legacy_row = _required_backtest_kwargs()
+    assert "execution_diagnostics" not in legacy_row
+    result = BacktestResult.model_validate(legacy_row)
+    assert result.execution_diagnostics is None
+
+
+def test_backtest_result_with_diagnostics_round_trips_through_json():
+    diag = BacktestExecutionDiagnostics(
+        bars_processed=500,
+        orders_emitted=3,
+        orders_rejected=3,
+        orders_rejection_reasons={"risk_filter:position_size": 3},
+        last_order_events=[
+            OrderLifecycleEvent(
+                event_type=OrderLifecycleEventType.REJECTED,
+                timestamp="2026-04-01T13:30:00Z",
+                symbol="AAPL",
+                reason="risk_filter:position_size",
+            ),
+        ],
+        open_positions_at_end=[],
+        zero_trade_category=ZeroTradeCategory.ORDERS_REJECTED,
+        summary="3 orders emitted; all rejected by position-size filter.",
+    )
+    original = BacktestResult(**_required_backtest_kwargs(), execution_diagnostics=diag)
+    restored = BacktestResult.model_validate_json(original.model_dump_json())
+    assert restored == original
+    assert restored.execution_diagnostics is not None
+    assert restored.execution_diagnostics.zero_trade_category is ZeroTradeCategory.ORDERS_REJECTED
+
+
+def test_order_lifecycle_event_rejects_invalid_event_type():
+    with pytest.raises(ValidationError):
+        OrderLifecycleEvent(event_type="not_a_real_type", timestamp="2026-04-01T00:00:00Z")


### PR DESCRIPTION
First sub-task of #404 (Strategy Lab zero-trade diagnostics envelope).

## Summary
- Adds `ZeroTradeCategory` and `OrderLifecycleEventType` enums covering the five categories and seven event types from the #404 spec.
- Adds `OrderLifecycleEvent`, `OpenPositionDiagnostic`, and `BacktestExecutionDiagnostics` Pydantic models. The envelope holds order counters, a rejection-reason histogram, capped recent lifecycle events (`MAX_RECENT_ORDER_EVENTS = 50`, tail preserved via `field_validator`), final open positions, the zero-trade category, and an optional summary.
- Threads `execution_diagnostics: Optional[BacktestExecutionDiagnostics] = None` onto `BacktestResult`. Legacy persisted rows that lack the field deserialize unchanged with the new field defaulting to `None`.

## Scope
Pure model additions. **No** producer or consumer is wired up in this PR — `BacktestResult` is constructed today exactly as before, and `BacktestAnomalyDetector` still emits the generic zero-trade message. The trading-service / fill-simulator instrumentation, construction-site plumbing, `StrategyRunResult` propagation, anomaly classification, and refinement-prompt updates ride on the rest of the #404 chain (#408 → #409 → #410 → #411 → #412 → #413 → #414).

The four end-to-end zero-trade-category acceptance tests called out by #404 land alongside #413 once the producers and the classifier exist.

## Note on issue state
Issue #407 was previously closed prematurely — none of the three required model classes existed in `backend/agents/investment_team/models.py` when this branch was cut. The issue has been reopened.

## Test plan
- [x] New `backend/agents/investment_team/tests/test_execution_diagnostics_models.py` (9 cases) passes locally:
  - `OrderLifecycleEvent` / `OpenPositionDiagnostic` / `BacktestResult` round-trip through `model_dump_json` ↔ `model_validate_json`
  - Default `BacktestExecutionDiagnostics()` has all-zero counters and empty collections
  - `last_order_events` truncates to `MAX_RECENT_ORDER_EVENTS` and preserves the tail
  - `ZeroTradeCategory` parses known values and rejects unknown
  - Legacy `BacktestResult` rows (no `execution_diagnostics` key) deserialize with the field defaulting to `None` — explicit acceptance criterion of #407
  - `OrderLifecycleEvent` rejects an invalid `event_type`
- [x] `ruff check` + `ruff format --check` clean on the touched files
- [ ] Reviewer sanity: confirm no other call site needs the new types re-exported (none today — the package `__init__.py` already keeps `BacktestResult` itself unexported and consumers reach for `from investment_team.models import …` directly)

https://claude.ai/code/session_01HRVYFrSpPjQ29E4vGyVhBC

---
_Generated by [Claude Code](https://claude.ai/code/session_01HRVYFrSpPjQ29E4vGyVhBC)_