### PR TITLE
investment-team: add target_symbols to StrategySpec (#523)

### DIFF
--- a/backend/agents/investment_team/api/main.py
+++ b/backend/agents/investment_team/api/main.py
@@ -1067,9 +1067,9 @@ def _run_real_data_backtest(
         )
 
     market_service = MarketDataService()
-    symbols = market_service.get_symbols_for_strategy(strategy)
-    # Use top 5 symbols to keep data fetching reasonable
-    symbols = symbols[:5]
+    # Issue #523 — honour explicit target_symbols; otherwise fall back to
+    # the asset-class default universe (capped to 5; #525 removes the cap).
+    symbols = market_service.resolve_strategy_symbols(strategy)
 
     logger.info(
         "Fetching historical data for %s backtest (%s to %s, %d symbols)...",
@@ -1156,9 +1156,10 @@ def _run_paper_trading_step(
     from investment_team.paper_trading_agent import PaperTradingAgent
 
     market_service = MarketDataService()
-    symbols = market_service.get_symbols_for_strategy(strategy)
-    # Match the standalone endpoint: cap at top 5 symbols to bound fetch cost
-    symbols = symbols[:5]
+    # Issue #523 — paper trading must honour the same universe as the
+    # backtest that promoted this spec, otherwise a winning QQQ-only
+    # strategy gets paper-traded against AAPL/MSFT/... .
+    symbols = market_service.resolve_strategy_symbols(strategy)
 
     logger.info(
         "Paper-trading step: fetching %d days of market data for %d symbols (%s) ...",
@@ -2667,7 +2668,8 @@ def _run_paper_trading_background(
 
     try:
         market_service = MarketDataService()
-        symbols = market_service.get_symbols_for_strategy(strategy)[:5]
+        # Issue #523 — match the orchestrator backtest's universe choice.
+        symbols = market_service.resolve_strategy_symbols(strategy)
         logger.info(
             "Paper trade %s: fetching %d days of market data for %d symbols (%s) ...",
             session_id,
@@ -2927,12 +2929,13 @@ def _run_live_paper_trading_background(
         _live_paper_stop_controllers[session_id] = controller
 
     try:
-        # Choose symbols the same way the legacy path does — but only up to the
-        # first few to keep bandwidth bounded during paper trading.
+        # Issue #523 — honour target_symbols when set; otherwise fall back
+        # to the asset-class default universe (capped at 5; #525 removes
+        # the magic cap).
         from investment_team.market_data_service import MarketDataService
 
         market_service = MarketDataService()
-        symbols = market_service.get_symbols_for_strategy(strategy)[:5]
+        symbols = market_service.resolve_strategy_symbols(strategy)
         if not symbols:
             raise RuntimeError("no symbols resolved for strategy")
 

--- a/backend/agents/investment_team/market_data_service.py
+++ b/backend/agents/investment_team/market_data_service.py
@@ -32,6 +32,7 @@ from .symbols import (
     FUTURES_SYMBOLS,
     STOCK_SYMBOLS,
     YAHOO_CRYPTO_TICKERS,
+    classify_symbol,
 )
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -251,10 +252,36 @@ class MarketDataService:
         asset-class default universe is returned, capped at 5 symbols to
         bound fetch cost — that magic literal is replaced by
         ``STRATEGY_LAB_MAX_UNIVERSE_SYMBOLS`` in #525.
+
+        When the declared ``asset_class`` doesn't match the natural class
+        of a target symbol (e.g. ``asset_class="stocks"`` +
+        ``target_symbols=["BTC"]``), a warning is logged. The fetch still
+        proceeds — operators see the warning instead of a silent empty
+        result. Ambiguous symbols (cross-asset ETFs like GLD, QQQ) are
+        not flagged.
         """
         if strategy.target_symbols:
+            self._warn_on_asset_class_mismatch(strategy)
             return list(strategy.target_symbols)
         return self.get_symbols_for_strategy(strategy)[:5]
+
+    def _warn_on_asset_class_mismatch(self, strategy: StrategySpec) -> None:
+        declared = normalize_asset_class(strategy.asset_class)
+        mismatches: list[tuple[str, str]] = []
+        for sym in strategy.target_symbols:
+            natural = classify_symbol(sym)
+            if natural is not None and natural != declared:
+                mismatches.append((sym, natural))
+        if mismatches:
+            logger.warning(
+                "Strategy %s: target_symbols %s do not match asset_class=%s — "
+                "the %s provider chain will be used and may return no data. "
+                "Update target_symbols or asset_class to align.",
+                strategy.strategy_id,
+                mismatches,
+                declared,
+                declared,
+            )
 
     def fetch_multi_symbol(
         self, symbols: List[str], asset_class: str, days: int = 365

--- a/backend/agents/investment_team/market_data_service.py
+++ b/backend/agents/investment_team/market_data_service.py
@@ -242,6 +242,20 @@ class MarketDataService:
         }
         return list(symbol_map.get(asset, STOCK_SYMBOLS))
 
+    def resolve_strategy_symbols(self, strategy: StrategySpec) -> List[str]:
+        """Issue #523 — pick the symbol universe a strategy should trade.
+
+        When ``strategy.target_symbols`` is non-empty it is returned
+        verbatim, so a hypothesis naming QQQ is backtested and paper-traded
+        on QQQ instead of the asset-class default. Otherwise the
+        asset-class default universe is returned, capped at 5 symbols to
+        bound fetch cost — that magic literal is replaced by
+        ``STRATEGY_LAB_MAX_UNIVERSE_SYMBOLS`` in #525.
+        """
+        if strategy.target_symbols:
+            return list(strategy.target_symbols)
+        return self.get_symbols_for_strategy(strategy)[:5]
+
     def fetch_multi_symbol(
         self, symbols: List[str], asset_class: str, days: int = 365
     ) -> Dict[str, List[OHLCVBar]]:

--- a/backend/agents/investment_team/models.py
+++ b/backend/agents/investment_team/models.py
@@ -200,6 +200,11 @@ class StrategySpec(BaseModel):
     entry_rules: List[str] = Field(default_factory=list)
     exit_rules: List[str] = Field(default_factory=list)
     sizing_rules: List[str] = Field(default_factory=list)
+    # Issue #523 — explicit list of tickers the strategy is designed to
+    # trade. When non-empty, the fetch path uses this list verbatim
+    # instead of the asset-class default universe, so a hypothesis naming
+    # QQQ doesn't get silently backtested on AAPL.
+    target_symbols: List[str] = Field(default_factory=list)
     # Phase 3: risk_limits is validated at spec construction time.  Dicts
     # authored by the LLM (or persisted before this field was typed) are
     # accepted and routed through ``RiskLimits.from_legacy_dict``, which
@@ -219,6 +224,25 @@ class StrategySpec(BaseModel):
         if isinstance(v, dict):
             return RiskLimits.from_legacy_dict(v)
         return v
+
+    @field_validator("target_symbols", mode="before")
+    @classmethod
+    def _normalize_target_symbols(cls, v: Any) -> List[str]:
+        if v is None:
+            return []
+        if not isinstance(v, list):
+            raise ValueError("target_symbols must be a list of strings")
+        seen: set[str] = set()
+        out: List[str] = []
+        for item in v:
+            if not isinstance(item, str):
+                raise ValueError("target_symbols entries must be strings")
+            sym = item.strip().upper()
+            if not sym or sym in seen:
+                continue
+            seen.add(sym)
+            out.append(sym)
+        return out
 
 
 class ValidationCheck(BaseModel):

--- a/backend/agents/investment_team/strategy_lab/agents/ideation.py
+++ b/backend/agents/investment_team/strategy_lab/agents/ideation.py
@@ -47,6 +47,7 @@ Return ONLY a JSON object with no markdown:
   "entry_rules": ["rule 1", "rule 2", "rule 3"],
   "exit_rules": ["exit rule 1", "exit rule 2"],
   "sizing_rules": ["sizing rule 1"],
+  "target_symbols": ["UPPERCASE tickers if your hypothesis names specific ones, e.g. QQQ; else []"],
   "risk_limits": {{"max_position_pct": 5, "stop_loss_pct": 3}},
   "speculative": false,
   "rationale": "Why this strategy and asset class now, given priors and the diversity hint",

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -1565,11 +1565,7 @@ class StrategyLabOrchestrator:
             # back to the asset-class default universe otherwise. The
             # ``symbols[:5]`` truncation on the fallback path is removed
             # in #525.
-            if spec.target_symbols:
-                symbols = list(spec.target_symbols)
-            else:
-                symbols = self.market_data_service.get_symbols_for_strategy(spec)
-                symbols = symbols[:5]
+            symbols = self.market_data_service.resolve_strategy_symbols(spec)
             if not symbols:
                 return None
             as_of = (getattr(spec, "audit", None) and spec.audit.data_snapshot_id) or None

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -244,6 +244,7 @@ class StrategyLabOrchestrator:
             entry_rules=strategy_dict.get("entry_rules", []),
             exit_rules=strategy_dict.get("exit_rules", []),
             sizing_rules=strategy_dict.get("sizing_rules", []),
+            target_symbols=strategy_dict.get("target_symbols", []),
             risk_limits=strategy_dict.get("risk_limits", {}),
             speculative=strategy_dict.get("speculative", False),
             strategy_code=code,
@@ -1560,12 +1561,20 @@ class StrategyLabOrchestrator:
         Specs without it use ``None`` (latest).
         """
         try:
-            symbols = self.market_data_service.get_symbols_for_strategy(spec)
+            # Issue #523 — honour explicit target_symbols verbatim; fall
+            # back to the asset-class default universe otherwise. The
+            # ``symbols[:5]`` truncation on the fallback path is removed
+            # in #525.
+            if spec.target_symbols:
+                symbols = list(spec.target_symbols)
+            else:
+                symbols = self.market_data_service.get_symbols_for_strategy(spec)
+                symbols = symbols[:5]
             if not symbols:
                 return None
             as_of = (getattr(spec, "audit", None) and spec.audit.data_snapshot_id) or None
             data = self.market_data_service.fetch_multi_symbol_range(
-                symbols=symbols[:5],
+                symbols=symbols,
                 asset_class=spec.asset_class,
                 start_date=config.start_date,
                 end_date=config.end_date,

--- a/backend/agents/investment_team/strategy_lab/prompts/ideation_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/ideation_system.md
@@ -25,6 +25,10 @@ Design strategies as a **mixture of signal types**, not a single indicator. Comb
 
 Diversify across: stocks, crypto, forex, options, futures, commodities. Do NOT default to equities unless explicitly directed.
 
+## Target symbols
+
+Whenever your hypothesis or signal definition names specific tickers (e.g. "QQQ trend continuation", "long GLD vs short USO"), populate `target_symbols` in the JSON response with exactly those tickers, uppercase. The backtest engine then fetches and trades that universe verbatim — no asset-class default substitution. Use yfinance-style suffixes when applicable: forex pairs end in `=X` (`EURUSD=X`), futures in `=F` (`GC=F`). If the hypothesis is universe-agnostic ("any liquid US large-cap"), return `[]` and the asset-class default universe is used.
+
 ## Execution model (read this carefully — it's NEW)
 
 You do **NOT** write a batch `run_strategy(data, config)` function anymore. The backtest and paper-trading engines are event-driven: they deliver **one `Bar` at a time** to your strategy's `on_bar(ctx, bar)` method, you decide what order (if any) to submit via `ctx.submit_order(...)`, and the engine decides whether/when/at-what-price it fills.

--- a/backend/agents/investment_team/symbols.py
+++ b/backend/agents/investment_team/symbols.py
@@ -6,6 +6,8 @@ engine (synthetic trade generation), and any future consumer that routes by asse
 
 from __future__ import annotations
 
+from typing import Optional
+
 # Yahoo Finance ticker mapping for crypto symbols (symbol → yfinance ticker)
 YAHOO_CRYPTO_TICKERS: dict[str, str] = {
     "BTC": "BTC-USD",
@@ -92,3 +94,50 @@ FUTURES_SYMBOLS_BARE: list[str] = ["ES", "NQ", "CL", "GC", "SI", "ZB", "NG", "ZM
 COMMODITY_SYMBOLS: list[str] = ["GLD", "USO", "SLV", "DBA", "UNG", "PDBC", "DBC"]
 # Broad ETFs used as a fallback
 OTHER_SYMBOLS: list[str] = ["GLD", "USO", "TLT", "QQQ", "IWM", "EEM", "GDX", "XLE", "XLF"]
+
+
+def classify_symbol(symbol: str) -> Optional[str]:
+    """Issue #523 — best-effort asset-class classification of a single ticker.
+
+    Returns one of ``"stocks" | "crypto" | "forex" | "futures" | "commodities"``
+    when the symbol unambiguously belongs to that class, else ``None``.
+
+    Used to detect ``target_symbols`` vs ``asset_class`` mismatches (e.g.
+    a strategy with ``asset_class="stocks"`` requesting ``target_symbols=["BTC"]``)
+    so the operator gets a warning instead of a silent empty fetch.
+
+    Cross-asset ETFs (``OTHER_SYMBOLS`` — GLD, USO, TLT, QQQ, ...) are
+    deliberately *not* classified: they trade like stocks via Yahoo even
+    when their underlying exposure is a different class, so flagging them
+    would be a false positive in the common case.
+    """
+    sym = symbol.upper()
+
+    if sym in OTHER_SYMBOLS:
+        return None
+
+    matched: list[str] = []
+    if sym in STOCK_SYMBOLS:
+        matched.append("stocks")
+    if sym in CRYPTO_SYMBOLS:
+        matched.append("crypto")
+    if sym in FOREX_SYMBOLS or sym in FOREX_SYMBOLS_BARE:
+        matched.append("forex")
+    if sym in FUTURES_SYMBOLS or sym in FUTURES_SYMBOLS_BARE:
+        matched.append("futures")
+    if sym in COMMODITY_SYMBOLS:
+        matched.append("commodities")
+
+    if len(matched) == 1:
+        return matched[0]
+    if matched:
+        return None  # ambiguous — don't guess
+
+    # Suffix heuristics for symbols outside our canonical lists.
+    if sym.endswith("=X"):
+        return "forex"
+    if sym.endswith("=F"):
+        return "futures"
+    if sym.endswith("-USD"):
+        return "crypto"
+    return None

--- a/backend/agents/investment_team/tests/test_backtest_endpoint.py
+++ b/backend/agents/investment_team/tests/test_backtest_endpoint.py
@@ -84,6 +84,13 @@ class _FakeMarketDataService:
     def get_symbols_for_strategy(self, strategy: StrategySpec) -> List[str]:
         return list(self._market_data.keys())
 
+    def resolve_strategy_symbols(self, strategy: StrategySpec) -> List[str]:
+        # Issue #523 — mirror the real ``MarketDataService.resolve_strategy_symbols``
+        # so endpoint tests honour ``spec.target_symbols`` when set.
+        if strategy.target_symbols:
+            return list(strategy.target_symbols)
+        return self.get_symbols_for_strategy(strategy)[:5]
+
     def fetch_multi_symbol_range(
         self, symbols: List[str], asset_class: str, start: str, end: str
     ) -> Dict[str, List[OHLCVBar]]:

--- a/backend/agents/investment_team/tests/test_investment_team.py
+++ b/backend/agents/investment_team/tests/test_investment_team.py
@@ -1099,6 +1099,141 @@ def test_market_data_service_fetch_multi_symbol_range(tmp_path) -> None:
     assert result["AAPL"][0].close == 153.0
 
 
+def test_strategy_spec_target_symbols_normalization() -> None:
+    """Issue #523 — target_symbols is uppercased, stripped, deduped, preserves order."""
+    spec = StrategySpec(
+        strategy_id="s-norm",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="h",
+        signal_definition="s",
+        target_symbols=["qqq", " GLD ", "QQQ", "spy"],
+    )
+    assert spec.target_symbols == ["QQQ", "GLD", "SPY"]
+
+    # default (omitted) is an empty list, preserving backward compat
+    bare = StrategySpec(
+        strategy_id="s-bare",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="h",
+        signal_definition="s",
+    )
+    assert bare.target_symbols == []
+
+    # None coerces to []
+    none_spec = StrategySpec(
+        strategy_id="s-none",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="h",
+        signal_definition="s",
+        target_symbols=None,
+    )
+    assert none_spec.target_symbols == []
+
+
+def test_strategy_spec_target_symbols_rejects_non_strings() -> None:
+    """Issue #523 — non-string entries (and non-list values) are rejected."""
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        StrategySpec(
+            strategy_id="s-bad",
+            authored_by="test",
+            asset_class="stocks",
+            hypothesis="h",
+            signal_definition="s",
+            target_symbols=["AAPL", 42],
+        )
+
+    with pytest.raises(ValidationError):
+        StrategySpec(
+            strategy_id="s-bad2",
+            authored_by="test",
+            asset_class="stocks",
+            hypothesis="h",
+            signal_definition="s",
+            target_symbols="AAPL",  # type: ignore[arg-type]
+        )
+
+
+def test_fetch_market_data_uses_target_symbols_when_set() -> None:
+    """Issue #523 — when spec.target_symbols is non-empty, the fetcher receives
+    it verbatim and the asset-class default universe is bypassed."""
+    from unittest.mock import MagicMock
+
+    from agents.investment_team.models import BacktestConfig
+    from agents.investment_team.strategy_lab.orchestrator import StrategyLabOrchestrator
+
+    orchestrator = StrategyLabOrchestrator.__new__(StrategyLabOrchestrator)
+    captured: dict = {}
+
+    def fake_fetch(*, symbols, asset_class, start_date, end_date, as_of):
+        captured["symbols"] = list(symbols)
+        captured["asset_class"] = asset_class
+        return {sym: ["bar"] for sym in symbols}
+
+    market = MagicMock()
+    market.fetch_multi_symbol_range.side_effect = fake_fetch
+    # If get_symbols_for_strategy were called it would short-circuit the test —
+    # raise to make accidental calls obvious.
+    market.get_symbols_for_strategy.side_effect = AssertionError(
+        "fallback should not be used when target_symbols is set"
+    )
+    orchestrator.market_data_service = market
+
+    spec = StrategySpec(
+        strategy_id="s-tgt",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="QQQ trend continuation",
+        signal_definition="s",
+        target_symbols=["QQQ"],
+    )
+    config = BacktestConfig(start_date="2023-01-01", end_date="2023-12-31")
+
+    result = orchestrator._fetch_market_data(spec, config)
+    assert captured["symbols"] == ["QQQ"]
+    assert result == {"QQQ": ["bar"]}
+
+
+def test_fetch_market_data_falls_back_when_target_symbols_empty() -> None:
+    """Issue #523 — empty target_symbols routes through the asset-class default
+    universe. Current behaviour caps at 5 symbols; #525 will tighten this."""
+    from unittest.mock import MagicMock
+
+    from agents.investment_team.models import BacktestConfig
+    from agents.investment_team.strategy_lab.orchestrator import StrategyLabOrchestrator
+    from agents.investment_team.symbols import STOCK_SYMBOLS
+
+    orchestrator = StrategyLabOrchestrator.__new__(StrategyLabOrchestrator)
+    captured: dict = {}
+
+    def fake_fetch(*, symbols, asset_class, start_date, end_date, as_of):
+        captured["symbols"] = list(symbols)
+        return {sym: ["bar"] for sym in symbols}
+
+    market = MagicMock()
+    market.get_symbols_for_strategy.return_value = list(STOCK_SYMBOLS)
+    market.fetch_multi_symbol_range.side_effect = fake_fetch
+    orchestrator.market_data_service = market
+
+    spec = StrategySpec(
+        strategy_id="s-default",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="generic large-cap momentum",
+        signal_definition="s",
+    )
+    config = BacktestConfig(start_date="2023-01-01", end_date="2023-12-31")
+
+    orchestrator._fetch_market_data(spec, config)
+    # Sanity: the fallback path uses the default universe (capped to 5 until #525).
+    assert captured["symbols"] == list(STOCK_SYMBOLS[:5])
+
+
 def test_agent_catalog_includes_signal_intelligence_expert() -> None:
     from agents.investment_team.agent_catalog import CORE_AGENTS
 

--- a/backend/agents/investment_team/tests/test_investment_team.py
+++ b/backend/agents/investment_team/tests/test_investment_team.py
@@ -1159,30 +1159,57 @@ def test_strategy_spec_target_symbols_rejects_non_strings() -> None:
         )
 
 
+def test_resolve_strategy_symbols_prefers_target_symbols() -> None:
+    """Issue #523 — resolve_strategy_symbols returns target_symbols verbatim
+    when set, regardless of asset_class."""
+    from agents.investment_team.market_data_service import MarketDataService
+
+    service = MarketDataService()
+    spec = StrategySpec(
+        strategy_id="s-tgt",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="QQQ trend continuation",
+        signal_definition="s",
+        target_symbols=["QQQ", "GLD"],
+    )
+    assert service.resolve_strategy_symbols(spec) == ["QQQ", "GLD"]
+
+
+def test_resolve_strategy_symbols_falls_back_to_asset_class_universe() -> None:
+    """Issue #523 — empty target_symbols falls through to the asset-class default
+    universe (capped at 5; #525 tightens this)."""
+    from agents.investment_team.market_data_service import MarketDataService
+    from agents.investment_team.symbols import STOCK_SYMBOLS
+
+    service = MarketDataService()
+    spec = StrategySpec(
+        strategy_id="s-default",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="generic large-cap momentum",
+        signal_definition="s",
+    )
+    assert service.resolve_strategy_symbols(spec) == list(STOCK_SYMBOLS[:5])
+
+
 def test_fetch_market_data_uses_target_symbols_when_set() -> None:
     """Issue #523 — when spec.target_symbols is non-empty, the fetcher receives
     it verbatim and the asset-class default universe is bypassed."""
-    from unittest.mock import MagicMock
+    from unittest.mock import patch
 
+    from agents.investment_team.market_data_service import MarketDataService
     from agents.investment_team.models import BacktestConfig
     from agents.investment_team.strategy_lab.orchestrator import StrategyLabOrchestrator
 
     orchestrator = StrategyLabOrchestrator.__new__(StrategyLabOrchestrator)
+    orchestrator.market_data_service = MarketDataService()
     captured: dict = {}
 
     def fake_fetch(*, symbols, asset_class, start_date, end_date, as_of):
         captured["symbols"] = list(symbols)
         captured["asset_class"] = asset_class
         return {sym: ["bar"] for sym in symbols}
-
-    market = MagicMock()
-    market.fetch_multi_symbol_range.side_effect = fake_fetch
-    # If get_symbols_for_strategy were called it would short-circuit the test —
-    # raise to make accidental calls obvious.
-    market.get_symbols_for_strategy.side_effect = AssertionError(
-        "fallback should not be used when target_symbols is set"
-    )
-    orchestrator.market_data_service = market
 
     spec = StrategySpec(
         strategy_id="s-tgt",
@@ -1194,7 +1221,11 @@ def test_fetch_market_data_uses_target_symbols_when_set() -> None:
     )
     config = BacktestConfig(start_date="2023-01-01", end_date="2023-12-31")
 
-    result = orchestrator._fetch_market_data(spec, config)
+    with patch.object(
+        orchestrator.market_data_service, "fetch_multi_symbol_range", side_effect=fake_fetch
+    ):
+        result = orchestrator._fetch_market_data(spec, config)
+
     assert captured["symbols"] == ["QQQ"]
     assert result == {"QQQ": ["bar"]}
 
@@ -1202,23 +1233,20 @@ def test_fetch_market_data_uses_target_symbols_when_set() -> None:
 def test_fetch_market_data_falls_back_when_target_symbols_empty() -> None:
     """Issue #523 — empty target_symbols routes through the asset-class default
     universe. Current behaviour caps at 5 symbols; #525 will tighten this."""
-    from unittest.mock import MagicMock
+    from unittest.mock import patch
 
+    from agents.investment_team.market_data_service import MarketDataService
     from agents.investment_team.models import BacktestConfig
     from agents.investment_team.strategy_lab.orchestrator import StrategyLabOrchestrator
     from agents.investment_team.symbols import STOCK_SYMBOLS
 
     orchestrator = StrategyLabOrchestrator.__new__(StrategyLabOrchestrator)
+    orchestrator.market_data_service = MarketDataService()
     captured: dict = {}
 
     def fake_fetch(*, symbols, asset_class, start_date, end_date, as_of):
         captured["symbols"] = list(symbols)
         return {sym: ["bar"] for sym in symbols}
-
-    market = MagicMock()
-    market.get_symbols_for_strategy.return_value = list(STOCK_SYMBOLS)
-    market.fetch_multi_symbol_range.side_effect = fake_fetch
-    orchestrator.market_data_service = market
 
     spec = StrategySpec(
         strategy_id="s-default",
@@ -1229,7 +1257,11 @@ def test_fetch_market_data_falls_back_when_target_symbols_empty() -> None:
     )
     config = BacktestConfig(start_date="2023-01-01", end_date="2023-12-31")
 
-    orchestrator._fetch_market_data(spec, config)
+    with patch.object(
+        orchestrator.market_data_service, "fetch_multi_symbol_range", side_effect=fake_fetch
+    ):
+        orchestrator._fetch_market_data(spec, config)
+
     # Sanity: the fallback path uses the default universe (capped to 5 until #525).
     assert captured["symbols"] == list(STOCK_SYMBOLS[:5])
 

--- a/backend/agents/investment_team/tests/test_investment_team.py
+++ b/backend/agents/investment_team/tests/test_investment_team.py
@@ -1176,6 +1176,106 @@ def test_resolve_strategy_symbols_prefers_target_symbols() -> None:
     assert service.resolve_strategy_symbols(spec) == ["QQQ", "GLD"]
 
 
+def test_classify_symbol_unambiguous_cases() -> None:
+    """Issue #523 — classify_symbol returns the natural asset class for symbols
+    that unambiguously belong to one canonical universe."""
+    from agents.investment_team.symbols import classify_symbol
+
+    assert classify_symbol("BTC") == "crypto"
+    assert classify_symbol("ETH") == "crypto"
+    assert classify_symbol("AAPL") == "stocks"
+    assert classify_symbol("EURUSD=X") == "forex"
+    assert classify_symbol("EURUSD") == "forex"
+    assert classify_symbol("GC=F") == "futures"
+    # Suffix-only fallback (symbol not in any canonical list)
+    assert classify_symbol("BTC-USD") == "crypto"
+    assert classify_symbol("AUDCHF=X") == "forex"
+    assert classify_symbol("RTY=F") == "futures"
+
+
+def test_classify_symbol_returns_none_for_ambiguous_or_unknown() -> None:
+    """Issue #523 — cross-asset ETFs and unknown tickers don't get classified
+    so the mismatch warning doesn't false-positive."""
+    from agents.investment_team.symbols import classify_symbol
+
+    # OTHER_SYMBOLS — tradeable as stocks via Yahoo even with non-stock exposure
+    assert classify_symbol("GLD") is None
+    assert classify_symbol("QQQ") is None
+    assert classify_symbol("TLT") is None
+    # Unknown ticker — don't guess
+    assert classify_symbol("NEWCO") is None
+
+
+def test_resolve_strategy_symbols_warns_on_asset_class_mismatch(caplog) -> None:
+    """Issue #523 — a strategy declaring asset_class="stocks" with
+    target_symbols=["BTC"] should emit a warning so the operator sees the
+    mismatch instead of getting an empty fetch silently."""
+    import logging
+
+    from agents.investment_team.market_data_service import MarketDataService
+
+    service = MarketDataService()
+    spec = StrategySpec(
+        strategy_id="s-mismatch",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="bitcoin trend follow",
+        signal_definition="s",
+        target_symbols=["BTC"],
+    )
+    with caplog.at_level(logging.WARNING, logger="agents.investment_team.market_data_service"):
+        result = service.resolve_strategy_symbols(spec)
+
+    # The fetch still proceeds against the requested symbols.
+    assert result == ["BTC"]
+    # But the operator sees the diagnostic.
+    assert any(
+        "s-mismatch" in r.message and "BTC" in r.message and "stocks" in r.message
+        for r in caplog.records
+    ), f"expected mismatch warning, got: {[r.message for r in caplog.records]}"
+
+
+def test_resolve_strategy_symbols_no_warning_on_matching_asset_class(caplog) -> None:
+    """Issue #523 — no warning when target_symbols match the declared
+    asset_class, nor for cross-asset ETFs (GLD, QQQ) which deliberately
+    aren't classified to avoid false positives."""
+    import logging
+
+    from agents.investment_team.market_data_service import MarketDataService
+
+    service = MarketDataService()
+    aligned = StrategySpec(
+        strategy_id="s-aligned",
+        authored_by="test",
+        asset_class="crypto",
+        hypothesis="BTC trend follow",
+        signal_definition="s",
+        target_symbols=["BTC"],
+    )
+    qqq_stocks = StrategySpec(
+        strategy_id="s-qqq",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="QQQ trend continuation",
+        signal_definition="s",
+        target_symbols=["QQQ", "GLD"],
+    )
+    unknown = StrategySpec(
+        strategy_id="s-unknown",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="momentum on a fresh ticker",
+        signal_definition="s",
+        target_symbols=["NEWCO"],
+    )
+    with caplog.at_level(logging.WARNING, logger="agents.investment_team.market_data_service"):
+        service.resolve_strategy_symbols(aligned)
+        service.resolve_strategy_symbols(qqq_stocks)
+        service.resolve_strategy_symbols(unknown)
+
+    assert caplog.records == [], f"unexpected warnings: {[r.message for r in caplog.records]}"
+
+
 def test_resolve_strategy_symbols_falls_back_to_asset_class_universe() -> None:
     """Issue #523 — empty target_symbols falls through to the asset-class default
     universe (capped at 5; #525 tightens this)."""


### PR DESCRIPTION
## Summary

Closes #523 (1 of 2 in the P0 universe-correctness cluster; #525 follows).

Strategy Lab runs were producing "execution fidelity" failures where the analysis narrative named one ticker (e.g. "QQQ trend continuation") but the backtest actually traded a different one (TSLA, AAPL…). Root cause: a `StrategySpec` carried only `asset_class` plus free-form prose, with nothing machine-readable telling the fetch path *which symbols* to use. The orchestrator therefore fell back to the asset-class default universe (`STOCK_SYMBOLS` doesn't even contain QQQ), so the hypothesis could never be tested as written.

This PR wires an explicit `target_symbols: list[str]` through ideation → spec → fetch.

## Changes

- **`backend/agents/investment_team/models.py`** — add `StrategySpec.target_symbols` field with a Pydantic v2 `@field_validator` that uppercases, strips, dedupes, and rejects non-strings. Default `[]` preserves backward compat for persisted specs.
- **`backend/agents/investment_team/strategy_lab/prompts/ideation_system.md`** — add a "Target symbols" section instructing the LLM to populate the field whenever the hypothesis names tickers, with yfinance-style suffix guidance (`=X` for forex, `=F` for futures), and `[]` for universe-agnostic hypotheses.
- **`backend/agents/investment_team/strategy_lab/agents/ideation.py`** — extend the JSON template with the new key.
- **`backend/agents/investment_team/strategy_lab/orchestrator.py`** — pass `target_symbols` through `StrategySpec(...)` construction; in `_fetch_market_data`, use `spec.target_symbols` verbatim when non-empty; otherwise fall through to the asset-class default universe (still capped at 5 symbols here — #525 removes that next).
- **`backend/agents/investment_team/tests/test_investment_team.py`** — 4 new tests:
  - `test_strategy_spec_target_symbols_normalization` — uppercase/strip/dedupe/`None`-coerce
  - `test_strategy_spec_target_symbols_rejects_non_strings` — validator failures
  - `test_fetch_market_data_uses_target_symbols_when_set` — verbatim path
  - `test_fetch_market_data_falls_back_when_target_symbols_empty` — asset-class default path

## Deliberately deferred

- Drop the `symbols[:5]` truncation + env-cap with logging — covered by #525 (PR 2 of 2), which also fixes the matching sites in `api/main.py` (`/backtest`, paper-trading data fetch).
- Symbol-filter guard inside generated `on_bar` — #524.
- `target_symbol_coverage` quality gate — #526.
- `data_provenance` audit-trail expansion — #533.

## Test plan

- [x] `ruff check` + `ruff format --check` clean on changed files
- [x] `pytest agents/investment_team/tests/test_investment_team.py -k "target_symbols or market_data_service or strategy_spec or fetch_market_data"` — 10 passed
- [x] `pytest agents/investment_team/tests -k "strategy_lab"` — 96 passed, 1 skipped (no regressions)
- [x] Full `agents/investment_team/tests/test_investment_team.py` — 58 passed
- [ ] Manual smoke (optional, requires running stack): submit a Strategy Lab run with a hypothesis naming a ticker outside the default universe (e.g. QQQ); confirm the saved `StrategySpec.target_symbols == ["QQQ"]` and that `_fetch_market_data` requests QQQ from `MarketDataService`.

https://claude.ai/code/session_01JyvzzDb3Foue4wzDCzCocD

---
_Generated by [Claude Code](https://claude.ai/code/session_01JyvzzDb3Foue4wzDCzCocD)_