### PR TITLE
investment-team: perf-guard for coverage-probe success path (#453)

### DIFF
--- a/backend/agents/investment_team/tests/test_coverage_probe_perf_guard.py
+++ b/backend/agents/investment_team/tests/test_coverage_probe_perf_guard.py
@@ -1,0 +1,139 @@
+"""Perf-guard for the #451 coverage-probe stage on the success path (#453, F).
+
+Acceptance criterion (F) of #453: on a successful backtest the orchestrator's
+coverage-probe stage MUST short-circuit (``BacktestResult.coverage_report =
+None``) and add at most ``1.1×`` to the total runtime vs. the unprobed path.
+
+Structural correctness on the success path is already exercised by
+``test_coverage_probe_orchestrator_stage.py`` (``no_ops_when_gate_off``); this
+module pins the *quantitative* runtime bound called out in the issue.
+"""
+
+from __future__ import annotations
+
+import time
+from statistics import median
+from typing import Any
+
+import pytest
+
+from investment_team.models import BacktestResult
+from investment_team.strategy_lab import orchestrator as orch_mod
+from investment_team.strategy_lab.orchestrator import _maybe_attach_coverage_report
+
+from ._coverage_probe_test_helpers import (
+    make_config,
+    make_diag,
+    make_exec_result,
+    make_flat_df,
+    make_spec,
+)
+
+_ITERATIONS = 200
+_RUNTIME_RATIO_BOUND = 1.1
+_WORKLOAD_OPS = 2000
+
+
+def _fresh_metrics() -> BacktestResult:
+    return BacktestResult(
+        total_return_pct=8.0,
+        annualized_return_pct=12.0,
+        volatility_pct=15.0,
+        sharpe_ratio=1.1,
+        max_drawdown_pct=4.0,
+        win_rate_pct=55.0,
+        profit_factor=1.6,
+    )
+
+
+def _success_kwargs() -> dict[str, Any]:
+    return dict(
+        spec=make_spec("X = 1\n"),
+        market_data={"AAPL": make_flat_df(50)},
+        config=make_config(),
+        exec_result=make_exec_result(make_diag(closed=10, orders_accepted=10)),
+    )
+
+
+def _synthetic_backtest_workload() -> float:
+    total = 0.0
+    for i in range(_WORKLOAD_OPS):
+        total += (i * 0.5) - 0.25
+    return total
+
+
+def test_success_path_does_not_invoke_probe_stage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A run with ``closed_trades >= LOW_TRADE_THRESHOLD`` and no
+    ``zero_trade_category`` must never reach ``run_coverage_stage`` —
+    the gate in ``should_run_probes`` short-circuits and
+    ``BacktestResult.coverage_report`` stays ``None``.
+
+    Re-locks #453 (G) at the success-path boundary: the probe stage is
+    the only LLM-touching code path here, so "stage never runs" implies
+    "no LLM call on a successful backtest".
+    """
+
+    def _must_not_run(**_kwargs: Any) -> None:
+        raise AssertionError("run_coverage_stage must not run on a successful backtest")
+
+    monkeypatch.setattr(orch_mod, "run_coverage_stage", _must_not_run)
+
+    metrics = _fresh_metrics()
+    _maybe_attach_coverage_report(metrics=metrics, **_success_kwargs())
+
+    assert metrics.coverage_report is None
+
+
+def test_success_path_runtime_within_ten_percent_of_unprobed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Median runtime of (workload + helper-gated-off) must stay within
+    ``1.1×`` of (workload alone).
+
+    The helper itself is O(1) on success (one ``should_run_probes`` call
+    plus a Python-level branch), so this is effectively a regression
+    guard: a future refactor that started doing real work on the success
+    path would have to either fail this bound or stash that work behind
+    a different name.
+
+    Samples are interleaved so a transient CPU spike biases both
+    populations equally — straight back-to-back loops let scheduler
+    hiccups cluster on one side and flake CI.
+    """
+
+    def _must_not_run(**_kwargs: Any) -> None:
+        raise AssertionError("run_coverage_stage must not run on a successful backtest")
+
+    monkeypatch.setattr(orch_mod, "run_coverage_stage", _must_not_run)
+
+    kwargs = _success_kwargs()
+    metrics = _fresh_metrics()
+
+    baseline_samples: list[float] = []
+    probed_samples: list[float] = []
+    for _ in range(_ITERATIONS):
+        t0 = time.perf_counter()
+        _synthetic_backtest_workload()
+        baseline_samples.append(time.perf_counter() - t0)
+
+        t0 = time.perf_counter()
+        _synthetic_backtest_workload()
+        _maybe_attach_coverage_report(metrics=metrics, **kwargs)
+        probed_samples.append(time.perf_counter() - t0)
+
+    baseline_med = median(baseline_samples)
+    probed_med = median(probed_samples)
+    # Floor the denominator at 1µs to defang the unlikely zero-baseline
+    # corner case; real samples on any CI machine sit in the 50–500µs
+    # band given _WORKLOAD_OPS=2000.
+    baseline_floor = max(baseline_med, 1e-6)
+
+    assert probed_med <= _RUNTIME_RATIO_BOUND * baseline_floor, (
+        "coverage-probe gate added > "
+        f"{(_RUNTIME_RATIO_BOUND - 1) * 100:.0f}% on successful backtest: "
+        f"baseline_med={baseline_med * 1e6:.2f}µs, "
+        f"probed_med={probed_med * 1e6:.2f}µs"
+    )
+    assert metrics.coverage_report is None


### PR DESCRIPTION
## Summary

Closes the last open acceptance criterion of #453 (the Strategy Lab
coverage-probe epic #406 capstone).

An audit of `backend/agents/investment_team/tests/` against the seven
criteria in the #453 body showed that six of them are already covered by
tests landed in #446–#452. The genuinely-missing piece is the
**quantitative `1.1×` runtime bound on the success path** — every other
test pins the structural contract (the helper short-circuits and
`coverage_report` stays `None`) but nothing pins the budget.

This PR adds one focused test module, `test_coverage_probe_perf_guard.py`,
with two tests:

- **`test_success_path_does_not_invoke_probe_stage`** — monkeypatches
  `run_coverage_stage` to a fail-loud sentinel, calls
  `_maybe_attach_coverage_report` with `closed_trades=10`
  diagnostics, asserts the stage never ran and `coverage_report is None`.
- **`test_success_path_runtime_within_ten_percent_of_unprobed`** — times
  an interleaved baseline workload against the same workload plus the
  helper call. Asserts the median ratio stays within `1.1×`. The sentinel
  monkeypatch is kept active so a regression that started spinning up
  the stage on the success path can't hide behind timing noise.

## Acceptance-criterion → evidence map (for #453)

| #453 criterion | Evidence |
|---|---|
| (A) Pydantic round-trip + `BacktestResult` back-compat for `coverage_report=None` | `test_coverage_probe_models.py` |
| (B) Static probe categorisation | `test_strategy_lab_static_probe.py` |
| (C) Indicator probe hit-rate / conjunction / partial-fire | `test_indicator_probe_robustness.py` (+ `_basic.py`, `_conjunction.py`) |
| (D) Runtime instrument: trades preserved, events bounded, idempotent | `test_strategy_lab_runtime_instrument.py` (+ `_golden.py`), `test_coverage_probe_stage.py` |
| (E) `format_coverage_report` + `QualityGateResult.details` carry the category | `test_coverage_probe_rendering.py`, `test_backtest_anomaly_zero_trade_diagnostics.py::test_zero_trade_details_include_coverage_line_when_report_present` |
| **(F) success → `coverage_report=None` + ≤1.1× total runtime** | **`test_coverage_probe_perf_guard.py` ← this PR** |
| (G) no LLM call on probe paths | `test_coverage_probe_stage.py::test_no_llm_calls_made` (+ re-locked at the success boundary by the new perf-guard's spy) |

## Test plan

- [x] `pytest agents/investment_team/tests/test_coverage_probe_perf_guard.py -v` — 2 passed
- [x] `pytest agents/investment_team/tests/test_coverage_probe_*.py agents/investment_team/tests/test_backtest_anomaly_zero_trade_diagnostics.py -q` — 73 passed, no regressions
- [x] `ruff check` + `ruff format --check` on the new file

## Out of scope

- Recreating the test files named in the #453 body that already exist
  under different names (would duplicate signal).
- Refactoring the probe modules — the open follow-ups #465–#471 cover that
  and are explicitly out of #453's scope.

https://claude.ai/code/session_012UE4Nh9AkoMv9ps32BQkWw

---
_Generated by [Claude Code](https://claude.ai/code/session_012UE4Nh9AkoMv9ps32BQkWw)_