### PR TITLE
fix(user_agent_founder): unblock Temporal worker on first /start request

### DIFF
--- a/backend/agents/user_agent_founder/api/main.py
+++ b/backend/agents/user_agent_founder/api/main.py
@@ -31,6 +31,23 @@ async def _lifespan(application: FastAPI):
         register_team_schemas(USER_AGENT_FOUNDER_POSTGRES_SCHEMA)
     except Exception:
         logger.exception("user_agent_founder postgres schema registration failed")
+    # Backstop for local dev (`uvicorn user_agent_founder.api.main:app`):
+    # the team_service entrypoint normally starts the Temporal worker
+    # via TEAM_TEMPORAL_WORKER_MODULE before uvicorn accepts requests, but
+    # when running this app standalone there is no entrypoint. Calling the
+    # idempotent start helper here ensures the worker (and its connected
+    # client) is up either way. No-op when TEMPORAL_ADDRESS is unset.
+    try:
+        from user_agent_founder.temporal.worker import (
+            start_user_agent_founder_temporal_worker_thread,
+        )
+
+        start_user_agent_founder_temporal_worker_thread()
+    except Exception:
+        logger.warning(
+            "user_agent_founder Temporal worker start (lifespan backstop) failed",
+            exc_info=True,
+        )
     yield
     try:
         from shared_postgres import close_pool

--- a/backend/agents/user_agent_founder/temporal/__init__.py
+++ b/backend/agents/user_agent_founder/temporal/__init__.py
@@ -1,52 +1,29 @@
-"""Temporal workflow + activity wrapping the user-agent founder workflow."""
+"""Temporal workflow + activity wrapping the user-agent founder workflow.
+
+The workflow class and activity live in :mod:`workflows` (sandbox-safe —
+no top-level non-deterministic calls). Worker startup lives in
+:mod:`worker` and is invoked by the team_service entrypoint at boot
+(``TEAM_TEMPORAL_WORKER_MODULE`` / ``TEAM_TEMPORAL_WORKER_FUNC``) so the
+Temporal client is connected before the API serves its first request.
+"""
 
 from __future__ import annotations
 
-from datetime import timedelta
-from typing import Any
-
-from temporalio import activity, workflow
-
-
-@activity.defn(name="user_agent_founder_run_pipeline")
-def run_pipeline_activity(run_id: str) -> dict[str, Any]:
-    """Execute the founder workflow for ``run_id``.
-
-    Reconstructs the store + agent inside the activity because neither is
-    serialisable across the Temporal boundary. The activity is idempotent
-    from the orchestrator's perspective — ``run_workflow`` internally
-    updates both the founder store and the centralized job service on
-    every phase transition and on failure.
-    """
-    from user_agent_founder.agent import FounderAgent
-    from user_agent_founder.orchestrator import run_workflow
-    from user_agent_founder.store import get_founder_store
-
-    store = get_founder_store()
-    agent = FounderAgent()
-    # run_workflow resolves the adapter from the run row's target_team_key
-    # when none is supplied — keeps this boundary thin.
-    run_workflow(run_id, store, agent)
-    return {"run_id": run_id}
-
-
-@workflow.defn(name="UserAgentFounderWorkflow")
-class UserAgentFounderWorkflow:
-    @workflow.run
-    async def run(self, run_id: str) -> dict[str, Any]:
-        return await workflow.execute_activity(
-            run_pipeline_activity,
-            run_id,
-            start_to_close_timeout=timedelta(hours=2),
-        )
-
+from user_agent_founder.temporal.workflows import (
+    UserAgentFounderWorkflow,
+    run_pipeline_activity,
+)
 
 WORKFLOWS = [UserAgentFounderWorkflow]
 ACTIVITIES = [run_pipeline_activity]
 TASK_QUEUE = "user_agent_founder-queue"
 WORKFLOW_ID_PREFIX = "user-agent-founder-"
 
-from shared_temporal import is_temporal_enabled, start_team_worker  # noqa: E402
-
-if is_temporal_enabled():
-    start_team_worker("user_agent_founder", WORKFLOWS, ACTIVITIES, task_queue=TASK_QUEUE)
+__all__ = [
+    "ACTIVITIES",
+    "TASK_QUEUE",
+    "UserAgentFounderWorkflow",
+    "WORKFLOWS",
+    "WORKFLOW_ID_PREFIX",
+    "run_pipeline_activity",
+]

--- a/backend/agents/user_agent_founder/temporal/start_workflow.py
+++ b/backend/agents/user_agent_founder/temporal/start_workflow.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import time
 from typing import Any
 
 from shared_temporal import get_temporal_client, get_temporal_loop
@@ -20,24 +21,44 @@ from user_agent_founder.temporal import (
 logger = logging.getLogger(__name__)
 
 START_WORKFLOW_TIMEOUT = 30
+# How long to wait for the Temporal worker thread to connect its client
+# before giving up. The worker connects in a daemon thread, so the very
+# first request after a cold start can race the connect call.
+CLIENT_READY_TIMEOUT_S = 10.0
+CLIENT_READY_POLL_S = 0.05
+
+
+def _wait_for_client(timeout_s: float = CLIENT_READY_TIMEOUT_S) -> tuple[Any, Any]:
+    """Block briefly until the Temporal client + loop are populated.
+
+    The team_service entrypoint normally starts the worker before uvicorn
+    accepts requests, but when the worker is started from the API
+    lifespan (local dev) the daemon thread can lag behind the first
+    request by tens of milliseconds. Polling here turns that race into a
+    short wait instead of a 500.
+    """
+    deadline = time.monotonic() + timeout_s
+    while True:
+        client = get_temporal_client()
+        loop = get_temporal_loop()
+        if client is not None and loop is not None:
+            return client, loop
+        if time.monotonic() >= deadline:
+            raise RuntimeError(
+                "Temporal client not available; is the user_agent_founder worker running?"
+            )
+        time.sleep(CLIENT_READY_POLL_S)
 
 
 def _run_async(coro: Any) -> Any:
-    loop = get_temporal_loop()
-    client = get_temporal_client()
-    if loop is None or client is None:
-        raise RuntimeError(
-            "Temporal client not available; is the user_agent_founder worker running?"
-        )
+    _, loop = _wait_for_client()
     future = asyncio.run_coroutine_threadsafe(coro, loop)
     return future.result(timeout=START_WORKFLOW_TIMEOUT)
 
 
 def start_founder_workflow(run_id: str) -> None:
     """Start ``UserAgentFounderWorkflow`` for the given run id."""
-    client = get_temporal_client()
-    if client is None:
-        raise RuntimeError("Temporal client not available")
+    client, _ = _wait_for_client()
     workflow_id = f"{WORKFLOW_ID_PREFIX}{run_id}"
     _run_async(
         client.start_workflow(

--- a/backend/agents/user_agent_founder/temporal/worker.py
+++ b/backend/agents/user_agent_founder/temporal/worker.py
@@ -1,0 +1,39 @@
+"""Temporal worker bootstrap for the user_agent_founder team.
+
+Exposes a no-arg ``start_user_agent_founder_temporal_worker_thread``
+that the generic team_service entrypoint can invoke at boot via the
+``TEAM_TEMPORAL_WORKER_MODULE`` / ``TEAM_TEMPORAL_WORKER_FUNC`` env
+vars, so the Temporal worker (and its connected client) is ready
+before uvicorn starts accepting requests.
+
+This shape mirrors ``software_engineering_team.temporal.worker.
+start_se_temporal_worker_thread`` and ``blogging.temporal.worker.
+start_blogging_temporal_worker_thread`` — same contract, same boot
+hook in docker-compose.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from shared_temporal import is_temporal_enabled, start_team_worker
+from user_agent_founder.temporal import ACTIVITIES, TASK_QUEUE, WORKFLOWS
+
+logger = logging.getLogger(__name__)
+
+
+def start_user_agent_founder_temporal_worker_thread() -> bool:
+    """Start the user_agent_founder Temporal worker (no-op when disabled).
+
+    Returns True if a worker thread is running (or already running), False
+    when Temporal is disabled. Safe to call multiple times — the underlying
+    ``start_team_worker`` is idempotent per team.
+    """
+    if not is_temporal_enabled():
+        return False
+    return start_team_worker(
+        "user_agent_founder",
+        WORKFLOWS,
+        ACTIVITIES,
+        task_queue=TASK_QUEUE,
+    )

--- a/backend/agents/user_agent_founder/temporal/workflows.py
+++ b/backend/agents/user_agent_founder/temporal/workflows.py
@@ -1,0 +1,49 @@
+"""Temporal workflow + activity for the user_agent_founder team.
+
+Kept in its own module (separate from the package ``__init__``) so the
+temporalio workflow sandbox can re-import the workflow class without
+executing any non-deterministic top-level code (e.g. ``os.getenv``,
+worker bootstrap). The previous layout co-located ``start_team_worker``
+with the workflow class, which the sandbox aborted with
+``__call__ on os.getenv restricted``.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+from temporalio import activity, workflow
+
+
+@activity.defn(name="user_agent_founder_run_pipeline")
+def run_pipeline_activity(run_id: str) -> dict[str, Any]:
+    """Execute the founder workflow for ``run_id``.
+
+    Reconstructs the store + agent inside the activity because neither is
+    serialisable across the Temporal boundary. The activity is idempotent
+    from the orchestrator's perspective — ``run_workflow`` internally
+    updates both the founder store and the centralized job service on
+    every phase transition and on failure.
+    """
+    from user_agent_founder.agent import FounderAgent
+    from user_agent_founder.orchestrator import run_workflow
+    from user_agent_founder.store import get_founder_store
+
+    store = get_founder_store()
+    agent = FounderAgent()
+    # run_workflow resolves the adapter from the run row's target_team_key
+    # when none is supplied — keeps this boundary thin.
+    run_workflow(run_id, store, agent)
+    return {"run_id": run_id}
+
+
+@workflow.defn(name="UserAgentFounderWorkflow")
+class UserAgentFounderWorkflow:
+    @workflow.run
+    async def run(self, run_id: str) -> dict[str, Any]:
+        return await workflow.execute_activity(
+            run_pipeline_activity,
+            run_id,
+            start_to_close_timeout=timedelta(hours=2),
+        )

--- a/backend/agents/user_agent_founder/tests/test_temporal_bootstrap.py
+++ b/backend/agents/user_agent_founder/tests/test_temporal_bootstrap.py
@@ -1,0 +1,122 @@
+"""Regression tests for the user_agent_founder Temporal bootstrap.
+
+Two bugs were fixed together here. Both have to be guarded:
+
+1. **Race on first request.** Importing ``user_agent_founder.temporal``
+   used to call ``shared_temporal.start_team_worker(...)`` at module
+   load. The worker thread connected the Temporal client asynchronously,
+   so the very first ``start_founder_workflow`` call lost the race and
+   raised ``RuntimeError: Temporal client not available``. The package
+   must no longer self-bootstrap a worker at import time — boot is the
+   team_service entrypoint's job (or the API lifespan as a backstop).
+
+2. **Workflow sandbox blocks ``os.getenv``.** The temporalio sandbox
+   re-imports the workflow module to load ``UserAgentFounderWorkflow``.
+   The previous ``__init__.py`` called ``is_temporal_enabled()`` —
+   which calls ``os.getenv("TEMPORAL_ADDRESS")`` — at module level, and
+   the sandbox aborted with ``__call__ on os.getenv restricted``. Both
+   the package ``__init__`` and the dedicated ``workflows`` module must
+   load without invoking ``os.getenv``.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import unittest.mock as mock
+
+
+def _purge(prefix: str) -> None:
+    for name in list(sys.modules):
+        if name == prefix or name.startswith(prefix + "."):
+            del sys.modules[name]
+
+
+def test_importing_temporal_package_does_not_call_start_team_worker():
+    """Loading the package must NOT spin up a worker thread."""
+    import shared_temporal
+
+    _purge("user_agent_founder.temporal")
+    with mock.patch.object(shared_temporal, "start_team_worker") as patched:
+        importlib.import_module("user_agent_founder.temporal")
+        importlib.import_module("user_agent_founder.temporal.workflows")
+        importlib.import_module("user_agent_founder.temporal.start_workflow")
+        assert patched.call_count == 0, (
+            f"Module-level start_team_worker bootstrap re-introduced "
+            f"(call count = {patched.call_count}). This causes a race on the "
+            f"first request and a temporalio sandbox os.getenv violation when "
+            f"the workflow registers."
+        )
+
+
+def test_workflows_module_does_not_call_os_getenv_at_import_time():
+    """The workflow module is reimported by the temporalio sandbox.
+
+    Anything the sandbox restricts (``os.getenv``, time/random, etc.)
+    must not be invoked at module top level — it has to live inside
+    activity bodies or the worker bootstrap.
+    """
+    _purge("user_agent_founder.temporal")
+    import os
+
+    with mock.patch.object(os, "getenv", wraps=os.getenv) as spy:
+        importlib.import_module("user_agent_founder.temporal.workflows")
+        # Allow any getenv calls that come from temporalio itself loading;
+        # what we care about is that *our* module didn't add new ones.
+        # The cheap check: walking the call stack inside the spy is brittle,
+        # so instead assert workflows.py loaded clean (no exception).
+        # Also reimport the package __init__ — that path is what the sandbox
+        # actually replays.
+        spy.reset_mock()
+        importlib.import_module("user_agent_founder.temporal")
+        # The package __init__ must not call os.getenv at all.
+        assert spy.call_count == 0, (
+            f"user_agent_founder.temporal.__init__ called os.getenv "
+            f"{spy.call_count} time(s) at import — this trips the temporalio "
+            f"workflow sandbox during workflow registration."
+        )
+
+
+def test_worker_module_exposes_team_service_entrypoint():
+    """team_service/entrypoint.py looks up ``TEAM_TEMPORAL_WORKER_FUNC`` on
+    ``TEAM_TEMPORAL_WORKER_MODULE``. Keep that contract pinned so a rename
+    can't silently break docker-compose.
+    """
+    from user_agent_founder.temporal import worker
+
+    fn = getattr(worker, "start_user_agent_founder_temporal_worker_thread", None)
+    assert callable(fn), (
+        "team_service entrypoint expects a no-arg "
+        "start_user_agent_founder_temporal_worker_thread() in "
+        "user_agent_founder.temporal.worker"
+    )
+
+
+def test_worker_start_is_no_op_when_temporal_disabled(monkeypatch):
+    """Standalone uvicorn dev path: with TEMPORAL_ADDRESS unset, the
+    backstop in the lifespan must return False instead of raising."""
+    monkeypatch.delenv("TEMPORAL_ADDRESS", raising=False)
+    from user_agent_founder.temporal.worker import (
+        start_user_agent_founder_temporal_worker_thread,
+    )
+
+    assert start_user_agent_founder_temporal_worker_thread() is False
+
+
+def test_start_workflow_waits_for_client_then_raises(monkeypatch):
+    """When the worker is genuinely not running, the helper must time out
+    with the original error message — not raise immediately and not wait
+    forever. The wait window is what makes the lifespan-backstop case
+    work; the eventual failure is what surfaces config bugs in CI.
+    """
+    from user_agent_founder.temporal import start_workflow as sw
+
+    monkeypatch.setattr(sw, "get_temporal_client", lambda: None)
+    monkeypatch.setattr(sw, "get_temporal_loop", lambda: None)
+    monkeypatch.setattr(sw, "CLIENT_READY_TIMEOUT_S", 0.05)
+    monkeypatch.setattr(sw, "CLIENT_READY_POLL_S", 0.01)
+
+    import pytest
+
+    with pytest.raises(RuntimeError, match="Temporal client not available"):
+        sw._wait_for_client()

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -696,8 +696,8 @@ services:
       TEAM_MODULE: user_agent_founder.api.main
       TEAM_NAME: user_agent_founder
       TEAM_PORT: "8109"
-      TEAM_TEMPORAL_WORKER_MODULE: ""
-      TEAM_TEMPORAL_WORKER_FUNC: ""
+      TEAM_TEMPORAL_WORKER_MODULE: user_agent_founder.temporal.worker
+      TEAM_TEMPORAL_WORKER_FUNC: start_user_agent_founder_temporal_worker_thread
     volumes: *team-volumes
     extra_hosts: *team-extra-hosts
     ports: ["8109:8109"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -690,6 +690,7 @@ services:
     container_name: khala-user-agent-founder-service
     depends_on:
       postgres: { condition: service_healthy }
+      temporal: { condition: service_started }
       job-service: { condition: service_healthy }
     environment:
       <<: *team-env-base


### PR DESCRIPTION
## Summary

Two bugs were blocking every founder run when `TEMPORAL_ADDRESS` is set. Both stemmed from one anti-pattern: `user_agent_founder/temporal/__init__.py` co-located the workflow class with `start_team_worker(...)` at module top level.

- **Race on first request.** `_dispatch_founder_run` lazily imported the temporal module on the first `/start`, which triggered `start_team_worker(...)` at import. The worker ran `connect_temporal_client()` async inside a daemon thread while `start_founder_workflow` raced ahead, found `_client = None`, and raised `RuntimeError: Temporal client not available`. Logs showed the worker thread starting at `:31.093`, dispatch failing at `:31.093`, client connecting at `:31.123`.
- **Sandbox violation.** Even with the race fixed, the temporalio workflow sandbox re-imports the workflow module to register `UserAgentFounderWorkflow`. The previous module-level `is_temporal_enabled()` call invoked `os.getenv("TEMPORAL_ADDRESS")`, which the sandbox aborted with `__call__ on os.getenv restricted`. The worker could never register the workflow.

Restructured to match the SE/blogging pattern:
- `temporal/workflows.py` (new) — workflow class + activity, sandbox-safe (no top-level `os.getenv`, no worker bootstrap).
- `temporal/__init__.py` — re-exports only; no module-level `start_team_worker`.
- `temporal/worker.py` (new) — `start_user_agent_founder_temporal_worker_thread()`, the no-arg helper the team_service entrypoint expects.
- `docker/docker-compose.yml` — sets `TEAM_TEMPORAL_WORKER_MODULE` / `TEAM_TEMPORAL_WORKER_FUNC` so the worker boots before uvicorn accepts requests.
- `temporal/start_workflow.py` — bounded `_wait_for_client` poll (10s) so any residual race becomes a short wait, not a 500.
- `api/main.py` — lifespan calls the same idempotent worker bootstrap as a backstop for non-Docker dev (`uvicorn user_agent_founder.api.main:app`); no-op when `TEMPORAL_ADDRESS` is unset.

## Follow-up worth knowing

Other teams using the same `start_team_worker` self-boot from their own `temporal/__init__.py` (`startup_advisor`, `coding_team`, `branding`, `sales`, `agentic_team_provisioning`, `deepthought`, `accessibility_audit`, `road_trip_planning`, `market_research`, `investment`) have the same latent bug — they just haven't tripped it because nothing actually invokes those workflows yet. Worth lifting the same fix across them in a follow-up PR.

## Test plan
- [x] `pytest agents/user_agent_founder/tests/` — 82 passing (77 prior + 5 new regression tests in `test_temporal_bootstrap.py`)
- [x] `ruff check` + `ruff format --check` clean on changed files
- [x] Verified `import user_agent_founder.temporal` no longer calls `start_team_worker` at import
- [x] Verified `import user_agent_founder.temporal` no longer calls `os.getenv` at module level
- [ ] In Docker stack with `TEMPORAL_ADDRESS` set: `POST /start` to user-agent-founder-service succeeds on first request after a cold start (no `RuntimeError: Temporal client not available`, no `__call__ on os.getenv restricted`)
- [ ] Confirm `khala-user-agent-founder-service` logs show `Temporal worker started for user_agent_founder` **before** the first `/start` POST lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)