### PR TITLE
investment-team: SpecReadinessGate — deterministic implementability gate (#540)

### DIFF
--- a/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
+++ b/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
@@ -106,6 +106,44 @@ class _AlignmentLoopOutcome:
         return len(self.alignment_attempts)
 
 
+@dataclass
+class _SynthesisLoopOutcome:
+    """Bundle of state mutated by ``_run_synthesis_loop``.
+
+    The synthesis refinement loop iterates up to ``MAX_CODE_REFINEMENT_ROUNDS``
+    rounds of (validate → fetch → execute → trade-collect → evaluate),
+    refining ``spec``/``code`` between rounds and short-circuiting on
+    fatal failures (market-data unavailable, target-symbol coverage,
+    max-rounds exhaustion).
+
+    Returning the full final state keeps the boundary explicit so
+    ``_run_design_attempt`` doesn't need to inspect loop internals.
+
+    Invariants on return:
+    - ``execution_succeeded=True`` implies ``trades`` reflects a clean
+      run with no critical anomalies and ``metrics`` was computed from
+      those trades.
+    - ``execution_succeeded=False`` implies the loop short-circuited or
+      exhausted its rounds; ``trades``/``metrics`` may be empty defaults
+      or carry the last failed round's partials.
+    - ``market_data`` is ``None`` only when the first ``_fetch_market_data``
+      call returned an empty payload — the loop breaks immediately in
+      that case and downstream phases skip alignment.
+    - ``max_rounds_exhausted`` is mutually exclusive with
+      ``execution_succeeded=True``.
+    """
+
+    spec: StrategySpec
+    code: str
+    trades: List[TradeRecord]
+    metrics: BacktestResult
+    market_data: Optional[Dict[str, List[OHLCVBar]]]
+    requested_symbols: List[str]
+    fetched_symbols: List[str]
+    execution_succeeded: bool
+    max_rounds_exhausted: bool
+
+
 # ──────────────────────────────────────────────────────────────────────────
 # Pure helpers used by the orchestrator (and a few external callers).
 # ──────────────────────────────────────────────────────────────────────────

--- a/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
+++ b/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
@@ -107,6 +107,58 @@ class _AlignmentLoopOutcome:
 
 
 @dataclass
+class _AlignmentRoundOutcome:
+    """One iteration of ``_run_trade_alignment_loop``.
+
+    Semantics:
+    - ``terminate=True`` ⇒ caller breaks the loop. The spec/code/trades/
+      metrics fields carry the pre-iteration state (either because the
+      audit reported aligned, the proposal was rejected, or the round
+      budget is spent).
+    - ``terminate=False`` ⇒ caller continues. The spec/code/trades/
+      metrics fields carry the just-committed proposal as the new
+      known-good state.
+
+    The helper mutates ``alignment_reports``, ``alignment_attempts``,
+    and ``all_gate_results`` in place; callers observe those lists
+    directly.
+    """
+
+    spec: StrategySpec
+    code: str
+    trades: List[TradeRecord]
+    metrics: BacktestResult
+    terminate: bool
+
+
+@dataclass
+class _AnomalyRecoveryOutcome:
+    """Bundle of state returned by ``_handle_critical_anomalies``.
+
+    The synthesis loop's evaluation phase delegates to that helper when
+    the backtest produces critical anomaly gates. The helper either
+    commits a zero-trade-repair proposal, applies a generic refinement,
+    or exhausts the round budget — and the loop body needs to know which
+    outcome happened so it can continue or break.
+
+    Invariants on return:
+    - ``exhausted=True`` ⇒ caller breaks the synthesis loop with
+      ``max_rounds_exhausted=True``; the spec/code/trades/metrics fields
+      carry the last failed-round values (callers should not commit them).
+    - ``exhausted=False`` ⇒ caller continues to the next round; the
+      spec/code/trades/metrics/exec_result fields carry the new known-good
+      state (either ZTR-committed proposal or generic-refined source).
+    """
+
+    spec: StrategySpec
+    code: str
+    trades: List[TradeRecord]
+    metrics: BacktestResult
+    exec_result: StrategyRunResult
+    exhausted: bool
+
+
+@dataclass
 class _SynthesisLoopOutcome:
     """Bundle of state mutated by ``_run_synthesis_loop``.
 

--- a/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
+++ b/backend/agents/investment_team/strategy_lab/_orchestrator_helpers.py
@@ -1,0 +1,359 @@
+"""Pure helpers + outcome dataclasses extracted from :mod:`orchestrator`.
+
+These types and functions all live "below" :class:`StrategyLabOrchestrator`
+in the dependency graph — they take primitive inputs (specs, bar lists,
+metrics) and return fresh values. Hosting them in a sibling module keeps
+``orchestrator.py`` focused on the coordinator's surface.
+
+External callers (``zero_trade_repair.py``, the test suite,
+``agents/refinement.py``'s docstring reference) historically imported
+these names via ``investment_team.strategy_lab.orchestrator``. The
+orchestrator re-exports them so existing import sites keep working.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import os
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+from ..execution.metrics import build_equity_curve_from_trades
+from ..execution.risk_filter import _RISK_LIMIT_TIGHTEN_DIRECTION, RiskLimits
+from ..market_data_service import OHLCVBar
+from ..models import (
+    BacktestConfig,
+    BacktestExecutionDiagnostics,
+    BacktestResult,
+    StrategySpec,
+    TradeRecord,
+)
+from ..trading_service.modes.sandbox_compat import StrategyRunResult, run_strategy_code
+from .coverage_probe import run_coverage_stage, should_run_probes
+from .quality_gates.models import QualityGateResult
+
+logger = logging.getLogger(__name__)
+
+# Cap on how many ``last_order_events`` entries the diagnostics block
+# carries through to the refinement prompt. The diagnostics model already
+# trims to 20; 10 is enough signal for the LLM to spot the failure pattern
+# while keeping the JSON line under ~1 KB.
+_DIAGNOSTICS_LAST_EVENTS_CAP = 10
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Outcome dataclasses returned by the orchestrator's phase methods.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class _MarketDataFetch:
+    """Issue #525 — return envelope for ``_fetch_market_data``.
+
+    Carries the OHLCV payload alongside the audit trail of the symbols the
+    fetch was asked to retrieve and the symbols that actually returned
+    usable bars. Both lists feed ``BacktestRecord`` so reviewers can see
+    when a fetch silently dropped tickers without re-running the cycle.
+    """
+
+    data: Optional[Dict[str, List[OHLCVBar]]]
+    requested_symbols: List[str]
+    fetched_symbols: List[str]
+
+
+@dataclass
+class _VerificationOutcome:
+    """Bundle of state mutated by ``_run_verification_phase``.
+
+    The verification phase runs walk-forward (or its fallback anomaly
+    recheck), exit-rule conformance, resolves ``is_winning``, and
+    augments ``metrics.acceptance_reason`` with any veto causes.
+    Returning a dataclass keeps the boundary explicit without forcing
+    ``_run_design_attempt`` to learn the internal branches.
+    """
+
+    metrics: BacktestResult
+    is_winning: bool
+    upstream_admitted: bool
+    acceptance_results: List[QualityGateResult]
+    walk_forward_failed: bool
+    exit_rule_conformance_passed: bool
+
+
+@dataclass
+class _AlignmentLoopOutcome:
+    """Bundle of state mutated by ``_run_trade_alignment_loop``.
+
+    The trade-alignment loop can replace the run's known-good
+    ``spec`` / ``code`` / ``trades`` / ``metrics`` if it commits a fix,
+    and tracks attempt strings + per-round reports the caller consumes.
+    Returning a single dataclass keeps ``_run_design_attempt``'s
+    unpacking explicit and small.
+    """
+
+    spec: StrategySpec
+    code: str
+    trades: List[TradeRecord]
+    metrics: BacktestResult
+    alignment_attempts: List[str] = field(default_factory=list)
+    alignment_reports: List[Any] = field(default_factory=list)
+    trades_aligned: bool = False
+
+    @property
+    def alignment_rounds(self) -> int:
+        return len(self.alignment_attempts)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Pure helpers used by the orchestrator (and a few external callers).
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _maybe_attach_coverage_report(
+    *,
+    metrics: BacktestResult,
+    spec: StrategySpec,
+    market_data: Dict[str, List[OHLCVBar]],
+    config: BacktestConfig,
+    exec_result: StrategyRunResult,
+) -> None:
+    """Run the #451 coverage stage and stamp the report onto ``metrics``.
+
+    The ``spec`` argument MUST carry the same ``strategy_code`` that was
+    handed to ``run_strategy_code`` to produce ``exec_result``. The
+    alignment and zero-trade-repair paths use a ``proposed_spec`` variant
+    of the surrounding spec; pass that, not the loop-level ``spec``,
+    otherwise the static probe will analyse stale source.
+
+    No-ops when ``should_run_probes`` says the run isn't zero/low-trade —
+    successful runs keep ``metrics.coverage_report = None`` and pay no
+    probe cost.
+    """
+    if should_run_probes(exec_result.execution_diagnostics):
+        metrics.coverage_report = run_coverage_stage(
+            spec=spec,
+            market_data=market_data,
+            config=config,
+            exec_result=exec_result,
+            run_strategy_code_fn=run_strategy_code,
+        )
+
+
+def _format_execution_diagnostics(
+    diagnostics: Optional[BacktestExecutionDiagnostics],
+) -> str:
+    """Render a compact JSON block of execution diagnostics for the
+    refinement prompt (issue #414, part of #404).
+
+    Returns an empty string when diagnostics is missing or the executor
+    couldn't classify a zero-trade failure — healthy backtests must not
+    bloat the prompt. When a ``zero_trade_category`` is present, returns a
+    single line ``"Execution Diagnostics: {<json>}"`` whose JSON payload is
+    stable-key-sorted and compact. ``last_order_events`` is capped to the
+    most recent ``_DIAGNOSTICS_LAST_EVENTS_CAP`` entries.
+    """
+    if diagnostics is None or diagnostics.zero_trade_category is None:
+        return ""
+
+    payload = diagnostics.model_dump(mode="json", exclude_none=True)
+    events = payload.get("last_order_events") or []
+    if len(events) > _DIAGNOSTICS_LAST_EVENTS_CAP:
+        payload["last_order_events"] = events[-_DIAGNOSTICS_LAST_EVENTS_CAP:]
+
+    encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True)
+    return f"Execution Diagnostics: {encoded}"
+
+
+def _apply_veto_to_acceptance_reason(
+    metrics: BacktestResult,
+    suffix: str,
+    *,
+    upstream_admitted: bool,
+) -> Tuple[BacktestResult, bool]:
+    """Stamp a publication veto's cause onto ``metrics.acceptance_reason``.
+
+    Both the conformance veto (#527) and the alignment veto (#529)
+    follow the same shape: replace a stale success-style upstream
+    reason; append to a real upstream rejection. Returns the updated
+    ``metrics`` and ``False`` for the new ``upstream_admitted``, so a
+    subsequent veto on the same run appends to this one rather than
+    overwriting it.
+
+    The delimiter is ``" | "`` (not ``"; "`` which
+    :func:`summarize_acceptance_reason` uses between failing gates)
+    so downstream parsers can disambiguate the veto boundary from
+    gate-internal boundaries.
+
+    Whitespace-only upstream reasons (``None``, ``""``, ``"   "``)
+    collapse to the suffix alone — never produces
+    ``"   | <suffix>"`` with an empty left side.
+    """
+    prior = (metrics.acceptance_reason or "").strip()
+    if prior and not upstream_admitted:
+        combined = f"{prior} | {suffix}"
+    else:
+        combined = suffix
+    return metrics.model_copy(update={"acceptance_reason": combined}), False
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Pure helpers (formerly @staticmethod on StrategyLabOrchestrator).
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _merge_risk_limits_tighten_only(
+    current: RiskLimits, proposed: Any
+) -> Tuple[RiskLimits, List[str], List[str]]:
+    """Tighten-only merge of refinement-proposed risk limits (#543).
+
+    Returns ``(merged_limits, loosened_fields, discarded_unknown_keys)``.
+
+    - ``loosened_fields`` lists fields whose proposed value would loosen
+      the limit (raise an "lower"-direction cap, lower a "higher"-direction
+      floor, or transition ``target_annual_vol`` from ``None`` to a
+      value — which fundamentally changes the sizing model and is
+      treated as loosening).
+    - ``discarded_unknown_keys`` lists fields the caller proposed that
+      either aren't in the ``RiskLimits`` schema or are marked
+      immutable in ``_RISK_LIMIT_TIGHTEN_DIRECTION`` (e.g.
+      ``vol_lookback_days``).
+
+    Callers raise ``SpecImplementabilityError`` when ``loosened_fields``
+    is non-empty; unknown keys are warned but never trip.
+    """
+    loosened: List[str] = []
+    unknown: List[str] = []
+    if not isinstance(proposed, dict):
+        return current, loosened, unknown
+
+    merged_data = current.model_dump()
+    for key, new_value in proposed.items():
+        direction = _RISK_LIMIT_TIGHTEN_DIRECTION.get(key)
+        if direction is None:
+            # Either unknown to RiskLimits or explicitly immutable.
+            unknown.append(key)
+            continue
+
+        current_value = merged_data.get(key)
+
+        # Special-case ``target_annual_vol``: ``None`` means "no vol
+        # target" (flat sizing). Switching to a value or vice-versa
+        # changes the sizing model — treat any None↔value transition
+        # as loosening.
+        if key == "target_annual_vol":
+            if current_value is None and new_value is not None:
+                loosened.append(key)
+                continue
+            if current_value is not None and new_value is None:
+                loosened.append(key)
+                continue
+
+        try:
+            cmp_current = float(current_value) if current_value is not None else None
+            cmp_new = float(new_value) if new_value is not None else None
+        except (TypeError, ValueError):
+            unknown.append(key)
+            continue
+
+        if cmp_current is None or cmp_new is None:
+            # Already handled above; defensive.
+            continue
+
+        if direction == "lower":
+            if cmp_new < cmp_current:
+                merged_data[key] = new_value
+            elif cmp_new > cmp_current:
+                loosened.append(key)
+            # equal: no-op
+        elif direction == "higher":
+            if cmp_new > cmp_current:
+                merged_data[key] = new_value
+            elif cmp_new < cmp_current:
+                loosened.append(key)
+            # equal: no-op
+
+    try:
+        merged = RiskLimits.model_validate(merged_data)
+    except Exception:
+        # Validation failed on the merged limits — bail out without
+        # mutating; surface every proposed key as unknown so the caller
+        # logs the full set and keeps the original limits.
+        logger.warning(
+            "Refined risk_limits failed pydantic validation; keeping current limits unchanged."
+        )
+        return current, loosened, sorted(set(unknown) | set(proposed.keys()))
+
+    return merged, loosened, unknown
+
+
+def _daily_returns_from_trades(
+    trades: Sequence[TradeRecord],
+    initial_capital: float,
+    start_date: str,
+    end_date: str,
+) -> List[float]:
+    """Daily log returns from the equity curve implied by the trades.
+
+    Log basis matches :meth:`EquityCurve.daily_returns` and the rest of
+    the metrics module, so OOS-Sharpe / DSR / bootstrap CIs computed
+    downstream share the same return convention as the in-sample
+    ``compute_performance_metrics`` Sharpe.
+
+    If the equity curve crosses zero (portfolio ruin), the series is
+    returned **empty** rather than zero-padding the ruin step. Zeroing
+    a wipeout would convert it to a neutral day and let the OOS DSR /
+    Sharpe CI / moments report misleadingly low risk; an empty series
+    falls through every downstream consumer
+    (:func:`summarize_return_moments`, :func:`compute_deflated_sharpe`,
+    :func:`bootstrap_sharpe_ci`) as their well-defined "no data" path.
+    """
+    curve = build_equity_curve_from_trades(
+        trades, initial_capital, start_date=start_date, end_date=end_date
+    )
+    if len(curve.equity) < 2:
+        return []
+    if any(v <= 0 for v in curve.equity):
+        # Ruin: invalidate the whole series.
+        return []
+    out: List[float] = []
+    for i in range(1, len(curve.equity)):
+        out.append(math.log(curve.equity[i] / curve.equity[i - 1]))
+    return out
+
+
+def _equity_to_returns(equity: Sequence[float]) -> List[float]:
+    out: List[float] = []
+    for i in range(1, len(equity)):
+        prev = equity[i - 1]
+        if prev <= 0:
+            out.append(0.0)
+        else:
+            out.append((equity[i] - prev) / prev)
+    return out
+
+
+def _closes_to_equity(closes: Sequence[float], initial_capital: float) -> List[float]:
+    if not closes or closes[0] <= 0:
+        return []
+    scale = initial_capital / closes[0]
+    return [c * scale for c in closes]
+
+
+def _parse_bar_date(d: str) -> Any:
+    from datetime import date
+
+    return date.fromisoformat(d[:10])
+
+
+def _resolve_vix_provider() -> Optional[Callable[[Sequence[Any]], List[float]]]:
+    """Return a VIX provider callable when ``STRATEGY_LAB_VIX_SOURCE`` is
+    set, otherwise None so :func:`vix_quartile_subwindows` falls back to
+    realized-vol on the benchmark series. Production deployments can
+    wire in a Yahoo ``^VIX`` fetcher here without touching callers."""
+    source = os.environ.get("STRATEGY_LAB_VIX_SOURCE", "").strip().lower()
+    if not source:
+        return None
+    # Hook point for production providers; unset → realized-vol fallback.
+    return None

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -65,6 +65,7 @@ from .quality_gates.code_safety import CodeSafetyChecker
 from .quality_gates.convergence_tracker import ConvergenceTracker
 from .quality_gates.exit_rule_conformance import ExitRuleConformanceGate
 from .quality_gates.models import QualityGateResult
+from .quality_gates.spec_readiness import SpecReadinessGate
 from .quality_gates.strategy_validator import StrategySpecValidator
 from .quality_gates.target_symbol_coverage import TargetSymbolCoverageGate
 from .spec_dsl import DEFAULT_SIZING_PAYLOAD
@@ -271,6 +272,7 @@ class StrategyLabOrchestrator:
         self.zero_trade_repair_agent = ZeroTradeRepairAgent()
         self.analysis_agent = AnalysisAgent()
         self.strategy_validator = StrategySpecValidator()
+        self.spec_readiness_gate = SpecReadinessGate()
         self.code_safety_checker = CodeSafetyChecker()
         self.anomaly_detector = BacktestAnomalyDetector()
         self.acceptance_gate = AcceptanceGate()
@@ -486,6 +488,13 @@ class StrategyLabOrchestrator:
             for g in pre_spec_gates_raw
             if not (g.severity == "critical" and g.details.startswith("strategy_code is missing"))
         ]
+        # Issue #540 — SpecReadinessGate runs in the design phase, blocking
+        # exit to synthesis on any critical failure. Hands its results to the
+        # same short-circuit path as StrategySpecValidator below.
+        readiness_design = self.spec_readiness_gate.validate(
+            spec, phase="design", backtest_config=config
+        )
+        pre_spec_gates.extend(readiness_design)
         for g in pre_spec_gates:
             g.refinement_round = -1
         all_gate_results.extend(pre_spec_gates)
@@ -533,6 +542,17 @@ class StrategyLabOrchestrator:
             #       pre-synthesis and is immutable for this cycle, see
             #       #547 items 1 & 2).
             emit("coding", {"sub_phase": "started", "refinement_round": round_num})
+            # Issue #540 — re-run SpecReadinessGate on the first synthesis
+            # round as a defense-in-depth sanity check that the spec wasn't
+            # mutated between design exit and synthesis entry. The spec is
+            # immutable across the remaining rounds so we don't repeat the
+            # check.
+            if round_num == 0:
+                round_gate_results.extend(
+                    self.spec_readiness_gate.validate(
+                        spec, phase="synthesis", backtest_config=config
+                    )
+                )
             code_gates = self.code_safety_checker.check(code, spec)
             round_gate_results.extend(code_gates)
             for g in round_gate_results:
@@ -615,6 +635,7 @@ class StrategyLabOrchestrator:
                             gate_name="market_data",
                             passed=False,
                             severity="critical",
+                            phase="synthesis",
                             details=f"No market data available for asset class '{spec.asset_class}'.",
                             refinement_round=round_num,
                         )
@@ -653,6 +674,7 @@ class StrategyLabOrchestrator:
                         gate_name="code_execution",
                         passed=False,
                         severity="critical",
+                        phase="synthesis",
                         details=f"Execution failed ({exec_result.error_type}): {exec_result.stderr[:500]}",
                         refinement_round=round_num,
                     )
@@ -920,6 +942,7 @@ class StrategyLabOrchestrator:
                         gate_name="trade_alignment",
                         passed=report.aligned,
                         severity=gate_severity,  # type: ignore[arg-type]
+                        phase="verification",
                         details=gate_details,
                         refinement_round=align_round,
                     )
@@ -1038,6 +1061,7 @@ class StrategyLabOrchestrator:
                             gate_name="alignment_code_execution",
                             passed=False,
                             severity="critical",
+                            phase="verification",
                             details=(
                                 f"Re-execution after alignment fix failed "
                                 f"({align_exec.error_type}): {align_exec.stderr[:400]}"
@@ -1725,6 +1749,7 @@ class StrategyLabOrchestrator:
                     gate_name="zero_trade_repair_dropped_spec_keys",
                     passed=False,
                     severity="warning",
+                    phase="synthesis",
                     details=(
                         "Zero-trade repair proposed off-list spec keys "
                         f"{dropped_spec_keys}; dropped per #530 "
@@ -1817,6 +1842,7 @@ class StrategyLabOrchestrator:
                 gate_name="zero_trade_repair_code_execution",
                 passed=False,
                 severity="critical",
+                phase="synthesis",
                 details=(
                     f"Re-execution after zero-trade repair failed "
                     f"({repair_exec.error_type}): {repair_exec.stderr[:400]}"

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -43,7 +43,7 @@ from ..models import (
 )
 from ..signal_intelligence_models import SignalIntelligenceBriefV1
 from ..trade_simulator import compute_metrics
-from ..trading_service.modes.sandbox_compat import run_strategy_code
+from ..trading_service.modes.sandbox_compat import StrategyRunResult, run_strategy_code
 from .agents.alignment import AlignmentAuditError, TradeAlignmentAgent, TradeAlignmentReport
 from .agents.analysis import AnalysisAgent
 from .agents.ideation import IdeationAgent
@@ -489,39 +489,24 @@ class StrategyLabOrchestrator:
                         "checks_total": checks_total,
                     },
                 )
-                if round_num < MAX_CODE_REFINEMENT_ROUNDS - 1:
-                    emit(
-                        "coding",
-                        {
-                            "sub_phase": "refining",
-                            "refinement_round": round_num,
-                            "failure_phase": "validation",
-                        },
-                    )
-                    failure_details = "\n".join(
-                        f"- [{g.gate_name}] {g.details}" for g in critical_failures
-                    )
-                    updates, code = self._refine(
-                        spec, code, "validation", failure_details, None, refinement_attempts
-                    )
-                    spec = self._apply_updates(spec, updates, code, failure_phase="validation")
-                    changes = updates.get("changes_made", "validation fix")
-                    refinement_attempts.append(changes)
-                    emit(
-                        "coding",
-                        {
-                            "sub_phase": "refined",
-                            "refinement_round": round_num,
-                            "changes_made": changes,
-                        },
-                    )
-                    continue
-                else:
-                    logger.warning(
-                        "Max code refinement rounds reached on validation for %s", spec.strategy_id
-                    )
+                failure_details = "\n".join(
+                    f"- [{g.gate_name}] {g.details}" for g in critical_failures
+                )
+                spec, code, exhausted = self._refine_or_exhaust(
+                    spec=spec,
+                    code=code,
+                    failure_phase="validation",
+                    failure_details=failure_details,
+                    metrics=None,
+                    refinement_attempts=refinement_attempts,
+                    round_num=round_num,
+                    default_change_label="validation fix",
+                    emit=emit,
+                )
+                if exhausted:
                     max_rounds_exhausted = True
                     break
+                continue
 
             emit(
                 "coding",
@@ -582,40 +567,25 @@ class StrategyLabOrchestrator:
                         refinement_round=round_num,
                     )
                 )
-                if round_num < MAX_CODE_REFINEMENT_ROUNDS - 1:
-                    emit(
-                        "coding",
-                        {
-                            "sub_phase": "refining",
-                            "refinement_round": round_num,
-                            "failure_phase": "execution",
-                        },
-                    )
-                    failure_details = (
-                        f"Error type: {exec_result.error_type}\n"
-                        f"stderr:\n{exec_result.stderr[:2000]}"
-                    )
-                    updates, code = self._refine(
-                        spec, code, "execution", failure_details, None, refinement_attempts
-                    )
-                    spec = self._apply_updates(spec, updates, code, failure_phase="execution")
-                    changes = updates.get("changes_made", "execution fix")
-                    refinement_attempts.append(changes)
-                    emit(
-                        "coding",
-                        {
-                            "sub_phase": "refined",
-                            "refinement_round": round_num,
-                            "changes_made": changes,
-                        },
-                    )
-                    continue
-                else:
-                    logger.warning(
-                        "Max code refinement rounds reached on execution for %s", spec.strategy_id
-                    )
+                failure_details = (
+                    f"Error type: {exec_result.error_type}\n"
+                    f"stderr:\n{exec_result.stderr[:2000]}"
+                )
+                spec, code, exhausted = self._refine_or_exhaust(
+                    spec=spec,
+                    code=code,
+                    failure_phase="execution",
+                    failure_details=failure_details,
+                    metrics=None,
+                    refinement_attempts=refinement_attempts,
+                    round_num=round_num,
+                    default_change_label="execution fix",
+                    emit=emit,
+                )
+                if exhausted:
                     max_rounds_exhausted = True
                     break
+                continue
 
             # ── 2d: COLLECT TRADES + target-symbol coverage on trades ─
             trades = exec_result.trades
@@ -663,94 +633,25 @@ class StrategyLabOrchestrator:
                 g for g in anomaly_gates if not g.passed and g.severity == "critical"
             ]
             if critical_anomalies:
-                if round_num < MAX_CODE_REFINEMENT_ROUNDS - 1:
-                    emit(
-                        "coding",
-                        {
-                            "sub_phase": "refining",
-                            "refinement_round": round_num,
-                            "failure_phase": "evaluation",
-                        },
-                    )
-                    failure_details = "\n".join(f"- {g.details}" for g in critical_anomalies)
-                    diagnostics_block = _format_execution_diagnostics(
-                        exec_result.execution_diagnostics
-                    )
-                    if diagnostics_block:
-                        failure_details = f"{failure_details}\n{diagnostics_block}"
-                    coverage_block = format_coverage_report(metrics.coverage_report)
-                    if coverage_block:
-                        failure_details = f"{failure_details}\n{coverage_block}"
-
-                    diag = exec_result.execution_diagnostics
-                    if (
-                        diag is not None
-                        and diag.zero_trade_category is not None
-                        and market_data is not None
-                    ):
-                        zt_outcome = self.zero_trade_repairer.try_repair(
-                            spec=spec,
-                            code=code,
-                            exec_result=exec_result,
-                            coverage_report=metrics.coverage_report,
-                            market_data=market_data,
-                            config=config,
-                            zero_trade_attempts=zero_trade_attempts,
-                            round_num=round_num,
-                            emit=emit,
-                        )
-                        all_gate_results.extend(zt_outcome.new_gates)
-                        if zt_outcome.committed:
-                            assert zt_outcome.new_spec is not None
-                            assert zt_outcome.new_metrics is not None
-                            assert zt_outcome.new_exec_result is not None
-                            code = zt_outcome.new_code
-                            spec = zt_outcome.new_spec
-                            trades = zt_outcome.new_trades
-                            metrics = zt_outcome.new_metrics
-                            exec_result = zt_outcome.new_exec_result
-                            refinement_attempts.append(
-                                f"zero-trade repair: {zt_outcome.changes_made}"
-                                if zt_outcome.changes_made
-                                else "zero-trade repair"
-                            )
-                            emit(
-                                "coding",
-                                {
-                                    "sub_phase": "refined",
-                                    "refinement_round": round_num,
-                                    "changes_made": (
-                                        zt_outcome.changes_made or "zero-trade repair"
-                                    ),
-                                    "via": "zero_trade_repair",
-                                },
-                            )
-                            continue
-
-                    updates, code = self._refine(
-                        spec,
-                        code,
-                        "evaluation (backtest anomaly)",
-                        failure_details,
-                        metrics,
-                        refinement_attempts,
-                    )
-                    spec = self._apply_updates(spec, updates, code, failure_phase="evaluation")
-                    changes = updates.get("changes_made", "anomaly fix")
-                    refinement_attempts.append(changes)
-                    emit(
-                        "coding",
-                        {
-                            "sub_phase": "refined",
-                            "refinement_round": round_num,
-                            "changes_made": changes,
-                        },
-                    )
-                    continue
-                else:
-                    logger.warning(
-                        "Max code refinement rounds reached on evaluation for %s", spec.strategy_id
-                    )
+                recovery = self._handle_critical_anomalies(
+                    spec=spec,
+                    code=code,
+                    trades=trades,
+                    metrics=metrics,
+                    exec_result=exec_result,
+                    market_data=market_data,
+                    config=config,
+                    critical_anomalies=critical_anomalies,
+                    all_gate_results=all_gate_results,
+                    refinement_attempts=refinement_attempts,
+                    zero_trade_attempts=zero_trade_attempts,
+                    round_num=round_num,
+                    emit=emit,
+                )
+                spec, code = recovery.spec, recovery.code
+                trades, metrics = recovery.trades, recovery.metrics
+                exec_result = recovery.exec_result
+                if recovery.exhausted:
                     # Even if the code is technically correct, the cycle
                     # exhausted its rounds on an unresolved anomaly. Leaving
                     # execution_succeeded=False ensures is_winning stays False
@@ -758,6 +659,7 @@ class StrategyLabOrchestrator:
                     # "failed: max_refinement_rounds" record.
                     max_rounds_exhausted = True
                     break
+                continue
 
             # All gates passed — code is clean and backtest is sound
             execution_succeeded = True
@@ -777,6 +679,121 @@ class StrategyLabOrchestrator:
             fetched_symbols=fetched_symbols,
             execution_succeeded=execution_succeeded,
             max_rounds_exhausted=max_rounds_exhausted,
+        )
+
+    def _handle_critical_anomalies(
+        self,
+        *,
+        spec: StrategySpec,
+        code: str,
+        trades: List[TradeRecord],
+        metrics: BacktestResult,
+        exec_result: StrategyRunResult,
+        market_data: Dict[str, List[OHLCVBar]],
+        config: BacktestConfig,
+        critical_anomalies: List[QualityGateResult],
+        all_gate_results: List[QualityGateResult],
+        refinement_attempts: List[str],
+        zero_trade_attempts: List[str],
+        round_num: int,
+        emit: PhaseCallback,
+    ) -> _AnomalyRecoveryOutcome:
+        """Recover from critical backtest anomalies in the evaluation phase.
+
+        Pre: ``critical_anomalies`` is non-empty; the caller has already
+        run the anomaly detector and recorded its gates;
+        ``all_gate_results``, ``refinement_attempts``, ``zero_trade_attempts``
+        are running lists the helper mutates in place.
+        Post: returns an ``_AnomalyRecoveryOutcome``. On ``exhausted=False``
+        the spec/code/trades/metrics/exec_result fields carry the new
+        known-good state (either a committed zero-trade-repair proposal or
+        the source the generic refinement loop produced) and the caller
+        ``continue``s the synthesis loop. On ``exhausted=True`` the round
+        budget is spent and the caller breaks with
+        ``max_rounds_exhausted=True``.
+
+        Strategy:
+          1. If diagnostics carry a ``zero_trade_category`` AND there is
+             market data, ask the specialised repair agent first. A
+             committed proposal has already cleared safety + fresh
+             backtest + anomaly gates, so we use it directly.
+          2. Otherwise (or if the repair did not commit), fall through
+             to the generic refinement agent via ``_refine_or_exhaust``.
+        """
+        assert critical_anomalies, "_handle_critical_anomalies requires at least one critical"
+        assert isinstance(market_data, dict) and market_data, "market_data must be non-empty"
+
+        # ── 1: Build the failure-details prompt block (also used by generic refine) ──
+        failure_details = "\n".join(f"- {g.details}" for g in critical_anomalies)
+        diagnostics_block = _format_execution_diagnostics(exec_result.execution_diagnostics)
+        if diagnostics_block:
+            failure_details = f"{failure_details}\n{diagnostics_block}"
+        coverage_block = format_coverage_report(metrics.coverage_report)
+        if coverage_block:
+            failure_details = f"{failure_details}\n{coverage_block}"
+
+        # ── 2: Specialised zero-trade repair (if diagnostics support it) ──
+        diag = exec_result.execution_diagnostics
+        if diag is not None and diag.zero_trade_category is not None:
+            zt_outcome = self.zero_trade_repairer.try_repair(
+                spec=spec,
+                code=code,
+                exec_result=exec_result,
+                coverage_report=metrics.coverage_report,
+                market_data=market_data,
+                config=config,
+                zero_trade_attempts=zero_trade_attempts,
+                round_num=round_num,
+                emit=emit,
+            )
+            all_gate_results.extend(zt_outcome.new_gates)
+            if zt_outcome.committed:
+                assert zt_outcome.new_spec is not None, "committed ZTR must carry new_spec"
+                assert zt_outcome.new_metrics is not None, "committed ZTR must carry new_metrics"
+                assert zt_outcome.new_exec_result is not None, "committed ZTR must carry new_exec_result"
+                refinement_attempts.append(
+                    f"zero-trade repair: {zt_outcome.changes_made}"
+                    if zt_outcome.changes_made
+                    else "zero-trade repair"
+                )
+                emit(
+                    "coding",
+                    {
+                        "sub_phase": "refined",
+                        "refinement_round": round_num,
+                        "changes_made": (zt_outcome.changes_made or "zero-trade repair"),
+                        "via": "zero_trade_repair",
+                    },
+                )
+                return _AnomalyRecoveryOutcome(
+                    spec=zt_outcome.new_spec,
+                    code=zt_outcome.new_code,
+                    trades=zt_outcome.new_trades,
+                    metrics=zt_outcome.new_metrics,
+                    exec_result=zt_outcome.new_exec_result,
+                    exhausted=False,
+                )
+
+        # ── 3: Generic refinement (or exhaust the round budget) ──
+        new_spec, new_code, exhausted = self._refine_or_exhaust(
+            spec=spec,
+            code=code,
+            failure_phase="evaluation",
+            refine_label="evaluation (backtest anomaly)",
+            failure_details=failure_details,
+            metrics=metrics,
+            refinement_attempts=refinement_attempts,
+            round_num=round_num,
+            default_change_label="anomaly fix",
+            emit=emit,
+        )
+        return _AnomalyRecoveryOutcome(
+            spec=new_spec,
+            code=new_code,
+            trades=trades,
+            metrics=metrics,
+            exec_result=exec_result,
+            exhausted=exhausted,
         )
 
     def _run_trade_alignment_loop(
@@ -833,233 +850,23 @@ class StrategyLabOrchestrator:
             )
 
         for align_round in range(MAX_ALIGNMENT_ROUNDS):
-            emit(
-                "aligning",
-                {
-                    "sub_phase": "evaluating",
-                    "alignment_round": align_round,
-                    "trades_count": len(trades),
-                },
-            )
-
-            report = self._run_alignment_audit(
+            round_outcome = self._run_alignment_round(
                 spec=spec,
                 code=code,
                 trades=trades,
                 metrics=metrics,
-                prior_attempts=alignment_attempts,
-            )
-            alignment_reports.append(report)
-
-            gate_severity = "info" if report.aligned else "critical"
-            gate_details = (
-                report.rationale or "Trades aligned with strategy."
-                if report.aligned
-                else (
-                    report.rationale
-                    or f"Trades did not align with strategy ({len(report.issues)} issues)."
-                )
-            )
-            all_gate_results.append(
-                self.build_orchestrator_gate(
-                    "trade_alignment",
-                    phase="verification",
-                    severity=gate_severity,  # type: ignore[arg-type]
-                    details=gate_details,
-                    refinement_round=align_round,
-                )
-            )
-
-            if report.aligned:
-                emit(
-                    "aligning",
-                    {"sub_phase": "aligned", "alignment_round": align_round},
-                )
-                break
-
-            emit(
-                "aligning",
-                {
-                    "sub_phase": "not_aligned",
-                    "alignment_round": align_round,
-                    "issues_count": len(report.issues),
-                    "issues_preview": [
-                        {
-                            "rule_type": i.rule_type,
-                            "severity": i.severity,
-                            "description": i.description[:160],
-                        }
-                        for i in report.issues[:5]
-                    ],
-                },
-            )
-
-            if not report.proposed_code:
-                emit(
-                    "aligning",
-                    {"sub_phase": "no_proposed_fix", "alignment_round": align_round},
-                )
-                break
-
-            if align_round >= MAX_ALIGNMENT_ROUNDS - 1:
-                emit(
-                    "aligning",
-                    {"sub_phase": "max_rounds_reached", "alignment_round": align_round},
-                )
-                logger.warning(
-                    "Max alignment rounds (%d) reached for %s",
-                    MAX_ALIGNMENT_ROUNDS,
-                    spec.strategy_id,
-                )
-                break
-
-            emit(
-                "aligning",
-                {
-                    "sub_phase": "refining_code",
-                    "alignment_round": align_round,
-                    "predicted_aligned_after_fix": report.predicted_aligned_after_fix,
-                },
-            )
-            proposed_code = report.proposed_code
-            proposed_spec = self._apply_updates(spec, {}, proposed_code)
-            change_summary = report.changes_made or "alignment fix"
-
-            # Re-validate code safety on the proposed code — alignment runs
-            # after backtest, so the phase tag is verification.
-            safety_gates = self.code_safety_checker.check(
-                proposed_code, proposed_spec, phase="verification"
-            )
-            self.record_gates(
-                safety_gates,
-                all_gate_results,
-                refinement_round=align_round,
-                gate_name_prefix="alignment_",
-            )
-            critical_safety = [
-                g for g in safety_gates if not g.passed and g.severity == "critical"
-            ]
-            if critical_safety:
-                emit(
-                    "aligning",
-                    {
-                        "sub_phase": "rejected_unsafe_code",
-                        "alignment_round": align_round,
-                        "details": "; ".join(g.details for g in critical_safety)[:400],
-                    },
-                )
-                logger.warning(
-                    "Alignment-proposed code failed safety gate for %s", spec.strategy_id
-                )
-                break
-
-            emit(
-                "backtesting",
-                {
-                    "sub_phase": "running_code",
-                    "alignment_round": align_round,
-                    "trigger": "trade_alignment_fix",
-                },
-            )
-            align_exec = run_strategy_code(proposed_code, market_data, config, strategy=spec)
-            if not align_exec.success:
-                all_gate_results.append(
-                    self.build_orchestrator_gate(
-                        "alignment_code_execution",
-                        phase="verification",
-                        details=(
-                            f"Re-execution after alignment fix failed "
-                            f"({align_exec.error_type}): {align_exec.stderr[:400]}"
-                        ),
-                        refinement_round=align_round,
-                    )
-                )
-                emit(
-                    "aligning",
-                    {
-                        "sub_phase": "re_execution_failed",
-                        "alignment_round": align_round,
-                        "error_type": align_exec.error_type,
-                    },
-                )
-                break
-
-            new_trades = align_exec.trades
-            new_metrics = compute_metrics(
-                new_trades, config.initial_capital, config.start_date, config.end_date
-            )
-
-            # Alignment re-backtest path attaches a CoverageReport when the
-            # fix produced zero/low trades. Pass ``proposed_spec`` (which
-            # carries ``proposed_code``) — the loop-level ``spec`` still
-            # holds the pre-alignment source.
-            _maybe_attach_coverage_report(
-                metrics=new_metrics,
-                spec=proposed_spec,
                 market_data=market_data,
                 config=config,
-                exec_result=align_exec,
+                align_round=align_round,
+                all_gate_results=all_gate_results,
+                alignment_attempts=alignment_attempts,
+                alignment_reports=alignment_reports,
+                emit=emit,
             )
-
-            anomaly_gates = self.anomaly_detector.check(
-                new_metrics,
-                new_trades,
-                dsr_aware=config.walk_forward_enabled,
-                diagnostics=align_exec.execution_diagnostics,
-                coverage_report=new_metrics.coverage_report,
-                phase="verification",
-            )
-            self.record_gates(
-                anomaly_gates,
-                all_gate_results,
-                refinement_round=align_round,
-                gate_name_prefix="alignment_",
-            )
-            critical_anomalies = [
-                g for g in anomaly_gates if not g.passed and g.severity == "critical"
-            ]
-            if critical_anomalies:
-                diagnostics_block = _format_execution_diagnostics(
-                    align_exec.execution_diagnostics
-                )
-                emit_payload: Dict[str, Any] = {
-                    "sub_phase": "anomaly_detected",
-                    "alignment_round": align_round,
-                    "details": "; ".join(g.details for g in critical_anomalies)[:400],
-                }
-                if diagnostics_block:
-                    emit_payload["execution_diagnostics"] = diagnostics_block
-                emit("aligning", emit_payload)
-                if diagnostics_block:
-                    logger.warning(
-                        "Alignment fix introduced backtest anomaly for %s — %s",
-                        spec.strategy_id,
-                        diagnostics_block,
-                    )
-                else:
-                    logger.warning(
-                        "Alignment fix introduced backtest anomaly for %s",
-                        spec.strategy_id,
-                    )
+            spec, code = round_outcome.spec, round_outcome.code
+            trades, metrics = round_outcome.trades, round_outcome.metrics
+            if round_outcome.terminate:
                 break
-
-            # All gates passed — commit the proposal as the new known-good
-            # state and continue to the next audit.
-            code = proposed_code
-            spec = proposed_spec
-            trades = new_trades
-            metrics = new_metrics
-            alignment_attempts.append(change_summary)
-
-            emit(
-                "aligning",
-                {
-                    "sub_phase": "refined",
-                    "alignment_round": align_round,
-                    "changes_made": change_summary,
-                    "trades_count": len(trades),
-                },
-            )
 
         return _AlignmentLoopOutcome(
             spec=spec,
@@ -1069,6 +876,273 @@ class StrategyLabOrchestrator:
             alignment_attempts=alignment_attempts,
             alignment_reports=alignment_reports,
             trades_aligned=bool(alignment_reports and alignment_reports[-1].aligned),
+        )
+
+    def _run_alignment_round(
+        self,
+        *,
+        spec: StrategySpec,
+        code: str,
+        trades: List[TradeRecord],
+        metrics: BacktestResult,
+        market_data: Dict[str, List[OHLCVBar]],
+        config: BacktestConfig,
+        align_round: int,
+        all_gate_results: List[QualityGateResult],
+        alignment_attempts: List[str],
+        alignment_reports: List[TradeAlignmentReport],
+        emit: PhaseCallback,
+    ) -> _AlignmentRoundOutcome:
+        """One iteration of ``_run_trade_alignment_loop``.
+
+        Pre: ``align_round`` is the current 0-indexed iteration;
+        ``alignment_reports``, ``alignment_attempts``, ``all_gate_results``
+        are running lists the helper mutates in place.
+        Post: returns an ``_AlignmentRoundOutcome``. On ``terminate=True``
+        the caller breaks (state carries the pre-iteration values);
+        on ``terminate=False`` the caller continues (state carries the
+        committed proposal as the new known-good baseline).
+
+        Step sequence:
+          1. Audit current trades → append report → record gate.
+          2. If aligned: terminate with success (no state change).
+          3. If no proposed fix: terminate.
+          4. If at max rounds: terminate.
+          5. Run code-safety on proposed code; if critical: terminate.
+          6. Re-execute proposed code; if failed: terminate.
+          7. Compute metrics + coverage; run anomaly gates;
+             if critical: terminate.
+          8. Commit proposal as new known-good state; continue.
+        """
+        assert align_round >= 0, "align_round must be non-negative"
+        assert isinstance(market_data, dict) and market_data, "market_data must be non-empty"
+
+        emit(
+            "aligning",
+            {
+                "sub_phase": "evaluating",
+                "alignment_round": align_round,
+                "trades_count": len(trades),
+            },
+        )
+        report = self._run_alignment_audit(
+            spec=spec,
+            code=code,
+            trades=trades,
+            metrics=metrics,
+            prior_attempts=alignment_attempts,
+        )
+        alignment_reports.append(report)
+
+        gate_severity = "info" if report.aligned else "critical"
+        gate_details = (
+            report.rationale or "Trades aligned with strategy."
+            if report.aligned
+            else (
+                report.rationale
+                or f"Trades did not align with strategy ({len(report.issues)} issues)."
+            )
+        )
+        all_gate_results.append(
+            self.build_orchestrator_gate(
+                "trade_alignment",
+                phase="verification",
+                severity=gate_severity,  # type: ignore[arg-type]
+                details=gate_details,
+                refinement_round=align_round,
+            )
+        )
+
+        def _terminate() -> _AlignmentRoundOutcome:
+            return _AlignmentRoundOutcome(
+                spec=spec, code=code, trades=trades, metrics=metrics, terminate=True
+            )
+
+        if report.aligned:
+            emit("aligning", {"sub_phase": "aligned", "alignment_round": align_round})
+            return _terminate()
+
+        emit(
+            "aligning",
+            {
+                "sub_phase": "not_aligned",
+                "alignment_round": align_round,
+                "issues_count": len(report.issues),
+                "issues_preview": [
+                    {
+                        "rule_type": i.rule_type,
+                        "severity": i.severity,
+                        "description": i.description[:160],
+                    }
+                    for i in report.issues[:5]
+                ],
+            },
+        )
+
+        if not report.proposed_code:
+            emit(
+                "aligning",
+                {"sub_phase": "no_proposed_fix", "alignment_round": align_round},
+            )
+            return _terminate()
+
+        if align_round >= MAX_ALIGNMENT_ROUNDS - 1:
+            emit(
+                "aligning",
+                {"sub_phase": "max_rounds_reached", "alignment_round": align_round},
+            )
+            logger.warning(
+                "Max alignment rounds (%d) reached for %s",
+                MAX_ALIGNMENT_ROUNDS,
+                spec.strategy_id,
+            )
+            return _terminate()
+
+        emit(
+            "aligning",
+            {
+                "sub_phase": "refining_code",
+                "alignment_round": align_round,
+                "predicted_aligned_after_fix": report.predicted_aligned_after_fix,
+            },
+        )
+        proposed_code = report.proposed_code
+        proposed_spec = self._apply_updates(spec, {}, proposed_code)
+        change_summary = report.changes_made or "alignment fix"
+
+        # Re-validate code safety on the proposed code — alignment runs
+        # after backtest, so the phase tag is verification.
+        safety_gates = self.code_safety_checker.check(
+            proposed_code, proposed_spec, phase="verification"
+        )
+        self.record_gates(
+            safety_gates,
+            all_gate_results,
+            refinement_round=align_round,
+            gate_name_prefix="alignment_",
+        )
+        critical_safety = [g for g in safety_gates if not g.passed and g.severity == "critical"]
+        if critical_safety:
+            emit(
+                "aligning",
+                {
+                    "sub_phase": "rejected_unsafe_code",
+                    "alignment_round": align_round,
+                    "details": "; ".join(g.details for g in critical_safety)[:400],
+                },
+            )
+            logger.warning(
+                "Alignment-proposed code failed safety gate for %s", spec.strategy_id
+            )
+            return _terminate()
+
+        emit(
+            "backtesting",
+            {
+                "sub_phase": "running_code",
+                "alignment_round": align_round,
+                "trigger": "trade_alignment_fix",
+            },
+        )
+        align_exec = run_strategy_code(proposed_code, market_data, config, strategy=spec)
+        if not align_exec.success:
+            all_gate_results.append(
+                self.build_orchestrator_gate(
+                    "alignment_code_execution",
+                    phase="verification",
+                    details=(
+                        f"Re-execution after alignment fix failed "
+                        f"({align_exec.error_type}): {align_exec.stderr[:400]}"
+                    ),
+                    refinement_round=align_round,
+                )
+            )
+            emit(
+                "aligning",
+                {
+                    "sub_phase": "re_execution_failed",
+                    "alignment_round": align_round,
+                    "error_type": align_exec.error_type,
+                },
+            )
+            return _terminate()
+
+        new_trades = align_exec.trades
+        new_metrics = compute_metrics(
+            new_trades, config.initial_capital, config.start_date, config.end_date
+        )
+
+        # Alignment re-backtest path attaches a CoverageReport when the
+        # fix produced zero/low trades. Pass ``proposed_spec`` (which
+        # carries ``proposed_code``) — the loop-level ``spec`` still
+        # holds the pre-alignment source.
+        _maybe_attach_coverage_report(
+            metrics=new_metrics,
+            spec=proposed_spec,
+            market_data=market_data,
+            config=config,
+            exec_result=align_exec,
+        )
+
+        anomaly_gates = self.anomaly_detector.check(
+            new_metrics,
+            new_trades,
+            dsr_aware=config.walk_forward_enabled,
+            diagnostics=align_exec.execution_diagnostics,
+            coverage_report=new_metrics.coverage_report,
+            phase="verification",
+        )
+        self.record_gates(
+            anomaly_gates,
+            all_gate_results,
+            refinement_round=align_round,
+            gate_name_prefix="alignment_",
+        )
+        critical_anomalies = [
+            g for g in anomaly_gates if not g.passed and g.severity == "critical"
+        ]
+        if critical_anomalies:
+            diagnostics_block = _format_execution_diagnostics(
+                align_exec.execution_diagnostics
+            )
+            emit_payload: Dict[str, Any] = {
+                "sub_phase": "anomaly_detected",
+                "alignment_round": align_round,
+                "details": "; ".join(g.details for g in critical_anomalies)[:400],
+            }
+            if diagnostics_block:
+                emit_payload["execution_diagnostics"] = diagnostics_block
+            emit("aligning", emit_payload)
+            if diagnostics_block:
+                logger.warning(
+                    "Alignment fix introduced backtest anomaly for %s — %s",
+                    spec.strategy_id,
+                    diagnostics_block,
+                )
+            else:
+                logger.warning(
+                    "Alignment fix introduced backtest anomaly for %s",
+                    spec.strategy_id,
+                )
+            return _terminate()
+
+        # All gates passed — commit the proposal as the new known-good state.
+        alignment_attempts.append(change_summary)
+        emit(
+            "aligning",
+            {
+                "sub_phase": "refined",
+                "alignment_round": align_round,
+                "changes_made": change_summary,
+                "trades_count": len(new_trades),
+            },
+        )
+        return _AlignmentRoundOutcome(
+            spec=proposed_spec,
+            code=proposed_code,
+            trades=new_trades,
+            metrics=new_metrics,
+            terminate=False,
         )
 
     def _run_verification_phase(
@@ -1703,6 +1777,77 @@ class StrategyLabOrchestrator:
             logger.exception("Refinement agent failed, returning original code")
             return {"changes_made": "refinement failed — no changes"}, code
 
+    def _refine_or_exhaust(
+        self,
+        *,
+        spec: StrategySpec,
+        code: str,
+        failure_phase: str,
+        failure_details: str,
+        metrics: Optional[BacktestResult],
+        refinement_attempts: List[str],
+        round_num: int,
+        default_change_label: str,
+        emit: PhaseCallback,
+        refine_label: Optional[str] = None,
+    ) -> tuple[StrategySpec, str, bool]:
+        """Apply one refinement attempt or exhaust the round budget.
+
+        Pre: ``round_num`` is the current 0-indexed loop iteration;
+        ``refinement_attempts`` is the running change-log the caller persists.
+        Post: returns ``(new_spec, new_code, exhausted)``. When
+        ``exhausted=False`` the caller should ``continue`` (refinement was
+        applied and ``refinement_attempts`` was appended in-place); when
+        ``exhausted=True`` the caller should ``break`` (no state mutated
+        beyond a warning log).
+
+        ``refine_label`` overrides ``failure_phase`` for the ``_refine``
+        call only — used by the evaluation phase which passes
+        ``"evaluation (backtest anomaly)"`` to the refinement LLM while
+        emitting ``"evaluation"`` to the event stream.
+        """
+        assert isinstance(spec, StrategySpec), "spec must be a StrategySpec"
+        assert isinstance(code, str), "code must be a string"
+        assert isinstance(failure_phase, str) and failure_phase, "failure_phase must be non-empty"
+        assert round_num >= 0, "round_num must be non-negative"
+
+        if round_num >= MAX_CODE_REFINEMENT_ROUNDS - 1:
+            logger.warning(
+                "Max code refinement rounds reached on %s for %s",
+                failure_phase,
+                spec.strategy_id,
+            )
+            return spec, code, True
+
+        emit(
+            "coding",
+            {
+                "sub_phase": "refining",
+                "refinement_round": round_num,
+                "failure_phase": failure_phase,
+            },
+        )
+        updates, new_code = self._refine(
+            spec,
+            code,
+            refine_label or failure_phase,
+            failure_details,
+            metrics,
+            refinement_attempts,
+        )
+        new_spec = self._apply_updates(spec, updates, new_code, failure_phase=failure_phase)
+        changes = updates.get("changes_made", default_change_label)
+        refinement_attempts.append(changes)
+        emit(
+            "coding",
+            {
+                "sub_phase": "refined",
+                "refinement_round": round_num,
+                "changes_made": changes,
+            },
+        )
+        return new_spec, new_code, False
+
     def _run_alignment_audit(
         self,
         spec: StrategySpec,
@@ -2243,6 +2388,8 @@ class StrategyLabOrchestrator:
 # ──────────────────────────────────────────────────────────────────────────
 from ._orchestrator_helpers import (  # noqa: E402  — keep at file end
     _AlignmentLoopOutcome,
+    _AlignmentRoundOutcome,
+    _AnomalyRecoveryOutcome,
     _apply_veto_to_acceptance_reason,
     _closes_to_equity,
     _daily_returns_from_trades,

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -1673,90 +1673,6 @@ class StrategyLabOrchestrator:
             ),
         )
 
-    @staticmethod
-    def _merge_risk_limits_tighten_only(
-        current: RiskLimits, proposed: Any
-    ) -> Tuple[RiskLimits, List[str], List[str]]:
-        """Tighten-only merge of refinement-proposed risk limits (#543).
-
-        Returns ``(merged_limits, loosened_fields, discarded_unknown_keys)``.
-
-        - ``loosened_fields`` lists fields whose proposed value would loosen
-          the limit (raise an "lower"-direction cap, lower a "higher"-direction
-          floor, or transition ``target_annual_vol`` from ``None`` to a
-          value — which fundamentally changes the sizing model and is
-          treated as loosening).
-        - ``discarded_unknown_keys`` lists fields the caller proposed that
-          either aren't in the ``RiskLimits`` schema or are marked
-          immutable in ``_RISK_LIMIT_TIGHTEN_DIRECTION`` (e.g.
-          ``vol_lookback_days``).
-
-        Callers raise ``SpecImplementabilityError`` when ``loosened_fields``
-        is non-empty; unknown keys are warned but never trip.
-        """
-        loosened: List[str] = []
-        unknown: List[str] = []
-        if not isinstance(proposed, dict):
-            return current, loosened, unknown
-
-        merged_data = current.model_dump()
-        for key, new_value in proposed.items():
-            direction = _RISK_LIMIT_TIGHTEN_DIRECTION.get(key)
-            if direction is None:
-                # Either unknown to RiskLimits or explicitly immutable.
-                unknown.append(key)
-                continue
-
-            current_value = merged_data.get(key)
-
-            # Special-case ``target_annual_vol``: ``None`` means "no vol
-            # target" (flat sizing). Switching to a value or vice-versa
-            # changes the sizing model — treat any None↔value transition
-            # as loosening.
-            if key == "target_annual_vol":
-                if current_value is None and new_value is not None:
-                    loosened.append(key)
-                    continue
-                if current_value is not None and new_value is None:
-                    loosened.append(key)
-                    continue
-
-            try:
-                cmp_current = float(current_value) if current_value is not None else None
-                cmp_new = float(new_value) if new_value is not None else None
-            except (TypeError, ValueError):
-                unknown.append(key)
-                continue
-
-            if cmp_current is None or cmp_new is None:
-                # Already handled above; defensive.
-                continue
-
-            if direction == "lower":
-                if cmp_new < cmp_current:
-                    merged_data[key] = new_value
-                elif cmp_new > cmp_current:
-                    loosened.append(key)
-                # equal: no-op
-            elif direction == "higher":
-                if cmp_new > cmp_current:
-                    merged_data[key] = new_value
-                elif cmp_new < cmp_current:
-                    loosened.append(key)
-                # equal: no-op
-
-        try:
-            merged = RiskLimits.model_validate(merged_data)
-        except Exception:
-            # Validation failed on the merged limits — bail out without
-            # mutating; surface every proposed key as unknown so the caller
-            # logs the full set and keeps the original limits.
-            logger.warning(
-                "Refined risk_limits failed pydantic validation; keeping current limits unchanged."
-            )
-            return current, loosened, sorted(set(unknown) | set(proposed.keys()))
-
-        return merged, loosened, unknown
 
     def _apply_updates(
         self,
@@ -1785,7 +1701,7 @@ class StrategyLabOrchestrator:
         risk_limits_proposed = updates.get("risk_limits")
 
         if risk_limits_proposed is not None:
-            merged_limits, loosened, unknown = self._merge_risk_limits_tighten_only(
+            merged_limits, loosened, unknown = _merge_risk_limits_tighten_only(
                 spec.risk_limits, risk_limits_proposed
             )
             if loosened:
@@ -2071,7 +1987,7 @@ class StrategyLabOrchestrator:
         # Pooled OOS daily-return series for DSR + bootstrap CI. Uses the
         # same equity-curve construction the metrics engine uses, so the
         # series is consistent with the per-fold OOS Sharpes.
-        oos_returns = self._daily_returns_from_trades(
+        oos_returns = _daily_returns_from_trades(
             all_oos_trades, config.initial_capital, config.start_date, config.end_date
         )
         skew, kurt = summarize_return_moments(oos_returns)
@@ -2100,41 +2016,6 @@ class StrategyLabOrchestrator:
             }
         )
 
-    @staticmethod
-    def _daily_returns_from_trades(
-        trades: Sequence[TradeRecord],
-        initial_capital: float,
-        start_date: str,
-        end_date: str,
-    ) -> List[float]:
-        """Daily log returns from the equity curve implied by the trades.
-
-        Log basis matches :meth:`EquityCurve.daily_returns` and the rest of
-        the metrics module, so OOS-Sharpe / DSR / bootstrap CIs computed
-        downstream share the same return convention as the in-sample
-        ``compute_performance_metrics`` Sharpe.
-
-        If the equity curve crosses zero (portfolio ruin), the series is
-        returned **empty** rather than zero-padding the ruin step. Zeroing
-        a wipeout would convert it to a neutral day and let the OOS DSR /
-        Sharpe CI / moments report misleadingly low risk; an empty series
-        falls through every downstream consumer
-        (:func:`summarize_return_moments`, :func:`compute_deflated_sharpe`,
-        :func:`bootstrap_sharpe_ci`) as their well-defined "no data" path.
-        """
-        curve = build_equity_curve_from_trades(
-            trades, initial_capital, start_date=start_date, end_date=end_date
-        )
-        if len(curve.equity) < 2:
-            return []
-        if any(v <= 0 for v in curve.equity):
-            # Ruin: invalidate the whole series. Any downstream Sharpe / DSR
-            # / CI on a curve that touched zero would be meaningless.
-            return []
-        out: List[float] = []
-        for i in range(1, len(curve.equity)):
-            out.append(math.log(curve.equity[i] / curve.equity[i - 1]))
-        return out
 
     def _evaluate_regimes(
         self,
@@ -2161,12 +2042,12 @@ class StrategyLabOrchestrator:
             )
             if len(curve.equity) < 2:
                 return []
-            strategy_returns = self._equity_to_returns(curve.equity)
+            strategy_returns = _equity_to_returns(curve.equity)
 
             bench_dates, bench_equity = self._build_benchmark_equity(spec, market_data, config)
             if len(bench_equity) < 2:
                 return []
-            benchmark_returns = self._equity_to_returns(bench_equity)
+            benchmark_returns = _equity_to_returns(bench_equity)
 
             n = min(len(strategy_returns), len(benchmark_returns))
             strategy_returns = strategy_returns[:n]
@@ -2176,23 +2057,13 @@ class StrategyLabOrchestrator:
             subwindows = vix_quartile_subwindows(
                 aligned_dates,
                 benchmark_returns,
-                vix_provider=self._resolve_vix_provider(),
+                vix_provider=_resolve_vix_provider(),
             )
             return regime_comparison(strategy_returns, benchmark_returns, subwindows)
         except Exception:
             logger.exception("Regime evaluation failed for %s", spec.strategy_id)
             return []
 
-    @staticmethod
-    def _equity_to_returns(equity: Sequence[float]) -> List[float]:
-        out: List[float] = []
-        for i in range(1, len(equity)):
-            prev = equity[i - 1]
-            if prev <= 0:
-                out.append(0.0)
-            else:
-                out.append((equity[i] - prev) / prev)
-        return out
 
     def _build_benchmark_equity(
         self,
@@ -2228,11 +2099,11 @@ class StrategyLabOrchestrator:
             if blend and "SPY" in blend and "AGG" in blend and blend["SPY"] and blend["AGG"]:
                 spy_bars = blend["SPY"]
                 agg_bars = blend["AGG"]
-                spy_dates = [self._parse_bar_date(b.date) for b in spy_bars]
-                spy_equity = self._closes_to_equity(
+                spy_dates = [_parse_bar_date(b.date) for b in spy_bars]
+                spy_equity = _closes_to_equity(
                     [b.close for b in spy_bars], config.initial_capital
                 )
-                agg_equity = self._closes_to_equity(
+                agg_equity = _closes_to_equity(
                     [b.close for b in agg_bars], config.initial_capital
                 )
                 blended = build_60_40_equity(
@@ -2256,33 +2127,168 @@ class StrategyLabOrchestrator:
             single = None
         if single and bench_symbol in single and single[bench_symbol]:
             bars = single[bench_symbol]
-            dates = [self._parse_bar_date(b.date) for b in bars]
-            equity = self._closes_to_equity([b.close for b in bars], config.initial_capital)
+            dates = [_parse_bar_date(b.date) for b in bars]
+            equity = _closes_to_equity([b.close for b in bars], config.initial_capital)
             n = min(len(dates), len(equity))
             return dates[:n], equity[:n]
         return [], []
 
-    @staticmethod
-    def _closes_to_equity(closes: Sequence[float], initial_capital: float) -> List[float]:
-        if not closes or closes[0] <= 0:
-            return []
-        scale = initial_capital / closes[0]
-        return [c * scale for c in closes]
 
-    @staticmethod
-    def _parse_bar_date(d: str) -> Any:
-        from datetime import date
 
-        return date.fromisoformat(d[:10])
 
-    @staticmethod
-    def _resolve_vix_provider() -> Optional[Callable[[Sequence[Any]], List[float]]]:
-        """Return a VIX provider callable when ``STRATEGY_LAB_VIX_SOURCE`` is
-        set, otherwise None so :func:`vix_quartile_subwindows` falls back to
-        realized-vol on the benchmark series. Production deployments can
-        wire in a Yahoo ``^VIX`` fetcher here without touching callers."""
-        source = os.environ.get("STRATEGY_LAB_VIX_SOURCE", "").strip().lower()
-        if not source:
-            return None
-        # Hook point for production providers; unset → realized-vol fallback.
+# ──────────────────────────────────────────────────────────────────────────
+# Pure helpers (formerly @staticmethod on StrategyLabOrchestrator). Each is
+# stateless — moved to module-level so the orchestrator class body reflects
+# coordination state only.
+# ──────────────────────────────────────────────────────────────────────────
+
+def _merge_risk_limits_tighten_only(
+    current: RiskLimits, proposed: Any
+) -> Tuple[RiskLimits, List[str], List[str]]:
+    """Tighten-only merge of refinement-proposed risk limits (#543).
+
+    Returns ``(merged_limits, loosened_fields, discarded_unknown_keys)``.
+
+    - ``loosened_fields`` lists fields whose proposed value would loosen
+      the limit (raise an "lower"-direction cap, lower a "higher"-direction
+      floor, or transition ``target_annual_vol`` from ``None`` to a
+      value — which fundamentally changes the sizing model and is
+      treated as loosening).
+    - ``discarded_unknown_keys`` lists fields the caller proposed that
+      either aren't in the ``RiskLimits`` schema or are marked
+      immutable in ``_RISK_LIMIT_TIGHTEN_DIRECTION`` (e.g.
+      ``vol_lookback_days``).
+
+    Callers raise ``SpecImplementabilityError`` when ``loosened_fields``
+    is non-empty; unknown keys are warned but never trip.
+    """
+    loosened: List[str] = []
+    unknown: List[str] = []
+    if not isinstance(proposed, dict):
+        return current, loosened, unknown
+
+    merged_data = current.model_dump()
+    for key, new_value in proposed.items():
+        direction = _RISK_LIMIT_TIGHTEN_DIRECTION.get(key)
+        if direction is None:
+            # Either unknown to RiskLimits or explicitly immutable.
+            unknown.append(key)
+            continue
+
+        current_value = merged_data.get(key)
+
+        # Special-case ``target_annual_vol``: ``None`` means "no vol
+        # target" (flat sizing). Switching to a value or vice-versa
+        # changes the sizing model — treat any None↔value transition
+        # as loosening.
+        if key == "target_annual_vol":
+            if current_value is None and new_value is not None:
+                loosened.append(key)
+                continue
+            if current_value is not None and new_value is None:
+                loosened.append(key)
+                continue
+
+        try:
+            cmp_current = float(current_value) if current_value is not None else None
+            cmp_new = float(new_value) if new_value is not None else None
+        except (TypeError, ValueError):
+            unknown.append(key)
+            continue
+
+        if cmp_current is None or cmp_new is None:
+            # Already handled above; defensive.
+            continue
+
+        if direction == "lower":
+            if cmp_new < cmp_current:
+                merged_data[key] = new_value
+            elif cmp_new > cmp_current:
+                loosened.append(key)
+            # equal: no-op
+        elif direction == "higher":
+            if cmp_new > cmp_current:
+                merged_data[key] = new_value
+            elif cmp_new < cmp_current:
+                loosened.append(key)
+            # equal: no-op
+
+    try:
+        merged = RiskLimits.model_validate(merged_data)
+    except Exception:
+        # Validation failed on the merged limits — bail out without
+        # mutating; surface every proposed key as unknown so the caller
+        # logs the full set and keeps the original limits.
+        logger.warning(
+            "Refined risk_limits failed pydantic validation; keeping current limits unchanged."
+        )
+        return current, loosened, sorted(set(unknown) | set(proposed.keys()))
+
+    return merged, loosened, unknown
+
+def _daily_returns_from_trades(
+    trades: Sequence[TradeRecord],
+    initial_capital: float,
+    start_date: str,
+    end_date: str,
+) -> List[float]:
+    """Daily log returns from the equity curve implied by the trades.
+
+    Log basis matches :meth:`EquityCurve.daily_returns` and the rest of
+    the metrics module, so OOS-Sharpe / DSR / bootstrap CIs computed
+    downstream share the same return convention as the in-sample
+    ``compute_performance_metrics`` Sharpe.
+
+    If the equity curve crosses zero (portfolio ruin), the series is
+    returned **empty** rather than zero-padding the ruin step. Zeroing
+    a wipeout would convert it to a neutral day and let the OOS DSR /
+    Sharpe CI / moments report misleadingly low risk; an empty series
+    falls through every downstream consumer
+    (:func:`summarize_return_moments`, :func:`compute_deflated_sharpe`,
+    :func:`bootstrap_sharpe_ci`) as their well-defined "no data" path.
+    """
+    curve = build_equity_curve_from_trades(
+        trades, initial_capital, start_date=start_date, end_date=end_date
+    )
+    if len(curve.equity) < 2:
+        return []
+    if any(v <= 0 for v in curve.equity):
+        # Ruin: invalidate the whole series. Any downstream Sharpe / DSR
+        # / CI on a curve that touched zero would be meaningless.
+        return []
+    out: List[float] = []
+    for i in range(1, len(curve.equity)):
+        out.append(math.log(curve.equity[i] / curve.equity[i - 1]))
+    return out
+
+def _equity_to_returns(equity: Sequence[float]) -> List[float]:
+    out: List[float] = []
+    for i in range(1, len(equity)):
+        prev = equity[i - 1]
+        if prev <= 0:
+            out.append(0.0)
+        else:
+            out.append((equity[i] - prev) / prev)
+    return out
+
+def _closes_to_equity(closes: Sequence[float], initial_capital: float) -> List[float]:
+    if not closes or closes[0] <= 0:
+        return []
+    scale = initial_capital / closes[0]
+    return [c * scale for c in closes]
+
+def _parse_bar_date(d: str) -> Any:
+    from datetime import date
+
+    return date.fromisoformat(d[:10])
+
+def _resolve_vix_provider() -> Optional[Callable[[Sequence[Any]], List[float]]]:
+    """Return a VIX provider callable when ``STRATEGY_LAB_VIX_SOURCE`` is
+    set, otherwise None so :func:`vix_quartile_subwindows` falls back to
+    realized-vol on the benchmark series. Production deployments can
+    wire in a Yahoo ``^VIX`` fetcher here without touching callers."""
+    source = os.environ.get("STRATEGY_LAB_VIX_SOURCE", "").strip().lower()
+    if not source:
         return None
+    # Hook point for production providers; unset → realized-vol fallback.
+    return None

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -441,6 +441,79 @@ class StrategyLabOrchestrator:
             emit=emit,
         )
 
+    def _run_pre_synthesis_phase(
+        self,
+        *,
+        spec: StrategySpec,
+        config: BacktestConfig,
+        all_gate_results: List[QualityGateResult],
+        code: str,
+        original_spec: StrategySpec,
+        original_code: str,
+        rationale: str,
+        refinement_attempts: List[Dict[str, Any]],
+        emit: PhaseCallback,
+    ) -> Optional[StrategyLabRecord]:
+        """Run spec validation + readiness gate before the refinement loop.
+
+        Pre: ``spec`` is a constructed ``StrategySpec``; ``all_gate_results``
+        is the orchestrator's running gate list that the caller persists.
+        Post: returns a short-circuit ``StrategyLabRecord`` when a critical
+        gate fires (and ``all_gate_results`` is extended in place with the
+        pre-synthesis gates); returns ``None`` to signal the caller can
+        continue into the synthesis refinement loop.
+
+        The "strategy_code is missing" critical from StrategySpecValidator
+        is deliberately filtered: post-ideation we always have *some* code
+        (the loop's existing safety + regeneration paths repair degenerate
+        inputs), so short-circuiting on that critical would regress a
+        recoverable case into an outright failure.
+        """
+        pre_spec_gates_raw = self.strategy_validator.validate(spec)
+        pre_spec_gates = [
+            g
+            for g in pre_spec_gates_raw
+            if not (g.severity == "critical" and g.details.startswith("strategy_code is missing"))
+        ]
+        # SpecReadinessGate (design phase) — critical here flows into the
+        # same short-circuit path as StrategySpecValidator critical so the
+        # synthesis loop cannot run on an unimplementable spec.
+        readiness_design = self.spec_readiness_gate.validate(
+            spec, phase="design", backtest_config=config
+        )
+        pre_spec_gates.extend(readiness_design)
+        self.record_gates(pre_spec_gates, all_gate_results, refinement_round=-1)
+
+        criticals = [g for g in pre_spec_gates if not g.passed and g.severity == "critical"]
+        if not criticals:
+            return None
+
+        emit(
+            "coding",
+            {
+                "sub_phase": "failed",
+                "phase": "pre_synthesis",
+                "checks_total": len(pre_spec_gates),
+                "checks_passed": sum(1 for g in pre_spec_gates if g.passed),
+            },
+        )
+        return self._build_short_circuit_record(
+            spec=spec,
+            config=config,
+            code=code,
+            original_spec=original_spec,
+            original_code=original_code,
+            rationale=rationale,
+            all_gate_results=all_gate_results,
+            refinement_attempts=refinement_attempts,
+            short_circuit_status="failed: spec_validation",
+            short_circuit_reason=(
+                "Spec validation failed before code synthesis: "
+                + "; ".join(g.details for g in criticals)
+            ),
+            emit=emit,
+        )
+
     def _run_design_attempt(
         self,
         *,
@@ -545,50 +618,19 @@ class StrategyLabOrchestrator:
         # generic refinement loop never re-runs StrategySpecValidator),
         # which would also reach convergence_tracker.record() as an
         # unresolved spec failure.
-        pre_spec_gates_raw = self.strategy_validator.validate(spec)
-        pre_spec_gates = [
-            g
-            for g in pre_spec_gates_raw
-            if not (g.severity == "critical" and g.details.startswith("strategy_code is missing"))
-        ]
-        # SpecReadinessGate (design phase). Postcondition: any critical
-        # result here flows into the same short-circuit path that
-        # StrategySpecValidator's criticals already do, so the synthesis
-        # phase cannot be entered with an unimplementable spec.
-        readiness_design = self.spec_readiness_gate.validate(
-            spec, phase="design", backtest_config=config
+        pre_synthesis = self._run_pre_synthesis_phase(
+            spec=spec,
+            config=config,
+            all_gate_results=all_gate_results,
+            code=code,
+            original_spec=original_spec,
+            original_code=original_code,
+            rationale=rationale,
+            refinement_attempts=refinement_attempts,
+            emit=emit,
         )
-        pre_spec_gates.extend(readiness_design)
-        self.record_gates(pre_spec_gates, all_gate_results, refinement_round=-1)
-        pre_synthesis_criticals = [
-            g for g in pre_spec_gates if not g.passed and g.severity == "critical"
-        ]
-        if pre_synthesis_criticals:
-            emit(
-                "coding",
-                {
-                    "sub_phase": "failed",
-                    "phase": "pre_synthesis",
-                    "checks_total": len(pre_spec_gates),
-                    "checks_passed": sum(1 for g in pre_spec_gates if g.passed),
-                },
-            )
-            return self._build_short_circuit_record(
-                spec=spec,
-                config=config,
-                code=code,
-                original_spec=original_spec,
-                original_code=original_code,
-                rationale=rationale,
-                all_gate_results=all_gate_results,
-                refinement_attempts=refinement_attempts,
-                short_circuit_status="failed: spec_validation",
-                short_circuit_reason=(
-                    "Spec validation failed before code synthesis: "
-                    + "; ".join(g.details for g in pre_synthesis_criticals)
-                ),
-                emit=emit,
-            )
+        if pre_synthesis is not None:
+            return pre_synthesis
 
         # ── Phase 2: CODE REFINEMENT LOOP ─────────────────────────────
         # Iterate up to MAX_CODE_REFINEMENT_ROUNDS, refining the

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -1083,6 +1083,62 @@ class StrategyLabOrchestrator:
             exit_rule_conformance_passed=exit_rule_conformance_passed,
         )
 
+    def _run_analysis_phase(
+        self,
+        *,
+        spec: StrategySpec,
+        metrics: BacktestResult,
+        trades: List[TradeRecord],
+        rationale: str,
+        is_winning: bool,
+        execution_succeeded: bool,
+        refinement_attempts: List[Dict[str, Any]],
+        all_gate_results: List[QualityGateResult],
+        emit: PhaseCallback,
+    ) -> str:
+        """Run the analysis agent and return the narrative string.
+
+        Pre: synthesis + alignment + verification have settled. The narrative
+        is whatever the analysis agent produces, or a synthetic auto-summary
+        when the agent raises or there were no trades to analyse.
+        Post: returns a non-empty string when ``execution_succeeded and trades``
+        was true (or the failure-path auto-summary). Empty string only when
+        the cycle had no trades AND no execution failure to summarise — a
+        state the orchestrator treats as "nothing to write about".
+        """
+        if execution_succeeded and trades:
+            emit("analyzing", {"sub_phase": "draft"})
+            try:
+
+                def _on_analysis_sub(sub: str) -> None:
+                    emit("analyzing", {"sub_phase": sub})
+
+                narrative = self.analysis_agent.run(
+                    spec,
+                    metrics,
+                    trades,
+                    rationale,
+                    on_sub_phase=_on_analysis_sub,
+                    is_winning=is_winning,
+                )
+                emit("analyzing", {"sub_phase": "completed", "is_winning": is_winning})
+                return narrative
+            except Exception:
+                logger.exception("Analysis agent failed for %s", spec.strategy_id)
+                label = "winning" if is_winning else "losing"
+                return (
+                    f"Auto-summary: {spec.asset_class} strategy ({label}) with "
+                    f"annualized return {metrics.annualized_return_pct:.1f}%. "
+                    f"(Detailed narrative generation failed.)"
+                )
+        if not execution_succeeded:
+            return (
+                f"Strategy failed to produce valid backtest results after "
+                f"{len(refinement_attempts)} refinement round(s). "
+                f"Last failure: {all_gate_results[-1].details if all_gate_results else 'unknown'}."
+            )
+        return ""
+
     def _assemble_record(
         self,
         *,
@@ -1703,37 +1759,17 @@ class StrategyLabOrchestrator:
         # to carry every downstream-visible signal. The fields stay on the
         # dataclass for callers that want to inspect the outcome directly.
         # ── Phase 3: ANALYSIS ─────────────────────────────────────────
-        narrative = ""
-        if execution_succeeded and trades:
-            emit("analyzing", {"sub_phase": "draft"})
-            try:
-
-                def _on_analysis_sub(sub: str) -> None:
-                    emit("analyzing", {"sub_phase": sub})
-
-                narrative = self.analysis_agent.run(
-                    spec,
-                    metrics,
-                    trades,
-                    rationale,
-                    on_sub_phase=_on_analysis_sub,
-                    is_winning=is_winning,
-                )
-                emit("analyzing", {"sub_phase": "completed", "is_winning": is_winning})
-            except Exception:
-                logger.exception("Analysis agent failed for %s", spec.strategy_id)
-                label = "winning" if is_winning else "losing"
-                narrative = (
-                    f"Auto-summary: {spec.asset_class} strategy ({label}) with "
-                    f"annualized return {metrics.annualized_return_pct:.1f}%. "
-                    f"(Detailed narrative generation failed.)"
-                )
-        elif not execution_succeeded:
-            narrative = (
-                f"Strategy failed to produce valid backtest results after "
-                f"{len(refinement_attempts)} refinement round(s). "
-                f"Last failure: {all_gate_results[-1].details if all_gate_results else 'unknown'}."
-            )
+        narrative = self._run_analysis_phase(
+            spec=spec,
+            metrics=metrics,
+            trades=trades,
+            rationale=rationale,
+            is_winning=is_winning,
+            execution_succeeded=execution_succeeded,
+            refinement_attempts=refinement_attempts,
+            all_gate_results=all_gate_results,
+            emit=emit,
+        )
 
         # ── Phase 4: RECORD ───────────────────────────────────────────
         return self._assemble_record(

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -1083,6 +1083,104 @@ class StrategyLabOrchestrator:
             exit_rule_conformance_passed=exit_rule_conformance_passed,
         )
 
+    def _assemble_record(
+        self,
+        *,
+        spec: StrategySpec,
+        code: str,
+        config: BacktestConfig,
+        metrics: BacktestResult,
+        trades: List[TradeRecord],
+        narrative: str,
+        original_spec: StrategySpec,
+        original_code: str,
+        rationale: str,
+        requested_symbols: List[str],
+        fetched_symbols: List[str],
+        max_rounds_exhausted: bool,
+        execution_succeeded: bool,
+        is_winning: bool,
+        trades_aligned: bool,
+        refinement_rounds: int,
+        alignment_rounds: int,
+        all_gate_results: List[QualityGateResult],
+        emit: PhaseCallback,
+    ) -> StrategyLabRecord:
+        """Build the final ``StrategyLabRecord`` from a settled cycle.
+
+        Pre: ``spec`` / ``code`` / ``metrics`` / ``trades`` are the
+        known-good post-verification state. ``narrative`` came from the
+        analysis phase (or a synthetic auto-summary on failure).
+        Post: a ``BacktestRecord`` + ``StrategyLabRecord`` are constructed;
+        the convergence tracker is updated; a ``"complete"`` event is
+        emitted; the record is returned.
+
+        ``status`` resolution mirrors the three terminal-state branches:
+          * cap exhausted → ``"failed: max_refinement_rounds"``
+          * clean exit → ``"completed"``
+          * everything else → ``"failed"``
+        """
+        now_iso = datetime.now(timezone.utc).isoformat()
+
+        # Cap-exhaustion status: the evaluation-phase site sets
+        # ``execution_succeeded=True`` ("anomalous but code is correct"),
+        # so without this branch those cycles would silently report
+        # ``status="completed"`` despite never reaching a clean backtest.
+        if max_rounds_exhausted:
+            backtest_status = "failed: max_refinement_rounds"
+        elif execution_succeeded:
+            backtest_status = "completed"
+        else:
+            backtest_status = "failed"
+
+        backtest_id = f"bt-{uuid.uuid4().hex[:8]}"
+        backtest_record = BacktestRecord(
+            backtest_id=backtest_id,
+            strategy_id=spec.strategy_id,
+            strategy=spec,
+            config=config,
+            submitted_by="strategy_lab_v2",
+            submitted_at=now_iso,
+            completed_at=now_iso,
+            status=backtest_status,
+            result=metrics,
+            trades=trades,
+            requested_symbols=requested_symbols,
+            fetched_symbols=fetched_symbols,
+        )
+
+        lab_record_id = f"lab-{uuid.uuid4().hex[:8]}"
+        record = StrategyLabRecord(
+            lab_record_id=lab_record_id,
+            strategy=spec,
+            backtest=backtest_record,
+            is_winning=is_winning,
+            strategy_rationale=rationale,
+            analysis_narrative=narrative,
+            created_at=now_iso,
+            refinement_rounds=refinement_rounds,
+            quality_gate_results=[g.model_dump() for g in all_gate_results],
+            strategy_code=code,
+            original_spec=original_spec,
+            original_code=original_code,
+        )
+
+        self.convergence_tracker.record(spec, all_gate_results)
+
+        emit(
+            "complete",
+            {
+                "record_id": lab_record_id,
+                "is_winning": is_winning,
+                "metrics": metrics.model_dump(),
+                "refinement_rounds": refinement_rounds,
+                "alignment_rounds": alignment_rounds,
+                "trades_aligned": trades_aligned,
+            },
+        )
+
+        return record
+
     def _run_design_attempt(
         self,
         *,
@@ -1638,69 +1736,27 @@ class StrategyLabOrchestrator:
             )
 
         # ── Phase 4: RECORD ───────────────────────────────────────────
-        now_iso = datetime.now(timezone.utc).isoformat()
-
-        # #547 item 7: queryable cap-exhaustion status. The evaluation-phase
-        # site sets ``execution_succeeded=True`` ("anomalous but code is
-        # correct"), so without this branch those cycles would silently
-        # report ``status="completed"`` despite never reaching a clean
-        # backtest. With the strict reading, all three exhaustion sites now
-        # flip status to ``failed: max_refinement_rounds``.
-        if max_rounds_exhausted:
-            backtest_status = "failed: max_refinement_rounds"
-        elif execution_succeeded:
-            backtest_status = "completed"
-        else:
-            backtest_status = "failed"
-
-        backtest_id = f"bt-{uuid.uuid4().hex[:8]}"
-        backtest_record = BacktestRecord(
-            backtest_id=backtest_id,
-            strategy_id=spec.strategy_id,
-            strategy=spec,
+        return self._assemble_record(
+            spec=spec,
+            code=code,
             config=config,
-            submitted_by="strategy_lab_v2",
-            submitted_at=now_iso,
-            completed_at=now_iso,
-            status=backtest_status,
-            result=metrics,
+            metrics=metrics,
             trades=trades,
-            requested_symbols=requested_symbols,
-            fetched_symbols=fetched_symbols,
-        )
-
-        lab_record_id = f"lab-{uuid.uuid4().hex[:8]}"
-        record = StrategyLabRecord(
-            lab_record_id=lab_record_id,
-            strategy=spec,
-            backtest=backtest_record,
-            is_winning=is_winning,
-            strategy_rationale=rationale,
-            analysis_narrative=narrative,
-            created_at=now_iso,
-            refinement_rounds=len(refinement_attempts),
-            quality_gate_results=[g.model_dump() for g in all_gate_results],
-            strategy_code=code,
+            narrative=narrative,
             original_spec=original_spec,
             original_code=original_code,
+            rationale=rationale,
+            requested_symbols=requested_symbols,
+            fetched_symbols=fetched_symbols,
+            max_rounds_exhausted=max_rounds_exhausted,
+            execution_succeeded=execution_succeeded,
+            is_winning=is_winning,
+            trades_aligned=trades_aligned,
+            refinement_rounds=len(refinement_attempts),
+            alignment_rounds=alignment_rounds,
+            all_gate_results=all_gate_results,
+            emit=emit,
         )
-
-        # Update convergence tracker
-        self.convergence_tracker.record(spec, all_gate_results)
-
-        emit(
-            "complete",
-            {
-                "record_id": lab_record_id,
-                "is_winning": is_winning,
-                "metrics": metrics.model_dump(),
-                "refinement_rounds": len(refinement_attempts),
-                "alignment_rounds": alignment_rounds,
-                "trades_aligned": trades_aligned,
-            },
-        )
-
-        return record
 
     # ------------------------------------------------------------------
     # Helpers

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -406,6 +406,379 @@ class StrategyLabOrchestrator:
             emit=emit,
         )
 
+    def _run_synthesis_loop(
+        self,
+        *,
+        spec: StrategySpec,
+        code: str,
+        config: BacktestConfig,
+        all_gate_results: List[QualityGateResult],
+        refinement_attempts: List[str],
+        zero_trade_attempts: List[str],
+        emit: PhaseCallback,
+    ) -> _SynthesisLoopOutcome:
+        """Run up to ``MAX_CODE_REFINEMENT_ROUNDS`` of (validate → fetch →
+        execute → trade-collect → evaluate), refining ``spec``/``code``
+        between rounds.
+
+        Pre: pre-synthesis spec gating already passed (the caller's
+        ``_run_pre_synthesis_phase`` returned ``None``); ``all_gate_results``
+        is the running gate list the loop appends to via ``record_gates``;
+        ``refinement_attempts`` and ``zero_trade_attempts`` are the running
+        change-log lists the loop appends to in-place.
+        Post: returns a ``_SynthesisLoopOutcome`` carrying the final
+        ``spec``/``code``/``trades``/``metrics`` (plus ``market_data`` and
+        the universe audit lists), with ``execution_succeeded=True`` iff
+        a round produced a clean run with no critical anomalies, and
+        ``max_rounds_exhausted=True`` iff the loop ran the full budget
+        without converging. The two flags are mutually exclusive. The
+        loop never raises — fatal failures short-circuit by setting flags
+        and returning.
+
+        State mutations on the caller's lists (``all_gate_results``,
+        ``refinement_attempts``, ``zero_trade_attempts``) happen in-place
+        and the caller observes them directly; the outcome dataclass
+        carries only values the caller cannot read off shared mutable
+        state.
+        """
+        assert isinstance(spec, StrategySpec), "spec must be a StrategySpec"
+        assert isinstance(code, str), "code must be a string"
+        assert isinstance(config, BacktestConfig), "config must be a BacktestConfig"
+        assert isinstance(all_gate_results, list), "all_gate_results must be a list"
+        assert isinstance(refinement_attempts, list), "refinement_attempts must be a list"
+        assert isinstance(zero_trade_attempts, list), "zero_trade_attempts must be a list"
+
+        trades: List[TradeRecord] = []
+        metrics = compute_metrics(
+            [], config.initial_capital, config.start_date, config.end_date
+        )
+        execution_succeeded = False
+        market_data: Optional[Dict[str, List[OHLCVBar]]] = None
+        requested_symbols: List[str] = []
+        fetched_symbols: List[str] = []
+        max_rounds_exhausted = False
+
+        for round_num in range(MAX_CODE_REFINEMENT_ROUNDS):
+            round_gate_results: List[QualityGateResult] = []
+
+            # ── 2a: VALIDATE (code safety + spec readiness on round 0) ───
+            emit("coding", {"sub_phase": "started", "refinement_round": round_num})
+            if round_num == 0:
+                round_gate_results.extend(
+                    self.spec_readiness_gate.validate(
+                        spec, phase="synthesis", backtest_config=config
+                    )
+                )
+            code_gates = self.code_safety_checker.check(code, spec)
+            round_gate_results.extend(code_gates)
+            self.record_gates(round_gate_results, all_gate_results, refinement_round=round_num)
+
+            checks_total = len(round_gate_results)
+            checks_passed = sum(1 for g in round_gate_results if g.passed)
+
+            critical_failures = [
+                g for g in round_gate_results if not g.passed and g.severity == "critical"
+            ]
+            if critical_failures:
+                emit(
+                    "coding",
+                    {
+                        "sub_phase": "failed",
+                        "refinement_round": round_num,
+                        "checks_passed": checks_passed,
+                        "checks_total": checks_total,
+                    },
+                )
+                if round_num < MAX_CODE_REFINEMENT_ROUNDS - 1:
+                    emit(
+                        "coding",
+                        {
+                            "sub_phase": "refining",
+                            "refinement_round": round_num,
+                            "failure_phase": "validation",
+                        },
+                    )
+                    failure_details = "\n".join(
+                        f"- [{g.gate_name}] {g.details}" for g in critical_failures
+                    )
+                    updates, code = self._refine(
+                        spec, code, "validation", failure_details, None, refinement_attempts
+                    )
+                    spec = self._apply_updates(spec, updates, code, failure_phase="validation")
+                    changes = updates.get("changes_made", "validation fix")
+                    refinement_attempts.append(changes)
+                    emit(
+                        "coding",
+                        {
+                            "sub_phase": "refined",
+                            "refinement_round": round_num,
+                            "changes_made": changes,
+                        },
+                    )
+                    continue
+                else:
+                    logger.warning(
+                        "Max code refinement rounds reached on validation for %s", spec.strategy_id
+                    )
+                    max_rounds_exhausted = True
+                    break
+
+            emit(
+                "coding",
+                {
+                    "sub_phase": "completed",
+                    "refinement_round": round_num,
+                    "checks_passed": checks_passed,
+                    "checks_total": checks_total,
+                },
+            )
+
+            # ── 2b: FETCH DATA (once, reuse across rounds) ───────────
+            if market_data is None:
+                emit("backtesting", {"sub_phase": "fetching_data"})
+                fetch = self._fetch_market_data(spec, config)
+                requested_symbols = list(fetch.requested_symbols)
+                fetched_symbols = list(fetch.fetched_symbols)
+                market_data = fetch.data
+                if not market_data:
+                    all_gate_results.append(
+                        self.build_orchestrator_gate(
+                            "market_data",
+                            phase="synthesis",
+                            details=f"No market data available for asset class '{spec.asset_class}'.",
+                            refinement_round=round_num,
+                        )
+                    )
+                    break
+                total_bars = sum(len(bars) for bars in market_data.values())
+                emit(
+                    "backtesting",
+                    {
+                        "sub_phase": "data_loaded",
+                        "symbols_count": len(market_data),
+                        "bars_count": total_bars,
+                    },
+                )
+
+                fetch_coverage_gates = self.target_symbol_coverage_gate.check_fetch(
+                    spec, requested_symbols, fetched_symbols
+                )
+                self.record_gates(
+                    fetch_coverage_gates, all_gate_results, refinement_round=round_num
+                )
+                if any(not g.passed and g.severity == "critical" for g in fetch_coverage_gates):
+                    break
+
+            # ── 2c: EXECUTE (syntax / runtime correctness) ───────────
+            emit("backtesting", {"sub_phase": "running_code", "refinement_round": round_num})
+            exec_result = run_strategy_code(code, market_data, config, strategy=spec)
+
+            if not exec_result.success:
+                all_gate_results.append(
+                    self.build_orchestrator_gate(
+                        "code_execution",
+                        phase="synthesis",
+                        details=f"Execution failed ({exec_result.error_type}): {exec_result.stderr[:500]}",
+                        refinement_round=round_num,
+                    )
+                )
+                if round_num < MAX_CODE_REFINEMENT_ROUNDS - 1:
+                    emit(
+                        "coding",
+                        {
+                            "sub_phase": "refining",
+                            "refinement_round": round_num,
+                            "failure_phase": "execution",
+                        },
+                    )
+                    failure_details = (
+                        f"Error type: {exec_result.error_type}\n"
+                        f"stderr:\n{exec_result.stderr[:2000]}"
+                    )
+                    updates, code = self._refine(
+                        spec, code, "execution", failure_details, None, refinement_attempts
+                    )
+                    spec = self._apply_updates(spec, updates, code, failure_phase="execution")
+                    changes = updates.get("changes_made", "execution fix")
+                    refinement_attempts.append(changes)
+                    emit(
+                        "coding",
+                        {
+                            "sub_phase": "refined",
+                            "refinement_round": round_num,
+                            "changes_made": changes,
+                        },
+                    )
+                    continue
+                else:
+                    logger.warning(
+                        "Max code refinement rounds reached on execution for %s", spec.strategy_id
+                    )
+                    max_rounds_exhausted = True
+                    break
+
+            # ── 2d: COLLECT TRADES + target-symbol coverage on trades ─
+            trades = exec_result.trades
+
+            trade_coverage_gates = self.target_symbol_coverage_gate.check_trades(spec, trades)
+            self.record_gates(
+                trade_coverage_gates, all_gate_results, refinement_round=round_num
+            )
+            if any(not g.passed and g.severity == "critical" for g in trade_coverage_gates):
+                max_rounds_exhausted = True
+                break
+
+            emit(
+                "backtesting",
+                {
+                    "sub_phase": "completed",
+                    "trades_count": len(trades),
+                    "execution_time": exec_result.execution_time_seconds,
+                },
+            )
+
+            # ── 2e: BACKTEST EVALUATION (anomaly gates → zero-trade-repair → generic refine) ─
+            metrics = compute_metrics(
+                trades, config.initial_capital, config.start_date, config.end_date
+            )
+
+            _maybe_attach_coverage_report(
+                metrics=metrics,
+                spec=spec,
+                market_data=market_data,
+                config=config,
+                exec_result=exec_result,
+            )
+
+            anomaly_gates = self.anomaly_detector.check(
+                metrics,
+                trades,
+                dsr_aware=config.walk_forward_enabled,
+                diagnostics=exec_result.execution_diagnostics,
+                coverage_report=metrics.coverage_report,
+            )
+            self.record_gates(anomaly_gates, all_gate_results, refinement_round=round_num)
+
+            critical_anomalies = [
+                g for g in anomaly_gates if not g.passed and g.severity == "critical"
+            ]
+            if critical_anomalies:
+                if round_num < MAX_CODE_REFINEMENT_ROUNDS - 1:
+                    emit(
+                        "coding",
+                        {
+                            "sub_phase": "refining",
+                            "refinement_round": round_num,
+                            "failure_phase": "evaluation",
+                        },
+                    )
+                    failure_details = "\n".join(f"- {g.details}" for g in critical_anomalies)
+                    diagnostics_block = _format_execution_diagnostics(
+                        exec_result.execution_diagnostics
+                    )
+                    if diagnostics_block:
+                        failure_details = f"{failure_details}\n{diagnostics_block}"
+                    coverage_block = format_coverage_report(metrics.coverage_report)
+                    if coverage_block:
+                        failure_details = f"{failure_details}\n{coverage_block}"
+
+                    diag = exec_result.execution_diagnostics
+                    if (
+                        diag is not None
+                        and diag.zero_trade_category is not None
+                        and market_data is not None
+                    ):
+                        zt_outcome = self.zero_trade_repairer.try_repair(
+                            spec=spec,
+                            code=code,
+                            exec_result=exec_result,
+                            coverage_report=metrics.coverage_report,
+                            market_data=market_data,
+                            config=config,
+                            zero_trade_attempts=zero_trade_attempts,
+                            round_num=round_num,
+                            emit=emit,
+                        )
+                        all_gate_results.extend(zt_outcome.new_gates)
+                        if zt_outcome.committed:
+                            assert zt_outcome.new_spec is not None
+                            assert zt_outcome.new_metrics is not None
+                            assert zt_outcome.new_exec_result is not None
+                            code = zt_outcome.new_code
+                            spec = zt_outcome.new_spec
+                            trades = zt_outcome.new_trades
+                            metrics = zt_outcome.new_metrics
+                            exec_result = zt_outcome.new_exec_result
+                            refinement_attempts.append(
+                                f"zero-trade repair: {zt_outcome.changes_made}"
+                                if zt_outcome.changes_made
+                                else "zero-trade repair"
+                            )
+                            emit(
+                                "coding",
+                                {
+                                    "sub_phase": "refined",
+                                    "refinement_round": round_num,
+                                    "changes_made": (
+                                        zt_outcome.changes_made or "zero-trade repair"
+                                    ),
+                                    "via": "zero_trade_repair",
+                                },
+                            )
+                            continue
+
+                    updates, code = self._refine(
+                        spec,
+                        code,
+                        "evaluation (backtest anomaly)",
+                        failure_details,
+                        metrics,
+                        refinement_attempts,
+                    )
+                    spec = self._apply_updates(spec, updates, code, failure_phase="evaluation")
+                    changes = updates.get("changes_made", "anomaly fix")
+                    refinement_attempts.append(changes)
+                    emit(
+                        "coding",
+                        {
+                            "sub_phase": "refined",
+                            "refinement_round": round_num,
+                            "changes_made": changes,
+                        },
+                    )
+                    continue
+                else:
+                    logger.warning(
+                        "Max code refinement rounds reached on evaluation for %s", spec.strategy_id
+                    )
+                    # Even if the code is technically correct, the cycle
+                    # exhausted its rounds on an unresolved anomaly. Leaving
+                    # execution_succeeded=False ensures is_winning stays False
+                    # so paper-trading does not fire on a
+                    # "failed: max_refinement_rounds" record.
+                    max_rounds_exhausted = True
+                    break
+
+            # All gates passed — code is clean and backtest is sound
+            execution_succeeded = True
+            break
+
+        # Post-condition: success and round-exhaustion are mutually exclusive.
+        assert not (execution_succeeded and max_rounds_exhausted), (
+            "synthesis loop returned both execution_succeeded and max_rounds_exhausted"
+        )
+        return _SynthesisLoopOutcome(
+            spec=spec,
+            code=code,
+            trades=trades,
+            metrics=metrics,
+            market_data=market_data,
+            requested_symbols=requested_symbols,
+            fetched_symbols=fetched_symbols,
+            execution_succeeded=execution_succeeded,
+            max_rounds_exhausted=max_rounds_exhausted,
+        )
+
     def _run_trade_alignment_loop(
         self,
         *,
@@ -1155,21 +1528,6 @@ class StrategyLabOrchestrator:
         all_gate_results: List[QualityGateResult] = []
         refinement_attempts: List[str] = []
         zero_trade_attempts: List[str] = []
-        trades: List[TradeRecord] = []
-        metrics = compute_metrics([], config.initial_capital, config.start_date, config.end_date)
-        execution_succeeded = False
-        market_data: Optional[Dict[str, List[OHLCVBar]]] = None
-        # Issue #525 — audit trail of the symbol universe the fetch was
-        # asked to retrieve and the symbols that actually returned bars.
-        # Persisted on ``BacktestRecord`` so reviewers can see when a
-        # fetch silently dropped tickers.
-        requested_symbols: List[str] = []
-        fetched_symbols: List[str] = []
-        # #547 item 7: track whether the refinement loop exhausted the round
-        # cap so the persisted record's ``status`` is queryable rather than
-        # buried in logs. Set at each of the three break-on-max sites
-        # (validation / execution / evaluation phases).
-        max_rounds_exhausted = False
 
         # ── Phase 1b: PRE-SYNTHESIS SPEC GATING (#547 item 1) ─────────
         # Validate the ideation-time spec ONCE before entering the
@@ -1205,356 +1563,31 @@ class StrategyLabOrchestrator:
             return pre_synthesis
 
         # ── Phase 2: CODE REFINEMENT LOOP ─────────────────────────────
-        # Iterate up to MAX_CODE_REFINEMENT_ROUNDS, refining the
-        # generated code for correctness, performance, syntax errors,
-        # build errors, runtime errors, and backtest anomalies (zero
-        # trades, implausible returns, etc.).  The loop exits only when
-        # all quality gates pass AND the backtest produces sound results.
-
-        for round_num in range(MAX_CODE_REFINEMENT_ROUNDS):
-            round_gate_results: List[QualityGateResult] = []
-
-            # ── 2a: VALIDATE (code safety only — spec was validated
-            #       pre-synthesis and is immutable for this cycle, see
-            #       #547 items 1 & 2).
-            emit("coding", {"sub_phase": "started", "refinement_round": round_num})
-            # Re-run SpecReadinessGate on the first synthesis round.
-            # Precondition: design-phase readiness passed. Postcondition:
-            # a critical failure here means the spec was mutated between
-            # design exit and synthesis entry — the same short-circuit
-            # path that fires for any other critical synthesis-phase gate
-            # picks it up. Skipped on round_num > 0 because the spec is
-            # immutable across the synthesis loop.
-            if round_num == 0:
-                round_gate_results.extend(
-                    self.spec_readiness_gate.validate(
-                        spec, phase="synthesis", backtest_config=config
-                    )
-                )
-            code_gates = self.code_safety_checker.check(code, spec)
-            round_gate_results.extend(code_gates)
-            self.record_gates(round_gate_results, all_gate_results, refinement_round=round_num)
-
-            checks_total = len(round_gate_results)
-            checks_passed = sum(1 for g in round_gate_results if g.passed)
-
-            critical_failures = [
-                g for g in round_gate_results if not g.passed and g.severity == "critical"
-            ]
-            if critical_failures:
-                emit(
-                    "coding",
-                    {
-                        "sub_phase": "failed",
-                        "refinement_round": round_num,
-                        "checks_passed": checks_passed,
-                        "checks_total": checks_total,
-                    },
-                )
-                if round_num < MAX_CODE_REFINEMENT_ROUNDS - 1:
-                    emit(
-                        "coding",
-                        {
-                            "sub_phase": "refining",
-                            "refinement_round": round_num,
-                            "failure_phase": "validation",
-                        },
-                    )
-                    failure_details = "\n".join(
-                        f"- [{g.gate_name}] {g.details}" for g in critical_failures
-                    )
-                    updates, code = self._refine(
-                        spec, code, "validation", failure_details, None, refinement_attempts
-                    )
-                    spec = self._apply_updates(spec, updates, code, failure_phase="validation")
-                    changes = updates.get("changes_made", "validation fix")
-                    refinement_attempts.append(changes)
-                    emit(
-                        "coding",
-                        {
-                            "sub_phase": "refined",
-                            "refinement_round": round_num,
-                            "changes_made": changes,
-                        },
-                    )
-                    continue
-                else:
-                    logger.warning(
-                        "Max code refinement rounds reached on validation for %s", spec.strategy_id
-                    )
-                    max_rounds_exhausted = True
-                    break
-
-            emit(
-                "coding",
-                {
-                    "sub_phase": "completed",
-                    "refinement_round": round_num,
-                    "checks_passed": checks_passed,
-                    "checks_total": checks_total,
-                },
-            )
-
-            # ── 2b: FETCH DATA (once, reuse across rounds) ───────────
-            if market_data is None:
-                emit("backtesting", {"sub_phase": "fetching_data"})
-                fetch = self._fetch_market_data(spec, config)
-                # Issue #525 — record requested/fetched on every cycle,
-                # even when the fetch returns nothing usable, so the
-                # audit trail captures intent on failed runs too.
-                requested_symbols = list(fetch.requested_symbols)
-                fetched_symbols = list(fetch.fetched_symbols)
-                market_data = fetch.data
-                if not market_data:
-                    all_gate_results.append(
-                        self.build_orchestrator_gate(
-                            "market_data",
-                            phase="synthesis",
-                            details=f"No market data available for asset class '{spec.asset_class}'.",
-                            refinement_round=round_num,
-                        )
-                    )
-                    break
-                total_bars = sum(len(bars) for bars in market_data.values())
-                emit(
-                    "backtesting",
-                    {
-                        "sub_phase": "data_loaded",
-                        "symbols_count": len(market_data),
-                        "bars_count": total_bars,
-                    },
-                )
-
-                # Issue #526 — fail closed if the fetched universe doesn't
-                # include the spec's target_symbols. Code refinement can't
-                # fix this (the data simply isn't there), so we break out
-                # the same way the no-market-data branch above does.
-                fetch_coverage_gates = self.target_symbol_coverage_gate.check_fetch(
-                    spec, requested_symbols, fetched_symbols
-                )
-                self.record_gates(
-                    fetch_coverage_gates, all_gate_results, refinement_round=round_num
-                )
-                if any(not g.passed and g.severity == "critical" for g in fetch_coverage_gates):
-                    break
-
-            # ── 2c: EXECUTE (syntax / runtime correctness) ───────────
-            emit("backtesting", {"sub_phase": "running_code", "refinement_round": round_num})
-            exec_result = run_strategy_code(code, market_data, config, strategy=spec)
-
-            if not exec_result.success:
-                all_gate_results.append(
-                    self.build_orchestrator_gate(
-                        "code_execution",
-                        phase="synthesis",
-                        details=f"Execution failed ({exec_result.error_type}): {exec_result.stderr[:500]}",
-                        refinement_round=round_num,
-                    )
-                )
-                if round_num < MAX_CODE_REFINEMENT_ROUNDS - 1:
-                    emit(
-                        "coding",
-                        {
-                            "sub_phase": "refining",
-                            "refinement_round": round_num,
-                            "failure_phase": "execution",
-                        },
-                    )
-                    failure_details = (
-                        f"Error type: {exec_result.error_type}\n"
-                        f"stderr:\n{exec_result.stderr[:2000]}"
-                    )
-                    updates, code = self._refine(
-                        spec, code, "execution", failure_details, None, refinement_attempts
-                    )
-                    spec = self._apply_updates(spec, updates, code, failure_phase="execution")
-                    changes = updates.get("changes_made", "execution fix")
-                    refinement_attempts.append(changes)
-                    emit(
-                        "coding",
-                        {
-                            "sub_phase": "refined",
-                            "refinement_round": round_num,
-                            "changes_made": changes,
-                        },
-                    )
-                    continue
-                else:
-                    logger.warning(
-                        "Max code refinement rounds reached on execution for %s", spec.strategy_id
-                    )
-                    max_rounds_exhausted = True
-                    break
-
-            # ── 2d: COLLECT TRADES ────────────────────────────────────
-            # TradingService has already finalised trades through
-            # FillSimulator, so the legacy raw-trade validation step is a
-            # no-op here. Kept the same ``trades`` variable name so the
-            # rest of the loop is untouched.
-            trades = exec_result.trades
-
-            # Issue #526 — fail closed when the ledger contains symbols
-            # outside spec.target_symbols. Uses ``max_rounds_exhausted`` to
-            # leave ``execution_succeeded=False`` so ``is_winning`` stays
-            # False at the acceptance gate (same precedent as the
-            # max-refinement-rounds anomaly branch below).
-            trade_coverage_gates = self.target_symbol_coverage_gate.check_trades(spec, trades)
-            self.record_gates(
-                trade_coverage_gates, all_gate_results, refinement_round=round_num
-            )
-            if any(not g.passed and g.severity == "critical" for g in trade_coverage_gates):
-                max_rounds_exhausted = True
-                break
-
-            emit(
-                "backtesting",
-                {
-                    "sub_phase": "completed",
-                    "trades_count": len(trades),
-                    "execution_time": exec_result.execution_time_seconds,
-                },
-            )
-
-            # ── 2e: BACKTEST EVALUATION ───────────────────────────────
-            # Code ran cleanly — now compute metrics and check for
-            # anomalies.  Critical anomalies (zero trades, implausible
-            # returns, etc.) trigger refinement while budget remains.
-            metrics = compute_metrics(
-                trades, config.initial_capital, config.start_date, config.end_date
-            )
-
-            # Issue #451 — attach a deterministic CoverageReport when the
-            # run is zero/low-trade. Successful runs pay no probe cost.
-            _maybe_attach_coverage_report(
-                metrics=metrics,
-                spec=spec,
-                market_data=market_data,
-                config=config,
-                exec_result=exec_result,
-            )
-
-            anomaly_gates = self.anomaly_detector.check(
-                metrics,
-                trades,
-                dsr_aware=config.walk_forward_enabled,
-                diagnostics=exec_result.execution_diagnostics,
-                coverage_report=metrics.coverage_report,
-            )
-            self.record_gates(anomaly_gates, all_gate_results, refinement_round=round_num)
-
-            critical_anomalies = [
-                g for g in anomaly_gates if not g.passed and g.severity == "critical"
-            ]
-            if critical_anomalies:
-                if round_num < MAX_CODE_REFINEMENT_ROUNDS - 1:
-                    emit(
-                        "coding",
-                        {
-                            "sub_phase": "refining",
-                            "refinement_round": round_num,
-                            "failure_phase": "evaluation",
-                        },
-                    )
-                    failure_details = "\n".join(f"- {g.details}" for g in critical_anomalies)
-                    diagnostics_block = _format_execution_diagnostics(
-                        exec_result.execution_diagnostics
-                    )
-                    if diagnostics_block:
-                        failure_details = f"{failure_details}\n{diagnostics_block}"
-                    coverage_block = format_coverage_report(metrics.coverage_report)
-                    if coverage_block:
-                        failure_details = f"{failure_details}\n{coverage_block}"
-
-                    # Issue #405 — specialized zero-trade repair branch.
-                    # If the critical anomaly carries a deterministic
-                    # ``zero_trade_category``, ask the targeted repair
-                    # agent first. On a successful repair the proposal
-                    # has already passed code-safety, a fresh backtest,
-                    # and the anomaly gates, so we commit it and re-
-                    # enter the loop. On a failed proposal we fall
-                    # through to the generic refinement agent so the
-                    # existing loop semantics are preserved.
-                    diag = exec_result.execution_diagnostics
-                    if (
-                        diag is not None
-                        and diag.zero_trade_category is not None
-                        and market_data is not None
-                    ):
-                        zt_outcome = self.zero_trade_repairer.try_repair(
-                            spec=spec,
-                            code=code,
-                            exec_result=exec_result,
-                            coverage_report=metrics.coverage_report,
-                            market_data=market_data,
-                            config=config,
-                            zero_trade_attempts=zero_trade_attempts,
-                            round_num=round_num,
-                            emit=emit,
-                        )
-                        all_gate_results.extend(zt_outcome.new_gates)
-                        if zt_outcome.committed:
-                            assert zt_outcome.new_spec is not None
-                            assert zt_outcome.new_metrics is not None
-                            assert zt_outcome.new_exec_result is not None
-                            code = zt_outcome.new_code
-                            spec = zt_outcome.new_spec
-                            trades = zt_outcome.new_trades
-                            metrics = zt_outcome.new_metrics
-                            exec_result = zt_outcome.new_exec_result
-                            refinement_attempts.append(
-                                f"zero-trade repair: {zt_outcome.changes_made}"
-                                if zt_outcome.changes_made
-                                else "zero-trade repair"
-                            )
-                            emit(
-                                "coding",
-                                {
-                                    "sub_phase": "refined",
-                                    "refinement_round": round_num,
-                                    "changes_made": (
-                                        zt_outcome.changes_made or "zero-trade repair"
-                                    ),
-                                    "via": "zero_trade_repair",
-                                },
-                            )
-                            continue
-
-                    updates, code = self._refine(
-                        spec,
-                        code,
-                        "evaluation (backtest anomaly)",
-                        failure_details,
-                        metrics,
-                        refinement_attempts,
-                    )
-                    spec = self._apply_updates(spec, updates, code, failure_phase="evaluation")
-                    changes = updates.get("changes_made", "anomaly fix")
-                    refinement_attempts.append(changes)
-                    emit(
-                        "coding",
-                        {
-                            "sub_phase": "refined",
-                            "refinement_round": round_num,
-                            "changes_made": changes,
-                        },
-                    )
-                    continue
-                else:
-                    logger.warning(
-                        "Max code refinement rounds reached on evaluation for %s", spec.strategy_id
-                    )
-                    # Do NOT flip execution_succeeded — even if the code is
-                    # technically correct, the cycle exhausted its rounds on
-                    # an unresolved anomaly. Leaving execution_succeeded=False
-                    # ensures is_winning stays False so paper-trading does
-                    # not fire on a "failed: max_refinement_rounds" record
-                    # (#547 review feedback).
-                    max_rounds_exhausted = True
-                    break
-
-            # All gates passed — code is clean and backtest is sound
-            execution_succeeded = True
-            break
+        # ``_run_synthesis_loop`` iterates up to ``MAX_CODE_REFINEMENT_ROUNDS``
+        # rounds of (validate → fetch → execute → trade-collect → evaluate)
+        # and either converges (``execution_succeeded=True``) or
+        # short-circuits with ``max_rounds_exhausted`` / a fatal-fetch flag.
+        # The loop appends to ``all_gate_results``, ``refinement_attempts``,
+        # and ``zero_trade_attempts`` in-place; the returned outcome carries
+        # the final spec/code/trades/metrics + universe audit.
+        synthesis = self._run_synthesis_loop(
+            spec=spec,
+            code=code,
+            config=config,
+            all_gate_results=all_gate_results,
+            refinement_attempts=refinement_attempts,
+            zero_trade_attempts=zero_trade_attempts,
+            emit=emit,
+        )
+        spec = synthesis.spec
+        code = synthesis.code
+        trades = synthesis.trades
+        metrics = synthesis.metrics
+        market_data = synthesis.market_data
+        requested_symbols = synthesis.requested_symbols
+        fetched_symbols = synthesis.fetched_symbols
+        execution_succeeded = synthesis.execution_succeeded
+        max_rounds_exhausted = synthesis.max_rounds_exhausted
 
         # ── Phase 2.5: TRADE ALIGNMENT LOOP ───────────────────────────
         alignment_outcome = self._run_trade_alignment_loop(
@@ -2220,5 +2253,6 @@ from ._orchestrator_helpers import (  # noqa: E402  — keep at file end
     _merge_risk_limits_tighten_only,
     _parse_bar_date,
     _resolve_vix_provider,
+    _SynthesisLoopOutcome,
     _VerificationOutcome,
 )

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -11,14 +11,11 @@ Pipeline:
 
 from __future__ import annotations
 
-import json
 import logging
-import math
 import os
 import uuid
-from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 
 from ..execution.benchmarks import benchmark_for_strategy, build_60_40_equity
 from ..execution.metrics import (
@@ -28,7 +25,6 @@ from ..execution.metrics import (
     summarize_return_moments,
 )
 from ..execution.regimes import regime_comparison, vix_quartile_subwindows
-from ..execution.risk_filter import _RISK_LIMIT_TIGHTEN_DIRECTION, RiskLimits
 from ..execution.walk_forward import (
     build_purged_walk_forward,
     filter_trades_in_fold_training,
@@ -38,7 +34,6 @@ from ..execution.walk_forward import (
 from ..market_data_service import MarketDataService, OHLCVBar
 from ..models import (
     BacktestConfig,
-    BacktestExecutionDiagnostics,
     BacktestRecord,
     BacktestResult,
     StrategyLabRecord,
@@ -48,13 +43,13 @@ from ..models import (
 )
 from ..signal_intelligence_models import SignalIntelligenceBriefV1
 from ..trade_simulator import compute_metrics
-from ..trading_service.modes.sandbox_compat import StrategyRunResult, run_strategy_code
+from ..trading_service.modes.sandbox_compat import run_strategy_code
 from .agents.alignment import AlignmentAuditError, TradeAlignmentAgent, TradeAlignmentReport
 from .agents.analysis import AnalysisAgent
 from .agents.ideation import IdeationAgent
 from .agents.refinement import RefinementAgent
 from .agents.zero_trade_repair import ZeroTradeRepairAgent
-from .coverage_probe import format_coverage_report, run_coverage_stage, should_run_probes
+from .coverage_probe import format_coverage_report
 from .exceptions import SpecImplementabilityError
 from .quality_gates.acceptance_gate import AcceptanceGate, summarize_acceptance_reason
 from .quality_gates.backtest_anomaly import BacktestAnomalyDetector
@@ -71,64 +66,6 @@ from .zero_trade_repair import ZeroTradeRepairer
 logger = logging.getLogger(__name__)
 
 PhaseCallback = Callable[[str, Dict[str, Any]], None]
-
-
-@dataclass(frozen=True)
-class _MarketDataFetch:
-    """Issue #525 — return envelope for ``_fetch_market_data``.
-
-    Carries the OHLCV payload alongside the audit trail of the symbols the
-    fetch was asked to retrieve and the symbols that actually returned
-    usable bars. Both lists feed ``BacktestRecord`` so reviewers can see
-    when a fetch silently dropped tickers without re-running the cycle.
-    """
-
-    data: Optional[Dict[str, List[OHLCVBar]]]
-    requested_symbols: List[str]
-    fetched_symbols: List[str]
-
-
-@dataclass
-class _VerificationOutcome:
-    """Bundle of state mutated by ``_run_verification_phase``.
-
-    The verification phase runs walk-forward (or its fallback anomaly
-    recheck), exit-rule conformance, resolves ``is_winning``, and
-    augments ``metrics.acceptance_reason`` with any veto causes.
-    Returning a dataclass keeps the boundary explicit without forcing
-    ``_run_design_attempt`` to learn the internal branches.
-    """
-
-    metrics: "BacktestResult"
-    is_winning: bool
-    upstream_admitted: bool
-    acceptance_results: List[QualityGateResult]
-    walk_forward_failed: bool
-    exit_rule_conformance_passed: bool
-
-
-@dataclass
-class _AlignmentLoopOutcome:
-    """Bundle of state mutated by ``_run_trade_alignment_loop``.
-
-    The trade-alignment loop can replace the run's known-good
-    ``spec`` / ``code`` / ``trades`` / ``metrics`` if it commits a fix,
-    and tracks attempt strings + per-round reports the caller consumes.
-    Returning a single dataclass keeps ``_run_design_attempt``'s
-    unpacking explicit and small.
-    """
-
-    spec: StrategySpec
-    code: str
-    trades: List[TradeRecord]
-    metrics: "BacktestResult"
-    alignment_attempts: List[str]
-    alignment_reports: List["TradeAlignmentReport"]
-    trades_aligned: bool
-
-    @property
-    def alignment_rounds(self) -> int:
-        return len(self.alignment_attempts)
 
 
 # Refinement output is code-only post-#543. Anything else the LLM emits is
@@ -173,94 +110,6 @@ WINNING_THRESHOLD = 8.0
 # block. The model already trims to 20; 10 is enough signal for the LLM to
 # spot the failure pattern while keeping the JSON line under ~1 KB.
 _DIAGNOSTICS_LAST_EVENTS_CAP = 10
-
-
-def _maybe_attach_coverage_report(
-    *,
-    metrics: BacktestResult,
-    spec: StrategySpec,
-    market_data: Dict[str, List[OHLCVBar]],
-    config: BacktestConfig,
-    exec_result: StrategyRunResult,
-) -> None:
-    """Run the #451 coverage stage and stamp the report onto ``metrics``.
-
-    The ``spec`` argument MUST carry the same ``strategy_code`` that was
-    handed to ``run_strategy_code`` to produce ``exec_result``. The
-    alignment and zero-trade-repair paths use a ``proposed_spec`` variant
-    of the surrounding spec; pass that, not the loop-level ``spec``,
-    otherwise the static probe will analyse stale source.
-
-    No-ops when ``should_run_probes`` says the run isn't zero/low-trade —
-    successful runs keep ``metrics.coverage_report = None`` and pay no
-    probe cost.
-    """
-    if should_run_probes(exec_result.execution_diagnostics):
-        metrics.coverage_report = run_coverage_stage(
-            spec=spec,
-            market_data=market_data,
-            config=config,
-            exec_result=exec_result,
-            run_strategy_code_fn=run_strategy_code,
-        )
-
-
-def _format_execution_diagnostics(
-    diagnostics: Optional[BacktestExecutionDiagnostics],
-) -> str:
-    """Render a compact JSON block of execution diagnostics for the
-    refinement prompt (issue #414, part of #404).
-
-    Returns an empty string when diagnostics is missing or the executor
-    couldn't classify a zero-trade failure — healthy backtests must not
-    bloat the prompt. When a ``zero_trade_category`` is present, returns a
-    single line ``"Execution Diagnostics: {<json>}"`` whose JSON payload is
-    stable-key-sorted and compact. ``last_order_events`` is capped to the
-    most recent ``_DIAGNOSTICS_LAST_EVENTS_CAP`` entries.
-    """
-    if diagnostics is None or diagnostics.zero_trade_category is None:
-        return ""
-
-    payload = diagnostics.model_dump(mode="json", exclude_none=True)
-    events = payload.get("last_order_events") or []
-    if len(events) > _DIAGNOSTICS_LAST_EVENTS_CAP:
-        payload["last_order_events"] = events[-_DIAGNOSTICS_LAST_EVENTS_CAP:]
-
-    encoded = json.dumps(payload, separators=(",", ":"), sort_keys=True)
-    return f"Execution Diagnostics: {encoded}"
-
-
-
-def _apply_veto_to_acceptance_reason(
-    metrics: BacktestResult,
-    suffix: str,
-    *,
-    upstream_admitted: bool,
-) -> tuple[BacktestResult, bool]:
-    """Stamp a publication veto's cause onto ``metrics.acceptance_reason``.
-
-    Both the conformance veto (#527) and the alignment veto (#529)
-    follow the same shape: replace a stale success-style upstream
-    reason; append to a real upstream rejection. Returns the updated
-    ``metrics`` and ``False`` for the new ``upstream_admitted``, so a
-    subsequent veto on the same run appends to this one rather than
-    overwriting it.
-
-    The delimiter is ``" | "`` (not ``"; "`` which
-    :func:`summarize_acceptance_reason` uses between failing gates)
-    so downstream parsers can disambiguate the veto boundary from
-    gate-internal boundaries.
-
-    Whitespace-only upstream reasons (``None``, ``""``, ``"   "``)
-    collapse to the suffix alone — never produces
-    ``"   | <suffix>"`` with an empty left side.
-    """
-    prior = (metrics.acceptance_reason or "").strip()
-    if prior and not upstream_admitted:
-        combined = f"{prior} | {suffix}"
-    else:
-        combined = suffix
-    return metrics.model_copy(update={"acceptance_reason": combined}), False
 
 
 class StrategyLabOrchestrator:
@@ -2354,158 +2203,22 @@ class StrategyLabOrchestrator:
 
 
 # ──────────────────────────────────────────────────────────────────────────
-# Pure helpers (formerly @staticmethod on StrategyLabOrchestrator). Each is
-# stateless — moved to module-level so the orchestrator class body reflects
-# coordination state only.
+# Re-exports — these symbols live in :mod:`_orchestrator_helpers`. The
+# orchestrator module re-exports them so existing call sites that import
+# from ``investment_team.strategy_lab.orchestrator`` keep working without
+# the helpers cluttering this file.
 # ──────────────────────────────────────────────────────────────────────────
-
-def _merge_risk_limits_tighten_only(
-    current: RiskLimits, proposed: Any
-) -> Tuple[RiskLimits, List[str], List[str]]:
-    """Tighten-only merge of refinement-proposed risk limits (#543).
-
-    Returns ``(merged_limits, loosened_fields, discarded_unknown_keys)``.
-
-    - ``loosened_fields`` lists fields whose proposed value would loosen
-      the limit (raise an "lower"-direction cap, lower a "higher"-direction
-      floor, or transition ``target_annual_vol`` from ``None`` to a
-      value — which fundamentally changes the sizing model and is
-      treated as loosening).
-    - ``discarded_unknown_keys`` lists fields the caller proposed that
-      either aren't in the ``RiskLimits`` schema or are marked
-      immutable in ``_RISK_LIMIT_TIGHTEN_DIRECTION`` (e.g.
-      ``vol_lookback_days``).
-
-    Callers raise ``SpecImplementabilityError`` when ``loosened_fields``
-    is non-empty; unknown keys are warned but never trip.
-    """
-    loosened: List[str] = []
-    unknown: List[str] = []
-    if not isinstance(proposed, dict):
-        return current, loosened, unknown
-
-    merged_data = current.model_dump()
-    for key, new_value in proposed.items():
-        direction = _RISK_LIMIT_TIGHTEN_DIRECTION.get(key)
-        if direction is None:
-            # Either unknown to RiskLimits or explicitly immutable.
-            unknown.append(key)
-            continue
-
-        current_value = merged_data.get(key)
-
-        # Special-case ``target_annual_vol``: ``None`` means "no vol
-        # target" (flat sizing). Switching to a value or vice-versa
-        # changes the sizing model — treat any None↔value transition
-        # as loosening.
-        if key == "target_annual_vol":
-            if current_value is None and new_value is not None:
-                loosened.append(key)
-                continue
-            if current_value is not None and new_value is None:
-                loosened.append(key)
-                continue
-
-        try:
-            cmp_current = float(current_value) if current_value is not None else None
-            cmp_new = float(new_value) if new_value is not None else None
-        except (TypeError, ValueError):
-            unknown.append(key)
-            continue
-
-        if cmp_current is None or cmp_new is None:
-            # Already handled above; defensive.
-            continue
-
-        if direction == "lower":
-            if cmp_new < cmp_current:
-                merged_data[key] = new_value
-            elif cmp_new > cmp_current:
-                loosened.append(key)
-            # equal: no-op
-        elif direction == "higher":
-            if cmp_new > cmp_current:
-                merged_data[key] = new_value
-            elif cmp_new < cmp_current:
-                loosened.append(key)
-            # equal: no-op
-
-    try:
-        merged = RiskLimits.model_validate(merged_data)
-    except Exception:
-        # Validation failed on the merged limits — bail out without
-        # mutating; surface every proposed key as unknown so the caller
-        # logs the full set and keeps the original limits.
-        logger.warning(
-            "Refined risk_limits failed pydantic validation; keeping current limits unchanged."
-        )
-        return current, loosened, sorted(set(unknown) | set(proposed.keys()))
-
-    return merged, loosened, unknown
-
-def _daily_returns_from_trades(
-    trades: Sequence[TradeRecord],
-    initial_capital: float,
-    start_date: str,
-    end_date: str,
-) -> List[float]:
-    """Daily log returns from the equity curve implied by the trades.
-
-    Log basis matches :meth:`EquityCurve.daily_returns` and the rest of
-    the metrics module, so OOS-Sharpe / DSR / bootstrap CIs computed
-    downstream share the same return convention as the in-sample
-    ``compute_performance_metrics`` Sharpe.
-
-    If the equity curve crosses zero (portfolio ruin), the series is
-    returned **empty** rather than zero-padding the ruin step. Zeroing
-    a wipeout would convert it to a neutral day and let the OOS DSR /
-    Sharpe CI / moments report misleadingly low risk; an empty series
-    falls through every downstream consumer
-    (:func:`summarize_return_moments`, :func:`compute_deflated_sharpe`,
-    :func:`bootstrap_sharpe_ci`) as their well-defined "no data" path.
-    """
-    curve = build_equity_curve_from_trades(
-        trades, initial_capital, start_date=start_date, end_date=end_date
-    )
-    if len(curve.equity) < 2:
-        return []
-    if any(v <= 0 for v in curve.equity):
-        # Ruin: invalidate the whole series. Any downstream Sharpe / DSR
-        # / CI on a curve that touched zero would be meaningless.
-        return []
-    out: List[float] = []
-    for i in range(1, len(curve.equity)):
-        out.append(math.log(curve.equity[i] / curve.equity[i - 1]))
-    return out
-
-def _equity_to_returns(equity: Sequence[float]) -> List[float]:
-    out: List[float] = []
-    for i in range(1, len(equity)):
-        prev = equity[i - 1]
-        if prev <= 0:
-            out.append(0.0)
-        else:
-            out.append((equity[i] - prev) / prev)
-    return out
-
-def _closes_to_equity(closes: Sequence[float], initial_capital: float) -> List[float]:
-    if not closes or closes[0] <= 0:
-        return []
-    scale = initial_capital / closes[0]
-    return [c * scale for c in closes]
-
-def _parse_bar_date(d: str) -> Any:
-    from datetime import date
-
-    return date.fromisoformat(d[:10])
-
-def _resolve_vix_provider() -> Optional[Callable[[Sequence[Any]], List[float]]]:
-    """Return a VIX provider callable when ``STRATEGY_LAB_VIX_SOURCE`` is
-    set, otherwise None so :func:`vix_quartile_subwindows` falls back to
-    realized-vol on the benchmark series. Production deployments can
-    wire in a Yahoo ``^VIX`` fetcher here without touching callers."""
-    source = os.environ.get("STRATEGY_LAB_VIX_SOURCE", "").strip().lower()
-    if not source:
-        return None
-    # Hook point for production providers; unset → realized-vol fallback.
-    return None
+from ._orchestrator_helpers import (  # noqa: E402  — keep at file end
+    _AlignmentLoopOutcome,
+    _apply_veto_to_acceptance_reason,
+    _closes_to_equity,
+    _daily_returns_from_trades,
+    _equity_to_returns,
+    _format_execution_diagnostics,
+    _MarketDataFetch,
+    _maybe_attach_coverage_report,
+    _merge_risk_limits_tighten_only,
+    _parse_bar_date,
+    _resolve_vix_provider,
+    _VerificationOutcome,
+)

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -261,10 +261,16 @@ class StrategyLabOrchestrator:
         """Recent-close lookup wired into ``SpecReadinessGate.Rule 5``.
 
         Pre: ``symbol`` and ``asset_class`` are non-empty strings.
-        Post: returns a strictly positive finite price. Falls back to
-        ``100.0`` only when the provider chain is exhausted, the symbol is
-        unknown, or any unexpected exception is raised — so the gate degrades
-        to its static default rather than crashing the cycle.
+        Post: returns either a strictly positive finite price *or*
+        ``float("nan")`` when no live price is available — so Rule 5's
+        non-finite check fails the gate closed instead of silently sizing
+        against a synthetic placeholder that could let a high-priced spec
+        slip through.
+
+        The cycle never crashes on a data-fetch failure: the exception is
+        logged and the NaN return turns into a critical readiness failure
+        the operator can act on, rather than a "looks fine, then runs to
+        zero trades" silent error downstream.
         """
         assert isinstance(symbol, str) and symbol, "symbol must be a non-empty str"
         assert isinstance(asset_class, str) and asset_class, "asset_class must be a non-empty str"
@@ -274,14 +280,14 @@ class StrategyLabOrchestrator:
                 close = float(bars[-1].close)
                 if close > 0:
                     return close
-        except Exception as exc:  # noqa: BLE001 — fail-soft to static default
+        except Exception as exc:  # noqa: BLE001 — fail-closed via NaN below
             logger.debug(
-                "readiness price provider fell back for %s/%s: %s",
+                "readiness price provider returned NaN for %s/%s: %s",
                 symbol,
                 asset_class,
                 exc,
             )
-        return 100.0
+        return float("nan")
 
     def _record_gates(
         self,

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -16,11 +16,9 @@ import logging
 import math
 import os
 import uuid
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple
-
-from pydantic import ValidationError
 
 from ..execution.benchmarks import benchmark_for_strategy, build_60_40_equity
 from ..execution.metrics import (
@@ -43,7 +41,6 @@ from ..models import (
     BacktestExecutionDiagnostics,
     BacktestRecord,
     BacktestResult,
-    CoverageReport,
     StrategyLabRecord,
     StrategySpec,
     TradeRecord,
@@ -56,7 +53,7 @@ from .agents.alignment import AlignmentAuditError, TradeAlignmentAgent, TradeAli
 from .agents.analysis import AnalysisAgent
 from .agents.ideation import IdeationAgent
 from .agents.refinement import RefinementAgent
-from .agents.zero_trade_repair import ZeroTradeRepairAgent, ZeroTradeRepairReport
+from .agents.zero_trade_repair import ZeroTradeRepairAgent
 from .coverage_probe import format_coverage_report, run_coverage_stage, should_run_probes
 from .exceptions import SpecImplementabilityError
 from .quality_gates.acceptance_gate import AcceptanceGate, summarize_acceptance_reason
@@ -69,6 +66,7 @@ from .quality_gates.spec_readiness import SpecReadinessGate
 from .quality_gates.strategy_validator import StrategySpecValidator
 from .quality_gates.target_symbol_coverage import TargetSymbolCoverageGate
 from .spec_dsl import DEFAULT_SIZING_PAYLOAD
+from .zero_trade_repair import ZeroTradeRepairer
 
 logger = logging.getLogger(__name__)
 
@@ -189,41 +187,6 @@ def _format_execution_diagnostics(
     return f"Execution Diagnostics: {encoded}"
 
 
-# Spec keys honoured when applying ``ZeroTradeRepairReport.proposed_spec_updates``.
-# Mirrors the agent-side whitelist so the orchestrator silently drops any
-# off-list keys an LLM might invent.
-#
-# #530: narrowed to ``risk_limits`` only. The repair agent must fix the
-# **code**, not weaken the **spec** — letting it rewrite entry/exit/sizing
-# rules, the hypothesis, or the signal_definition is the formal mechanism
-# by which a thesis silently mutates across refinement rounds to "make
-# trades happen". Off-list keys are dropped with a ``logger.warning`` and
-# a ``zero_trade_repair_dropped_spec_keys`` quality gate so the drift is
-# visible in the persisted ``quality_gate_results``.
-_ZERO_TRADE_SPEC_UPDATE_KEYS = frozenset({"risk_limits"})
-
-
-@dataclass
-class _ZeroTradeRepairOutcome:
-    """Result of one specialized zero-trade repair attempt.
-
-    ``committed=True`` means the proposed code passed code-safety, ran
-    cleanly, and produced trades that no longer trip a critical anomaly
-    gate; the orchestrator should swap in the new state. ``False`` means
-    the caller should fall through to the generic refinement agent so
-    the existing loop semantics are preserved.
-    """
-
-    committed: bool
-    new_code: str = ""
-    new_spec: Optional[StrategySpec] = None
-    new_trades: List[TradeRecord] = field(default_factory=list)
-    new_metrics: Optional[BacktestResult] = None
-    new_exec_result: Optional[StrategyRunResult] = None
-    new_gates: List[QualityGateResult] = field(default_factory=list)
-    failure_reason: str = ""
-    changes_made: str = ""
-
 
 def _apply_veto_to_acceptance_reason(
     metrics: BacktestResult,
@@ -283,6 +246,11 @@ class StrategyLabOrchestrator:
         self.spec_readiness_gate = SpecReadinessGate(
             market_sample_provider=self._readiness_price_provider,
         )
+        # Zero-trade repair sub-pipeline. Lives in its own module so the
+        # ~340 lines of branching logic + the four gates it threads through
+        # don't bloat this class. The repairer reads gate instances off
+        # ``self`` so no API surface is duplicated.
+        self.zero_trade_repairer = ZeroTradeRepairer(self)
         # Per-failure_phase counter of consecutive refinement rounds where
         # the LLM emitted stray spec-mutating keys. Reset at the start of
         # each ``_run_design_attempt`` and tripped when any phase hits
@@ -892,7 +860,7 @@ class StrategyLabOrchestrator:
                         and diag.zero_trade_category is not None
                         and market_data is not None
                     ):
-                        zt_outcome = self._run_zero_trade_repair(
+                        zt_outcome = self.zero_trade_repairer.try_repair(
                             spec=spec,
                             code=code,
                             exec_result=exec_result,
@@ -1698,365 +1666,6 @@ class StrategyLabOrchestrator:
                 f"{type(last_exc).__name__}: {last_exc}"
             ),
         )
-
-    def _run_zero_trade_repair(
-        self,
-        *,
-        spec: StrategySpec,
-        code: str,
-        exec_result: StrategyRunResult,
-        market_data: Dict[str, List[OHLCVBar]],
-        config: BacktestConfig,
-        zero_trade_attempts: List[str],
-        round_num: int,
-        emit: PhaseCallback,
-        coverage_report: Optional[CoverageReport] = None,
-    ) -> _ZeroTradeRepairOutcome:
-        """Issue #405 — specialized zero-trade repair attempt.
-
-        Asks :class:`ZeroTradeRepairAgent` for a targeted code fix based
-        on the deterministic execution diagnostics (issue #404), then
-        gates the proposal through code-safety + a fresh backtest +
-        :class:`BacktestAnomalyDetector` before signalling commit.
-        Mirrors the alignment loop's break-without-commit posture: any
-        failed gate appends a record to ``zero_trade_attempts`` and
-        returns ``committed=False`` so the caller falls through to the
-        generic :class:`RefinementAgent`.
-        """
-        diagnostics = exec_result.execution_diagnostics
-        # Caller is responsible for the routing guard, but be defensive.
-        if diagnostics is None or diagnostics.zero_trade_category is None:
-            return _ZeroTradeRepairOutcome(
-                committed=False,
-                failure_reason="no zero_trade_category on diagnostics envelope",
-            )
-
-        emit(
-            "coding",
-            {
-                "sub_phase": "zero_trade_repair_started",
-                "refinement_round": round_num,
-                "zero_trade_category": diagnostics.zero_trade_category,
-                "prior_attempts": len(zero_trade_attempts),
-            },
-        )
-
-        try:
-            report: ZeroTradeRepairReport = self.zero_trade_repair_agent.run(
-                spec=spec,
-                code=code,
-                diagnostics=diagnostics,
-                coverage_report=coverage_report,
-                prior_attempts=zero_trade_attempts,
-            )
-        except Exception as exc:
-            logger.exception("Zero-trade repair agent raised; falling through to refinement")
-            zero_trade_attempts.append(f"agent_error: {type(exc).__name__}: {str(exc)[:160]}")
-            emit(
-                "coding",
-                {
-                    "sub_phase": "zero_trade_repair_skipped",
-                    "refinement_round": round_num,
-                    "reason": "agent_error",
-                },
-            )
-            return _ZeroTradeRepairOutcome(committed=False, failure_reason=f"agent_error: {exc}")
-
-        if not report.proposed_code:
-            zero_trade_attempts.append(
-                f"no_proposal ({report.root_cause_category}): "
-                f"{report.evidence[:160] or 'agent declined to propose'}"
-            )
-            emit(
-                "coding",
-                {
-                    "sub_phase": "zero_trade_repair_skipped",
-                    "refinement_round": round_num,
-                    "reason": "no_proposed_code",
-                    "root_cause_category": report.root_cause_category,
-                },
-            )
-            return _ZeroTradeRepairOutcome(committed=False, failure_reason="no_proposed_code")
-
-        # ── Code-safety gate on the proposed code ────────────────────
-        # Stamp-only: this method's caller persists ``safety_gates`` via the
-        # outcome's ``new_gates=`` so the orchestrator's running list is not
-        # extended here.
-        safety_gates = self._record_gates(
-            self.code_safety_checker.check(report.proposed_code, spec),
-            refinement_round=round_num,
-            gate_name_prefix="zero_trade_repair_",
-        )
-        critical_safety = [g for g in safety_gates if not g.passed and g.severity == "critical"]
-        if critical_safety:
-            zero_trade_attempts.append(
-                f"unsafe_code ({report.root_cause_category}): "
-                f"{'; '.join(g.details for g in critical_safety)[:160]}"
-            )
-            emit(
-                "coding",
-                {
-                    "sub_phase": "zero_trade_repair_rejected",
-                    "refinement_round": round_num,
-                    "reason": "unsafe_code",
-                    "details": "; ".join(g.details for g in critical_safety)[:400],
-                },
-            )
-            return _ZeroTradeRepairOutcome(
-                committed=False,
-                new_gates=safety_gates,
-                failure_reason="unsafe_code",
-            )
-
-        # ── Surface any off-list spec keys the agent tried to mutate ─
-        # #530: the orchestrator's whitelist is now ``{"risk_limits"}``.
-        # In production the agent's own filter has already stripped
-        # off-list keys before we see them and recorded the names on
-        # ``report.dropped_spec_update_keys``; in tests or via future
-        # bypasses, keys may still be present on ``proposed_spec_updates``.
-        # Union both sources so the warning and the
-        # ``zero_trade_repair_dropped_spec_keys`` quality gate fire in both
-        # flows and the drift is auditable on the persisted
-        # ``quality_gate_results``.
-        dropped_spec_keys: List[str] = sorted(
-            set(report.dropped_spec_update_keys)
-            | {
-                k
-                for k in (report.proposed_spec_updates or {})
-                if k not in _ZERO_TRADE_SPEC_UPDATE_KEYS
-            }
-        )
-        dropped_keys_gates: List[QualityGateResult] = []
-        if dropped_spec_keys:
-            logger.warning(
-                "Zero-trade repair discarded spec-mutating keys %s for round=%s "
-                "(post-#530 repair may only adjust risk_limits; fix the code, "
-                "not the spec).",
-                dropped_spec_keys,
-                round_num,
-            )
-            # #530: build the gate once so every early-return path carries
-            # it forward (the ValidationError path below would otherwise
-            # drop the audit trail even though the warning was logged).
-            dropped_keys_gates = [
-                self._orchestrator_gate(
-                    "zero_trade_repair_dropped_spec_keys",
-                    phase="synthesis",
-                    severity="warning",
-                    details=(
-                        "Zero-trade repair proposed off-list spec keys "
-                        f"{dropped_spec_keys}; dropped per #530 "
-                        "(risk_limits only)."
-                    ),
-                    refinement_round=round_num,
-                )
-            ]
-
-        # ── Fresh backtest of the proposed code ──────────────────────
-        try:
-            proposed_spec = self._apply_zero_trade_spec_updates(
-                spec, report.proposed_spec_updates, report.proposed_code
-            )
-        except ValidationError as exc:
-            # Whitelisted keys can still arrive with the wrong shape (e.g.
-            # ``entry_rules`` as a string, ``risk_limits`` as a list).
-            # Reject the proposal as we would for unsafe code and let
-            # the caller fall through to generic refinement instead of
-            # aborting the Strategy Lab cycle.
-            logger.warning("Zero-trade repair proposal had invalid spec updates: %s", exc)
-            zero_trade_attempts.append(
-                f"invalid_spec_updates ({report.root_cause_category}): "
-                f"{str(exc).splitlines()[0][:160]}"
-            )
-            emit(
-                "coding",
-                {
-                    "sub_phase": "zero_trade_repair_rejected",
-                    "refinement_round": round_num,
-                    "reason": "invalid_spec_updates",
-                    "details": str(exc).splitlines()[0][:400],
-                },
-            )
-            return _ZeroTradeRepairOutcome(
-                committed=False,
-                new_gates=safety_gates + dropped_keys_gates,
-                failure_reason="invalid_spec_updates",
-            )
-
-        # ── Re-validate the spec after repair-driven mutation ────────
-        # The pre-synthesis gate (#547 item 1) only runs once at ideation.
-        # Post-#530, zero-trade repair may only mutate ``risk_limits`` via
-        # the whitelist; that single mutation still bypasses the
-        # pre-synthesis gate. A Pydantic-valid risk_limits value (e.g.
-        # max_position_pct=99) can still be a critical spec failure under
-        # StrategySpecValidator. Re-validate before committing; on accept,
-        # carry the gates forward in ``new_gates`` so warnings (e.g. tight
-        # drawdown limits on a repaired spec) reach the persisted
-        # ``quality_gate_results`` rather than being silently dropped.
-        post_repair_spec_gates: List[QualityGateResult] = []
-        if report.proposed_spec_updates:
-            # Zero-trade repair runs inside the synthesis refinement loop —
-            # re-validate the patched spec under that phase rather than design.
-            # Stamp-only; the caller persists via the outcome's ``new_gates=``.
-            post_repair_spec_gates = self._record_gates(
-                self.strategy_validator.validate(proposed_spec, phase="synthesis"),
-                refinement_round=round_num,
-                gate_name_prefix="zero_trade_repair_",
-            )
-        # #530: extend with the pre-built dropped-keys gate so the
-        # persisted ``quality_gate_results`` records the attempted spec
-        # mutation even when no whitelisted key was present (same gate
-        # object the ValidationError early-return carries forward).
-        post_repair_spec_gates.extend(dropped_keys_gates)
-        spec_criticals = [
-            g for g in post_repair_spec_gates if not g.passed and g.severity == "critical"
-        ]
-        if spec_criticals:
-            zero_trade_attempts.append(
-                f"invalid_spec_after_repair ({report.root_cause_category}): "
-                f"{'; '.join(g.details for g in spec_criticals)[:160]}"
-            )
-            emit(
-                "coding",
-                {
-                    "sub_phase": "zero_trade_repair_rejected",
-                    "refinement_round": round_num,
-                    "reason": "invalid_spec_after_repair",
-                    "details": "; ".join(g.details for g in spec_criticals)[:400],
-                },
-            )
-            return _ZeroTradeRepairOutcome(
-                committed=False,
-                new_gates=safety_gates + post_repair_spec_gates,
-                failure_reason="invalid_spec_after_repair",
-            )
-
-        repair_exec = run_strategy_code(
-            report.proposed_code, market_data, config, strategy=proposed_spec
-        )
-        if not repair_exec.success:
-            failure_gate = self._orchestrator_gate(
-                "zero_trade_repair_code_execution",
-                phase="synthesis",
-                details=(
-                    f"Re-execution after zero-trade repair failed "
-                    f"({repair_exec.error_type}): {repair_exec.stderr[:400]}"
-                ),
-                refinement_round=round_num,
-            )
-            zero_trade_attempts.append(
-                f"reexec_failed ({report.root_cause_category}): {repair_exec.error_type}"
-            )
-            emit(
-                "coding",
-                {
-                    "sub_phase": "zero_trade_repair_rejected",
-                    "refinement_round": round_num,
-                    "reason": "re_execution_failed",
-                    "error_type": repair_exec.error_type,
-                },
-            )
-            return _ZeroTradeRepairOutcome(
-                committed=False,
-                new_gates=safety_gates + post_repair_spec_gates + [failure_gate],
-                failure_reason=f"re_execution_failed: {repair_exec.error_type}",
-            )
-
-        new_trades = repair_exec.trades
-        new_metrics = compute_metrics(
-            new_trades, config.initial_capital, config.start_date, config.end_date
-        )
-
-        # Issue #451 — repair re-execution path also attaches a
-        # CoverageReport when the proposed fix produces zero/low trades.
-        _maybe_attach_coverage_report(
-            metrics=new_metrics,
-            spec=proposed_spec,
-            market_data=market_data,
-            config=config,
-            exec_result=repair_exec,
-        )
-
-        # ── Anomaly recheck ──────────────────────────────────────────
-        # Stamp-only; ``new_gates`` is persisted by the caller via the outcome.
-        new_anomaly_gates = self._record_gates(
-            self.anomaly_detector.check(
-                new_metrics,
-                new_trades,
-                dsr_aware=config.walk_forward_enabled,
-                diagnostics=repair_exec.execution_diagnostics,
-                coverage_report=new_metrics.coverage_report,
-            ),
-            refinement_round=round_num,
-            gate_name_prefix="zero_trade_repair_",
-        )
-
-        new_critical = [g for g in new_anomaly_gates if not g.passed and g.severity == "critical"]
-        if new_critical:
-            zero_trade_attempts.append(
-                f"anomaly_after_repair ({report.root_cause_category}): "
-                f"{'; '.join(g.details for g in new_critical)[:160]}"
-            )
-            emit(
-                "coding",
-                {
-                    "sub_phase": "zero_trade_repair_rejected",
-                    "refinement_round": round_num,
-                    "reason": "anomaly_after_repair",
-                    "details": "; ".join(g.details for g in new_critical)[:400],
-                },
-            )
-            return _ZeroTradeRepairOutcome(
-                committed=False,
-                new_gates=safety_gates + post_repair_spec_gates + new_anomaly_gates,
-                failure_reason="anomaly_after_repair",
-            )
-
-        # All gates passed — commit the proposal.
-        change_summary = report.changes_made or f"repair {report.root_cause_category}"
-        zero_trade_attempts.append(
-            f"committed ({report.root_cause_category}): {change_summary[:160]}"
-        )
-        emit(
-            "coding",
-            {
-                "sub_phase": "zero_trade_repair_committed",
-                "refinement_round": round_num,
-                "root_cause_category": report.root_cause_category,
-                "changes_made": change_summary,
-                "trades_count": len(new_trades),
-            },
-        )
-        return _ZeroTradeRepairOutcome(
-            committed=True,
-            new_code=report.proposed_code,
-            new_spec=proposed_spec,
-            new_trades=new_trades,
-            new_metrics=new_metrics,
-            new_exec_result=repair_exec,
-            new_gates=safety_gates + post_repair_spec_gates + new_anomaly_gates,
-            changes_made=change_summary,
-        )
-
-    @staticmethod
-    def _apply_zero_trade_spec_updates(
-        spec: StrategySpec, updates: Optional[Dict[str, Any]], code: str
-    ) -> StrategySpec:
-        """Apply whitelisted spec updates from a zero-trade repair report.
-
-        Restricts merges to :data:`_ZERO_TRADE_SPEC_UPDATE_KEYS` so an
-        off-list LLM hallucination cannot rewrite arbitrary spec fields.
-        Post-#530 the whitelist is ``{"risk_limits"}`` — the repair agent
-        must fix the **code**, not weaken the **spec**. Off-list keys are
-        surfaced as a ``zero_trade_repair_dropped_spec_keys`` gate by the
-        caller; this helper only applies what is allowed.
-        """
-        data = spec.model_dump()
-        for key in _ZERO_TRADE_SPEC_UPDATE_KEYS:
-            if updates and key in updates:
-                data[key] = updates[key]
-        data["strategy_code"] = code
-        return StrategySpec.model_validate(data)
 
     @staticmethod
     def _merge_risk_limits_tighten_only(

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -88,6 +88,30 @@ class _MarketDataFetch:
     fetched_symbols: List[str]
 
 
+@dataclass
+class _AlignmentLoopOutcome:
+    """Bundle of state mutated by ``_run_trade_alignment_loop``.
+
+    The trade-alignment loop can replace the run's known-good
+    ``spec`` / ``code`` / ``trades`` / ``metrics`` if it commits a fix,
+    and tracks attempt strings + per-round reports the caller consumes.
+    Returning a single dataclass keeps ``_run_design_attempt``'s
+    unpacking explicit and small.
+    """
+
+    spec: StrategySpec
+    code: str
+    trades: List[TradeRecord]
+    metrics: "BacktestResult"
+    alignment_attempts: List[str]
+    alignment_reports: List["TradeAlignmentReport"]
+    trades_aligned: bool
+
+    @property
+    def alignment_rounds(self) -> int:
+        return len(self.alignment_attempts)
+
+
 # Refinement output is code-only post-#543. Anything else the LLM emits is
 # logged + discarded by ``_apply_updates``; ``risk_limits`` is the lone
 # exception, handled with tighten-only semantics.
@@ -512,6 +536,298 @@ class StrategyLabOrchestrator:
                 + "; ".join(g.details for g in criticals)
             ),
             emit=emit,
+        )
+
+    def _run_trade_alignment_loop(
+        self,
+        *,
+        spec: StrategySpec,
+        code: str,
+        trades: List[TradeRecord],
+        metrics: BacktestResult,
+        market_data: Dict[str, List[OHLCVBar]],
+        config: BacktestConfig,
+        execution_succeeded: bool,
+        all_gate_results: List[QualityGateResult],
+        emit: PhaseCallback,
+    ) -> _AlignmentLoopOutcome:
+        """Run the trade-alignment audit loop after the synthesis loop settles.
+
+        Pre: synthesis loop has produced (``code``, ``spec``, ``trades``,
+        ``metrics``) plus ``market_data`` was fetched at least once and
+        ``execution_succeeded`` tracks whether the last execution cleared
+        the anomaly gates.
+        Post: returns an ``_AlignmentLoopOutcome`` carrying the (possibly
+        updated) ``spec`` / ``code`` / ``trades`` / ``metrics`` plus the
+        attempt-string history and per-round reports the caller persists.
+        Mutates ``all_gate_results`` in place (gates appended with
+        ``alignment_`` prefix on each commit / failure).
+
+        The loop exits early when:
+          * The agent reports the trades aligned (``aligned=True``) — committed.
+          * The agent returns no ``proposed_code`` — nothing to retry.
+          * ``MAX_ALIGNMENT_ROUNDS`` is reached.
+          * The proposed code fails code-safety or sandbox re-execution.
+          * The post-fix backtest trips a critical anomaly.
+        Every break short-circuits the loop with the known-good state from
+        the most recent committed round.
+        """
+        alignment_attempts: List[str] = []
+        alignment_reports: List[TradeAlignmentReport] = []
+
+        # Issue #527 — engine-side enforcement of structured ``exit_rules``
+        # has a deterministic conformance gate that runs once the trade
+        # ledger is settled. It runs AFTER this loop because alignment
+        # re-execution can replace ``trades`` / ``metrics`` with a new
+        # ledger that has different conformance characteristics.
+        if not (execution_succeeded and trades and market_data is not None):
+            return _AlignmentLoopOutcome(
+                spec=spec,
+                code=code,
+                trades=trades,
+                metrics=metrics,
+                alignment_attempts=alignment_attempts,
+                alignment_reports=alignment_reports,
+                trades_aligned=False,
+            )
+
+        for align_round in range(MAX_ALIGNMENT_ROUNDS):
+            emit(
+                "aligning",
+                {
+                    "sub_phase": "evaluating",
+                    "alignment_round": align_round,
+                    "trades_count": len(trades),
+                },
+            )
+
+            report = self._run_alignment_audit(
+                spec=spec,
+                code=code,
+                trades=trades,
+                metrics=metrics,
+                prior_attempts=alignment_attempts,
+            )
+            alignment_reports.append(report)
+
+            gate_severity = "info" if report.aligned else "critical"
+            gate_details = (
+                report.rationale or "Trades aligned with strategy."
+                if report.aligned
+                else (
+                    report.rationale
+                    or f"Trades did not align with strategy ({len(report.issues)} issues)."
+                )
+            )
+            all_gate_results.append(
+                self.build_orchestrator_gate(
+                    "trade_alignment",
+                    phase="verification",
+                    severity=gate_severity,  # type: ignore[arg-type]
+                    details=gate_details,
+                    refinement_round=align_round,
+                )
+            )
+
+            if report.aligned:
+                emit(
+                    "aligning",
+                    {"sub_phase": "aligned", "alignment_round": align_round},
+                )
+                break
+
+            emit(
+                "aligning",
+                {
+                    "sub_phase": "not_aligned",
+                    "alignment_round": align_round,
+                    "issues_count": len(report.issues),
+                    "issues_preview": [
+                        {
+                            "rule_type": i.rule_type,
+                            "severity": i.severity,
+                            "description": i.description[:160],
+                        }
+                        for i in report.issues[:5]
+                    ],
+                },
+            )
+
+            if not report.proposed_code:
+                emit(
+                    "aligning",
+                    {"sub_phase": "no_proposed_fix", "alignment_round": align_round},
+                )
+                break
+
+            if align_round >= MAX_ALIGNMENT_ROUNDS - 1:
+                emit(
+                    "aligning",
+                    {"sub_phase": "max_rounds_reached", "alignment_round": align_round},
+                )
+                logger.warning(
+                    "Max alignment rounds (%d) reached for %s",
+                    MAX_ALIGNMENT_ROUNDS,
+                    spec.strategy_id,
+                )
+                break
+
+            emit(
+                "aligning",
+                {
+                    "sub_phase": "refining_code",
+                    "alignment_round": align_round,
+                    "predicted_aligned_after_fix": report.predicted_aligned_after_fix,
+                },
+            )
+            proposed_code = report.proposed_code
+            proposed_spec = self._apply_updates(spec, {}, proposed_code)
+            change_summary = report.changes_made or "alignment fix"
+
+            # Re-validate code safety on the proposed code — alignment runs
+            # after backtest, so the phase tag is verification.
+            safety_gates = self.code_safety_checker.check(
+                proposed_code, proposed_spec, phase="verification"
+            )
+            self.record_gates(
+                safety_gates,
+                all_gate_results,
+                refinement_round=align_round,
+                gate_name_prefix="alignment_",
+            )
+            critical_safety = [
+                g for g in safety_gates if not g.passed and g.severity == "critical"
+            ]
+            if critical_safety:
+                emit(
+                    "aligning",
+                    {
+                        "sub_phase": "rejected_unsafe_code",
+                        "alignment_round": align_round,
+                        "details": "; ".join(g.details for g in critical_safety)[:400],
+                    },
+                )
+                logger.warning(
+                    "Alignment-proposed code failed safety gate for %s", spec.strategy_id
+                )
+                break
+
+            emit(
+                "backtesting",
+                {
+                    "sub_phase": "running_code",
+                    "alignment_round": align_round,
+                    "trigger": "trade_alignment_fix",
+                },
+            )
+            align_exec = run_strategy_code(proposed_code, market_data, config, strategy=spec)
+            if not align_exec.success:
+                all_gate_results.append(
+                    self.build_orchestrator_gate(
+                        "alignment_code_execution",
+                        phase="verification",
+                        details=(
+                            f"Re-execution after alignment fix failed "
+                            f"({align_exec.error_type}): {align_exec.stderr[:400]}"
+                        ),
+                        refinement_round=align_round,
+                    )
+                )
+                emit(
+                    "aligning",
+                    {
+                        "sub_phase": "re_execution_failed",
+                        "alignment_round": align_round,
+                        "error_type": align_exec.error_type,
+                    },
+                )
+                break
+
+            new_trades = align_exec.trades
+            new_metrics = compute_metrics(
+                new_trades, config.initial_capital, config.start_date, config.end_date
+            )
+
+            # Alignment re-backtest path attaches a CoverageReport when the
+            # fix produced zero/low trades. Pass ``proposed_spec`` (which
+            # carries ``proposed_code``) — the loop-level ``spec`` still
+            # holds the pre-alignment source.
+            _maybe_attach_coverage_report(
+                metrics=new_metrics,
+                spec=proposed_spec,
+                market_data=market_data,
+                config=config,
+                exec_result=align_exec,
+            )
+
+            anomaly_gates = self.anomaly_detector.check(
+                new_metrics,
+                new_trades,
+                dsr_aware=config.walk_forward_enabled,
+                diagnostics=align_exec.execution_diagnostics,
+                coverage_report=new_metrics.coverage_report,
+                phase="verification",
+            )
+            self.record_gates(
+                anomaly_gates,
+                all_gate_results,
+                refinement_round=align_round,
+                gate_name_prefix="alignment_",
+            )
+            critical_anomalies = [
+                g for g in anomaly_gates if not g.passed and g.severity == "critical"
+            ]
+            if critical_anomalies:
+                diagnostics_block = _format_execution_diagnostics(
+                    align_exec.execution_diagnostics
+                )
+                emit_payload: Dict[str, Any] = {
+                    "sub_phase": "anomaly_detected",
+                    "alignment_round": align_round,
+                    "details": "; ".join(g.details for g in critical_anomalies)[:400],
+                }
+                if diagnostics_block:
+                    emit_payload["execution_diagnostics"] = diagnostics_block
+                emit("aligning", emit_payload)
+                if diagnostics_block:
+                    logger.warning(
+                        "Alignment fix introduced backtest anomaly for %s — %s",
+                        spec.strategy_id,
+                        diagnostics_block,
+                    )
+                else:
+                    logger.warning(
+                        "Alignment fix introduced backtest anomaly for %s",
+                        spec.strategy_id,
+                    )
+                break
+
+            # All gates passed — commit the proposal as the new known-good
+            # state and continue to the next audit.
+            code = proposed_code
+            spec = proposed_spec
+            trades = new_trades
+            metrics = new_metrics
+            alignment_attempts.append(change_summary)
+
+            emit(
+                "aligning",
+                {
+                    "sub_phase": "refined",
+                    "alignment_round": align_round,
+                    "changes_made": change_summary,
+                    "trades_count": len(trades),
+                },
+            )
+
+        return _AlignmentLoopOutcome(
+            spec=spec,
+            code=code,
+            trades=trades,
+            metrics=metrics,
+            alignment_attempts=alignment_attempts,
+            alignment_reports=alignment_reports,
+            trades_aligned=bool(alignment_reports and alignment_reports[-1].aligned),
         )
 
     def _run_design_attempt(
@@ -985,289 +1301,27 @@ class StrategyLabOrchestrator:
             break
 
         # ── Phase 2.5: TRADE ALIGNMENT LOOP ───────────────────────────
-        # Now that the code runs cleanly and produces sensible aggregate
-        # metrics, audit whether the executed trades actually implement
-        # the strategy specification (entry/exit/sizing/risk rules). If
-        # not, enter a problem-solving loop (capped at
-        # MAX_ALIGNMENT_ROUNDS) where the alignment agent identifies the
-        # bug, rewrites the Python code, and we send the script back
-        # through the sandbox for a fresh backtest. The loop exits as
-        # soon as the agent reports the trades are aligned (or the cap
-        # is reached).
-        alignment_attempts: List[str] = []
-        alignment_reports: List[TradeAlignmentReport] = []
-
-        # Issue #527 — engine-side enforcement of structured ``exit_rules``
-        # has a deterministic conformance gate that runs once the trade
-        # ledger is settled. It runs AFTER the alignment loop because
-        # alignment re-execution can replace ``trades`` / ``metrics`` with
-        # a new ledger that has different conformance characteristics —
-        # running before alignment would leave us evaluating a stale run.
-        # See the gate invocation just before the ``is_winning``
-        # resolution below.
-
-        if execution_succeeded and trades and market_data is not None:
-            for align_round in range(MAX_ALIGNMENT_ROUNDS):
-                emit(
-                    "aligning",
-                    {
-                        "sub_phase": "evaluating",
-                        "alignment_round": align_round,
-                        "trades_count": len(trades),
-                    },
-                )
-
-                report = self._run_alignment_audit(
-                    spec=spec,
-                    code=code,
-                    trades=trades,
-                    metrics=metrics,
-                    prior_attempts=alignment_attempts,
-                )
-                alignment_reports.append(report)
-
-                gate_severity = "info" if report.aligned else "critical"
-                gate_details = (
-                    report.rationale or "Trades aligned with strategy."
-                    if report.aligned
-                    else (
-                        report.rationale
-                        or f"Trades did not align with strategy ({len(report.issues)} issues)."
-                    )
-                )
-                all_gate_results.append(
-                    self.build_orchestrator_gate(
-                        "trade_alignment",
-                        phase="verification",
-                        severity=gate_severity,  # type: ignore[arg-type]
-                        details=gate_details,
-                        refinement_round=align_round,
-                    )
-                )
-
-                if report.aligned:
-                    emit(
-                        "aligning",
-                        {
-                            "sub_phase": "aligned",
-                            "alignment_round": align_round,
-                        },
-                    )
-                    break
-
-                emit(
-                    "aligning",
-                    {
-                        "sub_phase": "not_aligned",
-                        "alignment_round": align_round,
-                        "issues_count": len(report.issues),
-                        "issues_preview": [
-                            {
-                                "rule_type": i.rule_type,
-                                "severity": i.severity,
-                                "description": i.description[:160],
-                            }
-                            for i in report.issues[:5]
-                        ],
-                    },
-                )
-
-                # Without a proposed code fix the loop has nothing to
-                # send back to backtesting; stop early.
-                if not report.proposed_code:
-                    emit(
-                        "aligning",
-                        {
-                            "sub_phase": "no_proposed_fix",
-                            "alignment_round": align_round,
-                        },
-                    )
-                    break
-
-                if align_round >= MAX_ALIGNMENT_ROUNDS - 1:
-                    emit(
-                        "aligning",
-                        {
-                            "sub_phase": "max_rounds_reached",
-                            "alignment_round": align_round,
-                        },
-                    )
-                    logger.warning(
-                        "Max alignment rounds (%d) reached for %s",
-                        MAX_ALIGNMENT_ROUNDS,
-                        spec.strategy_id,
-                    )
-                    break
-
-                # The agent is confident enough to propose a rewrite.
-                # Validate, re-execute in the sandbox, rebuild trades, and
-                # re-run anomaly detection BEFORE committing the proposal
-                # over the last known-good ``code`` / ``spec`` / ``trades``
-                # / ``metrics``. If any of those checks fail, the loop
-                # breaks with the prior backtest intact so the persisted
-                # record never holds code that was never successfully
-                # executed for the reported results.
-                emit(
-                    "aligning",
-                    {
-                        "sub_phase": "refining_code",
-                        "alignment_round": align_round,
-                        "predicted_aligned_after_fix": report.predicted_aligned_after_fix,
-                    },
-                )
-                proposed_code = report.proposed_code
-                proposed_spec = self._apply_updates(spec, {}, proposed_code)
-                change_summary = report.changes_made or "alignment fix"
-
-                # ── Re-validate code safety on the proposed code ──────
-                # Alignment runs after backtest — phase tag is verification.
-                safety_gates = self.code_safety_checker.check(
-                    proposed_code, proposed_spec, phase="verification"
-                )
-                self.record_gates(
-                    safety_gates,
-                    all_gate_results,
-                    refinement_round=align_round,
-                    gate_name_prefix="alignment_",
-                )
-                critical_safety = [
-                    g for g in safety_gates if not g.passed and g.severity == "critical"
-                ]
-                if critical_safety:
-                    emit(
-                        "aligning",
-                        {
-                            "sub_phase": "rejected_unsafe_code",
-                            "alignment_round": align_round,
-                            "details": "; ".join(g.details for g in critical_safety)[:400],
-                        },
-                    )
-                    logger.warning(
-                        "Alignment-proposed code failed safety gate for %s", spec.strategy_id
-                    )
-                    break
-
-                # ── Send the script back to backtesting ───────────────
-                emit(
-                    "backtesting",
-                    {
-                        "sub_phase": "running_code",
-                        "alignment_round": align_round,
-                        "trigger": "trade_alignment_fix",
-                    },
-                )
-                align_exec = run_strategy_code(proposed_code, market_data, config, strategy=spec)
-                if not align_exec.success:
-                    all_gate_results.append(
-                        self.build_orchestrator_gate(
-                            "alignment_code_execution",
-                            phase="verification",
-                            details=(
-                                f"Re-execution after alignment fix failed "
-                                f"({align_exec.error_type}): {align_exec.stderr[:400]}"
-                            ),
-                            refinement_round=align_round,
-                        )
-                    )
-                    emit(
-                        "aligning",
-                        {
-                            "sub_phase": "re_execution_failed",
-                            "alignment_round": align_round,
-                            "error_type": align_exec.error_type,
-                        },
-                    )
-                    break
-
-                # Trades are already finalised by TradingService; the
-                # legacy raw-trade validation step is a no-op here.
-                new_trades = align_exec.trades
-
-                new_metrics = compute_metrics(
-                    new_trades, config.initial_capital, config.start_date, config.end_date
-                )
-
-                # Issue #451 — alignment re-backtest path also surfaces a
-                # CoverageReport when the fix produced zero/low trades.
-                # Pass ``proposed_spec`` (which carries ``proposed_code``)
-                # — the loop-level ``spec`` still holds the pre-alignment
-                # source, which would mislead the static probe.
-                _maybe_attach_coverage_report(
-                    metrics=new_metrics,
-                    spec=proposed_spec,
-                    market_data=market_data,
-                    config=config,
-                    exec_result=align_exec,
-                )
-
-                # ── Anomaly gates on the post-fix backtest ────────────
-                # The main refinement loop runs these checks after every
-                # sandbox round; the alignment loop must too, otherwise a
-                # fix could introduce zero-trade or implausible-return
-                # output that bypasses quality gates and still flows into
-                # analysis and the win/loss classification.
-                anomaly_gates = self.anomaly_detector.check(
-                    new_metrics,
-                    new_trades,
-                    dsr_aware=config.walk_forward_enabled,
-                    diagnostics=align_exec.execution_diagnostics,
-                    coverage_report=new_metrics.coverage_report,
-                    phase="verification",
-                )
-                self.record_gates(
-                    anomaly_gates,
-                    all_gate_results,
-                    refinement_round=align_round,
-                    gate_name_prefix="alignment_",
-                )
-                critical_anomalies = [
-                    g for g in anomaly_gates if not g.passed and g.severity == "critical"
-                ]
-                if critical_anomalies:
-                    diagnostics_block = _format_execution_diagnostics(
-                        align_exec.execution_diagnostics
-                    )
-                    emit_payload: Dict[str, Any] = {
-                        "sub_phase": "anomaly_detected",
-                        "alignment_round": align_round,
-                        "details": "; ".join(g.details for g in critical_anomalies)[:400],
-                    }
-                    if diagnostics_block:
-                        emit_payload["execution_diagnostics"] = diagnostics_block
-                    emit("aligning", emit_payload)
-                    if diagnostics_block:
-                        logger.warning(
-                            "Alignment fix introduced backtest anomaly for %s — %s",
-                            spec.strategy_id,
-                            diagnostics_block,
-                        )
-                    else:
-                        logger.warning(
-                            "Alignment fix introduced backtest anomaly for %s",
-                            spec.strategy_id,
-                        )
-                    break
-
-                # All gates passed — commit the proposal as the new
-                # known-good state and continue to the next audit.
-                code = proposed_code
-                spec = proposed_spec
-                trades = new_trades
-                metrics = new_metrics
-                alignment_attempts.append(change_summary)
-
-                emit(
-                    "aligning",
-                    {
-                        "sub_phase": "refined",
-                        "alignment_round": align_round,
-                        "changes_made": change_summary,
-                        "trades_count": len(trades),
-                    },
-                )
-
-        alignment_rounds = len(alignment_attempts)
-        trades_aligned = bool(alignment_reports and alignment_reports[-1].aligned)
+        alignment_outcome = self._run_trade_alignment_loop(
+            spec=spec,
+            code=code,
+            trades=trades,
+            metrics=metrics,
+            market_data=market_data,
+            config=config,
+            execution_succeeded=execution_succeeded,
+            all_gate_results=all_gate_results,
+            emit=emit,
+        )
+        spec = alignment_outcome.spec
+        code = alignment_outcome.code
+        trades = alignment_outcome.trades
+        metrics = alignment_outcome.metrics
+        alignment_rounds = alignment_outcome.alignment_rounds
+        trades_aligned = alignment_outcome.trades_aligned
+        # ``alignment_reports`` flows through to the alignment-veto guard
+        # below; the guard reads it to know whether the audit actually ran
+        # (skipped when ``market_data`` is None).
+        alignment_reports = alignment_outcome.alignment_reports
 
         # ── Phase 2.6: TRIAL COUNTING (issue #247) ────────────────────
         # Every refinement round on the same window contributes to the

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -89,6 +89,25 @@ class _MarketDataFetch:
 
 
 @dataclass
+class _VerificationOutcome:
+    """Bundle of state mutated by ``_run_verification_phase``.
+
+    The verification phase runs walk-forward (or its fallback anomaly
+    recheck), exit-rule conformance, resolves ``is_winning``, and
+    augments ``metrics.acceptance_reason`` with any veto causes.
+    Returning a dataclass keeps the boundary explicit without forcing
+    ``_run_design_attempt`` to learn the internal branches.
+    """
+
+    metrics: "BacktestResult"
+    is_winning: bool
+    upstream_admitted: bool
+    acceptance_results: List[QualityGateResult]
+    walk_forward_failed: bool
+    exit_rule_conformance_passed: bool
+
+
+@dataclass
 class _AlignmentLoopOutcome:
     """Bundle of state mutated by ``_run_trade_alignment_loop``.
 
@@ -830,6 +849,240 @@ class StrategyLabOrchestrator:
             trades_aligned=bool(alignment_reports and alignment_reports[-1].aligned),
         )
 
+    def _run_verification_phase(
+        self,
+        *,
+        spec: StrategySpec,
+        trades: List[TradeRecord],
+        metrics: BacktestResult,
+        market_data: Optional[Dict[str, List[OHLCVBar]]],
+        config: BacktestConfig,
+        execution_succeeded: bool,
+        trades_aligned: bool,
+        alignment_reports: List[TradeAlignmentReport],
+        all_gate_results: List[QualityGateResult],
+        emit: PhaseCallback,
+    ) -> _VerificationOutcome:
+        """Run walk-forward + acceptance, conformance, is_winning resolution.
+
+        Pre: synthesis + alignment loops have settled (``spec`` / ``trades``
+        / ``metrics`` are the known-good state). ``execution_succeeded``
+        tracks whether the last execution cleared the anomaly gates.
+        Post: returns a ``_VerificationOutcome`` carrying possibly-mutated
+        ``metrics`` (acceptance_reason / oos_* fields) plus the resolved
+        ``is_winning`` flag and the gate-level facts the caller persists.
+        Mutates ``all_gate_results`` in place (acceptance + conformance +
+        optional fallback gates appended).
+
+        The three is_winning branches mirror the orchestrator's three
+        publication-decision paths:
+          * Walk-forward succeeded → acceptance_gate verdict
+          * Walk-forward raised → anomaly recheck with ``dsr_aware=False``
+          * Walk-forward disabled / no trades → ``is_winning=False``
+        """
+        acceptance_results: List[QualityGateResult] = []
+        acceptance_reason: Optional[str] = None
+        walk_forward_failed = False
+        if (
+            execution_succeeded
+            and trades
+            and market_data is not None
+            and config.walk_forward_enabled
+        ):
+            try:
+                emit("backtesting", {"sub_phase": "walk_forward_started"})
+                metrics = self._evaluate_walk_forward(spec, market_data, config, trades, metrics)
+                acceptance_results = self.acceptance_gate.check(
+                    metrics,
+                    config,
+                    n_trials=self.convergence_tracker.trial_count,
+                )
+                all_gate_results.extend(acceptance_results)
+                acceptance_reason = summarize_acceptance_reason(acceptance_results)
+                metrics = metrics.model_copy(
+                    update={
+                        "n_trials_when_accepted": self.convergence_tracker.trial_count,
+                        "acceptance_reason": acceptance_reason,
+                    }
+                )
+                emit(
+                    "backtesting",
+                    {
+                        "sub_phase": "walk_forward_completed",
+                        "deflated_sharpe": metrics.deflated_sharpe,
+                        "oos_sharpe": metrics.oos_sharpe,
+                        "is_oos_degradation_pct": metrics.is_oos_degradation_pct,
+                        "oos_trade_count": metrics.oos_trade_count,
+                        "n_trials": self.convergence_tracker.trial_count,
+                        "acceptance_reason": acceptance_reason,
+                    },
+                )
+            except Exception:
+                logger.exception(
+                    "Walk-forward evaluation failed for %s; falling back to "
+                    "legacy single-window acceptance",
+                    spec.strategy_id,
+                )
+                acceptance_results = []
+                acceptance_reason = None
+                walk_forward_failed = True
+
+        # Issue #527 — deterministic check that the engine enforced
+        # ``spec.exit_rules`` against the FINAL trade ledger
+        # (post-alignment-loop). Critical failure vetoes ``is_winning``
+        # below; results are appended to ``all_gate_results`` for the
+        # persisted record.
+        exit_rule_conformance_passed = True
+        if execution_succeeded and trades:
+            conformance_gate = ExitRuleConformanceGate()
+            conformance_results = conformance_gate.check(
+                exit_rules=spec.exit_rules,
+                trades=trades,
+                diagnostics=metrics.execution_diagnostics,
+                config=config,
+                timeframe=spec.timeframe,
+            )
+            all_gate_results.extend(conformance_results)
+            exit_rule_conformance_passed = not any(
+                (not r.passed) and r.severity == "critical" for r in conformance_results
+            )
+
+        # Resolve is_winning across the three publication-decision paths.
+        # ``upstream_admitted`` records whether the upstream gate (walk-
+        # forward or fallback) said admit. It feeds the veto-augmentation
+        # block below: a success-style ``acceptance_reason`` is REPLACED
+        # by the veto cause; a failure-style reason is PRESERVED with the
+        # veto appended.
+        upstream_admitted = False
+        if acceptance_results:
+            acceptance_passed = all(r.passed for r in acceptance_results)
+            is_winning = (
+                execution_succeeded
+                and acceptance_passed
+                and trades_aligned
+                and exit_rule_conformance_passed
+            )
+            upstream_admitted = acceptance_passed
+        elif walk_forward_failed and execution_succeeded:
+            # Walk-forward fallback: anomaly recheck occurs after refinement
+            # in the verification phase. Anomaly checks during refinement
+            # ran with ``dsr_aware=True``, which downgraded ``Sharpe > 5.0``
+            # from critical to warning on the assumption that OOS DSR would
+            # adjudicate. Re-run with ``dsr_aware=False`` and reject if any
+            # critical fires — otherwise an obvious overfit could be marked
+            # winning on annualized return alone.
+            fallback_anomalies = self.anomaly_detector.check(
+                metrics,
+                trades,
+                dsr_aware=False,
+                coverage_report=metrics.coverage_report,
+                phase="verification",
+            )
+            fallback_criticals = [
+                g for g in fallback_anomalies if not g.passed and g.severity == "critical"
+            ]
+            return_ok = metrics.annualized_return_pct > WINNING_THRESHOLD
+            is_winning = (
+                return_ok
+                and not fallback_criticals
+                and trades_aligned
+                and exit_rule_conformance_passed
+            )
+            upstream_admitted = return_ok and not fallback_criticals
+            if fallback_criticals:
+                # Surface the upgraded severities so the persisted gate-
+                # result history reflects the true rejection reason.
+                self.record_gates(
+                    fallback_anomalies, all_gate_results, gate_name_prefix="fallback_"
+                )
+            # Mirror the fallback gate's own verdict onto
+            # ``acceptance_reason`` so consumers don't have to grep
+            # ``quality_gate_results`` for ``fallback_`` prefixes.
+            if upstream_admitted:
+                metrics = metrics.model_copy(
+                    update={
+                        "acceptance_reason": "walk_forward_fallback_passed: anomaly recheck clean"
+                    }
+                )
+            else:
+                fallback_reasons: List[str] = []
+                if fallback_criticals:
+                    fallback_reasons.append("; ".join(g.details for g in fallback_criticals))
+                if not return_ok:
+                    fallback_reasons.append(
+                        f"annualized_return {metrics.annualized_return_pct:.2f}% <= "
+                        f"{WINNING_THRESHOLD:g}% threshold"
+                    )
+                metrics = metrics.model_copy(
+                    update={
+                        "acceptance_reason": (
+                            "walk_forward_fallback_rejected: " + "; ".join(fallback_reasons)
+                        )
+                    }
+                )
+        else:
+            is_winning = False
+            # Self-document why publication was blocked on each else-branch
+            # entry path. Without this, the persisted record shows
+            # ``is_winning=False`` with an empty ``acceptance_reason``. The
+            # no-trades case is checked first because it's the more
+            # proximate cause when both conditions hold.
+            if execution_succeeded and not trades:
+                metrics = metrics.model_copy(
+                    update={"acceptance_reason": "publication_disabled: no trades produced"}
+                )
+            elif execution_succeeded and trades and not config.walk_forward_enabled:
+                metrics = metrics.model_copy(
+                    update={"acceptance_reason": "publication_disabled: walk_forward_enabled=False"}
+                )
+
+        # Publication vetoes — surface each veto's cause on
+        # ``acceptance_reason`` so the audit trail explains why publication
+        # was blocked even when the upstream acceptance gate passed.
+        # ``_apply_veto_to_acceptance_reason`` codifies the "replace stale
+        # success, append real rejection" rule.
+        if execution_succeeded and trades and not exit_rule_conformance_passed:
+            conformance_criticals = [
+                r
+                for r in all_gate_results
+                if r.gate_name == "exit_rule_conformance"
+                and not r.passed
+                and r.severity == "critical"
+            ]
+            detail = "; ".join(r.details for r in conformance_criticals)
+            suffix = (
+                f"exit_rule_conformance_failed: {detail}"
+                if detail
+                else "exit_rule_conformance_failed: engine enforcement leaked"
+            )
+            metrics, upstream_admitted = _apply_veto_to_acceptance_reason(
+                metrics, suffix, upstream_admitted=upstream_admitted
+            )
+
+        if execution_succeeded and trades and alignment_reports and not trades_aligned:
+            last_report = alignment_reports[-1]
+            # NOTE: do NOT name this ``rationale`` — the strategy-rationale
+            # string is bound by the caller's ideation result and is also
+            # what gets persisted to ``StrategyLabRecord.strategy_rationale``.
+            align_rationale = (last_report.rationale or "").strip()
+            suffix = (
+                f"alignment_failed: {align_rationale}"
+                if align_rationale
+                else "alignment_failed: trades did not implement strategy spec"
+            )
+            metrics, upstream_admitted = _apply_veto_to_acceptance_reason(
+                metrics, suffix, upstream_admitted=upstream_admitted
+            )
+
+        return _VerificationOutcome(
+            metrics=metrics,
+            is_winning=is_winning,
+            upstream_admitted=upstream_admitted,
+            acceptance_results=acceptance_results,
+            walk_forward_failed=walk_forward_failed,
+            exit_rule_conformance_passed=exit_rule_conformance_passed,
+        )
+
     def _run_design_attempt(
         self,
         *,
@@ -1330,251 +1583,27 @@ class StrategyLabOrchestrator:
         # round (which has no recorded "attempt") still counts.
         self.convergence_tracker.increment_trials(max(1, len(refinement_attempts) + 1))
 
-        # ── Phase 2.7: WALK-FORWARD + ACCEPTANCE GATE (issue #247) ────
-        # Replaces the legacy ``WINNING_THRESHOLD`` annualized-return scalar
-        # with a composite OOS gate evaluated on purged, embargoed K-fold
-        # walk-forward diagnostics. Skipped when walk-forward is disabled
-        # (legacy fallback) or there is no successful execution to evaluate.
-        acceptance_results: List[QualityGateResult] = []
-        acceptance_reason: Optional[str] = None
-        walk_forward_failed = False
-        if (
-            execution_succeeded
-            and trades
-            and market_data is not None
-            and config.walk_forward_enabled
-        ):
-            try:
-                emit("backtesting", {"sub_phase": "walk_forward_started"})
-                metrics = self._evaluate_walk_forward(spec, market_data, config, trades, metrics)
-                acceptance_results = self.acceptance_gate.check(
-                    metrics,
-                    config,
-                    n_trials=self.convergence_tracker.trial_count,
-                )
-                all_gate_results.extend(acceptance_results)
-                acceptance_reason = summarize_acceptance_reason(acceptance_results)
-                metrics = metrics.model_copy(
-                    update={
-                        "n_trials_when_accepted": self.convergence_tracker.trial_count,
-                        "acceptance_reason": acceptance_reason,
-                    }
-                )
-                emit(
-                    "backtesting",
-                    {
-                        "sub_phase": "walk_forward_completed",
-                        "deflated_sharpe": metrics.deflated_sharpe,
-                        "oos_sharpe": metrics.oos_sharpe,
-                        "is_oos_degradation_pct": metrics.is_oos_degradation_pct,
-                        "oos_trade_count": metrics.oos_trade_count,
-                        "n_trials": self.convergence_tracker.trial_count,
-                        "acceptance_reason": acceptance_reason,
-                    },
-                )
-            except Exception:
-                logger.exception(
-                    "Walk-forward evaluation failed for %s; falling back to "
-                    "legacy single-window acceptance",
-                    spec.strategy_id,
-                )
-                acceptance_results = []
-                acceptance_reason = None
-                walk_forward_failed = True
-
-        # ── Exit-rule conformance ─────────────────────────────────────
-        # Issue #527 — deterministic check that the engine actually
-        # enforced ``spec.exit_rules`` against the FINAL trade ledger
-        # (post-alignment-loop). Critical failure vetoes ``is_winning``
-        # below; results are appended to ``all_gate_results`` for the
-        # persisted record.
-        exit_rule_conformance_passed = True
-        if execution_succeeded and trades:
-            conformance_gate = ExitRuleConformanceGate()
-            conformance_results = conformance_gate.check(
-                exit_rules=spec.exit_rules,
-                trades=trades,
-                diagnostics=metrics.execution_diagnostics,
-                config=config,
-                timeframe=spec.timeframe,
-            )
-            all_gate_results.extend(conformance_results)
-            exit_rule_conformance_passed = not any(
-                (not r.passed) and r.severity == "critical" for r in conformance_results
-            )
-
-        # ── Resolve is_winning ────────────────────────────────────────
-        # Publication requires (a) the walk-forward acceptance gate (or
-        # its overfit-recheck fallback) AND (b) trade-alignment
-        # convergence (``trades_aligned``, #529). A strategy whose final
-        # ``TradeAlignmentReport.aligned`` is False — because the loop hit
-        # ``MAX_ALIGNMENT_ROUNDS`` or broke early with no proposed fix —
-        # cannot be marked winning regardless of metrics, since the
-        # executed trades do not implement the strategy spec.
-        #
-        # Walk-forward fallback: anomaly checks during refinement ran with
-        # ``dsr_aware=True``, which downgraded the ``Sharpe > 5.0`` flag
-        # from critical to warning on the assumption that the OOS DSR
-        # would adjudicate. With AcceptanceGate unavailable, re-run the
-        # anomaly checks with ``dsr_aware=False`` and reject if any
-        # critical fires — otherwise an obvious overfit could still be
-        # marked winning on annualized return alone.
-        #
-        # The legacy ``walk_forward_enabled=False`` single-window
-        # ``WINNING_THRESHOLD`` branch was removed (#529): a bare
-        # annualized-return scalar with no DSR correction is not a
-        # publication gate. Runs configured without walk-forward still
-        # execute and generate a narrative, but cannot be marked winning.
-        # ``upstream_admitted`` records whether the upstream publication
-        # gate (walk-forward acceptance, or its anomaly-recheck fallback)
-        # said "admit". It feeds the alignment-augmentation block below:
-        # a success-style ``acceptance_reason`` becomes stale the moment
-        # alignment vetoes a run, so we REPLACE it; a failure-style
-        # reason captures a real co-cause and is PRESERVED with the
-        # alignment cause appended.
-        upstream_admitted = False
-        if acceptance_results:
-            acceptance_passed = all(r.passed for r in acceptance_results)
-            is_winning = (
-                execution_succeeded
-                and acceptance_passed
-                and trades_aligned
-                and exit_rule_conformance_passed
-            )
-            upstream_admitted = acceptance_passed
-        elif walk_forward_failed and execution_succeeded:
-            # Walk-forward fallback: anomaly recheck occurs after refinement
-            # in the verification phase.
-            fallback_anomalies = self.anomaly_detector.check(
-                metrics,
-                trades,
-                dsr_aware=False,
-                coverage_report=metrics.coverage_report,
-                phase="verification",
-            )
-            fallback_criticals = [
-                g for g in fallback_anomalies if not g.passed and g.severity == "critical"
-            ]
-            return_ok = metrics.annualized_return_pct > WINNING_THRESHOLD
-            is_winning = (
-                return_ok
-                and not fallback_criticals
-                and trades_aligned
-                and exit_rule_conformance_passed
-            )
-            upstream_admitted = return_ok and not fallback_criticals
-            if fallback_criticals:
-                # Surface the upgraded severities so the persisted
-                # gate-result history reflects the true rejection reason.
-                self.record_gates(
-                    fallback_anomalies, all_gate_results, gate_name_prefix="fallback_"
-                )
-            # Gap 7 / 9: mirror the fallback gate's own verdict onto
-            # ``acceptance_reason`` so consumers don't have to grep
-            # ``quality_gate_results`` for ``fallback_`` prefixes to see
-            # why publication was admitted or rejected. The augmentation
-            # block below uses ``upstream_admitted`` to decide whether
-            # to replace this message (alignment vetoes a "passed"
-            # verdict) or to append (both gates fired their own reasons).
-            if upstream_admitted:
-                metrics = metrics.model_copy(
-                    update={
-                        "acceptance_reason": "walk_forward_fallback_passed: anomaly recheck clean"
-                    }
-                )
-            else:
-                fallback_reasons: List[str] = []
-                if fallback_criticals:
-                    fallback_reasons.append("; ".join(g.details for g in fallback_criticals))
-                if not return_ok:
-                    fallback_reasons.append(
-                        f"annualized_return {metrics.annualized_return_pct:.2f}% <= "
-                        f"{WINNING_THRESHOLD:g}% threshold"
-                    )
-                metrics = metrics.model_copy(
-                    update={
-                        "acceptance_reason": (
-                            "walk_forward_fallback_rejected: " + "; ".join(fallback_reasons)
-                        )
-                    }
-                )
-        else:
-            is_winning = False
-            # Gap 4 / 8: self-document why publication was blocked on
-            # each else-branch entry path. Without this, the persisted
-            # record shows ``is_winning=False`` with an empty
-            # ``acceptance_reason``. The no-trades case is checked first
-            # because it's the more proximate cause when both conditions
-            # hold (a run with no trades cannot publish regardless of
-            # ``walk_forward_enabled``). Execution-failure paths are
-            # handled by the elif-narrative branch in Phase 3 instead.
-            if execution_succeeded and not trades:
-                metrics = metrics.model_copy(
-                    update={"acceptance_reason": "publication_disabled: no trades produced"}
-                )
-            elif execution_succeeded and trades and not config.walk_forward_enabled:
-                metrics = metrics.model_copy(
-                    update={"acceptance_reason": "publication_disabled: walk_forward_enabled=False"}
-                )
-
-        # ── Publication vetoes ────────────────────────────────────────
-        # Surface each veto's cause on ``acceptance_reason`` so the
-        # audit trail explains why publication was blocked even when
-        # the upstream acceptance gate otherwise passed. Vetoes stack:
-        # the first to fire is treated as the upstream rejection by the
-        # second, so a multi-gate failure preserves both causes.
-        #
-        # Helper :func:`_apply_veto_to_acceptance_reason` codifies the
-        # "replace stale success, append real rejection" rule so adding
-        # a future veto is one new call here rather than another copy
-        # of the mutation shape.
-        #
-        # Each veto's ``execution_succeeded and trades`` precondition
-        # ensures the alignment / conformance verdicts are meaningful —
-        # both gates need a non-empty trade ledger to evaluate.
-        # ``alignment_reports`` is in the alignment guard so we only
-        # attribute the rejection to alignment when the audit actually
-        # ran (skipped when ``market_data is None``).
-
-        # Issue #527 — conformance veto.
-        if execution_succeeded and trades and not exit_rule_conformance_passed:
-            conformance_criticals = [
-                r
-                for r in all_gate_results
-                if r.gate_name == "exit_rule_conformance"
-                and not r.passed
-                and r.severity == "critical"
-            ]
-            detail = "; ".join(r.details for r in conformance_criticals)
-            suffix = (
-                f"exit_rule_conformance_failed: {detail}"
-                if detail
-                else "exit_rule_conformance_failed: engine enforcement leaked"
-            )
-            metrics, upstream_admitted = _apply_veto_to_acceptance_reason(
-                metrics, suffix, upstream_admitted=upstream_admitted
-            )
-
-        # Issue #529 — alignment veto.
-        if execution_succeeded and trades and alignment_reports and not trades_aligned:
-            last_report = alignment_reports[-1]
-            # NOTE: do NOT name this ``rationale`` — that shadows the
-            # strategy-rationale string bound earlier from the ideation
-            # agent (and used positionally when calling
-            # ``self.analysis_agent.run`` plus persisted on
-            # ``StrategyLabRecord.strategy_rationale``). Shadowing would
-            # silently corrupt both the analysis prompt and the audit
-            # record on every alignment-failure path.
-            align_rationale = (last_report.rationale or "").strip()
-            suffix = (
-                f"alignment_failed: {align_rationale}"
-                if align_rationale
-                else "alignment_failed: trades did not implement strategy spec"
-            )
-            metrics, upstream_admitted = _apply_veto_to_acceptance_reason(
-                metrics, suffix, upstream_admitted=upstream_admitted
-            )
-
+        # ── Phase 2.7: WALK-FORWARD + ACCEPTANCE + CONFORMANCE + is_winning ────
+        verification = self._run_verification_phase(
+            spec=spec,
+            trades=trades,
+            metrics=metrics,
+            market_data=market_data,
+            config=config,
+            execution_succeeded=execution_succeeded,
+            trades_aligned=trades_aligned,
+            alignment_reports=alignment_reports,
+            all_gate_results=all_gate_results,
+            emit=emit,
+        )
+        metrics = verification.metrics
+        is_winning = verification.is_winning
+        # The other ``_VerificationOutcome`` fields (acceptance_results,
+        # walk_forward_failed, upstream_admitted, exit_rule_conformance_passed)
+        # are unused beyond this point — the verification phase already
+        # extended ``all_gate_results`` and mutated ``metrics.acceptance_reason``
+        # to carry every downstream-visible signal. The fields stay on the
+        # dataclass for callers that want to inspect the outcome directly.
         # ── Phase 3: ANALYSIS ─────────────────────────────────────────
         narrative = ""
         if execution_succeeded and trades:

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -289,7 +289,7 @@ class StrategyLabOrchestrator:
             )
         return float("nan")
 
-    def _record_gates(
+    def record_gates(
         self,
         results: List[QualityGateResult],
         all_gate_results: Optional[List[QualityGateResult]] = None,
@@ -321,7 +321,7 @@ class StrategyLabOrchestrator:
             all_gate_results.extend(results)
         return results
 
-    def _orchestrator_gate(
+    def build_orchestrator_gate(
         self,
         name: str,
         *,
@@ -559,7 +559,7 @@ class StrategyLabOrchestrator:
             spec, phase="design", backtest_config=config
         )
         pre_spec_gates.extend(readiness_design)
-        self._record_gates(pre_spec_gates, all_gate_results, refinement_round=-1)
+        self.record_gates(pre_spec_gates, all_gate_results, refinement_round=-1)
         pre_synthesis_criticals = [
             g for g in pre_spec_gates if not g.passed and g.severity == "critical"
         ]
@@ -619,7 +619,7 @@ class StrategyLabOrchestrator:
                 )
             code_gates = self.code_safety_checker.check(code, spec)
             round_gate_results.extend(code_gates)
-            self._record_gates(round_gate_results, all_gate_results, refinement_round=round_num)
+            self.record_gates(round_gate_results, all_gate_results, refinement_round=round_num)
 
             checks_total = len(round_gate_results)
             checks_passed = sum(1 for g in round_gate_results if g.passed)
@@ -693,7 +693,7 @@ class StrategyLabOrchestrator:
                 market_data = fetch.data
                 if not market_data:
                     all_gate_results.append(
-                        self._orchestrator_gate(
+                        self.build_orchestrator_gate(
                             "market_data",
                             phase="synthesis",
                             details=f"No market data available for asset class '{spec.asset_class}'.",
@@ -718,7 +718,7 @@ class StrategyLabOrchestrator:
                 fetch_coverage_gates = self.target_symbol_coverage_gate.check_fetch(
                     spec, requested_symbols, fetched_symbols
                 )
-                self._record_gates(
+                self.record_gates(
                     fetch_coverage_gates, all_gate_results, refinement_round=round_num
                 )
                 if any(not g.passed and g.severity == "critical" for g in fetch_coverage_gates):
@@ -730,7 +730,7 @@ class StrategyLabOrchestrator:
 
             if not exec_result.success:
                 all_gate_results.append(
-                    self._orchestrator_gate(
+                    self.build_orchestrator_gate(
                         "code_execution",
                         phase="synthesis",
                         details=f"Execution failed ({exec_result.error_type}): {exec_result.stderr[:500]}",
@@ -785,7 +785,7 @@ class StrategyLabOrchestrator:
             # False at the acceptance gate (same precedent as the
             # max-refinement-rounds anomaly branch below).
             trade_coverage_gates = self.target_symbol_coverage_gate.check_trades(spec, trades)
-            self._record_gates(
+            self.record_gates(
                 trade_coverage_gates, all_gate_results, refinement_round=round_num
             )
             if any(not g.passed and g.severity == "critical" for g in trade_coverage_gates):
@@ -826,7 +826,7 @@ class StrategyLabOrchestrator:
                 diagnostics=exec_result.execution_diagnostics,
                 coverage_report=metrics.coverage_report,
             )
-            self._record_gates(anomaly_gates, all_gate_results, refinement_round=round_num)
+            self.record_gates(anomaly_gates, all_gate_results, refinement_round=round_num)
 
             critical_anomalies = [
                 g for g in anomaly_gates if not g.passed and g.severity == "critical"
@@ -994,7 +994,7 @@ class StrategyLabOrchestrator:
                     )
                 )
                 all_gate_results.append(
-                    self._orchestrator_gate(
+                    self.build_orchestrator_gate(
                         "trade_alignment",
                         phase="verification",
                         severity=gate_severity,  # type: ignore[arg-type]
@@ -1082,7 +1082,7 @@ class StrategyLabOrchestrator:
                 safety_gates = self.code_safety_checker.check(
                     proposed_code, proposed_spec, phase="verification"
                 )
-                self._record_gates(
+                self.record_gates(
                     safety_gates,
                     all_gate_results,
                     refinement_round=align_round,
@@ -1117,7 +1117,7 @@ class StrategyLabOrchestrator:
                 align_exec = run_strategy_code(proposed_code, market_data, config, strategy=spec)
                 if not align_exec.success:
                     all_gate_results.append(
-                        self._orchestrator_gate(
+                        self.build_orchestrator_gate(
                             "alignment_code_execution",
                             phase="verification",
                             details=(
@@ -1172,7 +1172,7 @@ class StrategyLabOrchestrator:
                     coverage_report=new_metrics.coverage_report,
                     phase="verification",
                 )
-                self._record_gates(
+                self.record_gates(
                     anomaly_gates,
                     all_gate_results,
                     refinement_round=align_round,
@@ -1370,7 +1370,7 @@ class StrategyLabOrchestrator:
             if fallback_criticals:
                 # Surface the upgraded severities so the persisted
                 # gate-result history reflects the true rejection reason.
-                self._record_gates(
+                self.record_gates(
                     fallback_anomalies, all_gate_results, gate_name_prefix="fallback_"
                 )
             # Gap 7 / 9: mirror the fallback gate's own verdict onto

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -1056,7 +1056,10 @@ class StrategyLabOrchestrator:
                 change_summary = report.changes_made or "alignment fix"
 
                 # ── Re-validate code safety on the proposed code ──────
-                safety_gates = self.code_safety_checker.check(proposed_code, proposed_spec)
+                # Alignment runs after backtest — phase tag is verification.
+                safety_gates = self.code_safety_checker.check(
+                    proposed_code, proposed_spec, phase="verification"
+                )
                 for g in safety_gates:
                     g.refinement_round = align_round
                     g.gate_name = f"alignment_{g.gate_name}"
@@ -1145,6 +1148,7 @@ class StrategyLabOrchestrator:
                     dsr_aware=config.walk_forward_enabled,
                     diagnostics=align_exec.execution_diagnostics,
                     coverage_report=new_metrics.coverage_report,
+                    phase="verification",
                 )
                 for g in anomaly_gates:
                     g.refinement_round = align_round
@@ -1319,11 +1323,14 @@ class StrategyLabOrchestrator:
             )
             upstream_admitted = acceptance_passed
         elif walk_forward_failed and execution_succeeded:
+            # Walk-forward fallback: anomaly recheck occurs after refinement
+            # in the verification phase.
             fallback_anomalies = self.anomaly_detector.check(
                 metrics,
                 trades,
                 dsr_aware=False,
                 coverage_report=metrics.coverage_report,
+                phase="verification",
             )
             fallback_criticals = [
                 g for g in fallback_anomalies if not g.passed and g.severity == "critical"
@@ -1835,7 +1842,11 @@ class StrategyLabOrchestrator:
         # ``quality_gate_results`` rather than being silently dropped.
         post_repair_spec_gates: List[QualityGateResult] = []
         if report.proposed_spec_updates:
-            post_repair_spec_gates = self.strategy_validator.validate(proposed_spec)
+            # Zero-trade repair runs inside the synthesis refinement loop —
+            # re-validate the patched spec under that phase rather than design.
+            post_repair_spec_gates = self.strategy_validator.validate(
+                proposed_spec, phase="synthesis"
+            )
             for g in post_repair_spec_gates:
                 g.refinement_round = round_num
                 g.gate_name = f"zero_trade_repair_{g.gate_name}"

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -18,7 +18,7 @@ import os
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+from typing import Any, Callable, Dict, List, Literal, Optional, Sequence, Tuple
 
 from pydantic import ValidationError
 
@@ -64,7 +64,7 @@ from .quality_gates.backtest_anomaly import BacktestAnomalyDetector
 from .quality_gates.code_safety import CodeSafetyChecker
 from .quality_gates.convergence_tracker import ConvergenceTracker
 from .quality_gates.exit_rule_conformance import ExitRuleConformanceGate
-from .quality_gates.models import QualityGateResult
+from .quality_gates.models import QualityGateResult, StrategyLabPhase
 from .quality_gates.spec_readiness import SpecReadinessGate
 from .quality_gates.strategy_validator import StrategySpecValidator
 from .quality_gates.target_symbol_coverage import TargetSymbolCoverageGate
@@ -315,6 +315,65 @@ class StrategyLabOrchestrator:
             )
         return 100.0
 
+    def _record_gates(
+        self,
+        results: List[QualityGateResult],
+        all_gate_results: Optional[List[QualityGateResult]] = None,
+        *,
+        refinement_round: Optional[int] = None,
+        gate_name_prefix: str = "",
+    ) -> List[QualityGateResult]:
+        """Stamp metadata on each result; optionally extend a running list.
+
+        Pre: ``results`` is a list of ``QualityGateResult``;
+        ``all_gate_results`` is either ``None`` (stamp only) or another list
+        to extend with ``results``; ``refinement_round`` is an int (``-1`` for
+        pre-synthesis sites) or ``None`` to leave the existing value.
+        Post: every entry in ``results`` carries the supplied
+        ``refinement_round`` (when not ``None``); if ``gate_name_prefix`` is
+        non-empty the prefix is applied to ``gate_name``. When
+        ``all_gate_results`` is provided it is extended in place. ``results``
+        is returned to allow chaining.
+        """
+        assert isinstance(results, list) and all(
+            isinstance(g, QualityGateResult) for g in results
+        ), "results must be a list of QualityGateResult"
+        for g in results:
+            if refinement_round is not None:
+                g.refinement_round = refinement_round
+            if gate_name_prefix:
+                g.gate_name = f"{gate_name_prefix}{g.gate_name}"
+        if all_gate_results is not None:
+            all_gate_results.extend(results)
+        return results
+
+    def _orchestrator_gate(
+        self,
+        name: str,
+        *,
+        phase: StrategyLabPhase,
+        severity: Literal["info", "warning", "critical"] = "critical",
+        details: str,
+        refinement_round: int = 0,
+    ) -> QualityGateResult:
+        """Bespoke result for failures the orchestrator detects directly.
+
+        Pre: ``name`` is a non-empty string; ``phase`` is one of the four
+        valid labels; ``details`` is a non-empty string.
+        Post: returns a ``QualityGateResult`` whose ``passed`` flag is
+        derived from ``severity`` (info → True, warning/critical → False).
+        """
+        assert name, "gate name must be non-empty"
+        assert details, "details must be non-empty"
+        return QualityGateResult(
+            gate_name=name,
+            phase=phase,
+            passed=severity == "info",
+            severity=severity,
+            details=details,
+            refinement_round=refinement_round,
+        )
+
     def run_cycle(
         self,
         prior_records: List[StrategyLabRecord],
@@ -526,9 +585,7 @@ class StrategyLabOrchestrator:
             spec, phase="design", backtest_config=config
         )
         pre_spec_gates.extend(readiness_design)
-        for g in pre_spec_gates:
-            g.refinement_round = -1
-        all_gate_results.extend(pre_spec_gates)
+        self._record_gates(pre_spec_gates, all_gate_results, refinement_round=-1)
         pre_synthesis_criticals = [
             g for g in pre_spec_gates if not g.passed and g.severity == "critical"
         ]
@@ -588,9 +645,7 @@ class StrategyLabOrchestrator:
                 )
             code_gates = self.code_safety_checker.check(code, spec)
             round_gate_results.extend(code_gates)
-            for g in round_gate_results:
-                g.refinement_round = round_num
-            all_gate_results.extend(round_gate_results)
+            self._record_gates(round_gate_results, all_gate_results, refinement_round=round_num)
 
             checks_total = len(round_gate_results)
             checks_passed = sum(1 for g in round_gate_results if g.passed)
@@ -664,10 +719,8 @@ class StrategyLabOrchestrator:
                 market_data = fetch.data
                 if not market_data:
                     all_gate_results.append(
-                        QualityGateResult(
-                            gate_name="market_data",
-                            passed=False,
-                            severity="critical",
+                        self._orchestrator_gate(
+                            "market_data",
                             phase="synthesis",
                             details=f"No market data available for asset class '{spec.asset_class}'.",
                             refinement_round=round_num,
@@ -691,9 +744,9 @@ class StrategyLabOrchestrator:
                 fetch_coverage_gates = self.target_symbol_coverage_gate.check_fetch(
                     spec, requested_symbols, fetched_symbols
                 )
-                for g in fetch_coverage_gates:
-                    g.refinement_round = round_num
-                all_gate_results.extend(fetch_coverage_gates)
+                self._record_gates(
+                    fetch_coverage_gates, all_gate_results, refinement_round=round_num
+                )
                 if any(not g.passed and g.severity == "critical" for g in fetch_coverage_gates):
                     break
 
@@ -703,10 +756,8 @@ class StrategyLabOrchestrator:
 
             if not exec_result.success:
                 all_gate_results.append(
-                    QualityGateResult(
-                        gate_name="code_execution",
-                        passed=False,
-                        severity="critical",
+                    self._orchestrator_gate(
+                        "code_execution",
                         phase="synthesis",
                         details=f"Execution failed ({exec_result.error_type}): {exec_result.stderr[:500]}",
                         refinement_round=round_num,
@@ -760,9 +811,9 @@ class StrategyLabOrchestrator:
             # False at the acceptance gate (same precedent as the
             # max-refinement-rounds anomaly branch below).
             trade_coverage_gates = self.target_symbol_coverage_gate.check_trades(spec, trades)
-            for g in trade_coverage_gates:
-                g.refinement_round = round_num
-            all_gate_results.extend(trade_coverage_gates)
+            self._record_gates(
+                trade_coverage_gates, all_gate_results, refinement_round=round_num
+            )
             if any(not g.passed and g.severity == "critical" for g in trade_coverage_gates):
                 max_rounds_exhausted = True
                 break
@@ -801,9 +852,7 @@ class StrategyLabOrchestrator:
                 diagnostics=exec_result.execution_diagnostics,
                 coverage_report=metrics.coverage_report,
             )
-            for g in anomaly_gates:
-                g.refinement_round = round_num
-            all_gate_results.extend(anomaly_gates)
+            self._record_gates(anomaly_gates, all_gate_results, refinement_round=round_num)
 
             critical_anomalies = [
                 g for g in anomaly_gates if not g.passed and g.severity == "critical"
@@ -971,11 +1020,10 @@ class StrategyLabOrchestrator:
                     )
                 )
                 all_gate_results.append(
-                    QualityGateResult(
-                        gate_name="trade_alignment",
-                        passed=report.aligned,
-                        severity=gate_severity,  # type: ignore[arg-type]
+                    self._orchestrator_gate(
+                        "trade_alignment",
                         phase="verification",
+                        severity=gate_severity,  # type: ignore[arg-type]
                         details=gate_details,
                         refinement_round=align_round,
                     )
@@ -1060,10 +1108,12 @@ class StrategyLabOrchestrator:
                 safety_gates = self.code_safety_checker.check(
                     proposed_code, proposed_spec, phase="verification"
                 )
-                for g in safety_gates:
-                    g.refinement_round = align_round
-                    g.gate_name = f"alignment_{g.gate_name}"
-                all_gate_results.extend(safety_gates)
+                self._record_gates(
+                    safety_gates,
+                    all_gate_results,
+                    refinement_round=align_round,
+                    gate_name_prefix="alignment_",
+                )
                 critical_safety = [
                     g for g in safety_gates if not g.passed and g.severity == "critical"
                 ]
@@ -1093,10 +1143,8 @@ class StrategyLabOrchestrator:
                 align_exec = run_strategy_code(proposed_code, market_data, config, strategy=spec)
                 if not align_exec.success:
                     all_gate_results.append(
-                        QualityGateResult(
-                            gate_name="alignment_code_execution",
-                            passed=False,
-                            severity="critical",
+                        self._orchestrator_gate(
+                            "alignment_code_execution",
                             phase="verification",
                             details=(
                                 f"Re-execution after alignment fix failed "
@@ -1150,10 +1198,12 @@ class StrategyLabOrchestrator:
                     coverage_report=new_metrics.coverage_report,
                     phase="verification",
                 )
-                for g in anomaly_gates:
-                    g.refinement_round = align_round
-                    g.gate_name = f"alignment_{g.gate_name}"
-                all_gate_results.extend(anomaly_gates)
+                self._record_gates(
+                    anomaly_gates,
+                    all_gate_results,
+                    refinement_round=align_round,
+                    gate_name_prefix="alignment_",
+                )
                 critical_anomalies = [
                     g for g in anomaly_gates if not g.passed and g.severity == "critical"
                 ]
@@ -1346,9 +1396,9 @@ class StrategyLabOrchestrator:
             if fallback_criticals:
                 # Surface the upgraded severities so the persisted
                 # gate-result history reflects the true rejection reason.
-                for g in fallback_anomalies:
-                    g.gate_name = f"fallback_{g.gate_name}"
-                all_gate_results.extend(fallback_anomalies)
+                self._record_gates(
+                    fallback_anomalies, all_gate_results, gate_name_prefix="fallback_"
+                )
             # Gap 7 / 9: mirror the fallback gate's own verdict onto
             # ``acceptance_reason`` so consumers don't have to grep
             # ``quality_gate_results`` for ``fallback_`` prefixes to see
@@ -1729,10 +1779,14 @@ class StrategyLabOrchestrator:
             return _ZeroTradeRepairOutcome(committed=False, failure_reason="no_proposed_code")
 
         # ── Code-safety gate on the proposed code ────────────────────
-        safety_gates = self.code_safety_checker.check(report.proposed_code, spec)
-        for g in safety_gates:
-            g.refinement_round = round_num
-            g.gate_name = f"zero_trade_repair_{g.gate_name}"
+        # Stamp-only: this method's caller persists ``safety_gates`` via the
+        # outcome's ``new_gates=`` so the orchestrator's running list is not
+        # extended here.
+        safety_gates = self._record_gates(
+            self.code_safety_checker.check(report.proposed_code, spec),
+            refinement_round=round_num,
+            gate_name_prefix="zero_trade_repair_",
+        )
         critical_safety = [g for g in safety_gates if not g.passed and g.severity == "critical"]
         if critical_safety:
             zero_trade_attempts.append(
@@ -1785,11 +1839,10 @@ class StrategyLabOrchestrator:
             # it forward (the ValidationError path below would otherwise
             # drop the audit trail even though the warning was logged).
             dropped_keys_gates = [
-                QualityGateResult(
-                    gate_name="zero_trade_repair_dropped_spec_keys",
-                    passed=False,
-                    severity="warning",
+                self._orchestrator_gate(
+                    "zero_trade_repair_dropped_spec_keys",
                     phase="synthesis",
+                    severity="warning",
                     details=(
                         "Zero-trade repair proposed off-list spec keys "
                         f"{dropped_spec_keys}; dropped per #530 "
@@ -1844,12 +1897,12 @@ class StrategyLabOrchestrator:
         if report.proposed_spec_updates:
             # Zero-trade repair runs inside the synthesis refinement loop —
             # re-validate the patched spec under that phase rather than design.
-            post_repair_spec_gates = self.strategy_validator.validate(
-                proposed_spec, phase="synthesis"
+            # Stamp-only; the caller persists via the outcome's ``new_gates=``.
+            post_repair_spec_gates = self._record_gates(
+                self.strategy_validator.validate(proposed_spec, phase="synthesis"),
+                refinement_round=round_num,
+                gate_name_prefix="zero_trade_repair_",
             )
-            for g in post_repair_spec_gates:
-                g.refinement_round = round_num
-                g.gate_name = f"zero_trade_repair_{g.gate_name}"
         # #530: extend with the pre-built dropped-keys gate so the
         # persisted ``quality_gate_results`` records the attempted spec
         # mutation even when no whitelisted key was present (same gate
@@ -1882,10 +1935,8 @@ class StrategyLabOrchestrator:
             report.proposed_code, market_data, config, strategy=proposed_spec
         )
         if not repair_exec.success:
-            failure_gate = QualityGateResult(
-                gate_name="zero_trade_repair_code_execution",
-                passed=False,
-                severity="critical",
+            failure_gate = self._orchestrator_gate(
+                "zero_trade_repair_code_execution",
                 phase="synthesis",
                 details=(
                     f"Re-execution after zero-trade repair failed "
@@ -1927,16 +1978,18 @@ class StrategyLabOrchestrator:
         )
 
         # ── Anomaly recheck ──────────────────────────────────────────
-        new_anomaly_gates = self.anomaly_detector.check(
-            new_metrics,
-            new_trades,
-            dsr_aware=config.walk_forward_enabled,
-            diagnostics=repair_exec.execution_diagnostics,
-            coverage_report=new_metrics.coverage_report,
+        # Stamp-only; ``new_gates`` is persisted by the caller via the outcome.
+        new_anomaly_gates = self._record_gates(
+            self.anomaly_detector.check(
+                new_metrics,
+                new_trades,
+                dsr_aware=config.walk_forward_enabled,
+                diagnostics=repair_exec.execution_diagnostics,
+                coverage_report=new_metrics.coverage_report,
+            ),
+            refinement_round=round_num,
+            gate_name_prefix="zero_trade_repair_",
         )
-        for g in new_anomaly_gates:
-            g.refinement_round = round_num
-            g.gate_name = f"zero_trade_repair_{g.gate_name}"
 
         new_critical = [g for g in new_anomaly_gates if not g.passed and g.severity == "critical"]
         if new_critical:

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -488,9 +488,10 @@ class StrategyLabOrchestrator:
             for g in pre_spec_gates_raw
             if not (g.severity == "critical" and g.details.startswith("strategy_code is missing"))
         ]
-        # Issue #540 — SpecReadinessGate runs in the design phase, blocking
-        # exit to synthesis on any critical failure. Hands its results to the
-        # same short-circuit path as StrategySpecValidator below.
+        # SpecReadinessGate (design phase). Postcondition: any critical
+        # result here flows into the same short-circuit path that
+        # StrategySpecValidator's criticals already do, so the synthesis
+        # phase cannot be entered with an unimplementable spec.
         readiness_design = self.spec_readiness_gate.validate(
             spec, phase="design", backtest_config=config
         )
@@ -542,11 +543,13 @@ class StrategyLabOrchestrator:
             #       pre-synthesis and is immutable for this cycle, see
             #       #547 items 1 & 2).
             emit("coding", {"sub_phase": "started", "refinement_round": round_num})
-            # Issue #540 — re-run SpecReadinessGate on the first synthesis
-            # round as a defense-in-depth sanity check that the spec wasn't
-            # mutated between design exit and synthesis entry. The spec is
-            # immutable across the remaining rounds so we don't repeat the
-            # check.
+            # Re-run SpecReadinessGate on the first synthesis round.
+            # Precondition: design-phase readiness passed. Postcondition:
+            # a critical failure here means the spec was mutated between
+            # design exit and synthesis entry — the same short-circuit
+            # path that fires for any other critical synthesis-phase gate
+            # picks it up. Skipped on round_num > 0 because the spec is
+            # immutable across the synthesis loop.
             if round_num == 0:
                 round_gate_results.extend(
                     self.spec_readiness_gate.validate(

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -272,18 +272,48 @@ class StrategyLabOrchestrator:
         self.zero_trade_repair_agent = ZeroTradeRepairAgent()
         self.analysis_agent = AnalysisAgent()
         self.strategy_validator = StrategySpecValidator()
-        self.spec_readiness_gate = SpecReadinessGate()
         self.code_safety_checker = CodeSafetyChecker()
         self.anomaly_detector = BacktestAnomalyDetector()
         self.acceptance_gate = AcceptanceGate()
         self.target_symbol_coverage_gate = TargetSymbolCoverageGate()
         self.convergence_tracker = convergence_tracker or ConvergenceTracker()
         self.market_data_service = MarketDataService()
+        # SpecReadinessGate is wired to the live MarketDataService so Rule 5
+        # sizes against real recent closes rather than a synthetic default.
+        self.spec_readiness_gate = SpecReadinessGate(
+            market_sample_provider=self._readiness_price_provider,
+        )
         # Per-failure_phase counter of consecutive refinement rounds where
         # the LLM emitted stray spec-mutating keys. Reset at the start of
         # each ``_run_design_attempt`` and tripped when any phase hits
         # ``_SPEC_MUTATION_TRIP_THRESHOLD``.
         self._consecutive_spec_mutation_rounds: Dict[str, int] = {}
+
+    def _readiness_price_provider(self, symbol: str, asset_class: str) -> float:
+        """Recent-close lookup wired into ``SpecReadinessGate.Rule 5``.
+
+        Pre: ``symbol`` and ``asset_class`` are non-empty strings.
+        Post: returns a strictly positive finite price. Falls back to
+        ``100.0`` only when the provider chain is exhausted, the symbol is
+        unknown, or any unexpected exception is raised — so the gate degrades
+        to its static default rather than crashing the cycle.
+        """
+        assert isinstance(symbol, str) and symbol, "symbol must be a non-empty str"
+        assert isinstance(asset_class, str) and asset_class, "asset_class must be a non-empty str"
+        try:
+            bars = self.market_data_service.fetch_ohlcv(symbol, asset_class, days=5)
+            if bars:
+                close = float(bars[-1].close)
+                if close > 0:
+                    return close
+        except Exception as exc:  # noqa: BLE001 — fail-soft to static default
+            logger.debug(
+                "readiness price provider fell back for %s/%s: %s",
+                symbol,
+                asset_class,
+                exc,
+            )
+        return 100.0
 
     def run_cycle(
         self,

--- a/backend/agents/investment_team/strategy_lab/quality_gates/__init__.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/__init__.py
@@ -4,7 +4,8 @@ from .acceptance_gate import AcceptanceGate, summarize_acceptance_reason
 from .backtest_anomaly import BacktestAnomalyDetector
 from .code_safety import CodeSafetyChecker
 from .convergence_tracker import ConvergenceTracker
-from .models import QualityGateResult
+from .models import QualityGateResult, StrategyLabPhase
+from .spec_readiness import SpecReadinessGate
 from .strategy_validator import StrategySpecValidator
 from .target_symbol_coverage import TargetSymbolCoverageGate
 
@@ -14,6 +15,8 @@ __all__ = [
     "CodeSafetyChecker",
     "ConvergenceTracker",
     "QualityGateResult",
+    "SpecReadinessGate",
+    "StrategyLabPhase",
     "StrategySpecValidator",
     "TargetSymbolCoverageGate",
     "summarize_acceptance_reason",

--- a/backend/agents/investment_team/strategy_lab/quality_gates/acceptance_gate.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/acceptance_gate.py
@@ -52,82 +52,73 @@ class AcceptanceGate(GateResultsMixin):
         DSR itself is already deflated upstream.
         """
         with self._using_phase(phase):
-            return self._evaluate(result, config, n_trials=n_trials)
+            missing: List[str] = []
+            if result.oos_sharpe is None:
+                missing.append("oos_sharpe")
+            if result.is_oos_degradation_pct is None:
+                missing.append("is_oos_degradation_pct")
+            if result.oos_trade_count is None:
+                missing.append("oos_trade_count")
+            if missing:
+                return [
+                    self._warning(
+                        "Acceptance gate cannot evaluate — walk-forward diagnostics "
+                        f"missing: {', '.join(missing)}."
+                    )
+                ]
 
-    def _evaluate(
-        self,
-        result: BacktestResult,
-        config: BacktestConfig,
-        *,
-        n_trials: Optional[int],
-    ) -> List[QualityGateResult]:
-        missing: List[str] = []
-        if result.oos_sharpe is None:
-            missing.append("oos_sharpe")
-        if result.is_oos_degradation_pct is None:
-            missing.append("is_oos_degradation_pct")
-        if result.oos_trade_count is None:
-            missing.append("oos_trade_count")
-        if missing:
-            return [
-                self._warning(
-                    "Acceptance gate cannot evaluate — walk-forward diagnostics "
-                    f"missing: {', '.join(missing)}."
+            results: List[QualityGateResult] = []
+
+            # 1. Deflated Sharpe threshold.
+            dsr = float(result.deflated_sharpe)
+            passed_dsr = dsr >= config.dsr_threshold
+            results.append(
+                (self._info if passed_dsr else self._critical)(
+                    f"OOS DSR {dsr:.3f} "
+                    f"{'meets' if passed_dsr else 'below'} threshold "
+                    f"{config.dsr_threshold:.3f}"
+                    + (f" (n_trials={n_trials})" if n_trials is not None else "")
                 )
-            ]
-
-        results: List[QualityGateResult] = []
-
-        # 1. Deflated Sharpe threshold.
-        dsr = float(result.deflated_sharpe)
-        passed_dsr = dsr >= config.dsr_threshold
-        results.append(
-            (self._info if passed_dsr else self._critical)(
-                f"OOS DSR {dsr:.3f} "
-                f"{'meets' if passed_dsr else 'below'} threshold "
-                f"{config.dsr_threshold:.3f}"
-                + (f" (n_trials={n_trials})" if n_trials is not None else "")
             )
-        )
 
-        # 2. IS → OOS degradation.
-        deg = float(result.is_oos_degradation_pct)
-        passed_deg = deg <= config.max_is_oos_degradation_pct
-        results.append(
-            (self._info if passed_deg else self._critical)(
-                f"IS→OOS Sharpe degradation {deg:.1f}% "
-                f"{'within' if passed_deg else 'exceeds'} "
-                f"{config.max_is_oos_degradation_pct:.1f}% ceiling"
+            # 2. IS → OOS degradation.
+            deg = float(result.is_oos_degradation_pct)
+            passed_deg = deg <= config.max_is_oos_degradation_pct
+            results.append(
+                (self._info if passed_deg else self._critical)(
+                    f"IS→OOS Sharpe degradation {deg:.1f}% "
+                    f"{'within' if passed_deg else 'exceeds'} "
+                    f"{config.max_is_oos_degradation_pct:.1f}% ceiling"
+                )
             )
-        )
 
-        # 3. OOS trade count.
-        n_oos = int(result.oos_trade_count)
-        passed_count = n_oos >= config.min_oos_trades
-        results.append(
-            (self._info if passed_count else self._critical)(
-                f"OOS trade count {n_oos} "
-                f"{'meets' if passed_count else 'below'} minimum "
-                f"{config.min_oos_trades}"
+            # 3. OOS trade count.
+            n_oos = int(result.oos_trade_count)
+            passed_count = n_oos >= config.min_oos_trades
+            results.append(
+                (self._info if passed_count else self._critical)(
+                    f"OOS trade count {n_oos} "
+                    f"{'meets' if passed_count else 'below'} minimum "
+                    f"{config.min_oos_trades}"
+                )
             )
-        )
 
-        # 4. Regime-conditional pass.
-        regime_results = result.regime_results or []
-        beats = sum(1 for r in regime_results if r.get("beat_benchmark"))
-        total = len(regime_results)
-        passed_regime = beats >= self._min_regime_beats
-        regime_detail = (
-            f"Beat benchmark in {beats} of {total} regime subwindows "
-            f"(threshold: {self._min_regime_beats})"
-            if total
-            else "No regime subwindows evaluated"
-        )
-        results.append(
-            (self._info if passed_regime else self._critical)(regime_detail)
-        )
+            # 4. Regime-conditional pass.
+            regime_results = result.regime_results or []
+            beats = sum(1 for r in regime_results if r.get("beat_benchmark"))
+            total = len(regime_results)
+            passed_regime = beats >= self._min_regime_beats
+            regime_detail = (
+                f"Beat benchmark in {beats} of {total} regime subwindows "
+                f"(threshold: {self._min_regime_beats})"
+                if total
+                else "No regime subwindows evaluated"
+            )
+            results.append(
+                (self._info if passed_regime else self._critical)(regime_detail)
+            )
 
-        return results
+            return results
 
 
 def summarize_acceptance_reason(results: List[QualityGateResult]) -> str:

--- a/backend/agents/investment_team/strategy_lab/quality_gates/acceptance_gate.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/acceptance_gate.py
@@ -59,6 +59,7 @@ class AcceptanceGate:
             return [
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="verification",
                     passed=False,
                     severity="warning",
                     details=(
@@ -76,6 +77,7 @@ class AcceptanceGate:
         results.append(
             QualityGateResult(
                 gate_name=GATE,
+                phase="verification",
                 passed=passed_dsr,
                 severity="info" if passed_dsr else "critical",
                 details=(
@@ -93,6 +95,7 @@ class AcceptanceGate:
         results.append(
             QualityGateResult(
                 gate_name=GATE,
+                phase="verification",
                 passed=passed_deg,
                 severity="info" if passed_deg else "critical",
                 details=(
@@ -109,6 +112,7 @@ class AcceptanceGate:
         results.append(
             QualityGateResult(
                 gate_name=GATE,
+                phase="verification",
                 passed=passed_count,
                 severity="info" if passed_count else "critical",
                 details=(
@@ -133,6 +137,7 @@ class AcceptanceGate:
         results.append(
             QualityGateResult(
                 gate_name=GATE,
+                phase="verification",
                 passed=passed_regime,
                 severity="info" if passed_regime else "critical",
                 details=regime_detail,

--- a/backend/agents/investment_team/strategy_lab/quality_gates/acceptance_gate.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/acceptance_gate.py
@@ -17,18 +17,20 @@ incomplete evaluation rather than silently passing.
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 
 from ...models import BacktestConfig, BacktestResult
-from .models import QualityGateResult
+from .models import GateResultsMixin, QualityGateResult, StrategyLabPhase
 
 GATE = "acceptance_gate"
 
 DEFAULT_MIN_REGIME_BEATS = 2
 
 
-class AcceptanceGate:
+class AcceptanceGate(GateResultsMixin):
     """Composite OOS acceptance gate built on walk-forward diagnostics."""
+
+    GATE: ClassVar[str] = GATE
 
     def __init__(self, min_regime_beats: int = DEFAULT_MIN_REGIME_BEATS):
         if min_regime_beats < 0:
@@ -41,6 +43,7 @@ class AcceptanceGate:
         config: BacktestConfig,
         *,
         n_trials: Optional[int] = None,
+        phase: StrategyLabPhase = "verification",
     ) -> List[QualityGateResult]:
         """Return one ``QualityGateResult`` per sub-criterion.
 
@@ -48,6 +51,8 @@ class AcceptanceGate:
         want to adjust the DSR threshold based on cumulative trial count; the
         DSR itself is already deflated upstream.
         """
+        self._set_phase(phase)
+
         missing: List[str] = []
         if result.oos_sharpe is None:
             missing.append("oos_sharpe")
@@ -57,15 +62,9 @@ class AcceptanceGate:
             missing.append("oos_trade_count")
         if missing:
             return [
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase="verification",
-                    passed=False,
-                    severity="warning",
-                    details=(
-                        "Acceptance gate cannot evaluate — walk-forward diagnostics "
-                        f"missing: {', '.join(missing)}."
-                    ),
+                self._warning(
+                    "Acceptance gate cannot evaluate — walk-forward diagnostics "
+                    f"missing: {', '.join(missing)}."
                 )
             ]
 
@@ -75,17 +74,11 @@ class AcceptanceGate:
         dsr = float(result.deflated_sharpe)
         passed_dsr = dsr >= config.dsr_threshold
         results.append(
-            QualityGateResult(
-                gate_name=GATE,
-                phase="verification",
-                passed=passed_dsr,
-                severity="info" if passed_dsr else "critical",
-                details=(
-                    f"OOS DSR {dsr:.3f} "
-                    f"{'meets' if passed_dsr else 'below'} threshold "
-                    f"{config.dsr_threshold:.3f}"
-                    + (f" (n_trials={n_trials})" if n_trials is not None else "")
-                ),
+            (self._info if passed_dsr else self._critical)(
+                f"OOS DSR {dsr:.3f} "
+                f"{'meets' if passed_dsr else 'below'} threshold "
+                f"{config.dsr_threshold:.3f}"
+                + (f" (n_trials={n_trials})" if n_trials is not None else "")
             )
         )
 
@@ -93,16 +86,10 @@ class AcceptanceGate:
         deg = float(result.is_oos_degradation_pct)
         passed_deg = deg <= config.max_is_oos_degradation_pct
         results.append(
-            QualityGateResult(
-                gate_name=GATE,
-                phase="verification",
-                passed=passed_deg,
-                severity="info" if passed_deg else "critical",
-                details=(
-                    f"IS→OOS Sharpe degradation {deg:.1f}% "
-                    f"{'within' if passed_deg else 'exceeds'} "
-                    f"{config.max_is_oos_degradation_pct:.1f}% ceiling"
-                ),
+            (self._info if passed_deg else self._critical)(
+                f"IS→OOS Sharpe degradation {deg:.1f}% "
+                f"{'within' if passed_deg else 'exceeds'} "
+                f"{config.max_is_oos_degradation_pct:.1f}% ceiling"
             )
         )
 
@@ -110,16 +97,10 @@ class AcceptanceGate:
         n_oos = int(result.oos_trade_count)
         passed_count = n_oos >= config.min_oos_trades
         results.append(
-            QualityGateResult(
-                gate_name=GATE,
-                phase="verification",
-                passed=passed_count,
-                severity="info" if passed_count else "critical",
-                details=(
-                    f"OOS trade count {n_oos} "
-                    f"{'meets' if passed_count else 'below'} minimum "
-                    f"{config.min_oos_trades}"
-                ),
+            (self._info if passed_count else self._critical)(
+                f"OOS trade count {n_oos} "
+                f"{'meets' if passed_count else 'below'} minimum "
+                f"{config.min_oos_trades}"
             )
         )
 
@@ -135,13 +116,7 @@ class AcceptanceGate:
             else "No regime subwindows evaluated"
         )
         results.append(
-            QualityGateResult(
-                gate_name=GATE,
-                phase="verification",
-                passed=passed_regime,
-                severity="info" if passed_regime else "critical",
-                details=regime_detail,
-            )
+            (self._info if passed_regime else self._critical)(regime_detail)
         )
 
         return results

--- a/backend/agents/investment_team/strategy_lab/quality_gates/acceptance_gate.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/acceptance_gate.py
@@ -51,8 +51,16 @@ class AcceptanceGate(GateResultsMixin):
         want to adjust the DSR threshold based on cumulative trial count; the
         DSR itself is already deflated upstream.
         """
-        self._set_phase(phase)
+        with self._using_phase(phase):
+            return self._evaluate(result, config, n_trials=n_trials)
 
+    def _evaluate(
+        self,
+        result: BacktestResult,
+        config: BacktestConfig,
+        *,
+        n_trials: Optional[int],
+    ) -> List[QualityGateResult]:
         missing: List[str] = []
         if result.oos_sharpe is None:
             missing.append("oos_sharpe")

--- a/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
@@ -2,10 +2,29 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import ClassVar, Iterable, List, Optional
 
 from ...models import BacktestExecutionDiagnostics, BacktestResult, CoverageReport, TradeRecord
 from .models import GateResultsMixin, QualityGateResult, StrategyLabPhase
+
+
+@dataclass(frozen=True)
+class BacktestAnomalyCtx:
+    """Per-``check`` context handed to every rule in ``BacktestAnomalyDetector._RULES``.
+
+    Frozen so individual rules cannot accidentally mutate state visible to
+    later rules. Built once at the top of ``check`` and threaded through each
+    rule call — replaces the previous ``self._<attr>`` pattern that risked
+    bleed-over across concurrent ``check`` invocations.
+    """
+
+    metrics: BacktestResult
+    trades: List[TradeRecord]
+    mode: str
+    dsr_aware: bool
+    diagnostics: Optional[BacktestExecutionDiagnostics]
+    coverage_report: Optional[CoverageReport]
 
 GATE = "backtest_anomaly"
 
@@ -115,58 +134,52 @@ class BacktestAnomalyDetector(GateResultsMixin):
         Other rules ignore them.
         """
         self._set_phase(phase)
-        # Store call-scoped context so each rule reads from instance state
-        # without an explicit-arg parade.
-        self._metrics = metrics
-        self._trades = trades
-        self._mode = mode
-        self._dsr_aware = dsr_aware
-        self._diagnostics = diagnostics
-        self._coverage_report = coverage_report
-        try:
-            # Zero trades is a hard short-circuit — every downstream statistic
-            # is meaningless without trades, so we return immediately.
-            if not trades:
-                return [
-                    self._critical(_format_zero_trade_details(diagnostics, coverage_report))
-                ]
-            results = [r for rule in self._RULES for r in rule(self)]
-            return results or [self._info("Backtest results passed all anomaly checks.")]
-        finally:
-            self._metrics = None  # type: ignore[assignment]
-            self._trades = None  # type: ignore[assignment]
-            self._diagnostics = None
-            self._coverage_report = None
+        # Zero trades is a hard short-circuit — every downstream statistic
+        # is meaningless without trades, so we return immediately.
+        if not trades:
+            return [
+                self._critical(_format_zero_trade_details(diagnostics, coverage_report))
+            ]
+        ctx = BacktestAnomalyCtx(
+            metrics=metrics,
+            trades=trades,
+            mode=mode,
+            dsr_aware=dsr_aware,
+            diagnostics=diagnostics,
+            coverage_report=coverage_report,
+        )
+        results = [r for rule in self._RULES for r in rule(self, ctx)]
+        return results or [self._info("Backtest results passed all anomaly checks.")]
 
     # ------------------------------------------------------------------
-    # Rules — each reads call-scoped state from ``self`` and yields zero or
-    # more results. Listed in ``_RULES`` below.
+    # Rules — each takes the per-call ``BacktestAnomalyCtx`` and yields zero
+    # or more results. Listed in ``_RULES`` below.
     # ------------------------------------------------------------------
-    def _check_trade_count_floor(self) -> Iterable[QualityGateResult]:
+    def _check_trade_count_floor(self, ctx: BacktestAnomalyCtx) -> Iterable[QualityGateResult]:
         # Paper sessions run over short windows (a few weeks at most) so a
         # <5-trade minimum is inappropriate; the signals_per_bar floor is the
         # paper-mode equivalent.
-        if self._mode != "paper" and len(self._trades) < 5:
+        if ctx.mode != "paper" and len(ctx.trades) < 5:
             return (
                 self._critical(
-                    f"Only {len(self._trades)} trades — "
+                    f"Only {len(ctx.trades)} trades — "
                     "statistically meaningless for a multi-year backtest."
                 ),
             )
         return ()
 
-    def _check_annualized_return_ceiling(self) -> Iterable[QualityGateResult]:
-        if self._metrics.annualized_return_pct > 200:
+    def _check_annualized_return_ceiling(self, ctx: BacktestAnomalyCtx) -> Iterable[QualityGateResult]:
+        if ctx.metrics.annualized_return_pct > 200:
             return (
                 self._critical(
-                    f"Annualized return {self._metrics.annualized_return_pct:.1f}% is "
+                    f"Annualized return {ctx.metrics.annualized_return_pct:.1f}% is "
                     "suspiciously high (>200%) — likely a data or logic bug."
                 ),
             )
         return ()
 
-    def _check_win_rate(self) -> Iterable[QualityGateResult]:
-        wr = self._metrics.win_rate_pct
+    def _check_win_rate(self, ctx: BacktestAnomalyCtx) -> Iterable[QualityGateResult]:
+        wr = ctx.metrics.win_rate_pct
         if wr > 95:
             return (
                 self._critical(
@@ -182,23 +195,23 @@ class BacktestAnomalyDetector(GateResultsMixin):
             )
         return ()
 
-    def _check_profit_factor(self) -> Iterable[QualityGateResult]:
-        if self._metrics.profit_factor > 10:
+    def _check_profit_factor(self, ctx: BacktestAnomalyCtx) -> Iterable[QualityGateResult]:
+        if ctx.metrics.profit_factor > 10:
             return (
                 self._critical(
-                    f"Profit factor {self._metrics.profit_factor:.1f} exceeds 10 — "
+                    f"Profit factor {ctx.metrics.profit_factor:.1f} exceeds 10 — "
                     "likely data snooping or bug."
                 ),
             )
         return ()
 
-    def _check_sharpe_ratio(self) -> Iterable[QualityGateResult]:
+    def _check_sharpe_ratio(self, ctx: BacktestAnomalyCtx) -> Iterable[QualityGateResult]:
         # When the orchestrator runs walk-forward + AcceptanceGate, OOS
         # Deflated Sharpe is the authoritative overfitting check — so the
         # single-window ``Sharpe > 5.0`` flag is downgraded from critical to
         # warning to avoid double-rejecting strategies whose IS Sharpe is
         # high but OOS DSR clears.
-        sr = self._metrics.sharpe_ratio
+        sr = ctx.metrics.sharpe_ratio
         if sr > 5.0:
             details = (
                 f"Sharpe ratio {sr:.2f} exceeds 5.0 — almost certainly indicates "
@@ -206,12 +219,12 @@ class BacktestAnomalyDetector(GateResultsMixin):
                 + (
                     "AcceptanceGate's OOS Deflated Sharpe is the authoritative "
                     "overfitting check on this run."
-                    if self._dsr_aware
+                    if ctx.dsr_aware
                     else "When walk-forward is available, AcceptanceGate's OOS "
                     "Deflated Sharpe is the more precise overfitting check."
                 )
             )
-            return (self._warning(details) if self._dsr_aware else self._critical(details),)
+            return (self._warning(details) if ctx.dsr_aware else self._critical(details),)
         if sr > 3.0:
             return (
                 self._warning(
@@ -221,8 +234,8 @@ class BacktestAnomalyDetector(GateResultsMixin):
             )
         return ()
 
-    def _check_avg_hold_time(self) -> Iterable[QualityGateResult]:
-        avg_hold = sum(t.hold_days for t in self._trades) / len(self._trades)
+    def _check_avg_hold_time(self, ctx: BacktestAnomalyCtx) -> Iterable[QualityGateResult]:
+        avg_hold = sum(t.hold_days for t in ctx.trades) / len(ctx.trades)
         if avg_hold < 1:
             return (
                 self._critical(
@@ -233,11 +246,11 @@ class BacktestAnomalyDetector(GateResultsMixin):
             )
         return ()
 
-    def _check_trade_concentration(self) -> Iterable[QualityGateResult]:
-        total_pnl = sum(abs(t.net_pnl) for t in self._trades)
+    def _check_trade_concentration(self, ctx: BacktestAnomalyCtx) -> Iterable[QualityGateResult]:
+        total_pnl = sum(abs(t.net_pnl) for t in ctx.trades)
         if total_pnl <= 0:
             return ()
-        max_single = max(abs(t.net_pnl) for t in self._trades)
+        max_single = max(abs(t.net_pnl) for t in ctx.trades)
         if max_single / total_pnl > 0.5:
             return (
                 self._warning(
@@ -247,29 +260,29 @@ class BacktestAnomalyDetector(GateResultsMixin):
             )
         return ()
 
-    def _check_trade_diversification(self) -> Iterable[QualityGateResult]:
-        if len(self._trades) <= 1:
+    def _check_trade_diversification(self, ctx: BacktestAnomalyCtx) -> Iterable[QualityGateResult]:
+        if len(ctx.trades) <= 1:
             return ()
-        sides = {t.side for t in self._trades}
-        symbols = {t.symbol for t in self._trades}
+        sides = {t.side for t in ctx.trades}
+        symbols = {t.symbol for t in ctx.trades}
         if len(sides) == 1 and len(symbols) == 1:
             return (
                 self._warning(
-                    f"All {len(self._trades)} trades are {next(iter(sides))} on "
+                    f"All {len(ctx.trades)} trades are {next(iter(sides))} on "
                     f"{next(iter(symbols))} — no diversification."
                 ),
             )
         return ()
 
-    def _check_cost_sensitivity(self) -> Iterable[QualityGateResult]:
-        gross_wins = sum(t.gross_pnl for t in self._trades if t.gross_pnl > 0)
-        gross_losses = abs(sum(t.gross_pnl for t in self._trades if t.gross_pnl <= 0))
+    def _check_cost_sensitivity(self, ctx: BacktestAnomalyCtx) -> Iterable[QualityGateResult]:
+        gross_wins = sum(t.gross_pnl for t in ctx.trades if t.gross_pnl > 0)
+        gross_losses = abs(sum(t.gross_pnl for t in ctx.trades if t.gross_pnl <= 0))
         gross_pf = gross_wins / gross_losses if gross_losses > 0 else 0.0
-        if gross_pf > 1.0 and self._metrics.profit_factor < 1.0:
+        if gross_pf > 1.0 and ctx.metrics.profit_factor < 1.0:
             return (
                 self._warning(
                     f"Profit factor drops from {gross_pf:.2f} (gross) to "
-                    f"{self._metrics.profit_factor:.2f} (net) — strategy edge is "
+                    f"{ctx.metrics.profit_factor:.2f} (net) — strategy edge is "
                     "consumed by transaction costs."
                 ),
             )

--- a/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-from typing import List, Optional
+from typing import ClassVar, List, Optional
 
 from ...models import BacktestExecutionDiagnostics, BacktestResult, CoverageReport, TradeRecord
-from .models import QualityGateResult, StrategyLabPhase
+from .models import GateResultsMixin, QualityGateResult, StrategyLabPhase
 
 GATE = "backtest_anomaly"
 
@@ -84,8 +84,10 @@ def _format_coverage_line(coverage_report: Optional[CoverageReport]) -> str:
     return f"Coverage: {coverage_report.coverage_category.value} — {summary}"
 
 
-class BacktestAnomalyDetector:
+class BacktestAnomalyDetector(GateResultsMixin):
     """Flag backtest results that are statistically implausible or likely buggy."""
+
+    GATE: ClassVar[str] = GATE
 
     def check(
         self,
@@ -125,19 +127,14 @@ class BacktestAnomalyDetector:
         details so the persisted ``QualityGateResult`` carries the static
         probe's verdict alongside the executor's view. Other gates ignore it.
         """
+        self._set_phase(phase)
         results: List[QualityGateResult] = []
 
         # 1. Zero trades (always flagged — even in paper mode a non-trading
         # strategy is a hard failure).
         if not trades:
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details=_format_zero_trade_details(diagnostics, coverage_report),
-                )
+                self._critical(_format_zero_trade_details(diagnostics, coverage_report))
             )
             return results
 
@@ -147,59 +144,29 @@ class BacktestAnomalyDetector:
         # is the paper-mode equivalent.
         if mode != "paper" and len(trades) < 5:
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details=f"Only {len(trades)} trades — statistically meaningless for a multi-year backtest.",
-                )
+                self._critical(f"Only {len(trades)} trades — statistically meaningless for a multi-year backtest.")
             )
 
         # 3. Annualized return > 200%
         if metrics.annualized_return_pct > 200:
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details=f"Annualized return {metrics.annualized_return_pct:.1f}% is suspiciously high (>200%) — likely a data or logic bug.",
-                )
+                self._critical(f"Annualized return {metrics.annualized_return_pct:.1f}% is suspiciously high (>200%) — likely a data or logic bug.")
             )
 
         # 4. Win rate thresholds
         if metrics.win_rate_pct > 95:
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details=f"Win rate {metrics.win_rate_pct:.1f}% exceeds 95% — almost certainly overfitting or lookahead bias.",
-                )
+                self._critical(f"Win rate {metrics.win_rate_pct:.1f}% exceeds 95% — almost certainly overfitting or lookahead bias.")
             )
         elif metrics.win_rate_pct > 90:
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="warning",
-                    details=f"Win rate {metrics.win_rate_pct:.1f}% exceeds 90% — review for possible overfitting.",
-                )
+                self._warning(f"Win rate {metrics.win_rate_pct:.1f}% exceeds 90% — review for possible overfitting.")
             )
 
         # 5. Extreme profit factor
         if metrics.profit_factor > 10:
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details=f"Profit factor {metrics.profit_factor:.1f} exceeds 10 — likely data snooping or bug.",
-                )
+                self._critical(f"Profit factor {metrics.profit_factor:.1f} exceeds 10 — likely data snooping or bug.")
             )
 
         # 5b. Sharpe ratio thresholds.
@@ -212,36 +179,23 @@ class BacktestAnomalyDetector:
         # Without ``dsr_aware`` the orchestrator only sees the single window,
         # so a Sharpe > 5.0 stays critical to trigger refinement.
         if metrics.sharpe_ratio > 5.0:
-            results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="warning" if dsr_aware else "critical",
-                    details=(
-                        f"Sharpe ratio {metrics.sharpe_ratio:.2f} exceeds 5.0 — "
-                        "almost certainly indicates look-ahead bias or a "
-                        "calculation artifact. "
-                        + (
-                            "AcceptanceGate's OOS Deflated Sharpe is the "
-                            "authoritative overfitting check on this run."
-                            if dsr_aware
-                            else "When walk-forward is available, "
-                            "AcceptanceGate's OOS Deflated Sharpe is the more "
-                            "precise overfitting check."
-                        )
-                    ),
+            details = (
+                f"Sharpe ratio {metrics.sharpe_ratio:.2f} exceeds 5.0 — "
+                "almost certainly indicates look-ahead bias or a "
+                "calculation artifact. "
+                + (
+                    "AcceptanceGate's OOS Deflated Sharpe is the "
+                    "authoritative overfitting check on this run."
+                    if dsr_aware
+                    else "When walk-forward is available, "
+                    "AcceptanceGate's OOS Deflated Sharpe is the more "
+                    "precise overfitting check."
                 )
             )
+            results.append(self._warning(details) if dsr_aware else self._critical(details))
         elif metrics.sharpe_ratio > 3.0:
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="warning",
-                    details=f"Sharpe ratio {metrics.sharpe_ratio:.2f} exceeds 3.0 — review for overfitting or data snooping.",
-                )
+                self._warning(f"Sharpe ratio {metrics.sharpe_ratio:.2f} exceeds 3.0 — review for overfitting or data snooping.")
             )
 
         # 6. Average hold time < 1 day → hard fail on daily bars (Phase 2).
@@ -249,17 +203,9 @@ class BacktestAnomalyDetector:
             avg_hold = sum(t.hold_days for t in trades) / len(trades)
             if avg_hold < 1:
                 results.append(
-                    QualityGateResult(
-                        gate_name=GATE,
-                        phase=phase,
-                        passed=False,
-                        severity="critical",
-                        details=(
-                            f"Average hold time {avg_hold:.1f} days — sub-day holds "
+                    self._critical(f"Average hold time {avg_hold:.1f} days — sub-day holds "
                             "on daily-bar data are a strong indicator of look-ahead "
-                            "bias or intra-bar execution that cannot be replicated live."
-                        ),
-                    )
+                            "bias or intra-bar execution that cannot be replicated live.")
                 )
 
         # 7. Single trade concentration
@@ -269,13 +215,7 @@ class BacktestAnomalyDetector:
                 max_single = max(abs(t.net_pnl) for t in trades)
                 if max_single / total_pnl > 0.5:
                     results.append(
-                        QualityGateResult(
-                            gate_name=GATE,
-                            phase=phase,
-                            passed=False,
-                            severity="warning",
-                            details=f"Largest single trade is {max_single / total_pnl:.0%} of total absolute P&L — high concentration risk.",
-                        )
+                        self._warning(f"Largest single trade is {max_single / total_pnl:.0%} of total absolute P&L — high concentration risk.")
                     )
 
         # 8. All trades identical direction and symbol
@@ -284,13 +224,7 @@ class BacktestAnomalyDetector:
             symbols = {t.symbol for t in trades}
             if len(sides) == 1 and len(symbols) == 1:
                 results.append(
-                    QualityGateResult(
-                        gate_name=GATE,
-                        phase=phase,
-                        passed=False,
-                        severity="warning",
-                        details=f"All {len(trades)} trades are {next(iter(sides))} on {next(iter(symbols))} — no diversification.",
-                    )
+                    self._warning(f"All {len(trades)} trades are {next(iter(sides))} on {next(iter(symbols))} — no diversification.")
                 )
 
         # 9. Cost sensitivity — edge consumed by transaction costs
@@ -300,27 +234,13 @@ class BacktestAnomalyDetector:
             gross_pf = gross_wins / gross_losses if gross_losses > 0 else 0.0
             if gross_pf > 1.0 and metrics.profit_factor < 1.0:
                 results.append(
-                    QualityGateResult(
-                        gate_name=GATE,
-                        phase=phase,
-                        passed=False,
-                        severity="warning",
-                        details=(
-                            f"Profit factor drops from {gross_pf:.2f} (gross) to "
-                            f"{metrics.profit_factor:.2f} (net) — strategy edge is consumed by transaction costs."
-                        ),
-                    )
+                    self._warning(f"Profit factor drops from {gross_pf:.2f} (gross) to "
+                            f"{metrics.profit_factor:.2f} (net) — strategy edge is consumed by transaction costs.")
                 )
 
         if not results:
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=True,
-                    severity="info",
-                    details="Backtest results passed all anomaly checks.",
-                )
+                self._info("Backtest results passed all anomaly checks.")
             )
 
         return results

--- a/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import List, Optional
 
 from ...models import BacktestExecutionDiagnostics, BacktestResult, CoverageReport, TradeRecord
-from .models import QualityGateResult
+from .models import QualityGateResult, StrategyLabPhase
 
 GATE = "backtest_anomaly"
 
@@ -96,6 +96,7 @@ class BacktestAnomalyDetector:
         dsr_aware: bool = False,
         diagnostics: Optional[BacktestExecutionDiagnostics] = None,
         coverage_report: Optional[CoverageReport] = None,
+        phase: StrategyLabPhase = "synthesis",
     ) -> List[QualityGateResult]:
         """Run anomaly checks.
 
@@ -132,7 +133,7 @@ class BacktestAnomalyDetector:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="verification",
+                    phase=phase,
                     passed=False,
                     severity="critical",
                     details=_format_zero_trade_details(diagnostics, coverage_report),
@@ -148,7 +149,7 @@ class BacktestAnomalyDetector:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="verification",
+                    phase=phase,
                     passed=False,
                     severity="critical",
                     details=f"Only {len(trades)} trades — statistically meaningless for a multi-year backtest.",
@@ -160,7 +161,7 @@ class BacktestAnomalyDetector:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="verification",
+                    phase=phase,
                     passed=False,
                     severity="critical",
                     details=f"Annualized return {metrics.annualized_return_pct:.1f}% is suspiciously high (>200%) — likely a data or logic bug.",
@@ -172,7 +173,7 @@ class BacktestAnomalyDetector:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="verification",
+                    phase=phase,
                     passed=False,
                     severity="critical",
                     details=f"Win rate {metrics.win_rate_pct:.1f}% exceeds 95% — almost certainly overfitting or lookahead bias.",
@@ -182,7 +183,7 @@ class BacktestAnomalyDetector:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="verification",
+                    phase=phase,
                     passed=False,
                     severity="warning",
                     details=f"Win rate {metrics.win_rate_pct:.1f}% exceeds 90% — review for possible overfitting.",
@@ -194,7 +195,7 @@ class BacktestAnomalyDetector:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="verification",
+                    phase=phase,
                     passed=False,
                     severity="critical",
                     details=f"Profit factor {metrics.profit_factor:.1f} exceeds 10 — likely data snooping or bug.",
@@ -214,7 +215,7 @@ class BacktestAnomalyDetector:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="verification",
+                    phase=phase,
                     passed=False,
                     severity="warning" if dsr_aware else "critical",
                     details=(
@@ -236,7 +237,7 @@ class BacktestAnomalyDetector:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="verification",
+                    phase=phase,
                     passed=False,
                     severity="warning",
                     details=f"Sharpe ratio {metrics.sharpe_ratio:.2f} exceeds 3.0 — review for overfitting or data snooping.",
@@ -250,7 +251,7 @@ class BacktestAnomalyDetector:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
-                        phase="verification",
+                        phase=phase,
                         passed=False,
                         severity="critical",
                         details=(
@@ -270,7 +271,7 @@ class BacktestAnomalyDetector:
                     results.append(
                         QualityGateResult(
                             gate_name=GATE,
-                            phase="verification",
+                            phase=phase,
                             passed=False,
                             severity="warning",
                             details=f"Largest single trade is {max_single / total_pnl:.0%} of total absolute P&L — high concentration risk.",
@@ -285,7 +286,7 @@ class BacktestAnomalyDetector:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
-                        phase="verification",
+                        phase=phase,
                         passed=False,
                         severity="warning",
                         details=f"All {len(trades)} trades are {next(iter(sides))} on {next(iter(symbols))} — no diversification.",
@@ -301,7 +302,7 @@ class BacktestAnomalyDetector:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
-                        phase="verification",
+                        phase=phase,
                         passed=False,
                         severity="warning",
                         details=(
@@ -315,7 +316,7 @@ class BacktestAnomalyDetector:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="verification",
+                    phase=phase,
                     passed=True,
                     severity="info",
                     details="Backtest results passed all anomaly checks.",

--- a/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import ClassVar, List, Optional
+from typing import ClassVar, Iterable, List, Optional
 
 from ...models import BacktestExecutionDiagnostics, BacktestResult, CoverageReport, TradeRecord
 from .models import GateResultsMixin, QualityGateResult, StrategyLabPhase
@@ -20,17 +20,13 @@ def _format_zero_trade_details(
 ) -> str:
     """Build the ``QualityGateResult.details`` string for a zero-trade backtest.
 
-    When ``diagnostics`` carries a deterministic ``zero_trade_category`` (see
-    issue #404), surface the category, the executor's summary, the order
-    counters, and any rejection-reason histogram so the refinement agent has
-    enough evidence to repair the entry/exit path. Falls back to the
-    historical generic message when diagnostics are missing or the executor
-    couldn't classify the failure.
-
-    When ``coverage_report`` is also present (issue #452), append a one-line
+    When ``diagnostics`` carries a deterministic ``zero_trade_category``,
+    surface the category, the executor's summary, the order counters, and any
+    rejection-reason histogram. Falls back to the historical generic message
+    when diagnostics are missing or the executor couldn't classify the
+    failure. When ``coverage_report`` is also present, append a one-line
     ``Coverage: <category> — <summary>`` so the persisted gate result records
-    the deterministic rule-coverage verdict from the #451 probe alongside the
-    executor's view.
+    the deterministic rule-coverage verdict alongside the executor's view.
     """
     coverage_line = _format_coverage_line(coverage_report)
 
@@ -70,14 +66,6 @@ def _format_zero_trade_details(
 
 
 def _format_coverage_line(coverage_report: Optional[CoverageReport]) -> str:
-    """One-line ``Coverage: <category> — <summary>`` for the gate details.
-
-    Returns empty string when no report is attached, so callers can treat
-    the line as additive (issue #452). Uses ``.value`` so the persisted
-    string is the bare category name (e.g. ``ENTRY_CONDITION_NEVER_TRUE``)
-    rather than the Python enum repr, matching the existing ``Category:``
-    line style produced by the diagnostics envelope.
-    """
     if coverage_report is None:
         return ""
     summary = coverage_report.summary or "(no summary)"
@@ -85,7 +73,14 @@ def _format_coverage_line(coverage_report: Optional[CoverageReport]) -> str:
 
 
 class BacktestAnomalyDetector(GateResultsMixin):
-    """Flag backtest results that are statistically implausible or likely buggy."""
+    """Flag backtest results that are statistically implausible or likely buggy.
+
+    Contract: every call to :meth:`check` returns a non-empty
+    ``List[QualityGateResult]``. Every result carries the caller's ``phase``
+    and ``gate_name == GATE``. Rules are listed in ``_RULES`` and iterated in
+    order; the zero-trade short-circuit fires before any other rule because a
+    no-trade backtest invalidates every downstream statistic.
+    """
 
     GATE: ClassVar[str] = GATE
 
@@ -100,7 +95,10 @@ class BacktestAnomalyDetector(GateResultsMixin):
         coverage_report: Optional[CoverageReport] = None,
         phase: StrategyLabPhase = "synthesis",
     ) -> List[QualityGateResult]:
-        """Run anomaly checks.
+        """Run anomaly checks and tag every result with ``phase``.
+
+        Pre: ``metrics`` is a BacktestResult; ``trades`` is a list.
+        Post: results non-empty; every entry carries the caller's ``phase``.
 
         ``mode="backtest"`` (default) runs the full gate set; ``mode="paper"``
         relaxes gates that assume a multi-year backtest window so short
@@ -110,137 +108,182 @@ class BacktestAnomalyDetector(GateResultsMixin):
         when walk-forward + ``AcceptanceGate`` is wired in: the OOS Deflated
         Sharpe Ratio is then the authoritative overfitting check, so the
         ``Sharpe > 5.0`` single-window flag is downgraded from critical to
-        warning — it still surfaces in the gate result list but no longer
-        forces a refinement-loop rewrite when the OOS DSR clears the gate.
+        warning.
 
-        ``diagnostics`` (default None) is the optional execution-path
-        envelope produced by the trading service (see issue #404). When
-        provided on a zero-trade backtest it enriches the gate result with
-        a deterministic failure category and order counters so the
-        refinement agent can target the actual failure mode. Other gates
-        ignore it.
-
-        ``coverage_report`` (default None, issue #452) is the optional
-        deterministic rule-coverage probe output produced by the orchestrator
-        (issue #451) on zero/low-trade runs. When provided it adds a single
-        ``Coverage: <category> — <summary>`` line to the zero-trade gate
-        details so the persisted ``QualityGateResult`` carries the static
-        probe's verdict alongside the executor's view. Other gates ignore it.
+        ``diagnostics`` and ``coverage_report`` enrich the zero-trade gate
+        result with a deterministic failure category and order counters.
+        Other rules ignore them.
         """
         self._set_phase(phase)
-        results: List[QualityGateResult] = []
+        # Store call-scoped context so each rule reads from instance state
+        # without an explicit-arg parade.
+        self._metrics = metrics
+        self._trades = trades
+        self._mode = mode
+        self._dsr_aware = dsr_aware
+        self._diagnostics = diagnostics
+        self._coverage_report = coverage_report
+        try:
+            # Zero trades is a hard short-circuit — every downstream statistic
+            # is meaningless without trades, so we return immediately.
+            if not trades:
+                return [
+                    self._critical(_format_zero_trade_details(diagnostics, coverage_report))
+                ]
+            results = [r for rule in self._RULES for r in rule(self)]
+            return results or [self._info("Backtest results passed all anomaly checks.")]
+        finally:
+            self._metrics = None  # type: ignore[assignment]
+            self._trades = None  # type: ignore[assignment]
+            self._diagnostics = None
+            self._coverage_report = None
 
-        # 1. Zero trades (always flagged — even in paper mode a non-trading
-        # strategy is a hard failure).
-        if not trades:
-            results.append(
-                self._critical(_format_zero_trade_details(diagnostics, coverage_report))
+    # ------------------------------------------------------------------
+    # Rules — each reads call-scoped state from ``self`` and yields zero or
+    # more results. Listed in ``_RULES`` below.
+    # ------------------------------------------------------------------
+    def _check_trade_count_floor(self) -> Iterable[QualityGateResult]:
+        # Paper sessions run over short windows (a few weeks at most) so a
+        # <5-trade minimum is inappropriate; the signals_per_bar floor is the
+        # paper-mode equivalent.
+        if self._mode != "paper" and len(self._trades) < 5:
+            return (
+                self._critical(
+                    f"Only {len(self._trades)} trades — "
+                    "statistically meaningless for a multi-year backtest."
+                ),
             )
-            return results
+        return ()
 
-        # 2. Too few trades — backtest-only: paper sessions run over short
-        # windows (a few weeks at most) so a <5-trade minimum is
-        # inappropriate.  The signals_per_bar floor in BacktestConfig
-        # is the paper-mode equivalent.
-        if mode != "paper" and len(trades) < 5:
-            results.append(
-                self._critical(f"Only {len(trades)} trades — statistically meaningless for a multi-year backtest.")
+    def _check_annualized_return_ceiling(self) -> Iterable[QualityGateResult]:
+        if self._metrics.annualized_return_pct > 200:
+            return (
+                self._critical(
+                    f"Annualized return {self._metrics.annualized_return_pct:.1f}% is "
+                    "suspiciously high (>200%) — likely a data or logic bug."
+                ),
             )
+        return ()
 
-        # 3. Annualized return > 200%
-        if metrics.annualized_return_pct > 200:
-            results.append(
-                self._critical(f"Annualized return {metrics.annualized_return_pct:.1f}% is suspiciously high (>200%) — likely a data or logic bug.")
+    def _check_win_rate(self) -> Iterable[QualityGateResult]:
+        wr = self._metrics.win_rate_pct
+        if wr > 95:
+            return (
+                self._critical(
+                    f"Win rate {wr:.1f}% exceeds 95% — almost certainly overfitting "
+                    "or lookahead bias."
+                ),
             )
+        if wr > 90:
+            return (
+                self._warning(
+                    f"Win rate {wr:.1f}% exceeds 90% — review for possible overfitting."
+                ),
+            )
+        return ()
 
-        # 4. Win rate thresholds
-        if metrics.win_rate_pct > 95:
-            results.append(
-                self._critical(f"Win rate {metrics.win_rate_pct:.1f}% exceeds 95% — almost certainly overfitting or lookahead bias.")
+    def _check_profit_factor(self) -> Iterable[QualityGateResult]:
+        if self._metrics.profit_factor > 10:
+            return (
+                self._critical(
+                    f"Profit factor {self._metrics.profit_factor:.1f} exceeds 10 — "
+                    "likely data snooping or bug."
+                ),
             )
-        elif metrics.win_rate_pct > 90:
-            results.append(
-                self._warning(f"Win rate {metrics.win_rate_pct:.1f}% exceeds 90% — review for possible overfitting.")
-            )
+        return ()
 
-        # 5. Extreme profit factor
-        if metrics.profit_factor > 10:
-            results.append(
-                self._critical(f"Profit factor {metrics.profit_factor:.1f} exceeds 10 — likely data snooping or bug.")
-            )
-
-        # 5b. Sharpe ratio thresholds.
-        # Issue #247: when the orchestrator runs walk-forward and invokes
-        # ``AcceptanceGate`` on the OOS Deflated Sharpe, that gate is the
-        # authoritative overfitting check — so we downgrade the single-window
-        # ``Sharpe > 5.0`` flag from critical to warning under ``dsr_aware``
-        # to avoid double-rejecting (and to avoid forcing a refinement rewrite
-        # on a strategy whose IS Sharpe is high but OOS DSR clears the gate).
-        # Without ``dsr_aware`` the orchestrator only sees the single window,
-        # so a Sharpe > 5.0 stays critical to trigger refinement.
-        if metrics.sharpe_ratio > 5.0:
+    def _check_sharpe_ratio(self) -> Iterable[QualityGateResult]:
+        # When the orchestrator runs walk-forward + AcceptanceGate, OOS
+        # Deflated Sharpe is the authoritative overfitting check — so the
+        # single-window ``Sharpe > 5.0`` flag is downgraded from critical to
+        # warning to avoid double-rejecting strategies whose IS Sharpe is
+        # high but OOS DSR clears.
+        sr = self._metrics.sharpe_ratio
+        if sr > 5.0:
             details = (
-                f"Sharpe ratio {metrics.sharpe_ratio:.2f} exceeds 5.0 — "
-                "almost certainly indicates look-ahead bias or a "
-                "calculation artifact. "
+                f"Sharpe ratio {sr:.2f} exceeds 5.0 — almost certainly indicates "
+                "look-ahead bias or a calculation artifact. "
                 + (
-                    "AcceptanceGate's OOS Deflated Sharpe is the "
-                    "authoritative overfitting check on this run."
-                    if dsr_aware
-                    else "When walk-forward is available, "
-                    "AcceptanceGate's OOS Deflated Sharpe is the more "
-                    "precise overfitting check."
+                    "AcceptanceGate's OOS Deflated Sharpe is the authoritative "
+                    "overfitting check on this run."
+                    if self._dsr_aware
+                    else "When walk-forward is available, AcceptanceGate's OOS "
+                    "Deflated Sharpe is the more precise overfitting check."
                 )
             )
-            results.append(self._warning(details) if dsr_aware else self._critical(details))
-        elif metrics.sharpe_ratio > 3.0:
-            results.append(
-                self._warning(f"Sharpe ratio {metrics.sharpe_ratio:.2f} exceeds 3.0 — review for overfitting or data snooping.")
+            return (self._warning(details) if self._dsr_aware else self._critical(details),)
+        if sr > 3.0:
+            return (
+                self._warning(
+                    f"Sharpe ratio {sr:.2f} exceeds 3.0 — review for overfitting "
+                    "or data snooping."
+                ),
             )
+        return ()
 
-        # 6. Average hold time < 1 day → hard fail on daily bars (Phase 2).
-        if trades:
-            avg_hold = sum(t.hold_days for t in trades) / len(trades)
-            if avg_hold < 1:
-                results.append(
-                    self._critical(f"Average hold time {avg_hold:.1f} days — sub-day holds "
-                            "on daily-bar data are a strong indicator of look-ahead "
-                            "bias or intra-bar execution that cannot be replicated live.")
-                )
-
-        # 7. Single trade concentration
-        if trades:
-            total_pnl = sum(abs(t.net_pnl) for t in trades)
-            if total_pnl > 0:
-                max_single = max(abs(t.net_pnl) for t in trades)
-                if max_single / total_pnl > 0.5:
-                    results.append(
-                        self._warning(f"Largest single trade is {max_single / total_pnl:.0%} of total absolute P&L — high concentration risk.")
-                    )
-
-        # 8. All trades identical direction and symbol
-        if len(trades) > 1:
-            sides = {t.side for t in trades}
-            symbols = {t.symbol for t in trades}
-            if len(sides) == 1 and len(symbols) == 1:
-                results.append(
-                    self._warning(f"All {len(trades)} trades are {next(iter(sides))} on {next(iter(symbols))} — no diversification.")
-                )
-
-        # 9. Cost sensitivity — edge consumed by transaction costs
-        if trades:
-            gross_wins = sum(t.gross_pnl for t in trades if t.gross_pnl > 0)
-            gross_losses = abs(sum(t.gross_pnl for t in trades if t.gross_pnl <= 0))
-            gross_pf = gross_wins / gross_losses if gross_losses > 0 else 0.0
-            if gross_pf > 1.0 and metrics.profit_factor < 1.0:
-                results.append(
-                    self._warning(f"Profit factor drops from {gross_pf:.2f} (gross) to "
-                            f"{metrics.profit_factor:.2f} (net) — strategy edge is consumed by transaction costs.")
-                )
-
-        if not results:
-            results.append(
-                self._info("Backtest results passed all anomaly checks.")
+    def _check_avg_hold_time(self) -> Iterable[QualityGateResult]:
+        avg_hold = sum(t.hold_days for t in self._trades) / len(self._trades)
+        if avg_hold < 1:
+            return (
+                self._critical(
+                    f"Average hold time {avg_hold:.1f} days — sub-day holds on "
+                    "daily-bar data are a strong indicator of look-ahead bias or "
+                    "intra-bar execution that cannot be replicated live."
+                ),
             )
+        return ()
 
-        return results
+    def _check_trade_concentration(self) -> Iterable[QualityGateResult]:
+        total_pnl = sum(abs(t.net_pnl) for t in self._trades)
+        if total_pnl <= 0:
+            return ()
+        max_single = max(abs(t.net_pnl) for t in self._trades)
+        if max_single / total_pnl > 0.5:
+            return (
+                self._warning(
+                    f"Largest single trade is {max_single / total_pnl:.0%} of total "
+                    "absolute P&L — high concentration risk."
+                ),
+            )
+        return ()
+
+    def _check_trade_diversification(self) -> Iterable[QualityGateResult]:
+        if len(self._trades) <= 1:
+            return ()
+        sides = {t.side for t in self._trades}
+        symbols = {t.symbol for t in self._trades}
+        if len(sides) == 1 and len(symbols) == 1:
+            return (
+                self._warning(
+                    f"All {len(self._trades)} trades are {next(iter(sides))} on "
+                    f"{next(iter(symbols))} — no diversification."
+                ),
+            )
+        return ()
+
+    def _check_cost_sensitivity(self) -> Iterable[QualityGateResult]:
+        gross_wins = sum(t.gross_pnl for t in self._trades if t.gross_pnl > 0)
+        gross_losses = abs(sum(t.gross_pnl for t in self._trades if t.gross_pnl <= 0))
+        gross_pf = gross_wins / gross_losses if gross_losses > 0 else 0.0
+        if gross_pf > 1.0 and self._metrics.profit_factor < 1.0:
+            return (
+                self._warning(
+                    f"Profit factor drops from {gross_pf:.2f} (gross) to "
+                    f"{self._metrics.profit_factor:.2f} (net) — strategy edge is "
+                    "consumed by transaction costs."
+                ),
+            )
+        return ()
+
+    # Rules iterated in order by ``check``. Adding a rule is a one-line edit.
+    _RULES: ClassVar[tuple] = (
+        _check_trade_count_floor,
+        _check_annualized_return_ceiling,
+        _check_win_rate,
+        _check_profit_factor,
+        _check_sharpe_ratio,
+        _check_avg_hold_time,
+        _check_trade_concentration,
+        _check_trade_diversification,
+        _check_cost_sensitivity,
+    )

--- a/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
@@ -133,23 +133,23 @@ class BacktestAnomalyDetector(GateResultsMixin):
         result with a deterministic failure category and order counters.
         Other rules ignore them.
         """
-        self._set_phase(phase)
-        # Zero trades is a hard short-circuit — every downstream statistic
-        # is meaningless without trades, so we return immediately.
-        if not trades:
-            return [
-                self._critical(_format_zero_trade_details(diagnostics, coverage_report))
-            ]
-        ctx = BacktestAnomalyCtx(
-            metrics=metrics,
-            trades=trades,
-            mode=mode,
-            dsr_aware=dsr_aware,
-            diagnostics=diagnostics,
-            coverage_report=coverage_report,
-        )
-        results = [r for rule in self._RULES for r in rule(self, ctx)]
-        return results or [self._info("Backtest results passed all anomaly checks.")]
+        with self._using_phase(phase):
+            # Zero trades is a hard short-circuit — every downstream statistic
+            # is meaningless without trades, so we return immediately.
+            if not trades:
+                return [
+                    self._critical(_format_zero_trade_details(diagnostics, coverage_report))
+                ]
+            ctx = BacktestAnomalyCtx(
+                metrics=metrics,
+                trades=trades,
+                mode=mode,
+                dsr_aware=dsr_aware,
+                diagnostics=diagnostics,
+                coverage_report=coverage_report,
+            )
+            results = [r for rule in self._RULES for r in rule(self, ctx)]
+            return results or [self._info("Backtest results passed all anomaly checks.")]
 
     # ------------------------------------------------------------------
     # Rules — each takes the per-call ``BacktestAnomalyCtx`` and yields zero

--- a/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
@@ -132,6 +132,7 @@ class BacktestAnomalyDetector:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="verification",
                     passed=False,
                     severity="critical",
                     details=_format_zero_trade_details(diagnostics, coverage_report),
@@ -147,6 +148,7 @@ class BacktestAnomalyDetector:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="verification",
                     passed=False,
                     severity="critical",
                     details=f"Only {len(trades)} trades — statistically meaningless for a multi-year backtest.",
@@ -158,6 +160,7 @@ class BacktestAnomalyDetector:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="verification",
                     passed=False,
                     severity="critical",
                     details=f"Annualized return {metrics.annualized_return_pct:.1f}% is suspiciously high (>200%) — likely a data or logic bug.",
@@ -169,6 +172,7 @@ class BacktestAnomalyDetector:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="verification",
                     passed=False,
                     severity="critical",
                     details=f"Win rate {metrics.win_rate_pct:.1f}% exceeds 95% — almost certainly overfitting or lookahead bias.",
@@ -178,6 +182,7 @@ class BacktestAnomalyDetector:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="verification",
                     passed=False,
                     severity="warning",
                     details=f"Win rate {metrics.win_rate_pct:.1f}% exceeds 90% — review for possible overfitting.",
@@ -189,6 +194,7 @@ class BacktestAnomalyDetector:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="verification",
                     passed=False,
                     severity="critical",
                     details=f"Profit factor {metrics.profit_factor:.1f} exceeds 10 — likely data snooping or bug.",
@@ -208,6 +214,7 @@ class BacktestAnomalyDetector:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="verification",
                     passed=False,
                     severity="warning" if dsr_aware else "critical",
                     details=(
@@ -229,6 +236,7 @@ class BacktestAnomalyDetector:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="verification",
                     passed=False,
                     severity="warning",
                     details=f"Sharpe ratio {metrics.sharpe_ratio:.2f} exceeds 3.0 — review for overfitting or data snooping.",
@@ -242,6 +250,7 @@ class BacktestAnomalyDetector:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
+                        phase="verification",
                         passed=False,
                         severity="critical",
                         details=(
@@ -261,6 +270,7 @@ class BacktestAnomalyDetector:
                     results.append(
                         QualityGateResult(
                             gate_name=GATE,
+                            phase="verification",
                             passed=False,
                             severity="warning",
                             details=f"Largest single trade is {max_single / total_pnl:.0%} of total absolute P&L — high concentration risk.",
@@ -275,6 +285,7 @@ class BacktestAnomalyDetector:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
+                        phase="verification",
                         passed=False,
                         severity="warning",
                         details=f"All {len(trades)} trades are {next(iter(sides))} on {next(iter(symbols))} — no diversification.",
@@ -290,6 +301,7 @@ class BacktestAnomalyDetector:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
+                        phase="verification",
                         passed=False,
                         severity="warning",
                         details=(
@@ -303,6 +315,7 @@ class BacktestAnomalyDetector:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="verification",
                     passed=True,
                     severity="info",
                     details="Backtest results passed all anomaly checks.",

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import ast
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, ClassVar, Dict, List, Optional
 
-from .models import QualityGateResult, StrategyLabPhase
+from .models import GateResultsMixin, QualityGateResult, StrategyLabPhase
 
 GATE = "code_safety"
 
@@ -102,8 +102,10 @@ _LOOKAHEAD_PATTERNS = [
 ]
 
 
-class CodeSafetyChecker:
+class CodeSafetyChecker(GateResultsMixin):
     """Scan generated strategy code for unsafe patterns before subprocess execution."""
+
+    GATE: ClassVar[str] = GATE
 
     def check(
         self,
@@ -120,16 +122,15 @@ class CodeSafetyChecker:
         loop call site; callers re-using the checker in a different phase
         (e.g. the trade-alignment fix path, which lives in verification)
         must pass ``phase`` explicitly.
-        """
-        """Run all code-safety rules against ``code``.
 
         ``spec`` is the active ``StrategySpec`` when available; it's used by
-        the symbol-universe rule (#524) to verify that the generated module
+        the symbol-universe rule to verify that the generated module
         contains a ``UNIVERSE`` constant and a ``bar.symbol not in
         self.UNIVERSE: return`` guard whenever ``spec.target_symbols`` is
         non-empty. Other rules ignore ``spec``; passing ``None`` (the
         default) keeps the legacy call sites and tests behaving as before.
         """
+        self._set_phase(phase)
         results: List[QualityGateResult] = []
 
         # 1. Parse the code
@@ -137,13 +138,7 @@ class CodeSafetyChecker:
             tree = ast.parse(code)
         except SyntaxError as e:
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details=f"Code has a syntax error: {e}",
-                )
+                self._critical(f"Code has a syntax error: {e}")
             )
             return results
 
@@ -155,44 +150,22 @@ class CodeSafetyChecker:
         strategy_classes = _find_strategy_subclasses(tree)
         if len(strategy_classes) == 0:
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details=(
-                        "Code must define exactly one subclass of contract.Strategy; "
+                self._critical("Code must define exactly one subclass of contract.Strategy; "
                         "none found. Use `from contract import Strategy` and `class "
-                        "MyStrategy(Strategy): ...`."
-                    ),
-                )
+                        "MyStrategy(Strategy): ...`.")
             )
         elif len(strategy_classes) > 1:
             names = ", ".join(sorted(c.name for c in strategy_classes))
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details=(
-                        f"Code defines multiple Strategy subclasses ({names}); the "
-                        "harness accepts exactly one."
-                    ),
-                )
+                self._critical(f"Code defines multiple Strategy subclasses ({names}); the "
+                        "harness accepts exactly one.")
             )
         else:
             strategy_cls = strategy_classes[0]
             on_bar_issue = _validate_on_bar(strategy_cls)
             if on_bar_issue is not None:
                 results.append(
-                    QualityGateResult(
-                        gate_name=GATE,
-                        phase=phase,
-                        passed=False,
-                        severity="critical",
-                        details=on_bar_issue,
-                    )
+                    self._critical(on_bar_issue)
                 )
 
         # 3. Walk AST for banned imports
@@ -202,23 +175,11 @@ class CodeSafetyChecker:
                     top_module = alias.name.split(".")[0]
                     if top_module in BANNED_IMPORTS:
                         results.append(
-                            QualityGateResult(
-                                gate_name=GATE,
-                                phase=phase,
-                                passed=False,
-                                severity="critical",
-                                details=f"Banned import: '{alias.name}' — network/filesystem/system access not allowed.",
-                            )
+                            self._critical(f"Banned import: '{alias.name}' — network/filesystem/system access not allowed.")
                         )
                     elif top_module not in ALLOWED_IMPORTS:
                         results.append(
-                            QualityGateResult(
-                                gate_name=GATE,
-                                phase=phase,
-                                passed=False,
-                                severity="warning",
-                                details=f"Non-allowlisted import: '{alias.name}' — may not be available in sandbox.",
-                            )
+                            self._warning(f"Non-allowlisted import: '{alias.name}' — may not be available in sandbox.")
                         )
 
             elif isinstance(node, ast.ImportFrom):
@@ -226,23 +187,11 @@ class CodeSafetyChecker:
                     top_module = node.module.split(".")[0]
                     if top_module in BANNED_IMPORTS:
                         results.append(
-                            QualityGateResult(
-                                gate_name=GATE,
-                                phase=phase,
-                                passed=False,
-                                severity="critical",
-                                details=f"Banned import: 'from {node.module}' — network/filesystem/system access not allowed.",
-                            )
+                            self._critical(f"Banned import: 'from {node.module}' — network/filesystem/system access not allowed.")
                         )
                     elif top_module not in ALLOWED_IMPORTS:
                         results.append(
-                            QualityGateResult(
-                                gate_name=GATE,
-                                phase=phase,
-                                passed=False,
-                                severity="warning",
-                                details=f"Non-allowlisted import: 'from {node.module}' — may not be available in sandbox.",
-                            )
+                            self._warning(f"Non-allowlisted import: 'from {node.module}' — may not be available in sandbox.")
                         )
 
         # 4. Walk AST for banned function calls
@@ -251,33 +200,15 @@ class CodeSafetyChecker:
                 func_name = _get_call_name(node)
                 if func_name in ("exec", "eval", "compile", "__import__", "globals", "breakpoint"):
                     results.append(
-                        QualityGateResult(
-                            gate_name=GATE,
-                            phase=phase,
-                            passed=False,
-                            severity="critical",
-                            details=f"Banned function call: '{func_name}()' — dynamic code execution not allowed.",
-                        )
+                        self._critical(f"Banned function call: '{func_name}()' — dynamic code execution not allowed.")
                     )
                 if func_name == "open":
                     results.append(
-                        QualityGateResult(
-                            gate_name=GATE,
-                            phase=phase,
-                            passed=False,
-                            severity="critical",
-                            details="Banned function call: 'open()' — file I/O not allowed in strategy code.",
-                        )
+                        self._critical("Banned function call: 'open()' — file I/O not allowed in strategy code.")
                     )
                 if func_name in ("setattr", "delattr"):
                     results.append(
-                        QualityGateResult(
-                            gate_name=GATE,
-                            phase=phase,
-                            passed=False,
-                            severity="critical",
-                            details=f"Banned function call: '{func_name}()' — attribute manipulation not allowed.",
-                        )
+                        self._critical(f"Banned function call: '{func_name}()' — attribute manipulation not allowed.")
                     )
 
         # 5. Regex fallback for patterns AST might miss
@@ -285,13 +216,7 @@ class CodeSafetyChecker:
             if pattern.search(code):
                 match_text = pattern.pattern.replace(r"\b", "").replace(r"\s*\(", "(")
                 results.append(
-                    QualityGateResult(
-                        gate_name=GATE,
-                        phase=phase,
-                        passed=False,
-                        severity="critical",
-                        details=f"Regex detected banned pattern: '{match_text}'.",
-                    )
+                    self._critical(f"Regex detected banned pattern: '{match_text}'.")
                 )
 
         # 6. Look-ahead bias detection (run against executable code only,
@@ -300,26 +225,14 @@ class CodeSafetyChecker:
         for pattern, reason in _LOOKAHEAD_PATTERNS:
             if pattern.search(executable):
                 results.append(
-                    QualityGateResult(
-                        gate_name=GATE,
-                        phase=phase,
-                        passed=False,
-                        severity="critical",
-                        details=f"Look-ahead bias: {reason}",
-                    )
+                    self._critical(f"Look-ahead bias: {reason}")
                 )
 
         # 7. Code length
         line_count = len(code.splitlines())
         if line_count > 1000:
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="warning",
-                    details=f"Code is {line_count} lines — consider simplifying (limit: 1000).",
-                )
+                self._warning(f"Code is {line_count} lines — consider simplifying (limit: 1000).")
             )
 
         # 8. Order-flow shape (#547): every viable strategy must call
@@ -351,20 +264,12 @@ class CodeSafetyChecker:
             hook_calls = _collect_hook_submit_calls(strategy_classes[0])
             if len(hook_calls) == 0:
                 results.append(
-                    QualityGateResult(
-                        gate_name=GATE,
-                        phase=phase,
-                        passed=False,
-                        severity="critical",
-                        details=(
-                            "No ctx.submit_order call reachable from on_bar — strategy "
+                    self._critical("No ctx.submit_order call reachable from on_bar — strategy "
                             "has no entry path that the engine will process. The "
                             "trading service only consumes orders submitted from "
                             "on_bar (responses from on_start / on_fill / on_end are "
                             "currently dropped), so any submission outside on_bar is "
-                            "silently ignored."
-                        ),
-                    )
+                            "silently ignored.")
                 )
             elif not _calls_form_entry_exit_pair(hook_calls):
                 if len(hook_calls) == 1:
@@ -383,13 +288,7 @@ class CodeSafetyChecker:
                         "bracket leg."
                     )
                 results.append(
-                    QualityGateResult(
-                        gate_name=GATE,
-                        phase=phase,
-                        passed=False,
-                        severity="critical",
-                        details=detail,
-                    )
+                    self._critical(detail)
                 )
 
         # 9. Symbol-universe guard (#524). When ``spec.target_symbols`` is
@@ -404,48 +303,26 @@ class CodeSafetyChecker:
                 strategy_cls = strategy_classes[0]
                 if not _has_universe_constant(strategy_cls):
                     results.append(
-                        QualityGateResult(
-                            gate_name=GATE,
-                            phase=phase,
-                            passed=False,
-                            severity="critical",
-                            details=(
-                                "Spec has non-empty target_symbols but the strategy "
+                        self._critical("Spec has non-empty target_symbols but the strategy "
                                 "class is missing a UNIVERSE = frozenset({...}) (or "
                                 "set/tuple) class-level constant. Without UNIVERSE + "
                                 "an `if bar.symbol not in self.UNIVERSE: return` guard "
                                 "at the top of on_bar, the historical replay stream "
                                 "will feed bars for every fetched symbol to the "
-                                "signal logic and trades will land on the wrong asset."
-                            ),
-                        )
+                                "signal logic and trades will land on the wrong asset.")
                     )
                 elif not _has_universe_guard_in_on_bar(strategy_cls):
                     results.append(
-                        QualityGateResult(
-                            gate_name=GATE,
-                            phase=phase,
-                            passed=False,
-                            severity="critical",
-                            details=(
-                                "Strategy defines UNIVERSE but on_bar is missing the "
+                        self._critical("Strategy defines UNIVERSE but on_bar is missing the "
                                 "`if bar.symbol not in self.UNIVERSE: return` guard. "
                                 "Without the early-exit, the historical replay stream "
                                 "will deliver bars for every fetched symbol and the "
-                                "signal logic will trade tickers outside target_symbols."
-                            ),
-                        )
+                                "signal logic will trade tickers outside target_symbols.")
                     )
 
         if not results:
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=True,
-                    severity="info",
-                    details="Code passed all safety checks.",
-                )
+                self._info("Code passed all safety checks.")
             )
 
         return results

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -6,7 +6,7 @@ import ast
 import re
 from typing import Any, Dict, List, Optional
 
-from .models import QualityGateResult
+from .models import QualityGateResult, StrategyLabPhase
 
 GATE = "code_safety"
 
@@ -105,7 +105,22 @@ _LOOKAHEAD_PATTERNS = [
 class CodeSafetyChecker:
     """Scan generated strategy code for unsafe patterns before subprocess execution."""
 
-    def check(self, code: str, spec: Any = None) -> List[QualityGateResult]:
+    def check(
+        self,
+        code: str,
+        spec: Any = None,
+        *,
+        phase: StrategyLabPhase = "synthesis",
+    ) -> List[QualityGateResult]:
+        """Run the safety checks and tag every result with ``phase``.
+
+        Pre: ``code`` is a string; ``phase`` is a valid phase literal.
+        Post: every returned result carries the caller's ``phase`` and
+        ``gate_name == GATE``. The default matches the primary refinement-
+        loop call site; callers re-using the checker in a different phase
+        (e.g. the trade-alignment fix path, which lives in verification)
+        must pass ``phase`` explicitly.
+        """
         """Run all code-safety rules against ``code``.
 
         ``spec`` is the active ``StrategySpec`` when available; it's used by
@@ -124,7 +139,7 @@ class CodeSafetyChecker:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="synthesis",
+                    phase=phase,
                     passed=False,
                     severity="critical",
                     details=f"Code has a syntax error: {e}",
@@ -142,7 +157,7 @@ class CodeSafetyChecker:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="synthesis",
+                    phase=phase,
                     passed=False,
                     severity="critical",
                     details=(
@@ -157,7 +172,7 @@ class CodeSafetyChecker:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="synthesis",
+                    phase=phase,
                     passed=False,
                     severity="critical",
                     details=(
@@ -173,7 +188,7 @@ class CodeSafetyChecker:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
-                        phase="synthesis",
+                        phase=phase,
                         passed=False,
                         severity="critical",
                         details=on_bar_issue,
@@ -189,7 +204,7 @@ class CodeSafetyChecker:
                         results.append(
                             QualityGateResult(
                                 gate_name=GATE,
-                                phase="synthesis",
+                                phase=phase,
                                 passed=False,
                                 severity="critical",
                                 details=f"Banned import: '{alias.name}' — network/filesystem/system access not allowed.",
@@ -199,7 +214,7 @@ class CodeSafetyChecker:
                         results.append(
                             QualityGateResult(
                                 gate_name=GATE,
-                                phase="synthesis",
+                                phase=phase,
                                 passed=False,
                                 severity="warning",
                                 details=f"Non-allowlisted import: '{alias.name}' — may not be available in sandbox.",
@@ -213,7 +228,7 @@ class CodeSafetyChecker:
                         results.append(
                             QualityGateResult(
                                 gate_name=GATE,
-                                phase="synthesis",
+                                phase=phase,
                                 passed=False,
                                 severity="critical",
                                 details=f"Banned import: 'from {node.module}' — network/filesystem/system access not allowed.",
@@ -223,7 +238,7 @@ class CodeSafetyChecker:
                         results.append(
                             QualityGateResult(
                                 gate_name=GATE,
-                                phase="synthesis",
+                                phase=phase,
                                 passed=False,
                                 severity="warning",
                                 details=f"Non-allowlisted import: 'from {node.module}' — may not be available in sandbox.",
@@ -238,7 +253,7 @@ class CodeSafetyChecker:
                     results.append(
                         QualityGateResult(
                             gate_name=GATE,
-                            phase="synthesis",
+                            phase=phase,
                             passed=False,
                             severity="critical",
                             details=f"Banned function call: '{func_name}()' — dynamic code execution not allowed.",
@@ -248,7 +263,7 @@ class CodeSafetyChecker:
                     results.append(
                         QualityGateResult(
                             gate_name=GATE,
-                            phase="synthesis",
+                            phase=phase,
                             passed=False,
                             severity="critical",
                             details="Banned function call: 'open()' — file I/O not allowed in strategy code.",
@@ -258,7 +273,7 @@ class CodeSafetyChecker:
                     results.append(
                         QualityGateResult(
                             gate_name=GATE,
-                            phase="synthesis",
+                            phase=phase,
                             passed=False,
                             severity="critical",
                             details=f"Banned function call: '{func_name}()' — attribute manipulation not allowed.",
@@ -272,7 +287,7 @@ class CodeSafetyChecker:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
-                        phase="synthesis",
+                        phase=phase,
                         passed=False,
                         severity="critical",
                         details=f"Regex detected banned pattern: '{match_text}'.",
@@ -287,7 +302,7 @@ class CodeSafetyChecker:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
-                        phase="synthesis",
+                        phase=phase,
                         passed=False,
                         severity="critical",
                         details=f"Look-ahead bias: {reason}",
@@ -300,7 +315,7 @@ class CodeSafetyChecker:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="synthesis",
+                    phase=phase,
                     passed=False,
                     severity="warning",
                     details=f"Code is {line_count} lines — consider simplifying (limit: 1000).",
@@ -338,7 +353,7 @@ class CodeSafetyChecker:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
-                        phase="synthesis",
+                        phase=phase,
                         passed=False,
                         severity="critical",
                         details=(
@@ -370,7 +385,7 @@ class CodeSafetyChecker:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
-                        phase="synthesis",
+                        phase=phase,
                         passed=False,
                         severity="critical",
                         details=detail,
@@ -391,7 +406,7 @@ class CodeSafetyChecker:
                     results.append(
                         QualityGateResult(
                             gate_name=GATE,
-                            phase="synthesis",
+                            phase=phase,
                             passed=False,
                             severity="critical",
                             details=(
@@ -409,7 +424,7 @@ class CodeSafetyChecker:
                     results.append(
                         QualityGateResult(
                             gate_name=GATE,
-                            phase="synthesis",
+                            phase=phase,
                             passed=False,
                             severity="critical",
                             details=(
@@ -426,7 +441,7 @@ class CodeSafetyChecker:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="synthesis",
+                    phase=phase,
                     passed=True,
                     severity="info",
                     details="Code passed all safety checks.",

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -136,23 +136,23 @@ class CodeSafetyChecker(GateResultsMixin):
         non-empty. Other rules ignore ``spec``; passing ``None`` (the
         default) keeps the legacy call sites and tests behaving as before.
         """
-        self._set_phase(phase)
-        # Parse first — a syntax error is a hard short-circuit because every
-        # AST rule below requires a tree.
-        try:
-            tree = ast.parse(code)
-        except SyntaxError as e:
-            return [self._critical(f"Code has a syntax error: {e}")]
+        with self._using_phase(phase):
+            # Parse first — a syntax error is a hard short-circuit because
+            # every AST rule below requires a tree.
+            try:
+                tree = ast.parse(code)
+            except SyntaxError as e:
+                return [self._critical(f"Code has a syntax error: {e}")]
 
-        ctx = CodeSafetyCtx(
-            code=code,
-            tree=tree,
-            spec=spec,
-            strategy_classes=_find_strategy_subclasses(tree),
-            executable=_strip_comments_and_strings(code),
-        )
-        results = [r for rule in self._RULES for r in rule(self, ctx)]
-        return results or [self._info("Code passed all safety checks.")]
+            ctx = CodeSafetyCtx(
+                code=code,
+                tree=tree,
+                spec=spec,
+                strategy_classes=_find_strategy_subclasses(tree),
+                executable=_strip_comments_and_strings(code),
+            )
+            results = [r for rule in self._RULES for r in rule(self, ctx)]
+            return results or [self._info("Code passed all safety checks.")]
 
     # ------------------------------------------------------------------
     # Rules — each reads call-scoped state and yields zero or more results.

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -3,9 +3,21 @@
 from __future__ import annotations
 
 import ast
-import re
-from typing import Any, ClassVar, Dict, Iterable, List, Optional
+from dataclasses import dataclass
+from typing import Any, ClassVar, Iterable, List
 
+from .code_safety_ast import (
+    _BANNED_CALL_PATTERNS,
+    _LOOKAHEAD_PATTERNS,
+    _calls_form_entry_exit_pair,
+    _collect_hook_submit_calls,
+    _find_strategy_subclasses,
+    _get_call_name,
+    _has_universe_constant,
+    _has_universe_guard_in_on_bar,
+    _strip_comments_and_strings,
+    _validate_on_bar,
+)
 from .models import GateResultsMixin, QualityGateResult, StrategyLabPhase
 
 GATE = "code_safety"
@@ -70,36 +82,23 @@ ALLOWED_IMPORTS = frozenset(
     }
 )
 
-# Regex patterns for dangerous calls that AST analysis might miss in edge cases.
-_BANNED_CALL_PATTERNS = [
-    re.compile(r"\bexec\s*\("),
-    re.compile(r"\beval\s*\("),
-    re.compile(r"\bcompile\s*\("),
-    re.compile(r"\b__import__\s*\("),
-    re.compile(r"\bglobals\s*\("),
-    re.compile(r"\bbreakpoint\s*\("),
-]
 
-# Look-ahead bias patterns — accessing future data from within the
-# ``Strategy`` subclass. Most look-ahead is structurally impossible in the
-# event-driven contract (``ctx`` has no accessor for future data, and
-# ``AttributeError`` on a forward field is trapped as ``lookahead_violation``
-# at runtime), but these regexes catch obvious tripwires before the code
-# even runs.
-_LOOKAHEAD_PATTERNS = [
-    (
-        re.compile(r"\bctx\s*\.\s*future_\w+"),
-        "ctx.future_* does not exist — use only ctx.history(symbol, n)",
-    ),
-    (
-        re.compile(r"\bbar\s*\.\s*(?:next|future)_\w+"),
-        "bar.next_* / bar.future_* does not exist — only current-bar fields are delivered",
-    ),
-    (
-        re.compile(r"\bctx\s*\.\s*peek\b"),
-        "ctx.peek(...) does not exist — the engine does not expose forward bars",
-    ),
-]
+
+@dataclass(frozen=True)
+class CodeSafetyCtx:
+    """Per-``check`` context handed to every rule in ``CodeSafetyChecker._RULES``.
+
+    Built once at the top of ``check`` after the syntax-error short-circuit.
+    Threading the ctx explicitly through each rule replaces the previous
+    ``self._<attr>`` pattern that risked bleed-over across concurrent
+    ``check`` invocations.
+    """
+
+    code: str
+    tree: ast.Module
+    spec: Any
+    strategy_classes: List[ast.ClassDef]
+    executable: str
 
 
 class CodeSafetyChecker(GateResultsMixin):
@@ -145,30 +144,24 @@ class CodeSafetyChecker(GateResultsMixin):
         except SyntaxError as e:
             return [self._critical(f"Code has a syntax error: {e}")]
 
-        # Stash call-scoped context so each rule reads from instance state.
-        self._code = code
-        self._tree = tree
-        self._spec = spec
-        self._strategy_classes = _find_strategy_subclasses(tree)
-        self._executable = _strip_comments_and_strings(code)
-        try:
-            results = [r for rule in self._RULES for r in rule(self)]
-            return results or [self._info("Code passed all safety checks.")]
-        finally:
-            self._code = ""
-            self._tree = None  # type: ignore[assignment]
-            self._spec = None
-            self._strategy_classes = []
-            self._executable = ""
+        ctx = CodeSafetyCtx(
+            code=code,
+            tree=tree,
+            spec=spec,
+            strategy_classes=_find_strategy_subclasses(tree),
+            executable=_strip_comments_and_strings(code),
+        )
+        results = [r for rule in self._RULES for r in rule(self, ctx)]
+        return results or [self._info("Code passed all safety checks.")]
 
     # ------------------------------------------------------------------
     # Rules — each reads call-scoped state and yields zero or more results.
     # ------------------------------------------------------------------
-    def _check_strategy_class_shape(self) -> Iterable[QualityGateResult]:
+    def _check_strategy_class_shape(self, ctx: CodeSafetyCtx) -> Iterable[QualityGateResult]:
         # The streaming harness requires exactly one Strategy subclass with a
         # correctly-shaped ``on_bar``. Flagging here turns a runtime
         # classification error into an actionable refinement hint.
-        n = len(self._strategy_classes)
+        n = len(ctx.strategy_classes)
         if n == 0:
             return (
                 self._critical(
@@ -178,21 +171,21 @@ class CodeSafetyChecker(GateResultsMixin):
                 ),
             )
         if n > 1:
-            names = ", ".join(sorted(c.name for c in self._strategy_classes))
+            names = ", ".join(sorted(c.name for c in ctx.strategy_classes))
             return (
                 self._critical(
                     f"Code defines multiple Strategy subclasses ({names}); the "
                     "harness accepts exactly one."
                 ),
             )
-        on_bar_issue = _validate_on_bar(self._strategy_classes[0])
+        on_bar_issue = _validate_on_bar(ctx.strategy_classes[0])
         if on_bar_issue is not None:
             return (self._critical(on_bar_issue),)
         return ()
 
-    def _check_banned_imports(self) -> Iterable[QualityGateResult]:
+    def _check_banned_imports(self, ctx: CodeSafetyCtx) -> Iterable[QualityGateResult]:
         out: List[QualityGateResult] = []
-        for node in ast.walk(self._tree):
+        for node in ast.walk(ctx.tree):
             if isinstance(node, ast.Import):
                 for alias in node.names:
                     top_module = alias.name.split(".")[0]
@@ -228,9 +221,9 @@ class CodeSafetyChecker(GateResultsMixin):
                     )
         return out
 
-    def _check_banned_calls(self) -> Iterable[QualityGateResult]:
+    def _check_banned_calls(self, ctx: CodeSafetyCtx) -> Iterable[QualityGateResult]:
         out: List[QualityGateResult] = []
-        for node in ast.walk(self._tree):
+        for node in ast.walk(ctx.tree):
             if not isinstance(node, ast.Call):
                 continue
             func_name = _get_call_name(node)
@@ -256,27 +249,27 @@ class CodeSafetyChecker(GateResultsMixin):
                 )
         return out
 
-    def _check_banned_call_regex(self) -> Iterable[QualityGateResult]:
+    def _check_banned_call_regex(self, ctx: CodeSafetyCtx) -> Iterable[QualityGateResult]:
         # AST sometimes misses patterns hidden behind getattr / dynamic
         # attribute access; the regex pass catches those.
         out: List[QualityGateResult] = []
         for pattern in _BANNED_CALL_PATTERNS:
-            if pattern.search(self._code):
+            if pattern.search(ctx.code):
                 match_text = pattern.pattern.replace(r"\b", "").replace(r"\s*\(", "(")
                 out.append(self._critical(f"Regex detected banned pattern: '{match_text}'."))
         return out
 
-    def _check_lookahead_bias(self) -> Iterable[QualityGateResult]:
+    def _check_lookahead_bias(self, ctx: CodeSafetyCtx) -> Iterable[QualityGateResult]:
         # Run against executable code only — comments and string literals are
         # stripped to avoid false positives.
         out: List[QualityGateResult] = []
         for pattern, reason in _LOOKAHEAD_PATTERNS:
-            if pattern.search(self._executable):
+            if pattern.search(ctx.executable):
                 out.append(self._critical(f"Look-ahead bias: {reason}"))
         return out
 
-    def _check_code_length(self) -> Iterable[QualityGateResult]:
-        line_count = len(self._code.splitlines())
+    def _check_code_length(self, ctx: CodeSafetyCtx) -> Iterable[QualityGateResult]:
+        line_count = len(ctx.code.splitlines())
         if line_count > 1000:
             return (
                 self._warning(
@@ -285,7 +278,7 @@ class CodeSafetyChecker(GateResultsMixin):
             )
         return ()
 
-    def _check_order_flow_shape(self) -> Iterable[QualityGateResult]:
+    def _check_order_flow_shape(self, ctx: CodeSafetyCtx) -> Iterable[QualityGateResult]:
         # Every viable strategy must call ``ctx.submit_order(...)`` from
         # inside ``on_bar`` (directly or via a helper), and the reachable
         # calls must form an entry+exit pair — either two calls with
@@ -296,9 +289,9 @@ class CodeSafetyChecker(GateResultsMixin):
         # ``send_bar``; responses from ``send_start`` / ``send_fill`` /
         # ``send_end`` are discarded, so submissions outside ``on_bar`` are
         # silently dropped — they don't count here.
-        if len(self._strategy_classes) != 1:
+        if len(ctx.strategy_classes) != 1:
             return ()
-        hook_calls = _collect_hook_submit_calls(self._strategy_classes[0])
+        hook_calls = _collect_hook_submit_calls(ctx.strategy_classes[0])
         if not hook_calls:
             return (
                 self._critical(
@@ -329,18 +322,18 @@ class CodeSafetyChecker(GateResultsMixin):
             )
         return (self._critical(detail),)
 
-    def _check_universe_guard(self) -> Iterable[QualityGateResult]:
+    def _check_universe_guard(self, ctx: CodeSafetyCtx) -> Iterable[QualityGateResult]:
         # When ``spec.target_symbols`` is non-empty the generated module MUST
         # declare a class-level ``UNIVERSE`` set/frozenset and guard ``on_bar``
         # with ``if bar.symbol not in self.UNIVERSE: return``. The historical
         # replay stream interleaves bars across every fetched symbol; without
         # this guard a permissive predicate trades whichever ticker fires
         # first, not the one named in the hypothesis.
-        if self._spec is None or not getattr(self._spec, "target_symbols", None):
+        if ctx.spec is None or not getattr(ctx.spec, "target_symbols", None):
             return ()
-        if len(self._strategy_classes) != 1:
+        if len(ctx.strategy_classes) != 1:
             return ()
-        strategy_cls = self._strategy_classes[0]
+        strategy_cls = ctx.strategy_classes[0]
         if not _has_universe_constant(strategy_cls):
             return (
                 self._critical(
@@ -378,624 +371,3 @@ class CodeSafetyChecker(GateResultsMixin):
         _check_universe_guard,
     )
 
-
-def _get_call_name(node: ast.Call) -> str:
-    """Extract the function name from a Call node (handles simple names and attribute access)."""
-    if isinstance(node.func, ast.Name):
-        return node.func.id
-    if isinstance(node.func, ast.Attribute):
-        return node.func.attr
-    return ""
-
-
-# Hook methods whose ``submit_order`` calls actually reach the engine.
-#
-# The streaming harness sends every hook (``on_start`` / ``on_bar`` /
-# ``on_fill`` / ``on_end``) to the strategy subprocess, but the trading
-# service ONLY processes the ``HarnessResponse`` returned from ``send_bar``
-# into pending orders (see ``trading_service/service.py``). The responses
-# from ``send_start`` (line 483-489), ``send_fill`` (line 637-641), and
-# ``send_end`` (line 1114) are discarded, so any ``submit_order`` made
-# from those hooks is dropped before backtesting. The order-flow gate
-# only credits ``on_bar`` calls — matching the engine's real behaviour
-# avoids passing strategies that would silently emit zero trades.
-_PROCESSED_HOOK_METHODS = frozenset({"on_bar"})
-
-
-def _iter_method_body_nodes(method: ast.FunctionDef | ast.AsyncFunctionDef):
-    """Yield every AST node in ``method``'s body without descending into
-    nested ``def`` / ``async def`` / ``lambda`` / ``class`` bodies.
-
-    Python only creates the function/class object for a nested
-    declaration; its body never runs unless something explicitly invokes
-    it. Naïvely using ``ast.walk(method)`` would treat ``submit_order``
-    calls inside an uninvoked local helper inside the hook as reachable,
-    which is wrong — those calls never reach the runtime engine.
-    """
-    stack: List[ast.AST] = list(method.body)
-    while stack:
-        node = stack.pop()
-        yield node
-        # Stop descent at any nested function / class / lambda boundary —
-        # its body is a new scope that only runs if explicitly invoked.
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)):
-            continue
-        for child in ast.iter_child_nodes(node):
-            stack.append(child)
-
-
-def _iter_method_body_in_source_order(scope: ast.AST):
-    """Yield every node in ``scope``'s body in source order, without
-    descending into nested ``def`` / ``class`` / ``lambda`` bodies.
-
-    Unlike :func:`_iter_method_body_nodes` (stack-based, arbitrary
-    pop order), this generator visits parent statements before their
-    children and processes sibling statements in declaration order.
-    The flow-sensitive alias tracker depends on this ordering so a
-    ``trade_ctx = ctx`` assignment updates state BEFORE later
-    ``trade_ctx.submit_order(...)`` calls are visited.
-    """
-    body = getattr(scope, "body", None)
-    if not isinstance(body, list):
-        return
-
-    def visit(node: ast.AST):
-        yield node
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)):
-            return
-        for child in ast.iter_child_nodes(node):
-            yield from visit(child)
-
-    for stmt in body:
-        yield from visit(stmt)
-
-
-def _find_nested_def_defs(
-    method: ast.FunctionDef | ast.AsyncFunctionDef,
-) -> Dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
-    """Return a name → def map for every nested function defined directly
-    inside ``method``'s body (any depth, but not inside another nested
-    def or class).
-
-    These are local closures: ``def enter(): ctx.submit_order(...)`` style
-    helpers. When the outer scope explicitly calls them by name, the
-    engine reaches their body — so the order-flow walker needs to descend.
-    """
-    local_defs: Dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
-    # Walk method's body but stop at nested def/class boundaries so we
-    # collect only the immediate closures of this scope (not closures of
-    # closures).
-    for node in _iter_method_body_nodes(method):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            local_defs.setdefault(node.name, node)
-    return local_defs
-
-
-def _resolve_helper_receivers(
-    call: ast.Call,
-    helper: ast.FunctionDef | ast.AsyncFunctionDef,
-    outer_receivers: frozenset[str],
-) -> frozenset[str]:
-    """Return the helper parameter names that are bound to the outer
-    scope's context at the call site.
-
-    For ``self._trade(ctx, bar)`` where the outer scope's
-    ``receiver_names`` is ``{"ctx"}``: the first positional after self
-    in ``_trade``'s signature receives ``ctx``, so its name (e.g.
-    ``ctx`` or whatever the helper named that parameter) goes into the
-    returned set. Calls that don't pass any outer-receiver name as an
-    argument end up with an empty set — a ``submit_order`` inside such
-    a helper does NOT satisfy the gate.
-
-    Both positional and keyword arguments are tracked. Star-args /
-    keyword-spreads are ignored (rare in strategy code).
-    """
-    helper_params = [arg.arg for arg in helper.args.args if arg.arg != "self"]
-    bound: set[str] = set()
-
-    # Positional arguments — match against helper params by index.
-    for idx, arg in enumerate(call.args):
-        if idx >= len(helper_params):
-            break
-        if isinstance(arg, ast.Name) and arg.id in outer_receivers:
-            bound.add(helper_params[idx])
-
-    # Keyword arguments — match the parameter the keyword names.
-    for kw in call.keywords:
-        if kw.arg is None:
-            # **kwargs spread — can't statically resolve.
-            continue
-        if (
-            isinstance(kw.value, ast.Name)
-            and kw.value.id in outer_receivers
-            and kw.arg in helper_params
-        ):
-            bound.add(kw.arg)
-
-    return frozenset(bound)
-
-
-def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
-    """Return every ``submit_order(...)`` call reachable from ``on_bar``.
-
-    ``on_bar`` is the only engine hook whose ``HarnessResponse`` is
-    actually processed into pending orders by the trading service
-    (``send_start`` / ``send_fill`` / ``send_end`` are called without
-    consuming their responses, so any ``submit_order`` made from those
-    hooks is silently dropped). Limiting the gate's roots to ``on_bar``
-    matches the engine's real behaviour.
-
-    The walker follows three kinds of edges from each reachable scope:
-
-    * ``self.<method>(...)`` — descends into class methods. The helper
-      has its own parameter list; we relax the receiver check to any
-      non-``self`` positional parameter since the call site can pass
-      the context through any of them.
-    * ``<local_name>(...)`` — descends into local closures defined in
-      the SAME scope (e.g. ``def enter(): ctx.submit_order(...)`` then
-      ``enter()`` inside ``on_bar``). Local closures inherit the outer
-      scope's bindings, so they keep the OUTER scope's receiver names
-      rather than introducing their own (the closure captures ``ctx``
-      from the enclosing frame).
-
-    Walks each scope's body but stops at nested ``def`` / ``class`` /
-    ``lambda`` boundaries — bodies of locally-defined-but-uninvoked
-    helpers are not reachable because Python only creates the function
-    object and never executes the body without a call.
-
-    ``on_bar`` is dispatched positionally, so only its second positional
-    parameter is the StrategyContext.
-    """
-    methods_by_name: Dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
-    for node in ast.iter_child_nodes(cls):
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            methods_by_name[node.name] = node
-
-    calls: List[ast.Call] = []
-    # Visit key is (id(scope), receiver_names) so a helper called twice
-    # with different bindings (e.g. ``self._trade(bar)`` then
-    # ``self._trade(ctx)``) is analyzed once per distinct binding rather
-    # than getting masked by the first visit.
-    visited_keys: set[tuple[int, frozenset[str]]] = set()
-    # Worklist entries: (scope_node, receiver_names). receiver_names is
-    # the set of identifiers we accept as the context receiver inside
-    # this scope's body — for hooks, the second positional; for class
-    # helpers, parameters bound at the call site; for local closures,
-    # call-site-bound parameters PLUS the outer scope's receivers (the
-    # closure also captures them from the enclosing frame).
-    worklist: List[tuple[ast.AST, frozenset[str]]] = []
-    for name, m in methods_by_name.items():
-        if name in _PROCESSED_HOOK_METHODS:
-            if len(m.args.args) >= 2:
-                worklist.append((m, frozenset({m.args.args[1].arg})))
-
-    while worklist:
-        scope, initial_receivers = worklist.pop()
-        visit_key = (id(scope), initial_receivers)
-        if visit_key in visited_keys:
-            continue
-        visited_keys.add(visit_key)
-
-        # Local closures defined directly in this scope — followed only
-        # when their name is invoked below.
-        local_defs = (
-            _find_nested_def_defs(scope)
-            if isinstance(scope, (ast.FunctionDef, ast.AsyncFunctionDef))
-            else {}
-        )
-
-        # Flow-sensitive walk. ``state`` tracks the currently-live alias
-        # set as we proceed through the scope in source order. The walker
-        # updates it as it encounters ``Assign`` / ``AnnAssign`` events,
-        # so a ``submit_order`` call is credited only when the alias was
-        # bound to a known receiver at or before the call's source
-        # position — calls before a ``trade_ctx = ctx`` assignment, and
-        # calls after a later ``trade_ctx = something_else`` rebind, no
-        # longer pick up the alias.
-        state: set[str] = set(initial_receivers)
-
-        for sub in _iter_method_body_in_source_order(scope):
-            # Update alias state on simple name-to-name assignments.
-            if (
-                isinstance(sub, ast.Assign)
-                and len(sub.targets) == 1
-                and isinstance(sub.targets[0], ast.Name)
-            ):
-                target = sub.targets[0].id
-                if isinstance(sub.value, ast.Name) and sub.value.id in state:
-                    state.add(target)
-                elif target in state:
-                    # Rebound to a non-receiver expression — drop the alias.
-                    state.discard(target)
-                continue
-            if isinstance(sub, ast.AnnAssign) and isinstance(sub.target, ast.Name):
-                target = sub.target.id
-                if isinstance(sub.value, ast.Name) and sub.value.id in state:
-                    state.add(target)
-                elif target in state:
-                    state.discard(target)
-                continue
-
-            if not isinstance(sub, ast.Call):
-                continue
-
-            current_receivers = frozenset(state)
-
-            # 1. <ctx>.submit_order(...) — the order we count.
-            if (
-                isinstance(sub.func, ast.Attribute)
-                and sub.func.attr == "submit_order"
-                and isinstance(sub.func.value, ast.Name)
-                and sub.func.value.id in current_receivers
-            ):
-                calls.append(sub)
-                continue
-            # 2. self.<helper>(...) — class method. The helper's accepted
-            #    receivers are bound to the call-site arguments: only
-            #    parameters that received a name from the OUTER scope's
-            #    live receivers are treated as ctx-bound.
-            if (
-                isinstance(sub.func, ast.Attribute)
-                and isinstance(sub.func.value, ast.Name)
-                and sub.func.value.id == "self"
-            ):
-                helper = methods_by_name.get(sub.func.attr)
-                if helper is not None:
-                    helper_receivers = _resolve_helper_receivers(sub, helper, current_receivers)
-                    if (id(helper), helper_receivers) not in visited_keys:
-                        worklist.append((helper, helper_receivers))
-                continue
-            # 3. <local_name>(...) — closure defined in the same scope.
-            #    Closures see two sources of context bindings:
-            #    - Parameters bound at the call site (``def enter(c): ...;
-            #      enter(ctx)`` binds ``c`` to ``ctx``).
-            #    - Outer-scope captures (``def enter(): ctx.submit_order(
-            #      ...)`` references the enclosing frame's live receivers).
-            #    Captured names are visible only when the closure does
-            #    NOT shadow them with its own parameter — ``def
-            #    enter(ctx): ...; enter(bar)`` rebinds ``ctx`` to ``bar``,
-            #    so the outer ``ctx`` is no longer reachable inside.
-            if isinstance(sub.func, ast.Name):
-                local = local_defs.get(sub.func.id)
-                if local is not None:
-                    call_bound = _resolve_helper_receivers(sub, local, current_receivers)
-                    closure_param_names = frozenset(
-                        arg.arg for arg in local.args.args if arg.arg != "self"
-                    )
-                    captured = current_receivers - closure_param_names
-                    closure_receivers = captured | call_bound
-                    if (id(local), closure_receivers) not in visited_keys:
-                        worklist.append((local, closure_receivers))
-
-    return calls
-
-
-# Recognised ``OrderSide`` literal values. The runtime contract
-# (``trading_service.strategy.contract.OrderSide``) defines exactly two
-# enum members — ``LONG`` and ``SHORT`` — and ``StrategyContext.submit_order``
-# coerces with ``OrderSide(side)``. ``FLAT`` / ``CLOSE`` / ``BUY`` / ``SELL``
-# literals would crash at runtime, so they are NOT recognised here; the
-# gate treats them as "unknown" and lets the downstream backtest surface
-# the real validation error.
-_RECOGNISED_SIDES = frozenset({"LONG", "SHORT"})
-
-
-def _submit_order_side(node: ast.Call) -> Optional[str]:
-    """Best-effort extraction of the ``side`` value from a submit_order call.
-
-    Returns an upper-cased string when the call uses a recognised
-    ``OrderSide`` literal form, else None when the side is dynamic / a
-    non-OrderSide literal / can't be determined statically.
-    """
-    for kw in node.keywords:
-        if kw.arg != "side":
-            continue
-        val = kw.value
-        if isinstance(val, ast.Constant) and isinstance(val.value, str):
-            upper = val.value.upper()
-            return upper if upper in _RECOGNISED_SIDES else None
-        if isinstance(val, ast.Attribute):
-            upper = val.attr.upper()
-            return upper if upper in _RECOGNISED_SIDES else None
-    return None
-
-
-def _submit_order_symbol(node: ast.Call) -> Optional[str]:
-    """Best-effort extraction of the ``symbol`` value from a submit_order
-    call. Returns the literal string when the call uses a string Constant,
-    else None when the symbol is computed/dynamic or missing.
-
-    Dynamic-symbol calls (``symbol=bar.symbol`` etc.) all share the same
-    runtime symbol per ``on_bar`` invocation, so the entry/exit grouping
-    treats them as one logical group (key=None).
-    """
-    for kw in node.keywords:
-        if kw.arg != "symbol":
-            continue
-        if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
-            return kw.value.value
-    return None
-
-
-def _group_forms_entry_exit_pair(calls: List[ast.Call]) -> bool:
-    """True iff a single-symbol group of submit_order calls plausibly
-    contains both an entry and an opposite-side exit leg.
-
-    * Any call carrying a non-None ``attached_stop_loss`` /
-      ``attached_take_profit`` bracket leg satisfies the group on its own.
-    * Otherwise require both ``LONG`` and ``SHORT`` to appear across the
-      group's calls. Same-side multiplicity (``LONG`` + ``LONG``) fails.
-    * Unknown / dynamic side values are treated optimistically — the
-      runtime branch may pick either direction.
-    """
-    if any(_has_attached_exit_kwarg(c) for c in calls):
-        return True
-    sides_seen: set[str] = set()
-    has_unknown = False
-    for c in calls:
-        side = _submit_order_side(c)
-        if side is None:
-            has_unknown = True
-        else:
-            sides_seen.add(side)
-    if "LONG" in sides_seen and "SHORT" in sides_seen:
-        return True
-    if has_unknown:
-        return True
-    return False
-
-
-def _calls_form_entry_exit_pair(calls: List[ast.Call]) -> bool:
-    """True iff the collected submit_order calls plausibly form an
-    entry+exit pair on EVERY symbol they target.
-
-    The engine closes positions per-symbol — ``portfolio.positions[bar.symbol]``
-    is looked up against the order's own symbol — so a strategy that
-    opens ``LONG`` on ``"SPY"`` and ``SHORT`` on ``"TLT"`` has two
-    open entries and zero exits, not a balanced pair.
-
-    Grouping rules:
-
-    * Calls with literal-string ``symbol`` arguments form per-symbol
-      groups (one per distinct literal).
-    * Calls with dynamic / computed / missing ``symbol`` arguments are
-      pooled in a single "unknown" group, since within one ``on_bar``
-      invocation they all resolve to the same runtime symbol.
-    * Dynamic-symbol calls AUGMENT each literal-symbol group's pair
-      check: on a single-symbol run, a generated strategy may enter
-      with ``symbol=bar.symbol`` and exit with ``symbol="SPY"`` (or
-      vice versa), so the dynamic group's calls plausibly target each
-      literal symbol at runtime. Each literal group passes iff
-      ``literal_calls + dynamic_calls`` forms a valid pair.
-    * The dynamic group also passes on its own when no literal groups
-      exist (all calls dynamic).
-    """
-    literal_groups: Dict[str, List[ast.Call]] = {}
-    dynamic_calls: List[ast.Call] = []
-    for c in calls:
-        sym = _submit_order_symbol(c)
-        if sym is None:
-            dynamic_calls.append(c)
-        else:
-            literal_groups.setdefault(sym, []).append(c)
-
-    if not literal_groups:
-        return _group_forms_entry_exit_pair(dynamic_calls)
-
-    for group in literal_groups.values():
-        if not _group_forms_entry_exit_pair(group + dynamic_calls):
-            return False
-    return True
-
-
-def _has_attached_exit_kwarg(node: ast.Call) -> bool:
-    """True iff the call passes a non-None ``attached_stop_loss`` or
-    ``attached_take_profit``.
-
-    Bracket / OCO orders (issue #389) bundle the exit logic onto the entry
-    submission, so a single ``ctx.submit_order(..., attached_stop_loss=...)``
-    is a complete entry+exit pair. Explicit ``=None`` literals are
-    excluded — at the AST level ``kw.value`` is always an ``ast.AST``
-    node (e.g. ``ast.Constant(value=None)``), never a Python ``None``,
-    so the older ``kw.value is not None`` check would falsely accept
-    an explicit ``attached_stop_loss=None`` as a real bracket leg.
-    """
-    for kw in node.keywords:
-        if kw.arg not in ("attached_stop_loss", "attached_take_profit"):
-            continue
-        if isinstance(kw.value, ast.Constant) and kw.value.value is None:
-            continue
-        return True
-    return False
-
-
-def _find_strategy_subclasses(tree: ast.AST) -> List[ast.ClassDef]:
-    """Return every top-level class whose bases include a reference to
-    ``Strategy`` or ``contract.Strategy``.
-
-    We can't resolve inheritance across modules statically, so this is a
-    syntactic check — but the harness uses the same shape (``issubclass``
-    against the imported ``contract.Strategy``) and will agree with our
-    classification for any direct subclass defined in the module.
-    """
-    out: List[ast.ClassDef] = []
-    for node in ast.iter_child_nodes(tree):
-        if not isinstance(node, ast.ClassDef):
-            continue
-        for base in node.bases:
-            if isinstance(base, ast.Name) and base.id == "Strategy":
-                out.append(node)
-                break
-            if (
-                isinstance(base, ast.Attribute)
-                and base.attr == "Strategy"
-                and isinstance(base.value, ast.Name)
-                and base.value.id == "contract"
-            ):
-                out.append(node)
-                break
-    return out
-
-
-def _validate_on_bar(cls: ast.ClassDef) -> Optional[str]:
-    """Return a human-readable error string if ``cls`` lacks a usable
-    ``on_bar`` override, else ``None``.
-
-    The harness requires ``on_bar(self, ctx, bar)``. Missing the method is
-    allowed (the base class no-op runs and produces no trades — caught by
-    anomaly gates), but a wrong signature would crash at the first call
-    and deserves a clearer up-front error.
-    """
-    for node in ast.iter_child_nodes(cls):
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            continue
-        if node.name != "on_bar":
-            continue
-        if isinstance(node, ast.AsyncFunctionDef):
-            return (
-                "on_bar must be a regular (non-async) method — the harness calls "
-                "it synchronously once per finalised bar."
-            )
-        param_count = len(node.args.args)
-        if param_count != 3:
-            return (
-                f"{cls.name}.on_bar must accept exactly 3 parameters (self, ctx, bar); "
-                f"found {param_count}."
-            )
-        return None
-    # No on_bar override — the base class no-op would emit zero trades, so
-    # this is a critical failure (#547). CodeSafetyChecker.check wraps any
-    # non-None return here as severity="critical".
-    return (
-        f"{cls.name} does not override on_bar(self, ctx, bar); the base class "
-        "no-op will run and the strategy will emit zero trades."
-    )
-
-
-# Regex that matches Python comments and string literals (single/double,
-# triple-quoted, and raw strings).  Used to produce a "code-only" view
-# for look-ahead bias scanning so that examples in comments or docstrings
-# don't trigger false-positive critical failures.
-_COMMENTS_AND_STRINGS = re.compile(
-    r"#[^\n]*"  # line comments
-    r'|"""[\s\S]*?"""'  # triple-double-quoted strings
-    r"|'''[\s\S]*?'''"  # triple-single-quoted strings
-    r'|"(?:\\.|[^"\\])*"'  # double-quoted strings
-    r"|'(?:\\.|[^'\\])*'",  # single-quoted strings
-)
-
-
-def _strip_comments_and_strings(code: str) -> str:
-    """Replace comments and string literals with whitespace-equivalent placeholders."""
-    return _COMMENTS_AND_STRINGS.sub(lambda m: " " * len(m.group()), code)
-
-
-# ──────────────────────────────────────────────────────────────────────────
-# Issue #524 — symbol-universe guard detection
-# ──────────────────────────────────────────────────────────────────────────
-
-
-def _has_universe_constant(cls: ast.ClassDef) -> bool:
-    """True iff ``cls`` declares a class-level ``UNIVERSE`` bound to a
-    ``frozenset``/``set``/``tuple`` literal (or a set/list/tuple displayed
-    literal).
-
-    The boilerplate uses ``UNIVERSE = frozenset({"QQQ"})`` but LLMs vary —
-    ``set(...)``, ``{"QQQ"}`` (set literal), ``("QQQ",)``, and ``["QQQ"]``
-    are all accepted because the runtime guard only requires ``in``-able
-    membership. An empty literal is fine — when ``target_symbols`` is
-    non-empty the generation contract should produce a non-empty set, but
-    the gate's job is structural presence, not content equality (#526
-    will gate the runtime trade-vs-target match).
-    """
-    for node in ast.iter_child_nodes(cls):
-        if isinstance(node, ast.Assign):
-            for target in node.targets:
-                if isinstance(target, ast.Name) and target.id == "UNIVERSE":
-                    return _is_collection_literal_expr(node.value)
-        elif isinstance(node, ast.AnnAssign):
-            if isinstance(node.target, ast.Name) and node.target.id == "UNIVERSE":
-                return node.value is not None and _is_collection_literal_expr(node.value)
-    return False
-
-
-_COLLECTION_BUILDERS = frozenset({"frozenset", "set", "tuple", "list"})
-
-
-def _is_collection_literal_expr(value: ast.AST) -> bool:
-    """True iff ``value`` is a set/list/tuple display or a call to one of
-    the recognised collection builders (``frozenset(...)``, ``set(...)``,
-    ``tuple(...)``, ``list(...)``).
-    """
-    if isinstance(value, (ast.Set, ast.List, ast.Tuple)):
-        return True
-    if isinstance(value, ast.Call) and isinstance(value.func, ast.Name):
-        return value.func.id in _COLLECTION_BUILDERS
-    return False
-
-
-def _has_universe_guard_in_on_bar(cls: ast.ClassDef) -> bool:
-    """True iff ``on_bar`` contains an early-exit of the shape
-    ``if <name>.symbol not in self.UNIVERSE: return`` somewhere in its
-    top-level body.
-
-    Only ``on_bar`` is checked — the engine guards bar dispatch, so the
-    other hooks don't need the same predicate. The receiver-name on the
-    left is intentionally not pinned to ``bar``: the engine dispatches
-    positionally and ``on_bar(self, ctx, my_bar)`` is also valid. We
-    accept ``self.UNIVERSE`` and bare ``UNIVERSE`` on the right.
-    """
-    for node in ast.iter_child_nodes(cls):
-        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-            continue
-        if node.name != "on_bar":
-            continue
-        for stmt in node.body:
-            if _is_universe_guard_stmt(stmt):
-                return True
-        return False
-    return False
-
-
-def _is_universe_guard_stmt(stmt: ast.AST) -> bool:
-    """True iff ``stmt`` matches ``if <Name>.symbol not in {self.,}UNIVERSE: return``."""
-    if not isinstance(stmt, ast.If):
-        return False
-    test = stmt.test
-    if not (isinstance(test, ast.Compare) and len(test.ops) == 1):
-        return False
-    if not isinstance(test.ops[0], ast.NotIn):
-        return False
-    # Left side: <Name>.symbol
-    left = test.left
-    if not (
-        isinstance(left, ast.Attribute)
-        and left.attr == "symbol"
-        and isinstance(left.value, ast.Name)
-    ):
-        return False
-    # Right side: self.UNIVERSE or UNIVERSE
-    right = test.comparators[0]
-    if isinstance(right, ast.Attribute):
-        if not (
-            right.attr == "UNIVERSE"
-            and isinstance(right.value, ast.Name)
-            and right.value.id == "self"
-        ):
-            return False
-    elif isinstance(right, ast.Name):
-        if right.id != "UNIVERSE":
-            return False
-    else:
-        return False
-    # Body must contain a ``return`` (bare or ``return None``) as the first
-    # statement. ``return None`` is semantically identical to a bare
-    # ``return`` and some lint styles prefer it; both are accepted.
-    if not stmt.body:
-        return False
-    first = stmt.body[0]
-    if not isinstance(first, ast.Return):
-        return False
-    if first.value is None:
-        return True
-    return isinstance(first.value, ast.Constant) and first.value.value is None

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import ast
 import re
-from typing import Any, ClassVar, Dict, List, Optional
+from typing import Any, ClassVar, Dict, Iterable, List, Optional
 
 from .models import GateResultsMixin, QualityGateResult, StrategyLabPhase
 
@@ -103,7 +103,14 @@ _LOOKAHEAD_PATTERNS = [
 
 
 class CodeSafetyChecker(GateResultsMixin):
-    """Scan generated strategy code for unsafe patterns before subprocess execution."""
+    """Scan generated strategy code for unsafe patterns before subprocess execution.
+
+    Contract: every call to :meth:`check` returns a non-empty
+    ``List[QualityGateResult]``. Every entry carries the caller's ``phase``
+    and ``gate_name == GATE``. Rules are listed in ``_RULES`` and iterated in
+    order; a syntax-error short-circuit fires before any other rule because
+    the AST-based rules cannot run without a parse tree.
+    """
 
     GATE: ClassVar[str] = GATE
 
@@ -131,201 +138,245 @@ class CodeSafetyChecker(GateResultsMixin):
         default) keeps the legacy call sites and tests behaving as before.
         """
         self._set_phase(phase)
-        results: List[QualityGateResult] = []
-
-        # 1. Parse the code
+        # Parse first — a syntax error is a hard short-circuit because every
+        # AST rule below requires a tree.
         try:
             tree = ast.parse(code)
         except SyntaxError as e:
-            results.append(
-                self._critical(f"Code has a syntax error: {e}")
-            )
-            return results
+            return [self._critical(f"Code has a syntax error: {e}")]
 
-        # 2. Check the module defines exactly one contract.Strategy subclass
-        #    with a correctly-shaped ``on_bar`` method. The PR-3 streaming
-        #    harness requires this shape and raises at runtime otherwise;
-        #    flagging here turns a runtime classification error into an
-        #    actionable refinement hint.
-        strategy_classes = _find_strategy_subclasses(tree)
-        if len(strategy_classes) == 0:
-            results.append(
-                self._critical("Code must define exactly one subclass of contract.Strategy; "
-                        "none found. Use `from contract import Strategy` and `class "
-                        "MyStrategy(Strategy): ...`.")
-            )
-        elif len(strategy_classes) > 1:
-            names = ", ".join(sorted(c.name for c in strategy_classes))
-            results.append(
-                self._critical(f"Code defines multiple Strategy subclasses ({names}); the "
-                        "harness accepts exactly one.")
-            )
-        else:
-            strategy_cls = strategy_classes[0]
-            on_bar_issue = _validate_on_bar(strategy_cls)
-            if on_bar_issue is not None:
-                results.append(
-                    self._critical(on_bar_issue)
-                )
+        # Stash call-scoped context so each rule reads from instance state.
+        self._code = code
+        self._tree = tree
+        self._spec = spec
+        self._strategy_classes = _find_strategy_subclasses(tree)
+        self._executable = _strip_comments_and_strings(code)
+        try:
+            results = [r for rule in self._RULES for r in rule(self)]
+            return results or [self._info("Code passed all safety checks.")]
+        finally:
+            self._code = ""
+            self._tree = None  # type: ignore[assignment]
+            self._spec = None
+            self._strategy_classes = []
+            self._executable = ""
 
-        # 3. Walk AST for banned imports
-        for node in ast.walk(tree):
+    # ------------------------------------------------------------------
+    # Rules — each reads call-scoped state and yields zero or more results.
+    # ------------------------------------------------------------------
+    def _check_strategy_class_shape(self) -> Iterable[QualityGateResult]:
+        # The streaming harness requires exactly one Strategy subclass with a
+        # correctly-shaped ``on_bar``. Flagging here turns a runtime
+        # classification error into an actionable refinement hint.
+        n = len(self._strategy_classes)
+        if n == 0:
+            return (
+                self._critical(
+                    "Code must define exactly one subclass of contract.Strategy; "
+                    "none found. Use `from contract import Strategy` and `class "
+                    "MyStrategy(Strategy): ...`."
+                ),
+            )
+        if n > 1:
+            names = ", ".join(sorted(c.name for c in self._strategy_classes))
+            return (
+                self._critical(
+                    f"Code defines multiple Strategy subclasses ({names}); the "
+                    "harness accepts exactly one."
+                ),
+            )
+        on_bar_issue = _validate_on_bar(self._strategy_classes[0])
+        if on_bar_issue is not None:
+            return (self._critical(on_bar_issue),)
+        return ()
+
+    def _check_banned_imports(self) -> Iterable[QualityGateResult]:
+        out: List[QualityGateResult] = []
+        for node in ast.walk(self._tree):
             if isinstance(node, ast.Import):
                 for alias in node.names:
                     top_module = alias.name.split(".")[0]
                     if top_module in BANNED_IMPORTS:
-                        results.append(
-                            self._critical(f"Banned import: '{alias.name}' — network/filesystem/system access not allowed.")
+                        out.append(
+                            self._critical(
+                                f"Banned import: '{alias.name}' — "
+                                "network/filesystem/system access not allowed."
+                            )
                         )
                     elif top_module not in ALLOWED_IMPORTS:
-                        results.append(
-                            self._warning(f"Non-allowlisted import: '{alias.name}' — may not be available in sandbox.")
+                        out.append(
+                            self._warning(
+                                f"Non-allowlisted import: '{alias.name}' — "
+                                "may not be available in sandbox."
+                            )
                         )
-
-            elif isinstance(node, ast.ImportFrom):
-                if node.module:
-                    top_module = node.module.split(".")[0]
-                    if top_module in BANNED_IMPORTS:
-                        results.append(
-                            self._critical(f"Banned import: 'from {node.module}' — network/filesystem/system access not allowed.")
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                top_module = node.module.split(".")[0]
+                if top_module in BANNED_IMPORTS:
+                    out.append(
+                        self._critical(
+                            f"Banned import: 'from {node.module}' — "
+                            "network/filesystem/system access not allowed."
                         )
-                    elif top_module not in ALLOWED_IMPORTS:
-                        results.append(
-                            self._warning(f"Non-allowlisted import: 'from {node.module}' — may not be available in sandbox.")
+                    )
+                elif top_module not in ALLOWED_IMPORTS:
+                    out.append(
+                        self._warning(
+                            f"Non-allowlisted import: 'from {node.module}' — "
+                            "may not be available in sandbox."
                         )
+                    )
+        return out
 
-        # 4. Walk AST for banned function calls
-        for node in ast.walk(tree):
-            if isinstance(node, ast.Call):
-                func_name = _get_call_name(node)
-                if func_name in ("exec", "eval", "compile", "__import__", "globals", "breakpoint"):
-                    results.append(
-                        self._critical(f"Banned function call: '{func_name}()' — dynamic code execution not allowed.")
+    def _check_banned_calls(self) -> Iterable[QualityGateResult]:
+        out: List[QualityGateResult] = []
+        for node in ast.walk(self._tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func_name = _get_call_name(node)
+            if func_name in ("exec", "eval", "compile", "__import__", "globals", "breakpoint"):
+                out.append(
+                    self._critical(
+                        f"Banned function call: '{func_name}()' — "
+                        "dynamic code execution not allowed."
                     )
-                if func_name == "open":
-                    results.append(
-                        self._critical("Banned function call: 'open()' — file I/O not allowed in strategy code.")
+                )
+            if func_name == "open":
+                out.append(
+                    self._critical(
+                        "Banned function call: 'open()' — file I/O not allowed in strategy code."
                     )
-                if func_name in ("setattr", "delattr"):
-                    results.append(
-                        self._critical(f"Banned function call: '{func_name}()' — attribute manipulation not allowed.")
+                )
+            if func_name in ("setattr", "delattr"):
+                out.append(
+                    self._critical(
+                        f"Banned function call: '{func_name}()' — "
+                        "attribute manipulation not allowed."
                     )
+                )
+        return out
 
-        # 5. Regex fallback for patterns AST might miss
+    def _check_banned_call_regex(self) -> Iterable[QualityGateResult]:
+        # AST sometimes misses patterns hidden behind getattr / dynamic
+        # attribute access; the regex pass catches those.
+        out: List[QualityGateResult] = []
         for pattern in _BANNED_CALL_PATTERNS:
-            if pattern.search(code):
+            if pattern.search(self._code):
                 match_text = pattern.pattern.replace(r"\b", "").replace(r"\s*\(", "(")
-                results.append(
-                    self._critical(f"Regex detected banned pattern: '{match_text}'.")
-                )
+                out.append(self._critical(f"Regex detected banned pattern: '{match_text}'."))
+        return out
 
-        # 6. Look-ahead bias detection (run against executable code only,
-        #    excluding comments and string literals to avoid false positives)
-        executable = _strip_comments_and_strings(code)
+    def _check_lookahead_bias(self) -> Iterable[QualityGateResult]:
+        # Run against executable code only — comments and string literals are
+        # stripped to avoid false positives.
+        out: List[QualityGateResult] = []
         for pattern, reason in _LOOKAHEAD_PATTERNS:
-            if pattern.search(executable):
-                results.append(
-                    self._critical(f"Look-ahead bias: {reason}")
-                )
+            if pattern.search(self._executable):
+                out.append(self._critical(f"Look-ahead bias: {reason}"))
+        return out
 
-        # 7. Code length
-        line_count = len(code.splitlines())
+    def _check_code_length(self) -> Iterable[QualityGateResult]:
+        line_count = len(self._code.splitlines())
         if line_count > 1000:
-            results.append(
-                self._warning(f"Code is {line_count} lines — consider simplifying (limit: 1000).")
+            return (
+                self._warning(
+                    f"Code is {line_count} lines — consider simplifying (limit: 1000)."
+                ),
             )
+        return ()
 
-        # 8. Order-flow shape (#547): every viable strategy must call
-        #    ``ctx.submit_order(...)`` from inside ``on_bar`` (directly or
-        #    via a helper invoked from it), and the reachable calls must
-        #    form a real entry+exit pair — either two calls with distinct
-        #    ``side`` values, or a single call with a non-None
-        #    ``attached_stop_loss`` / ``attached_take_profit`` (bracket /
-        #    OCO support, #389).
+    def _check_order_flow_shape(self) -> Iterable[QualityGateResult]:
+        # Every viable strategy must call ``ctx.submit_order(...)`` from
+        # inside ``on_bar`` (directly or via a helper), and the reachable
+        # calls must form an entry+exit pair — either two calls with
+        # distinct ``side`` values, or a single call with a non-None
+        # ``attached_stop_loss`` / ``attached_take_profit`` bracket leg.
         #
-        #    * The trading service only processes the ``HarnessResponse``
-        #      from ``send_bar``; ``send_start`` / ``send_fill`` /
-        #      ``send_end`` responses are discarded today, so any
-        #      ``submit_order`` made from those hooks is dropped before
-        #      backtesting. The gate counts only ``on_bar``-reachable
-        #      calls to match the engine's real behaviour.
-        #    * ``on_bar`` accepts only its second positional parameter as
-        #      the context receiver (``def on_bar(self, ctx, bar):``
-        #      looks for ``ctx.submit_order``; a swapped
-        #      ``def on_bar(self, bar, ctx):`` accepts only ``bar`` and
-        #      ``ctx.submit_order`` would crash at runtime — flagged).
-        #    * Helpers reached via ``self.<method>(...)`` from ``on_bar``
-        #      relax the receiver check to any non-``self`` positional
-        #      parameter, since the call site we can't statically resolve
-        #      may pass the context through.
-        #    * Two ``side="LONG"`` calls do not form an entry+exit pair;
-        #      a real exit requires the opposite side or a bracket leg.
-        if len(strategy_classes) == 1:
-            hook_calls = _collect_hook_submit_calls(strategy_classes[0])
-            if len(hook_calls) == 0:
-                results.append(
-                    self._critical("No ctx.submit_order call reachable from on_bar — strategy "
-                            "has no entry path that the engine will process. The "
-                            "trading service only consumes orders submitted from "
-                            "on_bar (responses from on_start / on_fill / on_end are "
-                            "currently dropped), so any submission outside on_bar is "
-                            "silently ignored.")
-                )
-            elif not _calls_form_entry_exit_pair(hook_calls):
-                if len(hook_calls) == 1:
-                    detail = (
-                        "Only one ctx.submit_order call found in the engine hooks "
-                        "and no non-None attached bracket exit (attached_stop_loss "
-                        "/ attached_take_profit) — strategy has no exit path."
-                    )
-                else:
-                    detail = (
-                        "Multiple ctx.submit_order calls found but all use the same "
-                        "OrderSide and no bracket exit is attached — strategy has no "
-                        "real exit leg. Closing a position requires submitting the "
-                        "opposite OrderSide (LONG closes SHORT, SHORT closes LONG) or "
-                        "attaching an attached_stop_loss / attached_take_profit "
-                        "bracket leg."
-                    )
-                results.append(
-                    self._critical(detail)
-                )
-
-        # 9. Symbol-universe guard (#524). When ``spec.target_symbols`` is
-        #    non-empty, the generated module MUST declare a class-level
-        #    ``UNIVERSE`` set/frozenset and guard ``on_bar`` with
-        #    ``if bar.symbol not in self.UNIVERSE: return``. The historical
-        #    replay stream interleaves bars across every fetched symbol;
-        #    without this guard a permissive predicate trades whichever
-        #    ticker fires first, not the one named in the hypothesis.
-        if spec is not None and getattr(spec, "target_symbols", None):
-            if len(strategy_classes) == 1:
-                strategy_cls = strategy_classes[0]
-                if not _has_universe_constant(strategy_cls):
-                    results.append(
-                        self._critical("Spec has non-empty target_symbols but the strategy "
-                                "class is missing a UNIVERSE = frozenset({...}) (or "
-                                "set/tuple) class-level constant. Without UNIVERSE + "
-                                "an `if bar.symbol not in self.UNIVERSE: return` guard "
-                                "at the top of on_bar, the historical replay stream "
-                                "will feed bars for every fetched symbol to the "
-                                "signal logic and trades will land on the wrong asset.")
-                    )
-                elif not _has_universe_guard_in_on_bar(strategy_cls):
-                    results.append(
-                        self._critical("Strategy defines UNIVERSE but on_bar is missing the "
-                                "`if bar.symbol not in self.UNIVERSE: return` guard. "
-                                "Without the early-exit, the historical replay stream "
-                                "will deliver bars for every fetched symbol and the "
-                                "signal logic will trade tickers outside target_symbols.")
-                    )
-
-        if not results:
-            results.append(
-                self._info("Code passed all safety checks.")
+        # The trading service only processes ``HarnessResponse`` from
+        # ``send_bar``; responses from ``send_start`` / ``send_fill`` /
+        # ``send_end`` are discarded, so submissions outside ``on_bar`` are
+        # silently dropped — they don't count here.
+        if len(self._strategy_classes) != 1:
+            return ()
+        hook_calls = _collect_hook_submit_calls(self._strategy_classes[0])
+        if not hook_calls:
+            return (
+                self._critical(
+                    "No ctx.submit_order call reachable from on_bar — strategy "
+                    "has no entry path that the engine will process. The "
+                    "trading service only consumes orders submitted from "
+                    "on_bar (responses from on_start / on_fill / on_end are "
+                    "currently dropped), so any submission outside on_bar is "
+                    "silently ignored."
+                ),
             )
+        if _calls_form_entry_exit_pair(hook_calls):
+            return ()
+        if len(hook_calls) == 1:
+            detail = (
+                "Only one ctx.submit_order call found in the engine hooks "
+                "and no non-None attached bracket exit (attached_stop_loss "
+                "/ attached_take_profit) — strategy has no exit path."
+            )
+        else:
+            detail = (
+                "Multiple ctx.submit_order calls found but all use the same "
+                "OrderSide and no bracket exit is attached — strategy has no "
+                "real exit leg. Closing a position requires submitting the "
+                "opposite OrderSide (LONG closes SHORT, SHORT closes LONG) or "
+                "attaching an attached_stop_loss / attached_take_profit "
+                "bracket leg."
+            )
+        return (self._critical(detail),)
 
-        return results
+    def _check_universe_guard(self) -> Iterable[QualityGateResult]:
+        # When ``spec.target_symbols`` is non-empty the generated module MUST
+        # declare a class-level ``UNIVERSE`` set/frozenset and guard ``on_bar``
+        # with ``if bar.symbol not in self.UNIVERSE: return``. The historical
+        # replay stream interleaves bars across every fetched symbol; without
+        # this guard a permissive predicate trades whichever ticker fires
+        # first, not the one named in the hypothesis.
+        if self._spec is None or not getattr(self._spec, "target_symbols", None):
+            return ()
+        if len(self._strategy_classes) != 1:
+            return ()
+        strategy_cls = self._strategy_classes[0]
+        if not _has_universe_constant(strategy_cls):
+            return (
+                self._critical(
+                    "Spec has non-empty target_symbols but the strategy "
+                    "class is missing a UNIVERSE = frozenset({...}) (or "
+                    "set/tuple) class-level constant. Without UNIVERSE + "
+                    "an `if bar.symbol not in self.UNIVERSE: return` guard "
+                    "at the top of on_bar, the historical replay stream "
+                    "will feed bars for every fetched symbol to the "
+                    "signal logic and trades will land on the wrong asset."
+                ),
+            )
+        if not _has_universe_guard_in_on_bar(strategy_cls):
+            return (
+                self._critical(
+                    "Strategy defines UNIVERSE but on_bar is missing the "
+                    "`if bar.symbol not in self.UNIVERSE: return` guard. "
+                    "Without the early-exit, the historical replay stream "
+                    "will deliver bars for every fetched symbol and the "
+                    "signal logic will trade tickers outside target_symbols."
+                ),
+            )
+        return ()
+
+    # Rules iterated in order by ``check``. Order is preserved so error
+    # messages remain stable across runs.
+    _RULES: ClassVar[tuple] = (
+        _check_strategy_class_shape,
+        _check_banned_imports,
+        _check_banned_calls,
+        _check_banned_call_regex,
+        _check_lookahead_bias,
+        _check_code_length,
+        _check_order_flow_shape,
+        _check_universe_guard,
+    )
 
 
 def _get_call_name(node: ast.Call) -> str:

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety.py
@@ -124,6 +124,7 @@ class CodeSafetyChecker:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="synthesis",
                     passed=False,
                     severity="critical",
                     details=f"Code has a syntax error: {e}",
@@ -141,6 +142,7 @@ class CodeSafetyChecker:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="synthesis",
                     passed=False,
                     severity="critical",
                     details=(
@@ -155,6 +157,7 @@ class CodeSafetyChecker:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="synthesis",
                     passed=False,
                     severity="critical",
                     details=(
@@ -170,6 +173,7 @@ class CodeSafetyChecker:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
+                        phase="synthesis",
                         passed=False,
                         severity="critical",
                         details=on_bar_issue,
@@ -185,6 +189,7 @@ class CodeSafetyChecker:
                         results.append(
                             QualityGateResult(
                                 gate_name=GATE,
+                                phase="synthesis",
                                 passed=False,
                                 severity="critical",
                                 details=f"Banned import: '{alias.name}' — network/filesystem/system access not allowed.",
@@ -194,6 +199,7 @@ class CodeSafetyChecker:
                         results.append(
                             QualityGateResult(
                                 gate_name=GATE,
+                                phase="synthesis",
                                 passed=False,
                                 severity="warning",
                                 details=f"Non-allowlisted import: '{alias.name}' — may not be available in sandbox.",
@@ -207,6 +213,7 @@ class CodeSafetyChecker:
                         results.append(
                             QualityGateResult(
                                 gate_name=GATE,
+                                phase="synthesis",
                                 passed=False,
                                 severity="critical",
                                 details=f"Banned import: 'from {node.module}' — network/filesystem/system access not allowed.",
@@ -216,6 +223,7 @@ class CodeSafetyChecker:
                         results.append(
                             QualityGateResult(
                                 gate_name=GATE,
+                                phase="synthesis",
                                 passed=False,
                                 severity="warning",
                                 details=f"Non-allowlisted import: 'from {node.module}' — may not be available in sandbox.",
@@ -230,6 +238,7 @@ class CodeSafetyChecker:
                     results.append(
                         QualityGateResult(
                             gate_name=GATE,
+                            phase="synthesis",
                             passed=False,
                             severity="critical",
                             details=f"Banned function call: '{func_name}()' — dynamic code execution not allowed.",
@@ -239,6 +248,7 @@ class CodeSafetyChecker:
                     results.append(
                         QualityGateResult(
                             gate_name=GATE,
+                            phase="synthesis",
                             passed=False,
                             severity="critical",
                             details="Banned function call: 'open()' — file I/O not allowed in strategy code.",
@@ -248,6 +258,7 @@ class CodeSafetyChecker:
                     results.append(
                         QualityGateResult(
                             gate_name=GATE,
+                            phase="synthesis",
                             passed=False,
                             severity="critical",
                             details=f"Banned function call: '{func_name}()' — attribute manipulation not allowed.",
@@ -261,6 +272,7 @@ class CodeSafetyChecker:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
+                        phase="synthesis",
                         passed=False,
                         severity="critical",
                         details=f"Regex detected banned pattern: '{match_text}'.",
@@ -275,6 +287,7 @@ class CodeSafetyChecker:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
+                        phase="synthesis",
                         passed=False,
                         severity="critical",
                         details=f"Look-ahead bias: {reason}",
@@ -287,6 +300,7 @@ class CodeSafetyChecker:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="synthesis",
                     passed=False,
                     severity="warning",
                     details=f"Code is {line_count} lines — consider simplifying (limit: 1000).",
@@ -324,6 +338,7 @@ class CodeSafetyChecker:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
+                        phase="synthesis",
                         passed=False,
                         severity="critical",
                         details=(
@@ -355,6 +370,7 @@ class CodeSafetyChecker:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
+                        phase="synthesis",
                         passed=False,
                         severity="critical",
                         details=detail,
@@ -375,6 +391,7 @@ class CodeSafetyChecker:
                     results.append(
                         QualityGateResult(
                             gate_name=GATE,
+                            phase="synthesis",
                             passed=False,
                             severity="critical",
                             details=(
@@ -392,6 +409,7 @@ class CodeSafetyChecker:
                     results.append(
                         QualityGateResult(
                             gate_name=GATE,
+                            phase="synthesis",
                             passed=False,
                             severity="critical",
                             details=(
@@ -408,6 +426,7 @@ class CodeSafetyChecker:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="synthesis",
                     passed=True,
                     severity="info",
                     details="Code passed all safety checks.",

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_safety_ast.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_safety_ast.py
@@ -1,0 +1,665 @@
+"""AST + regex helpers backing the rules in :mod:`code_safety`.
+
+These helpers are pure functions over ``ast`` / source text. They live in
+their own module so :mod:`code_safety` can stay focused on the gate's rule
+set and registry, and so the AST analysis (alias tracking, closure descent,
+universe-guard pattern matching) has its own testable boundary.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from typing import Dict, List, Optional
+
+# Regex patterns for dangerous calls that AST analysis might miss in edge cases.
+_BANNED_CALL_PATTERNS = [
+    re.compile(r"\bexec\s*\("),
+    re.compile(r"\beval\s*\("),
+    re.compile(r"\bcompile\s*\("),
+    re.compile(r"\b__import__\s*\("),
+    re.compile(r"\bglobals\s*\("),
+    re.compile(r"\bbreakpoint\s*\("),
+]
+
+# Look-ahead bias patterns — accessing future data from within the
+# ``Strategy`` subclass. Most look-ahead is structurally impossible in the
+# event-driven contract (``ctx`` has no accessor for future data, and
+# ``AttributeError`` on a forward field is trapped as ``lookahead_violation``
+# at runtime), but these regexes catch obvious tripwires before the code
+# even runs.
+_LOOKAHEAD_PATTERNS = [
+    (
+        re.compile(r"\bctx\s*\.\s*future_\w+"),
+        "ctx.future_* does not exist — use only ctx.history(symbol, n)",
+    ),
+    (
+        re.compile(r"\bbar\s*\.\s*(?:next|future)_\w+"),
+        "bar.next_* / bar.future_* does not exist — only current-bar fields are delivered",
+    ),
+    (
+        re.compile(r"\bctx\s*\.\s*peek\b"),
+        "ctx.peek(...) does not exist — the engine does not expose forward bars",
+    ),
+]
+
+def _get_call_name(node: ast.Call) -> str:
+    """Extract the function name from a Call node (handles simple names and attribute access)."""
+    if isinstance(node.func, ast.Name):
+        return node.func.id
+    if isinstance(node.func, ast.Attribute):
+        return node.func.attr
+    return ""
+
+
+# Hook methods whose ``submit_order`` calls actually reach the engine.
+#
+# The streaming harness sends every hook (``on_start`` / ``on_bar`` /
+# ``on_fill`` / ``on_end``) to the strategy subprocess, but the trading
+# service ONLY processes the ``HarnessResponse`` returned from ``send_bar``
+# into pending orders (see ``trading_service/service.py``). The responses
+# from ``send_start`` (line 483-489), ``send_fill`` (line 637-641), and
+# ``send_end`` (line 1114) are discarded, so any ``submit_order`` made
+# from those hooks is dropped before backtesting. The order-flow gate
+# only credits ``on_bar`` calls — matching the engine's real behaviour
+# avoids passing strategies that would silently emit zero trades.
+_PROCESSED_HOOK_METHODS = frozenset({"on_bar"})
+
+
+def _iter_method_body_nodes(method: ast.FunctionDef | ast.AsyncFunctionDef):
+    """Yield every AST node in ``method``'s body without descending into
+    nested ``def`` / ``async def`` / ``lambda`` / ``class`` bodies.
+
+    Python only creates the function/class object for a nested
+    declaration; its body never runs unless something explicitly invokes
+    it. Naïvely using ``ast.walk(method)`` would treat ``submit_order``
+    calls inside an uninvoked local helper inside the hook as reachable,
+    which is wrong — those calls never reach the runtime engine.
+    """
+    stack: List[ast.AST] = list(method.body)
+    while stack:
+        node = stack.pop()
+        yield node
+        # Stop descent at any nested function / class / lambda boundary —
+        # its body is a new scope that only runs if explicitly invoked.
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)):
+            continue
+        for child in ast.iter_child_nodes(node):
+            stack.append(child)
+
+
+def _iter_method_body_in_source_order(scope: ast.AST):
+    """Yield every node in ``scope``'s body in source order, without
+    descending into nested ``def`` / ``class`` / ``lambda`` bodies.
+
+    Unlike :func:`_iter_method_body_nodes` (stack-based, arbitrary
+    pop order), this generator visits parent statements before their
+    children and processes sibling statements in declaration order.
+    The flow-sensitive alias tracker depends on this ordering so a
+    ``trade_ctx = ctx`` assignment updates state BEFORE later
+    ``trade_ctx.submit_order(...)`` calls are visited.
+    """
+    body = getattr(scope, "body", None)
+    if not isinstance(body, list):
+        return
+
+    def visit(node: ast.AST):
+        yield node
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)):
+            return
+        for child in ast.iter_child_nodes(node):
+            yield from visit(child)
+
+    for stmt in body:
+        yield from visit(stmt)
+
+
+def _find_nested_def_defs(
+    method: ast.FunctionDef | ast.AsyncFunctionDef,
+) -> Dict[str, ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Return a name → def map for every nested function defined directly
+    inside ``method``'s body (any depth, but not inside another nested
+    def or class).
+
+    These are local closures: ``def enter(): ctx.submit_order(...)`` style
+    helpers. When the outer scope explicitly calls them by name, the
+    engine reaches their body — so the order-flow walker needs to descend.
+    """
+    local_defs: Dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
+    # Walk method's body but stop at nested def/class boundaries so we
+    # collect only the immediate closures of this scope (not closures of
+    # closures).
+    for node in _iter_method_body_nodes(method):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            local_defs.setdefault(node.name, node)
+    return local_defs
+
+
+def _resolve_helper_receivers(
+    call: ast.Call,
+    helper: ast.FunctionDef | ast.AsyncFunctionDef,
+    outer_receivers: frozenset[str],
+) -> frozenset[str]:
+    """Return the helper parameter names that are bound to the outer
+    scope's context at the call site.
+
+    For ``self._trade(ctx, bar)`` where the outer scope's
+    ``receiver_names`` is ``{"ctx"}``: the first positional after self
+    in ``_trade``'s signature receives ``ctx``, so its name (e.g.
+    ``ctx`` or whatever the helper named that parameter) goes into the
+    returned set. Calls that don't pass any outer-receiver name as an
+    argument end up with an empty set — a ``submit_order`` inside such
+    a helper does NOT satisfy the gate.
+
+    Both positional and keyword arguments are tracked. Star-args /
+    keyword-spreads are ignored (rare in strategy code).
+    """
+    helper_params = [arg.arg for arg in helper.args.args if arg.arg != "self"]
+    bound: set[str] = set()
+
+    # Positional arguments — match against helper params by index.
+    for idx, arg in enumerate(call.args):
+        if idx >= len(helper_params):
+            break
+        if isinstance(arg, ast.Name) and arg.id in outer_receivers:
+            bound.add(helper_params[idx])
+
+    # Keyword arguments — match the parameter the keyword names.
+    for kw in call.keywords:
+        if kw.arg is None:
+            # **kwargs spread — can't statically resolve.
+            continue
+        if (
+            isinstance(kw.value, ast.Name)
+            and kw.value.id in outer_receivers
+            and kw.arg in helper_params
+        ):
+            bound.add(kw.arg)
+
+    return frozenset(bound)
+
+
+def _collect_hook_submit_calls(cls: ast.ClassDef) -> List[ast.Call]:
+    """Return every ``submit_order(...)`` call reachable from ``on_bar``.
+
+    ``on_bar`` is the only engine hook whose ``HarnessResponse`` is
+    actually processed into pending orders by the trading service
+    (``send_start`` / ``send_fill`` / ``send_end`` are called without
+    consuming their responses, so any ``submit_order`` made from those
+    hooks is silently dropped). Limiting the gate's roots to ``on_bar``
+    matches the engine's real behaviour.
+
+    The walker follows three kinds of edges from each reachable scope:
+
+    * ``self.<method>(...)`` — descends into class methods. The helper
+      has its own parameter list; we relax the receiver check to any
+      non-``self`` positional parameter since the call site can pass
+      the context through any of them.
+    * ``<local_name>(...)`` — descends into local closures defined in
+      the SAME scope (e.g. ``def enter(): ctx.submit_order(...)`` then
+      ``enter()`` inside ``on_bar``). Local closures inherit the outer
+      scope's bindings, so they keep the OUTER scope's receiver names
+      rather than introducing their own (the closure captures ``ctx``
+      from the enclosing frame).
+
+    Walks each scope's body but stops at nested ``def`` / ``class`` /
+    ``lambda`` boundaries — bodies of locally-defined-but-uninvoked
+    helpers are not reachable because Python only creates the function
+    object and never executes the body without a call.
+
+    ``on_bar`` is dispatched positionally, so only its second positional
+    parameter is the StrategyContext.
+    """
+    methods_by_name: Dict[str, ast.FunctionDef | ast.AsyncFunctionDef] = {}
+    for node in ast.iter_child_nodes(cls):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            methods_by_name[node.name] = node
+
+    calls: List[ast.Call] = []
+    # Visit key is (id(scope), receiver_names) so a helper called twice
+    # with different bindings (e.g. ``self._trade(bar)`` then
+    # ``self._trade(ctx)``) is analyzed once per distinct binding rather
+    # than getting masked by the first visit.
+    visited_keys: set[tuple[int, frozenset[str]]] = set()
+    # Worklist entries: (scope_node, receiver_names). receiver_names is
+    # the set of identifiers we accept as the context receiver inside
+    # this scope's body — for hooks, the second positional; for class
+    # helpers, parameters bound at the call site; for local closures,
+    # call-site-bound parameters PLUS the outer scope's receivers (the
+    # closure also captures them from the enclosing frame).
+    worklist: List[tuple[ast.AST, frozenset[str]]] = []
+    for name, m in methods_by_name.items():
+        if name in _PROCESSED_HOOK_METHODS:
+            if len(m.args.args) >= 2:
+                worklist.append((m, frozenset({m.args.args[1].arg})))
+
+    while worklist:
+        scope, initial_receivers = worklist.pop()
+        visit_key = (id(scope), initial_receivers)
+        if visit_key in visited_keys:
+            continue
+        visited_keys.add(visit_key)
+
+        # Local closures defined directly in this scope — followed only
+        # when their name is invoked below.
+        local_defs = (
+            _find_nested_def_defs(scope)
+            if isinstance(scope, (ast.FunctionDef, ast.AsyncFunctionDef))
+            else {}
+        )
+
+        # Flow-sensitive walk. ``state`` tracks the currently-live alias
+        # set as we proceed through the scope in source order. The walker
+        # updates it as it encounters ``Assign`` / ``AnnAssign`` events,
+        # so a ``submit_order`` call is credited only when the alias was
+        # bound to a known receiver at or before the call's source
+        # position — calls before a ``trade_ctx = ctx`` assignment, and
+        # calls after a later ``trade_ctx = something_else`` rebind, no
+        # longer pick up the alias.
+        state: set[str] = set(initial_receivers)
+
+        for sub in _iter_method_body_in_source_order(scope):
+            # Update alias state on simple name-to-name assignments.
+            if (
+                isinstance(sub, ast.Assign)
+                and len(sub.targets) == 1
+                and isinstance(sub.targets[0], ast.Name)
+            ):
+                target = sub.targets[0].id
+                if isinstance(sub.value, ast.Name) and sub.value.id in state:
+                    state.add(target)
+                elif target in state:
+                    # Rebound to a non-receiver expression — drop the alias.
+                    state.discard(target)
+                continue
+            if isinstance(sub, ast.AnnAssign) and isinstance(sub.target, ast.Name):
+                target = sub.target.id
+                if isinstance(sub.value, ast.Name) and sub.value.id in state:
+                    state.add(target)
+                elif target in state:
+                    state.discard(target)
+                continue
+
+            if not isinstance(sub, ast.Call):
+                continue
+
+            current_receivers = frozenset(state)
+
+            # 1. <ctx>.submit_order(...) — the order we count.
+            if (
+                isinstance(sub.func, ast.Attribute)
+                and sub.func.attr == "submit_order"
+                and isinstance(sub.func.value, ast.Name)
+                and sub.func.value.id in current_receivers
+            ):
+                calls.append(sub)
+                continue
+            # 2. self.<helper>(...) — class method. The helper's accepted
+            #    receivers are bound to the call-site arguments: only
+            #    parameters that received a name from the OUTER scope's
+            #    live receivers are treated as ctx-bound.
+            if (
+                isinstance(sub.func, ast.Attribute)
+                and isinstance(sub.func.value, ast.Name)
+                and sub.func.value.id == "self"
+            ):
+                helper = methods_by_name.get(sub.func.attr)
+                if helper is not None:
+                    helper_receivers = _resolve_helper_receivers(sub, helper, current_receivers)
+                    if (id(helper), helper_receivers) not in visited_keys:
+                        worklist.append((helper, helper_receivers))
+                continue
+            # 3. <local_name>(...) — closure defined in the same scope.
+            #    Closures see two sources of context bindings:
+            #    - Parameters bound at the call site (``def enter(c): ...;
+            #      enter(ctx)`` binds ``c`` to ``ctx``).
+            #    - Outer-scope captures (``def enter(): ctx.submit_order(
+            #      ...)`` references the enclosing frame's live receivers).
+            #    Captured names are visible only when the closure does
+            #    NOT shadow them with its own parameter — ``def
+            #    enter(ctx): ...; enter(bar)`` rebinds ``ctx`` to ``bar``,
+            #    so the outer ``ctx`` is no longer reachable inside.
+            if isinstance(sub.func, ast.Name):
+                local = local_defs.get(sub.func.id)
+                if local is not None:
+                    call_bound = _resolve_helper_receivers(sub, local, current_receivers)
+                    closure_param_names = frozenset(
+                        arg.arg for arg in local.args.args if arg.arg != "self"
+                    )
+                    captured = current_receivers - closure_param_names
+                    closure_receivers = captured | call_bound
+                    if (id(local), closure_receivers) not in visited_keys:
+                        worklist.append((local, closure_receivers))
+
+    return calls
+
+
+# Recognised ``OrderSide`` literal values. The runtime contract
+# (``trading_service.strategy.contract.OrderSide``) defines exactly two
+# enum members — ``LONG`` and ``SHORT`` — and ``StrategyContext.submit_order``
+# coerces with ``OrderSide(side)``. ``FLAT`` / ``CLOSE`` / ``BUY`` / ``SELL``
+# literals would crash at runtime, so they are NOT recognised here; the
+# gate treats them as "unknown" and lets the downstream backtest surface
+# the real validation error.
+_RECOGNISED_SIDES = frozenset({"LONG", "SHORT"})
+
+
+def _submit_order_side(node: ast.Call) -> Optional[str]:
+    """Best-effort extraction of the ``side`` value from a submit_order call.
+
+    Returns an upper-cased string when the call uses a recognised
+    ``OrderSide`` literal form, else None when the side is dynamic / a
+    non-OrderSide literal / can't be determined statically.
+    """
+    for kw in node.keywords:
+        if kw.arg != "side":
+            continue
+        val = kw.value
+        if isinstance(val, ast.Constant) and isinstance(val.value, str):
+            upper = val.value.upper()
+            return upper if upper in _RECOGNISED_SIDES else None
+        if isinstance(val, ast.Attribute):
+            upper = val.attr.upper()
+            return upper if upper in _RECOGNISED_SIDES else None
+    return None
+
+
+def _submit_order_symbol(node: ast.Call) -> Optional[str]:
+    """Best-effort extraction of the ``symbol`` value from a submit_order
+    call. Returns the literal string when the call uses a string Constant,
+    else None when the symbol is computed/dynamic or missing.
+
+    Dynamic-symbol calls (``symbol=bar.symbol`` etc.) all share the same
+    runtime symbol per ``on_bar`` invocation, so the entry/exit grouping
+    treats them as one logical group (key=None).
+    """
+    for kw in node.keywords:
+        if kw.arg != "symbol":
+            continue
+        if isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, str):
+            return kw.value.value
+    return None
+
+
+def _group_forms_entry_exit_pair(calls: List[ast.Call]) -> bool:
+    """True iff a single-symbol group of submit_order calls plausibly
+    contains both an entry and an opposite-side exit leg.
+
+    * Any call carrying a non-None ``attached_stop_loss`` /
+      ``attached_take_profit`` bracket leg satisfies the group on its own.
+    * Otherwise require both ``LONG`` and ``SHORT`` to appear across the
+      group's calls. Same-side multiplicity (``LONG`` + ``LONG``) fails.
+    * Unknown / dynamic side values are treated optimistically — the
+      runtime branch may pick either direction.
+    """
+    if any(_has_attached_exit_kwarg(c) for c in calls):
+        return True
+    sides_seen: set[str] = set()
+    has_unknown = False
+    for c in calls:
+        side = _submit_order_side(c)
+        if side is None:
+            has_unknown = True
+        else:
+            sides_seen.add(side)
+    if "LONG" in sides_seen and "SHORT" in sides_seen:
+        return True
+    if has_unknown:
+        return True
+    return False
+
+
+def _calls_form_entry_exit_pair(calls: List[ast.Call]) -> bool:
+    """True iff the collected submit_order calls plausibly form an
+    entry+exit pair on EVERY symbol they target.
+
+    The engine closes positions per-symbol — ``portfolio.positions[bar.symbol]``
+    is looked up against the order's own symbol — so a strategy that
+    opens ``LONG`` on ``"SPY"`` and ``SHORT`` on ``"TLT"`` has two
+    open entries and zero exits, not a balanced pair.
+
+    Grouping rules:
+
+    * Calls with literal-string ``symbol`` arguments form per-symbol
+      groups (one per distinct literal).
+    * Calls with dynamic / computed / missing ``symbol`` arguments are
+      pooled in a single "unknown" group, since within one ``on_bar``
+      invocation they all resolve to the same runtime symbol.
+    * Dynamic-symbol calls AUGMENT each literal-symbol group's pair
+      check: on a single-symbol run, a generated strategy may enter
+      with ``symbol=bar.symbol`` and exit with ``symbol="SPY"`` (or
+      vice versa), so the dynamic group's calls plausibly target each
+      literal symbol at runtime. Each literal group passes iff
+      ``literal_calls + dynamic_calls`` forms a valid pair.
+    * The dynamic group also passes on its own when no literal groups
+      exist (all calls dynamic).
+    """
+    literal_groups: Dict[str, List[ast.Call]] = {}
+    dynamic_calls: List[ast.Call] = []
+    for c in calls:
+        sym = _submit_order_symbol(c)
+        if sym is None:
+            dynamic_calls.append(c)
+        else:
+            literal_groups.setdefault(sym, []).append(c)
+
+    if not literal_groups:
+        return _group_forms_entry_exit_pair(dynamic_calls)
+
+    for group in literal_groups.values():
+        if not _group_forms_entry_exit_pair(group + dynamic_calls):
+            return False
+    return True
+
+
+def _has_attached_exit_kwarg(node: ast.Call) -> bool:
+    """True iff the call passes a non-None ``attached_stop_loss`` or
+    ``attached_take_profit``.
+
+    Bracket / OCO orders (issue #389) bundle the exit logic onto the entry
+    submission, so a single ``ctx.submit_order(..., attached_stop_loss=...)``
+    is a complete entry+exit pair. Explicit ``=None`` literals are
+    excluded — at the AST level ``kw.value`` is always an ``ast.AST``
+    node (e.g. ``ast.Constant(value=None)``), never a Python ``None``,
+    so the older ``kw.value is not None`` check would falsely accept
+    an explicit ``attached_stop_loss=None`` as a real bracket leg.
+    """
+    for kw in node.keywords:
+        if kw.arg not in ("attached_stop_loss", "attached_take_profit"):
+            continue
+        if isinstance(kw.value, ast.Constant) and kw.value.value is None:
+            continue
+        return True
+    return False
+
+
+def _find_strategy_subclasses(tree: ast.AST) -> List[ast.ClassDef]:
+    """Return every top-level class whose bases include a reference to
+    ``Strategy`` or ``contract.Strategy``.
+
+    We can't resolve inheritance across modules statically, so this is a
+    syntactic check — but the harness uses the same shape (``issubclass``
+    against the imported ``contract.Strategy``) and will agree with our
+    classification for any direct subclass defined in the module.
+    """
+    out: List[ast.ClassDef] = []
+    for node in ast.iter_child_nodes(tree):
+        if not isinstance(node, ast.ClassDef):
+            continue
+        for base in node.bases:
+            if isinstance(base, ast.Name) and base.id == "Strategy":
+                out.append(node)
+                break
+            if (
+                isinstance(base, ast.Attribute)
+                and base.attr == "Strategy"
+                and isinstance(base.value, ast.Name)
+                and base.value.id == "contract"
+            ):
+                out.append(node)
+                break
+    return out
+
+
+def _validate_on_bar(cls: ast.ClassDef) -> Optional[str]:
+    """Return a human-readable error string if ``cls`` lacks a usable
+    ``on_bar`` override, else ``None``.
+
+    The harness requires ``on_bar(self, ctx, bar)``. Missing the method is
+    allowed (the base class no-op runs and produces no trades — caught by
+    anomaly gates), but a wrong signature would crash at the first call
+    and deserves a clearer up-front error.
+    """
+    for node in ast.iter_child_nodes(cls):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name != "on_bar":
+            continue
+        if isinstance(node, ast.AsyncFunctionDef):
+            return (
+                "on_bar must be a regular (non-async) method — the harness calls "
+                "it synchronously once per finalised bar."
+            )
+        param_count = len(node.args.args)
+        if param_count != 3:
+            return (
+                f"{cls.name}.on_bar must accept exactly 3 parameters (self, ctx, bar); "
+                f"found {param_count}."
+            )
+        return None
+    # No on_bar override — the base class no-op would emit zero trades, so
+    # this is a critical failure (#547). CodeSafetyChecker.check wraps any
+    # non-None return here as severity="critical".
+    return (
+        f"{cls.name} does not override on_bar(self, ctx, bar); the base class "
+        "no-op will run and the strategy will emit zero trades."
+    )
+
+
+# Regex that matches Python comments and string literals (single/double,
+# triple-quoted, and raw strings).  Used to produce a "code-only" view
+# for look-ahead bias scanning so that examples in comments or docstrings
+# don't trigger false-positive critical failures.
+_COMMENTS_AND_STRINGS = re.compile(
+    r"#[^\n]*"  # line comments
+    r'|"""[\s\S]*?"""'  # triple-double-quoted strings
+    r"|'''[\s\S]*?'''"  # triple-single-quoted strings
+    r'|"(?:\\.|[^"\\])*"'  # double-quoted strings
+    r"|'(?:\\.|[^'\\])*'",  # single-quoted strings
+)
+
+
+def _strip_comments_and_strings(code: str) -> str:
+    """Replace comments and string literals with whitespace-equivalent placeholders."""
+    return _COMMENTS_AND_STRINGS.sub(lambda m: " " * len(m.group()), code)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Issue #524 — symbol-universe guard detection
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def _has_universe_constant(cls: ast.ClassDef) -> bool:
+    """True iff ``cls`` declares a class-level ``UNIVERSE`` bound to a
+    ``frozenset``/``set``/``tuple`` literal (or a set/list/tuple displayed
+    literal).
+
+    The boilerplate uses ``UNIVERSE = frozenset({"QQQ"})`` but LLMs vary —
+    ``set(...)``, ``{"QQQ"}`` (set literal), ``("QQQ",)``, and ``["QQQ"]``
+    are all accepted because the runtime guard only requires ``in``-able
+    membership. An empty literal is fine — when ``target_symbols`` is
+    non-empty the generation contract should produce a non-empty set, but
+    the gate's job is structural presence, not content equality (#526
+    will gate the runtime trade-vs-target match).
+    """
+    for node in ast.iter_child_nodes(cls):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "UNIVERSE":
+                    return _is_collection_literal_expr(node.value)
+        elif isinstance(node, ast.AnnAssign):
+            if isinstance(node.target, ast.Name) and node.target.id == "UNIVERSE":
+                return node.value is not None and _is_collection_literal_expr(node.value)
+    return False
+
+
+_COLLECTION_BUILDERS = frozenset({"frozenset", "set", "tuple", "list"})
+
+
+def _is_collection_literal_expr(value: ast.AST) -> bool:
+    """True iff ``value`` is a set/list/tuple display or a call to one of
+    the recognised collection builders (``frozenset(...)``, ``set(...)``,
+    ``tuple(...)``, ``list(...)``).
+    """
+    if isinstance(value, (ast.Set, ast.List, ast.Tuple)):
+        return True
+    if isinstance(value, ast.Call) and isinstance(value.func, ast.Name):
+        return value.func.id in _COLLECTION_BUILDERS
+    return False
+
+
+def _has_universe_guard_in_on_bar(cls: ast.ClassDef) -> bool:
+    """True iff ``on_bar`` contains an early-exit of the shape
+    ``if <name>.symbol not in self.UNIVERSE: return`` somewhere in its
+    top-level body.
+
+    Only ``on_bar`` is checked — the engine guards bar dispatch, so the
+    other hooks don't need the same predicate. The receiver-name on the
+    left is intentionally not pinned to ``bar``: the engine dispatches
+    positionally and ``on_bar(self, ctx, my_bar)`` is also valid. We
+    accept ``self.UNIVERSE`` and bare ``UNIVERSE`` on the right.
+    """
+    for node in ast.iter_child_nodes(cls):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if node.name != "on_bar":
+            continue
+        for stmt in node.body:
+            if _is_universe_guard_stmt(stmt):
+                return True
+        return False
+    return False
+
+
+def _is_universe_guard_stmt(stmt: ast.AST) -> bool:
+    """True iff ``stmt`` matches ``if <Name>.symbol not in {self.,}UNIVERSE: return``."""
+    if not isinstance(stmt, ast.If):
+        return False
+    test = stmt.test
+    if not (isinstance(test, ast.Compare) and len(test.ops) == 1):
+        return False
+    if not isinstance(test.ops[0], ast.NotIn):
+        return False
+    # Left side: <Name>.symbol
+    left = test.left
+    if not (
+        isinstance(left, ast.Attribute)
+        and left.attr == "symbol"
+        and isinstance(left.value, ast.Name)
+    ):
+        return False
+    # Right side: self.UNIVERSE or UNIVERSE
+    right = test.comparators[0]
+    if isinstance(right, ast.Attribute):
+        if not (
+            right.attr == "UNIVERSE"
+            and isinstance(right.value, ast.Name)
+            and right.value.id == "self"
+        ):
+            return False
+    elif isinstance(right, ast.Name):
+        if right.id != "UNIVERSE":
+            return False
+    else:
+        return False
+    # Body must contain a ``return`` (bare or ``return None``) as the first
+    # statement. ``return None`` is semantically identical to a bare
+    # ``return`` and some lint styles prefer it; both are accepted.
+    if not stmt.body:
+        return False
+    first = stmt.body[0]
+    if not isinstance(first, ast.Return):
+        return False
+    if first.value is None:
+        return True
+    return isinstance(first.value, ast.Constant) and first.value.value is None

--- a/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
@@ -71,66 +71,49 @@ class ExitRuleConformanceGate(GateResultsMixin):
         phase: StrategyLabPhase = "verification",
     ) -> List[QualityGateResult]:
         with self._using_phase(phase):
-            return self._check_body(
-                exit_rules=exit_rules,
-                trades=trades,
-                diagnostics=diagnostics,
-                config=config,
-                timeframe=timeframe,
-            )
+            if not exit_rules:
+                return [
+                    self._info("spec.exit_rules empty; engine-enforcement check skipped.")
+                ]
 
-    def _check_body(
-        self,
-        *,
-        exit_rules: Sequence[ExitRule],
-        trades: Sequence[TradeRecord],
-        diagnostics: Optional[BacktestExecutionDiagnostics],
-        config: BacktestConfig,
-        timeframe: str,
-    ) -> List[QualityGateResult]:
-        if not exit_rules:
-            return [
-                self._info("spec.exit_rules empty; engine-enforcement check skipped.")
-            ]
+            results: List[QualityGateResult] = []
+            firings = (diagnostics.exit_rule_firings if diagnostics is not None else None) or {}
+            firings_by_symbol = (
+                diagnostics.exit_rule_firings_by_symbol if diagnostics is not None else None
+            ) or {}
 
-        results: List[QualityGateResult] = []
-        firings = (diagnostics.exit_rule_firings if diagnostics is not None else None) or {}
-        firings_by_symbol = (
-            diagnostics.exit_rule_firings_by_symbol if diagnostics is not None else None
-        ) or {}
+            # ---- StopLossRule (entry_price basis only — trailing variants need
+            # bar-by-bar replay which the gate cannot reconstruct from the trade
+            # ledger alone) ----
+            stop_losses = [r for r in exit_rules if isinstance(r, StopLossRule)]
+            for rule in stop_losses:
+                results.append(self._check_stop_loss(rule, trades, firings_by_symbol))
 
-        # ---- StopLossRule (entry_price basis only — trailing variants need
-        # bar-by-bar replay which the gate cannot reconstruct from the trade
-        # ledger alone) ----
-        stop_losses = [r for r in exit_rules if isinstance(r, StopLossRule)]
-        for rule in stop_losses:
-            results.append(self._check_stop_loss(rule, trades, firings_by_symbol))
+            # ---- TakeProfitRule (sanity only) ----
+            take_profits = [r for r in exit_rules if isinstance(r, TakeProfitRule)]
+            for rule in take_profits:
+                results.append(self._check_take_profit(rule, trades, exit_rules, firings))
 
-        # ---- TakeProfitRule (sanity only) ----
-        take_profits = [r for r in exit_rules if isinstance(r, TakeProfitRule)]
-        for rule in take_profits:
-            results.append(self._check_take_profit(rule, trades, exit_rules, firings))
+            # ---- SignalExitRule — not yet engine-enforced ----
+            signal_exits = [r for r in exit_rules if isinstance(r, SignalExitRule)]
+            if signal_exits:
+                results.append(
+                    self._info(f"{len(signal_exits)} SignalExitRule(s) present but not yet "
+                            "engine-enforced (see rule_compiler module docstring).")
+                )
 
-        # ---- SignalExitRule — not yet engine-enforced ----
-        signal_exits = [r for r in exit_rules if isinstance(r, SignalExitRule)]
-        if signal_exits:
-            results.append(
-                self._info(f"{len(signal_exits)} SignalExitRule(s) present but not yet "
-                        "engine-enforced (see rule_compiler module docstring).")
-            )
+            # ---- Aggregate: engine emitted at least one exit when expected ----
+            if diagnostics is not None:
+                firings = diagnostics.exit_rule_firings or {}
+                total = sum(firings.values())
+                details = "engine_exits: " + (
+                    ", ".join(f"{k}={v}" for k, v in sorted(firings.items())) or "none"
+                )
+                results.append(
+                    self._info(details + f" (total={total}, trades={len(trades)})")
+                )
 
-        # ---- Aggregate: engine emitted at least one exit when expected ----
-        if diagnostics is not None:
-            firings = diagnostics.exit_rule_firings or {}
-            total = sum(firings.values())
-            details = "engine_exits: " + (
-                ", ".join(f"{k}={v}" for k, v in sorted(firings.items())) or "none"
-            )
-            results.append(
-                self._info(details + f" (total={total}, trades={len(trades)})")
-            )
-
-        return results
+            return results
 
     # ------------------------------------------------------------------
     # Per-rule checks

--- a/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
@@ -70,7 +70,24 @@ class ExitRuleConformanceGate(GateResultsMixin):
         timeframe: str = "1d",
         phase: StrategyLabPhase = "verification",
     ) -> List[QualityGateResult]:
-        self._set_phase(phase)
+        with self._using_phase(phase):
+            return self._check_body(
+                exit_rules=exit_rules,
+                trades=trades,
+                diagnostics=diagnostics,
+                config=config,
+                timeframe=timeframe,
+            )
+
+    def _check_body(
+        self,
+        *,
+        exit_rules: Sequence[ExitRule],
+        trades: Sequence[TradeRecord],
+        diagnostics: Optional[BacktestExecutionDiagnostics],
+        config: BacktestConfig,
+        timeframe: str,
+    ) -> List[QualityGateResult]:
         if not exit_rules:
             return [
                 self._info("spec.exit_rules empty; engine-enforcement check skipped.")

--- a/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
@@ -71,6 +71,7 @@ class ExitRuleConformanceGate:
             return [
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="verification",
                     passed=True,
                     severity="info",
                     details="spec.exit_rules empty; engine-enforcement check skipped.",
@@ -101,6 +102,7 @@ class ExitRuleConformanceGate:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="verification",
                     passed=True,
                     severity="info",
                     details=(
@@ -120,6 +122,7 @@ class ExitRuleConformanceGate:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="verification",
                     passed=True,
                     severity="info",
                     details=details + f" (total={total}, trades={len(trades)})",
@@ -141,6 +144,7 @@ class ExitRuleConformanceGate:
         if rule.basis != "entry_price":
             return QualityGateResult(
                 gate_name=GATE,
+                phase="verification",
                 passed=True,
                 severity="info",
                 details=(
@@ -214,6 +218,7 @@ class ExitRuleConformanceGate:
             sample = [(t.trade_num, t.symbol, t.return_pct) for t in unaccounted[:5]]
             return QualityGateResult(
                 gate_name=GATE,
+                phase="verification",
                 passed=False,
                 severity="critical",
                 details=(
@@ -225,6 +230,7 @@ class ExitRuleConformanceGate:
             )
         return QualityGateResult(
             gate_name=GATE,
+            phase="verification",
             passed=True,
             severity="info",
             details=(
@@ -259,6 +265,7 @@ class ExitRuleConformanceGate:
         if not only_rule:
             return QualityGateResult(
                 gate_name=GATE,
+                phase="verification",
                 passed=True,
                 severity="info",
                 details=(
@@ -271,6 +278,7 @@ class ExitRuleConformanceGate:
         if tp_firings >= 1:
             return QualityGateResult(
                 gate_name=GATE,
+                phase="verification",
                 passed=True,
                 severity="info",
                 details=(
@@ -281,6 +289,7 @@ class ExitRuleConformanceGate:
         if not trades:
             return QualityGateResult(
                 gate_name=GATE,
+                phase="verification",
                 passed=True,
                 severity="info",
                 details=(
@@ -289,6 +298,7 @@ class ExitRuleConformanceGate:
             )
         return QualityGateResult(
             gate_name=GATE,
+            phase="verification",
             passed=False,
             severity="warning",
             details=(

--- a/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/exit_rule_conformance.py
@@ -36,7 +36,7 @@ of which the alignment agent's LLM-driven audit should defer to.
 
 from __future__ import annotations
 
-from typing import List, Mapping, Optional, Sequence
+from typing import ClassVar, List, Mapping, Optional, Sequence
 
 from ...models import (
     BacktestConfig,
@@ -50,13 +50,15 @@ from ..spec_dsl import (
     StopLossRule,
     TakeProfitRule,
 )
-from .models import QualityGateResult
+from .models import GateResultsMixin, QualityGateResult, StrategyLabPhase
 
 GATE = "exit_rule_conformance"
 
 
-class ExitRuleConformanceGate:
+class ExitRuleConformanceGate(GateResultsMixin):
     """Deterministic post-run check that engine-emitted exits match the spec."""
+
+    GATE: ClassVar[str] = GATE
 
     def check(
         self,
@@ -66,16 +68,12 @@ class ExitRuleConformanceGate:
         diagnostics: Optional[BacktestExecutionDiagnostics],
         config: BacktestConfig,
         timeframe: str = "1d",
+        phase: StrategyLabPhase = "verification",
     ) -> List[QualityGateResult]:
+        self._set_phase(phase)
         if not exit_rules:
             return [
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase="verification",
-                    passed=True,
-                    severity="info",
-                    details="spec.exit_rules empty; engine-enforcement check skipped.",
-                )
+                self._info("spec.exit_rules empty; engine-enforcement check skipped.")
             ]
 
         results: List[QualityGateResult] = []
@@ -100,16 +98,8 @@ class ExitRuleConformanceGate:
         signal_exits = [r for r in exit_rules if isinstance(r, SignalExitRule)]
         if signal_exits:
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase="verification",
-                    passed=True,
-                    severity="info",
-                    details=(
-                        f"{len(signal_exits)} SignalExitRule(s) present but not yet "
-                        "engine-enforced (see rule_compiler module docstring)."
-                    ),
-                )
+                self._info(f"{len(signal_exits)} SignalExitRule(s) present but not yet "
+                        "engine-enforced (see rule_compiler module docstring).")
             )
 
         # ---- Aggregate: engine emitted at least one exit when expected ----
@@ -120,13 +110,7 @@ class ExitRuleConformanceGate:
                 ", ".join(f"{k}={v}" for k, v in sorted(firings.items())) or "none"
             )
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase="verification",
-                    passed=True,
-                    severity="info",
-                    details=details + f" (total={total}, trades={len(trades)})",
-                )
+                self._info(details + f" (total={total}, trades={len(trades)})")
             )
 
         return results
@@ -135,23 +119,15 @@ class ExitRuleConformanceGate:
     # Per-rule checks
     # ------------------------------------------------------------------
 
-    @staticmethod
     def _check_stop_loss(
+        self,
         rule: StopLossRule,
         trades: Sequence[TradeRecord],
         firings_by_symbol: Mapping[str, Mapping[str, int]],
     ) -> QualityGateResult:
         if rule.basis != "entry_price":
-            return QualityGateResult(
-                gate_name=GATE,
-                phase="verification",
-                passed=True,
-                severity="info",
-                details=(
-                    f"StopLossRule(basis={rule.basis!r}) conformance check skipped "
-                    "(trailing variants require bar-by-bar replay)."
-                ),
-            )
+            return self._info(f"StopLossRule(basis={rule.basis!r}) conformance check skipped "
+                    "(trailing variants require bar-by-bar replay).")
         # The engine detects the trigger on bar N's low (long) / high
         # (short), but the synthetic market close fills on bar N+1's
         # open. That next-bar fill can land arbitrarily far below the
@@ -216,33 +192,17 @@ class ExitRuleConformanceGate:
         )
         if unaccounted:
             sample = [(t.trade_num, t.symbol, t.return_pct) for t in unaccounted[:5]]
-            return QualityGateResult(
-                gate_name=GATE,
-                phase="verification",
-                passed=False,
-                severity="critical",
-                details=(
-                    f"StopLossRule(pct={rule.pct}) leak: {total_tripped} engine-attributed "
+            return self._critical(f"StopLossRule(pct={rule.pct}) leak: {total_tripped} engine-attributed "
                     f"trade(s) closed below the {raw_floor_pct:.2f}% floor; "
                     f"{len(unaccounted)} unaccounted for by per-symbol firings. "
-                    f"Sample (trade_num, symbol, return_pct)={sample}{skipped_suffix}."
-                ),
-            )
-        return QualityGateResult(
-            gate_name=GATE,
-            phase="verification",
-            passed=True,
-            severity="info",
-            details=(
-                f"StopLossRule(pct={rule.pct}) — per-symbol firings cover "
+                    f"Sample (trade_num, symbol, return_pct)={sample}{skipped_suffix}.")
+        return self._info(f"StopLossRule(pct={rule.pct}) — per-symbol firings cover "
                 f"{total_tripped} engine-attributed below-floor trade(s) across "
                 f"{len(by_symbol_tripped)} symbol(s); "
-                f"total firings={total_firings}{skipped_suffix}."
-            ),
-        )
+                f"total firings={total_firings}{skipped_suffix}.")
 
-    @staticmethod
     def _check_take_profit(
+        self,
         rule: TakeProfitRule,
         trades: Sequence[TradeRecord],
         all_rules: Sequence[ExitRule],
@@ -263,47 +223,15 @@ class ExitRuleConformanceGate:
         # threshold is unreachable on the symbols' actual price action.
         only_rule = len(all_rules) == 1
         if not only_rule:
-            return QualityGateResult(
-                gate_name=GATE,
-                phase="verification",
-                passed=True,
-                severity="info",
-                details=(
-                    f"TakeProfitRule(pct={rule.pct}) co-exists with other exit "
+            return self._info(f"TakeProfitRule(pct={rule.pct}) co-exists with other exit "
                     "rules; conformance is informational (other rules may close "
-                    "trades before the take-profit threshold is reached)."
-                ),
-            )
+                    "trades before the take-profit threshold is reached).")
         tp_firings = firings.get("take_profit", 0)
         if tp_firings >= 1:
-            return QualityGateResult(
-                gate_name=GATE,
-                phase="verification",
-                passed=True,
-                severity="info",
-                details=(
-                    f"TakeProfitRule(pct={rule.pct}) — {tp_firings} engine firing(s) "
-                    f"recorded across {len(trades)} trade(s)."
-                ),
-            )
+            return self._info(f"TakeProfitRule(pct={rule.pct}) — {tp_firings} engine firing(s) "
+                    f"recorded across {len(trades)} trade(s).")
         if not trades:
-            return QualityGateResult(
-                gate_name=GATE,
-                phase="verification",
-                passed=True,
-                severity="info",
-                details=(
-                    f"TakeProfitRule(pct={rule.pct}) — zero trades produced; no firings to verify."
-                ),
-            )
-        return QualityGateResult(
-            gate_name=GATE,
-            phase="verification",
-            passed=False,
-            severity="warning",
-            details=(
-                f"TakeProfitRule(pct={rule.pct}) is the only exit rule but the engine "
+            return self._info(f"TakeProfitRule(pct={rule.pct}) — zero trades produced; no firings to verify.")
+        return self._warning(f"TakeProfitRule(pct={rule.pct}) is the only exit rule but the engine "
                 f"recorded zero take_profit firings across {len(trades)} trade(s) — "
-                "the threshold may be unreachable on the strategy's universe."
-            ),
-        )
+                "the threshold may be unreachable on the strategy's universe.")

--- a/backend/agents/investment_team/strategy_lab/quality_gates/models.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/models.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Literal
+from typing import ClassVar, Literal, Optional
 
 from pydantic import BaseModel
 
 StrategyLabPhase = Literal["design", "design_review", "synthesis", "verification"]
+
+_VALID_PHASES: frozenset[str] = frozenset(StrategyLabPhase.__args__)  # type: ignore[attr-defined]
 
 
 class QualityGateResult(BaseModel):
@@ -18,3 +20,58 @@ class QualityGateResult(BaseModel):
     severity: Literal["info", "warning", "critical"]
     phase: StrategyLabPhase
     refinement_round: int = 0
+
+
+class GateResultsMixin:
+    """Mixin that fills in ``gate_name`` and ``phase`` automatically.
+
+    Subclasses declare ``GATE`` (the gate name stamped on every result) and
+    call ``self._set_phase(phase)`` once at the entry of their public
+    ``check()`` / ``validate()`` method. Helpers (``_critical`` / ``_warning``
+    / ``_info``) then read the gate name and phase from instance state, so
+    individual result construction sites collapse from seven lines to one.
+
+    Contract:
+      Pre: ``GATE`` is defined; ``_set_phase`` has been called with a valid
+      phase before any helper is invoked.
+      Post: every emitted ``QualityGateResult`` carries the gate's ``GATE``
+      string and the phase the caller declared.
+
+    The pattern is not re-entrant: helpers read a single ``_phase`` slot, so
+    a gate instance must not be shared across concurrent ``check()`` calls.
+    Strategy Lab orchestration is sequential, so this is acceptable.
+    """
+
+    GATE: ClassVar[str] = ""
+    _phase: Optional[StrategyLabPhase] = None
+
+    def _set_phase(self, phase: StrategyLabPhase) -> None:
+        # Pre: phase is one of the four valid labels.
+        assert phase in _VALID_PHASES, f"invalid phase: {phase!r}"
+        # Pre: subclass must declare GATE.
+        assert self.GATE, f"{type(self).__name__} must declare a non-empty GATE constant"
+        self._phase = phase
+
+    def _critical(self, details: str) -> QualityGateResult:
+        return self._emit(passed=False, severity="critical", details=details)
+
+    def _warning(self, details: str) -> QualityGateResult:
+        return self._emit(passed=False, severity="warning", details=details)
+
+    def _info(self, details: str = "") -> QualityGateResult:
+        return self._emit(passed=True, severity="info", details=details)
+
+    def _emit(
+        self, *, passed: bool, severity: Literal["info", "warning", "critical"], details: str
+    ) -> QualityGateResult:
+        # Pre: _set_phase has been called.
+        assert self._phase is not None, (
+            f"{type(self).__name__}._set_phase must be called before emitting results"
+        )
+        return QualityGateResult(
+            gate_name=self.GATE,
+            phase=self._phase,
+            passed=passed,
+            severity=severity,
+            details=details,
+        )

--- a/backend/agents/investment_team/strategy_lab/quality_gates/models.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/models.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import ClassVar, Literal, Optional
+from contextlib import contextmanager
+from typing import ClassVar, Iterator, Literal, Optional
 
 from pydantic import BaseModel
 
@@ -26,31 +27,41 @@ class GateResultsMixin:
     """Mixin that fills in ``gate_name`` and ``phase`` automatically.
 
     Subclasses declare ``GATE`` (the gate name stamped on every result) and
-    call ``self._set_phase(phase)`` once at the entry of their public
-    ``check()`` / ``validate()`` method. Helpers (``_critical`` / ``_warning``
-    / ``_info``) then read the gate name and phase from instance state, so
-    individual result construction sites collapse from seven lines to one.
+    wrap their public ``check()`` / ``validate()`` body in
+    ``with self._using_phase(phase): ...``. Helpers (``_critical`` /
+    ``_warning`` / ``_info``) then read the gate name and phase from
+    instance state.
 
     Contract:
-      Pre: ``GATE`` is defined; ``_set_phase`` has been called with a valid
-      phase before any helper is invoked.
-      Post: every emitted ``QualityGateResult`` carries the gate's ``GATE``
-      string and the phase the caller declared.
-
-    The pattern is not re-entrant: helpers read a single ``_phase`` slot, so
-    a gate instance must not be shared across concurrent ``check()`` calls.
-    Strategy Lab orchestration is sequential, so this is acceptable.
+      Pre: ``GATE`` is non-empty; ``_using_phase`` is active when any
+      helper is invoked.
+      Post: every emitted ``QualityGateResult`` carries the gate's
+      ``GATE`` string and the phase the context manager declared.
+      The context manager restores the previous ``_phase`` on exit
+      (including the unwound state after an exception), so a rule that
+      raises mid-``check`` cannot leak a stale phase into a subsequent
+      call. The slot is still a single attribute on ``self``, so the
+      gate must not be shared across concurrent ``check()`` calls —
+      Strategy Lab orchestration is sequential.
     """
 
     GATE: ClassVar[str] = ""
     _phase: Optional[StrategyLabPhase] = None
 
-    def _set_phase(self, phase: StrategyLabPhase) -> None:
+    @contextmanager
+    def _using_phase(self, phase: StrategyLabPhase) -> Iterator[None]:
         # Pre: phase is one of the four valid labels.
         assert phase in _VALID_PHASES, f"invalid phase: {phase!r}"
         # Pre: subclass must declare GATE.
         assert self.GATE, f"{type(self).__name__} must declare a non-empty GATE constant"
+        prev = self._phase
         self._phase = phase
+        try:
+            yield
+        finally:
+            # Post: phase slot reverts even when the body raises, so a rule
+            # that throws never leaves stale state visible to the next caller.
+            self._phase = prev
 
     def _critical(self, details: str) -> QualityGateResult:
         return self._emit(passed=False, severity="critical", details=details)
@@ -64,9 +75,10 @@ class GateResultsMixin:
     def _emit(
         self, *, passed: bool, severity: Literal["info", "warning", "critical"], details: str
     ) -> QualityGateResult:
-        # Pre: _set_phase has been called.
+        # Pre: ``_using_phase`` is active.
         assert self._phase is not None, (
-            f"{type(self).__name__}._set_phase must be called before emitting results"
+            f"{type(self).__name__} must be inside `with self._using_phase(...)` "
+            "to emit a QualityGateResult"
         )
         return QualityGateResult(
             gate_name=self.GATE,

--- a/backend/agents/investment_team/strategy_lab/quality_gates/models.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/models.py
@@ -6,6 +6,8 @@ from typing import Literal
 
 from pydantic import BaseModel
 
+StrategyLabPhase = Literal["design", "design_review", "synthesis", "verification"]
+
 
 class QualityGateResult(BaseModel):
     """Result of a single quality gate check."""
@@ -14,4 +16,5 @@ class QualityGateResult(BaseModel):
     passed: bool
     details: str
     severity: Literal["info", "warning", "critical"]
+    phase: StrategyLabPhase
     refinement_round: int = 0

--- a/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
@@ -1,0 +1,494 @@
+"""Deterministic implementability gate for `StrategySpec` (issue #540).
+
+Runs in the design phase (before any code is written) and again as the first
+gate of the synthesis phase as a sanity check that the spec wasn't mutated.
+Each rule is deterministic, has a dedicated test, and fails closed.
+
+The eight rules implemented here are the ones enumerated in issue #540.
+Several of them overlap with :class:`StrategySpecValidator` — that is
+intentional: this gate is self-contained and runs at a different phase, with
+critical (rather than warning) severity on the items #540 deems blocking.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Callable, List, Optional
+
+from ...models import BacktestConfig, StrategySpec
+from ...symbols import COMMODITY_SYMBOLS, CRYPTO_SYMBOLS, OTHER_SYMBOLS, STOCK_SYMBOLS
+from ..spec_dsl import (
+    EntryRule,
+    IndicatorName,
+    IndicatorRef,
+    Predicate,
+    SignalExitRule,
+    StopLossRule,
+    TakeProfitRule,
+)
+from .models import QualityGateResult, StrategyLabPhase
+
+GATE = "spec_readiness"
+
+# Whitelist regex matches any tradeable symbol the spec is allowed to name in
+# its hypothesis. STOCK ∪ CRYPTO ∪ COMMODITY ∪ OTHER (broad ETFs). Word-bounded
+# so "ETH" doesn't match "ETHEREUM" appearing as a prose adjective.
+_SYMBOL_WHITELIST: frozenset[str] = frozenset(
+    {*STOCK_SYMBOLS, *CRYPTO_SYMBOLS, *COMMODITY_SYMBOLS, *OTHER_SYMBOLS}
+)
+_SYMBOL_REGEX = re.compile(
+    r"\b(" + "|".join(sorted(_SYMBOL_WHITELIST, key=len, reverse=True)) + r")\b"
+)
+
+# Asset classes that today's data-provider chain supports for every timeframe
+# (stocks/crypto have minute-bar yfinance coverage). Other classes only fetch
+# daily bars reliably — intraday timeframes on those classes are rejected.
+_FULL_TIMEFRAME_ASSET_CLASSES: frozenset[str] = frozenset({"stocks", "crypto"})
+
+# Authoritative set of DSL indicator names. Mirrors `IndicatorName` so a
+# constructed IndicatorRef always satisfies this set; the gate enforces it
+# again as defense-in-depth against a future refactor that bypasses Pydantic.
+_KNOWN_INDICATOR_NAMES: frozenset[str] = frozenset(IndicatorName.__args__)
+
+# Indicators whose `params` must include a specific key — derived from
+# `_INDICATOR_PARAM_SPECS` in spec_dsl.py. `rsi` is intentionally absent here:
+# the DSL ships a `period=14` default, so a bare `IndicatorRef(name="rsi")` is
+# fully realisable.
+_INDICATOR_REQUIRED_PARAMS: dict[str, frozenset[str]] = {
+    "sma": frozenset({"period"}),
+    "ema": frozenset({"period"}),
+}
+
+# Reuse the indicator vocabulary the existing validator uses for prose mentions.
+_CONCEPT_TERMS = re.compile(
+    r"\b(rsi|macd|moving\s+average|ema|sma|bollinger|atr|stochastic|adx|vwap)\b",
+    re.IGNORECASE,
+)
+_CONCEPT_TO_INDICATOR_NAME: dict[str, str] = {
+    "rsi": "rsi",
+    "macd": "macd",
+    "moving average": "sma",
+    "ema": "ema",
+    "sma": "sma",
+    "bollinger": "bollinger",
+    "atr": "atr",
+    "stochastic": "stochastic",
+    "adx": "adx",
+    "vwap": "vwap",
+}
+
+
+MarketSampleProvider = Callable[[str], float]
+
+
+def _default_universe_for(asset_class: str) -> List[str]:
+    ac = asset_class.lower()
+    if ac == "stocks":
+        return list(STOCK_SYMBOLS)
+    if ac == "crypto":
+        return list(CRYPTO_SYMBOLS)
+    if ac == "commodities":
+        return list(COMMODITY_SYMBOLS)
+    return list(OTHER_SYMBOLS)
+
+
+def _default_market_sample_provider(symbol: str) -> float:
+    """Static fallback price used when no real recent-bar feed is wired."""
+    return 100.0
+
+
+class SpecReadinessGate:
+    """Deterministic implementability checks on a constructed ``StrategySpec``.
+
+    Issue #540 — eight blocking rules that refuse a vague or unimplementable
+    spec *before* code synthesis. The gate is self-contained; failures are
+    persisted via ``StrategyLabRecord.quality_gate_results`` with the supplied
+    ``phase`` tag so design-phase vs synthesis-phase invocations are
+    distinguishable downstream.
+    """
+
+    def __init__(
+        self,
+        *,
+        market_sample_provider: Optional[MarketSampleProvider] = None,
+        backtest_config: Optional[BacktestConfig] = None,
+    ) -> None:
+        self._market_sample_provider: MarketSampleProvider = (
+            market_sample_provider or _default_market_sample_provider
+        )
+        self._backtest_config = backtest_config
+
+    def validate(
+        self,
+        spec: StrategySpec,
+        *,
+        phase: StrategyLabPhase = "design",
+        backtest_config: Optional[BacktestConfig] = None,
+    ) -> List[QualityGateResult]:
+        results: List[QualityGateResult] = []
+        config = backtest_config or self._backtest_config
+
+        results.extend(self._check_universe_set(spec, phase))
+        results.extend(self._check_entry_rules_non_trivial(spec, phase))
+        results.extend(self._check_indicator_validity(spec, phase))
+        results.extend(self._check_exit_completeness(spec, phase))
+        results.extend(self._check_sizing_realisable(spec, phase, config))
+        results.extend(self._check_hypothesis_rule_consistency(spec, phase))
+        results.extend(self._check_timeframe_availability(spec, phase))
+        results.extend(self._check_risk_limit_coherence(spec, phase))
+
+        if not results:
+            results.append(
+                QualityGateResult(
+                    gate_name=GATE,
+                    phase=phase,
+                    passed=True,
+                    severity="info",
+                    details="Strategy spec passed all readiness checks.",
+                )
+            )
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Rule 1: Universe set
+    # ------------------------------------------------------------------
+    def _check_universe_set(
+        self, spec: StrategySpec, phase: StrategyLabPhase
+    ) -> List[QualityGateResult]:
+        named = {m.group(0).upper() for m in _SYMBOL_REGEX.finditer(spec.hypothesis or "")}
+        targets = {s.upper() for s in spec.target_symbols}
+
+        # Pass-through cases: no symbols named in hypothesis AND target_symbols
+        # is also empty → asset-class default universe will be used (handled
+        # by the fetch path). That's acceptable here; rule 1 only fires on a
+        # mismatch between named and targeted symbols.
+        if not named and not targets:
+            return []
+
+        if named and not targets:
+            return [
+                QualityGateResult(
+                    gate_name=GATE,
+                    phase=phase,
+                    passed=False,
+                    severity="critical",
+                    details=(
+                        f"Hypothesis names symbol(s) {sorted(named)} but "
+                        "target_symbols is empty — backtest universe would not "
+                        "include the symbols the strategy is about."
+                    ),
+                )
+            ]
+
+        missing = named - targets
+        if missing:
+            return [
+                QualityGateResult(
+                    gate_name=GATE,
+                    phase=phase,
+                    passed=False,
+                    severity="critical",
+                    details=(
+                        f"Hypothesis names symbol(s) {sorted(missing)} not "
+                        f"present in target_symbols {sorted(targets)}."
+                    ),
+                )
+            ]
+
+        return []
+
+    # ------------------------------------------------------------------
+    # Rule 2: Entry rules non-trivial
+    # ------------------------------------------------------------------
+    def _check_entry_rules_non_trivial(
+        self, spec: StrategySpec, phase: StrategyLabPhase
+    ) -> List[QualityGateResult]:
+        if not spec.entry_rules:
+            return [
+                QualityGateResult(
+                    gate_name=GATE,
+                    phase=phase,
+                    passed=False,
+                    severity="critical",
+                    details="No entry rules — strategy cannot generate trades.",
+                )
+            ]
+
+        for idx, rule in enumerate(spec.entry_rules):
+            if not isinstance(rule, EntryRule):
+                return [
+                    QualityGateResult(
+                        gate_name=GATE,
+                        phase=phase,
+                        passed=False,
+                        severity="critical",
+                        details=(
+                            f"entry_rules[{idx}] is not a structured EntryRule "
+                            f"(got {type(rule).__name__})."
+                        ),
+                    )
+                ]
+            pred = rule.when
+            if not isinstance(pred, Predicate):
+                return [
+                    QualityGateResult(
+                        gate_name=GATE,
+                        phase=phase,
+                        passed=False,
+                        severity="critical",
+                        details=(
+                            f"entry_rules[{idx}].when is not a Predicate "
+                            f"(got {type(pred).__name__})."
+                        ),
+                    )
+                ]
+
+        return []
+
+    # ------------------------------------------------------------------
+    # Rule 3: Indicator validity
+    # ------------------------------------------------------------------
+    def _check_indicator_validity(
+        self, spec: StrategySpec, phase: StrategyLabPhase
+    ) -> List[QualityGateResult]:
+        for ref in self._iter_indicator_refs(spec):
+            if ref.name not in _KNOWN_INDICATOR_NAMES:
+                return [
+                    QualityGateResult(
+                        gate_name=GATE,
+                        phase=phase,
+                        passed=False,
+                        severity="critical",
+                        details=(
+                            f"Indicator '{ref.name}' is not in the supported "
+                            f"set {sorted(_KNOWN_INDICATOR_NAMES)}."
+                        ),
+                    )
+                ]
+            required = _INDICATOR_REQUIRED_PARAMS.get(ref.name, frozenset())
+            missing = sorted(required - set(ref.params.keys()))
+            if missing:
+                return [
+                    QualityGateResult(
+                        gate_name=GATE,
+                        phase=phase,
+                        passed=False,
+                        severity="critical",
+                        details=(f"Indicator '{ref.name}' is missing required param(s) {missing}."),
+                    )
+                ]
+        return []
+
+    # ------------------------------------------------------------------
+    # Rule 4: Exit completeness
+    # ------------------------------------------------------------------
+    def _check_exit_completeness(
+        self, spec: StrategySpec, phase: StrategyLabPhase
+    ) -> List[QualityGateResult]:
+        allowed_kinds = {"signal_exit", "stop_loss", "take_profit"}
+        if not spec.exit_rules:
+            return [
+                QualityGateResult(
+                    gate_name=GATE,
+                    phase=phase,
+                    passed=False,
+                    severity="critical",
+                    details=(
+                        "No exit rules — positions would never close. Add at "
+                        "least one of: signal_exit, stop_loss, take_profit."
+                    ),
+                )
+            ]
+        if not any(getattr(r, "kind", None) in allowed_kinds for r in spec.exit_rules):
+            return [
+                QualityGateResult(
+                    gate_name=GATE,
+                    phase=phase,
+                    passed=False,
+                    severity="critical",
+                    details=(f"exit_rules contains no rule of kind in {sorted(allowed_kinds)}."),
+                )
+            ]
+        return []
+
+    # ------------------------------------------------------------------
+    # Rule 5: Sizing realisable
+    # ------------------------------------------------------------------
+    def _check_sizing_realisable(
+        self,
+        spec: StrategySpec,
+        phase: StrategyLabPhase,
+        config: Optional[BacktestConfig],
+    ) -> List[QualityGateResult]:
+        if config is None:
+            return []  # no capital basis available; skip silently
+
+        kind = getattr(spec.sizing, "kind", None)
+        # Use target_symbols when set; otherwise pick a deterministic
+        # representative from the asset-class default universe.
+        symbols = spec.target_symbols or _default_universe_for(spec.asset_class)
+        if not symbols:
+            return []
+        capital = config.initial_capital
+
+        for sym in symbols:
+            try:
+                price = float(self._market_sample_provider(sym))
+            except Exception:
+                price = 0.0
+            if price <= 0:
+                return [
+                    QualityGateResult(
+                        gate_name=GATE,
+                        phase=phase,
+                        passed=False,
+                        severity="critical",
+                        details=(
+                            f"Sizing realisability: no positive price sample "
+                            f"for '{sym}' (got {price!r})."
+                        ),
+                    )
+                ]
+            if kind == "fixed_fraction":
+                notional = capital * float(spec.sizing.fraction)
+            elif kind == "fixed_notional":
+                notional = float(spec.sizing.notional_usd)
+            elif kind == "volatility_target":
+                # Volatility-target sizing can't be evaluated without realised
+                # vol; treat as realisable for this static check.
+                continue
+            else:
+                continue
+            qty = notional / price
+            if qty < 1:
+                return [
+                    QualityGateResult(
+                        gate_name=GATE,
+                        phase=phase,
+                        passed=False,
+                        severity="critical",
+                        details=(
+                            f"Sizing yields qty={qty:.4f} < 1 for symbol "
+                            f"'{sym}' at sample price ${price:.2f} with "
+                            f"capital ${capital:.0f}."
+                        ),
+                    )
+                ]
+        return []
+
+    # ------------------------------------------------------------------
+    # Rule 6: Hypothesis–rule consistency
+    # ------------------------------------------------------------------
+    def _check_hypothesis_rule_consistency(
+        self, spec: StrategySpec, phase: StrategyLabPhase
+    ) -> List[QualityGateResult]:
+        hypothesis = spec.hypothesis or ""
+        terms_in_hypothesis = {
+            re.sub(r"\s+", " ", m.group(0).lower()) for m in _CONCEPT_TERMS.finditer(hypothesis)
+        }
+        referenced = {ref.name for ref in self._iter_indicator_refs(spec)}
+        orphan = sorted(
+            t
+            for t in terms_in_hypothesis
+            if (n := _CONCEPT_TO_INDICATOR_NAME.get(t)) is not None and n not in referenced
+        )
+        if orphan:
+            return [
+                QualityGateResult(
+                    gate_name=GATE,
+                    phase=phase,
+                    passed=False,
+                    severity="critical",
+                    details=(
+                        f"Hypothesis names indicator concept(s) {sorted(orphan)} "
+                        "that no entry/exit rule references."
+                    ),
+                )
+            ]
+        return []
+
+    # ------------------------------------------------------------------
+    # Rule 7: Timeframe data availability
+    # ------------------------------------------------------------------
+    def _check_timeframe_availability(
+        self, spec: StrategySpec, phase: StrategyLabPhase
+    ) -> List[QualityGateResult]:
+        if spec.timeframe == "1d":
+            return []
+        if spec.asset_class.lower() not in _FULL_TIMEFRAME_ASSET_CLASSES:
+            return [
+                QualityGateResult(
+                    gate_name=GATE,
+                    phase=phase,
+                    passed=False,
+                    severity="critical",
+                    details=(
+                        f"Asset class '{spec.asset_class}' has no reliable "
+                        f"intraday data for timeframe '{spec.timeframe}'; "
+                        "use '1d' or pick stocks/crypto."
+                    ),
+                )
+            ]
+        return []
+
+    # ------------------------------------------------------------------
+    # Rule 8: Risk-limit coherence
+    # ------------------------------------------------------------------
+    def _check_risk_limit_coherence(
+        self, spec: StrategySpec, phase: StrategyLabPhase
+    ) -> List[QualityGateResult]:
+        out: List[QualityGateResult] = []
+
+        stop_losses = [r for r in spec.exit_rules if isinstance(r, StopLossRule)]
+        take_profits = [r for r in spec.exit_rules if isinstance(r, TakeProfitRule)]
+        if stop_losses and take_profits:
+            min_tp = min(r.pct for r in take_profits)
+            max_sl = max(r.pct for r in stop_losses)
+            if max_sl >= min_tp:
+                out.append(
+                    QualityGateResult(
+                        gate_name=GATE,
+                        phase=phase,
+                        passed=False,
+                        severity="critical",
+                        details=(
+                            f"stop_loss.pct={max_sl} ≥ take_profit.pct={min_tp} — "
+                            "stop would trigger before profit target."
+                        ),
+                    )
+                )
+
+        if spec.risk_limits.max_position_pct > 25:
+            out.append(
+                QualityGateResult(
+                    gate_name=GATE,
+                    phase=phase,
+                    passed=False,
+                    severity="critical",
+                    details=(
+                        f"max_position_pct={spec.risk_limits.max_position_pct}% "
+                        "exceeds the 25% cap for a single-position risk budget."
+                    ),
+                )
+            )
+
+        return out
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _iter_indicator_refs(spec: StrategySpec):
+        for rule in spec.entry_rules:
+            yield from SpecReadinessGate._predicate_indicator_refs(rule.when)
+        for rule in spec.exit_rules:
+            if isinstance(rule, SignalExitRule):
+                yield from SpecReadinessGate._predicate_indicator_refs(rule.when)
+
+    @staticmethod
+    def _predicate_indicator_refs(pred: Predicate):
+        if isinstance(pred.lhs, IndicatorRef):
+            yield pred.lhs
+        if isinstance(pred.rhs, IndicatorRef):
+            yield pred.rhs

--- a/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
@@ -119,6 +119,20 @@ def _default_universe_for(asset_class: str) -> List[str]:
     return out
 
 
+def _canonicalize_ticker(symbol: str) -> str:
+    # Strip Yahoo provider suffixes so bare aliases compare equal to their
+    # provider-form counterparts. Post: returns an upper-cased string with no
+    # `=F` / `=X` suffix.
+    assert isinstance(symbol, str), "symbol must be a str"
+    s = symbol.upper()
+    for suffix in ("=F", "=X"):
+        if s.endswith(suffix):
+            s = s[: -len(suffix)]
+            break
+    assert not s.endswith(("=F", "=X")), "canonical form must not retain a provider suffix"
+    return s
+
+
 def _default_market_sample_provider(symbol: str) -> float:
     # Pre: symbol is a non-empty string.
     assert isinstance(symbol, str) and symbol, "symbol must be a non-empty str"
@@ -212,13 +226,18 @@ class SpecReadinessGate:
         assert isinstance(spec, StrategySpec)
         assert phase in _VALID_PHASES
 
-        named = {m.group(0).upper() for m in _SYMBOL_REGEX.finditer(spec.hypothesis or "")}
-        targets = {s.upper() for s in spec.target_symbols}
+        named_raw = {m.group(0).upper() for m in _SYMBOL_REGEX.finditer(spec.hypothesis or "")}
+        targets_raw = {s.upper() for s in spec.target_symbols}
+        # Compare on the canonical (suffix-stripped) form so `ES` ≡ `ES=F` and
+        # `EURUSD` ≡ `EURUSD=X` — the spec is implementable either way; the
+        # downstream fetcher resolves the provider form when needed.
+        named_canon = {_canonicalize_ticker(s) for s in named_raw}
+        targets_canon = {_canonicalize_ticker(s) for s in targets_raw}
 
         out: List[QualityGateResult] = []
-        if not named and not targets:
+        if not named_canon and not targets_canon:
             pass  # asset-class default universe will be used
-        elif named and not targets:
+        elif named_canon and not targets_canon:
             out.append(
                 QualityGateResult(
                     gate_name=GATE,
@@ -226,15 +245,16 @@ class SpecReadinessGate:
                     passed=False,
                     severity="critical",
                     details=(
-                        f"Hypothesis names symbol(s) {sorted(named)} but "
+                        f"Hypothesis names symbol(s) {sorted(named_raw)} but "
                         "target_symbols is empty — backtest universe would not "
                         "include the symbols the strategy is about."
                     ),
                 )
             )
         else:
-            missing = named - targets
-            if missing:
+            missing_canon = named_canon - targets_canon
+            if missing_canon:
+                missing_raw = sorted(s for s in named_raw if _canonicalize_ticker(s) in missing_canon)
                 out.append(
                     QualityGateResult(
                         gate_name=GATE,
@@ -242,8 +262,8 @@ class SpecReadinessGate:
                         passed=False,
                         severity="critical",
                         details=(
-                            f"Hypothesis names symbol(s) {sorted(missing)} not "
-                            f"present in target_symbols {sorted(targets)}."
+                            f"Hypothesis names symbol(s) {missing_raw} not "
+                            f"present in target_symbols {sorted(targets_raw)}."
                         ),
                     )
                 )

--- a/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
@@ -15,7 +15,16 @@ import re
 from typing import Callable, Iterator, List, Optional
 
 from ...models import BacktestConfig, StrategySpec
-from ...symbols import COMMODITY_SYMBOLS, CRYPTO_SYMBOLS, OTHER_SYMBOLS, STOCK_SYMBOLS
+from ...symbols import (
+    COMMODITY_SYMBOLS,
+    CRYPTO_SYMBOLS,
+    FOREX_SYMBOLS,
+    FOREX_SYMBOLS_BARE,
+    FUTURES_SYMBOLS,
+    FUTURES_SYMBOLS_BARE,
+    OTHER_SYMBOLS,
+    STOCK_SYMBOLS,
+)
 from ..spec_dsl import (
     EntryRule,
     IndicatorName,
@@ -29,13 +38,26 @@ from .models import QualityGateResult, StrategyLabPhase
 
 GATE = "spec_readiness"
 
-# Whitelist regex matches any tradeable symbol the spec is allowed to name in
-# its hypothesis. Word-bounded so "ETH" doesn't match "ETHEREUM".
+# Whitelist of every tradeable symbol the spec is allowed to name in its
+# hypothesis. Covers all five asset classes plus the broad ETFs; word-bounded
+# so "ETH" doesn't match "ETHEREUM" and "ES" doesn't match arbitrary prose.
 _SYMBOL_WHITELIST: frozenset[str] = frozenset(
-    {*STOCK_SYMBOLS, *CRYPTO_SYMBOLS, *COMMODITY_SYMBOLS, *OTHER_SYMBOLS}
+    {
+        *STOCK_SYMBOLS,
+        *CRYPTO_SYMBOLS,
+        *COMMODITY_SYMBOLS,
+        *FOREX_SYMBOLS,
+        *FOREX_SYMBOLS_BARE,
+        *FUTURES_SYMBOLS,
+        *FUTURES_SYMBOLS_BARE,
+        *OTHER_SYMBOLS,
+    }
 )
+# `=X` / `=F` suffixes are non-word characters, so `\b` after the literal `F`
+# / `X` still sits at a word/non-word boundary. Longest-first alternation
+# ensures `ES=F` is preferred over the bare `ES` when both could match.
 _SYMBOL_REGEX = re.compile(
-    r"\b(" + "|".join(sorted(_SYMBOL_WHITELIST, key=len, reverse=True)) + r")\b"
+    r"\b(" + "|".join(sorted(map(re.escape, _SYMBOL_WHITELIST), key=len, reverse=True)) + r")\b"
 )
 
 # Asset classes whose intraday timeframes the data-provider chain supports.

--- a/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
@@ -11,6 +11,7 @@ escalates a subset of the overlapping items to critical severity.
 
 from __future__ import annotations
 
+import math
 import re
 from typing import Callable, Iterator, List, Optional
 
@@ -116,6 +117,10 @@ def _default_universe_for(asset_class: str) -> List[str]:
         out = list(CRYPTO_SYMBOLS)
     elif ac == "commodities":
         out = list(COMMODITY_SYMBOLS)
+    elif ac == "forex":
+        out = list(FOREX_SYMBOLS)
+    elif ac == "futures":
+        out = list(FUTURES_SYMBOLS)
     else:
         out = list(OTHER_SYMBOLS)
 
@@ -459,8 +464,10 @@ class SpecReadinessGate:
             try:
                 price = float(self._market_sample_provider(sym))
             except Exception:
-                price = 0.0
-            if price <= 0:
+                price = float("nan")
+            # Fail closed on NaN / +inf / -inf — the gate cannot validate
+            # sizing without a finite positive price.
+            if not math.isfinite(price) or price <= 0:
                 out.append(
                     QualityGateResult(
                         gate_name=GATE,
@@ -468,7 +475,7 @@ class SpecReadinessGate:
                         passed=False,
                         severity="critical",
                         details=(
-                            f"Sizing realisability: no positive price sample "
+                            f"Sizing realisability: no usable price sample "
                             f"for '{sym}' (got {price!r})."
                         ),
                     )
@@ -484,10 +491,11 @@ class SpecReadinessGate:
             else:
                 continue
             qty = notional / price
-            # Crypto/forex accept fractional positions, so anything > 0 is fine.
-            # Stocks/futures/commodities are rejected when qty < 1.
+            # Crypto/forex accept any positive position (threshold 0, strict >).
+            # Stocks/futures/commodities require at least one whole unit;
+            # qty == 1.0 exactly is implementable, so the comparison is strict.
             threshold = 1.0 if enforce_whole_lot else 0.0
-            if qty <= threshold:
+            if qty < threshold or (not enforce_whole_lot and qty <= threshold):
                 out.append(
                     QualityGateResult(
                         gate_name=GATE,

--- a/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
@@ -63,6 +63,11 @@ _SYMBOL_REGEX = re.compile(
 # Asset classes whose intraday timeframes the data-provider chain supports.
 _FULL_TIMEFRAME_ASSET_CLASSES: frozenset[str] = frozenset({"stocks", "crypto"})
 
+# Asset classes that trade in whole units (shares / contracts). Crypto and
+# forex accept fractional quantities, so Rule 5's whole-lot check is skipped
+# for them — the runtime contract takes ``qty: float = Field(gt=0)``.
+_WHOLE_LOT_ASSET_CLASSES: frozenset[str] = frozenset({"stocks", "futures", "commodities"})
+
 # Authoritative set of DSL indicator names. A constructed IndicatorRef always
 # satisfies this set; the gate enforces it again as defense-in-depth against
 # a future refactor that bypasses Pydantic.
@@ -445,6 +450,9 @@ class SpecReadinessGate:
         capital = config.initial_capital
         # Class invariant: BacktestConfig guarantees initial_capital > 0.
         assert capital > 0, "initial_capital must be strictly positive"
+        # Crypto/forex accept fractional quantities — only enforce the whole-lot
+        # threshold for asset classes that need it.
+        enforce_whole_lot = spec.asset_class.lower() in _WHOLE_LOT_ASSET_CLASSES
 
         out: List[QualityGateResult] = []
         for sym in symbols:
@@ -476,7 +484,10 @@ class SpecReadinessGate:
             else:
                 continue
             qty = notional / price
-            if qty < 1:
+            # Crypto/forex accept fractional positions, so anything > 0 is fine.
+            # Stocks/futures/commodities are rejected when qty < 1.
+            threshold = 1.0 if enforce_whole_lot else 0.0
+            if qty <= threshold:
                 out.append(
                     QualityGateResult(
                         gate_name=GATE,
@@ -484,9 +495,9 @@ class SpecReadinessGate:
                         passed=False,
                         severity="critical",
                         details=(
-                            f"Sizing yields qty={qty:.4f} < 1 for symbol "
-                            f"'{sym}' at sample price ${price:.2f} with "
-                            f"capital ${capital:.0f}."
+                            f"Sizing yields qty={qty:.4f} (threshold {threshold}) "
+                            f"for symbol '{sym}' at sample price ${price:.2f} "
+                            f"with capital ${capital:.0f}."
                         ),
                     )
                 )

--- a/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
@@ -445,11 +445,19 @@ class SpecReadinessGate(GateResultsMixin):
             min_tp = min(r.pct for r in take_profits)
             max_sl = max(r.pct for r in stop_losses)
             assert min_tp > 0 and max_sl > 0, "exit-rule pcts must be strictly positive"
+            # Wider stops than profit targets are a deliberate risk/reward
+            # choice for trend-following strategies (let losers run a bit
+            # further before bailing, take winners quicker). The two legs
+            # don't "race" each other — they trigger on opposite price
+            # directions — so this isn't an implementability failure. Warn
+            # so the refinement prompt notices the unusual ratio, but don't
+            # block synthesis.
             if max_sl >= min_tp:
                 out.append(
-                    self._critical(
-                        f"stop_loss.pct={max_sl} ≥ take_profit.pct={min_tp} — "
-                        "stop would trigger before profit target."
+                    self._warning(
+                        f"stop_loss.pct={max_sl} ≥ take_profit.pct={min_tp}; "
+                        "wider stop than profit target is a valid risk/reward "
+                        "choice but unusual — confirm the asymmetry is intentional."
                     )
                 )
 

--- a/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
@@ -1,19 +1,18 @@
-"""Deterministic implementability gate for `StrategySpec` (issue #540).
+"""Deterministic implementability gate for `StrategySpec`.
 
 Runs in the design phase (before any code is written) and again as the first
-gate of the synthesis phase as a sanity check that the spec wasn't mutated.
-Each rule is deterministic, has a dedicated test, and fails closed.
+gate of the synthesis phase to confirm the spec wasn't mutated. Eight
+deterministic rules, each unit-testable and failing closed.
 
-The eight rules implemented here are the ones enumerated in issue #540.
-Several of them overlap with :class:`StrategySpecValidator` — that is
-intentional: this gate is self-contained and runs at a different phase, with
-critical (rather than warning) severity on the items #540 deems blocking.
+Several rules overlap with :class:`StrategySpecValidator`. The overlap is
+intentional: this gate is self-contained, runs at a different phase, and
+escalates a subset of the overlapping items to critical severity.
 """
 
 from __future__ import annotations
 
 import re
-from typing import Callable, List, Optional
+from typing import Callable, Iterator, List, Optional
 
 from ...models import BacktestConfig, StrategySpec
 from ...symbols import COMMODITY_SYMBOLS, CRYPTO_SYMBOLS, OTHER_SYMBOLS, STOCK_SYMBOLS
@@ -31,8 +30,7 @@ from .models import QualityGateResult, StrategyLabPhase
 GATE = "spec_readiness"
 
 # Whitelist regex matches any tradeable symbol the spec is allowed to name in
-# its hypothesis. STOCK ∪ CRYPTO ∪ COMMODITY ∪ OTHER (broad ETFs). Word-bounded
-# so "ETH" doesn't match "ETHEREUM" appearing as a prose adjective.
+# its hypothesis. Word-bounded so "ETH" doesn't match "ETHEREUM".
 _SYMBOL_WHITELIST: frozenset[str] = frozenset(
     {*STOCK_SYMBOLS, *CRYPTO_SYMBOLS, *COMMODITY_SYMBOLS, *OTHER_SYMBOLS}
 )
@@ -40,26 +38,25 @@ _SYMBOL_REGEX = re.compile(
     r"\b(" + "|".join(sorted(_SYMBOL_WHITELIST, key=len, reverse=True)) + r")\b"
 )
 
-# Asset classes that today's data-provider chain supports for every timeframe
-# (stocks/crypto have minute-bar yfinance coverage). Other classes only fetch
-# daily bars reliably — intraday timeframes on those classes are rejected.
+# Asset classes whose intraday timeframes the data-provider chain supports.
 _FULL_TIMEFRAME_ASSET_CLASSES: frozenset[str] = frozenset({"stocks", "crypto"})
 
-# Authoritative set of DSL indicator names. Mirrors `IndicatorName` so a
-# constructed IndicatorRef always satisfies this set; the gate enforces it
-# again as defense-in-depth against a future refactor that bypasses Pydantic.
+# Authoritative set of DSL indicator names. A constructed IndicatorRef always
+# satisfies this set; the gate enforces it again as defense-in-depth against
+# a future refactor that bypasses Pydantic.
 _KNOWN_INDICATOR_NAMES: frozenset[str] = frozenset(IndicatorName.__args__)
 
-# Indicators whose `params` must include a specific key — derived from
-# `_INDICATOR_PARAM_SPECS` in spec_dsl.py. `rsi` is intentionally absent here:
-# the DSL ships a `period=14` default, so a bare `IndicatorRef(name="rsi")` is
-# fully realisable.
+# Indicators whose `params` must include a specific key. `rsi` is intentionally
+# absent: the DSL ships a `period=14` default, so a bare `IndicatorRef(name="rsi")`
+# is fully realisable.
 _INDICATOR_REQUIRED_PARAMS: dict[str, frozenset[str]] = {
     "sma": frozenset({"period"}),
     "ema": frozenset({"period"}),
 }
 
-# Reuse the indicator vocabulary the existing validator uses for prose mentions.
+_VALID_PHASES: frozenset[str] = frozenset({"design", "design_review", "synthesis", "verification"})
+
+# Indicator concept vocabulary for prose mentions in the hypothesis.
 _CONCEPT_TERMS = re.compile(
     r"\b(rsi|macd|moving\s+average|ema|sma|bollinger|atr|stochastic|adx|vwap)\b",
     re.IGNORECASE,
@@ -82,29 +79,39 @@ MarketSampleProvider = Callable[[str], float]
 
 
 def _default_universe_for(asset_class: str) -> List[str]:
+    # Pre: asset_class is a non-empty string.
+    assert isinstance(asset_class, str) and asset_class, "asset_class must be a non-empty str"
+
     ac = asset_class.lower()
     if ac == "stocks":
-        return list(STOCK_SYMBOLS)
-    if ac == "crypto":
-        return list(CRYPTO_SYMBOLS)
-    if ac == "commodities":
-        return list(COMMODITY_SYMBOLS)
-    return list(OTHER_SYMBOLS)
+        out = list(STOCK_SYMBOLS)
+    elif ac == "crypto":
+        out = list(CRYPTO_SYMBOLS)
+    elif ac == "commodities":
+        out = list(COMMODITY_SYMBOLS)
+    else:
+        out = list(OTHER_SYMBOLS)
+
+    # Post: returns a non-empty list of upper-case ticker strings.
+    assert out and all(isinstance(s, str) and s for s in out), "default universe must be non-empty"
+    return out
 
 
 def _default_market_sample_provider(symbol: str) -> float:
-    """Static fallback price used when no real recent-bar feed is wired."""
-    return 100.0
+    # Pre: symbol is a non-empty string.
+    assert isinstance(symbol, str) and symbol, "symbol must be a non-empty str"
+    # Post: returns a strictly positive finite price.
+    price = 100.0
+    assert price > 0, "price must be strictly positive"
+    return price
 
 
 class SpecReadinessGate:
     """Deterministic implementability checks on a constructed ``StrategySpec``.
 
-    Issue #540 — eight blocking rules that refuse a vague or unimplementable
-    spec *before* code synthesis. The gate is self-contained; failures are
-    persisted via ``StrategyLabRecord.quality_gate_results`` with the supplied
-    ``phase`` tag so design-phase vs synthesis-phase invocations are
-    distinguishable downstream.
+    Contract (class invariant): every call to :meth:`validate` returns a
+    non-empty ``List[QualityGateResult]``. Every result in that list carries
+    the ``phase`` argument the caller supplied and has ``gate_name == GATE``.
     """
 
     def __init__(
@@ -113,10 +120,22 @@ class SpecReadinessGate:
         market_sample_provider: Optional[MarketSampleProvider] = None,
         backtest_config: Optional[BacktestConfig] = None,
     ) -> None:
+        # Pre: market_sample_provider, if supplied, must be callable.
+        assert market_sample_provider is None or callable(market_sample_provider), (
+            "market_sample_provider must be callable or None"
+        )
+        # Pre: backtest_config, if supplied, must be a BacktestConfig.
+        assert backtest_config is None or isinstance(backtest_config, BacktestConfig), (
+            "backtest_config must be a BacktestConfig or None"
+        )
+
         self._market_sample_provider: MarketSampleProvider = (
             market_sample_provider or _default_market_sample_provider
         )
         self._backtest_config = backtest_config
+
+        # Post: provider is callable, config slot is the supplied value or None.
+        assert callable(self._market_sample_provider), "provider slot must be callable"
 
     def validate(
         self,
@@ -125,6 +144,13 @@ class SpecReadinessGate:
         phase: StrategyLabPhase = "design",
         backtest_config: Optional[BacktestConfig] = None,
     ) -> List[QualityGateResult]:
+        # Pre: spec is a StrategySpec; phase is one of the four valid labels.
+        assert isinstance(spec, StrategySpec), "spec must be a StrategySpec"
+        assert phase in _VALID_PHASES, f"phase must be one of {sorted(_VALID_PHASES)}; got {phase!r}"
+        assert backtest_config is None or isinstance(backtest_config, BacktestConfig), (
+            "backtest_config override must be a BacktestConfig or None"
+        )
+
         results: List[QualityGateResult] = []
         config = backtest_config or self._backtest_config
 
@@ -148,6 +174,10 @@ class SpecReadinessGate:
                 )
             )
 
+        # Post: results non-empty; every result carries the caller's phase and GATE name.
+        assert results, "validate must always return at least one result"
+        assert all(r.phase == phase for r in results), "every result must carry the caller's phase"
+        assert all(r.gate_name == GATE for r in results), "every result must carry GATE name"
         return results
 
     # ------------------------------------------------------------------
@@ -156,18 +186,18 @@ class SpecReadinessGate:
     def _check_universe_set(
         self, spec: StrategySpec, phase: StrategyLabPhase
     ) -> List[QualityGateResult]:
+        # Pre: spec is StrategySpec, phase is a valid phase literal.
+        assert isinstance(spec, StrategySpec)
+        assert phase in _VALID_PHASES
+
         named = {m.group(0).upper() for m in _SYMBOL_REGEX.finditer(spec.hypothesis or "")}
         targets = {s.upper() for s in spec.target_symbols}
 
-        # Pass-through cases: no symbols named in hypothesis AND target_symbols
-        # is also empty → asset-class default universe will be used (handled
-        # by the fetch path). That's acceptable here; rule 1 only fires on a
-        # mismatch between named and targeted symbols.
+        out: List[QualityGateResult] = []
         if not named and not targets:
-            return []
-
-        if named and not targets:
-            return [
+            pass  # asset-class default universe will be used
+        elif named and not targets:
+            out.append(
                 QualityGateResult(
                     gate_name=GATE,
                     phase=phase,
@@ -179,24 +209,27 @@ class SpecReadinessGate:
                         "include the symbols the strategy is about."
                     ),
                 )
-            ]
-
-        missing = named - targets
-        if missing:
-            return [
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details=(
-                        f"Hypothesis names symbol(s) {sorted(missing)} not "
-                        f"present in target_symbols {sorted(targets)}."
-                    ),
+            )
+        else:
+            missing = named - targets
+            if missing:
+                out.append(
+                    QualityGateResult(
+                        gate_name=GATE,
+                        phase=phase,
+                        passed=False,
+                        severity="critical",
+                        details=(
+                            f"Hypothesis names symbol(s) {sorted(missing)} not "
+                            f"present in target_symbols {sorted(targets)}."
+                        ),
+                    )
                 )
-            ]
 
-        return []
+        # Post: 0 or 1 critical failures; never warnings or info.
+        assert len(out) <= 1, "universe-set check emits at most one result"
+        assert all(not r.passed and r.severity == "critical" for r in out)
+        return out
 
     # ------------------------------------------------------------------
     # Rule 2: Entry rules non-trivial
@@ -204,8 +237,13 @@ class SpecReadinessGate:
     def _check_entry_rules_non_trivial(
         self, spec: StrategySpec, phase: StrategyLabPhase
     ) -> List[QualityGateResult]:
+        # Pre: spec is StrategySpec, phase is a valid phase literal.
+        assert isinstance(spec, StrategySpec)
+        assert phase in _VALID_PHASES
+
+        out: List[QualityGateResult] = []
         if not spec.entry_rules:
-            return [
+            out.append(
                 QualityGateResult(
                     gate_name=GATE,
                     phase=phase,
@@ -213,38 +251,42 @@ class SpecReadinessGate:
                     severity="critical",
                     details="No entry rules — strategy cannot generate trades.",
                 )
-            ]
-
-        for idx, rule in enumerate(spec.entry_rules):
-            if not isinstance(rule, EntryRule):
-                return [
-                    QualityGateResult(
-                        gate_name=GATE,
-                        phase=phase,
-                        passed=False,
-                        severity="critical",
-                        details=(
-                            f"entry_rules[{idx}] is not a structured EntryRule "
-                            f"(got {type(rule).__name__})."
-                        ),
+            )
+        else:
+            for idx, rule in enumerate(spec.entry_rules):
+                if not isinstance(rule, EntryRule):
+                    out.append(
+                        QualityGateResult(
+                            gate_name=GATE,
+                            phase=phase,
+                            passed=False,
+                            severity="critical",
+                            details=(
+                                f"entry_rules[{idx}] is not a structured EntryRule "
+                                f"(got {type(rule).__name__})."
+                            ),
+                        )
                     )
-                ]
-            pred = rule.when
-            if not isinstance(pred, Predicate):
-                return [
-                    QualityGateResult(
-                        gate_name=GATE,
-                        phase=phase,
-                        passed=False,
-                        severity="critical",
-                        details=(
-                            f"entry_rules[{idx}].when is not a Predicate "
-                            f"(got {type(pred).__name__})."
-                        ),
+                    break
+                if not isinstance(rule.when, Predicate):
+                    out.append(
+                        QualityGateResult(
+                            gate_name=GATE,
+                            phase=phase,
+                            passed=False,
+                            severity="critical",
+                            details=(
+                                f"entry_rules[{idx}].when is not a Predicate "
+                                f"(got {type(rule.when).__name__})."
+                            ),
+                        )
                     )
-                ]
+                    break
 
-        return []
+        # Post: 0 or 1 critical failures.
+        assert len(out) <= 1
+        assert all(not r.passed and r.severity == "critical" for r in out)
+        return out
 
     # ------------------------------------------------------------------
     # Rule 3: Indicator validity
@@ -252,9 +294,14 @@ class SpecReadinessGate:
     def _check_indicator_validity(
         self, spec: StrategySpec, phase: StrategyLabPhase
     ) -> List[QualityGateResult]:
+        # Pre: spec is StrategySpec, phase is a valid phase literal.
+        assert isinstance(spec, StrategySpec)
+        assert phase in _VALID_PHASES
+
+        out: List[QualityGateResult] = []
         for ref in self._iter_indicator_refs(spec):
             if ref.name not in _KNOWN_INDICATOR_NAMES:
-                return [
+                out.append(
                     QualityGateResult(
                         gate_name=GATE,
                         phase=phase,
@@ -265,20 +312,29 @@ class SpecReadinessGate:
                             f"set {sorted(_KNOWN_INDICATOR_NAMES)}."
                         ),
                     )
-                ]
+                )
+                break
             required = _INDICATOR_REQUIRED_PARAMS.get(ref.name, frozenset())
             missing = sorted(required - set(ref.params.keys()))
             if missing:
-                return [
+                out.append(
                     QualityGateResult(
                         gate_name=GATE,
                         phase=phase,
                         passed=False,
                         severity="critical",
-                        details=(f"Indicator '{ref.name}' is missing required param(s) {missing}."),
+                        details=(
+                            f"Indicator '{ref.name}' is missing required "
+                            f"param(s) {missing}."
+                        ),
                     )
-                ]
-        return []
+                )
+                break
+
+        # Post: 0 or 1 critical failures (short-circuits on first violation).
+        assert len(out) <= 1
+        assert all(not r.passed and r.severity == "critical" for r in out)
+        return out
 
     # ------------------------------------------------------------------
     # Rule 4: Exit completeness
@@ -286,9 +342,14 @@ class SpecReadinessGate:
     def _check_exit_completeness(
         self, spec: StrategySpec, phase: StrategyLabPhase
     ) -> List[QualityGateResult]:
+        # Pre: spec is StrategySpec, phase is a valid phase literal.
+        assert isinstance(spec, StrategySpec)
+        assert phase in _VALID_PHASES
+
         allowed_kinds = {"signal_exit", "stop_loss", "take_profit"}
+        out: List[QualityGateResult] = []
         if not spec.exit_rules:
-            return [
+            out.append(
                 QualityGateResult(
                     gate_name=GATE,
                     phase=phase,
@@ -299,18 +360,24 @@ class SpecReadinessGate:
                         "least one of: signal_exit, stop_loss, take_profit."
                     ),
                 )
-            ]
-        if not any(getattr(r, "kind", None) in allowed_kinds for r in spec.exit_rules):
-            return [
+            )
+        elif not any(getattr(r, "kind", None) in allowed_kinds for r in spec.exit_rules):
+            out.append(
                 QualityGateResult(
                     gate_name=GATE,
                     phase=phase,
                     passed=False,
                     severity="critical",
-                    details=(f"exit_rules contains no rule of kind in {sorted(allowed_kinds)}."),
+                    details=(
+                        f"exit_rules contains no rule of kind in {sorted(allowed_kinds)}."
+                    ),
                 )
-            ]
-        return []
+            )
+
+        # Post: 0 or 1 critical failures.
+        assert len(out) <= 1
+        assert all(not r.passed and r.severity == "critical" for r in out)
+        return out
 
     # ------------------------------------------------------------------
     # Rule 5: Sizing realisable
@@ -321,24 +388,30 @@ class SpecReadinessGate:
         phase: StrategyLabPhase,
         config: Optional[BacktestConfig],
     ) -> List[QualityGateResult]:
+        # Pre: spec is StrategySpec, phase is valid, config is BacktestConfig or None.
+        assert isinstance(spec, StrategySpec)
+        assert phase in _VALID_PHASES
+        assert config is None or isinstance(config, BacktestConfig)
+
         if config is None:
-            return []  # no capital basis available; skip silently
+            return []
 
         kind = getattr(spec.sizing, "kind", None)
-        # Use target_symbols when set; otherwise pick a deterministic
-        # representative from the asset-class default universe.
         symbols = spec.target_symbols or _default_universe_for(spec.asset_class)
         if not symbols:
             return []
         capital = config.initial_capital
+        # Class invariant: BacktestConfig guarantees initial_capital > 0.
+        assert capital > 0, "initial_capital must be strictly positive"
 
+        out: List[QualityGateResult] = []
         for sym in symbols:
             try:
                 price = float(self._market_sample_provider(sym))
             except Exception:
                 price = 0.0
             if price <= 0:
-                return [
+                out.append(
                     QualityGateResult(
                         gate_name=GATE,
                         phase=phase,
@@ -349,20 +422,20 @@ class SpecReadinessGate:
                             f"for '{sym}' (got {price!r})."
                         ),
                     )
-                ]
+                )
+                break
             if kind == "fixed_fraction":
                 notional = capital * float(spec.sizing.fraction)
             elif kind == "fixed_notional":
                 notional = float(spec.sizing.notional_usd)
             elif kind == "volatility_target":
-                # Volatility-target sizing can't be evaluated without realised
-                # vol; treat as realisable for this static check.
+                # Cannot evaluate without realised vol; treat as realisable.
                 continue
             else:
                 continue
             qty = notional / price
             if qty < 1:
-                return [
+                out.append(
                     QualityGateResult(
                         gate_name=GATE,
                         phase=phase,
@@ -374,8 +447,13 @@ class SpecReadinessGate:
                             f"capital ${capital:.0f}."
                         ),
                     )
-                ]
-        return []
+                )
+                break
+
+        # Post: 0 or 1 critical failures (short-circuits on first symbol that fails).
+        assert len(out) <= 1
+        assert all(not r.passed and r.severity == "critical" for r in out)
+        return out
 
     # ------------------------------------------------------------------
     # Rule 6: Hypothesis–rule consistency
@@ -383,9 +461,14 @@ class SpecReadinessGate:
     def _check_hypothesis_rule_consistency(
         self, spec: StrategySpec, phase: StrategyLabPhase
     ) -> List[QualityGateResult]:
+        # Pre: spec is StrategySpec, phase is a valid phase literal.
+        assert isinstance(spec, StrategySpec)
+        assert phase in _VALID_PHASES
+
         hypothesis = spec.hypothesis or ""
         terms_in_hypothesis = {
-            re.sub(r"\s+", " ", m.group(0).lower()) for m in _CONCEPT_TERMS.finditer(hypothesis)
+            re.sub(r"\s+", " ", m.group(0).lower())
+            for m in _CONCEPT_TERMS.finditer(hypothesis)
         }
         referenced = {ref.name for ref in self._iter_indicator_refs(spec)}
         orphan = sorted(
@@ -393,8 +476,10 @@ class SpecReadinessGate:
             for t in terms_in_hypothesis
             if (n := _CONCEPT_TO_INDICATOR_NAME.get(t)) is not None and n not in referenced
         )
+
+        out: List[QualityGateResult] = []
         if orphan:
-            return [
+            out.append(
                 QualityGateResult(
                     gate_name=GATE,
                     phase=phase,
@@ -405,8 +490,12 @@ class SpecReadinessGate:
                         "that no entry/exit rule references."
                     ),
                 )
-            ]
-        return []
+            )
+
+        # Post: 0 or 1 critical failures.
+        assert len(out) <= 1
+        assert all(not r.passed and r.severity == "critical" for r in out)
+        return out
 
     # ------------------------------------------------------------------
     # Rule 7: Timeframe data availability
@@ -414,10 +503,13 @@ class SpecReadinessGate:
     def _check_timeframe_availability(
         self, spec: StrategySpec, phase: StrategyLabPhase
     ) -> List[QualityGateResult]:
-        if spec.timeframe == "1d":
-            return []
-        if spec.asset_class.lower() not in _FULL_TIMEFRAME_ASSET_CLASSES:
-            return [
+        # Pre: spec is StrategySpec, phase is a valid phase literal.
+        assert isinstance(spec, StrategySpec)
+        assert phase in _VALID_PHASES
+
+        out: List[QualityGateResult] = []
+        if spec.timeframe != "1d" and spec.asset_class.lower() not in _FULL_TIMEFRAME_ASSET_CLASSES:
+            out.append(
                 QualityGateResult(
                     gate_name=GATE,
                     phase=phase,
@@ -429,8 +521,12 @@ class SpecReadinessGate:
                         "use '1d' or pick stocks/crypto."
                     ),
                 )
-            ]
-        return []
+            )
+
+        # Post: 0 or 1 critical failures.
+        assert len(out) <= 1
+        assert all(not r.passed and r.severity == "critical" for r in out)
+        return out
 
     # ------------------------------------------------------------------
     # Rule 8: Risk-limit coherence
@@ -438,6 +534,10 @@ class SpecReadinessGate:
     def _check_risk_limit_coherence(
         self, spec: StrategySpec, phase: StrategyLabPhase
     ) -> List[QualityGateResult]:
+        # Pre: spec is StrategySpec, phase is a valid phase literal.
+        assert isinstance(spec, StrategySpec)
+        assert phase in _VALID_PHASES
+
         out: List[QualityGateResult] = []
 
         stop_losses = [r for r in spec.exit_rules if isinstance(r, StopLossRule)]
@@ -445,6 +545,8 @@ class SpecReadinessGate:
         if stop_losses and take_profits:
             min_tp = min(r.pct for r in take_profits)
             max_sl = max(r.pct for r in stop_losses)
+            # Class invariant: StopLossRule.pct and TakeProfitRule.pct are > 0.
+            assert min_tp > 0 and max_sl > 0, "exit-rule pcts must be strictly positive"
             if max_sl >= min_tp:
                 out.append(
                     QualityGateResult(
@@ -473,13 +575,18 @@ class SpecReadinessGate:
                 )
             )
 
+        # Post: 0, 1, or 2 critical failures (the two sub-checks are independent).
+        assert len(out) <= 2
+        assert all(not r.passed and r.severity == "critical" for r in out)
         return out
 
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
     @staticmethod
-    def _iter_indicator_refs(spec: StrategySpec):
+    def _iter_indicator_refs(spec: StrategySpec) -> Iterator[IndicatorRef]:
+        # Pre: spec is a StrategySpec.
+        assert isinstance(spec, StrategySpec)
         for rule in spec.entry_rules:
             yield from SpecReadinessGate._predicate_indicator_refs(rule.when)
         for rule in spec.exit_rules:
@@ -487,7 +594,9 @@ class SpecReadinessGate:
                 yield from SpecReadinessGate._predicate_indicator_refs(rule.when)
 
     @staticmethod
-    def _predicate_indicator_refs(pred: Predicate):
+    def _predicate_indicator_refs(pred: Predicate) -> Iterator[IndicatorRef]:
+        # Pre: pred is a Predicate.
+        assert isinstance(pred, Predicate)
         if isinstance(pred.lhs, IndicatorRef):
             yield pred.lhs
         if isinstance(pred.rhs, IndicatorRef):

--- a/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import math
 import re
-from typing import Callable, Iterator, List, Optional
+from typing import Callable, ClassVar, Iterable, Iterator, List, Optional
 
 from ...models import BacktestConfig, StrategySpec
 from ...symbols import (
@@ -35,7 +35,7 @@ from ..spec_dsl import (
     StopLossRule,
     TakeProfitRule,
 )
-from .models import QualityGateResult, StrategyLabPhase
+from .models import GateResultsMixin, QualityGateResult, StrategyLabPhase
 
 GATE = "spec_readiness"
 
@@ -82,8 +82,6 @@ _INDICATOR_REQUIRED_PARAMS: dict[str, frozenset[str]] = {
     "sma": frozenset({"period"}),
     "ema": frozenset({"period"}),
 }
-
-_VALID_PHASES: frozenset[str] = frozenset({"design", "design_review", "synthesis", "verification"})
 
 # Indicator concept vocabulary for prose mentions in the hypothesis.
 _CONCEPT_TERMS = re.compile(
@@ -164,13 +162,15 @@ def _default_market_sample_provider(symbol: str, asset_class: str) -> float:
     return price
 
 
-class SpecReadinessGate:
+class SpecReadinessGate(GateResultsMixin):
     """Deterministic implementability checks on a constructed ``StrategySpec``.
 
     Contract (class invariant): every call to :meth:`validate` returns a
     non-empty ``List[QualityGateResult]``. Every result in that list carries
     the ``phase`` argument the caller supplied and has ``gate_name == GATE``.
     """
+
+    GATE: ClassVar[str] = GATE
 
     def __init__(
         self,
@@ -191,6 +191,11 @@ class SpecReadinessGate:
             market_sample_provider or _default_market_sample_provider
         )
         self._backtest_config = backtest_config
+        # Per-call config slot — set by ``validate()`` before any rule runs so
+        # individual ``_check_*`` methods can read it without an extra
+        # parameter. Reset back to ``None`` on exit so the gate can be safely
+        # re-used across cycles.
+        self._call_config: Optional[BacktestConfig] = None
 
         # Post: provider is callable, config slot is the supplied value or None.
         assert callable(self._market_sample_provider), "provider slot must be callable"
@@ -202,418 +207,230 @@ class SpecReadinessGate:
         phase: StrategyLabPhase = "design",
         backtest_config: Optional[BacktestConfig] = None,
     ) -> List[QualityGateResult]:
-        # Pre: spec is a StrategySpec; phase is one of the four valid labels.
+        """Run every readiness rule and return one result list.
+
+        Pre: ``spec`` is a StrategySpec; ``phase`` is a valid phase literal.
+        Post: result list is non-empty; every entry carries the caller's
+        ``phase`` and ``gate_name == GATE``.
+        """
         assert isinstance(spec, StrategySpec), "spec must be a StrategySpec"
-        assert phase in _VALID_PHASES, f"phase must be one of {sorted(_VALID_PHASES)}; got {phase!r}"
         assert backtest_config is None or isinstance(backtest_config, BacktestConfig), (
             "backtest_config override must be a BacktestConfig or None"
         )
-
-        results: List[QualityGateResult] = []
-        config = backtest_config or self._backtest_config
-
-        results.extend(self._check_universe_set(spec, phase))
-        results.extend(self._check_entry_rules_non_trivial(spec, phase))
-        results.extend(self._check_indicator_validity(spec, phase))
-        results.extend(self._check_exit_completeness(spec, phase))
-        results.extend(self._check_sizing_realisable(spec, phase, config))
-        results.extend(self._check_hypothesis_rule_consistency(spec, phase))
-        results.extend(self._check_timeframe_availability(spec, phase))
-        results.extend(self._check_risk_limit_coherence(spec, phase))
-
-        if not results:
-            results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=True,
-                    severity="info",
-                    details="Strategy spec passed all readiness checks.",
-                )
+        self._set_phase(phase)
+        self._call_config = backtest_config or self._backtest_config
+        try:
+            results: List[QualityGateResult] = [
+                r for rule in self._RULES for r in rule(self, spec)
+            ]
+            if not results:
+                results.append(self._info("Strategy spec passed all readiness checks."))
+            # Post: every result carries the caller's phase and GATE name.
+            assert all(r.phase == phase for r in results), (
+                "every result must carry the caller's phase"
             )
-
-        # Post: results non-empty; every result carries the caller's phase and GATE name.
-        assert results, "validate must always return at least one result"
-        assert all(r.phase == phase for r in results), "every result must carry the caller's phase"
-        assert all(r.gate_name == GATE for r in results), "every result must carry GATE name"
-        return results
+            assert all(r.gate_name == GATE for r in results), (
+                "every result must carry GATE name"
+            )
+            return results
+        finally:
+            self._call_config = None
 
     # ------------------------------------------------------------------
-    # Rule 1: Universe set
+    # Rule 1: Universe set — every whitelisted ticker named in the
+    # hypothesis must also appear in ``target_symbols`` (after stripping
+    # Yahoo provider suffixes).
     # ------------------------------------------------------------------
-    def _check_universe_set(
-        self, spec: StrategySpec, phase: StrategyLabPhase
-    ) -> List[QualityGateResult]:
-        # Pre: spec is StrategySpec, phase is a valid phase literal.
+    def _check_universe_set(self, spec: StrategySpec) -> Iterable[QualityGateResult]:
         assert isinstance(spec, StrategySpec)
-        assert phase in _VALID_PHASES
-
         named_raw = {m.group(0).upper() for m in _SYMBOL_REGEX.finditer(spec.hypothesis or "")}
         targets_raw = {s.upper() for s in spec.target_symbols}
-        # Compare on the canonical (suffix-stripped) form so `ES` ≡ `ES=F` and
-        # `EURUSD` ≡ `EURUSD=X` — the spec is implementable either way; the
-        # downstream fetcher resolves the provider form when needed.
-        named_canon = {_canonicalize_ticker(s) for s in named_raw}
-        targets_canon = {_canonicalize_ticker(s) for s in targets_raw}
+        named = {_canonicalize_ticker(s) for s in named_raw}
+        targets = {_canonicalize_ticker(s) for s in targets_raw}
+        if not named or named <= targets:
+            return ()
+        if not targets:
+            return (
+                self._critical(
+                    f"Hypothesis names symbol(s) {sorted(named_raw)} but "
+                    "target_symbols is empty — backtest universe would not "
+                    "include the symbols the strategy is about."
+                ),
+            )
+        missing_canon = named - targets
+        missing_raw = sorted(s for s in named_raw if _canonicalize_ticker(s) in missing_canon)
+        return (
+            self._critical(
+                f"Hypothesis names symbol(s) {missing_raw} not "
+                f"present in target_symbols {sorted(targets_raw)}."
+            ),
+        )
 
-        out: List[QualityGateResult] = []
-        if not named_canon and not targets_canon:
-            pass  # asset-class default universe will be used
-        elif named_canon and not targets_canon:
-            out.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details=(
-                        f"Hypothesis names symbol(s) {sorted(named_raw)} but "
-                        "target_symbols is empty — backtest universe would not "
-                        "include the symbols the strategy is about."
+    # ------------------------------------------------------------------
+    # Rule 2: Entry rules non-trivial.
+    # ------------------------------------------------------------------
+    def _check_entry_rules_non_trivial(self, spec: StrategySpec) -> Iterable[QualityGateResult]:
+        assert isinstance(spec, StrategySpec)
+        if not spec.entry_rules:
+            return (self._critical("No entry rules — strategy cannot generate trades."),)
+        for idx, rule in enumerate(spec.entry_rules):
+            if not isinstance(rule, EntryRule):
+                return (
+                    self._critical(
+                        f"entry_rules[{idx}] is not a structured EntryRule "
+                        f"(got {type(rule).__name__})."
                     ),
                 )
-            )
-        else:
-            missing_canon = named_canon - targets_canon
-            if missing_canon:
-                missing_raw = sorted(s for s in named_raw if _canonicalize_ticker(s) in missing_canon)
-                out.append(
-                    QualityGateResult(
-                        gate_name=GATE,
-                        phase=phase,
-                        passed=False,
-                        severity="critical",
-                        details=(
-                            f"Hypothesis names symbol(s) {missing_raw} not "
-                            f"present in target_symbols {sorted(targets_raw)}."
-                        ),
-                    )
+            if not isinstance(rule.when, Predicate):
+                return (
+                    self._critical(
+                        f"entry_rules[{idx}].when is not a Predicate "
+                        f"(got {type(rule.when).__name__})."
+                    ),
                 )
-
-        # Post: 0 or 1 critical failures; never warnings or info.
-        assert len(out) <= 1, "universe-set check emits at most one result"
-        assert all(not r.passed and r.severity == "critical" for r in out)
-        return out
+        return ()
 
     # ------------------------------------------------------------------
-    # Rule 2: Entry rules non-trivial
+    # Rule 3: Indicator validity.
     # ------------------------------------------------------------------
-    def _check_entry_rules_non_trivial(
-        self, spec: StrategySpec, phase: StrategyLabPhase
-    ) -> List[QualityGateResult]:
-        # Pre: spec is StrategySpec, phase is a valid phase literal.
+    def _check_indicator_validity(self, spec: StrategySpec) -> Iterable[QualityGateResult]:
         assert isinstance(spec, StrategySpec)
-        assert phase in _VALID_PHASES
-
-        out: List[QualityGateResult] = []
-        if not spec.entry_rules:
-            out.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details="No entry rules — strategy cannot generate trades.",
-                )
-            )
-        else:
-            for idx, rule in enumerate(spec.entry_rules):
-                if not isinstance(rule, EntryRule):
-                    out.append(
-                        QualityGateResult(
-                            gate_name=GATE,
-                            phase=phase,
-                            passed=False,
-                            severity="critical",
-                            details=(
-                                f"entry_rules[{idx}] is not a structured EntryRule "
-                                f"(got {type(rule).__name__})."
-                            ),
-                        )
-                    )
-                    break
-                if not isinstance(rule.when, Predicate):
-                    out.append(
-                        QualityGateResult(
-                            gate_name=GATE,
-                            phase=phase,
-                            passed=False,
-                            severity="critical",
-                            details=(
-                                f"entry_rules[{idx}].when is not a Predicate "
-                                f"(got {type(rule.when).__name__})."
-                            ),
-                        )
-                    )
-                    break
-
-        # Post: 0 or 1 critical failures.
-        assert len(out) <= 1
-        assert all(not r.passed and r.severity == "critical" for r in out)
-        return out
-
-    # ------------------------------------------------------------------
-    # Rule 3: Indicator validity
-    # ------------------------------------------------------------------
-    def _check_indicator_validity(
-        self, spec: StrategySpec, phase: StrategyLabPhase
-    ) -> List[QualityGateResult]:
-        # Pre: spec is StrategySpec, phase is a valid phase literal.
-        assert isinstance(spec, StrategySpec)
-        assert phase in _VALID_PHASES
-
-        out: List[QualityGateResult] = []
         for ref in self._iter_indicator_refs(spec):
             if ref.name not in _KNOWN_INDICATOR_NAMES:
-                out.append(
-                    QualityGateResult(
-                        gate_name=GATE,
-                        phase=phase,
-                        passed=False,
-                        severity="critical",
-                        details=(
-                            f"Indicator '{ref.name}' is not in the supported "
-                            f"set {sorted(_KNOWN_INDICATOR_NAMES)}."
-                        ),
-                    )
+                return (
+                    self._critical(
+                        f"Indicator '{ref.name}' is not in the supported "
+                        f"set {sorted(_KNOWN_INDICATOR_NAMES)}."
+                    ),
                 )
-                break
             required = _INDICATOR_REQUIRED_PARAMS.get(ref.name, frozenset())
             missing = sorted(required - set(ref.params.keys()))
             if missing:
-                out.append(
-                    QualityGateResult(
-                        gate_name=GATE,
-                        phase=phase,
-                        passed=False,
-                        severity="critical",
-                        details=(
-                            f"Indicator '{ref.name}' is missing required "
-                            f"param(s) {missing}."
-                        ),
-                    )
+                return (
+                    self._critical(
+                        f"Indicator '{ref.name}' is missing required param(s) {missing}."
+                    ),
                 )
-                break
-
-        # Post: 0 or 1 critical failures (short-circuits on first violation).
-        assert len(out) <= 1
-        assert all(not r.passed and r.severity == "critical" for r in out)
-        return out
+        return ()
 
     # ------------------------------------------------------------------
-    # Rule 4: Exit completeness
+    # Rule 4: Exit completeness.
     # ------------------------------------------------------------------
-    def _check_exit_completeness(
-        self, spec: StrategySpec, phase: StrategyLabPhase
-    ) -> List[QualityGateResult]:
-        # Pre: spec is StrategySpec, phase is a valid phase literal.
+    def _check_exit_completeness(self, spec: StrategySpec) -> Iterable[QualityGateResult]:
         assert isinstance(spec, StrategySpec)
-        assert phase in _VALID_PHASES
-
         allowed_kinds = {"signal_exit", "stop_loss", "take_profit"}
-        out: List[QualityGateResult] = []
         if not spec.exit_rules:
-            out.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details=(
-                        "No exit rules — positions would never close. Add at "
-                        "least one of: signal_exit, stop_loss, take_profit."
-                    ),
-                )
+            return (
+                self._critical(
+                    "No exit rules — positions would never close. Add at "
+                    "least one of: signal_exit, stop_loss, take_profit."
+                ),
             )
-        elif not any(getattr(r, "kind", None) in allowed_kinds for r in spec.exit_rules):
-            out.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details=(
-                        f"exit_rules contains no rule of kind in {sorted(allowed_kinds)}."
-                    ),
-                )
+        if not any(getattr(r, "kind", None) in allowed_kinds for r in spec.exit_rules):
+            return (
+                self._critical(
+                    f"exit_rules contains no rule of kind in {sorted(allowed_kinds)}."
+                ),
             )
-
-        # Post: 0 or 1 critical failures.
-        assert len(out) <= 1
-        assert all(not r.passed and r.severity == "critical" for r in out)
-        return out
+        return ()
 
     # ------------------------------------------------------------------
-    # Rule 5: Sizing realisable
+    # Rule 5: Sizing realisable.
     # ------------------------------------------------------------------
-    def _check_sizing_realisable(
-        self,
-        spec: StrategySpec,
-        phase: StrategyLabPhase,
-        config: Optional[BacktestConfig],
-    ) -> List[QualityGateResult]:
-        # Pre: spec is StrategySpec, phase is valid, config is BacktestConfig or None.
+    def _check_sizing_realisable(self, spec: StrategySpec) -> Iterable[QualityGateResult]:
         assert isinstance(spec, StrategySpec)
-        assert phase in _VALID_PHASES
-        assert config is None or isinstance(config, BacktestConfig)
-
+        config = self._call_config
         if config is None:
-            return []
+            return ()
 
         kind = getattr(spec.sizing, "kind", None)
         symbols = spec.target_symbols or _default_universe_for(spec.asset_class)
         if not symbols:
-            return []
+            return ()
         capital = config.initial_capital
-        # Class invariant: BacktestConfig guarantees initial_capital > 0.
         assert capital > 0, "initial_capital must be strictly positive"
-        # Crypto/forex accept fractional quantities — only enforce the whole-lot
-        # threshold for asset classes that need it.
         enforce_whole_lot = spec.asset_class.lower() in _WHOLE_LOT_ASSET_CLASSES
+        threshold = 1.0 if enforce_whole_lot else 0.0
 
-        out: List[QualityGateResult] = []
         for sym in symbols:
             try:
                 price = float(self._market_sample_provider(sym, spec.asset_class))
             except Exception:
                 price = float("nan")
-            # Fail closed on NaN / +inf / -inf — the gate cannot validate
-            # sizing without a finite positive price.
             if not math.isfinite(price) or price <= 0:
-                out.append(
-                    QualityGateResult(
-                        gate_name=GATE,
-                        phase=phase,
-                        passed=False,
-                        severity="critical",
-                        details=(
-                            f"Sizing realisability: no usable price sample "
-                            f"for '{sym}' (got {price!r})."
-                        ),
-                    )
+                return (
+                    self._critical(
+                        f"Sizing realisability: no usable price sample for '{sym}' (got {price!r})."
+                    ),
                 )
-                break
             if kind == "fixed_fraction":
                 notional = capital * float(spec.sizing.fraction)
             elif kind == "fixed_notional":
                 notional = float(spec.sizing.notional_usd)
-            elif kind == "volatility_target":
-                # Cannot evaluate without realised vol; treat as realisable.
-                continue
             else:
+                # volatility_target needs realised vol — cannot evaluate here.
                 continue
             qty = notional / price
-            # Crypto/forex accept any positive position (threshold 0, strict >).
-            # Stocks/futures/commodities require at least one whole unit;
-            # qty == 1.0 exactly is implementable, so the comparison is strict.
-            threshold = 1.0 if enforce_whole_lot else 0.0
             if qty < threshold or (not enforce_whole_lot and qty <= threshold):
-                out.append(
-                    QualityGateResult(
-                        gate_name=GATE,
-                        phase=phase,
-                        passed=False,
-                        severity="critical",
-                        details=(
-                            f"Sizing yields qty={qty:.4f} (threshold {threshold}) "
-                            f"for symbol '{sym}' at sample price ${price:.2f} "
-                            f"with capital ${capital:.0f}."
-                        ),
-                    )
+                return (
+                    self._critical(
+                        f"Sizing yields qty={qty:.4f} (threshold {threshold}) "
+                        f"for symbol '{sym}' at sample price ${price:.2f} "
+                        f"with capital ${capital:.0f}."
+                    ),
                 )
-                break
-
-        # Post: 0 or 1 critical failures (short-circuits on first symbol that fails).
-        assert len(out) <= 1
-        assert all(not r.passed and r.severity == "critical" for r in out)
-        return out
+        return ()
 
     # ------------------------------------------------------------------
-    # Rule 6: Hypothesis–rule consistency
+    # Rule 6: Hypothesis–rule consistency.
     # ------------------------------------------------------------------
     def _check_hypothesis_rule_consistency(
-        self, spec: StrategySpec, phase: StrategyLabPhase
-    ) -> List[QualityGateResult]:
-        # Pre: spec is StrategySpec, phase is a valid phase literal.
+        self, spec: StrategySpec
+    ) -> Iterable[QualityGateResult]:
         assert isinstance(spec, StrategySpec)
-        assert phase in _VALID_PHASES
-
-        hypothesis = spec.hypothesis or ""
-        terms_in_hypothesis = {
+        terms = {
             re.sub(r"\s+", " ", m.group(0).lower())
-            for m in _CONCEPT_TERMS.finditer(hypothesis)
+            for m in _CONCEPT_TERMS.finditer(spec.hypothesis or "")
         }
         referenced = {ref.name for ref in self._iter_indicator_refs(spec)}
-        # A concept fires only when *none* of its allowed indicators is
-        # referenced — so "moving average" is satisfied by either SMA or EMA.
+        # A concept fires only when *none* of its allowed indicators is referenced,
+        # so "moving average" is satisfied by either SMA or EMA.
         orphan = sorted(
             t
-            for t in terms_in_hypothesis
+            for t in terms
             if (names := _CONCEPT_TO_INDICATOR_NAMES.get(t)) is not None
             and not (names & referenced)
         )
-
-        out: List[QualityGateResult] = []
-        if orphan:
-            out.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details=(
-                        f"Hypothesis names indicator concept(s) {sorted(orphan)} "
-                        "that no entry/exit rule references."
-                    ),
-                )
-            )
-
-        # Post: 0 or 1 critical failures.
-        assert len(out) <= 1
-        assert all(not r.passed and r.severity == "critical" for r in out)
-        return out
+        if not orphan:
+            return ()
+        return (
+            self._critical(
+                f"Hypothesis names indicator concept(s) {orphan} "
+                "that no entry/exit rule references."
+            ),
+        )
 
     # ------------------------------------------------------------------
-    # Rule 7: Timeframe data availability
+    # Rule 7: Timeframe data availability.
     # ------------------------------------------------------------------
-    def _check_timeframe_availability(
-        self, spec: StrategySpec, phase: StrategyLabPhase
-    ) -> List[QualityGateResult]:
-        # Pre: spec is StrategySpec, phase is a valid phase literal.
+    def _check_timeframe_availability(self, spec: StrategySpec) -> Iterable[QualityGateResult]:
         assert isinstance(spec, StrategySpec)
-        assert phase in _VALID_PHASES
-
-        out: List[QualityGateResult] = []
-        if spec.timeframe != "1d" and spec.asset_class.lower() not in _FULL_TIMEFRAME_ASSET_CLASSES:
-            out.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details=(
-                        f"Asset class '{spec.asset_class}' has no reliable "
-                        f"intraday data for timeframe '{spec.timeframe}'; "
-                        "use '1d' or pick stocks/crypto."
-                    ),
-                )
-            )
-
-        # Post: 0 or 1 critical failures.
-        assert len(out) <= 1
-        assert all(not r.passed and r.severity == "critical" for r in out)
-        return out
+        if spec.timeframe == "1d" or spec.asset_class.lower() in _FULL_TIMEFRAME_ASSET_CLASSES:
+            return ()
+        return (
+            self._critical(
+                f"Asset class '{spec.asset_class}' has no reliable "
+                f"intraday data for timeframe '{spec.timeframe}'; "
+                "use '1d' or pick stocks/crypto."
+            ),
+        )
 
     # ------------------------------------------------------------------
-    # Rule 8: Risk-limit coherence
+    # Rule 8: Risk-limit coherence — independent stop/profit and position
+    # caps; both sub-checks can fire on the same spec.
     # ------------------------------------------------------------------
-    def _check_risk_limit_coherence(
-        self, spec: StrategySpec, phase: StrategyLabPhase
-    ) -> List[QualityGateResult]:
-        # Pre: spec is StrategySpec, phase is a valid phase literal.
+    def _check_risk_limit_coherence(self, spec: StrategySpec) -> Iterable[QualityGateResult]:
         assert isinstance(spec, StrategySpec)
-        assert phase in _VALID_PHASES
-
         out: List[QualityGateResult] = []
 
         stop_losses = [r for r in spec.exit_rules if isinstance(r, StopLossRule)]
@@ -621,47 +438,44 @@ class SpecReadinessGate:
         if stop_losses and take_profits:
             min_tp = min(r.pct for r in take_profits)
             max_sl = max(r.pct for r in stop_losses)
-            # Class invariant: StopLossRule.pct and TakeProfitRule.pct are > 0.
             assert min_tp > 0 and max_sl > 0, "exit-rule pcts must be strictly positive"
             if max_sl >= min_tp:
                 out.append(
-                    QualityGateResult(
-                        gate_name=GATE,
-                        phase=phase,
-                        passed=False,
-                        severity="critical",
-                        details=(
-                            f"stop_loss.pct={max_sl} ≥ take_profit.pct={min_tp} — "
-                            "stop would trigger before profit target."
-                        ),
+                    self._critical(
+                        f"stop_loss.pct={max_sl} ≥ take_profit.pct={min_tp} — "
+                        "stop would trigger before profit target."
                     )
                 )
 
         if spec.risk_limits.max_position_pct > 25:
             out.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details=(
-                        f"max_position_pct={spec.risk_limits.max_position_pct}% "
-                        "exceeds the 25% cap for a single-position risk budget."
-                    ),
+                self._critical(
+                    f"max_position_pct={spec.risk_limits.max_position_pct}% "
+                    "exceeds the 25% cap for a single-position risk budget."
                 )
             )
-
-        # Post: 0, 1, or 2 critical failures (the two sub-checks are independent).
-        assert len(out) <= 2
-        assert all(not r.passed and r.severity == "critical" for r in out)
         return out
+
+    # ------------------------------------------------------------------
+    # Rule registry — declarative list iterated by ``validate``. Order is
+    # preserved so error messages remain stable across runs.
+    # ------------------------------------------------------------------
+    _RULES: ClassVar[tuple] = (
+        _check_universe_set,
+        _check_entry_rules_non_trivial,
+        _check_indicator_validity,
+        _check_exit_completeness,
+        _check_sizing_realisable,
+        _check_hypothesis_rule_consistency,
+        _check_timeframe_availability,
+        _check_risk_limit_coherence,
+    )
 
     # ------------------------------------------------------------------
     # Helpers
     # ------------------------------------------------------------------
     @staticmethod
     def _iter_indicator_refs(spec: StrategySpec) -> Iterator[IndicatorRef]:
-        # Pre: spec is a StrategySpec.
         assert isinstance(spec, StrategySpec)
         for rule in spec.entry_rules:
             yield from SpecReadinessGate._predicate_indicator_refs(rule.when)
@@ -671,7 +485,6 @@ class SpecReadinessGate:
 
     @staticmethod
     def _predicate_indicator_refs(pred: Predicate) -> Iterator[IndicatorRef]:
-        # Pre: pred is a Predicate.
         assert isinstance(pred, Predicate)
         if isinstance(pred.lhs, IndicatorRef):
             yield pred.lhs

--- a/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import math
 import re
+from dataclasses import dataclass
 from typing import Callable, ClassVar, Iterable, Iterator, List, Optional
 
 from ...models import BacktestConfig, StrategySpec
@@ -162,6 +163,19 @@ def _default_market_sample_provider(symbol: str, asset_class: str) -> float:
     return price
 
 
+@dataclass(frozen=True)
+class SpecReadinessCtx:
+    """Per-``validate`` context handed to every rule in ``SpecReadinessGate._RULES``.
+
+    Built once at the top of ``validate``. Threading the ctx explicitly
+    through each rule replaces the previous ``ctx.config`` slot that
+    had to be reset in a ``finally`` block.
+    """
+
+    spec: StrategySpec
+    config: Optional[BacktestConfig]
+
+
 class SpecReadinessGate(GateResultsMixin):
     """Deterministic implementability checks on a constructed ``StrategySpec``.
 
@@ -191,13 +205,8 @@ class SpecReadinessGate(GateResultsMixin):
             market_sample_provider or _default_market_sample_provider
         )
         self._backtest_config = backtest_config
-        # Per-call config slot — set by ``validate()`` before any rule runs so
-        # individual ``_check_*`` methods can read it without an extra
-        # parameter. Reset back to ``None`` on exit so the gate can be safely
-        # re-used across cycles.
-        self._call_config: Optional[BacktestConfig] = None
 
-        # Post: provider is callable, config slot is the supplied value or None.
+        # Post: provider is callable.
         assert callable(self._market_sample_provider), "provider slot must be callable"
 
     def validate(
@@ -218,33 +227,30 @@ class SpecReadinessGate(GateResultsMixin):
             "backtest_config override must be a BacktestConfig or None"
         )
         self._set_phase(phase)
-        self._call_config = backtest_config or self._backtest_config
-        try:
-            results: List[QualityGateResult] = [
-                r for rule in self._RULES for r in rule(self, spec)
-            ]
-            if not results:
-                results.append(self._info("Strategy spec passed all readiness checks."))
-            # Post: every result carries the caller's phase and GATE name.
-            assert all(r.phase == phase for r in results), (
-                "every result must carry the caller's phase"
-            )
-            assert all(r.gate_name == GATE for r in results), (
-                "every result must carry GATE name"
-            )
-            return results
-        finally:
-            self._call_config = None
+        ctx = SpecReadinessCtx(spec=spec, config=backtest_config or self._backtest_config)
+        results: List[QualityGateResult] = [
+            r for rule in self._RULES for r in rule(self, ctx)
+        ]
+        if not results:
+            results.append(self._info("Strategy spec passed all readiness checks."))
+        # Post: every result carries the caller's phase and GATE name.
+        assert all(r.phase == phase for r in results), (
+            "every result must carry the caller's phase"
+        )
+        assert all(r.gate_name == GATE for r in results), (
+            "every result must carry GATE name"
+        )
+        return results
 
     # ------------------------------------------------------------------
     # Rule 1: Universe set — every whitelisted ticker named in the
     # hypothesis must also appear in ``target_symbols`` (after stripping
     # Yahoo provider suffixes).
     # ------------------------------------------------------------------
-    def _check_universe_set(self, spec: StrategySpec) -> Iterable[QualityGateResult]:
-        assert isinstance(spec, StrategySpec)
-        named_raw = {m.group(0).upper() for m in _SYMBOL_REGEX.finditer(spec.hypothesis or "")}
-        targets_raw = {s.upper() for s in spec.target_symbols}
+    def _check_universe_set(self, ctx: SpecReadinessCtx) -> Iterable[QualityGateResult]:
+        assert isinstance(ctx.spec, StrategySpec)
+        named_raw = {m.group(0).upper() for m in _SYMBOL_REGEX.finditer(ctx.spec.hypothesis or "")}
+        targets_raw = {s.upper() for s in ctx.spec.target_symbols}
         named = {_canonicalize_ticker(s) for s in named_raw}
         targets = {_canonicalize_ticker(s) for s in targets_raw}
         if not named or named <= targets:
@@ -269,11 +275,11 @@ class SpecReadinessGate(GateResultsMixin):
     # ------------------------------------------------------------------
     # Rule 2: Entry rules non-trivial.
     # ------------------------------------------------------------------
-    def _check_entry_rules_non_trivial(self, spec: StrategySpec) -> Iterable[QualityGateResult]:
-        assert isinstance(spec, StrategySpec)
-        if not spec.entry_rules:
+    def _check_entry_rules_non_trivial(self, ctx: SpecReadinessCtx) -> Iterable[QualityGateResult]:
+        assert isinstance(ctx.spec, StrategySpec)
+        if not ctx.spec.entry_rules:
             return (self._critical("No entry rules — strategy cannot generate trades."),)
-        for idx, rule in enumerate(spec.entry_rules):
+        for idx, rule in enumerate(ctx.spec.entry_rules):
             if not isinstance(rule, EntryRule):
                 return (
                     self._critical(
@@ -293,9 +299,9 @@ class SpecReadinessGate(GateResultsMixin):
     # ------------------------------------------------------------------
     # Rule 3: Indicator validity.
     # ------------------------------------------------------------------
-    def _check_indicator_validity(self, spec: StrategySpec) -> Iterable[QualityGateResult]:
-        assert isinstance(spec, StrategySpec)
-        for ref in self._iter_indicator_refs(spec):
+    def _check_indicator_validity(self, ctx: SpecReadinessCtx) -> Iterable[QualityGateResult]:
+        assert isinstance(ctx.spec, StrategySpec)
+        for ref in self._iter_indicator_refs(ctx.spec):
             if ref.name not in _KNOWN_INDICATOR_NAMES:
                 return (
                     self._critical(
@@ -316,17 +322,17 @@ class SpecReadinessGate(GateResultsMixin):
     # ------------------------------------------------------------------
     # Rule 4: Exit completeness.
     # ------------------------------------------------------------------
-    def _check_exit_completeness(self, spec: StrategySpec) -> Iterable[QualityGateResult]:
-        assert isinstance(spec, StrategySpec)
+    def _check_exit_completeness(self, ctx: SpecReadinessCtx) -> Iterable[QualityGateResult]:
+        assert isinstance(ctx.spec, StrategySpec)
         allowed_kinds = {"signal_exit", "stop_loss", "take_profit"}
-        if not spec.exit_rules:
+        if not ctx.spec.exit_rules:
             return (
                 self._critical(
                     "No exit rules — positions would never close. Add at "
                     "least one of: signal_exit, stop_loss, take_profit."
                 ),
             )
-        if not any(getattr(r, "kind", None) in allowed_kinds for r in spec.exit_rules):
+        if not any(getattr(r, "kind", None) in allowed_kinds for r in ctx.spec.exit_rules):
             return (
                 self._critical(
                     f"exit_rules contains no rule of kind in {sorted(allowed_kinds)}."
@@ -337,24 +343,24 @@ class SpecReadinessGate(GateResultsMixin):
     # ------------------------------------------------------------------
     # Rule 5: Sizing realisable.
     # ------------------------------------------------------------------
-    def _check_sizing_realisable(self, spec: StrategySpec) -> Iterable[QualityGateResult]:
-        assert isinstance(spec, StrategySpec)
-        config = self._call_config
+    def _check_sizing_realisable(self, ctx: SpecReadinessCtx) -> Iterable[QualityGateResult]:
+        assert isinstance(ctx.spec, StrategySpec)
+        config = ctx.config
         if config is None:
             return ()
 
-        kind = getattr(spec.sizing, "kind", None)
-        symbols = spec.target_symbols or _default_universe_for(spec.asset_class)
+        kind = getattr(ctx.spec.sizing, "kind", None)
+        symbols = ctx.spec.target_symbols or _default_universe_for(ctx.spec.asset_class)
         if not symbols:
             return ()
         capital = config.initial_capital
         assert capital > 0, "initial_capital must be strictly positive"
-        enforce_whole_lot = spec.asset_class.lower() in _WHOLE_LOT_ASSET_CLASSES
+        enforce_whole_lot = ctx.spec.asset_class.lower() in _WHOLE_LOT_ASSET_CLASSES
         threshold = 1.0 if enforce_whole_lot else 0.0
 
         for sym in symbols:
             try:
-                price = float(self._market_sample_provider(sym, spec.asset_class))
+                price = float(self._market_sample_provider(sym, ctx.spec.asset_class))
             except Exception:
                 price = float("nan")
             if not math.isfinite(price) or price <= 0:
@@ -364,9 +370,9 @@ class SpecReadinessGate(GateResultsMixin):
                     ),
                 )
             if kind == "fixed_fraction":
-                notional = capital * float(spec.sizing.fraction)
+                notional = capital * float(ctx.spec.sizing.fraction)
             elif kind == "fixed_notional":
-                notional = float(spec.sizing.notional_usd)
+                notional = float(ctx.spec.sizing.notional_usd)
             else:
                 # volatility_target needs realised vol — cannot evaluate here.
                 continue
@@ -385,14 +391,14 @@ class SpecReadinessGate(GateResultsMixin):
     # Rule 6: Hypothesis–rule consistency.
     # ------------------------------------------------------------------
     def _check_hypothesis_rule_consistency(
-        self, spec: StrategySpec
+        self, ctx: SpecReadinessCtx
     ) -> Iterable[QualityGateResult]:
-        assert isinstance(spec, StrategySpec)
+        assert isinstance(ctx.spec, StrategySpec)
         terms = {
             re.sub(r"\s+", " ", m.group(0).lower())
-            for m in _CONCEPT_TERMS.finditer(spec.hypothesis or "")
+            for m in _CONCEPT_TERMS.finditer(ctx.spec.hypothesis or "")
         }
-        referenced = {ref.name for ref in self._iter_indicator_refs(spec)}
+        referenced = {ref.name for ref in self._iter_indicator_refs(ctx.spec)}
         # A concept fires only when *none* of its allowed indicators is referenced,
         # so "moving average" is satisfied by either SMA or EMA.
         orphan = sorted(
@@ -413,14 +419,14 @@ class SpecReadinessGate(GateResultsMixin):
     # ------------------------------------------------------------------
     # Rule 7: Timeframe data availability.
     # ------------------------------------------------------------------
-    def _check_timeframe_availability(self, spec: StrategySpec) -> Iterable[QualityGateResult]:
-        assert isinstance(spec, StrategySpec)
-        if spec.timeframe == "1d" or spec.asset_class.lower() in _FULL_TIMEFRAME_ASSET_CLASSES:
+    def _check_timeframe_availability(self, ctx: SpecReadinessCtx) -> Iterable[QualityGateResult]:
+        assert isinstance(ctx.spec, StrategySpec)
+        if ctx.spec.timeframe == "1d" or ctx.spec.asset_class.lower() in _FULL_TIMEFRAME_ASSET_CLASSES:
             return ()
         return (
             self._critical(
-                f"Asset class '{spec.asset_class}' has no reliable "
-                f"intraday data for timeframe '{spec.timeframe}'; "
+                f"Asset class '{ctx.spec.asset_class}' has no reliable "
+                f"intraday data for timeframe '{ctx.spec.timeframe}'; "
                 "use '1d' or pick stocks/crypto."
             ),
         )
@@ -429,12 +435,12 @@ class SpecReadinessGate(GateResultsMixin):
     # Rule 8: Risk-limit coherence — independent stop/profit and position
     # caps; both sub-checks can fire on the same spec.
     # ------------------------------------------------------------------
-    def _check_risk_limit_coherence(self, spec: StrategySpec) -> Iterable[QualityGateResult]:
-        assert isinstance(spec, StrategySpec)
+    def _check_risk_limit_coherence(self, ctx: SpecReadinessCtx) -> Iterable[QualityGateResult]:
+        assert isinstance(ctx.spec, StrategySpec)
         out: List[QualityGateResult] = []
 
-        stop_losses = [r for r in spec.exit_rules if isinstance(r, StopLossRule)]
-        take_profits = [r for r in spec.exit_rules if isinstance(r, TakeProfitRule)]
+        stop_losses = [r for r in ctx.spec.exit_rules if isinstance(r, StopLossRule)]
+        take_profits = [r for r in ctx.spec.exit_rules if isinstance(r, TakeProfitRule)]
         if stop_losses and take_profits:
             min_tp = min(r.pct for r in take_profits)
             max_sl = max(r.pct for r in stop_losses)
@@ -447,10 +453,10 @@ class SpecReadinessGate(GateResultsMixin):
                     )
                 )
 
-        if spec.risk_limits.max_position_pct > 25:
+        if ctx.spec.risk_limits.max_position_pct > 25:
             out.append(
                 self._critical(
-                    f"max_position_pct={spec.risk_limits.max_position_pct}% "
+                    f"max_position_pct={ctx.spec.risk_limits.max_position_pct}% "
                     "exceeds the 25% cap for a single-position risk budget."
                 )
             )

--- a/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
@@ -114,8 +114,23 @@ non-positive values are interpreted as a missing price and fail Rule 5 closed.
 """
 
 
+_KNOWN_ASSET_CLASSES: frozenset[str] = frozenset(
+    {"stocks", "crypto", "commodities", "forex", "futures"}
+)
+
+
 def _default_universe_for(asset_class: str) -> List[str]:
-    # Pre: asset_class is a non-empty string.
+    """Return the canonical default universe for ``asset_class``.
+
+    Pre: ``asset_class`` is a non-empty string.
+    Post: returns a non-empty list of upper-case ticker strings.
+
+    Raises ``ValueError`` for asset classes outside
+    :data:`_KNOWN_ASSET_CLASSES`. The old ``else`` branch silently fell
+    back to ``OTHER_SYMBOLS`` (a stocks-equivalent broad-ETF list), which
+    let a typo'd ``asset_class="bonds"`` size against TLT/QQQ/EEM/etc. —
+    exactly the false-confidence Codex flagged for forex/futures earlier.
+    """
     assert isinstance(asset_class, str) and asset_class, "asset_class must be a non-empty str"
 
     ac = asset_class.lower()
@@ -130,9 +145,11 @@ def _default_universe_for(asset_class: str) -> List[str]:
     elif ac == "futures":
         out = list(FUTURES_SYMBOLS)
     else:
-        out = list(OTHER_SYMBOLS)
+        raise ValueError(
+            f"unknown asset_class {asset_class!r}; "
+            f"expected one of {sorted(_KNOWN_ASSET_CLASSES)}"
+        )
 
-    # Post: returns a non-empty list of upper-case ticker strings.
     assert out and all(isinstance(s, str) and s for s in out), "default universe must be non-empty"
     return out
 
@@ -226,13 +243,13 @@ class SpecReadinessGate(GateResultsMixin):
         assert backtest_config is None or isinstance(backtest_config, BacktestConfig), (
             "backtest_config override must be a BacktestConfig or None"
         )
-        self._set_phase(phase)
         ctx = SpecReadinessCtx(spec=spec, config=backtest_config or self._backtest_config)
-        results: List[QualityGateResult] = [
-            r for rule in self._RULES for r in rule(self, ctx)
-        ]
-        if not results:
-            results.append(self._info("Strategy spec passed all readiness checks."))
+        with self._using_phase(phase):
+            results: List[QualityGateResult] = [
+                r for rule in self._RULES for r in rule(self, ctx)
+            ]
+            if not results:
+                results.append(self._info("Strategy spec passed all readiness checks."))
         # Post: every result carries the caller's phase and GATE name.
         assert all(r.phase == phase for r in results), (
             "every result must carry the caller's phase"
@@ -350,7 +367,40 @@ class SpecReadinessGate(GateResultsMixin):
             return ()
 
         kind = getattr(ctx.spec.sizing, "kind", None)
-        symbols = ctx.spec.target_symbols or _default_universe_for(ctx.spec.asset_class)
+
+        # Volatility-target sizing depends on realised volatility, which we
+        # cannot estimate at design time. Emit a warning so the operator
+        # notices that Rule 5 abstained — a silent skip would let an
+        # implausibly low ``target_annual_vol`` (e.g. 0.001) bypass the
+        # implementability check entirely.
+        if kind == "volatility_target":
+            tav = getattr(ctx.spec.sizing, "target_annual_vol", None)
+            return (
+                self._warning(
+                    "Sizing realisability: volatility_target sizing requires "
+                    "realised vol and cannot be evaluated at readiness time. "
+                    f"Confirm target_annual_vol={tav!r} is sensible "
+                    "(typical range: 0.05–0.30)."
+                ),
+            )
+
+        # Resolve the universe to size against. ``_default_universe_for`` now
+        # raises on unknown asset classes (previously it silently fell back to
+        # ``OTHER_SYMBOLS``); surface that as a critical so the operator sees
+        # the misclassification instead of a sizing pass against an unrelated
+        # universe.
+        if ctx.spec.target_symbols:
+            symbols = list(ctx.spec.target_symbols)
+        else:
+            try:
+                symbols = _default_universe_for(ctx.spec.asset_class)
+            except ValueError as exc:
+                return (
+                    self._critical(
+                        f"Sizing realisability: {exc}. Set spec.target_symbols "
+                        "explicitly or pick a supported asset_class."
+                    ),
+                )
         if not symbols:
             return ()
         capital = config.initial_capital
@@ -374,7 +424,8 @@ class SpecReadinessGate(GateResultsMixin):
             elif kind == "fixed_notional":
                 notional = float(ctx.spec.sizing.notional_usd)
             else:
-                # volatility_target needs realised vol — cannot evaluate here.
+                # Unknown sizing kind — covered by spec_dsl validation, but
+                # be defensive: nothing further to evaluate.
                 continue
             qty = notional / price
             if qty < threshold or (not enforce_whole_lot and qty <= threshold):

--- a/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
@@ -103,7 +103,12 @@ _CONCEPT_TO_INDICATOR_NAME: dict[str, str] = {
 }
 
 
-MarketSampleProvider = Callable[[str], float]
+MarketSampleProvider = Callable[[str, str], float]
+"""(symbol, asset_class) → recent close price in USD.
+
+Implementations must return a strictly positive finite float. NaN / inf /
+non-positive values are interpreted as a missing price and fail Rule 5 closed.
+"""
 
 
 def _default_universe_for(asset_class: str) -> List[str]:
@@ -143,10 +148,13 @@ def _canonicalize_ticker(symbol: str) -> str:
     return s
 
 
-def _default_market_sample_provider(symbol: str) -> float:
-    # Pre: symbol is a non-empty string.
+def _default_market_sample_provider(symbol: str, asset_class: str) -> float:
+    # Pre: symbol and asset_class are non-empty strings.
     assert isinstance(symbol, str) and symbol, "symbol must be a non-empty str"
-    # Post: returns a strictly positive finite price.
+    assert isinstance(asset_class, str) and asset_class, "asset_class must be a non-empty str"
+    # Post: returns a strictly positive finite price. The static fallback is
+    # intentionally arbitrary — real callers inject a `MarketDataService`-backed
+    # provider so high-priced symbols are sized against a real recent close.
     price = 100.0
     assert price > 0, "price must be strictly positive"
     return price
@@ -462,7 +470,7 @@ class SpecReadinessGate:
         out: List[QualityGateResult] = []
         for sym in symbols:
             try:
-                price = float(self._market_sample_provider(sym))
+                price = float(self._market_sample_provider(sym, spec.asset_class))
             except Exception:
                 price = float("nan")
             # Fail closed on NaN / +inf / -inf — the gate cannot validate

--- a/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
@@ -408,6 +408,29 @@ class SpecReadinessGate(GateResultsMixin):
         enforce_whole_lot = ctx.spec.asset_class.lower() in _WHOLE_LOT_ASSET_CLASSES
         threshold = 1.0 if enforce_whole_lot else 0.0
 
+        # Notional is symbol-independent for both supported kinds, so resolve
+        # it once. fixed_notional with notional_usd > initial_capital can
+        # never produce a fillable order — the fill engine rejects with
+        # ``insufficient_capital`` the moment ``portfolio.capital < notional``
+        # (see ``fill_simulator.py``). fixed_fraction is bounded by
+        # ``fraction <= 1.0`` in the DSL so it cannot trip this branch.
+        if kind == "fixed_fraction":
+            notional = capital * float(ctx.spec.sizing.fraction)
+        elif kind == "fixed_notional":
+            notional = float(ctx.spec.sizing.notional_usd)
+            if notional > capital:
+                return (
+                    self._critical(
+                        f"Sizing realisability: fixed_notional ${notional:.0f} "
+                        f"exceeds initial_capital ${capital:.0f}; the first "
+                        "order would be rejected with insufficient_capital."
+                    ),
+                )
+        else:
+            # Unknown sizing kind — covered by spec_dsl validation, but be
+            # defensive: nothing further to evaluate.
+            return ()
+
         for sym in symbols:
             try:
                 price = float(self._market_sample_provider(sym, ctx.spec.asset_class))
@@ -419,14 +442,6 @@ class SpecReadinessGate(GateResultsMixin):
                         f"Sizing realisability: no usable price sample for '{sym}' (got {price!r})."
                     ),
                 )
-            if kind == "fixed_fraction":
-                notional = capital * float(ctx.spec.sizing.fraction)
-            elif kind == "fixed_notional":
-                notional = float(ctx.spec.sizing.notional_usd)
-            else:
-                # Unknown sizing kind — covered by spec_dsl validation, but
-                # be defensive: nothing further to evaluate.
-                continue
             qty = notional / price
             if qty < threshold or (not enforce_whole_lot and qty <= threshold):
                 return (

--- a/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py
@@ -58,7 +58,8 @@ _SYMBOL_WHITELIST: frozenset[str] = frozenset(
 # / `X` still sits at a word/non-word boundary. Longest-first alternation
 # ensures `ES=F` is preferred over the bare `ES` when both could match.
 _SYMBOL_REGEX = re.compile(
-    r"\b(" + "|".join(sorted(map(re.escape, _SYMBOL_WHITELIST), key=len, reverse=True)) + r")\b"
+    r"\b(" + "|".join(sorted(map(re.escape, _SYMBOL_WHITELIST), key=len, reverse=True)) + r")\b",
+    re.IGNORECASE,
 )
 
 # Asset classes whose intraday timeframes the data-provider chain supports.
@@ -89,17 +90,20 @@ _CONCEPT_TERMS = re.compile(
     r"\b(rsi|macd|moving\s+average|ema|sma|bollinger|atr|stochastic|adx|vwap)\b",
     re.IGNORECASE,
 )
-_CONCEPT_TO_INDICATOR_NAME: dict[str, str] = {
-    "rsi": "rsi",
-    "macd": "macd",
-    "moving average": "sma",
-    "ema": "ema",
-    "sma": "sma",
-    "bollinger": "bollinger",
-    "atr": "atr",
-    "stochastic": "stochastic",
-    "adx": "adx",
-    "vwap": "vwap",
+# Map each prose concept to the set of DSL indicator names that satisfy it.
+# A concept is "orphan" iff *none* of its allowed indicators appears in the
+# spec's predicates — so "moving average" is satisfied by either SMA or EMA.
+_CONCEPT_TO_INDICATOR_NAMES: dict[str, frozenset[str]] = {
+    "rsi": frozenset({"rsi"}),
+    "macd": frozenset({"macd"}),
+    "moving average": frozenset({"sma", "ema"}),
+    "ema": frozenset({"ema"}),
+    "sma": frozenset({"sma"}),
+    "bollinger": frozenset({"bollinger"}),
+    "atr": frozenset({"atr"}),
+    "stochastic": frozenset({"stochastic"}),
+    "adx": frozenset({"adx"}),
+    "vwap": frozenset({"vwap"}),
 }
 
 
@@ -540,10 +544,13 @@ class SpecReadinessGate:
             for m in _CONCEPT_TERMS.finditer(hypothesis)
         }
         referenced = {ref.name for ref in self._iter_indicator_refs(spec)}
+        # A concept fires only when *none* of its allowed indicators is
+        # referenced — so "moving average" is satisfied by either SMA or EMA.
         orphan = sorted(
             t
             for t in terms_in_hypothesis
-            if (n := _CONCEPT_TO_INDICATOR_NAME.get(t)) is not None and n not in referenced
+            if (names := _CONCEPT_TO_INDICATOR_NAMES.get(t)) is not None
+            and not (names & referenced)
         )
 
         out: List[QualityGateResult] = []

--- a/backend/agents/investment_team/strategy_lab/quality_gates/strategy_validator.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/strategy_validator.py
@@ -55,107 +55,104 @@ class StrategySpecValidator(GateResultsMixin):
         where the spec was actually re-checked.
         """
         with self._using_phase(phase):
-            return self._run_checks(spec)
+            results: List[QualityGateResult] = []
 
-    def _run_checks(self, spec: StrategySpec) -> List[QualityGateResult]:
-        results: List[QualityGateResult] = []
-
-        if normalize_asset_class(spec.asset_class) == "options":
-            results.append(
-                self._critical(
-                    "Asset class 'options' is not yet supported — no "
-                    "option-chain data, Greeks, or contract execution "
-                    "model is available. Choose stocks, crypto, forex, "
-                    "futures, or commodities."
+            if normalize_asset_class(spec.asset_class) == "options":
+                results.append(
+                    self._critical(
+                        "Asset class 'options' is not yet supported — no "
+                        "option-chain data, Greeks, or contract execution "
+                        "model is available. Choose stocks, crypto, forex, "
+                        "futures, or commodities."
+                    )
                 )
-            )
 
-        if not spec.entry_rules:
-            results.append(
-                self._critical("No entry rules defined — strategy cannot generate trades.")
-            )
-
-        if not spec.exit_rules:
-            results.append(
-                self._critical("No exit rules defined — positions would never close.")
-            )
-
-        if not spec.hypothesis or not spec.hypothesis.strip():
-            results.append(
-                self._warning("Hypothesis is empty — strategy rationale is unclear.")
-            )
-
-        if not spec.strategy_code or not spec.strategy_code.strip():
-            results.append(self._critical("strategy_code is missing — nothing to execute."))
-
-        risk = spec.risk_limits
-        max_pos = risk.max_position_pct
-        if max_pos < 1 or max_pos > 25:
-            results.append(
-                self._critical(
-                    f"max_position_pct={max_pos}% is outside safe range [1%, 25%]."
+            if not spec.entry_rules:
+                results.append(
+                    self._critical("No entry rules defined — strategy cannot generate trades.")
                 )
-            )
 
-        if risk.max_drawdown_pct < 5 or risk.max_drawdown_pct > 50:
-            results.append(
-                self._warning(
-                    f"max_drawdown_pct={risk.max_drawdown_pct}% is outside typical range [5%, 50%]."
+            if not spec.exit_rules:
+                results.append(
+                    self._critical("No exit rules defined — positions would never close.")
                 )
-            )
 
-        # Spec rule fields are structured DSL nodes — render through the
-        # spec_dsl formatters to recover a human-readable text view for the
-        # asset-class and non-computable scans. Unparseable prose lives in
-        # ``spec.unparsed_rules`` and is folded into the same scan.
-        all_rules_text = " ".join(
-            [
-                format_rules_for_prompt(spec.entry_rules),
-                format_rules_for_prompt(spec.exit_rules),
-                format_sizing_rule(spec.sizing),
-                " ".join(spec.unparsed_rules),
-            ]
-        )
-        pattern = _ASSET_MISMATCH.get(spec.asset_class.lower())
-        if pattern and pattern.search(all_rules_text):
-            results.append(
-                self._warning(
-                    f"Rules reference concepts mismatched with asset class '{spec.asset_class}'."
+            if not spec.hypothesis or not spec.hypothesis.strip():
+                results.append(
+                    self._warning("Hypothesis is empty — strategy rationale is unclear.")
                 )
-            )
 
-        if _NON_COMPUTABLE_KEYWORDS.search(all_rules_text):
-            results.append(
-                self._warning(
-                    "Rules reference non-computable data (sentiment, social media, etc.) "
-                    "without a numerical proxy."
+            if not spec.strategy_code or not spec.strategy_code.strip():
+                results.append(self._critical("strategy_code is missing — nothing to execute."))
+
+            risk = spec.risk_limits
+            max_pos = risk.max_position_pct
+            if max_pos < 1 or max_pos > 25:
+                results.append(
+                    self._critical(
+                        f"max_position_pct={max_pos}% is outside safe range [1%, 25%]."
+                    )
                 )
-            )
 
-        # Hypothesis-vs-rules consistency. If the hypothesis names indicator
-        # concepts that no entry/exit rule references (or vice versa), the
-        # operational spec and the narrative rationale are out of sync.
-        rules_text = " ".join(
-            [
-                format_rules_for_prompt(spec.entry_rules),
-                format_rules_for_prompt(spec.exit_rules),
-                " ".join(spec.unparsed_rules),
-            ]
-        )
-        terms_in_hypothesis = {
-            m.group(0).lower() for m in _CONCEPT_TERMS.finditer(spec.hypothesis or "")
-        }
-        terms_in_rules = {m.group(0).lower() for m in _CONCEPT_TERMS.finditer(rules_text)}
-        orphan_in_hypothesis = terms_in_hypothesis - terms_in_rules
-        orphan_in_rules = terms_in_rules - terms_in_hypothesis
-        if orphan_in_hypothesis or orphan_in_rules:
-            results.append(
-                self._warning(
-                    "Hypothesis/rules consistency: hypothesis mentions "
-                    f"{sorted(orphan_in_hypothesis) or 'nothing'} that rules don't "
-                    f"reference; rules mention {sorted(orphan_in_rules) or 'nothing'} "
-                    "that hypothesis doesn't."
+            if risk.max_drawdown_pct < 5 or risk.max_drawdown_pct > 50:
+                results.append(
+                    self._warning(
+                        f"max_drawdown_pct={risk.max_drawdown_pct}% is outside typical range [5%, 50%]."
+                    )
                 )
-            )
 
-        return results or [self._info("Strategy spec passed all validation checks.")]
+            # Spec rule fields are structured DSL nodes — render through the
+            # spec_dsl formatters to recover a human-readable text view for the
+            # asset-class and non-computable scans. Unparseable prose lives in
+            # ``spec.unparsed_rules`` and is folded into the same scan.
+            all_rules_text = " ".join(
+                [
+                    format_rules_for_prompt(spec.entry_rules),
+                    format_rules_for_prompt(spec.exit_rules),
+                    format_sizing_rule(spec.sizing),
+                    " ".join(spec.unparsed_rules),
+                ]
+            )
+            pattern = _ASSET_MISMATCH.get(spec.asset_class.lower())
+            if pattern and pattern.search(all_rules_text):
+                results.append(
+                    self._warning(
+                        f"Rules reference concepts mismatched with asset class '{spec.asset_class}'."
+                    )
+                )
+
+            if _NON_COMPUTABLE_KEYWORDS.search(all_rules_text):
+                results.append(
+                    self._warning(
+                        "Rules reference non-computable data (sentiment, social media, etc.) "
+                        "without a numerical proxy."
+                    )
+                )
+
+            # Hypothesis-vs-rules consistency. If the hypothesis names indicator
+            # concepts that no entry/exit rule references (or vice versa), the
+            # operational spec and the narrative rationale are out of sync.
+            rules_text = " ".join(
+                [
+                    format_rules_for_prompt(spec.entry_rules),
+                    format_rules_for_prompt(spec.exit_rules),
+                    " ".join(spec.unparsed_rules),
+                ]
+            )
+            terms_in_hypothesis = {
+                m.group(0).lower() for m in _CONCEPT_TERMS.finditer(spec.hypothesis or "")
+            }
+            terms_in_rules = {m.group(0).lower() for m in _CONCEPT_TERMS.finditer(rules_text)}
+            orphan_in_hypothesis = terms_in_hypothesis - terms_in_rules
+            orphan_in_rules = terms_in_rules - terms_in_hypothesis
+            if orphan_in_hypothesis or orphan_in_rules:
+                results.append(
+                    self._warning(
+                        "Hypothesis/rules consistency: hypothesis mentions "
+                        f"{sorted(orphan_in_hypothesis) or 'nothing'} that rules don't "
+                        f"reference; rules mention {sorted(orphan_in_rules) or 'nothing'} "
+                        "that hypothesis doesn't."
+                    )
+                )
+
+            return results or [self._info("Strategy spec passed all validation checks.")]

--- a/backend/agents/investment_team/strategy_lab/quality_gates/strategy_validator.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/strategy_validator.py
@@ -54,7 +54,10 @@ class StrategySpecValidator(GateResultsMixin):
         pass an explicit ``phase`` so the persisted gate history reflects
         where the spec was actually re-checked.
         """
-        self._set_phase(phase)
+        with self._using_phase(phase):
+            return self._run_checks(spec)
+
+    def _run_checks(self, spec: StrategySpec) -> List[QualityGateResult]:
         results: List[QualityGateResult] = []
 
         if normalize_asset_class(spec.asset_class) == "options":

--- a/backend/agents/investment_team/strategy_lab/quality_gates/strategy_validator.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/strategy_validator.py
@@ -49,6 +49,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="design",
                     passed=False,
                     severity="critical",
                     details=(
@@ -65,6 +66,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="design",
                     passed=False,
                     severity="critical",
                     details="No entry rules defined — strategy cannot generate trades.",
@@ -76,6 +78,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="design",
                     passed=False,
                     severity="critical",
                     details="No exit rules defined — positions would never close.",
@@ -87,6 +90,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="design",
                     passed=False,
                     severity="warning",
                     details="Hypothesis is empty — strategy rationale is unclear.",
@@ -98,6 +102,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="design",
                     passed=False,
                     severity="critical",
                     details="strategy_code is missing — nothing to execute.",
@@ -111,6 +116,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="design",
                     passed=False,
                     severity="critical",
                     details=f"max_position_pct={max_pos}% is outside safe range [1%, 25%].",
@@ -121,6 +127,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="design",
                     passed=False,
                     severity="warning",
                     details=(
@@ -151,6 +158,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="design",
                     passed=False,
                     severity="warning",
                     details=f"Rules reference concepts mismatched with asset class '{spec.asset_class}'.",
@@ -162,6 +170,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="design",
                     passed=False,
                     severity="warning",
                     details="Rules reference non-computable data (sentiment, social media, etc.) without a numerical proxy.",
@@ -191,6 +200,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="design",
                     passed=False,
                     severity="warning",
                     details=(
@@ -207,6 +217,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="design",
                     passed=True,
                     severity="info",
                     details="Strategy spec passed all validation checks.",

--- a/backend/agents/investment_team/strategy_lab/quality_gates/strategy_validator.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/strategy_validator.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import re
-from typing import List
+from typing import ClassVar, List
 
 from ...models import StrategySpec
 from ...strategy_lab_context import normalize_asset_class
 from ..spec_dsl import format_rules_for_prompt, format_sizing_rule
-from .models import QualityGateResult, StrategyLabPhase
+from .models import GateResultsMixin, QualityGateResult, StrategyLabPhase
 
 GATE = "strategy_spec_validator"
 
@@ -27,8 +27,8 @@ _ASSET_MISMATCH: dict[str, re.Pattern[str]] = {
 }
 
 # Recognised indicator/concept vocabulary for the hypothesis-vs-rules
-# consistency gate (#547 item 6). Word-boundary anchored so substrings like
-# "thematic" don't accidentally match "ema".
+# consistency gate. Word-boundary anchored so substrings like "thematic"
+# don't accidentally match "ema".
 _CONCEPT_TERMS = re.compile(
     r"\b(rsi|macd|moving\s+average|ema|sma|bollinger|atr|breakout|"
     r"mean\s+reversion|momentum|volatility|volume|vwap|stochastic|adx|obv)\b",
@@ -36,8 +36,10 @@ _CONCEPT_TERMS = re.compile(
 )
 
 
-class StrategySpecValidator:
+class StrategySpecValidator(GateResultsMixin):
     """Run deterministic checks on a StrategySpec before code execution."""
+
+    GATE: ClassVar[str] = GATE
 
     def validate(
         self, spec: StrategySpec, *, phase: StrategyLabPhase = "design"
@@ -52,110 +54,57 @@ class StrategySpecValidator:
         pass an explicit ``phase`` so the persisted gate history reflects
         where the spec was actually re-checked.
         """
+        self._set_phase(phase)
         results: List[QualityGateResult] = []
 
-        # 0. Asset class supported (#535). 'options' has no chain data,
-        #    Greeks, or contract execution model — reject before
-        #    market-data fetch silently treats it as equities.
         if normalize_asset_class(spec.asset_class) == "options":
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details=(
-                        "Asset class 'options' is not yet supported — no "
-                        "option-chain data, Greeks, or contract execution "
-                        "model is available. Choose stocks, crypto, forex, "
-                        "futures, or commodities."
-                    ),
+                self._critical(
+                    "Asset class 'options' is not yet supported — no "
+                    "option-chain data, Greeks, or contract execution "
+                    "model is available. Choose stocks, crypto, forex, "
+                    "futures, or commodities."
                 )
             )
 
-        # 1. Entry rules present
         if not spec.entry_rules:
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details="No entry rules defined — strategy cannot generate trades.",
-                )
+                self._critical("No entry rules defined — strategy cannot generate trades.")
             )
 
-        # 2. Exit rules present
         if not spec.exit_rules:
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details="No exit rules defined — positions would never close.",
-                )
+                self._critical("No exit rules defined — positions would never close.")
             )
 
-        # 3. Hypothesis present
         if not spec.hypothesis or not spec.hypothesis.strip():
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="warning",
-                    details="Hypothesis is empty — strategy rationale is unclear.",
-                )
+                self._warning("Hypothesis is empty — strategy rationale is unclear.")
             )
 
-        # 4. Strategy code present
         if not spec.strategy_code or not spec.strategy_code.strip():
-            results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details="strategy_code is missing — nothing to execute.",
-                )
-            )
+            results.append(self._critical("strategy_code is missing — nothing to execute."))
 
-        # 5. Risk limits bounds (Phase 3: reads validated RiskLimits attributes).
         risk = spec.risk_limits
         max_pos = risk.max_position_pct
         if max_pos < 1 or max_pos > 25:
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details=f"max_position_pct={max_pos}% is outside safe range [1%, 25%].",
+                self._critical(
+                    f"max_position_pct={max_pos}% is outside safe range [1%, 25%]."
                 )
             )
 
         if risk.max_drawdown_pct < 5 or risk.max_drawdown_pct > 50:
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="warning",
-                    details=(
-                        f"max_drawdown_pct={risk.max_drawdown_pct}% is outside typical "
-                        "range [5%, 50%]."
-                    ),
+                self._warning(
+                    f"max_drawdown_pct={risk.max_drawdown_pct}% is outside typical range [5%, 50%]."
                 )
             )
 
-        # 6. Asset-class keyword mismatch. Issue #551/#537: spec rule fields
-        #    are structured DSL nodes — render them through the spec_dsl
-        #    formatters to recover a human-readable text view suitable for
-        #    regex matching. Unparseable prose now lives in
-        #    ``spec.unparsed_rules`` (#537 replaced the discriminator
-        #    variants) and is folded into the same scan so prose that
-        #    escaped the adapter is still caught.
+        # Spec rule fields are structured DSL nodes — render through the
+        # spec_dsl formatters to recover a human-readable text view for the
+        # asset-class and non-computable scans. Unparseable prose lives in
+        # ``spec.unparsed_rules`` and is folded into the same scan.
         all_rules_text = " ".join(
             [
                 format_rules_for_prompt(spec.entry_rules),
@@ -164,39 +113,25 @@ class StrategySpecValidator:
                 " ".join(spec.unparsed_rules),
             ]
         )
-        ac = spec.asset_class.lower()
-        pattern = _ASSET_MISMATCH.get(ac)
+        pattern = _ASSET_MISMATCH.get(spec.asset_class.lower())
         if pattern and pattern.search(all_rules_text):
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="warning",
-                    details=f"Rules reference concepts mismatched with asset class '{spec.asset_class}'.",
+                self._warning(
+                    f"Rules reference concepts mismatched with asset class '{spec.asset_class}'."
                 )
             )
 
-        # 7. Non-computable data references
         if _NON_COMPUTABLE_KEYWORDS.search(all_rules_text):
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="warning",
-                    details="Rules reference non-computable data (sentiment, social media, etc.) without a numerical proxy.",
+                self._warning(
+                    "Rules reference non-computable data (sentiment, social media, etc.) "
+                    "without a numerical proxy."
                 )
             )
 
-        # 8. Hypothesis-vs-rules consistency (#547 item 6). If the hypothesis
-        #    names indicator concepts that no entry/exit rule references (or
-        #    vice versa), the operational spec and the narrative rationale are
-        #    out of sync. Warning only — the refinement prompt can react.
-        #    Issue #537: ``unparsed_rules`` is part of the rule surface for
-        #    this scan — pre-migration legacy specs may carry indicator
-        #    mentions in there.
-        hypothesis_text = spec.hypothesis or ""
+        # Hypothesis-vs-rules consistency. If the hypothesis names indicator
+        # concepts that no entry/exit rule references (or vice versa), the
+        # operational spec and the narrative rationale are out of sync.
         rules_text = " ".join(
             [
                 format_rules_for_prompt(spec.entry_rules),
@@ -204,36 +139,20 @@ class StrategySpecValidator:
                 " ".join(spec.unparsed_rules),
             ]
         )
-        terms_in_hypothesis = {m.group(0).lower() for m in _CONCEPT_TERMS.finditer(hypothesis_text)}
+        terms_in_hypothesis = {
+            m.group(0).lower() for m in _CONCEPT_TERMS.finditer(spec.hypothesis or "")
+        }
         terms_in_rules = {m.group(0).lower() for m in _CONCEPT_TERMS.finditer(rules_text)}
         orphan_in_hypothesis = terms_in_hypothesis - terms_in_rules
         orphan_in_rules = terms_in_rules - terms_in_hypothesis
         if orphan_in_hypothesis or orphan_in_rules:
             results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="warning",
-                    details=(
-                        "Hypothesis/rules consistency: hypothesis mentions "
-                        f"{sorted(orphan_in_hypothesis) or 'nothing'} that rules don't "
-                        f"reference; rules mention {sorted(orphan_in_rules) or 'nothing'} "
-                        "that hypothesis doesn't."
-                    ),
+                self._warning(
+                    "Hypothesis/rules consistency: hypothesis mentions "
+                    f"{sorted(orphan_in_hypothesis) or 'nothing'} that rules don't "
+                    f"reference; rules mention {sorted(orphan_in_rules) or 'nothing'} "
+                    "that hypothesis doesn't."
                 )
             )
 
-        # All passed if we got here with no additions
-        if not results:
-            results.append(
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=True,
-                    severity="info",
-                    details="Strategy spec passed all validation checks.",
-                )
-            )
-
-        return results
+        return results or [self._info("Strategy spec passed all validation checks.")]

--- a/backend/agents/investment_team/strategy_lab/quality_gates/strategy_validator.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/strategy_validator.py
@@ -8,7 +8,7 @@ from typing import List
 from ...models import StrategySpec
 from ...strategy_lab_context import normalize_asset_class
 from ..spec_dsl import format_rules_for_prompt, format_sizing_rule
-from .models import QualityGateResult
+from .models import QualityGateResult, StrategyLabPhase
 
 GATE = "strategy_spec_validator"
 
@@ -39,7 +39,19 @@ _CONCEPT_TERMS = re.compile(
 class StrategySpecValidator:
     """Run deterministic checks on a StrategySpec before code execution."""
 
-    def validate(self, spec: StrategySpec) -> List[QualityGateResult]:
+    def validate(
+        self, spec: StrategySpec, *, phase: StrategyLabPhase = "design"
+    ) -> List[QualityGateResult]:
+        """Run the validator and tag every result with ``phase``.
+
+        Pre: ``spec`` is a StrategySpec; ``phase`` is a valid phase literal.
+        Post: every returned result carries the caller's ``phase`` and
+        ``gate_name == GATE``. The default matches the primary pre-synthesis
+        call; callers that re-run the validator outside the design phase
+        (e.g. the zero-trade repair path inside the refinement loop) must
+        pass an explicit ``phase`` so the persisted gate history reflects
+        where the spec was actually re-checked.
+        """
         results: List[QualityGateResult] = []
 
         # 0. Asset class supported (#535). 'options' has no chain data,
@@ -49,7 +61,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="design",
+                    phase=phase,
                     passed=False,
                     severity="critical",
                     details=(
@@ -66,7 +78,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="design",
+                    phase=phase,
                     passed=False,
                     severity="critical",
                     details="No entry rules defined — strategy cannot generate trades.",
@@ -78,7 +90,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="design",
+                    phase=phase,
                     passed=False,
                     severity="critical",
                     details="No exit rules defined — positions would never close.",
@@ -90,7 +102,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="design",
+                    phase=phase,
                     passed=False,
                     severity="warning",
                     details="Hypothesis is empty — strategy rationale is unclear.",
@@ -102,7 +114,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="design",
+                    phase=phase,
                     passed=False,
                     severity="critical",
                     details="strategy_code is missing — nothing to execute.",
@@ -116,7 +128,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="design",
+                    phase=phase,
                     passed=False,
                     severity="critical",
                     details=f"max_position_pct={max_pos}% is outside safe range [1%, 25%].",
@@ -127,7 +139,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="design",
+                    phase=phase,
                     passed=False,
                     severity="warning",
                     details=(
@@ -158,7 +170,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="design",
+                    phase=phase,
                     passed=False,
                     severity="warning",
                     details=f"Rules reference concepts mismatched with asset class '{spec.asset_class}'.",
@@ -170,7 +182,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="design",
+                    phase=phase,
                     passed=False,
                     severity="warning",
                     details="Rules reference non-computable data (sentiment, social media, etc.) without a numerical proxy.",
@@ -200,7 +212,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="design",
+                    phase=phase,
                     passed=False,
                     severity="warning",
                     details=(
@@ -217,7 +229,7 @@ class StrategySpecValidator:
             results.append(
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="design",
+                    phase=phase,
                     passed=True,
                     severity="info",
                     details="Strategy spec passed all validation checks.",

--- a/backend/agents/investment_team/strategy_lab/quality_gates/target_symbol_coverage.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/target_symbol_coverage.py
@@ -73,7 +73,15 @@ class TargetSymbolCoverageGate(GateResultsMixin):
         *,
         phase: StrategyLabPhase = "synthesis",
     ) -> List[QualityGateResult]:
-        self._set_phase(phase)
+        with self._using_phase(phase):
+            return self._check_fetch_body(spec, requested_symbols, fetched_symbols)
+
+    def _check_fetch_body(
+        self,
+        spec: StrategySpec,
+        requested_symbols: List[str],
+        fetched_symbols: List[str],
+    ) -> List[QualityGateResult]:
         results: List[QualityGateResult] = []
         fetched_upper = {s.strip().upper() for s in fetched_symbols if s and s.strip()}
 
@@ -113,7 +121,14 @@ class TargetSymbolCoverageGate(GateResultsMixin):
         *,
         phase: StrategyLabPhase = "synthesis",
     ) -> List[QualityGateResult]:
-        self._set_phase(phase)
+        with self._using_phase(phase):
+            return self._check_trades_body(spec, trades)
+
+    def _check_trades_body(
+        self,
+        spec: StrategySpec,
+        trades: List[TradeRecord],
+    ) -> List[QualityGateResult]:
         if not spec.target_symbols:
             return [
                 self._info("spec.target_symbols empty; trade-symbol coverage check skipped.")

--- a/backend/agents/investment_team/strategy_lab/quality_gates/target_symbol_coverage.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/target_symbol_coverage.py
@@ -36,7 +36,7 @@ from ...symbols import (
     OTHER_SYMBOLS,
     STOCK_SYMBOLS,
 )
-from .models import QualityGateResult
+from .models import QualityGateResult, StrategyLabPhase
 
 GATE = "target_symbol_coverage"
 
@@ -68,6 +68,8 @@ class TargetSymbolCoverageGate:
         spec: StrategySpec,
         requested_symbols: List[str],
         fetched_symbols: List[str],
+        *,
+        phase: StrategyLabPhase = "synthesis",
     ) -> List[QualityGateResult]:
         results: List[QualityGateResult] = []
         fetched_upper = {s.strip().upper() for s in fetched_symbols if s and s.strip()}
@@ -79,7 +81,7 @@ class TargetSymbolCoverageGate:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
-                        phase="verification",
+                        phase=phase,
                         passed=False,
                         severity="critical",
                         details=(
@@ -93,7 +95,7 @@ class TargetSymbolCoverageGate:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
-                        phase="verification",
+                        phase=phase,
                         passed=True,
                         severity="info",
                         details=f"All {len(target_upper)} target_symbols present in fetched data.",
@@ -105,7 +107,7 @@ class TargetSymbolCoverageGate:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
-                        phase="verification",
+                        phase=phase,
                         passed=False,
                         severity="warning",
                         details=(
@@ -120,7 +122,7 @@ class TargetSymbolCoverageGate:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
-                        phase="verification",
+                        phase=phase,
                         passed=True,
                         severity="info",
                         details="spec.target_symbols empty; no specific tickers referenced in hypothesis.",
@@ -133,12 +135,14 @@ class TargetSymbolCoverageGate:
         self,
         spec: StrategySpec,
         trades: List[TradeRecord],
+        *,
+        phase: StrategyLabPhase = "synthesis",
     ) -> List[QualityGateResult]:
         if not spec.target_symbols:
             return [
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="verification",
+                    phase=phase,
                     passed=True,
                     severity="info",
                     details="spec.target_symbols empty; trade-symbol coverage check skipped.",
@@ -151,7 +155,7 @@ class TargetSymbolCoverageGate:
             return [
                 QualityGateResult(
                     gate_name=GATE,
-                    phase="verification",
+                    phase=phase,
                     passed=False,
                     severity="critical",
                     details=(
@@ -164,7 +168,7 @@ class TargetSymbolCoverageGate:
         return [
             QualityGateResult(
                 gate_name=GATE,
-                phase="verification",
+                phase=phase,
                 passed=True,
                 severity="info",
                 details=f"All {len(trades)} trades within target_symbols.",

--- a/backend/agents/investment_team/strategy_lab/quality_gates/target_symbol_coverage.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/target_symbol_coverage.py
@@ -23,7 +23,7 @@ fix by rewriting strategy code.
 from __future__ import annotations
 
 import re
-from typing import List
+from typing import ClassVar, List
 
 from ...models import StrategySpec, TradeRecord
 from ...symbols import (
@@ -36,7 +36,7 @@ from ...symbols import (
     OTHER_SYMBOLS,
     STOCK_SYMBOLS,
 )
-from .models import QualityGateResult, StrategyLabPhase
+from .models import GateResultsMixin, QualityGateResult, StrategyLabPhase
 
 GATE = "target_symbol_coverage"
 
@@ -60,8 +60,10 @@ _KNOWN_TICKERS: frozenset[str] = frozenset(
 _TICKER_RE = re.compile(r"\b([A-Z]{2,6})\b")
 
 
-class TargetSymbolCoverageGate:
+class TargetSymbolCoverageGate(GateResultsMixin):
     """Critical gate enforcing that the realized universe matches intent."""
+
+    GATE: ClassVar[str] = GATE
 
     def check_fetch(
         self,
@@ -71,6 +73,7 @@ class TargetSymbolCoverageGate:
         *,
         phase: StrategyLabPhase = "synthesis",
     ) -> List[QualityGateResult]:
+        self._set_phase(phase)
         results: List[QualityGateResult] = []
         fetched_upper = {s.strip().upper() for s in fetched_symbols if s and s.strip()}
 
@@ -79,54 +82,26 @@ class TargetSymbolCoverageGate:
             missing = sorted(target_upper - fetched_upper)
             if missing:
                 results.append(
-                    QualityGateResult(
-                        gate_name=GATE,
-                        phase=phase,
-                        passed=False,
-                        severity="critical",
-                        details=(
-                            "target_symbols missing from fetched market data: "
+                    self._critical("target_symbols missing from fetched market data: "
                             f"{missing}. Requested={sorted({s.upper() for s in requested_symbols})}, "
-                            f"fetched={sorted(fetched_upper)}."
-                        ),
-                    )
+                            f"fetched={sorted(fetched_upper)}.")
                 )
             else:
                 results.append(
-                    QualityGateResult(
-                        gate_name=GATE,
-                        phase=phase,
-                        passed=True,
-                        severity="info",
-                        details=f"All {len(target_upper)} target_symbols present in fetched data.",
-                    )
+                    self._info(f"All {len(target_upper)} target_symbols present in fetched data.")
                 )
         else:
             mentioned = sorted(self._tickers_in_hypothesis(spec.hypothesis or ""))
             if mentioned:
                 results.append(
-                    QualityGateResult(
-                        gate_name=GATE,
-                        phase=phase,
-                        passed=False,
-                        severity="warning",
-                        details=(
-                            f"Hypothesis mentions known ticker(s) {mentioned} but "
+                    self._warning(f"Hypothesis mentions known ticker(s) {mentioned} but "
                             "spec.target_symbols is empty; the backtest is using the "
                             "asset-class default universe. Set spec.target_symbols "
-                            "explicitly to guarantee the run trades the intended tickers."
-                        ),
-                    )
+                            "explicitly to guarantee the run trades the intended tickers.")
                 )
             else:
                 results.append(
-                    QualityGateResult(
-                        gate_name=GATE,
-                        phase=phase,
-                        passed=True,
-                        severity="info",
-                        details="spec.target_symbols empty; no specific tickers referenced in hypothesis.",
-                    )
+                    self._info("spec.target_symbols empty; no specific tickers referenced in hypothesis.")
                 )
 
         return results
@@ -138,41 +113,22 @@ class TargetSymbolCoverageGate:
         *,
         phase: StrategyLabPhase = "synthesis",
     ) -> List[QualityGateResult]:
+        self._set_phase(phase)
         if not spec.target_symbols:
             return [
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=True,
-                    severity="info",
-                    details="spec.target_symbols empty; trade-symbol coverage check skipped.",
-                )
+                self._info("spec.target_symbols empty; trade-symbol coverage check skipped.")
             ]
 
         target_upper = {s.strip().upper() for s in spec.target_symbols if s and s.strip()}
         offending = sorted({t.symbol.strip().upper() for t in trades if t.symbol} - target_upper)
         if offending:
             return [
-                QualityGateResult(
-                    gate_name=GATE,
-                    phase=phase,
-                    passed=False,
-                    severity="critical",
-                    details=(
-                        "Trade ledger contains symbols outside spec.target_symbols: "
-                        f"{offending}. target_symbols={sorted(target_upper)}."
-                    ),
-                )
+                self._critical("Trade ledger contains symbols outside spec.target_symbols: "
+                        f"{offending}. target_symbols={sorted(target_upper)}.")
             ]
 
         return [
-            QualityGateResult(
-                gate_name=GATE,
-                phase=phase,
-                passed=True,
-                severity="info",
-                details=f"All {len(trades)} trades within target_symbols.",
-            )
+            self._info(f"All {len(trades)} trades within target_symbols.")
         ]
 
     @staticmethod

--- a/backend/agents/investment_team/strategy_lab/quality_gates/target_symbol_coverage.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/target_symbol_coverage.py
@@ -79,6 +79,7 @@ class TargetSymbolCoverageGate:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
+                        phase="verification",
                         passed=False,
                         severity="critical",
                         details=(
@@ -92,6 +93,7 @@ class TargetSymbolCoverageGate:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
+                        phase="verification",
                         passed=True,
                         severity="info",
                         details=f"All {len(target_upper)} target_symbols present in fetched data.",
@@ -103,6 +105,7 @@ class TargetSymbolCoverageGate:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
+                        phase="verification",
                         passed=False,
                         severity="warning",
                         details=(
@@ -117,6 +120,7 @@ class TargetSymbolCoverageGate:
                 results.append(
                     QualityGateResult(
                         gate_name=GATE,
+                        phase="verification",
                         passed=True,
                         severity="info",
                         details="spec.target_symbols empty; no specific tickers referenced in hypothesis.",
@@ -134,6 +138,7 @@ class TargetSymbolCoverageGate:
             return [
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="verification",
                     passed=True,
                     severity="info",
                     details="spec.target_symbols empty; trade-symbol coverage check skipped.",
@@ -146,6 +151,7 @@ class TargetSymbolCoverageGate:
             return [
                 QualityGateResult(
                     gate_name=GATE,
+                    phase="verification",
                     passed=False,
                     severity="critical",
                     details=(
@@ -158,6 +164,7 @@ class TargetSymbolCoverageGate:
         return [
             QualityGateResult(
                 gate_name=GATE,
+                phase="verification",
                 passed=True,
                 severity="info",
                 details=f"All {len(trades)} trades within target_symbols.",

--- a/backend/agents/investment_team/strategy_lab/quality_gates/target_symbol_coverage.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/target_symbol_coverage.py
@@ -74,45 +74,37 @@ class TargetSymbolCoverageGate(GateResultsMixin):
         phase: StrategyLabPhase = "synthesis",
     ) -> List[QualityGateResult]:
         with self._using_phase(phase):
-            return self._check_fetch_body(spec, requested_symbols, fetched_symbols)
+            results: List[QualityGateResult] = []
+            fetched_upper = {s.strip().upper() for s in fetched_symbols if s and s.strip()}
 
-    def _check_fetch_body(
-        self,
-        spec: StrategySpec,
-        requested_symbols: List[str],
-        fetched_symbols: List[str],
-    ) -> List[QualityGateResult]:
-        results: List[QualityGateResult] = []
-        fetched_upper = {s.strip().upper() for s in fetched_symbols if s and s.strip()}
-
-        if spec.target_symbols:
-            target_upper = {s.strip().upper() for s in spec.target_symbols if s and s.strip()}
-            missing = sorted(target_upper - fetched_upper)
-            if missing:
-                results.append(
-                    self._critical("target_symbols missing from fetched market data: "
-                            f"{missing}. Requested={sorted({s.upper() for s in requested_symbols})}, "
-                            f"fetched={sorted(fetched_upper)}.")
-                )
+            if spec.target_symbols:
+                target_upper = {s.strip().upper() for s in spec.target_symbols if s and s.strip()}
+                missing = sorted(target_upper - fetched_upper)
+                if missing:
+                    results.append(
+                        self._critical("target_symbols missing from fetched market data: "
+                                f"{missing}. Requested={sorted({s.upper() for s in requested_symbols})}, "
+                                f"fetched={sorted(fetched_upper)}.")
+                    )
+                else:
+                    results.append(
+                        self._info(f"All {len(target_upper)} target_symbols present in fetched data.")
+                    )
             else:
-                results.append(
-                    self._info(f"All {len(target_upper)} target_symbols present in fetched data.")
-                )
-        else:
-            mentioned = sorted(self._tickers_in_hypothesis(spec.hypothesis or ""))
-            if mentioned:
-                results.append(
-                    self._warning(f"Hypothesis mentions known ticker(s) {mentioned} but "
-                            "spec.target_symbols is empty; the backtest is using the "
-                            "asset-class default universe. Set spec.target_symbols "
-                            "explicitly to guarantee the run trades the intended tickers.")
-                )
-            else:
-                results.append(
-                    self._info("spec.target_symbols empty; no specific tickers referenced in hypothesis.")
-                )
+                mentioned = sorted(self._tickers_in_hypothesis(spec.hypothesis or ""))
+                if mentioned:
+                    results.append(
+                        self._warning(f"Hypothesis mentions known ticker(s) {mentioned} but "
+                                "spec.target_symbols is empty; the backtest is using the "
+                                "asset-class default universe. Set spec.target_symbols "
+                                "explicitly to guarantee the run trades the intended tickers.")
+                    )
+                else:
+                    results.append(
+                        self._info("spec.target_symbols empty; no specific tickers referenced in hypothesis.")
+                    )
 
-        return results
+            return results
 
     def check_trades(
         self,
@@ -122,29 +114,22 @@ class TargetSymbolCoverageGate(GateResultsMixin):
         phase: StrategyLabPhase = "synthesis",
     ) -> List[QualityGateResult]:
         with self._using_phase(phase):
-            return self._check_trades_body(spec, trades)
+            if not spec.target_symbols:
+                return [
+                    self._info("spec.target_symbols empty; trade-symbol coverage check skipped.")
+                ]
 
-    def _check_trades_body(
-        self,
-        spec: StrategySpec,
-        trades: List[TradeRecord],
-    ) -> List[QualityGateResult]:
-        if not spec.target_symbols:
+            target_upper = {s.strip().upper() for s in spec.target_symbols if s and s.strip()}
+            offending = sorted({t.symbol.strip().upper() for t in trades if t.symbol} - target_upper)
+            if offending:
+                return [
+                    self._critical("Trade ledger contains symbols outside spec.target_symbols: "
+                            f"{offending}. target_symbols={sorted(target_upper)}.")
+                ]
+
             return [
-                self._info("spec.target_symbols empty; trade-symbol coverage check skipped.")
+                self._info(f"All {len(trades)} trades within target_symbols.")
             ]
-
-        target_upper = {s.strip().upper() for s in spec.target_symbols if s and s.strip()}
-        offending = sorted({t.symbol.strip().upper() for t in trades if t.symbol} - target_upper)
-        if offending:
-            return [
-                self._critical("Trade ledger contains symbols outside spec.target_symbols: "
-                        f"{offending}. target_symbols={sorted(target_upper)}.")
-            ]
-
-        return [
-            self._info(f"All {len(trades)} trades within target_symbols.")
-        ]
 
     @staticmethod
     def _tickers_in_hypothesis(text: str) -> set[str]:

--- a/backend/agents/investment_team/strategy_lab/zero_trade_repair.py
+++ b/backend/agents/investment_team/strategy_lab/zero_trade_repair.py
@@ -15,8 +15,8 @@ sub-pipeline now; the orchestrator instantiates one repairer in
 at the single call site.
 
 The orchestrator is passed in by reference and the repairer reads the
-gate instances and helper methods (``_record_gates``,
-``_orchestrator_gate``) off it — no API surface is duplicated, but the
+gate instances and helper methods (``record_gates``,
+``build_orchestrator_gate``) off it — no API surface is duplicated, but the
 ~340 lines of branching now sit in their own module with their own test
 boundary.
 """
@@ -118,7 +118,7 @@ class ZeroTradeRepairer:
 
     def __init__(self, orchestrator: "StrategyLabOrchestrator") -> None:
         # Pre: orchestrator is non-None; the repairer reads gate instances
-        # and helper methods (``_record_gates``, ``_orchestrator_gate``) off
+        # and helper methods (``record_gates``, ``build_orchestrator_gate``) off
         # it. No duplication of those collaborators here.
         assert orchestrator is not None, "orchestrator must be supplied"
         self._orch = orchestrator
@@ -215,7 +215,7 @@ class ZeroTradeRepairer:
         # ── Code-safety gate on the proposed code ────────────────────
         # Stamp-only: the caller persists ``safety_gates`` via the outcome's
         # ``new_gates=`` so the orchestrator's running list is not extended here.
-        safety_gates = orch._record_gates(
+        safety_gates = orch.record_gates(
             orch.code_safety_checker.check(report.proposed_code, spec),
             refinement_round=round_num,
             gate_name_prefix="zero_trade_repair_",
@@ -269,7 +269,7 @@ class ZeroTradeRepairer:
             # forward (the ValidationError path below would otherwise drop
             # the audit trail even though the warning was logged).
             dropped_keys_gates = [
-                orch._orchestrator_gate(
+                orch.build_orchestrator_gate(
                     "zero_trade_repair_dropped_spec_keys",
                     phase="synthesis",
                     severity="warning",
@@ -327,7 +327,7 @@ class ZeroTradeRepairer:
             # Zero-trade repair runs inside the synthesis refinement loop —
             # re-validate the patched spec under that phase rather than design.
             # Stamp-only; the caller persists via the outcome's ``new_gates=``.
-            post_repair_spec_gates = orch._record_gates(
+            post_repair_spec_gates = orch.record_gates(
                 orch.strategy_validator.validate(proposed_spec, phase="synthesis"),
                 refinement_round=round_num,
                 gate_name_prefix="zero_trade_repair_",
@@ -365,7 +365,7 @@ class ZeroTradeRepairer:
             report.proposed_code, market_data, config, strategy=proposed_spec
         )
         if not repair_exec.success:
-            failure_gate = orch._orchestrator_gate(
+            failure_gate = orch.build_orchestrator_gate(
                 "zero_trade_repair_code_execution",
                 phase="synthesis",
                 details=(
@@ -411,7 +411,7 @@ class ZeroTradeRepairer:
 
         # ── Anomaly recheck ──────────────────────────────────────────
         # Stamp-only; ``new_gates`` is persisted by the caller via the outcome.
-        new_anomaly_gates = orch._record_gates(
+        new_anomaly_gates = orch.record_gates(
             orch.anomaly_detector.check(
                 new_metrics,
                 new_trades,

--- a/backend/agents/investment_team/strategy_lab/zero_trade_repair.py
+++ b/backend/agents/investment_team/strategy_lab/zero_trade_repair.py
@@ -80,6 +80,27 @@ class ZeroTradeRepairOutcome:
     changes_made: str = ""
 
 
+@dataclass
+class _RepairCtx:
+    """Per-call context passed through ``ZeroTradeRepairer``'s step methods.
+
+    Holds the immutable inputs from ``try_repair`` plus the gate-list
+    accumulator that each step appends to before deciding to commit or
+    reject. The flow is linear (each step either succeeds-with-state or
+    returns a terminating outcome), so bundling the inputs lets the step
+    method signatures stay short.
+    """
+
+    spec: StrategySpec
+    code: str
+    market_data: Dict[str, List[OHLCVBar]]
+    config: BacktestConfig
+    zero_trade_attempts: List[str]
+    round_num: int
+    emit: PhaseCallback
+    coverage_report: Optional[CoverageReport]
+
+
 def _apply_zero_trade_spec_updates(
     spec: StrategySpec, updates: Optional[Dict[str, Any]], code: str
 ) -> StrategySpec:
@@ -114,6 +135,12 @@ class ZeroTradeRepairer:
     on ``committed=False`` the caller falls through to the generic
     refinement agent. Either way, ``new_gates`` carries the gate results
     produced during the attempt so they reach the persisted record.
+
+    ``try_repair`` reads as a top-to-bottom sequence of step methods, each
+    of which either returns ``None`` (continue) or a fully-built
+    ``ZeroTradeRepairOutcome`` (terminate). The ``_reject`` helper collapses
+    the rejection-emit-and-outcome pattern that fires at every step's
+    failure path.
     """
 
     def __init__(self, orchestrator: "StrategyLabOrchestrator") -> None:
@@ -138,29 +165,37 @@ class ZeroTradeRepairer:
     ) -> ZeroTradeRepairOutcome:
         """Specialized zero-trade repair attempt.
 
-        Asks the :class:`ZeroTradeRepairAgent` (held on the orchestrator)
-        for a targeted code fix based on the deterministic execution
-        diagnostics, then gates the proposal through code-safety + a fresh
+        Asks the :class:`ZeroTradeRepairAgent` for a targeted code fix
+        based on the deterministic execution diagnostics, then gates the
+        proposal through code-safety + spec re-validation + a fresh
         backtest + :class:`BacktestAnomalyDetector` before signalling
-        commit. Mirrors the alignment loop's break-without-commit posture:
-        any failed gate appends a record to ``zero_trade_attempts`` and
-        returns ``committed=False`` so the caller falls through to the
-        generic :class:`RefinementAgent`.
+        commit. Any failed gate appends a record to
+        ``zero_trade_attempts`` and returns ``committed=False`` so the
+        caller falls through to the generic :class:`RefinementAgent`.
 
         Pre: ``spec`` is a StrategySpec; ``code`` is the current code;
         ``exec_result.execution_diagnostics`` must be present.
         Post: returns a ZeroTradeRepairOutcome whose ``new_gates`` reflect
         every gate the proposal exercised, regardless of commit status.
         """
-        orch = self._orch
         diagnostics = exec_result.execution_diagnostics
-        # Caller is responsible for the routing guard, but be defensive.
         if diagnostics is None or diagnostics.zero_trade_category is None:
+            # Caller is responsible for the routing guard; be defensive.
             return ZeroTradeRepairOutcome(
                 committed=False,
                 failure_reason="no zero_trade_category on diagnostics envelope",
             )
 
+        ctx = _RepairCtx(
+            spec=spec,
+            code=code,
+            market_data=market_data,
+            config=config,
+            zero_trade_attempts=zero_trade_attempts,
+            round_num=round_num,
+            emit=emit,
+            coverage_report=coverage_report,
+        )
         emit(
             "coding",
             {
@@ -171,280 +206,68 @@ class ZeroTradeRepairer:
             },
         )
 
-        try:
-            report: ZeroTradeRepairReport = orch.zero_trade_repair_agent.run(
-                spec=spec,
-                code=code,
-                diagnostics=diagnostics,
-                coverage_report=coverage_report,
-                prior_attempts=zero_trade_attempts,
-            )
-        except Exception as exc:
-            logger.exception("Zero-trade repair agent raised; falling through to refinement")
-            zero_trade_attempts.append(
-                f"agent_error: {type(exc).__name__}: {str(exc)[:160]}"
-            )
-            emit(
-                "coding",
-                {
-                    "sub_phase": "zero_trade_repair_skipped",
-                    "refinement_round": round_num,
-                    "reason": "agent_error",
-                },
-            )
-            return ZeroTradeRepairOutcome(
-                committed=False, failure_reason=f"agent_error: {exc}"
-            )
+        # Step 1 — ask the agent for a proposal.
+        report_or_outcome = self._fetch_proposal(ctx, diagnostics)
+        if isinstance(report_or_outcome, ZeroTradeRepairOutcome):
+            return report_or_outcome
+        report = report_or_outcome
 
-        if not report.proposed_code:
-            zero_trade_attempts.append(
-                f"no_proposal ({report.root_cause_category}): "
-                f"{report.evidence[:160] or 'agent declined to propose'}"
-            )
-            emit(
-                "coding",
-                {
-                    "sub_phase": "zero_trade_repair_skipped",
-                    "refinement_round": round_num,
-                    "reason": "no_proposed_code",
-                    "root_cause_category": report.root_cause_category,
-                },
-            )
-            return ZeroTradeRepairOutcome(committed=False, failure_reason="no_proposed_code")
+        # Step 2 — code-safety gate on the proposed code.
+        safety_gates_or_outcome = self._gate_proposed_code_safety(ctx, report)
+        if isinstance(safety_gates_or_outcome, ZeroTradeRepairOutcome):
+            return safety_gates_or_outcome
+        safety_gates = safety_gates_or_outcome
 
-        # ── Code-safety gate on the proposed code ────────────────────
-        # Stamp-only: the caller persists ``safety_gates`` via the outcome's
-        # ``new_gates=`` so the orchestrator's running list is not extended here.
-        safety_gates = orch.record_gates(
-            orch.code_safety_checker.check(report.proposed_code, spec),
-            refinement_round=round_num,
-            gate_name_prefix="zero_trade_repair_",
+        # Off-list spec keys → warning gate, carried forward to every
+        # subsequent early-return so the audit trail is intact.
+        dropped_keys_gates = self._build_dropped_keys_gates(ctx, report)
+
+        # Step 3 — apply whitelisted spec updates, surface ValidationError.
+        spec_or_outcome = self._apply_spec_updates(
+            ctx, report, safety_gates=safety_gates, dropped_keys_gates=dropped_keys_gates
         )
-        critical_safety = [
-            g for g in safety_gates if not g.passed and g.severity == "critical"
-        ]
-        if critical_safety:
-            zero_trade_attempts.append(
-                f"unsafe_code ({report.root_cause_category}): "
-                f"{'; '.join(g.details for g in critical_safety)[:160]}"
-            )
-            emit(
-                "coding",
-                {
-                    "sub_phase": "zero_trade_repair_rejected",
-                    "refinement_round": round_num,
-                    "reason": "unsafe_code",
-                    "details": "; ".join(g.details for g in critical_safety)[:400],
-                },
-            )
-            return ZeroTradeRepairOutcome(
-                committed=False,
-                new_gates=safety_gates,
-                failure_reason="unsafe_code",
-            )
+        if isinstance(spec_or_outcome, ZeroTradeRepairOutcome):
+            return spec_or_outcome
+        proposed_spec = spec_or_outcome
 
-        # ── Surface any off-list spec keys the agent tried to mutate ─
-        # Union the agent's own filter (``report.dropped_spec_update_keys``)
-        # with any keys still on ``proposed_spec_updates`` so the warning
-        # and the ``zero_trade_repair_dropped_spec_keys`` quality gate fire
-        # in both flows and the drift is auditable.
-        dropped_spec_keys: List[str] = sorted(
-            set(report.dropped_spec_update_keys)
-            | {
-                k
-                for k in (report.proposed_spec_updates or {})
-                if k not in _ZERO_TRADE_SPEC_UPDATE_KEYS
-            }
+        # Step 4 — re-validate the spec after the mutation.
+        spec_gates_or_outcome = self._revalidate_spec(
+            ctx,
+            report,
+            proposed_spec=proposed_spec,
+            safety_gates=safety_gates,
+            dropped_keys_gates=dropped_keys_gates,
         )
-        dropped_keys_gates: List[QualityGateResult] = []
-        if dropped_spec_keys:
-            logger.warning(
-                "Zero-trade repair discarded spec-mutating keys %s for round=%s "
-                "(post-#530 repair may only adjust risk_limits; fix the code, "
-                "not the spec).",
-                dropped_spec_keys,
-                round_num,
-            )
-            # Build the gate once so every early-return path carries it
-            # forward (the ValidationError path below would otherwise drop
-            # the audit trail even though the warning was logged).
-            dropped_keys_gates = [
-                orch.build_orchestrator_gate(
-                    "zero_trade_repair_dropped_spec_keys",
-                    phase="synthesis",
-                    severity="warning",
-                    details=(
-                        "Zero-trade repair proposed off-list spec keys "
-                        f"{dropped_spec_keys}; dropped per #530 "
-                        "(risk_limits only)."
-                    ),
-                    refinement_round=round_num,
-                )
-            ]
+        if isinstance(spec_gates_or_outcome, ZeroTradeRepairOutcome):
+            return spec_gates_or_outcome
+        post_repair_spec_gates = spec_gates_or_outcome
 
-        # ── Fresh backtest of the proposed code ──────────────────────
-        try:
-            proposed_spec = _apply_zero_trade_spec_updates(
-                spec, report.proposed_spec_updates, report.proposed_code
-            )
-        except ValidationError as exc:
-            # Whitelisted keys can still arrive with the wrong shape (e.g.
-            # ``risk_limits`` as a list). Reject the proposal as we would
-            # for unsafe code and let the caller fall through to generic
-            # refinement instead of aborting the Strategy Lab cycle.
-            logger.warning(
-                "Zero-trade repair proposal had invalid spec updates: %s", exc
-            )
-            zero_trade_attempts.append(
-                f"invalid_spec_updates ({report.root_cause_category}): "
-                f"{str(exc).splitlines()[0][:160]}"
-            )
-            emit(
-                "coding",
-                {
-                    "sub_phase": "zero_trade_repair_rejected",
-                    "refinement_round": round_num,
-                    "reason": "invalid_spec_updates",
-                    "details": str(exc).splitlines()[0][:400],
-                },
-            )
-            return ZeroTradeRepairOutcome(
-                committed=False,
-                new_gates=safety_gates + dropped_keys_gates,
-                failure_reason="invalid_spec_updates",
-            )
-
-        # ── Re-validate the spec after repair-driven mutation ────────
-        # The pre-synthesis gate only runs once at ideation. Post-#530,
-        # zero-trade repair may only mutate ``risk_limits`` via the whitelist;
-        # that single mutation still bypasses the pre-synthesis gate. A
-        # Pydantic-valid risk_limits value (e.g. max_position_pct=99) can
-        # still be a critical spec failure under StrategySpecValidator.
-        # Re-validate before committing; on accept, carry the gates forward
-        # in ``new_gates`` so warnings reach the persisted record.
-        post_repair_spec_gates: List[QualityGateResult] = []
-        if report.proposed_spec_updates:
-            # Zero-trade repair runs inside the synthesis refinement loop —
-            # re-validate the patched spec under that phase rather than design.
-            # Stamp-only; the caller persists via the outcome's ``new_gates=``.
-            post_repair_spec_gates = orch.record_gates(
-                orch.strategy_validator.validate(proposed_spec, phase="synthesis"),
-                refinement_round=round_num,
-                gate_name_prefix="zero_trade_repair_",
-            )
-        # Extend with the pre-built dropped-keys gate so the persisted
-        # ``quality_gate_results`` records the attempted spec mutation even
-        # when no whitelisted key was present.
-        post_repair_spec_gates.extend(dropped_keys_gates)
-        spec_criticals = [
-            g
-            for g in post_repair_spec_gates
-            if not g.passed and g.severity == "critical"
-        ]
-        if spec_criticals:
-            zero_trade_attempts.append(
-                f"invalid_spec_after_repair ({report.root_cause_category}): "
-                f"{'; '.join(g.details for g in spec_criticals)[:160]}"
-            )
-            emit(
-                "coding",
-                {
-                    "sub_phase": "zero_trade_repair_rejected",
-                    "refinement_round": round_num,
-                    "reason": "invalid_spec_after_repair",
-                    "details": "; ".join(g.details for g in spec_criticals)[:400],
-                },
-            )
-            return ZeroTradeRepairOutcome(
-                committed=False,
-                new_gates=safety_gates + post_repair_spec_gates,
-                failure_reason="invalid_spec_after_repair",
-            )
-
-        repair_exec = run_strategy_code(
-            report.proposed_code, market_data, config, strategy=proposed_spec
+        # Step 5 — fresh backtest of the proposed code.
+        exec_or_outcome = self._re_execute(
+            ctx,
+            report,
+            proposed_spec=proposed_spec,
+            safety_gates=safety_gates,
+            post_repair_spec_gates=post_repair_spec_gates,
         )
-        if not repair_exec.success:
-            failure_gate = orch.build_orchestrator_gate(
-                "zero_trade_repair_code_execution",
-                phase="synthesis",
-                details=(
-                    f"Re-execution after zero-trade repair failed "
-                    f"({repair_exec.error_type}): {repair_exec.stderr[:400]}"
-                ),
-                refinement_round=round_num,
-            )
-            zero_trade_attempts.append(
-                f"reexec_failed ({report.root_cause_category}): {repair_exec.error_type}"
-            )
-            emit(
-                "coding",
-                {
-                    "sub_phase": "zero_trade_repair_rejected",
-                    "refinement_round": round_num,
-                    "reason": "re_execution_failed",
-                    "error_type": repair_exec.error_type,
-                },
-            )
-            return ZeroTradeRepairOutcome(
-                committed=False,
-                new_gates=safety_gates + post_repair_spec_gates + [failure_gate],
-                failure_reason=f"re_execution_failed: {repair_exec.error_type}",
-            )
+        if isinstance(exec_or_outcome, ZeroTradeRepairOutcome):
+            return exec_or_outcome
+        repair_exec, new_trades, new_metrics = exec_or_outcome
 
-        new_trades = repair_exec.trades
-        new_metrics = compute_metrics(
-            new_trades, config.initial_capital, config.start_date, config.end_date
+        # Step 6 — anomaly recheck on the post-fix backtest.
+        anomaly_gates_or_outcome = self._anomaly_recheck(
+            ctx,
+            report,
+            proposed_spec=proposed_spec,
+            repair_exec=repair_exec,
+            new_trades=new_trades,
+            new_metrics=new_metrics,
+            safety_gates=safety_gates,
+            post_repair_spec_gates=post_repair_spec_gates,
         )
-
-        # Repair re-execution path also attaches a CoverageReport when the
-        # proposed fix produces zero/low trades.
-        from .orchestrator import _maybe_attach_coverage_report  # local import — avoids cycle
-
-        _maybe_attach_coverage_report(
-            metrics=new_metrics,
-            spec=proposed_spec,
-            market_data=market_data,
-            config=config,
-            exec_result=repair_exec,
-        )
-
-        # ── Anomaly recheck ──────────────────────────────────────────
-        # Stamp-only; ``new_gates`` is persisted by the caller via the outcome.
-        new_anomaly_gates = orch.record_gates(
-            orch.anomaly_detector.check(
-                new_metrics,
-                new_trades,
-                dsr_aware=config.walk_forward_enabled,
-                diagnostics=repair_exec.execution_diagnostics,
-                coverage_report=new_metrics.coverage_report,
-            ),
-            refinement_round=round_num,
-            gate_name_prefix="zero_trade_repair_",
-        )
-
-        new_critical = [
-            g for g in new_anomaly_gates if not g.passed and g.severity == "critical"
-        ]
-        if new_critical:
-            zero_trade_attempts.append(
-                f"anomaly_after_repair ({report.root_cause_category}): "
-                f"{'; '.join(g.details for g in new_critical)[:160]}"
-            )
-            emit(
-                "coding",
-                {
-                    "sub_phase": "zero_trade_repair_rejected",
-                    "refinement_round": round_num,
-                    "reason": "anomaly_after_repair",
-                    "details": "; ".join(g.details for g in new_critical)[:400],
-                },
-            )
-            return ZeroTradeRepairOutcome(
-                committed=False,
-                new_gates=safety_gates + post_repair_spec_gates + new_anomaly_gates,
-                failure_reason="anomaly_after_repair",
-            )
+        if isinstance(anomaly_gates_or_outcome, ZeroTradeRepairOutcome):
+            return anomaly_gates_or_outcome
+        new_anomaly_gates = anomaly_gates_or_outcome
 
         # All gates passed — commit the proposal.
         change_summary = report.changes_made or f"repair {report.root_cause_category}"
@@ -471,3 +294,352 @@ class ZeroTradeRepairer:
             new_gates=safety_gates + post_repair_spec_gates + new_anomaly_gates,
             changes_made=change_summary,
         )
+
+    # ------------------------------------------------------------------
+    # Step methods. Each returns ``None`` / a step-specific success value
+    # to continue, or a ``ZeroTradeRepairOutcome`` to terminate.
+    # ------------------------------------------------------------------
+
+    def _reject(
+        self,
+        ctx: _RepairCtx,
+        *,
+        sub_phase: str,
+        attempt: str,
+        failure_reason: str,
+        new_gates: Optional[List[QualityGateResult]] = None,
+        extra_event: Optional[Dict[str, Any]] = None,
+    ) -> ZeroTradeRepairOutcome:
+        """Build a not-committed outcome with the matching emit + attempt log.
+
+        Every step's rejection path follows the same three-step shape: log
+        the attempt, emit the sub-phase event, return the outcome. This
+        helper folds the duplication so each step's failure branch is one
+        call instead of fifteen lines.
+        """
+        ctx.zero_trade_attempts.append(attempt)
+        event: Dict[str, Any] = {
+            "sub_phase": sub_phase,
+            "refinement_round": ctx.round_num,
+        }
+        if extra_event:
+            event.update(extra_event)
+        ctx.emit("coding", event)
+        return ZeroTradeRepairOutcome(
+            committed=False,
+            new_gates=list(new_gates or []),
+            failure_reason=failure_reason,
+        )
+
+    def _fetch_proposal(
+        self, ctx: _RepairCtx, diagnostics: Any
+    ) -> "ZeroTradeRepairReport | ZeroTradeRepairOutcome":
+        """Call the repair agent. Returns the report or a rejection outcome."""
+        orch = self._orch
+        try:
+            report: ZeroTradeRepairReport = orch.zero_trade_repair_agent.run(
+                spec=ctx.spec,
+                code=ctx.code,
+                diagnostics=diagnostics,
+                coverage_report=ctx.coverage_report,
+                prior_attempts=ctx.zero_trade_attempts,
+            )
+        except Exception as exc:
+            logger.exception("Zero-trade repair agent raised; falling through to refinement")
+            return self._reject(
+                ctx,
+                sub_phase="zero_trade_repair_skipped",
+                attempt=f"agent_error: {type(exc).__name__}: {str(exc)[:160]}",
+                failure_reason=f"agent_error: {exc}",
+                extra_event={"reason": "agent_error"},
+            )
+
+        if not report.proposed_code:
+            return self._reject(
+                ctx,
+                sub_phase="zero_trade_repair_skipped",
+                attempt=(
+                    f"no_proposal ({report.root_cause_category}): "
+                    f"{report.evidence[:160] or 'agent declined to propose'}"
+                ),
+                failure_reason="no_proposed_code",
+                extra_event={
+                    "reason": "no_proposed_code",
+                    "root_cause_category": report.root_cause_category,
+                },
+            )
+        return report
+
+    def _gate_proposed_code_safety(
+        self, ctx: _RepairCtx, report: ZeroTradeRepairReport
+    ) -> "list[QualityGateResult] | ZeroTradeRepairOutcome":
+        """Run code-safety against the proposed code, return gates or outcome."""
+        orch = self._orch
+        # Stamp-only: the caller persists ``safety_gates`` via the outcome's
+        # ``new_gates=`` so the orchestrator's running list isn't extended.
+        safety_gates = orch.record_gates(
+            orch.code_safety_checker.check(report.proposed_code, ctx.spec),
+            refinement_round=ctx.round_num,
+            gate_name_prefix="zero_trade_repair_",
+        )
+        critical_safety = [
+            g for g in safety_gates if not g.passed and g.severity == "critical"
+        ]
+        if critical_safety:
+            return self._reject(
+                ctx,
+                sub_phase="zero_trade_repair_rejected",
+                attempt=(
+                    f"unsafe_code ({report.root_cause_category}): "
+                    f"{'; '.join(g.details for g in critical_safety)[:160]}"
+                ),
+                failure_reason="unsafe_code",
+                new_gates=safety_gates,
+                extra_event={
+                    "reason": "unsafe_code",
+                    "details": "; ".join(g.details for g in critical_safety)[:400],
+                },
+            )
+        return safety_gates
+
+    def _build_dropped_keys_gates(
+        self, ctx: _RepairCtx, report: ZeroTradeRepairReport
+    ) -> List[QualityGateResult]:
+        """Union the agent's filtered-key list with any off-list keys still on
+        ``proposed_spec_updates`` and emit a warning gate when non-empty.
+
+        Both sources are checked because the agent-side filter strips
+        off-list keys before we see them in production, but tests / future
+        bypasses may leave keys on ``proposed_spec_updates``. Logging both
+        keeps the audit trail intact.
+        """
+        dropped_spec_keys = sorted(
+            set(report.dropped_spec_update_keys)
+            | {
+                k
+                for k in (report.proposed_spec_updates or {})
+                if k not in _ZERO_TRADE_SPEC_UPDATE_KEYS
+            }
+        )
+        if not dropped_spec_keys:
+            return []
+        logger.warning(
+            "Zero-trade repair discarded spec-mutating keys %s for round=%s "
+            "(post-#530 repair may only adjust risk_limits; fix the code, "
+            "not the spec).",
+            dropped_spec_keys,
+            ctx.round_num,
+        )
+        return [
+            self._orch.build_orchestrator_gate(
+                "zero_trade_repair_dropped_spec_keys",
+                phase="synthesis",
+                severity="warning",
+                details=(
+                    "Zero-trade repair proposed off-list spec keys "
+                    f"{dropped_spec_keys}; dropped per #530 "
+                    "(risk_limits only)."
+                ),
+                refinement_round=ctx.round_num,
+            )
+        ]
+
+    def _apply_spec_updates(
+        self,
+        ctx: _RepairCtx,
+        report: ZeroTradeRepairReport,
+        *,
+        safety_gates: List[QualityGateResult],
+        dropped_keys_gates: List[QualityGateResult],
+    ) -> "StrategySpec | ZeroTradeRepairOutcome":
+        """Apply whitelisted spec updates; turn ValidationError into a rejection."""
+        try:
+            return _apply_zero_trade_spec_updates(
+                ctx.spec, report.proposed_spec_updates, report.proposed_code
+            )
+        except ValidationError as exc:
+            # Whitelisted keys can still arrive with the wrong shape
+            # (``risk_limits`` as a list, e.g.). Reject the proposal as we
+            # would for unsafe code and let the caller fall through to
+            # generic refinement instead of aborting the cycle.
+            logger.warning(
+                "Zero-trade repair proposal had invalid spec updates: %s", exc
+            )
+            return self._reject(
+                ctx,
+                sub_phase="zero_trade_repair_rejected",
+                attempt=(
+                    f"invalid_spec_updates ({report.root_cause_category}): "
+                    f"{str(exc).splitlines()[0][:160]}"
+                ),
+                failure_reason="invalid_spec_updates",
+                new_gates=safety_gates + dropped_keys_gates,
+                extra_event={
+                    "reason": "invalid_spec_updates",
+                    "details": str(exc).splitlines()[0][:400],
+                },
+            )
+
+    def _revalidate_spec(
+        self,
+        ctx: _RepairCtx,
+        report: ZeroTradeRepairReport,
+        *,
+        proposed_spec: StrategySpec,
+        safety_gates: List[QualityGateResult],
+        dropped_keys_gates: List[QualityGateResult],
+    ) -> "list[QualityGateResult] | ZeroTradeRepairOutcome":
+        """Re-run the spec validator on the patched spec.
+
+        The pre-synthesis gate runs once at ideation; the whitelisted
+        ``risk_limits`` mutation bypasses it. A Pydantic-valid value can
+        still be a critical spec failure under ``StrategySpecValidator``
+        (e.g. ``max_position_pct=99``). Re-validate before committing.
+        """
+        orch = self._orch
+        post_repair_spec_gates: List[QualityGateResult] = []
+        if report.proposed_spec_updates:
+            # Zero-trade repair runs inside the synthesis refinement loop —
+            # re-validate the patched spec under that phase rather than design.
+            # Stamp-only; the caller persists via the outcome's ``new_gates=``.
+            post_repair_spec_gates = orch.record_gates(
+                orch.strategy_validator.validate(proposed_spec, phase="synthesis"),
+                refinement_round=ctx.round_num,
+                gate_name_prefix="zero_trade_repair_",
+            )
+        # Extend with the pre-built dropped-keys gate so the persisted
+        # ``quality_gate_results`` records the attempted spec mutation even
+        # when no whitelisted key was present.
+        post_repair_spec_gates.extend(dropped_keys_gates)
+        spec_criticals = [
+            g
+            for g in post_repair_spec_gates
+            if not g.passed and g.severity == "critical"
+        ]
+        if spec_criticals:
+            return self._reject(
+                ctx,
+                sub_phase="zero_trade_repair_rejected",
+                attempt=(
+                    f"invalid_spec_after_repair ({report.root_cause_category}): "
+                    f"{'; '.join(g.details for g in spec_criticals)[:160]}"
+                ),
+                failure_reason="invalid_spec_after_repair",
+                new_gates=safety_gates + post_repair_spec_gates,
+                extra_event={
+                    "reason": "invalid_spec_after_repair",
+                    "details": "; ".join(g.details for g in spec_criticals)[:400],
+                },
+            )
+        return post_repair_spec_gates
+
+    def _re_execute(
+        self,
+        ctx: _RepairCtx,
+        report: ZeroTradeRepairReport,
+        *,
+        proposed_spec: StrategySpec,
+        safety_gates: List[QualityGateResult],
+        post_repair_spec_gates: List[QualityGateResult],
+    ) -> "tuple[StrategyRunResult, List[TradeRecord], BacktestResult] | ZeroTradeRepairOutcome":
+        """Run the proposed code in the sandbox.
+
+        Returns the ``(exec_result, trades, metrics)`` triple on success,
+        or a rejection outcome on exec failure. Also stamps a coverage
+        report onto ``new_metrics`` when the post-fix run produced
+        zero/low trades.
+        """
+        repair_exec = run_strategy_code(
+            report.proposed_code, ctx.market_data, ctx.config, strategy=proposed_spec
+        )
+        if not repair_exec.success:
+            failure_gate = self._orch.build_orchestrator_gate(
+                "zero_trade_repair_code_execution",
+                phase="synthesis",
+                details=(
+                    f"Re-execution after zero-trade repair failed "
+                    f"({repair_exec.error_type}): {repair_exec.stderr[:400]}"
+                ),
+                refinement_round=ctx.round_num,
+            )
+            return self._reject(
+                ctx,
+                sub_phase="zero_trade_repair_rejected",
+                attempt=(
+                    f"reexec_failed ({report.root_cause_category}): {repair_exec.error_type}"
+                ),
+                failure_reason=f"re_execution_failed: {repair_exec.error_type}",
+                new_gates=safety_gates + post_repair_spec_gates + [failure_gate],
+                extra_event={
+                    "reason": "re_execution_failed",
+                    "error_type": repair_exec.error_type,
+                },
+            )
+
+        new_trades = repair_exec.trades
+        new_metrics = compute_metrics(
+            new_trades, ctx.config.initial_capital, ctx.config.start_date, ctx.config.end_date
+        )
+
+        # Repair re-execution path also attaches a CoverageReport when the
+        # proposed fix produces zero/low trades.
+        from .orchestrator import _maybe_attach_coverage_report  # local import — avoids cycle
+
+        _maybe_attach_coverage_report(
+            metrics=new_metrics,
+            spec=proposed_spec,
+            market_data=ctx.market_data,
+            config=ctx.config,
+            exec_result=repair_exec,
+        )
+        return repair_exec, new_trades, new_metrics
+
+    def _anomaly_recheck(
+        self,
+        ctx: _RepairCtx,
+        report: ZeroTradeRepairReport,
+        *,
+        proposed_spec: StrategySpec,  # noqa: ARG002  — kept for symmetry
+        repair_exec: StrategyRunResult,
+        new_trades: List[TradeRecord],
+        new_metrics: BacktestResult,
+        safety_gates: List[QualityGateResult],
+        post_repair_spec_gates: List[QualityGateResult],
+    ) -> "list[QualityGateResult] | ZeroTradeRepairOutcome":
+        """Run the anomaly detector on the post-fix backtest.
+
+        Returns the new anomaly gates on success or a rejection outcome on
+        critical anomaly.
+        """
+        orch = self._orch
+        # Stamp-only; ``new_gates`` is persisted by the caller via the outcome.
+        new_anomaly_gates = orch.record_gates(
+            orch.anomaly_detector.check(
+                new_metrics,
+                new_trades,
+                dsr_aware=ctx.config.walk_forward_enabled,
+                diagnostics=repair_exec.execution_diagnostics,
+                coverage_report=new_metrics.coverage_report,
+            ),
+            refinement_round=ctx.round_num,
+            gate_name_prefix="zero_trade_repair_",
+        )
+        new_critical = [
+            g for g in new_anomaly_gates if not g.passed and g.severity == "critical"
+        ]
+        if new_critical:
+            return self._reject(
+                ctx,
+                sub_phase="zero_trade_repair_rejected",
+                attempt=(
+                    f"anomaly_after_repair ({report.root_cause_category}): "
+                    f"{'; '.join(g.details for g in new_critical)[:160]}"
+                ),
+                failure_reason="anomaly_after_repair",
+                new_gates=safety_gates + post_repair_spec_gates + new_anomaly_gates,
+                extra_event={
+                    "reason": "anomaly_after_repair",
+                    "details": "; ".join(g.details for g in new_critical)[:400],
+                },
+            )
+        return new_anomaly_gates

--- a/backend/agents/investment_team/strategy_lab/zero_trade_repair.py
+++ b/backend/agents/investment_team/strategy_lab/zero_trade_repair.py
@@ -1,0 +1,473 @@
+"""Zero-trade repair sub-pipeline extracted from the Strategy Lab orchestrator.
+
+When a backtest produces zero trades, the orchestrator can invoke a
+specialised :class:`ZeroTradeRepairAgent` to propose a targeted code fix
+based on the deterministic execution diagnostics. The proposal then runs
+through the same battery of gates a normal refinement round would face
+(code-safety + spec re-validation + fresh backtest + anomaly recheck)
+before the orchestrator commits it.
+
+That whole flow used to live inline on :class:`StrategyLabOrchestrator`,
+threading ~340 lines of business logic and four collaborating gates
+through one private method. :class:`ZeroTradeRepairer` owns the
+sub-pipeline now; the orchestrator instantiates one repairer in
+``__init__`` and delegates with ``self.zero_trade_repairer.try_repair(...)``
+at the single call site.
+
+The orchestrator is passed in by reference and the repairer reads the
+gate instances and helper methods (``_record_gates``,
+``_orchestrator_gate``) off it — no API surface is duplicated, but the
+~340 lines of branching now sit in their own module with their own test
+boundary.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+
+from pydantic import ValidationError
+
+from ..market_data_service import OHLCVBar
+from ..models import (
+    BacktestConfig,
+    BacktestResult,
+    CoverageReport,
+    StrategySpec,
+    TradeRecord,
+)
+from ..trade_simulator import compute_metrics
+from ..trading_service.modes.sandbox_compat import StrategyRunResult, run_strategy_code
+from .agents.zero_trade_repair import ZeroTradeRepairReport
+from .quality_gates.models import QualityGateResult
+
+if TYPE_CHECKING:  # circular at runtime; only needed for type hints.
+    from .orchestrator import StrategyLabOrchestrator
+
+logger = logging.getLogger(__name__)
+
+PhaseCallback = Callable[[str, Dict[str, Any]], None]
+
+
+# Issue #530 — zero-trade repair may only mutate ``risk_limits`` via the
+# whitelist; the repair agent must fix the **code**, not weaken the **spec**.
+# Off-list keys are dropped with a ``logger.warning`` and a
+# ``zero_trade_repair_dropped_spec_keys`` quality gate so the drift is
+# visible in the persisted ``quality_gate_results``.
+_ZERO_TRADE_SPEC_UPDATE_KEYS = frozenset({"risk_limits"})
+
+
+@dataclass
+class ZeroTradeRepairOutcome:
+    """Result of one specialized zero-trade repair attempt.
+
+    ``committed=True`` means the proposed code passed code-safety, ran
+    cleanly, and produced trades that no longer trip a critical anomaly
+    gate; the orchestrator should swap in the new state. ``False`` means
+    the caller should fall through to the generic refinement agent so
+    the existing loop semantics are preserved.
+    """
+
+    committed: bool
+    new_code: str = ""
+    new_spec: Optional[StrategySpec] = None
+    new_trades: List[TradeRecord] = field(default_factory=list)
+    new_metrics: Optional[BacktestResult] = None
+    new_exec_result: Optional[StrategyRunResult] = None
+    new_gates: List[QualityGateResult] = field(default_factory=list)
+    failure_reason: str = ""
+    changes_made: str = ""
+
+
+def _apply_zero_trade_spec_updates(
+    spec: StrategySpec, updates: Optional[Dict[str, Any]], code: str
+) -> StrategySpec:
+    """Apply whitelisted spec updates from a zero-trade repair report.
+
+    Pre: ``spec`` is a StrategySpec; ``updates`` is a dict or None;
+    ``code`` is a string.
+    Post: returns a fresh StrategySpec whose ``strategy_code`` is ``code``
+    and whose ``risk_limits`` reflect any whitelisted update. Off-list
+    keys in ``updates`` are silently dropped (the caller surfaces them
+    via a ``zero_trade_repair_dropped_spec_keys`` warning gate).
+
+    Restricts merges to :data:`_ZERO_TRADE_SPEC_UPDATE_KEYS` so an off-list
+    LLM hallucination cannot rewrite arbitrary spec fields.
+    """
+    assert isinstance(spec, StrategySpec), "spec must be a StrategySpec"
+    assert isinstance(code, str), "code must be a str"
+    data = spec.model_dump()
+    for key in _ZERO_TRADE_SPEC_UPDATE_KEYS:
+        if updates and key in updates:
+            data[key] = updates[key]
+    data["strategy_code"] = code
+    return StrategySpec.model_validate(data)
+
+
+class ZeroTradeRepairer:
+    """Encapsulates the zero-trade repair sub-pipeline.
+
+    Contract: every call to :meth:`try_repair` returns a
+    :class:`ZeroTradeRepairOutcome`. On ``committed=True`` the orchestrator
+    swaps in ``new_code`` / ``new_spec`` / ``new_trades`` / ``new_metrics``;
+    on ``committed=False`` the caller falls through to the generic
+    refinement agent. Either way, ``new_gates`` carries the gate results
+    produced during the attempt so they reach the persisted record.
+    """
+
+    def __init__(self, orchestrator: "StrategyLabOrchestrator") -> None:
+        # Pre: orchestrator is non-None; the repairer reads gate instances
+        # and helper methods (``_record_gates``, ``_orchestrator_gate``) off
+        # it. No duplication of those collaborators here.
+        assert orchestrator is not None, "orchestrator must be supplied"
+        self._orch = orchestrator
+
+    def try_repair(
+        self,
+        *,
+        spec: StrategySpec,
+        code: str,
+        exec_result: StrategyRunResult,
+        market_data: Dict[str, List[OHLCVBar]],
+        config: BacktestConfig,
+        zero_trade_attempts: List[str],
+        round_num: int,
+        emit: PhaseCallback,
+        coverage_report: Optional[CoverageReport] = None,
+    ) -> ZeroTradeRepairOutcome:
+        """Specialized zero-trade repair attempt.
+
+        Asks the :class:`ZeroTradeRepairAgent` (held on the orchestrator)
+        for a targeted code fix based on the deterministic execution
+        diagnostics, then gates the proposal through code-safety + a fresh
+        backtest + :class:`BacktestAnomalyDetector` before signalling
+        commit. Mirrors the alignment loop's break-without-commit posture:
+        any failed gate appends a record to ``zero_trade_attempts`` and
+        returns ``committed=False`` so the caller falls through to the
+        generic :class:`RefinementAgent`.
+
+        Pre: ``spec`` is a StrategySpec; ``code`` is the current code;
+        ``exec_result.execution_diagnostics`` must be present.
+        Post: returns a ZeroTradeRepairOutcome whose ``new_gates`` reflect
+        every gate the proposal exercised, regardless of commit status.
+        """
+        orch = self._orch
+        diagnostics = exec_result.execution_diagnostics
+        # Caller is responsible for the routing guard, but be defensive.
+        if diagnostics is None or diagnostics.zero_trade_category is None:
+            return ZeroTradeRepairOutcome(
+                committed=False,
+                failure_reason="no zero_trade_category on diagnostics envelope",
+            )
+
+        emit(
+            "coding",
+            {
+                "sub_phase": "zero_trade_repair_started",
+                "refinement_round": round_num,
+                "zero_trade_category": diagnostics.zero_trade_category,
+                "prior_attempts": len(zero_trade_attempts),
+            },
+        )
+
+        try:
+            report: ZeroTradeRepairReport = orch.zero_trade_repair_agent.run(
+                spec=spec,
+                code=code,
+                diagnostics=diagnostics,
+                coverage_report=coverage_report,
+                prior_attempts=zero_trade_attempts,
+            )
+        except Exception as exc:
+            logger.exception("Zero-trade repair agent raised; falling through to refinement")
+            zero_trade_attempts.append(
+                f"agent_error: {type(exc).__name__}: {str(exc)[:160]}"
+            )
+            emit(
+                "coding",
+                {
+                    "sub_phase": "zero_trade_repair_skipped",
+                    "refinement_round": round_num,
+                    "reason": "agent_error",
+                },
+            )
+            return ZeroTradeRepairOutcome(
+                committed=False, failure_reason=f"agent_error: {exc}"
+            )
+
+        if not report.proposed_code:
+            zero_trade_attempts.append(
+                f"no_proposal ({report.root_cause_category}): "
+                f"{report.evidence[:160] or 'agent declined to propose'}"
+            )
+            emit(
+                "coding",
+                {
+                    "sub_phase": "zero_trade_repair_skipped",
+                    "refinement_round": round_num,
+                    "reason": "no_proposed_code",
+                    "root_cause_category": report.root_cause_category,
+                },
+            )
+            return ZeroTradeRepairOutcome(committed=False, failure_reason="no_proposed_code")
+
+        # ── Code-safety gate on the proposed code ────────────────────
+        # Stamp-only: the caller persists ``safety_gates`` via the outcome's
+        # ``new_gates=`` so the orchestrator's running list is not extended here.
+        safety_gates = orch._record_gates(
+            orch.code_safety_checker.check(report.proposed_code, spec),
+            refinement_round=round_num,
+            gate_name_prefix="zero_trade_repair_",
+        )
+        critical_safety = [
+            g for g in safety_gates if not g.passed and g.severity == "critical"
+        ]
+        if critical_safety:
+            zero_trade_attempts.append(
+                f"unsafe_code ({report.root_cause_category}): "
+                f"{'; '.join(g.details for g in critical_safety)[:160]}"
+            )
+            emit(
+                "coding",
+                {
+                    "sub_phase": "zero_trade_repair_rejected",
+                    "refinement_round": round_num,
+                    "reason": "unsafe_code",
+                    "details": "; ".join(g.details for g in critical_safety)[:400],
+                },
+            )
+            return ZeroTradeRepairOutcome(
+                committed=False,
+                new_gates=safety_gates,
+                failure_reason="unsafe_code",
+            )
+
+        # ── Surface any off-list spec keys the agent tried to mutate ─
+        # Union the agent's own filter (``report.dropped_spec_update_keys``)
+        # with any keys still on ``proposed_spec_updates`` so the warning
+        # and the ``zero_trade_repair_dropped_spec_keys`` quality gate fire
+        # in both flows and the drift is auditable.
+        dropped_spec_keys: List[str] = sorted(
+            set(report.dropped_spec_update_keys)
+            | {
+                k
+                for k in (report.proposed_spec_updates or {})
+                if k not in _ZERO_TRADE_SPEC_UPDATE_KEYS
+            }
+        )
+        dropped_keys_gates: List[QualityGateResult] = []
+        if dropped_spec_keys:
+            logger.warning(
+                "Zero-trade repair discarded spec-mutating keys %s for round=%s "
+                "(post-#530 repair may only adjust risk_limits; fix the code, "
+                "not the spec).",
+                dropped_spec_keys,
+                round_num,
+            )
+            # Build the gate once so every early-return path carries it
+            # forward (the ValidationError path below would otherwise drop
+            # the audit trail even though the warning was logged).
+            dropped_keys_gates = [
+                orch._orchestrator_gate(
+                    "zero_trade_repair_dropped_spec_keys",
+                    phase="synthesis",
+                    severity="warning",
+                    details=(
+                        "Zero-trade repair proposed off-list spec keys "
+                        f"{dropped_spec_keys}; dropped per #530 "
+                        "(risk_limits only)."
+                    ),
+                    refinement_round=round_num,
+                )
+            ]
+
+        # ── Fresh backtest of the proposed code ──────────────────────
+        try:
+            proposed_spec = _apply_zero_trade_spec_updates(
+                spec, report.proposed_spec_updates, report.proposed_code
+            )
+        except ValidationError as exc:
+            # Whitelisted keys can still arrive with the wrong shape (e.g.
+            # ``risk_limits`` as a list). Reject the proposal as we would
+            # for unsafe code and let the caller fall through to generic
+            # refinement instead of aborting the Strategy Lab cycle.
+            logger.warning(
+                "Zero-trade repair proposal had invalid spec updates: %s", exc
+            )
+            zero_trade_attempts.append(
+                f"invalid_spec_updates ({report.root_cause_category}): "
+                f"{str(exc).splitlines()[0][:160]}"
+            )
+            emit(
+                "coding",
+                {
+                    "sub_phase": "zero_trade_repair_rejected",
+                    "refinement_round": round_num,
+                    "reason": "invalid_spec_updates",
+                    "details": str(exc).splitlines()[0][:400],
+                },
+            )
+            return ZeroTradeRepairOutcome(
+                committed=False,
+                new_gates=safety_gates + dropped_keys_gates,
+                failure_reason="invalid_spec_updates",
+            )
+
+        # ── Re-validate the spec after repair-driven mutation ────────
+        # The pre-synthesis gate only runs once at ideation. Post-#530,
+        # zero-trade repair may only mutate ``risk_limits`` via the whitelist;
+        # that single mutation still bypasses the pre-synthesis gate. A
+        # Pydantic-valid risk_limits value (e.g. max_position_pct=99) can
+        # still be a critical spec failure under StrategySpecValidator.
+        # Re-validate before committing; on accept, carry the gates forward
+        # in ``new_gates`` so warnings reach the persisted record.
+        post_repair_spec_gates: List[QualityGateResult] = []
+        if report.proposed_spec_updates:
+            # Zero-trade repair runs inside the synthesis refinement loop —
+            # re-validate the patched spec under that phase rather than design.
+            # Stamp-only; the caller persists via the outcome's ``new_gates=``.
+            post_repair_spec_gates = orch._record_gates(
+                orch.strategy_validator.validate(proposed_spec, phase="synthesis"),
+                refinement_round=round_num,
+                gate_name_prefix="zero_trade_repair_",
+            )
+        # Extend with the pre-built dropped-keys gate so the persisted
+        # ``quality_gate_results`` records the attempted spec mutation even
+        # when no whitelisted key was present.
+        post_repair_spec_gates.extend(dropped_keys_gates)
+        spec_criticals = [
+            g
+            for g in post_repair_spec_gates
+            if not g.passed and g.severity == "critical"
+        ]
+        if spec_criticals:
+            zero_trade_attempts.append(
+                f"invalid_spec_after_repair ({report.root_cause_category}): "
+                f"{'; '.join(g.details for g in spec_criticals)[:160]}"
+            )
+            emit(
+                "coding",
+                {
+                    "sub_phase": "zero_trade_repair_rejected",
+                    "refinement_round": round_num,
+                    "reason": "invalid_spec_after_repair",
+                    "details": "; ".join(g.details for g in spec_criticals)[:400],
+                },
+            )
+            return ZeroTradeRepairOutcome(
+                committed=False,
+                new_gates=safety_gates + post_repair_spec_gates,
+                failure_reason="invalid_spec_after_repair",
+            )
+
+        repair_exec = run_strategy_code(
+            report.proposed_code, market_data, config, strategy=proposed_spec
+        )
+        if not repair_exec.success:
+            failure_gate = orch._orchestrator_gate(
+                "zero_trade_repair_code_execution",
+                phase="synthesis",
+                details=(
+                    f"Re-execution after zero-trade repair failed "
+                    f"({repair_exec.error_type}): {repair_exec.stderr[:400]}"
+                ),
+                refinement_round=round_num,
+            )
+            zero_trade_attempts.append(
+                f"reexec_failed ({report.root_cause_category}): {repair_exec.error_type}"
+            )
+            emit(
+                "coding",
+                {
+                    "sub_phase": "zero_trade_repair_rejected",
+                    "refinement_round": round_num,
+                    "reason": "re_execution_failed",
+                    "error_type": repair_exec.error_type,
+                },
+            )
+            return ZeroTradeRepairOutcome(
+                committed=False,
+                new_gates=safety_gates + post_repair_spec_gates + [failure_gate],
+                failure_reason=f"re_execution_failed: {repair_exec.error_type}",
+            )
+
+        new_trades = repair_exec.trades
+        new_metrics = compute_metrics(
+            new_trades, config.initial_capital, config.start_date, config.end_date
+        )
+
+        # Repair re-execution path also attaches a CoverageReport when the
+        # proposed fix produces zero/low trades.
+        from .orchestrator import _maybe_attach_coverage_report  # local import — avoids cycle
+
+        _maybe_attach_coverage_report(
+            metrics=new_metrics,
+            spec=proposed_spec,
+            market_data=market_data,
+            config=config,
+            exec_result=repair_exec,
+        )
+
+        # ── Anomaly recheck ──────────────────────────────────────────
+        # Stamp-only; ``new_gates`` is persisted by the caller via the outcome.
+        new_anomaly_gates = orch._record_gates(
+            orch.anomaly_detector.check(
+                new_metrics,
+                new_trades,
+                dsr_aware=config.walk_forward_enabled,
+                diagnostics=repair_exec.execution_diagnostics,
+                coverage_report=new_metrics.coverage_report,
+            ),
+            refinement_round=round_num,
+            gate_name_prefix="zero_trade_repair_",
+        )
+
+        new_critical = [
+            g for g in new_anomaly_gates if not g.passed and g.severity == "critical"
+        ]
+        if new_critical:
+            zero_trade_attempts.append(
+                f"anomaly_after_repair ({report.root_cause_category}): "
+                f"{'; '.join(g.details for g in new_critical)[:160]}"
+            )
+            emit(
+                "coding",
+                {
+                    "sub_phase": "zero_trade_repair_rejected",
+                    "refinement_round": round_num,
+                    "reason": "anomaly_after_repair",
+                    "details": "; ".join(g.details for g in new_critical)[:400],
+                },
+            )
+            return ZeroTradeRepairOutcome(
+                committed=False,
+                new_gates=safety_gates + post_repair_spec_gates + new_anomaly_gates,
+                failure_reason="anomaly_after_repair",
+            )
+
+        # All gates passed — commit the proposal.
+        change_summary = report.changes_made or f"repair {report.root_cause_category}"
+        zero_trade_attempts.append(
+            f"committed ({report.root_cause_category}): {change_summary[:160]}"
+        )
+        emit(
+            "coding",
+            {
+                "sub_phase": "zero_trade_repair_committed",
+                "refinement_round": round_num,
+                "root_cause_category": report.root_cause_category,
+                "changes_made": change_summary,
+                "trades_count": len(new_trades),
+            },
+        )
+        return ZeroTradeRepairOutcome(
+            committed=True,
+            new_code=report.proposed_code,
+            new_spec=proposed_spec,
+            new_trades=new_trades,
+            new_metrics=new_metrics,
+            new_exec_result=repair_exec,
+            new_gates=safety_gates + post_repair_spec_gates + new_anomaly_gates,
+            changes_made=change_summary,
+        )

--- a/backend/agents/investment_team/tests/conftest.py
+++ b/backend/agents/investment_team/tests/conftest.py
@@ -1,22 +1,64 @@
-"""Shared pytest fixtures for the investment_team test suite.
+"""Shared pytest fixtures + markers for the investment_team test suite.
 
-The ``stub_readiness_market_data_fetch`` fixture is **opt-in**: tests
-that build a real ``StrategyLabOrchestrator`` and drive ``run_cycle``
-without otherwise mocking the data layer request it explicitly. Making
-it autouse would mask the production fail-closed path in every
-integration test, defeating the very check ``_readiness_price_provider``
-implements (return ``NaN`` when the live service raises / returns no
-bars so ``SpecReadinessGate`` Rule 5 surfaces a critical instead of
-silently passing).
+Tests that build a real ``StrategyLabOrchestrator`` and drive
+``run_cycle`` need a deterministic ``MarketDataService.fetch_ohlcv``
+because ``_readiness_price_provider`` fails closed (returns ``NaN``)
+when the live data layer returns nothing — which would otherwise trip
+``SpecReadinessGate`` Rule 5 on every integration test, masking the
+real failure being tested.
 
-Tests that test the fail-closed path itself (regression tests in
-``test_spec_readiness.py``) must not request this fixture and instead
-override ``orch.market_data_service.fetch_ohlcv`` per-instance.
+The opt-in mechanism is a **marker**:
+
+    @pytest.mark.strategy_lab_integration
+    def test_run_cycle_does_X(...): ...
+
+or at module scope:
+
+    pytestmark = pytest.mark.strategy_lab_integration
+
+Marked tests automatically receive the ``stub_readiness_market_data_fetch``
+fixture via ``pytest_collection_modifyitems``. Tests that exercise the
+fail-closed path itself (regression tests in ``test_spec_readiness.py``)
+must NOT carry the marker; they override
+``orch.market_data_service.fetch_ohlcv`` per-instance instead.
+
+The marker name documents test intent (this is an integration test
+against the Strategy Lab pipeline) rather than the implementation
+detail (which fixture to request) — easier to remember for future
+tests, and harder to forget than a manually-typed fixture name.
 """
 
 from __future__ import annotations
 
 import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    config.addinivalue_line(
+        "markers",
+        "strategy_lab_integration: test drives a real StrategyLabOrchestrator "
+        "through run_cycle; auto-applies stub_readiness_market_data_fetch.",
+    )
+
+
+def pytest_collection_modifyitems(
+    config: pytest.Config, items: list[pytest.Item]
+) -> None:
+    """Auto-apply ``stub_readiness_market_data_fetch`` to every
+    ``strategy_lab_integration`` test.
+
+    Pre: every test that needs the readiness stub carries the marker
+    (at item or module scope).
+    Post: items carrying the marker pick up the fixture via fixturenames,
+    so the live readiness path is exercised everywhere else.
+    """
+    for item in items:
+        if item.get_closest_marker("strategy_lab_integration") is None:
+            continue
+        # pytest fixtures are requested by name. Appending to ``fixturenames``
+        # only works on Function items; non-function items don't have the slot.
+        if hasattr(item, "fixturenames") and "stub_readiness_market_data_fetch" not in item.fixturenames:  # type: ignore[attr-defined]
+            item.fixturenames.append("stub_readiness_market_data_fetch")  # type: ignore[attr-defined]
 
 
 @pytest.fixture

--- a/backend/agents/investment_team/tests/conftest.py
+++ b/backend/agents/investment_team/tests/conftest.py
@@ -1,0 +1,50 @@
+"""Shared pytest fixtures for the investment_team test suite.
+
+Autouse-stubs the live ``MarketDataService.fetch_ohlcv`` lookup so the
+readiness price provider on ``StrategyLabOrchestrator`` sees a
+deterministic, finite price during tests. Without this, the production
+fail-closed path (``_readiness_price_provider`` returns ``NaN`` when the
+live service raises or returns no bars) trips ``SpecReadinessGate``
+Rule 5 in every test that builds a real orchestrator and calls
+``run_cycle`` — those tests never wanted to exercise the readiness
+sizing path and would otherwise short-circuit on a spurious critical.
+
+Tests that explicitly need the fail-closed behaviour (e.g. the
+``_readiness_price_provider`` regression tests in
+``test_spec_readiness.py``) replace ``orch.market_data_service.fetch_ohlcv``
+per-instance after the fixture has run; those instance overrides take
+precedence over the class-level stub installed here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _stub_readiness_market_data_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Return a single synthetic OHLCV bar for any ``fetch_ohlcv`` call.
+
+    Patches the class so every ``MarketDataService`` instance — including
+    ones built inside ``StrategyLabOrchestrator.__init__`` — picks up the
+    stub before the orchestrator's ``_readiness_price_provider`` reaches
+    it. Tests that need a different return can override the instance
+    attribute (``orch.market_data_service.fetch_ohlcv = ...``).
+    """
+    from investment_team.market_data_service import MarketDataService, OHLCVBar
+
+    sentinel = [
+        OHLCVBar(
+            date="2024-06-01",
+            open=100.0,
+            high=100.5,
+            low=99.5,
+            close=100.0,
+            volume=1_000_000,
+        )
+    ]
+
+    def _stub(self, symbol, asset_class, days=365):  # noqa: ARG001 — match signature
+        return list(sentinel)
+
+    monkeypatch.setattr(MarketDataService, "fetch_ohlcv", _stub)

--- a/backend/agents/investment_team/tests/conftest.py
+++ b/backend/agents/investment_team/tests/conftest.py
@@ -1,19 +1,17 @@
 """Shared pytest fixtures for the investment_team test suite.
 
-Autouse-stubs the live ``MarketDataService.fetch_ohlcv`` lookup so the
-readiness price provider on ``StrategyLabOrchestrator`` sees a
-deterministic, finite price during tests. Without this, the production
-fail-closed path (``_readiness_price_provider`` returns ``NaN`` when the
-live service raises or returns no bars) trips ``SpecReadinessGate``
-Rule 5 in every test that builds a real orchestrator and calls
-``run_cycle`` — those tests never wanted to exercise the readiness
-sizing path and would otherwise short-circuit on a spurious critical.
+The ``stub_readiness_market_data_fetch`` fixture is **opt-in**: tests
+that build a real ``StrategyLabOrchestrator`` and drive ``run_cycle``
+without otherwise mocking the data layer request it explicitly. Making
+it autouse would mask the production fail-closed path in every
+integration test, defeating the very check ``_readiness_price_provider``
+implements (return ``NaN`` when the live service raises / returns no
+bars so ``SpecReadinessGate`` Rule 5 surfaces a critical instead of
+silently passing).
 
-Tests that explicitly need the fail-closed behaviour (e.g. the
-``_readiness_price_provider`` regression tests in
-``test_spec_readiness.py``) replace ``orch.market_data_service.fetch_ohlcv``
-per-instance after the fixture has run; those instance overrides take
-precedence over the class-level stub installed here.
+Tests that test the fail-closed path itself (regression tests in
+``test_spec_readiness.py``) must not request this fixture and instead
+override ``orch.market_data_service.fetch_ohlcv`` per-instance.
 """
 
 from __future__ import annotations
@@ -21,15 +19,16 @@ from __future__ import annotations
 import pytest
 
 
-@pytest.fixture(autouse=True)
-def _stub_readiness_market_data_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.fixture
+def stub_readiness_market_data_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
     """Return a single synthetic OHLCV bar for any ``fetch_ohlcv`` call.
 
     Patches the class so every ``MarketDataService`` instance — including
     ones built inside ``StrategyLabOrchestrator.__init__`` — picks up the
     stub before the orchestrator's ``_readiness_price_provider`` reaches
     it. Tests that need a different return can override the instance
-    attribute (``orch.market_data_service.fetch_ohlcv = ...``).
+    attribute (``orch.market_data_service.fetch_ohlcv = ...``) after the
+    fixture has run.
     """
     from investment_team.market_data_service import MarketDataService, OHLCVBar
 

--- a/backend/agents/investment_team/tests/conftest.py
+++ b/backend/agents/investment_team/tests/conftest.py
@@ -22,13 +22,17 @@ fail-closed path itself (regression tests in ``test_spec_readiness.py``)
 must NOT carry the marker; they override
 ``orch.market_data_service.fetch_ohlcv`` per-instance instead.
 
-The marker name documents test intent (this is an integration test
-against the Strategy Lab pipeline) rather than the implementation
-detail (which fixture to request) — easier to remember for future
-tests, and harder to forget than a manually-typed fixture name.
+Stub-builder helpers (``ideation_returning``, ``noop_refine``,
+``empty_market_data``, ``failing_sandbox``) are exported so individual
+test files don't redefine the same boilerplate. Use them to mock
+``orch.ideation_agent.run`` / ``orch.refinement_agent.run`` /
+``_fetch_market_data`` / ``run_strategy_code`` with one-line monkeypatch
+calls.
 """
 
 from __future__ import annotations
+
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import pytest
 
@@ -89,3 +93,91 @@ def stub_readiness_market_data_fetch(monkeypatch: pytest.MonkeyPatch) -> None:
         return list(sentinel)
 
     monkeypatch.setattr(MarketDataService, "fetch_ohlcv", _stub)
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Stub builders for ``StrategyLabOrchestrator`` collaborators.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+def ideation_returning(
+    spec_dict: Dict[str, Any], code: str, *, rationale: str = "scripted rationale"
+) -> Callable[..., Tuple[Dict[str, Any], str, str]]:
+    """Build a stub ``IdeationAgent.run`` that returns scripted output.
+
+    Tests call ``monkeypatch.setattr(orch.ideation_agent, "run",
+    ideation_returning(spec, code))`` to bypass the LLM and pin the spec
+    + code the orchestrator's design phase sees.
+    """
+
+    def _run(**_kwargs) -> Tuple[Dict[str, Any], str, str]:
+        return spec_dict, code, rationale
+
+    return _run
+
+
+def noop_refine(code: str) -> Callable[..., Tuple[Dict[str, Any], str]]:
+    """Build a stub ``RefinementAgent.run`` that returns the same code unchanged.
+
+    Useful when a test forces the refinement loop to exhaust on the same
+    failure mode — refinement must produce something or the orchestrator
+    would early-exit, but the something must be the unchanged input so the
+    loop re-fails the gate it's testing.
+    """
+
+    def _run(**_kwargs) -> Tuple[Dict[str, Any], str]:
+        return {"changes_made": "no-op"}, code
+
+    return _run
+
+
+def empty_market_data(
+    *, requested: Optional[List[str]] = None, fetched: Optional[List[str]] = None
+) -> Callable[..., Any]:
+    """Build a stub ``_fetch_market_data`` that returns a "fetched but empty" envelope.
+
+    Pre: ``requested`` defaults to ``["AAPL"]``; ``fetched`` defaults to ``requested``.
+    Post: returns a callable suitable for
+    ``monkeypatch.setattr(StrategyLabOrchestrator, "_fetch_market_data", ...)``
+    that yields a ``_MarketDataFetch`` whose ``data`` maps each requested
+    symbol to an empty bar list. This shape matters: the orchestrator
+    checks ``if not market_data: break`` (no-market-data short-circuit),
+    so the dict must be non-empty even when there are no bars — otherwise
+    the test exercises the no-data path instead of the execution-failure
+    path it usually intends to.
+    """
+    requested_symbols = list(requested or ["AAPL"])
+    fetched_symbols = list(fetched if fetched is not None else requested_symbols)
+
+    def _fetch(*_a, **_kw):
+        from investment_team.strategy_lab.orchestrator import _MarketDataFetch
+
+        return _MarketDataFetch(
+            data={s: [] for s in requested_symbols},
+            requested_symbols=requested_symbols,
+            fetched_symbols=fetched_symbols,
+        )
+
+    return _fetch
+
+
+def failing_sandbox(
+    *, error_type: str = "runtime_error", stderr: str = "forced failure for test"
+) -> Callable[..., Any]:
+    """Build a stub ``run_strategy_code`` that always reports execution failure.
+
+    Use via
+    ``monkeypatch.setattr(orchestrator_module, "run_strategy_code", failing_sandbox())``
+    when the test wants the synthesis loop to exhaust on the execute path.
+    """
+    from investment_team.trading_service.modes.sandbox_compat import StrategyRunResult
+
+    def _run(*_a, **_kw) -> StrategyRunResult:
+        return StrategyRunResult(
+            success=False,
+            trades=[],
+            stderr=stderr,
+            error_type=error_type,
+        )
+
+    return _run

--- a/backend/agents/investment_team/tests/test_convergence_tracker.py
+++ b/backend/agents/investment_team/tests/test_convergence_tracker.py
@@ -50,6 +50,7 @@ def _passing_gate() -> QualityGateResult:
         gate_name="dummy",
         passed=True,
         severity="info",
+        phase="design",
         details="",
     )
 

--- a/backend/agents/investment_team/tests/test_coverage_probe_orchestrator_stage.py
+++ b/backend/agents/investment_team/tests/test_coverage_probe_orchestrator_stage.py
@@ -83,7 +83,14 @@ def test_maybe_attach_coverage_report_runs_stage_when_gate_on(
         captured.append(kwargs)
         return make_report(CoverageCategory.INDICATOR_FILTER_TOO_RESTRICTIVE)
 
-    monkeypatch.setattr(orch_mod, "run_coverage_stage", _spy_run_coverage_stage)
+    # ``_maybe_attach_coverage_report`` was hoisted into
+    # ``_orchestrator_helpers`` so the helpers module — not the orchestrator
+    # module — is the actual lookup site for ``run_coverage_stage``. The
+    # orchestrator still re-exports the helper for backwards compatibility,
+    # but the monkeypatch must hit the module where the lookup happens.
+    from investment_team.strategy_lab import _orchestrator_helpers as helpers_mod
+
+    monkeypatch.setattr(helpers_mod, "run_coverage_stage", _spy_run_coverage_stage)
 
     metrics = _zeroed_metrics()
     spec = make_spec("Y = 2\n")

--- a/backend/agents/investment_team/tests/test_coverage_probe_orchestrator_stage.py
+++ b/backend/agents/investment_team/tests/test_coverage_probe_orchestrator_stage.py
@@ -111,13 +111,11 @@ def test_maybe_attach_coverage_report_runs_stage_when_gate_on(
 def test_orchestrator_call_sites_use_consistent_spec_and_exec_result() -> None:
     """Every ``_maybe_attach_coverage_report`` call site must pair an
     ``exec_result`` with the spec whose ``strategy_code`` matches the
-    code that produced it. The alignment-site bug (PR #475 review)
-    passed the loop-level ``spec`` alongside ``align_exec`` when
-    ``proposed_spec`` is the source of truth. Lock the AST shape so a
-    future refactor that re-introduces the drift fails loudly here.
+    code that produced it. Lock the AST shape across both the orchestrator
+    and the zero-trade repair module so a future refactor that
+    re-introduces the spec/exec drift fails loudly here.
     """
-    source = inspect.getsource(orch_mod)
-    tree = ast.parse(source)
+    from investment_team.strategy_lab import zero_trade_repair as zt_repair_mod
 
     expected_spec_for_exec = {
         "exec_result": "spec",
@@ -126,24 +124,28 @@ def test_orchestrator_call_sites_use_consistent_spec_and_exec_result() -> None:
     }
 
     sites: list[dict[str, Any]] = []
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        func = node.func
-        name = getattr(func, "id", None) or getattr(func, "attr", None)
-        if name != "_maybe_attach_coverage_report":
-            continue
-        kwargs = {kw.arg: kw.value for kw in node.keywords if kw.arg}
-        spec_arg = kwargs.get("spec")
-        exec_arg = kwargs.get("exec_result")
-        lineno = node.lineno
-        assert isinstance(spec_arg, ast.Name), (
-            f"orchestrator.py:{lineno} — spec kwarg must be a bare Name reference"
-        )
-        assert isinstance(exec_arg, ast.Name), (
-            f"orchestrator.py:{lineno} — exec_result kwarg must be a bare Name reference"
-        )
-        sites.append({"spec": spec_arg.id, "exec_result": exec_arg.id, "lineno": lineno})
+    for module in (orch_mod, zt_repair_mod):
+        source = inspect.getsource(module)
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            func = node.func
+            name = getattr(func, "id", None) or getattr(func, "attr", None)
+            if name != "_maybe_attach_coverage_report":
+                continue
+            kwargs = {kw.arg: kw.value for kw in node.keywords if kw.arg}
+            spec_arg = kwargs.get("spec")
+            exec_arg = kwargs.get("exec_result")
+            lineno = node.lineno
+            modname = module.__name__.rsplit(".", 1)[-1]
+            assert isinstance(spec_arg, ast.Name), (
+                f"{modname}.py:{lineno} — spec kwarg must be a bare Name reference"
+            )
+            assert isinstance(exec_arg, ast.Name), (
+                f"{modname}.py:{lineno} — exec_result kwarg must be a bare Name reference"
+            )
+            sites.append({"spec": spec_arg.id, "exec_result": exec_arg.id, "lineno": lineno})
 
     assert len(sites) == 3, f"expected 3 _maybe_attach_coverage_report sites, found {sites}"
     for site in sites:
@@ -166,13 +168,21 @@ def test_orchestrator_call_sites_use_consistent_spec_and_exec_result() -> None:
 
 
 def _collect_attribute_call_sites(
-    source: str, *, owner_attr: str, method_attr: str
+    source: str,
+    *,
+    owner_attr: str,
+    method_attr: str,
+    root_names: frozenset = frozenset({"self"}),
 ) -> list[dict[str, Any]]:
-    """Walk ``source`` and return every ``self.{owner_attr}.{method_attr}(...)``
+    """Walk ``source`` and return every ``<root>.{owner_attr}.{method_attr}(...)``
     call as ``{lineno, kwargs}``. Used by the source-level invariants
     below; the AST shape keeps tests independent of import paths and
-    avoids false positives from unrelated ``.check``/``.run`` methods
-    (or from an alias on something other than ``self``).
+    avoids false positives from unrelated ``.check``/``.run`` methods.
+
+    ``root_names`` controls which leftmost tokens count as the receiver:
+    in :mod:`orchestrator` it's ``{"self"}``; in :mod:`zero_trade_repair`
+    the gate/agent collaborators live on ``self._orch`` (locally bound to
+    ``orch``) so ``{"orch", "self"}`` covers both shapes.
     """
     tree = ast.parse(source)
     sites: list[dict[str, Any]] = []
@@ -185,9 +195,8 @@ def _collect_attribute_call_sites(
         owner = func.value
         if not isinstance(owner, ast.Attribute) or owner.attr != owner_attr:
             continue
-        # Pin the leftmost token to ``self`` so an unrelated alias
-        # (e.g. ``other.<owner_attr>.<method_attr>``) doesn't match.
-        if not isinstance(owner.value, ast.Name) or owner.value.id != "self":
+        # Pin the leftmost token so an unrelated alias doesn't match.
+        if not isinstance(owner.value, ast.Name) or owner.value.id not in root_names:
             continue
         sites.append({"lineno": node.lineno, "kwargs": {kw.arg for kw in node.keywords}})
     return sites
@@ -228,22 +237,31 @@ def test_collect_attribute_call_sites_helper_isolates_matching_calls() -> None:
 
 
 def test_every_anomaly_detector_check_call_forwards_coverage_report() -> None:
-    """Issue #452 — every ``self.anomaly_detector.check(...)`` call in the
-    orchestrator must forward ``coverage_report=`` so the persisted gate
-    result carries the static probe's verdict (when one is attached).
+    """Every ``anomaly_detector.check(...)`` call across the orchestrator
+    and the zero-trade repair module must forward ``coverage_report=`` so
+    the persisted gate result carries the static probe's verdict.
 
     Locking this at source level catches the alignment-loop and walk-
     forward-fallback paths that are not directly exercised by the
-    existing isolated drivers. The site count is pinned (``== 4``) for
-    parity with the sibling ``_maybe_attach_coverage_report`` invariant
-    above — a new call site is a deliberate change and should bump the
-    expected total here intentionally.
+    existing isolated drivers. Four call sites are expected: main loop +
+    alignment loop + walk-forward fallback live on the orchestrator
+    (``self.anomaly_detector.check``); the zero-trade-repair recheck
+    lives in :mod:`zero_trade_repair` (``orch.anomaly_detector.check``).
     """
-    sites = _collect_attribute_call_sites(
+    from investment_team.strategy_lab import zero_trade_repair as zt_repair_mod
+
+    orch_sites = _collect_attribute_call_sites(
         inspect.getsource(orch_mod),
         owner_attr="anomaly_detector",
         method_attr="check",
     )
+    zt_sites = _collect_attribute_call_sites(
+        inspect.getsource(zt_repair_mod),
+        owner_attr="anomaly_detector",
+        method_attr="check",
+        root_names=frozenset({"orch"}),
+    )
+    sites = orch_sites + zt_sites
     assert len(sites) == 4, (
         "expected exactly 4 anomaly_detector.check sites (main loop, alignment "
         "loop, walk-forward-fallback, zero-trade-repair recheck); if a new "
@@ -257,19 +275,23 @@ def test_every_anomaly_detector_check_call_forwards_coverage_report() -> None:
 
 
 def test_repair_agent_run_call_forwards_coverage_report() -> None:
-    """Issue #452 — ``self.zero_trade_repair_agent.run(...)`` in the
-    orchestrator must forward ``coverage_report=`` so the agent's prompt
-    sees the static probe's verdict alongside the executor diagnostics.
+    """The ``zero_trade_repair_agent.run(...)`` call in the repair module
+    must forward ``coverage_report=`` so the agent's prompt sees the
+    static probe's verdict alongside the executor diagnostics.
 
     Functional coverage of the forwarding lives in
     ``test_strategy_lab_zero_trade_repair.py``; this AST check locks the
     contract at the source level too so a refactor that drops the kwarg
-    fails loudly.
+    fails loudly. The call lives in :mod:`zero_trade_repair`
+    (``orch.zero_trade_repair_agent.run``).
     """
+    from investment_team.strategy_lab import zero_trade_repair as zt_repair_mod
+
     sites = _collect_attribute_call_sites(
-        inspect.getsource(orch_mod),
+        inspect.getsource(zt_repair_mod),
         owner_attr="zero_trade_repair_agent",
         method_attr="run",
+        root_names=frozenset({"orch"}),
     )
     assert len(sites) == 1, (
         "expected exactly 1 zero_trade_repair_agent.run site; if a new call "

--- a/backend/agents/investment_team/tests/test_coverage_probe_perf_guard.py
+++ b/backend/agents/investment_team/tests/test_coverage_probe_perf_guard.py
@@ -18,7 +18,7 @@ from typing import Any
 import pytest
 
 from investment_team.models import BacktestResult
-from investment_team.strategy_lab import orchestrator as orch_mod
+from investment_team.strategy_lab import _orchestrator_helpers as helpers_mod
 from investment_team.strategy_lab.orchestrator import _maybe_attach_coverage_report
 
 from ._coverage_probe_test_helpers import (
@@ -81,7 +81,7 @@ def test_success_path_does_not_invoke_probe_stage(
     def _must_not_run(**_kwargs: Any) -> None:
         raise AssertionError("run_coverage_stage must not run on a successful backtest")
 
-    monkeypatch.setattr(orch_mod, "run_coverage_stage", _must_not_run)
+    monkeypatch.setattr(helpers_mod, "run_coverage_stage", _must_not_run)
 
     metrics = _fresh_metrics()
     _maybe_attach_coverage_report(metrics=metrics, **_success_kwargs())
@@ -109,7 +109,7 @@ def test_success_path_runtime_within_ten_percent_of_unprobed(
     def _must_not_run(**_kwargs: Any) -> None:
         raise AssertionError("run_coverage_stage must not run on a successful backtest")
 
-    monkeypatch.setattr(orch_mod, "run_coverage_stage", _must_not_run)
+    monkeypatch.setattr(helpers_mod, "run_coverage_stage", _must_not_run)
 
     kwargs = _success_kwargs()
     metrics = _fresh_metrics()

--- a/backend/agents/investment_team/tests/test_spec_readiness.py
+++ b/backend/agents/investment_team/tests/test_spec_readiness.py
@@ -1,7 +1,7 @@
-"""Unit tests for ``SpecReadinessGate`` (issue #540).
+"""Unit tests for ``SpecReadinessGate``.
 
-Eight deterministic implementability rules + the two end-to-end scenarios
-named in the issue's acceptance criteria. Every rule has at least one
+Eight deterministic implementability rules plus the two end-to-end scenarios
+that match the gate's acceptance contract. Every rule has at least one
 dedicated test that exercises its failure path.
 """
 
@@ -265,7 +265,7 @@ def test_rule8_max_position_pct_above_25_is_critical() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Issue #540 acceptance criteria: end-to-end vague + well-formed cases
+# Acceptance contract: end-to-end vague + well-formed cases
 # ---------------------------------------------------------------------------
 
 

--- a/backend/agents/investment_team/tests/test_spec_readiness.py
+++ b/backend/agents/investment_team/tests/test_spec_readiness.py
@@ -1,0 +1,353 @@
+"""Unit tests for ``SpecReadinessGate`` (issue #540).
+
+Eight deterministic implementability rules + the two end-to-end scenarios
+named in the issue's acceptance criteria. Every rule has at least one
+dedicated test that exercises its failure path.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from investment_team.models import BacktestConfig, StrategySpec
+from investment_team.strategy_lab.quality_gates.spec_readiness import (
+    GATE,
+    SpecReadinessGate,
+)
+from investment_team.strategy_lab.spec_dsl import (
+    EntryRule,
+    FixedFractionSizing,
+    FixedNotionalSizing,
+    IndicatorRef,
+    Predicate,
+    SignalExitRule,
+    StopLossRule,
+    TakeProfitRule,
+)
+
+
+def _spec(
+    *,
+    hypothesis: str = "RSI(14) below 30 on AAPL signals long entry.",
+    entry: List | None = None,
+    exit_: List | None = None,
+    asset_class: str = "stocks",
+    timeframe: str = "1d",
+    target_symbols: List[str] | None = None,
+    sizing=None,
+    risk_limits: dict | None = None,
+) -> StrategySpec:
+    if entry is None:
+        entry = [
+            EntryRule(
+                side="long",
+                when=Predicate(
+                    lhs=IndicatorRef(name="rsi", params={"period": 14}),
+                    op="<",
+                    rhs=30.0,
+                ),
+            )
+        ]
+    if exit_ is None:
+        exit_ = [
+            SignalExitRule(
+                when=Predicate(
+                    lhs=IndicatorRef(name="rsi", params={"period": 14}),
+                    op=">",
+                    rhs=70.0,
+                )
+            )
+        ]
+    if target_symbols is None:
+        target_symbols = ["AAPL"]
+    kwargs: dict = dict(
+        strategy_id="strat-readiness-test",
+        authored_by="test",
+        asset_class=asset_class,
+        hypothesis=hypothesis,
+        signal_definition="sig",
+        timeframe=timeframe,
+        entry_rules=entry,
+        exit_rules=exit_,
+        target_symbols=target_symbols,
+        risk_limits=risk_limits or {"max_position_pct": 5, "max_drawdown_pct": 10},
+        speculative=False,
+        strategy_code="from contract import Strategy\nclass S(Strategy):\n    def on_bar(self, ctx, bar):\n        pass\n",
+    )
+    if sizing is not None:
+        kwargs["sizing"] = sizing
+    return StrategySpec(**kwargs)
+
+
+def _config() -> BacktestConfig:
+    return BacktestConfig(start_date="2024-01-01", end_date="2024-06-01")
+
+
+def _critical(results) -> list[str]:
+    return [r.details for r in results if r.severity == "critical" and not r.passed]
+
+
+# ---------------------------------------------------------------------------
+# Rule 1: Universe set
+# ---------------------------------------------------------------------------
+
+
+def test_rule1_target_symbols_missing_when_hypothesis_names_ticker() -> None:
+    spec = _spec(
+        hypothesis="QQQ tends to revert to its 50-day SMA after a 2-sigma move.",
+        target_symbols=[],
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    critical = _critical(results)
+    assert any("QQQ" in c and "target_symbols" in c for c in critical), critical
+
+
+def test_rule1_hypothesis_symbol_not_in_target_symbols() -> None:
+    spec = _spec(
+        hypothesis="QQQ tends to revert to its 50-day SMA after a 2-sigma move.",
+        target_symbols=["AAPL"],
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    critical = _critical(results)
+    assert any("QQQ" in c for c in critical), critical
+
+
+def test_rule1_passes_when_no_symbols_in_hypothesis_and_no_targets() -> None:
+    spec = _spec(
+        hypothesis="RSI(14) below 30 signals long entry.",
+        target_symbols=[],
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    rule1_failures = [
+        c for c in _critical(results) if "target_symbols" in c or "Hypothesis names symbol" in c
+    ]
+    assert not rule1_failures, rule1_failures
+
+
+# ---------------------------------------------------------------------------
+# Rule 2: Entry rules non-trivial
+# ---------------------------------------------------------------------------
+
+
+def test_rule2_no_entry_rules_is_critical() -> None:
+    spec = _spec(entry=[])
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    assert any("No entry rules" in c for c in _critical(results))
+
+
+# ---------------------------------------------------------------------------
+# Rule 3: Indicator validity
+# ---------------------------------------------------------------------------
+
+
+def test_rule3_sma_without_period_param_is_critical() -> None:
+    # Bypass Pydantic validation by constructing a spec then mutating an
+    # IndicatorRef's params dict — the gate must catch what slipped past.
+    spec = _spec()
+    ref = spec.entry_rules[0].when.lhs
+    assert isinstance(ref, IndicatorRef)
+    # Swap the well-formed rsi(period=14) for sma with no params dict entry
+    spec.entry_rules[0].when.lhs = IndicatorRef.model_construct(
+        name="sma", params={}, source="close"
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    assert any("sma" in c and "period" in c for c in _critical(results))
+
+
+# ---------------------------------------------------------------------------
+# Rule 4: Exit completeness
+# ---------------------------------------------------------------------------
+
+
+def test_rule4_no_exit_rules_is_critical() -> None:
+    spec = _spec(exit_=[])
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    assert any("No exit rules" in c for c in _critical(results))
+
+
+# ---------------------------------------------------------------------------
+# Rule 5: Sizing realisable
+# ---------------------------------------------------------------------------
+
+
+def test_rule5_sizing_under_one_share_is_critical() -> None:
+    spec = _spec(
+        sizing=FixedNotionalSizing(notional_usd=10.0),
+        target_symbols=["AAPL"],
+    )
+    # Default provider returns $100/share; $10 notional / $100 = 0.1 share.
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    assert any("qty=" in c and "AAPL" in c for c in _critical(results))
+
+
+def test_rule5_passes_with_realistic_sizing() -> None:
+    spec = _spec(
+        sizing=FixedFractionSizing(fraction=0.02),
+        target_symbols=["AAPL"],
+    )
+    # 0.02 * $100k = $2000 / $100 = 20 shares.
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    sizing_failures = [c for c in _critical(results) if "qty=" in c]
+    assert not sizing_failures, sizing_failures
+
+
+# ---------------------------------------------------------------------------
+# Rule 6: Hypothesis–rule consistency
+# ---------------------------------------------------------------------------
+
+
+def test_rule6_hypothesis_mentions_indicator_not_in_rules_is_critical() -> None:
+    spec = _spec(
+        hypothesis="MACD bullish crossovers on AAPL signal long entries.",
+        # entry rule uses RSI, not MACD
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    assert any("macd" in c.lower() for c in _critical(results))
+
+
+def test_rule6_passes_when_hypothesis_and_rules_match() -> None:
+    spec = _spec(
+        hypothesis="RSI(14) below 30 on AAPL signals oversold conditions.",
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    rule6_failures = [c for c in _critical(results) if "Hypothesis names indicator" in c]
+    assert not rule6_failures, rule6_failures
+
+
+# ---------------------------------------------------------------------------
+# Rule 7: Timeframe data availability
+# ---------------------------------------------------------------------------
+
+
+def test_rule7_intraday_timeframe_on_commodities_is_critical() -> None:
+    spec = _spec(
+        asset_class="commodities",
+        timeframe="5m",
+        target_symbols=["GLD"],
+        hypothesis="GLD intraday momentum.",
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    assert any("intraday" in c and "commodities" in c for c in _critical(results))
+
+
+def test_rule7_daily_timeframe_on_commodities_passes() -> None:
+    spec = _spec(
+        asset_class="commodities",
+        timeframe="1d",
+        target_symbols=["GLD"],
+        hypothesis="GLD daily mean reversion.",
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    tf_failures = [c for c in _critical(results) if "intraday" in c]
+    assert not tf_failures, tf_failures
+
+
+# ---------------------------------------------------------------------------
+# Rule 8: Risk-limit coherence
+# ---------------------------------------------------------------------------
+
+
+def test_rule8_stop_loss_geq_take_profit_is_critical() -> None:
+    spec = _spec(
+        exit_=[
+            StopLossRule(pct=0.10),
+            TakeProfitRule(pct=0.05),
+        ],
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    assert any("stop_loss.pct" in c for c in _critical(results))
+
+
+def test_rule8_max_position_pct_above_25_is_critical() -> None:
+    spec = _spec(risk_limits={"max_position_pct": 30, "max_drawdown_pct": 10})
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    assert any("max_position_pct=30" in c for c in _critical(results))
+
+
+# ---------------------------------------------------------------------------
+# Issue #540 acceptance criteria: end-to-end vague + well-formed cases
+# ---------------------------------------------------------------------------
+
+
+def test_vague_spec_returns_multiple_criticals() -> None:
+    """A spec that is structurally valid but vague trips multiple rules."""
+    spec = _spec(
+        hypothesis="enter on bullish momentum on QQQ — MACD watch",
+        entry=[],  # Rule 2: no entries
+        exit_=[],  # Rule 4: no exits
+        target_symbols=[],  # Rule 1: QQQ named, no targets
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    critical = _critical(results)
+    # Expect at least three independent criticals across the three rules.
+    assert len(critical) >= 3, critical
+    assert any("entry" in c.lower() for c in critical)
+    assert any("exit" in c.lower() for c in critical)
+    assert any("QQQ" in c for c in critical)
+
+
+def test_well_formed_spec_passes() -> None:
+    """RSI(14) cross_above 30, SMA(50) > SMA(200) — clean entry/exit."""
+    spec = _spec(
+        hypothesis="On AAPL, RSI(14) crossing above 30 with SMA(50) > SMA(200) marks long entry.",
+        entry=[
+            EntryRule(
+                side="long",
+                when=Predicate(
+                    lhs=IndicatorRef(name="rsi", params={"period": 14}),
+                    op="cross_above",
+                    rhs=30.0,
+                ),
+            ),
+            EntryRule(
+                side="long",
+                when=Predicate(
+                    lhs=IndicatorRef(name="sma", params={"period": 50}),
+                    op=">",
+                    rhs=IndicatorRef(name="sma", params={"period": 200}),
+                ),
+            ),
+        ],
+        exit_=[
+            SignalExitRule(
+                when=Predicate(
+                    lhs=IndicatorRef(name="rsi", params={"period": 14}),
+                    op=">",
+                    rhs=70.0,
+                )
+            ),
+            StopLossRule(pct=0.03),
+            TakeProfitRule(pct=0.10),
+        ],
+        sizing=FixedFractionSizing(fraction=0.02),
+        target_symbols=["AAPL"],
+        risk_limits={"max_position_pct": 5, "max_drawdown_pct": 10},
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    assert not _critical(results), _critical(results)
+    # Single passing summary result
+    assert any(r.gate_name == GATE and r.passed and r.severity == "info" for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Phase tagging
+# ---------------------------------------------------------------------------
+
+
+def test_phase_tag_propagates_to_results() -> None:
+    spec = _spec()
+    design = SpecReadinessGate().validate(spec, phase="design", backtest_config=_config())
+    synth = SpecReadinessGate().validate(spec, phase="synthesis", backtest_config=_config())
+    assert all(r.phase == "design" for r in design)
+    assert all(r.phase == "synthesis" for r in synth)
+
+
+def test_custom_market_sample_provider_is_used() -> None:
+    spec = _spec(
+        sizing=FixedNotionalSizing(notional_usd=500.0),
+        target_symbols=["AAPL"],
+    )
+    # Pretend AAPL is $1000 — $500 notional yields 0.5 share, should fail.
+    gate = SpecReadinessGate(market_sample_provider=lambda sym: 1000.0)
+    results = gate.validate(spec, backtest_config=_config())
+    assert any("qty=" in c for c in _critical(results))

--- a/backend/agents/investment_team/tests/test_spec_readiness.py
+++ b/backend/agents/investment_team/tests/test_spec_readiness.py
@@ -393,7 +393,8 @@ def test_rule7_daily_timeframe_on_commodities_passes() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_rule8_stop_loss_geq_take_profit_is_critical() -> None:
+def test_rule8_stop_loss_geq_take_profit_is_warning_not_critical() -> None:
+    """A wider stop than profit target is a valid risk/reward choice — warn, don't block."""
     spec = _spec(
         exit_=[
             StopLossRule(pct=0.10),
@@ -401,7 +402,11 @@ def test_rule8_stop_loss_geq_take_profit_is_critical() -> None:
         ],
     )
     results = SpecReadinessGate().validate(spec, backtest_config=_config())
-    assert any("stop_loss.pct" in c for c in _critical(results))
+    # No criticals about the stop/profit ratio.
+    assert not any("stop_loss.pct" in c for c in _critical(results))
+    # Warning surfaced so the refinement prompt notices the unusual asymmetry.
+    warnings = [r.details for r in results if r.severity == "warning" and not r.passed]
+    assert any("stop_loss.pct" in w for w in warnings), warnings
 
 
 def test_rule8_max_position_pct_above_25_is_critical() -> None:
@@ -520,8 +525,10 @@ def test_orchestrator_wires_readiness_price_provider() -> None:
     assert any("qty=" in c and "NVDA" in c for c in _critical(results))
 
 
-def test_readiness_price_provider_falls_back_on_failure() -> None:
-    """Provider returns the static fallback when the data service raises."""
+def test_readiness_price_provider_fails_closed_on_data_failure() -> None:
+    """Provider returns ``NaN`` when the data service raises, so Rule 5 fails closed."""
+    import math
+
     from investment_team.strategy_lab.orchestrator import StrategyLabOrchestrator
 
     orch = StrategyLabOrchestrator()
@@ -531,7 +538,19 @@ def test_readiness_price_provider_falls_back_on_failure() -> None:
 
     orch.market_data_service.fetch_ohlcv = boom
     price = orch._readiness_price_provider("AAPL", "stocks")
-    assert price == 100.0
+    assert math.isnan(price)
+
+
+def test_readiness_price_provider_fails_closed_on_empty_bars() -> None:
+    """Provider returns ``NaN`` when the data service returns no bars."""
+    import math
+
+    from investment_team.strategy_lab.orchestrator import StrategyLabOrchestrator
+
+    orch = StrategyLabOrchestrator()
+    orch.market_data_service.fetch_ohlcv = lambda *_a, **_kw: []
+    price = orch._readiness_price_provider("AAPL", "stocks")
+    assert math.isnan(price)
 
 
 def test_custom_market_sample_provider_is_used() -> None:

--- a/backend/agents/investment_team/tests/test_spec_readiness.py
+++ b/backend/agents/investment_team/tests/test_spec_readiness.py
@@ -304,6 +304,57 @@ def test_rule5_volatility_target_emits_warning() -> None:
     assert not sizing_criticals, sizing_criticals
 
 
+def test_check_sizing_realisable_directly_catches_unknown_asset_class_value_error() -> None:
+    """Direct probe of the rule's ``ValueError`` catch path.
+
+    The end-to-end ``test_rule5_unknown_asset_class_is_critical`` exercises
+    this transitively via the rule-table iteration in ``validate``; this
+    unit test pins the catch-and-convert behaviour at the rule boundary so
+    a future refactor that moves the asset-class resolution out of Rule 5
+    fails loudly here rather than silently dropping the critical.
+    """
+    from investment_team.strategy_lab.quality_gates.spec_readiness import (
+        SpecReadinessCtx,
+        SpecReadinessGate,
+    )
+
+    spec = _spec(
+        asset_class="bonds",
+        target_symbols=[],
+        timeframe="1d",
+        hypothesis="generic mean reversion",
+    )
+    gate = SpecReadinessGate()
+    ctx = SpecReadinessCtx(spec=spec, config=_config())
+    with gate._using_phase("design"):
+        results = list(gate._check_sizing_realisable(ctx))
+    assert len(results) == 1
+    assert results[0].severity == "critical"
+    assert "unknown asset_class" in results[0].details
+
+
+def test_check_sizing_realisable_directly_emits_volatility_target_warning() -> None:
+    """Direct probe of the rule's volatility-target abstention path."""
+    from investment_team.strategy_lab.quality_gates.spec_readiness import (
+        SpecReadinessCtx,
+        SpecReadinessGate,
+    )
+    from investment_team.strategy_lab.spec_dsl import VolatilityTargetSizing
+
+    spec = _spec(
+        sizing=VolatilityTargetSizing(target_annual_vol=0.001),
+        target_symbols=["AAPL"],
+    )
+    gate = SpecReadinessGate()
+    ctx = SpecReadinessCtx(spec=spec, config=_config())
+    with gate._using_phase("design"):
+        results = list(gate._check_sizing_realisable(ctx))
+    assert len(results) == 1
+    assert results[0].severity == "warning"
+    assert "volatility_target" in results[0].details
+    assert "0.001" in results[0].details
+
+
 def test_rule5_accepts_fractional_qty_on_crypto() -> None:
     """Crypto specs accept fractional positions — 0.1 BTC is implementable."""
     spec = _spec(

--- a/backend/agents/investment_team/tests/test_spec_readiness.py
+++ b/backend/agents/investment_team/tests/test_spec_readiness.py
@@ -252,7 +252,7 @@ def test_rule5_nan_price_fails_closed() -> None:
         target_symbols=["AAPL"],
         asset_class="stocks",
     )
-    gate = SpecReadinessGate(market_sample_provider=lambda sym: float("nan"))
+    gate = SpecReadinessGate(market_sample_provider=lambda sym, asset_class: float("nan"))
     results = gate.validate(spec, backtest_config=_config())
     assert any("no usable price sample" in c for c in _critical(results))
 
@@ -458,12 +458,58 @@ def test_phase_tag_propagates_to_results() -> None:
     assert all(r.phase == "synthesis" for r in synth)
 
 
+def test_orchestrator_wires_readiness_price_provider() -> None:
+    """``StrategyLabOrchestrator`` constructs the gate with a real-price provider.
+
+    The provider invokes ``MarketDataService.fetch_ohlcv``; we verify the
+    wiring by monkeypatching the service to return a sentinel close and
+    confirming Rule 5 uses that price.
+    """
+    from investment_team.market_data_service import OHLCVBar
+    from investment_team.strategy_lab.orchestrator import StrategyLabOrchestrator
+
+    orch = StrategyLabOrchestrator()
+
+    sentinel_bar = OHLCVBar(
+        date="2024-06-01",
+        open=950.0,
+        high=960.0,
+        low=940.0,
+        close=950.0,
+        volume=1_000_000,
+    )
+    orch.market_data_service.fetch_ohlcv = lambda symbol, asset_class, days=5: [sentinel_bar]
+
+    spec = _spec(
+        sizing=FixedNotionalSizing(notional_usd=500.0),
+        target_symbols=["NVDA"],
+        asset_class="stocks",
+    )
+    # $500 notional / $950 = 0.526 share — fails the whole-lot check.
+    results = orch.spec_readiness_gate.validate(spec, backtest_config=_config())
+    assert any("qty=" in c and "NVDA" in c for c in _critical(results))
+
+
+def test_readiness_price_provider_falls_back_on_failure() -> None:
+    """Provider returns the static fallback when the data service raises."""
+    from investment_team.strategy_lab.orchestrator import StrategyLabOrchestrator
+
+    orch = StrategyLabOrchestrator()
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("network down")
+
+    orch.market_data_service.fetch_ohlcv = boom
+    price = orch._readiness_price_provider("AAPL", "stocks")
+    assert price == 100.0
+
+
 def test_custom_market_sample_provider_is_used() -> None:
     spec = _spec(
         sizing=FixedNotionalSizing(notional_usd=500.0),
         target_symbols=["AAPL"],
     )
     # Pretend AAPL is $1000 — $500 notional yields 0.5 share, should fail.
-    gate = SpecReadinessGate(market_sample_provider=lambda sym: 1000.0)
+    gate = SpecReadinessGate(market_sample_provider=lambda sym, asset_class: 1000.0)
     results = gate.validate(spec, backtest_config=_config())
     assert any("qty=" in c for c in _critical(results))

--- a/backend/agents/investment_team/tests/test_spec_readiness.py
+++ b/backend/agents/investment_team/tests/test_spec_readiness.py
@@ -232,6 +232,40 @@ def test_rule5_sizing_under_one_share_is_critical() -> None:
     assert any("qty=" in c and "AAPL" in c for c in _critical(results))
 
 
+def test_rule5_exactly_one_whole_lot_passes_for_stocks() -> None:
+    """A notional spec yielding qty=1.0 on stocks is implementable."""
+    spec = _spec(
+        sizing=FixedNotionalSizing(notional_usd=100.0),
+        target_symbols=["AAPL"],
+        asset_class="stocks",
+    )
+    # Default provider returns $100/share; 100 / 100 = 1.0 exactly.
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    sizing_failures = [c for c in _critical(results) if "qty=" in c]
+    assert not sizing_failures, sizing_failures
+
+
+def test_rule5_nan_price_fails_closed() -> None:
+    """A provider returning NaN must trip Rule 5 — fail closed."""
+    spec = _spec(
+        sizing=FixedNotionalSizing(notional_usd=1000.0),
+        target_symbols=["AAPL"],
+        asset_class="stocks",
+    )
+    gate = SpecReadinessGate(market_sample_provider=lambda sym: float("nan"))
+    results = gate.validate(spec, backtest_config=_config())
+    assert any("no usable price sample" in c for c in _critical(results))
+
+
+def test_default_universe_for_futures_and_forex() -> None:
+    """`_default_universe_for` must return matching asset-class symbols."""
+    from investment_team.strategy_lab.quality_gates.spec_readiness import _default_universe_for
+    from investment_team.symbols import FOREX_SYMBOLS, FUTURES_SYMBOLS
+
+    assert _default_universe_for("futures") == list(FUTURES_SYMBOLS)
+    assert _default_universe_for("forex") == list(FOREX_SYMBOLS)
+
+
 def test_rule5_accepts_fractional_qty_on_crypto() -> None:
     """Crypto specs accept fractional positions — 0.1 BTC is implementable."""
     spec = _spec(

--- a/backend/agents/investment_team/tests/test_spec_readiness.py
+++ b/backend/agents/investment_team/tests/test_spec_readiness.py
@@ -266,6 +266,44 @@ def test_default_universe_for_futures_and_forex() -> None:
     assert _default_universe_for("forex") == list(FOREX_SYMBOLS)
 
 
+def test_default_universe_for_raises_on_unknown_asset_class() -> None:
+    """Unknown asset classes must raise instead of silently returning ETF list."""
+    import pytest
+
+    from investment_team.strategy_lab.quality_gates.spec_readiness import _default_universe_for
+
+    with pytest.raises(ValueError, match="unknown asset_class 'bonds'"):
+        _default_universe_for("bonds")
+
+
+def test_rule5_unknown_asset_class_is_critical() -> None:
+    """A typo'd asset_class with empty target_symbols emits a Rule 5 critical."""
+    spec = _spec(
+        asset_class="bonds",
+        target_symbols=[],
+        timeframe="1d",
+        hypothesis="generic mean reversion",
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    assert any("unknown asset_class" in c for c in _critical(results))
+
+
+def test_rule5_volatility_target_emits_warning() -> None:
+    """Vol-target sizing cannot be evaluated statically — surface as warning."""
+    from investment_team.strategy_lab.spec_dsl import VolatilityTargetSizing
+
+    spec = _spec(
+        sizing=VolatilityTargetSizing(target_annual_vol=0.15),
+        target_symbols=["AAPL"],
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    warnings = [r.details for r in results if r.severity == "warning" and not r.passed]
+    assert any("volatility_target" in w and "0.15" in w for w in warnings), warnings
+    # No critical from Rule 5 (the rule abstained, not failed).
+    sizing_criticals = [c for c in _critical(results) if "Sizing" in c or "qty=" in c]
+    assert not sizing_criticals, sizing_criticals
+
+
 def test_rule5_accepts_fractional_qty_on_crypto() -> None:
     """Crypto specs accept fractional positions — 0.1 BTC is implementable."""
     spec = _spec(

--- a/backend/agents/investment_team/tests/test_spec_readiness.py
+++ b/backend/agents/investment_team/tests/test_spec_readiness.py
@@ -245,6 +245,24 @@ def test_rule5_exactly_one_whole_lot_passes_for_stocks() -> None:
     assert not sizing_failures, sizing_failures
 
 
+def test_rule5_fixed_notional_exceeds_initial_capital_is_critical() -> None:
+    """A fixed_notional spec whose notional exceeds initial_capital cannot
+    be filled — fill engine rejects with ``insufficient_capital`` the
+    moment ``portfolio.capital < notional``. The readiness gate must
+    catch this before code synthesis."""
+    spec = _spec(
+        sizing=FixedNotionalSizing(notional_usd=150_000.0),  # > default $100k
+        target_symbols=["AAPL"],
+        asset_class="stocks",
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    matches = [
+        c for c in _critical(results)
+        if "exceeds initial_capital" in c and "insufficient_capital" in c
+    ]
+    assert matches, _critical(results)
+
+
 def test_rule5_nan_price_fails_closed() -> None:
     """A provider returning NaN must trip Rule 5 — fail closed."""
     spec = _spec(

--- a/backend/agents/investment_team/tests/test_spec_readiness.py
+++ b/backend/agents/investment_team/tests/test_spec_readiness.py
@@ -136,6 +136,34 @@ def test_rule1_catches_forex_ticker_mismatch() -> None:
     assert any("EURUSD=X" in c for c in critical), critical
 
 
+def test_rule1_canonicalizes_bare_futures_against_provider_suffix() -> None:
+    """``ES`` in hypothesis matches ``ES=F`` in target_symbols — same symbol."""
+    spec = _spec(
+        hypothesis="Trade ES gaps on Monday mornings.",
+        target_symbols=["ES=F"],
+        asset_class="futures",
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    rule1_failures = [
+        c for c in _critical(results) if "target_symbols" in c or "Hypothesis names symbol" in c
+    ]
+    assert not rule1_failures, rule1_failures
+
+
+def test_rule1_canonicalizes_bare_forex_against_provider_suffix() -> None:
+    """``EURUSD`` in hypothesis matches ``EURUSD=X`` in target_symbols."""
+    spec = _spec(
+        hypothesis="EURUSD tends to revert intraday.",
+        target_symbols=["EURUSD=X"],
+        asset_class="forex",
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    rule1_failures = [
+        c for c in _critical(results) if "target_symbols" in c or "Hypothesis names symbol" in c
+    ]
+    assert not rule1_failures, rule1_failures
+
+
 def test_rule1_passes_when_no_symbols_in_hypothesis_and_no_targets() -> None:
     spec = _spec(
         hypothesis="RSI(14) below 30 signals long entry.",

--- a/backend/agents/investment_team/tests/test_spec_readiness.py
+++ b/backend/agents/investment_team/tests/test_spec_readiness.py
@@ -232,6 +232,36 @@ def test_rule5_sizing_under_one_share_is_critical() -> None:
     assert any("qty=" in c and "AAPL" in c for c in _critical(results))
 
 
+def test_rule5_accepts_fractional_qty_on_crypto() -> None:
+    """Crypto specs accept fractional positions — 0.1 BTC is implementable."""
+    spec = _spec(
+        asset_class="crypto",
+        target_symbols=["BTC"],
+        sizing=FixedNotionalSizing(notional_usd=10.0),
+        hypothesis="BTC mean-reversion on the 1d timeframe.",
+        # Replace the default RSI entry with a self-consistent one to avoid
+        # tripping Rule 6 (hypothesis mentions reversion but no rsi term).
+    )
+    # Default provider returns $100/BTC → 0.1 BTC. Crypto allows fractional, pass.
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    sizing_failures = [c for c in _critical(results) if "qty=" in c]
+    assert not sizing_failures, sizing_failures
+
+
+def test_rule5_accepts_fractional_qty_on_forex() -> None:
+    """Forex specs accept fractional positions — sub-lot sizing is valid."""
+    spec = _spec(
+        asset_class="forex",
+        target_symbols=["EURUSD=X"],
+        sizing=FixedNotionalSizing(notional_usd=50.0),
+        hypothesis="EURUSD=X mean-reverts intraday on RSI(14).",
+        timeframe="1h",
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    sizing_failures = [c for c in _critical(results) if "qty=" in c]
+    assert not sizing_failures, sizing_failures
+
+
 def test_rule5_passes_with_realistic_sizing() -> None:
     spec = _spec(
         sizing=FixedFractionSizing(fraction=0.02),

--- a/backend/agents/investment_team/tests/test_spec_readiness.py
+++ b/backend/agents/investment_team/tests/test_spec_readiness.py
@@ -112,6 +112,30 @@ def test_rule1_hypothesis_symbol_not_in_target_symbols() -> None:
     assert any("QQQ" in c for c in critical), critical
 
 
+def test_rule1_catches_futures_ticker_mismatch() -> None:
+    """Bare futures names (`ES`, `NQ`) in the hypothesis must be caught."""
+    spec = _spec(
+        hypothesis="Trade ES on Monday-morning gaps.",
+        target_symbols=["NQ=F"],
+        asset_class="futures",
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    critical = _critical(results)
+    assert any("ES" in c for c in critical), critical
+
+
+def test_rule1_catches_forex_ticker_mismatch() -> None:
+    """Forex suffixed tickers (`EURUSD=X`) in the hypothesis must be caught."""
+    spec = _spec(
+        hypothesis="EURUSD=X tends to revert intraday.",
+        target_symbols=["GBPUSD=X"],
+        asset_class="forex",
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    critical = _critical(results)
+    assert any("EURUSD=X" in c for c in critical), critical
+
+
 def test_rule1_passes_when_no_symbols_in_hypothesis_and_no_targets() -> None:
     spec = _spec(
         hypothesis="RSI(14) below 30 signals long entry.",

--- a/backend/agents/investment_team/tests/test_spec_readiness.py
+++ b/backend/agents/investment_team/tests/test_spec_readiness.py
@@ -321,6 +321,36 @@ def test_rule6_hypothesis_mentions_indicator_not_in_rules_is_critical() -> None:
     assert any("macd" in c.lower() for c in _critical(results))
 
 
+def test_rule1_matches_lowercase_ticker_in_hypothesis() -> None:
+    """Rule 1's regex is case-insensitive: `qqq` in hypothesis is caught."""
+    spec = _spec(
+        hypothesis="qqq mean-reverts to its 50-day moving average.",
+        target_symbols=[],
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    assert any("QQQ" in c for c in _critical(results))
+
+
+def test_rule6_moving_average_is_satisfied_by_ema() -> None:
+    """'Moving average' in the hypothesis is satisfied by either SMA or EMA."""
+    spec = _spec(
+        hypothesis="AAPL crosses its EMA moving average to signal long entry.",
+        entry=[
+            EntryRule(
+                side="long",
+                when=Predicate(
+                    lhs=IndicatorRef(name="ema", params={"period": 20}),
+                    op="cross_above",
+                    rhs="bar.close",
+                ),
+            ),
+        ],
+    )
+    results = SpecReadinessGate().validate(spec, backtest_config=_config())
+    rule6_failures = [c for c in _critical(results) if "moving average" in c]
+    assert not rule6_failures, rule6_failures
+
+
 def test_rule6_passes_when_hypothesis_and_rules_match() -> None:
     spec = _spec(
         hypothesis="RSI(14) below 30 on AAPL signals oversold conditions.",

--- a/backend/agents/investment_team/tests/test_strategy_lab_alignment.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_alignment.py
@@ -360,6 +360,7 @@ def _drive_alignment_loop(
                 gate_name="trade_alignment",
                 passed=report.aligned,
                 severity=gate_severity,  # type: ignore[arg-type]
+                phase="verification",
                 details=report.rationale or "n/a",
                 refinement_round=align_round,
             )
@@ -412,6 +413,7 @@ def _drive_alignment_loop(
                     gate_name="alignment_code_execution",
                     passed=False,
                     severity="critical",
+                    phase="verification",
                     details=f"re-exec failed: {align_exec.error_type}",
                     refinement_round=align_round,
                 )

--- a/backend/agents/investment_team/tests/test_strategy_lab_max_rounds_exhaustion.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_max_rounds_exhaustion.py
@@ -11,7 +11,7 @@ assert on the final record's ``status``.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Tuple
+from typing import Any, Dict
 
 import pytest
 
@@ -80,36 +80,15 @@ def _spec_dict() -> Dict[str, Any]:
     }
 
 
-def _ideation_returning(d: Dict[str, Any], code: str) -> Any:
-    def _run(**_kwargs) -> Tuple[Dict[str, Any], str, str]:
-        return d, code, "scripted rationale"
-
-    return _run
-
-
-def _stub_market_data(*_a, **_kw):
-    # Issue #525 — orchestrator now returns a _MarketDataFetch envelope.
-    from investment_team.strategy_lab.orchestrator import _MarketDataFetch
-
-    return _MarketDataFetch(
-        data={"AAPL": []},
-        requested_symbols=["AAPL"],
-        fetched_symbols=[],
-    )
-
-
 def test_validation_phase_exhaustion_sets_max_rounds_status(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Code-safety always critical → loop exhausts validation phase."""
+    from investment_team.tests.conftest import ideation_returning, noop_refine
+
     orch = StrategyLabOrchestrator()
-    monkeypatch.setattr(orch.ideation_agent, "run", _ideation_returning(_spec_dict(), _VALID_CODE))
-
-    # Refinement is a no-op: same code back, so each round re-fails code-safety.
-    def _stub_refine(**_kw):
-        return {"changes_made": "no-op"}, _VALID_CODE
-
-    monkeypatch.setattr(orch.refinement_agent, "run", _stub_refine)
+    monkeypatch.setattr(orch.ideation_agent, "run", ideation_returning(_spec_dict(), _VALID_CODE))
+    monkeypatch.setattr(orch.refinement_agent, "run", noop_refine(_VALID_CODE))
 
     def _always_critical(_code: str, _spec=None):
         return [
@@ -137,26 +116,18 @@ def test_execution_phase_exhaustion_sets_max_rounds_status(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Sandbox always reports execution failure → loop exhausts execution phase."""
-    from investment_team.trading_service.modes.sandbox_compat import StrategyRunResult
+    from investment_team.tests.conftest import (
+        empty_market_data,
+        failing_sandbox,
+        ideation_returning,
+        noop_refine,
+    )
 
     orch = StrategyLabOrchestrator()
-    monkeypatch.setattr(orch.ideation_agent, "run", _ideation_returning(_spec_dict(), _VALID_CODE))
-    monkeypatch.setattr(StrategyLabOrchestrator, "_fetch_market_data", _stub_market_data)
-
-    def _stub_refine(**_kw):
-        return {"changes_made": "no-op"}, _VALID_CODE
-
-    monkeypatch.setattr(orch.refinement_agent, "run", _stub_refine)
-
-    def _always_fails(*_a, **_kw):
-        return StrategyRunResult(
-            success=False,
-            trades=[],
-            stderr="forced failure for test",
-            error_type="runtime_error",
-        )
-
-    monkeypatch.setattr(orchestrator_module, "run_strategy_code", _always_fails)
+    monkeypatch.setattr(orch.ideation_agent, "run", ideation_returning(_spec_dict(), _VALID_CODE))
+    monkeypatch.setattr(StrategyLabOrchestrator, "_fetch_market_data", empty_market_data())
+    monkeypatch.setattr(orch.refinement_agent, "run", noop_refine(_VALID_CODE))
+    monkeypatch.setattr(orchestrator_module, "run_strategy_code", failing_sandbox())
 
     record = orch.run_cycle(prior_records=[], config=_config())
 
@@ -171,26 +142,26 @@ def test_evaluation_phase_exhaustion_does_not_mark_winner(
     evaluation must NOT be persisted with is_winning=True (#547 review feedback).
     Otherwise paper-trading would fire on a 'failed: max_refinement_rounds' record."""
     from investment_team.strategy_lab.quality_gates.models import QualityGateResult
+    from investment_team.tests.conftest import (
+        empty_market_data,
+        ideation_returning,
+        noop_refine,
+    )
     from investment_team.tests.test_strategy_lab_alignment import (
         _benign_sandbox_trades,
         _code_exec,
     )
 
     orch = StrategyLabOrchestrator()
-    monkeypatch.setattr(orch.ideation_agent, "run", _ideation_returning(_spec_dict(), _VALID_CODE))
-    monkeypatch.setattr(StrategyLabOrchestrator, "_fetch_market_data", _stub_market_data)
+    monkeypatch.setattr(orch.ideation_agent, "run", ideation_returning(_spec_dict(), _VALID_CODE))
+    monkeypatch.setattr(StrategyLabOrchestrator, "_fetch_market_data", empty_market_data())
 
     # Sandbox always succeeds with benign trades — execution itself is fine.
     def _ok_sandbox(*_a, **_kw):
         return _code_exec(success=True, raw_trades=_benign_sandbox_trades())
 
     monkeypatch.setattr(orchestrator_module, "run_strategy_code", _ok_sandbox)
-
-    # Refinement is a no-op so the loop keeps hitting the same anomaly.
-    def _stub_refine(**_kw):
-        return {"changes_made": "no-op"}, _VALID_CODE
-
-    monkeypatch.setattr(orch.refinement_agent, "run", _stub_refine)
+    monkeypatch.setattr(orch.refinement_agent, "run", noop_refine(_VALID_CODE))
 
     # Anomaly detector always reports critical → evaluation-phase exhaustion.
     def _always_anomalous(*_a, **_kw):

--- a/backend/agents/investment_team/tests/test_strategy_lab_max_rounds_exhaustion.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_max_rounds_exhaustion.py
@@ -29,6 +29,14 @@ from investment_team.strategy_lab.spec_dsl import (
     SignalExitRule,
 )
 
+# Every test in this module builds a real ``StrategyLabOrchestrator`` and
+# drives ``run_cycle``, so the readiness price provider would otherwise hit
+# the live yfinance chain (or its test-environment stub) and trip
+# SpecReadinessGate Rule 5 on a NaN. Use the opt-in fixture from
+# ``conftest.py`` so every test in this file sees a deterministic price
+# without an autouse fixture masking production fail-closed behaviour.
+pytestmark = pytest.mark.usefixtures("stub_readiness_market_data_fetch")
+
 
 def _rsi_entry_dict() -> Dict[str, Any]:
     return EntryRule(

--- a/backend/agents/investment_team/tests/test_strategy_lab_max_rounds_exhaustion.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_max_rounds_exhaustion.py
@@ -112,6 +112,7 @@ def test_validation_phase_exhaustion_sets_max_rounds_status(
                 gate_name="code_safety",
                 passed=False,
                 severity="critical",
+                phase="synthesis",
                 details="forced critical for test",
             )
         ]
@@ -193,6 +194,7 @@ def test_evaluation_phase_exhaustion_does_not_mark_winner(
                 gate_name="backtest_anomaly",
                 passed=False,
                 severity="critical",
+                phase="verification",
                 details="forced anomaly for test",
             )
         ]

--- a/backend/agents/investment_team/tests/test_strategy_lab_max_rounds_exhaustion.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_max_rounds_exhaustion.py
@@ -29,13 +29,10 @@ from investment_team.strategy_lab.spec_dsl import (
     SignalExitRule,
 )
 
-# Every test in this module builds a real ``StrategyLabOrchestrator`` and
-# drives ``run_cycle``, so the readiness price provider would otherwise hit
-# the live yfinance chain (or its test-environment stub) and trip
-# SpecReadinessGate Rule 5 on a NaN. Use the opt-in fixture from
-# ``conftest.py`` so every test in this file sees a deterministic price
-# without an autouse fixture masking production fail-closed behaviour.
-pytestmark = pytest.mark.usefixtures("stub_readiness_market_data_fetch")
+# Every test in this module drives `run_cycle` on a real
+# StrategyLabOrchestrator; the marker auto-applies the readiness fetch
+# stub from conftest. See conftest.py for the contract.
+pytestmark = pytest.mark.strategy_lab_integration
 
 
 def _rsi_entry_dict() -> Dict[str, Any]:

--- a/backend/agents/investment_team/tests/test_strategy_lab_pre_synthesis_gating.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_pre_synthesis_gating.py
@@ -28,6 +28,14 @@ from investment_team.strategy_lab.spec_dsl import (
     StopLossRule,
 )
 
+# Every test in this module builds a real ``StrategyLabOrchestrator`` and
+# drives ``run_cycle``, so the readiness price provider would otherwise hit
+# the live yfinance chain (or its test-environment stub) and trip
+# SpecReadinessGate Rule 5 on a NaN. Use the opt-in fixture from
+# ``conftest.py`` so every test in this file sees a deterministic price
+# without an autouse fixture masking production fail-closed behaviour.
+pytestmark = pytest.mark.usefixtures("stub_readiness_market_data_fetch")
+
 
 def _rsi_entry_dict() -> Dict[str, Any]:
     return EntryRule(

--- a/backend/agents/investment_team/tests/test_strategy_lab_pre_synthesis_gating.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_pre_synthesis_gating.py
@@ -28,13 +28,10 @@ from investment_team.strategy_lab.spec_dsl import (
     StopLossRule,
 )
 
-# Every test in this module builds a real ``StrategyLabOrchestrator`` and
-# drives ``run_cycle``, so the readiness price provider would otherwise hit
-# the live yfinance chain (or its test-environment stub) and trip
-# SpecReadinessGate Rule 5 on a NaN. Use the opt-in fixture from
-# ``conftest.py`` so every test in this file sees a deterministic price
-# without an autouse fixture masking production fail-closed behaviour.
-pytestmark = pytest.mark.usefixtures("stub_readiness_market_data_fetch")
+# Every test in this module drives `run_cycle` on a real
+# StrategyLabOrchestrator; the marker auto-applies the readiness fetch
+# stub from conftest. See conftest.py for the contract.
+pytestmark = pytest.mark.strategy_lab_integration
 
 
 def _rsi_entry_dict() -> Dict[str, Any]:

--- a/backend/agents/investment_team/tests/test_strategy_lab_refinement_freeze.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_refinement_freeze.py
@@ -45,13 +45,10 @@ from investment_team.strategy_lab.spec_dsl import (
 )
 from investment_team.trading_service.modes.sandbox_compat import StrategyRunResult
 
-# Every test in this module builds a real ``StrategyLabOrchestrator`` and
-# drives ``run_cycle``, so the readiness price provider would otherwise hit
-# the live yfinance chain (or its test-environment stub) and trip
-# SpecReadinessGate Rule 5 on a NaN. Use the opt-in fixture from
-# ``conftest.py`` so every test in this file sees a deterministic price
-# without an autouse fixture masking production fail-closed behaviour.
-pytestmark = pytest.mark.usefixtures("stub_readiness_market_data_fetch")
+# Every test in this module drives `run_cycle` on a real
+# StrategyLabOrchestrator; the marker auto-applies the readiness fetch
+# stub from conftest. See conftest.py for the contract.
+pytestmark = pytest.mark.strategy_lab_integration
 
 # ---------------------------------------------------------------------------
 # Fixtures / helpers

--- a/backend/agents/investment_team/tests/test_strategy_lab_refinement_freeze.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_refinement_freeze.py
@@ -36,6 +36,7 @@ from investment_team.strategy_lab.exceptions import SpecImplementabilityError
 from investment_team.strategy_lab.orchestrator import (
     MAX_DESIGN_REENTRIES,
     StrategyLabOrchestrator,
+    _merge_risk_limits_tighten_only,
 )
 from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
@@ -196,7 +197,7 @@ def test_refinement_agent_passes_risk_limits_through(
 
 def test_merge_risk_limits_tightening_accepted() -> None:
     current = RiskLimits()  # default max_position_pct = 6.0
-    merged, loosened, unknown = StrategyLabOrchestrator._merge_risk_limits_tighten_only(
+    merged, loosened, unknown = _merge_risk_limits_tighten_only(
         current, {"max_position_pct": 3.0}
     )
     assert loosened == []
@@ -206,7 +207,7 @@ def test_merge_risk_limits_tightening_accepted() -> None:
 
 def test_merge_risk_limits_loosening_rejected() -> None:
     current = RiskLimits()
-    _, loosened, unknown = StrategyLabOrchestrator._merge_risk_limits_tighten_only(
+    _, loosened, unknown = _merge_risk_limits_tighten_only(
         current, {"max_position_pct": 99.0}
     )
     assert loosened == ["max_position_pct"]
@@ -215,7 +216,7 @@ def test_merge_risk_limits_loosening_rejected() -> None:
 
 def test_merge_risk_limits_unknown_key_discarded() -> None:
     current = RiskLimits()
-    merged, loosened, unknown = StrategyLabOrchestrator._merge_risk_limits_tighten_only(
+    merged, loosened, unknown = _merge_risk_limits_tighten_only(
         current, {"made_up_field": 0.1}
     )
     assert loosened == []
@@ -226,7 +227,7 @@ def test_merge_risk_limits_unknown_key_discarded() -> None:
 def test_merge_risk_limits_immutable_key_discarded() -> None:
     """``vol_lookback_days`` is mapped to ``None`` direction → discard, not trip."""
     current = RiskLimits()
-    _, loosened, unknown = StrategyLabOrchestrator._merge_risk_limits_tighten_only(
+    _, loosened, unknown = _merge_risk_limits_tighten_only(
         current, {"vol_lookback_days": 50}
     )
     assert loosened == []
@@ -237,7 +238,7 @@ def test_merge_risk_limits_target_vol_none_to_value_is_loosening() -> None:
     """Going from None (flat sizing) to a vol target changes sizing model."""
     current = RiskLimits()
     assert current.target_annual_vol is None
-    _, loosened, _ = StrategyLabOrchestrator._merge_risk_limits_tighten_only(
+    _, loosened, _ = _merge_risk_limits_tighten_only(
         current, {"target_annual_vol": 0.10}
     )
     assert loosened == ["target_annual_vol"]

--- a/backend/agents/investment_team/tests/test_strategy_lab_refinement_freeze.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_refinement_freeze.py
@@ -45,6 +45,14 @@ from investment_team.strategy_lab.spec_dsl import (
 )
 from investment_team.trading_service.modes.sandbox_compat import StrategyRunResult
 
+# Every test in this module builds a real ``StrategyLabOrchestrator`` and
+# drives ``run_cycle``, so the readiness price provider would otherwise hit
+# the live yfinance chain (or its test-environment stub) and trip
+# SpecReadinessGate Rule 5 on a NaN. Use the opt-in fixture from
+# ``conftest.py`` so every test in this file sees a deterministic price
+# without an autouse fixture masking production fail-closed behaviour.
+pytestmark = pytest.mark.usefixtures("stub_readiness_market_data_fetch")
+
 # ---------------------------------------------------------------------------
 # Fixtures / helpers
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
@@ -201,6 +201,15 @@ def _orchestrator(
     orch = StrategyLabOrchestrator()
     if market_data_service is not None:
         orch.market_data_service = market_data_service  # type: ignore[assignment]
+    # The stub market-data service implements ``fetch_multi_symbol_range``
+    # but not ``fetch_ohlcv``; ``_readiness_price_provider`` would raise on
+    # the attribute miss and (now that the provider fails closed) return
+    # ``NaN``, tripping SpecReadinessGate Rule 5 before the test's
+    # walk-forward path can run. Stamp a fixed sentinel directly on the
+    # gate's bound slot so readiness sees a usable price.
+    orch.spec_readiness_gate._market_sample_provider = (
+        lambda symbol, asset_class: 100.0
+    )
     return orch
 
 
@@ -707,6 +716,19 @@ def _wire_run_cycle_stubs(
     """
     from investment_team.strategy_lab.agents.alignment import TradeAlignmentReport
     from investment_team.strategy_lab.orchestrator import _MarketDataFetch
+
+    # ``_readiness_price_provider`` now fails closed (NaN) when the live
+    # ``MarketDataService.fetch_ohlcv`` returns no bars, so without a stub
+    # SpecReadinessGate's Rule 5 critical short-circuits the design phase
+    # before any test reaches the walk-forward path it exercises. Replace
+    # the gate's bound provider with a fixed sentinel so readiness sees a
+    # usable price and the test can drive the rest of the cycle. We poke
+    # the gate's slot directly because the bound reference was captured
+    # at ``__init__`` time — patching ``orch._readiness_price_provider``
+    # alone does not redirect it.
+    orch.spec_readiness_gate._market_sample_provider = (
+        lambda symbol, asset_class: 100.0
+    )
 
     spec_dict = {
         "asset_class": "stocks",

--- a/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
@@ -815,12 +815,14 @@ def test_failed_alignment_forces_is_winning_false_on_acceptance_path(monkeypatch
                 gate_name="oos_deflated_sharpe",
                 passed=True,
                 severity="info",
+                phase="verification",
                 details="DSR passes",
             ),
             QualityGateResult(
                 gate_name="is_oos_degradation",
                 passed=True,
                 severity="info",
+                phase="verification",
                 details="IS->OOS within tolerance",
             ),
         ],
@@ -914,6 +916,7 @@ def test_failed_alignment_forces_is_winning_false_on_walk_forward_fallback(monke
                 gate_name="sharpe_sane",
                 passed=True,
                 severity="info",
+                phase="verification",
                 details="ok",
             )
         ],
@@ -993,12 +996,14 @@ def test_acceptance_failures_and_alignment_failure_both_recorded(monkeypatch):
                 gate_name="oos_deflated_sharpe",
                 passed=False,
                 severity="critical",
+                phase="verification",
                 details="DSR below threshold",
             ),
             QualityGateResult(
                 gate_name="oos_trade_count",
                 passed=False,
                 severity="critical",
+                phase="verification",
                 details="trade count below floor",
             ),
         ],
@@ -1102,6 +1107,7 @@ def test_walk_forward_fallback_rejected_records_acceptance_reason(monkeypatch):
                 gate_name="sharpe_sane",
                 passed=False,
                 severity="critical",
+                phase="verification",
                 details="Sharpe ratio 6.40 > 5.0 (overfit suspect)",
             )
         ]
@@ -1144,7 +1150,7 @@ def test_walk_forward_fallback_passed_records_provenance(monkeypatch):
         orch.anomaly_detector,
         "check",
         lambda *a, **kw: [
-            _QGR(gate_name="sharpe_sane", passed=True, severity="info", details="ok")
+            _QGR(gate_name="sharpe_sane", passed=True, severity="info", phase="verification", details="ok")
         ],
     )
 

--- a/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
@@ -27,7 +27,12 @@ import pytest
 from investment_team.execution.metrics import compute_deflated_sharpe
 from investment_team.market_data_service import OHLCVBar
 from investment_team.models import BacktestConfig, BacktestResult, StrategySpec, TradeRecord
-from investment_team.strategy_lab.orchestrator import StrategyLabOrchestrator
+from investment_team.strategy_lab.orchestrator import (
+    StrategyLabOrchestrator,
+    _closes_to_equity,
+    _daily_returns_from_trades,
+    _equity_to_returns,
+)
 from investment_team.strategy_lab.quality_gates.acceptance_gate import AcceptanceGate
 from investment_team.strategy_lab.quality_gates.convergence_tracker import ConvergenceTracker
 from investment_team.strategy_lab.spec_dsl import (
@@ -451,7 +456,7 @@ def test_acceptance_gate_rejects_overfit_pattern():
 
 def test_daily_returns_from_trades_handles_empty_input():
     """Returns an empty list rather than raising on an empty trade ledger."""
-    out = StrategyLabOrchestrator._daily_returns_from_trades(
+    out = _daily_returns_from_trades(
         [], 100_000.0, "2022-01-03", "2022-12-30"
     )
     assert out == [] or all(r == 0.0 for r in out)
@@ -472,7 +477,7 @@ def test_daily_returns_from_trades_emits_log_returns():
             symbol="TST",
         )
     ]
-    out = StrategyLabOrchestrator._daily_returns_from_trades(
+    out = _daily_returns_from_trades(
         trades, 100_000.0, "2023-01-03", "2023-01-05"
     )
     assert len(out) >= 1
@@ -499,7 +504,7 @@ def test_daily_returns_from_trades_invalidates_ruin_series():
             symbol="TST",
         )
     ]
-    out = StrategyLabOrchestrator._daily_returns_from_trades(
+    out = _daily_returns_from_trades(
         trades, 100_000.0, "2023-01-03", "2023-01-06"
     )
     assert out == []
@@ -508,14 +513,14 @@ def test_daily_returns_from_trades_invalidates_ruin_series():
 def test_equity_to_returns_skips_zero_or_negative_prev():
     """Zero/negative previous equity yields a 0.0 return at that step (no
     ZeroDivisionError, no NaN)."""
-    out = StrategyLabOrchestrator._equity_to_returns([100.0, 0.0, 50.0])
+    out = _equity_to_returns([100.0, 0.0, 50.0])
     assert len(out) == 2
     assert out[0] == pytest.approx(-1.0)
     assert out[1] == 0.0
 
 
 def test_closes_to_equity_scales_to_initial_capital():
-    out = StrategyLabOrchestrator._closes_to_equity([10.0, 11.0, 12.0], 100_000.0)
+    out = _closes_to_equity([10.0, 11.0, 12.0], 100_000.0)
     assert out[0] == pytest.approx(100_000.0)
     assert out[-1] == pytest.approx(100_000.0 * 12.0 / 10.0)
 

--- a/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_zero_trade_repair.py
@@ -7,7 +7,7 @@ the generic ``RefinementAgent``, the orchestrator first asks
 :class:`ZeroTradeRepairAgent` for a targeted fix and, if the proposal
 clears code-safety + a fresh backtest + the anomaly gates, commits it
 in place. Failed proposals fall through to generic refinement. These
-tests exercise :meth:`StrategyLabOrchestrator._run_zero_trade_repair`
+tests exercise :meth:`ZeroTradeRepairer.try_repair`
 directly with stubs for the agent and ``run_strategy_code``.
 """
 
@@ -26,11 +26,9 @@ from investment_team.models import (
     StrategySpec,
 )
 from investment_team.strategy_lab import orchestrator as orchestrator_module
+from investment_team.strategy_lab import zero_trade_repair as zero_trade_repair_module
 from investment_team.strategy_lab.agents.zero_trade_repair import ZeroTradeRepairReport
-from investment_team.strategy_lab.orchestrator import (
-    StrategyLabOrchestrator,
-    _ZeroTradeRepairOutcome,
-)
+from investment_team.strategy_lab.orchestrator import StrategyLabOrchestrator
 from investment_team.strategy_lab.quality_gates.models import QualityGateResult
 from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
@@ -38,6 +36,9 @@ from investment_team.strategy_lab.spec_dsl import (
     Predicate,
     SignalExitRule,
     StopLossRule,
+)
+from investment_team.strategy_lab.zero_trade_repair import (
+    ZeroTradeRepairOutcome as _ZeroTradeRepairOutcome,
 )
 from investment_team.tests.test_strategy_lab_alignment import (
     _benign_sandbox_trades,
@@ -235,6 +236,10 @@ def _make_orchestrator_with_stubs(
     sandbox_stub = _StubSandbox(sandbox_results or [])
     orch.zero_trade_repair_agent = repair_stub  # type: ignore[assignment]
     monkeypatch.setattr(orchestrator_module, "run_strategy_code", sandbox_stub)
+    # The zero-trade repairer module imports ``run_strategy_code`` directly
+    # rather than going through ``orchestrator_module``, so it needs its own
+    # monkeypatch target.
+    monkeypatch.setattr(zero_trade_repair_module, "run_strategy_code", sandbox_stub)
     return orch, repair_stub, sandbox_stub
 
 
@@ -249,7 +254,7 @@ def _drive_repair(
     zero_trade_attempts: Optional[List[str]] = None,
     coverage_report: Optional[CoverageReport] = None,
 ) -> tuple[_ZeroTradeRepairOutcome, List[tuple[str, Dict[str, Any]]], List[str]]:
-    """Convenience wrapper around ``orch._run_zero_trade_repair``.
+    """Convenience wrapper around ``orch.zero_trade_repairer.try_repair``.
 
     Captures emitted phase callbacks and the orchestrator's
     ``zero_trade_attempts`` log so tests can assert on them.
@@ -265,7 +270,7 @@ def _drive_repair(
     def emit(phase: str, data: Dict[str, Any]) -> None:
         events.append((phase, data))
 
-    outcome = orch._run_zero_trade_repair(
+    outcome = orch.zero_trade_repairer.try_repair(
         spec=spec,
         code=code,
         exec_result=exec_result,
@@ -1006,7 +1011,7 @@ def test_quality_gate_results_are_typed() -> None:
     orch = StrategyLabOrchestrator()
 
     no_category_diag = BacktestExecutionDiagnostics(zero_trade_category=None)
-    outcome = orch._run_zero_trade_repair(
+    outcome = orch.zero_trade_repairer.try_repair(
         spec=_spec(),
         code=_spec().strategy_code or "",
         exec_result=StrategyRunResult(
@@ -1030,7 +1035,7 @@ def test_coverage_report_is_forwarded_to_repair_agent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """When the orchestrator has attached a CoverageReport (#451) to the
-    failing run's metrics, ``_run_zero_trade_repair`` must forward it to
+    failing run's metrics, ``ZeroTradeRepairer.try_repair`` must forward it to
     the repair agent so the prompt sees the static probe's verdict
     alongside the executor diagnostics.
     """


### PR DESCRIPTION
Closes #540.

## Summary

Adds `SpecReadinessGate` (`backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py`) — a deterministic, blocking gate that refuses vague or unimplementable strategy specs **before** any code is written, sitting on the design→synthesis transition of epic #536.

The gate runs the eight implementability rules from issue #540:

1. **Universe set** — `target_symbols` must include every whitelisted ticker the hypothesis names.
2. **Entry rules non-trivial** — `entry_rules` non-empty; each `EntryRule.when` is a structured `Predicate`.
3. **Indicator validity** — every `IndicatorRef.name` is in the DSL's `IndicatorName` set; required params are present (`sma`/`ema` require `period`).
4. **Exit completeness** — at least one `ExitRule` of kind `signal_exit`, `stop_loss`, or `take_profit`.
5. **Sizing realisable** — `FixedFractionSizing`/`FixedNotionalSizing` against `BacktestConfig.initial_capital` and a `market_sample_provider` yields qty ≥ 1.
6. **Hypothesis–rule consistency** — every indicator name in the hypothesis appears in at least one predicate (critical, not warning).
7. **Timeframe data availability** — intraday timeframes require asset class `stocks` or `crypto`; everything else is restricted to `1d`.
8. **Risk-limit coherence** — `stop_loss.pct < take_profit.pct` across exit rules; `max_position_pct ≤ 25`.

The gate is wired into `orchestrator.py` twice: once at the design-phase pre-synthesis gate (line ~485), feeding the existing `pre_synthesis_criticals` short-circuit path; and again at the start of the synthesis refinement loop (`round_num == 0`) as a sanity check that the spec wasn't mutated.

`QualityGateResult` now carries a required `phase: Literal["design","design_review","synthesis","verification"]` so the persisted `StrategyLabRecord.quality_gate_results` is queryable by phase. Every existing gate caller is updated in lockstep — no default, no compat shim.

## Adaptations from the issue text

The issue was authored before #527 (structured rules) closed; a few field names drifted. Each adaptation is documented in the gate's module docstring.

- `EntryRule.predicates` → `EntryRule.when` (singular).
- Exit kinds: `time_stop` dropped (not in the DSL union); the rule accepts `{signal_exit, stop_loss, take_profit}`.
- `BacktestConfig.timeframe` → `StrategySpec.timeframe`.
- `risk_limits.stop_loss_pct`/`take_profit_pct` → percentages live on `StopLossRule.pct`/`TakeProfitRule.pct`; gate cross-checks across exit rules.

## Files

- **New:** `backend/agents/investment_team/strategy_lab/quality_gates/spec_readiness.py`
- **New:** `backend/agents/investment_team/tests/test_spec_readiness.py` (18 tests covering all 8 rules plus the two end-to-end scenarios from the acceptance criteria)
- **Modified:** every `quality_gates/*.py` caller of `QualityGateResult(...)` now passes `phase=` explicitly (`strategy_validator` → design, `code_safety` → synthesis, `acceptance_gate`/`backtest_anomaly`/`exit_rule_conformance`/`target_symbol_coverage` → verification).
- **Modified:** `orchestrator.py` (6 internal `QualityGateResult` constructions get phases; gate is instantiated and wired into both design and synthesis-round-0 paths).
- **Modified:** existing test fixtures that build `QualityGateResult` literals (`test_strategy_lab_max_rounds_exhaustion.py`, `test_convergence_tracker.py`, `test_strategy_lab_walk_forward_integration.py`, `test_strategy_lab_alignment.py`).

## Out of scope / follow-up candidates

- Adding `time_stop` to the DSL exit union (not blocking; some prompts still mention it).
- Replacing the static `market_sample_provider` ($100/share default) with a real recent-bar feed.
- Querying `MarketDataService` directly for timeframe support instead of the static per-asset-class map.

## Test plan

- [x] `pytest agents/investment_team/tests/test_spec_readiness.py -v` — 18/18 passing locally.
- [x] `pytest agents/investment_team/tests/` — 1389 passing, 13 skipped (no regressions).
- [x] `ruff check` + `ruff format --check` clean across touched files.
- [ ] CI green on this PR.

https://claude.ai/code/session_01RZptPMAbA1NWzp1EqcJH8d

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZptPMAbA1NWzp1EqcJH8d)_