### PR TITLE
investment-team: attach execution diagnostics to BacktestResult (#411)

### DIFF
--- a/backend/agents/investment_team/tests/golden/snapshots/overfit_hardcoded_dates.json
+++ b/backend/agents/investment_team/tests/golden/snapshots/overfit_hardcoded_dates.json
@@ -68,7 +68,203 @@
     },
     "dataset_fingerprint": "0208fd94d618909ae3d24532db28f9795def93386fb41804d816c9fa94357c30",
     "deflated_sharpe": 0.0,
-    "execution_diagnostics": null,
+    "execution_diagnostics": {
+      "bars_processed": 504,
+      "closed_trades": 5,
+      "entries_filled": 5,
+      "exits_emitted": 5,
+      "last_order_events": [
+        {
+          "detail": "",
+          "event_type": "accepted",
+          "order_type": "market",
+          "reason": "",
+          "side": "short",
+          "symbol": "BBB",
+          "timestamp": "2024-05-06"
+        },
+        {
+          "detail": "",
+          "event_type": "exit_filled",
+          "order_type": "market",
+          "reason": "full",
+          "side": "short",
+          "symbol": "BBB",
+          "timestamp": "2024-05-07"
+        },
+        {
+          "detail": "",
+          "event_type": "emitted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "BBB",
+          "timestamp": "2024-06-03"
+        },
+        {
+          "detail": "",
+          "event_type": "accepted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "BBB",
+          "timestamp": "2024-06-03"
+        },
+        {
+          "detail": "",
+          "event_type": "entry_filled",
+          "order_type": "market",
+          "reason": "full",
+          "side": "long",
+          "symbol": "BBB",
+          "timestamp": "2024-06-04"
+        },
+        {
+          "detail": "",
+          "event_type": "emitted",
+          "order_type": "market",
+          "reason": "",
+          "side": "short",
+          "symbol": "BBB",
+          "timestamp": "2024-07-01"
+        },
+        {
+          "detail": "",
+          "event_type": "accepted",
+          "order_type": "market",
+          "reason": "",
+          "side": "short",
+          "symbol": "BBB",
+          "timestamp": "2024-07-01"
+        },
+        {
+          "detail": "",
+          "event_type": "exit_filled",
+          "order_type": "market",
+          "reason": "full",
+          "side": "short",
+          "symbol": "BBB",
+          "timestamp": "2024-07-02"
+        },
+        {
+          "detail": "",
+          "event_type": "emitted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "BBB",
+          "timestamp": "2024-07-29"
+        },
+        {
+          "detail": "",
+          "event_type": "accepted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "BBB",
+          "timestamp": "2024-07-29"
+        },
+        {
+          "detail": "",
+          "event_type": "entry_filled",
+          "order_type": "market",
+          "reason": "full",
+          "side": "long",
+          "symbol": "BBB",
+          "timestamp": "2024-07-30"
+        },
+        {
+          "detail": "",
+          "event_type": "emitted",
+          "order_type": "market",
+          "reason": "",
+          "side": "short",
+          "symbol": "BBB",
+          "timestamp": "2024-08-26"
+        },
+        {
+          "detail": "",
+          "event_type": "accepted",
+          "order_type": "market",
+          "reason": "",
+          "side": "short",
+          "symbol": "BBB",
+          "timestamp": "2024-08-26"
+        },
+        {
+          "detail": "",
+          "event_type": "exit_filled",
+          "order_type": "market",
+          "reason": "full",
+          "side": "short",
+          "symbol": "BBB",
+          "timestamp": "2024-08-27"
+        },
+        {
+          "detail": "",
+          "event_type": "emitted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "BBB",
+          "timestamp": "2024-09-23"
+        },
+        {
+          "detail": "",
+          "event_type": "accepted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "BBB",
+          "timestamp": "2024-09-23"
+        },
+        {
+          "detail": "",
+          "event_type": "entry_filled",
+          "order_type": "market",
+          "reason": "full",
+          "side": "long",
+          "symbol": "BBB",
+          "timestamp": "2024-09-24"
+        },
+        {
+          "detail": "",
+          "event_type": "emitted",
+          "order_type": "market",
+          "reason": "",
+          "side": "short",
+          "symbol": "BBB",
+          "timestamp": "2024-10-21"
+        },
+        {
+          "detail": "",
+          "event_type": "accepted",
+          "order_type": "market",
+          "reason": "",
+          "side": "short",
+          "symbol": "BBB",
+          "timestamp": "2024-10-21"
+        },
+        {
+          "detail": "",
+          "event_type": "exit_filled",
+          "order_type": "market",
+          "reason": "full",
+          "side": "short",
+          "symbol": "BBB",
+          "timestamp": "2024-10-22"
+        }
+      ],
+      "open_positions_at_end": [],
+      "orders_accepted": 10,
+      "orders_emitted": 10,
+      "orders_rejected": 0,
+      "orders_rejection_reasons": {},
+      "orders_unfilled": 0,
+      "summary": "Backtest closed 5 trade(s) across 504 post-warmup bar(s).",
+      "warmup_orders_dropped": 0,
+      "zero_trade_category": null
+    },
     "fold_results": null,
     "information_ratio": null,
     "is_oos_degradation_pct": null,

--- a/backend/agents/investment_team/tests/golden/snapshots/round_trip.json
+++ b/backend/agents/investment_team/tests/golden/snapshots/round_trip.json
@@ -68,7 +68,203 @@
     },
     "dataset_fingerprint": "0208fd94d618909ae3d24532db28f9795def93386fb41804d816c9fa94357c30",
     "deflated_sharpe": 0.0,
-    "execution_diagnostics": null,
+    "execution_diagnostics": {
+      "bars_processed": 504,
+      "closed_trades": 0,
+      "entries_filled": 0,
+      "exits_emitted": 0,
+      "last_order_events": [
+        {
+          "detail": "",
+          "event_type": "accepted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-11-19"
+        },
+        {
+          "detail": "",
+          "event_type": "unfilled",
+          "order_type": "market",
+          "reason": "day_expired",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-11-20"
+        },
+        {
+          "detail": "",
+          "event_type": "emitted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-11-22"
+        },
+        {
+          "detail": "",
+          "event_type": "accepted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-11-22"
+        },
+        {
+          "detail": "",
+          "event_type": "unfilled",
+          "order_type": "market",
+          "reason": "day_expired",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-11-25"
+        },
+        {
+          "detail": "",
+          "event_type": "emitted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-11-27"
+        },
+        {
+          "detail": "",
+          "event_type": "accepted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-11-27"
+        },
+        {
+          "detail": "",
+          "event_type": "unfilled",
+          "order_type": "market",
+          "reason": "day_expired",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-11-28"
+        },
+        {
+          "detail": "",
+          "event_type": "emitted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-02"
+        },
+        {
+          "detail": "",
+          "event_type": "accepted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-02"
+        },
+        {
+          "detail": "",
+          "event_type": "unfilled",
+          "order_type": "market",
+          "reason": "day_expired",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-03"
+        },
+        {
+          "detail": "",
+          "event_type": "emitted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-05"
+        },
+        {
+          "detail": "",
+          "event_type": "accepted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-05"
+        },
+        {
+          "detail": "",
+          "event_type": "unfilled",
+          "order_type": "market",
+          "reason": "day_expired",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-06"
+        },
+        {
+          "detail": "",
+          "event_type": "emitted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-10"
+        },
+        {
+          "detail": "",
+          "event_type": "accepted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-10"
+        },
+        {
+          "detail": "",
+          "event_type": "unfilled",
+          "order_type": "market",
+          "reason": "day_expired",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-11"
+        },
+        {
+          "detail": "",
+          "event_type": "emitted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-13"
+        },
+        {
+          "detail": "",
+          "event_type": "accepted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-13"
+        },
+        {
+          "detail": "",
+          "event_type": "unfilled",
+          "order_type": "market",
+          "reason": "day_expired",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-16"
+        }
+      ],
+      "open_positions_at_end": [],
+      "orders_accepted": 84,
+      "orders_emitted": 84,
+      "orders_rejected": 0,
+      "orders_rejection_reasons": {},
+      "orders_unfilled": 84,
+      "summary": "Backtest closed zero trades; 84 order(s) left unfilled with no entry fills recorded.",
+      "warmup_orders_dropped": 0,
+      "zero_trade_category": "ORDERS_UNFILLED"
+    },
     "fold_results": null,
     "information_ratio": null,
     "is_oos_degradation_pct": null,

--- a/backend/agents/investment_team/tests/golden/snapshots/sma_crossover.json
+++ b/backend/agents/investment_team/tests/golden/snapshots/sma_crossover.json
@@ -68,7 +68,203 @@
     },
     "dataset_fingerprint": "0208fd94d618909ae3d24532db28f9795def93386fb41804d816c9fa94357c30",
     "deflated_sharpe": 0.0,
-    "execution_diagnostics": null,
+    "execution_diagnostics": {
+      "bars_processed": 504,
+      "closed_trades": 9,
+      "entries_filled": 10,
+      "exits_emitted": 9,
+      "last_order_events": [
+        {
+          "detail": "",
+          "event_type": "emitted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-10"
+        },
+        {
+          "detail": "",
+          "event_type": "accepted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-10"
+        },
+        {
+          "detail": "",
+          "event_type": "unfilled",
+          "order_type": "market",
+          "reason": "day_expired",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-11"
+        },
+        {
+          "detail": "",
+          "event_type": "emitted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-11"
+        },
+        {
+          "detail": "",
+          "event_type": "accepted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-11"
+        },
+        {
+          "detail": "",
+          "event_type": "unfilled",
+          "order_type": "market",
+          "reason": "day_expired",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-12"
+        },
+        {
+          "detail": "",
+          "event_type": "emitted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-12"
+        },
+        {
+          "detail": "",
+          "event_type": "accepted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-12"
+        },
+        {
+          "detail": "",
+          "event_type": "unfilled",
+          "order_type": "market",
+          "reason": "day_expired",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-13"
+        },
+        {
+          "detail": "",
+          "event_type": "emitted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-13"
+        },
+        {
+          "detail": "",
+          "event_type": "accepted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-13"
+        },
+        {
+          "detail": "",
+          "event_type": "unfilled",
+          "order_type": "market",
+          "reason": "day_expired",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-16"
+        },
+        {
+          "detail": "",
+          "event_type": "emitted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-16"
+        },
+        {
+          "detail": "",
+          "event_type": "accepted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-16"
+        },
+        {
+          "detail": "",
+          "event_type": "emitted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "BBB",
+          "timestamp": "2024-12-16"
+        },
+        {
+          "detail": "",
+          "event_type": "unfilled",
+          "order_type": "market",
+          "reason": "day_expired",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-17"
+        },
+        {
+          "detail": "",
+          "event_type": "accepted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "BBB",
+          "timestamp": "2024-12-16"
+        },
+        {
+          "detail": "",
+          "event_type": "emitted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-17"
+        },
+        {
+          "detail": "",
+          "event_type": "accepted",
+          "order_type": "market",
+          "reason": "",
+          "side": "long",
+          "symbol": "AAA",
+          "timestamp": "2024-12-17"
+        },
+        {
+          "detail": "",
+          "event_type": "entry_filled",
+          "order_type": "market",
+          "reason": "full",
+          "side": "long",
+          "symbol": "BBB",
+          "timestamp": "2024-12-17"
+        }
+      ],
+      "open_positions_at_end": [],
+      "orders_accepted": 140,
+      "orders_emitted": 140,
+      "orders_rejected": 0,
+      "orders_rejection_reasons": {},
+      "orders_unfilled": 120,
+      "summary": "Backtest closed 9 trade(s) across 504 post-warmup bar(s).",
+      "warmup_orders_dropped": 0,
+      "zero_trade_category": null
+    },
     "fold_results": null,
     "information_ratio": null,
     "is_oos_degradation_pct": null,

--- a/backend/agents/investment_team/tests/test_liquidity_and_cost_stress.py
+++ b/backend/agents/investment_team/tests/test_liquidity_and_cost_stress.py
@@ -20,7 +20,13 @@ import textwrap
 from typing import List
 
 from investment_team.market_data_service import OHLCVBar, compute_adv_from_bars
-from investment_team.models import BacktestConfig, BacktestResult, StrategySpec, TradeRecord
+from investment_team.models import (
+    BacktestConfig,
+    BacktestExecutionDiagnostics,
+    BacktestResult,
+    StrategySpec,
+    TradeRecord,
+)
 from investment_team.strategy_lab.quality_gates.backtest_anomaly import (
     BacktestAnomalyDetector,
 )
@@ -354,6 +360,84 @@ def test_cost_stress_disabled_leaves_results_none() -> None:
         market_data={"AAA": _bars(20)},
     )
     assert result.result.cost_stress_results is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #411 — execution diagnostics envelope on baseline BacktestResult
+# ---------------------------------------------------------------------------
+
+
+_NO_ORDER_CODE = textwrap.dedent('''\
+    """Never submits an order — exercises the no-orders-emitted diagnostics path."""
+    from contract import Strategy
+
+
+    class NoOrders(Strategy):
+        def on_bar(self, ctx, bar):
+            return
+''')
+
+
+def test_baseline_attaches_execution_diagnostics() -> None:
+    """A normal round-trip backtest surfaces ``execution_diagnostics`` on the result."""
+    result = run_backtest(
+        strategy=_spec(_ROUND_TRIP_CODE, "rt-diag"),
+        config=_config(),
+        market_data={"AAA": _bars(20)},
+    )
+    diag = result.result.execution_diagnostics
+    assert diag is not None
+    assert isinstance(diag, BacktestExecutionDiagnostics)
+    assert diag.bars_processed == result.service_result.bars_processed
+    assert diag.bars_processed > 0
+    assert diag.orders_emitted >= diag.entries_filled
+
+
+def test_cost_stress_rows_stay_compact_without_diagnostics() -> None:
+    """Cost-stress replay rows must keep their compact ``CostStressRow`` shape (#411)."""
+    result = run_backtest(
+        strategy=_spec(_ROUND_TRIP_CODE, "stress-compact"),
+        config=_config(
+            transaction_cost_bps=1.0,
+            slippage_bps=1.0,
+            cost_stress=True,
+        ),
+        market_data={"AAA": _bars(20)},
+    )
+    rows = result.result.cost_stress_results
+    assert rows is not None
+    expected_keys = {
+        "multiplier",
+        "sharpe_ratio",
+        "annualized_return_pct",
+        "max_drawdown_pct",
+        "trade_count",
+    }
+    for r in rows:
+        assert set(r.keys()) == expected_keys
+    # Baseline result still carries diagnostics alongside the compact rows.
+    assert result.result.execution_diagnostics is not None
+
+
+def test_zero_trade_baseline_carries_execution_diagnostics() -> None:
+    """A strategy that never emits an order still surfaces a populated envelope.
+
+    Downstream sub-issues (#413, #414) consume ``zero_trade_category`` and
+    the order-lifecycle counters off this envelope, so the zero-trade path
+    must not leave ``execution_diagnostics`` as ``None`` on the persisted
+    ``BacktestResult``.
+    """
+    result = run_backtest(
+        strategy=_spec(_NO_ORDER_CODE, "no-orders"),
+        config=_config(),
+        market_data={"AAA": _bars(20)},
+    )
+    diag = result.result.execution_diagnostics
+    assert diag is not None
+    assert diag.bars_processed > 0
+    assert diag.orders_emitted == 0
+    assert diag.closed_trades == 0
+    assert diag.zero_trade_category == "NO_ORDERS_EMITTED"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/trading_service/modes/backtest.py
+++ b/backend/agents/investment_team/trading_service/modes/backtest.py
@@ -198,6 +198,14 @@ def run_backtest(
     if service_result.terminated_reason:
         update["terminated_reason"] = service_result.terminated_reason
 
+    # Issue #411 — surface the TradingService's execution diagnostics envelope
+    # on the baseline BacktestResult so Strategy Lab's anomaly detector and
+    # refinement prompts (#413, #414) can reason about zero-trade categories,
+    # order lifecycle counters, and rejection reasons without reaching into
+    # the raw service_result. Cost-stress replay rows stay compact — the
+    # CostStressRow shape is intentionally not extended.
+    update["execution_diagnostics"] = service_result.execution_diagnostics
+
     # Phase 4: signals-per-bar is computed off the bars the strategy
     # subprocess actually received — the TradingService counts non-warmup
     # bars as it runs, so both the legacy pre-fetched path and the


### PR DESCRIPTION
## Summary

Closes #411 (sub-issue of #404).

Forwards `TradingServiceResult.execution_diagnostics` onto the baseline `BacktestResult` so Strategy Lab's anomaly detector (#413) and refinement prompts (#414) can read zero-trade categories, order lifecycle counters, and rejection reasons directly off the persisted result instead of reaching into the raw `service_result`. The downstream zero-trade repair work (#405) and rule-coverage probes (#406) also depend on this envelope being available.

### Change

Single insertion in `backend/agents/investment_team/trading_service/modes/backtest.py`: the baseline run's `service_result.execution_diagnostics` is added to the `update` dict that's overlaid onto `metrics` via `model_copy`. The cost-stress path (`_stress_row` → `CostStressRow`) is untouched, so replay rows keep their compact shape.

`BacktestResult.execution_diagnostics` and `BacktestExecutionDiagnostics` already existed on the model — no schema change needed.

### Acceptance criteria (from #411)

- [x] Baseline backtests return `result.execution_diagnostics`.
- [x] Cost-stress result rows keep their current compact shape.
- [x] Existing metrics fields and trade records remain unchanged.

## Test plan

- [x] `pytest agents/investment_team/tests/test_liquidity_and_cost_stress.py` — 18 passed (15 existing + 3 new):
  - `test_baseline_attaches_execution_diagnostics`
  - `test_cost_stress_rows_stay_compact_without_diagnostics`
  - `test_zero_trade_baseline_carries_execution_diagnostics`
- [x] Regression sweep across sibling backtest tests — 25 passed:
  - `test_backtest_anomaly_dsr_aware.py`
  - `test_subdaily_backtest.py`
  - `test_backtest_endpoint.py`
  - `test_fill_simulator_diagnostics.py`
- [x] `ruff check` and `ruff format --check` clean.

## Out of scope (handled by sibling sub-issues)

- `StrategyRunResult.execution_diagnostics` — #412
- `BacktestAnomalyDetector` consuming diagnostics — #413
- Refinement prompt formatting — #414

https://claude.ai/code/session_01ScMjqWYPwG4LRaTunubTjX

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScMjqWYPwG4LRaTunubTjX)_