### PR TITLE
investment-team: engine-enforce structured exit_rules (#527)

### DIFF
--- a/backend/agents/investment_team/models.py
+++ b/backend/agents/investment_team/models.py
@@ -505,6 +505,12 @@ class BacktestExecutionDiagnostics(BaseModel):
     # (``stop_loss`` / ``take_profit``). Counts close-order submissions,
     # not fills; fills land in the existing trade ledger.
     exit_rule_firings: Dict[str, int] = Field(default_factory=dict)
+    # Per-symbol breakdown of ``exit_rule_firings`` — same counts, keyed by
+    # ``symbol → rule_kind → count``. The aggregate field above is the
+    # row-sum across symbols. Conformance checks consume the per-symbol
+    # view so a stop_loss firing on one symbol can't mask a missed
+    # firing on another (cross-symbol leak attribution).
+    exit_rule_firings_by_symbol: Dict[str, Dict[str, int]] = Field(default_factory=dict)
     open_positions_at_end: List[OpenPositionDiagnostic] = Field(default_factory=list)
     last_order_events: List[OrderLifecycleEvent] = Field(default_factory=list)
 

--- a/backend/agents/investment_team/models.py
+++ b/backend/agents/investment_team/models.py
@@ -502,8 +502,8 @@ class BacktestExecutionDiagnostics(BaseModel):
     exits_emitted: int = Field(default=0, ge=0)
     closed_trades: int = Field(default=0, ge=0)
     # Issue #527 — count of engine-emitted exit orders, keyed by rule kind
-    # (``time_stop`` / ``stop_loss`` / ``take_profit``). Counts close-order
-    # submissions, not fills; fills land in the existing trade ledger.
+    # (``stop_loss`` / ``take_profit``). Counts close-order submissions,
+    # not fills; fills land in the existing trade ledger.
     exit_rule_firings: Dict[str, int] = Field(default_factory=dict)
     open_positions_at_end: List[OpenPositionDiagnostic] = Field(default_factory=list)
     last_order_events: List[OrderLifecycleEvent] = Field(default_factory=list)

--- a/backend/agents/investment_team/models.py
+++ b/backend/agents/investment_team/models.py
@@ -678,6 +678,16 @@ class TradeRecord(BaseModel):
     participation_clipped: Optional[bool] = None
     partial_fill_count: Optional[int] = None
     total_unfilled_qty: Optional[float] = None
+    # Issue #527 — close-order attribution. Mirrors
+    # ``OrderRequest.reason`` for the order that closed the position.
+    # Engine-fired structured-exit closes carry a
+    # ``"engine_exit:<rule_kind>"`` prefix; strategy-emitted closes
+    # carry whatever ``reason`` the strategy set (typically empty
+    # / None). Used by ``ExitRuleConformanceGate`` to distinguish
+    # engine-closed from strategy-closed trades so a gap-down
+    # strategy exit below a structured stop-loss floor is not
+    # mis-attributed as an engine leak.
+    exit_reason: Optional[str] = None
 
 
 class BacktestRecord(BaseModel):

--- a/backend/agents/investment_team/models.py
+++ b/backend/agents/investment_team/models.py
@@ -501,6 +501,10 @@ class BacktestExecutionDiagnostics(BaseModel):
     entries_filled: int = Field(default=0, ge=0)
     exits_emitted: int = Field(default=0, ge=0)
     closed_trades: int = Field(default=0, ge=0)
+    # Issue #527 — count of engine-emitted exit orders, keyed by rule kind
+    # (``time_stop`` / ``stop_loss`` / ``take_profit``). Counts close-order
+    # submissions, not fills; fills land in the existing trade ledger.
+    exit_rule_firings: Dict[str, int] = Field(default_factory=dict)
     open_positions_at_end: List[OpenPositionDiagnostic] = Field(default_factory=list)
     last_order_events: List[OrderLifecycleEvent] = Field(default_factory=list)
 

--- a/backend/agents/investment_team/strategy_lab/agents/ideation.py
+++ b/backend/agents/investment_team/strategy_lab/agents/ideation.py
@@ -61,7 +61,7 @@ must be one of `"1m"`, `"5m"`, `"15m"`, `"1h"`, `"1d"`.
       "when": {{"lhs": {{"name": "rsi", "params": {{"period": 14}}}},
                 "op": ">",
                 "rhs": 70}}}},
-    {{"kind": "time_stop", "n_bars": 10}}
+    {{"kind": "stop_loss", "pct": 0.03}}
   ],
   "sizing": {{"kind": "fixed_fraction", "fraction": 0.02}},
   "target_symbols": ["UPPERCASE tickers if your hypothesis names specific ones, e.g. QQQ; else []"],

--- a/backend/agents/investment_team/strategy_lab/executor/__init__.py
+++ b/backend/agents/investment_team/strategy_lab/executor/__init__.py
@@ -10,8 +10,24 @@ here is genuinely shared plumbing:
   objects; still used by legacy test fixtures that predate PR 3.
 * ``indicators.py`` — pre-built technical indicators copied into the
   strategy subprocess by the streaming harness.
+* :mod:`rule_compiler` — pure-functional evaluator for structured
+  ``ExitRule`` discriminated unions (issue #527). The trading service's
+  bar loop calls :func:`evaluate_exit_rules` after delivering each bar to
+  the strategy and emits any returned ``ExitIntent`` as a close order.
 """
 
+from .rule_compiler import (
+    BarSnapshot,
+    ExitIntent,
+    PositionState,
+    evaluate_exit_rules,
+)
 from .trade_builder import build_trade_records
 
-__all__ = ["build_trade_records"]
+__all__ = [
+    "BarSnapshot",
+    "ExitIntent",
+    "PositionState",
+    "build_trade_records",
+    "evaluate_exit_rules",
+]

--- a/backend/agents/investment_team/strategy_lab/executor/rule_compiler.py
+++ b/backend/agents/investment_team/strategy_lab/executor/rule_compiler.py
@@ -1,0 +1,177 @@
+"""Pure-functional evaluator for structured ``ExitRule`` discriminated unions.
+
+Issue #527 — the executor's bar loop owns enforcement of structured exit
+rules (``TimeStopRule`` / ``StopLossRule`` / ``TakeProfitRule``). Strategy
+code authors only the entry/signal logic; the engine reads the spec's
+``exit_rules`` and emits close orders when a rule fires.
+
+This module is intentionally side-effect free: it takes the current per-
+position state and the current bar, and returns a list of ``ExitIntent``
+records. The caller (``TradingService``) is responsible for translating
+each intent into an actual close order on the order book.
+
+``SignalExitRule`` is deferred to a follow-up — the engine does not have a
+shared per-bar indicator runtime today (the streaming harness computes
+indicators inside the strategy subprocess, not the parent), so evaluating
+``Predicate`` would require new plumbing out of scope for the MVP. The
+evaluator treats it as a silent no-op (``False`` from ``_rule_triggers``)
+so a spec mixing ``SignalExitRule`` with other rules still gets the
+other rules enforced.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Mapping, Sequence
+
+from ..spec_dsl import (
+    ExitRule,
+    SignalExitRule,
+    StopLossRule,
+    TakeProfitRule,
+    TimeStopRule,
+)
+
+ExitRuleKind = Literal["time_stop", "stop_loss", "take_profit", "signal_exit"]
+
+
+@dataclass(frozen=True)
+class PositionState:
+    """Snapshot of one open position, as seen by the rule evaluator."""
+
+    symbol: str
+    side: Literal["long", "short"]
+    qty: float
+    entry_price: float
+    bars_held: int
+    high_since_entry: float
+    low_since_entry: float
+
+
+@dataclass(frozen=True)
+class BarSnapshot:
+    """Minimal bar payload the evaluator needs. Decoupled from ``contract.Bar``
+    so unit tests can pass plain dataclasses without importing the trading
+    service plumbing.
+    """
+
+    high: float
+    low: float
+    close: float
+
+
+@dataclass(frozen=True)
+class ExitIntent:
+    """One rule-triggered close order request, ready for the engine to submit."""
+
+    symbol: str
+    rule_kind: ExitRuleKind
+    rule_index: int  # index into the spec's ``exit_rules`` list, for traceability
+    note: str = ""
+
+
+def evaluate_exit_rules(
+    rules: Sequence[ExitRule],
+    positions: Mapping[str, PositionState],
+    bars: Mapping[str, BarSnapshot],
+) -> list[ExitIntent]:
+    """Return one ``ExitIntent`` per (open position × first triggered rule).
+
+    Order semantics:
+      * Iterate rules in spec order; the first rule that fires for a given
+        position wins. Subsequent rules for the same position are skipped
+        on the same bar (only one close per position per bar).
+      * Positions with no open qty (or missing from ``bars``) are skipped.
+      * ``SignalExitRule`` is a silent no-op (returns ``False`` from
+        ``_rule_triggers``) — see module docstring for rationale.
+    """
+    intents: list[ExitIntent] = []
+    for symbol, position in positions.items():
+        if position.qty <= 0:
+            continue
+        bar = bars.get(symbol)
+        if bar is None:
+            continue
+        for idx, rule in enumerate(rules):
+            if _rule_triggers(rule, position, bar):
+                intents.append(
+                    ExitIntent(
+                        symbol=symbol,
+                        rule_kind=_kind_of(rule),
+                        rule_index=idx,
+                        note=getattr(rule, "note", "") or "",
+                    )
+                )
+                break
+    return intents
+
+
+def _kind_of(rule: ExitRule) -> ExitRuleKind:
+    if isinstance(rule, TimeStopRule):
+        return "time_stop"
+    if isinstance(rule, StopLossRule):
+        return "stop_loss"
+    if isinstance(rule, TakeProfitRule):
+        return "take_profit"
+    if isinstance(rule, SignalExitRule):
+        return "signal_exit"
+    raise TypeError(f"unknown ExitRule subclass: {type(rule).__name__}")
+
+
+def _rule_triggers(rule: ExitRule, position: PositionState, bar: BarSnapshot) -> bool:
+    if isinstance(rule, TimeStopRule):
+        # ``n_bars`` counts inclusively from the entry bar — ``n_bars=1`` means
+        # "close on the entry bar itself", ``n_bars=10`` means close once the
+        # position has been held for at least 10 bars (entry + 9 subsequent).
+        return position.bars_held >= rule.n_bars
+
+    if isinstance(rule, StopLossRule):
+        return _stop_loss_triggers(rule, position, bar)
+
+    if isinstance(rule, TakeProfitRule):
+        return _take_profit_triggers(rule, position, bar)
+
+    if isinstance(rule, SignalExitRule):
+        # Predicate-based exits need a shared per-bar indicator runtime in
+        # the parent engine — out of scope for the issue #527 MVP. Treat as
+        # a no-op so the evaluator can still process surrounding rules; the
+        # conformance gate flags SignalExit presence in an info row. Callers
+        # who need explicit detection should check ``isinstance`` before
+        # calling :func:`evaluate_exit_rules`.
+        return False
+
+    raise TypeError(f"unknown ExitRule subclass: {type(rule).__name__}")
+
+
+def _stop_loss_triggers(rule: StopLossRule, position: PositionState, bar: BarSnapshot) -> bool:
+    pct = rule.pct
+    if position.side == "long":
+        if rule.basis == "entry_price":
+            floor = position.entry_price * (1.0 - pct)
+        elif rule.basis == "trailing_high":
+            floor = position.high_since_entry * (1.0 - pct)
+        else:
+            # ``trailing_low`` only makes sense for shorts; treated as no-op
+            # for longs rather than firing, so a misconfigured spec doesn't
+            # silently flush every long position on bar 1.
+            return False
+        return bar.low <= floor
+
+    # short
+    if rule.basis == "entry_price":
+        ceiling = position.entry_price * (1.0 + pct)
+    elif rule.basis == "trailing_low":
+        ceiling = position.low_since_entry * (1.0 + pct)
+    else:
+        # ``trailing_high`` is the long-side counterpart; no-op for shorts.
+        return False
+    return bar.high >= ceiling
+
+
+def _take_profit_triggers(rule: TakeProfitRule, position: PositionState, bar: BarSnapshot) -> bool:
+    pct = rule.pct
+    if position.side == "long":
+        target = position.entry_price * (1.0 + pct)
+        return bar.high >= target
+    target = position.entry_price * (1.0 - pct)
+    return bar.low <= target

--- a/backend/agents/investment_team/strategy_lab/executor/rule_compiler.py
+++ b/backend/agents/investment_team/strategy_lab/executor/rule_compiler.py
@@ -1,22 +1,31 @@
 """Pure-functional evaluator for structured ``ExitRule`` discriminated unions.
 
 Issue #527 — the executor's bar loop owns enforcement of structured exit
-rules (``TimeStopRule`` / ``StopLossRule`` / ``TakeProfitRule``). Strategy
-code authors only the entry/signal logic; the engine reads the spec's
-``exit_rules`` and emits close orders when a rule fires.
+rules. Strategy code authors the entry/signal logic; the engine reads
+``StrategySpec.exit_rules`` and emits close orders when a rule fires.
 
-This module is intentionally side-effect free: it takes the current per-
-position state and the current bar, and returns a list of ``ExitIntent``
-records. The caller (``TradingService``) is responsible for translating
-each intent into an actual close order on the order book.
+Supported rule kinds (matching the discriminated ``ExitRule`` union in
+``spec_dsl``):
 
-``SignalExitRule`` is deferred to a follow-up — the engine does not have a
-shared per-bar indicator runtime today (the streaming harness computes
-indicators inside the strategy subprocess, not the parent), so evaluating
-``Predicate`` would require new plumbing out of scope for the MVP. The
-evaluator treats it as a silent no-op (``False`` from ``_rule_triggers``)
-so a spec mixing ``SignalExitRule`` with other rules still gets the
-other rules enforced.
+* ``StopLossRule(pct, basis)`` — close when the bar's low (long) or
+  high (short) crosses the rule's price floor. ``basis`` selects
+  ``entry_price`` / ``trailing_high`` / ``trailing_low``.
+* ``TakeProfitRule(pct)`` — close when the bar's high (long) or low
+  (short) clears the rule's price target.
+* ``SignalExitRule(when)`` — close when a predicate fires. Not yet
+  engine-enforced (the parent engine has no per-bar indicator runtime
+  today); the evaluator treats it as a silent no-op so a spec mixing
+  signal exits with stop/take-profit still gets the latter enforced.
+
+Bar-counting "time stops" are deliberately absent: real traders close
+on price action, P&L, or signal reversal — not on an arbitrary "Nth
+bar held" counter.
+
+This module is intentionally side-effect free: it takes the current
+per-position state and the current bar, and returns a list of
+``ExitIntent`` records. The caller (``TradingService``) is responsible
+for translating each intent into an actual close order on the order
+book.
 """
 
 from __future__ import annotations
@@ -29,10 +38,9 @@ from ..spec_dsl import (
     SignalExitRule,
     StopLossRule,
     TakeProfitRule,
-    TimeStopRule,
 )
 
-ExitRuleKind = Literal["time_stop", "stop_loss", "take_profit", "signal_exit"]
+ExitRuleKind = Literal["stop_loss", "take_profit", "signal_exit"]
 
 
 @dataclass(frozen=True)
@@ -43,7 +51,6 @@ class PositionState:
     side: Literal["long", "short"]
     qty: float
     entry_price: float
-    bars_held: int
     high_since_entry: float
     low_since_entry: float
 
@@ -107,8 +114,6 @@ def evaluate_exit_rules(
 
 
 def _kind_of(rule: ExitRule) -> ExitRuleKind:
-    if isinstance(rule, TimeStopRule):
-        return "time_stop"
     if isinstance(rule, StopLossRule):
         return "stop_loss"
     if isinstance(rule, TakeProfitRule):
@@ -119,12 +124,6 @@ def _kind_of(rule: ExitRule) -> ExitRuleKind:
 
 
 def _rule_triggers(rule: ExitRule, position: PositionState, bar: BarSnapshot) -> bool:
-    if isinstance(rule, TimeStopRule):
-        # ``n_bars`` counts inclusively from the entry bar — ``n_bars=1`` means
-        # "close on the entry bar itself", ``n_bars=10`` means close once the
-        # position has been held for at least 10 bars (entry + 9 subsequent).
-        return position.bars_held >= rule.n_bars
-
     if isinstance(rule, StopLossRule):
         return _stop_loss_triggers(rule, position, bar)
 

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -853,6 +853,16 @@ class StrategyLabOrchestrator:
         # persisted record alongside the LLM alignment verdict; the alignment
         # agent's prompt (now treating exit rules as engine-enforced) reads
         # the same trade ledger and reaches a compatible verdict.
+        #
+        # ``exit_rule_conformance_passed`` vetos ``is_winning`` below: a
+        # critical failure here means the engine's per-bar enforcement
+        # leaked (e.g. a trade overshot a structured stop-loss floor by
+        # more than slippage tolerance, or held past ``TimeStop.n_bars+1``).
+        # That's an engine-side correctness bug, not a strategy-code bug,
+        # so refinement won't fix it — but we must NOT publish the run as
+        # winning even if the LLM alignment agent later agrees the trades
+        # look reasonable.
+        exit_rule_conformance_passed = True
         if execution_succeeded and trades:
             conformance_gate = ExitRuleConformanceGate()
             conformance_results = conformance_gate.check(
@@ -863,6 +873,9 @@ class StrategyLabOrchestrator:
                 timeframe=spec.timeframe,
             )
             all_gate_results.extend(conformance_results)
+            exit_rule_conformance_passed = not any(
+                (not r.passed) and r.severity == "critical" for r in conformance_results
+            )
 
         if execution_succeeded and trades and market_data is not None:
             for align_round in range(MAX_ALIGNMENT_ROUNDS):
@@ -1211,7 +1224,12 @@ class StrategyLabOrchestrator:
         upstream_admitted = False
         if acceptance_results:
             acceptance_passed = all(r.passed for r in acceptance_results)
-            is_winning = execution_succeeded and acceptance_passed and trades_aligned
+            is_winning = (
+                execution_succeeded
+                and acceptance_passed
+                and trades_aligned
+                and exit_rule_conformance_passed
+            )
             upstream_admitted = acceptance_passed
         elif walk_forward_failed and execution_succeeded:
             fallback_anomalies = self.anomaly_detector.check(
@@ -1224,7 +1242,12 @@ class StrategyLabOrchestrator:
                 g for g in fallback_anomalies if not g.passed and g.severity == "critical"
             ]
             return_ok = metrics.annualized_return_pct > WINNING_THRESHOLD
-            is_winning = return_ok and not fallback_criticals and trades_aligned
+            is_winning = (
+                return_ok
+                and not fallback_criticals
+                and trades_aligned
+                and exit_rule_conformance_passed
+            )
             upstream_admitted = return_ok and not fallback_criticals
             if fallback_criticals:
                 # Surface the upgraded severities so the persisted
@@ -1291,6 +1314,37 @@ class StrategyLabOrchestrator:
         # skipped entirely when ``market_data is None``, in which case
         # ``trades_aligned`` is False for unrelated reasons and an
         # ``alignment_failed`` suffix would be misleading.
+        # Issue #527 — surface a conformance-veto reason on
+        # ``acceptance_reason`` so the audit trail explains why publication
+        # was blocked when the deterministic exit-rule gate fired. Mirrors
+        # the alignment-failure suffix logic below: replace a stale
+        # success-style reason from an upstream admit, append to a
+        # real upstream rejection.
+        if execution_succeeded and trades and not exit_rule_conformance_passed:
+            conformance_criticals = [
+                r
+                for r in all_gate_results
+                if r.gate_name == "exit_rule_conformance"
+                and not r.passed
+                and r.severity == "critical"
+            ]
+            detail = "; ".join(r.details for r in conformance_criticals)
+            conformance_suffix = (
+                f"exit_rule_conformance_failed: {detail}"
+                if detail
+                else "exit_rule_conformance_failed: engine enforcement leaked"
+            )
+            prior_reason = (metrics.acceptance_reason or "").strip()
+            if prior_reason and not upstream_admitted:
+                combined = f"{prior_reason} | {conformance_suffix}"
+            else:
+                combined = conformance_suffix
+            metrics = metrics.model_copy(update={"acceptance_reason": combined})
+            # Future replacement by the alignment-suffix block sees the
+            # conformance reason as the "prior" reason and will append
+            # rather than overwrite when both gates rejected.
+            upstream_admitted = False
+
         if execution_succeeded and trades and alignment_reports and not trades_aligned:
             last_report = alignment_reports[-1]
             # NOTE: do NOT name this ``rationale`` — that shadows the

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -63,6 +63,7 @@ from .quality_gates.acceptance_gate import AcceptanceGate, summarize_acceptance_
 from .quality_gates.backtest_anomaly import BacktestAnomalyDetector
 from .quality_gates.code_safety import CodeSafetyChecker
 from .quality_gates.convergence_tracker import ConvergenceTracker
+from .quality_gates.exit_rule_conformance import ExitRuleConformanceGate
 from .quality_gates.models import QualityGateResult
 from .quality_gates.strategy_validator import StrategySpecValidator
 from .quality_gates.target_symbol_coverage import TargetSymbolCoverageGate
@@ -843,6 +844,25 @@ class StrategyLabOrchestrator:
         # is reached).
         alignment_attempts: List[str] = []
         alignment_reports: List[TradeAlignmentReport] = []
+
+        # Issue #527 — run the deterministic exit-rule conformance gate before
+        # the LLM alignment loop. ``ExitRuleConformanceGate`` reads the trade
+        # ledger and the engine's ``exit_rule_firings`` diagnostic to verify
+        # every trade obeys the structured exit rules within tolerance. The
+        # results are appended to ``all_gate_results`` so they surface on the
+        # persisted record alongside the LLM alignment verdict; the alignment
+        # agent's prompt (now treating exit rules as engine-enforced) reads
+        # the same trade ledger and reaches a compatible verdict.
+        if execution_succeeded and trades:
+            conformance_gate = ExitRuleConformanceGate()
+            conformance_results = conformance_gate.check(
+                exit_rules=spec.exit_rules,
+                trades=trades,
+                diagnostics=metrics.execution_diagnostics,
+                config=config,
+                timeframe=spec.timeframe,
+            )
+            all_gate_results.extend(conformance_results)
 
         if execution_succeeded and trades and market_data is not None:
             for align_round in range(MAX_ALIGNMENT_ROUNDS):

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -224,6 +224,38 @@ class _ZeroTradeRepairOutcome:
     changes_made: str = ""
 
 
+def _apply_veto_to_acceptance_reason(
+    metrics: BacktestResult,
+    suffix: str,
+    *,
+    upstream_admitted: bool,
+) -> tuple[BacktestResult, bool]:
+    """Stamp a publication veto's cause onto ``metrics.acceptance_reason``.
+
+    Both the conformance veto (#527) and the alignment veto (#529)
+    follow the same shape: replace a stale success-style upstream
+    reason; append to a real upstream rejection. Returns the updated
+    ``metrics`` and ``False`` for the new ``upstream_admitted``, so a
+    subsequent veto on the same run appends to this one rather than
+    overwriting it.
+
+    The delimiter is ``" | "`` (not ``"; "`` which
+    :func:`summarize_acceptance_reason` uses between failing gates)
+    so downstream parsers can disambiguate the veto boundary from
+    gate-internal boundaries.
+
+    Whitespace-only upstream reasons (``None``, ``""``, ``"   "``)
+    collapse to the suffix alone — never produces
+    ``"   | <suffix>"`` with an empty left side.
+    """
+    prior = (metrics.acceptance_reason or "").strip()
+    if prior and not upstream_admitted:
+        combined = f"{prior} | {suffix}"
+    else:
+        combined = suffix
+    return metrics.model_copy(update={"acceptance_reason": combined}), False
+
+
 class StrategyLabOrchestrator:
     """Deterministic pipeline controller for the Strategy Lab.
 
@@ -1301,23 +1333,26 @@ class StrategyLabOrchestrator:
                     update={"acceptance_reason": "publication_disabled: walk_forward_enabled=False"}
                 )
 
-        # Surface the alignment-failure cause on ``acceptance_reason`` so
-        # the audit trail explains why publication was blocked even when
-        # the acceptance gate / threshold otherwise passed (#529). The
-        # ``trade_alignment`` QualityGateResult already lives in
-        # ``all_gate_results`` (appended per alignment round above); this
-        # mirrors the signal onto ``BacktestResult.acceptance_reason``.
-        # ``alignment_reports`` is in the guard so we only attribute the
-        # rejection to alignment when the audit actually ran — the loop is
-        # skipped entirely when ``market_data is None``, in which case
-        # ``trades_aligned`` is False for unrelated reasons and an
-        # ``alignment_failed`` suffix would be misleading.
-        # Issue #527 — surface a conformance-veto reason on
-        # ``acceptance_reason`` so the audit trail explains why publication
-        # was blocked when the deterministic exit-rule gate fired. Mirrors
-        # the alignment-failure suffix logic below: replace a stale
-        # success-style reason from an upstream admit, append to a
-        # real upstream rejection.
+        # ── Publication vetoes ────────────────────────────────────────
+        # Surface each veto's cause on ``acceptance_reason`` so the
+        # audit trail explains why publication was blocked even when
+        # the upstream acceptance gate otherwise passed. Vetoes stack:
+        # the first to fire is treated as the upstream rejection by the
+        # second, so a multi-gate failure preserves both causes.
+        #
+        # Helper :func:`_apply_veto_to_acceptance_reason` codifies the
+        # "replace stale success, append real rejection" rule so adding
+        # a future veto is one new call here rather than another copy
+        # of the mutation shape.
+        #
+        # Each veto's ``execution_succeeded and trades`` precondition
+        # ensures the alignment / conformance verdicts are meaningful —
+        # both gates need a non-empty trade ledger to evaluate.
+        # ``alignment_reports`` is in the alignment guard so we only
+        # attribute the rejection to alignment when the audit actually
+        # ran (skipped when ``market_data is None``).
+
+        # Issue #527 — conformance veto.
         if execution_succeeded and trades and not exit_rule_conformance_passed:
             conformance_criticals = [
                 r
@@ -1327,22 +1362,16 @@ class StrategyLabOrchestrator:
                 and r.severity == "critical"
             ]
             detail = "; ".join(r.details for r in conformance_criticals)
-            conformance_suffix = (
+            suffix = (
                 f"exit_rule_conformance_failed: {detail}"
                 if detail
                 else "exit_rule_conformance_failed: engine enforcement leaked"
             )
-            prior_reason = (metrics.acceptance_reason or "").strip()
-            if prior_reason and not upstream_admitted:
-                combined = f"{prior_reason} | {conformance_suffix}"
-            else:
-                combined = conformance_suffix
-            metrics = metrics.model_copy(update={"acceptance_reason": combined})
-            # Future replacement by the alignment-suffix block sees the
-            # conformance reason as the "prior" reason and will append
-            # rather than overwrite when both gates rejected.
-            upstream_admitted = False
+            metrics, upstream_admitted = _apply_veto_to_acceptance_reason(
+                metrics, suffix, upstream_admitted=upstream_admitted
+            )
 
+        # Issue #529 — alignment veto.
         if execution_succeeded and trades and alignment_reports and not trades_aligned:
             last_report = alignment_reports[-1]
             # NOTE: do NOT name this ``rationale`` — that shadows the
@@ -1353,30 +1382,14 @@ class StrategyLabOrchestrator:
             # silently corrupt both the analysis prompt and the audit
             # record on every alignment-failure path.
             align_rationale = (last_report.rationale or "").strip()
-            if align_rationale:
-                reason_suffix = f"alignment_failed: {align_rationale}"
-            else:
-                reason_suffix = "alignment_failed: trades did not implement strategy spec"
-            # When the upstream gate admitted the run (acceptance fully
-            # passed, or fallback anomaly recheck clean), its success
-            # summary is no longer truthful — alignment is now the
-            # rejection cause. Replace rather than append so the audit
-            # trail isn't self-contradictory. When the upstream gate
-            # itself rejected, keep its reason and add the alignment
-            # cause — both are real rejection causes. Use a ``" | "``
-            # delimiter (not ``"; "``, which ``summarize_acceptance_reason``
-            # uses internally between failing gates) so downstream parsers
-            # can disambiguate the alignment boundary from gate boundaries.
-            # Use the stripped form so a whitespace-only upstream reason
-            # (None, "", "   ", "\n") collapses to the alignment suffix
-            # alone — never produces ``"   | alignment_failed: ..."`` with
-            # an empty left side.
-            prior_reason = (metrics.acceptance_reason or "").strip()
-            if prior_reason and not upstream_admitted:
-                combined = f"{prior_reason} | {reason_suffix}"
-            else:
-                combined = reason_suffix
-            metrics = metrics.model_copy(update={"acceptance_reason": combined})
+            suffix = (
+                f"alignment_failed: {align_rationale}"
+                if align_rationale
+                else "alignment_failed: trades did not implement strategy spec"
+            )
+            metrics, upstream_admitted = _apply_veto_to_acceptance_reason(
+                metrics, suffix, upstream_admitted=upstream_admitted
+            )
 
         # ── Phase 3: ANALYSIS ─────────────────────────────────────────
         narrative = ""

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -857,8 +857,8 @@ class StrategyLabOrchestrator:
         # ``exit_rule_conformance_passed`` vetos ``is_winning`` below: a
         # critical failure here means the engine's per-bar enforcement
         # leaked (e.g. a trade overshot a structured stop-loss floor by
-        # more than slippage tolerance, or held past ``TimeStop.n_bars+1``).
-        # That's an engine-side correctness bug, not a strategy-code bug,
+        # more than slippage tolerance). That's an engine-side
+        # correctness bug, not a strategy-code bug,
         # so refinement won't fix it — but we must NOT publish the run as
         # winning even if the LLM alignment agent later agrees the trades
         # look reasonable.

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -845,37 +845,14 @@ class StrategyLabOrchestrator:
         alignment_attempts: List[str] = []
         alignment_reports: List[TradeAlignmentReport] = []
 
-        # Issue #527 — run the deterministic exit-rule conformance gate before
-        # the LLM alignment loop. ``ExitRuleConformanceGate`` reads the trade
-        # ledger and the engine's ``exit_rule_firings`` diagnostic to verify
-        # every trade obeys the structured exit rules within tolerance. The
-        # results are appended to ``all_gate_results`` so they surface on the
-        # persisted record alongside the LLM alignment verdict; the alignment
-        # agent's prompt (now treating exit rules as engine-enforced) reads
-        # the same trade ledger and reaches a compatible verdict.
-        #
-        # ``exit_rule_conformance_passed`` vetos ``is_winning`` below: a
-        # critical failure here means the engine's per-bar enforcement
-        # leaked (e.g. a trade overshot a structured stop-loss floor by
-        # more than slippage tolerance). That's an engine-side
-        # correctness bug, not a strategy-code bug,
-        # so refinement won't fix it — but we must NOT publish the run as
-        # winning even if the LLM alignment agent later agrees the trades
-        # look reasonable.
-        exit_rule_conformance_passed = True
-        if execution_succeeded and trades:
-            conformance_gate = ExitRuleConformanceGate()
-            conformance_results = conformance_gate.check(
-                exit_rules=spec.exit_rules,
-                trades=trades,
-                diagnostics=metrics.execution_diagnostics,
-                config=config,
-                timeframe=spec.timeframe,
-            )
-            all_gate_results.extend(conformance_results)
-            exit_rule_conformance_passed = not any(
-                (not r.passed) and r.severity == "critical" for r in conformance_results
-            )
+        # Issue #527 — engine-side enforcement of structured ``exit_rules``
+        # has a deterministic conformance gate that runs once the trade
+        # ledger is settled. It runs AFTER the alignment loop because
+        # alignment re-execution can replace ``trades`` / ``metrics`` with
+        # a new ledger that has different conformance characteristics —
+        # running before alignment would leave us evaluating a stale run.
+        # See the gate invocation just before the ``is_winning``
+        # resolution below.
 
         if execution_succeeded and trades and market_data is not None:
             for align_round in range(MAX_ALIGNMENT_ROUNDS):
@@ -1191,6 +1168,27 @@ class StrategyLabOrchestrator:
                 acceptance_results = []
                 acceptance_reason = None
                 walk_forward_failed = True
+
+        # ── Exit-rule conformance ─────────────────────────────────────
+        # Issue #527 — deterministic check that the engine actually
+        # enforced ``spec.exit_rules`` against the FINAL trade ledger
+        # (post-alignment-loop). Critical failure vetoes ``is_winning``
+        # below; results are appended to ``all_gate_results`` for the
+        # persisted record.
+        exit_rule_conformance_passed = True
+        if execution_succeeded and trades:
+            conformance_gate = ExitRuleConformanceGate()
+            conformance_results = conformance_gate.check(
+                exit_rules=spec.exit_rules,
+                trades=trades,
+                diagnostics=metrics.execution_diagnostics,
+                config=config,
+                timeframe=spec.timeframe,
+            )
+            all_gate_results.extend(conformance_results)
+            exit_rule_conformance_passed = not any(
+                (not r.passed) and r.severity == "critical" for r in conformance_results
+            )
 
         # ── Resolve is_winning ────────────────────────────────────────
         # Publication requires (a) the walk-forward acceptance gate (or

--- a/backend/agents/investment_team/strategy_lab/prompts/alignment_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/alignment_system.md
@@ -21,7 +21,7 @@ The spec contains two kinds of rules; treat them differently:
 ### Enforced rules (engine-checked — `severity: critical` allowed)
 
 These are the rules the backtest engine actually applies. Deviations here
-are real bugs in the strategy code.
+are real bugs in the strategy code or the engine, not artistic licence.
 
 - **Sizing rules** — `shares` respects the documented sizing scheme (fixed
   fraction, volatility target, notional cap, etc.).
@@ -30,26 +30,31 @@ are real bugs in the strategy code.
   ignored stop-losses are critical misalignments.
 - **Universe & direction** — only `asset_class`-appropriate symbols and only
   `long`/`short` sides allowed by the spec should appear.
+- **Exit rules** — `exit_rules` are structured `TimeStopRule` /
+  `StopLossRule` / `TakeProfitRule` / `SignalExitRule` objects that the
+  parent engine evaluates after every bar and enforces by emitting close
+  orders on the strategy's behalf. A separate deterministic conformance
+  gate (`exit_rule_conformance`) is run before this audit and counts the
+  engine firings; trust it. Your job is to flag the rare residual case
+  where the engine's enforcement could not protect the trade (e.g. an
+  overshoot beyond the stop-loss floor by more than slippage tolerance).
+  `severity: critical` is appropriate here. `SignalExitRule` is not yet
+  engine-enforced — see the aspirational section below.
 
 ### Aspirational rules (prose intent — downgrade severity)
 
-`entry_rules` and `exit_rules` are author-supplied prose intent. Until the
-structured-rule DSL work lands, the engine does NOT mechanically enforce
-them — the strategy code is free to ignore prose like "exit after 10 bars"
-or "enter when RSI < 30", and the backtest will still run. Report behavioural
-gaps against this intent, but downgrade them:
+`entry_rules` are author-supplied intent. The engine does NOT
+mechanically open positions from them — the strategy code is free to
+ignore prose like "enter when RSI < 30", and the backtest will still
+run. Report behavioural gaps against this intent, but downgrade them:
 
 - **Entry rules** — describe whether the trade-entry behaviour is consistent
   with the authored intent. If a trade looks like it ignored the intent,
   flag it — but use `severity: warning` (or `info`), not `critical`,
   unless the same trade also breaches an enforced rule above.
-- **Exit rules** — describe whether each exit appears consistent with the
-  authored intent (signal reversal, stop-loss, take-profit, time stop,
-  force-close at the final bar). Holding longer than the prose suggests, or
-  exiting earlier than the prose suggests, is reportable but is NOT a
-  critical misalignment by itself — keep `severity` at `warning` or `info`.
-  Reserve `critical` for cases where the same trade also breaches an
-  enforced rule (e.g. an ignored stop-loss).
+- **SignalExitRule** specifically (predicate-based exits) is also not
+  yet engine-enforced; same `warning` / `info` treatment until the
+  shared per-bar indicator runtime lands.
 
 Cosmetic differences (rounding, tie-breaker behavior on identical signals)
 do NOT count as misalignment. Code is misaligned only when trade behavior
@@ -59,15 +64,17 @@ meaningfully diverges from the specification.
 
 1. **SCAN the spec** — restate each entry rule, exit rule, sizing rule, and
    risk limit. Tag each one as **enforced** (sizing, risk limits, universe,
-   direction) or **aspirational** (entry_rules / exit_rules prose).
+   direction, and every structured `exit_rules` entry except `SignalExitRule`)
+   or **aspirational** (entry_rules prose intent, plus any `SignalExitRule`).
 2. **SPOT-CHECK trades** — use the provided sample ledger rows to check
    whether trade behaviour is consistent with the authored intent. Look for:
    - Trades whose entry behaviour is inconsistent with the authored entry
      intent (note: `severity: warning` unless an enforced rule is also
      breached).
-   - Trades that overshoot the stop-loss (enforced — `critical` allowed)
-     or that exit inconsistently with the authored exit intent (aspirational
-     — `warning` / `info`).
+   - Trades that overshoot the structured stop-loss floor by more than
+     slippage tolerance (enforced — `critical` allowed), or that
+     exceeded a structured time-stop or take-profit threshold (the
+     deterministic conformance gate flags these; defer to it).
    - Trades whose sizing exceeds `max_position_pct` of capital at entry
      (enforced — `critical` allowed).
    - Repeated same-day entries/exits, lookahead bias, or single-bar holds
@@ -100,9 +107,11 @@ invent misalignments.
 ## Output
 
 Reserve `severity: critical` for issues against enforced rules (sizing,
-risk_limits, universe, direction). Issues citing only `entry_rules` or
-`exit_rules` prose MUST use `severity: warning` or `info` unless the same
-trade also breaches an enforced rule.
+risk_limits, universe, direction, structured `exit_rules` except
+`SignalExitRule`). Issues citing only `entry_rules` prose (or a
+`SignalExitRule` predicate, which is not yet engine-enforced) MUST use
+`severity: warning` or `info` unless the same trade also breaches an
+enforced rule.
 
 Return ONLY a JSON object with no markdown:
 

--- a/backend/agents/investment_team/strategy_lab/prompts/alignment_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/alignment_system.md
@@ -30,11 +30,11 @@ are real bugs in the strategy code or the engine, not artistic licence.
   ignored stop-losses are critical misalignments.
 - **Universe & direction** — only `asset_class`-appropriate symbols and only
   `long`/`short` sides allowed by the spec should appear.
-- **Exit rules** — `exit_rules` are structured `TimeStopRule` /
-  `StopLossRule` / `TakeProfitRule` / `SignalExitRule` objects that the
-  parent engine evaluates after every bar and enforces by emitting close
-  orders on the strategy's behalf. A separate deterministic conformance
-  gate (`exit_rule_conformance`) is run before this audit and counts the
+- **Exit rules** — `exit_rules` are structured `StopLossRule` /
+  `TakeProfitRule` / `SignalExitRule` objects that the parent engine
+  evaluates after every bar and enforces by emitting close orders on the
+  strategy's behalf. A separate deterministic conformance gate
+  (`exit_rule_conformance`) is run before this audit and counts the
   engine firings; trust it. Your job is to flag the rare residual case
   where the engine's enforcement could not protect the trade (e.g. an
   overshoot beyond the stop-loss floor by more than slippage tolerance).

--- a/backend/agents/investment_team/strategy_lab/prompts/analysis_lose.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/analysis_lose.md
@@ -5,7 +5,7 @@ Asset class: {asset_class}
 Hypothesis: {hypothesis}
 Signal: {signal_definition}
 Intended entry rules (as authored — may not all be machine-enforced): {entry_rules}
-Intended exit rules (as authored — may not all be machine-enforced): {exit_rules}
+Engine-enforced exit rules (structured DSL applied by the parent engine every bar): {exit_rules}
 Sizing / risk: {sizing_rules}
 Rationale for testing: {rationale}
 
@@ -22,7 +22,7 @@ Volatility: {volatility_pct:.1f}%
 {simulated_trades_section}
 
 ## Instructions
-The entry/exit rules above are prose specifications, not engine-enforced behaviour — do not assert that trades "violated" them; instead describe whether trade behaviour was consistent with the intent.
+Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced: the parent engine emits time-stop / stop-loss / take-profit closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. a tight cluster of N-day holds points to a time stop firing).
 Think step by step: what failure modes explain weak performance — signal timing, risk/reward asymmetry, cost drag, or rules misaligned with the market regime implied by the results?
 Use the trade-level evidence where it supports your reasoning.
 Write 5-8 sentences. Be specific about *why* this strategy underperformed.

--- a/backend/agents/investment_team/strategy_lab/prompts/analysis_lose.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/analysis_lose.md
@@ -22,7 +22,7 @@ Volatility: {volatility_pct:.1f}%
 {simulated_trades_section}
 
 ## Instructions
-Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced for `TimeStopRule`, `StopLossRule`, and `TakeProfitRule`: the parent engine emits closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. a tight cluster of N-day holds points to a time stop firing). `SignalExitRule` entries in the list above are NOT yet engine-enforced — treat any predicate-based exit prose the same way as entry intent.
+Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced for `StopLossRule` and `TakeProfitRule`: the parent engine emits closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. losing trades clustered near the stop-loss floor point to it firing). `SignalExitRule` entries in the list above are NOT yet engine-enforced — treat any predicate-based exit prose the same way as entry intent.
 Think step by step: what failure modes explain weak performance — signal timing, risk/reward asymmetry, cost drag, or rules misaligned with the market regime implied by the results?
 Use the trade-level evidence where it supports your reasoning.
 Write 5-8 sentences. Be specific about *why* this strategy underperformed.

--- a/backend/agents/investment_team/strategy_lab/prompts/analysis_lose.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/analysis_lose.md
@@ -22,7 +22,7 @@ Volatility: {volatility_pct:.1f}%
 {simulated_trades_section}
 
 ## Instructions
-Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced: the parent engine emits time-stop / stop-loss / take-profit closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. a tight cluster of N-day holds points to a time stop firing).
+Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced for `TimeStopRule`, `StopLossRule`, and `TakeProfitRule`: the parent engine emits closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. a tight cluster of N-day holds points to a time stop firing). `SignalExitRule` entries in the list above are NOT yet engine-enforced — treat any predicate-based exit prose the same way as entry intent.
 Think step by step: what failure modes explain weak performance — signal timing, risk/reward asymmetry, cost drag, or rules misaligned with the market regime implied by the results?
 Use the trade-level evidence where it supports your reasoning.
 Write 5-8 sentences. Be specific about *why* this strategy underperformed.

--- a/backend/agents/investment_team/strategy_lab/prompts/analysis_win.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/analysis_win.md
@@ -5,7 +5,7 @@ Asset class: {asset_class}
 Hypothesis: {hypothesis}
 Signal: {signal_definition}
 Intended entry rules (as authored — may not all be machine-enforced): {entry_rules}
-Intended exit rules (as authored — may not all be machine-enforced): {exit_rules}
+Engine-enforced exit rules (structured DSL applied by the parent engine every bar): {exit_rules}
 Sizing / risk: {sizing_rules}
 Rationale for testing: {rationale}
 
@@ -22,7 +22,7 @@ Volatility: {volatility_pct:.1f}%
 {simulated_trades_section}
 
 ## Instructions
-The entry/exit rules above are prose specifications, not engine-enforced behaviour — do not assert that trades "violated" them; instead describe whether trade behaviour was consistent with the intent.
+Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced: the parent engine emits time-stop / stop-loss / take-profit closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. a tight cluster of N-day holds points to a time stop firing).
 Think step by step: what in the strategy design plausibly produced strong risk-adjusted returns?
 Relate the hypothesis and rules to (1) Sharpe/drawdown/volatility, (2) win rate vs profit factor, (3) patterns in the simulated trades (hold periods, win/loss mix, concentration).
 Write 5-8 sentences. Be specific — avoid generic praise. Explain *why* this strategy class succeeded in this backtest.

--- a/backend/agents/investment_team/strategy_lab/prompts/analysis_win.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/analysis_win.md
@@ -22,7 +22,7 @@ Volatility: {volatility_pct:.1f}%
 {simulated_trades_section}
 
 ## Instructions
-Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced: the parent engine emits time-stop / stop-loss / take-profit closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. a tight cluster of N-day holds points to a time stop firing).
+Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced for `TimeStopRule`, `StopLossRule`, and `TakeProfitRule`: the parent engine emits closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. a tight cluster of N-day holds points to a time stop firing). `SignalExitRule` entries in the list above are NOT yet engine-enforced — treat any predicate-based exit prose the same way as entry intent.
 Think step by step: what in the strategy design plausibly produced strong risk-adjusted returns?
 Relate the hypothesis and rules to (1) Sharpe/drawdown/volatility, (2) win rate vs profit factor, (3) patterns in the simulated trades (hold periods, win/loss mix, concentration).
 Write 5-8 sentences. Be specific — avoid generic praise. Explain *why* this strategy class succeeded in this backtest.

--- a/backend/agents/investment_team/strategy_lab/prompts/analysis_win.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/analysis_win.md
@@ -22,7 +22,7 @@ Volatility: {volatility_pct:.1f}%
 {simulated_trades_section}
 
 ## Instructions
-Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced for `TimeStopRule`, `StopLossRule`, and `TakeProfitRule`: the parent engine emits closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. a tight cluster of N-day holds points to a time stop firing). `SignalExitRule` entries in the list above are NOT yet engine-enforced — treat any predicate-based exit prose the same way as entry intent.
+Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced for `StopLossRule` and `TakeProfitRule`: the parent engine emits closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. losing trades clustered near the stop-loss floor point to it firing). `SignalExitRule` entries in the list above are NOT yet engine-enforced — treat any predicate-based exit prose the same way as entry intent.
 Think step by step: what in the strategy design plausibly produced strong risk-adjusted returns?
 Relate the hypothesis and rules to (1) Sharpe/drawdown/volatility, (2) win rate vs profit factor, (3) patterns in the simulated trades (hold periods, win/loss mix, concentration).
 Write 5-8 sentences. Be specific — avoid generic praise. Explain *why* this strategy class succeeded in this backtest.

--- a/backend/agents/investment_team/strategy_lab/prompts/ideation_system.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/ideation_system.md
@@ -53,10 +53,10 @@ Bare bar fields are addressed by the string literals `"bar.close"`, `"bar.high"`
 
 - **`entry_rules`**: list of objects with `{"kind": "entry", "side": "long"|"short", "when": Predicate, "note": str}`.
 - **`exit_rules`**: list of one or more of:
-  - `{"kind": "time_stop", "n_bars": int>0, "note": str}` — exit after N bars.
   - `{"kind": "stop_loss", "pct": 0<float<=1.0, "basis": "entry_price"|"trailing_high"|"trailing_low", "note": str}` — note `pct` is a fraction (`0.03` = 3%), not a percent.
   - `{"kind": "take_profit", "pct": float>0, "note": str}` — `pct` is a fraction.
   - `{"kind": "signal_exit", "when": Predicate, "note": str}`.
+  Bar-counting "time stops" are deliberately NOT a supported kind — real traders close on price, P&L, or signal reversal, not on an arbitrary "exit after N bars" trigger.
 - **`sizing`** (single object, not a list):
   - `{"kind": "fixed_fraction", "fraction": 0<float<=1.0, "note": str}` — fraction is `0.02` for 2% per trade.
   - `{"kind": "volatility_target", "target_annual_vol": float>0, "note": str}`.
@@ -87,7 +87,7 @@ A `Predicate` is `{"lhs": <side>, "op": <op>, "rhs": <side>}` where:
      "when": {"lhs": {"name": "rsi", "params": {"period": 14}},
               "op": ">",
               "rhs": 70}},
-    {"kind": "time_stop", "n_bars": 10}
+    {"kind": "stop_loss", "pct": 0.03}
   ],
   "sizing": {"kind": "fixed_fraction", "fraction": 0.02},
   "risk_limits": {"max_position_pct": 5},
@@ -101,7 +101,7 @@ A `Predicate` is `{"lhs": <side>, "op": <op>, "rhs": <side>}` where:
 ```json
 {
   "entry_rules": ["close > sma(20)"],
-  "exit_rules": ["exit after 10 bars"],
+  "exit_rules": ["stop loss 3%"],
   "sizing_rules": ["risk 2% per trade"]
 }
 ```

--- a/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
@@ -5,17 +5,23 @@ bar loop, every trade either obeys the rules within tolerance or comes from
 the strategy code's own exit logic.  This gate iterates the trade ledger
 and the execution diagnostics and reports:
 
-* **StopLossRule(pct=P, basis="entry_price")** — count below-floor
-  trades per symbol and compare to the engine's per-symbol
+* **StopLossRule(pct=P, basis="entry_price")** — count engine-attributed
+  below-floor trades per symbol and compare to the engine's per-symbol
   ``stop_loss`` firings. Critical failure fires when any symbol's
-  below-floor trade count exceeds its firing count (the rule was
-  tripped but the enforcement path didn't run). Per-symbol attribution
-  prevents a stop firing on symbol A from masking a leak on symbol B.
-  The engine triggers on bar N's low (long) / high (short) and fills
-  on bar N+1's open, so realised return can land below the rule's
-  raw threshold via gap fills — those are absorbed when matched 1:1
-  with firings. Trailing variants need bar-by-bar replay and are
-  flagged as informational.
+  engine-attributed below-floor trade count exceeds its firing count
+  (the rule was tripped but the enforcement path didn't run). Per-
+  symbol attribution prevents a stop firing on symbol A from masking
+  a leak on symbol B. Strategy-closed below-floor trades are EXCLUDED:
+  a strategy market exit can fill on a next-bar gap-down open beneath
+  the floor before the engine evaluates that bar, so no engine firing
+  is possible even though realised return is below the floor — the
+  strategy made the call, not the engine. ``TradeRecord.exit_reason``
+  carries the close ``OrderRequest.reason``; engine closes are stamped
+  ``engine_exit:<rule_kind>``. The engine triggers on bar N's low
+  (long) / high (short) and fills on bar N+1's open, so realised
+  return can land below the rule's raw threshold via gap fills —
+  those are absorbed when matched 1:1 with firings. Trailing variants
+  need bar-by-bar replay and are flagged as informational.
 * **TakeProfitRule(pct=P)** — sanity-only: when ``exit_rules`` contains
   exactly one rule and that rule is the take-profit, we expect at least
   one engine firing. When other rules are present, the take-profit may
@@ -37,6 +43,7 @@ from ...models import (
     BacktestExecutionDiagnostics,
     TradeRecord,
 )
+from ...trading_service.service import ENGINE_EXIT_REASON_PREFIX
 from ..spec_dsl import (
     ExitRule,
     SignalExitRule,
@@ -150,18 +157,46 @@ class ExitRuleConformanceGate:
         # ``return_pct`` against a strict floor without false-positive
         # criticals on every gap.
         #
-        # Per-symbol attribution: count below-floor trades per symbol
-        # and compare to the engine's per-symbol ``stop_loss`` firings.
-        # A global rule-kind count would let an unrelated firing on
-        # symbol A mask a leak on symbol B; per-symbol attribution
-        # confines the gate's reasoning to one symbol at a time. Cap
-        # ``min(tripped_count, firings_count)`` covers the protected
-        # trades; the rest are leaks.
+        # Per-symbol attribution: count engine-attributed below-floor
+        # trades per symbol and compare to the engine's per-symbol
+        # ``stop_loss`` firings. A global rule-kind count would let
+        # an unrelated firing on symbol A mask a leak on symbol B;
+        # per-symbol attribution confines the gate's reasoning to
+        # one symbol at a time. Cap ``min(tripped_count, firings_count)``
+        # covers the protected trades; the rest are leaks.
+        #
+        # The gate only counts below-floor trades the engine itself
+        # claimed via ``exit_reason == "engine_exit:stop_loss"``. The
+        # exclusions:
+        #
+        # * ``exit_reason`` is None / empty / a strategy string —
+        #   strategy closed the position; the engine never had a
+        #   chance to fire on that bar (e.g. strategy market exit
+        #   fills on a gap-down next-bar open beneath the floor
+        #   BEFORE the engine evaluates rules). Not a leak — the
+        #   strategy made the call.
+        # * ``exit_reason`` is some other ``engine_exit:<kind>`` —
+        #   engine fired a different rule (e.g. take_profit) which
+        #   filled below the floor on a gap. That's a deliberate
+        #   engine choice for a different rule, not a stop_loss leak.
+        #
+        # What's left ("engine_exit:stop_loss" + below floor) must
+        # match the engine's per-symbol stop_loss firing count. Any
+        # excess is a bookkeeping leak between the dispatcher's
+        # emission path and the diagnostics counter.
         raw_floor_pct = -(rule.pct * 100.0)
+        engine_stop_kind = f"{ENGINE_EXIT_REASON_PREFIX}stop_loss"
         by_symbol_tripped: dict[str, list[TradeRecord]] = {}
+        skipped_strategy_closes = 0
         for t in trades:
-            if t.return_pct < raw_floor_pct:
-                by_symbol_tripped.setdefault(t.symbol, []).append(t)
+            if t.return_pct >= raw_floor_pct:
+                continue
+            if t.exit_reason != engine_stop_kind:
+                # Strategy-closed OR engine-closed via a different
+                # rule — neither indicates a stop_loss leak.
+                skipped_strategy_closes += 1
+                continue
+            by_symbol_tripped.setdefault(t.symbol, []).append(t)
         unaccounted: list[TradeRecord] = []
         total_firings = 0
         for sym, tripped in by_symbol_tripped.items():
@@ -170,6 +205,11 @@ class ExitRuleConformanceGate:
             if len(tripped) > sym_firings:
                 unaccounted.extend(tripped[sym_firings:])
         total_tripped = sum(len(v) for v in by_symbol_tripped.values())
+        skipped_suffix = (
+            f"; excluded {skipped_strategy_closes} strategy-closed below-floor trade(s)"
+            if skipped_strategy_closes
+            else ""
+        )
         if unaccounted:
             sample = [(t.trade_num, t.symbol, t.return_pct) for t in unaccounted[:5]]
             return QualityGateResult(
@@ -177,10 +217,10 @@ class ExitRuleConformanceGate:
                 passed=False,
                 severity="critical",
                 details=(
-                    f"StopLossRule(pct={rule.pct}) leak: {total_tripped} trade(s) "
-                    f"closed below the {raw_floor_pct:.2f}% floor; "
+                    f"StopLossRule(pct={rule.pct}) leak: {total_tripped} engine-attributed "
+                    f"trade(s) closed below the {raw_floor_pct:.2f}% floor; "
                     f"{len(unaccounted)} unaccounted for by per-symbol firings. "
-                    f"Sample (trade_num, symbol, return_pct)={sample}."
+                    f"Sample (trade_num, symbol, return_pct)={sample}{skipped_suffix}."
                 ),
             )
         return QualityGateResult(
@@ -189,9 +229,9 @@ class ExitRuleConformanceGate:
             severity="info",
             details=(
                 f"StopLossRule(pct={rule.pct}) — per-symbol firings cover "
-                f"{total_tripped} below-floor trade(s) across "
+                f"{total_tripped} engine-attributed below-floor trade(s) across "
                 f"{len(by_symbol_tripped)} symbol(s); "
-                f"total firings={total_firings}."
+                f"total firings={total_firings}{skipped_suffix}."
             ),
         )
 

--- a/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
@@ -5,12 +5,15 @@ bar loop, every trade either obeys the rules within tolerance or comes from
 the strategy code's own exit logic.  This gate iterates the trade ledger
 and the execution diagnostics and reports:
 
-* **StopLossRule(pct=P, basis="entry_price")** — for losing trades, the
-  worst observed return is bounded by ``-pct - slippage_tolerance``.
-  Slippage on the close fill can push the realised return slightly past
-  the rule's floor; the tolerance band derives from
-  ``BacktestConfig.slippage_bps``. Trailing variants need bar-by-bar
-  replay and are flagged as informational.
+* **StopLossRule(pct=P, basis="entry_price")** — count trades whose
+  return cleared the raw ``-pct`` floor. The engine detects the trigger
+  on bar N's low (long) / high (short) but the synthetic close fills on
+  bar N+1's open, so an overnight gap can land the realised return
+  arbitrarily far below the rule's threshold without indicating an
+  enforcement bug. Critical failure fires only when below-floor trades
+  exist *and* the engine never emitted any ``stop_loss`` close — i.e.
+  the rule was tripped but the enforcement path didn't run. Trailing
+  variants need bar-by-bar replay and are flagged as informational.
 * **TakeProfitRule(pct=P)** — sanity-only: when ``exit_rules`` contains
   exactly one rule and that rule is the take-profit, we expect at least
   one engine firing. When other rules are present, the take-profit may
@@ -25,7 +28,7 @@ of which the alignment agent's LLM-driven audit should defer to.
 
 from __future__ import annotations
 
-from typing import List, Optional, Sequence
+from typing import List, Mapping, Optional, Sequence
 
 from ...models import (
     BacktestConfig,
@@ -66,13 +69,14 @@ class ExitRuleConformanceGate:
             ]
 
         results: List[QualityGateResult] = []
+        firings = (diagnostics.exit_rule_firings if diagnostics is not None else None) or {}
 
         # ---- StopLossRule (entry_price basis only — trailing variants need
         # bar-by-bar replay which the gate cannot reconstruct from the trade
         # ledger alone) ----
         stop_losses = [r for r in exit_rules if isinstance(r, StopLossRule)]
         for rule in stop_losses:
-            results.append(self._check_stop_loss(rule, trades, config))
+            results.append(self._check_stop_loss(rule, trades, firings))
 
         # ---- TakeProfitRule (sanity only) ----
         take_profits = [r for r in exit_rules if isinstance(r, TakeProfitRule)]
@@ -120,7 +124,7 @@ class ExitRuleConformanceGate:
     def _check_stop_loss(
         rule: StopLossRule,
         trades: Sequence[TradeRecord],
-        config: BacktestConfig,
+        firings: Mapping[str, int],
     ) -> QualityGateResult:
         if rule.basis != "entry_price":
             return QualityGateResult(
@@ -132,22 +136,34 @@ class ExitRuleConformanceGate:
                     "(trailing variants require bar-by-bar replay)."
                 ),
             )
-        # Tolerance band: slippage on the close fill can push the realised
-        # return past the rule's floor. Use 2x the configured slippage as
-        # an upper-bound on cumulative entry+exit slip, plus a small
-        # absolute pad so float-equality noise doesn't trip the gate.
-        slip_pct = (config.slippage_bps / 10_000.0) * 2.0
-        floor_pct = -(rule.pct * 100.0) - (slip_pct * 100.0) - 0.5
-        offenders = [t for t in trades if t.return_pct < floor_pct]
-        if offenders:
-            sample = [(t.trade_num, t.return_pct) for t in offenders[:5]]
+        # The engine detects the trigger on bar N's low (long) / high
+        # (short), but the synthetic market close fills on bar N+1's
+        # open. That next-bar fill can land arbitrarily far below the
+        # trigger price on an overnight gap (long entry at 100, stop at
+        # 95, next bar opens at 80 → return_pct ≈ -20% even though the
+        # engine emitted the exit as designed). So we can't bound
+        # ``return_pct`` against a strict floor without false-positive
+        # criticals on every gap.
+        #
+        # Instead: count trades whose return clearly tripped the rule's
+        # raw threshold (no slippage tolerance). If those exist AND the
+        # engine never emitted any ``stop_loss`` close, that's a
+        # genuine enforcement leak. Otherwise the firings counter
+        # confirms the engine did its job and the residual gap is a
+        # real-world market-execution cost, not a conformance bug.
+        raw_floor_pct = -(rule.pct * 100.0)
+        tripped = [t for t in trades if t.return_pct < raw_floor_pct]
+        stop_firings = firings.get("stop_loss", 0)
+        if tripped and stop_firings == 0:
+            sample = [(t.trade_num, t.return_pct) for t in tripped[:5]]
             return QualityGateResult(
                 gate_name=GATE,
                 passed=False,
                 severity="critical",
                 details=(
-                    f"StopLossRule(pct={rule.pct}) violated: {len(offenders)} "
-                    f"trade(s) below floor {floor_pct:.2f}%. Sample "
+                    f"StopLossRule(pct={rule.pct}) leak: {len(tripped)} trade(s) "
+                    f"closed below the {raw_floor_pct:.2f}% floor but the engine "
+                    "never emitted a stop_loss exit. Sample "
                     f"(trade_num, return_pct)={sample}."
                 ),
             )
@@ -156,8 +172,9 @@ class ExitRuleConformanceGate:
             passed=True,
             severity="info",
             details=(
-                f"StopLossRule(pct={rule.pct}) satisfied across "
-                f"{len(trades)} trade(s); floor={floor_pct:.2f}%."
+                f"StopLossRule(pct={rule.pct}) — "
+                f"{stop_firings} engine firing(s) recorded; "
+                f"{len(tripped)} trade(s) below raw floor (gap-fill expected on next-bar opens)."
             ),
         )
 

--- a/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
@@ -81,7 +81,7 @@ class ExitRuleConformanceGate:
         # ---- TakeProfitRule (sanity only) ----
         take_profits = [r for r in exit_rules if isinstance(r, TakeProfitRule)]
         for rule in take_profits:
-            results.append(self._check_take_profit(rule, trades, exit_rules))
+            results.append(self._check_take_profit(rule, trades, exit_rules, firings))
 
         # ---- SignalExitRule — not yet engine-enforced ----
         signal_exits = [r for r in exit_rules if isinstance(r, SignalExitRule)]
@@ -145,16 +145,22 @@ class ExitRuleConformanceGate:
         # ``return_pct`` against a strict floor without false-positive
         # criticals on every gap.
         #
-        # Instead: count trades whose return clearly tripped the rule's
-        # raw threshold (no slippage tolerance). If those exist AND the
-        # engine never emitted any ``stop_loss`` close, that's a
-        # genuine enforcement leak. Otherwise the firings counter
-        # confirms the engine did its job and the residual gap is a
-        # real-world market-execution cost, not a conformance bug.
+        # Per-trade comparison: count trades whose return cleared the
+        # rule's raw threshold (no slippage tolerance) and compare to
+        # the recorded ``stop_loss`` firing count. If the number of
+        # below-floor trades EXCEEDS the firing count, at least one
+        # trade fell through without engine enforcement — that's a
+        # leak. ``stop_firings >= tripped`` means each below-floor
+        # trade is plausibly accounted for by a matching engine
+        # emission (and the residual return shortfall is a gap fill, not
+        # a leak). Pure trade-count comparison can't tell which
+        # specific trade leaked, but it can't mask leaks behind
+        # unrelated firings either.
         raw_floor_pct = -(rule.pct * 100.0)
         tripped = [t for t in trades if t.return_pct < raw_floor_pct]
         stop_firings = firings.get("stop_loss", 0)
-        if tripped and stop_firings == 0:
+        if len(tripped) > stop_firings:
+            leak_count = len(tripped) - stop_firings
             sample = [(t.trade_num, t.return_pct) for t in tripped[:5]]
             return QualityGateResult(
                 gate_name=GATE,
@@ -163,7 +169,8 @@ class ExitRuleConformanceGate:
                 details=(
                     f"StopLossRule(pct={rule.pct}) leak: {len(tripped)} trade(s) "
                     f"closed below the {raw_floor_pct:.2f}% floor but the engine "
-                    "never emitted a stop_loss exit. Sample "
+                    f"recorded only {stop_firings} stop_loss firing(s) "
+                    f"({leak_count} unaccounted-for trade(s)). Sample "
                     f"(trade_num, return_pct)={sample}."
                 ),
             )
@@ -173,8 +180,8 @@ class ExitRuleConformanceGate:
             severity="info",
             details=(
                 f"StopLossRule(pct={rule.pct}) — "
-                f"{stop_firings} engine firing(s) recorded; "
-                f"{len(tripped)} trade(s) below raw floor (gap-fill expected on next-bar opens)."
+                f"{stop_firings} engine firing(s) covers "
+                f"{len(tripped)} below-floor trade(s) (gap-fill expected on next-bar opens)."
             ),
         )
 
@@ -183,13 +190,21 @@ class ExitRuleConformanceGate:
         rule: TakeProfitRule,
         trades: Sequence[TradeRecord],
         all_rules: Sequence[ExitRule],
+        firings: Mapping[str, int],
     ) -> QualityGateResult:
         # Take-profit is hardest to assert on. The engine fires it whenever
-        # bar.high >= entry * (1 + pct), but other rules (stop loss) can
-        # close a trade first. So a passing trade ledger may legitimately
-        # never hit the take-profit floor. We only flag the "lonely
-        # take-profit" case: take-profit is the ONLY rule and zero trades
-        # cleared its threshold.
+        # ``bar.high >= entry * (1 + pct)``, but the synthetic close fills
+        # on bar N+1's open — gaps and slippage can land the realised
+        # ``return_pct`` below the rule's raw target even on a valid
+        # firing. And when other exit rules (stop loss) co-exist, they
+        # can close a trade first.
+        #
+        # The robust signal is the engine ``take_profit`` firings counter:
+        # at least one emission means the rule did its job. We only flag
+        # the "lonely take-profit" case: take-profit is the ONLY rule,
+        # trades exist, and the engine never emitted any take_profit
+        # close — meaning the rule was either misconfigured or the
+        # threshold is unreachable on the symbols' actual price action.
         only_rule = len(all_rules) == 1
         if not only_rule:
             return QualityGateResult(
@@ -202,15 +217,15 @@ class ExitRuleConformanceGate:
                     "trades before the take-profit threshold is reached)."
                 ),
             )
-        target_pct = rule.pct * 100.0
-        if any(t.return_pct >= target_pct for t in trades):
+        tp_firings = firings.get("take_profit", 0)
+        if tp_firings >= 1:
             return QualityGateResult(
                 gate_name=GATE,
                 passed=True,
                 severity="info",
                 details=(
-                    f"TakeProfitRule(pct={rule.pct}) reached on at least one of "
-                    f"{len(trades)} trade(s)."
+                    f"TakeProfitRule(pct={rule.pct}) — {tp_firings} engine firing(s) "
+                    f"recorded across {len(trades)} trade(s)."
                 ),
             )
         if not trades:
@@ -227,8 +242,8 @@ class ExitRuleConformanceGate:
             passed=False,
             severity="warning",
             details=(
-                f"TakeProfitRule(pct={rule.pct}) is the only exit rule but no "
-                f"trade reached the {target_pct:.2f}% threshold across "
-                f"{len(trades)} trade(s)."
+                f"TakeProfitRule(pct={rule.pct}) is the only exit rule but the engine "
+                f"recorded zero take_profit firings across {len(trades)} trade(s) — "
+                "the threshold may be unreachable on the strategy's universe."
             ),
         )

--- a/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
@@ -27,6 +27,7 @@ of which the alignment agent's LLM-driven audit should defer to.
 
 from __future__ import annotations
 
+import math
 from typing import List, Optional, Sequence
 
 from ...models import (
@@ -142,12 +143,20 @@ class ExitRuleConformanceGate:
                     f"timeframe={timeframe!r} (gate is daily-only for the MVP)."
                 ),
             )
-        # Engine emits the close on the Nth bar; fill lands on the (N+1)th
-        # bar's open. Worst-case observed ``hold_days`` is ``n_bars`` —
-        # entry on day 1, close on day N+1, hold_days = N. Add a one-day
-        # safety margin to account for weekend/holiday gaps where the next
-        # trading day is more than 24h after the close emission.
-        ceiling = rule.n_bars + 1
+        # ``hold_days`` is a calendar-day delta on ``TradeRecord``; the
+        # rule's ``n_bars`` counts trading bars. For daily-bar US-equity
+        # data, every 5 trading bars span at least one weekend (2 calendar
+        # days). Plus a 1-bar fill-lag (close emitted on bar N, fills on
+        # bar N+1's open — and that next trading day can be a Monday) and
+        # an allowance for the ~10 US market holidays per year (~1 day per
+        # 25 trading days). The conservative upper bound is
+        # ``n_bars + ceil(n_bars * 2/5) + ceil(n_bars / 25) + 3``: it
+        # widens to absorb weekends/holidays but is still tight enough to
+        # catch gross engine-enforcement leaks (e.g. ``n_bars=5`` allows
+        # at most 10 calendar days). Without this, a 1-bar hold across a
+        # Fri→Mon weekend records ``hold_days==3`` and trips a false
+        # critical for ``TimeStopRule(n_bars=1)``.
+        ceiling = rule.n_bars + math.ceil(rule.n_bars * 2 / 5) + math.ceil(rule.n_bars / 25) + 3
         offenders = [t for t in trades if t.hold_days > ceiling]
         if offenders:
             sample = [t.trade_num for t in offenders[:5]]

--- a/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
@@ -5,15 +5,17 @@ bar loop, every trade either obeys the rules within tolerance or comes from
 the strategy code's own exit logic.  This gate iterates the trade ledger
 and the execution diagnostics and reports:
 
-* **StopLossRule(pct=P, basis="entry_price")** — count trades whose
-  return cleared the raw ``-pct`` floor. The engine detects the trigger
-  on bar N's low (long) / high (short) but the synthetic close fills on
-  bar N+1's open, so an overnight gap can land the realised return
-  arbitrarily far below the rule's threshold without indicating an
-  enforcement bug. Critical failure fires only when below-floor trades
-  exist *and* the engine never emitted any ``stop_loss`` close — i.e.
-  the rule was tripped but the enforcement path didn't run. Trailing
-  variants need bar-by-bar replay and are flagged as informational.
+* **StopLossRule(pct=P, basis="entry_price")** — count below-floor
+  trades per symbol and compare to the engine's per-symbol
+  ``stop_loss`` firings. Critical failure fires when any symbol's
+  below-floor trade count exceeds its firing count (the rule was
+  tripped but the enforcement path didn't run). Per-symbol attribution
+  prevents a stop firing on symbol A from masking a leak on symbol B.
+  The engine triggers on bar N's low (long) / high (short) and fills
+  on bar N+1's open, so realised return can land below the rule's
+  raw threshold via gap fills — those are absorbed when matched 1:1
+  with firings. Trailing variants need bar-by-bar replay and are
+  flagged as informational.
 * **TakeProfitRule(pct=P)** — sanity-only: when ``exit_rules`` contains
   exactly one rule and that rule is the take-profit, we expect at least
   one engine firing. When other rules are present, the take-profit may
@@ -70,13 +72,16 @@ class ExitRuleConformanceGate:
 
         results: List[QualityGateResult] = []
         firings = (diagnostics.exit_rule_firings if diagnostics is not None else None) or {}
+        firings_by_symbol = (
+            diagnostics.exit_rule_firings_by_symbol if diagnostics is not None else None
+        ) or {}
 
         # ---- StopLossRule (entry_price basis only — trailing variants need
         # bar-by-bar replay which the gate cannot reconstruct from the trade
         # ledger alone) ----
         stop_losses = [r for r in exit_rules if isinstance(r, StopLossRule)]
         for rule in stop_losses:
-            results.append(self._check_stop_loss(rule, trades, firings))
+            results.append(self._check_stop_loss(rule, trades, firings_by_symbol))
 
         # ---- TakeProfitRule (sanity only) ----
         take_profits = [r for r in exit_rules if isinstance(r, TakeProfitRule)]
@@ -124,7 +129,7 @@ class ExitRuleConformanceGate:
     def _check_stop_loss(
         rule: StopLossRule,
         trades: Sequence[TradeRecord],
-        firings: Mapping[str, int],
+        firings_by_symbol: Mapping[str, Mapping[str, int]],
     ) -> QualityGateResult:
         if rule.basis != "entry_price":
             return QualityGateResult(
@@ -145,33 +150,37 @@ class ExitRuleConformanceGate:
         # ``return_pct`` against a strict floor without false-positive
         # criticals on every gap.
         #
-        # Per-trade comparison: count trades whose return cleared the
-        # rule's raw threshold (no slippage tolerance) and compare to
-        # the recorded ``stop_loss`` firing count. If the number of
-        # below-floor trades EXCEEDS the firing count, at least one
-        # trade fell through without engine enforcement — that's a
-        # leak. ``stop_firings >= tripped`` means each below-floor
-        # trade is plausibly accounted for by a matching engine
-        # emission (and the residual return shortfall is a gap fill, not
-        # a leak). Pure trade-count comparison can't tell which
-        # specific trade leaked, but it can't mask leaks behind
-        # unrelated firings either.
+        # Per-symbol attribution: count below-floor trades per symbol
+        # and compare to the engine's per-symbol ``stop_loss`` firings.
+        # A global rule-kind count would let an unrelated firing on
+        # symbol A mask a leak on symbol B; per-symbol attribution
+        # confines the gate's reasoning to one symbol at a time. Cap
+        # ``min(tripped_count, firings_count)`` covers the protected
+        # trades; the rest are leaks.
         raw_floor_pct = -(rule.pct * 100.0)
-        tripped = [t for t in trades if t.return_pct < raw_floor_pct]
-        stop_firings = firings.get("stop_loss", 0)
-        if len(tripped) > stop_firings:
-            leak_count = len(tripped) - stop_firings
-            sample = [(t.trade_num, t.return_pct) for t in tripped[:5]]
+        by_symbol_tripped: dict[str, list[TradeRecord]] = {}
+        for t in trades:
+            if t.return_pct < raw_floor_pct:
+                by_symbol_tripped.setdefault(t.symbol, []).append(t)
+        unaccounted: list[TradeRecord] = []
+        total_firings = 0
+        for sym, tripped in by_symbol_tripped.items():
+            sym_firings = firings_by_symbol.get(sym, {}).get("stop_loss", 0)
+            total_firings += sym_firings
+            if len(tripped) > sym_firings:
+                unaccounted.extend(tripped[sym_firings:])
+        total_tripped = sum(len(v) for v in by_symbol_tripped.values())
+        if unaccounted:
+            sample = [(t.trade_num, t.symbol, t.return_pct) for t in unaccounted[:5]]
             return QualityGateResult(
                 gate_name=GATE,
                 passed=False,
                 severity="critical",
                 details=(
-                    f"StopLossRule(pct={rule.pct}) leak: {len(tripped)} trade(s) "
-                    f"closed below the {raw_floor_pct:.2f}% floor but the engine "
-                    f"recorded only {stop_firings} stop_loss firing(s) "
-                    f"({leak_count} unaccounted-for trade(s)). Sample "
-                    f"(trade_num, return_pct)={sample}."
+                    f"StopLossRule(pct={rule.pct}) leak: {total_tripped} trade(s) "
+                    f"closed below the {raw_floor_pct:.2f}% floor; "
+                    f"{len(unaccounted)} unaccounted for by per-symbol firings. "
+                    f"Sample (trade_num, symbol, return_pct)={sample}."
                 ),
             )
         return QualityGateResult(
@@ -179,9 +188,10 @@ class ExitRuleConformanceGate:
             passed=True,
             severity="info",
             details=(
-                f"StopLossRule(pct={rule.pct}) — "
-                f"{stop_firings} engine firing(s) covers "
-                f"{len(tripped)} below-floor trade(s) (gap-fill expected on next-bar opens)."
+                f"StopLossRule(pct={rule.pct}) — per-symbol firings cover "
+                f"{total_tripped} below-floor trade(s) across "
+                f"{len(by_symbol_tripped)} symbol(s); "
+                f"total firings={total_firings}."
             ),
         )
 

--- a/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
@@ -3,31 +3,28 @@
 Once :class:`TradingService` enforces structured ``ExitRule`` objects in its
 bar loop, every trade either obeys the rules within tolerance or comes from
 the strategy code's own exit logic.  This gate iterates the trade ledger
-and the execution diagnostics and reports the first kind of violation:
+and the execution diagnostics and reports:
 
-* **TimeStopRule(n_bars=N)** — every trade ``hold_days <= N + 1`` (the +1
-  is the bar of fill lag: engine emits the close on bar N, fills at bar
-  N+1's open).  Only meaningful on daily timeframes; sub-daily runs are
-  flagged as ``info`` (not enforced) until bar-aware hold counting lands.
 * **StopLossRule(pct=P, basis="entry_price")** — for losing trades, the
   worst observed return is bounded by ``-pct - slippage_tolerance``.
   Slippage on the close fill can push the realised return slightly past
   the rule's floor; the tolerance band derives from
-  ``BacktestConfig.slippage_bps``.
+  ``BacktestConfig.slippage_bps``. Trailing variants need bar-by-bar
+  replay and are flagged as informational.
 * **TakeProfitRule(pct=P)** — sanity-only: when ``exit_rules`` contains
   exactly one rule and that rule is the take-profit, we expect at least
-  one engine firing.  When other rules are present, the take-profit may
-  legitimately never fire (a time stop closed the trade first).
+  one engine firing. When other rules are present, the take-profit may
+  legitimately never fire (a stop-loss closed the trade first).
+* **SignalExitRule** — informational; not yet engine-enforced.
 
-The gate is **deterministic and post-hoc**.  It does not re-run the
-strategy or call out to an LLM.  Critical failures here indicate either
+The gate is **deterministic and post-hoc**. It does not re-run the
+strategy or call out to an LLM. Critical failures here indicate either
 a bug in :mod:`rule_compiler` or a violation of engine invariants — both
 of which the alignment agent's LLM-driven audit should defer to.
 """
 
 from __future__ import annotations
 
-import math
 from typing import List, Optional, Sequence
 
 from ...models import (
@@ -40,7 +37,6 @@ from ..spec_dsl import (
     SignalExitRule,
     StopLossRule,
     TakeProfitRule,
-    TimeStopRule,
 )
 from .models import QualityGateResult
 
@@ -70,11 +66,6 @@ class ExitRuleConformanceGate:
             ]
 
         results: List[QualityGateResult] = []
-
-        # ---- TimeStopRule ----
-        time_stops = [r for r in exit_rules if isinstance(r, TimeStopRule)]
-        for rule in time_stops:
-            results.append(self._check_time_stop(rule, trades, timeframe))
 
         # ---- StopLossRule (entry_price basis only — trailing variants need
         # bar-by-bar replay which the gate cannot reconstruct from the trade
@@ -124,60 +115,6 @@ class ExitRuleConformanceGate:
     # ------------------------------------------------------------------
     # Per-rule checks
     # ------------------------------------------------------------------
-
-    @staticmethod
-    def _check_time_stop(
-        rule: TimeStopRule,
-        trades: Sequence[TradeRecord],
-        timeframe: str,
-    ) -> QualityGateResult:
-        if timeframe != "1d":
-            # ``hold_days`` is calendar-day granular; comparing against
-            # ``n_bars`` only makes sense when one bar == one day.
-            return QualityGateResult(
-                gate_name=GATE,
-                passed=True,
-                severity="info",
-                details=(
-                    f"TimeStopRule(n_bars={rule.n_bars}) conformance check skipped on "
-                    f"timeframe={timeframe!r} (gate is daily-only for the MVP)."
-                ),
-            )
-        # ``hold_days`` is a calendar-day delta on ``TradeRecord``; the
-        # rule's ``n_bars`` counts trading bars. For daily-bar US-equity
-        # data, every 5 trading bars span at least one weekend (2 calendar
-        # days). Plus a 1-bar fill-lag (close emitted on bar N, fills on
-        # bar N+1's open — and that next trading day can be a Monday) and
-        # an allowance for the ~10 US market holidays per year (~1 day per
-        # 25 trading days). The conservative upper bound is
-        # ``n_bars + ceil(n_bars * 2/5) + ceil(n_bars / 25) + 3``: it
-        # widens to absorb weekends/holidays but is still tight enough to
-        # catch gross engine-enforcement leaks (e.g. ``n_bars=5`` allows
-        # at most 10 calendar days). Without this, a 1-bar hold across a
-        # Fri→Mon weekend records ``hold_days==3`` and trips a false
-        # critical for ``TimeStopRule(n_bars=1)``.
-        ceiling = rule.n_bars + math.ceil(rule.n_bars * 2 / 5) + math.ceil(rule.n_bars / 25) + 3
-        offenders = [t for t in trades if t.hold_days > ceiling]
-        if offenders:
-            sample = [t.trade_num for t in offenders[:5]]
-            return QualityGateResult(
-                gate_name=GATE,
-                passed=False,
-                severity="critical",
-                details=(
-                    f"TimeStopRule(n_bars={rule.n_bars}) violated: "
-                    f"{len(offenders)} trade(s) held > {ceiling} days "
-                    f"(sample trade_nums={sample})."
-                ),
-            )
-        return QualityGateResult(
-            gate_name=GATE,
-            passed=True,
-            severity="info",
-            details=(
-                f"TimeStopRule(n_bars={rule.n_bars}) satisfied across {len(trades)} trade(s)."
-            ),
-        )
 
     @staticmethod
     def _check_stop_loss(
@@ -231,11 +168,11 @@ class ExitRuleConformanceGate:
         all_rules: Sequence[ExitRule],
     ) -> QualityGateResult:
         # Take-profit is hardest to assert on. The engine fires it whenever
-        # bar.high >= entry * (1 + pct), but other rules (time stop, stop
-        # loss) can close a trade first. So a passing trade ledger may
-        # legitimately never hit the take-profit floor. We only flag the
-        # "lonely take-profit" case: take-profit is the ONLY rule and zero
-        # trades cleared its threshold.
+        # bar.high >= entry * (1 + pct), but other rules (stop loss) can
+        # close a trade first. So a passing trade ledger may legitimately
+        # never hit the take-profit floor. We only flag the "lonely
+        # take-profit" case: take-profit is the ONLY rule and zero trades
+        # cleared its threshold.
         only_rule = len(all_rules) == 1
         if not only_rule:
             return QualityGateResult(

--- a/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
@@ -1,0 +1,271 @@
+"""Issue #527 — deterministic conformance gate for engine-enforced exit rules.
+
+Once :class:`TradingService` enforces structured ``ExitRule`` objects in its
+bar loop, every trade either obeys the rules within tolerance or comes from
+the strategy code's own exit logic.  This gate iterates the trade ledger
+and the execution diagnostics and reports the first kind of violation:
+
+* **TimeStopRule(n_bars=N)** — every trade ``hold_days <= N + 1`` (the +1
+  is the bar of fill lag: engine emits the close on bar N, fills at bar
+  N+1's open).  Only meaningful on daily timeframes; sub-daily runs are
+  flagged as ``info`` (not enforced) until bar-aware hold counting lands.
+* **StopLossRule(pct=P, basis="entry_price")** — for losing trades, the
+  worst observed return is bounded by ``-pct - slippage_tolerance``.
+  Slippage on the close fill can push the realised return slightly past
+  the rule's floor; the tolerance band derives from
+  ``BacktestConfig.slippage_bps``.
+* **TakeProfitRule(pct=P)** — sanity-only: when ``exit_rules`` contains
+  exactly one rule and that rule is the take-profit, we expect at least
+  one engine firing.  When other rules are present, the take-profit may
+  legitimately never fire (a time stop closed the trade first).
+
+The gate is **deterministic and post-hoc**.  It does not re-run the
+strategy or call out to an LLM.  Critical failures here indicate either
+a bug in :mod:`rule_compiler` or a violation of engine invariants — both
+of which the alignment agent's LLM-driven audit should defer to.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Sequence
+
+from ...models import (
+    BacktestConfig,
+    BacktestExecutionDiagnostics,
+    TradeRecord,
+)
+from ..spec_dsl import (
+    ExitRule,
+    SignalExitRule,
+    StopLossRule,
+    TakeProfitRule,
+    TimeStopRule,
+)
+from .models import QualityGateResult
+
+GATE = "exit_rule_conformance"
+
+
+class ExitRuleConformanceGate:
+    """Deterministic post-run check that engine-emitted exits match the spec."""
+
+    def check(
+        self,
+        *,
+        exit_rules: Sequence[ExitRule],
+        trades: Sequence[TradeRecord],
+        diagnostics: Optional[BacktestExecutionDiagnostics],
+        config: BacktestConfig,
+        timeframe: str = "1d",
+    ) -> List[QualityGateResult]:
+        if not exit_rules:
+            return [
+                QualityGateResult(
+                    gate_name=GATE,
+                    passed=True,
+                    severity="info",
+                    details="spec.exit_rules empty; engine-enforcement check skipped.",
+                )
+            ]
+
+        results: List[QualityGateResult] = []
+
+        # ---- TimeStopRule ----
+        time_stops = [r for r in exit_rules if isinstance(r, TimeStopRule)]
+        for rule in time_stops:
+            results.append(self._check_time_stop(rule, trades, timeframe))
+
+        # ---- StopLossRule (entry_price basis only — trailing variants need
+        # bar-by-bar replay which the gate cannot reconstruct from the trade
+        # ledger alone) ----
+        stop_losses = [r for r in exit_rules if isinstance(r, StopLossRule)]
+        for rule in stop_losses:
+            results.append(self._check_stop_loss(rule, trades, config))
+
+        # ---- TakeProfitRule (sanity only) ----
+        take_profits = [r for r in exit_rules if isinstance(r, TakeProfitRule)]
+        for rule in take_profits:
+            results.append(self._check_take_profit(rule, trades, exit_rules))
+
+        # ---- SignalExitRule — not yet engine-enforced ----
+        signal_exits = [r for r in exit_rules if isinstance(r, SignalExitRule)]
+        if signal_exits:
+            results.append(
+                QualityGateResult(
+                    gate_name=GATE,
+                    passed=True,
+                    severity="info",
+                    details=(
+                        f"{len(signal_exits)} SignalExitRule(s) present but not yet "
+                        "engine-enforced (see rule_compiler module docstring)."
+                    ),
+                )
+            )
+
+        # ---- Aggregate: engine emitted at least one exit when expected ----
+        if diagnostics is not None:
+            firings = diagnostics.exit_rule_firings or {}
+            total = sum(firings.values())
+            details = "engine_exits: " + (
+                ", ".join(f"{k}={v}" for k, v in sorted(firings.items())) or "none"
+            )
+            results.append(
+                QualityGateResult(
+                    gate_name=GATE,
+                    passed=True,
+                    severity="info",
+                    details=details + f" (total={total}, trades={len(trades)})",
+                )
+            )
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Per-rule checks
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _check_time_stop(
+        rule: TimeStopRule,
+        trades: Sequence[TradeRecord],
+        timeframe: str,
+    ) -> QualityGateResult:
+        if timeframe != "1d":
+            # ``hold_days`` is calendar-day granular; comparing against
+            # ``n_bars`` only makes sense when one bar == one day.
+            return QualityGateResult(
+                gate_name=GATE,
+                passed=True,
+                severity="info",
+                details=(
+                    f"TimeStopRule(n_bars={rule.n_bars}) conformance check skipped on "
+                    f"timeframe={timeframe!r} (gate is daily-only for the MVP)."
+                ),
+            )
+        # Engine emits the close on the Nth bar; fill lands on the (N+1)th
+        # bar's open. Worst-case observed ``hold_days`` is ``n_bars`` —
+        # entry on day 1, close on day N+1, hold_days = N. Add a one-day
+        # safety margin to account for weekend/holiday gaps where the next
+        # trading day is more than 24h after the close emission.
+        ceiling = rule.n_bars + 1
+        offenders = [t for t in trades if t.hold_days > ceiling]
+        if offenders:
+            sample = [t.trade_num for t in offenders[:5]]
+            return QualityGateResult(
+                gate_name=GATE,
+                passed=False,
+                severity="critical",
+                details=(
+                    f"TimeStopRule(n_bars={rule.n_bars}) violated: "
+                    f"{len(offenders)} trade(s) held > {ceiling} days "
+                    f"(sample trade_nums={sample})."
+                ),
+            )
+        return QualityGateResult(
+            gate_name=GATE,
+            passed=True,
+            severity="info",
+            details=(
+                f"TimeStopRule(n_bars={rule.n_bars}) satisfied across {len(trades)} trade(s)."
+            ),
+        )
+
+    @staticmethod
+    def _check_stop_loss(
+        rule: StopLossRule,
+        trades: Sequence[TradeRecord],
+        config: BacktestConfig,
+    ) -> QualityGateResult:
+        if rule.basis != "entry_price":
+            return QualityGateResult(
+                gate_name=GATE,
+                passed=True,
+                severity="info",
+                details=(
+                    f"StopLossRule(basis={rule.basis!r}) conformance check skipped "
+                    "(trailing variants require bar-by-bar replay)."
+                ),
+            )
+        # Tolerance band: slippage on the close fill can push the realised
+        # return past the rule's floor. Use 2x the configured slippage as
+        # an upper-bound on cumulative entry+exit slip, plus a small
+        # absolute pad so float-equality noise doesn't trip the gate.
+        slip_pct = (config.slippage_bps / 10_000.0) * 2.0
+        floor_pct = -(rule.pct * 100.0) - (slip_pct * 100.0) - 0.5
+        offenders = [t for t in trades if t.return_pct < floor_pct]
+        if offenders:
+            sample = [(t.trade_num, t.return_pct) for t in offenders[:5]]
+            return QualityGateResult(
+                gate_name=GATE,
+                passed=False,
+                severity="critical",
+                details=(
+                    f"StopLossRule(pct={rule.pct}) violated: {len(offenders)} "
+                    f"trade(s) below floor {floor_pct:.2f}%. Sample "
+                    f"(trade_num, return_pct)={sample}."
+                ),
+            )
+        return QualityGateResult(
+            gate_name=GATE,
+            passed=True,
+            severity="info",
+            details=(
+                f"StopLossRule(pct={rule.pct}) satisfied across "
+                f"{len(trades)} trade(s); floor={floor_pct:.2f}%."
+            ),
+        )
+
+    @staticmethod
+    def _check_take_profit(
+        rule: TakeProfitRule,
+        trades: Sequence[TradeRecord],
+        all_rules: Sequence[ExitRule],
+    ) -> QualityGateResult:
+        # Take-profit is hardest to assert on. The engine fires it whenever
+        # bar.high >= entry * (1 + pct), but other rules (time stop, stop
+        # loss) can close a trade first. So a passing trade ledger may
+        # legitimately never hit the take-profit floor. We only flag the
+        # "lonely take-profit" case: take-profit is the ONLY rule and zero
+        # trades cleared its threshold.
+        only_rule = len(all_rules) == 1
+        if not only_rule:
+            return QualityGateResult(
+                gate_name=GATE,
+                passed=True,
+                severity="info",
+                details=(
+                    f"TakeProfitRule(pct={rule.pct}) co-exists with other exit "
+                    "rules; conformance is informational (other rules may close "
+                    "trades before the take-profit threshold is reached)."
+                ),
+            )
+        target_pct = rule.pct * 100.0
+        if any(t.return_pct >= target_pct for t in trades):
+            return QualityGateResult(
+                gate_name=GATE,
+                passed=True,
+                severity="info",
+                details=(
+                    f"TakeProfitRule(pct={rule.pct}) reached on at least one of "
+                    f"{len(trades)} trade(s)."
+                ),
+            )
+        if not trades:
+            return QualityGateResult(
+                gate_name=GATE,
+                passed=True,
+                severity="info",
+                details=(
+                    f"TakeProfitRule(pct={rule.pct}) — zero trades produced; no firings to verify."
+                ),
+            )
+        return QualityGateResult(
+            gate_name=GATE,
+            passed=False,
+            severity="warning",
+            details=(
+                f"TakeProfitRule(pct={rule.pct}) is the only exit rule but no "
+                f"trade reached the {target_pct:.2f}% threshold across "
+                f"{len(trades)} trade(s)."
+            ),
+        )

--- a/backend/agents/investment_team/strategy_lab/spec_dsl.py
+++ b/backend/agents/investment_team/strategy_lab/spec_dsl.py
@@ -277,12 +277,6 @@ class EntryRule(_SpecNode):
 EntryRuleUnion = EntryRule
 
 
-class TimeStopRule(_SpecNode):
-    kind: Literal["time_stop"] = "time_stop"
-    n_bars: int = Field(gt=0)
-    note: str = ""
-
-
 class StopLossRule(_SpecNode):
     kind: Literal["stop_loss"] = "stop_loss"
     pct: float = Field(gt=0, le=1.0)
@@ -302,8 +296,12 @@ class SignalExitRule(_SpecNode):
     note: str = ""
 
 
+# Exit rules: structured close conditions the engine enforces (stop-loss /
+# take-profit) plus aspirational signal-based exits. Bar-counting time stops
+# are deliberately *not* a member — real traders close on price, P&L, or
+# signal reversal, not on an arbitrary "Nth bar held" trigger.
 ExitRule = Annotated[
-    Union[TimeStopRule, StopLossRule, TakeProfitRule, SignalExitRule],
+    Union[StopLossRule, TakeProfitRule, SignalExitRule],
     Field(discriminator="kind"),
 ]
 
@@ -345,7 +343,6 @@ SizingRule = Annotated[
 IndicatorRef.model_rebuild()
 Predicate.model_rebuild()
 EntryRule.model_rebuild()
-TimeStopRule.model_rebuild()
 StopLossRule.model_rebuild()
 TakeProfitRule.model_rebuild()
 SignalExitRule.model_rebuild()
@@ -467,12 +464,10 @@ _STOP_LOSS_BASIS_PREFIX: dict[str, str] = {
 
 
 def _format_rule(
-    rule: Union[EntryRule, TimeStopRule, StopLossRule, TakeProfitRule, SignalExitRule],
+    rule: Union[EntryRule, StopLossRule, TakeProfitRule, SignalExitRule],
 ) -> str:
     if isinstance(rule, EntryRule):
         return f"{rule.side} when {_format_predicate(rule.when)}"
-    if isinstance(rule, TimeStopRule):
-        return f"exit after {rule.n_bars} bars"
     if isinstance(rule, StopLossRule):
         prefix = _STOP_LOSS_BASIS_PREFIX.get(rule.basis, "")
         return f"{prefix}stop loss {_format_number(rule.pct * 100)}%"
@@ -497,5 +492,3 @@ def format_sizing_rule(sizing) -> str:
     if isinstance(sizing, FixedNotionalSizing):
         return f"${_format_number(sizing.notional_usd)} per trade"
     raise TypeError(f"unknown SizingRule variant: {type(sizing).__name__}")
-
-

--- a/backend/agents/investment_team/tests/golden/snapshots/overfit_hardcoded_dates.json
+++ b/backend/agents/investment_team/tests/golden/snapshots/overfit_hardcoded_dates.json
@@ -74,6 +74,7 @@
       "closed_trades": 5,
       "entries_filled": 5,
       "exit_rule_firings": {},
+      "exit_rule_firings_by_symbol": {},
       "exits_emitted": 5,
       "last_order_events": [
         {

--- a/backend/agents/investment_team/tests/golden/snapshots/overfit_hardcoded_dates.json
+++ b/backend/agents/investment_team/tests/golden/snapshots/overfit_hardcoded_dates.json
@@ -73,6 +73,7 @@
       "bars_processed": 504,
       "closed_trades": 5,
       "entries_filled": 5,
+      "exit_rule_firings": {},
       "exits_emitted": 5,
       "last_order_events": [
         {

--- a/backend/agents/investment_team/tests/golden/snapshots/prompt_alignment_system.txt
+++ b/backend/agents/investment_team/tests/golden/snapshots/prompt_alignment_system.txt
@@ -21,7 +21,7 @@ The spec contains two kinds of rules; treat them differently:
 ### Enforced rules (engine-checked — `severity: critical` allowed)
 
 These are the rules the backtest engine actually applies. Deviations here
-are real bugs in the strategy code.
+are real bugs in the strategy code or the engine, not artistic licence.
 
 - **Sizing rules** — `shares` respects the documented sizing scheme (fixed
   fraction, volatility target, notional cap, etc.).
@@ -30,26 +30,31 @@ are real bugs in the strategy code.
   ignored stop-losses are critical misalignments.
 - **Universe & direction** — only `asset_class`-appropriate symbols and only
   `long`/`short` sides allowed by the spec should appear.
+- **Exit rules** — `exit_rules` are structured `TimeStopRule` /
+  `StopLossRule` / `TakeProfitRule` / `SignalExitRule` objects that the
+  parent engine evaluates after every bar and enforces by emitting close
+  orders on the strategy's behalf. A separate deterministic conformance
+  gate (`exit_rule_conformance`) is run before this audit and counts the
+  engine firings; trust it. Your job is to flag the rare residual case
+  where the engine's enforcement could not protect the trade (e.g. an
+  overshoot beyond the stop-loss floor by more than slippage tolerance).
+  `severity: critical` is appropriate here. `SignalExitRule` is not yet
+  engine-enforced — see the aspirational section below.
 
 ### Aspirational rules (prose intent — downgrade severity)
 
-`entry_rules` and `exit_rules` are author-supplied prose intent. Until the
-structured-rule DSL work lands, the engine does NOT mechanically enforce
-them — the strategy code is free to ignore prose like "exit after 10 bars"
-or "enter when RSI < 30", and the backtest will still run. Report behavioural
-gaps against this intent, but downgrade them:
+`entry_rules` are author-supplied intent. The engine does NOT
+mechanically open positions from them — the strategy code is free to
+ignore prose like "enter when RSI < 30", and the backtest will still
+run. Report behavioural gaps against this intent, but downgrade them:
 
 - **Entry rules** — describe whether the trade-entry behaviour is consistent
   with the authored intent. If a trade looks like it ignored the intent,
   flag it — but use `severity: warning` (or `info`), not `critical`,
   unless the same trade also breaches an enforced rule above.
-- **Exit rules** — describe whether each exit appears consistent with the
-  authored intent (signal reversal, stop-loss, take-profit, time stop,
-  force-close at the final bar). Holding longer than the prose suggests, or
-  exiting earlier than the prose suggests, is reportable but is NOT a
-  critical misalignment by itself — keep `severity` at `warning` or `info`.
-  Reserve `critical` for cases where the same trade also breaches an
-  enforced rule (e.g. an ignored stop-loss).
+- **SignalExitRule** specifically (predicate-based exits) is also not
+  yet engine-enforced; same `warning` / `info` treatment until the
+  shared per-bar indicator runtime lands.
 
 Cosmetic differences (rounding, tie-breaker behavior on identical signals)
 do NOT count as misalignment. Code is misaligned only when trade behavior
@@ -59,15 +64,17 @@ meaningfully diverges from the specification.
 
 1. **SCAN the spec** — restate each entry rule, exit rule, sizing rule, and
    risk limit. Tag each one as **enforced** (sizing, risk limits, universe,
-   direction) or **aspirational** (entry_rules / exit_rules prose).
+   direction, and every structured `exit_rules` entry except `SignalExitRule`)
+   or **aspirational** (entry_rules prose intent, plus any `SignalExitRule`).
 2. **SPOT-CHECK trades** — use the provided sample ledger rows to check
    whether trade behaviour is consistent with the authored intent. Look for:
    - Trades whose entry behaviour is inconsistent with the authored entry
      intent (note: `severity: warning` unless an enforced rule is also
      breached).
-   - Trades that overshoot the stop-loss (enforced — `critical` allowed)
-     or that exit inconsistently with the authored exit intent (aspirational
-     — `warning` / `info`).
+   - Trades that overshoot the structured stop-loss floor by more than
+     slippage tolerance (enforced — `critical` allowed), or that
+     exceeded a structured time-stop or take-profit threshold (the
+     deterministic conformance gate flags these; defer to it).
    - Trades whose sizing exceeds `max_position_pct` of capital at entry
      (enforced — `critical` allowed).
    - Repeated same-day entries/exits, lookahead bias, or single-bar holds
@@ -100,9 +107,11 @@ invent misalignments.
 ## Output
 
 Reserve `severity: critical` for issues against enforced rules (sizing,
-risk_limits, universe, direction). Issues citing only `entry_rules` or
-`exit_rules` prose MUST use `severity: warning` or `info` unless the same
-trade also breaches an enforced rule.
+risk_limits, universe, direction, structured `exit_rules` except
+`SignalExitRule`). Issues citing only `entry_rules` prose (or a
+`SignalExitRule` predicate, which is not yet engine-enforced) MUST use
+`severity: warning` or `info` unless the same trade also breaches an
+enforced rule.
 
 Return ONLY a JSON object with no markdown:
 

--- a/backend/agents/investment_team/tests/golden/snapshots/prompt_alignment_system.txt
+++ b/backend/agents/investment_team/tests/golden/snapshots/prompt_alignment_system.txt
@@ -30,11 +30,11 @@ are real bugs in the strategy code or the engine, not artistic licence.
   ignored stop-losses are critical misalignments.
 - **Universe & direction** — only `asset_class`-appropriate symbols and only
   `long`/`short` sides allowed by the spec should appear.
-- **Exit rules** — `exit_rules` are structured `TimeStopRule` /
-  `StopLossRule` / `TakeProfitRule` / `SignalExitRule` objects that the
-  parent engine evaluates after every bar and enforces by emitting close
-  orders on the strategy's behalf. A separate deterministic conformance
-  gate (`exit_rule_conformance`) is run before this audit and counts the
+- **Exit rules** — `exit_rules` are structured `StopLossRule` /
+  `TakeProfitRule` / `SignalExitRule` objects that the parent engine
+  evaluates after every bar and enforces by emitting close orders on the
+  strategy's behalf. A separate deterministic conformance gate
+  (`exit_rule_conformance`) is run before this audit and counts the
   engine firings; trust it. Your job is to flag the rare residual case
   where the engine's enforcement could not protect the trade (e.g. an
   overshoot beyond the stop-loss floor by more than slippage tolerance).

--- a/backend/agents/investment_team/tests/golden/snapshots/prompt_analysis_lose.txt
+++ b/backend/agents/investment_team/tests/golden/snapshots/prompt_analysis_lose.txt
@@ -5,7 +5,7 @@ Asset class: equity
 Hypothesis: Trend-followers profit when SMA(20) crosses above SMA(50).
 Signal: SMA(20) > SMA(50)
 Intended entry rules (as authored — may not all be machine-enforced): long when sma(20) > sma(50)
-Engine-enforced exit rules (structured DSL applied by the parent engine every bar): exit after 10 bars, stop loss 2%
+Engine-enforced exit rules (structured DSL applied by the parent engine every bar): take profit 5%, stop loss 2%
 Sizing / risk: risk 1% per trade
 Rationale for testing: Validate SMA-cross trend following on the equity sleeve.
 
@@ -23,7 +23,7 @@ Trade 1: BUY AAA on 2024-01-15 @ 100.00, SELL on 2024-01-25 @ 102.50 (+2.5%)
 Trade 2: BUY BBB on 2024-02-01 @ 50.00, SELL on 2024-02-11 @ 49.00 (-2.0%)
 
 ## Instructions
-Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced for `TimeStopRule`, `StopLossRule`, and `TakeProfitRule`: the parent engine emits closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. a tight cluster of N-day holds points to a time stop firing). `SignalExitRule` entries in the list above are NOT yet engine-enforced — treat any predicate-based exit prose the same way as entry intent.
+Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced for `StopLossRule` and `TakeProfitRule`: the parent engine emits closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. losing trades clustered near the stop-loss floor point to it firing). `SignalExitRule` entries in the list above are NOT yet engine-enforced — treat any predicate-based exit prose the same way as entry intent.
 Think step by step: what failure modes explain weak performance — signal timing, risk/reward asymmetry, cost drag, or rules misaligned with the market regime implied by the results?
 Use the trade-level evidence where it supports your reasoning.
 Write 5-8 sentences. Be specific about *why* this strategy underperformed.

--- a/backend/agents/investment_team/tests/golden/snapshots/prompt_analysis_lose.txt
+++ b/backend/agents/investment_team/tests/golden/snapshots/prompt_analysis_lose.txt
@@ -23,7 +23,7 @@ Trade 1: BUY AAA on 2024-01-15 @ 100.00, SELL on 2024-01-25 @ 102.50 (+2.5%)
 Trade 2: BUY BBB on 2024-02-01 @ 50.00, SELL on 2024-02-11 @ 49.00 (-2.0%)
 
 ## Instructions
-Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced: the parent engine emits time-stop / stop-loss / take-profit closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. a tight cluster of N-day holds points to a time stop firing).
+Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced for `TimeStopRule`, `StopLossRule`, and `TakeProfitRule`: the parent engine emits closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. a tight cluster of N-day holds points to a time stop firing). `SignalExitRule` entries in the list above are NOT yet engine-enforced — treat any predicate-based exit prose the same way as entry intent.
 Think step by step: what failure modes explain weak performance — signal timing, risk/reward asymmetry, cost drag, or rules misaligned with the market regime implied by the results?
 Use the trade-level evidence where it supports your reasoning.
 Write 5-8 sentences. Be specific about *why* this strategy underperformed.

--- a/backend/agents/investment_team/tests/golden/snapshots/prompt_analysis_lose.txt
+++ b/backend/agents/investment_team/tests/golden/snapshots/prompt_analysis_lose.txt
@@ -5,7 +5,7 @@ Asset class: equity
 Hypothesis: Trend-followers profit when SMA(20) crosses above SMA(50).
 Signal: SMA(20) > SMA(50)
 Intended entry rules (as authored — may not all be machine-enforced): long when sma(20) > sma(50)
-Intended exit rules (as authored — may not all be machine-enforced): exit after 10 bars, stop loss 2%
+Engine-enforced exit rules (structured DSL applied by the parent engine every bar): exit after 10 bars, stop loss 2%
 Sizing / risk: risk 1% per trade
 Rationale for testing: Validate SMA-cross trend following on the equity sleeve.
 
@@ -23,7 +23,7 @@ Trade 1: BUY AAA on 2024-01-15 @ 100.00, SELL on 2024-01-25 @ 102.50 (+2.5%)
 Trade 2: BUY BBB on 2024-02-01 @ 50.00, SELL on 2024-02-11 @ 49.00 (-2.0%)
 
 ## Instructions
-The entry/exit rules above are prose specifications, not engine-enforced behaviour — do not assert that trades "violated" them; instead describe whether trade behaviour was consistent with the intent.
+Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced: the parent engine emits time-stop / stop-loss / take-profit closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. a tight cluster of N-day holds points to a time stop firing).
 Think step by step: what failure modes explain weak performance — signal timing, risk/reward asymmetry, cost drag, or rules misaligned with the market regime implied by the results?
 Use the trade-level evidence where it supports your reasoning.
 Write 5-8 sentences. Be specific about *why* this strategy underperformed.

--- a/backend/agents/investment_team/tests/golden/snapshots/prompt_analysis_win.txt
+++ b/backend/agents/investment_team/tests/golden/snapshots/prompt_analysis_win.txt
@@ -23,7 +23,7 @@ Trade 1: BUY AAA on 2024-01-15 @ 100.00, SELL on 2024-01-25 @ 102.50 (+2.5%)
 Trade 2: BUY BBB on 2024-02-01 @ 50.00, SELL on 2024-02-11 @ 49.00 (-2.0%)
 
 ## Instructions
-Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced: the parent engine emits time-stop / stop-loss / take-profit closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. a tight cluster of N-day holds points to a time stop firing).
+Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced for `TimeStopRule`, `StopLossRule`, and `TakeProfitRule`: the parent engine emits closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. a tight cluster of N-day holds points to a time stop firing). `SignalExitRule` entries in the list above are NOT yet engine-enforced — treat any predicate-based exit prose the same way as entry intent.
 Think step by step: what in the strategy design plausibly produced strong risk-adjusted returns?
 Relate the hypothesis and rules to (1) Sharpe/drawdown/volatility, (2) win rate vs profit factor, (3) patterns in the simulated trades (hold periods, win/loss mix, concentration).
 Write 5-8 sentences. Be specific — avoid generic praise. Explain *why* this strategy class succeeded in this backtest.

--- a/backend/agents/investment_team/tests/golden/snapshots/prompt_analysis_win.txt
+++ b/backend/agents/investment_team/tests/golden/snapshots/prompt_analysis_win.txt
@@ -5,7 +5,7 @@ Asset class: equity
 Hypothesis: Trend-followers profit when SMA(20) crosses above SMA(50).
 Signal: SMA(20) > SMA(50)
 Intended entry rules (as authored — may not all be machine-enforced): long when sma(20) > sma(50)
-Intended exit rules (as authored — may not all be machine-enforced): exit after 10 bars, stop loss 2%
+Engine-enforced exit rules (structured DSL applied by the parent engine every bar): exit after 10 bars, stop loss 2%
 Sizing / risk: risk 1% per trade
 Rationale for testing: Validate SMA-cross trend following on the equity sleeve.
 
@@ -23,7 +23,7 @@ Trade 1: BUY AAA on 2024-01-15 @ 100.00, SELL on 2024-01-25 @ 102.50 (+2.5%)
 Trade 2: BUY BBB on 2024-02-01 @ 50.00, SELL on 2024-02-11 @ 49.00 (-2.0%)
 
 ## Instructions
-The entry/exit rules above are prose specifications, not engine-enforced behaviour — do not assert that trades "violated" them; instead describe whether trade behaviour was consistent with the intent.
+Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced: the parent engine emits time-stop / stop-loss / take-profit closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. a tight cluster of N-day holds points to a time stop firing).
 Think step by step: what in the strategy design plausibly produced strong risk-adjusted returns?
 Relate the hypothesis and rules to (1) Sharpe/drawdown/volatility, (2) win rate vs profit factor, (3) patterns in the simulated trades (hold periods, win/loss mix, concentration).
 Write 5-8 sentences. Be specific — avoid generic praise. Explain *why* this strategy class succeeded in this backtest.

--- a/backend/agents/investment_team/tests/golden/snapshots/prompt_analysis_win.txt
+++ b/backend/agents/investment_team/tests/golden/snapshots/prompt_analysis_win.txt
@@ -5,7 +5,7 @@ Asset class: equity
 Hypothesis: Trend-followers profit when SMA(20) crosses above SMA(50).
 Signal: SMA(20) > SMA(50)
 Intended entry rules (as authored — may not all be machine-enforced): long when sma(20) > sma(50)
-Engine-enforced exit rules (structured DSL applied by the parent engine every bar): exit after 10 bars, stop loss 2%
+Engine-enforced exit rules (structured DSL applied by the parent engine every bar): take profit 5%, stop loss 2%
 Sizing / risk: risk 1% per trade
 Rationale for testing: Validate SMA-cross trend following on the equity sleeve.
 
@@ -23,7 +23,7 @@ Trade 1: BUY AAA on 2024-01-15 @ 100.00, SELL on 2024-01-25 @ 102.50 (+2.5%)
 Trade 2: BUY BBB on 2024-02-01 @ 50.00, SELL on 2024-02-11 @ 49.00 (-2.0%)
 
 ## Instructions
-Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced for `TimeStopRule`, `StopLossRule`, and `TakeProfitRule`: the parent engine emits closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. a tight cluster of N-day holds points to a time stop firing). `SignalExitRule` entries in the list above are NOT yet engine-enforced — treat any predicate-based exit prose the same way as entry intent.
+Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced for `StopLossRule` and `TakeProfitRule`: the parent engine emits closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. losing trades clustered near the stop-loss floor point to it firing). `SignalExitRule` entries in the list above are NOT yet engine-enforced — treat any predicate-based exit prose the same way as entry intent.
 Think step by step: what in the strategy design plausibly produced strong risk-adjusted returns?
 Relate the hypothesis and rules to (1) Sharpe/drawdown/volatility, (2) win rate vs profit factor, (3) patterns in the simulated trades (hold periods, win/loss mix, concentration).
 Write 5-8 sentences. Be specific — avoid generic praise. Explain *why* this strategy class succeeded in this backtest.

--- a/backend/agents/investment_team/tests/golden/snapshots/round_trip.json
+++ b/backend/agents/investment_team/tests/golden/snapshots/round_trip.json
@@ -74,6 +74,7 @@
       "closed_trades": 0,
       "entries_filled": 0,
       "exit_rule_firings": {},
+      "exit_rule_firings_by_symbol": {},
       "exits_emitted": 0,
       "last_order_events": [
         {

--- a/backend/agents/investment_team/tests/golden/snapshots/round_trip.json
+++ b/backend/agents/investment_team/tests/golden/snapshots/round_trip.json
@@ -73,6 +73,7 @@
       "bars_processed": 504,
       "closed_trades": 0,
       "entries_filled": 0,
+      "exit_rule_firings": {},
       "exits_emitted": 0,
       "last_order_events": [
         {

--- a/backend/agents/investment_team/tests/golden/snapshots/sma_crossover.json
+++ b/backend/agents/investment_team/tests/golden/snapshots/sma_crossover.json
@@ -73,6 +73,7 @@
       "bars_processed": 504,
       "closed_trades": 9,
       "entries_filled": 10,
+      "exit_rule_firings": {},
       "exits_emitted": 9,
       "last_order_events": [
         {

--- a/backend/agents/investment_team/tests/golden/snapshots/sma_crossover.json
+++ b/backend/agents/investment_team/tests/golden/snapshots/sma_crossover.json
@@ -74,6 +74,7 @@
       "closed_trades": 9,
       "entries_filled": 10,
       "exit_rule_firings": {},
+      "exit_rule_firings_by_symbol": {},
       "exits_emitted": 9,
       "last_order_events": [
         {

--- a/backend/agents/investment_team/tests/test_agent_prompts_structured.py
+++ b/backend/agents/investment_team/tests/test_agent_prompts_structured.py
@@ -194,7 +194,7 @@ def test_ideation_accepts_structured_rules(monkeypatch: pytest.MonkeyPatch) -> N
     """The structured-DSL shape round-trips through ``IdeationAgent.run``."""
     payload = _ideation_payload(
         entry_rules=[_structured_entry_rule_dict()],
-        exit_rules=[_structured_signal_exit_rule_dict(), {"kind": "time_stop", "n_bars": 10}],
+        exit_rules=[_structured_signal_exit_rule_dict(), {"kind": "stop_loss", "pct": 0.03}],
         sizing=_structured_sizing_dict(),
     )
     _patch_ideation(monkeypatch, payload)

--- a/backend/agents/investment_team/tests/test_analysis_agent_verdict.py
+++ b/backend/agents/investment_team/tests/test_analysis_agent_verdict.py
@@ -31,7 +31,7 @@ from investment_team.strategy_lab.agents.analysis import AnalysisAgent
 from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
     Predicate,
-    TimeStopRule,
+    StopLossRule,
 )
 
 
@@ -49,7 +49,7 @@ def _spec() -> StrategySpec:
                 when=Predicate(lhs="bar.close", op=">", rhs=0),
             )
         ],
-        exit_rules=[TimeStopRule(n_bars=5)],
+        exit_rules=[StopLossRule(pct=0.03)],
         risk_limits={},
         speculative=False,
     )

--- a/backend/agents/investment_team/tests/test_analysis_alignment_prompts.py
+++ b/backend/agents/investment_team/tests/test_analysis_alignment_prompts.py
@@ -145,25 +145,38 @@ def test_rendered_prompt_matches_golden(
         pytest.param("analysis_lose", _render_lose, id="analysis_lose"),
     ],
 )
-def test_analysis_prompts_have_intended_not_enforced_label(
+def test_analysis_prompts_label_entry_intent_and_exit_enforcement(
     label: str, renderer: _PromptRenderer
 ) -> None:
-    """Issue #528: prose rules must be labelled as intent, not enforced behaviour."""
+    """Issue #527: entry rules stay 'intended' prose; exit rules became
+    engine-enforced once the structured DSL got wired into the bar loop.
+    Issue #528's 'Intended entry rules' / 'may not all be machine-enforced'
+    framing survives on the entry half so the LLM still doesn't police
+    prose entry intent as a mandatory rule.
+    """
     rendered = renderer()
-    assert "may not all be machine-enforced" in rendered, (
-        f"{label} prompt must label entry/exit rules as 'may not all be "
-        "machine-enforced' (issue #528)."
-    )
     assert "Intended entry rules" in rendered, (
-        f"{label} prompt must use 'Intended entry rules' (issue #528)."
+        f"{label} prompt must label entry rules as 'Intended entry rules' "
+        "(carry-over from issue #528)."
     )
-    assert "Intended exit rules" in rendered, (
-        f"{label} prompt must use 'Intended exit rules' (issue #528)."
+    assert "may not all be machine-enforced" in rendered, (
+        f"{label} prompt must still label entry rules as 'may not all be "
+        "machine-enforced' (carry-over from issue #528)."
+    )
+    assert "Engine-enforced exit rules" in rendered, (
+        f"{label} prompt must label exit rules as 'Engine-enforced exit rules' "
+        "(issue #527 — structured exit rules are now applied by the parent "
+        "engine every bar)."
     )
 
 
 def test_alignment_prompt_splits_enforced_and_aspirational() -> None:
-    """Issue #528: alignment prompt must distinguish enforced vs aspirational rules."""
+    """Issue #528 introduced the enforced vs aspirational split. Issue #527
+    promotes structured ``exit_rules`` from the aspirational side into the
+    enforced section; both section headers must remain so the LLM still
+    sees the two-bucket framing for the rules that *are* aspirational
+    (entry intent, SignalExitRule).
+    """
     rendered = _render_alignment_system()
     assert "Enforced rules" in rendered, (
         "alignment_system.md must introduce 'Enforced rules' section (issue #528)."
@@ -174,6 +187,25 @@ def test_alignment_prompt_splits_enforced_and_aspirational() -> None:
     # Severity guidance above the JSON output must reserve `critical` for enforced rules.
     assert "Reserve `severity: critical`" in rendered, (
         "alignment_system.md must reserve `severity: critical` for enforced rules (issue #528)."
+    )
+
+
+def test_alignment_prompt_marks_exit_rules_engine_enforced() -> None:
+    """Issue #527: alignment prompt must describe ``exit_rules`` as engine-
+    enforced rather than aspirational prose. Guards the prompt's role-in-
+    pipeline framing so the LLM doesn't down-weight critical exit-rule
+    violations the deterministic conformance gate flags.
+    """
+    rendered = _render_alignment_system()
+    assert (
+        "engine evaluates after every bar" in rendered or "evaluates after every bar" in rendered
+    ), (
+        "alignment_system.md must state the engine evaluates structured exit "
+        "rules every bar (issue #527)."
+    )
+    assert "exit_rule_conformance" in rendered, (
+        "alignment_system.md must reference the deterministic "
+        "``exit_rule_conformance`` gate (issue #527)."
     )
 
 

--- a/backend/agents/investment_team/tests/test_analysis_alignment_prompts.py
+++ b/backend/agents/investment_team/tests/test_analysis_alignment_prompts.py
@@ -37,7 +37,7 @@ from investment_team.strategy_lab.spec_dsl import (
     IndicatorRef,
     Predicate,
     StopLossRule,
-    TimeStopRule,
+    TakeProfitRule,
     format_rules_for_prompt,
     format_sizing_rule,
 )
@@ -59,7 +59,7 @@ def _render_inputs() -> dict[str, object]:
             rhs=IndicatorRef(name="sma", params={"period": 50}),
         ),
     )
-    exits = [TimeStopRule(n_bars=10), StopLossRule(pct=0.02)]
+    exits = [TakeProfitRule(pct=0.05), StopLossRule(pct=0.02)]
     sizing = FixedFractionSizing(fraction=0.01)
     return {
         "asset_class": "equity",

--- a/backend/agents/investment_team/tests/test_asset_class_mix_hint.py
+++ b/backend/agents/investment_team/tests/test_asset_class_mix_hint.py
@@ -20,7 +20,7 @@ from investment_team.models import (
 from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
     Predicate,
-    TimeStopRule,
+    StopLossRule,
 )
 from investment_team.strategy_lab_context import asset_class_mix_hint
 
@@ -50,7 +50,7 @@ def _record(asset_class: str) -> StrategyLabRecord:
         signal_definition="sig",
         timeframe="1d",
         entry_rules=[EntryRule(side="long", when=Predicate(lhs="bar.close", op=">", rhs=0))],
-        exit_rules=[TimeStopRule(n_bars=5)],
+        exit_rules=[StopLossRule(pct=0.03)],
         risk_limits={},
         speculative=False,
     )

--- a/backend/agents/investment_team/tests/test_dataset_fingerprint.py
+++ b/backend/agents/investment_team/tests/test_dataset_fingerprint.py
@@ -26,7 +26,7 @@ from investment_team.market_data_service import OHLCVBar
 from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
     Predicate,
-    TimeStopRule,
+    StopLossRule,
 )
 
 
@@ -118,7 +118,7 @@ def test_backtest_result_fingerprint_stable_across_runs(tmp_path: Path) -> None:
         signal_definition="hold-forever",
         timeframe="1d",
         entry_rules=[EntryRule(side="long", when=Predicate(lhs="bar.close", op=">", rhs=0))],
-        exit_rules=[TimeStopRule(n_bars=10000)],
+        exit_rules=[StopLossRule(pct=0.03)],
         strategy_code=textwrap.dedent(
             """
             def on_bar(bar, ctx):

--- a/backend/agents/investment_team/tests/test_engine_exit_enforcement.py
+++ b/backend/agents/investment_team/tests/test_engine_exit_enforcement.py
@@ -265,15 +265,19 @@ def test_no_exit_rules_leaves_position_open_at_end_of_run() -> None:
     )
 
 
-def test_strategy_emitted_close_dedupes_engine_firing_same_bar() -> None:
-    """If the strategy already submits an opposite-side close on the bar the
-    engine rule would fire, the engine must not stack a duplicate close
-    onto ``pending_for_prev``. Asserts exactly one exit-emission diagnostic
-    per round trip rather than two.
+def test_strategy_emitted_close_does_not_skip_engine_emission() -> None:
+    """When the strategy submits a same-bar full-market close on the bar the
+    engine rule fires, BOTH orders queue. On next bar the order book
+    submits in order; whichever fills first closes the position, and the
+    other order's stale-continuation guard (engine via binding, strategy
+    via ``existing_pos is None``) drops the survivor. The engine
+    therefore records its emission in ``exit_rule_firings`` (emitted, not
+    necessarily filled) — the fill side is what matters for actual
+    position closure.
     """
     strategy_with_self_exit = textwrap.dedent(
         '''\
-        """Enter long once, exit on bar 4 — same bar a TimeStopRule(n_bars=3) fires."""
+        """Enter long once, exit on bar 3 — same bar a TimeStopRule(n_bars=2) fires."""
         from contract import OrderSide, OrderType, Strategy
 
 
@@ -312,7 +316,7 @@ def test_strategy_emitted_close_dedupes_engine_firing_same_bar() -> None:
                 ),
             )
         ],
-        exit_rules=[TimeStopRule(n_bars=3)],
+        exit_rules=[TimeStopRule(n_bars=2)],
         strategy_code=strategy_with_self_exit,
     )
 
@@ -320,11 +324,13 @@ def test_strategy_emitted_close_dedupes_engine_firing_same_bar() -> None:
 
     assert run.service_result.error is None, run.service_result.error
     diag = run.service_result.execution_diagnostics
-    # At most one closed trade in this synthetic — and zero engine firings,
-    # because the strategy's own exit was queued first and the engine deduped.
-    assert diag.exit_rule_firings.get("time_stop", 0) == 0, (
-        "engine should have deduped against the strategy's own exit on the "
-        f"same bar; firings={diag.exit_rule_firings}"
+    # Engine emits its close — robustness against participation/IOC/FOK
+    # clipping of the strategy's market order. The fill simulator's
+    # stale-continuation guard drops whichever of the two orders arrives
+    # against an already-closed position.
+    assert diag.exit_rule_firings.get("time_stop", 0) >= 1, (
+        f"engine should emit even when strategy also submits a same-bar close; "
+        f"firings={diag.exit_rule_firings}"
     )
 
 

--- a/backend/agents/investment_team/tests/test_engine_exit_enforcement.py
+++ b/backend/agents/investment_team/tests/test_engine_exit_enforcement.py
@@ -25,7 +25,6 @@ from investment_team.strategy_lab.spec_dsl import (
     Predicate,
     StopLossRule,
     TakeProfitRule,
-    TimeStopRule,
 )
 from investment_team.trading_service.modes.backtest import run_backtest
 from investment_team.trading_service.service import ENGINE_EXIT_REASON_PREFIX
@@ -179,27 +178,13 @@ def _spec(*, exit_rules) -> StrategySpec:
 # ---------------------------------------------------------------------------
 
 
-def test_time_stop_closes_position_strategy_left_open() -> None:
-    spec = _spec(exit_rules=[TimeStopRule(n_bars=5)])
-    run = run_backtest(strategy=spec, config=_config(), market_data=_flat_bars())
-
-    assert run.service_result.error is None, run.service_result.error
-    # At least one closed trade — engine emitted the close.
-    assert len(run.trades) >= 1
-    # Every trade respects the time stop within the +1 bar fill-lag ceiling.
-    for trade in run.trades:
-        assert trade.hold_days <= 6, (
-            f"trade {trade.trade_num} held {trade.hold_days} days, "
-            "expected <= 6 (n_bars=5 + 1 bar fill lag)"
-        )
-    # Diagnostics records the firing.
-    diag = run.service_result.execution_diagnostics
-    assert diag.exit_rule_firings.get("time_stop", 0) >= 1, diag.exit_rule_firings
-
-
 def test_engine_emitted_close_carries_reason_prefix() -> None:
-    spec = _spec(exit_rules=[TimeStopRule(n_bars=3)])
-    run = run_backtest(strategy=spec, config=_config(), market_data=_flat_bars())
+    spec = _spec(exit_rules=[StopLossRule(pct=0.05)])
+    run = run_backtest(
+        strategy=spec,
+        config=_config(),
+        market_data=_falling_bars(n_pre_drop=5, drop_bar_low=90.0, n_post_drop=10),
+    )
 
     diag = run.service_result.execution_diagnostics
     emitted = [
@@ -215,7 +200,7 @@ def test_engine_emitted_close_carries_reason_prefix() -> None:
     for e in emitted:
         # Reason format: ``engine_exit:<rule_kind>``.
         suffix = (e.reason or "").split(":", 1)[1]
-        assert suffix in {"time_stop", "stop_loss", "take_profit"}, e.reason
+        assert suffix in {"stop_loss", "take_profit"}, e.reason
 
 
 def test_stop_loss_closes_when_price_breaks_floor() -> None:
@@ -277,7 +262,7 @@ def test_strategy_emitted_close_does_not_skip_engine_emission() -> None:
     """
     strategy_with_self_exit = textwrap.dedent(
         '''\
-        """Enter long once, exit on bar 3 — same bar a TimeStopRule(n_bars=2) fires."""
+        """Enter long once, then self-exit on the bar a stop-loss fires."""
         from contract import OrderSide, OrderType, Strategy
 
 
@@ -292,7 +277,9 @@ def test_strategy_emitted_close_does_not_skip_engine_emission() -> None:
                         symbol=bar.symbol, side=OrderSide.LONG, qty=10,
                         order_type=OrderType.MARKET, reason="self_entry",
                     )
-                elif pos is not None and self._bar_count >= 3:
+                elif pos is not None and bar.low < 92.0:
+                    # On the drop bar (low=90), the engine StopLossRule(pct=0.05)
+                    # ALSO fires. Both orders queue.
                     ctx.submit_order(
                         symbol=bar.symbol, side=OrderSide.SHORT, qty=pos.qty,
                         order_type=OrderType.MARKET, reason="self_exit",
@@ -316,11 +303,15 @@ def test_strategy_emitted_close_does_not_skip_engine_emission() -> None:
                 ),
             )
         ],
-        exit_rules=[TimeStopRule(n_bars=2)],
+        exit_rules=[StopLossRule(pct=0.05)],
         strategy_code=strategy_with_self_exit,
     )
 
-    run = run_backtest(strategy=spec, config=_config(), market_data=_flat_bars())
+    run = run_backtest(
+        strategy=spec,
+        config=_config(),
+        market_data=_falling_bars(n_pre_drop=5, drop_bar_low=90.0, n_post_drop=10),
+    )
 
     assert run.service_result.error is None, run.service_result.error
     diag = run.service_result.execution_diagnostics
@@ -328,7 +319,7 @@ def test_strategy_emitted_close_does_not_skip_engine_emission() -> None:
     # clipping of the strategy's market order. The fill simulator's
     # stale-continuation guard drops whichever of the two orders arrives
     # against an already-closed position.
-    assert diag.exit_rule_firings.get("time_stop", 0) >= 1, (
+    assert diag.exit_rule_firings.get("stop_loss", 0) >= 1, (
         f"engine should emit even when strategy also submits a same-bar close; "
         f"firings={diag.exit_rule_firings}"
     )
@@ -336,13 +327,13 @@ def test_strategy_emitted_close_does_not_skip_engine_emission() -> None:
 
 def test_partial_strategy_unwind_does_not_suppress_engine_close() -> None:
     """If the strategy submits a partial unwind (e.g. sells 1 of 10 long
-    shares) on the bar a time-stop fires, the engine must still emit a
+    shares) on the bar a stop-loss fires, the engine must still emit a
     close for the residual qty rather than treating the partial as a
     full close. Regression for the P1 review comment on issue #527 PR.
     """
     strategy_with_partial_unwind = textwrap.dedent(
         '''\
-        """Enter 10 shares, partial-unwind 1 share on the bar a TimeStop fires."""
+        """Enter 10 shares, partial-unwind 1 share on the bar a stop-loss fires."""
         from contract import OrderSide, OrderType, Strategy
 
 
@@ -357,10 +348,11 @@ def test_partial_strategy_unwind_does_not_suppress_engine_close() -> None:
                         symbol=bar.symbol, side=OrderSide.LONG, qty=10,
                         order_type=OrderType.MARKET, reason="self_entry",
                     )
-                elif pos is not None and self._bar_count == 3:
-                    # Token partial: sell 1 of 10. Engine TimeStopRule(n_bars=3)
-                    # should still emit a close for the residual 9 — not be
-                    # suppressed by this 1-share decoration.
+                elif pos is not None and bar.low < 92.0:
+                    # Token partial: sell 1 of 10 on the drop bar. The engine's
+                    # ``StopLossRule(pct=0.05)`` should still emit a close for
+                    # the residual 9 — not be suppressed by this 1-share
+                    # decoration.
                     ctx.submit_order(
                         symbol=bar.symbol, side=OrderSide.SHORT, qty=1,
                         order_type=OrderType.MARKET, reason="partial_unwind",
@@ -372,7 +364,7 @@ def test_partial_strategy_unwind_does_not_suppress_engine_close() -> None:
         authored_by="tests",
         asset_class="equity",
         hypothesis="partial unwind doesn't suppress engine close",
-        signal_definition="enter 10, partial unwind 1 same bar TimeStop fires",
+        signal_definition="enter 10, partial unwind 1 same bar stop-loss fires",
         timeframe="1d",
         entry_rules=[
             EntryRule(
@@ -384,16 +376,20 @@ def test_partial_strategy_unwind_does_not_suppress_engine_close() -> None:
                 ),
             )
         ],
-        exit_rules=[TimeStopRule(n_bars=3)],
+        exit_rules=[StopLossRule(pct=0.05)],
         strategy_code=strategy_with_partial_unwind,
     )
 
-    run = run_backtest(strategy=spec, config=_config(), market_data=_flat_bars())
+    run = run_backtest(
+        strategy=spec,
+        config=_config(),
+        market_data=_falling_bars(n_pre_drop=5, drop_bar_low=90.0, n_post_drop=10),
+    )
 
     assert run.service_result.error is None, run.service_result.error
     diag = run.service_result.execution_diagnostics
-    # Engine MUST still fire a time-stop close (for the residual 9 shares).
-    assert diag.exit_rule_firings.get("time_stop", 0) >= 1, (
+    # Engine MUST still fire a stop-loss close (for the residual 9 shares).
+    assert diag.exit_rule_firings.get("stop_loss", 0) >= 1, (
         "engine should still fire engine_exit when strategy only partially "
         f"unwinds; firings={diag.exit_rule_firings}"
     )
@@ -409,6 +405,6 @@ def test_chunked_path_rejected_when_exit_rules_present(monkeypatch: pytest.Monke
     rather than silently lose enforcement (issue #527 scope decision).
     """
     monkeypatch.setenv("BAR_CHUNK_SIZE", "8")
-    spec = _spec(exit_rules=[TimeStopRule(n_bars=5)])
+    spec = _spec(exit_rules=[StopLossRule(pct=0.05)])
     with pytest.raises(NotImplementedError, match="chunked-bar protocol"):
         run_backtest(strategy=spec, config=_config(), market_data=_flat_bars())

--- a/backend/agents/investment_team/tests/test_engine_exit_enforcement.py
+++ b/backend/agents/investment_team/tests/test_engine_exit_enforcement.py
@@ -328,6 +328,71 @@ def test_strategy_emitted_close_dedupes_engine_firing_same_bar() -> None:
     )
 
 
+def test_partial_strategy_unwind_does_not_suppress_engine_close() -> None:
+    """If the strategy submits a partial unwind (e.g. sells 1 of 10 long
+    shares) on the bar a time-stop fires, the engine must still emit a
+    close for the residual qty rather than treating the partial as a
+    full close. Regression for the P1 review comment on issue #527 PR.
+    """
+    strategy_with_partial_unwind = textwrap.dedent(
+        '''\
+        """Enter 10 shares, partial-unwind 1 share on the bar a TimeStop fires."""
+        from contract import OrderSide, OrderType, Strategy
+
+
+        class PartialUnwind(Strategy):
+            _bar_count = 0
+
+            def on_bar(self, ctx, bar):
+                self._bar_count += 1
+                pos = ctx.position(bar.symbol)
+                if pos is None and self._bar_count == 1:
+                    ctx.submit_order(
+                        symbol=bar.symbol, side=OrderSide.LONG, qty=10,
+                        order_type=OrderType.MARKET, reason="self_entry",
+                    )
+                elif pos is not None and self._bar_count == 3:
+                    # Token partial: sell 1 of 10. Engine TimeStopRule(n_bars=3)
+                    # should still emit a close for the residual 9 — not be
+                    # suppressed by this 1-share decoration.
+                    ctx.submit_order(
+                        symbol=bar.symbol, side=OrderSide.SHORT, qty=1,
+                        order_type=OrderType.MARKET, reason="partial_unwind",
+                    )
+        '''
+    )
+    spec = StrategySpec(
+        strategy_id="strat-partial-dedup",
+        authored_by="tests",
+        asset_class="equity",
+        hypothesis="partial unwind doesn't suppress engine close",
+        signal_definition="enter 10, partial unwind 1 same bar TimeStop fires",
+        timeframe="1d",
+        entry_rules=[
+            EntryRule(
+                side="long",
+                when=Predicate(
+                    lhs="bar.close",
+                    op=">",
+                    rhs=IndicatorRef(name="sma", params={"period": 5}),
+                ),
+            )
+        ],
+        exit_rules=[TimeStopRule(n_bars=3)],
+        strategy_code=strategy_with_partial_unwind,
+    )
+
+    run = run_backtest(strategy=spec, config=_config(), market_data=_flat_bars())
+
+    assert run.service_result.error is None, run.service_result.error
+    diag = run.service_result.execution_diagnostics
+    # Engine MUST still fire a time-stop close (for the residual 9 shares).
+    assert diag.exit_rule_firings.get("time_stop", 0) >= 1, (
+        "engine should still fire engine_exit when strategy only partially "
+        f"unwinds; firings={diag.exit_rule_firings}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Chunked path rejection
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/tests/test_engine_exit_enforcement.py
+++ b/backend/agents/investment_team/tests/test_engine_exit_enforcement.py
@@ -49,8 +49,9 @@ def _flat_bars(n: int = 30, start_price: float = 100.0) -> Dict[str, List[OHLCVB
     """30 daily bars that drift up by 1c/bar — slow steady uptrend.
 
     Slow enough that none of the stop-loss / take-profit thresholds used in
-    the tests fire on price alone, so the time-stop test isolates the
-    bars-held trigger.
+    the tests fire on price alone — these bars are the "no-trigger
+    baseline" the dedup / fallback tests use to verify engine behaviour
+    in the absence of a structured-exit event.
     """
     out: List[OHLCVBar] = []
     for i in range(n):
@@ -396,15 +397,36 @@ def test_partial_strategy_unwind_does_not_suppress_engine_close() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Chunked path rejection
+# Chunked path fallback
 # ---------------------------------------------------------------------------
 
 
-def test_chunked_path_rejected_when_exit_rules_present(monkeypatch: pytest.MonkeyPatch) -> None:
-    """``BAR_CHUNK_SIZE>1`` combined with non-empty ``exit_rules`` must raise
-    rather than silently lose enforcement (issue #527 scope decision).
+def test_chunked_path_falls_back_to_per_bar_when_exit_rules_present(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """``BAR_CHUNK_SIZE>1`` combined with non-empty ``exit_rules`` must NOT
+    crash ``run_backtest`` — engine-side enforcement is wired only on the
+    per-bar path, so we fall back to per-bar mode for this run and log a
+    warning. Raising would crash every Strategy Lab / API run that has a
+    structured exit rule whenever the global env var is set.
     """
+    import logging
+
     monkeypatch.setenv("BAR_CHUNK_SIZE", "8")
     spec = _spec(exit_rules=[StopLossRule(pct=0.05)])
-    with pytest.raises(NotImplementedError, match="chunked-bar protocol"):
-        run_backtest(strategy=spec, config=_config(), market_data=_flat_bars())
+
+    with caplog.at_level(logging.WARNING, logger="investment_team.trading_service.service"):
+        run = run_backtest(
+            strategy=spec,
+            config=_config(),
+            market_data=_falling_bars(n_pre_drop=5, drop_bar_low=90.0, n_post_drop=10),
+        )
+
+    # Run completed (no crash) and engine still enforced the stop-loss.
+    assert run.service_result.error is None, run.service_result.error
+    diag = run.service_result.execution_diagnostics
+    assert diag.exit_rule_firings.get("stop_loss", 0) >= 1, diag.exit_rule_firings
+    # Operator-visible warning explains the fallback.
+    assert any(
+        "BAR_CHUNK_SIZE" in rec.message and "falling back" in rec.message for rec in caplog.records
+    ), [rec.message for rec in caplog.records]

--- a/backend/agents/investment_team/tests/test_engine_exit_enforcement.py
+++ b/backend/agents/investment_team/tests/test_engine_exit_enforcement.py
@@ -1,0 +1,343 @@
+"""End-to-end integration tests for engine-side exit-rule enforcement
+(issue #527).
+
+Feeds ``run_backtest`` a strategy that opens a position and *never closes
+it on its own*, plus structured ``exit_rules`` on the spec. Asserts that
+the engine emits the corresponding close orders and the resulting trade
+ledger respects the rule.
+
+The strategy code intentionally avoids any exit logic so every closed
+trade in the ledger must have come from the engine's enforcement path.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from typing import Dict, List
+
+import pytest
+
+from investment_team.market_data_service import OHLCVBar
+from investment_team.models import BacktestConfig, StrategySpec
+from investment_team.strategy_lab.spec_dsl import (
+    EntryRule,
+    IndicatorRef,
+    Predicate,
+    StopLossRule,
+    TakeProfitRule,
+    TimeStopRule,
+)
+from investment_team.trading_service.modes.backtest import run_backtest
+from investment_team.trading_service.service import ENGINE_EXIT_REASON_PREFIX
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _mk_bar(date_iso: str, close: float, *, high: float = None, low: float = None) -> OHLCVBar:
+    return OHLCVBar(
+        date=date_iso,
+        open=close - 0.2,
+        high=close + 0.5 if high is None else high,
+        low=close - 0.5 if low is None else low,
+        close=close,
+        volume=1_000_000,
+    )
+
+
+def _flat_bars(n: int = 30, start_price: float = 100.0) -> Dict[str, List[OHLCVBar]]:
+    """30 daily bars that drift up by 1c/bar — slow steady uptrend.
+
+    Slow enough that none of the stop-loss / take-profit thresholds used in
+    the tests fire on price alone, so the time-stop test isolates the
+    bars-held trigger.
+    """
+    out: List[OHLCVBar] = []
+    for i in range(n):
+        day = i + 1
+        month = 1 if day <= 31 else 2
+        d = day if month == 1 else day - 31
+        out.append(_mk_bar(f"2024-{month:02d}-{d:02d}", start_price + i * 0.01))
+    return {"AAA": out}
+
+
+def _falling_bars(
+    n_pre_drop: int = 5, drop_bar_low: float = 90.0, n_post_drop: int = 10
+) -> Dict[str, List[OHLCVBar]]:
+    """Flat → big single-bar drop → flat. Triggers a stop-loss on entry-day.
+
+    The ``drop_bar`` has ``low=drop_bar_low`` so a stop-loss with pct=0.05
+    against entry price 100 (floor=95) fires on that bar.
+    """
+    out: List[OHLCVBar] = []
+    base = 100.0
+    for i in range(n_pre_drop):
+        out.append(_mk_bar(f"2024-01-{i + 1:02d}", base))
+    # Drop bar — bar low much lower than entry.
+    drop_day = n_pre_drop + 1
+    out.append(
+        OHLCVBar(
+            date=f"2024-01-{drop_day:02d}",
+            open=base - 0.5,
+            high=base,
+            low=drop_bar_low,
+            close=base - 8.0,
+            volume=1_000_000,
+        )
+    )
+    for i in range(n_post_drop):
+        day = drop_day + 1 + i
+        out.append(_mk_bar(f"2024-01-{day:02d}", base - 8.0))
+    return {"AAA": out}
+
+
+def _rising_bars(
+    n_pre_pop: int = 5, pop_bar_high: float = 110.0, n_post_pop: int = 10
+) -> Dict[str, List[OHLCVBar]]:
+    """Flat → big single-bar pop → flat. Triggers a take-profit."""
+    out: List[OHLCVBar] = []
+    base = 100.0
+    for i in range(n_pre_pop):
+        out.append(_mk_bar(f"2024-01-{i + 1:02d}", base))
+    pop_day = n_pre_pop + 1
+    out.append(
+        OHLCVBar(
+            date=f"2024-01-{pop_day:02d}",
+            open=base + 0.5,
+            high=pop_bar_high,
+            low=base,
+            close=base + 8.0,
+            volume=1_000_000,
+        )
+    )
+    for i in range(n_post_pop):
+        day = pop_day + 1 + i
+        out.append(_mk_bar(f"2024-01-{day:02d}", base + 8.0))
+    return {"AAA": out}
+
+
+# Strategy that opens a single long position on the first non-warmup bar
+# and never exits. Any closed trade in the ledger must therefore come
+# from engine enforcement.
+_ENTRY_ONLY_STRATEGY = textwrap.dedent(
+    '''\
+    """Open one long, never exit. Engine enforcement is on its own."""
+    from contract import OrderSide, OrderType, Strategy
+
+
+    class EntryOnly(Strategy):
+        def on_bar(self, ctx, bar):
+            if ctx.position(bar.symbol) is not None:
+                return
+            ctx.submit_order(
+                symbol=bar.symbol,
+                side=OrderSide.LONG,
+                qty=10,
+                order_type=OrderType.MARKET,
+                reason="entry_only",
+            )
+    '''
+)
+
+
+def _config() -> BacktestConfig:
+    return BacktestConfig(
+        start_date="2024-01-01",
+        end_date="2024-02-15",
+        initial_capital=100_000.0,
+        slippage_bps=2.0,
+        transaction_cost_bps=5.0,
+    )
+
+
+def _spec(*, exit_rules) -> StrategySpec:
+    return StrategySpec(
+        strategy_id="strat-engine-exit",
+        authored_by="tests",
+        asset_class="equity",
+        hypothesis="engine-side exit rules close positions strategy_code leaves open",
+        signal_definition="enter long once, leave to the engine to close",
+        timeframe="1d",
+        entry_rules=[
+            EntryRule(
+                side="long",
+                when=Predicate(
+                    lhs="bar.close",
+                    op=">",
+                    rhs=IndicatorRef(name="sma", params={"period": 5}),
+                ),
+            )
+        ],
+        exit_rules=exit_rules,
+        strategy_code=_ENTRY_ONLY_STRATEGY,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_time_stop_closes_position_strategy_left_open() -> None:
+    spec = _spec(exit_rules=[TimeStopRule(n_bars=5)])
+    run = run_backtest(strategy=spec, config=_config(), market_data=_flat_bars())
+
+    assert run.service_result.error is None, run.service_result.error
+    # At least one closed trade — engine emitted the close.
+    assert len(run.trades) >= 1
+    # Every trade respects the time stop within the +1 bar fill-lag ceiling.
+    for trade in run.trades:
+        assert trade.hold_days <= 6, (
+            f"trade {trade.trade_num} held {trade.hold_days} days, "
+            "expected <= 6 (n_bars=5 + 1 bar fill lag)"
+        )
+    # Diagnostics records the firing.
+    diag = run.service_result.execution_diagnostics
+    assert diag.exit_rule_firings.get("time_stop", 0) >= 1, diag.exit_rule_firings
+
+
+def test_engine_emitted_close_carries_reason_prefix() -> None:
+    spec = _spec(exit_rules=[TimeStopRule(n_bars=3)])
+    run = run_backtest(strategy=spec, config=_config(), market_data=_flat_bars())
+
+    diag = run.service_result.execution_diagnostics
+    emitted = [
+        e
+        for e in diag.last_order_events
+        if e.event_type == "emitted" and (e.reason or "").startswith(ENGINE_EXIT_REASON_PREFIX)
+    ]
+    assert emitted, (
+        "expected at least one OrderLifecycleEvent tagged with the engine "
+        f"exit reason prefix {ENGINE_EXIT_REASON_PREFIX!r}; got reasons "
+        f"{[e.reason for e in diag.last_order_events]}"
+    )
+    for e in emitted:
+        # Reason format: ``engine_exit:<rule_kind>``.
+        suffix = (e.reason or "").split(":", 1)[1]
+        assert suffix in {"time_stop", "stop_loss", "take_profit"}, e.reason
+
+
+def test_stop_loss_closes_when_price_breaks_floor() -> None:
+    # Entry ~100; stop-loss pct=0.05 → floor=95; the drop bar low is 90.
+    spec = _spec(exit_rules=[StopLossRule(pct=0.05)])
+    run = run_backtest(
+        strategy=spec,
+        config=_config(),
+        market_data=_falling_bars(n_pre_drop=5, drop_bar_low=90.0, n_post_drop=10),
+    )
+
+    assert run.service_result.error is None, run.service_result.error
+    assert len(run.trades) >= 1
+    diag = run.service_result.execution_diagnostics
+    assert diag.exit_rule_firings.get("stop_loss", 0) >= 1, diag.exit_rule_firings
+
+
+def test_take_profit_closes_when_price_clears_target() -> None:
+    # Entry ~100; take-profit pct=0.05 → target=105; the pop bar high is 110.
+    spec = _spec(exit_rules=[TakeProfitRule(pct=0.05)])
+    run = run_backtest(
+        strategy=spec,
+        config=_config(),
+        market_data=_rising_bars(n_pre_pop=5, pop_bar_high=110.0, n_post_pop=10),
+    )
+
+    assert run.service_result.error is None, run.service_result.error
+    assert len(run.trades) >= 1
+    diag = run.service_result.execution_diagnostics
+    assert diag.exit_rule_firings.get("take_profit", 0) >= 1, diag.exit_rule_firings
+
+
+def test_no_exit_rules_leaves_position_open_at_end_of_run() -> None:
+    """Sanity check: with no engine exit rules, the entry-only strategy
+    leaves the position open (proving the engine isn't fabricating closes
+    when ``exit_rules`` is empty).
+    """
+    spec = _spec(exit_rules=[])
+    run = run_backtest(strategy=spec, config=_config(), market_data=_flat_bars())
+
+    assert run.service_result.error is None, run.service_result.error
+    # No closes — at most a final open position; trade ledger is empty.
+    diag = run.service_result.execution_diagnostics
+    assert diag.exit_rule_firings == {}, diag.exit_rule_firings
+    assert run.trades == [] or all(not (t.exit_date or "").strip() for t in run.trades), (
+        "expected no closed trades when exit_rules is empty"
+    )
+
+
+def test_strategy_emitted_close_dedupes_engine_firing_same_bar() -> None:
+    """If the strategy already submits an opposite-side close on the bar the
+    engine rule would fire, the engine must not stack a duplicate close
+    onto ``pending_for_prev``. Asserts exactly one exit-emission diagnostic
+    per round trip rather than two.
+    """
+    strategy_with_self_exit = textwrap.dedent(
+        '''\
+        """Enter long once, exit on bar 4 — same bar a TimeStopRule(n_bars=3) fires."""
+        from contract import OrderSide, OrderType, Strategy
+
+
+        class SelfExit(Strategy):
+            _bar_count = 0
+
+            def on_bar(self, ctx, bar):
+                self._bar_count += 1
+                pos = ctx.position(bar.symbol)
+                if pos is None and self._bar_count == 1:
+                    ctx.submit_order(
+                        symbol=bar.symbol, side=OrderSide.LONG, qty=10,
+                        order_type=OrderType.MARKET, reason="self_entry",
+                    )
+                elif pos is not None and self._bar_count >= 3:
+                    ctx.submit_order(
+                        symbol=bar.symbol, side=OrderSide.SHORT, qty=pos.qty,
+                        order_type=OrderType.MARKET, reason="self_exit",
+                    )
+        '''
+    )
+    spec = StrategySpec(
+        strategy_id="strat-dedup",
+        authored_by="tests",
+        asset_class="equity",
+        hypothesis="dedup test",
+        signal_definition="enter once, self-exit same bar engine would",
+        timeframe="1d",
+        entry_rules=[
+            EntryRule(
+                side="long",
+                when=Predicate(
+                    lhs="bar.close",
+                    op=">",
+                    rhs=IndicatorRef(name="sma", params={"period": 5}),
+                ),
+            )
+        ],
+        exit_rules=[TimeStopRule(n_bars=3)],
+        strategy_code=strategy_with_self_exit,
+    )
+
+    run = run_backtest(strategy=spec, config=_config(), market_data=_flat_bars())
+
+    assert run.service_result.error is None, run.service_result.error
+    diag = run.service_result.execution_diagnostics
+    # At most one closed trade in this synthetic — and zero engine firings,
+    # because the strategy's own exit was queued first and the engine deduped.
+    assert diag.exit_rule_firings.get("time_stop", 0) == 0, (
+        "engine should have deduped against the strategy's own exit on the "
+        f"same bar; firings={diag.exit_rule_firings}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Chunked path rejection
+# ---------------------------------------------------------------------------
+
+
+def test_chunked_path_rejected_when_exit_rules_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``BAR_CHUNK_SIZE>1`` combined with non-empty ``exit_rules`` must raise
+    rather than silently lose enforcement (issue #527 scope decision).
+    """
+    monkeypatch.setenv("BAR_CHUNK_SIZE", "8")
+    spec = _spec(exit_rules=[TimeStopRule(n_bars=5)])
+    with pytest.raises(NotImplementedError, match="chunked-bar protocol"):
+        run_backtest(strategy=spec, config=_config(), market_data=_flat_bars())

--- a/backend/agents/investment_team/tests/test_engine_exit_helpers.py
+++ b/backend/agents/investment_team/tests/test_engine_exit_helpers.py
@@ -380,3 +380,142 @@ def test_engine_emission_registers_binding_to_entry_order_id() -> None:
     cid = pending[0].client_order_id
     assert cid in engine_exit_bindings
     assert engine_exit_bindings[cid] == "o1"
+
+
+def test_engine_binds_unbound_resting_strategy_exits_to_position() -> None:
+    """A strategy GTC/limit close resting on the book BEFORE the engine
+    fires a stop-loss must be retired alongside the engine's market close,
+    or it survives the position-close and a later trigger opens an
+    unintended reverse position (``FillSimulator.process_bar`` routes the
+    unbound order to ``_fill_entry`` because ``existing_pos is None``).
+    The engine binds the resting order to the same ``entry_order_id`` so
+    the stale-continuation guard drops it when the engine close fires.
+    """
+    svc = _service(exit_rules=[StopLossRule(pct=0.02)])
+    tracker, portfolio, order_book = _populate_tracker_and_portfolio()
+    bar = _bar(high=105, low=95)  # bar.low=95 trips the 98 stop floor
+    result = TradingServiceResult()
+
+    # Strategy has a resting GTC SELL LIMIT at 200 (a take-profit far
+    # above market) — opposite side to the long position, unbound.
+    resting_strategy_exit = OrderRequest(
+        client_order_id="c1",
+        symbol="AAA",
+        side=OrderSide.SHORT,
+        qty=100.0,
+        order_type=OrderType.LIMIT,
+        limit_price=200.0,
+        tif=TimeInForce.GTC,
+        reason="strategy_take_profit",
+    )
+    resting_po = order_book.submit(
+        resting_strategy_exit,
+        submitted_at="2024-01-05T00:00:00",
+        submitted_equity=100_000.0,
+    )
+    # Sanity: starts unbound.
+    assert resting_po.working_against_entry_order_id is None
+
+    pending: list[OrderRequest] = []
+    svc._maybe_emit_engine_exits(
+        cur_bar=bar,
+        position_tracker=tracker,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        order_book=order_book,
+        result=result,
+        engine_order_seq=0,
+        engine_exit_bindings={},
+    )
+
+    # Engine emitted its stop-loss close…
+    engine_orders = [r for r in pending if (r.reason or "").startswith(ENGINE_EXIT_REASON_PREFIX)]
+    assert len(engine_orders) == 1
+    # …and the resting strategy GTC limit is now bound to the same
+    # position. When the engine close fills next bar and removes the
+    # position, the fill simulator's stale guard will drop the GTC at
+    # its next trigger instead of opening a reverse short.
+    assert resting_po.working_against_entry_order_id == "o1"
+
+
+def test_engine_does_not_rebind_already_bound_resting_orders() -> None:
+    """The binding pass must leave already-bound orders alone — e.g. a
+    prior bar's engine exit or a strategy partial that's already in
+    flight against the position. Re-binding to a fresh ``entry_order_id``
+    on every subsequent bar would be a no-op here (same id), but the
+    invariant is what we're guarding.
+    """
+    svc = _service(exit_rules=[StopLossRule(pct=0.02)])
+    tracker, portfolio, order_book = _populate_tracker_and_portfolio()
+    bar = _bar(high=105, low=95)
+    result = TradingServiceResult()
+
+    prior = OrderRequest(
+        client_order_id="c-prior",
+        symbol="AAA",
+        side=OrderSide.SHORT,
+        qty=100.0,
+        order_type=OrderType.LIMIT,
+        limit_price=150.0,
+        tif=TimeInForce.GTC,
+        reason="strategy_other",
+    )
+    prior_po = order_book.submit(
+        prior, submitted_at="2024-01-05T00:00:00", submitted_equity=100_000.0
+    )
+    prior_po.working_against_entry_order_id = "o-other"  # pre-bound elsewhere
+
+    pending: list[OrderRequest] = []
+    svc._maybe_emit_engine_exits(
+        cur_bar=bar,
+        position_tracker=tracker,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        order_book=order_book,
+        result=result,
+        engine_order_seq=0,
+        engine_exit_bindings={},
+    )
+
+    # Binding preserved — engine binding loop must not stomp prior bindings.
+    assert prior_po.working_against_entry_order_id == "o-other"
+
+
+def test_engine_does_not_bind_same_side_resting_orders() -> None:
+    """A resting same-side order is an add, not a close — it has nothing
+    to do with the engine's exit and must not be bound to the position.
+    """
+    svc = _service(exit_rules=[StopLossRule(pct=0.02)])
+    tracker, portfolio, order_book = _populate_tracker_and_portfolio()
+    bar = _bar(high=105, low=95)
+    result = TradingServiceResult()
+
+    # Same-side (LONG) limit — strategy intends to add to the position.
+    resting_add = OrderRequest(
+        client_order_id="c-add",
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=50.0,
+        order_type=OrderType.LIMIT,
+        limit_price=80.0,
+        tif=TimeInForce.GTC,
+        reason="strategy_scale_in",
+    )
+    add_po = order_book.submit(
+        resting_add, submitted_at="2024-01-05T00:00:00", submitted_equity=100_000.0
+    )
+
+    pending: list[OrderRequest] = []
+    svc._maybe_emit_engine_exits(
+        cur_bar=bar,
+        position_tracker=tracker,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        order_book=order_book,
+        result=result,
+        engine_order_seq=0,
+        engine_exit_bindings={},
+    )
+
+    # Same-side resting order stays unbound — it isn't a close.
+    assert add_po.working_against_entry_order_id is None

--- a/backend/agents/investment_team/tests/test_engine_exit_helpers.py
+++ b/backend/agents/investment_team/tests/test_engine_exit_helpers.py
@@ -26,7 +26,7 @@ from dataclasses import dataclass
 from typing import Dict
 
 from investment_team.models import BacktestConfig
-from investment_team.strategy_lab.spec_dsl import StopLossRule
+from investment_team.strategy_lab.spec_dsl import StopLossRule, TakeProfitRule
 from investment_team.trading_service.engine.order_book import OrderBook
 from investment_team.trading_service.engine.portfolio import Portfolio, Position
 from investment_team.trading_service.service import (
@@ -105,13 +105,15 @@ def test_tracker_resets_when_position_identity_changes() -> None:
     """Same-bar exit + re-entry replaces the underlying ``Position`` with a
     new ``entry_order_id``. The tracker must reset trailing watermarks
     against the new entry — not carry the prior trade's stale state,
-    which could fire a trailing-stop immediately.
+    which could fire a trailing-stop immediately. The fresh entry is
+    flagged ``just_opened`` so rule evaluation skips this bar.
     """
     tracker: Dict[str, _TrackedPosition] = {
         "AAA": _TrackedPosition(
             side="long",
             entry_price=100.0,
             entry_order_id="o1",
+            just_opened=False,
             high_since_entry=120.0,
             low_since_entry=95.0,
         )
@@ -135,21 +137,26 @@ def test_tracker_resets_when_position_identity_changes() -> None:
     state = tracker["AAA"]
     assert state.entry_order_id == "o2"
     assert state.entry_price == 110.0
-    assert state.high_since_entry == 112.0
-    assert state.low_since_entry == 109.0
+    assert state.just_opened is True
+    # Watermarks initialised at entry_price, NOT the bar's full OHLC, so
+    # pre-entry extremes can't drive same-bar rule evaluation later.
+    assert state.high_since_entry == 110.0
+    assert state.low_since_entry == 110.0
 
 
 def test_tracker_carries_over_when_entry_order_id_unchanged() -> None:
     """Same ``entry_order_id`` → same trade. Weighted-average entry refresh
-    from scale-ins; watermarks extend.
+    from scale-ins; watermarks extend; ``just_opened`` flips to False on
+    the first carry-over bar.
     """
     tracker: Dict[str, _TrackedPosition] = {
         "AAA": _TrackedPosition(
             side="long",
             entry_price=100.0,
             entry_order_id="o1",
-            high_since_entry=105.0,
-            low_since_entry=98.0,
+            just_opened=True,
+            high_since_entry=100.0,
+            low_since_entry=100.0,
         )
     }
     # Same entry_order_id but ``Portfolio.extend`` would have updated
@@ -171,6 +178,7 @@ def test_tracker_carries_over_when_entry_order_id_unchanged() -> None:
 
     state = tracker["AAA"]
     assert state.entry_order_id == "o1"
+    assert state.just_opened is False  # first post-entry bar
     assert state.entry_price == 102.5  # scale-in refresh
     assert state.high_since_entry == 108.0  # extends
     assert state.low_since_entry == 97.0  # extends
@@ -182,6 +190,7 @@ def test_tracker_drops_entry_when_position_closed() -> None:
             side="long",
             entry_price=100.0,
             entry_order_id="o1",
+            just_opened=False,
             high_since_entry=110.0,
             low_since_entry=95.0,
         )
@@ -209,6 +218,7 @@ def _populate_tracker_and_portfolio() -> tuple[Dict[str, _TrackedPosition], Port
             side="long",
             entry_price=100.0,
             entry_order_id="o1",
+            just_opened=False,
             high_since_entry=110.0,
             low_since_entry=95.0,
         )
@@ -519,3 +529,188 @@ def test_engine_does_not_bind_same_side_resting_orders() -> None:
 
     # Same-side resting order stays unbound — it isn't a close.
     assert add_po.working_against_entry_order_id is None
+
+
+def test_engine_binds_same_bar_queued_strategy_exits_too() -> None:
+    """A strategy that emits an opposite-side GTC/limit close on the SAME
+    bar the engine fires a stop-loss queues the order in
+    ``pending_for_prev`` — it isn't on the book yet, so the resting-order
+    binding loop misses it. Without binding here too, the strategy's
+    close gets submitted unbound on the next bar, survives the engine's
+    close-fill, and can later open a reverse position. The fix routes
+    the binding through ``engine_exit_bindings`` so the submit step
+    stamps ``working_against_entry_order_id`` on its ``PendingOrder``.
+    """
+    svc = _service(exit_rules=[StopLossRule(pct=0.02)])
+    tracker, portfolio, order_book = _populate_tracker_and_portfolio()
+    bar = _bar(high=105, low=95)  # trips the 98 stop floor
+    result = TradingServiceResult()
+
+    # Strategy queues a SELL LIMIT at 150 on the same bar — not yet on the book.
+    queued_strategy_exit = OrderRequest(
+        client_order_id="c-queued",
+        symbol="AAA",
+        side=OrderSide.SHORT,
+        qty=100.0,
+        order_type=OrderType.LIMIT,
+        limit_price=150.0,
+        tif=TimeInForce.GTC,
+        reason="strategy_take_profit",
+    )
+    pending: list[OrderRequest] = [queued_strategy_exit]
+    engine_exit_bindings: Dict[str, str] = {}
+
+    svc._maybe_emit_engine_exits(
+        cur_bar=bar,
+        position_tracker=tracker,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        order_book=order_book,
+        result=result,
+        engine_order_seq=0,
+        engine_exit_bindings=engine_exit_bindings,
+    )
+
+    # Engine emitted its stop-loss close AND registered a binding for the
+    # strategy's same-bar queued limit. When the submit step processes
+    # ``pending_for_prev`` on the next bar, both orders get
+    # ``working_against_entry_order_id`` stamped → the stale-continuation
+    # guard drops the survivor when the engine close fills first.
+    assert "c-queued" in engine_exit_bindings
+    assert engine_exit_bindings["c-queued"] == "o1"
+
+
+def test_engine_does_not_bind_same_bar_same_side_queued_orders() -> None:
+    """Symmetric to the resting-order carve-out: a same-bar same-side
+    queued order (a scale-in entry) must NOT be bound to the position.
+    """
+    svc = _service(exit_rules=[StopLossRule(pct=0.02)])
+    tracker, portfolio, order_book = _populate_tracker_and_portfolio()
+    bar = _bar(high=105, low=95)
+    result = TradingServiceResult()
+
+    queued_add = OrderRequest(
+        client_order_id="c-add",
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=50.0,
+        order_type=OrderType.LIMIT,
+        limit_price=80.0,
+        tif=TimeInForce.GTC,
+        reason="strategy_scale_in",
+    )
+    pending: list[OrderRequest] = [queued_add]
+    engine_exit_bindings: Dict[str, str] = {}
+
+    svc._maybe_emit_engine_exits(
+        cur_bar=bar,
+        position_tracker=tracker,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        order_book=order_book,
+        result=result,
+        engine_order_seq=0,
+        engine_exit_bindings=engine_exit_bindings,
+    )
+
+    # The engine's own emission gets a binding; the same-side scale-in does not.
+    engine_orders = [r for r in pending if (r.reason or "").startswith(ENGINE_EXIT_REASON_PREFIX)]
+    engine_cid = engine_orders[0].client_order_id
+    assert engine_cid in engine_exit_bindings
+    assert "c-add" not in engine_exit_bindings
+
+
+def test_engine_skips_rule_eval_on_entry_bar() -> None:
+    """A limit-filled entry that lands mid-bar shares an OHLC bar with
+    price action from BEFORE the fill. If the engine evaluated rules on
+    that bar against ``bar.high`` / ``bar.low``, a take-profit could
+    fire from a pre-entry high (e.g. buy limit at 95 filled by a bar
+    with high=110 instantly trips TakeProfit(pct=0.05) → target=99.75).
+    ``just_opened=True`` skips rule eval entirely on the entry bar; the
+    next bar's tracker update clears the flag and rule eval resumes.
+    """
+    svc = _service(exit_rules=[TakeProfitRule(pct=0.05)])
+    # Position entered at 95, bar.high=110 would trip a take-profit at
+    # 95 * 1.05 = 99.75 if not gated by just_opened.
+    tracker = {
+        "AAA": _TrackedPosition(
+            side="long",
+            entry_price=95.0,
+            entry_order_id="o1",
+            just_opened=True,
+            high_since_entry=95.0,
+            low_since_entry=95.0,
+        )
+    }
+    portfolio = _portfolio_with(
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=100,
+        entry_price=95.0,
+        entry_order_id="o1",
+    )
+    order_book = OrderBook()
+    bar = _bar(high=110.0, low=95.0, close=105.0)
+    result = TradingServiceResult()
+
+    pending: list[OrderRequest] = []
+    svc._maybe_emit_engine_exits(
+        cur_bar=bar,
+        position_tracker=tracker,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        order_book=order_book,
+        result=result,
+        engine_order_seq=0,
+        engine_exit_bindings={},
+    )
+
+    # No engine emission — the entry bar is gated even though bar.high
+    # nominally clears the take-profit target. Rule eval resumes once
+    # the next bar flips just_opened to False.
+    assert pending == []
+    assert result.execution_diagnostics.exit_rule_firings == {}
+
+
+def test_engine_runs_rules_normally_after_first_post_entry_bar() -> None:
+    """Counterpart to ``test_engine_skips_rule_eval_on_entry_bar``: once
+    ``just_opened`` is False, take-profit / stop-loss evaluate against
+    the bar's OHLC as expected.
+    """
+    svc = _service(exit_rules=[TakeProfitRule(pct=0.05)])
+    tracker = {
+        "AAA": _TrackedPosition(
+            side="long",
+            entry_price=95.0,
+            entry_order_id="o1",
+            just_opened=False,  # first post-entry bar
+            high_since_entry=95.0,
+            low_since_entry=95.0,
+        )
+    }
+    portfolio = _portfolio_with(
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=100,
+        entry_price=95.0,
+        entry_order_id="o1",
+    )
+    order_book = OrderBook()
+    # Same bar shape as the entry-bar test, but now post-entry.
+    bar = _bar(high=110.0, low=95.0, close=105.0)
+    result = TradingServiceResult()
+
+    pending: list[OrderRequest] = []
+    svc._maybe_emit_engine_exits(
+        cur_bar=bar,
+        position_tracker=tracker,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        order_book=order_book,
+        result=result,
+        engine_order_seq=0,
+        engine_exit_bindings={},
+    )
+
+    # Take-profit fires off the bar's high.
+    assert result.execution_diagnostics.exit_rule_firings.get("take_profit") == 1

--- a/backend/agents/investment_team/tests/test_engine_exit_helpers.py
+++ b/backend/agents/investment_team/tests/test_engine_exit_helpers.py
@@ -109,9 +109,10 @@ def _bar(symbol: str = "AAA", **kwargs) -> _MockBar:
 def test_tracker_resets_on_limit_entry_with_just_opened_and_entry_price_watermarks() -> None:
     """Same-bar exit + re-entry with a NON-market entry. The tracker must
     reset trailing watermarks against the new entry — and because the
-    fill could have landed anywhere inside the bar, init watermarks at
-    ``entry_price`` and flag ``just_opened=True`` so rule eval skips
-    this bar.
+    fill could have landed anywhere inside the bar, flag
+    ``just_opened=True`` so rule eval skips this bar entirely.
+    Watermarks initialise at ``entry_price`` (same as the market-entry
+    case — see :func:`_extend_watermarks` for the lookahead rationale).
     """
     tracker: Dict[str, _TrackedPosition] = {
         "AAA": _TrackedPosition(
@@ -150,13 +151,16 @@ def test_tracker_resets_on_limit_entry_with_just_opened_and_entry_price_watermar
     assert state.low_since_entry == 110.0
 
 
-def test_tracker_resets_on_market_entry_using_bar_ohlc_without_gating() -> None:
-    """Market entries fill at the bar's open, so the bar's full
-    high/low IS post-entry price action. The tracker initialises
-    watermarks from the bar (so a same-bar stop/take-profit can be
-    captured) and leaves ``just_opened=False`` so rule eval runs on
-    this bar. Without this carve-out, longs opened at the open could
-    trade through their stop and recover with no engine emission.
+def test_tracker_resets_on_market_entry_with_entry_price_watermarks() -> None:
+    """Market entries fill at the bar's open. Rule eval is NOT gated
+    (``just_opened=False``) so a same-bar entry_price stop / take-profit
+    can fire — those rules consult ``entry_price`` not the trailing
+    watermark. The trailing watermark itself initialises at
+    ``entry_price`` to avoid intrabar lookahead: if it initialised at
+    ``cur_bar.high``/``cur_bar.low`` a trailing stop could trigger on
+    the same bar's low from a floor that was raised by the same bar's
+    high (regardless of which printed first). ``_extend_watermarks``
+    runs AFTER rule evaluation so the next bar reads the bar's range.
     """
     tracker: Dict[str, _TrackedPosition] = {}
     portfolio = _portfolio_with(
@@ -178,14 +182,19 @@ def test_tracker_resets_on_market_entry_using_bar_ohlc_without_gating() -> None:
     state = tracker["AAA"]
     assert state.entry_order_id == "o-mkt"
     assert state.just_opened is False  # rule eval runs on the entry bar
-    assert state.high_since_entry == 112.0  # full bar high captured
-    assert state.low_since_entry == 88.0  # full bar low captured
+    # Watermarks at entry_price — NOT the bar's OHLC — to keep the
+    # entry bar's eval lookahead-free. ``_extend_watermarks`` runs
+    # AFTER rule eval and updates them for the next bar.
+    assert state.high_since_entry == 100.0
+    assert state.low_since_entry == 100.0
 
 
 def test_tracker_carries_over_when_entry_order_id_unchanged() -> None:
     """Same ``entry_order_id`` → same trade. Weighted-average entry refresh
-    from scale-ins; watermarks extend; ``just_opened`` flips to False on
-    the first carry-over bar.
+    from scale-ins; ``just_opened`` flips to False on the first carry-
+    over bar. Watermarks are NOT extended here — ``_extend_watermarks``
+    runs separately AFTER rule evaluation so trailing-stop rules can't
+    fire from a floor that the current bar's high just raised.
     """
     tracker: Dict[str, _TrackedPosition] = {
         "AAA": _TrackedPosition(
@@ -218,8 +227,49 @@ def test_tracker_carries_over_when_entry_order_id_unchanged() -> None:
     assert state.entry_order_id == "o1"
     assert state.just_opened is False  # first post-entry bar
     assert state.entry_price == 102.5  # scale-in refresh
-    assert state.high_since_entry == 108.0  # extends
-    assert state.low_since_entry == 97.0  # extends
+    # Watermarks unchanged here — extension is now done by the
+    # separate ``_extend_watermarks`` call after rule eval. Updating
+    # them here would let a trailing stop fire on the same bar's low
+    # from a floor raised by the same bar's high (intrabar lookahead).
+    assert state.high_since_entry == 100.0
+    assert state.low_since_entry == 100.0
+
+
+def test_extend_watermarks_picks_up_bar_extremes() -> None:
+    """``_extend_watermarks`` runs after rule eval and pushes
+    high_since_entry / low_since_entry out to the current bar's
+    extremes so the NEXT bar's eval sees the latest trailing floor.
+    """
+    tracker: Dict[str, _TrackedPosition] = {
+        "AAA": _TrackedPosition(
+            side="long",
+            entry_price=100.0,
+            entry_order_id="o1",
+            just_opened=False,
+            high_since_entry=100.0,
+            low_since_entry=100.0,
+        )
+    }
+    bar = _bar(high=108.0, low=97.0)
+
+    TradingService._extend_watermarks(tracker=tracker, cur_bar=bar)
+
+    state = tracker["AAA"]
+    assert state.high_since_entry == 108.0
+    assert state.low_since_entry == 97.0
+
+
+def test_extend_watermarks_no_op_when_symbol_absent() -> None:
+    """``_extend_watermarks`` is a no-op when the tracker has no entry
+    for the bar's symbol — guards against KeyError after a same-bar
+    exit drops the position before watermark extension runs.
+    """
+    tracker: Dict[str, _TrackedPosition] = {}
+    bar = _bar(high=108.0, low=97.0)
+
+    TradingService._extend_watermarks(tracker=tracker, cur_bar=bar)
+
+    assert tracker == {}
 
 
 def test_tracker_drops_entry_when_position_closed() -> None:
@@ -794,3 +844,176 @@ def test_engine_cancels_pending_entry_continuation_when_exit_fires() -> None:
     engine_orders = [r for r in pending if (r.reason or "").startswith(ENGINE_EXIT_REASON_PREFIX)]
     assert len(engine_orders) == 1
     assert "o1" not in order_book._pending
+
+
+def test_trailing_stop_does_not_lookahead_within_a_bar() -> None:
+    """Regression: trailing-stop rules must not see the current bar's
+    high in the trailing floor while evaluating against the current
+    bar's low. A long entered at 100 with
+    ``StopLossRule(pct=0.05, basis="trailing_high")``: if today prints
+    high=120 and low=110, the trailing floor would be 120*(1-0.05)=114
+    and bar.low=110 would trip it — even though we don't know whether
+    the high or the low printed first. The fix initialises watermarks
+    at ``entry_price`` and defers watermark extension to
+    ``_extend_watermarks`` which runs AFTER rule evaluation.
+    """
+    disp = _dispatcher(exit_rules=[StopLossRule(pct=0.05, basis="trailing_high")])
+    # Fresh entry, watermarks at entry_price=100.
+    tracker: Dict[str, _TrackedPosition] = {
+        "AAA": _TrackedPosition(
+            side="long",
+            entry_price=100.0,
+            entry_order_id="o1",
+            just_opened=False,
+            high_since_entry=100.0,
+            low_since_entry=100.0,
+        )
+    }
+    portfolio = _portfolio_with(
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=100,
+        entry_price=100.0,
+        entry_order_id="o1",
+    )
+    order_book = OrderBook()
+    # Today: high=120 (would push trailing floor to 114), low=110.
+    # 110 > 100*(1-0.05)=95, so the trailing stop must NOT fire.
+    bar = _bar(high=120.0, low=110.0, close=115.0)
+    result = TradingServiceResult()
+
+    pending: list[OrderRequest] = []
+    disp.maybe_emit(
+        cur_bar=bar,
+        position_tracker=tracker,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        order_book=order_book,
+        result=result,
+    )
+
+    # No engine emission — the trailing floor is 95 (from entry_price),
+    # bar.low=110 is well clear.
+    assert pending == []
+    assert result.execution_diagnostics.exit_rule_firings == {}
+
+    # NOW extend watermarks (as the bar-loop does after rule eval).
+    # The high gets baked in for the next bar.
+    TradingService._extend_watermarks(tracker=tracker, cur_bar=bar)
+    assert tracker["AAA"].high_since_entry == 120.0
+
+
+def test_engine_oversizes_close_to_cover_same_bar_scale_ins() -> None:
+    """A strategy scale-in queued on the SAME bar the engine fires its
+    stop-loss submits BEFORE the engine close on the next bar (its
+    ``client_order_id`` is earlier in ``pending_for_prev``). When that
+    scale-in fills first, ``pos.qty`` grows past the snapshot the
+    engine saw at emission time, and ``_fill_exit`` clips the engine
+    close at ``min(req.qty, existing_pos.qty)`` — leaving the scale-in
+    residual exposure open even though the structured stop already
+    fired. Fix: sum same-side queued qtys and oversize the engine
+    close by that amount; the clip-down then nets to zero exposure.
+    """
+    disp = _dispatcher(exit_rules=[StopLossRule(pct=0.02)])
+    tracker, portfolio, order_book = _populate_tracker_and_portfolio()
+    bar = _bar(high=105, low=95)  # bar.low=95 trips floor=98
+    result = TradingServiceResult()
+
+    # Strategy queues a same-side LONG scale-in on this bar — fills
+    # before the engine close on the next bar.
+    queued_add = OrderRequest(
+        client_order_id="c-scale-in",
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=50.0,
+        order_type=OrderType.MARKET,
+        tif=TimeInForce.DAY,
+        reason="strategy_scale_in",
+    )
+    pending: list[OrderRequest] = [queued_add]
+
+    disp.maybe_emit(
+        cur_bar=bar,
+        position_tracker=tracker,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        order_book=order_book,
+        result=result,
+    )
+
+    engine_orders = [r for r in pending if (r.reason or "").startswith(ENGINE_EXIT_REASON_PREFIX)]
+    assert len(engine_orders) == 1
+    # Engine close sized to cover pos.qty (100) + scale-in (50) = 150.
+    # If the scale-in is rejected/clipped at fill time, ``_fill_exit``
+    # clips the engine close back down to existing_pos.qty.
+    assert engine_orders[0].qty == 150.0
+
+
+def test_engine_does_not_oversize_for_opposite_side_queued_orders() -> None:
+    """An opposite-side queued order is a strategy exit, not a
+    scale-in. It must NOT inflate the engine's close qty (the binding
+    machinery will dedup it at fill time instead).
+    """
+    disp = _dispatcher(exit_rules=[StopLossRule(pct=0.02)])
+    tracker, portfolio, order_book = _populate_tracker_and_portfolio()
+    bar = _bar(high=105, low=95)
+    result = TradingServiceResult()
+
+    queued_strategy_exit = OrderRequest(
+        client_order_id="c-strategy-exit",
+        symbol="AAA",
+        side=OrderSide.SHORT,
+        qty=50.0,
+        order_type=OrderType.MARKET,
+        tif=TimeInForce.DAY,
+        reason="strategy_close",
+    )
+    pending: list[OrderRequest] = [queued_strategy_exit]
+
+    disp.maybe_emit(
+        cur_bar=bar,
+        position_tracker=tracker,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        order_book=order_book,
+        result=result,
+    )
+
+    engine_orders = [r for r in pending if (r.reason or "").startswith(ENGINE_EXIT_REASON_PREFIX)]
+    assert len(engine_orders) == 1
+    # No oversize — exits aren't scale-ins.
+    assert engine_orders[0].qty == 100.0
+
+
+def test_engine_does_not_oversize_for_other_symbol_queued_orders() -> None:
+    """``_sum_same_side_queued`` is symbol-scoped — a same-side queued
+    order for a different symbol must not inflate the close qty.
+    """
+    disp = _dispatcher(exit_rules=[StopLossRule(pct=0.02)])
+    tracker, portfolio, order_book = _populate_tracker_and_portfolio()
+    bar = _bar(high=105, low=95)
+    result = TradingServiceResult()
+
+    queued_other = OrderRequest(
+        client_order_id="c-other-sym",
+        symbol="BBB",
+        side=OrderSide.LONG,
+        qty=200.0,
+        order_type=OrderType.MARKET,
+        tif=TimeInForce.DAY,
+        reason="strategy_other_symbol",
+    )
+    pending: list[OrderRequest] = [queued_other]
+
+    disp.maybe_emit(
+        cur_bar=bar,
+        position_tracker=tracker,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        order_book=order_book,
+        result=result,
+    )
+
+    engine_orders = [r for r in pending if (r.reason or "").startswith(ENGINE_EXIT_REASON_PREFIX)]
+    assert len(engine_orders) == 1
+    assert engine_orders[0].qty == 100.0

--- a/backend/agents/investment_team/tests/test_engine_exit_helpers.py
+++ b/backend/agents/investment_team/tests/test_engine_exit_helpers.py
@@ -749,3 +749,67 @@ def test_engine_runs_rules_normally_after_first_post_entry_bar() -> None:
 
     # Take-profit fires off the bar's high.
     assert result.execution_diagnostics.exit_rule_firings.get("take_profit") == 1
+
+
+def test_engine_cancels_pending_entry_continuation_when_exit_fires() -> None:
+    """A partial-fill entry remainder (REQUEUE_NEXT_BAR / TWAP slice) is
+    still pending on the book when the engine fires its stop-loss /
+    take-profit. Without cancelling, the continuation could fill on the
+    next bar before the engine's market close, growing the position
+    past the engine's sized close (which clips at the snapshot ``pos.qty``
+    via ``_fill_exit``'s ``min(req.qty, existing_pos.qty)`` invariant).
+    The fix scans ``order_book.pending_for_symbol(sym)`` for orders
+    matching ``pos.entry_order_id`` with ``cumulative_filled_qty > 0``
+    and cancels them so the rule's close is the last word on the
+    position.
+    """
+    svc = _service(exit_rules=[StopLossRule(pct=0.02)])
+    tracker, portfolio, order_book = _populate_tracker_and_portfolio()
+    bar = _bar(high=105, low=95)  # bar.low=95 trips floor=98
+    result = TradingServiceResult()
+
+    # Build a pending entry continuation: same side as position, marked
+    # as partially filled, ``order_id == pos.entry_order_id`` so the
+    # engine recognises it as a continuation.
+    entry_continuation = OrderRequest(
+        client_order_id="c-entry",
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=100.0,
+        order_type=OrderType.MARKET,
+        tif=TimeInForce.DAY,
+        reason="entry_continuation",
+    )
+    submitted_po = order_book.submit(
+        entry_continuation,
+        submitted_at="2024-01-05T00:00:00",
+        submitted_equity=100_000.0,
+    )
+    # Force the order_id to match the position's entry_order_id (the
+    # real engine assigns this on first submission; we splice it in for
+    # the test since the order book auto-assigns an "o2"-style id).
+    order_book._pending[submitted_po.order_id] = submitted_po
+    submitted_po.order_id = "o1"
+    order_book._pending["o1"] = submitted_po
+    submitted_po.cumulative_filled_qty = 40.0  # 40 of 100 already filled
+    # Map the order under the position's symbol bucket so
+    # ``pending_for_symbol`` returns it under the matched id.
+    order_book._by_symbol["AAA"].append("o1")
+
+    pending: list[OrderRequest] = []
+    svc._maybe_emit_engine_exits(
+        cur_bar=bar,
+        position_tracker=tracker,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        order_book=order_book,
+        result=result,
+        engine_order_seq=0,
+        engine_exit_bindings={},
+    )
+
+    # Engine emitted its stop-loss close AND cancelled the pending
+    # entry continuation so it can't fill on the next bar.
+    engine_orders = [r for r in pending if (r.reason or "").startswith(ENGINE_EXIT_REASON_PREFIX)]
+    assert len(engine_orders) == 1
+    assert "o1" not in order_book._pending

--- a/backend/agents/investment_team/tests/test_engine_exit_helpers.py
+++ b/backend/agents/investment_team/tests/test_engine_exit_helpers.py
@@ -116,7 +116,7 @@ def test_tracker_resets_on_limit_entry_with_just_opened_and_entry_price_watermar
     """
     tracker: Dict[str, _TrackedPosition] = {
         "AAA": _TrackedPosition(
-            side="long",
+            side=OrderSide.LONG,
             entry_price=100.0,
             entry_order_id="o1",
             just_opened=False,
@@ -198,7 +198,7 @@ def test_tracker_carries_over_when_entry_order_id_unchanged() -> None:
     """
     tracker: Dict[str, _TrackedPosition] = {
         "AAA": _TrackedPosition(
-            side="long",
+            side=OrderSide.LONG,
             entry_price=100.0,
             entry_order_id="o1",
             just_opened=True,
@@ -242,7 +242,7 @@ def test_extend_watermarks_picks_up_bar_extremes() -> None:
     """
     tracker: Dict[str, _TrackedPosition] = {
         "AAA": _TrackedPosition(
-            side="long",
+            side=OrderSide.LONG,
             entry_price=100.0,
             entry_order_id="o1",
             just_opened=False,
@@ -275,7 +275,7 @@ def test_extend_watermarks_no_op_when_symbol_absent() -> None:
 def test_tracker_drops_entry_when_position_closed() -> None:
     tracker: Dict[str, _TrackedPosition] = {
         "AAA": _TrackedPosition(
-            side="long",
+            side=OrderSide.LONG,
             entry_price=100.0,
             entry_order_id="o1",
             just_opened=False,
@@ -303,7 +303,7 @@ def test_tracker_drops_entry_when_position_closed() -> None:
 def _populate_tracker_and_portfolio() -> tuple[Dict[str, _TrackedPosition], Portfolio, OrderBook]:
     tracker = {
         "AAA": _TrackedPosition(
-            side="long",
+            side=OrderSide.LONG,
             entry_price=100.0,
             entry_order_id="o1",
             just_opened=False,
@@ -706,7 +706,7 @@ def test_engine_skips_rule_eval_on_entry_bar() -> None:
     # 95 * 1.05 = 99.75 if not gated by just_opened.
     tracker = {
         "AAA": _TrackedPosition(
-            side="long",
+            side=OrderSide.LONG,
             entry_price=95.0,
             entry_order_id="o1",
             just_opened=True,
@@ -750,7 +750,7 @@ def test_engine_runs_rules_normally_after_first_post_entry_bar() -> None:
     disp = _dispatcher(exit_rules=[TakeProfitRule(pct=0.05)])
     tracker = {
         "AAA": _TrackedPosition(
-            side="long",
+            side=OrderSide.LONG,
             entry_price=95.0,
             entry_order_id="o1",
             just_opened=False,  # first post-entry bar
@@ -861,7 +861,7 @@ def test_trailing_stop_does_not_lookahead_within_a_bar() -> None:
     # Fresh entry, watermarks at entry_price=100.
     tracker: Dict[str, _TrackedPosition] = {
         "AAA": _TrackedPosition(
-            side="long",
+            side=OrderSide.LONG,
             entry_price=100.0,
             entry_order_id="o1",
             just_opened=False,

--- a/backend/agents/investment_team/tests/test_engine_exit_helpers.py
+++ b/backend/agents/investment_team/tests/test_engine_exit_helpers.py
@@ -1,0 +1,345 @@
+"""Unit tests for :class:`TradingService`'s private exit-rule helpers
+(``_update_position_tracker`` / ``_maybe_emit_engine_exits``).
+
+These exercise behaviours hard to construct via the streaming subprocess
+end-to-end:
+
+* Tracker resets when the position identity (``entry_order_id``)
+  changes — a same-bar exit + re-entry must not inherit stale
+  ``bars_held`` / watermarks.
+* Engine dedup ignores non-market strategy orders (limit/stop closes
+  far from the market aren't guaranteed to fill).
+* Engine emissions bind to ``pos.entry_order_id`` via
+  ``engine_exit_bindings`` so the fill simulator's stale-continuation
+  guard can drop them when a prior strategy exit closes the position
+  first.
+
+Drives the helpers with hand-built ``Portfolio`` / ``OrderBook`` /
+``OrderRequest`` fixtures so the assertions are precise.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+from investment_team.models import BacktestConfig
+from investment_team.strategy_lab.spec_dsl import (
+    StopLossRule,
+    TimeStopRule,
+)
+from investment_team.trading_service.engine.order_book import OrderBook
+from investment_team.trading_service.engine.portfolio import Portfolio, Position
+from investment_team.trading_service.service import (
+    ENGINE_EXIT_REASON_PREFIX,
+    TradingService,
+    TradingServiceResult,
+    _TrackedPosition,
+)
+from investment_team.trading_service.strategy.contract import (
+    OrderRequest,
+    OrderSide,
+    OrderType,
+    TimeInForce,
+)
+
+
+@dataclass
+class _MockBar:
+    symbol: str
+    timestamp: str
+    high: float
+    low: float
+    close: float
+
+
+def _service(*, exit_rules) -> TradingService:
+    return TradingService(
+        strategy_code="from contract import Strategy\nclass S(Strategy):\n    pass\n",
+        config=BacktestConfig(start_date="2024-01-01", end_date="2024-12-31"),
+        exit_rules=exit_rules,
+    )
+
+
+def _portfolio_with(
+    *,
+    symbol: str,
+    side: OrderSide,
+    qty: float,
+    entry_price: float,
+    entry_order_id: str,
+    entry_timestamp: str = "2024-01-01",
+) -> Portfolio:
+    p = Portfolio(initial_capital=100_000.0)
+    p.positions[symbol] = Position(
+        symbol=symbol,
+        side=side,
+        qty=qty,
+        entry_price=entry_price,
+        entry_bid_price=entry_price,
+        entry_timestamp=entry_timestamp,
+        entry_order_id=entry_order_id,
+        entry_client_order_id=f"c-{entry_order_id}",
+        original_qty=qty,
+    )
+    return p
+
+
+def _bar(symbol: str = "AAA", **kwargs) -> _MockBar:
+    defaults = {
+        "symbol": symbol,
+        "timestamp": "2024-01-10T00:00:00",
+        "high": 105.0,
+        "low": 95.0,
+        "close": 100.0,
+    }
+    defaults.update(kwargs)
+    return _MockBar(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# _update_position_tracker
+# ---------------------------------------------------------------------------
+
+
+def test_tracker_resets_when_position_identity_changes() -> None:
+    """Same-bar exit + re-entry replaces the underlying ``Position`` with a
+    new ``entry_order_id``. The tracker must reset to ``bars_held=1`` /
+    fresh watermarks against the new entry — not carry the prior trade's
+    stale state, which could fire a ``TimeStopRule`` or trailing-stop
+    immediately.
+    """
+    tracker: Dict[str, _TrackedPosition] = {
+        "AAA": _TrackedPosition(
+            side="long",
+            entry_price=100.0,
+            entry_order_id="o1",
+            bars_held=9,
+            high_since_entry=120.0,
+            low_since_entry=95.0,
+        )
+    }
+    # Same-bar exit/re-entry — new Position, different entry_order_id.
+    portfolio = _portfolio_with(
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=10,
+        entry_price=110.0,
+        entry_order_id="o2",
+    )
+    bar = _bar(high=112.0, low=109.0)
+
+    TradingService._update_position_tracker(
+        tracker=tracker,
+        cur_bar=bar,
+        portfolio=portfolio,
+    )
+
+    state = tracker["AAA"]
+    assert state.entry_order_id == "o2"
+    assert state.entry_price == 110.0
+    assert state.bars_held == 1
+    assert state.high_since_entry == 112.0
+    assert state.low_since_entry == 109.0
+
+
+def test_tracker_carries_over_when_entry_order_id_unchanged() -> None:
+    """Same ``entry_order_id`` → same trade. bars_held++; weighted-average
+    entry refresh from scale-ins; watermarks extend.
+    """
+    tracker: Dict[str, _TrackedPosition] = {
+        "AAA": _TrackedPosition(
+            side="long",
+            entry_price=100.0,
+            entry_order_id="o1",
+            bars_held=3,
+            high_since_entry=105.0,
+            low_since_entry=98.0,
+        )
+    }
+    # Same entry_order_id but ``Portfolio.extend`` would have updated
+    # ``entry_price`` to a weighted average.
+    portfolio = _portfolio_with(
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=20,
+        entry_price=102.5,
+        entry_order_id="o1",
+    )
+    bar = _bar(high=108.0, low=97.0)
+
+    TradingService._update_position_tracker(
+        tracker=tracker,
+        cur_bar=bar,
+        portfolio=portfolio,
+    )
+
+    state = tracker["AAA"]
+    assert state.entry_order_id == "o1"
+    assert state.bars_held == 4
+    assert state.entry_price == 102.5  # scale-in refresh
+    assert state.high_since_entry == 108.0  # extends
+    assert state.low_since_entry == 97.0  # extends
+
+
+def test_tracker_drops_entry_when_position_closed() -> None:
+    tracker: Dict[str, _TrackedPosition] = {
+        "AAA": _TrackedPosition(
+            side="long",
+            entry_price=100.0,
+            entry_order_id="o1",
+            bars_held=5,
+            high_since_entry=110.0,
+            low_since_entry=95.0,
+        )
+    }
+    portfolio = Portfolio(initial_capital=100_000.0)  # empty positions
+    bar = _bar()
+
+    TradingService._update_position_tracker(
+        tracker=tracker,
+        cur_bar=bar,
+        portfolio=portfolio,
+    )
+
+    assert "AAA" not in tracker
+
+
+# ---------------------------------------------------------------------------
+# _maybe_emit_engine_exits
+# ---------------------------------------------------------------------------
+
+
+def _populate_tracker_and_portfolio() -> tuple[Dict[str, _TrackedPosition], Portfolio, OrderBook]:
+    tracker = {
+        "AAA": _TrackedPosition(
+            side="long",
+            entry_price=100.0,
+            entry_order_id="o1",
+            bars_held=10,
+            high_since_entry=110.0,
+            low_since_entry=95.0,
+        )
+    }
+    portfolio = _portfolio_with(
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=100,
+        entry_price=100.0,
+        entry_order_id="o1",
+    )
+    order_book = OrderBook()
+    return tracker, portfolio, order_book
+
+
+def test_dedup_ignores_limit_close_far_from_market() -> None:
+    """A strategy's full-size limit close far from market is not guaranteed
+    to fill — it must NOT suppress the engine's market emission. Otherwise
+    the rule is silently skipped while the limit hangs and the position
+    stays open past the structured-exit threshold.
+    """
+    svc = _service(exit_rules=[TimeStopRule(n_bars=10)])
+    tracker, portfolio, order_book = _populate_tracker_and_portfolio()
+    bar = _bar()
+    result = TradingServiceResult()
+
+    # Strategy emits a far-from-market LIMIT sell for 100 shares.
+    pending = [
+        OrderRequest(
+            client_order_id="c1",
+            symbol="AAA",
+            side=OrderSide.SHORT,
+            qty=100.0,
+            order_type=OrderType.LIMIT,
+            limit_price=200.0,  # well above; won't fill on next bar
+            tif=TimeInForce.DAY,
+            reason="strategy_limit_exit",
+        )
+    ]
+    engine_exit_bindings: Dict[str, str] = {}
+
+    svc._maybe_emit_engine_exits(
+        cur_bar=bar,
+        position_tracker=tracker,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        order_book=order_book,
+        result=result,
+        engine_order_seq=0,
+        engine_exit_bindings=engine_exit_bindings,
+    )
+
+    # Engine MUST still emit its market close — the limit isn't guaranteed.
+    engine_orders = [r for r in pending if (r.reason or "").startswith(ENGINE_EXIT_REASON_PREFIX)]
+    assert len(engine_orders) == 1
+    assert engine_orders[0].qty == 100.0
+    assert engine_orders[0].order_type == OrderType.MARKET
+    assert result.execution_diagnostics.exit_rule_firings.get("time_stop") == 1
+
+
+def test_dedup_skips_engine_emission_on_full_market_strategy_close() -> None:
+    """Full-size market close from strategy on the same bar → engine
+    emission is redundant and must be skipped.
+    """
+    svc = _service(exit_rules=[TimeStopRule(n_bars=10)])
+    tracker, portfolio, order_book = _populate_tracker_and_portfolio()
+    bar = _bar()
+    result = TradingServiceResult()
+
+    pending = [
+        OrderRequest(
+            client_order_id="c1",
+            symbol="AAA",
+            side=OrderSide.SHORT,
+            qty=100.0,
+            order_type=OrderType.MARKET,
+            tif=TimeInForce.DAY,
+            reason="strategy_full_exit",
+        )
+    ]
+    svc._maybe_emit_engine_exits(
+        cur_bar=bar,
+        position_tracker=tracker,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        order_book=order_book,
+        result=result,
+        engine_order_seq=0,
+        engine_exit_bindings={},
+    )
+
+    # No engine emission — strategy fully covered the close.
+    engine_orders = [r for r in pending if (r.reason or "").startswith(ENGINE_EXIT_REASON_PREFIX)]
+    assert engine_orders == []
+    assert result.execution_diagnostics.exit_rule_firings == {}
+
+
+def test_engine_emission_registers_binding_to_entry_order_id() -> None:
+    """The binding lets the fill simulator's stale-continuation guard drop
+    the engine close when a prior strategy exit closes the position
+    first. Without it, the engine market falls through to ``_fill_entry``
+    and opens a brand-new opposite-side position.
+    """
+    svc = _service(exit_rules=[StopLossRule(pct=0.02)])  # entry=100 → floor=98; bar.low=95 fires
+    tracker, portfolio, order_book = _populate_tracker_and_portfolio()
+    bar = _bar(high=105, low=95)
+    result = TradingServiceResult()
+
+    engine_exit_bindings: Dict[str, str] = {}
+    pending: list[OrderRequest] = []
+
+    svc._maybe_emit_engine_exits(
+        cur_bar=bar,
+        position_tracker=tracker,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        order_book=order_book,
+        result=result,
+        engine_order_seq=0,
+        engine_exit_bindings=engine_exit_bindings,
+    )
+
+    assert len(pending) == 1
+    cid = pending[0].client_order_id
+    assert cid in engine_exit_bindings
+    assert engine_exit_bindings[cid] == "o1"

--- a/backend/agents/investment_team/tests/test_engine_exit_helpers.py
+++ b/backend/agents/investment_team/tests/test_engine_exit_helpers.py
@@ -1017,3 +1017,196 @@ def test_engine_does_not_oversize_for_other_symbol_queued_orders() -> None:
     engine_orders = [r for r in pending if (r.reason or "").startswith(ENGINE_EXIT_REASON_PREFIX)]
     assert len(engine_orders) == 1
     assert engine_orders[0].qty == 100.0
+
+
+def test_engine_oversizes_close_to_cover_resting_same_side_scale_in() -> None:
+    """A same-side GTC/limit scale-in resting on the book from a
+    PRIOR bar isn't in ``pending_for_prev`` but could fill on the
+    next bar alongside the engine close. The engine close must size
+    to cover it for the same reason as the same-bar queued case
+    (see ``test_engine_oversizes_close_to_cover_same_bar_scale_ins``):
+    if the resting order fills first, ``_fill_exit`` clips to that
+    fattened ``existing_pos.qty`` and leaves the residual open.
+
+    Fix: ``_sum_same_side_resting`` scans the order book for unbound
+    same-side orders with remaining qty and the dispatcher sums that
+    into ``scale_in_qty`` alongside ``_sum_same_side_queued``.
+    """
+    disp = _dispatcher(exit_rules=[StopLossRule(pct=0.02)])
+    tracker, portfolio, order_book = _populate_tracker_and_portfolio()
+    bar = _bar(high=105, low=95)
+    result = TradingServiceResult()
+
+    # Resting GTC LONG scale-in from a prior bar — unbound.
+    resting_add = OrderRequest(
+        client_order_id="c-resting-add",
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=75.0,
+        order_type=OrderType.LIMIT,
+        limit_price=80.0,
+        tif=TimeInForce.GTC,
+        reason="strategy_scale_in",
+    )
+    order_book.submit(resting_add, submitted_at="2024-01-05T00:00:00", submitted_equity=100_000.0)
+
+    pending: list[OrderRequest] = []
+    disp.maybe_emit(
+        cur_bar=bar,
+        position_tracker=tracker,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        order_book=order_book,
+        result=result,
+    )
+
+    engine_orders = [r for r in pending if (r.reason or "").startswith(ENGINE_EXIT_REASON_PREFIX)]
+    assert len(engine_orders) == 1
+    # Engine close sized to cover pos.qty (100) + resting add (75) = 175.
+    assert engine_orders[0].qty == 175.0
+
+
+def test_engine_close_excludes_partially_filled_resting_scale_in_already_filled_qty() -> None:
+    """A resting same-side order that's been partially filled —
+    e.g. an entry continuation with cumulative_filled_qty>0 — has
+    its already-filled qty baked into ``pos.qty``. Only the
+    *remaining* unfilled qty needs to be covered by the engine
+    close oversize. Otherwise we'd double-count and oversize the
+    engine close past the maximum residual the position could
+    reach.
+    """
+    disp = _dispatcher(exit_rules=[StopLossRule(pct=0.02)])
+    tracker, portfolio, order_book = _populate_tracker_and_portfolio()
+    bar = _bar(high=105, low=95)
+    result = TradingServiceResult()
+
+    partial_resting = OrderRequest(
+        client_order_id="c-partial",
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=80.0,
+        order_type=OrderType.LIMIT,
+        limit_price=80.0,
+        tif=TimeInForce.GTC,
+        reason="strategy_partial_add",
+    )
+    po = order_book.submit(
+        partial_resting, submitted_at="2024-01-05T00:00:00", submitted_equity=100_000.0
+    )
+    po.cumulative_filled_qty = 30.0  # 50 left unfilled
+
+    pending: list[OrderRequest] = []
+    disp.maybe_emit(
+        cur_bar=bar,
+        position_tracker=tracker,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        order_book=order_book,
+        result=result,
+    )
+
+    engine_orders = [r for r in pending if (r.reason or "").startswith(ENGINE_EXIT_REASON_PREFIX)]
+    assert len(engine_orders) == 1
+    # 100 (pos) + 50 (resting unfilled) = 150 — the 30 already filled
+    # is already in pos.qty so we don't double-count it.
+    assert engine_orders[0].qty == 150.0
+
+
+def test_engine_does_not_oversize_for_already_bound_resting_orders() -> None:
+    """Already-bound resting orders (prior engine exits, bracket
+    children) will be retired by the stale-continuation guard once
+    the engine close fills; they won't grow the position, so they
+    must not inflate the engine close qty.
+    """
+    disp = _dispatcher(exit_rules=[StopLossRule(pct=0.02)])
+    tracker, portfolio, order_book = _populate_tracker_and_portfolio()
+    bar = _bar(high=105, low=95)
+    result = TradingServiceResult()
+
+    bound_resting = OrderRequest(
+        client_order_id="c-bound",
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=50.0,
+        order_type=OrderType.LIMIT,
+        limit_price=80.0,
+        tif=TimeInForce.GTC,
+        reason="strategy_other_run",
+    )
+    bound_po = order_book.submit(
+        bound_resting, submitted_at="2024-01-05T00:00:00", submitted_equity=100_000.0
+    )
+    bound_po.working_against_entry_order_id = "o-other"
+
+    pending: list[OrderRequest] = []
+    disp.maybe_emit(
+        cur_bar=bar,
+        position_tracker=tracker,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        order_book=order_book,
+        result=result,
+    )
+
+    engine_orders = [r for r in pending if (r.reason or "").startswith(ENGINE_EXIT_REASON_PREFIX)]
+    assert len(engine_orders) == 1
+    # Bound orders don't add to scale_in_qty.
+    assert engine_orders[0].qty == 100.0
+
+
+def test_extend_watermarks_skips_just_opened_entry_bar() -> None:
+    """Regression for the entry-bar lookahead carve-out. A non-market
+    fill (``just_opened=True``) shares OHLC with pre-entry price
+    action — including the entry bar's high/low in the watermark
+    would let a pre-entry intrabar spike drive a trailing-high stop
+    on the next bar from price action that happened before the
+    position existed. ``_extend_watermarks`` must skip while
+    ``just_opened=True`` and resume on the next bar after
+    ``_update_position_tracker`` flips the flag.
+    """
+    tracker: Dict[str, _TrackedPosition] = {
+        "AAA": _TrackedPosition(
+            side=OrderSide.LONG,
+            entry_price=110.0,
+            entry_order_id="o-limit",
+            just_opened=True,  # non-market entry on this bar
+            high_since_entry=110.0,
+            low_since_entry=110.0,
+        )
+    }
+    # Entry bar prints high=130 (pre-entry intrabar spike) and low=105
+    # (post-entry dip). For a limit fill at 110 mid-bar we don't know
+    # which side printed first — so the safe move is to skip the
+    # whole bar.
+    bar = _bar(high=130.0, low=105.0)
+
+    TradingService._extend_watermarks(tracker=tracker, cur_bar=bar)
+
+    state = tracker["AAA"]
+    # Watermarks unchanged — entry bar's range stays out of the
+    # trailing watermark.
+    assert state.high_since_entry == 110.0
+    assert state.low_since_entry == 110.0
+
+
+def test_extend_watermarks_resumes_after_just_opened_clears() -> None:
+    """Counterpart: once the tracker carry-over (next bar) flips
+    ``just_opened`` to False, ``_extend_watermarks`` runs normally.
+    """
+    tracker: Dict[str, _TrackedPosition] = {
+        "AAA": _TrackedPosition(
+            side=OrderSide.LONG,
+            entry_price=110.0,
+            entry_order_id="o-limit",
+            just_opened=False,  # carry-over bar
+            high_since_entry=110.0,
+            low_since_entry=110.0,
+        )
+    }
+    bar = _bar(high=120.0, low=108.0)
+
+    TradingService._extend_watermarks(tracker=tracker, cur_bar=bar)
+
+    state = tracker["AAA"]
+    assert state.high_since_entry == 120.0
+    assert state.low_since_entry == 108.0

--- a/backend/agents/investment_team/tests/test_engine_exit_helpers.py
+++ b/backend/agents/investment_team/tests/test_engine_exit_helpers.py
@@ -68,6 +68,7 @@ def _portfolio_with(
     entry_price: float,
     entry_order_id: str,
     entry_timestamp: str = "2024-01-01",
+    entry_order_type: str = "market",
 ) -> Portfolio:
     p = Portfolio(initial_capital=100_000.0)
     p.positions[symbol] = Position(
@@ -80,6 +81,7 @@ def _portfolio_with(
         entry_order_id=entry_order_id,
         entry_client_order_id=f"c-{entry_order_id}",
         original_qty=qty,
+        entry_order_type=entry_order_type,
     )
     return p
 
@@ -101,12 +103,12 @@ def _bar(symbol: str = "AAA", **kwargs) -> _MockBar:
 # ---------------------------------------------------------------------------
 
 
-def test_tracker_resets_when_position_identity_changes() -> None:
-    """Same-bar exit + re-entry replaces the underlying ``Position`` with a
-    new ``entry_order_id``. The tracker must reset trailing watermarks
-    against the new entry — not carry the prior trade's stale state,
-    which could fire a trailing-stop immediately. The fresh entry is
-    flagged ``just_opened`` so rule evaluation skips this bar.
+def test_tracker_resets_on_limit_entry_with_just_opened_and_entry_price_watermarks() -> None:
+    """Same-bar exit + re-entry with a NON-market entry. The tracker must
+    reset trailing watermarks against the new entry — and because the
+    fill could have landed anywhere inside the bar, init watermarks at
+    ``entry_price`` and flag ``just_opened=True`` so rule eval skips
+    this bar.
     """
     tracker: Dict[str, _TrackedPosition] = {
         "AAA": _TrackedPosition(
@@ -118,13 +120,14 @@ def test_tracker_resets_when_position_identity_changes() -> None:
             low_since_entry=95.0,
         )
     }
-    # Same-bar exit/re-entry — new Position, different entry_order_id.
+    # Same-bar exit/re-entry — new Position, different entry_order_id, LIMIT type.
     portfolio = _portfolio_with(
         symbol="AAA",
         side=OrderSide.LONG,
         qty=10,
         entry_price=110.0,
         entry_order_id="o2",
+        entry_order_type="limit",
     )
     bar = _bar(high=112.0, low=109.0)
 
@@ -142,6 +145,38 @@ def test_tracker_resets_when_position_identity_changes() -> None:
     # pre-entry extremes can't drive same-bar rule evaluation later.
     assert state.high_since_entry == 110.0
     assert state.low_since_entry == 110.0
+
+
+def test_tracker_resets_on_market_entry_using_bar_ohlc_without_gating() -> None:
+    """Market entries fill at the bar's open, so the bar's full
+    high/low IS post-entry price action. The tracker initialises
+    watermarks from the bar (so a same-bar stop/take-profit can be
+    captured) and leaves ``just_opened=False`` so rule eval runs on
+    this bar. Without this carve-out, longs opened at the open could
+    trade through their stop and recover with no engine emission.
+    """
+    tracker: Dict[str, _TrackedPosition] = {}
+    portfolio = _portfolio_with(
+        symbol="AAA",
+        side=OrderSide.LONG,
+        qty=10,
+        entry_price=100.0,
+        entry_order_id="o-mkt",
+        entry_order_type="market",
+    )
+    bar = _bar(high=112.0, low=88.0)
+
+    TradingService._update_position_tracker(
+        tracker=tracker,
+        cur_bar=bar,
+        portfolio=portfolio,
+    )
+
+    state = tracker["AAA"]
+    assert state.entry_order_id == "o-mkt"
+    assert state.just_opened is False  # rule eval runs on the entry bar
+    assert state.high_since_entry == 112.0  # full bar high captured
+    assert state.low_since_entry == 88.0  # full bar low captured
 
 
 def test_tracker_carries_over_when_entry_order_id_unchanged() -> None:

--- a/backend/agents/investment_team/tests/test_engine_exit_helpers.py
+++ b/backend/agents/investment_team/tests/test_engine_exit_helpers.py
@@ -232,18 +232,21 @@ def _populate_tracker_and_portfolio() -> tuple[Dict[str, _TrackedPosition], Port
     return tracker, portfolio, order_book
 
 
-def test_dedup_ignores_limit_close_far_from_market() -> None:
-    """A strategy's full-size limit close far from market is not guaranteed
-    to fill — it must NOT suppress the engine's market emission. Otherwise
-    the rule is silently skipped while the limit hangs and the position
-    stays open past the structured-exit threshold.
+def test_engine_always_emits_at_full_position_qty() -> None:
+    """The engine always emits its close at ``pos.qty`` and lets the fill
+    simulator handle dedup against any strategy same-bar close. This
+    keeps enforcement robust against participation-cap clipping and
+    FOK/IOC rejection on the strategy's own order — see the docstring
+    of ``_maybe_emit_engine_exits``.
+
+    Far-from-market limit close from the strategy: not guaranteed to
+    fill, so the engine emits its full-size market close regardless.
     """
     svc = _service(exit_rules=[TimeStopRule(n_bars=10)])
     tracker, portfolio, order_book = _populate_tracker_and_portfolio()
     bar = _bar()
     result = TradingServiceResult()
 
-    # Strategy emits a far-from-market LIMIT sell for 100 shares.
     pending = [
         OrderRequest(
             client_order_id="c1",
@@ -251,13 +254,11 @@ def test_dedup_ignores_limit_close_far_from_market() -> None:
             side=OrderSide.SHORT,
             qty=100.0,
             order_type=OrderType.LIMIT,
-            limit_price=200.0,  # well above; won't fill on next bar
+            limit_price=200.0,
             tif=TimeInForce.DAY,
             reason="strategy_limit_exit",
         )
     ]
-    engine_exit_bindings: Dict[str, str] = {}
-
     svc._maybe_emit_engine_exits(
         cur_bar=bar,
         position_tracker=tracker,
@@ -266,20 +267,25 @@ def test_dedup_ignores_limit_close_far_from_market() -> None:
         order_book=order_book,
         result=result,
         engine_order_seq=0,
-        engine_exit_bindings=engine_exit_bindings,
+        engine_exit_bindings={},
     )
-
-    # Engine MUST still emit its market close — the limit isn't guaranteed.
     engine_orders = [r for r in pending if (r.reason or "").startswith(ENGINE_EXIT_REASON_PREFIX)]
     assert len(engine_orders) == 1
     assert engine_orders[0].qty == 100.0
     assert engine_orders[0].order_type == OrderType.MARKET
-    assert result.execution_diagnostics.exit_rule_firings.get("time_stop") == 1
 
 
-def test_dedup_skips_engine_emission_on_full_market_strategy_close() -> None:
-    """Full-size market close from strategy on the same bar → engine
-    emission is redundant and must be skipped.
+def test_engine_emits_even_when_strategy_submits_full_market_close() -> None:
+    """A strategy full-size market close is not a coverage guarantee —
+    it can be FOK-rejected, IOC-clipped, or participation-cap-clipped at
+    fill time. The engine emits its full-qty market regardless; the fill
+    simulator's stale-continuation guard (via binding) drops the engine
+    close at fill time if the strategy's order fully closed the position
+    first, and clips the engine close to the residual qty otherwise.
+
+    This swaps the pre-fix expectation (engine skipped on full market
+    cover) for the post-fix expectation (always emit; let the fill
+    simulator handle the rest).
     """
     svc = _service(exit_rules=[TimeStopRule(n_bars=10)])
     tracker, portfolio, order_book = _populate_tracker_and_portfolio()
@@ -307,10 +313,52 @@ def test_dedup_skips_engine_emission_on_full_market_strategy_close() -> None:
         engine_order_seq=0,
         engine_exit_bindings={},
     )
-
-    # No engine emission — strategy fully covered the close.
     engine_orders = [r for r in pending if (r.reason or "").startswith(ENGINE_EXIT_REASON_PREFIX)]
-    assert engine_orders == []
+    assert len(engine_orders) == 1
+    assert engine_orders[0].qty == 100.0
+    assert result.execution_diagnostics.exit_rule_firings.get("time_stop") == 1
+
+
+def test_engine_skips_when_prior_engine_exit_still_pending() -> None:
+    """A prior bar's engine market exit (e.g. ``REQUEUE_NEXT_BAR`` residual
+    that didn't fully fill on the next bar) is still pending on the order
+    book. The engine must NOT re-emit while it's still in flight —
+    otherwise every subsequent bar where ``bars_held >= n_bars`` stacks
+    another engine market, polluting the book and the diagnostics.
+    """
+    svc = _service(exit_rules=[TimeStopRule(n_bars=10)])
+    tracker, portfolio, order_book = _populate_tracker_and_portfolio()
+    bar = _bar()
+    result = TradingServiceResult()
+
+    # Simulate a prior bar's engine exit sitting on the book.
+    prior_engine_exit = OrderRequest(
+        client_order_id="e1",
+        symbol="AAA",
+        side=OrderSide.SHORT,
+        qty=100.0,
+        order_type=OrderType.MARKET,
+        tif=TimeInForce.DAY,
+        reason=f"{ENGINE_EXIT_REASON_PREFIX}time_stop",
+    )
+    order_book.submit(
+        prior_engine_exit, submitted_at="2024-01-09T00:00:00", submitted_equity=100_000.0
+    )
+
+    pending: list[OrderRequest] = []
+    svc._maybe_emit_engine_exits(
+        cur_bar=bar,
+        position_tracker=tracker,
+        portfolio=portfolio,
+        pending_for_prev=pending,
+        order_book=order_book,
+        result=result,
+        engine_order_seq=1,
+        engine_exit_bindings={},
+    )
+
+    # No new engine emission — the prior one is still in flight.
+    assert pending == []
     assert result.execution_diagnostics.exit_rule_firings == {}
 
 

--- a/backend/agents/investment_team/tests/test_engine_exit_helpers.py
+++ b/backend/agents/investment_team/tests/test_engine_exit_helpers.py
@@ -25,7 +25,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict
 
-from investment_team.models import BacktestConfig
 from investment_team.strategy_lab.spec_dsl import StopLossRule, TakeProfitRule
 from investment_team.trading_service.engine.order_book import OrderBook
 from investment_team.trading_service.engine.portfolio import Portfolio, Position
@@ -33,6 +32,7 @@ from investment_team.trading_service.service import (
     ENGINE_EXIT_REASON_PREFIX,
     TradingService,
     TradingServiceResult,
+    _EngineExitDispatcher,
     _TrackedPosition,
 )
 from investment_team.trading_service.strategy.contract import (
@@ -52,11 +52,14 @@ class _MockBar:
     close: float
 
 
-def _service(*, exit_rules) -> TradingService:
-    return TradingService(
-        strategy_code="from contract import Strategy\nclass S(Strategy):\n    pass\n",
-        config=BacktestConfig(start_date="2024-01-01", end_date="2024-12-31"),
+def _dispatcher(*, exit_rules, bindings=None) -> _EngineExitDispatcher:
+    """Build a dispatcher with optional pre-seeded bindings. Tests that
+    don't seed bindings get an empty dict by default; ``bindings is not
+    None`` lets a test pass in its own mutable dict to observe writes.
+    """
+    return _EngineExitDispatcher(
         exit_rules=exit_rules,
+        engine_exit_bindings={} if bindings is None else bindings,
     )
 
 
@@ -280,7 +283,7 @@ def test_engine_always_emits_at_full_position_qty() -> None:
     fill, so the engine emits its full-size market close regardless.
     """
     # bar.low=95 trips a StopLossRule(pct=0.02) (floor=98).
-    svc = _service(exit_rules=[StopLossRule(pct=0.02)])
+    disp = _dispatcher(exit_rules=[StopLossRule(pct=0.02)])
     tracker, portfolio, order_book = _populate_tracker_and_portfolio()
     bar = _bar()
     result = TradingServiceResult()
@@ -297,15 +300,13 @@ def test_engine_always_emits_at_full_position_qty() -> None:
             reason="strategy_limit_exit",
         )
     ]
-    svc._maybe_emit_engine_exits(
+    disp.maybe_emit(
         cur_bar=bar,
         position_tracker=tracker,
         portfolio=portfolio,
         pending_for_prev=pending,
         order_book=order_book,
         result=result,
-        engine_order_seq=0,
-        engine_exit_bindings={},
     )
     engine_orders = [r for r in pending if (r.reason or "").startswith(ENGINE_EXIT_REASON_PREFIX)]
     assert len(engine_orders) == 1
@@ -321,7 +322,7 @@ def test_engine_emits_even_when_strategy_submits_full_market_close() -> None:
     close at fill time if the strategy's order fully closed the position
     first, and clips the engine close to the residual qty otherwise.
     """
-    svc = _service(exit_rules=[StopLossRule(pct=0.02)])
+    disp = _dispatcher(exit_rules=[StopLossRule(pct=0.02)])
     tracker, portfolio, order_book = _populate_tracker_and_portfolio()
     bar = _bar()  # low=95 trips the 98 floor
     result = TradingServiceResult()
@@ -337,15 +338,13 @@ def test_engine_emits_even_when_strategy_submits_full_market_close() -> None:
             reason="strategy_full_exit",
         )
     ]
-    svc._maybe_emit_engine_exits(
+    disp.maybe_emit(
         cur_bar=bar,
         position_tracker=tracker,
         portfolio=portfolio,
         pending_for_prev=pending,
         order_book=order_book,
         result=result,
-        engine_order_seq=0,
-        engine_exit_bindings={},
     )
     engine_orders = [r for r in pending if (r.reason or "").startswith(ENGINE_EXIT_REASON_PREFIX)]
     assert len(engine_orders) == 1
@@ -360,7 +359,7 @@ def test_engine_skips_when_prior_engine_exit_still_pending() -> None:
     otherwise every subsequent bar where the rule re-triggers stacks
     another engine market, polluting the book and the diagnostics.
     """
-    svc = _service(exit_rules=[StopLossRule(pct=0.02)])
+    disp = _dispatcher(exit_rules=[StopLossRule(pct=0.02)])
     tracker, portfolio, order_book = _populate_tracker_and_portfolio()
     bar = _bar()
     result = TradingServiceResult()
@@ -380,15 +379,13 @@ def test_engine_skips_when_prior_engine_exit_still_pending() -> None:
     )
 
     pending: list[OrderRequest] = []
-    svc._maybe_emit_engine_exits(
+    disp.maybe_emit(
         cur_bar=bar,
         position_tracker=tracker,
         portfolio=portfolio,
         pending_for_prev=pending,
         order_book=order_book,
         result=result,
-        engine_order_seq=1,
-        engine_exit_bindings={},
     )
 
     # No new engine emission — the prior one is still in flight.
@@ -402,23 +399,23 @@ def test_engine_emission_registers_binding_to_entry_order_id() -> None:
     first. Without it, the engine market falls through to ``_fill_entry``
     and opens a brand-new opposite-side position.
     """
-    svc = _service(exit_rules=[StopLossRule(pct=0.02)])  # entry=100 → floor=98; bar.low=95 fires
+    engine_exit_bindings: Dict[str, str] = {}
+    disp = _dispatcher(
+        exit_rules=[StopLossRule(pct=0.02)], bindings=engine_exit_bindings
+    )  # entry=100 → floor=98; bar.low=95 fires
     tracker, portfolio, order_book = _populate_tracker_and_portfolio()
     bar = _bar(high=105, low=95)
     result = TradingServiceResult()
 
-    engine_exit_bindings: Dict[str, str] = {}
     pending: list[OrderRequest] = []
 
-    svc._maybe_emit_engine_exits(
+    disp.maybe_emit(
         cur_bar=bar,
         position_tracker=tracker,
         portfolio=portfolio,
         pending_for_prev=pending,
         order_book=order_book,
         result=result,
-        engine_order_seq=0,
-        engine_exit_bindings=engine_exit_bindings,
     )
 
     assert len(pending) == 1
@@ -436,7 +433,7 @@ def test_engine_binds_unbound_resting_strategy_exits_to_position() -> None:
     The engine binds the resting order to the same ``entry_order_id`` so
     the stale-continuation guard drops it when the engine close fires.
     """
-    svc = _service(exit_rules=[StopLossRule(pct=0.02)])
+    disp = _dispatcher(exit_rules=[StopLossRule(pct=0.02)])
     tracker, portfolio, order_book = _populate_tracker_and_portfolio()
     bar = _bar(high=105, low=95)  # bar.low=95 trips the 98 stop floor
     result = TradingServiceResult()
@@ -462,15 +459,13 @@ def test_engine_binds_unbound_resting_strategy_exits_to_position() -> None:
     assert resting_po.working_against_entry_order_id is None
 
     pending: list[OrderRequest] = []
-    svc._maybe_emit_engine_exits(
+    disp.maybe_emit(
         cur_bar=bar,
         position_tracker=tracker,
         portfolio=portfolio,
         pending_for_prev=pending,
         order_book=order_book,
         result=result,
-        engine_order_seq=0,
-        engine_exit_bindings={},
     )
 
     # Engine emitted its stop-loss close…
@@ -490,7 +485,7 @@ def test_engine_does_not_rebind_already_bound_resting_orders() -> None:
     on every subsequent bar would be a no-op here (same id), but the
     invariant is what we're guarding.
     """
-    svc = _service(exit_rules=[StopLossRule(pct=0.02)])
+    disp = _dispatcher(exit_rules=[StopLossRule(pct=0.02)])
     tracker, portfolio, order_book = _populate_tracker_and_portfolio()
     bar = _bar(high=105, low=95)
     result = TradingServiceResult()
@@ -511,15 +506,13 @@ def test_engine_does_not_rebind_already_bound_resting_orders() -> None:
     prior_po.working_against_entry_order_id = "o-other"  # pre-bound elsewhere
 
     pending: list[OrderRequest] = []
-    svc._maybe_emit_engine_exits(
+    disp.maybe_emit(
         cur_bar=bar,
         position_tracker=tracker,
         portfolio=portfolio,
         pending_for_prev=pending,
         order_book=order_book,
         result=result,
-        engine_order_seq=0,
-        engine_exit_bindings={},
     )
 
     # Binding preserved — engine binding loop must not stomp prior bindings.
@@ -530,7 +523,7 @@ def test_engine_does_not_bind_same_side_resting_orders() -> None:
     """A resting same-side order is an add, not a close — it has nothing
     to do with the engine's exit and must not be bound to the position.
     """
-    svc = _service(exit_rules=[StopLossRule(pct=0.02)])
+    disp = _dispatcher(exit_rules=[StopLossRule(pct=0.02)])
     tracker, portfolio, order_book = _populate_tracker_and_portfolio()
     bar = _bar(high=105, low=95)
     result = TradingServiceResult()
@@ -551,15 +544,13 @@ def test_engine_does_not_bind_same_side_resting_orders() -> None:
     )
 
     pending: list[OrderRequest] = []
-    svc._maybe_emit_engine_exits(
+    disp.maybe_emit(
         cur_bar=bar,
         position_tracker=tracker,
         portfolio=portfolio,
         pending_for_prev=pending,
         order_book=order_book,
         result=result,
-        engine_order_seq=0,
-        engine_exit_bindings={},
     )
 
     # Same-side resting order stays unbound — it isn't a close.
@@ -576,7 +567,8 @@ def test_engine_binds_same_bar_queued_strategy_exits_too() -> None:
     the binding through ``engine_exit_bindings`` so the submit step
     stamps ``working_against_entry_order_id`` on its ``PendingOrder``.
     """
-    svc = _service(exit_rules=[StopLossRule(pct=0.02)])
+    engine_exit_bindings: Dict[str, str] = {}
+    disp = _dispatcher(exit_rules=[StopLossRule(pct=0.02)], bindings=engine_exit_bindings)
     tracker, portfolio, order_book = _populate_tracker_and_portfolio()
     bar = _bar(high=105, low=95)  # trips the 98 stop floor
     result = TradingServiceResult()
@@ -593,17 +585,14 @@ def test_engine_binds_same_bar_queued_strategy_exits_too() -> None:
         reason="strategy_take_profit",
     )
     pending: list[OrderRequest] = [queued_strategy_exit]
-    engine_exit_bindings: Dict[str, str] = {}
 
-    svc._maybe_emit_engine_exits(
+    disp.maybe_emit(
         cur_bar=bar,
         position_tracker=tracker,
         portfolio=portfolio,
         pending_for_prev=pending,
         order_book=order_book,
         result=result,
-        engine_order_seq=0,
-        engine_exit_bindings=engine_exit_bindings,
     )
 
     # Engine emitted its stop-loss close AND registered a binding for the
@@ -619,7 +608,8 @@ def test_engine_does_not_bind_same_bar_same_side_queued_orders() -> None:
     """Symmetric to the resting-order carve-out: a same-bar same-side
     queued order (a scale-in entry) must NOT be bound to the position.
     """
-    svc = _service(exit_rules=[StopLossRule(pct=0.02)])
+    engine_exit_bindings: Dict[str, str] = {}
+    disp = _dispatcher(exit_rules=[StopLossRule(pct=0.02)], bindings=engine_exit_bindings)
     tracker, portfolio, order_book = _populate_tracker_and_portfolio()
     bar = _bar(high=105, low=95)
     result = TradingServiceResult()
@@ -635,17 +625,14 @@ def test_engine_does_not_bind_same_bar_same_side_queued_orders() -> None:
         reason="strategy_scale_in",
     )
     pending: list[OrderRequest] = [queued_add]
-    engine_exit_bindings: Dict[str, str] = {}
 
-    svc._maybe_emit_engine_exits(
+    disp.maybe_emit(
         cur_bar=bar,
         position_tracker=tracker,
         portfolio=portfolio,
         pending_for_prev=pending,
         order_book=order_book,
         result=result,
-        engine_order_seq=0,
-        engine_exit_bindings=engine_exit_bindings,
     )
 
     # The engine's own emission gets a binding; the same-side scale-in does not.
@@ -664,7 +651,7 @@ def test_engine_skips_rule_eval_on_entry_bar() -> None:
     ``just_opened=True`` skips rule eval entirely on the entry bar; the
     next bar's tracker update clears the flag and rule eval resumes.
     """
-    svc = _service(exit_rules=[TakeProfitRule(pct=0.05)])
+    disp = _dispatcher(exit_rules=[TakeProfitRule(pct=0.05)])
     # Position entered at 95, bar.high=110 would trip a take-profit at
     # 95 * 1.05 = 99.75 if not gated by just_opened.
     tracker = {
@@ -689,15 +676,13 @@ def test_engine_skips_rule_eval_on_entry_bar() -> None:
     result = TradingServiceResult()
 
     pending: list[OrderRequest] = []
-    svc._maybe_emit_engine_exits(
+    disp.maybe_emit(
         cur_bar=bar,
         position_tracker=tracker,
         portfolio=portfolio,
         pending_for_prev=pending,
         order_book=order_book,
         result=result,
-        engine_order_seq=0,
-        engine_exit_bindings={},
     )
 
     # No engine emission — the entry bar is gated even though bar.high
@@ -712,7 +697,7 @@ def test_engine_runs_rules_normally_after_first_post_entry_bar() -> None:
     ``just_opened`` is False, take-profit / stop-loss evaluate against
     the bar's OHLC as expected.
     """
-    svc = _service(exit_rules=[TakeProfitRule(pct=0.05)])
+    disp = _dispatcher(exit_rules=[TakeProfitRule(pct=0.05)])
     tracker = {
         "AAA": _TrackedPosition(
             side="long",
@@ -736,15 +721,13 @@ def test_engine_runs_rules_normally_after_first_post_entry_bar() -> None:
     result = TradingServiceResult()
 
     pending: list[OrderRequest] = []
-    svc._maybe_emit_engine_exits(
+    disp.maybe_emit(
         cur_bar=bar,
         position_tracker=tracker,
         portfolio=portfolio,
         pending_for_prev=pending,
         order_book=order_book,
         result=result,
-        engine_order_seq=0,
-        engine_exit_bindings={},
     )
 
     # Take-profit fires off the bar's high.
@@ -763,7 +746,7 @@ def test_engine_cancels_pending_entry_continuation_when_exit_fires() -> None:
     and cancels them so the rule's close is the last word on the
     position.
     """
-    svc = _service(exit_rules=[StopLossRule(pct=0.02)])
+    disp = _dispatcher(exit_rules=[StopLossRule(pct=0.02)])
     tracker, portfolio, order_book = _populate_tracker_and_portfolio()
     bar = _bar(high=105, low=95)  # bar.low=95 trips floor=98
     result = TradingServiceResult()
@@ -797,15 +780,13 @@ def test_engine_cancels_pending_entry_continuation_when_exit_fires() -> None:
     order_book._by_symbol["AAA"].append("o1")
 
     pending: list[OrderRequest] = []
-    svc._maybe_emit_engine_exits(
+    disp.maybe_emit(
         cur_bar=bar,
         position_tracker=tracker,
         portfolio=portfolio,
         pending_for_prev=pending,
         order_book=order_book,
         result=result,
-        engine_order_seq=0,
-        engine_exit_bindings={},
     )
 
     # Engine emitted its stop-loss close AND cancelled the pending

--- a/backend/agents/investment_team/tests/test_engine_exit_helpers.py
+++ b/backend/agents/investment_team/tests/test_engine_exit_helpers.py
@@ -6,9 +6,11 @@ end-to-end:
 
 * Tracker resets when the position identity (``entry_order_id``)
   changes — a same-bar exit + re-entry must not inherit stale
-  ``bars_held`` / watermarks.
-* Engine dedup ignores non-market strategy orders (limit/stop closes
-  far from the market aren't guaranteed to fill).
+  trailing watermarks.
+* Engine emits at full ``pos.qty`` regardless of any same-bar strategy
+  close (the fill simulator does dedup at fill time via the binding).
+* In-flight engine markets prevent re-emission so the book doesn't
+  stack redundant engine closes across bars.
 * Engine emissions bind to ``pos.entry_order_id`` via
   ``engine_exit_bindings`` so the fill simulator's stale-continuation
   guard can drop them when a prior strategy exit closes the position
@@ -24,10 +26,7 @@ from dataclasses import dataclass
 from typing import Dict
 
 from investment_team.models import BacktestConfig
-from investment_team.strategy_lab.spec_dsl import (
-    StopLossRule,
-    TimeStopRule,
-)
+from investment_team.strategy_lab.spec_dsl import StopLossRule
 from investment_team.trading_service.engine.order_book import OrderBook
 from investment_team.trading_service.engine.portfolio import Portfolio, Position
 from investment_team.trading_service.service import (
@@ -104,17 +103,15 @@ def _bar(symbol: str = "AAA", **kwargs) -> _MockBar:
 
 def test_tracker_resets_when_position_identity_changes() -> None:
     """Same-bar exit + re-entry replaces the underlying ``Position`` with a
-    new ``entry_order_id``. The tracker must reset to ``bars_held=1`` /
-    fresh watermarks against the new entry — not carry the prior trade's
-    stale state, which could fire a ``TimeStopRule`` or trailing-stop
-    immediately.
+    new ``entry_order_id``. The tracker must reset trailing watermarks
+    against the new entry — not carry the prior trade's stale state,
+    which could fire a trailing-stop immediately.
     """
     tracker: Dict[str, _TrackedPosition] = {
         "AAA": _TrackedPosition(
             side="long",
             entry_price=100.0,
             entry_order_id="o1",
-            bars_held=9,
             high_since_entry=120.0,
             low_since_entry=95.0,
         )
@@ -138,21 +135,19 @@ def test_tracker_resets_when_position_identity_changes() -> None:
     state = tracker["AAA"]
     assert state.entry_order_id == "o2"
     assert state.entry_price == 110.0
-    assert state.bars_held == 1
     assert state.high_since_entry == 112.0
     assert state.low_since_entry == 109.0
 
 
 def test_tracker_carries_over_when_entry_order_id_unchanged() -> None:
-    """Same ``entry_order_id`` → same trade. bars_held++; weighted-average
-    entry refresh from scale-ins; watermarks extend.
+    """Same ``entry_order_id`` → same trade. Weighted-average entry refresh
+    from scale-ins; watermarks extend.
     """
     tracker: Dict[str, _TrackedPosition] = {
         "AAA": _TrackedPosition(
             side="long",
             entry_price=100.0,
             entry_order_id="o1",
-            bars_held=3,
             high_since_entry=105.0,
             low_since_entry=98.0,
         )
@@ -176,7 +171,6 @@ def test_tracker_carries_over_when_entry_order_id_unchanged() -> None:
 
     state = tracker["AAA"]
     assert state.entry_order_id == "o1"
-    assert state.bars_held == 4
     assert state.entry_price == 102.5  # scale-in refresh
     assert state.high_since_entry == 108.0  # extends
     assert state.low_since_entry == 97.0  # extends
@@ -188,7 +182,6 @@ def test_tracker_drops_entry_when_position_closed() -> None:
             side="long",
             entry_price=100.0,
             entry_order_id="o1",
-            bars_held=5,
             high_since_entry=110.0,
             low_since_entry=95.0,
         )
@@ -216,7 +209,6 @@ def _populate_tracker_and_portfolio() -> tuple[Dict[str, _TrackedPosition], Port
             side="long",
             entry_price=100.0,
             entry_order_id="o1",
-            bars_held=10,
             high_since_entry=110.0,
             low_since_entry=95.0,
         )
@@ -242,7 +234,8 @@ def test_engine_always_emits_at_full_position_qty() -> None:
     Far-from-market limit close from the strategy: not guaranteed to
     fill, so the engine emits its full-size market close regardless.
     """
-    svc = _service(exit_rules=[TimeStopRule(n_bars=10)])
+    # bar.low=95 trips a StopLossRule(pct=0.02) (floor=98).
+    svc = _service(exit_rules=[StopLossRule(pct=0.02)])
     tracker, portfolio, order_book = _populate_tracker_and_portfolio()
     bar = _bar()
     result = TradingServiceResult()
@@ -282,14 +275,10 @@ def test_engine_emits_even_when_strategy_submits_full_market_close() -> None:
     simulator's stale-continuation guard (via binding) drops the engine
     close at fill time if the strategy's order fully closed the position
     first, and clips the engine close to the residual qty otherwise.
-
-    This swaps the pre-fix expectation (engine skipped on full market
-    cover) for the post-fix expectation (always emit; let the fill
-    simulator handle the rest).
     """
-    svc = _service(exit_rules=[TimeStopRule(n_bars=10)])
+    svc = _service(exit_rules=[StopLossRule(pct=0.02)])
     tracker, portfolio, order_book = _populate_tracker_and_portfolio()
-    bar = _bar()
+    bar = _bar()  # low=95 trips the 98 floor
     result = TradingServiceResult()
 
     pending = [
@@ -316,17 +305,17 @@ def test_engine_emits_even_when_strategy_submits_full_market_close() -> None:
     engine_orders = [r for r in pending if (r.reason or "").startswith(ENGINE_EXIT_REASON_PREFIX)]
     assert len(engine_orders) == 1
     assert engine_orders[0].qty == 100.0
-    assert result.execution_diagnostics.exit_rule_firings.get("time_stop") == 1
+    assert result.execution_diagnostics.exit_rule_firings.get("stop_loss") == 1
 
 
 def test_engine_skips_when_prior_engine_exit_still_pending() -> None:
     """A prior bar's engine market exit (e.g. ``REQUEUE_NEXT_BAR`` residual
     that didn't fully fill on the next bar) is still pending on the order
     book. The engine must NOT re-emit while it's still in flight —
-    otherwise every subsequent bar where ``bars_held >= n_bars`` stacks
+    otherwise every subsequent bar where the rule re-triggers stacks
     another engine market, polluting the book and the diagnostics.
     """
-    svc = _service(exit_rules=[TimeStopRule(n_bars=10)])
+    svc = _service(exit_rules=[StopLossRule(pct=0.02)])
     tracker, portfolio, order_book = _populate_tracker_and_portfolio()
     bar = _bar()
     result = TradingServiceResult()
@@ -339,7 +328,7 @@ def test_engine_skips_when_prior_engine_exit_still_pending() -> None:
         qty=100.0,
         order_type=OrderType.MARKET,
         tif=TimeInForce.DAY,
-        reason=f"{ENGINE_EXIT_REASON_PREFIX}time_stop",
+        reason=f"{ENGINE_EXIT_REASON_PREFIX}stop_loss",
     )
     order_book.submit(
         prior_engine_exit, submitted_at="2024-01-09T00:00:00", submitted_equity=100_000.0

--- a/backend/agents/investment_team/tests/test_exit_rule_conformance_gate.py
+++ b/backend/agents/investment_team/tests/test_exit_rule_conformance_gate.py
@@ -62,9 +62,7 @@ def _trade(
     )
 
 
-def _diagnostics(
-    *, symbol: str = "AAA", **firings: int
-) -> BacktestExecutionDiagnostics:
+def _diagnostics(*, symbol: str = "AAA", **firings: int) -> BacktestExecutionDiagnostics:
     """Helper: build a diagnostics envelope where every firing is attributed
     to a single symbol. Tests that need cross-symbol scenarios construct
     ``BacktestExecutionDiagnostics`` directly.

--- a/backend/agents/investment_team/tests/test_exit_rule_conformance_gate.py
+++ b/backend/agents/investment_team/tests/test_exit_rule_conformance_gate.py
@@ -62,8 +62,17 @@ def _trade(
     )
 
 
-def _diagnostics(**firings: int) -> BacktestExecutionDiagnostics:
-    return BacktestExecutionDiagnostics(exit_rule_firings=dict(firings))
+def _diagnostics(
+    *, symbol: str = "AAA", **firings: int
+) -> BacktestExecutionDiagnostics:
+    """Helper: build a diagnostics envelope where every firing is attributed
+    to a single symbol. Tests that need cross-symbol scenarios construct
+    ``BacktestExecutionDiagnostics`` directly.
+    """
+    return BacktestExecutionDiagnostics(
+        exit_rule_firings=dict(firings),
+        exit_rule_firings_by_symbol={symbol: dict(firings)} if firings else {},
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -317,7 +326,7 @@ def test_stop_loss_fails_when_below_floor_trades_exceed_firings() -> None:
     assert len(fails) == 1
     assert fails[0].severity == "critical"
     assert "leak" in fails[0].details.lower()
-    assert "1 unaccounted-for trade" in fails[0].details
+    assert "1 unaccounted" in fails[0].details
 
 
 def test_stop_loss_passes_when_firings_cover_below_floor_count() -> None:
@@ -379,3 +388,70 @@ def test_take_profit_alone_warns_when_engine_never_fired() -> None:
     assert len(fails) == 1
     assert fails[0].severity == "warning"
     assert "zero take_profit firings" in fails[0].details
+
+
+def test_stop_loss_cross_symbol_firings_do_not_mask_leak() -> None:
+    """Per-symbol attribution: an engine stop_loss firing on symbol AAA
+    must NOT cover a missed firing on symbol BBB. A global rule-kind
+    count would pass this scenario (2 below-floor trades, 2 firings)
+    even though BBB never had its rule enforced. Regression for the P2
+    review comment on issue #527 PR.
+    """
+    gate = ExitRuleConformanceGate()
+    # AAA: one below-floor trade, one firing (protected).
+    # BBB: one below-floor trade, ZERO firings (leak).
+    trades = [
+        TradeRecord(
+            trade_num=1,
+            entry_date="2024-01-01",
+            exit_date="2024-01-02",
+            symbol="AAA",
+            side="long",
+            entry_price=100.0,
+            exit_price=92.0,
+            shares=100,
+            position_value=10_000.0,
+            gross_pnl=-800.0,
+            net_pnl=-800.0,
+            return_pct=-8.0,
+            hold_days=1,
+            outcome="loss",
+            cumulative_pnl=-800.0,
+        ),
+        TradeRecord(
+            trade_num=2,
+            entry_date="2024-01-03",
+            exit_date="2024-01-04",
+            symbol="BBB",
+            side="long",
+            entry_price=200.0,
+            exit_price=180.0,
+            shares=50,
+            position_value=10_000.0,
+            gross_pnl=-1_000.0,
+            net_pnl=-1_000.0,
+            return_pct=-10.0,
+            hold_days=1,
+            outcome="loss",
+            cumulative_pnl=-1_800.0,
+        ),
+    ]
+    # Aggregate firings would mask the leak (2 trades, 2 firings); per
+    # symbol, BBB has 0 firings.
+    diag = BacktestExecutionDiagnostics(
+        exit_rule_firings={"stop_loss": 2},
+        exit_rule_firings_by_symbol={
+            "AAA": {"stop_loss": 1},
+            "CCC": {"stop_loss": 1},  # unrelated firing on another symbol
+        },
+    )
+    results = gate.check(
+        exit_rules=[StopLossRule(pct=0.05)],
+        trades=trades,
+        diagnostics=diag,
+        config=_config(),
+    )
+    fails = [r for r in results if not r.passed]
+    assert len(fails) == 1
+    assert fails[0].severity == "critical"
+    assert "BBB" in fails[0].details

--- a/backend/agents/investment_team/tests/test_exit_rule_conformance_gate.py
+++ b/backend/agents/investment_team/tests/test_exit_rule_conformance_gate.py
@@ -293,3 +293,89 @@ def test_multi_rule_all_pass_returns_no_failures() -> None:
     )
     fails = [r for r in results if not r.passed]
     assert fails == [], [r.details for r in fails]
+
+
+def test_stop_loss_fails_when_below_floor_trades_exceed_firings() -> None:
+    """Per-trade leak counting: one correctly stopped trade must NOT mask
+    a separate trade that closed below the floor without an engine firing.
+    Regression for the P2 review comment on issue #527 PR: the previous
+    "any firings > 0 → pass" check was too loose.
+    """
+    gate = ExitRuleConformanceGate()
+    # Two below-floor trades, only one engine firing → 1 unaccounted leak.
+    trades = [
+        _trade(trade_num=1, return_pct=-7.0),
+        _trade(trade_num=2, return_pct=-8.0),
+    ]
+    results = gate.check(
+        exit_rules=[StopLossRule(pct=0.05)],
+        trades=trades,
+        diagnostics=_diagnostics(stop_loss=1),
+        config=_config(),
+    )
+    fails = [r for r in results if not r.passed]
+    assert len(fails) == 1
+    assert fails[0].severity == "critical"
+    assert "leak" in fails[0].details.lower()
+    assert "1 unaccounted-for trade" in fails[0].details
+
+
+def test_stop_loss_passes_when_firings_cover_below_floor_count() -> None:
+    """Exactly as many firings as below-floor trades → no leak. Each
+    below-floor trade is plausibly accounted for by a matching engine
+    emission; gap-fill semantics absorb the rest.
+    """
+    gate = ExitRuleConformanceGate()
+    trades = [
+        _trade(trade_num=1, return_pct=-7.0),
+        _trade(trade_num=2, return_pct=-8.0),
+    ]
+    results = gate.check(
+        exit_rules=[StopLossRule(pct=0.05)],
+        trades=trades,
+        diagnostics=_diagnostics(stop_loss=2),
+        config=_config(),
+    )
+    fails = [r for r in results if not r.passed]
+    assert fails == []
+
+
+def test_take_profit_alone_passes_on_firings_even_with_short_realized_return() -> None:
+    """Realized return below the rule's raw target is expected when the
+    engine fires take-profit on bar N's high but the synthetic close
+    fills on bar N+1's open (gap / slippage / costs eat into the
+    realised return). The gate must use the engine firings diagnostic,
+    not the trade ledger's ``return_pct``, to verify enforcement.
+    Regression for the P3 review comment on issue #527 PR.
+    """
+    gate = ExitRuleConformanceGate()
+    # take_profit target = 5%; trade realised 3% after gap/costs.
+    trades = [_trade(return_pct=3.0)]
+    results = gate.check(
+        exit_rules=[TakeProfitRule(pct=0.05)],
+        trades=trades,
+        diagnostics=_diagnostics(take_profit=1),
+        config=_config(),
+    )
+    fails = [r for r in results if not r.passed]
+    assert fails == [], [r.details for r in results]
+
+
+def test_take_profit_alone_warns_when_engine_never_fired() -> None:
+    """Take-profit is the only rule, trades exist, but engine recorded
+    zero firings — the threshold may be unreachable on the strategy's
+    universe. Surface as a warning so the operator can revisit the
+    spec.
+    """
+    gate = ExitRuleConformanceGate()
+    trades = [_trade(return_pct=1.0), _trade(trade_num=2, return_pct=2.0)]
+    results = gate.check(
+        exit_rules=[TakeProfitRule(pct=0.05)],
+        trades=trades,
+        diagnostics=_diagnostics(),
+        config=_config(),
+    )
+    fails = [r for r in results if not r.passed]
+    assert len(fails) == 1
+    assert fails[0].severity == "warning"
+    assert "zero take_profit firings" in fails[0].details

--- a/backend/agents/investment_team/tests/test_exit_rule_conformance_gate.py
+++ b/backend/agents/investment_team/tests/test_exit_rule_conformance_gate.py
@@ -90,13 +90,19 @@ def test_no_exit_rules_skips_with_info() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_stop_loss_entry_price_pass_within_tolerance() -> None:
+def test_stop_loss_passes_when_engine_fired_even_on_gap_fill() -> None:
+    """The engine detects the trigger on bar N's low but fills on bar N+1's
+    open. Overnight gaps can push the realised return well past the raw
+    floor without indicating an enforcement bug, so the gate must pass
+    as long as the engine emitted at least one stop_loss close.
+    """
     gate = ExitRuleConformanceGate()
-    # pct=0.03 → -3%. Slippage 2bps → 2x slip = 4bps = 0.04% extra each side.
-    # Tolerance band: -3.0 - 0.04 - 0.5 ≈ -3.54%. -3.5% should pass.
-    trades = [_trade(return_pct=-3.5)]
+    # pct=0.05 → raw floor=-5%. Trade closed at -20% (huge gap) — but the
+    # engine recorded a stop_loss firing, so this is a real-world gap
+    # fill, not a leak.
+    trades = [_trade(return_pct=-20.0)]
     results = gate.check(
-        exit_rules=[StopLossRule(pct=0.03)],
+        exit_rules=[StopLossRule(pct=0.05)],
         trades=trades,
         diagnostics=_diagnostics(stop_loss=1),
         config=_config(),
@@ -105,20 +111,42 @@ def test_stop_loss_entry_price_pass_within_tolerance() -> None:
     assert fails == [], [r.details for r in results]
 
 
-def test_stop_loss_entry_price_fail_when_below_floor() -> None:
+def test_stop_loss_fails_when_below_floor_and_engine_never_fired() -> None:
+    """Critical only when trades cleared the raw floor AND the engine
+    recorded no stop_loss firings — i.e. the rule should have triggered
+    but the enforcement path didn't run.
+    """
     gate = ExitRuleConformanceGate()
-    # pct=0.03 → floor ≈ -3.54%. -10% is well below.
+    # pct=0.05 → raw floor=-5%. -10% trade with zero engine firings:
+    # the engine missed the trigger, which is a real leak.
     trades = [_trade(return_pct=-10.0)]
     results = gate.check(
-        exit_rules=[StopLossRule(pct=0.03)],
+        exit_rules=[StopLossRule(pct=0.05)],
         trades=trades,
-        diagnostics=_diagnostics(),
+        diagnostics=_diagnostics(),  # no firings
         config=_config(),
     )
     fails = [r for r in results if not r.passed]
     assert len(fails) == 1
     assert fails[0].severity == "critical"
     assert "StopLossRule" in fails[0].details
+    assert "leak" in fails[0].details.lower()
+
+
+def test_stop_loss_passes_when_below_floor_but_engine_fired() -> None:
+    """Same below-floor trade, but engine recorded a firing → gap fill,
+    not a leak. Conformance should pass.
+    """
+    gate = ExitRuleConformanceGate()
+    trades = [_trade(return_pct=-10.0)]
+    results = gate.check(
+        exit_rules=[StopLossRule(pct=0.05)],
+        trades=trades,
+        diagnostics=_diagnostics(stop_loss=1),
+        config=_config(),
+    )
+    fails = [r for r in results if not r.passed]
+    assert fails == []
 
 
 def test_stop_loss_trailing_variant_skipped() -> None:

--- a/backend/agents/investment_team/tests/test_exit_rule_conformance_gate.py
+++ b/backend/agents/investment_team/tests/test_exit_rule_conformance_gate.py
@@ -15,7 +15,6 @@ from investment_team.models import (
     TradeRecord,
 )
 from investment_team.strategy_lab.quality_gates.exit_rule_conformance import (
-    GATE,
     ExitRuleConformanceGate,
 )
 from investment_team.strategy_lab.spec_dsl import (
@@ -24,7 +23,6 @@ from investment_team.strategy_lab.spec_dsl import (
     SignalExitRule,
     StopLossRule,
     TakeProfitRule,
-    TimeStopRule,
 )
 
 
@@ -85,95 +83,6 @@ def test_no_exit_rules_skips_with_info() -> None:
     assert results[0].passed is True
     assert results[0].severity == "info"
     assert "empty" in results[0].details.lower()
-
-
-# ---------------------------------------------------------------------------
-# TimeStopRule
-# ---------------------------------------------------------------------------
-
-
-def test_time_stop_pass_within_ceiling() -> None:
-    gate = ExitRuleConformanceGate()
-    trades = [_trade(hold_days=h) for h in (1, 3, 5)]
-    results = gate.check(
-        exit_rules=[TimeStopRule(n_bars=5)],
-        trades=trades,
-        diagnostics=_diagnostics(time_stop=2),
-        config=_config(),
-    )
-    # First result is the TimeStop check; gate may append an aggregate info row.
-    time_stop = [r for r in results if "TimeStopRule" in r.details]
-    assert all(r.passed for r in time_stop), [r.details for r in time_stop]
-
-
-def test_time_stop_fail_when_trade_exceeds_ceiling() -> None:
-    gate = ExitRuleConformanceGate()
-    # n_bars=5 → ceiling = 5 + ceil(10/5) + ceil(5/25) + 3 = 5+2+1+3 = 11.
-    # hold_days=20 is well past the weekend/holiday-tolerant ceiling.
-    trades = [_trade(hold_days=h) for h in (1, 20, 4)]
-    results = gate.check(
-        exit_rules=[TimeStopRule(n_bars=5)],
-        trades=trades,
-        diagnostics=_diagnostics(),
-        config=_config(),
-    )
-    fail = [r for r in results if not r.passed]
-    assert len(fail) == 1
-    assert fail[0].severity == "critical"
-    assert "TimeStopRule" in fail[0].details
-    assert fail[0].gate_name == GATE
-
-
-def test_time_stop_tolerates_weekend_and_holiday_gaps() -> None:
-    """A compliant 1-bar hold entered Friday and closed Monday records
-    ``hold_days==3`` because the calendar wraps a weekend. The ceiling
-    must be generous enough to absorb that — otherwise the gate fires a
-    false critical and vetoes ``is_winning`` on perfectly clean runs.
-    Regression for the P2 review comment on issue #527 PR.
-    """
-    gate = ExitRuleConformanceGate()
-    # TimeStopRule(n_bars=1) → ceiling = 1 + 1 + 1 + 3 = 6. A Fri-entry
-    # / Mon-fill 1-bar hold (hold_days=3) is well under 6.
-    trades = [_trade(hold_days=3)]
-    results = gate.check(
-        exit_rules=[TimeStopRule(n_bars=1)],
-        trades=trades,
-        diagnostics=_diagnostics(time_stop=1),
-        config=_config(),
-    )
-    fails = [r for r in results if not r.passed]
-    assert fails == [], [r.details for r in fails]
-
-
-def test_time_stop_skipped_on_sub_daily_timeframe() -> None:
-    gate = ExitRuleConformanceGate()
-    trades = [_trade(hold_days=99)]  # would fail on daily
-    results = gate.check(
-        exit_rules=[TimeStopRule(n_bars=5)],
-        trades=trades,
-        diagnostics=_diagnostics(),
-        config=_config(),
-        timeframe="15m",
-    )
-    # No critical violations; just info "skipped on sub-daily".
-    fails = [r for r in results if not r.passed]
-    assert fails == []
-    skipped = [r for r in results if "skipped" in r.details and "15m" in r.details]
-    assert skipped
-
-
-def test_time_stop_ceiling_absorbs_weekends_and_fill_lag() -> None:
-    # n_bars=10 → ceiling = 10 + ceil(20/5) + ceil(10/25) + 3 = 10+4+1+3 = 18.
-    # 18 calendar days easily covers 10 trading days + 2 weekends + holiday + fill lag.
-    gate = ExitRuleConformanceGate()
-    results = gate.check(
-        exit_rules=[TimeStopRule(n_bars=10)],
-        trades=[_trade(hold_days=18)],
-        diagnostics=_diagnostics(),
-        config=_config(),
-    )
-    fails = [r for r in results if not r.passed]
-    assert fails == []
 
 
 # ---------------------------------------------------------------------------
@@ -265,9 +174,9 @@ def test_take_profit_with_other_rules_is_informational() -> None:
     gate = ExitRuleConformanceGate()
     trades = [_trade(return_pct=1.0)]
     results = gate.check(
-        exit_rules=[TimeStopRule(n_bars=10), TakeProfitRule(pct=0.05)],
+        exit_rules=[StopLossRule(pct=0.05), TakeProfitRule(pct=0.05)],
         trades=trades,
-        diagnostics=_diagnostics(time_stop=1),
+        diagnostics=_diagnostics(stop_loss=1),
         config=_config(),
     )
     fails = [r for r in results if not r.passed]
@@ -307,24 +216,24 @@ def test_signal_exit_rule_is_informational_only() -> None:
 
 def test_diagnostics_summary_includes_firings_breakdown() -> None:
     gate = ExitRuleConformanceGate()
-    diag = _diagnostics(time_stop=3, stop_loss=1)
+    diag = _diagnostics(stop_loss=3, take_profit=1)
     results = gate.check(
-        exit_rules=[TimeStopRule(n_bars=10)],
-        trades=[_trade(hold_days=5)],
+        exit_rules=[StopLossRule(pct=0.05)],
+        trades=[_trade(return_pct=-1.0)],
         diagnostics=diag,
         config=_config(),
     )
     summary = [r for r in results if "engine_exits" in r.details]
     assert summary, [r.details for r in results]
-    assert "time_stop=3" in summary[0].details
-    assert "stop_loss=1" in summary[0].details
+    assert "stop_loss=3" in summary[0].details
+    assert "take_profit=1" in summary[0].details
 
 
 def test_diagnostics_summary_handles_no_firings() -> None:
     gate = ExitRuleConformanceGate()
     results = gate.check(
-        exit_rules=[TimeStopRule(n_bars=10)],
-        trades=[_trade(hold_days=5)],
+        exit_rules=[StopLossRule(pct=0.05)],
+        trades=[_trade(return_pct=1.0)],
         diagnostics=_diagnostics(),
         config=_config(),
     )
@@ -341,18 +250,17 @@ def test_diagnostics_summary_handles_no_firings() -> None:
 def test_multi_rule_all_pass_returns_no_failures() -> None:
     gate = ExitRuleConformanceGate()
     trades: List[TradeRecord] = [
-        _trade(trade_num=1, hold_days=3, return_pct=-2.0),
-        _trade(trade_num=2, hold_days=5, return_pct=1.0),
-        _trade(trade_num=3, hold_days=2, return_pct=6.0),
+        _trade(trade_num=1, return_pct=-2.0),
+        _trade(trade_num=2, return_pct=1.0),
+        _trade(trade_num=3, return_pct=6.0),
     ]
     results = gate.check(
         exit_rules=[
-            TimeStopRule(n_bars=10),
             StopLossRule(pct=0.05),
             TakeProfitRule(pct=0.05),
         ],
         trades=trades,
-        diagnostics=_diagnostics(time_stop=1, stop_loss=1, take_profit=1),
+        diagnostics=_diagnostics(stop_loss=1, take_profit=1),
         config=_config(),
     )
     fails = [r for r in results if not r.passed]

--- a/backend/agents/investment_team/tests/test_exit_rule_conformance_gate.py
+++ b/backend/agents/investment_team/tests/test_exit_rule_conformance_gate.py
@@ -108,8 +108,9 @@ def test_time_stop_pass_within_ceiling() -> None:
 
 def test_time_stop_fail_when_trade_exceeds_ceiling() -> None:
     gate = ExitRuleConformanceGate()
-    # n_bars=5 → ceiling = 5 + 1 = 6. hold_days=7 violates.
-    trades = [_trade(hold_days=h) for h in (1, 7, 4)]
+    # n_bars=5 → ceiling = 5 + ceil(10/5) + ceil(5/25) + 3 = 5+2+1+3 = 11.
+    # hold_days=20 is well past the weekend/holiday-tolerant ceiling.
+    trades = [_trade(hold_days=h) for h in (1, 20, 4)]
     results = gate.check(
         exit_rules=[TimeStopRule(n_bars=5)],
         trades=trades,
@@ -121,6 +122,27 @@ def test_time_stop_fail_when_trade_exceeds_ceiling() -> None:
     assert fail[0].severity == "critical"
     assert "TimeStopRule" in fail[0].details
     assert fail[0].gate_name == GATE
+
+
+def test_time_stop_tolerates_weekend_and_holiday_gaps() -> None:
+    """A compliant 1-bar hold entered Friday and closed Monday records
+    ``hold_days==3`` because the calendar wraps a weekend. The ceiling
+    must be generous enough to absorb that — otherwise the gate fires a
+    false critical and vetoes ``is_winning`` on perfectly clean runs.
+    Regression for the P2 review comment on issue #527 PR.
+    """
+    gate = ExitRuleConformanceGate()
+    # TimeStopRule(n_bars=1) → ceiling = 1 + 1 + 1 + 3 = 6. A Fri-entry
+    # / Mon-fill 1-bar hold (hold_days=3) is well under 6.
+    trades = [_trade(hold_days=3)]
+    results = gate.check(
+        exit_rules=[TimeStopRule(n_bars=1)],
+        trades=trades,
+        diagnostics=_diagnostics(time_stop=1),
+        config=_config(),
+    )
+    fails = [r for r in results if not r.passed]
+    assert fails == [], [r.details for r in fails]
 
 
 def test_time_stop_skipped_on_sub_daily_timeframe() -> None:
@@ -140,12 +162,13 @@ def test_time_stop_skipped_on_sub_daily_timeframe() -> None:
     assert skipped
 
 
-def test_time_stop_ceiling_includes_one_bar_fill_lag() -> None:
-    # n_bars=10 → ceiling=11. hold_days==11 should pass (not violate).
+def test_time_stop_ceiling_absorbs_weekends_and_fill_lag() -> None:
+    # n_bars=10 → ceiling = 10 + ceil(20/5) + ceil(10/25) + 3 = 10+4+1+3 = 18.
+    # 18 calendar days easily covers 10 trading days + 2 weekends + holiday + fill lag.
     gate = ExitRuleConformanceGate()
     results = gate.check(
         exit_rules=[TimeStopRule(n_bars=10)],
-        trades=[_trade(hold_days=11)],
+        trades=[_trade(hold_days=18)],
         diagnostics=_diagnostics(),
         config=_config(),
     )

--- a/backend/agents/investment_team/tests/test_exit_rule_conformance_gate.py
+++ b/backend/agents/investment_team/tests/test_exit_rule_conformance_gate.py
@@ -1,0 +1,336 @@
+"""Unit tests for ``ExitRuleConformanceGate`` (issue #527).
+
+Drives the gate with hand-built ``TradeRecord`` / diagnostics fixtures so
+each rule type's check is exercised in isolation, then a final happy-path
+test runs the whole gate end-to-end against a multi-rule spec.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from investment_team.models import (
+    BacktestConfig,
+    BacktestExecutionDiagnostics,
+    TradeRecord,
+)
+from investment_team.strategy_lab.quality_gates.exit_rule_conformance import (
+    GATE,
+    ExitRuleConformanceGate,
+)
+from investment_team.strategy_lab.spec_dsl import (
+    IndicatorRef,
+    Predicate,
+    SignalExitRule,
+    StopLossRule,
+    TakeProfitRule,
+    TimeStopRule,
+)
+
+
+def _config() -> BacktestConfig:
+    return BacktestConfig(
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+        slippage_bps=2.0,
+    )
+
+
+def _trade(
+    *,
+    trade_num: int = 1,
+    hold_days: int = 5,
+    return_pct: float = 1.0,
+    side: str = "long",
+    entry_price: float = 100.0,
+    exit_price: float = 101.0,
+) -> TradeRecord:
+    return TradeRecord(
+        trade_num=trade_num,
+        entry_date="2024-01-01",
+        exit_date="2024-01-06",
+        symbol="AAA",
+        side=side,
+        entry_price=entry_price,
+        exit_price=exit_price,
+        shares=100.0,
+        position_value=entry_price * 100.0,
+        gross_pnl=(exit_price - entry_price) * 100.0,
+        net_pnl=(exit_price - entry_price) * 100.0,
+        return_pct=return_pct,
+        hold_days=hold_days,
+        outcome="win" if return_pct > 0 else "loss",
+        cumulative_pnl=(exit_price - entry_price) * 100.0,
+    )
+
+
+def _diagnostics(**firings: int) -> BacktestExecutionDiagnostics:
+    return BacktestExecutionDiagnostics(exit_rule_firings=dict(firings))
+
+
+# ---------------------------------------------------------------------------
+# Empty exit_rules
+# ---------------------------------------------------------------------------
+
+
+def test_no_exit_rules_skips_with_info() -> None:
+    gate = ExitRuleConformanceGate()
+    results = gate.check(
+        exit_rules=[],
+        trades=[_trade()],
+        diagnostics=_diagnostics(),
+        config=_config(),
+    )
+    assert len(results) == 1
+    assert results[0].passed is True
+    assert results[0].severity == "info"
+    assert "empty" in results[0].details.lower()
+
+
+# ---------------------------------------------------------------------------
+# TimeStopRule
+# ---------------------------------------------------------------------------
+
+
+def test_time_stop_pass_within_ceiling() -> None:
+    gate = ExitRuleConformanceGate()
+    trades = [_trade(hold_days=h) for h in (1, 3, 5)]
+    results = gate.check(
+        exit_rules=[TimeStopRule(n_bars=5)],
+        trades=trades,
+        diagnostics=_diagnostics(time_stop=2),
+        config=_config(),
+    )
+    # First result is the TimeStop check; gate may append an aggregate info row.
+    time_stop = [r for r in results if "TimeStopRule" in r.details]
+    assert all(r.passed for r in time_stop), [r.details for r in time_stop]
+
+
+def test_time_stop_fail_when_trade_exceeds_ceiling() -> None:
+    gate = ExitRuleConformanceGate()
+    # n_bars=5 → ceiling = 5 + 1 = 6. hold_days=7 violates.
+    trades = [_trade(hold_days=h) for h in (1, 7, 4)]
+    results = gate.check(
+        exit_rules=[TimeStopRule(n_bars=5)],
+        trades=trades,
+        diagnostics=_diagnostics(),
+        config=_config(),
+    )
+    fail = [r for r in results if not r.passed]
+    assert len(fail) == 1
+    assert fail[0].severity == "critical"
+    assert "TimeStopRule" in fail[0].details
+    assert fail[0].gate_name == GATE
+
+
+def test_time_stop_skipped_on_sub_daily_timeframe() -> None:
+    gate = ExitRuleConformanceGate()
+    trades = [_trade(hold_days=99)]  # would fail on daily
+    results = gate.check(
+        exit_rules=[TimeStopRule(n_bars=5)],
+        trades=trades,
+        diagnostics=_diagnostics(),
+        config=_config(),
+        timeframe="15m",
+    )
+    # No critical violations; just info "skipped on sub-daily".
+    fails = [r for r in results if not r.passed]
+    assert fails == []
+    skipped = [r for r in results if "skipped" in r.details and "15m" in r.details]
+    assert skipped
+
+
+def test_time_stop_ceiling_includes_one_bar_fill_lag() -> None:
+    # n_bars=10 → ceiling=11. hold_days==11 should pass (not violate).
+    gate = ExitRuleConformanceGate()
+    results = gate.check(
+        exit_rules=[TimeStopRule(n_bars=10)],
+        trades=[_trade(hold_days=11)],
+        diagnostics=_diagnostics(),
+        config=_config(),
+    )
+    fails = [r for r in results if not r.passed]
+    assert fails == []
+
+
+# ---------------------------------------------------------------------------
+# StopLossRule
+# ---------------------------------------------------------------------------
+
+
+def test_stop_loss_entry_price_pass_within_tolerance() -> None:
+    gate = ExitRuleConformanceGate()
+    # pct=0.03 → -3%. Slippage 2bps → 2x slip = 4bps = 0.04% extra each side.
+    # Tolerance band: -3.0 - 0.04 - 0.5 ≈ -3.54%. -3.5% should pass.
+    trades = [_trade(return_pct=-3.5)]
+    results = gate.check(
+        exit_rules=[StopLossRule(pct=0.03)],
+        trades=trades,
+        diagnostics=_diagnostics(stop_loss=1),
+        config=_config(),
+    )
+    fails = [r for r in results if not r.passed]
+    assert fails == [], [r.details for r in results]
+
+
+def test_stop_loss_entry_price_fail_when_below_floor() -> None:
+    gate = ExitRuleConformanceGate()
+    # pct=0.03 → floor ≈ -3.54%. -10% is well below.
+    trades = [_trade(return_pct=-10.0)]
+    results = gate.check(
+        exit_rules=[StopLossRule(pct=0.03)],
+        trades=trades,
+        diagnostics=_diagnostics(),
+        config=_config(),
+    )
+    fails = [r for r in results if not r.passed]
+    assert len(fails) == 1
+    assert fails[0].severity == "critical"
+    assert "StopLossRule" in fails[0].details
+
+
+def test_stop_loss_trailing_variant_skipped() -> None:
+    gate = ExitRuleConformanceGate()
+    # Trailing variants can't be checked from the ledger alone.
+    trades = [_trade(return_pct=-50.0)]
+    results = gate.check(
+        exit_rules=[StopLossRule(pct=0.03, basis="trailing_high")],
+        trades=trades,
+        diagnostics=_diagnostics(),
+        config=_config(),
+    )
+    fails = [r for r in results if not r.passed]
+    assert fails == []
+
+
+# ---------------------------------------------------------------------------
+# TakeProfitRule
+# ---------------------------------------------------------------------------
+
+
+def test_take_profit_alone_fires_when_threshold_reached() -> None:
+    gate = ExitRuleConformanceGate()
+    trades = [_trade(return_pct=6.0)]  # >= 5% target
+    results = gate.check(
+        exit_rules=[TakeProfitRule(pct=0.05)],
+        trades=trades,
+        diagnostics=_diagnostics(take_profit=1),
+        config=_config(),
+    )
+    fails = [r for r in results if not r.passed]
+    assert fails == []
+
+
+def test_take_profit_alone_warns_when_never_reached() -> None:
+    gate = ExitRuleConformanceGate()
+    # take_profit is the only rule, no trade reached 5% — warning.
+    trades = [_trade(return_pct=1.0), _trade(trade_num=2, return_pct=2.0)]
+    results = gate.check(
+        exit_rules=[TakeProfitRule(pct=0.05)],
+        trades=trades,
+        diagnostics=_diagnostics(),
+        config=_config(),
+    )
+    fails = [r for r in results if not r.passed]
+    assert len(fails) == 1
+    assert fails[0].severity == "warning"
+
+
+def test_take_profit_with_other_rules_is_informational() -> None:
+    # With another rule present, never reaching the take-profit threshold
+    # is acceptable (the other rule may close trades first).
+    gate = ExitRuleConformanceGate()
+    trades = [_trade(return_pct=1.0)]
+    results = gate.check(
+        exit_rules=[TimeStopRule(n_bars=10), TakeProfitRule(pct=0.05)],
+        trades=trades,
+        diagnostics=_diagnostics(time_stop=1),
+        config=_config(),
+    )
+    fails = [r for r in results if not r.passed]
+    assert fails == []
+
+
+# ---------------------------------------------------------------------------
+# SignalExitRule
+# ---------------------------------------------------------------------------
+
+
+def test_signal_exit_rule_is_informational_only() -> None:
+    gate = ExitRuleConformanceGate()
+    rule = SignalExitRule(
+        when=Predicate(
+            lhs=IndicatorRef(name="rsi", params={"period": 14}),
+            op=">",
+            rhs=70.0,
+        )
+    )
+    results = gate.check(
+        exit_rules=[rule],
+        trades=[_trade()],
+        diagnostics=_diagnostics(),
+        config=_config(),
+    )
+    fails = [r for r in results if not r.passed]
+    assert fails == []
+    # The note appears in one of the info rows.
+    assert any("SignalExitRule" in r.details for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics summary row
+# ---------------------------------------------------------------------------
+
+
+def test_diagnostics_summary_includes_firings_breakdown() -> None:
+    gate = ExitRuleConformanceGate()
+    diag = _diagnostics(time_stop=3, stop_loss=1)
+    results = gate.check(
+        exit_rules=[TimeStopRule(n_bars=10)],
+        trades=[_trade(hold_days=5)],
+        diagnostics=diag,
+        config=_config(),
+    )
+    summary = [r for r in results if "engine_exits" in r.details]
+    assert summary, [r.details for r in results]
+    assert "time_stop=3" in summary[0].details
+    assert "stop_loss=1" in summary[0].details
+
+
+def test_diagnostics_summary_handles_no_firings() -> None:
+    gate = ExitRuleConformanceGate()
+    results = gate.check(
+        exit_rules=[TimeStopRule(n_bars=10)],
+        trades=[_trade(hold_days=5)],
+        diagnostics=_diagnostics(),
+        config=_config(),
+    )
+    summary = [r for r in results if "engine_exits" in r.details]
+    assert summary
+    assert "none" in summary[0].details
+
+
+# ---------------------------------------------------------------------------
+# Multi-rule integration
+# ---------------------------------------------------------------------------
+
+
+def test_multi_rule_all_pass_returns_no_failures() -> None:
+    gate = ExitRuleConformanceGate()
+    trades: List[TradeRecord] = [
+        _trade(trade_num=1, hold_days=3, return_pct=-2.0),
+        _trade(trade_num=2, hold_days=5, return_pct=1.0),
+        _trade(trade_num=3, hold_days=2, return_pct=6.0),
+    ]
+    results = gate.check(
+        exit_rules=[
+            TimeStopRule(n_bars=10),
+            StopLossRule(pct=0.05),
+            TakeProfitRule(pct=0.05),
+        ],
+        trades=trades,
+        diagnostics=_diagnostics(time_stop=1, stop_loss=1, take_profit=1),
+        config=_config(),
+    )
+    fails = [r for r in results if not r.passed]
+    assert fails == [], [r.details for r in fails]

--- a/backend/agents/investment_team/tests/test_exit_rule_conformance_gate.py
+++ b/backend/agents/investment_team/tests/test_exit_rule_conformance_gate.py
@@ -42,12 +42,20 @@ def _trade(
     side: str = "long",
     entry_price: float = 100.0,
     exit_price: float = 101.0,
+    symbol: str = "AAA",
+    exit_reason: str | None = "engine_exit:stop_loss",
 ) -> TradeRecord:
+    """Build a TradeRecord. ``exit_reason`` defaults to
+    ``"engine_exit:stop_loss"`` so legacy fixtures keep counting
+    below-floor trades against the engine — tests that need the
+    strategy-close exclusion pass ``exit_reason=None`` or a
+    non-engine string explicitly.
+    """
     return TradeRecord(
         trade_num=trade_num,
         entry_date="2024-01-01",
         exit_date="2024-01-06",
-        symbol="AAA",
+        symbol=symbol,
         side=side,
         entry_price=entry_price,
         exit_price=exit_price,
@@ -59,6 +67,7 @@ def _trade(
         hold_days=hold_days,
         outcome="win" if return_pct > 0 else "loss",
         cumulative_pnl=(exit_price - entry_price) * 100.0,
+        exit_reason=exit_reason,
     )
 
 
@@ -415,6 +424,7 @@ def test_stop_loss_cross_symbol_firings_do_not_mask_leak() -> None:
             hold_days=1,
             outcome="loss",
             cumulative_pnl=-800.0,
+            exit_reason="engine_exit:stop_loss",
         ),
         TradeRecord(
             trade_num=2,
@@ -432,6 +442,7 @@ def test_stop_loss_cross_symbol_firings_do_not_mask_leak() -> None:
             hold_days=1,
             outcome="loss",
             cumulative_pnl=-1_800.0,
+            exit_reason="engine_exit:stop_loss",
         ),
     ]
     # Aggregate firings would mask the leak (2 trades, 2 firings); per
@@ -453,3 +464,131 @@ def test_stop_loss_cross_symbol_firings_do_not_mask_leak() -> None:
     assert len(fails) == 1
     assert fails[0].severity == "critical"
     assert "BBB" in fails[0].details
+
+
+def test_stop_loss_excludes_strategy_closed_below_floor_trades() -> None:
+    """A strategy-emitted market exit that fills on a next-bar gap-down
+    open beneath the structured stop-loss floor must NOT count as an
+    engine leak: the engine never had a chance to fire on that bar
+    (position closed before rule eval). Regression for the P2 review
+    comment on PR #581 (issue #527).
+
+    Setup: two below-floor trades on AAA, zero engine firings. Trade
+    1 closed by strategy (``exit_reason="strategy_market_exit"``);
+    trade 2 closed by engine (``exit_reason=None`` would be ambiguous,
+    so explicit ``engine_exit:stop_loss``). Old behaviour: both count,
+    "2 unaccounted" critical. New behaviour: only trade 2 counts,
+    still flags 1 unaccounted critical (the real engine leak).
+    """
+    gate = ExitRuleConformanceGate()
+    trades = [
+        _trade(
+            trade_num=1,
+            symbol="AAA",
+            entry_price=100.0,
+            exit_price=92.0,
+            return_pct=-8.0,
+            exit_reason="strategy_market_exit",  # strategy closed
+        ),
+        _trade(
+            trade_num=2,
+            symbol="AAA",
+            entry_price=100.0,
+            exit_price=93.0,
+            return_pct=-7.0,
+            exit_reason="engine_exit:stop_loss",  # engine claim
+        ),
+    ]
+    # Zero engine firings — the engine claim on trade 2 is the leak
+    # (engine attribution but no recorded firing).
+    diag = BacktestExecutionDiagnostics(
+        exit_rule_firings={},
+        exit_rule_firings_by_symbol={"AAA": {}},
+    )
+    results = gate.check(
+        exit_rules=[StopLossRule(pct=0.05)],
+        trades=trades,
+        diagnostics=diag,
+        config=_config(),
+    )
+    fails = [r for r in results if not r.passed]
+    assert len(fails) == 1
+    assert fails[0].severity == "critical"
+    # Trade 2 (the engine-attributed one) is flagged; trade 1 is
+    # explicitly excluded with a count in the details.
+    assert "trade_num" in fails[0].details
+    assert "1 strategy-closed below-floor trade(s)" in fails[0].details
+    assert "excluded" in fails[0].details
+
+
+def test_stop_loss_passes_when_all_below_floor_are_strategy_closed() -> None:
+    """Counterpart: if every below-floor trade was strategy-closed
+    (None exit_reason for a vanilla strategy market exit, or an
+    explicit strategy string), the gate must pass — the engine had
+    nothing to do here.
+    """
+    gate = ExitRuleConformanceGate()
+    trades = [
+        _trade(
+            trade_num=1,
+            symbol="AAA",
+            entry_price=100.0,
+            exit_price=92.0,
+            return_pct=-8.0,
+            exit_reason=None,  # vanilla strategy market exit
+        ),
+        _trade(
+            trade_num=2,
+            symbol="AAA",
+            entry_price=100.0,
+            exit_price=93.0,
+            return_pct=-7.0,
+            exit_reason="strategy_close",  # explicit strategy reason
+        ),
+    ]
+    diag = BacktestExecutionDiagnostics(
+        exit_rule_firings={},
+        exit_rule_firings_by_symbol={"AAA": {}},
+    )
+    results = gate.check(
+        exit_rules=[StopLossRule(pct=0.05)],
+        trades=trades,
+        diagnostics=diag,
+        config=_config(),
+    )
+    fails = [r for r in results if not r.passed]
+    assert fails == []
+    info = next(r for r in results if r.gate_name == "exit_rule_conformance" and r.passed)
+    assert "2 strategy-closed below-floor trade(s)" in info.details
+
+
+def test_stop_loss_excludes_engine_take_profit_below_floor() -> None:
+    """An engine take_profit firing can fill below the stop-loss floor
+    on a gap (engine fired TP on bar N's high, fills on bar N+1's
+    open which gapped down past the SL floor). That's NOT a stop_loss
+    leak — the engine made a deliberate TP choice and the fill
+    happened where it happened.
+    """
+    gate = ExitRuleConformanceGate()
+    trades = [
+        _trade(
+            trade_num=1,
+            symbol="AAA",
+            entry_price=100.0,
+            exit_price=93.0,
+            return_pct=-7.0,
+            exit_reason="engine_exit:take_profit",  # engine TP fired
+        ),
+    ]
+    diag = BacktestExecutionDiagnostics(
+        exit_rule_firings={"take_profit": 1},
+        exit_rule_firings_by_symbol={"AAA": {"take_profit": 1}},
+    )
+    results = gate.check(
+        exit_rules=[StopLossRule(pct=0.05)],
+        trades=trades,
+        diagnostics=diag,
+        config=_config(),
+    )
+    fails = [r for r in results if not r.passed]
+    assert fails == []

--- a/backend/agents/investment_team/tests/test_investment_team.py
+++ b/backend/agents/investment_team/tests/test_investment_team.py
@@ -42,7 +42,7 @@ from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
     Predicate,
     SignalExitRule,
-    TimeStopRule,
+    StopLossRule,
 )
 from investment_team.tool_agents.web_interfaces import (
     BrowserType,
@@ -1818,7 +1818,7 @@ def _make_lab_record(
         signal_definition="sig",
         timeframe="1d",
         entry_rules=[EntryRule(side="long", when=Predicate(lhs="bar.close", op=">", rhs=1))],
-        exit_rules=[TimeStopRule(n_bars=1)],
+        exit_rules=[StopLossRule(pct=0.03)],
         risk_limits={},
         speculative=False,
     )

--- a/backend/agents/investment_team/tests/test_rule_compiler.py
+++ b/backend/agents/investment_team/tests/test_rule_compiler.py
@@ -1,0 +1,324 @@
+"""Unit tests for ``executor.rule_compiler.evaluate_exit_rules`` (issue #527).
+
+The evaluator is intentionally pure: it takes ``(rules, positions, bars)``
+and returns ``ExitIntent`` records. Each test fabricates synthetic state
+and asserts on the returned intents without touching the trading service.
+"""
+
+from __future__ import annotations
+
+from investment_team.strategy_lab.executor.rule_compiler import (
+    BarSnapshot,
+    PositionState,
+    evaluate_exit_rules,
+)
+from investment_team.strategy_lab.spec_dsl import (
+    IndicatorRef,
+    Predicate,
+    SignalExitRule,
+    StopLossRule,
+    TakeProfitRule,
+    TimeStopRule,
+)
+
+
+def _long(symbol: str = "AAA", **kwargs) -> PositionState:
+    defaults = {
+        "symbol": symbol,
+        "side": "long",
+        "qty": 100.0,
+        "entry_price": 100.0,
+        "bars_held": 1,
+        "high_since_entry": 100.0,
+        "low_since_entry": 100.0,
+    }
+    defaults.update(kwargs)
+    return PositionState(**defaults)
+
+
+def _short(symbol: str = "AAA", **kwargs) -> PositionState:
+    defaults = {
+        "symbol": symbol,
+        "side": "short",
+        "qty": 100.0,
+        "entry_price": 100.0,
+        "bars_held": 1,
+        "high_since_entry": 100.0,
+        "low_since_entry": 100.0,
+    }
+    defaults.update(kwargs)
+    return PositionState(**defaults)
+
+
+def _bar(high: float = 101.0, low: float = 99.0, close: float = 100.0) -> BarSnapshot:
+    return BarSnapshot(high=high, low=low, close=close)
+
+
+# ---------------------------------------------------------------------------
+# TimeStopRule
+# ---------------------------------------------------------------------------
+
+
+def test_time_stop_fires_at_threshold() -> None:
+    pos = _long(bars_held=10)
+    intents = evaluate_exit_rules([TimeStopRule(n_bars=10)], {"AAA": pos}, {"AAA": _bar()})
+    assert len(intents) == 1
+    assert intents[0].rule_kind == "time_stop"
+    assert intents[0].rule_index == 0
+    assert intents[0].symbol == "AAA"
+
+
+def test_time_stop_does_not_fire_before_threshold() -> None:
+    pos = _long(bars_held=9)
+    intents = evaluate_exit_rules([TimeStopRule(n_bars=10)], {"AAA": pos}, {"AAA": _bar()})
+    assert intents == []
+
+
+def test_time_stop_fires_well_past_threshold() -> None:
+    pos = _long(bars_held=42)
+    intents = evaluate_exit_rules([TimeStopRule(n_bars=10)], {"AAA": pos}, {"AAA": _bar()})
+    assert len(intents) == 1
+
+
+def test_time_stop_one_bar_fires_on_entry_bar() -> None:
+    # bars_held == 1 means "this is the entry bar" — TimeStopRule(n_bars=1)
+    # closes on the entry bar (engine emits at end of bar 1, fills bar 2).
+    pos = _long(bars_held=1)
+    intents = evaluate_exit_rules([TimeStopRule(n_bars=1)], {"AAA": pos}, {"AAA": _bar()})
+    assert len(intents) == 1
+
+
+# ---------------------------------------------------------------------------
+# StopLossRule — entry_price basis
+# ---------------------------------------------------------------------------
+
+
+def test_stop_loss_entry_price_long_fires_on_low_below_floor() -> None:
+    # entry=100, pct=0.03 → floor=97. Bar low=96.5 < 97 → fires.
+    pos = _long()
+    rule = StopLossRule(pct=0.03)  # default basis = entry_price
+    intents = evaluate_exit_rules([rule], {"AAA": pos}, {"AAA": _bar(high=98, low=96.5)})
+    assert len(intents) == 1
+    assert intents[0].rule_kind == "stop_loss"
+
+
+def test_stop_loss_entry_price_long_does_not_fire_when_low_above_floor() -> None:
+    pos = _long()
+    rule = StopLossRule(pct=0.03)
+    intents = evaluate_exit_rules([rule], {"AAA": pos}, {"AAA": _bar(low=97.5)})
+    assert intents == []
+
+
+def test_stop_loss_entry_price_long_fires_at_exact_floor() -> None:
+    pos = _long()
+    rule = StopLossRule(pct=0.05)  # floor=95
+    intents = evaluate_exit_rules([rule], {"AAA": pos}, {"AAA": _bar(low=95.0)})
+    assert len(intents) == 1
+
+
+def test_stop_loss_entry_price_short_fires_on_high_above_ceiling() -> None:
+    # short, entry=100, pct=0.03 → ceiling=103. Bar high=103.5 > 103 → fires.
+    pos = _short()
+    rule = StopLossRule(pct=0.03)
+    intents = evaluate_exit_rules([rule], {"AAA": pos}, {"AAA": _bar(high=103.5, low=99)})
+    assert len(intents) == 1
+
+
+def test_stop_loss_entry_price_short_does_not_fire_when_high_below_ceiling() -> None:
+    pos = _short()
+    rule = StopLossRule(pct=0.03)
+    intents = evaluate_exit_rules([rule], {"AAA": pos}, {"AAA": _bar(high=102, low=99)})
+    assert intents == []
+
+
+# ---------------------------------------------------------------------------
+# StopLossRule — trailing variants
+# ---------------------------------------------------------------------------
+
+
+def test_stop_loss_trailing_high_long_uses_watermark() -> None:
+    # entry=100, but the position has run up to a high of 110 since entry.
+    # pct=0.05 → trailing floor = 110 * 0.95 = 104.5. Bar low=104 < 104.5 → fires.
+    pos = _long(high_since_entry=110.0)
+    rule = StopLossRule(pct=0.05, basis="trailing_high")
+    intents = evaluate_exit_rules([rule], {"AAA": pos}, {"AAA": _bar(high=105, low=104)})
+    assert len(intents) == 1
+    assert intents[0].rule_kind == "stop_loss"
+
+
+def test_stop_loss_trailing_high_long_no_fire_when_no_run_up() -> None:
+    # Watermark == entry → trailing floor = entry * (1 - pct), same as entry basis.
+    pos = _long(high_since_entry=100.0)
+    rule = StopLossRule(pct=0.05, basis="trailing_high")
+    intents = evaluate_exit_rules([rule], {"AAA": pos}, {"AAA": _bar(low=96)})
+    assert intents == []
+
+
+def test_stop_loss_trailing_high_inapplicable_to_short_is_noop() -> None:
+    # ``trailing_high`` is the long-side counterpart; using it on a short
+    # must NOT silently flush the position. The rule is a no-op for shorts.
+    pos = _short(high_since_entry=110.0)
+    rule = StopLossRule(pct=0.05, basis="trailing_high")
+    intents = evaluate_exit_rules([rule], {"AAA": pos}, {"AAA": _bar(high=120, low=99)})
+    assert intents == []
+
+
+def test_stop_loss_trailing_low_short_uses_watermark() -> None:
+    # short, entry=100, drawn down to low=90. pct=0.05 → trailing ceiling =
+    # 90 * 1.05 = 94.5. Bar high=95 > 94.5 → fires.
+    pos = _short(low_since_entry=90.0)
+    rule = StopLossRule(pct=0.05, basis="trailing_low")
+    intents = evaluate_exit_rules([rule], {"AAA": pos}, {"AAA": _bar(high=95, low=88)})
+    assert len(intents) == 1
+
+
+def test_stop_loss_trailing_low_inapplicable_to_long_is_noop() -> None:
+    pos = _long(low_since_entry=90.0)
+    rule = StopLossRule(pct=0.05, basis="trailing_low")
+    intents = evaluate_exit_rules([rule], {"AAA": pos}, {"AAA": _bar(low=70)})
+    assert intents == []
+
+
+# ---------------------------------------------------------------------------
+# TakeProfitRule
+# ---------------------------------------------------------------------------
+
+
+def test_take_profit_long_fires_on_high_above_target() -> None:
+    pos = _long()
+    rule = TakeProfitRule(pct=0.05)  # target = 105
+    intents = evaluate_exit_rules([rule], {"AAA": pos}, {"AAA": _bar(high=105.5, low=102)})
+    assert len(intents) == 1
+    assert intents[0].rule_kind == "take_profit"
+
+
+def test_take_profit_long_does_not_fire_below_target() -> None:
+    pos = _long()
+    rule = TakeProfitRule(pct=0.05)
+    intents = evaluate_exit_rules([rule], {"AAA": pos}, {"AAA": _bar(high=104.9)})
+    assert intents == []
+
+
+def test_take_profit_short_fires_on_low_below_target() -> None:
+    pos = _short()
+    rule = TakeProfitRule(pct=0.05)  # target = 95 (profit when short and price falls)
+    intents = evaluate_exit_rules([rule], {"AAA": pos}, {"AAA": _bar(high=98, low=94.5)})
+    assert len(intents) == 1
+
+
+# ---------------------------------------------------------------------------
+# Multiple rules — first-by-spec-order wins
+# ---------------------------------------------------------------------------
+
+
+def test_first_triggered_rule_wins_when_both_fire() -> None:
+    pos = _long(bars_held=10)
+    rules = [StopLossRule(pct=0.05), TimeStopRule(n_bars=10)]
+    # Both fire (low=94 < 95 floor; bars_held >= 10).
+    intents = evaluate_exit_rules(rules, {"AAA": pos}, {"AAA": _bar(high=96, low=94)})
+    assert len(intents) == 1
+    # ``stop_loss`` first in spec → it wins.
+    assert intents[0].rule_kind == "stop_loss"
+    assert intents[0].rule_index == 0
+
+
+def test_rule_order_swapped_changes_winner() -> None:
+    pos = _long(bars_held=10)
+    rules = [TimeStopRule(n_bars=10), StopLossRule(pct=0.05)]
+    intents = evaluate_exit_rules(rules, {"AAA": pos}, {"AAA": _bar(high=96, low=94)})
+    assert len(intents) == 1
+    assert intents[0].rule_kind == "time_stop"
+
+
+def test_no_rules_yields_no_intents() -> None:
+    intents = evaluate_exit_rules([], {"AAA": _long()}, {"AAA": _bar()})
+    assert intents == []
+
+
+def test_no_open_positions_yields_no_intents() -> None:
+    intents = evaluate_exit_rules([TimeStopRule(n_bars=1)], {}, {"AAA": _bar()})
+    assert intents == []
+
+
+def test_zero_qty_position_skipped() -> None:
+    pos = _long(qty=0.0, bars_held=99)
+    intents = evaluate_exit_rules([TimeStopRule(n_bars=1)], {"AAA": pos}, {"AAA": _bar()})
+    assert intents == []
+
+
+def test_position_without_matching_bar_skipped() -> None:
+    pos = _long(bars_held=10)
+    intents = evaluate_exit_rules([TimeStopRule(n_bars=1)], {"AAA": pos}, {})
+    assert intents == []
+
+
+# ---------------------------------------------------------------------------
+# SignalExitRule — explicit NotImplementedError
+# ---------------------------------------------------------------------------
+
+
+def test_signal_exit_rule_is_silent_noop() -> None:
+    # SignalExitRule is not yet engine-enforced (predicate evaluation needs a
+    # shared per-bar indicator runtime). The evaluator treats it as a no-op
+    # so other rules in the same spec still get enforced — see module
+    # docstring + ``ExitRuleConformanceGate`` for the user-facing surface.
+    pos = _long()
+    rule = SignalExitRule(
+        when=Predicate(
+            lhs=IndicatorRef(name="rsi", params={"period": 14}),
+            op=">",
+            rhs=70.0,
+        )
+    )
+    intents = evaluate_exit_rules([rule], {"AAA": pos}, {"AAA": _bar()})
+    assert intents == []
+
+
+def test_signal_exit_does_not_block_other_rules_in_spec() -> None:
+    # Mix SignalExit + TimeStop. TimeStop should still fire even though the
+    # SignalExit is iterated first.
+    pos = _long(bars_held=10)
+    signal = SignalExitRule(
+        when=Predicate(
+            lhs=IndicatorRef(name="rsi", params={"period": 14}),
+            op=">",
+            rhs=70.0,
+        )
+    )
+    intents = evaluate_exit_rules(
+        [signal, TimeStopRule(n_bars=10)],
+        {"AAA": pos},
+        {"AAA": _bar()},
+    )
+    assert len(intents) == 1
+    assert intents[0].rule_kind == "time_stop"
+    assert intents[0].rule_index == 1
+
+
+# ---------------------------------------------------------------------------
+# Multi-symbol — each position evaluated independently
+# ---------------------------------------------------------------------------
+
+
+def test_multi_symbol_evaluates_each_position_against_its_own_bar() -> None:
+    rules = [TimeStopRule(n_bars=5)]
+    positions = {
+        "AAA": _long("AAA", bars_held=5),
+        "BBB": _long("BBB", bars_held=3),
+    }
+    bars = {"AAA": _bar(), "BBB": _bar()}
+    intents = evaluate_exit_rules(rules, positions, bars)
+    assert len(intents) == 1
+    assert intents[0].symbol == "AAA"
+
+
+def test_multi_symbol_skips_when_no_bar_for_symbol() -> None:
+    rules = [TimeStopRule(n_bars=1)]
+    positions = {
+        "AAA": _long("AAA", bars_held=10),
+        "BBB": _long("BBB", bars_held=10),
+    }
+    bars = {"AAA": _bar()}  # no bar for BBB
+    intents = evaluate_exit_rules(rules, positions, bars)
+    assert len(intents) == 1
+    assert intents[0].symbol == "AAA"

--- a/backend/agents/investment_team/tests/test_rule_compiler.py
+++ b/backend/agents/investment_team/tests/test_rule_compiler.py
@@ -18,7 +18,6 @@ from investment_team.strategy_lab.spec_dsl import (
     SignalExitRule,
     StopLossRule,
     TakeProfitRule,
-    TimeStopRule,
 )
 
 
@@ -28,7 +27,6 @@ def _long(symbol: str = "AAA", **kwargs) -> PositionState:
         "side": "long",
         "qty": 100.0,
         "entry_price": 100.0,
-        "bars_held": 1,
         "high_since_entry": 100.0,
         "low_since_entry": 100.0,
     }
@@ -42,7 +40,6 @@ def _short(symbol: str = "AAA", **kwargs) -> PositionState:
         "side": "short",
         "qty": 100.0,
         "entry_price": 100.0,
-        "bars_held": 1,
         "high_since_entry": 100.0,
         "low_since_entry": 100.0,
     }
@@ -52,40 +49,6 @@ def _short(symbol: str = "AAA", **kwargs) -> PositionState:
 
 def _bar(high: float = 101.0, low: float = 99.0, close: float = 100.0) -> BarSnapshot:
     return BarSnapshot(high=high, low=low, close=close)
-
-
-# ---------------------------------------------------------------------------
-# TimeStopRule
-# ---------------------------------------------------------------------------
-
-
-def test_time_stop_fires_at_threshold() -> None:
-    pos = _long(bars_held=10)
-    intents = evaluate_exit_rules([TimeStopRule(n_bars=10)], {"AAA": pos}, {"AAA": _bar()})
-    assert len(intents) == 1
-    assert intents[0].rule_kind == "time_stop"
-    assert intents[0].rule_index == 0
-    assert intents[0].symbol == "AAA"
-
-
-def test_time_stop_does_not_fire_before_threshold() -> None:
-    pos = _long(bars_held=9)
-    intents = evaluate_exit_rules([TimeStopRule(n_bars=10)], {"AAA": pos}, {"AAA": _bar()})
-    assert intents == []
-
-
-def test_time_stop_fires_well_past_threshold() -> None:
-    pos = _long(bars_held=42)
-    intents = evaluate_exit_rules([TimeStopRule(n_bars=10)], {"AAA": pos}, {"AAA": _bar()})
-    assert len(intents) == 1
-
-
-def test_time_stop_one_bar_fires_on_entry_bar() -> None:
-    # bars_held == 1 means "this is the entry bar" — TimeStopRule(n_bars=1)
-    # closes on the entry bar (engine emits at end of bar 1, fills bar 2).
-    pos = _long(bars_held=1)
-    intents = evaluate_exit_rules([TimeStopRule(n_bars=1)], {"AAA": pos}, {"AAA": _bar()})
-    assert len(intents) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -212,10 +175,10 @@ def test_take_profit_short_fires_on_low_below_target() -> None:
 
 
 def test_first_triggered_rule_wins_when_both_fire() -> None:
-    pos = _long(bars_held=10)
-    rules = [StopLossRule(pct=0.05), TimeStopRule(n_bars=10)]
-    # Both fire (low=94 < 95 floor; bars_held >= 10).
-    intents = evaluate_exit_rules(rules, {"AAA": pos}, {"AAA": _bar(high=96, low=94)})
+    pos = _long()
+    rules = [StopLossRule(pct=0.05), TakeProfitRule(pct=0.05)]
+    # Stop-loss fires (low=94 < 95 floor). Take-profit also fires (high=106 > 105).
+    intents = evaluate_exit_rules(rules, {"AAA": pos}, {"AAA": _bar(high=106, low=94)})
     assert len(intents) == 1
     # ``stop_loss`` first in spec → it wins.
     assert intents[0].rule_kind == "stop_loss"
@@ -223,11 +186,11 @@ def test_first_triggered_rule_wins_when_both_fire() -> None:
 
 
 def test_rule_order_swapped_changes_winner() -> None:
-    pos = _long(bars_held=10)
-    rules = [TimeStopRule(n_bars=10), StopLossRule(pct=0.05)]
-    intents = evaluate_exit_rules(rules, {"AAA": pos}, {"AAA": _bar(high=96, low=94)})
+    pos = _long()
+    rules = [TakeProfitRule(pct=0.05), StopLossRule(pct=0.05)]
+    intents = evaluate_exit_rules(rules, {"AAA": pos}, {"AAA": _bar(high=106, low=94)})
     assert len(intents) == 1
-    assert intents[0].rule_kind == "time_stop"
+    assert intents[0].rule_kind == "take_profit"
 
 
 def test_no_rules_yields_no_intents() -> None:
@@ -236,24 +199,24 @@ def test_no_rules_yields_no_intents() -> None:
 
 
 def test_no_open_positions_yields_no_intents() -> None:
-    intents = evaluate_exit_rules([TimeStopRule(n_bars=1)], {}, {"AAA": _bar()})
+    intents = evaluate_exit_rules([StopLossRule(pct=0.05)], {}, {"AAA": _bar()})
     assert intents == []
 
 
 def test_zero_qty_position_skipped() -> None:
-    pos = _long(qty=0.0, bars_held=99)
-    intents = evaluate_exit_rules([TimeStopRule(n_bars=1)], {"AAA": pos}, {"AAA": _bar()})
+    pos = _long(qty=0.0)
+    intents = evaluate_exit_rules([StopLossRule(pct=0.05)], {"AAA": pos}, {"AAA": _bar(low=90)})
     assert intents == []
 
 
 def test_position_without_matching_bar_skipped() -> None:
-    pos = _long(bars_held=10)
-    intents = evaluate_exit_rules([TimeStopRule(n_bars=1)], {"AAA": pos}, {})
+    pos = _long()
+    intents = evaluate_exit_rules([StopLossRule(pct=0.05)], {"AAA": pos}, {})
     assert intents == []
 
 
 # ---------------------------------------------------------------------------
-# SignalExitRule — explicit NotImplementedError
+# SignalExitRule — silent no-op (not yet engine-enforced)
 # ---------------------------------------------------------------------------
 
 
@@ -275,9 +238,9 @@ def test_signal_exit_rule_is_silent_noop() -> None:
 
 
 def test_signal_exit_does_not_block_other_rules_in_spec() -> None:
-    # Mix SignalExit + TimeStop. TimeStop should still fire even though the
+    # Mix SignalExit + StopLoss. StopLoss should still fire even though the
     # SignalExit is iterated first.
-    pos = _long(bars_held=10)
+    pos = _long()
     signal = SignalExitRule(
         when=Predicate(
             lhs=IndicatorRef(name="rsi", params={"period": 14}),
@@ -286,12 +249,12 @@ def test_signal_exit_does_not_block_other_rules_in_spec() -> None:
         )
     )
     intents = evaluate_exit_rules(
-        [signal, TimeStopRule(n_bars=10)],
+        [signal, StopLossRule(pct=0.05)],
         {"AAA": pos},
-        {"AAA": _bar()},
+        {"AAA": _bar(low=94)},
     )
     assert len(intents) == 1
-    assert intents[0].rule_kind == "time_stop"
+    assert intents[0].rule_kind == "stop_loss"
     assert intents[0].rule_index == 1
 
 
@@ -301,24 +264,26 @@ def test_signal_exit_does_not_block_other_rules_in_spec() -> None:
 
 
 def test_multi_symbol_evaluates_each_position_against_its_own_bar() -> None:
-    rules = [TimeStopRule(n_bars=5)]
+    rules = [StopLossRule(pct=0.05)]
     positions = {
-        "AAA": _long("AAA", bars_held=5),
-        "BBB": _long("BBB", bars_held=3),
+        "AAA": _long("AAA"),
+        "BBB": _long("BBB"),
     }
-    bars = {"AAA": _bar(), "BBB": _bar()}
+    # AAA bar trips the stop floor (low=94 < 95); BBB stays above (low=96).
+    bars = {"AAA": _bar(low=94), "BBB": _bar(low=96)}
     intents = evaluate_exit_rules(rules, positions, bars)
     assert len(intents) == 1
     assert intents[0].symbol == "AAA"
 
 
 def test_multi_symbol_skips_when_no_bar_for_symbol() -> None:
-    rules = [TimeStopRule(n_bars=1)]
+    rules = [StopLossRule(pct=0.05)]
     positions = {
-        "AAA": _long("AAA", bars_held=10),
-        "BBB": _long("BBB", bars_held=10),
+        "AAA": _long("AAA"),
+        "BBB": _long("BBB"),
     }
-    bars = {"AAA": _bar()}  # no bar for BBB
+    # Both would fire by bar alone, but BBB has no bar — only AAA emits.
+    bars = {"AAA": _bar(low=94)}
     intents = evaluate_exit_rules(rules, positions, bars)
     assert len(intents) == 1
     assert intents[0].symbol == "AAA"

--- a/backend/agents/investment_team/tests/test_spec_dsl.py
+++ b/backend/agents/investment_team/tests/test_spec_dsl.py
@@ -19,7 +19,6 @@ from investment_team.strategy_lab.spec_dsl import (
     SizingRuleAdapter,
     StopLossRule,
     TakeProfitRule,
-    TimeStopRule,
     VolatilityTargetSizing,
     format_rules_for_prompt,
     format_sizing_rule,
@@ -67,7 +66,6 @@ def test_entry_rule_round_trip():
 @pytest.mark.parametrize(
     "rule",
     [
-        TimeStopRule(n_bars=5),
         StopLossRule(pct=0.03),
         StopLossRule(pct=0.03, basis="trailing_high"),
         TakeProfitRule(pct=0.05),
@@ -125,13 +123,22 @@ def test_entry_discriminator_dispatch():
 
 def test_exit_discriminator_dispatch():
     assert isinstance(
-        ExitRuleAdapter.validate_python({"kind": "time_stop", "n_bars": 5}),
-        TimeStopRule,
-    )
-    assert isinstance(
         ExitRuleAdapter.validate_python({"kind": "stop_loss", "pct": 0.03}),
         StopLossRule,
     )
+    assert isinstance(
+        ExitRuleAdapter.validate_python({"kind": "take_profit", "pct": 0.05}),
+        TakeProfitRule,
+    )
+
+
+def test_exit_discriminator_rejects_legacy_time_stop():
+    """``TimeStopRule`` was removed — bar-counting exits aren't a real
+    trading concept. The discriminated union must now reject the legacy
+    payload shape so old fixtures don't silently get re-validated.
+    """
+    with pytest.raises(ValueError):
+        ExitRuleAdapter.validate_python({"kind": "time_stop", "n_bars": 5})
 
 
 def test_sizing_discriminator_dispatch():
@@ -236,11 +243,6 @@ def test_predicate_rhs_accepts_float():
     assert p.rhs == 30.0
 
 
-def test_time_stop_must_be_positive():
-    with pytest.raises(ValidationError):
-        TimeStopRule(n_bars=0)
-
-
 def test_fixed_fraction_upper_bound():
     with pytest.raises(ValidationError):
         FixedFractionSizing(fraction=1.5)
@@ -272,10 +274,6 @@ def test_format_entry_rsi_lt_30():
         when=Predicate(lhs=IndicatorRef(name="rsi", params={"period": 14}), op="<", rhs=30.0),
     )
     assert format_rules_for_prompt([rule]) == "long when rsi(14) < 30"
-
-
-def test_format_time_stop():
-    assert format_rules_for_prompt([TimeStopRule(n_bars=5)]) == "exit after 5 bars"
 
 
 def test_format_stop_loss():
@@ -341,9 +339,11 @@ def test_format_rules_for_prompt_join_separator():
     rules = [
         StopLossRule(pct=0.03),
         TakeProfitRule(pct=0.05),
-        TimeStopRule(n_bars=10),
+        StopLossRule(pct=0.02, basis="trailing_high"),
     ]
-    assert format_rules_for_prompt(rules) == "stop loss 3%, take profit 5%, exit after 10 bars"
+    assert (
+        format_rules_for_prompt(rules) == "stop loss 3%, take profit 5%, trailing-high stop loss 2%"
+    )
 
 
 def test_format_rules_for_prompt_empty():
@@ -373,7 +373,7 @@ def _make_structured_strategy_spec():
                 ),
             ),
         ],
-        exit_rules=[TimeStopRule(n_bars=10)],
+        exit_rules=[StopLossRule(pct=0.03)],
         sizing=FixedFractionSizing(fraction=0.02),
     )
 

--- a/backend/agents/investment_team/tests/test_strategies_endpoint_structured_wire.py
+++ b/backend/agents/investment_team/tests/test_strategies_endpoint_structured_wire.py
@@ -52,7 +52,7 @@ _STRUCTURED_BODY = {
             },
         }
     ],
-    "exit_rules": [{"kind": "time_stop", "n_bars": 10}],
+    "exit_rules": [{"kind": "stop_loss", "pct": 0.03}],
     "sizing": {"kind": "fixed_fraction", "fraction": 0.02},
 }
 
@@ -65,8 +65,8 @@ def test_structured_strategy_post_round_trips(client: TestClient) -> None:
     assert strategy["entry_rules"][0]["kind"] == "entry"
     assert strategy["entry_rules"][0]["side"] == "long"
     assert strategy["entry_rules"][0]["when"]["lhs"] == "bar.close"
-    assert strategy["exit_rules"][0]["kind"] == "time_stop"
-    assert strategy["exit_rules"][0]["n_bars"] == 10
+    assert strategy["exit_rules"][0]["kind"] == "stop_loss"
+    assert strategy["exit_rules"][0]["pct"] == 0.03
     assert strategy["sizing"]["kind"] == "fixed_fraction"
     assert strategy["sizing"]["fraction"] == 0.02
 
@@ -75,7 +75,7 @@ def test_structured_strategy_post_round_trips(client: TestClient) -> None:
     "field, prose_value",
     [
         ("entry_rules", ["close > sma(20)"]),
-        ("exit_rules", ["exit after 10 bars"]),
+        ("exit_rules", ["stop loss 3%"]),
         ("sizing", "risk 2% per trade"),
     ],
 )

--- a/backend/agents/investment_team/tests/test_strategy_lab_batches.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_batches.py
@@ -32,7 +32,7 @@ from investment_team.models import (  # noqa: E402
 from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
     Predicate,
-    TimeStopRule,
+    StopLossRule,
 )
 
 
@@ -64,7 +64,7 @@ def _make_record(idx: int, config: BacktestConfig) -> StrategyLabRecord:
         signal_definition="sig",
         timeframe="1d",
         entry_rules=[EntryRule(side="long", when=Predicate(lhs="bar.close", op=">", rhs=0))],
-        exit_rules=[TimeStopRule(n_bars=5)],
+        exit_rules=[StopLossRule(pct=0.03)],
         risk_limits={},
         speculative=False,
     )

--- a/backend/agents/investment_team/tests/test_strategy_lab_pre_synthesis_gating.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_pre_synthesis_gating.py
@@ -25,7 +25,7 @@ from investment_team.strategy_lab.spec_dsl import (
     IndicatorRef,
     Predicate,
     SignalExitRule,
-    TimeStopRule,
+    StopLossRule,
 )
 
 
@@ -43,7 +43,7 @@ def _rsi_exit_dict() -> Dict[str, Any]:
 
 
 def _time_stop_exit_dict() -> Dict[str, Any]:
-    return TimeStopRule(n_bars=5).model_dump()
+    return StopLossRule(pct=0.03).model_dump()
 
 
 def _config() -> BacktestConfig:

--- a/backend/agents/investment_team/tests/test_strategy_lab_resume.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_resume.py
@@ -34,7 +34,7 @@ from investment_team.models import (
 from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
     Predicate,
-    TimeStopRule,
+    StopLossRule,
 )
 
 # ---------------------------------------------------------------------------
@@ -65,7 +65,7 @@ def _make_record(record_id: str) -> StrategyLabRecord:
                 ),
             )
         ],
-        exit_rules=[TimeStopRule(n_bars=max(1, record_salt % 100))],
+        exit_rules=[StopLossRule(pct=0.03)],
     )
     backtest = BacktestRecord(
         backtest_id=f"bt-{record_id}",

--- a/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
@@ -34,7 +34,7 @@ from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
     Predicate,
     SignalExitRule,
-    TimeStopRule,
+    StopLossRule,
 )
 
 # ---------------------------------------------------------------------------
@@ -599,7 +599,7 @@ def test_walk_forward_fallback_rejects_overfit_via_anomaly_recheck(monkeypatch):
                 when=Predicate(lhs="bar.close", op=">", rhs=0),
             ).model_dump()
         ],
-        "exit_rules": [TimeStopRule(n_bars=5).model_dump()],
+        "exit_rules": [StopLossRule(pct=0.20).model_dump()],
         "risk_limits": {},
         "speculative": False,
     }
@@ -718,7 +718,7 @@ def _wire_run_cycle_stubs(
                 when=Predicate(lhs="bar.close", op=">", rhs=0),
             ).model_dump()
         ],
-        "exit_rules": [TimeStopRule(n_bars=5).model_dump()],
+        "exit_rules": [StopLossRule(pct=0.20).model_dump()],
         "risk_limits": {},
         "speculative": False,
     }

--- a/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
@@ -37,7 +37,7 @@ from investment_team.strategy_lab.spec_dsl import (
     IndicatorRef,
     Predicate,
     SignalExitRule,
-    TimeStopRule,
+    StopLossRule,
 )
 from investment_team.tests.test_strategy_lab_alignment import (
     _benign_sandbox_trades,
@@ -647,7 +647,7 @@ def test_zero_trade_repair_applies_proposed_spec_updates(
                 proposed_spec_updates={
                     "risk_limits": {"max_position_pct": 5, "max_drawdown_pct": 10},
                     # Off-list keys MUST NOT mutate the spec (#530).
-                    "exit_rules": [TimeStopRule(n_bars=10, note="added time stop").model_dump()],
+                    "exit_rules": [StopLossRule(pct=0.05, note="added stop").model_dump()],
                     "strategy_id": "hijacked",
                     "asset_class": "crypto",
                 },
@@ -720,7 +720,7 @@ def test_zero_trade_repair_drops_off_list_spec_keys_protects_thesis(
                             ),
                         ).model_dump()
                     ],
-                    "exit_rules": [TimeStopRule(n_bars=10, note="x").model_dump()],
+                    "exit_rules": [StopLossRule(pct=0.05, note="x").model_dump()],
                     "sizing": {"kind": "fixed_fraction", "fraction": 0.5},
                 },
                 changes_made="attempted to rewrite the thesis",

--- a/backend/agents/investment_team/tests/test_strategy_validator.py
+++ b/backend/agents/investment_team/tests/test_strategy_validator.py
@@ -19,7 +19,7 @@ from investment_team.strategy_lab.spec_dsl import (
     IndicatorRef,
     Predicate,
     SignalExitRule,
-    TimeStopRule,
+    StopLossRule,
 )
 
 
@@ -157,7 +157,7 @@ def test_hypothesis_term_missing_from_rules_emits_warning() -> None:
                 ),
             ),
         ],
-        exit_=[TimeStopRule(n_bars=5)],
+        exit_=[StopLossRule(pct=0.03)],
     )
     results = StrategySpecValidator().validate(spec)
     warnings = _warnings(results)
@@ -224,7 +224,7 @@ def test_no_recognised_terms_emits_no_consistency_warning() -> None:
                 when=Predicate(lhs="bar.close", op=">", rhs=0),
             ),
         ],
-        exit_=[TimeStopRule(n_bars=5)],
+        exit_=[StopLossRule(pct=0.03)],
     )
     results = StrategySpecValidator().validate(spec)
     warnings = _warnings(results)
@@ -241,7 +241,7 @@ def test_word_boundary_prevents_thematic_matching_ema() -> None:
                 when=Predicate(lhs="bar.close", op=">", rhs=0),
             ),
         ],
-        exit_=[TimeStopRule(n_bars=5)],
+        exit_=[StopLossRule(pct=0.03)],
     )
     results = StrategySpecValidator().validate(spec)
     warnings = _warnings(results)
@@ -273,7 +273,7 @@ def _spec_with_unparsed(
                 ),
             ),
         ],
-        exit_=[TimeStopRule(n_bars=5)],
+        exit_=[StopLossRule(pct=0.03)],
         asset_class=asset_class,
     ).model_copy(update={"unparsed_rules": unparsed_rules, "requires_redesign": True})
 
@@ -331,7 +331,7 @@ def test_hypothesis_consistency_scans_unparsed_rules() -> None:
                 ),
             ),
         ],
-        exit_=[TimeStopRule(n_bars=5)],
+        exit_=[StopLossRule(pct=0.03)],
     ).model_copy(update={"unparsed_rules": ["exit when rsi(14) > 70"], "requires_redesign": True})
     results = StrategySpecValidator().validate(spec)
     warnings = _warnings(results)

--- a/backend/agents/investment_team/trading_service/engine/fill_simulator.py
+++ b/backend/agents/investment_team/trading_service/engine/fill_simulator.py
@@ -1073,6 +1073,12 @@ class FillSimulator:
             participation_clipped=pos.participation_clipped,
             partial_fill_count=pos.partial_fill_count,
             total_unfilled_qty=pos.total_unfilled_qty,
+            # Issue #527 — propagate the close ``OrderRequest.reason``
+            # onto the trade record so the conformance gate can tell
+            # engine-fired closes (``engine_exit:<kind>``) from
+            # strategy-emitted closes. ``po.request.reason`` is None /
+            # empty for vanilla strategy market exits.
+            exit_reason=po.request.reason or None,
         )
         return exit_fill, record
 

--- a/backend/agents/investment_team/trading_service/modes/backtest.py
+++ b/backend/agents/investment_team/trading_service/modes/backtest.py
@@ -177,6 +177,12 @@ def run_backtest(
             # land only on the baseline ``service_result`` via the
             # capture_fingerprint code path.
             coverage_probe_mode=coverage_probe_mode,
+            # Issue #527 — pass the spec's structured exit rules to the
+            # engine so the per-bar loop emits time-stop / stop-loss /
+            # take-profit closes regardless of what ``strategy_code``
+            # does. Empty list (no rules in spec) preserves the legacy
+            # strategy-code-only path.
+            exit_rules=list(strategy.exit_rules),
         )
         outcome = service.run(stream)
         run_metrics = compute_metrics(

--- a/backend/agents/investment_team/trading_service/modes/paper_trade.py
+++ b/backend/agents/investment_team/trading_service/modes/paper_trade.py
@@ -235,9 +235,9 @@ def run_paper_trade(
         # mode regardless of ``BAR_CHUNK_SIZE``.
         bar_chunk_size=1,
         # Issue #527 — engine-enforce structured exit rules in paper mode
-        # too, so a spec with ``TimeStopRule`` / ``StopLossRule`` /
-        # ``TakeProfitRule`` doesn't leak open positions when
-        # ``strategy_code`` is purely entry-driven. Empty list is a no-op.
+        # too, so a spec with ``StopLossRule`` / ``TakeProfitRule`` doesn't
+        # leak open positions when ``strategy_code`` is purely entry-driven.
+        # Empty list is a no-op.
         exit_rules=list(strategy.exit_rules),
     )
 

--- a/backend/agents/investment_team/trading_service/modes/paper_trade.py
+++ b/backend/agents/investment_team/trading_service/modes/paper_trade.py
@@ -234,6 +234,11 @@ def run_paper_trade(
         # would corrupt decision-time portfolio reads. Pin to per-bar
         # mode regardless of ``BAR_CHUNK_SIZE``.
         bar_chunk_size=1,
+        # Issue #527 — engine-enforce structured exit rules in paper mode
+        # too, so a spec with ``TimeStopRule`` / ``StopLossRule`` /
+        # ``TakeProfitRule`` doesn't leak open positions when
+        # ``strategy_code`` is purely entry-driven. Empty list is a no-op.
+        exit_rules=list(strategy.exit_rules),
     )
 
     # First attempt: primary provider.

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -1324,31 +1324,30 @@ class TradingService:
         """Evaluate ``self._exit_rules`` against the current bar and emit
         synthetic close orders for any triggered rule.
 
-        Dedup rules of thumb:
-        * Sum the strategy's same-bar opposite-side **market** qty in
-          ``pending_for_prev`` for this symbol. Limit / stop / trailing
-          orders are NOT counted — they aren't guaranteed to fill on the
-          next bar, so treating them as "covering" would let a strategy
-          dodge engine enforcement with a price-far-from-market limit
-          order that never fills. The engine's structured rule fires
-          regardless and the strategy's separate limit hangs out on the
-          book until it triggers (or expires).
-        * Sum any in-flight engine-emitted market exits on the order book
-          the same way; if those already cover the open qty, no new
-          emission. Engine exits are always market, so the same
-          guaranteed-fill assumption applies.
-        * Partial coverage emits an engine close sized at
-          ``pos.qty - covered_qty`` rather than skipping entirely, so a
-          1-share decoration order can't suppress a structured rule on
-          the remaining qty.
+        Dedup model: the engine always emits at the position's full open
+        qty and lets the fill simulator + the position-identity binding
+        handle the rest. Specifically:
+
+        * Engine orders carry ``working_against_entry_order_id`` via
+          ``engine_exit_bindings`` (see the bar-loop submit step). If a
+          same-bar strategy order closes the position first on the next
+          bar, the fill simulator's stale-continuation guard drops the
+          engine close before it falls through to ``_fill_entry``.
+        * If the strategy's same-bar order is partial / clipped (FOK
+          rejection, IOC drop, participation cap, REQUEUE_NEXT_BAR
+          residual), the engine close sits behind it in submission order
+          and ``_fill_exit`` clips ``req.qty`` to ``existing_pos.qty`` —
+          residual exposure gets closed on the same bar rather than
+          waiting for the rule to fire again.
+        * The one explicit guard is on in-flight engine markets: if a
+          prior bar's engine exit is still pending (e.g. REQUEUE residual
+          across bars), skip re-emission so the order book doesn't
+          accumulate redundant engine markets while bars_held keeps
+          growing.
 
         Engine-emitted orders carry ``reason="engine_exit:<rule_kind>"`` so
         the conformance gate can count them off the order-lifecycle event
-        stream. The engine binds each emission to the targeted Position's
-        ``entry_order_id`` via ``engine_exit_bindings`` so the fill
-        simulator's stale-continuation guard drops the close when a prior
-        strategy exit closes the position first. Returns the updated
-        ``engine_order_seq``.
+        stream. Returns the updated ``engine_order_seq``.
         """
         sym = cur_bar.symbol
         if sym not in position_tracker:
@@ -1360,18 +1359,10 @@ class TradingService:
         tracked = position_tracker[sym]
         tracked_side: str = tracked.side
 
-        # Compute already-covered close qty from (a) the strategy's
-        # same-bar opposite-side **market** orders and (b) in-flight
-        # engine market exits on the order book. Non-market orders aren't
-        # guaranteed to fill on the next bar, so they don't count as
-        # coverage and the engine emits its market close regardless.
-        covered_qty = 0.0
-        for req in pending_for_prev:
-            if req.symbol != sym or req.order_type != OrderType.MARKET:
-                continue
-            req_side = "long" if req.side == OrderSide.LONG else "short"
-            if req_side != tracked_side:
-                covered_qty += req.qty
+        # Skip if a prior bar's engine market exit is still pending on the
+        # book — it will fire when the fill simulator can fill it, and we
+        # don't want to stack redundant engine markets while bars_held
+        # keeps growing across bars.
         for po in order_book.pending_for_symbol(sym):
             po_req = po.request
             if po_req.order_type != OrderType.MARKET:
@@ -1380,10 +1371,7 @@ class TradingService:
             if po_side != tracked_side and (po_req.reason or "").startswith(
                 ENGINE_EXIT_REASON_PREFIX
             ):
-                covered_qty += po_req.qty
-        if covered_qty >= pos.qty:
-            return engine_order_seq
-        engine_close_qty = pos.qty - covered_qty
+                return engine_order_seq
 
         snapshot = tracked.snapshot(sym, pos.qty)
         bar_snap = BarSnapshot(high=cur_bar.high, low=cur_bar.low, close=cur_bar.close)
@@ -1404,7 +1392,7 @@ class TradingService:
                 client_order_id=f"e{engine_order_seq}",
                 symbol=intent.symbol,
                 side=close_side,
-                qty=engine_close_qty,
+                qty=pos.qty,
                 order_type=OrderType.MARKET,
                 tif=TimeInForce.DAY,
                 reason=f"{ENGINE_EXIT_REASON_PREFIX}{intent.rule_kind}",

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -185,7 +185,21 @@ class _EngineExitDispatcher:
         if intent is None:
             return
 
-        req = self._build_close_order(intent, tracked, pos)
+        # Issue #527 — size the close to cover same-bar scale-ins. A
+        # same-side strategy order queued in ``pending_for_prev`` will
+        # submit BEFORE the engine close on the next bar and grow
+        # ``pos.qty`` past the snapshot the engine saw at emission
+        # time. ``_fill_exit`` clips the engine close at
+        # ``min(req.qty, existing_pos.qty)``, so without this we'd
+        # leave the scale-in residual exposure open even though the
+        # structured exit rule already fired. Sum the same-side queued
+        # qtys and oversize the engine close accordingly; if any
+        # scale-in is rejected / clipped at fill time the engine close
+        # clips back down to the actual ``existing_pos.qty`` — no
+        # over-close risk.
+        scale_in_qty = self._sum_same_side_queued(sym, tracked.side, pending_for_prev)
+
+        req = self._build_close_order(intent, tracked, pos, scale_in_qty)
         if req is None:
             return
 
@@ -255,14 +269,39 @@ class _EngineExitDispatcher:
         intents = evaluate_exit_rules(self.exit_rules, {sym: snapshot}, {sym: bar_snap})
         return intents[0] if intents else None
 
+    @staticmethod
+    def _sum_same_side_queued(
+        sym: str,
+        tracked_side: str,
+        pending_for_prev: List[OrderRequest],
+    ) -> float:
+        """Sum the qty of same-side strategy orders queued for the
+        same symbol — i.e. scale-ins the strategy submitted on this
+        bar that will fill on the next bar before the engine close.
+        """
+        total = 0.0
+        for queued in pending_for_prev:
+            if queued.symbol != sym:
+                continue
+            queued_side = "long" if queued.side == OrderSide.LONG else "short"
+            if queued_side != tracked_side:
+                continue
+            total += queued.qty
+        return total
+
     def _build_close_order(
         self,
         intent: ExitIntent,
         tracked: _TrackedPosition,
         pos: Position,
+        scale_in_qty: float = 0.0,
     ) -> Optional[OrderRequest]:
         """Construct + validate the engine's market close. Returns
         ``None`` on validation failure (logged, run continues).
+
+        ``scale_in_qty`` is added to ``pos.qty`` so any same-side
+        same-bar strategy order that grows the position next bar is
+        also closed by this emission (see ``_sum_same_side_queued``).
         """
         self._next_seq += 1
         close_side = OrderSide.SHORT if tracked.side == "long" else OrderSide.LONG
@@ -270,7 +309,7 @@ class _EngineExitDispatcher:
             client_order_id=f"e{self._next_seq}",
             symbol=intent.symbol,
             side=close_side,
-            qty=pos.qty,
+            qty=pos.qty + scale_in_qty,
             order_type=OrderType.MARKET,
             tif=TimeInForce.DAY,
             reason=f"{ENGINE_EXIT_REASON_PREFIX}{intent.rule_kind}",
@@ -1208,6 +1247,15 @@ class TradingService:
                         result=result,
                     )
 
+                    # Issue #527 — extend trailing watermarks AFTER rule
+                    # evaluation so the next bar's eval has cur_bar's
+                    # extreme baked in, but THIS bar's eval did not see
+                    # ``cur_bar.high`` raise the trailing floor and then
+                    # trigger off ``cur_bar.low`` (intrabar lookahead).
+                    # No-op when the spec has no exit rules.
+                    if self._exit_rules:
+                        self._extend_watermarks(tracker=position_tracker, cur_bar=cur_bar)
+
                     prev_bar = cur_bar
 
                 # End-of-stream: any orders still queued for "next bar" are
@@ -1583,12 +1631,26 @@ class TradingService:
     ) -> None:
         """Reconcile ``tracker`` against ``portfolio.positions`` for one symbol.
 
-        Called after fills are processed each bar. Refreshes
-        ``entry_price`` (for scaled-in positions) and extends trailing
-        high/low watermarks against the bar. When the underlying
-        ``Position`` is replaced (different ``entry_order_id``), the
-        tracker resets so a stale trailing watermark can't fire a rule
-        on a brand-new trade.
+        Called BEFORE rule evaluation each bar. Handles:
+
+        * Fresh-entry tracker creation (with watermarks initialised at
+          ``entry_price`` regardless of market vs limit entry — see the
+          ``_extend_watermarks`` docstring for why the entry bar's
+          high/low is NOT included here).
+        * Identity reset on same-bar exit + re-entry (different
+          ``entry_order_id``).
+        * ``entry_price`` refresh on scale-ins (partial-fill
+          continuation where ``Portfolio.extend`` updates the weighted-
+          average entry).
+        * ``just_opened`` flip from ``True`` to ``False`` on the first
+          carry-over bar.
+
+        Watermark extension is deliberately split off into
+        :meth:`_extend_watermarks` so trailing-stop rules don't see
+        the current bar's high/low while evaluating against the same
+        bar's high/low (would be intrabar lookahead — a long could
+        use ``cur_bar.high`` to raise the trailing floor and then
+        trigger off ``cur_bar.low`` even if the low printed first).
         """
         sym = cur_bar.symbol
         pos = portfolio.positions.get(sym)
@@ -1598,58 +1660,74 @@ class TradingService:
             return
         existing = tracker.get(sym)
         if existing is not None and existing.entry_order_id == pos.entry_order_id:
-            # When a partial entry scales in (REQUEUE_NEXT_BAR / TWAP_N),
-            # ``Portfolio.extend`` updates ``pos.entry_price`` to the new
-            # weighted-average entry. Mirror that here so
-            # ``StopLossRule(basis="entry_price")`` and ``TakeProfitRule``
-            # evaluate against the position's current basis rather than
-            # the first slice's price.
+            # Scale-in refresh: ``Portfolio.extend`` updates
+            # ``pos.entry_price`` to the new weighted-average entry on
+            # ``REQUEUE_NEXT_BAR`` / ``TWAP_N`` continuations. Mirror
+            # that here so ``StopLossRule(basis="entry_price")`` and
+            # ``TakeProfitRule`` evaluate against the position's current
+            # basis rather than the first slice's price.
             existing.entry_price = pos.entry_price
-            # First carry-over bar — the position has now seen a full bar
-            # of post-entry price action and rule evaluation can use the
-            # bar's high/low.
+            # First carry-over bar — the position has now seen a full
+            # bar of post-entry price action. Rule evaluation may use
+            # whatever watermark extension the prior bar's
+            # ``_extend_watermarks`` step produced.
             existing.just_opened = False
-            if cur_bar.high > existing.high_since_entry:
-                existing.high_since_entry = cur_bar.high
-            if cur_bar.low < existing.low_since_entry:
-                existing.low_since_entry = cur_bar.low
         else:
-            # Fresh entry this bar — either truly first entry, or a same-bar
-            # exit + re-entry replaced the prior position (different
-            # ``entry_order_id``). Two paths:
+            # Fresh entry this bar — either truly first entry, or a
+            # same-bar exit + re-entry replaced the prior position
+            # (different ``entry_order_id``).
             #
-            # * **Market entry** — filled at the bar's open, so the bar's
-            #   full high/low is post-entry price action. Initialise
-            #   watermarks from the bar and let rule evaluation run on
-            #   this bar; a stop-loss / take-profit that trips through
-            #   the bar's range is a real same-bar exit and must be
-            #   captured (otherwise a long opened at the open can trade
-            #   through its stop and recover with no engine emission).
-            # * **Non-market entry** (limit / stop / trailing-stop /
-            #   anything else) — the fill could have landed anywhere
-            #   inside the bar, so the bar's pre-fill price action is
-            #   ambiguous. Initialise watermarks at ``entry_price`` and
-            #   gate rule evaluation off the entry bar with
-            #   ``just_opened=True`` so pre-entry extremes can't queue
-            #   impossible same-bar closes. The next bar's tracker
-            #   update clears the flag.
-            is_market_entry = pos.entry_order_type == "market"
-            if is_market_entry:
-                high_init = cur_bar.high
-                low_init = cur_bar.low
-                just_opened = False
-            else:
-                high_init = pos.entry_price
-                low_init = pos.entry_price
-                just_opened = True
+            # Watermarks initialise at ``entry_price`` for BOTH market
+            # and non-market fills. Including the entry bar's high/low
+            # here would create intrabar lookahead for trailing stops
+            # (today's high raises the floor, today's low triggers it,
+            # regardless of which printed first). Non-market entries
+            # additionally set ``just_opened=True`` so rule evaluation
+            # is skipped entirely on the entry bar (the bar's pre-fill
+            # price action is ambiguous). Market entries leave
+            # ``just_opened=False`` so an entry_price stop-loss or
+            # take-profit can fire same-bar from ``bar.high`` / ``bar.low``
+            # against ``entry_price`` (the watermark isn't consulted
+            # for those rule kinds).
+            just_opened = pos.entry_order_type != "market"
             tracker[sym] = _TrackedPosition(
                 side=("long" if pos.side == OrderSide.LONG else "short"),
                 entry_price=pos.entry_price,
                 entry_order_id=pos.entry_order_id,
                 just_opened=just_opened,
-                high_since_entry=high_init,
-                low_since_entry=low_init,
+                high_since_entry=pos.entry_price,
+                low_since_entry=pos.entry_price,
             )
+
+    @staticmethod
+    def _extend_watermarks(
+        *,
+        tracker: Dict[str, _TrackedPosition],
+        cur_bar,
+    ) -> None:
+        """Extend ``high_since_entry`` / ``low_since_entry`` for the
+        current bar's symbol AFTER rule evaluation.
+
+        Why a separate call: ``_update_position_tracker`` runs before
+        :meth:`_EngineExitDispatcher.maybe_emit` so the tracker
+        reflects the current bar's fills + ``entry_price`` /
+        ``just_opened`` state. Watermark extension is deferred to
+        after rule evaluation so trailing-stop rules see only the
+        watermark "as of the prior bar" — they can't fire from a
+        floor that just moved up on the same bar's high.
+
+        The next bar's evaluation reads the now-extended watermark,
+        which is the intended trailing-stop semantics (track every
+        prior bar's extreme since entry).
+        """
+        sym = cur_bar.symbol
+        state = tracker.get(sym)
+        if state is None:
+            return
+        if cur_bar.high > state.high_since_entry:
+            state.high_since_entry = cur_bar.high
+        if cur_bar.low < state.low_since_entry:
+            state.low_since_entry = cur_bar.low
 
     # ------------------------------------------------------------------
 

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -188,19 +188,24 @@ class _EngineExitDispatcher:
         if intent is None:
             return
 
-        # Issue #527 — size the close to cover same-bar scale-ins. A
-        # same-side strategy order queued in ``pending_for_prev`` will
-        # submit BEFORE the engine close on the next bar and grow
-        # ``pos.qty`` past the snapshot the engine saw at emission
-        # time. ``_fill_exit`` clips the engine close at
-        # ``min(req.qty, existing_pos.qty)``, so without this we'd
-        # leave the scale-in residual exposure open even though the
-        # structured exit rule already fired. Sum the same-side queued
-        # qtys and oversize the engine close accordingly; if any
-        # scale-in is rejected / clipped at fill time the engine close
-        # clips back down to the actual ``existing_pos.qty`` — no
-        # over-close risk.
-        scale_in_qty = self._sum_same_side_queued(sym, tracked.side, pending_for_prev)
+        # Issue #527 — size the close to cover any same-side scale-in
+        # that could grow ``pos.qty`` past the snapshot the engine saw
+        # at emission. Two sources, both BEFORE the engine close on the
+        # next bar:
+        #   * Same-bar queued in ``pending_for_prev`` — strategy order
+        #     submitted on this bar; submits first next bar.
+        #   * Already resting on the order book — a GTC/limit scale-in
+        #     from a prior bar that's still working; could fill
+        #     alongside ``pending_for_prev`` next bar.
+        # ``_fill_exit`` clips the engine close at
+        # ``min(req.qty, existing_pos.qty)``, so without this oversize
+        # the residual exposure stays open even though the structured
+        # exit rule already fired. If any scale-in is rejected /
+        # clipped at fill time the engine close clips back down to the
+        # actual ``existing_pos.qty`` — no over-close risk.
+        scale_in_qty = self._sum_same_side_queued(
+            sym, tracked.side, pending_for_prev
+        ) + self._sum_same_side_resting(sym, tracked.side, order_book)
 
         req = self._build_close_order(intent, tracked, pos, scale_in_qty)
         if req is None:
@@ -288,6 +293,42 @@ class _EngineExitDispatcher:
             if queued.side != tracked_side:
                 continue
             total += queued.qty
+        return total
+
+    @staticmethod
+    def _sum_same_side_resting(
+        sym: str,
+        tracked_side: OrderSide,
+        order_book: OrderBook,
+    ) -> float:
+        """Sum the unfilled qty of same-side orders already resting
+        on the book — i.e. scale-ins the strategy submitted on a
+        prior bar that are still working and could fill on the next
+        bar alongside the engine close (e.g. GTC limits at a deeper
+        price).
+
+        Mirrors :meth:`_sum_same_side_queued` but for the resting
+        side of the world. The two are summed at the call site and
+        passed to :meth:`_build_close_order` as ``scale_in_qty``.
+
+        Excludes already-bound orders — those will be retired by the
+        stale-continuation guard once the engine close fills, so they
+        won't add to the position. ``cumulative_filled_qty`` is
+        subtracted off the unfilled portion: a partially filled
+        scale-in's already-filled qty is already accounted for in
+        ``pos.qty``.
+        """
+        total = 0.0
+        for po in order_book.pending_for_symbol(sym):
+            req = po.request
+            if req.side != tracked_side:
+                continue
+            if po.working_against_entry_order_id is not None:
+                continue
+            remaining = req.qty - po.cumulative_filled_qty
+            if remaining <= 0:
+                continue
+            total += remaining
         return total
 
     def _build_close_order(
@@ -1734,10 +1775,22 @@ class TradingService:
         The next bar's evaluation reads the now-extended watermark,
         which is the intended trailing-stop semantics (track every
         prior bar's extreme since entry).
+
+        ``just_opened=True`` (non-market entry) skips extension on
+        the entry bar: a limit / stop fill that landed mid-bar shares
+        OHLC with pre-entry price action — including the entry bar's
+        high / low here would let a pre-entry intrabar spike define
+        the trailing watermark and trigger a trailing-high stop on
+        the next bar from price action that happened before the
+        position existed. The tradeoff is losing the entry bar's
+        post-fill range; that's the safer side of the unknowable
+        intrabar fill location.
         """
         sym = cur_bar.symbol
         state = tracker.get(sym)
         if state is None:
+            return
+        if state.just_opened:
             return
         if cur_bar.high > state.high_since_entry:
             state.high_since_entry = cur_bar.high

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -16,7 +16,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from datetime import date as date_cls
-from typing import Any, Callable, Dict, Iterable, List, Optional
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Sequence
 
 import numpy as np
 
@@ -31,6 +31,7 @@ from ..models import (
 )
 from ..strategy_lab.executor.rule_compiler import (
     BarSnapshot,
+    ExitIntent,
     PositionState,
     evaluate_exit_rules,
 )
@@ -39,7 +40,7 @@ from .data_stream.protocol import BarEvent, EndOfStreamEvent, StreamEvent
 from .engine.execution_model import build_execution_model
 from .engine.fill_simulator import FillOutcome, FillSimulator, FillSimulatorConfig
 from .engine.order_book import OrderBook
-from .engine.portfolio import Portfolio
+from .engine.portfolio import Portfolio, Position
 from .strategy.contract import (
     OrderRequest,
     OrderSide,
@@ -78,7 +79,7 @@ class _TrackedPosition:
     brand-new trade.
 
     ``just_opened`` is ``True`` on the bar a position first appears.
-    :meth:`TradingService._maybe_emit_engine_exits` skips rule evaluation
+    :meth:`_EngineExitDispatcher.maybe_emit` skips rule evaluation
     while this flag is set so the entry bar's pre-fill price action (a
     limit fill at ``bar.low`` doesn't entitle a take-profit to fire from
     a pre-entry ``bar.high``) can't queue impossible close orders. The
@@ -100,6 +101,309 @@ class _TrackedPosition:
             entry_price=self.entry_price,
             high_since_entry=self.high_since_entry,
             low_since_entry=self.low_since_entry,
+        )
+
+
+@dataclass
+class _EngineExitDispatcher:
+    """Per-run owner of engine-side ``exit_rules`` enforcement.
+
+    Splits the per-bar engine-side enforcement loop into one method
+    per concern so each can be tested and extended in isolation. Holds
+    the run-scoped state that used to be threaded through helper
+    keyword arguments:
+
+    * ``exit_rules`` — the spec's structured close conditions (immutable
+      across the run).
+    * ``engine_exit_bindings`` — ``client_order_id → entry_order_id``
+      bindings consumed by the bar-loop submit step to stamp
+      ``working_against_entry_order_id`` on the resulting
+      ``PendingOrder``. Same map covers engine emissions and same-bar
+      piggybacked strategy orders.
+    * ``_next_seq`` — monotonic counter for engine-issued
+      ``client_order_id``\\ s. Strategy ids are emitted client-side; engine
+      ids must not collide, hence the ``e`` prefix vs the strategy's
+      ``c`` prefix.
+
+    Empty ``exit_rules`` makes :meth:`maybe_emit` a no-op.
+    """
+
+    exit_rules: Sequence[ExitRule]
+    engine_exit_bindings: Dict[str, str] = field(default_factory=dict)
+    _next_seq: int = 0
+
+    # ------------------------------------------------------------------
+
+    def maybe_emit(
+        self,
+        *,
+        cur_bar,
+        position_tracker: Mapping[str, _TrackedPosition],
+        portfolio: Portfolio,
+        pending_for_prev: List[OrderRequest],
+        order_book: OrderBook,
+        result: "TradingServiceResult",
+    ) -> None:
+        """Top-level entry point — call once per bar after strategy orders
+        have been queued into ``pending_for_prev``.
+
+        Dedup model: the engine always emits at the position's full open
+        qty and lets the fill simulator + the position-identity binding
+        handle the rest. Specifically:
+
+        * Engine orders carry ``working_against_entry_order_id`` via
+          ``engine_exit_bindings``. If a same-bar strategy order closes
+          the position first on the next bar, the fill simulator's
+          stale-continuation guard drops the engine close before it
+          falls through to ``_fill_entry``.
+        * If the strategy's same-bar order is partial / clipped (FOK
+          rejection, IOC drop, participation cap, REQUEUE_NEXT_BAR
+          residual), the engine close sits behind it in submission order
+          and ``_fill_exit`` clips ``req.qty`` to ``existing_pos.qty`` —
+          residual exposure gets closed on the same bar rather than
+          waiting for the rule to fire again.
+        * The one explicit guard is on in-flight engine markets: if a
+          prior bar's engine exit is still pending (e.g. REQUEUE
+          residual across bars), skip re-emission so the order book
+          doesn't accumulate redundant engine markets while the rule
+          keeps re-triggering.
+
+        Engine-emitted orders carry ``reason="engine_exit:<rule_kind>"``
+        so the conformance gate can count them off the
+        order-lifecycle event stream.
+        """
+        if not self.exit_rules:
+            return
+
+        sym = cur_bar.symbol
+        gating = self._should_evaluate(sym, position_tracker, portfolio, order_book)
+        if gating is None:
+            return
+        tracked, pos = gating
+
+        intent = self._evaluate(sym, tracked, pos, cur_bar)
+        if intent is None:
+            return
+
+        req = self._build_close_order(intent, tracked, pos)
+        if req is None:
+            return
+
+        pending_for_prev.append(req)
+        self._register_binding(req, pos)
+        self._retire_competing_resting_orders(sym, tracked.side, pos, order_book)
+        self._bind_same_bar_queued_exits(sym, tracked.side, pos, pending_for_prev)
+        self._cancel_pending_entry_continuations(sym, pos, order_book)
+        self._record_emission(req, intent, cur_bar, result)
+
+    # ------------------------------------------------------------------
+    # Sub-steps. Kept as private methods so subclasses or sibling unit
+    # tests can override / poke at a single concern.
+    # ------------------------------------------------------------------
+
+    def _should_evaluate(
+        self,
+        sym: str,
+        position_tracker: Mapping[str, _TrackedPosition],
+        portfolio: Portfolio,
+        order_book: OrderBook,
+    ) -> Optional[tuple[_TrackedPosition, Position]]:
+        """Return ``(tracked, pos)`` if rule evaluation should run for
+        this symbol on this bar, else ``None``.
+
+        Gates:
+        * Tracker has the symbol (a position is open).
+        * Portfolio agrees and has positive qty.
+        * ``tracked.just_opened`` is False — skip the entry bar for
+          non-market fills (see ``_update_position_tracker``).
+        * No in-flight engine market exit already pending on the
+          order book (avoid stacking redundant engine markets across
+          bars while the rule keeps re-triggering).
+        """
+        if sym not in position_tracker:
+            return None
+        pos = portfolio.positions.get(sym)
+        if pos is None or pos.qty <= 0:
+            return None
+        tracked = position_tracker[sym]
+        if tracked.just_opened:
+            return None
+        for po in order_book.pending_for_symbol(sym):
+            po_req = po.request
+            if po_req.order_type != OrderType.MARKET:
+                continue
+            po_side = "long" if po_req.side == OrderSide.LONG else "short"
+            if po_side != tracked.side and (po_req.reason or "").startswith(
+                ENGINE_EXIT_REASON_PREFIX
+            ):
+                return None
+        return tracked, pos
+
+    def _evaluate(
+        self,
+        sym: str,
+        tracked: _TrackedPosition,
+        pos: Position,
+        cur_bar,
+    ) -> Optional[ExitIntent]:
+        """Run the pure rule evaluator. Returns at most one intent per
+        symbol — :func:`evaluate_exit_rules` stops at the first
+        triggered rule per position.
+        """
+        snapshot = tracked.snapshot(sym, pos.qty)
+        bar_snap = BarSnapshot(high=cur_bar.high, low=cur_bar.low, close=cur_bar.close)
+        intents = evaluate_exit_rules(self.exit_rules, {sym: snapshot}, {sym: bar_snap})
+        return intents[0] if intents else None
+
+    def _build_close_order(
+        self,
+        intent: ExitIntent,
+        tracked: _TrackedPosition,
+        pos: Position,
+    ) -> Optional[OrderRequest]:
+        """Construct + validate the engine's market close. Returns
+        ``None`` on validation failure (logged, run continues).
+        """
+        self._next_seq += 1
+        close_side = OrderSide.SHORT if tracked.side == "long" else OrderSide.LONG
+        req = OrderRequest(
+            client_order_id=f"e{self._next_seq}",
+            symbol=intent.symbol,
+            side=close_side,
+            qty=pos.qty,
+            order_type=OrderType.MARKET,
+            tif=TimeInForce.DAY,
+            reason=f"{ENGINE_EXIT_REASON_PREFIX}{intent.rule_kind}",
+        )
+        try:
+            req.validate_prices()
+        except Exception as exc:  # pragma: no cover — engine-built request
+            logger.error(
+                "engine-issued exit order failed validation (rule=%s symbol=%s): %s",
+                intent.rule_kind,
+                intent.symbol,
+                exc,
+            )
+            return None
+        return req
+
+    def _register_binding(self, req: OrderRequest, pos: Position) -> None:
+        """Record the binding so the bar-loop submit step can set
+        ``working_against_entry_order_id`` on the resulting
+        ``PendingOrder``.
+        """
+        self.engine_exit_bindings[req.client_order_id] = pos.entry_order_id
+
+    def _retire_competing_resting_orders(
+        self,
+        sym: str,
+        tracked_side: str,
+        pos: Position,
+        order_book: OrderBook,
+    ) -> None:
+        """Bind any unbound opposite-side resting orders to the position
+        so they retire when the engine close removes the position.
+
+        Without this, an unbound GTC/limit strategy exit
+        (``cumulative_filled_qty==0`` AND
+        ``working_against_entry_order_id is None``) would survive the
+        engine close and, on a later trigger, fall through to
+        ``_fill_entry`` (``existing_pos is None``) — opening an
+        unintended reverse position.
+
+        Carve-outs:
+        * Already-bound orders (prior engine exits, bracket children)
+          keep their binding.
+        * Same-side resting orders are scale-in intents, not closes —
+          left alone.
+        * Partially filled orders are already bound to the position via
+          ``_fill_exit``'s auto-binding.
+        """
+        for resting in order_book.pending_for_symbol(sym):
+            if resting.working_against_entry_order_id is not None:
+                continue
+            if resting.cumulative_filled_qty > 0:
+                continue
+            resting_side = "long" if resting.request.side == OrderSide.LONG else "short"
+            if resting_side == tracked_side:
+                continue
+            resting.working_against_entry_order_id = pos.entry_order_id
+
+    def _bind_same_bar_queued_exits(
+        self,
+        sym: str,
+        tracked_side: str,
+        pos: Position,
+        pending_for_prev: List[OrderRequest],
+    ) -> None:
+        """Bind same-bar opposite-side strategy orders queued in
+        ``pending_for_prev`` (not yet on the order book). Same effect
+        as :meth:`_retire_competing_resting_orders` but for orders that
+        haven't reached the book yet — the binding goes into
+        ``engine_exit_bindings`` and the submit step applies it.
+        """
+        for queued in pending_for_prev:
+            if queued.symbol != sym:
+                continue
+            if queued.client_order_id in self.engine_exit_bindings:
+                continue
+            queued_side = "long" if queued.side == OrderSide.LONG else "short"
+            if queued_side == tracked_side:
+                continue
+            self.engine_exit_bindings[queued.client_order_id] = pos.entry_order_id
+
+    def _cancel_pending_entry_continuations(
+        self,
+        sym: str,
+        pos: Position,
+        order_book: OrderBook,
+    ) -> None:
+        """Cancel any in-flight continuation of the position's entry
+        order. A partial-fill remainder (``REQUEUE_NEXT_BAR`` or
+        ``TWAP_N``) still on the book would fill on the next bar
+        before the engine's close, growing the position past what the
+        engine sized for and leaving residual exposure after
+        ``_fill_exit`` clips at ``min(req.qty, existing_pos.qty)``.
+
+        Continuations are identified by ``po.order_id ==
+        pos.entry_order_id`` (exact — the strategy can't reuse an
+        engine-issued order_id, and same-side new strategy entries
+        have different order_ids).
+        """
+        for po in order_book.pending_for_symbol(sym):
+            if po.order_id != pos.entry_order_id:
+                continue
+            if po.cumulative_filled_qty <= 0:
+                continue
+            order_book.cancel(po.order_id)
+
+    def _record_emission(
+        self,
+        req: OrderRequest,
+        intent: ExitIntent,
+        cur_bar,
+        result: "TradingServiceResult",
+    ) -> None:
+        """Bump diagnostics counters (global + per-symbol firings,
+        ``orders_emitted`` / ``exits_emitted``) and append the
+        ``OrderLifecycleEvent``.
+        """
+        diag = result.execution_diagnostics
+        diag.orders_emitted += 1
+        diag.exits_emitted += 1
+        diag.exit_rule_firings[intent.rule_kind] = (
+            diag.exit_rule_firings.get(intent.rule_kind, 0) + 1
+        )
+        sym_firings = diag.exit_rule_firings_by_symbol.setdefault(intent.symbol, {})
+        sym_firings[intent.rule_kind] = sym_firings.get(intent.rule_kind, 0) + 1
+        _record_event(
+            diag,
+            "emitted",
+            timestamp=cur_bar.timestamp,
+            symbol=intent.symbol,
+            side=req.side.value,
+            order_type=OrderType.MARKET.value,
+            reason=req.reason,
         )
 
 
@@ -507,17 +811,13 @@ class TradingService:
         # structured exit rules. Keyed by symbol; populated after each bar's
         # fills are processed. No effect when ``self._exit_rules`` is empty.
         position_tracker: Dict[str, _TrackedPosition] = {}
-        # Issue #527 — engine-issued exit orders bind to the position they
-        # close so the fill simulator's stale-continuation guard drops them
-        # when a prior strategy exit (limit/stop/GTC) closes the position
-        # first. Keyed by client_order_id; consumed when the order moves
-        # from ``pending_for_prev`` to the order book.
-        engine_exit_bindings: Dict[str, str] = {}
-        # Monotonic counter for engine-issued client_order_ids so each
-        # rule-triggered close has a distinct id. Strategy ids are emitted
-        # client-side; engine ids must not collide with them, hence the
-        # ``e`` prefix vs the strategy's ``c`` prefix.
-        engine_order_seq = 0
+        # Issue #527 — owns engine-side exit-rule enforcement for this
+        # run. Encapsulates the ``client_order_id → entry_order_id``
+        # binding map (consumed by the submit step below), the sequence
+        # counter, and the per-bar dispatch logic split across
+        # :meth:`_EngineExitDispatcher.maybe_emit` sub-steps. No-op
+        # when ``self._exit_rules`` is empty.
+        engine_exits = _EngineExitDispatcher(exit_rules=self._exit_rules)
         execution_model = build_execution_model(
             self.config.execution_model,
             participation_cap=self.config.fill_participation_cap,
@@ -728,7 +1028,9 @@ class TradingService:
                                 # GTC/limit strategy exit is resting on the book
                                 # could fall through to ``_fill_entry`` and open
                                 # a new opposite-side position.
-                                bound_entry = engine_exit_bindings.pop(req.client_order_id, None)
+                                bound_entry = engine_exits.engine_exit_bindings.pop(
+                                    req.client_order_id, None
+                                )
                                 if bound_entry is not None:
                                     submitted_po.working_against_entry_order_id = bound_entry
                                 result.execution_diagnostics.orders_accepted += 1
@@ -895,18 +1197,16 @@ class TradingService:
                     # Issue #527 — engine-side enforcement of structured
                     # ``exit_rules``. Runs after the strategy's orders are
                     # queued so we can dedupe against strategy-emitted closes
-                    # and any in-flight engine exit on the order book.
-                    if self._exit_rules:
-                        engine_order_seq = self._maybe_emit_engine_exits(
-                            cur_bar=cur_bar,
-                            position_tracker=position_tracker,
-                            portfolio=portfolio,
-                            pending_for_prev=pending_for_prev,
-                            order_book=order_book,
-                            result=result,
-                            engine_order_seq=engine_order_seq,
-                            engine_exit_bindings=engine_exit_bindings,
-                        )
+                    # and any in-flight engine exit on the order book. No-op
+                    # when the spec has no exit rules.
+                    engine_exits.maybe_emit(
+                        cur_bar=cur_bar,
+                        position_tracker=position_tracker,
+                        portfolio=portfolio,
+                        pending_for_prev=pending_for_prev,
+                        order_book=order_book,
+                        result=result,
+                    )
 
                     prev_bar = cur_bar
 
@@ -1350,198 +1650,6 @@ class TradingService:
                 high_since_entry=high_init,
                 low_since_entry=low_init,
             )
-
-    def _maybe_emit_engine_exits(
-        self,
-        *,
-        cur_bar,
-        position_tracker: Dict[str, _TrackedPosition],
-        portfolio: Portfolio,
-        pending_for_prev: List[OrderRequest],
-        order_book: OrderBook,
-        result: "TradingServiceResult",
-        engine_order_seq: int,
-        engine_exit_bindings: Dict[str, str],
-    ) -> int:
-        """Evaluate ``self._exit_rules`` against the current bar and emit
-        synthetic close orders for any triggered rule.
-
-        Dedup model: the engine always emits at the position's full open
-        qty and lets the fill simulator + the position-identity binding
-        handle the rest. Specifically:
-
-        * Engine orders carry ``working_against_entry_order_id`` via
-          ``engine_exit_bindings`` (see the bar-loop submit step). If a
-          same-bar strategy order closes the position first on the next
-          bar, the fill simulator's stale-continuation guard drops the
-          engine close before it falls through to ``_fill_entry``.
-        * If the strategy's same-bar order is partial / clipped (FOK
-          rejection, IOC drop, participation cap, REQUEUE_NEXT_BAR
-          residual), the engine close sits behind it in submission order
-          and ``_fill_exit`` clips ``req.qty`` to ``existing_pos.qty`` —
-          residual exposure gets closed on the same bar rather than
-          waiting for the rule to fire again.
-        * The one explicit guard is on in-flight engine markets: if a
-          prior bar's engine exit is still pending (e.g. REQUEUE residual
-          across bars), skip re-emission so the order book doesn't
-          accumulate redundant engine markets across bars while the rule
-          keeps re-triggering.
-
-        Engine-emitted orders carry ``reason="engine_exit:<rule_kind>"`` so
-        the conformance gate can count them off the order-lifecycle event
-        stream. Returns the updated ``engine_order_seq``.
-        """
-        sym = cur_bar.symbol
-        if sym not in position_tracker:
-            return engine_order_seq
-        pos = portfolio.positions.get(sym)
-        if pos is None or pos.qty <= 0:
-            return engine_order_seq
-
-        tracked = position_tracker[sym]
-        # Skip the entry bar: for a limit / stop fill landing mid-bar, the
-        # bar's full OHLC may include price action from before the entry
-        # filled, and rule evaluation off ``bar.high`` / ``bar.low`` could
-        # queue impossible closes (e.g. take-profit firing from a
-        # pre-entry high). The next bar's tracker update clears
-        # ``just_opened`` and rule evaluation resumes normally.
-        if tracked.just_opened:
-            return engine_order_seq
-        tracked_side: str = tracked.side
-
-        # Skip if a prior bar's engine market exit is still pending on the
-        # book — it will fire when the fill simulator can fill it, and we
-        # don't want to stack redundant engine markets across bars while
-        # the rule keeps re-triggering against the same open position.
-        for po in order_book.pending_for_symbol(sym):
-            po_req = po.request
-            if po_req.order_type != OrderType.MARKET:
-                continue
-            po_side = "long" if po_req.side == OrderSide.LONG else "short"
-            if po_side != tracked_side and (po_req.reason or "").startswith(
-                ENGINE_EXIT_REASON_PREFIX
-            ):
-                return engine_order_seq
-
-        snapshot = tracked.snapshot(sym, pos.qty)
-        bar_snap = BarSnapshot(high=cur_bar.high, low=cur_bar.low, close=cur_bar.close)
-        intents = evaluate_exit_rules(
-            self._exit_rules,
-            {sym: snapshot},
-            {sym: bar_snap},
-        )
-        if not intents:
-            return engine_order_seq
-
-        # At most one intent per symbol — ``evaluate_exit_rules`` stops at the
-        # first triggered rule per position. Defensive iteration regardless.
-        for intent in intents:
-            engine_order_seq += 1
-            close_side = OrderSide.SHORT if tracked_side == "long" else OrderSide.LONG
-            req = OrderRequest(
-                client_order_id=f"e{engine_order_seq}",
-                symbol=intent.symbol,
-                side=close_side,
-                qty=pos.qty,
-                order_type=OrderType.MARKET,
-                tif=TimeInForce.DAY,
-                reason=f"{ENGINE_EXIT_REASON_PREFIX}{intent.rule_kind}",
-            )
-            try:
-                req.validate_prices()
-            except Exception as exc:  # pragma: no cover — engine-built request
-                logger.error(
-                    "engine-issued exit order failed validation (rule=%s symbol=%s): %s",
-                    intent.rule_kind,
-                    sym,
-                    exc,
-                )
-                continue
-            pending_for_prev.append(req)
-            # Record the binding so the submit step can set
-            # ``working_against_entry_order_id`` on the resulting PendingOrder
-            # — see :meth:`_update_position_tracker` for why position
-            # identity matters and ``fill_simulator.process_bar``'s
-            # stale-continuation guard for what consumes the binding.
-            engine_exit_bindings[req.client_order_id] = pos.entry_order_id
-            # Retire any other unbound opposite-side strategy orders resting
-            # on the book for this symbol: they were intended to close the
-            # current position, and once the engine emits its own close the
-            # position is going away. Without binding them too, an
-            # unbound GTC/limit strategy exit (``cumulative_filled_qty==0``
-            # AND ``working_against_entry_order_id is None``) would survive
-            # the engine close and, when it later triggers in
-            # ``FillSimulator.process_bar``, fall through to ``_fill_entry``
-            # because ``existing_pos is None`` — opening an unintended
-            # reverse position. Binding ties them to the position's
-            # ``entry_order_id`` so the same stale-continuation guard drops
-            # them when the engine close removes the position.
-            for resting in order_book.pending_for_symbol(sym):
-                if resting.working_against_entry_order_id is not None:
-                    continue
-                if resting.cumulative_filled_qty > 0:
-                    continue
-                resting_side = "long" if resting.request.side == OrderSide.LONG else "short"
-                if resting_side == tracked_side:
-                    # Same-side resting order is an add, not a close — leave alone.
-                    continue
-                resting.working_against_entry_order_id = pos.entry_order_id
-            # Same-bar pending strategy exits live in ``pending_for_prev``,
-            # not yet on the order book — they get submitted at the top of
-            # the next bar. Without binding them here too, a strategy
-            # GTC/limit close queued on the bar the engine fires would
-            # become an unbound resting order next bar, surviving the
-            # engine's close-fill and later opening a reverse position
-            # exactly like the resting-order scenario above. Routing the
-            # binding through ``engine_exit_bindings`` so the submit step
-            # stamps ``working_against_entry_order_id`` on the resulting
-            # ``PendingOrder`` works for both engine emissions and these
-            # piggybacked strategy orders.
-            for queued in pending_for_prev:
-                if queued.symbol != sym:
-                    continue
-                if queued.client_order_id in engine_exit_bindings:
-                    continue
-                queued_side = "long" if queued.side == OrderSide.LONG else "short"
-                if queued_side == tracked_side:
-                    continue
-                engine_exit_bindings[queued.client_order_id] = pos.entry_order_id
-            result.execution_diagnostics.orders_emitted += 1
-            result.execution_diagnostics.exits_emitted += 1
-            firings = result.execution_diagnostics.exit_rule_firings
-            firings[intent.rule_kind] = firings.get(intent.rule_kind, 0) + 1
-            # Per-symbol breakdown — the conformance gate uses this so a
-            # stop_loss firing on one symbol can't mask a missed firing
-            # on another.
-            by_symbol = result.execution_diagnostics.exit_rule_firings_by_symbol
-            sym_firings = by_symbol.setdefault(intent.symbol, {})
-            sym_firings[intent.rule_kind] = sym_firings.get(intent.rule_kind, 0) + 1
-            # Cancel any in-flight continuation of the position's entry
-            # order: a partial-fill remainder (``REQUEUE_NEXT_BAR`` or
-            # ``TWAP_N``) still on the book would fill on the next bar
-            # before the engine's close, growing the position past what
-            # the engine sized for and leaving residual exposure after
-            # the close clips at ``min(req.qty, existing_pos.qty)``.
-            # Identifying continuations by ``po.order_id ==
-            # pos.entry_order_id`` is exact — the strategy can't reuse an
-            # engine-issued order_id, and same-side new entries from the
-            # strategy have different order_ids.
-            for po in order_book.pending_for_symbol(sym):
-                if po.order_id != pos.entry_order_id:
-                    continue
-                if po.cumulative_filled_qty <= 0:
-                    continue
-                order_book.cancel(po.order_id)
-            _record_event(
-                result.execution_diagnostics,
-                "emitted",
-                timestamp=cur_bar.timestamp,
-                symbol=intent.symbol,
-                side=close_side.value,
-                order_type=OrderType.MARKET.value,
-                reason=req.reason,
-            )
-        return engine_order_seq
 
     # ------------------------------------------------------------------
 

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -76,11 +76,19 @@ class _TrackedPosition:
     :meth:`TradingService._update_position_tracker` detects that and starts
     fresh, so a stale trailing watermark can't fire a rule on the
     brand-new trade.
+
+    ``just_opened`` is ``True`` on the bar a position first appears.
+    :meth:`TradingService._maybe_emit_engine_exits` skips rule evaluation
+    while this flag is set so the entry bar's pre-fill price action (a
+    limit fill at ``bar.low`` doesn't entitle a take-profit to fire from
+    a pre-entry ``bar.high``) can't queue impossible close orders. The
+    next bar's tracker update clears the flag.
     """
 
     side: str  # "long" | "short"
     entry_price: float
     entry_order_id: str
+    just_opened: bool
     high_since_entry: float
     low_since_entry: float
 
@@ -1297,6 +1305,10 @@ class TradingService:
             # evaluate against the position's current basis rather than
             # the first slice's price.
             existing.entry_price = pos.entry_price
+            # First carry-over bar — the position has now seen a full bar
+            # of post-entry price action and rule evaluation can use the
+            # bar's high/low.
+            existing.just_opened = False
             if cur_bar.high > existing.high_since_entry:
                 existing.high_since_entry = cur_bar.high
             if cur_bar.low < existing.low_since_entry:
@@ -1304,14 +1316,21 @@ class TradingService:
         else:
             # Fresh entry this bar — either truly first entry, or a same-bar
             # exit + re-entry replaced the prior position (different
-            # ``entry_order_id``). Reset watermarks so a stale trailing high
-            # doesn't fire a rule against the new trade.
+            # ``entry_order_id``). Initialise watermarks at ``entry_price``
+            # rather than the entry bar's full OHLC: for a limit / stop
+            # entry filled mid-bar, the bar's high/low may include price
+            # action from BEFORE the fill, and using it would let
+            # take-profit / trailing-stop rules queue impossible closes
+            # off pre-entry extremes. ``just_opened=True`` keeps rule
+            # evaluation off this bar entirely; the next bar extends the
+            # watermarks normally.
             tracker[sym] = _TrackedPosition(
                 side=("long" if pos.side == OrderSide.LONG else "short"),
                 entry_price=pos.entry_price,
                 entry_order_id=pos.entry_order_id,
-                high_since_entry=cur_bar.high,
-                low_since_entry=cur_bar.low,
+                just_opened=True,
+                high_since_entry=pos.entry_price,
+                low_since_entry=pos.entry_price,
             )
 
     def _maybe_emit_engine_exits(
@@ -1362,6 +1381,14 @@ class TradingService:
             return engine_order_seq
 
         tracked = position_tracker[sym]
+        # Skip the entry bar: for a limit / stop fill landing mid-bar, the
+        # bar's full OHLC may include price action from before the entry
+        # filled, and rule evaluation off ``bar.high`` / ``bar.low`` could
+        # queue impossible closes (e.g. take-profit firing from a
+        # pre-entry high). The next bar's tracker update clears
+        # ``just_opened`` and rule evaluation resumes normally.
+        if tracked.just_opened:
+            return engine_order_seq
         tracked_side: str = tracked.side
 
         # Skip if a prior bar's engine market exit is still pending on the
@@ -1441,6 +1468,26 @@ class TradingService:
                     # Same-side resting order is an add, not a close — leave alone.
                     continue
                 resting.working_against_entry_order_id = pos.entry_order_id
+            # Same-bar pending strategy exits live in ``pending_for_prev``,
+            # not yet on the order book — they get submitted at the top of
+            # the next bar. Without binding them here too, a strategy
+            # GTC/limit close queued on the bar the engine fires would
+            # become an unbound resting order next bar, surviving the
+            # engine's close-fill and later opening a reverse position
+            # exactly like the resting-order scenario above. Routing the
+            # binding through ``engine_exit_bindings`` so the submit step
+            # stamps ``working_against_entry_order_id`` on the resulting
+            # ``PendingOrder`` works for both engine emissions and these
+            # piggybacked strategy orders.
+            for queued in pending_for_prev:
+                if queued.symbol != sym:
+                    continue
+                if queued.client_order_id in engine_exit_bindings:
+                    continue
+                queued_side = "long" if queued.side == OrderSide.LONG else "short"
+                if queued_side == tracked_side:
+                    continue
+                engine_exit_bindings[queued.client_order_id] = pos.entry_order_id
             result.execution_diagnostics.orders_emitted += 1
             result.execution_diagnostics.exits_emitted += 1
             firings = result.execution_diagnostics.exit_rule_firings

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -576,21 +576,29 @@ class TradingService:
                     chunk_size,
                 )
 
+            # Issue #527 — engine-side exit-rule enforcement is wired
+            # into the per-bar path only. The chunked path delivers
+            # multiple bars per strategy round-trip; emitting synthetic
+            # closes mid-chunk would require restructuring the rule
+            # evaluator to run inside the chunk replay, which is out of
+            # scope for the MVP. Rather than crashing
+            # ``run_backtest`` for any spec with exit rules whenever
+            # ``BAR_CHUNK_SIZE`` is set globally, fall back to per-bar
+            # mode for this run with a single ``logger.warning``: the
+            # caller asked for chunking, but enforcement is the more
+            # important guarantee.
+            if use_chunked and self._exit_rules:
+                logger.warning(
+                    "BAR_CHUNK_SIZE=%d requested but TradingService.exit_rules "
+                    "is non-empty; engine-side rule enforcement requires the "
+                    "per-bar protocol — falling back to BAR_CHUNK_SIZE=1 for "
+                    "this run. Set bar_chunk_size=1 explicitly to suppress "
+                    "this warning.",
+                    chunk_size,
+                )
+                use_chunked = False
+
             if use_chunked:
-                # Issue #527 — engine-side exit-rule enforcement is wired
-                # into the per-bar path only. The chunked path delivers
-                # multiple bars per strategy round-trip; emitting synthetic
-                # closes mid-chunk would require restructuring the rule
-                # evaluator to run inside the chunk replay, which is out of
-                # scope for the MVP. Surface this as a configuration error
-                # so operators don't silently lose enforcement.
-                if self._exit_rules:
-                    raise NotImplementedError(
-                        "TradingService.exit_rules is not supported with the "
-                        "chunked-bar protocol (BAR_CHUNK_SIZE > 1). Run with "
-                        "BAR_CHUNK_SIZE=1 or pass bar_chunk_size=1 to enable "
-                        "engine-enforced exit rules."
-                    )
                 return self._run_chunked(
                     stream=stream,
                     harness=harness,

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -1257,6 +1257,13 @@ class TradingService:
         if sym in tracker:
             state = tracker[sym]
             state.bars_held += 1
+            # When a partial entry scales in (REQUEUE_NEXT_BAR / TWAP_N),
+            # ``Portfolio.extend`` updates ``pos.entry_price`` to the new
+            # weighted-average entry. Mirror that here so
+            # ``StopLossRule(basis="entry_price")`` and ``TakeProfitRule``
+            # evaluate against the position's current basis rather than
+            # the first slice's price.
+            state.entry_price = pos.entry_price
             if cur_bar.high > state.high_since_entry:
                 state.high_since_entry = cur_bar.high
             if cur_bar.low < state.low_since_entry:
@@ -1286,10 +1293,15 @@ class TradingService:
         synthetic close orders for any triggered rule.
 
         Dedup rules of thumb:
-        * Skip symbols the strategy already chose to exit this bar (an
-          opposite-side order in ``pending_for_prev``).
-        * Skip symbols with an in-flight engine-emitted exit on the order
-          book (prior bar's enforcement is still pending fill).
+        * Sum the strategy's opposite-side qty in ``pending_for_prev`` for
+          this symbol. If the strategy is fully closing the position
+          (sum >= position.qty), skip the engine emission — its close is
+          redundant. If the strategy only partially unwinds (sum <
+          position.qty), the engine emits a close for the *remaining*
+          qty so a structured rule isn't suppressed by a 1-share
+          decoration order.
+        * Sum any in-flight engine-emitted exits on the order book the
+          same way; if those already cover the open qty, no new emission.
 
         Engine-emitted orders carry ``reason="engine_exit:<rule_kind>"`` so
         the conformance gate can count them off the order-lifecycle event
@@ -1305,22 +1317,27 @@ class TradingService:
         tracked = position_tracker[sym]
         tracked_side: str = tracked.side
 
-        # Dedup: strategy already submitted an opposite-side close this bar.
+        # Compute already-covered close qty from (a) the strategy's
+        # same-bar opposite-side orders and (b) in-flight engine exits on
+        # the order book. Treat the open position as already-covered only
+        # when the sum of covers meets or exceeds the open qty.
+        covered_qty = 0.0
         for req in pending_for_prev:
             if req.symbol != sym:
                 continue
             req_side = "long" if req.side == OrderSide.LONG else "short"
             if req_side != tracked_side:
-                return engine_order_seq
-
-        # Dedup: prior bar's engine exit is still on the order book.
+                covered_qty += req.qty
         for po in order_book.pending_for_symbol(sym):
             po_req = po.request
             po_side = "long" if po_req.side == OrderSide.LONG else "short"
             if po_side != tracked_side and (po_req.reason or "").startswith(
                 ENGINE_EXIT_REASON_PREFIX
             ):
-                return engine_order_seq
+                covered_qty += po_req.qty
+        if covered_qty >= pos.qty:
+            return engine_order_seq
+        engine_close_qty = pos.qty - covered_qty
 
         snapshot = tracked.snapshot(sym, pos.qty)
         bar_snap = BarSnapshot(high=cur_bar.high, low=cur_bar.low, close=cur_bar.close)
@@ -1341,7 +1358,7 @@ class TradingService:
                 client_order_id=f"e{engine_order_seq}",
                 symbol=intent.symbol,
                 side=close_side,
-                qty=pos.qty,
+                qty=engine_close_qty,
                 order_type=OrderType.MARKET,
                 tif=TimeInForce.DAY,
                 reason=f"{ENGINE_EXIT_REASON_PREFIX}{intent.rule_kind}",

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -1510,6 +1510,28 @@ class TradingService:
             result.execution_diagnostics.exits_emitted += 1
             firings = result.execution_diagnostics.exit_rule_firings
             firings[intent.rule_kind] = firings.get(intent.rule_kind, 0) + 1
+            # Per-symbol breakdown — the conformance gate uses this so a
+            # stop_loss firing on one symbol can't mask a missed firing
+            # on another.
+            by_symbol = result.execution_diagnostics.exit_rule_firings_by_symbol
+            sym_firings = by_symbol.setdefault(intent.symbol, {})
+            sym_firings[intent.rule_kind] = sym_firings.get(intent.rule_kind, 0) + 1
+            # Cancel any in-flight continuation of the position's entry
+            # order: a partial-fill remainder (``REQUEUE_NEXT_BAR`` or
+            # ``TWAP_N``) still on the book would fill on the next bar
+            # before the engine's close, growing the position past what
+            # the engine sized for and leaving residual exposure after
+            # the close clips at ``min(req.qty, existing_pos.qty)``.
+            # Identifying continuations by ``po.order_id ==
+            # pos.entry_order_id`` is exact — the strategy can't reuse an
+            # engine-issued order_id, and same-side new entries from the
+            # strategy have different order_ids.
+            for po in order_book.pending_for_symbol(sym):
+                if po.order_id != pos.entry_order_id:
+                    continue
+                if po.cumulative_filled_qty <= 0:
+                    continue
+                order_book.cancel(po.order_id)
             _record_event(
                 result.execution_diagnostics,
                 "emitted",

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -66,7 +66,7 @@ class _TrackedPosition:
     """Per-symbol state the parent engine maintains to evaluate exit rules.
 
     Mirrors the public :class:`PositionState` shape but is mutable so the bar
-    loop can update bars-held / watermarks in place. The snapshot handed to
+    loop can update watermarks in place. The snapshot handed to
     :func:`evaluate_exit_rules` is a fresh immutable copy.
 
     ``entry_order_id`` pins the tracker to a specific :class:`Position`
@@ -74,14 +74,13 @@ class _TrackedPosition:
     position, ``portfolio.positions[sym]`` swaps to a new ``Position`` with
     a different ``entry_order_id``; the tracker reset path in
     :meth:`TradingService._update_position_tracker` detects that and starts
-    fresh, so a stale ``bars_held`` / watermark can't fire a rule on the
+    fresh, so a stale trailing watermark can't fire a rule on the
     brand-new trade.
     """
 
     side: str  # "long" | "short"
     entry_price: float
     entry_order_id: str
-    bars_held: int
     high_since_entry: float
     low_since_entry: float
 
@@ -91,7 +90,6 @@ class _TrackedPosition:
             side=self.side,  # type: ignore[arg-type]
             qty=qty,
             entry_price=self.entry_price,
-            bars_held=self.bars_held,
             high_since_entry=self.high_since_entry,
             low_since_entry=self.low_since_entry,
         )
@@ -760,9 +758,9 @@ class TradingService:
                         # portfolio. No-op when exit_rules is empty (the
                         # tracker stays empty, the rule-eval block at the
                         # bottom of the loop short-circuits). Updating here
-                        # — after fills but before send_bar — means
-                        # ``bars_held`` reflects every bar the engine has
-                        # actually seen, regardless of strategy behaviour.
+                        # — after fills but before send_bar — keeps trailing
+                        # watermarks consistent with every bar the engine
+                        # has actually seen, regardless of strategy behaviour.
                         if self._exit_rules:
                             self._update_position_tracker(
                                 tracker=position_tracker,
@@ -1269,11 +1267,12 @@ class TradingService:
     ) -> None:
         """Reconcile ``tracker`` against ``portfolio.positions`` for one symbol.
 
-        Called after fills are processed each bar. ``bars_held`` for an
-        existing tracked position counts the entry bar as bar 1 and
-        increments by one on every subsequent bar the engine sees for
-        that symbol — so ``TimeStopRule(n_bars=N)`` fires once the
-        position has been observed across at least N bars.
+        Called after fills are processed each bar. Refreshes
+        ``entry_price`` (for scaled-in positions) and extends trailing
+        high/low watermarks against the bar. When the underlying
+        ``Position`` is replaced (different ``entry_order_id``), the
+        tracker resets so a stale trailing watermark can't fire a rule
+        on a brand-new trade.
         """
         sym = cur_bar.symbol
         pos = portfolio.positions.get(sym)
@@ -1283,7 +1282,6 @@ class TradingService:
             return
         existing = tracker.get(sym)
         if existing is not None and existing.entry_order_id == pos.entry_order_id:
-            existing.bars_held += 1
             # When a partial entry scales in (REQUEUE_NEXT_BAR / TWAP_N),
             # ``Portfolio.extend`` updates ``pos.entry_price`` to the new
             # weighted-average entry. Mirror that here so
@@ -1298,13 +1296,12 @@ class TradingService:
         else:
             # Fresh entry this bar — either truly first entry, or a same-bar
             # exit + re-entry replaced the prior position (different
-            # ``entry_order_id``). Reset bars_held / watermarks so a stale
-            # trailing high doesn't fire a rule against the new trade.
+            # ``entry_order_id``). Reset watermarks so a stale trailing high
+            # doesn't fire a rule against the new trade.
             tracker[sym] = _TrackedPosition(
                 side=("long" if pos.side == OrderSide.LONG else "short"),
                 entry_price=pos.entry_price,
                 entry_order_id=pos.entry_order_id,
-                bars_held=1,
                 high_since_entry=cur_bar.high,
                 low_since_entry=cur_bar.low,
             )
@@ -1342,8 +1339,8 @@ class TradingService:
         * The one explicit guard is on in-flight engine markets: if a
           prior bar's engine exit is still pending (e.g. REQUEUE residual
           across bars), skip re-emission so the order book doesn't
-          accumulate redundant engine markets while bars_held keeps
-          growing.
+          accumulate redundant engine markets across bars while the rule
+          keeps re-triggering.
 
         Engine-emitted orders carry ``reason="engine_exit:<rule_kind>"`` so
         the conformance gate can count them off the order-lifecycle event
@@ -1361,8 +1358,8 @@ class TradingService:
 
         # Skip if a prior bar's engine market exit is still pending on the
         # book — it will fire when the fill simulator can fill it, and we
-        # don't want to stack redundant engine markets while bars_held
-        # keeps growing across bars.
+        # don't want to stack redundant engine markets across bars while
+        # the rule keeps re-triggering against the same open position.
         for po in order_book.pending_for_symbol(sym):
             po_req = po.request
             if po_req.order_type != OrderType.MARKET:

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -68,10 +68,19 @@ class _TrackedPosition:
     Mirrors the public :class:`PositionState` shape but is mutable so the bar
     loop can update bars-held / watermarks in place. The snapshot handed to
     :func:`evaluate_exit_rules` is a fresh immutable copy.
+
+    ``entry_order_id`` pins the tracker to a specific :class:`Position`
+    instance. When a same-bar exit-then-re-entry replaces the underlying
+    position, ``portfolio.positions[sym]`` swaps to a new ``Position`` with
+    a different ``entry_order_id``; the tracker reset path in
+    :meth:`TradingService._update_position_tracker` detects that and starts
+    fresh, so a stale ``bars_held`` / watermark can't fire a rule on the
+    brand-new trade.
     """
 
     side: str  # "long" | "short"
     entry_price: float
+    entry_order_id: str
     bars_held: int
     high_since_entry: float
     low_since_entry: float
@@ -492,6 +501,12 @@ class TradingService:
         # structured exit rules. Keyed by symbol; populated after each bar's
         # fills are processed. No effect when ``self._exit_rules`` is empty.
         position_tracker: Dict[str, _TrackedPosition] = {}
+        # Issue #527 — engine-issued exit orders bind to the position they
+        # close so the fill simulator's stale-continuation guard drops them
+        # when a prior strategy exit (limit/stop/GTC) closes the position
+        # first. Keyed by client_order_id; consumed when the order moves
+        # from ``pending_for_prev`` to the order book.
+        engine_exit_bindings: Dict[str, str] = {}
         # Monotonic counter for engine-issued client_order_ids so each
         # rule-triggered close has a distinct id. Strategy ids are emitted
         # client-side; engine ids must not collide with them, hence the
@@ -676,7 +691,7 @@ class TradingService:
                                 if apply_default and req.unfilled_policy is None:
                                     req.unfilled_policy = self._default_unfilled_policy
                                 equity = portfolio.mark_to_market()
-                                order_book.submit(
+                                submitted_po = order_book.submit(
                                     req,
                                     submitted_at=prev_bar.timestamp,
                                     submitted_equity=equity,
@@ -691,6 +706,17 @@ class TradingService:
                                         or req.attached_take_profit is not None
                                     ),
                                 )
+                                # Issue #527 — pin engine-emitted exits to the
+                                # Position they target so the fill simulator's
+                                # stale-continuation guard drops them when a
+                                # prior strategy exit closes the position first.
+                                # Without this, an engine_exit submitted while a
+                                # GTC/limit strategy exit is resting on the book
+                                # could fall through to ``_fill_entry`` and open
+                                # a new opposite-side position.
+                                bound_entry = engine_exit_bindings.pop(req.client_order_id, None)
+                                if bound_entry is not None:
+                                    submitted_po.working_against_entry_order_id = bound_entry
                                 result.execution_diagnostics.orders_accepted += 1
                                 _record_event(
                                     result.execution_diagnostics,
@@ -865,6 +891,7 @@ class TradingService:
                             order_book=order_book,
                             result=result,
                             engine_order_seq=engine_order_seq,
+                            engine_exit_bindings=engine_exit_bindings,
                         )
 
                     prev_bar = cur_bar
@@ -1254,25 +1281,29 @@ class TradingService:
             # Position closed this bar (or never opened) — drop tracker entry.
             tracker.pop(sym, None)
             return
-        if sym in tracker:
-            state = tracker[sym]
-            state.bars_held += 1
+        existing = tracker.get(sym)
+        if existing is not None and existing.entry_order_id == pos.entry_order_id:
+            existing.bars_held += 1
             # When a partial entry scales in (REQUEUE_NEXT_BAR / TWAP_N),
             # ``Portfolio.extend`` updates ``pos.entry_price`` to the new
             # weighted-average entry. Mirror that here so
             # ``StopLossRule(basis="entry_price")`` and ``TakeProfitRule``
             # evaluate against the position's current basis rather than
             # the first slice's price.
-            state.entry_price = pos.entry_price
-            if cur_bar.high > state.high_since_entry:
-                state.high_since_entry = cur_bar.high
-            if cur_bar.low < state.low_since_entry:
-                state.low_since_entry = cur_bar.low
+            existing.entry_price = pos.entry_price
+            if cur_bar.high > existing.high_since_entry:
+                existing.high_since_entry = cur_bar.high
+            if cur_bar.low < existing.low_since_entry:
+                existing.low_since_entry = cur_bar.low
         else:
-            # Fresh entry this bar — entry bar counts as bars_held == 1.
+            # Fresh entry this bar — either truly first entry, or a same-bar
+            # exit + re-entry replaced the prior position (different
+            # ``entry_order_id``). Reset bars_held / watermarks so a stale
+            # trailing high doesn't fire a rule against the new trade.
             tracker[sym] = _TrackedPosition(
                 side=("long" if pos.side == OrderSide.LONG else "short"),
                 entry_price=pos.entry_price,
+                entry_order_id=pos.entry_order_id,
                 bars_held=1,
                 high_since_entry=cur_bar.high,
                 low_since_entry=cur_bar.low,
@@ -1288,24 +1319,36 @@ class TradingService:
         order_book: OrderBook,
         result: "TradingServiceResult",
         engine_order_seq: int,
+        engine_exit_bindings: Dict[str, str],
     ) -> int:
         """Evaluate ``self._exit_rules`` against the current bar and emit
         synthetic close orders for any triggered rule.
 
         Dedup rules of thumb:
-        * Sum the strategy's opposite-side qty in ``pending_for_prev`` for
-          this symbol. If the strategy is fully closing the position
-          (sum >= position.qty), skip the engine emission — its close is
-          redundant. If the strategy only partially unwinds (sum <
-          position.qty), the engine emits a close for the *remaining*
-          qty so a structured rule isn't suppressed by a 1-share
-          decoration order.
-        * Sum any in-flight engine-emitted exits on the order book the
-          same way; if those already cover the open qty, no new emission.
+        * Sum the strategy's same-bar opposite-side **market** qty in
+          ``pending_for_prev`` for this symbol. Limit / stop / trailing
+          orders are NOT counted — they aren't guaranteed to fill on the
+          next bar, so treating them as "covering" would let a strategy
+          dodge engine enforcement with a price-far-from-market limit
+          order that never fills. The engine's structured rule fires
+          regardless and the strategy's separate limit hangs out on the
+          book until it triggers (or expires).
+        * Sum any in-flight engine-emitted market exits on the order book
+          the same way; if those already cover the open qty, no new
+          emission. Engine exits are always market, so the same
+          guaranteed-fill assumption applies.
+        * Partial coverage emits an engine close sized at
+          ``pos.qty - covered_qty`` rather than skipping entirely, so a
+          1-share decoration order can't suppress a structured rule on
+          the remaining qty.
 
         Engine-emitted orders carry ``reason="engine_exit:<rule_kind>"`` so
         the conformance gate can count them off the order-lifecycle event
-        stream. Returns the updated ``engine_order_seq``.
+        stream. The engine binds each emission to the targeted Position's
+        ``entry_order_id`` via ``engine_exit_bindings`` so the fill
+        simulator's stale-continuation guard drops the close when a prior
+        strategy exit closes the position first. Returns the updated
+        ``engine_order_seq``.
         """
         sym = cur_bar.symbol
         if sym not in position_tracker:
@@ -1318,18 +1361,21 @@ class TradingService:
         tracked_side: str = tracked.side
 
         # Compute already-covered close qty from (a) the strategy's
-        # same-bar opposite-side orders and (b) in-flight engine exits on
-        # the order book. Treat the open position as already-covered only
-        # when the sum of covers meets or exceeds the open qty.
+        # same-bar opposite-side **market** orders and (b) in-flight
+        # engine market exits on the order book. Non-market orders aren't
+        # guaranteed to fill on the next bar, so they don't count as
+        # coverage and the engine emits its market close regardless.
         covered_qty = 0.0
         for req in pending_for_prev:
-            if req.symbol != sym:
+            if req.symbol != sym or req.order_type != OrderType.MARKET:
                 continue
             req_side = "long" if req.side == OrderSide.LONG else "short"
             if req_side != tracked_side:
                 covered_qty += req.qty
         for po in order_book.pending_for_symbol(sym):
             po_req = po.request
+            if po_req.order_type != OrderType.MARKET:
+                continue
             po_side = "long" if po_req.side == OrderSide.LONG else "short"
             if po_side != tracked_side and (po_req.reason or "").startswith(
                 ENGINE_EXIT_REASON_PREFIX
@@ -1374,6 +1420,12 @@ class TradingService:
                 )
                 continue
             pending_for_prev.append(req)
+            # Record the binding so the submit step can set
+            # ``working_against_entry_order_id`` on the resulting PendingOrder
+            # — see :meth:`_update_position_tracker` for why position
+            # identity matters and ``fill_simulator.process_bar``'s
+            # stale-continuation guard for what consumes the binding.
+            engine_exit_bindings[req.client_order_id] = pos.entry_order_id
             result.execution_diagnostics.orders_emitted += 1
             result.execution_diagnostics.exits_emitted += 1
             firings = result.execution_diagnostics.exit_rule_firings

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -29,6 +29,12 @@ from ..models import (
     OrderLifecycleEvent,
     TradeRecord,
 )
+from ..strategy_lab.executor.rule_compiler import (
+    BarSnapshot,
+    PositionState,
+    evaluate_exit_rules,
+)
+from ..strategy_lab.spec_dsl import ExitRule
 from .data_stream.protocol import BarEvent, EndOfStreamEvent, StreamEvent
 from .engine.execution_model import build_execution_model
 from .engine.fill_simulator import FillOutcome, FillSimulator, FillSimulatorConfig
@@ -37,6 +43,8 @@ from .engine.portfolio import Portfolio
 from .strategy.contract import (
     OrderRequest,
     OrderSide,
+    OrderType,
+    TimeInForce,
     UnfilledPolicy,
     UnsupportedOrderFeatureError,
 )
@@ -45,6 +53,40 @@ from .strategy.streaming_harness import StrategyRuntimeError, StreamingHarness
 logger = logging.getLogger(__name__)
 
 _MAX_ORDER_EVENTS = 20
+
+# Issue #527 — reserved order ``reason`` prefix the engine stamps on every
+# rule-triggered close order it emits on the strategy's behalf. The conformance
+# quality gate reads this prefix off ``OrderLifecycleEvent`` records to count
+# wrapper-emitted exits and verify each trade obeyed the structured rules.
+ENGINE_EXIT_REASON_PREFIX = "engine_exit:"
+
+
+@dataclass
+class _TrackedPosition:
+    """Per-symbol state the parent engine maintains to evaluate exit rules.
+
+    Mirrors the public :class:`PositionState` shape but is mutable so the bar
+    loop can update bars-held / watermarks in place. The snapshot handed to
+    :func:`evaluate_exit_rules` is a fresh immutable copy.
+    """
+
+    side: str  # "long" | "short"
+    entry_price: float
+    bars_held: int
+    high_since_entry: float
+    low_since_entry: float
+
+    def snapshot(self, symbol: str, qty: float) -> PositionState:
+        return PositionState(
+            symbol=symbol,
+            side=self.side,  # type: ignore[arg-type]
+            qty=qty,
+            entry_price=self.entry_price,
+            bars_held=self.bars_held,
+            high_since_entry=self.high_since_entry,
+            low_since_entry=self.low_since_entry,
+        )
+
 
 # Default chunk size for the batched-bar protocol (issue #377). 1 keeps
 # byte-identical behaviour with the per-bar codepath; values >1 only take
@@ -394,6 +436,7 @@ class TradingService:
         default_unfilled_policy: UnfilledPolicy = UnfilledPolicy.DROP,
         bar_chunk_size: Optional[int] = None,
         coverage_probe_mode: bool = False,
+        exit_rules: Optional[List[ExitRule]] = None,
     ) -> None:
         self.strategy_code = strategy_code
         self.config = config
@@ -410,6 +453,10 @@ class TradingService:
             limits = RiskLimits.from_legacy_dict(risk_limits or {})
         self._risk = RiskFilter(limits)
         self._default_unfilled_policy = default_unfilled_policy
+        # Issue #527 — structured exit rules the parent engine enforces after
+        # each bar's strategy response. Empty list (or None) preserves the
+        # legacy behaviour where strategy code is the only source of exits.
+        self._exit_rules: List[ExitRule] = list(exit_rules or [])
         # Issue #377: when set, overrides ``BAR_CHUNK_SIZE`` env. Paper-trade
         # mode pins this to 1 so live-bar handling never buffers. Reject
         # zero/negative or non-int explicitly so a future caller passing
@@ -441,6 +488,15 @@ class TradingService:
         """
         portfolio = Portfolio(initial_capital=self.config.initial_capital)
         order_book = OrderBook()
+        # Issue #527 — per-position state the engine uses to evaluate
+        # structured exit rules. Keyed by symbol; populated after each bar's
+        # fills are processed. No effect when ``self._exit_rules`` is empty.
+        position_tracker: Dict[str, _TrackedPosition] = {}
+        # Monotonic counter for engine-issued client_order_ids so each
+        # rule-triggered close has a distinct id. Strategy ids are emitted
+        # client-side; engine ids must not collide with them, hence the
+        # ``e`` prefix vs the strategy's ``c`` prefix.
+        engine_order_seq = 0
         execution_model = build_execution_model(
             self.config.execution_model,
             participation_cap=self.config.fill_participation_cap,
@@ -508,6 +564,20 @@ class TradingService:
                 )
 
             if use_chunked:
+                # Issue #527 — engine-side exit-rule enforcement is wired
+                # into the per-bar path only. The chunked path delivers
+                # multiple bars per strategy round-trip; emitting synthetic
+                # closes mid-chunk would require restructuring the rule
+                # evaluator to run inside the chunk replay, which is out of
+                # scope for the MVP. Surface this as a configuration error
+                # so operators don't silently lose enforcement.
+                if self._exit_rules:
+                    raise NotImplementedError(
+                        "TradingService.exit_rules is not supported with the "
+                        "chunked-bar protocol (BAR_CHUNK_SIZE > 1). Run with "
+                        "BAR_CHUNK_SIZE=1 or pass bar_chunk_size=1 to enable "
+                        "engine-enforced exit rules."
+                    )
                 return self._run_chunked(
                     stream=stream,
                     harness=harness,
@@ -659,6 +729,21 @@ class TradingService:
                             )
                             break
 
+                        # Issue #527 — refresh engine-side per-position state
+                        # for ``cur_bar.symbol`` based on the post-fill
+                        # portfolio. No-op when exit_rules is empty (the
+                        # tracker stays empty, the rule-eval block at the
+                        # bottom of the loop short-circuits). Updating here
+                        # — after fills but before send_bar — means
+                        # ``bars_held`` reflects every bar the engine has
+                        # actually seen, regardless of strategy behaviour.
+                        if self._exit_rules:
+                            self._update_position_tracker(
+                                tracker=position_tracker,
+                                cur_bar=cur_bar,
+                                portfolio=portfolio,
+                            )
+
                     # 4) Deliver the current bar to the strategy and collect
                     #    any orders it submits in response. Warm-up bars set
                     #    ``ctx.is_warmup = True`` in the subprocess so the
@@ -766,6 +851,21 @@ class TradingService:
                                 reason="malformed_request",
                                 detail=str(exc),
                             )
+
+                    # Issue #527 — engine-side enforcement of structured
+                    # ``exit_rules``. Runs after the strategy's orders are
+                    # queued so we can dedupe against strategy-emitted closes
+                    # and any in-flight engine exit on the order book.
+                    if self._exit_rules:
+                        engine_order_seq = self._maybe_emit_engine_exits(
+                            cur_bar=cur_bar,
+                            position_tracker=position_tracker,
+                            portfolio=portfolio,
+                            pending_for_prev=pending_for_prev,
+                            order_book=order_book,
+                            result=result,
+                            engine_order_seq=engine_order_seq,
+                        )
 
                     prev_bar = cur_bar
 
@@ -1128,6 +1228,149 @@ class TradingService:
         result.streaming_equity_curve = eod_buffer.materialize()
         result.probe_events = harness.probe_events
         return _finalize_diagnostics(result)
+
+    # ------------------------------------------------------------------
+    # Issue #527 — engine-side enforcement of structured ``exit_rules``.
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _update_position_tracker(
+        *,
+        tracker: Dict[str, _TrackedPosition],
+        cur_bar,
+        portfolio: Portfolio,
+    ) -> None:
+        """Reconcile ``tracker`` against ``portfolio.positions`` for one symbol.
+
+        Called after fills are processed each bar. ``bars_held`` for an
+        existing tracked position counts the entry bar as bar 1 and
+        increments by one on every subsequent bar the engine sees for
+        that symbol — so ``TimeStopRule(n_bars=N)`` fires once the
+        position has been observed across at least N bars.
+        """
+        sym = cur_bar.symbol
+        pos = portfolio.positions.get(sym)
+        if pos is None:
+            # Position closed this bar (or never opened) — drop tracker entry.
+            tracker.pop(sym, None)
+            return
+        if sym in tracker:
+            state = tracker[sym]
+            state.bars_held += 1
+            if cur_bar.high > state.high_since_entry:
+                state.high_since_entry = cur_bar.high
+            if cur_bar.low < state.low_since_entry:
+                state.low_since_entry = cur_bar.low
+        else:
+            # Fresh entry this bar — entry bar counts as bars_held == 1.
+            tracker[sym] = _TrackedPosition(
+                side=("long" if pos.side == OrderSide.LONG else "short"),
+                entry_price=pos.entry_price,
+                bars_held=1,
+                high_since_entry=cur_bar.high,
+                low_since_entry=cur_bar.low,
+            )
+
+    def _maybe_emit_engine_exits(
+        self,
+        *,
+        cur_bar,
+        position_tracker: Dict[str, _TrackedPosition],
+        portfolio: Portfolio,
+        pending_for_prev: List[OrderRequest],
+        order_book: OrderBook,
+        result: "TradingServiceResult",
+        engine_order_seq: int,
+    ) -> int:
+        """Evaluate ``self._exit_rules`` against the current bar and emit
+        synthetic close orders for any triggered rule.
+
+        Dedup rules of thumb:
+        * Skip symbols the strategy already chose to exit this bar (an
+          opposite-side order in ``pending_for_prev``).
+        * Skip symbols with an in-flight engine-emitted exit on the order
+          book (prior bar's enforcement is still pending fill).
+
+        Engine-emitted orders carry ``reason="engine_exit:<rule_kind>"`` so
+        the conformance gate can count them off the order-lifecycle event
+        stream. Returns the updated ``engine_order_seq``.
+        """
+        sym = cur_bar.symbol
+        if sym not in position_tracker:
+            return engine_order_seq
+        pos = portfolio.positions.get(sym)
+        if pos is None or pos.qty <= 0:
+            return engine_order_seq
+
+        tracked = position_tracker[sym]
+        tracked_side: str = tracked.side
+
+        # Dedup: strategy already submitted an opposite-side close this bar.
+        for req in pending_for_prev:
+            if req.symbol != sym:
+                continue
+            req_side = "long" if req.side == OrderSide.LONG else "short"
+            if req_side != tracked_side:
+                return engine_order_seq
+
+        # Dedup: prior bar's engine exit is still on the order book.
+        for po in order_book.pending_for_symbol(sym):
+            po_req = po.request
+            po_side = "long" if po_req.side == OrderSide.LONG else "short"
+            if po_side != tracked_side and (po_req.reason or "").startswith(
+                ENGINE_EXIT_REASON_PREFIX
+            ):
+                return engine_order_seq
+
+        snapshot = tracked.snapshot(sym, pos.qty)
+        bar_snap = BarSnapshot(high=cur_bar.high, low=cur_bar.low, close=cur_bar.close)
+        intents = evaluate_exit_rules(
+            self._exit_rules,
+            {sym: snapshot},
+            {sym: bar_snap},
+        )
+        if not intents:
+            return engine_order_seq
+
+        # At most one intent per symbol — ``evaluate_exit_rules`` stops at the
+        # first triggered rule per position. Defensive iteration regardless.
+        for intent in intents:
+            engine_order_seq += 1
+            close_side = OrderSide.SHORT if tracked_side == "long" else OrderSide.LONG
+            req = OrderRequest(
+                client_order_id=f"e{engine_order_seq}",
+                symbol=intent.symbol,
+                side=close_side,
+                qty=pos.qty,
+                order_type=OrderType.MARKET,
+                tif=TimeInForce.DAY,
+                reason=f"{ENGINE_EXIT_REASON_PREFIX}{intent.rule_kind}",
+            )
+            try:
+                req.validate_prices()
+            except Exception as exc:  # pragma: no cover — engine-built request
+                logger.error(
+                    "engine-issued exit order failed validation (rule=%s symbol=%s): %s",
+                    intent.rule_kind,
+                    sym,
+                    exc,
+                )
+                continue
+            pending_for_prev.append(req)
+            result.execution_diagnostics.orders_emitted += 1
+            result.execution_diagnostics.exits_emitted += 1
+            firings = result.execution_diagnostics.exit_rule_firings
+            firings[intent.rule_kind] = firings.get(intent.rule_kind, 0) + 1
+            _record_event(
+                result.execution_diagnostics,
+                "emitted",
+                timestamp=cur_bar.timestamp,
+                symbol=intent.symbol,
+                side=close_side.value,
+                order_type=OrderType.MARKET.value,
+                reason=req.reason,
+            )
+        return engine_order_seq
 
     # ------------------------------------------------------------------
 

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -955,6 +955,8 @@ class TradingService:
                     chunk_size=chunk_size,
                     on_trade=on_trade,
                     eod_buffer=eod_buffer,
+                    position_tracker=position_tracker,
+                    engine_exits=engine_exits,
                 )
 
             # We need one-bar lookahead in the fill simulator, so we buffer
@@ -1128,7 +1130,8 @@ class TradingService:
                     #    any orders it submits in response. Warm-up bars set
                     #    ``ctx.is_warmup = True`` in the subprocess so the
                     #    strategy can short-circuit order emission; we also
-                    #    drop any orders it emits anyway as a safety net.
+                    #    drop any orders it emits anyway as a safety net
+                    #    (handled inside ``_process_bar_strategy_response``).
                     resp = harness.send_bar(
                         bar=cur_bar.model_dump(mode="json"),
                         state=self._state(portfolio),
@@ -1141,119 +1144,18 @@ class TradingService:
                         # bars the strategy could actually have signaled on.
                         result.bars_processed += 1
 
-                    if is_warmup:
-                        if resp.orders:
-                            result.warmup_orders_dropped += len(resp.orders)
-                            logger.info(
-                                "dropped %d order(s) submitted during warm-up bar",
-                                len(resp.orders),
-                            )
-                            for o in resp.orders:
-                                _record_event(
-                                    result.execution_diagnostics,
-                                    "warmup_dropped",
-                                    timestamp=cur_bar.timestamp,
-                                    symbol=o.get("symbol"),
-                                    side=o.get("side"),
-                                    order_type=o.get("order_type"),
-                                )
-                        # Cancels during warm-up are also no-ops (no live order book).
-                        prev_bar = cur_bar
-                        continue
-
-                    # Map cancels.
-                    for c in resp.cancels:
-                        oid = c.get("order_id")
-                        if oid:
-                            order_book.cancel(oid)
-
-                    # Orders submitted now are evaluated against the *next*
-                    # bar (look-ahead-safe).
-                    for o in resp.orders:
-                        result.execution_diagnostics.orders_emitted += 1
-                        _record_event(
-                            result.execution_diagnostics,
-                            "emitted",
-                            timestamp=cur_bar.timestamp,
-                            symbol=o.get("symbol"),
-                            side=o.get("side"),
-                            order_type=o.get("order_type"),
-                        )
-                        try:
-                            req = OrderRequest(**o)
-                            req.validate_prices()
-                            pending_for_prev.append(req)
-                            # An opposite-side order against an existing open
-                            # position is the strategy's exit intent. Counted
-                            # here (parent-side, before fill) so the diagnostic
-                            # reflects emission, not execution; #410 owns the
-                            # fill-side ``exit_filled`` event.
-                            held = portfolio.positions.get(req.symbol)
-                            if held is not None and held.side != req.side:
-                                result.execution_diagnostics.exits_emitted += 1
-                        except UnsupportedOrderFeatureError as exc:
-                            # Runtime-support gates from validate_prices ("feature
-                            # ships in a later step of #379") must terminate the
-                            # run, not be silently dropped. Convert to a
-                            # StrategyRuntimeError so the outer loop returns a
-                            # structured ``TradingServiceResult.error`` instead
-                            # of crashing ``TradingService.run()``. The narrow
-                            # subclass keeps unrelated ``NotImplementedError``s
-                            # from strategy code in the generic catch below.
-                            # See #383.
-                            _increment_rejection(
-                                result.execution_diagnostics, "unsupported_feature"
-                            )
-                            _record_event(
-                                result.execution_diagnostics,
-                                "rejected",
-                                timestamp=cur_bar.timestamp,
-                                symbol=o.get("symbol"),
-                                side=o.get("side"),
-                                order_type=o.get("order_type"),
-                                reason="unsupported_feature",
-                                detail=str(exc),
-                            )
-                            raise StrategyRuntimeError(
-                                f"strategy emitted an unsupported order: {exc}",
-                                etype="unsupported_feature",
-                            ) from exc
-                        except Exception as exc:  # malformed request from strategy
-                            logger.warning("dropping malformed order from strategy: %s", exc)
-                            _increment_rejection(result.execution_diagnostics, "malformed_request")
-                            _record_event(
-                                result.execution_diagnostics,
-                                "rejected",
-                                timestamp=cur_bar.timestamp,
-                                symbol=o.get("symbol"),
-                                side=o.get("side"),
-                                order_type=o.get("order_type"),
-                                reason="malformed_request",
-                                detail=str(exc),
-                            )
-
-                    # Issue #527 — engine-side enforcement of structured
-                    # ``exit_rules``. Runs after the strategy's orders are
-                    # queued so we can dedupe against strategy-emitted closes
-                    # and any in-flight engine exit on the order book. No-op
-                    # when the spec has no exit rules.
-                    engine_exits.maybe_emit(
+                    self._process_bar_strategy_response(
                         cur_bar=cur_bar,
-                        position_tracker=position_tracker,
+                        bar_orders=resp.orders,
+                        bar_cancels=resp.cancels,
+                        is_warmup=is_warmup,
                         portfolio=portfolio,
-                        pending_for_prev=pending_for_prev,
                         order_book=order_book,
+                        pending_for_prev=pending_for_prev,
+                        position_tracker=position_tracker,
+                        engine_exits=engine_exits,
                         result=result,
                     )
-
-                    # Issue #527 — extend trailing watermarks AFTER rule
-                    # evaluation so the next bar's eval has cur_bar's
-                    # extreme baked in, but THIS bar's eval did not see
-                    # ``cur_bar.high`` raise the trailing floor and then
-                    # trigger off ``cur_bar.low`` (intrabar lookahead).
-                    # No-op when the spec has no exit rules.
-                    if self._exit_rules:
-                        self._extend_watermarks(tracker=position_tracker, cur_bar=cur_bar)
 
                     prev_bar = cur_bar
 
@@ -1322,6 +1224,8 @@ class TradingService:
         chunk_size: int,
         on_trade: Optional[Callable[[TradeRecord], None]],
         eod_buffer: "_StreamingEquityBuffer",
+        position_tracker: Dict[str, _TrackedPosition],
+        engine_exits: _EngineExitDispatcher,
     ) -> TradingServiceResult:
         prev_bar = None
         pending_for_prev: List[OrderRequest] = []
@@ -1470,78 +1374,42 @@ class TradingService:
 
                     result.bars_processed += 1
 
+                    # Issue #527 — refresh engine-side per-position state
+                    # for ``cur_bar.symbol`` based on the post-fill
+                    # portfolio. Mirrors the per-bar (``run``) path's
+                    # placement between fills+drawdown and the strategy-
+                    # response processing step. No-op when exit_rules is
+                    # empty.
+                    if self._exit_rules:
+                        self._update_position_tracker(
+                            tracker=position_tracker,
+                            cur_bar=cur_bar,
+                            portfolio=portfolio,
+                        )
+
                 # 4) Process the strategy's response for this bar.
-                if is_warmup:
-                    if bar_orders:
-                        result.warmup_orders_dropped += len(bar_orders)
-                        logger.info(
-                            "dropped %d order(s) submitted during warm-up bar",
-                            len(bar_orders),
-                        )
-                        for o in bar_orders:
-                            _record_event(
-                                result.execution_diagnostics,
-                                "warmup_dropped",
-                                timestamp=cur_bar.timestamp,
-                                symbol=o.get("symbol"),
-                                side=o.get("side"),
-                                order_type=o.get("order_type"),
-                            )
-                    prev_bar = cur_bar
-                    continue
-
-                for c in bar_cancels:
-                    oid = c.get("order_id")
-                    if oid:
-                        order_book.cancel(oid)
-
-                for o in bar_orders:
-                    result.execution_diagnostics.orders_emitted += 1
-                    _record_event(
-                        result.execution_diagnostics,
-                        "emitted",
-                        timestamp=cur_bar.timestamp,
-                        symbol=o.get("symbol"),
-                        side=o.get("side"),
-                        order_type=o.get("order_type"),
+                try:
+                    self._process_bar_strategy_response(
+                        cur_bar=cur_bar,
+                        bar_orders=bar_orders,
+                        bar_cancels=bar_cancels,
+                        is_warmup=is_warmup,
+                        portfolio=portfolio,
+                        order_book=order_book,
+                        pending_for_prev=pending_for_prev,
+                        position_tracker=position_tracker,
+                        engine_exits=engine_exits,
+                        result=result,
                     )
-                    try:
-                        req = OrderRequest(**o)
-                        req.validate_prices()
-                        pending_for_prev.append(req)
-                        held = portfolio.positions.get(req.symbol)
-                        if held is not None and held.side != req.side:
-                            result.execution_diagnostics.exits_emitted += 1
-                    except UnsupportedOrderFeatureError as exc:
-                        _increment_rejection(result.execution_diagnostics, "unsupported_feature")
-                        _record_event(
-                            result.execution_diagnostics,
-                            "rejected",
-                            timestamp=cur_bar.timestamp,
-                            symbol=o.get("symbol"),
-                            side=o.get("side"),
-                            order_type=o.get("order_type"),
-                            reason="unsupported_feature",
-                            detail=str(exc),
-                        )
-                        chunk_buffer.clear()
-                        raise StrategyRuntimeError(
-                            f"strategy emitted an unsupported order: {exc}",
-                            etype="unsupported_feature",
-                        ) from exc
-                    except Exception as exc:
-                        logger.warning("dropping malformed order from strategy: %s", exc)
-                        _increment_rejection(result.execution_diagnostics, "malformed_request")
-                        _record_event(
-                            result.execution_diagnostics,
-                            "rejected",
-                            timestamp=cur_bar.timestamp,
-                            symbol=o.get("symbol"),
-                            side=o.get("side"),
-                            order_type=o.get("order_type"),
-                            reason="malformed_request",
-                            detail=str(exc),
-                        )
+                except StrategyRuntimeError:
+                    # ``_process_bar_strategy_response`` raises on an
+                    # ``UnsupportedOrderFeatureError`` from the strategy.
+                    # The per-bar path just lets it propagate; the
+                    # chunked path needs to clear the buffer first so
+                    # the outer loop's recovery path doesn't replay
+                    # any buffered bars.
+                    chunk_buffer.clear()
+                    raise
 
                 prev_bar = cur_bar
 
@@ -1620,6 +1488,154 @@ class TradingService:
     # ------------------------------------------------------------------
     # Issue #527 — engine-side enforcement of structured ``exit_rules``.
     # ------------------------------------------------------------------
+
+    def _process_bar_strategy_response(
+        self,
+        *,
+        cur_bar,
+        bar_orders: List[Dict],
+        bar_cancels: List[Dict],
+        is_warmup: bool,
+        portfolio: Portfolio,
+        order_book: OrderBook,
+        pending_for_prev: List[OrderRequest],
+        position_tracker: Dict[str, _TrackedPosition],
+        engine_exits: _EngineExitDispatcher,
+        result: TradingServiceResult,
+    ) -> None:
+        """Apply one bar's strategy response (cancels + orders) to the
+        order book and pending-submit queue, then run the engine's
+        structured-exit-rule enforcement step.
+
+        Shared between the per-bar (``run``) and chunked
+        (``_run_chunked``) paths — extracted because earlier the engine-
+        exit enforcement step lived only in the per-bar copy, so any
+        run with ``BAR_CHUNK_SIZE>1`` silently skipped ``exit_rules``
+        evaluation entirely. The dedup makes that gap structurally
+        impossible.
+
+        Warm-up bars short-circuit: orders submitted during warm-up
+        are dropped with a ``warmup_dropped`` lifecycle event (the
+        strategy is expected to honour ``ctx.is_warmup``; we drop
+        anyway as a safety net), cancels are no-ops (no live book),
+        and the engine-exit step is skipped (no positions exist
+        during warm-up that could trip a rule).
+
+        Orders queued here are look-ahead-safe: the bar-loop caller
+        submits them against the NEXT bar.
+
+        Raises :class:`StrategyRuntimeError` on
+        ``UnsupportedOrderFeatureError`` from
+        ``OrderRequest.validate_prices`` — the chunked caller must
+        ``chunk_buffer.clear()`` before letting it propagate.
+        """
+        if is_warmup:
+            if bar_orders:
+                result.warmup_orders_dropped += len(bar_orders)
+                logger.info(
+                    "dropped %d order(s) submitted during warm-up bar",
+                    len(bar_orders),
+                )
+                for o in bar_orders:
+                    _record_event(
+                        result.execution_diagnostics,
+                        "warmup_dropped",
+                        timestamp=cur_bar.timestamp,
+                        symbol=o.get("symbol"),
+                        side=o.get("side"),
+                        order_type=o.get("order_type"),
+                    )
+            # Cancels during warm-up are no-ops (no live order book).
+            return
+
+        for c in bar_cancels:
+            oid = c.get("order_id")
+            if oid:
+                order_book.cancel(oid)
+
+        # Orders submitted now are evaluated against the *next* bar
+        # (look-ahead-safe).
+        for o in bar_orders:
+            result.execution_diagnostics.orders_emitted += 1
+            _record_event(
+                result.execution_diagnostics,
+                "emitted",
+                timestamp=cur_bar.timestamp,
+                symbol=o.get("symbol"),
+                side=o.get("side"),
+                order_type=o.get("order_type"),
+            )
+            try:
+                req = OrderRequest(**o)
+                req.validate_prices()
+                pending_for_prev.append(req)
+                # An opposite-side order against an existing open
+                # position is the strategy's exit intent. Counted
+                # here (parent-side, before fill) so the diagnostic
+                # reflects emission, not execution; #410 owns the
+                # fill-side ``exit_filled`` event.
+                held = portfolio.positions.get(req.symbol)
+                if held is not None and held.side != req.side:
+                    result.execution_diagnostics.exits_emitted += 1
+            except UnsupportedOrderFeatureError as exc:
+                # Runtime-support gates from validate_prices ("feature
+                # ships in a later step of #379") must terminate the
+                # run, not be silently dropped. Convert to a
+                # StrategyRuntimeError so the outer loop returns a
+                # structured ``TradingServiceResult.error`` instead of
+                # crashing ``TradingService.run()``. The narrow subclass
+                # keeps unrelated ``NotImplementedError``s from strategy
+                # code in the generic catch below. See #383.
+                _increment_rejection(result.execution_diagnostics, "unsupported_feature")
+                _record_event(
+                    result.execution_diagnostics,
+                    "rejected",
+                    timestamp=cur_bar.timestamp,
+                    symbol=o.get("symbol"),
+                    side=o.get("side"),
+                    order_type=o.get("order_type"),
+                    reason="unsupported_feature",
+                    detail=str(exc),
+                )
+                raise StrategyRuntimeError(
+                    f"strategy emitted an unsupported order: {exc}",
+                    etype="unsupported_feature",
+                ) from exc
+            except Exception as exc:  # malformed request from strategy
+                logger.warning("dropping malformed order from strategy: %s", exc)
+                _increment_rejection(result.execution_diagnostics, "malformed_request")
+                _record_event(
+                    result.execution_diagnostics,
+                    "rejected",
+                    timestamp=cur_bar.timestamp,
+                    symbol=o.get("symbol"),
+                    side=o.get("side"),
+                    order_type=o.get("order_type"),
+                    reason="malformed_request",
+                    detail=str(exc),
+                )
+
+        # Issue #527 — engine-side enforcement of structured
+        # ``exit_rules``. Runs after the strategy's orders are queued
+        # so we can dedupe against strategy-emitted closes and any
+        # in-flight engine exit on the order book. No-op when the
+        # spec has no exit rules.
+        engine_exits.maybe_emit(
+            cur_bar=cur_bar,
+            position_tracker=position_tracker,
+            portfolio=portfolio,
+            pending_for_prev=pending_for_prev,
+            order_book=order_book,
+            result=result,
+        )
+
+        # Issue #527 — extend trailing watermarks AFTER rule evaluation
+        # so the next bar's eval has cur_bar's extreme baked in, but
+        # THIS bar's eval did not see ``cur_bar.high`` raise the
+        # trailing floor and then trigger off ``cur_bar.low`` (intrabar
+        # lookahead). No-op when the spec has no exit rules.
+        if self._exit_rules:
+            self._extend_watermarks(tracker=position_tracker, cur_bar=cur_bar)
 
     @staticmethod
     def _update_position_tracker(

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -1419,6 +1419,28 @@ class TradingService:
             # identity matters and ``fill_simulator.process_bar``'s
             # stale-continuation guard for what consumes the binding.
             engine_exit_bindings[req.client_order_id] = pos.entry_order_id
+            # Retire any other unbound opposite-side strategy orders resting
+            # on the book for this symbol: they were intended to close the
+            # current position, and once the engine emits its own close the
+            # position is going away. Without binding them too, an
+            # unbound GTC/limit strategy exit (``cumulative_filled_qty==0``
+            # AND ``working_against_entry_order_id is None``) would survive
+            # the engine close and, when it later triggers in
+            # ``FillSimulator.process_bar``, fall through to ``_fill_entry``
+            # because ``existing_pos is None`` — opening an unintended
+            # reverse position. Binding ties them to the position's
+            # ``entry_order_id`` so the same stale-continuation guard drops
+            # them when the engine close removes the position.
+            for resting in order_book.pending_for_symbol(sym):
+                if resting.working_against_entry_order_id is not None:
+                    continue
+                if resting.cumulative_filled_qty > 0:
+                    continue
+                resting_side = "long" if resting.request.side == OrderSide.LONG else "short"
+                if resting_side == tracked_side:
+                    # Same-side resting order is an add, not a close — leave alone.
+                    continue
+                resting.working_against_entry_order_id = pos.entry_order_id
             result.execution_diagnostics.orders_emitted += 1
             result.execution_diagnostics.exits_emitted += 1
             firings = result.execution_diagnostics.exit_rule_firings

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -86,7 +86,7 @@ class _TrackedPosition:
     next bar's tracker update clears the flag.
     """
 
-    side: str  # "long" | "short"
+    side: OrderSide
     entry_price: float
     entry_order_id: str
     just_opened: bool
@@ -94,9 +94,12 @@ class _TrackedPosition:
     low_since_entry: float
 
     def snapshot(self, symbol: str, qty: float) -> PositionState:
+        # ``PositionState`` (the public evaluator input) carries the
+        # side as a ``"long" | "short"`` Literal; convert at the
+        # boundary so internal dispatcher logic stays enum-typed.
         return PositionState(
             symbol=symbol,
-            side=self.side,  # type: ignore[arg-type]
+            side="long" if self.side == OrderSide.LONG else "short",
             qty=qty,
             entry_price=self.entry_price,
             high_since_entry=self.high_since_entry,
@@ -246,8 +249,7 @@ class _EngineExitDispatcher:
             po_req = po.request
             if po_req.order_type != OrderType.MARKET:
                 continue
-            po_side = "long" if po_req.side == OrderSide.LONG else "short"
-            if po_side != tracked.side and (po_req.reason or "").startswith(
+            if po_req.side != tracked.side and (po_req.reason or "").startswith(
                 ENGINE_EXIT_REASON_PREFIX
             ):
                 return None
@@ -272,7 +274,7 @@ class _EngineExitDispatcher:
     @staticmethod
     def _sum_same_side_queued(
         sym: str,
-        tracked_side: str,
+        tracked_side: OrderSide,
         pending_for_prev: List[OrderRequest],
     ) -> float:
         """Sum the qty of same-side strategy orders queued for the
@@ -283,8 +285,7 @@ class _EngineExitDispatcher:
         for queued in pending_for_prev:
             if queued.symbol != sym:
                 continue
-            queued_side = "long" if queued.side == OrderSide.LONG else "short"
-            if queued_side != tracked_side:
+            if queued.side != tracked_side:
                 continue
             total += queued.qty
         return total
@@ -304,7 +305,7 @@ class _EngineExitDispatcher:
         also closed by this emission (see ``_sum_same_side_queued``).
         """
         self._next_seq += 1
-        close_side = OrderSide.SHORT if tracked.side == "long" else OrderSide.LONG
+        close_side = OrderSide.SHORT if tracked.side == OrderSide.LONG else OrderSide.LONG
         req = OrderRequest(
             client_order_id=f"e{self._next_seq}",
             symbol=intent.symbol,
@@ -336,7 +337,7 @@ class _EngineExitDispatcher:
     def _retire_competing_resting_orders(
         self,
         sym: str,
-        tracked_side: str,
+        tracked_side: OrderSide,
         pos: Position,
         order_book: OrderBook,
     ) -> None:
@@ -363,15 +364,14 @@ class _EngineExitDispatcher:
                 continue
             if resting.cumulative_filled_qty > 0:
                 continue
-            resting_side = "long" if resting.request.side == OrderSide.LONG else "short"
-            if resting_side == tracked_side:
+            if resting.request.side == tracked_side:
                 continue
             resting.working_against_entry_order_id = pos.entry_order_id
 
     def _bind_same_bar_queued_exits(
         self,
         sym: str,
-        tracked_side: str,
+        tracked_side: OrderSide,
         pos: Position,
         pending_for_prev: List[OrderRequest],
     ) -> None:
@@ -386,8 +386,7 @@ class _EngineExitDispatcher:
                 continue
             if queued.client_order_id in self.engine_exit_bindings:
                 continue
-            queued_side = "long" if queued.side == OrderSide.LONG else "short"
-            if queued_side == tracked_side:
+            if queued.side == tracked_side:
                 continue
             self.engine_exit_bindings[queued.client_order_id] = pos.entry_order_id
 
@@ -1691,7 +1690,7 @@ class TradingService:
             # for those rule kinds).
             just_opened = pos.entry_order_type != "market"
             tracker[sym] = _TrackedPosition(
-                side=("long" if pos.side == OrderSide.LONG else "short"),
+                side=pos.side,
                 entry_price=pos.entry_price,
                 entry_order_id=pos.entry_order_id,
                 just_opened=just_opened,

--- a/backend/agents/investment_team/trading_service/service.py
+++ b/backend/agents/investment_team/trading_service/service.py
@@ -1316,21 +1316,39 @@ class TradingService:
         else:
             # Fresh entry this bar — either truly first entry, or a same-bar
             # exit + re-entry replaced the prior position (different
-            # ``entry_order_id``). Initialise watermarks at ``entry_price``
-            # rather than the entry bar's full OHLC: for a limit / stop
-            # entry filled mid-bar, the bar's high/low may include price
-            # action from BEFORE the fill, and using it would let
-            # take-profit / trailing-stop rules queue impossible closes
-            # off pre-entry extremes. ``just_opened=True`` keeps rule
-            # evaluation off this bar entirely; the next bar extends the
-            # watermarks normally.
+            # ``entry_order_id``). Two paths:
+            #
+            # * **Market entry** — filled at the bar's open, so the bar's
+            #   full high/low is post-entry price action. Initialise
+            #   watermarks from the bar and let rule evaluation run on
+            #   this bar; a stop-loss / take-profit that trips through
+            #   the bar's range is a real same-bar exit and must be
+            #   captured (otherwise a long opened at the open can trade
+            #   through its stop and recover with no engine emission).
+            # * **Non-market entry** (limit / stop / trailing-stop /
+            #   anything else) — the fill could have landed anywhere
+            #   inside the bar, so the bar's pre-fill price action is
+            #   ambiguous. Initialise watermarks at ``entry_price`` and
+            #   gate rule evaluation off the entry bar with
+            #   ``just_opened=True`` so pre-entry extremes can't queue
+            #   impossible same-bar closes. The next bar's tracker
+            #   update clears the flag.
+            is_market_entry = pos.entry_order_type == "market"
+            if is_market_entry:
+                high_init = cur_bar.high
+                low_init = cur_bar.low
+                just_opened = False
+            else:
+                high_init = pos.entry_price
+                low_init = pos.entry_price
+                just_opened = True
             tracker[sym] = _TrackedPosition(
                 side=("long" if pos.side == OrderSide.LONG else "short"),
                 entry_price=pos.entry_price,
                 entry_order_id=pos.entry_order_id,
-                just_opened=True,
-                high_since_entry=pos.entry_price,
-                low_since_entry=pos.entry_price,
+                just_opened=just_opened,
+                high_since_entry=high_init,
+                low_since_entry=low_init,
             )
 
     def _maybe_emit_engine_exits(

--- a/user-interface/src/app/components/investment-strategy/editors/exit-rule-editor.component.html
+++ b/user-interface/src/app/components/investment-strategy/editors/exit-rule-editor.component.html
@@ -22,12 +22,6 @@
   </div>
 
   @switch (currentKind) {
-    @case ('time_stop') {
-      <mat-form-field appearance="outline" class="num-field">
-        <mat-label>n_bars</mat-label>
-        <input matInput type="number" min="1" step="1" formControlName="n_bars" />
-      </mat-form-field>
-    }
     @case ('stop_loss') {
       <mat-form-field appearance="outline" class="num-field">
         <mat-label>pct (0–1)</mat-label>

--- a/user-interface/src/app/components/investment-strategy/editors/exit-rule-editor.component.ts
+++ b/user-interface/src/app/components/investment-strategy/editors/exit-rule-editor.component.ts
@@ -10,7 +10,6 @@ import { Subscription } from 'rxjs';
 
 import { EXIT_RULE_KINDS, ExitRuleKind, STOP_LOSS_BASIS_OPTIONS } from '../../../models';
 import { PredicateEditorComponent } from './predicate-editor.component';
-import { integerValidator } from './strategy-validators';
 
 @Component({
   selector: 'app-exit-rule-editor',
@@ -55,7 +54,7 @@ export class ExitRuleEditorComponent implements OnInit, OnDestroy {
   }
 
   get currentKind(): ExitRuleKind {
-    return (this.group.get('kind')?.value ?? 'time_stop') as ExitRuleKind;
+    return (this.group.get('kind')?.value ?? 'stop_loss') as ExitRuleKind;
   }
 
   private setValidators(name: string, validators: ValidatorFn[]): void {
@@ -68,15 +67,10 @@ export class ExitRuleEditorComponent implements OnInit, OnDestroy {
   private applyForKind(kind: ExitRuleKind): void {
     // Clear everything first, then apply per kind. Numeric fields keep their
     // value across kind switches (cheap; harmless).
-    this.setValidators('n_bars', []);
     this.setValidators('pct', []);
     this.setValidators('basis', []);
 
     switch (kind) {
-      case 'time_stop':
-        // n_bars is declared as `int` on the backend; reject 1.5 client-side.
-        this.setValidators('n_bars', [Validators.required, Validators.min(1), integerValidator]);
-        break;
       case 'stop_loss':
         this.setValidators('pct', [Validators.required, Validators.min(0.0000001), Validators.max(1.0)]);
         this.setValidators('basis', [Validators.required]);

--- a/user-interface/src/app/components/investment-strategy/investment-strategy.component.spec.ts
+++ b/user-interface/src/app/components/investment-strategy/investment-strategy.component.spec.ts
@@ -134,16 +134,17 @@ describe('InvestmentStrategyComponent', () => {
     });
   });
 
-  it('prefills a TimeStopRule into the exit-rules array', () => {
+  it('prefills a StopLossRule into the exit-rules array', () => {
     const spec = baseSpec({
-      exit_rules: [{ kind: 'time_stop', n_bars: 10, note: '' }],
+      exit_rules: [{ kind: 'stop_loss', pct: 0.03, basis: 'entry_price', note: '' }],
     });
     component.populateForm(spec);
 
     expect(component.exitRulesArray.length).toBe(1);
     const row = component.exitRulesArray.at(0);
-    expect(row.get('kind')!.value).toBe('time_stop');
-    expect(row.get('n_bars')!.value).toBe(10);
+    expect(row.get('kind')!.value).toBe('stop_loss');
+    expect(row.get('pct')!.value).toBe(0.03);
+    expect(row.get('basis')!.value).toBe('entry_price');
     expect(component.hasPrefillErrors).toBe(false);
   });
 
@@ -250,36 +251,26 @@ describe('InvestmentStrategyComponent', () => {
     expect(params.get('period')).not.toBeNull();
   });
 
-  it('keeps the form valid after adding a time_stop exit rule', async () => {
+  it('keeps the form valid after adding a stop_loss exit rule', async () => {
     component.form.patchValue({ hypothesis: 'h', signal_definition: 's' });
     component.addExitRule();
     fixture.detectChanges();
 
-    // The exit rule defaults to time_stop with n_bars=10. The nested `when`
+    // The exit rule defaults to stop_loss with pct=0.05. The nested `when`
     // predicate would otherwise mark the form invalid via its required SMA
     // params; it must be disabled when kind != signal_exit.
     expect(component.form.valid).toBe(true);
 
     await component.createStrategy();
     const req = httpMock.expectOne(strategiesUrl);
-    expect(req.request.body.exit_rules).toEqual([{ kind: 'time_stop', n_bars: 10 }]);
+    expect(req.request.body.exit_rules).toEqual([
+      { kind: 'stop_loss', pct: 0.05, basis: 'entry_price' },
+    ]);
     req.flush({
-      strategy_id: 'strat-ts',
-      strategy: baseSpec({ strategy_id: 'strat-ts' }),
+      strategy_id: 'strat-sl',
+      strategy: baseSpec({ strategy_id: 'strat-sl' }),
       message: 'ok',
     });
-  });
-
-  it('rejects fractional n_bars on time_stop exit rules', () => {
-    component.form.patchValue({ hypothesis: 'h', signal_definition: 's' });
-    component.addExitRule();
-    fixture.detectChanges();
-
-    const rule = component.exitRulesArray.at(0);
-    rule.get('n_bars')!.setValue(1.5);
-
-    expect(rule.get('n_bars')!.hasError('notInteger')).toBe(true);
-    expect(component.form.valid).toBe(false);
   });
 
   it('drops blank optional indicator params from the wire payload', async () => {

--- a/user-interface/src/app/components/investment-strategy/investment-strategy.component.ts
+++ b/user-interface/src/app/components/investment-strategy/investment-strategy.component.ts
@@ -259,8 +259,7 @@ export class InvestmentStrategyComponent implements OnInit {
   }
 
   buildExitRuleGroup(initial?: ExitRule): FormGroup {
-    const kind = (initial?.kind && ALLOWED_EXIT_KINDS.has(initial.kind) ? initial.kind : 'time_stop') as ExitRuleKind;
-    const nBars = initial && initial.kind === 'time_stop' ? initial.n_bars : 10;
+    const kind = (initial?.kind && ALLOWED_EXIT_KINDS.has(initial.kind) ? initial.kind : 'stop_loss') as ExitRuleKind;
     const pct =
       initial && (initial.kind === 'stop_loss' || initial.kind === 'take_profit')
         ? initial.pct
@@ -270,7 +269,6 @@ export class InvestmentStrategyComponent implements OnInit {
 
     const group = this.fb.group({
       kind: [kind, Validators.required],
-      n_bars: [nBars],
       pct: [pct],
       basis: [basis],
       when: this.buildPredicateGroup(whenSeed),
@@ -417,8 +415,6 @@ export class InvestmentStrategyComponent implements OnInit {
     const kind = raw['kind'] as ExitRuleKind;
     const note = raw['note'] ? { note: raw['note'] as string } : {};
     switch (kind) {
-      case 'time_stop':
-        return { kind, n_bars: Number(raw['n_bars']), ...note };
       case 'stop_loss':
         return {
           kind,

--- a/user-interface/src/app/models/investment.model.ts
+++ b/user-interface/src/app/models/investment.model.ts
@@ -300,14 +300,17 @@ export interface EntryRule {
   note?: string;
 }
 
-export interface TimeStopRule    { kind: 'time_stop'; n_bars: number; note?: string; }
 export interface StopLossRule    { kind: 'stop_loss'; pct: number; basis?: 'entry_price' | 'trailing_high' | 'trailing_low'; note?: string; }
 export interface TakeProfitRule  { kind: 'take_profit'; pct: number; note?: string; }
 export interface SignalExitRule  { kind: 'signal_exit'; when: Predicate; note?: string; }
 
-export type ExitRule = TimeStopRule | StopLossRule | TakeProfitRule | SignalExitRule;
+// Exit rules: structured close conditions the engine enforces (stop-loss /
+// take-profit) plus aspirational signal-based exits. Bar-counting "time
+// stops" are deliberately NOT a member — real traders close on price,
+// P&L, or signal reversal.
+export type ExitRule = StopLossRule | TakeProfitRule | SignalExitRule;
 
-export const EXIT_RULE_KINDS = ['time_stop', 'stop_loss', 'take_profit', 'signal_exit'] as const;
+export const EXIT_RULE_KINDS = ['stop_loss', 'take_profit', 'signal_exit'] as const;
 export type ExitRuleKind = typeof EXIT_RULE_KINDS[number];
 
 export type StopLossBasis = 'entry_price' | 'trailing_high' | 'trailing_low';


### PR DESCRIPTION
Closes #527 (the enforcement half — the structured schema half shipped under #563).

## Summary

`StrategySpec.entry_rules` / `exit_rules` were structured Pydantic discriminated unions as of #563, but the parent engine still ran LLM-authored `strategy_code` and never consulted the rules — so the alignment agent labelled deviations from `TimeStopRule(n_bars=10)` as "mandatory violations" against a rule the engine never enforced. This PR makes structured **exit rules** engine-enforced and ships a deterministic conformance gate to replace the LLM's prose policing for that surface. Entry-rule enforcement remains a follow-up.

## What changed

**Trading service** (`backend/agents/investment_team/trading_service/`)
- `TradingService.__init__` accepts `exit_rules: List[ExitRule]`. The bar loop maintains a `_TrackedPosition` per symbol — `bars_held`, `high_since_entry`, `low_since_entry` — and after the strategy queues its orders, calls `evaluate_exit_rules` and submits synthetic close orders tagged `reason="engine_exit:<kind>"`. Dedup'd against same-bar strategy closes and in-flight prior engine exits.
- `BacktestExecutionDiagnostics.exit_rule_firings: Dict[str, int]` counts engine emissions per rule kind.
- `BAR_CHUNK_SIZE > 1` combined with non-empty `exit_rules` raises `NotImplementedError` rather than silently dropping enforcement. Per-bar path is the only enforced surface for the MVP.
- `run_backtest` threads `strategy.exit_rules` through.

**Rule evaluator** (`strategy_lab/executor/rule_compiler.py`, new) — pure-functional. Handles long + short for TimeStop, StopLoss (entry_price / trailing_high / trailing_low), TakeProfit. `SignalExitRule` is a silent no-op (predicate evaluation needs a shared per-bar indicator runtime — out of scope).

**Conformance gate** (`strategy_lab/quality_gates/exit_rule_conformance.py`, new) — reads the trade ledger + diagnostics. Critical on TimeStop overshoot (`hold_days > n_bars + 1` fill-lag) or StopLoss(entry_price) overshoot beyond `2 × slippage_bps + 0.5%`. Take-profit is sanity-only (other rules legitimately close trades first). Orchestrator runs the gate before the alignment loop and appends results to `all_gate_results`.

**Prompts**
- `alignment_system.md`: structured `exit_rules` move from the aspirational section into the enforced section. Entry rules and `SignalExitRule` stay aspirational.
- `analysis_win.md` / `analysis_lose.md`: exit rules labelled "Engine-enforced exit rules" instead of "Intended … may not all be machine-enforced".

**Backwards compatibility**: no `LegacyProseRule` is needed — the API has rejected prose with 422 since #563 and there are no live prose specs to migrate.

## Decisions locked during planning

- **Scope: exit rules only.** Acceptance criteria call out TimeStop / StopLoss / TakeProfit; entry-rule enforcement is filed as follow-up.
- **Enforcement: engine-side.** `TradingService` owns the rules and the bar-loop hooks; strategy code stays focused on the signal/entry half.
- **Audit: new deterministic gate + keep LLM audit.** The conformance gate runs before alignment; the LLM agent still flags entry-side / sizing / risk-limit issues.

## Tests

- `tests/test_rule_compiler.py` — 27 unit tests covering every rule kind × long/short × trigger geometry.
- `tests/test_exit_rule_conformance_gate.py` — 15 unit tests for gate verdicts (pass / critical / warning / info paths, tolerance band, sub-daily skip).
- `tests/test_engine_exit_enforcement.py` — 7 end-to-end tests through `run_backtest` confirming the engine actually emits closes and dedupes against strategy-emitted closes on the same bar.
- `tests/test_analysis_alignment_prompts.py` — refreshed assertions for the new prompt wording (entry intent / exit enforcement split, gate reference).
- Golden snapshots regenerated: `prompt_*.txt`, `sma_crossover.json`, `round_trip.json`, `overfit_hardcoded_dates.json` (picks up the new `exit_rule_firings` diagnostic field).

## Test plan

- [x] `pytest agents/investment_team/tests/` → 1335 passed, 13 skipped
- [x] `ruff check agents/investment_team/` → all checks passed
- [x] `ruff format --check` on every modified file
- [ ] End-to-end Strategy Lab cycle through `POST /api/investment/strategy-lab/run` against a known-leaky exit-rule spec (manual smoke, not in CI)

## Follow-ups (out of scope)

1. Entry-rule engine enforcement (auto-emit entries from structured `EntryRule` predicates).
2. `SignalExitRule` enforcement — needs a shared per-bar indicator runtime in the parent engine.
3. Multi-timeframe `TimeStopRule` — gate currently hard-codes daily; sub-daily timeframes get a skipped-info row.
4. Chunked-bar protocol support for engine-enforced rules.
5. Bracket-order optimisation — convert `StopLossRule(basis="entry_price")` / `TakeProfitRule` into `attached_stop_loss` / `attached_take_profit` on the entry order so the broker simulator handles them rather than the parent's per-bar polling.

https://claude.ai/code/session_01T9ho99rPVnxFjuGJRzyPHo

---
_Generated by [Claude Code](https://claude.ai/code/session_01T9ho99rPVnxFjuGJRzyPHo)_