### PR TITLE
market_research_team: raise test coverage from 88% to 97%

### DIFF
--- a/backend/agents/market_research_team/tests/test_api_lifecycle.py
+++ b/backend/agents/market_research_team/tests/test_api_lifecycle.py
@@ -1,0 +1,167 @@
+"""Coverage for the cancel / delete / list endpoints and job-store wrappers
+that the happy-path tests in ``test_api.py`` don't exercise.
+
+These tests rely on the autouse ``fake_job_client`` fixture from the team
+conftest, which routes every ``job_store._client()`` call through an
+in-memory ``FakeJobServiceClient``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from market_research_team.api import main as api_main
+from market_research_team.api.main import _run_market_research_background, app
+from market_research_team.models import HumanReview, ResearchMission, TeamTopology
+from market_research_team.shared import job_store as js
+
+client = TestClient(app)
+
+
+def test_list_jobs_returns_running_filter_then_all(fake_job_client) -> None:
+    running_id = str(uuid4())
+    completed_id = str(uuid4())
+    fake_job_client.create_job(running_id, status=js.JOB_STATUS_RUNNING)
+    fake_job_client.create_job(completed_id, status=js.JOB_STATUS_COMPLETED)
+
+    running_only = client.get("/market-research/jobs", params={"running_only": True})
+    assert running_only.status_code == 200
+    ids = {item["job_id"] for item in running_only.json()["jobs"]}
+    assert running_id in ids
+    assert completed_id not in ids
+
+    all_jobs = client.get("/market-research/jobs")
+    assert all_jobs.status_code == 200
+    ids = {item["job_id"] for item in all_jobs.json()["jobs"]}
+    assert running_id in ids
+    assert completed_id in ids
+
+
+def test_cancel_endpoint_pending_then_completed_then_unknown(fake_job_client) -> None:
+    pending_id = str(uuid4())
+    completed_id = str(uuid4())
+    fake_job_client.create_job(pending_id, status=js.JOB_STATUS_PENDING)
+    fake_job_client.create_job(completed_id, status=js.JOB_STATUS_COMPLETED)
+
+    ok = client.post(f"/market-research/jobs/{pending_id}/cancel")
+    assert ok.status_code == 200
+    body = ok.json()
+    assert body["success"] is True
+    assert body["status"] == js.JOB_STATUS_CANCELLED
+
+    bad = client.post(f"/market-research/jobs/{completed_id}/cancel")
+    assert bad.status_code == 200
+    body = bad.json()
+    assert body["success"] is False
+    assert js.JOB_STATUS_COMPLETED in body["message"]
+
+    missing = client.post(f"/market-research/jobs/{uuid4()}/cancel")
+    assert missing.status_code == 404
+
+
+def test_delete_endpoint_present_then_missing(fake_job_client) -> None:
+    job_id = str(uuid4())
+    fake_job_client.create_job(job_id, status=js.JOB_STATUS_COMPLETED)
+
+    ok = client.delete(f"/market-research/jobs/{job_id}")
+    assert ok.status_code == 200
+    assert ok.json() == {"job_id": job_id, "deleted": True}
+
+    again = client.delete(f"/market-research/jobs/{job_id}")
+    assert again.status_code == 404
+
+
+def test_background_runner_returns_early_when_cancelled_before_start(
+    monkeypatch: pytest.MonkeyPatch, fake_job_client
+) -> None:
+    """Pre-cancelled jobs must not invoke the orchestrator."""
+
+    called: dict[str, bool] = {"ran": False}
+
+    class _ShouldNotRun:
+        def run(self, *_: Any, **__: Any) -> Any:  # pragma: no cover
+            called["ran"] = True
+            raise AssertionError("Orchestrator should not run on cancelled job")
+
+    monkeypatch.setattr(api_main, "MarketResearchOrchestrator", _ShouldNotRun)
+
+    job_id = str(uuid4())
+    fake_job_client.create_job(job_id, status=js.JOB_STATUS_CANCELLED)
+
+    mission = ResearchMission(
+        product_concept="Cancelled before start",
+        target_users="x",
+        business_goal="y",
+        topology=TeamTopology.UNIFIED,
+    )
+    _run_market_research_background(job_id, mission, HumanReview(approved=True))
+
+    assert called["ran"] is False
+    assert fake_job_client.get_job(job_id)["status"] == js.JOB_STATUS_CANCELLED
+
+
+def test_background_runner_skips_completion_update_when_cancelled_mid_run(
+    monkeypatch: pytest.MonkeyPatch, fake_job_client
+) -> None:
+    """Cancellation after run() returns must skip the COMPLETED update."""
+
+    job_id = str(uuid4())
+    fake_job_client.create_job(job_id, status=js.JOB_STATUS_RUNNING)
+
+    class _CancelDuringRun:
+        def run(self, *_: Any, **__: Any) -> Any:
+            fake_job_client.update_job(job_id, status=js.JOB_STATUS_CANCELLED)
+
+            class _Result:
+                @staticmethod
+                def model_dump() -> dict[str, Any]:
+                    return {"topology": "unified"}
+
+            return _Result()
+
+    monkeypatch.setattr(api_main, "MarketResearchOrchestrator", _CancelDuringRun)
+
+    mission = ResearchMission(
+        product_concept="Cancelled mid-run",
+        target_users="x",
+        business_goal="y",
+        topology=TeamTopology.UNIFIED,
+    )
+    _run_market_research_background(job_id, mission, HumanReview(approved=True))
+
+    job = fake_job_client.get_job(job_id)
+    assert job["status"] == js.JOB_STATUS_CANCELLED
+    assert job.get("result") is None
+
+
+def test_background_runner_skips_failure_update_when_cancelled_during_exception(
+    monkeypatch: pytest.MonkeyPatch, fake_job_client
+) -> None:
+    """Cancellation between an orchestrator exception and the FAILED update
+    must keep the job in cancelled state without overwriting it."""
+
+    job_id = str(uuid4())
+    fake_job_client.create_job(job_id, status=js.JOB_STATUS_RUNNING)
+
+    class _CancelThenRaise:
+        def run(self, *_: Any, **__: Any) -> Any:
+            fake_job_client.update_job(job_id, status=js.JOB_STATUS_CANCELLED)
+            raise RuntimeError("boom after cancel")
+
+    monkeypatch.setattr(api_main, "MarketResearchOrchestrator", _CancelThenRaise)
+
+    mission = ResearchMission(
+        product_concept="Cancelled on exception",
+        target_users="x",
+        business_goal="y",
+        topology=TeamTopology.UNIFIED,
+    )
+    _run_market_research_background(job_id, mission, HumanReview(approved=True))
+
+    job = fake_job_client.get_job(job_id)
+    assert job["status"] == js.JOB_STATUS_CANCELLED
+    assert job.get("error") is None

--- a/backend/agents/market_research_team/tests/test_job_store.py
+++ b/backend/agents/market_research_team/tests/test_job_store.py
@@ -1,0 +1,94 @@
+"""Direct coverage for the team's ``job_store`` thin-wrapper module.
+
+These tests bypass the autouse patch that re-binds ``_client`` to the fake
+in order to exercise:
+
+* the lazy-singleton ``_client()`` factory itself (the original function),
+* ``list_jobs(statuses=...)`` pass-through, and
+* ``mark_all_running_jobs_failed``'s success and failure-tolerant branches.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from job_service_client_fake import FakeJobServiceClient
+from market_research_team.shared import job_store as js
+
+
+def test_client_factory_constructs_lazy_singleton(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The original ``_client()`` factory should build a JobServiceClient
+    on first call and reuse it thereafter."""
+
+    # The autouse conftest fixture rebinds ``js._client`` to a lambda that
+    # always returns the fake. Undo every patch on this test's monkeypatch
+    # so the real factory runs under coverage, then re-establish only the
+    # constructor stub we want.
+    monkeypatch.undo()
+
+    constructed: list[FakeJobServiceClient] = []
+
+    def _ctor(team: str) -> FakeJobServiceClient:
+        client = FakeJobServiceClient(team=team)
+        constructed.append(client)
+        return client
+
+    monkeypatch.setattr(js, "_client_instance", None, raising=False)
+    monkeypatch.setattr(js, "JobServiceClient", _ctor)
+
+    first = js._client()
+    second = js._client()
+
+    assert first is second
+    assert len(constructed) == 1
+    assert constructed[0].team == "market_research_team"
+
+
+def test_list_jobs_passes_statuses_to_client(
+    monkeypatch: pytest.MonkeyPatch, fake_job_client: FakeJobServiceClient
+) -> None:
+    """``list_jobs`` must thread the ``statuses`` keyword through to the client."""
+
+    received: dict[str, Any] = {}
+    original = fake_job_client.list_jobs
+
+    def _spy(*, statuses: list[str] | None = None) -> list[dict[str, Any]]:
+        received["statuses"] = statuses
+        return original(statuses=statuses)
+
+    monkeypatch.setattr(fake_job_client, "list_jobs", _spy)
+
+    js.list_jobs(statuses=[js.JOB_STATUS_RUNNING])
+
+    assert received["statuses"] == [js.JOB_STATUS_RUNNING]
+
+
+def test_mark_all_running_jobs_failed_delegates_to_client(
+    fake_job_client: FakeJobServiceClient,
+) -> None:
+    fake_job_client.create_job("active-1", status=js.JOB_STATUS_RUNNING)
+    fake_job_client.create_job("active-2", status=js.JOB_STATUS_PENDING)
+
+    js.mark_all_running_jobs_failed("shutdown")
+
+    for job_id in ("active-1", "active-2"):
+        job = fake_job_client.get_job(job_id)
+        assert job is not None
+        assert job["status"] == "failed"
+        assert job["error"] == "shutdown"
+
+
+def test_mark_all_running_jobs_failed_swallows_client_errors(
+    monkeypatch: pytest.MonkeyPatch, fake_job_client: FakeJobServiceClient
+) -> None:
+    """The wrapper logs and absorbs exceptions from the underlying client."""
+
+    def _boom(*_: Any, **__: Any) -> None:
+        raise RuntimeError("client down")
+
+    monkeypatch.setattr(fake_job_client, "mark_all_active_jobs_failed", _boom)
+
+    # Must not raise — coverage of the except branch.
+    js.mark_all_running_jobs_failed("network outage")

--- a/backend/agents/market_research_team/tests/test_orchestrator_parsers.py
+++ b/backend/agents/market_research_team/tests/test_orchestrator_parsers.py
@@ -1,0 +1,133 @@
+"""Unit coverage for the orchestrator's text-parsing helpers and the
+signal-padding fallback. These branches are not reached by the
+end-to-end ``test_market_research_orchestrator.py`` paths because the
+autouse Strands mock always returns well-formed JSON for every node.
+"""
+
+from __future__ import annotations
+
+import json
+
+from market_research_team.models import ResearchMission, TeamTopology
+from market_research_team.orchestrator import (
+    _DEFAULT_SCRIPTS_FALLBACK,
+    _parse_insights_from_text,
+    _parse_scripts_from_text,
+    _parse_signals_from_text,
+    _parse_viability_from_text,
+)
+
+
+def test_parse_insights_handles_json_list_of_objects() -> None:
+    payload = json.dumps(
+        [
+            {
+                "source": "interview_a",
+                "user_jobs": ["job-a"],
+                "pain_points": ["pain-a"],
+                "desired_outcomes": ["outcome-a"],
+                "direct_quotes": ["quote-a"],
+            },
+            {
+                "user_jobs": ["job-b"],
+                "pain_points": [],
+                "desired_outcomes": [],
+                "direct_quotes": [],
+            },
+            "not-an-object-skipped",
+        ]
+    )
+
+    insights = _parse_insights_from_text(payload)
+
+    assert [i.source for i in insights] == ["interview_a", "graph_analysis"]
+    assert insights[0].user_jobs == ["job-a"]
+    assert insights[1].user_jobs == ["job-b"]
+
+
+def test_parse_insights_returns_empty_for_non_collection() -> None:
+    assert _parse_insights_from_text(json.dumps(42)) == []
+
+
+def test_parse_signals_returns_empty_for_non_collection() -> None:
+    assert _parse_signals_from_text(json.dumps("just a string")) == []
+
+
+def test_parse_viability_recovers_from_non_dict_json() -> None:
+    mission = ResearchMission(
+        product_concept="Concept",
+        target_users="Users",
+        business_goal="Goal",
+        topology=TeamTopology.UNIFIED,
+    )
+
+    rec = _parse_viability_from_text(json.dumps([1, 2, 3]), mission)
+
+    assert rec.verdict == "needs_more_validation"
+    assert rec.suggested_next_experiments
+    assert "Mission concept: Concept." in rec.rationale[0]
+
+
+def test_parse_viability_normalises_invalid_verdict() -> None:
+    mission = ResearchMission(
+        product_concept="Concept",
+        target_users="Users",
+        business_goal="Goal",
+        topology=TeamTopology.UNIFIED,
+    )
+
+    payload = json.dumps({"verdict": "totally-bogus", "confidence": 0.9})
+    rec = _parse_viability_from_text(payload, mission)
+
+    assert rec.verdict == "needs_more_validation"
+    assert rec.confidence == 0.9
+
+
+def test_parse_scripts_falls_back_when_payload_is_not_string_list() -> None:
+    # Dict payload → fallback path.
+    assert _parse_scripts_from_text(json.dumps({"oops": True})) == list(
+        _DEFAULT_SCRIPTS_FALLBACK
+    )
+
+    # List with a non-string element → fallback path.
+    assert _parse_scripts_from_text(json.dumps(["ok", 7])) == list(_DEFAULT_SCRIPTS_FALLBACK)
+
+
+def test_orchestrator_pads_signals_when_graph_returns_none(monkeypatch) -> None:
+    """Unified topology, no transcripts, and an empty psychology node forces
+    the ``while len(market_signals) < 2`` padding loop to fire twice.
+    """
+
+    from market_research_team.models import HumanReview
+    from market_research_team.orchestrator import MarketResearchOrchestrator
+
+    def _empty_extract(result, node_id: str) -> str:
+        if node_id == "psychology":
+            return ""  # _parse_signals_from_text path is skipped, signals start empty
+        if node_id == "ux_research":
+            return ""
+        if node_id == "viability_synthesis":
+            return ""
+        if node_id == "scripts":
+            return ""
+        return ""
+
+    monkeypatch.setattr(
+        "market_research_team.orchestrator.extract_node_text", _empty_extract
+    )
+
+    mission = ResearchMission(
+        product_concept="Padding probe",
+        target_users="signal-pad users",
+        business_goal="hit the padding loop",
+        topology=TeamTopology.UNIFIED,
+    )
+
+    output = MarketResearchOrchestrator().run(mission, HumanReview(approved=True))
+
+    # Padding loop fills with the two fallback signals.
+    assert len(output.market_signals) == 2
+    assert output.market_signals[0].signal == "User pain urgency"
+    assert output.market_signals[1].signal == "Adoption motivation clarity"
+    # Empty scripts node → _parse_scripts_from_text not called, default fallback used.
+    assert output.proposed_research_scripts == list(_DEFAULT_SCRIPTS_FALLBACK)


### PR DESCRIPTION
## Summary

First step toward bringing every team to the 95% line-coverage bar set by the gate PR. The market_research_team unit suite was sitting at 87.74% line coverage; this PR adds three focused test files that bring it to **97.36%**.

| File | Before | After |
| --- | --- | --- |
| `agents/market_research_team/api/main.py` | 82% | 99% |
| `agents/market_research_team/orchestrator.py` | 85% | 100% |
| `agents/market_research_team/shared/job_store.py` | 67% | 100% |
| **TOTAL** | **88%** | **97%** |

### Tests added

- **`test_api_lifecycle.py`** — covers the cancel / list / delete endpoints (success, 404, and the "cannot cancel completed job" branch) and the three cancellation guards inside `_run_market_research_background`: pre-start, mid-run, and during-exception. Each guard test asserts the corresponding terminal-status update is **not** written when the job is already cancelled.
- **`test_orchestrator_parsers.py`** — covers the parser helpers' fallback branches (`_parse_insights_from_text` list-of-objects, `_parse_signals_from_text` returning `[]` for primitives, `_parse_viability_from_text` recovering from non-dict JSON and invalid verdicts, `_parse_scripts_from_text` falling back when payload isn't a list of strings) plus the `while len(market_signals) < 2` padding loop in the unified-topology branch.
- **`test_job_store.py`** — covers the lazy-singleton `_client()` factory (via `monkeypatch.undo()` to bypass the conftest autouse stub), the `list_jobs(statuses=...)` keyword pass-through, `mark_all_running_jobs_failed` delegating to the underlying client, and its except-branch (already pragma'd; the test still drives the catch for robustness).

### Out of scope

The remaining 11 uncovered statements all live in `agents.py` (lines 40, 48-53, 334, 367, 372, 478): the `_build_strands_agent` / `_call_agent` wrappers and a couple of JSON-fallback branches inside agent classes. The autouse conftest fixture replaces those wrappers wholesale for every test in the directory, so exercising them under coverage would require restructuring the team's test harness — out of scope here, and the team already comfortably clears 95% without them.

## Test plan

- [ ] `pytest agents/market_research_team/tests/ -m "not integration" --cov=agents/market_research_team --cov-fail-under=95` is green locally (51 tests pass, 97.36% coverage).
- [ ] `ruff check agents/market_research_team/` passes.
- [ ] CI: `Test – Market Research` and `Lint Python (ruff)` jobs pass.
- [ ] No changes to production code; this PR only adds new test files.

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5u4zW36taPZEx99n69c4n)_