### PR TITLE
jobs-dashboard: apply tabular-nums to numeric and mono cells (#488)

### DIFF
--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
@@ -44,6 +44,7 @@
       font-size: var(--kh-text-xs);
       color: var(--kh-text-secondary);
       font-family: var(--kh-font-mono);
+      font-variant-numeric: tabular-nums;
     }
 
     .live-dot {
@@ -503,6 +504,7 @@ tbody .col-actions {
   color: var(--kh-text-primary);
   font-family: var(--kh-font-mono);
   font-size: var(--kh-text-xs);
+  font-variant-numeric: tabular-nums;
 }
 
 .progress-cell {
@@ -523,6 +525,7 @@ tbody .col-actions {
     text-align: right;
     color: var(--kh-text-tertiary);
     font-family: var(--kh-font-mono);
+    font-variant-numeric: tabular-nums;
   }
 }
 
@@ -535,6 +538,7 @@ tbody .col-actions {
   color: var(--kh-text-secondary);
   font-size: var(--kh-text-xs);
   font-family: var(--kh-font-mono);
+  font-variant-numeric: tabular-nums;
 }
 
 // ── Agent Chips ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes #488. Adds `font-variant-numeric: tabular-nums;` to four mono-styled cells in the jobs-dashboard so polling-driven digit-width changes (e.g. `9m ago` → `10m ago`) no longer jitter the surrounding cells.

Selectors touched in `user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss`:

- `.last-updated` (top-bar live indicator)
- `.repo-name` (handles repo names containing digits)
- `.progress-label` (the `NN%` next to the progress bar)
- `.time-ago` (relative timestamp column)

Each block already used `font-family: var(--kh-font-mono);`; this PR appends one line per block. Matches the existing inline pattern already used in `agent-console/*` and `strategy-lab/*` SCSS — no new mixin or design token introduced.

## Test plan

- [x] `npm ci && npm run build` in `user-interface/` — Angular build succeeds; the pre-existing bundle-size warning is unrelated.
- [ ] Manual smoke on `/jobs-dashboard`: watch `9m ago` → `10m ago` and 1→2 digit progress transitions; surrounding cell widths should no longer shift on poll cycles.
- [ ] No regression in cell widths at rest.

## Notes

- Issue body line refs (286–293 / 332–339 / 347–351) were stale; current locations are `.last-updated` L40–47, `.repo-name` L497–506, `.progress-label` L519–526, `.time-ago` L534–538.

https://claude.ai/code/session_01S7KKS5atUETGUPsMejsFAW

---
_Generated by [Claude Code](https://claude.ai/code/session_01S7KKS5atUETGUPsMejsFAW)_