### PR TITLE
investment-team: lock in #553 prose-join regression guard

### DIFF
--- a/backend/agents/investment_team/tests/test_no_prose_rule_joins.py
+++ b/backend/agents/investment_team/tests/test_no_prose_rule_joins.py
@@ -1,0 +1,69 @@
+"""Regression guard for issue #553.
+
+After the #537 structured-`StrategySpec` DSL migration landed in PR #563
+(commit ``f382a66``), every agent-prompt formatter renders rule lists via
+``format_rules_for_prompt(...)`` / ``format_sizing_rule(...)`` from
+``backend/agents/investment_team/strategy_lab/spec_dsl.py``. Reintroducing
+``", ".join(spec.entry_rules)`` (or ``strategy.entry_rules``, or the ``exit``
+or ``sizing`` variants) would silently call ``str()`` on Pydantic model
+instances and produce garbage prompts. This test asserts no such call exists
+in the team's product source.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_INVESTMENT_ROOT = Path(__file__).resolve().parent.parent
+
+_FORBIDDEN_RE = re.compile(r"\.join\(\s*(?:spec|strategy)\.(?:entry|exit|sizing)_rules\b")
+
+_EXCLUDE_DIRS = {"tests", "__pycache__"}
+_EXCLUDE_FILES = {"spec_dsl.py"}  # docstring documents the anti-pattern
+
+
+def _iter_source_files() -> list[Path]:
+    return [
+        p
+        for p in _INVESTMENT_ROOT.rglob("*.py")
+        if not (set(p.relative_to(_INVESTMENT_ROOT).parts) & _EXCLUDE_DIRS)
+        and p.name not in _EXCLUDE_FILES
+    ]
+
+
+def test_no_prose_rule_joins_in_source() -> None:
+    offenders: list[str] = []
+    for path in _iter_source_files():
+        for lineno, line in enumerate(path.read_text().splitlines(), start=1):
+            if _FORBIDDEN_RE.search(line):
+                offenders.append(f"{path.relative_to(_INVESTMENT_ROOT)}:{lineno}: {line.strip()}")
+
+    assert not offenders, (
+        "Prose-join of structured rule lists reintroduced (issue #553 regression). "
+        "Use format_rules_for_prompt(...) / format_sizing_rule(...) from "
+        "investment_team.strategy_lab.spec_dsl instead.\n  " + "\n  ".join(offenders)
+    )
+
+
+def test_guard_regex_matches_known_violations() -> None:
+    violations = [
+        '", ".join(spec.entry_rules)',
+        '"; ".join(spec.exit_rules)',
+        ", ".join(['"; "']) + ".join(spec.sizing_rules)",
+        '", ".join(strategy.entry_rules)',
+        '"; ".join(strategy.exit_rules)',
+    ]
+    for v in violations:
+        assert _FORBIDDEN_RE.search(v), f"guard regex failed to match: {v!r}"
+
+
+def test_guard_regex_ignores_helper_usage() -> None:
+    safe_lines = [
+        "entry_rules=format_rules_for_prompt(spec.entry_rules)",
+        'exit_rules=format_rules_for_prompt(strategy.exit_rules, separator="; ")',
+        "sizing_rules=format_sizing_rule(spec.sizing)",
+        "rules = spec.entry_rules + spec.exit_rules",
+    ]
+    for line in safe_lines:
+        assert not _FORBIDDEN_RE.search(line), f"guard regex false-positive on: {line!r}"


### PR DESCRIPTION
## Summary

Closes #553.

Issue #553 ("step 5: rewrite 7 prose-join consumers to use `format_rules_for_prompt`") landed as part of the structured-`StrategySpec`-DSL migration in commit `f382a66` (PR #563), which already replaced every `", ".join(spec.entry_rules)` / `"; ".join(...)` / `", ".join(spec.sizing_rules)` site in the seven listed files with `format_rules_for_prompt(...)` / `format_sizing_rule(...)` from `investment_team.strategy_lab.spec_dsl`. The issue's acceptance grep returns zero hits today:

```bash
grep -rn 'join(spec\.\(entry\|exit\|sizing\)_rules' backend/agents/investment_team --include='*.py'
# (no matches)
```

…and the relevant strategy-lab test suite is green (`test_strategy_lab_*.py`, `test_agent_prompts_structured.py`, `test_spec_dsl.py` — 108 passing locally).

But #553 stayed open — the `closes` keyword in `f382a66`'s message did not auto-close the issue. This PR closes it out and locks in the migration with a small regression-guard test.

## Changes

- **New** `backend/agents/investment_team/tests/test_no_prose_rule_joins.py` — walks the team's product source and asserts no `.join((spec|strategy)\.(entry|exit|sizing)_rules)` pattern is reintroduced. Also exercises the guard regex against known violations and known-safe helper usage so future edits to the regex stay correct.

No production code changes.

## Test plan

- [x] `pytest backend/agents/investment_team/tests/test_no_prose_rule_joins.py -v` → 3/3 pass
- [x] `pytest backend/agents/investment_team/tests/test_strategy_lab_*.py test_agent_prompts_structured.py test_spec_dsl.py -q` → 108/108 pass
- [x] `ruff check` + `ruff format --check` clean on the new file
- [x] Acceptance grep from #553 is empty

---
_Generated by [Claude Code](https://claude.ai/code/session_01FVSEk862jzhpUFHKHmMBhk)_