### PR TITLE
investment-team: live ENTRY_WITH_NO_EXIT diagnostics test — closes #404 AC

### DIFF
--- a/backend/agents/investment_team/tests/test_trading_service.py
+++ b/backend/agents/investment_team/tests/test_trading_service.py
@@ -807,6 +807,47 @@ def test_diagnostics_last_order_events_capped_at_twenty() -> None:
     assert len(diagnostics.last_order_events) == _MAX_ORDER_EVENTS
 
 
+def test_diagnostics_entry_filled_no_exit_classified() -> None:
+    """An entry that fills but never sees a matching exit lands in ENTRY_WITH_NO_EXIT.
+
+    Closes the last AC for #404: covers the fourth required category alongside
+    NO_ORDERS_EMITTED, ORDERS_REJECTED, and ORDERS_UNFILLED.
+    """
+    market_data: Dict[str, List[OHLCVBar]] = {}
+    _uptrend_then_down_bars(market_data)
+
+    # LateMarketStrategy emits a market BUY on bar 0 (no position yet); once
+    # the order fills on bar 1, every subsequent on_bar returns early. With
+    # an empty ``exit_rules`` list the engine injects no synthetic closes, so
+    # the position stays open through end-of-stream — exactly the scenario
+    # the ENTRY_WITH_NO_EXIT category is meant to classify.
+    strategy = StrategySpec(
+        strategy_id="strat-404-entry-no-exit",
+        authored_by="tests",
+        asset_class="equity",
+        hypothesis="entry without exit",
+        signal_definition="buy once, never sell",
+        timeframe="1d",
+        entry_rules=[],
+        exit_rules=[],
+        strategy_code=_LATE_MARKET_ORDER_STRATEGY_CODE,
+    )
+
+    run = run_backtest(strategy=strategy, config=_config(), market_data=market_data)
+    diagnostics = run.service_result.execution_diagnostics
+
+    assert run.service_result.error is None, run.service_result.error
+    assert not run.trades
+    assert diagnostics.entries_filled >= 1
+    assert diagnostics.exits_emitted == 0
+    assert diagnostics.closed_trades == 0
+    assert diagnostics.orders_unfilled == 0
+    assert diagnostics.zero_trade_category == "ENTRY_WITH_NO_EXIT"
+    assert "filled but the strategy never emitted an exit" in diagnostics.summary
+    entry_events = [e for e in diagnostics.last_order_events if e.event_type == "entry_filled"]
+    assert entry_events, f"expected an entry_filled event, got {diagnostics.last_order_events}"
+
+
 def test_run_backtest_without_strategy_code_raises() -> None:
     """The LLM-per-bar fallback is removed; no strategy_code must fail fast."""
     strategy = StrategySpec(


### PR DESCRIPTION
## Summary

Closes the final acceptance criterion for #404 (Strategy Lab zero-trade diagnostics envelope). All 8 implementation sub-issues — #407, #408, #409, #410, #411, #412, #413, #414 — already merged. The umbrella AC required live engine tests for **four** zero-trade categories; three were covered, one was not.

| Category | Live engine test | Where |
|---|---|---|
| `NO_ORDERS_EMITTED` | ✅ existing | `test_trading_service.py::test_zero_trade_result_gets_no_orders_emitted_category` |
| `ORDERS_REJECTED` | ✅ existing | `test_trading_service.py::test_diagnostics_malformed_order_records_rejection_and_continues` + `test_fill_simulator_diagnostics.py::test_risk_gate_emits_rejected_event_with_prefix` / `test_insufficient_capital_emits_rejected_event` |
| `ORDERS_UNFILLED` | ✅ existing | `test_trading_service.py::test_diagnostics_day_order_expiry_records_unfilled` |
| `ENTRY_WITH_NO_EXIT` | ✅ **this PR** | `test_trading_service.py::test_diagnostics_entry_filled_no_exit_classified` |

Before this PR, `ENTRY_WITH_NO_EXIT` was only exercised by synthetic-diagnostics unit tests in `test_strategy_lab_zero_trade_repair.py` and `test_backtest_anomaly_zero_trade_diagnostics.py`. The classifier branch at `trading_service/service.py:805` had no live caller.

## What the test does

Reuses `_LATE_MARKET_ORDER_STRATEGY_CODE` — its early-return-when-position-exists branch is exactly the "buy once, never sell" shape this category is meant to catch. With `exit_rules=[]` the engine injects no synthetic closes (`_EngineExitDispatcher.maybe_emit` is a no-op when `self.exit_rules` is empty — see `service.py:178`), so the position stays open through end-of-stream. The classifier then tags the run `ENTRY_WITH_NO_EXIT` and emits the documented summary.

Asserts:
- `entries_filled >= 1`
- `exits_emitted == 0`
- `closed_trades == 0`
- `orders_unfilled == 0`
- `zero_trade_category == "ENTRY_WITH_NO_EXIT"`
- summary contains "filled but the strategy never emitted an exit"
- at least one `entry_filled` lifecycle event

## Follow-up noticed during this work (out of scope)

`BacktestExecutionDiagnostics.open_positions_at_end` is defined on the model and round-tripped in unit tests but **never populated by the trading service**. An entry-with-no-exit run that leaves a position open through EOS returns `open_positions_at_end=[]`. Worth filing as a small follow-up issue — the field is referenced by `_format_execution_diagnostics` and could improve refinement-prompt signal — but it's not part of #404's AC.

## Test plan

- [x] `pytest backend/agents/investment_team/tests/test_trading_service.py` — 24/24 pass
- [x] `pytest` adjacent diagnostics files (`test_execution_diagnostics_models.py`, `test_backtest_anomaly_zero_trade_diagnostics.py`, `test_strategy_lab_diagnostics_prompt.py`, `test_fill_simulator_diagnostics.py`) — 39/39 pass
- [x] `ruff check` + `ruff format --check` on the touched file — clean

On merge: please close #404.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KiP5qkVCd3pvRhwj48Fdxe)_