### PR TITLE
ai_systems_team: convert integration-marked tests to unit tests

### DIFF
--- a/backend/agents/ai_systems_team/tests/conftest.py
+++ b/backend/agents/ai_systems_team/tests/conftest.py
@@ -1,6 +1,25 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture(autouse=True)
+def _patched_job_store(monkeypatch, fake_job_client):
+    """Route the ai_systems_team job_store's ``_client`` through the in-memory fake.
+
+    Preconditions: pytest is running under ``backend/conftest.py`` so
+        ``fake_job_client`` resolves to the function-scoped
+        ``FakeJobServiceClient`` defined there.
+    Postconditions: every call to ``ai_systems_team.shared.job_store._client(...)``
+        within a test returns the same per-test ``FakeJobServiceClient`` instance;
+        the real ``JobServiceClient`` is never constructed.
+    """
+    from ai_systems_team.shared import job_store as js
+
+    monkeypatch.setattr(js, "_client", lambda *a, **kw: fake_job_client)
+    return fake_job_client

--- a/backend/agents/ai_systems_team/tests/test_api.py
+++ b/backend/agents/ai_systems_team/tests/test_api.py
@@ -1,17 +1,18 @@
 """Tests for ai_systems_team API endpoints.
 
-Hits the team API which calls the real job service.  Marked integration
-pending follow-up to mock the team's ``_client`` factory.
+Drives the team API through ``TestClient``. The autouse fixture in
+``tests/conftest.py`` swaps ``ai_systems_team.shared.job_store._client`` for an
+in-memory ``FakeJobServiceClient``, so any endpoint path that reaches the
+job_store helpers stays off the network. A few tests additionally patch the
+``api.main`` module-level imports of those helpers to assert specific return
+values; both layers cooperate.
 """
 
 from unittest.mock import patch
 
-import pytest
 from fastapi.testclient import TestClient
 
 from ai_systems_team.api.main import app
-
-pytestmark = [pytest.mark.integration]
 
 client = TestClient(app)
 

--- a/backend/agents/ai_systems_team/tests/test_job_store.py
+++ b/backend/agents/ai_systems_team/tests/test_job_store.py
@@ -1,8 +1,8 @@
 """Tests for ai_systems_team job store.
 
-Exercises the team's job_store helpers directly; relied on the file
-fallback that is now removed.  Marked integration until follow-up
-conversion to the in-memory fake.
+Exercises the team's job_store helpers directly. The autouse fixture in
+``tests/conftest.py`` swaps ``_client`` for an in-memory ``FakeJobServiceClient``,
+so these tests do not require a live job service or Postgres.
 """
 
 import pytest
@@ -23,8 +23,6 @@ from ai_systems_team.shared.job_store import (
     mark_job_failed,
     mark_job_running,
 )
-
-pytestmark = [pytest.mark.integration]
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary

- Add an autouse fixture in `backend/agents/ai_systems_team/tests/conftest.py` that monkeypatches `ai_systems_team.shared.job_store._client` to return the in-memory `FakeJobServiceClient` already exposed project-wide by `backend/conftest.py`.
- Drop `pytestmark = [pytest.mark.integration]` from `test_job_store.py` and `test_api.py`. Both files now run in the default fast suite without needing a live job service or Postgres.
- Pattern mirrors `backend/agents/software_engineering_team/tests/test_job_store_heartbeat.py`.

## Test plan

- [x] `pytest agents/ai_systems_team/tests/test_job_store.py agents/ai_systems_team/tests/test_api.py -v` — 20/20 pass.
- [x] `pytest agents/ai_systems_team/tests/ -v -m "not integration"` — 41/41 pass, none deselected.
- [x] `grep -rn "pytest.mark.integration" agents/ai_systems_team/tests/` — no matches.
- [x] `ruff check` and `ruff format --check` clean on the modified files.


---
_Generated by [Claude Code](https://claude.ai/code/session_01KdxYBoe77k7VdoPaG2HmCK)_