### PR TITLE
investment-team: review polish for #528 (follow-up to #570)

### DIFF
--- a/backend/agents/investment_team/strategy_lab/agents/alignment.py
+++ b/backend/agents/investment_team/strategy_lab/agents/alignment.py
@@ -131,6 +131,10 @@ class TradeAlignmentAgent:
         loop on a malformed LLM response (the fallback rationale records the
         parse error).
         """
+        # Loaded raw on purpose — alignment_system.md contains literal `{...}`
+        # in the `UNIVERSE = frozenset({...})` example, so it must not pass
+        # through `str.format`. The user template (`_ALIGNMENT_USER_TEMPLATE`)
+        # is what carries the placeholders that get formatted below.
         system_prompt = (_PROMPT_DIR / "alignment_system.md").read_text(encoding="utf-8")
 
         prior_text = (

--- a/backend/agents/investment_team/tests/test_analysis_alignment_prompts.py
+++ b/backend/agents/investment_team/tests/test_analysis_alignment_prompts.py
@@ -25,6 +25,7 @@ formatters is caught by this test.
 from __future__ import annotations
 
 import re
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -108,7 +109,9 @@ def _render_alignment_system() -> str:
     return (_PROMPT_DIR / "alignment_system.md").read_text(encoding="utf-8")
 
 
-_RENDERERS: dict[str, tuple[str, callable]] = {
+_PromptRenderer = Callable[[], str]
+
+_RENDERERS: dict[str, tuple[str, _PromptRenderer]] = {
     "prompt_analysis_win.txt": ("analysis_win", _render_win),
     "prompt_analysis_lose.txt": ("analysis_lose", _render_lose),
     "prompt_alignment_system.txt": ("alignment_system", _render_alignment_system),
@@ -117,11 +120,10 @@ _RENDERERS: dict[str, tuple[str, callable]] = {
 
 @pytest.mark.parametrize(
     "golden_filename,label,renderer",
-    [(f, label, fn) for f, (label, fn) in _RENDERERS.items()],
-    ids=[label for _, (label, _) in _RENDERERS.items()],
+    [pytest.param(filename, label, fn, id=label) for filename, (label, fn) in _RENDERERS.items()],
 )
 def test_rendered_prompt_matches_golden(
-    golden_filename: str, label: str, renderer: callable
+    golden_filename: str, label: str, renderer: _PromptRenderer
 ) -> None:
     """Rendered prompt MUST match the on-disk golden byte-for-byte.
 
@@ -139,11 +141,13 @@ def test_rendered_prompt_matches_golden(
 @pytest.mark.parametrize(
     "label,renderer",
     [
-        ("analysis_win", _render_win),
-        ("analysis_lose", _render_lose),
+        pytest.param("analysis_win", _render_win, id="analysis_win"),
+        pytest.param("analysis_lose", _render_lose, id="analysis_lose"),
     ],
 )
-def test_analysis_prompts_have_intended_not_enforced_label(label: str, renderer: callable) -> None:
+def test_analysis_prompts_have_intended_not_enforced_label(
+    label: str, renderer: _PromptRenderer
+) -> None:
     """Issue #528: prose rules must be labelled as intent, not enforced behaviour."""
     rendered = renderer()
     assert "may not all be machine-enforced" in rendered, (
@@ -176,12 +180,14 @@ def test_alignment_prompt_splits_enforced_and_aspirational() -> None:
 @pytest.mark.parametrize(
     "label,renderer",
     [
-        ("analysis_win", _render_win),
-        ("analysis_lose", _render_lose),
-        ("alignment_system", _render_alignment_system),
+        pytest.param("analysis_win", _render_win, id="analysis_win"),
+        pytest.param("analysis_lose", _render_lose, id="analysis_lose"),
+        pytest.param("alignment_system", _render_alignment_system, id="alignment_system"),
     ],
 )
-def test_prompts_do_not_use_mandatory_or_hard_rule_phrasing(label: str, renderer: callable) -> None:
+def test_prompts_do_not_use_mandatory_or_hard_rule_phrasing(
+    label: str, renderer: _PromptRenderer
+) -> None:
     """Issue #528: drop 'mandatory' / 'hard rule' phrasing across all three prompts."""
     rendered = renderer().lower()
     forbidden = ["mandatory", "hard rule", "hard-enforced"]
@@ -190,6 +196,22 @@ def test_prompts_do_not_use_mandatory_or_hard_rule_phrasing(label: str, renderer
         f"{label} prompt still contains forbidden phrasing {offenders} "
         "(issue #528 — prose rules are not engine-enforced)."
     )
+
+
+def test_alignment_prompt_keeps_severity_and_rule_type_enums_intact() -> None:
+    """Issue #528 stops short of touching the alignment JSON schema. The
+    severity/rule_type enums must stay exactly as the orchestrator's parsers
+    expect, otherwise alignment-loop tests start failing. Guard the literal
+    enum strings inside the JSON example block.
+    """
+    rendered = _render_alignment_system()
+    assert '"severity": "info" | "warning" | "critical"' in rendered, (
+        "alignment_system.md must keep the severity enum as info|warning|critical."
+    )
+    assert (
+        '"rule_type": "entry_rules" | "exit_rules" | "sizing_rules" | '
+        '"risk_limits" | "universe" | "direction"' in rendered
+    ), "alignment_system.md must keep the rule_type enum unchanged."
 
 
 def test_alignment_prompt_drops_all_count_as_misalignment() -> None:


### PR DESCRIPTION
## Summary

Follow-up to #570 (merged as 2089685e). The original PR shipped a P0 stopgap for #528 — analysis/alignment prompt rewording so the LLM stops policing prose `entry_rules` / `exit_rules` as machine-enforced. After a self-review on that PR I queued four small improvements as a follow-up commit, but #570 was merged + branch deleted before the polish commit made it in. This PR re-applies just those polish changes.

## Changes

- **`callable` → `Callable[[], str]`** (declared as `_PromptRenderer` typedef in the test file). The original `callable` was the Python builtin, not a real annotation — pyright/mypy would flag it.
- **`pytest.param(..., id=...)` on every parametrize** — test IDs now read as `[analysis_win]` instead of the noisy `[analysis_win-_render_win]`.
- **New `test_alignment_prompt_keeps_severity_and_rule_type_enums_intact`** — guards the literal `severity` (`info | warning | critical`) and `rule_type` enum strings inside the JSON example block, since #570 intentionally left those untouched and the orchestrator's `_coerce_report` parsers depend on them.
- **Code comment on `alignment.py` line 134** — flags that `alignment_system.md` is loaded raw on purpose (it contains literal `{...}` in the `UNIVERSE = frozenset({...})` example so it must not pass through `str.format`).

No prompt-text changes; goldens unaffected.

## Test plan

- [x] `pytest agents/investment_team/tests/test_analysis_alignment_prompts.py agents/investment_team/tests/test_strategy_lab_alignment.py` — 24 passed
- [x] `ruff check` + `ruff format --check` on changed paths — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01TgQSj8Do6gfmmME2hFTXCb)_