### PR TITLE
soc2_compliance_team: convert test_api.py to unit tests (#365)

### DIFF
--- a/backend/agents/soc2_compliance_team/tests/test_api.py
+++ b/backend/agents/soc2_compliance_team/tests/test_api.py
@@ -4,6 +4,7 @@ Patches the module-level ``_job_manager`` to the in-memory ``fake_job_client``
 fixture so these tests run hermetically in the default ``test-backend`` lane.
 """
 
+import time
 from pathlib import Path
 from unittest.mock import patch
 
@@ -20,6 +21,9 @@ client = TestClient(app)
 @pytest.fixture(autouse=True)
 def _patched(monkeypatch: pytest.MonkeyPatch, fake_job_client):
     monkeypatch.setattr(api_main, "_job_manager", fake_job_client)
+    # Force the threaded branch in `run_audit` — Temporal isn't available in
+    # unit tests, and `start_audit_workflow` would raise without a client.
+    monkeypatch.delenv("TEMPORAL_ADDRESS", raising=False)
     return fake_job_client
 
 
@@ -42,7 +46,7 @@ def test_run_audit_requires_repo_path() -> None:
     assert r.status_code == 400
 
 
-def test_run_audit_and_poll(tmp_path: Path) -> None:
+def test_run_audit_and_poll(tmp_path: Path, _patched) -> None:
     """POST with valid path returns job_id; status endpoint reports the job."""
     (tmp_path / "file.txt").write_text("x")
 
@@ -56,13 +60,23 @@ def test_run_audit_and_poll(tmp_path: Path) -> None:
         r = client.post("/soc2-audit/run", json={"repo_path": str(tmp_path)})
         assert r.status_code == 200
         data = r.json()
-        assert "job_id" in data
+        job_id = data["job_id"]
         assert data["status"] == "running"
 
-        r = client.get(f"/soc2-audit/status/{data['job_id']}")
+        # Wait for the background thread to finish *while the stub is still
+        # active*, so the real orchestrator path is never reached.
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline:
+            job = _patched.get_job(job_id)
+            if job and job.get("status") in ("completed", "failed"):
+                break
+            time.sleep(0.02)
+        else:
+            pytest.fail(f"Audit job {job_id} did not reach a terminal state in 2s")
+
+        r = client.get(f"/soc2-audit/status/{job_id}")
         assert r.status_code == 200
-        # Job may still be running or already completed depending on timing.
-        assert r.json()["status"] in ("pending", "running", "completed", "failed")
+        assert r.json()["status"] == "completed"
 
 
 def test_status_404() -> None:

--- a/backend/agents/soc2_compliance_team/tests/test_api.py
+++ b/backend/agents/soc2_compliance_team/tests/test_api.py
@@ -1,19 +1,26 @@
-"""Tests for SOC2 audit API.
+"""Unit tests for the SOC2 audit API.
 
-Hits the team API which calls the real job service.  Marked integration
-pending follow-up to mock the team's ``_job_manager``.
+Patches the module-level ``_job_manager`` to the in-memory ``fake_job_client``
+fixture so these tests run hermetically in the default ``test-backend`` lane.
 """
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
 
+from soc2_compliance_team.api import main as api_main
 from soc2_compliance_team.api.main import app
-
-pytestmark = [pytest.mark.integration]
+from soc2_compliance_team.models import SOC2AuditResult
 
 client = TestClient(app)
+
+
+@pytest.fixture(autouse=True)
+def _patched(monkeypatch: pytest.MonkeyPatch, fake_job_client):
+    monkeypatch.setattr(api_main, "_job_manager", fake_job_client)
+    return fake_job_client
 
 
 def test_health() -> None:
@@ -36,18 +43,26 @@ def test_run_audit_requires_repo_path() -> None:
 
 
 def test_run_audit_and_poll(tmp_path: Path) -> None:
-    """POST with valid path returns job_id; status endpoint returns 404 for unknown job."""
+    """POST with valid path returns job_id; status endpoint reports the job."""
     (tmp_path / "file.txt").write_text("x")
-    r = client.post("/soc2-audit/run", json={"repo_path": str(tmp_path)})
-    assert r.status_code == 200
-    data = r.json()
-    assert "job_id" in data
-    assert data["status"] == "running"
 
-    r = client.get(f"/soc2-audit/status/{data['job_id']}")
-    assert r.status_code == 200
-    # Job may still be running or already completed depending on timing
-    assert r.json()["status"] in ("pending", "running", "completed", "failed")
+    # Stub the orchestrator so the background thread completes quickly without
+    # external dependencies (LLM, etc.).
+    with patch.object(
+        api_main.SOC2AuditOrchestrator,
+        "run",
+        return_value=SOC2AuditResult(status="completed"),
+    ):
+        r = client.post("/soc2-audit/run", json={"repo_path": str(tmp_path)})
+        assert r.status_code == 200
+        data = r.json()
+        assert "job_id" in data
+        assert data["status"] == "running"
+
+        r = client.get(f"/soc2-audit/status/{data['job_id']}")
+        assert r.status_code == 200
+        # Job may still be running or already completed depending on timing.
+        assert r.json()["status"] in ("pending", "running", "completed", "failed")
 
 
 def test_status_404() -> None:


### PR DESCRIPTION
## Summary

Follow-up to #360. Converts `backend/agents/soc2_compliance_team/tests/test_api.py` from integration to unit tests so it runs in the default `test-backend` CI lane.

- Adds an autouse fixture that `monkeypatch.setattr`s `soc2_compliance_team.api.main._job_manager` to the in-memory `fake_job_client` (the exemplar from `social_media_marketing_team/tests/test_api_internal.py`, shipped in #360).
- Drops `pytestmark = [pytest.mark.integration]`.
- `test_run_audit_and_poll` now stubs `SOC2AuditOrchestrator.run` with `patch.object` so the background daemon thread completes deterministically without LLM/external dependencies.
- All four endpoint cases (`GET /health`, `POST /soc2-audit/run` 422/400/happy, `GET /soc2-audit/status/{id}` happy/404) preserved unchanged.

Closes #365.

## Test plan

- [x] `cd backend && pytest agents/soc2_compliance_team/tests/test_api.py -v` → 4 passed in 0.76s
- [x] `cd backend && pytest agents/soc2_compliance_team/tests/test_api.py -v -m "not integration"` → 4 passed (confirms they're no longer filtered out by the default lane)
- [x] `cd backend && pytest agents/soc2_compliance_team/tests -v` → 7 passed (no regression on sibling `test_soc2_orchestrator.py`)
- [x] `ruff check` + `ruff format --check` on the edited file pass

https://claude.ai/code/session_01GjfdvfYWsEeoR7YiDiYw17

---
_Generated by [Claude Code](https://claude.ai/code/session_01GjfdvfYWsEeoR7YiDiYw17)_