### PR TITLE
jobs-dashboard: verify status conveyance is not color-only (#496)

### DIFF
--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
@@ -231,6 +231,45 @@ describe('JobsDashboardComponent', () => {
     expect(host.querySelector('td.col-job .job-team')).toBeNull();
   });
 
+  it('renders non-empty status-badge text for every status (WCAG 1.4.1 safety net)', () => {
+    // The 3px left-border row indicator encodes status via colour only and shares
+    // colours across statuses (waiting/interrupted both use --kh-warning,
+    // pending/cancelled both use --kh-border-muted), so the badge text is the
+    // load-bearing non-colour cue. Guard against future refactors silently
+    // dropping that text fallback. See #496.
+    const cases = [
+      { status: 'running', waiting: false, expected: 'Running' },
+      { status: 'pending', waiting: false, expected: 'Pending' },
+      { status: 'completed', waiting: false, expected: 'Completed' },
+      { status: 'failed', waiting: false, expected: 'Failed' },
+      { status: 'cancelled', waiting: false, expected: 'Cancelled' },
+      { status: 'interrupted', waiting: false, expected: 'Interrupted' },
+      { status: 'running', waiting: true, expected: 'Waiting' },
+    ];
+    component.jobs = cases.map(({ status, waiting }, i) => ({
+      unified: {
+        source: 'software_engineering',
+        jobType: 'run_team',
+        jobId: `j${i}`,
+        status,
+        createdAt: new Date().toISOString(),
+        label: 'Run',
+        repoPath: '/work/repo',
+      },
+      seDetail: waiting ? { waitingForAnswers: true } : undefined,
+    }) as any);
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const badges = Array.from(host.querySelectorAll('.status-badge'));
+    expect(badges.length).toBe(cases.length);
+    const labels = badges.map((b) => (b.textContent ?? '').trim());
+    for (const label of labels) {
+      expect(label.length).toBeGreaterThan(0);
+    }
+    expect(new Set(labels)).toEqual(new Set(cases.map((c) => c.expected)));
+  });
+
   it('navigateToJob navigates with jobId and tab for SE job', () => {
     const job = {
       unified: { source: 'software_engineering', jobType: 'run_team', jobId: 'j1' },


### PR DESCRIPTION
Closes #496.

## Summary

- Verified that the 3px left-border row indicator on each Jobs Dashboard row, while colour-only, is **decorative redundancy** — the badge text + the row `aria-label` are the load-bearing non-colour cues, so WCAG 1.4.1 is satisfied without code changes to the indicator itself.
- Added one Vitest assertion in `jobs-dashboard.component.spec.ts` that every `.status-badge` renders non-empty text matching the expected status label across all seven statuses (`Running`, `Pending`, `Waiting`, `Completed`, `Failed`, `Cancelled`, `Interrupted`). This guards against a future refactor silently replacing the text with an icon-only badge.

No production source files are touched.

## Why the border is not — and cannot be — the source of truth

Resolved hex values from `user-interface/src/theme.scss`:

| Status      | Token                | Hex       |
|-------------|----------------------|-----------|
| running     | `--kh-accent`        | `#fbbf24` |
| pending     | `--kh-border-muted`  | `#71717a` |
| waiting     | `--kh-warning`       | `#fbbf24` |
| completed   | `--kh-success`       | `#4ade80` |
| failed      | `--kh-error`         | `#f87171` |
| cancelled   | `--kh-border-muted`  | `#71717a` |
| interrupted | `--kh-warning`       | `#fbbf24` |

`--kh-accent` and `--kh-warning` resolve to the same hex, and `--kh-border-muted` is shared between two statuses. So even with full colour vision, the border alone cannot distinguish:

- `running` ↔ `waiting` ↔ `interrupted` (all `#fbbf24`, ΔE2000 = 0.00)
- `pending` ↔ `cancelled` (both `#71717a`, ΔE2000 = 0.00)

The badge text is already the only way to disambiguate those — for every user. CVD only narrows separation further between groups; it cannot make the badge text suddenly insufficient.

## Analytical CVD evidence (ΔE2000)

Brettel-Vienot-Machado simulation matrices applied in linear sRGB, converted to CIE Lab (D65), pairwise ΔE2000 between every status. Threshold ≥ 5 = comfortably distinguishable.

Smallest ΔE2000 between any two **semantically distinct** statuses, per mode:

| Mode          | Min ΔE2000 (distinct pair) | Pair                  |
|---------------|---------------------------:|-----------------------|
| Normal vision | 30.85                      | pending vs failed     |
| Protanopia    | 9.92                       | running vs completed  |
| Deuteranopia  | 6.89                       | completed vs failed   |
| Tritanopia    | 17.19                      | running vs failed     |

Every distinct colour pair stays well above the ΔE2000 ≥ 5 perceptibility threshold under all three CVD types. The border colour itself is not breaking under CVD; the limitation is the shared-hex problem above, which the badge text already resolves for all users.

## Acceptance criteria

- [x] Manual CVD simulation pass documented in the PR description. (Analytical equivalent — Brettel-Vienot-Machado ΔE2000 — substituted because Chrome DevTools manual emulation is not available in the agent environment. Reviewer please verify by opening `/jobs-dashboard` in Chrome → DevTools → Rendering → Emulate vision deficiencies → Protanopia / Deuteranopia / Tritanopia / Achromatopsia, and confirming every row's badge text remains legible. Replace this note with screenshots if any mode reveals a regression.)
- [x] Left border is verified as redundant — status badge text carries the load and stays as-is. The row `aria-label` ("…status running, …") is the screen-reader equivalent.

## Test plan

- [x] `cd user-interface && npx vitest run src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts` — 79/79 passing (1 new test added).
- [x] `cd user-interface && npx ng lint` — clean.
- [x] `cd user-interface && npx ng build --configuration development` — clean.
- [ ] Manual CVD pass in Chrome DevTools (reviewer task — see note above).

## Out of scope

The sibling jobs-dashboard polish issues #483–#495 are not touched here.

https://claude.ai/code/session_01Vpc6Hd1yBQ4HESeqojTbEh

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vpc6Hd1yBQ4HESeqojTbEh)_
