### PR TITLE
investment-team: surface execution diagnostics in Strategy Lab refinement prompts (#414)

### DIFF
--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -11,6 +11,7 @@ Pipeline:
 
 from __future__ import annotations
 
+import json
 import logging
 import math
 import os
@@ -35,6 +36,7 @@ from ..execution.walk_forward import (
 from ..market_data_service import MarketDataService, OHLCVBar
 from ..models import (
     BacktestConfig,
+    BacktestExecutionDiagnostics,
     BacktestRecord,
     BacktestResult,
     StrategyLabRecord,
@@ -72,6 +74,36 @@ MAX_ALIGNMENT_ROUNDS = 10
 # count + regime beats); ``WINNING_THRESHOLD`` is now only consulted as a
 # fallback when ``BacktestConfig.walk_forward_enabled`` is False.
 WINNING_THRESHOLD = 8.0
+
+# Cap on `last_order_events` included in the refinement-prompt diagnostics
+# block. The model already trims to 20; 10 is enough signal for the LLM to
+# spot the failure pattern while keeping the JSON line under ~1 KB.
+_DIAGNOSTICS_LAST_EVENTS_CAP = 10
+
+
+def _format_execution_diagnostics(
+    diagnostics: Optional[BacktestExecutionDiagnostics],
+) -> str:
+    """Render a compact JSON block of execution diagnostics for the
+    refinement prompt (issue #414, part of #404).
+
+    Returns an empty string when diagnostics is missing or the executor
+    couldn't classify a zero-trade failure — healthy backtests must not
+    bloat the prompt. When a ``zero_trade_category`` is present, returns a
+    single line ``"Execution Diagnostics: {<json>}"`` whose JSON payload is
+    stable-key-sorted and compact. ``last_order_events`` is capped to the
+    most recent ``_DIAGNOSTICS_LAST_EVENTS_CAP`` entries.
+    """
+    if diagnostics is None or diagnostics.zero_trade_category is None:
+        return ""
+
+    payload = diagnostics.model_dump(mode="json", exclude_none=True)
+    events = payload.get("last_order_events") or []
+    if len(events) > _DIAGNOSTICS_LAST_EVENTS_CAP:
+        payload["last_order_events"] = events[-_DIAGNOSTICS_LAST_EVENTS_CAP:]
+
+    encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+    return f"Execution Diagnostics: {encoded}"
 
 
 class StrategyLabOrchestrator:
@@ -366,6 +398,11 @@ class StrategyLabOrchestrator:
                         },
                     )
                     failure_details = "\n".join(f"- {g.details}" for g in critical_anomalies)
+                    diagnostics_block = _format_execution_diagnostics(
+                        exec_result.execution_diagnostics
+                    )
+                    if diagnostics_block:
+                        failure_details = f"{failure_details}\n{diagnostics_block}"
                     updates, code = self._refine(
                         spec,
                         code,
@@ -607,17 +644,28 @@ class StrategyLabOrchestrator:
                     g for g in anomaly_gates if not g.passed and g.severity == "critical"
                 ]
                 if critical_anomalies:
-                    emit(
-                        "aligning",
-                        {
-                            "sub_phase": "anomaly_detected",
-                            "alignment_round": align_round,
-                            "details": "; ".join(g.details for g in critical_anomalies)[:400],
-                        },
+                    diagnostics_block = _format_execution_diagnostics(
+                        align_exec.execution_diagnostics
                     )
-                    logger.warning(
-                        "Alignment fix introduced backtest anomaly for %s", spec.strategy_id
-                    )
+                    emit_payload: Dict[str, Any] = {
+                        "sub_phase": "anomaly_detected",
+                        "alignment_round": align_round,
+                        "details": "; ".join(g.details for g in critical_anomalies)[:400],
+                    }
+                    if diagnostics_block:
+                        emit_payload["execution_diagnostics"] = diagnostics_block
+                    emit("aligning", emit_payload)
+                    if diagnostics_block:
+                        logger.warning(
+                            "Alignment fix introduced backtest anomaly for %s — %s",
+                            spec.strategy_id,
+                            diagnostics_block,
+                        )
+                    else:
+                        logger.warning(
+                            "Alignment fix introduced backtest anomaly for %s",
+                            spec.strategy_id,
+                        )
                     break
 
                 # All gates passed — commit the proposal as the new

--- a/backend/agents/investment_team/tests/test_strategy_lab_diagnostics_prompt.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_diagnostics_prompt.py
@@ -1,0 +1,145 @@
+"""Tests for ``_format_execution_diagnostics`` (issue #414, part of #404).
+
+The orchestrator wraps the executor's ``BacktestExecutionDiagnostics`` envelope
+into a single compact JSON line that gets appended to the refinement prompt's
+``failure_details`` string. The line lets the refinement agent see structured
+evidence (categories, counters, rejection reasons, lifecycle events) that the
+prose summary in the gate ``details`` text leaves out.
+"""
+
+from __future__ import annotations
+
+import json
+
+from investment_team.models import (
+    BacktestExecutionDiagnostics,
+    OpenPositionDiagnostic,
+    OrderLifecycleEvent,
+)
+from investment_team.strategy_lab.orchestrator import (
+    _DIAGNOSTICS_LAST_EVENTS_CAP,
+    _format_execution_diagnostics,
+)
+
+
+def _block_payload(line: str) -> dict:
+    """Strip the ``Execution Diagnostics: `` prefix and parse the JSON body."""
+    prefix = "Execution Diagnostics: "
+    assert line.startswith(prefix), line
+    return json.loads(line[len(prefix) :])
+
+
+def test_returns_empty_string_when_diagnostics_missing():
+    assert _format_execution_diagnostics(None) == ""
+
+
+def test_returns_empty_string_when_category_unset():
+    """Healthy backtests must not bloat the refinement prompt — the helper
+    only emits a block when the executor classified a zero-trade failure."""
+    diagnostics = BacktestExecutionDiagnostics(
+        zero_trade_category=None,
+        summary="",
+        bars_processed=250,
+        orders_emitted=12,
+        entries_filled=12,
+        closed_trades=12,
+    )
+    assert _format_execution_diagnostics(diagnostics) == ""
+
+
+def test_emits_compact_json_block_with_expected_keys():
+    diagnostics = BacktestExecutionDiagnostics(
+        zero_trade_category="ORDERS_REJECTED",
+        summary="All 12 emitted orders were rejected before fill.",
+        bars_processed=300,
+        orders_emitted=12,
+        orders_accepted=0,
+        orders_rejected=12,
+        orders_rejection_reasons={"risk_limit": 7, "insufficient_capital": 5},
+        last_order_events=[
+            OrderLifecycleEvent(
+                event_type="rejected",
+                symbol="AAPL",
+                side="long",
+                reason="risk_limit",
+                detail="position_size_exceeded",
+            ),
+        ],
+        open_positions_at_end=[
+            OpenPositionDiagnostic(
+                symbol="MSFT",
+                side="long",
+                qty=10.0,
+                entry_price=300.0,
+                entry_timestamp="2024-06-15T15:30:00",
+            ),
+        ],
+    )
+
+    line = _format_execution_diagnostics(diagnostics)
+    payload = _block_payload(line)
+
+    assert payload["zero_trade_category"] == "ORDERS_REJECTED"
+    assert payload["summary"] == "All 12 emitted orders were rejected before fill."
+    assert payload["orders_emitted"] == 12
+    assert payload["orders_rejected"] == 12
+    assert payload["orders_rejection_reasons"] == {
+        "risk_limit": 7,
+        "insufficient_capital": 5,
+    }
+    assert len(payload["last_order_events"]) == 1
+    assert payload["last_order_events"][0]["event_type"] == "rejected"
+    assert payload["open_positions_at_end"][0]["symbol"] == "MSFT"
+
+
+def test_last_order_events_truncated_to_cap_keeping_most_recent():
+    """``BacktestExecutionDiagnostics.last_order_events`` already caps at 20
+    inside the trading service; the prompt block trims further to the most
+    recent ``_DIAGNOSTICS_LAST_EVENTS_CAP`` to keep the JSON line short."""
+    over_cap = _DIAGNOSTICS_LAST_EVENTS_CAP + 5
+    events = [
+        OrderLifecycleEvent(
+            event_type="emitted",
+            symbol="AAPL",
+            side="long",
+            detail=f"event_{i}",
+        )
+        for i in range(over_cap)
+    ]
+    diagnostics = BacktestExecutionDiagnostics(
+        zero_trade_category="ORDERS_UNFILLED",
+        summary="never crossed the fill price",
+        last_order_events=events,
+    )
+
+    line = _format_execution_diagnostics(diagnostics)
+    payload = _block_payload(line)
+
+    kept = payload["last_order_events"]
+    assert len(kept) == _DIAGNOSTICS_LAST_EVENTS_CAP
+    # Most recent are kept (suffix), not the prefix.
+    assert kept[0]["detail"] == f"event_{over_cap - _DIAGNOSTICS_LAST_EVENTS_CAP}"
+    assert kept[-1]["detail"] == f"event_{over_cap - 1}"
+
+
+def test_json_is_compact_and_key_sorted_for_determinism():
+    """The block goes into LLM prompts — deterministic key ordering keeps
+    cache hits stable across runs and the compact separators minimize tokens.
+    """
+    diagnostics = BacktestExecutionDiagnostics(
+        zero_trade_category="NO_ORDERS_EMITTED",
+        summary="no orders",
+        bars_processed=100,
+        orders_emitted=0,
+    )
+
+    line = _format_execution_diagnostics(diagnostics)
+    body = line[len("Execution Diagnostics: ") :]
+
+    # Compact: no whitespace after separators.
+    assert ", " not in body
+    assert ": " not in body
+
+    # Key-sorted: re-encoding with sort_keys must be byte-identical.
+    payload = json.loads(body)
+    assert json.dumps(payload, separators=(",", ":"), sort_keys=True) == body


### PR DESCRIPTION
## Summary

Closes the last open child of epic #404 (Strategy Lab zero-trade diagnostics envelope).

The trading service has emitted a typed `BacktestExecutionDiagnostics` envelope since #407–#412, and #413 wired it into the zero-trade gate's prose `details` text. This change appends a compact, key-sorted JSON block of the same envelope to the `failure_details` string passed into `RefinementAgent.run`, so the refinement LLM sees structured evidence (`zero_trade_category`, counters, rejection histogram, `last_order_events`, `open_positions_at_end`) rather than only the prose summary.

- Add `_format_execution_diagnostics` helper in `strategy_lab/orchestrator.py` (returns `""` on healthy backtests; caps `last_order_events` to 10 to keep the prompt under ~1 KB).
- Append `Execution Diagnostics: {…}` to `failure_details` on the primary backtest-anomaly refinement path.
- Surface the same block in the alignment re-backtest emit payload and warning log (alignment loop logs + breaks; no refinement call, but operators see the same evidence).
- `RefinementAgent.run` signature unchanged.

## Test plan

- [x] `pytest backend/agents/investment_team/tests/test_strategy_lab_diagnostics_prompt.py` — 5 new cases (missing diagnostics, unset category, populated envelope, `last_order_events` truncation, compact key-sorted output)
- [x] `pytest backend/agents/investment_team/tests/test_strategy_lab_alignment.py test_backtest_anomaly_zero_trade_diagnostics.py test_backtest_anomaly_dsr_aware.py test_execution_diagnostics_models.py` — 36 passed (no regressions on the upstream #407–#413 work)
- [x] `ruff check backend/agents/investment_team/` — clean

Closes #414.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JNMdsFAJu3SRVxD89xNKz4)_