### PR TITLE
investment-team: thread alignment status into analysis prompts (#532)

### DIFF
--- a/backend/agents/investment_team/strategy_lab/agents/analysis.py
+++ b/backend/agents/investment_team/strategy_lab/agents/analysis.py
@@ -278,6 +278,26 @@ def _format_alignment_status_section(report: Optional[TradeAlignmentReport]) -> 
     return "\n".join(lines)
 
 
+def format_misalignment_prefix(report: Optional[TradeAlignmentReport]) -> str:
+    """Disclaimer + enumerated issues block for narrative outputs when
+    ``aligned=False``.
+
+    Returns an empty string for ``None`` or ``aligned=True`` so aligned and
+    legacy paths stay byte-identical. Shared between the agent's
+    ``_fallback_narrative`` and the orchestrator's analysis-phase exception
+    handler so a misaligned run cannot slip a confident auto-summary out
+    via either fallback path (#532).
+    """
+    if report is None or report.aligned:
+        return ""
+    parts: List[str] = [_MISALIGNED_DISCLAIMER]
+    if report.issues:
+        parts.append("Alignment issues:")
+        for issue in report.issues:
+            parts.append(f"- [{issue.severity}] {issue.rule_type}: {issue.description}")
+    return "\n".join(parts)
+
+
 def _fallback_narrative(
     spec: StrategySpec,
     metrics: BacktestResult,
@@ -301,16 +321,10 @@ def _fallback_narrative(
         f"max drawdown {metrics.max_drawdown_pct:.1f}%, win rate {metrics.win_rate_pct:.1f}%. "
         f"(Detailed narrative generation failed.)"
     )
-    if alignment_report is None or alignment_report.aligned:
+    prefix = format_misalignment_prefix(alignment_report)
+    if not prefix:
         return summary
-
-    parts: List[str] = [_MISALIGNED_DISCLAIMER]
-    if alignment_report.issues:
-        parts.append("Alignment issues:")
-        for issue in alignment_report.issues:
-            parts.append(f"- [{issue.severity}] {issue.rule_type}: {issue.description}")
-    parts.append(summary)
-    return "\n".join(parts)
+    return f"{prefix}\n{summary}"
 
 
 def _extract_json(text: str) -> Dict[str, Any]:

--- a/backend/agents/investment_team/strategy_lab/agents/analysis.py
+++ b/backend/agents/investment_team/strategy_lab/agents/analysis.py
@@ -129,10 +129,10 @@ class AnalysisAgent:
             draft_narrative = draft_parsed.get("draft_narrative", "")
         except Exception:
             logger.exception("Draft analysis failed")
-            return _fallback_narrative(spec, metrics, is_winning)
+            return _fallback_narrative(spec, metrics, is_winning, alignment_report)
 
         if not draft_narrative:
-            return _fallback_narrative(spec, metrics, is_winning)
+            return _fallback_narrative(spec, metrics, is_winning, alignment_report)
 
         # Phase 2: Self-review
         if on_sub_phase:
@@ -278,15 +278,39 @@ def _format_alignment_status_section(report: Optional[TradeAlignmentReport]) -> 
     return "\n".join(lines)
 
 
-def _fallback_narrative(spec: StrategySpec, metrics: BacktestResult, is_winning: bool) -> str:
-    """Auto-generated fallback when LLM analysis fails."""
+def _fallback_narrative(
+    spec: StrategySpec,
+    metrics: BacktestResult,
+    is_winning: bool,
+    alignment_report: Optional[TradeAlignmentReport] = None,
+) -> str:
+    """Auto-generated fallback when LLM analysis fails.
+
+    When the draft LLM call raises, returns unparseable JSON, or yields an
+    empty narrative, this deterministic summary takes over. If
+    ``alignment_report.aligned`` is False the summary is prefixed with the
+    misalignment disclaimer and the audit's enumerated issues, so a
+    fail-closed audit error or transient LLM outage cannot publish a
+    confident auto-summary on a run that didn't faithfully implement the
+    spec (#532).
+    """
     label = "winning" if is_winning else "losing"
-    return (
+    summary = (
         f"Auto-summary: {spec.asset_class} strategy ({label}) with annualized return "
         f"{metrics.annualized_return_pct:.1f}%, Sharpe {metrics.sharpe_ratio:.2f}, "
         f"max drawdown {metrics.max_drawdown_pct:.1f}%, win rate {metrics.win_rate_pct:.1f}%. "
         f"(Detailed narrative generation failed.)"
     )
+    if alignment_report is None or alignment_report.aligned:
+        return summary
+
+    parts: List[str] = [_MISALIGNED_DISCLAIMER]
+    if alignment_report.issues:
+        parts.append("Alignment issues:")
+        for issue in alignment_report.issues:
+            parts.append(f"- [{issue.severity}] {issue.rule_type}: {issue.description}")
+    parts.append(summary)
+    return "\n".join(parts)
 
 
 def _extract_json(text: str) -> Dict[str, Any]:

--- a/backend/agents/investment_team/strategy_lab/agents/analysis.py
+++ b/backend/agents/investment_team/strategy_lab/agents/analysis.py
@@ -301,31 +301,55 @@ def format_misalignment_prefix(report: Optional[TradeAlignmentReport]) -> str:
 def _ensure_misalignment_disclaimer(
     narrative: str, alignment_report: Optional[TradeAlignmentReport]
 ) -> str:
-    """Deterministically guarantee the misalignment disclaimer is present.
+    """Deterministically guarantee the misalignment disclaimer + audit
+    facts are visible on every published narrative.
 
     The LLM is *told* to open misaligned narratives with the disclaimer
-    verbatim, but cannot be trusted to comply — and the self-review pass
-    that's meant to enforce it may fail or return the raw draft. On
-    ``aligned=False`` runs this prepends the full ``format_misalignment_prefix``
-    block unless the narrative already **opens** with the disclaimer
-    string, so the safety rail holds even when the LLM ignores the
-    instruction or buries the disclaimer mid-narrative behind a causal
-    claim (#532, Codex follow-up on PR #584).
+    verbatim and to surface the concrete alignment issues, but cannot be
+    trusted to comply — and the self-review pass that's meant to enforce
+    it may fail or echo a non-compliant draft. The rail enforces two
+    deterministic guarantees on ``aligned=False`` runs:
 
-    No-ops on aligned / None reports and on narratives that already
-    *open* with the disclaimer (after stripping leading whitespace) — so
-    compliant LLM output and legacy callers stay byte-identical. A
-    narrative that mentions the disclaimer later in the body but opens
-    with anything else gets the full prefix prepended; the operator may
-    see the disclaimer twice, but it WILL appear before any
-    confident/causal framing.
+    1. **The disclaimer opens the narrative.** If the narrative does not
+       start with the disclaimer string (after ``lstrip``), the full
+       ``format_misalignment_prefix`` block is prepended. This catches
+       LLMs that buried the disclaimer mid-body behind a causal claim
+       (#532, Codex follow-up).
+    2. **Every concrete alignment issue is present somewhere in the
+       narrative.** If the LLM opened with the disclaimer but dropped
+       any ``AlignmentIssue.description`` strings, those issues are
+       deterministically appended to the narrative so operators always
+       see the audit facts — even if the LLM paraphrased the disclaimer
+       correctly but elided the issue list.
+
+    The rail intentionally cannot detect *causal claims* about strategy
+    design (e.g. "failed because of X") — that requires natural-language
+    understanding. The prompt + self-review pass remain the only
+    mitigation for that. What this helper guarantees is that the
+    operator always sees the disclaimer at the top and the concrete
+    audit facts somewhere below, regardless of LLM compliance.
+
+    No-ops on aligned / None reports so clean / legacy callers stay
+    byte-identical.
     """
     prefix = format_misalignment_prefix(alignment_report)
     if not prefix:
         return narrative
-    if narrative.lstrip().startswith(_MISALIGNED_DISCLAIMER):
-        return narrative
-    return f"{prefix}\n\n{narrative}"
+    # Guarantee #1: disclaimer opens the narrative.
+    if not narrative.lstrip().startswith(_MISALIGNED_DISCLAIMER):
+        return f"{prefix}\n\n{narrative}"
+    # Guarantee #2: every concrete alignment issue is somewhere in the body.
+    # ``alignment_report`` is non-None because ``prefix`` was non-empty.
+    assert alignment_report is not None
+    missing_issues = [
+        issue for issue in alignment_report.issues if issue.description not in narrative
+    ]
+    if missing_issues:
+        appended_lines = ["", "Alignment issues (deterministically appended):"]
+        for issue in missing_issues:
+            appended_lines.append(f"- [{issue.severity}] {issue.rule_type}: {issue.description}")
+        return narrative + "\n" + "\n".join(appended_lines)
+    return narrative
 
 
 def _fallback_narrative(

--- a/backend/agents/investment_team/strategy_lab/agents/analysis.py
+++ b/backend/agents/investment_team/strategy_lab/agents/analysis.py
@@ -307,18 +307,23 @@ def _ensure_misalignment_disclaimer(
     verbatim, but cannot be trusted to comply — and the self-review pass
     that's meant to enforce it may fail or return the raw draft. On
     ``aligned=False`` runs this prepends the full ``format_misalignment_prefix``
-    block when the disclaimer string is missing, so the safety rail holds
-    even when the LLM ignores the instruction (#532, Codex follow-up on
-    PR #584).
+    block unless the narrative already **opens** with the disclaimer
+    string, so the safety rail holds even when the LLM ignores the
+    instruction or buries the disclaimer mid-narrative behind a causal
+    claim (#532, Codex follow-up on PR #584).
 
     No-ops on aligned / None reports and on narratives that already
-    contain the disclaimer string verbatim, so compliant LLM output and
-    legacy callers stay byte-identical.
+    *open* with the disclaimer (after stripping leading whitespace) — so
+    compliant LLM output and legacy callers stay byte-identical. A
+    narrative that mentions the disclaimer later in the body but opens
+    with anything else gets the full prefix prepended; the operator may
+    see the disclaimer twice, but it WILL appear before any
+    confident/causal framing.
     """
     prefix = format_misalignment_prefix(alignment_report)
     if not prefix:
         return narrative
-    if _MISALIGNED_DISCLAIMER in narrative:
+    if narrative.lstrip().startswith(_MISALIGNED_DISCLAIMER):
         return narrative
     return f"{prefix}\n\n{narrative}"
 

--- a/backend/agents/investment_team/strategy_lab/agents/analysis.py
+++ b/backend/agents/investment_team/strategy_lab/agents/analysis.py
@@ -171,11 +171,11 @@ class AnalysisAgent:
             review_parsed = _extract_json(str(review_result))
             revised = review_parsed.get("revised_narrative", "")
             if revised:
-                return revised
+                return _ensure_misalignment_disclaimer(revised, alignment_report)
         except Exception:
             logger.exception("Self-review failed, using draft")
 
-        return draft_narrative
+        return _ensure_misalignment_disclaimer(draft_narrative, alignment_report)
 
 
 def _format_simulated_trades_summary(trades: List[TradeRecord], max_sample_rows: int = 14) -> str:
@@ -296,6 +296,31 @@ def format_misalignment_prefix(report: Optional[TradeAlignmentReport]) -> str:
         for issue in report.issues:
             parts.append(f"- [{issue.severity}] {issue.rule_type}: {issue.description}")
     return "\n".join(parts)
+
+
+def _ensure_misalignment_disclaimer(
+    narrative: str, alignment_report: Optional[TradeAlignmentReport]
+) -> str:
+    """Deterministically guarantee the misalignment disclaimer is present.
+
+    The LLM is *told* to open misaligned narratives with the disclaimer
+    verbatim, but cannot be trusted to comply — and the self-review pass
+    that's meant to enforce it may fail or return the raw draft. On
+    ``aligned=False`` runs this prepends the full ``format_misalignment_prefix``
+    block when the disclaimer string is missing, so the safety rail holds
+    even when the LLM ignores the instruction (#532, Codex follow-up on
+    PR #584).
+
+    No-ops on aligned / None reports and on narratives that already
+    contain the disclaimer string verbatim, so compliant LLM output and
+    legacy callers stay byte-identical.
+    """
+    prefix = format_misalignment_prefix(alignment_report)
+    if not prefix:
+        return narrative
+    if _MISALIGNED_DISCLAIMER in narrative:
+        return narrative
+    return f"{prefix}\n\n{narrative}"
 
 
 def _fallback_narrative(

--- a/backend/agents/investment_team/strategy_lab/agents/analysis.py
+++ b/backend/agents/investment_team/strategy_lab/agents/analysis.py
@@ -12,6 +12,7 @@ from strands import Agent
 
 from ...models import BacktestResult, StrategySpec, TradeRecord
 from ..spec_dsl import format_rules_for_prompt, format_sizing_rule
+from .alignment import TradeAlignmentReport
 from .model_factory import get_strands_model
 
 logger = logging.getLogger(__name__)
@@ -36,10 +37,12 @@ Outcome label: {outcome_label}
 ## Simulated trades summary (source of truth)
 {simulated_trades_section}
 
+{alignment_status_section}
 ## Draft analysis to verify
 {draft_narrative}
 
 ## Instructions
+0. If an "Alignment status" section above marks the run as misaligned, ensure the polished narrative opens with the disclaimer verbatim and contains no causal claims about strategy design ("worked because of X", "failed because of Y"). Treat the listed alignment issues as facts; do not soften them.
 1. Check every substantive claim in the draft against the strategy, metrics, and trade evidence.
 2. Remove or rewrite anything that is unsupported, vague, or contradicts the numbers.
 3. Produce a single polished narrative (5-10 sentences) that a risk committee could rely on.
@@ -48,6 +51,11 @@ Outcome label: {outcome_label}
 Return ONLY JSON with no markdown:
 {{"revised_narrative": "...", "verification_notes": "..."}}
 """
+
+_MISALIGNED_DISCLAIMER = (
+    "The executed trades did not faithfully implement the specification; "
+    "interpretation is preliminary."
+)
 
 
 class AnalysisAgent:
@@ -61,6 +69,7 @@ class AnalysisAgent:
         rationale: str,
         on_sub_phase: Any = None,
         is_winning: Optional[bool] = None,
+        alignment_report: Optional[TradeAlignmentReport] = None,
     ) -> str:
         """Produce a polished analysis narrative via draft + self-review.
 
@@ -72,12 +81,19 @@ class AnalysisAgent:
                 gate / fallback anomalies (#529) must pass it explicitly so the
                 narrative template and ``outcome_label`` match the persisted
                 ``StrategyLabRecord.is_winning``.
+            alignment_report: Latest ``TradeAlignmentReport`` from the alignment
+                loop. When ``aligned=False``, both the draft and self-review
+                prompts surface a disclaimer + the concrete alignment issues and
+                forbid causal claims about strategy design (#532). When None or
+                ``aligned=True``, the section is empty / a one-line affirmation
+                so legacy callers and clean runs are unaffected.
 
         Returns the final narrative string.
         """
         if is_winning is None:
             is_winning = metrics.annualized_return_pct > 8.0
         trades_summary = _format_simulated_trades_summary(trades)
+        alignment_section = _format_alignment_status_section(alignment_report)
 
         # Phase 1: Draft
         template_file = "analysis_win.md" if is_winning else "analysis_lose.md"
@@ -100,6 +116,7 @@ class AnalysisAgent:
             profit_factor=metrics.profit_factor,
             volatility_pct=metrics.volatility_pct,
             simulated_trades_section=trades_summary,
+            alignment_status_section=alignment_section,
         )
 
         agent = Agent(
@@ -135,6 +152,7 @@ class AnalysisAgent:
             volatility_pct=metrics.volatility_pct,
             outcome_label="WINNING" if is_winning else "LOSING",
             simulated_trades_section=trades_summary,
+            alignment_status_section=alignment_section,
             draft_narrative=draft_narrative,
         )
 
@@ -208,6 +226,55 @@ def _format_simulated_trades_summary(trades: List[TradeRecord], max_sample_rows:
     if n > len(seen):
         lines.append(f"  ... ({n - len(seen)} additional trades not shown) ...")
 
+    return "\n".join(lines)
+
+
+def _format_alignment_status_section(report: Optional[TradeAlignmentReport]) -> str:
+    """Render the ``## Alignment status`` block injected into analysis prompts.
+
+    ``None`` produces an empty string so legacy callers (and fallback paths
+    where no alignment report exists) render byte-identical prompts to before
+    issue #532. ``aligned=True`` produces a one-line affirmation. ``aligned=
+    False`` produces a disclaimer, the enumerated audit issues, and explicit
+    instructions that forbid causal claims about strategy design — the trades
+    are not a valid test of the spec, so the narrative must not say it
+    "worked because of X" or "failed because of Y".
+    """
+    if report is None:
+        return ""
+
+    if report.aligned:
+        return (
+            "## Alignment status\n"
+            "The executed trades faithfully implement the specification "
+            "(alignment audit clean).\n"
+        )
+
+    lines: List[str] = [
+        "## Alignment status — TRADES DID NOT IMPLEMENT THE SPEC",
+        "",
+        f'Disclaimer to surface in the narrative: "{_MISALIGNED_DISCLAIMER}"',
+        "",
+        "Concrete alignment issues (facts; do not paraphrase away):",
+    ]
+    if report.issues:
+        for issue in report.issues:
+            lines.append(f"- [{issue.severity}] {issue.rule_type}: {issue.description}")
+    else:
+        lines.append("- (audit returned aligned=False with no enumerated issues)")
+    if report.rationale:
+        lines.append("")
+        lines.append(f"Audit rationale: {report.rationale}")
+    lines.extend(
+        [
+            "",
+            "Constraints for this analysis:",
+            "- DO open the narrative with the disclaimer above.",
+            '- DO NOT make causal claims about strategy design (e.g. "worked because of X", "failed because of Y") — the trades are not a valid test of the spec.',
+            "- DO describe execution gaps factually and recommend re-running once aligned.",
+            "",
+        ]
+    )
     return "\n".join(lines)
 
 

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -1390,6 +1390,7 @@ class StrategyLabOrchestrator:
         execution_succeeded: bool,
         refinement_attempts: List[Dict[str, Any]],
         all_gate_results: List[QualityGateResult],
+        alignment_report: Optional[TradeAlignmentReport],
         emit: PhaseCallback,
     ) -> str:
         """Run the analysis agent and return the narrative string.
@@ -1416,6 +1417,7 @@ class StrategyLabOrchestrator:
                     rationale,
                     on_sub_phase=_on_analysis_sub,
                     is_winning=is_winning,
+                    alignment_report=alignment_report,
                 )
                 emit("analyzing", {"sub_phase": "completed", "is_winning": is_winning})
                 return narrative
@@ -1715,6 +1717,7 @@ class StrategyLabOrchestrator:
         # to carry every downstream-visible signal. The fields stay on the
         # dataclass for callers that want to inspect the outcome directly.
         # ── Phase 3: ANALYSIS ─────────────────────────────────────────
+        latest_alignment_report = alignment_reports[-1] if alignment_reports else None
         narrative = self._run_analysis_phase(
             spec=spec,
             metrics=metrics,
@@ -1724,6 +1727,7 @@ class StrategyLabOrchestrator:
             execution_succeeded=execution_succeeded,
             refinement_attempts=refinement_attempts,
             all_gate_results=all_gate_results,
+            alignment_report=latest_alignment_report,
             emit=emit,
         )
 

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -44,8 +44,13 @@ from ..models import (
 from ..signal_intelligence_models import SignalIntelligenceBriefV1
 from ..trade_simulator import compute_metrics
 from ..trading_service.modes.sandbox_compat import StrategyRunResult, run_strategy_code
-from .agents.alignment import AlignmentAuditError, TradeAlignmentAgent, TradeAlignmentReport
-from .agents.analysis import AnalysisAgent
+from .agents.alignment import (
+    AlignmentAuditError,
+    AlignmentIssue,
+    TradeAlignmentAgent,
+    TradeAlignmentReport,
+)
+from .agents.analysis import AnalysisAgent, format_misalignment_prefix
 from .agents.ideation import IdeationAgent
 from .agents.refinement import RefinementAgent
 from .agents.zero_trade_repair import ZeroTradeRepairAgent
@@ -110,6 +115,50 @@ WINNING_THRESHOLD = 8.0
 # block. The model already trims to 20; 10 is enough signal for the LLM to
 # spot the failure pattern while keeping the JSON line under ~1 KB.
 _DIAGNOSTICS_LAST_EVENTS_CAP = 10
+
+
+def _resolve_alignment_report_for_analysis(
+    alignment_reports: List[TradeAlignmentReport],
+    *,
+    exit_rule_conformance_passed: bool,
+) -> Optional[TradeAlignmentReport]:
+    """Pick the alignment report fed into the analysis prompts.
+
+    Returns the most recent report from the alignment loop unless the
+    deterministic ``ExitRuleConformanceGate`` then vetoed publication after
+    the LLM audit had cleared the run — in which case a synthetic
+    misaligned report is substituted so the analysis prompt can't narrate
+    "audit clean" over the conformance veto (#532).
+
+    Returns ``None`` when the alignment loop never ran (no reports).
+    """
+    if not alignment_reports:
+        return None
+    latest = alignment_reports[-1]
+    if latest.aligned and not exit_rule_conformance_passed:
+        return TradeAlignmentReport(
+            aligned=False,
+            rationale=(
+                "ExitRuleConformanceGate vetoed publication: the LLM "
+                "alignment audit returned aligned=True, but the "
+                "deterministic conformance check then flagged "
+                "engine-enforced exit-rule violations in the final ledger "
+                "that the audit had missed."
+            ),
+            issues=[
+                AlignmentIssue(
+                    rule_type="exit_rules",
+                    severity="critical",
+                    description=(
+                        "ExitRuleConformanceGate failed: structured exit "
+                        "rules did not fire as required on at least one "
+                        "trade. Treat the executed trades as not a valid "
+                        "test of the spec."
+                    ),
+                )
+            ],
+        )
+    return latest
 
 
 class StrategyLabOrchestrator:
@@ -1424,11 +1473,17 @@ class StrategyLabOrchestrator:
             except Exception:
                 logger.exception("Analysis agent failed for %s", spec.strategy_id)
                 label = "winning" if is_winning else "losing"
-                return (
+                summary = (
                     f"Auto-summary: {spec.asset_class} strategy ({label}) with "
                     f"annualized return {metrics.annualized_return_pct:.1f}%. "
                     f"(Detailed narrative generation failed.)"
                 )
+                # When the agent raises before its internal _fallback_narrative
+                # path runs (model factory, prompt-file IO, etc.), the
+                # misalignment disclaimer would otherwise be lost on aligned=
+                # False runs (#532).
+                prefix = format_misalignment_prefix(alignment_report)
+                return f"{prefix}\n{summary}" if prefix else summary
         if not execution_succeeded:
             return (
                 f"Strategy failed to produce valid backtest results after "
@@ -1711,13 +1766,18 @@ class StrategyLabOrchestrator:
         metrics = verification.metrics
         is_winning = verification.is_winning
         # The other ``_VerificationOutcome`` fields (acceptance_results,
-        # walk_forward_failed, upstream_admitted, exit_rule_conformance_passed)
-        # are unused beyond this point — the verification phase already
-        # extended ``all_gate_results`` and mutated ``metrics.acceptance_reason``
-        # to carry every downstream-visible signal. The fields stay on the
-        # dataclass for callers that want to inspect the outcome directly.
+        # walk_forward_failed, upstream_admitted) are unused beyond this
+        # point — the verification phase already extended
+        # ``all_gate_results`` and mutated ``metrics.acceptance_reason`` to
+        # carry every downstream-visible signal. ``exit_rule_conformance_passed``
+        # is consumed inside ``_resolve_alignment_report_for_analysis`` to
+        # override the alignment report when the deterministic conformance
+        # gate vetoes a clean LLM audit (#532).
         # ── Phase 3: ANALYSIS ─────────────────────────────────────────
-        latest_alignment_report = alignment_reports[-1] if alignment_reports else None
+        latest_alignment_report = _resolve_alignment_report_for_analysis(
+            alignment_reports,
+            exit_rule_conformance_passed=verification.exit_rule_conformance_passed,
+        )
         narrative = self._run_analysis_phase(
             spec=spec,
             metrics=metrics,

--- a/backend/agents/investment_team/strategy_lab/prompts/analysis_lose.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/analysis_lose.md
@@ -21,11 +21,13 @@ Volatility: {volatility_pct:.1f}%
 ## Simulated trade ledger (evidence)
 {simulated_trades_section}
 
+{alignment_status_section}
 ## Instructions
 Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced for `StopLossRule` and `TakeProfitRule`: the parent engine emits closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. losing trades clustered near the stop-loss floor point to it firing). `SignalExitRule` entries in the list above are NOT yet engine-enforced — treat any predicate-based exit prose the same way as entry intent.
 Think step by step: what failure modes explain weak performance — signal timing, risk/reward asymmetry, cost drag, or rules misaligned with the market regime implied by the results?
 Use the trade-level evidence where it supports your reasoning.
 Write 5-8 sentences. Be specific about *why* this strategy underperformed.
+If an "Alignment status" section above marks the run as misaligned, you MUST open with the disclaimer verbatim and treat the strategy design as untested. Do not attribute the weak performance to any design choice; describe the execution gaps factually and recommend re-running once aligned.
 
 Return ONLY JSON with no markdown:
 {{"draft_narrative": "your draft analysis"}}

--- a/backend/agents/investment_team/strategy_lab/prompts/analysis_win.md
+++ b/backend/agents/investment_team/strategy_lab/prompts/analysis_win.md
@@ -21,11 +21,13 @@ Volatility: {volatility_pct:.1f}%
 ## Simulated trade ledger (evidence)
 {simulated_trades_section}
 
+{alignment_status_section}
 ## Instructions
 Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced for `StopLossRule` and `TakeProfitRule`: the parent engine emits closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. losing trades clustered near the stop-loss floor point to it firing). `SignalExitRule` entries in the list above are NOT yet engine-enforced — treat any predicate-based exit prose the same way as entry intent.
 Think step by step: what in the strategy design plausibly produced strong risk-adjusted returns?
 Relate the hypothesis and rules to (1) Sharpe/drawdown/volatility, (2) win rate vs profit factor, (3) patterns in the simulated trades (hold periods, win/loss mix, concentration).
 Write 5-8 sentences. Be specific — avoid generic praise. Explain *why* this strategy class succeeded in this backtest.
+If an "Alignment status" section above marks the run as misaligned, you MUST open with the disclaimer verbatim and treat the strategy design as untested. Do not claim it worked or failed because of any design choice; describe the execution gaps factually and recommend re-running once aligned.
 
 Return ONLY JSON with no markdown:
 {{"draft_narrative": "your draft analysis"}}

--- a/backend/agents/investment_team/tests/golden/snapshots/prompt_analysis_lose_misaligned.txt
+++ b/backend/agents/investment_team/tests/golden/snapshots/prompt_analysis_lose_misaligned.txt
@@ -22,8 +22,20 @@ Volatility: 22.4%
 Trade 1: BUY AAA on 2024-01-15 @ 100.00, SELL on 2024-01-25 @ 102.50 (+2.5%)
 Trade 2: BUY BBB on 2024-02-01 @ 50.00, SELL on 2024-02-11 @ 49.00 (-2.0%)
 
-## Alignment status
-The executed trades faithfully implement the specification (alignment audit clean).
+## Alignment status — TRADES DID NOT IMPLEMENT THE SPEC
+
+Disclaimer to surface in the narrative: "The executed trades did not faithfully implement the specification; interpretation is preliminary."
+
+Concrete alignment issues (facts; do not paraphrase away):
+- [critical] exit_rules: stop-loss did not fire on trade #1 despite -8% drawdown
+- [warning] universe: trade #2 used symbol BBB which is outside the spec universe
+
+Audit rationale: Two trades skipped the stop-loss; one trade entered a symbol outside the spec universe.
+
+Constraints for this analysis:
+- DO open the narrative with the disclaimer above.
+- DO NOT make causal claims about strategy design (e.g. "worked because of X", "failed because of Y") — the trades are not a valid test of the spec.
+- DO describe execution gaps factually and recommend re-running once aligned.
 
 ## Instructions
 Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced for `StopLossRule` and `TakeProfitRule`: the parent engine emits closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. losing trades clustered near the stop-loss floor point to it firing). `SignalExitRule` entries in the list above are NOT yet engine-enforced — treat any predicate-based exit prose the same way as entry intent.

--- a/backend/agents/investment_team/tests/golden/snapshots/prompt_analysis_win.txt
+++ b/backend/agents/investment_team/tests/golden/snapshots/prompt_analysis_win.txt
@@ -22,11 +22,15 @@ Volatility: 14.2%
 Trade 1: BUY AAA on 2024-01-15 @ 100.00, SELL on 2024-01-25 @ 102.50 (+2.5%)
 Trade 2: BUY BBB on 2024-02-01 @ 50.00, SELL on 2024-02-11 @ 49.00 (-2.0%)
 
+## Alignment status
+The executed trades faithfully implement the specification (alignment audit clean).
+
 ## Instructions
 Entry rules above are prose intent only — describe whether trade behaviour was consistent with the intent rather than asserting that trades "violated" them. Exit rules ARE engine-enforced for `StopLossRule` and `TakeProfitRule`: the parent engine emits closes on the strategy's behalf, so attribute observed exit timing to those rules where evidence supports it (e.g. losing trades clustered near the stop-loss floor point to it firing). `SignalExitRule` entries in the list above are NOT yet engine-enforced — treat any predicate-based exit prose the same way as entry intent.
 Think step by step: what in the strategy design plausibly produced strong risk-adjusted returns?
 Relate the hypothesis and rules to (1) Sharpe/drawdown/volatility, (2) win rate vs profit factor, (3) patterns in the simulated trades (hold periods, win/loss mix, concentration).
 Write 5-8 sentences. Be specific — avoid generic praise. Explain *why* this strategy class succeeded in this backtest.
+If an "Alignment status" section above marks the run as misaligned, you MUST open with the disclaimer verbatim and treat the strategy design as untested. Do not claim it worked or failed because of any design choice; describe the execution gaps factually and recommend re-running once aligned.
 
 Return ONLY JSON with no markdown:
 {"draft_narrative": "your draft analysis"}

--- a/backend/agents/investment_team/tests/test_analysis_agent_verdict.py
+++ b/backend/agents/investment_team/tests/test_analysis_agent_verdict.py
@@ -25,6 +25,8 @@ import json
 from pathlib import Path
 from typing import Any, List
 
+import pytest
+
 from investment_team.models import BacktestResult, StrategySpec
 from investment_team.strategy_lab.agents import analysis as analysis_module
 from investment_team.strategy_lab.agents.alignment import (
@@ -307,3 +309,144 @@ def test_no_alignment_report_omits_section_entirely(monkeypatch):
     assert "## Alignment status" not in prompts
     assert "TRADES DID NOT IMPLEMENT THE SPEC" not in prompts
     assert "alignment audit clean" not in prompts
+
+
+# ---------------------------------------------------------------------------
+# Issue #532 (Codex follow-up): the deterministic fallback narrative must
+# carry the misalignment disclaimer + issues forward when the LLM draft path
+# fails. Otherwise a fail-closed audit error or transient draft outage would
+# publish a confident auto-summary on a run that didn't implement the spec.
+# ---------------------------------------------------------------------------
+
+
+def _install_failing_draft_recorder(monkeypatch, *, mode: str) -> _Recorder:
+    """Patch ``strands.Agent`` so the FIRST call (draft phase) fails per
+    ``mode`` and any subsequent call (self-review) returns a normal
+    response. Mirrors the production failure modes Codex flagged:
+
+    * ``raise``  — draft LLM call raises
+    * ``junk``   — draft returns non-JSON text (``_extract_json`` raises)
+    * ``empty``  — draft returns valid JSON with an empty ``draft_narrative``
+    """
+
+    rec = _Recorder()
+
+    class _FailingDraftAgent:
+        _call_count = 0
+
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        def __call__(self, prompt: str) -> str:
+            rec.prompts.append(prompt)
+            _FailingDraftAgent._call_count += 1
+            if _FailingDraftAgent._call_count == 1:
+                if mode == "raise":
+                    raise RuntimeError("simulated draft transport failure")
+                if mode == "junk":
+                    return "this is not json"
+                if mode == "empty":
+                    return json.dumps({"draft_narrative": ""})
+                raise AssertionError(f"unknown mode {mode!r}")
+            return rec.render_response()
+
+    monkeypatch.setattr(analysis_module, "Agent", _FailingDraftAgent)
+    monkeypatch.setattr(analysis_module, "get_strands_model", lambda _name: None)
+    return rec
+
+
+_MISALIGNED_REPORT = TradeAlignmentReport(
+    aligned=False,
+    rationale="Stop-loss skipped; trade entered outside the universe.",
+    issues=[
+        AlignmentIssue(
+            rule_type="exit_rules",
+            severity="critical",
+            description="stop-loss did not fire on trade #4 despite -8% drawdown",
+            affected_trades=[4],
+        ),
+        AlignmentIssue(
+            rule_type="universe",
+            severity="warning",
+            description="trade #7 used symbol outside the spec universe",
+            affected_trades=[7],
+        ),
+    ],
+)
+
+
+def _assert_misaligned_fallback(narrative: str) -> None:
+    assert (
+        "The executed trades did not faithfully implement the specification; "
+        "interpretation is preliminary." in narrative
+    ), "Fallback narrative dropped the misalignment disclaimer (issue #532)."
+    for issue in _MISALIGNED_REPORT.issues:
+        assert issue.description in narrative, (
+            f"Fallback narrative dropped alignment issue {issue.description!r} (issue #532)."
+        )
+    assert "Detailed narrative generation failed" in narrative, (
+        "Fallback narrative dropped the deterministic auto-summary tail."
+    )
+
+
+@pytest.mark.parametrize(
+    "mode", ["raise", "junk", "empty"], ids=["draft_raises", "draft_junk", "draft_empty"]
+)
+def test_misaligned_disclaimer_survives_draft_failure(monkeypatch, mode):
+    """Codex review on #532: when ``aligned=False`` and the draft LLM call
+    raises, returns unparseable JSON, or yields an empty narrative, the
+    deterministic fallback must still surface the disclaimer + each audit
+    issue so misaligned runs cannot publish a clean auto-summary."""
+
+    _install_failing_draft_recorder(monkeypatch, mode=mode)
+
+    narrative = AnalysisAgent().run(
+        _spec(),
+        _high_return_metrics(),
+        trades=[],
+        rationale="rationale",
+        is_winning=False,
+        alignment_report=_MISALIGNED_REPORT,
+    )
+
+    _assert_misaligned_fallback(narrative)
+
+
+def test_aligned_fallback_unchanged_on_draft_failure(monkeypatch):
+    """Aligned (or absent) reports must not inject any disclaimer into the
+    fallback narrative — keeps clean runs byte-identical to pre-#532
+    behaviour when the LLM happens to fail."""
+
+    _install_failing_draft_recorder(monkeypatch, mode="raise")
+
+    narrative = AnalysisAgent().run(
+        _spec(),
+        _high_return_metrics(),
+        trades=[],
+        rationale="rationale",
+        is_winning=True,
+        alignment_report=TradeAlignmentReport(aligned=True),
+    )
+
+    assert "did not faithfully implement the specification" not in narrative
+    assert "Alignment issues:" not in narrative
+    assert "Detailed narrative generation failed" in narrative
+
+
+def test_no_report_fallback_unchanged_on_draft_failure(monkeypatch):
+    """Legacy callers (no ``alignment_report``) get the original fallback
+    text byte-for-byte — back-compat guard."""
+
+    _install_failing_draft_recorder(monkeypatch, mode="empty")
+
+    narrative = AnalysisAgent().run(
+        _spec(),
+        _high_return_metrics(),
+        trades=[],
+        rationale="rationale",
+        is_winning=True,
+    )
+
+    assert "did not faithfully implement the specification" not in narrative
+    assert "Alignment issues:" not in narrative
+    assert "Detailed narrative generation failed" in narrative

--- a/backend/agents/investment_team/tests/test_analysis_agent_verdict.py
+++ b/backend/agents/investment_team/tests/test_analysis_agent_verdict.py
@@ -519,18 +519,29 @@ def test_misaligned_disclaimer_prepended_when_revised_drops_it(monkeypatch):
     assert "strong trend persistence" in narrative
 
 
-def test_misaligned_disclaimer_not_duplicated_when_opening_with_it(monkeypatch):
-    """If the LLM opens the narrative with the disclaimer verbatim, the
-    deterministic safety rail must NOT prepend a second copy — compliant
-    runs stay byte-identical."""
+def test_misaligned_no_modification_when_disclaimer_and_all_issues_present(monkeypatch):
+    """Fully-compliant LLM output (opens with the disclaimer AND includes
+    every concrete ``AlignmentIssue.description`` somewhere in the body)
+    must pass through the rail byte-identically — no duplicated
+    disclaimer, no appended issues block."""
 
     disclaimer = (
         "The executed trades did not faithfully implement the specification; "
         "interpretation is preliminary."
     )
+    # Fully compliant — opens with the disclaimer and mentions every issue.
     compliant_body = (
-        f"{disclaimer} The trades skipped the configured stop-loss; rerun once aligned."
+        f"{disclaimer} Specifically: "
+        "stop-loss did not fire on trade #4 despite -8% drawdown, "
+        "and trade #7 used symbol outside the spec universe. "
+        "Rerun once aligned."
     )
+    # Sanity-check the fixture so a refactor of _MISALIGNED_REPORT.issues
+    # surfaces in this test rather than as silent rail behaviour drift.
+    for issue in _MISALIGNED_REPORT.issues:
+        assert issue.description in compliant_body, (
+            f"Test fixture out of sync: {issue.description!r} missing from compliant_body."
+        )
 
     _install_compliant_review_recorder(monkeypatch, draft_body=compliant_body)
 
@@ -544,9 +555,84 @@ def test_misaligned_disclaimer_not_duplicated_when_opening_with_it(monkeypatch):
     )
 
     assert narrative.count(disclaimer) == 1
-    # The enumerated "Alignment issues:" block from format_misalignment_prefix
-    # must NOT be injected when the LLM already opened with the disclaimer.
-    assert "Alignment issues:\n- [" not in narrative
+    # Neither the prepend prefix nor the deterministic-append block must fire.
+    assert "Alignment issues:" not in narrative
+    assert "deterministically appended" not in narrative
+
+
+def test_misaligned_issues_appended_when_llm_opens_but_drops_issues(monkeypatch):
+    """Codex on PR #584 (commit 3518419): the LLM may open with the
+    disclaimer perfectly but then drop every concrete alignment issue
+    from the body. The rail must deterministically append the missing
+    issues so operators always see the audit facts — otherwise a
+    disclaimer-opening narrative could still bury the substance."""
+
+    disclaimer = (
+        "The executed trades did not faithfully implement the specification; "
+        "interpretation is preliminary."
+    )
+    # LLM opens with the disclaimer but otherwise paraphrases vaguely
+    # without naming any of the concrete issues.
+    partial_body = (
+        f"{disclaimer} The trades diverged from the design in subtle ways. Rerun once aligned."
+    )
+
+    _install_compliant_review_recorder(monkeypatch, draft_body=partial_body)
+
+    narrative = AnalysisAgent().run(
+        _spec(),
+        _high_return_metrics(),
+        trades=[],
+        rationale="rationale",
+        is_winning=False,
+        alignment_report=_MISALIGNED_REPORT,
+    )
+
+    # Disclaimer still opens (rail didn't prepend a second one).
+    assert narrative.lstrip().startswith(disclaimer)
+    assert narrative.count(disclaimer) == 1
+    # Each missing issue must have been deterministically appended.
+    assert "Alignment issues (deterministically appended):" in narrative
+    for issue in _MISALIGNED_REPORT.issues:
+        assert issue.description in narrative
+
+
+def test_misaligned_only_missing_issues_appended(monkeypatch):
+    """If the LLM mentions *some* issues verbatim but drops others, only
+    the dropped ones must be appended — the rail must not duplicate
+    issues the LLM already surfaced."""
+
+    disclaimer = (
+        "The executed trades did not faithfully implement the specification; "
+        "interpretation is preliminary."
+    )
+    # LLM mentions issue #1 verbatim but drops issue #2.
+    mentioned_issue = _MISALIGNED_REPORT.issues[0]
+    dropped_issue = _MISALIGNED_REPORT.issues[1]
+    partial_body = (
+        f"{disclaimer} The audit noted: {mentioned_issue.description}. Rerun once aligned."
+    )
+
+    _install_compliant_review_recorder(monkeypatch, draft_body=partial_body)
+
+    narrative = AnalysisAgent().run(
+        _spec(),
+        _high_return_metrics(),
+        trades=[],
+        rationale="rationale",
+        is_winning=False,
+        alignment_report=_MISALIGNED_REPORT,
+    )
+
+    # Mentioned issue must appear exactly once (LLM body); dropped issue
+    # must appear once (deterministic append).
+    assert narrative.count(mentioned_issue.description) == 1
+    assert narrative.count(dropped_issue.description) == 1
+    # The deterministic-append block must list ONLY the dropped issue.
+    append_idx = narrative.index("Alignment issues (deterministically appended):")
+    appended_block = narrative[append_idx:]
+    assert dropped_issue.description in appended_block
+    assert mentioned_issue.description not in appended_block
 
 
 def test_misaligned_disclaimer_enforced_when_buried_mid_narrative(monkeypatch):

--- a/backend/agents/investment_team/tests/test_analysis_agent_verdict.py
+++ b/backend/agents/investment_team/tests/test_analysis_agent_verdict.py
@@ -450,3 +450,173 @@ def test_no_report_fallback_unchanged_on_draft_failure(monkeypatch):
     assert "did not faithfully implement the specification" not in narrative
     assert "Alignment issues:" not in narrative
     assert "Detailed narrative generation failed" in narrative
+
+
+# ---------------------------------------------------------------------------
+# Issue #532 Codex follow-up (PR #584): the LLM cannot be trusted to follow
+# the "open with the disclaimer verbatim" instruction, and the self-review
+# pass meant to enforce it can itself fail. ``_ensure_misalignment_disclaimer``
+# is the deterministic safety rail that prepends the prefix on misaligned
+# runs whenever the published narrative is missing the disclaimer string.
+# ---------------------------------------------------------------------------
+
+
+def _install_compliant_review_recorder(monkeypatch, *, draft_body: str) -> _Recorder:
+    """Stubs ``strands.Agent`` so the FIRST call (draft) returns
+    ``draft_body`` (the test controls whether it contains the disclaimer)
+    and the SECOND call (self-review) returns a revised narrative that
+    echoes the draft. Captures both prompts in the recorder."""
+
+    rec = _Recorder()
+
+    class _StubAgent:
+        _call_count = 0
+
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        def __call__(self, prompt: str) -> str:
+            rec.prompts.append(prompt)
+            _StubAgent._call_count += 1
+            if _StubAgent._call_count == 1:
+                return json.dumps({"draft_narrative": draft_body})
+            # Self-review echoes the draft verbatim — exercises the
+            # "LLM ignored the disclaimer instruction" failure mode.
+            return json.dumps({"revised_narrative": draft_body, "verification_notes": "echoed"})
+
+    monkeypatch.setattr(analysis_module, "Agent", _StubAgent)
+    monkeypatch.setattr(analysis_module, "get_strands_model", lambda _name: None)
+    return rec
+
+
+def test_misaligned_disclaimer_prepended_when_revised_drops_it(monkeypatch):
+    """Codex on PR #584: even when self-review succeeds, the LLM can ignore
+    the disclaimer instruction. The agent must deterministically prepend
+    the prefix when the revised narrative is missing the disclaimer
+    string so a non-compliant LLM cannot publish a clean narrative on a
+    misaligned run."""
+
+    _install_compliant_review_recorder(
+        monkeypatch,
+        draft_body="The strategy succeeded because of strong trend persistence.",
+    )
+
+    narrative = AnalysisAgent().run(
+        _spec(),
+        _high_return_metrics(),
+        trades=[],
+        rationale="rationale",
+        is_winning=False,
+        alignment_report=_MISALIGNED_REPORT,
+    )
+
+    assert (
+        "The executed trades did not faithfully implement the specification; "
+        "interpretation is preliminary." in narrative
+    )
+    for issue in _MISALIGNED_REPORT.issues:
+        assert issue.description in narrative
+    assert "strong trend persistence" in narrative
+
+
+def test_misaligned_disclaimer_not_duplicated_when_already_present(monkeypatch):
+    """If the LLM did include the disclaimer verbatim, the deterministic
+    safety rail must NOT prepend a second copy — otherwise compliant runs
+    get a duplicated header that looks broken to operators."""
+
+    disclaimer = (
+        "The executed trades did not faithfully implement the specification; "
+        "interpretation is preliminary."
+    )
+    compliant_body = (
+        f"{disclaimer} The trades skipped the configured stop-loss; rerun once aligned."
+    )
+
+    _install_compliant_review_recorder(monkeypatch, draft_body=compliant_body)
+
+    narrative = AnalysisAgent().run(
+        _spec(),
+        _high_return_metrics(),
+        trades=[],
+        rationale="rationale",
+        is_winning=False,
+        alignment_report=_MISALIGNED_REPORT,
+    )
+
+    assert narrative.count(disclaimer) == 1
+    # The enumerated "Alignment issues:" block from format_misalignment_prefix
+    # must NOT be injected when the disclaimer is already present, otherwise
+    # we'd be appending audit content the LLM may have already summarized.
+    assert "Alignment issues:\n- [" not in narrative
+
+
+def test_misaligned_disclaimer_enforced_when_review_fails(monkeypatch):
+    """Codex's specific scenario: the self-review LLM call raises (or
+    returns junk), and the agent returns the draft as-is. If the draft
+    ignored the disclaimer instruction the safety rail must still
+    enforce it deterministically."""
+
+    rec = _Recorder()
+
+    class _FailingReviewAgent:
+        _call_count = 0
+
+        def __init__(self, *_: Any, **__: Any) -> None:
+            pass
+
+        def __call__(self, prompt: str) -> str:
+            rec.prompts.append(prompt)
+            _FailingReviewAgent._call_count += 1
+            if _FailingReviewAgent._call_count == 1:
+                return json.dumps(
+                    {
+                        "draft_narrative": (
+                            "The strategy underperformed because of slow regime adaptation."
+                        )
+                    }
+                )
+            raise RuntimeError("simulated review transport failure")
+
+    monkeypatch.setattr(analysis_module, "Agent", _FailingReviewAgent)
+    monkeypatch.setattr(analysis_module, "get_strands_model", lambda _name: None)
+
+    narrative = AnalysisAgent().run(
+        _spec(),
+        _high_return_metrics(),
+        trades=[],
+        rationale="rationale",
+        is_winning=False,
+        alignment_report=_MISALIGNED_REPORT,
+    )
+
+    assert (
+        "The executed trades did not faithfully implement the specification; "
+        "interpretation is preliminary." in narrative
+    )
+    for issue in _MISALIGNED_REPORT.issues:
+        assert issue.description in narrative
+    assert "slow regime adaptation" in narrative
+
+
+def test_aligned_runs_skip_disclaimer_enforcement(monkeypatch):
+    """The safety rail must no-op on aligned (and no-report) runs — clean
+    runs stay byte-identical to pre-#532 behaviour even if the LLM happens
+    to mention an aligned strategy in non-disclaimer terms."""
+
+    _install_compliant_review_recorder(
+        monkeypatch,
+        draft_body="The strategy worked because of clear trend signals.",
+    )
+
+    narrative = AnalysisAgent().run(
+        _spec(),
+        _high_return_metrics(),
+        trades=[],
+        rationale="rationale",
+        is_winning=True,
+        alignment_report=TradeAlignmentReport(aligned=True),
+    )
+
+    assert "did not faithfully implement the specification" not in narrative
+    assert "Alignment issues:" not in narrative
+    assert "clear trend signals" in narrative

--- a/backend/agents/investment_team/tests/test_analysis_agent_verdict.py
+++ b/backend/agents/investment_team/tests/test_analysis_agent_verdict.py
@@ -519,10 +519,10 @@ def test_misaligned_disclaimer_prepended_when_revised_drops_it(monkeypatch):
     assert "strong trend persistence" in narrative
 
 
-def test_misaligned_disclaimer_not_duplicated_when_already_present(monkeypatch):
-    """If the LLM did include the disclaimer verbatim, the deterministic
-    safety rail must NOT prepend a second copy — otherwise compliant runs
-    get a duplicated header that looks broken to operators."""
+def test_misaligned_disclaimer_not_duplicated_when_opening_with_it(monkeypatch):
+    """If the LLM opens the narrative with the disclaimer verbatim, the
+    deterministic safety rail must NOT prepend a second copy — compliant
+    runs stay byte-identical."""
 
     disclaimer = (
         "The executed trades did not faithfully implement the specification; "
@@ -545,9 +545,52 @@ def test_misaligned_disclaimer_not_duplicated_when_already_present(monkeypatch):
 
     assert narrative.count(disclaimer) == 1
     # The enumerated "Alignment issues:" block from format_misalignment_prefix
-    # must NOT be injected when the disclaimer is already present, otherwise
-    # we'd be appending audit content the LLM may have already summarized.
+    # must NOT be injected when the LLM already opened with the disclaimer.
     assert "Alignment issues:\n- [" not in narrative
+
+
+def test_misaligned_disclaimer_enforced_when_buried_mid_narrative(monkeypatch):
+    """Codex on PR #584 (commit 2c8fcf3): a containment-only check would
+    accept narratives that mention the disclaimer *later* in the body but
+    open with a confident/causal claim. The safety rail must require the
+    disclaimer to OPEN the narrative — anything else gets the full
+    prefix prepended."""
+
+    disclaimer = (
+        "The executed trades did not faithfully implement the specification; "
+        "interpretation is preliminary."
+    )
+    # LLM puts a causal claim first, then mentions the disclaimer later —
+    # exactly the bypass Codex flagged.
+    buried_body = (
+        f"The strategy succeeded because of strong trend persistence. (Aside: {disclaimer})"
+    )
+
+    _install_compliant_review_recorder(monkeypatch, draft_body=buried_body)
+
+    narrative = AnalysisAgent().run(
+        _spec(),
+        _high_return_metrics(),
+        trades=[],
+        rationale="rationale",
+        is_winning=False,
+        alignment_report=_MISALIGNED_REPORT,
+    )
+
+    # The safety rail must have prepended the full prefix — narrative
+    # opens with the disclaimer, not the causal claim.
+    assert narrative.lstrip().startswith(disclaimer), (
+        "Misaligned narrative must OPEN with the disclaimer; a containment-"
+        "only check would let a causal claim slip in first (Codex PR #584)."
+    )
+    # And the alignment issues must precede the LLM's causal body.
+    causal_idx = narrative.index("strong trend persistence")
+    for issue in _MISALIGNED_REPORT.issues:
+        issue_idx = narrative.index(issue.description)
+        assert issue_idx < causal_idx, (
+            f"Alignment issue {issue.description!r} must appear before "
+            "the LLM's causal claim, not after."
+        )
 
 
 def test_misaligned_disclaimer_enforced_when_review_fails(monkeypatch):

--- a/backend/agents/investment_team/tests/test_analysis_agent_verdict.py
+++ b/backend/agents/investment_team/tests/test_analysis_agent_verdict.py
@@ -27,6 +27,10 @@ from typing import Any, List
 
 from investment_team.models import BacktestResult, StrategySpec
 from investment_team.strategy_lab.agents import analysis as analysis_module
+from investment_team.strategy_lab.agents.alignment import (
+    AlignmentIssue,
+    TradeAlignmentReport,
+)
 from investment_team.strategy_lab.agents.analysis import AnalysisAgent
 from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
@@ -198,3 +202,108 @@ def test_analysis_agent_falls_back_to_metric_heuristic_when_unset(monkeypatch):
     assert "analysis_lose.md" not in rec.read_files
     prompts = "\n\n".join(rec.prompts)
     assert "Outcome label: WINNING" in prompts
+
+
+def test_misaligned_alignment_report_threads_disclaimer_into_draft_and_review(
+    monkeypatch,
+):
+    """Issue #532: when the orchestrator passes an ``alignment_report`` with
+    ``aligned=False``, both the draft template prompt and the self-review
+    prompt must surface the disclaimer + each concrete issue description.
+    Without this the LLM keeps writing confident causal narratives even when
+    the trades didn't implement the spec."""
+
+    rec = _install_recorder(monkeypatch)
+
+    report = TradeAlignmentReport(
+        aligned=False,
+        rationale="Stop-loss skipped; trade entered outside the universe.",
+        issues=[
+            AlignmentIssue(
+                rule_type="exit_rules",
+                severity="critical",
+                description="stop-loss did not fire on trade #4 despite -8% drawdown",
+                affected_trades=[4],
+            ),
+            AlignmentIssue(
+                rule_type="universe",
+                severity="warning",
+                description="trade #7 used symbol outside the spec universe",
+                affected_trades=[7],
+            ),
+        ],
+    )
+
+    AnalysisAgent().run(
+        _spec(),
+        _high_return_metrics(),
+        trades=[],
+        rationale="rationale",
+        is_winning=False,
+        alignment_report=report,
+    )
+
+    # Two prompts are expected: draft (Phase 1) and self-review (Phase 2).
+    assert len(rec.prompts) == 2, (
+        f"Expected exactly two LLM calls (draft + self-review); got {len(rec.prompts)}."
+    )
+    for label, prompt in zip(("draft", "self-review"), rec.prompts):
+        assert "TRADES DID NOT IMPLEMENT THE SPEC" in prompt, (
+            f"{label} prompt missing misalignment header (issue #532)."
+        )
+        assert (
+            "The executed trades did not faithfully implement the specification; "
+            "interpretation is preliminary." in prompt
+        ), f"{label} prompt missing verbatim disclaimer (issue #532)."
+        for issue in report.issues:
+            assert issue.description in prompt, (
+                f"{label} prompt dropped alignment issue {issue.description!r} (issue #532)."
+            )
+        assert "DO NOT make causal claims about strategy design" in prompt, (
+            f"{label} prompt missing 'no causal claims' instruction (issue #532)."
+        )
+
+
+def test_aligned_report_does_not_inject_disclaimer(monkeypatch):
+    """Issue #532: ``aligned=True`` must NOT inject the misalignment
+    disclaimer into either prompt (winning runs aren't disclaimed)."""
+
+    rec = _install_recorder(monkeypatch)
+
+    AnalysisAgent().run(
+        _spec(),
+        _high_return_metrics(),
+        trades=[],
+        rationale="rationale",
+        is_winning=True,
+        alignment_report=TradeAlignmentReport(aligned=True),
+    )
+
+    prompts = "\n\n".join(rec.prompts)
+    assert "TRADES DID NOT IMPLEMENT THE SPEC" not in prompts
+    assert "did not faithfully implement the specification" not in prompts
+    # The one-line clean affirmation IS expected on aligned runs.
+    assert "alignment audit clean" in prompts
+
+
+def test_no_alignment_report_omits_section_entirely(monkeypatch):
+    """Issue #532: legacy callers (and the orchestrator fallback path that
+    runs without any alignment report) must produce prompts that contain
+    neither the disclaimer nor the clean affirmation — just the legacy
+    body, byte-for-byte minus the empty placeholder."""
+
+    rec = _install_recorder(monkeypatch)
+
+    AnalysisAgent().run(
+        _spec(),
+        _high_return_metrics(),
+        trades=[],
+        rationale="rationale",
+        is_winning=True,
+        # alignment_report omitted (defaults to None)
+    )
+
+    prompts = "\n\n".join(rec.prompts)
+    assert "## Alignment status" not in prompts
+    assert "TRADES DID NOT IMPLEMENT THE SPEC" not in prompts
+    assert "alignment audit clean" not in prompts

--- a/backend/agents/investment_team/tests/test_analysis_alignment_prompts.py
+++ b/backend/agents/investment_team/tests/test_analysis_alignment_prompts.py
@@ -37,6 +37,7 @@ from investment_team.strategy_lab.agents.alignment import (
 from investment_team.strategy_lab.agents.analysis import (
     _PROMPT_DIR,
     _format_alignment_status_section,
+    format_misalignment_prefix,
 )
 from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
@@ -411,3 +412,45 @@ def test_analysis_templates_expose_alignment_placeholder(label: str, template_fi
     assert "{alignment_status_section}" in template, (
         f"{label} template missing {{alignment_status_section}} placeholder (issue #532)."
     )
+
+
+# ---------------------------------------------------------------------------
+# format_misalignment_prefix: shared between the agent fallback and the
+# orchestrator-level analysis-phase exception handler so the disclaimer can't
+# disappear via either fallback path (PR #584 Codex review).
+# ---------------------------------------------------------------------------
+
+
+def test_misalignment_prefix_empty_for_none() -> None:
+    assert format_misalignment_prefix(None) == ""
+
+
+def test_misalignment_prefix_empty_for_aligned() -> None:
+    assert format_misalignment_prefix(TradeAlignmentReport(aligned=True)) == ""
+
+
+def test_misalignment_prefix_lists_disclaimer_and_issues() -> None:
+    """Misaligned reports must emit the disclaimer first, then the
+    enumerated issues — anything else risks the prefix being silently
+    paraphrased away by downstream consumers."""
+    report = _misaligned_report()
+    prefix = format_misalignment_prefix(report)
+    lines = prefix.split("\n")
+    assert lines[0] == (
+        "The executed trades did not faithfully implement the "
+        "specification; interpretation is preliminary."
+    )
+    assert "Alignment issues:" in lines
+    for issue in report.issues:
+        assert any(
+            line == f"- [{issue.severity}] {issue.rule_type}: {issue.description}" for line in lines
+        ), f"Issue {issue.description!r} missing or malformed in prefix."
+
+
+def test_misalignment_prefix_handles_empty_issue_list() -> None:
+    """A degenerate ``aligned=False`` report with no enumerated issues
+    must still emit the disclaimer (so fail-closed alignment retries
+    can't slip through with a clean prefix)."""
+    prefix = format_misalignment_prefix(TradeAlignmentReport(aligned=False))
+    assert prefix.startswith("The executed trades did not faithfully implement the specification")
+    assert "Alignment issues:" not in prefix

--- a/backend/agents/investment_team/tests/test_analysis_alignment_prompts.py
+++ b/backend/agents/investment_team/tests/test_analysis_alignment_prompts.py
@@ -30,7 +30,14 @@ from pathlib import Path
 
 import pytest
 
-from investment_team.strategy_lab.agents.analysis import _PROMPT_DIR
+from investment_team.strategy_lab.agents.alignment import (
+    AlignmentIssue,
+    TradeAlignmentReport,
+)
+from investment_team.strategy_lab.agents.analysis import (
+    _PROMPT_DIR,
+    _format_alignment_status_section,
+)
 from investment_team.strategy_lab.spec_dsl import (
     EntryRule,
     FixedFractionSizing,
@@ -80,7 +87,35 @@ def _render_inputs() -> dict[str, object]:
             "Trade 1: BUY AAA on 2024-01-15 @ 100.00, SELL on 2024-01-25 @ 102.50 (+2.5%)\n"
             "Trade 2: BUY BBB on 2024-02-01 @ 50.00, SELL on 2024-02-11 @ 49.00 (-2.0%)"
         ),
+        "alignment_status_section": _format_alignment_status_section(
+            TradeAlignmentReport(aligned=True)
+        ),
     }
+
+
+def _misaligned_report() -> TradeAlignmentReport:
+    """Stable misaligned fixture for the analysis-prompt golden tests."""
+    return TradeAlignmentReport(
+        aligned=False,
+        rationale=(
+            "Two trades skipped the stop-loss; one trade entered a symbol "
+            "outside the spec universe."
+        ),
+        issues=[
+            AlignmentIssue(
+                rule_type="exit_rules",
+                severity="critical",
+                description="stop-loss did not fire on trade #1 despite -8% drawdown",
+                affected_trades=[1],
+            ),
+            AlignmentIssue(
+                rule_type="universe",
+                severity="warning",
+                description="trade #2 used symbol BBB which is outside the spec universe",
+                affected_trades=[2],
+            ),
+        ],
+    )
 
 
 def _render_win() -> str:
@@ -105,6 +140,24 @@ def _render_lose() -> str:
     return template.format(**inputs)
 
 
+def _render_lose_misaligned() -> str:
+    template = (_PROMPT_DIR / "analysis_lose.md").read_text(encoding="utf-8")
+    inputs = _render_inputs()
+    inputs.update(
+        {
+            "annualized_return_pct": 3.1,
+            "total_return_pct": 4.2,
+            "sharpe_ratio": 0.42,
+            "max_drawdown_pct": 18.7,
+            "win_rate_pct": 38.0,
+            "profit_factor": 0.95,
+            "volatility_pct": 22.4,
+            "alignment_status_section": _format_alignment_status_section(_misaligned_report()),
+        }
+    )
+    return template.format(**inputs)
+
+
 def _render_alignment_system() -> str:
     return (_PROMPT_DIR / "alignment_system.md").read_text(encoding="utf-8")
 
@@ -114,6 +167,10 @@ _PromptRenderer = Callable[[], str]
 _RENDERERS: dict[str, tuple[str, _PromptRenderer]] = {
     "prompt_analysis_win.txt": ("analysis_win", _render_win),
     "prompt_analysis_lose.txt": ("analysis_lose", _render_lose),
+    "prompt_analysis_lose_misaligned.txt": (
+        "analysis_lose_misaligned",
+        _render_lose_misaligned,
+    ),
     "prompt_alignment_system.txt": ("alignment_system", _render_alignment_system),
 }
 
@@ -279,4 +336,78 @@ def test_no_mandatory_when_hold_days_mismatch() -> None:
     # The template itself must not introduce "mandatory" phrasing.
     assert not re.search(r"\bmandatory\b", rendered, flags=re.IGNORECASE), (
         "analysis_lose.md re-introduced 'mandatory' wording (issue #528)."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Issue #532: alignment status threaded into analysis prompts
+# ---------------------------------------------------------------------------
+
+
+def test_alignment_section_empty_when_no_report() -> None:
+    """Issue #532: callers that don't pass an ``alignment_report`` get an
+    empty section so legacy behaviour is preserved byte-for-byte."""
+    assert _format_alignment_status_section(None) == ""
+
+
+def test_aligned_section_contains_clean_affirmation() -> None:
+    """Issue #532: ``aligned=True`` produces a one-line audit-clean
+    affirmation rather than the disclaimer block, so winning runs aren't
+    accidentally injected with a misleading misalignment notice."""
+    rendered = _format_alignment_status_section(TradeAlignmentReport(aligned=True))
+    assert "## Alignment status" in rendered
+    assert "audit clean" in rendered
+    assert "did not faithfully implement" not in rendered
+    assert "DO NOT make causal claims" not in rendered
+
+
+def test_misaligned_section_contains_disclaimer_and_issues() -> None:
+    """Issue #532: ``aligned=False`` must surface the disclaimer verbatim,
+    enumerate every audit issue, and forbid causal claims about the design.
+    Guards the safety-rail wording so refactors of the section don't
+    silently delete it.
+    """
+    report = _misaligned_report()
+    rendered = _format_alignment_status_section(report)
+    assert "TRADES DID NOT IMPLEMENT THE SPEC" in rendered
+    assert (
+        "The executed trades did not faithfully implement the specification; "
+        "interpretation is preliminary." in rendered
+    )
+    for issue in report.issues:
+        assert issue.description in rendered
+        assert issue.severity in rendered
+        assert issue.rule_type in rendered
+    assert report.rationale in rendered
+    assert "DO open the narrative with the disclaimer above" in rendered
+    assert "DO NOT make causal claims about strategy design" in rendered
+
+
+def test_misaligned_section_handles_empty_issue_list() -> None:
+    """Issue #532: even a degenerate ``aligned=False`` report with no
+    enumerated issues must still produce the disclaimer block (so a
+    fail-closed alignment retry path can't slip a confident narrative
+    through)."""
+    rendered = _format_alignment_status_section(TradeAlignmentReport(aligned=False))
+    assert "TRADES DID NOT IMPLEMENT THE SPEC" in rendered
+    assert "The executed trades did not faithfully implement the specification" in rendered
+    assert "aligned=False with no enumerated issues" in rendered
+
+
+@pytest.mark.parametrize(
+    "label,template_file",
+    [
+        pytest.param("analysis_win", "analysis_win.md", id="analysis_win"),
+        pytest.param("analysis_lose", "analysis_lose.md", id="analysis_lose"),
+    ],
+)
+def test_analysis_templates_expose_alignment_placeholder(label: str, template_file: str) -> None:
+    """Issue #532: both analysis prompt templates must expose the
+    ``{alignment_status_section}`` placeholder so the orchestrator can
+    inject the audit verdict + issues into the LLM context. Without this
+    placeholder the alignment_status arg is silently dropped on the floor.
+    """
+    template = (_PROMPT_DIR / template_file).read_text(encoding="utf-8")
+    assert "{alignment_status_section}" in template, (
+        f"{label} template missing {{alignment_status_section}} placeholder (issue #532)."
     )

--- a/backend/agents/investment_team/tests/test_analysis_orchestrator_fallback.py
+++ b/backend/agents/investment_team/tests/test_analysis_orchestrator_fallback.py
@@ -1,0 +1,278 @@
+"""Orchestrator-level regression guard for issue #532 (Codex review on PR #584).
+
+Two failure modes are pinned here:
+
+1. ``_resolve_alignment_report_for_analysis`` — when the LLM alignment audit
+   returns ``aligned=True`` but the deterministic ``ExitRuleConformanceGate``
+   then vetoes publication, a synthetic misaligned report must be substituted
+   so the analysis prompts can't narrate "audit clean" over the veto.
+
+2. ``StrategyLabOrchestrator._run_analysis_phase`` — when
+   ``analysis_agent.run`` itself raises (before its in-agent
+   ``_fallback_narrative`` can run, e.g. prompt-file IO or model factory
+   failure), the orchestrator-level auto-summary must still prepend the
+   disclaimer + alignment issues on misaligned runs.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from investment_team.models import BacktestResult, StrategySpec, TradeRecord
+from investment_team.strategy_lab.agents.alignment import (
+    AlignmentIssue,
+    TradeAlignmentReport,
+)
+from investment_team.strategy_lab.orchestrator import (
+    StrategyLabOrchestrator,
+    _resolve_alignment_report_for_analysis,
+)
+from investment_team.strategy_lab.spec_dsl import (
+    EntryRule,
+    Predicate,
+    StopLossRule,
+)
+
+# ---------------------------------------------------------------------------
+# _resolve_alignment_report_for_analysis
+# ---------------------------------------------------------------------------
+
+
+def _clean_report() -> TradeAlignmentReport:
+    return TradeAlignmentReport(aligned=True, rationale="audit clean")
+
+
+def _misaligned_report() -> TradeAlignmentReport:
+    return TradeAlignmentReport(
+        aligned=False,
+        rationale="audit caught a stop-loss skip",
+        issues=[
+            AlignmentIssue(
+                rule_type="exit_rules",
+                severity="critical",
+                description="stop-loss did not fire on trade #1",
+                affected_trades=[1],
+            )
+        ],
+    )
+
+
+def test_resolve_returns_none_when_no_reports() -> None:
+    """Strategies whose alignment loop never ran (e.g. execution failed
+    before alignment) get a ``None`` report — the analysis prompt then
+    renders an empty Alignment status section, byte-identical to legacy
+    behaviour."""
+    assert _resolve_alignment_report_for_analysis([], exit_rule_conformance_passed=True) is None
+    assert _resolve_alignment_report_for_analysis([], exit_rule_conformance_passed=False) is None
+
+
+def test_resolve_passes_through_clean_report_when_conformance_passes() -> None:
+    """The common happy path: clean LLM audit + clean conformance check
+    means the analysis prompts see ``aligned=True``."""
+    clean = _clean_report()
+    out = _resolve_alignment_report_for_analysis([clean], exit_rule_conformance_passed=True)
+    assert out is clean
+
+
+def test_resolve_passes_through_misaligned_report_regardless_of_conformance() -> None:
+    """A misaligned LLM audit must reach the analysis prompts unchanged
+    — the conformance flag is only consulted to *escalate* a clean audit
+    that the gate then rejected, never to soften a misaligned one."""
+    misaligned = _misaligned_report()
+    out_pass = _resolve_alignment_report_for_analysis(
+        [misaligned], exit_rule_conformance_passed=True
+    )
+    out_fail = _resolve_alignment_report_for_analysis(
+        [misaligned], exit_rule_conformance_passed=False
+    )
+    assert out_pass is misaligned
+    assert out_fail is misaligned
+
+
+def test_resolve_overrides_clean_audit_when_conformance_vetoes() -> None:
+    """The bug Codex flagged (PR #584): clean LLM audit + failing
+    ExitRuleConformanceGate must NOT narrate audit-clean. A synthetic
+    misaligned report carrying the conformance veto as a critical
+    exit_rules issue is substituted instead."""
+    out = _resolve_alignment_report_for_analysis(
+        [_clean_report()], exit_rule_conformance_passed=False
+    )
+    assert out is not None
+    assert out.aligned is False
+    assert "ExitRuleConformanceGate" in out.rationale
+    assert len(out.issues) == 1
+    issue = out.issues[0]
+    assert issue.rule_type == "exit_rules"
+    assert issue.severity == "critical"
+    assert "ExitRuleConformanceGate failed" in issue.description
+
+
+def test_resolve_picks_latest_when_multiple_reports() -> None:
+    """The alignment loop appends a report per round; only the latest is
+    consulted (matches the verification phase's ``alignment_reports[-1]``
+    convention)."""
+    first = _misaligned_report()
+    second = _clean_report()
+    out = _resolve_alignment_report_for_analysis([first, second], exit_rule_conformance_passed=True)
+    assert out is second
+
+
+# ---------------------------------------------------------------------------
+# StrategyLabOrchestrator._run_analysis_phase exception handler
+# ---------------------------------------------------------------------------
+
+
+def _spec() -> StrategySpec:
+    return StrategySpec(
+        strategy_id="strat-test",
+        authored_by="test-suite",
+        asset_class="stocks",
+        hypothesis="h",
+        signal_definition="s",
+        timeframe="1d",
+        entry_rules=[
+            EntryRule(
+                side="long",
+                when=Predicate(lhs="bar.close", op=">", rhs=0),
+            )
+        ],
+        exit_rules=[StopLossRule(pct=0.03)],
+        risk_limits={},
+        speculative=False,
+    )
+
+
+def _metrics() -> BacktestResult:
+    return BacktestResult(
+        total_return_pct=18.0,
+        annualized_return_pct=15.0,
+        volatility_pct=8.0,
+        sharpe_ratio=1.4,
+        max_drawdown_pct=4.0,
+        win_rate_pct=60.0,
+        profit_factor=2.0,
+        calmar_ratio=0.0,
+        deflated_sharpe=0.0,
+        sortino_ratio=0.0,
+    )
+
+
+def _stub_trade() -> TradeRecord:
+    return TradeRecord(
+        trade_num=1,
+        entry_date="2024-01-01",
+        exit_date="2024-01-05",
+        symbol="AAA",
+        side="long",
+        entry_price=100.0,
+        exit_price=102.0,
+        shares=100.0,
+        position_value=10000.0,
+        gross_pnl=200.0,
+        net_pnl=200.0,
+        return_pct=2.0,
+        hold_days=4,
+        outcome="win",
+        cumulative_pnl=200.0,
+    )
+
+
+class _RaisingAnalysisAgent:
+    """Stand-in for ``AnalysisAgent`` that always raises during ``run`` so
+    the orchestrator-level ``except Exception`` arm is exercised."""
+
+    def run(self, *_: Any, **__: Any) -> str:
+        raise RuntimeError("simulated catastrophic agent failure")
+
+
+def _make_orchestrator() -> StrategyLabOrchestrator:
+    """Build an orchestrator with all collaborators stubbed out. The
+    analysis-phase fallback exercised here only reads ``self.analysis_agent``
+    — every other collaborator is irrelevant, so MagicMock keeps the wiring
+    cheap."""
+    orch = StrategyLabOrchestrator.__new__(StrategyLabOrchestrator)
+    orch.analysis_agent = _RaisingAnalysisAgent()
+    return orch
+
+
+def _emit(*_args: Any, **_kwargs: Any) -> None:
+    pass
+
+
+def test_analysis_phase_fallback_injects_disclaimer_on_misaligned_run() -> None:
+    """Codex follow-up (PR #584): when ``analysis_agent.run`` raises
+    before its internal ``_fallback_narrative`` runs (e.g. prompt-file
+    IO or model factory failure), the orchestrator-level fallback must
+    still surface the disclaimer + audit issues on ``aligned=False`` runs.
+    Otherwise a transient outage publishes a confident auto-summary on a
+    misaligned run."""
+    orch = _make_orchestrator()
+    misaligned = _misaligned_report()
+
+    narrative = orch._run_analysis_phase(
+        spec=_spec(),
+        metrics=_metrics(),
+        trades=[_stub_trade()],
+        rationale="rationale",
+        is_winning=False,
+        execution_succeeded=True,
+        refinement_attempts=[],
+        all_gate_results=[],
+        alignment_report=misaligned,
+        emit=_emit,
+    )
+
+    assert (
+        "The executed trades did not faithfully implement the specification; "
+        "interpretation is preliminary." in narrative
+    )
+    for issue in misaligned.issues:
+        assert issue.description in narrative
+    assert "Detailed narrative generation failed" in narrative
+
+
+def test_analysis_phase_fallback_unchanged_on_aligned_run() -> None:
+    """Aligned runs (or runs with no alignment report) must keep the
+    legacy auto-summary text — no disclaimer is injected to keep clean
+    runs byte-identical to pre-#532 behaviour."""
+    orch = _make_orchestrator()
+
+    narrative = orch._run_analysis_phase(
+        spec=_spec(),
+        metrics=_metrics(),
+        trades=[_stub_trade()],
+        rationale="rationale",
+        is_winning=True,
+        execution_succeeded=True,
+        refinement_attempts=[],
+        all_gate_results=[],
+        alignment_report=TradeAlignmentReport(aligned=True),
+        emit=_emit,
+    )
+
+    assert "did not faithfully implement the specification" not in narrative
+    assert "Alignment issues:" not in narrative
+    assert "Detailed narrative generation failed" in narrative
+
+
+def test_analysis_phase_fallback_unchanged_with_no_alignment_report() -> None:
+    """Legacy callers that pass ``alignment_report=None`` (or pipeline
+    paths where the alignment loop never ran) keep the original
+    auto-summary text — back-compat guard."""
+    orch = _make_orchestrator()
+
+    narrative = orch._run_analysis_phase(
+        spec=_spec(),
+        metrics=_metrics(),
+        trades=[_stub_trade()],
+        rationale="rationale",
+        is_winning=True,
+        execution_succeeded=True,
+        refinement_attempts=[],
+        all_gate_results=[],
+        alignment_report=None,
+        emit=_emit,
+    )
+
+    assert "did not faithfully implement the specification" not in narrative
+    assert "Detailed narrative generation failed" in narrative


### PR DESCRIPTION
## Summary

Closes #532. When the alignment loop flags executed trades as not faithfully implementing the spec, the `AnalysisAgent` now threads that verdict into both the draft and self-review prompts so the narrative can't keep confidently explaining "why the strategy worked / failed" off a run that isn't a valid test of the design.

- `AnalysisAgent.run` accepts an optional `alignment_report: TradeAlignmentReport`. A new `_format_alignment_status_section` helper renders one of three things: empty string (legacy callers / no report — byte-identical to prior behaviour), a one-line clean affirmation, or a disclaimer block listing every `AlignmentIssue` and forbidding causal claims about strategy design.
- `analysis_win.md` / `analysis_lose.md` expose a `{alignment_status_section}` placeholder and a new instructions bullet that activates the disclaimer rules when the section marks the run misaligned. The `_SELF_REVIEW_PROMPT` gets the same placeholder + a new step-0 instruction.
- The Strategy Lab orchestrator forwards `alignment_reports[-1]` from the alignment loop into `_run_analysis_phase` → `AnalysisAgent.run`.

## Files

```
backend/agents/investment_team/strategy_lab/agents/analysis.py
backend/agents/investment_team/strategy_lab/orchestrator.py                       (+4 lines, signature + 2 keyword args)
backend/agents/investment_team/strategy_lab/prompts/analysis_win.md               (placeholder + instruction)
backend/agents/investment_team/strategy_lab/prompts/analysis_lose.md              (placeholder + instruction)
backend/agents/investment_team/tests/golden/snapshots/prompt_analysis_win.txt     (regenerated — aligned variant)
backend/agents/investment_team/tests/golden/snapshots/prompt_analysis_lose.txt    (regenerated — aligned variant)
backend/agents/investment_team/tests/golden/snapshots/prompt_analysis_lose_misaligned.txt  (NEW)
backend/agents/investment_team/tests/test_analysis_alignment_prompts.py           (+aligned/misaligned/missing-report cases + placeholder guard)
backend/agents/investment_team/tests/test_analysis_agent_verdict.py               (+3 cases: misaligned threads disclaimer through both prompts; aligned/None do not)
```

## Backward compatibility

`alignment_report=None` produces an empty section, so the verdict-suite legacy heuristic test and any non-migrated caller stay byte-identical.

## Test plan

- [x] `pytest agents/investment_team/tests/test_analysis_alignment_prompts.py agents/investment_team/tests/test_analysis_agent_verdict.py` — 26 passed
- [x] Strategy-Lab-related unit tests (`-k "strategy_lab or orchestrator or analysis or alignment"`) — 158 passed, 1 skipped, no regressions
- [x] Full `agents/investment_team/tests/` unit suite (`-m "not strategy_lab_integration"`) — 1405 passed. 5 pre-existing failures in `test_paper_trade_api_fixes.py` (flaky cross-test order issue with `httpx.ConnectError`, also reproducible on the unmodified parent commit — unrelated to this change)
- [x] `ruff check` on all touched files — clean
- [ ] Manual end-to-end with a known-misaligning spec to confirm a real LLM-generated narrative opens with the disclaimer (requires Ollama/Claude credentials; relying on the unit + golden coverage for now)

Plan file: `/root/.claude/plans/write-a-plan-for-whimsical-shamir.md`

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fk9sr3DWbY63Txd5RzLDeR)_