### PR TITLE
jobs-dashboard: switch row role to link to resolve nested ARIA controls (#499)

### DIFF
--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.html
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.html
@@ -60,7 +60,7 @@
             <tr class="job-row"
                 [class]="getStatusClass(job)"
                 tabindex="0"
-                role="button"
+                role="link"
                 [attr.aria-label]="getJobAriaLabel(job)"
                 (click)="navigateToJob(job)"
                 (keydown)="onRowKeydown($event, job)">

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
@@ -177,13 +177,10 @@ describe('JobsDashboardComponent', () => {
       expect(routerSpy.navigate).toHaveBeenCalled();
     });
 
-    it('navigates on Space and prevents default', () => {
+    it('ignores Space (role="link" only activates on Enter)', () => {
       const tr = document.createElement('tr');
-      const evt = makeEvent(' ', tr, tr);
-      const preventSpy = vi.spyOn(evt, 'preventDefault');
-      component.onRowKeydown(evt, seJob());
-      expect(preventSpy).toHaveBeenCalled();
-      expect(routerSpy.navigate).toHaveBeenCalled();
+      component.onRowKeydown(makeEvent(' ', tr, tr), seJob());
+      expect(routerSpy.navigate).not.toHaveBeenCalled();
     });
 
     it('ignores other keys', () => {

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
@@ -451,7 +451,7 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
 
   onRowKeydown(event: KeyboardEvent, job: DashboardRow): void {
     if (event.target !== event.currentTarget) return;
-    if (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar') {
+    if (event.key === 'Enter') {
       event.preventDefault();
       this.navigateToJob(job);
     }


### PR DESCRIPTION
## Summary

Closes #499.

PR #498 made each `<tr class="job-row">` keyboard-operable with `role="button"`, `tabindex="0"`, an `aria-label`, and an `(keydown)` handler. The row also contains `mat-icon-button`s for stop / resume / restart / delete, so axe-core flags the result as **"Nested interactive controls"** — native `<button>`s inside `role="button"` is an invalid ARIA pattern. The pattern is also semantically wrong: the row **navigates** via `router.navigate(...)`, it doesn't perform an in-place action.

This PR adopts **Option A** from the issue — switch the row to `role="link"`:

- `jobs-dashboard.component.html` — `role="button"` → `role="link"` on `<tr class="job-row">`.
- `jobs-dashboard.component.ts` — `onRowKeydown` drops the Space / Spacebar branch. Per the ARIA `link` spec, links activate on Enter only. The `event.target !== event.currentTarget` short-circuit (so inner action buttons keep their independent semantics) and the `preventDefault()` on Enter stay.
- `jobs-dashboard.component.spec.ts` — replaces the "navigates on Space and prevents default" test with an "ignores Space (role=\"link\" only activates on Enter)" assertion.

`getJobAriaLabel`, `navigateToJob`, all click handlers, focus styling (`box-shadow` inset accent ring), `cursor: pointer`, and the action buttons' `stopPropagation()` calls are unchanged.

### Acceptance mapping (#499)

| Criterion | Status |
|---|---|
| No "nested interactive controls" / "buttons must not contain interactive elements" violations from axe-core | Resolved by role change — manual axe DevTools check needed (no axe-core test harness in `user-interface/` today) |
| Keyboard activation from #481 preserved (Tab + Enter, action buttons independently focusable) | `onRowKeydown` still handles Enter; child-target short-circuit unchanged; action buttons' `stopPropagation()` unchanged |
| aria-label still conveys team / type / repo / status / time-ago | `getJobAriaLabel` unchanged |
| Spec coverage updated for the chosen role's activation key | Space test replaced with Space-ignored assertion |
| Manual screen-reader smoke: row announces as "link", action buttons as buttons | Pending reviewer verification |

## Test plan

- [x] `npx vitest run src/app/components/jobs-dashboard` — 25/25 pass.
- [x] `npx vitest run` — full suite 411/411 pass.
- [x] `npm run lint` — clean.
- [x] `npm run build` — clean (pre-existing bundle-size budget warning unrelated to this change, exists on `main`).
- [ ] Manual browser pass at `/jobs-dashboard`: Tab lands on each row with the inset accent focus ring; Enter navigates; **Space does nothing** (new vs. #498); Tab from a row reaches inner action buttons; activating an action button does not also navigate the row.
- [ ] **axe DevTools** on `/jobs-dashboard`: no "Nested interactive controls" / "buttons must not contain interactive elements" violations.
- [ ] **Screen reader (VoiceOver / NVDA)**: row focus announces "link, Open &lt;team&gt; &lt;type&gt; job for &lt;subject&gt;, status &lt;status&gt;, started &lt;when&gt;"; action buttons announce as buttons.

Refs #481, #498.

https://claude.ai/code/session_016n2jkaCV6Fcv8kitXZVEkm

---
_Generated by [Claude Code](https://claude.ai/code/session_016n2jkaCV6Fcv8kitXZVEkm)_