### PR TITLE
investment-team: reject 'options' asset class at validator gate (#535)

### DIFF
--- a/backend/agents/investment_team/market_data_service.py
+++ b/backend/agents/investment_team/market_data_service.py
@@ -257,13 +257,18 @@ class MarketDataService:
     def get_symbols_for_strategy(self, strategy: StrategySpec) -> List[str]:
         """Return relevant symbols based on the strategy's asset class."""
         asset = normalize_asset_class(strategy.asset_class)
-        symbol_map = {
+        symbol_map: dict[str, list[str]] = {
             "crypto": CRYPTO_SYMBOLS,
             "stocks": STOCK_SYMBOLS,
-            "options": STOCK_SYMBOLS,
             "forex": FOREX_SYMBOLS,
             "futures": FUTURES_SYMBOLS,
             "commodities": COMMODITY_SYMBOLS,
+            # #535: 'options' is not yet supported — no option-chain data,
+            # Greeks, or contract execution model. StrategySpecValidator
+            # rejects it as a critical gate failure before this runs; the
+            # empty list here is defense-in-depth for any path that skips
+            # the validator.
+            "options": [],
         }
         return list(symbol_map.get(asset, STOCK_SYMBOLS))
 

--- a/backend/agents/investment_team/strategy_ideation_agent.py
+++ b/backend/agents/investment_team/strategy_ideation_agent.py
@@ -29,7 +29,7 @@ _IDEATION_SYSTEM = (
     "You combine several signal families (price/volatility, macro, sentiment, corporate events) into coherent rules. "
     "You explicitly reason about information not in raw OHLCV: news and social sentiment, issuer filings, "
     "macro and micro structure, liquidity regimes, and confounding drivers that backtests may omit. "
-    "You diversify across asset classes (stocks, crypto, forex, options, futures, commodities) rather than "
+    "You diversify across asset classes (stocks, crypto, forex, futures, commodities) rather than "
     "defaulting to equities."
 )
 
@@ -56,7 +56,7 @@ Name which confounders you are leaning on and how they interact with price signa
 Each prior entry includes outcome, metrics, rationale, and post-backtest analysis. Generate a strategy that **differs** from prior ones and learns from their failures.
 Return ONLY a JSON object with no markdown:
 {{
-  "asset_class": "stocks" | "crypto" | "forex" | "options" | "futures" | "commodities",
+  "asset_class": "stocks" | "crypto" | "forex" | "futures" | "commodities",
   "hypothesis": "1-3 sentence investment thesis tying multiple signals to edge",
   "signal_definition": "Describe the **ensemble** of signals (e.g. price filter + macro gate + sentiment/filings trigger) and how they combine (AND/OR, scoring, veto rules)",
   "signal_sources": ["list of families used, e.g. price_action, macro_rates, news_sentiment, filings, social_sentiment, cross_asset"],

--- a/backend/agents/investment_team/strategy_lab/agents/ideation.py
+++ b/backend/agents/investment_team/strategy_lab/agents/ideation.py
@@ -45,7 +45,7 @@ and `sizing` MUST be the structured DSL objects described in the system
 prompt — prose strings will be rejected.
 
 {{
-  "asset_class": "stocks" | "crypto" | "forex" | "options" | "futures" | "commodities",
+  "asset_class": "stocks" | "crypto" | "forex" | "futures" | "commodities",
   "hypothesis": "1-3 sentence investment thesis tying multiple signals to edge",
   "signal_definition": "Describe the ensemble of signals and how they combine",
   "entry_rules": [

--- a/backend/agents/investment_team/strategy_lab/prompts/ideation_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/ideation_system.md
@@ -99,7 +99,7 @@ Prose strings (the shape above) and the legacy `sizing_rules` list-of-strings ar
 
 ## Asset class diversity
 
-Diversify across: stocks, crypto, forex, options, futures, commodities. Do NOT default to equities unless explicitly directed.
+Diversify across: stocks, crypto, forex, futures, commodities. Do NOT default to equities unless explicitly directed. The `options` asset class is rejected by the validator (no option-chain data, Greeks, or contract execution model yet) — do not choose it.
 
 ## Target symbols
 

--- a/backend/agents/investment_team/strategy_lab/quality_gates/strategy_validator.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/strategy_validator.py
@@ -6,6 +6,7 @@ import re
 from typing import List
 
 from ...models import StrategySpec
+from ...strategy_lab_context import normalize_asset_class
 from ..spec_dsl import format_rules_for_prompt, format_sizing_rule
 from .models import QualityGateResult
 
@@ -40,6 +41,24 @@ class StrategySpecValidator:
 
     def validate(self, spec: StrategySpec) -> List[QualityGateResult]:
         results: List[QualityGateResult] = []
+
+        # 0. Asset class supported (#535). 'options' has no chain data,
+        #    Greeks, or contract execution model — reject before
+        #    market-data fetch silently treats it as equities.
+        if normalize_asset_class(spec.asset_class) == "options":
+            results.append(
+                QualityGateResult(
+                    gate_name=GATE,
+                    passed=False,
+                    severity="critical",
+                    details=(
+                        "Asset class 'options' is not yet supported — no "
+                        "option-chain data, Greeks, or contract execution "
+                        "model is available. Choose stocks, crypto, forex, "
+                        "futures, or commodities."
+                    ),
+                )
+            )
 
         # 1. Entry rules present
         if not spec.entry_rules:

--- a/backend/agents/investment_team/strategy_lab_context.py
+++ b/backend/agents/investment_team/strategy_lab_context.py
@@ -71,7 +71,7 @@ def asset_class_mix_hint(records: List[StrategyLabRecord], *, tail: int = 24) ->
     if not records:
         return (
             "No prior lab strategies. Choose **asset_class** from "
-            "stocks, crypto, forex, options, futures, or commodities with similar frequency over time — "
+            "stocks, crypto, forex, futures, or commodities with similar frequency over time — "
             "do **not** default to stocks; pick the class that best fits your multi-signal story."
         )
 
@@ -97,7 +97,7 @@ def asset_class_mix_hint(records: List[StrategyLabRecord], *, tail: int = 24) ->
     if stock_share > 0.35 and n_sample >= 2:
         parts.append(
             "Equities are relatively heavy in this window — **strongly prefer** "
-            "crypto, forex, options, futures, or commodities for this run if you can state coherent rules."
+            "crypto, forex, futures, or commodities for this run if you can state coherent rules."
         )
     parts.append(
         "Underrepresented line(s) to favor when ties: "

--- a/backend/agents/investment_team/strategy_lab_context.py
+++ b/backend/agents/investment_team/strategy_lab_context.py
@@ -19,6 +19,14 @@ _CANONICAL_ASSET_CLASSES: tuple[str, ...] = (
     "commodities",
 )
 
+# Asset classes the LLM is allowed to choose for new strategies (#535).
+# 'options' is canonical (so ``normalize_asset_class`` preserves it for the
+# validator gate to reject) but not a valid ideation target, so it's
+# excluded from prompt counts and underrepresented-class steering.
+_PROMPT_ASSET_CLASSES: tuple[str, ...] = tuple(
+    c for c in _CANONICAL_ASSET_CLASSES if c != "options"
+)
+
 
 def normalize_asset_class(ac: object) -> str:
     """Map any asset-class string variant to one of the canonical labels.
@@ -77,7 +85,11 @@ def asset_class_mix_hint(records: List[StrategyLabRecord], *, tail: int = 24) ->
 
     ordered = sorted(records, key=lambda x: x.created_at)
     sample = ordered[-tail:] if len(ordered) > tail else ordered
-    counts = {c: 0 for c in _CANONICAL_ASSET_CLASSES}
+    # #535: count only asset classes the LLM may still target. 'options' is
+    # rejected by StrategySpecValidator, so leaving it in the count dict
+    # would push it into ``underrep`` whenever no options strategies have
+    # run and steer the LLM toward a guaranteed-failure choice.
+    counts = {c: 0 for c in _PROMPT_ASSET_CLASSES}
     for r in sample:
         k = normalize_asset_class(r.strategy.asset_class)
         if k in counts:

--- a/backend/agents/investment_team/tests/test_asset_class_mix_hint.py
+++ b/backend/agents/investment_team/tests/test_asset_class_mix_hint.py
@@ -1,0 +1,109 @@
+"""Regression tests for ``asset_class_mix_hint`` (#535).
+
+Verifies that ``options`` — which the validator now rejects as a
+critical gate failure — is no longer surfaced as an underrepresented
+asset class the LLM should favor.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from investment_team.api import main as lab_main
+from investment_team.models import (
+    BacktestConfig,
+    BacktestRecord,
+    BacktestResult,
+    StrategyLabRecord,
+    StrategySpec,
+)
+from investment_team.strategy_lab.spec_dsl import (
+    ConstRef,
+    EntryRule,
+    Predicate,
+    PriceRef,
+    TimeStopRule,
+)
+from investment_team.strategy_lab_context import asset_class_mix_hint
+
+
+def _stub_backtest_result() -> BacktestResult:
+    return BacktestResult(
+        total_return_pct=10.0,
+        annualized_return_pct=5.0,
+        volatility_pct=12.0,
+        sharpe_ratio=0.5,
+        max_drawdown_pct=-3.0,
+        win_rate_pct=55.0,
+        profit_factor=1.2,
+        calmar_ratio=0.0,
+        deflated_sharpe=0.0,
+        sortino_ratio=0.0,
+    )
+
+
+def _record(asset_class: str) -> StrategyLabRecord:
+    suffix = uuid.uuid4().hex[:6]
+    strategy = StrategySpec(
+        strategy_id=f"s-{suffix}",
+        authored_by="test",
+        asset_class=asset_class,
+        hypothesis="h",
+        signal_definition="sig",
+        entry_rules=[
+            EntryRule(side="long", when=Predicate(lhs=PriceRef(), op="gt", rhs=ConstRef(value=0)))
+        ],
+        exit_rules=[TimeStopRule(n_bars=5)],
+        risk_limits={},
+        speculative=False,
+    )
+    now = lab_main._now()
+    backtest = BacktestRecord(
+        backtest_id=f"bt-{suffix}",
+        strategy_id=strategy.strategy_id,
+        strategy=strategy,
+        config=BacktestConfig(start_date="2024-01-01", end_date="2024-12-31"),
+        submitted_by="test",
+        submitted_at=now,
+        completed_at=now,
+        result=_stub_backtest_result(),
+        notes=[],
+        trades=[],
+    )
+    return StrategyLabRecord(
+        lab_record_id=f"lab-{suffix}",
+        strategy=strategy,
+        backtest=backtest,
+        is_winning=False,
+        strategy_rationale="r",
+        analysis_narrative="ok",
+        created_at=now,
+        quality_gate_results=[],
+    )
+
+
+def test_hint_no_records_omits_options() -> None:
+    """With no prior strategies the menu of choices must not include options."""
+    out = asset_class_mix_hint([])
+    assert "options" not in out.lower(), out
+
+
+def test_hint_with_history_never_lists_options_as_underrepresented() -> None:
+    """A history of stocks-heavy runs would have left options=0 in the count
+    dict before the fix, sending the LLM to options as 'underrepresented'."""
+    records = [_record("stocks") for _ in range(5)] + [_record("crypto")]
+    out = asset_class_mix_hint(records)
+
+    # The recent-counts breakdown must not enumerate options at all.
+    assert "options=" not in out, out
+    # The underrepresented-line steering must not name options.
+    assert "options" not in out.lower(), out
+
+
+def test_hint_count_includes_supported_classes() -> None:
+    """The supported classes should still appear in the count breakdown so
+    the LLM gets useful diversification steering."""
+    records = [_record("stocks") for _ in range(3)]
+    out = asset_class_mix_hint(records)
+    for ac in ("stocks", "crypto", "forex", "futures", "commodities"):
+        assert f"{ac}=" in out, f"expected '{ac}=' in counts, got: {out}"

--- a/backend/agents/investment_team/tests/test_investment_team.py
+++ b/backend/agents/investment_team/tests/test_investment_team.py
@@ -1059,6 +1059,31 @@ def test_market_data_service_get_symbols_for_commodities() -> None:
     assert "GLD" in symbols
 
 
+def test_market_data_service_get_symbols_for_options_returns_empty() -> None:
+    """#535: 'options' must NOT silently fall back to stock symbols.
+
+    The StrategySpecValidator rejects options upstream as a critical gate
+    failure; the empty list returned here is defense-in-depth so any code
+    path that skips the validator gets an empty universe (and a downstream
+    failure) instead of silently-wrong equity data.
+    """
+    from investment_team.market_data_service import MarketDataService
+
+    service = MarketDataService()
+    options_strategy = StrategySpec(
+        strategy_id="s-opt",
+        authored_by="test",
+        asset_class="options",
+        hypothesis="h",
+        signal_definition="s",
+    )
+    symbols = service.get_symbols_for_strategy(options_strategy)
+    assert symbols == [], (
+        f"options must return empty universe, got {symbols} "
+        "(silent fallback to STOCK_SYMBOLS is the bug from #535)"
+    )
+
+
 def test_market_data_service_fetch_ohlcv_range_routes_by_asset_class() -> None:
     """Verify fetch_ohlcv_range tries Yahoo first for all asset classes via the provider chain."""
     from unittest.mock import patch

--- a/backend/agents/investment_team/tests/test_strategy_validator.py
+++ b/backend/agents/investment_team/tests/test_strategy_validator.py
@@ -58,6 +58,89 @@ def _warnings(results) -> list[str]:
     return [r.details for r in results if r.severity == "warning" and not r.passed]
 
 
+def _critical(results) -> list[str]:
+    return [r.details for r in results if r.severity == "critical" and not r.passed]
+
+
+# ---------------------------------------------------------------------------
+# Issue #535 — 'options' asset class must be rejected at the validator
+# gate. Strategy Lab has no option-chain data, Greeks, or contract
+# execution model, so silently treating options as equities produced
+# meaningless backtest metrics.
+# ---------------------------------------------------------------------------
+
+
+def test_validator_rejects_options_asset_class() -> None:
+    """asset_class='options' fails a critical gate with an explanatory message."""
+    spec = _spec(
+        hypothesis="Buy ATM puts on SPY when VIX > 25.",
+        entry=[
+            EntryRule(
+                side="long",
+                when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30)),
+            ),
+        ],
+        exit_=[
+            SignalExitRule(
+                when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)),
+            ),
+        ],
+        asset_class="options",
+    )
+    results = StrategySpecValidator().validate(spec)
+    critical = _critical(results)
+    assert any("options" in c.lower() and "not yet supported" in c.lower() for c in critical), (
+        f"Expected a critical gate rejecting options, got: {critical}"
+    )
+
+
+def test_validator_rejects_options_via_normalize_alias() -> None:
+    """An LLM that emits a canonical 'options' label (uppercase, whitespace)
+    is still rejected — the gate runs after ``normalize_asset_class``."""
+    spec = _spec(
+        hypothesis="Buy ATM puts on SPY when VIX > 25.",
+        entry=[
+            EntryRule(
+                side="long",
+                when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30)),
+            ),
+        ],
+        exit_=[
+            SignalExitRule(
+                when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)),
+            ),
+        ],
+        asset_class="  OPTIONS  ",
+    )
+    results = StrategySpecValidator().validate(spec)
+    assert any("options" in c.lower() for c in _critical(results)), _critical(results)
+
+
+def test_validator_does_not_reject_supported_asset_classes() -> None:
+    """Supported asset classes (stocks, crypto, forex, futures, commodities)
+    must not trip the #535 options gate."""
+    for ac in ("stocks", "crypto", "forex", "futures", "commodities"):
+        spec = _spec(
+            hypothesis="RSI mean reversion",
+            entry=[
+                EntryRule(
+                    side="long",
+                    when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30)),
+                ),
+            ],
+            exit_=[
+                SignalExitRule(
+                    when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)),
+                ),
+            ],
+            asset_class=ac,
+        )
+        results = StrategySpecValidator().validate(spec)
+        assert not any("options" in c.lower() for c in _critical(results)), (
+            f"asset_class={ac!r} unexpectedly tripped the options gate: {_critical(results)}"
+        )
+
+
 def test_hypothesis_term_missing_from_rules_emits_warning() -> None:
     """Hypothesis names RSI; rules use SMA → consistency warning fires.
 


### PR DESCRIPTION
## Summary
- Reject `asset_class="options"` at the `StrategySpecValidator` gate with a critical quality-gate failure recommending the supported classes.
- Return `[]` from `MarketDataService.get_symbols_for_strategy` for `options` (defense-in-depth) instead of silently falling back to `STOCK_SYMBOLS`.
- Drop `options` from both ideation prompts and the `asset_class_mix_hint` copy so the LLM stops proposing strategies that are guaranteed to fail the gate.

Fixes #535.

### Why
The Strategy Lab silently mapped `options` → `STOCK_SYMBOLS`, so an LLM-ideated options strategy ("buy ATM puts when …") was backtested as a daily-bar equity strategy — no chain data, no Greeks, no expiry, no contract execution model. The resulting metrics were meaningless.

This is Option 1 from the issue (reject until proper support exists). Real options support (chains, Greeks, contract execution) is its own multi-PR effort.

### Notes on what stayed
- `_CANONICAL_ASSET_CLASSES` keeps `"options"` so `normalize_asset_class` preserves the literal — folding it into `"stocks"` at normalize time would silently rewrite options to equities under a different name.
- Cost-model and benchmark-map entries for `"options"` are intentionally left alone — they're harmless after the gate fires.
- `agents.py` / `PortfolioConstraints.max_asset_class_pct` references to `"options"` belong to the higher-level IPS/portfolio agent, not Strategy Lab; out of scope.

## Test plan
- [x] `pytest agents/investment_team/tests/test_strategy_validator.py -v` — 12 passed (3 new)
- [x] `pytest agents/investment_team/tests/test_investment_team.py::test_market_data_service_get_symbols_for_*` — 5 passed (1 new)
- [x] `pytest agents/investment_team/tests/` — 1378 passed, 13 skipped, no regressions
- [x] `ruff check .` — clean
- [x] `ruff format --check` on touched files — clean

https://claude.ai/code/session_01TScLGkbtgCs94mtGKmRbUV

---
_Generated by [Claude Code](https://claude.ai/code/session_01TScLGkbtgCs94mtGKmRbUV)_