### PR TITLE
investment-team: strategy lab tactical hardening (#547)

### DIFF
--- a/backend/agents/investment_team/models.py
+++ b/backend/agents/investment_team/models.py
@@ -762,6 +762,14 @@ class StrategyLabRecord(BaseModel):
     refinement_rounds: int = 0
     quality_gate_results: List[Dict[str, Any]] = Field(default_factory=list)
     strategy_code: Optional[str] = None
+    original_spec: Optional[StrategySpec] = Field(
+        default=None,
+        description="Ideation-time spec before any refinement-driven mutation; null on legacy rows.",
+    )
+    original_code: Optional[str] = Field(
+        default=None,
+        description="Ideation-time strategy code before refinement; null on legacy rows.",
+    )
     signal_intelligence_brief: Optional[Dict[str, Any]] = Field(
         default=None,
         description="Signal Intelligence Expert JSON (brief_version, themes, …) or skipped metadata; null for legacy rows.",

--- a/backend/agents/investment_team/strategy_lab/agents/refinement.py
+++ b/backend/agents/investment_team/strategy_lab/agents/refinement.py
@@ -43,17 +43,14 @@ Risk limits: {risk_limits}
 
 ## Instructions
 1. Diagnose the root cause from the failure details.
-2. Fix the code (and optionally adjust strategy rules if the failure reveals a design flaw).
+2. Fix the code only. Do NOT alter the strategy spec (entry/exit/sizing
+   rules, risk limits, hypothesis) — spec changes go through ideation,
+   not refinement.
 3. Ensure your fix doesn't re-introduce any previously fixed issues.
 
 Return ONLY a JSON object with no markdown:
 {{
   "strategy_code": "the complete fixed Python code",
-  "entry_rules": ["rule 1", ...],
-  "exit_rules": ["rule 1", ...],
-  "sizing_rules": ["rule 1", ...],
-  "risk_limits": {{"max_position_pct": 5, "stop_loss_pct": 3}},
-  "hypothesis": "hypothesis (unchanged or updated)",
   "changes_made": "1-2 sentence summary of what you changed and why"
 }}
 """

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -277,6 +277,52 @@ class StrategyLabOrchestrator:
         metrics = compute_metrics([], config.initial_capital, config.start_date, config.end_date)
         execution_succeeded = False
         market_data: Optional[Dict[str, List[OHLCVBar]]] = None
+        # #547 item 7: track whether the refinement loop exhausted the round
+        # cap so the persisted record's ``status`` is queryable rather than
+        # buried in logs. Set at each of the three break-on-max sites
+        # (validation / execution / evaluation phases).
+        max_rounds_exhausted = False
+
+        # ── Phase 1b: PRE-SYNTHESIS SPEC GATING (#547 item 1) ─────────
+        # Validate the ideation-time spec ONCE before entering the
+        # refinement loop. Refinement is code-only post-#547 item 2, so
+        # the spec cannot drift between rounds; revalidating per round
+        # was redundant. A critical failure here short-circuits the
+        # cycle without ever calling run_strategy_code or fetching
+        # market data.
+        pre_spec_gates = self.strategy_validator.validate(spec)
+        for g in pre_spec_gates:
+            g.refinement_round = -1
+        all_gate_results.extend(pre_spec_gates)
+        pre_synthesis_criticals = [
+            g for g in pre_spec_gates if not g.passed and g.severity == "critical"
+        ]
+        if pre_synthesis_criticals:
+            emit(
+                "coding",
+                {
+                    "sub_phase": "failed",
+                    "phase": "pre_synthesis",
+                    "checks_total": len(pre_spec_gates),
+                    "checks_passed": sum(1 for g in pre_spec_gates if g.passed),
+                },
+            )
+            return self._build_short_circuit_record(
+                spec=spec,
+                config=config,
+                code=code,
+                original_spec=original_spec,
+                original_code=original_code,
+                rationale=rationale,
+                all_gate_results=all_gate_results,
+                refinement_attempts=refinement_attempts,
+                short_circuit_status="failed: spec_validation",
+                short_circuit_reason=(
+                    "Spec validation failed before code synthesis: "
+                    + "; ".join(g.details for g in pre_synthesis_criticals)
+                ),
+                emit=emit,
+            )
 
         # ── Phase 2: CODE REFINEMENT LOOP ─────────────────────────────
         # Iterate up to MAX_CODE_REFINEMENT_ROUNDS, refining the
@@ -288,11 +334,11 @@ class StrategyLabOrchestrator:
         for round_num in range(MAX_CODE_REFINEMENT_ROUNDS):
             round_gate_results: List[QualityGateResult] = []
 
-            # ── 2a: VALIDATE (spec + code safety) ────────────────────
+            # ── 2a: VALIDATE (code safety only — spec was validated
+            #       pre-synthesis and is immutable for this cycle, see
+            #       #547 items 1 & 2).
             emit("coding", {"sub_phase": "started", "refinement_round": round_num})
-            spec_gates = self.strategy_validator.validate(spec)
             code_gates = self.code_safety_checker.check(code)
-            round_gate_results.extend(spec_gates)
             round_gate_results.extend(code_gates)
             for g in round_gate_results:
                 g.refinement_round = round_num
@@ -345,6 +391,7 @@ class StrategyLabOrchestrator:
                     logger.warning(
                         "Max code refinement rounds reached on validation for %s", spec.strategy_id
                     )
+                    max_rounds_exhausted = True
                     break
 
             emit(
@@ -428,6 +475,7 @@ class StrategyLabOrchestrator:
                     logger.warning(
                         "Max code refinement rounds reached on execution for %s", spec.strategy_id
                     )
+                    max_rounds_exhausted = True
                     break
 
             # ── 2d: COLLECT TRADES ────────────────────────────────────
@@ -577,6 +625,7 @@ class StrategyLabOrchestrator:
                         "Max code refinement rounds reached on evaluation for %s", spec.strategy_id
                     )
                     execution_succeeded = True  # anomalous but code is correct
+                    max_rounds_exhausted = True
                     break
 
             # All gates passed — code is clean and backtest is sound
@@ -978,6 +1027,19 @@ class StrategyLabOrchestrator:
         # ── Phase 4: RECORD ───────────────────────────────────────────
         now_iso = datetime.now(timezone.utc).isoformat()
 
+        # #547 item 7: queryable cap-exhaustion status. The evaluation-phase
+        # site sets ``execution_succeeded=True`` ("anomalous but code is
+        # correct"), so without this branch those cycles would silently
+        # report ``status="completed"`` despite never reaching a clean
+        # backtest. With the strict reading, all three exhaustion sites now
+        # flip status to ``failed: max_refinement_rounds``.
+        if max_rounds_exhausted:
+            backtest_status = "failed: max_refinement_rounds"
+        elif execution_succeeded:
+            backtest_status = "completed"
+        else:
+            backtest_status = "failed"
+
         backtest_id = f"bt-{uuid.uuid4().hex[:8]}"
         backtest_record = BacktestRecord(
             backtest_id=backtest_id,
@@ -987,7 +1049,7 @@ class StrategyLabOrchestrator:
             submitted_by="strategy_lab_v2",
             submitted_at=now_iso,
             completed_at=now_iso,
-            status="completed" if execution_succeeded else "failed",
+            status=backtest_status,
             result=metrics,
             trades=trades,
         )
@@ -1344,13 +1406,85 @@ class StrategyLabOrchestrator:
 
     @staticmethod
     def _apply_updates(spec: StrategySpec, updates: Dict[str, Any], code: str) -> StrategySpec:
-        """Apply refinement updates to the strategy spec."""
+        """Apply refinement updates: code only.
+
+        The spec (entry/exit/sizing rules, risk limits, hypothesis) is
+        immutable post-ideation (#547 item 2). ``updates`` is kept in the
+        signature because callers still read ``updates['changes_made']``
+        for logging, but no spec fields are merged here.
+        """
         data = spec.model_dump()
-        for key in ("entry_rules", "exit_rules", "sizing_rules", "risk_limits", "hypothesis"):
-            if key in updates:
-                data[key] = updates[key]
         data["strategy_code"] = code
         return StrategySpec.model_validate(data)
+
+    def _build_short_circuit_record(
+        self,
+        *,
+        spec: StrategySpec,
+        config: BacktestConfig,
+        code: str,
+        original_spec: StrategySpec,
+        original_code: str,
+        rationale: str,
+        all_gate_results: List[QualityGateResult],
+        refinement_attempts: List[str],
+        short_circuit_status: str,
+        short_circuit_reason: str,
+        emit: PhaseCallback,
+    ) -> StrategyLabRecord:
+        """Persist a failed cycle that exited before code execution.
+
+        Used by the pre-synthesis spec gate (#547 item 1) so that
+        critical spec failures short-circuit without ever running
+        ``run_strategy_code`` or fetching market data. The record still
+        flows through ``convergence_tracker`` so failed specs influence
+        diversity directives on the next cycle.
+        """
+        now_iso = datetime.now(timezone.utc).isoformat()
+
+        backtest_record = BacktestRecord(
+            backtest_id=f"bt-{uuid.uuid4().hex[:8]}",
+            strategy_id=spec.strategy_id,
+            strategy=spec,
+            config=config,
+            submitted_by="strategy_lab_v2",
+            submitted_at=now_iso,
+            completed_at=now_iso,
+            status=short_circuit_status,
+            result=compute_metrics([], config.initial_capital, config.start_date, config.end_date),
+            trades=[],
+        )
+
+        lab_record_id = f"lab-{uuid.uuid4().hex[:8]}"
+        record = StrategyLabRecord(
+            lab_record_id=lab_record_id,
+            strategy=spec,
+            backtest=backtest_record,
+            is_winning=False,
+            strategy_rationale=rationale,
+            analysis_narrative=short_circuit_reason,
+            created_at=now_iso,
+            refinement_rounds=len(refinement_attempts),
+            quality_gate_results=[g.model_dump() for g in all_gate_results],
+            strategy_code=code,
+            original_spec=original_spec,
+            original_code=original_code,
+        )
+
+        self.convergence_tracker.record(spec, all_gate_results)
+
+        emit(
+            "complete",
+            {
+                "record_id": lab_record_id,
+                "is_winning": False,
+                "metrics": backtest_record.result.model_dump(),
+                "refinement_rounds": len(refinement_attempts),
+                "short_circuit": short_circuit_status,
+            },
+        )
+
+        return record
 
     def _fetch_market_data(
         self,

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -292,22 +292,27 @@ class StrategyLabOrchestrator:
         # market data.
         #
         # The "strategy_code is missing" critical is excluded from
-        # short-circuit eligibility: that's a code-generation failure
-        # (ideation produced an empty/whitespace strategy_code), and the
-        # refinement loop's existing code-safety + regeneration paths
-        # are equipped to repair it. Short-circuiting on that critical
-        # would regress a previously-recoverable case into an outright
-        # failure.
-        pre_spec_gates = self.strategy_validator.validate(spec)
+        # short-circuit eligibility AND from the persisted gate history:
+        # that's a code-generation failure (ideation produced an empty /
+        # whitespace strategy_code), and the refinement loop's existing
+        # code-safety + regeneration paths are equipped to repair it.
+        # Short-circuiting on that critical would regress a previously-
+        # recoverable case into an outright failure; persisting it would
+        # leave a permanently-unresolved critical on the record (the
+        # generic refinement loop never re-runs StrategySpecValidator),
+        # which would also reach convergence_tracker.record() as an
+        # unresolved spec failure.
+        pre_spec_gates_raw = self.strategy_validator.validate(spec)
+        pre_spec_gates = [
+            g
+            for g in pre_spec_gates_raw
+            if not (g.severity == "critical" and g.details.startswith("strategy_code is missing"))
+        ]
         for g in pre_spec_gates:
             g.refinement_round = -1
         all_gate_results.extend(pre_spec_gates)
         pre_synthesis_criticals = [
-            g
-            for g in pre_spec_gates
-            if not g.passed
-            and g.severity == "critical"
-            and not g.details.startswith("strategy_code is missing")
+            g for g in pre_spec_gates if not g.passed and g.severity == "critical"
         ]
         if pre_synthesis_criticals:
             emit(

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -249,6 +249,11 @@ class StrategyLabOrchestrator:
             strategy_code=code,
         )
 
+        # Snapshot ideation outputs so reviewers can compare against any
+        # refinement-driven mutation persisted on the final record (#547).
+        original_spec = spec.model_copy(deep=True)
+        original_code = code
+
         # Override generic fee defaults with asset-class-appropriate values
         if config.transaction_cost_bps == 5.0 and config.slippage_bps == 2.0:
             fee_defaults = get_fee_defaults(spec.asset_class)
@@ -999,6 +1004,8 @@ class StrategyLabOrchestrator:
             refinement_rounds=len(refinement_attempts),
             quality_gate_results=[g.model_dump() for g in all_gate_results],
             strategy_code=code,
+            original_spec=original_spec,
+            original_code=original_code,
         )
 
         # Update convergence tracker

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -1278,6 +1278,41 @@ class StrategyLabOrchestrator:
                 failure_reason="invalid_spec_updates",
             )
 
+        # ── Re-validate the spec after repair-driven mutation ────────
+        # The pre-synthesis gate (#547 item 1) only runs once at ideation.
+        # Zero-trade repair may mutate entry/exit/sizing rules, risk_limits,
+        # hypothesis, or signal_definition via the whitelist; those bypass
+        # the gate. A Pydantic-valid risk_limits value (e.g.
+        # max_position_pct=99) can still be a critical spec failure under
+        # StrategySpecValidator. Re-validate before committing.
+        if report.proposed_spec_updates:
+            post_repair_spec_gates = self.strategy_validator.validate(proposed_spec)
+            for g in post_repair_spec_gates:
+                g.refinement_round = round_num
+                g.gate_name = f"zero_trade_repair_{g.gate_name}"
+            spec_criticals = [
+                g for g in post_repair_spec_gates if not g.passed and g.severity == "critical"
+            ]
+            if spec_criticals:
+                zero_trade_attempts.append(
+                    f"invalid_spec_after_repair ({report.root_cause_category}): "
+                    f"{'; '.join(g.details for g in spec_criticals)[:160]}"
+                )
+                emit(
+                    "coding",
+                    {
+                        "sub_phase": "zero_trade_repair_rejected",
+                        "refinement_round": round_num,
+                        "reason": "invalid_spec_after_repair",
+                        "details": "; ".join(g.details for g in spec_criticals)[:400],
+                    },
+                )
+                return _ZeroTradeRepairOutcome(
+                    committed=False,
+                    new_gates=safety_gates + post_repair_spec_gates,
+                    failure_reason="invalid_spec_after_repair",
+                )
+
         repair_exec = run_strategy_code(
             report.proposed_code, market_data, config, strategy=proposed_spec
         )

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -287,15 +287,27 @@ class StrategyLabOrchestrator:
         # Validate the ideation-time spec ONCE before entering the
         # refinement loop. Refinement is code-only post-#547 item 2, so
         # the spec cannot drift between rounds; revalidating per round
-        # was redundant. A critical failure here short-circuits the
+        # was redundant. A critical SPEC failure here short-circuits the
         # cycle without ever calling run_strategy_code or fetching
         # market data.
+        #
+        # The "strategy_code is missing" critical is excluded from
+        # short-circuit eligibility: that's a code-generation failure
+        # (ideation produced an empty/whitespace strategy_code), and the
+        # refinement loop's existing code-safety + regeneration paths
+        # are equipped to repair it. Short-circuiting on that critical
+        # would regress a previously-recoverable case into an outright
+        # failure.
         pre_spec_gates = self.strategy_validator.validate(spec)
         for g in pre_spec_gates:
             g.refinement_round = -1
         all_gate_results.extend(pre_spec_gates)
         pre_synthesis_criticals = [
-            g for g in pre_spec_gates if not g.passed and g.severity == "critical"
+            g
+            for g in pre_spec_gates
+            if not g.passed
+            and g.severity == "critical"
+            and not g.details.startswith("strategy_code is missing")
         ]
         if pre_synthesis_criticals:
             emit(

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -624,7 +624,12 @@ class StrategyLabOrchestrator:
                     logger.warning(
                         "Max code refinement rounds reached on evaluation for %s", spec.strategy_id
                     )
-                    execution_succeeded = True  # anomalous but code is correct
+                    # Do NOT flip execution_succeeded — even if the code is
+                    # technically correct, the cycle exhausted its rounds on
+                    # an unresolved anomaly. Leaving execution_succeeded=False
+                    # ensures is_winning stays False so paper-trading does
+                    # not fire on a "failed: max_refinement_rounds" record
+                    # (#547 review feedback).
                     max_rounds_exhausted = True
                     break
 
@@ -1284,7 +1289,11 @@ class StrategyLabOrchestrator:
         # hypothesis, or signal_definition via the whitelist; those bypass
         # the gate. A Pydantic-valid risk_limits value (e.g.
         # max_position_pct=99) can still be a critical spec failure under
-        # StrategySpecValidator. Re-validate before committing.
+        # StrategySpecValidator. Re-validate before committing; on accept,
+        # carry the gates forward in ``new_gates`` so warnings (e.g.
+        # hypothesis/rules drift on a repaired spec) reach the persisted
+        # ``quality_gate_results`` rather than being silently dropped.
+        post_repair_spec_gates: List[QualityGateResult] = []
         if report.proposed_spec_updates:
             post_repair_spec_gates = self.strategy_validator.validate(proposed_spec)
             for g in post_repair_spec_gates:
@@ -1341,7 +1350,7 @@ class StrategyLabOrchestrator:
             )
             return _ZeroTradeRepairOutcome(
                 committed=False,
-                new_gates=safety_gates + [failure_gate],
+                new_gates=safety_gates + post_repair_spec_gates + [failure_gate],
                 failure_reason=f"re_execution_failed: {repair_exec.error_type}",
             )
 
@@ -1389,7 +1398,7 @@ class StrategyLabOrchestrator:
             )
             return _ZeroTradeRepairOutcome(
                 committed=False,
-                new_gates=safety_gates + new_anomaly_gates,
+                new_gates=safety_gates + post_repair_spec_gates + new_anomaly_gates,
                 failure_reason="anomaly_after_repair",
             )
 
@@ -1415,7 +1424,7 @@ class StrategyLabOrchestrator:
             new_trades=new_trades,
             new_metrics=new_metrics,
             new_exec_result=repair_exec,
-            new_gates=safety_gates + new_anomaly_gates,
+            new_gates=safety_gates + post_repair_spec_gates + new_anomaly_gates,
             changes_made=change_summary,
         )
 

--- a/backend/agents/investment_team/strategy_lab/prompts/refinement_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/refinement_system.md
@@ -11,7 +11,11 @@ Your task: fix and refine a generated trading strategy's Python code based on er
 1. **DIAGNOSE** the root cause of the failure from the error details
 2. **FIX** the code to address the specific issue
 3. **VERIFY** your fix doesn't introduce new problems
-4. **OPTIONALLY REFINE** the strategy rules if the failure reveals a design flaw (not just a code bug)
+
+You only fix code. The strategy spec (hypothesis, entry/exit/sizing rules,
+risk limits) is immutable here — if the failure reveals a design flaw in
+the spec itself, surface it in `changes_made`; spec changes are done by
+ideation, not refinement.
 
 ## Common failure types and how to handle them
 
@@ -27,9 +31,12 @@ Your task: fix and refine a generated trading strategy's Python code based on er
 - If profit factor too extreme (>10): likely overfitting
 
 ### Quality gate: strategy spec validation
-- Fix the strategy rules to match the asset class
-- Ensure entry/exit rules are non-empty
-- Adjust risk limits to reasonable ranges
+- These are spec-level issues (entry/exit rules missing, risk limits
+  out of range, asset-class mismatch). You cannot fix them here — the
+  spec is immutable post-ideation.
+- Describe the spec defect in `changes_made` and emit the best
+  code you can against the current (broken) spec; the orchestrator
+  will route the next iteration back through ideation if needed.
 
 ### Quality gate: code safety
 - Remove any banned imports or function calls
@@ -78,13 +85,9 @@ Return ONLY a JSON object with:
 ```json
 {
   "strategy_code": "the complete fixed Python code",
-  "entry_rules": ["updated rule 1", ...],
-  "exit_rules": ["updated rule 1", ...],
-  "sizing_rules": ["updated rule 1", ...],
-  "risk_limits": {"max_position_pct": 5, "stop_loss_pct": 3},
-  "hypothesis": "updated hypothesis if changed, or original",
   "changes_made": "1-2 sentence summary of what you changed and why"
 }
 ```
 
-If only the code needed fixing (not the strategy), keep the rules/hypothesis identical to the input.
+Refinement is code-only. The spec is fixed for this cycle — emit just
+the corrected Python and a short note explaining the fix.

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -616,17 +616,27 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
                         worklist.append((helper, helper_receivers))
                 continue
             # 3. <local_name>(...) — closure defined in the same scope.
-            #    Closures see two sources of context bindings: parameters
-            #    bound at the call site (``def enter(c): ...; enter(ctx)``
-            #    binds ``c`` to ``ctx``) AND outer-scope captures
-            #    (``def enter(): ctx.submit_order(...)`` references the
-            #    enclosing frame's ``ctx``). We union both so either
-            #    pattern is recognised.
+            #    Closures see two sources of context bindings:
+            #    - Parameters bound at the call site (``def enter(c): ...;
+            #      enter(ctx)`` binds ``c`` to ``ctx``).
+            #    - Outer-scope captures (``def enter(): ctx.submit_order(
+            #      ...)`` references the enclosing frame's ``ctx``).
+            #    Captured names are visible only when the closure does
+            #    NOT shadow them with its own parameter — ``def
+            #    enter(ctx): ...; enter(bar)`` rebinds ``ctx`` to ``bar``,
+            #    so the outer ``ctx`` is no longer reachable as a
+            #    receiver inside the closure body.
             if isinstance(sub.func, ast.Name):
                 local = local_defs.get(sub.func.id)
                 if local is not None:
                     call_bound = _resolve_helper_receivers(sub, local, receiver_names)
-                    closure_receivers = receiver_names | call_bound
+                    closure_param_names = frozenset(
+                        arg.arg for arg in local.args.args if arg.arg != "self"
+                    )
+                    # Outer receivers are captured by closure UNLESS a
+                    # parameter of the same name shadows them.
+                    captured = receiver_names - closure_param_names
+                    closure_receivers = captured | call_bound
                     if (id(local), closure_receivers) not in visited_keys:
                         worklist.append((local, closure_receivers))
 
@@ -663,24 +673,33 @@ def _submit_order_side(node: ast.Call) -> Optional[str]:
     return None
 
 
-def _calls_form_entry_exit_pair(calls: List[ast.Call]) -> bool:
-    """True iff the collected submit_order calls plausibly include both an
-    entry and an exit leg.
+def _submit_order_symbol(node: ast.Call) -> Optional[str]:
+    """Best-effort extraction of the ``symbol`` value from a submit_order
+    call. Returns the literal string when the call uses a string Constant,
+    else None when the symbol is computed/dynamic or missing.
 
-    The runtime contract closes a position by submitting an opposite-side
-    order (``LONG`` closes a ``SHORT``, ``SHORT`` closes a ``LONG``) with
-    ``qty == position.qty``. We approximate statically:
+    Dynamic-symbol calls (``symbol=bar.symbol`` etc.) all share the same
+    runtime symbol per ``on_bar`` invocation, so the entry/exit grouping
+    treats them as one logical group (key=None).
+    """
+    for kw in node.keywords:
+        if kw.arg != "symbol":
+            continue
+        if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+            return kw.value.value
+    return None
 
-    * If any call carries ``attached_stop_loss`` / ``attached_take_profit``
-      (a non-None bracket leg), it brings its own exit.
-    * Otherwise, require both ``LONG`` and ``SHORT`` to appear across the
-      collected calls. Same-side multiplicity (``LONG`` + ``LONG``) is one-
-      sided and fails the gate.
-    * Calls whose side cannot be determined statically (computed expression
-      that picks the direction from position / signal state) are treated
-      optimistically — even a single such call passes, since legitimate
-      strategies route both entry and exit through one call site whose
-      side is a runtime branch.
+
+def _group_forms_entry_exit_pair(calls: List[ast.Call]) -> bool:
+    """True iff a single-symbol group of submit_order calls plausibly
+    contains both an entry and an opposite-side exit leg.
+
+    * Any call carrying a non-None ``attached_stop_loss`` /
+      ``attached_take_profit`` bracket leg satisfies the group on its own.
+    * Otherwise require both ``LONG`` and ``SHORT`` to appear across the
+      group's calls. Same-side multiplicity (``LONG`` + ``LONG``) fails.
+    * Unknown / dynamic side values are treated optimistically — the
+      runtime branch may pick either direction.
     """
     if any(_has_attached_exit_kwarg(c) for c in calls):
         return True
@@ -692,15 +711,30 @@ def _calls_form_entry_exit_pair(calls: List[ast.Call]) -> bool:
             has_unknown = True
         else:
             sides_seen.add(side)
-    # Distinct LONG + SHORT means at least one is opposite-side closing the other.
     if "LONG" in sides_seen and "SHORT" in sides_seen:
         return True
-    # Dynamic side: accept any number of calls (including a single one) that
-    # route entry/exit through a runtime branch — false-failing these is
-    # worse than letting the backtest surface a genuinely one-sided runtime.
     if has_unknown:
         return True
     return False
+
+
+def _calls_form_entry_exit_pair(calls: List[ast.Call]) -> bool:
+    """True iff the collected submit_order calls plausibly form an
+    entry+exit pair on EVERY symbol they target.
+
+    The engine closes positions per-symbol — ``portfolio.positions[bar.symbol]``
+    is looked up against the order's own symbol — so a strategy that
+    opens ``LONG`` on ``"SPY"`` and ``SHORT`` on ``"TLT"`` has two
+    open entries and zero exits, not a balanced pair. The gate groups
+    calls by their literal ``symbol`` value (dynamic / computed symbols
+    share a single "unknown" group, since they all resolve to the same
+    runtime symbol within a single ``on_bar`` invocation) and requires
+    every group to form its own entry+exit pair.
+    """
+    groups: Dict[Optional[str], List[ast.Call]] = {}
+    for c in calls:
+        groups.setdefault(_submit_order_symbol(c), []).append(c)
+    return all(_group_forms_entry_exit_pair(group) for group in groups.values())
 
 
 def _has_attached_exit_kwarg(node: ast.Call) -> bool:

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -410,6 +410,32 @@ def _iter_method_body_nodes(method: ast.FunctionDef | ast.AsyncFunctionDef):
             stack.append(child)
 
 
+def _iter_method_body_in_source_order(scope: ast.AST):
+    """Yield every node in ``scope``'s body in source order, without
+    descending into nested ``def`` / ``class`` / ``lambda`` bodies.
+
+    Unlike :func:`_iter_method_body_nodes` (stack-based, arbitrary
+    pop order), this generator visits parent statements before their
+    children and processes sibling statements in declaration order.
+    The flow-sensitive alias tracker depends on this ordering so a
+    ``trade_ctx = ctx`` assignment updates state BEFORE later
+    ``trade_ctx.submit_order(...)`` calls are visited.
+    """
+    body = getattr(scope, "body", None)
+    if not isinstance(body, list):
+        return
+
+    def visit(node: ast.AST):
+        yield node
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)):
+            return
+        for child in ast.iter_child_nodes(node):
+            yield from visit(child)
+
+    for stmt in body:
+        yield from visit(stmt)
+
+
 def _find_nested_def_defs(
     method: ast.FunctionDef | ast.AsyncFunctionDef,
 ) -> Dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
@@ -530,8 +556,8 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
                 worklist.append((m, frozenset({m.args.args[1].arg})))
 
     while worklist:
-        scope, receiver_names = worklist.pop()
-        visit_key = (id(scope), receiver_names)
+        scope, initial_receivers = worklist.pop()
+        visit_key = (id(scope), initial_receivers)
         if visit_key in visited_keys:
             continue
         visited_keys.add(visit_key)
@@ -544,66 +570,56 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
             else {}
         )
 
-        # Expand receiver_names with simple aliases. A strategy may
-        # introduce a local alias before submitting orders:
-        #
-        #     trade_ctx = ctx
-        #     trade_ctx.submit_order(...)
-        #
-        # ``trade_ctx`` and ``ctx`` are interchangeable here — the
-        # binding flows trivially through ``Assign`` / ``AnnAssign``
-        # statements whose RHS is just another Name we already accept.
-        # Iterate to a fixed point so ``a = ctx; b = a`` accepts both.
-        expanded_receivers = set(receiver_names)
-        changed = True
-        while changed:
-            changed = False
-            for node in _iter_method_body_nodes(scope):
-                src_name: Optional[str] = None
-                target_name: Optional[str] = None
-                if (
-                    isinstance(node, ast.Assign)
-                    and len(node.targets) == 1
-                    and isinstance(node.targets[0], ast.Name)
-                    and isinstance(node.value, ast.Name)
-                ):
-                    target_name = node.targets[0].id
-                    src_name = node.value.id
-                elif (
-                    isinstance(node, ast.AnnAssign)
-                    and isinstance(node.target, ast.Name)
-                    and isinstance(node.value, ast.Name)
-                ):
-                    target_name = node.target.id
-                    src_name = node.value.id
-                if (
-                    src_name in expanded_receivers
-                    and target_name is not None
-                    and target_name not in expanded_receivers
-                ):
-                    expanded_receivers.add(target_name)
-                    changed = True
-        receiver_names = frozenset(expanded_receivers)
+        # Flow-sensitive walk. ``state`` tracks the currently-live alias
+        # set as we proceed through the scope in source order. The walker
+        # updates it as it encounters ``Assign`` / ``AnnAssign`` events,
+        # so a ``submit_order`` call is credited only when the alias was
+        # bound to a known receiver at or before the call's source
+        # position — calls before a ``trade_ctx = ctx`` assignment, and
+        # calls after a later ``trade_ctx = something_else`` rebind, no
+        # longer pick up the alias.
+        state: set[str] = set(initial_receivers)
 
-        for sub in _iter_method_body_nodes(scope):
+        for sub in _iter_method_body_in_source_order(scope):
+            # Update alias state on simple name-to-name assignments.
+            if (
+                isinstance(sub, ast.Assign)
+                and len(sub.targets) == 1
+                and isinstance(sub.targets[0], ast.Name)
+            ):
+                target = sub.targets[0].id
+                if isinstance(sub.value, ast.Name) and sub.value.id in state:
+                    state.add(target)
+                elif target in state:
+                    # Rebound to a non-receiver expression — drop the alias.
+                    state.discard(target)
+                continue
+            if isinstance(sub, ast.AnnAssign) and isinstance(sub.target, ast.Name):
+                target = sub.target.id
+                if isinstance(sub.value, ast.Name) and sub.value.id in state:
+                    state.add(target)
+                elif target in state:
+                    state.discard(target)
+                continue
+
             if not isinstance(sub, ast.Call):
                 continue
+
+            current_receivers = frozenset(state)
+
             # 1. <ctx>.submit_order(...) — the order we count.
             if (
                 isinstance(sub.func, ast.Attribute)
                 and sub.func.attr == "submit_order"
                 and isinstance(sub.func.value, ast.Name)
-                and sub.func.value.id in receiver_names
+                and sub.func.value.id in current_receivers
             ):
                 calls.append(sub)
                 continue
             # 2. self.<helper>(...) — class method. The helper's accepted
             #    receivers are bound to the call-site arguments: only
             #    parameters that received a name from the OUTER scope's
-            #    receiver_names are treated as ctx-bound. Helpers called
-            #    without passing the context (e.g. ``self._trade(bar)``)
-            #    end up with no receivers and a ``submit_order`` on the
-            #    Bar parameter does NOT satisfy the gate.
+            #    live receivers are treated as ctx-bound.
             if (
                 isinstance(sub.func, ast.Attribute)
                 and isinstance(sub.func.value, ast.Name)
@@ -611,7 +627,7 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
             ):
                 helper = methods_by_name.get(sub.func.attr)
                 if helper is not None:
-                    helper_receivers = _resolve_helper_receivers(sub, helper, receiver_names)
+                    helper_receivers = _resolve_helper_receivers(sub, helper, current_receivers)
                     if (id(helper), helper_receivers) not in visited_keys:
                         worklist.append((helper, helper_receivers))
                 continue
@@ -620,22 +636,19 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
             #    - Parameters bound at the call site (``def enter(c): ...;
             #      enter(ctx)`` binds ``c`` to ``ctx``).
             #    - Outer-scope captures (``def enter(): ctx.submit_order(
-            #      ...)`` references the enclosing frame's ``ctx``).
+            #      ...)`` references the enclosing frame's live receivers).
             #    Captured names are visible only when the closure does
             #    NOT shadow them with its own parameter — ``def
             #    enter(ctx): ...; enter(bar)`` rebinds ``ctx`` to ``bar``,
-            #    so the outer ``ctx`` is no longer reachable as a
-            #    receiver inside the closure body.
+            #    so the outer ``ctx`` is no longer reachable inside.
             if isinstance(sub.func, ast.Name):
                 local = local_defs.get(sub.func.id)
                 if local is not None:
-                    call_bound = _resolve_helper_receivers(sub, local, receiver_names)
+                    call_bound = _resolve_helper_receivers(sub, local, current_receivers)
                     closure_param_names = frozenset(
                         arg.arg for arg in local.args.args if arg.arg != "self"
                     )
-                    # Outer receivers are captured by closure UNLESS a
-                    # parameter of the same name shadows them.
-                    captured = receiver_names - closure_param_names
+                    captured = current_receivers - closure_param_names
                     closure_receivers = captured | call_bound
                     if (id(local), closure_receivers) not in visited_keys:
                         worklist.append((local, closure_receivers))
@@ -725,16 +738,40 @@ def _calls_form_entry_exit_pair(calls: List[ast.Call]) -> bool:
     The engine closes positions per-symbol — ``portfolio.positions[bar.symbol]``
     is looked up against the order's own symbol — so a strategy that
     opens ``LONG`` on ``"SPY"`` and ``SHORT`` on ``"TLT"`` has two
-    open entries and zero exits, not a balanced pair. The gate groups
-    calls by their literal ``symbol`` value (dynamic / computed symbols
-    share a single "unknown" group, since they all resolve to the same
-    runtime symbol within a single ``on_bar`` invocation) and requires
-    every group to form its own entry+exit pair.
+    open entries and zero exits, not a balanced pair.
+
+    Grouping rules:
+
+    * Calls with literal-string ``symbol`` arguments form per-symbol
+      groups (one per distinct literal).
+    * Calls with dynamic / computed / missing ``symbol`` arguments are
+      pooled in a single "unknown" group, since within one ``on_bar``
+      invocation they all resolve to the same runtime symbol.
+    * Dynamic-symbol calls AUGMENT each literal-symbol group's pair
+      check: on a single-symbol run, a generated strategy may enter
+      with ``symbol=bar.symbol`` and exit with ``symbol="SPY"`` (or
+      vice versa), so the dynamic group's calls plausibly target each
+      literal symbol at runtime. Each literal group passes iff
+      ``literal_calls + dynamic_calls`` forms a valid pair.
+    * The dynamic group also passes on its own when no literal groups
+      exist (all calls dynamic).
     """
-    groups: Dict[Optional[str], List[ast.Call]] = {}
+    literal_groups: Dict[str, List[ast.Call]] = {}
+    dynamic_calls: List[ast.Call] = []
     for c in calls:
-        groups.setdefault(_submit_order_symbol(c), []).append(c)
-    return all(_group_forms_entry_exit_pair(group) for group in groups.values())
+        sym = _submit_order_symbol(c)
+        if sym is None:
+            dynamic_calls.append(c)
+        else:
+            literal_groups.setdefault(sym, []).append(c)
+
+    if not literal_groups:
+        return _group_forms_entry_exit_pair(dynamic_calls)
+
+    for group in literal_groups.values():
+        if not _group_forms_entry_exit_pair(group + dynamic_calls):
+            return False
+    return True
 
 
 def _has_attached_exit_kwarg(node: ast.Call) -> bool:

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import ast
 import re
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from .models import QualityGateResult
 
@@ -362,49 +362,72 @@ def _get_call_name(node: ast.Call) -> str:
 _ENGINE_HOOK_METHODS = frozenset({"on_bar", "on_start", "on_fill", "on_end"})
 
 
-def _hook_context_param_name(method: ast.FunctionDef | ast.AsyncFunctionDef) -> Optional[str]:
-    """Return the name of the context parameter for an engine hook, or None.
-
-    Every hook has shape ``(self, ctx, ...)``; the first positional after
-    ``self`` is the engine context. Methods with too few parameters cannot
-    be valid hooks and return ``None``.
-    """
-    if len(method.args.args) < 2:
-        return None
-    return method.args.args[1].arg
-
-
-def _is_submit_order_on_receiver(node: ast.Call, receiver_name: str) -> bool:
-    """True iff ``node`` is ``<receiver_name>.submit_order(...)``."""
-    if not isinstance(node.func, ast.Attribute):
-        return False
-    if node.func.attr != "submit_order":
-        return False
-    receiver = node.func.value
-    return isinstance(receiver, ast.Name) and receiver.id == receiver_name
-
-
 def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
-    """Return every ``<ctx>.submit_order(...)`` call inside an engine hook.
+    """Return every ``submit_order(...)`` call reachable from an engine hook.
 
-    Restricts the AST walk to the four engine-invoked hook methods so
-    ``submit_order`` calls in dead/uninvoked helpers do not satisfy the
-    order-flow gate. For each hook we resolve the context parameter
-    name from its signature, so a strategy that names it ``context``
-    instead of ``ctx`` is still accepted.
+    Engine hooks (``on_bar`` / ``on_start`` / ``on_fill`` / ``on_end``) are
+    the only methods the runtime invokes directly. We:
+
+    1. Walk each hook and record ``<ctx_param>.submit_order(...)`` calls
+       where ``<ctx_param>`` is the hook's second positional parameter
+       (so ``context.submit_order(...)`` is accepted when the hook is
+       declared ``on_bar(self, context, bar)``).
+    2. Follow ``self.<method>(...)`` calls from each hook into other
+       methods of the same class — strategies routinely factor order
+       placement into helpers (e.g. ``self._enter(ctx, bar)``). In each
+       reachable helper, we treat any ``<param>.submit_order(...)`` call
+       on a positional parameter of that helper as a real order
+       submission, since the hook is the only entry point and any
+       parameter is plausibly the engine context threaded through.
+
+    A simple worklist with a ``visited`` set handles mutual recursion;
+    helpers never invoked from a hook (or transitively from one) are
+    still ignored, which is what we want.
     """
-    calls: List[ast.Call] = []
+    methods_by_name: Dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
     for node in ast.iter_child_nodes(cls):
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            methods_by_name[node.name] = node
+
+    calls: List[ast.Call] = []
+    visited: set[str] = set()
+    worklist: List[ast.FunctionDef | ast.AsyncFunctionDef] = [
+        m for name, m in methods_by_name.items() if name in _ENGINE_HOOK_METHODS
+    ]
+
+    while worklist:
+        method = worklist.pop()
+        if method.name in visited:
             continue
-        if node.name not in _ENGINE_HOOK_METHODS:
-            continue
-        ctx_name = _hook_context_param_name(node)
-        if ctx_name is None:
-            continue
-        for sub in ast.walk(node):
-            if isinstance(sub, ast.Call) and _is_submit_order_on_receiver(sub, ctx_name):
+        visited.add(method.name)
+
+        # Accepted receiver names for this method: every positional param
+        # except ``self``. For hooks the engine guarantees the second
+        # positional is the context; for helpers, any parameter could
+        # carry the threaded-through ctx.
+        param_names = {arg.arg for arg in method.args.args if arg.arg != "self"}
+
+        for sub in ast.walk(method):
+            if not isinstance(sub, ast.Call):
+                continue
+            if (
+                isinstance(sub.func, ast.Attribute)
+                and sub.func.attr == "submit_order"
+                and isinstance(sub.func.value, ast.Name)
+                and sub.func.value.id in param_names
+            ):
                 calls.append(sub)
+                continue
+            # Queue ``self.<helper>(...)`` for traversal.
+            if (
+                isinstance(sub.func, ast.Attribute)
+                and isinstance(sub.func.value, ast.Name)
+                and sub.func.value.id == "self"
+            ):
+                helper = methods_by_name.get(sub.func.attr)
+                if helper is not None and helper.name not in visited:
+                    worklist.append(helper)
+
     return calls
 
 

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -410,6 +410,27 @@ def _iter_method_body_nodes(method: ast.FunctionDef | ast.AsyncFunctionDef):
             stack.append(child)
 
 
+def _find_nested_def_defs(
+    method: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> Dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Return a name → def map for every nested function defined directly
+    inside ``method``'s body (any depth, but not inside another nested
+    def or class).
+
+    These are local closures: ``def enter(): ctx.submit_order(...)`` style
+    helpers. When the outer scope explicitly calls them by name, the
+    engine reaches their body — so the order-flow walker needs to descend.
+    """
+    local_defs: Dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
+    # Walk method's body but stop at nested def/class boundaries so we
+    # collect only the immediate closures of this scope (not closures of
+    # closures).
+    for node in _iter_method_body_nodes(method):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            local_defs.setdefault(node.name, node)
+    return local_defs
+
+
 def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
     """Return every ``submit_order(...)`` call reachable from ``on_bar``.
 
@@ -420,20 +441,26 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
     hooks is silently dropped). Limiting the gate's roots to ``on_bar``
     matches the engine's real behaviour.
 
-    The walker also follows ``self.<method>(...)`` edges into other
-    methods of the same class so a strategy that factors order placement
-    into helpers (e.g. ``self._enter(ctx, bar)`` invoked from ``on_bar``)
-    still satisfies the gate.
+    The walker follows three kinds of edges from each reachable scope:
 
-    Walks each method's body but stops at nested ``def`` / ``class`` /
-    ``lambda`` boundaries — an uninvoked local helper inside ``on_bar``
-    that contains ``ctx.submit_order(...)`` is not reachable because
-    Python only creates the function object and never executes its body.
+    * ``self.<method>(...)`` — descends into class methods. The helper
+      has its own parameter list; we relax the receiver check to any
+      non-``self`` positional parameter since the call site can pass
+      the context through any of them.
+    * ``<local_name>(...)`` — descends into local closures defined in
+      the SAME scope (e.g. ``def enter(): ctx.submit_order(...)`` then
+      ``enter()`` inside ``on_bar``). Local closures inherit the outer
+      scope's bindings, so they keep the OUTER scope's receiver names
+      rather than introducing their own (the closure captures ``ctx``
+      from the enclosing frame).
+
+    Walks each scope's body but stops at nested ``def`` / ``class`` /
+    ``lambda`` boundaries — bodies of locally-defined-but-uninvoked
+    helpers are not reachable because Python only creates the function
+    object and never executes the body without a call.
 
     ``on_bar`` is dispatched positionally, so only its second positional
-    parameter is the StrategyContext. Helpers reached via
-    ``self.<method>(...)`` relax to any non-``self`` positional parameter
-    since the call site can pass the context through any of them.
+    parameter is the StrategyContext.
     """
     methods_by_name: Dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
     for node in ast.iter_child_nodes(cls):
@@ -441,38 +468,37 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
             methods_by_name[node.name] = node
 
     calls: List[ast.Call] = []
-    visited: set[str] = set()
-    # Worklist entries: (method, is_hook). is_hook=True restricts the
-    # accepted receiver to the second positional parameter; helpers
-    # (is_hook=False) accept any non-self positional parameter since the
-    # call site may pass the context through any of them.
-    worklist: List[tuple[ast.FunctionDef | ast.AsyncFunctionDef, bool]] = []
+    # Visited keys on id() so distinct AST nodes don't collide on name.
+    visited_ids: set[int] = set()
+    # Worklist entries: (scope_node, receiver_names). receiver_names is
+    # the set of identifiers we accept as the context receiver inside
+    # this scope's body — for hooks, just the second positional; for
+    # helpers, every non-self positional; for local closures, the
+    # outer scope's receiver_names (captured by closure).
+    worklist: List[tuple[ast.AST, frozenset[str]]] = []
     for name, m in methods_by_name.items():
         if name in _PROCESSED_HOOK_METHODS:
-            worklist.append((m, True))
+            if len(m.args.args) >= 2:
+                worklist.append((m, frozenset({m.args.args[1].arg})))
 
     while worklist:
-        method, is_hook = worklist.pop()
-        if method.name in visited:
+        scope, receiver_names = worklist.pop()
+        if id(scope) in visited_ids:
             continue
-        visited.add(method.name)
+        visited_ids.add(id(scope))
 
-        if is_hook:
-            # Engine hook: only the second positional is the context.
-            # ``bar``/``fill`` siblings do not have ``submit_order``.
-            if len(method.args.args) >= 2:
-                receiver_names = {method.args.args[1].arg}
-            else:
-                receiver_names = set()
-        else:
-            # Helper reached from a hook: accept any positional parameter
-            # except ``self`` — we can't statically track which one was
-            # bound to the context, but any of them could be.
-            receiver_names = {arg.arg for arg in method.args.args if arg.arg != "self"}
+        # Local closures defined directly in this scope — followed only
+        # when their name is invoked below.
+        local_defs = (
+            _find_nested_def_defs(scope)
+            if isinstance(scope, (ast.FunctionDef, ast.AsyncFunctionDef))
+            else {}
+        )
 
-        for sub in _iter_method_body_nodes(method):
+        for sub in _iter_method_body_nodes(scope):
             if not isinstance(sub, ast.Call):
                 continue
+            # 1. <ctx>.submit_order(...) — the order we count.
             if (
                 isinstance(sub.func, ast.Attribute)
                 and sub.func.attr == "submit_order"
@@ -481,15 +507,27 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
             ):
                 calls.append(sub)
                 continue
-            # Queue ``self.<helper>(...)`` for traversal as a helper.
+            # 2. self.<helper>(...) — class method, traversed with its
+            #    own parameter set as the helper receiver names.
             if (
                 isinstance(sub.func, ast.Attribute)
                 and isinstance(sub.func.value, ast.Name)
                 and sub.func.value.id == "self"
             ):
                 helper = methods_by_name.get(sub.func.attr)
-                if helper is not None and helper.name not in visited:
-                    worklist.append((helper, False))
+                if helper is not None and id(helper) not in visited_ids:
+                    helper_receivers = frozenset(
+                        arg.arg for arg in helper.args.args if arg.arg != "self"
+                    )
+                    worklist.append((helper, helper_receivers))
+                continue
+            # 3. <local_name>(...) — closure defined in the same scope.
+            #    Walked with the OUTER scope's receiver_names because the
+            #    closure captures the context binding from this frame.
+            if isinstance(sub.func, ast.Name):
+                local = local_defs.get(sub.func.id)
+                if local is not None and id(local) not in visited_ids:
+                    worklist.append((local, receiver_names))
 
     return calls
 

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -328,10 +328,11 @@ class CodeSafetyChecker:
                 else:
                     detail = (
                         "Multiple ctx.submit_order calls found but all use the same "
-                        "side and no bracket exit is attached — strategy has no real "
-                        "exit leg. Closing a position requires submitting the opposite "
-                        "side (LONG↔SHORT/FLAT) or an attached_stop_loss / "
-                        "attached_take_profit bracket leg."
+                        "OrderSide and no bracket exit is attached — strategy has no "
+                        "real exit leg. Closing a position requires submitting the "
+                        "opposite OrderSide (LONG closes SHORT, SHORT closes LONG) or "
+                        "attaching an attached_stop_loss / attached_take_profit "
+                        "bracket leg."
                     )
                 results.append(
                     QualityGateResult(
@@ -454,31 +455,33 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
     return calls
 
 
-# Side values that indicate an entry leg (opens a position).
-_ENTRY_SIDES = frozenset({"LONG", "SHORT", "BUY", "SELL"})
-# Side values that indicate an exit leg (flattens an open position).
-_EXIT_SIDES = frozenset({"FLAT", "CLOSE", "EXIT"})
+# Recognised ``OrderSide`` literal values. The runtime contract
+# (``trading_service.strategy.contract.OrderSide``) defines exactly two
+# enum members — ``LONG`` and ``SHORT`` — and ``StrategyContext.submit_order``
+# coerces with ``OrderSide(side)``. ``FLAT`` / ``CLOSE`` / ``BUY`` / ``SELL``
+# literals would crash at runtime, so they are NOT recognised here; the
+# gate treats them as "unknown" and lets the downstream backtest surface
+# the real validation error.
+_RECOGNISED_SIDES = frozenset({"LONG", "SHORT"})
 
 
 def _submit_order_side(node: ast.Call) -> Optional[str]:
     """Best-effort extraction of the ``side`` value from a submit_order call.
 
-    Returns an upper-cased string when the call uses a recognised literal
-    form, else None when the side is dynamic / can't be determined
-    statically. Handles three forms:
-
-    * Keyword string literal: ``side="LONG"`` → ``"LONG"``.
-    * Keyword enum member: ``side=OrderSide.LONG`` → ``"LONG"``.
-    * Keyword string concatenations or computed values → ``None``.
+    Returns an upper-cased string when the call uses a recognised
+    ``OrderSide`` literal form, else None when the side is dynamic / a
+    non-OrderSide literal / can't be determined statically.
     """
     for kw in node.keywords:
         if kw.arg != "side":
             continue
         val = kw.value
         if isinstance(val, ast.Constant) and isinstance(val.value, str):
-            return val.value.upper()
+            upper = val.value.upper()
+            return upper if upper in _RECOGNISED_SIDES else None
         if isinstance(val, ast.Attribute):
-            return val.attr.upper()
+            upper = val.attr.upper()
+            return upper if upper in _RECOGNISED_SIDES else None
     return None
 
 
@@ -486,18 +489,20 @@ def _calls_form_entry_exit_pair(calls: List[ast.Call]) -> bool:
     """True iff the collected submit_order calls plausibly include both an
     entry and an exit leg.
 
-    The contract closes positions by submitting an opposite-side order
-    with ``qty == position.qty``. We approximate that here statically:
+    The runtime contract closes a position by submitting an opposite-side
+    order (``LONG`` closes a ``SHORT``, ``SHORT`` closes a ``LONG``) with
+    ``qty == position.qty``. We approximate statically:
 
     * If any call carries ``attached_stop_loss`` / ``attached_take_profit``
       (a non-None bracket leg), it brings its own exit.
-    * Otherwise we extract the literal ``side`` from each call and
-      require at least two distinct values. ``LONG`` + ``LONG`` is
-      one-sided and fails the gate; ``LONG`` + ``FLAT`` /
-      ``LONG`` + ``SHORT`` / ``BUY`` + ``CLOSE`` etc. pass.
-    * Calls whose side cannot be determined statically (dynamic
-      expressions) are treated optimistically as "could be either" so
-      they don't false-fail strategies that branch on a signal.
+    * Otherwise, require both ``LONG`` and ``SHORT`` to appear across the
+      collected calls. Same-side multiplicity (``LONG`` + ``LONG``) is one-
+      sided and fails the gate.
+    * Calls whose side cannot be determined statically (computed expression
+      that picks the direction from position / signal state) are treated
+      optimistically — even a single such call passes, since legitimate
+      strategies route both entry and exit through one call site whose
+      side is a runtime branch.
     """
     if any(_has_attached_exit_kwarg(c) for c in calls):
         return True
@@ -509,16 +514,13 @@ def _calls_form_entry_exit_pair(calls: List[ast.Call]) -> bool:
             has_unknown = True
         else:
             sides_seen.add(side)
-    # Distinct-side requirement: at least one entry-like and one exit-like,
-    # or simply two distinct recognised sides (covers BUY/SELL pairs etc.).
-    has_entry = bool(sides_seen & _ENTRY_SIDES)
-    has_exit = bool(sides_seen & _EXIT_SIDES)
-    if has_entry and has_exit:
+    # Distinct LONG + SHORT means at least one is opposite-side closing the other.
+    if "LONG" in sides_seen and "SHORT" in sides_seen:
         return True
-    if len(sides_seen) >= 2:
-        return True
-    # Could be a runtime-decided side — be permissive rather than false-fail.
-    if has_unknown and len(calls) >= 2:
+    # Dynamic side: accept any number of calls (including a single one) that
+    # route entry/exit through a runtime branch — false-failing these is
+    # worse than letting the backtest surface a genuinely one-sided runtime.
+    if has_unknown:
         return True
     return False
 

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -284,45 +284,51 @@ class CodeSafetyChecker:
                 )
             )
 
-        # 8. Order-flow shape (#547): every viable strategy must have at
-        #    least one ``ctx.submit_order(...)`` call (entry path) and either
-        #    a second ``ctx.submit_order`` (separate exit) or attached
-        #    bracket/OCO legs on the single call (``attached_stop_loss`` /
-        #    ``attached_take_profit``, #389). Calls on other receivers
-        #    (``self.submit_order(...)``, local helpers) are ignored — they
-        #    never reach the runtime engine.
+        # 8. Order-flow shape (#547): every viable strategy must call
+        #    ``ctx.submit_order(...)`` from inside one of the engine-callable
+        #    hook methods (``on_bar``, ``on_start``, ``on_fill``, ``on_end``),
+        #    and must either call it twice (separate entry + exit) or carry
+        #    a non-None ``attached_stop_loss`` / ``attached_take_profit``
+        #    on the single call (bracket / OCO support, #389).
+        #
+        #    * The hook signature determines the receiver name we count
+        #      against — ``on_bar(self, ctx, bar)`` looks for
+        #      ``ctx.submit_order``, ``on_bar(self, context, bar)`` looks
+        #      for ``context.submit_order``. The engine calls hooks
+        #      positionally so the parameter name is the strategy's choice.
+        #    * Helper methods are ignored unless they are themselves engine
+        #      hooks: a ``submit_order`` call sitting in an un-invoked
+        #      helper does not reach the runtime.
         if len(strategy_classes) == 1:
-            ctx_submit_calls = [
-                n
-                for n in ast.walk(strategy_classes[0])
-                if isinstance(n, ast.Call) and _is_ctx_submit_order(n)
-            ]
-            single_call_has_bracket_exit = len(ctx_submit_calls) == 1 and _has_attached_exit_kwarg(
-                ctx_submit_calls[0]
+            hook_calls = _collect_hook_submit_calls(strategy_classes[0])
+            single_call_has_bracket_exit = len(hook_calls) == 1 and _has_attached_exit_kwarg(
+                hook_calls[0]
             )
-            if len(ctx_submit_calls) == 0:
+            if len(hook_calls) == 0:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
                         passed=False,
                         severity="critical",
                         details=(
-                            "No ctx.submit_order call found in the Strategy class — "
-                            "strategy has no entry path and would emit zero trades."
+                            "No ctx.submit_order call found inside on_bar / on_start / "
+                            "on_fill / on_end — strategy has no entry path reachable "
+                            "from the engine and would emit zero trades."
                         ),
                     )
                 )
-            elif len(ctx_submit_calls) == 1 and not single_call_has_bracket_exit:
+            elif len(hook_calls) == 1 and not single_call_has_bracket_exit:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
                         passed=False,
                         severity="critical",
                         details=(
-                            "Only one ctx.submit_order call found and no attached "
-                            "bracket exit (attached_stop_loss / attached_take_profit) "
-                            "— strategy has no exit path. Add a second submit_order "
-                            "or attach a bracket leg to close positions."
+                            "Only one ctx.submit_order call found in the engine hooks "
+                            "and no non-None attached bracket exit (attached_stop_loss "
+                            "/ attached_take_profit) — strategy has no exit path. Add "
+                            "a second submit_order or attach a bracket leg to close "
+                            "positions."
                         ),
                     )
                 )
@@ -349,33 +355,78 @@ def _get_call_name(node: ast.Call) -> str:
     return ""
 
 
-def _is_ctx_submit_order(node: ast.Call) -> bool:
-    """True iff ``node`` is a ``ctx.submit_order(...)`` call.
+# Engine-callable hook method names (``contract.Strategy``). The runtime
+# invokes each positionally, so the parameter NAME the strategy chooses
+# for the context object is the strategy's choice — we read it off the
+# signature rather than hard-coding ``ctx``.
+_ENGINE_HOOK_METHODS = frozenset({"on_bar", "on_start", "on_fill", "on_end"})
 
-    Restricting on the receiver matters: a strategy that defines a helper
-    method ``self.submit_order(...)`` or a local function named
-    ``submit_order`` would otherwise satisfy the order-flow gate without
-    ever reaching the runtime engine.
+
+def _hook_context_param_name(method: ast.FunctionDef | ast.AsyncFunctionDef) -> Optional[str]:
+    """Return the name of the context parameter for an engine hook, or None.
+
+    Every hook has shape ``(self, ctx, ...)``; the first positional after
+    ``self`` is the engine context. Methods with too few parameters cannot
+    be valid hooks and return ``None``.
     """
+    if len(method.args.args) < 2:
+        return None
+    return method.args.args[1].arg
+
+
+def _is_submit_order_on_receiver(node: ast.Call, receiver_name: str) -> bool:
+    """True iff ``node`` is ``<receiver_name>.submit_order(...)``."""
     if not isinstance(node.func, ast.Attribute):
         return False
     if node.func.attr != "submit_order":
         return False
     receiver = node.func.value
-    return isinstance(receiver, ast.Name) and receiver.id == "ctx"
+    return isinstance(receiver, ast.Name) and receiver.id == receiver_name
+
+
+def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
+    """Return every ``<ctx>.submit_order(...)`` call inside an engine hook.
+
+    Restricts the AST walk to the four engine-invoked hook methods so
+    ``submit_order`` calls in dead/uninvoked helpers do not satisfy the
+    order-flow gate. For each hook we resolve the context parameter
+    name from its signature, so a strategy that names it ``context``
+    instead of ``ctx`` is still accepted.
+    """
+    calls: List[ast.Call] = []
+    for node in ast.iter_child_nodes(cls):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name not in _ENGINE_HOOK_METHODS:
+            continue
+        ctx_name = _hook_context_param_name(node)
+        if ctx_name is None:
+            continue
+        for sub in ast.walk(node):
+            if isinstance(sub, ast.Call) and _is_submit_order_on_receiver(sub, ctx_name):
+                calls.append(sub)
+    return calls
 
 
 def _has_attached_exit_kwarg(node: ast.Call) -> bool:
-    """True iff the call passes ``attached_stop_loss`` or ``attached_take_profit``.
+    """True iff the call passes a non-None ``attached_stop_loss`` or
+    ``attached_take_profit``.
 
     Bracket / OCO orders (issue #389) bundle the exit logic onto the entry
     submission, so a single ``ctx.submit_order(..., attached_stop_loss=...)``
-    is a complete entry+exit pair.
+    is a complete entry+exit pair. Explicit ``=None`` literals are
+    excluded — at the AST level ``kw.value`` is always an ``ast.AST``
+    node (e.g. ``ast.Constant(value=None)``), never a Python ``None``,
+    so the older ``kw.value is not None`` check would falsely accept
+    an explicit ``attached_stop_loss=None`` as a real bracket leg.
     """
-    return any(
-        kw.arg in ("attached_stop_loss", "attached_take_profit") and kw.value is not None
-        for kw in node.keywords
-    )
+    for kw in node.keywords:
+        if kw.arg not in ("attached_stop_loss", "attached_take_profit"):
+            continue
+        if isinstance(kw.value, ast.Constant) and kw.value.value is None:
+            continue
+        return True
+    return False
 
 
 def _find_strategy_subclasses(tree: ast.AST) -> List[ast.ClassDef]:

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -284,6 +284,42 @@ class CodeSafetyChecker:
                 )
             )
 
+        # 8. Order-flow shape (#547): every viable strategy must have at least
+        #    one ``ctx.submit_order(...)`` call (entry path) and at least two
+        #    distinct submit_order call sites in the Strategy class (entry +
+        #    exit). One-sided code emits orders without ever closing them and
+        #    wastes a full refinement cycle in the runtime gates.
+        if len(strategy_classes) == 1:
+            submit_calls = [
+                n
+                for n in ast.walk(strategy_classes[0])
+                if isinstance(n, ast.Call) and _get_call_name(n) == "submit_order"
+            ]
+            if len(submit_calls) == 0:
+                results.append(
+                    QualityGateResult(
+                        gate_name=GATE,
+                        passed=False,
+                        severity="critical",
+                        details=(
+                            "No ctx.submit_order call found in the Strategy class — "
+                            "strategy has no entry path and would emit zero trades."
+                        ),
+                    )
+                )
+            elif len(submit_calls) == 1:
+                results.append(
+                    QualityGateResult(
+                        gate_name=GATE,
+                        passed=False,
+                        severity="critical",
+                        details=(
+                            "Only one ctx.submit_order call found — strategy has no "
+                            "exit path. Add a second submit_order to close positions."
+                        ),
+                    )
+                )
+
         if not results:
             results.append(
                 QualityGateResult(
@@ -360,8 +396,9 @@ def _validate_on_bar(cls: ast.ClassDef) -> Optional[str]:
                 f"found {param_count}."
             )
         return None
-    # No on_bar at all — not strictly fatal (base class no-op), but no
-    # orders will be emitted so flag it.
+    # No on_bar override — the base class no-op would emit zero trades, so
+    # this is a critical failure (#547). CodeSafetyChecker.check wraps any
+    # non-None return here as severity="critical".
     return (
         f"{cls.name} does not override on_bar(self, ctx, bar); the base class "
         "no-op will run and the strategy will emit zero trades."

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -512,13 +512,17 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
             methods_by_name[node.name] = node
 
     calls: List[ast.Call] = []
-    # Visited keys on id() so distinct AST nodes don't collide on name.
-    visited_ids: set[int] = set()
+    # Visit key is (id(scope), receiver_names) so a helper called twice
+    # with different bindings (e.g. ``self._trade(bar)`` then
+    # ``self._trade(ctx)``) is analyzed once per distinct binding rather
+    # than getting masked by the first visit.
+    visited_keys: set[tuple[int, frozenset[str]]] = set()
     # Worklist entries: (scope_node, receiver_names). receiver_names is
     # the set of identifiers we accept as the context receiver inside
-    # this scope's body — for hooks, just the second positional; for
-    # helpers, every non-self positional; for local closures, the
-    # outer scope's receiver_names (captured by closure).
+    # this scope's body — for hooks, the second positional; for class
+    # helpers, parameters bound at the call site; for local closures,
+    # call-site-bound parameters PLUS the outer scope's receivers (the
+    # closure also captures them from the enclosing frame).
     worklist: List[tuple[ast.AST, frozenset[str]]] = []
     for name, m in methods_by_name.items():
         if name in _PROCESSED_HOOK_METHODS:
@@ -527,9 +531,10 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
 
     while worklist:
         scope, receiver_names = worklist.pop()
-        if id(scope) in visited_ids:
+        visit_key = (id(scope), receiver_names)
+        if visit_key in visited_keys:
             continue
-        visited_ids.add(id(scope))
+        visited_keys.add(visit_key)
 
         # Local closures defined directly in this scope — followed only
         # when their name is invoked below.
@@ -605,17 +610,25 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
                 and sub.func.value.id == "self"
             ):
                 helper = methods_by_name.get(sub.func.attr)
-                if helper is not None and id(helper) not in visited_ids:
+                if helper is not None:
                     helper_receivers = _resolve_helper_receivers(sub, helper, receiver_names)
-                    worklist.append((helper, helper_receivers))
+                    if (id(helper), helper_receivers) not in visited_keys:
+                        worklist.append((helper, helper_receivers))
                 continue
             # 3. <local_name>(...) — closure defined in the same scope.
-            #    Walked with the OUTER scope's receiver_names because the
-            #    closure captures the context binding from this frame.
+            #    Closures see two sources of context bindings: parameters
+            #    bound at the call site (``def enter(c): ...; enter(ctx)``
+            #    binds ``c`` to ``ctx``) AND outer-scope captures
+            #    (``def enter(): ctx.submit_order(...)`` references the
+            #    enclosing frame's ``ctx``). We union both so either
+            #    pattern is recognised.
             if isinstance(sub.func, ast.Name):
                 local = local_defs.get(sub.func.id)
-                if local is not None and id(local) not in visited_ids:
-                    worklist.append((local, receiver_names))
+                if local is not None:
+                    call_bound = _resolve_helper_receivers(sub, local, receiver_names)
+                    closure_receivers = receiver_names | call_bound
+                    if (id(local), closure_receivers) not in visited_keys:
+                        worklist.append((local, closure_receivers))
 
     return calls
 

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -284,18 +284,23 @@ class CodeSafetyChecker:
                 )
             )
 
-        # 8. Order-flow shape (#547): every viable strategy must have at least
-        #    one ``ctx.submit_order(...)`` call (entry path) and at least two
-        #    distinct submit_order call sites in the Strategy class (entry +
-        #    exit). One-sided code emits orders without ever closing them and
-        #    wastes a full refinement cycle in the runtime gates.
+        # 8. Order-flow shape (#547): every viable strategy must have at
+        #    least one ``ctx.submit_order(...)`` call (entry path) and either
+        #    a second ``ctx.submit_order`` (separate exit) or attached
+        #    bracket/OCO legs on the single call (``attached_stop_loss`` /
+        #    ``attached_take_profit``, #389). Calls on other receivers
+        #    (``self.submit_order(...)``, local helpers) are ignored — they
+        #    never reach the runtime engine.
         if len(strategy_classes) == 1:
-            submit_calls = [
+            ctx_submit_calls = [
                 n
                 for n in ast.walk(strategy_classes[0])
-                if isinstance(n, ast.Call) and _get_call_name(n) == "submit_order"
+                if isinstance(n, ast.Call) and _is_ctx_submit_order(n)
             ]
-            if len(submit_calls) == 0:
+            single_call_has_bracket_exit = len(ctx_submit_calls) == 1 and _has_attached_exit_kwarg(
+                ctx_submit_calls[0]
+            )
+            if len(ctx_submit_calls) == 0:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
@@ -307,15 +312,17 @@ class CodeSafetyChecker:
                         ),
                     )
                 )
-            elif len(submit_calls) == 1:
+            elif len(ctx_submit_calls) == 1 and not single_call_has_bracket_exit:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
                         passed=False,
                         severity="critical",
                         details=(
-                            "Only one ctx.submit_order call found — strategy has no "
-                            "exit path. Add a second submit_order to close positions."
+                            "Only one ctx.submit_order call found and no attached "
+                            "bracket exit (attached_stop_loss / attached_take_profit) "
+                            "— strategy has no exit path. Add a second submit_order "
+                            "or attach a bracket leg to close positions."
                         ),
                     )
                 )
@@ -340,6 +347,35 @@ def _get_call_name(node: ast.Call) -> str:
     if isinstance(node.func, ast.Attribute):
         return node.func.attr
     return ""
+
+
+def _is_ctx_submit_order(node: ast.Call) -> bool:
+    """True iff ``node`` is a ``ctx.submit_order(...)`` call.
+
+    Restricting on the receiver matters: a strategy that defines a helper
+    method ``self.submit_order(...)`` or a local function named
+    ``submit_order`` would otherwise satisfy the order-flow gate without
+    ever reaching the runtime engine.
+    """
+    if not isinstance(node.func, ast.Attribute):
+        return False
+    if node.func.attr != "submit_order":
+        return False
+    receiver = node.func.value
+    return isinstance(receiver, ast.Name) and receiver.id == "ctx"
+
+
+def _has_attached_exit_kwarg(node: ast.Call) -> bool:
+    """True iff the call passes ``attached_stop_loss`` or ``attached_take_profit``.
+
+    Bracket / OCO orders (issue #389) bundle the exit logic onto the entry
+    submission, so a single ``ctx.submit_order(..., attached_stop_loss=...)``
+    is a complete entry+exit pair.
+    """
+    return any(
+        kw.arg in ("attached_stop_loss", "attached_take_profit") and kw.value is not None
+        for kw in node.keywords
+    )
 
 
 def _find_strategy_subclasses(tree: ast.AST) -> List[ast.ClassDef]:

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -539,6 +539,47 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
             else {}
         )
 
+        # Expand receiver_names with simple aliases. A strategy may
+        # introduce a local alias before submitting orders:
+        #
+        #     trade_ctx = ctx
+        #     trade_ctx.submit_order(...)
+        #
+        # ``trade_ctx`` and ``ctx`` are interchangeable here — the
+        # binding flows trivially through ``Assign`` / ``AnnAssign``
+        # statements whose RHS is just another Name we already accept.
+        # Iterate to a fixed point so ``a = ctx; b = a`` accepts both.
+        expanded_receivers = set(receiver_names)
+        changed = True
+        while changed:
+            changed = False
+            for node in _iter_method_body_nodes(scope):
+                src_name: Optional[str] = None
+                target_name: Optional[str] = None
+                if (
+                    isinstance(node, ast.Assign)
+                    and len(node.targets) == 1
+                    and isinstance(node.targets[0], ast.Name)
+                    and isinstance(node.value, ast.Name)
+                ):
+                    target_name = node.targets[0].id
+                    src_name = node.value.id
+                elif (
+                    isinstance(node, ast.AnnAssign)
+                    and isinstance(node.target, ast.Name)
+                    and isinstance(node.value, ast.Name)
+                ):
+                    target_name = node.target.id
+                    src_name = node.value.id
+                if (
+                    src_name in expanded_receivers
+                    and target_name is not None
+                    and target_name not in expanded_receivers
+                ):
+                    expanded_receivers.add(target_name)
+                    changed = True
+        receiver_names = frozenset(expanded_receivers)
+
         for sub in _iter_method_body_nodes(scope):
             if not isinstance(sub, ast.Call):
                 continue

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -287,23 +287,24 @@ class CodeSafetyChecker:
         # 8. Order-flow shape (#547): every viable strategy must call
         #    ``ctx.submit_order(...)`` from inside one of the engine-callable
         #    hook methods (``on_bar``, ``on_start``, ``on_fill``, ``on_end``),
-        #    and must either call it twice (separate entry + exit) or carry
-        #    a non-None ``attached_stop_loss`` / ``attached_take_profit``
-        #    on the single call (bracket / OCO support, #389).
+        #    and the reachable calls must form a real entry+exit pair —
+        #    either two calls with distinct ``side`` values, or a single
+        #    call with a non-None ``attached_stop_loss`` /
+        #    ``attached_take_profit`` (bracket / OCO support, #389).
         #
-        #    * The hook signature determines the receiver name we count
-        #      against — ``on_bar(self, ctx, bar)`` looks for
-        #      ``ctx.submit_order``, ``on_bar(self, context, bar)`` looks
-        #      for ``context.submit_order``. The engine calls hooks
-        #      positionally so the parameter name is the strategy's choice.
-        #    * Helper methods are ignored unless they are themselves engine
-        #      hooks: a ``submit_order`` call sitting in an un-invoked
-        #      helper does not reach the runtime.
+        #    * Engine hooks accept only their second positional parameter
+        #      as the context receiver (``def on_bar(self, ctx, bar):``
+        #      looks for ``ctx.submit_order``; a swapped
+        #      ``def on_bar(self, bar, ctx):`` accepts only ``bar`` and
+        #      its ``submit_order`` would crash at runtime — flagged).
+        #    * Helpers reached via ``self.<method>(...)`` from a hook
+        #      relax the receiver check to any non-``self`` positional
+        #      parameter, since the call site we can't statically resolve
+        #      may pass the context through.
+        #    * Two ``side="LONG"`` calls do not form an entry+exit pair;
+        #      a real exit requires the opposite side or a bracket leg.
         if len(strategy_classes) == 1:
             hook_calls = _collect_hook_submit_calls(strategy_classes[0])
-            single_call_has_bracket_exit = len(hook_calls) == 1 and _has_attached_exit_kwarg(
-                hook_calls[0]
-            )
             if len(hook_calls) == 0:
                 results.append(
                     QualityGateResult(
@@ -317,19 +318,27 @@ class CodeSafetyChecker:
                         ),
                     )
                 )
-            elif len(hook_calls) == 1 and not single_call_has_bracket_exit:
+            elif not _calls_form_entry_exit_pair(hook_calls):
+                if len(hook_calls) == 1:
+                    detail = (
+                        "Only one ctx.submit_order call found in the engine hooks "
+                        "and no non-None attached bracket exit (attached_stop_loss "
+                        "/ attached_take_profit) — strategy has no exit path."
+                    )
+                else:
+                    detail = (
+                        "Multiple ctx.submit_order calls found but all use the same "
+                        "side and no bracket exit is attached — strategy has no real "
+                        "exit leg. Closing a position requires submitting the opposite "
+                        "side (LONG↔SHORT/FLAT) or an attached_stop_loss / "
+                        "attached_take_profit bracket leg."
+                    )
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
                         passed=False,
                         severity="critical",
-                        details=(
-                            "Only one ctx.submit_order call found in the engine hooks "
-                            "and no non-None attached bracket exit (attached_stop_loss "
-                            "/ attached_take_profit) — strategy has no exit path. Add "
-                            "a second submit_order or attach a bracket leg to close "
-                            "positions."
-                        ),
+                        details=detail,
                     )
                 )
 
@@ -368,21 +377,26 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
     Engine hooks (``on_bar`` / ``on_start`` / ``on_fill`` / ``on_end``) are
     the only methods the runtime invokes directly. We:
 
-    1. Walk each hook and record ``<ctx_param>.submit_order(...)`` calls
-       where ``<ctx_param>`` is the hook's second positional parameter
-       (so ``context.submit_order(...)`` is accepted when the hook is
-       declared ``on_bar(self, context, bar)``).
+    1. For each hook, accept ``<ctx>.submit_order(...)`` calls ONLY where
+       ``<ctx>`` is the hook's second positional parameter (after
+       ``self``). Engine hooks are dispatched positionally, so the
+       second positional is unambiguously the StrategyContext;
+       ``bar.submit_order(...)`` or a swapped
+       ``def on_bar(self, bar, ctx): bar.submit_order(...)`` would
+       crash at runtime and must not pass the gate.
     2. Follow ``self.<method>(...)`` calls from each hook into other
        methods of the same class — strategies routinely factor order
        placement into helpers (e.g. ``self._enter(ctx, bar)``). In each
-       reachable helper, we treat any ``<param>.submit_order(...)`` call
-       on a positional parameter of that helper as a real order
-       submission, since the hook is the only entry point and any
-       parameter is plausibly the engine context threaded through.
+       reachable helper we cannot reliably know which parameter carries
+       the threaded-through context (the call site uses positional or
+       keyword args we'd have to track symbolically), so we relax to
+       any non-``self`` positional parameter. This is permissive but
+       sound — the helper is reachable from a hook, and any of its
+       parameters could plausibly carry the context.
 
     A simple worklist with a ``visited`` set handles mutual recursion;
     helpers never invoked from a hook (or transitively from one) are
-    still ignored, which is what we want.
+    still ignored.
     """
     methods_by_name: Dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
     for node in ast.iter_child_nodes(cls):
@@ -391,21 +405,30 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
 
     calls: List[ast.Call] = []
     visited: set[str] = set()
-    worklist: List[ast.FunctionDef | ast.AsyncFunctionDef] = [
-        m for name, m in methods_by_name.items() if name in _ENGINE_HOOK_METHODS
+    # Worklist entries: (method, is_hook). is_hook=True restricts the
+    # accepted receiver to the second positional parameter only.
+    worklist: List[tuple[ast.FunctionDef | ast.AsyncFunctionDef, bool]] = [
+        (m, True) for name, m in methods_by_name.items() if name in _ENGINE_HOOK_METHODS
     ]
 
     while worklist:
-        method = worklist.pop()
+        method, is_hook = worklist.pop()
         if method.name in visited:
             continue
         visited.add(method.name)
 
-        # Accepted receiver names for this method: every positional param
-        # except ``self``. For hooks the engine guarantees the second
-        # positional is the context; for helpers, any parameter could
-        # carry the threaded-through ctx.
-        param_names = {arg.arg for arg in method.args.args if arg.arg != "self"}
+        if is_hook:
+            # Engine hook: only the second positional is the context.
+            # ``bar``/``fill`` siblings do not have ``submit_order``.
+            if len(method.args.args) >= 2:
+                receiver_names = {method.args.args[1].arg}
+            else:
+                receiver_names = set()
+        else:
+            # Helper reached from a hook: accept any positional parameter
+            # except ``self`` — we can't statically track which one was
+            # bound to the context, but any of them could be.
+            receiver_names = {arg.arg for arg in method.args.args if arg.arg != "self"}
 
         for sub in ast.walk(method):
             if not isinstance(sub, ast.Call):
@@ -414,11 +437,11 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
                 isinstance(sub.func, ast.Attribute)
                 and sub.func.attr == "submit_order"
                 and isinstance(sub.func.value, ast.Name)
-                and sub.func.value.id in param_names
+                and sub.func.value.id in receiver_names
             ):
                 calls.append(sub)
                 continue
-            # Queue ``self.<helper>(...)`` for traversal.
+            # Queue ``self.<helper>(...)`` for traversal as a helper.
             if (
                 isinstance(sub.func, ast.Attribute)
                 and isinstance(sub.func.value, ast.Name)
@@ -426,9 +449,78 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
             ):
                 helper = methods_by_name.get(sub.func.attr)
                 if helper is not None and helper.name not in visited:
-                    worklist.append(helper)
+                    worklist.append((helper, False))
 
     return calls
+
+
+# Side values that indicate an entry leg (opens a position).
+_ENTRY_SIDES = frozenset({"LONG", "SHORT", "BUY", "SELL"})
+# Side values that indicate an exit leg (flattens an open position).
+_EXIT_SIDES = frozenset({"FLAT", "CLOSE", "EXIT"})
+
+
+def _submit_order_side(node: ast.Call) -> Optional[str]:
+    """Best-effort extraction of the ``side`` value from a submit_order call.
+
+    Returns an upper-cased string when the call uses a recognised literal
+    form, else None when the side is dynamic / can't be determined
+    statically. Handles three forms:
+
+    * Keyword string literal: ``side="LONG"`` → ``"LONG"``.
+    * Keyword enum member: ``side=OrderSide.LONG`` → ``"LONG"``.
+    * Keyword string concatenations or computed values → ``None``.
+    """
+    for kw in node.keywords:
+        if kw.arg != "side":
+            continue
+        val = kw.value
+        if isinstance(val, ast.Constant) and isinstance(val.value, str):
+            return val.value.upper()
+        if isinstance(val, ast.Attribute):
+            return val.attr.upper()
+    return None
+
+
+def _calls_form_entry_exit_pair(calls: List[ast.Call]) -> bool:
+    """True iff the collected submit_order calls plausibly include both an
+    entry and an exit leg.
+
+    The contract closes positions by submitting an opposite-side order
+    with ``qty == position.qty``. We approximate that here statically:
+
+    * If any call carries ``attached_stop_loss`` / ``attached_take_profit``
+      (a non-None bracket leg), it brings its own exit.
+    * Otherwise we extract the literal ``side`` from each call and
+      require at least two distinct values. ``LONG`` + ``LONG`` is
+      one-sided and fails the gate; ``LONG`` + ``FLAT`` /
+      ``LONG`` + ``SHORT`` / ``BUY`` + ``CLOSE`` etc. pass.
+    * Calls whose side cannot be determined statically (dynamic
+      expressions) are treated optimistically as "could be either" so
+      they don't false-fail strategies that branch on a signal.
+    """
+    if any(_has_attached_exit_kwarg(c) for c in calls):
+        return True
+    sides_seen: set[str] = set()
+    has_unknown = False
+    for c in calls:
+        side = _submit_order_side(c)
+        if side is None:
+            has_unknown = True
+        else:
+            sides_seen.add(side)
+    # Distinct-side requirement: at least one entry-like and one exit-like,
+    # or simply two distinct recognised sides (covers BUY/SELL pairs etc.).
+    has_entry = bool(sides_seen & _ENTRY_SIDES)
+    has_exit = bool(sides_seen & _EXIT_SIDES)
+    if has_entry and has_exit:
+        return True
+    if len(sides_seen) >= 2:
+        return True
+    # Could be a runtime-decided side — be permissive rather than false-fail.
+    if has_unknown and len(calls) >= 2:
+        return True
+    return False
 
 
 def _has_attached_exit_kwarg(node: ast.Call) -> bool:

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -285,26 +285,32 @@ class CodeSafetyChecker:
             )
 
         # 8. Order-flow shape (#547): every viable strategy must call
-        #    ``ctx.submit_order(...)`` from inside one of the engine-callable
-        #    hook methods (``on_bar``, ``on_start``, ``on_fill``, ``on_end``),
-        #    and the reachable calls must form a real entry+exit pair —
-        #    either two calls with distinct ``side`` values, or a single
-        #    call with a non-None ``attached_stop_loss`` /
-        #    ``attached_take_profit`` (bracket / OCO support, #389).
+        #    ``ctx.submit_order(...)`` from inside ``on_bar`` (directly or
+        #    via a helper invoked from it), and the reachable calls must
+        #    form a real entry+exit pair — either two calls with distinct
+        #    ``side`` values, or a single call with a non-None
+        #    ``attached_stop_loss`` / ``attached_take_profit`` (bracket /
+        #    OCO support, #389).
         #
-        #    * Engine hooks accept only their second positional parameter
-        #      as the context receiver (``def on_bar(self, ctx, bar):``
+        #    * The trading service only processes the ``HarnessResponse``
+        #      from ``send_bar``; ``send_start`` / ``send_fill`` /
+        #      ``send_end`` responses are discarded today, so any
+        #      ``submit_order`` made from those hooks is dropped before
+        #      backtesting. The gate counts only ``on_bar``-reachable
+        #      calls to match the engine's real behaviour.
+        #    * ``on_bar`` accepts only its second positional parameter as
+        #      the context receiver (``def on_bar(self, ctx, bar):``
         #      looks for ``ctx.submit_order``; a swapped
         #      ``def on_bar(self, bar, ctx):`` accepts only ``bar`` and
-        #      its ``submit_order`` would crash at runtime — flagged).
-        #    * Helpers reached via ``self.<method>(...)`` from a hook
+        #      ``ctx.submit_order`` would crash at runtime — flagged).
+        #    * Helpers reached via ``self.<method>(...)`` from ``on_bar``
         #      relax the receiver check to any non-``self`` positional
         #      parameter, since the call site we can't statically resolve
         #      may pass the context through.
         #    * Two ``side="LONG"`` calls do not form an entry+exit pair;
         #      a real exit requires the opposite side or a bracket leg.
         if len(strategy_classes) == 1:
-            hook_calls, has_entry_capable_call = _collect_hook_submit_calls(strategy_classes[0])
+            hook_calls = _collect_hook_submit_calls(strategy_classes[0])
             if len(hook_calls) == 0:
                 results.append(
                     QualityGateResult(
@@ -312,28 +318,12 @@ class CodeSafetyChecker:
                         passed=False,
                         severity="critical",
                         details=(
-                            "No ctx.submit_order call found inside on_bar / on_start / "
-                            "on_fill / on_end — strategy has no entry path reachable "
-                            "from the engine and would emit zero trades."
-                        ),
-                    )
-                )
-            elif not has_entry_capable_call:
-                # All reachable submit_order calls live in on_fill / on_end,
-                # which the runtime only invokes AFTER a prior fill / at
-                # stream end. With no order originating from on_bar /
-                # on_start, the strategy never seeds a position and emits
-                # zero trades.
-                results.append(
-                    QualityGateResult(
-                        gate_name=GATE,
-                        passed=False,
-                        severity="critical",
-                        details=(
-                            "ctx.submit_order calls were found only in on_fill / on_end. "
-                            "Those hooks run after a prior fill / after the data stream "
-                            "and cannot bootstrap a position; the strategy needs at "
-                            "least one submit_order in on_bar or on_start."
+                            "No ctx.submit_order call reachable from on_bar — strategy "
+                            "has no entry path that the engine will process. The "
+                            "trading service only consumes orders submitted from "
+                            "on_bar (responses from on_start / on_fill / on_end are "
+                            "currently dropped), so any submission outside on_bar is "
+                            "silently ignored."
                         ),
                     )
                 )
@@ -384,20 +374,18 @@ def _get_call_name(node: ast.Call) -> str:
     return ""
 
 
-# Engine-callable hook method names (``contract.Strategy``). The runtime
-# invokes each positionally, so the parameter NAME the strategy chooses
-# for the context object is the strategy's choice — we read it off the
-# signature rather than hard-coding ``ctx``.
-_ENGINE_HOOK_METHODS = frozenset({"on_bar", "on_start", "on_fill", "on_end"})
-
-# Hooks that can BOOTSTRAP a position. ``on_bar`` runs on every finalised
-# bar; ``on_start`` runs once before the first bar. ``on_fill`` only runs
-# AFTER a prior order fill (so it can't seed the first order) and
-# ``on_end`` runs after the data stream — neither can initiate trading
-# on its own. The order-flow gate requires at least one ``submit_order``
-# reachable from an entry-capable hook to avoid the false-positive of a
-# strategy whose only orders sit in ``on_fill`` / ``on_end``.
-_ENTRY_CAPABLE_HOOK_METHODS = frozenset({"on_bar", "on_start"})
+# Hook methods whose ``submit_order`` calls actually reach the engine.
+#
+# The streaming harness sends every hook (``on_start`` / ``on_bar`` /
+# ``on_fill`` / ``on_end``) to the strategy subprocess, but the trading
+# service ONLY processes the ``HarnessResponse`` returned from ``send_bar``
+# into pending orders (see ``trading_service/service.py``). The responses
+# from ``send_start`` (line 483-489), ``send_fill`` (line 637-641), and
+# ``send_end`` (line 1114) are discarded, so any ``submit_order`` made
+# from those hooks is dropped before backtesting. The order-flow gate
+# only credits ``on_bar`` calls — matching the engine's real behaviour
+# avoids passing strategies that would silently emit zero trades.
+_PROCESSED_HOOK_METHODS = frozenset({"on_bar"})
 
 
 def _iter_method_body_nodes(method: ast.FunctionDef | ast.AsyncFunctionDef):
@@ -422,27 +410,27 @@ def _iter_method_body_nodes(method: ast.FunctionDef | ast.AsyncFunctionDef):
             stack.append(child)
 
 
-def _collect_hook_submit_calls(cls: ast.ClassDef) -> tuple[List[ast.Call], bool]:
-    """Return reachable ``submit_order(...)`` calls and an entry-reachability flag.
+def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
+    """Return every ``submit_order(...)`` call reachable from ``on_bar``.
 
-    Returns a tuple ``(calls, has_entry_capable_call)``:
+    ``on_bar`` is the only engine hook whose ``HarnessResponse`` is
+    actually processed into pending orders by the trading service
+    (``send_start`` / ``send_fill`` / ``send_end`` are called without
+    consuming their responses, so any ``submit_order`` made from those
+    hooks is silently dropped). Limiting the gate's roots to ``on_bar``
+    matches the engine's real behaviour.
 
-    * ``calls`` is every ``submit_order`` call statically reachable from
-      any engine hook (or from a helper invoked transitively via
-      ``self.<method>(...)``).
-    * ``has_entry_capable_call`` is True iff at least one call originates
-      from a hook that can initiate trading — ``on_bar`` or ``on_start``
-      directly, or a helper reachable from one of those hooks.
-      ``on_fill`` and ``on_end`` cannot bootstrap a position on their
-      own; a strategy whose only orders sit in those hooks will never
-      submit anything in practice.
+    The walker also follows ``self.<method>(...)`` edges into other
+    methods of the same class so a strategy that factors order placement
+    into helpers (e.g. ``self._enter(ctx, bar)`` invoked from ``on_bar``)
+    still satisfies the gate.
 
-    Walks the AST but stops at nested function/class boundaries — an
-    uninvoked local ``def`` inside ``on_bar`` containing
-    ``ctx.submit_order(...)`` does NOT satisfy the gate, because Python
-    only creates the function object and never executes its body.
+    Walks each method's body but stops at nested ``def`` / ``class`` /
+    ``lambda`` boundaries — an uninvoked local helper inside ``on_bar``
+    that contains ``ctx.submit_order(...)`` is not reachable because
+    Python only creates the function object and never executes its body.
 
-    Engine hooks are dispatched positionally; only the second positional
+    ``on_bar`` is dispatched positionally, so only its second positional
     parameter is the StrategyContext. Helpers reached via
     ``self.<method>(...)`` relax to any non-``self`` positional parameter
     since the call site can pass the context through any of them.
@@ -454,27 +442,20 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> tuple[List[ast.Call], bool]
 
     calls: List[ast.Call] = []
     visited: set[str] = set()
-    # Worklist entries: (method, is_hook, from_entry_capable_root). is_hook
-    # restricts the accepted receiver to the second positional parameter
-    # only; from_entry_capable_root tracks whether this method is reached
-    # transitively from on_bar / on_start so we can flag the entry path.
-    has_entry_capable_call = False
-    worklist: List[tuple[ast.FunctionDef | ast.AsyncFunctionDef, bool, bool]] = []
+    # Worklist entries: (method, is_hook). is_hook=True restricts the
+    # accepted receiver to the second positional parameter; helpers
+    # (is_hook=False) accept any non-self positional parameter since the
+    # call site may pass the context through any of them.
+    worklist: List[tuple[ast.FunctionDef | ast.AsyncFunctionDef, bool]] = []
     for name, m in methods_by_name.items():
-        if name in _ENGINE_HOOK_METHODS:
-            worklist.append((m, True, name in _ENTRY_CAPABLE_HOOK_METHODS))
+        if name in _PROCESSED_HOOK_METHODS:
+            worklist.append((m, True))
 
     while worklist:
-        method, is_hook, from_entry = worklist.pop()
-        # Multiple roots may reach the same helper. Visit each
-        # (method, from_entry) combination at most once so a helper
-        # reached from both on_bar and on_fill still propagates the
-        # entry-capable flag rather than getting masked by the first
-        # non-entry visit.
-        visit_key = f"{method.name}#{1 if from_entry else 0}"
-        if visit_key in visited:
+        method, is_hook = worklist.pop()
+        if method.name in visited:
             continue
-        visited.add(visit_key)
+        visited.add(method.name)
 
         if is_hook:
             # Engine hook: only the second positional is the context.
@@ -499,8 +480,6 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> tuple[List[ast.Call], bool]
                 and sub.func.value.id in receiver_names
             ):
                 calls.append(sub)
-                if from_entry:
-                    has_entry_capable_call = True
                 continue
             # Queue ``self.<helper>(...)`` for traversal as a helper.
             if (
@@ -509,12 +488,10 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> tuple[List[ast.Call], bool]
                 and sub.func.value.id == "self"
             ):
                 helper = methods_by_name.get(sub.func.attr)
-                if helper is not None:
-                    next_key = f"{helper.name}#{1 if from_entry else 0}"
-                    if next_key not in visited:
-                        worklist.append((helper, False, from_entry))
+                if helper is not None and helper.name not in visited:
+                    worklist.append((helper, False))
 
-    return calls, has_entry_capable_call
+    return calls
 
 
 # Recognised ``OrderSide`` literal values. The runtime contract

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -304,7 +304,7 @@ class CodeSafetyChecker:
         #    * Two ``side="LONG"`` calls do not form an entry+exit pair;
         #      a real exit requires the opposite side or a bracket leg.
         if len(strategy_classes) == 1:
-            hook_calls = _collect_hook_submit_calls(strategy_classes[0])
+            hook_calls, has_entry_capable_call = _collect_hook_submit_calls(strategy_classes[0])
             if len(hook_calls) == 0:
                 results.append(
                     QualityGateResult(
@@ -315,6 +315,25 @@ class CodeSafetyChecker:
                             "No ctx.submit_order call found inside on_bar / on_start / "
                             "on_fill / on_end — strategy has no entry path reachable "
                             "from the engine and would emit zero trades."
+                        ),
+                    )
+                )
+            elif not has_entry_capable_call:
+                # All reachable submit_order calls live in on_fill / on_end,
+                # which the runtime only invokes AFTER a prior fill / at
+                # stream end. With no order originating from on_bar /
+                # on_start, the strategy never seeds a position and emits
+                # zero trades.
+                results.append(
+                    QualityGateResult(
+                        gate_name=GATE,
+                        passed=False,
+                        severity="critical",
+                        details=(
+                            "ctx.submit_order calls were found only in on_fill / on_end. "
+                            "Those hooks run after a prior fill / after the data stream "
+                            "and cannot bootstrap a position; the strategy needs at "
+                            "least one submit_order in on_bar or on_start."
                         ),
                     )
                 )
@@ -371,33 +390,62 @@ def _get_call_name(node: ast.Call) -> str:
 # signature rather than hard-coding ``ctx``.
 _ENGINE_HOOK_METHODS = frozenset({"on_bar", "on_start", "on_fill", "on_end"})
 
+# Hooks that can BOOTSTRAP a position. ``on_bar`` runs on every finalised
+# bar; ``on_start`` runs once before the first bar. ``on_fill`` only runs
+# AFTER a prior order fill (so it can't seed the first order) and
+# ``on_end`` runs after the data stream — neither can initiate trading
+# on its own. The order-flow gate requires at least one ``submit_order``
+# reachable from an entry-capable hook to avoid the false-positive of a
+# strategy whose only orders sit in ``on_fill`` / ``on_end``.
+_ENTRY_CAPABLE_HOOK_METHODS = frozenset({"on_bar", "on_start"})
 
-def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
-    """Return every ``submit_order(...)`` call reachable from an engine hook.
 
-    Engine hooks (``on_bar`` / ``on_start`` / ``on_fill`` / ``on_end``) are
-    the only methods the runtime invokes directly. We:
+def _iter_method_body_nodes(method: ast.FunctionDef | ast.AsyncFunctionDef):
+    """Yield every AST node in ``method``'s body without descending into
+    nested ``def`` / ``async def`` / ``lambda`` / ``class`` bodies.
 
-    1. For each hook, accept ``<ctx>.submit_order(...)`` calls ONLY where
-       ``<ctx>`` is the hook's second positional parameter (after
-       ``self``). Engine hooks are dispatched positionally, so the
-       second positional is unambiguously the StrategyContext;
-       ``bar.submit_order(...)`` or a swapped
-       ``def on_bar(self, bar, ctx): bar.submit_order(...)`` would
-       crash at runtime and must not pass the gate.
-    2. Follow ``self.<method>(...)`` calls from each hook into other
-       methods of the same class — strategies routinely factor order
-       placement into helpers (e.g. ``self._enter(ctx, bar)``). In each
-       reachable helper we cannot reliably know which parameter carries
-       the threaded-through context (the call site uses positional or
-       keyword args we'd have to track symbolically), so we relax to
-       any non-``self`` positional parameter. This is permissive but
-       sound — the helper is reachable from a hook, and any of its
-       parameters could plausibly carry the context.
+    Python only creates the function/class object for a nested
+    declaration; its body never runs unless something explicitly invokes
+    it. Naïvely using ``ast.walk(method)`` would treat ``submit_order``
+    calls inside an uninvoked local helper inside the hook as reachable,
+    which is wrong — those calls never reach the runtime engine.
+    """
+    stack: List[ast.AST] = list(method.body)
+    while stack:
+        node = stack.pop()
+        yield node
+        # Stop descent at any nested function / class / lambda boundary —
+        # its body is a new scope that only runs if explicitly invoked.
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)):
+            continue
+        for child in ast.iter_child_nodes(node):
+            stack.append(child)
 
-    A simple worklist with a ``visited`` set handles mutual recursion;
-    helpers never invoked from a hook (or transitively from one) are
-    still ignored.
+
+def _collect_hook_submit_calls(cls: ast.ClassDef) -> tuple[List[ast.Call], bool]:
+    """Return reachable ``submit_order(...)`` calls and an entry-reachability flag.
+
+    Returns a tuple ``(calls, has_entry_capable_call)``:
+
+    * ``calls`` is every ``submit_order`` call statically reachable from
+      any engine hook (or from a helper invoked transitively via
+      ``self.<method>(...)``).
+    * ``has_entry_capable_call`` is True iff at least one call originates
+      from a hook that can initiate trading — ``on_bar`` or ``on_start``
+      directly, or a helper reachable from one of those hooks.
+      ``on_fill`` and ``on_end`` cannot bootstrap a position on their
+      own; a strategy whose only orders sit in those hooks will never
+      submit anything in practice.
+
+    Walks the AST but stops at nested function/class boundaries — an
+    uninvoked local ``def`` inside ``on_bar`` containing
+    ``ctx.submit_order(...)`` does NOT satisfy the gate, because Python
+    only creates the function object and never executes its body.
+
+    Engine hooks are dispatched positionally; only the second positional
+    parameter is the StrategyContext. Helpers reached via
+    ``self.<method>(...)`` relax to any non-``self`` positional parameter
+    since the call site can pass the context through any of them.
     """
     methods_by_name: Dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
     for node in ast.iter_child_nodes(cls):
@@ -406,17 +454,27 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
 
     calls: List[ast.Call] = []
     visited: set[str] = set()
-    # Worklist entries: (method, is_hook). is_hook=True restricts the
-    # accepted receiver to the second positional parameter only.
-    worklist: List[tuple[ast.FunctionDef | ast.AsyncFunctionDef, bool]] = [
-        (m, True) for name, m in methods_by_name.items() if name in _ENGINE_HOOK_METHODS
-    ]
+    # Worklist entries: (method, is_hook, from_entry_capable_root). is_hook
+    # restricts the accepted receiver to the second positional parameter
+    # only; from_entry_capable_root tracks whether this method is reached
+    # transitively from on_bar / on_start so we can flag the entry path.
+    has_entry_capable_call = False
+    worklist: List[tuple[ast.FunctionDef | ast.AsyncFunctionDef, bool, bool]] = []
+    for name, m in methods_by_name.items():
+        if name in _ENGINE_HOOK_METHODS:
+            worklist.append((m, True, name in _ENTRY_CAPABLE_HOOK_METHODS))
 
     while worklist:
-        method, is_hook = worklist.pop()
-        if method.name in visited:
+        method, is_hook, from_entry = worklist.pop()
+        # Multiple roots may reach the same helper. Visit each
+        # (method, from_entry) combination at most once so a helper
+        # reached from both on_bar and on_fill still propagates the
+        # entry-capable flag rather than getting masked by the first
+        # non-entry visit.
+        visit_key = f"{method.name}#{1 if from_entry else 0}"
+        if visit_key in visited:
             continue
-        visited.add(method.name)
+        visited.add(visit_key)
 
         if is_hook:
             # Engine hook: only the second positional is the context.
@@ -431,7 +489,7 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
             # bound to the context, but any of them could be.
             receiver_names = {arg.arg for arg in method.args.args if arg.arg != "self"}
 
-        for sub in ast.walk(method):
+        for sub in _iter_method_body_nodes(method):
             if not isinstance(sub, ast.Call):
                 continue
             if (
@@ -441,6 +499,8 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
                 and sub.func.value.id in receiver_names
             ):
                 calls.append(sub)
+                if from_entry:
+                    has_entry_capable_call = True
                 continue
             # Queue ``self.<helper>(...)`` for traversal as a helper.
             if (
@@ -449,10 +509,12 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
                 and sub.func.value.id == "self"
             ):
                 helper = methods_by_name.get(sub.func.attr)
-                if helper is not None and helper.name not in visited:
-                    worklist.append((helper, False))
+                if helper is not None:
+                    next_key = f"{helper.name}#{1 if from_entry else 0}"
+                    if next_key not in visited:
+                        worklist.append((helper, False, from_entry))
 
-    return calls
+    return calls, has_entry_capable_call
 
 
 # Recognised ``OrderSide`` literal values. The runtime contract

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -431,6 +431,50 @@ def _find_nested_def_defs(
     return local_defs
 
 
+def _resolve_helper_receivers(
+    call: ast.Call,
+    helper: ast.FunctionDef | ast.AsyncFunctionDef,
+    outer_receivers: frozenset[str],
+) -> frozenset[str]:
+    """Return the helper parameter names that are bound to the outer
+    scope's context at the call site.
+
+    For ``self._trade(ctx, bar)`` where the outer scope's
+    ``receiver_names`` is ``{"ctx"}``: the first positional after self
+    in ``_trade``'s signature receives ``ctx``, so its name (e.g.
+    ``ctx`` or whatever the helper named that parameter) goes into the
+    returned set. Calls that don't pass any outer-receiver name as an
+    argument end up with an empty set — a ``submit_order`` inside such
+    a helper does NOT satisfy the gate.
+
+    Both positional and keyword arguments are tracked. Star-args /
+    keyword-spreads are ignored (rare in strategy code).
+    """
+    helper_params = [arg.arg for arg in helper.args.args if arg.arg != "self"]
+    bound: set[str] = set()
+
+    # Positional arguments — match against helper params by index.
+    for idx, arg in enumerate(call.args):
+        if idx >= len(helper_params):
+            break
+        if isinstance(arg, ast.Name) and arg.id in outer_receivers:
+            bound.add(helper_params[idx])
+
+    # Keyword arguments — match the parameter the keyword names.
+    for kw in call.keywords:
+        if kw.arg is None:
+            # **kwargs spread — can't statically resolve.
+            continue
+        if (
+            isinstance(kw.value, ast.Name)
+            and kw.value.id in outer_receivers
+            and kw.arg in helper_params
+        ):
+            bound.add(kw.arg)
+
+    return frozenset(bound)
+
+
 def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
     """Return every ``submit_order(...)`` call reachable from ``on_bar``.
 
@@ -507,8 +551,13 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
             ):
                 calls.append(sub)
                 continue
-            # 2. self.<helper>(...) — class method, traversed with its
-            #    own parameter set as the helper receiver names.
+            # 2. self.<helper>(...) — class method. The helper's accepted
+            #    receivers are bound to the call-site arguments: only
+            #    parameters that received a name from the OUTER scope's
+            #    receiver_names are treated as ctx-bound. Helpers called
+            #    without passing the context (e.g. ``self._trade(bar)``)
+            #    end up with no receivers and a ``submit_order`` on the
+            #    Bar parameter does NOT satisfy the gate.
             if (
                 isinstance(sub.func, ast.Attribute)
                 and isinstance(sub.func.value, ast.Name)
@@ -516,9 +565,7 @@ def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
             ):
                 helper = methods_by_name.get(sub.func.attr)
                 if helper is not None and id(helper) not in visited_ids:
-                    helper_receivers = frozenset(
-                        arg.arg for arg in helper.args.args if arg.arg != "self"
-                    )
+                    helper_receivers = _resolve_helper_receivers(sub, helper, receiver_names)
                     worklist.append((helper, helper_receivers))
                 continue
             # 3. <local_name>(...) — closure defined in the same scope.

--- a/backend/agents/investment_team/strategy_lab/quality_gates/strategy_validator.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/strategy_validator.py
@@ -24,6 +24,15 @@ _ASSET_MISMATCH: dict[str, re.Pattern[str]] = {
     "commodities": re.compile(r"\b(earnings|dividend|P/E|EPS|market cap)\b", re.IGNORECASE),
 }
 
+# Recognised indicator/concept vocabulary for the hypothesis-vs-rules
+# consistency gate (#547 item 6). Word-boundary anchored so substrings like
+# "thematic" don't accidentally match "ema".
+_CONCEPT_TERMS = re.compile(
+    r"\b(rsi|macd|moving\s+average|ema|sma|bollinger|atr|breakout|"
+    r"mean\s+reversion|momentum|volatility|volume|vwap|stochastic|adx|obv)\b",
+    re.IGNORECASE,
+)
+
 
 class StrategySpecValidator:
     """Run deterministic checks on a StrategySpec before code execution."""
@@ -123,6 +132,31 @@ class StrategySpecValidator:
                     passed=False,
                     severity="warning",
                     details="Rules reference non-computable data (sentiment, social media, etc.) without a numerical proxy.",
+                )
+            )
+
+        # 8. Hypothesis-vs-rules consistency (#547 item 6). If the hypothesis
+        #    names indicator concepts that no entry/exit rule references (or
+        #    vice versa), the operational spec and the narrative rationale are
+        #    out of sync. Warning only — the refinement prompt can react.
+        hypothesis_text = spec.hypothesis or ""
+        rules_text = " ".join(spec.entry_rules + spec.exit_rules)
+        terms_in_hypothesis = {m.group(0).lower() for m in _CONCEPT_TERMS.finditer(hypothesis_text)}
+        terms_in_rules = {m.group(0).lower() for m in _CONCEPT_TERMS.finditer(rules_text)}
+        orphan_in_hypothesis = terms_in_hypothesis - terms_in_rules
+        orphan_in_rules = terms_in_rules - terms_in_hypothesis
+        if orphan_in_hypothesis or orphan_in_rules:
+            results.append(
+                QualityGateResult(
+                    gate_name=GATE,
+                    passed=False,
+                    severity="warning",
+                    details=(
+                        "Hypothesis/rules consistency: hypothesis mentions "
+                        f"{sorted(orphan_in_hypothesis) or 'nothing'} that rules don't "
+                        f"reference; rules mention {sorted(orphan_in_rules) or 'nothing'} "
+                        "that hypothesis doesn't."
+                    ),
                 )
             )
 

--- a/backend/agents/investment_team/tests/test_code_safety.py
+++ b/backend/agents/investment_team/tests/test_code_safety.py
@@ -760,6 +760,41 @@ def test_helper_receiver_bound_via_keyword_argument() -> None:
     assert not any("entry path" in c or "exit path" in c for c in criticals), criticals
 
 
+def test_simple_ctx_alias_is_tracked() -> None:
+    """A strategy may alias the context before submitting orders. The
+    walker should treat the alias as equivalent to the original
+    receiver name for the rest of the scope's body."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                trade_ctx = ctx
+                trade_ctx.submit_order(symbol='X', qty=1, side='LONG')
+                trade_ctx.submit_order(symbol='X', qty=1, side='SHORT')
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert not any("entry path" in c or "exit path" in c for c in criticals), criticals
+
+
+def test_chained_ctx_aliases_are_tracked() -> None:
+    """Alias chains (``a = ctx; b = a``) propagate at the fixed point."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                a = ctx
+                b = a
+                b.submit_order(symbol='X', qty=1, side='LONG')
+                b.submit_order(symbol='X', qty=1, side='SHORT')
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert not any("entry path" in c or "exit path" in c for c in criticals), criticals
+
+
 def test_helper_with_renamed_ctx_parameter_is_recognised() -> None:
     """When the helper renames its context parameter (``def _trade(self,
     my_ctx): my_ctx.submit_order(...)``), passing the hook's ``ctx`` as

--- a/backend/agents/investment_team/tests/test_code_safety.py
+++ b/backend/agents/investment_team/tests/test_code_safety.py
@@ -501,6 +501,64 @@ def test_dynamic_side_is_treated_optimistically() -> None:
     )
 
 
+def test_single_dynamic_side_call_is_accepted() -> None:
+    """A single ctx.submit_order(..., side=<dynamic>) that routes both entry
+    and exit through one call site (e.g. by inspecting ctx.position state)
+    is a legitimate pattern. The gate must not false-fail it just because
+    the side is not a literal LONG/SHORT."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+        from contract import OrderSide
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                pos = ctx.position(bar.symbol)
+                side = OrderSide.SHORT if pos else OrderSide.LONG
+                ctx.submit_order(symbol=bar.symbol, qty=1, side=side)
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert not any("entry path" in c or "exit path" in c or "exit leg" in c for c in criticals), (
+        criticals
+    )
+
+
+def test_non_order_side_literal_is_treated_as_unknown() -> None:
+    """OrderSide only defines LONG/SHORT. Strings like 'FLAT', 'CLOSE',
+    'BUY', 'SELL' would crash at runtime under OrderSide(side). The gate
+    treats them as unknown sides (not as recognised entry/exit markers),
+    so two same-side LONG calls do NOT slip through because the second
+    happens to be 'FLAT'."""
+    # Two calls both with non-OrderSide literals → both unknown → optimism
+    # rule (any unknown side) accepts. The runtime will surface the real
+    # error.
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                ctx.submit_order(symbol='X', qty=1, side='FLAT')
+                ctx.submit_order(symbol='X', qty=1, side='CLOSE')
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    # Both unknown → has_unknown=True → optimism. No "exit leg" critical.
+    assert not any("exit leg" in c for c in criticals), criticals
+
+    # But LONG + LONG (both recognised, same side, no unknown) still fails.
+    bad_code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                ctx.submit_order(symbol='X', qty=1, side='LONG')
+                ctx.submit_order(symbol='X', qty=1, side='LONG')
+    """)
+    bad_results = CodeSafetyChecker().check(bad_code)
+    bad_criticals = _critical_details(bad_results)
+    assert any("no real exit leg" in c for c in bad_criticals), bad_criticals
+
+
 def test_submit_order_on_bar_parameter_does_not_satisfy_gate() -> None:
     """The engine calls hooks positionally — the SECOND positional after
     ``self`` is always the context. A strategy that puts ``submit_order``

--- a/backend/agents/investment_team/tests/test_code_safety.py
+++ b/backend/agents/investment_team/tests/test_code_safety.py
@@ -40,7 +40,8 @@ def test_valid_minimal_strategy_passes() -> None:
 
         class MyStrat(Strategy):
             def on_bar(self, ctx, bar):
-                pass
+                ctx.submit_order(symbol='X', qty=1, side='LONG')
+                ctx.submit_order(symbol='X', qty=1, side='FLAT')
     """)
     results = CodeSafetyChecker().check(code)
     criticals = _critical_details(results)
@@ -84,7 +85,8 @@ def test_contract_attribute_base_also_recognised() -> None:
 
         class X(contract.Strategy):
             def on_bar(self, ctx, bar):
-                pass
+                ctx.submit_order(symbol='X', qty=1, side='LONG')
+                ctx.submit_order(symbol='X', qty=1, side='FLAT')
     """)
     results = CodeSafetyChecker().check(code)
     assert _critical_details(results) == []
@@ -159,7 +161,8 @@ def test_indicators_import_still_allowed() -> None:
 
         class S(Strategy):
             def on_bar(self, ctx, bar):
-                pass
+                ctx.submit_order(symbol='X', qty=1, side='LONG')
+                ctx.submit_order(symbol='X', qty=1, side='FLAT')
     """)
     results = CodeSafetyChecker().check(code)
     criticals = _critical_details(results)
@@ -245,3 +248,53 @@ def test_comment_mentioning_future_close_is_not_flagged() -> None:
     # assert no *lookahead* critical fired.
     criticals = _critical_details(results)
     assert not any("bar.next_" in c or "ctx.future_" in c or "ctx.peek" in c for c in criticals)
+
+
+# ---------------------------------------------------------------------------
+# Order-flow shape (#547 item 4): entry path + exit path required
+# ---------------------------------------------------------------------------
+
+
+def test_no_submit_order_is_critical_no_entry() -> None:
+    """A Strategy that never calls ``ctx.submit_order`` has no entry path."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                pass  # no submit_order — strategy emits zero trades
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert any("no entry path" in c for c in criticals), criticals
+
+
+def test_single_submit_order_is_critical_no_exit() -> None:
+    """A Strategy with only one ``ctx.submit_order`` call has no exit path."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                ctx.submit_order(symbol='X', qty=1, side='LONG')
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert any("no exit path" in c for c in criticals), criticals
+
+
+def test_two_submit_orders_passes_order_flow_gate() -> None:
+    """Two ``ctx.submit_order`` calls (entry + exit) satisfies the gate."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                if bar.close > 100:
+                    ctx.submit_order(symbol='X', qty=1, side='LONG')
+                else:
+                    ctx.submit_order(symbol='X', qty=1, side='FLAT')
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert not any("entry path" in c or "exit path" in c for c in criticals), criticals

--- a/backend/agents/investment_team/tests/test_code_safety.py
+++ b/backend/agents/investment_team/tests/test_code_safety.py
@@ -778,6 +778,57 @@ def test_simple_ctx_alias_is_tracked() -> None:
     assert not any("entry path" in c or "exit path" in c for c in criticals), criticals
 
 
+def test_local_closure_with_parameter_is_bound_at_call_site() -> None:
+    """A nested closure that accepts the context as a parameter and is
+    invoked with the runtime ctx should have that parameter bound:
+    ``def enter(c): c.submit_order(...); enter(ctx)``. Previously the
+    walker reused the outer receiver names and failed to count
+    ``c.submit_order``."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                def enter(c):
+                    c.submit_order(symbol='X', qty=1, side='LONG')
+                def exit_position(c):
+                    c.submit_order(symbol='X', qty=1, side='SHORT')
+                enter(ctx)
+                exit_position(ctx)
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert not any("entry path" in c or "exit path" in c for c in criticals), criticals
+
+
+def test_helper_revisited_with_distinct_bindings() -> None:
+    """When the same helper is invoked twice — once without the context
+    (``self._trade(bar)``) and once with (``self._trade(ctx)``) — the
+    walker must analyse both bindings rather than dedupe on the helper's
+    AST identity. The ctx-bound call's submit_order is what reaches
+    the engine, so the gate must recognise it."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def _trade(self, c):
+                c.submit_order(symbol='X', qty=1, side='LONG')
+                c.submit_order(symbol='X', qty=1, side='SHORT')
+            def on_bar(self, ctx, bar):
+                if bar.close > 100:
+                    # First call binds `c` to `bar` (not in receivers).
+                    self._trade(bar)
+                else:
+                    # Second call binds `c` to `ctx` — the gate must
+                    # recognise this even though _trade has been visited
+                    # once with the empty-binding from the first call.
+                    self._trade(ctx)
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert not any("entry path" in c or "exit path" in c for c in criticals), criticals
+
+
 def test_chained_ctx_aliases_are_tracked() -> None:
     """Alias chains (``a = ctx; b = a``) propagate at the fixed point."""
     code = textwrap.dedent("""

--- a/backend/agents/investment_team/tests/test_code_safety.py
+++ b/backend/agents/investment_team/tests/test_code_safety.py
@@ -298,3 +298,42 @@ def test_two_submit_orders_passes_order_flow_gate() -> None:
     results = CodeSafetyChecker().check(code)
     criticals = _critical_details(results)
     assert not any("entry path" in c or "exit path" in c for c in criticals), criticals
+
+
+def test_single_submit_order_with_bracket_exit_passes_order_flow_gate() -> None:
+    """A single ``ctx.submit_order(..., attached_stop_loss=...)`` is a complete
+    entry+bracket-exit pair (issue #389) and must not be flagged."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                ctx.submit_order(
+                    symbol='X',
+                    qty=1,
+                    side='LONG',
+                    attached_stop_loss={'stop_price': 95.0},
+                    attached_take_profit={'limit_price': 110.0},
+                )
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert not any("entry path" in c or "exit path" in c for c in criticals), criticals
+
+
+def test_self_submit_order_does_not_satisfy_order_flow_gate() -> None:
+    """Helper methods named ``self.submit_order`` never reach the runtime
+    engine, so they must NOT count toward the entry/exit requirement."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def submit_order(self, **kw):
+                pass  # internal helper, never calls ctx
+            def on_bar(self, ctx, bar):
+                self.submit_order(symbol='X')
+                self.submit_order(symbol='Y')
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert any("no entry path" in c for c in criticals), criticals

--- a/backend/agents/investment_team/tests/test_code_safety.py
+++ b/backend/agents/investment_team/tests/test_code_safety.py
@@ -719,6 +719,66 @@ def test_on_bar_with_swapped_signature_uses_second_positional_as_ctx() -> None:
     assert any("no entry path" in c for c in bad_criticals), bad_criticals
 
 
+def test_helper_receiver_bound_to_call_site_argument_rejects_bar_only() -> None:
+    """The walker must propagate the call-site argument that corresponds
+    to the hook's context — not blindly accept every helper parameter as
+    a possible receiver. ``def _trade(self, bar): bar.submit_order(...)``
+    called as ``self._trade(bar)`` would crash at runtime (bar is the
+    Bar object, not the StrategyContext) and must NOT pass the gate."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def _trade(self, bar):
+                bar.submit_order(symbol='X', qty=1, side='LONG')
+                bar.submit_order(symbol='X', qty=1, side='SHORT')
+            def on_bar(self, ctx, bar):
+                self._trade(bar)
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert any("no entry path" in c for c in criticals), criticals
+
+
+def test_helper_receiver_bound_via_keyword_argument() -> None:
+    """When the helper is called with the context as a keyword argument
+    (``self._trade(ctx=ctx, bar=bar)``), the helper's ``ctx`` parameter
+    is correctly bound to the runtime context and ``ctx.submit_order``
+    inside the helper satisfies the gate."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def _trade(self, bar, ctx):
+                ctx.submit_order(symbol='X', qty=1, side='LONG')
+                ctx.submit_order(symbol='X', qty=1, side='SHORT')
+            def on_bar(self, ctx, bar):
+                self._trade(ctx=ctx, bar=bar)
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert not any("entry path" in c or "exit path" in c for c in criticals), criticals
+
+
+def test_helper_with_renamed_ctx_parameter_is_recognised() -> None:
+    """When the helper renames its context parameter (``def _trade(self,
+    my_ctx): my_ctx.submit_order(...)``), passing the hook's ``ctx`` as
+    that positional argument must propagate the binding."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def _trade(self, my_ctx):
+                my_ctx.submit_order(symbol='X', qty=1, side='LONG')
+                my_ctx.submit_order(symbol='X', qty=1, side='SHORT')
+            def on_bar(self, ctx, bar):
+                self._trade(ctx)
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert not any("entry path" in c or "exit path" in c for c in criticals), criticals
+
+
 def test_transitive_helper_submit_orders_are_recognised() -> None:
     """Helpers called from helpers (transitively reachable from a hook)
     are still in the engine-reachable call graph and must count. The

--- a/backend/agents/investment_team/tests/test_code_safety.py
+++ b/backend/agents/investment_team/tests/test_code_safety.py
@@ -446,6 +446,118 @@ def test_submit_order_in_helper_called_from_on_bar_satisfies_order_flow_gate() -
     assert not any("entry path" in c or "exit path" in c for c in criticals), criticals
 
 
+def test_two_same_side_submit_orders_is_critical_no_exit() -> None:
+    """Two ``side='LONG'`` calls do not form an entry+exit pair — both are
+    entries. The gate must reject this as having no exit path."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                ctx.submit_order(symbol='X', qty=1, side='LONG')
+                ctx.submit_order(symbol='Y', qty=1, side='LONG')
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert any("no real exit leg" in c or "no exit path" in c for c in criticals), criticals
+
+
+def test_long_and_short_submit_orders_pass_order_flow_gate() -> None:
+    """``side='LONG'`` + ``side='SHORT'`` is a valid entry+opposite-exit pair."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                if bar.close > 100:
+                    ctx.submit_order(symbol='X', qty=1, side='LONG')
+                else:
+                    ctx.submit_order(symbol='X', qty=1, side='SHORT')
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert not any("entry path" in c or "exit path" in c or "exit leg" in c for c in criticals), (
+        criticals
+    )
+
+
+def test_dynamic_side_is_treated_optimistically() -> None:
+    """When the ``side`` is computed at runtime (not a literal), we cannot
+    statically tell whether the pair is one-sided, so we accept the strategy
+    rather than false-fail it. Two calls with dynamic sides pass."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                side = self._pick_side(bar)
+                ctx.submit_order(symbol='X', qty=1, side=side)
+                ctx.submit_order(symbol='Y', qty=1, side=side)
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert not any("entry path" in c or "exit path" in c or "exit leg" in c for c in criticals), (
+        criticals
+    )
+
+
+def test_submit_order_on_bar_parameter_does_not_satisfy_gate() -> None:
+    """The engine calls hooks positionally — the SECOND positional after
+    ``self`` is always the context. A strategy that puts ``submit_order``
+    on the wrong parameter (``bar.submit_order`` when the second positional
+    is ``ctx``) will crash at runtime because ``Bar`` has no submit_order.
+    The gate must reject this rather than accept the misplaced call.
+    """
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                bar.submit_order(symbol='X', qty=1, side='LONG')
+                bar.submit_order(symbol='X', qty=1, side='FLAT')
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    # ``ctx`` is the accepted receiver for the hook; ``bar.submit_order``
+    # is on the wrong parameter and is ignored, so the gate sees zero
+    # valid calls and emits "no entry path".
+    assert any("no entry path" in c for c in criticals), criticals
+
+
+def test_on_bar_with_swapped_signature_uses_second_positional_as_ctx() -> None:
+    """The engine calls hooks positionally — ``def on_bar(self, bar, ctx)``
+    binds the runtime ctx to the parameter named ``bar`` (second positional).
+    So ``bar.submit_order(...)`` is actually valid runtime code, and the
+    gate must accept it. Conversely, the unused-name parameter ``ctx`` is
+    bound to the Bar object and any ``ctx.submit_order`` would crash."""
+    # Legitimate case: ``bar`` is second positional → it IS the runtime ctx.
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, bar, ctx):
+                bar.submit_order(symbol='X', qty=1, side='LONG')
+                bar.submit_order(symbol='X', qty=1, side='FLAT')
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert not any("entry path" in c or "exit path" in c for c in criticals), criticals
+
+    # Buggy case: same swapped signature but submit_order on ``ctx``, which
+    # is now bound to the Bar object by the engine's positional dispatch.
+    bad_code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, bar, ctx):
+                ctx.submit_order(symbol='X', qty=1, side='LONG')
+                ctx.submit_order(symbol='X', qty=1, side='FLAT')
+    """)
+    bad_results = CodeSafetyChecker().check(bad_code)
+    bad_criticals = _critical_details(bad_results)
+    assert any("no entry path" in c for c in bad_criticals), bad_criticals
+
+
 def test_transitive_helper_submit_orders_are_recognised() -> None:
     """Helpers called from helpers (transitively reachable from a hook)
     are still in the engine-reachable call graph and must count. The

--- a/backend/agents/investment_team/tests/test_code_safety.py
+++ b/backend/agents/investment_team/tests/test_code_safety.py
@@ -481,6 +481,30 @@ def test_on_bar_entry_with_on_fill_exit_is_critical_no_exit() -> None:
     assert any("no exit path" in c for c in criticals), criticals
 
 
+def test_submit_order_in_invoked_local_closure_satisfies_gate() -> None:
+    """A nested ``def`` inside ``on_bar`` that IS called by name within
+    the same scope is engine-reachable — the closure captures ``ctx`` from
+    the outer frame. Common idiom: ``def enter(): ctx.submit_order(...);
+    enter()``."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                def enter():
+                    ctx.submit_order(symbol='X', qty=1, side='LONG')
+                def exit_position():
+                    ctx.submit_order(symbol='X', qty=1, side='SHORT')
+                if bar.close > 100:
+                    enter()
+                else:
+                    exit_position()
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert not any("entry path" in c or "exit path" in c for c in criticals), criticals
+
+
 def test_submit_order_in_uninvoked_nested_def_does_not_satisfy_gate() -> None:
     """Nested function bodies declared inside ``on_bar`` only run if the
     enclosing scope calls them. An uninvoked local ``def`` containing

--- a/backend/agents/investment_team/tests/test_code_safety.py
+++ b/backend/agents/investment_team/tests/test_code_safety.py
@@ -337,3 +337,88 @@ def test_self_submit_order_does_not_satisfy_order_flow_gate() -> None:
     results = CodeSafetyChecker().check(code)
     criticals = _critical_details(results)
     assert any("no entry path" in c for c in criticals), criticals
+
+
+def test_explicit_none_bracket_kwarg_does_not_satisfy_exit() -> None:
+    """``attached_stop_loss=None`` is not a real bracket attachment.
+
+    At the AST layer ``kw.value`` is always an ``ast.AST`` node — never
+    Python ``None`` — so a naive ``kw.value is not None`` check would
+    incorrectly accept the literal ``=None``. The gate must reject this
+    as a one-sided strategy.
+    """
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                ctx.submit_order(
+                    symbol='X',
+                    qty=1,
+                    side='LONG',
+                    attached_stop_loss=None,
+                    attached_take_profit=None,
+                )
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert any("no exit path" in c for c in criticals), criticals
+
+
+def test_on_bar_with_context_param_name_is_accepted() -> None:
+    """``on_bar(self, context, bar)`` is valid — the runtime calls hooks
+    positionally, so the parameter name is the strategy's choice. The
+    gate must accept ``context.submit_order(...)`` against a hook whose
+    second positional parameter is named ``context``."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, context, bar):
+                context.submit_order(symbol='X', qty=1, side='LONG')
+                context.submit_order(symbol='X', qty=1, side='FLAT')
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert not any("entry path" in c or "exit path" in c for c in criticals), criticals
+
+
+def test_submit_order_in_unused_helper_does_not_satisfy_order_flow_gate() -> None:
+    """``ctx.submit_order(...)`` inside a helper method that ``on_bar``
+    never calls cannot reach the runtime engine. Walking the whole class
+    body would falsely accept it; the gate must scan only engine hooks
+    (``on_bar`` / ``on_start`` / ``on_fill`` / ``on_end``)."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def _unused_helper(self, ctx, bar):
+                ctx.submit_order(symbol='X', qty=1, side='LONG')
+                ctx.submit_order(symbol='X', qty=1, side='FLAT')
+
+            def on_bar(self, ctx, bar):
+                pass  # engine calls this, but it never emits orders
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert any("no entry path" in c for c in criticals), criticals
+
+
+def test_submit_order_in_on_start_satisfies_entry_path() -> None:
+    """The engine calls ``on_start`` / ``on_fill`` / ``on_end`` too, so a
+    strategy that places orders from ``on_start`` (e.g. opening shot) and
+    ``on_fill`` (e.g. exit-on-fill bracket) is a valid two-call shape."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_start(self, ctx):
+                ctx.submit_order(symbol='X', qty=1, side='LONG')
+            def on_fill(self, ctx, fill):
+                ctx.submit_order(symbol='X', qty=1, side='FLAT')
+            def on_bar(self, ctx, bar):
+                pass
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert not any("entry path" in c or "exit path" in c for c in criticals), criticals

--- a/backend/agents/investment_team/tests/test_code_safety.py
+++ b/backend/agents/investment_team/tests/test_code_safety.py
@@ -422,3 +422,46 @@ def test_submit_order_in_on_start_satisfies_entry_path() -> None:
     results = CodeSafetyChecker().check(code)
     criticals = _critical_details(results)
     assert not any("entry path" in c or "exit path" in c for c in criticals), criticals
+
+
+def test_submit_order_in_helper_called_from_on_bar_satisfies_order_flow_gate() -> None:
+    """``on_bar`` that delegates to ``self._enter(ctx, bar)`` must be
+    recognised — the helper is reachable from the engine via the hook."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def _enter(self, ctx, bar):
+                ctx.submit_order(symbol='X', qty=1, side='LONG')
+            def _exit(self, ctx, bar):
+                ctx.submit_order(symbol='X', qty=1, side='FLAT')
+            def on_bar(self, ctx, bar):
+                if bar.close > 100:
+                    self._enter(ctx, bar)
+                else:
+                    self._exit(ctx, bar)
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert not any("entry path" in c or "exit path" in c for c in criticals), criticals
+
+
+def test_transitive_helper_submit_orders_are_recognised() -> None:
+    """Helpers called from helpers (transitively reachable from a hook)
+    are still in the engine-reachable call graph and must count. The
+    second submit_order lives two hops away from ``on_bar``."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def _emit_exit(self, ctx):
+                ctx.submit_order(symbol='X', qty=1, side='FLAT')
+            def _trade(self, ctx, bar):
+                ctx.submit_order(symbol='X', qty=1, side='LONG')
+                self._emit_exit(ctx)
+            def on_bar(self, ctx, bar):
+                self._trade(ctx, bar)
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert not any("entry path" in c or "exit path" in c for c in criticals), criticals

--- a/backend/agents/investment_team/tests/test_code_safety.py
+++ b/backend/agents/investment_team/tests/test_code_safety.py
@@ -778,6 +778,71 @@ def test_simple_ctx_alias_is_tracked() -> None:
     assert not any("entry path" in c or "exit path" in c for c in criticals), criticals
 
 
+def test_dynamic_symbol_pairs_with_literal_symbol_passes() -> None:
+    """A generated strategy may enter with ``symbol=bar.symbol`` and exit
+    with a configured literal symbol (or vice versa). On a single-symbol
+    backtest run those calls target the same runtime position, so the
+    gate must treat the dynamic call as augmenting every literal-symbol
+    group rather than splitting them into two failing buckets."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                if bar.close > 100:
+                    ctx.submit_order(symbol=bar.symbol, qty=1, side='LONG')
+                else:
+                    ctx.submit_order(symbol='SPY', qty=1, side='SHORT')
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert not any("entry path" in c or "exit path" in c or "exit leg" in c for c in criticals), (
+        criticals
+    )
+
+
+def test_call_before_alias_assignment_is_not_credited() -> None:
+    """A ``trade_ctx.submit_order(...)`` call that appears BEFORE the
+    ``trade_ctx = ctx`` assignment must NOT be credited as a runtime
+    order — at that point ``trade_ctx`` either doesn't exist or refers
+    to something else. The flow-sensitive alias tracker only adds the
+    alias to the live receiver set when the assignment is reached."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                # Two submits BEFORE the alias binding — invalid uses
+                # of the unbound name. Should not be credited.
+                trade_ctx.submit_order(symbol='X', qty=1, side='LONG')
+                trade_ctx.submit_order(symbol='X', qty=1, side='SHORT')
+                trade_ctx = ctx  # alias bound AFTER the calls above
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert any("no entry path" in c for c in criticals), criticals
+
+
+def test_call_after_alias_rebound_is_not_credited() -> None:
+    """When the alias name is later reassigned to a non-receiver, calls
+    after the rebind no longer reference the runtime context. The
+    flow-sensitive walker drops the alias from state on rebind."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                trade_ctx = ctx
+                # rebound to a non-receiver before any submit_order calls
+                trade_ctx = bar
+                trade_ctx.submit_order(symbol='X', qty=1, side='LONG')
+                trade_ctx.submit_order(symbol='X', qty=1, side='SHORT')
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert any("no entry path" in c for c in criticals), criticals
+
+
 def test_long_on_one_symbol_short_on_another_is_critical_no_exit() -> None:
     """Pair-trading-style strategy that opens LONG on SPY and SHORT on
     TLT has two unrelated entries, not an entry+exit pair. The engine

--- a/backend/agents/investment_team/tests/test_code_safety.py
+++ b/backend/agents/investment_team/tests/test_code_safety.py
@@ -778,6 +778,87 @@ def test_simple_ctx_alias_is_tracked() -> None:
     assert not any("entry path" in c or "exit path" in c for c in criticals), criticals
 
 
+def test_long_on_one_symbol_short_on_another_is_critical_no_exit() -> None:
+    """Pair-trading-style strategy that opens LONG on SPY and SHORT on
+    TLT has two unrelated entries, not an entry+exit pair. The engine
+    closes positions per-symbol (``portfolio.positions[bar.symbol]``),
+    so neither symbol has a real exit and the gate must reject it."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                ctx.submit_order(symbol='SPY', qty=1, side='LONG')
+                ctx.submit_order(symbol='TLT', qty=1, side='SHORT')
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert any("no exit path" in c or "no real exit leg" in c for c in criticals), criticals
+
+
+def test_long_and_short_on_same_symbol_passes() -> None:
+    """LONG + SHORT on the SAME literal symbol is a valid entry+exit pair."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                if bar.close > 100:
+                    ctx.submit_order(symbol='SPY', qty=1, side='LONG')
+                else:
+                    ctx.submit_order(symbol='SPY', qty=1, side='SHORT')
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert not any("entry path" in c or "exit path" in c or "exit leg" in c for c in criticals), (
+        criticals
+    )
+
+
+def test_dynamic_symbol_groups_together_and_passes() -> None:
+    """``symbol=bar.symbol`` resolves to the same runtime symbol within
+    one ``on_bar`` call, so dynamic-symbol calls share a single group.
+    LONG + SHORT on dynamic symbol passes."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                if bar.close > 100:
+                    ctx.submit_order(symbol=bar.symbol, qty=1, side='LONG')
+                else:
+                    ctx.submit_order(symbol=bar.symbol, qty=1, side='SHORT')
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert not any("entry path" in c or "exit path" in c or "exit leg" in c for c in criticals), (
+        criticals
+    )
+
+
+def test_closure_parameter_shadowing_outer_ctx_is_not_captured() -> None:
+    """A nested closure that names its own parameter ``ctx`` rebinds the
+    name inside the closure scope — the outer ``ctx`` is no longer
+    reachable as a receiver inside. So ``def enter(ctx): ctx.submit_order
+    (...); enter(bar)`` does NOT count as a valid entry (the inner ``ctx``
+    is bound to the Bar at runtime)."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                def enter(ctx):
+                    ctx.submit_order(symbol='X', qty=1, side='LONG')
+                def exit_position(ctx):
+                    ctx.submit_order(symbol='X', qty=1, side='SHORT')
+                enter(bar)
+                exit_position(bar)
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert any("no entry path" in c for c in criticals), criticals
+
+
 def test_local_closure_with_parameter_is_bound_at_call_site() -> None:
     """A nested closure that accepts the context as a parameter and is
     invoked with the runtime ctx should have that parameter bound:

--- a/backend/agents/investment_team/tests/test_code_safety.py
+++ b/backend/agents/investment_team/tests/test_code_safety.py
@@ -404,30 +404,31 @@ def test_submit_order_in_unused_helper_does_not_satisfy_order_flow_gate() -> Non
     assert any("no entry path" in c for c in criticals), criticals
 
 
-def test_submit_order_in_on_start_satisfies_entry_path() -> None:
-    """The engine calls ``on_start`` / ``on_fill`` / ``on_end`` too, so a
-    strategy that places orders from ``on_start`` (e.g. opening shot) and
-    ``on_fill`` (e.g. exit-on-fill bracket) is a valid two-call shape."""
+def test_submit_order_in_on_start_does_not_satisfy_gate() -> None:
+    """``send_start`` is invoked without processing its ``HarnessResponse``
+    in the current trading service, so any ``submit_order`` made from
+    ``on_start`` is dropped before backtesting. The gate must not count
+    those calls — the strategy needs at least one entry call in ``on_bar``.
+    """
     code = textwrap.dedent("""
         from contract import Strategy
 
         class S(Strategy):
             def on_start(self, ctx):
                 ctx.submit_order(symbol='X', qty=1, side='LONG')
-            def on_fill(self, ctx, fill):
                 ctx.submit_order(symbol='X', qty=1, side='SHORT')
             def on_bar(self, ctx, bar):
                 pass
     """)
     results = CodeSafetyChecker().check(code)
     criticals = _critical_details(results)
-    assert not any("entry path" in c or "exit path" in c for c in criticals), criticals
+    assert any("no entry path" in c for c in criticals), criticals
 
 
 def test_submit_order_only_in_on_fill_is_critical_no_entry() -> None:
-    """``on_fill`` runs only AFTER a prior fill, so it can't bootstrap a
-    position. A strategy whose only orders sit in ``on_fill`` will never
-    emit anything in practice; the gate must reject it."""
+    """``send_fill`` responses are dropped by the trading service today, so
+    orders in ``on_fill`` never reach the engine. A strategy whose only
+    submissions sit there must be rejected."""
     code = textwrap.dedent("""
         from contract import Strategy
 
@@ -440,12 +441,13 @@ def test_submit_order_only_in_on_fill_is_critical_no_entry() -> None:
     """)
     results = CodeSafetyChecker().check(code)
     criticals = _critical_details(results)
-    assert any("on_bar or on_start" in c for c in criticals), criticals
+    assert any("no entry path" in c for c in criticals), criticals
 
 
 def test_submit_order_only_in_on_end_is_critical_no_entry() -> None:
-    """``on_end`` runs after the data stream ends and cannot initiate
-    trading. A strategy with all orders in ``on_end`` is a no-op."""
+    """``send_end`` responses are dropped by the trading service today,
+    matching ``send_start`` / ``send_fill``. Orders in ``on_end`` never
+    reach the engine."""
     code = textwrap.dedent("""
         from contract import Strategy
 
@@ -458,7 +460,25 @@ def test_submit_order_only_in_on_end_is_critical_no_entry() -> None:
     """)
     results = CodeSafetyChecker().check(code)
     criticals = _critical_details(results)
-    assert any("on_bar or on_start" in c for c in criticals), criticals
+    assert any("no entry path" in c for c in criticals), criticals
+
+
+def test_on_bar_entry_with_on_fill_exit_is_critical_no_exit() -> None:
+    """A common temptation is entry in ``on_bar`` + exit-on-fill in
+    ``on_fill``. The on_fill response is dropped, so only the entry
+    reaches the engine — one-sided, no real exit. Reject."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                ctx.submit_order(symbol='X', qty=1, side='LONG')
+            def on_fill(self, ctx, fill):
+                ctx.submit_order(symbol='X', qty=1, side='SHORT')
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert any("no exit path" in c for c in criticals), criticals
 
 
 def test_submit_order_in_uninvoked_nested_def_does_not_satisfy_gate() -> None:

--- a/backend/agents/investment_team/tests/test_code_safety.py
+++ b/backend/agents/investment_team/tests/test_code_safety.py
@@ -415,13 +415,72 @@ def test_submit_order_in_on_start_satisfies_entry_path() -> None:
             def on_start(self, ctx):
                 ctx.submit_order(symbol='X', qty=1, side='LONG')
             def on_fill(self, ctx, fill):
-                ctx.submit_order(symbol='X', qty=1, side='FLAT')
+                ctx.submit_order(symbol='X', qty=1, side='SHORT')
             def on_bar(self, ctx, bar):
                 pass
     """)
     results = CodeSafetyChecker().check(code)
     criticals = _critical_details(results)
     assert not any("entry path" in c or "exit path" in c for c in criticals), criticals
+
+
+def test_submit_order_only_in_on_fill_is_critical_no_entry() -> None:
+    """``on_fill`` runs only AFTER a prior fill, so it can't bootstrap a
+    position. A strategy whose only orders sit in ``on_fill`` will never
+    emit anything in practice; the gate must reject it."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                pass  # never emits an entry order
+            def on_fill(self, ctx, fill):
+                ctx.submit_order(symbol='X', qty=1, side='LONG')
+                ctx.submit_order(symbol='X', qty=1, side='SHORT')
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert any("on_bar or on_start" in c for c in criticals), criticals
+
+
+def test_submit_order_only_in_on_end_is_critical_no_entry() -> None:
+    """``on_end`` runs after the data stream ends and cannot initiate
+    trading. A strategy with all orders in ``on_end`` is a no-op."""
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                pass
+            def on_end(self, ctx):
+                ctx.submit_order(symbol='X', qty=1, side='LONG')
+                ctx.submit_order(symbol='X', qty=1, side='SHORT')
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert any("on_bar or on_start" in c for c in criticals), criticals
+
+
+def test_submit_order_in_uninvoked_nested_def_does_not_satisfy_gate() -> None:
+    """Nested function bodies declared inside ``on_bar`` only run if the
+    enclosing scope calls them. An uninvoked local ``def`` containing
+    ``ctx.submit_order(...)`` must NOT count toward the order-flow gate
+    because Python never executes the body of a function it never calls.
+    """
+    code = textwrap.dedent("""
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                def _unused():
+                    ctx.submit_order(symbol='X', qty=1, side='LONG')
+                    ctx.submit_order(symbol='X', qty=1, side='SHORT')
+                # _unused is defined but never invoked, so neither call runs.
+                pass
+    """)
+    results = CodeSafetyChecker().check(code)
+    criticals = _critical_details(results)
+    assert any("no entry path" in c for c in criticals), criticals
 
 
 def test_submit_order_in_helper_called_from_on_bar_satisfies_order_flow_gate() -> None:

--- a/backend/agents/investment_team/tests/test_strategy_lab_alignment.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_alignment.py
@@ -489,7 +489,8 @@ def test_alignment_loop_recovers_after_one_fix_and_re_execution() -> None:
         "from contract import Strategy\n\n"
         "class S(Strategy):\n"
         "    def on_bar(self, ctx, bar):\n"
-        "        pass  # fixed\n"
+        "        ctx.submit_order(symbol='X', qty=1, side='LONG')\n"
+        "        ctx.submit_order(symbol='X', qty=1, side='FLAT')\n"
     )
     orch, align_stub, sandbox_stub = _make_orchestrator(
         alignment_reports=[
@@ -559,7 +560,8 @@ def test_alignment_loop_caps_at_max_rounds() -> None:
             "from contract import Strategy\n\n"
             "class S(Strategy):\n"
             "    def on_bar(self, ctx, bar):\n"
-            "        pass  # try again\n"
+            "        ctx.submit_order(symbol='X', qty=1, side='LONG')\n"
+            "        ctx.submit_order(symbol='X', qty=1, side='FLAT')\n"
         ),
         predicted_aligned_after_fix=True,
         changes_made="another attempt",
@@ -634,11 +636,14 @@ def test_alignment_loop_breaks_when_re_execution_fails() -> None:
     the last-good ``code`` / ``spec`` / ``trades`` / ``metrics`` intact so
     the persisted record never contains code that was never successfully
     executed for the reported results."""
+    # Body would raise at runtime, but the sandbox is stubbed so we only need
+    # the code to clear the code-safety gate (entry + exit submit_order).
     proposed_code = (
         "from contract import Strategy\n\n"
         "class S(Strategy):\n"
         "    def on_bar(self, ctx, bar):\n"
-        "        raise RuntimeError\n"
+        "        ctx.submit_order(symbol='X', qty=1, side='LONG')\n"
+        "        ctx.submit_order(symbol='X', qty=1, side='FLAT')\n"
     )
     orch, align_stub, sandbox_stub = _make_orchestrator(
         alignment_reports=[
@@ -694,7 +699,8 @@ def test_alignment_loop_breaks_on_critical_anomaly_after_rerun() -> None:
         "from contract import Strategy\n\n"
         "class S(Strategy):\n"
         "    def on_bar(self, ctx, bar):\n"
-        "        pass  # breaks everything\n"
+        "        ctx.submit_order(symbol='X', qty=1, side='LONG')\n"
+        "        ctx.submit_order(symbol='X', qty=1, side='FLAT')\n"
     )
     orch, align_stub, sandbox_stub = _make_orchestrator(
         alignment_reports=[

--- a/backend/agents/investment_team/tests/test_strategy_lab_max_rounds_exhaustion.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_max_rounds_exhaustion.py
@@ -131,3 +131,53 @@ def test_execution_phase_exhaustion_sets_max_rounds_status(
 
     assert record.backtest.status == "failed: max_refinement_rounds"
     assert record.is_winning is False
+
+
+def test_evaluation_phase_exhaustion_does_not_mark_winner(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Even a high-return anomalous cycle that exhausts the round cap on
+    evaluation must NOT be persisted with is_winning=True (#547 review feedback).
+    Otherwise paper-trading would fire on a 'failed: max_refinement_rounds' record."""
+    from investment_team.strategy_lab.quality_gates.models import QualityGateResult
+    from investment_team.tests.test_strategy_lab_alignment import (
+        _benign_sandbox_trades,
+        _code_exec,
+    )
+
+    orch = StrategyLabOrchestrator()
+    monkeypatch.setattr(orch.ideation_agent, "run", _ideation_returning(_spec_dict(), _VALID_CODE))
+    monkeypatch.setattr(StrategyLabOrchestrator, "_fetch_market_data", _stub_market_data)
+
+    # Sandbox always succeeds with benign trades — execution itself is fine.
+    def _ok_sandbox(*_a, **_kw):
+        return _code_exec(success=True, raw_trades=_benign_sandbox_trades())
+
+    monkeypatch.setattr(orchestrator_module, "run_strategy_code", _ok_sandbox)
+
+    # Refinement is a no-op so the loop keeps hitting the same anomaly.
+    def _stub_refine(**_kw):
+        return {"changes_made": "no-op"}, _VALID_CODE
+
+    monkeypatch.setattr(orch.refinement_agent, "run", _stub_refine)
+
+    # Anomaly detector always reports critical → evaluation-phase exhaustion.
+    def _always_anomalous(*_a, **_kw):
+        return [
+            QualityGateResult(
+                gate_name="backtest_anomaly",
+                passed=False,
+                severity="critical",
+                details="forced anomaly for test",
+            )
+        ]
+
+    monkeypatch.setattr(orch.anomaly_detector, "check", _always_anomalous)
+
+    record = orch.run_cycle(prior_records=[], config=_config())
+
+    assert record.backtest.status == "failed: max_refinement_rounds"
+    # The critical assertion: even if the cycle has trades and metrics
+    # (because the sandbox kept succeeding), is_winning must stay False
+    # because execution_succeeded was never flipped on the exhaustion path.
+    assert record.is_winning is False

--- a/backend/agents/investment_team/tests/test_strategy_lab_max_rounds_exhaustion.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_max_rounds_exhaustion.py
@@ -1,0 +1,133 @@
+"""Cap-exhaustion status (#547 item 7).
+
+The orchestrator's three ``MAX_CODE_REFINEMENT_ROUNDS`` break sites
+(validation / execution / evaluation) now flip the persisted
+``BacktestRecord.status`` to ``"failed: max_refinement_rounds"`` so
+operators can query for exhausted cycles rather than scraping logs.
+
+These tests force the loop to exhaust at each of the three sites and
+assert on the final record's ``status``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+import pytest
+
+from investment_team.models import BacktestConfig
+from investment_team.strategy_lab import orchestrator as orchestrator_module
+from investment_team.strategy_lab.orchestrator import (
+    MAX_CODE_REFINEMENT_ROUNDS,
+    StrategyLabOrchestrator,
+)
+from investment_team.strategy_lab.quality_gates.models import QualityGateResult
+
+
+def _config() -> BacktestConfig:
+    return BacktestConfig(
+        start_date="2023-01-01",
+        end_date="2023-12-31",
+        initial_capital=100_000.0,
+        benchmark_symbol="SPY",
+        transaction_cost_bps=5.0,
+        slippage_bps=2.0,
+    )
+
+
+_VALID_CODE = (
+    "from contract import Strategy\n\n"
+    "class S(Strategy):\n"
+    "    def on_bar(self, ctx, bar):\n"
+    "        ctx.submit_order(symbol='X', qty=1, side='LONG')\n"
+    "        ctx.submit_order(symbol='X', qty=1, side='FLAT')\n"
+)
+
+
+def _spec_dict() -> Dict[str, Any]:
+    return {
+        "asset_class": "stocks",
+        "hypothesis": "RSI signal strategy",
+        "signal_definition": "sig",
+        "entry_rules": ["enter when RSI < 30"],
+        "exit_rules": ["exit when RSI > 70"],
+        "sizing_rules": ["risk 2% per trade"],
+        "risk_limits": {"max_position_pct": 5, "max_drawdown_pct": 10},
+        "speculative": False,
+    }
+
+
+def _ideation_returning(d: Dict[str, Any], code: str) -> Any:
+    def _run(**_kwargs) -> Tuple[Dict[str, Any], str, str]:
+        return d, code, "scripted rationale"
+
+    return _run
+
+
+def _stub_market_data(*_a, **_kw):
+    return {"AAPL": []}
+
+
+def test_validation_phase_exhaustion_sets_max_rounds_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Code-safety always critical → loop exhausts validation phase."""
+    orch = StrategyLabOrchestrator()
+    monkeypatch.setattr(orch.ideation_agent, "run", _ideation_returning(_spec_dict(), _VALID_CODE))
+
+    # Refinement is a no-op: same code back, so each round re-fails code-safety.
+    def _stub_refine(**_kw):
+        return {"changes_made": "no-op"}, _VALID_CODE
+
+    monkeypatch.setattr(orch.refinement_agent, "run", _stub_refine)
+
+    def _always_critical(_code: str):
+        return [
+            QualityGateResult(
+                gate_name="code_safety",
+                passed=False,
+                severity="critical",
+                details="forced critical for test",
+            )
+        ]
+
+    monkeypatch.setattr(orch.code_safety_checker, "check", _always_critical)
+
+    record = orch.run_cycle(prior_records=[], config=_config())
+
+    assert record.backtest.status == "failed: max_refinement_rounds"
+    assert record.is_winning is False
+    # Refinement is called on every round except the final one (which falls
+    # into the else-break branch), so attempts == MAX_CODE_REFINEMENT_ROUNDS - 1.
+    assert record.refinement_rounds == MAX_CODE_REFINEMENT_ROUNDS - 1
+
+
+def test_execution_phase_exhaustion_sets_max_rounds_status(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Sandbox always reports execution failure → loop exhausts execution phase."""
+    from investment_team.trading_service.modes.sandbox_compat import StrategyRunResult
+
+    orch = StrategyLabOrchestrator()
+    monkeypatch.setattr(orch.ideation_agent, "run", _ideation_returning(_spec_dict(), _VALID_CODE))
+    monkeypatch.setattr(StrategyLabOrchestrator, "_fetch_market_data", _stub_market_data)
+
+    def _stub_refine(**_kw):
+        return {"changes_made": "no-op"}, _VALID_CODE
+
+    monkeypatch.setattr(orch.refinement_agent, "run", _stub_refine)
+
+    def _always_fails(*_a, **_kw):
+        return StrategyRunResult(
+            success=False,
+            trades=[],
+            stderr="forced failure for test",
+            error_type="runtime_error",
+        )
+
+    monkeypatch.setattr(orchestrator_module, "run_strategy_code", _always_fails)
+
+    record = orch.run_cycle(prior_records=[], config=_config())
+
+    assert record.backtest.status == "failed: max_refinement_rounds"
+    assert record.is_winning is False

--- a/backend/agents/investment_team/tests/test_strategy_lab_pre_synthesis_gating.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_pre_synthesis_gating.py
@@ -1,0 +1,129 @@
+"""Pre-synthesis spec gating in the Strategy Lab orchestrator (#547 item 1).
+
+The orchestrator now runs ``StrategySpecValidator`` once, immediately
+after ideation and before the refinement loop. Critical failures
+short-circuit the cycle: no sandbox call, no market-data fetch, and the
+persisted record carries ``status="failed: spec_validation"``.
+
+These tests stub ``IdeationAgent`` and patch
+``orchestrator_module.run_strategy_code`` so a failure trips the new
+short-circuit and the test fails loudly if the orchestrator ever calls
+the sandbox.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+import pytest
+
+from investment_team.models import BacktestConfig
+from investment_team.strategy_lab import orchestrator as orchestrator_module
+from investment_team.strategy_lab.orchestrator import StrategyLabOrchestrator
+
+
+def _config() -> BacktestConfig:
+    return BacktestConfig(
+        start_date="2023-01-01",
+        end_date="2023-12-31",
+        initial_capital=100_000.0,
+        benchmark_symbol="SPY",
+        transaction_cost_bps=5.0,
+        slippage_bps=2.0,
+    )
+
+
+def _ideation_returning(strategy_dict: Dict[str, Any], code: str) -> Any:
+    """Build a stub ``IdeationAgent.run`` that returns scripted output."""
+
+    def _run(**_kwargs) -> Tuple[Dict[str, Any], str, str]:
+        return strategy_dict, code, "scripted rationale"
+
+    return _run
+
+
+_VALID_CODE = (
+    "from contract import Strategy\n\n"
+    "class S(Strategy):\n"
+    "    def on_bar(self, ctx, bar):\n"
+    "        ctx.submit_order(symbol='X', qty=1, side='LONG')\n"
+    "        ctx.submit_order(symbol='X', qty=1, side='FLAT')\n"
+)
+
+
+def test_pre_synthesis_critical_failure_short_circuits(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty entry_rules trips the validator → cycle exits without sandbox call."""
+    bad_spec_dict = {
+        "asset_class": "stocks",
+        "hypothesis": "test",
+        "signal_definition": "sig",
+        "entry_rules": [],  # critical: no entry rules
+        "exit_rules": ["exit"],
+        "sizing_rules": ["risk 2%"],
+        "risk_limits": {"max_position_pct": 5, "max_drawdown_pct": 10},
+        "speculative": False,
+    }
+
+    orch = StrategyLabOrchestrator()
+    monkeypatch.setattr(orch.ideation_agent, "run", _ideation_returning(bad_spec_dict, _VALID_CODE))
+
+    def _sandbox_must_not_run(*_a, **_kw):
+        raise AssertionError("run_strategy_code must not be called when pre-synthesis gating fails")
+
+    monkeypatch.setattr(orchestrator_module, "run_strategy_code", _sandbox_must_not_run)
+
+    def _market_data_must_not_run(self, *_a, **_kw):
+        raise AssertionError(
+            "_fetch_market_data must not be called when pre-synthesis gating fails"
+        )
+
+    monkeypatch.setattr(StrategyLabOrchestrator, "_fetch_market_data", _market_data_must_not_run)
+
+    record = orch.run_cycle(prior_records=[], config=_config())
+
+    assert record.backtest.status == "failed: spec_validation"
+    assert record.is_winning is False
+    assert record.refinement_rounds == 0
+    # The pre-synthesis gate result must be persisted with refinement_round=-1
+    pre_synth_gates = [g for g in record.quality_gate_results if g.get("refinement_round") == -1]
+    assert pre_synth_gates, record.quality_gate_results
+    assert any(g.get("severity") == "critical" and not g.get("passed") for g in pre_synth_gates), (
+        pre_synth_gates
+    )
+
+
+def test_pre_synthesis_validator_persisted_even_on_pass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A valid spec records the pre-synthesis pass result and enters the loop."""
+    valid_spec_dict = {
+        "asset_class": "stocks",
+        "hypothesis": "RSI signal strategy",
+        "signal_definition": "sig",
+        "entry_rules": ["enter when RSI < 30"],
+        "exit_rules": ["exit when RSI > 70"],
+        "sizing_rules": ["risk 2% per trade"],
+        "risk_limits": {"max_position_pct": 5, "max_drawdown_pct": 10},
+        "speculative": False,
+    }
+
+    orch = StrategyLabOrchestrator()
+    monkeypatch.setattr(
+        orch.ideation_agent, "run", _ideation_returning(valid_spec_dict, _VALID_CODE)
+    )
+
+    # The orchestrator will then enter the refinement loop. Short-circuit on
+    # the first failed code_safety check so the test does not need a full
+    # sandbox stack — record stays in scope to assert on the pre-synth gates.
+    monkeypatch.setattr(
+        StrategyLabOrchestrator,
+        "_fetch_market_data",
+        lambda *_a, **_kw: None,
+    )
+
+    record = orch.run_cycle(prior_records=[], config=_config())
+
+    pre_synth_gates = [g for g in record.quality_gate_results if g.get("refinement_round") == -1]
+    assert pre_synth_gates, record.quality_gate_results
+    # All pre-synthesis gates passed (or are info-severity) — none should be critical.
+    assert not any(
+        g.get("severity") == "critical" and not g.get("passed") for g in pre_synth_gates
+    ), pre_synth_gates

--- a/backend/agents/investment_team/tests/test_strategy_lab_pre_synthesis_gating.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_pre_synthesis_gating.py
@@ -169,3 +169,15 @@ def test_missing_strategy_code_does_not_short_circuit(monkeypatch: pytest.Monkey
     # the validator's strategy_code critical was excluded from pre-synth
     # gating, so we proceeded past it.
     assert record.backtest.status != "failed: spec_validation", record.backtest.status
+
+    # And the gate must not be persisted as an unresolved critical on
+    # the record — the refinement loop's code-safety + regeneration
+    # paths repair it, so leaving it on the record would create a
+    # permanently-unresolved spec critical (the generic refinement loop
+    # never re-runs StrategySpecValidator). Filter the pre-synth slice.
+    pre_synth_gates = [g for g in record.quality_gate_results if g.get("refinement_round") == -1]
+    assert not any(
+        g.get("severity") == "critical"
+        and g.get("details", "").startswith("strategy_code is missing")
+        for g in pre_synth_gates
+    ), pre_synth_gates

--- a/backend/agents/investment_team/tests/test_strategy_lab_pre_synthesis_gating.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_pre_synthesis_gating.py
@@ -127,3 +127,45 @@ def test_pre_synthesis_validator_persisted_even_on_pass(monkeypatch: pytest.Monk
     assert not any(
         g.get("severity") == "critical" and not g.get("passed") for g in pre_synth_gates
     ), pre_synth_gates
+
+
+def test_missing_strategy_code_does_not_short_circuit(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ideation may return an empty ``strategy_code``. That's a
+    code-generation failure that the refinement loop's existing code-
+    safety + regeneration paths are equipped to repair; the pre-synthesis
+    spec gate must NOT short-circuit on it (regressing a previously-
+    recoverable case into an outright failure).
+
+    The validator's ``strategy_code is missing — nothing to execute``
+    critical is excluded from short-circuit eligibility; the cycle
+    proceeds into the refinement loop.
+    """
+    valid_spec_dict_but_no_code = {
+        "asset_class": "stocks",
+        "hypothesis": "RSI signal strategy",
+        "signal_definition": "sig",
+        "entry_rules": ["enter when RSI < 30"],
+        "exit_rules": ["exit when RSI > 70"],
+        "sizing_rules": ["risk 2% per trade"],
+        "risk_limits": {"max_position_pct": 5, "max_drawdown_pct": 10},
+        "speculative": False,
+    }
+
+    orch = StrategyLabOrchestrator()
+    # Empty string — triggers the validator's "strategy_code is missing"
+    # critical but the spec itself is otherwise valid.
+    monkeypatch.setattr(
+        orch.ideation_agent,
+        "run",
+        _ideation_returning(valid_spec_dict_but_no_code, ""),
+    )
+    # Short-circuit further down by returning no market data so the cycle
+    # exits cleanly without needing a full sandbox stack.
+    monkeypatch.setattr(StrategyLabOrchestrator, "_fetch_market_data", lambda *_a, **_kw: None)
+
+    record = orch.run_cycle(prior_records=[], config=_config())
+
+    # The cycle did NOT short-circuit with "failed: spec_validation":
+    # the validator's strategy_code critical was excluded from pre-synth
+    # gating, so we proceeded past it.
+    assert record.backtest.status != "failed: spec_validation", record.backtest.status

--- a/backend/agents/investment_team/tests/test_strategy_lab_record_provenance.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_record_provenance.py
@@ -1,0 +1,131 @@
+"""Provenance fields on ``StrategyLabRecord`` (#547 item 5).
+
+The Strategy Lab orchestrator now snapshots the ideation-time spec and
+code on the persisted record so reviewers can see any drift introduced
+by the refinement loop. These tests pin the model contract: the fields
+exist, default to ``None`` for legacy rows, and round-trip through
+JSON serialization without loss.
+"""
+
+from __future__ import annotations
+
+import json
+
+from investment_team.models import (
+    BacktestConfig,
+    BacktestRecord,
+    StrategyLabRecord,
+    StrategySpec,
+)
+from investment_team.trade_simulator import compute_metrics
+
+
+def _spec(strategy_id: str, *, hypothesis: str = "RSI mean reversion") -> StrategySpec:
+    return StrategySpec(
+        strategy_id=strategy_id,
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis=hypothesis,
+        signal_definition="sig",
+        entry_rules=["enter when RSI < 30"],
+        exit_rules=["exit when RSI > 70"],
+        sizing_rules=["risk 2% per trade"],
+        risk_limits={"max_position_pct": 5},
+        speculative=False,
+        strategy_code="# code",
+    )
+
+
+def _backtest_record(spec: StrategySpec) -> BacktestRecord:
+    config = BacktestConfig(
+        start_date="2023-01-01",
+        end_date="2023-12-31",
+        initial_capital=100_000.0,
+        benchmark_symbol="SPY",
+        transaction_cost_bps=5.0,
+        slippage_bps=2.0,
+    )
+    return BacktestRecord(
+        backtest_id="bt-test",
+        strategy_id=spec.strategy_id,
+        strategy=spec,
+        config=config,
+        submitted_by="test",
+        submitted_at="2026-01-01T00:00:00+00:00",
+        completed_at="2026-01-01T00:00:00+00:00",
+        status="completed",
+        result=compute_metrics([], config.initial_capital, config.start_date, config.end_date),
+        trades=[],
+    )
+
+
+def test_strategy_lab_record_original_fields_default_to_none() -> None:
+    """Legacy rows (pre-#547) and any caller that omits the fields stay valid."""
+    spec = _spec("strat-legacy")
+    record = StrategyLabRecord(
+        lab_record_id="lab-legacy",
+        strategy=spec,
+        backtest=_backtest_record(spec),
+        is_winning=False,
+        strategy_rationale="r",
+        analysis_narrative="n",
+        created_at="2026-01-01T00:00:00+00:00",
+    )
+
+    assert record.original_spec is None
+    assert record.original_code is None
+
+
+def test_strategy_lab_record_persists_ideation_snapshot() -> None:
+    """When refinement mutates the spec/code, the original snapshot is retained."""
+    ideation_spec = _spec("strat-prov", hypothesis="ideation hypothesis")
+    ideation_code = "# ideation code"
+
+    # Simulate post-refinement state: spec hypothesis and code both changed.
+    final_spec = ideation_spec.model_copy(
+        update={"hypothesis": "refined hypothesis", "strategy_code": "# refined code"}
+    )
+
+    record = StrategyLabRecord(
+        lab_record_id="lab-prov",
+        strategy=final_spec,
+        backtest=_backtest_record(final_spec),
+        is_winning=False,
+        strategy_rationale="r",
+        analysis_narrative="n",
+        created_at="2026-01-01T00:00:00+00:00",
+        strategy_code="# refined code",
+        original_spec=ideation_spec,
+        original_code=ideation_code,
+    )
+
+    assert record.original_code == "# ideation code"
+    assert record.original_spec is not None
+    assert record.original_spec.hypothesis == "ideation hypothesis"
+    assert record.strategy.hypothesis == "refined hypothesis"
+    assert record.original_code != record.strategy_code
+
+
+def test_strategy_lab_record_provenance_round_trips_through_json() -> None:
+    """The fields survive ``model_dump_json`` → ``model_validate_json``."""
+    ideation_spec = _spec("strat-json")
+    record = StrategyLabRecord(
+        lab_record_id="lab-json",
+        strategy=ideation_spec,
+        backtest=_backtest_record(ideation_spec),
+        is_winning=False,
+        strategy_rationale="r",
+        analysis_narrative="n",
+        created_at="2026-01-01T00:00:00+00:00",
+        strategy_code="# code",
+        original_spec=ideation_spec,
+        original_code="# code",
+    )
+
+    payload = json.loads(record.model_dump_json())
+    assert payload["original_code"] == "# code"
+    assert payload["original_spec"]["strategy_id"] == "strat-json"
+
+    rebuilt = StrategyLabRecord.model_validate(payload)
+    assert rebuilt.original_spec == ideation_spec
+    assert rebuilt.original_code == "# code"

--- a/backend/agents/investment_team/tests/test_strategy_lab_refinement_contract.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_refinement_contract.py
@@ -1,0 +1,58 @@
+"""Refinement contract narrowing (#547 item 2).
+
+After #547, the refinement agent's output is code-only. Even if a
+stubbed agent returns spec-mutating keys (legacy schema or
+hallucinated fields), ``StrategyLabOrchestrator._apply_updates`` must
+not merge them into the spec — only ``strategy_code`` is updated.
+"""
+
+from __future__ import annotations
+
+from investment_team.models import StrategySpec
+from investment_team.strategy_lab.orchestrator import StrategyLabOrchestrator
+
+
+def _spec() -> StrategySpec:
+    return StrategySpec(
+        strategy_id="strat-refine-contract",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="RSI mean reversion",
+        signal_definition="sig",
+        entry_rules=["enter when RSI < 30"],
+        exit_rules=["exit when RSI > 70"],
+        sizing_rules=["risk 2% per trade"],
+        risk_limits={"max_position_pct": 5, "max_drawdown_pct": 10},
+        speculative=False,
+        strategy_code="# original code",
+    )
+
+
+def test_apply_updates_swaps_code_only() -> None:
+    """Spec fields stay untouched even when the refinement dict requests changes."""
+    original = _spec()
+    legacy_updates = {
+        "entry_rules": ["should be ignored — refinement cannot mutate spec"],
+        "exit_rules": ["should be ignored"],
+        "sizing_rules": ["should be ignored"],
+        "risk_limits": {"max_position_pct": 99},
+        "hypothesis": "rewritten hypothesis",
+        "changes_made": "tightened RSI guard",
+    }
+
+    result = StrategyLabOrchestrator._apply_updates(original, legacy_updates, "# refined code")
+
+    assert result.entry_rules == original.entry_rules
+    assert result.exit_rules == original.exit_rules
+    assert result.sizing_rules == original.sizing_rules
+    assert result.hypothesis == original.hypothesis
+    assert result.risk_limits == original.risk_limits
+    assert result.strategy_code == "# refined code"
+
+
+def test_apply_updates_with_empty_dict_only_swaps_code() -> None:
+    """Empty ``updates`` (the zero-trade-repair path) still swaps code."""
+    original = _spec()
+    result = StrategyLabOrchestrator._apply_updates(original, {}, "# repaired code")
+    assert result.strategy_code == "# repaired code"
+    assert result.entry_rules == original.entry_rules

--- a/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
@@ -48,7 +48,12 @@ def _spec() -> StrategySpec:
         sizing_rules=["fixed size"],
         risk_limits={},
         speculative=False,
-        strategy_code="from contract import Strategy\n\nclass S(Strategy):\n    def on_bar(self, ctx, bar):\n        pass\n",
+        strategy_code=(
+            "from contract import Strategy\n\nclass S(Strategy):\n"
+            "    def on_bar(self, ctx, bar):\n"
+            "        ctx.submit_order(symbol='X', qty=1, side='LONG')\n"
+            "        ctx.submit_order(symbol='X', qty=1, side='FLAT')\n"
+        ),
     )
 
 
@@ -588,7 +593,12 @@ def test_walk_forward_fallback_rejects_overfit_via_anomaly_recheck(monkeypatch):
         "risk_limits": {},
         "speculative": False,
     }
-    overfit_code = "from contract import Strategy\n\nclass S(Strategy):\n    def on_bar(self, ctx, bar):\n        pass\n"
+    overfit_code = (
+        "from contract import Strategy\n\nclass S(Strategy):\n"
+        "    def on_bar(self, ctx, bar):\n"
+        "        ctx.submit_order(symbol='X', qty=1, side='LONG')\n"
+        "        ctx.submit_order(symbol='X', qty=1, side='FLAT')\n"
+    )
     monkeypatch.setattr(
         orch.ideation_agent, "run", lambda **kw: (spec_dict, overfit_code, "rationale")
     )

--- a/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
@@ -119,12 +119,14 @@ def _zero_trade_exec_result() -> StrategyRunResult:
 
 # Valid Strategy-subclass code that the safety gate accepts. Body intentionally
 # trivial — we never actually execute it because ``run_strategy_code`` is
-# stubbed via monkeypatch.
+# stubbed via monkeypatch. Entry + exit ``submit_order`` calls satisfy the
+# order-flow-shape gate added in #547.
 _REPAIRED_CODE = (
     "from contract import Strategy\n\n"
     "class S(Strategy):\n"
     "    def on_bar(self, ctx, bar):\n"
-    "        pass  # repaired (test stub)\n"
+    "        ctx.submit_order(symbol='X', qty=1, side='LONG')\n"
+    "        ctx.submit_order(symbol='X', qty=1, side='FLAT')\n"
 )
 
 

--- a/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
@@ -652,6 +652,61 @@ def test_zero_trade_repair_rejects_spec_updates_failing_post_repair_validator(
     ), gate_names
 
 
+def test_zero_trade_repair_accepted_carries_post_repair_spec_gates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When a repair mutates the spec and the post-repair validator emits
+    only warnings (no criticals), the warnings must reach the accepted
+    outcome's ``new_gates`` so they appear in the persisted
+    ``quality_gate_results``. Previously these were discarded on accept."""
+    orch, _repair_stub, _sandbox_stub = _make_orchestrator_with_stubs(
+        monkeypatch,
+        repair_reports=[
+            ZeroTradeRepairReport(
+                root_cause_category="ENTRY_WITH_NO_EXIT",
+                evidence="entries_filled=4 closed_trades=0",
+                proposed_code=_REPAIRED_CODE,
+                # ``max_drawdown_pct=4`` is below the validator's warning
+                # threshold of 5% (strategy_validator.py:91-102) — warning,
+                # not critical — so the repair is accepted but the gate must
+                # be carried forward.
+                proposed_spec_updates={
+                    "risk_limits": {"max_position_pct": 5, "max_drawdown_pct": 4}
+                },
+                changes_made="tightened risk limits",
+            ),
+        ],
+        sandbox_results=[
+            _code_exec(success=True, raw_trades=_benign_sandbox_trades()),
+        ],
+    )
+
+    outcome, _events, _attempts = _drive_repair(
+        orch,
+        exec_result=StrategyRunResult(
+            success=True,
+            trades=[],
+            execution_diagnostics=_zero_trade_diagnostics(category="ENTRY_WITH_NO_EXIT"),
+        ),
+    )
+
+    assert outcome.committed is True
+    # Look for the post-repair validator's warning in the carried gates.
+    spec_gate_names = [g.gate_name for g in outcome.new_gates]
+    assert any(
+        name.startswith("zero_trade_repair_strategy_spec_validator") for name in spec_gate_names
+    ), spec_gate_names
+    # And confirm it is a warning, not critical (else the repair would have
+    # been rejected, not accepted).
+    spec_warnings = [
+        g
+        for g in outcome.new_gates
+        if g.gate_name.startswith("zero_trade_repair_strategy_spec_validator")
+        and g.severity == "warning"
+    ]
+    assert spec_warnings, outcome.new_gates
+
+
 def test_zero_trade_repair_no_category_is_defensive_no_op(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
@@ -598,6 +598,60 @@ def test_zero_trade_repair_applies_proposed_spec_updates(
     assert outcome.new_spec.asset_class == "stocks"
 
 
+def test_zero_trade_repair_rejects_spec_updates_failing_post_repair_validator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Whitelisted spec_updates that pass Pydantic but fail StrategySpecValidator
+    (e.g. ``risk_limits.max_position_pct=99`` — Pydantic-valid but above the
+    25% safe range) must be rejected by the post-repair revalidation gate
+    added for #547 so the spec mutation never bypasses validation."""
+    orch, repair_stub, sandbox_stub = _make_orchestrator_with_stubs(
+        monkeypatch,
+        repair_reports=[
+            ZeroTradeRepairReport(
+                root_cause_category="ENTRY_WITH_NO_EXIT",
+                evidence="entries_filled=4 closed_trades=0",
+                proposed_code=_REPAIRED_CODE,
+                # ``max_position_pct=99`` is Pydantic-valid but the
+                # StrategySpecValidator marks anything outside [1, 25] as
+                # critical (safety_validator.py).
+                proposed_spec_updates={"risk_limits": {"max_position_pct": 99}},
+                changes_made="bumped position size",
+            ),
+        ],
+        sandbox_results=[],  # sandbox MUST NOT be called
+    )
+
+    outcome, events, attempts = _drive_repair(
+        orch,
+        exec_result=StrategyRunResult(
+            success=True,
+            trades=[],
+            execution_diagnostics=_zero_trade_diagnostics(category="ENTRY_WITH_NO_EXIT"),
+        ),
+    )
+
+    assert outcome.committed is False
+    assert outcome.failure_reason == "invalid_spec_after_repair"
+    # The sandbox must not run when the spec validator rejects the proposal.
+    assert sandbox_stub.calls == []
+    assert len(repair_stub.calls) == 1
+
+    assert len(attempts) == 1
+    assert attempts[0].startswith("invalid_spec_after_repair (ENTRY_WITH_NO_EXIT)")
+
+    rejected_event = next(
+        d for _, d in events if d.get("sub_phase") == "zero_trade_repair_rejected"
+    )
+    assert rejected_event["reason"] == "invalid_spec_after_repair"
+    # The post-repair spec gates are returned so the orchestrator can persist
+    # them on the failed-cycle record.
+    gate_names = [g.gate_name for g in outcome.new_gates]
+    assert any(
+        name.startswith("zero_trade_repair_strategy_spec_validator") for name in gate_names
+    ), gate_names
+
+
 def test_zero_trade_repair_no_category_is_defensive_no_op(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/backend/agents/investment_team/tests/test_strategy_validator.py
+++ b/backend/agents/investment_team/tests/test_strategy_validator.py
@@ -1,0 +1,98 @@
+"""Unit tests for ``StrategySpecValidator`` (#547 item 6).
+
+The gate runs deterministic checks against a ``StrategySpec`` before
+code execution. These tests focus on the hypothesis-vs-rules
+consistency check added in #547 — every other check has implicit
+coverage via the orchestrator integration tests.
+"""
+
+from __future__ import annotations
+
+from investment_team.models import StrategySpec
+from investment_team.strategy_lab.quality_gates.strategy_validator import (
+    StrategySpecValidator,
+)
+
+
+def _spec(*, hypothesis: str, entry: list[str], exit_: list[str]) -> StrategySpec:
+    return StrategySpec(
+        strategy_id="strat-validator-test",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis=hypothesis,
+        signal_definition="sig",
+        entry_rules=entry,
+        exit_rules=exit_,
+        sizing_rules=["risk 2% per trade"],
+        risk_limits={"max_position_pct": 5, "max_drawdown_pct": 10},
+        speculative=False,
+        strategy_code="from contract import Strategy\nclass S(Strategy):\n    def on_bar(self, ctx, bar):\n        pass\n",
+    )
+
+
+def _warnings(results) -> list[str]:
+    return [r.details for r in results if r.severity == "warning" and not r.passed]
+
+
+def test_hypothesis_term_missing_from_rules_emits_warning() -> None:
+    """Hypothesis names RSI; rules never reference it → consistency warning."""
+    spec = _spec(
+        hypothesis="RSI mean reversion on oversold conditions",
+        entry=["enter on volume spike above 2x average"],
+        exit_=["exit after 5 bars"],
+    )
+    results = StrategySpecValidator().validate(spec)
+    warnings = _warnings(results)
+    assert any("Hypothesis/rules consistency" in w and "rsi" in w.lower() for w in warnings), (
+        warnings
+    )
+
+
+def test_rules_term_missing_from_hypothesis_emits_warning() -> None:
+    """Rules reference MACD; hypothesis doesn't → consistency warning."""
+    spec = _spec(
+        hypothesis="Catch short-term trend continuation",
+        entry=["enter when MACD crosses above signal line"],
+        exit_=["exit when MACD crosses below signal line"],
+    )
+    results = StrategySpecValidator().validate(spec)
+    warnings = _warnings(results)
+    assert any("Hypothesis/rules consistency" in w and "macd" in w.lower() for w in warnings), (
+        warnings
+    )
+
+
+def test_aligned_hypothesis_and_rules_emit_no_consistency_warning() -> None:
+    """When hypothesis and rules share concept vocabulary, no warning fires."""
+    spec = _spec(
+        hypothesis="RSI signal strategy",
+        entry=["enter when RSI < 30"],
+        exit_=["exit when RSI > 70"],
+    )
+    results = StrategySpecValidator().validate(spec)
+    warnings = _warnings(results)
+    assert not any("Hypothesis/rules consistency" in w for w in warnings), warnings
+
+
+def test_no_recognised_terms_emits_no_consistency_warning() -> None:
+    """Hypothesis and rules without any recognised vocabulary stay silent."""
+    spec = _spec(
+        hypothesis="Buy low, sell high on a fixed schedule",
+        entry=["enter every Monday open"],
+        exit_=["exit every Friday close"],
+    )
+    results = StrategySpecValidator().validate(spec)
+    warnings = _warnings(results)
+    assert not any("Hypothesis/rules consistency" in w for w in warnings), warnings
+
+
+def test_word_boundary_prevents_thematic_matching_ema() -> None:
+    """The compiled regex uses ``\\b`` anchors so 'thematic' does not match 'ema'."""
+    spec = _spec(
+        hypothesis="Thematic exposure to growth sectors",
+        entry=["enter on quarterly rebalance into themes"],
+        exit_=["exit on rebalance day"],
+    )
+    results = StrategySpecValidator().validate(spec)
+    warnings = _warnings(results)
+    assert not any("Hypothesis/rules consistency" in w for w in warnings), warnings

--- a/user-interface/src/app/components/strategy-lab/strategy-lab.component.ts
+++ b/user-interface/src/app/components/strategy-lab/strategy-lab.component.ts
@@ -645,13 +645,20 @@ export class StrategyLabComponent implements OnInit, OnDestroy {
    * A failed gate is "remedied" if it failed in an earlier refinement round
    * and the final round produced a passing result (i.e. `refinement_rounds > 0`
    * and this gate's round is not the last one that ran).
+   *
+   * Pre-synthesis gates (refinement_round = -1, #547 item 1) are NOT
+   * subject to remediation: refinement is code-only, so a spec-level
+   * warning that fired before the refinement loop is immutable for the
+   * cycle and must not display as fixed when later code refinements run.
    */
   isRemedied(gate: QualityGateResult, record: StrategyLabRecord): boolean {
     if (gate.passed) return false;
+    const gateRound = gate.refinement_round ?? 0;
+    if (gateRound < 0) return false;
     const maxRound = record.refinement_rounds ?? 0;
     if (maxRound === 0) return false;
     // Gate failed in an earlier round — the strategy continued past it
-    return (gate.refinement_round ?? 0) < maxRound;
+    return gateRound < maxRound;
   }
 
   gateIcon(gate: QualityGateResult, record: StrategyLabRecord): string {

--- a/user-interface/src/app/components/strategy-lab/strategy-lab.component.ts
+++ b/user-interface/src/app/components/strategy-lab/strategy-lab.component.ts
@@ -642,19 +642,38 @@ export class StrategyLabComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * A failed gate is "remedied" if it failed in an earlier refinement round
-   * and the final round produced a passing result (i.e. `refinement_rounds > 0`
-   * and this gate's round is not the last one that ran).
+   * A failed gate is "remedied" if a later run of the same logical
+   * validator produced a passing result. Two channels:
    *
-   * Pre-synthesis gates (refinement_round = -1, #547 item 1) are NOT
-   * subject to remediation: refinement is code-only, so a spec-level
-   * warning that fired before the refinement loop is immutable for the
-   * cycle and must not display as fixed when later code refinements run.
+   * - Standard refinement-loop gates (refinement_round >= 0): remedied
+   *   when the gate's round is earlier than the cycle's last round
+   *   (the existing same-round-as-failure rule).
+   * - Pre-synthesis gates (refinement_round = -1, #547 item 1):
+   *   refinement itself is code-only and cannot fix them, but the
+   *   zero-trade repair path (#547 review) re-runs the spec validator
+   *   after committing whitelisted spec updates and emits gates with
+   *   gate_name `zero_trade_repair_<original>`. If any such later
+   *   validator pass produced a passing result for the same logical
+   *   check, the original pre-synthesis warning is remedied.
    */
   isRemedied(gate: QualityGateResult, record: StrategyLabRecord): boolean {
     if (gate.passed) return false;
+
     const gateRound = gate.refinement_round ?? 0;
-    if (gateRound < 0) return false;
+    if (gateRound < 0) {
+      // Pre-synthesis gate. Remedied only if a later validator pass for
+      // the same logical check returned a passing result.
+      const gates = record.quality_gate_results ?? [];
+      const baseName = gate.gate_name;
+      const repairName = `zero_trade_repair_${baseName}`;
+      return gates.some(
+        (g) =>
+          g.passed &&
+          (g.refinement_round ?? -1) >= 0 &&
+          (g.gate_name === baseName || g.gate_name === repairName),
+      );
+    }
+
     const maxRound = record.refinement_rounds ?? 0;
     if (maxRound === 0) return false;
     // Gate failed in an earlier round — the strategy continued past it

--- a/user-interface/src/app/models/investment.model.ts
+++ b/user-interface/src/app/models/investment.model.ts
@@ -487,6 +487,10 @@ export interface StrategyLabRecord {
   refinement_rounds?: number;
   quality_gate_results?: QualityGateResult[];
   strategy_code?: string;
+  /** Ideation-time spec before any refinement-driven mutation; absent on legacy rows. */
+  original_spec?: StrategySpec;
+  /** Ideation-time strategy code before refinement; absent on legacy rows. */
+  original_code?: string;
   /** Present on new runs: expert JSON or `{ skipped, skipped_reason }`. Legacy rows: undefined/null. */
   signal_intelligence_brief?: SignalIntelligenceBriefPayload;
 }

--- a/user-interface/src/app/models/investment.model.ts
+++ b/user-interface/src/app/models/investment.model.ts
@@ -487,10 +487,10 @@ export interface StrategyLabRecord {
   refinement_rounds?: number;
   quality_gate_results?: QualityGateResult[];
   strategy_code?: string;
-  /** Ideation-time spec before any refinement-driven mutation; absent on legacy rows. */
-  original_spec?: StrategySpec;
-  /** Ideation-time strategy code before refinement; absent on legacy rows. */
-  original_code?: string;
+  /** Ideation-time spec before any refinement-driven mutation; null on legacy rows. */
+  original_spec?: StrategySpec | null;
+  /** Ideation-time strategy code before refinement; null on legacy rows. */
+  original_code?: string | null;
   /** Present on new runs: expert JSON or `{ skipped, skipped_reason }`. Legacy rows: undefined/null. */
   signal_intelligence_brief?: SignalIntelligenceBriefPayload;
 }


### PR DESCRIPTION
## Summary

Implements GitHub issue #547 (Strategy Lab: tactical hardening bundle). Two commits on this branch, each landing one phase of the plan.

### Commit 1 — additive gates and provenance (items 3, 4, 5, 6)

- **Item 5 — Provenance fields.** `StrategyLabRecord` gains optional `original_spec` / `original_code`; orchestrator snapshots ideation outputs and persists them alongside the (possibly refined) final state. UI TS interface updated.
- **Item 3 — `no_on_bar` already critical.** Investigation found the wrapper at `code_safety.py:159-168` already promotes `_validate_on_bar`'s return to `severity="critical"`. The inline comment at line 363 was misleading. Comment fixed; existing `test_missing_on_bar_override_is_critical` covers regression.
- **Item 4 — Order-flow shape gate.** New AST check: critical fail when the `Strategy` class has zero `ctx.submit_order` calls (no entry) or exactly one (no exit). Strategies using a single conditional-side call are flagged — accepted trade-off; the detail makes it actionable.
- **Item 6 — Hypothesis-vs-rules consistency.** New warning when indicator concepts named in the hypothesis are absent from entry/exit rules (or vice versa). Word-boundary-anchored vocabulary regex.

### Commit 2 — refinement contract + pre-gating (items 2, 1, 7)

- **Item 2 — Refinement output narrowed to code-only.** `RefinementAgent`'s JSON schema now returns only `strategy_code` + `changes_made`. Both `refinement.py` and `refinement_system.md` prompts updated; `_apply_updates` merges only the new code (legacy spec keys are silently ignored).
- **Item 1 — Pre-synthesis spec validation.** `StrategySpecValidator` now runs once immediately after ideation, BEFORE the refinement loop. Critical failures short-circuit through new `_build_short_circuit_record` helper — no `run_strategy_code` call, no market-data fetch — and persist `status="failed: spec_validation"`. `convergence_tracker.record` is still called. Pre-synthesis gates carry `refinement_round=-1`. The in-loop spec_gates call is removed (safe now that item 2 makes the spec immutable post-ideation).
- **Item 7 — Queryable max-rounds status.** All three `MAX_CODE_REFINEMENT_ROUNDS` break sites flip status to `"failed: max_refinement_rounds"`. **Semantics change**: the evaluation-phase site previously reported `status="completed"` ("anomalous but code is correct"); it now reports failed. `is_winning` logic unchanged (strict reading of the issue).

Fixed three existing tests (`test_valid_minimal_strategy_passes`, `test_contract_attribute_base_also_recognised`, `test_indicators_import_still_allowed`) plus alignment / zero-trade / walk-forward fixtures whose stub code intentionally used `pass`-only `on_bar` bodies and now fail the new order-flow gate.

## Test plan
- [x] `pytest backend/agents/investment_team/tests/` — 1226 passed, 13 skipped
- [x] `ruff check backend/agents/investment_team/` — all checks passed
- [x] `ruff format --check` on touched files
- [x] New tests for each item:
  - `test_strategy_lab_record_provenance.py` (3)
  - `test_strategy_validator.py` (5)
  - new code-safety order-flow tests (3) in `test_code_safety.py`
  - `test_strategy_lab_refinement_contract.py` (2)
  - `test_strategy_lab_pre_synthesis_gating.py` (2)
  - `test_strategy_lab_max_rounds_exhaustion.py` (2)
- [ ] End-to-end smoke via Strategy Lab API (reviewer/owner; needs Postgres + job-service stack)

Closes #547.

https://claude.ai/code/session_01D9SShN1p2z8s6JaaayCwhg