### PR TITLE
nutrition-meal-planning: SPEC-007 W9 guardrail audit migration (#341)

### DIFF
--- a/backend/agents/nutrition_meal_planning_team/postgres/__init__.py
+++ b/backend/agents/nutrition_meal_planning_team/postgres/__init__.py
@@ -136,6 +136,37 @@ SCHEMA = TeamSchema(
             expires_at   TIMESTAMPTZ NOT NULL,
             created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
         )""",
+        # --- SPEC-007 additions (guardrail audit trail) ---
+        # Stamps every persisted recommendation with the guardrail
+        # version that cleared it, plus the parsed-ingredients / flags
+        # snapshot used to make the call. Nullable-default so legacy
+        # rows and the pre-W5 insert path stay valid; W5 begins
+        # populating them once the two-pass pipeline lands.
+        # ``restriction_snapshot_hash`` lets W12's replay job find
+        # rows whose snapshot predates the current RestrictionResolution
+        # KB version.
+        "ALTER TABLE nutrition_recommendations ADD COLUMN IF NOT EXISTS guardrail_version TEXT",
+        "ALTER TABLE nutrition_recommendations ADD COLUMN IF NOT EXISTS parsed_ingredients_json JSONB",
+        "ALTER TABLE nutrition_recommendations ADD COLUMN IF NOT EXISTS flags_json JSONB",
+        "ALTER TABLE nutrition_recommendations ADD COLUMN IF NOT EXISTS restriction_snapshot_hash TEXT",
+        # Append-only log of every guardrail rejection. One row per
+        # violation (not per recommendation) so a meal with two flagged
+        # ingredients produces two rows.
+        """CREATE TABLE IF NOT EXISTS nutrition_guardrail_rejections (
+            id                 BIGSERIAL PRIMARY KEY,
+            client_id          TEXT NOT NULL,
+            meal_snapshot      JSONB NOT NULL,
+            violation_reason   TEXT NOT NULL,
+            ingredient_raw     TEXT,
+            canonical_id       TEXT,
+            tag                TEXT,
+            detail             TEXT,
+            guardrail_version  TEXT NOT NULL,
+            kb_version         TEXT,
+            created_at         TIMESTAMPTZ NOT NULL DEFAULT now()
+        )""",
+        """CREATE INDEX IF NOT EXISTS idx_guardrail_rejections_client_time
+            ON nutrition_guardrail_rejections (client_id, created_at DESC)""",
     ],
     table_names=[
         "nutrition_profiles",
@@ -146,5 +177,6 @@ SCHEMA = TeamSchema(
         "nutrition_clinical_overrides_log",
         "nutrition_pantry",
         "nutrition_pantry_import_drafts",
+        "nutrition_guardrail_rejections",
     ],
 )

--- a/backend/agents/nutrition_meal_planning_team/shared/guardrail_audit_store.py
+++ b/backend/agents/nutrition_meal_planning_team/shared/guardrail_audit_store.py
@@ -1,0 +1,105 @@
+"""Postgres-backed append-only log of SPEC-007 guardrail rejections.
+
+One row per violation (not per recommendation): a meal flagged for two
+ingredients produces two rows. Reads are W11's job — this module is
+write-only for now.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+from shared_postgres import Json, get_conn
+from shared_postgres.metrics import timed_query
+
+logger = logging.getLogger(__name__)
+
+_STORE = "nutrition_meal_planning"
+
+
+@timed_query(store=_STORE, op="record_rejection")
+def record_rejection(
+    client_id: str,
+    meal_snapshot: Dict[str, Any],
+    violation_reason: str,
+    *,
+    guardrail_version: str,
+    ingredient_raw: Optional[str] = None,
+    canonical_id: Optional[str] = None,
+    tag: Optional[str] = None,
+    detail: Optional[str] = None,
+    kb_version: Optional[str] = None,
+) -> int:
+    """Append one rejection row. Returns the new id."""
+    ts = datetime.now(tz=timezone.utc)
+    with get_conn() as conn, conn.cursor() as cur:
+        cur.execute(
+            "INSERT INTO nutrition_guardrail_rejections "
+            "(client_id, meal_snapshot, violation_reason, ingredient_raw, "
+            " canonical_id, tag, detail, guardrail_version, kb_version, created_at) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s) RETURNING id",
+            (
+                client_id,
+                Json(meal_snapshot or {}),
+                violation_reason,
+                ingredient_raw,
+                canonical_id,
+                tag,
+                detail,
+                guardrail_version,
+                kb_version,
+                ts,
+            ),
+        )
+        row = cur.fetchone()
+        return int(row[0])
+
+
+class GuardrailAuditStore:
+    """Thin Postgres-backed store for SPEC-007 guardrail rejections."""
+
+    def __init__(self) -> None:
+        # Stateless; the connection pool lives inside shared_postgres.
+        pass
+
+    def record_rejection(
+        self,
+        client_id: str,
+        meal_snapshot: Dict[str, Any],
+        violation_reason: str,
+        *,
+        guardrail_version: str,
+        ingredient_raw: Optional[str] = None,
+        canonical_id: Optional[str] = None,
+        tag: Optional[str] = None,
+        detail: Optional[str] = None,
+        kb_version: Optional[str] = None,
+    ) -> int:
+        return record_rejection(
+            client_id,
+            meal_snapshot,
+            violation_reason,
+            guardrail_version=guardrail_version,
+            ingredient_raw=ingredient_raw,
+            canonical_id=canonical_id,
+            tag=tag,
+            detail=detail,
+            kb_version=kb_version,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Lazy singleton
+# ---------------------------------------------------------------------------
+
+_default_store: Optional[GuardrailAuditStore] = None
+
+
+def get_guardrail_audit_store() -> GuardrailAuditStore:
+    """Return the process-wide store, instantiating on first call."""
+    global _default_store
+    if _default_store is None:
+        _default_store = GuardrailAuditStore()
+    return _default_store

--- a/backend/agents/nutrition_meal_planning_team/shared/meal_feedback_store.py
+++ b/backend/agents/nutrition_meal_planning_team/shared/meal_feedback_store.py
@@ -47,16 +47,40 @@ def _parse_iso(value: Optional[str]) -> Optional[datetime]:
 
 
 @timed_query(store=_STORE, op="record_recommendation")
-def record_recommendation(client_id: str, meal_snapshot: Dict[str, Any]) -> str:
-    """Store a meal recommendation and return its recommendation_id."""
+def record_recommendation(
+    client_id: str,
+    meal_snapshot: Dict[str, Any],
+    *,
+    guardrail_version: Optional[str] = None,
+    parsed_ingredients: Optional[List[Dict[str, Any]]] = None,
+    flags: Optional[List[Dict[str, Any]]] = None,
+    restriction_snapshot_hash: Optional[str] = None,
+) -> str:
+    """Store a meal recommendation and return its recommendation_id.
+
+    Guardrail metadata kwargs are nullable for the legacy / pre-W5
+    insert path; SPEC-007 W5's two-pass pipeline starts populating them
+    once it lands.
+    """
     recommendation_id = str(uuid4())
     ts = datetime.now(tz=timezone.utc)
     with get_conn() as conn, conn.cursor() as cur:
         cur.execute(
             "INSERT INTO nutrition_recommendations "
-            "(recommendation_id, client_id, meal_snapshot, recommended_at) "
-            "VALUES (%s, %s, %s, %s)",
-            (recommendation_id, client_id, Json(meal_snapshot or {}), ts),
+            "(recommendation_id, client_id, meal_snapshot, recommended_at, "
+            " guardrail_version, parsed_ingredients_json, flags_json, "
+            " restriction_snapshot_hash) "
+            "VALUES (%s, %s, %s, %s, %s, %s, %s, %s)",
+            (
+                recommendation_id,
+                client_id,
+                Json(meal_snapshot or {}),
+                ts,
+                guardrail_version,
+                Json(parsed_ingredients) if parsed_ingredients is not None else None,
+                Json(flags) if flags is not None else None,
+                restriction_snapshot_hash,
+            ),
         )
     return recommendation_id
 
@@ -152,8 +176,24 @@ class MealFeedbackStore:
         # Stateless; the connection pool lives inside shared_postgres.
         pass
 
-    def record_recommendation(self, client_id: str, meal_snapshot: Dict[str, Any]) -> str:
-        return record_recommendation(client_id, meal_snapshot)
+    def record_recommendation(
+        self,
+        client_id: str,
+        meal_snapshot: Dict[str, Any],
+        *,
+        guardrail_version: Optional[str] = None,
+        parsed_ingredients: Optional[List[Dict[str, Any]]] = None,
+        flags: Optional[List[Dict[str, Any]]] = None,
+        restriction_snapshot_hash: Optional[str] = None,
+    ) -> str:
+        return record_recommendation(
+            client_id,
+            meal_snapshot,
+            guardrail_version=guardrail_version,
+            parsed_ingredients=parsed_ingredients,
+            flags=flags,
+            restriction_snapshot_hash=restriction_snapshot_hash,
+        )
 
     def record_feedback(
         self,

--- a/backend/agents/nutrition_meal_planning_team/tests/test_guardrail_audit_store.py
+++ b/backend/agents/nutrition_meal_planning_team/tests/test_guardrail_audit_store.py
@@ -1,0 +1,117 @@
+"""Unit tests for SPEC-007 GuardrailAuditStore (Postgres-backed)."""
+
+import pytest
+
+from nutrition_meal_planning_team.shared.guardrail_audit_store import (
+    GuardrailAuditStore,
+    get_guardrail_audit_store,
+    record_rejection,
+)
+from shared_postgres import dict_row, get_conn, is_postgres_enabled
+
+pytestmark = pytest.mark.skipif(
+    not is_postgres_enabled(),
+    reason="GuardrailAuditStore requires Postgres (set POSTGRES_HOST).",
+)
+
+
+class TestGuardrailAuditStore:
+    @pytest.fixture
+    def store(self):
+        return GuardrailAuditStore()
+
+    def test_record_rejection_inserts_row(self, store):
+        rejection_id = store.record_rejection(
+            "c-reject-1",
+            {"name": "Cashew curry"},
+            "ingredient violates allergen restriction",
+            guardrail_version="1.0.0",
+            ingredient_raw="cashews",
+            canonical_id="tree_nut",
+            tag="allergen",
+            detail="tree_nut",
+            kb_version="1.0.0",
+        )
+        assert rejection_id > 0
+        with get_conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                "SELECT client_id, meal_snapshot, violation_reason, "
+                "       ingredient_raw, canonical_id, tag, detail, "
+                "       guardrail_version, kb_version, created_at "
+                "FROM nutrition_guardrail_rejections WHERE id = %s",
+                (rejection_id,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row["client_id"] == "c-reject-1"
+        assert row["meal_snapshot"] == {"name": "Cashew curry"}
+        assert row["violation_reason"] == "ingredient violates allergen restriction"
+        assert row["ingredient_raw"] == "cashews"
+        assert row["canonical_id"] == "tree_nut"
+        assert row["tag"] == "allergen"
+        assert row["detail"] == "tree_nut"
+        assert row["guardrail_version"] == "1.0.0"
+        assert row["kb_version"] == "1.0.0"
+        assert row["created_at"] is not None
+
+    def test_record_rejection_multiple_violations(self, store):
+        # SPEC-007: one row per violation, not per recommendation.
+        meal = {"name": "Trail mix"}
+        first = store.record_rejection(
+            "c-reject-multi",
+            meal,
+            "ingredient violates allergen restriction",
+            guardrail_version="1.0.0",
+            canonical_id="tree_nut",
+        )
+        second = store.record_rejection(
+            "c-reject-multi",
+            meal,
+            "ingredient violates allergen restriction",
+            guardrail_version="1.0.0",
+            canonical_id="peanut",
+        )
+        assert first != second
+        with get_conn() as conn, conn.cursor() as cur:
+            cur.execute(
+                "SELECT COUNT(*) FROM nutrition_guardrail_rejections WHERE client_id = %s",
+                ("c-reject-multi",),
+            )
+            count = cur.fetchone()[0]
+        assert count == 2
+
+    def test_record_rejection_with_minimal_args(self, store):
+        # All ingredient-detail kwargs optional; only guardrail_version is required.
+        rejection_id = store.record_rejection(
+            "c-reject-minimal",
+            {"name": "Unknown dish"},
+            "policy violation",
+            guardrail_version="1.0.0",
+        )
+        assert rejection_id > 0
+        with get_conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                "SELECT ingredient_raw, canonical_id, tag, detail, kb_version "
+                "FROM nutrition_guardrail_rejections WHERE id = %s",
+                (rejection_id,),
+            )
+            row = cur.fetchone()
+        assert row["ingredient_raw"] is None
+        assert row["canonical_id"] is None
+        assert row["tag"] is None
+        assert row["detail"] is None
+        assert row["kb_version"] is None
+
+    def test_module_level_function(self):
+        rejection_id = record_rejection(
+            "c-reject-modlevel",
+            {"name": "Soup"},
+            "test",
+            guardrail_version="1.0.0",
+        )
+        assert rejection_id > 0
+
+    def test_singleton(self):
+        a = get_guardrail_audit_store()
+        b = get_guardrail_audit_store()
+        assert a is b

--- a/backend/agents/nutrition_meal_planning_team/tests/test_stores.py
+++ b/backend/agents/nutrition_meal_planning_team/tests/test_stores.py
@@ -18,7 +18,7 @@ from nutrition_meal_planning_team.shared.meal_feedback_store import (
     record_feedback,
     record_recommendation,
 )
-from shared_postgres import is_postgres_enabled
+from shared_postgres import dict_row, get_conn, is_postgres_enabled
 
 pytestmark = pytest.mark.skipif(
     not is_postgres_enabled(),
@@ -109,3 +109,46 @@ class TestMealFeedbackStore:
         entries = get_meal_history("c2")
         assert len(entries) == 1
         assert entries[0].feedback and entries[0].feedback.rating == 4
+
+    def test_record_recommendation_without_guardrail_kwargs(self, store):
+        # Legacy / pre-SPEC-007-W5 insert path: all four new columns
+        # must persist as NULL (acceptance: "accepts guardrail_version=None").
+        rec_id = store.record_recommendation("c-legacy", {"name": "Toast"})
+        with get_conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                "SELECT guardrail_version, parsed_ingredients_json, "
+                "       flags_json, restriction_snapshot_hash "
+                "FROM nutrition_recommendations WHERE recommendation_id = %s",
+                (rec_id,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row["guardrail_version"] is None
+        assert row["parsed_ingredients_json"] is None
+        assert row["flags_json"] is None
+        assert row["restriction_snapshot_hash"] is None
+
+    def test_record_recommendation_with_guardrail_metadata(self, store):
+        parsed = [{"raw": "almonds", "canonical_id": "tree_nut"}]
+        flags = [{"tag": "allergen", "detail": "tree_nut"}]
+        rec_id = store.record_recommendation(
+            "c-guarded",
+            {"name": "Almond bowl"},
+            guardrail_version="1.0.0",
+            parsed_ingredients=parsed,
+            flags=flags,
+            restriction_snapshot_hash="abc123",
+        )
+        with get_conn() as conn, conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                "SELECT guardrail_version, parsed_ingredients_json, "
+                "       flags_json, restriction_snapshot_hash "
+                "FROM nutrition_recommendations WHERE recommendation_id = %s",
+                (rec_id,),
+            )
+            row = cur.fetchone()
+        assert row is not None
+        assert row["guardrail_version"] == "1.0.0"
+        assert row["parsed_ingredients_json"] == parsed
+        assert row["flags_json"] == flags
+        assert row["restriction_snapshot_hash"] == "abc123"


### PR DESCRIPTION
Closes #341. Parent: #212. Plan: SPEC-007 §4.5, §4.9.

## Summary

Lays the SPEC-007 persistence floor that W5–W12 build on. Additive and nullable-default — no runtime behaviour change until W5's two-pass pipeline starts populating the new columns.

- `nutrition_recommendations` gains four nullable columns: `guardrail_version`, `parsed_ingredients_json`, `flags_json`, `restriction_snapshot_hash`. All use `ADD COLUMN IF NOT EXISTS` to match the SPEC-002/004/006/015 precedents in the same file (lines 93–96, 104–109) and to honour the issue's *"Idempotent on re-register"* acceptance criterion.
- New append-only `nutrition_guardrail_rejections` table — one row per violation (a meal flagged for two ingredients produces two rows). Indexed by `(client_id, created_at DESC)` like `nutrition_clinical_overrides_log`.
- `nutrition_guardrail_rejections` added to `SCHEMA.table_names` so `truncate_team_tables` cleans it between tests.
- `meal_feedback_store.record_recommendation` (and the `MealFeedbackStore` wrapper) gain four **keyword-only** optional kwargs so all existing positional callers keep working; the legacy / pre-W5 path stays a valid call shape.
- New `nutrition_meal_planning_team/shared/guardrail_audit_store.py` mirroring the `meal_feedback_store` shape: module-level `record_rejection` + thin `GuardrailAuditStore` class + lazy singleton `get_guardrail_audit_store()`. Write-only — reads are W11's job.
- Tests extend `test_stores.py` (two new tests proving the legacy NULL path and the populated path) and add `test_guardrail_audit_store.py` (rejection insert, multi-violation, minimal-args, module-level, singleton).

Unblocks: #337 (W7 orchestrator two-pass pipeline), #343 (W11 observability + rejection audit log), #344 (W12 replay job on KB bump).

## Out of scope (deliberately)

- Wiring W5 `meal_planning_agent.regenerate_single` — that is #337.
- UI surfacing of `flags_json` — that is #342 (W10).
- Observability counters — that is #343 (W11).
- The replay job that consumes `restriction_snapshot_hash` — that is #344 (W12).
- Reader API / `get_meal_history` returning the new columns.

## Test plan

- [x] `ruff check` + `ruff format --check` pass on all changed files.
- [x] All changed files byte-compile clean (no syntax errors).
- [ ] CI: `pytest agents/nutrition_meal_planning_team/tests/test_stores.py agents/nutrition_meal_planning_team/tests/test_guardrail_audit_store.py` against the live Postgres fixture. *(Could not run locally — sandbox has no Docker / no Postgres / no httpx in env; relying on CI.)*
- [ ] CI: `agents/shared_postgres/tests/test_shared_postgres.py` continues to pass (verifies `register_all_team_schemas()` still applies cleanly).
- [ ] Idempotency: re-running the schema apply against an already-migrated DB must succeed (all DDL uses `IF NOT EXISTS`).
- [ ] Existing-data safety: a legacy `nutrition_recommendations` row reads back with NULL for the four new columns after migration.
- [ ] Manual: `psql ... -c "\d nutrition_recommendations"` and `"\d nutrition_guardrail_rejections"` after a fresh staging apply.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qbh2o57spmg4jcGLmAFSua)_