### PR TITLE
investment-team: restrict zero-trade-repair spec updates to risk_limits (#530)

### DIFF
--- a/backend/agents/investment_team/strategy_lab/agents/zero_trade_repair.py
+++ b/backend/agents/investment_team/strategy_lab/agents/zero_trade_repair.py
@@ -66,6 +66,13 @@ class ZeroTradeRepairReport(BaseModel):
     expected_trade_count_change: int = 0
     changes_made: str = ""
     proposed_spec_updates: Optional[Dict[str, Any]] = Field(default=None)
+    # #530: keys the agent filtered out of ``proposed_spec_updates`` before
+    # returning. Populated by ``_coerce_report`` so the orchestrator can
+    # surface a ``logger.warning`` + ``zero_trade_repair_dropped_spec_keys``
+    # quality gate even when the agent strips off-list drift in production
+    # (otherwise the visibility added in #530 would only fire when the agent
+    # is stubbed in tests).
+    dropped_spec_update_keys: List[str] = Field(default_factory=list)
 
 
 # ---------------------------------------------------------------------------
@@ -259,8 +266,17 @@ def _coerce_report(
 
     raw_spec_updates = parsed.get("proposed_spec_updates")
     proposed_spec_updates: Optional[Dict[str, Any]]
+    dropped_spec_update_keys: List[str] = []
     if isinstance(raw_spec_updates, dict):
         whitelisted = {k: v for k, v in raw_spec_updates.items() if k in _ALLOWED_SPEC_UPDATE_KEYS}
+        # #530: record what the agent filtered so the orchestrator can
+        # surface it via logger.warning + a quality gate. Without this,
+        # the production agent-to-orchestrator flow would silently drop
+        # the drift because the orchestrator only sees the sanitized
+        # report.
+        dropped_spec_update_keys = sorted(
+            k for k in raw_spec_updates if k not in _ALLOWED_SPEC_UPDATE_KEYS
+        )
         # Reject prose / invalid structure on the rule-shaped keys so the
         # orchestrator does not propagate a malformed dict into
         # `_apply_updates`. The whitelist still gates which fields make it
@@ -295,6 +311,7 @@ def _coerce_report(
         expected_trade_count_change=_coerce_int(parsed.get("expected_trade_count_change", 0)),
         changes_made=str(parsed.get("changes_made", "")).strip(),
         proposed_spec_updates=proposed_spec_updates,
+        dropped_spec_update_keys=dropped_spec_update_keys,
     )
 
 

--- a/backend/agents/investment_team/strategy_lab/agents/zero_trade_repair.py
+++ b/backend/agents/investment_team/strategy_lab/agents/zero_trade_repair.py
@@ -35,16 +35,13 @@ _PROMPT_DIR = Path(__file__).resolve().parent.parent / "prompts"
 # Spec keys the orchestrator will honour from a ZeroTradeRepairReport's
 # ``proposed_spec_updates``. Anything else is silently dropped — the
 # specialized repair agent must not invent fields.
-_ALLOWED_SPEC_UPDATE_KEYS = frozenset(
-    {
-        "entry_rules",
-        "exit_rules",
-        "sizing",
-        "risk_limits",
-        "hypothesis",
-        "signal_definition",
-    }
-)
+#
+# #530: narrowed to ``risk_limits`` only. The repair agent must fix the
+# **code**, not weaken the **spec**. Rule-shaped keys (entry/exit/sizing),
+# the hypothesis, and the signal_definition stay locked at this stage so
+# a "make trades happen" LLM cannot quietly mutate the thesis. The
+# orchestrator additionally logs and gates off-list proposals.
+_ALLOWED_SPEC_UPDATE_KEYS = frozenset({"risk_limits"})
 
 # Cap on `last_order_events` included in the repair prompt. The model
 # already trims to 20; 10 is enough signal for the LLM to spot the

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -1620,6 +1620,7 @@ class StrategyLabOrchestrator:
                 if k not in _ZERO_TRADE_SPEC_UPDATE_KEYS
             }
         )
+        dropped_keys_gates: List[QualityGateResult] = []
         if dropped_spec_keys:
             logger.warning(
                 "Zero-trade repair discarded spec-mutating keys %s for round=%s "
@@ -1628,6 +1629,22 @@ class StrategyLabOrchestrator:
                 dropped_spec_keys,
                 round_num,
             )
+            # #530: build the gate once so every early-return path carries
+            # it forward (the ValidationError path below would otherwise
+            # drop the audit trail even though the warning was logged).
+            dropped_keys_gates = [
+                QualityGateResult(
+                    gate_name="zero_trade_repair_dropped_spec_keys",
+                    passed=False,
+                    severity="warning",
+                    details=(
+                        "Zero-trade repair proposed off-list spec keys "
+                        f"{dropped_spec_keys}; dropped per #530 "
+                        "(risk_limits only)."
+                    ),
+                    refinement_round=round_num,
+                )
+            ]
 
         # ── Fresh backtest of the proposed code ──────────────────────
         try:
@@ -1656,7 +1673,7 @@ class StrategyLabOrchestrator:
             )
             return _ZeroTradeRepairOutcome(
                 committed=False,
-                new_gates=safety_gates,
+                new_gates=safety_gates + dropped_keys_gates,
                 failure_reason="invalid_spec_updates",
             )
 
@@ -1676,23 +1693,11 @@ class StrategyLabOrchestrator:
             for g in post_repair_spec_gates:
                 g.refinement_round = round_num
                 g.gate_name = f"zero_trade_repair_{g.gate_name}"
-        if dropped_spec_keys:
-            # #530: surface the dropped keys as a warning gate so the
-            # persisted ``quality_gate_results`` records the attempted
-            # spec mutation even when no whitelisted key was present.
-            post_repair_spec_gates.append(
-                QualityGateResult(
-                    gate_name="zero_trade_repair_dropped_spec_keys",
-                    passed=False,
-                    severity="warning",
-                    details=(
-                        "Zero-trade repair proposed off-list spec keys "
-                        f"{dropped_spec_keys}; dropped per #530 "
-                        "(risk_limits only)."
-                    ),
-                    refinement_round=round_num,
-                )
-            )
+        # #530: extend with the pre-built dropped-keys gate so the
+        # persisted ``quality_gate_results`` records the attempted spec
+        # mutation even when no whitelisted key was present (same gate
+        # object the ValidationError early-return carries forward).
+        post_repair_spec_gates.extend(dropped_keys_gates)
         spec_criticals = [
             g for g in post_repair_spec_gates if not g.passed and g.severity == "critical"
         ]

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -1604,11 +1604,21 @@ class StrategyLabOrchestrator:
 
         # ── Surface any off-list spec keys the agent tried to mutate ─
         # #530: the orchestrator's whitelist is now ``{"risk_limits"}``.
-        # If the agent (or a future LLM that bypasses the agent filter)
-        # still proposes other keys, log a warning and append a quality
-        # gate so the drop is auditable in ``quality_gate_results``.
+        # In production the agent's own filter has already stripped
+        # off-list keys before we see them and recorded the names on
+        # ``report.dropped_spec_update_keys``; in tests or via future
+        # bypasses, keys may still be present on ``proposed_spec_updates``.
+        # Union both sources so the warning and the
+        # ``zero_trade_repair_dropped_spec_keys`` quality gate fire in both
+        # flows and the drift is auditable on the persisted
+        # ``quality_gate_results``.
         dropped_spec_keys: List[str] = sorted(
-            k for k in (report.proposed_spec_updates or {}) if k not in _ZERO_TRADE_SPEC_UPDATE_KEYS
+            set(report.dropped_spec_update_keys)
+            | {
+                k
+                for k in (report.proposed_spec_updates or {})
+                if k not in _ZERO_TRADE_SPEC_UPDATE_KEYS
+            }
         )
         if dropped_spec_keys:
             logger.warning(

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -190,16 +190,15 @@ def _format_execution_diagnostics(
 # Spec keys honoured when applying ``ZeroTradeRepairReport.proposed_spec_updates``.
 # Mirrors the agent-side whitelist so the orchestrator silently drops any
 # off-list keys an LLM might invent.
-_ZERO_TRADE_SPEC_UPDATE_KEYS = frozenset(
-    {
-        "entry_rules",
-        "exit_rules",
-        "sizing",
-        "risk_limits",
-        "hypothesis",
-        "signal_definition",
-    }
-)
+#
+# #530: narrowed to ``risk_limits`` only. The repair agent must fix the
+# **code**, not weaken the **spec** — letting it rewrite entry/exit/sizing
+# rules, the hypothesis, or the signal_definition is the formal mechanism
+# by which a thesis silently mutates across refinement rounds to "make
+# trades happen". Off-list keys are dropped with a ``logger.warning`` and
+# a ``zero_trade_repair_dropped_spec_keys`` quality gate so the drift is
+# visible in the persisted ``quality_gate_results``.
+_ZERO_TRADE_SPEC_UPDATE_KEYS = frozenset({"risk_limits"})
 
 
 @dataclass
@@ -1603,6 +1602,23 @@ class StrategyLabOrchestrator:
                 failure_reason="unsafe_code",
             )
 
+        # ── Surface any off-list spec keys the agent tried to mutate ─
+        # #530: the orchestrator's whitelist is now ``{"risk_limits"}``.
+        # If the agent (or a future LLM that bypasses the agent filter)
+        # still proposes other keys, log a warning and append a quality
+        # gate so the drop is auditable in ``quality_gate_results``.
+        dropped_spec_keys: List[str] = sorted(
+            k for k in (report.proposed_spec_updates or {}) if k not in _ZERO_TRADE_SPEC_UPDATE_KEYS
+        )
+        if dropped_spec_keys:
+            logger.warning(
+                "Zero-trade repair discarded spec-mutating keys %s for round=%s "
+                "(post-#530 repair may only adjust risk_limits; fix the code, "
+                "not the spec).",
+                dropped_spec_keys,
+                round_num,
+            )
+
         # ── Fresh backtest of the proposed code ──────────────────────
         try:
             proposed_spec = self._apply_zero_trade_spec_updates(
@@ -1636,13 +1652,13 @@ class StrategyLabOrchestrator:
 
         # ── Re-validate the spec after repair-driven mutation ────────
         # The pre-synthesis gate (#547 item 1) only runs once at ideation.
-        # Zero-trade repair may mutate entry/exit/sizing rules, risk_limits,
-        # hypothesis, or signal_definition via the whitelist; those bypass
-        # the gate. A Pydantic-valid risk_limits value (e.g.
+        # Post-#530, zero-trade repair may only mutate ``risk_limits`` via
+        # the whitelist; that single mutation still bypasses the
+        # pre-synthesis gate. A Pydantic-valid risk_limits value (e.g.
         # max_position_pct=99) can still be a critical spec failure under
         # StrategySpecValidator. Re-validate before committing; on accept,
-        # carry the gates forward in ``new_gates`` so warnings (e.g.
-        # hypothesis/rules drift on a repaired spec) reach the persisted
+        # carry the gates forward in ``new_gates`` so warnings (e.g. tight
+        # drawdown limits on a repaired spec) reach the persisted
         # ``quality_gate_results`` rather than being silently dropped.
         post_repair_spec_gates: List[QualityGateResult] = []
         if report.proposed_spec_updates:
@@ -1650,28 +1666,45 @@ class StrategyLabOrchestrator:
             for g in post_repair_spec_gates:
                 g.refinement_round = round_num
                 g.gate_name = f"zero_trade_repair_{g.gate_name}"
-            spec_criticals = [
-                g for g in post_repair_spec_gates if not g.passed and g.severity == "critical"
-            ]
-            if spec_criticals:
-                zero_trade_attempts.append(
-                    f"invalid_spec_after_repair ({report.root_cause_category}): "
-                    f"{'; '.join(g.details for g in spec_criticals)[:160]}"
+        if dropped_spec_keys:
+            # #530: surface the dropped keys as a warning gate so the
+            # persisted ``quality_gate_results`` records the attempted
+            # spec mutation even when no whitelisted key was present.
+            post_repair_spec_gates.append(
+                QualityGateResult(
+                    gate_name="zero_trade_repair_dropped_spec_keys",
+                    passed=False,
+                    severity="warning",
+                    details=(
+                        "Zero-trade repair proposed off-list spec keys "
+                        f"{dropped_spec_keys}; dropped per #530 "
+                        "(risk_limits only)."
+                    ),
+                    refinement_round=round_num,
                 )
-                emit(
-                    "coding",
-                    {
-                        "sub_phase": "zero_trade_repair_rejected",
-                        "refinement_round": round_num,
-                        "reason": "invalid_spec_after_repair",
-                        "details": "; ".join(g.details for g in spec_criticals)[:400],
-                    },
-                )
-                return _ZeroTradeRepairOutcome(
-                    committed=False,
-                    new_gates=safety_gates + post_repair_spec_gates,
-                    failure_reason="invalid_spec_after_repair",
-                )
+            )
+        spec_criticals = [
+            g for g in post_repair_spec_gates if not g.passed and g.severity == "critical"
+        ]
+        if spec_criticals:
+            zero_trade_attempts.append(
+                f"invalid_spec_after_repair ({report.root_cause_category}): "
+                f"{'; '.join(g.details for g in spec_criticals)[:160]}"
+            )
+            emit(
+                "coding",
+                {
+                    "sub_phase": "zero_trade_repair_rejected",
+                    "refinement_round": round_num,
+                    "reason": "invalid_spec_after_repair",
+                    "details": "; ".join(g.details for g in spec_criticals)[:400],
+                },
+            )
+            return _ZeroTradeRepairOutcome(
+                committed=False,
+                new_gates=safety_gates + post_repair_spec_gates,
+                failure_reason="invalid_spec_after_repair",
+            )
 
         repair_exec = run_strategy_code(
             report.proposed_code, market_data, config, strategy=proposed_spec
@@ -1787,10 +1820,10 @@ class StrategyLabOrchestrator:
 
         Restricts merges to :data:`_ZERO_TRADE_SPEC_UPDATE_KEYS` so an
         off-list LLM hallucination cannot rewrite arbitrary spec fields.
-        Unlike :meth:`_apply_updates` (which is shared with the generic
-        refinement agent and only knows the legacy refinement keys),
-        this helper also honours ``signal_definition`` because the
-        repair agent's prompt includes it in the whitelist.
+        Post-#530 the whitelist is ``{"risk_limits"}`` — the repair agent
+        must fix the **code**, not weaken the **spec**. Off-list keys are
+        surfaced as a ``zero_trade_repair_dropped_spec_keys`` gate by the
+        caller; this helper only applies what is allowed.
         """
         data = spec.model_dump()
         for key in _ZERO_TRADE_SPEC_UPDATE_KEYS:

--- a/backend/agents/investment_team/strategy_lab/prompts/zero_trade_repair_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/zero_trade_repair_system.md
@@ -100,43 +100,32 @@ together tell you where in the lifecycle execution stopped.
    orchestrator's re-backtest gate; conservative integers are fine
    (e.g. `+5` orders, `+3` trades).
 
-If the proposed fix requires a small spec change (e.g. a too-tight
-`entry_rules` or a missing `exit_rules` clause), you may also return a
-`proposed_spec_updates` object containing only the rule fields you are
-adjusting. Do not invent new keys; the orchestrator will only honour
-`entry_rules`, `exit_rules`, `sizing`, `risk_limits`, `hypothesis`,
-and `signal_definition`.
+**Do not weaken the spec to make trades happen.** Loosening
+`entry_rules`, removing an `exit_rules` clause, broadening `sizing`,
+rewording `hypothesis`, or rewriting `signal_definition` is exactly the
+wrong fix — it lets the strategy quietly drift away from its original
+thesis across refinement rounds. Those keys are **not** honoured by the
+orchestrator; if you emit them they will be silently dropped and a
+quality-gate warning will be raised. Fix the **code** instead.
 
-When `proposed_spec_updates` includes rule-shaped keys, the values MUST
-be the structured DSL objects (every rule carries a `kind` discriminator)
-— the parser rejects prose strings. The rule shapes the orchestrator
-accepts (mirrored from `spec_dsl.py`) are:
+The only spec key you may adjust is `risk_limits`, and only when the
+**diagnostics** show the current limits are actually responsible for
+the zero-trade outcome (e.g. `orders_rejected` with a
+`risk_gate:max_drawdown` reason against an overly tight
+`max_drawdown_pct`). When you do propose a `risk_limits` update, return
+the FULL replacement object — for example:
 
 ```json
 {
-  "entry_rules": [{
-    "kind": "entry", "side": "long",
-    "when": {"lhs": {"kind": "rsi", "period": 14},
-             "op": "lt",
-             "rhs": {"kind": "const", "value": 30}}
-  }],
-  "exit_rules": [
-    {"kind": "signal_exit",
-     "when": {"lhs": {"kind": "rsi", "period": 14},
-              "op": "gt",
-              "rhs": {"kind": "const", "value": 70}}},
-    {"kind": "time_stop", "n_bars": 10}
-  ],
-  "sizing": {"kind": "fixed_fraction", "fraction": 0.02}
+  "risk_limits": {
+    "max_position_pct": 5,
+    "max_drawdown_pct": 10
+  }
 }
 ```
 
-Indicator `kind`s accepted: `price`, `const`, `sma`, `ema`, `rsi`, `macd`,
-`bollinger`, `atr`, `adx`, `stochastic`, `vwap`. Comparison `op`s
-accepted: `gt`, `lt`, `ge`, `le`, `eq`, `cross_above`, `cross_below`.
-Exit-rule `kind`s accepted: `time_stop`, `stop_loss`, `take_profit`,
-`signal_exit`. Sizing `kind`s accepted: `fixed_fraction`,
-`volatility_target`, `fixed_notional`.
+The orchestrator will only honour `risk_limits`; any other key in
+`proposed_spec_updates` is silently dropped and logged.
 
 If the diagnostics do not give you enough evidence to propose a code
 change you are confident in, return `proposed_code: null` and explain
@@ -165,4 +154,6 @@ Return ONLY a JSON object with no markdown:
 - When you cannot diagnose the failure, set `proposed_code: null` and
   explain the gap; the orchestrator will fall back to generic refinement.
 - `proposed_spec_updates`, when non-null, MUST contain only the
-  whitelisted keys above; the orchestrator silently drops any other key.
+  `risk_limits` key (post-#530); the orchestrator silently drops every
+  other key and emits a `zero_trade_repair_dropped_spec_keys` warning
+  gate on the run.

--- a/backend/agents/investment_team/tests/test_agent_prompts_structured.py
+++ b/backend/agents/investment_team/tests/test_agent_prompts_structured.py
@@ -347,11 +347,16 @@ def _zero_trade_payload(*, proposed_spec_updates=None) -> str:
     return json.dumps(payload)
 
 
-def test_zero_trade_repair_accepts_structured_spec_updates(
+def test_zero_trade_repair_accepts_risk_limits_spec_update(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Structured ``proposed_spec_updates`` survives the repair agent intact."""
+    """Post-#530 only ``risk_limits`` survives the repair agent's whitelist;
+    rule-shaped keys (which would mutate the strategy thesis) are silently
+    dropped before they reach the orchestrator."""
     spec_updates = {
+        "risk_limits": {"max_position_pct": 5, "max_drawdown_pct": 10},
+        # Rule-shaped keys MUST be dropped — they represent the thesis
+        # and zero-trade repair may not weaken them.
         "entry_rules": [_structured_entry_rule_dict()],
         "exit_rules": [_structured_signal_exit_rule_dict()],
     }
@@ -363,52 +368,21 @@ def test_zero_trade_repair_accepts_structured_spec_updates(
         diagnostics=_zero_trade_diagnostics(),
     )
 
-    assert report.proposed_spec_updates == spec_updates
+    assert report.proposed_spec_updates == {
+        "risk_limits": {"max_position_pct": 5, "max_drawdown_pct": 10}
+    }
     assert report.proposed_code == "# repaired code"
 
 
-def test_zero_trade_repair_drops_prose_spec_updates(
-    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+def test_zero_trade_repair_drops_off_list_rule_spec_updates(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Prose-shaped ``proposed_spec_updates`` is dropped (orchestrator falls
-    through to generic refinement) but ``proposed_code`` survives."""
+    """Rule-shaped ``proposed_spec_updates`` keys are off-list post-#530 and
+    are silently filtered at the agent before they reach the orchestrator.
+    With no whitelisted key remaining, the field collapses to ``None``."""
     spec_updates = {
         "entry_rules": ["close > sma(20)"],
         "exit_rules": ["exit after 10 bars"],
-    }
-    _patch_zero_trade_repair(monkeypatch, _zero_trade_payload(proposed_spec_updates=spec_updates))
-
-    with caplog.at_level(
-        logging.WARNING,
-        logger="investment_team.strategy_lab.agents.zero_trade_repair",
-    ):
-        report = ZeroTradeRepairAgent().run(
-            spec=_spec(),
-            code="# original",
-            diagnostics=_zero_trade_diagnostics(),
-        )
-
-    assert report.proposed_spec_updates is None
-    assert report.proposed_code == "# repaired code"
-    assert any("invalid structured rule shape" in rec.message for rec in caplog.records)
-
-
-def test_zero_trade_repair_drops_invalid_structured_spec_updates(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Structured-but-invalid (unknown indicator bound violation) is dropped."""
-    spec_updates = {
-        "entry_rules": [
-            {
-                "kind": "entry",
-                "side": "long",
-                "when": {
-                    "lhs": {"kind": "rsi", "period": 1},  # below the ge=2 bound
-                    "op": "lt",
-                    "rhs": {"kind": "const", "value": 30},
-                },
-            }
-        ]
     }
     _patch_zero_trade_repair(monkeypatch, _zero_trade_payload(proposed_spec_updates=spec_updates))
 
@@ -419,3 +393,27 @@ def test_zero_trade_repair_drops_invalid_structured_spec_updates(
     )
 
     assert report.proposed_spec_updates is None
+    assert report.proposed_code == "# repaired code"
+
+
+def test_zero_trade_repair_drops_thesis_spec_updates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Thesis-defining keys (``hypothesis``, ``signal_definition``, ``sizing``)
+    are off-list post-#530 and dropped at the agent. The committed report
+    surfaces only the whitelisted ``risk_limits`` mutation."""
+    spec_updates = {
+        "hypothesis": "rewritten thesis",
+        "signal_definition": "loosened",
+        "sizing": {"kind": "fixed_fraction", "fraction": 0.5},
+        "risk_limits": {"max_position_pct": 5},
+    }
+    _patch_zero_trade_repair(monkeypatch, _zero_trade_payload(proposed_spec_updates=spec_updates))
+
+    report = ZeroTradeRepairAgent().run(
+        spec=_spec(),
+        code="# original",
+        diagnostics=_zero_trade_diagnostics(),
+    )
+
+    assert report.proposed_spec_updates == {"risk_limits": {"max_position_pct": 5}}

--- a/backend/agents/investment_team/tests/test_agent_prompts_structured.py
+++ b/backend/agents/investment_team/tests/test_agent_prompts_structured.py
@@ -372,6 +372,7 @@ def test_zero_trade_repair_accepts_risk_limits_spec_update(
         "risk_limits": {"max_position_pct": 5, "max_drawdown_pct": 10}
     }
     assert report.proposed_code == "# repaired code"
+    assert report.dropped_spec_update_keys == sorted(["entry_rules", "exit_rules"])
 
 
 def test_zero_trade_repair_drops_off_list_rule_spec_updates(
@@ -379,7 +380,9 @@ def test_zero_trade_repair_drops_off_list_rule_spec_updates(
 ) -> None:
     """Rule-shaped ``proposed_spec_updates`` keys are off-list post-#530 and
     are silently filtered at the agent before they reach the orchestrator.
-    With no whitelisted key remaining, the field collapses to ``None``."""
+    With no whitelisted key remaining, the field collapses to ``None`` but
+    the dropped keys are recorded so the orchestrator can still surface a
+    warning + quality gate on the production agent-to-orchestrator flow."""
     spec_updates = {
         "entry_rules": ["close > sma(20)"],
         "exit_rules": ["exit after 10 bars"],
@@ -394,6 +397,7 @@ def test_zero_trade_repair_drops_off_list_rule_spec_updates(
 
     assert report.proposed_spec_updates is None
     assert report.proposed_code == "# repaired code"
+    assert report.dropped_spec_update_keys == sorted(["entry_rules", "exit_rules"])
 
 
 def test_zero_trade_repair_drops_thesis_spec_updates(
@@ -401,7 +405,9 @@ def test_zero_trade_repair_drops_thesis_spec_updates(
 ) -> None:
     """Thesis-defining keys (``hypothesis``, ``signal_definition``, ``sizing``)
     are off-list post-#530 and dropped at the agent. The committed report
-    surfaces only the whitelisted ``risk_limits`` mutation."""
+    surfaces only the whitelisted ``risk_limits`` mutation, and records the
+    dropped keys on ``dropped_spec_update_keys`` so the orchestrator can
+    persist a warning + quality gate."""
     spec_updates = {
         "hypothesis": "rewritten thesis",
         "signal_definition": "loosened",
@@ -417,3 +423,4 @@ def test_zero_trade_repair_drops_thesis_spec_updates(
     )
 
     assert report.proposed_spec_updates == {"risk_limits": {"max_position_pct": 5}}
+    assert report.dropped_spec_update_keys == sorted(["hypothesis", "signal_definition", "sizing"])

--- a/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
@@ -493,7 +493,7 @@ def test_zero_trade_repair_invalid_spec_updates_falls_through(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A whitelisted ``proposed_spec_updates`` key with the wrong shape
-    (e.g. ``entry_rules`` as a string) must be rejected as a
+    (e.g. ``risk_limits`` as a bare string) must be rejected as a
     not-committed outcome — the helper must NOT let the resulting
     Pydantic ``ValidationError`` abort the entire Strategy Lab cycle."""
     orch, repair_stub, sandbox_stub = _make_orchestrator_with_stubs(
@@ -503,11 +503,11 @@ def test_zero_trade_repair_invalid_spec_updates_falls_through(
                 root_cause_category="ENTRY_WITH_NO_EXIT",
                 evidence="entries_filled=4 closed_trades=0",
                 proposed_code=_REPAIRED_CODE,
-                # ``entry_rules`` must be a list[str]; a bare string is
-                # the realistic LLM error mode that previously crashed
-                # the cycle.
-                proposed_spec_updates={"entry_rules": "exit after 5 bars"},
-                changes_made="malformed entry_rules",
+                # Post-#530, ``risk_limits`` is the only whitelisted key.
+                # A bare string is the realistic LLM error mode that
+                # previously crashed the cycle.
+                proposed_spec_updates={"risk_limits": "loosen drawdown please"},
+                changes_made="malformed risk_limits",
             ),
         ],
         sandbox_results=[],  # sandbox MUST NOT be called
@@ -574,7 +574,8 @@ def test_zero_trade_repair_applies_proposed_spec_updates(
 ) -> None:
     """Whitelisted ``proposed_spec_updates`` flow into the committed spec;
     off-list keys are silently dropped so an LLM hallucination cannot
-    rewrite arbitrary fields."""
+    rewrite arbitrary fields. Post-#530 the whitelist is ``risk_limits``
+    only."""
     orch, repair_stub, sandbox_stub = _make_orchestrator_with_stubs(
         monkeypatch,
         repair_reports=[
@@ -583,12 +584,13 @@ def test_zero_trade_repair_applies_proposed_spec_updates(
                 evidence="entries_filled=4 closed_trades=0",
                 proposed_code=_REPAIRED_CODE,
                 proposed_spec_updates={
+                    "risk_limits": {"max_position_pct": 5, "max_drawdown_pct": 10},
+                    # Off-list keys MUST NOT mutate the spec (#530).
                     "exit_rules": [TimeStopRule(n_bars=10, note="added time stop").model_dump()],
-                    # Off-list keys MUST NOT mutate the spec.
                     "strategy_id": "hijacked",
                     "asset_class": "crypto",
                 },
-                changes_made="added time-stop exit",
+                changes_made="loosened drawdown limit",
             ),
         ],
         sandbox_results=[
@@ -605,10 +607,113 @@ def test_zero_trade_repair_applies_proposed_spec_updates(
     assert outcome.committed is True
     assert outcome.new_spec is not None
     # Whitelisted update applied …
-    assert outcome.new_spec.exit_rules == [TimeStopRule(n_bars=10, note="added time stop")]
-    # … and off-list mutations were silently dropped.
+    assert outcome.new_spec.risk_limits.max_position_pct == 5
+    assert outcome.new_spec.risk_limits.max_drawdown_pct == 10
+    # … and off-list mutations were silently dropped (rule + immutable keys).
+    original_exit_rules = _spec().exit_rules
+    assert outcome.new_spec.exit_rules == original_exit_rules
     assert outcome.new_spec.strategy_id == "strat-zt-repair-test"
     assert outcome.new_spec.asset_class == "stocks"
+    # And a dropped-keys quality gate was surfaced on the committed run.
+    dropped_gates = [
+        g for g in outcome.new_gates if g.gate_name == "zero_trade_repair_dropped_spec_keys"
+    ]
+    assert dropped_gates, outcome.new_gates
+    assert dropped_gates[0].severity == "warning"
+    assert dropped_gates[0].passed is False
+    assert "exit_rules" in dropped_gates[0].details
+    assert "strategy_id" in dropped_gates[0].details
+    assert "asset_class" in dropped_gates[0].details
+
+
+def test_zero_trade_repair_drops_off_list_spec_keys_protects_thesis(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Issue #530: when the repair agent proposes ``hypothesis``,
+    ``entry_rules`` (or any other thesis-defining key), those mutations
+    MUST be dropped silently — never reach the committed spec — and the
+    drop MUST be surfaced as a warning gate plus a ``logger.warning`` so
+    the thesis cannot quietly mutate across refinement rounds."""
+    pre_repair_spec = _spec()
+
+    orch, repair_stub, sandbox_stub = _make_orchestrator_with_stubs(
+        monkeypatch,
+        repair_reports=[
+            ZeroTradeRepairReport(
+                root_cause_category="ENTRY_WITH_NO_EXIT",
+                evidence="entries_filled=4 closed_trades=0",
+                proposed_code=_REPAIRED_CODE,
+                # All of these MUST be dropped — only ``risk_limits`` is
+                # honoured post-#530.
+                proposed_spec_updates={
+                    "hypothesis": "QQQ → TSLA bait",
+                    "signal_definition": "loosened",
+                    "entry_rules": [
+                        EntryRule(
+                            side="long",
+                            when=Predicate(
+                                lhs=RSIRef(period=14),
+                                op="lt",
+                                rhs=ConstRef(value=90),
+                            ),
+                        ).model_dump()
+                    ],
+                    "exit_rules": [TimeStopRule(n_bars=10, note="x").model_dump()],
+                    "sizing": {"kind": "fixed_fraction", "fraction": 0.5},
+                },
+                changes_made="attempted to rewrite the thesis",
+            ),
+        ],
+        sandbox_results=[
+            _code_exec(success=True, raw_trades=_benign_sandbox_trades()),
+        ],
+    )
+
+    with caplog.at_level(
+        "WARNING",
+        logger="investment_team.strategy_lab.orchestrator",
+    ):
+        outcome, _events, _attempts = _drive_repair(
+            orch,
+            spec=pre_repair_spec,
+            exec_result=StrategyRunResult(
+                success=True,
+                trades=[],
+                execution_diagnostics=_zero_trade_diagnostics(category="ENTRY_WITH_NO_EXIT"),
+            ),
+        )
+
+    assert outcome.committed is True
+    assert outcome.new_spec is not None
+    # Thesis-defining keys are NEVER overwritten by zero-trade repair.
+    assert outcome.new_spec.hypothesis == pre_repair_spec.hypothesis
+    assert outcome.new_spec.signal_definition == pre_repair_spec.signal_definition
+    assert outcome.new_spec.entry_rules == pre_repair_spec.entry_rules
+    assert outcome.new_spec.exit_rules == pre_repair_spec.exit_rules
+    assert outcome.new_spec.sizing == pre_repair_spec.sizing
+    # risk_limits was untouched by the proposal so it must also be unchanged.
+    assert outcome.new_spec.risk_limits == pre_repair_spec.risk_limits
+
+    # The dropped-keys gate is surfaced on the committed run.
+    dropped_gates = [
+        g for g in outcome.new_gates if g.gate_name == "zero_trade_repair_dropped_spec_keys"
+    ]
+    assert len(dropped_gates) == 1, outcome.new_gates
+    gate = dropped_gates[0]
+    assert gate.severity == "warning"
+    assert gate.passed is False
+    for key in ("hypothesis", "signal_definition", "entry_rules", "exit_rules", "sizing"):
+        assert key in gate.details
+
+    # And the logger.warning fired with the dropped keys.
+    drop_logs = [
+        rec for rec in caplog.records if "discarded spec-mutating keys" in rec.getMessage()
+    ]
+    assert drop_logs, [rec.getMessage() for rec in caplog.records]
+    msg = drop_logs[0].getMessage()
+    for key in ("hypothesis", "signal_definition", "entry_rules", "exit_rules", "sizing"):
+        assert key in msg
 
 
 def test_zero_trade_repair_rejects_spec_updates_failing_post_repair_validator(

--- a/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
@@ -716,6 +716,79 @@ def test_zero_trade_repair_drops_off_list_spec_keys_protects_thesis(
         assert key in msg
 
 
+def test_zero_trade_repair_surfaces_agent_filtered_drops_in_production_flow(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Issue #530 (codex review follow-up): in the real production flow the
+    agent's ``_coerce_report`` strips off-list keys from ``proposed_spec_updates``
+    before the report reaches the orchestrator, so the orchestrator never sees
+    raw drift on ``proposed_spec_updates``. The orchestrator must still emit
+    the ``logger.warning`` and the ``zero_trade_repair_dropped_spec_keys`` gate
+    by reading ``report.dropped_spec_update_keys`` populated by the agent —
+    otherwise the visibility added in #530 only fires in tests with stubs."""
+    pre_repair_spec = _spec()
+
+    orch, repair_stub, sandbox_stub = _make_orchestrator_with_stubs(
+        monkeypatch,
+        repair_reports=[
+            ZeroTradeRepairReport(
+                root_cause_category="ENTRY_WITH_NO_EXIT",
+                evidence="entries_filled=4 closed_trades=0",
+                proposed_code=_REPAIRED_CODE,
+                # ``proposed_spec_updates`` is what the production agent
+                # would return after its own filter ran — only the
+                # whitelisted ``risk_limits`` survived. The off-list keys
+                # are reported separately via ``dropped_spec_update_keys``.
+                proposed_spec_updates=None,
+                dropped_spec_update_keys=["entry_rules", "hypothesis", "sizing"],
+                changes_made="risk_limits tweak only after agent filter",
+            ),
+        ],
+        sandbox_results=[
+            _code_exec(success=True, raw_trades=_benign_sandbox_trades()),
+        ],
+    )
+
+    with caplog.at_level(
+        "WARNING",
+        logger="investment_team.strategy_lab.orchestrator",
+    ):
+        outcome, _events, _attempts = _drive_repair(
+            orch,
+            spec=pre_repair_spec,
+            exec_result=StrategyRunResult(
+                success=True,
+                trades=[],
+                execution_diagnostics=_zero_trade_diagnostics(category="ENTRY_WITH_NO_EXIT"),
+            ),
+        )
+
+    assert outcome.committed is True
+    assert outcome.new_spec is not None
+    # No off-list mutation reached the committed spec.
+    assert outcome.new_spec.hypothesis == pre_repair_spec.hypothesis
+    assert outcome.new_spec.entry_rules == pre_repair_spec.entry_rules
+    assert outcome.new_spec.sizing == pre_repair_spec.sizing
+
+    # Even though ``proposed_spec_updates`` was already sanitised by the
+    # agent, the orchestrator surfaces what was dropped.
+    dropped_gates = [
+        g for g in outcome.new_gates if g.gate_name == "zero_trade_repair_dropped_spec_keys"
+    ]
+    assert len(dropped_gates) == 1, outcome.new_gates
+    gate = dropped_gates[0]
+    assert gate.severity == "warning"
+    assert gate.passed is False
+    for key in ("entry_rules", "hypothesis", "sizing"):
+        assert key in gate.details
+
+    drop_logs = [
+        rec for rec in caplog.records if "discarded spec-mutating keys" in rec.getMessage()
+    ]
+    assert drop_logs, [rec.getMessage() for rec in caplog.records]
+
+
 def test_zero_trade_repair_rejects_spec_updates_failing_post_repair_validator(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
@@ -541,6 +541,64 @@ def test_zero_trade_repair_invalid_spec_updates_falls_through(
     assert rejected_event["reason"] == "invalid_spec_updates"
 
 
+def test_zero_trade_repair_invalid_spec_updates_still_carries_dropped_keys_gate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Issue #530: when the proposal both (a) has off-list keys the agent
+    already filtered AND (b) the surviving ``risk_limits`` is malformed
+    enough to raise ``ValidationError`` in ``_apply_zero_trade_spec_updates``,
+    the early-return path must still surface the
+    ``zero_trade_repair_dropped_spec_keys`` audit gate. Previously the
+    ValidationError path returned ``new_gates=safety_gates`` only and the
+    dropped-keys gate was lost — the warning fired but the audit trail
+    was missing from ``quality_gate_results``."""
+    orch, repair_stub, sandbox_stub = _make_orchestrator_with_stubs(
+        monkeypatch,
+        repair_reports=[
+            ZeroTradeRepairReport(
+                root_cause_category="ENTRY_WITH_NO_EXIT",
+                evidence="entries_filled=4 closed_trades=0",
+                proposed_code=_REPAIRED_CODE,
+                # ``risk_limits`` as a bare string → Pydantic
+                # ValidationError when ``_apply_zero_trade_spec_updates``
+                # tries to coerce into ``RiskLimits``.
+                proposed_spec_updates={"risk_limits": "loosen drawdown please"},
+                # Agent-pre-filtered keys that should still be surfaced
+                # on the rejected run's quality gates.
+                dropped_spec_update_keys=["entry_rules", "hypothesis"],
+                changes_made="malformed risk_limits plus filtered drift",
+            ),
+        ],
+        sandbox_results=[],  # sandbox MUST NOT be called
+    )
+
+    outcome, events, attempts = _drive_repair(
+        orch,
+        exec_result=StrategyRunResult(
+            success=True,
+            trades=[],
+            execution_diagnostics=_zero_trade_diagnostics(category="ENTRY_WITH_NO_EXIT"),
+        ),
+    )
+
+    assert outcome.committed is False
+    assert outcome.failure_reason == "invalid_spec_updates"
+    assert sandbox_stub.calls == []
+
+    # The dropped-keys gate is preserved on the rejected outcome so the
+    # persisted ``quality_gate_results`` still reflects the attempted
+    # off-list mutation.
+    dropped_gates = [
+        g for g in outcome.new_gates if g.gate_name == "zero_trade_repair_dropped_spec_keys"
+    ]
+    assert len(dropped_gates) == 1, outcome.new_gates
+    gate = dropped_gates[0]
+    assert gate.severity == "warning"
+    assert gate.passed is False
+    for key in ("entry_rules", "hypothesis"):
+        assert key in gate.details
+
+
 def test_zero_trade_repair_agent_exception_falls_through(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary

Closes #530.

Zero-trade repair previously allowed `proposed_spec_updates` to mutate **six** spec keys (`entry_rules`, `exit_rules`, `sizing`, `risk_limits`, `hypothesis`, `signal_definition`). The path of least resistance for a "make trades happen" LLM was to **loosen the spec** — drop a constraint mentioning a missing symbol, broaden entry rules, reword the hypothesis — so a "QQQ" thesis could silently mutate into a TSLA-friendly one over a few refinement rounds.

This PR narrows both whitelists to **`risk_limits` only**. The repair agent must fix the **code**, not weaken the **spec**.

- `_ZERO_TRADE_SPEC_UPDATE_KEYS` (orchestrator) and `_ALLOWED_SPEC_UPDATE_KEYS` (agent) → `{"risk_limits"}`.
- Off-list keys are dropped with a `logger.warning` and surfaced as a new `zero_trade_repair_dropped_spec_keys` quality gate (`severity="warning"`, `passed=False`) so the attempted drift is visible in the persisted `quality_gate_results`.
- Agent prompt updated to instruct the LLM to fix the code; the rule-DSL example block is removed.

## Test plan

- [x] Existing `test_zero_trade_repair_applies_proposed_spec_updates` updated to use `risk_limits` as the whitelisted key with `exit_rules`/`strategy_id`/`asset_class` as off-list; asserts dropped-keys gate fires.
- [x] `test_zero_trade_repair_invalid_spec_updates_falls_through` updated to use malformed `risk_limits` (still exercises the Pydantic-rejection fall-through).
- [x] New `test_zero_trade_repair_drops_off_list_spec_keys_protects_thesis` asserts `hypothesis`, `signal_definition`, `entry_rules`, `exit_rules`, and `sizing` are never overwritten, that the dropped-keys gate is surfaced, and that the `logger.warning` fires.
- [x] Agent-level structured-prompts tests refactored: `test_zero_trade_repair_accepts_risk_limits_spec_update`, `test_zero_trade_repair_drops_off_list_rule_spec_updates`, `test_zero_trade_repair_drops_thesis_spec_updates`.
- [x] Full investment-team `zero_trade or repair or refinement or strategy_validator` suite: **65 passed**.
- [x] `ruff check` + `ruff format` clean on touched files.

https://claude.ai/code/session_01MyvFX1MqQLuryPCivsZRBH

---
_Generated by [Claude Code](https://claude.ai/code/session_01MyvFX1MqQLuryPCivsZRBH)_