### PR TITLE
investment-team: freeze spec after design phase in Strategy Lab (#543)

### DIFF
--- a/backend/agents/investment_team/execution/risk_filter.py
+++ b/backend/agents/investment_team/execution/risk_filter.py
@@ -58,6 +58,27 @@ class RiskLimits(BaseModel):
         return cls(**filtered)
 
 
+# Per-field tighten-direction map for the refinement carve-out (#543).
+# "lower"  → proposed value must be ``<= current`` to count as tightening.
+# "higher" → proposed value must be ``>= current`` to count as tightening.
+# None     → field is immutable from refinement; any change is discarded
+#            with a warning but does NOT raise ``SpecImplementabilityError``
+#            (cosmetic knobs only).
+#
+# ``target_annual_vol`` is "lower" because lowering the vol target shrinks
+# per-position size. ``None → value`` transitions fundamentally change the
+# sizing model and are treated as loosening (raises rather than mutates).
+_RISK_LIMIT_TIGHTEN_DIRECTION: Dict[str, Optional[str]] = {
+    "max_gross_leverage": "lower",
+    "max_position_pct": "lower",
+    "max_symbol_concentration_pct": "lower",
+    "max_drawdown_pct": "lower",
+    "max_open_positions": "lower",
+    "target_annual_vol": "lower",
+    "vol_lookback_days": None,
+}
+
+
 @dataclass
 class SizingDecision:
     shares: float

--- a/backend/agents/investment_team/strategy_lab/agents/refinement.py
+++ b/backend/agents/investment_team/strategy_lab/agents/refinement.py
@@ -18,6 +18,14 @@ logger = logging.getLogger(__name__)
 
 _PROMPT_DIR = Path(__file__).resolve().parent.parent / "prompts"
 
+# Refinement output is code-only (#543). ``strategy_code`` is consumed
+# separately; ``changes_made`` is logged. Any other top-level key in the
+# LLM payload is dropped with a warning. ``risk_limits`` is passed through
+# to the orchestrator, which applies tighten-only semantics (see
+# ``orchestrator._merge_risk_limits_tighten_only``).
+_ALLOWED_OUTPUT_KEYS = frozenset({"changes_made"})
+_PASSTHROUGH_FOR_ORCHESTRATOR = frozenset({"risk_limits"})
+
 _REFINEMENT_USER_TEMPLATE = """\
 Fix the following trading strategy code that failed {failure_phase}.
 
@@ -60,6 +68,13 @@ Return ONLY a JSON object with no markdown:
 class RefinementAgent:
     """Refine strategy code based on quality gate or execution failures."""
 
+    def __init__(self) -> None:
+        # Audit trail of every refinement round where the LLM emitted
+        # spec-mutating keys. Used by tests and surfaceable in logs to
+        # diagnose prompt drift. Each entry: {"failure_phase": str,
+        # "keys": list[str]}.
+        self.spec_mutation_history: List[Dict[str, Any]] = []
+
     def run(
         self,
         spec: StrategySpec,
@@ -73,6 +88,11 @@ class RefinementAgent:
 
         Returns:
             (updated_fields_dict, updated_code)
+
+        ``updated_fields_dict`` is narrowed to ``{"changes_made"}`` plus an
+        optional ``"risk_limits"`` passthrough (the orchestrator applies
+        tighten-only semantics). Any other top-level keys in the LLM
+        response are logged and discarded.
         """
         system_prompt = (_PROMPT_DIR / "refinement_system.md").read_text(encoding="utf-8")
 
@@ -119,7 +139,25 @@ class RefinementAgent:
         parsed = _extract_json(str(result))
 
         updated_code = parsed.pop("strategy_code", code)
-        return parsed, updated_code
+
+        stray = set(parsed) - _ALLOWED_OUTPUT_KEYS - _PASSTHROUGH_FOR_ORCHESTRATOR
+        if stray:
+            logger.warning(
+                "RefinementAgent emitted spec-mutating keys %s for failure_phase=%s; "
+                "discarding (refinement is code-only post-#543).",
+                sorted(stray),
+                failure_phase,
+            )
+            self.spec_mutation_history.append(
+                {"failure_phase": failure_phase, "keys": sorted(stray)}
+            )
+
+        narrowed: Dict[str, Any] = {
+            k: parsed[k]
+            for k in (_ALLOWED_OUTPUT_KEYS | _PASSTHROUGH_FOR_ORCHESTRATOR)
+            if k in parsed
+        }
+        return narrowed, updated_code
 
 
 def _extract_json(text: str) -> Dict[str, Any]:

--- a/backend/agents/investment_team/strategy_lab/exceptions.py
+++ b/backend/agents/investment_team/strategy_lab/exceptions.py
@@ -1,0 +1,38 @@
+"""Strategy Lab exceptions.
+
+Kept in a standalone module so the orchestrator and the refinement agent
+can both raise/catch ``SpecImplementabilityError`` without pulling each
+other in via a circular import.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+class SpecImplementabilityError(Exception):
+    """Raised when the refinement loop cannot make the spec implementable.
+
+    The orchestrator catches this and re-enters ideation with ``evidence``
+    appended to the convergence directives, bounded by
+    ``MAX_DESIGN_REENTRIES``.  ``failure_phase`` (when set) identifies the
+    refinement sub-phase that triggered the trip — one of ``"validation"``,
+    ``"execution"``, or ``"evaluation"``.
+
+    ``last_spec`` / ``last_code`` carry the just-pre-mutation spec and
+    code so the outer loop can build a useful short-circuit record on
+    re-entry exhaustion without re-running ideation.
+    """
+
+    def __init__(
+        self,
+        evidence: str,
+        failure_phase: Optional[str] = None,
+        last_spec: Any = None,
+        last_code: Optional[str] = None,
+    ) -> None:
+        super().__init__(evidence)
+        self.evidence = evidence
+        self.failure_phase = failure_phase
+        self.last_spec = last_spec
+        self.last_code = last_code

--- a/backend/agents/investment_team/strategy_lab/exceptions.py
+++ b/backend/agents/investment_team/strategy_lab/exceptions.py
@@ -7,7 +7,10 @@ other in via a circular import.
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from ..models import StrategySpec
 
 
 class SpecImplementabilityError(Exception):
@@ -21,15 +24,18 @@ class SpecImplementabilityError(Exception):
 
     ``last_spec`` / ``last_code`` carry the just-pre-mutation spec and
     code so the outer loop can build a useful short-circuit record on
-    re-entry exhaustion without re-running ideation.
+    re-entry exhaustion without re-running ideation. Raisers MUST set
+    both — ``run_cycle`` relies on them when building the
+    ``failed: spec_unimplementable`` record.
     """
 
     def __init__(
         self,
         evidence: str,
-        failure_phase: Optional[str] = None,
-        last_spec: Any = None,
-        last_code: Optional[str] = None,
+        *,
+        failure_phase: Optional[str],
+        last_spec: "StrategySpec",
+        last_code: str,
     ) -> None:
         super().__init__(evidence)
         self.evidence = evidence

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -30,6 +30,7 @@ from ..execution.metrics import (
     summarize_return_moments,
 )
 from ..execution.regimes import regime_comparison, vix_quartile_subwindows
+from ..execution.risk_filter import _RISK_LIMIT_TIGHTEN_DIRECTION, RiskLimits
 from ..execution.walk_forward import (
     build_purged_walk_forward,
     filter_trades_in_fold_training,
@@ -57,6 +58,7 @@ from .agents.ideation import IdeationAgent
 from .agents.refinement import RefinementAgent
 from .agents.zero_trade_repair import ZeroTradeRepairAgent, ZeroTradeRepairReport
 from .coverage_probe import format_coverage_report, run_coverage_stage, should_run_probes
+from .exceptions import SpecImplementabilityError
 from .quality_gates.acceptance_gate import AcceptanceGate, summarize_acceptance_reason
 from .quality_gates.backtest_anomaly import BacktestAnomalyDetector
 from .quality_gates.code_safety import CodeSafetyChecker
@@ -84,6 +86,22 @@ class _MarketDataFetch:
     requested_symbols: List[str]
     fetched_symbols: List[str]
 
+
+# Refinement output is code-only post-#543. Anything else the LLM emits is
+# logged + discarded by ``_apply_updates``; ``risk_limits`` is the lone
+# exception, handled with tighten-only semantics.
+_REFINEMENT_ALLOWED_KEYS = frozenset({"changes_made"})
+_REFINEMENT_PASSTHROUGH_KEYS = frozenset({"risk_limits"})
+
+# Threshold (per ``failure_phase``) at which repeated spec-mutation attempts
+# from the refinement agent trip ``SpecImplementabilityError`` and route the
+# cycle back to ideation.
+_SPEC_MUTATION_TRIP_THRESHOLD = 3
+
+# Outer-loop cap on how many times ``run_cycle`` re-enters ideation after a
+# ``SpecImplementabilityError``. ``MAX_DESIGN_REENTRIES = 2`` permits the
+# original ideation + 2 re-attempts before short-circuiting.
+MAX_DESIGN_REENTRIES = 2
 
 MAX_CODE_REFINEMENT_ROUNDS = 50
 # Maximum number of trade-alignment problem-solving rounds. Each round
@@ -216,6 +234,11 @@ class StrategyLabOrchestrator:
         self.acceptance_gate = AcceptanceGate()
         self.convergence_tracker = convergence_tracker or ConvergenceTracker()
         self.market_data_service = MarketDataService()
+        # Per-failure_phase counter of consecutive refinement rounds where
+        # the LLM emitted stray spec-mutating keys. Reset at the start of
+        # each ``_run_design_attempt`` and tripped when any phase hits
+        # ``_SPEC_MUTATION_TRIP_THRESHOLD``.
+        self._consecutive_spec_mutation_rounds: Dict[str, int] = {}
 
     def run_cycle(
         self,
@@ -227,11 +250,18 @@ class StrategyLabOrchestrator:
     ) -> StrategyLabRecord:
         """Run one full strategy lab cycle: ideate → code → backtest → analyze.
 
+        Wraps ``_run_design_attempt`` in an outer retry loop bounded by
+        ``MAX_DESIGN_REENTRIES`` (#543): when refinement detects the spec
+        is unimplementable (`SpecImplementabilityError`), the cycle
+        re-enters ideation with the failure evidence appended as a
+        convergence directive. On exhaustion, persists a short-circuit
+        record with ``status='failed: spec_unimplementable'``.
+
         Returns a StrategyLabRecord with the final result.
         """
         emit = on_phase or (lambda phase, data: None)
 
-        # Gather convergence directives
+        # Gather convergence directives once — appended to on loopback.
         directives: List[str] = []
         stall_dir = self.convergence_tracker.get_stall_directive()
         if stall_dir:
@@ -240,6 +270,75 @@ class StrategyLabOrchestrator:
         if diversity_dir:
             directives.append(diversity_dir)
         directives.extend(self.convergence_tracker.get_failure_directives())
+
+        last_evidence: Optional[str] = None
+        last_spec: Optional[StrategySpec] = None
+        last_code: str = ""
+        last_failure_phase: Optional[str] = None
+        for design_attempt in range(MAX_DESIGN_REENTRIES + 1):
+            try:
+                return self._run_design_attempt(
+                    prior_records=prior_records,
+                    config=config,
+                    signal_brief=signal_brief,
+                    emit=emit,
+                    exclude_asset_classes=exclude_asset_classes,
+                    directives=directives,
+                )
+            except SpecImplementabilityError as exc:
+                last_evidence = exc.evidence
+                last_spec = exc.last_spec
+                last_code = exc.last_code or ""
+                last_failure_phase = exc.failure_phase
+                if design_attempt >= MAX_DESIGN_REENTRIES:
+                    break
+                emit(
+                    "ideating",
+                    {
+                        "sub_phase": "loopback",
+                        "design_attempt": design_attempt + 1,
+                        "evidence": exc.evidence,
+                        "failure_phase": exc.failure_phase,
+                    },
+                )
+                directives.append(f"PREVIOUS SPEC UNIMPLEMENTABLE: {exc.evidence}")
+
+        # Re-entry budget exhausted — persist a failure record. ``last_spec``
+        # is the spec the most recent refinement attempt was operating on
+        # just before the trip; safe to reuse as the short-circuit spec.
+        assert last_spec is not None and last_evidence is not None
+        return self._build_short_circuit_record(
+            spec=last_spec,
+            config=config,
+            code=last_code,
+            original_spec=last_spec,
+            original_code=last_code,
+            rationale="",
+            all_gate_results=[],
+            refinement_attempts=[],
+            short_circuit_status="failed: spec_unimplementable",
+            short_circuit_reason=(
+                f"Spec unimplementable after {MAX_DESIGN_REENTRIES + 1} design attempts "
+                f"(last failure_phase={last_failure_phase}): {last_evidence}"
+            ),
+            emit=emit,
+        )
+
+    def _run_design_attempt(
+        self,
+        *,
+        prior_records: List[StrategyLabRecord],
+        config: BacktestConfig,
+        signal_brief: Optional[SignalIntelligenceBriefV1],
+        emit: PhaseCallback,
+        exclude_asset_classes: Optional[List[str]],
+        directives: List[str],
+    ) -> StrategyLabRecord:
+        """One design+refinement attempt (#543). May raise
+        ``SpecImplementabilityError`` to signal a need to re-enter
+        ideation; the outer ``run_cycle`` catches and re-routes."""
+        # Reset per-attempt counters so a re-entry starts fresh.
+        self._consecutive_spec_mutation_rounds = {}
 
         # ── Phase 1: IDEATION ──────────────────────────────────────────
         emit("ideating", {"sub_phase": "started"})
@@ -416,7 +515,7 @@ class StrategyLabOrchestrator:
                     updates, code = self._refine(
                         spec, code, "validation", failure_details, None, refinement_attempts
                     )
-                    spec = self._apply_updates(spec, updates, code)
+                    spec = self._apply_updates(spec, updates, code, failure_phase="validation")
                     changes = updates.get("changes_made", "validation fix")
                     refinement_attempts.append(changes)
                     emit(
@@ -506,7 +605,7 @@ class StrategyLabOrchestrator:
                     updates, code = self._refine(
                         spec, code, "execution", failure_details, None, refinement_attempts
                     )
-                    spec = self._apply_updates(spec, updates, code)
+                    spec = self._apply_updates(spec, updates, code, failure_phase="execution")
                     changes = updates.get("changes_made", "execution fix")
                     refinement_attempts.append(changes)
                     emit(
@@ -655,7 +754,7 @@ class StrategyLabOrchestrator:
                         metrics,
                         refinement_attempts,
                     )
-                    spec = self._apply_updates(spec, updates, code)
+                    spec = self._apply_updates(spec, updates, code, failure_phase="evaluation")
                     changes = updates.get("changes_made", "anomaly fix")
                     refinement_attempts.append(changes)
                     emit(
@@ -1498,16 +1597,163 @@ class StrategyLabOrchestrator:
         return StrategySpec.model_validate(data)
 
     @staticmethod
-    def _apply_updates(spec: StrategySpec, updates: Dict[str, Any], code: str) -> StrategySpec:
-        """Apply refinement updates: code only.
+    def _merge_risk_limits_tighten_only(
+        current: RiskLimits, proposed: Any
+    ) -> Tuple[RiskLimits, List[str], List[str]]:
+        """Tighten-only merge of refinement-proposed risk limits (#543).
 
-        The spec (entry/exit/sizing rules, risk limits, hypothesis) is
-        immutable post-ideation (#547 item 2). ``updates`` is kept in the
-        signature because callers still read ``updates['changes_made']``
-        for logging, but no spec fields are merged here.
+        Returns ``(merged_limits, loosened_fields, discarded_unknown_keys)``.
+
+        - ``loosened_fields`` lists fields whose proposed value would loosen
+          the limit (raise an "lower"-direction cap, lower a "higher"-direction
+          floor, or transition ``target_annual_vol`` from ``None`` to a
+          value — which fundamentally changes the sizing model and is
+          treated as loosening).
+        - ``discarded_unknown_keys`` lists fields the caller proposed that
+          either aren't in the ``RiskLimits`` schema or are marked
+          immutable in ``_RISK_LIMIT_TIGHTEN_DIRECTION`` (e.g.
+          ``vol_lookback_days``).
+
+        Callers raise ``SpecImplementabilityError`` when ``loosened_fields``
+        is non-empty; unknown keys are warned but never trip.
+        """
+        loosened: List[str] = []
+        unknown: List[str] = []
+        if not isinstance(proposed, dict):
+            return current, loosened, unknown
+
+        merged_data = current.model_dump()
+        for key, new_value in proposed.items():
+            direction = _RISK_LIMIT_TIGHTEN_DIRECTION.get(key)
+            if direction is None:
+                # Either unknown to RiskLimits or explicitly immutable.
+                unknown.append(key)
+                continue
+
+            current_value = merged_data.get(key)
+
+            # Special-case ``target_annual_vol``: ``None`` means "no vol
+            # target" (flat sizing). Switching to a value or vice-versa
+            # changes the sizing model — treat any None↔value transition
+            # as loosening.
+            if key == "target_annual_vol":
+                if current_value is None and new_value is not None:
+                    loosened.append(key)
+                    continue
+                if current_value is not None and new_value is None:
+                    loosened.append(key)
+                    continue
+
+            try:
+                cmp_current = float(current_value) if current_value is not None else None
+                cmp_new = float(new_value) if new_value is not None else None
+            except (TypeError, ValueError):
+                unknown.append(key)
+                continue
+
+            if cmp_current is None or cmp_new is None:
+                # Already handled above; defensive.
+                continue
+
+            if direction == "lower":
+                if cmp_new < cmp_current:
+                    merged_data[key] = new_value
+                elif cmp_new > cmp_current:
+                    loosened.append(key)
+                # equal: no-op
+            elif direction == "higher":
+                if cmp_new > cmp_current:
+                    merged_data[key] = new_value
+                elif cmp_new < cmp_current:
+                    loosened.append(key)
+                # equal: no-op
+
+        try:
+            merged = RiskLimits.model_validate(merged_data)
+        except Exception:
+            # Validation failed on the merged limits — bail out without
+            # mutating; treat as unknown so caller logs + skips.
+            logger.warning(
+                "Refined risk_limits failed pydantic validation; keeping current limits unchanged."
+            )
+            return current, loosened, list({*unknown, *proposed.keys()} - {"_validation"})
+
+        return merged, loosened, unknown
+
+    def _apply_updates(
+        self,
+        spec: StrategySpec,
+        updates: Dict[str, Any],
+        code: str,
+        failure_phase: Optional[str] = None,
+    ) -> StrategySpec:
+        """Apply refinement updates: code-only, with risk-limits tighten-only carve-out (#543).
+
+        The spec (entry/exit/sizing rules, hypothesis) is immutable
+        post-ideation; ``risk_limits`` may only be tightened. Stray
+        spec-mutating keys are logged and discarded. Repeated stray
+        emissions on the same ``failure_phase`` (≥ ``_SPEC_MUTATION_TRIP_THRESHOLD``
+        in a row) raise ``SpecImplementabilityError`` so the orchestrator
+        can re-route to ideation. Any attempted ``risk_limits`` loosening
+        also raises immediately.
         """
         data = spec.model_dump()
         data["strategy_code"] = code
+
+        stray = set(updates) - _REFINEMENT_ALLOWED_KEYS - _REFINEMENT_PASSTHROUGH_KEYS
+        risk_limits_proposed = updates.get("risk_limits")
+
+        if risk_limits_proposed is not None:
+            merged_limits, loosened, unknown = self._merge_risk_limits_tighten_only(
+                spec.risk_limits, risk_limits_proposed
+            )
+            if loosened:
+                raise SpecImplementabilityError(
+                    evidence=(f"refinement tried to loosen risk_limits fields: {sorted(loosened)}"),
+                    failure_phase=failure_phase,
+                    last_spec=spec,
+                    last_code=code,
+                )
+            if unknown:
+                logger.warning(
+                    "Refinement proposed unknown/immutable risk_limits keys %s; "
+                    "discarding for failure_phase=%s",
+                    sorted(unknown),
+                    failure_phase,
+                )
+            data["risk_limits"] = merged_limits.model_dump()
+
+        if stray:
+            logger.warning(
+                "Refinement discarded spec-mutating keys %s for failure_phase=%s "
+                "(refinement is code-only post-#543).",
+                sorted(stray),
+                failure_phase,
+            )
+            if failure_phase is not None:
+                counter = self._consecutive_spec_mutation_rounds
+                counter[failure_phase] = counter.get(failure_phase, 0) + 1
+                # Reset all other phases — threshold is consecutive within
+                # a single failure_phase, not interleaved.
+                for other in list(counter):
+                    if other != failure_phase:
+                        counter[other] = 0
+                if counter[failure_phase] >= _SPEC_MUTATION_TRIP_THRESHOLD:
+                    raise SpecImplementabilityError(
+                        evidence=(
+                            f"refinement repeatedly attempted spec mutations on "
+                            f"failure_phase={failure_phase}: keys={sorted(stray)} "
+                            f"(round {counter[failure_phase]} of consecutive mutation attempts)"
+                        ),
+                        failure_phase=failure_phase,
+                        last_spec=spec,
+                        last_code=code,
+                    )
+        elif failure_phase is not None:
+            # Clean refinement round on this phase — reset its counter
+            # so future stray emissions start fresh.
+            self._consecutive_spec_mutation_rounds[failure_phase] = 0
+
         return StrategySpec.model_validate(data)
 
     def _build_short_circuit_record(

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -90,6 +90,12 @@ class _MarketDataFetch:
 # Refinement output is code-only post-#543. Anything else the LLM emits is
 # logged + discarded by ``_apply_updates``; ``risk_limits`` is the lone
 # exception, handled with tighten-only semantics.
+#
+# NOTE: ``RefinementAgent`` enforces the same contract on its side via
+# ``_ALLOWED_OUTPUT_KEYS`` / ``_PASSTHROUGH_FOR_ORCHESTRATOR`` in
+# ``agents/refinement.py``. The duplication is intentional — agent-side
+# narrowing is a first line of defense; orchestrator-side narrowing is
+# authoritative. Keep the two passthrough sets in sync.
 _REFINEMENT_ALLOWED_KEYS = frozenset({"changes_made"})
 _REFINEMENT_PASSTHROUGH_KEYS = frozenset({"risk_limits"})
 
@@ -288,7 +294,7 @@ class StrategyLabOrchestrator:
             except SpecImplementabilityError as exc:
                 last_evidence = exc.evidence
                 last_spec = exc.last_spec
-                last_code = exc.last_code or ""
+                last_code = exc.last_code
                 last_failure_phase = exc.failure_phase
                 if design_attempt >= MAX_DESIGN_REENTRIES:
                     break
@@ -303,10 +309,19 @@ class StrategyLabOrchestrator:
                 )
                 directives.append(f"PREVIOUS SPEC UNIMPLEMENTABLE: {exc.evidence}")
 
-        # Re-entry budget exhausted — persist a failure record. ``last_spec``
-        # is the spec the most recent refinement attempt was operating on
-        # just before the trip; safe to reuse as the short-circuit spec.
-        assert last_spec is not None and last_evidence is not None
+        # Re-entry budget exhausted. The exception's ``last_spec`` /
+        # ``last_code`` carry the just-pre-mutation state from the most
+        # recent ``_apply_updates`` raise. They are required on the
+        # exception type, but guard defensively in case a future raiser
+        # somehow violates the contract — surface a clear runtime error
+        # rather than crashing in ``_build_short_circuit_record`` with a
+        # misleading traceback.
+        if last_spec is None or last_evidence is None:
+            raise RuntimeError(
+                "SpecImplementabilityError raised without last_spec/evidence; "
+                "cannot build short-circuit record. This is a bug in a refinement "
+                "code path; please file an issue with the run logs."
+            )
         return self._build_short_circuit_record(
             spec=last_spec,
             config=config,
@@ -1672,11 +1687,12 @@ class StrategyLabOrchestrator:
             merged = RiskLimits.model_validate(merged_data)
         except Exception:
             # Validation failed on the merged limits — bail out without
-            # mutating; treat as unknown so caller logs + skips.
+            # mutating; surface every proposed key as unknown so the caller
+            # logs the full set and keeps the original limits.
             logger.warning(
                 "Refined risk_limits failed pydantic validation; keeping current limits unchanged."
             )
-            return current, loosened, list({*unknown, *proposed.keys()} - {"_validation"})
+            return current, loosened, sorted(set(unknown) | set(proposed.keys()))
 
         return merged, loosened, unknown
 
@@ -1701,6 +1717,9 @@ class StrategyLabOrchestrator:
         data["strategy_code"] = code
 
         stray = set(updates) - _REFINEMENT_ALLOWED_KEYS - _REFINEMENT_PASSTHROUGH_KEYS
+        # ``risk_limits: null`` is treated as "no change requested" — skip the
+        # tighten-only merge entirely. Because the key is in
+        # ``_REFINEMENT_PASSTHROUGH_KEYS`` it is also not counted as stray.
         risk_limits_proposed = updates.get("risk_limits")
 
         if risk_limits_proposed is not None:

--- a/backend/agents/investment_team/tests/test_strategy_lab_refinement_contract.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_refinement_contract.py
@@ -1,14 +1,23 @@
-"""Refinement contract narrowing (#547 item 2).
+"""Refinement contract narrowing (#547 item 2, extended in #543).
 
 After #547, the refinement agent's output is code-only. Even if a
 stubbed agent returns spec-mutating keys (legacy schema or
 hallucinated fields), ``StrategyLabOrchestrator._apply_updates`` must
 not merge them into the spec — only ``strategy_code`` is updated.
+
+#543 strengthens the contract: stray spec-mutating keys now log a
+warning, ``risk_limits`` is the lone exception with tighten-only
+semantics, and ``_apply_updates`` is an instance method.
 """
 
 from __future__ import annotations
 
+import logging
+
+import pytest
+
 from investment_team.models import StrategySpec
+from investment_team.strategy_lab.exceptions import SpecImplementabilityError
 from investment_team.strategy_lab.orchestrator import StrategyLabOrchestrator
 from investment_team.strategy_lab.spec_dsl import (
     ConstRef,
@@ -40,19 +49,20 @@ def _spec() -> StrategySpec:
     )
 
 
-def test_apply_updates_swaps_code_only() -> None:
+def test_apply_updates_swaps_code_only(caplog: pytest.LogCaptureFixture) -> None:
     """Spec fields stay untouched even when the refinement dict requests changes."""
     original = _spec()
     legacy_updates = {
         "entry_rules": ["should be ignored — refinement cannot mutate spec"],
         "exit_rules": ["should be ignored"],
         "sizing_rules": ["should be ignored"],
-        "risk_limits": {"max_position_pct": 99},
         "hypothesis": "rewritten hypothesis",
         "changes_made": "tightened RSI guard",
     }
 
-    result = StrategyLabOrchestrator._apply_updates(original, legacy_updates, "# refined code")
+    orch = StrategyLabOrchestrator()
+    with caplog.at_level(logging.WARNING, logger="investment_team.strategy_lab.orchestrator"):
+        result = orch._apply_updates(original, legacy_updates, "# refined code")
 
     assert result.entry_rules == original.entry_rules
     assert result.exit_rules == original.exit_rules
@@ -60,11 +70,30 @@ def test_apply_updates_swaps_code_only() -> None:
     assert result.hypothesis == original.hypothesis
     assert result.risk_limits == original.risk_limits
     assert result.strategy_code == "# refined code"
+    assert any("Refinement discarded spec-mutating keys" in rec.message for rec in caplog.records)
 
 
 def test_apply_updates_with_empty_dict_only_swaps_code() -> None:
     """Empty ``updates`` (the zero-trade-repair path) still swaps code."""
     original = _spec()
-    result = StrategyLabOrchestrator._apply_updates(original, {}, "# repaired code")
+    orch = StrategyLabOrchestrator()
+    result = orch._apply_updates(original, {}, "# repaired code")
     assert result.strategy_code == "# repaired code"
     assert result.entry_rules == original.entry_rules
+
+
+def test_apply_updates_raises_on_risk_limits_loosening() -> None:
+    """A loosening risk_limits proposal trips ``SpecImplementabilityError``."""
+    original = _spec()
+    orch = StrategyLabOrchestrator()
+    with pytest.raises(SpecImplementabilityError) as exc_info:
+        orch._apply_updates(
+            original,
+            {"risk_limits": {"max_position_pct": 99}, "changes_made": "loosen sizing"},
+            "# refined code",
+            failure_phase="execution",
+        )
+    assert "loosen" in exc_info.value.evidence
+    assert exc_info.value.failure_phase == "execution"
+    assert exc_info.value.last_spec is original
+    assert exc_info.value.last_code == "# refined code"

--- a/backend/agents/investment_team/tests/test_strategy_lab_refinement_freeze.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_refinement_freeze.py
@@ -1,0 +1,412 @@
+"""Refinement spec-freeze regression suite (#543).
+
+These tests lock in the post-#543 contract:
+- ``RefinementAgent.run`` filters spec-mutating keys out of its output
+  and records them on ``spec_mutation_history`` (with a logger warning).
+- The orchestrator's ``_merge_risk_limits_tighten_only`` accepts
+  tightening, rejects loosening, and discards unknown / immutable keys.
+- ``_apply_updates`` raises ``SpecImplementabilityError`` on a
+  risk-limits loosening attempt or after ``_SPEC_MUTATION_TRIP_THRESHOLD``
+  consecutive stray-key rounds for the same ``failure_phase``.
+- ``run_cycle`` re-enters ideation on ``SpecImplementabilityError`` and
+  short-circuits with ``status='failed: spec_unimplementable'`` after
+  exhausting ``MAX_DESIGN_REENTRIES``.
+- The refinement loop preserves the original spec (``entry_rules``,
+  ``hypothesis``, etc.) even when the LLM stub emits spec-mutating
+  keys round after round.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from investment_team.execution.risk_filter import RiskLimits
+from investment_team.market_data_service import OHLCVBar
+from investment_team.models import (
+    BacktestConfig,
+    BacktestResult,
+    StrategySpec,
+)
+from investment_team.strategy_lab import orchestrator as orchestrator_module
+from investment_team.strategy_lab.agents.refinement import RefinementAgent
+from investment_team.strategy_lab.exceptions import SpecImplementabilityError
+from investment_team.strategy_lab.orchestrator import (
+    MAX_DESIGN_REENTRIES,
+    StrategyLabOrchestrator,
+)
+from investment_team.strategy_lab.spec_dsl import (
+    ConstRef,
+    EntryRule,
+    Predicate,
+    RSIRef,
+    SignalExitRule,
+)
+from investment_team.trading_service.modes.sandbox_compat import StrategyRunResult
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _config() -> BacktestConfig:
+    return BacktestConfig(
+        start_date="2023-01-01",
+        end_date="2023-12-31",
+        initial_capital=100_000.0,
+        benchmark_symbol="SPY",
+        transaction_cost_bps=5.0,
+        slippage_bps=2.0,
+        walk_forward_enabled=False,
+    )
+
+
+def _spec(strategy_id: str = "strat-freeze-test") -> StrategySpec:
+    return StrategySpec(
+        strategy_id=strategy_id,
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="RSI mean reversion baseline",
+        signal_definition="sig",
+        entry_rules=[
+            EntryRule(
+                side="long",
+                when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30)),
+            )
+        ],
+        exit_rules=[
+            SignalExitRule(when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)))
+        ],
+        risk_limits={"max_position_pct": 5, "max_drawdown_pct": 10},
+        speculative=False,
+        strategy_code="# original code",
+    )
+
+
+# ---------------------------------------------------------------------------
+# RefinementAgent output filtering
+# ---------------------------------------------------------------------------
+
+
+class _FakeStrandsAgentReturning:
+    """Callable stub that mimics the strands ``Agent`` instance the
+    refinement code instantiates inline. Always returns the same payload."""
+
+    def __init__(self, payload: str) -> None:
+        self._payload = payload
+
+    def __call__(self, prompt: str) -> str:
+        return self._payload
+
+
+def test_refinement_agent_filters_and_warns_on_spec_keys(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """LLM payloads carrying spec-mutating keys are narrowed before return."""
+    payload = (
+        "{"
+        '"strategy_code": "# refined",'
+        '"changes_made": "tightened RSI threshold",'
+        '"entry_rules": ["bogus"],'
+        '"hypothesis": "rewritten",'
+        '"sizing_rules": ["bogus"]'
+        "}"
+    )
+    fake_agent = _FakeStrandsAgentReturning(payload)
+
+    monkeypatch.setattr(
+        "investment_team.strategy_lab.agents.refinement.Agent",
+        lambda **kwargs: fake_agent,
+    )
+    monkeypatch.setattr(
+        "investment_team.strategy_lab.agents.refinement.get_strands_model",
+        lambda role: object(),
+    )
+
+    agent = RefinementAgent()
+    with caplog.at_level(logging.WARNING, logger="investment_team.strategy_lab.agents.refinement"):
+        updates, new_code = agent.run(
+            spec=_spec(),
+            code="# original code",
+            failure_phase="execution",
+            failure_details="boom",
+        )
+
+    assert new_code == "# refined"
+    assert set(updates) == {"changes_made"}
+    assert updates["changes_made"] == "tightened RSI threshold"
+    assert agent.spec_mutation_history == [
+        {
+            "failure_phase": "execution",
+            "keys": ["entry_rules", "hypothesis", "sizing_rules"],
+        }
+    ]
+    assert any("spec-mutating keys" in rec.message for rec in caplog.records)
+
+
+def test_refinement_agent_passes_risk_limits_through(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``risk_limits`` is the lone passthrough so the orchestrator can apply
+    its tighten-only carve-out."""
+    payload = (
+        "{"
+        '"strategy_code": "# refined",'
+        '"changes_made": "tighter sizing",'
+        '"risk_limits": {"max_position_pct": 3}'
+        "}"
+    )
+    monkeypatch.setattr(
+        "investment_team.strategy_lab.agents.refinement.Agent",
+        lambda **kwargs: _FakeStrandsAgentReturning(payload),
+    )
+    monkeypatch.setattr(
+        "investment_team.strategy_lab.agents.refinement.get_strands_model",
+        lambda role: object(),
+    )
+
+    agent = RefinementAgent()
+    updates, new_code = agent.run(
+        spec=_spec(),
+        code="# original",
+        failure_phase="execution",
+        failure_details="boom",
+    )
+
+    assert new_code == "# refined"
+    assert set(updates) == {"changes_made", "risk_limits"}
+    assert updates["risk_limits"] == {"max_position_pct": 3}
+    # No stray keys → no history entry, no warning.
+    assert agent.spec_mutation_history == []
+
+
+# ---------------------------------------------------------------------------
+# Risk-limits tighten-only merge
+# ---------------------------------------------------------------------------
+
+
+def test_merge_risk_limits_tightening_accepted() -> None:
+    current = RiskLimits()  # default max_position_pct = 6.0
+    merged, loosened, unknown = StrategyLabOrchestrator._merge_risk_limits_tighten_only(
+        current, {"max_position_pct": 3.0}
+    )
+    assert loosened == []
+    assert unknown == []
+    assert merged.max_position_pct == 3.0
+
+
+def test_merge_risk_limits_loosening_rejected() -> None:
+    current = RiskLimits()
+    _, loosened, unknown = StrategyLabOrchestrator._merge_risk_limits_tighten_only(
+        current, {"max_position_pct": 99.0}
+    )
+    assert loosened == ["max_position_pct"]
+    assert unknown == []
+
+
+def test_merge_risk_limits_unknown_key_discarded() -> None:
+    current = RiskLimits()
+    merged, loosened, unknown = StrategyLabOrchestrator._merge_risk_limits_tighten_only(
+        current, {"made_up_field": 0.1}
+    )
+    assert loosened == []
+    assert unknown == ["made_up_field"]
+    assert merged == current
+
+
+def test_merge_risk_limits_immutable_key_discarded() -> None:
+    """``vol_lookback_days`` is mapped to ``None`` direction → discard, not trip."""
+    current = RiskLimits()
+    _, loosened, unknown = StrategyLabOrchestrator._merge_risk_limits_tighten_only(
+        current, {"vol_lookback_days": 50}
+    )
+    assert loosened == []
+    assert unknown == ["vol_lookback_days"]
+
+
+def test_merge_risk_limits_target_vol_none_to_value_is_loosening() -> None:
+    """Going from None (flat sizing) to a vol target changes sizing model."""
+    current = RiskLimits()
+    assert current.target_annual_vol is None
+    _, loosened, _ = StrategyLabOrchestrator._merge_risk_limits_tighten_only(
+        current, {"target_annual_vol": 0.10}
+    )
+    assert loosened == ["target_annual_vol"]
+
+
+# ---------------------------------------------------------------------------
+# _apply_updates trip-threshold
+# ---------------------------------------------------------------------------
+
+
+def test_apply_updates_trips_after_threshold_consecutive_stray_keys() -> None:
+    orch = StrategyLabOrchestrator()
+    spec = _spec()
+    stray = {"entry_rules": ["bogus"], "changes_made": "noop"}
+    # Two rounds: stray emitted, no raise.
+    orch._apply_updates(spec, stray, "# c1", failure_phase="execution")
+    orch._apply_updates(spec, stray, "# c2", failure_phase="execution")
+    # Third consecutive round trips.
+    with pytest.raises(SpecImplementabilityError) as exc_info:
+        orch._apply_updates(spec, stray, "# c3", failure_phase="execution")
+    assert exc_info.value.failure_phase == "execution"
+    assert exc_info.value.last_spec is spec
+    assert exc_info.value.last_code == "# c3"
+
+
+def test_apply_updates_resets_counter_on_clean_round() -> None:
+    """A clean refinement round resets the per-phase counter."""
+    orch = StrategyLabOrchestrator()
+    spec = _spec()
+    stray = {"entry_rules": ["bogus"]}
+    orch._apply_updates(spec, stray, "# c1", failure_phase="execution")
+    orch._apply_updates(spec, stray, "# c2", failure_phase="execution")
+    # Clean round resets.
+    orch._apply_updates(spec, {"changes_made": "ok"}, "# c3", failure_phase="execution")
+    # Now two more stray rounds should NOT trip (counter reset).
+    orch._apply_updates(spec, stray, "# c4", failure_phase="execution")
+    orch._apply_updates(spec, stray, "# c5", failure_phase="execution")
+    # Third consecutive trips.
+    with pytest.raises(SpecImplementabilityError):
+        orch._apply_updates(spec, stray, "# c6", failure_phase="execution")
+
+
+def test_apply_updates_interleaved_phases_do_not_trip() -> None:
+    """Threshold is per-phase consecutive; interleaving phases resets counters."""
+    orch = StrategyLabOrchestrator()
+    spec = _spec()
+    stray = {"entry_rules": ["bogus"]}
+    orch._apply_updates(spec, stray, "# c1", failure_phase="execution")
+    orch._apply_updates(spec, stray, "# c2", failure_phase="validation")
+    orch._apply_updates(spec, stray, "# c3", failure_phase="execution")
+    # No phase has 3 consecutive yet — no raise.
+
+
+# ---------------------------------------------------------------------------
+# run_cycle re-entry loop
+# ---------------------------------------------------------------------------
+
+
+class _FakeIdeationAgent:
+    """Returns a fixed ideation tuple every call."""
+
+    def __init__(self, spec: StrategySpec) -> None:
+        self._spec = spec
+        self.call_count = 0
+
+    def run(
+        self,
+        *,
+        prior_records: List[Any],
+        signal_brief: Any = None,
+        convergence_directives: Optional[List[str]] = None,
+        exclude_asset_classes: Optional[List[str]] = None,
+    ) -> Tuple[Dict[str, Any], str, str]:
+        self.call_count += 1
+        strategy_dict = {
+            "asset_class": self._spec.asset_class,
+            "hypothesis": self._spec.hypothesis,
+            "signal_definition": self._spec.signal_definition,
+            "entry_rules": [r.model_dump() for r in self._spec.entry_rules],
+            "exit_rules": [r.model_dump() for r in self._spec.exit_rules],
+            "sizing": self._spec.sizing.model_dump(),
+            "risk_limits": self._spec.risk_limits.model_dump(),
+            "target_symbols": list(self._spec.target_symbols),
+        }
+        return strategy_dict, "# ideation code", "test rationale"
+
+
+class _LoosenOnceRefinementAgent:
+    """Stub that always emits a risk-limits loosening proposal so the
+    orchestrator's ``_apply_updates`` raises immediately."""
+
+    def __init__(self) -> None:
+        self.spec_mutation_history: List[Dict[str, Any]] = []
+
+    def run(
+        self,
+        spec: StrategySpec,
+        code: str,
+        failure_phase: str,
+        failure_details: str,
+        metrics: Optional[BacktestResult] = None,
+        prior_attempts: Optional[List[str]] = None,
+    ) -> Tuple[Dict[str, Any], str]:
+        return (
+            {
+                "changes_made": "loosen sizing",
+                "risk_limits": {"max_position_pct": 99.0},
+            },
+            "# refined code",
+        )
+
+
+def test_run_cycle_reroutes_then_short_circuits_on_persistent_loosening(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If every design attempt's refinement tries to loosen risk limits,
+    ``run_cycle`` emits loopback events and persists a
+    ``failed: spec_unimplementable`` record after exhaustion."""
+    spec = _spec()
+    orch = StrategyLabOrchestrator()
+    orch.ideation_agent = _FakeIdeationAgent(spec)  # type: ignore[assignment]
+    orch.refinement_agent = _LoosenOnceRefinementAgent()  # type: ignore[assignment]
+
+    # Make code-safety pass so the loop reaches refinement.
+    monkeypatch.setattr(
+        orch.code_safety_checker,
+        "check",
+        lambda code: [],
+    )
+    # Pre-synthesis spec validator passes.
+    monkeypatch.setattr(
+        orch.strategy_validator,
+        "validate",
+        lambda s: [],
+    )
+
+    # Force execution to fail so the refinement path fires.
+    def _failed_run(
+        code: str, market_data: Any, config: Any, strategy: Any = None
+    ) -> StrategyRunResult:
+        return StrategyRunResult(
+            success=False,
+            error_type="runtime_error",
+            stderr="forced failure for test",
+            stdout="",
+        )
+
+    monkeypatch.setattr(orchestrator_module, "run_strategy_code", _failed_run)
+
+    # Stub market-data fetch so the loop has data to "execute" against.
+    monkeypatch.setattr(
+        orch,
+        "_fetch_market_data",
+        lambda spec_arg, config_arg: orchestrator_module._MarketDataFetch(
+            data={
+                "SPY": [
+                    OHLCVBar(
+                        symbol="SPY", date="2023-01-01", open=1, high=1, low=1, close=1, volume=1
+                    )
+                ]
+            },
+            requested_symbols=["SPY"],
+            fetched_symbols=["SPY"],
+        ),
+    )
+
+    emitted: List[Tuple[str, Dict[str, Any]]] = []
+    record = orch.run_cycle(
+        prior_records=[],
+        config=_config(),
+        on_phase=lambda phase, data: emitted.append((phase, data)),
+    )
+
+    loopback_events = [
+        d for phase, d in emitted if phase == "ideating" and d.get("sub_phase") == "loopback"
+    ]
+    assert len(loopback_events) == MAX_DESIGN_REENTRIES
+    assert orch.ideation_agent.call_count == MAX_DESIGN_REENTRIES + 1  # type: ignore[attr-defined]
+    assert record.backtest.status == "failed: spec_unimplementable"

--- a/backend/agents/investment_team/tests/test_strategy_lab_refinement_freeze.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_refinement_freeze.py
@@ -343,6 +343,36 @@ class _LoosenOnceRefinementAgent:
         )
 
 
+class _StraySpecRefinementAgent:
+    """Stub that always emits stray spec-mutating keys (no risk-limits
+    loosening). After ``_SPEC_MUTATION_TRIP_THRESHOLD`` consecutive rounds
+    on the same ``failure_phase`` the orchestrator's ``_apply_updates``
+    trips ``SpecImplementabilityError`` via the threshold path."""
+
+    def __init__(self) -> None:
+        self.spec_mutation_history: List[Dict[str, Any]] = []
+        self.call_count = 0
+
+    def run(
+        self,
+        spec: StrategySpec,
+        code: str,
+        failure_phase: str,
+        failure_details: str,
+        metrics: Optional[BacktestResult] = None,
+        prior_attempts: Optional[List[str]] = None,
+    ) -> Tuple[Dict[str, Any], str]:
+        self.call_count += 1
+        return (
+            {
+                "changes_made": f"stray attempt {self.call_count}",
+                "entry_rules": [{"side": "long", "comment": "bogus"}],
+                "hypothesis": "rewritten by LLM",
+            },
+            f"# refined code {self.call_count}",
+        )
+
+
 def test_run_cycle_reroutes_then_short_circuits_on_persistent_loosening(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -410,3 +440,70 @@ def test_run_cycle_reroutes_then_short_circuits_on_persistent_loosening(
     assert len(loopback_events) == MAX_DESIGN_REENTRIES
     assert orch.ideation_agent.call_count == MAX_DESIGN_REENTRIES + 1  # type: ignore[attr-defined]
     assert record.backtest.status == "failed: spec_unimplementable"
+
+
+def test_run_cycle_reroutes_on_stray_key_threshold(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end coverage for the threshold-trip path (non-risk-limits):
+    when refinement emits stray spec keys for ``_SPEC_MUTATION_TRIP_THRESHOLD``
+    consecutive rounds on the same ``failure_phase``, ``run_cycle``
+    re-enters ideation and ultimately persists a
+    ``failed: spec_unimplementable`` record."""
+    spec = _spec()
+    orch = StrategyLabOrchestrator()
+    orch.ideation_agent = _FakeIdeationAgent(spec)  # type: ignore[assignment]
+    orch.refinement_agent = _StraySpecRefinementAgent()  # type: ignore[assignment]
+
+    monkeypatch.setattr(orch.code_safety_checker, "check", lambda code: [])
+    monkeypatch.setattr(orch.strategy_validator, "validate", lambda s: [])
+
+    # Force every execution to fail so the loop stays in the "execution"
+    # failure_phase and accumulates stray-key rounds against a single
+    # phase counter (the threshold is per-phase consecutive).
+    def _failed_run(
+        code: str, market_data: Any, config: Any, strategy: Any = None
+    ) -> StrategyRunResult:
+        return StrategyRunResult(
+            success=False,
+            error_type="runtime_error",
+            stderr="forced failure for test",
+            stdout="",
+        )
+
+    monkeypatch.setattr(orchestrator_module, "run_strategy_code", _failed_run)
+    monkeypatch.setattr(
+        orch,
+        "_fetch_market_data",
+        lambda spec_arg, config_arg: orchestrator_module._MarketDataFetch(
+            data={
+                "SPY": [
+                    OHLCVBar(
+                        symbol="SPY", date="2023-01-01", open=1, high=1, low=1, close=1, volume=1
+                    )
+                ]
+            },
+            requested_symbols=["SPY"],
+            fetched_symbols=["SPY"],
+        ),
+    )
+
+    emitted: List[Tuple[str, Dict[str, Any]]] = []
+    record = orch.run_cycle(
+        prior_records=[],
+        config=_config(),
+        on_phase=lambda phase, data: emitted.append((phase, data)),
+    )
+
+    loopback_events = [
+        d for phase, d in emitted if phase == "ideating" and d.get("sub_phase") == "loopback"
+    ]
+    assert len(loopback_events) == MAX_DESIGN_REENTRIES
+    # Each loopback's evidence references the threshold-path message, not
+    # risk-limits loosening — confirms we exercised the right code path.
+    for ev in loopback_events:
+        assert "consecutive mutation attempts" in ev["evidence"]
+        assert ev["failure_phase"] == "execution"
+    assert orch.ideation_agent.call_count == MAX_DESIGN_REENTRIES + 1  # type: ignore[attr-defined]
+    assert record.backtest.status == "failed: spec_unimplementable"
+    assert "spec_unimplementable" in record.backtest.status


### PR DESCRIPTION
## Summary

Closes #543. Tightens the post-#547 refinement contract so the persisted strategy spec can no longer drift from the spec that was reviewed at ideation time.

- `RefinementAgent.run` narrows its output to `{changes_made, risk_limits}` and logs + records any stray spec-mutating keys (audit trail on `spec_mutation_history`).
- `StrategyLabOrchestrator._apply_updates` is now an instance method that warns on stray keys, applies a **tighten-only `risk_limits` carve-out** (per-field via `_RISK_LIMIT_TIGHTEN_DIRECTION` in `risk_filter.py`), and raises `SpecImplementabilityError` on (a) any `risk_limits` loosening attempt or (b) three consecutive stray-key rounds within the same `failure_phase`.
- `run_cycle` wraps its body in `_run_design_attempt` and an outer retry loop bounded by `MAX_DESIGN_REENTRIES = 2`: on `SpecImplementabilityError` it appends the failure evidence as a convergence directive, re-enters ideation, and short-circuits with `status="failed: spec_unimplementable"` on exhaustion.
- New `strategy_lab/exceptions.py` houses `SpecImplementabilityError` (carries `evidence`, `failure_phase`, `last_spec`, `last_code`).

## Acceptance criteria (issue #543)

- [x] `RefinementAgent` output is code-only (narrowed to `{changes_made}` plus `risk_limits` passthrough for the tighten-only carve-out).
- [x] `prompts/refinement_system.md` no longer invites spec changes (already "immutable here" post-#547).
- [x] `_apply_updates` drops spec-mutating keys during synthesis/verification and **logs a warning**.
- [x] Existing tests updated; new test asserts refinement rounds never alter `spec.hypothesis` / `spec.entry_rules` once design has exited.
- [x] Risk-limits tightening allowed; loosening triggers a phase-back route to ideation.

## Test plan

- [x] `pytest agents/investment_team/tests/test_strategy_lab_refinement_contract.py` (3 tests — instance-method conversion, warning emission, risk-limits loosening trip)
- [x] `pytest agents/investment_team/tests/test_strategy_lab_refinement_freeze.py` (11 new tests — output filter, tighten-only merge, trip threshold, counter reset, interleaved-phase isolation, end-to-end loopback + short-circuit)
- [x] `pytest agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py` (10 tests — regression for the shared `_apply_updates` path)
- [x] `pytest agents/investment_team/tests/` — full investment-team suite, **1299 passed, 13 skipped**
- [x] `ruff check` + `ruff format --check` clean

## Notes / follow-ups

- `vol_lookback_days` is mapped to `None` (immutable) in `_RISK_LIMIT_TIGHTEN_DIRECTION` — proposed changes are discarded with a warning, not a trip. Cosmetic knob.
- `target_annual_vol: None → value` transitions are treated as loosening (raise) because they fundamentally change the sizing model. If this proves too aggressive in practice, follow-up to add a "first-set-allowed" rule.
- The release hook in `product_delivery` runs only on the legacy SE path; this change is orthogonal — no interaction.

https://claude.ai/code/session_01R4rs4QAV8p3vr6Zn7Hqm64

---
_Generated by [Claude Code](https://claude.ai/code/session_01R4rs4QAV8p3vr6Zn7Hqm64)_