### PR TITLE
jobs-dashboard: add live-refresh indicator next to "Updated" timestamp (#489)

### DIFF
--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.html
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.html
@@ -6,7 +6,10 @@
     </div>
     <div class="header-actions">
       @if (lastUpdated) {
-        <span class="last-updated">Updated {{ lastUpdated | date:'shortTime' }}</span>
+        <span class="last-updated" matTooltip="Auto-refreshes every 20 seconds">
+          <span class="live-dot" [class.is-paused]="!isPollingActive" aria-hidden="true"></span>
+          Updated {{ lastUpdated | date:'shortTime' }}
+        </span>
       }
       <button mat-icon-button (click)="refresh()" [disabled]="loading" matTooltip="Refresh jobs" aria-label="Refresh jobs">
         <mat-icon [class.spinning]="loading">refresh</mat-icon>

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
@@ -38,9 +38,26 @@
     gap: var(--kh-space-3);
 
     .last-updated {
+      display: inline-flex;
+      align-items: center;
+      gap: var(--kh-space-2);
       font-size: var(--kh-text-xs);
       color: var(--kh-text-secondary);
       font-family: var(--kh-font-mono);
+    }
+
+    .live-dot {
+      width: 6px;
+      height: 6px;
+      border-radius: 50%;
+      background: var(--kh-success);
+      animation: kh-pulse-live 2s ease-in-out infinite;
+      flex-shrink: 0;
+
+      &.is-paused {
+        animation: none;
+        opacity: 0.45;
+      }
     }
   }
 }
@@ -334,8 +351,14 @@
   50%      { opacity: 1; }
 }
 
+@keyframes kh-pulse-live {
+  0%, 100% { opacity: 0.55; }
+  50%      { opacity: 1; }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .stuck-indicator { animation: none; opacity: 1; }
+  .live-dot        { animation: none; opacity: 1; }
 }
 
 // ── Column Widths ───────────────────────────────────────────────────────────

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts
@@ -1185,4 +1185,37 @@ describe('JobsDashboardComponent', () => {
       expect(jobActionsSpy.delete).not.toHaveBeenCalled();
     });
   });
+
+  describe('live-refresh indicator', () => {
+    it('renders a pulsing live-dot next to the timestamp once lastUpdated is set', () => {
+      component.lastUpdated = new Date();
+      fixture.detectChanges();
+
+      const host = fixture.nativeElement as HTMLElement;
+      const lastUpdated = host.querySelector('.last-updated');
+      expect(lastUpdated).not.toBeNull();
+      // ng-reflect-message is set by MatTooltip in dev builds. Use a substring
+      // match — Angular's reflect-attribute serialization can drop trailing
+      // characters across runtimes, so anchoring on the stable prefix is more
+      // robust than a full string compare.
+      expect(lastUpdated?.getAttribute('ng-reflect-message') ?? '').toContain('Auto-refreshes every 20 second');
+
+      const dot = host.querySelector('.last-updated .live-dot');
+      expect(dot).not.toBeNull();
+      expect(dot?.classList.contains('is-paused')).toBe(false);
+      expect(dot?.getAttribute('aria-hidden')).toBe('true');
+    });
+
+    it('marks the live-dot as paused when the component is in an error state', () => {
+      component.lastUpdated = new Date();
+      component.error = 'boom';
+      fixture.detectChanges();
+
+      const host = fixture.nativeElement as HTMLElement;
+      const dot = host.querySelector('.last-updated .live-dot');
+      expect(dot).not.toBeNull();
+      expect(dot?.classList.contains('is-paused')).toBe(true);
+      expect(component.isPollingActive).toBe(false);
+    });
+  });
 });

--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.ts
@@ -189,13 +189,33 @@ export class JobsDashboardComponent implements OnInit, OnDestroy {
   /** Per-job progress history used by isStuck(). Key = `${source}::${jobId}`. */
   private progressHistory = new Map<string, ProgressSample>();
 
+  /** Tracks whether the browser tab is hidden so the live-refresh dot can
+   *  pause its pulse — polling itself still fires, but the visual signal
+   *  reflects that the user isn't actively watching. */
+  private isTabHidden = false;
+  private readonly onVisibilityChange = (): void => {
+    this.isTabHidden = typeof document !== 'undefined' && document.hidden;
+  };
+
+  /** Drives the live-refresh dot: pulses when true, static when polling
+   *  is effectively suspended (error state or tab hidden). */
+  get isPollingActive(): boolean {
+    return !this.error && !this.isTabHidden;
+  }
+
   ngOnInit(): void {
     this.loadFilters();
     this.startPolling();
+    if (typeof document !== 'undefined') {
+      document.addEventListener('visibilitychange', this.onVisibilityChange);
+    }
   }
 
   ngOnDestroy(): void {
     this.pollSub?.unsubscribe();
+    if (typeof document !== 'undefined') {
+      document.removeEventListener('visibilitychange', this.onVisibilityChange);
+    }
   }
 
   private startPolling(): void {


### PR DESCRIPTION
Closes #489.

## Summary

A small pulsing green dot now sits next to the "Updated HH:MM" timestamp on the Jobs Dashboard so operators can tell at a glance that auto-refresh is active. The dot goes static (and dims to 0.45 opacity) when polling is effectively suspended — either because the last fetch errored or the browser tab is hidden — and falls back to a non-animated dot under `prefers-reduced-motion`. The timestamp now carries an `Auto-refreshes every 20 seconds` tooltip.

## Changes

`user-interface/src/app/components/jobs-dashboard/`:

- **`*.component.html`** — wrap the timestamp in a flex container with a `.live-dot` span; bind `.is-paused` to `!isPollingActive`; attach `matTooltip="Auto-refreshes every 20 seconds"`. Dot is `aria-hidden="true"` (the meaning is conveyed by the timestamp + tooltip).
- **`*.component.scss`** — `.last-updated` becomes `inline-flex` with a `var(--kh-space-2)` gap; new `.live-dot` rule (6px, `var(--kh-success)`, `kh-pulse-live` 2s animation) plus an `.is-paused` modifier; new `@keyframes kh-pulse-live`; extended `@media (prefers-reduced-motion: reduce)` rule (mirrors the existing `.stuck-indicator` / `kh-stuck-pulse` pattern at lines 332-339 — no new conventions).
- **`*.component.ts`** — track `document.hidden` via a `visibilitychange` listener attached in `ngOnInit` / detached in `ngOnDestroy`; expose an `isPollingActive` getter (`!error && !isTabHidden`). Polling cadence is unchanged.
- **`*.component.spec.ts`** — two new tests: (1) dot renders with tooltip text and `aria-hidden="true"`, (2) `.is-paused` toggles on when `error` is set.

## Acceptance criteria (from #489)

- [x] Pulsing dot rendered next to "Updated".
- [x] `prefers-reduced-motion` respected — replace pulse with a static green dot.
- [x] Tooltip explains the polling interval.

## Test plan

- [x] `npx vitest run src/app/components/jobs-dashboard/jobs-dashboard.component.spec.ts` — 81/81 pass (including 2 new).
- [x] `npx vitest run src/app/components/jobs-dashboard/jobs-dashboard.component.a11y.spec.ts` — 2/2 pass (axe, no new violations).
- [x] `npx ng build --configuration=production` — succeeds (pre-existing bundle-size warning unrelated).
- [ ] Manual: `npm start`, navigate to Jobs Dashboard, confirm pulsing dot; hover timestamp for tooltip; switch tabs and back (dot pauses while hidden); stop the unified API and watch error state pause/dim the dot.
- [ ] Manual: enable Chrome devtools "Emulate CSS prefers-reduced-motion: reduce" — dot is solid, no animation.


---
_Generated by [Claude Code](https://claude.ai/code/session_01MCQRN3dEDhNbcT9yYNGLrd)_