### PR TITLE
market_research_team: convert test_api.py to unit tests via fake_job_client (#364)

### DIFF
--- a/backend/agents/market_research_team/tests/conftest.py
+++ b/backend/agents/market_research_team/tests/conftest.py
@@ -82,6 +82,21 @@ SAMPLE_CONSISTENCY_JSON = json.dumps(
 
 
 @pytest.fixture(autouse=True)
+def _patched_market_research_job_client(monkeypatch, fake_job_client):
+    """Route the team's job_store ``_client`` factory through the in-memory fake.
+
+    Lets ``test_api.py`` exercise the FastAPI app end-to-end without requiring
+    the real job service or Postgres. Also clears the module-level singleton
+    cache so a real client cached at import time can't leak in.
+    """
+    from market_research_team.shared import job_store as js
+
+    monkeypatch.setattr(js, "_client_instance", None, raising=False)
+    monkeypatch.setattr(js, "_client", lambda *a, **kw: fake_job_client)
+    return fake_job_client
+
+
+@pytest.fixture(autouse=True)
 def _mock_strands(monkeypatch):
     """Patch Strands agent construction and graph invocation for all tests.
 

--- a/backend/agents/market_research_team/tests/test_api.py
+++ b/backend/agents/market_research_team/tests/test_api.py
@@ -1,7 +1,8 @@
 """API tests for the Market Research team — async-only job flow.
 
-Hits the team API which calls the real job service.  Marked integration
-pending follow-up to mock the team's ``_client`` factory.
+Exercises the team API against the in-memory ``fake_job_client`` fixture
+(autouse-patched in ``tests/conftest.py``), so no real job service or
+Postgres is required.
 """
 
 from __future__ import annotations
@@ -15,8 +16,6 @@ from fastapi.testclient import TestClient
 
 from market_research_team.api import main as api_main
 from market_research_team.api.main import app
-
-pytestmark = [pytest.mark.integration]
 
 client = TestClient(app)
 


### PR DESCRIPTION
Closes #364.

## Summary

Follow-up to #360. `backend/agents/market_research_team/tests/test_api.py` was marked `@pytest.mark.integration` because the FastAPI app it exercises calls the real job service through `market_research_team.shared.job_store`. The default test run skips integration-marked tests, so these five tests didn't actually run in the unit-test pipeline.

This PR follows the recipe spelled out in #364:

- **`tests/conftest.py`** — adds an autouse `_patched_market_research_job_client` fixture that monkeypatches `market_research_team.shared.job_store._client` to a lambda returning the shared in-memory `fake_job_client` (re-exported from `backend/conftest.py:60`, source in `backend/agents/job_service_client_fake.py`). Also resets the module-level `_client_instance` singleton defensively so any cached real client can't leak through.
- **`tests/test_api.py`** — drops the file-level `pytestmark = [pytest.mark.integration]` and refreshes the module docstring.

Mirrors the pattern already in use:
- `backend/agents/blogging/tests/test_blogging_job_store.py:11-16`
- `backend/agents/software_engineering_team/tests/test_job_store_heartbeat.py:16-22`

## Test plan

- [x] `pytest agents/market_research_team/tests/test_api.py -v` — 5 passed in 0.31s (previously skipped by default)
- [x] `pytest agents/market_research_team/tests -v` — 34 passed
- [x] `env -u POSTGRES_HOST -u JOB_SERVICE_URL pytest agents/market_research_team/tests/test_api.py` — 5 passed; confirms no real job service or Postgres is needed
- [x] `ruff check` and `ruff format --check` clean on the test directory

https://claude.ai/code/session_013D3jFAvmGNaPsCpcRpUrnK

---
_Generated by [Claude Code](https://claude.ai/code/session_013D3jFAvmGNaPsCpcRpUrnK)_