### PR TITLE
investment-team: treat unmodelled AND conjuncts + nested helpers as unknown (#448)

### DIFF
--- a/backend/agents/investment_team/strategy_lab/coverage_probe/indicator_probe.py
+++ b/backend/agents/investment_team/strategy_lab/coverage_probe/indicator_probe.py
@@ -956,6 +956,18 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
                 sub = _build_subcond(term, name_periods, name_evaluators)
                 if sub is not None:
                     own_subs.append(sub)
+                elif _compare_is_static_constant(term, name_periods, name_evaluators):
+                    # Statically-decidable comparison whose both
+                    # operands resolved as constants (e.g. ``1 < 2``,
+                    # ``LIMIT == 1`` after ``LIMIT = 1``).
+                    # ``_build_subcond`` returned None because there's
+                    # no data-dependent operand, but the gate is still
+                    # exact — either always-true (no-op) or always-
+                    # false (statically dead). Neither shape narrows
+                    # the recognised mask in a way that would
+                    # invalidate ``COVERAGE_OK``, so don't tag the
+                    # group as unknown.
+                    pass
                 else:
                     # Compare term we couldn't model (e.g. ``self.flag ==
                     # True`` on an opaque attribute). Mark the group as
@@ -1905,6 +1917,34 @@ def _is_constant_literal(node: ast.expr) -> bool:
     don't tag the group as unknown for them.
     """
     return isinstance(node, ast.Constant)
+
+
+def _compare_is_static_constant(
+    node: ast.expr,
+    name_periods: Dict[str, int],
+    name_evaluators: Optional[Dict[str, Callable[[pd.DataFrame], pd.Series]]],
+) -> bool:
+    """True iff ``node`` is a 1-op ``Compare`` whose both operands
+    resolve via :func:`_build_operand` and neither is data-dependent.
+
+    Such comparisons are statically decidable (e.g. ``1 < 2``,
+    ``LIMIT == 1`` after ``LIMIT = 1``) and ``_build_subcond`` returns
+    ``None`` for them precisely because no operand reads the DataFrame.
+    They're not opaque — just constant — so ``_process_if`` should
+    skip them without tagging the group as
+    ``has_unknown_and_conjunct``: the recognised siblings' mask is
+    still exact whether the constant compare is true (no-op gate) or
+    false (predicate is statically dead).
+    """
+    if not isinstance(node, ast.Compare):
+        return False
+    if len(node.ops) != 1 or len(node.comparators) != 1:
+        return False
+    left = _build_operand(node.left, name_periods, name_evaluators)
+    right = _build_operand(node.comparators[0], name_periods, name_evaluators)
+    if left is None or right is None:
+        return False
+    return not (left.data_dependent or right.data_dependent)
 
 
 def _find_strategy_class(tree: ast.AST, on_bar: ast.AST) -> Optional[ast.ClassDef]:

--- a/backend/agents/investment_team/strategy_lab/coverage_probe/indicator_probe.py
+++ b/backend/agents/investment_team/strategy_lab/coverage_probe/indicator_probe.py
@@ -950,10 +950,24 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
             # literals make the predicate dead — also not "unknown
             # narrowing" in the sense the aggregator needs to suppress
             # COVERAGE_OK; the surviving recognised legs simply don't
-            # describe a reachable path. Conservatively skip both:
-            # _build_subcond rejects bare literals (no data-dependent
-            # operand), and we don't want to tag them as unknown.
-            if _is_constant_literal(term):
+            # describe a reachable path.
+            #
+            # Unified static-evaluation skip. ``True`` means the term
+            # is a statically-decidable no-op (literal ``True``,
+            # ``1 < 2``, ``1 + 1 == 2``, ...) — drop it from the
+            # group's recognised set without tagging the group as
+            # unknown. ``False`` was already short-circuited by the
+            # pre-scan above so we don't expect to see it here, but
+            # treating it like ``True`` is safe (the surviving
+            # recognised siblings can't carry the report; the group
+            # will still be empty). ``None`` (un-decidable) falls
+            # through to the regular type dispatch so an
+            # almost-static-but-unevaluable Compare (e.g.
+            # ``(5 % 2 == 0)`` whose ``Mod`` operand isn't in the
+            # constant-folding scope) lands in the unknown-conjunct
+            # path rather than slipping through as a silent no-op.
+            truth = _evaluate_static_predicate(term, name_periods, name_evaluators)
+            if truth is not None:
                 continue
             if isinstance(term, ast.Compare):
                 sym = _symbol_gate(term, name_strings, bar_name)
@@ -972,23 +986,16 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
                 sub = _build_subcond(term, name_periods, name_evaluators)
                 if sub is not None:
                     own_subs.append(sub)
-                elif _compare_is_static_constant(term, name_periods, name_evaluators):
-                    # Statically-decidable comparison whose both
-                    # operands resolved as constants (e.g. ``1 < 2``,
-                    # ``LIMIT == 1`` after ``LIMIT = 1``).
-                    # ``_build_subcond`` returned None because there's
-                    # no data-dependent operand, but the gate is still
-                    # exact — either always-true (no-op) or always-
-                    # false (statically dead). Neither shape narrows
-                    # the recognised mask in a way that would
-                    # invalidate ``COVERAGE_OK``, so don't tag the
-                    # group as unknown.
-                    pass
                 else:
-                    # Compare term we couldn't model (e.g. ``self.flag ==
-                    # True`` on an opaque attribute). Mark the group as
-                    # carrying an unknown conjunct so the aggregator
-                    # treats recognised hits as upper-bound only.
+                    # Compare term we couldn't model. Either an opaque
+                    # comparison (``self.flag == True``) or a static-
+                    # constant compare we couldn't actually fold
+                    # (``_build_operand`` accepted both BinOp operands
+                    # but ``_evaluate_static_predicate`` returned None
+                    # — see its docstring). In both cases the
+                    # recognised siblings' mask is at best an upper
+                    # bound on the real predicate, so tag the group
+                    # as unknown.
                     has_unknown_conjunct = True
                 continue
             # A nested OR inside the top-level AND, e.g.
@@ -1920,47 +1927,48 @@ def _flatten_top_terms(test: ast.expr) -> List[ast.expr]:
     return [test]
 
 
-def _is_constant_literal(node: ast.expr) -> bool:
-    """True iff ``node`` is a bare Python literal whose truthiness is
-    statically decidable (``True``, ``False``, ``None``, numbers,
-    strings, etc.).
-
-    Used by ``_process_if`` to skip statically-decidable AND conjuncts:
-    a literal ``True`` is a no-op gate (recognised siblings' mask is
-    exact in its presence) and a literal ``False`` makes the predicate
-    dead — neither narrows the recognised mask in a way that would
-    invalidate ``COVERAGE_OK`` from the recognised legs alone, so we
-    don't tag the group as unknown for them.
-    """
-    return isinstance(node, ast.Constant)
+_BINOP_FOLDERS: Dict[type, Callable[[float, float], float]] = {
+    ast.Mult: lambda a, b: a * b,
+    ast.Add: lambda a, b: a + b,
+    ast.Sub: lambda a, b: a - b,
+}
 
 
-def _compare_is_static_constant(
+def _static_scalar_value(
     node: ast.expr,
     name_periods: Dict[str, int],
-    name_evaluators: Optional[Dict[str, Callable[[pd.DataFrame], pd.Series]]],
-) -> bool:
-    """True iff ``node`` is a 1-op ``Compare`` whose both operands
-    resolve via :func:`_build_operand` and neither is data-dependent.
+) -> Optional[float]:
+    """Resolve ``node`` to a scalar ``float`` when it's a constant
+    expression, or ``None`` otherwise.
 
-    Such comparisons are statically decidable (e.g. ``1 < 2``,
-    ``LIMIT == 1`` after ``LIMIT = 1``) and ``_build_subcond`` returns
-    ``None`` for them precisely because no operand reads the DataFrame.
-    They're not opaque — just constant — so ``_process_if`` should
-    skip them without tagging the group as
-    ``has_unknown_and_conjunct``: the recognised siblings' mask is
-    still exact whether the constant compare is true (no-op gate) or
-    false (predicate is statically dead).
+    Mirrors the non-data-dependent scope of :func:`_build_operand`
+    (literals, ``USub``, named numeric bindings, and
+    ``Mult``/``Add``/``Sub`` ``BinOp`` chains over the same), so
+    :func:`_evaluate_static_predicate` can actually fold every
+    constant-only comparison that ``_build_operand`` would accept.
+    Without arithmetic ``BinOp`` folding, ``(1 + 1 == 3)`` was
+    rejected by :func:`_numeric_literal` and slipped through as an
+    "accepted but unevaluable" no-op skip even though the real
+    comparison is statically false.
     """
-    if not isinstance(node, ast.Compare):
-        return False
-    if len(node.ops) != 1 or len(node.comparators) != 1:
-        return False
-    left = _build_operand(node.left, name_periods, name_evaluators)
-    right = _build_operand(node.comparators[0], name_periods, name_evaluators)
-    if left is None or right is None:
-        return False
-    return not (left.data_dependent or right.data_dependent)
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        inner = _static_scalar_value(node.operand, name_periods)
+        if inner is None:
+            return None
+        return -inner
+    if isinstance(node, ast.BinOp):
+        folder = _BINOP_FOLDERS.get(type(node.op))
+        if folder is None:
+            return None
+        left = _static_scalar_value(node.left, name_periods)
+        right = _static_scalar_value(node.right, name_periods)
+        if left is None or right is None:
+            return None
+        try:
+            return float(folder(left, right))
+        except Exception:  # noqa: BLE001
+            return None
+    return _numeric_literal(node, name_periods)
 
 
 _STATIC_CMP_OPS: Dict[type, Callable[[float, float], bool]] = {
@@ -1984,26 +1992,33 @@ def _evaluate_static_predicate(
     Recognised shapes:
       - bare ``ast.Constant`` — Python's truthiness on the literal
         value (``False``/``None``/``0``/``""`` → False, everything
-        else → True)
-      - 1-op static-constant ``Compare`` (e.g. ``1 < 2``,
-        ``LIMIT == 1``) — both operands resolve via
-        :func:`_numeric_literal` and the op is applied directly.
+        else → True).
+      - 1-op ``Compare`` whose both operands resolve via
+        :func:`_static_scalar_value` (literals, ``USub``, named
+        numeric bindings, and arithmetic ``BinOp`` chains over the
+        same). The op is then applied directly on the folded scalars.
 
-    Used by ``_process_if`` to short-circuit the AND chain when any
-    term evaluates to ``False`` — the predicate is then unreachable
-    and must not be allowed to emit positive-evidence groups built
-    from the surviving recognised siblings.
+    Used by ``_process_if`` to (a) short-circuit the AND chain when
+    any term evaluates to ``False`` (predicate unreachable, recurse
+    into ``orelse`` only), and (b) silently skip ``True`` terms as
+    no-op gates. Returning ``None`` for any other shape — including a
+    constant-only Compare we couldn't actually fold (e.g. one whose
+    operands escape :func:`_static_scalar_value`'s constant-folding
+    scope) — sends the term through the unknown-conjunct path so the
+    aggregator treats recognised siblings' hits as upper-bound only,
+    rather than silently dropping the term as if it were a no-op.
     """
     if isinstance(node, ast.Constant):
         try:
             return bool(node.value)
         except Exception:  # noqa: BLE001
             return None
-    if not _compare_is_static_constant(node, name_periods, name_evaluators):
+    if not isinstance(node, ast.Compare):
         return None
-    # Both operands resolve to numeric literals; apply the op directly.
-    left_val = _numeric_literal(node.left, name_periods)
-    right_val = _numeric_literal(node.comparators[0], name_periods)
+    if len(node.ops) != 1 or len(node.comparators) != 1:
+        return None
+    left_val = _static_scalar_value(node.left, name_periods)
+    right_val = _static_scalar_value(node.comparators[0], name_periods)
     if left_val is None or right_val is None:
         return None
     op_fn = _STATIC_CMP_OPS.get(type(node.ops[0]))

--- a/backend/agents/investment_team/strategy_lab/coverage_probe/indicator_probe.py
+++ b/backend/agents/investment_team/strategy_lab/coverage_probe/indicator_probe.py
@@ -165,6 +165,17 @@ class _Group:
     # group: with an unmodelled alternative present we can't prove
     # the OR is unreachable, so flagging would be a false positive.
     has_unknown_or_leg: bool = False
+    # True when at least one top-level AND-conjunct in this group's
+    # source predicate could not be statically modelled (e.g.
+    # ``if close > 0 and self.custom_ok(bar):`` — the second conjunct
+    # is dropped). The recognised legs' mask is then only a SUPERSET
+    # of the real predicate, so the aggregator must not conclude
+    # ``COVERAGE_OK`` from the recognised legs firing alone — the
+    # un-modelled conjunct may still narrow the actual predicate to
+    # zero. Mirrors ``has_unknown_or_leg`` but with the opposite
+    # polarity: AND with an unknown conjunct widens the recognised
+    # mask, OR with an unknown alternative also widens it.
+    has_unknown_and_conjunct: bool = False
 
 
 def run_indicator_probe(
@@ -626,13 +637,25 @@ def _aggregate(
             **base_kwargs,
         )
 
-    # Final fallthrough check: if every group with an unknown OR leg
-    # has zero recognised firing legs and zero conjunction hits, we
-    # have no positive evidence the predicate fires — only an
-    # un-modellable alternative that *might*. Return
-    # ``UNKNOWN_LOW_COVERAGE`` rather than ``COVERAGE_OK`` so a sparse
-    # / zero-trade backtest isn't mislabelled "healthy" when the
-    # probe genuinely doesn't know.
+    # Final fallthrough check: if every group with an unknown leg /
+    # alternative / conjunct has produced no positive recognised
+    # evidence, we have no positive evidence the predicate fires —
+    # only an un-modellable component that *might* (OR-unknown) or
+    # *might not* (AND-unknown). Return ``UNKNOWN_LOW_COVERAGE``
+    # rather than ``COVERAGE_OK`` so a sparse / zero-trade backtest
+    # isn't mislabelled "healthy" when the probe genuinely doesn't
+    # know.
+    #
+    # Polarity differs by unknown kind:
+    #   - OR-leg / nested-OR unknown: an unknown alternative widens
+    #     the recognised mask. Recognised conjunction firing is
+    #     still sound positive evidence — the predicate fires at
+    #     least at those bars, possibly more.
+    #   - AND-conjunct unknown: an unknown conjunct narrows the
+    #     recognised mask. The recognised AND is only a SUPERSET of
+    #     the real predicate, so its conjunction firing does NOT
+    #     prove the real predicate fires. Such a group cannot
+    #     contribute positive evidence on its own.
     base = 0
     has_unknown_evidence = False
     has_recognised_evidence = False
@@ -642,16 +665,23 @@ def _aggregate(
             base += legs
             continue
         leg_hits = [sub_hit_counts[base + k] for k in range(legs)]
-        group_unknown = group.has_unknown_or_leg or any(
+        group_or_unknown = group.has_unknown_or_leg or any(
             group.subconds[k].has_unknown_leg for k in range(legs)
         )
+        group_and_unknown = group.has_unknown_and_conjunct
+        group_unknown = group_or_unknown or group_and_unknown
         if group_unknown:
             has_unknown_evidence = True
-            # Did any recognised leg fire AND the group's overall
-            # conjunction land on at least one bar? If so we have
-            # positive coverage signal even with the unknown
-            # alternative, so the report can stay COVERAGE_OK.
-            if group_conjunction_hits[group_idx] > 0 and any(h > 0 for h in leg_hits):
+            if group_and_unknown:
+                # AND-conjunct unknown: recognised mask is a superset
+                # of the real predicate. Conjunction hits only bound
+                # the real predicate from above and cannot supply
+                # positive evidence — skip without contributing.
+                pass
+            elif group_conjunction_hits[group_idx] > 0 and any(h > 0 for h in leg_hits):
+                # OR-side unknown only: a recognised alternative
+                # firing is sufficient positive evidence because the
+                # unknown alternative can only widen the disjunction.
                 has_recognised_evidence = True
         else:
             # Group has no unknown legs and got past the blocker
@@ -880,6 +910,11 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
 
         own_subs: List[_Subcond] = []
         own_symbols: Optional[set] = None
+        # Track whether any AND-conjunct could not be statically modelled.
+        # When set, the recognised mask is a SUPERSET of the real
+        # predicate so the aggregator must not conclude ``COVERAGE_OK``
+        # from the recognised legs alone — see ``_Group.has_unknown_and_conjunct``.
+        has_unknown_conjunct = False
         for term in _flatten_top_terms(test):
             if isinstance(term, ast.Compare):
                 sym = _symbol_gate(term, name_strings, bar_name)
@@ -898,6 +933,12 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
                 sub = _build_subcond(term, name_periods, name_evaluators)
                 if sub is not None:
                     own_subs.append(sub)
+                else:
+                    # Compare term we couldn't model (e.g. ``self.flag ==
+                    # True`` on an opaque attribute). Mark the group as
+                    # carrying an unknown conjunct so the aggregator
+                    # treats recognised hits as upper-bound only.
+                    has_unknown_conjunct = True
                 continue
             # A nested OR inside the top-level AND, e.g.
             # ``if close > 0 and (volume < 0 or close < -1):`` — flatten
@@ -931,6 +972,12 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
                             own_symbols = set(or_compound.target_symbols)
                         else:
                             own_symbols &= or_compound.target_symbols
+                else:
+                    # Couldn't model any leg of the inner OR — the whole
+                    # disjunction is opaque. Treat it as an unknown
+                    # conjunct so a sibling ``close > 0`` doesn't carry
+                    # the group to ``COVERAGE_OK`` on its own.
+                    has_unknown_conjunct = True
                 continue
             # Truthiness term — ``bool(x)`` or a bare ``Name`` referencing
             # a precomputed indicator. Required for the ideation/codegen
@@ -942,20 +989,45 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
             truthy = _build_truthy_subcond(term, name_periods, name_evaluators)
             if truthy is not None:
                 own_subs.append(truthy)
+            else:
+                # Un-modellable term (e.g. ``self.custom_ok(bar)``,
+                # ``some_function()``, attribute lookup that isn't a
+                # known indicator series). Tag the group so the
+                # aggregator knows the recognised mask is only a
+                # superset of the real predicate.
+                has_unknown_conjunct = True
 
         effective_symbols = _intersect_symbols(ancestor_symbols, own_symbols)
 
         group_subs: List[_Subcond] = []
         if not _budgeted_extend(group_subs, ancestors):
             if group_subs:
-                groups.append(_Group(subconds=group_subs, target_symbols=effective_symbols))
+                groups.append(
+                    _Group(
+                        subconds=group_subs,
+                        target_symbols=effective_symbols,
+                        has_unknown_and_conjunct=has_unknown_conjunct,
+                    )
+                )
             return False
         if not _budgeted_extend(group_subs, own_subs):
             if group_subs:
-                groups.append(_Group(subconds=group_subs, target_symbols=effective_symbols))
+                groups.append(
+                    _Group(
+                        subconds=group_subs,
+                        target_symbols=effective_symbols,
+                        has_unknown_and_conjunct=has_unknown_conjunct,
+                    )
+                )
             return False
         if group_subs and not (effective_symbols is not None and not effective_symbols):
-            groups.append(_Group(subconds=group_subs, target_symbols=effective_symbols))
+            groups.append(
+                _Group(
+                    subconds=group_subs,
+                    target_symbols=effective_symbols,
+                    has_unknown_and_conjunct=has_unknown_conjunct,
+                )
+            )
         if not _visit(body, ancestors + own_subs, effective_symbols):
             return False
         if not _visit(orelse, ancestors, ancestor_symbols):
@@ -1185,8 +1257,24 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
                     ):
                         return False
                 else:
+                    # Skip nested function / class bodies — they only
+                    # execute if explicitly invoked, and we don't model
+                    # arbitrary calls. Without this guard a local
+                    # helper such as ``def debug_helper(): if close <
+                    # 0: ...`` defined inside ``on_bar`` would have its
+                    # ``if`` predicates analysed as if they were on the
+                    # entry path, producing spurious
+                    # ``INDICATOR_FILTER_TOO_RESTRICTIVE`` blockers
+                    # from dead helper code. ``ClassDef`` is included
+                    # for symmetry — a strategy-defined inner class's
+                    # methods don't run on the entry path either.
+                    if isinstance(
+                        stmt,
+                        (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef),
+                    ):
+                        continue
                     # Descend into compound statements (For, While, With,
-                    # Try, FunctionDef body) but pass through ancestors so
+                    # Try) but pass through ancestors so
                     # ``for x in ...: if close > 100: ...`` still inherits
                     # nothing, which is correct.
                     for field in _BLOCK_FIELDS:

--- a/backend/agents/investment_team/strategy_lab/coverage_probe/indicator_probe.py
+++ b/backend/agents/investment_team/strategy_lab/coverage_probe/indicator_probe.py
@@ -919,6 +919,22 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
         if isinstance(test, ast.BoolOp) and isinstance(test.op, ast.Or):
             return _process_or_if(test, body, orelse, ancestors, ancestor_symbols, ancestor_unknown)
 
+        # Statically-unreachable AND short-circuit. If any conjunct is
+        # a literal-falsy ``Constant`` (``False`` / ``0`` / ``None`` /
+        # ``""``) or a statically-false ``Compare`` (e.g. ``1 < 0``,
+        # ``LIMIT == 0`` after ``LIMIT = 1``), the whole predicate is
+        # unreachable. Emitting a group from the surviving recognised
+        # siblings would let them carry the report to ``COVERAGE_OK``
+        # even though no bar can satisfy the real entry path. Skip
+        # body recursion entirely; ``orelse`` runs unconditionally so
+        # we still recurse into it.
+        for term in _flatten_top_terms(test):
+            truth = _evaluate_static_predicate(term, name_periods, name_evaluators)
+            if truth is False:
+                if not _visit(orelse, ancestors, ancestor_symbols, ancestor_unknown):
+                    return False
+                return True
+
         own_subs: List[_Subcond] = []
         own_symbols: Optional[set] = None
         # Track whether any AND-conjunct could not be statically modelled.
@@ -1945,6 +1961,58 @@ def _compare_is_static_constant(
     if left is None or right is None:
         return False
     return not (left.data_dependent or right.data_dependent)
+
+
+_STATIC_CMP_OPS: Dict[type, Callable[[float, float], bool]] = {
+    ast.Lt: lambda a, b: a < b,
+    ast.LtE: lambda a, b: a <= b,
+    ast.Gt: lambda a, b: a > b,
+    ast.GtE: lambda a, b: a >= b,
+    ast.Eq: lambda a, b: a == b,
+    ast.NotEq: lambda a, b: a != b,
+}
+
+
+def _evaluate_static_predicate(
+    node: ast.expr,
+    name_periods: Dict[str, int],
+    name_evaluators: Optional[Dict[str, Callable[[pd.DataFrame], pd.Series]]],
+) -> Optional[bool]:
+    """Return ``True`` / ``False`` when ``node`` is a statically-decidable
+    boolean term, ``None`` otherwise.
+
+    Recognised shapes:
+      - bare ``ast.Constant`` — Python's truthiness on the literal
+        value (``False``/``None``/``0``/``""`` → False, everything
+        else → True)
+      - 1-op static-constant ``Compare`` (e.g. ``1 < 2``,
+        ``LIMIT == 1``) — both operands resolve via
+        :func:`_numeric_literal` and the op is applied directly.
+
+    Used by ``_process_if`` to short-circuit the AND chain when any
+    term evaluates to ``False`` — the predicate is then unreachable
+    and must not be allowed to emit positive-evidence groups built
+    from the surviving recognised siblings.
+    """
+    if isinstance(node, ast.Constant):
+        try:
+            return bool(node.value)
+        except Exception:  # noqa: BLE001
+            return None
+    if not _compare_is_static_constant(node, name_periods, name_evaluators):
+        return None
+    # Both operands resolve to numeric literals; apply the op directly.
+    left_val = _numeric_literal(node.left, name_periods)
+    right_val = _numeric_literal(node.comparators[0], name_periods)
+    if left_val is None or right_val is None:
+        return None
+    op_fn = _STATIC_CMP_OPS.get(type(node.ops[0]))
+    if op_fn is None:
+        return None
+    try:
+        return bool(op_fn(left_val, right_val))
+    except Exception:  # noqa: BLE001
+        return None
 
 
 def _find_strategy_class(tree: ast.AST, on_bar: ast.AST) -> Optional[ast.ClassDef]:

--- a/backend/agents/investment_team/strategy_lab/coverage_probe/indicator_probe.py
+++ b/backend/agents/investment_team/strategy_lab/coverage_probe/indicator_probe.py
@@ -897,16 +897,27 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
         orelse: List[ast.stmt],
         ancestors: List[_Subcond],
         ancestor_symbols: Optional[set],
+        ancestor_unknown: bool,
     ) -> bool:
         """Process a single if-shape (test + body + orelse) given an
         ancestor stack. Used both for real ``ast.If`` statements and for
         synthesised ifs after stripping a position-gate conjunct.
+
+        ``ancestor_unknown`` is True when any enclosing ``if`` test had
+        an un-modellable AND conjunct. Body recursion inherits the flag
+        because the descendant predicate only fires when the unknown
+        ancestor conjunct is also true; the descendant group's
+        recognised mask is therefore still only an upper bound. Without
+        this, ``if close > 0 and self.custom_ok(bar): if volume > 0:
+        ...`` would emit a clean nested group whose recognised legs
+        carried the report to ``COVERAGE_OK`` even though the unknown
+        ancestor could narrow it to zero.
         """
         # Top-level OR predicate: each leg becomes an independent
         # subcondition row but the group's blocker classification uses
         # disjunction (only too-restrictive when ALL legs are zero).
         if isinstance(test, ast.BoolOp) and isinstance(test.op, ast.Or):
-            return _process_or_if(test, body, orelse, ancestors, ancestor_symbols)
+            return _process_or_if(test, body, orelse, ancestors, ancestor_symbols, ancestor_unknown)
 
         own_subs: List[_Subcond] = []
         own_symbols: Optional[set] = None
@@ -916,6 +927,18 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
         # from the recognised legs alone — see ``_Group.has_unknown_and_conjunct``.
         has_unknown_conjunct = False
         for term in _flatten_top_terms(test):
+            # Statically-true literal conjunct (``True``, non-zero
+            # number, non-empty string, etc.) is a no-op AND-gate. The
+            # recognised siblings' mask is exact in its presence, so
+            # don't taint the group as unknown. Statically-false
+            # literals make the predicate dead — also not "unknown
+            # narrowing" in the sense the aggregator needs to suppress
+            # COVERAGE_OK; the surviving recognised legs simply don't
+            # describe a reachable path. Conservatively skip both:
+            # _build_subcond rejects bare literals (no data-dependent
+            # operand), and we don't want to tag them as unknown.
+            if _is_constant_literal(term):
+                continue
             if isinstance(term, ast.Compare):
                 sym = _symbol_gate(term, name_strings, bar_name)
                 if sym is not None:
@@ -998,6 +1021,13 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
                 has_unknown_conjunct = True
 
         effective_symbols = _intersect_symbols(ancestor_symbols, own_symbols)
+        # Effective unknown narrowing for groups emitted at this level:
+        # the union of any inherited unknown ancestor and a locally-
+        # detected unknown conjunct. Body recursion uses the same flag
+        # so descendants remain tainted; orelse uses the bare inherited
+        # value because the negation of an unknown isn't an unknown
+        # gate on the orelse path.
+        effective_unknown = ancestor_unknown or has_unknown_conjunct
 
         group_subs: List[_Subcond] = []
         if not _budgeted_extend(group_subs, ancestors):
@@ -1006,7 +1036,7 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
                     _Group(
                         subconds=group_subs,
                         target_symbols=effective_symbols,
-                        has_unknown_and_conjunct=has_unknown_conjunct,
+                        has_unknown_and_conjunct=effective_unknown,
                     )
                 )
             return False
@@ -1016,7 +1046,7 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
                     _Group(
                         subconds=group_subs,
                         target_symbols=effective_symbols,
-                        has_unknown_and_conjunct=has_unknown_conjunct,
+                        has_unknown_and_conjunct=effective_unknown,
                     )
                 )
             return False
@@ -1025,12 +1055,12 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
                 _Group(
                     subconds=group_subs,
                     target_symbols=effective_symbols,
-                    has_unknown_and_conjunct=has_unknown_conjunct,
+                    has_unknown_and_conjunct=effective_unknown,
                 )
             )
-        if not _visit(body, ancestors + own_subs, effective_symbols):
+        if not _visit(body, ancestors + own_subs, effective_symbols, effective_unknown):
             return False
-        if not _visit(orelse, ancestors, ancestor_symbols):
+        if not _visit(orelse, ancestors, ancestor_symbols, ancestor_unknown):
             return False
         return True
 
@@ -1040,6 +1070,7 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
         orelse: List[ast.stmt],
         ancestors: List[_Subcond],
         ancestor_symbols: Optional[set],
+        ancestor_unknown: bool,
     ) -> bool:
         """Process ``if A or B or C:`` — each leg becomes an independent
         subcondition row, classified disjunctively at aggregation time.
@@ -1054,6 +1085,12 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
 
         ``orelse`` recursion remains bare-ancestor (consistent with the
         AND path).
+
+        ``ancestor_unknown`` (an inherited AND-side unknown narrowing,
+        not the OR-side leg uncertainty) is propagated unchanged to
+        body and orelse: an OR test does not introduce its own AND
+        narrowing, so descendants only inherit what was already in
+        place at this node's entry.
         """
         own_subs: List[_Subcond] = []
         # Track legs we couldn't statically model (e.g. an unrecognised
@@ -1116,9 +1153,9 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
         if not own_subs:
             # No recognised legs — fall through to body / orelse without
             # emitting a group, so nested ``if`` analysis still runs.
-            if not _visit(body, ancestors, ancestor_symbols):
+            if not _visit(body, ancestors, ancestor_symbols, ancestor_unknown):
                 return False
-            if not _visit(orelse, ancestors, ancestor_symbols):
+            if not _visit(orelse, ancestors, ancestor_symbols, ancestor_unknown):
                 return False
             return True
 
@@ -1136,6 +1173,7 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
                         target_symbols=ancestor_symbols,
                         combinator="and",
                         ancestor_count=len(group_subs),
+                        has_unknown_and_conjunct=ancestor_unknown,
                     )
                 )
             return False
@@ -1149,6 +1187,7 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
                         combinator="or",
                         ancestor_count=ancestor_count,
                         has_unknown_or_leg=has_unknown_leg,
+                        has_unknown_and_conjunct=ancestor_unknown,
                     )
                 )
             return False
@@ -1160,12 +1199,13 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
                     combinator="or",
                     ancestor_count=ancestor_count,
                     has_unknown_or_leg=has_unknown_leg,
+                    has_unknown_and_conjunct=ancestor_unknown,
                 )
             )
         # Body sees no extra ancestors — see docstring.
-        if not _visit(body, ancestors, ancestor_symbols):
+        if not _visit(body, ancestors, ancestor_symbols, ancestor_unknown):
             return False
-        if not _visit(orelse, ancestors, ancestor_symbols):
+        if not _visit(orelse, ancestors, ancestor_symbols, ancestor_unknown):
             return False
         return True
 
@@ -1173,6 +1213,7 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
         stmts: List[ast.stmt],
         ancestors: List[_Subcond],
         ancestor_symbols: Optional[set],
+        ancestor_unknown: bool = False,
     ) -> bool:
         # Transactional: snapshot at entry, restore at exit. Each call
         # to _visit (including the recursive descents from _process_if /
@@ -1226,7 +1267,7 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
                     position_check, gate_residual = _strip_position_gate(stmt.test)
                     if position_check == "vacant":  # pos is None — body is entry
                         if gate_residual is None:
-                            if not _visit(stmt.body, ancestors, current_symbols):
+                            if not _visit(stmt.body, ancestors, current_symbols, ancestor_unknown):
                                 return False
                             # Vacant guard-clause: ``if pos is None:
                             # return`` (or any single ``return``).
@@ -1244,16 +1285,22 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
                                 [],
                                 ancestors,
                                 current_symbols,
+                                ancestor_unknown,
                             ):
                                 return False
                         continue
                     if position_check == "occupied":  # pos is not None — orelse is entry
-                        if not _visit(stmt.orelse, ancestors, current_symbols):
+                        if not _visit(stmt.orelse, ancestors, current_symbols, ancestor_unknown):
                             return False
                         continue
 
                     if not _process_if(
-                        stmt.test, stmt.body, stmt.orelse, ancestors, current_symbols
+                        stmt.test,
+                        stmt.body,
+                        stmt.orelse,
+                        ancestors,
+                        current_symbols,
+                        ancestor_unknown,
                     ):
                         return False
                 else:
@@ -1280,7 +1327,7 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
                     for field in _BLOCK_FIELDS:
                         inner = getattr(stmt, field, None)
                         if isinstance(inner, list) and inner and isinstance(inner[0], ast.stmt):
-                            if not _visit(inner, ancestors, current_symbols):
+                            if not _visit(inner, ancestors, current_symbols, ancestor_unknown):
                                 return False
                     # ast.Try has handlers; each handler.body is a stmt list.
                     handlers = getattr(stmt, "handlers", None)
@@ -1288,7 +1335,7 @@ def _extract_subconditions(strategy_code: str) -> List[_Group]:
                         for h in handlers:
                             h_body = getattr(h, "body", None)
                             if isinstance(h_body, list) and h_body:
-                                if not _visit(h_body, ancestors, current_symbols):
+                                if not _visit(h_body, ancestors, current_symbols, ancestor_unknown):
                                     return False
             return True
         finally:
@@ -1843,6 +1890,21 @@ def _flatten_top_terms(test: ast.expr) -> List[ast.expr]:
             out.extend(_flatten_top_terms(value))
         return out
     return [test]
+
+
+def _is_constant_literal(node: ast.expr) -> bool:
+    """True iff ``node`` is a bare Python literal whose truthiness is
+    statically decidable (``True``, ``False``, ``None``, numbers,
+    strings, etc.).
+
+    Used by ``_process_if`` to skip statically-decidable AND conjuncts:
+    a literal ``True`` is a no-op gate (recognised siblings' mask is
+    exact in its presence) and a literal ``False`` makes the predicate
+    dead — neither narrows the recognised mask in a way that would
+    invalidate ``COVERAGE_OK`` from the recognised legs alone, so we
+    don't tag the group as unknown for them.
+    """
+    return isinstance(node, ast.Constant)
 
 
 def _find_strategy_class(tree: ast.AST, on_bar: ast.AST) -> Optional[ast.ClassDef]:

--- a/backend/agents/investment_team/tests/test_indicator_probe_robustness.py
+++ b/backend/agents/investment_team/tests/test_indicator_probe_robustness.py
@@ -4839,3 +4839,115 @@ def test_named_constant_compare_does_not_taint_group() -> None:
         market_data={"AAPL": _flat_ohlcv()},
     )
     assert report.coverage_category is CoverageCategory.COVERAGE_OK
+
+
+def test_literal_false_and_conjunct_makes_predicate_unreachable() -> None:
+    """A statically-false literal AND-conjunct (``and False``) makes
+    the entire predicate unreachable. The recognised siblings'
+    ``close > 0`` mask must NOT be allowed to carry the report to
+    ``COVERAGE_OK`` — the real entry path is dead.
+
+    With no live ``if`` predicates anywhere in ``on_bar``, the probe
+    has no recognised indicator subconditions to score and must
+    classify as ``UNKNOWN_LOW_COVERAGE``.
+    """
+    code = textwrap.dedent(
+        """
+        class S:
+            def on_bar(self, ctx, bar):
+                if close > 0 and False:
+                    pass
+        """
+    )
+    report = run_indicator_probe(
+        strategy_code=code,
+        market_data={"AAPL": _flat_ohlcv()},
+    )
+    assert report.coverage_category is CoverageCategory.UNKNOWN_LOW_COVERAGE
+
+
+def test_static_false_compare_makes_predicate_unreachable() -> None:
+    """A statically-false constant comparison (``1 < 0``) is the
+    Compare-shaped analogue of ``and False`` — same short-circuit
+    rule applies.
+    """
+    code = textwrap.dedent(
+        """
+        class S:
+            def on_bar(self, ctx, bar):
+                if close > 0 and 1 < 0:
+                    pass
+        """
+    )
+    report = run_indicator_probe(
+        strategy_code=code,
+        market_data={"AAPL": _flat_ohlcv()},
+    )
+    assert report.coverage_category is CoverageCategory.UNKNOWN_LOW_COVERAGE
+
+
+def test_static_false_named_constant_compare_makes_predicate_unreachable() -> None:
+    """The named-constant variant: a module-level ``LIMIT = 1``
+    paired with ``LIMIT == 0`` is statically false and must take the
+    unreachable short-circuit path.
+    """
+    code = textwrap.dedent(
+        """
+        LIMIT = 1
+
+        class S:
+            def on_bar(self, ctx, bar):
+                if close > 0 and LIMIT == 0:
+                    pass
+        """
+    )
+    report = run_indicator_probe(
+        strategy_code=code,
+        market_data={"AAPL": _flat_ohlcv()},
+    )
+    assert report.coverage_category is CoverageCategory.UNKNOWN_LOW_COVERAGE
+
+
+def test_static_false_conjunct_does_not_block_sibling_predicate() -> None:
+    """A dead ``if close > 0 and False:`` next to a live
+    ``if close > 0:`` must not poison the live predicate's report.
+    The live entry path still produces ``COVERAGE_OK``.
+    """
+    code = textwrap.dedent(
+        """
+        class S:
+            def on_bar(self, ctx, bar):
+                if close > 0 and False:
+                    pass
+                if close > 0:
+                    pass
+        """
+    )
+    report = run_indicator_probe(
+        strategy_code=code,
+        market_data={"AAPL": _flat_ohlcv()},
+    )
+    assert report.coverage_category is CoverageCategory.COVERAGE_OK
+
+
+def test_static_false_conjunct_routes_to_orelse() -> None:
+    """An ``if X and False: ... else: <live entry>`` must still pick
+    up the live entry from the orelse branch — it's the always-taken
+    path.
+    """
+    code = textwrap.dedent(
+        """
+        class S:
+            def on_bar(self, ctx, bar):
+                if close > 0 and False:
+                    pass
+                else:
+                    if close > 0:
+                        pass
+        """
+    )
+    report = run_indicator_probe(
+        strategy_code=code,
+        market_data={"AAPL": _flat_ohlcv()},
+    )
+    assert report.coverage_category is CoverageCategory.COVERAGE_OK

--- a/backend/agents/investment_team/tests/test_indicator_probe_robustness.py
+++ b/backend/agents/investment_team/tests/test_indicator_probe_robustness.py
@@ -4951,3 +4951,73 @@ def test_static_false_conjunct_routes_to_orelse() -> None:
         market_data={"AAPL": _flat_ohlcv()},
     )
     assert report.coverage_category is CoverageCategory.COVERAGE_OK
+
+
+def test_static_false_arithmetic_compare_is_unreachable() -> None:
+    """A constant-only ``Compare`` whose operands are arithmetic
+    ``BinOp`` expressions (e.g. ``1 + 1 == 3``) must be evaluated, not
+    silently dropped. Previously ``_compare_is_static_constant``
+    accepted it (``_build_operand`` folds ``BinOp`` of constants) but
+    ``_evaluate_static_predicate`` couldn't fold the ``BinOp`` and
+    returned ``None``, so the term slipped through as a no-op skip
+    and the surviving ``close > 0`` reported ``COVERAGE_OK``. The
+    arithmetic-folding scalar resolver now sees ``1 + 1 == 3`` as
+    statically false, the AND short-circuits, and the predicate is
+    reported unreachable.
+    """
+    code = textwrap.dedent(
+        """
+        class S:
+            def on_bar(self, ctx, bar):
+                if close > 0 and (1 + 1 == 3):
+                    pass
+        """
+    )
+    report = run_indicator_probe(
+        strategy_code=code,
+        market_data={"AAPL": _flat_ohlcv()},
+    )
+    assert report.coverage_category is CoverageCategory.UNKNOWN_LOW_COVERAGE
+
+
+def test_static_true_arithmetic_compare_is_no_op() -> None:
+    """The matching truthy polarity: ``1 + 1 == 2`` is statically
+    true, so the AND-conjunct is a no-op gate and the recognised
+    sibling's mask remains exact — ``COVERAGE_OK`` is correct.
+    """
+    code = textwrap.dedent(
+        """
+        class S:
+            def on_bar(self, ctx, bar):
+                if close > 0 and (1 + 1 == 2):
+                    pass
+        """
+    )
+    report = run_indicator_probe(
+        strategy_code=code,
+        market_data={"AAPL": _flat_ohlcv()},
+    )
+    assert report.coverage_category is CoverageCategory.COVERAGE_OK
+
+
+def test_unfoldable_static_constant_compare_is_unknown() -> None:
+    """A constant-only Compare we genuinely cannot fold (e.g. an
+    ``ast.Mod`` ``BinOp`` operand the static-scalar resolver does not
+    handle) must NOT silently be skipped. The recognised siblings'
+    mask is at best an upper bound on the real predicate, so the
+    aggregator sees the group as unknown-tainted and refuses to use
+    the recognised firing leg as positive evidence.
+    """
+    code = textwrap.dedent(
+        """
+        class S:
+            def on_bar(self, ctx, bar):
+                if close > 0 and (5 % 2 == 0):
+                    pass
+        """
+    )
+    report = run_indicator_probe(
+        strategy_code=code,
+        market_data={"AAPL": _flat_ohlcv()},
+    )
+    assert report.coverage_category is CoverageCategory.UNKNOWN_LOW_COVERAGE

--- a/backend/agents/investment_team/tests/test_indicator_probe_robustness.py
+++ b/backend/agents/investment_team/tests/test_indicator_probe_robustness.py
@@ -4702,3 +4702,93 @@ def test_nested_class_in_on_bar_is_skipped() -> None:
     )
     assert report.coverage_category is CoverageCategory.COVERAGE_OK
     assert len(report.subconditions) == 1
+
+
+def test_unknown_and_conjunct_propagates_to_nested_body() -> None:
+    """An unknown AND conjunct on an outer ``if`` test must taint
+    nested groups — those nested groups only fire when the unknown
+    ancestor conjunct is also true, so their recognised mask is still
+    only an upper bound on the real predicate.
+
+    Without propagation, ``if close > 0 and self.custom_ok(bar):``
+    /``if volume > 0:`` emitted a clean nested group whose
+    ``volume > 0`` + ``close > 0`` ancestor carried the report to
+    ``COVERAGE_OK`` even though ``self.custom_ok`` could narrow the
+    real entry path to zero.
+    """
+    code = textwrap.dedent(
+        """
+        class S:
+            def on_bar(self, ctx, bar):
+                if close > 0 and self.custom_ok(bar):
+                    if volume > 0:
+                        pass
+        """
+    )
+    report = run_indicator_probe(
+        strategy_code=code,
+        market_data={"AAPL": _flat_ohlcv()},
+    )
+    assert report.coverage_category is CoverageCategory.UNKNOWN_LOW_COVERAGE
+
+
+def test_unknown_and_conjunct_propagates_through_or_into_nested_body() -> None:
+    """The OR-wrapped variant: an unknown AND ancestor must still
+    propagate even when an intermediate ``if`` test is an OR, so the
+    deepest nested group inherits the unknown narrowing.
+    """
+    code = textwrap.dedent(
+        """
+        class S:
+            def on_bar(self, ctx, bar):
+                if close > 0 and self.custom_ok(bar):
+                    if volume > 0 or close > 50:
+                        if close > 25:
+                            pass
+        """
+    )
+    report = run_indicator_probe(
+        strategy_code=code,
+        market_data={"AAPL": _flat_ohlcv()},
+    )
+    assert report.coverage_category is CoverageCategory.UNKNOWN_LOW_COVERAGE
+
+
+def test_literal_true_and_conjunct_does_not_taint_group() -> None:
+    """A statically-true literal AND-conjunct (``and True``) is a
+    no-op gate. The recognised siblings' mask is exact, so the
+    aggregator must keep ``COVERAGE_OK`` rather than refusing to use
+    a recognised firing leg as positive evidence.
+    """
+    code = textwrap.dedent(
+        """
+        class S:
+            def on_bar(self, ctx, bar):
+                if close > 0 and True:
+                    pass
+        """
+    )
+    report = run_indicator_probe(
+        strategy_code=code,
+        market_data={"AAPL": _flat_ohlcv()},
+    )
+    assert report.coverage_category is CoverageCategory.COVERAGE_OK
+
+
+def test_literal_truthy_constants_do_not_taint_group() -> None:
+    """Other statically-decidable literal constants (non-zero ints,
+    non-empty strings) follow the same rule as ``True``.
+    """
+    code = textwrap.dedent(
+        """
+        class S:
+            def on_bar(self, ctx, bar):
+                if close > 0 and 1 and "enabled":
+                    pass
+        """
+    )
+    report = run_indicator_probe(
+        strategy_code=code,
+        market_data={"AAPL": _flat_ohlcv()},
+    )
+    assert report.coverage_category is CoverageCategory.COVERAGE_OK

--- a/backend/agents/investment_team/tests/test_indicator_probe_robustness.py
+++ b/backend/agents/investment_team/tests/test_indicator_probe_robustness.py
@@ -4792,3 +4792,50 @@ def test_literal_truthy_constants_do_not_taint_group() -> None:
         market_data={"AAPL": _flat_ohlcv()},
     )
     assert report.coverage_category is CoverageCategory.COVERAGE_OK
+
+
+def test_constant_compare_does_not_taint_group() -> None:
+    """A statically-decidable AND-conjunct comparison (e.g. ``1 < 2``)
+    has no data-dependent operand, so ``_build_subcond`` returns
+    ``None``. That ``None`` previously tainted the group as having an
+    unknown conjunct and demoted the report from ``COVERAGE_OK`` to
+    ``UNKNOWN_LOW_COVERAGE``. The aggregator should keep
+    ``COVERAGE_OK`` because the recognised siblings' mask is still
+    exact.
+    """
+    code = textwrap.dedent(
+        """
+        class S:
+            def on_bar(self, ctx, bar):
+                if close > 0 and 1 < 2:
+                    pass
+        """
+    )
+    report = run_indicator_probe(
+        strategy_code=code,
+        market_data={"AAPL": _flat_ohlcv()},
+    )
+    assert report.coverage_category is CoverageCategory.COVERAGE_OK
+
+
+def test_named_constant_compare_does_not_taint_group() -> None:
+    """The named-constant variant of the above: a module-level
+    ``LIMIT = 1`` resolves through ``name_periods`` so both operands
+    of ``LIMIT == 1`` are constants; the group must stay
+    ``COVERAGE_OK``.
+    """
+    code = textwrap.dedent(
+        """
+        LIMIT = 1
+
+        class S:
+            def on_bar(self, ctx, bar):
+                if close > 0 and LIMIT == 1:
+                    pass
+        """
+    )
+    report = run_indicator_probe(
+        strategy_code=code,
+        market_data={"AAPL": _flat_ohlcv()},
+    )
+    assert report.coverage_category is CoverageCategory.COVERAGE_OK

--- a/backend/agents/investment_team/tests/test_indicator_probe_robustness.py
+++ b/backend/agents/investment_team/tests/test_indicator_probe_robustness.py
@@ -4415,7 +4415,16 @@ def test_positive_symbol_in_allowlist_gates_predicate() -> None:
 
 def test_partial_symbol_in_allowlist_does_not_gate() -> None:
     """An ``in`` allow-list with an unresolvable element refuses to
-    gate (better unconstrained than wrongly constrained)."""
+    gate (better unconstrained than wrongly constrained).
+
+    Because the partial allow-list is dropped from the group as an
+    un-modellable Compare conjunct, the surviving ``close > 100``
+    sub-condition is a SUPERSET of the real predicate. The probe must
+    not flip to ``COVERAGE_OK`` from that recognised leg alone — the
+    dropped allow-list could be narrowing the real predicate to zero.
+    The conservative refuse-to-gate is still the test point; the
+    aggregator now correctly classifies as ``UNKNOWN_LOW_COVERAGE``.
+    """
     code = textwrap.dedent(
         """
         class S:
@@ -4437,10 +4446,7 @@ def test_partial_symbol_in_allowlist_does_not_gate() -> None:
         index=idx,
     )
     report = run_indicator_probe(strategy_code=code, market_data={"GOOG": df})
-    # Gate refused → ``close > 100`` runs against every symbol; GOOG
-    # close=200 satisfies → COVERAGE_OK. (The conservative refuse-to-gate
-    # is the test point; the resulting category isn't the bug.)
-    assert report.coverage_category is CoverageCategory.COVERAGE_OK
+    assert report.coverage_category is CoverageCategory.UNKNOWN_LOW_COVERAGE
 
 
 def test_renamed_bar_param_preserves_symbol_gate() -> None:
@@ -4549,3 +4555,150 @@ def test_bool_call_on_unbound_name_remains_unknown() -> None:
     )
     assert report.coverage_category is CoverageCategory.UNKNOWN_LOW_COVERAGE
     assert report.subconditions == []
+
+
+def test_unmodelled_and_conjunct_demotes_coverage_ok_to_unknown() -> None:
+    """An entry predicate that mixes a recognised indicator/column check
+    with an un-modellable AND conjunct (``self.custom_ok(bar)``) is only
+    bounded from above by the recognised legs: the unknown conjunct may
+    still narrow the predicate to zero. The probe must surface this as
+    ``UNKNOWN_LOW_COVERAGE`` rather than letting ``close > 0`` carry
+    the report to ``COVERAGE_OK``.
+    """
+    code = textwrap.dedent(
+        """
+        class S:
+            def on_bar(self, ctx, bar):
+                if close > 0 and self.custom_ok(bar):
+                    pass
+        """
+    )
+    report = run_indicator_probe(
+        strategy_code=code,
+        market_data={"AAPL": _flat_ohlcv()},
+    )
+    assert report.coverage_category is CoverageCategory.UNKNOWN_LOW_COVERAGE
+
+
+def test_unmodelled_and_conjunct_with_zero_recognised_leg_still_flags() -> None:
+    """An AND group with a never-firing recognised leg AND an unknown
+    conjunct must still flag ``INDICATOR_FILTER_TOO_RESTRICTIVE``: the
+    recognised mask is a superset of the real predicate, so an empty
+    superset proves the real predicate is also empty (subset of
+    empty = empty).
+    """
+    code = textwrap.dedent(
+        """
+        class S:
+            def on_bar(self, ctx, bar):
+                if close < -50 and self.custom_ok(bar):
+                    pass
+        """
+    )
+    report = run_indicator_probe(
+        strategy_code=code,
+        market_data={"AAPL": _flat_ohlcv()},
+    )
+    assert report.coverage_category is CoverageCategory.INDICATOR_FILTER_TOO_RESTRICTIVE
+
+
+def test_unmodelled_and_conjunct_alongside_clean_predicate_stays_ok() -> None:
+    """A separate clean predicate elsewhere in ``on_bar`` provides
+    independent positive evidence. The probe must not over-flag: the
+    presence of *one* group with an unknown AND conjunct should not
+    veto ``COVERAGE_OK`` when another sibling group fires unaided.
+    """
+    code = textwrap.dedent(
+        """
+        class S:
+            def on_bar(self, ctx, bar):
+                if close > 0 and self.custom_ok(bar):
+                    pass
+                if close > 0:
+                    pass
+        """
+    )
+    report = run_indicator_probe(
+        strategy_code=code,
+        market_data={"AAPL": _flat_ohlcv()},
+    )
+    assert report.coverage_category is CoverageCategory.COVERAGE_OK
+
+
+def test_nested_function_in_on_bar_is_skipped() -> None:
+    """A locally-defined helper inside ``on_bar`` must not have its
+    ``if`` predicates analysed as if they ran on the entry path: the
+    helper executes only when explicitly invoked, and the probe doesn't
+    model arbitrary calls. Without this guard a dead-code helper such
+    as ``def debug_helper(): if close < -50: ...`` produced a spurious
+    ``INDICATOR_FILTER_TOO_RESTRICTIVE`` blocker even when the real
+    entry predicate (``if close > 0:``) is satisfied on every bar.
+    """
+    code = textwrap.dedent(
+        """
+        class S:
+            def on_bar(self, ctx, bar):
+                def debug_helper():
+                    if close < -50:
+                        return False
+                    return True
+                if close > 0:
+                    pass
+        """
+    )
+    report = run_indicator_probe(
+        strategy_code=code,
+        market_data={"AAPL": _flat_ohlcv()},
+    )
+    assert report.coverage_category is CoverageCategory.COVERAGE_OK
+    assert len(report.subconditions) == 1
+    assert report.subconditions[0].label == "close > 0"
+
+
+def test_async_nested_function_in_on_bar_is_skipped() -> None:
+    """``AsyncFunctionDef`` shape (``async def`` helpers) must be
+    skipped for the same reason as plain ``FunctionDef``.
+    """
+    code = textwrap.dedent(
+        """
+        class S:
+            def on_bar(self, ctx, bar):
+                async def fetch_helper():
+                    if close < -50:
+                        return False
+                    return True
+                if close > 0:
+                    pass
+        """
+    )
+    report = run_indicator_probe(
+        strategy_code=code,
+        market_data={"AAPL": _flat_ohlcv()},
+    )
+    assert report.coverage_category is CoverageCategory.COVERAGE_OK
+    assert len(report.subconditions) == 1
+
+
+def test_nested_class_in_on_bar_is_skipped() -> None:
+    """A class defined inside ``on_bar`` should not have its method
+    bodies analysed as entry-path predicates either.
+    """
+    code = textwrap.dedent(
+        """
+        class S:
+            def on_bar(self, ctx, bar):
+                class Inner:
+                    def helper(self):
+                        if close < -50:
+                            return False
+                        return True
+                if close > 0:
+                    pass
+        """
+    )
+    report = run_indicator_probe(
+        strategy_code=code,
+        market_data={"AAPL": _flat_ohlcv()},
+    )
+    assert report.coverage_category is CoverageCategory.COVERAGE_OK
+    assert len(report.subconditions) == 1


### PR DESCRIPTION
## Summary

Addresses the two unresolved review comments on #456:

1. **Treat unmodelled AND conjuncts as unknown** ([discussion_r3213748113](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/pull/456#discussion_r3213748113)). When a predicate mixes a recognised indicator/column check with an un-modellable AND conjunct (e.g. `if close > 0 and self.custom_ok(bar):`), the recognised legs' mask is only a SUPERSET of the real predicate. The probe no longer concludes `COVERAGE_OK` from the recognised legs alone for such groups — the un-modellable conjunct could still narrow the actual predicate to zero. `_Group` carries a new `has_unknown_and_conjunct` flag; the COVERAGE_OK fallthrough requires positive evidence from a group with no unknown legs/conjuncts. Zero-hit and `CONJUNCTION_NEVER_TRUE` blockers still fire because a subset of an empty mask is empty.

2. **Skip nested function / class bodies on the entry-path walk** ([discussion_r3213748116](https://github.com/brandonkindred/Khala-Agentic-AI-Teams/pull/456#discussion_r3213748116)). A locally-defined helper inside `on_bar` (`def debug_helper(): if close < -50: ...`) had its `if` predicates analysed as if they ran on every bar, producing spurious `INDICATOR_FILTER_TOO_RESTRICTIVE` blockers from dead helper code. `_visit` now skips `FunctionDef`, `AsyncFunctionDef`, and nested `ClassDef` in the generic compound-statement descent.

Also updated `test_partial_symbol_in_allowlist_does_not_gate` to reflect the new (and more correct) `UNKNOWN_LOW_COVERAGE` outcome — its previous `COVERAGE_OK` assertion was the exact symptom the first comment flagged.

## Test plan

- [x] `pytest agents/investment_team/tests/test_indicator_probe_basic.py agents/investment_team/tests/test_indicator_probe_conjunction.py agents/investment_team/tests/test_indicator_probe_robustness.py agents/investment_team/tests/test_coverage_probe_models.py` — 150 / 150 pass
- [x] Regression: `pytest agents/investment_team/tests/test_strategy_lab_static_probe.py` — 17 / 17 pass
- [x] `ruff check` + `ruff format --check` clean on both touched files
- [ ] CI green on this branch

New regression tests:

- `test_unmodelled_and_conjunct_demotes_coverage_ok_to_unknown`
- `test_unmodelled_and_conjunct_with_zero_recognised_leg_still_flags`
- `test_unmodelled_and_conjunct_alongside_clean_predicate_stays_ok`
- `test_nested_function_in_on_bar_is_skipped`
- `test_async_nested_function_in_on_bar_is_skipped`
- `test_nested_class_in_on_bar_is_skipped`

https://claude.ai/code/session_01AhpQUZULEDD2D7f2mWfHSa

---
_Generated by [Claude Code](https://claude.ai/code/session_01AhpQUZULEDD2D7f2mWfHSa)_