### PR TITLE
investment-team: add runtime AST instrumenter for coverage probe (#449)

### DIFF
--- a/backend/agents/investment_team/models.py
+++ b/backend/agents/investment_team/models.py
@@ -517,6 +517,12 @@ class CoverageReport(BaseModel):
     likely_blockers: List[LikelyBlocker] = Field(default_factory=list)
 
 
+class RuleIndex(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    rules: dict[str, str] = Field(default_factory=dict)
+
+
 class BacktestResult(BaseModel):
     total_return_pct: float
     annualized_return_pct: float

--- a/backend/agents/investment_team/strategy_lab/coverage_probe/__init__.py
+++ b/backend/agents/investment_team/strategy_lab/coverage_probe/__init__.py
@@ -1,5 +1,8 @@
 """Strategy Lab deterministic rule-coverage probes (#406)."""
 
+from investment_team.models import RuleIndex
+
+from .runtime_instrument import instrument_strategy_code
 from .static_probe import run_static_probe
 
-__all__ = ["run_static_probe"]
+__all__ = ["RuleIndex", "instrument_strategy_code", "run_static_probe"]

--- a/backend/agents/investment_team/strategy_lab/coverage_probe/runtime_instrument.py
+++ b/backend/agents/investment_team/strategy_lab/coverage_probe/runtime_instrument.py
@@ -2,18 +2,24 @@
 
 Rewrites a generated strategy module so that every ``if`` / ``elif``
 predicate inside ``on_bar`` records the truth of each subcondition via
-``__probe_record__(rule_id, bar_index, value)``. The default
+``__probe_record__(rule_id, __probe_bar_index__, value)``. The default
 ``__probe_record__`` defined by the bootstrap prelude is the identity
 function, so the rewritten module behaves identically to the original
 when no harness has injected a real recorder. The runtime probe harness
-(#450) will rebind ``__probe_record__`` and ``bar_index`` in the exec
-globals before each bar.
+(#450) will rebind ``__probe_record__`` and ``__probe_bar_index__`` in
+the exec globals before each bar.
 
-The dunder-style name is deliberate: a plain ``__probe_record`` would be
-subject to Python's class-private name mangling and become
-``_StrategyClass__probe_record`` when referenced inside the strategy
-class body, breaking the harness contract. Trailing underscores opt out
-of mangling.
+The dunder-style names are deliberate. A plain ``__probe_record`` /
+``__bar_index`` inside the strategy class body would be subject to
+Python's class-private name mangling and become
+``_StrategyClass__probe_record`` etc., breaking the harness contract.
+Equally, a non-prefixed name like ``bar_index`` would be captured by any
+``on_bar`` local of the same name (Python resolves identifiers via
+function-scope symbol tables, not by lexical order), turning a probe
+read into an ``UnboundLocalError`` or — worse — silently recording the
+strategy's loop counter. Trailing underscores opt out of mangling, and
+the dunder prefix makes collision with hand-written strategy locals
+practically impossible.
 
 Pure source-to-source: no execution, no I/O, no LLM.
 
@@ -32,7 +38,7 @@ from typing import List, Tuple
 from investment_team.models import RuleIndex
 
 _PROBE_NAME = "__probe_record__"
-_BAR_INDEX_NAME = "bar_index"
+_BAR_INDEX_NAME = "__probe_bar_index__"
 _LABEL_MAX_LEN = 120
 
 
@@ -71,7 +77,8 @@ def instrument_strategy_code(code: str) -> Tuple[str, RuleIndex]:
         return code, RuleIndex()
 
     prelude = _bootstrap_prelude()
-    tree.body = prelude + tree.body
+    insert_at = _prelude_insertion_index(tree)
+    tree.body = tree.body[:insert_at] + prelude + tree.body[insert_at:]
     ast.fix_missing_locations(tree)
 
     try:
@@ -232,8 +239,33 @@ def _bootstrap_prelude() -> List[ast.stmt]:
         "    def __probe_record__(_rid, _bidx, _value):\n"
         "        return _value\n"
         "try:\n"
-        "    bar_index  # noqa: F821\n"
+        "    __probe_bar_index__  # noqa: F821\n"
         "except NameError:\n"
-        "    bar_index = 0\n"
+        "    __probe_bar_index__ = 0\n"
     )
     return ast.parse(src).body
+
+
+def _prelude_insertion_index(tree: ast.Module) -> int:
+    """Return the index in ``tree.body`` after which the prelude is safe to
+    insert. Skips a leading module docstring and any ``from __future__``
+    imports — those statements have placement constraints (``__future__``
+    must be the first non-docstring statement) and prepending the prelude
+    ahead of them would emit a module that no longer compiles.
+    """
+    idx = 0
+    body = tree.body
+    if (
+        idx < len(body)
+        and isinstance(body[idx], ast.Expr)
+        and isinstance(body[idx].value, ast.Constant)
+        and isinstance(body[idx].value.value, str)
+    ):
+        idx += 1
+    while (
+        idx < len(body)
+        and isinstance(body[idx], ast.ImportFrom)
+        and body[idx].module == "__future__"
+    ):
+        idx += 1
+    return idx

--- a/backend/agents/investment_team/strategy_lab/coverage_probe/runtime_instrument.py
+++ b/backend/agents/investment_team/strategy_lab/coverage_probe/runtime_instrument.py
@@ -1,0 +1,239 @@
+"""Runtime AST instrumenter for Strategy Lab coverage probe (#449).
+
+Rewrites a generated strategy module so that every ``if`` / ``elif``
+predicate inside ``on_bar`` records the truth of each subcondition via
+``__probe_record__(rule_id, bar_index, value)``. The default
+``__probe_record__`` defined by the bootstrap prelude is the identity
+function, so the rewritten module behaves identically to the original
+when no harness has injected a real recorder. The runtime probe harness
+(#450) will rebind ``__probe_record__`` and ``bar_index`` in the exec
+globals before each bar.
+
+The dunder-style name is deliberate: a plain ``__probe_record`` would be
+subject to Python's class-private name mangling and become
+``_StrategyClass__probe_record`` when referenced inside the strategy
+class body, breaking the harness contract. Trailing underscores opt out
+of mangling.
+
+Pure source-to-source: no execution, no I/O, no LLM.
+
+The code emitted by this module is intended to be executed only by the
+probe harness — it is **not** re-fed through ``CodeSafetyChecker``. The
+prelude uses ``try/except NameError`` rather than ``globals()`` because the
+safety gate bans the latter.
+"""
+
+from __future__ import annotations
+
+import ast
+import warnings
+from typing import List, Tuple
+
+from investment_team.models import RuleIndex
+
+_PROBE_NAME = "__probe_record__"
+_BAR_INDEX_NAME = "bar_index"
+_LABEL_MAX_LEN = 120
+
+
+def instrument_strategy_code(code: str) -> Tuple[str, RuleIndex]:
+    """Wrap each subcondition inside ``on_bar`` if-tests with a probe call.
+
+    Returns ``(rewritten_code, rule_index)``. On malformed source, on a
+    module without an ``on_bar`` method, or when the source is already
+    instrumented, returns a sensible no-op pair (see acceptance criteria
+    in #449). Never raises.
+    """
+    try:
+        tree = ast.parse(code)
+    except SyntaxError as exc:
+        warnings.warn(
+            f"runtime_instrument: source did not parse ({exc}); returning original",
+            UserWarning,
+            stacklevel=2,
+        )
+        return code, RuleIndex()
+
+    if _is_already_instrumented(tree):
+        return code, _rebuild_index_from_existing(tree)
+
+    on_bar = _find_on_bar(tree)
+    if on_bar is None:
+        return code, RuleIndex()
+
+    rules: dict[str, str] = {}
+    counter = [0]
+    transformer = _IfTransformer(rules, counter)
+    on_bar.body = [transformer.visit(stmt) for stmt in on_bar.body]
+    ast.fix_missing_locations(on_bar)
+
+    if not rules:
+        return code, RuleIndex()
+
+    prelude = _bootstrap_prelude()
+    tree.body = prelude + tree.body
+    ast.fix_missing_locations(tree)
+
+    try:
+        rewritten = ast.unparse(tree)
+    except Exception as exc:  # pragma: no cover — ast.unparse is robust on parsed trees
+        warnings.warn(
+            f"runtime_instrument: ast.unparse failed ({exc}); returning original",
+            UserWarning,
+            stacklevel=2,
+        )
+        return code, RuleIndex()
+
+    return rewritten, RuleIndex(rules=rules)
+
+
+def _is_already_instrumented(tree: ast.AST) -> bool:
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == _PROBE_NAME
+        ):
+            return True
+    return False
+
+
+def _rebuild_index_from_existing(tree: ast.AST) -> RuleIndex:
+    rules: dict[str, str] = {}
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == _PROBE_NAME
+            and len(node.args) == 3
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+        ):
+            rid = node.args[0].value
+            if rid in rules:
+                continue
+            rules[rid] = _label_for(node.args[2])
+    return RuleIndex(rules=rules)
+
+
+def _find_on_bar(tree: ast.AST) -> ast.FunctionDef | None:
+    for node in ast.iter_child_nodes(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        if not _is_strategy_subclass(node):
+            continue
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.FunctionDef) and child.name == "on_bar":
+                return child
+    return None
+
+
+def _is_strategy_subclass(cls: ast.ClassDef) -> bool:
+    for base in cls.bases:
+        if isinstance(base, ast.Name) and base.id == "Strategy":
+            return True
+        if (
+            isinstance(base, ast.Attribute)
+            and base.attr == "Strategy"
+            and isinstance(base.value, ast.Name)
+            and base.value.id == "contract"
+        ):
+            return True
+    return False
+
+
+class _IfTransformer(ast.NodeTransformer):
+    """Wraps subconditions of ``If.test`` nodes within ``on_bar``.
+
+    Descends through compound bodies (``If``, ``For``, ``While``, ``With``,
+    ``Try``) but stops at nested function / lambda boundaries so helper
+    functions defined inside ``on_bar`` are left untouched.
+    """
+
+    def __init__(self, rules: dict[str, str], counter: List[int]) -> None:
+        self._rules = rules
+        self._counter = counter
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.AST:  # noqa: N802
+        return node
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> ast.AST:  # noqa: N802
+        return node
+
+    def visit_Lambda(self, node: ast.Lambda) -> ast.AST:  # noqa: N802
+        return node
+
+    def visit_If(self, node: ast.If) -> ast.AST:  # noqa: N802
+        node.test = _wrap_expr(node.test, self._rules, self._counter)
+        node.body = [self.visit(child) for child in node.body]
+        node.orelse = [self.visit(child) for child in node.orelse]
+        return node
+
+
+def _wrap_expr(expr: ast.expr, rules: dict[str, str], counter: List[int]) -> ast.expr:
+    if isinstance(expr, ast.BoolOp):
+        expr.values = [_wrap_expr(v, rules, counter) for v in expr.values]
+        return expr
+    if _is_already_wrapped(expr):
+        return expr
+    if isinstance(expr, ast.Constant):
+        return expr
+    return _wrap_leg(expr, rules, counter)
+
+
+def _wrap_leg(leg: ast.expr, rules: dict[str, str], counter: List[int]) -> ast.Call:
+    rid = f"r{counter[0]}"
+    counter[0] += 1
+    rules[rid] = _label_for(leg)
+    call = ast.Call(
+        func=ast.Name(id=_PROBE_NAME, ctx=ast.Load()),
+        args=[
+            ast.Constant(value=rid),
+            ast.Name(id=_BAR_INDEX_NAME, ctx=ast.Load()),
+            leg,
+        ],
+        keywords=[],
+    )
+    ast.copy_location(call, leg)
+    return call
+
+
+def _is_already_wrapped(expr: ast.expr) -> bool:
+    return (
+        isinstance(expr, ast.Call)
+        and isinstance(expr.func, ast.Name)
+        and expr.func.id == _PROBE_NAME
+    )
+
+
+def _label_for(expr: ast.expr) -> str:
+    try:
+        text = ast.unparse(expr)
+    except Exception:  # pragma: no cover
+        return ""
+    text = " ".join(text.split())
+    if len(text) > _LABEL_MAX_LEN:
+        text = text[: _LABEL_MAX_LEN - 1] + "…"
+    return text
+
+
+def _bootstrap_prelude() -> List[ast.stmt]:
+    """Return AST statements that define no-op defaults for the probe API.
+
+    Uses ``try/except NameError`` rather than a ``globals()`` check because
+    the strategy code-safety gate bans ``globals(`` patterns. Both names
+    are only defined when not already present, so the harness (#450) can
+    pre-bind real implementations in the exec globals.
+    """
+    src = (
+        "try:\n"
+        "    __probe_record__  # noqa: F821\n"
+        "except NameError:\n"
+        "    def __probe_record__(_rid, _bidx, _value):\n"
+        "        return _value\n"
+        "try:\n"
+        "    bar_index  # noqa: F821\n"
+        "except NameError:\n"
+        "    bar_index = 0\n"
+    )
+    return ast.parse(src).body

--- a/backend/agents/investment_team/tests/test_strategy_lab_runtime_instrument.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_runtime_instrument.py
@@ -1,0 +1,251 @@
+"""Unit tests for the runtime AST instrumenter (#449)."""
+
+from __future__ import annotations
+
+import ast
+import textwrap
+
+import pytest
+
+from investment_team.models import RuleIndex
+from investment_team.strategy_lab.coverage_probe import instrument_strategy_code
+from investment_team.strategy_lab.quality_gates.code_safety import CodeSafetyChecker
+
+
+def _wrap_in_strategy(on_bar_body: str) -> str:
+    body = textwrap.indent(textwrap.dedent(on_bar_body).strip("\n"), " " * 8)
+    return (
+        textwrap.dedent(
+            """\
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+        """
+        )
+        + body
+        + "\n"
+    )
+
+
+def _probe_calls(code: str) -> list[ast.Call]:
+    tree = ast.parse(code)
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "__probe_record__"
+    ]
+
+
+def test_returns_rule_index_for_simple_if() -> None:
+    code = _wrap_in_strategy(
+        """
+        rsi = 10
+        if rsi < 25:
+            return
+        """
+    )
+    rewritten, index = instrument_strategy_code(code)
+
+    assert isinstance(index, RuleIndex)
+    assert len(index.rules) == 1
+    label = next(iter(index.rules.values()))
+    assert label == "rsi < 25"
+    assert len(_probe_calls(rewritten)) == 1
+
+
+def test_boolop_and_splits_into_legs() -> None:
+    code = _wrap_in_strategy(
+        """
+        a = 1
+        b = 0
+        if a > 0 and b < 1:
+            return
+        """
+    )
+    rewritten, index = instrument_strategy_code(code)
+
+    assert len(index.rules) == 2
+    assert "a > 0" in index.rules.values()
+    assert "b < 1" in index.rules.values()
+
+    tree = ast.parse(rewritten)
+    if_nodes = [n for n in ast.walk(tree) if isinstance(n, ast.If)]
+    assert any(isinstance(n.test, ast.BoolOp) and isinstance(n.test.op, ast.And) for n in if_nodes)
+
+
+def test_nested_boolop_recurses() -> None:
+    code = _wrap_in_strategy(
+        """
+        a = 1
+        b = 0
+        c = 1
+        if (a or b) and c:
+            return
+        """
+    )
+    _, index = instrument_strategy_code(code)
+    assert len(index.rules) == 3
+    assert {"a", "b", "c"}.issubset(set(index.rules.values()))
+
+
+def test_unaryop_not_is_single_leaf() -> None:
+    code = _wrap_in_strategy(
+        """
+        x = False
+        if not x:
+            return
+        """
+    )
+    _, index = instrument_strategy_code(code)
+    assert len(index.rules) == 1
+    assert next(iter(index.rules.values())) == "not x"
+
+
+def test_elif_chain_each_branch_indexed() -> None:
+    code = _wrap_in_strategy(
+        """
+        x = 0
+        if x < 0:
+            return
+        elif x == 0:
+            return
+        elif x > 100:
+            return
+        else:
+            return
+        """
+    )
+    _, index = instrument_strategy_code(code)
+    labels = set(index.rules.values())
+    assert labels == {"x < 0", "x == 0", "x > 100"}
+
+
+def test_idempotent_second_pass_is_noop() -> None:
+    code = _wrap_in_strategy(
+        """
+        a = 1
+        if a > 0:
+            return
+        """
+    )
+    once, index_once = instrument_strategy_code(code)
+    twice, index_twice = instrument_strategy_code(once)
+
+    assert once == twice
+    assert index_once.rules == index_twice.rules
+
+
+def test_malformed_source_returns_original_with_empty_index_and_warns() -> None:
+    bad_code = "def x("
+    with pytest.warns(UserWarning):
+        rewritten, index = instrument_strategy_code(bad_code)
+    assert rewritten == bad_code
+    assert index.rules == {}
+
+
+def test_no_on_bar_returns_original_unchanged() -> None:
+    code = textwrap.dedent(
+        """
+        from contract import Strategy
+
+        class S(Strategy):
+            pass
+        """
+    )
+    rewritten, index = instrument_strategy_code(code)
+    assert rewritten == code
+    assert index.rules == {}
+
+
+def test_helper_function_if_is_not_wrapped() -> None:
+    code = textwrap.dedent(
+        """
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                def _filter(x):
+                    if x > 0:
+                        return True
+                    return False
+                if _filter(1):
+                    return
+        """
+    )
+    _, index = instrument_strategy_code(code)
+    # Only the on_bar's top-level if is wrapped; the nested helper's if is not.
+    assert len(index.rules) == 1
+    assert next(iter(index.rules.values())) == "_filter(1)"
+
+
+def test_constant_test_is_not_wrapped() -> None:
+    code = _wrap_in_strategy(
+        """
+        if True:
+            return
+        """
+    )
+    _, index = instrument_strategy_code(code)
+    assert index.rules == {}
+
+
+def test_instrumented_code_passes_code_safety_gate() -> None:
+    from .golden.strategies import SMA_CROSSOVER_CODE
+
+    rewritten, _ = instrument_strategy_code(SMA_CROSSOVER_CODE)
+    results = CodeSafetyChecker().check(rewritten)
+    criticals = [r for r in results if r.severity == "critical"]
+    assert criticals == [], [r.details for r in criticals]
+
+
+def test_no_harness_runs_with_identity_default() -> None:
+    code = _wrap_in_strategy(
+        """
+        a = 5
+        b = 1
+        if a > 0 and b < 10:
+            self.fired = True
+        """
+    )
+    rewritten, _ = instrument_strategy_code(code)
+    # Replace the contract import + class so we can exec-and-call without the
+    # real Strategy base. We just need the on_bar body to execute under the
+    # bootstrap prelude.
+    standalone = rewritten.replace("from contract import Strategy", "Strategy = object")
+    namespace: dict = {}
+    exec(compile(standalone, "<probe-test>", "exec"), namespace)
+    instance = namespace["S"]()
+    instance.on_bar(None, None)
+    assert getattr(instance, "fired", False) is True
+
+
+def test_index_is_rebuilt_when_already_instrumented() -> None:
+    code = _wrap_in_strategy(
+        """
+        a = 1
+        if a > 0:
+            return
+        """
+    )
+    once, index_once = instrument_strategy_code(code)
+    _, index_again = instrument_strategy_code(once)
+    assert index_again.rules == index_once.rules
+
+
+def test_rule_ids_are_stable_and_sequential() -> None:
+    code = _wrap_in_strategy(
+        """
+        a = 1
+        b = 2
+        c = 3
+        if a > 0 and b > 0:
+            return
+        if c > 0:
+            return
+        """
+    )
+    _, index = instrument_strategy_code(code)
+    assert sorted(index.rules.keys()) == ["r0", "r1", "r2"]

--- a/backend/agents/investment_team/tests/test_strategy_lab_runtime_instrument.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_runtime_instrument.py
@@ -235,6 +235,74 @@ def test_index_is_rebuilt_when_already_instrumented() -> None:
     assert index_again.rules == index_once.rules
 
 
+def test_future_import_stays_first_after_instrumentation() -> None:
+    code = textwrap.dedent(
+        '''
+        """Top-level module docstring."""
+
+        from __future__ import annotations
+
+        from contract import Strategy
+
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                a = 1
+                if a > 0:
+                    return
+        '''
+    ).lstrip()
+    rewritten, index = instrument_strategy_code(code)
+    assert len(index.rules) == 1
+
+    # Must compile (the actual constraint __future__ enforces).
+    compile(rewritten, "<probe-test>", "exec")
+
+    # And the __future__ import must still appear before any non-docstring
+    # non-future statement in the rewritten module.
+    tree = ast.parse(rewritten)
+    seen_future = False
+    for stmt in tree.body:
+        if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Constant):
+            continue
+        if isinstance(stmt, ast.ImportFrom) and stmt.module == "__future__":
+            seen_future = True
+            continue
+        # Once we hit any other statement, the future import must already
+        # have been seen.
+        assert seen_future, (
+            f"non-future stmt {type(stmt).__name__} appeared before __future__ import"
+        )
+        break
+
+
+def test_strategy_local_bar_index_does_not_capture_probe_reference() -> None:
+    """A strategy that binds ``bar_index`` locally must not break the probe.
+
+    Regression for the codex-connector P2 finding: if the probe used a
+    plain ``bar_index`` name, Python's symbol-table analysis would treat
+    every reference inside ``on_bar`` as a local (LOAD_FAST), shadowing
+    the harness global. Using the dunder name ``__probe_bar_index__``
+    avoids the collision entirely.
+    """
+    code = _wrap_in_strategy(
+        """
+        for bar_index in range(3):
+            pass
+        a = 1
+        if a > 0:
+            self.fired = True
+        """
+    )
+    rewritten, _ = instrument_strategy_code(code)
+    standalone = rewritten.replace("from contract import Strategy", "Strategy = object")
+    namespace: dict = {}
+    exec(compile(standalone, "<probe-test>", "exec"), namespace)
+    instance = namespace["S"]()
+    instance.on_bar(None, None)
+    assert getattr(instance, "fired", False) is True
+
+
 def test_rule_ids_are_stable_and_sequential() -> None:
     code = _wrap_in_strategy(
         """

--- a/backend/agents/investment_team/tests/test_strategy_lab_runtime_instrument_golden.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_runtime_instrument_golden.py
@@ -1,0 +1,112 @@
+"""Round-trip behaviour-preservation tests for the runtime instrumenter (#449).
+
+For each known fixture strategy, run the original and instrumented sources
+through the in-process backtest harness and assert that the resulting trade
+list is byte-identical. This is the acceptance criterion from the issue:
+"round-trip rewrite preserves the observed trade list on a known fixture
+strategy".
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import pytest
+
+from investment_team.models import BacktestConfig, StrategySpec, TradeRecord
+from investment_team.strategy_lab.coverage_probe import instrument_strategy_code
+from investment_team.trading_service.modes.backtest import run_backtest
+
+from .golden.fixtures import DEFAULT_DAYS, golden_market_data
+from .golden.strategies import (
+    BUY_AND_HOLD_CODE,
+    OVERFIT_HARDCODED_DATES_CODE,
+    ROUND_TRIP_CODE,
+    SMA_CROSSOVER_CODE,
+)
+
+
+def _make_spec(name: str, code: str) -> StrategySpec:
+    return StrategySpec(
+        strategy_id=f"runtime-instrument-{name}",
+        authored_by="runtime-instrument-tests",
+        asset_class="stocks",
+        hypothesis="instrumented round-trip",
+        signal_definition="see strategies.py",
+        strategy_code=code,
+    )
+
+
+def _make_config() -> BacktestConfig:
+    return BacktestConfig(
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+        initial_capital=100_000.0,
+        transaction_cost_bps=0.0,
+        slippage_bps=0.0,
+        execution_model="optimistic",
+    )
+
+
+def _trade_tuples(trades: List[TradeRecord]) -> list[tuple]:
+    return [
+        (
+            t.trade_num,
+            t.symbol,
+            t.side,
+            t.entry_date,
+            t.exit_date,
+            round(t.shares, 4),
+            round(t.gross_pnl, 2),
+            round(t.net_pnl, 2),
+            t.hold_days,
+            t.outcome,
+        )
+        for t in trades
+    ]
+
+
+def _run_pair(name: str, code: str) -> tuple[list[tuple], list[tuple]]:
+    rewritten, index = instrument_strategy_code(code)
+    assert rewritten != code, "fixture should produce at least one wrapped subcondition"
+    assert len(index.rules) > 0
+
+    config = _make_config()
+    market_data = golden_market_data(n_days=DEFAULT_DAYS)
+
+    original_result = run_backtest(
+        strategy=_make_spec(f"{name}-original", code),
+        config=config,
+        market_data=market_data,
+    )
+    instrumented_result = run_backtest(
+        strategy=_make_spec(f"{name}-instrumented", rewritten),
+        config=config,
+        market_data=market_data,
+    )
+
+    return _trade_tuples(original_result.trades), _trade_tuples(instrumented_result.trades)
+
+
+@pytest.mark.slow_subprocess
+def test_sma_crossover_trades_unchanged() -> None:
+    original, instrumented = _run_pair("sma_crossover", SMA_CROSSOVER_CODE)
+    assert original == instrumented
+
+
+@pytest.mark.slow_subprocess
+def test_round_trip_trades_unchanged() -> None:
+    original, instrumented = _run_pair("round_trip", ROUND_TRIP_CODE)
+    assert original == instrumented
+
+
+@pytest.mark.slow_subprocess
+def test_buy_and_hold_trades_unchanged() -> None:
+    original, instrumented = _run_pair("buy_and_hold", BUY_AND_HOLD_CODE)
+    assert original == instrumented
+
+
+@pytest.mark.slow_subprocess
+def test_overfit_hardcoded_dates_trades_unchanged() -> None:
+    original, instrumented = _run_pair("overfit_hardcoded_dates", OVERFIT_HARDCODED_DATES_CODE)
+    assert original == instrumented


### PR DESCRIPTION
## Summary

Implements **#449** — the runtime AST instrumenter for the **#406** Strategy Lab coverage-probe epic.

Adds `backend/agents/investment_team/strategy_lab/coverage_probe/runtime_instrument.py`, exposing:

```python
def instrument_strategy_code(code: str) -> tuple[str, RuleIndex]
```

The transformer walks every top-level `if` / `elif` predicate inside the strategy's `on_bar` method and wraps each subcondition with `__probe_record__(rule_id, bar_index, value)`. A bootstrap prelude defines no-op defaults via `try/except NameError` (gate-safe — `globals()` is banned by `code_safety.py`) so the rewritten module remains standalone-executable. The runtime probe harness (#450) will rebind both names in the exec globals before each bar.

The dunder-style name (`__probe_record__`) is deliberate: a plain `__probe_record` would be subject to Python's class-private name mangling and become `_StrategyClass__probe_record` when referenced inside the strategy class body, breaking the harness contract. Trailing underscores opt out of mangling.

A small `RuleIndex` Pydantic model is added to `investment_team/models.py` next to the other #446 coverage models and re-exported from `coverage_probe/__init__.py` for symmetry with `run_static_probe`.

### Acceptance criteria from #449

- [x] Pure source-to-source transform; no execution required for tests
- [x] Round-trip preserves observed trade list on known fixture strategies (4 golden tests)
- [x] Malformed source returns original code with empty `RuleIndex` and a `UserWarning`, never raises
- [x] Idempotent — re-running on already-instrumented code is a no-op and re-builds the index by walking existing probe calls

### Out of scope (separate sub-issues)

- Runtime collector + harness wiring → **#450**
- Orchestrator coverage-probe stage → **#451**
- Surfacing coverage in refinement / gate details → **#452**
- Bounded-runtime guarantee tests → **#453**

## Test plan

- [x] `pytest agents/investment_team/tests/test_strategy_lab_runtime_instrument.py` — **14 / 14** pass (boolop split, nested boolop, unary not, elif chain, idempotency, malformed source, no-on-bar, helper-function isolation, constant test, code-safety gate compatibility, exec-with-identity-default, index rebuild, sequential rule ids).
- [x] `pytest agents/investment_team/tests/test_strategy_lab_runtime_instrument_golden.py` — **4 / 4** pass. Round-trips `SMA_CROSSOVER_CODE`, `ROUND_TRIP_CODE`, `BUY_AND_HOLD_CODE`, `OVERFIT_HARDCODED_DATES_CODE` through the in-process `run_backtest` driver and asserts byte-identical `TradeRecord` tuples.
- [x] Regression: `pytest agents/investment_team/tests/test_strategy_lab_static_probe.py agents/investment_team/tests/test_coverage_probe_models.py` — **26 / 26** pass.
- [x] `ruff check` + `ruff format --check` clean on all 5 changed files.
- [ ] CI green on this branch.

No conflict with PR #456 (#448 indicator probe) — the only shared file is `coverage_probe/__init__.py`, where both PRs only append.

https://claude.ai/code/session_014ahP7ZA8gwnQMe3ZT7fmJo

---
_Generated by [Claude Code](https://claude.ai/code/session_014ahP7ZA8gwnQMe3ZT7fmJo)_