### PR TITLE
Implement bracket order materialization and OCO sibling cancellation (#389)

### DIFF
--- a/backend/agents/investment_team/tests/test_bracket_orders.py
+++ b/backend/agents/investment_team/tests/test_bracket_orders.py
@@ -21,7 +21,9 @@ on the no-attachment path and two follow-ups from the PR review:
     instead of letting a later trigger open a new opposite-side position.
 11. TWAP_N bracket parent that ages out via the no-trigger counter still
     materializes protective legs for the partially-filled position.
-12. Trailing-stop attachments (``StopAttachment.trail_offset``) remain
+12. DAY-TIF bracket parent that expires after a partial fill still
+    materializes protective legs for the open position.
+13. Trailing-stop attachments (``StopAttachment.trail_offset``) remain
     gated until #390 — runtime materialization lands with Step 8.
 """
 
@@ -694,6 +696,71 @@ def test_twap_age_out_bracket_parent_materializes_brackets_for_open_position() -
     assert sl.armed is True and tp.armed is True
     assert sl.submitted_at == "2024-01-03"
     assert tp.submitted_at == "2024-01-03"
+    assert portfolio.positions["AAA"].qty == pytest.approx(100.0, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# DAY-TIF bracket parent that expires after a partial fill must still
+# materialize protective legs for the open position (Codex P1 follow-up on
+# commit 90b5753)
+# ---------------------------------------------------------------------------
+
+
+def test_day_expiry_partial_bracket_parent_materializes_brackets() -> None:
+    """A DAY-TIF bracket entry that fills its first slice on day D and is
+    requeued must still get protective legs when the parent expires on
+    day D+1's session boundary. The expiry routes through
+    ``FillSimulator.expire_day_orders``, which calls
+    ``_maybe_materialize_brackets_on_abandon`` for partial bracket
+    parents — the order_book uses ``was_filled=True`` for those so the
+    eligible-parent registration survives long enough for
+    ``submit_attached`` to succeed."""
+    sim, order_book, portfolio = _make_simulator()
+    parent = order_book.submit(
+        OrderRequest(
+            client_order_id="entry-1",
+            symbol="AAA",
+            side=OrderSide.LONG,
+            qty=200.0,
+            order_type=OrderType.MARKET,
+            tif=TimeInForce.DAY,
+            unfilled_policy=UnfilledPolicy.REQUEUE_NEXT_BAR,
+            attached_stop_loss=StopAttachment(stop_price=95.0),
+            attached_take_profit=LimitAttachment(limit_price=110.0),
+        ),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+        expect_brackets=True,
+    )
+
+    # Bar on day D (the day after submission): low ADV → 50% partial fill
+    # (100 shares), remainder requeued with ``submitted_at`` advanced to
+    # the fill bar; ``original_submitted_at`` stays at "2024-01-01".
+    sim.process_bar(_bar("2024-01-02", open_price=100.0, volume=1_000.0))
+    assert portfolio.positions["AAA"].qty == pytest.approx(100.0, rel=1e-9)
+    assert parent.order_id in order_book
+    assert order_book.children_of(parent.order_id) == []
+
+    # Day boundary: simulate the date-change expiry hook the service
+    # invokes before processing day D+1's first bar.
+    next_session_bar = _bar("2024-01-03", open_price=100.0)
+    expired = sim.expire_day_orders(next_session_bar)
+
+    assert len(expired) == 1
+    assert expired[0].order_id == parent.order_id
+    assert parent.order_id not in order_book
+
+    # Brackets materialized for the still-open 100-share position.
+    children = order_book.children_of(parent.order_id)
+    assert len(children) == 2, "expired partial bracket parent must spawn protective legs"
+    sl = next(c for c in children if c.request.order_type == OrderType.STOP)
+    tp = next(c for c in children if c.request.order_type == OrderType.LIMIT)
+    assert sl.request.qty == pytest.approx(100.0, rel=1e-9)
+    assert tp.request.qty == pytest.approx(100.0, rel=1e-9)
+    assert sl.armed is True and tp.armed is True
+    assert sl.submitted_at == "2024-01-03"
+    assert tp.submitted_at == "2024-01-03"
+    # Position untouched by the expiry; the bracket now covers it.
     assert portfolio.positions["AAA"].qty == pytest.approx(100.0, rel=1e-9)
 
 

--- a/backend/agents/investment_team/tests/test_bracket_orders.py
+++ b/backend/agents/investment_team/tests/test_bracket_orders.py
@@ -1,6 +1,7 @@
 """Bracket / OCO materialization tests (Trading 5/5 Step 7 — issue #389).
 
-Covers the five acceptance bullets from the issue:
+Covers the five acceptance bullets from the issue plus a regression guard
+on the no-attachment path and two follow-ups from the PR review:
 
 1. Entry fill materializes two children with shared ``oco_group_id`` and
    ``parent_order_id`` set.
@@ -8,8 +9,11 @@ Covers the five acceptance bullets from the issue:
 3. Stop-loss fills first → take-profit removed.
 4. Parent never fills (e.g. LIMIT not crossed) → no children materialized.
 5. Children not eligible for fill on the same bar as parent entry (bar-safety).
-
-A sixth case for trailing stops will land with #390 (Step 8).
+6. No-attachment regression: plain entry round-trip is unchanged.
+7. ``REQUEUE_NEXT_BAR`` partial-fill terminal slice materializes brackets
+   sized to the cumulative position (default backtest policy).
+8. Trailing-stop attachments (``StopAttachment.trail_offset``) remain
+   gated until #390 — runtime materialization lands with Step 8.
 """
 
 from __future__ import annotations
@@ -35,6 +39,8 @@ from investment_team.trading_service.strategy.contract import (
     OrderType,
     StopAttachment,
     TimeInForce,
+    UnfilledPolicy,
+    UnsupportedOrderFeatureError,
 )
 
 
@@ -337,3 +343,103 @@ def test_no_attachment_path_is_unchanged() -> None:
     assert len(outcome.closed_trades) == 1
     assert "AAA" not in portfolio.positions
     assert order_book.all_pending() == []
+
+
+# ---------------------------------------------------------------------------
+# REQUEUE_NEXT_BAR partial-fill entries materialize brackets at the terminal
+# slice (default backtest policy — Codex P1)
+# ---------------------------------------------------------------------------
+
+
+def test_requeue_partial_entry_materializes_brackets_on_terminal_fill() -> None:
+    """A bracket entry that's clipped by the participation cap and requeued
+    must still get its protective legs once the parent terminally fills.
+    Children are sized to the *cumulative* opened position, not the first
+    slice alone.
+    """
+    sim, order_book, portfolio = _make_simulator()
+    parent = order_book.submit(
+        OrderRequest(
+            client_order_id="entry-1",
+            symbol="AAA",
+            side=OrderSide.LONG,
+            qty=2_000.0,
+            order_type=OrderType.MARKET,
+            tif=TimeInForce.DAY,
+            unfilled_policy=UnfilledPolicy.REQUEUE_NEXT_BAR,
+            attached_stop_loss=StopAttachment(stop_price=95.0),
+            attached_take_profit=LimitAttachment(limit_price=110.0),
+        ),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+        expect_brackets=True,
+    )
+
+    # Bar 2: low ADV → 50% partial fill (notional 200k vs $1M bar = 0.20
+    # raw participation, capped at 0.10 → qty_fraction=0.5 → 1_000 filled).
+    sim.process_bar(_bar("2024-01-02", open_price=100.0, volume=10_000.0))
+    assert parent.order_id in order_book, "parent should still be pending after partial fill"
+    assert order_book.children_of(parent.order_id) == [], "no brackets yet — wait for terminal fill"
+
+    # Bar 3: high ADV → remainder fills cleanly, parent terminally completes.
+    sim.process_bar(_bar("2024-01-03", open_price=100.0, volume=10_000_000.0))
+    assert parent.order_id not in order_book
+
+    children = order_book.children_of(parent.order_id)
+    assert len(children) == 2
+    sl = next(c for c in children if c.request.order_type == OrderType.STOP)
+    tp = next(c for c in children if c.request.order_type == OrderType.LIMIT)
+    # Sized to the cumulative position (1_000 + 1_000 = 2_000), not just the
+    # first slice's 1_000.
+    assert sl.request.qty == pytest.approx(2_000.0, rel=1e-9)
+    assert tp.request.qty == pytest.approx(2_000.0, rel=1e-9)
+    # Anchored to the terminal-fill bar so bar-safety blocks same-bar fills.
+    assert sl.submitted_at == "2024-01-03"
+    assert tp.submitted_at == "2024-01-03"
+    assert sl.armed is True and tp.armed is True
+    assert portfolio.positions["AAA"].qty == pytest.approx(2_000.0, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Trailing-stop attachments remain gated until #390 (Codex P2)
+# ---------------------------------------------------------------------------
+
+
+def test_trailing_stop_attachment_is_gated_until_step_8() -> None:
+    """``StopAttachment(trail_offset=...)`` is a trailing stop; the
+    materializer would otherwise silently downgrade it to a fixed STOP at
+    ``stop_price``. Reject loudly until #390 ships trailing-stop runtime."""
+    req = OrderRequest(
+        client_order_id="entry-1",
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=10.0,
+        order_type=OrderType.MARKET,
+        attached_stop_loss=StopAttachment(stop_price=95.0, trail_offset=2.0),
+    )
+    with pytest.raises(UnsupportedOrderFeatureError, match="#390"):
+        req.validate_prices()
+
+    # ``trail_offset_kind="bps"`` variant is also blocked.
+    req_bps = OrderRequest(
+        client_order_id="entry-1",
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=10.0,
+        order_type=OrderType.MARKET,
+        attached_stop_loss=StopAttachment(
+            stop_price=95.0, trail_offset=20.0, trail_offset_kind="bps"
+        ),
+    )
+    with pytest.raises(UnsupportedOrderFeatureError, match="#390"):
+        req_bps.validate_prices()
+
+    # Plain fixed-stop attachment (no trail_offset) still validates.
+    OrderRequest(
+        client_order_id="entry-1",
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=10.0,
+        order_type=OrderType.MARKET,
+        attached_stop_loss=StopAttachment(stop_price=95.0),
+    ).validate_prices()

--- a/backend/agents/investment_team/tests/test_bracket_orders.py
+++ b/backend/agents/investment_team/tests/test_bracket_orders.py
@@ -12,7 +12,9 @@ on the no-attachment path and two follow-ups from the PR review:
 6. No-attachment regression: plain entry round-trip is unchanged.
 7. ``REQUEUE_NEXT_BAR`` partial-fill terminal slice materializes brackets
    sized to the cumulative position (default backtest policy).
-8. Trailing-stop attachments (``StopAttachment.trail_offset``) remain
+8. Partial bracket-exit fill requeues the surviving leg (after OCO cancel
+   removes the sibling) so residual position exposure stays protected.
+9. Trailing-stop attachments (``StopAttachment.trail_offset``) remain
    gated until #390 — runtime materialization lands with Step 8.
 """
 
@@ -33,6 +35,7 @@ from investment_team.trading_service.engine.order_book import OrderBook
 from investment_team.trading_service.engine.portfolio import Portfolio
 from investment_team.trading_service.strategy.contract import (
     Bar,
+    FillKind,
     LimitAttachment,
     OrderRequest,
     OrderSide,
@@ -398,6 +401,78 @@ def test_requeue_partial_entry_materializes_brackets_on_terminal_fill() -> None:
     assert tp.submitted_at == "2024-01-03"
     assert sl.armed is True and tp.armed is True
     assert portfolio.positions["AAA"].qty == pytest.approx(2_000.0, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Partial bracket-exit fill must requeue the remainder so residual position
+# exposure stays protected (Codex P1 follow-up on commit 5189795)
+# ---------------------------------------------------------------------------
+
+
+def test_partial_bracket_exit_requeues_remainder_after_oco_cancel() -> None:
+    """When the realistic execution model only partially fills a protective
+    leg (low-ADV bar clipped by the participation cap), the OCO cancel
+    has already removed the sibling — so the surviving leg MUST stay
+    alive for the residual position. Verifies the leg is requeued via
+    ``REQUEUE_NEXT_BAR`` and the residual qty closes on a follow-up bar.
+    """
+    sim, order_book, portfolio = _make_simulator()
+    parent = order_book.submit(
+        OrderRequest(
+            client_order_id="entry-1",
+            symbol="AAA",
+            side=OrderSide.LONG,
+            qty=2_000.0,
+            order_type=OrderType.MARKET,
+            tif=TimeInForce.DAY,
+            attached_stop_loss=StopAttachment(stop_price=95.0),
+            attached_take_profit=LimitAttachment(limit_price=110.0),
+        ),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+        expect_brackets=True,
+    )
+
+    # Bar 2: full entry fill on a deep bar → SL / TP children materialized.
+    sim.process_bar(_bar("2024-01-02", open_price=100.0, volume=10_000_000.0))
+    children = order_book.children_of(parent.order_id)
+    assert len(children) == 2
+
+    # Bar 3: TP triggers (high >= 110) on a low-ADV bar. Notional 2_000 * 110
+    # = 220_000 vs bar dollar volume 10_000 * 110 = 1_100_000 → raw_participation
+    # = 0.20, capped at 0.10 → qty_fraction 0.5 → 1_000 fills, 1_000 remains.
+    bar3 = sim.process_bar(
+        _bar("2024-01-03", open_price=109.0, high=112.0, low=107.0, close=110.0, volume=10_000.0)
+    )
+    assert len(bar3.exit_fills) == 1
+    assert bar3.exit_fills[0].fill_kind == FillKind.PARTIAL
+    assert bar3.exit_fills[0].qty == pytest.approx(1_000.0, rel=1e-9)
+
+    # OCO sibling already cancelled on the first fill.
+    surviving = order_book.children_of(parent.order_id)
+    assert len(surviving) == 1, "stop sibling should be cancelled by OCO"
+    assert surviving[0].request.order_type == OrderType.LIMIT
+    # Remainder requeued (via REQUEUE_NEXT_BAR) so the residual position
+    # stays protected; submitted_at advanced to the partial-fill bar.
+    assert surviving[0].remaining_qty == pytest.approx(1_000.0, rel=1e-9)
+    assert surviving[0].cumulative_filled_qty == pytest.approx(1_000.0, rel=1e-9)
+    assert surviving[0].submitted_at == "2024-01-03"
+
+    # Position still half-open, no closed trade yet.
+    assert portfolio.positions["AAA"].qty == pytest.approx(1_000.0, rel=1e-9)
+    assert bar3.closed_trades == []
+
+    # Bar 4: deep bar with high >= 110 → residual TP fills, position closes.
+    bar4 = sim.process_bar(
+        _bar(
+            "2024-01-04", open_price=110.0, high=112.0, low=109.0, close=111.0, volume=10_000_000.0
+        )
+    )
+    assert len(bar4.exit_fills) == 1
+    assert bar4.exit_fills[0].qty == pytest.approx(1_000.0, rel=1e-9)
+    assert len(bar4.closed_trades) == 1
+    assert "AAA" not in portfolio.positions
+    assert order_book.all_pending() == []
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/tests/test_bracket_orders.py
+++ b/backend/agents/investment_team/tests/test_bracket_orders.py
@@ -1,0 +1,339 @@
+"""Bracket / OCO materialization tests (Trading 5/5 Step 7 — issue #389).
+
+Covers the five acceptance bullets from the issue:
+
+1. Entry fill materializes two children with shared ``oco_group_id`` and
+   ``parent_order_id`` set.
+2. Take-profit fills next bar → stop-loss removed from book (OCO).
+3. Stop-loss fills first → take-profit removed.
+4. Parent never fills (e.g. LIMIT not crossed) → no children materialized.
+5. Children not eligible for fill on the same bar as parent entry (bar-safety).
+
+A sixth case for trailing stops will land with #390 (Step 8).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from investment_team.execution.bar_safety import BarSafetyAssertion
+from investment_team.execution.risk_filter import RiskFilter, RiskLimits
+from investment_team.trading_service.engine.execution_model import (
+    RealisticExecutionModel,
+)
+from investment_team.trading_service.engine.fill_simulator import (
+    FillSimulator,
+    FillSimulatorConfig,
+)
+from investment_team.trading_service.engine.order_book import OrderBook
+from investment_team.trading_service.engine.portfolio import Portfolio
+from investment_team.trading_service.strategy.contract import (
+    Bar,
+    LimitAttachment,
+    OrderRequest,
+    OrderSide,
+    OrderType,
+    StopAttachment,
+    TimeInForce,
+)
+
+
+def _bar(
+    ts: str,
+    *,
+    open_price: float = 100.0,
+    high: float | None = None,
+    low: float | None = None,
+    close: float | None = None,
+    volume: float = 1_000_000.0,
+) -> Bar:
+    return Bar(
+        symbol="AAA",
+        timestamp=ts,
+        timeframe="1d",
+        open=open_price,
+        high=high if high is not None else open_price + 1.0,
+        low=low if low is not None else open_price - 1.0,
+        close=close if close is not None else open_price,
+        volume=volume,
+    )
+
+
+def _make_simulator(
+    initial_capital: float = 10_000_000.0,
+) -> tuple[FillSimulator, OrderBook, Portfolio]:
+    portfolio = Portfolio(initial_capital=initial_capital)
+    order_book = OrderBook()
+    sim = FillSimulator(
+        portfolio=portfolio,
+        order_book=order_book,
+        risk_filter=RiskFilter(RiskLimits(max_position_pct=100, max_gross_leverage=10.0)),
+        config=FillSimulatorConfig(slippage_bps=0.0, transaction_cost_bps=0.0),
+        bar_safety=BarSafetyAssertion(),
+        execution_model=RealisticExecutionModel(participation_cap=0.10),
+    )
+    return sim, order_book, portfolio
+
+
+def _bracket_entry(
+    *,
+    qty: float = 10.0,
+    stop_price: float | None = 95.0,
+    take_profit_price: float | None = 110.0,
+    side: OrderSide = OrderSide.LONG,
+    order_type: OrderType = OrderType.MARKET,
+    limit_price: float | None = None,
+) -> OrderRequest:
+    return OrderRequest(
+        client_order_id="entry-1",
+        symbol="AAA",
+        side=side,
+        qty=qty,
+        order_type=order_type,
+        limit_price=limit_price,
+        tif=TimeInForce.DAY,
+        attached_stop_loss=StopAttachment(stop_price=stop_price)
+        if stop_price is not None
+        else None,
+        attached_take_profit=(
+            LimitAttachment(limit_price=take_profit_price)
+            if take_profit_price is not None
+            else None
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Entry fill materializes both children with correct shape
+# ---------------------------------------------------------------------------
+
+
+def test_entry_fill_materializes_stop_and_take_profit_children() -> None:
+    sim, order_book, portfolio = _make_simulator()
+    parent = order_book.submit(
+        _bracket_entry(qty=10.0, stop_price=95.0, take_profit_price=110.0),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+        expect_brackets=True,
+    )
+
+    outcome = sim.process_bar(_bar("2024-01-02", open_price=100.0, volume=1_000_000.0))
+
+    # Entry fully filled on bar 2.
+    assert len(outcome.entry_fills) == 1
+    assert outcome.entry_fills[0].qty == pytest.approx(10.0, rel=1e-9)
+    # Parent removed from the book (terminal-fill path).
+    assert parent.order_id not in order_book
+
+    # Two children attached against the parent.
+    children = order_book.children_of(parent.order_id)
+    assert len(children) == 2
+    expected_oco = f"oco_{parent.order_id}"
+    sl = next(c for c in children if c.request.order_type == OrderType.STOP)
+    tp = next(c for c in children if c.request.order_type == OrderType.LIMIT)
+
+    for child in (sl, tp):
+        assert child.armed is True
+        # Opposite side to LONG parent.
+        assert child.request.side == OrderSide.SHORT
+        assert child.request.symbol == "AAA"
+        assert child.request.qty == pytest.approx(10.0, rel=1e-9)
+        assert child.request.parent_order_id == parent.order_id
+        assert child.request.oco_group_id == expected_oco
+        # GTC so the bracket survives across sessions; bar-safety blocks
+        # same-bar fills via ``submitted_at`` (see test 5).
+        assert child.request.tif == TimeInForce.GTC
+        assert child.submitted_at == "2024-01-02"
+
+    assert sl.request.stop_price == pytest.approx(95.0, rel=1e-9)
+    assert sl.request.reason == "bracket_sl"
+    assert tp.request.limit_price == pytest.approx(110.0, rel=1e-9)
+    assert tp.request.reason == "bracket_tp"
+
+    # Position is open; no trade closed yet.
+    assert portfolio.positions["AAA"].qty == pytest.approx(10.0, rel=1e-9)
+    assert outcome.closed_trades == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Take-profit fill cancels stop-loss sibling
+# ---------------------------------------------------------------------------
+
+
+def test_take_profit_fill_cancels_stop_sibling() -> None:
+    sim, order_book, portfolio = _make_simulator()
+    parent = order_book.submit(
+        _bracket_entry(qty=10.0, stop_price=95.0, take_profit_price=110.0),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+        expect_brackets=True,
+    )
+
+    # Bar 2: entry fills, children materialized.
+    sim.process_bar(_bar("2024-01-02", open_price=100.0))
+
+    # Bar 3: high crosses 110 → SHORT LIMIT take-profit fires.
+    outcome = sim.process_bar(
+        _bar("2024-01-03", open_price=108.0, high=112.0, low=107.0, close=111.0)
+    )
+
+    assert len(outcome.exit_fills) == 1
+    assert outcome.exit_fills[0].price == pytest.approx(110.0, rel=1e-9)
+    assert len(outcome.closed_trades) == 1
+    # Position is closed, OCO siblings cleared from the book.
+    assert "AAA" not in portfolio.positions
+    assert order_book.children_of(parent.order_id) == []
+    assert order_book.all_pending() == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Stop-loss fill cancels take-profit sibling (mirror of test 2)
+# ---------------------------------------------------------------------------
+
+
+def test_stop_loss_fill_cancels_take_profit_sibling() -> None:
+    sim, order_book, portfolio = _make_simulator()
+    parent = order_book.submit(
+        _bracket_entry(qty=10.0, stop_price=95.0, take_profit_price=110.0),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+        expect_brackets=True,
+    )
+
+    sim.process_bar(_bar("2024-01-02", open_price=100.0))
+
+    # Bar 3: low crosses 95 → SHORT STOP stop-loss fires.
+    outcome = sim.process_bar(_bar("2024-01-03", open_price=97.0, high=98.0, low=93.0, close=94.0))
+
+    assert len(outcome.exit_fills) == 1
+    # Stop child fills at ``min(bar.open, stop_price)`` for SHORT stop —
+    # i.e. at 95 (bar opens above the stop level).
+    assert outcome.exit_fills[0].price == pytest.approx(95.0, rel=1e-9)
+    assert len(outcome.closed_trades) == 1
+    assert "AAA" not in portfolio.positions
+    assert order_book.children_of(parent.order_id) == []
+    assert order_book.all_pending() == []
+
+
+# ---------------------------------------------------------------------------
+# 4. Parent never fills → no children materialized
+# ---------------------------------------------------------------------------
+
+
+def test_unfilled_limit_parent_does_not_materialize_children() -> None:
+    """A LIMIT parent whose limit price never crosses on the fill bar leaves
+    the parent pending and produces no bracket children."""
+    sim, order_book, _ = _make_simulator()
+    parent = order_book.submit(
+        _bracket_entry(
+            qty=10.0,
+            stop_price=95.0,
+            take_profit_price=110.0,
+            order_type=OrderType.LIMIT,
+            # Buy limit at 90 — never crosses on the bars we feed below.
+            limit_price=90.0,
+        ),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+        expect_brackets=True,
+    )
+
+    outcome = sim.process_bar(
+        _bar("2024-01-02", open_price=100.0, high=105.0, low=98.0, close=102.0)
+    )
+
+    # Parent did not fill, no children materialized.
+    assert outcome.entry_fills == []
+    assert order_book.children_of(parent.order_id) == []
+    # Parent still in the book waiting for its limit to cross.
+    assert parent.order_id in order_book
+
+
+# ---------------------------------------------------------------------------
+# 5. Children not eligible for fill on the same bar as parent entry
+# ---------------------------------------------------------------------------
+
+
+def test_children_not_eligible_for_fill_on_entry_bar() -> None:
+    """Bar-safety guard: children submitted with ``submitted_at=bar.timestamp``
+    cannot fill on the same bar — even if the bar's range covers their
+    trigger prices. Children remain pending until the next bar."""
+    sim, order_book, portfolio = _make_simulator()
+    parent = order_book.submit(
+        _bracket_entry(qty=10.0, stop_price=95.0, take_profit_price=110.0),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+        expect_brackets=True,
+    )
+
+    # Bar 2's range covers BOTH child trigger prices (low=92 < stop=95;
+    # high=115 > tp=110). Despite that, children must not fill on this
+    # bar — only the entry fills.
+    outcome = sim.process_bar(
+        _bar("2024-01-02", open_price=100.0, high=115.0, low=92.0, close=100.0)
+    )
+
+    assert len(outcome.entry_fills) == 1
+    assert outcome.exit_fills == []
+    assert outcome.closed_trades == []
+
+    children = order_book.children_of(parent.order_id)
+    assert len(children) == 2
+    for child in children:
+        assert child.armed is True
+        # ``submitted_at`` anchored to the entry-fill bar so bar-safety
+        # blocks same-bar fills.
+        assert child.submitted_at == "2024-01-02"
+        # Still pending — has not filled.
+        assert child.cumulative_filled_qty == 0.0
+
+    assert portfolio.positions["AAA"].qty == pytest.approx(10.0, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Regression guard: the no-attachment path is byte-identical to pre-#389
+# ---------------------------------------------------------------------------
+
+
+def test_no_attachment_path_is_unchanged() -> None:
+    """Plain MARKET entry without attachments: no children created, no
+    eligible-parent registration leakage, simple round-trip identical to
+    pre-#389 behavior. Protects against the materializer accidentally
+    firing on the no-bracket path."""
+    sim, order_book, portfolio = _make_simulator()
+    plain_entry = OrderRequest(
+        client_order_id="entry-1",
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=10.0,
+        order_type=OrderType.MARKET,
+        tif=TimeInForce.DAY,
+    )
+    parent = order_book.submit(
+        plain_entry,
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+        # expect_brackets left at default ``False``.
+    )
+
+    sim.process_bar(_bar("2024-01-02", open_price=100.0))
+    assert order_book.children_of(parent.order_id) == []
+
+    plain_exit = OrderRequest(
+        client_order_id="exit-1",
+        symbol="AAA",
+        side=OrderSide.SHORT,
+        qty=10.0,
+        order_type=OrderType.MARKET,
+        tif=TimeInForce.DAY,
+    )
+    order_book.submit(
+        plain_exit,
+        submitted_at="2024-01-02",
+        submitted_equity=10_000_000.0,
+    )
+    outcome = sim.process_bar(_bar("2024-01-03", open_price=105.0))
+
+    assert len(outcome.closed_trades) == 1
+    assert "AAA" not in portfolio.positions
+    assert order_book.all_pending() == []

--- a/backend/agents/investment_team/tests/test_bracket_orders.py
+++ b/backend/agents/investment_team/tests/test_bracket_orders.py
@@ -14,8 +14,10 @@ on the no-attachment path and two follow-ups from the PR review:
    sized to the cumulative position (default backtest policy).
 8. Partial bracket-exit fill requeues the surviving leg (after OCO cancel
    removes the sibling) so residual position exposure stays protected.
-9. Trailing-stop attachments (``StopAttachment.trail_offset``) remain
-   gated until #390 — runtime materialization lands with Step 8.
+9. Continuation rejection of a partial-fill bracket parent (risk-gate or
+   capital check) still materializes legs for the open position.
+10. Trailing-stop attachments (``StopAttachment.trail_offset``) remain
+    gated until #390 — runtime materialization lands with Step 8.
 """
 
 from __future__ import annotations
@@ -473,6 +475,84 @@ def test_partial_bracket_exit_requeues_remainder_after_oco_cancel() -> None:
     assert len(bar4.closed_trades) == 1
     assert "AAA" not in portfolio.positions
     assert order_book.all_pending() == []
+
+
+# ---------------------------------------------------------------------------
+# Bracket parent abandoned mid-flight (continuation fails capital / risk
+# check after a partial entry fill) must still get protective legs for the
+# already-opened position (Codex P1 follow-up on commit 2b390a5)
+# ---------------------------------------------------------------------------
+
+
+def test_continuation_risk_gate_rejection_materializes_brackets_for_open_position() -> None:
+    """A 200-share bracket that fills 100 on bar 2, then has the
+    continuation rejected by the risk gate on bar 3 (post-extend notional
+    exceeds ``max_symbol_concentration_pct`` of equity), must still
+    materialize protective legs sized to the 100 shares actually open —
+    otherwise the residual position runs unprotected."""
+    portfolio = Portfolio(initial_capital=12_000.0)
+    order_book = OrderBook()
+    sim = FillSimulator(
+        portfolio=portfolio,
+        order_book=order_book,
+        # ``max_symbol_concentration_pct`` is what gates ``can_enter`` per
+        # symbol; raise it to 100 so the 83% first slice is admitted but the
+        # 167% post-extend continuation breaches the cap.
+        risk_filter=RiskFilter(
+            RiskLimits(
+                max_position_pct=100,
+                max_gross_leverage=10.0,
+                max_symbol_concentration_pct=100,
+            )
+        ),
+        config=FillSimulatorConfig(slippage_bps=0.0, transaction_cost_bps=0.0),
+        bar_safety=BarSafetyAssertion(),
+        execution_model=RealisticExecutionModel(participation_cap=0.10),
+    )
+    parent = order_book.submit(
+        OrderRequest(
+            client_order_id="entry-1",
+            symbol="AAA",
+            side=OrderSide.LONG,
+            qty=200.0,
+            order_type=OrderType.MARKET,
+            tif=TimeInForce.DAY,
+            unfilled_policy=UnfilledPolicy.REQUEUE_NEXT_BAR,
+            attached_stop_loss=StopAttachment(stop_price=95.0),
+            attached_take_profit=LimitAttachment(limit_price=110.0),
+        ),
+        submitted_at="2024-01-01",
+        submitted_equity=12_000.0,
+        expect_brackets=True,
+    )
+
+    # Bar 2: low ADV (1_000 * 100 = 100_000 dollar volume; 200 * 100 = 20_000
+    # notional → raw 0.20 → cap clips to 0.5 → 100 shares fill, 100 requeued).
+    # First slice's 10_000 notional is 83% of 12_000 equity → under the 100%
+    # ``max_symbol_concentration_pct`` cap → admitted.
+    sim.process_bar(_bar("2024-01-02", open_price=100.0, volume=1_000.0))
+    assert portfolio.positions["AAA"].qty == pytest.approx(100.0, rel=1e-9)
+    assert parent.order_id in order_book, "parent should still be pending after partial fill"
+    assert order_book.children_of(parent.order_id) == []
+
+    # Bar 3: ample liquidity but the post-extend notional (200 * 100 = 20_000)
+    # is 167% of equity (~12_000) → above the 100% ``max_symbol_concentration_pct``
+    # cap → the risk gate rejects the continuation slice. The fix materializes
+    # brackets sized to the 100-share open position before returning.
+    sim.process_bar(_bar("2024-01-03", open_price=100.0, volume=10_000_000.0))
+
+    assert parent.order_id not in order_book
+    children = order_book.children_of(parent.order_id)
+    assert len(children) == 2, "abandoned bracket parent must still spawn protective legs"
+    sl = next(c for c in children if c.request.order_type == OrderType.STOP)
+    tp = next(c for c in children if c.request.order_type == OrderType.LIMIT)
+    assert sl.request.qty == pytest.approx(100.0, rel=1e-9)
+    assert tp.request.qty == pytest.approx(100.0, rel=1e-9)
+    assert sl.armed is True and tp.armed is True
+    assert sl.submitted_at == "2024-01-03"
+    assert tp.submitted_at == "2024-01-03"
+    # Position is still open — the 100 shares from bar 2 weren't unwound.
+    assert portfolio.positions["AAA"].qty == pytest.approx(100.0, rel=1e-9)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/tests/test_bracket_orders.py
+++ b/backend/agents/investment_team/tests/test_bracket_orders.py
@@ -19,7 +19,9 @@ on the no-attachment path and two follow-ups from the PR review:
 10. Bracket children are bound to the parent position at materialization,
     so a separate exit that closes the position drops the children
     instead of letting a later trigger open a new opposite-side position.
-11. Trailing-stop attachments (``StopAttachment.trail_offset``) remain
+11. TWAP_N bracket parent that ages out via the no-trigger counter still
+    materializes protective legs for the partially-filled position.
+12. Trailing-stop attachments (``StopAttachment.trail_offset``) remain
     gated until #390 — runtime materialization lands with Step 8.
 """
 
@@ -627,6 +629,72 @@ def test_bracket_children_dropped_when_position_closed_by_separate_exit() -> Non
     assert bar4.closed_trades == []
     assert "AAA" not in portfolio.positions
     assert order_book.children_of(parent.order_id) == []
+
+
+# ---------------------------------------------------------------------------
+# TWAP_N bracket parent that ages out via the no-trigger counter must still
+# materialize protective legs for the partially-filled position (Codex P2
+# follow-up on commit 9b7888b)
+# ---------------------------------------------------------------------------
+
+
+def test_twap_age_out_bracket_parent_materializes_brackets_for_open_position() -> None:
+    """A bracketed TWAP_N LIMIT entry that fills its first slice (seeding
+    ``twap_slices_remaining``) and then has its remaining slices all expire
+    on no-trigger bars must still materialize protective legs sized to the
+    open position. The ``process_bar`` TWAP-tick branch removes the parent
+    with ``was_filled=True`` outside ``_handle_entry_remainder`` /
+    ``_continue_entry``, so the post-handler materializer never runs
+    without an explicit hook in that branch."""
+    sim, order_book, portfolio = _make_simulator()
+    parent = order_book.submit(
+        OrderRequest(
+            client_order_id="entry-1",
+            symbol="AAA",
+            side=OrderSide.LONG,
+            qty=200.0,
+            order_type=OrderType.LIMIT,
+            limit_price=100.0,
+            tif=TimeInForce.DAY,
+            unfilled_policy=UnfilledPolicy.TWAP_N,
+            twap_slices=2,
+            attached_stop_loss=StopAttachment(stop_price=95.0),
+            attached_take_profit=LimitAttachment(limit_price=110.0),
+        ),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+        expect_brackets=True,
+    )
+
+    # Bar 2: low (98) ≤ limit_price (100) → trigger fires → first slice
+    # partially fills against a low-ADV bar (200 * 100 = 20_000 notional vs
+    # 1_000 * 100 = 100_000 dollar volume → raw 0.20 → cap clips to 0.5 →
+    # 100 fills, 100 requeued; ``twap_slices_remaining`` seeded to 1).
+    sim.process_bar(
+        _bar("2024-01-02", open_price=99.0, high=101.0, low=98.0, close=100.0, volume=1_000.0)
+    )
+    assert portfolio.positions["AAA"].qty == pytest.approx(100.0, rel=1e-9)
+    assert parent.order_id in order_book
+    assert order_book.children_of(parent.order_id) == []
+
+    # Bar 3: bar.low (104) > limit_price (100) for LONG LIMIT → no trigger
+    # → ``compute_fill_terms`` returns None → process_bar's TWAP_N tick
+    # decrements ``twap_slices_remaining`` from 1 to 0 → parent removed
+    # with ``was_filled=True``. The fix materializes brackets sized to the
+    # 100-share open position before the loop continues.
+    sim.process_bar(_bar("2024-01-03", open_price=105.0, high=107.0, low=104.0, close=106.0))
+
+    assert parent.order_id not in order_book
+    children = order_book.children_of(parent.order_id)
+    assert len(children) == 2, "TWAP-aged-out bracket parent must still spawn protective legs"
+    sl = next(c for c in children if c.request.order_type == OrderType.STOP)
+    tp = next(c for c in children if c.request.order_type == OrderType.LIMIT)
+    assert sl.request.qty == pytest.approx(100.0, rel=1e-9)
+    assert tp.request.qty == pytest.approx(100.0, rel=1e-9)
+    assert sl.armed is True and tp.armed is True
+    assert sl.submitted_at == "2024-01-03"
+    assert tp.submitted_at == "2024-01-03"
+    assert portfolio.positions["AAA"].qty == pytest.approx(100.0, rel=1e-9)
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/tests/test_bracket_orders.py
+++ b/backend/agents/investment_team/tests/test_bracket_orders.py
@@ -16,7 +16,10 @@ on the no-attachment path and two follow-ups from the PR review:
    removes the sibling) so residual position exposure stays protected.
 9. Continuation rejection of a partial-fill bracket parent (risk-gate or
    capital check) still materializes legs for the open position.
-10. Trailing-stop attachments (``StopAttachment.trail_offset``) remain
+10. Bracket children are bound to the parent position at materialization,
+    so a separate exit that closes the position drops the children
+    instead of letting a later trigger open a new opposite-side position.
+11. Trailing-stop attachments (``StopAttachment.trail_offset``) remain
     gated until #390 — runtime materialization lands with Step 8.
 """
 
@@ -553,6 +556,77 @@ def test_continuation_risk_gate_rejection_materializes_brackets_for_open_positio
     assert tp.submitted_at == "2024-01-03"
     # Position is still open — the 100 shares from bar 2 weren't unwound.
     assert portfolio.positions["AAA"].qty == pytest.approx(100.0, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Bracket children must NOT outlive the position they protect: if a separate
+# exit closes the position before either OCO leg triggers, the children must
+# be dropped rather than open a brand-new opposite-side position on a later
+# stop/limit hit (Codex P1 follow-up on commit 8502876)
+# ---------------------------------------------------------------------------
+
+
+def test_bracket_children_dropped_when_position_closed_by_separate_exit() -> None:
+    """Without binding children to the parent position at materialization,
+    a manual market exit that closes the LONG position before the SL/TP
+    children fire would leave the children pending; a later bar whose low
+    crossed the stop level would route the SHORT STOP through
+    ``_fill_entry`` (existing_pos is None → ``is_entry=True``) and open a
+    fresh SHORT position. Setting ``working_against_entry_order_id`` at
+    materialization plus extending the stale-continuation guard to also
+    fire on cumulative_filled_qty == 0 (when bound) drops the children
+    cleanly."""
+    sim, order_book, portfolio = _make_simulator()
+    parent = order_book.submit(
+        _bracket_entry(qty=10.0, stop_price=95.0, take_profit_price=110.0),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+        expect_brackets=True,
+    )
+
+    # Bar 2: entry fills, children materialized.
+    sim.process_bar(_bar("2024-01-02", open_price=100.0))
+    assert portfolio.positions["AAA"].qty == pytest.approx(10.0, rel=1e-9)
+    assert len(order_book.children_of(parent.order_id)) == 2
+
+    # A manual SHORT market exit submitted between bars (simulating a
+    # separate strategy decision or an external position close) — note no
+    # parent_order_id / oco_group_id, so the OCO cancel block in _fill_exit
+    # does NOT fire and the bracket children stay in the book.
+    order_book.submit(
+        OrderRequest(
+            client_order_id="manual-exit",
+            symbol="AAA",
+            side=OrderSide.SHORT,
+            qty=10.0,
+            order_type=OrderType.MARKET,
+            tif=TimeInForce.DAY,
+        ),
+        submitted_at="2024-01-02",
+        submitted_equity=10_000_000.0,
+    )
+
+    # Bar 3: manual exit fills, position closes. Bracket children stay
+    # pending in the book (they have no OCO relationship with the manual
+    # exit).
+    sim.process_bar(_bar("2024-01-03", open_price=100.0))
+    assert "AAA" not in portfolio.positions
+    survivors_before = order_book.children_of(parent.order_id)
+    assert len(survivors_before) == 2, (
+        "manual exit should not cancel bracket children — only the OCO "
+        "relationship between siblings does"
+    )
+
+    # Bar 4: bar's low (93) crosses the SL stop_price (95). WITHOUT THE FIX
+    # the SHORT STOP would route through _fill_entry (no position open) and
+    # open a fresh SHORT position. WITH THE FIX the stale-continuation
+    # guard drops both children and emits no fills.
+    bar4 = sim.process_bar(_bar("2024-01-04", open_price=97.0, high=98.0, low=93.0, close=94.0))
+    assert bar4.entry_fills == [], "stale bracket child must not open a new position"
+    assert bar4.exit_fills == []
+    assert bar4.closed_trades == []
+    assert "AAA" not in portfolio.positions
+    assert order_book.children_of(parent.order_id) == []
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/tests/test_bracket_orders.py
+++ b/backend/agents/investment_team/tests/test_bracket_orders.py
@@ -23,7 +23,10 @@ on the no-attachment path and two follow-ups from the PR review:
     materializes protective legs for the partially-filled position.
 12. DAY-TIF bracket parent that expires after a partial fill still
     materializes protective legs for the open position.
-13. Trailing-stop attachments (``StopAttachment.trail_offset``) remain
+13. Bracket children materialized at expiry time defer past the bar that
+    triggered the expiry — a gap-through opening must not abort the
+    backtest via ``LookAheadError``.
+14. Trailing-stop attachments (``StopAttachment.trail_offset``) remain
     gated until #390 — runtime materialization lands with Step 8.
 """
 
@@ -762,6 +765,80 @@ def test_day_expiry_partial_bracket_parent_materializes_brackets() -> None:
     assert tp.submitted_at == "2024-01-03"
     # Position untouched by the expiry; the bracket now covers it.
     assert portfolio.positions["AAA"].qty == pytest.approx(100.0, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# Expiry-created bracket children defer past the bar that triggered the
+# expiry — a gap-through opening on that same bar must not abort the run
+# via LookAheadError (Codex P1 follow-up on commit f5d535e)
+# ---------------------------------------------------------------------------
+
+
+def test_expiry_bar_gap_through_does_not_abort_via_lookahead() -> None:
+    """``FillSimulator.expire_day_orders(cur_bar)`` materializes bracket
+    children with ``submitted_at=cur_bar.timestamp`` BEFORE the service
+    calls ``process_bar(cur_bar)``, so the children land in this bar's
+    pending snapshot. If that bar's range crosses a child's stop or
+    limit price, the engine-internal soft-skip in ``process_bar``
+    must defer the child to the next bar instead of triggering
+    ``bar_safety.check_fill``'s ``LookAheadError``. Without the skip,
+    a normal overnight gap would abort the backtest."""
+    sim, order_book, portfolio = _make_simulator()
+    parent = order_book.submit(
+        OrderRequest(
+            client_order_id="entry-1",
+            symbol="AAA",
+            side=OrderSide.LONG,
+            qty=200.0,
+            order_type=OrderType.MARKET,
+            tif=TimeInForce.DAY,
+            unfilled_policy=UnfilledPolicy.REQUEUE_NEXT_BAR,
+            attached_stop_loss=StopAttachment(stop_price=95.0),
+            attached_take_profit=LimitAttachment(limit_price=110.0),
+        ),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+        expect_brackets=True,
+    )
+
+    # Day D (2024-01-02): partial fill (100 shares), remainder requeued.
+    sim.process_bar(_bar("2024-01-02", open_price=100.0, volume=1_000.0))
+    assert portfolio.positions["AAA"].qty == pytest.approx(100.0, rel=1e-9)
+
+    # Day D+1 (2024-01-03) opens with a gap-down through the stop level
+    # (low=92 < stop_price=95). The service calls expire_day_orders FIRST
+    # (with cur_bar=2024-01-03), then process_bar(cur_bar). Without the
+    # soft-skip the SHORT STOP child — submitted at 2024-01-03 — would
+    # trip ``bar_safety.check_fill`` and raise ``LookAheadError``.
+    next_session_bar = _bar("2024-01-03", open_price=93.0, high=94.0, low=92.0, close=93.0)
+    sim.expire_day_orders(next_session_bar)
+
+    # Children materialized on the expiry bar.
+    children_after_expire = order_book.children_of(parent.order_id)
+    assert len(children_after_expire) == 2
+    for child in children_after_expire:
+        assert child.submitted_at == "2024-01-03"
+
+    # process_bar on the same bar must NOT raise LookAheadError despite the
+    # gap-through — the soft-skip defers the children to the next bar.
+    outcome = sim.process_bar(next_session_bar)
+    assert outcome.entry_fills == []
+    assert outcome.exit_fills == []
+    assert outcome.closed_trades == []
+
+    # Children still pending and bound, ready to fire on the next bar.
+    children_after_process = order_book.children_of(parent.order_id)
+    assert len(children_after_process) == 2
+
+    # Day D+2 (2024-01-04): another bar with low ≤ stop. Now bar.timestamp
+    # > children's submitted_at → soft-skip doesn't fire → SHORT STOP
+    # fires as a normal exit, OCO cancels the take-profit.
+    bar_after = _bar("2024-01-04", open_price=94.0, high=95.0, low=93.0, close=94.0)
+    final_outcome = sim.process_bar(bar_after)
+    assert len(final_outcome.exit_fills) == 1
+    assert final_outcome.exit_fills[0].fill_kind == FillKind.FULL
+    assert "AAA" not in portfolio.positions
+    assert order_book.children_of(parent.order_id) == []
 
 
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/tests/test_contract_gates.py
+++ b/backend/agents/investment_team/tests/test_contract_gates.py
@@ -53,32 +53,49 @@ def test_gates_raise_unsupported_order_feature_subclass():
         req.validate_prices()
 
 
-def test_attached_stop_loss_is_gated_until_step_7():
-    req = _base(attached_stop_loss=StopAttachment(stop_price=10.0))
-    with pytest.raises(NotImplementedError, match="#389"):
-        req.validate_prices()
+def test_attachments_validate_post_step_7():
+    """Bracket attachments (``attached_stop_loss`` / ``attached_take_profit``)
+    are runtime-supported as of #389; ``validate_prices`` must accept them
+    without raising. The mutual-exclusion check
+    (``test_attachments_and_parent_order_id_are_mutually_exclusive``) is now
+    the live invariant."""
+    _base(attached_stop_loss=StopAttachment(stop_price=95.0)).validate_prices()
+    _base(attached_take_profit=LimitAttachment(limit_price=110.0)).validate_prices()
+    _base(
+        attached_stop_loss=StopAttachment(stop_price=95.0),
+        attached_take_profit=LimitAttachment(limit_price=110.0),
+    ).validate_prices()
 
 
-def test_attached_take_profit_is_gated_until_step_7():
-    req = _base(attached_take_profit=LimitAttachment(limit_price=120.0))
-    with pytest.raises(NotImplementedError, match="#389"):
-        req.validate_prices()
+def test_parent_order_id_and_oco_group_id_validate_post_step_7():
+    """``parent_order_id`` / ``oco_group_id`` are engine-internal — set by
+    ``OrderBook.submit_attached`` on bracket children. ``validate_prices``
+    no longer rejects them outright; the gateway-level rejection
+    (top-level ``OrderBook.submit`` refuses to accept them) is exercised
+    in ``test_order_book``."""
+    _base(parent_order_id="parent-123").validate_prices()
+    _base(oco_group_id="oco-1").validate_prices()
+    _base(parent_order_id="parent-123", oco_group_id="oco-1").validate_prices()
 
 
-def test_parent_order_id_is_gated_until_step_7():
-    req = _base(parent_order_id="parent-123")
-    with pytest.raises(NotImplementedError, match="#389"):
-        req.validate_prices()
-
-
-def test_oco_group_id_is_gated_until_step_7():
-    req = _base(oco_group_id="oco-1")
-    with pytest.raises(NotImplementedError, match="#389"):
-        req.validate_prices()
+def test_attachments_and_parent_order_id_are_mutually_exclusive():
+    """Attachments may only be set on entry-creating orders. A bracket
+    child (``parent_order_id`` set) carrying further attachments would
+    imply a multi-level bracket tree, which the API does not support."""
+    with pytest.raises(ValueError, match="entry-creating orders"):
+        _base(
+            parent_order_id="parent-123",
+            attached_stop_loss=StopAttachment(stop_price=95.0),
+        ).validate_prices()
+    with pytest.raises(ValueError, match="entry-creating orders"):
+        _base(
+            parent_order_id="parent-123",
+            attached_take_profit=LimitAttachment(limit_price=110.0),
+        ).validate_prices()
 
 
 def test_default_market_order_still_validates():
-    """Sanity: the gates only fire on the new feature flags."""
+    """Sanity: the remaining gates only fire on still-deferred features."""
     _base().validate_prices()
     _base(order_type=OrderType.LIMIT, limit_price=100.0).validate_prices()
     _base(order_type=OrderType.STOP, stop_price=105.0).validate_prices()

--- a/backend/agents/investment_team/tests/test_contract_gates.py
+++ b/backend/agents/investment_team/tests/test_contract_gates.py
@@ -56,9 +56,9 @@ def test_gates_raise_unsupported_order_feature_subclass():
 def test_attachments_validate_post_step_7():
     """Bracket attachments (``attached_stop_loss`` / ``attached_take_profit``)
     are runtime-supported as of #389; ``validate_prices`` must accept them
-    without raising. The mutual-exclusion check
-    (``test_attachments_and_parent_order_id_are_mutually_exclusive``) is now
-    the live invariant."""
+    without raising. (``parent_order_id`` / ``oco_group_id`` remain rejected
+    on the strategy path — see ``test_parent_order_id_is_engine_internal``.)
+    """
     _base(attached_stop_loss=StopAttachment(stop_price=95.0)).validate_prices()
     _base(attached_take_profit=LimitAttachment(limit_price=110.0)).validate_prices()
     _base(
@@ -67,31 +67,25 @@ def test_attachments_validate_post_step_7():
     ).validate_prices()
 
 
-def test_parent_order_id_and_oco_group_id_validate_post_step_7():
-    """``parent_order_id`` / ``oco_group_id`` are engine-internal — set by
-    ``OrderBook.submit_attached`` on bracket children. ``validate_prices``
-    no longer rejects them outright; the gateway-level rejection
-    (top-level ``OrderBook.submit`` refuses to accept them) is exercised
-    in ``test_order_book``."""
-    _base(parent_order_id="parent-123").validate_prices()
-    _base(oco_group_id="oco-1").validate_prices()
-    _base(parent_order_id="parent-123", oco_group_id="oco-1").validate_prices()
+def test_parent_order_id_is_engine_internal():
+    """``parent_order_id`` is set by ``OrderBook.submit_attached`` when the
+    engine materializes a bracket child; strategies must NOT supply it.
+    ``submit_attached`` re-runs ``validate_prices`` on a clone with the
+    field cleared, so this gate doesn't block the engine path while
+    keeping strategy-side requests well-formed (otherwise a strategy
+    that passed it would crash the run at ``OrderBook.submit``'s
+    defense-in-depth ``ValueError`` rather than producing a structured
+    ``unsupported_feature`` rejection)."""
+    req = _base(parent_order_id="parent-123")
+    with pytest.raises(UnsupportedOrderFeatureError, match="engine-internal"):
+        req.validate_prices()
 
 
-def test_attachments_and_parent_order_id_are_mutually_exclusive():
-    """Attachments may only be set on entry-creating orders. A bracket
-    child (``parent_order_id`` set) carrying further attachments would
-    imply a multi-level bracket tree, which the API does not support."""
-    with pytest.raises(ValueError, match="entry-creating orders"):
-        _base(
-            parent_order_id="parent-123",
-            attached_stop_loss=StopAttachment(stop_price=95.0),
-        ).validate_prices()
-    with pytest.raises(ValueError, match="entry-creating orders"):
-        _base(
-            parent_order_id="parent-123",
-            attached_take_profit=LimitAttachment(limit_price=110.0),
-        ).validate_prices()
+def test_oco_group_id_is_engine_internal():
+    """Same as ``parent_order_id`` — set by ``OrderBook.submit_attached``."""
+    req = _base(oco_group_id="oco-1")
+    with pytest.raises(UnsupportedOrderFeatureError, match="engine-internal"):
+        req.validate_prices()
 
 
 def test_default_market_order_still_validates():

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -935,11 +935,13 @@ def test_children_of_rejects_bad_parent_id(bad_parent) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_submit_attached_skips_risk_gates() -> None:
-    """``submit_attached`` must accept a request with ``parent_order_id`` /
-    ``oco_group_id`` set even though calling ``validate_prices()`` directly on
-    the same payload still raises (the gate is owned by the strategy-side
-    service path; engine-side bracket materialization owns its own correctness).
+def test_submit_attached_accepts_parent_and_oco_ids() -> None:
+    """``submit_attached`` is the engine-internal entry point for bracket
+    children: it accepts a request and re-tags it with ``parent_order_id`` /
+    ``oco_group_id`` server-side. The same fields are rejected by the
+    top-level ``OrderBook.submit()`` so a strategy can't smuggle a bracket
+    child in as a parent (multi-level bracket trees would break
+    ``children_of`` traversal and OCO scoping).
     """
     book = OrderBook()
     parent = book.submit(
@@ -949,7 +951,9 @@ def test_submit_attached_skips_risk_gates() -> None:
         expect_brackets=True,
     )
 
-    # Independent proof that the gate is real on the strategy path.
+    # Independent proof that the top-level gateway rejects child-shaped
+    # requests (the gate moved from ``validate_prices`` to ``submit`` when
+    # #389 lifted the strategy-side gate so the engine can wire up brackets).
     gated = OrderRequest(
         client_order_id="child",
         symbol="AAA",
@@ -960,10 +964,10 @@ def test_submit_attached_skips_risk_gates() -> None:
         parent_order_id=parent.order_id,
         oco_group_id="g1",
     )
-    with pytest.raises(UnsupportedOrderFeatureError):
-        gated.validate_prices()
+    with pytest.raises(ValueError, match="parent_order_id or oco_group_id"):
+        book.submit(gated, submitted_at="2024-01-03", submitted_equity=100_000.0)
 
-    # submit_attached must not raise on the same payload shape.
+    # submit_attached must accept a clean child payload and tag it.
     child = book.submit_attached(
         _base(side=OrderSide.SHORT, qty=10.0, order_type=OrderType.LIMIT, limit_price=110.0),
         submitted_at="2024-01-03",

--- a/backend/agents/investment_team/tests/test_trading_service.py
+++ b/backend/agents/investment_team/tests/test_trading_service.py
@@ -394,8 +394,8 @@ def test_execution_diagnostic_helpers_cap_events_and_count_rejections() -> None:
 _UNSUPPORTED_FEATURE_STRATEGY_CODE = textwrap.dedent('''\
     """Strategy that bypasses ``submit_order``'s subprocess-side validation
     to exercise the parent's ``UnsupportedOrderFeatureError`` rejection
-    path. Sets ``parent_order_id``, which still raises in the parent's
-    ``OrderRequest.validate_prices`` until #389 lands.
+    path. Sets ``order_type=trailing_stop`` — still gated in
+    ``OrderRequest.validate_prices`` until #390 (Trading 5/5 Step 8).
     """
     from contract import Strategy
 
@@ -416,9 +416,9 @@ _UNSUPPORTED_FEATURE_STRATEGY_CODE = textwrap.dedent('''\
                     "symbol": bar.symbol,
                     "side": "long",
                     "qty": 1.0,
-                    "order_type": "market",
+                    "order_type": "trailing_stop",
+                    "stop_price": 100.0,
                     "tif": "day",
-                    "parent_order_id": "fake-parent",
                 },
             })
 ''')
@@ -599,7 +599,7 @@ def test_diagnostics_emitted_and_accepted_counts_round_trip() -> None:
 
 
 def test_diagnostics_unsupported_feature_records_rejection() -> None:
-    """``parent_order_id`` is gated until #389; counts as unsupported_feature."""
+    """``trailing_stop`` is gated until #390; counts as unsupported_feature."""
     market_data: Dict[str, List[OHLCVBar]] = {}
     _uptrend_then_down_bars(market_data)
 

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -160,10 +160,16 @@ class FillSimulator:
             # against the wrong position on a later triggered bar.
             # Fresh entries (``cumulative_filled_qty == 0``) and live
             # continuations (target position still open and intact) are
-            # unaffected.
+            # unaffected. Bracket children (#389) are also bound at
+            # materialization (``working_against_entry_order_id`` set to the
+            # parent entry's id), so the same guard catches a child whose
+            # target position has been closed by a separate exit before
+            # either OCO leg fired — without it the child would later
+            # trigger as ``is_entry`` and open a brand-new opposite-side
+            # position.
             existing_pos = self.portfolio.positions.get(bar.symbol)
-            if po.cumulative_filled_qty > 0:
-                bound_id = po.working_against_entry_order_id
+            bound_id = po.working_against_entry_order_id
+            if po.cumulative_filled_qty > 0 or bound_id is not None:
                 if existing_pos is None or (
                     bound_id is not None and existing_pos.entry_order_id != bound_id
                 ):
@@ -1216,6 +1222,13 @@ class FillSimulator:
         liquidity bar — without it, ``_handle_exit_remainder`` would drop
         the unfilled remainder while the OCO cancel had already removed
         the sibling, leaving residual position exposure unprotected.
+        Each child has ``working_against_entry_order_id`` set to the parent
+        entry's id at materialization (rather than waiting for the first
+        fill in ``_fill_exit``) so the stale-continuation guard in
+        ``process_bar`` drops the child if the position is closed by a
+        separate exit before any OCO leg triggers — otherwise a later
+        stop/limit hit would route through ``_fill_entry`` and open a
+        brand-new opposite-side position.
         """
         req = po.request
         child_side = OrderSide.SHORT if req.side == OrderSide.LONG else OrderSide.LONG
@@ -1233,13 +1246,14 @@ class FillSimulator:
                 unfilled_policy=UnfilledPolicy.REQUEUE_NEXT_BAR,
                 reason="bracket_sl",
             )
-            self.order_book.submit_attached(
+            sl_child = self.order_book.submit_attached(
                 sl_req,
                 submitted_at=bar.timestamp,
                 submitted_equity=po.submitted_equity,
                 parent_order_id=po.order_id,
                 oco_group_id=oco_group_id,
             )
+            sl_child.working_against_entry_order_id = po.order_id
         if req.attached_take_profit is not None:
             tp = req.attached_take_profit
             tp_req = OrderRequest(
@@ -1253,13 +1267,14 @@ class FillSimulator:
                 unfilled_policy=UnfilledPolicy.REQUEUE_NEXT_BAR,
                 reason="bracket_tp",
             )
-            self.order_book.submit_attached(
+            tp_child = self.order_book.submit_attached(
                 tp_req,
                 submitted_at=bar.timestamp,
                 submitted_equity=po.submitted_equity,
                 parent_order_id=po.order_id,
                 oco_group_id=oco_group_id,
             )
+            tp_child.working_against_entry_order_id = po.order_id
 
 
 def _date_diff(t1: str, t2: str) -> int:

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -21,7 +21,7 @@ import logging
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
-from ...execution.bar_safety import BarSafetyAssertion
+from ...execution.bar_safety import BarSafetyAssertion, _ts_le
 from ...execution.risk_filter import RiskFilter
 from ...models import TradeRecord
 from ..strategy.contract import (
@@ -137,6 +137,25 @@ class FillSimulator:
             # Skipping them here keeps protective legs from firing as
             # standalone orders before the entry has actually opened.
             if not po.armed:
+                continue
+            # Defer engine-internal orders (those bound to a position via
+            # ``working_against_entry_order_id``) whose submission bar isn't
+            # strictly earlier than this one. The canonical case is bracket
+            # children materialized by ``FillSimulator.expire_day_orders``
+            # (#389) on a date change: the service calls that hook *before*
+            # ``process_bar(cur_bar)``, so the children land in this bar's
+            # pending snapshot with ``submitted_at=cur_bar.timestamp``.
+            # Without this skip, ``bar_safety.check_fill`` below would raise
+            # ``LookAheadError`` on a bar whose range crosses the child's
+            # stop or limit price — aborting the run on a normal overnight
+            # gap rather than waiting until the next eligible bar. The skip
+            # is intentionally narrow (only orders bound by the engine, not
+            # strategy-side requests) so a strategy that emits an order
+            # tagged with the current bar's timestamp still trips
+            # ``bar_safety`` below as a programmer-error guard.
+            if po.working_against_entry_order_id is not None and _ts_le(
+                bar.timestamp, po.submitted_at
+            ):
                 continue
             req = po.request
 

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -669,6 +669,7 @@ class FillSimulator:
             # from ``OrderBook``'s eligible-parent set and break any later
             # ``submit_attached`` call against this parent.
             self.order_book.remove(po.order_id, was_filled=True)
+            self._maybe_materialize_brackets_on_abandon(po=po, bar=bar)
             return None, f"risk_gate:{gate.reason}"
 
         # Capital check against the *additional* notional only — the existing
@@ -685,6 +686,7 @@ class FillSimulator:
             # parent's eligible-parent registration since the first slice
             # already filled.
             self.order_book.remove(po.order_id, was_filled=True)
+            self._maybe_materialize_brackets_on_abandon(po=po, bar=bar)
             return None, "insufficient_capital"
 
         pos = self.portfolio.extend(req.symbol, filled_qty, fill_price, ref_price)
@@ -1164,6 +1166,32 @@ class FillSimulator:
     # ------------------------------------------------------------------
     # Bracket / OCO materialization (#389)
     # ------------------------------------------------------------------
+
+    def _maybe_materialize_brackets_on_abandon(
+        self,
+        *,
+        po: PendingOrder,
+        bar: Bar,
+    ) -> None:
+        """Materialize protective legs when ``_continue_entry`` abandons an
+        already-filled bracket parent (risk-gate or insufficient-capital
+        rejection of a continuation slice).
+
+        These rejection paths return early without going through
+        ``_handle_entry_remainder``, so the post-handler materializer block
+        in ``_continue_entry`` doesn't fire — but the parent has been
+        ``remove(was_filled=True)``-ed and a position is open. Without
+        this hook the residual position runs unprotected (no SL, no TP).
+        Sized to the existing position's cumulative entry-filled qty so
+        the legs cover everything that was actually opened.
+        """
+        req = po.request
+        if req.attached_stop_loss is None and req.attached_take_profit is None:
+            return
+        pos = self.portfolio.positions.get(req.symbol)
+        if pos is None:
+            return
+        self._materialize_bracket_children(po=po, bar=bar, filled_qty=pos.original_qty)
 
     def _materialize_bracket_children(
         self,

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -24,7 +24,16 @@ from typing import List, Optional, Tuple
 from ...execution.bar_safety import BarSafetyAssertion
 from ...execution.risk_filter import RiskFilter
 from ...models import TradeRecord
-from ..strategy.contract import Bar, Fill, FillKind, OrderSide, TimeInForce, UnfilledPolicy
+from ..strategy.contract import (
+    Bar,
+    Fill,
+    FillKind,
+    OrderRequest,
+    OrderSide,
+    OrderType,
+    TimeInForce,
+    UnfilledPolicy,
+)
 from .execution_model import ExecutionModel, FillTerms, OptimisticExecutionModel
 from .order_book import OrderBook, PendingOrder
 from .portfolio import Portfolio, Position
@@ -541,6 +550,19 @@ class FillSimulator:
         # stale-continuation guard in ``process_bar``.
         po.working_against_entry_order_id = po.order_id
         self._handle_entry_remainder(po, bar, unfilled)
+        # Bracket / OCO materialization (#389): once the parent's first slice
+        # has opened a position *and* has been terminally filled, submit the
+        # linked protective legs so they can fire on subsequent bars. Must run
+        # AFTER ``_handle_entry_remainder`` so the membership check below
+        # reflects whether the parent is still pending — full fills remove
+        # the parent (``submit_attached`` returns ``armed=True``); partial
+        # fills (REQUEUE / TWAP) leave the parent pending and Step 7 skips
+        # materialization (REQUEUE-grown brackets are deferred — a known
+        # limitation; ``test_bracket_orders.py`` covers the full-fill path).
+        if (
+            req.attached_stop_loss is not None or req.attached_take_profit is not None
+        ) and po.order_id not in self.order_book:
+            self._materialize_bracket_children(po=po, bar=bar, filled_qty=filled_qty)
 
         return (
             Fill(
@@ -873,6 +895,24 @@ class FillSimulator:
             return rejected, None
 
         self.portfolio.partial_close(bar.symbol, filled_qty, exit_price, ref_price)
+        # OCO sibling cancellation (#389): on the first non-rejected fill of
+        # a bracket child, cancel the protective leg we DIDN'T just hit so
+        # it can't also fire. Must run BEFORE the survivor is removed
+        # from the book (full-close path at ``order_book.remove(...)`` below)
+        # — ``oco_cancel_siblings`` validates that ``except_order_id`` is
+        # still pending. Gated on ``cumulative_filled_qty == 0`` so on a
+        # partial-exit child the cancel fires once on the first slice and
+        # not on every requeued continuation bar.
+        if (
+            req.parent_order_id is not None
+            and req.oco_group_id is not None
+            and po.cumulative_filled_qty == 0
+        ):
+            self.order_book.oco_cancel_siblings(
+                req.oco_group_id,
+                except_order_id=po.order_id,
+                parent_order_id=req.parent_order_id,
+            )
         # Only the participation-cap-clipped portion (``fillable_qty -
         # filled_qty``) accumulates into ``pos.total_unfilled_qty`` — the
         # over-ask portion (``po.remaining_qty - fillable_qty``) is a
@@ -1108,6 +1148,71 @@ class FillSimulator:
             )
             return
         self.order_book.remove(po.order_id)
+
+    # ------------------------------------------------------------------
+    # Bracket / OCO materialization (#389)
+    # ------------------------------------------------------------------
+
+    def _materialize_bracket_children(
+        self,
+        *,
+        po: PendingOrder,
+        bar: Bar,
+        filled_qty: float,
+    ) -> None:
+        """Submit ``StopAttachment`` / ``LimitAttachment`` legs as OCO children.
+
+        Called once per parent on a successful terminal-fill entry slice.
+        Each child is opposite-side to the parent, sized to ``filled_qty``,
+        and tagged with a deterministic ``oco_group_id`` derived from the
+        parent so OCO sibling cancellation can scope correctly.
+        ``submitted_at=bar.timestamp`` blocks same-bar fills via the
+        bar-safety guard (children are eligible from the next bar onward).
+        ``tif=GTC`` so the protective legs survive across sessions —
+        otherwise a DAY child would expire at the end of the entry-fill
+        session and leave the position unprotected overnight.
+        """
+        req = po.request
+        child_side = OrderSide.SHORT if req.side == OrderSide.LONG else OrderSide.LONG
+        oco_group_id = f"oco_{po.order_id}"
+        if req.attached_stop_loss is not None:
+            sl = req.attached_stop_loss
+            sl_req = OrderRequest(
+                client_order_id=sl.client_order_id or f"{req.client_order_id}_sl",
+                symbol=req.symbol,
+                side=child_side,
+                qty=filled_qty,
+                order_type=OrderType.STOP,
+                stop_price=sl.stop_price,
+                tif=TimeInForce.GTC,
+                reason="bracket_sl",
+            )
+            self.order_book.submit_attached(
+                sl_req,
+                submitted_at=bar.timestamp,
+                submitted_equity=po.submitted_equity,
+                parent_order_id=po.order_id,
+                oco_group_id=oco_group_id,
+            )
+        if req.attached_take_profit is not None:
+            tp = req.attached_take_profit
+            tp_req = OrderRequest(
+                client_order_id=tp.client_order_id or f"{req.client_order_id}_tp",
+                symbol=req.symbol,
+                side=child_side,
+                qty=filled_qty,
+                order_type=OrderType.LIMIT,
+                limit_price=tp.limit_price,
+                tif=TimeInForce.GTC,
+                reason="bracket_tp",
+            )
+            self.order_book.submit_attached(
+                tp_req,
+                submitted_at=bar.timestamp,
+                submitted_equity=po.submitted_equity,
+                parent_order_id=po.order_id,
+                oco_group_id=oco_group_id,
+            )
 
 
 def _date_diff(t1: str, t2: str) -> int:

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -550,15 +550,14 @@ class FillSimulator:
         # stale-continuation guard in ``process_bar``.
         po.working_against_entry_order_id = po.order_id
         self._handle_entry_remainder(po, bar, unfilled)
-        # Bracket / OCO materialization (#389): once the parent's first slice
-        # has opened a position *and* has been terminally filled, submit the
-        # linked protective legs so they can fire on subsequent bars. Must run
-        # AFTER ``_handle_entry_remainder`` so the membership check below
-        # reflects whether the parent is still pending — full fills remove
-        # the parent (``submit_attached`` returns ``armed=True``); partial
-        # fills (REQUEUE / TWAP) leave the parent pending and Step 7 skips
-        # materialization (REQUEUE-grown brackets are deferred — a known
-        # limitation; ``test_bracket_orders.py`` covers the full-fill path).
+        # Bracket / OCO materialization (#389): when the parent's first slice
+        # is also its terminal slice (full fill), submit the protective legs.
+        # Must run AFTER ``_handle_entry_remainder`` so the membership check
+        # below reflects whether the parent is still pending — full fills
+        # remove the parent (``submit_attached`` returns ``armed=True``).
+        # Partial-fill entries (REQUEUE / TWAP) defer materialization to the
+        # mirrored block in ``_continue_entry`` so the children are sized to
+        # the *cumulative* position rather than just the first slice.
         if (
             req.attached_stop_loss is not None or req.attached_take_profit is not None
         ) and po.order_id not in self.order_book:
@@ -710,6 +709,19 @@ class FillSimulator:
         # + filled_qty`` after the requeue would double-count this slice.
         fill_cumulative_qty = po.cumulative_filled_qty + filled_qty
         self._handle_entry_remainder(po, bar, unfilled)
+        # Bracket / OCO materialization (#389) for the terminal slice of a
+        # partial-fill entry: if the parent had attachments and is now fully
+        # done (``_handle_entry_remainder`` removed it from the book on this
+        # slice), submit the protective legs sized to the cumulative position
+        # — ``pos.original_qty`` was just bumped to reflect the full opened
+        # qty across all prior continuations. Default backtest policy is
+        # ``REQUEUE_NEXT_BAR``, so without this any participation-capped
+        # bracket entry would silently run unprotected once the parent
+        # eventually completes.
+        if (
+            req.attached_stop_loss is not None or req.attached_take_profit is not None
+        ) and po.order_id not in self.order_book:
+            self._materialize_bracket_children(po=po, bar=bar, filled_qty=pos.original_qty)
 
         return (
             Fill(

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -279,6 +279,14 @@ class FillSimulator:
                     was_filled = po.cumulative_filled_qty > 0
                     if new_slices_remaining <= 0:
                         self.order_book.remove(po.order_id, was_filled=was_filled)
+                        # Bracket / OCO materialization (#389): if the parent
+                        # had attachments and at least one prior slice opened
+                        # a position, the TWAP horizon expiring without a
+                        # final-bar trigger leaves an open partial position.
+                        # Submit protective legs sized to the existing
+                        # position so it doesn't run unprotected.
+                        if was_filled:
+                            self._maybe_materialize_brackets_on_abandon(po=po, bar=bar)
                     else:
                         self.order_book.requeue(
                             po.order_id,

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -1178,6 +1178,27 @@ class FillSimulator:
         self.order_book.remove(po.order_id)
 
     # ------------------------------------------------------------------
+    # TIF expiry hook (#389)
+    # ------------------------------------------------------------------
+
+    def expire_day_orders(self, bar: Bar) -> List[PendingOrder]:
+        """Expire DAY-TIF orders against ``bar``'s session boundary.
+
+        Wraps ``OrderBook.expire_day_orders`` to materialize protective
+        bracket legs for *partially-filled* bracket parents before the
+        bracket is fully abandoned (#389). Without this hook, the
+        previously-opened position would silently run unprotected after
+        TIF expiry — the order-book level uses ``was_filled=True`` for
+        partial bracket parents specifically so this hook can still
+        ``submit_attached`` against their (still-registered) id here.
+        """
+        expired = self.order_book.expire_day_orders(bar.timestamp)
+        for po in expired:
+            if po.cumulative_filled_qty > 0:
+                self._maybe_materialize_brackets_on_abandon(po=po, bar=bar)
+        return expired
+
+    # ------------------------------------------------------------------
     # Bracket / OCO materialization (#389)
     # ------------------------------------------------------------------
 

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -1183,6 +1183,11 @@ class FillSimulator:
         ``tif=GTC`` so the protective legs survive across sessions —
         otherwise a DAY child would expire at the end of the entry-fill
         session and leave the position unprotected overnight.
+        ``unfilled_policy=REQUEUE_NEXT_BAR`` keeps the surviving leg alive
+        when the realistic execution model partially fills it on a low-
+        liquidity bar — without it, ``_handle_exit_remainder`` would drop
+        the unfilled remainder while the OCO cancel had already removed
+        the sibling, leaving residual position exposure unprotected.
         """
         req = po.request
         child_side = OrderSide.SHORT if req.side == OrderSide.LONG else OrderSide.LONG
@@ -1197,6 +1202,7 @@ class FillSimulator:
                 order_type=OrderType.STOP,
                 stop_price=sl.stop_price,
                 tif=TimeInForce.GTC,
+                unfilled_policy=UnfilledPolicy.REQUEUE_NEXT_BAR,
                 reason="bracket_sl",
             )
             self.order_book.submit_attached(
@@ -1216,6 +1222,7 @@ class FillSimulator:
                 order_type=OrderType.LIMIT,
                 limit_price=tp.limit_price,
                 tif=TimeInForce.GTC,
+                unfilled_policy=UnfilledPolicy.REQUEUE_NEXT_BAR,
                 reason="bracket_tp",
             )
             self.order_book.submit_attached(

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -63,17 +63,25 @@ class PendingOrder:
     effective_stop_price: Optional[float] = None  # live trailing stop (Step 8 / #390)
     trailing_water: Optional[float] = None  # running high (LONG) / low (SHORT); Step 8
     armed: bool = True
-    # Identity of the position this order is committed to act against, set
-    # on the *first* fill: for entries it's ``po.order_id`` itself (the id
-    # of the position they just opened); for exits it's the existing
-    # position's ``entry_order_id`` (the entry that originally opened the
-    # position being closed). Used by ``process_bar``'s stale-continuation
-    # guard to drop pre-filled remainders whose original target position
-    # has been closed *and* replaced by an unrelated position on the same
-    # symbol — without this, a stale TWAP/REQUEUE remainder could fire
-    # against a brand-new position via ``_fill_exit`` (#387 review note).
-    # ``None`` for orders that haven't filled yet (cumulative_filled_qty
-    # == 0); the guard short-circuits in that case.
+    # Identity of the position this order is committed to act against,
+    # bound at one of three points:
+    #   - First entry fill: set to ``po.order_id`` itself (the id of the
+    #     position they just opened).
+    #   - First exit fill: set to the existing position's
+    #     ``entry_order_id`` (the entry that originally opened the
+    #     position being closed).
+    #   - Bracket child materialization (#389): set to the parent entry's
+    #     id at submit time (before the child has filled), so the
+    #     stale-continuation guard catches a child whose target position
+    #     was closed by a separate exit before either OCO leg fired.
+    # Used by ``process_bar``'s stale-continuation guard to drop orders
+    # whose original target position has been closed *or* replaced by an
+    # unrelated position on the same symbol — without this, a stale
+    # TWAP/REQUEUE remainder could fire against a brand-new position via
+    # ``_fill_exit`` (#387 review note), or a stale bracket child could
+    # open a new opposite-side position via ``_fill_entry`` (#389 review
+    # note). The guard fires whenever this field is set OR
+    # ``cumulative_filled_qty > 0``.
     working_against_entry_order_id: Optional[str] = None
 
 

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -696,6 +696,15 @@ class OrderBook:
         any pending attached children via ``remove()``'s default
         (``was_filled=False``) lifecycle path so we don't leave orphan
         protective legs in the book.
+
+        For partially-filled bracket parents (``cumulative_filled_qty > 0``)
+        the removal uses ``was_filled=True`` instead, preserving the
+        eligible-parent registration so the simulator can materialize
+        protective legs against the position that the first slice actually
+        opened — see ``FillSimulator.expire_day_orders`` (#389). Without
+        this exception, the position would survive the expiry while the
+        parent's id was already evicted, leaving ``submit_attached``
+        unable to spawn the bracket.
         """
         expired: List[PendingOrder] = []
         for oid in list(self._pending.keys()):
@@ -714,9 +723,15 @@ class OrderBook:
             # Compare date prefix only so intraday timestamps also work.
             if _date_only(anchor) < _date_only(current_date):
                 expired.append(po)
-                # ``remove(was_filled=False)`` evicts the parent from the
-                # eligible-parent set *and* cascades to any pending children.
-                self.remove(oid)
+                # ``was_filled=True`` for partially-filled parents keeps the
+                # eligible-parent registration alive long enough for the
+                # simulator's expiry hook to spawn protective bracket legs;
+                # for un-filled parents the default ``False`` path evicts
+                # the registration and cascade-cancels any pending children
+                # (relevant only when a fully-filled parent's children are
+                # themselves DAY orders, which today's materializer overrides
+                # to ``GTC``).
+                self.remove(oid, was_filled=po.cumulative_filled_qty > 0)
         return expired
 
 

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -529,6 +529,16 @@ class TradingService:
                                     req,
                                     submitted_at=prev_bar.timestamp,
                                     submitted_equity=equity,
+                                    # #389: register the parent as eligible to
+                                    # carry bracket children when the strategy
+                                    # attached protective legs. ``submit_attached``
+                                    # rejects children whose parent isn't in the
+                                    # eligible-parent set; non-bracket entries
+                                    # pay zero overhead (flag is False).
+                                    expect_brackets=(
+                                        req.attached_stop_loss is not None
+                                        or req.attached_take_profit is not None
+                                    ),
                                 )
                                 result.execution_diagnostics.orders_accepted += 1
                                 _record_event(
@@ -836,6 +846,13 @@ class TradingService:
                                 req,
                                 submitted_at=prev_bar.timestamp,
                                 submitted_equity=equity,
+                                # #389: register the parent as eligible to
+                                # carry bracket children when the strategy
+                                # attached protective legs.
+                                expect_brackets=(
+                                    req.attached_stop_loss is not None
+                                    or req.attached_take_profit is not None
+                                ),
                             )
                             result.execution_diagnostics.orders_accepted += 1
                             _record_event(

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -491,11 +491,14 @@ class TradingService:
                         # Skip non-bar events but keep looking.
 
                     if not is_warmup:
-                        # 1) Expire day orders on date change.
+                        # 1) Expire day orders on date change. Routes through
+                        #    ``FillSimulator.expire_day_orders`` so partially-
+                        #    filled bracket parents get protective legs before
+                        #    the parent is dropped (#389).
                         if prev_bar is not None and (
                             cur_bar.timestamp[:10] != prev_bar.timestamp[:10]
                         ):
-                            expired = order_book.expire_day_orders(cur_bar.timestamp)
+                            expired = fill_sim.expire_day_orders(cur_bar)
                             if expired:
                                 result.execution_diagnostics.orders_unfilled += len(expired)
                                 for ex in expired:
@@ -819,9 +822,11 @@ class TradingService:
                 bar_cancels = cancels_by_bar.get(i, [])
 
                 if not is_warmup:
-                    # 1) Expire day orders on date change.
+                    # 1) Expire day orders on date change. See chunked path
+                    #    above — routes through the simulator so brackets on
+                    #    partially-filled parents survive expiry (#389).
                     if prev_bar is not None and (cur_bar.timestamp[:10] != prev_bar.timestamp[:10]):
-                        expired = order_book.expire_day_orders(cur_bar.timestamp)
+                        expired = fill_sim.expire_day_orders(cur_bar)
                         if expired:
                             result.execution_diagnostics.orders_unfilled += len(expired)
                             for ex in expired:

--- a/backend/agents/investment_team/trading_service/strategy/contract.py
+++ b/backend/agents/investment_team/trading_service/strategy/contract.py
@@ -172,6 +172,31 @@ class OrderRequest(BaseModel):
                 "execution engine; see #390 (Trading 5/5 Step 8) for trailing-stop "
                 "runtime support"
             )
+        # ``parent_order_id`` / ``oco_group_id`` are engine-internal: the
+        # bracket materializer in ``FillSimulator`` calls
+        # ``OrderBook.submit_attached`` which clones the request with these
+        # fields cleared before re-running ``validate_prices``, so this
+        # gate doesn't block the engine path. It DOES block strategy code
+        # that tries to set them via ``StrategyContext.submit_order`` — a
+        # bracket child must be created via the engine, not by the strategy
+        # itself, so trapping here keeps the request stream well-formed
+        # and routes a programming error through the structured
+        # ``unsupported_feature`` rejection rather than crashing the run
+        # at ``OrderBook.submit``'s defense-in-depth ``ValueError``.
+        if self.parent_order_id is not None:
+            raise UnsupportedOrderFeatureError(
+                "parent_order_id is engine-internal; bracket children are "
+                "created by the engine via OrderBook.submit_attached. Strategies "
+                "must leave parent_order_id unset and rely on attached_stop_loss "
+                "/ attached_take_profit instead."
+            )
+        if self.oco_group_id is not None:
+            raise UnsupportedOrderFeatureError(
+                "oco_group_id is engine-internal; bracket children are "
+                "created by the engine via OrderBook.submit_attached. Strategies "
+                "must leave oco_group_id unset and rely on attached_stop_loss "
+                "/ attached_take_profit instead."
+            )
         # Shape-consistency checks. Most are currently unreachable because
         # the gates above fire first, but they remain in place so that when
         # each gate is lifted by its corresponding step, the consistency

--- a/backend/agents/investment_team/trading_service/strategy/contract.py
+++ b/backend/agents/investment_team/trading_service/strategy/contract.py
@@ -161,6 +161,17 @@ class OrderRequest(BaseModel):
                 "trailing_stop is not yet supported by the execution engine; "
                 "see #390 (Trading 5/5 Step 8) for runtime support"
             )
+        # Bracket attachments are runtime-supported as of #389, but the
+        # trailing-stop variant of ``StopAttachment`` is still gated until
+        # #390. Reject at submit time rather than silently materializing as
+        # a fixed STOP — that would backtest a different strategy than the
+        # one the author wrote.
+        if self.attached_stop_loss is not None and self.attached_stop_loss.trail_offset is not None:
+            raise UnsupportedOrderFeatureError(
+                "attached_stop_loss.trail_offset is not yet supported by the "
+                "execution engine; see #390 (Trading 5/5 Step 8) for trailing-stop "
+                "runtime support"
+            )
         # Shape-consistency checks. Most are currently unreachable because
         # the gates above fire first, but they remain in place so that when
         # each gate is lifted by its corresponding step, the consistency

--- a/backend/agents/investment_team/trading_service/strategy/contract.py
+++ b/backend/agents/investment_team/trading_service/strategy/contract.py
@@ -151,30 +151,15 @@ class OrderRequest(BaseModel):
         ``unsupported_feature`` failure), not a generic ``ValueError`` that
         the broad ``except`` in ``TradingService`` would silently log-and-drop.
         """
-        # Runtime-support gates. The schema fields below land in this PR (#383)
-        # so callers and Pydantic models compile, but the execution engine does
-        # not yet honor them — that lands in later steps of #379. Until those
-        # steps ship, fail loudly at submission time rather than silently
-        # producing never-filled orders or IOC/FOK that behave like GTC.
+        # Runtime-support gates. The schema fields below land in #383 so
+        # callers and Pydantic models compile, but the execution engine
+        # honors them only as their respective steps of #379 ship. Until
+        # those steps land, fail loudly at submission time rather than
+        # silently producing never-filled orders.
         if self.order_type == OrderType.TRAILING_STOP:
             raise UnsupportedOrderFeatureError(
                 "trailing_stop is not yet supported by the execution engine; "
                 "see #390 (Trading 5/5 Step 8) for runtime support"
-            )
-        if self.attached_stop_loss is not None or self.attached_take_profit is not None:
-            raise UnsupportedOrderFeatureError(
-                "attached_stop_loss / attached_take_profit are not yet materialized "
-                "as bracket children; see #389 (Trading 5/5 Step 7) for runtime support"
-            )
-        if self.parent_order_id is not None:
-            raise UnsupportedOrderFeatureError(
-                "parent_order_id is not yet honored; see #389 (Trading 5/5 Step 7) "
-                "for bracket-child materialization"
-            )
-        if self.oco_group_id is not None:
-            raise UnsupportedOrderFeatureError(
-                "oco_group_id is not yet honored; see #389 (Trading 5/5 Step 7) "
-                "for OCO sibling cancellation"
             )
         # Shape-consistency checks. Most are currently unreachable because
         # the gates above fire first, but they remain in place so that when
@@ -340,12 +325,12 @@ class StrategyContext:
     ) -> str:
         """Submit an order. Returns the strategy-side ``client_order_id``.
 
-        The trailing keyword arguments (``unfilled_policy``,
-        ``attached_stop_loss``, ``attached_take_profit``,
-        ``parent_order_id``, ``oco_group_id``) belong to the partial-fill /
-        bracket / OCO surface introduced in #383. They are accepted by the
-        API but currently raise ``NotImplementedError`` from
-        ``validate_prices`` until the relevant runtime step of #379 lands.
+        The trailing keyword arguments belong to the partial-fill / bracket
+        / OCO surface introduced in #383. ``unfilled_policy`` /
+        ``attached_stop_loss`` / ``attached_take_profit`` are runtime-
+        supported as of #389; ``parent_order_id`` / ``oco_group_id`` are
+        engine-internal (set on bracket children by ``OrderBook.submit_attached``
+        — strategies do not pass them).
         """
         self._next_client_order_id += 1
         cid = f"c{self._next_client_order_id}"


### PR DESCRIPTION
## Summary

This PR implements bracket order (OCO) materialization for the execution engine, enabling traders to submit entry orders with attached stop-loss and take-profit protective legs that are automatically materialized as children orders when the parent entry fills.

## Key Changes

- **Bracket child materialization**: When an entry order with `attached_stop_loss` and/or `attached_take_profit` fills, the engine now automatically submits opposite-side children orders tagged with a shared `oco_group_id` and `parent_order_id`. Children are submitted with `tif=GTC` to survive across sessions and `submitted_at=bar.timestamp` to enforce bar-safety (preventing same-bar fills).

- **OCO sibling cancellation**: When one bracket child (stop-loss or take-profit) fills, the engine automatically cancels its sibling via `oco_cancel_siblings()`, ensuring only one leg of the protective bracket executes.

- **Validation gate removal**: Lifted the `NotImplementedError` gates in `OrderRequest.validate_prices()` for `attached_stop_loss`, `attached_take_profit`, `parent_order_id`, and `oco_group_id` since the engine now supports these fields at runtime.

- **Gateway-level protection**: Added a new mutual-exclusion check in `validate_prices()` to prevent multi-level bracket trees (attachments and `parent_order_id` cannot coexist), and moved the `parent_order_id`/`oco_group_id` rejection from `validate_prices()` to the top-level `OrderBook.submit()` gateway so the engine's internal `submit_attached()` path can wire up brackets.

- **Service-side integration**: Updated `TradingService` to pass `expect_brackets=True` when submitting orders that carry bracket attachments, registering them as eligible parents for child materialization.

- **Comprehensive test coverage**: Added 339 lines of test cases covering all five acceptance criteria:
  1. Entry fill materializes both children with correct shape
  2. Take-profit fill cancels stop-loss sibling
  3. Stop-loss fill cancels take-profit sibling
  4. Unfilled parent (e.g., LIMIT not crossed) produces no children
  5. Children not eligible for fill on same bar as parent entry (bar-safety)
  6. Regression guard for non-bracket orders

## Implementation Details

- Bracket materialization happens in `_fill_entry()` after the parent's terminal fill and remainder handling, ensuring the parent is removed from the book before children are submitted.

- OCO sibling cancellation happens in `_fill_exit()` before the survivor is removed, gated on `cumulative_filled_qty == 0` to fire only once per child on the first fill slice.

- Children are sized to the actual `filled_qty` of the parent entry, supporting partial fills correctly.

- The `oco_group_id` is deterministically derived as `f"oco_{parent_order_id}"` for reliable sibling lookup.

https://claude.ai/code/session_01DDUc7SDYemu3venXQTAC1Q