### PR TITLE
investment-team: pin idempotent re-instrumentation for coverage probe (#453)

### DIFF
--- a/backend/agents/investment_team/tests/test_streaming_harness_coverage_probe.py
+++ b/backend/agents/investment_team/tests/test_streaming_harness_coverage_probe.py
@@ -317,3 +317,28 @@ def test_probe_mode_truncated_flag_when_distinct_rule_ids_exceed_cap(
     assert payload["truncated"] is True
     # Only the first 3 distinct rule_ids should have been tracked.
     assert len(payload["events"]) == 3
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+
+
+def test_instrument_strategy_code_is_idempotent() -> None:
+    """Re-instrumenting an already-instrumented module is a no-op (#449/#453).
+
+    Pins the ``_is_already_instrumented`` short-circuit in
+    ``runtime_instrument.py``: a second pass over rewritten code returns
+    the input bytes unchanged and reconstructs the same ``RuleIndex``
+    from the already-emitted ``__probe_record__`` calls. Without this
+    guarantee the bootstrap prelude would be inserted twice and rule_ids
+    would renumber, breaking the harness's per-rule aggregation.
+    """
+    code1, rule_index1 = instrument_strategy_code(_TWO_RULE_CODE)
+    code2, rule_index2 = instrument_strategy_code(code1)
+
+    assert code1 == code2
+    assert rule_index2.rules == rule_index1.rules
+    # The prelude is emitted exactly once on the first pass. A second
+    # pass must not append another copy.
+    assert code1.count("def __probe_record__(_rid, _bidx, _value):") == 1


### PR DESCRIPTION
## Summary

Closes out the last open acceptance item on #453 ("#406: Tests + bounded-runtime guarantees") — idempotent re-instrumentation of strategy code under the Strategy Lab coverage probe.

An audit of `backend/agents/investment_team/tests/` against #453's seven acceptance items found 6/7 already shipped via PRs #454 (#446), #458 (#449), #474 (#450), #475 (#451), and #504 (#453 perf-guard). The only uncovered item was the runtime-probe contract that "rewriting an already-instrumented file is a no-op" — already implemented in `runtime_instrument._is_already_instrumented`, but not pinned by a test.

### Change

One new test in `backend/agents/investment_team/tests/test_streaming_harness_coverage_probe.py`:

- `test_instrument_strategy_code_is_idempotent()` — calls `instrument_strategy_code` twice on the same source, asserts:
  - `code1 == code2` (bytewise — the short-circuit returns the input unchanged on the second pass)
  - `rule_index2.rules == rule_index1.rules` (no rule renumbering)
  - The bootstrap prelude `def __probe_record__(_rid, _bidx, _value):` appears exactly once (not duplicated by a second pass).

No production code is changed; the test pins an existing contract so a future refactor of `runtime_instrument.py` can't silently regress per-rule aggregation.

### Audit cross-reference (for #453 closer)

| # | Acceptance item | Covered by |
|---|---|---|
| 1 | Pydantic round-trip + `BacktestResult` back-compat | `test_coverage_probe_models.py:31-97` |
| 2 | Static probe (warmup / missing symbol / malformed) | `test_strategy_lab_static_probe.py:63-193` |
| 3 | Indicator probe (`hit_rate=0`, conjunction-never-true, partial-fire) | `test_indicator_probe_basic.py:77-121`, `test_indicator_probe_conjunction.py:35-59` |
| 4 | Runtime probe (golden trades, bounded events, **idempotent re-instrumentation**) | `test_streaming_harness_coverage_probe.py` — this PR closes the last sub-item |
| 5 | Refinement prompt + `QualityGateResult.details` contains category | `test_coverage_probe_rendering.py:31-66`, `test_backtest_anomaly_zero_trade_diagnostics.py:218-266` |
| 6 | Perf guard (probe skipped on success; ≤1.1×) | `test_coverage_probe_perf_guard.py:65-140` |
| 7 | No probe path issues an LLM call | `test_coverage_probe_stage.py:580-600` |

Once this merges, #453 and the parent #406 epic can be closed. The already-merged-but-still-open #450 and #451 should be closed at the same time as housekeeping (they shipped via PRs #474 and #475 respectively).

## Test plan

- [x] `python3 -m pytest agents/investment_team/tests/test_streaming_harness_coverage_probe.py::test_instrument_strategy_code_is_idempotent -v` → PASSED
- [x] `python3 -m pytest agents/investment_team/tests/test_streaming_harness_coverage_probe.py -v` → 8/8 PASSED (no regression in the existing 7 tests)
- [x] `ruff check` and `ruff format --check` on the modified file → clean
- [ ] CI `lint` job green
- [ ] CI `test-backend` investment-team slice green

Refs #453, #406.

https://claude.ai/code/session_01TXKrJUA9qeCYnMhRTnALiw

---
_Generated by [Claude Code](https://claude.ai/code/session_01TXKrJUA9qeCYnMhRTnALiw)_