### PR TITLE
investment-ui: migrate Angular strategy form to structured DSL (#560)

### DIFF
--- a/user-interface/src/app/components/investment-strategy/editors/entry-rule-editor.component.html
+++ b/user-interface/src/app/components/investment-strategy/editors/entry-rule-editor.component.html
@@ -1,0 +1,29 @@
+<div class="entry-rule-row" [formGroup]="group">
+  <div class="rule-header">
+    <span class="rule-index">#{{ index + 1 }}</span>
+    <mat-form-field appearance="outline" class="side-field">
+      <mat-label>side</mat-label>
+      <mat-select formControlName="side">
+        <mat-option value="long">long</mat-option>
+        <mat-option value="short">short</mat-option>
+      </mat-select>
+    </mat-form-field>
+    <button
+      mat-icon-button
+      color="warn"
+      type="button"
+      class="remove-btn"
+      aria-label="Remove entry rule"
+      (click)="remove.emit()"
+    >
+      <mat-icon>delete</mat-icon>
+    </button>
+  </div>
+
+  <app-predicate-editor [group]="whenGroup" />
+
+  <mat-form-field appearance="outline" class="note-field">
+    <mat-label>note (optional)</mat-label>
+    <input matInput formControlName="note" />
+  </mat-form-field>
+</div>

--- a/user-interface/src/app/components/investment-strategy/editors/entry-rule-editor.component.ts
+++ b/user-interface/src/app/components/investment-strategy/editors/entry-rule-editor.component.ts
@@ -1,0 +1,35 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+
+import { PredicateEditorComponent } from './predicate-editor.component';
+
+@Component({
+  selector: 'app-entry-rule-editor',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatButtonModule,
+    MatIconModule,
+    PredicateEditorComponent,
+  ],
+  templateUrl: './entry-rule-editor.component.html',
+})
+export class EntryRuleEditorComponent {
+  @Input({ required: true }) group!: FormGroup;
+  @Input() index = 0;
+  @Output() remove = new EventEmitter<void>();
+
+  get whenGroup(): FormGroup {
+    return this.group.get('when') as FormGroup;
+  }
+}

--- a/user-interface/src/app/components/investment-strategy/editors/exit-rule-editor.component.html
+++ b/user-interface/src/app/components/investment-strategy/editors/exit-rule-editor.component.html
@@ -1,0 +1,60 @@
+<div class="exit-rule-row" [formGroup]="group">
+  <div class="rule-header">
+    <span class="rule-index">#{{ index + 1 }}</span>
+    <mat-form-field appearance="outline" class="kind-field">
+      <mat-label>kind</mat-label>
+      <mat-select formControlName="kind">
+        @for (k of kindOptions; track k) {
+          <mat-option [value]="k">{{ k }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+    <button
+      mat-icon-button
+      color="warn"
+      type="button"
+      class="remove-btn"
+      aria-label="Remove exit rule"
+      (click)="remove.emit()"
+    >
+      <mat-icon>delete</mat-icon>
+    </button>
+  </div>
+
+  @switch (currentKind) {
+    @case ('time_stop') {
+      <mat-form-field appearance="outline" class="num-field">
+        <mat-label>n_bars</mat-label>
+        <input matInput type="number" min="1" step="1" formControlName="n_bars" />
+      </mat-form-field>
+    }
+    @case ('stop_loss') {
+      <mat-form-field appearance="outline" class="num-field">
+        <mat-label>pct (0–1)</mat-label>
+        <input matInput type="number" min="0" max="1" step="0.001" formControlName="pct" />
+      </mat-form-field>
+      <mat-form-field appearance="outline" class="basis-field">
+        <mat-label>basis</mat-label>
+        <mat-select formControlName="basis">
+          @for (b of basisOptions; track b) {
+            <mat-option [value]="b">{{ b }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+    }
+    @case ('take_profit') {
+      <mat-form-field appearance="outline" class="num-field">
+        <mat-label>pct</mat-label>
+        <input matInput type="number" min="0" step="0.001" formControlName="pct" />
+      </mat-form-field>
+    }
+    @case ('signal_exit') {
+      <app-predicate-editor [group]="whenGroup" />
+    }
+  }
+
+  <mat-form-field appearance="outline" class="note-field">
+    <mat-label>note (optional)</mat-label>
+    <input matInput formControlName="note" />
+  </mat-form-field>
+</div>

--- a/user-interface/src/app/components/investment-strategy/editors/exit-rule-editor.component.ts
+++ b/user-interface/src/app/components/investment-strategy/editors/exit-rule-editor.component.ts
@@ -10,6 +10,7 @@ import { Subscription } from 'rxjs';
 
 import { EXIT_RULE_KINDS, ExitRuleKind, STOP_LOSS_BASIS_OPTIONS } from '../../../models';
 import { PredicateEditorComponent } from './predicate-editor.component';
+import { integerValidator } from './strategy-validators';
 
 @Component({
   selector: 'app-exit-rule-editor',
@@ -73,7 +74,8 @@ export class ExitRuleEditorComponent implements OnInit, OnDestroy {
 
     switch (kind) {
       case 'time_stop':
-        this.setValidators('n_bars', [Validators.required, Validators.min(1)]);
+        // n_bars is declared as `int` on the backend; reject 1.5 client-side.
+        this.setValidators('n_bars', [Validators.required, Validators.min(1), integerValidator]);
         break;
       case 'stop_loss':
         this.setValidators('pct', [Validators.required, Validators.min(0.0000001), Validators.max(1.0)]);
@@ -85,6 +87,16 @@ export class ExitRuleEditorComponent implements OnInit, OnDestroy {
       case 'signal_exit':
         // Nested predicate child components own their own validation.
         break;
+    }
+
+    // The nested `when` predicate is only serialized for signal_exit; its
+    // default IndicatorRef params have required fields that would otherwise
+    // keep the form invalid.
+    const whenGroup = this.group.get('when');
+    if (whenGroup) {
+      const opts = { emitEvent: false };
+      if (kind === 'signal_exit') whenGroup.enable(opts);
+      else whenGroup.disable(opts);
     }
   }
 }

--- a/user-interface/src/app/components/investment-strategy/editors/exit-rule-editor.component.ts
+++ b/user-interface/src/app/components/investment-strategy/editors/exit-rule-editor.component.ts
@@ -1,0 +1,90 @@
+import { Component, EventEmitter, Input, OnDestroy, OnInit, Output } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AbstractControl, FormGroup, ReactiveFormsModule, ValidatorFn, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { Subscription } from 'rxjs';
+
+import { EXIT_RULE_KINDS, ExitRuleKind, STOP_LOSS_BASIS_OPTIONS } from '../../../models';
+import { PredicateEditorComponent } from './predicate-editor.component';
+
+@Component({
+  selector: 'app-exit-rule-editor',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    MatButtonModule,
+    MatIconModule,
+    PredicateEditorComponent,
+  ],
+  templateUrl: './exit-rule-editor.component.html',
+})
+export class ExitRuleEditorComponent implements OnInit, OnDestroy {
+  @Input({ required: true }) group!: FormGroup;
+  @Input() index = 0;
+  @Output() remove = new EventEmitter<void>();
+
+  readonly kindOptions = EXIT_RULE_KINDS;
+  readonly basisOptions = STOP_LOSS_BASIS_OPTIONS;
+
+  private kindSub?: Subscription;
+
+  ngOnInit(): void {
+    const kindCtrl = this.group.get('kind');
+    if (!kindCtrl) return;
+    this.applyForKind(kindCtrl.value as ExitRuleKind);
+    this.kindSub = kindCtrl.valueChanges.subscribe((kind: ExitRuleKind) => {
+      this.applyForKind(kind);
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.kindSub?.unsubscribe();
+  }
+
+  get whenGroup(): FormGroup {
+    return this.group.get('when') as FormGroup;
+  }
+
+  get currentKind(): ExitRuleKind {
+    return (this.group.get('kind')?.value ?? 'time_stop') as ExitRuleKind;
+  }
+
+  private setValidators(name: string, validators: ValidatorFn[]): void {
+    const ctrl: AbstractControl | null = this.group.get(name);
+    if (!ctrl) return;
+    ctrl.setValidators(validators.length ? validators : null);
+    ctrl.updateValueAndValidity({ emitEvent: false });
+  }
+
+  private applyForKind(kind: ExitRuleKind): void {
+    // Clear everything first, then apply per kind. Numeric fields keep their
+    // value across kind switches (cheap; harmless).
+    this.setValidators('n_bars', []);
+    this.setValidators('pct', []);
+    this.setValidators('basis', []);
+
+    switch (kind) {
+      case 'time_stop':
+        this.setValidators('n_bars', [Validators.required, Validators.min(1)]);
+        break;
+      case 'stop_loss':
+        this.setValidators('pct', [Validators.required, Validators.min(0.0000001), Validators.max(1.0)]);
+        this.setValidators('basis', [Validators.required]);
+        break;
+      case 'take_profit':
+        this.setValidators('pct', [Validators.required, Validators.min(0.0000001)]);
+        break;
+      case 'signal_exit':
+        // Nested predicate child components own their own validation.
+        break;
+    }
+  }
+}

--- a/user-interface/src/app/components/investment-strategy/editors/indicator-ref-editor.component.html
+++ b/user-interface/src/app/components/investment-strategy/editors/indicator-ref-editor.component.html
@@ -1,0 +1,48 @@
+<div class="indicator-editor" [formGroup]="group">
+  <mat-form-field appearance="outline" class="name-field">
+    <mat-label>Indicator</mat-label>
+    <mat-select formControlName="name">
+      @for (n of indicatorNames; track n) {
+        <mat-option [value]="n">{{ n }}</mat-option>
+      }
+    </mat-select>
+  </mat-form-field>
+
+  <div class="params-row" formGroupName="params">
+    @for (p of paramsFor(currentName()); track p.key) {
+      @if (p.kind === 'enum') {
+        <mat-form-field appearance="outline" class="param-field">
+          <mat-label>{{ p.key }}</mat-label>
+          <mat-select [formControlName]="p.key">
+            @for (opt of p.options ?? []; track opt) {
+              <mat-option [value]="opt">{{ opt }}</mat-option>
+            }
+          </mat-select>
+        </mat-form-field>
+      } @else {
+        <mat-form-field appearance="outline" class="param-field">
+          <mat-label>{{ p.key }}</mat-label>
+          <input
+            matInput
+            type="number"
+            [min]="p.min ?? null"
+            [max]="p.max ?? null"
+            [step]="p.kind === 'float' ? 'any' : 1"
+            [formControlName]="p.key"
+          />
+        </mat-form-field>
+      }
+    }
+  </div>
+
+  @if (allowsSource()) {
+    <mat-form-field appearance="outline" class="source-field">
+      <mat-label>source</mat-label>
+      <mat-select formControlName="source">
+        @for (s of sourceOptions; track s) {
+          <mat-option [value]="s">{{ s }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  }
+</div>

--- a/user-interface/src/app/components/investment-strategy/editors/indicator-ref-editor.component.ts
+++ b/user-interface/src/app/components/investment-strategy/editors/indicator-ref-editor.component.ts
@@ -31,7 +31,10 @@ export class IndicatorRefEditorComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     const nameCtrl = this.group.get('name');
     if (!nameCtrl) return;
-    this.applyForName(nameCtrl.value as IndicatorName);
+    // Do NOT call applyForName here — the parent's buildIndicatorGroup()
+    // has already seeded the params controls from the prefill payload, and
+    // applyForName would wipe those seeds in favour of spec defaults.
+    // Only react to user-driven name changes from here on.
     this.nameSub = nameCtrl.valueChanges.subscribe((name: IndicatorName) => {
       this.applyForName(name);
     });

--- a/user-interface/src/app/components/investment-strategy/editors/indicator-ref-editor.component.ts
+++ b/user-interface/src/app/components/investment-strategy/editors/indicator-ref-editor.component.ts
@@ -13,6 +13,7 @@ import {
   IndicatorName,
   IndicatorParamSpec,
 } from '../../../models';
+import { integerValidator } from './strategy-validators';
 
 @Component({
   selector: 'app-indicator-ref-editor',
@@ -77,6 +78,7 @@ export class IndicatorRefEditorComponent implements OnInit, OnDestroy {
         if (p.min !== undefined) validators.push(Validators.min(p.min));
         if (p.max !== undefined) validators.push(Validators.max(p.max));
       }
+      if (p.kind === 'int') validators.push(integerValidator);
       paramsGroup.addControl(p.key, new FormControl(initial, validators));
     }
 

--- a/user-interface/src/app/components/investment-strategy/editors/indicator-ref-editor.component.ts
+++ b/user-interface/src/app/components/investment-strategy/editors/indicator-ref-editor.component.ts
@@ -1,0 +1,90 @@
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { Subscription } from 'rxjs';
+
+import {
+  INDICATOR_NAME_OPTIONS,
+  INDICATOR_SOURCE_OPTIONS,
+  INDICATOR_SPECS,
+  IndicatorName,
+  IndicatorParamSpec,
+} from '../../../models';
+
+@Component({
+  selector: 'app-indicator-ref-editor',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, MatFormFieldModule, MatInputModule, MatSelectModule],
+  templateUrl: './indicator-ref-editor.component.html',
+})
+export class IndicatorRefEditorComponent implements OnInit, OnDestroy {
+  @Input({ required: true }) group!: FormGroup;
+
+  readonly indicatorNames = INDICATOR_NAME_OPTIONS;
+  readonly sourceOptions = INDICATOR_SOURCE_OPTIONS;
+
+  private nameSub?: Subscription;
+
+  ngOnInit(): void {
+    const nameCtrl = this.group.get('name');
+    if (!nameCtrl) return;
+    this.applyForName(nameCtrl.value as IndicatorName);
+    this.nameSub = nameCtrl.valueChanges.subscribe((name: IndicatorName) => {
+      this.applyForName(name);
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.nameSub?.unsubscribe();
+  }
+
+  get paramsGroup(): FormGroup {
+    return this.group.get('params') as FormGroup;
+  }
+
+  paramsFor(name: IndicatorName): IndicatorParamSpec[] {
+    return INDICATOR_SPECS[name]?.params ?? [];
+  }
+
+  currentName(): IndicatorName {
+    return (this.group.get('name')?.value ?? 'sma') as IndicatorName;
+  }
+
+  allowsSource(): boolean {
+    return INDICATOR_SPECS[this.currentName()]?.allowSource ?? false;
+  }
+
+  private applyForName(name: IndicatorName): void {
+    const spec = INDICATOR_SPECS[name];
+    const paramsGroup = this.paramsGroup;
+
+    Object.keys(paramsGroup.controls).forEach((key) => paramsGroup.removeControl(key));
+
+    if (!spec) return;
+
+    for (const p of spec.params) {
+      const initial =
+        p.default ?? (p.kind === 'enum' ? (p.options?.[0] ?? null) : null);
+      const validators = [];
+      if (p.required) validators.push(Validators.required);
+      if (p.kind !== 'enum') {
+        if (p.min !== undefined) validators.push(Validators.min(p.min));
+        if (p.max !== undefined) validators.push(Validators.max(p.max));
+      }
+      paramsGroup.addControl(p.key, new FormControl(initial, validators));
+    }
+
+    const sourceCtrl = this.group.get('source');
+    if (sourceCtrl) {
+      if (!spec.allowSource) {
+        sourceCtrl.setValue('close', { emitEvent: false });
+        sourceCtrl.disable({ emitEvent: false });
+      } else {
+        sourceCtrl.enable({ emitEvent: false });
+      }
+    }
+  }
+}

--- a/user-interface/src/app/components/investment-strategy/editors/predicate-editor.component.html
+++ b/user-interface/src/app/components/investment-strategy/editors/predicate-editor.component.html
@@ -1,0 +1,14 @@
+<div class="predicate-editor" [formGroup]="group">
+  <app-predicate-side-editor [group]="lhsGroup" [allowNumber]="false" label="LHS" />
+
+  <mat-form-field appearance="outline" class="op-field">
+    <mat-label>op</mat-label>
+    <mat-select formControlName="op">
+      @for (o of opOptions; track o.value) {
+        <mat-option [value]="o.value">{{ o.label }}</mat-option>
+      }
+    </mat-select>
+  </mat-form-field>
+
+  <app-predicate-side-editor [group]="rhsGroup" [allowNumber]="true" label="RHS" />
+</div>

--- a/user-interface/src/app/components/investment-strategy/editors/predicate-editor.component.ts
+++ b/user-interface/src/app/components/investment-strategy/editors/predicate-editor.component.ts
@@ -1,0 +1,34 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatSelectModule } from '@angular/material/select';
+
+import { COMPARISON_OP_OPTIONS } from '../../../models';
+import { PredicateSideEditorComponent } from './predicate-side-editor.component';
+
+@Component({
+  selector: 'app-predicate-editor',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatSelectModule,
+    PredicateSideEditorComponent,
+  ],
+  templateUrl: './predicate-editor.component.html',
+})
+export class PredicateEditorComponent {
+  @Input({ required: true }) group!: FormGroup;
+
+  readonly opOptions = COMPARISON_OP_OPTIONS;
+
+  get lhsGroup(): FormGroup {
+    return this.group.get('lhs') as FormGroup;
+  }
+
+  get rhsGroup(): FormGroup {
+    return this.group.get('rhs') as FormGroup;
+  }
+}

--- a/user-interface/src/app/components/investment-strategy/editors/predicate-side-editor.component.html
+++ b/user-interface/src/app/components/investment-strategy/editors/predicate-side-editor.component.html
@@ -1,0 +1,34 @@
+<div class="predicate-side" [formGroup]="group">
+  <mat-form-field appearance="outline" class="side-kind-field">
+    <mat-label>{{ label }} type</mat-label>
+    <mat-select formControlName="side_kind">
+      <mat-option value="indicator">Indicator</mat-option>
+      <mat-option value="bar_field">Bar field</mat-option>
+      @if (allowNumber) {
+        <mat-option value="number">Constant</mat-option>
+      }
+    </mat-select>
+  </mat-form-field>
+
+  @switch (sideKind) {
+    @case ('indicator') {
+      <app-indicator-ref-editor [group]="indicatorGroup" />
+    }
+    @case ('bar_field') {
+      <mat-form-field appearance="outline" class="bar-field">
+        <mat-label>bar field</mat-label>
+        <mat-select formControlName="bar_field">
+          @for (b of barFields; track b) {
+            <mat-option [value]="b">{{ b }}</mat-option>
+          }
+        </mat-select>
+      </mat-form-field>
+    }
+    @case ('number') {
+      <mat-form-field appearance="outline" class="number-field">
+        <mat-label>value</mat-label>
+        <input matInput type="number" step="any" formControlName="number_val" />
+      </mat-form-field>
+    }
+  }
+</div>

--- a/user-interface/src/app/components/investment-strategy/editors/predicate-side-editor.component.ts
+++ b/user-interface/src/app/components/investment-strategy/editors/predicate-side-editor.component.ts
@@ -1,0 +1,38 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+
+import { BAR_FIELD_OPTIONS } from '../../../models';
+import { IndicatorRefEditorComponent } from './indicator-ref-editor.component';
+
+@Component({
+  selector: 'app-predicate-side-editor',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    IndicatorRefEditorComponent,
+  ],
+  templateUrl: './predicate-side-editor.component.html',
+})
+export class PredicateSideEditorComponent {
+  @Input({ required: true }) group!: FormGroup;
+  @Input() allowNumber = false;
+  @Input() label = 'Side';
+
+  readonly barFields = BAR_FIELD_OPTIONS;
+
+  get sideKind(): string {
+    return (this.group.get('side_kind')?.value ?? 'indicator') as string;
+  }
+
+  get indicatorGroup(): FormGroup {
+    return this.group.get('indicator') as FormGroup;
+  }
+}

--- a/user-interface/src/app/components/investment-strategy/editors/sizing-editor.component.html
+++ b/user-interface/src/app/components/investment-strategy/editors/sizing-editor.component.html
@@ -1,0 +1,36 @@
+<div class="sizing-editor" [formGroup]="group">
+  <mat-form-field appearance="outline" class="kind-field">
+    <mat-label>sizing kind</mat-label>
+    <mat-select formControlName="kind">
+      @for (k of kindOptions; track k) {
+        <mat-option [value]="k">{{ k }}</mat-option>
+      }
+    </mat-select>
+  </mat-form-field>
+
+  @switch (currentKind) {
+    @case ('fixed_fraction') {
+      <mat-form-field appearance="outline" class="num-field">
+        <mat-label>fraction (0–1)</mat-label>
+        <input matInput type="number" min="0" max="1" step="0.001" formControlName="fraction" />
+      </mat-form-field>
+    }
+    @case ('volatility_target') {
+      <mat-form-field appearance="outline" class="num-field">
+        <mat-label>target annualised vol</mat-label>
+        <input matInput type="number" min="0" step="0.001" formControlName="target_annual_vol" />
+      </mat-form-field>
+    }
+    @case ('fixed_notional') {
+      <mat-form-field appearance="outline" class="num-field">
+        <mat-label>notional USD</mat-label>
+        <input matInput type="number" min="0" step="1" formControlName="notional_usd" />
+      </mat-form-field>
+    }
+  }
+
+  <mat-form-field appearance="outline" class="note-field">
+    <mat-label>note (optional)</mat-label>
+    <input matInput formControlName="note" />
+  </mat-form-field>
+</div>

--- a/user-interface/src/app/components/investment-strategy/editors/sizing-editor.component.ts
+++ b/user-interface/src/app/components/investment-strategy/editors/sizing-editor.component.ts
@@ -1,0 +1,65 @@
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { AbstractControl, FormGroup, ReactiveFormsModule, ValidatorFn, Validators } from '@angular/forms';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { Subscription } from 'rxjs';
+
+import { SIZING_KINDS, SizingKind } from '../../../models';
+
+@Component({
+  selector: 'app-sizing-editor',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, MatFormFieldModule, MatInputModule, MatSelectModule],
+  templateUrl: './sizing-editor.component.html',
+})
+export class SizingEditorComponent implements OnInit, OnDestroy {
+  @Input({ required: true }) group!: FormGroup;
+
+  readonly kindOptions = SIZING_KINDS;
+
+  private kindSub?: Subscription;
+
+  ngOnInit(): void {
+    const kindCtrl = this.group.get('kind');
+    if (!kindCtrl) return;
+    this.applyForKind(kindCtrl.value as SizingKind);
+    this.kindSub = kindCtrl.valueChanges.subscribe((kind: SizingKind) => {
+      this.applyForKind(kind);
+    });
+  }
+
+  ngOnDestroy(): void {
+    this.kindSub?.unsubscribe();
+  }
+
+  get currentKind(): SizingKind {
+    return (this.group.get('kind')?.value ?? 'fixed_fraction') as SizingKind;
+  }
+
+  private setValidators(name: string, validators: ValidatorFn[]): void {
+    const ctrl: AbstractControl | null = this.group.get(name);
+    if (!ctrl) return;
+    ctrl.setValidators(validators.length ? validators : null);
+    ctrl.updateValueAndValidity({ emitEvent: false });
+  }
+
+  private applyForKind(kind: SizingKind): void {
+    this.setValidators('fraction', []);
+    this.setValidators('target_annual_vol', []);
+    this.setValidators('notional_usd', []);
+
+    switch (kind) {
+      case 'fixed_fraction':
+        this.setValidators('fraction', [Validators.required, Validators.min(0.0000001), Validators.max(1.0)]);
+        break;
+      case 'volatility_target':
+        this.setValidators('target_annual_vol', [Validators.required, Validators.min(0.0000001)]);
+        break;
+      case 'fixed_notional':
+        this.setValidators('notional_usd', [Validators.required, Validators.min(0.0000001)]);
+        break;
+    }
+  }
+}

--- a/user-interface/src/app/components/investment-strategy/editors/strategy-validators.ts
+++ b/user-interface/src/app/components/investment-strategy/editors/strategy-validators.ts
@@ -1,0 +1,14 @@
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+/**
+ * Reject non-integer numeric values. Used for indicator params declared as
+ * `kind: 'int'` in INDICATOR_SPECS — the backend Pydantic validator rejects
+ * floats, so we surface that as a client-side error instead of a 422.
+ */
+export const integerValidator: ValidatorFn = (ctrl: AbstractControl): ValidationErrors | null => {
+  const v = ctrl.value;
+  if (v === null || v === undefined || v === '') return null;
+  const n = Number(v);
+  if (!Number.isFinite(n) || !Number.isInteger(n)) return { notInteger: true };
+  return null;
+};

--- a/user-interface/src/app/components/investment-strategy/investment-strategy.component.html
+++ b/user-interface/src/app/components/investment-strategy/investment-strategy.component.html
@@ -83,7 +83,7 @@
               <mat-icon>add</mat-icon> Add entry rule
             </button>
           </div>
-          @for (ctrl of entryRulesArray.controls; track $index; let i = $index) {
+          @for (ctrl of entryRulesArray.controls; track ctrl; let i = $index) {
             <app-entry-rule-editor
               class="rule-card"
               [group]="ctrl"
@@ -102,7 +102,7 @@
               <mat-icon>add</mat-icon> Add exit rule
             </button>
           </div>
-          @for (ctrl of exitRulesArray.controls; track $index; let i = $index) {
+          @for (ctrl of exitRulesArray.controls; track ctrl; let i = $index) {
             <app-exit-rule-editor
               class="rule-card"
               [group]="ctrl"

--- a/user-interface/src/app/components/investment-strategy/investment-strategy.component.html
+++ b/user-interface/src/app/components/investment-strategy/investment-strategy.component.html
@@ -18,6 +18,13 @@
         </div>
       }
 
+      @if (hasPrefillErrors) {
+        <div class="error-banner" data-testid="prefill-errors-banner">
+          <mat-icon>error</mat-icon>
+          <span>Cannot edit this strategy — unsupported rule shape: {{ prefillErrors.join(', ') }}</span>
+        </div>
+      }
+
       <form [formGroup]="form">
         <!-- Strategy Definition -->
         <section class="form-section">
@@ -33,12 +40,21 @@
               </mat-select>
             </mat-form-field>
 
-            <div class="toggle-container">
-              <mat-slide-toggle formControlName="speculative">
-                Speculative Strategy
-              </mat-slide-toggle>
-              <span class="toggle-hint">Higher risk strategies subject to IPS sleeve caps</span>
-            </div>
+            <mat-form-field appearance="outline">
+              <mat-label>Timeframe</mat-label>
+              <mat-select formControlName="timeframe">
+                @for (tf of timeframeOptions; track tf) {
+                  <mat-option [value]="tf">{{ tf }}</mat-option>
+                }
+              </mat-select>
+            </mat-form-field>
+          </div>
+
+          <div class="toggle-container">
+            <mat-slide-toggle formControlName="speculative">
+              Speculative Strategy
+            </mat-slide-toggle>
+            <span class="toggle-hint">Higher risk strategies subject to IPS sleeve caps</span>
           </div>
 
           <mat-form-field appearance="outline" class="full-width">
@@ -60,48 +76,47 @@
 
         <mat-divider></mat-divider>
 
-        <!-- Trading Rules — structured DSL (issue #551). A visual rule
-             builder is deferred; edit as JSON for now. -->
         <section class="form-section">
-          <h3>Trading Rules (structured DSL)</h3>
-
-          @if (rulesError) {
-            <div class="error-banner">
-              <mat-icon>error</mat-icon>
-              <span>{{ rulesError }}</span>
-            </div>
+          <div class="section-header">
+            <h3>Entry Rules</h3>
+            <button mat-stroked-button type="button" (click)="addEntryRule()">
+              <mat-icon>add</mat-icon> Add entry rule
+            </button>
+          </div>
+          @for (ctrl of entryRulesArray.controls; track $index; let i = $index) {
+            <app-entry-rule-editor
+              class="rule-card"
+              [group]="ctrl"
+              [index]="i"
+              (remove)="removeEntryRule(i)"
+            />
           }
+        </section>
 
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>Entry Rules (JSON array of EntryRule)</mat-label>
-            <textarea matInput formControlName="entry_rules_json" rows="6" spellcheck="false" placeholder='[
-  {
-    "kind": "entry",
-    "side": "long",
-    "when": {
-      "lhs": {"kind": "price", "field": "close"},
-      "op": "gt",
-      "rhs": {"kind": "sma", "period": 20}
-    }
-  }
-]'></textarea>
-            <mat-hint>JSON array. See spec_dsl.py for the supported shapes.</mat-hint>
-          </mat-form-field>
+        <mat-divider></mat-divider>
 
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>Exit Rules (JSON array of ExitRule)</mat-label>
-            <textarea matInput formControlName="exit_rules_json" rows="6" spellcheck="false" placeholder='[
-  {"kind": "time_stop", "n_bars": 10},
-  {"kind": "stop_loss", "pct": 0.05}
-]'></textarea>
-            <mat-hint>Discriminator field: kind = time_stop | stop_loss | take_profit | signal_exit</mat-hint>
-          </mat-form-field>
+        <section class="form-section">
+          <div class="section-header">
+            <h3>Exit Rules</h3>
+            <button mat-stroked-button type="button" (click)="addExitRule()">
+              <mat-icon>add</mat-icon> Add exit rule
+            </button>
+          </div>
+          @for (ctrl of exitRulesArray.controls; track $index; let i = $index) {
+            <app-exit-rule-editor
+              class="rule-card"
+              [group]="ctrl"
+              [index]="i"
+              (remove)="removeExitRule(i)"
+            />
+          }
+        </section>
 
-          <mat-form-field appearance="outline" class="full-width">
-            <mat-label>Position Sizing (JSON SizingRule)</mat-label>
-            <textarea matInput formControlName="sizing_json" rows="4" spellcheck="false" placeholder='{"kind": "fixed_fraction", "fraction": 0.02}'></textarea>
-            <mat-hint>Discriminator field: kind = fixed_fraction | volatility_target | fixed_notional</mat-hint>
-          </mat-form-field>
+        <mat-divider></mat-divider>
+
+        <section class="form-section">
+          <h3>Position Sizing</h3>
+          <app-sizing-editor [group]="sizingGroup" />
         </section>
       </form>
 
@@ -183,7 +198,7 @@
 
     <mat-card-actions align="end">
       @if (!currentStrategy) {
-        <button mat-raised-button color="primary" (click)="createStrategy()" [disabled]="loading || form.invalid">
+        <button mat-raised-button color="primary" (click)="createStrategy()" [disabled]="loading || form.invalid || hasPrefillErrors">
           @if (loading) {
             Creating...
           } @else {

--- a/user-interface/src/app/components/investment-strategy/investment-strategy.component.scss
+++ b/user-interface/src/app/components/investment-strategy/investment-strategy.component.scss
@@ -96,6 +96,73 @@
   }
 }
 
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+
+  h3 {
+    margin: 0;
+  }
+}
+
+.rule-card {
+  display: block;
+  padding: 12px;
+  margin-bottom: 12px;
+  border: 1px solid var(--mat-sys-outline-variant, rgba(0, 0, 0, 0.12));
+  border-radius: 8px;
+  background: var(--mat-sys-surface-container, rgba(0, 0, 0, 0.02));
+
+  .rule-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 8px;
+
+    .rule-index {
+      font-weight: 600;
+      color: rgba(0, 0, 0, 0.6);
+      min-width: 32px;
+    }
+
+    .remove-btn {
+      margin-left: auto;
+    }
+  }
+
+  .predicate-editor,
+  .predicate-side,
+  .indicator-editor {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    align-items: flex-start;
+  }
+
+  .params-row {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+
+  .note-field {
+    width: 100%;
+  }
+}
+
+.sizing-editor {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: flex-start;
+
+  .note-field {
+    flex: 1 1 100%;
+  }
+}
+
 .validation-panel {
   margin-top: 16px;
 

--- a/user-interface/src/app/components/investment-strategy/investment-strategy.component.spec.ts
+++ b/user-interface/src/app/components/investment-strategy/investment-strategy.component.spec.ts
@@ -250,6 +250,38 @@ describe('InvestmentStrategyComponent', () => {
     expect(params.get('period')).not.toBeNull();
   });
 
+  it('keeps the form valid after adding a time_stop exit rule', async () => {
+    component.form.patchValue({ hypothesis: 'h', signal_definition: 's' });
+    component.addExitRule();
+    fixture.detectChanges();
+
+    // The exit rule defaults to time_stop with n_bars=10. The nested `when`
+    // predicate would otherwise mark the form invalid via its required SMA
+    // params; it must be disabled when kind != signal_exit.
+    expect(component.form.valid).toBe(true);
+
+    await component.createStrategy();
+    const req = httpMock.expectOne(strategiesUrl);
+    expect(req.request.body.exit_rules).toEqual([{ kind: 'time_stop', n_bars: 10 }]);
+    req.flush({
+      strategy_id: 'strat-ts',
+      strategy: baseSpec({ strategy_id: 'strat-ts' }),
+      message: 'ok',
+    });
+  });
+
+  it('rejects fractional n_bars on time_stop exit rules', () => {
+    component.form.patchValue({ hypothesis: 'h', signal_definition: 's' });
+    component.addExitRule();
+    fixture.detectChanges();
+
+    const rule = component.exitRulesArray.at(0);
+    rule.get('n_bars')!.setValue(1.5);
+
+    expect(rule.get('n_bars')!.hasError('notInteger')).toBe(true);
+    expect(component.form.valid).toBe(false);
+  });
+
   it('flags an unknown exit-rule kind', () => {
     const spec = baseSpec({
       exit_rules: [{ kind: 'gibberish' } as unknown as StrategySpec['exit_rules'][number]],

--- a/user-interface/src/app/components/investment-strategy/investment-strategy.component.spec.ts
+++ b/user-interface/src/app/components/investment-strategy/investment-strategy.component.spec.ts
@@ -1,12 +1,49 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideHttpClient } from '@angular/common/http';
-import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+
 import { InvestmentStrategyComponent } from './investment-strategy.component';
+import { AuditContext, StrategySpec } from '../../models';
+import { environment } from '../../../environments/environment';
+
+function emptyAudit(): AuditContext {
+  return {
+    data_snapshot_id: '',
+    assumptions: [],
+    calc_artifacts: [],
+    gate_trace: [],
+    agent_versions: {},
+  };
+}
+
+function baseSpec(overrides: Partial<StrategySpec> = {}): StrategySpec {
+  return {
+    strategy_id: 'strat-1',
+    authored_by: 'tester',
+    asset_class: 'equities',
+    hypothesis: 'h',
+    signal_definition: 's',
+    timeframe: '1d',
+    entry_rules: [],
+    exit_rules: [],
+    sizing: { kind: 'fixed_fraction', fraction: 0.02 },
+    target_symbols: [],
+    risk_limits: {},
+    speculative: false,
+    requires_redesign: false,
+    unparsed_rules: [],
+    audit: emptyAudit(),
+    ...overrides,
+  };
+}
 
 describe('InvestmentStrategyComponent', () => {
   let component: InvestmentStrategyComponent;
   let fixture: ComponentFixture<InvestmentStrategyComponent>;
+  let httpMock: HttpTestingController;
+
+  const strategiesUrl = `${environment.investmentApiUrl}/strategies`;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
@@ -16,10 +53,133 @@ describe('InvestmentStrategyComponent', () => {
 
     fixture = TestBed.createComponent(InvestmentStrategyComponent);
     component = fixture.componentInstance;
+    httpMock = TestBed.inject(HttpTestingController);
     fixture.detectChanges();
   });
 
-  it('should create', () => {
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('creates without errors', () => {
     expect(component).toBeTruthy();
+    expect(component.entryRulesArray.length).toBe(0);
+    expect(component.exitRulesArray.length).toBe(0);
+    expect(component.hasPrefillErrors).toBe(false);
+  });
+
+  it('submits empty entry_rules and default fixed_fraction sizing', async () => {
+    component.form.patchValue({
+      hypothesis: 'mean reversion',
+      signal_definition: 'rsi',
+    });
+
+    await component.createStrategy();
+
+    const req = httpMock.expectOne(strategiesUrl);
+    expect(req.request.method).toBe('POST');
+    expect(req.request.body.entry_rules).toEqual([]);
+    expect(req.request.body.exit_rules).toEqual([]);
+    expect(req.request.body.timeframe).toBe('1d');
+    expect(req.request.body.sizing).toEqual({ kind: 'fixed_fraction', fraction: 0.02 });
+    expect(req.request.body.asset_class).toBe('equities');
+    expect(req.request.body.speculative).toBe(false);
+
+    req.flush({
+      strategy_id: 'strat-x',
+      strategy: baseSpec({ strategy_id: 'strat-x' }),
+      message: 'ok',
+    });
+  });
+
+  it('serialises an RSI(14) < 30 entry rule as structured DSL', async () => {
+    component.form.patchValue({
+      hypothesis: 'h',
+      signal_definition: 's',
+    });
+    component.addEntryRule();
+    const rule = component.entryRulesArray.at(0);
+
+    rule.patchValue({ side: 'long' });
+    const when = rule.get('when')!;
+    const lhs = when.get('lhs')!;
+    lhs.patchValue({ side_kind: 'indicator' });
+    const indicator = lhs.get('indicator')!;
+    indicator.patchValue({ name: 'rsi' });
+    indicator.get('params')!.patchValue({ period: 14 });
+
+    when.patchValue({ op: '<' });
+
+    const rhs = when.get('rhs')!;
+    rhs.patchValue({ side_kind: 'number', number_val: 30 });
+
+    await component.createStrategy();
+
+    const req = httpMock.expectOne(strategiesUrl);
+    expect(req.request.body.entry_rules).toHaveLength(1);
+    expect(req.request.body.entry_rules[0]).toEqual({
+      kind: 'entry',
+      side: 'long',
+      when: {
+        lhs: { name: 'rsi', params: { period: 14 }, source: 'close' },
+        op: '<',
+        rhs: 30,
+      },
+    });
+
+    req.flush({
+      strategy_id: 'strat-y',
+      strategy: baseSpec({ strategy_id: 'strat-y' }),
+      message: 'ok',
+    });
+  });
+
+  it('prefills a TimeStopRule into the exit-rules array', () => {
+    const spec = baseSpec({
+      exit_rules: [{ kind: 'time_stop', n_bars: 10, note: '' }],
+    });
+    component.populateForm(spec);
+
+    expect(component.exitRulesArray.length).toBe(1);
+    const row = component.exitRulesArray.at(0);
+    expect(row.get('kind')!.value).toBe('time_stop');
+    expect(row.get('n_bars')!.value).toBe(10);
+    expect(component.hasPrefillErrors).toBe(false);
+  });
+
+  it('flags an unknown indicator name and blocks submit', async () => {
+    const spec = baseSpec({
+      entry_rules: [
+        {
+          kind: 'entry',
+          side: 'long',
+          when: {
+            lhs: { name: 'not_real' as unknown as 'sma', params: {} },
+            op: '<',
+            rhs: 30,
+          },
+        },
+      ],
+    });
+
+    component.populateForm(spec);
+
+    expect(component.hasPrefillErrors).toBe(true);
+    expect(component.prefillErrors.some((e) => e.includes('not_real'))).toBe(true);
+
+    await component.createStrategy();
+    httpMock.expectNone(strategiesUrl);
+  });
+
+  it('flags an unknown exit-rule kind', () => {
+    const spec = baseSpec({
+      exit_rules: [{ kind: 'gibberish' } as unknown as StrategySpec['exit_rules'][number]],
+    });
+
+    component.populateForm(spec);
+
+    expect(component.hasPrefillErrors).toBe(true);
+    expect(component.prefillErrors).toContain('exit_rule:gibberish');
+    expect(component.exitRulesArray.length).toBe(0);
   });
 });

--- a/user-interface/src/app/components/investment-strategy/investment-strategy.component.spec.ts
+++ b/user-interface/src/app/components/investment-strategy/investment-strategy.component.spec.ts
@@ -282,6 +282,46 @@ describe('InvestmentStrategyComponent', () => {
     expect(component.form.valid).toBe(false);
   });
 
+  it('drops blank optional indicator params from the wire payload', async () => {
+    component.form.patchValue({ hypothesis: 'h', signal_definition: 's' });
+    component.addEntryRule();
+    // Mount the child editor so its name.valueChanges subscription rebuilds
+    // params for RSI (where `period` is optional) instead of leaving the
+    // default SMA shape (where `period` is required).
+    fixture.detectChanges();
+
+    const rule = component.entryRulesArray.at(0);
+    const lhs = rule.get('when')!.get('lhs')!;
+    lhs.patchValue({ side_kind: 'indicator' });
+    const indicator = lhs.get('indicator')!;
+    indicator.patchValue({ name: 'rsi' });
+    fixture.detectChanges();
+
+    // User clears the optional `period` field. The control passes validation
+    // (no required validator) but {period: null} would be rejected by the
+    // backend's int|float|str Pydantic validator if the serializer let it
+    // through.
+    indicator.get('params')!.patchValue({ period: null });
+
+    const rhs = rule.get('when')!.get('rhs')!;
+    rhs.patchValue({ side_kind: 'number', number_val: 30 });
+
+    expect(component.form.valid).toBe(true);
+
+    await component.createStrategy();
+    const req = httpMock.expectOne(strategiesUrl);
+    const lhsPayload = req.request.body.entry_rules[0].when.lhs;
+    expect(lhsPayload.name).toBe('rsi');
+    expect(lhsPayload.params).toEqual({});
+    expect('period' in lhsPayload.params).toBe(false);
+
+    req.flush({
+      strategy_id: 'strat-drop',
+      strategy: baseSpec({ strategy_id: 'strat-drop' }),
+      message: 'ok',
+    });
+  });
+
   it('flags an unknown exit-rule kind', () => {
     const spec = baseSpec({
       exit_rules: [{ kind: 'gibberish' } as unknown as StrategySpec['exit_rules'][number]],

--- a/user-interface/src/app/components/investment-strategy/investment-strategy.component.spec.ts
+++ b/user-interface/src/app/components/investment-strategy/investment-strategy.component.spec.ts
@@ -213,6 +213,43 @@ describe('InvestmentStrategyComponent', () => {
     httpMock.expectNone(strategiesUrl);
   });
 
+  it('rejects fractional values for integer indicator params', () => {
+    component.addEntryRule();
+    const rule = component.entryRulesArray.at(0);
+    const indicator = rule.get('when')!.get('lhs')!.get('indicator')!;
+    indicator.patchValue({ name: 'sma' });
+    indicator.get('params')!.patchValue({ period: 2.5 });
+
+    expect(indicator.get('params')!.get('period')!.hasError('notInteger')).toBe(true);
+    expect(component.form.valid).toBe(false);
+  });
+
+  it('preserves entry-rule subscriptions when a non-last row is removed', async () => {
+    component.form.patchValue({ hypothesis: 'h', signal_definition: 's' });
+    component.addEntryRule();
+    component.addEntryRule();
+    fixture.detectChanges();
+
+    component.removeEntryRule(0);
+    fixture.detectChanges();
+
+    expect(component.entryRulesArray.length).toBe(1);
+
+    // The remaining row's indicator name swap must still rebuild params
+    // correctly (i.e. the child editor's name.valueChanges subscription
+    // is still attached to the surviving FormGroup, not the destroyed one).
+    const rule = component.entryRulesArray.at(0);
+    const indicator = rule.get('when')!.get('lhs')!.get('indicator')!;
+    indicator.patchValue({ name: 'rsi' });
+    fixture.detectChanges();
+
+    const params = indicator.get('params')!;
+    // RSI's spec has a `period` param (default 14); SMA had one too but
+    // with a different validator profile. Either way, after the swap the
+    // params group must still contain `period`.
+    expect(params.get('period')).not.toBeNull();
+  });
+
   it('flags an unknown exit-rule kind', () => {
     const spec = baseSpec({
       exit_rules: [{ kind: 'gibberish' } as unknown as StrategySpec['exit_rules'][number]],

--- a/user-interface/src/app/components/investment-strategy/investment-strategy.component.spec.ts
+++ b/user-interface/src/app/components/investment-strategy/investment-strategy.component.spec.ts
@@ -171,6 +171,48 @@ describe('InvestmentStrategyComponent', () => {
     httpMock.expectNone(strategiesUrl);
   });
 
+  it('preserves prefilled indicator params (does not reset to spec defaults)', () => {
+    const spec = baseSpec({
+      entry_rules: [
+        {
+          kind: 'entry',
+          side: 'long',
+          when: {
+            lhs: { name: 'rsi', params: { period: 7 }, source: 'close' },
+            op: '<',
+            rhs: 30,
+          },
+        },
+      ],
+    });
+
+    component.populateForm(spec);
+    fixture.detectChanges();
+
+    expect(component.hasPrefillErrors).toBe(false);
+    const indicator = component.entryRulesArray
+      .at(0)
+      .get('when')!
+      .get('lhs')!
+      .get('indicator')!;
+    expect(indicator.get('name')!.value).toBe('rsi');
+    expect(indicator.get('params')!.get('period')!.value).toBe(7);
+  });
+
+  it('blocks submit when an RHS constant is left blank', async () => {
+    component.form.patchValue({ hypothesis: 'h', signal_definition: 's' });
+    component.addEntryRule();
+    const rule = component.entryRulesArray.at(0);
+    const rhs = rule.get('when')!.get('rhs')!;
+    rhs.patchValue({ side_kind: 'number', number_val: null });
+
+    expect(rule.valid).toBe(false);
+    expect(component.form.valid).toBe(false);
+
+    await component.createStrategy();
+    httpMock.expectNone(strategiesUrl);
+  });
+
   it('flags an unknown exit-rule kind', () => {
     const spec = baseSpec({
       exit_rules: [{ kind: 'gibberish' } as unknown as StrategySpec['exit_rules'][number]],

--- a/user-interface/src/app/components/investment-strategy/investment-strategy.component.ts
+++ b/user-interface/src/app/components/investment-strategy/investment-strategy.component.ts
@@ -464,12 +464,18 @@ export class InvestmentStrategyComponent implements OnInit {
     }
     const indicator = raw['indicator'] as Record<string, unknown>;
     const params = { ...(indicator['params'] as Record<string, unknown>) };
-    // Cast string numerics to numbers for int/float params per the spec registry.
     const name = indicator['name'] as IndicatorName;
     const spec = INDICATOR_SPECS[name];
     for (const p of spec?.params ?? []) {
-      if (p.kind !== 'enum' && params[p.key] !== null && params[p.key] !== undefined) {
-        params[p.key] = Number(params[p.key]);
+      const v = params[p.key];
+      // Drop blank optional params so the backend applies its own default;
+      // otherwise {period: null} fails the Pydantic int|float|str validator.
+      if (v === null || v === undefined || v === '') {
+        delete params[p.key];
+        continue;
+      }
+      if (p.kind !== 'enum') {
+        params[p.key] = Number(v);
       }
     }
     return {

--- a/user-interface/src/app/components/investment-strategy/investment-strategy.component.ts
+++ b/user-interface/src/app/components/investment-strategy/investment-strategy.component.ts
@@ -222,15 +222,21 @@ export class InvestmentStrategyComponent implements OnInit {
       indicator?.enable(opts);
       barField?.disable(opts);
       number?.disable(opts);
+      number?.clearValidators();
     } else if (kind === 'bar_field') {
       indicator?.disable(opts);
       barField?.enable(opts);
       number?.disable(opts);
+      number?.clearValidators();
     } else if (kind === 'number') {
       indicator?.disable(opts);
       barField?.disable(opts);
       number?.enable(opts);
+      // Blank constants must block submit; without this, Number(null) → 0
+      // silently lands as a 0-valued predicate threshold.
+      number?.setValidators([Validators.required]);
     }
+    number?.updateValueAndValidity(opts);
   }
 
   buildPredicateGroup(initial?: Predicate): FormGroup {

--- a/user-interface/src/app/components/investment-strategy/investment-strategy.component.ts
+++ b/user-interface/src/app/components/investment-strategy/investment-strategy.component.ts
@@ -41,6 +41,7 @@ import {
 import { EntryRuleEditorComponent } from './editors/entry-rule-editor.component';
 import { ExitRuleEditorComponent } from './editors/exit-rule-editor.component';
 import { SizingEditorComponent } from './editors/sizing-editor.component';
+import { integerValidator } from './editors/strategy-validators';
 
 const ALLOWED_EXIT_KINDS: ReadonlySet<string> = new Set(EXIT_RULE_KINDS);
 const ALLOWED_SIZING_KINDS: ReadonlySet<string> = new Set(SIZING_KINDS);
@@ -166,6 +167,7 @@ export class InvestmentStrategyComponent implements OnInit {
         if (p.min !== undefined) validators.push(Validators.min(p.min));
         if (p.max !== undefined) validators.push(Validators.max(p.max));
       }
+      if (p.kind === 'int') validators.push(integerValidator);
       paramsGroup.addControl(p.key, new FormControl(value, validators));
     }
     const sourceCtrl = new FormControl(initial?.source ?? 'close');

--- a/user-interface/src/app/components/investment-strategy/investment-strategy.component.ts
+++ b/user-interface/src/app/components/investment-strategy/investment-strategy.component.ts
@@ -268,7 +268,7 @@ export class InvestmentStrategyComponent implements OnInit {
     const basis = initial && initial.kind === 'stop_loss' ? (initial.basis ?? 'entry_price') : 'entry_price';
     const whenSeed = initial && initial.kind === 'signal_exit' ? initial.when : undefined;
 
-    return this.fb.group({
+    const group = this.fb.group({
       kind: [kind, Validators.required],
       n_bars: [nBars],
       pct: [pct],
@@ -276,6 +276,15 @@ export class InvestmentStrategyComponent implements OnInit {
       when: this.buildPredicateGroup(whenSeed),
       note: [initial?.note ?? ''],
     });
+
+    // The `when` predicate is only relevant to signal_exit. For other kinds
+    // it carries default required IndicatorRef params that would otherwise
+    // keep the form invalid (and the submit button disabled).
+    if (kind !== 'signal_exit') {
+      group.get('when')!.disable({ emitEvent: false });
+    }
+
+    return group;
   }
 
   buildSizingGroup(initial?: SizingRule): FormGroup {

--- a/user-interface/src/app/components/investment-strategy/investment-strategy.component.ts
+++ b/user-interface/src/app/components/investment-strategy/investment-strategy.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Output, EventEmitter, inject, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { FormsModule, ReactiveFormsModule, FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule, FormArray, FormBuilder, FormControl, FormGroup, Validators } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
@@ -22,9 +22,29 @@ import {
   ValidateStrategyResponse,
   EntryRule,
   ExitRule,
+  ExitRuleKind,
+  SizingKind,
   SizingRule,
-  FixedFractionSizing,
+  Predicate,
+  PredicateSide,
+  IndicatorRef,
+  IndicatorName,
+  BarFieldRef,
+  ComparisonOp,
+  StrategyTimeframe,
+  INDICATOR_SPECS,
+  STRATEGY_TIMEFRAME_OPTIONS,
+  EXIT_RULE_KINDS,
+  SIZING_KINDS,
 } from '../../models';
+
+import { EntryRuleEditorComponent } from './editors/entry-rule-editor.component';
+import { ExitRuleEditorComponent } from './editors/exit-rule-editor.component';
+import { SizingEditorComponent } from './editors/sizing-editor.component';
+
+const ALLOWED_EXIT_KINDS: ReadonlySet<string> = new Set(EXIT_RULE_KINDS);
+const ALLOWED_SIZING_KINDS: ReadonlySet<string> = new Set(SIZING_KINDS);
+const BAR_FIELDS: ReadonlySet<string> = new Set(['bar.close', 'bar.high', 'bar.low', 'bar.volume']);
 
 @Component({
   selector: 'app-investment-strategy',
@@ -46,6 +66,9 @@ import {
     MatExpansionModule,
     MatListModule,
     MatTooltipModule,
+    EntryRuleEditorComponent,
+    ExitRuleEditorComponent,
+    SizingEditorComponent,
   ],
   templateUrl: './investment-strategy.component.html',
   styleUrl: './investment-strategy.component.scss',
@@ -59,6 +82,7 @@ export class InvestmentStrategyComponent implements OnInit {
   private readonly fb = inject(FormBuilder);
 
   readonly assetClasses = ['equities', 'bonds', 'crypto', 'options', 'forex', 'commodities', 'multi_asset'];
+  readonly timeframeOptions = STRATEGY_TIMEFRAME_OPTIONS;
 
   loading = false;
   validating = false;
@@ -67,24 +91,16 @@ export class InvestmentStrategyComponent implements OnInit {
   currentStrategy: StrategySpec | null = null;
   validationResult: ValidateStrategyResponse | null = null;
 
-  // Issue #551 — the backend's StrategySpec now uses structured DSL types
-  // (EntryRule[], ExitRule[], SizingRule). Building a full visual rule editor
-  // is deferred; for now this component edits the three rule fields as JSON.
-  // The textareas are validated on submit and any parse / schema error is
-  // surfaced inline.
-  readonly defaultEntryRulesJson = '[]';
-  readonly defaultExitRulesJson = '[]';
-  readonly defaultSizingJson = '{\n  "kind": "fixed_fraction",\n  "fraction": 0.02\n}';
-
-  rulesError: string | null = null;
+  prefillErrors: string[] = [];
 
   form: FormGroup = this.fb.group({
     asset_class: ['equities', Validators.required],
     hypothesis: ['', Validators.required],
     signal_definition: ['', Validators.required],
-    entry_rules_json: [this.defaultEntryRulesJson],
-    exit_rules_json: [this.defaultExitRulesJson],
-    sizing_json: [this.defaultSizingJson],
+    timeframe: ['1d' as StrategyTimeframe, Validators.required],
+    entry_rules: this.fb.array<FormGroup>([]),
+    exit_rules: this.fb.array<FormGroup>([]),
+    sizing: this.buildSizingGroup(),
     speculative: [false],
   });
 
@@ -95,23 +111,226 @@ export class InvestmentStrategyComponent implements OnInit {
     }
   }
 
+  // ---- Template helpers ---------------------------------------------------
+
+  get entryRulesArray(): FormArray<FormGroup> {
+    return this.form.get('entry_rules') as FormArray<FormGroup>;
+  }
+
+  get exitRulesArray(): FormArray<FormGroup> {
+    return this.form.get('exit_rules') as FormArray<FormGroup>;
+  }
+
+  get sizingGroup(): FormGroup {
+    return this.form.get('sizing') as FormGroup;
+  }
+
+  get hasPrefillErrors(): boolean {
+    return this.prefillErrors.length > 0;
+  }
+
+  addEntryRule(): void {
+    this.entryRulesArray.push(this.buildEntryRuleGroup());
+  }
+
+  removeEntryRule(i: number): void {
+    this.entryRulesArray.removeAt(i);
+  }
+
+  addExitRule(): void {
+    this.exitRulesArray.push(this.buildExitRuleGroup());
+  }
+
+  removeExitRule(i: number): void {
+    this.exitRulesArray.removeAt(i);
+  }
+
+  // ---- Form-group builders ------------------------------------------------
+
+  buildIndicatorGroup(initial?: IndicatorRef): FormGroup {
+    const name = (initial?.name && INDICATOR_SPECS[initial.name as IndicatorName] ? initial.name : 'sma') as IndicatorName;
+    if (initial?.name && !INDICATOR_SPECS[initial.name as IndicatorName]) {
+      this.prefillErrors.push(`indicator:${initial.name}`);
+    }
+    const paramsGroup = this.fb.group({});
+    const spec = INDICATOR_SPECS[name];
+    for (const p of spec.params) {
+      const seeded = initial?.params?.[p.key];
+      const value =
+        seeded !== undefined
+          ? seeded
+          : (p.default ?? (p.kind === 'enum' ? (p.options?.[0] ?? null) : null));
+      const validators = [];
+      if (p.required) validators.push(Validators.required);
+      if (p.kind !== 'enum') {
+        if (p.min !== undefined) validators.push(Validators.min(p.min));
+        if (p.max !== undefined) validators.push(Validators.max(p.max));
+      }
+      paramsGroup.addControl(p.key, new FormControl(value, validators));
+    }
+    const sourceCtrl = new FormControl(initial?.source ?? 'close');
+    if (!spec.allowSource) sourceCtrl.disable();
+    return this.fb.group({
+      name: [name, Validators.required],
+      params: paramsGroup,
+      source: sourceCtrl,
+    });
+  }
+
+  buildPredicateSideGroup(initial?: PredicateSide | number): FormGroup {
+    let sideKind: 'indicator' | 'bar_field' | 'number' = 'indicator';
+    let indicatorSeed: IndicatorRef | undefined;
+    let barFieldSeed: BarFieldRef = 'bar.close';
+    let numberSeed: number | null = null;
+
+    if (typeof initial === 'number') {
+      sideKind = 'number';
+      numberSeed = initial;
+    } else if (typeof initial === 'string') {
+      if (BAR_FIELDS.has(initial)) {
+        sideKind = 'bar_field';
+        barFieldSeed = initial as BarFieldRef;
+      } else {
+        this.prefillErrors.push(`bar_field:${initial}`);
+      }
+    } else if (initial && typeof initial === 'object' && 'name' in initial) {
+      sideKind = 'indicator';
+      indicatorSeed = initial as IndicatorRef;
+    }
+
+    const group = this.fb.group({
+      side_kind: [sideKind, Validators.required],
+      indicator: this.buildIndicatorGroup(indicatorSeed),
+      bar_field: [barFieldSeed],
+      number_val: [numberSeed],
+    });
+
+    this.applySideKindEnablement(group, sideKind);
+    group.get('side_kind')!.valueChanges.subscribe((kind: string | null) => {
+      this.applySideKindEnablement(group, kind ?? 'indicator');
+    });
+
+    return group;
+  }
+
+  private applySideKindEnablement(group: FormGroup, kind: string): void {
+    const indicator = group.get('indicator');
+    const barField = group.get('bar_field');
+    const number = group.get('number_val');
+    const opts = { emitEvent: false };
+    if (kind === 'indicator') {
+      indicator?.enable(opts);
+      barField?.disable(opts);
+      number?.disable(opts);
+    } else if (kind === 'bar_field') {
+      indicator?.disable(opts);
+      barField?.enable(opts);
+      number?.disable(opts);
+    } else if (kind === 'number') {
+      indicator?.disable(opts);
+      barField?.disable(opts);
+      number?.enable(opts);
+    }
+  }
+
+  buildPredicateGroup(initial?: Predicate): FormGroup {
+    return this.fb.group({
+      lhs: this.buildPredicateSideGroup(initial?.lhs),
+      op: [(initial?.op ?? '<') as ComparisonOp, Validators.required],
+      rhs: this.buildPredicateSideGroup(initial?.rhs),
+    });
+  }
+
+  buildEntryRuleGroup(initial?: EntryRule): FormGroup {
+    return this.fb.group({
+      kind: ['entry'],
+      side: [initial?.side ?? 'long', Validators.required],
+      when: this.buildPredicateGroup(initial?.when),
+      note: [initial?.note ?? ''],
+    });
+  }
+
+  buildExitRuleGroup(initial?: ExitRule): FormGroup {
+    const kind = (initial?.kind && ALLOWED_EXIT_KINDS.has(initial.kind) ? initial.kind : 'time_stop') as ExitRuleKind;
+    const nBars = initial && initial.kind === 'time_stop' ? initial.n_bars : 10;
+    const pct =
+      initial && (initial.kind === 'stop_loss' || initial.kind === 'take_profit')
+        ? initial.pct
+        : 0.05;
+    const basis = initial && initial.kind === 'stop_loss' ? (initial.basis ?? 'entry_price') : 'entry_price';
+    const whenSeed = initial && initial.kind === 'signal_exit' ? initial.when : undefined;
+
+    return this.fb.group({
+      kind: [kind, Validators.required],
+      n_bars: [nBars],
+      pct: [pct],
+      basis: [basis],
+      when: this.buildPredicateGroup(whenSeed),
+      note: [initial?.note ?? ''],
+    });
+  }
+
+  buildSizingGroup(initial?: SizingRule): FormGroup {
+    let kind: SizingKind = 'fixed_fraction';
+    if (initial && ALLOWED_SIZING_KINDS.has(initial.kind)) {
+      kind = initial.kind;
+    } else if (initial) {
+      this.prefillErrors.push(`sizing:${initial.kind}`);
+    }
+    const fraction = initial && initial.kind === 'fixed_fraction' ? initial.fraction : 0.02;
+    const targetVol = initial && initial.kind === 'volatility_target' ? initial.target_annual_vol : 0.15;
+    const notional = initial && initial.kind === 'fixed_notional' ? initial.notional_usd : 10000;
+
+    return this.fb.group({
+      kind: [kind, Validators.required],
+      fraction: [fraction],
+      target_annual_vol: [targetVol],
+      notional_usd: [notional],
+      note: [initial?.note ?? ''],
+    });
+  }
+
+  // ---- Prefill ------------------------------------------------------------
+
   populateForm(strategy: StrategySpec): void {
+    this.prefillErrors = [];
+
     this.form.patchValue({
       asset_class: strategy.asset_class,
       hypothesis: strategy.hypothesis,
       signal_definition: strategy.signal_definition,
-      entry_rules_json: JSON.stringify(strategy.entry_rules ?? [], null, 2),
-      exit_rules_json: JSON.stringify(strategy.exit_rules ?? [], null, 2),
-      sizing_json: JSON.stringify(
-        strategy.sizing ?? ({ kind: 'fixed_fraction', fraction: 0.02 } as FixedFractionSizing),
-        null,
-        2,
-      ),
-      speculative: strategy.speculative,
+      timeframe: strategy.timeframe ?? '1d',
+      speculative: strategy.speculative ?? false,
     });
+
+    this.entryRulesArray.clear();
+    for (const e of strategy.entry_rules ?? []) {
+      this.entryRulesArray.push(this.buildEntryRuleGroup(e));
+    }
+
+    this.exitRulesArray.clear();
+    for (const x of strategy.exit_rules ?? []) {
+      if (!ALLOWED_EXIT_KINDS.has(x.kind)) {
+        this.prefillErrors.push(`exit_rule:${(x as { kind: string }).kind}`);
+        continue;
+      }
+      this.exitRulesArray.push(this.buildExitRuleGroup(x));
+    }
+
+    this.form.setControl('sizing', this.buildSizingGroup(strategy.sizing));
+
+    if (strategy.requires_redesign) {
+      this.prefillErrors.push('backend:requires_redesign');
+    }
+    for (const item of strategy.unparsed_rules ?? []) {
+      this.prefillErrors.push(`unparsed:${item}`);
+    }
   }
 
+  // ---- Submit -------------------------------------------------------------
+
   async createStrategy(): Promise<void> {
+    if (this.hasPrefillErrors) return;
     if (this.form.invalid) {
       this.form.markAllAsTouched();
       return;
@@ -119,35 +338,19 @@ export class InvestmentStrategyComponent implements OnInit {
 
     this.loading = true;
     this.error = null;
-    this.rulesError = null;
 
-    const formValue = this.form.value;
-
-    let entryRules: EntryRule[];
-    let exitRules: ExitRule[];
-    let sizing: SizingRule;
-    try {
-      entryRules = this.parseRulesJson<EntryRule[]>(formValue.entry_rules_json, 'entry_rules', []);
-      exitRules = this.parseRulesJson<ExitRule[]>(formValue.exit_rules_json, 'exit_rules', []);
-      sizing = this.parseRulesJson<SizingRule>(formValue.sizing_json, 'sizing', {
-        kind: 'fixed_fraction',
-        fraction: 0.02,
-      } as FixedFractionSizing);
-    } catch (parseErr) {
-      this.loading = false;
-      this.rulesError = (parseErr as Error).message;
-      return;
-    }
+    const raw = this.form.getRawValue();
 
     const request: CreateStrategyRequest = {
       authored_by: 'ui_user',
-      asset_class: formValue.asset_class,
-      hypothesis: formValue.hypothesis,
-      signal_definition: formValue.signal_definition,
-      entry_rules: entryRules,
-      exit_rules: exitRules,
-      sizing,
-      speculative: formValue.speculative,
+      asset_class: raw.asset_class,
+      hypothesis: raw.hypothesis,
+      signal_definition: raw.signal_definition,
+      timeframe: raw.timeframe,
+      entry_rules: (raw.entry_rules ?? []).map((r: Record<string, unknown>) => this.serializeEntryRule(r)),
+      exit_rules: (raw.exit_rules ?? []).map((r: Record<string, unknown>) => this.serializeExitRule(r)),
+      sizing: this.serializeSizing(raw.sizing),
+      speculative: raw.speculative,
     };
 
     this.api.createStrategy(request).subscribe({
@@ -182,6 +385,85 @@ export class InvestmentStrategyComponent implements OnInit {
     });
   }
 
+  // ---- Serializers --------------------------------------------------------
+
+  private serializeEntryRule(raw: Record<string, unknown>): EntryRule {
+    return {
+      kind: 'entry',
+      side: raw['side'] as 'long' | 'short',
+      when: this.serializePredicate(raw['when'] as Record<string, unknown>),
+      ...(raw['note'] ? { note: raw['note'] as string } : {}),
+    };
+  }
+
+  private serializeExitRule(raw: Record<string, unknown>): ExitRule {
+    const kind = raw['kind'] as ExitRuleKind;
+    const note = raw['note'] ? { note: raw['note'] as string } : {};
+    switch (kind) {
+      case 'time_stop':
+        return { kind, n_bars: Number(raw['n_bars']), ...note };
+      case 'stop_loss':
+        return {
+          kind,
+          pct: Number(raw['pct']),
+          basis: raw['basis'] as 'entry_price' | 'trailing_high' | 'trailing_low',
+          ...note,
+        };
+      case 'take_profit':
+        return { kind, pct: Number(raw['pct']), ...note };
+      case 'signal_exit':
+        return { kind, when: this.serializePredicate(raw['when'] as Record<string, unknown>), ...note };
+    }
+  }
+
+  private serializeSizing(raw: Record<string, unknown>): SizingRule {
+    const kind = raw['kind'] as SizingKind;
+    const note = raw['note'] ? { note: raw['note'] as string } : {};
+    switch (kind) {
+      case 'fixed_fraction':
+        return { kind, fraction: Number(raw['fraction']), ...note };
+      case 'volatility_target':
+        return { kind, target_annual_vol: Number(raw['target_annual_vol']), ...note };
+      case 'fixed_notional':
+        return { kind, notional_usd: Number(raw['notional_usd']), ...note };
+    }
+  }
+
+  private serializePredicate(raw: Record<string, unknown>): Predicate {
+    return {
+      lhs: this.serializeSide(raw['lhs'] as Record<string, unknown>, false) as PredicateSide,
+      op: raw['op'] as ComparisonOp,
+      rhs: this.serializeSide(raw['rhs'] as Record<string, unknown>, true),
+    };
+  }
+
+  private serializeSide(raw: Record<string, unknown>, allowNumber: boolean): PredicateSide | number {
+    const kind = raw['side_kind'] as 'indicator' | 'bar_field' | 'number';
+    if (kind === 'number' && allowNumber) {
+      return Number(raw['number_val']);
+    }
+    if (kind === 'bar_field') {
+      return raw['bar_field'] as BarFieldRef;
+    }
+    const indicator = raw['indicator'] as Record<string, unknown>;
+    const params = { ...(indicator['params'] as Record<string, unknown>) };
+    // Cast string numerics to numbers for int/float params per the spec registry.
+    const name = indicator['name'] as IndicatorName;
+    const spec = INDICATOR_SPECS[name];
+    for (const p of spec?.params ?? []) {
+      if (p.kind !== 'enum' && params[p.key] !== null && params[p.key] !== undefined) {
+        params[p.key] = Number(params[p.key]);
+      }
+    }
+    return {
+      name,
+      params: params as Record<string, number | string>,
+      source: indicator['source'] as IndicatorRef['source'],
+    };
+  }
+
+  // ---- Misc ---------------------------------------------------------------
+
   getCheckIcon(status: string): string {
     switch (status) {
       case 'pass':
@@ -197,15 +479,5 @@ export class InvestmentStrategyComponent implements OnInit {
 
   getCheckClass(status: string): string {
     return `check-${status}`;
-  }
-
-  private parseRulesJson<T>(raw: string, field: string, fallback: T): T {
-    const text = (raw ?? '').trim();
-    if (!text) return fallback;
-    try {
-      return JSON.parse(text) as T;
-    } catch (err) {
-      throw new Error(`${field}: invalid JSON — ${(err as Error).message}`);
-    }
   }
 }

--- a/user-interface/src/app/models/investment.model.ts
+++ b/user-interface/src/app/models/investment.model.ts
@@ -166,61 +166,136 @@ export interface PortfolioProposal {
 }
 
 // ---------------------------------------------------------------------------
-// Strategy DSL (mirrors backend/agents/investment_team/strategy_lab/spec_dsl.py,
-// issue #550). Producers must emit the structured shape — the backend
-// (#551) rejects prose strings on input.
+// Strategy DSL (mirrors backend/agents/investment_team/strategy_lab/spec_dsl.py).
+// Wire-format types: IndicatorRef has the same { name, params, source } shape
+// as the Python Pydantic class. Predicate sides accept either a structured
+// IndicatorRef, a bar-field literal string, or (rhs only) a numeric constant.
 // ---------------------------------------------------------------------------
 
 export type IndicatorSource = 'close' | 'high' | 'low' | 'open' | 'volume' | 'hl2' | 'ohlc4';
-export type ComparisonOp = 'gt' | 'lt' | 'ge' | 'le' | 'eq' | 'cross_above' | 'cross_below';
 
-export interface PriceRef       { kind: 'price'; field?: IndicatorSource; }
-export interface ConstRef       { kind: 'const'; value: number; }
-export interface SMARef         { kind: 'sma'; period: number; source?: IndicatorSource; }
-export interface EMARef         { kind: 'ema'; period: number; source?: IndicatorSource; }
-export interface RSIRef         { kind: 'rsi'; period?: number; source?: IndicatorSource; }
-export interface MACDRef {
-  kind: 'macd';
-  fast?: number;
-  slow?: number;
-  signal?: number;
-  output?: 'macd' | 'signal' | 'histogram';
+export type ComparisonOp = '<' | '>' | '<=' | '>=' | '==' | 'cross_above' | 'cross_below';
+
+export const COMPARISON_OP_OPTIONS: { value: ComparisonOp; label: string }[] = [
+  { value: '<', label: '<' },
+  { value: '>', label: '>' },
+  { value: '<=', label: '<=' },
+  { value: '>=', label: '>=' },
+  { value: '==', label: '==' },
+  { value: 'cross_above', label: 'crosses above' },
+  { value: 'cross_below', label: 'crosses below' },
+];
+
+export type IndicatorName =
+  | 'sma'
+  | 'ema'
+  | 'rsi'
+  | 'macd'
+  | 'bollinger'
+  | 'atr'
+  | 'adx'
+  | 'stochastic'
+  | 'vwap';
+
+export const INDICATOR_NAME_OPTIONS: IndicatorName[] = [
+  'sma', 'ema', 'rsi', 'macd', 'bollinger', 'atr', 'adx', 'stochastic', 'vwap',
+];
+
+export type IndicatorParamValue = number | string;
+
+export interface IndicatorRef {
+  name: IndicatorName;
+  params: Record<string, IndicatorParamValue>;
   source?: IndicatorSource;
 }
-export interface BollingerRef {
-  kind: 'bollinger';
-  period?: number;
-  num_std?: number;
-  band?: 'upper' | 'middle' | 'lower';
-  source?: IndicatorSource;
-}
-export interface ATRRef         { kind: 'atr'; period?: number; }
-export interface ADXRef         { kind: 'adx'; period?: number; }
-export interface StochasticRef  { kind: 'stochastic'; k_period?: number; d_period?: number; output?: 'k' | 'd'; }
-export interface VWAPRef        { kind: 'vwap'; }
 
-export type IndicatorRef =
-  | PriceRef
-  | ConstRef
-  | SMARef
-  | EMARef
-  | RSIRef
-  | MACDRef
-  | BollingerRef
-  | ATRRef
-  | ADXRef
-  | StochasticRef
-  | VWAPRef;
+export type BarFieldRef = 'bar.close' | 'bar.high' | 'bar.low' | 'bar.volume';
+
+export const BAR_FIELD_OPTIONS: BarFieldRef[] = ['bar.close', 'bar.high', 'bar.low', 'bar.volume'];
+
+export const INDICATOR_SOURCE_OPTIONS: IndicatorSource[] = [
+  'close', 'high', 'low', 'open', 'volume', 'hl2', 'ohlc4',
+];
+
+// Mirrors _INDICATOR_PARAM_SPECS in spec_dsl.py — kept in sync because the form
+// needs to know per-indicator which params to render, their bounds, and whether
+// the source override is accepted.
+export interface IndicatorParamSpec {
+  key: string;
+  required: boolean;
+  default?: number | string;
+  kind: 'int' | 'float' | 'enum';
+  min?: number;
+  max?: number;
+  options?: string[];
+}
+
+export interface IndicatorSpec {
+  name: IndicatorName;
+  allowSource: boolean;
+  params: IndicatorParamSpec[];
+}
+
+export const INDICATOR_SPECS: Record<IndicatorName, IndicatorSpec> = {
+  sma: {
+    name: 'sma', allowSource: true,
+    params: [{ key: 'period', required: true, kind: 'int', min: 2, max: 400 }],
+  },
+  ema: {
+    name: 'ema', allowSource: true,
+    params: [{ key: 'period', required: true, kind: 'int', min: 2, max: 400 }],
+  },
+  rsi: {
+    name: 'rsi', allowSource: true,
+    params: [{ key: 'period', required: false, default: 14, kind: 'int', min: 2, max: 200 }],
+  },
+  macd: {
+    name: 'macd', allowSource: true,
+    params: [
+      { key: 'fast', required: false, default: 12, kind: 'int', min: 2, max: 200 },
+      { key: 'slow', required: false, default: 26, kind: 'int', min: 3, max: 400 },
+      { key: 'signal', required: false, default: 9, kind: 'int', min: 2, max: 100 },
+      { key: 'output', required: false, default: 'macd', kind: 'enum', options: ['macd', 'signal', 'histogram'] },
+    ],
+  },
+  bollinger: {
+    name: 'bollinger', allowSource: true,
+    params: [
+      { key: 'period', required: false, default: 20, kind: 'int', min: 5, max: 200 },
+      { key: 'num_std', required: false, default: 2.0, kind: 'float', min: 0.000001 },
+      { key: 'band', required: false, default: 'middle', kind: 'enum', options: ['upper', 'middle', 'lower'] },
+    ],
+  },
+  atr: {
+    name: 'atr', allowSource: false,
+    params: [{ key: 'period', required: false, default: 14, kind: 'int', min: 2, max: 200 }],
+  },
+  adx: {
+    name: 'adx', allowSource: false,
+    params: [{ key: 'period', required: false, default: 14, kind: 'int', min: 2, max: 200 }],
+  },
+  stochastic: {
+    name: 'stochastic', allowSource: false,
+    params: [
+      { key: 'k_period', required: false, default: 14, kind: 'int', min: 2, max: 200 },
+      { key: 'd_period', required: false, default: 3, kind: 'int', min: 1, max: 100 },
+      { key: 'output', required: false, default: 'k', kind: 'enum', options: ['k', 'd'] },
+    ],
+  },
+  vwap: { name: 'vwap', allowSource: false, params: [] },
+};
+
+export type PredicateSide = IndicatorRef | BarFieldRef;
 
 export interface Predicate {
-  lhs: IndicatorRef;
+  lhs: PredicateSide;
   op: ComparisonOp;
-  rhs: IndicatorRef;
+  rhs: PredicateSide | number;
 }
 
 export interface EntryRule {
   kind: 'entry';
-  side?: 'long' | 'short';
+  side: 'long' | 'short';
   when: Predicate;
   note?: string;
 }
@@ -229,16 +304,30 @@ export interface TimeStopRule    { kind: 'time_stop'; n_bars: number; note?: str
 export interface StopLossRule    { kind: 'stop_loss'; pct: number; basis?: 'entry_price' | 'trailing_high' | 'trailing_low'; note?: string; }
 export interface TakeProfitRule  { kind: 'take_profit'; pct: number; note?: string; }
 export interface SignalExitRule  { kind: 'signal_exit'; when: Predicate; note?: string; }
-export interface UnparsableRule  { kind: 'unparsable'; prose: string; reason?: string; }
 
-export type ExitRule = TimeStopRule | StopLossRule | TakeProfitRule | SignalExitRule | UnparsableRule;
+export type ExitRule = TimeStopRule | StopLossRule | TakeProfitRule | SignalExitRule;
+
+export const EXIT_RULE_KINDS = ['time_stop', 'stop_loss', 'take_profit', 'signal_exit'] as const;
+export type ExitRuleKind = typeof EXIT_RULE_KINDS[number];
+
+export type StopLossBasis = 'entry_price' | 'trailing_high' | 'trailing_low';
+
+export const STOP_LOSS_BASIS_OPTIONS: StopLossBasis[] = [
+  'entry_price', 'trailing_high', 'trailing_low',
+];
 
 export interface FixedFractionSizing    { kind: 'fixed_fraction'; fraction: number; note?: string; }
 export interface VolatilityTargetSizing { kind: 'volatility_target'; target_annual_vol: number; note?: string; }
 export interface FixedNotionalSizing    { kind: 'fixed_notional'; notional_usd: number; note?: string; }
-export interface UnparsableSizing       { kind: 'unparsable_sizing'; prose: string; reason?: string; }
 
-export type SizingRule = FixedFractionSizing | VolatilityTargetSizing | FixedNotionalSizing | UnparsableSizing;
+export type SizingRule = FixedFractionSizing | VolatilityTargetSizing | FixedNotionalSizing;
+
+export const SIZING_KINDS = ['fixed_fraction', 'volatility_target', 'fixed_notional'] as const;
+export type SizingKind = typeof SIZING_KINDS[number];
+
+export type StrategyTimeframe = '1m' | '5m' | '15m' | '1h' | '1d';
+
+export const STRATEGY_TIMEFRAME_OPTIONS: StrategyTimeframe[] = ['1m', '5m', '15m', '1h', '1d'];
 
 // ---------------------------------------------------------------------------
 // Strategy Models
@@ -250,12 +339,16 @@ export interface StrategySpec {
   asset_class: string;
   hypothesis: string;
   signal_definition: string;
+  timeframe: StrategyTimeframe;
   entry_rules: EntryRule[];
   exit_rules: ExitRule[];
   sizing: SizingRule;
+  target_symbols: string[];
   risk_limits: Record<string, unknown>;
   speculative: boolean;
   strategy_code?: string;
+  requires_redesign: boolean;
+  unparsed_rules: string[];
   audit: AuditContext;
 }
 
@@ -386,6 +479,7 @@ export interface CreateStrategyRequest {
   asset_class: string;
   hypothesis: string;
   signal_definition: string;
+  timeframe: StrategyTimeframe;
   entry_rules?: EntryRule[];
   exit_rules?: ExitRule[];
   sizing?: SizingRule;


### PR DESCRIPTION
Closes #560.

## Summary

Replace the JSON-textarea workaround in `InvestmentStrategyComponent` with per-rule reactive-form editors split into six child components, and wire `investment.model.ts` to the actual Python wire shape (`spec_dsl.py`).

### Model changes (`investment.model.ts`)
- `IndicatorRef` is now `{ name, params, source }` (the Python wire shape) — not per-kind interfaces with flat fields. New `INDICATOR_SPECS` registry mirrors `_INDICATOR_PARAM_SPECS` so the form knows which params + bounds to render for each indicator name.
- `ComparisonOp` switched from alias names (`gt`, `lt`, …) to wire symbols (`<`, `>`, `<=`, `>=`, `==`, `cross_above`, `cross_below`).
- `Predicate` sides accept indicator | bar-field literal | numeric constant (rhs only) — matching `Union[IndicatorRef, "bar.close" | …, float]` on the backend.
- `StrategySpec` + `CreateStrategyRequest` gain required `timeframe` (the backend already requires it and was 422-ing every submit). Spec also gets `target_symbols`, `requires_redesign`, `unparsed_rules`.
- Drop `UnparsableRule` / `UnparsableSizing` — not part of the DSL.

### New editor components
`user-interface/src/app/components/investment-strategy/editors/`:
- `IndicatorRefEditorComponent` — name dropdown → renders param controls + source from `INDICATOR_SPECS[name]`.
- `PredicateSideEditorComponent` — `side_kind` picker (`indicator | bar_field | number`).
- `PredicateEditorComponent` — lhs / op / rhs.
- `EntryRuleEditorComponent`, `ExitRuleEditorComponent`, `SizingEditorComponent` — kind-driven `@switch` editors with kind-aware validators (`Validators.required` + `min`/`max` swapped on `kind.valueChanges`).

Children take their `FormGroup` via `@Input()` — no `ControlValueAccessor` boilerplate. The host owns the `FormArray`s and the form-group builders (`buildIndicatorGroup`, `buildPredicateSideGroup`, `buildEntryRuleGroup`, …).

### Prefill safety
`populateForm` validates discriminators against allow-lists: unknown indicator names, unknown exit kinds, unknown sizing kinds, plus `strategy.requires_redesign` and `strategy.unparsed_rules` all surface a banner and disable the submit button rather than silently corrupting data on round-trip.

### Submit path
Reads `form.getRawValue()` (so disabled `source` controls on indicators like ATR/ADX/Stochastic/VWAP still surface their value) and serialises directly into the typed `CreateStrategyRequest`. No `JSON.parse`. Predicate-side serializer switches on `side_kind` so disabled branches are ignored.

## Test plan
- [x] `npm test` — 484 tests pass (6 new tests cover #560 acceptance criteria a–d plus a defence-in-depth case for unknown exit kinds).
- [x] `npm run build` — green (pre-existing bundle-size warning unrelated).
- [x] `npm run lint` — green.
- [x] No textarea-driven rule input remains in the strategy form.
- [x] `grep -rn '_spec_to_api' backend/agents/investment_team` returns zero matches (acceptance criterion sanity check).
- [ ] Manual browser smoke: start backend + UI, create a strategy with RSI(14) < 30 entry rule + time_stop(10) exit, verify network tab shows structured DSL; pass response back via `[existingStrategy]` to verify prefill round-trip.

https://claude.ai/code/session_01RPqak8yiSnqnWKyY9KEyPh

---
_Generated by [Claude Code](https://claude.ai/code/session_01RPqak8yiSnqnWKyY9KEyPh)_