### PR TITLE
fix(ui): treat health 'healthy' as ok in HealthIndicator

### DIFF
--- a/user-interface/src/app/components/health-indicator/health-indicator.component.spec.ts
+++ b/user-interface/src/app/components/health-indicator/health-indicator.component.spec.ts
@@ -34,4 +34,12 @@ describe('HealthIndicatorComponent', () => {
     c.ngOnInit();
     expect(c.status).toBe('error');
   });
+
+  it('should treat status "healthy" as ok (agent provisioning convention)', () => {
+    const f = TestBed.createComponent(HealthIndicatorComponent);
+    const c = f.componentInstance;
+    c.healthCheck = () => of({ status: 'healthy' });
+    c.ngOnInit();
+    expect(c.status).toBe('ok');
+  });
 });

--- a/user-interface/src/app/components/health-indicator/health-indicator.component.ts
+++ b/user-interface/src/app/components/health-indicator/health-indicator.component.ts
@@ -28,7 +28,10 @@ export class HealthIndicatorComponent implements OnInit {
     if (this.healthCheck) {
       this.healthCheck()
         .pipe(
-          map((r) => (r?.status === 'ok' ? 'ok' : 'error')),
+          map((r) => {
+            const s = (r?.status ?? '').toLowerCase();
+            return s === 'ok' || s === 'healthy' ? 'ok' : 'error';
+          }),
           catchError(() => of('error'))
         )
         .subscribe((s) => {


### PR DESCRIPTION
## Summary

The Agent Provisioning screen (Provisioning & Environments tab in `/agent-console`) displayed **"Agent Provisioning API: Unavailable"** even when the upstream API was healthy.

**Root cause:** `HealthIndicatorComponent` mapped only `status === 'ok'` to the healthy state, but the agent_provisioning_team's `/health` endpoint returns `{"status": "healthy", "service": "agent-provisioning"}` (`backend/agents/agent_provisioning_team/api/main.py:642-645`). Anything other than the literal string `"ok"` fell through to `"error"` → tooltip "Unavailable".

The same bug also silently affected three other dashboards whose backends use the `"healthy"` convention:
- AI Systems (`ai_systems_team/api/main.py:406`)
- Accessibility Audit (`accessibility_audit_team/api/main.py:688`)
- Personal Assistant (`personal_assistant_team/api/main.py:262`)

## Fix

Accept both `"ok"` and `"healthy"` (case-insensitive) in `HealthIndicatorComponent`. Added a regression test for the `"healthy"` case.

## Test plan

- [ ] `npm test` in `user-interface/` (HealthIndicator spec includes new case)
- [ ] Open `/agent-console` → "Provisioning & Environments" tab → verify the indicator shows green "Healthy" instead of "Unavailable" while the agent_provisioning service is up
- [ ] Spot-check AI Systems, Accessibility Audit, Personal Assistant dashboards now show "Healthy"

https://claude.ai/code/session_01A531o7RQtQm3nJKSkduFC7

---
_Generated by [Claude Code](https://claude.ai/code/session_01A531o7RQtQm3nJKSkduFC7)_