### PR TITLE
product-delivery: GET /sprints?product_id route + drop UI degrade branch (#372)

### DIFF
--- a/backend/agents/product_delivery/tests/test_api.py
+++ b/backend/agents/product_delivery/tests/test_api.py
@@ -443,6 +443,14 @@ class _FakeStore:
     def get_sprint(self, sprint_id: str) -> Sprint | None:
         return self.sprints.get(sprint_id)
 
+    def list_sprints_for_product(self, product_id: str) -> list[Sprint]:
+        # Mirror the real store: unknown product → 404, otherwise return
+        # sprints under the product ordered created_at desc.
+        if product_id not in self.products:
+            raise UnknownProductDeliveryEntity(f"unknown product: {product_id}")
+        rows = [s for s in self.sprints.values() if s.product_id == product_id]
+        return sorted(rows, key=lambda s: s.created_at, reverse=True)
+
     def add_story_to_sprint(self, *, sprint_id: str, story_id: str) -> bool:
         if sprint_id not in self.sprints or story_id not in self.stories:
             raise UnknownProductDeliveryEntity(
@@ -1822,6 +1830,48 @@ def test_get_sprint_returns_planned_stories_ordered_by_wsjf(
 def test_get_sprint_404_when_missing(client: TestClient) -> None:
     r = client.get("/api/product-delivery/sprints/missing")
     assert r.status_code == 404
+
+
+def test_list_sprints_for_product_round_trip(
+    client_and_store: tuple[TestClient, _FakeStore],
+) -> None:
+    """`GET /sprints?product_id=…` returns the product's sprints, newest first.
+
+    Mirrors `list_releases_for_product` (newest by `created_at`). The two
+    sprints are created in order S1 then S2, so S2 must come back first.
+    """
+    client, _ = client_and_store
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    s1 = client.post(
+        "/api/product-delivery/sprints",
+        json={"product_id": pid, "name": "S1", "capacity_points": 5},
+    ).json()["id"]
+    s2 = client.post(
+        "/api/product-delivery/sprints",
+        json={"product_id": pid, "name": "S2", "capacity_points": 5},
+    ).json()["id"]
+    resp = client.get(f"/api/product-delivery/sprints?product_id={pid}")
+    assert resp.status_code == 200, resp.text
+    ids = [s["id"] for s in resp.json()]
+    assert ids == [s2, s1]
+
+
+def test_list_sprints_for_product_empty_for_product_with_no_sprints(
+    client_and_store: tuple[TestClient, _FakeStore],
+) -> None:
+    client, _ = client_and_store
+    pid = client.post("/api/product-delivery/products", json={"name": "P"}).json()["id"]
+    resp = client.get(f"/api/product-delivery/sprints?product_id={pid}")
+    assert resp.status_code == 200, resp.text
+    assert resp.json() == []
+
+
+def test_list_sprints_unknown_product_returns_404(
+    client_and_store: tuple[TestClient, _FakeStore],
+) -> None:
+    client, _ = client_and_store
+    resp = client.get("/api/product-delivery/sprints?product_id=missing")
+    assert resp.status_code == 404
 
 
 def test_sprint_plan_404_when_sprint_missing(client: TestClient) -> None:

--- a/backend/unified_api/routes/product_delivery.py
+++ b/backend/unified_api/routes/product_delivery.py
@@ -339,6 +339,18 @@ def create_sprint(body: CreateSprintRequest) -> Sprint:
     )
 
 
+@router.get("/sprints", response_model=list[Sprint])
+def list_sprints(product_id: str) -> list[Sprint]:
+    """List sprints under a product, newest first.
+
+    A missing product surfaces as 404 via ``UnknownProductDeliveryEntity``
+    (raised by ``store.list_sprints_for_product`` in the same
+    REPEATABLE READ transaction as the SELECT — no TOCTTOU window where a
+    concurrent product delete could turn a 404 into ``200 []``).
+    """
+    return get_store().list_sprints_for_product(product_id)
+
+
 @router.post("/sprints/{sprint_id}/plan", response_model=SprintPlanResult)
 def plan_sprint(
     sprint_id: str,

--- a/user-interface/src/app/components/agent-console/sprints-tab/sprints-tab.component.html
+++ b/user-interface/src/app/components/agent-console/sprints-tab/sprints-tab.component.html
@@ -61,13 +61,6 @@
     <div class="sprints-tab__loading">
       <mat-spinner diameter="32"></mat-spinner>
     </div>
-  } @else if (endpointMissing()) {
-    <div class="sprints-tab__empty">
-      Sprint listing endpoint isn't available on this deployment. Create sprints via
-      <code>POST /api/product-delivery/sprints</code> and use
-      <code>POST /sprints/{{ '{' }}id{{ '}' }}/plan</code> directly until the listing
-      route ships.
-    </div>
   } @else if (sprints().length === 0) {
     <div class="sprints-tab__empty">No sprints yet for this product.</div>
   } @else {

--- a/user-interface/src/app/components/agent-console/sprints-tab/sprints-tab.component.spec.ts
+++ b/user-interface/src/app/components/agent-console/sprints-tab/sprints-tab.component.spec.ts
@@ -70,21 +70,20 @@ describe('SprintsTabComponent', () => {
     expect(fixture.componentInstance.sprints()).toEqual([sprint]);
   });
 
-  it('degrades gracefully when the sprints endpoint 404s', () => {
-    api.listSprints = vi.fn().mockReturnValue(throwError(() => ({ status: 404 })));
+  it('renders the empty state when the product has no sprints', () => {
+    api.listSprints = vi.fn().mockReturnValue(of([]));
     const fixture = build();
     fixture.detectChanges();
-    expect(fixture.componentInstance.endpointMissing()).toBe(true);
     expect(fixture.componentInstance.sprints()).toEqual([]);
     expect(fixture.componentInstance.error()).toBeNull();
   });
 
-  it('surfaces non-404 sprint errors', () => {
+  it('surfaces sprint listing errors', () => {
     api.listSprints = vi.fn().mockReturnValue(throwError(() => ({ error: { detail: 'boom' } })));
     const fixture = build();
     fixture.detectChanges();
     expect(fixture.componentInstance.error()).toBe('boom');
-    expect(fixture.componentInstance.endpointMissing()).toBe(false);
+    expect(fixture.componentInstance.sprints()).toEqual([]);
   });
 
   it('enables Plan only for draft/proposed/planning sprints', () => {

--- a/user-interface/src/app/components/agent-console/sprints-tab/sprints-tab.component.ts
+++ b/user-interface/src/app/components/agent-console/sprints-tab/sprints-tab.component.ts
@@ -51,8 +51,6 @@ export class SprintsTabComponent implements OnInit {
   readonly planningId = signal<string | null>(null);
   readonly planResult = signal<SprintPlanResult | null>(null);
   readonly error = signal<string | null>(null);
-  /** When the endpoint isn't implemented yet, degrade silently to empty. */
-  readonly endpointMissing = signal<boolean>(false);
 
   ngOnInit(): void {
     this.refreshProducts();
@@ -87,7 +85,6 @@ export class SprintsTabComponent implements OnInit {
     if (!productId) return;
     this.loadingSprints.set(true);
     this.error.set(null);
-    this.endpointMissing.set(false);
     this.api.listSprints(productId).subscribe({
       next: (rows) => {
         this.sprints.set(rows);
@@ -96,15 +93,7 @@ export class SprintsTabComponent implements OnInit {
       error: (err) => {
         this.sprints.set([]);
         this.loadingSprints.set(false);
-        // The plan calls out graceful degradation: a 404 / 503 on
-        // sprints listing means the route isn't there yet — render an
-        // explainer instead of a hard error so the tab doesn't claim
-        // the loop is broken.
-        if (err?.status === 404 || err?.status === 503) {
-          this.endpointMissing.set(true);
-        } else {
-          this.error.set(err?.error?.detail ?? err?.message ?? 'Failed to load sprints.');
-        }
+        this.error.set(err?.error?.detail ?? err?.message ?? 'Failed to load sprints.');
       },
     });
   }

--- a/user-interface/src/app/services/product-delivery.service.ts
+++ b/user-interface/src/app/services/product-delivery.service.ts
@@ -84,14 +84,7 @@ export class ProductDeliveryService {
   // Sprints
   // -------------------------------------------------------------------------
 
-  /**
-   * The backend doesn't expose `GET /sprints?product_id=…` directly today;
-   * the canonical listing route is `GET /products/{id}/backlog` for stories
-   * and individual `GET /sprints/{id}` for sprint detail. We list per
-   * product via the dedicated sprints listing endpoint when one is added;
-   * meanwhile this method returns the empty list and components degrade
-   * gracefully (`Phase 2/3 ships sprints; UI degrades to empty on 404`).
-   */
+  /** List every sprint under a product, newest first. */
   listSprints(productId: string): Observable<Sprint[]> {
     let params = new HttpParams();
     params = params.set('product_id', productId);


### PR DESCRIPTION
## Summary

Closes the last gap behind the Agent Console Sprints tab. The Postgres store already had `list_sprints_for_product` (REPEATABLE READ existence check + SELECT in one transaction → 404 on unknown product), but the FastAPI router only exposed `POST /sprints`, `POST /sprints/{id}/plan`, and `GET /sprints/{id}` — so the tab was permanently stuck on its "endpoint missing" graceful-degradation explainer.

- **Backend** — `unified_api/routes/product_delivery.py`: add `GET /api/product-delivery/sprints?product_id=…` returning `list[Sprint]`. Thin wrapper over `store.list_sprints_for_product`; missing product surfaces as 404 via the global `UnknownProductDeliveryEntity` handler. Mirrors the shape of `GET /releases?product_id=…`.
- **Backend tests** — add `_FakeStore.list_sprints_for_product` plus three API tests (round-trip newest-first, empty for product with no sprints, 404 for unknown product).
- **UI** — drop the now-dead `endpointMissing` signal + the 404/503 branch in `loadSprints`, drop the `@else if (endpointMissing())` template block, and clean up the stale JSDoc on `ProductDeliveryService.listSprints`. The existing "No sprints yet for this product." empty state covers the legitimate empty case.
- **UI tests** — replace the 404-degrade test with an empty-state test; tighten the error test to drop the now-removed `endpointMissing()` assertion.

This closes #372. The bulk of that issue shipped in #476 (the four new Agent Console tabs); only the sprints listing route + the explainer cleanup remained.

## Test plan

- [x] `ruff check` + `ruff format --check` on touched backend files
- [x] `python3 -m pytest agents/product_delivery/tests/test_api.py` — 109 passed (incl. 3 new)
- [x] `python3 -m pytest agents/product_delivery/tests/` (excluding live-Postgres `test_store.py`) — 233 passed
- [x] `npx vitest run src/app/components/agent-console/sprints-tab/` — 7 passed
- [x] `npx vitest run src/app/services/product-delivery.service.spec.ts` — 20 passed
- [x] `npx eslint` on touched UI files — clean
- [x] `npm run build` — clean (pre-existing bundle-size warning, unrelated)
- [ ] Live smoke: stand up Postgres + unified API + UI, create product+sprint via curl, confirm Sprints tab lists it (no explainer) and Plan button works

https://claude.ai/code/session_01QG5mU1hFh7gdUsQeCQpvJs

---
_Generated by [Claude Code](https://claude.ai/code/session_01QG5mU1hFh7gdUsQeCQpvJs)_