### PR TITLE
investment-team: add specialized zero-trade repair loop to Strategy Lab (#405)

### DIFF
--- a/backend/agents/investment_team/strategy_lab/agents/zero_trade_repair.py
+++ b/backend/agents/investment_team/strategy_lab/agents/zero_trade_repair.py
@@ -1,0 +1,305 @@
+"""Strands Agent that diagnoses zero-trade backtest failures and proposes
+Python code fixes targeted at the deterministic `zero_trade_category`
+classified by the trading service (see issue #404).
+
+Used by :class:`StrategyLabOrchestrator` ahead of the generic
+:class:`RefinementAgent` whenever a refinement-loop backtest produces a
+critical zero-trade anomaly. The orchestrator drives a one-shot repair
+attempt per refinement round: the proposed code is sent through code
+safety + a fresh backtest + the anomaly gates before being committed
+over the previous known-good state. Failed proposals fall through to
+the generic refinement agent so existing behavior is preserved.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field
+from strands import Agent
+
+from ...models import BacktestExecutionDiagnostics, StrategySpec, ZeroTradeCategory
+from .model_factory import get_strands_model
+
+logger = logging.getLogger(__name__)
+
+_PROMPT_DIR = Path(__file__).resolve().parent.parent / "prompts"
+
+# Spec keys the orchestrator will honour from a ZeroTradeRepairReport's
+# ``proposed_spec_updates``. Anything else is silently dropped — the
+# specialized repair agent must not invent fields.
+_ALLOWED_SPEC_UPDATE_KEYS = frozenset(
+    {
+        "entry_rules",
+        "exit_rules",
+        "sizing_rules",
+        "risk_limits",
+        "hypothesis",
+        "signal_definition",
+    }
+)
+
+# Cap on `last_order_events` included in the repair prompt. The model
+# already trims to 20; 10 is enough signal for the LLM to spot the
+# failure pattern while keeping the JSON line under ~1 KB.
+_DIAGNOSTICS_LAST_EVENTS_CAP = 10
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class ZeroTradeRepairReport(BaseModel):
+    """Verdict from one zero-trade repair attempt."""
+
+    root_cause_category: ZeroTradeCategory
+    evidence: str = ""
+    code_issue: Optional[str] = None
+    strategy_rule_issue: Optional[str] = None
+    proposed_code: Optional[str] = None
+    expected_order_count_change: int = 0
+    expected_trade_count_change: int = 0
+    changes_made: str = ""
+    proposed_spec_updates: Optional[Dict[str, Any]] = Field(default=None)
+
+
+# ---------------------------------------------------------------------------
+# Prompts
+# ---------------------------------------------------------------------------
+
+
+_ZERO_TRADE_USER_TEMPLATE = """\
+The most recent backtest produced zero trades. Diagnose the failure
+using the deterministic execution diagnostics below and propose a
+minimal Python code fix so the next run emits and closes trades that
+remain consistent with the strategy specification.
+
+## Strategy Specification (source of truth)
+Asset class: {asset_class}
+Hypothesis: {hypothesis}
+Signal definition: {signal_definition}
+Entry rules: {entry_rules}
+Exit rules: {exit_rules}
+Sizing rules: {sizing_rules}
+Risk limits: {risk_limits}
+
+## Current Strategy Code
+```python
+{strategy_code}
+```
+
+## Execution Diagnostics
+Zero-trade category: {zero_trade_category}
+Summary: {summary}
+{diagnostics_block}
+
+## Prior Zero-Trade Repair Attempts ({n_prior_attempts} so far)
+{prior_attempts_text}
+
+## Instructions
+1. Restate the `zero_trade_category` and quote the counters / rejection
+   reasons / lifecycle events that prove the diagnosis.
+2. Identify the specific code branch that produced the failure.
+3. Rewrite the FULL Python module so the identified failure no longer
+   occurs while preserving the spec's intent. Keep the
+   `class _(Strategy)` + `on_bar(self, ctx, bar)` contract and use only
+   allowed imports.
+4. Predict the change in order and trade count your fix should produce.
+
+Return ONLY a JSON object with no markdown.
+"""
+
+
+# ---------------------------------------------------------------------------
+# Agent
+# ---------------------------------------------------------------------------
+
+
+class ZeroTradeRepairAgent:
+    """Diagnose a zero-trade backtest and propose a targeted code fix."""
+
+    def run(
+        self,
+        spec: StrategySpec,
+        code: str,
+        diagnostics: BacktestExecutionDiagnostics,
+        prior_attempts: Optional[List[str]] = None,
+    ) -> ZeroTradeRepairReport:
+        """Run one specialized zero-trade repair attempt.
+
+        Returns a :class:`ZeroTradeRepairReport`. On parser failure the
+        report falls back to ``proposed_code=None`` with the parse error
+        in ``evidence`` so the orchestrator falls through to the generic
+        refinement agent (matching the alignment agent's
+        no-infinite-loop posture).
+        """
+        if diagnostics.zero_trade_category is None:
+            # The orchestrator should not have routed a non-zero-trade
+            # diagnostics envelope here. Be defensive — return a no-op
+            # report so the caller falls through to generic refinement.
+            return ZeroTradeRepairReport(
+                root_cause_category="UNKNOWN_ZERO_TRADE_PATH",
+                evidence=(
+                    "Diagnostics envelope had no zero_trade_category; skipping specialized repair."
+                ),
+            )
+
+        system_prompt = (_PROMPT_DIR / "zero_trade_repair_system.md").read_text(encoding="utf-8")
+
+        prior_text = (
+            "None yet."
+            if not prior_attempts
+            else "\n".join(f"  Round {i + 1}: {a}" for i, a in enumerate(prior_attempts))
+        )
+
+        user_prompt = _ZERO_TRADE_USER_TEMPLATE.format(
+            asset_class=spec.asset_class,
+            hypothesis=spec.hypothesis,
+            signal_definition=spec.signal_definition,
+            entry_rules=", ".join(spec.entry_rules),
+            exit_rules=", ".join(spec.exit_rules),
+            sizing_rules=", ".join(spec.sizing_rules),
+            risk_limits=spec.risk_limits.model_dump_json(),
+            strategy_code=code,
+            zero_trade_category=diagnostics.zero_trade_category,
+            summary=diagnostics.summary or "(no executor summary)",
+            diagnostics_block=_format_diagnostics_block(diagnostics),
+            n_prior_attempts=len(prior_attempts) if prior_attempts else 0,
+            prior_attempts_text=prior_text,
+        )
+
+        agent = Agent(
+            model=get_strands_model("strategy_ideation"),
+            system_prompt=system_prompt,
+            tools=[],
+        )
+
+        try:
+            result = agent(user_prompt)
+            parsed = _extract_json(str(result))
+        except Exception as exc:
+            logger.exception("Zero-trade repair agent failed to produce parseable JSON")
+            return ZeroTradeRepairReport(
+                root_cause_category=diagnostics.zero_trade_category,
+                evidence=(
+                    f"Zero-trade repair skipped: LLM response could not be parsed ({exc}). "
+                    "Falling through to generic refinement."
+                ),
+            )
+
+        return _coerce_report(parsed, fallback_category=diagnostics.zero_trade_category)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _format_diagnostics_block(diagnostics: BacktestExecutionDiagnostics) -> str:
+    """Render a compact JSON block of the diagnostics envelope.
+
+    Mirrors :func:`strategy_lab.orchestrator._format_execution_diagnostics`
+    so the repair-prompt payload matches what the generic refinement
+    prompt sees, but always emits the full envelope (the orchestrator
+    only routes here when ``zero_trade_category`` is set).
+    """
+    payload = diagnostics.model_dump(mode="json", exclude_none=True)
+    events = payload.get("last_order_events") or []
+    if len(events) > _DIAGNOSTICS_LAST_EVENTS_CAP:
+        payload["last_order_events"] = events[-_DIAGNOSTICS_LAST_EVENTS_CAP:]
+    encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+    return f"Envelope: {encoded}"
+
+
+def _coerce_report(
+    parsed: Dict[str, Any], fallback_category: ZeroTradeCategory
+) -> ZeroTradeRepairReport:
+    """Convert raw LLM JSON into a :class:`ZeroTradeRepairReport`.
+
+    Tolerates loose schemas (missing fields, snake_case vs camelCase
+    issues, integer-as-string deltas) so a small format drift in the LLM
+    does not abort the specialized repair branch — the caller will fall
+    through to generic refinement on a no-op report.
+    """
+    raw_category = parsed.get("root_cause_category")
+    valid_categories = {
+        "NO_ORDERS_EMITTED",
+        "ONLY_WARMUP_ORDERS",
+        "ORDERS_REJECTED",
+        "ORDERS_UNFILLED",
+        "ENTRY_WITH_NO_EXIT",
+        "UNKNOWN_ZERO_TRADE_PATH",
+    }
+    category = raw_category if raw_category in valid_categories else fallback_category
+
+    proposed_code_raw = parsed.get("proposed_code")
+    proposed_code = (
+        str(proposed_code_raw).strip()
+        if isinstance(proposed_code_raw, str) and proposed_code_raw.strip()
+        else None
+    )
+
+    raw_spec_updates = parsed.get("proposed_spec_updates")
+    proposed_spec_updates: Optional[Dict[str, Any]]
+    if isinstance(raw_spec_updates, dict):
+        whitelisted = {k: v for k, v in raw_spec_updates.items() if k in _ALLOWED_SPEC_UPDATE_KEYS}
+        proposed_spec_updates = whitelisted or None
+    else:
+        proposed_spec_updates = None
+
+    def _coerce_int(value: Any) -> int:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return 0
+
+    return ZeroTradeRepairReport(
+        root_cause_category=category,  # type: ignore[arg-type]
+        evidence=str(parsed.get("evidence", "")).strip(),
+        code_issue=_optional_str(parsed.get("code_issue")),
+        strategy_rule_issue=_optional_str(parsed.get("strategy_rule_issue")),
+        proposed_code=proposed_code,
+        expected_order_count_change=_coerce_int(parsed.get("expected_order_count_change", 0)),
+        expected_trade_count_change=_coerce_int(parsed.get("expected_trade_count_change", 0)),
+        changes_made=str(parsed.get("changes_made", "")).strip(),
+        proposed_spec_updates=proposed_spec_updates,
+    )
+
+
+def _optional_str(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _extract_json(text: str) -> Dict[str, Any]:
+    """Extract a JSON object from LLM output, handling markdown fences."""
+    fence_match = re.search(r"```(?:json)?\s*\n?(.*?)\n?```", text, re.DOTALL)
+    if fence_match:
+        text = fence_match.group(1)
+
+    start = text.find("{")
+    if start == -1:
+        raise ValueError("No JSON object found in LLM response")
+
+    depth = 0
+    end = start
+    for i in range(start, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                end = i + 1
+                break
+
+    try:
+        return json.loads(text[start:end])
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Failed to parse JSON from LLM response: {e}") from e

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -16,6 +16,7 @@ import logging
 import math
 import os
 import uuid
+from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
@@ -46,11 +47,12 @@ from ..models import (
 )
 from ..signal_intelligence_models import SignalIntelligenceBriefV1
 from ..trade_simulator import compute_metrics
-from ..trading_service.modes.sandbox_compat import run_strategy_code
+from ..trading_service.modes.sandbox_compat import StrategyRunResult, run_strategy_code
 from .agents.alignment import TradeAlignmentAgent, TradeAlignmentReport
 from .agents.analysis import AnalysisAgent
 from .agents.ideation import IdeationAgent
 from .agents.refinement import RefinementAgent
+from .agents.zero_trade_repair import ZeroTradeRepairAgent, ZeroTradeRepairReport
 from .quality_gates.acceptance_gate import AcceptanceGate, summarize_acceptance_reason
 from .quality_gates.backtest_anomaly import BacktestAnomalyDetector
 from .quality_gates.code_safety import CodeSafetyChecker
@@ -106,6 +108,43 @@ def _format_execution_diagnostics(
     return f"Execution Diagnostics: {encoded}"
 
 
+# Spec keys honoured when applying ``ZeroTradeRepairReport.proposed_spec_updates``.
+# Mirrors the agent-side whitelist so the orchestrator silently drops any
+# off-list keys an LLM might invent.
+_ZERO_TRADE_SPEC_UPDATE_KEYS = frozenset(
+    {
+        "entry_rules",
+        "exit_rules",
+        "sizing_rules",
+        "risk_limits",
+        "hypothesis",
+        "signal_definition",
+    }
+)
+
+
+@dataclass
+class _ZeroTradeRepairOutcome:
+    """Result of one specialized zero-trade repair attempt.
+
+    ``committed=True`` means the proposed code passed code-safety, ran
+    cleanly, and produced trades that no longer trip a critical anomaly
+    gate; the orchestrator should swap in the new state. ``False`` means
+    the caller should fall through to the generic refinement agent so
+    the existing loop semantics are preserved.
+    """
+
+    committed: bool
+    new_code: str = ""
+    new_spec: Optional[StrategySpec] = None
+    new_trades: List[TradeRecord] = field(default_factory=list)
+    new_metrics: Optional[BacktestResult] = None
+    new_exec_result: Optional[StrategyRunResult] = None
+    new_gates: List[QualityGateResult] = field(default_factory=list)
+    failure_reason: str = ""
+    changes_made: str = ""
+
+
 class StrategyLabOrchestrator:
     """Deterministic pipeline controller for the Strategy Lab.
 
@@ -118,6 +157,7 @@ class StrategyLabOrchestrator:
         self.ideation_agent = IdeationAgent()
         self.refinement_agent = RefinementAgent()
         self.alignment_agent = TradeAlignmentAgent()
+        self.zero_trade_repair_agent = ZeroTradeRepairAgent()
         self.analysis_agent = AnalysisAgent()
         self.strategy_validator = StrategySpecValidator()
         self.code_safety_checker = CodeSafetyChecker()
@@ -193,6 +233,7 @@ class StrategyLabOrchestrator:
 
         all_gate_results: List[QualityGateResult] = []
         refinement_attempts: List[str] = []
+        zero_trade_attempts: List[str] = []
         trades: List[TradeRecord] = []
         metrics = compute_metrics([], config.initial_capital, config.start_date, config.end_date)
         execution_succeeded = False
@@ -403,6 +444,60 @@ class StrategyLabOrchestrator:
                     )
                     if diagnostics_block:
                         failure_details = f"{failure_details}\n{diagnostics_block}"
+
+                    # Issue #405 — specialized zero-trade repair branch.
+                    # If the critical anomaly carries a deterministic
+                    # ``zero_trade_category``, ask the targeted repair
+                    # agent first. On a successful repair the proposal
+                    # has already passed code-safety, a fresh backtest,
+                    # and the anomaly gates, so we commit it and re-
+                    # enter the loop. On a failed proposal we fall
+                    # through to the generic refinement agent so the
+                    # existing loop semantics are preserved.
+                    diag = exec_result.execution_diagnostics
+                    if (
+                        diag is not None
+                        and diag.zero_trade_category is not None
+                        and market_data is not None
+                    ):
+                        zt_outcome = self._run_zero_trade_repair(
+                            spec=spec,
+                            code=code,
+                            exec_result=exec_result,
+                            market_data=market_data,
+                            config=config,
+                            zero_trade_attempts=zero_trade_attempts,
+                            round_num=round_num,
+                            emit=emit,
+                        )
+                        all_gate_results.extend(zt_outcome.new_gates)
+                        if zt_outcome.committed:
+                            assert zt_outcome.new_spec is not None
+                            assert zt_outcome.new_metrics is not None
+                            assert zt_outcome.new_exec_result is not None
+                            code = zt_outcome.new_code
+                            spec = zt_outcome.new_spec
+                            trades = zt_outcome.new_trades
+                            metrics = zt_outcome.new_metrics
+                            exec_result = zt_outcome.new_exec_result
+                            refinement_attempts.append(
+                                f"zero-trade repair: {zt_outcome.changes_made}"
+                                if zt_outcome.changes_made
+                                else "zero-trade repair"
+                            )
+                            emit(
+                                "coding",
+                                {
+                                    "sub_phase": "refined",
+                                    "refinement_round": round_num,
+                                    "changes_made": (
+                                        zt_outcome.changes_made or "zero-trade repair"
+                                    ),
+                                    "via": "zero_trade_repair",
+                                },
+                            )
+                            continue
+
                     updates, code = self._refine(
                         spec,
                         code,
@@ -909,6 +1004,228 @@ class StrategyLabOrchestrator:
                     f"{type(exc).__name__}. Treating trades as aligned to avoid stalling."
                 ),
             )
+
+    def _run_zero_trade_repair(
+        self,
+        *,
+        spec: StrategySpec,
+        code: str,
+        exec_result: StrategyRunResult,
+        market_data: Dict[str, List[OHLCVBar]],
+        config: BacktestConfig,
+        zero_trade_attempts: List[str],
+        round_num: int,
+        emit: PhaseCallback,
+    ) -> _ZeroTradeRepairOutcome:
+        """Issue #405 — specialized zero-trade repair attempt.
+
+        Asks :class:`ZeroTradeRepairAgent` for a targeted code fix based
+        on the deterministic execution diagnostics (issue #404), then
+        gates the proposal through code-safety + a fresh backtest +
+        :class:`BacktestAnomalyDetector` before signalling commit.
+        Mirrors the alignment loop's break-without-commit posture: any
+        failed gate appends a record to ``zero_trade_attempts`` and
+        returns ``committed=False`` so the caller falls through to the
+        generic :class:`RefinementAgent`.
+        """
+        diagnostics = exec_result.execution_diagnostics
+        # Caller is responsible for the routing guard, but be defensive.
+        if diagnostics is None or diagnostics.zero_trade_category is None:
+            return _ZeroTradeRepairOutcome(
+                committed=False,
+                failure_reason="no zero_trade_category on diagnostics envelope",
+            )
+
+        emit(
+            "coding",
+            {
+                "sub_phase": "zero_trade_repair_started",
+                "refinement_round": round_num,
+                "zero_trade_category": diagnostics.zero_trade_category,
+                "prior_attempts": len(zero_trade_attempts),
+            },
+        )
+
+        try:
+            report: ZeroTradeRepairReport = self.zero_trade_repair_agent.run(
+                spec=spec,
+                code=code,
+                diagnostics=diagnostics,
+                prior_attempts=zero_trade_attempts,
+            )
+        except Exception as exc:
+            logger.exception("Zero-trade repair agent raised; falling through to refinement")
+            zero_trade_attempts.append(f"agent_error: {type(exc).__name__}: {str(exc)[:160]}")
+            emit(
+                "coding",
+                {
+                    "sub_phase": "zero_trade_repair_skipped",
+                    "refinement_round": round_num,
+                    "reason": "agent_error",
+                },
+            )
+            return _ZeroTradeRepairOutcome(committed=False, failure_reason=f"agent_error: {exc}")
+
+        if not report.proposed_code:
+            zero_trade_attempts.append(
+                f"no_proposal ({report.root_cause_category}): "
+                f"{report.evidence[:160] or 'agent declined to propose'}"
+            )
+            emit(
+                "coding",
+                {
+                    "sub_phase": "zero_trade_repair_skipped",
+                    "refinement_round": round_num,
+                    "reason": "no_proposed_code",
+                    "root_cause_category": report.root_cause_category,
+                },
+            )
+            return _ZeroTradeRepairOutcome(committed=False, failure_reason="no_proposed_code")
+
+        # ── Code-safety gate on the proposed code ────────────────────
+        safety_gates = self.code_safety_checker.check(report.proposed_code)
+        for g in safety_gates:
+            g.refinement_round = round_num
+            g.gate_name = f"zero_trade_repair_{g.gate_name}"
+        critical_safety = [g for g in safety_gates if not g.passed and g.severity == "critical"]
+        if critical_safety:
+            zero_trade_attempts.append(
+                f"unsafe_code ({report.root_cause_category}): "
+                f"{'; '.join(g.details for g in critical_safety)[:160]}"
+            )
+            emit(
+                "coding",
+                {
+                    "sub_phase": "zero_trade_repair_rejected",
+                    "refinement_round": round_num,
+                    "reason": "unsafe_code",
+                    "details": "; ".join(g.details for g in critical_safety)[:400],
+                },
+            )
+            return _ZeroTradeRepairOutcome(
+                committed=False,
+                new_gates=safety_gates,
+                failure_reason="unsafe_code",
+            )
+
+        # ── Fresh backtest of the proposed code ──────────────────────
+        proposed_spec = self._apply_zero_trade_spec_updates(
+            spec, report.proposed_spec_updates, report.proposed_code
+        )
+        repair_exec = run_strategy_code(
+            report.proposed_code, market_data, config, strategy=proposed_spec
+        )
+        if not repair_exec.success:
+            failure_gate = QualityGateResult(
+                gate_name="zero_trade_repair_code_execution",
+                passed=False,
+                severity="critical",
+                details=(
+                    f"Re-execution after zero-trade repair failed "
+                    f"({repair_exec.error_type}): {repair_exec.stderr[:400]}"
+                ),
+                refinement_round=round_num,
+            )
+            zero_trade_attempts.append(
+                f"reexec_failed ({report.root_cause_category}): {repair_exec.error_type}"
+            )
+            emit(
+                "coding",
+                {
+                    "sub_phase": "zero_trade_repair_rejected",
+                    "refinement_round": round_num,
+                    "reason": "re_execution_failed",
+                    "error_type": repair_exec.error_type,
+                },
+            )
+            return _ZeroTradeRepairOutcome(
+                committed=False,
+                new_gates=safety_gates + [failure_gate],
+                failure_reason=f"re_execution_failed: {repair_exec.error_type}",
+            )
+
+        new_trades = repair_exec.trades
+        new_metrics = compute_metrics(
+            new_trades, config.initial_capital, config.start_date, config.end_date
+        )
+
+        # ── Anomaly recheck ──────────────────────────────────────────
+        new_anomaly_gates = self.anomaly_detector.check(
+            new_metrics,
+            new_trades,
+            dsr_aware=config.walk_forward_enabled,
+            diagnostics=repair_exec.execution_diagnostics,
+        )
+        for g in new_anomaly_gates:
+            g.refinement_round = round_num
+            g.gate_name = f"zero_trade_repair_{g.gate_name}"
+
+        new_critical = [g for g in new_anomaly_gates if not g.passed and g.severity == "critical"]
+        if new_critical:
+            zero_trade_attempts.append(
+                f"anomaly_after_repair ({report.root_cause_category}): "
+                f"{'; '.join(g.details for g in new_critical)[:160]}"
+            )
+            emit(
+                "coding",
+                {
+                    "sub_phase": "zero_trade_repair_rejected",
+                    "refinement_round": round_num,
+                    "reason": "anomaly_after_repair",
+                    "details": "; ".join(g.details for g in new_critical)[:400],
+                },
+            )
+            return _ZeroTradeRepairOutcome(
+                committed=False,
+                new_gates=safety_gates + new_anomaly_gates,
+                failure_reason="anomaly_after_repair",
+            )
+
+        # All gates passed — commit the proposal.
+        change_summary = report.changes_made or f"repair {report.root_cause_category}"
+        zero_trade_attempts.append(
+            f"committed ({report.root_cause_category}): {change_summary[:160]}"
+        )
+        emit(
+            "coding",
+            {
+                "sub_phase": "zero_trade_repair_committed",
+                "refinement_round": round_num,
+                "root_cause_category": report.root_cause_category,
+                "changes_made": change_summary,
+                "trades_count": len(new_trades),
+            },
+        )
+        return _ZeroTradeRepairOutcome(
+            committed=True,
+            new_code=report.proposed_code,
+            new_spec=proposed_spec,
+            new_trades=new_trades,
+            new_metrics=new_metrics,
+            new_exec_result=repair_exec,
+            new_gates=safety_gates + new_anomaly_gates,
+            changes_made=change_summary,
+        )
+
+    @staticmethod
+    def _apply_zero_trade_spec_updates(
+        spec: StrategySpec, updates: Optional[Dict[str, Any]], code: str
+    ) -> StrategySpec:
+        """Apply whitelisted spec updates from a zero-trade repair report.
+
+        Restricts merges to :data:`_ZERO_TRADE_SPEC_UPDATE_KEYS` so an
+        off-list LLM hallucination cannot rewrite arbitrary spec fields.
+        Unlike :meth:`_apply_updates` (which is shared with the generic
+        refinement agent and only knows the legacy refinement keys),
+        this helper also honours ``signal_definition`` because the
+        repair agent's prompt includes it in the whitelist.
+        """
+        data = spec.model_dump()
+        for key in _ZERO_TRADE_SPEC_UPDATE_KEYS:
+            if updates and key in updates:
+                data[key] = updates[key]
+        data["strategy_code"] = code
+        return StrategySpec.model_validate(data)
 
     @staticmethod
     def _apply_updates(spec: StrategySpec, updates: Dict[str, Any], code: str) -> StrategySpec:

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -20,6 +20,8 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
 
+from pydantic import ValidationError
+
 from ..execution.benchmarks import benchmark_for_strategy, build_60_40_equity
 from ..execution.metrics import (
     bootstrap_sharpe_ci,
@@ -1109,9 +1111,36 @@ class StrategyLabOrchestrator:
             )
 
         # ── Fresh backtest of the proposed code ──────────────────────
-        proposed_spec = self._apply_zero_trade_spec_updates(
-            spec, report.proposed_spec_updates, report.proposed_code
-        )
+        try:
+            proposed_spec = self._apply_zero_trade_spec_updates(
+                spec, report.proposed_spec_updates, report.proposed_code
+            )
+        except ValidationError as exc:
+            # Whitelisted keys can still arrive with the wrong shape (e.g.
+            # ``entry_rules`` as a string, ``risk_limits`` as a list).
+            # Reject the proposal as we would for unsafe code and let
+            # the caller fall through to generic refinement instead of
+            # aborting the Strategy Lab cycle.
+            logger.warning("Zero-trade repair proposal had invalid spec updates: %s", exc)
+            zero_trade_attempts.append(
+                f"invalid_spec_updates ({report.root_cause_category}): "
+                f"{str(exc).splitlines()[0][:160]}"
+            )
+            emit(
+                "coding",
+                {
+                    "sub_phase": "zero_trade_repair_rejected",
+                    "refinement_round": round_num,
+                    "reason": "invalid_spec_updates",
+                    "details": str(exc).splitlines()[0][:400],
+                },
+            )
+            return _ZeroTradeRepairOutcome(
+                committed=False,
+                new_gates=safety_gates,
+                failure_reason="invalid_spec_updates",
+            )
+
         repair_exec = run_strategy_code(
             report.proposed_code, market_data, config, strategy=proposed_spec
         )

--- a/backend/agents/investment_team/strategy_lab/prompts/zero_trade_repair_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/zero_trade_repair_system.md
@@ -1,0 +1,131 @@
+You are an expert quantitative trading triage engineer. Your task is to
+diagnose why a strategy backtest produced **zero trades**, and to propose
+the smallest concrete Python code change that will make the next backtest
+emit and close trades that are still consistent with the strategy
+specification.
+
+You will be given:
+1. The strategy specification — hypothesis, signal_definition, entry_rules,
+   exit_rules, sizing_rules, risk_limits, asset_class.
+2. The current Python strategy code (a subclass of `contract.Strategy`
+   whose `on_bar(self, ctx, bar)` method drives event-driven order
+   submission via `ctx.submit_order(...)`).
+3. A deterministic execution-diagnostics envelope produced by the trading
+   service. The envelope's `zero_trade_category` field classifies the
+   failure into one of six buckets (see below) and is your primary signal
+   about which part of the order lifecycle broke.
+4. A history of prior zero-trade-repair attempts (to avoid re-trying a
+   fix that already failed).
+
+## Zero-trade categories
+
+Use `zero_trade_category` to focus your diagnosis. The envelope's
+counters (`orders_emitted`, `orders_accepted`, `orders_rejected`,
+`orders_unfilled`, `warmup_orders_dropped`, `entries_filled`,
+`exits_emitted`), the `orders_rejection_reasons` histogram, the
+`open_positions_at_end` snapshot, and the recent `last_order_events`
+together tell you where in the lifecycle execution stopped.
+
+- **NO_ORDERS_EMITTED** — `on_bar` never called `ctx.submit_order(...)`.
+  The entry predicate is impossible, contradictory, or never true on the
+  fetched history (e.g. an indicator window longer than the available
+  bars, a comparison against an unset attribute, a guard that requires a
+  symbol that is not in the universe, or a combination of filters whose
+  conjunction never holds). Inspect the entry condition and any
+  warm-up/state initialisation. Loosen or correct the predicate; do not
+  remove the spec's intent (e.g. don't drop the RSI<30 rule — fix the
+  indicator wiring or the comparison).
+
+- **ONLY_WARMUP_ORDERS** — orders were emitted but every one was dropped
+  during the indicator warm-up window (`warmup_orders_dropped > 0`,
+  `orders_accepted == 0`). The warm-up window is too long for the
+  configured backtest range, or the strategy submits orders before the
+  first valid indicator value. Shorten the warm-up, gate order
+  submission on `len(history) >= window`, or extend the backtest range
+  via the spec.
+
+- **ORDERS_REJECTED** — orders reached the trading service but every one
+  was rejected (`orders_rejected > 0`, `orders_accepted == 0`). The
+  `orders_rejection_reasons` histogram tells you which gate fired:
+  `malformed_request` → bad order shape; `unsupported_feature` → using
+  an order type the harness doesn't accept; `insufficient_capital` →
+  sizing exceeds available capital (often a position-percent or notional
+  bug); `risk_gate:*` → a documented risk limit fired (`max_position_pct`
+  or similar); `same_side_order_ignored` → trying to add to an existing
+  position when the spec doesn't allow pyramiding; `zero_fill_qty` →
+  computed share count rounded to zero. Fix the offending sizing/risk
+  arithmetic without violating the documented limits.
+
+- **ORDERS_UNFILLED** — orders were accepted but never filled
+  (`orders_accepted > 0`, `entries_filled == 0`). Most often a DAY order
+  expired without a touch, or the simulated price never crossed a limit
+  level. Use marketable orders where the spec calls for opportunistic
+  entries, or widen the limit so the simulated bar can fill it.
+
+- **ENTRY_WITH_NO_EXIT** — entries filled but exits never fired so no
+  closed trades exist (`entries_filled > 0`, `closed_trades == 0`,
+  `open_positions_at_end` non-empty). The exit rules are too strict,
+  reference an unset attribute, or only fire on conditions that never
+  occur in the test window. Add a fallback exit (time stop or
+  end-of-data force-close) and tighten the rules so trades close.
+
+- **UNKNOWN_ZERO_TRADE_PATH** — the trading service crashed before it
+  could classify the failure, or the strategy raised before any bar was
+  processed. Inspect `summary` for the underlying error and fix the
+  startup-time bug.
+
+## Your reasoning process
+
+1. **CLASSIFY** — restate the `zero_trade_category` and quote the most
+   relevant counters / rejection reasons / lifecycle events as evidence.
+2. **LOCATE** — point at the specific lines or branches in the current
+   code that produced this category (e.g. "the `if rsi < 30` guard
+   compares `self.rsi` which is never updated").
+3. **PROPOSE A MINIMAL FIX** — rewrite the FULL Python module so the
+   identified failure no longer occurs. Preserve the contract: exactly
+   one subclass of `contract.Strategy` with `on_bar(self, ctx, bar)`
+   driving order submission through `ctx.submit_order(...)`. Use only
+   allowed imports: `contract`, `indicators`, `math`, `datetime`,
+   `collections`, `itertools`, `functools`, `typing`, `dataclasses`,
+   `enum`, `abc`, `re`, `copy`, `statistics`, `operator`. Do NOT import
+   pandas, numpy, or any filesystem / network module.
+4. **PREDICT** — estimate the change in order count and trade count your
+   fix should produce. These predictions are sanity checks for the
+   orchestrator's re-backtest gate; conservative integers are fine
+   (e.g. `+5` orders, `+3` trades).
+
+If the proposed fix requires a small spec change (e.g. a too-tight
+`entry_rules` or a missing `exit_rules` clause), you may also return a
+`proposed_spec_updates` object containing only the rule fields you are
+adjusting. Do not invent new keys; the orchestrator will only honour
+`entry_rules`, `exit_rules`, `sizing_rules`, `risk_limits`, `hypothesis`,
+and `signal_definition`.
+
+If the diagnostics do not give you enough evidence to propose a code
+change you are confident in, return `proposed_code: null` and explain
+the gap in `evidence`. The orchestrator will fall back to the generic
+refinement agent.
+
+## Output
+
+Return ONLY a JSON object with no markdown:
+
+```json
+{
+  "root_cause_category": "NO_ORDERS_EMITTED" | "ONLY_WARMUP_ORDERS" | "ORDERS_REJECTED" | "ORDERS_UNFILLED" | "ENTRY_WITH_NO_EXIT" | "UNKNOWN_ZERO_TRADE_PATH",
+  "evidence": "1-3 sentences citing counters / rejection reasons / events that prove the diagnosis",
+  "code_issue": "the specific line or branch in the current code that produced the failure (or null)",
+  "strategy_rule_issue": "spec rule that contributes to the failure (or null)",
+  "proposed_code": "full fixed Python source for the Strategy subclass module (or null when diagnosis is too uncertain to propose code)",
+  "expected_order_count_change": 0,
+  "expected_trade_count_change": 0,
+  "changes_made": "1-2 sentence summary of what you changed and why",
+  "proposed_spec_updates": null
+}
+```
+
+- `proposed_code` MUST be the complete revised module source, not a diff.
+- When you cannot diagnose the failure, set `proposed_code: null` and
+  explain the gap; the orchestrator will fall back to generic refinement.
+- `proposed_spec_updates`, when non-null, MUST contain only the
+  whitelisted keys above; the orchestrator silently drops any other key.

--- a/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
@@ -1,0 +1,599 @@
+"""Tests for the Strategy Lab specialized zero-trade repair loop (#405).
+
+The orchestrator's main code-refinement loop now branches on a critical
+``backtest_anomaly`` whose diagnostics envelope (issue #404) carries a
+deterministic ``zero_trade_category``. Instead of routing straight to
+the generic ``RefinementAgent``, the orchestrator first asks
+:class:`ZeroTradeRepairAgent` for a targeted fix and, if the proposal
+clears code-safety + a fresh backtest + the anomaly gates, commits it
+in place. Failed proposals fall through to generic refinement. These
+tests exercise :meth:`StrategyLabOrchestrator._run_zero_trade_repair`
+directly with stubs for the agent and ``run_strategy_code``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from investment_team.market_data_service import OHLCVBar
+from investment_team.models import (
+    BacktestConfig,
+    BacktestExecutionDiagnostics,
+    StrategySpec,
+)
+from investment_team.strategy_lab import orchestrator as orchestrator_module
+from investment_team.strategy_lab.agents.zero_trade_repair import ZeroTradeRepairReport
+from investment_team.strategy_lab.orchestrator import (
+    StrategyLabOrchestrator,
+    _ZeroTradeRepairOutcome,
+)
+from investment_team.strategy_lab.quality_gates.models import QualityGateResult
+from investment_team.tests.test_strategy_lab_alignment import (
+    _benign_sandbox_trades,
+    _code_exec,
+)
+from investment_team.trading_service.modes.sandbox_compat import StrategyRunResult
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _config() -> BacktestConfig:
+    return BacktestConfig(
+        start_date="2023-01-01",
+        end_date="2023-12-31",
+        initial_capital=100_000.0,
+        benchmark_symbol="SPY",
+        transaction_cost_bps=5.0,
+        slippage_bps=2.0,
+    )
+
+
+def _spec() -> StrategySpec:
+    return StrategySpec(
+        strategy_id="strat-zt-repair-test",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="hyp",
+        signal_definition="sig",
+        entry_rules=["enter when RSI < 30"],
+        exit_rules=["exit when RSI > 70"],
+        sizing_rules=["risk 2% per trade"],
+        risk_limits={"max_position_pct": 5},
+        speculative=False,
+        strategy_code=(
+            "from contract import Strategy\n\n"
+            "class S(Strategy):\n"
+            "    def on_bar(self, ctx, bar):\n"
+            "        pass  # never submits an order — original buggy code\n"
+        ),
+    )
+
+
+def _market_data() -> Dict[str, List[OHLCVBar]]:
+    bars = [
+        OHLCVBar(
+            date=f"2023-01-{i + 1:02d}",
+            open=100.0 + i,
+            high=101.0 + i,
+            low=99.0 + i,
+            close=100.5 + i,
+            volume=1_000_000,
+        )
+        for i in range(20)
+    ]
+    return {"AAPL": bars}
+
+
+def _zero_trade_diagnostics(
+    category: str = "NO_ORDERS_EMITTED",
+) -> BacktestExecutionDiagnostics:
+    return BacktestExecutionDiagnostics(
+        zero_trade_category=category,  # type: ignore[arg-type]
+        summary="strategy never submitted an order across 20 bars",
+        bars_processed=20,
+        orders_emitted=0,
+        orders_accepted=0,
+        orders_rejected=0,
+        orders_unfilled=0,
+        warmup_orders_dropped=0,
+        entries_filled=0,
+        exits_emitted=0,
+        closed_trades=0,
+    )
+
+
+def _zero_trade_exec_result() -> StrategyRunResult:
+    """Initial backtest result: zero trades + diagnostics with category."""
+    return StrategyRunResult(
+        success=True,
+        trades=[],
+        execution_diagnostics=_zero_trade_diagnostics(),
+    )
+
+
+# Valid Strategy-subclass code that the safety gate accepts. Body intentionally
+# trivial — we never actually execute it because ``run_strategy_code`` is
+# stubbed via monkeypatch.
+_REPAIRED_CODE = (
+    "from contract import Strategy\n\n"
+    "class S(Strategy):\n"
+    "    def on_bar(self, ctx, bar):\n"
+    "        pass  # repaired (test stub)\n"
+)
+
+
+# Code that fails the safety gate (banned import).
+_UNSAFE_CODE = (
+    "import os\n\n"
+    "from contract import Strategy\n\n"
+    "class S(Strategy):\n"
+    "    def on_bar(self, ctx, bar):\n"
+    "        os.system('rm -rf /')  # banned\n"
+)
+
+
+class _StubZeroTradeRepairAgent:
+    """Records calls and returns scripted ``ZeroTradeRepairReport`` objects.
+
+    Mirrors ``_StubAlignmentAgent`` from ``test_strategy_lab_alignment.py``
+    but for the repair agent's signature.
+    """
+
+    def __init__(
+        self,
+        *,
+        reports: Optional[List[ZeroTradeRepairReport]] = None,
+        raise_on_call: Optional[Exception] = None,
+    ) -> None:
+        self._reports = list(reports or [])
+        self._raise = raise_on_call
+        self.calls: List[Dict[str, Any]] = []
+
+    def run(
+        self,
+        spec: StrategySpec,
+        code: str,
+        diagnostics: BacktestExecutionDiagnostics,
+        prior_attempts: Optional[List[str]] = None,
+    ) -> ZeroTradeRepairReport:
+        self.calls.append(
+            {
+                "code": code,
+                "category": diagnostics.zero_trade_category,
+                "prior_attempts": list(prior_attempts or []),
+            }
+        )
+        if self._raise is not None:
+            raise self._raise
+        if not self._reports:
+            raise AssertionError("repair stub called more times than scripted")
+        return self._reports.pop(0)
+
+
+class _StubSandbox:
+    """Stub for ``run_strategy_code``. ``results`` is consumed in order.
+
+    Patched into ``investment_team.strategy_lab.orchestrator.run_strategy_code``
+    via monkeypatch so the helper picks up the stub when re-running the
+    proposed code.
+    """
+
+    def __init__(self, results: List[StrategyRunResult]) -> None:
+        self._results = list(results)
+        self.calls: List[str] = []
+
+    def __call__(
+        self,
+        strategy_code: str,
+        market_data: Any,
+        config: Any,
+        *,
+        strategy: Any = None,
+    ) -> StrategyRunResult:
+        self.calls.append(strategy_code)
+        if not self._results:
+            raise AssertionError("sandbox stub called more times than scripted")
+        return self._results.pop(0)
+
+
+def _make_orchestrator_with_stubs(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    repair_reports: Optional[List[ZeroTradeRepairReport]] = None,
+    repair_raises: Optional[Exception] = None,
+    sandbox_results: Optional[List[StrategyRunResult]] = None,
+) -> tuple[StrategyLabOrchestrator, _StubZeroTradeRepairAgent, _StubSandbox]:
+    orch = StrategyLabOrchestrator()
+    repair_stub = _StubZeroTradeRepairAgent(reports=repair_reports, raise_on_call=repair_raises)
+    sandbox_stub = _StubSandbox(sandbox_results or [])
+    orch.zero_trade_repair_agent = repair_stub  # type: ignore[assignment]
+    monkeypatch.setattr(orchestrator_module, "run_strategy_code", sandbox_stub)
+    return orch, repair_stub, sandbox_stub
+
+
+def _drive_repair(
+    orch: StrategyLabOrchestrator,
+    *,
+    spec: Optional[StrategySpec] = None,
+    code: Optional[str] = None,
+    exec_result: Optional[StrategyRunResult] = None,
+    market_data: Optional[Dict[str, List[OHLCVBar]]] = None,
+    config: Optional[BacktestConfig] = None,
+    zero_trade_attempts: Optional[List[str]] = None,
+) -> tuple[_ZeroTradeRepairOutcome, List[tuple[str, Dict[str, Any]]], List[str]]:
+    """Convenience wrapper around ``orch._run_zero_trade_repair``.
+
+    Captures emitted phase callbacks and the orchestrator's
+    ``zero_trade_attempts`` log so tests can assert on them.
+    """
+    spec = spec or _spec()
+    code = code if code is not None else (spec.strategy_code or "")
+    exec_result = exec_result or _zero_trade_exec_result()
+    market_data = market_data or _market_data()
+    config = config or _config()
+    attempts = zero_trade_attempts if zero_trade_attempts is not None else []
+    events: List[tuple[str, Dict[str, Any]]] = []
+
+    def emit(phase: str, data: Dict[str, Any]) -> None:
+        events.append((phase, data))
+
+    outcome = orch._run_zero_trade_repair(
+        spec=spec,
+        code=code,
+        exec_result=exec_result,
+        market_data=market_data,
+        config=config,
+        zero_trade_attempts=attempts,
+        round_num=0,
+        emit=emit,
+    )
+    return outcome, events, attempts
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_zero_trade_repair_succeeds_on_first_proposal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Repair agent proposes new code; re-backtest produces trades that
+    clear the anomaly gates. Outcome is committed with the new state."""
+    orch, repair_stub, sandbox_stub = _make_orchestrator_with_stubs(
+        monkeypatch,
+        repair_reports=[
+            ZeroTradeRepairReport(
+                root_cause_category="NO_ORDERS_EMITTED",
+                evidence="orders_emitted=0 with bars_processed=20",
+                code_issue="entry guard never true",
+                proposed_code=_REPAIRED_CODE,
+                expected_order_count_change=12,
+                expected_trade_count_change=6,
+                changes_made="loosened RSI guard so signals fire",
+            ),
+        ],
+        sandbox_results=[
+            _code_exec(success=True, raw_trades=_benign_sandbox_trades()),
+        ],
+    )
+
+    outcome, events, attempts = _drive_repair(orch)
+
+    assert outcome.committed is True
+    assert outcome.new_code == _REPAIRED_CODE
+    assert outcome.new_spec is not None
+    assert outcome.new_spec.strategy_code == _REPAIRED_CODE
+    assert outcome.new_metrics is not None
+    assert outcome.new_trades, "committed outcome must carry the post-repair ledger"
+    assert outcome.new_exec_result is not None
+    assert outcome.new_exec_result.success is True
+    assert outcome.changes_made.startswith("loosened RSI guard")
+
+    # The agent and the sandbox were each called exactly once.
+    assert len(repair_stub.calls) == 1
+    assert sandbox_stub.calls == [_REPAIRED_CODE]
+
+    # The attempts log records the commit so prior_attempts on a future
+    # round can read it as evidence.
+    assert len(attempts) == 1
+    assert attempts[0].startswith("committed (NO_ORDERS_EMITTED)")
+
+    # Phase emits: started → committed.
+    sub_phases = [d.get("sub_phase") for _, d in events]
+    assert sub_phases == [
+        "zero_trade_repair_started",
+        "zero_trade_repair_committed",
+    ]
+
+    # Gate results include both safety + post-repair anomaly gates.
+    assert outcome.new_gates, "committed outcome must surface its quality gates"
+    gate_names = {g.gate_name for g in outcome.new_gates}
+    assert any(name.startswith("zero_trade_repair_") for name in gate_names)
+
+
+def test_zero_trade_repair_failed_proposal_preserves_state(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Re-backtest of the proposal still produces zero trades → critical
+    anomaly → outcome is not committed and the attempts log records the
+    rejection. The caller therefore retains its prior known-good state.
+    """
+    orch, repair_stub, sandbox_stub = _make_orchestrator_with_stubs(
+        monkeypatch,
+        repair_reports=[
+            ZeroTradeRepairReport(
+                root_cause_category="NO_ORDERS_EMITTED",
+                evidence="orders_emitted=0",
+                proposed_code=_REPAIRED_CODE,
+                changes_made="attempted RSI loosen",
+            ),
+        ],
+        sandbox_results=[
+            # Re-execution yields zero trades again → BacktestAnomalyDetector
+            # flags critical, repair must NOT commit.
+            _code_exec(success=True, raw_trades=[]),
+        ],
+    )
+
+    outcome, events, attempts = _drive_repair(orch)
+
+    assert outcome.committed is False
+    assert outcome.failure_reason == "anomaly_after_repair"
+    assert outcome.new_code == ""
+    assert outcome.new_spec is None
+    assert outcome.new_metrics is None
+    assert outcome.new_exec_result is None
+
+    assert len(repair_stub.calls) == 1
+    assert sandbox_stub.calls == [_REPAIRED_CODE]
+
+    assert len(attempts) == 1
+    assert attempts[0].startswith("anomaly_after_repair (NO_ORDERS_EMITTED)")
+
+    sub_phases = [d.get("sub_phase") for _, d in events]
+    assert sub_phases == [
+        "zero_trade_repair_started",
+        "zero_trade_repair_rejected",
+    ]
+    rejected_event = next(
+        d for _, d in events if d.get("sub_phase") == "zero_trade_repair_rejected"
+    )
+    assert rejected_event["reason"] == "anomaly_after_repair"
+
+    # Surfaced gates include the critical anomaly so downstream telemetry
+    # can audit the failed attempt.
+    critical_gates = [g for g in outcome.new_gates if not g.passed and g.severity == "critical"]
+    assert critical_gates, "expected at least one critical anomaly gate"
+    assert all(g.gate_name.startswith("zero_trade_repair_") for g in critical_gates)
+
+
+def test_zero_trade_repair_unsafe_code_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Proposed code with a banned import fails code-safety; the helper
+    short-circuits without invoking ``run_strategy_code``."""
+    orch, repair_stub, sandbox_stub = _make_orchestrator_with_stubs(
+        monkeypatch,
+        repair_reports=[
+            ZeroTradeRepairReport(
+                root_cause_category="ORDERS_REJECTED",
+                evidence="orders_rejected=5 with reason insufficient_capital",
+                proposed_code=_UNSAFE_CODE,
+                changes_made="unsafe rewrite",
+            ),
+        ],
+        sandbox_results=[],  # sandbox MUST NOT be called
+    )
+
+    diagnostics = _zero_trade_diagnostics(category="ORDERS_REJECTED")
+    outcome, events, attempts = _drive_repair(
+        orch,
+        exec_result=StrategyRunResult(success=True, trades=[], execution_diagnostics=diagnostics),
+    )
+
+    assert outcome.committed is False
+    assert outcome.failure_reason == "unsafe_code"
+    assert sandbox_stub.calls == []  # short-circuited before re-execution
+    assert len(repair_stub.calls) == 1
+
+    assert len(attempts) == 1
+    assert attempts[0].startswith("unsafe_code (ORDERS_REJECTED)")
+
+    sub_phases = [d.get("sub_phase") for _, d in events]
+    assert sub_phases == [
+        "zero_trade_repair_started",
+        "zero_trade_repair_rejected",
+    ]
+    rejected_event = next(
+        d for _, d in events if d.get("sub_phase") == "zero_trade_repair_rejected"
+    )
+    assert rejected_event["reason"] == "unsafe_code"
+
+    # Safety gates include the critical failure.
+    critical_safety = [
+        g
+        for g in outcome.new_gates
+        if not g.passed
+        and g.severity == "critical"
+        and g.gate_name == "zero_trade_repair_code_safety"
+    ]
+    assert critical_safety, "expected the code_safety gate to fire on banned import"
+
+
+def test_zero_trade_repair_no_proposed_code_falls_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Agent declined to propose code (e.g. evidence too thin). The helper
+    reports not-committed and the sandbox is never invoked. The caller is
+    expected to fall through to the generic refinement agent."""
+    orch, repair_stub, sandbox_stub = _make_orchestrator_with_stubs(
+        monkeypatch,
+        repair_reports=[
+            ZeroTradeRepairReport(
+                root_cause_category="UNKNOWN_ZERO_TRADE_PATH",
+                evidence="diagnostics envelope was unclassified; not enough signal",
+                proposed_code=None,
+            ),
+        ],
+        sandbox_results=[],
+    )
+
+    outcome, events, attempts = _drive_repair(
+        orch,
+        exec_result=StrategyRunResult(
+            success=True,
+            trades=[],
+            execution_diagnostics=_zero_trade_diagnostics(category="UNKNOWN_ZERO_TRADE_PATH"),
+        ),
+    )
+
+    assert outcome.committed is False
+    assert outcome.failure_reason == "no_proposed_code"
+    assert sandbox_stub.calls == []
+    assert len(repair_stub.calls) == 1
+
+    assert len(attempts) == 1
+    assert attempts[0].startswith("no_proposal (UNKNOWN_ZERO_TRADE_PATH)")
+
+    sub_phases = [d.get("sub_phase") for _, d in events]
+    assert sub_phases == [
+        "zero_trade_repair_started",
+        "zero_trade_repair_skipped",
+    ]
+
+
+def test_zero_trade_repair_agent_exception_falls_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A raised exception inside the agent collapses to a not-committed
+    outcome and is logged in attempts so the caller can fall through."""
+    orch, repair_stub, sandbox_stub = _make_orchestrator_with_stubs(
+        monkeypatch,
+        repair_raises=RuntimeError("LLM provider timeout"),
+        sandbox_results=[],
+    )
+
+    outcome, events, attempts = _drive_repair(orch)
+
+    assert outcome.committed is False
+    assert outcome.failure_reason.startswith("agent_error")
+    assert sandbox_stub.calls == []
+    assert len(repair_stub.calls) == 1
+
+    assert len(attempts) == 1
+    assert attempts[0].startswith("agent_error: RuntimeError")
+
+    sub_phases = [d.get("sub_phase") for _, d in events]
+    assert sub_phases == [
+        "zero_trade_repair_started",
+        "zero_trade_repair_skipped",
+    ]
+
+
+def test_zero_trade_repair_applies_proposed_spec_updates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whitelisted ``proposed_spec_updates`` flow into the committed spec;
+    off-list keys are silently dropped so an LLM hallucination cannot
+    rewrite arbitrary fields."""
+    orch, repair_stub, sandbox_stub = _make_orchestrator_with_stubs(
+        monkeypatch,
+        repair_reports=[
+            ZeroTradeRepairReport(
+                root_cause_category="ENTRY_WITH_NO_EXIT",
+                evidence="entries_filled=4 closed_trades=0",
+                proposed_code=_REPAIRED_CODE,
+                proposed_spec_updates={
+                    "exit_rules": ["exit after 10 bars (added time stop)"],
+                    # Off-list keys MUST NOT mutate the spec.
+                    "strategy_id": "hijacked",
+                    "asset_class": "crypto",
+                },
+                changes_made="added time-stop exit",
+            ),
+        ],
+        sandbox_results=[
+            _code_exec(success=True, raw_trades=_benign_sandbox_trades()),
+        ],
+    )
+
+    diagnostics = _zero_trade_diagnostics(category="ENTRY_WITH_NO_EXIT")
+    outcome, _events, _attempts = _drive_repair(
+        orch,
+        exec_result=StrategyRunResult(success=True, trades=[], execution_diagnostics=diagnostics),
+    )
+
+    assert outcome.committed is True
+    assert outcome.new_spec is not None
+    # Whitelisted update applied …
+    assert outcome.new_spec.exit_rules == ["exit after 10 bars (added time stop)"]
+    # … and off-list mutations were silently dropped.
+    assert outcome.new_spec.strategy_id == "strat-zt-repair-test"
+    assert outcome.new_spec.asset_class == "stocks"
+
+
+def test_zero_trade_repair_no_category_is_defensive_no_op(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Defensive path: if the orchestrator's routing guard ever lets a
+    diagnostics-without-category through to the helper, we report
+    not-committed without calling the agent."""
+    orch, repair_stub, sandbox_stub = _make_orchestrator_with_stubs(
+        monkeypatch,
+        repair_reports=[],
+        sandbox_results=[],
+    )
+
+    no_category_diag = BacktestExecutionDiagnostics(zero_trade_category=None)
+    outcome, events, attempts = _drive_repair(
+        orch,
+        exec_result=StrategyRunResult(
+            success=True, trades=[], execution_diagnostics=no_category_diag
+        ),
+    )
+
+    assert outcome.committed is False
+    assert "zero_trade_category" in outcome.failure_reason
+    assert repair_stub.calls == []
+    assert sandbox_stub.calls == []
+    assert attempts == []
+    assert events == []
+
+
+def test_orchestrator_constructs_zero_trade_repair_agent_by_default() -> None:
+    """The orchestrator wires up a real :class:`ZeroTradeRepairAgent` so
+    callers that don't inject one still pick up the specialized branch."""
+    from investment_team.strategy_lab.agents.zero_trade_repair import (
+        ZeroTradeRepairAgent,
+    )
+
+    orch = StrategyLabOrchestrator()
+    assert isinstance(orch.zero_trade_repair_agent, ZeroTradeRepairAgent)
+
+
+def test_quality_gate_results_are_typed() -> None:
+    """Sanity check: the helper's surfaced gates must be ``QualityGateResult``s
+    so existing telemetry consumers (Strategy Lab dashboards, persisted
+    records) don't choke on a foreign payload."""
+    # No monkeypatch needed — exercise the defensive no-op path.
+    orch = StrategyLabOrchestrator()
+
+    no_category_diag = BacktestExecutionDiagnostics(zero_trade_category=None)
+    outcome = orch._run_zero_trade_repair(
+        spec=_spec(),
+        code=_spec().strategy_code or "",
+        exec_result=StrategyRunResult(
+            success=True, trades=[], execution_diagnostics=no_category_diag
+        ),
+        market_data=_market_data(),
+        config=_config(),
+        zero_trade_attempts=[],
+        round_num=0,
+        emit=lambda _phase, _data: None,
+    )
+    assert all(isinstance(g, QualityGateResult) for g in outcome.new_gates)

--- a/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
@@ -467,6 +467,58 @@ def test_zero_trade_repair_no_proposed_code_falls_through(
     ]
 
 
+def test_zero_trade_repair_invalid_spec_updates_falls_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A whitelisted ``proposed_spec_updates`` key with the wrong shape
+    (e.g. ``entry_rules`` as a string) must be rejected as a
+    not-committed outcome — the helper must NOT let the resulting
+    Pydantic ``ValidationError`` abort the entire Strategy Lab cycle."""
+    orch, repair_stub, sandbox_stub = _make_orchestrator_with_stubs(
+        monkeypatch,
+        repair_reports=[
+            ZeroTradeRepairReport(
+                root_cause_category="ENTRY_WITH_NO_EXIT",
+                evidence="entries_filled=4 closed_trades=0",
+                proposed_code=_REPAIRED_CODE,
+                # ``entry_rules`` must be a list[str]; a bare string is
+                # the realistic LLM error mode that previously crashed
+                # the cycle.
+                proposed_spec_updates={"entry_rules": "exit after 5 bars"},
+                changes_made="malformed entry_rules",
+            ),
+        ],
+        sandbox_results=[],  # sandbox MUST NOT be called
+    )
+
+    outcome, events, attempts = _drive_repair(
+        orch,
+        exec_result=StrategyRunResult(
+            success=True,
+            trades=[],
+            execution_diagnostics=_zero_trade_diagnostics(category="ENTRY_WITH_NO_EXIT"),
+        ),
+    )
+
+    assert outcome.committed is False
+    assert outcome.failure_reason == "invalid_spec_updates"
+    assert sandbox_stub.calls == []  # short-circuited before re-execution
+    assert len(repair_stub.calls) == 1
+
+    assert len(attempts) == 1
+    assert attempts[0].startswith("invalid_spec_updates (ENTRY_WITH_NO_EXIT)")
+
+    sub_phases = [d.get("sub_phase") for _, d in events]
+    assert sub_phases == [
+        "zero_trade_repair_started",
+        "zero_trade_repair_rejected",
+    ]
+    rejected_event = next(
+        d for _, d in events if d.get("sub_phase") == "zero_trade_repair_rejected"
+    )
+    assert rejected_event["reason"] == "invalid_spec_updates"
+
+
 def test_zero_trade_repair_agent_exception_falls_through(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Closes #405. Adds a specialized zero-trade repair loop to the Strategy Lab orchestrator that runs ahead of the generic `RefinementAgent` whenever a backtest's critical anomaly carries a deterministic `zero_trade_category` (the diagnostics envelope shipped via #404 / sub-issues #407–#414).

The new `ZeroTradeRepairAgent` consumes `BacktestExecutionDiagnostics` (category, counters, rejection-reason histogram, recent lifecycle events) and proposes a targeted Python code fix. The orchestrator's new helper `_run_zero_trade_repair` gates the proposal through code-safety → a fresh backtest → the anomaly detector before committing it over the prior known-good state — mirroring the alignment loop's break-without-commit posture. Failed or skipped proposals fall through to the generic refinement agent, so the existing loop semantics are preserved.

- New agent: `backend/agents/investment_team/strategy_lab/agents/zero_trade_repair.py` — `ZeroTradeRepairAgent` + `ZeroTradeRepairReport` Pydantic schema (`root_cause_category`, `evidence`, `code_issue`, `strategy_rule_issue`, `proposed_code`, `expected_order_count_change`, `expected_trade_count_change`, `changes_made`, whitelisted `proposed_spec_updates`).
- New system prompt: `backend/agents/investment_team/strategy_lab/prompts/zero_trade_repair_system.md` — per-category triage guidance for all six `ZeroTradeCategory` values.
- Orchestrator wiring: constructor wires the agent; refinement loop branches on `diag.zero_trade_category is not None and market_data is not None` ahead of `_refine`; helper reuses `code_safety_checker` + `run_strategy_code` + `anomaly_detector`; whitelisted `_apply_zero_trade_spec_updates` shallow-merges only the safe rule fields.
- Tests: 9 new tests in `test_strategy_lab_zero_trade_repair.py` cover successful repair, failed-proposal state preservation, unsafe code rejection, no-proposal fall-through, agent-exception fall-through, whitelisted spec updates, defensive guards, and orchestrator wiring.

## Test plan

- [x] `pytest agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py -v` — 9 passed
- [x] `pytest agents/investment_team/tests/test_strategy_lab_alignment.py -v` — 12 passed (no regressions)
- [x] `pytest agents/investment_team/tests/test_strategy_lab_*.py test_backtest_anomaly_*.py test_code_safety.py` — 59 passed
- [x] `pytest agents/investment_team/tests/` — 726 passed, 13 skipped
- [x] `ruff check` + `ruff format --check` clean on all changed files
- [ ] Manual end-to-end via `make run` with a known zero-trade-prone spec — confirm `ZeroTradeRepairAgent.run` is invoked, second backtest emits trades, alignment loop engages; with an unfixable spec, confirm `zero_trade_attempts` is recorded and prior state is preserved

https://claude.ai/code/session_019tbsmMHqyVfhcZHAQWnwq8

---
_Generated by [Claude Code](https://claude.ai/code/session_019tbsmMHqyVfhcZHAQWnwq8)_