### PR TITLE
investment-team: regression tests for #552 quality-gate text-view + signature determinism

### DIFF
--- a/backend/agents/investment_team/tests/test_convergence_tracker.py
+++ b/backend/agents/investment_team/tests/test_convergence_tracker.py
@@ -230,3 +230,74 @@ def test_merge_from_lowers_dsr_on_subsequent_cycle():
         "Expected post-merge DSR to deflate further once sibling trial "
         f"counts are visible; got pre={dsr_pre_merge:.6f} post={dsr_post_merge:.6f}"
     )
+
+
+# ----------------------------------------------------------------------
+# Issue #552 — _strategy_signature determinism under the structured DSL.
+# ----------------------------------------------------------------------
+
+
+def _spec_with_entries(entry_rules, asset_class: str = "stocks") -> StrategySpec:
+    return StrategySpec(
+        strategy_id="s1",
+        authored_by="test",
+        asset_class=asset_class,
+        hypothesis="test hypothesis",
+        signal_definition="sig",
+        entry_rules=entry_rules,
+        exit_rules=[
+            SignalExitRule(
+                when=Predicate(lhs=PriceRef(), op="lt", rhs=SMARef(period=5)),
+            ),
+        ],
+    )
+
+
+def test_strategy_signature_is_stable_across_construction_order():
+    """Two specs whose ``entry_rules`` list contains the same rules in
+    different order canonicalise to the same token set — guaranteed by the
+    ``sorted((_canon(r) for r in spec.entry_rules))`` pass plus
+    ``sort_keys=True`` inside ``_canon``."""
+    rule_a = EntryRule(
+        side="long",
+        when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=20)),
+    )
+    rule_b = EntryRule(
+        side="long",
+        when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=50)),
+    )
+
+    sig_ab = ConvergenceTracker._strategy_signature(_spec_with_entries([rule_a, rule_b]))
+    sig_ba = ConvergenceTracker._strategy_signature(_spec_with_entries([rule_b, rule_a]))
+
+    assert sig_ab == sig_ba
+
+
+def test_strategy_signature_differs_when_rule_payload_differs():
+    """A meaningful payload change — ``SMARef(period=20)`` vs
+    ``SMARef(period=50)`` — must produce a different entry token. Guards
+    against an over-aggressive canonicalisation that collapses distinct
+    rules."""
+    rule_20 = EntryRule(
+        side="long",
+        when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=20)),
+    )
+    rule_50 = EntryRule(
+        side="long",
+        when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=50)),
+    )
+
+    sig_20 = ConvergenceTracker._strategy_signature(_spec_with_entries([rule_20]))
+    sig_50 = ConvergenceTracker._strategy_signature(_spec_with_entries([rule_50]))
+
+    assert sig_20 != sig_50
+
+
+def test_strategy_signature_includes_asset_class_token():
+    """``_strategy_signature`` emits an ``ac:<lower>`` token. Two specs with
+    identical rules but different asset classes must differ exactly in that
+    token."""
+    sig_stocks = ConvergenceTracker._strategy_signature(_mk_spec("stocks"))
+    sig_crypto = ConvergenceTracker._strategy_signature(_mk_spec("crypto"))
+
+    assert sig_stocks ^ sig_crypto == {"ac:stocks", "ac:crypto"}

--- a/backend/agents/investment_team/tests/test_convergence_tracker.py
+++ b/backend/agents/investment_team/tests/test_convergence_tracker.py
@@ -253,11 +253,11 @@ def _spec_with_entries(entry_rules, asset_class: str = "stocks") -> StrategySpec
     )
 
 
-def test_strategy_signature_is_stable_across_construction_order():
-    """Two specs whose ``entry_rules`` list contains the same rules in
-    different order canonicalise to the same token set — guaranteed by the
-    ``sorted((_canon(r) for r in spec.entry_rules))`` pass plus
-    ``sort_keys=True`` inside ``_canon``."""
+def test_strategy_signature_invariant_to_entry_list_order():
+    """``_strategy_signature`` is invariant to the position of rules within
+    ``entry_rules`` — guaranteed by the use of a ``Set`` for the returned
+    tokens (and reinforced by the ``sorted((_canon(r) for r in ...))`` pass
+    inside the helper)."""
     rule_a = EntryRule(
         side="long",
         when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=20)),
@@ -271,6 +271,28 @@ def test_strategy_signature_is_stable_across_construction_order():
     sig_ba = ConvergenceTracker._strategy_signature(_spec_with_entries([rule_b, rule_a]))
 
     assert sig_ab == sig_ba
+
+
+def test_strategy_signature_canonicalises_across_distinct_equivalent_rules():
+    """Two structurally identical rules built as separate Python objects
+    must produce the same token. This is the property ``sort_keys=True``
+    inside ``_canon`` exists to defend: a future change to dict-ordering
+    semantics in Pydantic or stdlib ``json`` must not silently
+    desynchronise the signature."""
+    rule_v1 = EntryRule(
+        side="long",
+        when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=20)),
+    )
+    rule_v2 = EntryRule(
+        side="long",
+        when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=20)),
+    )
+    assert rule_v1 is not rule_v2
+
+    sig_1 = ConvergenceTracker._strategy_signature(_spec_with_entries([rule_v1]))
+    sig_2 = ConvergenceTracker._strategy_signature(_spec_with_entries([rule_v2]))
+
+    assert sig_1 == sig_2
 
 
 def test_strategy_signature_differs_when_rule_payload_differs():

--- a/backend/agents/investment_team/tests/test_strategy_validator.py
+++ b/backend/agents/investment_team/tests/test_strategy_validator.py
@@ -24,14 +24,23 @@ from investment_team.strategy_lab.spec_dsl import (
     SignalExitRule,
     SMARef,
     TimeStopRule,
+    UnparsableRule,
+    UnparsableSizing,
 )
 
 
-def _spec(*, hypothesis: str, entry: List, exit_: List) -> StrategySpec:
-    return StrategySpec(
+def _spec(
+    *,
+    hypothesis: str,
+    entry: List,
+    exit_: List,
+    asset_class: str = "stocks",
+    sizing=None,
+) -> StrategySpec:
+    kwargs: dict = dict(
         strategy_id="strat-validator-test",
         authored_by="test",
-        asset_class="stocks",
+        asset_class=asset_class,
         hypothesis=hypothesis,
         signal_definition="sig",
         entry_rules=entry,
@@ -40,6 +49,9 @@ def _spec(*, hypothesis: str, entry: List, exit_: List) -> StrategySpec:
         speculative=False,
         strategy_code="from contract import Strategy\nclass S(Strategy):\n    def on_bar(self, ctx, bar):\n        pass\n",
     )
+    if sizing is not None:
+        kwargs["sizing"] = sizing
+    return StrategySpec(**kwargs)
 
 
 def _warnings(results) -> list[str]:
@@ -150,3 +162,106 @@ def test_word_boundary_prevents_thematic_matching_ema() -> None:
     results = StrategySpecValidator().validate(spec)
     warnings = _warnings(results)
     assert not any("Hypothesis/rules consistency" in w for w in warnings), warnings
+
+
+# ---------------------------------------------------------------------------
+# Issue #552 — keyword/non-computable scans on structured rules.
+#
+# Under the DSL (#551) the asset-class mismatch and non-computable keyword
+# scans only see free text through ``UnparsableRule.prose`` /
+# ``UnparsableSizing.prose`` — the only escape hatches for prose that
+# survived the migration. ``StrategySpec.entry_rules`` is typed
+# ``List[EntryRule]`` (no prose escape hatch on entries), so the prose
+# surface to exercise is ``exit_rules`` (its union admits ``UnparsableRule``)
+# and ``sizing`` (its union admits ``UnparsableSizing``).
+# ---------------------------------------------------------------------------
+
+
+def test_asset_class_mismatch_fires_on_unparsable_exit_rule_prose() -> None:
+    """Equity keyword 'dividend' in an ``UnparsableRule.prose`` exit rule on
+    a forex spec is surfaced by ``format_rules_for_prompt`` and trips the
+    asset-class mismatch scan."""
+    spec = _spec(
+        hypothesis="trend follow on currency pairs",
+        entry=[
+            EntryRule(
+                side="long",
+                when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=20)),
+            ),
+        ],
+        exit_=[UnparsableRule(prose="exit on dividend ex-date", reason="prose")],
+        asset_class="forex",
+    )
+    results = StrategySpecValidator().validate(spec)
+    warnings = _warnings(results)
+    assert any("mismatched with asset class 'forex'" in w for w in warnings), warnings
+
+
+def test_asset_class_mismatch_fires_on_unparsable_sizing_prose() -> None:
+    """Equity keyword 'EPS' in ``UnparsableSizing.prose`` on a crypto spec
+    is surfaced by ``format_sizing_rule`` and trips the asset-class mismatch
+    scan."""
+    spec = _spec(
+        hypothesis="momentum on majors",
+        entry=[
+            EntryRule(
+                side="long",
+                when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=20)),
+            ),
+        ],
+        exit_=[TimeStopRule(n_bars=5)],
+        asset_class="crypto",
+        sizing=UnparsableSizing(prose="size by EPS growth", reason="prose"),
+    )
+    results = StrategySpecValidator().validate(spec)
+    warnings = _warnings(results)
+    assert any("mismatched with asset class 'crypto'" in w for w in warnings), warnings
+
+
+def test_non_computable_keyword_fires_on_unparsable_exit_rule_prose() -> None:
+    """A prose exit rule referencing 'twitter sentiment' trips the
+    non-computable-data warning regardless of asset class."""
+    spec = _spec(
+        hypothesis="mean reversion on retail flow",
+        entry=[
+            EntryRule(
+                side="long",
+                when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=20)),
+            ),
+        ],
+        exit_=[
+            UnparsableRule(
+                prose="exit when twitter sentiment turns negative",
+                reason="prose",
+            ),
+        ],
+    )
+    results = StrategySpecValidator().validate(spec)
+    warnings = _warnings(results)
+    assert any("non-computable data" in w for w in warnings), warnings
+
+
+def test_structured_rules_do_not_trigger_keyword_scans() -> None:
+    """Negative case: purely structured rules format to text like
+    ``long when close > sma(20)`` / ``risk 2% per trade``, none of which
+    match the asset-class or non-computable keyword regexes — even with a
+    mismatch-sensitive asset class set."""
+    spec = _spec(
+        hypothesis="SMA crossover on equities",
+        entry=[
+            EntryRule(
+                side="long",
+                when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=20)),
+            ),
+        ],
+        exit_=[
+            SignalExitRule(
+                when=Predicate(lhs=PriceRef(), op="lt", rhs=SMARef(period=5)),
+            ),
+        ],
+        asset_class="forex",
+    )
+    results = StrategySpecValidator().validate(spec)
+    warnings = _warnings(results)
+    assert not any("mismatched with asset class" in w for w in warnings), warnings
+    assert not any("non-computable data" in w for w in warnings), warnings


### PR DESCRIPTION
Closes #552.

## Summary

#552 prescribed two production-code updates to the Strategy Lab quality
gates (sorted-JSON hashing in `convergence_tracker._strategy_signature`,
DSL-helper text-view in `strategy_validator`). Audit found both updates
**already shipped** under the #551 DSL migration — the doc-comments in
both files literally cite "Issue #551/#552". The remaining unmet
acceptance criterion was the **regression test**.

This PR closes that gap. Tests-only; no production code touched.

## Changes

- **`test_strategy_validator.py`** — 4 new tests:
  - `test_asset_class_mismatch_fires_on_unparsable_exit_rule_prose` — forex
    spec with `UnparsableRule(prose="exit on dividend ex-date")` in
    `exit_rules` trips the asset-class mismatch warning via
    `format_rules_for_prompt`.
  - `test_asset_class_mismatch_fires_on_unparsable_sizing_prose` — crypto
    spec with `UnparsableSizing(prose="size by EPS growth")` trips the
    asset-class mismatch warning via `format_sizing_rule`.
  - `test_non_computable_keyword_fires_on_unparsable_exit_rule_prose` —
    exit-rule prose referencing "twitter sentiment" trips the
    non-computable-data warning.
  - `test_structured_rules_do_not_trigger_keyword_scans` — negative case:
    purely structured rules format to `"long when close > sma(20)"` /
    `"risk 2% per trade"` and don't trip either scan even on a
    mismatch-sensitive asset class.
  - `_spec(...)` widened to accept `asset_class` and `sizing` kwargs
    (defaults preserve all existing call sites).

  Note: `StrategySpec.entry_rules` is typed `List[EntryRule]` (concrete,
  no prose escape hatch), so the prose surface exercised is the `ExitRule`
  union and `SizingRule` union — both of which admit the `Unparsable*`
  variants.

- **`test_convergence_tracker.py`** — 3 new tests covering the
  `_strategy_signature` helper under the structured DSL:
  - `test_strategy_signature_is_stable_across_construction_order` —
    list-order invariance, exercising the `sorted((_canon(r) …))` pass
    plus `sort_keys=True` inside `_canon`.
  - `test_strategy_signature_differs_when_rule_payload_differs` —
    `SMARef(period=20)` vs `SMARef(period=50)` produce distinct entry
    tokens (guards against over-aggressive canonicalisation).
  - `test_strategy_signature_includes_asset_class_token` — pins the
    `ac:<lower>` token contract via symmetric difference of two specs
    that differ only in `asset_class`.

## Test plan

- [x] `pytest backend/agents/investment_team/tests/test_strategy_validator.py -v` — 9 passed
- [x] `pytest backend/agents/investment_team/tests/test_convergence_tracker.py -v` — 17 passed (acceptance criterion #3)
- [x] `pytest backend/agents/investment_team/tests -k "convergence or validator or signature or strategy_lab"` — 164 passed, 1 skipped, 0 failed
- [x] `ruff check` + `ruff format --check` on the two test files — clean


---
_Generated by [Claude Code](https://claude.ai/code/session_01H3CYe1cS7SsqRZfxCMyXfa)_