### PR TITLE
investment-team: trailing-stop ratchet runtime + bracket child (#390)

### DIFF
--- a/backend/agents/investment_team/tests/test_bracket_orders.py
+++ b/backend/agents/investment_team/tests/test_bracket_orders.py
@@ -26,8 +26,11 @@ on the no-attachment path and two follow-ups from the PR review:
 13. Bracket children materialized at expiry time defer past the bar that
     triggered the expiry — a gap-through opening must not abort the
     backtest via ``LookAheadError``.
-14. Trailing-stop attachments (``StopAttachment.trail_offset``) remain
-    gated until #390 — runtime materialization lands with Step 8.
+14. Trailing-stop attachments (``StopAttachment.trail_offset``) materialize
+    as TRAILING_STOP children with ratchet state pre-seeded from the
+    parent's fill price (#390).
+15. Trailing-stop bracket child ratchets across bars and OCO-cancels the
+    take-profit sibling on first child fill.
 """
 
 from __future__ import annotations
@@ -55,7 +58,6 @@ from investment_team.trading_service.strategy.contract import (
     StopAttachment,
     TimeInForce,
     UnfilledPolicy,
-    UnsupportedOrderFeatureError,
 )
 
 
@@ -842,27 +844,23 @@ def test_expiry_bar_gap_through_does_not_abort_via_lookahead() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Trailing-stop attachments remain gated until #390 (Codex P2)
+# Trailing-stop attachments are runtime-supported as of #390
 # ---------------------------------------------------------------------------
 
 
-def test_trailing_stop_attachment_is_gated_until_step_8() -> None:
-    """``StopAttachment(trail_offset=...)`` is a trailing stop; the
-    materializer would otherwise silently downgrade it to a fixed STOP at
-    ``stop_price``. Reject loudly until #390 ships trailing-stop runtime."""
-    req = OrderRequest(
+def test_trailing_stop_attachment_validates_and_materializes_as_trailing_child() -> None:
+    """``StopAttachment(trail_offset=...)`` materializes as a TRAILING_STOP
+    child with the ratchet pre-seeded from the parent's fill price (#390)."""
+    # Both abs and bps variants now validate at submission time.
+    OrderRequest(
         client_order_id="entry-1",
         symbol="AAA",
         side=OrderSide.LONG,
         qty=10.0,
         order_type=OrderType.MARKET,
         attached_stop_loss=StopAttachment(stop_price=95.0, trail_offset=2.0),
-    )
-    with pytest.raises(UnsupportedOrderFeatureError, match="#390"):
-        req.validate_prices()
-
-    # ``trail_offset_kind="bps"`` variant is also blocked.
-    req_bps = OrderRequest(
+    ).validate_prices()
+    OrderRequest(
         client_order_id="entry-1",
         symbol="AAA",
         side=OrderSide.LONG,
@@ -871,11 +869,9 @@ def test_trailing_stop_attachment_is_gated_until_step_8() -> None:
         attached_stop_loss=StopAttachment(
             stop_price=95.0, trail_offset=20.0, trail_offset_kind="bps"
         ),
-    )
-    with pytest.raises(UnsupportedOrderFeatureError, match="#390"):
-        req_bps.validate_prices()
+    ).validate_prices()
 
-    # Plain fixed-stop attachment (no trail_offset) still validates.
+    # Plain fixed-stop attachment (no trail_offset) is unaffected.
     OrderRequest(
         client_order_id="entry-1",
         symbol="AAA",
@@ -884,3 +880,93 @@ def test_trailing_stop_attachment_is_gated_until_step_8() -> None:
         order_type=OrderType.MARKET,
         attached_stop_loss=StopAttachment(stop_price=95.0),
     ).validate_prices()
+
+    # End-to-end: entry fill materializes a TRAILING_STOP child whose
+    # ``trailing_water`` / ``effective_stop_price`` are pre-seeded from
+    # the parent's fill price (so the first eligible bar trails from
+    # the entry, not from that bar's high).
+    sim, order_book, _portfolio = _make_simulator()
+    parent = order_book.submit(
+        OrderRequest(
+            client_order_id="entry-1",
+            symbol="AAA",
+            side=OrderSide.LONG,
+            qty=10.0,
+            order_type=OrderType.MARKET,
+            tif=TimeInForce.DAY,
+            attached_stop_loss=StopAttachment(stop_price=95.0, trail_offset=2.0),
+            attached_take_profit=LimitAttachment(limit_price=110.0),
+        ),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+        expect_brackets=True,
+    )
+    sim.process_bar(_bar("2024-01-02", open_price=100.0))
+
+    children = order_book.children_of(parent.order_id)
+    sl = next(c for c in children if c.request.order_type == OrderType.TRAILING_STOP)
+    assert sl.request.trail_offset == pytest.approx(2.0, rel=1e-9)
+    assert sl.request.trail_offset_kind == "abs"
+    assert sl.trailing_water == pytest.approx(100.0, rel=1e-9)
+    assert sl.effective_stop_price == pytest.approx(98.0, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# 15. Trailing-stop bracket child ratchets across bars; TP fill cancels SL via OCO
+# ---------------------------------------------------------------------------
+
+
+def test_trailing_stop_bracket_child_ratchets_and_oco_cancels_on_tp_fill() -> None:
+    """Trailing-stop bracket child must (a) ratchet ``trailing_water`` and
+    ``effective_stop_price`` favorably across bars, (b) leave them
+    untouched on an adverse bar, and (c) be removed via the existing OCO
+    cancellation when its take-profit sibling fills first."""
+    sim, order_book, portfolio = _make_simulator()
+    parent = order_book.submit(
+        OrderRequest(
+            client_order_id="entry-1",
+            symbol="AAA",
+            side=OrderSide.LONG,
+            qty=10.0,
+            order_type=OrderType.MARKET,
+            tif=TimeInForce.DAY,
+            attached_stop_loss=StopAttachment(stop_price=95.0, trail_offset=2.0),
+            attached_take_profit=LimitAttachment(limit_price=110.0),
+        ),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+        expect_brackets=True,
+    )
+
+    # Bar 1: entry fills at 100 → trailing child pre-seeded to (100, 98).
+    sim.process_bar(_bar("2024-01-02", open_price=100.0))
+    children = order_book.children_of(parent.order_id)
+    sl = next(c for c in children if c.request.order_type == OrderType.TRAILING_STOP)
+    tp = next(c for c in children if c.request.order_type == OrderType.LIMIT)
+    assert sl.trailing_water == pytest.approx(100.0, rel=1e-9)
+    assert sl.effective_stop_price == pytest.approx(98.0, rel=1e-9)
+
+    # Bar 2: favorable move (high 108, low 107 — above the new eff=106 so SL
+    # doesn't fire) → ratchet up.
+    sim.process_bar(_bar("2024-01-03", open_price=105.0, high=108.0, low=107.0, close=107.5))
+    assert sl.trailing_water == pytest.approx(108.0, rel=1e-9)
+    assert sl.effective_stop_price == pytest.approx(106.0, rel=1e-9)
+
+    # Bar 3: adverse retrace (high 107.5, low 106.5 — still above eff=106) →
+    # no change to ratchet.
+    sim.process_bar(_bar("2024-01-04", open_price=107.0, high=107.5, low=106.5, close=106.8))
+    assert sl.trailing_water == pytest.approx(108.0, rel=1e-9)
+    assert sl.effective_stop_price == pytest.approx(106.0, rel=1e-9)
+
+    # Bar 4: high 112 crosses TP limit 110; low 111 stays above SL eff_stop
+    # (which ratchets to 112-2=110 on this bar). TP fills first; OCO cancels
+    # the trailing SL sibling.
+    outcome = sim.process_bar(
+        _bar("2024-01-05", open_price=109.0, high=112.0, low=111.0, close=111.5)
+    )
+    assert len(outcome.exit_fills) == 1
+    assert outcome.exit_fills[0].price == pytest.approx(110.0, rel=1e-9)
+    assert outcome.exit_fills[0].order_id == tp.order_id
+    assert "AAA" not in portfolio.positions
+    assert order_book.children_of(parent.order_id) == []
+    assert order_book.all_pending() == []

--- a/backend/agents/investment_team/tests/test_contract_gates.py
+++ b/backend/agents/investment_team/tests/test_contract_gates.py
@@ -37,10 +37,32 @@ def _base(**overrides) -> OrderRequest:
     return OrderRequest(**kwargs)
 
 
-def test_trailing_stop_is_gated_until_step_8():
-    req = _base(order_type=OrderType.TRAILING_STOP, stop_price=10.0)
-    with pytest.raises(NotImplementedError, match="#390"):
-        req.validate_prices()
+def test_trailing_stop_validates_post_step_8():
+    """``TRAILING_STOP`` is runtime-supported as of #390. The blanket
+    submission-time gate is gone; the remaining shape-consistency checks
+    require ``stop_price`` (initial water mark) and ``trail_offset``."""
+    _base(
+        order_type=OrderType.TRAILING_STOP,
+        stop_price=10.0,
+        trail_offset=1.0,
+    ).validate_prices()
+    _base(
+        order_type=OrderType.TRAILING_STOP,
+        stop_price=10.0,
+        trail_offset=20.0,
+        trail_offset_kind="bps",
+    ).validate_prices()
+    # Missing required fields still rejected.
+    with pytest.raises(ValueError, match="trail_offset"):
+        _base(order_type=OrderType.TRAILING_STOP, stop_price=10.0).validate_prices()
+    with pytest.raises(ValueError, match="stop_price"):
+        _base(order_type=OrderType.TRAILING_STOP, trail_offset=1.0).validate_prices()
+    with pytest.raises(ValueError, match="non-negative"):
+        _base(
+            order_type=OrderType.TRAILING_STOP,
+            stop_price=10.0,
+            trail_offset=-1.0,
+        ).validate_prices()
 
 
 def test_gates_raise_unsupported_order_feature_subclass():
@@ -48,7 +70,7 @@ def test_gates_raise_unsupported_order_feature_subclass():
     ``NotImplementedError``, so streaming_harness only re-classifies real
     gate violations as ``unsupported_feature`` (and lets unrelated
     ``NotImplementedError`` from strategy code stay as ``runtime_error``)."""
-    req = _base(order_type=OrderType.TRAILING_STOP, stop_price=10.0)
+    req = _base(parent_order_id="p-1")
     with pytest.raises(UnsupportedOrderFeatureError):
         req.validate_prices()
 

--- a/backend/agents/investment_team/tests/test_order_book.py
+++ b/backend/agents/investment_team/tests/test_order_book.py
@@ -24,7 +24,6 @@ from investment_team.trading_service.strategy.contract import (
     OrderSide,
     OrderType,
     TimeInForce,
-    UnsupportedOrderFeatureError,
 )
 
 
@@ -1051,16 +1050,22 @@ def test_submit_attached_rejects_stop_child_without_price() -> None:
     assert book.children_of(parent.order_id) == []
 
 
-def test_submit_attached_rejects_trailing_stop_child() -> None:
-    """TRAILING_STOP is gated until #390 ships — the gate must still fire on
-    bracket children even though strategy-level submit was bypassed.
+def test_submit_attached_rejects_trailing_stop_child_without_trail_offset() -> None:
+    """TRAILING_STOP children are runtime-supported as of #390, but
+    ``submit_attached`` still re-runs ``validate_prices`` so a
+    malformed child (missing ``trail_offset``) is rejected at submit
+    time rather than queued and crashing the simulator later.
     """
     book = OrderBook()
     parent = _bracket_parent(book)
-    with pytest.raises(UnsupportedOrderFeatureError, match="#390"):
+    with pytest.raises(ValueError, match="trail_offset"):
         book.submit_attached(
             _base(
-                side=OrderSide.SHORT, qty=10.0, order_type=OrderType.TRAILING_STOP, stop_price=95.0
+                side=OrderSide.SHORT,
+                qty=10.0,
+                order_type=OrderType.TRAILING_STOP,
+                stop_price=95.0,
+                # trail_offset deliberately omitted
             ),
             submitted_at="2024-01-03",
             submitted_equity=100_000.0,
@@ -1068,6 +1073,22 @@ def test_submit_attached_rejects_trailing_stop_child() -> None:
             oco_group_id="g1",
         )
     assert book.children_of(parent.order_id) == []
+
+    # Well-formed TRAILING_STOP child queues successfully.
+    book.submit_attached(
+        _base(
+            side=OrderSide.SHORT,
+            qty=10.0,
+            order_type=OrderType.TRAILING_STOP,
+            stop_price=95.0,
+            trail_offset=2.0,
+        ),
+        submitted_at="2024-01-03",
+        submitted_equity=100_000.0,
+        parent_order_id=parent.order_id,
+        oco_group_id="g1",
+    )
+    assert len(book.children_of(parent.order_id)) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -2119,8 +2140,8 @@ def test_requeue_handles_compact_offset_in_regression_check() -> None:
 
 def test_submit_attached_market_rejection_message_lists_supported_types() -> None:
     """The MARKET-rejection message must point callers at types that are
-    actually supported (``LIMIT`` / ``STOP``) — not at ``STOP_LIMIT``
-    (doesn't exist) or ``TRAILING_STOP`` (still gated until #390).
+    actually supported (``LIMIT`` / ``STOP`` / ``TRAILING_STOP``) — not
+    at ``STOP_LIMIT`` (doesn't exist).
     """
     book = OrderBook()
     parent = book.submit(
@@ -2138,8 +2159,8 @@ def test_submit_attached_market_rejection_message_lists_supported_types() -> Non
             oco_group_id="g1",
         )
     msg = str(excinfo.value)
-    assert "LIMIT or STOP" in msg
-    # Make sure we're not pointing callers at non-existent or gated types.
+    assert "LIMIT / STOP / TRAILING_STOP" in msg
+    # Make sure we're not pointing callers at non-existent types.
     assert "STOP_LIMIT" not in msg
 
 

--- a/backend/agents/investment_team/tests/test_trading_service.py
+++ b/backend/agents/investment_team/tests/test_trading_service.py
@@ -394,8 +394,8 @@ def test_execution_diagnostic_helpers_cap_events_and_count_rejections() -> None:
 _UNSUPPORTED_FEATURE_STRATEGY_CODE = textwrap.dedent('''\
     """Strategy that bypasses ``submit_order``'s subprocess-side validation
     to exercise the parent's ``UnsupportedOrderFeatureError`` rejection
-    path. Sets ``order_type=trailing_stop`` — still gated in
-    ``OrderRequest.validate_prices`` until #390 (Trading 5/5 Step 8).
+    path. Sets ``parent_order_id`` — still engine-internal and refused at
+    the strategy-side gate in ``OrderRequest.validate_prices``.
     """
     from contract import Strategy
 
@@ -416,9 +416,9 @@ _UNSUPPORTED_FEATURE_STRATEGY_CODE = textwrap.dedent('''\
                     "symbol": bar.symbol,
                     "side": "long",
                     "qty": 1.0,
-                    "order_type": "trailing_stop",
-                    "stop_price": 100.0,
+                    "order_type": "market",
                     "tif": "day",
+                    "parent_order_id": "engine-internal-id",
                 },
             })
 ''')

--- a/backend/agents/investment_team/tests/test_trailing_stop.py
+++ b/backend/agents/investment_team/tests/test_trailing_stop.py
@@ -1,0 +1,412 @@
+"""Trailing-stop runtime tests (Trading 5/5 Step 8 — issue #390).
+
+Covers the six new test cases for the standalone ``TRAILING_STOP`` order
+type and the ratchet mechanics. Bracket-child trailing stops are tested
+separately in ``test_bracket_orders.py``.
+
+Triggers follow the existing STOP geometry once the simulator's
+effective-request shim swaps ``po.effective_stop_price`` in for
+``req.stop_price``:
+
+* A SHORT stop closing a LONG position triggers when ``bar.low <= eff_stop``
+  and fills at ``min(bar.open, eff_stop)``.
+* A LONG stop closing a SHORT position triggers when ``bar.high >= eff_stop``
+  and fills at ``max(bar.open, eff_stop)``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from investment_team.execution.bar_safety import BarSafetyAssertion
+from investment_team.execution.risk_filter import RiskFilter, RiskLimits
+from investment_team.trading_service.engine.execution_model import (
+    RealisticExecutionModel,
+)
+from investment_team.trading_service.engine.fill_simulator import (
+    FillSimulator,
+    FillSimulatorConfig,
+)
+from investment_team.trading_service.engine.order_book import OrderBook
+from investment_team.trading_service.engine.portfolio import Portfolio
+from investment_team.trading_service.strategy.contract import (
+    Bar,
+    OrderRequest,
+    OrderSide,
+    OrderType,
+    TimeInForce,
+)
+
+
+def _bar(
+    ts: str,
+    *,
+    open_price: float,
+    high: float,
+    low: float,
+    close: float | None = None,
+    volume: float = 1_000_000.0,
+) -> Bar:
+    return Bar(
+        symbol="AAA",
+        timestamp=ts,
+        timeframe="1d",
+        open=open_price,
+        high=high,
+        low=low,
+        close=close if close is not None else open_price,
+        volume=volume,
+    )
+
+
+def _make_simulator() -> tuple[FillSimulator, OrderBook, Portfolio]:
+    portfolio = Portfolio(initial_capital=10_000_000.0)
+    order_book = OrderBook()
+    sim = FillSimulator(
+        portfolio=portfolio,
+        order_book=order_book,
+        risk_filter=RiskFilter(RiskLimits(max_position_pct=100, max_gross_leverage=10.0)),
+        config=FillSimulatorConfig(slippage_bps=0.0, transaction_cost_bps=0.0),
+        bar_safety=BarSafetyAssertion(),
+        execution_model=RealisticExecutionModel(participation_cap=0.10),
+    )
+    return sim, order_book, portfolio
+
+
+def _open_long(
+    sim: FillSimulator,
+    order_book: OrderBook,
+    *,
+    qty: float = 10.0,
+    entry_bar_ts: str = "2024-01-02",
+    entry_open: float = 100.0,
+) -> str:
+    """Open a LONG position via a MARKET entry order that fills on
+    ``entry_bar_ts``. Returns the position's entry ``order_id``."""
+    order_book.submit(
+        OrderRequest(
+            client_order_id="entry-1",
+            symbol="AAA",
+            side=OrderSide.LONG,
+            qty=qty,
+            order_type=OrderType.MARKET,
+            tif=TimeInForce.DAY,
+        ),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+    )
+    sim.process_bar(_bar(entry_bar_ts, open_price=entry_open, high=entry_open, low=entry_open))
+    return "entry-1"
+
+
+def _open_short(
+    sim: FillSimulator,
+    order_book: OrderBook,
+    *,
+    qty: float = 10.0,
+    entry_bar_ts: str = "2024-01-02",
+    entry_open: float = 100.0,
+) -> str:
+    order_book.submit(
+        OrderRequest(
+            client_order_id="entry-1",
+            symbol="AAA",
+            side=OrderSide.SHORT,
+            qty=qty,
+            order_type=OrderType.MARKET,
+            tif=TimeInForce.DAY,
+        ),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+    )
+    sim.process_bar(_bar(entry_bar_ts, open_price=entry_open, high=entry_open, low=entry_open))
+    return "entry-1"
+
+
+def _trailing_stop_po(order_book: OrderBook, client_order_id: str):
+    """Find a pending trailing-stop order by client_order_id."""
+    for po in order_book.all_pending():
+        if po.request.client_order_id == client_order_id:
+            return po
+    raise AssertionError(f"trailing stop {client_order_id!r} not found in book")
+
+
+# ---------------------------------------------------------------------------
+# 1. LONG trailing stop ratchets then fills (abs offset)
+# ---------------------------------------------------------------------------
+
+
+def test_long_trailing_stop_ratchets_then_fills() -> None:
+    """LONG position closed by SHORT TRAILING_STOP, abs offset=5.
+
+    Bars present highs of 100 → 110 → 107. Eff stop ratchets:
+    bar 1 → 95 (no trigger), bar 2 → 105 (no trigger), bar 3 stays 105
+    (water=110 sticky), and bar 3 low=104 ≤ 105 triggers the stop at 105.
+    """
+    sim, order_book, portfolio = _make_simulator()
+    _open_long(sim, order_book, qty=10.0, entry_bar_ts="2024-01-02", entry_open=100.0)
+    assert "AAA" in portfolio.positions
+
+    order_book.submit(
+        OrderRequest(
+            client_order_id="trail-1",
+            symbol="AAA",
+            side=OrderSide.SHORT,
+            qty=10.0,
+            order_type=OrderType.TRAILING_STOP,
+            stop_price=95.0,  # initial water seed
+            trail_offset=5.0,
+            trail_offset_kind="abs",
+            tif=TimeInForce.GTC,
+        ),
+        submitted_at="2024-01-02",
+        submitted_equity=10_000_000.0,
+    )
+
+    # Bar 2: high=100, low=98 — water=100 (max(95, 100)), eff=95. low > 95.
+    sim.process_bar(_bar("2024-01-03", open_price=100.0, high=100.0, low=98.0, close=99.5))
+    sl = _trailing_stop_po(order_book, "trail-1")
+    assert sl.trailing_water == pytest.approx(100.0, rel=1e-9)
+    assert sl.effective_stop_price == pytest.approx(95.0, rel=1e-9)
+
+    # Bar 3: favorable — high=110, low=106. water=110, eff=105. low > 105.
+    sim.process_bar(_bar("2024-01-04", open_price=101.0, high=110.0, low=106.0, close=109.0))
+    sl = _trailing_stop_po(order_book, "trail-1")
+    assert sl.trailing_water == pytest.approx(110.0, rel=1e-9)
+    assert sl.effective_stop_price == pytest.approx(105.0, rel=1e-9)
+
+    # Bar 4: retrace — high=107, low=104. water=110 stays, eff=105. low ≤ 105: trigger.
+    outcome = sim.process_bar(
+        _bar("2024-01-05", open_price=107.0, high=107.0, low=104.0, close=105.0)
+    )
+    assert len(outcome.exit_fills) == 1
+    assert outcome.exit_fills[0].price == pytest.approx(105.0, rel=1e-9)
+    assert "AAA" not in portfolio.positions
+
+
+# ---------------------------------------------------------------------------
+# 2. Retrace fixture — water=120 sticks, fills at 115 (not 95)
+# ---------------------------------------------------------------------------
+
+
+def test_long_trailing_stop_holds_through_retrace() -> None:
+    """Confirms the ratchet only moves favorably. After a peak at 120 the
+    eff_stop locks at 115 and survives a retrace; it must NOT relax back
+    toward the initial 95 just because the price came back down."""
+    sim, order_book, portfolio = _make_simulator()
+    _open_long(sim, order_book, qty=10.0, entry_bar_ts="2024-01-02", entry_open=100.0)
+
+    order_book.submit(
+        OrderRequest(
+            client_order_id="trail-1",
+            symbol="AAA",
+            side=OrderSide.SHORT,
+            qty=10.0,
+            order_type=OrderType.TRAILING_STOP,
+            stop_price=95.0,
+            trail_offset=5.0,
+            tif=TimeInForce.GTC,
+        ),
+        submitted_at="2024-01-02",
+        submitted_equity=10_000_000.0,
+    )
+
+    # Bar 2: high=100. water=100, eff=95.
+    sim.process_bar(_bar("2024-01-03", open_price=100.0, high=100.0, low=99.0, close=100.0))
+    # Bar 3: peak — high=120, low=118. water=120, eff=115. low > 115.
+    sim.process_bar(_bar("2024-01-04", open_price=110.0, high=120.0, low=118.0, close=119.0))
+    sl = _trailing_stop_po(order_book, "trail-1")
+    assert sl.trailing_water == pytest.approx(120.0, rel=1e-9)
+    assert sl.effective_stop_price == pytest.approx(115.0, rel=1e-9)
+
+    # Bar 4: retrace — high=117 (below previous water), low=116. water STAYS at 120,
+    # eff STAYS at 115 (this is the ratchet-only-favorable invariant).
+    sim.process_bar(_bar("2024-01-05", open_price=117.0, high=117.0, low=116.0, close=116.5))
+    sl = _trailing_stop_po(order_book, "trail-1")
+    assert sl.trailing_water == pytest.approx(120.0, rel=1e-9)
+    assert sl.effective_stop_price == pytest.approx(115.0, rel=1e-9)
+
+    # Bar 5: low=114 ≤ 115 → trigger. ref = min(open=116, 115) = 115. NOT 95.
+    outcome = sim.process_bar(
+        _bar("2024-01-06", open_price=116.0, high=116.0, low=114.0, close=115.0)
+    )
+    assert len(outcome.exit_fills) == 1
+    assert outcome.exit_fills[0].price == pytest.approx(115.0, rel=1e-9)
+    assert "AAA" not in portfolio.positions
+
+
+# ---------------------------------------------------------------------------
+# 3. SHORT trailing stop ratchets DOWN only
+# ---------------------------------------------------------------------------
+
+
+def test_short_trailing_stop_ratchets_down_only() -> None:
+    """Mirror of test 1 on the short side. SHORT position closed by LONG
+    TRAILING_STOP — water tracks bar.low and eff = water + offset.
+    Ratchet only moves down (favorable for a short)."""
+    sim, order_book, portfolio = _make_simulator()
+    _open_short(sim, order_book, qty=10.0, entry_bar_ts="2024-01-02", entry_open=100.0)
+
+    order_book.submit(
+        OrderRequest(
+            client_order_id="trail-1",
+            symbol="AAA",
+            side=OrderSide.LONG,
+            qty=10.0,
+            order_type=OrderType.TRAILING_STOP,
+            stop_price=105.0,  # initial water seed for SHORT (above current price)
+            trail_offset=5.0,
+            tif=TimeInForce.GTC,
+        ),
+        submitted_at="2024-01-02",
+        submitted_equity=10_000_000.0,
+    )
+
+    # Bar 2: high=101, low=100. water = min(105, 100) = 100, eff=105. high=101 < 105.
+    sim.process_bar(_bar("2024-01-03", open_price=100.0, high=101.0, low=100.0, close=100.0))
+    sl = _trailing_stop_po(order_book, "trail-1")
+    assert sl.trailing_water == pytest.approx(100.0, rel=1e-9)
+    assert sl.effective_stop_price == pytest.approx(105.0, rel=1e-9)
+
+    # Bar 3: favorable — high=92, low=90. water=90, eff=95. high=92 < 95.
+    sim.process_bar(_bar("2024-01-04", open_price=99.0, high=92.0, low=90.0, close=91.0))
+    sl = _trailing_stop_po(order_book, "trail-1")
+    assert sl.trailing_water == pytest.approx(90.0, rel=1e-9)
+    assert sl.effective_stop_price == pytest.approx(95.0, rel=1e-9)
+
+    # Bar 4: adverse retrace — high=94, low=93. water STAYS 90, eff STAYS 95.
+    sim.process_bar(_bar("2024-01-05", open_price=92.0, high=94.0, low=93.0, close=93.5))
+    sl = _trailing_stop_po(order_book, "trail-1")
+    assert sl.trailing_water == pytest.approx(90.0, rel=1e-9)
+    assert sl.effective_stop_price == pytest.approx(95.0, rel=1e-9)
+
+    # Bar 5: high=95 ≥ 95 → trigger. ref = max(open=94, 95) = 95.
+    outcome = sim.process_bar(_bar("2024-01-06", open_price=94.0, high=95.0, low=93.0, close=94.5))
+    assert len(outcome.exit_fills) == 1
+    assert outcome.exit_fills[0].price == pytest.approx(95.0, rel=1e-9)
+    assert "AAA" not in portfolio.positions
+
+
+# ---------------------------------------------------------------------------
+# 4. Zero offset degenerates to break-even after favorable bar
+# ---------------------------------------------------------------------------
+
+
+def test_zero_offset_degenerates_to_breakeven_after_favorable_bar() -> None:
+    """``trail_offset=0`` means the eff_stop equals the running high — the
+    instant price retraces from the high (or even closes at it), the stop
+    fires. On a flat bar that opens at the previous high, this fills at
+    the bar's open (the "break-even" interpretation)."""
+    sim, order_book, portfolio = _make_simulator()
+    _open_long(sim, order_book, qty=10.0, entry_bar_ts="2024-01-02", entry_open=100.0)
+
+    order_book.submit(
+        OrderRequest(
+            client_order_id="trail-1",
+            symbol="AAA",
+            side=OrderSide.SHORT,
+            qty=10.0,
+            order_type=OrderType.TRAILING_STOP,
+            stop_price=100.0,
+            trail_offset=0.0,
+            tif=TimeInForce.GTC,
+        ),
+        submitted_at="2024-01-02",
+        submitted_equity=10_000_000.0,
+    )
+
+    # Degenerate flat bar at 100: water=100, eff=100. low=100 ≤ 100 → triggers
+    # at min(open=100, 100) = 100. Position closes at break-even with entry.
+    outcome = sim.process_bar(
+        _bar("2024-01-03", open_price=100.0, high=100.0, low=100.0, close=100.0)
+    )
+    assert len(outcome.exit_fills) == 1
+    assert outcome.exit_fills[0].price == pytest.approx(100.0, rel=1e-9)
+    assert "AAA" not in portfolio.positions
+    # Net P&L is zero — break-even round-trip.
+    assert portfolio.cumulative_pnl == pytest.approx(0.0, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# 5. Standalone TRAILING_STOP uses stop_price as initial water seed
+# ---------------------------------------------------------------------------
+
+
+def test_standalone_trailing_stop_uses_stop_price_as_initial_water() -> None:
+    """If a bar's high is BELOW the strategy's ``stop_price`` on first
+    observation, the water mark must stay at ``stop_price`` (the explicit
+    seed) rather than collapse to the bar's high. Confirms the
+    ``trailing_water or req.stop_price or bar.high`` fallback chain in
+    ``_update_trailing``."""
+    sim, order_book, _portfolio = _make_simulator()
+    _open_long(sim, order_book, qty=10.0, entry_bar_ts="2024-01-02", entry_open=100.0)
+
+    order_book.submit(
+        OrderRequest(
+            client_order_id="trail-1",
+            symbol="AAA",
+            side=OrderSide.SHORT,
+            qty=10.0,
+            order_type=OrderType.TRAILING_STOP,
+            stop_price=100.0,  # explicit initial water
+            trail_offset=5.0,
+            tif=TimeInForce.GTC,
+        ),
+        submitted_at="2024-01-02",
+        submitted_equity=10_000_000.0,
+    )
+
+    # Bar 2: high=98 (below the 100 seed). water = max(100, 98) = 100 — NOT 98.
+    sim.process_bar(_bar("2024-01-03", open_price=98.0, high=98.0, low=97.0, close=97.5))
+    sl = _trailing_stop_po(order_book, "trail-1")
+    assert sl.trailing_water == pytest.approx(100.0, rel=1e-9)
+    assert sl.effective_stop_price == pytest.approx(95.0, rel=1e-9)
+
+
+# ---------------------------------------------------------------------------
+# 6. bps trail_offset variant
+# ---------------------------------------------------------------------------
+
+
+def test_bps_trail_offset_variant() -> None:
+    """``trail_offset_kind="bps"`` computes the offset as a percentage of
+    the current water (200 bps = 2%). Eff_stop drifts with the water mark
+    rather than being a fixed dollar distance."""
+    sim, order_book, portfolio = _make_simulator()
+    _open_long(sim, order_book, qty=10.0, entry_bar_ts="2024-01-02", entry_open=100.0)
+
+    order_book.submit(
+        OrderRequest(
+            client_order_id="trail-1",
+            symbol="AAA",
+            side=OrderSide.SHORT,
+            qty=10.0,
+            order_type=OrderType.TRAILING_STOP,
+            stop_price=95.0,
+            trail_offset=200.0,
+            trail_offset_kind="bps",
+            tif=TimeInForce.GTC,
+        ),
+        submitted_at="2024-01-02",
+        submitted_equity=10_000_000.0,
+    )
+
+    # Bar 2: high=100. water=100, eff = 100 * 0.98 = 98. low > 98.
+    sim.process_bar(_bar("2024-01-03", open_price=100.0, high=100.0, low=99.0, close=100.0))
+    sl = _trailing_stop_po(order_book, "trail-1")
+    assert sl.trailing_water == pytest.approx(100.0, rel=1e-9)
+    assert sl.effective_stop_price == pytest.approx(98.0, rel=1e-9)
+
+    # Bar 3: favorable — high=120. water=120, eff = 120 * 0.98 = 117.6.
+    sim.process_bar(_bar("2024-01-04", open_price=110.0, high=120.0, low=118.0, close=119.0))
+    sl = _trailing_stop_po(order_book, "trail-1")
+    assert sl.trailing_water == pytest.approx(120.0, rel=1e-9)
+    assert sl.effective_stop_price == pytest.approx(117.6, rel=1e-9)
+
+    # Bar 4: low=117 ≤ 117.6 → trigger. ref = min(open=119, 117.6) = 117.6.
+    outcome = sim.process_bar(
+        _bar("2024-01-05", open_price=119.0, high=119.0, low=117.0, close=117.5)
+    )
+    assert len(outcome.exit_fills) == 1
+    assert outcome.exit_fills[0].price == pytest.approx(117.6, rel=1e-9)
+    assert "AAA" not in portfolio.positions

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -210,12 +210,31 @@ class FillSimulator:
             )
             is_entry_side = is_entry or is_partial_entry_continuation
 
+            # Trailing-stop ratchet (#390): refresh ``po.trailing_water`` /
+            # ``po.effective_stop_price`` against this bar BEFORE the
+            # trigger check so a bar that both ratchets the stop and
+            # gaps through the new level triggers at the new level. The
+            # effective-request shim below routes the ratcheted price
+            # into the execution model without touching the immutable
+            # ``request`` or changing the execution-model protocol.
+            self._update_trailing(po, bar)
+            effective_req = (
+                req.model_copy(
+                    update={
+                        "order_type": OrderType.STOP,
+                        "stop_price": po.effective_stop_price,
+                    }
+                )
+                if req.order_type == OrderType.TRAILING_STOP and po.effective_stop_price is not None
+                else req
+            )
+
             # Determine whether this bar triggered the order and at what
             # terms (price, partial-fill fraction, adverse-selection
             # haircut). The execution model encapsulates the (model-
             # dependent) parts; risk gates and money math are simulator-
             # owned below.
-            terms = self.execution_model.compute_fill_terms(req, bar, next_bar)
+            terms = self.execution_model.compute_fill_terms(effective_req, bar, next_bar)
             if terms is None:
                 # IOC / FOK semantics demand cancel-on-this-bar when the
                 # order doesn't trigger (e.g. a LIMIT IOC whose limit
@@ -1218,6 +1237,76 @@ class FillSimulator:
         return expired
 
     # ------------------------------------------------------------------
+    # Trailing-stop ratchet (#390)
+    # ------------------------------------------------------------------
+
+    def _update_trailing(self, po: PendingOrder, bar: Bar) -> None:
+        """Ratchet ``po.trailing_water`` and ``po.effective_stop_price``.
+
+        Runs every bar for any order whose request is a TRAILING_STOP —
+        whether standalone or a materialized bracket child. Early-exits
+        cheaply for the common non-trailing case so golden-parity
+        strategies pay nothing.
+
+        Ratchet direction is governed by the *protected position*, not
+        by the order's own side. A trailing stop is always opposite-side
+        to the position it protects:
+
+        * SHORT TRAILING_STOP closes a LONG → water tracks ``bar.high``
+          (the long position's favorable direction) and ``eff_stop`` sits
+          ``offset`` below it.
+        * LONG TRAILING_STOP closes a SHORT → water tracks ``bar.low``
+          and ``eff_stop`` sits ``offset`` above it.
+
+        An adverse bar leaves prior state untouched (ratchet only moves
+        favorably).
+
+        Initial-water seed chain (first bar after activation):
+        1. ``po.trailing_water`` if already set — the bracket
+           materializer pre-seeds this from the parent's fill price so
+           the first post-entry bar doesn't reset to that bar's extreme.
+        2. ``req.stop_price`` if set — standalone TRAILING_STOP carries
+           an explicit initial water mark via this field.
+        3. ``bar.high`` / ``bar.low`` as a defensive fallback.
+           ``validate_prices`` should have rejected a TRAILING_STOP
+           without ``stop_price`` upstream, but the fallback keeps the
+           helper safe to call against any future caller that bypasses
+           validation.
+        """
+        req = po.request
+        if req.order_type != OrderType.TRAILING_STOP:
+            return
+        if req.trail_offset is None:
+            return  # defensive — validate_prices should have rejected this
+
+        if req.side == OrderSide.SHORT:
+            # Closes a LONG position; ratchet up against bar.high.
+            seed = (
+                po.trailing_water
+                if po.trailing_water is not None
+                else (req.stop_price if req.stop_price is not None else bar.high)
+            )
+            water = max(seed, bar.high)
+        else:
+            # Closes a SHORT position; ratchet down against bar.low.
+            seed = (
+                po.trailing_water
+                if po.trailing_water is not None
+                else (req.stop_price if req.stop_price is not None else bar.low)
+            )
+            water = min(seed, bar.low)
+
+        if req.trail_offset_kind == "abs":
+            offset = req.trail_offset
+        else:  # "bps"
+            offset = water * (req.trail_offset / 10_000.0)
+
+        eff_stop = (water - offset) if req.side == OrderSide.SHORT else (water + offset)
+
+        po.trailing_water = water
+        po.effective_stop_price = eff_stop
+
+    # ------------------------------------------------------------------
     # Bracket / OCO materialization (#389)
     # ------------------------------------------------------------------
 
@@ -1281,15 +1370,28 @@ class FillSimulator:
         req = po.request
         child_side = OrderSide.SHORT if req.side == OrderSide.LONG else OrderSide.LONG
         oco_group_id = f"oco_{po.order_id}"
+        # Seed water for trailing-stop children from the parent's *fill*
+        # price (#390). Reading ``pos.entry_price`` instead of ``bar.high``
+        # avoids resetting the ratchet to the new bar's high on the first
+        # eligible post-entry bar — strategies expect the trail to be
+        # anchored at where they actually entered, not at the next bar's
+        # extreme. ``pos`` is guaranteed to exist whenever this method
+        # runs (the entry path opens the position immediately before
+        # calling us; the abandon path checks explicitly).
+        pos = self.portfolio.positions.get(req.symbol)
+        entry_fill_price = pos.entry_price if pos is not None else None
         if req.attached_stop_loss is not None:
             sl = req.attached_stop_loss
+            is_trailing = sl.trail_offset is not None
             sl_req = OrderRequest(
                 client_order_id=sl.client_order_id or f"{req.client_order_id}_sl",
                 symbol=req.symbol,
                 side=child_side,
                 qty=filled_qty,
-                order_type=OrderType.STOP,
+                order_type=OrderType.TRAILING_STOP if is_trailing else OrderType.STOP,
                 stop_price=sl.stop_price,
+                trail_offset=sl.trail_offset,
+                trail_offset_kind=sl.trail_offset_kind,
                 tif=TimeInForce.GTC,
                 unfilled_policy=UnfilledPolicy.REQUEUE_NEXT_BAR,
                 reason="bracket_sl",
@@ -1302,6 +1404,22 @@ class FillSimulator:
                 oco_group_id=oco_group_id,
             )
             sl_child.working_against_entry_order_id = po.order_id
+            if is_trailing and entry_fill_price is not None:
+                # Pre-seed the ratchet so the first eligible bar after
+                # entry trails from where we filled (rather than that
+                # bar's high). ``effective_stop_price`` is set so the
+                # initial level is well-defined even before
+                # ``_update_trailing`` first runs against a real bar.
+                sl_child.trailing_water = entry_fill_price
+                if sl.trail_offset_kind == "abs":
+                    offset = sl.trail_offset
+                else:  # "bps"
+                    offset = entry_fill_price * (sl.trail_offset / 10_000.0)
+                sl_child.effective_stop_price = (
+                    entry_fill_price - offset
+                    if req.side == OrderSide.LONG
+                    else entry_fill_price + offset
+                )
         if req.attached_take_profit is not None:
             tp = req.attached_take_profit
             tp_req = OrderRequest(

--- a/backend/agents/investment_team/trading_service/engine/order_book.py
+++ b/backend/agents/investment_team/trading_service/engine/order_book.py
@@ -60,8 +60,13 @@ class PendingOrder:
     cumulative_filled_qty: float = 0.0
     remaining_qty: float = 0.0  # initialized to request.qty in submit()
     twap_slices_remaining: Optional[int] = None
-    effective_stop_price: Optional[float] = None  # live trailing stop (Step 8 / #390)
-    trailing_water: Optional[float] = None  # running high (LONG) / low (SHORT); Step 8
+    # Live trailing-stop state (#390). ``trailing_water`` is the running
+    # high (LONG) / low (SHORT) since activation; ``effective_stop_price``
+    # is ``water ± offset`` and is the price the execution model triggers
+    # against (via the simulator's effective-request shim). Both stay
+    # ``None`` for non-trailing orders.
+    effective_stop_price: Optional[float] = None
+    trailing_water: Optional[float] = None
     armed: bool = True
     # Identity of the position this order is committed to act against,
     # bound at one of three points:
@@ -194,11 +199,11 @@ class OrderBook:
         ``oco_group_id`` to be set on the queued order — the strategy-side
         ``validate_prices()`` gate refuses both fields outright (they are
         engine-internal). All *other* runtime-support gates and shape-consistency
-        checks (LIMIT requires ``limit_price``, STOP requires ``stop_price``,
-        no TRAILING_STOP / IOC / FOK / unfilled_policy until their respective
-        steps ship, no nested attachments) still apply; we re-run
-        ``validate_prices`` on a clone with parent/OCO cleared so we don't
-        re-fire the very gates this method is meant to bypass.
+        checks (LIMIT requires ``limit_price``, STOP / TRAILING_STOP require
+        ``stop_price``, TRAILING_STOP requires ``trail_offset``, no nested
+        attachments) still apply; we re-run ``validate_prices`` on a clone
+        with parent/OCO cleared so we don't re-fire the very gates this
+        method is meant to bypass.
         """
         if not isinstance(parent_order_id, str) or not parent_order_id:
             raise TypeError(
@@ -249,9 +254,9 @@ class OrderBook:
         # error rather than an unintended fill.
         if request.order_type == OrderType.MARKET:
             raise ValueError(
-                "submit_attached child must be LIMIT or STOP, not MARKET — market "
-                "children would fire immediately on the next bar instead of acting as "
-                "protective legs (TRAILING_STOP is gated until #390 / Step 8 lands)"
+                "submit_attached child must be LIMIT / STOP / TRAILING_STOP, "
+                "not MARKET — market children would fire immediately on the "
+                "next bar instead of acting as protective legs"
             )
         attached_request = request.model_copy(
             update={"parent_order_id": parent_order_id, "oco_group_id": oco_group_id}

--- a/backend/agents/investment_team/trading_service/strategy/contract.py
+++ b/backend/agents/investment_team/trading_service/strategy/contract.py
@@ -133,6 +133,13 @@ class OrderRequest(BaseModel):
     order_type: OrderType = OrderType.MARKET
     limit_price: Optional[float] = None
     stop_price: Optional[float] = None
+    # Trailing-stop ratchet specifier (#390). Only consulted when
+    # ``order_type == TRAILING_STOP`` (standalone) or when this request was
+    # cloned from a ``StopAttachment`` with ``trail_offset`` set (bracket
+    # child). ``stop_price`` is the initial water mark for standalone
+    # trailing stops; the engine ratchets from there.
+    trail_offset: Optional[float] = None
+    trail_offset_kind: Literal["abs", "bps"] = "abs"
     tif: TimeInForce = TimeInForce.DAY
     reason: str = ""  # free-form annotation; surfaced in logs / fills
     unfilled_policy: Optional[UnfilledPolicy] = None
@@ -156,22 +163,18 @@ class OrderRequest(BaseModel):
         # honors them only as their respective steps of #379 ship. Until
         # those steps land, fail loudly at submission time rather than
         # silently producing never-filled orders.
-        if self.order_type == OrderType.TRAILING_STOP:
-            raise UnsupportedOrderFeatureError(
-                "trailing_stop is not yet supported by the execution engine; "
-                "see #390 (Trading 5/5 Step 8) for runtime support"
-            )
-        # Bracket attachments are runtime-supported as of #389, but the
-        # trailing-stop variant of ``StopAttachment`` is still gated until
-        # #390. Reject at submit time rather than silently materializing as
-        # a fixed STOP — that would backtest a different strategy than the
-        # one the author wrote.
+        #
+        # Trailing-stop runtime support landed with #390. The
+        # standalone ``TRAILING_STOP`` order type and bracketed
+        # ``attached_stop_loss.trail_offset`` are validated by the
+        # shape-consistency checks below (``stop_price`` required for
+        # standalone TRAILING_STOP; non-negative ``trail_offset``).
         if self.attached_stop_loss is not None and self.attached_stop_loss.trail_offset is not None:
-            raise UnsupportedOrderFeatureError(
-                "attached_stop_loss.trail_offset is not yet supported by the "
-                "execution engine; see #390 (Trading 5/5 Step 8) for trailing-stop "
-                "runtime support"
-            )
+            if self.attached_stop_loss.trail_offset < 0:
+                raise ValueError(
+                    "attached_stop_loss.trail_offset must be non-negative, "
+                    f"got {self.attached_stop_loss.trail_offset!r}"
+                )
         # ``parent_order_id`` / ``oco_group_id`` are engine-internal: the
         # bracket materializer in ``FillSimulator`` calls
         # ``OrderBook.submit_attached`` which clones the request with these
@@ -207,8 +210,16 @@ class OrderRequest(BaseModel):
             raise ValueError("limit order requires limit_price")
         if self.order_type == OrderType.STOP and self.stop_price is None:
             raise ValueError("stop order requires stop_price")
-        if self.order_type == OrderType.TRAILING_STOP and self.stop_price is None:
-            raise ValueError("trailing_stop order requires stop_price")
+        if self.order_type == OrderType.TRAILING_STOP:
+            if self.stop_price is None:
+                raise ValueError("trailing_stop order requires stop_price")
+            if self.trail_offset is None:
+                raise ValueError("trailing_stop order requires trail_offset")
+            if self.trail_offset < 0:
+                raise ValueError(
+                    f"trailing_stop order trail_offset must be non-negative, "
+                    f"got {self.trail_offset!r}"
+                )
         if self.tif in (TimeInForce.IOC, TimeInForce.FOK) and self.order_type not in (
             OrderType.MARKET,
             OrderType.LIMIT,
@@ -350,6 +361,8 @@ class StrategyContext:
         order_type: OrderType | str = OrderType.MARKET,
         limit_price: Optional[float] = None,
         stop_price: Optional[float] = None,
+        trail_offset: Optional[float] = None,
+        trail_offset_kind: Literal["abs", "bps"] = "abs",
         tif: TimeInForce | str = TimeInForce.DAY,
         reason: str = "",
         unfilled_policy: Optional[UnfilledPolicy | str] = None,
@@ -380,6 +393,8 @@ class StrategyContext:
             ),
             limit_price=limit_price,
             stop_price=stop_price,
+            trail_offset=trail_offset,
+            trail_offset_kind=trail_offset_kind,
             tif=TimeInForce(tif) if not isinstance(tif, TimeInForce) else tif,
             reason=reason,
             unfilled_policy=(


### PR DESCRIPTION
Closes #390.

## Summary

- Lift `validate_prices` gates on `OrderType.TRAILING_STOP` (standalone) and `attached_stop_loss.trail_offset` (bracket child); wire the fill simulator through to the already-reserved `PendingOrder.trailing_water` / `effective_stop_price` fields.
- Per bar, before `compute_fill_terms`, `_update_trailing(po, bar)` ratchets `trailing_water` (running high for SHORT-orders-closing-LONGs, running low for LONG-orders-closing-SHORTs) and recomputes `effective_stop_price` = water ± offset. Ratchet only moves favorably; adverse bars leave prior state untouched.
- Trigger detection routes through an effective-request shim: the simulator clones `req` with `order_type=STOP` + `stop_price=po.effective_stop_price` and hands that into `compute_fill_terms`. Execution models stay stateless; golden snapshots are byte-identical (no reference strategy uses `TRAILING_STOP`, so the new code paths short-circuit).
- `_materialize_bracket_children` emits `OrderType.TRAILING_STOP` children when `attached_stop_loss.trail_offset` is set, pre-seeding `trailing_water` from the parent's fill price so the first eligible bar trails from the entry rather than from that bar's extreme.
- `OrderRequest` gains `trail_offset` / `trail_offset_kind` fields; `StrategyContext.submit_order` plumbs them through so strategy code can submit standalone trailing stops.

## Tests

- New: `agents/investment_team/tests/test_trailing_stop.py` — 6 cases covering abs/bps offsets, LONG/SHORT directions, the retrace fixture (ratchet sticks), zero-offset break-even, and standalone `stop_price`-as-initial-water seeding.
- Extended: `test_bracket_orders.py` — 1 new test for trailing-stop bracket child ratcheting across bars + OCO cancellation on TP fill. The previously gated `test_trailing_stop_attachment_is_gated_until_step_8` is inverted to a positive assertion.
- Refreshed gated tests in `test_contract_gates.py`, `test_order_book.py`, `test_trading_service.py` — the `unsupported_feature` diagnostics test now exercises `parent_order_id` (still engine-internal) instead of `trailing_stop`.

## Test plan

- [x] `pytest agents/investment_team/tests/test_trailing_stop.py`
- [x] `pytest agents/investment_team/tests/test_bracket_orders.py`
- [x] `pytest agents/investment_team/tests/golden/` — parity preserved
- [x] `pytest agents/investment_team/tests/` — 1033 passed, 13 skipped
- [x] `ruff check` / `ruff format --check`

https://claude.ai/code/session_01HeAFx5dRZbjPXTfHAxaWcp

---
_Generated by [Claude Code](https://claude.ai/code/session_01HeAFx5dRZbjPXTfHAxaWcp)_