### PR TITLE
investment-team: rewrite StrategySpec DSL to issue #537 literal schema

### DIFF
--- a/backend/agents/investment_team/api/main.py
+++ b/backend/agents/investment_team/api/main.py
@@ -9,7 +9,7 @@ import threading
 import uuid
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import StreamingResponse
@@ -418,7 +418,12 @@ class CreateStrategyRequest(BaseModel):
     asset_class: str = Field(..., description="Primary asset class")
     hypothesis: str = Field(..., description="Investment hypothesis")
     signal_definition: str = Field(..., description="Signal definition")
-    # Issue #551/#554: rule fields are structured DSL nodes. Typed directly
+    # Issue #537: every spec must declare the bar timeframe it was designed
+    # against — required, no default.
+    timeframe: Literal["1m", "5m", "15m", "1h", "1d"] = Field(
+        ..., description="Bar timeframe the strategy was designed against"
+    )
+    # Issue #551/#554/#537: rule fields are structured DSL nodes. Typed directly
     # so FastAPI publishes the discriminated-union schema in OpenAPI and
     # returns 422 (rather than 500) for malformed input.
     entry_rules: List[EntryRule] = Field(default_factory=list)
@@ -692,6 +697,7 @@ def create_strategy(request: CreateStrategyRequest) -> CreateStrategyResponse:
         asset_class=request.asset_class,
         hypothesis=request.hypothesis,
         signal_definition=request.signal_definition,
+        timeframe=request.timeframe,
         entry_rules=request.entry_rules,
         exit_rules=request.exit_rules,
         sizing=request.sizing if request.sizing is not None else DEFAULT_SIZING_PAYLOAD,
@@ -1269,6 +1275,11 @@ def _build_strategy_from_ideation(strategy_data: Dict[str, Any]) -> tuple[Strate
         asset_class=_normalize_strategy_lab_asset_class(strategy_data.get("asset_class")),
         hypothesis=str(strategy_data.get("hypothesis", "")),
         signal_definition=str(strategy_data.get("signal_definition", "")),
+        # Issue #537: ideation must declare a timeframe. Default to "1d"
+        # only when the LLM forgot the field — the prompt makes it
+        # mandatory; this fallback keeps the cycle alive rather than
+        # forcing a re-run for a clearly-resolvable omission.
+        timeframe=strategy_data.get("timeframe") or "1d",
         # Issue #551/#554: pass structured rule payloads through to
         # Pydantic; non-dict / non-DSL items are discarded so a malformed
         # ideation LLM response doesn't crash the cycle.

--- a/backend/agents/investment_team/models.py
+++ b/backend/agents/investment_team/models.py
@@ -204,9 +204,17 @@ class StrategySpec(BaseModel):
     asset_class: str
     hypothesis: str
     signal_definition: str
-    # Issue #537 — bar timeframe the strategy was designed against. Required.
-    # No default: callers must declare what they're trading on. Legacy persisted
-    # specs are migrated to ``"1d"`` by the ``_migrate_legacy_payload`` rewriter.
+    # Issue #537 — bar timeframe the strategy was designed against. Required;
+    # no default. Fresh callers (``CreateStrategyRequest``, ideation, the
+    # orchestrator) declare this explicitly. Persisted pre-#537 records lack
+    # the field — those that carry structural legacy markers (old op names,
+    # typed ``IndicatorRef`` dicts, ``sizing_rules`` list, ``unparsable``
+    # variants) are migrated to ``"1d"`` in-flight by
+    # ``_migrate_legacy_payload``. Minimal-shape persisted records that
+    # carry no markers AND no timeframe (e.g. empty rules with default
+    # sizing) must be rewritten by
+    # ``investment_team.scripts.backfill_strategy_specs`` before deploy —
+    # they will not deserialise otherwise.
     timeframe: Literal["1m", "5m", "15m", "1h", "1d"]
     # Issue #551/#537 — entry/exit/sizing are structured DSL nodes. Pydantic
     # discriminator validation rejects prose ("close > sma(20)") on input;

--- a/backend/agents/investment_team/models.py
+++ b/backend/agents/investment_team/models.py
@@ -425,19 +425,31 @@ def _indicator_dict_is_legacy(value: Any) -> bool:
 
 
 def _migrate_indicator_side(value: Any) -> Any:
-    """Migrate one side of a Predicate from legacy to issue-#537 shape."""
+    """Migrate one side of a Predicate from legacy to issue-#537 shape.
+
+    Non-dict values (strings like ``"bar.close"``, floats) pass through
+    unchanged. Dicts already in the new shape (``{"name": ..., "params":
+    ...}`` — no legacy ``kind`` discriminator) also pass through so a
+    mixed-state payload doesn't silently drop hand-migrated rules.
+    Returns ``None`` only when the value is a legacy ``PriceRef`` whose
+    field isn't representable in the new schema (``open`` / ``hl2`` /
+    ``ohlc4``) — that's the signal for the caller to drop the rule and
+    stash the original prose in ``unparsed_rules``.
+    """
     if not isinstance(value, dict):
         return value
     kind = value.get("kind")
+    if kind is None or kind not in _LEGACY_INDICATOR_KINDS:
+        # Already new-shape (``{"name": ...}``) or unknown discriminator —
+        # let Pydantic surface any real validation error downstream.
+        return value
     if kind == "price":
         field = value.get("field", "close")
         if field in {"close", "high", "low", "volume"}:
             return f"bar.{field}"
         # ``hl2`` / ``ohlc4`` / ``open`` were addressable on the legacy
         # PriceRef but the issue-#537 literal set only includes the four
-        # above. Fall back to a synthetic IndicatorRef on the "open" case
-        # (treat as SMA(2) over open? no — surface as unparseable).
-        # Returning ``None`` here signals the caller to drop the rule.
+        # above. Returning ``None`` signals the caller to drop the rule.
         return None
     if kind == "const":
         try:
@@ -465,8 +477,10 @@ def _migrate_indicator_side(value: Any) -> Any:
     if kind == "stochastic":
         params = {k: v for k, v in value.items() if k in {"k_period", "d_period", "output"}}
         return {"name": "stochastic", "params": params}
-    # Unknown legacy kind — caller will route to unparsed_rules.
-    return None
+    # Unreachable: every entry in ``_LEGACY_INDICATOR_KINDS`` has a branch
+    # above. Defensive fall-through — pass through so Pydantic surfaces the
+    # error rather than silently dropping the rule.
+    return value
 
 
 def _migrate_predicate(predicate: Any) -> Optional[dict]:

--- a/backend/agents/investment_team/models.py
+++ b/backend/agents/investment_team/models.py
@@ -5,10 +5,11 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any, Dict, List, Literal, Optional
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from .execution.risk_filter import RiskLimits
 from .strategy_lab.spec_dsl import (
+    DEFAULT_SIZING_PAYLOAD,
     EntryRule,
     ExitRule,
     FixedFractionSizing,
@@ -203,10 +204,14 @@ class StrategySpec(BaseModel):
     asset_class: str
     hypothesis: str
     signal_definition: str
-    # Issue #551 — entry/exit/sizing are structured DSL nodes. Pydantic
+    # Issue #537 — bar timeframe the strategy was designed against. Required.
+    # No default: callers must declare what they're trading on. Legacy persisted
+    # specs are migrated to ``"1d"`` by the ``_migrate_legacy_payload`` rewriter.
+    timeframe: Literal["1m", "5m", "15m", "1h", "1d"]
+    # Issue #551/#537 — entry/exit/sizing are structured DSL nodes. Pydantic
     # discriminator validation rejects prose ("close > sma(20)") on input;
-    # producers must emit structured. See `strategy_lab/spec_dsl.py` (#550)
-    # for the union definitions.
+    # producers must emit structured. See `strategy_lab/spec_dsl.py` for the
+    # union definitions.
     entry_rules: List[EntryRule] = Field(default_factory=list)
     exit_rules: List[ExitRule] = Field(default_factory=list)
     sizing: SizingRule = Field(default_factory=lambda: FixedFractionSizing(fraction=0.02))
@@ -222,7 +227,86 @@ class StrategySpec(BaseModel):
     risk_limits: RiskLimits = Field(default_factory=RiskLimits)
     speculative: bool = False
     strategy_code: Optional[str] = None
+    # Issue #537 — surface for rules that couldn't be parsed by ``from_prose``
+    # / the legacy-payload rewriter. When non-empty, ``requires_redesign``
+    # is set so the design agent re-routes the spec to ideation.
+    requires_redesign: bool = False
+    unparsed_rules: List[str] = Field(default_factory=list)
     audit: AuditContext = Field(default_factory=AuditContext)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _migrate_legacy_payload(cls, data: Any) -> Any:
+        """Rewrite pre-#537 payload shapes to the current schema.
+
+        Detects legacy markers (old op names ``"gt"``/``"lt"``/…, typed
+        indicator dicts with ``"kind": "sma"`` etc., the discontinued
+        ``UnparsableRule`` discriminator, the renamed ``sizing_rules`` list,
+        a missing ``timeframe``) and rewrites them in-flight so persisted
+        specs and partway-migrated callers continue to deserialise. Fresh
+        callers that don't hit any legacy marker pass through untouched —
+        a missing ``timeframe`` then raises a normal required-field error.
+        """
+        if not isinstance(data, dict):
+            return data
+
+        is_legacy = _looks_like_legacy_payload(data)
+        if not is_legacy:
+            return data
+
+        payload: dict = dict(data)
+        unparsed: List[str] = list(payload.get("unparsed_rules") or [])
+        requires_redesign = bool(payload.get("requires_redesign", False))
+
+        # 1. entry_rules — migrate indicator shape, op names, drop unparsables.
+        new_entries: List[Any] = []
+        for raw in payload.get("entry_rules") or []:
+            migrated, prose = _migrate_entry_rule(raw)
+            if migrated is not None:
+                new_entries.append(migrated)
+            if prose is not None:
+                unparsed.append(prose)
+                requires_redesign = True
+        payload["entry_rules"] = new_entries
+
+        # 2. exit_rules — same migration; drop legacy unparsable variants.
+        new_exits: List[Any] = []
+        for raw in payload.get("exit_rules") or []:
+            migrated, prose = _migrate_exit_rule(raw)
+            if migrated is not None:
+                new_exits.append(migrated)
+            if prose is not None:
+                unparsed.append(prose)
+                requires_redesign = True
+        payload["exit_rules"] = new_exits
+
+        # 3. sizing — collapse legacy ``sizing_rules`` list and drop
+        # ``unparsable_sizing`` variants.
+        if "sizing_rules" in payload:
+            sizing_list = payload.pop("sizing_rules") or []
+            from .strategy_lab.spec_dsl_adapter import parse_sizing_list
+
+            if sizing_list and all(isinstance(s, str) for s in sizing_list):
+                parsed = parse_sizing_list(sizing_list)
+                if parsed is None:
+                    unparsed.extend(sizing_list)
+                    requires_redesign = True
+                    payload.setdefault("sizing", dict(DEFAULT_SIZING_PAYLOAD))
+                else:
+                    payload["sizing"] = parsed.model_dump()
+        sizing_value = payload.get("sizing")
+        if isinstance(sizing_value, dict) and sizing_value.get("kind") == "unparsable_sizing":
+            unparsed.append(str(sizing_value.get("prose", "")))
+            requires_redesign = True
+            payload["sizing"] = dict(DEFAULT_SIZING_PAYLOAD)
+
+        # 4. timeframe — legacy specs predate the field; default to daily
+        # so persisted records deserialise without manual surgery.
+        payload.setdefault("timeframe", "1d")
+
+        payload["unparsed_rules"] = unparsed
+        payload["requires_redesign"] = requires_redesign
+        return payload
 
     @field_validator("risk_limits", mode="before")
     @classmethod
@@ -253,6 +337,181 @@ class StrategySpec(BaseModel):
             seen.add(sym)
             out.append(sym)
         return out
+
+
+# ---------------------------------------------------------------------------
+# Issue #537 — legacy-payload migration helpers. These run only in
+# ``StrategySpec._migrate_legacy_payload`` (mode="before") when a payload
+# shows pre-#537 markers. Fresh payloads bypass this path entirely.
+# ---------------------------------------------------------------------------
+
+
+_LEGACY_INDICATOR_KINDS = frozenset(
+    {
+        "price",
+        "const",
+        "sma",
+        "ema",
+        "rsi",
+        "macd",
+        "bollinger",
+        "atr",
+        "adx",
+        "stochastic",
+        "vwap",
+    }
+)
+_LEGACY_OP_MAP = {
+    "gt": ">",
+    "lt": "<",
+    "ge": ">=",
+    "le": "<=",
+    "eq": "==",
+}
+_LEGACY_UNPARSABLE_KINDS = frozenset({"unparsable", "unparsable_sizing"})
+
+
+def _looks_like_legacy_payload(data: dict) -> bool:
+    """Heuristic — does this payload carry pre-#537 structural markers?
+
+    Returns True if any of the following structural pre-#537 markers are
+    present (a missing ``timeframe`` alone is NOT counted — fresh callers
+    that forget the required field get the standard pydantic error):
+    - a top-level ``sizing_rules`` list (renamed to ``sizing`` post-#554);
+    - any rule with the legacy ``kind="unparsable"`` discriminator;
+    - sizing with the legacy ``kind="unparsable_sizing"`` discriminator;
+    - any indicator dict carrying a legacy ``kind`` discriminator;
+    - any predicate op naming the legacy string aliases (``"gt"``, ``"lt"``…).
+    """
+    if "sizing_rules" in data:
+        return True
+    sizing = data.get("sizing")
+    if isinstance(sizing, dict) and sizing.get("kind") == "unparsable_sizing":
+        return True
+    for slot in ("entry_rules", "exit_rules"):
+        rules = data.get(slot) or []
+        if not isinstance(rules, list):
+            continue
+        for raw in rules:
+            if _rule_dict_is_legacy(raw):
+                return True
+    return False
+
+
+def _rule_dict_is_legacy(rule: Any) -> bool:
+    if not isinstance(rule, dict):
+        return False
+    if rule.get("kind") in _LEGACY_UNPARSABLE_KINDS:
+        return True
+    when = rule.get("when")
+    if isinstance(when, dict):
+        if when.get("op") in _LEGACY_OP_MAP:
+            return True
+        if _indicator_dict_is_legacy(when.get("lhs")) or _indicator_dict_is_legacy(when.get("rhs")):
+            return True
+    return False
+
+
+def _indicator_dict_is_legacy(value: Any) -> bool:
+    return isinstance(value, dict) and "kind" in value and value["kind"] in _LEGACY_INDICATOR_KINDS
+
+
+def _migrate_indicator_side(value: Any) -> Any:
+    """Migrate one side of a Predicate from legacy to issue-#537 shape."""
+    if not isinstance(value, dict):
+        return value
+    kind = value.get("kind")
+    if kind == "price":
+        field = value.get("field", "close")
+        if field in {"close", "high", "low", "volume"}:
+            return f"bar.{field}"
+        # ``hl2`` / ``ohlc4`` / ``open`` were addressable on the legacy
+        # PriceRef but the issue-#537 literal set only includes the four
+        # above. Fall back to a synthetic IndicatorRef on the "open" case
+        # (treat as SMA(2) over open? no — surface as unparseable).
+        # Returning ``None`` here signals the caller to drop the rule.
+        return None
+    if kind == "const":
+        try:
+            return float(value.get("value", 0.0))
+        except (TypeError, ValueError):
+            return None
+    if kind in {"sma", "ema", "rsi", "atr", "adx", "vwap"}:
+        params: dict = {k: v for k, v in value.items() if k not in {"kind", "source"}}
+        out: dict = {"name": kind, "params": params}
+        if "source" in value:
+            out["source"] = value["source"]
+        return out
+    if kind == "macd":
+        params = {k: v for k, v in value.items() if k in {"fast", "slow", "signal", "output"}}
+        out = {"name": "macd", "params": params}
+        if "source" in value:
+            out["source"] = value["source"]
+        return out
+    if kind == "bollinger":
+        params = {k: v for k, v in value.items() if k in {"period", "num_std", "band"}}
+        out = {"name": "bollinger", "params": params}
+        if "source" in value:
+            out["source"] = value["source"]
+        return out
+    if kind == "stochastic":
+        params = {k: v for k, v in value.items() if k in {"k_period", "d_period", "output"}}
+        return {"name": "stochastic", "params": params}
+    # Unknown legacy kind — caller will route to unparsed_rules.
+    return None
+
+
+def _migrate_predicate(predicate: Any) -> Optional[dict]:
+    if not isinstance(predicate, dict):
+        return None
+    lhs = _migrate_indicator_side(predicate.get("lhs"))
+    rhs = _migrate_indicator_side(predicate.get("rhs"))
+    if lhs is None or rhs is None:
+        return None
+    op = predicate.get("op")
+    op = _LEGACY_OP_MAP.get(op, op)
+    return {"lhs": lhs, "op": op, "rhs": rhs}
+
+
+def _migrate_entry_rule(rule: Any) -> tuple[Optional[Any], Optional[str]]:
+    """Returns (migrated_rule, prose_to_stash). At most one is non-None."""
+    if not isinstance(rule, dict):
+        return rule, None
+    if rule.get("kind") == "unparsable":
+        return None, str(rule.get("prose", ""))
+    if "when" not in rule:
+        return rule, None
+    when = _migrate_predicate(rule["when"])
+    if when is None:
+        return None, _describe_rule(rule)
+    new_rule = dict(rule)
+    new_rule["when"] = when
+    return new_rule, None
+
+
+def _migrate_exit_rule(rule: Any) -> tuple[Optional[Any], Optional[str]]:
+    if not isinstance(rule, dict):
+        return rule, None
+    if rule.get("kind") == "unparsable":
+        return None, str(rule.get("prose", ""))
+    if "when" not in rule:
+        return rule, None
+    when = _migrate_predicate(rule["when"])
+    if when is None:
+        return None, _describe_rule(rule)
+    new_rule = dict(rule)
+    new_rule["when"] = when
+    return new_rule, None
+
+
+def _describe_rule(rule: dict) -> str:
+    """Render a rule dict for the unparsed_rules stash — best-effort."""
+    try:
+        import json
+
+        return json.dumps(rule, default=str, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return str(rule)
 
 
 class ValidationCheck(BaseModel):

--- a/backend/agents/investment_team/scripts/backfill_strategy_specs.py
+++ b/backend/agents/investment_team/scripts/backfill_strategy_specs.py
@@ -1,0 +1,139 @@
+"""Backfill persisted ``StrategySpec`` JSON to the issue #537 schema.
+
+Run once before deploying the strict-schema commit.
+
+The job-service teams that hold ``StrategySpec`` payloads are:
+  - ``investment_strategy_lab_records`` — each lab record carries a
+    ``strategy`` field shaped like ``StrategySpec.model_dump()``.
+  - ``investment_backtests``            — each backtest carries a
+    ``strategy`` field with the same shape.
+  - ``investment_strategies``           — strategies persisted via
+    ``POST /strategies``.
+
+For each row we round-trip ``data["strategy"]`` through
+``StrategySpec.model_validate(...)`` — which runs the in-flight legacy
+rewriter — then write the canonicalised JSON back. Rows that fail
+validation (genuinely malformed payloads, not just schema-version drift)
+are reported and skipped; rerun after fixing them by hand.
+
+Usage::
+
+    PYTHONPATH=agents python3 -m investment_team.scripts.backfill_strategy_specs [--dry-run] [--limit N]
+
+Requires ``JOB_SERVICE_URL`` to be set (same env var as the running API).
+
+The script is idempotent: re-running on already-migrated rows is a no-op
+(canonical JSON in = canonical JSON out).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import sys
+
+logger = logging.getLogger("backfill_strategy_specs")
+
+
+_TEAMS = (
+    "investment_strategy_lab_records",
+    "investment_backtests",
+    "investment_strategies",
+)
+
+
+def _migrate_one(payload: dict) -> tuple[bool, dict]:
+    """Round-trip a job-service payload's ``strategy`` field through StrategySpec.
+
+    Returns ``(changed, new_payload)``. ``changed`` is True only when the
+    canonicalised JSON differs from the original — so idempotent runs are
+    safe.
+    """
+    from investment_team.models import StrategySpec
+
+    if not isinstance(payload, dict):
+        return False, payload
+    raw = payload.get("strategy")
+    if not isinstance(raw, dict):
+        return False, payload
+
+    migrated = StrategySpec.model_validate(raw)
+    new_strategy = migrated.model_dump(mode="json")
+    if new_strategy == raw:
+        return False, payload
+
+    new_payload = dict(payload)
+    new_payload["strategy"] = new_strategy
+    return True, new_payload
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Run the migration without writing back"
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Maximum number of rows to migrate per team (0 = all).",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+
+    from job_service_client import JobServiceClient
+
+    total_changed = 0
+    total_unchanged = 0
+    total_failed = 0
+
+    for team in _TEAMS:
+        client = JobServiceClient(team=team)
+        jobs = client.list_jobs() or []
+        logger.info("%s: %d job(s) found", team, len(jobs))
+        n_changed = 0
+        n_unchanged = 0
+        n_failed = 0
+        for i, job in enumerate(jobs):
+            if args.limit and i >= args.limit:
+                break
+            jid = job.get("job_id")
+            data = job.get("data") or {}
+            if not jid:
+                continue
+            try:
+                changed, new_data = _migrate_one(data)
+            except Exception as exc:  # noqa: BLE001
+                n_failed += 1
+                logger.warning("%s/%s migration failed: %s", team, jid, exc)
+                continue
+
+            if not changed:
+                n_unchanged += 1
+                continue
+
+            if args.dry_run:
+                logger.info("[dry-run] would rewrite %s/%s", team, jid)
+            else:
+                client.update_job(jid, data=new_data)
+                logger.info("rewrote %s/%s", team, jid)
+            n_changed += 1
+
+        logger.info("%s: changed=%d unchanged=%d failed=%d", team, n_changed, n_unchanged, n_failed)
+        total_changed += n_changed
+        total_unchanged += n_unchanged
+        total_failed += n_failed
+
+    logger.info(
+        "done — total changed=%d unchanged=%d failed=%d%s",
+        total_changed,
+        total_unchanged,
+        total_failed,
+        " (dry run)" if args.dry_run else "",
+    )
+    return 0 if total_failed == 0 else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/agents/investment_team/scripts/backfill_strategy_specs.py
+++ b/backend/agents/investment_team/scripts/backfill_strategy_specs.py
@@ -2,19 +2,31 @@
 
 Run once before deploying the strict-schema commit.
 
-The job-service teams that hold ``StrategySpec`` payloads are:
-  - ``investment_strategy_lab_records`` — each lab record carries a
-    ``strategy`` field shaped like ``StrategySpec.model_dump()``.
-  - ``investment_backtests``            — each backtest carries a
-    ``strategy`` field with the same shape.
-  - ``investment_strategies``           — strategies persisted via
-    ``POST /strategies``.
+Per-team payload shapes (the script handles each correctly):
+  - ``investment_strategies``           — ``data`` IS the
+    ``StrategySpec.model_dump()`` payload (via
+    ``_PersistentDict.__setitem__`` in ``api/main.py`` — no nested
+    ``strategy`` key).
+  - ``investment_backtests``            — ``data`` is a
+    ``BacktestRecord`` with the spec nested at ``data["strategy"]``.
+  - ``investment_strategy_lab_records`` — ``data`` is a
+    ``StrategyLabRecord`` with the spec at ``data["strategy"]`` AND
+    ``data["original_spec"]`` AND ``data["backtest"]["strategy"]``;
+    all three are migrated.
 
-For each row we round-trip ``data["strategy"]`` through
+For each spec we round-trip the JSON through
 ``StrategySpec.model_validate(...)`` — which runs the in-flight legacy
-rewriter — then write the canonicalised JSON back. Rows that fail
-validation (genuinely malformed payloads, not just schema-version drift)
-are reported and skipped; rerun after fixing them by hand.
+rewriter — then write the canonicalised JSON back. The backfill is
+deliberately **permissive** about a missing ``timeframe``: persisted
+pre-#537 records that lack any structural legacy markers (e.g. empty
+``entry_rules``/``exit_rules`` with default sizing) bypass the runtime
+``_migrate_legacy_payload`` heuristic, so the script injects
+``timeframe="1d"`` defensively before validating. Fresh callers
+go through the strict ``CreateStrategyRequest`` contract, which still
+requires the field.
+
+Rows that fail validation for any other reason are reported and
+skipped; rerun after fixing them by hand.
 
 Usage::
 
@@ -31,6 +43,7 @@ from __future__ import annotations
 import argparse
 import logging
 import sys
+from typing import Any
 
 logger = logging.getLogger("backfill_strategy_specs")
 
@@ -41,30 +54,84 @@ _TEAMS = (
     "investment_strategies",
 )
 
+_DEFAULT_TIMEFRAME = "1d"
 
-def _migrate_one(payload: dict) -> tuple[bool, dict]:
-    """Round-trip a job-service payload's ``strategy`` field through StrategySpec.
 
-    Returns ``(changed, new_payload)``. ``changed`` is True only when the
-    canonicalised JSON differs from the original — so idempotent runs are
-    safe.
+def _migrate_spec_payload(raw: Any) -> tuple[bool, Any]:
+    """Migrate one ``StrategySpec``-shaped dict.
+
+    Returns ``(changed, new_spec_dict)``. Permissive about missing
+    ``timeframe``: when the field is absent we inject ``"1d"`` before
+    validation, since the runtime ``_migrate_legacy_payload`` heuristic
+    only defaults timeframe when other structural legacy markers are
+    present.
     """
     from investment_team.models import StrategySpec
 
+    if not isinstance(raw, dict):
+        return False, raw
+
+    raw_with_tf: dict = dict(raw)
+    raw_with_tf.setdefault("timeframe", _DEFAULT_TIMEFRAME)
+
+    migrated = StrategySpec.model_validate(raw_with_tf)
+    new_spec = migrated.model_dump(mode="json")
+    if new_spec == raw:
+        return False, raw
+    return True, new_spec
+
+
+def _migrate_one(team: str, payload: dict) -> tuple[bool, dict]:
+    """Per-team payload migration. Returns ``(changed, new_payload)``."""
     if not isinstance(payload, dict):
         return False, payload
-    raw = payload.get("strategy")
-    if not isinstance(raw, dict):
-        return False, payload
 
-    migrated = StrategySpec.model_validate(raw)
-    new_strategy = migrated.model_dump(mode="json")
-    if new_strategy == raw:
-        return False, payload
+    if team == "investment_strategies":
+        # ``_PersistentDict("strategies").__setitem__`` writes
+        # ``StrategySpec.model_dump()`` straight into ``data`` — no
+        # nested ``strategy`` key. Treat the whole payload as the spec.
+        if not payload.get("strategy_id"):
+            return False, payload
+        return _migrate_spec_payload(payload)
 
-    new_payload = dict(payload)
-    new_payload["strategy"] = new_strategy
-    return True, new_payload
+    if team == "investment_backtests":
+        raw = payload.get("strategy")
+        changed, new_spec = _migrate_spec_payload(raw)
+        if not changed:
+            return False, payload
+        new_payload = dict(payload)
+        new_payload["strategy"] = new_spec
+        return True, new_payload
+
+    if team == "investment_strategy_lab_records":
+        # The lab record nests the spec in three places — all three are
+        # in scope so a partial migration doesn't leave the record
+        # internally inconsistent.
+        any_changed = False
+        new_payload = dict(payload)
+
+        for key in ("strategy", "original_spec"):
+            spec_raw = new_payload.get(key)
+            if isinstance(spec_raw, dict):
+                changed, new_spec = _migrate_spec_payload(spec_raw)
+                if changed:
+                    new_payload[key] = new_spec
+                    any_changed = True
+
+        bt = new_payload.get("backtest")
+        if isinstance(bt, dict):
+            bt_strategy = bt.get("strategy")
+            if isinstance(bt_strategy, dict):
+                changed, new_spec = _migrate_spec_payload(bt_strategy)
+                if changed:
+                    new_bt = dict(bt)
+                    new_bt["strategy"] = new_spec
+                    new_payload["backtest"] = new_bt
+                    any_changed = True
+
+        return any_changed, new_payload
+
+    return False, payload
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -103,7 +170,7 @@ def main(argv: list[str] | None = None) -> int:
             if not jid:
                 continue
             try:
-                changed, new_data = _migrate_one(data)
+                changed, new_data = _migrate_one(team, data)
             except Exception as exc:  # noqa: BLE001
                 n_failed += 1
                 logger.warning("%s/%s migration failed: %s", team, jid, exc)

--- a/backend/agents/investment_team/strategy_lab/agents/ideation.py
+++ b/backend/agents/investment_team/strategy_lab/agents/ideation.py
@@ -42,23 +42,25 @@ Each prior entry includes outcome, metrics, rationale, and post-backtest analysi
 
 Return ONLY a JSON object with no markdown. `entry_rules`, `exit_rules`,
 and `sizing` MUST be the structured DSL objects described in the system
-prompt — prose strings will be rejected.
+prompt — prose strings will be rejected. `timeframe` is REQUIRED and
+must be one of `"1m"`, `"5m"`, `"15m"`, `"1h"`, `"1d"`.
 
 {{
   "asset_class": "stocks" | "crypto" | "forex" | "futures" | "commodities",
   "hypothesis": "1-3 sentence investment thesis tying multiple signals to edge",
   "signal_definition": "Describe the ensemble of signals and how they combine",
+  "timeframe": "1d",
   "entry_rules": [
     {{"kind": "entry", "side": "long",
-      "when": {{"lhs": {{"kind": "rsi", "period": 14}},
-                "op": "lt",
-                "rhs": {{"kind": "const", "value": 30}}}}}}
+      "when": {{"lhs": {{"name": "rsi", "params": {{"period": 14}}}},
+                "op": "<",
+                "rhs": 30}}}}
   ],
   "exit_rules": [
     {{"kind": "signal_exit",
-      "when": {{"lhs": {{"kind": "rsi", "period": 14}},
-                "op": "gt",
-                "rhs": {{"kind": "const", "value": 70}}}}}},
+      "when": {{"lhs": {{"name": "rsi", "params": {{"period": 14}}}},
+                "op": ">",
+                "rhs": 70}}}},
     {{"kind": "time_stop", "n_bars": 10}}
   ],
   "sizing": {{"kind": "fixed_fraction", "fraction": 0.02}},

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -376,6 +376,9 @@ class StrategyLabOrchestrator:
             asset_class=strategy_dict.get("asset_class", "stocks"),
             hypothesis=strategy_dict.get("hypothesis", ""),
             signal_definition=strategy_dict.get("signal_definition", ""),
+            # Issue #537: ideation must declare a timeframe. Default to "1d"
+            # if the LLM forgot the field — the prompt makes it mandatory.
+            timeframe=strategy_dict.get("timeframe") or "1d",
             entry_rules=strategy_dict.get("entry_rules", []),
             exit_rules=strategy_dict.get("exit_rules", []),
             sizing=strategy_dict.get("sizing", DEFAULT_SIZING_PAYLOAD),

--- a/backend/agents/investment_team/strategy_lab/prompts/ideation_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/ideation_system.md
@@ -23,16 +23,20 @@ Design strategies as a **mixture of signal types**, not a single indicator. Comb
 
 ## Strategy spec output shape — STRUCTURED DSL (mandatory)
 
-`entry_rules`, `exit_rules`, and `sizing` are **structured discriminated objects** — not prose strings. Every rule object MUST carry a `kind` field; the parser rejects bare strings with a pydantic `ValidationError` and the cycle is discarded.
+`entry_rules`, `exit_rules`, and `sizing` are **structured discriminated objects** — not prose strings. Every rule object MUST carry a `kind` field; the parser rejects bare strings with a pydantic `ValidationError` and the cycle is discarded. `timeframe` is also REQUIRED — declare the bar timeframe your strategy was designed against: one of `"1m"`, `"5m"`, `"15m"`, `"1h"`, `"1d"`.
 
 ### Indicator catalogue
 
-Every indicator reference is an object with a `kind` discriminator. The accepted kinds and their parameter shapes mirror `spec_dsl.IndicatorRef` exactly:
+An **`IndicatorRef`** is a flat object with `name`, `params`, and an optional `source` field:
 
-| `kind` | Required params | Defaults / optional |
+```json
+{"name": "<indicator>", "params": {...}, "source": "close"}
+```
+
+The accepted `name` values and their parameter schemas:
+
+| `name` | Required params | Defaults / optional |
 |---|---|---|
-| `price` | — | `field`: one of `close` / `high` / `low` / `open` / `volume` / `hl2` / `ohlc4` (default `close`) |
-| `const` | `value: float` | — |
 | `sma` | `period: int` (2-400) | `source` (default `close`) |
 | `ema` | `period: int` (2-400) | `source` (default `close`) |
 | `rsi` | — | `period: int` (2-200, default 14), `source` (default `close`) |
@@ -42,6 +46,8 @@ Every indicator reference is an object with a `kind` discriminator. The accepted
 | `adx` | — | `period` (default 14, 2-200) |
 | `stochastic` | — | `k_period` (default 14), `d_period` (default 3), `output` ∈ {k, d} (default `k`) |
 | `vwap` | — | — |
+
+Bare bar fields are addressed by the string literals `"bar.close"`, `"bar.high"`, `"bar.low"`, `"bar.volume"` (used as `Predicate.lhs` / `Predicate.rhs` directly — no wrapper object).
 
 ### Rule kinds
 
@@ -56,7 +62,11 @@ Every indicator reference is an object with a `kind` discriminator. The accepted
   - `{"kind": "volatility_target", "target_annual_vol": float>0, "note": str}`.
   - `{"kind": "fixed_notional", "notional_usd": float>0, "note": str}`.
 
-A `Predicate` is `{"lhs": IndicatorRef, "op": op, "rhs": IndicatorRef}` where `op ∈ {gt, lt, ge, le, eq, cross_above, cross_below}`. **Both sides are IndicatorRefs** — to compare against a constant, use `{"kind": "const", "value": 30}` on the right.
+A `Predicate` is `{"lhs": <side>, "op": <op>, "rhs": <side>}` where:
+
+- `op ∈ {"<", ">", "<=", ">=", "==", "cross_above", "cross_below"}` (the literal symbol, not name aliases).
+- `lhs` is either an `IndicatorRef` or one of the bar-field literals `"bar.close"` / `"bar.high"` / `"bar.low"` / `"bar.volume"`.
+- `rhs` is either an `IndicatorRef`, a bar-field literal (same four), or a plain numeric constant (e.g. `30`, `70.0`).
 
 ### Worked structured example (mean-reversion RSI strategy)
 
@@ -65,17 +75,18 @@ A `Predicate` is `{"lhs": IndicatorRef, "op": op, "rhs": IndicatorRef}` where `o
   "asset_class": "stocks",
   "hypothesis": "...",
   "signal_definition": "...",
+  "timeframe": "1d",
   "entry_rules": [{
     "kind": "entry", "side": "long",
-    "when": {"lhs": {"kind": "rsi", "period": 14},
-             "op": "lt",
-             "rhs": {"kind": "const", "value": 30}}
+    "when": {"lhs": {"name": "rsi", "params": {"period": 14}},
+             "op": "<",
+             "rhs": 30}
   }],
   "exit_rules": [
     {"kind": "signal_exit",
-     "when": {"lhs": {"kind": "rsi", "period": 14},
-              "op": "gt",
-              "rhs": {"kind": "const", "value": 70}}},
+     "when": {"lhs": {"name": "rsi", "params": {"period": 14}},
+              "op": ">",
+              "rhs": 70}},
     {"kind": "time_stop", "n_bars": 10}
   ],
   "sizing": {"kind": "fixed_fraction", "fraction": 0.02},
@@ -95,7 +106,7 @@ A `Predicate` is `{"lhs": IndicatorRef, "op": op, "rhs": IndicatorRef}` where `o
 }
 ```
 
-Prose strings (the shape above) and the legacy `sizing_rules` list-of-strings are both rejected by the parser. The orchestrator will discard the ideation cycle and ask for a redo.
+Prose strings, the legacy `sizing_rules` list-of-strings, and the pre-#537 `{"kind": "sma", "period": 20}` / `{"kind": "const", "value": 30}` indicator shapes are all rejected by the parser. The orchestrator will discard the ideation cycle and ask for a redo.
 
 ## Asset class diversity
 

--- a/backend/agents/investment_team/strategy_lab/quality_gates/strategy_validator.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/strategy_validator.py
@@ -172,11 +172,15 @@ class StrategySpecValidator:
         #    names indicator concepts that no entry/exit rule references (or
         #    vice versa), the operational spec and the narrative rationale are
         #    out of sync. Warning only — the refinement prompt can react.
+        #    Issue #537: ``unparsed_rules`` is part of the rule surface for
+        #    this scan — pre-migration legacy specs may carry indicator
+        #    mentions in there.
         hypothesis_text = spec.hypothesis or ""
         rules_text = " ".join(
             [
                 format_rules_for_prompt(spec.entry_rules),
                 format_rules_for_prompt(spec.exit_rules),
+                " ".join(spec.unparsed_rules),
             ]
         )
         terms_in_hypothesis = {m.group(0).lower() for m in _CONCEPT_TERMS.finditer(hypothesis_text)}

--- a/backend/agents/investment_team/strategy_lab/quality_gates/strategy_validator.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/strategy_validator.py
@@ -130,15 +130,19 @@ class StrategySpecValidator:
                 )
             )
 
-        # 6. Asset-class keyword mismatch. Issue #551: spec rule fields are
-        #    structured DSL nodes — render them through the spec_dsl
+        # 6. Asset-class keyword mismatch. Issue #551/#537: spec rule fields
+        #    are structured DSL nodes — render them through the spec_dsl
         #    formatters to recover a human-readable text view suitable for
-        #    regex matching.
+        #    regex matching. Unparseable prose now lives in
+        #    ``spec.unparsed_rules`` (#537 replaced the discriminator
+        #    variants) and is folded into the same scan so prose that
+        #    escaped the adapter is still caught.
         all_rules_text = " ".join(
             [
                 format_rules_for_prompt(spec.entry_rules),
                 format_rules_for_prompt(spec.exit_rules),
                 format_sizing_rule(spec.sizing),
+                " ".join(spec.unparsed_rules),
             ]
         )
         ac = spec.asset_class.lower()

--- a/backend/agents/investment_team/strategy_lab/spec_dsl.py
+++ b/backend/agents/investment_team/strategy_lab/spec_dsl.py
@@ -1,44 +1,68 @@
-"""Structured `StrategySpec` DSL (issue #550, step 1 of 8 from #537).
+"""Structured `StrategySpec` DSL — issue #537 literal schema.
 
-This module defines a typed, machine-readable replacement for today's
-`StrategySpec.entry_rules: list[str]` / `exit_rules: list[str]` /
-`sizing_rules: list[str]` (`backend/agents/investment_team/models.py:194-210`).
-Nothing wires `StrategySpec` to these types yet — that is step 2 of #537 and
-intentionally out of scope here. This module is a pure addition.
+This module defines a typed, machine-readable replacement for prose
+`entry_rules: list[str]` / `exit_rules: list[str]` / `sizing_rules:
+list[str]`. The schema mirrors the proposed shape in
+`https://github.com/brandonkindred/Khala-Agentic-AI-Teams/issues/537`:
 
-House pattern mirrored from
-`backend/agents/investment_team/strategy_lab/factors/models.py`:
+- `IndicatorRef` is a single flat class — `name` selects the indicator,
+  `params` carries the (typed) per-indicator arguments, `source`
+  selects the bar field. Per-indicator required/optional/bounds
+  validation lives in a registry-backed `model_validator`.
+- `Predicate.op` uses the symbol literals (``"<"``, ``">"``, …).
+- `Predicate.lhs` is either an `IndicatorRef` or a
+  ``Literal["bar.close","bar.high","bar.low","bar.volume"]`` bar-field
+  reference. `Predicate.rhs` additionally accepts a plain ``float``.
+- `EntryRule`, `ExitRule`, and `SizingRule` discriminated unions use
+  `kind` exactly as before. Unparseable inputs are surfaced at the
+  spec level via `StrategySpec.requires_redesign` + `unparsed_rules`,
+  not as discriminator variants.
 
-- `_SpecNode(BaseModel)` base with `extra="forbid"`.
-- Every concrete node carries a `Literal[...]` `kind` discriminator.
-- Top-level unions written as
-  ``Annotated[Union[...], Field(discriminator="kind")]``.
-- Trailing `Model.model_rebuild()` for forward-ref resolution.
-
-Indicator **defaults** mirror
-`backend/agents/investment_team/strategy_lab/executor/indicators.py` exactly
-(RSI period=14, MACD 12/26/9, Bollinger 20/2.0, etc.).
-
-Indicator **bound style** (e.g. `ge=2, le=400`) mirrors the existing house
+Indicator bound style (``ge=2, le=400``) mirrors the existing house
 factor DSL at `strategy_lab/factors/models.py`. The runtime helpers in
 `executor/indicators.py` themselves accept any positive integer — the
-coverage-probe registry there only enforces positive-int /
-positive-float-for-``num_std``. We apply the same sanity caps the factor
-DSL applies so degenerate spec payloads (`period=0`, `period=10000`) are
-rejected at validation time rather than silently producing all-NaN
-columns downstream.
+sanity caps here reject degenerate spec payloads (``period=0``,
+``period=10000``) that would silently produce all-NaN columns
+downstream.
+
+Persisted-payload migration: this module is intentionally strict and
+does not coerce legacy shapes. ``StrategySpec.model_validator(mode="before")``
+in `models.py` handles the in-flight rewriter for legacy payloads and
+the `from_prose` function at the bottom of this module provides a
+top-level entry point for callers that own raw prose specs.
 """
 
 from __future__ import annotations
 
 import math
-from typing import Annotated, Literal, Union
+from typing import Annotated, Any, Literal, Union
 
 from pydantic import BaseModel, ConfigDict, Field, TypeAdapter, model_validator
 
-ComparisonOp = Literal["gt", "lt", "ge", "le", "eq", "cross_above", "cross_below"]
+# Issue #537: comparison ops are the literal symbols, not name aliases.
+ComparisonOp = Literal["<", ">", "<=", ">=", "==", "cross_above", "cross_below"]
 
 Source = Literal["close", "high", "low", "open", "volume", "hl2", "ohlc4"]
+
+# Bar-field price references. `lhs` may name any of these; `rhs` cannot
+# reference "bar.volume" (semantic comparison against a volume on the
+# right side is rarely meaningful and unsupported here).
+PriceRefLiteral = Literal["bar.close", "bar.high", "bar.low", "bar.volume"]
+ExitPriceRefLiteral = Literal["bar.close", "bar.high", "bar.low"]
+
+IndicatorName = Literal[
+    "sma",
+    "ema",
+    "rsi",
+    "macd",
+    "bollinger",
+    "atr",
+    "adx",
+    "stochastic",
+    "vwap",
+]
+
+_PRICE_REF_LITERALS: frozenset[str] = frozenset({"bar.close", "bar.high", "bar.low", "bar.volume"})
 
 
 class _SpecNode(BaseModel):
@@ -49,9 +73,9 @@ class _SpecNode(BaseModel):
         """Reject NaN / +inf / -inf for every float field on this node.
 
         Non-finite floats round-trip badly: ``model_dump_json()`` serialises
-        them as ``null`` / ``Infinity`` (neither of which the adapter parses
-        back), and ``_format_number`` refuses them outright.  Rejecting here
-        keeps the DSL's validation/serialisation contract internally
+        them as ``null`` / ``Infinity`` (neither of which downstream parsers
+        accept), and ``_format_number`` refuses them outright.  Rejecting
+        here keeps the DSL's validation/serialisation contract internally
         consistent regardless of which numeric field a caller supplies.
         """
         for name, value in self.__dict__.items():
@@ -61,94 +85,169 @@ class _SpecNode(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# IndicatorRef union — discriminator "kind".  Bounds mirror
-# strategy_lab/executor/indicators.py.
+# Per-indicator param registry. Each entry describes the params an indicator
+# accepts; the registry is consulted by `IndicatorRef._validate_params` to
+# enforce required keys, default fill-ins on optional keys, and per-param
+# type/bounds. This is the per-indicator validation the issue-text shape
+# (``params: dict[str, float | int | str]``) cannot enforce at the type level.
 # ---------------------------------------------------------------------------
 
 
-class PriceRef(_SpecNode):
-    kind: Literal["price"] = "price"
-    field: Source = "close"
+def _int_in(lo: int, hi: int):
+    def check(value: Any) -> None:
+        if not isinstance(value, int) or isinstance(value, bool):
+            raise ValueError(f"must be int (got {type(value).__name__})")
+        if not (lo <= value <= hi):
+            raise ValueError(f"must be in [{lo}, {hi}] (got {value})")
+
+    return check
 
 
-class ConstRef(_SpecNode):
-    kind: Literal["const"] = "const"
-    # Non-finite values are rejected by ``_SpecNode._reject_non_finite_floats``.
-    value: float
+def _float_gt(threshold: float):
+    def check(value: Any) -> None:
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(f"must be numeric (got {type(value).__name__})")
+        if not (math.isfinite(float(value)) and float(value) > threshold):
+            raise ValueError(f"must be > {threshold} (got {value})")
+
+    return check
 
 
-class SMARef(_SpecNode):
-    kind: Literal["sma"] = "sma"
-    period: int = Field(ge=2, le=400)
+def _one_of(*allowed: str):
+    allowed_set = set(allowed)
+
+    def check(value: Any) -> None:
+        if value not in allowed_set:
+            raise ValueError(f"must be one of {sorted(allowed_set)} (got {value!r})")
+
+    return check
+
+
+# Each entry: required[key] = validator; optional[key] = (default, validator).
+# ``allow_source`` mirrors the previous per-class behaviour: ATR/ADX/Stochastic
+# do not accept a ``source`` override (they read OHLC directly).
+_INDICATOR_PARAM_SPECS: dict[str, dict[str, Any]] = {
+    "sma": {
+        "required": {"period": _int_in(2, 400)},
+        "optional": {},
+        "allow_source": True,
+    },
+    "ema": {
+        "required": {"period": _int_in(2, 400)},
+        "optional": {},
+        "allow_source": True,
+    },
+    "rsi": {
+        "required": {},
+        "optional": {"period": (14, _int_in(2, 200))},
+        "allow_source": True,
+    },
+    "macd": {
+        "required": {},
+        "optional": {
+            "fast": (12, _int_in(2, 200)),
+            "slow": (26, _int_in(3, 400)),
+            "signal": (9, _int_in(2, 100)),
+            "output": ("macd", _one_of("macd", "signal", "histogram")),
+        },
+        "allow_source": True,
+    },
+    "bollinger": {
+        "required": {},
+        "optional": {
+            "period": (20, _int_in(5, 200)),
+            "num_std": (2.0, _float_gt(0)),
+            "band": ("middle", _one_of("upper", "middle", "lower")),
+        },
+        "allow_source": True,
+    },
+    "atr": {
+        "required": {},
+        "optional": {"period": (14, _int_in(2, 200))},
+        "allow_source": False,
+    },
+    "adx": {
+        "required": {},
+        "optional": {"period": (14, _int_in(2, 200))},
+        "allow_source": False,
+    },
+    "stochastic": {
+        "required": {},
+        "optional": {
+            "k_period": (14, _int_in(2, 200)),
+            "d_period": (3, _int_in(1, 100)),
+            "output": ("k", _one_of("k", "d")),
+        },
+        "allow_source": False,
+    },
+    "vwap": {
+        "required": {},
+        "optional": {},
+        "allow_source": False,
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# IndicatorRef — flat shape per issue #537. The `name` field selects the
+# indicator; `params` is a dict whose accepted keys/values are governed by
+# `_INDICATOR_PARAM_SPECS`. `params` is widened to `float | int | str` (vs.
+# the issue's literal `float | int`) so the existing `macd.output`,
+# `bollinger.band`, `stochastic.output` selectors keep working — these are
+# discrete-choice params, not free strings.
+# ---------------------------------------------------------------------------
+
+
+class IndicatorRef(_SpecNode):
+    name: IndicatorName
+    params: dict[str, Union[int, float, str]] = Field(default_factory=dict)
     source: Source = "close"
 
+    @model_validator(mode="after")
+    def _validate_params(self):
+        spec = _INDICATOR_PARAM_SPECS[self.name]
+        required: dict[str, Any] = spec["required"]
+        optional: dict[str, Any] = spec["optional"]
+        allow_source: bool = spec["allow_source"]
 
-class EMARef(_SpecNode):
-    kind: Literal["ema"] = "ema"
-    period: int = Field(ge=2, le=400)
-    source: Source = "close"
+        for key, check in required.items():
+            if key not in self.params:
+                raise ValueError(f"indicator {self.name!r} requires param {key!r}")
+            check(self.params[key])
 
+        for key, value in self.params.items():
+            if key in required:
+                continue
+            if key not in optional:
+                allowed = sorted(set(required) | set(optional))
+                raise ValueError(
+                    f"indicator {self.name!r} got unexpected param {key!r}; allowed: {allowed}"
+                )
+            _default, check = optional[key]
+            check(value)
 
-class RSIRef(_SpecNode):
-    kind: Literal["rsi"] = "rsi"
-    period: int = Field(default=14, ge=2, le=200)
-    source: Source = "close"
+        if not allow_source and self.source != "close":
+            raise ValueError(f"indicator {self.name!r} does not accept a 'source' override")
 
+        # Fill in defaults for any optional params that weren't supplied so
+        # constructed nodes are self-describing — e.g. ``IndicatorRef(name="rsi")``
+        # is equivalent post-construction to
+        # ``IndicatorRef(name="rsi", params={"period": 14})``. Two IndicatorRefs
+        # with the same effective configuration compare equal regardless of
+        # whether the caller passed the default explicitly.
+        for key, (default, _check) in optional.items():
+            self.params.setdefault(key, default)
 
-class MACDRef(_SpecNode):
-    kind: Literal["macd"] = "macd"
-    fast: int = Field(default=12, ge=2, le=200)
-    slow: int = Field(default=26, ge=3, le=400)
-    signal: int = Field(default=9, ge=2, le=100)
-    output: Literal["macd", "signal", "histogram"] = "macd"
-    source: Source = "close"
+        return self
 
-
-class BollingerRef(_SpecNode):
-    kind: Literal["bollinger"] = "bollinger"
-    period: int = Field(default=20, ge=5, le=200)
-    num_std: float = Field(default=2.0, gt=0)
-    band: Literal["upper", "middle", "lower"] = "middle"
-    source: Source = "close"
-
-
-class ATRRef(_SpecNode):
-    kind: Literal["atr"] = "atr"
-    period: int = Field(default=14, ge=2, le=200)
-
-
-class ADXRef(_SpecNode):
-    kind: Literal["adx"] = "adx"
-    period: int = Field(default=14, ge=2, le=200)
-
-
-class StochasticRef(_SpecNode):
-    kind: Literal["stochastic"] = "stochastic"
-    k_period: int = Field(default=14, ge=2, le=200)
-    d_period: int = Field(default=3, ge=1, le=100)
-    output: Literal["k", "d"] = "k"
-
-
-class VWAPRef(_SpecNode):
-    kind: Literal["vwap"] = "vwap"
-
-
-IndicatorRef = Annotated[
-    Union[
-        PriceRef,
-        ConstRef,
-        SMARef,
-        EMARef,
-        RSIRef,
-        MACDRef,
-        BollingerRef,
-        ATRRef,
-        ADXRef,
-        StochasticRef,
-        VWAPRef,
-    ],
-    Field(discriminator="kind"),
-]
+    def param(self, key: str, default: Any = None) -> Any:
+        """Return ``params[key]`` if set, else the registry default, else ``default``."""
+        if key in self.params:
+            return self.params[key]
+        spec = _INDICATOR_PARAM_SPECS[self.name]
+        if key in spec["optional"]:
+            return spec["optional"][key][0]
+        return default
 
 
 # ---------------------------------------------------------------------------
@@ -156,10 +255,32 @@ IndicatorRef = Annotated[
 # ---------------------------------------------------------------------------
 
 
+PredicateLhs = Union[IndicatorRef, PriceRefLiteral]
+PredicateRhs = Union[IndicatorRef, PriceRefLiteral, float]
+
+
 class Predicate(_SpecNode):
-    lhs: IndicatorRef
+    lhs: PredicateLhs
     op: ComparisonOp
-    rhs: IndicatorRef
+    # ``rhs`` is intentionally widened beyond the issue's
+    # ``ExitPriceRefLiteral`` to accept ``"bar.volume"`` symmetrically with
+    # ``lhs``. Comparing volume against indicators is uncommon but supported
+    # for symmetry. Floats are accepted only on the rhs.
+    rhs: PredicateRhs
+
+    @model_validator(mode="after")
+    def _validate_sides(self):
+        if isinstance(self.lhs, str) and self.lhs not in _PRICE_REF_LITERALS:
+            raise ValueError(
+                f"Predicate.lhs string must be one of {sorted(_PRICE_REF_LITERALS)}; "
+                f"got {self.lhs!r}"
+            )
+        if isinstance(self.rhs, str) and self.rhs not in _PRICE_REF_LITERALS:
+            raise ValueError(
+                f"Predicate.rhs string must be one of {sorted(_PRICE_REF_LITERALS)} "
+                f"or a float; got {self.rhs!r}"
+            )
+        return self
 
 
 class EntryRule(_SpecNode):
@@ -169,18 +290,10 @@ class EntryRule(_SpecNode):
     note: str = ""
 
 
-class UnparsableRule(_SpecNode):
-    """Shared variant used in entry or exit slots when prose can't be parsed."""
-
-    kind: Literal["unparsable"] = "unparsable"
-    prose: str
-    reason: str = ""
-
-
-EntryRuleUnion = Annotated[
-    Union[EntryRule, UnparsableRule],
-    Field(discriminator="kind"),
-]
+# Back-compat alias — earlier the entry union included an Unparsable variant.
+# Issue #537 lifts unparseable handling to the spec level; this alias keeps
+# import sites unchanged.
+EntryRuleUnion = EntryRule
 
 
 class TimeStopRule(_SpecNode):
@@ -209,13 +322,17 @@ class SignalExitRule(_SpecNode):
 
 
 ExitRule = Annotated[
-    Union[TimeStopRule, StopLossRule, TakeProfitRule, SignalExitRule, UnparsableRule],
+    Union[TimeStopRule, StopLossRule, TakeProfitRule, SignalExitRule],
     Field(discriminator="kind"),
 ]
 
 
 # ---------------------------------------------------------------------------
-# SizingRule union.
+# SizingRule union. Kept as a typed union (vs. the issue's flat
+# ``{kind, params}`` shape) so the existing typed call sites in the
+# orchestrator/ideation continue to validate at the type level. The
+# user-listed scope only required reshaping ``IndicatorRef`` and
+# ``Predicate``; the sizing union was not included.
 # ---------------------------------------------------------------------------
 
 
@@ -237,38 +354,16 @@ class FixedNotionalSizing(_SpecNode):
     note: str = ""
 
 
-class UnparsableSizing(_SpecNode):
-    kind: Literal["unparsable_sizing"] = "unparsable_sizing"
-    prose: str
-    reason: str = ""
-
-
 SizingRule = Annotated[
-    Union[
-        FixedFractionSizing,
-        VolatilityTargetSizing,
-        FixedNotionalSizing,
-        UnparsableSizing,
-    ],
+    Union[FixedFractionSizing, VolatilityTargetSizing, FixedNotionalSizing],
     Field(discriminator="kind"),
 ]
 
 
 # Resolve forward refs so union members are usable from outside the module.
-PriceRef.model_rebuild()
-ConstRef.model_rebuild()
-SMARef.model_rebuild()
-EMARef.model_rebuild()
-RSIRef.model_rebuild()
-MACDRef.model_rebuild()
-BollingerRef.model_rebuild()
-ATRRef.model_rebuild()
-ADXRef.model_rebuild()
-StochasticRef.model_rebuild()
-VWAPRef.model_rebuild()
+IndicatorRef.model_rebuild()
 Predicate.model_rebuild()
 EntryRule.model_rebuild()
-UnparsableRule.model_rebuild()
 TimeStopRule.model_rebuild()
 StopLossRule.model_rebuild()
 TakeProfitRule.model_rebuild()
@@ -276,13 +371,12 @@ SignalExitRule.model_rebuild()
 FixedFractionSizing.model_rebuild()
 VolatilityTargetSizing.model_rebuild()
 FixedNotionalSizing.model_rebuild()
-UnparsableSizing.model_rebuild()
 
 
 # TypeAdapters expose discriminator dispatch for callers that need to
 # validate a raw dict without pre-selecting the concrete class.
 IndicatorRefAdapter: TypeAdapter = TypeAdapter(IndicatorRef)
-EntryRuleAdapter: TypeAdapter = TypeAdapter(EntryRuleUnion)
+EntryRuleAdapter: TypeAdapter = TypeAdapter(EntryRule)
 ExitRuleAdapter: TypeAdapter = TypeAdapter(ExitRule)
 SizingRuleAdapter: TypeAdapter = TypeAdapter(SizingRule)
 
@@ -295,43 +389,28 @@ DEFAULT_SIZING_PAYLOAD: dict = {"kind": "fixed_fraction", "fraction": 0.02}
 
 
 # ---------------------------------------------------------------------------
-# Human-readable formatters.  Outputs are chosen to round-trip through
-# spec_dsl_adapter.parse_* (step 1's adapter), so feeding format_rule's
-# output back into the adapter returns an equal structured rule.
+# Human-readable formatters. Outputs are chosen to round-trip through
+# spec_dsl_adapter.parse_*, so feeding _format_rule's output back into the
+# adapter returns an equal structured rule.
 # ---------------------------------------------------------------------------
 
 
 _OP_SYMBOL: dict[str, str] = {
-    "gt": ">",
-    "lt": "<",
-    "ge": ">=",
-    "le": "<=",
-    "eq": "==",
+    "<": "<",
+    ">": ">",
+    "<=": "<=",
+    ">=": ">=",
+    "==": "==",
     "cross_above": "crosses above",
     "cross_below": "crosses below",
 }
 
 
 def _format_number(x: float) -> str:
-    """Render a float as decimal text the adapter regex can parse back.
-
-    Integer-valued floats (including those that fall on an integer after the
-    usual ``0.02 * 100 == 2.0000000000000004`` float-arithmetic jitter) render
-    as bare integers.  Everything else uses ``repr(x)``, which gives Python's
-    shortest unambiguous representation.  ``repr`` may emit scientific
-    notation for very small or very large values (e.g. ``1e-13``); the adapter
-    accepts that form via ``_NUMBER_PAT``.  Non-finite values raise — they're
-    rejected at construction time by ``_SpecNode`` but we double-check here.
-    """
+    """Render a float as decimal text the adapter regex can parse back."""
     if not math.isfinite(x):
         raise ValueError(f"cannot format non-finite value: {x!r}")
     rounded = round(x)
-    # Relative-tolerance check absorbs float jitter like 0.10 * 100 →
-    # 10.000000000000002 without collapsing genuinely tiny values:
-    # math.isclose(5e-10, 0, rel_tol=1e-12, abs_tol=0) is False because
-    # rel_tol*max(|5e-10|, 0) = 5e-22 < 5e-10.  The -1e16..1e16 bound keeps
-    # very large floats out of the integer fast path (their decimal form
-    # would lose precision).
     if math.isclose(x, rounded, rel_tol=1e-12, abs_tol=0) and -1e16 < x < 1e16:
         return str(rounded)
     return repr(x)
@@ -349,40 +428,56 @@ def _with_source(base: str, source: str) -> str:
 
 
 def _format_indicator_ref(ref: IndicatorRef) -> str:
-    if isinstance(ref, PriceRef):
-        return ref.field
-    if isinstance(ref, ConstRef):
-        return _format_number(ref.value)
-    if isinstance(ref, SMARef):
-        return _with_source(f"sma({ref.period})", ref.source)
-    if isinstance(ref, EMARef):
-        return _with_source(f"ema({ref.period})", ref.source)
-    if isinstance(ref, RSIRef):
-        return _with_source(f"rsi({ref.period})", ref.source)
-    if isinstance(ref, MACDRef):
-        # Default `output="macd"` formats as bare `macd(…)`; otherwise emit
-        # `macd_signal(…)` / `macd_histogram(…)` so the token matches one of
-        # the adapter's recognised indicator names.
-        macd_name = "macd" if ref.output == "macd" else f"macd_{ref.output}"
-        return _with_source(f"{macd_name}({ref.fast},{ref.slow},{ref.signal})", ref.source)
-    if isinstance(ref, BollingerRef):
-        return _with_source(
-            f"bollinger_{ref.band}({ref.period},{_format_number(ref.num_std)})",
-            ref.source,
-        )
-    if isinstance(ref, ATRRef):
-        return f"atr({ref.period})"
-    if isinstance(ref, ADXRef):
-        return f"adx({ref.period})"
-    if isinstance(ref, StochasticRef):
-        return f"stochastic_{ref.output}({ref.k_period},{ref.d_period})"
-    if isinstance(ref, VWAPRef):
+    name = ref.name
+    if name == "sma":
+        base = f"sma({ref.param('period')})"
+        return _with_source(base, ref.source)
+    if name == "ema":
+        base = f"ema({ref.param('period')})"
+        return _with_source(base, ref.source)
+    if name == "rsi":
+        base = f"rsi({ref.param('period')})"
+        return _with_source(base, ref.source)
+    if name == "macd":
+        output = ref.param("output")
+        macd_name = "macd" if output == "macd" else f"macd_{output}"
+        base = f"{macd_name}({ref.param('fast')},{ref.param('slow')},{ref.param('signal')})"
+        return _with_source(base, ref.source)
+    if name == "bollinger":
+        period = ref.param("period")
+        num_std = float(ref.param("num_std"))
+        band = ref.param("band")
+        base = f"bollinger_{band}({period},{_format_number(num_std)})"
+        return _with_source(base, ref.source)
+    if name == "atr":
+        return f"atr({ref.param('period')})"
+    if name == "adx":
+        return f"adx({ref.param('period')})"
+    if name == "stochastic":
+        output = ref.param("output")
+        return f"stochastic_{output}({ref.param('k_period')},{ref.param('d_period')})"
+    if name == "vwap":
         return "vwap()"
-    raise TypeError(f"unknown IndicatorRef variant: {type(ref).__name__}")
+    raise TypeError(f"unknown IndicatorRef name: {name!r}")
+
+
+def _format_side(side: Union[IndicatorRef, str, int, float]) -> str:
+    """Render one side of a `Predicate` for the prose formatter."""
+    if isinstance(side, IndicatorRef):
+        return _format_indicator_ref(side)
+    if isinstance(side, str):
+        if side in _PRICE_REF_LITERALS:
+            return side.split(".", 1)[1]  # "bar.close" -> "close"
+        raise ValueError(f"unexpected string side: {side!r}")
+    if isinstance(side, bool):
+        raise TypeError("boolean is not a valid predicate side")
+    if isinstance(side, (int, float)):
+        return _format_number(float(side))
+    raise TypeError(f"unknown predicate side type: {type(side).__name__}")
 
 
 def _format_predicate(p: Predicate) -> str:
-    return f"{_format_indicator_ref(p.lhs)} {_OP_SYMBOL[p.op]} {_format_indicator_ref(p.rhs)}"
+    return f"{_format_side(p.lhs)} {_OP_SYMBOL[p.op]} {_format_side(p.rhs)}"
 
 
 _STOP_LOSS_BASIS_PREFIX: dict[str, str] = {
@@ -392,12 +487,7 @@ _STOP_LOSS_BASIS_PREFIX: dict[str, str] = {
 
 
 def _format_rule(
-    rule: EntryRule
-    | UnparsableRule
-    | TimeStopRule
-    | StopLossRule
-    | TakeProfitRule
-    | SignalExitRule,
+    rule: Union[EntryRule, TimeStopRule, StopLossRule, TakeProfitRule, SignalExitRule],
 ) -> str:
     if isinstance(rule, EntryRule):
         return f"{rule.side} when {_format_predicate(rule.when)}"
@@ -410,8 +500,6 @@ def _format_rule(
         return f"take profit {_format_number(rule.pct * 100)}%"
     if isinstance(rule, SignalExitRule):
         return f"exit when {_format_predicate(rule.when)}"
-    if isinstance(rule, UnparsableRule):
-        return rule.prose
     raise TypeError(f"unknown rule variant: {type(rule).__name__}")
 
 
@@ -421,13 +509,110 @@ def format_rules_for_prompt(rules, separator: str = ", ") -> str:
 
 
 def format_sizing_rule(sizing) -> str:
-    """Render a structured sizing rule back into the prose forms the adapter parses."""
+    """Render a structured sizing rule back into prose the adapter parses."""
     if isinstance(sizing, FixedFractionSizing):
         return f"risk {_format_number(sizing.fraction * 100)}% per trade"
     if isinstance(sizing, VolatilityTargetSizing):
         return f"vol-target {_format_number(sizing.target_annual_vol * 100)}%"
     if isinstance(sizing, FixedNotionalSizing):
         return f"${_format_number(sizing.notional_usd)} per trade"
-    if isinstance(sizing, UnparsableSizing):
-        return sizing.prose
     raise TypeError(f"unknown SizingRule variant: {type(sizing).__name__}")
+
+
+# ---------------------------------------------------------------------------
+# from_prose — top-level entry point for legacy prose specs.
+#
+# The issue text proposes ``spec_dsl.from_prose(spec_legacy)`` as the
+# single-call migration. Returns a structured `StrategySpec` where rules
+# that couldn't be parsed are stashed in ``unparsed_rules`` and
+# ``requires_redesign`` is set so the design agent re-runs.
+# ---------------------------------------------------------------------------
+
+
+def from_prose(spec_legacy: Any) -> Any:
+    """Best-effort migrate a legacy prose-shaped spec to the structured DSL.
+
+    Accepts a ``dict`` (with ``entry_rules: list[str]``, ``exit_rules:
+    list[str]``, and either ``sizing_rules: list[str]`` or ``sizing: str``),
+    or any object with a ``model_dump()`` method. Unparseable rules are
+    dropped from the rule lists, their raw prose appended to
+    ``unparsed_rules``, and ``requires_redesign=True`` is set. Missing
+    ``timeframe`` defaults to ``"1d"`` in this legacy path only — fresh
+    callers must declare it explicitly.
+
+    Returns a freshly validated ``StrategySpec``.
+    """
+    # Local import to avoid an import cycle through `models.py`.
+    from ..models import StrategySpec
+    from . import spec_dsl_adapter
+
+    if isinstance(spec_legacy, dict):
+        payload: dict = dict(spec_legacy)
+    elif hasattr(spec_legacy, "model_dump"):
+        payload = spec_legacy.model_dump()
+    else:
+        raise TypeError(
+            f"from_prose expected a dict or BaseModel; got {type(spec_legacy).__name__}"
+        )
+
+    unparsed: list[str] = list(payload.get("unparsed_rules") or [])
+    requires_redesign = bool(payload.get("requires_redesign", False))
+
+    # entry_rules
+    raw_entries = payload.get("entry_rules") or []
+    new_entries: list[dict] = []
+    for raw in raw_entries:
+        if isinstance(raw, str):
+            parsed = spec_dsl_adapter.parse_entry_rule(raw)
+            if parsed is None:
+                unparsed.append(raw)
+                requires_redesign = True
+            else:
+                new_entries.append(parsed.model_dump())
+        else:
+            new_entries.append(raw)
+    payload["entry_rules"] = new_entries
+
+    # exit_rules
+    raw_exits = payload.get("exit_rules") or []
+    new_exits: list[dict] = []
+    for raw in raw_exits:
+        if isinstance(raw, str):
+            parsed = spec_dsl_adapter.parse_exit_rule(raw)
+            if parsed is None:
+                unparsed.append(raw)
+                requires_redesign = True
+            else:
+                new_exits.append(parsed.model_dump())
+        else:
+            new_exits.append(raw)
+    payload["exit_rules"] = new_exits
+
+    # sizing — accept legacy ``sizing_rules: list[str]`` or ``sizing: str``.
+    if "sizing_rules" in payload:
+        sizing_list = payload.pop("sizing_rules") or []
+        if sizing_list and all(isinstance(s, str) for s in sizing_list):
+            parsed = spec_dsl_adapter.parse_sizing_list(sizing_list)
+            if parsed is None:
+                unparsed.extend(sizing_list)
+                requires_redesign = True
+                payload["sizing"] = dict(DEFAULT_SIZING_PAYLOAD)
+            else:
+                payload["sizing"] = parsed.model_dump()
+    if isinstance(payload.get("sizing"), str):
+        parsed = spec_dsl_adapter.parse_sizing_rule(payload["sizing"])
+        if parsed is None:
+            unparsed.append(payload["sizing"])
+            requires_redesign = True
+            payload["sizing"] = dict(DEFAULT_SIZING_PAYLOAD)
+        else:
+            payload["sizing"] = parsed.model_dump()
+
+    payload["unparsed_rules"] = unparsed
+    payload["requires_redesign"] = requires_redesign
+
+    # Legacy specs predate the required ``timeframe`` field; default to
+    # daily so the migration path is non-fatal.
+    payload.setdefault("timeframe", "1d")
+
+    return StrategySpec.model_validate(payload)

--- a/backend/agents/investment_team/strategy_lab/spec_dsl_adapter.py
+++ b/backend/agents/investment_team/strategy_lab/spec_dsl_adapter.py
@@ -1,41 +1,30 @@
-"""Regex-based prose → spec_dsl adapter (issue #550, step 1 of 8 from #537).
+"""Regex-based prose → spec_dsl adapter (issue #537 literal schema).
 
 Pure regex; no LLM; no Pydantic-side-effects beyond constructing DSL nodes.
-First-match-wins ordering. Unmatched prose returns the shared ``UnparsableRule``
-variant (or ``UnparsableSizing`` in the sizing slot) so callers can route the
-ungroomed text back to a redesign loop.
+First-match-wins ordering. Unmatched prose returns ``None`` so the caller
+(``spec_dsl.from_prose`` / ``StrategySpec`` legacy-payload rewriter) can
+stash the raw text in ``unparsed_rules`` and set ``requires_redesign=True``
+on the spec.
 """
 
 from __future__ import annotations
 
 import re
-from typing import Literal
+from typing import Literal, Optional
 
 from pydantic import ValidationError
 
 from .spec_dsl import (
-    ADXRef,
-    ATRRef,
-    BollingerRef,
-    ConstRef,
-    EMARef,
     EntryRule,
     FixedFractionSizing,
     FixedNotionalSizing,
-    MACDRef,
+    IndicatorRef,
     Predicate,
-    PriceRef,
-    RSIRef,
     SignalExitRule,
-    SMARef,
-    StochasticRef,
     StopLossRule,
     TakeProfitRule,
     TimeStopRule,
-    UnparsableRule,
-    UnparsableSizing,
     VolatilityTargetSizing,
-    VWAPRef,
 )
 
 # ---------------------------------------------------------------------------
@@ -66,7 +55,7 @@ _INDICATOR_NAMES = (
 
 # Token: either a price field, a number (int / decimal / leading-dot decimal /
 # scientific), or ``name(arg1[,arg2,...])`` / bare ``name`` for the indicators
-# above.  Longest names come first so ``macd_signal`` matches before ``macd``.
+# above. Longest names come first so ``macd_signal`` matches before ``macd``.
 # Each underscore in the indicator name is allowed to appear as ``-`` or ``_``
 # so hyphenated aliases (``macd-signal``) parse identically to the
 # underscored form.
@@ -78,8 +67,7 @@ _TOKEN_PAT = (
     r"|(?:" + _INDICATOR_NAME_PAT + r")\b"
     r"|" + _NUMBER_PAT
 )
-# ``cross(?:es)?`` matches singular `cross` and plural `crosses` (the previous
-# ``crosses?`` matched only `crosse`/`crosses` — never bare `cross`).
+# ``cross(?:es)?`` matches singular `cross` and plural `crosses`.
 _OP_PAT = r"(>=|<=|==|>|<|cross(?:es)?\s+above|cross(?:es)?\s+below)"
 
 _PREDICATE_RE = re.compile(
@@ -95,7 +83,7 @@ _TIME_STOP_RE = re.compile(
     re.IGNORECASE,
 )
 
-# Positive numeric pattern (no leading sign).  Includes scientific notation
+# Positive numeric pattern (no leading sign). Includes scientific notation
 # so tiny fractions like ``1e-12`` round-trip through the formatter; Pydantic
 # `gt=0` constraints reject negative parses, so we don't need to forbid the
 # minus sign here.
@@ -131,37 +119,34 @@ _FIXED_NOTIONAL_RE = re.compile(
 )
 
 
-# Per-indicator argument parser.  ``_parse_call_args`` splits ``raw`` into
+# Per-indicator argument parser. ``_parse_call_args`` splits ``raw`` into
 # positional values and a single optional ``source=X`` kwarg, rejecting:
 #   - extra positional args beyond what the indicator accepts,
 #   - any kwarg other than ``source`` (or any ``source=`` when the indicator
 #     has no ``source`` field),
 #   - positional args appearing after a kwarg,
 #   - non-numeric positional tokens.
-# Returning ``None`` makes the caller emit ``UnparsableRule``.
+# Returning ``None`` makes the caller emit nothing (caller stashes prose).
 def _parse_call_args(
     raw: str,
     int_slots: int,
     float_slots: int = 0,
     allow_source: bool = True,
-) -> tuple[list[int | float], str | None] | None:
+) -> Optional[tuple[list, Optional[str]]]:
     if not raw.strip():
         return [], None
-    # Don't filter empty slots: ``sma(,20)`` / ``macd(12,,9)`` would silently
-    # shift positional values to the wrong parameters.  Any empty slot is a
-    # malformed call.
     parts = [p.strip() for p in raw.split(",")]
     if any(not p for p in parts):
         return None
     positional_tokens: list[str] = []
-    source: str | None = None
+    source: Optional[str] = None
     saw_kwarg = False
     for part in parts:
         if "=" in part:
             saw_kwarg = True
             k, v = part.split("=", 1)
             k = k.strip().lower()
-            v = v.strip().lower()  # `SOURCE=OPEN` → `source=open` so the Literal accepts it
+            v = v.strip().lower()
             if k != "source" or not allow_source or source is not None:
                 return None
             source = v
@@ -173,7 +158,7 @@ def _parse_call_args(
     if len(positional_tokens) > int_slots + float_slots:
         return None
 
-    parsed: list[int | float] = []
+    parsed: list = []
     for i, val in enumerate(positional_tokens):
         try:
             parsed.append(int(val) if i < int_slots else float(val))
@@ -182,76 +167,87 @@ def _parse_call_args(
     return parsed, source
 
 
-def _parse_indicator_call(name: str, raw_args: str):
-    def _single_period(cls, require_positional: bool):
+def _build_indicator(name: str, params: dict, source: Optional[str]) -> Optional[IndicatorRef]:
+    kwargs: dict = {"name": name, "params": params}
+    if source is not None:
+        kwargs["source"] = source
+    try:
+        return IndicatorRef(**kwargs)
+    except (ValueError, ValidationError):
+        return None
+
+
+def _parse_indicator_call(name: str, raw_args: str) -> Optional[IndicatorRef]:
+    if name == "sma":
         res = _parse_call_args(raw_args, int_slots=1, allow_source=True)
         if res is None:
             return None
         pos, source = res
-        if require_positional and not pos:
+        if not pos:
             return None
-        kwargs: dict = {}
-        if pos:
-            kwargs["period"] = pos[0]
-        if source is not None:
-            kwargs["source"] = source
-        return cls(**kwargs)
-
-    if name == "sma":
-        return _single_period(SMARef, require_positional=True)
+        return _build_indicator("sma", {"period": pos[0]}, source)
     if name == "ema":
-        return _single_period(EMARef, require_positional=True)
+        res = _parse_call_args(raw_args, int_slots=1, allow_source=True)
+        if res is None:
+            return None
+        pos, source = res
+        if not pos:
+            return None
+        return _build_indicator("ema", {"period": pos[0]}, source)
     if name == "rsi":
-        return _single_period(RSIRef, require_positional=False)
+        res = _parse_call_args(raw_args, int_slots=1, allow_source=True)
+        if res is None:
+            return None
+        pos, source = res
+        params: dict = {"period": pos[0]} if pos else {}
+        return _build_indicator("rsi", params, source)
     if name == "atr":
         res = _parse_call_args(raw_args, int_slots=1, allow_source=False)
         if res is None:
             return None
         pos, _ = res
-        return ATRRef(**({"period": pos[0]} if pos else {}))
+        return _build_indicator("atr", {"period": pos[0]} if pos else {}, None)
     if name == "adx":
         res = _parse_call_args(raw_args, int_slots=1, allow_source=False)
         if res is None:
             return None
         pos, _ = res
-        return ADXRef(**({"period": pos[0]} if pos else {}))
+        return _build_indicator("adx", {"period": pos[0]} if pos else {}, None)
     if name in ("macd", "macd_signal", "macd_histogram"):
         output = name.split("_", 1)[1] if "_" in name else "macd"
         res = _parse_call_args(raw_args, int_slots=3, allow_source=True)
         if res is None:
             return None
         pos, source = res
-        kwargs = dict(zip(("fast", "slow", "signal"), pos))
-        if source is not None:
-            kwargs["source"] = source
-        return MACDRef(output=output, **kwargs)  # type: ignore[arg-type]
+        params = dict(zip(("fast", "slow", "signal"), pos))
+        params["output"] = output
+        return _build_indicator("macd", params, source)
     if name in ("bollinger", "bollinger_upper", "bollinger_lower", "bollinger_middle"):
         band = name.split("_", 1)[1] if "_" in name else "middle"
         res = _parse_call_args(raw_args, int_slots=1, float_slots=1, allow_source=True)
         if res is None:
             return None
         pos, source = res
-        kwargs: dict = {}
+        params = {"band": band}
         if pos:
-            kwargs["period"] = pos[0]
+            params["period"] = pos[0]
         if len(pos) >= 2:
-            kwargs["num_std"] = pos[1]
-        if source is not None:
-            kwargs["source"] = source
-        return BollingerRef(band=band, **kwargs)  # type: ignore[arg-type]
+            params["num_std"] = pos[1]
+        return _build_indicator("bollinger", params, source)
     if name in ("stochastic", "stochastic_k", "stochastic_d"):
         output = name.split("_", 1)[1] if "_" in name else "k"
         res = _parse_call_args(raw_args, int_slots=2, allow_source=False)
         if res is None:
             return None
         pos, _ = res
-        kwargs = dict(zip(("k_period", "d_period"), pos))
-        return StochasticRef(output=output, **kwargs)  # type: ignore[arg-type]
+        params = dict(zip(("k_period", "d_period"), pos))
+        params["output"] = output
+        return _build_indicator("stochastic", params, None)
     if name == "vwap":
         res = _parse_call_args(raw_args, int_slots=0, allow_source=False)
         if res is None:
             return None
-        return VWAPRef()
+        return _build_indicator("vwap", {}, None)
     return None
 
 
@@ -266,30 +262,37 @@ _BARE_NAME_RE = re.compile(
 
 
 def _parse_token(tok: str):
-    """Return an IndicatorRef-compatible node, or ``None`` if unparseable."""
+    """Return one of:
+
+    - an ``IndicatorRef`` instance, when the token names an indicator;
+    - the bar-field literal string (``"bar.close"`` etc.) when the token
+      is a bare price field — these are valid lhs/rhs values for
+      ``Predicate`` directly;
+    - a bare ``float`` for numeric tokens (valid only on the rhs);
+    - ``None`` when the token can't be parsed.
+    """
     tok = tok.strip()
     if not tok:
         return None
     low = tok.lower()
     if low in _PRICE_FIELDS:
-        return PriceRef(field=low)  # type: ignore[arg-type]
-    # bare number
+        # Bar volume / hl2 / ohlc4 don't have a Predicate-level literal
+        # form — they're addressable via an IndicatorRef-like wrapper, but
+        # the issue's literal schema only permits "bar.close"/"bar.high"/
+        # "bar.low"/"bar.volume". For everything else, signal unparseable.
+        if low in {"close", "high", "low", "volume"}:
+            return f"bar.{low}"
+        return None
     try:
-        return ConstRef(value=float(tok))
+        return float(tok)
     except ValueError:
         pass
     m = _INDICATOR_CALL_RE.match(tok)
     if m:
-        try:
-            return _parse_indicator_call(_canonical_name(m.group(1)), m.group(2))
-        except (ValueError, ValidationError):
-            return None
+        return _parse_indicator_call(_canonical_name(m.group(1)), m.group(2))
     m = _BARE_NAME_RE.match(tok)
     if m:
-        try:
-            return _parse_indicator_call(_canonical_name(m.group(1)), "")
-        except (ValueError, ValidationError):
-            return None
+        return _parse_indicator_call(_canonical_name(m.group(1)), "")
     return None
 
 
@@ -298,21 +301,10 @@ def _canonical_name(raw: str) -> str:
     return raw.lower().replace("-", "_")
 
 
-_OP_MAP = {
-    ">": "gt",
-    "<": "lt",
-    ">=": "ge",
-    "<=": "le",
-    "==": "eq",
-}
-
-
-def _normalise_op(op_text: str) -> str | None:
+def _normalise_op(op_text: str) -> Optional[str]:
     op_text = op_text.strip().lower()
-    if op_text in _OP_MAP:
-        return _OP_MAP[op_text]
-    # ``crosses above`` / ``cross above`` (and below) — note ``crosses?`` only
-    # matches ``crosse``/``crosses``, so we use ``cross(?:es)?`` for both forms.
+    if op_text in {">", "<", ">=", "<=", "=="}:
+        return op_text
     if re.match(r"cross(?:es)?\s+above", op_text):
         return "cross_above"
     if re.match(r"cross(?:es)?\s+below", op_text):
@@ -320,14 +312,14 @@ def _normalise_op(op_text: str) -> str | None:
     return None
 
 
-def _basis_from_trail(trail: str | None) -> str:
+def _basis_from_trail(trail: Optional[str]) -> str:
     """Map a captured ``trailing-high`` / ``trailing-low`` prefix to a StopLossRule basis."""
     if trail is None:
         return "entry_price"
     return "trailing_high" if "high" in trail.lower() else "trailing_low"
 
 
-def _parse_predicate(prose: str) -> Predicate | None:
+def _parse_predicate(prose: str) -> Optional[Predicate]:
     m = _PREDICATE_RE.match(prose)
     if not m:
         return None
@@ -336,8 +328,12 @@ def _parse_predicate(prose: str) -> Predicate | None:
     rhs = _parse_token(m.group(3))
     if lhs is None or op is None or rhs is None:
         return None
+    # lhs cannot be a bare float in the new schema — issue #537 reserves
+    # float rhs as the only "numeric literal" position.
+    if isinstance(lhs, float):
+        return None
     try:
-        return Predicate(lhs=lhs, op=op, rhs=rhs)  # type: ignore[arg-type]
+        return Predicate(lhs=lhs, op=op, rhs=rhs)
     except ValidationError:
         return None
 
@@ -347,13 +343,11 @@ def _parse_predicate(prose: str) -> Predicate | None:
 # ---------------------------------------------------------------------------
 
 
-def parse_entry_rule(prose: str) -> EntryRule | UnparsableRule:
+def parse_entry_rule(prose: str) -> Optional[EntryRule]:
     """Parse a single entry-rule prose string.
 
-    Accepts a bare predicate (``"close > sma(20)"``), the formatter's own
-    output (``"long when …"`` / ``"short when …"``), or the legacy repo
-    convention (``"enter when …"``, optionally ``"enter long when …"`` /
-    ``"enter short when …"``).
+    Returns ``None`` when no pattern matches; the caller is responsible
+    for stashing the raw prose into ``StrategySpec.unparsed_rules``.
     """
     text = prose.strip()
     side: Literal["long", "short"] = "short" if _SHORT_RE.search(text) else "long"
@@ -366,12 +360,16 @@ def parse_entry_rule(prose: str) -> EntryRule | UnparsableRule:
     )
     predicate = _parse_predicate(body)
     if predicate is None:
-        return UnparsableRule(prose=text, reason="no pattern matched")
+        return None
     return EntryRule(side=side, when=predicate)
 
 
 def parse_exit_rule(prose: str):
-    """Parse a single exit-rule prose string; returns one of the ExitRule union members."""
+    """Parse a single exit-rule prose string.
+
+    Returns one of the ExitRule union members, or ``None`` when no
+    pattern matches (caller stashes the prose).
+    """
     text = prose.strip()
 
     m = _TIME_STOP_RE.match(text)
@@ -379,46 +377,50 @@ def parse_exit_rule(prose: str):
         try:
             return TimeStopRule(n_bars=int(m.group(1)))
         except ValidationError:
-            return UnparsableRule(prose=text, reason="time_stop out of bounds")
+            return None
 
     m = _EXIT_WHEN_RE.match(text)
     if m:
         predicate = _parse_predicate(m.group(1))
         if predicate is not None:
             return SignalExitRule(when=predicate)
-        return UnparsableRule(prose=text, reason="exit predicate not recognised")
+        return None
 
     m = _STOP_LOSS_PCT_RE.search(text)
     if m:
         try:
             return StopLossRule(pct=float(m.group(2)) / 100.0, basis=_basis_from_trail(m.group(1)))
         except ValidationError:
-            return UnparsableRule(prose=text, reason="stop_loss out of bounds")
+            return None
 
     m = _STOP_LOSS_DECIMAL_RE.search(text)
     if m:
         try:
             return StopLossRule(pct=float(m.group(2)), basis=_basis_from_trail(m.group(1)))
         except ValidationError:
-            return UnparsableRule(prose=text, reason="stop_loss out of bounds")
+            return None
 
     m = _TAKE_PROFIT_RE.search(text)
     if m:
         try:
             return TakeProfitRule(pct=float(m.group(1)) / 100.0)
         except ValidationError:
-            return UnparsableRule(prose=text, reason="take_profit out of bounds")
+            return None
 
     # Bare predicate in the exit slot is treated as a SignalExitRule.
     predicate = _parse_predicate(text)
     if predicate is not None:
         return SignalExitRule(when=predicate)
 
-    return UnparsableRule(prose=text, reason="no pattern matched")
+    return None
 
 
 def parse_sizing_rule(prose: str):
-    """Parse a single sizing-rule prose string; returns one of the SizingRule union members."""
+    """Parse a single sizing-rule prose string.
+
+    Returns one of the SizingRule union members, or ``None`` when no
+    pattern matches (caller stashes the prose).
+    """
     text = prose.strip()
 
     m = _FIXED_FRACTION_RE.search(text)
@@ -426,27 +428,27 @@ def parse_sizing_rule(prose: str):
         try:
             return FixedFractionSizing(fraction=float(m.group(1)) / 100.0)
         except ValidationError:
-            return UnparsableSizing(prose=text, reason="fixed_fraction out of bounds")
+            return None
 
     m = _VOL_TARGET_RE.search(text)
     if m:
         try:
             return VolatilityTargetSizing(target_annual_vol=float(m.group(1)) / 100.0)
         except ValidationError:
-            return UnparsableSizing(prose=text, reason="vol_target out of bounds")
+            return None
 
     m = _FIXED_NOTIONAL_RE.search(text)
     if m:
         try:
             return FixedNotionalSizing(notional_usd=float(m.group(1)))
         except ValidationError:
-            return UnparsableSizing(prose=text, reason="fixed_notional out of bounds")
+            return None
 
-    return UnparsableSizing(prose=text, reason="no pattern matched")
+    return None
 
 
 def parse_rule_list(prose_list: list[str], kind: Literal["entry", "exit"]) -> list:
-    """Map a legacy list[str] of rules to a list of structured rules."""
+    """Map a legacy list[str] of rules to a list of structured rules or ``None``."""
     parser = parse_entry_rule if kind == "entry" else parse_exit_rule
     return [parser(p) for p in prose_list]
 
@@ -454,13 +456,12 @@ def parse_rule_list(prose_list: list[str], kind: Literal["entry", "exit"]) -> li
 def parse_sizing_list(prose_list: list[str]):
     """Collapse a legacy list[str] of sizing rules to a single structured rule.
 
-    Multiple entries: first parsable wins; remaining entries are concatenated
-    into the chosen variant's ``note`` field.  All-unparsable returns
-    ``UnparsableSizing`` covering every input joined by ``"; "``.
-    Empty list returns ``UnparsableSizing(prose="", reason="empty")``.
+    Multiple entries: first parseable wins; remaining entries are concatenated
+    into the chosen variant's ``note`` field. All-unparseable returns
+    ``None``. Empty list also returns ``None``.
     """
     if not prose_list:
-        return UnparsableSizing(prose="", reason="empty")
+        return None
     if len(prose_list) == 1:
         return parse_sizing_rule(prose_list[0])
 
@@ -468,16 +469,13 @@ def parse_sizing_list(prose_list: list[str]):
     leftovers: list[str] = []
     for entry in prose_list:
         parsed = parse_sizing_rule(entry)
-        if chosen is None and not isinstance(parsed, UnparsableSizing):
+        if chosen is None and parsed is not None:
             chosen = parsed
         else:
             leftovers.append(entry)
 
     if chosen is None:
-        return UnparsableSizing(
-            prose="; ".join(p.strip() for p in prose_list),
-            reason="no pattern matched",
-        )
+        return None
 
     note = "; ".join(p.strip() for p in leftovers)
     return chosen.model_copy(update={"note": note})

--- a/backend/agents/investment_team/tests/_coverage_probe_test_helpers.py
+++ b/backend/agents/investment_team/tests/_coverage_probe_test_helpers.py
@@ -23,10 +23,9 @@ from investment_team.models import (
     SubconditionCoverage,
 )
 from investment_team.strategy_lab.spec_dsl import (
-    ConstRef,
     EntryRule,
+    IndicatorRef,
     Predicate,
-    RSIRef,
     SignalExitRule,
 )
 from investment_team.trading_service.modes.sandbox_compat import StrategyRunResult
@@ -50,13 +49,17 @@ def make_spec(strategy_code: str | None) -> StrategySpec:
         asset_class="stocks",
         hypothesis="hyp",
         signal_definition="sig",
+        timeframe="1d",
         entry_rules=[
             EntryRule(
-                side="long", when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=25))
+                side="long",
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op="<", rhs=25),
             )
         ],
         exit_rules=[
-            SignalExitRule(when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)))
+            SignalExitRule(
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op=">", rhs=70)
+            )
         ],
         risk_limits={"max_position_pct": 5},
         speculative=False,

--- a/backend/agents/investment_team/tests/golden/test_reference_strategies.py
+++ b/backend/agents/investment_team/tests/golden/test_reference_strategies.py
@@ -33,6 +33,7 @@ def _make_spec(name: str, code: str) -> StrategySpec:
         asset_class="stocks",
         hypothesis="deterministic reference",
         signal_definition="see strategies.py",
+        timeframe="1d",
         strategy_code=code,
     )
 

--- a/backend/agents/investment_team/tests/golden/test_simulator_invariants.py
+++ b/backend/agents/investment_team/tests/golden/test_simulator_invariants.py
@@ -107,6 +107,7 @@ def _config() -> BacktestConfig:
 
 def _spec(code: str, *, strategy_id: str = "hyp") -> StrategySpec:
     return StrategySpec(
+        timeframe="1d",
         strategy_id=strategy_id,
         authored_by="hypothesis",
         asset_class="stocks",

--- a/backend/agents/investment_team/tests/test_agent_prompts_structured.py
+++ b/backend/agents/investment_team/tests/test_agent_prompts_structured.py
@@ -31,11 +31,10 @@ from investment_team.strategy_lab.agents.ideation import IdeationAgent
 from investment_team.strategy_lab.agents.refinement import RefinementAgent
 from investment_team.strategy_lab.agents.zero_trade_repair import ZeroTradeRepairAgent
 from investment_team.strategy_lab.spec_dsl import (
-    ConstRef,
     EntryRule,
     EntryRuleAdapter,
+    IndicatorRef,
     Predicate,
-    RSIRef,
     SignalExitRule,
 )
 
@@ -60,9 +59,9 @@ def _structured_entry_rule_dict() -> dict:
         "kind": "entry",
         "side": "long",
         "when": {
-            "lhs": {"kind": "rsi", "period": 14},
-            "op": "lt",
-            "rhs": {"kind": "const", "value": 30},
+            "lhs": {"name": "rsi", "params": {"period": 14}},
+            "op": "<",
+            "rhs": 30,
         },
     }
 
@@ -71,9 +70,9 @@ def _structured_signal_exit_rule_dict() -> dict:
     return {
         "kind": "signal_exit",
         "when": {
-            "lhs": {"kind": "rsi", "period": 14},
-            "op": "gt",
-            "rhs": {"kind": "const", "value": 70},
+            "lhs": {"name": "rsi", "params": {"period": 14}},
+            "op": ">",
+            "rhs": 70,
         },
     }
 
@@ -90,14 +89,17 @@ def _spec() -> StrategySpec:
         asset_class="stocks",
         hypothesis="RSI mean reversion",
         signal_definition="sig",
+        timeframe="1d",
         entry_rules=[
             EntryRule(
                 side="long",
-                when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30)),
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op="<", rhs=30),
             )
         ],
         exit_rules=[
-            SignalExitRule(when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)))
+            SignalExitRule(
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op=">", rhs=70)
+            )
         ],
         risk_limits={"max_position_pct": 5, "max_drawdown_pct": 10},
         speculative=False,

--- a/backend/agents/investment_team/tests/test_analysis_agent_verdict.py
+++ b/backend/agents/investment_team/tests/test_analysis_agent_verdict.py
@@ -29,10 +29,8 @@ from investment_team.models import BacktestResult, StrategySpec
 from investment_team.strategy_lab.agents import analysis as analysis_module
 from investment_team.strategy_lab.agents.analysis import AnalysisAgent
 from investment_team.strategy_lab.spec_dsl import (
-    ConstRef,
     EntryRule,
     Predicate,
-    PriceRef,
     TimeStopRule,
 )
 
@@ -44,10 +42,11 @@ def _spec() -> StrategySpec:
         asset_class="stocks",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
         entry_rules=[
             EntryRule(
                 side="long",
-                when=Predicate(lhs=PriceRef(), op="gt", rhs=ConstRef(value=0)),
+                when=Predicate(lhs="bar.close", op=">", rhs=0),
             )
         ],
         exit_rules=[TimeStopRule(n_bars=5)],

--- a/backend/agents/investment_team/tests/test_analysis_alignment_prompts.py
+++ b/backend/agents/investment_team/tests/test_analysis_alignment_prompts.py
@@ -34,8 +34,8 @@ from investment_team.strategy_lab.agents.analysis import _PROMPT_DIR
 from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
     FixedFractionSizing,
+    IndicatorRef,
     Predicate,
-    SMARef,
     StopLossRule,
     TimeStopRule,
     format_rules_for_prompt,
@@ -54,9 +54,9 @@ def _render_inputs() -> dict[str, object]:
     entry = EntryRule(
         side="long",
         when=Predicate(
-            lhs=SMARef(period=20),
-            op="gt",
-            rhs=SMARef(period=50),
+            lhs=IndicatorRef(name="sma", params={"period": 20}),
+            op=">",
+            rhs=IndicatorRef(name="sma", params={"period": 50}),
         ),
     )
     exits = [TimeStopRule(n_bars=10), StopLossRule(pct=0.02)]

--- a/backend/agents/investment_team/tests/test_asset_class_mix_hint.py
+++ b/backend/agents/investment_team/tests/test_asset_class_mix_hint.py
@@ -18,10 +18,8 @@ from investment_team.models import (
     StrategySpec,
 )
 from investment_team.strategy_lab.spec_dsl import (
-    ConstRef,
     EntryRule,
     Predicate,
-    PriceRef,
     TimeStopRule,
 )
 from investment_team.strategy_lab_context import asset_class_mix_hint
@@ -50,9 +48,8 @@ def _record(asset_class: str) -> StrategyLabRecord:
         asset_class=asset_class,
         hypothesis="h",
         signal_definition="sig",
-        entry_rules=[
-            EntryRule(side="long", when=Predicate(lhs=PriceRef(), op="gt", rhs=ConstRef(value=0)))
-        ],
+        timeframe="1d",
+        entry_rules=[EntryRule(side="long", when=Predicate(lhs="bar.close", op=">", rhs=0))],
         exit_rules=[TimeStopRule(n_bars=5)],
         risk_limits={},
         speculative=False,

--- a/backend/agents/investment_team/tests/test_backtest_endpoint.py
+++ b/backend/agents/investment_team/tests/test_backtest_endpoint.py
@@ -32,7 +32,6 @@ from investment_team.models import (
 from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
     Predicate,
-    PriceRef,
     SignalExitRule,
 )
 
@@ -48,17 +47,14 @@ def _sample_strategy(*, code: str | None) -> StrategySpec:
         asset_class="equity",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
         entry_rules=[
             EntryRule(
                 side="long",
-                when=Predicate(lhs=PriceRef(field="high"), op="gt", rhs=PriceRef(field="low")),
+                when=Predicate(lhs="bar.high", op=">", rhs="bar.low"),
             )
         ],
-        exit_rules=[
-            SignalExitRule(
-                when=Predicate(lhs=PriceRef(field="low"), op="gt", rhs=PriceRef(field="high"))
-            )
-        ],
+        exit_rules=[SignalExitRule(when=Predicate(lhs="bar.low", op=">", rhs="bar.high"))],
         strategy_code=code,
     )
 

--- a/backend/agents/investment_team/tests/test_bar_safety.py
+++ b/backend/agents/investment_team/tests/test_bar_safety.py
@@ -267,6 +267,7 @@ def test_end_to_end_round_trip_strategy_never_triggers_safety() -> None:
         asset_class="stocks",
         hypothesis="invariant",
         signal_definition="invariant",
+        timeframe="1d",
         strategy_code=ROUND_TRIP_CODE,
     )
     config = BacktestConfig(

--- a/backend/agents/investment_team/tests/test_convergence_tracker.py
+++ b/backend/agents/investment_team/tests/test_convergence_tracker.py
@@ -13,10 +13,9 @@ from investment_team.strategy_lab.quality_gates.convergence_tracker import (
 from investment_team.strategy_lab.quality_gates.models import QualityGateResult
 from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
+    IndicatorRef,
     Predicate,
-    PriceRef,
     SignalExitRule,
-    SMARef,
 )
 
 
@@ -27,10 +26,22 @@ def _mk_spec(asset_class: str = "stocks") -> StrategySpec:
         asset_class=asset_class,
         hypothesis="test hypothesis",
         signal_definition="close crosses above SMA(20)",
+        timeframe="1d",
         entry_rules=[
-            EntryRule(side="long", when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=20)))
+            EntryRule(
+                side="long",
+                when=Predicate(
+                    lhs="bar.close", op=">", rhs=IndicatorRef(name="sma", params={"period": 20})
+                ),
+            )
         ],
-        exit_rules=[SignalExitRule(when=Predicate(lhs=PriceRef(), op="lt", rhs=SMARef(period=5)))],
+        exit_rules=[
+            SignalExitRule(
+                when=Predicate(
+                    lhs="bar.close", op="<", rhs=IndicatorRef(name="sma", params={"period": 5})
+                )
+            )
+        ],
     )
 
 
@@ -244,10 +255,13 @@ def _spec_with_entries(entry_rules, asset_class: str = "stocks") -> StrategySpec
         asset_class=asset_class,
         hypothesis="test hypothesis",
         signal_definition="sig",
+        timeframe="1d",
         entry_rules=entry_rules,
         exit_rules=[
             SignalExitRule(
-                when=Predicate(lhs=PriceRef(), op="lt", rhs=SMARef(period=5)),
+                when=Predicate(
+                    lhs="bar.close", op="<", rhs=IndicatorRef(name="sma", params={"period": 5})
+                ),
             ),
         ],
     )
@@ -260,11 +274,15 @@ def test_strategy_signature_invariant_to_entry_list_order():
     inside the helper)."""
     rule_a = EntryRule(
         side="long",
-        when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=20)),
+        when=Predicate(
+            lhs="bar.close", op=">", rhs=IndicatorRef(name="sma", params={"period": 20})
+        ),
     )
     rule_b = EntryRule(
         side="long",
-        when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=50)),
+        when=Predicate(
+            lhs="bar.close", op=">", rhs=IndicatorRef(name="sma", params={"period": 50})
+        ),
     )
 
     sig_ab = ConvergenceTracker._strategy_signature(_spec_with_entries([rule_a, rule_b]))
@@ -281,11 +299,15 @@ def test_strategy_signature_canonicalises_across_distinct_equivalent_rules():
     desynchronise the signature."""
     rule_v1 = EntryRule(
         side="long",
-        when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=20)),
+        when=Predicate(
+            lhs="bar.close", op=">", rhs=IndicatorRef(name="sma", params={"period": 20})
+        ),
     )
     rule_v2 = EntryRule(
         side="long",
-        when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=20)),
+        when=Predicate(
+            lhs="bar.close", op=">", rhs=IndicatorRef(name="sma", params={"period": 20})
+        ),
     )
     assert rule_v1 is not rule_v2
 
@@ -296,17 +318,21 @@ def test_strategy_signature_canonicalises_across_distinct_equivalent_rules():
 
 
 def test_strategy_signature_differs_when_rule_payload_differs():
-    """A meaningful payload change — ``SMARef(period=20)`` vs
-    ``SMARef(period=50)`` — must produce a different entry token. Guards
+    """A meaningful payload change — ``IndicatorRef(name="sma", params={"period": 20})`` vs
+    ``IndicatorRef(name="sma", params={"period": 50})`` — must produce a different entry token. Guards
     against an over-aggressive canonicalisation that collapses distinct
     rules."""
     rule_20 = EntryRule(
         side="long",
-        when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=20)),
+        when=Predicate(
+            lhs="bar.close", op=">", rhs=IndicatorRef(name="sma", params={"period": 20})
+        ),
     )
     rule_50 = EntryRule(
         side="long",
-        when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=50)),
+        when=Predicate(
+            lhs="bar.close", op=">", rhs=IndicatorRef(name="sma", params={"period": 50})
+        ),
     )
 
     sig_20 = ConvergenceTracker._strategy_signature(_spec_with_entries([rule_20]))

--- a/backend/agents/investment_team/tests/test_dataset_fingerprint.py
+++ b/backend/agents/investment_team/tests/test_dataset_fingerprint.py
@@ -24,10 +24,8 @@ from investment_team.market_data_cache import (
 )
 from investment_team.market_data_service import OHLCVBar
 from investment_team.strategy_lab.spec_dsl import (
-    ConstRef,
     EntryRule,
     Predicate,
-    PriceRef,
     TimeStopRule,
 )
 
@@ -118,9 +116,8 @@ def test_backtest_result_fingerprint_stable_across_runs(tmp_path: Path) -> None:
         asset_class="stocks",
         hypothesis="trivial",
         signal_definition="hold-forever",
-        entry_rules=[
-            EntryRule(side="long", when=Predicate(lhs=PriceRef(), op="gt", rhs=ConstRef(value=0)))
-        ],
+        timeframe="1d",
+        entry_rules=[EntryRule(side="long", when=Predicate(lhs="bar.close", op=">", rhs=0))],
         exit_rules=[TimeStopRule(n_bars=10000)],
         strategy_code=textwrap.dedent(
             """

--- a/backend/agents/investment_team/tests/test_execution_metrics.py
+++ b/backend/agents/investment_team/tests/test_execution_metrics.py
@@ -104,6 +104,7 @@ def _spec(asset_class: str) -> StrategySpec:
         asset_class=asset_class,
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
     )
 
 

--- a/backend/agents/investment_team/tests/test_fill_simulator_diagnostics.py
+++ b/backend/agents/investment_team/tests/test_fill_simulator_diagnostics.py
@@ -23,10 +23,9 @@ from investment_team.market_data_service import OHLCVBar
 from investment_team.models import BacktestConfig, StrategySpec
 from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
+    IndicatorRef,
     Predicate,
-    PriceRef,
     SignalExitRule,
-    SMARef,
 )
 from investment_team.trading_service.engine.execution_model import (
     FillTerms,
@@ -498,10 +497,22 @@ def test_round_trip_propagates_entry_and_exit_filled_events() -> None:
         asset_class="equity",
         hypothesis="round-trip",
         signal_definition="sma",
+        timeframe="1d",
         entry_rules=[
-            EntryRule(side="long", when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=5)))
+            EntryRule(
+                side="long",
+                when=Predicate(
+                    lhs="bar.close", op=">", rhs=IndicatorRef(name="sma", params={"period": 5})
+                ),
+            )
         ],
-        exit_rules=[SignalExitRule(when=Predicate(lhs=PriceRef(), op="lt", rhs=SMARef(period=5)))],
+        exit_rules=[
+            SignalExitRule(
+                when=Predicate(
+                    lhs="bar.close", op="<", rhs=IndicatorRef(name="sma", params={"period": 5})
+                )
+            )
+        ],
         strategy_code=_SMA_STRATEGY_CODE,
     )
 
@@ -530,6 +541,7 @@ def test_same_side_addon_propagates_rejection_to_diagnostics() -> None:
         asset_class="equity",
         hypothesis="same-side suppression",
         signal_definition="double-long",
+        timeframe="1d",
         entry_rules=[],
         exit_rules=[],
         strategy_code=_DOUBLE_LONG_STRATEGY_CODE,
@@ -575,6 +587,7 @@ def test_fill_side_rejection_propagates_end_to_end() -> None:
         asset_class="equity",
         hypothesis="fill-side rejection",
         signal_definition="sma",
+        timeframe="1d",
         entry_rules=[],
         exit_rules=[],
         strategy_code=_SMA_STRATEGY_CODE,

--- a/backend/agents/investment_team/tests/test_investment_team.py
+++ b/backend/agents/investment_team/tests/test_investment_team.py
@@ -39,10 +39,8 @@ from investment_team.models import (
 )
 from investment_team.orchestrator import InvestmentTeamOrchestrator, WorkflowState
 from investment_team.strategy_lab.spec_dsl import (
-    ConstRef,
     EntryRule,
     Predicate,
-    PriceRef,
     SignalExitRule,
     TimeStopRule,
 )
@@ -134,6 +132,7 @@ def test_promotion_gate_requires_human_approval_for_live() -> None:
         asset_class="equities",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
     )
     decision = PromotionGateAgent().decide(
         strategy=strategy,
@@ -166,6 +165,7 @@ def test_promotion_gate_revises_when_validation_strategy_mismatch() -> None:
         asset_class="equities",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
     )
     validation = _sample_validation()
     validation.strategy_id = "other"
@@ -383,12 +383,9 @@ def test_backtest_record_captures_strategy_and_metrics() -> None:
         asset_class="equities",
         hypothesis="mean reversion",
         signal_definition="z-score",
-        entry_rules=[
-            EntryRule(side="long", when=Predicate(lhs=PriceRef(), op="lt", rhs=ConstRef(value=-2)))
-        ],
-        exit_rules=[
-            SignalExitRule(when=Predicate(lhs=PriceRef(), op="gt", rhs=ConstRef(value=-0.5)))
-        ],
+        timeframe="1d",
+        entry_rules=[EntryRule(side="long", when=Predicate(lhs="bar.close", op="<", rhs=-2))],
+        exit_rules=[SignalExitRule(when=Predicate(lhs="bar.close", op=">", rhs=-0.5))],
     )
 
     record = BacktestRecord(
@@ -741,6 +738,7 @@ def test_paper_trading_session_model_creation() -> None:
             asset_class="stocks",
             hypothesis="mean reversion",
             signal_definition="RSI oversold bounce",
+            timeframe="1d",
         ),
         status=PaperTradingStatus.COMPLETED,
         initial_capital=100000.0,
@@ -997,6 +995,7 @@ def test_market_data_service_get_symbols_for_strategy() -> None:
         asset_class="stocks",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
     )
     symbols = service.get_symbols_for_strategy(stock_strategy)
     assert "AAPL" in symbols
@@ -1008,6 +1007,7 @@ def test_market_data_service_get_symbols_for_strategy() -> None:
         asset_class="crypto",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
     )
     symbols = service.get_symbols_for_strategy(crypto_strategy)
     assert "BTC" in symbols
@@ -1024,6 +1024,7 @@ def test_market_data_service_get_symbols_for_forex() -> None:
         asset_class="forex",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
     )
     symbols = service.get_symbols_for_strategy(strategy)
     assert any("=X" in s for s in symbols)
@@ -1039,6 +1040,7 @@ def test_market_data_service_get_symbols_for_futures() -> None:
         asset_class="futures",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
     )
     symbols = service.get_symbols_for_strategy(strategy)
     assert any("=F" in s for s in symbols)
@@ -1054,6 +1056,7 @@ def test_market_data_service_get_symbols_for_commodities() -> None:
         asset_class="commodities",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
     )
     symbols = service.get_symbols_for_strategy(strategy)
     assert "GLD" in symbols
@@ -1076,6 +1079,7 @@ def test_market_data_service_get_symbols_for_options_returns_empty() -> None:
         asset_class="options",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
     )
     symbols = service.get_symbols_for_strategy(options_strategy)
     assert symbols == [], (
@@ -1146,6 +1150,7 @@ def test_strategy_spec_target_symbols_normalization() -> None:
         asset_class="stocks",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
         target_symbols=["qqq", " GLD ", "QQQ", "spy"],
     )
     assert spec.target_symbols == ["QQQ", "GLD", "SPY"]
@@ -1157,6 +1162,7 @@ def test_strategy_spec_target_symbols_normalization() -> None:
         asset_class="stocks",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
     )
     assert bare.target_symbols == []
 
@@ -1167,6 +1173,7 @@ def test_strategy_spec_target_symbols_normalization() -> None:
         asset_class="stocks",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
         target_symbols=None,
     )
     assert none_spec.target_symbols == []
@@ -1184,6 +1191,7 @@ def test_strategy_spec_target_symbols_rejects_non_strings() -> None:
             asset_class="stocks",
             hypothesis="h",
             signal_definition="s",
+            timeframe="1d",
             target_symbols=["AAPL", 42],
         )
 
@@ -1194,6 +1202,7 @@ def test_strategy_spec_target_symbols_rejects_non_strings() -> None:
             asset_class="stocks",
             hypothesis="h",
             signal_definition="s",
+            timeframe="1d",
             target_symbols="AAPL",  # type: ignore[arg-type]
         )
 
@@ -1210,6 +1219,7 @@ def test_resolve_strategy_symbols_prefers_target_symbols() -> None:
         asset_class="stocks",
         hypothesis="QQQ trend continuation",
         signal_definition="s",
+        timeframe="1d",
         target_symbols=["QQQ", "GLD"],
     )
     assert service.resolve_strategy_symbols(spec) == ["QQQ", "GLD"]
@@ -1260,6 +1270,7 @@ def test_resolve_strategy_symbols_warns_on_asset_class_mismatch(caplog) -> None:
         asset_class="stocks",
         hypothesis="bitcoin trend follow",
         signal_definition="s",
+        timeframe="1d",
         target_symbols=["BTC"],
     )
     with caplog.at_level(logging.WARNING, logger="agents.investment_team.market_data_service"):
@@ -1289,6 +1300,7 @@ def test_resolve_strategy_symbols_no_warning_on_matching_asset_class(caplog) -> 
         asset_class="crypto",
         hypothesis="BTC trend follow",
         signal_definition="s",
+        timeframe="1d",
         target_symbols=["BTC"],
     )
     qqq_stocks = StrategySpec(
@@ -1297,6 +1309,7 @@ def test_resolve_strategy_symbols_no_warning_on_matching_asset_class(caplog) -> 
         asset_class="stocks",
         hypothesis="QQQ trend continuation",
         signal_definition="s",
+        timeframe="1d",
         target_symbols=["QQQ", "GLD"],
     )
     unknown = StrategySpec(
@@ -1305,6 +1318,7 @@ def test_resolve_strategy_symbols_no_warning_on_matching_asset_class(caplog) -> 
         asset_class="stocks",
         hypothesis="momentum on a fresh ticker",
         signal_definition="s",
+        timeframe="1d",
         target_symbols=["NEWCO"],
     )
     with caplog.at_level(logging.WARNING, logger="agents.investment_team.market_data_service"):
@@ -1328,6 +1342,7 @@ def test_resolve_strategy_symbols_falls_back_to_asset_class_universe() -> None:
         asset_class="stocks",
         hypothesis="generic large-cap momentum",
         signal_definition="s",
+        timeframe="1d",
     )
     # STOCK_SYMBOLS has 10 entries; the default cap is 10 so nothing is dropped.
     assert service.resolve_strategy_symbols(spec) == list(STOCK_SYMBOLS)
@@ -1349,6 +1364,7 @@ def test_resolve_strategy_symbols_respects_max_universe_env_var(monkeypatch, cap
         asset_class="stocks",
         hypothesis="generic large-cap momentum",
         signal_definition="s",
+        timeframe="1d",
     )
     with caplog.at_level(logging.WARNING, logger="agents.investment_team.market_data_service"):
         result = service.resolve_strategy_symbols(spec)
@@ -1376,6 +1392,7 @@ def test_resolve_strategy_symbols_invalid_env_var_falls_back(monkeypatch, caplog
         asset_class="stocks",
         hypothesis="generic large-cap momentum",
         signal_definition="s",
+        timeframe="1d",
     )
     with caplog.at_level(logging.WARNING, logger="agents.investment_team.market_data_service"):
         result = service.resolve_strategy_symbols(spec)
@@ -1401,6 +1418,7 @@ def test_resolve_strategy_symbols_no_warning_when_under_cap(caplog) -> None:
         asset_class="stocks",
         hypothesis="generic large-cap momentum",
         signal_definition="s",
+        timeframe="1d",
     )
     with caplog.at_level(logging.WARNING, logger="agents.investment_team.market_data_service"):
         service.resolve_strategy_symbols(spec)
@@ -1425,6 +1443,7 @@ def test_resolve_strategy_symbols_stable_across_universe_reordering(
         asset_class="stocks",
         hypothesis="generic large-cap momentum",
         signal_definition="s",
+        timeframe="1d",
     )
     baseline = set(service.resolve_strategy_symbols(spec))
 
@@ -1464,6 +1483,7 @@ def test_fetch_market_data_uses_target_symbols_when_set() -> None:
         asset_class="stocks",
         hypothesis="QQQ trend continuation",
         signal_definition="s",
+        timeframe="1d",
         target_symbols=["QQQ"],
     )
     config = BacktestConfig(start_date="2023-01-01", end_date="2023-12-31")
@@ -1503,6 +1523,7 @@ def test_fetch_market_data_falls_back_when_target_symbols_empty() -> None:
         asset_class="stocks",
         hypothesis="generic large-cap momentum",
         signal_definition="s",
+        timeframe="1d",
     )
     config = BacktestConfig(start_date="2023-01-01", end_date="2023-12-31")
 
@@ -1539,6 +1560,7 @@ def test_fetch_market_data_records_dropped_symbols() -> None:
         asset_class="stocks",
         hypothesis="momentum",
         signal_definition="s",
+        timeframe="1d",
         target_symbols=["AAPL", "MSFT"],
     )
     config = BacktestConfig(start_date="2023-01-01", end_date="2023-12-31")
@@ -1573,6 +1595,7 @@ def test_fetch_market_data_records_intent_on_provider_exception() -> None:
         asset_class="stocks",
         hypothesis="momentum",
         signal_definition="s",
+        timeframe="1d",
         target_symbols=["AAPL", "MSFT"],
     )
     config = BacktestConfig(start_date="2023-01-01", end_date="2023-12-31")
@@ -1602,6 +1625,7 @@ def test_backtest_record_persists_symbol_audit_fields() -> None:
         asset_class="stocks",
         hypothesis="momentum",
         signal_definition="s",
+        timeframe="1d",
     )
     record = BacktestRecord(
         backtest_id="bt-rt",
@@ -1792,9 +1816,8 @@ def _make_lab_record(
         asset_class="equities",
         hypothesis="test",
         signal_definition="sig",
-        entry_rules=[
-            EntryRule(side="long", when=Predicate(lhs=PriceRef(), op="gt", rhs=ConstRef(value=1)))
-        ],
+        timeframe="1d",
+        entry_rules=[EntryRule(side="long", when=Predicate(lhs="bar.close", op=">", rhs=1))],
         exit_rules=[TimeStopRule(n_bars=1)],
         risk_limits={},
         speculative=False,

--- a/backend/agents/investment_team/tests/test_liquidity_and_cost_stress.py
+++ b/backend/agents/investment_team/tests/test_liquidity_and_cost_stress.py
@@ -155,6 +155,7 @@ def _spec(code: str, sid: str = "phase4") -> StrategySpec:
         asset_class="stocks",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
         strategy_code=code,
     )
 

--- a/backend/agents/investment_team/tests/test_paper_trade.py
+++ b/backend/agents/investment_team/tests/test_paper_trade.py
@@ -190,6 +190,7 @@ def _strategy(code: str) -> StrategySpec:
         asset_class="crypto",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
         entry_rules=[],
         exit_rules=[],
         strategy_code=code,
@@ -399,6 +400,7 @@ def test_stocks_asset_class_routes_to_equities_provider() -> None:
         asset_class="stocks",  # ← the key: legacy label, not "equities"
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
         entry_rules=[],
         exit_rules=[],
         strategy_code=_ALTERNATING_STRATEGY,
@@ -507,6 +509,7 @@ def test_missing_strategy_code_raises() -> None:
                 asset_class="crypto",
                 hypothesis="h",
                 signal_definition="s",
+                timeframe="1d",
                 strategy_code=None,
             ),
             backtest_config=_btc_config(),

--- a/backend/agents/investment_team/tests/test_paper_trade_api_fixes.py
+++ b/backend/agents/investment_team/tests/test_paper_trade_api_fixes.py
@@ -86,6 +86,7 @@ def _make_session(session_id: str, status: PaperTradingStatus) -> PaperTradingSe
             asset_class="crypto",
             hypothesis="h",
             signal_definition="s",
+            timeframe="1d",
         ),
         status=status,
         initial_capital=100_000.0,

--- a/backend/agents/investment_team/tests/test_risk_limit_enforcement.py
+++ b/backend/agents/investment_team/tests/test_risk_limit_enforcement.py
@@ -53,6 +53,7 @@ def _base_spec(**overrides) -> StrategySpec:
         asset_class="stocks",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
     )
     kwargs.update(overrides)
     return StrategySpec(**kwargs)

--- a/backend/agents/investment_team/tests/test_sandbox_compat.py
+++ b/backend/agents/investment_team/tests/test_sandbox_compat.py
@@ -39,6 +39,7 @@ def _strategy() -> StrategySpec:
         asset_class="equity",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
         entry_rules=[],
         exit_rules=[],
         strategy_code="# unused — run_backtest is patched in tests below\n",

--- a/backend/agents/investment_team/tests/test_spec_dsl.py
+++ b/backend/agents/investment_team/tests/test_spec_dsl.py
@@ -571,6 +571,51 @@ def test_strategy_spec_legacy_sizing_rules_field_migrates():
     assert spec.sizing.fraction == 0.02
 
 
+def test_strategy_spec_mixed_legacy_and_new_shape_rules_both_survive():
+    """Regression: a payload with structural legacy markers in one rule
+    must not drop sibling rules that are already in the new shape."""
+    from investment_team.models import StrategySpec
+
+    payload = {
+        "strategy_id": "mixed",
+        "authored_by": "test",
+        "asset_class": "stocks",
+        "hypothesis": "h",
+        "signal_definition": "s",
+        "entry_rules": [
+            # legacy-shape (triggers _migrate_legacy_payload)
+            {
+                "kind": "entry",
+                "side": "long",
+                "when": {
+                    "lhs": {"kind": "price", "field": "close"},
+                    "op": "gt",
+                    "rhs": {"kind": "sma", "period": 20},
+                },
+            },
+            # already-new-shape — must pass through unchanged
+            {
+                "kind": "entry",
+                "side": "long",
+                "when": {
+                    "lhs": "bar.close",
+                    "op": ">",
+                    "rhs": {"name": "rsi", "params": {"period": 14}},
+                },
+            },
+        ],
+        "exit_rules": [],
+    }
+    spec = StrategySpec.model_validate(payload)
+    assert len(spec.entry_rules) == 2
+    assert spec.unparsed_rules == []
+    assert spec.requires_redesign is False
+    assert isinstance(spec.entry_rules[0].when.rhs, IndicatorRef)
+    assert spec.entry_rules[0].when.rhs.name == "sma"
+    assert isinstance(spec.entry_rules[1].when.rhs, IndicatorRef)
+    assert spec.entry_rules[1].when.rhs.name == "rsi"
+
+
 # ---------------------------------------------------------------------------
 # Issue #537 — `from_prose` top-level adapter.
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/tests/test_spec_dsl.py
+++ b/backend/agents/investment_team/tests/test_spec_dsl.py
@@ -1,4 +1,4 @@
-"""Tests for the spec_dsl module (issue #550, step 1 of 8 from #537)."""
+"""Tests for the spec_dsl module (issue #537 literal schema)."""
 
 from __future__ import annotations
 
@@ -6,54 +6,41 @@ import pytest
 from pydantic import ValidationError
 
 from investment_team.strategy_lab.spec_dsl import (
-    ADXRef,
-    ATRRef,
-    BollingerRef,
-    ConstRef,
-    EMARef,
+    DEFAULT_SIZING_PAYLOAD,
     EntryRule,
     EntryRuleAdapter,
     ExitRuleAdapter,
     FixedFractionSizing,
     FixedNotionalSizing,
+    IndicatorRef,
     IndicatorRefAdapter,
-    MACDRef,
     Predicate,
-    PriceRef,
-    RSIRef,
     SignalExitRule,
     SizingRuleAdapter,
-    SMARef,
-    StochasticRef,
     StopLossRule,
     TakeProfitRule,
     TimeStopRule,
-    UnparsableRule,
-    UnparsableSizing,
     VolatilityTargetSizing,
-    VWAPRef,
     format_rules_for_prompt,
     format_sizing_rule,
+    from_prose,
 )
 
 # ---------------------------------------------------------------------------
-# Round-trip serialisation per union member.
+# Round-trip serialisation per indicator name.
 # ---------------------------------------------------------------------------
 
 
 _INDICATOR_FIXTURES = [
-    PriceRef(field="close"),
-    PriceRef(field="high"),
-    ConstRef(value=30),
-    SMARef(period=20),
-    EMARef(period=50, source="open"),
-    RSIRef(period=14),
-    MACDRef(fast=12, slow=26, signal=9, output="signal"),
-    BollingerRef(period=20, num_std=2.0, band="upper"),
-    ATRRef(period=14),
-    ADXRef(period=14),
-    StochasticRef(k_period=14, d_period=3, output="k"),
-    VWAPRef(),
+    IndicatorRef(name="sma", params={"period": 20}),
+    IndicatorRef(name="ema", params={"period": 50}, source="open"),
+    IndicatorRef(name="rsi", params={"period": 14}),
+    IndicatorRef(name="macd", params={"fast": 12, "slow": 26, "signal": 9, "output": "signal"}),
+    IndicatorRef(name="bollinger", params={"period": 20, "num_std": 2.0, "band": "upper"}),
+    IndicatorRef(name="atr", params={"period": 14}),
+    IndicatorRef(name="adx", params={"period": 14}),
+    IndicatorRef(name="stochastic", params={"k_period": 14, "d_period": 3, "output": "k"}),
+    IndicatorRef(name="vwap"),
 ]
 
 
@@ -67,15 +54,13 @@ def test_indicator_round_trip(model):
 def test_entry_rule_round_trip():
     rule = EntryRule(
         side="long",
-        when=Predicate(lhs=PriceRef(field="close"), op="gt", rhs=SMARef(period=20)),
+        when=Predicate(
+            lhs="bar.close",
+            op=">",
+            rhs=IndicatorRef(name="sma", params={"period": 20}),
+        ),
         note="trend-follow",
     )
-    rebuilt = EntryRuleAdapter.validate_json(rule.model_dump_json())
-    assert rebuilt == rule
-
-
-def test_unparsable_entry_round_trip():
-    rule = UnparsableRule(prose="enter on vibes", reason="no pattern matched")
     rebuilt = EntryRuleAdapter.validate_json(rule.model_dump_json())
     assert rebuilt == rule
 
@@ -87,8 +72,9 @@ def test_unparsable_entry_round_trip():
         StopLossRule(pct=0.03),
         StopLossRule(pct=0.03, basis="trailing_high"),
         TakeProfitRule(pct=0.05),
-        SignalExitRule(when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70))),
-        UnparsableRule(prose="exit on vibes"),
+        SignalExitRule(
+            when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op=">", rhs=70.0)
+        ),
     ],
 )
 def test_exit_rule_round_trip(rule):
@@ -102,7 +88,6 @@ def test_exit_rule_round_trip(rule):
         FixedFractionSizing(fraction=0.02),
         VolatilityTargetSizing(target_annual_vol=0.10),
         FixedNotionalSizing(notional_usd=50000),
-        UnparsableSizing(prose="size based on confidence"),
     ],
 )
 def test_sizing_round_trip(rule):
@@ -111,14 +96,16 @@ def test_sizing_round_trip(rule):
 
 
 # ---------------------------------------------------------------------------
-# Discriminator dispatch — raw dicts route to the right concrete class.
+# Discriminator / type-dispatch — raw dicts route to the right concrete class.
 # ---------------------------------------------------------------------------
 
 
-def test_indicator_discriminator_dispatch():
-    assert isinstance(IndicatorRefAdapter.validate_python({"kind": "rsi"}), RSIRef)
-    assert isinstance(IndicatorRefAdapter.validate_python({"kind": "sma", "period": 20}), SMARef)
-    assert isinstance(IndicatorRefAdapter.validate_python({"kind": "macd"}), MACDRef)
+def test_indicator_dispatch():
+    ref = IndicatorRefAdapter.validate_python({"name": "rsi", "params": {"period": 14}})
+    assert isinstance(ref, IndicatorRef) and ref.name == "rsi"
+
+    ref = IndicatorRefAdapter.validate_python({"name": "sma", "params": {"period": 20}})
+    assert isinstance(ref, IndicatorRef) and ref.name == "sma"
 
 
 def test_entry_discriminator_dispatch():
@@ -126,14 +113,15 @@ def test_entry_discriminator_dispatch():
         "kind": "entry",
         "side": "long",
         "when": {
-            "lhs": {"kind": "price", "field": "close"},
-            "op": "gt",
-            "rhs": {"kind": "sma", "period": 20},
+            "lhs": "bar.close",
+            "op": ">",
+            "rhs": {"name": "sma", "params": {"period": 20}},
         },
     }
     parsed = EntryRuleAdapter.validate_python(payload)
     assert isinstance(parsed, EntryRule)
-    assert isinstance(parsed.when.rhs, SMARef)
+    assert isinstance(parsed.when.rhs, IndicatorRef)
+    assert parsed.when.rhs.name == "sma"
 
 
 def test_exit_discriminator_dispatch():
@@ -145,10 +133,6 @@ def test_exit_discriminator_dispatch():
         ExitRuleAdapter.validate_python({"kind": "stop_loss", "pct": 0.03}),
         StopLossRule,
     )
-    assert isinstance(
-        ExitRuleAdapter.validate_python({"kind": "unparsable", "prose": "..."}),
-        UnparsableRule,
-    )
 
 
 def test_sizing_discriminator_dispatch():
@@ -156,40 +140,52 @@ def test_sizing_discriminator_dispatch():
         SizingRuleAdapter.validate_python({"kind": "fixed_fraction", "fraction": 0.02}),
         FixedFractionSizing,
     )
-    assert isinstance(
-        SizingRuleAdapter.validate_python({"kind": "unparsable_sizing", "prose": "x"}),
-        UnparsableSizing,
-    )
 
 
 # ---------------------------------------------------------------------------
-# Bounds-violation tests.
+# Per-indicator bounds & params — registry-backed `_validate_params`.
 # ---------------------------------------------------------------------------
 
 
 def test_sma_period_lower_bound():
     with pytest.raises(ValidationError):
-        SMARef(period=1)
+        IndicatorRef(name="sma", params={"period": 1})
 
 
 def test_sma_period_upper_bound():
     with pytest.raises(ValidationError):
-        SMARef(period=401)
+        IndicatorRef(name="sma", params={"period": 401})
 
 
 def test_rsi_period_upper_bound():
     with pytest.raises(ValidationError):
-        RSIRef(period=201)
+        IndicatorRef(name="rsi", params={"period": 201})
 
 
 def test_bollinger_num_std_must_be_positive():
     with pytest.raises(ValidationError):
-        BollingerRef(period=20, num_std=-1)
+        IndicatorRef(name="bollinger", params={"period": 20, "num_std": -1})
 
 
 def test_macd_fast_lower_bound():
     with pytest.raises(ValidationError):
-        MACDRef(fast=1)
+        IndicatorRef(name="macd", params={"fast": 1})
+
+
+def test_sma_requires_period():
+    with pytest.raises(ValidationError):
+        IndicatorRef(name="sma", params={})
+
+
+def test_indicator_rejects_unknown_param():
+    with pytest.raises(ValidationError):
+        IndicatorRef(name="rsi", params={"period": 14, "foo": 1})
+
+
+def test_indicator_rejects_source_when_disallowed():
+    # ATR / ADX / Stochastic / VWAP do not accept a `source` override.
+    with pytest.raises(ValidationError):
+        IndicatorRef(name="atr", params={"period": 14}, source="open")
 
 
 def test_stop_loss_negative_pct():
@@ -210,10 +206,35 @@ def test_take_profit_negative_pct():
 def test_predicate_unknown_op():
     with pytest.raises(ValidationError):
         Predicate(
-            lhs=PriceRef(field="close"),
+            lhs="bar.close",
             op="bogus",  # type: ignore[arg-type]
-            rhs=SMARef(period=20),
+            rhs=IndicatorRef(name="sma", params={"period": 20}),
         )
+
+
+def test_predicate_legacy_op_rejected():
+    # Issue #537: ops are symbol literals (">", "<", …) — the legacy
+    # "gt"/"lt" name aliases are no longer accepted on direct construction.
+    with pytest.raises(ValidationError):
+        Predicate(
+            lhs="bar.close",
+            op="gt",  # type: ignore[arg-type]
+            rhs=IndicatorRef(name="sma", params={"period": 20}),
+        )
+
+
+def test_predicate_lhs_unknown_literal_rejected():
+    with pytest.raises(ValidationError):
+        Predicate(
+            lhs="bar.spread",  # type: ignore[arg-type]
+            op=">",
+            rhs=IndicatorRef(name="sma", params={"period": 20}),
+        )
+
+
+def test_predicate_rhs_accepts_float():
+    p = Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op="<", rhs=30.0)
+    assert p.rhs == 30.0
 
 
 def test_time_stop_must_be_positive():
@@ -228,12 +249,7 @@ def test_fixed_fraction_upper_bound():
 
 def test_extra_field_is_forbidden():
     with pytest.raises(ValidationError):
-        RSIRef.model_validate({"kind": "rsi", "period": 14, "foo": 1})
-
-
-def test_missing_required_const_value():
-    with pytest.raises(ValidationError):
-        ConstRef.model_validate({"kind": "const"})
+        IndicatorRef.model_validate({"name": "rsi", "params": {"period": 14}, "foo": 1})
 
 
 # ---------------------------------------------------------------------------
@@ -244,7 +260,9 @@ def test_missing_required_const_value():
 def test_format_entry_close_gt_sma():
     rule = EntryRule(
         side="long",
-        when=Predicate(lhs=PriceRef(field="close"), op="gt", rhs=SMARef(period=20)),
+        when=Predicate(
+            lhs="bar.close", op=">", rhs=IndicatorRef(name="sma", params={"period": 20})
+        ),
     )
     assert format_rules_for_prompt([rule]) == "long when close > sma(20)"
 
@@ -252,7 +270,7 @@ def test_format_entry_close_gt_sma():
 def test_format_entry_rsi_lt_30():
     rule = EntryRule(
         side="long",
-        when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30)),
+        when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op="<", rhs=30.0),
     )
     assert format_rules_for_prompt([rule]) == "long when rsi(14) < 30"
 
@@ -278,7 +296,9 @@ def test_format_stop_loss_trailing_low():
 def test_format_indicator_source_default_omitted():
     rule = EntryRule(
         side="long",
-        when=Predicate(lhs=EMARef(period=50), op="gt", rhs=PriceRef(field="close")),
+        when=Predicate(
+            lhs=IndicatorRef(name="ema", params={"period": 50}), op=">", rhs="bar.close"
+        ),
     )
     assert format_rules_for_prompt([rule]) == "long when ema(50) > close"
 
@@ -287,9 +307,9 @@ def test_format_indicator_source_non_default_emitted():
     rule = EntryRule(
         side="long",
         when=Predicate(
-            lhs=EMARef(period=50, source="open"),
-            op="gt",
-            rhs=PriceRef(field="close"),
+            lhs=IndicatorRef(name="ema", params={"period": 50}, source="open"),
+            op=">",
+            rhs="bar.close",
         ),
     )
     assert format_rules_for_prompt([rule]) == "long when ema(50, source=open) > close"
@@ -300,12 +320,10 @@ def test_format_take_profit():
 
 
 def test_format_signal_exit_rsi_gt_70():
-    rule = SignalExitRule(when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)))
+    rule = SignalExitRule(
+        when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op=">", rhs=70.0)
+    )
     assert format_rules_for_prompt([rule]) == "exit when rsi(14) > 70"
-
-
-def test_format_unparsable_returns_prose():
-    assert format_rules_for_prompt([UnparsableRule(prose="enter on vibes")]) == "enter on vibes"
 
 
 def test_format_sizing_fixed_fraction():
@@ -318,13 +336,6 @@ def test_format_sizing_volatility_target():
 
 def test_format_sizing_fixed_notional():
     assert format_sizing_rule(FixedNotionalSizing(notional_usd=50000)) == "$50000 per trade"
-
-
-def test_format_sizing_unparsable_returns_prose():
-    assert (
-        format_sizing_rule(UnparsableSizing(prose="size up on confidence"))
-        == "size up on confidence"
-    )
 
 
 def test_format_rules_for_prompt_join_separator():
@@ -341,7 +352,7 @@ def test_format_rules_for_prompt_empty():
 
 
 # ---------------------------------------------------------------------------
-# Issue #551 — StrategySpec wires the DSL types directly. No coercion.
+# Issue #537 — `StrategySpec` wires the DSL types and requires `timeframe`.
 # ---------------------------------------------------------------------------
 
 
@@ -354,10 +365,13 @@ def _make_structured_strategy_spec():
         asset_class="stocks",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
         entry_rules=[
             EntryRule(
                 side="long",
-                when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=20)),
+                when=Predicate(
+                    lhs="bar.close", op=">", rhs=IndicatorRef(name="sma", params={"period": 20})
+                ),
             ),
         ],
         exit_rules=[TimeStopRule(n_bars=10)],
@@ -381,6 +395,7 @@ def test_strategy_spec_default_sizing_is_fixed_fraction_two_pct():
         asset_class="stocks",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
     )
     assert isinstance(spec.sizing, FixedFractionSizing)
     assert spec.sizing.fraction == 0.02
@@ -396,6 +411,7 @@ def test_strategy_spec_rejects_prose_entry_rules():
             asset_class="stocks",
             hypothesis="h",
             signal_definition="s",
+            timeframe="1d",
             entry_rules=["close > sma(20)"],
         )
 
@@ -410,6 +426,7 @@ def test_strategy_spec_rejects_prose_exit_rules():
             asset_class="stocks",
             hypothesis="h",
             signal_definition="s",
+            timeframe="1d",
             exit_rules=["exit after 10 bars"],
         )
 
@@ -424,15 +441,174 @@ def test_strategy_spec_rejects_prose_sizing():
             asset_class="stocks",
             hypothesis="h",
             signal_definition="s",
+            timeframe="1d",
             sizing="risk 2% per trade",
         )
 
 
 def test_strategy_spec_has_no_sizing_rules_field():
-    """`sizing_rules` was replaced by the singular `sizing` field; extra=forbid
-    is not set on StrategySpec, but the field name change is part of the API
-    surface and must be observable."""
     from investment_team.models import StrategySpec
 
     assert "sizing_rules" not in StrategySpec.model_fields
     assert "sizing" in StrategySpec.model_fields
+
+
+# ---------------------------------------------------------------------------
+# Issue #537 — timeframe required, legacy payload migration.
+# ---------------------------------------------------------------------------
+
+
+def test_strategy_spec_timeframe_required_when_no_legacy_markers():
+    from investment_team.models import StrategySpec
+
+    with pytest.raises(ValidationError) as exc_info:
+        StrategySpec(
+            strategy_id="t",
+            authored_by="t",
+            asset_class="stocks",
+            hypothesis="h",
+            signal_definition="s",
+            # no timeframe; no legacy markers either
+        )
+    errors = exc_info.value.errors()
+    assert any(e["loc"] == ("timeframe",) for e in errors)
+
+
+@pytest.mark.parametrize("tf", ["1m", "5m", "15m", "1h", "1d"])
+def test_strategy_spec_accepts_each_timeframe_literal(tf):
+    from investment_team.models import StrategySpec
+
+    spec = StrategySpec(
+        strategy_id="t",
+        authored_by="t",
+        asset_class="stocks",
+        hypothesis="h",
+        signal_definition="s",
+        timeframe=tf,
+    )
+    assert spec.timeframe == tf
+
+
+def test_strategy_spec_rejects_unknown_timeframe():
+    from investment_team.models import StrategySpec
+
+    with pytest.raises(ValidationError):
+        StrategySpec(
+            strategy_id="t",
+            authored_by="t",
+            asset_class="stocks",
+            hypothesis="h",
+            signal_definition="s",
+            timeframe="7d",  # type: ignore[arg-type]
+        )
+
+
+def test_strategy_spec_legacy_payload_migrates_in_place():
+    """Legacy persisted shape — typed IndicatorRef + 'gt' op + no timeframe — rewrites in-flight."""
+    from investment_team.models import StrategySpec
+
+    legacy = {
+        "strategy_id": "legacy-1",
+        "authored_by": "test",
+        "asset_class": "stocks",
+        "hypothesis": "h",
+        "signal_definition": "s",
+        "entry_rules": [
+            {
+                "kind": "entry",
+                "side": "long",
+                "when": {
+                    "lhs": {"kind": "price", "field": "close"},
+                    "op": "gt",
+                    "rhs": {"kind": "sma", "period": 20},
+                },
+            }
+        ],
+        "exit_rules": [{"kind": "time_stop", "n_bars": 10}],
+        "sizing": {"kind": "fixed_fraction", "fraction": 0.02},
+    }
+    spec = StrategySpec.model_validate(legacy)
+    assert spec.timeframe == "1d"
+    assert spec.entry_rules[0].when.lhs == "bar.close"
+    assert spec.entry_rules[0].when.op == ">"
+    assert isinstance(spec.entry_rules[0].when.rhs, IndicatorRef)
+    assert spec.entry_rules[0].when.rhs.name == "sma"
+
+
+def test_strategy_spec_legacy_unparsable_rule_routed_to_unparsed():
+    from investment_team.models import StrategySpec
+
+    legacy = {
+        "strategy_id": "legacy-unparseable",
+        "authored_by": "test",
+        "asset_class": "stocks",
+        "hypothesis": "h",
+        "signal_definition": "s",
+        "entry_rules": [{"kind": "unparsable", "prose": "enter on vibes"}],
+        "exit_rules": [],
+    }
+    spec = StrategySpec.model_validate(legacy)
+    assert spec.entry_rules == []
+    assert spec.requires_redesign is True
+    assert "enter on vibes" in spec.unparsed_rules
+
+
+def test_strategy_spec_legacy_sizing_rules_field_migrates():
+    from investment_team.models import StrategySpec
+
+    legacy = {
+        "strategy_id": "legacy-sizing",
+        "authored_by": "test",
+        "asset_class": "stocks",
+        "hypothesis": "h",
+        "signal_definition": "s",
+        "entry_rules": [],
+        "exit_rules": [],
+        "sizing_rules": ["risk 2% per trade"],
+    }
+    spec = StrategySpec.model_validate(legacy)
+    assert isinstance(spec.sizing, FixedFractionSizing)
+    assert spec.sizing.fraction == 0.02
+
+
+# ---------------------------------------------------------------------------
+# Issue #537 — `from_prose` top-level adapter.
+# ---------------------------------------------------------------------------
+
+
+def test_from_prose_parses_clean_legacy_spec():
+    legacy = {
+        "strategy_id": "prose-1",
+        "authored_by": "test",
+        "asset_class": "stocks",
+        "hypothesis": "h",
+        "signal_definition": "s",
+        "entry_rules": ["close > sma(20)"],
+        "exit_rules": ["exit after 10 bars"],
+        "sizing_rules": ["risk 2% per trade"],
+    }
+    spec = from_prose(legacy)
+    assert spec.timeframe == "1d"
+    assert spec.requires_redesign is False
+    assert spec.unparsed_rules == []
+    assert spec.entry_rules[0].when.lhs == "bar.close"
+
+
+def test_from_prose_flags_requires_redesign_on_unparseable():
+    legacy = {
+        "strategy_id": "prose-bad",
+        "authored_by": "test",
+        "asset_class": "stocks",
+        "hypothesis": "h",
+        "signal_definition": "s",
+        "entry_rules": ["enter on vibes", "close > sma(20)"],
+        "exit_rules": [],
+    }
+    spec = from_prose(legacy)
+    assert spec.requires_redesign is True
+    assert "enter on vibes" in spec.unparsed_rules
+    assert len(spec.entry_rules) == 1  # only the parseable one
+
+
+def test_default_sizing_payload_is_two_pct():
+    assert DEFAULT_SIZING_PAYLOAD == {"kind": "fixed_fraction", "fraction": 0.02}

--- a/backend/agents/investment_team/tests/test_spec_dsl_adapter.py
+++ b/backend/agents/investment_team/tests/test_spec_dsl_adapter.py
@@ -1,25 +1,19 @@
-"""Tests for the spec_dsl_adapter module (issue #550, step 1 of 8 from #537)."""
+"""Tests for the spec_dsl_adapter module (issue #537 literal schema)."""
 
 from __future__ import annotations
 
 import pytest
 
 from investment_team.strategy_lab.spec_dsl import (
-    ConstRef,
-    EMARef,
     EntryRule,
     FixedFractionSizing,
     FixedNotionalSizing,
+    IndicatorRef,
     Predicate,
-    PriceRef,
-    RSIRef,
     SignalExitRule,
-    SMARef,
     StopLossRule,
     TakeProfitRule,
     TimeStopRule,
-    UnparsableRule,
-    UnparsableSizing,
     VolatilityTargetSizing,
     format_rules_for_prompt,
     format_sizing_rule,
@@ -32,6 +26,19 @@ from investment_team.strategy_lab.spec_dsl_adapter import (
     parse_sizing_rule,
 )
 
+
+def _sma(period: int) -> IndicatorRef:
+    return IndicatorRef(name="sma", params={"period": period})
+
+
+def _ema(period: int, source: str = "close") -> IndicatorRef:
+    return IndicatorRef(name="ema", params={"period": period}, source=source)
+
+
+def _rsi(period: int = 14) -> IndicatorRef:
+    return IndicatorRef(name="rsi", params={"period": period})
+
+
 # ---------------------------------------------------------------------------
 # Entry-rule patterns.
 # ---------------------------------------------------------------------------
@@ -41,35 +48,33 @@ def test_entry_close_gt_sma():
     parsed = parse_entry_rule("close > sma(20)")
     assert isinstance(parsed, EntryRule)
     assert parsed.side == "long"
-    assert parsed.when == Predicate(lhs=PriceRef(field="close"), op="gt", rhs=SMARef(period=20))
+    assert parsed.when == Predicate(lhs="bar.close", op=">", rhs=_sma(20))
 
 
 def test_entry_rsi_lt_30():
     parsed = parse_entry_rule("RSI < 30")
     assert isinstance(parsed, EntryRule)
-    assert parsed.when == Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30))
+    assert parsed.when == Predicate(lhs=_rsi(), op="<", rhs=30.0)
 
 
 def test_entry_short_when_rsi_gt_70():
     parsed = parse_entry_rule("short when rsi(14) > 70")
     assert isinstance(parsed, EntryRule)
     assert parsed.side == "short"
-    assert parsed.when == Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70))
+    assert parsed.when == Predicate(lhs=_rsi(14), op=">", rhs=70.0)
 
 
 def test_entry_crosses_above():
     parsed = parse_entry_rule("sma(20) crosses above sma(50)")
     assert isinstance(parsed, EntryRule)
     assert parsed.when.op == "cross_above"
-    assert parsed.when.lhs == SMARef(period=20)
-    assert parsed.when.rhs == SMARef(period=50)
+    assert parsed.when.lhs == _sma(20)
+    assert parsed.when.rhs == _sma(50)
 
 
-def test_entry_unparsable():
+def test_entry_unparsable_returns_none():
     parsed = parse_entry_rule("enter on bullish momentum")
-    assert isinstance(parsed, UnparsableRule)
-    assert parsed.prose == "enter on bullish momentum"
-    assert parsed.reason == "no pattern matched"
+    assert parsed is None
 
 
 # ---------------------------------------------------------------------------
@@ -80,7 +85,7 @@ def test_entry_unparsable():
 def test_exit_when_rsi_gt_70():
     parsed = parse_exit_rule("exit when RSI > 70")
     assert isinstance(parsed, SignalExitRule)
-    assert parsed.when == Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70))
+    assert parsed.when == Predicate(lhs=_rsi(14), op=">", rhs=70.0)
 
 
 @pytest.mark.parametrize(
@@ -125,10 +130,9 @@ def test_exit_take_profit(prose, expected_pct):
     assert parsed.pct == pytest.approx(expected_pct)
 
 
-def test_exit_unparsable():
+def test_exit_unparsable_returns_none():
     parsed = parse_exit_rule("vibes")
-    assert isinstance(parsed, UnparsableRule)
-    assert parsed.prose == "vibes"
+    assert parsed is None
 
 
 # ---------------------------------------------------------------------------
@@ -178,10 +182,9 @@ def test_sizing_fixed_notional(prose, expected_usd):
     assert parsed.notional_usd == pytest.approx(expected_usd)
 
 
-def test_sizing_unparsable():
+def test_sizing_unparsable_returns_none():
     parsed = parse_sizing_rule("size up if confident")
-    assert isinstance(parsed, UnparsableSizing)
-    assert parsed.prose == "size up if confident"
+    assert parsed is None
 
 
 # ---------------------------------------------------------------------------
@@ -193,7 +196,7 @@ def test_parse_rule_list_entry():
     parsed = parse_rule_list(["close > sma(20)", "vibes"], kind="entry")
     assert len(parsed) == 2
     assert isinstance(parsed[0], EntryRule)
-    assert isinstance(parsed[1], UnparsableRule)
+    assert parsed[1] is None
 
 
 def test_parse_rule_list_exit():
@@ -202,11 +205,8 @@ def test_parse_rule_list_exit():
     assert isinstance(parsed[1], TimeStopRule)
 
 
-def test_sizing_list_empty():
-    parsed = parse_sizing_list([])
-    assert isinstance(parsed, UnparsableSizing)
-    assert parsed.prose == ""
-    assert parsed.reason == "empty"
+def test_sizing_list_empty_returns_none():
+    assert parse_sizing_list([]) is None
 
 
 def test_sizing_list_single():
@@ -231,10 +231,8 @@ def test_sizing_list_collapse_skips_unparsable_then_chooses():
     assert "max 5% gross" in parsed.note
 
 
-def test_sizing_list_all_unparsable():
-    parsed = parse_sizing_list(["foo", "bar"])
-    assert isinstance(parsed, UnparsableSizing)
-    assert parsed.prose == "foo; bar"
+def test_sizing_list_all_unparsable_returns_none():
+    assert parse_sizing_list(["foo", "bar"]) is None
 
 
 # ---------------------------------------------------------------------------
@@ -245,14 +243,8 @@ def test_sizing_list_all_unparsable():
 @pytest.mark.parametrize(
     "rule",
     [
-        EntryRule(
-            side="long",
-            when=Predicate(lhs=PriceRef(field="close"), op="gt", rhs=SMARef(period=20)),
-        ),
-        EntryRule(
-            side="short",
-            when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)),
-        ),
+        EntryRule(side="long", when=Predicate(lhs="bar.close", op=">", rhs=_sma(20))),
+        EntryRule(side="short", when=Predicate(lhs=_rsi(14), op=">", rhs=70.0)),
     ],
 )
 def test_entry_formatter_round_trip(rule):
@@ -271,13 +263,12 @@ def test_entry_formatter_round_trip(rule):
         StopLossRule(pct=0.03, basis="trailing_high"),
         StopLossRule(pct=0.03, basis="trailing_low"),
         TakeProfitRule(pct=0.05),
-        SignalExitRule(when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70))),
+        SignalExitRule(when=Predicate(lhs=_rsi(14), op=">", rhs=70.0)),
     ],
 )
 def test_exit_formatter_round_trip(rule):
     rendered = format_rules_for_prompt([rule])
     reparsed = parse_exit_rule(rendered)
-    # Compare on the model_dump to avoid `note` default-flag noise.
     assert type(reparsed) is type(rule)
     assert reparsed.model_dump(exclude={"note"}) == rule.model_dump(exclude={"note"})
 
@@ -298,7 +289,7 @@ def test_sizing_formatter_round_trip(rule):
 
 
 # ---------------------------------------------------------------------------
-# Regression tests for the four bugs raised on PR #558.
+# Regression tests carried forward from PR #558.
 # ---------------------------------------------------------------------------
 
 
@@ -307,29 +298,25 @@ def test_entry_enter_when_legacy_phrasing():
     parsed = parse_entry_rule("enter when RSI < 30")
     assert isinstance(parsed, EntryRule)
     assert parsed.side == "long"
-    assert parsed.when == Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30))
+    assert parsed.when == Predicate(lhs=_rsi(14), op="<", rhs=30.0)
 
 
 def test_indicator_source_preserved_in_round_trip():
     rule = EntryRule(
         side="long",
-        when=Predicate(
-            lhs=EMARef(period=50, source="open"),
-            op="gt",
-            rhs=PriceRef(field="close"),
-        ),
+        when=Predicate(lhs=_ema(50, source="open"), op=">", rhs="bar.close"),
     )
     rendered = format_rules_for_prompt([rule])
     assert "source=open" in rendered
     reparsed = parse_entry_rule(rendered)
     assert isinstance(reparsed, EntryRule)
-    assert reparsed.when.lhs == EMARef(period=50, source="open")
+    assert reparsed.when.lhs == _ema(50, source="open")
 
 
 def test_indicator_source_kwarg_parses():
     parsed = parse_entry_rule("ema(50, source=open) > close")
     assert isinstance(parsed, EntryRule)
-    assert parsed.when.lhs == EMARef(period=50, source="open")
+    assert parsed.when.lhs == _ema(50, source="open")
 
 
 def test_trailing_stop_loss_round_trip_high():
@@ -352,62 +339,55 @@ def test_trailing_stop_loss_round_trip_low():
 
 
 def test_indicator_extra_positional_args_rejected():
-    """`sma(20,50) > close` had silently dropped the 50; now → UnparsableRule."""
-    parsed = parse_entry_rule("sma(20,50) > close")
-    assert isinstance(parsed, UnparsableRule)
+    """`sma(20,50) > close` had silently dropped the 50; now → None."""
+    assert parse_entry_rule("sma(20,50) > close") is None
 
 
 def test_macd_extra_positional_args_rejected():
-    parsed = parse_entry_rule("macd(12,26,9,99) > 0")
-    assert isinstance(parsed, UnparsableRule)
+    assert parse_entry_rule("macd(12,26,9,99) > 0") is None
 
 
 def test_indicator_unknown_kwarg_rejected():
-    parsed = parse_entry_rule("sma(20, foo=bar) > close")
-    assert isinstance(parsed, UnparsableRule)
+    assert parse_entry_rule("sma(20, foo=bar) > close") is None
 
 
 def test_atr_source_kwarg_rejected():
     """ATR has no `source` field; specifying one must reject."""
-    parsed = parse_exit_rule("exit when atr(14, source=open) > 0")
-    assert isinstance(parsed, UnparsableRule)
+    assert parse_exit_rule("exit when atr(14, source=open) > 0") is None
 
 
 # ---------------------------------------------------------------------------
-# Bare default-argument indicators in predicates (#558 second pass).
+# Bare default-argument indicators in predicates.
 # ---------------------------------------------------------------------------
 
 
 def test_predicate_bare_adx():
-    from investment_team.strategy_lab.spec_dsl import ADXRef
-
     parsed = parse_entry_rule("ADX > 25")
     assert isinstance(parsed, EntryRule)
-    assert parsed.when.lhs == ADXRef(period=14)
-    assert parsed.when.rhs == ConstRef(value=25)
+    assert parsed.when.lhs == IndicatorRef(name="adx", params={"period": 14})
+    assert parsed.when.rhs == 25.0
 
 
 def test_predicate_bare_macd():
-    from investment_team.strategy_lab.spec_dsl import MACDRef
-
     parsed = parse_entry_rule("macd > 0")
     assert isinstance(parsed, EntryRule)
-    assert parsed.when.lhs == MACDRef()
-    assert parsed.when.rhs == ConstRef(value=0)
+    assert parsed.when.lhs == IndicatorRef(
+        name="macd", params={"fast": 12, "slow": 26, "signal": 9, "output": "macd"}
+    )
+    assert parsed.when.rhs == 0.0
 
 
 def test_predicate_bare_stochastic_k():
-    from investment_team.strategy_lab.spec_dsl import StochasticRef
-
     parsed = parse_entry_rule("stochastic_k < 20")
     assert isinstance(parsed, EntryRule)
-    assert parsed.when.lhs == StochasticRef()
+    assert parsed.when.lhs == IndicatorRef(
+        name="stochastic", params={"k_period": 14, "d_period": 3, "output": "k"}
+    )
 
 
 def test_predicate_bare_sma_stays_unparsable():
     """SMA/EMA still need an explicit period — bare `sma > x` should fail."""
-    parsed = parse_entry_rule("sma > close")
-    assert isinstance(parsed, UnparsableRule)
+    assert parse_entry_rule("sma > close") is None
 
 
 # ---------------------------------------------------------------------------
@@ -419,14 +399,14 @@ def test_entry_enter_short_when():
     parsed = parse_entry_rule("enter short when rsi > 70")
     assert isinstance(parsed, EntryRule)
     assert parsed.side == "short"
-    assert parsed.when == Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70))
+    assert parsed.when == Predicate(lhs=_rsi(14), op=">", rhs=70.0)
 
 
 def test_entry_enter_long_when():
     parsed = parse_entry_rule("enter long when close > sma(20)")
     assert isinstance(parsed, EntryRule)
     assert parsed.side == "long"
-    assert parsed.when == Predicate(lhs=PriceRef(field="close"), op="gt", rhs=SMARef(period=20))
+    assert parsed.when == Predicate(lhs="bar.close", op=">", rhs=_sma(20))
 
 
 # ---------------------------------------------------------------------------
@@ -435,19 +415,19 @@ def test_entry_enter_long_when():
 
 
 def test_hyphenated_indicator_alias_call():
-    from investment_team.strategy_lab.spec_dsl import MACDRef
-
     parsed = parse_entry_rule("macd-signal(12,26,9) > 0")
     assert isinstance(parsed, EntryRule)
-    assert parsed.when.lhs == MACDRef(fast=12, slow=26, signal=9, output="signal")
+    assert parsed.when.lhs == IndicatorRef(
+        name="macd", params={"fast": 12, "slow": 26, "signal": 9, "output": "signal"}
+    )
 
 
 def test_hyphenated_indicator_alias_bare():
-    from investment_team.strategy_lab.spec_dsl import StochasticRef
-
     parsed = parse_entry_rule("stochastic-k < 20")
     assert isinstance(parsed, EntryRule)
-    assert parsed.when.lhs == StochasticRef()
+    assert parsed.when.lhs == IndicatorRef(
+        name="stochastic", params={"k_period": 14, "d_period": 3, "output": "k"}
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -458,7 +438,7 @@ def test_hyphenated_indicator_alias_bare():
 def test_source_kwarg_case_insensitive():
     parsed = parse_entry_rule("EMA(50, SOURCE=OPEN) > CLOSE")
     assert isinstance(parsed, EntryRule)
-    assert parsed.when.lhs == EMARef(period=50, source="open")
+    assert parsed.when.lhs == _ema(50, source="open")
 
 
 # ---------------------------------------------------------------------------
@@ -467,28 +447,19 @@ def test_source_kwarg_case_insensitive():
 
 
 def test_macd_default_output_round_trip():
-    from investment_team.strategy_lab.spec_dsl import MACDRef
-
-    rule = EntryRule(
-        side="long",
-        when=Predicate(lhs=MACDRef(), op="gt", rhs=ConstRef(value=0)),
-    )
+    macd = IndicatorRef(name="macd", params={"fast": 12, "slow": 26, "signal": 9, "output": "macd"})
+    rule = EntryRule(side="long", when=Predicate(lhs=macd, op=">", rhs=0.0))
     rendered = format_rules_for_prompt([rule])
     # The default output ("macd") must format as bare `macd(...)`, not
     # `macd_macd(...)`, otherwise the adapter can't reparse it.
     assert "macd_macd" not in rendered
     reparsed = parse_entry_rule(rendered)
     assert isinstance(reparsed, EntryRule)
-    assert reparsed.when.lhs == MACDRef()
+    assert reparsed.when.lhs == macd
 
 
 # ---------------------------------------------------------------------------
-# Formatter ↔ adapter round-trip for small decimals.
-# ---------------------------------------------------------------------------
-
-
-# ---------------------------------------------------------------------------
-# Empty positional slots (#558 third pass).
+# Empty positional slots.
 # ---------------------------------------------------------------------------
 
 
@@ -498,8 +469,7 @@ def test_macd_default_output_round_trip():
 )
 def test_indicator_empty_positional_slot_rejected(prose):
     """`sma(,20)` etc. used to silently drop the empty slot and shift values."""
-    parsed = parse_entry_rule(prose)
-    assert isinstance(parsed, UnparsableRule)
+    assert parse_entry_rule(prose) is None
 
 
 # ---------------------------------------------------------------------------
@@ -527,33 +497,12 @@ def test_singular_cross_below():
 def test_predicate_leading_dot_number():
     parsed = parse_entry_rule("rsi < .5")
     assert isinstance(parsed, EntryRule)
-    assert parsed.when.rhs == ConstRef(value=0.5)
+    assert parsed.when.rhs == 0.5
 
 
 # ---------------------------------------------------------------------------
-# Non-finite ConstRef values are rejected at construction time.
+# Formatter ↔ adapter round-trip across the full float range.
 # ---------------------------------------------------------------------------
-
-
-def test_const_ref_rejects_nan():
-    from pydantic import ValidationError as _VE
-
-    with pytest.raises(_VE):
-        ConstRef(value=float("nan"))
-
-
-def test_const_ref_rejects_inf():
-    from pydantic import ValidationError as _VE
-
-    with pytest.raises(_VE):
-        ConstRef(value=float("inf"))
-
-
-def test_const_ref_rejects_neg_inf():
-    from pydantic import ValidationError as _VE
-
-    with pytest.raises(_VE):
-        ConstRef(value=float("-inf"))
 
 
 @pytest.mark.parametrize(
@@ -561,42 +510,26 @@ def test_const_ref_rejects_neg_inf():
     [1e-13, 1e-06, 0.0001, 0.5, 100.5, 1e20],
 )
 def test_small_decimal_round_trip(value):
-    """Formatter/adapter must round-trip across the full float range, including
-    values for which `repr` emits scientific notation."""
     rule = EntryRule(
         side="long",
-        when=Predicate(lhs=PriceRef(field="close"), op="gt", rhs=ConstRef(value=value)),
+        when=Predicate(lhs="bar.close", op=">", rhs=float(value)),
     )
     rendered = format_rules_for_prompt([rule])
     reparsed = parse_entry_rule(rendered)
     assert isinstance(reparsed, EntryRule)
-    assert reparsed.when.rhs.value == pytest.approx(value)
-
-
-# ---------------------------------------------------------------------------
-# Tiny non-zero values must NOT collapse to 0 (#558 fourth pass).
-# ---------------------------------------------------------------------------
+    assert reparsed.when.rhs == pytest.approx(value)
 
 
 @pytest.mark.parametrize("value", [5e-10, 1e-12, 1e-15])
 def test_tiny_const_not_collapsed_to_zero(value):
     rendered = format_rules_for_prompt(
-        [
-            EntryRule(
-                side="long",
-                when=Predicate(
-                    lhs=PriceRef(field="close"),
-                    op="gt",
-                    rhs=ConstRef(value=value),
-                ),
-            )
-        ]
+        [EntryRule(side="long", when=Predicate(lhs="bar.close", op=">", rhs=float(value)))]
     )
     # Must not collapse to the bare `0` integer.
     assert not rendered.endswith("> 0")
     reparsed = parse_entry_rule(rendered)
     assert isinstance(reparsed, EntryRule)
-    assert reparsed.when.rhs.value == pytest.approx(value)
+    assert reparsed.when.rhs == pytest.approx(value)
 
 
 def test_tiny_fixed_fraction_round_trip():
@@ -619,7 +552,7 @@ def test_tiny_vol_target_round_trip():
 
 
 # ---------------------------------------------------------------------------
-# Every float-bearing DSL node rejects non-finite values (#558 fourth pass).
+# Every float-bearing DSL node rejects non-finite values.
 # ---------------------------------------------------------------------------
 
 
@@ -644,7 +577,5 @@ def test_dsl_nodes_reject_non_finite_floats(factory, bad):
 def test_bollinger_num_std_rejects_non_finite():
     from pydantic import ValidationError as _VE
 
-    from investment_team.strategy_lab.spec_dsl import BollingerRef
-
     with pytest.raises(_VE):
-        BollingerRef(num_std=float("inf"))
+        IndicatorRef(name="bollinger", params={"num_std": float("inf")})

--- a/backend/agents/investment_team/tests/test_strategy_lab_alignment.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_alignment.py
@@ -33,10 +33,9 @@ from investment_team.strategy_lab.orchestrator import (
 )
 from investment_team.strategy_lab.quality_gates.models import QualityGateResult
 from investment_team.strategy_lab.spec_dsl import (
-    ConstRef,
     EntryRule,
+    IndicatorRef,
     Predicate,
-    RSIRef,
     SignalExitRule,
 )
 from investment_team.trading_service.modes.sandbox_compat import StrategyRunResult
@@ -150,13 +149,17 @@ def _spec() -> StrategySpec:
         asset_class="stocks",
         hypothesis="hyp",
         signal_definition="sig",
+        timeframe="1d",
         entry_rules=[
             EntryRule(
-                side="long", when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30))
+                side="long",
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op="<", rhs=30),
             )
         ],
         exit_rules=[
-            SignalExitRule(when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)))
+            SignalExitRule(
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op=">", rhs=70)
+            )
         ],
         risk_limits={"max_position_pct": 5},
         speculative=False,

--- a/backend/agents/investment_team/tests/test_strategy_lab_batches.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_batches.py
@@ -30,10 +30,8 @@ from investment_team.models import (  # noqa: E402
     StrategySpec,
 )
 from investment_team.strategy_lab.spec_dsl import (
-    ConstRef,
     EntryRule,
     Predicate,
-    PriceRef,
     TimeStopRule,
 )
 
@@ -64,9 +62,8 @@ def _make_record(idx: int, config: BacktestConfig) -> StrategyLabRecord:
         asset_class="stocks",
         hypothesis=f"hypothesis #{idx}",
         signal_definition="sig",
-        entry_rules=[
-            EntryRule(side="long", when=Predicate(lhs=PriceRef(), op="gt", rhs=ConstRef(value=0)))
-        ],
+        timeframe="1d",
+        entry_rules=[EntryRule(side="long", when=Predicate(lhs="bar.close", op=">", rhs=0))],
         exit_rules=[TimeStopRule(n_bars=5)],
         risk_limits={},
         speculative=False,

--- a/backend/agents/investment_team/tests/test_strategy_lab_max_rounds_exhaustion.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_max_rounds_exhaustion.py
@@ -23,10 +23,9 @@ from investment_team.strategy_lab.orchestrator import (
 )
 from investment_team.strategy_lab.quality_gates.models import QualityGateResult
 from investment_team.strategy_lab.spec_dsl import (
-    ConstRef,
     EntryRule,
+    IndicatorRef,
     Predicate,
-    RSIRef,
     SignalExitRule,
 )
 
@@ -34,13 +33,13 @@ from investment_team.strategy_lab.spec_dsl import (
 def _rsi_entry_dict() -> Dict[str, Any]:
     return EntryRule(
         side="long",
-        when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30)),
+        when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op="<", rhs=30),
     ).model_dump()
 
 
 def _rsi_exit_dict() -> Dict[str, Any]:
     return SignalExitRule(
-        when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)),
+        when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op=">", rhs=70),
     ).model_dump()
 
 

--- a/backend/agents/investment_team/tests/test_strategy_lab_pre_synthesis_gating.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_pre_synthesis_gating.py
@@ -21,10 +21,9 @@ from investment_team.models import BacktestConfig
 from investment_team.strategy_lab import orchestrator as orchestrator_module
 from investment_team.strategy_lab.orchestrator import StrategyLabOrchestrator
 from investment_team.strategy_lab.spec_dsl import (
-    ConstRef,
     EntryRule,
+    IndicatorRef,
     Predicate,
-    RSIRef,
     SignalExitRule,
     TimeStopRule,
 )
@@ -33,13 +32,13 @@ from investment_team.strategy_lab.spec_dsl import (
 def _rsi_entry_dict() -> Dict[str, Any]:
     return EntryRule(
         side="long",
-        when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30)),
+        when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op="<", rhs=30),
     ).model_dump()
 
 
 def _rsi_exit_dict() -> Dict[str, Any]:
     return SignalExitRule(
-        when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)),
+        when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op=">", rhs=70),
     ).model_dump()
 
 

--- a/backend/agents/investment_team/tests/test_strategy_lab_record_provenance.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_record_provenance.py
@@ -18,10 +18,9 @@ from investment_team.models import (
     StrategySpec,
 )
 from investment_team.strategy_lab.spec_dsl import (
-    ConstRef,
     EntryRule,
+    IndicatorRef,
     Predicate,
-    RSIRef,
     SignalExitRule,
 )
 from investment_team.trade_simulator import compute_metrics
@@ -34,13 +33,17 @@ def _spec(strategy_id: str, *, hypothesis: str = "RSI mean reversion") -> Strate
         asset_class="stocks",
         hypothesis=hypothesis,
         signal_definition="sig",
+        timeframe="1d",
         entry_rules=[
             EntryRule(
-                side="long", when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30))
+                side="long",
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op="<", rhs=30),
             )
         ],
         exit_rules=[
-            SignalExitRule(when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)))
+            SignalExitRule(
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op=">", rhs=70)
+            )
         ],
         risk_limits={"max_position_pct": 5},
         speculative=False,

--- a/backend/agents/investment_team/tests/test_strategy_lab_refinement_contract.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_refinement_contract.py
@@ -20,10 +20,9 @@ from investment_team.models import StrategySpec
 from investment_team.strategy_lab.exceptions import SpecImplementabilityError
 from investment_team.strategy_lab.orchestrator import StrategyLabOrchestrator
 from investment_team.strategy_lab.spec_dsl import (
-    ConstRef,
     EntryRule,
+    IndicatorRef,
     Predicate,
-    RSIRef,
     SignalExitRule,
 )
 
@@ -35,13 +34,17 @@ def _spec() -> StrategySpec:
         asset_class="stocks",
         hypothesis="RSI mean reversion",
         signal_definition="sig",
+        timeframe="1d",
         entry_rules=[
             EntryRule(
-                side="long", when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30))
+                side="long",
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op="<", rhs=30),
             )
         ],
         exit_rules=[
-            SignalExitRule(when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)))
+            SignalExitRule(
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op=">", rhs=70)
+            )
         ],
         risk_limits={"max_position_pct": 5, "max_drawdown_pct": 10},
         speculative=False,

--- a/backend/agents/investment_team/tests/test_strategy_lab_refinement_freeze.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_refinement_freeze.py
@@ -38,10 +38,9 @@ from investment_team.strategy_lab.orchestrator import (
     StrategyLabOrchestrator,
 )
 from investment_team.strategy_lab.spec_dsl import (
-    ConstRef,
     EntryRule,
+    IndicatorRef,
     Predicate,
-    RSIRef,
     SignalExitRule,
 )
 from investment_team.trading_service.modes.sandbox_compat import StrategyRunResult
@@ -70,14 +69,17 @@ def _spec(strategy_id: str = "strat-freeze-test") -> StrategySpec:
         asset_class="stocks",
         hypothesis="RSI mean reversion baseline",
         signal_definition="sig",
+        timeframe="1d",
         entry_rules=[
             EntryRule(
                 side="long",
-                when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30)),
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op="<", rhs=30),
             )
         ],
         exit_rules=[
-            SignalExitRule(when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)))
+            SignalExitRule(
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op=">", rhs=70)
+            )
         ],
         risk_limits={"max_position_pct": 5, "max_drawdown_pct": 10},
         speculative=False,

--- a/backend/agents/investment_team/tests/test_strategy_lab_resume.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_resume.py
@@ -32,10 +32,8 @@ from investment_team.models import (
     StrategySpec,
 )
 from investment_team.strategy_lab.spec_dsl import (
-    ConstRef,
     EntryRule,
     Predicate,
-    PriceRef,
     TimeStopRule,
 )
 
@@ -56,13 +54,14 @@ def _make_record(record_id: str) -> StrategyLabRecord:
         asset_class="equities",
         hypothesis="test hypothesis",
         signal_definition="test signal",
+        timeframe="1d",
         entry_rules=[
             EntryRule(
                 side="long",
                 when=Predicate(
-                    lhs=PriceRef(),
-                    op="gt",
-                    rhs=ConstRef(value=float(record_salt % 100)),
+                    lhs="bar.close",
+                    op=">",
+                    rhs=float(record_salt % 100),
                 ),
             )
         ],

--- a/backend/agents/investment_team/tests/test_strategy_lab_runtime_instrument_golden.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_runtime_instrument_golden.py
@@ -33,6 +33,7 @@ def _make_spec(name: str, code: str) -> StrategySpec:
         asset_class="stocks",
         hypothesis="instrumented round-trip",
         signal_definition="see strategies.py",
+        timeframe="1d",
         strategy_code=code,
     )
 

--- a/backend/agents/investment_team/tests/test_strategy_lab_static_probe.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_static_probe.py
@@ -10,10 +10,9 @@ from investment_team.models import (
 )
 from investment_team.strategy_lab.coverage_probe import run_static_probe
 from investment_team.strategy_lab.spec_dsl import (
-    ConstRef,
     EntryRule,
+    IndicatorRef,
     Predicate,
-    RSIRef,
     SignalExitRule,
 )
 
@@ -25,13 +24,17 @@ def _spec(strategy_code: str | None, *, max_position_pct: float = 6.0) -> Strate
         asset_class="stocks",
         hypothesis="hyp",
         signal_definition="sig",
+        timeframe="1d",
         entry_rules=[
             EntryRule(
-                side="long", when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30))
+                side="long",
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op="<", rhs=30),
             )
         ],
         exit_rules=[
-            SignalExitRule(when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)))
+            SignalExitRule(
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op=">", rhs=70)
+            )
         ],
         risk_limits={"max_position_pct": max_position_pct},
         speculative=False,

--- a/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
@@ -31,10 +31,8 @@ from investment_team.strategy_lab.orchestrator import StrategyLabOrchestrator
 from investment_team.strategy_lab.quality_gates.acceptance_gate import AcceptanceGate
 from investment_team.strategy_lab.quality_gates.convergence_tracker import ConvergenceTracker
 from investment_team.strategy_lab.spec_dsl import (
-    ConstRef,
     EntryRule,
     Predicate,
-    PriceRef,
     SignalExitRule,
     TimeStopRule,
 )
@@ -51,10 +49,9 @@ def _spec() -> StrategySpec:
         asset_class="stocks",
         hypothesis="hyp",
         signal_definition="sig",
-        entry_rules=[
-            EntryRule(side="long", when=Predicate(lhs=PriceRef(), op="gt", rhs=ConstRef(value=0)))
-        ],
-        exit_rules=[SignalExitRule(when=Predicate(lhs=PriceRef(), op="lt", rhs=ConstRef(value=0)))],
+        timeframe="1d",
+        entry_rules=[EntryRule(side="long", when=Predicate(lhs="bar.close", op=">", rhs=0))],
+        exit_rules=[SignalExitRule(when=Predicate(lhs="bar.close", op="<", rhs=0))],
         risk_limits={},
         speculative=False,
         strategy_code=(
@@ -599,7 +596,7 @@ def test_walk_forward_fallback_rejects_overfit_via_anomaly_recheck(monkeypatch):
         "entry_rules": [
             EntryRule(
                 side="long",
-                when=Predicate(lhs=PriceRef(), op="gt", rhs=ConstRef(value=0)),
+                when=Predicate(lhs="bar.close", op=">", rhs=0),
             ).model_dump()
         ],
         "exit_rules": [TimeStopRule(n_bars=5).model_dump()],
@@ -718,7 +715,7 @@ def _wire_run_cycle_stubs(
         "entry_rules": [
             EntryRule(
                 side="long",
-                when=Predicate(lhs=PriceRef(), op="gt", rhs=ConstRef(value=0)),
+                when=Predicate(lhs="bar.close", op=">", rhs=0),
             ).model_dump()
         ],
         "exit_rules": [TimeStopRule(n_bars=5).model_dump()],

--- a/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
@@ -33,10 +33,9 @@ from investment_team.strategy_lab.orchestrator import (
 )
 from investment_team.strategy_lab.quality_gates.models import QualityGateResult
 from investment_team.strategy_lab.spec_dsl import (
-    ConstRef,
     EntryRule,
+    IndicatorRef,
     Predicate,
-    RSIRef,
     SignalExitRule,
     TimeStopRule,
 )
@@ -69,13 +68,17 @@ def _spec() -> StrategySpec:
         asset_class="stocks",
         hypothesis="hyp",
         signal_definition="sig",
+        timeframe="1d",
         entry_rules=[
             EntryRule(
-                side="long", when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30))
+                side="long",
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op="<", rhs=30),
             )
         ],
         exit_rules=[
-            SignalExitRule(when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)))
+            SignalExitRule(
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op=">", rhs=70)
+            )
         ],
         risk_limits={"max_position_pct": 5},
         speculative=False,
@@ -711,9 +714,9 @@ def test_zero_trade_repair_drops_off_list_spec_keys_protects_thesis(
                         EntryRule(
                             side="long",
                             when=Predicate(
-                                lhs=RSIRef(period=14),
-                                op="lt",
-                                rhs=ConstRef(value=90),
+                                lhs=IndicatorRef(name="rsi", params={"period": 14}),
+                                op="<",
+                                rhs=90,
                             ),
                         ).model_dump()
                     ],

--- a/backend/agents/investment_team/tests/test_strategy_validator.py
+++ b/backend/agents/investment_team/tests/test_strategy_validator.py
@@ -15,17 +15,11 @@ from investment_team.strategy_lab.quality_gates.strategy_validator import (
     StrategySpecValidator,
 )
 from investment_team.strategy_lab.spec_dsl import (
-    ConstRef,
     EntryRule,
-    MACDRef,
+    IndicatorRef,
     Predicate,
-    PriceRef,
-    RSIRef,
     SignalExitRule,
-    SMARef,
     TimeStopRule,
-    UnparsableRule,
-    UnparsableSizing,
 )
 
 
@@ -43,6 +37,7 @@ def _spec(
         asset_class=asset_class,
         hypothesis=hypothesis,
         signal_definition="sig",
+        timeframe="1d",
         entry_rules=entry,
         exit_rules=exit_,
         risk_limits={"max_position_pct": 5, "max_drawdown_pct": 10},
@@ -77,12 +72,12 @@ def test_validator_rejects_options_asset_class() -> None:
         entry=[
             EntryRule(
                 side="long",
-                when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30)),
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op="<", rhs=30),
             ),
         ],
         exit_=[
             SignalExitRule(
-                when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)),
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op=">", rhs=70),
             ),
         ],
         asset_class="options",
@@ -102,12 +97,12 @@ def test_validator_rejects_options_via_normalize_alias() -> None:
         entry=[
             EntryRule(
                 side="long",
-                when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30)),
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op="<", rhs=30),
             ),
         ],
         exit_=[
             SignalExitRule(
-                when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)),
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op=">", rhs=70),
             ),
         ],
         asset_class="  OPTIONS  ",
@@ -125,12 +120,16 @@ def test_validator_does_not_reject_supported_asset_classes() -> None:
             entry=[
                 EntryRule(
                     side="long",
-                    when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30)),
+                    when=Predicate(
+                        lhs=IndicatorRef(name="rsi", params={"period": 14}), op="<", rhs=30
+                    ),
                 ),
             ],
             exit_=[
                 SignalExitRule(
-                    when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)),
+                    when=Predicate(
+                        lhs=IndicatorRef(name="rsi", params={"period": 14}), op=">", rhs=70
+                    ),
                 ),
             ],
             asset_class=ac,
@@ -153,7 +152,9 @@ def test_hypothesis_term_missing_from_rules_emits_warning() -> None:
         entry=[
             EntryRule(
                 side="long",
-                when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=20)),
+                when=Predicate(
+                    lhs="bar.close", op=">", rhs=IndicatorRef(name="sma", params={"period": 20})
+                ),
             ),
         ],
         exit_=[TimeStopRule(n_bars=5)],
@@ -172,12 +173,12 @@ def test_rules_term_missing_from_hypothesis_emits_warning() -> None:
         entry=[
             EntryRule(
                 side="long",
-                when=Predicate(lhs=MACDRef(), op="gt", rhs=ConstRef(value=0)),
+                when=Predicate(lhs=IndicatorRef(name="macd"), op=">", rhs=0),
             ),
         ],
         exit_=[
             SignalExitRule(
-                when=Predicate(lhs=MACDRef(), op="lt", rhs=ConstRef(value=0)),
+                when=Predicate(lhs=IndicatorRef(name="macd"), op="<", rhs=0),
             ),
         ],
     )
@@ -195,12 +196,12 @@ def test_aligned_hypothesis_and_rules_emit_no_consistency_warning() -> None:
         entry=[
             EntryRule(
                 side="long",
-                when=Predicate(lhs=RSIRef(period=14), op="lt", rhs=ConstRef(value=30)),
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op="<", rhs=30),
             ),
         ],
         exit_=[
             SignalExitRule(
-                when=Predicate(lhs=RSIRef(period=14), op="gt", rhs=ConstRef(value=70)),
+                when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op=">", rhs=70),
             ),
         ],
     )
@@ -220,7 +221,7 @@ def test_no_recognised_terms_emits_no_consistency_warning() -> None:
         entry=[
             EntryRule(
                 side="long",
-                when=Predicate(lhs=PriceRef(), op="gt", rhs=ConstRef(value=0)),
+                when=Predicate(lhs="bar.close", op=">", rhs=0),
             ),
         ],
         exit_=[TimeStopRule(n_bars=5)],
@@ -237,7 +238,7 @@ def test_word_boundary_prevents_thematic_matching_ema() -> None:
         entry=[
             EntryRule(
                 side="long",
-                when=Predicate(lhs=PriceRef(), op="gt", rhs=ConstRef(value=0)),
+                when=Predicate(lhs="bar.close", op=">", rhs=0),
             ),
         ],
         exit_=[TimeStopRule(n_bars=5)],
@@ -248,76 +249,67 @@ def test_word_boundary_prevents_thematic_matching_ema() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Issue #552 — keyword/non-computable scans on structured rules.
+# Issue #552/#537 — keyword/non-computable scans cover unparseable prose.
 #
-# Under the DSL (#551) the asset-class mismatch and non-computable keyword
-# scans only see free text through ``UnparsableRule.prose`` /
-# ``UnparsableSizing.prose`` — the only escape hatches for prose that
-# survived the migration. ``StrategySpec.entry_rules`` is typed
-# ``List[EntryRule]`` (no prose escape hatch on entries), so the prose
-# surface to exercise is ``exit_rules`` (its union admits ``UnparsableRule``)
-# and ``sizing`` (its union admits ``UnparsableSizing``).
+# After #537 unparseable rules live as raw strings on
+# ``StrategySpec.unparsed_rules`` (the previous ``UnparsableRule`` /
+# ``UnparsableSizing`` discriminator variants were dropped). The
+# validator folds ``unparsed_rules`` into the same text view as the
+# structured rules so an asset-class-mismatched or non-computable
+# keyword in legacy prose is still caught.
 # ---------------------------------------------------------------------------
 
 
-def test_asset_class_mismatch_fires_on_unparsable_exit_rule_prose() -> None:
-    """Equity keyword 'dividend' in an ``UnparsableRule.prose`` exit rule on
-    a forex spec is surfaced by ``format_rules_for_prompt`` and trips the
-    asset-class mismatch scan."""
-    spec = _spec(
-        hypothesis="trend follow on currency pairs",
+def _spec_with_unparsed(
+    *, unparsed_rules: list[str], asset_class: str, hypothesis: str
+) -> StrategySpec:
+    return _spec(
+        hypothesis=hypothesis,
         entry=[
             EntryRule(
                 side="long",
-                when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=20)),
+                when=Predicate(
+                    lhs="bar.close", op=">", rhs=IndicatorRef(name="sma", params={"period": 20})
+                ),
             ),
         ],
-        exit_=[UnparsableRule(prose="exit on dividend ex-date", reason="prose")],
+        exit_=[TimeStopRule(n_bars=5)],
+        asset_class=asset_class,
+    ).model_copy(update={"unparsed_rules": unparsed_rules, "requires_redesign": True})
+
+
+def test_asset_class_mismatch_fires_on_unparsed_exit_rule_prose() -> None:
+    """Equity keyword 'dividend' in `unparsed_rules` on a forex spec
+    trips the asset-class mismatch scan."""
+    spec = _spec_with_unparsed(
+        unparsed_rules=["exit on dividend ex-date"],
         asset_class="forex",
+        hypothesis="trend follow on currency pairs",
     )
     results = StrategySpecValidator().validate(spec)
     warnings = _warnings(results)
     assert any("mismatched with asset class 'forex'" in w for w in warnings), warnings
 
 
-def test_asset_class_mismatch_fires_on_unparsable_sizing_prose() -> None:
-    """Equity keyword 'EPS' in ``UnparsableSizing.prose`` on a crypto spec
-    is surfaced by ``format_sizing_rule`` and trips the asset-class mismatch
-    scan."""
-    spec = _spec(
-        hypothesis="momentum on majors",
-        entry=[
-            EntryRule(
-                side="long",
-                when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=20)),
-            ),
-        ],
-        exit_=[TimeStopRule(n_bars=5)],
+def test_asset_class_mismatch_fires_on_unparsed_sizing_prose() -> None:
+    """Equity keyword 'EPS' on a crypto spec trips the asset-class mismatch scan."""
+    spec = _spec_with_unparsed(
+        unparsed_rules=["size by EPS growth"],
         asset_class="crypto",
-        sizing=UnparsableSizing(prose="size by EPS growth", reason="prose"),
+        hypothesis="momentum on majors",
     )
     results = StrategySpecValidator().validate(spec)
     warnings = _warnings(results)
     assert any("mismatched with asset class 'crypto'" in w for w in warnings), warnings
 
 
-def test_non_computable_keyword_fires_on_unparsable_exit_rule_prose() -> None:
+def test_non_computable_keyword_fires_on_unparsed_exit_rule_prose() -> None:
     """A prose exit rule referencing 'twitter sentiment' trips the
     non-computable-data warning regardless of asset class."""
-    spec = _spec(
+    spec = _spec_with_unparsed(
+        unparsed_rules=["exit when twitter sentiment turns negative"],
+        asset_class="stocks",
         hypothesis="mean reversion on retail flow",
-        entry=[
-            EntryRule(
-                side="long",
-                when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=20)),
-            ),
-        ],
-        exit_=[
-            UnparsableRule(
-                prose="exit when twitter sentiment turns negative",
-                reason="prose",
-            ),
-        ],
     )
     results = StrategySpecValidator().validate(spec)
     warnings = _warnings(results)
@@ -334,12 +326,16 @@ def test_structured_rules_do_not_trigger_keyword_scans() -> None:
         entry=[
             EntryRule(
                 side="long",
-                when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=20)),
+                when=Predicate(
+                    lhs="bar.close", op=">", rhs=IndicatorRef(name="sma", params={"period": 20})
+                ),
             ),
         ],
         exit_=[
             SignalExitRule(
-                when=Predicate(lhs=PriceRef(), op="lt", rhs=SMARef(period=5)),
+                when=Predicate(
+                    lhs="bar.close", op="<", rhs=IndicatorRef(name="sma", params={"period": 5})
+                ),
             ),
         ],
         asset_class="forex",

--- a/backend/agents/investment_team/tests/test_strategy_validator.py
+++ b/backend/agents/investment_team/tests/test_strategy_validator.py
@@ -316,6 +316,31 @@ def test_non_computable_keyword_fires_on_unparsed_exit_rule_prose() -> None:
     assert any("non-computable data" in w for w in warnings), warnings
 
 
+def test_hypothesis_consistency_scans_unparsed_rules() -> None:
+    """Issue #537: indicator concepts that appear only in `unparsed_rules`
+    still satisfy the hypothesis-vs-rules consistency check, matching the
+    pre-#537 behavior where unparseable prose was rendered through the
+    formatters."""
+    spec = _spec(
+        hypothesis="RSI mean reversion strategy",
+        entry=[
+            EntryRule(
+                side="long",
+                when=Predicate(
+                    lhs="bar.close", op=">", rhs=IndicatorRef(name="sma", params={"period": 20})
+                ),
+            ),
+        ],
+        exit_=[TimeStopRule(n_bars=5)],
+    ).model_copy(update={"unparsed_rules": ["exit when rsi(14) > 70"], "requires_redesign": True})
+    results = StrategySpecValidator().validate(spec)
+    warnings = _warnings(results)
+    consistency_warnings = [w for w in warnings if "Hypothesis/rules consistency" in w]
+    # 'rsi' is mentioned in both hypothesis and unparsed_rules → not an orphan.
+    # The warning may still fire for 'sma'/'mean reversion' but must NOT cite 'rsi'.
+    assert not any("'rsi'" in w for w in consistency_warnings), consistency_warnings
+
+
 def test_structured_rules_do_not_trigger_keyword_scans() -> None:
     """Negative case: purely structured rules format to text like
     ``long when close > sma(20)`` / ``risk 2% per trade``, none of which

--- a/backend/agents/investment_team/tests/test_streaming_equity_curve.py
+++ b/backend/agents/investment_team/tests/test_streaming_equity_curve.py
@@ -360,6 +360,7 @@ def test_streaming_curve_matches_between_per_bar_and_chunked_paths() -> None:
         asset_class="stocks",
         hypothesis="parity",
         signal_definition="noop",
+        timeframe="1d",
         strategy_code=_NOOP_STRATEGY_CODE,
     )
     cfg = BacktestConfig(
@@ -439,6 +440,7 @@ def test_streaming_buffer_matches_reconstructed_curve_byte_for_byte() -> None:
         asset_class="stocks",
         hypothesis="parity",
         signal_definition="noop",
+        timeframe="1d",
         strategy_code=_NOOP_STRATEGY_CODE,
     )
 

--- a/backend/agents/investment_team/tests/test_streaming_harness_chunked.py
+++ b/backend/agents/investment_team/tests/test_streaming_harness_chunked.py
@@ -297,6 +297,7 @@ def test_service_chunked_path_runs_round_trip_strategy_without_lookahead() -> No
         asset_class="stocks",
         hypothesis="invariant",
         signal_definition="invariant",
+        timeframe="1d",
         strategy_code=ROUND_TRIP_CODE,
     )
     config = BacktestConfig(

--- a/backend/agents/investment_team/tests/test_subdaily_backtest.py
+++ b/backend/agents/investment_team/tests/test_subdaily_backtest.py
@@ -102,6 +102,7 @@ def _strategy() -> StrategySpec:
         asset_class="crypto",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
         entry_rules=[],
         exit_rules=[],
         strategy_code=_SMA_STRATEGY_CODE,

--- a/backend/agents/investment_team/tests/test_target_symbol_coverage.py
+++ b/backend/agents/investment_team/tests/test_target_symbol_coverage.py
@@ -20,6 +20,7 @@ def _spec(
         asset_class="stocks",
         hypothesis=hypothesis,
         signal_definition="sig",
+        timeframe="1d",
         entry_rules=[],
         exit_rules=[],
         risk_limits={"max_position_pct": 5, "max_drawdown_pct": 10},

--- a/backend/agents/investment_team/tests/test_trading_service.py
+++ b/backend/agents/investment_team/tests/test_trading_service.py
@@ -24,10 +24,9 @@ from investment_team.models import (
 )
 from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
+    IndicatorRef,
     Predicate,
-    PriceRef,
     SignalExitRule,
-    SMARef,
 )
 from investment_team.trading_service.data_stream.historical_replay import (
     HistoricalReplayStream,
@@ -200,15 +199,27 @@ def test_trading_service_runs_sma_strategy_and_produces_trade() -> None:
     _uptrend_then_down_bars(market_data)
 
     strategy = StrategySpec(
+        timeframe="1d",
         strategy_id="strat-sma-1",
         authored_by="tests",
         asset_class="equity",
         hypothesis="momentum via SMA(5)",
         signal_definition="close vs sma(5)",
         entry_rules=[
-            EntryRule(side="long", when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=5)))
+            EntryRule(
+                side="long",
+                when=Predicate(
+                    lhs="bar.close", op=">", rhs=IndicatorRef(name="sma", params={"period": 5})
+                ),
+            )
         ],
-        exit_rules=[SignalExitRule(when=Predicate(lhs=PriceRef(), op="lt", rhs=SMARef(period=5)))],
+        exit_rules=[
+            SignalExitRule(
+                when=Predicate(
+                    lhs="bar.close", op="<", rhs=IndicatorRef(name="sma", params={"period": 5})
+                )
+            )
+        ],
         strategy_code=_SMA_STRATEGY_CODE,
     )
 
@@ -242,6 +253,7 @@ def test_trading_service_surfaces_lookahead_violation() -> None:
     _uptrend_then_down_bars(market_data)
 
     strategy = StrategySpec(
+        timeframe="1d",
         strategy_id="strat-peeker-1",
         authored_by="tests",
         asset_class="equity",
@@ -278,6 +290,7 @@ def test_zero_trade_result_gets_no_orders_emitted_category() -> None:
         asset_class="equity",
         hypothesis="no-op",
         signal_definition="none",
+        timeframe="1d",
         entry_rules=[],
         exit_rules=[],
         strategy_code=_NOOP_STRATEGY_CODE,
@@ -357,6 +370,7 @@ def test_runtime_error_return_path_includes_finalized_diagnostics() -> None:
         asset_class="equity",
         hypothesis="runtime error",
         signal_definition="raise",
+        timeframe="1d",
         entry_rules=[],
         exit_rules=[],
         strategy_code=_BROKEN_BAR_STRATEGY_CODE,
@@ -580,10 +594,22 @@ def test_diagnostics_emitted_and_accepted_counts_round_trip() -> None:
         asset_class="equity",
         hypothesis="round-trip",
         signal_definition="sma",
+        timeframe="1d",
         entry_rules=[
-            EntryRule(side="long", when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=5)))
+            EntryRule(
+                side="long",
+                when=Predicate(
+                    lhs="bar.close", op=">", rhs=IndicatorRef(name="sma", params={"period": 5})
+                ),
+            )
         ],
-        exit_rules=[SignalExitRule(when=Predicate(lhs=PriceRef(), op="lt", rhs=SMARef(period=5)))],
+        exit_rules=[
+            SignalExitRule(
+                when=Predicate(
+                    lhs="bar.close", op="<", rhs=IndicatorRef(name="sma", params={"period": 5})
+                )
+            )
+        ],
         strategy_code=_SMA_STRATEGY_CODE,
     )
 
@@ -620,6 +646,7 @@ def test_diagnostics_unsupported_feature_records_rejection() -> None:
         asset_class="equity",
         hypothesis="unsupported feature",
         signal_definition="parent_order_id",
+        timeframe="1d",
         entry_rules=[],
         exit_rules=[],
         strategy_code=_UNSUPPORTED_FEATURE_STRATEGY_CODE,
@@ -653,6 +680,7 @@ def test_diagnostics_malformed_order_records_rejection_and_continues() -> None:
         asset_class="equity",
         hypothesis="malformed payload",
         signal_definition="missing fields",
+        timeframe="1d",
         entry_rules=[],
         exit_rules=[],
         strategy_code=_MALFORMED_ORDER_STRATEGY_CODE,
@@ -706,6 +734,7 @@ def test_diagnostics_end_of_stream_unfilled_recorded() -> None:
         asset_class="equity",
         hypothesis="end-of-stream",
         signal_definition="late market",
+        timeframe="1d",
         entry_rules=[],
         exit_rules=[],
         strategy_code=_LATE_MARKET_ORDER_STRATEGY_CODE,
@@ -764,6 +793,7 @@ def test_diagnostics_last_order_events_capped_at_twenty() -> None:
         asset_class="equity",
         hypothesis="noisy",
         signal_definition="emit every bar",
+        timeframe="1d",
         entry_rules=[],
         exit_rules=[],
         strategy_code=_NOISY_ORDER_STRATEGY_CODE,
@@ -785,6 +815,7 @@ def test_run_backtest_without_strategy_code_raises() -> None:
         asset_class="equity",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
         strategy_code=None,
     )
     with pytest.raises(ValueError, match="strategy_code is required"):
@@ -802,15 +833,27 @@ def test_run_backtest_attaches_data_quality_report() -> None:
     _uptrend_then_down_bars(market_data)
 
     strategy = StrategySpec(
+        timeframe="1d",
         strategy_id="strat-sma-dq-1",
         authored_by="tests",
         asset_class="equity",
         hypothesis="momentum via SMA(5)",
         signal_definition="close vs sma(5)",
         entry_rules=[
-            EntryRule(side="long", when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=5)))
+            EntryRule(
+                side="long",
+                when=Predicate(
+                    lhs="bar.close", op=">", rhs=IndicatorRef(name="sma", params={"period": 5})
+                ),
+            )
         ],
-        exit_rules=[SignalExitRule(when=Predicate(lhs=PriceRef(), op="lt", rhs=SMARef(period=5)))],
+        exit_rules=[
+            SignalExitRule(
+                when=Predicate(
+                    lhs="bar.close", op="<", rhs=IndicatorRef(name="sma", params={"period": 5})
+                )
+            )
+        ],
         strategy_code=_SMA_STRATEGY_CODE,
     )
 
@@ -836,6 +879,7 @@ def test_run_backtest_strict_fails_on_ohlc_violation() -> None:
         asset_class="equity",
         hypothesis="h",
         signal_definition="s",
+        timeframe="1d",
         strategy_code=_SMA_STRATEGY_CODE,
     )
 
@@ -935,15 +979,27 @@ def test_run_backtest_passes_requeue_default_to_service(monkeypatch) -> None:
     _uptrend_then_down_bars(market_data)
 
     strategy = StrategySpec(
+        timeframe="1d",
         strategy_id="strat-sma-385-backtest",
         authored_by="tests",
         asset_class="equity",
         hypothesis="momentum via SMA(5)",
         signal_definition="close vs sma(5)",
         entry_rules=[
-            EntryRule(side="long", when=Predicate(lhs=PriceRef(), op="gt", rhs=SMARef(period=5)))
+            EntryRule(
+                side="long",
+                when=Predicate(
+                    lhs="bar.close", op=">", rhs=IndicatorRef(name="sma", params={"period": 5})
+                ),
+            )
         ],
-        exit_rules=[SignalExitRule(when=Predicate(lhs=PriceRef(), op="lt", rhs=SMARef(period=5)))],
+        exit_rules=[
+            SignalExitRule(
+                when=Predicate(
+                    lhs="bar.close", op="<", rhs=IndicatorRef(name="sma", params={"period": 5})
+                )
+            )
+        ],
         strategy_code=_SMA_STRATEGY_CODE,
     )
 

--- a/backend/agents/investment_team/trading_service/modes/sandbox_compat.py
+++ b/backend/agents/investment_team/trading_service/modes/sandbox_compat.py
@@ -84,6 +84,9 @@ def run_strategy_code(
             asset_class="equity",
             hypothesis="",
             signal_definition="",
+            # Issue #537: synthetic ad-hoc specs run against daily bars by
+            # default — the compat shim never resolves a specific timeframe.
+            timeframe="1d",
             entry_rules=[],
             exit_rules=[],
             strategy_code=strategy_code,


### PR DESCRIPTION
## Summary

Closes #537 by reshaping the structured `StrategySpec` DSL to match the
literal schema proposed in the issue body. Most of #537 had already
shipped via #550–#559 (PRs #558/#563/#566/#569/#575) but with a
better-typed-but-non-literal schema; this PR makes the as-shipped shape
match the issue text and adds the missing pieces.

### What changes

- **`IndicatorRef`** is now a single flat class — `name: Literal[...]`,
  `params: dict[str, int | float | str]`, `source: Literal[...]`. The
  previous typed union (`SMARef`, `RSIRef`, `MACDRef`, …) is gone.
  Per-indicator required/optional/bounds validation lives in a
  registry-backed `model_validator(mode="after")` so the original
  guarantees (sma period ∈ [2, 400], rsi ∈ [2, 200], bollinger.num_std
  > 0, etc.) are preserved.
- **`Predicate.op`** uses the symbol literals `"<"`, `">"`, `"<="`,
  `">="`, `"=="` (plus `"cross_above"`, `"cross_below"`) — the name
  aliases `"gt"`/`"lt"`/etc. are no longer accepted on direct
  construction.
- **`Predicate.lhs`** accepts an `IndicatorRef` or one of the bar-field
  string literals `"bar.close"` / `"bar.high"` / `"bar.low"` /
  `"bar.volume"` directly. **`Predicate.rhs`** additionally accepts a
  plain `float` for numeric comparisons. The `PriceRef` / `ConstRef`
  wrapper classes are gone.
- **`StrategySpec.timeframe`** is required (`Literal["1m","5m","15m","1h","1d"]`,
  no default). Fresh callers must declare it; persisted records get the
  legacy migration path below.
- **`spec_dsl.from_prose(spec_legacy)`** is a new top-level adapter
  that best-effort-parses a legacy prose-shaped dict into the
  structured DSL, stashes rules it can't parse on
  `spec.unparsed_rules`, and sets `requires_redesign=True` so the
  design agent re-routes the spec.
- **`UnparsableRule` / `UnparsableSizing`** discriminator variants are
  removed; their role moves to the spec-level
  `requires_redesign: bool` + `unparsed_rules: list[str]`. The
  `StrategySpecValidator` now folds `unparsed_rules` into its keyword
  scans so legacy prose still trips asset-class-mismatch /
  non-computable warnings.
- **Legacy-payload rewriter** on
  `StrategySpec.model_validator(mode="before")` detects pre-#537
  payload markers (old op names, typed indicator dicts, `sizing_rules`
  list, `unparsable` discriminator) and rewrites them in-flight. A
  missing `timeframe` is **not** counted as a legacy marker — fresh
  callers that forget it get the standard required-field error.

### Migration

`backend/agents/investment_team/scripts/backfill_strategy_specs.py`
canonicalises persisted `StrategySpec` JSON across three job-service
teams (`investment_strategy_lab_records`, `investment_backtests`,
`investment_strategies`). Idempotent; supports `--dry-run` and
`--limit N`.

### Surface area

- Core schema: `strategy_lab/spec_dsl.py`, `strategy_lab/spec_dsl_adapter.py`,
  `models.py`.
- Producers / consumers: `strategy_lab/agents/ideation.py` (prompt
  update for the new shape + required `timeframe`),
  `strategy_lab/prompts/ideation_system.md`,
  `strategy_lab/orchestrator.py`, `trading_service/modes/sandbox_compat.py`,
  `api/main.py` (`CreateStrategyRequest` requires `timeframe`).
- Validator: `strategy_lab/quality_gates/strategy_validator.py` now
  scans `unparsed_rules`.
- 38 test files migrated to the new constructor shape; new tests cover
  `timeframe` required-field semantics, legacy-payload migration,
  `from_prose` round-trip, and the validator's `unparsed_rules` scan.

## Test plan

- [x] `ruff check agents/investment_team/` — clean.
- [x] `ruff format --check agents/investment_team/` — clean.
- [x] `pytest agents/investment_team/tests/` — **1388 passed, 13 skipped**.
  - Includes the rewritten `test_spec_dsl.py` (74 tests covering
    round-trip, discriminator dispatch, registry bounds, `timeframe`
    required vs. legacy migration, `from_prose`) and `test_spec_dsl_adapter.py`.
- [x] Pre-existing unified_api failures (`test_main_routes::test_list_teams_*`,
      `test_integrations_routes::test_slack_oauth_*`) confirmed
      independent of this change.
- [ ] Run `python -m investment_team.scripts.backfill_strategy_specs --dry-run`
      against a Postgres snapshot once one is available.
- [ ] End-to-end smoke: `POST /api/investment/strategy-lab/run` with
      `"timeframe": "1h"`; confirm round-trip + 400 on missing field.

https://claude.ai/code/session_01Knp7yUSZRRoEwzoVTwXDRo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Knp7yUSZRRoEwzoVTwXDRo)_