### PR TITLE
investment-team: add target_symbol_coverage critical quality gate (#526)

### DIFF
--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -65,6 +65,7 @@ from .quality_gates.code_safety import CodeSafetyChecker
 from .quality_gates.convergence_tracker import ConvergenceTracker
 from .quality_gates.models import QualityGateResult
 from .quality_gates.strategy_validator import StrategySpecValidator
+from .quality_gates.target_symbol_coverage import TargetSymbolCoverageGate
 from .spec_dsl import DEFAULT_SIZING_PAYLOAD
 
 logger = logging.getLogger(__name__)
@@ -238,6 +239,7 @@ class StrategyLabOrchestrator:
         self.code_safety_checker = CodeSafetyChecker()
         self.anomaly_detector = BacktestAnomalyDetector()
         self.acceptance_gate = AcceptanceGate()
+        self.target_symbol_coverage_gate = TargetSymbolCoverageGate()
         self.convergence_tracker = convergence_tracker or ConvergenceTracker()
         self.market_data_service = MarketDataService()
         # Per-failure_phase counter of consecutive refinement rounds where
@@ -590,6 +592,19 @@ class StrategyLabOrchestrator:
                     },
                 )
 
+                # Issue #526 — fail closed if the fetched universe doesn't
+                # include the spec's target_symbols. Code refinement can't
+                # fix this (the data simply isn't there), so we break out
+                # the same way the no-market-data branch above does.
+                fetch_coverage_gates = self.target_symbol_coverage_gate.check_fetch(
+                    spec, requested_symbols, fetched_symbols
+                )
+                for g in fetch_coverage_gates:
+                    g.refinement_round = round_num
+                all_gate_results.extend(fetch_coverage_gates)
+                if any(not g.passed and g.severity == "critical" for g in fetch_coverage_gates):
+                    break
+
             # ── 2c: EXECUTE (syntax / runtime correctness) ───────────
             emit("backtesting", {"sub_phase": "running_code", "refinement_round": round_num})
             exec_result = run_strategy_code(code, market_data, config, strategy=spec)
@@ -645,6 +660,19 @@ class StrategyLabOrchestrator:
             # no-op here. Kept the same ``trades`` variable name so the
             # rest of the loop is untouched.
             trades = exec_result.trades
+
+            # Issue #526 — fail closed when the ledger contains symbols
+            # outside spec.target_symbols. Uses ``max_rounds_exhausted`` to
+            # leave ``execution_succeeded=False`` so ``is_winning`` stays
+            # False at the acceptance gate (same precedent as the
+            # max-refinement-rounds anomaly branch below).
+            trade_coverage_gates = self.target_symbol_coverage_gate.check_trades(spec, trades)
+            for g in trade_coverage_gates:
+                g.refinement_round = round_num
+            all_gate_results.extend(trade_coverage_gates)
+            if any(not g.passed and g.severity == "critical" for g in trade_coverage_gates):
+                max_rounds_exhausted = True
+                break
 
             emit(
                 "backtesting",

--- a/backend/agents/investment_team/strategy_lab/quality_gates/__init__.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/__init__.py
@@ -6,6 +6,7 @@ from .code_safety import CodeSafetyChecker
 from .convergence_tracker import ConvergenceTracker
 from .models import QualityGateResult
 from .strategy_validator import StrategySpecValidator
+from .target_symbol_coverage import TargetSymbolCoverageGate
 
 __all__ = [
     "AcceptanceGate",
@@ -14,5 +15,6 @@ __all__ = [
     "ConvergenceTracker",
     "QualityGateResult",
     "StrategySpecValidator",
+    "TargetSymbolCoverageGate",
     "summarize_acceptance_reason",
 ]

--- a/backend/agents/investment_team/strategy_lab/quality_gates/target_symbol_coverage.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/target_symbol_coverage.py
@@ -54,9 +54,10 @@ _KNOWN_TICKERS: frozenset[str] = frozenset(
     )
 )
 
-# Uppercase tokens 2-5 chars; conservative enough to skip common English words
-# while still catching tickers embedded in prose like "buy QQQ when ...".
-_TICKER_RE = re.compile(r"\b([A-Z]{2,5})\b")
+# Uppercase tokens 2-6 chars; conservative enough to skip common English words
+# while still catching tickers embedded in prose like "buy QQQ when ..." and
+# 6-char forex bare names like EURUSD/USDJPY in FOREX_SYMBOLS_BARE.
+_TICKER_RE = re.compile(r"\b([A-Z]{2,6})\b")
 
 
 class TargetSymbolCoverageGate:

--- a/backend/agents/investment_team/strategy_lab/quality_gates/target_symbol_coverage.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/target_symbol_coverage.py
@@ -1,0 +1,168 @@
+"""Issue #526 — assert the backtest universe matches the requested symbols.
+
+Without this gate, a hypothesis naming ``QQQ`` can silently be backtested on
+the asset-class default universe (TSLA/AAPL/...) and the analysis agent
+will confidently write about the wrong tickers. The gate fires twice per
+backtest round:
+
+* ``check_fetch`` — right after market data is fetched; verifies that every
+  entry in ``spec.target_symbols`` was actually fetched. When
+  ``spec.target_symbols`` is empty but the hypothesis text mentions a
+  known ticker, emits a warning recommending the operator set it
+  explicitly.
+* ``check_trades`` — right after the backtest produces a trade ledger;
+  verifies that every executed trade's symbol is inside
+  ``spec.target_symbols``.
+
+Critical failures from this gate cause the orchestrator to fail the run
+closed (``is_winning`` stays False) without attempting code refinement —
+a target-symbol mismatch is a spec/data issue, not something the LLM can
+fix by rewriting strategy code.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+from ...models import StrategySpec, TradeRecord
+from ...symbols import (
+    COMMODITY_SYMBOLS,
+    CRYPTO_SYMBOLS,
+    FOREX_SYMBOLS,
+    FOREX_SYMBOLS_BARE,
+    FUTURES_SYMBOLS,
+    FUTURES_SYMBOLS_BARE,
+    OTHER_SYMBOLS,
+    STOCK_SYMBOLS,
+)
+from .models import QualityGateResult
+
+GATE = "target_symbol_coverage"
+
+_KNOWN_TICKERS: frozenset[str] = frozenset(
+    s.upper()
+    for s in (
+        *STOCK_SYMBOLS,
+        *CRYPTO_SYMBOLS,
+        *COMMODITY_SYMBOLS,
+        *FOREX_SYMBOLS,
+        *FOREX_SYMBOLS_BARE,
+        *FUTURES_SYMBOLS,
+        *FUTURES_SYMBOLS_BARE,
+        *OTHER_SYMBOLS,
+    )
+)
+
+# Uppercase tokens 2-5 chars; conservative enough to skip common English words
+# while still catching tickers embedded in prose like "buy QQQ when ...".
+_TICKER_RE = re.compile(r"\b([A-Z]{2,5})\b")
+
+
+class TargetSymbolCoverageGate:
+    """Critical gate enforcing that the realized universe matches intent."""
+
+    def check_fetch(
+        self,
+        spec: StrategySpec,
+        requested_symbols: List[str],
+        fetched_symbols: List[str],
+    ) -> List[QualityGateResult]:
+        results: List[QualityGateResult] = []
+        fetched_upper = {s.strip().upper() for s in fetched_symbols if s and s.strip()}
+
+        if spec.target_symbols:
+            target_upper = {s.strip().upper() for s in spec.target_symbols if s and s.strip()}
+            missing = sorted(target_upper - fetched_upper)
+            if missing:
+                results.append(
+                    QualityGateResult(
+                        gate_name=GATE,
+                        passed=False,
+                        severity="critical",
+                        details=(
+                            "target_symbols missing from fetched market data: "
+                            f"{missing}. Requested={sorted({s.upper() for s in requested_symbols})}, "
+                            f"fetched={sorted(fetched_upper)}."
+                        ),
+                    )
+                )
+            else:
+                results.append(
+                    QualityGateResult(
+                        gate_name=GATE,
+                        passed=True,
+                        severity="info",
+                        details=f"All {len(target_upper)} target_symbols present in fetched data.",
+                    )
+                )
+        else:
+            mentioned = sorted(self._tickers_in_hypothesis(spec.hypothesis or ""))
+            if mentioned:
+                results.append(
+                    QualityGateResult(
+                        gate_name=GATE,
+                        passed=False,
+                        severity="warning",
+                        details=(
+                            f"Hypothesis mentions known ticker(s) {mentioned} but "
+                            "spec.target_symbols is empty; the backtest is using the "
+                            "asset-class default universe. Set spec.target_symbols "
+                            "explicitly to guarantee the run trades the intended tickers."
+                        ),
+                    )
+                )
+            else:
+                results.append(
+                    QualityGateResult(
+                        gate_name=GATE,
+                        passed=True,
+                        severity="info",
+                        details="spec.target_symbols empty; no specific tickers referenced in hypothesis.",
+                    )
+                )
+
+        return results
+
+    def check_trades(
+        self,
+        spec: StrategySpec,
+        trades: List[TradeRecord],
+    ) -> List[QualityGateResult]:
+        if not spec.target_symbols:
+            return [
+                QualityGateResult(
+                    gate_name=GATE,
+                    passed=True,
+                    severity="info",
+                    details="spec.target_symbols empty; trade-symbol coverage check skipped.",
+                )
+            ]
+
+        target_upper = {s.strip().upper() for s in spec.target_symbols if s and s.strip()}
+        offending = sorted({t.symbol.strip().upper() for t in trades if t.symbol} - target_upper)
+        if offending:
+            return [
+                QualityGateResult(
+                    gate_name=GATE,
+                    passed=False,
+                    severity="critical",
+                    details=(
+                        "Trade ledger contains symbols outside spec.target_symbols: "
+                        f"{offending}. target_symbols={sorted(target_upper)}."
+                    ),
+                )
+            ]
+
+        return [
+            QualityGateResult(
+                gate_name=GATE,
+                passed=True,
+                severity="info",
+                details=f"All {len(trades)} trades within target_symbols.",
+            )
+        ]
+
+    @staticmethod
+    def _tickers_in_hypothesis(text: str) -> set[str]:
+        return {tok for tok in _TICKER_RE.findall(text or "") if tok in _KNOWN_TICKERS}

--- a/backend/agents/investment_team/tests/test_target_symbol_coverage.py
+++ b/backend/agents/investment_team/tests/test_target_symbol_coverage.py
@@ -119,6 +119,19 @@ def test_check_fetch_warns_on_crypto_and_commodity_tickers_too() -> None:
         assert ticker in warnings[0].details
 
 
+def test_check_fetch_warns_on_forex_bare_names() -> None:
+    """6-char forex bare names (EURUSD/USDJPY) must still trigger the warning."""
+    gate = TargetSymbolCoverageGate()
+    spec = _spec(hypothesis="Long EURUSD when USDJPY breaks support.", target_symbols=[])
+
+    results = gate.check_fetch(spec, requested_symbols=["AAPL"], fetched_symbols=["AAPL"])
+
+    warnings = _warnings(results)
+    assert len(warnings) == 1
+    assert "EURUSD" in warnings[0].details
+    assert "USDJPY" in warnings[0].details
+
+
 def test_check_fetch_does_not_warn_when_target_symbols_set_even_if_hypothesis_mentions_ticker() -> (
     None
 ):

--- a/backend/agents/investment_team/tests/test_target_symbol_coverage.py
+++ b/backend/agents/investment_team/tests/test_target_symbol_coverage.py
@@ -1,0 +1,195 @@
+"""Issue #526 — TargetSymbolCoverageGate unit tests."""
+
+from __future__ import annotations
+
+from typing import List
+
+from investment_team.models import StrategySpec, TradeRecord
+from investment_team.strategy_lab.quality_gates.target_symbol_coverage import (
+    GATE,
+    TargetSymbolCoverageGate,
+)
+
+
+def _spec(
+    *, hypothesis: str = "Catch short-term momentum.", target_symbols: List[str] | None = None
+) -> StrategySpec:
+    return StrategySpec(
+        strategy_id="strat-coverage-test",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis=hypothesis,
+        signal_definition="sig",
+        entry_rules=[],
+        exit_rules=[],
+        risk_limits={"max_position_pct": 5, "max_drawdown_pct": 10},
+        speculative=False,
+        strategy_code="from contract import Strategy\nclass S(Strategy):\n    def on_bar(self, ctx, bar):\n        pass\n",
+        target_symbols=target_symbols or [],
+    )
+
+
+def _trade(symbol: str, trade_num: int = 1) -> TradeRecord:
+    return TradeRecord(
+        trade_num=trade_num,
+        entry_date="2024-01-02",
+        exit_date="2024-01-05",
+        symbol=symbol,
+        side="long",
+        entry_price=100.0,
+        exit_price=105.0,
+        shares=10.0,
+        position_value=1000.0,
+        gross_pnl=50.0,
+        net_pnl=49.0,
+        return_pct=5.0,
+        hold_days=3,
+        outcome="win",
+        cumulative_pnl=49.0,
+    )
+
+
+def _criticals(results):
+    return [r for r in results if not r.passed and r.severity == "critical"]
+
+
+def _warnings(results):
+    return [r for r in results if not r.passed and r.severity == "warning"]
+
+
+# ── check_fetch ──────────────────────────────────────────────────────────
+
+
+def test_check_fetch_passes_when_target_symbols_subset_of_fetched() -> None:
+    gate = TargetSymbolCoverageGate()
+    spec = _spec(target_symbols=["QQQ", "SPY"])
+
+    results = gate.check_fetch(
+        spec, requested_symbols=["QQQ", "SPY"], fetched_symbols=["QQQ", "SPY", "IWM"]
+    )
+
+    assert _criticals(results) == []
+    assert any(r.passed and r.gate_name == GATE for r in results)
+
+
+def test_check_fetch_critical_when_target_symbol_missing_from_fetched() -> None:
+    gate = TargetSymbolCoverageGate()
+    spec = _spec(target_symbols=["QQQ", "SPY"])
+
+    results = gate.check_fetch(spec, requested_symbols=["QQQ", "SPY"], fetched_symbols=["QQQ"])
+
+    criticals = _criticals(results)
+    assert len(criticals) == 1
+    assert "SPY" in criticals[0].details
+    assert criticals[0].gate_name == GATE
+
+
+def test_check_fetch_passes_when_target_symbols_empty_and_no_ticker_in_hypothesis() -> None:
+    gate = TargetSymbolCoverageGate()
+    spec = _spec(hypothesis="Catch short-term momentum across the market.", target_symbols=[])
+
+    results = gate.check_fetch(spec, requested_symbols=["AAPL"], fetched_symbols=["AAPL"])
+
+    assert _criticals(results) == []
+    assert _warnings(results) == []
+    assert any(r.passed for r in results)
+
+
+def test_check_fetch_warns_when_hypothesis_mentions_ticker_but_target_symbols_empty() -> None:
+    gate = TargetSymbolCoverageGate()
+    spec = _spec(hypothesis="Trade QQQ on RSI oversold breakouts.", target_symbols=[])
+
+    results = gate.check_fetch(
+        spec, requested_symbols=["AAPL", "TSLA"], fetched_symbols=["AAPL", "TSLA"]
+    )
+
+    warnings = _warnings(results)
+    assert len(warnings) == 1
+    assert "QQQ" in warnings[0].details
+    assert "target_symbols" in warnings[0].details
+
+
+def test_check_fetch_warns_on_crypto_and_commodity_tickers_too() -> None:
+    gate = TargetSymbolCoverageGate()
+    for ticker in ("BTC", "GLD"):
+        spec = _spec(hypothesis=f"Long {ticker} on volume spikes.", target_symbols=[])
+        results = gate.check_fetch(spec, requested_symbols=["AAPL"], fetched_symbols=["AAPL"])
+        warnings = _warnings(results)
+        assert len(warnings) == 1, f"expected warning for {ticker}, got {warnings}"
+        assert ticker in warnings[0].details
+
+
+def test_check_fetch_does_not_warn_when_target_symbols_set_even_if_hypothesis_mentions_ticker() -> (
+    None
+):
+    gate = TargetSymbolCoverageGate()
+    spec = _spec(hypothesis="Trade QQQ on RSI oversold breakouts.", target_symbols=["QQQ"])
+
+    results = gate.check_fetch(spec, requested_symbols=["QQQ"], fetched_symbols=["QQQ"])
+
+    assert _warnings(results) == []
+    assert _criticals(results) == []
+
+
+def test_check_fetch_case_insensitive_match() -> None:
+    gate = TargetSymbolCoverageGate()
+    spec = _spec(target_symbols=["QQQ"])
+
+    results = gate.check_fetch(spec, requested_symbols=["qqq"], fetched_symbols=["qqq"])
+
+    assert _criticals(results) == []
+
+
+# ── check_trades ────────────────────────────────────────────────────────
+
+
+def test_check_trades_passes_when_every_trade_symbol_in_target_symbols() -> None:
+    gate = TargetSymbolCoverageGate()
+    spec = _spec(target_symbols=["QQQ", "SPY"])
+
+    results = gate.check_trades(spec, trades=[_trade("QQQ"), _trade("SPY", trade_num=2)])
+
+    assert _criticals(results) == []
+    assert any(r.passed for r in results)
+
+
+def test_check_trades_critical_when_trade_symbol_outside_target_symbols() -> None:
+    gate = TargetSymbolCoverageGate()
+    spec = _spec(target_symbols=["QQQ"])
+
+    results = gate.check_trades(spec, trades=[_trade("QQQ"), _trade("AAPL", trade_num=2)])
+
+    criticals = _criticals(results)
+    assert len(criticals) == 1
+    assert "AAPL" in criticals[0].details
+    assert criticals[0].gate_name == GATE
+
+
+def test_check_trades_info_when_target_symbols_empty() -> None:
+    gate = TargetSymbolCoverageGate()
+    spec = _spec(target_symbols=[])
+
+    results = gate.check_trades(spec, trades=[_trade("AAPL")])
+
+    assert _criticals(results) == []
+    assert _warnings(results) == []
+    assert all(r.passed and r.severity == "info" for r in results)
+
+
+def test_check_trades_case_insensitive_match() -> None:
+    gate = TargetSymbolCoverageGate()
+    spec = _spec(target_symbols=["qqq"])  # normaliser uppercases this, but be defensive
+
+    results = gate.check_trades(spec, trades=[_trade("QQQ")])
+
+    assert _criticals(results) == []
+
+
+def test_check_trades_empty_ledger_passes() -> None:
+    gate = TargetSymbolCoverageGate()
+    spec = _spec(target_symbols=["QQQ"])
+
+    results = gate.check_trades(spec, trades=[])
+
+    assert _criticals(results) == []
+    assert any(r.passed for r in results)


### PR DESCRIPTION
Closes #526.

## Summary

Adds `TargetSymbolCoverageGate` — a critical Strategy Lab quality gate that fails the cycle closed when the realized backtest universe diverges from what the hypothesis asked for. Without it, a strategy saying "QQQ" can silently backtest on the asset-class default universe (TSLA/AAPL/…) and ship as a "winning strategy" about tickers the user never requested.

## What changed

**New gate** — `backend/agents/investment_team/strategy_lab/quality_gates/target_symbol_coverage.py`

Two public methods so the orchestrator can call them at two distinct points without a dummy `trades=None` arg:

- `check_fetch(spec, requested_symbols, fetched_symbols)` — covers scenarios (1) and (3) from the issue:
  - critical failure when any entry in `spec.target_symbols` is missing from `fetched_symbols`
  - warning when `spec.target_symbols` is empty but the hypothesis text mentions a known ticker (intersection of `STOCK_SYMBOLS ∪ CRYPTO_SYMBOLS ∪ COMMODITY_SYMBOLS ∪ FOREX_SYMBOLS ∪ FUTURES_SYMBOLS ∪ OTHER_SYMBOLS` from `investment_team/symbols.py`)
- `check_trades(spec, trades)` — covers scenario (2): critical failure when any `trade.symbol` is outside `spec.target_symbols`

**Orchestrator wiring** — `backend/agents/investment_team/strategy_lab/orchestrator.py`

- Instantiated alongside `BacktestAnomalyDetector` per the issue.
- `check_fetch` fires right after `_fetch_market_data` returns. Critical failures `break` the refinement loop the same way the existing no-market-data branch does (`orchestrator.py:572-582`).
- `check_trades` fires right after `trades = exec_result.trades`. Critical failures set `max_rounds_exhausted=True` so `execution_succeeded` stays `False`, which leaves `is_winning=False` at the acceptance gate (`orchestrator.py:1141-1142`). No refinement attempt — the LLM cannot fix a symbol/spec mismatch by rewriting strategy code.

Both gate results land in `StrategyLabRecord.quality_gate_history` via the existing `all_gate_results` plumbing, so the failure is queryable on persisted records.

## Acceptance criteria

- [x] Gate exists with tests for all three scenarios from the issue (12 tests total).
- [x] Critical failure rejects the cycle; orchestrator does not mark `is_winning=True` on coverage failure.
- [x] Quality-gate history on the persisted record shows the failure.

## Test plan

- [x] `pytest agents/investment_team/tests/test_target_symbol_coverage.py` — 12/12 pass
- [x] `pytest agents/investment_team/tests/` — 1328 pass, 9 skipped (no regressions from the orchestrator wiring)
- [x] `ruff check` + `ruff format --check` on changed files — clean
- [ ] CI green on this PR

https://claude.ai/code/session_01NXXuQ9jKPQjrJsEHDDaY7L

---
_Generated by [Claude Code](https://claude.ai/code/session_01NXXuQ9jKPQjrJsEHDDaY7L)_