### PR TITLE
plan: spec_dsl + spec_dsl_adapter for issue #550

### DIFF
--- a/backend/agents/investment_team/strategy_lab/spec_dsl.py
+++ b/backend/agents/investment_team/strategy_lab/spec_dsl.py
@@ -295,21 +295,35 @@ def _format_number(x: float) -> str:
     return f"{x:g}"
 
 
+def _with_source(base: str, source: str) -> str:
+    """Append ``, source=X`` (or ``source=X`` for arg-less calls) when non-default."""
+    if source == "close":
+        return base
+    assert base.endswith(")")
+    inner = base[:-1]
+    if inner.endswith("("):
+        return f"{inner}source={source})"
+    return f"{inner}, source={source})"
+
+
 def _format_indicator_ref(ref: IndicatorRef) -> str:
     if isinstance(ref, PriceRef):
         return ref.field
     if isinstance(ref, ConstRef):
         return _format_number(ref.value)
     if isinstance(ref, SMARef):
-        return f"sma({ref.period})"
+        return _with_source(f"sma({ref.period})", ref.source)
     if isinstance(ref, EMARef):
-        return f"ema({ref.period})"
+        return _with_source(f"ema({ref.period})", ref.source)
     if isinstance(ref, RSIRef):
-        return f"rsi({ref.period})"
+        return _with_source(f"rsi({ref.period})", ref.source)
     if isinstance(ref, MACDRef):
-        return f"macd_{ref.output}({ref.fast},{ref.slow},{ref.signal})"
+        return _with_source(f"macd_{ref.output}({ref.fast},{ref.slow},{ref.signal})", ref.source)
     if isinstance(ref, BollingerRef):
-        return f"bollinger_{ref.band}({ref.period},{_format_number(ref.num_std)})"
+        return _with_source(
+            f"bollinger_{ref.band}({ref.period},{_format_number(ref.num_std)})",
+            ref.source,
+        )
     if isinstance(ref, ATRRef):
         return f"atr({ref.period})"
     if isinstance(ref, ADXRef):
@@ -325,6 +339,12 @@ def _format_predicate(p: Predicate) -> str:
     return f"{_format_indicator_ref(p.lhs)} {_OP_SYMBOL[p.op]} {_format_indicator_ref(p.rhs)}"
 
 
+_STOP_LOSS_BASIS_PREFIX: dict[str, str] = {
+    "trailing_high": "trailing-high ",
+    "trailing_low": "trailing-low ",
+}
+
+
 def _format_rule(
     rule: EntryRule
     | UnparsableRule
@@ -338,7 +358,8 @@ def _format_rule(
     if isinstance(rule, TimeStopRule):
         return f"exit after {rule.n_bars} bars"
     if isinstance(rule, StopLossRule):
-        return f"stop loss {_format_number(rule.pct * 100)}%"
+        prefix = _STOP_LOSS_BASIS_PREFIX.get(rule.basis, "")
+        return f"{prefix}stop loss {_format_number(rule.pct * 100)}%"
     if isinstance(rule, TakeProfitRule):
         return f"take profit {_format_number(rule.pct * 100)}%"
     if isinstance(rule, SignalExitRule):

--- a/backend/agents/investment_team/strategy_lab/spec_dsl.py
+++ b/backend/agents/investment_team/strategy_lab/spec_dsl.py
@@ -15,9 +15,18 @@ House pattern mirrored from
   ``Annotated[Union[...], Field(discriminator="kind")]``.
 - Trailing `Model.model_rebuild()` for forward-ref resolution.
 
-Indicator param bounds and defaults mirror
+Indicator **defaults** mirror
 `backend/agents/investment_team/strategy_lab/executor/indicators.py` exactly
-so the DSL and the runtime helpers can't drift.
+(RSI period=14, MACD 12/26/9, Bollinger 20/2.0, etc.).
+
+Indicator **bound style** (e.g. `ge=2, le=400`) mirrors the existing house
+factor DSL at `strategy_lab/factors/models.py`. The runtime helpers in
+`executor/indicators.py` themselves accept any positive integer — the
+coverage-probe registry there only enforces positive-int /
+positive-float-for-``num_std``. We apply the same sanity caps the factor
+DSL applies so degenerate spec payloads (`period=0`, `period=10000`) are
+rejected at validation time rather than silently producing all-NaN
+columns downstream.
 """
 
 from __future__ import annotations

--- a/backend/agents/investment_team/strategy_lab/spec_dsl.py
+++ b/backend/agents/investment_team/strategy_lab/spec_dsl.py
@@ -31,9 +31,10 @@ columns downstream.
 
 from __future__ import annotations
 
+import math
 from typing import Annotated, Literal, Union
 
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, field_validator
 
 ComparisonOp = Literal["gt", "lt", "ge", "le", "eq", "cross_above", "cross_below"]
 
@@ -58,6 +59,16 @@ class PriceRef(_SpecNode):
 class ConstRef(_SpecNode):
     kind: Literal["const"] = "const"
     value: float
+
+    @field_validator("value")
+    @classmethod
+    def _value_must_be_finite(cls, v: float) -> float:
+        # NaN/inf serialise as `null`/`Infinity` in JSON and emit `nan`/`inf` in
+        # prompt text, neither of which the adapter can round-trip.  Reject at
+        # construction time.
+        if not math.isfinite(v):
+            raise ValueError(f"ConstRef.value must be finite (got {v!r})")
+        return v
 
 
 class SMARef(_SpecNode):
@@ -289,18 +300,24 @@ _OP_SYMBOL: dict[str, str] = {
 
 
 def _format_number(x: float) -> str:
-    """Render a float as plain decimal text the adapter regex can parse back.
+    """Render a float as decimal text the adapter regex can parse back.
 
-    `:g` would switch to scientific notation for small values (e.g. `1e-06`),
-    which `spec_dsl_adapter._TOKEN_PAT` (``-?\\d+(?:\\.\\d+)?``) does not accept.
-    We use fixed-point with up to 12 decimal places and strip trailing zeros so
-    the round-trip contract holds for the range of values the DSL is expected
-    to carry (percentages, periods, prices, small thresholds).
+    Integer-valued floats (including those that fall on an integer after the
+    usual ``0.02 * 100 == 2.0000000000000004`` float-arithmetic jitter) render
+    as bare integers.  Everything else uses ``repr(x)``, which gives Python's
+    shortest unambiguous representation.  ``repr`` may emit scientific
+    notation for very small or very large values (e.g. ``1e-13``); the adapter
+    accepts that form via ``_NUMBER_PAT``.  Non-finite values raise — they're
+    rejected at construction time by ``ConstRef`` but we double-check here.
     """
-    if float(x).is_integer():
-        return str(int(x))
-    s = f"{x:.12f}".rstrip("0").rstrip(".")
-    return s if s else "0"
+    if not math.isfinite(x):
+        raise ValueError(f"cannot format non-finite value: {x!r}")
+    rounded = round(x)
+    # 1e-9 tolerance absorbs float-arithmetic jitter (`0.10 * 100`) without
+    # collapsing values that the caller actually meant as small thresholds.
+    if abs(x - rounded) < 1e-9 and -1e16 < x < 1e16:
+        return str(rounded)
+    return repr(x)
 
 
 def _with_source(base: str, source: str) -> str:

--- a/backend/agents/investment_team/strategy_lab/spec_dsl.py
+++ b/backend/agents/investment_team/strategy_lab/spec_dsl.py
@@ -289,10 +289,18 @@ _OP_SYMBOL: dict[str, str] = {
 
 
 def _format_number(x: float) -> str:
-    """Render a float as the shortest exact-looking decimal we can manage."""
+    """Render a float as plain decimal text the adapter regex can parse back.
+
+    `:g` would switch to scientific notation for small values (e.g. `1e-06`),
+    which `spec_dsl_adapter._TOKEN_PAT` (``-?\\d+(?:\\.\\d+)?``) does not accept.
+    We use fixed-point with up to 12 decimal places and strip trailing zeros so
+    the round-trip contract holds for the range of values the DSL is expected
+    to carry (percentages, periods, prices, small thresholds).
+    """
     if float(x).is_integer():
         return str(int(x))
-    return f"{x:g}"
+    s = f"{x:.12f}".rstrip("0").rstrip(".")
+    return s if s else "0"
 
 
 def _with_source(base: str, source: str) -> str:
@@ -318,7 +326,11 @@ def _format_indicator_ref(ref: IndicatorRef) -> str:
     if isinstance(ref, RSIRef):
         return _with_source(f"rsi({ref.period})", ref.source)
     if isinstance(ref, MACDRef):
-        return _with_source(f"macd_{ref.output}({ref.fast},{ref.slow},{ref.signal})", ref.source)
+        # Default `output="macd"` formats as bare `macd(…)`; otherwise emit
+        # `macd_signal(…)` / `macd_histogram(…)` so the token matches one of
+        # the adapter's recognised indicator names.
+        macd_name = "macd" if ref.output == "macd" else f"macd_{ref.output}"
+        return _with_source(f"{macd_name}({ref.fast},{ref.slow},{ref.signal})", ref.source)
     if isinstance(ref, BollingerRef):
         return _with_source(
             f"bollinger_{ref.band}({ref.period},{_format_number(ref.num_std)})",

--- a/backend/agents/investment_team/strategy_lab/spec_dsl.py
+++ b/backend/agents/investment_team/strategy_lab/spec_dsl.py
@@ -34,7 +34,7 @@ from __future__ import annotations
 import math
 from typing import Annotated, Literal, Union
 
-from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, field_validator
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
 
 ComparisonOp = Literal["gt", "lt", "ge", "le", "eq", "cross_above", "cross_below"]
 
@@ -43,6 +43,21 @@ Source = Literal["close", "high", "low", "open", "volume", "hl2", "ohlc4"]
 
 class _SpecNode(BaseModel):
     model_config = ConfigDict(extra="forbid")
+
+    @model_validator(mode="after")
+    def _reject_non_finite_floats(self):
+        """Reject NaN / +inf / -inf for every float field on this node.
+
+        Non-finite floats round-trip badly: ``model_dump_json()`` serialises
+        them as ``null`` / ``Infinity`` (neither of which the adapter parses
+        back), and ``_format_number`` refuses them outright.  Rejecting here
+        keeps the DSL's validation/serialisation contract internally
+        consistent regardless of which numeric field a caller supplies.
+        """
+        for name, value in self.__dict__.items():
+            if isinstance(value, float) and not math.isfinite(value):
+                raise ValueError(f"{type(self).__name__}.{name} must be finite (got {value!r})")
+        return self
 
 
 # ---------------------------------------------------------------------------
@@ -58,17 +73,8 @@ class PriceRef(_SpecNode):
 
 class ConstRef(_SpecNode):
     kind: Literal["const"] = "const"
+    # Non-finite values are rejected by ``_SpecNode._reject_non_finite_floats``.
     value: float
-
-    @field_validator("value")
-    @classmethod
-    def _value_must_be_finite(cls, v: float) -> float:
-        # NaN/inf serialise as `null`/`Infinity` in JSON and emit `nan`/`inf` in
-        # prompt text, neither of which the adapter can round-trip.  Reject at
-        # construction time.
-        if not math.isfinite(v):
-            raise ValueError(f"ConstRef.value must be finite (got {v!r})")
-        return v
 
 
 class SMARef(_SpecNode):
@@ -308,14 +314,18 @@ def _format_number(x: float) -> str:
     shortest unambiguous representation.  ``repr`` may emit scientific
     notation for very small or very large values (e.g. ``1e-13``); the adapter
     accepts that form via ``_NUMBER_PAT``.  Non-finite values raise — they're
-    rejected at construction time by ``ConstRef`` but we double-check here.
+    rejected at construction time by ``_SpecNode`` but we double-check here.
     """
     if not math.isfinite(x):
         raise ValueError(f"cannot format non-finite value: {x!r}")
     rounded = round(x)
-    # 1e-9 tolerance absorbs float-arithmetic jitter (`0.10 * 100`) without
-    # collapsing values that the caller actually meant as small thresholds.
-    if abs(x - rounded) < 1e-9 and -1e16 < x < 1e16:
+    # Relative-tolerance check absorbs float jitter like 0.10 * 100 →
+    # 10.000000000000002 without collapsing genuinely tiny values:
+    # math.isclose(5e-10, 0, rel_tol=1e-12, abs_tol=0) is False because
+    # rel_tol*max(|5e-10|, 0) = 5e-22 < 5e-10.  The -1e16..1e16 bound keeps
+    # very large floats out of the integer fast path (their decimal form
+    # would lose precision).
+    if math.isclose(x, rounded, rel_tol=1e-12, abs_tol=0) and -1e16 < x < 1e16:
         return str(rounded)
     return repr(x)
 

--- a/backend/agents/investment_team/strategy_lab/spec_dsl.py
+++ b/backend/agents/investment_team/strategy_lab/spec_dsl.py
@@ -1,0 +1,357 @@
+"""Structured `StrategySpec` DSL (issue #550, step 1 of 8 from #537).
+
+This module defines a typed, machine-readable replacement for today's
+`StrategySpec.entry_rules: list[str]` / `exit_rules: list[str]` /
+`sizing_rules: list[str]` (`backend/agents/investment_team/models.py:194-210`).
+Nothing wires `StrategySpec` to these types yet — that is step 2 of #537 and
+intentionally out of scope here. This module is a pure addition.
+
+House pattern mirrored from
+`backend/agents/investment_team/strategy_lab/factors/models.py`:
+
+- `_SpecNode(BaseModel)` base with `extra="forbid"`.
+- Every concrete node carries a `Literal[...]` `kind` discriminator.
+- Top-level unions written as
+  ``Annotated[Union[...], Field(discriminator="kind")]``.
+- Trailing `Model.model_rebuild()` for forward-ref resolution.
+
+Indicator param bounds and defaults mirror
+`backend/agents/investment_team/strategy_lab/executor/indicators.py` exactly
+so the DSL and the runtime helpers can't drift.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Literal, Union
+
+from pydantic import BaseModel, ConfigDict, Field, TypeAdapter
+
+ComparisonOp = Literal["gt", "lt", "ge", "le", "eq", "cross_above", "cross_below"]
+
+Source = Literal["close", "high", "low", "open", "volume", "hl2", "ohlc4"]
+
+
+class _SpecNode(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+# ---------------------------------------------------------------------------
+# IndicatorRef union — discriminator "kind".  Bounds mirror
+# strategy_lab/executor/indicators.py.
+# ---------------------------------------------------------------------------
+
+
+class PriceRef(_SpecNode):
+    kind: Literal["price"] = "price"
+    field: Source = "close"
+
+
+class ConstRef(_SpecNode):
+    kind: Literal["const"] = "const"
+    value: float
+
+
+class SMARef(_SpecNode):
+    kind: Literal["sma"] = "sma"
+    period: int = Field(ge=2, le=400)
+    source: Source = "close"
+
+
+class EMARef(_SpecNode):
+    kind: Literal["ema"] = "ema"
+    period: int = Field(ge=2, le=400)
+    source: Source = "close"
+
+
+class RSIRef(_SpecNode):
+    kind: Literal["rsi"] = "rsi"
+    period: int = Field(default=14, ge=2, le=200)
+    source: Source = "close"
+
+
+class MACDRef(_SpecNode):
+    kind: Literal["macd"] = "macd"
+    fast: int = Field(default=12, ge=2, le=200)
+    slow: int = Field(default=26, ge=3, le=400)
+    signal: int = Field(default=9, ge=2, le=100)
+    output: Literal["macd", "signal", "histogram"] = "macd"
+    source: Source = "close"
+
+
+class BollingerRef(_SpecNode):
+    kind: Literal["bollinger"] = "bollinger"
+    period: int = Field(default=20, ge=5, le=200)
+    num_std: float = Field(default=2.0, gt=0)
+    band: Literal["upper", "middle", "lower"] = "middle"
+    source: Source = "close"
+
+
+class ATRRef(_SpecNode):
+    kind: Literal["atr"] = "atr"
+    period: int = Field(default=14, ge=2, le=200)
+
+
+class ADXRef(_SpecNode):
+    kind: Literal["adx"] = "adx"
+    period: int = Field(default=14, ge=2, le=200)
+
+
+class StochasticRef(_SpecNode):
+    kind: Literal["stochastic"] = "stochastic"
+    k_period: int = Field(default=14, ge=2, le=200)
+    d_period: int = Field(default=3, ge=1, le=100)
+    output: Literal["k", "d"] = "k"
+
+
+class VWAPRef(_SpecNode):
+    kind: Literal["vwap"] = "vwap"
+
+
+IndicatorRef = Annotated[
+    Union[
+        PriceRef,
+        ConstRef,
+        SMARef,
+        EMARef,
+        RSIRef,
+        MACDRef,
+        BollingerRef,
+        ATRRef,
+        ADXRef,
+        StochasticRef,
+        VWAPRef,
+    ],
+    Field(discriminator="kind"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Predicate, EntryRule, ExitRule.
+# ---------------------------------------------------------------------------
+
+
+class Predicate(_SpecNode):
+    lhs: IndicatorRef
+    op: ComparisonOp
+    rhs: IndicatorRef
+
+
+class EntryRule(_SpecNode):
+    kind: Literal["entry"] = "entry"
+    side: Literal["long", "short"] = "long"
+    when: Predicate
+    note: str = ""
+
+
+class UnparsableRule(_SpecNode):
+    """Shared variant used in entry or exit slots when prose can't be parsed."""
+
+    kind: Literal["unparsable"] = "unparsable"
+    prose: str
+    reason: str = ""
+
+
+EntryRuleUnion = Annotated[
+    Union[EntryRule, UnparsableRule],
+    Field(discriminator="kind"),
+]
+
+
+class TimeStopRule(_SpecNode):
+    kind: Literal["time_stop"] = "time_stop"
+    n_bars: int = Field(gt=0)
+    note: str = ""
+
+
+class StopLossRule(_SpecNode):
+    kind: Literal["stop_loss"] = "stop_loss"
+    pct: float = Field(gt=0, le=1.0)
+    basis: Literal["entry_price", "trailing_high", "trailing_low"] = "entry_price"
+    note: str = ""
+
+
+class TakeProfitRule(_SpecNode):
+    kind: Literal["take_profit"] = "take_profit"
+    pct: float = Field(gt=0)
+    note: str = ""
+
+
+class SignalExitRule(_SpecNode):
+    kind: Literal["signal_exit"] = "signal_exit"
+    when: Predicate
+    note: str = ""
+
+
+ExitRule = Annotated[
+    Union[TimeStopRule, StopLossRule, TakeProfitRule, SignalExitRule, UnparsableRule],
+    Field(discriminator="kind"),
+]
+
+
+# ---------------------------------------------------------------------------
+# SizingRule union.
+# ---------------------------------------------------------------------------
+
+
+class FixedFractionSizing(_SpecNode):
+    kind: Literal["fixed_fraction"] = "fixed_fraction"
+    fraction: float = Field(gt=0, le=1.0)
+    note: str = ""
+
+
+class VolatilityTargetSizing(_SpecNode):
+    kind: Literal["volatility_target"] = "volatility_target"
+    target_annual_vol: float = Field(gt=0)
+    note: str = ""
+
+
+class FixedNotionalSizing(_SpecNode):
+    kind: Literal["fixed_notional"] = "fixed_notional"
+    notional_usd: float = Field(gt=0)
+    note: str = ""
+
+
+class UnparsableSizing(_SpecNode):
+    kind: Literal["unparsable_sizing"] = "unparsable_sizing"
+    prose: str
+    reason: str = ""
+
+
+SizingRule = Annotated[
+    Union[
+        FixedFractionSizing,
+        VolatilityTargetSizing,
+        FixedNotionalSizing,
+        UnparsableSizing,
+    ],
+    Field(discriminator="kind"),
+]
+
+
+# Resolve forward refs so union members are usable from outside the module.
+PriceRef.model_rebuild()
+ConstRef.model_rebuild()
+SMARef.model_rebuild()
+EMARef.model_rebuild()
+RSIRef.model_rebuild()
+MACDRef.model_rebuild()
+BollingerRef.model_rebuild()
+ATRRef.model_rebuild()
+ADXRef.model_rebuild()
+StochasticRef.model_rebuild()
+VWAPRef.model_rebuild()
+Predicate.model_rebuild()
+EntryRule.model_rebuild()
+UnparsableRule.model_rebuild()
+TimeStopRule.model_rebuild()
+StopLossRule.model_rebuild()
+TakeProfitRule.model_rebuild()
+SignalExitRule.model_rebuild()
+FixedFractionSizing.model_rebuild()
+VolatilityTargetSizing.model_rebuild()
+FixedNotionalSizing.model_rebuild()
+UnparsableSizing.model_rebuild()
+
+
+# TypeAdapters expose discriminator dispatch for callers that need to
+# validate a raw dict without pre-selecting the concrete class.
+IndicatorRefAdapter: TypeAdapter = TypeAdapter(IndicatorRef)
+EntryRuleAdapter: TypeAdapter = TypeAdapter(EntryRuleUnion)
+ExitRuleAdapter: TypeAdapter = TypeAdapter(ExitRule)
+SizingRuleAdapter: TypeAdapter = TypeAdapter(SizingRule)
+
+
+# ---------------------------------------------------------------------------
+# Human-readable formatters.  Outputs are chosen to round-trip through
+# spec_dsl_adapter.parse_* (step 1's adapter), so feeding format_rule's
+# output back into the adapter returns an equal structured rule.
+# ---------------------------------------------------------------------------
+
+
+_OP_SYMBOL: dict[str, str] = {
+    "gt": ">",
+    "lt": "<",
+    "ge": ">=",
+    "le": "<=",
+    "eq": "==",
+    "cross_above": "crosses above",
+    "cross_below": "crosses below",
+}
+
+
+def _format_number(x: float) -> str:
+    """Render a float as the shortest exact-looking decimal we can manage."""
+    if float(x).is_integer():
+        return str(int(x))
+    return f"{x:g}"
+
+
+def _format_indicator_ref(ref: IndicatorRef) -> str:
+    if isinstance(ref, PriceRef):
+        return ref.field
+    if isinstance(ref, ConstRef):
+        return _format_number(ref.value)
+    if isinstance(ref, SMARef):
+        return f"sma({ref.period})"
+    if isinstance(ref, EMARef):
+        return f"ema({ref.period})"
+    if isinstance(ref, RSIRef):
+        return f"rsi({ref.period})"
+    if isinstance(ref, MACDRef):
+        return f"macd_{ref.output}({ref.fast},{ref.slow},{ref.signal})"
+    if isinstance(ref, BollingerRef):
+        return f"bollinger_{ref.band}({ref.period},{_format_number(ref.num_std)})"
+    if isinstance(ref, ATRRef):
+        return f"atr({ref.period})"
+    if isinstance(ref, ADXRef):
+        return f"adx({ref.period})"
+    if isinstance(ref, StochasticRef):
+        return f"stochastic_{ref.output}({ref.k_period},{ref.d_period})"
+    if isinstance(ref, VWAPRef):
+        return "vwap()"
+    raise TypeError(f"unknown IndicatorRef variant: {type(ref).__name__}")
+
+
+def _format_predicate(p: Predicate) -> str:
+    return f"{_format_indicator_ref(p.lhs)} {_OP_SYMBOL[p.op]} {_format_indicator_ref(p.rhs)}"
+
+
+def _format_rule(
+    rule: EntryRule
+    | UnparsableRule
+    | TimeStopRule
+    | StopLossRule
+    | TakeProfitRule
+    | SignalExitRule,
+) -> str:
+    if isinstance(rule, EntryRule):
+        return f"{rule.side} when {_format_predicate(rule.when)}"
+    if isinstance(rule, TimeStopRule):
+        return f"exit after {rule.n_bars} bars"
+    if isinstance(rule, StopLossRule):
+        return f"stop loss {_format_number(rule.pct * 100)}%"
+    if isinstance(rule, TakeProfitRule):
+        return f"take profit {_format_number(rule.pct * 100)}%"
+    if isinstance(rule, SignalExitRule):
+        return f"exit when {_format_predicate(rule.when)}"
+    if isinstance(rule, UnparsableRule):
+        return rule.prose
+    raise TypeError(f"unknown rule variant: {type(rule).__name__}")
+
+
+def format_rules_for_prompt(rules, separator: str = ", ") -> str:
+    """Render a list of structured rules as a single human-readable string."""
+    return separator.join(_format_rule(r) for r in rules)
+
+
+def format_sizing_rule(sizing) -> str:
+    """Render a structured sizing rule back into the prose forms the adapter parses."""
+    if isinstance(sizing, FixedFractionSizing):
+        return f"risk {_format_number(sizing.fraction * 100)}% per trade"
+    if isinstance(sizing, VolatilityTargetSizing):
+        return f"vol-target {_format_number(sizing.target_annual_vol * 100)}%"
+    if isinstance(sizing, FixedNotionalSizing):
+        return f"${_format_number(sizing.notional_usd)} per trade"
+    if isinstance(sizing, UnparsableSizing):
+        return sizing.prose
+    raise TypeError(f"unknown SizingRule variant: {type(sizing).__name__}")

--- a/backend/agents/investment_team/strategy_lab/spec_dsl_adapter.py
+++ b/backend/agents/investment_team/strategy_lab/spec_dsl_adapter.py
@@ -64,20 +64,23 @@ _INDICATOR_NAMES = (
     "vwap",
 )
 
-# Token: either a price field, a number (int or decimal), or
-# ``name(arg1[,arg2,...])`` / bare ``name`` for the indicators above.
-# Longest names come first so ``macd_signal`` matches before ``macd``.
-# Each underscore in the indicator name is allowed to appear as ``-`` or
-# ``_`` so hyphenated aliases (``macd-signal``) parse identically to the
+# Token: either a price field, a number (int / decimal / leading-dot decimal /
+# scientific), or ``name(arg1[,arg2,...])`` / bare ``name`` for the indicators
+# above.  Longest names come first so ``macd_signal`` matches before ``macd``.
+# Each underscore in the indicator name is allowed to appear as ``-`` or ``_``
+# so hyphenated aliases (``macd-signal``) parse identically to the
 # underscored form.
 _INDICATOR_NAME_PAT = "|".join(name.replace("_", "[-_]") for name in _INDICATOR_NAMES)
+_NUMBER_PAT = r"-?(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?"
 _TOKEN_PAT = (
     r"(?:" + _INDICATOR_NAME_PAT + r")\s*\([^)]*\)"
     r"|(?:close|high|low|open|volume|hl2|ohlc4)\b"
     r"|(?:" + _INDICATOR_NAME_PAT + r")\b"
-    r"|-?\d+(?:\.\d+)?"
+    r"|" + _NUMBER_PAT
 )
-_OP_PAT = r"(>=|<=|==|>|<|crosses?\s+above|crosses?\s+below)"
+# ``cross(?:es)?`` matches singular `cross` and plural `crosses` (the previous
+# ``crosses?`` matched only `crosse`/`crosses` — never bare `cross`).
+_OP_PAT = r"(>=|<=|==|>|<|cross(?:es)?\s+above|cross(?:es)?\s+below)"
 
 _PREDICATE_RE = re.compile(
     rf"^\s*({_TOKEN_PAT})\s*{_OP_PAT}\s*({_TOKEN_PAT})\s*$",
@@ -138,7 +141,12 @@ def _parse_call_args(
 ) -> tuple[list[int | float], str | None] | None:
     if not raw.strip():
         return [], None
-    parts = [p.strip() for p in raw.split(",") if p.strip()]
+    # Don't filter empty slots: ``sma(,20)`` / ``macd(12,,9)`` would silently
+    # shift positional values to the wrong parameters.  Any empty slot is a
+    # malformed call.
+    parts = [p.strip() for p in raw.split(",")]
+    if any(not p for p in parts):
+        return None
     positional_tokens: list[str] = []
     source: str | None = None
     saw_kwarg = False
@@ -297,10 +305,11 @@ def _normalise_op(op_text: str) -> str | None:
     op_text = op_text.strip().lower()
     if op_text in _OP_MAP:
         return _OP_MAP[op_text]
-    # ``crosses above`` / ``cross above`` (and below)
-    if re.match(r"crosses?\s+above", op_text):
+    # ``crosses above`` / ``cross above`` (and below) — note ``crosses?`` only
+    # matches ``crosse``/``crosses``, so we use ``cross(?:es)?`` for both forms.
+    if re.match(r"cross(?:es)?\s+above", op_text):
         return "cross_above"
-    if re.match(r"crosses?\s+below", op_text):
+    if re.match(r"cross(?:es)?\s+below", op_text):
         return "cross_below"
     return None
 

--- a/backend/agents/investment_team/strategy_lab/spec_dsl_adapter.py
+++ b/backend/agents/investment_team/strategy_lab/spec_dsl_adapter.py
@@ -1,0 +1,373 @@
+"""Regex-based prose → spec_dsl adapter (issue #550, step 1 of 8 from #537).
+
+Pure regex; no LLM; no Pydantic-side-effects beyond constructing DSL nodes.
+First-match-wins ordering. Unmatched prose returns the shared ``UnparsableRule``
+variant (or ``UnparsableSizing`` in the sizing slot) so callers can route the
+ungroomed text back to a redesign loop.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from pydantic import ValidationError
+
+from .spec_dsl import (
+    ADXRef,
+    ATRRef,
+    BollingerRef,
+    ConstRef,
+    EMARef,
+    EntryRule,
+    FixedFractionSizing,
+    FixedNotionalSizing,
+    MACDRef,
+    Predicate,
+    PriceRef,
+    RSIRef,
+    SignalExitRule,
+    SMARef,
+    StochasticRef,
+    StopLossRule,
+    TakeProfitRule,
+    TimeStopRule,
+    UnparsableRule,
+    UnparsableSizing,
+    VolatilityTargetSizing,
+    VWAPRef,
+)
+
+# ---------------------------------------------------------------------------
+# Module-level compiled regex constants.
+# ---------------------------------------------------------------------------
+
+
+_PRICE_FIELDS = frozenset({"close", "high", "low", "open", "volume", "hl2", "ohlc4"})
+
+_INDICATOR_NAMES = (
+    "sma",
+    "ema",
+    "rsi",
+    "macd_signal",
+    "macd_histogram",
+    "macd",
+    "bollinger_upper",
+    "bollinger_lower",
+    "bollinger_middle",
+    "bollinger",
+    "atr",
+    "adx",
+    "stochastic_k",
+    "stochastic_d",
+    "stochastic",
+    "vwap",
+)
+
+# Token: either a price field, a number (int or decimal), or
+# ``name(arg1[,arg2,...])`` for the indicators above.  Longest indicator
+# names come first so ``macd_signal`` matches before ``macd``.
+_INDICATOR_NAME_PAT = "|".join(re.escape(name) for name in _INDICATOR_NAMES)
+_TOKEN_PAT = (
+    r"(?:"
+    + _INDICATOR_NAME_PAT
+    + r")\s*\([^)]*\)"
+    + r"|(?:close|high|low|open|volume|hl2|ohlc4)\b"
+    + r"|(?:vwap)\b"
+    + r"|-?\d+(?:\.\d+)?"
+    + r"|(?:rsi)\b"
+)
+_OP_PAT = r"(>=|<=|==|>|<|crosses?\s+above|crosses?\s+below)"
+
+_PREDICATE_RE = re.compile(
+    rf"^\s*({_TOKEN_PAT})\s*{_OP_PAT}\s*({_TOKEN_PAT})\s*$",
+    re.IGNORECASE,
+)
+
+_SHORT_RE = re.compile(r"\bshort\b", re.IGNORECASE)
+
+_EXIT_WHEN_RE = re.compile(r"^\s*exit\s+when\s+(.+)$", re.IGNORECASE)
+_TIME_STOP_RE = re.compile(
+    r"^\s*exit\s+after\s+(\d+)\s*(bars?|days?|periods?)\s*$",
+    re.IGNORECASE,
+)
+
+_STOP_LOSS_PCT_RE = re.compile(
+    r"\bstop[\s_-]?loss[:\s]+(\d+(?:\.\d+)?)\s*%",
+    re.IGNORECASE,
+)
+_STOP_LOSS_DECIMAL_RE = re.compile(
+    r"\bstop[\s_-]?loss[:\s]+(0?\.\d+)\b",
+    re.IGNORECASE,
+)
+
+_TAKE_PROFIT_RE = re.compile(
+    r"\b(?:take[\s_-]?profit|target)[:\s]+(\d+(?:\.\d+)?)\s*%",
+    re.IGNORECASE,
+)
+
+_FIXED_FRACTION_RE = re.compile(
+    r"\b(?:risk|allocate)\s+(\d+(?:\.\d+)?)\s*%\s+per\s+trade\b",
+    re.IGNORECASE,
+)
+
+_VOL_TARGET_RE = re.compile(
+    r"\bvol(?:atility)?[\s_-]?target\s+(\d+(?:\.\d+)?)\s*%",
+    re.IGNORECASE,
+)
+
+_FIXED_NOTIONAL_RE = re.compile(
+    r"\$(\d+(?:\.\d+)?)\s+(?:per\s+trade|notional)",
+    re.IGNORECASE,
+)
+
+
+# Per-indicator argument parsers.  Each entry returns the constructed
+# IndicatorRef instance (or raises ValidationError, which the caller
+# catches to emit UnparsableRule).
+def _parse_int_args(raw: str, names: tuple[str, ...]) -> dict:
+    parts = [p.strip() for p in raw.split(",") if p.strip()]
+    return {name: int(part) for name, part in zip(names, parts)}
+
+
+def _parse_indicator_call(name: str, raw_args: str):
+    if name == "sma":
+        kwargs = _parse_int_args(raw_args, ("period",)) if raw_args.strip() else {}
+        return SMARef(**kwargs) if kwargs else None
+    if name == "ema":
+        kwargs = _parse_int_args(raw_args, ("period",)) if raw_args.strip() else {}
+        return EMARef(**kwargs) if kwargs else None
+    if name == "rsi":
+        kwargs = _parse_int_args(raw_args, ("period",)) if raw_args.strip() else {}
+        return RSIRef(**kwargs)
+    if name == "atr":
+        kwargs = _parse_int_args(raw_args, ("period",)) if raw_args.strip() else {}
+        return ATRRef(**kwargs)
+    if name == "adx":
+        kwargs = _parse_int_args(raw_args, ("period",)) if raw_args.strip() else {}
+        return ADXRef(**kwargs)
+    if name in ("macd", "macd_signal", "macd_histogram"):
+        output = name.split("_", 1)[1] if "_" in name else "macd"
+        kwargs = _parse_int_args(raw_args, ("fast", "slow", "signal")) if raw_args.strip() else {}
+        return MACDRef(output=output, **kwargs)  # type: ignore[arg-type]
+    if name in ("bollinger", "bollinger_upper", "bollinger_lower", "bollinger_middle"):
+        band = name.split("_", 1)[1] if "_" in name else "middle"
+        parts = [p.strip() for p in raw_args.split(",") if p.strip()]
+        kwargs: dict = {}
+        if parts:
+            kwargs["period"] = int(parts[0])
+        if len(parts) >= 2:
+            kwargs["num_std"] = float(parts[1])
+        return BollingerRef(band=band, **kwargs)  # type: ignore[arg-type]
+    if name in ("stochastic", "stochastic_k", "stochastic_d"):
+        output = name.split("_", 1)[1] if "_" in name else "k"
+        kwargs = _parse_int_args(raw_args, ("k_period", "d_period")) if raw_args.strip() else {}
+        return StochasticRef(output=output, **kwargs)  # type: ignore[arg-type]
+    if name == "vwap":
+        return VWAPRef()
+    return None
+
+
+_INDICATOR_CALL_RE = re.compile(
+    rf"^\s*({_INDICATOR_NAME_PAT})\s*\(([^)]*)\)\s*$",
+    re.IGNORECASE,
+)
+_BARE_NAME_RE = re.compile(
+    rf"^\s*({_INDICATOR_NAME_PAT}|vwap)\s*$",
+    re.IGNORECASE,
+)
+
+
+def _parse_token(tok: str):
+    """Return an IndicatorRef-compatible node, or ``None`` if unparseable."""
+    tok = tok.strip()
+    if not tok:
+        return None
+    low = tok.lower()
+    if low in _PRICE_FIELDS:
+        return PriceRef(field=low)  # type: ignore[arg-type]
+    # bare number
+    try:
+        return ConstRef(value=float(tok))
+    except ValueError:
+        pass
+    m = _INDICATOR_CALL_RE.match(tok)
+    if m:
+        try:
+            return _parse_indicator_call(m.group(1).lower(), m.group(2))
+        except (ValueError, ValidationError):
+            return None
+    m = _BARE_NAME_RE.match(tok)
+    if m:
+        try:
+            return _parse_indicator_call(m.group(1).lower(), "")
+        except (ValueError, ValidationError):
+            return None
+    return None
+
+
+_OP_MAP = {
+    ">": "gt",
+    "<": "lt",
+    ">=": "ge",
+    "<=": "le",
+    "==": "eq",
+}
+
+
+def _normalise_op(op_text: str) -> str | None:
+    op_text = op_text.strip().lower()
+    if op_text in _OP_MAP:
+        return _OP_MAP[op_text]
+    # ``crosses above`` / ``cross above`` (and below)
+    if re.match(r"crosses?\s+above", op_text):
+        return "cross_above"
+    if re.match(r"crosses?\s+below", op_text):
+        return "cross_below"
+    return None
+
+
+def _parse_predicate(prose: str) -> Predicate | None:
+    m = _PREDICATE_RE.match(prose)
+    if not m:
+        return None
+    lhs = _parse_token(m.group(1))
+    op = _normalise_op(m.group(2))
+    rhs = _parse_token(m.group(3))
+    if lhs is None or op is None or rhs is None:
+        return None
+    try:
+        return Predicate(lhs=lhs, op=op, rhs=rhs)  # type: ignore[arg-type]
+    except ValidationError:
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Public API.
+# ---------------------------------------------------------------------------
+
+
+def parse_entry_rule(prose: str) -> EntryRule | UnparsableRule:
+    """Parse a single entry-rule prose string."""
+    text = prose.strip()
+    side: Literal["long", "short"] = "short" if _SHORT_RE.search(text) else "long"
+    # Strip a leading "long when " / "short when " marker if present so the
+    # remaining text is a pure predicate.
+    body = re.sub(r"^\s*(?:long|short)\s+when\s+", "", text, count=1, flags=re.IGNORECASE)
+    predicate = _parse_predicate(body)
+    if predicate is None:
+        return UnparsableRule(prose=text, reason="no pattern matched")
+    return EntryRule(side=side, when=predicate)
+
+
+def parse_exit_rule(prose: str):
+    """Parse a single exit-rule prose string; returns one of the ExitRule union members."""
+    text = prose.strip()
+
+    m = _TIME_STOP_RE.match(text)
+    if m:
+        try:
+            return TimeStopRule(n_bars=int(m.group(1)))
+        except ValidationError:
+            return UnparsableRule(prose=text, reason="time_stop out of bounds")
+
+    m = _EXIT_WHEN_RE.match(text)
+    if m:
+        predicate = _parse_predicate(m.group(1))
+        if predicate is not None:
+            return SignalExitRule(when=predicate)
+        return UnparsableRule(prose=text, reason="exit predicate not recognised")
+
+    m = _STOP_LOSS_PCT_RE.search(text)
+    if m:
+        try:
+            return StopLossRule(pct=float(m.group(1)) / 100.0)
+        except ValidationError:
+            return UnparsableRule(prose=text, reason="stop_loss out of bounds")
+
+    m = _STOP_LOSS_DECIMAL_RE.search(text)
+    if m:
+        try:
+            return StopLossRule(pct=float(m.group(1)))
+        except ValidationError:
+            return UnparsableRule(prose=text, reason="stop_loss out of bounds")
+
+    m = _TAKE_PROFIT_RE.search(text)
+    if m:
+        try:
+            return TakeProfitRule(pct=float(m.group(1)) / 100.0)
+        except ValidationError:
+            return UnparsableRule(prose=text, reason="take_profit out of bounds")
+
+    # Bare predicate in the exit slot is treated as a SignalExitRule.
+    predicate = _parse_predicate(text)
+    if predicate is not None:
+        return SignalExitRule(when=predicate)
+
+    return UnparsableRule(prose=text, reason="no pattern matched")
+
+
+def parse_sizing_rule(prose: str):
+    """Parse a single sizing-rule prose string; returns one of the SizingRule union members."""
+    text = prose.strip()
+
+    m = _FIXED_FRACTION_RE.search(text)
+    if m:
+        try:
+            return FixedFractionSizing(fraction=float(m.group(1)) / 100.0)
+        except ValidationError:
+            return UnparsableSizing(prose=text, reason="fixed_fraction out of bounds")
+
+    m = _VOL_TARGET_RE.search(text)
+    if m:
+        try:
+            return VolatilityTargetSizing(target_annual_vol=float(m.group(1)) / 100.0)
+        except ValidationError:
+            return UnparsableSizing(prose=text, reason="vol_target out of bounds")
+
+    m = _FIXED_NOTIONAL_RE.search(text)
+    if m:
+        try:
+            return FixedNotionalSizing(notional_usd=float(m.group(1)))
+        except ValidationError:
+            return UnparsableSizing(prose=text, reason="fixed_notional out of bounds")
+
+    return UnparsableSizing(prose=text, reason="no pattern matched")
+
+
+def parse_rule_list(prose_list: list[str], kind: Literal["entry", "exit"]) -> list:
+    """Map a legacy list[str] of rules to a list of structured rules."""
+    parser = parse_entry_rule if kind == "entry" else parse_exit_rule
+    return [parser(p) for p in prose_list]
+
+
+def parse_sizing_list(prose_list: list[str]):
+    """Collapse a legacy list[str] of sizing rules to a single structured rule.
+
+    Multiple entries: first parsable wins; remaining entries are concatenated
+    into the chosen variant's ``note`` field.  All-unparsable returns
+    ``UnparsableSizing`` covering every input joined by ``"; "``.
+    Empty list returns ``UnparsableSizing(prose="", reason="empty")``.
+    """
+    if not prose_list:
+        return UnparsableSizing(prose="", reason="empty")
+    if len(prose_list) == 1:
+        return parse_sizing_rule(prose_list[0])
+
+    chosen = None
+    leftovers: list[str] = []
+    for entry in prose_list:
+        parsed = parse_sizing_rule(entry)
+        if chosen is None and not isinstance(parsed, UnparsableSizing):
+            chosen = parsed
+        else:
+            leftovers.append(entry)
+
+    if chosen is None:
+        return UnparsableSizing(
+            prose="; ".join(p.strip() for p in prose_list),
+            reason="no pattern matched",
+        )
+
+    note = "; ".join(p.strip() for p in leftovers)
+    return chosen.model_copy(update={"note": note})

--- a/backend/agents/investment_team/strategy_lab/spec_dsl_adapter.py
+++ b/backend/agents/investment_team/strategy_lab/spec_dsl_adapter.py
@@ -93,11 +93,11 @@ _TIME_STOP_RE = re.compile(
 )
 
 _STOP_LOSS_PCT_RE = re.compile(
-    r"\bstop[\s_-]?loss[:\s]+(\d+(?:\.\d+)?)\s*%",
+    r"\b(?:(trailing[-\s_]?(?:high|low))\s+)?stop[\s_-]?loss[:\s]+(\d+(?:\.\d+)?)\s*%",
     re.IGNORECASE,
 )
 _STOP_LOSS_DECIMAL_RE = re.compile(
-    r"\bstop[\s_-]?loss[:\s]+(0?\.\d+)\b",
+    r"\b(?:(trailing[-\s_]?(?:high|low))\s+)?stop[\s_-]?loss[:\s]+(0?\.\d+)\b",
     re.IGNORECASE,
 )
 
@@ -122,48 +122,121 @@ _FIXED_NOTIONAL_RE = re.compile(
 )
 
 
-# Per-indicator argument parsers.  Each entry returns the constructed
-# IndicatorRef instance (or raises ValidationError, which the caller
-# catches to emit UnparsableRule).
-def _parse_int_args(raw: str, names: tuple[str, ...]) -> dict:
+# Per-indicator argument parser.  ``_parse_call_args`` splits ``raw`` into
+# positional values and a single optional ``source=X`` kwarg, rejecting:
+#   - extra positional args beyond what the indicator accepts,
+#   - any kwarg other than ``source`` (or any ``source=`` when the indicator
+#     has no ``source`` field),
+#   - positional args appearing after a kwarg,
+#   - non-numeric positional tokens.
+# Returning ``None`` makes the caller emit ``UnparsableRule``.
+def _parse_call_args(
+    raw: str,
+    int_slots: int,
+    float_slots: int = 0,
+    allow_source: bool = True,
+) -> tuple[list[int | float], str | None] | None:
+    if not raw.strip():
+        return [], None
     parts = [p.strip() for p in raw.split(",") if p.strip()]
-    return {name: int(part) for name, part in zip(names, parts)}
+    positional_tokens: list[str] = []
+    source: str | None = None
+    saw_kwarg = False
+    for part in parts:
+        if "=" in part:
+            saw_kwarg = True
+            k, v = part.split("=", 1)
+            k = k.strip().lower()
+            v = v.strip()
+            if k != "source" or not allow_source or source is not None:
+                return None
+            source = v
+        else:
+            if saw_kwarg:
+                return None
+            positional_tokens.append(part)
+
+    if len(positional_tokens) > int_slots + float_slots:
+        return None
+
+    parsed: list[int | float] = []
+    for i, val in enumerate(positional_tokens):
+        try:
+            parsed.append(int(val) if i < int_slots else float(val))
+        except ValueError:
+            return None
+    return parsed, source
 
 
 def _parse_indicator_call(name: str, raw_args: str):
+    def _single_period(cls, require_positional: bool):
+        res = _parse_call_args(raw_args, int_slots=1, allow_source=True)
+        if res is None:
+            return None
+        pos, source = res
+        if require_positional and not pos:
+            return None
+        kwargs: dict = {}
+        if pos:
+            kwargs["period"] = pos[0]
+        if source is not None:
+            kwargs["source"] = source
+        return cls(**kwargs)
+
     if name == "sma":
-        kwargs = _parse_int_args(raw_args, ("period",)) if raw_args.strip() else {}
-        return SMARef(**kwargs) if kwargs else None
+        return _single_period(SMARef, require_positional=True)
     if name == "ema":
-        kwargs = _parse_int_args(raw_args, ("period",)) if raw_args.strip() else {}
-        return EMARef(**kwargs) if kwargs else None
+        return _single_period(EMARef, require_positional=True)
     if name == "rsi":
-        kwargs = _parse_int_args(raw_args, ("period",)) if raw_args.strip() else {}
-        return RSIRef(**kwargs)
+        return _single_period(RSIRef, require_positional=False)
     if name == "atr":
-        kwargs = _parse_int_args(raw_args, ("period",)) if raw_args.strip() else {}
-        return ATRRef(**kwargs)
+        res = _parse_call_args(raw_args, int_slots=1, allow_source=False)
+        if res is None:
+            return None
+        pos, _ = res
+        return ATRRef(**({"period": pos[0]} if pos else {}))
     if name == "adx":
-        kwargs = _parse_int_args(raw_args, ("period",)) if raw_args.strip() else {}
-        return ADXRef(**kwargs)
+        res = _parse_call_args(raw_args, int_slots=1, allow_source=False)
+        if res is None:
+            return None
+        pos, _ = res
+        return ADXRef(**({"period": pos[0]} if pos else {}))
     if name in ("macd", "macd_signal", "macd_histogram"):
         output = name.split("_", 1)[1] if "_" in name else "macd"
-        kwargs = _parse_int_args(raw_args, ("fast", "slow", "signal")) if raw_args.strip() else {}
+        res = _parse_call_args(raw_args, int_slots=3, allow_source=True)
+        if res is None:
+            return None
+        pos, source = res
+        kwargs = dict(zip(("fast", "slow", "signal"), pos))
+        if source is not None:
+            kwargs["source"] = source
         return MACDRef(output=output, **kwargs)  # type: ignore[arg-type]
     if name in ("bollinger", "bollinger_upper", "bollinger_lower", "bollinger_middle"):
         band = name.split("_", 1)[1] if "_" in name else "middle"
-        parts = [p.strip() for p in raw_args.split(",") if p.strip()]
+        res = _parse_call_args(raw_args, int_slots=1, float_slots=1, allow_source=True)
+        if res is None:
+            return None
+        pos, source = res
         kwargs: dict = {}
-        if parts:
-            kwargs["period"] = int(parts[0])
-        if len(parts) >= 2:
-            kwargs["num_std"] = float(parts[1])
+        if pos:
+            kwargs["period"] = pos[0]
+        if len(pos) >= 2:
+            kwargs["num_std"] = pos[1]
+        if source is not None:
+            kwargs["source"] = source
         return BollingerRef(band=band, **kwargs)  # type: ignore[arg-type]
     if name in ("stochastic", "stochastic_k", "stochastic_d"):
         output = name.split("_", 1)[1] if "_" in name else "k"
-        kwargs = _parse_int_args(raw_args, ("k_period", "d_period")) if raw_args.strip() else {}
+        res = _parse_call_args(raw_args, int_slots=2, allow_source=False)
+        if res is None:
+            return None
+        pos, _ = res
+        kwargs = dict(zip(("k_period", "d_period"), pos))
         return StochasticRef(output=output, **kwargs)  # type: ignore[arg-type]
     if name == "vwap":
+        res = _parse_call_args(raw_args, int_slots=0, allow_source=False)
+        if res is None:
+            return None
         return VWAPRef()
     return None
 
@@ -227,6 +300,13 @@ def _normalise_op(op_text: str) -> str | None:
     return None
 
 
+def _basis_from_trail(trail: str | None) -> str:
+    """Map a captured ``trailing-high`` / ``trailing-low`` prefix to a StopLossRule basis."""
+    if trail is None:
+        return "entry_price"
+    return "trailing_high" if "high" in trail.lower() else "trailing_low"
+
+
 def _parse_predicate(prose: str) -> Predicate | None:
     m = _PREDICATE_RE.match(prose)
     if not m:
@@ -248,12 +328,21 @@ def _parse_predicate(prose: str) -> Predicate | None:
 
 
 def parse_entry_rule(prose: str) -> EntryRule | UnparsableRule:
-    """Parse a single entry-rule prose string."""
+    """Parse a single entry-rule prose string.
+
+    Accepts a bare predicate (``"close > sma(20)"``), the formatter's own
+    output (``"long when …"`` / ``"short when …"``), or the legacy repo
+    convention (``"enter when …"``).
+    """
     text = prose.strip()
     side: Literal["long", "short"] = "short" if _SHORT_RE.search(text) else "long"
-    # Strip a leading "long when " / "short when " marker if present so the
-    # remaining text is a pure predicate.
-    body = re.sub(r"^\s*(?:long|short)\s+when\s+", "", text, count=1, flags=re.IGNORECASE)
+    body = re.sub(
+        r"^\s*(?:long|short|enter)\s+when\s+",
+        "",
+        text,
+        count=1,
+        flags=re.IGNORECASE,
+    )
     predicate = _parse_predicate(body)
     if predicate is None:
         return UnparsableRule(prose=text, reason="no pattern matched")
@@ -281,14 +370,14 @@ def parse_exit_rule(prose: str):
     m = _STOP_LOSS_PCT_RE.search(text)
     if m:
         try:
-            return StopLossRule(pct=float(m.group(1)) / 100.0)
+            return StopLossRule(pct=float(m.group(2)) / 100.0, basis=_basis_from_trail(m.group(1)))
         except ValidationError:
             return UnparsableRule(prose=text, reason="stop_loss out of bounds")
 
     m = _STOP_LOSS_DECIMAL_RE.search(text)
     if m:
         try:
-            return StopLossRule(pct=float(m.group(1)))
+            return StopLossRule(pct=float(m.group(2)), basis=_basis_from_trail(m.group(1)))
         except ValidationError:
             return UnparsableRule(prose=text, reason="stop_loss out of bounds")
 

--- a/backend/agents/investment_team/strategy_lab/spec_dsl_adapter.py
+++ b/backend/agents/investment_team/strategy_lab/spec_dsl_adapter.py
@@ -65,17 +65,17 @@ _INDICATOR_NAMES = (
 )
 
 # Token: either a price field, a number (int or decimal), or
-# ``name(arg1[,arg2,...])`` for the indicators above.  Longest indicator
-# names come first so ``macd_signal`` matches before ``macd``.
-_INDICATOR_NAME_PAT = "|".join(re.escape(name) for name in _INDICATOR_NAMES)
+# ``name(arg1[,arg2,...])`` / bare ``name`` for the indicators above.
+# Longest names come first so ``macd_signal`` matches before ``macd``.
+# Each underscore in the indicator name is allowed to appear as ``-`` or
+# ``_`` so hyphenated aliases (``macd-signal``) parse identically to the
+# underscored form.
+_INDICATOR_NAME_PAT = "|".join(name.replace("_", "[-_]") for name in _INDICATOR_NAMES)
 _TOKEN_PAT = (
-    r"(?:"
-    + _INDICATOR_NAME_PAT
-    + r")\s*\([^)]*\)"
-    + r"|(?:close|high|low|open|volume|hl2|ohlc4)\b"
-    + r"|(?:vwap)\b"
-    + r"|-?\d+(?:\.\d+)?"
-    + r"|(?:rsi)\b"
+    r"(?:" + _INDICATOR_NAME_PAT + r")\s*\([^)]*\)"
+    r"|(?:close|high|low|open|volume|hl2|ohlc4)\b"
+    r"|(?:" + _INDICATOR_NAME_PAT + r")\b"
+    r"|-?\d+(?:\.\d+)?"
 )
 _OP_PAT = r"(>=|<=|==|>|<|crosses?\s+above|crosses?\s+below)"
 
@@ -147,7 +147,7 @@ def _parse_call_args(
             saw_kwarg = True
             k, v = part.split("=", 1)
             k = k.strip().lower()
-            v = v.strip()
+            v = v.strip().lower()  # `SOURCE=OPEN` → `source=open` so the Literal accepts it
             if k != "source" or not allow_source or source is not None:
                 return None
             source = v
@@ -246,7 +246,7 @@ _INDICATOR_CALL_RE = re.compile(
     re.IGNORECASE,
 )
 _BARE_NAME_RE = re.compile(
-    rf"^\s*({_INDICATOR_NAME_PAT}|vwap)\s*$",
+    rf"^\s*({_INDICATOR_NAME_PAT})\s*$",
     re.IGNORECASE,
 )
 
@@ -267,16 +267,21 @@ def _parse_token(tok: str):
     m = _INDICATOR_CALL_RE.match(tok)
     if m:
         try:
-            return _parse_indicator_call(m.group(1).lower(), m.group(2))
+            return _parse_indicator_call(_canonical_name(m.group(1)), m.group(2))
         except (ValueError, ValidationError):
             return None
     m = _BARE_NAME_RE.match(tok)
     if m:
         try:
-            return _parse_indicator_call(m.group(1).lower(), "")
+            return _parse_indicator_call(_canonical_name(m.group(1)), "")
         except (ValueError, ValidationError):
             return None
     return None
+
+
+def _canonical_name(raw: str) -> str:
+    """Lowercase and convert hyphenated indicator aliases to the underscored form."""
+    return raw.lower().replace("-", "_")
 
 
 _OP_MAP = {
@@ -332,12 +337,13 @@ def parse_entry_rule(prose: str) -> EntryRule | UnparsableRule:
 
     Accepts a bare predicate (``"close > sma(20)"``), the formatter's own
     output (``"long when …"`` / ``"short when …"``), or the legacy repo
-    convention (``"enter when …"``).
+    convention (``"enter when …"``, optionally ``"enter long when …"`` /
+    ``"enter short when …"``).
     """
     text = prose.strip()
     side: Literal["long", "short"] = "short" if _SHORT_RE.search(text) else "long"
     body = re.sub(
-        r"^\s*(?:long|short|enter)\s+when\s+",
+        r"^\s*(?:enter\s+)?(?:(?:long|short)\s+)?when\s+",
         "",
         text,
         count=1,

--- a/backend/agents/investment_team/strategy_lab/spec_dsl_adapter.py
+++ b/backend/agents/investment_team/strategy_lab/spec_dsl_adapter.py
@@ -95,32 +95,38 @@ _TIME_STOP_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Positive numeric pattern (no leading sign).  Includes scientific notation
+# so tiny fractions like ``1e-12`` round-trip through the formatter; Pydantic
+# `gt=0` constraints reject negative parses, so we don't need to forbid the
+# minus sign here.
+_POS_NUMBER_PAT = r"(?:\d+(?:\.\d+)?|\.\d+)(?:[eE][+-]?\d+)?"
+
 _STOP_LOSS_PCT_RE = re.compile(
-    r"\b(?:(trailing[-\s_]?(?:high|low))\s+)?stop[\s_-]?loss[:\s]+(\d+(?:\.\d+)?)\s*%",
+    r"\b(?:(trailing[-\s_]?(?:high|low))\s+)?stop[\s_-]?loss[:\s]+(" + _POS_NUMBER_PAT + r")\s*%",
     re.IGNORECASE,
 )
 _STOP_LOSS_DECIMAL_RE = re.compile(
-    r"\b(?:(trailing[-\s_]?(?:high|low))\s+)?stop[\s_-]?loss[:\s]+(0?\.\d+)\b",
+    r"\b(?:(trailing[-\s_]?(?:high|low))\s+)?stop[\s_-]?loss[:\s]+(" + _POS_NUMBER_PAT + r")",
     re.IGNORECASE,
 )
 
 _TAKE_PROFIT_RE = re.compile(
-    r"\b(?:take[\s_-]?profit|target)[:\s]+(\d+(?:\.\d+)?)\s*%",
+    r"\b(?:take[\s_-]?profit|target)[:\s]+(" + _POS_NUMBER_PAT + r")\s*%",
     re.IGNORECASE,
 )
 
 _FIXED_FRACTION_RE = re.compile(
-    r"\b(?:risk|allocate)\s+(\d+(?:\.\d+)?)\s*%\s+per\s+trade\b",
+    r"\b(?:risk|allocate)\s+(" + _POS_NUMBER_PAT + r")\s*%\s+per\s+trade\b",
     re.IGNORECASE,
 )
 
 _VOL_TARGET_RE = re.compile(
-    r"\bvol(?:atility)?[\s_-]?target\s+(\d+(?:\.\d+)?)\s*%",
+    r"\bvol(?:atility)?[\s_-]?target\s+(" + _POS_NUMBER_PAT + r")\s*%",
     re.IGNORECASE,
 )
 
 _FIXED_NOTIONAL_RE = re.compile(
-    r"\$(\d+(?:\.\d+)?)\s+(?:per\s+trade|notional)",
+    r"\$(" + _POS_NUMBER_PAT + r")\s+(?:per\s+trade|notional)",
     re.IGNORECASE,
 )
 

--- a/backend/agents/investment_team/tests/test_spec_dsl.py
+++ b/backend/agents/investment_team/tests/test_spec_dsl.py
@@ -1,0 +1,310 @@
+"""Tests for the spec_dsl module (issue #550, step 1 of 8 from #537)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from investment_team.strategy_lab.spec_dsl import (
+    ADXRef,
+    ATRRef,
+    BollingerRef,
+    ConstRef,
+    EMARef,
+    EntryRule,
+    EntryRuleAdapter,
+    ExitRuleAdapter,
+    FixedFractionSizing,
+    FixedNotionalSizing,
+    IndicatorRefAdapter,
+    MACDRef,
+    Predicate,
+    PriceRef,
+    RSIRef,
+    SignalExitRule,
+    SizingRuleAdapter,
+    SMARef,
+    StochasticRef,
+    StopLossRule,
+    TakeProfitRule,
+    TimeStopRule,
+    UnparsableRule,
+    UnparsableSizing,
+    VolatilityTargetSizing,
+    VWAPRef,
+    format_rules_for_prompt,
+    format_sizing_rule,
+)
+
+# ---------------------------------------------------------------------------
+# Round-trip serialisation per union member.
+# ---------------------------------------------------------------------------
+
+
+_INDICATOR_FIXTURES = [
+    PriceRef(field="close"),
+    PriceRef(field="high"),
+    ConstRef(value=30),
+    SMARef(period=20),
+    EMARef(period=50, source="open"),
+    RSIRef(period=14),
+    MACDRef(fast=12, slow=26, signal=9, output="signal"),
+    BollingerRef(period=20, num_std=2.0, band="upper"),
+    ATRRef(period=14),
+    ADXRef(period=14),
+    StochasticRef(k_period=14, d_period=3, output="k"),
+    VWAPRef(),
+]
+
+
+@pytest.mark.parametrize("model", _INDICATOR_FIXTURES)
+def test_indicator_round_trip(model):
+    dumped = model.model_dump_json()
+    rebuilt = IndicatorRefAdapter.validate_json(dumped)
+    assert rebuilt == model
+
+
+def test_entry_rule_round_trip():
+    rule = EntryRule(
+        side="long",
+        when=Predicate(lhs=PriceRef(field="close"), op="gt", rhs=SMARef(period=20)),
+        note="trend-follow",
+    )
+    rebuilt = EntryRuleAdapter.validate_json(rule.model_dump_json())
+    assert rebuilt == rule
+
+
+def test_unparsable_entry_round_trip():
+    rule = UnparsableRule(prose="enter on vibes", reason="no pattern matched")
+    rebuilt = EntryRuleAdapter.validate_json(rule.model_dump_json())
+    assert rebuilt == rule
+
+
+@pytest.mark.parametrize(
+    "rule",
+    [
+        TimeStopRule(n_bars=5),
+        StopLossRule(pct=0.03),
+        StopLossRule(pct=0.03, basis="trailing_high"),
+        TakeProfitRule(pct=0.05),
+        SignalExitRule(when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70))),
+        UnparsableRule(prose="exit on vibes"),
+    ],
+)
+def test_exit_rule_round_trip(rule):
+    rebuilt = ExitRuleAdapter.validate_json(rule.model_dump_json())
+    assert rebuilt == rule
+
+
+@pytest.mark.parametrize(
+    "rule",
+    [
+        FixedFractionSizing(fraction=0.02),
+        VolatilityTargetSizing(target_annual_vol=0.10),
+        FixedNotionalSizing(notional_usd=50000),
+        UnparsableSizing(prose="size based on confidence"),
+    ],
+)
+def test_sizing_round_trip(rule):
+    rebuilt = SizingRuleAdapter.validate_json(rule.model_dump_json())
+    assert rebuilt == rule
+
+
+# ---------------------------------------------------------------------------
+# Discriminator dispatch — raw dicts route to the right concrete class.
+# ---------------------------------------------------------------------------
+
+
+def test_indicator_discriminator_dispatch():
+    assert isinstance(IndicatorRefAdapter.validate_python({"kind": "rsi"}), RSIRef)
+    assert isinstance(IndicatorRefAdapter.validate_python({"kind": "sma", "period": 20}), SMARef)
+    assert isinstance(IndicatorRefAdapter.validate_python({"kind": "macd"}), MACDRef)
+
+
+def test_entry_discriminator_dispatch():
+    payload = {
+        "kind": "entry",
+        "side": "long",
+        "when": {
+            "lhs": {"kind": "price", "field": "close"},
+            "op": "gt",
+            "rhs": {"kind": "sma", "period": 20},
+        },
+    }
+    parsed = EntryRuleAdapter.validate_python(payload)
+    assert isinstance(parsed, EntryRule)
+    assert isinstance(parsed.when.rhs, SMARef)
+
+
+def test_exit_discriminator_dispatch():
+    assert isinstance(
+        ExitRuleAdapter.validate_python({"kind": "time_stop", "n_bars": 5}),
+        TimeStopRule,
+    )
+    assert isinstance(
+        ExitRuleAdapter.validate_python({"kind": "stop_loss", "pct": 0.03}),
+        StopLossRule,
+    )
+    assert isinstance(
+        ExitRuleAdapter.validate_python({"kind": "unparsable", "prose": "..."}),
+        UnparsableRule,
+    )
+
+
+def test_sizing_discriminator_dispatch():
+    assert isinstance(
+        SizingRuleAdapter.validate_python({"kind": "fixed_fraction", "fraction": 0.02}),
+        FixedFractionSizing,
+    )
+    assert isinstance(
+        SizingRuleAdapter.validate_python({"kind": "unparsable_sizing", "prose": "x"}),
+        UnparsableSizing,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bounds-violation tests.
+# ---------------------------------------------------------------------------
+
+
+def test_sma_period_lower_bound():
+    with pytest.raises(ValidationError):
+        SMARef(period=1)
+
+
+def test_sma_period_upper_bound():
+    with pytest.raises(ValidationError):
+        SMARef(period=401)
+
+
+def test_rsi_period_upper_bound():
+    with pytest.raises(ValidationError):
+        RSIRef(period=201)
+
+
+def test_bollinger_num_std_must_be_positive():
+    with pytest.raises(ValidationError):
+        BollingerRef(period=20, num_std=-1)
+
+
+def test_macd_fast_lower_bound():
+    with pytest.raises(ValidationError):
+        MACDRef(fast=1)
+
+
+def test_stop_loss_negative_pct():
+    with pytest.raises(ValidationError):
+        StopLossRule(pct=-0.01)
+
+
+def test_stop_loss_pct_over_one():
+    with pytest.raises(ValidationError):
+        StopLossRule(pct=1.5)
+
+
+def test_take_profit_negative_pct():
+    with pytest.raises(ValidationError):
+        TakeProfitRule(pct=-0.05)
+
+
+def test_predicate_unknown_op():
+    with pytest.raises(ValidationError):
+        Predicate(
+            lhs=PriceRef(field="close"),
+            op="bogus",  # type: ignore[arg-type]
+            rhs=SMARef(period=20),
+        )
+
+
+def test_time_stop_must_be_positive():
+    with pytest.raises(ValidationError):
+        TimeStopRule(n_bars=0)
+
+
+def test_fixed_fraction_upper_bound():
+    with pytest.raises(ValidationError):
+        FixedFractionSizing(fraction=1.5)
+
+
+def test_extra_field_is_forbidden():
+    with pytest.raises(ValidationError):
+        RSIRef.model_validate({"kind": "rsi", "period": 14, "foo": 1})
+
+
+def test_missing_required_const_value():
+    with pytest.raises(ValidationError):
+        ConstRef.model_validate({"kind": "const"})
+
+
+# ---------------------------------------------------------------------------
+# Formatter golden strings.
+# ---------------------------------------------------------------------------
+
+
+def test_format_entry_close_gt_sma():
+    rule = EntryRule(
+        side="long",
+        when=Predicate(lhs=PriceRef(field="close"), op="gt", rhs=SMARef(period=20)),
+    )
+    assert format_rules_for_prompt([rule]) == "long when close > sma(20)"
+
+
+def test_format_entry_rsi_lt_30():
+    rule = EntryRule(
+        side="long",
+        when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30)),
+    )
+    assert format_rules_for_prompt([rule]) == "long when rsi(14) < 30"
+
+
+def test_format_time_stop():
+    assert format_rules_for_prompt([TimeStopRule(n_bars=5)]) == "exit after 5 bars"
+
+
+def test_format_stop_loss():
+    assert format_rules_for_prompt([StopLossRule(pct=0.03)]) == "stop loss 3%"
+
+
+def test_format_take_profit():
+    assert format_rules_for_prompt([TakeProfitRule(pct=0.05)]) == "take profit 5%"
+
+
+def test_format_signal_exit_rsi_gt_70():
+    rule = SignalExitRule(when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)))
+    assert format_rules_for_prompt([rule]) == "exit when rsi(14) > 70"
+
+
+def test_format_unparsable_returns_prose():
+    assert format_rules_for_prompt([UnparsableRule(prose="enter on vibes")]) == "enter on vibes"
+
+
+def test_format_sizing_fixed_fraction():
+    assert format_sizing_rule(FixedFractionSizing(fraction=0.02)) == "risk 2% per trade"
+
+
+def test_format_sizing_volatility_target():
+    assert format_sizing_rule(VolatilityTargetSizing(target_annual_vol=0.10)) == "vol-target 10%"
+
+
+def test_format_sizing_fixed_notional():
+    assert format_sizing_rule(FixedNotionalSizing(notional_usd=50000)) == "$50000 per trade"
+
+
+def test_format_sizing_unparsable_returns_prose():
+    assert (
+        format_sizing_rule(UnparsableSizing(prose="size up on confidence"))
+        == "size up on confidence"
+    )
+
+
+def test_format_rules_for_prompt_join_separator():
+    rules = [
+        StopLossRule(pct=0.03),
+        TakeProfitRule(pct=0.05),
+        TimeStopRule(n_bars=10),
+    ]
+    assert format_rules_for_prompt(rules) == "stop loss 3%, take profit 5%, exit after 10 bars"
+
+
+def test_format_rules_for_prompt_empty():
+    assert format_rules_for_prompt([]) == ""

--- a/backend/agents/investment_team/tests/test_spec_dsl.py
+++ b/backend/agents/investment_team/tests/test_spec_dsl.py
@@ -265,6 +265,36 @@ def test_format_stop_loss():
     assert format_rules_for_prompt([StopLossRule(pct=0.03)]) == "stop loss 3%"
 
 
+def test_format_stop_loss_trailing_high():
+    rule = StopLossRule(pct=0.03, basis="trailing_high")
+    assert format_rules_for_prompt([rule]) == "trailing-high stop loss 3%"
+
+
+def test_format_stop_loss_trailing_low():
+    rule = StopLossRule(pct=0.05, basis="trailing_low")
+    assert format_rules_for_prompt([rule]) == "trailing-low stop loss 5%"
+
+
+def test_format_indicator_source_default_omitted():
+    rule = EntryRule(
+        side="long",
+        when=Predicate(lhs=EMARef(period=50), op="gt", rhs=PriceRef(field="close")),
+    )
+    assert format_rules_for_prompt([rule]) == "long when ema(50) > close"
+
+
+def test_format_indicator_source_non_default_emitted():
+    rule = EntryRule(
+        side="long",
+        when=Predicate(
+            lhs=EMARef(period=50, source="open"),
+            op="gt",
+            rhs=PriceRef(field="close"),
+        ),
+    )
+    assert format_rules_for_prompt([rule]) == "long when ema(50, source=open) > close"
+
+
 def test_format_take_profit():
     assert format_rules_for_prompt([TakeProfitRule(pct=0.05)]) == "take profit 5%"
 

--- a/backend/agents/investment_team/tests/test_spec_dsl_adapter.py
+++ b/backend/agents/investment_team/tests/test_spec_dsl_adapter.py
@@ -371,3 +371,133 @@ def test_atr_source_kwarg_rejected():
     """ATR has no `source` field; specifying one must reject."""
     parsed = parse_exit_rule("exit when atr(14, source=open) > 0")
     assert isinstance(parsed, UnparsableRule)
+
+
+# ---------------------------------------------------------------------------
+# Bare default-argument indicators in predicates (#558 second pass).
+# ---------------------------------------------------------------------------
+
+
+def test_predicate_bare_adx():
+    from investment_team.strategy_lab.spec_dsl import ADXRef
+
+    parsed = parse_entry_rule("ADX > 25")
+    assert isinstance(parsed, EntryRule)
+    assert parsed.when.lhs == ADXRef(period=14)
+    assert parsed.when.rhs == ConstRef(value=25)
+
+
+def test_predicate_bare_macd():
+    from investment_team.strategy_lab.spec_dsl import MACDRef
+
+    parsed = parse_entry_rule("macd > 0")
+    assert isinstance(parsed, EntryRule)
+    assert parsed.when.lhs == MACDRef()
+    assert parsed.when.rhs == ConstRef(value=0)
+
+
+def test_predicate_bare_stochastic_k():
+    from investment_team.strategy_lab.spec_dsl import StochasticRef
+
+    parsed = parse_entry_rule("stochastic_k < 20")
+    assert isinstance(parsed, EntryRule)
+    assert parsed.when.lhs == StochasticRef()
+
+
+def test_predicate_bare_sma_stays_unparsable():
+    """SMA/EMA still need an explicit period — bare `sma > x` should fail."""
+    parsed = parse_entry_rule("sma > close")
+    assert isinstance(parsed, UnparsableRule)
+
+
+# ---------------------------------------------------------------------------
+# Enter prefix with explicit side.
+# ---------------------------------------------------------------------------
+
+
+def test_entry_enter_short_when():
+    parsed = parse_entry_rule("enter short when rsi > 70")
+    assert isinstance(parsed, EntryRule)
+    assert parsed.side == "short"
+    assert parsed.when == Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70))
+
+
+def test_entry_enter_long_when():
+    parsed = parse_entry_rule("enter long when close > sma(20)")
+    assert isinstance(parsed, EntryRule)
+    assert parsed.side == "long"
+    assert parsed.when == Predicate(lhs=PriceRef(field="close"), op="gt", rhs=SMARef(period=20))
+
+
+# ---------------------------------------------------------------------------
+# Hyphenated indicator aliases.
+# ---------------------------------------------------------------------------
+
+
+def test_hyphenated_indicator_alias_call():
+    from investment_team.strategy_lab.spec_dsl import MACDRef
+
+    parsed = parse_entry_rule("macd-signal(12,26,9) > 0")
+    assert isinstance(parsed, EntryRule)
+    assert parsed.when.lhs == MACDRef(fast=12, slow=26, signal=9, output="signal")
+
+
+def test_hyphenated_indicator_alias_bare():
+    from investment_team.strategy_lab.spec_dsl import StochasticRef
+
+    parsed = parse_entry_rule("stochastic-k < 20")
+    assert isinstance(parsed, EntryRule)
+    assert parsed.when.lhs == StochasticRef()
+
+
+# ---------------------------------------------------------------------------
+# Case-insensitive source value.
+# ---------------------------------------------------------------------------
+
+
+def test_source_kwarg_case_insensitive():
+    parsed = parse_entry_rule("EMA(50, SOURCE=OPEN) > CLOSE")
+    assert isinstance(parsed, EntryRule)
+    assert parsed.when.lhs == EMARef(period=50, source="open")
+
+
+# ---------------------------------------------------------------------------
+# MACD default-output formatter round-trip.
+# ---------------------------------------------------------------------------
+
+
+def test_macd_default_output_round_trip():
+    from investment_team.strategy_lab.spec_dsl import MACDRef
+
+    rule = EntryRule(
+        side="long",
+        when=Predicate(lhs=MACDRef(), op="gt", rhs=ConstRef(value=0)),
+    )
+    rendered = format_rules_for_prompt([rule])
+    # The default output ("macd") must format as bare `macd(...)`, not
+    # `macd_macd(...)`, otherwise the adapter can't reparse it.
+    assert "macd_macd" not in rendered
+    reparsed = parse_entry_rule(rendered)
+    assert isinstance(reparsed, EntryRule)
+    assert reparsed.when.lhs == MACDRef()
+
+
+# ---------------------------------------------------------------------------
+# Formatter ↔ adapter round-trip for small decimals.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value",
+    [1e-06, 0.0001, 0.5, 100.5],
+)
+def test_small_decimal_round_trip(value):
+    rule = EntryRule(
+        side="long",
+        when=Predicate(lhs=PriceRef(field="close"), op="gt", rhs=ConstRef(value=value)),
+    )
+    rendered = format_rules_for_prompt([rule])
+    assert "e-" not in rendered.lower()  # no scientific notation
+    reparsed = parse_entry_rule(rendered)
+    assert isinstance(reparsed, EntryRule)
+    assert reparsed.when.rhs.value == pytest.approx(value)

--- a/backend/agents/investment_team/tests/test_spec_dsl_adapter.py
+++ b/backend/agents/investment_team/tests/test_spec_dsl_adapter.py
@@ -1,0 +1,296 @@
+"""Tests for the spec_dsl_adapter module (issue #550, step 1 of 8 from #537)."""
+
+from __future__ import annotations
+
+import pytest
+
+from investment_team.strategy_lab.spec_dsl import (
+    ConstRef,
+    EntryRule,
+    FixedFractionSizing,
+    FixedNotionalSizing,
+    Predicate,
+    PriceRef,
+    RSIRef,
+    SignalExitRule,
+    SMARef,
+    StopLossRule,
+    TakeProfitRule,
+    TimeStopRule,
+    UnparsableRule,
+    UnparsableSizing,
+    VolatilityTargetSizing,
+    format_rules_for_prompt,
+    format_sizing_rule,
+)
+from investment_team.strategy_lab.spec_dsl_adapter import (
+    parse_entry_rule,
+    parse_exit_rule,
+    parse_rule_list,
+    parse_sizing_list,
+    parse_sizing_rule,
+)
+
+# ---------------------------------------------------------------------------
+# Entry-rule patterns.
+# ---------------------------------------------------------------------------
+
+
+def test_entry_close_gt_sma():
+    parsed = parse_entry_rule("close > sma(20)")
+    assert isinstance(parsed, EntryRule)
+    assert parsed.side == "long"
+    assert parsed.when == Predicate(lhs=PriceRef(field="close"), op="gt", rhs=SMARef(period=20))
+
+
+def test_entry_rsi_lt_30():
+    parsed = parse_entry_rule("RSI < 30")
+    assert isinstance(parsed, EntryRule)
+    assert parsed.when == Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30))
+
+
+def test_entry_short_when_rsi_gt_70():
+    parsed = parse_entry_rule("short when rsi(14) > 70")
+    assert isinstance(parsed, EntryRule)
+    assert parsed.side == "short"
+    assert parsed.when == Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70))
+
+
+def test_entry_crosses_above():
+    parsed = parse_entry_rule("sma(20) crosses above sma(50)")
+    assert isinstance(parsed, EntryRule)
+    assert parsed.when.op == "cross_above"
+    assert parsed.when.lhs == SMARef(period=20)
+    assert parsed.when.rhs == SMARef(period=50)
+
+
+def test_entry_unparsable():
+    parsed = parse_entry_rule("enter on bullish momentum")
+    assert isinstance(parsed, UnparsableRule)
+    assert parsed.prose == "enter on bullish momentum"
+    assert parsed.reason == "no pattern matched"
+
+
+# ---------------------------------------------------------------------------
+# Exit-rule patterns.
+# ---------------------------------------------------------------------------
+
+
+def test_exit_when_rsi_gt_70():
+    parsed = parse_exit_rule("exit when RSI > 70")
+    assert isinstance(parsed, SignalExitRule)
+    assert parsed.when == Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70))
+
+
+@pytest.mark.parametrize(
+    "prose,expected_bars",
+    [
+        ("exit after 5 bars", 5),
+        ("exit after 10 days", 10),
+        ("exit after 7 periods", 7),
+    ],
+)
+def test_exit_time_stop(prose, expected_bars):
+    parsed = parse_exit_rule(prose)
+    assert isinstance(parsed, TimeStopRule)
+    assert parsed.n_bars == expected_bars
+
+
+@pytest.mark.parametrize(
+    "prose,expected_pct",
+    [
+        ("stop loss 3%", 0.03),
+        ("stop-loss: 0.03", 0.03),
+        ("stop loss: 5%", 0.05),
+    ],
+)
+def test_exit_stop_loss(prose, expected_pct):
+    parsed = parse_exit_rule(prose)
+    assert isinstance(parsed, StopLossRule)
+    assert parsed.pct == pytest.approx(expected_pct)
+
+
+@pytest.mark.parametrize(
+    "prose,expected_pct",
+    [
+        ("take profit 5%", 0.05),
+        ("target 5%", 0.05),
+        ("take-profit: 10%", 0.10),
+    ],
+)
+def test_exit_take_profit(prose, expected_pct):
+    parsed = parse_exit_rule(prose)
+    assert isinstance(parsed, TakeProfitRule)
+    assert parsed.pct == pytest.approx(expected_pct)
+
+
+def test_exit_unparsable():
+    parsed = parse_exit_rule("vibes")
+    assert isinstance(parsed, UnparsableRule)
+    assert parsed.prose == "vibes"
+
+
+# ---------------------------------------------------------------------------
+# Sizing patterns.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "prose,expected_fraction",
+    [
+        ("risk 2% per trade", 0.02),
+        ("allocate 2% per trade", 0.02),
+        ("risk 1.5% per trade", 0.015),
+    ],
+)
+def test_sizing_fixed_fraction(prose, expected_fraction):
+    parsed = parse_sizing_rule(prose)
+    assert isinstance(parsed, FixedFractionSizing)
+    assert parsed.fraction == pytest.approx(expected_fraction)
+
+
+@pytest.mark.parametrize(
+    "prose,expected_vol",
+    [
+        ("vol-target 10%", 0.10),
+        ("volatility-target 10%", 0.10),
+        ("vol target 12.5%", 0.125),
+    ],
+)
+def test_sizing_vol_target(prose, expected_vol):
+    parsed = parse_sizing_rule(prose)
+    assert isinstance(parsed, VolatilityTargetSizing)
+    assert parsed.target_annual_vol == pytest.approx(expected_vol)
+
+
+@pytest.mark.parametrize(
+    "prose,expected_usd",
+    [
+        ("$50000 per trade", 50000),
+        ("$50000 notional", 50000),
+        ("$1000.50 per trade", 1000.50),
+    ],
+)
+def test_sizing_fixed_notional(prose, expected_usd):
+    parsed = parse_sizing_rule(prose)
+    assert isinstance(parsed, FixedNotionalSizing)
+    assert parsed.notional_usd == pytest.approx(expected_usd)
+
+
+def test_sizing_unparsable():
+    parsed = parse_sizing_rule("size up if confident")
+    assert isinstance(parsed, UnparsableSizing)
+    assert parsed.prose == "size up if confident"
+
+
+# ---------------------------------------------------------------------------
+# parse_rule_list / parse_sizing_list collapse semantics.
+# ---------------------------------------------------------------------------
+
+
+def test_parse_rule_list_entry():
+    parsed = parse_rule_list(["close > sma(20)", "vibes"], kind="entry")
+    assert len(parsed) == 2
+    assert isinstance(parsed[0], EntryRule)
+    assert isinstance(parsed[1], UnparsableRule)
+
+
+def test_parse_rule_list_exit():
+    parsed = parse_rule_list(["stop loss 3%", "exit after 5 bars"], kind="exit")
+    assert isinstance(parsed[0], StopLossRule)
+    assert isinstance(parsed[1], TimeStopRule)
+
+
+def test_sizing_list_empty():
+    parsed = parse_sizing_list([])
+    assert isinstance(parsed, UnparsableSizing)
+    assert parsed.prose == ""
+    assert parsed.reason == "empty"
+
+
+def test_sizing_list_single():
+    parsed = parse_sizing_list(["risk 2% per trade"])
+    assert isinstance(parsed, FixedFractionSizing)
+    assert parsed.fraction == pytest.approx(0.02)
+
+
+def test_sizing_list_collapse_first_wins_with_note():
+    parsed = parse_sizing_list(["risk 2% per trade", "max 5% gross"])
+    assert isinstance(parsed, FixedFractionSizing)
+    assert parsed.fraction == pytest.approx(0.02)
+    assert parsed.note == "max 5% gross"
+
+
+def test_sizing_list_collapse_skips_unparsable_then_chooses():
+    parsed = parse_sizing_list(["size on vibes", "risk 2% per trade", "max 5% gross"])
+    assert isinstance(parsed, FixedFractionSizing)
+    assert parsed.fraction == pytest.approx(0.02)
+    # Both the unparseable leader and the trailing constraint land in note.
+    assert "size on vibes" in parsed.note
+    assert "max 5% gross" in parsed.note
+
+
+def test_sizing_list_all_unparsable():
+    parsed = parse_sizing_list(["foo", "bar"])
+    assert isinstance(parsed, UnparsableSizing)
+    assert parsed.prose == "foo; bar"
+
+
+# ---------------------------------------------------------------------------
+# Formatter <-> adapter round-trip.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "rule",
+    [
+        EntryRule(
+            side="long",
+            when=Predicate(lhs=PriceRef(field="close"), op="gt", rhs=SMARef(period=20)),
+        ),
+        EntryRule(
+            side="short",
+            when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)),
+        ),
+    ],
+)
+def test_entry_formatter_round_trip(rule):
+    rendered = format_rules_for_prompt([rule])
+    reparsed = parse_entry_rule(rendered)
+    assert isinstance(reparsed, EntryRule)
+    assert reparsed.side == rule.side
+    assert reparsed.when == rule.when
+
+
+@pytest.mark.parametrize(
+    "rule",
+    [
+        TimeStopRule(n_bars=5),
+        StopLossRule(pct=0.03),
+        TakeProfitRule(pct=0.05),
+        SignalExitRule(when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70))),
+    ],
+)
+def test_exit_formatter_round_trip(rule):
+    rendered = format_rules_for_prompt([rule])
+    reparsed = parse_exit_rule(rendered)
+    # Compare on the model_dump to avoid `note`/default-flag noise.
+    assert type(reparsed) is type(rule)
+    assert reparsed.model_dump(exclude={"note", "basis"}) == rule.model_dump(
+        exclude={"note", "basis"}
+    )
+
+
+@pytest.mark.parametrize(
+    "rule",
+    [
+        FixedFractionSizing(fraction=0.02),
+        VolatilityTargetSizing(target_annual_vol=0.10),
+        FixedNotionalSizing(notional_usd=50000),
+    ],
+)
+def test_sizing_formatter_round_trip(rule):
+    rendered = format_sizing_rule(rule)
+    reparsed = parse_sizing_rule(rendered)
+    assert type(reparsed) is type(rule)
+    assert reparsed.model_dump(exclude={"note"}) == rule.model_dump(exclude={"note"})

--- a/backend/agents/investment_team/tests/test_spec_dsl_adapter.py
+++ b/backend/agents/investment_team/tests/test_spec_dsl_adapter.py
@@ -571,3 +571,80 @@ def test_small_decimal_round_trip(value):
     reparsed = parse_entry_rule(rendered)
     assert isinstance(reparsed, EntryRule)
     assert reparsed.when.rhs.value == pytest.approx(value)
+
+
+# ---------------------------------------------------------------------------
+# Tiny non-zero values must NOT collapse to 0 (#558 fourth pass).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [5e-10, 1e-12, 1e-15])
+def test_tiny_const_not_collapsed_to_zero(value):
+    rendered = format_rules_for_prompt(
+        [
+            EntryRule(
+                side="long",
+                when=Predicate(
+                    lhs=PriceRef(field="close"),
+                    op="gt",
+                    rhs=ConstRef(value=value),
+                ),
+            )
+        ]
+    )
+    # Must not collapse to the bare `0` integer.
+    assert not rendered.endswith("> 0")
+    reparsed = parse_entry_rule(rendered)
+    assert isinstance(reparsed, EntryRule)
+    assert reparsed.when.rhs.value == pytest.approx(value)
+
+
+def test_tiny_fixed_fraction_round_trip():
+    rule = FixedFractionSizing(fraction=1e-12)
+    rendered = format_sizing_rule(rule)
+    # Must not collapse to the literal "risk 0% per trade" prose, which the
+    # adapter would round-trip into a Pydantic `gt=0` failure.
+    assert rendered != "risk 0% per trade"
+    reparsed = parse_sizing_rule(rendered)
+    assert isinstance(reparsed, FixedFractionSizing)
+    assert reparsed.fraction == pytest.approx(1e-12)
+
+
+def test_tiny_vol_target_round_trip():
+    rule = VolatilityTargetSizing(target_annual_vol=1e-10)
+    rendered = format_sizing_rule(rule)
+    reparsed = parse_sizing_rule(rendered)
+    assert isinstance(reparsed, VolatilityTargetSizing)
+    assert reparsed.target_annual_vol == pytest.approx(1e-10)
+
+
+# ---------------------------------------------------------------------------
+# Every float-bearing DSL node rejects non-finite values (#558 fourth pass).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+@pytest.mark.parametrize(
+    "factory",
+    [
+        lambda v: StopLossRule(pct=v),
+        lambda v: TakeProfitRule(pct=v),
+        lambda v: FixedFractionSizing(fraction=v),
+        lambda v: VolatilityTargetSizing(target_annual_vol=v),
+        lambda v: FixedNotionalSizing(notional_usd=v),
+    ],
+)
+def test_dsl_nodes_reject_non_finite_floats(factory, bad):
+    from pydantic import ValidationError as _VE
+
+    with pytest.raises(_VE):
+        factory(bad)
+
+
+def test_bollinger_num_std_rejects_non_finite():
+    from pydantic import ValidationError as _VE
+
+    from investment_team.strategy_lab.spec_dsl import BollingerRef
+
+    with pytest.raises(_VE):
+        BollingerRef(num_std=float("inf"))

--- a/backend/agents/investment_team/tests/test_spec_dsl_adapter.py
+++ b/backend/agents/investment_team/tests/test_spec_dsl_adapter.py
@@ -6,6 +6,7 @@ import pytest
 
 from investment_team.strategy_lab.spec_dsl import (
     ConstRef,
+    EMARef,
     EntryRule,
     FixedFractionSizing,
     FixedNotionalSizing,
@@ -267,6 +268,8 @@ def test_entry_formatter_round_trip(rule):
     [
         TimeStopRule(n_bars=5),
         StopLossRule(pct=0.03),
+        StopLossRule(pct=0.03, basis="trailing_high"),
+        StopLossRule(pct=0.03, basis="trailing_low"),
         TakeProfitRule(pct=0.05),
         SignalExitRule(when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70))),
     ],
@@ -274,11 +277,9 @@ def test_entry_formatter_round_trip(rule):
 def test_exit_formatter_round_trip(rule):
     rendered = format_rules_for_prompt([rule])
     reparsed = parse_exit_rule(rendered)
-    # Compare on the model_dump to avoid `note`/default-flag noise.
+    # Compare on the model_dump to avoid `note` default-flag noise.
     assert type(reparsed) is type(rule)
-    assert reparsed.model_dump(exclude={"note", "basis"}) == rule.model_dump(
-        exclude={"note", "basis"}
-    )
+    assert reparsed.model_dump(exclude={"note"}) == rule.model_dump(exclude={"note"})
 
 
 @pytest.mark.parametrize(
@@ -294,3 +295,79 @@ def test_sizing_formatter_round_trip(rule):
     reparsed = parse_sizing_rule(rendered)
     assert type(reparsed) is type(rule)
     assert reparsed.model_dump(exclude={"note"}) == rule.model_dump(exclude={"note"})
+
+
+# ---------------------------------------------------------------------------
+# Regression tests for the four bugs raised on PR #558.
+# ---------------------------------------------------------------------------
+
+
+def test_entry_enter_when_legacy_phrasing():
+    """Legacy specs use `enter when …`; the adapter must accept that wording."""
+    parsed = parse_entry_rule("enter when RSI < 30")
+    assert isinstance(parsed, EntryRule)
+    assert parsed.side == "long"
+    assert parsed.when == Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30))
+
+
+def test_indicator_source_preserved_in_round_trip():
+    rule = EntryRule(
+        side="long",
+        when=Predicate(
+            lhs=EMARef(period=50, source="open"),
+            op="gt",
+            rhs=PriceRef(field="close"),
+        ),
+    )
+    rendered = format_rules_for_prompt([rule])
+    assert "source=open" in rendered
+    reparsed = parse_entry_rule(rendered)
+    assert isinstance(reparsed, EntryRule)
+    assert reparsed.when.lhs == EMARef(period=50, source="open")
+
+
+def test_indicator_source_kwarg_parses():
+    parsed = parse_entry_rule("ema(50, source=open) > close")
+    assert isinstance(parsed, EntryRule)
+    assert parsed.when.lhs == EMARef(period=50, source="open")
+
+
+def test_trailing_stop_loss_round_trip_high():
+    rule = StopLossRule(pct=0.03, basis="trailing_high")
+    rendered = format_rules_for_prompt([rule])
+    assert rendered == "trailing-high stop loss 3%"
+    reparsed = parse_exit_rule(rendered)
+    assert isinstance(reparsed, StopLossRule)
+    assert reparsed.basis == "trailing_high"
+    assert reparsed.pct == pytest.approx(0.03)
+
+
+def test_trailing_stop_loss_round_trip_low():
+    rule = StopLossRule(pct=0.05, basis="trailing_low")
+    rendered = format_rules_for_prompt([rule])
+    assert rendered == "trailing-low stop loss 5%"
+    reparsed = parse_exit_rule(rendered)
+    assert isinstance(reparsed, StopLossRule)
+    assert reparsed.basis == "trailing_low"
+
+
+def test_indicator_extra_positional_args_rejected():
+    """`sma(20,50) > close` had silently dropped the 50; now → UnparsableRule."""
+    parsed = parse_entry_rule("sma(20,50) > close")
+    assert isinstance(parsed, UnparsableRule)
+
+
+def test_macd_extra_positional_args_rejected():
+    parsed = parse_entry_rule("macd(12,26,9,99) > 0")
+    assert isinstance(parsed, UnparsableRule)
+
+
+def test_indicator_unknown_kwarg_rejected():
+    parsed = parse_entry_rule("sma(20, foo=bar) > close")
+    assert isinstance(parsed, UnparsableRule)
+
+
+def test_atr_source_kwarg_rejected():
+    """ATR has no `source` field; specifying one must reject."""
+    parsed = parse_exit_rule("exit when atr(14, source=open) > 0")
+    assert isinstance(parsed, UnparsableRule)

--- a/backend/agents/investment_team/tests/test_spec_dsl_adapter.py
+++ b/backend/agents/investment_team/tests/test_spec_dsl_adapter.py
@@ -487,17 +487,87 @@ def test_macd_default_output_round_trip():
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Empty positional slots (#558 third pass).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "prose",
+    ["sma(,20) > close", "macd(12,,9) > 0", "sma(20,) > close"],
+)
+def test_indicator_empty_positional_slot_rejected(prose):
+    """`sma(,20)` etc. used to silently drop the empty slot and shift values."""
+    parsed = parse_entry_rule(prose)
+    assert isinstance(parsed, UnparsableRule)
+
+
+# ---------------------------------------------------------------------------
+# Singular `cross` operator.
+# ---------------------------------------------------------------------------
+
+
+def test_singular_cross_above():
+    parsed = parse_entry_rule("sma(20) cross above sma(50)")
+    assert isinstance(parsed, EntryRule)
+    assert parsed.when.op == "cross_above"
+
+
+def test_singular_cross_below():
+    parsed = parse_entry_rule("sma(20) cross below sma(50)")
+    assert isinstance(parsed, EntryRule)
+    assert parsed.when.op == "cross_below"
+
+
+# ---------------------------------------------------------------------------
+# Leading-dot numeric thresholds.
+# ---------------------------------------------------------------------------
+
+
+def test_predicate_leading_dot_number():
+    parsed = parse_entry_rule("rsi < .5")
+    assert isinstance(parsed, EntryRule)
+    assert parsed.when.rhs == ConstRef(value=0.5)
+
+
+# ---------------------------------------------------------------------------
+# Non-finite ConstRef values are rejected at construction time.
+# ---------------------------------------------------------------------------
+
+
+def test_const_ref_rejects_nan():
+    from pydantic import ValidationError as _VE
+
+    with pytest.raises(_VE):
+        ConstRef(value=float("nan"))
+
+
+def test_const_ref_rejects_inf():
+    from pydantic import ValidationError as _VE
+
+    with pytest.raises(_VE):
+        ConstRef(value=float("inf"))
+
+
+def test_const_ref_rejects_neg_inf():
+    from pydantic import ValidationError as _VE
+
+    with pytest.raises(_VE):
+        ConstRef(value=float("-inf"))
+
+
 @pytest.mark.parametrize(
     "value",
-    [1e-06, 0.0001, 0.5, 100.5],
+    [1e-13, 1e-06, 0.0001, 0.5, 100.5, 1e20],
 )
 def test_small_decimal_round_trip(value):
+    """Formatter/adapter must round-trip across the full float range, including
+    values for which `repr` emits scientific notation."""
     rule = EntryRule(
         side="long",
         when=Predicate(lhs=PriceRef(field="close"), op="gt", rhs=ConstRef(value=value)),
     )
     rendered = format_rules_for_prompt([rule])
-    assert "e-" not in rendered.lower()  # no scientific notation
     reparsed = parse_entry_rule(rendered)
     assert isinstance(reparsed, EntryRule)
     assert reparsed.when.rhs.value == pytest.approx(value)

--- a/backend/agents/plans/spec_dsl_issue_550.plan.md
+++ b/backend/agents/plans/spec_dsl_issue_550.plan.md
@@ -55,11 +55,25 @@ Module structure, top-to-bottom:
 4. `Source = Literal["close","high","low","open","volume","hl2","ohlc4"]`
    (default `"close"`). Restricted set per #537.
 5. `_SpecNode(BaseModel)` base — `extra="forbid"`.
-6. **IndicatorRef union** (discriminator `"kind"`). Param bounds MUST
-   match `strategy_lab/executor/indicators.py` exactly. Source of
-   truth bounds:
+6. **IndicatorRef union** (discriminator `"kind"`). Two distinct
+   sources of truth, since they live in different files:
 
-   | DSL node       | kind            | params (bounds, defaults) — must mirror `executor/indicators.py` |
+   - **Defaults** mirror
+     `strategy_lab/executor/indicators.py` exactly — RSI `period=14`,
+     MACD `fast=12 / slow=26 / signal=9`, Bollinger `period=20 /
+     num_std=2.0`, Stochastic `k_period=14 / d_period=3`, ATR/ADX
+     `period=14`.
+   - **Bound style** (`ge=2, le=400` etc.) mirrors the existing house
+     factor DSL at `strategy_lab/factors/models.py:53-101`. The
+     runtime helpers themselves accept any positive integer (the
+     coverage-probe registry at
+     `strategy_lab/executor/indicators.py:217-266` only enforces
+     positive-int / positive-float-for-`num_std`); we apply
+     sanity caps in the DSL the same way `factors/models.py` does,
+     so a spec authored at e.g. `period=10000` is rejected before it
+     reaches the runtime.
+
+   | DSL node       | kind            | params (defaults from `executor/indicators.py`; bound style from `factors/models.py`) |
    |----------------|-----------------|------------------------------------------------------------------|
    | `PriceRef`     | `"price"`       | `field: Source = "close"`                                        |
    | `ConstRef`     | `"const"`       | `value: float`                                                   |
@@ -76,6 +90,13 @@ Module structure, top-to-bottom:
    Note on `BollingerRef.num_std`: the `executor/indicators.py` registry
    marks `num_std` as a `float_kwargs` member, so it must be a positive
    float (`gt=0`); we mirror that here verbatim.
+
+   Why bounds at all when the runtime doesn't enforce them: the same
+   reason `factors/models.py` does — to reject obviously-broken spec
+   payloads (`period=0`, `period=10000`) at validation time rather
+   than letting pandas produce all-NaN columns silently. The chosen
+   caps are generous (≥200 for most, ≥400 for SMA/EMA) and match the
+   factor DSL exactly so the two stay in sync.
 
    Tuple-returning indicators (`MACDRef`, `BollingerRef`, `StochasticRef`)
    pick the scalar to expose via the literal `output` / `band` field as

--- a/backend/agents/plans/spec_dsl_issue_550.plan.md
+++ b/backend/agents/plans/spec_dsl_issue_550.plan.md
@@ -1,0 +1,393 @@
+---
+name: spec_dsl + spec_dsl_adapter (issue #550)
+overview: |
+  Step 1 of 8 from #537. Pure-addition of two new modules
+  (`spec_dsl.py`, `spec_dsl_adapter.py`) plus their unit tests under
+  `backend/agents/investment_team/`. Nothing else in the codebase imports
+  them yet; the wiring to `StrategySpec` is step 2 (separate issue).
+issue: 550
+parent_issue: 537
+isProject: false
+---
+
+# Plan: `spec_dsl.py` + `spec_dsl_adapter.py` (issue #550)
+
+## Why this is safe to land in isolation
+
+The two new modules are not imported from anywhere else in the codebase yet.
+`backend/agents/investment_team/models.py:194-210` still defines
+`StrategySpec` with `entry_rules: List[str]`, `exit_rules: List[str]`,
+`sizing_rules: List[str]`. Switching those fields to the new DSL is
+explicitly out of scope for this issue (step 2 of #537).
+
+Every consumer that today reads the prose lists — see
+`StrategySpec`-readers in `strategy_lab/agents/refinement.py`,
+`strategy_lab/orchestrator.py`, `strategy_lab/agents/alignment.py`,
+`strategy_lab/agents/analysis.py`,
+`strategy_lab/quality_gates/strategy_validator.py`, etc. — keeps reading
+strings. They are untouched.
+
+## House pattern we are copying
+
+`backend/agents/investment_team/strategy_lab/factors/models.py:39-357` is
+the authoritative house pattern for discriminated-union Pydantic DSLs in
+this team. We mirror it:
+
+- `_NodeBase(BaseModel)` with `model_config = ConfigDict(extra="forbid")`.
+- Every concrete node carries a `Literal[...]` discriminator
+  (`type` for factor models, `kind` here per #537's schema).
+- Top-level unions written as
+  `Annotated[Union[...], Field(discriminator="kind")]`.
+- Trailing `Model.model_rebuild()` for each union member so forward refs
+  resolve. (We have no self-recursive nodes in this step, but the
+  call-site is still required for forward-string annotations used by
+  `EntryRuleUnion` / `ExitRule` / `SizingRule`.)
+
+## Files to add
+
+### 1. `backend/agents/investment_team/strategy_lab/spec_dsl.py`
+
+Module structure, top-to-bottom:
+
+1. Header docstring referencing issue #537/#550.
+2. `from __future__ import annotations`; typing/Pydantic imports.
+3. `ComparisonOp = Literal["gt","lt","ge","le","eq","cross_above","cross_below"]`.
+4. `Source = Literal["close","high","low","open","volume","hl2","ohlc4"]`
+   (default `"close"`). Restricted set per #537.
+5. `_SpecNode(BaseModel)` base — `extra="forbid"`.
+6. **IndicatorRef union** (discriminator `"kind"`). Param bounds MUST
+   match `strategy_lab/executor/indicators.py` exactly. Source of
+   truth bounds:
+
+   | DSL node       | kind            | params (bounds, defaults) — must mirror `executor/indicators.py` |
+   |----------------|-----------------|------------------------------------------------------------------|
+   | `PriceRef`     | `"price"`       | `field: Source = "close"`                                        |
+   | `ConstRef`     | `"const"`       | `value: float`                                                   |
+   | `SMARef`       | `"sma"`         | `period: int = Field(ge=2, le=400)`, `source: Source = "close"`  |
+   | `EMARef`       | `"ema"`         | `period: int = Field(ge=2, le=400)`, `source: Source = "close"`  |
+   | `RSIRef`       | `"rsi"`         | `period: int = Field(default=14, ge=2, le=200)`, `source`        |
+   | `MACDRef`      | `"macd"`        | `fast=12 ge=2 le=200`, `slow=26 ge=3 le=400`, `signal=9 ge=2 le=100`, `output: Literal["macd","signal","histogram"] = "macd"`, `source` |
+   | `BollingerRef` | `"bollinger"`   | `period=20 ge=5 le=200`, `num_std=2.0 gt=0`, `band: Literal["upper","middle","lower"] = "middle"`, `source` |
+   | `ATRRef`       | `"atr"`         | `period=14 ge=2 le=200`                                          |
+   | `ADXRef`       | `"adx"`         | `period=14 ge=2 le=200`                                          |
+   | `StochasticRef`| `"stochastic"`  | `k_period=14 ge=2 le=200`, `d_period=3 ge=1 le=100`, `output: Literal["k","d"] = "k"` |
+   | `VWAPRef`      | `"vwap"`        | (no params; cumulative VWAP per OHLCV bars)                       |
+
+   Note on `BollingerRef.num_std`: the `executor/indicators.py` registry
+   marks `num_std` as a `float_kwargs` member, so it must be a positive
+   float (`gt=0`); we mirror that here verbatim.
+
+   Tuple-returning indicators (`MACDRef`, `BollingerRef`, `StochasticRef`)
+   pick the scalar to expose via the literal `output` / `band` field as
+   the issue specifies (this matches the runtime helpers in
+   `executor/indicators.py:45-145` returning `(macd, signal, histogram)`,
+   `(upper, middle, lower)`, `(%K, %D)`).
+
+   ```python
+   IndicatorRef = Annotated[
+       Union[PriceRef, ConstRef, SMARef, EMARef, RSIRef, MACDRef,
+             BollingerRef, ATRRef, ADXRef, StochasticRef, VWAPRef],
+       Field(discriminator="kind"),
+   ]
+   ```
+
+7. **Predicate**
+
+   ```python
+   class Predicate(_SpecNode):
+       lhs: IndicatorRef
+       op: ComparisonOp
+       rhs: IndicatorRef
+   ```
+
+   No `kind` discriminator on `Predicate` itself — it is not part of any
+   union. (Allowing `ConstRef` on either side covers numeric literals
+   such as `"RSI < 30"`; the adapter wraps bare numbers in `ConstRef`.)
+
+8. **EntryRule + UnparsableRule**
+
+   ```python
+   class EntryRule(_SpecNode):
+       kind: Literal["entry"] = "entry"
+       side: Literal["long","short"]
+       when: Predicate
+       note: str = ""
+
+   class UnparsableRule(_SpecNode):
+       kind: Literal["unparsable"] = "unparsable"
+       prose: str
+       reason: str = ""
+
+   EntryRuleUnion = Annotated[
+       Union[EntryRule, UnparsableRule],
+       Field(discriminator="kind"),
+   ]
+   ```
+
+   `UnparsableRule` is shared with the exit slot per the issue (same
+   discriminator key `"unparsable"`).
+
+9. **ExitRule union**
+
+   ```python
+   class TimeStopRule(_SpecNode):
+       kind: Literal["time_stop"] = "time_stop"
+       n_bars: int = Field(gt=0)
+       note: str = ""
+
+   class StopLossRule(_SpecNode):
+       kind: Literal["stop_loss"] = "stop_loss"
+       pct: float = Field(gt=0, le=1.0)   # 0.03 = 3 %
+       basis: Literal["entry_price","trailing_high","trailing_low"] = "entry_price"
+       note: str = ""
+
+   class TakeProfitRule(_SpecNode):
+       kind: Literal["take_profit"] = "take_profit"
+       pct: float = Field(gt=0)
+       note: str = ""
+
+   class SignalExitRule(_SpecNode):
+       kind: Literal["signal_exit"] = "signal_exit"
+       when: Predicate
+       note: str = ""
+
+   ExitRule = Annotated[
+       Union[TimeStopRule, StopLossRule, TakeProfitRule,
+             SignalExitRule, UnparsableRule],
+       Field(discriminator="kind"),
+   ]
+   ```
+
+10. **SizingRule union**
+
+    ```python
+    class FixedFractionSizing(_SpecNode):
+        kind: Literal["fixed_fraction"] = "fixed_fraction"
+        fraction: float = Field(gt=0, le=1.0)
+        note: str = ""
+
+    class VolatilityTargetSizing(_SpecNode):
+        kind: Literal["volatility_target"] = "volatility_target"
+        target_annual_vol: float = Field(gt=0)
+        note: str = ""
+
+    class FixedNotionalSizing(_SpecNode):
+        kind: Literal["fixed_notional"] = "fixed_notional"
+        notional_usd: float = Field(gt=0)
+        note: str = ""
+
+    class UnparsableSizing(_SpecNode):
+        kind: Literal["unparsable_sizing"] = "unparsable_sizing"
+        prose: str
+        reason: str = ""
+
+    SizingRule = Annotated[
+        Union[FixedFractionSizing, VolatilityTargetSizing,
+              FixedNotionalSizing, UnparsableSizing],
+        Field(discriminator="kind"),
+    ]
+    ```
+
+    `UnparsableSizing` uses a distinct kind value
+    (`"unparsable_sizing"`) so it cannot accidentally satisfy
+    `EntryRuleUnion` / `ExitRule` at validation time.
+
+11. Trailing `model_rebuild()` calls for every union member that uses a
+    forward-string annotation. (Strictly only needed for models that
+    reference other Pydantic models by name with `from __future__ import
+    annotations`; doing it for every union member keeps us aligned with
+    `factors/models.py:339-348` so future edits don't bite us.)
+
+12. **Public formatters** — drop-in replacements for today's prose
+    strings:
+
+    - `format_predicate(p: Predicate) -> str` — internal helper.
+      `"close > sma(20)"`, `"RSI < 30"`, `"sma(20) crosses above sma(50)"`.
+      Uses `_format_indicator_ref` that emits canonical short forms:
+      `"close"`/`"high"`/...for `PriceRef`, the bare number for
+      `ConstRef`, and `"sma(20)"`/`"rsi(14)"`/`"macd_signal(12,26,9)"`
+      etc. for the indicators.
+    - `format_rule(rule: EntryRule | ExitRule | UnparsableRule) -> str`
+      — internal helper that dispatches on `kind`:
+        - `"entry"` → `"long when close > sma(20)"` (omit side prefix
+          when implicit-long elsewhere; keep `"short when …"` explicit).
+        - `"time_stop"` → `"exit after {n} bars"`.
+        - `"stop_loss"` → `"stop loss {pct*100:g}%"`.
+        - `"take_profit"` → `"take profit {pct*100:g}%"`.
+        - `"signal_exit"` → `"exit when {predicate}"`.
+        - `"unparsable"` → the original `prose` verbatim.
+    - `format_rules_for_prompt(rules, separator=", ") -> str` — joins
+      with `separator`; empty list returns `""`.
+    - `format_sizing_rule(sizing: SizingRule) -> str`:
+        - `"fixed_fraction"` → `"risk {fraction*100:g}% per trade"`.
+        - `"volatility_target"` →
+          `"vol-target {target_annual_vol*100:g}%"`.
+        - `"fixed_notional"` → `"${notional_usd:.0f} per trade"`.
+        - `"unparsable_sizing"` → `prose` verbatim.
+
+      The output strings are chosen to round-trip through the adapter's
+      regex set in step 2 (i.e. feeding `format_sizing_rule` back into
+      `parse_sizing_rule` produces an equivalent structured rule).
+
+### 2. `backend/agents/investment_team/strategy_lab/spec_dsl_adapter.py`
+
+- Pure regex; no LLM; no Pydantic side-effects beyond constructing DSL
+  nodes.
+- `import re`; relative import of the DSL types from `.spec_dsl`.
+- Module-level compiled-regex constants for readability and perf.
+
+Public API:
+
+```python
+def parse_entry_rule(prose: str) -> EntryRule | UnparsableRule: ...
+def parse_exit_rule(prose: str) -> ExitRule: ...               # may be UnparsableRule
+def parse_sizing_rule(prose: str) -> SizingRule: ...           # may be UnparsableSizing
+def parse_rule_list(
+    prose_list: list[str],
+    kind: Literal["entry","exit"],
+) -> list: ...
+def parse_sizing_list(prose_list: list[str]) -> SizingRule: ...  # internal helper
+```
+
+Pattern order (first match wins; case-insensitive; tolerant of
+whitespace / `_` vs `-` in indicator names):
+
+1. **Comparison predicates** —
+   `(<indicator>|<price-field>|<number>)\s*(>|<|>=|<=|==|crosses?\s+(above|below))\s*(<indicator>|<price-field>|<number>)`.
+   `_parse_indicator_token` recognises `close|high|low|open|volume`,
+   bare numbers (→ `ConstRef`), and `name(arg1[,arg2,...])` for the
+   nine indicators. Default-args fall through to the DSL defaults.
+   Result: `Predicate`. For entry-slot use, wrap into
+   `EntryRule(side="long", when=…)`; the side is `"short"` only when
+   the prose contains `\bshort\b` (case-insensitive). For exit-slot
+   use, wrap into `SignalExitRule(when=…)` (with leading `"exit when"`
+   stripped from the predicate text before re-parsing).
+2. `^\s*exit\s+when\s+(.+)$` → recurse into the predicate parser.
+   Result: `SignalExitRule`.
+3. `^\s*exit\s+after\s+(\d+)\s*(bars?|days?|periods?)\s*$` →
+   `TimeStopRule(n_bars=int(...))`.
+4. `\bstop[- ]?loss[: ]\s*(\d+(?:\.\d+)?)\s*%` or
+   `\bstop[- ]?loss[: ]\s*(0?\.\d+)\b` →
+   `StopLossRule(pct=...)`. Percent form divides by 100; decimal form
+   used verbatim. Apply the `gt=0, le=1.0` bound; values that fail are
+   `UnparsableRule(reason="stop_loss out of bounds")`.
+5. `\b(take[- ]?profit|target)[: ]\s*(\d+(?:\.\d+)?)\s*%` →
+   `TakeProfitRule(pct=.../100)`. Same `gt=0` bound applies.
+6. `\b(risk|allocate)\s+(\d+(?:\.\d+)?)\s*%\s+per\s+trade\b` →
+   `FixedFractionSizing(fraction=.../100)`.
+7. `\bvol(?:atility)?-?target\s+(\d+(?:\.\d+)?)\s*%` →
+   `VolatilityTargetSizing(target_annual_vol=.../100)`.
+8. `\$(\d+(?:\.\d+)?)\s+(per\s+trade|notional)` →
+   `FixedNotionalSizing(notional_usd=...)`.
+9. Anything else →
+   `UnparsableRule(prose=prose.strip(), reason="no pattern matched")`
+   for entry/exit slots, or `UnparsableSizing(prose=...)` for sizing.
+
+Sizing-list collapse (`parse_sizing_list`):
+
+- Empty list → `UnparsableSizing(prose="", reason="empty")`.
+- Single element → return `parse_sizing_rule(elem)`.
+- Multiple elements → first parsable wins; the remaining entries are
+  concatenated into the chosen variant's `note` field (`"; ".join`).
+- All-unparsable → return
+  `UnparsableSizing(prose="; ".join(prose_list), reason="no pattern matched")`.
+
+### 3. `backend/agents/investment_team/tests/test_spec_dsl.py`
+
+- One round-trip test per union member:
+  `dumped = m.model_dump_json(); reread = type(m).model_validate_json(dumped)`
+  with `assert reread == m`.
+- Discriminator-dispatch tests: `IndicatorRef`-style adapter built via
+  `pydantic.TypeAdapter(IndicatorRef)`; feed `{"kind":"rsi"}` → assert
+  `RSIRef`. Repeat for `EntryRuleUnion`, `ExitRule`, `SizingRule`.
+- Bounds-violation tests (must raise `ValidationError`):
+  - `SMARef(period=1)`, `SMARef(period=401)`.
+  - `BollingerRef(period=20, num_std=-1)`.
+  - `StopLossRule(pct=-0.01)`, `StopLossRule(pct=1.5)`.
+  - `Predicate(lhs=..., op="bogus", rhs=...)`.
+  - Missing required: `MACDRef()` with no `fast` etc. (these default,
+    so the bounds-test is `MACDRef(fast=1)` to trip `ge=2`).
+- Forbid-extra:
+  `RSIRef.model_validate({"kind":"rsi","period":14,"foo":1})` raises.
+- `format_rules_for_prompt` / `format_sizing_rule` golden strings:
+  - `format_rule(EntryRule(side="long", when=Predicate(lhs=PriceRef(field="close"), op="gt", rhs=SMARef(period=20)))) == "long when close > sma(20)"`.
+  - `format_rule(EntryRule(side="long", when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30)))) == "long when rsi(14) < 30"`.
+  - `format_rule(TimeStopRule(n_bars=5)) == "exit after 5 bars"`.
+  - `format_rule(StopLossRule(pct=0.03)) == "stop loss 3%"`.
+  - `format_rule(TakeProfitRule(pct=0.05)) == "take profit 5%"`.
+  - `format_rule(SignalExitRule(when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)))) == "exit when rsi(14) > 70"`.
+  - `format_sizing_rule(FixedFractionSizing(fraction=0.02)) == "risk 2% per trade"`.
+  - `format_sizing_rule(VolatilityTargetSizing(target_annual_vol=0.10)) == "vol-target 10%"`.
+  - `format_sizing_rule(FixedNotionalSizing(notional_usd=50000)) == "$50000 per trade"`.
+
+### 4. `backend/agents/investment_team/tests/test_spec_dsl_adapter.py`
+
+- Full pattern matrix (one parametrised test per row):
+  - `"close > sma(20)"` → `EntryRule(side="long", when=Predicate(PriceRef("close"), "gt", SMARef(period=20)))`.
+  - `"RSI < 30"` → `EntryRule(side="long", when=Predicate(RSIRef(period=14), "lt", ConstRef(value=30)))`.
+  - `"short when rsi(70) > 70"` → `EntryRule(side="short", ...)`.
+  - `"sma(20) crosses above sma(50)"` → `EntryRule(..., op="cross_above", ...)`.
+  - `"exit when RSI > 70"` → `SignalExitRule(when=Predicate(RSIRef(period=14), "gt", ConstRef(value=70)))`.
+  - `"exit after 5 bars"` / `"exit after 10 days"` → `TimeStopRule(n_bars=5)` / `TimeStopRule(n_bars=10)`.
+  - `"stop loss 3%"` / `"stop-loss: 0.03"` → `StopLossRule(pct=0.03)`.
+  - `"take profit 5%"` / `"target 5%"` → `TakeProfitRule(pct=0.05)`.
+  - `"risk 2% per trade"` / `"allocate 2% per trade"` → `FixedFractionSizing(fraction=0.02)`.
+  - `"vol-target 10%"` / `"volatility-target 10%"` → `VolatilityTargetSizing(target_annual_vol=0.10)`.
+  - `"$50000 per trade"` / `"$50000 notional"` → `FixedNotionalSizing(notional_usd=50000)`.
+- Unparsable prose:
+  - `parse_entry_rule("enter on bullish momentum")` →
+    `UnparsableRule(prose="enter on bullish momentum", reason="no pattern matched")`.
+  - `parse_exit_rule("vibes")` → `UnparsableRule(...)`.
+  - `parse_sizing_rule("size up if confident")` → `UnparsableSizing(prose="size up if confident", ...)`.
+- Sizing-list collapse:
+  - `parse_sizing_list([])` → `UnparsableSizing(prose="", reason="empty")`.
+  - `parse_sizing_list(["risk 2% per trade"])` → `FixedFractionSizing(fraction=0.02)`.
+  - `parse_sizing_list(["risk 2% per trade", "max 5% gross"])` →
+    `FixedFractionSizing(fraction=0.02, note="max 5% gross")`.
+  - `parse_sizing_list(["foo", "bar"])` →
+    `UnparsableSizing(prose="foo; bar", reason="no pattern matched")`.
+- Round-trip via formatters: for each successful parse case, feed the
+  result through `format_rule` / `format_sizing_rule` and assert
+  re-parsing it returns an equal structured rule. (This is a cheap
+  smoke-test that the formatter strings stay regex-compatible.)
+
+## Execution order
+
+1. Write `spec_dsl.py` (DSL types + formatters).
+2. Write `test_spec_dsl.py` and iterate against
+   `pytest backend/agents/investment_team/tests/test_spec_dsl.py -v`
+   until green.
+3. Write `spec_dsl_adapter.py` (regex parser).
+4. Write `test_spec_dsl_adapter.py` and iterate.
+5. Run `ruff check` and `ruff format` on the two new modules; both
+   must come back clean before commit.
+6. Sanity-grep to confirm no other file imports the new modules
+   yet — `git grep -n "spec_dsl"` should match only the four new
+   files.
+7. Commit + push to `claude/plan-issue-550-Yjl26`; open a draft PR
+   that references #550 and notes that wiring to `StrategySpec`
+   (step 2 of #537) is intentionally deferred.
+
+## Acceptance gates (from the issue)
+
+- [ ] `spec_dsl.py` defines every union member listed in the issue,
+      with `extra="forbid"` everywhere.
+- [ ] `spec_dsl_adapter.py` matches the documented prose patterns.
+- [ ] `pytest backend/agents/investment_team/tests/test_spec_dsl.py
+      backend/agents/investment_team/tests/test_spec_dsl_adapter.py -v`
+      passes.
+- [ ] `ruff check backend/agents/investment_team/strategy_lab/spec_dsl.py
+      backend/agents/investment_team/strategy_lab/spec_dsl_adapter.py`
+      is clean.
+- [ ] `git grep -n "from .* import .*spec_dsl"` shows no consumers
+      besides the new test files.
+
+## Out of scope (deferred)
+
+- Changing `StrategySpec.entry_rules` / `exit_rules` / `sizing_rules`
+  from `list[str]` to the DSL types — that's step 2 of #537.
+- Updating prompts, validators, alignment, analysis, orchestrator,
+  refinement, zero-trade-repair, or quality-gate code paths to consume
+  the DSL.
+- Compiler (#C), SpecReadinessGate (#D2), CodeConformanceGate (#E1),
+  deterministic alignment (#G).


### PR DESCRIPTION
## Summary

Implementation plan for #550 (step 1 of 8 from #537). Adds
`backend/agents/plans/spec_dsl_issue_550.plan.md`; no code yet.

The plan covers:

- **`spec_dsl.py`** — full schema for `IndicatorRef` (11 variants),
  `Predicate`, `EntryRule` + `UnparsableRule`, `ExitRule` union
  (`TimeStop`, `StopLoss`, `TakeProfit`, `SignalExit`, `Unparsable`),
  `SizingRule` union, plus public formatters (`format_rules_for_prompt`,
  `format_sizing_rule`). Each indicator's param bounds are pinned to
  `strategy_lab/executor/indicators.py` so the DSL and runtime helpers
  can't drift.
- **`spec_dsl_adapter.py`** — first-match-wins regex matrix covering
  every prose pattern the issue calls out, plus the sizing-list-collapse
  rules.
- **Tests** — round-trip serialisation per union member, discriminator
  dispatch, bounds-violation cases, formatter golden strings, the full
  adapter pattern matrix, and a formatter↔adapter round-trip smoke test
  so the two stay in sync.
- Explicit out-of-scope boundary: `StrategySpec` itself is unchanged —
  that wiring is step 2 of #537.

## Test plan

- [ ] Implement `spec_dsl.py` and run
      `pytest backend/agents/investment_team/tests/test_spec_dsl.py -v`.
- [ ] Implement `spec_dsl_adapter.py` and run
      `pytest backend/agents/investment_team/tests/test_spec_dsl_adapter.py -v`.
- [ ] `ruff check` clean on both new modules.
- [ ] `git grep "spec_dsl"` returns only the four new files (no
      premature consumers).

Closes part of #537. Resolves #550.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SoZa5uszvJV9o7NHgd5bqe)_