### PR TITLE
theme: bump --kh-text-muted to WCAG AA, add --kh-border-muted (#502)

### DIFF
--- a/user-interface/src/app/components/blogging-dashboard/blogging-dashboard.component.scss
+++ b/user-interface/src/app/components/blogging-dashboard/blogging-dashboard.component.scss
@@ -101,7 +101,7 @@
   &.status-running, &.status-pending { border-left-color: var(--kh-accent); }
   &.status-completed, &.status-needs_human_review { border-left-color: var(--kh-success); }
   &.status-failed    { border-left-color: var(--kh-error); }
-  &.status-cancelled { border-left-color: var(--kh-text-muted); }
+  &.status-cancelled { border-left-color: var(--kh-border-muted); }
   &.status-interrupted { border-left-color: var(--kh-warning, #d97706); }
 
   .brief-text {

--- a/user-interface/src/app/components/deepthought-dashboard/deepthought-dashboard.component.scss
+++ b/user-interface/src/app/components/deepthought-dashboard/deepthought-dashboard.component.scss
@@ -389,7 +389,7 @@
   span {
     width: 7px;
     height: 7px;
-    background: var(--kh-text-muted, #71717a);
+    background: var(--kh-border-muted, #71717a);
     border-radius: 50%;
     animation: bounce 1.4s infinite ease-in-out;
     &:nth-child(1) { animation-delay: 0s; }

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
@@ -166,11 +166,11 @@
 
       // Status left-border indicators
       &.status-running   { border-left: 3px solid var(--kh-accent); }
-      &.status-pending    { border-left: 3px solid var(--kh-text-muted); }
+      &.status-pending    { border-left: 3px solid var(--kh-border-muted); }
       &.status-waiting    { border-left: 3px solid var(--kh-warning); }
       &.status-completed  { border-left: 3px solid var(--kh-success); }
       &.status-failed     { border-left: 3px solid var(--kh-error); }
-      &.status-cancelled    { border-left: 3px solid var(--kh-text-muted); }
+      &.status-cancelled    { border-left: 3px solid var(--kh-border-muted); }
       &.status-interrupted  { border-left: 3px solid var(--kh-warning); }
 
       td {

--- a/user-interface/src/app/components/team-assistant-chat/team-assistant-chat.component.scss
+++ b/user-interface/src/app/components/team-assistant-chat/team-assistant-chat.component.scss
@@ -112,7 +112,7 @@
   display: flex; gap: 4px; padding: 4px 0;
   span {
     width: 7px; height: 7px;
-    background: var(--kh-text-muted, #8b949e);
+    background: var(--kh-border-muted, #8b949e);
     border-radius: 50%;
     animation: bounce 1.4s infinite ease-in-out;
     &:nth-child(1) { animation-delay: 0s; }

--- a/user-interface/src/theme.scss
+++ b/user-interface/src/theme.scss
@@ -32,8 +32,10 @@ body {
 
 :root {
   // ── HIGH CONTRAST DESIGN ────────────────────────────────────────────────
-  // Designed for color acuity issues. Most text/background pairs exceed
-  // WCAG AAA (7:1); --kh-text-muted is the lone exception (see note below).
+  // Designed for color acuity issues. All text/background pairs exceed
+  // WCAG AAA (7:1) except --kh-text-muted, which clears AA (≥ 4.5:1) on
+  // every --kh-surface-* layer. Decorative usages of the original muted
+  // shade live on --kh-border-muted.
   // Semantic colors are maximally separated in luminance, not just hue.
   // Borders and surfaces have strong visible separation.
 
@@ -58,20 +60,18 @@ body {
   --kh-glass-active:      rgba(255, 255, 255, 0.16);
   --kh-glass-border:      rgba(255, 255, 255, 0.10);
 
-  // ── Text Colors (high contrast — all exceed 7:1 on surface-0/1/2) ──────
+  // ── Text Colors (high contrast — primary/secondary/tertiary exceed 7:1
+  // on surface-0/1/2; muted clears AA ≥ 4.5:1 on every surface) ───────────
   --kh-text-primary:      #ffffff;
   --kh-text-secondary:    #d4d4d8;
   --kh-text-tertiary:     #a1a1aa;
-  // --kh-text-muted is BELOW WCAG AA (4.5:1) for body text on surface-0/1/2.
-  // Use it only for decorative borders or icons. For text, prefer
-  // --kh-text-tertiary or --kh-text-secondary. Global token bump tracked in
-  // the follow-up issue to #494.
-  --kh-text-muted:        #71717a;
+  --kh-text-muted:        #909099;
 
   // ── Borders (strong and visible) ────────────────────────────────────────
   --kh-border:            rgba(255, 255, 255, 0.16);
   --kh-border-subtle:     rgba(255, 255, 255, 0.10);
   --kh-border-strong:     rgba(255, 255, 255, 0.25);
+  --kh-border-muted:      #71717a;   // decorative-only — matches pre-#502 --kh-text-muted
 
   // ── Semantic Colors (maximally bright — high luminance contrast) ────────
   // These are chosen to differ in LUMINANCE, not just hue, so they remain


### PR DESCRIPTION
## Summary

Closes #502.

- Bumps `--kh-text-muted` from `#71717a` (sub-AA, 3.13–4.10:1 on dark surfaces) to `#909099`, clearing WCAG AA (≥ 4.5:1) on every `--kh-surface-*` layer while preserving the 4-tier text hierarchy.
- Introduces `--kh-border-muted: #71717a` so decorative usages that depended on the original darker shade keep their visual weight.
- Migrates 5 non-color decorative usages off `--kh-text-muted`:
  - `jobs-dashboard.component.scss` — `&.status-pending` / `&.status-cancelled` `border-left`
  - `blogging-dashboard.component.scss` — `&.status-cancelled` `border-left-color`
  - `deepthought-dashboard.component.scss` — typing-indicator dot `background`
  - `team-assistant-chat.component.scss` — typing-indicator dot `background`
- Restores the WCAG-AAA assertion in `theme.scss` softened in #494, with an explicit note that `--kh-text-muted` is the AA-only exception.

The ~127 `color:` consumers of `--kh-text-muted` (across blogging-dashboard, strategy-lab, deepthought-dashboard, software-engineering-dashboard, persona-testing-dashboard, integrations-dashboard, app-shell, agent-console, etc.) inherit the new lighter value automatically.

## Contrast math (WCAG 2.1)

`--kh-text-muted: #909099` on each surface:

| Surface | Hex | Ratio | Result |
|---|---|---|---|
| `--kh-surface-0` | `#000000` | 6.64:1 | AA |
| `--kh-surface-1` | `#0a0a0a` | 6.26:1 | AA |
| `--kh-surface-2` | `#171717` | 5.66:1 | AA |
| `--kh-surface-3` | `#262626` | 4.78:1 | AA |

For reference, `--kh-text-tertiary` (`#a1a1aa`) stays at 5.90–8.19:1 — still visibly the brighter neighbour, so the 4-tier hierarchy is preserved.

## Why narrower than the original issue scope?

Issue #502 listed both border/background decorative usages *and* icon `color:` hits (e.g. strategy-lab phase chips, jobs-dashboard empty-state icon, blog-pipeline-flow). After confirming with the requester during planning, only **non-color** CSS properties were migrated to `--kh-border-muted`. Icon `color:` usages stay on `--kh-text-muted` and benefit from the readability bump — they're foreground UI elements where the new lighter value is a net win.

## Acceptance criteria

- [x] `--kh-text-muted` clears WCAG AA (≥ 4.5:1) on `--kh-surface-0`/-1/-2/-3.
- [x] `--kh-border-muted` introduced; decorative consumers migrated.
- [x] Header comment in `theme.scss` restored (AAA-everywhere except muted, which is AA).
- [ ] Manual axe DevTools sweep — see Test plan below; needs a human pass in a browser since jsdom can't paint.

## Test plan

- [x] `npm run build` — production build green.
- [x] `npm test` — 99 test files / 413 tests pass; the existing `jobs-dashboard.component.a11y.spec.ts` structural axe spec still passes (color-contrast rule remains disabled — jsdom limitation, unchanged).
- [ ] Browser axe DevTools sweep at `/jobs`, `/blogging`, `/strategy-lab`, `/deepthought`, `/software-engineering`, `/persona-testing`, `/integrations`, plus app-shell chrome. Expect zero color-contrast violations on muted-class text and no visual regression on the 5 migrated decorative spots.

## Out of scope

- Playwright + axe color-contrast browser specs (issue defers to future work).
- Re-enabling `color-contrast` in the existing jsdom-based a11y spec.
- Sibling jobs-dashboard polish work (#478–#496).

https://claude.ai/code/session_01V3Uk89357yUytiHsF5ukMz

---
_Generated by [Claude Code](https://claude.ai/code/session_01V3Uk89357yUytiHsF5ukMz)_