### PR TITLE
investment-team: structured-DSL prompts + JSON parsers (#559)

### DIFF
--- a/backend/agents/investment_team/strategy_lab/agents/_parse_helpers.py
+++ b/backend/agents/investment_team/strategy_lab/agents/_parse_helpers.py
@@ -1,0 +1,104 @@
+"""Shared LLM-output validators for the Strategy Lab agent suite (#559).
+
+After the structured-DSL migration (#537 step 2, #551), `StrategySpec`
+accepts only structured `EntryRule` / `ExitRule` / `SizingRule` objects.
+Agents that author specs from LLM JSON must therefore reject prose
+payloads up front so the error surface points at the LLM call rather
+than the orchestrator's `StrategySpec(...)` construction.
+
+The helper here dispatches the rule-shaped slots of a parsed LLM dict
+through the existing TypeAdapters in
+``backend/agents/investment_team/strategy_lab/spec_dsl.py`` and wraps any
+pydantic ``ValidationError`` in :class:`StrategySpecParseError` with a
+message that names the offending field and quotes the failing payload.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Iterable
+
+from pydantic import ValidationError
+
+from ..spec_dsl import EntryRuleAdapter, ExitRuleAdapter, SizingRuleAdapter
+
+
+class StrategySpecParseError(ValueError):
+    """Raised when an LLM payload cannot be parsed into the structured DSL.
+
+    ``field`` is the spec field that failed (``entry_rules``, ``exit_rules``,
+    ``sizing``). ``payload`` is the offending sub-value, snipped for log
+    safety. ``cause`` is the chained pydantic ``ValidationError``.
+    """
+
+    def __init__(self, field: str, payload: Any, cause: Exception) -> None:
+        snippet = _snippet(payload)
+        super().__init__(
+            f"LLM emitted prose or invalid structure; structured DSL required. "
+            f"Field={field}; payload={snippet}; pydantic error={cause}"
+        )
+        self.field = field
+        self.payload = payload
+        self.__cause__ = cause
+
+
+_RULE_LIST_FIELDS: Dict[str, Any] = {
+    "entry_rules": EntryRuleAdapter,
+    "exit_rules": ExitRuleAdapter,
+}
+
+
+def validate_structured_rules(parsed: Dict[str, Any]) -> None:
+    """Dispatch rule-shaped slots of ``parsed`` through the DSL TypeAdapters.
+
+    Mutates nothing. Raises :class:`StrategySpecParseError` on the first
+    field that fails to validate. Fields that are absent from ``parsed``
+    are skipped — the caller is responsible for required-field policy.
+    """
+    for field, adapter in _RULE_LIST_FIELDS.items():
+        if field not in parsed:
+            continue
+        value = parsed[field]
+        if not isinstance(value, list):
+            raise StrategySpecParseError(
+                field,
+                value,
+                TypeError(f"expected a list of rule objects, got {type(value).__name__}"),
+            )
+        for index, item in enumerate(value):
+            try:
+                adapter.validate_python(item)
+            except ValidationError as exc:
+                raise StrategySpecParseError(f"{field}[{index}]", item, exc) from exc
+
+    if "sizing" in parsed:
+        value = parsed["sizing"]
+        try:
+            SizingRuleAdapter.validate_python(value)
+        except ValidationError as exc:
+            raise StrategySpecParseError("sizing", value, exc) from exc
+
+
+def _snippet(value: Any, limit: int = 200) -> str:
+    """Render ``value`` as a short, log-safe string.
+
+    Strings are quoted; dict / list payloads are JSON-encoded. Anything
+    longer than ``limit`` chars is truncated with an ellipsis so prose
+    runaways do not flood log lines.
+    """
+    if isinstance(value, str):
+        text = repr(value)
+    else:
+        try:
+            text = json.dumps(value, separators=(",", ":"), default=str)
+        except (TypeError, ValueError):
+            text = repr(value)
+    if len(text) > limit:
+        return text[: limit - 1] + "…"
+    return text
+
+
+__all__: Iterable[str] = (
+    "StrategySpecParseError",
+    "validate_structured_rules",
+)

--- a/backend/agents/investment_team/strategy_lab/agents/ideation.py
+++ b/backend/agents/investment_team/strategy_lab/agents/ideation.py
@@ -14,6 +14,7 @@ from ...models import StrategyLabRecord
 from ...signal_intelligence_agent import brief_to_prompt_block
 from ...signal_intelligence_models import SignalIntelligenceBriefV1
 from ...strategy_lab_context import asset_class_mix_hint, format_prior_results
+from ._parse_helpers import StrategySpecParseError, validate_structured_rules
 from .model_factory import get_strands_model
 
 logger = logging.getLogger(__name__)
@@ -39,14 +40,28 @@ Follow your decomposed reasoning process: ANALYZE → HYPOTHESIZE → DESIGN →
 
 Each prior entry includes outcome, metrics, rationale, and post-backtest analysis. Generate a strategy that **differs** from prior ones and learns from their failures.
 
-Return ONLY a JSON object with no markdown:
+Return ONLY a JSON object with no markdown. `entry_rules`, `exit_rules`,
+and `sizing` MUST be the structured DSL objects described in the system
+prompt — prose strings will be rejected.
+
 {{
   "asset_class": "stocks" | "crypto" | "forex" | "options" | "futures" | "commodities",
   "hypothesis": "1-3 sentence investment thesis tying multiple signals to edge",
   "signal_definition": "Describe the ensemble of signals and how they combine",
-  "entry_rules": ["rule 1", "rule 2", "rule 3"],
-  "exit_rules": ["exit rule 1", "exit rule 2"],
-  "sizing_rules": ["sizing rule 1"],
+  "entry_rules": [
+    {{"kind": "entry", "side": "long",
+      "when": {{"lhs": {{"kind": "rsi", "period": 14}},
+                "op": "lt",
+                "rhs": {{"kind": "const", "value": 30}}}}}}
+  ],
+  "exit_rules": [
+    {{"kind": "signal_exit",
+      "when": {{"lhs": {{"kind": "rsi", "period": 14}},
+                "op": "gt",
+                "rhs": {{"kind": "const", "value": 70}}}}}},
+    {{"kind": "time_stop", "n_bars": 10}}
+  ],
+  "sizing": {{"kind": "fixed_fraction", "fraction": 0.02}},
   "target_symbols": ["UPPERCASE tickers if your hypothesis names specific ones, e.g. QQQ; else []"],
   "risk_limits": {{"max_position_pct": 5, "stop_loss_pct": 3}},
   "speculative": false,
@@ -117,6 +132,15 @@ class IdeationAgent:
 
         strategy_code = parsed.pop("strategy_code", "")
         rationale = parsed.pop("rationale", "")
+
+        # Fail loud if the LLM emitted prose / legacy-shaped rules. The
+        # orchestrator's StrategySpec(...) call would otherwise raise a
+        # less actionable pydantic error far from the ideation site.
+        try:
+            validate_structured_rules(parsed)
+        except StrategySpecParseError as exc:
+            logger.warning("Ideation LLM emitted invalid rule shape: %s", exc)
+            raise
 
         return parsed, strategy_code, rationale
 

--- a/backend/agents/investment_team/strategy_lab/agents/refinement.py
+++ b/backend/agents/investment_team/strategy_lab/agents/refinement.py
@@ -54,10 +54,11 @@ Risk limits: {risk_limits}
 1. Diagnose the root cause from the failure details.
 2. Fix the code only. Do NOT alter the strategy spec (entry/exit/sizing
    rules, risk limits, hypothesis) — spec changes go through ideation,
-   not refinement.
+   not refinement. The rules above are rendered text views of structured
+   DSL objects; do NOT emit them back in your response.
 3. Ensure your fix doesn't re-introduce any previously fixed issues.
 
-Return ONLY a JSON object with no markdown:
+Return ONLY a JSON object with no markdown — exactly these two keys:
 {{
   "strategy_code": "the complete fixed Python code",
   "changes_made": "1-2 sentence summary of what you changed and why"

--- a/backend/agents/investment_team/strategy_lab/agents/zero_trade_repair.py
+++ b/backend/agents/investment_team/strategy_lab/agents/zero_trade_repair.py
@@ -25,6 +25,7 @@ from strands import Agent
 from ...models import BacktestExecutionDiagnostics, CoverageReport, StrategySpec, ZeroTradeCategory
 from ..coverage_probe import format_coverage_report
 from ..spec_dsl import format_rules_for_prompt, format_sizing_rule
+from ._parse_helpers import StrategySpecParseError, validate_structured_rules
 from .model_factory import get_strands_model
 
 logger = logging.getLogger(__name__)
@@ -263,6 +264,20 @@ def _coerce_report(
     proposed_spec_updates: Optional[Dict[str, Any]]
     if isinstance(raw_spec_updates, dict):
         whitelisted = {k: v for k, v in raw_spec_updates.items() if k in _ALLOWED_SPEC_UPDATE_KEYS}
+        # Reject prose / invalid structure on the rule-shaped keys so the
+        # orchestrator does not propagate a malformed dict into
+        # `_apply_updates`. The whitelist still gates which fields make it
+        # through (#530); validation only runs on rule-shaped values.
+        try:
+            validate_structured_rules(whitelisted)
+        except StrategySpecParseError as exc:
+            logger.warning(
+                "Zero-trade repair emitted invalid structured rule shape; dropping "
+                "proposed_spec_updates so the orchestrator falls back to generic "
+                "refinement: %s",
+                exc,
+            )
+            whitelisted = {}
         proposed_spec_updates = whitelisted or None
     else:
         proposed_spec_updates = None

--- a/backend/agents/investment_team/strategy_lab/prompts/ideation_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/ideation_system.md
@@ -21,6 +21,82 @@ Design strategies as a **mixture of signal types**, not a single indicator. Comb
 - **Mean reversion**: RSI, Bollinger Bands, Stochastic oscillator
 - **Volatility regime**: ATR expansion/contraction, VIX-based filters (if applicable)
 
+## Strategy spec output shape — STRUCTURED DSL (mandatory)
+
+`entry_rules`, `exit_rules`, and `sizing` are **structured discriminated objects** — not prose strings. Every rule object MUST carry a `kind` field; the parser rejects bare strings with a pydantic `ValidationError` and the cycle is discarded.
+
+### Indicator catalogue
+
+Every indicator reference is an object with a `kind` discriminator. The accepted kinds and their parameter shapes mirror `spec_dsl.IndicatorRef` exactly:
+
+| `kind` | Required params | Defaults / optional |
+|---|---|---|
+| `price` | — | `field`: one of `close` / `high` / `low` / `open` / `volume` / `hl2` / `ohlc4` (default `close`) |
+| `const` | `value: float` | — |
+| `sma` | `period: int` (2-400) | `source` (default `close`) |
+| `ema` | `period: int` (2-400) | `source` (default `close`) |
+| `rsi` | — | `period: int` (2-200, default 14), `source` (default `close`) |
+| `macd` | — | `fast` (default 12), `slow` (default 26), `signal` (default 9), `output` ∈ {macd, signal, histogram} (default `macd`), `source` (default `close`) |
+| `bollinger` | — | `period` (default 20, 5-200), `num_std` (default 2.0, >0), `band` ∈ {upper, middle, lower} (default `middle`), `source` (default `close`) |
+| `atr` | — | `period` (default 14, 2-200) |
+| `adx` | — | `period` (default 14, 2-200) |
+| `stochastic` | — | `k_period` (default 14), `d_period` (default 3), `output` ∈ {k, d} (default `k`) |
+| `vwap` | — | — |
+
+### Rule kinds
+
+- **`entry_rules`**: list of objects with `{"kind": "entry", "side": "long"|"short", "when": Predicate, "note": str}`.
+- **`exit_rules`**: list of one or more of:
+  - `{"kind": "time_stop", "n_bars": int>0, "note": str}` — exit after N bars.
+  - `{"kind": "stop_loss", "pct": 0<float<=1.0, "basis": "entry_price"|"trailing_high"|"trailing_low", "note": str}` — note `pct` is a fraction (`0.03` = 3%), not a percent.
+  - `{"kind": "take_profit", "pct": float>0, "note": str}` — `pct` is a fraction.
+  - `{"kind": "signal_exit", "when": Predicate, "note": str}`.
+- **`sizing`** (single object, not a list):
+  - `{"kind": "fixed_fraction", "fraction": 0<float<=1.0, "note": str}` — fraction is `0.02` for 2% per trade.
+  - `{"kind": "volatility_target", "target_annual_vol": float>0, "note": str}`.
+  - `{"kind": "fixed_notional", "notional_usd": float>0, "note": str}`.
+
+A `Predicate` is `{"lhs": IndicatorRef, "op": op, "rhs": IndicatorRef}` where `op ∈ {gt, lt, ge, le, eq, cross_above, cross_below}`. **Both sides are IndicatorRefs** — to compare against a constant, use `{"kind": "const", "value": 30}` on the right.
+
+### Worked structured example (mean-reversion RSI strategy)
+
+```json
+{
+  "asset_class": "stocks",
+  "hypothesis": "...",
+  "signal_definition": "...",
+  "entry_rules": [{
+    "kind": "entry", "side": "long",
+    "when": {"lhs": {"kind": "rsi", "period": 14},
+             "op": "lt",
+             "rhs": {"kind": "const", "value": 30}}
+  }],
+  "exit_rules": [
+    {"kind": "signal_exit",
+     "when": {"lhs": {"kind": "rsi", "period": 14},
+              "op": "gt",
+              "rhs": {"kind": "const", "value": 70}}},
+    {"kind": "time_stop", "n_bars": 10}
+  ],
+  "sizing": {"kind": "fixed_fraction", "fraction": 0.02},
+  "risk_limits": {"max_position_pct": 5},
+  "rationale": "...",
+  "strategy_code": "..."
+}
+```
+
+### Negative example — do NOT emit
+
+```json
+{
+  "entry_rules": ["close > sma(20)"],
+  "exit_rules": ["exit after 10 bars"],
+  "sizing_rules": ["risk 2% per trade"]
+}
+```
+
+Prose strings (the shape above) and the legacy `sizing_rules` list-of-strings are both rejected by the parser. The orchestrator will discard the ideation cycle and ask for a redo.
+
 ## Asset class diversity
 
 Diversify across: stocks, crypto, forex, options, futures, commodities. Do NOT default to equities unless explicitly directed.

--- a/backend/agents/investment_team/strategy_lab/prompts/refinement_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/refinement_system.md
@@ -17,6 +17,12 @@ risk limits) is immutable here — if the failure reveals a design flaw in
 the spec itself, surface it in `changes_made`; spec changes are done by
 ideation, not refinement.
 
+The spec's `entry_rules`, `exit_rules`, and `sizing` are now structured DSL
+objects (every rule carries a `kind` discriminator). They are shown in this
+prompt rendered as readable text for context only — do NOT emit them back.
+The orchestrator drops any top-level key other than `strategy_code` and
+`changes_made` with a warning.
+
 ## Common failure types and how to handle them
 
 ### Code execution errors (syntax, import, runtime)

--- a/backend/agents/investment_team/strategy_lab/prompts/zero_trade_repair_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/zero_trade_repair_system.md
@@ -98,8 +98,39 @@ If the proposed fix requires a small spec change (e.g. a too-tight
 `entry_rules` or a missing `exit_rules` clause), you may also return a
 `proposed_spec_updates` object containing only the rule fields you are
 adjusting. Do not invent new keys; the orchestrator will only honour
-`entry_rules`, `exit_rules`, `sizing_rules`, `risk_limits`, `hypothesis`,
+`entry_rules`, `exit_rules`, `sizing`, `risk_limits`, `hypothesis`,
 and `signal_definition`.
+
+When `proposed_spec_updates` includes rule-shaped keys, the values MUST
+be the structured DSL objects (every rule carries a `kind` discriminator)
+— the parser rejects prose strings. The rule shapes the orchestrator
+accepts (mirrored from `spec_dsl.py`) are:
+
+```json
+{
+  "entry_rules": [{
+    "kind": "entry", "side": "long",
+    "when": {"lhs": {"kind": "rsi", "period": 14},
+             "op": "lt",
+             "rhs": {"kind": "const", "value": 30}}
+  }],
+  "exit_rules": [
+    {"kind": "signal_exit",
+     "when": {"lhs": {"kind": "rsi", "period": 14},
+              "op": "gt",
+              "rhs": {"kind": "const", "value": 70}}},
+    {"kind": "time_stop", "n_bars": 10}
+  ],
+  "sizing": {"kind": "fixed_fraction", "fraction": 0.02}
+}
+```
+
+Indicator `kind`s accepted: `price`, `const`, `sma`, `ema`, `rsi`, `macd`,
+`bollinger`, `atr`, `adx`, `stochastic`, `vwap`. Comparison `op`s
+accepted: `gt`, `lt`, `ge`, `le`, `eq`, `cross_above`, `cross_below`.
+Exit-rule `kind`s accepted: `time_stop`, `stop_loss`, `take_profit`,
+`signal_exit`. Sizing `kind`s accepted: `fixed_fraction`,
+`volatility_target`, `fixed_notional`.
 
 If the diagnostics do not give you enough evidence to propose a code
 change you are confident in, return `proposed_code: null` and explain

--- a/backend/agents/investment_team/tests/test_agent_prompts_structured.py
+++ b/backend/agents/investment_team/tests/test_agent_prompts_structured.py
@@ -1,0 +1,421 @@
+"""Structured-DSL contract for Strategy Lab LLM agents (#559).
+
+After #551 swapped ``StrategySpec`` to structured DSL rule types, the
+LLM-driven agents that author specs must:
+
+1. Emit JSON with structured rule objects (every rule carries a ``kind``
+   discriminator).
+2. Reject prose payloads with :class:`StrategySpecParseError` so the
+   orchestrator does not propagate a malformed dict into ``StrategySpec``.
+
+This suite locks in that contract for the three agents that touch rule
+shapes: :class:`IdeationAgent` (authors specs from scratch),
+:class:`RefinementAgent` (code-only — must drop stray rule keys), and
+:class:`ZeroTradeRepairAgent` (may emit ``proposed_spec_updates``
+containing rule-shaped values).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import pytest
+
+from investment_team.models import (
+    BacktestExecutionDiagnostics,
+    StrategySpec,
+)
+from investment_team.strategy_lab.agents._parse_helpers import StrategySpecParseError
+from investment_team.strategy_lab.agents.ideation import IdeationAgent
+from investment_team.strategy_lab.agents.refinement import RefinementAgent
+from investment_team.strategy_lab.agents.zero_trade_repair import ZeroTradeRepairAgent
+from investment_team.strategy_lab.spec_dsl import (
+    ConstRef,
+    EntryRule,
+    EntryRuleAdapter,
+    Predicate,
+    RSIRef,
+    SignalExitRule,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _FakeStrandsAgentReturning:
+    """Callable stub that mimics the ``strands.Agent`` instance each agent
+    builds inline. Returns the same string payload for every call."""
+
+    def __init__(self, payload: str) -> None:
+        self._payload = payload
+
+    def __call__(self, prompt: str) -> str:
+        return self._payload
+
+
+def _structured_entry_rule_dict() -> dict:
+    return {
+        "kind": "entry",
+        "side": "long",
+        "when": {
+            "lhs": {"kind": "rsi", "period": 14},
+            "op": "lt",
+            "rhs": {"kind": "const", "value": 30},
+        },
+    }
+
+
+def _structured_signal_exit_rule_dict() -> dict:
+    return {
+        "kind": "signal_exit",
+        "when": {
+            "lhs": {"kind": "rsi", "period": 14},
+            "op": "gt",
+            "rhs": {"kind": "const", "value": 70},
+        },
+    }
+
+
+def _structured_sizing_dict() -> dict:
+    return {"kind": "fixed_fraction", "fraction": 0.02}
+
+
+def _spec() -> StrategySpec:
+    """Minimal structured-DSL spec usable as input to refinement / repair."""
+    return StrategySpec(
+        strategy_id="strat-prompts-test",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="RSI mean reversion",
+        signal_definition="sig",
+        entry_rules=[
+            EntryRule(
+                side="long",
+                when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30)),
+            )
+        ],
+        exit_rules=[
+            SignalExitRule(when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)))
+        ],
+        risk_limits={"max_position_pct": 5, "max_drawdown_pct": 10},
+        speculative=False,
+        strategy_code="# original",
+    )
+
+
+def _patch_ideation(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    monkeypatch.setattr(
+        "investment_team.strategy_lab.agents.ideation.Agent",
+        lambda **kwargs: _FakeStrandsAgentReturning(payload),
+    )
+    monkeypatch.setattr(
+        "investment_team.strategy_lab.agents.ideation.get_strands_model",
+        lambda role: object(),
+    )
+
+
+def _patch_refinement(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    monkeypatch.setattr(
+        "investment_team.strategy_lab.agents.refinement.Agent",
+        lambda **kwargs: _FakeStrandsAgentReturning(payload),
+    )
+    monkeypatch.setattr(
+        "investment_team.strategy_lab.agents.refinement.get_strands_model",
+        lambda role: object(),
+    )
+
+
+def _patch_zero_trade_repair(monkeypatch: pytest.MonkeyPatch, payload: str) -> None:
+    monkeypatch.setattr(
+        "investment_team.strategy_lab.agents.zero_trade_repair.Agent",
+        lambda **kwargs: _FakeStrandsAgentReturning(payload),
+    )
+    monkeypatch.setattr(
+        "investment_team.strategy_lab.agents.zero_trade_repair.get_strands_model",
+        lambda role: object(),
+    )
+
+
+def _zero_trade_diagnostics() -> BacktestExecutionDiagnostics:
+    return BacktestExecutionDiagnostics(
+        orders_emitted=0,
+        orders_accepted=0,
+        orders_rejected=0,
+        orders_unfilled=0,
+        warmup_orders_dropped=0,
+        entries_filled=0,
+        exits_emitted=0,
+        closed_trades=0,
+        open_positions_at_end=[],
+        orders_rejection_reasons={},
+        last_order_events=[],
+        summary="never emitted",
+        zero_trade_category="NO_ORDERS_EMITTED",
+    )
+
+
+# ---------------------------------------------------------------------------
+# IdeationAgent — must accept structured, reject prose / invalid structured
+# ---------------------------------------------------------------------------
+
+
+def _ideation_payload(
+    *,
+    entry_rules,
+    exit_rules,
+    sizing=None,
+    extra=None,
+) -> str:
+    """Build an LLM-style ideation JSON payload as a string."""
+    payload: dict = {
+        "asset_class": "stocks",
+        "hypothesis": "h",
+        "signal_definition": "s",
+        "entry_rules": entry_rules,
+        "exit_rules": exit_rules,
+        "target_symbols": [],
+        "risk_limits": {"max_position_pct": 5},
+        "speculative": False,
+        "rationale": "r",
+        "strategy_code": "# generated code",
+    }
+    if sizing is not None:
+        payload["sizing"] = sizing
+    if extra:
+        payload.update(extra)
+    return json.dumps(payload)
+
+
+def test_ideation_accepts_structured_rules(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The structured-DSL shape round-trips through ``IdeationAgent.run``."""
+    payload = _ideation_payload(
+        entry_rules=[_structured_entry_rule_dict()],
+        exit_rules=[_structured_signal_exit_rule_dict(), {"kind": "time_stop", "n_bars": 10}],
+        sizing=_structured_sizing_dict(),
+    )
+    _patch_ideation(monkeypatch, payload)
+
+    parsed, code, rationale = IdeationAgent().run(prior_records=[])
+
+    assert code == "# generated code"
+    assert rationale == "r"
+    # entry_rules round-trips through the DSL adapter.
+    rule_model = EntryRuleAdapter.validate_python(parsed["entry_rules"][0])
+    assert rule_model.kind == "entry"
+    assert rule_model.side == "long"
+    assert parsed["sizing"] == _structured_sizing_dict()
+
+
+def test_ideation_rejects_prose_entry_rules(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Prose strings in ``entry_rules`` raise ``StrategySpecParseError``."""
+    payload = _ideation_payload(
+        entry_rules=["close > sma(20)"],
+        exit_rules=[_structured_signal_exit_rule_dict()],
+        sizing=_structured_sizing_dict(),
+    )
+    _patch_ideation(monkeypatch, payload)
+
+    with pytest.raises(StrategySpecParseError) as exc_info:
+        IdeationAgent().run(prior_records=[])
+
+    assert exc_info.value.field.startswith("entry_rules")
+    assert "close > sma(20)" in str(exc_info.value)
+
+
+def test_ideation_rejects_legacy_sizing_rules_list(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The pre-#551 ``sizing_rules: list[str]`` shape is not silently passed
+    through. With no ``sizing`` key the parser is forgiving (the orchestrator
+    falls back to the DSL default), but prose rules still raise."""
+    payload = _ideation_payload(
+        entry_rules=[_structured_entry_rule_dict()],
+        exit_rules=["exit after 10 bars"],
+        sizing=_structured_sizing_dict(),
+    )
+    _patch_ideation(monkeypatch, payload)
+
+    with pytest.raises(StrategySpecParseError) as exc_info:
+        IdeationAgent().run(prior_records=[])
+
+    assert exc_info.value.field.startswith("exit_rules")
+
+
+def test_ideation_rejects_invalid_structured_indicator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Structured-but-invalid rules (unknown indicator ``kind``) raise with the
+    pydantic error chained as ``__cause__``."""
+    bad_entry = {
+        "kind": "entry",
+        "side": "long",
+        "when": {
+            "lhs": {"kind": "ema", "period": 1},  # period < 2 trips the bound
+            "op": "lt",
+            "rhs": {"kind": "const", "value": 30},
+        },
+    }
+    payload = _ideation_payload(
+        entry_rules=[bad_entry],
+        exit_rules=[_structured_signal_exit_rule_dict()],
+        sizing=_structured_sizing_dict(),
+    )
+    _patch_ideation(monkeypatch, payload)
+
+    with pytest.raises(StrategySpecParseError) as exc_info:
+        IdeationAgent().run(prior_records=[])
+
+    assert exc_info.value.field.startswith("entry_rules")
+    assert exc_info.value.__cause__ is not None  # pydantic ValidationError chained
+
+
+def test_ideation_rejects_prose_sizing_object(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``sizing`` as a prose string is rejected — only structured kinds parse."""
+    payload = _ideation_payload(
+        entry_rules=[_structured_entry_rule_dict()],
+        exit_rules=[_structured_signal_exit_rule_dict()],
+        sizing="risk 2% per trade",
+    )
+    _patch_ideation(monkeypatch, payload)
+
+    with pytest.raises(StrategySpecParseError) as exc_info:
+        IdeationAgent().run(prior_records=[])
+
+    assert exc_info.value.field == "sizing"
+
+
+# ---------------------------------------------------------------------------
+# RefinementAgent — stray rule keys must be discarded with a warning
+# ---------------------------------------------------------------------------
+
+
+def test_refinement_discards_stray_rule_keys(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A refinement LLM payload with stray rule keys is narrowed to
+    ``{"strategy_code", "changes_made"}`` and the discarded keys land in
+    ``spec_mutation_history`` (#543 contract, re-confirmed under the DSL)."""
+    payload = json.dumps(
+        {
+            "strategy_code": "# refined",
+            "changes_made": "tightened RSI guard",
+            "entry_rules": [_structured_entry_rule_dict()],
+            "exit_rules": [_structured_signal_exit_rule_dict()],
+            "sizing": _structured_sizing_dict(),
+        }
+    )
+    _patch_refinement(monkeypatch, payload)
+
+    agent = RefinementAgent()
+    with caplog.at_level(logging.WARNING, logger="investment_team.strategy_lab.agents.refinement"):
+        updates, code = agent.run(
+            spec=_spec(),
+            code="# original",
+            failure_phase="execution",
+            failure_details="boom",
+        )
+
+    assert code == "# refined"
+    assert set(updates) == {"changes_made"}
+    assert agent.spec_mutation_history == [
+        {
+            "failure_phase": "execution",
+            "keys": ["entry_rules", "exit_rules", "sizing"],
+        }
+    ]
+    assert any("spec-mutating keys" in rec.message for rec in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# ZeroTradeRepairAgent — proposed_spec_updates must be structured
+# ---------------------------------------------------------------------------
+
+
+def _zero_trade_payload(*, proposed_spec_updates=None) -> str:
+    """Build a zero-trade repair LLM payload as a JSON string."""
+    payload: dict = {
+        "root_cause_category": "NO_ORDERS_EMITTED",
+        "evidence": "entries never fired",
+        "code_issue": "RSI guard never true on history",
+        "strategy_rule_issue": None,
+        "proposed_code": "# repaired code",
+        "expected_order_count_change": 5,
+        "expected_trade_count_change": 3,
+        "changes_made": "loosened RSI threshold",
+        "proposed_spec_updates": proposed_spec_updates,
+    }
+    return json.dumps(payload)
+
+
+def test_zero_trade_repair_accepts_structured_spec_updates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Structured ``proposed_spec_updates`` survives the repair agent intact."""
+    spec_updates = {
+        "entry_rules": [_structured_entry_rule_dict()],
+        "exit_rules": [_structured_signal_exit_rule_dict()],
+    }
+    _patch_zero_trade_repair(monkeypatch, _zero_trade_payload(proposed_spec_updates=spec_updates))
+
+    report = ZeroTradeRepairAgent().run(
+        spec=_spec(),
+        code="# original",
+        diagnostics=_zero_trade_diagnostics(),
+    )
+
+    assert report.proposed_spec_updates == spec_updates
+    assert report.proposed_code == "# repaired code"
+
+
+def test_zero_trade_repair_drops_prose_spec_updates(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Prose-shaped ``proposed_spec_updates`` is dropped (orchestrator falls
+    through to generic refinement) but ``proposed_code`` survives."""
+    spec_updates = {
+        "entry_rules": ["close > sma(20)"],
+        "exit_rules": ["exit after 10 bars"],
+    }
+    _patch_zero_trade_repair(monkeypatch, _zero_trade_payload(proposed_spec_updates=spec_updates))
+
+    with caplog.at_level(
+        logging.WARNING,
+        logger="investment_team.strategy_lab.agents.zero_trade_repair",
+    ):
+        report = ZeroTradeRepairAgent().run(
+            spec=_spec(),
+            code="# original",
+            diagnostics=_zero_trade_diagnostics(),
+        )
+
+    assert report.proposed_spec_updates is None
+    assert report.proposed_code == "# repaired code"
+    assert any("invalid structured rule shape" in rec.message for rec in caplog.records)
+
+
+def test_zero_trade_repair_drops_invalid_structured_spec_updates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Structured-but-invalid (unknown indicator bound violation) is dropped."""
+    spec_updates = {
+        "entry_rules": [
+            {
+                "kind": "entry",
+                "side": "long",
+                "when": {
+                    "lhs": {"kind": "rsi", "period": 1},  # below the ge=2 bound
+                    "op": "lt",
+                    "rhs": {"kind": "const", "value": 30},
+                },
+            }
+        ]
+    }
+    _patch_zero_trade_repair(monkeypatch, _zero_trade_payload(proposed_spec_updates=spec_updates))
+
+    report = ZeroTradeRepairAgent().run(
+        spec=_spec(),
+        code="# original",
+        diagnostics=_zero_trade_diagnostics(),
+    )
+
+    assert report.proposed_spec_updates is None


### PR DESCRIPTION
## Summary

Step 3 of 8 in the Strategy Lab structured-`StrategySpec`-DSL migration (epic #537). #551 (step 2) swapped `StrategySpec.entry_rules` / `exit_rules` / `sizing` to structured discriminated unions but left the LLM-driven agents teaching the model to emit prose strings — every ideation cycle was getting discarded by pydantic discriminator validation in `StrategyLabOrchestrator`. This PR teaches the three LLM agents the DSL and adds a parser that fails loud with a clear "prose detected" error at the LLM call site (not 100 lines downstream in the orchestrator).

Closes #559.

## What changed

- **Prompts** (`backend/agents/investment_team/strategy_lab/prompts/`): added an indicator catalogue, discriminator rule, structured JSON example, and a negative example to `ideation_system.md` and `zero_trade_repair_system.md`. `refinement_system.md` gains a one-line "rules are read-only" nudge.
- **Agent JSON templates**: `ideation.py` `_IDEATION_USER_TEMPLATE` now emits the structured example (RSI<30 entry, RSI>70 signal_exit + 10-bar time_stop, fixed_fraction 0.02 sizing); renamed `sizing_rules` → `sizing` to match post-#551.
- **New helper** `backend/agents/investment_team/strategy_lab/agents/_parse_helpers.py`: `StrategySpecParseError` + `validate_structured_rules(parsed)` which dispatches `entry_rules`, `exit_rules`, `sizing` through the existing `EntryRuleAdapter` / `ExitRuleAdapter` / `SizingRuleAdapter` from `spec_dsl.py:284-287`. Names the failing field, quotes a log-safe snippet, chains pydantic's `ValidationError` as `__cause__`.
- **Parser wiring**:
  - `ideation.py`: validates parsed dict before returning; raises on prose so the orchestrator's retry path engages near the LLM call.
  - `zero_trade_repair.py`: validates rule-shaped `proposed_spec_updates`; on prose, drops them with a warning so the orchestrator falls through to generic refinement (today's behaviour for any malformed repair).
  - `refinement.py`: no parser changes — output is code-only post-#543; existing `_ALLOWED_OUTPUT_KEYS` filter + `spec_mutation_history` already log + drop stray rule keys.
- **New tests** (`backend/agents/investment_team/tests/test_agent_prompts_structured.py`): 9 cases covering structured / prose / invalid-structured for ideation and zero-trade-repair, plus the refinement stray-key contract under the new DSL.

## Scope reconciliation vs. the issue body

A few line-number references in #559 are stale; the surgical intent is preserved:

- `agents/strategy_ideation_agent.py` doesn't exist — the agent is at `agents/ideation.py` (handled as one file).
- `ideation.py` doesn't construct `StrategySpec`; the orchestrator (`orchestrator.py:369`) does. Validating in `ideation.py` after `_extract_json` keeps the error message next to the LLM output, which matches the issue's intent ("LLM emitted prose; structured DSL required").
- `refinement.py` is code-only post-#543 — no rule fields in its output schema, so no parser change is needed there.

## Verification

- `pytest backend/agents/investment_team/tests/test_agent_prompts_structured.py -v` → 9 passed.
- `pytest backend/agents/investment_team/tests/ -k "orchestrator or ideation or refinement or zero_trade or strategy_lab"` → 161 passed.
- `pytest backend/agents/investment_team/tests/test_spec_dsl.py` → 49 passed (DSL contract unchanged).
- `ruff check` + `ruff format --check` on all touched files: clean.
- 15 unrelated failures in the sandbox suite are all `ModuleNotFoundError: No module named 'pyarrow'` in market-data cache tests, not regressions from this PR.
- **No manual LLM smoke test** — `OLLAMA_API_KEY` / network egress aren't available in this sandbox. Worth a once-through on a dev box before merge.

## Test plan

- [ ] Reviewer runs `pytest backend/agents/investment_team/tests/test_agent_prompts_structured.py -v` locally.
- [ ] Reviewer runs one ideation cycle end-to-end against the real LLM and confirms `StrategySpec` builds without prose errors (manual smoke per #559 acceptance criteria).
- [ ] Reviewer skims the three updated prompts for tone/accuracy.

## Out of scope (tracked separately)

- Removing `UnparsableRule` / `UnparsableSizing` from `spec_dsl.py` — #550's acceptance criteria said these shouldn't exist; they do. Flagging for a follow-up.
- Narrowing `_ALLOWED_SPEC_UPDATE_KEYS` in `zero_trade_repair.py` — that's #530.
- Frontend migration — #560 (depends on #554).
- Test-fixture rewrites — #555.

## Related

- Parent: #537 (epic)
- Predecessors: #550 (closed), #551 (closed)
- Co-merge companions still open: #555 (test fixtures), #560 (Angular frontend)

https://claude.ai/code/session_01DEAAkukn8FWrWFg9x56UR7

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEAAkukn8FWrWFg9x56UR7)_