### PR TITLE
docs: add Product Delivery Loop section to ARCHITECTURE.md (#373)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -532,7 +532,7 @@ The loop is driven by three agents and one orchestrator hook:
 - **ProductOwnerAgent** (`product_delivery/product_owner_agent/agent.py`): runs `POST /api/product-delivery/groom`, scores backlog items via WSJF or RICE with per-item rationale, and (when `persist=true`) writes scores back to the store.
 - **SprintPlannerAgent** (`product_delivery/sprint_planner_agent/agent.py`): runs `POST /api/product-delivery/sprints/{id}/plan`, performing capacity-aware greedy selection of scored stories into the sprint via `select_sprint_scope` (no LLM).
 - **SE Orchestrator with `sprint_id`** (`software_engineering_team/orchestrator.py`, `_load_requirements_from_sprint`): when `POST /api/software-engineering/run-team` is called with `{sprint_id}`, the orchestrator skips spec parsing and the Product Requirements Analyst, hydrates `ProductRequirements` directly from the sprint's planned stories + acceptance criteria, and stores `sprint_id` + `story_ids` in job metadata.
-- **ReleaseManagerAgent** (`product_delivery/release_manager_agent/agent.py`): triggered by the Integration-phase hook `_run_release_manager_hook` in the SE orchestrator. On a sprint run where every planned story has reached a terminal status, the agent writes `plan/releases/<version>.md` via the technical-writer release-notes agent, inserts a `product_delivery_releases` row, and promotes Integration / DevOps / QA failures into `product_delivery_feedback_items` tagged with the sprint id.
+- **ReleaseManagerAgent** (`product_delivery/release_manager_agent/agent.py`): triggered by the SE orchestrator's release hook `_maybe_ship_sprint_release` (`orchestrator.py`), called after the Integration phase. On a sprint run where every planned story has reached a terminal status, the agent writes `plan/releases/<version>.md` via the technical-writer release-notes agent, inserts a `product_delivery_releases` row, and promotes Integration-phase failures (`int_result.issues`) into `product_delivery_feedback_items` tagged with the sprint id. **Today this hook is only reached on the legacy SE pipeline path** — the default `use_coding_team=True` runtime completes the SE job before the Integration block, so release shipping does not currently fire on the default path. See "Known limitations" below.
 
 ### The loop
 
@@ -552,9 +552,9 @@ flowchart TB
         Discovery --> Design --> Execution --> Integration
     end
 
-    Release["ReleaseManagerAgent\n_run_release_manager_hook\n(post-Integration)"]
+    Release["ReleaseManagerAgent\n_maybe_ship_sprint_release\n(post-Integration; legacy SE path only)"]
     Notes["plan/releases/<version>.md\n+ product_delivery_releases row"]
-    Feedback["Auto-feedback\nIntegration/DevOps/QA failures →\nproduct_delivery_feedback_items\n(tagged with sprint_id)"]
+    Feedback["Auto-feedback\nIntegration-phase failures →\nproduct_delivery_feedback_items\n(tagged with sprint_id)"]
 
     Backlog --> Groom --> Plan --> Run --> Discovery
     Integration --> Release
@@ -591,11 +591,11 @@ sequenceDiagram
     SE->>Pipe: Discovery → Design → Execution → Integration
     Pipe-->>SE: phase outputs / failures
 
-    SE->>RM: _run_release_manager_hook
+    SE->>RM: _maybe_ship_sprint_release (legacy SE path only)
     alt all planned stories terminal
         RM->>RM: write plan/releases/<version>.md
         RM->>PD: insert product_delivery_releases
-        RM->>FB: promote Integration/DevOps/QA failures (sprint_id tagged)
+        RM->>FB: promote Integration-phase failures (sprint_id tagged)
     else open stories remain
         RM-->>SE: skip (sprint not complete)
     end
@@ -605,12 +605,16 @@ sequenceDiagram
 
 ### Failure and re-entry
 
-Two contracts keep the loop self-healing:
+Two contracts keep the loop self-healing on the path where the hook actually fires:
 
-1. **Non-fatal release hook** — `_run_release_manager_hook` wraps `ReleaseManagerAgent.ship()` in `try/except`. Agent exceptions never fail the SE job; instead a `release-manager-error` feedback item is opened with the exception text and `job_id`, surfaced to the next groom.
-2. **Sprint-scoped feedback as queryable signal** — every failure promoted from Integration / DevOps / QA carries `sprint_id`, so it surfaces in `GET /api/product-delivery/feedback?product_id=…&status=open` (and the Agent Console Feedback tab). `POST /groom` itself only reads story rows today — it does not consume feedback automatically — so triaging the new feedback into stories (e.g. via the Feedback tab's "link to story" action) is what feeds the next backlog pass.
+1. **Non-fatal release hook** — `_maybe_ship_sprint_release` wraps `ReleaseManagerAgent.ship()` in `try/except`. Agent exceptions never fail the SE job; instead a `release-manager-error` feedback item is opened with the exception text and `job_id`, visible to operators reviewing feedback before the next groom.
+2. **Sprint-scoped feedback as queryable signal** — every Integration-phase failure promoted by the hook carries `sprint_id`, so it surfaces in `GET /api/product-delivery/feedback?product_id=…&status=open` (and the Agent Console Feedback tab). `POST /groom` itself only reads story rows today — it does not consume feedback automatically — so triaging the new feedback into stories (e.g. via the Feedback tab's "link to story" action) is what feeds the next backlog pass.
 
-Temporal-mode runs currently raise a 400 when `sprint_id` is supplied (same contract as Phase 2/3 — see `product_delivery/README.md`); the in-thread runtime is the only mode wired end-to-end today.
+### Known limitations
+
+- **Default SE path skips the release hook.** The SE orchestrator defaults to `use_coding_team=True` and returns immediately after `run_coding_team_orchestrator`, before reaching the Integration block where `_maybe_ship_sprint_release` is called. Today the documented release-shipping flow only fires on the legacy SE path (`use_coding_team=False`). Wiring the coding_team path to invoke the release hook is tracked as follow-up work.
+- **Only Integration failures auto-promote.** The hook passes only `integration_issues=int_result.issues` to `ReleaseManagerAgent.ship()`. The agent itself accepts `qa_failures` / `devops_failures` arguments, but the SE call site does not supply them today, so DevOps and QA failures are not currently turned into sprint-tagged feedback items.
+- **Temporal mode unsupported for `sprint_id` runs.** `POST /run-team` raises a 400 when `sprint_id` is supplied with `TEMPORAL_ADDRESS` set (same contract as Phase 2/3 — see `product_delivery/README.md`); the in-thread runtime is the only mode wired end-to-end today.
 
 ---
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -17,7 +17,8 @@ This document describes the architecture of the Software Engineering Team — a 
 - [8. DevOps Team Pipeline](#8-devops-team-pipeline)
 - [9. Planning Loop](#9-planning-loop)
 - [10. Plan Folder and Artifacts](#10-plan-folder-and-artifacts)
-- [11. Repo Layout](#11-repo-layout)
+- [11. Product Delivery Loop](#11-product-delivery-loop)
+- [12. Repo Layout](#12-repo-layout)
 
 ---
 
@@ -522,7 +523,98 @@ The `master_plan.md` consolidation includes a risk register and ship checklist.
 
 ---
 
-## 11. Repo Layout
+## 11. Product Delivery Loop
+
+The Product Delivery team (`backend/agents/product_delivery/`) wraps the SE pipeline in a persistent, repeatable loop: backlog → grooming → sprint planning → SE pipeline run → release → feedback intake → next groom. It owns the durable artifacts the SE pipeline doesn't: products, initiatives, epics, stories, sprints, releases, and feedback items. Schema, full API surface, and local smoke tests live in `backend/agents/product_delivery/README.md`; this section documents how the runtime pieces fit together.
+
+The loop is driven by three agents and one orchestrator hook:
+
+- **ProductOwnerAgent** (`product_delivery/product_owner_agent/agent.py`): runs `POST /api/product-delivery/groom`, scores backlog items via WSJF or RICE with per-item rationale, and (when `persist=true`) writes scores back to the store.
+- **SprintPlannerAgent** (`product_delivery/sprint_planner_agent/agent.py`): runs `POST /api/product-delivery/sprints/{id}/plan`, performing capacity-aware greedy selection of scored stories into the sprint via `select_sprint_scope` (no LLM).
+- **SE Orchestrator with `sprint_id`** (`software_engineering_team/orchestrator.py`, `_load_requirements_from_sprint`): when `POST /api/software-engineering/run-team` is called with `{sprint_id}`, the orchestrator skips spec parsing and the Product Requirements Analyst, hydrates `ProductRequirements` directly from the sprint's planned stories + acceptance criteria, and stores `sprint_id` + `story_ids` in job metadata.
+- **ReleaseManagerAgent** (`product_delivery/release_manager_agent/agent.py`): triggered by the Integration-phase hook `_run_release_manager_hook` in the SE orchestrator. On a sprint run where every planned story has reached a terminal status, the agent writes `plan/releases/<version>.md` via the technical-writer release-notes agent, inserts a `product_delivery_releases` row, and promotes Integration / DevOps / QA failures into `product_delivery_feedback_items` tagged with the sprint id.
+
+### The loop
+
+```mermaid
+flowchart TB
+    Backlog["Backlog tables\nproducts → initiatives → epics → stories"]
+    Groom["ProductOwnerAgent\nPOST /groom\n(WSJF or RICE + rationale)"]
+    Plan["SprintPlannerAgent\nPOST /sprints/{id}/plan\n(greedy fit by capacity)"]
+    Run["SE Orchestrator\nPOST /run-team {sprint_id}"]
+
+    subgraph se ["SE pipeline (existing 4 phases)"]
+        direction TB
+        Discovery["Discovery\n(skipped when sprint_id\nhydrates requirements directly)"]
+        Design["Design\nTech Lead + Architecture Expert"]
+        Execution["Execution\nbackend + frontend workers"]
+        Integration["Integration\nintegration_team validation"]
+        Discovery --> Design --> Execution --> Integration
+    end
+
+    Release["ReleaseManagerAgent\n_run_release_manager_hook\n(post-Integration)"]
+    Notes["plan/releases/<version>.md\n+ product_delivery_releases row"]
+    Feedback["Auto-feedback\nIntegration/DevOps/QA failures →\nproduct_delivery_feedback_items\n(tagged with sprint_id)"]
+
+    Backlog --> Groom --> Plan --> Run --> Discovery
+    Integration --> Release
+    Release --> Notes
+    Release --> Feedback
+    Feedback -->|"next sprint"| Groom
+```
+
+### End-to-end sequence
+
+```mermaid
+sequenceDiagram
+    actor Op as Operator / Agent Console
+    participant PD as product_delivery API
+    participant PO as ProductOwnerAgent
+    participant SP as SprintPlannerAgent
+    participant SE as SE Orchestrator
+    participant Pipe as Planning V3 / Coding / DevOps / Integration
+    participant RM as ReleaseManagerAgent
+    participant FB as feedback_items
+
+    Op->>PD: POST /groom {product_id, method}
+    PD->>PO: groom()
+    PO-->>PD: ranked items + rationale (persisted)
+    PD-->>Op: GroomResult
+
+    Op->>PD: POST /sprints/{id}/plan
+    PD->>SP: plan()
+    SP-->>PD: selected stories (capacity fit)
+    PD-->>Op: SprintPlanResult
+
+    Op->>SE: POST /run-team {sprint_id}
+    SE->>SE: _load_requirements_from_sprint
+    SE->>Pipe: Discovery → Design → Execution → Integration
+    Pipe-->>SE: phase outputs / failures
+
+    SE->>RM: _run_release_manager_hook
+    alt all planned stories terminal
+        RM->>RM: write plan/releases/<version>.md
+        RM->>PD: insert product_delivery_releases
+        RM->>FB: promote Integration/DevOps/QA failures (sprint_id tagged)
+    else open stories remain
+        RM-->>SE: skip (sprint not complete)
+    end
+
+    Note over FB,Op: Next POST /groom scopes candidate inputs by sprint_id
+```
+
+### Failure and re-entry
+
+Two contracts keep the loop self-healing:
+
+1. **Non-fatal release hook** — `_run_release_manager_hook` wraps `ReleaseManagerAgent.ship()` in `try/except`. Agent exceptions never fail the SE job; instead a `release-manager-error` feedback item is opened with the exception text and `job_id`, surfaced to the next groom.
+2. **Sprint-scoped feedback as seeds** — every failure promoted from Integration / DevOps / QA carries `sprint_id`, so `POST /groom` can filter "feedback this sprint surfaced" as candidate input for the next backlog pass without manual curation.
+
+Temporal-mode runs currently raise a 400 when `sprint_id` is supplied (same contract as Phase 2/3 — see `product_delivery/README.md`); the in-thread runtime is the only mode wired end-to-end today.
+
+---
+
+## 12. Repo Layout
 
 The repository contains two independent agent systems. The software engineering team is the primary system documented above; a separate blogging agent system exists under `agents/blogging/`.
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -600,7 +600,7 @@ sequenceDiagram
         RM-->>SE: skip (sprint not complete)
     end
 
-    Note over FB,Op: Next POST /groom scopes candidate inputs by sprint_id
+    Note over FB,Op: Failures are queryable via GET /feedback (sprint_id-tagged); operator triages them into stories before the next groom
 ```
 
 ### Failure and re-entry
@@ -608,7 +608,7 @@ sequenceDiagram
 Two contracts keep the loop self-healing:
 
 1. **Non-fatal release hook** — `_run_release_manager_hook` wraps `ReleaseManagerAgent.ship()` in `try/except`. Agent exceptions never fail the SE job; instead a `release-manager-error` feedback item is opened with the exception text and `job_id`, surfaced to the next groom.
-2. **Sprint-scoped feedback as seeds** — every failure promoted from Integration / DevOps / QA carries `sprint_id`, so `POST /groom` can filter "feedback this sprint surfaced" as candidate input for the next backlog pass without manual curation.
+2. **Sprint-scoped feedback as queryable signal** — every failure promoted from Integration / DevOps / QA carries `sprint_id`, so it surfaces in `GET /api/product-delivery/feedback?product_id=…&status=open` (and the Agent Console Feedback tab). `POST /groom` itself only reads story rows today — it does not consume feedback automatically — so triaging the new feedback into stories (e.g. via the Feedback tab's "link to story" action) is what feeds the next backlog pass.
 
 Temporal-mode runs currently raise a 400 when `sprint_id` is supplied (same contract as Phase 2/3 — see `product_delivery/README.md`); the in-thread runtime is the only mode wired end-to-end today.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,9 +44,11 @@ backend/
                              # + releases tables, sprint_planner_agent, _load_requirements_from_sprint
                              # in the SE orchestrator. Phase 3 (#371): release_manager_agent ships sprint
                              # completion → plan/releases/<version>.md + product_delivery_releases row,
-                             # auto-promotes Integration / DevOps / QA failures into sprint-tagged
-                             # feedback_items so the next /groom sees them as candidate backlog seeds;
-                             # POST/GET /releases routes; SE Integration-phase hook (sprint runs only).
+                             # auto-promotes Integration-phase failures into sprint-tagged
+                             # feedback_items (queryable via GET /feedback; operator triage feeds the
+                             # next groom — POST /groom does not consume feedback automatically);
+                             # POST/GET /releases routes; SE Integration-phase hook (legacy SE path
+                             # only — default use_coding_team=True path currently skips the hook).
     shared_agent_invoke/     # Invoke shim mounted inside the sandbox image; exposes POST /_agents/{id}/invoke
     integrations/            # Shared integration contracts (Google login, Medium, etc.)
     artifact_registry/       # Shared artifact persistence
@@ -207,7 +209,7 @@ The old `/agent-provisioning` route redirects to `/agent-console` for backward c
 
 ### Product Delivery Loop
 
-The `product_delivery` team (`backend/agents/product_delivery/`, mounted at `/api/product-delivery`) wraps the SE 4-phase pipeline in a persistent loop: backlog → grooming (`ProductOwnerAgent`, WSJF/RICE) → sprint planning (`SprintPlannerAgent`, capacity-aware) → SE run with `{sprint_id}` (orchestrator hydrates requirements directly via `_load_requirements_from_sprint`) → Integration-phase release hook (`ReleaseManagerAgent` writes `plan/releases/<version>.md` and a `product_delivery_releases` row, promotes Integration / DevOps / QA failures into sprint-tagged `feedback_items`) → next groom. See `ARCHITECTURE.md` §11 ("Product Delivery Loop") for the sequence diagram and runtime contracts.
+The `product_delivery` team (`backend/agents/product_delivery/`, mounted at `/api/product-delivery`) wraps the SE 4-phase pipeline in a persistent loop: backlog → grooming (`ProductOwnerAgent`, WSJF/RICE) → sprint planning (`SprintPlannerAgent`, capacity-aware) → SE run with `{sprint_id}` (orchestrator hydrates requirements directly via `_load_requirements_from_sprint`) → Integration-phase release hook (`ReleaseManagerAgent` writes `plan/releases/<version>.md` and a `product_delivery_releases` row, promotes Integration-phase failures into sprint-tagged `feedback_items`) → next groom. The release hook (`_maybe_ship_sprint_release`) fires on the legacy SE path today; the default `use_coding_team=True` path completes before reaching it. See `ARCHITECTURE.md` §11 ("Product Delivery Loop") for the sequence diagram, known limitations, and runtime contracts.
 
 ### LLM Integration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,6 +205,10 @@ The catalog is backed by `backend/agents/agent_registry/`, which loads declarati
 
 The old `/agent-provisioning` route redirects to `/agent-console` for backward compatibility.
 
+### Product Delivery Loop
+
+The `product_delivery` team (`backend/agents/product_delivery/`, mounted at `/api/product-delivery`) wraps the SE 4-phase pipeline in a persistent loop: backlog → grooming (`ProductOwnerAgent`, WSJF/RICE) → sprint planning (`SprintPlannerAgent`, capacity-aware) → SE run with `{sprint_id}` (orchestrator hydrates requirements directly via `_load_requirements_from_sprint`) → Integration-phase release hook (`ReleaseManagerAgent` writes `plan/releases/<version>.md` and a `product_delivery_releases` row, promotes Integration / DevOps / QA failures into sprint-tagged `feedback_items`) → next groom. See `ARCHITECTURE.md` §11 ("Product Delivery Loop") for the sequence diagram and runtime contracts.
+
 ### LLM Integration
 
 `backend/agents/llm_service/` provides a unified client that supports:
@@ -276,7 +280,7 @@ Environment variables for LLM: `LLM_PROVIDER`, `LLM_BASE_URL`, `LLM_MODEL`
 ## Reference Docs
 
 - `backend/agents/agent_provisioning_team/AGENT_ANATOMY.md` — Required structure for AI agents (Input/Output, Tools, Memory, Prompts, Security Guardrails, Subagents); diagrams in `design_assets/`
-- `ARCHITECTURE.md` — 26KB detailed architecture with Mermaid diagrams (11 sections)
+- `ARCHITECTURE.md` — detailed architecture with Mermaid diagrams (12 sections, including the Product Delivery Loop)
 - `backend/agents/software_engineering_team/README.md` — 31KB SE team deep dive
 - `docker/README.md` — Full-stack setup, ports, env vars, security
 - `user-interface/README.md` — UI setup and API configuration

--- a/backend/agents/product_delivery/README.md
+++ b/backend/agents/product_delivery/README.md
@@ -31,13 +31,18 @@ If every planned story has reached a terminal status the
 3. Records a `product_delivery_releases` row with `notes_path` and
    `shipped_at`.
 4. Promotes Integration / DevOps / QA failures into
-   `product_delivery_feedback_items`, each tagged with `sprint_id` so
-   the next `POST /groom` can scope candidate inputs to "what this
-   sprint surfaced".
+   `product_delivery_feedback_items`, each tagged with `sprint_id`.
+   These rows are queryable via
+   `GET /api/product-delivery/feedback?product_id=…&status=open`
+   (and the Agent Console Feedback tab); `POST /groom` itself only
+   reads story rows today and does not consume feedback automatically,
+   so triaging the new failures into stories is what feeds the next
+   grooming pass.
 
 Failures are non-fatal — the hook wraps the agent in `try/except` and,
 on agent failure, opens a `release-manager-error` feedback item with
-the exception text + `job_id` so the next grooming sees the gap.
+the exception text + `job_id` so the gap is visible to operators
+reviewing feedback before the next grooming pass.
 
 ## What's deferred to follow-up issues
 

--- a/backend/agents/product_delivery/README.md
+++ b/backend/agents/product_delivery/README.md
@@ -42,11 +42,14 @@ the exception text + `job_id` so the next grooming sees the gap.
 ## What's deferred to follow-up issues
 
 - Agent Console "Backlog", "Sprints", and "Releases" tabs (Angular).
-- `ARCHITECTURE.md` "Product Delivery Loop" section.
 - Versioning policy beyond date-stamps (semver vs date — issue #371
   explicitly defers this).
 - Temporal-mode plumbing for `sprint_id` runs (Phase 2 raises a 400
   in Temporal mode; same contract here).
+
+For the end-to-end architectural picture (loop diagram + sequence
+diagram + runtime contracts), see
+[`ARCHITECTURE.md` §11 — Product Delivery Loop](../../../ARCHITECTURE.md#11-product-delivery-loop).
 
 ## Schema
 

--- a/backend/agents/product_delivery/README.md
+++ b/backend/agents/product_delivery/README.md
@@ -30,9 +30,12 @@ If every planned story has reached a terminal status the
    UTC date `YYYY-MM-DD`, with `-N` suffix on collisions).
 3. Records a `product_delivery_releases` row with `notes_path` and
    `shipped_at`.
-4. Promotes Integration / DevOps / QA failures into
-   `product_delivery_feedback_items`, each tagged with `sprint_id`.
-   These rows are queryable via
+4. Promotes Integration-phase failures (passed by the SE hook as
+   `int_result.issues`) into `product_delivery_feedback_items`, each
+   tagged with `sprint_id`. `ReleaseManagerAgent.ship()` itself accepts
+   `qa_failures` and `devops_failures` arguments, but the SE call site
+   only supplies the Integration list today, so DevOps and QA failures
+   are not currently auto-promoted. These rows are queryable via
    `GET /api/product-delivery/feedback?product_id=…&status=open`
    (and the Agent Console Feedback tab); `POST /groom` itself only
    reads story rows today and does not consume feedback automatically,

--- a/backend/agents/software_engineering_team/README.md
+++ b/backend/agents/software_engineering_team/README.md
@@ -106,6 +106,8 @@ flowchart LR
   quality --> integration
 ```
 
+**Product Delivery loop:** when `POST /api/software-engineering/run-team` is called with `{sprint_id}`, the orchestrator skips Discovery and hydrates `ProductRequirements` from the sprint's planned stories via `_load_requirements_from_sprint`. The Integration phase then fires `_run_release_manager_hook`, which (on a fully-completed sprint) ships a release via `ReleaseManagerAgent` and auto-promotes Integration / DevOps / QA failures into `product_delivery_feedback_items` for the next groom. See [`ARCHITECTURE.md` §11 — Product Delivery Loop](../../../ARCHITECTURE.md#11-product-delivery-loop) and `backend/agents/product_delivery/README.md`.
+
 ### Per-Task Workflow Gates
 
 **Backend:** build verification → code review → acceptance verifier → security → QA → DbC → Tech Lead review → documentation

--- a/backend/agents/software_engineering_team/README.md
+++ b/backend/agents/software_engineering_team/README.md
@@ -106,7 +106,7 @@ flowchart LR
   quality --> integration
 ```
 
-**Product Delivery loop:** when `POST /api/software-engineering/run-team` is called with `{sprint_id}`, the orchestrator skips Discovery and hydrates `ProductRequirements` from the sprint's planned stories via `_load_requirements_from_sprint`. The Integration phase then fires `_run_release_manager_hook`, which (on a fully-completed sprint) ships a release via `ReleaseManagerAgent` and auto-promotes Integration / DevOps / QA failures into `product_delivery_feedback_items` for the next groom. See [`ARCHITECTURE.md` §11 — Product Delivery Loop](../../../ARCHITECTURE.md#11-product-delivery-loop) and `backend/agents/product_delivery/README.md`.
+**Product Delivery loop:** when `POST /api/software-engineering/run-team` is called with `{sprint_id}`, the orchestrator skips Discovery and hydrates `ProductRequirements` from the sprint's planned stories via `_load_requirements_from_sprint`. The Integration phase then fires `_run_release_manager_hook`, which (on a fully-completed sprint) ships a release via `ReleaseManagerAgent` and auto-promotes Integration / DevOps / QA failures into `product_delivery_feedback_items` tagged with the sprint id (queryable via `GET /api/product-delivery/feedback`; operator triage feeds the next groom). See [`ARCHITECTURE.md` §11 — Product Delivery Loop](../../../ARCHITECTURE.md#11-product-delivery-loop) and `backend/agents/product_delivery/README.md`.
 
 ### Per-Task Workflow Gates
 

--- a/backend/agents/software_engineering_team/README.md
+++ b/backend/agents/software_engineering_team/README.md
@@ -106,7 +106,7 @@ flowchart LR
   quality --> integration
 ```
 
-**Product Delivery loop:** when `POST /api/software-engineering/run-team` is called with `{sprint_id}`, the orchestrator skips Discovery and hydrates `ProductRequirements` from the sprint's planned stories via `_load_requirements_from_sprint`. The Integration phase then fires `_run_release_manager_hook`, which (on a fully-completed sprint) ships a release via `ReleaseManagerAgent` and auto-promotes Integration / DevOps / QA failures into `product_delivery_feedback_items` tagged with the sprint id (queryable via `GET /api/product-delivery/feedback`; operator triage feeds the next groom). See [`ARCHITECTURE.md` §11 — Product Delivery Loop](../../../ARCHITECTURE.md#11-product-delivery-loop) and `backend/agents/product_delivery/README.md`.
+**Product Delivery loop:** when `POST /api/software-engineering/run-team` is called with `{sprint_id}`, the orchestrator skips Discovery and hydrates `ProductRequirements` from the sprint's planned stories via `_load_requirements_from_sprint`. On the legacy SE pipeline path the Integration phase then fires `_maybe_ship_sprint_release` (the default `use_coding_team=True` path currently returns before this hook), which on a fully-completed sprint ships a release via `ReleaseManagerAgent` and auto-promotes Integration-phase failures into `product_delivery_feedback_items` tagged with the sprint id (queryable via `GET /api/product-delivery/feedback`; operator triage feeds the next groom). See [`ARCHITECTURE.md` §11 — Product Delivery Loop](../../../ARCHITECTURE.md#11-product-delivery-loop) and `backend/agents/product_delivery/README.md`.
 
 ### Per-Task Workflow Gates
 


### PR DESCRIPTION
## Summary

- Adds **§11 "Product Delivery Loop"** to `ARCHITECTURE.md` with a flowchart of the persistent loop (backlog → groom → sprint plan → SE pipeline → release → feedback → next groom) and a Mermaid `sequenceDiagram` tying `product_delivery` to the SE orchestrator and its 4 phases. Renumbers the trailing **Repo Layout** section to §12 and updates the Table of Contents.
- Adds a one-paragraph **Product Delivery Loop** subsection under `CLAUDE.md` → Architecture, plus a stale section-count fix at the bottom of the file.
- Cross-links from `backend/agents/software_engineering_team/README.md` (after the SDLC Flow Diagram) noting how a `sprint_id`-scoped run fires `_load_requirements_from_sprint` and the Integration-phase release hook.
- Drops the now-closed deferred bullet in `backend/agents/product_delivery/README.md` and forward-links to the architecture section.

Closes #373.

## Background

The Product Delivery Loop runtime has shipped in three phases — Phase 1 (#369: backlog + grooming + feedback), Phase 2 (#396: sprints + planner + SE `{sprint_id}` plumbing), Phase 3 (#371: release manager + auto-feedback promotion) — and the Agent Console UI shipped in #476 (closing #372). But `ARCHITECTURE.md` still had zero mentions of `product_delivery`, and `product_delivery/README.md` explicitly listed this section as deferred. This PR closes that gap; the "land in the same PR as Phase 2 or immediately after" gate from the issue body is satisfied since Phase 2 and 3 are both already in `main`.

## Test plan

- [ ] On GitHub, open `ARCHITECTURE.md` and verify both new Mermaid diagrams render (flowchart + `sequenceDiagram`).
- [ ] Click the Table-of-Contents links — `#11-product-delivery-loop` and `#12-repo-layout` resolve to the right headings.
- [ ] Open `CLAUDE.md` and confirm the new `### Product Delivery Loop` subsection sits under `## Architecture` and is the next sibling after `### Agent Console & Agent Registry`.
- [ ] Open `backend/agents/software_engineering_team/README.md` — the cross-link paragraph follows the SDLC Flow Diagram and the `ARCHITECTURE.md#11-product-delivery-loop` link resolves.
- [ ] Open `backend/agents/product_delivery/README.md` — "What's deferred" no longer mentions the ARCHITECTURE.md section, and the forward-link at the bottom of that subsection resolves.
- [ ] `grep -nE '^## [0-9]+\.' ARCHITECTURE.md` — section numbering is monotonic 1..12.

https://claude.ai/code/session_01FdhHhhu2iQejjTDVZy15rQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01FdhHhhu2iQejjTDVZy15rQ)_