### PR TITLE
investment-team: close out #379 — strategy↔harness protocol version negotiation

### DIFF
--- a/backend/agents/investment_team/tests/test_streaming_harness_chunked.py
+++ b/backend/agents/investment_team/tests/test_streaming_harness_chunked.py
@@ -364,3 +364,156 @@ def test_trading_service_rejects_invalid_bar_chunk_size() -> None:
     TradingService(strategy_code="x", config=config, bar_chunk_size=None)
     TradingService(strategy_code="x", config=config, bar_chunk_size=1)
     TradingService(strategy_code="x", config=config, bar_chunk_size=256)
+
+
+# ---------------------------------------------------------------------------
+# Strategy protocol versioning (#379 Step 9 / criterion 9)
+# ---------------------------------------------------------------------------
+
+
+_LEGACY_V1_CODE = textwrap.dedent('''\
+    """A strategy that does NOT declare ``protocol_version``. It must
+    inherit ``Strategy.protocol_version = 1`` and continue to work
+    (legacy mode) — this is the explicit #379 criterion 9 case.
+    """
+    from contract import Strategy
+
+
+    class Legacy(Strategy):
+        def on_bar(self, ctx, bar):
+            pass
+''')
+
+
+_EXPLICIT_V1_CODE = textwrap.dedent('''\
+    """A strategy that explicitly declares ``protocol_version = 1``.
+    Equivalent to the inherited default but pins intent at the call site.
+    """
+    from contract import Strategy
+
+
+    class ExplicitV1(Strategy):
+        protocol_version = 1
+
+        def on_bar(self, ctx, bar):
+            pass
+''')
+
+
+_FUTURE_VERSION_CODE = textwrap.dedent('''\
+    """A strategy declaring a protocol version higher than the engine
+    knows about. The harness must reject this at handshake so a strategy
+    written against a future engine can't silently behave like v1.
+    """
+    from contract import Strategy
+
+
+    class FutureProtocol(Strategy):
+        protocol_version = 99
+
+        def on_bar(self, ctx, bar):
+            pass
+''')
+
+
+_INVALID_VERSION_CODE = textwrap.dedent('''\
+    """A strategy declaring a non-positive / non-int protocol_version.
+    The harness must reject so a typo can't masquerade as legacy mode.
+    """
+    from contract import Strategy
+
+
+    class InvalidProtocol(Strategy):
+        protocol_version = "v2"  # type: ignore[assignment]
+
+        def on_bar(self, ctx, bar):
+            pass
+''')
+
+
+def test_legacy_strategy_without_protocol_version_works_unchanged() -> None:
+    """#379 criterion 9: a strategy with no ``protocol_version`` field
+    must continue to work in legacy mode.
+
+    Inherits ``Strategy.protocol_version = 1`` (the default), runs through
+    a normal lifecycle, and the harness reports the negotiated version as
+    ``1`` in both the capabilities payload and the parent-side property.
+    """
+    with StreamingHarness(_LEGACY_V1_CODE) as harness:
+        resp = harness.send_start(config={"initial_capital": 100_000.0})
+        assert resp.capabilities.get("protocol_version") == 1
+        assert resp.capabilities.get("engine_protocol_version") == 1
+        assert harness.protocol_version == 1
+        assert harness.engine_protocol_version == 1
+        # A normal lifecycle still works — legacy strategies are not
+        # downgraded to a degraded path; v1 IS the engine's current level.
+        harness.send_bar(bar=_bar("2024-01-01"), state=_state())
+        harness.send_end()
+
+
+def test_explicit_protocol_version_one_is_advertised() -> None:
+    """A strategy that pins ``protocol_version = 1`` explicitly behaves
+    identically to a strategy that inherits the default — important
+    because the same call-site pattern is what a future v2 strategy will
+    use, just with a higher number.
+    """
+    with StreamingHarness(_EXPLICIT_V1_CODE) as harness:
+        resp = harness.send_start(config={"initial_capital": 100_000.0})
+        assert resp.capabilities.get("protocol_version") == 1
+        assert harness.protocol_version == 1
+        harness.send_end()
+
+
+def test_future_protocol_version_is_rejected_at_handshake() -> None:
+    """A strategy declaring a ``protocol_version`` higher than the
+    engine's ``CURRENT_PROTOCOL_VERSION`` must be rejected at handshake
+    with ``etype="contract_error"`` so it can't silently run as v1
+    and drop whatever feature the strategy was written against.
+    """
+    import pytest
+
+    from investment_team.trading_service.strategy.streaming_harness import (
+        StrategyRuntimeError,
+    )
+
+    with StreamingHarness(_FUTURE_VERSION_CODE) as harness:
+        with pytest.raises(StrategyRuntimeError) as ei:
+            harness.send_start(config={"initial_capital": 100_000.0})
+        assert ei.value.etype == "contract_error"
+        assert "protocol_version" in str(ei.value)
+
+
+def test_invalid_protocol_version_is_rejected_at_handshake() -> None:
+    """A non-int / non-positive ``protocol_version`` must be rejected
+    rather than silently coerced to legacy mode — a typo like
+    ``protocol_version = "v2"`` would otherwise look like a perfectly
+    fine v1 strategy and the strategy author would never learn about it.
+    """
+    import pytest
+
+    from investment_team.trading_service.strategy.streaming_harness import (
+        StrategyRuntimeError,
+    )
+
+    with StreamingHarness(_INVALID_VERSION_CODE) as harness:
+        with pytest.raises(StrategyRuntimeError) as ei:
+            harness.send_start(config={"initial_capital": 100_000.0})
+        assert ei.value.etype == "contract_error"
+        assert "protocol_version" in str(ei.value)
+
+
+def test_protocol_version_matches_contract_current_protocol_version() -> None:
+    """The engine-advertised ``engine_protocol_version`` must match
+    ``contract.CURRENT_PROTOCOL_VERSION`` — guards against a future
+    bump that updates the contract constant but forgets to thread the
+    new value through the harness capability payload.
+    """
+    from investment_team.trading_service.strategy.contract import (
+        CURRENT_PROTOCOL_VERSION,
+    )
+
+    with StreamingHarness(_LEGACY_V1_CODE) as harness:
+        resp = harness.send_start(config={"initial_capital": 100_000.0})
+        assert resp.capabilities.get("engine_protocol_version") == CURRENT_PROTOCOL_VERSION
+        assert harness.engine_protocol_version == CURRENT_PROTOCOL_VERSION
+        harness.send_end()

--- a/backend/agents/investment_team/tests/test_tif.py
+++ b/backend/agents/investment_team/tests/test_tif.py
@@ -212,6 +212,50 @@ def test_ioc_overrides_requeue_next_bar_policy() -> None:
     assert order_book.all_pending() == []
 
 
+def test_day_order_expires_at_session_close() -> None:
+    """A DAY-TIF order submitted on day D that did not fill must be
+    cancelled by ``OrderBook.expire_day_orders`` when the next session
+    arrives (#379 criterion 7, DAY leg).
+
+    Submits a LIMIT DAY whose price is far enough below the first bar's
+    range that it cannot trigger, then advances to a new session and
+    asserts the order is removed and never fills on the new day's bar.
+    Anchors on ``original_submitted_at`` (immutable) so the test
+    survives any future requeue path that might advance ``submitted_at``.
+    """
+    sim, order_book, portfolio = _make_simulator()
+    order_book.submit(
+        OrderRequest(
+            client_order_id="day-1",
+            symbol="AAA",
+            side=OrderSide.LONG,
+            qty=100,
+            order_type=OrderType.LIMIT,
+            limit_price=50.0,  # well below the bar range — won't cross
+            tif=TimeInForce.DAY,
+        ),
+        submitted_at="2024-01-01",
+        submitted_equity=10_000_000.0,
+    )
+
+    # Day-of bar: the LIMIT did not cross, so no fill. Order still pending.
+    outcome = sim.process_bar(_bar("2024-01-01", price=100.0, volume=10_000_000))
+    assert outcome.entry_fills == []
+    assert len(order_book.all_pending()) == 1
+
+    # New session arrives → expire DAY orders submitted on a strictly earlier date.
+    expired = order_book.expire_day_orders("2024-01-02")
+    assert len(expired) == 1
+    assert expired[0].request.client_order_id == "day-1"
+    assert order_book.all_pending() == []
+
+    # Even if the new day's bar would have crossed the limit, the order
+    # is already gone — DAY expiry is durable, not a deferred decision.
+    follow_up = sim.process_bar(_bar("2024-01-02", price=50.0, volume=10_000_000))
+    assert follow_up.entry_fills == []
+    assert "AAA" not in portfolio.positions
+
+
 def test_no_trigger_ioc_same_side_addon_drops_silently() -> None:
     """A same-side IOC LIMIT add-on against an already-open position must be
     silently suppressed (no Fill emitted) — same as the triggered same-side

--- a/backend/agents/investment_team/trading_service/strategy/contract.py
+++ b/backend/agents/investment_team/trading_service/strategy/contract.py
@@ -20,9 +20,20 @@ for future data in this process at all.
 from __future__ import annotations
 
 from enum import Enum
-from typing import Dict, List, Literal, Optional
+from typing import ClassVar, Dict, List, Literal, Optional
 
 from pydantic import BaseModel, Field
+
+# Current strategy↔harness protocol version. Bumped when the wire format or
+# the set of guaranteed callbacks changes in a way that could surprise a
+# strategy written against an earlier engine build (issue #379, Trading 5/5
+# Step 9 / criterion 9). The default ``Strategy.protocol_version`` is pinned
+# at ``1`` so every existing strategy keeps working unchanged; strategies
+# that want to opt in to v≥2 features (currently: nothing user-visible —
+# the version channel exists so future changes have a graceful migration
+# path) override the class attribute. The harness advertises both values
+# in its capability handshake so the parent can negotiate.
+CURRENT_PROTOCOL_VERSION = 1
 
 
 class OrderSide(str, Enum):
@@ -457,7 +468,21 @@ class Strategy:
 
     Subclasses override the ``on_*`` hooks they care about. The default
     implementations are no-ops so minimal strategies stay terse.
+
+    ``protocol_version`` (issue #379, Trading 5/5 Step 9) is the
+    strategy's declared compatibility level with the engine's
+    strategy↔harness wire protocol. Defaults to ``1`` so every existing
+    strategy keeps working unchanged (legacy mode). The harness echoes
+    the resolved version in its ``ready`` ``capabilities`` payload so the
+    parent ``TradingService`` can negotiate features that were added
+    after v1 without breaking older strategies. Override the class
+    attribute when a strategy is written against a newer protocol level;
+    a strategy declaring a version *higher* than the engine knows about
+    is rejected at handshake with a structured ``contract_error`` so
+    silent forward-compat drift can't ship invisible behaviour gaps.
     """
+
+    protocol_version: ClassVar[int] = 1
 
     def on_start(self, ctx: StrategyContext) -> None:  # noqa: D401 - hook
         """Called once before the first bar."""

--- a/backend/agents/investment_team/trading_service/strategy/streaming_harness.py
+++ b/backend/agents/investment_team/trading_service/strategy/streaming_harness.py
@@ -13,8 +13,19 @@ parsed a final JSON) with a stream-driven protocol:
         {"kind": "order", "payload": {...}}
         {"kind": "cancel", "payload": {...}}
         {"kind": "log", "level": "info", "message": "..."}
-        {"kind": "ready"}           # sent after every parent message processed
+        {"kind": "ready", "capabilities": {"chunked_bars": True,
+            "protocol_version": 1, "engine_protocol_version": 1}}
         {"kind": "error", "etype": "lookahead_violation", "message": "..."}
+
+The ``capabilities`` payload reports both the strategy-declared
+``protocol_version`` (defaults to ``1`` for any strategy that doesn't
+override ``Strategy.protocol_version``) and the engine's own
+``engine_protocol_version`` so the parent can detect a strategy that
+asks for features the engine doesn't ship. A strategy declaring a
+version *higher* than ``engine_protocol_version`` is rejected at
+handshake with ``etype="contract_error"``; older strategies (no
+``protocol_version`` attribute, or version ≤ engine version) work in
+legacy mode unchanged. Issue #379, Trading 5/5 Step 9 / criterion 9.
 
 Every parent message is answered with zero-or-more ``order``/``cancel``/``log``
 records followed by exactly one ``ready`` (or one ``error``). This gives the
@@ -236,6 +247,35 @@ class StreamingHarness:
         ``ready``. False until ``send_start`` has returned.
         """
         return bool(self._capabilities.get("chunked_bars"))
+
+    @property
+    def protocol_version(self) -> int:
+        """Negotiated strategy↔harness protocol version.
+
+        Reflects ``Strategy.protocol_version`` from the loaded subclass
+        (default ``1`` for any pre-#379 strategy that doesn't override
+        it). Returns ``1`` until the first ``ready`` arrives so callers
+        querying before ``send_start`` see the safe legacy default.
+        """
+        version = self._capabilities.get("protocol_version", 1)
+        try:
+            return int(version)
+        except (TypeError, ValueError):
+            return 1
+
+    @property
+    def engine_protocol_version(self) -> int:
+        """Engine-side strategy↔harness protocol version.
+
+        Sourced from the child's capabilities payload (which in turn
+        reflects ``contract.CURRENT_PROTOCOL_VERSION`` inside the
+        subprocess). Returns ``1`` until the first ``ready`` arrives.
+        """
+        version = self._capabilities.get("engine_protocol_version", 1)
+        try:
+            return int(version)
+        except (TypeError, ValueError):
+            return 1
 
     @property
     def probe_events(self) -> Optional[Dict[str, Any]]:
@@ -527,7 +567,18 @@ _HARNESS_SCRIPT = textwrap.dedent('''\
     # parent uses this to decide whether it may invoke ``send_bars``
     # with chunked payloads. Older parents that don't read
     # ``capabilities`` simply ignore the field.
-    _CAPABILITIES = {"chunked_bars": True}
+    #
+    # ``engine_protocol_version`` is the engine-side strategy↔harness
+    # protocol level (sourced from ``contract.CURRENT_PROTOCOL_VERSION``);
+    # ``protocol_version`` is filled in by ``main`` from the resolved
+    # strategy class's class attribute (defaults to ``1`` via
+    # ``Strategy.protocol_version``) so the parent sees the negotiated
+    # value. Issue #379 Step 9 / criterion 9.
+    _CAPABILITIES = {
+        "chunked_bars": True,
+        "engine_protocol_version": contract.CURRENT_PROTOCOL_VERSION,
+        "protocol_version": contract.CURRENT_PROTOCOL_VERSION,
+    }
 
 
     def main():
@@ -536,6 +587,44 @@ _HARNESS_SCRIPT = textwrap.dedent('''\
         except Exception as exc:
             _emit({"kind": "error", "etype": "contract_error", "message": str(exc)})
             sys.exit(1)
+
+        # Resolve the strategy's declared protocol version. Pre-#379
+        # strategies (no ``protocol_version`` attribute) inherit
+        # ``Strategy.protocol_version = 1`` and work in legacy mode.
+        # A strategy explicitly declaring a version greater than the
+        # engine's ``CURRENT_PROTOCOL_VERSION`` is rejected at handshake
+        # so a strategy written against a future engine fails fast with
+        # a structured ``contract_error`` rather than silently behaving
+        # like v1 (which would drop whatever feature the strategy
+        # expected at the newer version).
+        strategy_protocol_version = getattr(cls, "protocol_version", 1)
+        if (
+            not isinstance(strategy_protocol_version, int)
+            or isinstance(strategy_protocol_version, bool)
+            or strategy_protocol_version < 1
+        ):
+            _emit({
+                "kind": "error",
+                "etype": "contract_error",
+                "message": (
+                    f"Strategy.protocol_version must be a positive int, got "
+                    f"{strategy_protocol_version!r}"
+                ),
+            })
+            sys.exit(1)
+        if strategy_protocol_version > contract.CURRENT_PROTOCOL_VERSION:
+            _emit({
+                "kind": "error",
+                "etype": "contract_error",
+                "message": (
+                    f"strategy declares protocol_version="
+                    f"{strategy_protocol_version} but engine only supports "
+                    f"up to {contract.CURRENT_PROTOCOL_VERSION}; upgrade the "
+                    f"engine or pin the strategy to a supported version"
+                ),
+            })
+            sys.exit(1)
+        _CAPABILITIES["protocol_version"] = strategy_protocol_version
 
         instance = cls()
         # Use the bar_index-tagging emit so strategies can never forge


### PR DESCRIPTION
## Summary

Closes the last open piece of #379 (Trading 5/5 — truthful partial-fill
accounting + bracket / OCO / trailing-stop primitives): the strategy↔harness
wire protocol now carries a negotiated version so legacy strategies keep
working unchanged while a future engine bump can detect strategies written
against a newer level (acceptance criterion 9).

**Audit finding** — most of #379 already shipped piecewise under sibling
issues:

- #386 — `Fill.fill_kind` / `Fill.unfilled_qty` / `TradeRecord.participation_clipped`,
  Position-level partial-fill accounting, `unfilled_policy` routing through the
  participation-cap clip in `_fill_entry` / `_continue_entry` / `_fill_exit`.
- #388 — IOC remainder cancel and FOK reject-if-not-fully-fillable in
  `process_bar` / `_handle_entry_remainder` / `_handle_exit_remainder`.
- #389 — bracket / OCO routing and materialization on terminal fill.
- #390 — trailing-stop ratchet via `PendingOrder.effective_stop_price` and
  the simulator's effective-request shim.

Tests for those criteria already exist (`test_partial_fills.py` 31 tests,
`test_bracket_orders.py` 15 tests, `test_trailing_stop.py` 6 tests,
`test_tif.py` 5 tests, `test_realistic_fill_model.py` 25 tests). Only the
protocol-version criterion and an explicit DAY-expiry-at-session-close
assertion needed work.

## Changes

- `trading_service/strategy/contract.py` — `Strategy.protocol_version: ClassVar[int] = 1`
  and `CURRENT_PROTOCOL_VERSION` constant.
- `trading_service/strategy/streaming_harness.py` — child advertises both
  `protocol_version` (strategy-declared, defaults to 1) and
  `engine_protocol_version` in the capabilities payload; parent exposes
  both as properties; strategies declaring a future or malformed version
  are rejected at handshake with `etype="contract_error"`.
- `tests/test_streaming_harness_chunked.py` — 5 new tests covering legacy
  v1 fallback, explicit v1, future-version rejection, invalid-version
  rejection, and parity between advertised version and
  `CURRENT_PROTOCOL_VERSION`.
- `tests/test_tif.py` — explicit DAY-expiry-at-session-close test for
  acceptance criterion 7 (DAY leg).

## Test plan

- [x] `ruff check` clean on touched subtree
- [x] `ruff format --check` clean on touched files
- [x] `pytest agents/investment_team/tests/test_tif.py agents/investment_team/tests/test_streaming_harness_chunked.py` — 19/19 green
- [x] `pytest agents/investment_team/tests/golden/test_simulator_invariants.py` — byte-identical (4 passed)
- [x] `pytest agents/investment_team/tests/` — 1056 passed / 9 skipped (pre-existing) / 0 failed
- [x] CI green on PR
- [ ] Manually verify a legacy strategy (no `protocol_version` field) still
      completes a full backtest under the realistic execution model

## Acceptance criteria coverage (#379)

| # | Criterion | Where |
|---|---|---|
| 1 | Cap-clip → `Fill(fill_kind=partial, unfilled_qty=…)` + `TradeRecord.participation_clipped=True` | `test_realistic_fill_model::test_realistic_low_adv_emits_partial_entry_fill` (#386) |
| 2 | `requeue_next_bar` re-evaluates remainder on next bar | `test_partial_fills::test_requeue_next_bar_two_partials_sum_to_original` (#386) |
| 3 | `twap_n` slices sum to original remainder | `test_partial_fills::test_twap_n_three_bars_slices_sum_to_original` (#386) |
| 4 | `drop` preserves current behaviour | `test_partial_fills::test_drop_policy_emits_partial_fill_but_does_not_requeue` (#386) |
| 5 | Bracket entry → OCO; either fill cancels the other | `test_bracket_orders::test_take_profit_fill_cancels_stop_sibling` / `test_stop_loss_fill_cancels_take_profit_sibling` (#389) |
| 6 | Trailing stop ratchets only favorably (with retrace) | `test_trailing_stop::test_long_trailing_stop_holds_through_retrace` (#390) |
| 7 | IOC same-bar cancel; FOK reject-if-not-full; DAY session close | `test_tif.py` (#388) + new `test_day_order_expires_at_session_close` |
| 8 | OptimisticExecutionModel golden parity byte-identical | `tests/golden/test_simulator_invariants.py` |
| 9 | Strategy without `protocol_version` works in legacy mode | new `test_legacy_strategy_without_protocol_version_works_unchanged` (this PR) |

Closes #379.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QafRxrgBUG9bag7LvcDFLQ)_