### PR TITLE
investment-team: propagate execution_diagnostics through StrategyRunResult (#412)

### DIFF
--- a/backend/agents/investment_team/tests/test_sandbox_compat.py
+++ b/backend/agents/investment_team/tests/test_sandbox_compat.py
@@ -12,6 +12,7 @@ from typing import List
 
 from investment_team.models import (
     BacktestConfig,
+    BacktestExecutionDiagnostics,
     BacktestResult,
     StrategySpec,
     TradeRecord,
@@ -105,12 +106,19 @@ def test_mid_run_crash_with_partial_trades_fails_not_succeeds(monkeypatch) -> No
     — a path that could promote a broken strategy to paper/live.
     """
     partial: List[TradeRecord] = [_partial_trade()]
+    diagnostics = BacktestExecutionDiagnostics(
+        zero_trade_category="ORDERS_REJECTED",
+        summary="3 of 4 orders rejected by risk limits before crash",
+        orders_emitted=4,
+        orders_rejected=3,
+    )
     _patch_run_backtest(
         monkeypatch,
         service_result=TradingServiceResult(
             trades=partial,
             error="IndexError: list index out of range\n<traceback>",
             lookahead_violation=False,
+            execution_diagnostics=diagnostics,
         ),
     )
 
@@ -121,6 +129,9 @@ def test_mid_run_crash_with_partial_trades_fails_not_succeeds(monkeypatch) -> No
     assert "IndexError" in (result.stderr or "")
     # Partial trades are carried through for diagnostic visibility.
     assert result.trades == partial
+    # Service-level diagnostics propagate on the runtime-error path so #413/#414
+    # can route the failure on top of evidence rather than a generic message.
+    assert result.execution_diagnostics is diagnostics
 
 
 def test_lookahead_violation_with_partial_trades_still_classified_as_lookahead(
@@ -128,12 +139,17 @@ def test_lookahead_violation_with_partial_trades_still_classified_as_lookahead(
 ) -> None:
     """A lookahead_violation with prior fills keeps its own error_type."""
     partial: List[TradeRecord] = [_partial_trade()]
+    diagnostics = BacktestExecutionDiagnostics(
+        summary="lookahead detected mid-run",
+        bars_processed=42,
+    )
     _patch_run_backtest(
         monkeypatch,
         service_result=TradingServiceResult(
             trades=partial,
             error="AttributeError: Bar has no 'next_close'",
             lookahead_violation=True,
+            execution_diagnostics=diagnostics,
         ),
     )
 
@@ -142,23 +158,37 @@ def test_lookahead_violation_with_partial_trades_still_classified_as_lookahead(
     assert result.success is False
     assert result.error_type == "lookahead_violation"
     assert result.trades == partial
+    assert result.execution_diagnostics is diagnostics
 
 
 def test_clean_run_reports_success(monkeypatch) -> None:
     """Baseline: no error + trades present → success=True."""
     trades: List[TradeRecord] = [_partial_trade()]
+    diagnostics = BacktestExecutionDiagnostics(
+        summary="strategy emitted and closed 1 trade",
+        bars_processed=20,
+        orders_emitted=2,
+        orders_accepted=2,
+        entries_filled=1,
+        exits_emitted=1,
+        closed_trades=1,
+    )
     _patch_run_backtest(
         monkeypatch,
         service_result=TradingServiceResult(
             trades=trades,
             error=None,
             lookahead_violation=False,
+            execution_diagnostics=diagnostics,
         ),
     )
     result = sandbox_compat.run_strategy_code("dummy", {}, _config(), strategy=_strategy())
     assert result.success is True
     assert result.error_type is None
     assert result.trades == trades
+    # Diagnostics flow through on the success path too — refinement only fires
+    # on anomalies, but persisted run records (#414) want the envelope either way.
+    assert result.execution_diagnostics is diagnostics
 
 
 def test_initialisation_failure_with_empty_ledger_still_fails(monkeypatch) -> None:
@@ -166,15 +196,47 @@ def test_initialisation_failure_with_empty_ledger_still_fails(monkeypatch) -> No
     (strategy module missing, subprocess startup failure) still reports
     ``success=False`` now that the guard no longer depends on
     ``not run.trades``."""
+    diagnostics = BacktestExecutionDiagnostics(
+        zero_trade_category="NO_ORDERS_EMITTED",
+        summary="strategy module never initialised; no bars processed",
+    )
     _patch_run_backtest(
         monkeypatch,
         service_result=TradingServiceResult(
             trades=[],
             error="strategy module must define a subclass of contract.Strategy",
             lookahead_violation=False,
+            execution_diagnostics=diagnostics,
         ),
     )
     result = sandbox_compat.run_strategy_code("dummy", {}, _config(), strategy=_strategy())
     assert result.success is False
     assert result.error_type == "runtime_error"
     assert "strategy module" in (result.stderr or "")
+    assert result.execution_diagnostics is diagnostics
+
+
+def test_pre_backtest_value_error_synthesizes_unknown_zero_trade_diagnostics(
+    monkeypatch,
+) -> None:
+    """When ``run_backtest`` raises ``ValueError`` before any service result
+    exists (missing strategy_code, ambiguous market_data), the shim must
+    synthesize a minimal diagnostics envelope tagged
+    ``UNKNOWN_ZERO_TRADE_PATH`` so #413/#414 can still classify the failure."""
+
+    def _raise(*_args, **_kwargs):
+        raise ValueError("strategy_code is required")
+
+    monkeypatch.setattr(sandbox_compat, "run_backtest", _raise)
+
+    result = sandbox_compat.run_strategy_code("", {}, _config(), strategy=_strategy())
+
+    assert result.success is False
+    assert result.error_type == "runtime_error"
+    assert "strategy_code is required" in (result.stderr or "")
+    assert result.execution_diagnostics is not None
+    assert result.execution_diagnostics.zero_trade_category == "UNKNOWN_ZERO_TRADE_PATH"
+    assert "strategy_code is required" in result.execution_diagnostics.summary
+    # Counter fields stay at their model defaults — no bars were processed.
+    assert result.execution_diagnostics.bars_processed == 0
+    assert result.execution_diagnostics.orders_emitted == 0

--- a/backend/agents/investment_team/trading_service/modes/sandbox_compat.py
+++ b/backend/agents/investment_team/trading_service/modes/sandbox_compat.py
@@ -17,7 +17,7 @@ import time
 from dataclasses import dataclass, field
 from typing import Dict, List, Optional
 
-from ...models import BacktestConfig, StrategySpec, TradeRecord
+from ...models import BacktestConfig, BacktestExecutionDiagnostics, StrategySpec, TradeRecord
 from .backtest import run_backtest
 
 logger = logging.getLogger(__name__)
@@ -41,6 +41,7 @@ class StrategyRunResult:
     stderr: str = ""
     execution_time_seconds: float = 0.0
     error_type: Optional[str] = None
+    execution_diagnostics: Optional[BacktestExecutionDiagnostics] = None
 
 
 # Keys here match the legacy sandbox ``error_type`` taxonomy so the
@@ -86,12 +87,19 @@ def run_strategy_code(
         run = run_backtest(strategy=strategy, config=config, market_data=market_data)
     except ValueError as exc:
         # Typically raised when strategy_code is missing or the market_data
-        # arg is ambiguous — surface as a generic runtime error.
+        # arg is ambiguous — surface as a generic runtime error. No service
+        # result exists at this point, so synthesize a minimal diagnostics
+        # envelope tagged ``UNKNOWN_ZERO_TRADE_PATH`` so the refinement loop
+        # still sees that this was a startup-time failure.
         return StrategyRunResult(
             success=False,
             error_type=_RUNTIME_ERROR_TYPE,
             stderr=str(exc)[:2000],
             execution_time_seconds=time.monotonic() - start,
+            execution_diagnostics=BacktestExecutionDiagnostics(
+                zero_trade_category="UNKNOWN_ZERO_TRADE_PATH",
+                summary=f"Strategy startup failure before backtest could run: {str(exc)[:500]}",
+            ),
         )
 
     elapsed = time.monotonic() - start
@@ -104,6 +112,7 @@ def run_strategy_code(
             error_type=_LOOKAHEAD_ERROR_TYPE,
             stderr=(service_result.error or "")[:2000],
             execution_time_seconds=elapsed,
+            execution_diagnostics=service_result.execution_diagnostics,
         )
     if service_result.error:
         # Any surfaced service error — initialisation failure, mid-run
@@ -120,12 +129,14 @@ def run_strategy_code(
             error_type=_RUNTIME_ERROR_TYPE,
             stderr=service_result.error[:2000],
             execution_time_seconds=elapsed,
+            execution_diagnostics=service_result.execution_diagnostics,
         )
 
     return StrategyRunResult(
         success=True,
         trades=run.trades,
         execution_time_seconds=elapsed,
+        execution_diagnostics=service_result.execution_diagnostics,
     )
 
 


### PR DESCRIPTION
## Summary

Foundation of epic #404 (Strategy Lab zero-trade diagnostics envelope).

- Adds optional `execution_diagnostics: Optional[BacktestExecutionDiagnostics]` to `StrategyRunResult`
- Copies `service_result.execution_diagnostics` through on the success, lookahead-violation, and runtime-error return paths in `sandbox_compat.run_strategy_code`
- For the pre-backtest `ValueError` path (no service result to copy from), synthesizes a minimal envelope tagged `UNKNOWN_ZERO_TRADE_PATH` with a startup-failure summary
- Field defaults to `None`, so all existing callers and direct `StrategyRunResult(...)` constructions remain valid — purely additive

Closes #412. Unblocks #413 (BacktestAnomalyDetector consumes diagnostics) and #414 (orchestrator pipes diagnostics into refinement prompt).

## Files

- `backend/agents/investment_team/trading_service/modes/sandbox_compat.py`
- `backend/agents/investment_team/tests/test_sandbox_compat.py`

## Test plan

- [x] `ruff check` + `ruff format --check` on both files pass
- [x] `pytest agents/investment_team/tests/test_sandbox_compat.py` — 5/5 pass (4 existing tests extended with diagnostics assertions + 1 new `test_pre_backtest_value_error_synthesizes_unknown_zero_trade_diagnostics`)
- [x] `pytest agents/investment_team/tests/test_trading_service.py agents/investment_team/tests/test_execution_diagnostics_models.py` — 31/31 pass (no regressions in the upstream diagnostics producer)
- [x] Existing `success`/`trades`/`stderr`/`error_type` semantics unchanged — verified by the four pre-existing test paths still passing on their original assertions

## Acceptance criteria mapping (from #412)

- [x] Orchestrator can access `exec_result.execution_diagnostics`
- [x] Runtime error and lookahead paths preserve diagnostics
- [x] Pre-backtest `ValueError` path produces `UNKNOWN_ZERO_TRADE_PATH` + startup failure summary
- [x] Existing `success`, `trades`, `stderr`, and `error_type` behavior is unchanged


---
_Generated by [Claude Code](https://claude.ai/code/session_01VdL1UfwTja3vq5GkH1NZQC)_