### PR TITLE
[Trading 4/5 — C] Parallelize cost-stress multiplier sweeps (#431)

### DIFF
--- a/backend/agents/investment_team/trading_service/modes/backtest.py
+++ b/backend/agents/investment_team/trading_service/modes/backtest.py
@@ -217,37 +217,60 @@ def run_backtest(
     if config.cost_stress and config.cost_stress_multipliers:
         report = CostStressReport()
         multipliers = list(config.cost_stress_multipliers)
-        workers = min(len(multipliers), os.cpu_count() or 4)
         # Index by input position, not multiplier value: callers may pass
         # duplicate multipliers (e.g. for repeatability checks of a
         # non-deterministic strategy), and each duplicate must produce its
         # own row, matching the prior sequential behavior.
         rows_by_index: List[Optional[CostStressRow]] = [None] * len(multipliers)
-        with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="cost-stress") as pool:
-            futures = {
-                pool.submit(
-                    _run_once,
-                    _scaled_cost_config(config, multiplier),
-                    capture_fingerprint=False,
-                ): idx
-                for idx, multiplier in enumerate(multipliers)
-            }
-            for fut in as_completed(futures):
-                idx = futures[fut]
-                multiplier = multipliers[idx]
-                stress_result, stress_metrics = fut.result()
-                rows_by_index[idx] = CostStressRow(
-                    multiplier=multiplier,
-                    sharpe_ratio=stress_metrics.sharpe_ratio,
-                    annualized_return_pct=stress_metrics.annualized_return_pct,
-                    max_drawdown_pct=stress_metrics.max_drawdown_pct,
-                    # Each stressed run generates its own trade ledger —
-                    # turnover shifts with costs, so use the stressed
-                    # run's count, not the baseline's.
-                    trade_count=len(stress_result.trades),
-                )
+
+        def _stress_row(idx: int) -> CostStressRow:
+            multiplier = multipliers[idx]
+            stress_result, stress_metrics = _run_once(
+                _scaled_cost_config(config, multiplier),
+                capture_fingerprint=False,
+            )
+            return CostStressRow(
+                multiplier=multiplier,
+                sharpe_ratio=stress_metrics.sharpe_ratio,
+                annualized_return_pct=stress_metrics.annualized_return_pct,
+                max_drawdown_pct=stress_metrics.max_drawdown_pct,
+                # Each stressed run generates its own trade ledger —
+                # turnover shifts with costs, so use the stressed
+                # run's count, not the baseline's.
+                trade_count=len(stress_result.trades),
+            )
+
+        # Cache-stampede guard: the snapshot cache is only populated when
+        # a CachingProviderHistoricalStream drains EndOfStreamEvent (or
+        # cache-hits up-front). When the baseline trips early — e.g. via
+        # the TradingService drawdown breaker — the cache is still cold,
+        # and a parallel fan-out would have every worker miss cache and
+        # duplicate the same upstream provider fetch (rate limits,
+        # competing snapshot writes). Detect that case via the baseline's
+        # fingerprint and run the first multiplier sequentially so its
+        # persist step warms the cache before the rest go in parallel.
+        # The legacy ``market_data`` path skips this entirely — it has no
+        # provider cache to warm.
+        baseline_stream = streaming_holder["current"]
+        cache_warm = has_legacy or (
+            baseline_stream is not None and baseline_stream.dataset_fingerprint is not None
+        )
+        parallel_start = 0
+        if not cache_warm:
+            rows_by_index[0] = _stress_row(0)
+            parallel_start = 1
+
+        parallel_indices = list(range(parallel_start, len(multipliers)))
+        if parallel_indices:
+            workers = min(len(parallel_indices), os.cpu_count() or 4)
+            with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="cost-stress") as pool:
+                futures = {pool.submit(_stress_row, idx): idx for idx in parallel_indices}
+                for fut in as_completed(futures):
+                    idx = futures[fut]
+                    rows_by_index[idx] = fut.result()
+
         for row in rows_by_index:
-            assert row is not None  # every future ran or raised
+            assert row is not None  # every position filled
             report.rows.append(row)
         update["cost_stress_results"] = report.to_payload()
 

--- a/backend/agents/investment_team/trading_service/modes/backtest.py
+++ b/backend/agents/investment_team/trading_service/modes/backtest.py
@@ -247,18 +247,28 @@ def run_backtest(
         # and a parallel fan-out would have every worker miss cache and
         # duplicate the same upstream provider fetch (rate limits,
         # competing snapshot writes). Detect that case via the baseline's
-        # fingerprint and run the first multiplier sequentially so its
-        # persist step warms the cache before the rest go in parallel.
-        # The legacy ``market_data`` path skips this entirely — it has no
-        # provider cache to warm.
+        # fingerprint and run multipliers sequentially until one warms
+        # the cache (its stream gets a non-``None`` ``dataset_fingerprint``
+        # via either a cache hit or a successful drain), then fan out
+        # the remainder. If no multiplier warms the cache, the whole
+        # sweep stays sequential — no parallel stampede possible.
+        # The legacy ``market_data`` path skips this entirely — it has
+        # no provider cache to warm.
         baseline_stream = streaming_holder["current"]
         cache_warm = has_legacy or (
             baseline_stream is not None and baseline_stream.dataset_fingerprint is not None
         )
         parallel_start = 0
         if not cache_warm:
-            rows_by_index[0] = _stress_row(0)
-            parallel_start = 1
+            for idx in range(len(multipliers)):
+                rows_by_index[idx] = _stress_row(idx)
+                # ``_build_stream`` appends every non-baseline stream to
+                # ``stress_streams``; the just-completed run is at the tail.
+                if stress_streams and stress_streams[-1].dataset_fingerprint is not None:
+                    parallel_start = idx + 1
+                    break
+            else:
+                parallel_start = len(multipliers)
 
         parallel_indices = list(range(parallel_start, len(multipliers)))
         if parallel_indices:

--- a/backend/agents/investment_team/trading_service/modes/backtest.py
+++ b/backend/agents/investment_team/trading_service/modes/backtest.py
@@ -207,20 +207,25 @@ def run_backtest(
         report = CostStressReport()
         multipliers = list(config.cost_stress_multipliers)
         workers = min(len(multipliers), os.cpu_count() or 4)
-        rows_by_mult: Dict[float, CostStressRow] = {}
+        # Index by input position, not multiplier value: callers may pass
+        # duplicate multipliers (e.g. for repeatability checks of a
+        # non-deterministic strategy), and each duplicate must produce its
+        # own row, matching the prior sequential behavior.
+        rows_by_index: List[Optional[CostStressRow]] = [None] * len(multipliers)
         with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="cost-stress") as pool:
             futures = {
                 pool.submit(
                     _run_once,
                     _scaled_cost_config(config, multiplier),
                     capture_fingerprint=False,
-                ): multiplier
-                for multiplier in multipliers
+                ): idx
+                for idx, multiplier in enumerate(multipliers)
             }
             for fut in as_completed(futures):
-                multiplier = futures[fut]
+                idx = futures[fut]
+                multiplier = multipliers[idx]
                 stress_result, stress_metrics = fut.result()
-                rows_by_mult[multiplier] = CostStressRow(
+                rows_by_index[idx] = CostStressRow(
                     multiplier=multiplier,
                     sharpe_ratio=stress_metrics.sharpe_ratio,
                     annualized_return_pct=stress_metrics.annualized_return_pct,
@@ -230,8 +235,9 @@ def run_backtest(
                     # run's count, not the baseline's.
                     trade_count=len(stress_result.trades),
                 )
-        for multiplier in multipliers:
-            report.rows.append(rows_by_mult[multiplier])
+        for row in rows_by_index:
+            assert row is not None  # every future ran or raised
+            report.rows.append(row)
         update["cost_stress_results"] = report.to_payload()
 
         # Gate: fail when Sharpe at the 2x multiplier drops below the

--- a/backend/agents/investment_team/trading_service/modes/backtest.py
+++ b/backend/agents/investment_team/trading_service/modes/backtest.py
@@ -19,6 +19,8 @@ only branch is where the ``MarketDataStream`` comes from.
 from __future__ import annotations
 
 import logging
+import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import Dict, List, Optional
 
@@ -114,7 +116,7 @@ def run_backtest(
 
     streaming_holder: Dict[str, Optional[CachingProviderHistoricalStream]] = {"current": None}
 
-    def _build_stream() -> object:
+    def _build_stream(*, capture_fingerprint: bool) -> object:
         if has_legacy:
             return HistoricalReplayStream(market_data, timeframe=timeframe)
         reg = registry or default_registry()
@@ -132,13 +134,20 @@ def run_backtest(
             timeframe=timeframe,
             as_of=as_of,
         )
-        streaming_holder["current"] = stream
+        # Only the baseline run records its stream into the holder so the
+        # post-loop fingerprint read (#376) is a single-writer operation —
+        # cost-stress workers run concurrently (#431) and would otherwise
+        # race on this slot.
+        if capture_fingerprint:
+            streaming_holder["current"] = stream
         return stream
 
     def _run_once(
         run_config: BacktestConfig,
+        *,
+        capture_fingerprint: bool = False,
     ) -> tuple[TradingServiceResult, BacktestResult]:
-        stream = _build_stream()
+        stream = _build_stream(capture_fingerprint=capture_fingerprint)
         service = TradingService(
             strategy_code=strategy.strategy_code,
             config=run_config,
@@ -160,7 +169,7 @@ def run_backtest(
         )
         return outcome, run_metrics
 
-    service_result, metrics = _run_once(config)
+    service_result, metrics = _run_once(config, capture_fingerprint=True)
 
     if service_result.error and not service_result.trades:
         logger.warning(
@@ -189,12 +198,29 @@ def run_backtest(
             update.setdefault("reject_reason", "low_signals_per_bar")
 
     # Phase 4: cost-stress replay.  Only runs when the flag is on.
+    # Issue #431: replays are pure CPU/sim against the cached dataset
+    # (#376), so fan them out across a thread pool. Ordering of
+    # ``report.rows`` must match ``config.cost_stress_multipliers``
+    # regardless of completion order — the ``min_sharpe_at_2x`` gate and
+    # downstream consumers rely on it.
     if config.cost_stress and config.cost_stress_multipliers:
         report = CostStressReport()
-        for multiplier in config.cost_stress_multipliers:
-            stress_result, stress_metrics = _run_once(_scaled_cost_config(config, multiplier))
-            report.rows.append(
-                CostStressRow(
+        multipliers = list(config.cost_stress_multipliers)
+        workers = min(len(multipliers), os.cpu_count() or 4)
+        rows_by_mult: Dict[float, CostStressRow] = {}
+        with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="cost-stress") as pool:
+            futures = {
+                pool.submit(
+                    _run_once,
+                    _scaled_cost_config(config, multiplier),
+                    capture_fingerprint=False,
+                ): multiplier
+                for multiplier in multipliers
+            }
+            for fut in as_completed(futures):
+                multiplier = futures[fut]
+                stress_result, stress_metrics = fut.result()
+                rows_by_mult[multiplier] = CostStressRow(
                     multiplier=multiplier,
                     sharpe_ratio=stress_metrics.sharpe_ratio,
                     annualized_return_pct=stress_metrics.annualized_return_pct,
@@ -204,7 +230,8 @@ def run_backtest(
                     # run's count, not the baseline's.
                     trade_count=len(stress_result.trades),
                 )
-            )
+        for multiplier in multipliers:
+            report.rows.append(rows_by_mult[multiplier])
         update["cost_stress_results"] = report.to_payload()
 
         # Gate: fail when Sharpe at the 2x multiplier drops below the

--- a/backend/agents/investment_team/trading_service/modes/backtest.py
+++ b/backend/agents/investment_team/trading_service/modes/backtest.py
@@ -115,6 +115,13 @@ def run_backtest(
         legacy_fingerprint = compute_dataset_fingerprint(market_data)
 
     streaming_holder: Dict[str, Optional[CachingProviderHistoricalStream]] = {"current": None}
+    # Stressed-run streams are tracked separately so we can fall back to
+    # one of their fingerprints if the baseline exits early (e.g. via
+    # the TradingService drawdown breaker) and never drains its
+    # generator — without that fallback, ``dataset_fingerprint`` would
+    # silently regress to ``None`` for cost-stress runs that did
+    # generate fully replayed data.
+    stress_streams: List[CachingProviderHistoricalStream] = []
 
     def _build_stream(*, capture_fingerprint: bool) -> object:
         if has_legacy:
@@ -137,9 +144,13 @@ def run_backtest(
         # Only the baseline run records its stream into the holder so the
         # post-loop fingerprint read (#376) is a single-writer operation —
         # cost-stress workers run concurrently (#431) and would otherwise
-        # race on this slot.
+        # race on this slot. Stressed streams are appended to a side list
+        # (list.append is atomic under the GIL) so we still have access
+        # to their fingerprints if the baseline never drains.
         if capture_fingerprint:
             streaming_holder["current"] = stream
+        else:
+            stress_streams.append(stream)
         return stream
 
     def _run_once(
@@ -256,11 +267,20 @@ def run_backtest(
     # Issue #376 — surface the dataset fingerprint for byte-equality
     # checks on rerun.  Streaming path takes precedence over the legacy
     # hash so both routes converge on the same content-addressed key.
+    # Issue #431 — if the baseline exited early (drawdown breaker, etc.)
+    # and never drained its generator, fall back to any stressed-run
+    # stream that did, so reproducibility doesn't regress when cost-
+    # stress executions still produced fully replayed data.
     streaming_fp = (
         streaming_holder["current"].dataset_fingerprint
         if streaming_holder["current"] is not None
         else None
     )
+    if streaming_fp is None:
+        for s in stress_streams:
+            if s.dataset_fingerprint is not None:
+                streaming_fp = s.dataset_fingerprint
+                break
     fingerprint = streaming_fp or legacy_fingerprint
     if fingerprint:
         update["dataset_fingerprint"] = fingerprint


### PR DESCRIPTION
Closes #431. Part of #378.

## Summary

- Replace the sequential `for multiplier in config.cost_stress_multipliers:` loop in `run_backtest` with a `ThreadPoolExecutor` sweep. Worker count = `min(len(multipliers), os.cpu_count() or 4)`. The `CachingProviderHistoricalStream` cache (#376) is hit on every replay, so workers are pure CPU/sim and parallelize cleanly.
- Preserve `report.rows` ordering by collecting completed futures into a `dict[multiplier, CostStressRow]` via `as_completed`, then appending in the original input order. The `min_sharpe_at_2x` gate is unchanged.
- Fix the latent race on `streaming_holder["current"]`: `_build_stream` now takes `capture_fingerprint: bool` and only the **baseline** `_run_once` call writes the provider stream into the holder. Cost-stress workers pass `capture_fingerprint=False`, so the post-loop fingerprint read is a single-writer operation.

## Notes

- `risk_free_rate.get_risk_free_rate` has no in-process cache today (only env-var read + optional FRED HTTP), and `httpx.Client` is thread-safe, so no lock was added. If a process-local cache is added later it will need a `threading.Lock()`.
- `TradingService` already isolates strategy state in a subprocess, so no per-worker strategy contention.

## Test plan

- [x] `pytest agents/investment_team/tests/test_liquidity_and_cost_stress.py -v` — all 15 pass, including:
  - `test_cost_stress_populates_cost_stress_results` (ordering `[1.0, 2.0, 3.0]`)
  - `test_min_sharpe_at_2x_rejects_overfit_strategy` (gate still triggers)
  - `test_cost_stress_trade_counts_reflect_each_stressed_run` (per-row trade counts come from each stressed run's own config — isolation preserved under parallelism)
  - `test_cost_stress_disabled_leaves_results_none`
- [x] `pytest agents/investment_team/tests/test_subdaily_backtest.py agents/investment_team/tests/test_backtest_anomaly_dsr_aware.py agents/investment_team/tests/test_cost_model.py agents/investment_team/tests/test_trading_service.py` — 56 pass, 0 fail.
- [x] `ruff check` and `ruff format --check` clean on the touched file.
- [ ] Wall-clock check: 5-multiplier sweep on a 10-year daily fixture should run in ~1/N of the sequential baseline (acceptance criterion #1) — recommend a dedicated profiling run before merge.

https://claude.ai/code/session_01U6UU35KpwrWCMSBEuFWc68

---
_Generated by [Claude Code](https://claude.ai/code/session_01U6UU35KpwrWCMSBEuFWc68)_