### PR TITLE
jobs-dashboard: surface stuck-job affordance (#482)

### DIFF
--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.html
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.html
@@ -177,6 +177,8 @@
               <td class="col-time">
                 @if (isStuck(job)) {
                   <mat-icon class="stuck-indicator"
+                            role="img"
+                            aria-hidden="false"
                             [attr.aria-label]="getStuckTooltip(job)"
                             [matTooltip]="getStuckTooltip(job)">warning_amber</mat-icon>
                 }

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.html
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.html
@@ -175,6 +175,11 @@
                 }
               </td>
               <td class="col-time">
+                @if (isStuck(job)) {
+                  <mat-icon class="stuck-indicator"
+                            [attr.aria-label]="getStuckTooltip(job)"
+                            [matTooltip]="getStuckTooltip(job)">warning_amber</mat-icon>
+                }
                 <span class="time-ago">{{ getTimeAgo(job.unified.createdAt) }}</span>
               </td>
               <td class="col-actions">

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.html
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.html
@@ -176,11 +176,12 @@
               </td>
               <td class="col-time">
                 @if (isStuck(job)) {
+                  @let stuckLabel = getStuckTooltip(job);
                   <mat-icon class="stuck-indicator"
                             role="img"
                             aria-hidden="false"
-                            [attr.aria-label]="getStuckTooltip(job)"
-                            [matTooltip]="getStuckTooltip(job)">warning_amber</mat-icon>
+                            [attr.aria-label]="stuckLabel"
+                            [matTooltip]="stuckLabel">warning_amber</mat-icon>
                 }
                 <span class="time-ago">{{ getTimeAgo(job.unified.createdAt) }}</span>
               </td>

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
@@ -315,6 +315,29 @@
   }
 }
 
+// Stuck-job affordance: an inline warning glyph rendered next to the
+// "Started" cell when isStuck(job) is true. Combined with the tooltip it
+// gives operators a shape-based (not color-only) signal that a long-running
+// job has stopped advancing.
+.stuck-indicator {
+  color: var(--kh-warning);
+  font-size: 18px;
+  width: 18px;
+  height: 18px;
+  vertical-align: middle;
+  margin-right: var(--kh-space-1);
+  animation: kh-stuck-pulse 2s ease-in-out infinite;
+}
+
+@keyframes kh-stuck-pulse {
+  0%, 100% { opacity: 0.55; }
+  50%      { opacity: 1; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .stuck-indicator { animation: none; opacity: 1; }
+}
+
 // ── Column Widths ───────────────────────────────────────────────────────────
 // Widths are hints — `table-layout: auto` lets columns shrink so the
 // table fits the viewport without horizontal scroll on a 15" MacBook.

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
@@ -669,6 +669,44 @@ describe('JobsDashboardComponent', () => {
       expect(component.isStuck(makeRunTeam('task-b', 2))).toBe(false);
     });
 
+    it('does not flag a run_team SE job whose microtask phase advances within one task', () => {
+      // Within a single task the orchestrator ticks current_microtask /
+      // current_microtask_phase / current_microtask_index / phase_detail
+      // long before microtasks_completed changes. The fingerprint must
+      // capture that motion.
+      const makeRunTeam = (microPhase: string, idx: number) => {
+        const job = makeJob('running', 'rt-1', oldCreatedAt(), 40);
+        job.unified.jobType = 'run_team';
+        job.seDetail = {
+          progress: 40,
+          statusText: 'executing',
+          currentPhase: 'execution',
+          teamStatuses: [
+            {
+              teamId: 'backend',
+              label: 'Backend',
+              icon: 'dns',
+              phase: 'coding',
+              phaseLabel: 'Coding',
+              isActive: true,
+              currentTaskId: 'task-a',
+              microtasksCompleted: 0,
+              currentMicrotask: 'mt-1',
+              currentMicrotaskPhase: microPhase,
+              currentMicrotaskIndex: idx,
+              phaseDetail: `mt:${idx} ${microPhase}`,
+            },
+          ],
+        } as any;
+        return job;
+      };
+      record([makeRunTeam('coding', 0)]);
+      waitPastStillness();
+      record([makeRunTeam('review', 0)]);
+      // Microtask phase advanced → signal flipped → not stuck.
+      expect(component.isStuck(makeRunTeam('review', 0))).toBe(false);
+    });
+
     it('flags a run_team SE job whose per-team progress is frozen', () => {
       const makeRunTeam = () => {
         const job = makeJob('running', 'rt-1', oldCreatedAt(), 40);

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
@@ -636,6 +636,68 @@ describe('JobsDashboardComponent', () => {
       expect(component.isStuck(job)).toBe(false);
     });
 
+    it('does not flag a run_team SE job whose per-team currentTaskId advances', () => {
+      // run_team orchestrator ticks team_progress.current_task_id / microtask
+      // counters while job-level progress/phase stay constant for long
+      // stretches. The fingerprint must capture that motion.
+      const makeRunTeam = (taskId: string, completed: number) => {
+        const job = makeJob('running', 'rt-1', oldCreatedAt(), 40);
+        job.unified.jobType = 'run_team';
+        job.seDetail = {
+          progress: 40,
+          statusText: 'executing',
+          currentPhase: 'execution',
+          teamStatuses: [
+            {
+              teamId: 'backend',
+              label: 'Backend',
+              icon: 'dns',
+              phase: 'coding',
+              phaseLabel: 'Coding',
+              isActive: true,
+              currentTaskId: taskId,
+              microtasksCompleted: completed,
+            },
+          ],
+        } as any;
+        return job;
+      };
+      record([makeRunTeam('task-a', 1)]);
+      waitPastStillness();
+      record([makeRunTeam('task-b', 2)]);
+      // Per-team task advanced → signal flipped → not stuck.
+      expect(component.isStuck(makeRunTeam('task-b', 2))).toBe(false);
+    });
+
+    it('flags a run_team SE job whose per-team progress is frozen', () => {
+      const makeRunTeam = () => {
+        const job = makeJob('running', 'rt-1', oldCreatedAt(), 40);
+        job.unified.jobType = 'run_team';
+        job.seDetail = {
+          progress: 40,
+          statusText: 'executing',
+          currentPhase: 'execution',
+          teamStatuses: [
+            {
+              teamId: 'backend',
+              label: 'Backend',
+              icon: 'dns',
+              phase: 'coding',
+              phaseLabel: 'Coding',
+              isActive: true,
+              currentTaskId: 'task-a',
+              microtasksCompleted: 1,
+            },
+          ],
+        } as any;
+        return job;
+      };
+      record([makeRunTeam()]);
+      waitPastStillness();
+      record([makeRunTeam()]);
+      expect(component.isStuck(makeRunTeam())).toBe(true);
+    });
+
     it('renders the stuck glyph with aria-hidden="false" and a non-empty aria-label', () => {
       const job = makeJob('running', 'j1', oldCreatedAt(), 25);
       job.unified.jobType = 'run_team';

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
@@ -591,6 +591,19 @@ describe('JobsDashboardComponent', () => {
       expect(component.isStuck(resumed)).toBe(true);
     });
 
+    it('does not flag an SE row whose detail fetch failed (no observable signal)', () => {
+      // fetchSEDetail returned null → seDetail is undefined, progress is null,
+      // phase and statusText are empty. Repeated polls in that state must
+      // not trip the stuck heuristic, even past the age gate.
+      const job = makeJob('running', 'j1', oldCreatedAt(), null);
+      job.seDetail = undefined;
+      delete (job.unified as any).phase;
+      record([job]);
+      record([job]);
+      record([job]);
+      expect(component.isStuck(job)).toBe(false);
+    });
+
     it('excludes SE jobs waiting for answers even after threshold elapsed', () => {
       const job = makeJob('running', 'j1', oldCreatedAt(), 25);
       job.seDetail = { waitingForAnswers: true, progress: 25 } as any;

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
@@ -473,11 +473,45 @@ describe('JobsDashboardComponent', () => {
       expect(component.isStuck(b)).toBe(false);
     });
 
-    it('treats missing createdAt as not stuck', () => {
+    it('uses firstSeenAt as age basis when createdAt is missing', () => {
       const job = makeJob('running', 'j1', '', 10);
       record([job]);
       record([job]);
+      // Two polls fired at the same fake-clock instant → firstSeenAt == now,
+      // age == 0, so still not stuck.
       expect(component.isStuck(job)).toBe(false);
+    });
+
+    it('flags a Planning-V3-style job (no createdAt) after enough observed-poll time', () => {
+      // Planning V3 list endpoint omits created_at, so the row arrives with
+      // createdAt undefined. The dashboard should still be able to flag it
+      // stuck once it has observed the job frozen for STUCK_THRESHOLD_MS+.
+      const makePV3 = (phase: string) => {
+        const job = makeJob('running', 'pv3-1', undefined as unknown as string, null);
+        job.unified.source = 'planning_v3';
+        job.unified.phase = phase;
+        return job;
+      };
+      record([makePV3('drafting')]);
+      // Advance past the threshold while keeping the signal stable.
+      vi.setSystemTime(new Date(Date.now() + STUCK_MS + 60_000));
+      record([makePV3('drafting')]);
+      expect(component.isStuck(makePV3('drafting'))).toBe(true);
+    });
+
+    it('does not flag a Planning-V3 job whose phase is still advancing', () => {
+      const makePV3 = (phase: string) => {
+        const job = makeJob('running', 'pv3-1', undefined as unknown as string, null);
+        job.unified.source = 'planning_v3';
+        job.unified.phase = phase;
+        return job;
+      };
+      record([makePV3('drafting')]);
+      vi.setSystemTime(new Date(Date.now() + STUCK_MS + 60_000));
+      record([makePV3('reviewing')]);
+      // Signal changed → sampleCount resets to 1, firstSeenAt resets to now,
+      // so the age basis is fresh and the row is not flagged.
+      expect(component.isStuck(makePV3('reviewing'))).toBe(false);
     });
 
     it('tooltip uses getTimeAgo-style phrasing relative to lastChangedAt', () => {

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
@@ -537,6 +537,26 @@ describe('JobsDashboardComponent', () => {
       expect(component.isStuck(makePhaseJob())).toBe(true);
     });
 
+    it('resets sampleCount when a failed job is resumed back into running', () => {
+      // Job has been failing in place with identical progress / no phase
+      // change across many polls. When the user resumes it, the next poll
+      // shows it as 'running' again with the same progress and phase. The
+      // resumed running attempt should *not* be flagged stuck on its first
+      // observation just because the fingerprint pre-resume was sticky.
+      const failed = makeJob('failed', 'j1', oldCreatedAt(), 25);
+      record([failed]);
+      record([failed]);
+      record([failed]); // sampleCount = 3 while failed
+
+      const resumed = makeJob('running', 'j1', oldCreatedAt(), 25);
+      record([resumed]);
+      expect(component.isStuck(resumed)).toBe(false);
+      // And on the next poll where it's still unchanged, the running streak
+      // is now 2 → stuck (so the heuristic still works post-resume).
+      record([resumed]);
+      expect(component.isStuck(resumed)).toBe(true);
+    });
+
     it('excludes SE jobs waiting for answers even after threshold elapsed', () => {
       const job = makeJob('running', 'j1', oldCreatedAt(), 25);
       job.seDetail = { waitingForAnswers: true, progress: 25 } as any;

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
@@ -407,6 +407,114 @@ describe('JobsDashboardComponent', () => {
     expect(component.trackByJobId(0, job)).toBe('se:j1');
   });
 
+  describe('stuck-job detection', () => {
+    const STUCK_MS = 2 * 60 * 60 * 1000;
+    const oldCreatedAt = () => new Date(Date.now() - STUCK_MS - 60_000).toISOString();
+    const youngCreatedAt = () => new Date(Date.now() - 60_000).toISOString();
+
+    const makeJob = (
+      status: string,
+      jobId: string,
+      createdAt: string,
+      progress: number | null = null,
+    ) =>
+      ({
+        unified: {
+          source: 'software_engineering',
+          jobId,
+          status,
+          createdAt,
+          label: 'job',
+          progress,
+        },
+        seDetail: undefined,
+      }) as any;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-12T12:00:00Z'));
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    const record = (rows: any[]) => (component as any).recordProgressSamples(rows);
+
+    it('is false when status is not running, even after threshold elapsed', () => {
+      const job = makeJob('failed', 'j1', oldCreatedAt(), 50);
+      record([job]);
+      record([job]);
+      expect(component.isStuck(job)).toBe(false);
+    });
+
+    it('is false when running but younger than threshold', () => {
+      const job = makeJob('running', 'j1', youngCreatedAt(), 10);
+      record([job]);
+      record([job]);
+      expect(component.isStuck(job)).toBe(false);
+    });
+
+    it('is false after one unchanged poll, true after the second', () => {
+      const job = makeJob('running', 'j1', oldCreatedAt(), 25);
+      record([job]);
+      expect(component.isStuck(job)).toBe(false);
+      record([job]);
+      expect(component.isStuck(job)).toBe(true);
+    });
+
+    it('resets when progress changes', () => {
+      const a = makeJob('running', 'j1', oldCreatedAt(), 25);
+      const b = makeJob('running', 'j1', oldCreatedAt(), 35);
+      record([a]);
+      record([a]);
+      expect(component.isStuck(a)).toBe(true);
+      record([b]);
+      expect(component.isStuck(b)).toBe(false);
+    });
+
+    it('treats missing createdAt as not stuck', () => {
+      const job = makeJob('running', 'j1', '', 10);
+      record([job]);
+      record([job]);
+      expect(component.isStuck(job)).toBe(false);
+    });
+
+    it('tooltip uses getTimeAgo-style phrasing relative to lastChangedAt', () => {
+      const job = makeJob('running', 'j1', oldCreatedAt(), 25);
+      record([job]);
+      // Advance 7 minutes; progress still unchanged in the next sample.
+      vi.setSystemTime(new Date(Date.now() + 7 * 60_000));
+      record([job]);
+      expect(component.getStuckTooltip(job)).toBe('No progress in 7m — may be stuck');
+    });
+
+    it('returns fallback tooltip when no history exists', () => {
+      const job = makeJob('running', 'unseen', oldCreatedAt(), 0);
+      expect(component.getStuckTooltip(job)).toBe('No progress detected — may be stuck');
+    });
+
+    it('prunes history for jobs that disappear from a subsequent poll', () => {
+      const a = makeJob('running', 'j1', oldCreatedAt(), 25);
+      const b = makeJob('running', 'j2', oldCreatedAt(), 50);
+      record([a, b]);
+      const history: Map<string, unknown> = (component as any).progressHistory;
+      expect(history.has('software_engineering::j1')).toBe(true);
+      expect(history.has('software_engineering::j2')).toBe(true);
+      record([a]);
+      expect(history.has('software_engineering::j1')).toBe(true);
+      expect(history.has('software_engineering::j2')).toBe(false);
+    });
+
+    it('aria-label on the row mentions "appears stuck" when stuck', () => {
+      const job = makeJob('running', 'j1', oldCreatedAt(), 25);
+      job.unified.jobType = 'run_team';
+      record([job]);
+      record([job]);
+      expect(component.getJobAriaLabel(job)).toContain('appears stuck');
+    });
+  });
+
   describe('canResumeJob', () => {
     const makeJob = (status: string, source = 'software_engineering') =>
       ({ unified: { source, jobId: 'j1', status }, seDetail: null } as any);

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
@@ -404,7 +404,7 @@ describe('JobsDashboardComponent', () => {
 
   it('trackByJobId returns composite key', () => {
     const job = { unified: { source: 'se', jobId: 'j1' } } as any;
-    expect(component.trackByJobId(0, job)).toBe('se:j1');
+    expect(component.trackByJobId(0, job)).toBe('se::j1');
   });
 
   describe('stuck-job detection', () => {
@@ -480,6 +480,18 @@ describe('JobsDashboardComponent', () => {
       vi.setSystemTime(new Date(Date.now() + STILL_MS - 60_000));
       record([old]);
       expect(component.isStuck(old)).toBe(false);
+    });
+
+    it('flips to stuck exactly at the stillness boundary', () => {
+      const old = makeJob('running', 'j1', oldCreatedAt(), 25);
+      record([old]);
+      // Just under the boundary → still not stuck.
+      vi.setSystemTime(new Date(Date.now() + STILL_MS - 1));
+      record([old]);
+      expect(component.isStuck(old)).toBe(false);
+      // Bump exactly to the boundary → stuck (the gate is `>=`).
+      vi.setSystemTime(new Date(Date.now() + 1));
+      expect(component.isStuck(old)).toBe(true);
     });
 
     it('resets when progress changes', () => {
@@ -753,6 +765,21 @@ describe('JobsDashboardComponent', () => {
       expect(glyph?.getAttribute('aria-hidden')).toBe('false');
       expect(glyph?.getAttribute('role')).toBe('img');
       expect(glyph?.getAttribute('aria-label')?.length ?? 0).toBeGreaterThan(0);
+    });
+
+    it('renders the row aria-label with "appears stuck" once the row is stuck', () => {
+      const job = makeJob('running', 'j1', oldCreatedAt(), 25);
+      job.unified.jobType = 'run_team';
+      job.unified.repoPath = '/work/payments-api';
+      record([job]);
+      waitPastStillness();
+      record([job]);
+      component.jobs = [job];
+      fixture.detectChanges();
+      const host = fixture.nativeElement as HTMLElement;
+      const row = host.querySelector('tr.job-row') as HTMLElement | null;
+      expect(row).toBeTruthy();
+      expect(row?.getAttribute('aria-label')).toContain('appears stuck');
     });
   });
 

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
@@ -409,8 +409,11 @@ describe('JobsDashboardComponent', () => {
 
   describe('stuck-job detection', () => {
     const STUCK_MS = 2 * 60 * 60 * 1000;
+    const STILL_MS = 30 * 60 * 1000;
+    const PAST_STILL_MS = STILL_MS + 60_000;
     const oldCreatedAt = () => new Date(Date.now() - STUCK_MS - 60_000).toISOString();
     const youngCreatedAt = () => new Date(Date.now() - 60_000).toISOString();
+    const waitPastStillness = () => vi.setSystemTime(new Date(Date.now() + PAST_STILL_MS));
 
     const makeJob = (
       status: string,
@@ -455,18 +458,35 @@ describe('JobsDashboardComponent', () => {
       expect(component.isStuck(job)).toBe(false);
     });
 
-    it('is false after one unchanged poll, true after the second', () => {
+    it('is false after one unchanged poll, true after the second once stillness elapses', () => {
       const job = makeJob('running', 'j1', oldCreatedAt(), 25);
       record([job]);
       expect(component.isStuck(job)).toBe(false);
+      // Even a second unchanged poll arriving 40s later must not flip the
+      // row to "stuck" — the stillness gate guards against that.
+      vi.setSystemTime(new Date(Date.now() + 40_000));
       record([job]);
+      expect(component.isStuck(job)).toBe(false);
+      waitPastStillness();
       expect(component.isStuck(job)).toBe(true);
+    });
+
+    it('is not stuck within STUCK_STILL_DURATION_MS of the last signal change', () => {
+      const old = makeJob('running', 'j1', oldCreatedAt(), 25);
+      record([old]);
+      record([old]); // sampleCount = 2 but stillness ≈ 0
+      expect(component.isStuck(old)).toBe(false);
+      // 29 minutes — still under the 30-minute stillness threshold.
+      vi.setSystemTime(new Date(Date.now() + STILL_MS - 60_000));
+      record([old]);
+      expect(component.isStuck(old)).toBe(false);
     });
 
     it('resets when progress changes', () => {
       const a = makeJob('running', 'j1', oldCreatedAt(), 25);
       const b = makeJob('running', 'j1', oldCreatedAt(), 35);
       record([a]);
+      waitPastStillness();
       record([a]);
       expect(component.isStuck(a)).toBe(true);
       record([b]);
@@ -544,6 +564,7 @@ describe('JobsDashboardComponent', () => {
       const job = makeJob('running', 'j1', oldCreatedAt(), 25);
       job.unified.jobType = 'run_team';
       record([job]);
+      waitPastStillness();
       record([job]);
       expect(component.getJobAriaLabel(job)).toContain('appears stuck');
     });
@@ -567,6 +588,7 @@ describe('JobsDashboardComponent', () => {
         return job;
       };
       record([makePhaseJob()]);
+      waitPastStillness();
       record([makePhaseJob()]);
       expect(component.isStuck(makePhaseJob())).toBe(true);
     });
@@ -585,8 +607,10 @@ describe('JobsDashboardComponent', () => {
       const resumed = makeJob('running', 'j1', oldCreatedAt(), 25);
       record([resumed]);
       expect(component.isStuck(resumed)).toBe(false);
-      // And on the next poll where it's still unchanged, the running streak
-      // is now 2 → stuck (so the heuristic still works post-resume).
+      // And on a later poll where it's still unchanged and the stillness
+      // duration has elapsed, the running streak satisfies all gates → stuck
+      // (so the heuristic still works post-resume).
+      waitPastStillness();
       record([resumed]);
       expect(component.isStuck(resumed)).toBe(true);
     });
@@ -617,6 +641,7 @@ describe('JobsDashboardComponent', () => {
       job.unified.jobType = 'run_team';
       job.unified.repoPath = '/work/payments-api';
       record([job]);
+      waitPastStillness();
       record([job]);
       component.jobs = [job];
       fixture.detectChanges();

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
@@ -513,6 +513,24 @@ describe('JobsDashboardComponent', () => {
       record([job]);
       expect(component.getJobAriaLabel(job)).toContain('appears stuck');
     });
+
+    it('renders the stuck glyph with aria-hidden="false" and a non-empty aria-label', () => {
+      const job = makeJob('running', 'j1', oldCreatedAt(), 25);
+      job.unified.jobType = 'run_team';
+      job.unified.repoPath = '/work/payments-api';
+      record([job]);
+      record([job]);
+      component.jobs = [job];
+      fixture.detectChanges();
+      const host = fixture.nativeElement as HTMLElement;
+      const glyph = host.querySelector('.col-time .stuck-indicator') as HTMLElement | null;
+      expect(glyph).toBeTruthy();
+      // mat-icon defaults aria-hidden=true; we must override so SRs announce
+      // the label.
+      expect(glyph?.getAttribute('aria-hidden')).toBe('false');
+      expect(glyph?.getAttribute('role')).toBe('img');
+      expect(glyph?.getAttribute('aria-label')?.length ?? 0).toBeGreaterThan(0);
+    });
   });
 
   describe('canResumeJob', () => {

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
@@ -514,6 +514,37 @@ describe('JobsDashboardComponent', () => {
       expect(component.getJobAriaLabel(job)).toContain('appears stuck');
     });
 
+    it('does not flag a job whose progress is null but phase keeps changing', () => {
+      const makePhaseJob = (phase: string) => {
+        const job = makeJob('running', 'j1', oldCreatedAt(), null);
+        job.unified.phase = phase;
+        return job;
+      };
+      record([makePhaseJob('setup')]);
+      record([makePhaseJob('planning')]);
+      record([makePhaseJob('execution')]);
+      expect(component.isStuck(makePhaseJob('execution'))).toBe(false);
+    });
+
+    it('flags a job with null progress + frozen phase across enough polls', () => {
+      const makePhaseJob = () => {
+        const job = makeJob('running', 'j1', oldCreatedAt(), null);
+        job.unified.phase = 'execution';
+        return job;
+      };
+      record([makePhaseJob()]);
+      record([makePhaseJob()]);
+      expect(component.isStuck(makePhaseJob())).toBe(true);
+    });
+
+    it('excludes SE jobs waiting for answers even after threshold elapsed', () => {
+      const job = makeJob('running', 'j1', oldCreatedAt(), 25);
+      job.seDetail = { waitingForAnswers: true, progress: 25 } as any;
+      record([job]);
+      record([job]);
+      expect(component.isStuck(job)).toBe(false);
+    });
+
     it('renders the stuck glyph with aria-hidden="false" and a non-empty aria-label', () => {
       const job = makeJob('running', 'j1', oldCreatedAt(), 25);
       job.unified.jobType = 'run_team';

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
@@ -238,6 +238,23 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * True only when we have at least one piece of progress information for
+   * this job (numeric progress, a phase, or a status text). When this returns
+   * false (e.g. an SE row whose detail fetch failed so seDetail is null and
+   * nothing else surfaces), we can't honestly distinguish "stuck" from
+   * "couldn't observe" and isStuck() should bail out — otherwise a transient
+   * detail-endpoint outage would mass-surface false stuck warnings.
+   */
+  private hasObservableSignal(job: DashboardRow): boolean {
+    if (this.getProgress(job) != null) return true;
+    const phase = job.seDetail?.currentPhase ?? job.unified.phase ?? '';
+    if (phase !== '') return true;
+    const statusText = job.seDetail?.statusText ?? '';
+    if (statusText !== '') return true;
+    return false;
+  }
+
+  /**
    * Update per-job progress history from the latest poll. Resets sampleCount
    * whenever the signal changes; otherwise increments it. Prunes entries for
    * jobs that disappeared from the dashboard.
@@ -504,6 +521,10 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
     // status === 'running' but the dashboard labels them "Waiting". Don't
     // double-surface those as stuck.
     if (job.seDetail?.waitingForAnswers) return false;
+    // Without any observable progress signal we can't distinguish "stuck"
+    // from "we couldn't read its state" — refuse to flag rather than fire
+    // false alarms during a transient detail-endpoint outage.
+    if (!this.hasObservableSignal(job)) return false;
     const entry = this.progressHistory.get(this.historyKey(job));
     if (!entry) return false;
     // Prefer createdAt for the age gate; fall back to firstSeenAt for sources

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
@@ -245,8 +245,18 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
     const phase = job.seDetail?.currentPhase ?? job.unified.phase ?? '';
     const statusText = job.seDetail?.statusText ?? '';
     const currentTask = job.seDetail?.currentTask ?? '';
+    // Per-team fingerprint also covers microtask-level fields — the
+    // orchestrator updates current_microtask / current_microtask_phase /
+    // current_microtask_index / phase_detail while a single task moves
+    // through coding/review/QA before microtasks_completed ticks, so we'd
+    // miss real motion if we only watched task IDs and completion counts.
     const teamFp = (job.seDetail?.teamStatuses ?? [])
-      .map((t) => `${t.teamId}=${t.phase}:${t.currentTaskId ?? ''}:${t.microtasksCompleted ?? ''}`)
+      .map(
+        (t) =>
+          `${t.teamId}=${t.phase}:${t.currentTaskId ?? ''}:${t.microtasksCompleted ?? ''}` +
+          `:${t.currentMicrotaskIndex ?? ''}:${t.currentMicrotask ?? ''}` +
+          `:${t.currentMicrotaskPhase ?? ''}:${t.phaseDetail ?? ''}`,
+      )
       .join(',');
     return `${status}|${progress ?? 'null'}|${phase}|${statusText}|${currentTask}|${teamFp}`;
   }
@@ -502,6 +512,10 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
           isActive: phase !== 'completed' && phase !== '',
           currentTaskId: entry.current_task_id,
           microtasksCompleted: entry.microtasks_completed,
+          currentMicrotask: entry.current_microtask,
+          currentMicrotaskPhase: entry.current_microtask_phase,
+          currentMicrotaskIndex: entry.current_microtask_index,
+          phaseDetail: entry.phase_detail,
         };
       });
   }

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
@@ -122,6 +122,7 @@ const STUCK_REQUIRED_STILL_POLLS = 2;
 
 interface ProgressSample {
   signal: string;
+  firstSeenAt: number;
   lastChangedAt: number;
   sampleCount: number;
 }
@@ -252,12 +253,14 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
       if (!prev || prev.signal !== signal) {
         this.progressHistory.set(key, {
           signal,
+          firstSeenAt: now,
           lastChangedAt: now,
           sampleCount: 1,
         });
       } else {
         this.progressHistory.set(key, {
           signal: prev.signal,
+          firstSeenAt: prev.firstSeenAt,
           lastChangedAt: prev.lastChangedAt,
           sampleCount: prev.sampleCount + 1,
         });
@@ -501,12 +504,18 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
     // status === 'running' but the dashboard labels them "Waiting". Don't
     // double-surface those as stuck.
     if (job.seDetail?.waitingForAnswers) return false;
-    const createdAt = job.unified.createdAt;
-    if (!createdAt) return false;
-    const age = Date.now() - new Date(createdAt).getTime();
-    if (!Number.isFinite(age) || age <= STUCK_THRESHOLD_MS) return false;
     const entry = this.progressHistory.get(this.historyKey(job));
-    return !!entry && entry.sampleCount >= STUCK_REQUIRED_STILL_POLLS;
+    if (!entry) return false;
+    // Prefer createdAt for the age gate; fall back to firstSeenAt for sources
+    // that don't surface createdAt (e.g. Planning V3 jobs) so they can still
+    // be flagged once the dashboard itself has observed them frozen long
+    // enough.
+    const createdAt = job.unified.createdAt;
+    const createdTs = createdAt ? new Date(createdAt).getTime() : NaN;
+    const ageBasis = Number.isFinite(createdTs) ? createdTs : entry.firstSeenAt;
+    const age = Date.now() - ageBasis;
+    if (!Number.isFinite(age) || age <= STUCK_THRESHOLD_MS) return false;
+    return entry.sampleCount >= STUCK_REQUIRED_STILL_POLLS;
   }
 
   getStuckTooltip(job: DashboardRow): string {

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
@@ -115,10 +115,15 @@ const TEAM_FILTER_ORDER: JobSource[] = (Object.keys(SOURCE_DISPLAY) as JobSource
 const FILTER_STORAGE_KEY = 'jobs-dashboard-filters-v1';
 
 // Stuck-job detection: a running job is "stuck" once it has been alive longer
-// than STUCK_THRESHOLD_MS and its progress value has been unchanged across at
-// least STUCK_REQUIRED_STILL_POLLS consecutive polls. Tune both here.
-const STUCK_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2h since createdAt
-const STUCK_REQUIRED_STILL_POLLS = 2;
+// than STUCK_THRESHOLD_MS, its progress signal has been unchanged across at
+// least STUCK_REQUIRED_STILL_POLLS consecutive polls (anti-blip), AND wall
+// clock has advanced STUCK_STILL_DURATION_MS since the last signal change.
+// The sampleCount gate alone wasn't enough — for any old job, two polls (40s)
+// of unchanged progress would otherwise trip the warning right after a real
+// phase tick. Tune all three here.
+const STUCK_THRESHOLD_MS = 2 * 60 * 60 * 1000;     // 2h since createdAt / firstSeenAt
+const STUCK_REQUIRED_STILL_POLLS = 2;              // unchanged across N polls
+const STUCK_STILL_DURATION_MS = 30 * 60 * 1000;    // 30min since last signal change
 
 interface ProgressSample {
   signal: string;
@@ -527,6 +532,7 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
     if (!this.hasObservableSignal(job)) return false;
     const entry = this.progressHistory.get(this.historyKey(job));
     if (!entry) return false;
+    const now = Date.now();
     // Prefer createdAt for the age gate; fall back to firstSeenAt for sources
     // that don't surface createdAt (e.g. Planning V3 jobs) so they can still
     // be flagged once the dashboard itself has observed them frozen long
@@ -534,9 +540,13 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
     const createdAt = job.unified.createdAt;
     const createdTs = createdAt ? new Date(createdAt).getTime() : NaN;
     const ageBasis = Number.isFinite(createdTs) ? createdTs : entry.firstSeenAt;
-    const age = Date.now() - ageBasis;
+    const age = now - ageBasis;
     if (!Number.isFinite(age) || age <= STUCK_THRESHOLD_MS) return false;
-    return entry.sampleCount >= STUCK_REQUIRED_STILL_POLLS;
+    if (entry.sampleCount < STUCK_REQUIRED_STILL_POLLS) return false;
+    // Stillness duration gate: the signal must have actually been frozen for
+    // STUCK_STILL_DURATION_MS — otherwise a long-running job that just ticked
+    // its phase would flip to "stuck" on the very next poll.
+    return now - entry.lastChangedAt >= STUCK_STILL_DURATION_MS;
   }
 
   getStuckTooltip(job: DashboardRow): string {

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
@@ -226,29 +226,39 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Fingerprint of all "is the job advancing?" signals: status plus numeric
-   * progress plus phase / status text. Sources without numeric progress (e.g.
-   * founder, generic jobs) still surface phase or statusText changes, and
-   * including the status field guarantees that a transition through any
-   * non-running state (failed/cancelled/interrupted → resume) flips the
-   * fingerprint and resets sampleCount, so a freshly resumed job is never
-   * marked stuck on its first post-resume poll.
+   * Fingerprint of all "is the job advancing?" signals. Includes:
+   *  - `status` so a transition through any non-running state
+   *    (failed/cancelled/interrupted → resume) flips the fingerprint and
+   *    resets sampleCount, preventing a freshly resumed job from being
+   *    marked stuck on its first post-resume poll.
+   *  - `progress`, `phase`, `statusText` — the headline progress fields.
+   *  - SE per-team `phase`, `currentTaskId`, `microtasksCompleted` plus the
+   *    job-level `currentTask`. The SE orchestrator advances work by
+   *    updating task IDs / microtask counters while job-level phase /
+   *    status_text can stay unchanged for long stretches, so without these
+   *    a long-running SE job that is actively progressing through tasks
+   *    would satisfy the stillness gate and be flagged as stuck.
    */
   private progressSignal(job: DashboardRow): string {
     const status = job.unified.status ?? '';
     const progress = this.getProgress(job);
     const phase = job.seDetail?.currentPhase ?? job.unified.phase ?? '';
     const statusText = job.seDetail?.statusText ?? '';
-    return `${status}|${progress ?? 'null'}|${phase}|${statusText}`;
+    const currentTask = job.seDetail?.currentTask ?? '';
+    const teamFp = (job.seDetail?.teamStatuses ?? [])
+      .map((t) => `${t.teamId}=${t.phase}:${t.currentTaskId ?? ''}:${t.microtasksCompleted ?? ''}`)
+      .join(',');
+    return `${status}|${progress ?? 'null'}|${phase}|${statusText}|${currentTask}|${teamFp}`;
   }
 
   /**
    * True only when we have at least one piece of progress information for
-   * this job (numeric progress, a phase, or a status text). When this returns
-   * false (e.g. an SE row whose detail fetch failed so seDetail is null and
-   * nothing else surfaces), we can't honestly distinguish "stuck" from
-   * "couldn't observe" and isStuck() should bail out — otherwise a transient
-   * detail-endpoint outage would mass-surface false stuck warnings.
+   * this job (numeric progress, a phase, a status text, a current task, or
+   * a per-team phase). When this returns false (e.g. an SE row whose detail
+   * fetch failed so seDetail is null and nothing else surfaces), we can't
+   * honestly distinguish "stuck" from "couldn't observe" and isStuck() should
+   * bail out — otherwise a transient detail-endpoint outage would mass-
+   * surface false stuck warnings.
    */
   private hasObservableSignal(job: DashboardRow): boolean {
     if (this.getProgress(job) != null) return true;
@@ -256,6 +266,10 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
     if (phase !== '') return true;
     const statusText = job.seDetail?.statusText ?? '';
     if (statusText !== '') return true;
+    if ((job.seDetail?.currentTask ?? '') !== '') return true;
+    if ((job.seDetail?.teamStatuses ?? []).some((t) => t.phase !== '' || !!t.currentTaskId)) {
+      return true;
+    }
     return false;
   }
 
@@ -446,6 +460,7 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
         statusText: status.status_text,
         currentPhase: status.phase,
         waitingForAnswers: status.waiting_for_answers,
+        currentTask: status.current_task,
         teamProgress: status.team_progress,
       })),
       catchError(() => of(null))
@@ -457,6 +472,7 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
     statusText?: string;
     currentPhase?: string;
     waitingForAnswers?: boolean;
+    currentTask?: string;
     teamProgress?: Record<string, TeamProgressEntry>;
   }): SEDetail {
     return {
@@ -464,6 +480,7 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
       statusText: params.statusText,
       currentPhase: params.currentPhase,
       waitingForAnswers: params.waitingForAnswers,
+      currentTask: params.currentTask,
       teamStatuses: this.buildTeamStatuses(params.teamProgress),
     };
   }
@@ -483,6 +500,8 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
           phase,
           phaseLabel,
           isActive: phase !== 'completed' && phase !== '',
+          currentTaskId: entry.current_task_id,
+          microtasksCompleted: entry.microtasks_completed,
         };
       });
   }

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
@@ -220,17 +220,20 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * Fingerprint of all "is the job advancing?" signals: numeric progress plus
-   * phase / status text. Sources without numeric progress (e.g. founder,
-   * generic jobs) still surface phase or statusText changes, so combining
-   * them prevents a row from being flagged stuck when its progress field is
-   * permanently null but its phase ticks forward.
+   * Fingerprint of all "is the job advancing?" signals: status plus numeric
+   * progress plus phase / status text. Sources without numeric progress (e.g.
+   * founder, generic jobs) still surface phase or statusText changes, and
+   * including the status field guarantees that a transition through any
+   * non-running state (failed/cancelled/interrupted → resume) flips the
+   * fingerprint and resets sampleCount, so a freshly resumed job is never
+   * marked stuck on its first post-resume poll.
    */
   private progressSignal(job: DashboardRow): string {
+    const status = job.unified.status ?? '';
     const progress = this.getProgress(job);
     const phase = job.seDetail?.currentPhase ?? job.unified.phase ?? '';
     const statusText = job.seDetail?.statusText ?? '';
-    return `${progress ?? 'null'}|${phase}|${statusText}`;
+    return `${status}|${progress ?? 'null'}|${phase}|${statusText}`;
   }
 
   /**

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
@@ -114,6 +114,18 @@ const TEAM_FILTER_ORDER: JobSource[] = (Object.keys(SOURCE_DISPLAY) as JobSource
 
 const FILTER_STORAGE_KEY = 'jobs-dashboard-filters-v1';
 
+// Stuck-job detection: a running job is "stuck" once it has been alive longer
+// than STUCK_THRESHOLD_MS and its progress value has been unchanged across at
+// least STUCK_REQUIRED_STILL_POLLS consecutive polls. Tune both here.
+const STUCK_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2h since createdAt
+const STUCK_REQUIRED_STILL_POLLS = 2;
+
+interface ProgressSample {
+  progress: number | null;
+  lastChangedAt: number;
+  sampleCount: number;
+}
+
 interface PersistedFilters {
   status: StatusBucket;
   teams: JobSource[];
@@ -168,6 +180,9 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
   private pollSub: Subscription | null = null;
   private readonly POLL_INTERVAL = 20000;
 
+  /** Per-job progress history used by isStuck(). Key = `${source}::${jobId}`. */
+  private progressHistory = new Map<string, ProgressSample>();
+
   ngOnInit(): void {
     this.loadFilters();
     this.startPolling();
@@ -191,12 +206,49 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
       )
       .subscribe({
         next: (dashboardRows) => {
+          this.recordProgressSamples(dashboardRows);
           this.jobs = dashboardRows;
           this.loading = false;
           this.error = null;
           this.lastUpdated = new Date();
         },
       });
+  }
+
+  private historyKey(job: DashboardRow): string {
+    return `${job.unified.source}::${job.unified.jobId}`;
+  }
+
+  /**
+   * Update per-job progress history from the latest poll. Resets sampleCount
+   * whenever the progress value changes; otherwise increments it. Prunes
+   * entries for jobs that disappeared from the dashboard.
+   */
+  private recordProgressSamples(rows: DashboardRow[]): void {
+    const now = Date.now();
+    const seen = new Set<string>();
+    for (const job of rows) {
+      const key = this.historyKey(job);
+      seen.add(key);
+      const current = this.getProgress(job);
+      const prev = this.progressHistory.get(key);
+      if (!prev || prev.progress !== current) {
+        this.progressHistory.set(key, {
+          progress: current,
+          lastChangedAt: now,
+          sampleCount: 1,
+        });
+      } else {
+        this.progressHistory.set(key, {
+          progress: prev.progress,
+          lastChangedAt: prev.lastChangedAt,
+          sampleCount: prev.sampleCount + 1,
+        });
+      }
+    }
+    for (const key of this.progressHistory.keys()) {
+      if (!seen.has(key)) this.progressHistory.delete(key);
+    }
   }
 
   /** Fetch from all team list endpoints and merge into sorted DashboardRow[] (seDetail not set yet). */
@@ -421,6 +473,32 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
     return parts[parts.length - 1] || repoPath;
   }
 
+  /**
+   * A running job is considered stuck once it has been alive past the
+   * threshold and its progress has been unchanged across at least the
+   * required number of consecutive polls. See top-of-file constants to tune.
+   */
+  isStuck(job: DashboardRow): boolean {
+    if (job.unified.status !== 'running') return false;
+    const createdAt = job.unified.createdAt;
+    if (!createdAt) return false;
+    const age = Date.now() - new Date(createdAt).getTime();
+    if (!Number.isFinite(age) || age <= STUCK_THRESHOLD_MS) return false;
+    const entry = this.progressHistory.get(this.historyKey(job));
+    return !!entry && entry.sampleCount >= STUCK_REQUIRED_STILL_POLLS;
+  }
+
+  getStuckTooltip(job: DashboardRow): string {
+    const entry = this.progressHistory.get(this.historyKey(job));
+    if (!entry) return 'No progress detected — may be stuck';
+    // getTimeAgo returns "Just now" or "Nm ago"/"Nh ago"/"Nd ago"; strip the
+    // trailing " ago" so the tooltip reads "No progress in 40m — may be stuck".
+    const ago = this.getTimeAgo(new Date(entry.lastChangedAt).toISOString());
+    if (!ago || ago === 'Just now') return 'No progress detected — may be stuck';
+    const since = ago.replace(/ ago$/, '');
+    return `No progress in ${since} — may be stuck`;
+  }
+
   getStatusClass(job: DashboardRow): string {
     if (job.seDetail?.waitingForAnswers) return 'status-waiting';
     switch (job.unified.status) {
@@ -515,6 +593,7 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
     const when = this.getTimeAgo(job.unified.createdAt);
     const parts = [`Open ${team} ${type} job for ${subject}`, `status ${status}`];
     if (when) parts.push(`started ${when}`);
+    if (this.isStuck(job)) parts.push('appears stuck');
     return parts.join(', ');
   }
 

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
@@ -121,7 +121,7 @@ const STUCK_THRESHOLD_MS = 2 * 60 * 60 * 1000; // 2h since createdAt
 const STUCK_REQUIRED_STILL_POLLS = 2;
 
 interface ProgressSample {
-  progress: number | null;
+  signal: string;
   lastChangedAt: number;
   sampleCount: number;
 }
@@ -220,9 +220,23 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
   }
 
   /**
+   * Fingerprint of all "is the job advancing?" signals: numeric progress plus
+   * phase / status text. Sources without numeric progress (e.g. founder,
+   * generic jobs) still surface phase or statusText changes, so combining
+   * them prevents a row from being flagged stuck when its progress field is
+   * permanently null but its phase ticks forward.
+   */
+  private progressSignal(job: DashboardRow): string {
+    const progress = this.getProgress(job);
+    const phase = job.seDetail?.currentPhase ?? job.unified.phase ?? '';
+    const statusText = job.seDetail?.statusText ?? '';
+    return `${progress ?? 'null'}|${phase}|${statusText}`;
+  }
+
+  /**
    * Update per-job progress history from the latest poll. Resets sampleCount
-   * whenever the progress value changes; otherwise increments it. Prunes
-   * entries for jobs that disappeared from the dashboard.
+   * whenever the signal changes; otherwise increments it. Prunes entries for
+   * jobs that disappeared from the dashboard.
    */
   private recordProgressSamples(rows: DashboardRow[]): void {
     const now = Date.now();
@@ -230,17 +244,17 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
     for (const job of rows) {
       const key = this.historyKey(job);
       seen.add(key);
-      const current = this.getProgress(job);
+      const signal = this.progressSignal(job);
       const prev = this.progressHistory.get(key);
-      if (!prev || prev.progress !== current) {
+      if (!prev || prev.signal !== signal) {
         this.progressHistory.set(key, {
-          progress: current,
+          signal,
           lastChangedAt: now,
           sampleCount: 1,
         });
       } else {
         this.progressHistory.set(key, {
-          progress: prev.progress,
+          signal: prev.signal,
           lastChangedAt: prev.lastChangedAt,
           sampleCount: prev.sampleCount + 1,
         });
@@ -480,6 +494,10 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
    */
   isStuck(job: DashboardRow): boolean {
     if (job.unified.status !== 'running') return false;
+    // SE jobs that are intentionally paused for user input show
+    // status === 'running' but the dashboard labels them "Waiting". Don't
+    // double-surface those as stuck.
+    if (job.seDetail?.waitingForAnswers) return false;
     const createdAt = job.unified.createdAt;
     if (!createdAt) return false;
     const age = Date.now() - new Date(createdAt).getTime();

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
@@ -277,7 +277,22 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
     const statusText = job.seDetail?.statusText ?? '';
     if (statusText !== '') return true;
     if ((job.seDetail?.currentTask ?? '') !== '') return true;
-    if ((job.seDetail?.teamStatuses ?? []).some((t) => t.phase !== '' || !!t.currentTaskId)) {
+    // Match the set of TeamStatus fields consumed by progressSignal so a row
+    // whose only ticking signal is e.g. currentMicrotaskPhase still counts as
+    // observable and isn't filtered out by the outage guard.
+    const teams = job.seDetail?.teamStatuses ?? [];
+    if (
+      teams.some(
+        (t) =>
+          t.phase !== '' ||
+          !!t.currentTaskId ||
+          t.microtasksCompleted != null ||
+          t.currentMicrotaskIndex != null ||
+          !!t.currentMicrotask ||
+          !!t.currentMicrotaskPhase ||
+          !!t.phaseDetail,
+      )
+    ) {
       return true;
     }
     return false;
@@ -587,6 +602,11 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
     if (!entry) return 'No progress detected — may be stuck';
     // getTimeAgo returns "Just now" or "Nm ago"/"Nh ago"/"Nd ago"; strip the
     // trailing " ago" so the tooltip reads "No progress in 40m — may be stuck".
+    // The "Just now" fallback is defense-in-depth: in practice isStuck() only
+    // returns true after STUCK_STILL_DURATION_MS (30min), so a stuck row's
+    // tooltip never legitimately reads "Just now" — but this method is also
+    // exposed publicly, so guard against a caller invoking it for a row that
+    // was recently observed.
     const ago = this.getTimeAgo(new Date(entry.lastChangedAt).toISOString());
     if (!ago || ago === 'Just now') return 'No progress detected — may be stuck';
     const since = ago.replace(/ ago$/, '');
@@ -783,7 +803,7 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
   }
 
   trackByJobId(_index: number, job: DashboardRow): string {
-    return `${job.unified.source}:${job.unified.jobId}`;
+    return `${job.unified.source}::${job.unified.jobId}`;
   }
 
   getPhaseColorClass(phase: string): string {

--- a/user-interface/src/app/models/jobs-dashboard.model.ts
+++ b/user-interface/src/app/models/jobs-dashboard.model.ts
@@ -48,6 +48,10 @@ export interface TeamStatus {
   phase: string;
   phaseLabel: string;
   isActive: boolean;
+  /** Identifier of the task currently being worked on by this team, if any. */
+  currentTaskId?: string;
+  /** Number of microtasks this team has completed so far. */
+  microtasksCompleted?: number;
 }
 
 /** Extended detail for software-engineering jobs only (from detail API). */
@@ -56,6 +60,8 @@ export interface SEDetail {
   statusText?: string;
   currentPhase?: string;
   waitingForAnswers?: boolean;
+  /** Identifier of the task currently being executed at the job level. */
+  currentTask?: string;
   teamStatuses?: TeamStatus[];
 }
 

--- a/user-interface/src/app/models/jobs-dashboard.model.ts
+++ b/user-interface/src/app/models/jobs-dashboard.model.ts
@@ -52,6 +52,14 @@ export interface TeamStatus {
   currentTaskId?: string;
   /** Number of microtasks this team has completed so far. */
   microtasksCompleted?: number;
+  /** Identifier / label of the microtask currently being executed. */
+  currentMicrotask?: string;
+  /** Phase of the current microtask (coding/review/qa/etc.). */
+  currentMicrotaskPhase?: string;
+  /** Zero-based index of the microtask within the current task. */
+  currentMicrotaskIndex?: number;
+  /** Free-form phase detail set by the orchestrator. */
+  phaseDetail?: string;
 }
 
 /** Extended detail for software-engineering jobs only (from detail API). */


### PR DESCRIPTION
Closes #482.

## Summary
- Track per-job progress across the 20s poll loop in `progressHistory` (Map keyed by `${source}::${jobId}`) so the component can tell when a running job has stopped advancing.
- A row is considered stuck when `status === 'running'`, age since `createdAt` > `STUCK_THRESHOLD_MS` (2h), and progress has been unchanged for ≥ `STUCK_REQUIRED_STILL_POLLS` (2) consecutive polls. Both thresholds are top-of-file consts — single place to tune.
- New `isStuck(job)` and `getStuckTooltip(job)` predicates power a `warning_amber` mat-icon rendered next to the `Started` cell, with a matTooltip ("No progress in 40m — may be stuck") and `aria-label` so the signal is shape + text, not color-only (also relevant to sibling issue #496 on CVD).
- `getJobAriaLabel` appends "appears stuck" when stuck so the row's aria-label conveys the state to AT users.
- Subtle 2s pulse keyframe on the glyph; respects `prefers-reduced-motion`.

## Test plan
- [x] `npm test -- --run jobs-dashboard.component.spec.ts` — 64 tests pass, including 9 new cases for the stuck-detection logic (not-running, age gate, sample-count gate, progress-changed reset, missing createdAt, tooltip phrasing, fallback tooltip, history pruning, row aria-label).
- [x] `npm run build` succeeds (no new warnings; pre-existing initial-bundle budget warning unchanged).
- [ ] Manual smoke: temporarily lower `STUCK_THRESHOLD_MS` to ~30s, observe glyph appear on a stalled running job within two poll cycles and disappear when progress advances. Revert constants before merge.
- [ ] CVD simulator (Chrome DevTools → Rendering → Emulate vision deficiencies) — confirm glyph remains distinguishable independent of color.

https://claude.ai/code/session_01Ad8T3AS1vjb6foxL1q3cqo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ad8T3AS1vjb6foxL1q3cqo)_