### PR TITLE
investment-team: add CodeConformanceGate — deterministic spec→code check (#541)

### DIFF
--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -58,6 +58,7 @@ from .coverage_probe import format_coverage_report
 from .exceptions import SpecImplementabilityError
 from .quality_gates.acceptance_gate import AcceptanceGate, summarize_acceptance_reason
 from .quality_gates.backtest_anomaly import BacktestAnomalyDetector
+from .quality_gates.code_conformance import CodeConformanceGate
 from .quality_gates.code_safety import CodeSafetyChecker
 from .quality_gates.convergence_tracker import ConvergenceTracker
 from .quality_gates.exit_rule_conformance import ExitRuleConformanceGate
@@ -177,6 +178,7 @@ class StrategyLabOrchestrator:
         self.analysis_agent = AnalysisAgent()
         self.strategy_validator = StrategySpecValidator()
         self.code_safety_checker = CodeSafetyChecker()
+        self.code_conformance_gate = CodeConformanceGate()
         self.anomaly_detector = BacktestAnomalyDetector()
         self.acceptance_gate = AcceptanceGate()
         self.target_symbol_coverage_gate = TargetSymbolCoverageGate()
@@ -520,6 +522,8 @@ class StrategyLabOrchestrator:
                 )
             code_gates = self.code_safety_checker.check(code, spec)
             round_gate_results.extend(code_gates)
+            conformance_gates = self.code_conformance_gate.check(code, spec)
+            round_gate_results.extend(conformance_gates)
             self.record_gates(round_gate_results, all_gate_results, refinement_round=round_num)
 
             checks_total = len(round_gate_results)

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_conformance.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_conformance.py
@@ -1,0 +1,636 @@
+"""Deterministic spec→code conformance gate (issue #541).
+
+Runs immediately after :class:`CodeSafetyChecker` and before the first
+sandbox execution. Fails ``severity="critical"`` when generated strategy
+code does not implement what the spec declares — e.g. a spec rule
+references an indicator that the code never calls, or an entry rule has
+no corresponding code branch.
+
+The post-hoc, LLM-driven :class:`TradeAlignmentAgent` can only reason
+about rules that actually fired in the test window. This gate catches the
+silent failure mode where a rule is never implemented and therefore
+never fires at all.
+
+Critical failures route back to synthesis via the orchestrator's
+``_refine_or_exhaust(failure_phase="validation")`` path (same routing as
+``CodeSafetyChecker``).
+
+Scope choices (issue #541, v1):
+
+* Check #1 (indicator presence) requires **named calls only** — inline
+  equivalents (e.g. ``sum(x)/len(x)`` as a hand-rolled SMA) are not
+  recognised and will fail. Recognising inline patterns is a future
+  enhancement; the deterministic compiler track (#538) makes it
+  unnecessary on the compiled path.
+* Check #7 (time-stop enforcement) is a no-op today because the spec
+  DSL has no ``TimeStopRule`` (``spec_dsl.py`` explicitly excludes
+  bar-counting time stops). The check is wired up so it activates the
+  moment the DSL adds the rule.
+* Check #2 (symbol gate) reuses the same AST helpers as
+  ``CodeSafetyChecker._check_universe_guard``. The duplication is
+  intentional defense-in-depth so this gate remains self-sufficient.
+"""
+
+from __future__ import annotations
+
+import ast
+from typing import Any, ClassVar, Iterable, List, Optional
+
+from ..spec_dsl import (
+    EntryRule,
+    IndicatorName,
+    IndicatorRef,
+    Predicate,
+    SignalExitRule,
+    StopLossRule,
+    TakeProfitRule,
+)
+from .code_safety_ast import (
+    _find_strategy_subclasses,
+    _get_call_name,
+    _has_universe_constant,
+    _has_universe_guard_in_on_bar,
+    _iter_method_body_nodes,
+)
+from .models import GateResultsMixin, QualityGateResult, StrategyLabPhase
+
+GATE = "code_conformance"
+
+# Hook methods on the Strategy class within which ``ctx.submit_order`` is
+# allowed. Helper methods whose names start with "_" are also allowed
+# because the existing :class:`CodeSafetyChecker` order-flow gate already
+# requires reachable order flow to originate in ``on_bar``; the conformance
+# gate's role here is to forbid stray submissions in unrelated methods
+# (e.g. ``__init__`` or a public ``run`` wrapper).
+_ALLOWED_HOOK_NAMES: frozenset[str] = frozenset({"on_bar", "on_fill", "on_end"})
+
+# DSL → set of acceptable AST call-name(s) for the indicator's named
+# implementation. Most map 1:1 with the indicator name; ``bollinger``
+# accepts the ``bollinger_bands`` helper name from
+# ``strategy_lab/executor/indicators.py``.
+_INDICATOR_ALLOWED_CALL_NAMES: dict[str, frozenset[str]] = {
+    "sma": frozenset({"sma"}),
+    "ema": frozenset({"ema"}),
+    "rsi": frozenset({"rsi"}),
+    "macd": frozenset({"macd"}),
+    "bollinger": frozenset({"bollinger_bands", "bollinger"}),
+    "atr": frozenset({"atr"}),
+    "adx": frozenset({"adx"}),
+    "stochastic": frozenset({"stochastic"}),
+    "vwap": frozenset({"vwap"}),
+}
+
+assert set(_INDICATOR_ALLOWED_CALL_NAMES) == set(IndicatorName.__args__), (
+    "indicator allow-list must cover every DSL IndicatorName literal"
+)
+
+# Names recognised as the position-snapshot receiver in exit branches.
+_POSITION_RECEIVER_NAMES: frozenset[str] = frozenset({"position", "pos"})
+
+
+def _indicators_in_predicate(p: Predicate) -> set[str]:
+    """Return the set of DSL indicator names referenced on either side of ``p``."""
+    out: set[str] = set()
+    for side in (p.lhs, p.rhs):
+        if isinstance(side, IndicatorRef):
+            out.add(side.name)
+    return out
+
+
+def _collect_required_indicators(spec: Any) -> set[str]:
+    """Return the union of indicator names referenced by every rule in ``spec``."""
+    refs: set[str] = set()
+    for rule in getattr(spec, "entry_rules", []) or []:
+        if isinstance(rule, EntryRule):
+            refs |= _indicators_in_predicate(rule.when)
+    for rule in getattr(spec, "exit_rules", []) or []:
+        if isinstance(rule, SignalExitRule):
+            refs |= _indicators_in_predicate(rule.when)
+    return refs
+
+
+def _collect_called_names(tree: ast.AST) -> set[str]:
+    """Return the set of function-call names anywhere in ``tree``.
+
+    Uses ``_get_call_name`` so ``indicators.sma(...)`` and bare ``sma(...)``
+    both contribute ``"sma"``.
+    """
+    out: set[str] = set()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            name = _get_call_name(node)
+            if name:
+                out.add(name)
+    return out
+
+
+def _is_submit_order_call(node: ast.AST) -> bool:
+    """True iff ``node`` is a ``Call`` whose function attribute is ``submit_order``."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "submit_order"
+    )
+
+
+def _submit_order_has_side_literal(call: ast.Call) -> bool:
+    """True iff the call has a ``side=`` kwarg with any value.
+
+    The CodeSafetyChecker shapes the recognised literal forms more
+    strictly (``OrderSide.LONG`` / ``"LONG"``); for conformance coverage
+    the presence of a ``side=`` kwarg at all is enough to mark the
+    branch as an entry path. Exit paths use ``qty=position.qty`` and are
+    detected by ``_submit_order_closes_position`` instead.
+    """
+    return any(kw.arg == "side" for kw in call.keywords)
+
+
+def _submit_order_closes_position(call: ast.Call) -> bool:
+    """True iff ``call`` passes ``qty=<pos|position>.qty``.
+
+    Matches the exit shape from the issue:
+    ``ctx.submit_order(..., qty=position.qty)`` or the ``pos`` alias.
+    """
+    for kw in call.keywords:
+        if kw.arg != "qty":
+            continue
+        v = kw.value
+        if (
+            isinstance(v, ast.Attribute)
+            and v.attr == "qty"
+            and isinstance(v.value, ast.Name)
+            and v.value.id in _POSITION_RECEIVER_NAMES
+        ):
+            return True
+    return False
+
+
+def _node_references_ctx_equity(node: ast.AST) -> bool:
+    """True iff ``node`` (or any sub-expression) references ``ctx.equity``
+    or ``ctx.capital``. Used by the sizing check to confirm the account
+    value flows into the qty calculation somewhere in the same scope.
+    """
+    for sub in ast.walk(node):
+        if (
+            isinstance(sub, ast.Attribute)
+            and sub.attr in ("equity", "capital")
+            and isinstance(sub.value, ast.Name)
+            and sub.value.id == "ctx"
+        ):
+            return True
+    return False
+
+
+def _qty_is_constant_int(call: ast.Call) -> bool:
+    """True iff the call's ``qty=`` is a literal int (the anti-pattern)."""
+    for kw in call.keywords:
+        if kw.arg != "qty":
+            continue
+        return isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, int)
+    return False
+
+
+def _iter_strategy_methods(
+    cls: ast.ClassDef,
+) -> Iterable[ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Yield every method directly defined on ``cls`` (excludes nested defs)."""
+    for node in ast.iter_child_nodes(cls):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            yield node
+
+
+def _find_if_branches_with_submit_order(
+    cls: ast.ClassDef,
+) -> List[tuple[ast.If, List[ast.Call]]]:
+    """Walk every method on ``cls`` and yield ``(if_node, submit_calls)``
+    pairs where ``submit_calls`` is a non-empty list of ``submit_order``
+    calls in that ``If``'s body or its ``orelse`` branches.
+
+    Each top-level ``If`` body and each ``elif`` chain branch is treated
+    as a separate "branch": ``if A: submit(); elif B: submit()`` yields
+    two pairs. Branches nested inside loops or other ``If``s are also
+    walked (the engine reaches them too).
+    """
+    out: List[tuple[ast.If, List[ast.Call]]] = []
+    for method in _iter_strategy_methods(cls):
+        for node in _iter_method_body_nodes(method):
+            if not isinstance(node, ast.If):
+                continue
+            for branch in _iter_if_branches(node):
+                calls = [
+                    sub for sub in _iter_branch_body_nodes(branch) if _is_submit_order_call(sub)
+                ]
+                if calls:
+                    out.append((branch, calls))
+    return out
+
+
+def _iter_if_branches(node: ast.If) -> Iterable[ast.If]:
+    """Yield every ``If`` node in an ``if/elif/.../else`` chain rooted at
+    ``node``.
+
+    Python represents ``elif`` as a single-element ``orelse`` containing
+    another ``If`` node. ``else: ...`` becomes a non-empty ``orelse``
+    whose elements are statements (not an ``If``); the gate ignores
+    plain ``else`` branches because they have no test referencing
+    indicators.
+    """
+    cur: Optional[ast.If] = node
+    while isinstance(cur, ast.If):
+        yield cur
+        if len(cur.orelse) == 1 and isinstance(cur.orelse[0], ast.If):
+            cur = cur.orelse[0]
+        else:
+            cur = None
+
+
+def _iter_branch_body_nodes(branch: ast.If) -> Iterable[ast.AST]:
+    """Yield every node in ``branch.body`` without descending past nested
+    ``def`` / ``class`` / ``lambda`` boundaries."""
+    stack: List[ast.AST] = list(branch.body)
+    while stack:
+        node = stack.pop()
+        yield node
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)):
+            continue
+        for child in ast.iter_child_nodes(node):
+            stack.append(child)
+
+
+def _names_referenced(expr: ast.AST) -> set[str]:
+    """Return the set of all ``Name.id`` and ``Call`` func-names within ``expr``."""
+    out: set[str] = set()
+    for node in ast.walk(expr):
+        if isinstance(node, ast.Name):
+            out.add(node.id)
+        if isinstance(node, ast.Call):
+            name = _get_call_name(node)
+            if name:
+                out.add(name)
+    return out
+
+
+def _find_enclosing_funcdef(
+    tree: ast.AST, target: ast.AST
+) -> Optional[ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Return the innermost ``FunctionDef`` whose body contains ``target``,
+    or ``None`` when ``target`` is at module scope.
+
+    Walks every function definition and uses ``_iter_method_body_nodes``
+    (which stops at nested ``def`` / ``class`` / ``lambda`` boundaries)
+    so the innermost direct enclosing scope is the one that matches.
+    """
+    enclosing: Optional[ast.FunctionDef | ast.AsyncFunctionDef] = None
+    for func in ast.walk(tree):
+        if not isinstance(func, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for sub in _iter_method_body_nodes(func):
+            if sub is target:
+                enclosing = func
+                break
+    return enclosing
+
+
+class CodeConformanceGate(GateResultsMixin):
+    """Deterministic gate that checks generated code implements ``spec``.
+
+    Runs synchronously in the synthesis phase, after
+    :class:`CodeSafetyChecker` and before the sandbox executes. Yields one
+    or more :class:`QualityGateResult` entries per check; every critical
+    failure routes the orchestrator back into refinement.
+    """
+
+    GATE: ClassVar[str] = GATE
+
+    def check(
+        self,
+        code: str,
+        spec: Any,
+        *,
+        phase: StrategyLabPhase = "synthesis",
+    ) -> List[QualityGateResult]:
+        """Run every conformance check.
+
+        Pre: ``code`` is a string; ``phase`` is a valid phase literal.
+        Post: returned list is non-empty; every entry carries the
+        caller's ``phase`` and ``gate_name == GATE``.
+        """
+        with self._using_phase(phase):
+            try:
+                tree = ast.parse(code)
+            except SyntaxError as e:
+                return [self._critical(f"Code has a syntax error: {e}")]
+
+            strategy_classes = _find_strategy_subclasses(tree)
+            if len(strategy_classes) != 1:
+                # CodeSafetyChecker owns the "exactly one Strategy class"
+                # rule and emits its own critical. Conformance needs a
+                # single class to walk; emit info and let the safety gate
+                # drive the failure.
+                return [
+                    self._info(
+                        "Skipped: code has 0 or multiple Strategy subclasses "
+                        "(handled by code_safety)."
+                    )
+                ]
+            cls = strategy_classes[0]
+
+            results: List[QualityGateResult] = []
+            results.extend(self._check_indicator_presence(tree, spec))
+            results.extend(self._check_symbol_gate(spec, cls))
+            results.extend(self._check_entry_coverage(cls, spec))
+            results.extend(self._check_signal_exit_coverage(cls, spec))
+            results.extend(self._check_stop_loss_enforcement(cls, spec))
+            results.extend(self._check_take_profit_enforcement(cls, spec))
+            results.extend(self._check_time_stop_enforcement(spec))
+            results.extend(self._check_sizing_math(cls))
+            results.extend(self._check_no_extra_side_effects(tree, cls))
+
+            return results or [self._info("Code conforms to spec across all conformance checks.")]
+
+    # ------------------------------------------------------------------
+    # Check 1 — indicator presence
+    # ------------------------------------------------------------------
+    def _check_indicator_presence(self, tree: ast.AST, spec: Any) -> Iterable[QualityGateResult]:
+        required = _collect_required_indicators(spec)
+        if not required:
+            return ()
+        called = _collect_called_names(tree)
+        missing: List[str] = []
+        for name in sorted(required):
+            allowed = _INDICATOR_ALLOWED_CALL_NAMES.get(name, frozenset({name}))
+            if not (called & allowed):
+                missing.append(name)
+        if not missing:
+            return ()
+        return (
+            self._critical(
+                f"Spec references indicator(s) {missing} but the generated code "
+                f"contains no call to any of their named implementations. v1 "
+                "requires the named-call form (e.g. ``sma(bars, 50)``); inline "
+                "equivalents are not recognised."
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Check 2 — symbol/universe gate (defense-in-depth with code_safety)
+    # ------------------------------------------------------------------
+    def _check_symbol_gate(self, spec: Any, cls: ast.ClassDef) -> Iterable[QualityGateResult]:
+        if not getattr(spec, "target_symbols", None):
+            return ()
+        if not _has_universe_constant(cls):
+            return (
+                self._critical(
+                    "Spec has non-empty target_symbols but the Strategy class "
+                    "does not declare a UNIVERSE = frozenset({...}) (or "
+                    "set/tuple) class-level constant. Without UNIVERSE plus "
+                    "an ``if bar.symbol not in self.UNIVERSE: return`` guard "
+                    "in on_bar, bars for non-target symbols will be processed."
+                ),
+            )
+        if not _has_universe_guard_in_on_bar(cls):
+            return (
+                self._critical(
+                    "Strategy defines UNIVERSE but on_bar lacks the runtime "
+                    "``if bar.symbol not in self.UNIVERSE: return`` guard "
+                    "rejecting bars whose symbol is not in the universe."
+                ),
+            )
+        return ()
+
+    # ------------------------------------------------------------------
+    # Check 3 — entry predicate coverage
+    # ------------------------------------------------------------------
+    def _check_entry_coverage(self, cls: ast.ClassDef, spec: Any) -> Iterable[QualityGateResult]:
+        entry_rules = [
+            r for r in (getattr(spec, "entry_rules", []) or []) if isinstance(r, EntryRule)
+        ]
+        if not entry_rules:
+            return ()
+
+        branches = _find_if_branches_with_submit_order(cls)
+        entry_branches: List[tuple[ast.If, List[ast.Call]]] = []
+        for if_node, calls in branches:
+            if any(
+                _submit_order_has_side_literal(c) and not _submit_order_closes_position(c)
+                for c in calls
+            ):
+                entry_branches.append((if_node, calls))
+
+        if not entry_branches:
+            return (
+                self._critical(
+                    f"Spec declares {len(entry_rules)} entry rule(s) but no "
+                    "if/elif branch in the Strategy class contains a "
+                    "ctx.submit_order(..., side=...) entry call. Drop the "
+                    "entry path was likely removed during refinement."
+                ),
+            )
+
+        if len(entry_branches) < len(entry_rules):
+            return (
+                self._critical(
+                    f"Spec declares {len(entry_rules)} entry rule(s) but only "
+                    f"{len(entry_branches)} entry branch(es) were found in the "
+                    "Strategy class. Each EntryRule needs its own if/elif "
+                    "branch with a ctx.submit_order(..., side=...) call."
+                ),
+            )
+        return ()
+
+    # ------------------------------------------------------------------
+    # Check 4 — signal-exit predicate coverage
+    # ------------------------------------------------------------------
+    def _check_signal_exit_coverage(
+        self, cls: ast.ClassDef, spec: Any
+    ) -> Iterable[QualityGateResult]:
+        signal_exits = [
+            r for r in (getattr(spec, "exit_rules", []) or []) if isinstance(r, SignalExitRule)
+        ]
+        if not signal_exits:
+            return ()
+
+        branches = _find_if_branches_with_submit_order(cls)
+        exit_branches = [
+            (if_node, calls)
+            for if_node, calls in branches
+            if any(_submit_order_closes_position(c) for c in calls)
+        ]
+        if not exit_branches:
+            return (
+                self._critical(
+                    f"Spec declares {len(signal_exits)} signal-exit rule(s) "
+                    "but no if/elif branch contains a "
+                    "ctx.submit_order(..., qty=position.qty) close call."
+                ),
+            )
+
+        if len(exit_branches) < len(signal_exits):
+            return (
+                self._critical(
+                    f"Spec declares {len(signal_exits)} signal-exit rule(s) "
+                    f"but only {len(exit_branches)} exit branch(es) were found "
+                    "in the Strategy class."
+                ),
+            )
+        return ()
+
+    # ------------------------------------------------------------------
+    # Check 5 — stop-loss enforcement
+    # ------------------------------------------------------------------
+    def _check_stop_loss_enforcement(
+        self, cls: ast.ClassDef, spec: Any
+    ) -> Iterable[QualityGateResult]:
+        stop_rules = [
+            r for r in (getattr(spec, "exit_rules", []) or []) if isinstance(r, StopLossRule)
+        ]
+        if not stop_rules:
+            return ()
+        if self._class_references_position_entry_price(cls):
+            return ()
+        return (
+            self._critical(
+                "Spec has a StopLossRule but the Strategy class never "
+                "references ``position.entry_price`` (or ``pos.entry_price``) "
+                "— the stop-loss threshold cannot be computed against the "
+                "entry without it."
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Check 6 — take-profit enforcement
+    # ------------------------------------------------------------------
+    def _check_take_profit_enforcement(
+        self, cls: ast.ClassDef, spec: Any
+    ) -> Iterable[QualityGateResult]:
+        tp_rules = [
+            r for r in (getattr(spec, "exit_rules", []) or []) if isinstance(r, TakeProfitRule)
+        ]
+        if not tp_rules:
+            return ()
+        if self._class_references_position_entry_price(cls):
+            return ()
+        return (
+            self._critical(
+                "Spec has a TakeProfitRule but the Strategy class never "
+                "references ``position.entry_price`` (or ``pos.entry_price``) "
+                "— the take-profit threshold cannot be computed against the "
+                "entry without it."
+            ),
+        )
+
+    def _class_references_position_entry_price(self, cls: ast.ClassDef) -> bool:
+        for node in ast.walk(cls):
+            if (
+                isinstance(node, ast.Attribute)
+                and node.attr == "entry_price"
+                and isinstance(node.value, ast.Name)
+                and node.value.id in _POSITION_RECEIVER_NAMES
+            ):
+                return True
+        return False
+
+    # ------------------------------------------------------------------
+    # Check 7 — time-stop enforcement (no-op until the DSL grows the rule)
+    # ------------------------------------------------------------------
+    def _check_time_stop_enforcement(self, spec: Any) -> Iterable[QualityGateResult]:
+        # ``TimeStopRule`` is intentionally not a member of the
+        # ``ExitRule`` union (see ``spec_dsl.py``); the check stays wired
+        # up so it activates the moment the DSL adds it.
+        time_stop_cls = globals().get("TimeStopRule")
+        if time_stop_cls is None:
+            return (
+                self._info(
+                    "Time-stop check is a no-op: TimeStopRule is not part "
+                    "of the current spec DSL (see spec_dsl.py)."
+                ),
+            )
+        time_rules = [
+            r for r in (getattr(spec, "exit_rules", []) or []) if isinstance(r, time_stop_cls)
+        ]
+        if not time_rules:
+            return ()
+        # Future activation path: look for ctx.bars_held or a class-level
+        # held-bars dict updated in on_bar / on_fill. Critical when neither
+        # is present.
+        return ()  # pragma: no cover — activates with DSL change
+
+    # ------------------------------------------------------------------
+    # Check 8 — sizing math present
+    # ------------------------------------------------------------------
+    def _check_sizing_math(self, cls: ast.ClassDef) -> Iterable[QualityGateResult]:
+        all_submit_calls = [
+            sub
+            for method in _iter_strategy_methods(cls)
+            for sub in _iter_method_body_nodes(method)
+            if _is_submit_order_call(sub)
+        ]
+        entry_submit_calls = [c for c in all_submit_calls if not _submit_order_closes_position(c)]
+        if not entry_submit_calls:
+            # No entry submit_orders to size — Check #3 will already have
+            # fired, so silence this one to avoid noisy double-failure.
+            return ()
+
+        # Hardcoded-int qty on every entry is an immediate fail regardless
+        # of whether ctx.equity is referenced elsewhere in the class.
+        if all(_qty_is_constant_int(c) for c in entry_submit_calls):
+            return (
+                self._critical(
+                    "Every entry ctx.submit_order call passes a literal "
+                    "integer ``qty=``. Sizing must be derived from "
+                    "``ctx.equity`` or ``ctx.capital`` so the position "
+                    "scales with the account, not a hardcoded number."
+                ),
+            )
+
+        # Otherwise: any reference to ctx.equity / ctx.capital anywhere in
+        # the Strategy class is enough — qty is usually computed into a
+        # local variable (``qty = max(1, int(ctx.equity * 0.02 / bar.close))``)
+        # which then flows into the submit_order call as ``qty=qty``. We
+        # do not attempt to trace the local var across statements; the
+        # presence of the account-value reference and the absence of a
+        # hardcoded int kwarg is the v1 contract.
+        if _node_references_ctx_equity(cls):
+            return ()
+        return (
+            self._critical(
+                "Strategy class never references ``ctx.equity`` or "
+                "``ctx.capital``. Sizing must derive ``qty=`` from the "
+                "account value so the strategy scales correctly."
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Check 9 — no submit_order calls outside hook/helper methods
+    # ------------------------------------------------------------------
+    def _check_no_extra_side_effects(
+        self, tree: ast.AST, cls: ast.ClassDef
+    ) -> Iterable[QualityGateResult]:
+        offenders: List[str] = []
+        for node in ast.walk(tree):
+            if not _is_submit_order_call(node):
+                continue
+            enclosing = _find_enclosing_funcdef(tree, node)
+            if enclosing is None:
+                offenders.append("<module scope>")
+                continue
+            name = enclosing.name
+            if name in _ALLOWED_HOOK_NAMES:
+                continue
+            # ``_helper`` is the conventional name for hook-reachable
+            # closures, so a single leading underscore is allowed. Dunder
+            # methods (``__init__`` / ``__call__`` / ``__enter__`` …) are
+            # never the right place for a submit_order — exclude them.
+            if name.startswith("_") and not (name.startswith("__") and name.endswith("__")):
+                continue
+            offenders.append(name)
+        if not offenders:
+            return ()
+        return (
+            self._critical(
+                f"ctx.submit_order called from disallowed scope(s) "
+                f"{sorted(set(offenders))}. Order submissions must live in "
+                "on_bar / on_fill / on_end (or in a private ``_helper`` "
+                "method reachable from one of those hooks)."
+            ),
+        )

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_conformance.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_conformance.py
@@ -199,12 +199,52 @@ def _iter_strategy_methods(
             yield node
 
 
+def _methods_reachable_from_on_bar(cls: ast.ClassDef) -> frozenset[str]:
+    """Return the set of method names reachable from ``on_bar`` via
+    ``self.<method>(...)`` calls (transitively).
+
+    Entry/exit coverage checks must restrict their walk to reachable
+    code: an unused ``_dead`` helper containing
+    ``if ...: ctx.submit_order(...)`` would otherwise satisfy coverage
+    without actually being executed at runtime (PR #588 review).
+    """
+    methods = {m.name: m for m in _iter_strategy_methods(cls)}
+    if "on_bar" not in methods:
+        return frozenset()
+    reachable: set[str] = {"on_bar"}
+    worklist: List[str] = ["on_bar"]
+    while worklist:
+        name = worklist.pop()
+        method = methods.get(name)
+        if method is None:
+            continue
+        for node in _iter_method_body_nodes(method):
+            if not (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "self"
+            ):
+                continue
+            callee = node.func.attr
+            if callee in methods and callee not in reachable:
+                reachable.add(callee)
+                worklist.append(callee)
+    return frozenset(reachable)
+
+
 def _find_if_branches_with_submit_order(
     cls: ast.ClassDef,
+    *,
+    reachable_method_names: Optional[frozenset[str]] = None,
 ) -> List[tuple[ast.If, List[ast.Call]]]:
-    """Walk every method on ``cls`` and yield ``(if_node, submit_calls)``
+    """Walk methods on ``cls`` and yield ``(if_node, submit_calls)``
     pairs where ``submit_calls`` is a non-empty list of ``submit_order``
     calls in that ``If``'s body or its ``orelse`` branches.
+
+    When ``reachable_method_names`` is supplied, methods not in that set
+    are skipped — used by entry/exit coverage so dead code in unused
+    helpers cannot satisfy the gate.
 
     Each top-level ``If`` body and each ``elif`` chain branch is treated
     as a separate "branch": ``if A: submit(); elif B: submit()`` yields
@@ -213,6 +253,8 @@ def _find_if_branches_with_submit_order(
     """
     out: List[tuple[ast.If, List[ast.Call]]] = []
     for method in _iter_strategy_methods(cls):
+        if reachable_method_names is not None and method.name not in reachable_method_names:
+            continue
         for node in _iter_method_body_nodes(method):
             if not isinstance(node, ast.If):
                 continue
@@ -408,7 +450,8 @@ class CodeConformanceGate(GateResultsMixin):
         if not entry_rules:
             return ()
 
-        branches = _find_if_branches_with_submit_order(cls)
+        reachable = _methods_reachable_from_on_bar(cls)
+        branches = _find_if_branches_with_submit_order(cls, reachable_method_names=reachable)
         entry_branches: List[tuple[ast.If, List[ast.Call]]] = []
         for if_node, calls in branches:
             if any(
@@ -421,9 +464,10 @@ class CodeConformanceGate(GateResultsMixin):
             return (
                 self._critical(
                     f"Spec declares {len(entry_rules)} entry rule(s) but no "
-                    "if/elif branch in the Strategy class contains a "
-                    "ctx.submit_order(..., side=...) entry call. Drop the "
-                    "entry path was likely removed during refinement."
+                    "if/elif branch reachable from on_bar contains a "
+                    "ctx.submit_order(..., side=...) entry call. The entry "
+                    "path was likely removed during refinement or lives in "
+                    "an unreachable helper."
                 ),
             )
 
@@ -431,9 +475,10 @@ class CodeConformanceGate(GateResultsMixin):
             return (
                 self._critical(
                     f"Spec declares {len(entry_rules)} entry rule(s) but only "
-                    f"{len(entry_branches)} entry branch(es) were found in the "
-                    "Strategy class. Each EntryRule needs its own if/elif "
-                    "branch with a ctx.submit_order(..., side=...) call."
+                    f"{len(entry_branches)} entry branch(es) were found "
+                    "reachable from on_bar. Each EntryRule needs its own "
+                    "if/elif branch with a ctx.submit_order(..., side=...) "
+                    "call."
                 ),
             )
         return ()
@@ -450,7 +495,8 @@ class CodeConformanceGate(GateResultsMixin):
         if not signal_exits:
             return ()
 
-        branches = _find_if_branches_with_submit_order(cls)
+        reachable = _methods_reachable_from_on_bar(cls)
+        branches = _find_if_branches_with_submit_order(cls, reachable_method_names=reachable)
         exit_branches = [
             (if_node, calls)
             for if_node, calls in branches
@@ -460,7 +506,7 @@ class CodeConformanceGate(GateResultsMixin):
             return (
                 self._critical(
                     f"Spec declares {len(signal_exits)} signal-exit rule(s) "
-                    "but no if/elif branch contains a "
+                    "but no if/elif branch reachable from on_bar contains a "
                     "ctx.submit_order(..., qty=position.qty) close call."
                 ),
             )
@@ -470,7 +516,7 @@ class CodeConformanceGate(GateResultsMixin):
                 self._critical(
                     f"Spec declares {len(signal_exits)} signal-exit rule(s) "
                     f"but only {len(exit_branches)} exit branch(es) were found "
-                    "in the Strategy class."
+                    "reachable from on_bar."
                 ),
             )
         return ()

--- a/backend/agents/investment_team/strategy_lab/quality_gates/code_conformance.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/code_conformance.py
@@ -109,18 +109,26 @@ def _collect_required_indicators(spec: Any) -> set[str]:
     return refs
 
 
-def _collect_called_names(tree: ast.AST) -> set[str]:
-    """Return the set of function-call names anywhere in ``tree``.
+def _collect_called_names_in_methods(cls: ast.ClassDef, method_names: frozenset[str]) -> set[str]:
+    """Return the set of function-call names found inside the listed
+    methods of ``cls`` (descent stops at nested defs/classes/lambdas).
 
-    Uses ``_get_call_name`` so ``indicators.sma(...)`` and bare ``sma(...)``
-    both contribute ``"sma"``.
+    Used by check #1 (indicator presence) so that ``sma(...)`` called
+    only from a dead helper does not satisfy the requirement that
+    ``on_bar`` actually computes the indicator at runtime.
+
+    ``_get_call_name`` normalises ``indicators.sma(...)`` and bare
+    ``sma(...)`` to the same ``"sma"`` key.
     """
     out: set[str] = set()
-    for node in ast.walk(tree):
-        if isinstance(node, ast.Call):
-            name = _get_call_name(node)
-            if name:
-                out.add(name)
+    for method in _iter_strategy_methods(cls):
+        if method.name not in method_names:
+            continue
+        for node in _iter_method_body_nodes(method):
+            if isinstance(node, ast.Call):
+                name = _get_call_name(node)
+                if name:
+                    out.add(name)
     return out
 
 
@@ -143,6 +151,18 @@ def _submit_order_has_side_literal(call: ast.Call) -> bool:
     detected by ``_submit_order_closes_position`` instead.
     """
     return any(kw.arg == "side" for kw in call.keywords)
+
+
+def _submit_order_is_kwargs_spread(call: ast.Call) -> bool:
+    """True iff the call uses a ``**kwargs`` expansion.
+
+    ``ctx.submit_order(**order_kwargs)`` cannot be statically resolved —
+    the spread may carry ``side`` (entry) or ``qty=position.qty`` (exit)
+    dynamically. Coverage checks credit a branch with such a call as
+    BOTH a plausible entry and a plausible exit so conformant code that
+    builds kwargs dynamically does not trip false-positive criticals.
+    """
+    return any(kw.arg is None for kw in call.keywords)
 
 
 def _submit_order_closes_position(call: ast.Call) -> bool:
@@ -182,11 +202,20 @@ def _node_references_ctx_equity(node: ast.AST) -> bool:
 
 
 def _qty_is_constant_int(call: ast.Call) -> bool:
-    """True iff the call's ``qty=`` is a literal int (the anti-pattern)."""
+    """True iff the call's ``qty=`` is a literal int (the anti-pattern).
+
+    Excludes ``bool`` even though ``True`` / ``False`` are ``int``
+    subclasses — a boolean qty is a different anti-pattern that the
+    sizing check would misreport as "literal integer" otherwise.
+    """
     for kw in call.keywords:
         if kw.arg != "qty":
             continue
-        return isinstance(kw.value, ast.Constant) and isinstance(kw.value.value, int)
+        return (
+            isinstance(kw.value, ast.Constant)
+            and isinstance(kw.value.value, int)
+            and not isinstance(kw.value.value, bool)
+        )
     return False
 
 
@@ -199,20 +228,18 @@ def _iter_strategy_methods(
             yield node
 
 
-def _methods_reachable_from_on_bar(cls: ast.ClassDef) -> frozenset[str]:
-    """Return the set of method names reachable from ``on_bar`` via
+def _methods_reachable_from(cls: ast.ClassDef, roots: Iterable[str]) -> frozenset[str]:
+    """Return method names reachable from ``roots`` via
     ``self.<method>(...)`` calls (transitively).
 
-    Entry/exit coverage checks must restrict their walk to reachable
-    code: an unused ``_dead`` helper containing
-    ``if ...: ctx.submit_order(...)`` would otherwise satisfy coverage
-    without actually being executed at runtime (PR #588 review).
+    Used by every check that needs "is this code actually executed at
+    runtime?" — entry/exit coverage walks from ``on_bar`` only, while
+    check #9 (side-effects) walks from every allowed hook so a private
+    helper reachable from ``on_fill`` is not flagged as a dead helper.
     """
     methods = {m.name: m for m in _iter_strategy_methods(cls)}
-    if "on_bar" not in methods:
-        return frozenset()
-    reachable: set[str] = {"on_bar"}
-    worklist: List[str] = ["on_bar"]
+    reachable: set[str] = {r for r in roots if r in methods}
+    worklist: List[str] = list(reachable)
     while worklist:
         name = worklist.pop()
         method = methods.get(name)
@@ -231,6 +258,19 @@ def _methods_reachable_from_on_bar(cls: ast.ClassDef) -> frozenset[str]:
                 reachable.add(callee)
                 worklist.append(callee)
     return frozenset(reachable)
+
+
+def _methods_reachable_from_on_bar(cls: ast.ClassDef) -> frozenset[str]:
+    """BFS from ``on_bar`` — used by entry/exit coverage checks."""
+    return _methods_reachable_from(cls, ("on_bar",))
+
+
+def _methods_reachable_from_hooks(cls: ast.ClassDef) -> frozenset[str]:
+    """BFS from every allowed hook (``on_bar`` / ``on_fill`` / ``on_end``)
+    — used by check #9 (side-effects) so a private helper reachable
+    from ``on_fill`` is not treated as dead code.
+    """
+    return _methods_reachable_from(cls, _ALLOWED_HOOK_NAMES)
 
 
 def _find_if_branches_with_submit_order(
@@ -287,13 +327,23 @@ def _iter_if_branches(node: ast.If) -> Iterable[ast.If]:
 
 
 def _iter_branch_body_nodes(branch: ast.If) -> Iterable[ast.AST]:
-    """Yield every node in ``branch.body`` without descending past nested
-    ``def`` / ``class`` / ``lambda`` boundaries."""
+    """Yield every node directly in ``branch.body`` without descending
+    past nested ``def`` / ``class`` / ``lambda`` / ``If`` boundaries.
+
+    Stopping at nested ``If`` boundaries is what makes branch-coverage
+    counts honest: ``if A: if B: submit()`` is one logical entry, not
+    two. The inner ``If`` is enumerated separately as its own branch
+    by ``_find_if_branches_with_submit_order``, so its ``submit_order``
+    is credited once — to the innermost branch — not double-counted
+    against both the outer and inner.
+    """
     stack: List[ast.AST] = list(branch.body)
     while stack:
         node = stack.pop()
         yield node
-        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef)):
+        if isinstance(
+            node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda, ast.ClassDef, ast.If)
+        ):
             continue
         for child in ast.iter_child_nodes(node):
             stack.append(child)
@@ -378,7 +428,7 @@ class CodeConformanceGate(GateResultsMixin):
             cls = strategy_classes[0]
 
             results: List[QualityGateResult] = []
-            results.extend(self._check_indicator_presence(tree, spec))
+            results.extend(self._check_indicator_presence(cls, spec))
             results.extend(self._check_symbol_gate(spec, cls))
             results.extend(self._check_entry_coverage(cls, spec))
             results.extend(self._check_signal_exit_coverage(cls, spec))
@@ -393,11 +443,16 @@ class CodeConformanceGate(GateResultsMixin):
     # ------------------------------------------------------------------
     # Check 1 — indicator presence
     # ------------------------------------------------------------------
-    def _check_indicator_presence(self, tree: ast.AST, spec: Any) -> Iterable[QualityGateResult]:
+    def _check_indicator_presence(
+        self, cls: ast.ClassDef, spec: Any
+    ) -> Iterable[QualityGateResult]:
         required = _collect_required_indicators(spec)
         if not required:
             return ()
-        called = _collect_called_names(tree)
+        # Indicator calls only count when they are actually executed at
+        # runtime: walk methods reachable from on_bar (Codex PR #588 P1).
+        reachable = _methods_reachable_from_on_bar(cls)
+        called = _collect_called_names_in_methods(cls, reachable)
         missing: List[str] = []
         for name in sorted(required):
             allowed = _INDICATOR_ALLOWED_CALL_NAMES.get(name, frozenset({name}))
@@ -407,10 +462,11 @@ class CodeConformanceGate(GateResultsMixin):
             return ()
         return (
             self._critical(
-                f"Spec references indicator(s) {missing} but the generated code "
-                f"contains no call to any of their named implementations. v1 "
-                "requires the named-call form (e.g. ``sma(bars, 50)``); inline "
-                "equivalents are not recognised."
+                f"Spec references indicator(s) {missing} but no method "
+                "reachable from on_bar calls any of their named "
+                "implementations. v1 requires the named-call form "
+                "(e.g. ``sma(bars, 50)``); inline equivalents and calls "
+                "in unreachable helpers are not recognised."
             ),
         )
 
@@ -454,8 +510,14 @@ class CodeConformanceGate(GateResultsMixin):
         branches = _find_if_branches_with_submit_order(cls, reachable_method_names=reachable)
         entry_branches: List[tuple[ast.If, List[ast.Call]]] = []
         for if_node, calls in branches:
+            # A branch counts as an entry path when it contains either:
+            # - an explicit ``side=`` literal that isn't a position close, OR
+            # - a ``**kwargs`` spread whose contents we can't statically
+            #   resolve (treat optimistically — same lenient stance the
+            #   CodeSafetyChecker order-flow gate takes on unknown sides).
             if any(
-                _submit_order_has_side_literal(c) and not _submit_order_closes_position(c)
+                _submit_order_is_kwargs_spread(c)
+                or (_submit_order_has_side_literal(c) and not _submit_order_closes_position(c))
                 for c in calls
             ):
                 entry_branches.append((if_node, calls))
@@ -500,7 +562,12 @@ class CodeConformanceGate(GateResultsMixin):
         exit_branches = [
             (if_node, calls)
             for if_node, calls in branches
-            if any(_submit_order_closes_position(c) for c in calls)
+            # Same lenient stance as entry coverage: a ``**kwargs`` spread
+            # may dynamically carry ``qty=position.qty`` so we can't fail
+            # closed on it.
+            if any(
+                _submit_order_closes_position(c) or _submit_order_is_kwargs_spread(c) for c in calls
+            )
         ]
         if not exit_branches:
             return (
@@ -652,6 +719,10 @@ class CodeConformanceGate(GateResultsMixin):
     def _check_no_extra_side_effects(
         self, tree: ast.AST, cls: ast.ClassDef
     ) -> Iterable[QualityGateResult]:
+        # ``_helper`` methods are only allowed when actually reachable
+        # from an allowed hook — a dead ``_helper`` containing
+        # ctx.submit_order would otherwise pass silently (Codex PR #588).
+        reachable_helpers = _methods_reachable_from_hooks(cls)
         offenders: List[str] = []
         for node in ast.walk(tree):
             if not _is_submit_order_call(node):
@@ -664,10 +735,14 @@ class CodeConformanceGate(GateResultsMixin):
             if name in _ALLOWED_HOOK_NAMES:
                 continue
             # ``_helper`` is the conventional name for hook-reachable
-            # closures, so a single leading underscore is allowed. Dunder
+            # closures; allow it only when actually reachable. Dunder
             # methods (``__init__`` / ``__call__`` / ``__enter__`` …) are
-            # never the right place for a submit_order — exclude them.
-            if name.startswith("_") and not (name.startswith("__") and name.endswith("__")):
+            # never the right place for a submit_order — exclude them
+            # outright.
+            is_helper_name = name.startswith("_") and not (
+                name.startswith("__") and name.endswith("__")
+            )
+            if is_helper_name and name in reachable_helpers:
                 continue
             offenders.append(name)
         if not offenders:

--- a/backend/agents/investment_team/tests/test_code_conformance_gate.py
+++ b/backend/agents/investment_team/tests/test_code_conformance_gate.py
@@ -1,0 +1,519 @@
+"""Unit tests for ``CodeConformanceGate`` (issue #541).
+
+Hand-built ``StrategySpec`` + strategy-code fixtures exercise each of the
+nine conformance checks in isolation, with at least one positive and one
+negative case per check. The two mandatory acceptance tests from the
+issue are kept distinct: dropping the entry submit_order triggers
+check #3, and replacing the universe guard with ``True`` triggers
+check #2.
+"""
+
+from __future__ import annotations
+
+import textwrap
+
+from investment_team.models import StrategySpec
+from investment_team.strategy_lab.quality_gates.code_conformance import (
+    CodeConformanceGate,
+)
+from investment_team.strategy_lab.spec_dsl import (
+    DEFAULT_SIZING_PAYLOAD,
+    EntryRule,
+    IndicatorRef,
+    Predicate,
+    SignalExitRule,
+    StopLossRule,
+    TakeProfitRule,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+
+def _spec(
+    *,
+    entry_rules=None,
+    exit_rules=None,
+    target_symbols=None,
+) -> StrategySpec:
+    return StrategySpec(
+        strategy_id="t-1",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="QQQ trend-follow on SMA cross.",
+        signal_definition="sma(50) > sma(200)",
+        timeframe="1d",
+        entry_rules=list(entry_rules or []),
+        exit_rules=list(exit_rules or []),
+        sizing=DEFAULT_SIZING_PAYLOAD,
+        target_symbols=list(target_symbols or []),
+    )
+
+
+def _sma_cross_entry(side: str = "long") -> EntryRule:
+    return EntryRule(
+        side=side,
+        when=Predicate(
+            lhs=IndicatorRef(name="sma", params={"period": 50}),
+            op=">",
+            rhs=IndicatorRef(name="sma", params={"period": 200}),
+        ),
+    )
+
+
+def _rsi_signal_exit() -> SignalExitRule:
+    return SignalExitRule(
+        when=Predicate(
+            lhs=IndicatorRef(name="rsi"),
+            op=">",
+            rhs=70.0,
+        ),
+    )
+
+
+# Minimal valid strategy: SMA cross entry, RSI signal exit, stop-loss,
+# universe guard, qty derived from ctx.equity. Every conformance check
+# passes; mutated variants drop one piece to drive the negative tests.
+_HAPPY_CODE = textwrap.dedent(
+    """
+    from contract import Strategy
+
+    class S(Strategy):
+        UNIVERSE = frozenset({"QQQ"})
+
+        def on_bar(self, ctx, bar):
+            if bar.symbol not in self.UNIVERSE:
+                return
+            bars = ctx.history(bar.symbol, 200)
+            if len(bars) < 200:
+                return
+            fast = sma(bars, 50)
+            slow = sma(bars, 200)
+            r = rsi(bars, 14)
+            pos = ctx.position(bar.symbol)
+            qty = max(1, int(ctx.equity * 0.02 / bar.close))
+            if pos is None and fast > slow:
+                ctx.submit_order(symbol=bar.symbol, qty=qty, side="LONG")
+            elif pos is not None and r > 70:
+                ctx.submit_order(symbol=bar.symbol, qty=pos.qty, side="SHORT")
+            elif pos is not None and bar.close < pos.entry_price * 0.95:
+                ctx.submit_order(symbol=bar.symbol, qty=pos.qty, side="SHORT")
+    """
+)
+
+
+def _happy_spec() -> StrategySpec:
+    return _spec(
+        entry_rules=[_sma_cross_entry()],
+        exit_rules=[_rsi_signal_exit(), StopLossRule(pct=0.05)],
+        target_symbols=["QQQ"],
+    )
+
+
+def _critical_details(results):
+    return [r.details for r in results if r.severity == "critical" and not r.passed]
+
+
+# ---------------------------------------------------------------------------
+# Sanity
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_passes_every_check() -> None:
+    results = CodeConformanceGate().check(_HAPPY_CODE, _happy_spec())
+    assert _critical_details(results) == [], _critical_details(results)
+    # Every result must carry the synthesis phase + the gate name.
+    assert all(r.phase == "synthesis" for r in results)
+    assert all(r.gate_name == "code_conformance" for r in results)
+
+
+def test_syntax_error_is_critical() -> None:
+    results = CodeConformanceGate().check("def broken(:\n", _happy_spec())
+    assert len(results) == 1
+    assert results[0].severity == "critical"
+    assert "syntax error" in results[0].details.lower()
+
+
+def test_multiple_strategy_classes_skips_with_info() -> None:
+    code = textwrap.dedent(
+        """
+        from contract import Strategy
+        class A(Strategy):
+            def on_bar(self, ctx, bar): pass
+        class B(Strategy):
+            def on_bar(self, ctx, bar): pass
+        """
+    )
+    results = CodeConformanceGate().check(code, _happy_spec())
+    assert _critical_details(results) == []
+    assert any("Skipped" in r.details for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Check 1: indicator presence
+# ---------------------------------------------------------------------------
+
+
+def test_indicator_presence_passes_when_named_calls_exist() -> None:
+    results = CodeConformanceGate().check(_HAPPY_CODE, _happy_spec())
+    assert not any("indicator" in d.lower() for d in _critical_details(results))
+
+
+def test_indicator_presence_fails_when_indicator_never_called() -> None:
+    # Strip every sma() call by computing rolling mean inline — v1 does
+    # NOT accept inline equivalents and must flag this.
+    code = textwrap.dedent(
+        """
+        from contract import Strategy
+
+        class S(Strategy):
+            UNIVERSE = frozenset({"QQQ"})
+
+            def on_bar(self, ctx, bar):
+                if bar.symbol not in self.UNIVERSE:
+                    return
+                bars = ctx.history(bar.symbol, 200)
+                fast = sum(b.close for b in bars[-50:]) / 50
+                slow = sum(b.close for b in bars[-200:]) / 200
+                pos = ctx.position(bar.symbol)
+                qty = max(1, int(ctx.equity * 0.02 / bar.close))
+                if pos is None and fast > slow:
+                    ctx.submit_order(symbol=bar.symbol, qty=qty, side="LONG")
+                elif pos is not None and bar.close < pos.entry_price * 0.95:
+                    ctx.submit_order(symbol=bar.symbol, qty=pos.qty, side="SHORT")
+        """
+    )
+    spec = _spec(
+        entry_rules=[_sma_cross_entry()],
+        exit_rules=[StopLossRule(pct=0.05)],
+        target_symbols=["QQQ"],
+    )
+    results = CodeConformanceGate().check(code, spec)
+    crits = _critical_details(results)
+    assert any("indicator" in c.lower() and "sma" in c for c in crits), crits
+
+
+# ---------------------------------------------------------------------------
+# Check 2: symbol gate
+# ---------------------------------------------------------------------------
+
+
+def test_symbol_gate_passes_with_universe_guard() -> None:
+    results = CodeConformanceGate().check(_HAPPY_CODE, _happy_spec())
+    assert not any("UNIVERSE" in d for d in _critical_details(results))
+
+
+def test_symbol_gate_fails_when_universe_guard_replaced_with_true() -> None:
+    """Mandatory acceptance test from the issue: swap the runtime
+    membership check for ``True`` → critical failure on check #2."""
+    code = _HAPPY_CODE.replace(
+        "if bar.symbol not in self.UNIVERSE:",
+        "if not True:",
+    )
+    results = CodeConformanceGate().check(code, _happy_spec())
+    crits = _critical_details(results)
+    assert any("UNIVERSE" in c and "guard" in c for c in crits), crits
+
+
+def test_symbol_gate_fails_when_universe_constant_missing() -> None:
+    code = textwrap.dedent(
+        """
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                bars = ctx.history(bar.symbol, 200)
+                fast = sma(bars, 50)
+                slow = sma(bars, 200)
+                r = rsi(bars, 14)
+                pos = ctx.position(bar.symbol)
+                qty = max(1, int(ctx.equity * 0.02 / bar.close))
+                if pos is None and fast > slow:
+                    ctx.submit_order(symbol=bar.symbol, qty=qty, side="LONG")
+                elif pos is not None and r > 70:
+                    ctx.submit_order(symbol=bar.symbol, qty=pos.qty, side="SHORT")
+                elif pos is not None and bar.close < pos.entry_price * 0.95:
+                    ctx.submit_order(symbol=bar.symbol, qty=pos.qty, side="SHORT")
+        """
+    )
+    results = CodeConformanceGate().check(code, _happy_spec())
+    crits = _critical_details(results)
+    assert any("UNIVERSE" in c and "constant" in c for c in crits), crits
+
+
+def test_symbol_gate_skipped_when_target_symbols_empty() -> None:
+    # No UNIVERSE constant — but spec has no target_symbols, so check #2
+    # should not fire.
+    code = textwrap.dedent(
+        """
+        from contract import Strategy
+
+        class S(Strategy):
+            def on_bar(self, ctx, bar):
+                bars = ctx.history(bar.symbol, 200)
+                fast = sma(bars, 50)
+                slow = sma(bars, 200)
+                pos = ctx.position(bar.symbol)
+                qty = max(1, int(ctx.equity * 0.02 / bar.close))
+                if pos is None and fast > slow:
+                    ctx.submit_order(symbol=bar.symbol, qty=qty, side="LONG")
+                elif pos is not None and bar.close < pos.entry_price * 0.95:
+                    ctx.submit_order(symbol=bar.symbol, qty=pos.qty, side="SHORT")
+        """
+    )
+    spec = _spec(
+        entry_rules=[_sma_cross_entry()],
+        exit_rules=[StopLossRule(pct=0.05)],
+        target_symbols=[],
+    )
+    results = CodeConformanceGate().check(code, spec)
+    assert not any("UNIVERSE" in c for c in _critical_details(results))
+
+
+# ---------------------------------------------------------------------------
+# Check 3: entry coverage (the issue's other mandatory acceptance test)
+# ---------------------------------------------------------------------------
+
+
+def test_entry_coverage_passes_when_entry_branch_present() -> None:
+    results = CodeConformanceGate().check(_HAPPY_CODE, _happy_spec())
+    assert not any("entry rule" in d.lower() for d in _critical_details(results))
+
+
+def test_entry_coverage_fails_when_entry_submit_order_dropped() -> None:
+    """Mandatory acceptance test from the issue: drop the entry
+    submit_order from a working strategy → critical failure on check #3."""
+    code = _HAPPY_CODE.replace(
+        'ctx.submit_order(symbol=bar.symbol, qty=qty, side="LONG")',
+        "pass  # entry submit_order removed",
+    )
+    results = CodeConformanceGate().check(code, _happy_spec())
+    crits = _critical_details(results)
+    assert any("entry rule" in c.lower() for c in crits), crits
+
+
+# ---------------------------------------------------------------------------
+# Check 4: signal-exit coverage
+# ---------------------------------------------------------------------------
+
+
+def test_signal_exit_coverage_passes_with_position_qty_close() -> None:
+    results = CodeConformanceGate().check(_HAPPY_CODE, _happy_spec())
+    assert not any("signal-exit" in d.lower() for d in _critical_details(results))
+
+
+def test_signal_exit_coverage_fails_when_no_position_qty_close() -> None:
+    # Spec declares a signal-exit but the code only closes via stop-loss
+    # (qty=pos.qty kept, but every exit happens in the stop-loss branch
+    # — fine in isolation, but we drop the rsi branch entirely).
+    code = textwrap.dedent(
+        """
+        from contract import Strategy
+
+        class S(Strategy):
+            UNIVERSE = frozenset({"QQQ"})
+
+            def on_bar(self, ctx, bar):
+                if bar.symbol not in self.UNIVERSE:
+                    return
+                bars = ctx.history(bar.symbol, 200)
+                fast = sma(bars, 50)
+                slow = sma(bars, 200)
+                r = rsi(bars, 14)
+                pos = ctx.position(bar.symbol)
+                qty = max(1, int(ctx.equity * 0.02 / bar.close))
+                if pos is None and fast > slow:
+                    ctx.submit_order(symbol=bar.symbol, qty=qty, side="LONG")
+                elif pos is not None and bar.close < pos.entry_price * 0.95:
+                    # Closes via a constant qty instead of pos.qty — does
+                    # not satisfy the signal-exit shape.
+                    ctx.submit_order(symbol=bar.symbol, qty=1, side="SHORT")
+        """
+    )
+    spec = _spec(
+        entry_rules=[_sma_cross_entry()],
+        exit_rules=[_rsi_signal_exit(), StopLossRule(pct=0.05)],
+        target_symbols=["QQQ"],
+    )
+    results = CodeConformanceGate().check(code, spec)
+    crits = _critical_details(results)
+    assert any("signal-exit" in c.lower() for c in crits), crits
+
+
+# ---------------------------------------------------------------------------
+# Check 5: stop-loss enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_stop_loss_passes_when_entry_price_referenced() -> None:
+    results = CodeConformanceGate().check(_HAPPY_CODE, _happy_spec())
+    assert not any("StopLossRule" in d for d in _critical_details(results))
+
+
+def test_stop_loss_fails_when_entry_price_never_referenced() -> None:
+    # Strip both `pos.entry_price` references → check #5 fires.
+    code = _HAPPY_CODE.replace("pos.entry_price * 0.95", "0.0")
+    spec = _spec(
+        entry_rules=[_sma_cross_entry()],
+        exit_rules=[StopLossRule(pct=0.05)],
+        target_symbols=["QQQ"],
+    )
+    results = CodeConformanceGate().check(code, spec)
+    crits = _critical_details(results)
+    assert any("StopLossRule" in c and "entry_price" in c for c in crits), crits
+
+
+# ---------------------------------------------------------------------------
+# Check 6: take-profit enforcement
+# ---------------------------------------------------------------------------
+
+
+def test_take_profit_passes_when_entry_price_referenced() -> None:
+    spec = _spec(
+        entry_rules=[_sma_cross_entry()],
+        exit_rules=[TakeProfitRule(pct=0.10)],
+        target_symbols=["QQQ"],
+    )
+    results = CodeConformanceGate().check(_HAPPY_CODE, spec)
+    assert not any("TakeProfitRule" in d for d in _critical_details(results))
+
+
+def test_take_profit_fails_when_entry_price_never_referenced() -> None:
+    code = _HAPPY_CODE.replace("pos.entry_price * 0.95", "0.0")
+    spec = _spec(
+        entry_rules=[_sma_cross_entry()],
+        exit_rules=[TakeProfitRule(pct=0.10)],
+        target_symbols=["QQQ"],
+    )
+    results = CodeConformanceGate().check(code, spec)
+    crits = _critical_details(results)
+    assert any("TakeProfitRule" in c and "entry_price" in c for c in crits), crits
+
+
+# ---------------------------------------------------------------------------
+# Check 7: time-stop enforcement (no-op until DSL adds TimeStopRule)
+# ---------------------------------------------------------------------------
+
+
+def test_time_stop_check_is_currently_noop() -> None:
+    results = CodeConformanceGate().check(_HAPPY_CODE, _happy_spec())
+    time_stop_infos = [r for r in results if "TimeStopRule" in r.details and r.severity == "info"]
+    assert len(time_stop_infos) == 1
+
+
+# ---------------------------------------------------------------------------
+# Check 8: sizing math
+# ---------------------------------------------------------------------------
+
+
+def test_sizing_passes_when_qty_uses_ctx_equity() -> None:
+    results = CodeConformanceGate().check(_HAPPY_CODE, _happy_spec())
+    assert not any("Sizing" in d or "qty=" in d for d in _critical_details(results))
+
+
+def test_sizing_fails_when_qty_is_hardcoded_int() -> None:
+    code = _HAPPY_CODE.replace(
+        "qty = max(1, int(ctx.equity * 0.02 / bar.close))",
+        "qty = 10",
+    )
+    results = CodeConformanceGate().check(code, _happy_spec())
+    crits = _critical_details(results)
+    assert any("ctx.equity" in c or "ctx.capital" in c for c in crits), crits
+
+
+def test_sizing_fails_when_qty_is_inline_literal_int() -> None:
+    code = _HAPPY_CODE.replace(
+        'ctx.submit_order(symbol=bar.symbol, qty=qty, side="LONG")',
+        'ctx.submit_order(symbol=bar.symbol, qty=5, side="LONG")',
+    )
+    # The unused ``qty`` assignment still references ctx.equity above —
+    # to truly exercise the check, also strip the qty derivation.
+    code = code.replace(
+        "qty = max(1, int(ctx.equity * 0.02 / bar.close))",
+        "qty = 1",
+    )
+    results = CodeConformanceGate().check(code, _happy_spec())
+    crits = _critical_details(results)
+    assert any("Every entry" in c or "ctx.equity" in c or "ctx.capital" in c for c in crits), crits
+
+
+# ---------------------------------------------------------------------------
+# Check 9: no side-effects outside hooks/helpers
+# ---------------------------------------------------------------------------
+
+
+def test_no_extra_side_effects_passes_when_calls_only_in_on_bar() -> None:
+    results = CodeConformanceGate().check(_HAPPY_CODE, _happy_spec())
+    assert not any("disallowed scope" in d for d in _critical_details(results))
+
+
+def test_no_extra_side_effects_passes_for_helper_underscore_method() -> None:
+    code = textwrap.dedent(
+        """
+        from contract import Strategy
+
+        class S(Strategy):
+            UNIVERSE = frozenset({"QQQ"})
+
+            def _enter(self, ctx, bar):
+                qty = max(1, int(ctx.equity * 0.02 / bar.close))
+                ctx.submit_order(symbol=bar.symbol, qty=qty, side="LONG")
+
+            def on_bar(self, ctx, bar):
+                if bar.symbol not in self.UNIVERSE:
+                    return
+                bars = ctx.history(bar.symbol, 200)
+                fast = sma(bars, 50)
+                slow = sma(bars, 200)
+                pos = ctx.position(bar.symbol)
+                if pos is None and fast > slow:
+                    self._enter(ctx, bar)
+                elif pos is not None and bar.close < pos.entry_price * 0.95:
+                    ctx.submit_order(symbol=bar.symbol, qty=pos.qty, side="SHORT")
+        """
+    )
+    spec = _spec(
+        entry_rules=[_sma_cross_entry()],
+        exit_rules=[StopLossRule(pct=0.05)],
+        target_symbols=["QQQ"],
+    )
+    results = CodeConformanceGate().check(code, spec)
+    assert not any("disallowed scope" in d for d in _critical_details(results))
+
+
+def test_no_extra_side_effects_fails_when_submit_in_init() -> None:
+    code = textwrap.dedent(
+        """
+        from contract import Strategy
+
+        class S(Strategy):
+            UNIVERSE = frozenset({"QQQ"})
+
+            def __init__(self, ctx=None):
+                super().__init__()
+                if ctx is not None:
+                    ctx.submit_order(symbol="QQQ", qty=1, side="LONG")
+
+            def on_bar(self, ctx, bar):
+                if bar.symbol not in self.UNIVERSE:
+                    return
+                bars = ctx.history(bar.symbol, 200)
+                fast = sma(bars, 50)
+                slow = sma(bars, 200)
+                pos = ctx.position(bar.symbol)
+                qty = max(1, int(ctx.equity * 0.02 / bar.close))
+                if pos is None and fast > slow:
+                    ctx.submit_order(symbol=bar.symbol, qty=qty, side="LONG")
+                elif pos is not None and bar.close < pos.entry_price * 0.95:
+                    ctx.submit_order(symbol=bar.symbol, qty=pos.qty, side="SHORT")
+        """
+    )
+    spec = _spec(
+        entry_rules=[_sma_cross_entry()],
+        exit_rules=[StopLossRule(pct=0.05)],
+        target_symbols=["QQQ"],
+    )
+    results = CodeConformanceGate().check(code, spec)
+    crits = _critical_details(results)
+    assert any("disallowed scope" in c and "__init__" in c for c in crits), crits

--- a/backend/agents/investment_team/tests/test_code_conformance_gate.py
+++ b/backend/agents/investment_team/tests/test_code_conformance_gate.py
@@ -556,3 +556,220 @@ def test_no_extra_side_effects_fails_when_submit_in_init() -> None:
     results = CodeConformanceGate().check(code, spec)
     crits = _critical_details(results)
     assert any("disallowed scope" in c and "__init__" in c for c in crits), crits
+
+
+# ---------------------------------------------------------------------------
+# PR #588 Codex review — follow-up regressions
+# ---------------------------------------------------------------------------
+
+
+def test_indicator_presence_ignores_calls_in_unreachable_methods() -> None:
+    """Codex P1: an ``sma(...)`` call in a never-called helper must not
+    satisfy the indicator-presence check. ``on_bar`` is what runs at
+    runtime, so calls only count when reachable from it."""
+    code = textwrap.dedent(
+        """
+        from contract import Strategy
+
+        class S(Strategy):
+            UNIVERSE = frozenset({"QQQ"})
+
+            def _dead(self, ctx, bar):
+                # Reference sma here only — never called from on_bar.
+                _ = sma(ctx.history(bar.symbol, 50), 50)
+
+            def on_bar(self, ctx, bar):
+                if bar.symbol not in self.UNIVERSE:
+                    return
+                bars = ctx.history(bar.symbol, 200)
+                # Inline mean rather than calling sma() — and the spec's
+                # sma reference lives in the unreachable _dead helper.
+                fast = sum(b.close for b in bars[-50:]) / 50
+                slow = sum(b.close for b in bars[-200:]) / 200
+                pos = ctx.position(bar.symbol)
+                qty = max(1, int(ctx.equity * 0.02 / bar.close))
+                if pos is None and fast > slow:
+                    ctx.submit_order(symbol=bar.symbol, qty=qty, side="LONG")
+                elif pos is not None and bar.close < pos.entry_price * 0.95:
+                    ctx.submit_order(symbol=bar.symbol, qty=pos.qty, side="SHORT")
+        """
+    )
+    spec = _spec(
+        entry_rules=[_sma_cross_entry()],
+        exit_rules=[StopLossRule(pct=0.05)],
+        target_symbols=["QQQ"],
+    )
+    results = CodeConformanceGate().check(code, spec)
+    crits = _critical_details(results)
+    assert any("indicator" in c.lower() and "sma" in c for c in crits), crits
+
+
+def test_branch_coverage_does_not_double_count_nested_branches() -> None:
+    """Codex P1: ``if A: if B: submit()`` is one logical entry, not two.
+
+    The strategy below has two entry rules in spec but only ONE nested
+    submit_order. Without the nested-branch fix, both the outer and the
+    inner If would count as entry branches (2 ≥ 2) and the test would
+    silently pass. With the fix, only the innermost If is credited,
+    leaving 1 < 2 entry branches — critical fires."""
+    code = textwrap.dedent(
+        """
+        from contract import Strategy
+
+        class S(Strategy):
+            UNIVERSE = frozenset({"QQQ"})
+
+            def on_bar(self, ctx, bar):
+                if bar.symbol not in self.UNIVERSE:
+                    return
+                bars = ctx.history(bar.symbol, 200)
+                fast = sma(bars, 50)
+                slow = sma(bars, 200)
+                r = rsi(bars, 14)
+                pos = ctx.position(bar.symbol)
+                qty = max(1, int(ctx.equity * 0.02 / bar.close))
+                if pos is None:
+                    if fast > slow:
+                        ctx.submit_order(symbol=bar.symbol, qty=qty, side="LONG")
+                elif bar.close < pos.entry_price * 0.95:
+                    ctx.submit_order(symbol=bar.symbol, qty=pos.qty, side="SHORT")
+        """
+    )
+    spec = _spec(
+        entry_rules=[_sma_cross_entry(), _sma_cross_entry(side="short")],
+        exit_rules=[StopLossRule(pct=0.05)],
+        target_symbols=["QQQ"],
+    )
+    results = CodeConformanceGate().check(code, spec)
+    crits = _critical_details(results)
+    assert any("2 entry rule" in c and "only 1" in c for c in crits), crits
+
+
+def test_no_extra_side_effects_flags_dead_helper_with_submit() -> None:
+    """Codex P2: an unreachable ``_helper`` containing a submit_order
+    must trip check #9 — the helper convention is only safe when the
+    helper is actually called from a hook."""
+    code = textwrap.dedent(
+        """
+        from contract import Strategy
+
+        class S(Strategy):
+            UNIVERSE = frozenset({"QQQ"})
+
+            def _dead(self, ctx, bar):
+                # Never called from any hook — stray order code that the
+                # gate must surface, not silently accept.
+                ctx.submit_order(symbol="QQQ", qty=1, side="LONG")
+
+            def on_bar(self, ctx, bar):
+                if bar.symbol not in self.UNIVERSE:
+                    return
+                bars = ctx.history(bar.symbol, 200)
+                fast = sma(bars, 50)
+                slow = sma(bars, 200)
+                pos = ctx.position(bar.symbol)
+                qty = max(1, int(ctx.equity * 0.02 / bar.close))
+                if pos is None and fast > slow:
+                    ctx.submit_order(symbol=bar.symbol, qty=qty, side="LONG")
+                elif pos is not None and bar.close < pos.entry_price * 0.95:
+                    ctx.submit_order(symbol=bar.symbol, qty=pos.qty, side="SHORT")
+        """
+    )
+    spec = _spec(
+        entry_rules=[_sma_cross_entry()],
+        exit_rules=[StopLossRule(pct=0.05)],
+        target_symbols=["QQQ"],
+    )
+    results = CodeConformanceGate().check(code, spec)
+    crits = _critical_details(results)
+    assert any("disallowed scope" in c and "_dead" in c for c in crits), crits
+
+
+def test_entry_coverage_accepts_kwargs_spread_submit() -> None:
+    """Codex P2: ``ctx.submit_order(**order_kwargs)`` may dynamically
+    carry ``side`` — the gate must treat the spread as a plausible entry
+    rather than failing closed."""
+    code = textwrap.dedent(
+        """
+        from contract import Strategy
+
+        class S(Strategy):
+            UNIVERSE = frozenset({"QQQ"})
+
+            def on_bar(self, ctx, bar):
+                if bar.symbol not in self.UNIVERSE:
+                    return
+                bars = ctx.history(bar.symbol, 200)
+                fast = sma(bars, 50)
+                slow = sma(bars, 200)
+                pos = ctx.position(bar.symbol)
+                qty = max(1, int(ctx.equity * 0.02 / bar.close))
+                if pos is None and fast > slow:
+                    order_kwargs = {"symbol": bar.symbol, "qty": qty, "side": "LONG"}
+                    ctx.submit_order(**order_kwargs)
+                elif pos is not None and bar.close < pos.entry_price * 0.95:
+                    ctx.submit_order(symbol=bar.symbol, qty=pos.qty, side="SHORT")
+        """
+    )
+    spec = _spec(
+        entry_rules=[_sma_cross_entry()],
+        exit_rules=[StopLossRule(pct=0.05)],
+        target_symbols=["QQQ"],
+    )
+    results = CodeConformanceGate().check(code, spec)
+    crits = _critical_details(results)
+    assert not any("entry rule" in c.lower() for c in crits), crits
+
+
+def test_signal_exit_coverage_accepts_kwargs_spread_submit() -> None:
+    """Codex P2: ``ctx.submit_order(**close_kwargs)`` may dynamically
+    carry ``qty=position.qty`` — the gate must treat the spread as a
+    plausible close."""
+    code = textwrap.dedent(
+        """
+        from contract import Strategy
+
+        class S(Strategy):
+            UNIVERSE = frozenset({"QQQ"})
+
+            def on_bar(self, ctx, bar):
+                if bar.symbol not in self.UNIVERSE:
+                    return
+                bars = ctx.history(bar.symbol, 200)
+                fast = sma(bars, 50)
+                slow = sma(bars, 200)
+                r = rsi(bars, 14)
+                pos = ctx.position(bar.symbol)
+                qty = max(1, int(ctx.equity * 0.02 / bar.close))
+                if pos is None and fast > slow:
+                    ctx.submit_order(symbol=bar.symbol, qty=qty, side="LONG")
+                elif pos is not None and r > 70:
+                    close_kwargs = {"symbol": bar.symbol, "qty": pos.qty, "side": "SHORT"}
+                    ctx.submit_order(**close_kwargs)
+        """
+    )
+    spec = _spec(
+        entry_rules=[_sma_cross_entry()],
+        exit_rules=[_rsi_signal_exit()],
+        target_symbols=["QQQ"],
+    )
+    results = CodeConformanceGate().check(code, spec)
+    crits = _critical_details(results)
+    assert not any("signal-exit" in c.lower() for c in crits), crits
+
+
+def test_sizing_does_not_flag_boolean_qty_as_hardcoded_int() -> None:
+    """Codex P3: ``True`` / ``False`` are ``int`` subclasses; the
+    hardcoded-int check must exclude them so a boolean qty (itself an
+    anti-pattern, but a different one) is not misreported."""
+    code = _HAPPY_CODE.replace(
+        'ctx.submit_order(symbol=bar.symbol, qty=qty, side="LONG")',
+        'ctx.submit_order(symbol=bar.symbol, qty=True, side="LONG")',
+    )
+    results = CodeConformanceGate().check(code, _happy_spec())
+    crits = _critical_details(results)
+    # The "Every entry … literal integer ``qty=``" message must not fire
+    # for a boolean. ``ctx.equity`` is still referenced in the (unused)
+    # qty assignment, so the sizing fallback also passes — no sizing
+    # critical at all.
+    assert not any("literal integer" in c or "Every entry" in c for c in crits), crits

--- a/backend/agents/investment_team/tests/test_code_conformance_gate.py
+++ b/backend/agents/investment_team/tests/test_code_conformance_gate.py
@@ -293,6 +293,45 @@ def test_entry_coverage_fails_when_entry_submit_order_dropped() -> None:
     assert any("entry rule" in c.lower() for c in crits), crits
 
 
+def test_entry_coverage_ignores_unreachable_helper_branches() -> None:
+    """Codex P1 from PR #588: a branch in an unused helper must not
+    satisfy entry coverage. The submit_order in ``_dead`` is never
+    executed because nothing in on_bar calls ``self._dead(...)``."""
+    code = textwrap.dedent(
+        """
+        from contract import Strategy
+
+        class S(Strategy):
+            UNIVERSE = frozenset({"QQQ"})
+
+            def _dead(self, ctx, bar):
+                # Unreachable from on_bar — must NOT satisfy entry coverage.
+                if True:
+                    ctx.submit_order(symbol=bar.symbol, qty=1, side="LONG")
+
+            def on_bar(self, ctx, bar):
+                if bar.symbol not in self.UNIVERSE:
+                    return
+                bars = ctx.history(bar.symbol, 200)
+                fast = sma(bars, 50)
+                slow = sma(bars, 200)
+                qty = max(1, int(ctx.equity * 0.02 / bar.close))
+                # No entry submit_order in any on_bar branch.
+                pos = ctx.position(bar.symbol)
+                if pos is not None and bar.close < pos.entry_price * 0.95:
+                    ctx.submit_order(symbol=bar.symbol, qty=pos.qty, side="SHORT")
+        """
+    )
+    spec = _spec(
+        entry_rules=[_sma_cross_entry()],
+        exit_rules=[StopLossRule(pct=0.05)],
+        target_symbols=["QQQ"],
+    )
+    results = CodeConformanceGate().check(code, spec)
+    crits = _critical_details(results)
+    assert any("entry rule" in c.lower() and "reachable" in c.lower() for c in crits), crits
+
+
 # ---------------------------------------------------------------------------
 # Check 4: signal-exit coverage
 # ---------------------------------------------------------------------------

--- a/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_walk_forward_integration.py
@@ -629,6 +629,11 @@ def test_walk_forward_fallback_rejects_overfit_via_anomaly_recheck(monkeypatch):
     monkeypatch.setattr(
         orch.refinement_agent, "run", lambda **kw: ({"changes_made": "x"}, overfit_code)
     )
+    # CodeConformanceGate (#541) rejects the minimal stub strategy code
+    # used here (qty=1, no entry conditional). Neutralise it the same
+    # way the other gates are neutralised — synthesis-phase code
+    # conformance is not the subject under test on the fallback path.
+    monkeypatch.setattr(orch.code_conformance_gate, "check", lambda *a, **kw: [])
     monkeypatch.setattr(
         orch.alignment_agent, "run", lambda **kw: TradeAlignmentReport(aligned=True, rationale="ok")
     )
@@ -757,6 +762,11 @@ def _wire_run_cycle_stubs(
     )
     monkeypatch.setattr(orch.ideation_agent, "run", lambda **kw: (spec_dict, code, "rationale"))
     monkeypatch.setattr(orch.refinement_agent, "run", lambda **kw: ({"changes_made": "x"}, code))
+    # CodeConformanceGate (#541) rejects the minimal stub strategy used in
+    # these tests (qty=1, no entry conditional). Neutralise it the same
+    # way other gates are neutralised — the walk-forward path is the
+    # subject under test, not synthesis-phase code conformance.
+    monkeypatch.setattr(orch.code_conformance_gate, "check", lambda *a, **kw: [])
     monkeypatch.setattr(
         orch.alignment_agent,
         "run",


### PR DESCRIPTION
Closes #541.

## Summary

New deterministic synthesis-phase quality gate that verifies generated strategy code actually implements the rules declared in the spec. Runs immediately after `CodeSafetyChecker` and before the first sandbox execution; critical failures route back to `RefinementAgent` via the existing `_refine_or_exhaust(failure_phase="validation")` path.

Catches the silent failure mode where a rule is never implemented and therefore never fires in the test window — the post-hoc `TradeAlignmentAgent` cannot reason about rules that never produced trades.

Unblocks #542 (synthetic-bar probes), #545 (replace LLM alignment audit), and #549 (acceptance criteria) under EPIC #536.

## The nine checks

| # | Check | Behavior |
|---|---|---|
| 1 | Indicator presence | Every `IndicatorRef` in entry/exit predicates must appear as a named call (`sma(...)`, `bollinger_bands(...)`). v1 does not accept inline equivalents — see scope notes. |
| 2 | Symbol gate | When `spec.target_symbols` is non-empty, the class must declare a `UNIVERSE` constant AND `on_bar` must contain the `if bar.symbol not in self.UNIVERSE: return` guard. Reuses `code_safety_ast` helpers as defense-in-depth. |
| 3 | Entry predicate coverage | Each `EntryRule` needs an `if`/`elif` branch with `ctx.submit_order(..., side=...)` (non-closing). |
| 4 | Signal-exit coverage | Each `SignalExitRule` needs an `if`/`elif` branch with `ctx.submit_order(..., qty=position.qty)`. |
| 5 | Stop-loss enforcement | When `StopLossRule` present, the class must reference `position.entry_price` somewhere. |
| 6 | Take-profit enforcement | Same shape as #5 (entry-price reference). |
| 7 | Time-stop enforcement | No-op today — `spec_dsl.py` deliberately excludes `TimeStopRule`. Wired up so it activates the moment the DSL adds it. |
| 8 | Sizing math | Strategy class must reference `ctx.equity` / `ctx.capital`; hardcoded-int `qty=` on every entry submit is an immediate critical. |
| 9 | No extra side-effects | `ctx.submit_order` is only allowed in `on_bar` / `on_fill` / `on_end` (or a single-underscore `_helper` method). Dunder methods like `__init__` are forbidden. |

## Scope choices (v1)

- **Named indicator calls only** (no inline-equivalent matching). The deterministic compiler track (#538) makes inline-equivalent detection unnecessary on the compiled path.
- **Time-stop check** is a no-op until `TimeStopRule` lands in the DSL — implemented as a guarded `globals().get(...)` lookup so the gate emits an `info` today.
- **Symbol-gate** intentionally duplicates `CodeSafetyChecker._check_universe_guard` as defense-in-depth so this gate is self-sufficient.

## Acceptance tests from the issue

- ✅ Drop the entry `submit_order` from a working strategy → critical failure on check #3 (`test_entry_coverage_fails_when_entry_submit_order_dropped`).
- ✅ Replace `bar.symbol in UNIVERSE` with `True` → critical failure on check #2 (`test_symbol_gate_fails_when_universe_guard_replaced_with_true`).

## Wiring

- `orchestrator.py:__init__` instantiates `self.code_conformance_gate`.
- `orchestrator.py:_run_synthesis_loop` calls `self.code_conformance_gate.check(code, spec)` right after `self.code_safety_checker.check(code, spec)`; results join `round_gate_results` and feed the same critical→refinement routing.
- `_wire_run_cycle_stubs` (walk-forward integration tests) and the one bespoke fallback test stub the new gate to `[]`, matching how `anomaly_detector` / `target_symbol_coverage_gate` are stubbed in those tests — synthesis-phase code conformance is not the subject under test on those paths.

## Test plan

- [x] 24 new tests in `tests/test_code_conformance_gate.py` — at least one positive and one negative case per check, plus the two issue-mandated acceptance tests.
- [x] Full `agents/investment_team/tests/` suite: **1,473 passed, 10 skipped**.
- [x] `ruff check` + `ruff format` clean on touched files.
- [ ] Manual smoke through `POST /api/investment/strategy-lab/...` after Postgres + job-service are up — confirm `quality_gate_results` contains entries with `gate_name="code_conformance"` and `phase="synthesis"`, and that mutating a strategy template (e.g. swapping an `sma()` call for an inline rolling-mean loop) triggers refinement.

## Out of scope (separate issues)

- Replacing `TradeAlignmentAgent` (#545).
- Inline-equivalent matching for check #1 (future enhancement).
- Synthetic-bar probes (#542).
- Deterministic compiler integration (#538).


---
_Generated by [Claude Code](https://claude.ai/code/session_01PeKSFod5UQGHPSYPAQDmqZ)_