### PR TITLE
investment-team: surface zero-trade diagnostics in BacktestAnomalyDetector (#413)

### DIFF
--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -343,7 +343,10 @@ class StrategyLabOrchestrator:
             )
 
             anomaly_gates = self.anomaly_detector.check(
-                metrics, trades, dsr_aware=config.walk_forward_enabled
+                metrics,
+                trades,
+                dsr_aware=config.walk_forward_enabled,
+                diagnostics=exec_result.execution_diagnostics,
             )
             for g in anomaly_gates:
                 g.refinement_round = round_num
@@ -591,7 +594,10 @@ class StrategyLabOrchestrator:
                 # output that bypasses quality gates and still flows into
                 # analysis and the win/loss classification.
                 anomaly_gates = self.anomaly_detector.check(
-                    new_metrics, new_trades, dsr_aware=config.walk_forward_enabled
+                    new_metrics,
+                    new_trades,
+                    dsr_aware=config.walk_forward_enabled,
+                    diagnostics=align_exec.execution_diagnostics,
                 )
                 for g in anomaly_gates:
                     g.refinement_round = align_round

--- a/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
@@ -2,12 +2,56 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import List, Optional
 
-from ...models import BacktestResult, TradeRecord
+from ...models import BacktestExecutionDiagnostics, BacktestResult, TradeRecord
 from .models import QualityGateResult
 
 GATE = "backtest_anomaly"
+
+_GENERIC_ZERO_TRADE_DETAILS = (
+    "Backtest produced zero trades — strategy code never entered a position."
+)
+
+
+def _format_zero_trade_details(diagnostics: Optional[BacktestExecutionDiagnostics]) -> str:
+    """Build the ``QualityGateResult.details`` string for a zero-trade backtest.
+
+    When ``diagnostics`` carries a deterministic ``zero_trade_category`` (see
+    issue #404), surface the category, the executor's summary, the order
+    counters, and any rejection-reason histogram so the refinement agent has
+    enough evidence to repair the entry/exit path. Falls back to the
+    historical generic message when diagnostics are missing or the executor
+    couldn't classify the failure.
+    """
+    if diagnostics is None or diagnostics.zero_trade_category is None:
+        return _GENERIC_ZERO_TRADE_DETAILS
+
+    parts: List[str] = [
+        f"Backtest produced zero trades — Category: {diagnostics.zero_trade_category}."
+    ]
+    if diagnostics.summary:
+        parts.append(diagnostics.summary)
+
+    counters = (
+        f"orders_emitted={diagnostics.orders_emitted} "
+        f"orders_accepted={diagnostics.orders_accepted} "
+        f"orders_rejected={diagnostics.orders_rejected} "
+        f"orders_unfilled={diagnostics.orders_unfilled} "
+        f"warmup_orders_dropped={diagnostics.warmup_orders_dropped} "
+        f"entries_filled={diagnostics.entries_filled} "
+        f"exits_emitted={diagnostics.exits_emitted}"
+    )
+    parts.append(counters)
+
+    if diagnostics.orders_rejection_reasons:
+        reasons = ", ".join(
+            f"{reason}={count}"
+            for reason, count in sorted(diagnostics.orders_rejection_reasons.items())
+        )
+        parts.append(f"rejection_reasons: {reasons}")
+
+    return " ".join(parts)
 
 
 class BacktestAnomalyDetector:
@@ -20,6 +64,7 @@ class BacktestAnomalyDetector:
         *,
         mode: str = "backtest",
         dsr_aware: bool = False,
+        diagnostics: Optional[BacktestExecutionDiagnostics] = None,
     ) -> List[QualityGateResult]:
         """Run anomaly checks.
 
@@ -33,6 +78,13 @@ class BacktestAnomalyDetector:
         ``Sharpe > 5.0`` single-window flag is downgraded from critical to
         warning — it still surfaces in the gate result list but no longer
         forces a refinement-loop rewrite when the OOS DSR clears the gate.
+
+        ``diagnostics`` (default None) is the optional execution-path
+        envelope produced by the trading service (see issue #404). When
+        provided on a zero-trade backtest it enriches the gate result with
+        a deterministic failure category and order counters so the
+        refinement agent can target the actual failure mode. Other gates
+        ignore it.
         """
         results: List[QualityGateResult] = []
 
@@ -44,7 +96,7 @@ class BacktestAnomalyDetector:
                     gate_name=GATE,
                     passed=False,
                     severity="critical",
-                    details="Backtest produced zero trades — strategy code never entered a position.",
+                    details=_format_zero_trade_details(diagnostics),
                 )
             )
             return results

--- a/backend/agents/investment_team/tests/test_backtest_anomaly_zero_trade_diagnostics.py
+++ b/backend/agents/investment_team/tests/test_backtest_anomaly_zero_trade_diagnostics.py
@@ -1,0 +1,207 @@
+"""Regression for zero-trade diagnostics enrichment in
+``BacktestAnomalyDetector`` (issue #413, part of #404).
+
+When the trading service supplies a ``BacktestExecutionDiagnostics`` envelope,
+the zero-trade gate result must carry the deterministic category, the
+executor's summary, the order counters, and (where present) the
+rejection-reason histogram so the refinement agent can target the actual
+failure mode. When diagnostics are missing, the existing generic message is
+preserved for backwards compatibility.
+"""
+
+from __future__ import annotations
+
+from investment_team.models import (
+    BacktestExecutionDiagnostics,
+    BacktestResult,
+    TradeRecord,
+)
+from investment_team.strategy_lab.quality_gates.backtest_anomaly import (
+    BacktestAnomalyDetector,
+)
+
+_GENERIC_ZERO_TRADE = "Backtest produced zero trades — strategy code never entered a position."
+
+
+def _empty_metrics() -> BacktestResult:
+    return BacktestResult(
+        total_return_pct=0.0,
+        annualized_return_pct=0.0,
+        volatility_pct=0.0,
+        sharpe_ratio=0.0,
+        max_drawdown_pct=0.0,
+        win_rate_pct=0.0,
+        profit_factor=0.0,
+    )
+
+
+def _winning_metrics() -> BacktestResult:
+    return BacktestResult(
+        total_return_pct=20.0,
+        annualized_return_pct=15.0,
+        volatility_pct=8.0,
+        sharpe_ratio=1.4,
+        max_drawdown_pct=5.0,
+        win_rate_pct=58.0,
+        profit_factor=1.6,
+    )
+
+
+def _trades_minimum() -> list[TradeRecord]:
+    """Six diversified, multi-day trades — enough to clear the < 5 floor,
+    avg-hold-< 1d, and concentration / single-side gates so non-zero-trade
+    tests don't false-positive on unrelated checks.
+    """
+    out: list[TradeRecord] = []
+    cum = 0.0
+    for i in range(6):
+        net = 30.0 if i % 2 == 0 else -10.0
+        cum += net
+        out.append(
+            TradeRecord(
+                trade_num=i + 1,
+                entry_date=f"2024-03-{i + 1:02d}",
+                exit_date=f"2024-04-{i + 1:02d}",
+                symbol="AAPL" if i % 2 == 0 else "MSFT",
+                side="long" if i % 2 == 0 else "short",
+                entry_price=100.0,
+                exit_price=100.0 + net / 10.0,
+                shares=10.0,
+                position_value=1000.0,
+                gross_pnl=net,
+                net_pnl=net,
+                return_pct=net / 1000.0 * 100,
+                hold_days=20,
+                outcome="win" if net > 0 else "loss",
+                cumulative_pnl=cum,
+            )
+        )
+    return out
+
+
+def test_zero_trade_with_no_orders_emitted_category():
+    diagnostics = BacktestExecutionDiagnostics(
+        zero_trade_category="NO_ORDERS_EMITTED",
+        summary="Strategy ran 250 bars but never emitted an order.",
+        bars_processed=250,
+    )
+    detector = BacktestAnomalyDetector()
+    results = detector.check(_empty_metrics(), [], diagnostics=diagnostics)
+    assert len(results) == 1
+    detail = results[0].details
+    assert "Category: NO_ORDERS_EMITTED" in detail
+    assert "Strategy ran 250 bars but never emitted an order." in detail
+    assert "orders_emitted=0" in detail
+    assert results[0].severity == "critical"
+    assert results[0].passed is False
+
+
+def test_zero_trade_with_orders_rejected_includes_reasons():
+    diagnostics = BacktestExecutionDiagnostics(
+        zero_trade_category="ORDERS_REJECTED",
+        summary="All 12 emitted orders were rejected before fill.",
+        bars_processed=300,
+        orders_emitted=12,
+        orders_rejected=12,
+        orders_rejection_reasons={"risk_limit": 7, "insufficient_capital": 5},
+    )
+    detector = BacktestAnomalyDetector()
+    results = detector.check(_empty_metrics(), [], diagnostics=diagnostics)
+    detail = results[0].details
+    assert "Category: ORDERS_REJECTED" in detail
+    assert "orders_emitted=12" in detail
+    assert "orders_rejected=12" in detail
+    # Rejection reasons must be deterministic (sorted alphabetically by key).
+    assert "rejection_reasons: insufficient_capital=5, risk_limit=7" in detail
+
+
+def test_zero_trade_with_orders_unfilled_category():
+    diagnostics = BacktestExecutionDiagnostics(
+        zero_trade_category="ORDERS_UNFILLED",
+        summary="Orders accepted but never crossed the fill price.",
+        orders_emitted=4,
+        orders_accepted=4,
+        orders_unfilled=4,
+    )
+    detector = BacktestAnomalyDetector()
+    results = detector.check(_empty_metrics(), [], diagnostics=diagnostics)
+    detail = results[0].details
+    assert "Category: ORDERS_UNFILLED" in detail
+    assert "orders_unfilled=4" in detail
+
+
+def test_zero_trade_with_entry_with_no_exit_category():
+    diagnostics = BacktestExecutionDiagnostics(
+        zero_trade_category="ENTRY_WITH_NO_EXIT",
+        summary="One position opened but never closed before end of stream.",
+        orders_emitted=1,
+        orders_accepted=1,
+        entries_filled=1,
+        exits_emitted=0,
+    )
+    detector = BacktestAnomalyDetector()
+    results = detector.check(_empty_metrics(), [], diagnostics=diagnostics)
+    detail = results[0].details
+    assert "Category: ENTRY_WITH_NO_EXIT" in detail
+    assert "entries_filled=1" in detail
+    assert "exits_emitted=0" in detail
+
+
+def test_zero_trade_diagnostics_missing_falls_back_to_generic_message():
+    """No diagnostics envelope → preserve the historical exact string verbatim,
+    so the existing #404 sub-issue spec and any downstream consumers that
+    grepped for it keep working.
+    """
+    detector = BacktestAnomalyDetector()
+    results = detector.check(_empty_metrics(), [])
+    assert len(results) == 1
+    assert results[0].details == _GENERIC_ZERO_TRADE
+
+
+def test_zero_trade_diagnostics_present_but_category_none_falls_back_to_generic():
+    """Executor surfaced a diagnostics envelope but couldn't classify the
+    failure (category=None) → fall back to the generic message rather than
+    leaking partial counters that don't explain anything.
+    """
+    diagnostics = BacktestExecutionDiagnostics(
+        zero_trade_category=None,
+        summary="",
+        bars_processed=10,
+    )
+    detector = BacktestAnomalyDetector()
+    results = detector.check(_empty_metrics(), [], diagnostics=diagnostics)
+    assert results[0].details == _GENERIC_ZERO_TRADE
+
+
+def test_existing_callers_without_diagnostics_kwarg_still_work():
+    """Callers that pre-date #413 must keep working: positional ``check``,
+    ``mode=``, and ``dsr_aware=`` invocations all return the same generic
+    zero-trade gate result without a TypeError.
+    """
+    detector = BacktestAnomalyDetector()
+
+    bare = detector.check(_empty_metrics(), [])
+    assert bare[0].details == _GENERIC_ZERO_TRADE
+
+    with_dsr = detector.check(_empty_metrics(), [], dsr_aware=True)
+    assert with_dsr[0].details == _GENERIC_ZERO_TRADE
+
+    paper = detector.check(_empty_metrics(), [], mode="paper")
+    assert paper[0].details == _GENERIC_ZERO_TRADE
+
+
+def test_non_zero_trade_behaviour_unchanged_with_diagnostics_passed():
+    """Diagnostics is consulted only inside the zero-trade branch — passing it
+    on a successful, non-zero-trade backtest must not perturb the gate
+    results.
+    """
+    diagnostics = BacktestExecutionDiagnostics(
+        zero_trade_category="NO_ORDERS_EMITTED",
+        summary="should be ignored when trades exist",
+    )
+    detector = BacktestAnomalyDetector()
+    with_diag = detector.check(_winning_metrics(), _trades_minimum(), diagnostics=diagnostics)
+    without_diag = detector.check(_winning_metrics(), _trades_minimum())
+    assert [(r.gate_name, r.passed, r.severity, r.details) for r in with_diag] == [
+        (r.gate_name, r.passed, r.severity, r.details) for r in without_diag
+    ]

--- a/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
@@ -609,6 +609,7 @@ def test_walk_forward_fallback_rejects_overfit_via_anomaly_recheck(monkeypatch):
             self.execution_time_seconds = 0.01
             self.error_type = None
             self.stderr = ""
+            self.execution_diagnostics = None
 
     monkeypatch.setattr(
         "investment_team.strategy_lab.orchestrator.run_strategy_code",


### PR DESCRIPTION
Closes #413 (part of #404).

## Summary
- `BacktestAnomalyDetector.check` accepts an optional `BacktestExecutionDiagnostics` envelope. On a zero-trade run the gate's `details` string is enriched with the deterministic category, the executor's summary, the order counters, and a sorted `rejection_reasons` histogram so the refinement agent can target the actual entry/exit failure path instead of seeing the same generic message every round.
- When `diagnostics` is missing or `zero_trade_category is None`, the historical generic detail string is preserved verbatim — existing callers and any downstream string-matchers stay valid.
- Orchestrator main loop and alignment loop now pass `diagnostics=exec_result.execution_diagnostics` / `align_exec.execution_diagnostics`. The walk-forward fallback site is left unchanged because it only runs with non-empty trades, so the new branch can't fire.
- New test module `test_backtest_anomaly_zero_trade_diagnostics.py` covers all four executor categories called out in #404 (`NO_ORDERS_EMITTED`, `ORDERS_REJECTED` with reasons, `ORDERS_UNFILLED`, `ENTRY_WITH_NO_EXIT`), the two fallback paths (no envelope, envelope-without-category), positional/`mode=`/`dsr_aware=` invocations, and a regression that non-zero-trade behaviour is unaffected when diagnostics are passed.

## Test plan
- [x] `ruff check` + `ruff format --check` on the three touched files
- [x] Targeted smoke run of the new tests (8 cases) — all pass
- [ ] CI: full `pytest backend/agents/investment_team/tests/`
- [ ] CI: ruff + docker smoke test

## Acceptance-criteria mapping (issue #413)
- "Zero-trade `QualityGateResult.details` contains the deterministic category" — `_format_zero_trade_details` + four category tests
- "Existing callers remain valid because diagnostics is optional" — keyword-only param defaulting to `None` + `test_existing_callers_without_diagnostics_kwarg_still_work`
- "Non-zero-trade anomaly behavior is unchanged" — `diagnostics` is consulted only inside the `if not trades:` block + `test_non_zero_trade_behaviour_unchanged_with_diagnostics_passed`

---
_Generated by [Claude Code](https://claude.ai/code/session_015y8fxXDQuGe68UmnSmUxAt)_