### PR TITLE
jobs-dashboard: keyboard accessibility for clickable rows (#481)

### DIFF
--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.html
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.html
@@ -57,7 +57,13 @@
         </thead>
         <tbody>
           @for (job of jobs; track trackByJobId($index, job)) {
-            <tr class="job-row" [class]="getStatusClass(job)" (click)="navigateToJob(job)">
+            <tr class="job-row"
+                [class]="getStatusClass(job)"
+                tabindex="0"
+                role="button"
+                [attr.aria-label]="getJobAriaLabel(job)"
+                (click)="navigateToJob(job)"
+                (keydown)="onRowKeydown($event, job)">
               <td class="col-status">
                 <span class="status-badge" [class]="getStatusClass(job)">{{ getStatusLabel(job) }}</span>
               </td>

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
@@ -159,6 +159,11 @@
         background: var(--kh-glass-hover);
       }
 
+      &:focus-visible {
+        outline: none;
+        box-shadow: inset 0 0 0 2px var(--kh-accent);
+      }
+
       // Status left-border indicators
       &.status-running   { border-left: 3px solid var(--kh-accent); }
       &.status-pending    { border-left: 3px solid var(--kh-text-muted); }

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
@@ -157,6 +157,81 @@ describe('JobsDashboardComponent', () => {
     expect(routerSpy.navigate).toHaveBeenCalledWith(['/software-engineering'], { queryParams: { jobId: 'j1', tab: 0 } });
   });
 
+  describe('onRowKeydown', () => {
+    const seJob = () =>
+      ({
+        unified: { source: 'software_engineering', jobType: 'run_team', jobId: 'j1' },
+        seDetail: undefined,
+      }) as any;
+
+    const makeEvent = (key: string, target: EventTarget, currentTarget: EventTarget): KeyboardEvent => {
+      const evt = new KeyboardEvent('keydown', { key, cancelable: true });
+      Object.defineProperty(evt, 'target', { value: target });
+      Object.defineProperty(evt, 'currentTarget', { value: currentTarget });
+      return evt;
+    };
+
+    it('navigates on Enter', () => {
+      const tr = document.createElement('tr');
+      component.onRowKeydown(makeEvent('Enter', tr, tr), seJob());
+      expect(routerSpy.navigate).toHaveBeenCalled();
+    });
+
+    it('navigates on Space and prevents default', () => {
+      const tr = document.createElement('tr');
+      const evt = makeEvent(' ', tr, tr);
+      const preventSpy = vi.spyOn(evt, 'preventDefault');
+      component.onRowKeydown(evt, seJob());
+      expect(preventSpy).toHaveBeenCalled();
+      expect(routerSpy.navigate).toHaveBeenCalled();
+    });
+
+    it('ignores other keys', () => {
+      const tr = document.createElement('tr');
+      component.onRowKeydown(makeEvent('Tab', tr, tr), seJob());
+      expect(routerSpy.navigate).not.toHaveBeenCalled();
+    });
+
+    it('ignores events whose target is a child control', () => {
+      const tr = document.createElement('tr');
+      const button = document.createElement('button');
+      component.onRowKeydown(makeEvent('Enter', button, tr), seJob());
+      expect(routerSpy.navigate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getJobAriaLabel', () => {
+    it('composes team, type, repo, status, time-ago for SE job', () => {
+      const job = {
+        unified: {
+          source: 'software_engineering',
+          jobType: 'run_team',
+          jobId: 'j1',
+          status: 'running',
+          label: 'Run',
+          repoPath: '/work/payments-api',
+          createdAt: new Date(Date.now() - 3 * 60_000).toISOString(),
+        },
+        seDetail: undefined,
+      } as any;
+      const label = component.getJobAriaLabel(job);
+      expect(label).toContain('Run Team');
+      expect(label).toContain('repo payments-api');
+      expect(label).toContain('status running');
+      expect(label).toContain('started 3m ago');
+    });
+
+    it('falls back to job label for non-SE rows', () => {
+      const job = {
+        unified: { source: 'blogging', jobType: undefined, jobId: 'j1', status: 'completed', label: 'My Post', createdAt: '' },
+        seDetail: undefined,
+      } as any;
+      const label = component.getJobAriaLabel(job);
+      expect(label).toContain('My Post');
+      expect(label).toContain('status completed');
+    });
+  });
+
   it('refresh sets loading and restarts polling', () => {
     component.refresh();
     expect(component.loading).toBe(true);

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
@@ -230,6 +230,23 @@ describe('JobsDashboardComponent', () => {
       expect(label).toContain('My Post');
       expect(label).toContain('status completed');
     });
+
+    it('reports "status waiting" for SE jobs awaiting answers', () => {
+      const job = {
+        unified: {
+          source: 'software_engineering',
+          jobType: 'run_team',
+          jobId: 'j1',
+          status: 'running',
+          label: 'Run',
+          repoPath: '/work/payments-api',
+          createdAt: '',
+        },
+        seDetail: { waitingForAnswers: true },
+      } as any;
+      const label = component.getJobAriaLabel(job);
+      expect(label).toContain('status waiting');
+    });
   });
 
   it('refresh sets loading and restarts polling', () => {

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
@@ -449,6 +449,28 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
     }
   }
 
+  onRowKeydown(event: KeyboardEvent, job: DashboardRow): void {
+    if (event.target !== event.currentTarget) return;
+    if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+      event.preventDefault();
+      this.navigateToJob(job);
+    }
+  }
+
+  getJobAriaLabel(job: DashboardRow): string {
+    const team = SOURCE_DISPLAY[job.unified.source]?.label ?? job.unified.source;
+    const type = this.getJobTypeInfo(job).label;
+    const subject =
+      job.unified.source === 'software_engineering' && job.unified.repoPath
+        ? `repo ${this.getRepoName(job.unified.repoPath)}`
+        : job.unified.label;
+    const status = this.getStatusLabel(job).toLowerCase();
+    const when = this.getTimeAgo(job.unified.createdAt);
+    const parts = [`Open ${team} ${type} job for ${subject}`, `status ${status}`];
+    if (when) parts.push(`started ${when}`);
+    return parts.join(', ');
+  }
+
   stopJob(event: Event, job: DashboardRow): void {
     event.stopPropagation();
     if (!confirm(`Are you sure you want to stop the job for "${job.unified.label}"?`)) return;


### PR DESCRIPTION
## Summary

Closes #481. The jobs dashboard table rows were mouse-only — keyboard users could not reach or activate them, and screen readers got no role or accessible name. This violates **WCAG 2.1.1 (Keyboard, A)** and **4.1.2 (Name, Role, Value)**.

Each row now:
- Is focusable (`tabindex="0"`) with `role="button"` and a composed `aria-label`, e.g. *"Open Backend Code V2 Run Team job for repo payments-api, status running, started 3 minutes ago"*.
- Activates `navigateToJob(job)` on **Enter** and **Space** (Space calls `preventDefault` to avoid scrolling the page).
- Renders a visible inset focus ring (`box-shadow: inset 0 0 0 2px var(--kh-accent)`) — the global `outline` rule renders awkwardly on a `<tr>`.
- Doesn't fight inner action buttons: `onRowKeydown` short-circuits when `event.target !== event.currentTarget`, and the existing `stopPropagation()` calls on `stopJob` / `resumeJob` / `restartJob` / `deleteJob` keep their click/keyboard semantics independent.

### Changes

- `jobs-dashboard.component.html` — add `tabindex`, `role`, `aria-label`, and `(keydown)` to `<tr class="job-row">`.
- `jobs-dashboard.component.ts` — add `onRowKeydown(event, job)` and `getJobAriaLabel(job)` (reuses existing `SOURCE_DISPLAY`, `getJobTypeInfo`, `getRepoName`, `getStatusLabel`, `getTimeAgo`).
- `jobs-dashboard.component.scss` — `.job-row:focus-visible` inset accent ring.
- `jobs-dashboard.component.spec.ts` — 7 new tests: Enter / Space (+ preventDefault) / other-key no-op / child-target no-op, and aria-label composition for SE + non-SE rows.

### Acceptance mapping

| Issue criterion | Status |
|---|---|
| Tab traversal reaches every visible row | `tabindex="0"` |
| Enter and Space both activate `navigateToJob` | covered by `onRowKeydown` and tests |
| Focus ring visible against `--kh-surface-2` | inset `--kh-accent` box-shadow |
| aria-label assembled from team / type / status / time-ago | `getJobAriaLabel` |
| Action buttons don't steal row focus on tab | unchanged — `mat-icon-button`s keep native tab order; keydown short-circuit + existing `stopPropagation()` |

## Test plan

- [x] `npx vitest run src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts` — 24/24 pass (17 existing + 7 new).
- [x] `npm test` — full suite 410/410 pass.
- [x] `npm run build` — succeeds (pre-existing bundle-size budget warning unrelated to this change).
- [ ] Manual browser pass at `/jobs-dashboard`: Tab lands on each row with a visible inset accent ring; Enter and Space navigate; Space does not scroll; Tab from a row reaches the inner action buttons; activating an action button does not also fire row navigation.
- [ ] Screen reader (VoiceOver / NVDA) announces the composed aria-label and "button" role on row focus.
- [ ] axe DevTools on `/jobs-dashboard`: no new violations.

https://claude.ai/code/session_018ES5r5THDsJrk5YPw8QYNb

---
_Generated by [Claude Code](https://claude.ai/code/session_018ES5r5THDsJrk5YPw8QYNb)_