### PR TITLE
investment-team: gate is_winning on trade-alignment + drop legacy threshold path (#529)

### DIFF
--- a/backend/agents/investment_team/models.py
+++ b/backend/agents/investment_team/models.py
@@ -796,7 +796,7 @@ class StrategyLabRecord(BaseModel):
     lab_record_id: str
     strategy: StrategySpec
     backtest: BacktestRecord
-    is_winning: bool  # annualized_return_pct > 8.0
+    is_winning: bool  # walk-forward acceptance gate (or fallback) AND alignment veto (#247, #529)
     strategy_rationale: str  # why the agent chose this strategy
     analysis_narrative: str  # LLM post-backtest analysis
     created_at: str

--- a/backend/agents/investment_team/strategy_lab/agents/analysis.py
+++ b/backend/agents/investment_team/strategy_lab/agents/analysis.py
@@ -6,7 +6,7 @@ import json
 import logging
 import re
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from strands import Agent
 
@@ -60,15 +60,23 @@ class AnalysisAgent:
         trades: List[TradeRecord],
         rationale: str,
         on_sub_phase: Any = None,
+        is_winning: Optional[bool] = None,
     ) -> str:
         """Produce a polished analysis narrative via draft + self-review.
 
         Args:
             on_sub_phase: Optional callback ``(sub_phase: str) -> None`` for progress.
+            is_winning: Authoritative verdict from the orchestrator. When None,
+                falls back to the legacy metric-only heuristic; callers that
+                resolve ``is_winning`` against the alignment loop / acceptance
+                gate / fallback anomalies (#529) must pass it explicitly so the
+                narrative template and ``outcome_label`` match the persisted
+                ``StrategyLabRecord.is_winning``.
 
         Returns the final narrative string.
         """
-        is_winning = metrics.annualized_return_pct > 8.0
+        if is_winning is None:
+            is_winning = metrics.annualized_return_pct > 8.0
         trades_summary = _format_simulated_trades_summary(trades)
 
         # Phase 1: Draft

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -1237,7 +1237,12 @@ class StrategyLabOrchestrator:
                     emit("analyzing", {"sub_phase": sub})
 
                 narrative = self.analysis_agent.run(
-                    spec, metrics, trades, rationale, on_sub_phase=_on_analysis_sub
+                    spec,
+                    metrics,
+                    trades,
+                    rationale,
+                    on_sub_phase=_on_analysis_sub,
+                    is_winning=is_winning,
                 )
                 emit("analyzing", {"sub_phase": "completed", "is_winning": is_winning})
             except Exception:

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -1293,8 +1293,13 @@ class StrategyLabOrchestrator:
             # delimiter (not ``"; "``, which ``summarize_acceptance_reason``
             # uses internally between failing gates) so downstream parsers
             # can disambiguate the alignment boundary from gate boundaries.
-            if metrics.acceptance_reason and not upstream_admitted:
-                combined = f"{metrics.acceptance_reason} | {reason_suffix}"
+            # Use the stripped form so a whitespace-only upstream reason
+            # (None, "", "   ", "\n") collapses to the alignment suffix
+            # alone — never produces ``"   | alignment_failed: ..."`` with
+            # an empty left side.
+            prior_reason = (metrics.acceptance_reason or "").strip()
+            if prior_reason and not upstream_admitted:
+                combined = f"{prior_reason} | {reason_suffix}"
             else:
                 combined = reason_suffix
             metrics = metrics.model_copy(update={"acceptance_reason": combined})
@@ -1942,6 +1947,20 @@ class StrategyLabOrchestrator:
         """
         now_iso = datetime.now(timezone.utc).isoformat()
 
+        # Mirror the short-circuit cause onto ``acceptance_reason`` so the
+        # persisted record self-documents — consistent with the Gap 4/8/7/9
+        # audit-trail messages set on the main publication path (#529).
+        # ``short_circuit_status`` carries a ``"failed: <cause>"`` prefix at
+        # every current call site; strip it so the resulting field reads
+        # ``"publication_disabled: <cause>"``.
+        short_circuit_metrics = compute_metrics(
+            [], config.initial_capital, config.start_date, config.end_date
+        )
+        status_suffix = short_circuit_status.removeprefix("failed: ") or short_circuit_status
+        short_circuit_metrics = short_circuit_metrics.model_copy(
+            update={"acceptance_reason": f"publication_disabled: {status_suffix}"}
+        )
+
         backtest_record = BacktestRecord(
             backtest_id=f"bt-{uuid.uuid4().hex[:8]}",
             strategy_id=spec.strategy_id,
@@ -1951,7 +1970,7 @@ class StrategyLabOrchestrator:
             submitted_at=now_iso,
             completed_at=now_iso,
             status=short_circuit_status,
-            result=compute_metrics([], config.initial_capital, config.start_date, config.end_date),
+            result=short_circuit_metrics,
             trades=[],
         )
 

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -1271,9 +1271,16 @@ class StrategyLabOrchestrator:
         # ``alignment_failed`` suffix would be misleading.
         if execution_succeeded and trades and alignment_reports and not trades_aligned:
             last_report = alignment_reports[-1]
-            rationale = (last_report.rationale or "").strip()
-            if rationale:
-                reason_suffix = f"alignment_failed: {rationale}"
+            # NOTE: do NOT name this ``rationale`` — that shadows the
+            # strategy-rationale string bound earlier from the ideation
+            # agent (and used positionally when calling
+            # ``self.analysis_agent.run`` plus persisted on
+            # ``StrategyLabRecord.strategy_rationale``). Shadowing would
+            # silently corrupt both the analysis prompt and the audit
+            # record on every alignment-failure path.
+            align_rationale = (last_report.rationale or "").strip()
+            if align_rationale:
+                reason_suffix = f"alignment_failed: {align_rationale}"
             else:
                 reason_suffix = "alignment_failed: trades did not implement strategy spec"
             # When the upstream gate admitted the run (acceptance fully

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -1214,9 +1214,14 @@ class StrategyLabOrchestrator:
         # ``all_gate_results`` (appended per alignment round above); this
         # mirrors the signal onto ``BacktestResult.acceptance_reason``
         # without overwriting any prior walk-forward acceptance summary.
-        if execution_succeeded and trades and not trades_aligned:
-            last_report = alignment_reports[-1] if alignment_reports else None
-            if last_report is not None and last_report.rationale:
+        # ``alignment_reports`` is in the guard so we only attribute the
+        # rejection to alignment when the audit actually ran — the loop is
+        # skipped entirely when ``market_data is None``, in which case
+        # ``trades_aligned`` is False for unrelated reasons and an
+        # ``alignment_failed`` suffix would be misleading.
+        if execution_succeeded and trades and alignment_reports and not trades_aligned:
+            last_report = alignment_reports[-1]
+            if last_report.rationale:
                 reason_suffix = f"alignment_failed: {last_report.rationale}"
             else:
                 reason_suffix = "alignment_failed: trades did not implement strategy spec"

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -1179,10 +1179,9 @@ class StrategyLabOrchestrator:
         # annualized-return scalar with no DSR correction is not a
         # publication gate. Runs configured without walk-forward still
         # execute and generate a narrative, but cannot be marked winning.
+        acceptance_passed = bool(acceptance_results) and all(r.passed for r in acceptance_results)
         if acceptance_results:
-            is_winning = (
-                execution_succeeded and all(r.passed for r in acceptance_results) and trades_aligned
-            )
+            is_winning = execution_succeeded and acceptance_passed and trades_aligned
         elif walk_forward_failed and execution_succeeded:
             fallback_anomalies = self.anomaly_detector.check(
                 metrics,
@@ -1206,14 +1205,31 @@ class StrategyLabOrchestrator:
                 all_gate_results.extend(fallback_anomalies)
         else:
             is_winning = False
+            # Gap-4 audit trail: ``walk_forward_enabled=False`` runs still
+            # execute and generate a narrative but cannot publish through
+            # the removed legacy path (#529). Without this entry, the
+            # persisted record would show ``is_winning=False`` with no
+            # ``acceptance_reason`` explaining why. Only set when the run
+            # actually completed — execution failures already log their
+            # own gate details and ``acceptance_reason`` would mislead.
+            if (
+                execution_succeeded
+                and trades
+                and not config.walk_forward_enabled
+                and not metrics.acceptance_reason
+            ):
+                metrics = metrics.model_copy(
+                    update={
+                        "acceptance_reason": ("publication_disabled: walk_forward_enabled=False")
+                    }
+                )
 
         # Surface the alignment-failure cause on ``acceptance_reason`` so
         # the audit trail explains why publication was blocked even when
         # the acceptance gate / threshold otherwise passed (#529). The
         # ``trade_alignment`` QualityGateResult already lives in
         # ``all_gate_results`` (appended per alignment round above); this
-        # mirrors the signal onto ``BacktestResult.acceptance_reason``
-        # without overwriting any prior walk-forward acceptance summary.
+        # mirrors the signal onto ``BacktestResult.acceptance_reason``.
         # ``alignment_reports`` is in the guard so we only attribute the
         # rejection to alignment when the audit actually ran — the loop is
         # skipped entirely when ``market_data is None``, in which case
@@ -1221,15 +1237,24 @@ class StrategyLabOrchestrator:
         # ``alignment_failed`` suffix would be misleading.
         if execution_succeeded and trades and alignment_reports and not trades_aligned:
             last_report = alignment_reports[-1]
-            if last_report.rationale:
-                reason_suffix = f"alignment_failed: {last_report.rationale}"
+            rationale = (last_report.rationale or "").strip()
+            if rationale:
+                reason_suffix = f"alignment_failed: {rationale}"
             else:
                 reason_suffix = "alignment_failed: trades did not implement strategy spec"
-            combined = (
-                f"{metrics.acceptance_reason}; {reason_suffix}"
-                if metrics.acceptance_reason
-                else reason_suffix
-            )
+            # When the acceptance gate fully passed, its ``"all four
+            # criteria met"`` summary is no longer truthful (we're rejecting
+            # on alignment grounds). Replace rather than append so the audit
+            # trail isn't self-contradictory. When the acceptance gate had
+            # its own failure reasons, keep them and add the alignment
+            # cause — both are real rejection causes. Use a ``" | "``
+            # delimiter (not ``"; "``, which ``summarize_acceptance_reason``
+            # uses internally between failing gates) so downstream parsers
+            # can disambiguate the alignment boundary from gate boundaries.
+            if metrics.acceptance_reason and not acceptance_passed:
+                combined = f"{metrics.acceptance_reason} | {reason_suffix}"
+            else:
+                combined = reason_suffix
             metrics = metrics.model_copy(update={"acceptance_reason": combined})
 
         # ── Phase 3: ANALYSIS ─────────────────────────────────────────

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -1179,9 +1179,18 @@ class StrategyLabOrchestrator:
         # annualized-return scalar with no DSR correction is not a
         # publication gate. Runs configured without walk-forward still
         # execute and generate a narrative, but cannot be marked winning.
-        acceptance_passed = bool(acceptance_results) and all(r.passed for r in acceptance_results)
+        # ``upstream_admitted`` records whether the upstream publication
+        # gate (walk-forward acceptance, or its anomaly-recheck fallback)
+        # said "admit". It feeds the alignment-augmentation block below:
+        # a success-style ``acceptance_reason`` becomes stale the moment
+        # alignment vetoes a run, so we REPLACE it; a failure-style
+        # reason captures a real co-cause and is PRESERVED with the
+        # alignment cause appended.
+        upstream_admitted = False
         if acceptance_results:
+            acceptance_passed = all(r.passed for r in acceptance_results)
             is_winning = execution_succeeded and acceptance_passed and trades_aligned
+            upstream_admitted = acceptance_passed
         elif walk_forward_failed and execution_succeeded:
             fallback_anomalies = self.anomaly_detector.check(
                 metrics,
@@ -1192,36 +1201,61 @@ class StrategyLabOrchestrator:
             fallback_criticals = [
                 g for g in fallback_anomalies if not g.passed and g.severity == "critical"
             ]
-            is_winning = (
-                metrics.annualized_return_pct > WINNING_THRESHOLD
-                and not fallback_criticals
-                and trades_aligned
-            )
+            return_ok = metrics.annualized_return_pct > WINNING_THRESHOLD
+            is_winning = return_ok and not fallback_criticals and trades_aligned
+            upstream_admitted = return_ok and not fallback_criticals
             if fallback_criticals:
                 # Surface the upgraded severities so the persisted
                 # gate-result history reflects the true rejection reason.
                 for g in fallback_anomalies:
                     g.gate_name = f"fallback_{g.gate_name}"
                 all_gate_results.extend(fallback_anomalies)
-        else:
-            is_winning = False
-            # Gap-4 audit trail: ``walk_forward_enabled=False`` runs still
-            # execute and generate a narrative but cannot publish through
-            # the removed legacy path (#529). Without this entry, the
-            # persisted record would show ``is_winning=False`` with no
-            # ``acceptance_reason`` explaining why. Only set when the run
-            # actually completed — execution failures already log their
-            # own gate details and ``acceptance_reason`` would mislead.
-            if (
-                execution_succeeded
-                and trades
-                and not config.walk_forward_enabled
-                and not metrics.acceptance_reason
-            ):
+            # Gap 7 / 9: mirror the fallback gate's own verdict onto
+            # ``acceptance_reason`` so consumers don't have to grep
+            # ``quality_gate_results`` for ``fallback_`` prefixes to see
+            # why publication was admitted or rejected. The augmentation
+            # block below uses ``upstream_admitted`` to decide whether
+            # to replace this message (alignment vetoes a "passed"
+            # verdict) or to append (both gates fired their own reasons).
+            if upstream_admitted:
                 metrics = metrics.model_copy(
                     update={
-                        "acceptance_reason": ("publication_disabled: walk_forward_enabled=False")
+                        "acceptance_reason": "walk_forward_fallback_passed: anomaly recheck clean"
                     }
+                )
+            else:
+                fallback_reasons: List[str] = []
+                if fallback_criticals:
+                    fallback_reasons.append("; ".join(g.details for g in fallback_criticals))
+                if not return_ok:
+                    fallback_reasons.append(
+                        f"annualized_return {metrics.annualized_return_pct:.2f}% <= "
+                        f"{WINNING_THRESHOLD:g}% threshold"
+                    )
+                metrics = metrics.model_copy(
+                    update={
+                        "acceptance_reason": (
+                            "walk_forward_fallback_rejected: " + "; ".join(fallback_reasons)
+                        )
+                    }
+                )
+        else:
+            is_winning = False
+            # Gap 4 / 8: self-document why publication was blocked on
+            # each else-branch entry path. Without this, the persisted
+            # record shows ``is_winning=False`` with an empty
+            # ``acceptance_reason``. The no-trades case is checked first
+            # because it's the more proximate cause when both conditions
+            # hold (a run with no trades cannot publish regardless of
+            # ``walk_forward_enabled``). Execution-failure paths are
+            # handled by the elif-narrative branch in Phase 3 instead.
+            if execution_succeeded and not trades:
+                metrics = metrics.model_copy(
+                    update={"acceptance_reason": "publication_disabled: no trades produced"}
+                )
+            elif execution_succeeded and trades and not config.walk_forward_enabled:
+                metrics = metrics.model_copy(
+                    update={"acceptance_reason": "publication_disabled: walk_forward_enabled=False"}
                 )
 
         # Surface the alignment-failure cause on ``acceptance_reason`` so
@@ -1242,16 +1276,17 @@ class StrategyLabOrchestrator:
                 reason_suffix = f"alignment_failed: {rationale}"
             else:
                 reason_suffix = "alignment_failed: trades did not implement strategy spec"
-            # When the acceptance gate fully passed, its ``"all four
-            # criteria met"`` summary is no longer truthful (we're rejecting
-            # on alignment grounds). Replace rather than append so the audit
-            # trail isn't self-contradictory. When the acceptance gate had
-            # its own failure reasons, keep them and add the alignment
+            # When the upstream gate admitted the run (acceptance fully
+            # passed, or fallback anomaly recheck clean), its success
+            # summary is no longer truthful — alignment is now the
+            # rejection cause. Replace rather than append so the audit
+            # trail isn't self-contradictory. When the upstream gate
+            # itself rejected, keep its reason and add the alignment
             # cause — both are real rejection causes. Use a ``" | "``
             # delimiter (not ``"; "``, which ``summarize_acceptance_reason``
             # uses internally between failing gates) so downstream parsers
             # can disambiguate the alignment boundary from gate boundaries.
-            if metrics.acceptance_reason and not acceptance_passed:
+            if metrics.acceptance_reason and not upstream_admitted:
                 combined = f"{metrics.acceptance_reason} | {reason_suffix}"
             else:
                 combined = reason_suffix

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -117,10 +117,13 @@ MAX_CODE_REFINEMENT_ROUNDS = 50
 # through the sandbox for a fresh backtest. The cap prevents runaway loops
 # when the agent cannot converge.
 MAX_ALIGNMENT_ROUNDS = 10
-# Legacy single-window acceptance threshold. Issue #247 replaced this with
-# the composite ``AcceptanceGate`` (OOS DSR + IS→OOS degradation + OOS trade
-# count + regime beats); ``WINNING_THRESHOLD`` is now only consulted as a
-# fallback when ``BacktestConfig.walk_forward_enabled`` is False.
+# Single-window annualized-return floor consulted only when the walk-forward
+# acceptance gate is unavailable (i.e. ``_evaluate_walk_forward`` raised and
+# we drop into the fallback path). Issue #247 replaced this scalar with the
+# composite ``AcceptanceGate`` (OOS DSR + IS→OOS degradation + OOS trade
+# count + regime beats) on the primary publication path, and #529 removed
+# the legacy ``walk_forward_enabled=False`` branch that previously used this
+# threshold as a publication gate.
 WINNING_THRESHOLD = 8.0
 
 # Cap on `last_order_events` included in the refinement-prompt diagnostics
@@ -1155,7 +1158,14 @@ class StrategyLabOrchestrator:
                 walk_forward_failed = True
 
         # ── Resolve is_winning ────────────────────────────────────────
-        # Walk-forward path: composite gate is authoritative.
+        # Publication requires (a) the walk-forward acceptance gate (or
+        # its overfit-recheck fallback) AND (b) trade-alignment
+        # convergence (``trades_aligned``, #529). A strategy whose final
+        # ``TradeAlignmentReport.aligned`` is False — because the loop hit
+        # ``MAX_ALIGNMENT_ROUNDS`` or broke early with no proposed fix —
+        # cannot be marked winning regardless of metrics, since the
+        # executed trades do not implement the strategy spec.
+        #
         # Walk-forward fallback: anomaly checks during refinement ran with
         # ``dsr_aware=True``, which downgraded the ``Sharpe > 5.0`` flag
         # from critical to warning on the assumption that the OOS DSR
@@ -1163,11 +1173,16 @@ class StrategyLabOrchestrator:
         # anomaly checks with ``dsr_aware=False`` and reject if any
         # critical fires — otherwise an obvious overfit could still be
         # marked winning on annualized return alone.
-        # Legacy path (``walk_forward_enabled=False``): unchanged
-        # ``WINNING_THRESHOLD`` comparison; the refinement loop already
-        # ran with ``dsr_aware=False`` so no re-check is needed.
+        #
+        # The legacy ``walk_forward_enabled=False`` single-window
+        # ``WINNING_THRESHOLD`` branch was removed (#529): a bare
+        # annualized-return scalar with no DSR correction is not a
+        # publication gate. Runs configured without walk-forward still
+        # execute and generate a narrative, but cannot be marked winning.
         if acceptance_results:
-            is_winning = execution_succeeded and all(r.passed for r in acceptance_results)
+            is_winning = (
+                execution_succeeded and all(r.passed for r in acceptance_results) and trades_aligned
+            )
         elif walk_forward_failed and execution_succeeded:
             fallback_anomalies = self.anomaly_detector.check(
                 metrics,
@@ -1179,7 +1194,9 @@ class StrategyLabOrchestrator:
                 g for g in fallback_anomalies if not g.passed and g.severity == "critical"
             ]
             is_winning = (
-                metrics.annualized_return_pct > WINNING_THRESHOLD and not fallback_criticals
+                metrics.annualized_return_pct > WINNING_THRESHOLD
+                and not fallback_criticals
+                and trades_aligned
             )
             if fallback_criticals:
                 # Surface the upgraded severities so the persisted
@@ -1188,7 +1205,27 @@ class StrategyLabOrchestrator:
                     g.gate_name = f"fallback_{g.gate_name}"
                 all_gate_results.extend(fallback_anomalies)
         else:
-            is_winning = execution_succeeded and metrics.annualized_return_pct > WINNING_THRESHOLD
+            is_winning = False
+
+        # Surface the alignment-failure cause on ``acceptance_reason`` so
+        # the audit trail explains why publication was blocked even when
+        # the acceptance gate / threshold otherwise passed (#529). The
+        # ``trade_alignment`` QualityGateResult already lives in
+        # ``all_gate_results`` (appended per alignment round above); this
+        # mirrors the signal onto ``BacktestResult.acceptance_reason``
+        # without overwriting any prior walk-forward acceptance summary.
+        if execution_succeeded and trades and not trades_aligned:
+            last_report = alignment_reports[-1] if alignment_reports else None
+            if last_report is not None and last_report.rationale:
+                reason_suffix = f"alignment_failed: {last_report.rationale}"
+            else:
+                reason_suffix = "alignment_failed: trades did not implement strategy spec"
+            combined = (
+                f"{metrics.acceptance_reason}; {reason_suffix}"
+                if metrics.acceptance_reason
+                else reason_suffix
+            )
+            metrics = metrics.model_copy(update={"acceptance_reason": combined})
 
         # ── Phase 3: ANALYSIS ─────────────────────────────────────────
         narrative = ""

--- a/backend/agents/investment_team/strategy_lab/quality_gates/acceptance_gate.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/acceptance_gate.py
@@ -145,9 +145,12 @@ class AcceptanceGate:
 def summarize_acceptance_reason(results: List[QualityGateResult]) -> str:
     """Human-readable summary of the composite gate outcome.
 
-    Returns ``"all four criteria met"`` on full pass; otherwise a
-    comma-separated list of the failing sub-gate detail strings.
+    Returns ``"no acceptance gates evaluated"`` for an empty input (no
+    gates were run), ``"all four criteria met"`` on full pass, or a
+    semicolon-joined list of the failing sub-gate detail strings.
     """
+    if not results:
+        return "no acceptance gates evaluated"
     fails = [r for r in results if not r.passed]
     if not fails:
         return "all four criteria met"

--- a/backend/agents/investment_team/tests/test_acceptance_gate.py
+++ b/backend/agents/investment_team/tests/test_acceptance_gate.py
@@ -123,6 +123,13 @@ def test_summarize_acceptance_reason_all_pass():
     assert summarize_acceptance_reason(results) == "all four criteria met"
 
 
+def test_summarize_acceptance_reason_empty_input():
+    """PR #573 Bug 3: an empty input means no gates were evaluated, not
+    that every gate passed. Returning ``"all four criteria met"`` here
+    (the previous behaviour) would mislead the audit trail."""
+    assert summarize_acceptance_reason([]) == "no acceptance gates evaluated"
+
+
 def test_summarize_acceptance_reason_lists_failing_gates():
     gate = AcceptanceGate()
     results = gate.check(

--- a/backend/agents/investment_team/tests/test_analysis_agent_verdict.py
+++ b/backend/agents/investment_team/tests/test_analysis_agent_verdict.py
@@ -1,0 +1,173 @@
+"""Regression guard for issue #529 follow-up review (PR #573).
+
+``AnalysisAgent.run`` used to derive its own verdict from
+``metrics.annualized_return_pct > 8.0`` to choose between ``analysis_win.md``
+and ``analysis_lose.md`` and set ``outcome_label="WINNING"|"LOSING"``. After
+#529, the orchestrator can mark a high-return run as ``is_winning=False`` —
+the alignment loop, the walk-forward acceptance gate, or the removal of the
+legacy ``walk_forward_enabled=False`` publication path can all veto. The
+caller now threads the resolved verdict in, and this test pins that the agent
+honours it instead of looking at the metric.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, List
+
+from investment_team.models import BacktestResult, StrategySpec
+from investment_team.strategy_lab.agents import analysis as analysis_module
+from investment_team.strategy_lab.agents.analysis import AnalysisAgent
+from investment_team.strategy_lab.spec_dsl import (
+    ConstRef,
+    EntryRule,
+    Predicate,
+    PriceRef,
+    TimeStopRule,
+)
+
+
+def _spec() -> StrategySpec:
+    return StrategySpec(
+        strategy_id="strat-test",
+        authored_by="test-suite",
+        asset_class="stocks",
+        hypothesis="h",
+        signal_definition="s",
+        entry_rules=[
+            EntryRule(
+                side="long",
+                when=Predicate(lhs=PriceRef(), op="gt", rhs=ConstRef(value=0)),
+            )
+        ],
+        exit_rules=[TimeStopRule(n_bars=5)],
+        risk_limits={},
+        speculative=False,
+    )
+
+
+def _high_return_metrics() -> BacktestResult:
+    # Above the legacy WINNING_THRESHOLD (8.0) — under the old code path
+    # this would force ``is_winning=True`` inside AnalysisAgent.
+    return BacktestResult(
+        total_return_pct=18.0,
+        annualized_return_pct=15.0,
+        volatility_pct=8.0,
+        sharpe_ratio=1.4,
+        max_drawdown_pct=4.0,
+        win_rate_pct=60.0,
+        profit_factor=2.0,
+        calmar_ratio=0.0,
+        deflated_sharpe=0.0,
+        sortino_ratio=0.0,
+    )
+
+
+class _RecordingAgent:
+    """Stand-in for ``strands.Agent``. Records every prompt it is called with
+    and returns a JSON-shaped string the production code can parse."""
+
+    instances: List["_RecordingAgent"] = []
+    call_count = 0
+
+    def __init__(self, *_: Any, **__: Any) -> None:
+        self.prompts: List[str] = []
+        _RecordingAgent.instances.append(self)
+
+    def __call__(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        _RecordingAgent.call_count += 1
+        if _RecordingAgent.call_count == 1:
+            return json.dumps({"draft_narrative": "draft body"})
+        return json.dumps(
+            {
+                "revised_narrative": "final revised narrative",
+                "verification_notes": "checked",
+            }
+        )
+
+
+def _install_recording_agent(monkeypatch) -> None:
+    _RecordingAgent.instances = []
+    _RecordingAgent.call_count = 0
+    monkeypatch.setattr(analysis_module, "Agent", _RecordingAgent)
+    monkeypatch.setattr(analysis_module, "get_strands_model", lambda _name: None)
+
+
+def _all_prompts() -> str:
+    return "\n\n".join(p for inst in _RecordingAgent.instances for p in inst.prompts)
+
+
+def test_analysis_agent_honours_explicit_is_winning_false_on_high_return(monkeypatch):
+    """Even with metrics.annualized_return_pct=15% (legacy ``is_winning=True``),
+    an explicit ``is_winning=False`` from the orchestrator must select the
+    LOSING template + ``outcome_label="LOSING"`` so the narrative cannot tell
+    users the strategy won."""
+
+    _install_recording_agent(monkeypatch)
+
+    AnalysisAgent().run(
+        _spec(),
+        _high_return_metrics(),
+        trades=[],
+        rationale="rationale",
+        is_winning=False,
+    )
+
+    prompts = _all_prompts()
+    # The draft template selected must be the losing one. Its checked-in
+    # opening line is the simplest cross-prompt sentinel.
+    assert "LOSING swing-trading strategy" in prompts, (
+        "AnalysisAgent must use analysis_lose.md when is_winning=False is "
+        "forced by the orchestrator (issue #529 follow-up)."
+    )
+    assert "WINNING swing-trading strategy" not in prompts, (
+        "AnalysisAgent must NOT use analysis_win.md when is_winning=False is "
+        "forced by the orchestrator (issue #529 follow-up)."
+    )
+    # Self-review's outcome_label must agree.
+    assert "Outcome label: LOSING" in prompts
+    assert "Outcome label: WINNING" not in prompts
+
+
+def test_analysis_agent_honours_explicit_is_winning_true_on_low_return(monkeypatch):
+    """Symmetric guard: when the orchestrator says is_winning=True the
+    narrative must use the WINNING template even if metrics alone would
+    have rendered LOSING."""
+
+    _install_recording_agent(monkeypatch)
+
+    low_return = _high_return_metrics().model_copy(
+        update={"annualized_return_pct": 3.0, "total_return_pct": 3.5}
+    )
+
+    AnalysisAgent().run(
+        _spec(),
+        low_return,
+        trades=[],
+        rationale="rationale",
+        is_winning=True,
+    )
+
+    prompts = _all_prompts()
+    assert "WINNING swing-trading strategy" in prompts
+    assert "Outcome label: WINNING" in prompts
+
+
+def test_analysis_agent_falls_back_to_metric_heuristic_when_unset(monkeypatch):
+    """Back-compat: when no ``is_winning`` is passed the legacy
+    metric-based derivation is preserved (no behaviour change for callers
+    that haven't migrated)."""
+
+    _install_recording_agent(monkeypatch)
+
+    AnalysisAgent().run(
+        _spec(),
+        _high_return_metrics(),  # 15% annualized → legacy heuristic says winning
+        trades=[],
+        rationale="rationale",
+    )
+
+    prompts = _all_prompts()
+    assert "WINNING swing-trading strategy" in prompts
+    assert "Outcome label: WINNING" in prompts

--- a/backend/agents/investment_team/tests/test_analysis_agent_verdict.py
+++ b/backend/agents/investment_team/tests/test_analysis_agent_verdict.py
@@ -8,11 +8,21 @@ the alignment loop, the walk-forward acceptance gate, or the removal of the
 legacy ``walk_forward_enabled=False`` publication path can all veto. The
 caller now threads the resolved verdict in, and this test pins that the agent
 honours it instead of looking at the metric.
+
+Robustness notes:
+- Template selection is verified by spying on ``Path.read_text`` to record
+  which prompt file was opened — this survives wording edits to
+  ``analysis_win.md`` / ``analysis_lose.md`` (the goldens in
+  ``test_analysis_alignment_prompts.py`` pin the actual content).
+- ``Outcome label: <LABEL>`` is asserted against the rendered self-review
+  prompt; that placeholder lives in ``analysis.py`` itself (the
+  ``_SELF_REVIEW_PROMPT`` constant), not in a drifting template.
 """
 
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any, List
 
 from investment_team.models import BacktestResult, StrategySpec
@@ -63,21 +73,18 @@ def _high_return_metrics() -> BacktestResult:
     )
 
 
-class _RecordingAgent:
-    """Stand-in for ``strands.Agent``. Records every prompt it is called with
-    and returns a JSON-shaped string the production code can parse."""
+class _Recorder:
+    """Per-test recorder for prompts sent to the stubbed ``strands.Agent``
+    and prompt-file basenames read by the analysis module."""
 
-    instances: List["_RecordingAgent"] = []
-    call_count = 0
-
-    def __init__(self, *_: Any, **__: Any) -> None:
+    def __init__(self) -> None:
         self.prompts: List[str] = []
-        _RecordingAgent.instances.append(self)
+        self.read_files: List[str] = []
+        self._call_count = 0
 
-    def __call__(self, prompt: str) -> str:
-        self.prompts.append(prompt)
-        _RecordingAgent.call_count += 1
-        if _RecordingAgent.call_count == 1:
+    def render_response(self) -> str:
+        self._call_count += 1
+        if self._call_count == 1:
             return json.dumps({"draft_narrative": "draft body"})
         return json.dumps(
             {
@@ -87,15 +94,32 @@ class _RecordingAgent:
         )
 
 
-def _install_recording_agent(monkeypatch) -> None:
-    _RecordingAgent.instances = []
-    _RecordingAgent.call_count = 0
-    monkeypatch.setattr(analysis_module, "Agent", _RecordingAgent)
+def _install_recorder(monkeypatch) -> _Recorder:
+    """Patch ``strands.Agent``, the strands model factory, and
+    ``Path.read_text`` so the test can capture prompt text + template
+    selection without hitting the LLM. Returns the live recorder."""
+
+    rec = _Recorder()
+
+    class _StubAgent:
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        def __call__(self, prompt: str) -> str:
+            rec.prompts.append(prompt)
+            return rec.render_response()
+
+    monkeypatch.setattr(analysis_module, "Agent", _StubAgent)
     monkeypatch.setattr(analysis_module, "get_strands_model", lambda _name: None)
 
+    original_read_text = Path.read_text
 
-def _all_prompts() -> str:
-    return "\n\n".join(p for inst in _RecordingAgent.instances for p in inst.prompts)
+    def _spy_read_text(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+        rec.read_files.append(self.name)
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _spy_read_text)
+    return rec
 
 
 def test_analysis_agent_honours_explicit_is_winning_false_on_high_return(monkeypatch):
@@ -104,7 +128,7 @@ def test_analysis_agent_honours_explicit_is_winning_false_on_high_return(monkeyp
     LOSING template + ``outcome_label="LOSING"`` so the narrative cannot tell
     users the strategy won."""
 
-    _install_recording_agent(monkeypatch)
+    rec = _install_recorder(monkeypatch)
 
     AnalysisAgent().run(
         _spec(),
@@ -114,18 +138,19 @@ def test_analysis_agent_honours_explicit_is_winning_false_on_high_return(monkeyp
         is_winning=False,
     )
 
-    prompts = _all_prompts()
-    # The draft template selected must be the losing one. Its checked-in
-    # opening line is the simplest cross-prompt sentinel.
-    assert "LOSING swing-trading strategy" in prompts, (
-        "AnalysisAgent must use analysis_lose.md when is_winning=False is "
+    # Template selection: the LOSING file must have been read; the WINNING
+    # file must NOT. This is robust to wording edits in either template.
+    assert "analysis_lose.md" in rec.read_files, (
+        "AnalysisAgent must read analysis_lose.md when is_winning=False is "
         "forced by the orchestrator (issue #529 follow-up)."
     )
-    assert "WINNING swing-trading strategy" not in prompts, (
-        "AnalysisAgent must NOT use analysis_win.md when is_winning=False is "
+    assert "analysis_win.md" not in rec.read_files, (
+        "AnalysisAgent must NOT read analysis_win.md when is_winning=False is "
         "forced by the orchestrator (issue #529 follow-up)."
     )
-    # Self-review's outcome_label must agree.
+    # The outcome_label placeholder lives in analysis.py's _SELF_REVIEW_PROMPT
+    # constant, so this stays stable even if the template files are reworded.
+    prompts = "\n\n".join(rec.prompts)
     assert "Outcome label: LOSING" in prompts
     assert "Outcome label: WINNING" not in prompts
 
@@ -135,7 +160,7 @@ def test_analysis_agent_honours_explicit_is_winning_true_on_low_return(monkeypat
     narrative must use the WINNING template even if metrics alone would
     have rendered LOSING."""
 
-    _install_recording_agent(monkeypatch)
+    rec = _install_recorder(monkeypatch)
 
     low_return = _high_return_metrics().model_copy(
         update={"annualized_return_pct": 3.0, "total_return_pct": 3.5}
@@ -149,9 +174,11 @@ def test_analysis_agent_honours_explicit_is_winning_true_on_low_return(monkeypat
         is_winning=True,
     )
 
-    prompts = _all_prompts()
-    assert "WINNING swing-trading strategy" in prompts
+    assert "analysis_win.md" in rec.read_files
+    assert "analysis_lose.md" not in rec.read_files
+    prompts = "\n\n".join(rec.prompts)
     assert "Outcome label: WINNING" in prompts
+    assert "Outcome label: LOSING" not in prompts
 
 
 def test_analysis_agent_falls_back_to_metric_heuristic_when_unset(monkeypatch):
@@ -159,7 +186,7 @@ def test_analysis_agent_falls_back_to_metric_heuristic_when_unset(monkeypatch):
     metric-based derivation is preserved (no behaviour change for callers
     that haven't migrated)."""
 
-    _install_recording_agent(monkeypatch)
+    rec = _install_recorder(monkeypatch)
 
     AnalysisAgent().run(
         _spec(),
@@ -168,6 +195,7 @@ def test_analysis_agent_falls_back_to_metric_heuristic_when_unset(monkeypatch):
         rationale="rationale",
     )
 
-    prompts = _all_prompts()
-    assert "WINNING swing-trading strategy" in prompts
+    assert "analysis_win.md" in rec.read_files
+    assert "analysis_lose.md" not in rec.read_files
+    prompts = "\n\n".join(rec.prompts)
     assert "Outcome label: WINNING" in prompts

--- a/backend/agents/investment_team/tests/test_strategy_lab_refinement_freeze.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_refinement_freeze.py
@@ -440,6 +440,14 @@ def test_run_cycle_reroutes_then_short_circuits_on_persistent_loosening(
     assert len(loopback_events) == MAX_DESIGN_REENTRIES
     assert orch.ideation_agent.call_count == MAX_DESIGN_REENTRIES + 1  # type: ignore[attr-defined]
     assert record.backtest.status == "failed: spec_unimplementable"
+    # PR #573 round-5 Note 2: short-circuit records must populate
+    # ``acceptance_reason`` so a reader of the persisted record sees
+    # the rejection cause without having to inspect ``status`` or
+    # ``quality_gate_results`` separately.
+    ar = record.backtest.result.acceptance_reason or ""
+    assert "publication_disabled" in ar and "spec_unimplementable" in ar, (
+        f"expected publication_disabled / spec_unimplementable in {ar!r}"
+    )
 
 
 def test_run_cycle_reroutes_on_stray_key_threshold(
@@ -507,3 +515,9 @@ def test_run_cycle_reroutes_on_stray_key_threshold(
     assert orch.ideation_agent.call_count == MAX_DESIGN_REENTRIES + 1  # type: ignore[attr-defined]
     assert record.backtest.status == "failed: spec_unimplementable"
     assert "spec_unimplementable" in record.backtest.status
+    # PR #573 round-5 Note 2: short-circuit records must populate
+    # ``acceptance_reason`` for the same audit-trail reason.
+    ar = record.backtest.result.acceptance_reason or ""
+    assert "publication_disabled" in ar and "spec_unimplementable" in ar, (
+        f"expected publication_disabled / spec_unimplementable in {ar!r}"
+    )

--- a/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
@@ -862,6 +862,14 @@ def test_failed_alignment_forces_is_winning_false_on_acceptance_path(monkeypatch
     reason = record.backtest.result.acceptance_reason or ""
     assert "alignment_failed" in reason
     assert "entries fire before signal triggers" in reason
+    # When the acceptance gate fully passed but alignment vetoed, the
+    # ``"all four criteria met"`` summary is no longer truthful — the
+    # alignment cause must REPLACE it, not appear alongside it (Bug 1).
+    assert "all four criteria met" not in reason, (
+        "acceptance_reason must not contradict itself: when acceptance "
+        "fully passed but alignment vetoed, the alignment cause replaces "
+        "the now-stale 'all four criteria met' summary."
+    )
     # The orchestrator must thread the resolved verdict through so the
     # narrative template + outcome_label match the persisted record.
     assert captured_analysis_kwargs.get("is_winning") is False, (
@@ -910,6 +918,18 @@ def test_failed_alignment_forces_is_winning_false_on_walk_forward_fallback(monke
         alignment_rationale="trades hit wrong symbol",
     )
 
+    # Pin the orchestrator → AnalysisAgent wiring on this branch too
+    # (Gap 6): the call site is shared, so a regression on either path
+    # is the same root cause, but defensive duplication makes the
+    # failure mode obvious from either test.
+    captured_analysis_kwargs: dict = {}
+
+    def _recording_analysis(*_args, **kwargs):
+        captured_analysis_kwargs.update(kwargs)
+        return "narrative"
+
+    monkeypatch.setattr(orch.analysis_agent, "run", _recording_analysis)
+
     config = _config(walk_forward_enabled=True)
     record: StrategyLabRecord = orch.run_cycle(prior_records=[], config=config)
 
@@ -919,13 +939,79 @@ def test_failed_alignment_forces_is_winning_false_on_walk_forward_fallback(monke
     ]
     assert alignment_gates and all(g["passed"] is False for g in alignment_gates)
     assert "alignment_failed" in (record.backtest.result.acceptance_reason or "")
+    assert captured_analysis_kwargs.get("is_winning") is False, (
+        "orchestrator must pass is_winning=False on the walk-forward fallback path too (Gap 6)."
+    )
+
+
+def test_acceptance_failures_and_alignment_failure_both_recorded(monkeypatch):
+    """#529 / PR #573 Bug 1: when the acceptance gate has real failure
+    reasons AND alignment also fails, both must survive on the audit
+    trail joined with ``" | "`` so a downstream parser can disambiguate
+    the alignment boundary from ``summarize_acceptance_reason``'s
+    internal ``"; "`` joiner."""
+
+    from investment_team.models import StrategyLabRecord
+    from investment_team.strategy_lab.quality_gates.models import QualityGateResult
+
+    orch = _orchestrator(_StubMarketDataService())
+
+    monkeypatch.setattr(
+        orch, "_evaluate_walk_forward", lambda spec, md, cfg, trades, metrics: metrics
+    )
+    # Acceptance gate returns two failing entries — their ``details``
+    # strings get joined with ``"; "`` by ``summarize_acceptance_reason``.
+    monkeypatch.setattr(
+        orch.acceptance_gate,
+        "check",
+        lambda metrics, config, n_trials: [
+            QualityGateResult(
+                gate_name="oos_deflated_sharpe",
+                passed=False,
+                severity="critical",
+                details="DSR below threshold",
+            ),
+            QualityGateResult(
+                gate_name="oos_trade_count",
+                passed=False,
+                severity="critical",
+                details="trade count below floor",
+            ),
+        ],
+    )
+
+    _wire_run_cycle_stubs(
+        orch,
+        monkeypatch,
+        alignment_aligned=False,
+        alignment_rationale="entries fire on wrong symbol",
+    )
+
+    config = _config(walk_forward_enabled=True)
+    record: StrategyLabRecord = orch.run_cycle(prior_records=[], config=config)
+
+    assert record.is_winning is False
+    reason = record.backtest.result.acceptance_reason or ""
+    # Both acceptance failures preserved (joined internally with "; ")
+    assert "DSR below threshold" in reason
+    assert "trade count below floor" in reason
+    # Alignment cause appended after a " | " boundary so the categories
+    # are distinguishable.
+    assert " | alignment_failed:" in reason, (
+        f"expected ' | alignment_failed:' boundary in {reason!r}"
+    )
+    assert "entries fire on wrong symbol" in reason
 
 
 def test_legacy_walk_forward_disabled_cannot_publish(monkeypatch):
     """#529: the legacy ``walk_forward_enabled=False`` publication path
     was removed. A run that skips walk-forward (still permitted to
     execute) cannot be marked winning even when alignment passes and
-    annualized return clears the old WINNING_THRESHOLD."""
+    annualized return clears the old WINNING_THRESHOLD.
+
+    Gap 4: the audit trail must explain WHY publication was blocked —
+    a record with ``is_winning=False`` and ``acceptance_reason=None``
+    leaves a user guessing."""
 
     from investment_team.models import StrategyLabRecord
 
@@ -945,3 +1031,10 @@ def test_legacy_walk_forward_disabled_cannot_publish(monkeypatch):
     # Narrative still generated — the run isn't a failure, it just can't
     # publish through the removed legacy path.
     assert record.analysis_narrative
+    # Gap 4: the persisted record must explain why publication was
+    # blocked. Without this entry, a user sees ``is_winning=False`` with
+    # no audit-trail field describing the cause.
+    assert (
+        record.backtest.result.acceptance_reason
+        == "publication_disabled: walk_forward_enabled=False"
+    )

--- a/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
@@ -836,6 +836,19 @@ def test_failed_alignment_forces_is_winning_false_on_acceptance_path(monkeypatch
         alignment_rationale="entries fire before signal triggers",
     )
 
+    # Pin the orchestrator → AnalysisAgent wiring (PR #573 review): if the
+    # call ever drops the ``is_winning`` kwarg the narrative would silently
+    # re-derive WINNING from metrics. The wide-stub above (``lambda *a, **k:
+    # "narrative"``) would happily absorb that regression, so capture and
+    # assert the kwarg directly here.
+    captured_analysis_kwargs: dict = {}
+
+    def _recording_analysis(*_args, **kwargs):
+        captured_analysis_kwargs.update(kwargs)
+        return "narrative"
+
+    monkeypatch.setattr(orch.analysis_agent, "run", _recording_analysis)
+
     config = _config(walk_forward_enabled=True)
     record: StrategyLabRecord = orch.run_cycle(prior_records=[], config=config)
 
@@ -849,6 +862,12 @@ def test_failed_alignment_forces_is_winning_false_on_acceptance_path(monkeypatch
     reason = record.backtest.result.acceptance_reason or ""
     assert "alignment_failed" in reason
     assert "entries fire before signal triggers" in reason
+    # The orchestrator must thread the resolved verdict through so the
+    # narrative template + outcome_label match the persisted record.
+    assert captured_analysis_kwargs.get("is_winning") is False, (
+        "orchestrator must pass is_winning=False to AnalysisAgent.run when "
+        "alignment vetoes the publication (PR #573 review follow-up)."
+    )
 
 
 def test_failed_alignment_forces_is_winning_false_on_walk_forward_fallback(monkeypatch):

--- a/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
@@ -938,7 +938,17 @@ def test_failed_alignment_forces_is_winning_false_on_walk_forward_fallback(monke
         g for g in record.quality_gate_results if g.get("gate_name") == "trade_alignment"
     ]
     assert alignment_gates and all(g["passed"] is False for g in alignment_gates)
-    assert "alignment_failed" in (record.backtest.result.acceptance_reason or "")
+    reason = record.backtest.result.acceptance_reason or ""
+    assert "alignment_failed" in reason
+    # Bug 1 symmetry on the fallback path: the anomaly recheck admitted
+    # the run (no criticals + return > threshold), so its
+    # ``"walk_forward_fallback_passed: ..."`` summary is no longer
+    # truthful once alignment vetoes. The augmentation block must
+    # REPLACE it (using ``upstream_admitted``) rather than append.
+    assert "walk_forward_fallback_passed" not in reason, (
+        "fallback success summary must be replaced (not appended) when "
+        "alignment vetoes a fallback-admitted run."
+    )
     assert captured_analysis_kwargs.get("is_winning") is False, (
         "orchestrator must pass is_winning=False on the walk-forward fallback path too (Gap 6)."
     )
@@ -1032,9 +1042,143 @@ def test_legacy_walk_forward_disabled_cannot_publish(monkeypatch):
     # publish through the removed legacy path.
     assert record.analysis_narrative
     # Gap 4: the persisted record must explain why publication was
-    # blocked. Without this entry, a user sees ``is_winning=False`` with
-    # no audit-trail field describing the cause.
-    assert (
-        record.backtest.result.acceptance_reason
-        == "publication_disabled: walk_forward_enabled=False"
+    # blocked. Permissive substring match so future wording tweaks
+    # (e.g. adding remediation guidance) don't break the test —
+    # the structural prefix is the contract.
+    reason = record.backtest.result.acceptance_reason or ""
+    assert "publication_disabled" in reason and "walk_forward_enabled=False" in reason, (
+        f"expected publication_disabled / walk_forward_enabled=False in {reason!r}"
+    )
+
+
+def _raise_walk_forward(*_args, **_kwargs):
+    raise RuntimeError("walk-forward fold construction failed (synthetic)")
+
+
+def test_walk_forward_fallback_rejected_records_acceptance_reason(monkeypatch):
+    """Gap 7: when the walk-forward fallback rejects via a critical
+    anomaly (e.g. upgraded ``Sharpe > 5.0``), the persisted
+    ``acceptance_reason`` must mirror that rejection — a consumer
+    reading the field alone shouldn't have to know to grep
+    ``quality_gate_results`` for ``fallback_`` entries."""
+
+    from investment_team.models import StrategyLabRecord
+    from investment_team.strategy_lab.quality_gates.models import QualityGateResult as _QGR
+
+    orch = _orchestrator(_StubMarketDataService())
+
+    monkeypatch.setattr(orch, "_evaluate_walk_forward", _raise_walk_forward)
+
+    # ``anomaly_detector.check`` is called twice in this flow: once
+    # inside the refinement loop with ``dsr_aware=True`` (because
+    # ``walk_forward_enabled=True``), and again on the fallback path
+    # with ``dsr_aware=False``. We only want a critical to surface on
+    # the second call; on the first, the loop would otherwise refine
+    # forever and exhaust ``MAX_CODE_REFINEMENT_ROUNDS``.
+    def _anomaly_stub(*_a, **kw):
+        if kw.get("dsr_aware", False):
+            return []  # refinement-time: pass through
+        return [
+            _QGR(
+                gate_name="sharpe_sane",
+                passed=False,
+                severity="critical",
+                details="Sharpe ratio 6.40 > 5.0 (overfit suspect)",
+            )
+        ]
+
+    monkeypatch.setattr(orch.anomaly_detector, "check", _anomaly_stub)
+
+    _wire_run_cycle_stubs(
+        orch,
+        monkeypatch,
+        alignment_aligned=True,
+        alignment_rationale="trades match spec",
+    )
+
+    config = _config(walk_forward_enabled=True)
+    record: StrategyLabRecord = orch.run_cycle(prior_records=[], config=config)
+
+    assert record.is_winning is False
+    reason = record.backtest.result.acceptance_reason or ""
+    assert reason.startswith("walk_forward_fallback_rejected:"), (
+        f"expected walk_forward_fallback_rejected prefix in {reason!r}"
+    )
+    assert "Sharpe ratio 6.40" in reason
+
+
+def test_walk_forward_fallback_passed_records_provenance(monkeypatch):
+    """Gap 9: when the walk-forward fallback admits a run (no critical
+    anomalies, return above threshold, alignment passes), the
+    persisted ``acceptance_reason`` must record that provenance so
+    the audit trail distinguishes a primary-acceptance-gate winner
+    from a fallback-admitted winner."""
+
+    from investment_team.models import StrategyLabRecord
+    from investment_team.strategy_lab.quality_gates.models import QualityGateResult as _QGR
+
+    orch = _orchestrator(_StubMarketDataService())
+
+    monkeypatch.setattr(orch, "_evaluate_walk_forward", _raise_walk_forward)
+    # Anomalies all info-severity — fallback_criticals stays empty.
+    monkeypatch.setattr(
+        orch.anomaly_detector,
+        "check",
+        lambda *a, **kw: [
+            _QGR(gate_name="sharpe_sane", passed=True, severity="info", details="ok")
+        ],
+    )
+
+    _wire_run_cycle_stubs(
+        orch,
+        monkeypatch,
+        alignment_aligned=True,
+        alignment_rationale="trades match spec",
+    )
+
+    config = _config(walk_forward_enabled=True)
+    record: StrategyLabRecord = orch.run_cycle(prior_records=[], config=config)
+
+    assert record.is_winning is True
+    reason = record.backtest.result.acceptance_reason or ""
+    assert "walk_forward_fallback_passed" in reason, (
+        f"expected fallback-passed provenance in {reason!r}"
+    )
+
+
+def test_no_trades_produced_records_acceptance_reason(monkeypatch):
+    """Gap 8: a run that drives ``execution_succeeded=True`` with zero
+    trades (e.g. when the upstream gates have been stubbed out, or in
+    production when an alignment-loop fix produces an empty ledger)
+    can't publish — walk-forward and alignment both require trades.
+    The persisted ``acceptance_reason`` must explain this rather than
+    leave an empty field."""
+
+    from investment_team.models import StrategyLabRecord
+
+    orch = _orchestrator(_StubMarketDataService())
+
+    # Bypass the gates that normally veto zero-trade runs during
+    # refinement so we can drive ``execution_succeeded=True`` with
+    # ``trades=[]`` and exercise the Gap 8 else-branch entry path.
+    monkeypatch.setattr(orch.target_symbol_coverage_gate, "check_trades", lambda *a, **k: [])
+    monkeypatch.setattr(orch.anomaly_detector, "check", lambda *a, **kw: [])
+
+    _wire_run_cycle_stubs(
+        orch,
+        monkeypatch,
+        # ``alignment_aligned`` is irrelevant — the alignment loop is
+        # skipped when ``trades`` is empty.
+        alignment_aligned=True,
+        alignment_rationale="n/a",
+        trades_override=[],
+    )
+
+    config = _config(walk_forward_enabled=True)
+    record: StrategyLabRecord = orch.run_cycle(prior_records=[], config=config)
+
+    assert record.is_winning is False
+    reason = record.backtest.result.acceptance_reason or ""
+    assert "publication_disabled" in reason and "no trades produced" in reason, (
+        f"expected publication_disabled / no trades produced in {reason!r}"
     )

--- a/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
@@ -686,3 +686,243 @@ def test_walk_forward_fallback_rejects_overfit_via_anomaly_recheck(monkeypatch):
         g.get("severity") == "critical" and "Sharpe ratio" in g.get("details", "")
         for g in fallback_gates
     )
+
+
+# ---------------------------------------------------------------------------
+# #529 — alignment-loop failure forces is_winning=False
+# ---------------------------------------------------------------------------
+
+
+def _wire_run_cycle_stubs(
+    orch: StrategyLabOrchestrator,
+    monkeypatch,
+    *,
+    alignment_aligned: bool,
+    alignment_rationale: str = "ok",
+    metrics: Optional[BacktestResult] = None,
+    trades_override: Optional[List[TradeRecord]] = None,
+) -> None:
+    """Common stub wiring for end-to-end ``run_cycle`` tests below.
+
+    Bypasses every LLM- or sandbox-touching call site so the orchestrator
+    falls through to the is_winning resolution block with a deterministic
+    set of inputs.
+    """
+    from investment_team.strategy_lab.agents.alignment import TradeAlignmentReport
+    from investment_team.strategy_lab.orchestrator import _MarketDataFetch
+
+    spec_dict = {
+        "asset_class": "stocks",
+        "hypothesis": "h",
+        "signal_definition": "s",
+        "entry_rules": [
+            EntryRule(
+                side="long",
+                when=Predicate(lhs=PriceRef(), op="gt", rhs=ConstRef(value=0)),
+            ).model_dump()
+        ],
+        "exit_rules": [TimeStopRule(n_bars=5).model_dump()],
+        "risk_limits": {},
+        "speculative": False,
+    }
+    code = (
+        "from contract import Strategy\n\nclass S(Strategy):\n"
+        "    def on_bar(self, ctx, bar):\n"
+        "        ctx.submit_order(symbol='X', qty=1, side='LONG')\n"
+        "        ctx.submit_order(symbol='X', qty=1, side='FLAT')\n"
+    )
+    monkeypatch.setattr(orch.ideation_agent, "run", lambda **kw: (spec_dict, code, "rationale"))
+    monkeypatch.setattr(orch.refinement_agent, "run", lambda **kw: ({"changes_made": "x"}, code))
+    monkeypatch.setattr(
+        orch.alignment_agent,
+        "run",
+        lambda **kw: TradeAlignmentReport(
+            aligned=alignment_aligned, rationale=alignment_rationale, proposed_code=None
+        ),
+    )
+    monkeypatch.setattr(orch.analysis_agent, "run", lambda *a, **k: "narrative")
+    monkeypatch.setattr(
+        orch,
+        "_fetch_market_data",
+        lambda spec, config: _MarketDataFetch(
+            data={"AAPL": _stub_bars("AAPL")},
+            requested_symbols=["AAPL"],
+            fetched_symbols=["AAPL"],
+        ),
+    )
+
+    sample_trades = (
+        trades_override
+        if trades_override is not None
+        else _trades_across_year(n_per_month=4, base_pnl=80.0)
+    )
+    sample_metrics = (
+        metrics
+        if metrics is not None
+        else BacktestResult(
+            total_return_pct=18.0,
+            annualized_return_pct=15.0,
+            volatility_pct=8.0,
+            sharpe_ratio=1.4,
+            max_drawdown_pct=4.0,
+            win_rate_pct=60.0,
+            profit_factor=2.0,
+            calmar_ratio=0.0,
+            deflated_sharpe=0.0,
+            sortino_ratio=0.0,
+        )
+    )
+
+    class _StubExecResult:
+        def __init__(self):
+            self.success = True
+            self.trades = sample_trades
+            self.execution_time_seconds = 0.01
+            self.error_type = None
+            self.stderr = ""
+            self.execution_diagnostics = None
+
+    monkeypatch.setattr(
+        "investment_team.strategy_lab.orchestrator.run_strategy_code",
+        lambda *a, **k: _StubExecResult(),
+    )
+    monkeypatch.setattr(
+        "investment_team.strategy_lab.orchestrator.compute_metrics",
+        lambda *a, **k: sample_metrics,
+    )
+
+
+def test_failed_alignment_forces_is_winning_false_on_acceptance_path(monkeypatch):
+    """#529: even when the walk-forward acceptance gate passes every check,
+    a final alignment report with ``aligned=False`` must veto publication.
+    The audit trail keeps the ``trade_alignment`` gate (passed=False) on
+    ``quality_gate_results`` and surfaces ``alignment_failed`` on
+    ``acceptance_reason`` for downstream consumers."""
+
+    from investment_team.models import StrategyLabRecord
+    from investment_team.strategy_lab.quality_gates.models import QualityGateResult
+
+    orch = _orchestrator(_StubMarketDataService())
+
+    # Stub the acceptance gate to return all-passing (so alignment is the
+    # only veto in play). Also stub walk-forward evaluation to leave the
+    # metrics untouched so we don't have to construct a full OOS payload.
+    monkeypatch.setattr(
+        orch, "_evaluate_walk_forward", lambda spec, md, cfg, trades, metrics: metrics
+    )
+    monkeypatch.setattr(
+        orch.acceptance_gate,
+        "check",
+        lambda metrics, config, n_trials: [
+            QualityGateResult(
+                gate_name="oos_deflated_sharpe",
+                passed=True,
+                severity="info",
+                details="DSR passes",
+            ),
+            QualityGateResult(
+                gate_name="is_oos_degradation",
+                passed=True,
+                severity="info",
+                details="IS->OOS within tolerance",
+            ),
+        ],
+    )
+
+    _wire_run_cycle_stubs(
+        orch,
+        monkeypatch,
+        alignment_aligned=False,
+        alignment_rationale="entries fire before signal triggers",
+    )
+
+    config = _config(walk_forward_enabled=True)
+    record: StrategyLabRecord = orch.run_cycle(prior_records=[], config=config)
+
+    assert record.is_winning is False
+    alignment_gates = [
+        g for g in record.quality_gate_results if g.get("gate_name") == "trade_alignment"
+    ]
+    assert alignment_gates, "trade_alignment gate must appear in quality_gate_results"
+    assert all(g["passed"] is False for g in alignment_gates)
+    assert record.analysis_narrative  # narrative still generated for context
+    reason = record.backtest.result.acceptance_reason or ""
+    assert "alignment_failed" in reason
+    assert "entries fire before signal triggers" in reason
+
+
+def test_failed_alignment_forces_is_winning_false_on_walk_forward_fallback(monkeypatch):
+    """#529: the walk-forward fallback branch (entered when
+    ``_evaluate_walk_forward`` raised) must also honour the alignment
+    veto. Even with annualized return > WINNING_THRESHOLD and no critical
+    anomalies, ``is_winning`` is False when alignment fails."""
+
+    from investment_team.models import StrategyLabRecord
+
+    orch = _orchestrator(_StubMarketDataService())
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("walk-forward fold construction failed (synthetic)")
+
+    monkeypatch.setattr(orch, "_evaluate_walk_forward", _raise)
+
+    # Stub anomaly detector to return only info-severity (no critical) so
+    # the fallback branch would have marked is_winning=True absent the
+    # alignment check.
+    from investment_team.strategy_lab.quality_gates.models import QualityGateResult as _QGR
+
+    monkeypatch.setattr(
+        orch.anomaly_detector,
+        "check",
+        lambda *a, **kw: [
+            _QGR(
+                gate_name="sharpe_sane",
+                passed=True,
+                severity="info",
+                details="ok",
+            )
+        ],
+    )
+
+    _wire_run_cycle_stubs(
+        orch,
+        monkeypatch,
+        alignment_aligned=False,
+        alignment_rationale="trades hit wrong symbol",
+    )
+
+    config = _config(walk_forward_enabled=True)
+    record: StrategyLabRecord = orch.run_cycle(prior_records=[], config=config)
+
+    assert record.is_winning is False
+    alignment_gates = [
+        g for g in record.quality_gate_results if g.get("gate_name") == "trade_alignment"
+    ]
+    assert alignment_gates and all(g["passed"] is False for g in alignment_gates)
+    assert "alignment_failed" in (record.backtest.result.acceptance_reason or "")
+
+
+def test_legacy_walk_forward_disabled_cannot_publish(monkeypatch):
+    """#529: the legacy ``walk_forward_enabled=False`` publication path
+    was removed. A run that skips walk-forward (still permitted to
+    execute) cannot be marked winning even when alignment passes and
+    annualized return clears the old WINNING_THRESHOLD."""
+
+    from investment_team.models import StrategyLabRecord
+
+    orch = _orchestrator(_StubMarketDataService())
+
+    _wire_run_cycle_stubs(
+        orch,
+        monkeypatch,
+        alignment_aligned=True,
+        alignment_rationale="trades match spec",
+    )
+
+    config = _config(walk_forward_enabled=False)
+    record: StrategyLabRecord = orch.run_cycle(prior_records=[], config=config)
+
+    assert record.is_winning is False
+    # Narrative still generated — the run isn't a failure, it just can't
+    # publish through the removed legacy path.
+    assert record.analysis_narrative

--- a/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
@@ -876,6 +876,17 @@ def test_failed_alignment_forces_is_winning_false_on_acceptance_path(monkeypatch
         "orchestrator must pass is_winning=False to AnalysisAgent.run when "
         "alignment vetoes the publication (PR #573 review follow-up)."
     )
+    # PR #573 round-4 regression guard: the alignment-augmentation block
+    # used to bind a local ``rationale`` that shadowed the strategy
+    # rationale, corrupting both the analysis prompt and
+    # ``StrategyLabRecord.strategy_rationale`` on every alignment-failure
+    # path. The ideation stub returns ``"rationale"`` as the strategy
+    # rationale; if the shadowing comes back, ``record.strategy_rationale``
+    # would be ``"entries fire before signal triggers"`` instead.
+    assert record.strategy_rationale == "rationale", (
+        "alignment-augmentation must not shadow the strategy rationale "
+        f"(got {record.strategy_rationale!r})."
+    )
 
 
 def test_failed_alignment_forces_is_winning_false_on_walk_forward_fallback(monkeypatch):
@@ -952,6 +963,12 @@ def test_failed_alignment_forces_is_winning_false_on_walk_forward_fallback(monke
     assert captured_analysis_kwargs.get("is_winning") is False, (
         "orchestrator must pass is_winning=False on the walk-forward fallback path too (Gap 6)."
     )
+    # PR #573 round-4 regression guard (rationale-shadowing). See the
+    # parallel assertion in the acceptance-path test for the full story.
+    assert record.strategy_rationale == "rationale", (
+        "alignment-augmentation must not shadow the strategy rationale "
+        f"(got {record.strategy_rationale!r})."
+    )
 
 
 def test_acceptance_failures_and_alignment_failure_both_recorded(monkeypatch):
@@ -1011,6 +1028,11 @@ def test_acceptance_failures_and_alignment_failure_both_recorded(monkeypatch):
         f"expected ' | alignment_failed:' boundary in {reason!r}"
     )
     assert "entries fire on wrong symbol" in reason
+    # PR #573 round-4 regression guard (rationale-shadowing).
+    assert record.strategy_rationale == "rationale", (
+        "alignment-augmentation must not shadow the strategy rationale "
+        f"(got {record.strategy_rationale!r})."
+    )
 
 
 def test_legacy_walk_forward_disabled_cannot_publish(monkeypatch):


### PR DESCRIPTION
Closes #529.

## Summary

- `StrategyLabOrchestrator.run_cycle` computed `trades_aligned` but never read it. A strategy whose final `TradeAlignmentReport.aligned` was `False` (loop hit `MAX_ALIGNMENT_ROUNDS`, or broke early with no proposed fix) could still publish as `is_winning=True` on metrics alone — the bug described in #529 (the "QQQ trend continuation → 100% TSLA trades" pattern).
- AND `trades_aligned` into the walk-forward acceptance-gate branch and the walk-forward fallback branch so a misaligned run cannot publish regardless of metrics.
- Remove the legacy `walk_forward_enabled=False` single-window `WINNING_THRESHOLD` publication branch. A bare annualized-return scalar with no DSR correction is not a publication gate; runs that skip walk-forward still execute and produce a narrative but cannot be marked winning. `WINNING_THRESHOLD` itself stays in place — the walk-forward fallback branch still uses it as a gross-return floor.
- When alignment is the rejection cause, augment `BacktestResult.acceptance_reason` with `alignment_failed: <rationale>` so the audit trail surfaces the cause without clobbering any walk-forward acceptance summary. The per-round `trade_alignment` `QualityGateResult` rows on `quality_gate_results` already record the gate verdict — no schema change.

## Test plan

- [x] New `test_failed_alignment_forces_is_winning_false_on_acceptance_path` — acceptance gate stubbed all-passing, alignment fails → `is_winning=False`, `acceptance_reason` contains `alignment_failed`.
- [x] New `test_failed_alignment_forces_is_winning_false_on_walk_forward_fallback` — `_evaluate_walk_forward` raises, fallback anomalies all `info`, alignment fails → `is_winning=False`.
- [x] New `test_legacy_walk_forward_disabled_cannot_publish` — `walk_forward_enabled=False`, alignment passes, annualized return > old threshold → `is_winning=False` (legacy branch removed).
- [x] Full `agents/investment_team/tests` suite: 1350 passed, 13 skipped.
- [x] `ruff check` + `ruff format --check` clean.

## Out of scope

- Removing the `walk_forward_enabled` config flag itself — still gates whether walk-forward evaluation runs.
- #531 fail-closed defaults on alignment-agent parse/runtime errors.
- #532 threading `alignment_status` into AnalysisAgent prompts.
- The #527 / #536 / #540–#541 structured-DSL / unified-gate arc.

---
_Generated by [Claude Code](https://claude.ai/code/session_017njo8Jzirf4ZodsRACWfi8)_