### PR TITLE
investment-team: add static/code-aware coverage probe (#447)

### DIFF
--- a/backend/agents/investment_team/strategy_lab/coverage_probe/__init__.py
+++ b/backend/agents/investment_team/strategy_lab/coverage_probe/__init__.py
@@ -1,0 +1,5 @@
+"""Strategy Lab deterministic rule-coverage probes (#406)."""
+
+from .static_probe import run_static_probe
+
+__all__ = ["run_static_probe"]

--- a/backend/agents/investment_team/strategy_lab/coverage_probe/static_probe.py
+++ b/backend/agents/investment_team/strategy_lab/coverage_probe/static_probe.py
@@ -1,0 +1,212 @@
+"""Static, AST-based coverage probe for Strategy Lab strategies (#447).
+
+Inspects ``StrategySpec.strategy_code`` without executing it and flags
+configurations that would deterministically prevent entries: warm-up
+windows longer than the available history, hardcoded symbols missing
+from the fetched universe, and position-percent literals exceeding the
+strategy's own ``risk_limits.max_position_pct``.
+
+Pure: no I/O, no market fetch, no LLM. Bounded: single ``ast.parse`` +
+single ``ast.walk`` over the input source.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from typing import Iterable, List, Sequence
+
+from investment_team.models import (
+    CoverageCategory,
+    CoverageReport,
+    LikelyBlocker,
+    StrategySpec,
+)
+
+_PERIOD_NAME_RE = re.compile(
+    r"^(?:WINDOW(?:_[A-Z0-9]+)?|[A-Z0-9_]*_(?:PERIOD|LOOKBACK)|LOOKBACK[A-Z0-9_]*|MIN_HISTORY)$"
+)
+_PCT_NAME_RE = re.compile(r"^(?:POSITION_PCT|MAX_POSITION_PCT|[A-Z0-9_]+_PERCENT|[A-Z0-9_]+_PCT)$")
+_PCT_KWARG_NAMES = frozenset({"pct", "position_pct", "max_position_pct"})
+
+
+def run_static_probe(
+    spec: StrategySpec,
+    fetched_universe: Sequence[str],
+    available_bars: int,
+) -> CoverageReport:
+    """Return a partial CoverageReport derived from static analysis only.
+
+    ``available_bars`` is the count of bars the upcoming backtest can
+    reach for the longest-history symbol (caller computes from
+    ``BacktestConfig`` + market data length). The probe never reads
+    market data itself.
+    """
+    universe_set = {s for s in fetched_universe if isinstance(s, str)}
+    symbols_checked = len(universe_set)
+
+    code = spec.strategy_code
+    if not code:
+        return CoverageReport(
+            coverage_category=CoverageCategory.UNKNOWN_LOW_COVERAGE,
+            summary="no strategy_code provided",
+            symbols_checked=symbols_checked,
+            bars_checked=max(0, int(available_bars)),
+        )
+
+    try:
+        tree = ast.parse(code)
+    except (SyntaxError, ValueError):
+        return CoverageReport(
+            coverage_category=CoverageCategory.UNKNOWN_LOW_COVERAGE,
+            summary="strategy_code did not parse",
+            symbols_checked=symbols_checked,
+            bars_checked=max(0, int(available_bars)),
+        )
+
+    periods: List[int] = []
+    hardcoded_symbols: List[str] = []
+    position_pcts: List[float] = []
+
+    for node in ast.walk(tree):
+        # 1) Constant assignments: WINDOW = 80, MIN_HISTORY = 20, POSITION_PCT = 5.0
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                _collect_named_constant(target, node.value, periods, position_pcts)
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            _collect_named_constant(node.target, node.value, periods, position_pcts)
+
+        # 2) Call sites: ctx.submit_order(symbol="TSLA", ...), ctx.history(sym, 100)
+        elif isinstance(node, ast.Call):
+            attr = _attr_name(node.func)
+            if attr == "submit_order":
+                for kw in node.keywords:
+                    if (
+                        kw.arg == "symbol"
+                        and isinstance(kw.value, ast.Constant)
+                        and isinstance(kw.value.value, str)
+                    ):
+                        hardcoded_symbols.append(kw.value.value)
+                    elif kw.arg in _PCT_KWARG_NAMES:
+                        val = _numeric_constant(kw.value)
+                        if val is not None:
+                            position_pcts.append(val)
+            elif attr == "history" and len(node.args) >= 2:
+                second = node.args[1]
+                if (
+                    isinstance(second, ast.Constant)
+                    and isinstance(second.value, int)
+                    and not isinstance(second.value, bool)
+                ):
+                    if second.value > 0:
+                        periods.append(second.value)
+
+    warmup_bars_required = max(periods) if periods else 0
+    missing_symbols = [s for s in _dedupe(hardcoded_symbols) if s not in universe_set]
+    max_pct_limit = float(spec.risk_limits.max_position_pct)
+    over_limit_pcts = [p for p in position_pcts if p > max_pct_limit]
+
+    blockers: List[LikelyBlocker] = []
+    category = CoverageCategory.COVERAGE_OK
+    summary = "static probe found no blockers"
+
+    if available_bars > 0 and warmup_bars_required > available_bars:
+        category = CoverageCategory.WARMUP_EXCEEDS_HISTORY
+        summary = f"warmup window {warmup_bars_required} exceeds {available_bars} available bars"
+        blockers.append(
+            LikelyBlocker(
+                reason="warmup_exceeds_history",
+                evidence=f"warmup={warmup_bars_required} > available_bars={available_bars}",
+            )
+        )
+
+    if missing_symbols:
+        if category == CoverageCategory.COVERAGE_OK:
+            category = CoverageCategory.TARGET_SYMBOL_MISSING
+            summary = f"target symbol {missing_symbols[0]!r} not present in fetched universe"
+        for sym in missing_symbols:
+            blockers.append(
+                LikelyBlocker(
+                    reason="target_symbol_missing",
+                    evidence=f"target symbol {sym!r} not present in fetched universe",
+                )
+            )
+
+    for pct in over_limit_pcts:
+        blockers.append(
+            LikelyBlocker(
+                reason="position_pct_exceeds_risk_limit",
+                evidence=f"position_pct literal {pct} > risk_limits.max_position_pct {max_pct_limit}",
+            )
+        )
+
+    return CoverageReport(
+        coverage_category=category,
+        summary=summary,
+        symbols_checked=symbols_checked,
+        bars_checked=max(0, int(available_bars)),
+        warmup_bars_required=warmup_bars_required,
+        entry_orders_emitted=0,
+        likely_blockers=blockers,
+    )
+
+
+def _collect_named_constant(
+    target: ast.expr,
+    value: ast.expr,
+    periods: List[int],
+    position_pcts: List[float],
+) -> None:
+    name = _target_name(target)
+    if name is None:
+        return
+    numeric = _numeric_constant(value)
+    if numeric is None:
+        return
+    if _PERIOD_NAME_RE.match(name):
+        if isinstance(numeric, float) and not numeric.is_integer():
+            return
+        ivalue = int(numeric)
+        if ivalue > 0:
+            periods.append(ivalue)
+    elif _PCT_NAME_RE.match(name):
+        position_pcts.append(float(numeric))
+
+
+def _target_name(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        # e.g. ``self.WINDOW = 80`` inside ``__init__`` — flag the attr name.
+        return node.attr
+    return None
+
+
+def _attr_name(func: ast.expr) -> str | None:
+    if isinstance(func, ast.Attribute):
+        return func.attr
+    return None
+
+
+def _numeric_constant(node: ast.expr) -> float | int | None:
+    if (
+        isinstance(node, ast.Constant)
+        and isinstance(node.value, (int, float))
+        and not isinstance(node.value, bool)
+    ):
+        return node.value
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        inner = _numeric_constant(node.operand)
+        if inner is not None:
+            return -inner
+    return None
+
+
+def _dedupe(items: Iterable[str]) -> List[str]:
+    seen: set[str] = set()
+    out: List[str] = []
+    for item in items:
+        if item not in seen:
+            seen.add(item)
+            out.append(item)
+    return out

--- a/backend/agents/investment_team/strategy_lab/coverage_probe/static_probe.py
+++ b/backend/agents/investment_team/strategy_lab/coverage_probe/static_probe.py
@@ -104,7 +104,16 @@ def run_static_probe(
     warmup_bars_required = max(periods) if periods else 0
     missing_symbols = [s for s in _dedupe(hardcoded_symbols) if s not in universe_set]
     max_pct_limit = float(spec.risk_limits.max_position_pct)
-    over_limit_pcts = [p for p in position_pcts if p > max_pct_limit]
+    # Strategies often express sizing as a fraction (the ideation prompt
+    # documents ``qty = ctx.equity * pct / bar.close``), while
+    # ``RiskLimits.max_position_pct`` is in percent units (0..100).
+    # Normalize literals in (0, 1] to percent before comparing so a
+    # ``POSITION_PCT = 0.10`` (10%) gets caught against a 6% limit.
+    over_limit_pcts: List[tuple[float, float]] = []
+    for raw in position_pcts:
+        normalized = raw * 100.0 if 0.0 < raw <= 1.0 else raw
+        if normalized > max_pct_limit:
+            over_limit_pcts.append((float(raw), normalized))
 
     blockers: List[LikelyBlocker] = []
     category = CoverageCategory.COVERAGE_OK
@@ -132,11 +141,18 @@ def run_static_probe(
                 )
             )
 
-    for pct in over_limit_pcts:
+    for raw, normalized in over_limit_pcts:
+        if normalized != raw:
+            evidence = (
+                f"position_pct literal {raw} (={normalized}% of equity) "
+                f"> risk_limits.max_position_pct {max_pct_limit}"
+            )
+        else:
+            evidence = f"position_pct literal {raw} > risk_limits.max_position_pct {max_pct_limit}"
         blockers.append(
             LikelyBlocker(
                 reason="position_pct_exceeds_risk_limit",
-                evidence=f"position_pct literal {pct} > risk_limits.max_position_pct {max_pct_limit}",
+                evidence=evidence,
             )
         )
 

--- a/backend/agents/investment_team/tests/test_strategy_lab_static_probe.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_static_probe.py
@@ -114,6 +114,65 @@ def test_position_pct_over_limit_does_not_change_category() -> None:
     assert any(b.reason == "position_pct_exceeds_risk_limit" for b in report.likely_blockers)
 
 
+def test_fractional_position_pct_is_normalized_against_percent_limit() -> None:
+    # The ideation prompt documents ``qty = ctx.equity * pct / bar.close``,
+    # so ``POSITION_PCT = 0.10`` is a 10% fraction. RiskLimits.max_position_pct
+    # is 6.0 (i.e. 6%), so this must flag an oversize position.
+    code = "POSITION_PCT = 0.10\n"
+    report = run_static_probe(
+        _spec(code, max_position_pct=6.0),
+        fetched_universe=["AAPL"],
+        available_bars=250,
+    )
+
+    over_limit = [
+        b for b in report.likely_blockers if b.reason == "position_pct_exceeds_risk_limit"
+    ]
+    assert len(over_limit) == 1
+    # Evidence should make the conversion auditable.
+    assert "10" in over_limit[0].evidence and "0.1" in over_limit[0].evidence
+
+
+def test_fractional_position_pct_within_limit_not_flagged() -> None:
+    code = "POSITION_PCT = 0.05\n"  # 5%, under the 6% limit
+    report = run_static_probe(
+        _spec(code, max_position_pct=6.0),
+        fetched_universe=["AAPL"],
+        available_bars=250,
+    )
+
+    assert all(b.reason != "position_pct_exceeds_risk_limit" for b in report.likely_blockers)
+
+
+def test_full_equity_fraction_is_flagged() -> None:
+    # ``pct = 1.0`` means 100% of equity in the documented fraction
+    # convention — far over any reasonable max_position_pct.
+    code = "POSITION_PCT = 1.0\n"
+    report = run_static_probe(
+        _spec(code, max_position_pct=6.0),
+        fetched_universe=["AAPL"],
+        available_bars=250,
+    )
+
+    assert any(b.reason == "position_pct_exceeds_risk_limit" for b in report.likely_blockers)
+
+
+def test_pct_kwarg_fractional_value_is_normalized() -> None:
+    code = textwrap.dedent(
+        """
+        def on_bar(self, ctx, bar):
+            ctx.submit_order(symbol=bar.symbol, side="LONG", qty=10, pct=0.20)
+        """
+    )
+    report = run_static_probe(
+        _spec(code, max_position_pct=6.0),
+        fetched_universe=["AAPL"],
+        available_bars=250,
+    )
+
+    assert any(b.reason == "position_pct_exceeds_risk_limit" for b in report.likely_blockers)
+
+
 def test_malformed_code_returns_unknown_low_coverage() -> None:
     report = run_static_probe(
         _spec("def on_bar(:::"),

--- a/backend/agents/investment_team/tests/test_strategy_lab_static_probe.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_static_probe.py
@@ -1,0 +1,210 @@
+"""Tests for the static/code-aware coverage probe (#447)."""
+
+from __future__ import annotations
+
+import textwrap
+
+from investment_team.models import (
+    CoverageCategory,
+    StrategySpec,
+)
+from investment_team.strategy_lab.coverage_probe import run_static_probe
+
+
+def _spec(strategy_code: str | None, *, max_position_pct: float = 6.0) -> StrategySpec:
+    return StrategySpec(
+        strategy_id="strat-test",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="hyp",
+        signal_definition="sig",
+        entry_rules=["enter when RSI < 30"],
+        exit_rules=["exit when RSI > 70"],
+        sizing_rules=["risk 2% per trade"],
+        risk_limits={"max_position_pct": max_position_pct},
+        speculative=False,
+        strategy_code=strategy_code,
+    )
+
+
+def test_clean_factor_compiled_code_returns_coverage_ok() -> None:
+    code = textwrap.dedent(
+        """
+        from contract import Strategy, OrderSide, OrderType
+
+        class S(Strategy):
+            MIN_HISTORY = 20
+
+            def on_bar(self, ctx, bar):
+                bars = ctx.history(bar.symbol, self.MIN_HISTORY + 4)
+                if len(bars) < self.MIN_HISTORY:
+                    return
+                pos = ctx.position(bar.symbol)
+                if pos is None:
+                    ctx.submit_order(
+                        symbol=bar.symbol,
+                        side=OrderSide.LONG,
+                        qty=10,
+                        order_type=OrderType.MARKET,
+                        reason="entry",
+                    )
+        """
+    )
+    report = run_static_probe(_spec(code), fetched_universe=["AAPL", "MSFT"], available_bars=250)
+
+    assert report.coverage_category is CoverageCategory.COVERAGE_OK
+    assert report.likely_blockers == []
+    assert report.warmup_bars_required == 20
+    assert report.symbols_checked == 2
+    assert report.bars_checked == 250
+    assert report.entry_orders_emitted == 0
+
+
+def test_warmup_exceeds_history_takes_priority() -> None:
+    code = "WINDOW = 500\n"
+    report = run_static_probe(_spec(code), fetched_universe=["AAPL"], available_bars=200)
+
+    assert report.coverage_category is CoverageCategory.WARMUP_EXCEEDS_HISTORY
+    assert report.warmup_bars_required == 500
+    assert any(b.reason == "warmup_exceeds_history" for b in report.likely_blockers)
+    assert "500" in report.summary and "200" in report.summary
+
+
+def test_missing_target_symbol_flagged() -> None:
+    code = textwrap.dedent(
+        """
+        def on_bar(self, ctx, bar):
+            ctx.submit_order(symbol="TSLA", side="LONG", qty=10)
+        """
+    )
+    report = run_static_probe(_spec(code), fetched_universe=["AAPL", "MSFT"], available_bars=250)
+
+    assert report.coverage_category is CoverageCategory.TARGET_SYMBOL_MISSING
+    assert any(
+        b.reason == "target_symbol_missing" and "TSLA" in b.evidence for b in report.likely_blockers
+    )
+
+
+def test_warmup_takes_priority_over_missing_symbol() -> None:
+    code = textwrap.dedent(
+        """
+        WINDOW = 800
+
+        def on_bar(self, ctx, bar):
+            ctx.submit_order(symbol="TSLA", side="LONG", qty=10)
+        """
+    )
+    report = run_static_probe(_spec(code), fetched_universe=["AAPL"], available_bars=200)
+
+    assert report.coverage_category is CoverageCategory.WARMUP_EXCEEDS_HISTORY
+    reasons = {b.reason for b in report.likely_blockers}
+    assert "warmup_exceeds_history" in reasons
+    assert "target_symbol_missing" in reasons
+
+
+def test_position_pct_over_limit_does_not_change_category() -> None:
+    code = "POSITION_PCT = 15.0\n"
+    report = run_static_probe(
+        _spec(code, max_position_pct=6.0),
+        fetched_universe=["AAPL"],
+        available_bars=250,
+    )
+
+    assert report.coverage_category is CoverageCategory.COVERAGE_OK
+    assert any(b.reason == "position_pct_exceeds_risk_limit" for b in report.likely_blockers)
+
+
+def test_malformed_code_returns_unknown_low_coverage() -> None:
+    report = run_static_probe(
+        _spec("def on_bar(:::"),
+        fetched_universe=["AAPL"],
+        available_bars=250,
+    )
+
+    assert report.coverage_category is CoverageCategory.UNKNOWN_LOW_COVERAGE
+    assert "did not parse" in report.summary
+    assert report.likely_blockers == []
+
+
+def test_none_strategy_code_returns_unknown_low_coverage() -> None:
+    report = run_static_probe(_spec(None), fetched_universe=["AAPL"], available_bars=250)
+
+    assert report.coverage_category is CoverageCategory.UNKNOWN_LOW_COVERAGE
+    assert "no strategy_code" in report.summary
+
+
+def test_dynamic_bar_symbol_only_does_not_flag_symbol() -> None:
+    code = textwrap.dedent(
+        """
+        def on_bar(self, ctx, bar):
+            ctx.submit_order(symbol=bar.symbol, side="LONG", qty=10)
+        """
+    )
+    report = run_static_probe(_spec(code), fetched_universe=["AAPL"], available_bars=250)
+
+    assert report.coverage_category is CoverageCategory.COVERAGE_OK
+    assert all(b.reason != "target_symbol_missing" for b in report.likely_blockers)
+
+
+def test_class_attribute_period_is_extracted() -> None:
+    code = textwrap.dedent(
+        """
+        class S:
+            WINDOW = 80
+        """
+    )
+    report = run_static_probe(_spec(code), fetched_universe=["AAPL"], available_bars=250)
+
+    assert report.warmup_bars_required == 80
+    assert report.coverage_category is CoverageCategory.COVERAGE_OK
+
+
+def test_inline_history_call_arg_is_extracted() -> None:
+    code = textwrap.dedent(
+        """
+        def on_bar(self, ctx, bar):
+            bars = ctx.history(bar.symbol, 100)
+        """
+    )
+    report = run_static_probe(_spec(code), fetched_universe=["AAPL"], available_bars=250)
+
+    assert report.warmup_bars_required == 100
+
+
+def test_period_alias_names_are_picked_up() -> None:
+    code = textwrap.dedent(
+        """
+        RSI_PERIOD = 14
+        SMA_LOOKBACK = 200
+        LOOKBACK_LONG = 50
+        """
+    )
+    report = run_static_probe(_spec(code), fetched_universe=["AAPL"], available_bars=300)
+
+    assert report.warmup_bars_required == 200
+
+
+def test_duplicate_missing_symbols_yield_one_blocker_per_unique_symbol() -> None:
+    code = textwrap.dedent(
+        """
+        def on_bar(self, ctx, bar):
+            ctx.submit_order(symbol="TSLA", side="LONG", qty=1)
+            ctx.submit_order(symbol="TSLA", side="SHORT", qty=1)
+            ctx.submit_order(symbol="NVDA", side="LONG", qty=1)
+        """
+    )
+    report = run_static_probe(_spec(code), fetched_universe=["AAPL"], available_bars=250)
+
+    missing_blockers = [b for b in report.likely_blockers if b.reason == "target_symbol_missing"]
+    assert len(missing_blockers) == 2
+    evidence_text = " ".join(b.evidence for b in missing_blockers)
+    assert "TSLA" in evidence_text and "NVDA" in evidence_text
+
+
+def test_zero_or_negative_available_bars_does_not_trigger_warmup_blocker() -> None:
+    code = "WINDOW = 50\n"
+    report = run_static_probe(_spec(code), fetched_universe=["AAPL"], available_bars=0)
+
+    assert report.coverage_category is CoverageCategory.COVERAGE_OK
+    assert report.warmup_bars_required == 50
+    assert all(b.reason != "warmup_exceeds_history" for b in report.likely_blockers)


### PR DESCRIPTION
## Summary

Closes #447. First of two coverage probes for #406's deterministic rule-coverage stage.

- **New** `backend/agents/investment_team/strategy_lab/coverage_probe/static_probe.py` — pure AST walk over `StrategySpec.strategy_code` returning a partial `CoverageReport`.
- Flags `WARMUP_EXCEEDS_HISTORY` when extracted period constants (`WINDOW`, `*_PERIOD`, `*_LOOKBACK`, `MIN_HISTORY`, plus inline `ctx.history(symbol, n)` literals) exceed `available_bars`.
- Flags `TARGET_SYMBOL_MISSING` when a hardcoded `symbol="..."` kwarg in `ctx.submit_order(...)` is not in the fetched universe (dynamic `bar.symbol` is ignored).
- Adds non-categorising `position_pct_exceeds_risk_limit` blockers when literals named `POSITION_PCT`/`*_PCT`/`*_PERCENT` (or `pct=`/`position_pct=` kwargs) exceed `spec.risk_limits.max_position_pct`.
- Malformed code or `strategy_code=None` returns `UNKNOWN_LOW_COVERAGE` (never raises).
- 13 unit tests; pure (no I/O, no LLM, no market fetch). Bounded: single `ast.parse` + single `ast.walk`.

Wiring into the orchestrator and refinement prompt is intentionally out of scope — handled by #451 (orchestrator stage) and #452 (refinement prompt). Indicator-coverage stats remain for #448; runtime probes for #449/#450.

Note: issue body referenced `client.order(...)`/`positions[...]`, but the actual generated-strategy API in this repo is `ctx.submit_order(...)` / `ctx.position(...)` (confirmed in `factors/compiler.py:581-606` and `quality_gates/code_safety.py:91-97`). The probe targets the real API.

## Test plan

- [x] `ruff check` + `ruff format --check` pass on new files
- [x] `pytest agents/investment_team/tests/test_strategy_lab_static_probe.py` — 13 passed
- [ ] CI green on full backend suite
- [ ] Reviewer sanity-check that the AST patterns match what generated strategies actually look like (factor-compiled + LLM-generated)

https://claude.ai/code/session_01Qjhb4fn88G31qoyLGwpryV

---
_Generated by [Claude Code](https://claude.ai/code/session_01Qjhb4fn88G31qoyLGwpryV)_