### PR TITLE
software_engineering_team: convert integration-marked tests back to unit tests (#361)

### DIFF
--- a/backend/agents/software_engineering_team/tests/conftest.py
+++ b/backend/agents/software_engineering_team/tests/conftest.py
@@ -23,6 +23,20 @@ from job_service_client_fake import fake_job_client  # noqa: F401, E402
 from llm_service import DummyLLMClient  # noqa: E402
 
 
+@pytest.fixture
+def patched_job_store(monkeypatch, fake_job_client):  # noqa: F811 (pytest fixture name)
+    """Route the SE ``job_store._client`` factory through the in-memory fake.
+
+    Opt-in shared form of the pattern in ``test_job_store_heartbeat.py``.
+    Tests that want it applied unconditionally should wrap it with their
+    own ``autouse=True`` fixture (see e.g. ``test_api.py``).
+    """
+    from software_engineering_team.shared import job_store as js
+
+    monkeypatch.setattr(js, "_client", lambda *a, **kw: fake_job_client)
+    return fake_job_client
+
+
 def pytest_configure(config: pytest.Config) -> None:
     config.addinivalue_line(
         "markers",

--- a/backend/agents/software_engineering_team/tests/test_api.py
+++ b/backend/agents/software_engineering_team/tests/test_api.py
@@ -1,8 +1,9 @@
 """Tests for the run-team API endpoint.
 
-MIXED file: most tests are mock-driven and could run as unit tests, but
-a handful exercise the real job store and would fail without the live
-job service.  Marked integration until we split it.
+Routed through the in-memory ``FakeJobServiceClient`` via the autouse
+``_autouse_patched_job_store`` fixture, so every job-store call (including
+those made by orchestrator background threads spawned from API endpoints)
+lands in a per-test in-memory dict.
 """
 
 import importlib.util
@@ -18,8 +19,6 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-pytestmark = [pytest.mark.integration]
-
 _team_dir = Path(__file__).resolve().parent.parent
 if str(_team_dir) not in sys.path:
     sys.path.insert(0, str(_team_dir))
@@ -30,6 +29,11 @@ _spec = importlib.util.spec_from_file_location(
 _api_main = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_api_main)
 app = _api_main.app
+
+
+@pytest.fixture(autouse=True)
+def _autouse_patched_job_store(patched_job_store):
+    return patched_job_store
 
 
 @pytest.fixture

--- a/backend/agents/software_engineering_team/tests/test_backend_code_v2_api.py
+++ b/backend/agents/software_engineering_team/tests/test_backend_code_v2_api.py
@@ -3,8 +3,9 @@ API tests for the backend-code-v2 endpoints:
   POST /backend-code-v2/run
   GET /backend-code-v2/status/{job_id}
 
-Hits the team API which calls the real job store; marked integration
-pending a follow-up that mocks job_store at the API boundary.
+Routed through the in-memory ``FakeJobServiceClient`` via the autouse
+``_autouse_patched_job_store`` fixture, so the team API's job-store calls
+land in a per-test in-memory dict.
 """
 
 from __future__ import annotations
@@ -18,8 +19,6 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-pytestmark = [pytest.mark.integration]
-
 _team_dir = Path(__file__).resolve().parent.parent
 if str(_team_dir) not in sys.path:
     sys.path.insert(0, str(_team_dir))
@@ -31,6 +30,11 @@ _spec = importlib.util.spec_from_file_location(
 _api_main = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_api_main)
 app = _api_main.app
+
+
+@pytest.fixture(autouse=True)
+def _autouse_patched_job_store(patched_job_store):
+    return patched_job_store
 
 
 @pytest.fixture

--- a/backend/agents/software_engineering_team/tests/test_frontend_code_v2_api.py
+++ b/backend/agents/software_engineering_team/tests/test_frontend_code_v2_api.py
@@ -3,8 +3,9 @@ API tests for the frontend-code-v2 endpoints:
   POST /frontend-code-v2/run
   GET /frontend-code-v2/status/{job_id}
 
-Hits the team API which calls the real job store; marked integration
-pending a follow-up that mocks job_store at the API boundary.
+Routed through the in-memory ``FakeJobServiceClient`` via the autouse
+``_autouse_patched_job_store`` fixture, so the team API's job-store calls
+land in a per-test in-memory dict.
 """
 
 from __future__ import annotations
@@ -18,8 +19,6 @@ from pathlib import Path
 import pytest
 from fastapi.testclient import TestClient
 
-pytestmark = [pytest.mark.integration]
-
 _team_dir = Path(__file__).resolve().parent.parent
 if str(_team_dir) not in sys.path:
     sys.path.insert(0, str(_team_dir))
@@ -31,6 +30,11 @@ _spec = importlib.util.spec_from_file_location(
 _api_main = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_api_main)
 app = _api_main.app
+
+
+@pytest.fixture(autouse=True)
+def _autouse_patched_job_store(patched_job_store):
+    return patched_job_store
 
 
 @pytest.fixture

--- a/backend/agents/software_engineering_team/tests/test_repair_agent.py
+++ b/backend/agents/software_engineering_team/tests/test_repair_agent.py
@@ -1,8 +1,9 @@
 """Unit tests for the Repair Expert agent and crash handling.
 
-Spawns orchestrator worker threads that talk to the job store directly,
-so this currently needs the live job service.  Marked integration pending
-follow-up to mock those threads out.
+The orchestrator-worker-thread tests at the bottom of this file talk to the
+job store from background threads; the autouse ``_autouse_patched_job_store``
+fixture below applies the ``_client`` monkeypatch before threads spawn, so
+every write lands in the in-memory ``FakeJobServiceClient``.
 """
 
 import json
@@ -11,10 +12,13 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-pytestmark = [pytest.mark.integration]
+from agent_repair_team.agent import RepairExpertAgent
+from agent_repair_team.models import RepairInput, RepairOutput
 
-from agent_repair_team.agent import RepairExpertAgent  # noqa: E402
-from agent_repair_team.models import RepairInput, RepairOutput  # noqa: E402
+
+@pytest.fixture(autouse=True)
+def _autouse_patched_job_store(patched_job_store):
+    return patched_job_store
 
 
 class _FakeAgentResult:

--- a/backend/agents/software_engineering_team/tests/test_software_engineering_orchestrator.py
+++ b/backend/agents/software_engineering_team/tests/test_software_engineering_orchestrator.py
@@ -1,8 +1,8 @@
 """Unit tests for the orchestrator.
 
-Some tests in this file call the real SE job_store (which now requires
-either a live job service or the in-memory fake).  Marked integration
-pending follow-up to swap those to ``fake_job_client``.
+Routed through the in-memory ``FakeJobServiceClient`` via the autouse
+``_autouse_patched_job_store`` fixture, so direct ``job_store`` calls in
+these tests no longer require a live job service.
 """
 
 from pathlib import Path
@@ -22,7 +22,10 @@ from software_engineering_team.shared.models import (
     TaskUpdate,
 )
 
-pytestmark = [pytest.mark.integration]
+
+@pytest.fixture(autouse=True)
+def _autouse_patched_job_store(patched_job_store):
+    return patched_job_store
 
 
 def test_run_build_verification_appends_fix_line_when_pytest_fails_with_test_error_handlers(

--- a/backend/agents/software_engineering_team/tests/test_temporal_integration.py
+++ b/backend/agents/software_engineering_team/tests/test_temporal_integration.py
@@ -1,9 +1,11 @@
 """Tests for Temporal integration: when enabled, API starts workflows instead of threads.
 
-Optional integration test with a real Temporal server (e.g. Docker): start the stack with
-TEMPORAL_ADDRESS set, POST /run-team to start a job, kill the API process, restart it,
-then verify the workflow continues or the job can be resumed via POST /run-team/{id}/resume.
-See ARCHITECTURE.md section \"Temporal (durable execution)\" for env and setup."""
+Routed through the in-memory ``FakeJobServiceClient`` so they run as unit tests
+without a live job service.  A real-Temporal smoke run is still possible by
+starting the stack with ``TEMPORAL_ADDRESS`` set, POSTing /run-team, killing
+the API process, restarting it, and resuming the job — see ARCHITECTURE.md
+section "Temporal (durable execution)" for env and setup.
+"""
 
 import sys
 from pathlib import Path
@@ -11,11 +13,6 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
-
-# Touches the central job service via SE job_store; opt out of unit-default
-# pytest runs.  Follow-up: split this file's pure-mock tests off and convert
-# the storage-touching ones to use ``fake_job_client``.
-pytestmark = [pytest.mark.integration]
 
 _team_dir = Path(__file__).resolve().parent.parent
 if str(_team_dir) not in sys.path:
@@ -31,6 +28,11 @@ _spec = importlib.util.spec_from_file_location(
 _api_main = importlib.util.module_from_spec(_spec)
 _spec.loader.exec_module(_api_main)
 app = _api_main.app
+
+
+@pytest.fixture(autouse=True)
+def _autouse_patched_job_store(patched_job_store):
+    return patched_job_store
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

Closes #361.

Six SE test files were tagged `pytestmark = [pytest.mark.integration]` in #360 (when the file-backed `JobServiceClient` fallback was removed) so the default `make test` loop could stay green without Postgres + the central job service. This restores them to unit-test status by routing every `job_store` call through the in-memory `FakeJobServiceClient`, using the pattern already shipped in `test_job_store_heartbeat.py`.

### Why this works

`backend/agents/software_engineering_team/shared/job_store.py:56-63` is the **single** construction point for `JobServiceClient` anywhere under `software_engineering_team/` — every CRUD helper, every API endpoint, every orchestrator background thread (incl. retry/repair threads), and every Temporal activity routes through `_client()`. Sub-teams `backend_code_v2_team/` and `frontend_code_v2_team/` have no `job_store.py` of their own and reuse the SE one. So one `monkeypatch.setattr(js, "_client", ...)` covers the whole call graph — including writes from threads spawned before the test body runs, because the autouse fixture is applied before the threads launch.

### Changes

- **`tests/conftest.py`** — add opt-in `patched_job_store` fixture that wraps the monkeypatch recipe from `test_job_store_heartbeat.py` so the six files don't each have to repeat it.
- **Six test files** — drop the file-level integration marker, add an autouse wrapper that pulls in `patched_job_store`:
  - `test_temporal_integration.py` (6 tests)
  - `test_software_engineering_orchestrator.py` (7 tests)
  - `test_repair_agent.py` (9 tests, incl. 2 that spawn orchestrator worker threads)
  - `test_api.py` (27 tests, incl. the composite-update test the plan flagged as risky — `FakeJobServiceClient.atomic_update` reproduces the semantic faithfully so it stayed unit)
  - `test_backend_code_v2_api.py` (7 tests)
  - `test_frontend_code_v2_api.py` (7 tests)

### Test plan

- [x] `pytest agents/software_engineering_team/tests/` with **no** Postgres / no `JOB_SERVICE_URL` → 731 passed, 3 skipped (pre-existing).
- [x] `pytest tests/ -m integration --co` → 734 collected, 734 deselected, 0 selected (zero integration-marked SE tests remain).
- [x] Targeted thread-spawning tests `test_orchestrator_repair_requeue_on_backend_crash` and `test_orchestrator_requeues_when_task_contract_is_repaired` pass in isolation with `-xvs`; no `httpx.ConnectError` leaks from worker threads.
- [x] `ruff check` + `ruff format --check` clean on all modified files.
- [x] No new direct `JobServiceClient(...)` constructions introduced.

### Notes for follow-ups

The same `patched_job_store` recipe will work verbatim for the sibling-team conversions (#362, #363, #366, #367, #368) — they just need an analogous fixture re-exporting `fake_job_client` in their team's `tests/conftest.py`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FeEBEEx9eTXTZqN6n4Jh9o)_