### PR TITLE
investment-team: runtime probe harness wiring + collector (#450)

### DIFF
--- a/backend/agents/investment_team/tests/test_sandbox_compat.py
+++ b/backend/agents/investment_team/tests/test_sandbox_compat.py
@@ -78,10 +78,21 @@ def _empty_metrics() -> BacktestResult:
     )
 
 
-def _patch_run_backtest(monkeypatch, *, service_result: TradingServiceResult) -> None:
-    """Replace ``run_backtest`` with a stub returning a canned service result."""
+def _patch_run_backtest(monkeypatch, *, service_result: TradingServiceResult) -> dict:
+    """Replace ``run_backtest`` with a stub returning a canned service result.
 
-    def _fake(*, strategy, config, market_data=None, **_kwargs):
+    Returns the ``captured`` kwargs dict so #450's threading test can
+    assert that ``coverage_probe_mode`` actually reached ``run_backtest``.
+    Existing callers that ignore the return value remain unaffected.
+    """
+
+    captured: dict[str, object] = {}
+
+    def _fake(*, strategy, config, market_data=None, **kwargs):
+        # Capture the kwargs so individual tests can assert that
+        # ``run_strategy_code`` actually forwarded options like
+        # ``coverage_probe_mode`` to ``run_backtest`` (#450).
+        captured.update(kwargs)
         return BacktestRunResult(
             result=_empty_metrics(),
             trades=service_result.trades,
@@ -89,6 +100,7 @@ def _patch_run_backtest(monkeypatch, *, service_result: TradingServiceResult) ->
         )
 
     monkeypatch.setattr(sandbox_compat, "run_backtest", _fake)
+    return captured  # type: ignore[return-value]
 
 
 # ---------------------------------------------------------------------------
@@ -240,3 +252,143 @@ def test_pre_backtest_value_error_synthesizes_unknown_zero_trade_diagnostics(
     # Counter fields stay at their model defaults — no bars were processed.
     assert result.execution_diagnostics.bars_processed == 0
     assert result.execution_diagnostics.orders_emitted == 0
+
+
+# ---------------------------------------------------------------------------
+# Coverage-probe events propagation (#450)
+# ---------------------------------------------------------------------------
+
+
+def test_probe_events_default_to_none_on_dataclass() -> None:
+    """``StrategyRunResult.probe_events`` is opt-in: every existing
+    construction site that didn't pass the field gets ``None``."""
+    r = sandbox_compat.StrategyRunResult(success=True)
+    assert r.probe_events is None
+
+
+def test_probe_events_propagate_through_success_path(monkeypatch) -> None:
+    """When the service result carries ``probe_events``, the success-path
+    construction in ``run_strategy_code`` must copy them onto the
+    returned ``StrategyRunResult`` (#450)."""
+    diagnostics = BacktestExecutionDiagnostics(
+        summary="clean run, 1 trade",
+        bars_processed=10,
+        closed_trades=1,
+    )
+    payload = {
+        "events": [
+            {"rule_id": "r0", "hit_count": 4, "first_true_bar": 0, "last_true_bar": 9},
+        ],
+        "truncated": False,
+    }
+    _patch_run_backtest(
+        monkeypatch,
+        service_result=TradingServiceResult(
+            trades=[_partial_trade()],
+            execution_diagnostics=diagnostics,
+            probe_events=payload,
+        ),
+    )
+
+    result = sandbox_compat.run_strategy_code(
+        "dummy", {}, _config(), strategy=_strategy(), coverage_probe_mode=True
+    )
+
+    assert result.success is True
+    assert result.probe_events is payload
+
+
+def test_probe_events_propagate_through_runtime_error_path(monkeypatch) -> None:
+    """Probe events also flow on the mid-run-crash path so refinement
+    can still see whatever subconditions did fire before the strategy
+    raised."""
+    partial_payload = {
+        "events": [
+            {"rule_id": "r0", "hit_count": 1, "first_true_bar": 3, "last_true_bar": 3},
+        ],
+        "truncated": False,
+    }
+    _patch_run_backtest(
+        monkeypatch,
+        service_result=TradingServiceResult(
+            trades=[],
+            error="IndexError: list index out of range",
+            lookahead_violation=False,
+            execution_diagnostics=BacktestExecutionDiagnostics(
+                zero_trade_category="UNKNOWN_ZERO_TRADE_PATH",
+                summary="crash mid-run",
+            ),
+            probe_events=partial_payload,
+        ),
+    )
+
+    result = sandbox_compat.run_strategy_code(
+        "dummy", {}, _config(), strategy=_strategy(), coverage_probe_mode=True
+    )
+
+    assert result.success is False
+    assert result.error_type == "runtime_error"
+    assert result.probe_events is partial_payload
+
+
+def test_probe_events_propagate_through_lookahead_path(monkeypatch) -> None:
+    """Same as above for the lookahead-violation path."""
+    payload = {
+        "events": [
+            {"rule_id": "r0", "hit_count": 2, "first_true_bar": 1, "last_true_bar": 5},
+        ],
+        "truncated": False,
+    }
+    _patch_run_backtest(
+        monkeypatch,
+        service_result=TradingServiceResult(
+            trades=[],
+            error="AttributeError: Bar has no 'next_close'",
+            lookahead_violation=True,
+            execution_diagnostics=BacktestExecutionDiagnostics(
+                summary="lookahead detected",
+            ),
+            probe_events=payload,
+        ),
+    )
+
+    result = sandbox_compat.run_strategy_code(
+        "dummy", {}, _config(), strategy=_strategy(), coverage_probe_mode=True
+    )
+
+    assert result.success is False
+    assert result.error_type == "lookahead_violation"
+    assert result.probe_events is payload
+
+
+def test_coverage_probe_mode_is_forwarded_to_run_backtest(monkeypatch) -> None:
+    """The plumbing: ``run_strategy_code(coverage_probe_mode=True)`` must
+    forward the flag through to ``run_backtest`` so the underlying
+    ``TradingService`` and ``StreamingHarness`` get the env var set."""
+    captured = _patch_run_backtest(
+        monkeypatch,
+        service_result=TradingServiceResult(
+            execution_diagnostics=BacktestExecutionDiagnostics(),
+        ),
+    )
+
+    sandbox_compat.run_strategy_code(
+        "dummy", {}, _config(), strategy=_strategy(), coverage_probe_mode=True
+    )
+
+    assert captured.get("coverage_probe_mode") is True
+
+
+def test_coverage_probe_mode_defaults_off(monkeypatch) -> None:
+    """Regression guard: callers that don't opt in keep the off path —
+    no breakage of existing zero-overhead expectations."""
+    captured = _patch_run_backtest(
+        monkeypatch,
+        service_result=TradingServiceResult(
+            execution_diagnostics=BacktestExecutionDiagnostics(),
+        ),
+    )
+
+    sandbox_compat.run_strategy_code("dummy", {}, _config(), strategy=_strategy())
+
+    assert captured.get("coverage_probe_mode") is False

--- a/backend/agents/investment_team/tests/test_streaming_harness_coverage_probe.py
+++ b/backend/agents/investment_team/tests/test_streaming_harness_coverage_probe.py
@@ -1,0 +1,319 @@
+"""Unit tests for the coverage-probe harness wiring added in issue #450.
+
+Covers the streaming-harness surface in isolation (subprocess round-trip,
+no ``TradingService``):
+
+* Off path: ``coverage_probe_mode=False`` leaves ``harness.probe_events``
+  ``None`` and never emits a ``probe_event`` frame — the existing JSONL
+  protocol is unchanged.
+* On path: a strategy instrumented by ``instrument_strategy_code`` (#449)
+  and run with ``coverage_probe_mode=True`` produces aggregated per-rule
+  hit counts plus first/last true bar indices.
+* Cap behaviour: when more distinct ``rule_id``s than the env-configured
+  cap fire, the flushed payload sets ``truncated: True``.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+import pytest
+
+from investment_team.strategy_lab.coverage_probe.runtime_instrument import (
+    instrument_strategy_code,
+)
+from investment_team.trading_service.strategy.streaming_harness import (
+    StreamingHarness,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: tiny strategies whose on_bar contains predicate logic the
+# instrumenter can wrap. Each emits one MARKET order when the predicate
+# fires so we can also assert behaviour-preservation off/on.
+# ---------------------------------------------------------------------------
+
+
+_TWO_RULE_CODE = textwrap.dedent('''\
+    """Two-rule strategy: an entry guarded by ``close > 100`` and an exit
+    guarded by ``close < 50``. Used to exercise per-rule aggregation and
+    first/last_true_bar tracking under both probe-off and probe-on runs.
+    """
+    from contract import OrderSide, OrderType, Strategy
+
+
+    class TwoRule(Strategy):
+        def on_bar(self, ctx, bar):
+            if bar.close > 100:
+                ctx.submit_order(
+                    symbol=bar.symbol,
+                    side=OrderSide.LONG,
+                    qty=1.0,
+                    order_type=OrderType.MARKET,
+                    reason="entry",
+                )
+            if bar.close < 50:
+                ctx.submit_order(
+                    symbol=bar.symbol,
+                    side=OrderSide.SHORT,
+                    qty=1.0,
+                    order_type=OrderType.MARKET,
+                    reason="exit",
+                )
+''')
+
+
+_AND_RULE_CODE = textwrap.dedent('''\
+    """Conjunction: both legs (volume > 1000 AND close > 100) must fire
+    for the order to emit, exercising the per-leg unwrap of BoolOp in
+    the instrumenter and bar-wise aggregation in the collector.
+    """
+    from contract import OrderSide, OrderType, Strategy
+
+
+    class AndRule(Strategy):
+        def on_bar(self, ctx, bar):
+            if bar.volume > 1000 and bar.close > 100:
+                ctx.submit_order(
+                    symbol=bar.symbol,
+                    side=OrderSide.LONG,
+                    qty=1.0,
+                    order_type=OrderType.MARKET,
+                    reason="and",
+                )
+''')
+
+
+def _bar(ts: str, *, close: float = 100.0, volume: float = 1000.0, symbol: str = "AAA") -> dict:
+    return {
+        "symbol": symbol,
+        "timestamp": ts,
+        "timeframe": "1d",
+        "open": close,
+        "high": close + 1.0,
+        "low": close - 1.0,
+        "close": close,
+        "volume": volume,
+    }
+
+
+def _state() -> dict:
+    return {"capital": 100_000.0, "equity": 100_000.0, "positions": []}
+
+
+def _run_bars(harness: StreamingHarness, closes: list[float], volumes: list[float] | None = None):
+    """Drive a list of bars through ``harness`` per-bar, return aggregated orders."""
+    if volumes is None:
+        volumes = [1000.0] * len(closes)
+    assert len(closes) == len(volumes)
+    orders: list[dict] = []
+    for i, (close, volume) in enumerate(zip(closes, volumes), start=1):
+        resp = harness.send_bar(
+            bar=_bar(f"2024-01-{i:02d}", close=close, volume=volume),
+            state=_state(),
+        )
+        orders.extend(resp.orders)
+    return orders
+
+
+# ---------------------------------------------------------------------------
+# Off path
+# ---------------------------------------------------------------------------
+
+
+def test_probe_mode_off_leaves_probe_events_none() -> None:
+    """``coverage_probe_mode=False`` is the zero-overhead default — no
+    ``probe_event`` frame flushed, ``harness.probe_events`` stays
+    ``None`` end-to-end."""
+    instrumented, rule_index = instrument_strategy_code(_TWO_RULE_CODE)
+    assert len(rule_index.rules) == 2  # sanity: instrumenter wrapped both legs
+
+    with StreamingHarness(instrumented) as harness:
+        harness.send_start(config={"initial_capital": 100_000.0})
+        _run_bars(harness, closes=[150.0, 25.0, 75.0])
+        harness.send_end()
+        assert harness.probe_events is None
+
+
+def test_probe_mode_off_preserves_orders_byte_identical_to_uninstrumented() -> None:
+    """Probe mode off, instrumented vs uninstrumented strategy: identical
+    emitted orders. Proves the default no-op ``__probe_record__`` from
+    the prelude is true-identity and doesn't drift the strategy state."""
+    closes = [150.0, 25.0, 75.0, 200.0]
+
+    with StreamingHarness(_TWO_RULE_CODE) as harness:
+        harness.send_start(config={"initial_capital": 100_000.0})
+        baseline = _run_bars(harness, closes=closes)
+        harness.send_end()
+
+    instrumented, _ = instrument_strategy_code(_TWO_RULE_CODE)
+    with StreamingHarness(instrumented) as harness:
+        harness.send_start(config={"initial_capital": 100_000.0})
+        rewritten = _run_bars(harness, closes=closes)
+        harness.send_end()
+
+    assert baseline == rewritten
+
+
+# ---------------------------------------------------------------------------
+# On path
+# ---------------------------------------------------------------------------
+
+
+def test_probe_mode_on_populates_per_rule_hit_counts() -> None:
+    """Probe mode on: ``harness.probe_events`` is a dict with one entry
+    per wrapped subcondition, carrying hit_count plus first/last
+    true bar indices keyed by the AST counter from #449."""
+    instrumented, rule_index = instrument_strategy_code(_TWO_RULE_CODE)
+    rule_ids = list(rule_index.rules)
+    assert rule_ids == ["r0", "r1"]
+
+    closes = [150.0, 25.0, 30.0, 75.0, 200.0]  # r0 fires on bars 0, 4; r1 fires on bars 1, 2
+    with StreamingHarness(instrumented, coverage_probe_mode=True) as harness:
+        harness.send_start(config={"initial_capital": 100_000.0})
+        _run_bars(harness, closes=closes)
+        harness.send_end()
+        payload = harness.probe_events
+
+    assert payload is not None
+    assert payload["truncated"] is False
+    events = {ev["rule_id"]: ev for ev in payload["events"]}
+    # r0 == close > 100 fires on bars 0 (close=150) and 4 (close=200).
+    assert events["r0"]["hit_count"] == 2
+    assert events["r0"]["first_true_bar"] == 0
+    assert events["r0"]["last_true_bar"] == 4
+    # r1 == close < 50 fires on bars 1 (close=25) and 2 (close=30).
+    assert events["r1"]["hit_count"] == 2
+    assert events["r1"]["first_true_bar"] == 1
+    assert events["r1"]["last_true_bar"] == 2
+
+
+def test_probe_mode_on_preserves_orders_vs_off() -> None:
+    """Same instrumented strategy, same bars: trades / orders are
+    byte-identical with probe mode on vs off — the collector must be
+    an identity function on the AST-rewritten leg value."""
+    instrumented, _ = instrument_strategy_code(_TWO_RULE_CODE)
+    closes = [150.0, 25.0, 75.0, 200.0]
+
+    with StreamingHarness(instrumented) as harness:
+        harness.send_start(config={"initial_capital": 100_000.0})
+        off_orders = _run_bars(harness, closes=closes)
+        harness.send_end()
+
+    with StreamingHarness(instrumented, coverage_probe_mode=True) as harness:
+        harness.send_start(config={"initial_capital": 100_000.0})
+        on_orders = _run_bars(harness, closes=closes)
+        harness.send_end()
+
+    assert off_orders == on_orders
+
+
+def test_probe_mode_on_handles_conjunction_per_leg() -> None:
+    """``BoolOp`` predicates are split per-leg by the instrumenter, so
+    each leg has its own rule_id. Short-circuit semantics are preserved
+    (Python's ``and`` skips the right leg when the left is falsy), which
+    is exactly what makes the per-leg signal useful: the harness sees
+    "r0 fired but r1 never got the chance to" without re-evaluating.
+    This matches the intent of #406 — diagnosing which leg blocks
+    entry without re-running the strategy."""
+    instrumented, rule_index = instrument_strategy_code(_AND_RULE_CODE)
+    assert len(rule_index.rules) == 2
+
+    # Bar 0: volume=2000 (r0 truthy), close=50 (r1 evaluated, falsy) → no order.
+    # Bar 1: volume=500 (r0 falsy), r1 short-circuited (never evaluated).
+    # Bar 2: volume=3000 (r0 truthy), close=200 (r1 truthy) → order emitted.
+    closes = [50.0, 150.0, 200.0]
+    volumes = [2000.0, 500.0, 3000.0]
+
+    with StreamingHarness(instrumented, coverage_probe_mode=True) as harness:
+        harness.send_start(config={"initial_capital": 100_000.0})
+        orders = _run_bars(harness, closes=closes, volumes=volumes)
+        harness.send_end()
+        payload = harness.probe_events
+
+    assert len(orders) == 1  # only bar 2 satisfied both legs
+    assert payload is not None
+    events = {ev["rule_id"]: ev for ev in payload["events"]}
+    # r0 == volume > 1000 was evaluated on every bar; truthy on 0 and 2.
+    assert events["r0"]["hit_count"] == 2
+    assert events["r0"]["first_true_bar"] == 0
+    assert events["r0"]["last_true_bar"] == 2
+    # r1 == close > 100 only evaluates when r0 is truthy (short-circuit),
+    # so it fires once on bar 2 only.
+    assert events["r1"]["hit_count"] == 1
+    assert events["r1"]["first_true_bar"] == 2
+    assert events["r1"]["last_true_bar"] == 2
+
+
+def test_probe_mode_on_skips_unwrapped_strategy() -> None:
+    """An uninstrumented strategy under probe mode still runs cleanly:
+    the harness installs the collector but the strategy code never
+    calls ``__probe_record__``, so ``events`` ends up empty (and the
+    flushed payload is still well-formed). Defends against the
+    common bug of forgetting to instrument before opting into probe
+    mode."""
+    with StreamingHarness(_TWO_RULE_CODE, coverage_probe_mode=True) as harness:
+        harness.send_start(config={"initial_capital": 100_000.0})
+        _run_bars(harness, closes=[150.0, 25.0])
+        harness.send_end()
+        payload = harness.probe_events
+
+    assert payload == {"events": [], "truncated": False}
+
+
+# ---------------------------------------------------------------------------
+# Cap behaviour
+# ---------------------------------------------------------------------------
+
+
+def _build_many_rule_strategy(n: int) -> str:
+    """Generate a strategy whose on_bar has N independent if-predicates
+    so the instrumenter produces N distinct rule_ids — used to drive
+    the cap-truncation path without depending on the default cap of
+    5000.
+    """
+    lines = [
+        "from contract import OrderSide, OrderType, Strategy",
+        "",
+        "",
+        "class ManyRule(Strategy):",
+        "    def on_bar(self, ctx, bar):",
+    ]
+    for i in range(n):
+        # Each rule is "close > <unique_int>": deterministic, indicator-
+        # free, and reliably true for a high enough close to populate
+        # every leg in a single bar — fastest path to N distinct rule_ids.
+        lines.append(f"        if bar.close > {i}:")
+        lines.append("            pass")
+    return "\n".join(lines) + "\n"
+
+
+def test_probe_mode_truncated_flag_when_distinct_rule_ids_exceed_cap(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Past the env-configured rule-id cap, new ``rule_id``s are dropped
+    rather than tracked, and the flushed payload sets
+    ``truncated: True``. We dial the cap down so the test stays cheap;
+    the production default (5000) is exercised via the env var."""
+    # Cap the child to 3 distinct rule_ids; the strategy has 5 if-predicates.
+    monkeypatch.setenv("STRATLAB_COVERAGE_PROBE_CAP_OVERRIDE_HINT", "3")
+    # The harness reads STRATLAB_COVERAGE_PROBE_CAP from the parent env,
+    # so we set it directly. (The above is just for human-reading.)
+    monkeypatch.setattr(
+        "investment_team.trading_service.strategy.streaming_harness.COVERAGE_PROBE_RULE_CAP",
+        3,
+    )
+
+    code = _build_many_rule_strategy(5)
+    instrumented, rule_index = instrument_strategy_code(code)
+    assert len(rule_index.rules) == 5
+
+    with StreamingHarness(instrumented, coverage_probe_mode=True) as harness:
+        harness.send_start(config={"initial_capital": 100_000.0})
+        _run_bars(harness, closes=[1000.0])  # close > i is true for every i
+        harness.send_end()
+        payload = harness.probe_events
+
+    assert payload is not None
+    assert payload["truncated"] is True
+    # Only the first 3 distinct rule_ids should have been tracked.
+    assert len(payload["events"]) == 3

--- a/backend/agents/investment_team/trading_service/modes/backtest.py
+++ b/backend/agents/investment_team/trading_service/modes/backtest.py
@@ -57,6 +57,7 @@ def run_backtest(
     provider_id: Optional[str] = None,
     registry: Optional[ProviderRegistry] = None,
     as_of: Optional[str] = None,
+    coverage_probe_mode: bool = False,
 ) -> BacktestRunResult:
     """Run a backtest for ``strategy``.
 
@@ -169,6 +170,13 @@ def run_backtest(
             # TRADING_PARTIAL_FILL_DEFAULTS_ENABLED until #386 wires
             # consumption.
             default_unfilled_policy=UnfilledPolicy.REQUEUE_NEXT_BAR,
+            # #450: opt-in coverage-probe mode threaded from the caller
+            # (typically ``run_strategy_code``). Cost-stress replays
+            # below also pick this up so a single backtest call can
+            # produce both baseline + stress probe data; the events
+            # land only on the baseline ``service_result`` via the
+            # capture_fingerprint code path.
+            coverage_probe_mode=coverage_probe_mode,
         )
         outcome = service.run(stream)
         run_metrics = compute_metrics(

--- a/backend/agents/investment_team/trading_service/modes/sandbox_compat.py
+++ b/backend/agents/investment_team/trading_service/modes/sandbox_compat.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 
 from ...models import BacktestConfig, BacktestExecutionDiagnostics, StrategySpec, TradeRecord
 from .backtest import run_backtest
@@ -42,6 +42,13 @@ class StrategyRunResult:
     execution_time_seconds: float = 0.0
     error_type: Optional[str] = None
     execution_diagnostics: Optional[BacktestExecutionDiagnostics] = None
+    #: Aggregated coverage-probe events from the strategy subprocess
+    #: (#450). ``None`` unless ``run_strategy_code`` was called with
+    #: ``coverage_probe_mode=True`` and the run reached its clean
+    #: ``end`` to flush a ``probe_event`` frame. Shape mirrors
+    #: ``TradingServiceResult.probe_events``: ``{"events": [...],
+    #: "truncated": bool}``.
+    probe_events: Optional[Dict[str, Any]] = None
 
 
 # Keys here match the legacy sandbox ``error_type`` taxonomy so the
@@ -57,6 +64,7 @@ def run_strategy_code(
     config: BacktestConfig,
     *,
     strategy: Optional[StrategySpec] = None,
+    coverage_probe_mode: bool = False,
 ) -> StrategyRunResult:
     """Execute ``strategy_code`` through :func:`run_backtest`.
 
@@ -84,7 +92,12 @@ def run_strategy_code(
         strategy = strategy.model_copy(update={"strategy_code": strategy_code})
 
     try:
-        run = run_backtest(strategy=strategy, config=config, market_data=market_data)
+        run = run_backtest(
+            strategy=strategy,
+            config=config,
+            market_data=market_data,
+            coverage_probe_mode=coverage_probe_mode,
+        )
     except ValueError as exc:
         # Typically raised when strategy_code is missing or the market_data
         # arg is ambiguous — surface as a generic runtime error. No service
@@ -113,6 +126,7 @@ def run_strategy_code(
             stderr=(service_result.error or "")[:2000],
             execution_time_seconds=elapsed,
             execution_diagnostics=service_result.execution_diagnostics,
+            probe_events=service_result.probe_events,
         )
     if service_result.error:
         # Any surfaced service error — initialisation failure, mid-run
@@ -130,6 +144,7 @@ def run_strategy_code(
             stderr=service_result.error[:2000],
             execution_time_seconds=elapsed,
             execution_diagnostics=service_result.execution_diagnostics,
+            probe_events=service_result.probe_events,
         )
 
     return StrategyRunResult(
@@ -137,6 +152,7 @@ def run_strategy_code(
         trades=run.trades,
         execution_time_seconds=elapsed,
         execution_diagnostics=service_result.execution_diagnostics,
+        probe_events=service_result.probe_events,
     )
 
 

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -16,7 +16,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from datetime import date as date_cls
-from typing import Callable, Dict, Iterable, List, Optional
+from typing import Any, Callable, Dict, Iterable, List, Optional
 
 from ..execution.bar_safety import LookAheadError
 from ..execution.metrics import EquityCurve
@@ -114,6 +114,13 @@ class TradingServiceResult:
     #: from the closed-trade ledger. ``None`` when no bars were processed
     #: (e.g. ``harness.send_start`` failure or empty stream).
     streaming_equity_curve: Optional[EquityCurve] = None
+    #: Aggregated coverage-probe events from the strategy subprocess
+    #: (#450). Populated only when the service was constructed with
+    #: ``coverage_probe_mode=True`` *and* the child flushed a
+    #: ``probe_event`` frame (currently emitted on clean ``end``).
+    #: Shape: ``{"events": [{rule_id, hit_count, first_true_bar,
+    #: last_true_bar}, ...], "truncated": bool}``.
+    probe_events: Optional[Dict[str, Any]] = None
 
 
 def _record_event(
@@ -330,9 +337,13 @@ class TradingService:
         risk_limits: Optional["RiskLimits | Dict"] = None,
         default_unfilled_policy: UnfilledPolicy = UnfilledPolicy.DROP,
         bar_chunk_size: Optional[int] = None,
+        coverage_probe_mode: bool = False,
     ) -> None:
         self.strategy_code = strategy_code
         self.config = config
+        # #450: opt-in coverage-probe mode. Off by default so all
+        # existing callers keep the zero-overhead path.
+        self._coverage_probe_mode = coverage_probe_mode
         # Phase 3: StrategySpec.risk_limits is now a validated RiskLimits
         # instance; keep accepting raw dicts for callers that haven't
         # migrated (the backtest API still carries a ``Dict[str, Any]`` at
@@ -401,7 +412,10 @@ class TradingService:
         if chunk_size is None:
             chunk_size = _resolve_bar_chunk_size()
 
-        with StreamingHarness(self.strategy_code) as harness:
+        with StreamingHarness(
+            self.strategy_code,
+            coverage_probe_mode=self._coverage_probe_mode,
+        ) as harness:
             try:
                 harness.send_start(
                     config={
@@ -414,6 +428,7 @@ class TradingService:
                 result.error = str(exc)
                 result.lookahead_violation = exc.etype == "lookahead_violation"
                 _apply_streaming_curve(result, eod_equity, self.config.initial_capital)
+                result.probe_events = harness.probe_events
                 return _finalize_diagnostics(result)
 
             # Issue #377: chunked-bar protocol. Only opt in when the env var
@@ -720,14 +735,17 @@ class TradingService:
                 result.error = str(exc)
                 result.lookahead_violation = True
                 _apply_streaming_curve(result, eod_equity, self.config.initial_capital)
+                result.probe_events = harness.probe_events
                 return _finalize_diagnostics(result)
             except StrategyRuntimeError as exc:
                 result.error = str(exc)
                 result.lookahead_violation = exc.etype == "lookahead_violation"
                 _apply_streaming_curve(result, eod_equity, self.config.initial_capital)
+                result.probe_events = harness.probe_events
                 return _finalize_diagnostics(result)
 
         _apply_streaming_curve(result, eod_equity, self.config.initial_capital)
+        result.probe_events = harness.probe_events
         return _finalize_diagnostics(result)
 
     # ------------------------------------------------------------------
@@ -1035,14 +1053,17 @@ class TradingService:
             result.error = str(exc)
             result.lookahead_violation = True
             _apply_streaming_curve(result, eod_equity, self.config.initial_capital)
+            result.probe_events = harness.probe_events
             return _finalize_diagnostics(result)
         except StrategyRuntimeError as exc:
             result.error = str(exc)
             result.lookahead_violation = exc.etype == "lookahead_violation"
             _apply_streaming_curve(result, eod_equity, self.config.initial_capital)
+            result.probe_events = harness.probe_events
             return _finalize_diagnostics(result)
 
         _apply_streaming_curve(result, eod_equity, self.config.initial_capital)
+        result.probe_events = harness.probe_events
         return _finalize_diagnostics(result)
 
     # ------------------------------------------------------------------

--- a/backend/agents/investment_team/trading_service/strategy/streaming_harness.py
+++ b/backend/agents/investment_team/trading_service/strategy/streaming_harness.py
@@ -44,6 +44,12 @@ logger = logging.getLogger(__name__)
 DEFAULT_TOTAL_TIMEOUT_SEC = 600  # hard ceiling for a full session
 DEFAULT_EVENT_TIMEOUT_SEC = 30  # per-event watchdog
 
+# Hard cap on distinct ``rule_id`` aggregates the child tracks under
+# coverage-probe mode (#450). Past this point new ``rule_id``s are
+# dropped and ``probe_events["truncated"]`` flips to True so the parent
+# can surface "we lost some signal" without silently discarding.
+COVERAGE_PROBE_RULE_CAP = 5000
+
 
 class StrategyRuntimeError(RuntimeError):
     """Raised when the strategy subprocess misbehaves (crash, timeout, protocol)."""
@@ -92,10 +98,12 @@ class StreamingHarness:
         *,
         total_timeout_sec: int = DEFAULT_TOTAL_TIMEOUT_SEC,
         event_timeout_sec: int = DEFAULT_EVENT_TIMEOUT_SEC,
+        coverage_probe_mode: bool = False,
     ) -> None:
         self._strategy_code = strategy_code
         self._total_timeout = total_timeout_sec
         self._event_timeout = event_timeout_sec
+        self._coverage_probe_mode = coverage_probe_mode
         self._tmpdir: Optional[tempfile.TemporaryDirectory] = None
         self._proc: Optional[subprocess.Popen] = None
         self._started_at: float = 0.0
@@ -103,6 +111,10 @@ class StreamingHarness:
         # the child predates capability negotiation — treat as per-bar
         # only (no ``chunked_bars``).
         self._capabilities: Dict[str, Any] = {}
+        # Aggregated coverage-probe events from the child (issue #450).
+        # ``None`` when probe mode was off or the run never emitted a
+        # frame; otherwise a dict ``{"events": [...], "truncated": bool}``.
+        self._probe_events: Optional[Dict[str, Any]] = None
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -141,6 +153,12 @@ class StreamingHarness:
         venv = os.environ.get("VIRTUAL_ENV")
         if venv:
             env["VIRTUAL_ENV"] = venv
+        # #450: probe mode is opt-in via env var so the child can skip
+        # the collector install and the parent can keep the off-path
+        # zero-overhead.
+        if self._coverage_probe_mode:
+            env["STRATLAB_COVERAGE_PROBE"] = "1"
+            env["STRATLAB_COVERAGE_PROBE_CAP"] = str(COVERAGE_PROBE_RULE_CAP)
 
         self._proc = subprocess.Popen(
             [sys.executable, "_harness.py"],
@@ -219,6 +237,17 @@ class StreamingHarness:
         """
         return bool(self._capabilities.get("chunked_bars"))
 
+    @property
+    def probe_events(self) -> Optional[Dict[str, Any]]:
+        """Aggregated coverage-probe events from the child (#450).
+
+        ``None`` when ``coverage_probe_mode`` was off or the subprocess
+        never flushed a ``probe_event`` frame (e.g. crash before ``end``).
+        Otherwise: ``{"events": [{rule_id, hit_count, first_true_bar,
+        last_true_bar}, ...], "truncated": bool}``.
+        """
+        return self._probe_events
+
     # ------------------------------------------------------------------
     # Internal: protocol round-trip
     # ------------------------------------------------------------------
@@ -278,6 +307,14 @@ class StreamingHarness:
                 resp.cancel_bar_indices.append(record.get("bar_index"))
             elif kind == "log":
                 resp.logs.append(record)
+            elif kind == "probe_event":
+                # #450: child flushes aggregated coverage probe state.
+                # Latest flush wins so a periodic flusher could overwrite
+                # without loss; the v1 child only emits once on ``end``.
+                payload = record.get("payload")
+                if isinstance(payload, dict):
+                    self._probe_events = payload
+                continue
             elif kind == "ready":
                 # Capability handshake (issue #377): the child advertises
                 # ``chunked_bars`` in its first ready after start. Update
@@ -323,6 +360,7 @@ _HARNESS_SCRIPT = textwrap.dedent('''\
     #!/usr/bin/env python3
     """Child-side strategy harness. Auto-written; do not edit."""
     import json
+    import os
     import sys
     import traceback
 
@@ -343,6 +381,92 @@ _HARNESS_SCRIPT = textwrap.dedent('''\
     def _emit(record):
         sys.stdout.write(json.dumps(record) + "\\n")
         sys.stdout.flush()
+
+
+    # ------------------------------------------------------------------
+    # Coverage probe mode (#450)
+    # ------------------------------------------------------------------
+    # When STRATLAB_COVERAGE_PROBE is set, install a real
+    # ``__probe_record__`` collector on the imported strategy module so
+    # the AST-instrumented (#449) ``if`` predicates record per-bar
+    # subcondition truth. The instrumented prelude defines a no-op
+    # default at import time; rebinding the module attribute after
+    # import is safe because the wrapped calls do a free-name lookup at
+    # call time (Python resolves ``__probe_record__`` against the
+    # strategy module's globals on every invocation). ``_chunk_state``-
+    # style attribute access from the strategy can still reach
+    # ``strategy.__probe_record__``, but that's a known cooperative
+    # interface, not a security boundary — same threat model as the
+    # ``_chunk_state`` documentation in ``_tagged_emit``.
+    _probe_enabled = os.environ.get("STRATLAB_COVERAGE_PROBE") == "1"
+    _probe_state = {}  # rule_id -> {hit_count, first_true_bar, last_true_bar}
+    _probe_truncated = False
+    try:
+        _probe_cap = int(os.environ.get("STRATLAB_COVERAGE_PROBE_CAP", "5000"))
+    except ValueError:
+        _probe_cap = 5000
+
+
+    def _probe_record(_rid, _bidx, _value):
+        # Behaviour-preserving: always return the original truth value
+        # so the AST-rewritten predicate evaluates identically.
+        if _value:
+            entry = _probe_state.get(_rid)
+            if entry is None:
+                global _probe_truncated
+                if len(_probe_state) >= _probe_cap:
+                    _probe_truncated = True
+                else:
+                    _probe_state[_rid] = {
+                        "hit_count": 1,
+                        "first_true_bar": _bidx,
+                        "last_true_bar": _bidx,
+                    }
+            else:
+                entry["hit_count"] += 1
+                entry["last_true_bar"] = _bidx
+        return _value
+
+
+    # Monotonic per-bar counter for the probe ``__probe_bar_index__``.
+    # Distinct from ``_chunk_state["i"]`` (which is chunk-local, used
+    # for order tagging) — the probe wants a stable, cross-chunk index
+    # so ``first_true_bar`` / ``last_true_bar`` are comparable across
+    # the whole run.
+    _probe_bar_counter = {"i": -1}
+
+
+    def _next_probe_bar_index():
+        _probe_bar_counter["i"] += 1
+        return _probe_bar_counter["i"]
+
+
+    def _set_bar_index(idx):
+        if _probe_enabled:
+            strategy.__probe_bar_index__ = idx
+
+
+    def _flush_probe_events():
+        if not _probe_enabled:
+            return
+        events = [
+            {
+                "rule_id": rid,
+                "hit_count": entry["hit_count"],
+                "first_true_bar": entry["first_true_bar"],
+                "last_true_bar": entry["last_true_bar"],
+            }
+            for rid, entry in _probe_state.items()
+        ]
+        _emit({
+            "kind": "probe_event",
+            "payload": {"events": events, "truncated": _probe_truncated},
+        })
+
+
+    if _probe_enabled:
+        strategy.__probe_record__ = _probe_record
+        strategy.__probe_bar_index__ = 0
 
 
     # Harness-private bar_index state for the chunked protocol (PR #425
@@ -439,6 +563,9 @@ _HARNESS_SCRIPT = textwrap.dedent('''\
                     state = msg.get("state") or {}
                     _apply_state(ctx, state, is_warmup=bool(msg.get("is_warmup", False)))
                     ctx._ingest_bar(bar)
+                    # #450: bump the probe bar index so #449's wrapped
+                    # subconditions can stamp first/last_true_bar.
+                    _set_bar_index(_next_probe_bar_index())
                     instance.on_bar(ctx, bar)
                 elif kind == "bars":
                     # Chunked-bar protocol (issue #377). Each entry has its
@@ -483,6 +610,10 @@ _HARNESS_SCRIPT = textwrap.dedent('''\
                             # Harness-managed bar_index for ``_tagged_emit``;
                             # strategy code cannot reach ``_chunk_state``.
                             _chunk_state["i"] = i
+                            # #450: also advance the probe's cross-chunk
+                            # bar counter so first/last_true_bar are
+                            # globally meaningful even under chunked mode.
+                            _set_bar_index(_next_probe_bar_index())
                             instance.on_bar(ctx, bar)
                     finally:
                         _chunk_state["i"] = None
@@ -494,6 +625,10 @@ _HARNESS_SCRIPT = textwrap.dedent('''\
                 elif kind == "end":
                     if started:
                         instance.on_end(ctx)
+                    # #450: flush aggregated probe events before the
+                    # final ready so the parent's _exchange loop sees
+                    # them in the same round-trip.
+                    _flush_probe_events()
                     _emit({"kind": "ready", "capabilities": _CAPABILITIES})
                     return
                 else:


### PR DESCRIPTION
## Summary

Implements **#450** — the runtime probe harness wiring + collector for the #406 epic. Threads a `coverage_probe_mode` flag from `run_strategy_code` → `run_backtest` → `TradingService` → `StreamingHarness`. When set, the child subprocess installs a real `__probe_record__` collector on the imported strategy module so the AST-instrumented (#449) predicates record per-bar subcondition truth. On clean `end` the child flushes one `probe_event` JSONL frame; the parent stores it on `harness.probe_events` and the trading-service result chain surfaces it as `StrategyRunResult.probe_events`.

### Acceptance criteria from #450
- [x] `coverage_probe_mode=False` is the zero-overhead default: no env var, no collector install, no extra emit, no new parse branch executed.
- [x] `coverage_probe_mode=True` populates a bounded dict `{"events": [{rule_id, hit_count, first_true_bar, last_true_bar}, ...], "truncated": bool}`.
- [x] Existing `success`, `trades`, `stderr`, `error_type` behaviour unchanged in both modes — verified via regression on chunked, equity-curve, sandbox-compat, and golden round-trip suites.
- [x] Hard-capped at `COVERAGE_PROBE_RULE_CAP` distinct `rule_id`s (default 5000); over-cap rules flip `truncated` rather than evicting silently.

### Files changed
- `backend/agents/investment_team/trading_service/strategy/streaming_harness.py` — `coverage_probe_mode` kwarg, `probe_events` property, `STRATLAB_COVERAGE_PROBE` env opt-in, child-side collector + bar-index counter + final flush on `end`, parent-side `probe_event` JSONL handling.
- `backend/agents/investment_team/trading_service/service.py` — `coverage_probe_mode` kwarg on `TradingService.__init__`, `probe_events` field on `TradingServiceResult`, capture into result on all return paths (run + chunked).
- `backend/agents/investment_team/trading_service/modes/backtest.py` — `coverage_probe_mode` kwarg on `run_backtest`, threaded into the `TradingService` construction.
- `backend/agents/investment_team/trading_service/modes/sandbox_compat.py` — `probe_events` field on `StrategyRunResult`, kwarg on `run_strategy_code`, propagated into success / lookahead / runtime-error construction sites.

### Test plan
- [x] `pytest agents/investment_team/tests/test_streaming_harness_coverage_probe.py` — 7/7 (new file; off path, on path, conjunction, unwrapped strategy, cap truncation, byte-identical orders off vs on).
- [x] `pytest agents/investment_team/tests/test_sandbox_compat.py` — 11/11 (5 new tests for probe_events propagation on success / lookahead / runtime-error paths + flag forwarding).
- [x] `pytest agents/investment_team/tests/` — 799 passed, 13 skipped, no regressions.
- [x] `ruff check` + `ruff format --check` clean on all 6 changed files.
- [ ] CI green on this branch.

### Out of scope (separate sub-issues of #406)
- Orchestrator wiring to call `instrument_strategy_code` and read `probe_events` → **#451**.
- Mapping events + `RuleIndex` into `CoverageReport` for refinement → **#452**.
- Bounded-runtime / convergence guarantees → **#453**.
- Closing #449 (already merged via PR #458 but still open on the tracker).

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_016y3RFqUzMt7TQsoHUTkfZp)_