### PR TITLE
investment-team: add coverage-probe data models (#446)

### DIFF
--- a/backend/agents/investment_team/models.py
+++ b/backend/agents/investment_team/models.py
@@ -472,6 +472,51 @@ class BacktestExecutionDiagnostics(BaseModel):
     last_order_events: List[OrderLifecycleEvent] = Field(default_factory=list)
 
 
+class CoverageCategory(str, Enum):
+    """Why a backtest produced zero or sparse entries (#406)."""
+
+    COVERAGE_OK = "COVERAGE_OK"
+    ENTRY_CONDITION_NEVER_TRUE = "ENTRY_CONDITION_NEVER_TRUE"
+    WARMUP_EXCEEDS_HISTORY = "WARMUP_EXCEEDS_HISTORY"
+    TARGET_SYMBOL_MISSING = "TARGET_SYMBOL_MISSING"
+    INDICATOR_FILTER_TOO_RESTRICTIVE = "INDICATOR_FILTER_TOO_RESTRICTIVE"
+    CONJUNCTION_NEVER_TRUE = "CONJUNCTION_NEVER_TRUE"
+    INSUFFICIENT_BARS = "INSUFFICIENT_BARS"
+    UNKNOWN_LOW_COVERAGE = "UNKNOWN_LOW_COVERAGE"
+
+
+class LikelyBlocker(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    reason: str
+    evidence: str = ""
+    hit_rate: Optional[float] = None
+
+
+class SubconditionCoverage(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    label: str
+    hit_count: int = Field(default=0, ge=0)
+    hit_rate: float = Field(default=0.0, ge=0.0, le=1.0)
+    last_true_bar: Optional[str] = None
+
+
+class CoverageReport(BaseModel):
+    """Deterministic rule-coverage probe output for zero/low-trade backtests."""
+
+    model_config = ConfigDict(extra="ignore")
+
+    coverage_category: CoverageCategory = CoverageCategory.UNKNOWN_LOW_COVERAGE
+    summary: str = ""
+    symbols_checked: int = Field(default=0, ge=0)
+    bars_checked: int = Field(default=0, ge=0)
+    warmup_bars_required: int = Field(default=0, ge=0)
+    entry_orders_emitted: int = Field(default=0, ge=0)
+    subconditions: List[SubconditionCoverage] = Field(default_factory=list)
+    likely_blockers: List[LikelyBlocker] = Field(default_factory=list)
+
+
 class BacktestResult(BaseModel):
     total_return_pct: float
     annualized_return_pct: float
@@ -496,6 +541,7 @@ class BacktestResult(BaseModel):
     cost_stress_results: Optional[List[Dict[str, Any]]] = None
     reject_reason: Optional[str] = None
     execution_diagnostics: Optional[BacktestExecutionDiagnostics] = None
+    coverage_report: Optional[CoverageReport] = None
     # Issue #247 — walk-forward + DSR diagnostics.
     deflated_sharpe: float = 0.0
     sharpe_ci_low: Optional[float] = None
@@ -523,7 +569,9 @@ class BacktestResult(BaseModel):
     # cache).
     dataset_fingerprint: Optional[str] = None
 
-    @field_validator("sortino_ratio", "calmar_ratio", "risk_free_rate", "deflated_sharpe", mode="before")
+    @field_validator(
+        "sortino_ratio", "calmar_ratio", "risk_free_rate", "deflated_sharpe", mode="before"
+    )
     @classmethod
     def _coerce_float_none_to_zero(cls, v: object) -> object:
         return 0.0 if v is None else v

--- a/backend/agents/investment_team/models.py
+++ b/backend/agents/investment_team/models.py
@@ -490,7 +490,7 @@ class LikelyBlocker(BaseModel):
 
     reason: str
     evidence: str = ""
-    hit_rate: Optional[float] = None
+    hit_rate: Optional[float] = Field(default=None, ge=0.0, le=1.0)
 
 
 class SubconditionCoverage(BaseModel):

--- a/backend/agents/investment_team/tests/golden/snapshots/overfit_hardcoded_dates.json
+++ b/backend/agents/investment_team/tests/golden/snapshots/overfit_hardcoded_dates.json
@@ -16,6 +16,7 @@
     "beta": null,
     "calmar_ratio": 0.03,
     "cost_stress_results": null,
+    "coverage_report": null,
     "data_quality_report": {
       "asset_class": "stocks",
       "cross_symbol_alignment_misses": 0,

--- a/backend/agents/investment_team/tests/golden/snapshots/round_trip.json
+++ b/backend/agents/investment_team/tests/golden/snapshots/round_trip.json
@@ -16,6 +16,7 @@
     "beta": null,
     "calmar_ratio": 0.0,
     "cost_stress_results": null,
+    "coverage_report": null,
     "data_quality_report": {
       "asset_class": "stocks",
       "cross_symbol_alignment_misses": 0,

--- a/backend/agents/investment_team/tests/golden/snapshots/sma_crossover.json
+++ b/backend/agents/investment_team/tests/golden/snapshots/sma_crossover.json
@@ -16,6 +16,7 @@
     "beta": null,
     "calmar_ratio": -0.84,
     "cost_stress_results": null,
+    "coverage_report": null,
     "data_quality_report": {
       "asset_class": "stocks",
       "cross_symbol_alignment_misses": 0,

--- a/backend/agents/investment_team/tests/test_coverage_probe_models.py
+++ b/backend/agents/investment_team/tests/test_coverage_probe_models.py
@@ -113,6 +113,12 @@ def test_hit_rate_outside_unit_interval_fails_validation() -> None:
     with pytest.raises(ValidationError):
         SubconditionCoverage(label="rsi < 25", hit_count=0, hit_rate=-0.1)
 
+    with pytest.raises(ValidationError):
+        LikelyBlocker(reason="bad rate", hit_rate=1.5)
+
+    with pytest.raises(ValidationError):
+        LikelyBlocker(reason="bad rate", hit_rate=-0.1)
+
 
 def test_extra_fields_are_ignored_inside_coverage_models() -> None:
     report = CoverageReport.model_validate(

--- a/backend/agents/investment_team/tests/test_coverage_probe_models.py
+++ b/backend/agents/investment_team/tests/test_coverage_probe_models.py
@@ -1,0 +1,170 @@
+"""Model tests for Strategy Lab rule-coverage probes (#446)."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from investment_team.models import (
+    BacktestResult,
+    CoverageCategory,
+    CoverageReport,
+    LikelyBlocker,
+    SubconditionCoverage,
+)
+
+
+def _backtest_payload() -> dict[str, float]:
+    return {
+        "total_return_pct": 0.0,
+        "annualized_return_pct": 0.0,
+        "volatility_pct": 0.0,
+        "sharpe_ratio": 0.0,
+        "max_drawdown_pct": 0.0,
+        "win_rate_pct": 0.0,
+        "profit_factor": 0.0,
+    }
+
+
+def test_backtest_result_construction_stays_backward_compatible() -> None:
+    result = BacktestResult(**_backtest_payload())
+
+    assert result.coverage_report is None
+
+
+def test_backtest_result_model_validate_accepts_legacy_payload() -> None:
+    result = BacktestResult.model_validate(_backtest_payload())
+
+    assert result.coverage_report is None
+
+
+def test_coverage_report_defaults_are_empty() -> None:
+    report = CoverageReport()
+
+    assert report.coverage_category is CoverageCategory.UNKNOWN_LOW_COVERAGE
+    assert report.summary == ""
+    assert report.symbols_checked == 0
+    assert report.bars_checked == 0
+    assert report.warmup_bars_required == 0
+    assert report.entry_orders_emitted == 0
+    assert report.subconditions == []
+    assert report.likely_blockers == []
+
+
+def test_coverage_report_validates_populated_payload() -> None:
+    report = CoverageReport.model_validate(
+        {
+            "coverage_category": "ENTRY_CONDITION_NEVER_TRUE",
+            "summary": "Combined RSI<25 and close>SMA200 never occurred.",
+            "symbols_checked": 5,
+            "bars_checked": 1250,
+            "warmup_bars_required": 80,
+            "entry_orders_emitted": 0,
+            "subconditions": [
+                {
+                    "label": "rsi < 25",
+                    "hit_count": 0,
+                    "hit_rate": 0.0,
+                    "last_true_bar": None,
+                },
+                {
+                    "label": "close > sma200",
+                    "hit_count": 612,
+                    "hit_rate": 0.49,
+                    "last_true_bar": "2025-09-30",
+                },
+            ],
+            "likely_blockers": [
+                {
+                    "reason": "volume_filter_hit_rate=0.0%",
+                    "evidence": "volume > avg_volume * 1.5 never true over 1250 bars",
+                    "hit_rate": 0.0,
+                },
+                {
+                    "reason": "target symbol TSLA not present in fetched universe",
+                    "evidence": "fetched={AAPL, MSFT, NVDA, GOOG, AMZN}",
+                },
+            ],
+        }
+    )
+
+    assert report.coverage_category is CoverageCategory.ENTRY_CONDITION_NEVER_TRUE
+    assert report.subconditions[0].label == "rsi < 25"
+    assert report.subconditions[1].last_true_bar == "2025-09-30"
+    assert report.likely_blockers[1].hit_rate is None
+
+
+def test_invalid_coverage_category_fails_validation() -> None:
+    with pytest.raises(ValidationError):
+        CoverageReport(coverage_category="NOT_A_CATEGORY")
+
+
+def test_negative_counter_values_fail_validation() -> None:
+    with pytest.raises(ValidationError):
+        CoverageReport(bars_checked=-1)
+
+
+def test_hit_rate_outside_unit_interval_fails_validation() -> None:
+    with pytest.raises(ValidationError):
+        SubconditionCoverage(label="rsi < 25", hit_count=0, hit_rate=1.5)
+
+    with pytest.raises(ValidationError):
+        SubconditionCoverage(label="rsi < 25", hit_count=0, hit_rate=-0.1)
+
+
+def test_extra_fields_are_ignored_inside_coverage_models() -> None:
+    report = CoverageReport.model_validate(
+        {
+            "coverage_category": "WARMUP_EXCEEDS_HISTORY",
+            "extra_top_level": "ignored",
+            "subconditions": [
+                {
+                    "label": "rsi < 25",
+                    "hit_count": 1,
+                    "hit_rate": 0.001,
+                    "extra_subcondition": "ignored",
+                }
+            ],
+            "likely_blockers": [
+                {
+                    "reason": "warmup=200 > history=120",
+                    "extra_blocker": "ignored",
+                }
+            ],
+        }
+    )
+
+    dumped = report.model_dump()
+    assert "extra_top_level" not in dumped
+    assert "extra_subcondition" not in report.subconditions[0].model_dump()
+    assert "extra_blocker" not in report.likely_blockers[0].model_dump()
+
+
+def test_backtest_result_with_coverage_dumps_as_json_serializable_dict() -> None:
+    result = BacktestResult(
+        **_backtest_payload(),
+        coverage_report=CoverageReport(
+            coverage_category=CoverageCategory.TARGET_SYMBOL_MISSING,
+            summary="Target symbol TSLA not in fetched universe.",
+            symbols_checked=5,
+            bars_checked=1250,
+            warmup_bars_required=200,
+            entry_orders_emitted=0,
+            likely_blockers=[
+                LikelyBlocker(
+                    reason="target symbol TSLA not present in fetched universe",
+                    evidence="fetched={AAPL, MSFT}",
+                ),
+            ],
+        ),
+    )
+
+    dumped = result.model_dump(mode="json")
+    json.dumps(dumped)
+
+    assert dumped["coverage_report"]["coverage_category"] == "TARGET_SYMBOL_MISSING"
+    assert dumped["coverage_report"]["likely_blockers"][0]["reason"].startswith(
+        "target symbol TSLA"
+    )


### PR DESCRIPTION
Closes #446. Part of #406.

## Summary
Adds the typed Pydantic envelope every later #406 sub-issue (#447–#453) writes into:
- `CoverageCategory` enum (8 values: `COVERAGE_OK`, `ENTRY_CONDITION_NEVER_TRUE`, `WARMUP_EXCEEDS_HISTORY`, `TARGET_SYMBOL_MISSING`, `INDICATOR_FILTER_TOO_RESTRICTIVE`, `CONJUNCTION_NEVER_TRUE`, `INSUFFICIENT_BARS`, `UNKNOWN_LOW_COVERAGE`).
- `LikelyBlocker`, `SubconditionCoverage`, `CoverageReport` models — same shape conventions as the #404 diagnostics envelope (`ConfigDict(extra="ignore")`, `Field(ge=0)` counters, `default_factory=list`).
- `BacktestResult.coverage_report: Optional[CoverageReport] = None` — purely additive; legacy payloads still deserialize.

`CoverageCategory` is a real `Enum` subclass (rather than the `Literal` alias #404 used) so #451 can hang category-priority logic on the class when merging probe outputs. Subclassing `str` keeps JSON serialization identical to the `Literal` form.

## Test plan
- [x] `pytest agents/investment_team/tests/test_coverage_probe_models.py` — 9 new tests (defaults, populated round-trip, invalid-enum rejection, negative-counter rejection, `hit_rate` bounded to `[0, 1]`, extra-fields-ignored, JSON round-trip, `BacktestResult` back-compat) — all pass.
- [x] `pytest agents/investment_team/tests/test_execution_diagnostics_models.py` — #407 back-compat — all 8 still pass.
- [x] `ruff check` + `ruff format --check` — clean on the touched files.

## Acceptance criteria from #446
- ✅ Pydantic validates.
- ✅ `BacktestResult` construction stays backward compatible (`coverage_report` defaults to `None`).
- ✅ Legacy persisted rows deserialize with `coverage_report=None`.
- ✅ Output shape matches the JSON envelope example in #406's body (`coverage_category`, `symbols_checked`, `bars_checked`, `warmup_bars_required`, `entry_orders_emitted`, `likely_blockers`).

https://claude.ai/code/session_01GyraoJUXhK95rA34z6iELr

---
_Generated by [Claude Code](https://claude.ai/code/session_01GyraoJUXhK95rA34z6iELr)_