### PR TITLE
sales_team: raise test coverage from 55% to 100%

### DIFF
--- a/backend/agents/sales_team/tests/test_api_main.py
+++ b/backend/agents/sales_team/tests/test_api_main.py
@@ -1,0 +1,1149 @@
+"""Tests for ``sales_team.api.main``.
+
+These cover the FastAPI surface that previously had 0% coverage. Each test
+patches the orchestrator and job manager so we exercise the route logic
+without any LLM, Postgres, or Temporal dependency.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from fastapi.testclient import TestClient
+
+from sales_team.api import main as api_main
+from sales_team.models import (
+    BANTScore,
+    CloseType,
+    ClosingStrategy,
+    DealResult,
+    DeepResearchResult,
+    DiscoveryPlan,
+    LearningInsights,
+    MEDDICScore,
+    NurtureSequence,
+    OutcomeResult,
+    OutreachSequence,
+    OutreachVariant,
+    PipelineCoachingReport,
+    PipelineStage,
+    Prospect,
+    ProspectDossier,
+    QualificationScore,
+    ROIModel,
+    SalesPipelineResult,
+    SalesProposal,
+    SPINQuestions,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch, fake_job_client) -> TestClient:
+    """Bind the FakeJobServiceClient and isolate outcome store paths."""
+    monkeypatch.setattr(api_main, "_job_manager", fake_job_client)
+    return TestClient(api_main.app)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_outcome_store(tmp_path, monkeypatch: pytest.MonkeyPatch):
+    """Point the outcome store at a tmpdir so list/insights endpoints don't
+    leak between tests."""
+    from sales_team import outcome_store
+
+    cache_root = tmp_path / "outcomes"
+    insights = tmp_path / "insights" / "current.json"
+    monkeypatch.setattr(outcome_store, "_CACHE_ROOT", cache_root)
+    monkeypatch.setattr(outcome_store, "_INSIGHTS_PATH", insights)
+
+
+@pytest.fixture
+def sample_prospect() -> Prospect:
+    return Prospect(
+        id="prs_api_test",
+        company_name="Acme Corp",
+        contact_name="Jane Smith",
+        contact_title="VP Sales",
+        icp_match_score=0.85,
+    )
+
+
+@pytest.fixture
+def sample_icp_payload() -> dict:
+    return {
+        "industry": ["SaaS"],
+        "company_size_min": 50,
+        "company_size_max": 500,
+        "job_titles": ["VP Sales"],
+        "pain_points": ["manual reporting"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def test_now_returns_iso_utc_string() -> None:
+    out = api_main._now()
+    assert "T" in out
+    assert out.endswith("+00:00") or out.endswith("Z")
+
+
+def test_update_job_delegates_to_job_manager(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class _Stub:
+        def update_job(self, job_id: str, **fields: Any) -> None:
+            captured["job_id"] = job_id
+            captured["fields"] = fields
+
+    monkeypatch.setattr(api_main, "_job_manager", _Stub())
+    api_main._update_job("j1", status="running", progress=12)
+    assert captured == {"job_id": "j1", "fields": {"status": "running", "progress": 12}}
+
+
+def test_mark_all_running_jobs_failed_delegates(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, Any] = {}
+
+    class _Stub:
+        def mark_stale_active_jobs_failed(self, *, stale_after_seconds: float, reason: str) -> None:
+            captured["stale"] = stale_after_seconds
+            captured["reason"] = reason
+
+    monkeypatch.setattr(api_main, "_job_manager", _Stub())
+    api_main.mark_all_running_jobs_failed("server shutdown")
+    assert captured == {"stale": 0, "reason": "server shutdown"}
+
+
+# ---------------------------------------------------------------------------
+# /sales/pipeline/run + background runner
+# ---------------------------------------------------------------------------
+
+
+def test_run_pipeline_creates_pending_job_and_starts_thread(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, fake_job_client, sample_icp_payload
+) -> None:
+    """Stub the orchestrator so the background thread completes deterministically."""
+
+    # Override threading.Thread with a synchronous stand-in that runs the
+    # target inline on .start(). This lets us assert the post-completion job
+    # state without sleeps or polling.
+    class _InlineThread:
+        def __init__(self, target=None, args=(), kwargs=None, daemon=None):  # noqa: ANN001
+            self._target = target
+            self._args = args
+            self._kwargs = kwargs or {}
+
+        def start(self):
+            self._target(*self._args, **self._kwargs)
+
+    monkeypatch.setattr(api_main.threading, "Thread", _InlineThread)
+
+    class _StubOrch:
+        def run(self, request, job_id, update_cb=None):
+            update_cb("prospecting", 50)
+            return SalesPipelineResult(
+                job_id=job_id, entry_stage=request.entry_stage, product_name=request.product_name
+            )
+
+    monkeypatch.setattr(api_main, "SalesPodOrchestrator", _StubOrch)
+
+    response = client.post(
+        "/sales/pipeline/run",
+        json={
+            "product_name": "ProductX",
+            "value_proposition": "Save 20% on outbound time",
+            "icp": sample_icp_payload,
+            "entry_stage": "prospecting",
+            "max_prospects": 5,
+            "existing_prospects": [],
+            "company_context": "ctx",
+            "case_study_snippets": [],
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert "job_id" in body
+    job_id = body["job_id"]
+
+    # The fake job client must contain the completed job.
+    job = fake_job_client.get_job(job_id)
+    assert job["status"] == "completed"
+    assert job["progress"] == 100
+    assert job["result"]["job_id"] == job_id
+
+
+def test_run_pipeline_job_failure_branch(monkeypatch: pytest.MonkeyPatch, fake_job_client) -> None:
+    """When the orchestrator raises, the background runner marks the job failed."""
+    monkeypatch.setattr(api_main, "_job_manager", fake_job_client)
+    fake_job_client.create_job("j-fail", status="pending")
+
+    class _RaisingOrch:
+        def run(self, request, job_id, update_cb=None):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(api_main, "SalesPodOrchestrator", _RaisingOrch)
+
+    # Build a minimal request — pass-through values fine since orchestrator raises.
+    request = api_main.SalesPipelineRequest(
+        product_name="P",
+        value_proposition="A valid value proposition.",
+        icp={"industry": ["SaaS"]},
+    )
+    api_main._run_pipeline_job("j-fail", request)
+    job = fake_job_client.get_job("j-fail")
+    assert job["status"] == "failed"
+    assert job["error"] == "boom"
+    assert job["current_stage"] == "failed"
+
+
+# ---------------------------------------------------------------------------
+# /sales/pipeline/status
+# ---------------------------------------------------------------------------
+
+
+def test_get_pipeline_status_404_when_missing(client: TestClient) -> None:
+    resp = client.get("/sales/pipeline/status/no-such-job")
+    assert resp.status_code == 404
+
+
+def test_get_pipeline_status_returns_running_job(client: TestClient, fake_job_client) -> None:
+    fake_job_client.create_job(
+        "j-run",
+        status="running",
+        current_stage="prospecting",
+        progress=20,
+        product_name="ProductX",
+        last_updated_at="2026-05-21T00:00:00+00:00",
+    )
+    resp = client.get("/sales/pipeline/status/j-run")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["job_id"] == "j-run"
+    assert body["status"] == "running"
+    assert body["product_name"] == "ProductX"
+    assert body["result"] is None
+
+
+def test_get_pipeline_status_parses_result_when_present(
+    client: TestClient, fake_job_client
+) -> None:
+    result = SalesPipelineResult(
+        job_id="j-done", entry_stage=PipelineStage.PROSPECTING, product_name="P"
+    ).model_dump()
+    fake_job_client.create_job(
+        "j-done",
+        status="completed",
+        current_stage="completed",
+        progress=100,
+        product_name="P",
+        result=result,
+    )
+    resp = client.get("/sales/pipeline/status/j-done")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["result"]["job_id"] == "j-done"
+
+
+def test_get_pipeline_status_handles_unparseable_result(
+    client: TestClient, fake_job_client
+) -> None:
+    """An obviously-bad result dict should make ``result`` come back as None."""
+    fake_job_client.create_job(
+        "j-bad",
+        status="completed",
+        current_stage="completed",
+        progress=100,
+        product_name="P",
+        result={"random": "shape"},  # missing required fields
+    )
+    resp = client.get("/sales/pipeline/status/j-bad")
+    assert resp.status_code == 200
+    assert resp.json()["result"] is None
+
+
+# ---------------------------------------------------------------------------
+# /sales/pipeline/jobs (list)
+# ---------------------------------------------------------------------------
+
+
+def test_list_pipeline_jobs_returns_all_by_default(client: TestClient, fake_job_client) -> None:
+    fake_job_client.create_job(
+        "a", status="running", current_stage="x", progress=5, product_name="A"
+    )
+    fake_job_client.create_job(
+        "b", status="completed", current_stage="completed", progress=100, product_name="B"
+    )
+    resp = client.get("/sales/pipeline/jobs")
+    assert resp.status_code == 200
+    ids = {item["job_id"] for item in resp.json()}
+    assert ids == {"a", "b"}
+
+
+def test_list_pipeline_jobs_running_only_filter(client: TestClient, fake_job_client) -> None:
+    fake_job_client.create_job("a", status="running", product_name="A")
+    fake_job_client.create_job("b", status="completed", product_name="B")
+    resp = client.get("/sales/pipeline/jobs?running_only=true")
+    assert resp.status_code == 200
+    ids = {item["job_id"] for item in resp.json()}
+    assert ids == {"a"}
+
+
+# ---------------------------------------------------------------------------
+# /sales/pipeline/job/{id}/cancel
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_pipeline_job_marks_cancelled(client: TestClient, fake_job_client) -> None:
+    fake_job_client.create_job("j", status="running", product_name="P")
+    resp = client.post("/sales/pipeline/job/j/cancel")
+    assert resp.status_code == 200
+    assert fake_job_client.get_job("j")["status"] == "cancelled"
+
+
+def test_cancel_pipeline_job_404_when_missing(client: TestClient) -> None:
+    assert client.post("/sales/pipeline/job/missing/cancel").status_code == 404
+
+
+def test_cancel_pipeline_job_400_when_terminal(client: TestClient, fake_job_client) -> None:
+    fake_job_client.create_job("j", status="completed", product_name="P")
+    resp = client.post("/sales/pipeline/job/j/cancel")
+    assert resp.status_code == 400
+
+
+# ---------------------------------------------------------------------------
+# DELETE /sales/pipeline/job/{id}
+# ---------------------------------------------------------------------------
+
+
+def test_delete_pipeline_job_404_when_missing(client: TestClient) -> None:
+    assert client.delete("/sales/pipeline/job/missing").status_code == 404
+
+
+def test_delete_pipeline_job_409_when_active(client: TestClient, fake_job_client) -> None:
+    fake_job_client.create_job("j", status="running", product_name="P")
+    resp = client.delete("/sales/pipeline/job/j")
+    assert resp.status_code == 409
+
+
+def test_delete_pipeline_job_succeeds_when_terminal(client: TestClient, fake_job_client) -> None:
+    fake_job_client.create_job("j", status="completed", product_name="P")
+    resp = client.delete("/sales/pipeline/job/j")
+    assert resp.status_code == 200
+    assert fake_job_client.get_job("j") is None
+
+
+def test_delete_pipeline_job_404_when_underlying_delete_returns_false(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the job is found but delete_job returns False, surface 404."""
+
+    class _StubJM:
+        def get_job(self, job_id):
+            return {"status": "completed", "product_name": "P"}
+
+        def delete_job(self, job_id):
+            return False
+
+    monkeypatch.setattr(api_main, "_job_manager", _StubJM())
+    resp = client.delete("/sales/pipeline/job/j")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# /sales/prospect
+# ---------------------------------------------------------------------------
+
+
+def test_prospect_returns_orchestrator_output(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, sample_icp_payload, sample_prospect
+) -> None:
+    class _Orch:
+        def prospect_only(self, **kw):
+            return [sample_prospect]
+
+    monkeypatch.setattr(api_main, "SalesPodOrchestrator", _Orch)
+    resp = client.post(
+        "/sales/prospect",
+        json={
+            "icp": sample_icp_payload,
+            "product_name": "P",
+            "value_proposition": "value",
+            "max_prospects": 3,
+            "company_context": "",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["count"] == 1
+    assert body["prospects"][0]["company_name"] == "Acme Corp"
+
+
+# ---------------------------------------------------------------------------
+# /sales/outreach
+# ---------------------------------------------------------------------------
+
+
+def test_generate_outreach_returns_sequences_and_skipped(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, sample_prospect
+) -> None:
+    p_kept = sample_prospect
+    p_skipped = Prospect(id="prs_missing", company_name="Beta")
+    dossier = ProspectDossier(
+        prospect_id=p_kept.id,
+        full_name="Jane",
+        current_title="VP",
+        current_company="Acme",
+    )
+    sequence = OutreachSequence(
+        prospect=p_kept,
+        dossier_id="d1",
+        dossier_confidence=0.8,
+        variants=[OutreachVariant(angle="company_soft_opener", personalization_grade="fallback")],
+    )
+
+    class _Orch:
+        def load_dossiers_for_prospects(self, prospects):
+            return {p_kept.id: dossier}
+
+        def outreach_only(self, **kw):
+            return [sequence]
+
+    monkeypatch.setattr(api_main, "SalesPodOrchestrator", _Orch)
+    resp = client.post(
+        "/sales/outreach",
+        json={
+            "prospects": [p_kept.model_dump(), p_skipped.model_dump()],
+            "product_name": "P",
+            "value_proposition": "value",
+            "case_study_snippets": [],
+            "company_context": "",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["count"] == 1
+    assert body["skipped_prospect_ids"] == [p_skipped.id]
+
+
+# ---------------------------------------------------------------------------
+# /sales/qualify
+# ---------------------------------------------------------------------------
+
+
+def test_qualify_lead_500_when_orchestrator_returns_none(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, sample_prospect
+) -> None:
+    class _Orch:
+        def qualify_only(self, **kw):
+            return None
+
+    monkeypatch.setattr(api_main, "SalesPodOrchestrator", _Orch)
+    resp = client.post(
+        "/sales/qualify",
+        json={
+            "prospect": sample_prospect.model_dump(),
+            "product_name": "P",
+            "value_proposition": "V",
+            "call_notes": "",
+        },
+    )
+    assert resp.status_code == 500
+
+
+def test_qualify_lead_returns_score(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, sample_prospect
+) -> None:
+    score = QualificationScore(
+        prospect=sample_prospect,
+        bant=BANTScore(budget=8, authority=9, need=7, timeline=8),
+        meddic=MEDDICScore(
+            metrics_identified=True,
+            economic_buyer_known=True,
+            decision_criteria_understood=True,
+            decision_process_mapped=True,
+            identify_pain=True,
+            champion_found=True,
+        ),
+        overall_score=0.85,
+        value_creation_level=3,
+        recommended_action="advance",
+    )
+
+    class _Orch:
+        def qualify_only(self, **kw):
+            return score
+
+    monkeypatch.setattr(api_main, "SalesPodOrchestrator", _Orch)
+    resp = client.post(
+        "/sales/qualify",
+        json={
+            "prospect": sample_prospect.model_dump(),
+            "product_name": "P",
+            "value_proposition": "V",
+            "call_notes": "",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["overall_score"] == 0.85
+
+
+# ---------------------------------------------------------------------------
+# /sales/nurture
+# ---------------------------------------------------------------------------
+
+
+def test_build_nurture_returns_sequences(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, sample_prospect
+) -> None:
+    nurture = NurtureSequence(prospect=sample_prospect, duration_days=30)
+
+    class _Orch:
+        def nurture_only(self, **kw):
+            return [nurture]
+
+    monkeypatch.setattr(api_main, "SalesPodOrchestrator", _Orch)
+    resp = client.post(
+        "/sales/nurture",
+        json={
+            "prospects": [sample_prospect.model_dump()],
+            "product_name": "P",
+            "value_proposition": "V",
+            "duration_days": 30,
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# /sales/proposal
+# ---------------------------------------------------------------------------
+
+
+def test_write_proposal_500_when_orchestrator_returns_none(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, sample_prospect
+) -> None:
+    class _Orch:
+        def propose_only(self, req):
+            return None
+
+    monkeypatch.setattr(api_main, "SalesPodOrchestrator", _Orch)
+    resp = client.post(
+        "/sales/proposal",
+        json={
+            "prospect": sample_prospect.model_dump(),
+            "product_name": "P",
+            "value_proposition": "V",
+            "annual_cost_usd": 25000.0,
+            "discovery_notes": "",
+            "case_study_snippets": [],
+            "company_context": "",
+        },
+    )
+    assert resp.status_code == 500
+
+
+def test_write_proposal_returns_serialized_proposal(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, sample_prospect
+) -> None:
+    proposal = SalesProposal(
+        prospect=sample_prospect,
+        executive_summary="...",
+        situation_analysis="...",
+        proposed_solution="...",
+        roi_model=ROIModel(
+            annual_cost_usd=25000.0,
+            estimated_annual_benefit_usd=70000.0,
+            payback_months=6.0,
+            roi_percentage=180.0,
+        ),
+    )
+
+    class _Orch:
+        def propose_only(self, req):
+            return proposal
+
+    monkeypatch.setattr(api_main, "SalesPodOrchestrator", _Orch)
+    resp = client.post(
+        "/sales/proposal",
+        json={
+            "prospect": sample_prospect.model_dump(),
+            "product_name": "P",
+            "value_proposition": "V",
+            "annual_cost_usd": 25000.0,
+            "discovery_notes": "",
+            "case_study_snippets": [],
+            "company_context": "",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["roi_model"]["payback_months"] == 6.0
+
+
+# ---------------------------------------------------------------------------
+# /sales/coaching
+# ---------------------------------------------------------------------------
+
+
+def test_get_coaching_500_when_orchestrator_returns_none(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, sample_prospect
+) -> None:
+    class _Orch:
+        def coach_only(self, **kw):
+            return None
+
+    monkeypatch.setattr(api_main, "SalesPodOrchestrator", _Orch)
+    resp = client.post(
+        "/sales/coaching",
+        json={
+            "prospects": [sample_prospect.model_dump()],
+            "product_name": "P",
+            "pipeline_context": "",
+        },
+    )
+    assert resp.status_code == 500
+
+
+def test_get_coaching_returns_report(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, sample_prospect
+) -> None:
+    report = PipelineCoachingReport(prospects_reviewed=1, coaching_summary="OK")
+
+    class _Orch:
+        def coach_only(self, **kw):
+            return report
+
+    monkeypatch.setattr(api_main, "SalesPodOrchestrator", _Orch)
+    resp = client.post(
+        "/sales/coaching",
+        json={
+            "prospects": [sample_prospect.model_dump()],
+            "product_name": "P",
+            "pipeline_context": "",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["coaching_summary"] == "OK"
+
+
+# ---------------------------------------------------------------------------
+# /sales/prospect/deep-research
+# ---------------------------------------------------------------------------
+
+
+def test_deep_research_endpoint_returns_result(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, sample_icp_payload
+) -> None:
+    deep_result = DeepResearchResult(
+        list_id="plst_x",
+        product_name="P",
+        generated_at="2026-05-21T00:00:00+00:00",
+        total_prospects=0,
+        companies_represented=0,
+        entries=[],
+    )
+
+    class _Orch:
+        def deep_research_only(self, body, dossier_url_builder=None):
+            # Exercise the url-builder branch by calling it.
+            assert dossier_url_builder("dsr_test").endswith("dsr_test")
+            return deep_result
+
+    monkeypatch.setattr(api_main, "SalesPodOrchestrator", _Orch)
+    resp = client.post(
+        "/sales/prospect/deep-research",
+        json={
+            "product_name": "P",
+            "value_proposition": "Value with at least ten chars",
+            "icp": sample_icp_payload,
+            "target_prospects": 10,
+            "max_per_company": 2,
+            "company_context": "",
+        },
+    )
+    assert resp.status_code == 200
+    assert resp.json()["list_id"] == "plst_x"
+
+
+# ---------------------------------------------------------------------------
+# /sales/dossiers/{id}
+# ---------------------------------------------------------------------------
+
+
+def test_get_dossier_503_when_store_import_fails(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """If the dossier_store module raises at import time, surface 503."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _import(name, *args, **kwargs):
+        if name == "sales_team.dossier_store":
+            raise ImportError("missing psycopg")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _import)
+    resp = client.get("/sales/dossiers/dsr_x")
+    assert resp.status_code == 503
+
+
+def test_get_dossier_503_when_store_construct_fails(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from sales_team import dossier_store as ds_mod
+
+    class _BrokenStore:
+        def __init__(self):
+            raise RuntimeError("pool init failed")
+
+    monkeypatch.setattr(ds_mod, "DossierStore", _BrokenStore)
+    resp = client.get("/sales/dossiers/dsr_x")
+    assert resp.status_code == 503
+
+
+def test_get_dossier_404_when_store_returns_none(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from sales_team import dossier_store as ds_mod
+
+    class _EmptyStore:
+        def get_dossier(self, dossier_id):
+            return None
+
+    monkeypatch.setattr(ds_mod, "DossierStore", _EmptyStore)
+    resp = client.get("/sales/dossiers/dsr_missing")
+    assert resp.status_code == 404
+
+
+def test_get_dossier_503_when_store_call_raises(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from sales_team import dossier_store as ds_mod
+
+    class _BrokenStore:
+        def get_dossier(self, dossier_id):
+            raise RuntimeError("Postgres down")
+
+    monkeypatch.setattr(ds_mod, "DossierStore", _BrokenStore)
+    resp = client.get("/sales/dossiers/dsr_x")
+    assert resp.status_code == 503
+
+
+def test_get_dossier_returns_payload(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    from sales_team import dossier_store as ds_mod
+
+    dossier = ProspectDossier(
+        prospect_id="prs_z",
+        full_name="Jane",
+        current_title="VP",
+        current_company="Acme",
+    )
+
+    class _Store:
+        def get_dossier(self, dossier_id):
+            return dossier
+
+    monkeypatch.setattr(ds_mod, "DossierStore", _Store)
+    resp = client.get("/sales/dossiers/dsr_x")
+    assert resp.status_code == 200
+    assert resp.json()["full_name"] == "Jane"
+
+
+# ---------------------------------------------------------------------------
+# /sales/prospect-lists/{id} + list
+# ---------------------------------------------------------------------------
+
+
+def test_get_prospect_list_404_when_store_returns_none(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from sales_team import dossier_store as ds_mod
+
+    class _Store:
+        def get_prospect_list(self, list_id):
+            return None
+
+    monkeypatch.setattr(ds_mod, "DossierStore", _Store)
+    resp = client.get("/sales/prospect-lists/plst_missing")
+    assert resp.status_code == 404
+
+
+def test_get_prospect_list_503_when_store_call_raises(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from sales_team import dossier_store as ds_mod
+
+    class _Store:
+        def get_prospect_list(self, list_id):
+            raise RuntimeError("down")
+
+    monkeypatch.setattr(ds_mod, "DossierStore", _Store)
+    assert client.get("/sales/prospect-lists/plst_x").status_code == 503
+
+
+def test_get_prospect_list_returns_payload(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from sales_team import dossier_store as ds_mod
+
+    res = DeepResearchResult(
+        list_id="plst_x",
+        product_name="P",
+        generated_at="2026-05-21T00:00:00+00:00",
+        total_prospects=0,
+        companies_represented=0,
+    )
+
+    class _Store:
+        def get_prospect_list(self, list_id):
+            return res
+
+    monkeypatch.setattr(ds_mod, "DossierStore", _Store)
+    resp = client.get("/sales/prospect-lists/plst_x")
+    assert resp.status_code == 200
+    assert resp.json()["list_id"] == "plst_x"
+
+
+def test_list_prospect_lists_returns_summaries(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from sales_team import dossier_store as ds_mod
+
+    class _Store:
+        def list_prospect_lists(self, limit):
+            return [
+                {
+                    "list_id": "plst_a",
+                    "product_name": "A",
+                    "total_prospects": 1,
+                    "companies_represented": 1,
+                    "generated_at": "now",
+                }
+            ]
+
+    monkeypatch.setattr(ds_mod, "DossierStore", _Store)
+    resp = client.get("/sales/prospect-lists?limit=10")
+    assert resp.status_code == 200
+    assert resp.json()[0]["product_name"] == "A"
+
+
+def test_list_prospect_lists_503_on_store_error(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from sales_team import dossier_store as ds_mod
+
+    class _Store:
+        def list_prospect_lists(self, limit):
+            raise RuntimeError("Postgres down")
+
+    monkeypatch.setattr(ds_mod, "DossierStore", _Store)
+    assert client.get("/sales/prospect-lists").status_code == 503
+
+
+def test_list_prospect_lists_caps_limit_to_reasonable_range(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Limit must be clamped to [1, 200] before hitting the store."""
+    from sales_team import dossier_store as ds_mod
+
+    captured: list[int] = []
+
+    class _Store:
+        def list_prospect_lists(self, limit):
+            captured.append(limit)
+            return []
+
+    monkeypatch.setattr(ds_mod, "DossierStore", _Store)
+    client.get("/sales/prospect-lists?limit=0")  # below the floor
+    client.get("/sales/prospect-lists?limit=99999")  # above the ceiling
+    assert captured == [1, 200]
+
+
+# ---------------------------------------------------------------------------
+# /sales/outcomes/{stage,deal}
+# ---------------------------------------------------------------------------
+
+
+def test_record_stage_outcome_endpoint(client: TestClient) -> None:
+    resp = client.post(
+        "/sales/outcomes/stage",
+        json={
+            "company_name": "Acme",
+            "stage": "outreach",
+            "outcome": "converted",
+            "industry": "SaaS",
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["outcome_id"]
+    assert "Acme" in body["message"]
+
+
+def test_record_deal_outcome_endpoint(client: TestClient) -> None:
+    resp = client.post(
+        "/sales/outcomes/deal",
+        json={
+            "company_name": "Acme",
+            "result": "won",
+            "final_stage_reached": "closed_won",
+            "deal_size_usd": 100000.0,
+        },
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["outcome_id"]
+    assert "won" in body["message"]
+
+
+def test_get_outcome_summary_returns_counts(client: TestClient) -> None:
+    resp = client.get("/sales/outcomes/summary")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert set(body.keys()) == {"stage_outcomes", "deal_outcomes", "has_insights"}
+
+
+def test_list_stage_outcomes_returns_recorded_entries(client: TestClient) -> None:
+    client.post(
+        "/sales/outcomes/stage",
+        json={"company_name": "X", "stage": "outreach", "outcome": "converted"},
+    )
+    resp = client.get("/sales/outcomes/stage?limit=10")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert len(body) == 1
+    assert body[0]["company_name"] == "X"
+
+
+def test_list_deal_outcomes_returns_recorded_entries(client: TestClient) -> None:
+    client.post(
+        "/sales/outcomes/deal",
+        json={
+            "company_name": "X",
+            "result": "won",
+            "final_stage_reached": "closed_won",
+        },
+    )
+    resp = client.get("/sales/outcomes/deal?limit=10")
+    assert resp.status_code == 200
+    assert len(resp.json()) == 1
+
+
+def test_list_stage_outcomes_caps_limit_at_500(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: list[int] = []
+
+    def _fake_load(limit):
+        captured.append(limit)
+        return []
+
+    monkeypatch.setattr(api_main, "load_stage_outcomes", _fake_load)
+    client.get("/sales/outcomes/stage?limit=9999")
+    assert captured == [500]
+
+
+def test_list_deal_outcomes_caps_limit_at_500(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: list[int] = []
+
+    def _fake_load(limit):
+        captured.append(limit)
+        return []
+
+    monkeypatch.setattr(api_main, "load_deal_outcomes", _fake_load)
+    client.get("/sales/outcomes/deal?limit=9999")
+    assert captured == [500]
+
+
+# ---------------------------------------------------------------------------
+# /sales/insights + /sales/insights/refresh
+# ---------------------------------------------------------------------------
+
+
+def test_get_insights_404_when_no_history(client: TestClient) -> None:
+    resp = client.get("/sales/insights")
+    assert resp.status_code == 404
+
+
+def test_get_insights_returns_persisted(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    insights = LearningInsights(
+        total_outcomes_analyzed=2,
+        win_rate=0.5,
+        winning_patterns=["mt"],
+        insights_version=1,
+        generated_at="2026-05-21T00:00:00+00:00",
+    )
+    monkeypatch.setattr(api_main, "load_current_insights", lambda: insights)
+    resp = client.get("/sales/insights")
+    assert resp.status_code == 200
+    assert resp.json()["win_rate"] == 0.5
+
+
+def test_refresh_insights_runs_engine(client: TestClient, monkeypatch: pytest.MonkeyPatch) -> None:
+    refreshed = LearningInsights(
+        total_outcomes_analyzed=3,
+        win_rate=0.66,
+        insights_version=2,
+        generated_at="2026-05-21T00:00:00+00:00",
+    )
+
+    class _Engine:
+        def refresh(self):
+            return refreshed
+
+    monkeypatch.setattr(api_main, "LearningEngine", _Engine)
+    resp = client.post("/sales/insights/refresh")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["insights_version"] == 2
+    assert body["total_outcomes_analyzed"] == 3
+    assert body["win_rate"] == 0.66
+
+
+# ---------------------------------------------------------------------------
+# /health
+# ---------------------------------------------------------------------------
+
+
+def test_health_returns_ok_with_counts(client: TestClient) -> None:
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert "stage_outcomes_recorded" in body
+    assert "insights_available" in body
+
+
+# ---------------------------------------------------------------------------
+# Lifespan
+# ---------------------------------------------------------------------------
+
+
+def test_lifespan_swallows_postgres_import_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The lifespan must not crash app boot when shared_postgres is unavailable."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _import(name, *args, **kwargs):
+        # Block both possible imports inside the lifespan branches.
+        if name in ("sales_team.postgres", "shared_postgres"):
+            raise ImportError("simulated")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _import)
+    # The TestClient context manager triggers startup + shutdown.
+    with TestClient(api_main.app) as c:
+        assert c.get("/health").status_code == 200
+
+
+def test_lifespan_runs_register_and_close_when_imports_succeed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When shared_postgres imports succeed, ``register_team_schemas`` and
+    ``close_pool`` are both called (exercising lines 65-67 and 74)."""
+    import shared_postgres as sp_mod
+
+    captured: dict[str, int] = {"register": 0, "close": 0}
+
+    def _fake_register(*schemas):
+        captured["register"] += 1
+
+    def _fake_close():
+        captured["close"] += 1
+
+    monkeypatch.setattr(sp_mod, "register_team_schemas", _fake_register)
+    monkeypatch.setattr(sp_mod, "close_pool", _fake_close)
+    with TestClient(api_main.app):
+        pass
+    assert captured["register"] == 1
+    assert captured["close"] == 1
+
+
+def test_lifespan_swallows_close_pool_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When close_pool raises during shutdown, the warning is logged but the
+    lifespan exit succeeds (covers the except branch on lines 75-76)."""
+    import shared_postgres as sp_mod
+
+    monkeypatch.setattr(sp_mod, "register_team_schemas", lambda *a, **kw: None)
+    monkeypatch.setattr(sp_mod, "close_pool", lambda: (_ for _ in ()).throw(RuntimeError("down")))
+    with TestClient(api_main.app):
+        pass  # exiting triggers close_pool
+
+
+def test_deep_research_url_builder_fallback_when_url_for_raises(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch, sample_icp_payload
+) -> None:
+    """If request.url_for raises (e.g. routing context missing), the URL
+    builder must fall back to the hard-coded /api/sales/dossiers/<id>
+    shape."""
+    deep_result = DeepResearchResult(
+        list_id="plst_x",
+        product_name="P",
+        generated_at="2026-05-21T00:00:00+00:00",
+        total_prospects=0,
+        companies_represented=0,
+        entries=[],
+    )
+
+    class _Orch:
+        def deep_research_only(self, body, dossier_url_builder=None):
+            # Trigger the fallback by accessing the builder after patching
+            # url_for to raise. The builder will catch and emit the fallback.
+            url = dossier_url_builder("dsr_abc")
+            assert url == "/api/sales/dossiers/dsr_abc"
+            return deep_result
+
+    # Patch the FastAPI Request.url_for so the inner builder's try/except
+    # routes to the fallback.
+    from starlette.requests import Request as StarletteRequest
+
+    def _bad_url_for(self, *args, **kwargs):
+        raise RuntimeError("no routing context")
+
+    monkeypatch.setattr(StarletteRequest, "url_for", _bad_url_for, raising=True)
+    monkeypatch.setattr(api_main, "SalesPodOrchestrator", _Orch)
+    resp = client.post(
+        "/sales/prospect/deep-research",
+        json={
+            "product_name": "P",
+            "value_proposition": "Value with at least ten chars",
+            "icp": sample_icp_payload,
+            "target_prospects": 10,
+            "max_per_company": 2,
+            "company_context": "",
+        },
+    )
+    assert resp.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# Extra: SalesPipelineResult round-trip through DiscoveryPlan / ClosingStrategy
+# (sanity that route models import cleanly under coverage)
+# ---------------------------------------------------------------------------
+
+
+def test_route_models_import_cleanly() -> None:
+    DiscoveryPlan(
+        prospect=Prospect(company_name="x"),
+        spin_questions=SPINQuestions(),
+    )
+    ClosingStrategy(
+        prospect=Prospect(company_name="x"),
+        recommended_close_technique=CloseType.SUMMARY,
+        close_script="s",
+    )
+    # Touch the enum-value branches without provoking ruff for unused locals.
+    assert DealResult.WON.value == "won"
+    assert OutcomeResult.CONVERTED.value == "converted"

--- a/backend/agents/sales_team/tests/test_dossier_render.py
+++ b/backend/agents/sales_team/tests/test_dossier_render.py
@@ -1,0 +1,240 @@
+"""Tests for ``sales_team.prompts._dossier_render.render_dossier_for_prompt``.
+
+The renderer translates a ``ProspectDossier`` into the markdown block the
+outreach prompt embeds. It must be:
+
+  * deterministic (same input → same output),
+  * bounded (long lists truncated to top-K),
+  * empty-aware (no section heading for an empty list),
+  * source-faithful (the Sources section preserves the input list exactly).
+"""
+
+from __future__ import annotations
+
+from sales_team.models import ProspectDossier, PublicWorkItem
+from sales_team.prompts._dossier_render import (
+    _DOSSIER_LIST_TOP_K,
+    _truncate,
+    render_dossier_for_prompt,
+)
+
+# ---------------------------------------------------------------------------
+# _truncate
+# ---------------------------------------------------------------------------
+
+
+def test_truncate_returns_input_unchanged_when_short() -> None:
+    items = [1, 2, 3]
+    out = _truncate(items, k=5)
+    assert out == items
+    # Same list object back (no copy) — confirms the short-circuit branch.
+    assert out is items
+
+
+def test_truncate_respects_k() -> None:
+    assert _truncate([1, 2, 3, 4, 5, 6], k=3) == [1, 2, 3]
+
+
+def test_truncate_default_k_is_five() -> None:
+    out = _truncate(list(range(10)))
+    assert len(out) == _DOSSIER_LIST_TOP_K
+
+
+# ---------------------------------------------------------------------------
+# render_dossier_for_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_minimal_dossier_renders_header_and_identity() -> None:
+    dossier = ProspectDossier(
+        prospect_id="prs_min",
+        full_name="Jane Smith",
+        current_title="VP Sales",
+        current_company="Acme Corp",
+        confidence=0.42,
+    )
+    out = render_dossier_for_prompt(dossier)
+    assert out.startswith("## Prospect Dossier (confidence: 0.42)")
+    assert "### Identity" in out
+    assert "Jane Smith — VP Sales at Acme Corp" in out
+    # No optional sections for an otherwise-empty dossier.
+    assert "### Executive Summary" not in out
+    assert "### Trigger Events" not in out
+    assert "### Sources" not in out
+
+
+def test_identity_omits_dash_when_title_and_company_are_blank() -> None:
+    """When both current_title and current_company are empty, the renderer
+    still uses just the name. (Defensive — model_validator allows empty
+    strings on these fields.)"""
+    dossier = ProspectDossier(
+        prospect_id="prs_x",
+        full_name="Bare Name",
+        current_title="",
+        current_company="",
+    )
+    out = render_dossier_for_prompt(dossier)
+    assert "Bare Name" in out
+
+
+def test_identity_includes_location_linkedin_and_personal_site() -> None:
+    dossier = ProspectDossier(
+        prospect_id="prs_full_id",
+        full_name="Jane Smith",
+        current_title="VP Sales",
+        current_company="Acme",
+        location="New York, NY",
+        linkedin_url="https://linkedin.com/in/jane-smith",
+        personal_site="https://janesmith.example.com",
+    )
+    out = render_dossier_for_prompt(dossier)
+    assert "Location: New York, NY" in out
+    assert "LinkedIn: https://linkedin.com/in/jane-smith" in out
+    assert "Personal site: https://janesmith.example.com" in out
+
+
+def test_executive_summary_renders_when_present() -> None:
+    dossier = ProspectDossier(
+        prospect_id="prs_e",
+        full_name="Jane",
+        current_title="VP",
+        current_company="Acme",
+        executive_summary="Two-sentence summary.",
+    )
+    out = render_dossier_for_prompt(dossier)
+    assert "### Executive Summary" in out
+    assert "Two-sentence summary." in out
+
+
+def test_trigger_events_truncate_to_top_k() -> None:
+    events = [f"event-{i}" for i in range(8)]
+    dossier = ProspectDossier(
+        prospect_id="prs_te",
+        full_name="J",
+        current_title="V",
+        current_company="A",
+        trigger_events=events,
+    )
+    out = render_dossier_for_prompt(dossier)
+    # Top-K rendered, rest dropped.
+    rendered = [e for e in events if e in out]
+    assert len(rendered) == _DOSSIER_LIST_TOP_K
+
+
+def test_publications_render_all_metadata_fields() -> None:
+    dossier = ProspectDossier(
+        prospect_id="prs_pubs",
+        full_name="Jane",
+        current_title="VP",
+        current_company="Acme",
+        publications=[
+            PublicWorkItem(
+                kind="talk",
+                title="Scaling SDR Teams",
+                url="https://qcon.example.com/talk",
+                venue="QCon SF",
+                date="2025-11",
+            ),
+            PublicWorkItem(kind="article", title="Cadence basics"),
+        ],
+    )
+    out = render_dossier_for_prompt(dossier)
+    assert "### Publications" in out
+    assert "[talk] Scaling SDR Teams" in out
+    assert "— QCon SF" in out
+    assert "(2025-11)" in out
+    assert "https://qcon.example.com/talk" in out
+    # The bare article publication still renders without venue/date/url.
+    assert "[article] Cadence basics" in out
+
+
+def test_recent_activity_conversation_hooks_and_mutual_connections() -> None:
+    dossier = ProspectDossier(
+        prospect_id="prs_rl",
+        full_name="J",
+        current_title="V",
+        current_company="A",
+        recent_activity=["Posted on LinkedIn about pipeline scale"],
+        conversation_hooks=["Series B funding → pipeline scale"],
+        mutual_connection_angles=["Worked at Stripe with our champion"],
+    )
+    out = render_dossier_for_prompt(dossier)
+    assert "### Recent Activity" in out
+    assert "Posted on LinkedIn about pipeline scale" in out
+    assert "### Conversation Hooks" in out
+    assert "Series B funding → pipeline scale" in out
+    assert "### Mutual Connection Angles" in out
+    assert "Worked at Stripe with our champion" in out
+
+
+def test_stated_beliefs_render_when_present() -> None:
+    dossier = ProspectDossier(
+        prospect_id="prs_b",
+        full_name="J",
+        current_title="V",
+        current_company="A",
+        stated_beliefs=["Outbound is dead", "Multi-thread or die"],
+    )
+    out = render_dossier_for_prompt(dossier)
+    assert "### Stated Beliefs" in out
+    assert "Outbound is dead" in out
+    assert "Multi-thread or die" in out
+
+
+def test_topics_of_interest_render_inline_comma_separated() -> None:
+    dossier = ProspectDossier(
+        prospect_id="prs_topics",
+        full_name="J",
+        current_title="V",
+        current_company="A",
+        topics_of_interest=["sales ops", "RevOps", "CRO playbook"],
+    )
+    out = render_dossier_for_prompt(dossier)
+    assert "### Topics of Interest" in out
+    assert "sales ops, RevOps, CRO playbook" in out
+
+
+def test_topics_of_interest_truncate_to_top_ten() -> None:
+    topics = [f"topic-{i}" for i in range(15)]
+    dossier = ProspectDossier(
+        prospect_id="prs_t",
+        full_name="J",
+        current_title="V",
+        current_company="A",
+        topics_of_interest=topics,
+    )
+    out = render_dossier_for_prompt(dossier)
+    # The function truncates Topics to top-10 (k=10), not the default top-K.
+    assert "topic-0" in out
+    assert "topic-9" in out
+    assert "topic-10" not in out
+
+
+def test_sources_render_full_unbounded_list() -> None:
+    sources = [f"https://src-{i}.example.com" for i in range(8)]
+    dossier = ProspectDossier(
+        prospect_id="prs_s",
+        full_name="J",
+        current_title="V",
+        current_company="A",
+        sources=sources,
+    )
+    out = render_dossier_for_prompt(dossier)
+    assert "### Sources (only these URLs may be cited)" in out
+    # All sources appear (sources are intentionally NOT truncated).
+    for s in sources:
+        assert s in out
+
+
+def test_render_is_deterministic_across_calls() -> None:
+    dossier = ProspectDossier(
+        prospect_id="prs_det",
+        full_name="J",
+        current_title="V",
+        current_company="A",
+        trigger_events=["e1"],
+        sources=["https://x"],
+    )
+    a = render_dossier_for_prompt(dossier)
+    b = render_dossier_for_prompt(dossier)
+    assert a == b

--- a/backend/agents/sales_team/tests/test_dossier_store.py
+++ b/backend/agents/sales_team/tests/test_dossier_store.py
@@ -1,0 +1,362 @@
+"""Tests for ``sales_team.dossier_store.DossierStore``.
+
+The store is Postgres-only in production. These tests swap the module's
+``get_conn`` for a dict-backed fake cursor so we exercise every code path
+(insert, upsert, batch lookup, missing rows, ts parsing) without needing
+a live database.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from sales_team import dossier_store
+from sales_team.models import DeepResearchResult, Prospect, ProspectDossier, ProspectListEntry
+
+# ---------------------------------------------------------------------------
+# Fake Postgres
+# ---------------------------------------------------------------------------
+
+
+class _FakeCursor:
+    def __init__(self, db: dict[str, Any]) -> None:
+        self._db = db
+        self._last_fetch_one: dict | None = None
+        self._last_fetch_all: list[dict] = []
+        self.rowcount = 0
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def execute(self, sql: str, params: tuple | list = ()) -> None:
+        sql_l = " ".join(sql.split()).lower()
+        params = tuple(params)
+
+        if sql_l.startswith("insert into sales_dossiers"):
+            (id_, prospect_id, company_name, full_name, data, generated_at) = params
+            payload = data.obj if hasattr(data, "obj") else data
+            self._db["dossiers"][id_] = {
+                "id": id_,
+                "prospect_id": prospect_id,
+                "company_name": company_name,
+                "full_name": full_name,
+                "data": payload,
+                "generated_at": generated_at,
+            }
+            return
+
+        if sql_l.startswith("select data from sales_dossiers where id"):
+            (id_,) = params
+            row = self._db["dossiers"].get(id_)
+            self._last_fetch_one = {"data": row["data"]} if row else None
+            return
+
+        if "select prospect_id, data from sales_dossiers where prospect_id" in sql_l:
+            (ids,) = params
+            wanted = set(ids)
+            self._last_fetch_all = [
+                {"prospect_id": row["prospect_id"], "data": row["data"]}
+                for row in self._db["dossiers"].values()
+                if row["prospect_id"] in wanted
+            ]
+            return
+
+        if sql_l.startswith("insert into sales_prospect_lists"):
+            (
+                id_,
+                product_name,
+                total_prospects,
+                companies_represented,
+                data,
+                generated_at,
+            ) = params
+            payload = data.obj if hasattr(data, "obj") else data
+            self._db["lists"][id_] = {
+                "id": id_,
+                "product_name": product_name,
+                "total_prospects": total_prospects,
+                "companies_represented": companies_represented,
+                "data": payload,
+                "generated_at": generated_at,
+            }
+            return
+
+        if sql_l.startswith("select data from sales_prospect_lists where id"):
+            (id_,) = params
+            row = self._db["lists"].get(id_)
+            self._last_fetch_one = {"data": row["data"]} if row else None
+            return
+
+        if "from sales_prospect_lists" in sql_l and "order by generated_at desc" in sql_l:
+            (limit,) = params
+            ordered = sorted(
+                self._db["lists"].values(),
+                key=lambda r: r["generated_at"],
+                reverse=True,
+            )[:limit]
+            self._last_fetch_all = [
+                {
+                    "id": r["id"],
+                    "product_name": r["product_name"],
+                    "total_prospects": r["total_prospects"],
+                    "companies_represented": r["companies_represented"],
+                    "generated_at": r["generated_at"],
+                }
+                for r in ordered
+            ]
+            return
+
+        raise AssertionError(f"unexpected SQL in fake cursor: {sql!r}")
+
+    def fetchone(self):
+        return self._last_fetch_one
+
+    def fetchall(self):
+        return self._last_fetch_all
+
+
+class _FakeConn:
+    def __init__(self, db: dict[str, Any]) -> None:
+        self._db = db
+
+    def cursor(self, row_factory=None):  # noqa: ANN001
+        return _FakeCursor(self._db)
+
+
+@pytest.fixture
+def fake_pg(monkeypatch: pytest.MonkeyPatch):
+    """Install the fake ``get_conn`` on the dossier_store module."""
+    db: dict[str, Any] = {"dossiers": {}, "lists": {}}
+
+    @contextmanager
+    def _fake_get_conn(*args, **kwargs):
+        yield _FakeConn(db)
+
+    monkeypatch.setattr(dossier_store, "get_conn", _fake_get_conn)
+    return db
+
+
+# ---------------------------------------------------------------------------
+# Helpers / module-level
+# ---------------------------------------------------------------------------
+
+
+def test_now_iso_returns_iso_with_offset() -> None:
+    out = dossier_store._now_iso()
+    assert "T" in out
+    assert out.endswith("+00:00") or out.endswith("Z")
+
+
+def test_parse_ts_returns_now_on_empty_string() -> None:
+    out = dossier_store._parse_ts("")
+    assert isinstance(out, datetime)
+    assert out.tzinfo is timezone.utc
+
+
+def test_parse_ts_returns_now_on_invalid_string() -> None:
+    out = dossier_store._parse_ts("not-a-timestamp")
+    assert isinstance(out, datetime)
+
+
+def test_parse_ts_parses_valid_iso8601() -> None:
+    out = dossier_store._parse_ts("2026-05-21T01:02:03+00:00")
+    assert out.year == 2026
+    assert out.month == 5
+    assert out.day == 21
+
+
+# ---------------------------------------------------------------------------
+# DossierStore.save_dossier / get_dossier
+# ---------------------------------------------------------------------------
+
+
+def _make_dossier(**overrides) -> ProspectDossier:
+    fields = dict(
+        prospect_id="prs_1",
+        full_name="Jane Smith",
+        current_title="VP Sales",
+        current_company="Acme Corp",
+        executive_summary="Runs the SDR team at Acme.",
+        sources=["https://news.example.com/acme-series-b"],
+        confidence=0.7,
+    )
+    fields.update(overrides)
+    return ProspectDossier(**fields)
+
+
+def test_save_dossier_assigns_id_and_timestamp_when_missing(fake_pg) -> None:
+    store = dossier_store.DossierStore()
+    saved = store.save_dossier(_make_dossier())
+    assert saved.dossier_id.startswith("dsr_")
+    assert saved.generated_at
+    # And it landed in the fake DB.
+    assert saved.dossier_id in fake_pg["dossiers"]
+
+
+def test_save_dossier_keeps_caller_id_and_timestamp(fake_pg) -> None:
+    store = dossier_store.DossierStore()
+    dossier = _make_dossier(dossier_id="dsr_existing", generated_at="2026-05-21T00:00:00+00:00")
+    saved = store.save_dossier(dossier)
+    assert saved.dossier_id == "dsr_existing"
+    assert saved.generated_at == "2026-05-21T00:00:00+00:00"
+    # The data column carries the full model dump.
+    row = fake_pg["dossiers"]["dsr_existing"]
+    assert row["data"]["prospect_id"] == "prs_1"
+
+
+def test_get_dossier_returns_none_when_missing(fake_pg) -> None:
+    store = dossier_store.DossierStore()
+    assert store.get_dossier("dsr_missing") is None
+
+
+def test_get_dossier_round_trip(fake_pg) -> None:
+    store = dossier_store.DossierStore()
+    saved = store.save_dossier(_make_dossier())
+    loaded = store.get_dossier(saved.dossier_id)
+    assert loaded is not None
+    assert loaded.full_name == "Jane Smith"
+    assert loaded.prospect_id == "prs_1"
+
+
+# ---------------------------------------------------------------------------
+# DossierStore.get_dossiers_by_prospect_ids
+# ---------------------------------------------------------------------------
+
+
+def test_get_dossiers_by_prospect_ids_returns_empty_when_no_ids(fake_pg) -> None:
+    store = dossier_store.DossierStore()
+    # Early-return branch — must NOT touch Postgres.
+    assert store.get_dossiers_by_prospect_ids([]) == {}
+
+
+def test_get_dossiers_by_prospect_ids_returns_keyed_map(fake_pg) -> None:
+    store = dossier_store.DossierStore()
+    a = store.save_dossier(_make_dossier(prospect_id="prs_a", full_name="A"))
+    b = store.save_dossier(_make_dossier(prospect_id="prs_b", full_name="B"))
+    out = store.get_dossiers_by_prospect_ids(["prs_a", "prs_b", "prs_missing"])
+    assert set(out.keys()) == {"prs_a", "prs_b"}
+    assert out["prs_a"].dossier_id == a.dossier_id
+    assert out["prs_b"].dossier_id == b.dossier_id
+
+
+def test_get_dossiers_by_prospect_ids_keeps_newest_when_duplicate(fake_pg) -> None:
+    store = dossier_store.DossierStore()
+    # Save older.
+    store.save_dossier(
+        _make_dossier(
+            dossier_id="dsr_old",
+            prospect_id="prs_dup",
+            generated_at="2025-01-01T00:00:00+00:00",
+        )
+    )
+    # Save newer.
+    store.save_dossier(
+        _make_dossier(
+            dossier_id="dsr_new",
+            prospect_id="prs_dup",
+            generated_at="2026-01-01T00:00:00+00:00",
+        )
+    )
+    out = store.get_dossiers_by_prospect_ids(["prs_dup"])
+    assert out["prs_dup"].dossier_id == "dsr_new"
+
+
+# ---------------------------------------------------------------------------
+# DossierStore.save_prospect_list / get / list
+# ---------------------------------------------------------------------------
+
+
+def _make_list(**overrides) -> DeepResearchResult:
+    p = Prospect(id="prs_a", company_name="Acme")
+    entry = ProspectListEntry(
+        rank=1, prospect=p, dossier_id="dsr_x", dossier_url="/api/sales/dossiers/dsr_x"
+    )
+    fields = dict(
+        list_id="",
+        product_name="ProductX",
+        generated_at="",
+        total_prospects=1,
+        companies_represented=1,
+        entries=[entry],
+    )
+    fields.update(overrides)
+    return DeepResearchResult(**fields)
+
+
+def test_save_prospect_list_assigns_id_and_timestamp(fake_pg) -> None:
+    store = dossier_store.DossierStore()
+    saved = store.save_prospect_list(_make_list())
+    assert saved.list_id.startswith("plst_")
+    assert saved.generated_at
+    assert saved.list_id in fake_pg["lists"]
+
+
+def test_save_prospect_list_keeps_caller_provided_id(fake_pg) -> None:
+    store = dossier_store.DossierStore()
+    saved = store.save_prospect_list(
+        _make_list(list_id="plst_explicit", generated_at="2026-05-21T01:01:01+00:00")
+    )
+    assert saved.list_id == "plst_explicit"
+
+
+def test_get_prospect_list_returns_none_when_missing(fake_pg) -> None:
+    store = dossier_store.DossierStore()
+    assert store.get_prospect_list("plst_nope") is None
+
+
+def test_get_prospect_list_round_trip(fake_pg) -> None:
+    store = dossier_store.DossierStore()
+    saved = store.save_prospect_list(_make_list())
+    loaded = store.get_prospect_list(saved.list_id)
+    assert loaded is not None
+    assert loaded.product_name == "ProductX"
+    assert loaded.entries[0].prospect.company_name == "Acme"
+
+
+def test_list_prospect_lists_returns_summaries_sorted_newest_first(fake_pg) -> None:
+    store = dossier_store.DossierStore()
+    store.save_prospect_list(_make_list(product_name="A", generated_at="2025-01-01T00:00:00+00:00"))
+    store.save_prospect_list(_make_list(product_name="B", generated_at="2026-05-21T00:00:00+00:00"))
+    summaries = store.list_prospect_lists(limit=50)
+    names = [s["product_name"] for s in summaries]
+    assert names == ["B", "A"]
+    # Summary fields are the minimal ones, not the full data payload.
+    expected_keys = {
+        "list_id",
+        "product_name",
+        "total_prospects",
+        "companies_represented",
+        "generated_at",
+    }
+    assert set(summaries[0].keys()) == expected_keys
+
+
+def test_list_prospect_lists_respects_limit(fake_pg) -> None:
+    store = dossier_store.DossierStore()
+    for i in range(5):
+        store.save_prospect_list(
+            _make_list(product_name=f"P{i}", generated_at=f"2025-01-0{i + 1}T00:00:00+00:00")
+        )
+    assert len(store.list_prospect_lists(limit=2)) == 2
+
+
+def test_list_prospect_lists_normalizes_non_datetime_generated_at(fake_pg) -> None:
+    """If the DB ever returns a string for generated_at (unusual but possible
+    if the column type drifted), the summary serialiser must still produce
+    a string without raising."""
+    store = dossier_store.DossierStore()
+    store.save_prospect_list(_make_list(generated_at="2026-05-21T00:00:00+00:00"))
+    # Mutate the fake row to use a plain string for generated_at (mimics
+    # type drift). The store's branch ``isinstance(...)`` falls through to
+    # ``str(...)`` in that case.
+    list_id = next(iter(fake_pg["lists"]))
+    fake_pg["lists"][list_id]["generated_at"] = "not-a-datetime"
+    summaries = store.list_prospect_lists()
+    assert summaries[0]["generated_at"] == "not-a-datetime"

--- a/backend/agents/sales_team/tests/test_learning_engine.py
+++ b/backend/agents/sales_team/tests/test_learning_engine.py
@@ -1,0 +1,209 @@
+"""Additional tests for ``sales_team.learning_engine``.
+
+Existing tests in ``test_sales_team.py`` cover the empty-outcomes and
+happy-path branches of ``LearningEngine.refresh``. This module covers the
+``format_insights_for_prompt`` helper and the remaining branches in
+``refresh``:
+
+  * version increments off an existing snapshot,
+  * defensive total_outcomes_analyzed backfill when the LLM under-reports,
+  * default-load of stage/deal outcomes when caller passes ``None``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from llm_service.interface import LLMClient
+from sales_team import learning_engine as le_mod
+from sales_team.learning_engine import (
+    LearningEngine,
+    format_insights_for_prompt,
+)
+from sales_team.models import (
+    DealOutcome,
+    DealResult,
+    LearningInsights,
+    OutcomeResult,
+    PipelineStage,
+    StageOutcome,
+)
+
+# ---------------------------------------------------------------------------
+# Canned LLM client (local to keep this file self-contained)
+# ---------------------------------------------------------------------------
+
+
+class CannedLLM(LLMClient):
+    def __init__(self, responses: List[Dict[str, Any]]) -> None:
+        self._responses = list(responses)
+        self.calls: List[Dict[str, Any]] = []
+
+    def complete_json(
+        self,
+        prompt: str,
+        *,
+        temperature: float = 0.0,
+        system_prompt: Optional[str] = None,
+        tools: Optional[list] = None,
+        think: bool = False,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        self.calls.append({"prompt": prompt, "system_prompt": system_prompt})
+        if not self._responses:
+            raise AssertionError("CannedLLM out of responses")
+        return self._responses.pop(0)
+
+
+# ---------------------------------------------------------------------------
+# format_insights_for_prompt
+# ---------------------------------------------------------------------------
+
+
+def test_format_returns_empty_when_insights_none() -> None:
+    assert format_insights_for_prompt(None) == ""
+
+
+def test_format_returns_empty_when_no_outcomes_analyzed() -> None:
+    assert format_insights_for_prompt(LearningInsights(total_outcomes_analyzed=0)) == ""
+
+
+def test_format_renders_all_optional_sections() -> None:
+    insights = LearningInsights(
+        total_outcomes_analyzed=12,
+        win_rate=0.42,
+        insights_version=3,
+        winning_patterns=["multi-thread", "EB on call"],
+        losing_patterns=["single-thread", "no champion"],
+        top_performing_industries=["SaaS", "FinTech"],
+        common_objections=["price", "timing"],
+        best_close_techniques=["summary", "alternative_choice"],
+        best_outreach_angles=["trigger_event", "peer_proof"],
+        actionable_recommendations=["multi-thread earlier", "ask for EB"],
+        avg_sales_cycle_days=42.0,
+        stage_conversion_rates={"qualification": 0.4, "discovery": 0.7},
+    )
+    out = format_insights_for_prompt(insights)
+    assert "Learned from 12 past outcomes" in out
+    assert "What's working" in out
+    assert "multi-thread" in out
+    assert "Watch out for" in out
+    assert "Top industries" in out and "SaaS" in out
+    assert "Most frequent objections" in out
+    assert "Best close techniques" in out
+    assert "High-reply outreach angles" in out
+    assert "Top recommendations" in out
+    assert "Avg sales cycle (won)" in out
+    assert "Biggest funnel leak" in out
+    # Worst converter is "qualification" with 0.4 conversion.
+    assert "qualification" in out
+
+
+def test_format_omits_optional_sections_when_lists_empty() -> None:
+    """Minimal insights with only total_outcomes_analyzed=1 → only header."""
+    insights = LearningInsights(total_outcomes_analyzed=1)
+    out = format_insights_for_prompt(insights)
+    assert "Learned from 1 past outcomes" in out
+    assert "What's working" not in out
+    assert "Watch out for" not in out
+    assert "Top industries" not in out
+    assert "Biggest funnel leak" not in out
+
+
+# ---------------------------------------------------------------------------
+# LearningEngine.refresh: version increments and defensive backfill
+# ---------------------------------------------------------------------------
+
+
+def test_refresh_increments_version_off_existing_snapshot(monkeypatch: pytest.MonkeyPatch) -> None:
+    existing = LearningInsights(insights_version=5, total_outcomes_analyzed=10)
+    saved: Dict[str, Any] = {}
+
+    monkeypatch.setattr(le_mod, "load_current_insights", lambda: existing)
+    monkeypatch.setattr(le_mod, "save_insights", lambda i: saved.setdefault("i", i))
+
+    llm = CannedLLM(
+        [
+            {
+                "total_outcomes_analyzed": 1,
+                "win_rate": 0.0,
+                "winning_patterns": [],
+                "actionable_recommendations": [],
+            }
+        ]
+    )
+    engine = LearningEngine(llm_client=llm)
+    stage = StageOutcome(
+        company_name="A",
+        stage=PipelineStage.OUTREACH,
+        outcome=OutcomeResult.CONVERTED,
+    )
+    insights = engine.refresh(stage_outcomes=[stage], deal_outcomes=[])
+    assert insights.insights_version == 6  # existing 5 + 1
+    assert saved["i"] is insights
+
+
+def test_refresh_backfills_total_outcomes_when_llm_under_reports(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the LLM forgets to set total_outcomes_analyzed, the engine must
+    fill it with the actual record count so the UI is honest."""
+    monkeypatch.setattr(le_mod, "load_current_insights", lambda: None)
+    monkeypatch.setattr(le_mod, "save_insights", lambda i: None)
+
+    llm = CannedLLM(
+        [
+            {
+                "total_outcomes_analyzed": 0,  # LLM forgot
+                "win_rate": 0.5,
+                "winning_patterns": [],
+                "actionable_recommendations": [],
+            }
+        ]
+    )
+    engine = LearningEngine(llm_client=llm)
+    stages = [
+        StageOutcome(
+            company_name=f"A{i}",
+            stage=PipelineStage.OUTREACH,
+            outcome=OutcomeResult.CONVERTED,
+        )
+        for i in range(3)
+    ]
+    deals = [
+        DealOutcome(
+            company_name="A0",
+            final_stage_reached=PipelineStage.CLOSED_WON,
+            result=DealResult.WON,
+        )
+    ]
+    insights = engine.refresh(stage_outcomes=stages, deal_outcomes=deals)
+    # 3 stages + 1 deal = 4
+    assert insights.total_outcomes_analyzed == 4
+
+
+def test_refresh_loads_outcomes_when_caller_passes_none(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When ``stage_outcomes`` / ``deal_outcomes`` are None, the engine must
+    fall back to ``load_stage_outcomes()`` / ``load_deal_outcomes()``."""
+    captured: dict[str, int] = {"stage_loaded": 0, "deal_loaded": 0}
+
+    def _fake_load_stage():
+        captured["stage_loaded"] += 1
+        return []
+
+    def _fake_load_deal():
+        captured["deal_loaded"] += 1
+        return []
+
+    monkeypatch.setattr(le_mod, "load_stage_outcomes", _fake_load_stage)
+    monkeypatch.setattr(le_mod, "load_deal_outcomes", _fake_load_deal)
+    monkeypatch.setattr(le_mod, "load_current_insights", lambda: None)
+    monkeypatch.setattr(le_mod, "save_insights", lambda i: None)
+
+    llm = CannedLLM([])  # zero outcomes, never called
+    engine = LearningEngine(llm_client=llm)
+    insights = engine.refresh()  # default args
+    assert insights.total_outcomes_analyzed == 0
+    assert captured == {"stage_loaded": 1, "deal_loaded": 1}

--- a/backend/agents/sales_team/tests/test_misc_branches.py
+++ b/backend/agents/sales_team/tests/test_misc_branches.py
@@ -1,0 +1,260 @@
+"""Targeted tests for small, isolated branches not naturally covered elsewhere:
+
+* ``EmailTouch`` citation validator with non-None context but no
+  ``dossier_source_urls`` key.
+* ``agents._with_insights`` whitespace-only fallback branch.
+* Outreach / proposal critic prompts when dossier exceeds the char cap
+  (truncation marker appears).
+* ``ProposalCriticAgent`` invariant override (LLM says approved=True but
+  must_fix > 0 → critic flips approved to False).
+* ``format_critic_feedback`` notes-appended branch.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from llm_service.interface import LLMClient
+from sales_team.agents import _with_insights
+from sales_team.critics import (
+    OutreachCriticAgent,
+    ProposalCriticAgent,
+    format_critic_feedback,
+)
+from sales_team.critics.outreach_critic import _DOSSIER_CHAR_CAP
+from sales_team.models import (
+    BANTScore,
+    CriticViolation,
+    EmailTouch,
+    IdealCustomerProfile,
+    MEDDICScore,
+    OutreachSequence,
+    OutreachVariant,
+    Prospect,
+    ProspectDossier,
+    QualificationScore,
+    ROIModel,
+    SalesProposal,
+)
+
+
+class _CannedLLM(LLMClient):
+    def __init__(self, responses: List[Dict[str, Any]]) -> None:
+        self._responses = list(responses)
+        self.calls: List[Dict[str, Any]] = []
+
+    def complete_json(
+        self,
+        prompt: str,
+        *,
+        temperature: float = 0.0,
+        system_prompt: Optional[str] = None,
+        tools: Optional[list] = None,
+        think: bool = False,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        self.calls.append({"prompt": prompt})
+        return self._responses.pop(0)
+
+
+# ---------------------------------------------------------------------------
+# EmailTouch validator: context present but no source URLs registered.
+# ---------------------------------------------------------------------------
+
+
+def test_email_touch_keeps_citations_when_context_missing_source_urls() -> None:
+    """When validation context exists but lacks ``dossier_source_urls``,
+    the validator must return the citations unchanged (no stripping)."""
+    ctx: Dict[str, Any] = {"some_other_key": True}
+    touch = EmailTouch.model_validate(
+        {
+            "day": 1,
+            "subject_line": "s",
+            "body": "b",
+            "evidence_citations": [
+                {"claim": "c", "dossier_field": "f", "source_url": "https://anywhere.com"}
+            ],
+        },
+        context=ctx,
+    )
+    assert len(touch.evidence_citations) == 1
+    assert touch.evidence_citations[0].source_url == "https://anywhere.com"
+
+
+# ---------------------------------------------------------------------------
+# agents._with_insights: empty / whitespace-only insights.
+# ---------------------------------------------------------------------------
+
+
+def test_with_insights_returns_base_when_insights_is_none() -> None:
+    assert _with_insights("base prompt", None) == "base prompt"
+
+
+def test_with_insights_returns_base_when_insights_is_whitespace() -> None:
+    assert _with_insights("base prompt", "   \n  ") == "base prompt"
+
+
+def test_with_insights_prepends_when_insights_is_substantive() -> None:
+    out = _with_insights("base prompt", "context")
+    assert out.startswith("context")
+    assert "base prompt" in out
+
+
+# ---------------------------------------------------------------------------
+# Critic _build_prompt — dossier truncation branch.
+# ---------------------------------------------------------------------------
+
+
+def _huge_dossier() -> ProspectDossier:
+    """Build a dossier whose JSON exceeds the 12_000-char cap."""
+    big_text = "lorem ipsum " * 2000  # ~24k chars
+    return ProspectDossier(
+        prospect_id="prs_big",
+        full_name="Jane",
+        current_title="VP",
+        current_company="Acme",
+        executive_summary=big_text,
+    )
+
+
+def _sequence(prospect: Prospect, dossier_id: str) -> OutreachSequence:
+    return OutreachSequence(
+        prospect=prospect,
+        dossier_id=dossier_id,
+        dossier_confidence=0.8,
+        variants=[
+            OutreachVariant(
+                angle="company_soft_opener",
+                personalization_grade="fallback",
+                email_sequence=[EmailTouch(day=1, subject_line="s", body="b")],
+            )
+        ],
+    )
+
+
+def test_outreach_critic_truncates_oversize_dossier_in_prompt() -> None:
+    prospect = Prospect(id="prs_x", company_name="Acme")
+    dossier = _huge_dossier()
+    icp = IdealCustomerProfile(industry=["SaaS"])
+    seq = _sequence(prospect, dossier.dossier_id or "d_x")
+    llm = _CannedLLM(
+        [{"status": "PASS", "approved": True, "violations": [], "rubric_version": "v1"}]
+    )
+    critic = OutreachCriticAgent(llm_client=llm)
+    critic.review(seq, dossier, icp)
+    # The critic's prompt should contain the truncation marker because the
+    # dossier JSON exceeds the cap.
+    assert any("dossier truncated" in (c["prompt"] or "") for c in llm.calls)
+    # And the prompt should be capped near _DOSSIER_CHAR_CAP for the dossier slice.
+    assert _DOSSIER_CHAR_CAP < len(llm.calls[0]["prompt"])  # full prompt > cap, sanity
+
+
+def test_outreach_critic_emits_no_dossier_marker_when_dossier_none() -> None:
+    """If the outreach critic is called without a dossier, the prompt
+    embeds the explicit '(no dossier supplied)' marker."""
+    prospect = Prospect(id="prs_x", company_name="Acme")
+    icp = IdealCustomerProfile(industry=["SaaS"])
+    seq = _sequence(prospect, "dsr_x")
+    llm = _CannedLLM(
+        [{"status": "PASS", "approved": True, "violations": [], "rubric_version": "v1"}]
+    )
+    critic = OutreachCriticAgent(llm_client=llm)
+    critic.review(seq, None, icp)
+    assert any("(no dossier supplied)" in (c["prompt"] or "") for c in llm.calls)
+
+
+def test_proposal_critic_truncates_oversize_dossier_in_prompt() -> None:
+    prospect = Prospect(id="prs_p", company_name="Acme")
+    dossier = _huge_dossier()
+    proposal = SalesProposal(
+        prospect=prospect,
+        executive_summary="s",
+        situation_analysis="s",
+        proposed_solution="s",
+        roi_model=ROIModel(
+            annual_cost_usd=1.0,
+            estimated_annual_benefit_usd=1.0,
+            payback_months=12.0,
+            roi_percentage=0.0,
+        ),
+    )
+    qual = QualificationScore(
+        prospect=prospect,
+        bant=BANTScore(budget=5, authority=5, need=5, timeline=5),
+        meddic=MEDDICScore(),
+        overall_score=0.5,
+        value_creation_level=2,
+        recommended_action="advance",
+    )
+    llm = _CannedLLM(
+        [{"status": "PASS", "approved": True, "violations": [], "rubric_version": "v1"}]
+    )
+    critic = ProposalCriticAgent(llm_client=llm)
+    critic.review(proposal, dossier, qual)
+    assert any("dossier truncated" in (c["prompt"] or "") for c in llm.calls)
+
+
+# ---------------------------------------------------------------------------
+# ProposalCriticAgent invariant override (line 131).
+# ---------------------------------------------------------------------------
+
+
+def test_proposal_critic_overrides_approved_when_model_lies() -> None:
+    """The model says approved=True but lists a must_fix violation — the
+    critic must flip ``approved`` to False."""
+    prospect = Prospect(id="prs_p", company_name="Acme")
+    proposal = SalesProposal(
+        prospect=prospect,
+        executive_summary="s",
+        situation_analysis="s",
+        proposed_solution="s",
+        roi_model=ROIModel(
+            annual_cost_usd=1.0,
+            estimated_annual_benefit_usd=1.0,
+            payback_months=12.0,
+            roi_percentage=0.0,
+        ),
+    )
+    qual = QualificationScore(
+        prospect=prospect,
+        bant=BANTScore(budget=5, authority=5, need=5, timeline=5),
+        meddic=MEDDICScore(),
+        overall_score=0.5,
+        value_creation_level=2,
+        recommended_action="advance",
+    )
+    bogus = {
+        "status": "PASS",
+        "approved": True,
+        "violations": [
+            {
+                "rule_id": "proposal.roi.arithmetic",
+                "severity": "must_fix",
+                "description": "off by 50%",
+                "suggested_fix": "recompute",
+            }
+        ],
+        "rubric_version": "v1",
+    }
+    critic = ProposalCriticAgent(llm_client=_CannedLLM([bogus]))
+    report = critic.review(proposal, None, qual)
+    assert report.approved is False
+
+
+# ---------------------------------------------------------------------------
+# format_critic_feedback — notes branch.
+# ---------------------------------------------------------------------------
+
+
+def test_format_critic_feedback_appends_notes_when_provided() -> None:
+    violations = [
+        CriticViolation(
+            rule_id="r",
+            severity="must_fix",
+            description="d",
+            suggested_fix="f",
+        )
+    ]
+    out = format_critic_feedback(violations, notes="LLM hint: bound CTA to dossier")
+    assert "Critic notes:" in out
+    assert "LLM hint" in out

--- a/backend/agents/sales_team/tests/test_orchestrator.py
+++ b/backend/agents/sales_team/tests/test_orchestrator.py
@@ -1,0 +1,1169 @@
+"""Tests for ``sales_team.orchestrator.SalesPodOrchestrator``.
+
+These tests focus on the orchestrator's policy code — the parts that wrap
+agent outputs, gate stages, and assemble the final pipeline result. They
+use stub agents (set via attribute assignment) so the orchestrator's own
+LLM clients never run.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List
+from unittest.mock import MagicMock
+
+import pytest
+
+from sales_team import orchestrator as orch_mod
+from sales_team.models import (
+    BANTScore,
+    CloseType,
+    ClosingStrategyBody,
+    DecisionMakerEntry,
+    DecisionMakerList,
+    DeepResearchRequest,
+    DiscoveryPlanBody,
+    EmailTouch,
+    EvidenceCitation,
+    IdealCustomerProfile,
+    LearningInsights,
+    MEDDICScore,
+    NurtureSequenceBody,
+    OutreachVariant,
+    OutreachVariantList,
+    PipelineCoachingReport,
+    PipelineStage,
+    ProposalRequest,
+    Prospect,
+    ProspectDossier,
+    ProspectList,
+    QualificationScoreBody,
+    ROIModel,
+    SalesPipelineRequest,
+    SalesProposalBody,
+    SPINQuestions,
+)
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_icp() -> IdealCustomerProfile:
+    return IdealCustomerProfile(
+        industry=["SaaS"],
+        company_size_min=50,
+        company_size_max=500,
+        job_titles=["VP Sales"],
+        pain_points=["manual reporting"],
+    )
+
+
+@pytest.fixture
+def sample_prospect() -> Prospect:
+    return Prospect(
+        id="prs_p1",
+        company_name="Acme Corp",
+        contact_name="Jane Smith",
+        contact_title="VP Sales",
+        icp_match_score=0.85,
+    )
+
+
+@pytest.fixture
+def sample_dossier(sample_prospect: Prospect) -> ProspectDossier:
+    return ProspectDossier(
+        dossier_id="dsr_main",
+        prospect_id=sample_prospect.id,
+        full_name="Jane Smith",
+        current_title="VP Sales",
+        current_company="Acme Corp",
+        executive_summary="Runs sales at Acme.",
+        sources=["https://news.example.com/acme"],
+        confidence=0.82,
+    )
+
+
+@pytest.fixture
+def stub_orch(monkeypatch: pytest.MonkeyPatch) -> orch_mod.SalesPodOrchestrator:
+    """Construct an orchestrator with all agent slots replaced by MagicMocks."""
+    o = orch_mod.SalesPodOrchestrator()
+    o.prospector = MagicMock()
+    o.outreach = MagicMock()
+    o.qualifier = MagicMock()
+    o.nurture = MagicMock()
+    o.discovery = MagicMock()
+    o.proposal = MagicMock()
+    o.closer = MagicMock()
+    o.coach = MagicMock()
+    o.decision_maker_mapper = MagicMock()
+    o.dossier_builder = MagicMock()
+    o.learning_engine = MagicMock()
+    o.outreach_critic = MagicMock()
+    o.proposal_critic = MagicMock()
+    return o
+
+
+# ---------------------------------------------------------------------------
+# _decision_makers_to_entries
+# ---------------------------------------------------------------------------
+
+
+def test_decision_makers_to_entries_skips_blank_names() -> None:
+    company = Prospect(company_name="Acme", research_notes="base notes")
+    dm_list = DecisionMakerList(
+        contacts=[
+            DecisionMakerEntry(contact_name="", confidence=0.8),
+            DecisionMakerEntry(contact_name="   ", confidence=0.8),
+            DecisionMakerEntry(
+                contact_name="Jane Smith",
+                contact_title="VP Sales",
+                linkedin_url="https://linkedin.com/in/jane",
+                decision_maker_rationale="Owns budget",
+                confidence=0.9,
+            ),
+        ]
+    )
+    entries = orch_mod._decision_makers_to_entries(dm_list, company)
+    assert len(entries) == 1
+    prospect, conf = entries[0]
+    assert prospect.contact_name == "Jane Smith"
+    assert prospect.contact_email is None  # never fabricated
+    assert conf == 0.9
+    # Notes get combined.
+    assert "base notes" in prospect.research_notes
+    assert "Owns budget" in prospect.research_notes
+    assert "confidence: 0.9" in prospect.research_notes
+
+
+def test_decision_makers_to_entries_handles_empty_rationale_and_notes() -> None:
+    company = Prospect(company_name="Acme", research_notes="")
+    dm_list = DecisionMakerList(
+        contacts=[
+            DecisionMakerEntry(contact_name="J", decision_maker_rationale=""),
+        ]
+    )
+    entries = orch_mod._decision_makers_to_entries(dm_list, company)
+    assert len(entries) == 1
+    # rationale empty → extra_notes still contains the confidence — but base_notes
+    # was empty so notes = extra_notes only.
+    assert "confidence" in entries[0][0].research_notes
+
+
+# ---------------------------------------------------------------------------
+# _rank_score / _enforce_cap_and_rank (cap_and_rank already partially covered)
+# ---------------------------------------------------------------------------
+
+
+def test_rank_score_weighted_average() -> None:
+    p = Prospect(company_name="Acme", icp_match_score=0.5)
+    assert abs(orch_mod._rank_score((p, 1.0)) - (0.7 * 0.5 + 0.3 * 1.0)) < 1e-9
+
+
+def test_enforce_cap_and_rank_dedupes_by_linkedin_or_contact() -> None:
+    a = Prospect(company_name="Acme", contact_name="J", linkedin_url="https://x/jane")
+    b = Prospect(company_name="Acme", contact_name="J", linkedin_url="https://x/jane")  # dup
+    c = Prospect(company_name="Acme", contact_name="K")  # different
+    out = orch_mod._enforce_cap_and_rank(
+        [(a, 0.9), (b, 0.9), (c, 0.9)], max_per_company=10, target_count=10
+    )
+    assert len(out) == 2
+
+
+# ---------------------------------------------------------------------------
+# _build_fallback_variant (extra branches covered by existing test_sales_team)
+# ---------------------------------------------------------------------------
+
+
+def test_build_fallback_variant_has_day1_email(sample_prospect: Prospect) -> None:
+    variant = orch_mod._build_fallback_variant(sample_prospect)
+    assert variant.email_sequence[0].day == 1
+    assert "15-minute call" in variant.email_sequence[0].call_to_action
+
+
+# ---------------------------------------------------------------------------
+# _wrap_outreach_sequence — fallback emit branch when all variants filtered
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_outreach_sequence_emits_fallback_when_all_filtered(
+    sample_prospect: Prospect,
+) -> None:
+    low_conf = ProspectDossier(
+        dossier_id="d_low",
+        prospect_id=sample_prospect.id,
+        full_name="J",
+        current_title="V",
+        current_company="A",
+        confidence=0.3,  # below threshold
+    )
+    # Variants are non-soft-opener; confidence gate inside the model_validator
+    # drops them all, leaving variants=[] so the orchestrator emits the fallback.
+    raw = OutreachVariantList(
+        variants=[
+            OutreachVariant(
+                angle="trigger_event",
+                email_sequence=[
+                    EmailTouch(
+                        day=1,
+                        subject_line="hi",
+                        body="b",
+                        evidence_citations=[
+                            EvidenceCitation(
+                                claim="c",
+                                dossier_field="trigger_events[0]",
+                                source_url="https://news.example.com/acme",
+                            )
+                        ],
+                    )
+                ],
+                personalization_grade="high",
+            )
+        ]
+    )
+    seq = orch_mod._wrap_outreach_sequence(raw, sample_prospect, low_conf)
+    assert len(seq.variants) == 1
+    assert seq.variants[0].angle == "company_soft_opener"
+    assert seq.variants[0].personalization_grade == "fallback"
+
+
+# ---------------------------------------------------------------------------
+# _should_run
+# ---------------------------------------------------------------------------
+
+
+def test_should_run_true_when_stage_at_or_after_entry(stub_orch) -> None:
+    assert stub_orch._should_run(PipelineStage.QUALIFICATION, PipelineStage.PROSPECTING) is True
+    assert stub_orch._should_run(PipelineStage.PROSPECTING, PipelineStage.PROSPECTING) is True
+
+
+def test_should_run_false_when_stage_before_entry(stub_orch) -> None:
+    assert stub_orch._should_run(PipelineStage.PROSPECTING, PipelineStage.PROPOSAL) is False
+
+
+def test_should_run_false_when_stage_not_in_order_list(stub_orch) -> None:
+    """CLOSED_WON is not in _STAGE_ORDER; _should_run must return False."""
+    assert stub_orch._should_run(PipelineStage.CLOSED_WON, PipelineStage.PROSPECTING) is False
+
+
+# ---------------------------------------------------------------------------
+# _generate_outreach_with_critic
+# ---------------------------------------------------------------------------
+
+
+def _good_variant_list(source_url: str = "https://news.example.com/acme") -> OutreachVariantList:
+    return OutreachVariantList(
+        variants=[
+            OutreachVariant(
+                angle="trigger_event",
+                email_sequence=[
+                    EmailTouch(
+                        day=1,
+                        subject_line="s",
+                        body="b",
+                        evidence_citations=[
+                            EvidenceCitation(
+                                claim="c",
+                                dossier_field="trigger_events[0]",
+                                source_url=source_url,
+                            )
+                        ],
+                    )
+                ],
+                personalization_grade="high",
+            )
+        ]
+    )
+
+
+def test_generate_outreach_with_critic_outreach_raises_during_initial_emit(
+    stub_orch,
+    sample_prospect: Prospect,
+    sample_dossier: ProspectDossier,
+    sample_icp: IdealCustomerProfile,
+) -> None:
+    # Initial emit raises → exception propagates out of the helper.
+    stub_orch.outreach.generate_sequence.side_effect = RuntimeError("LLM down")
+    with pytest.raises(RuntimeError):
+        stub_orch._generate_outreach_with_critic(
+            sample_prospect, sample_dossier, "p", "v", "", "", None, sample_icp
+        )
+
+
+def test_generate_outreach_with_critic_keeps_original_when_refine_raises(
+    stub_orch,
+    sample_prospect: Prospect,
+    sample_dossier: ProspectDossier,
+    sample_icp: IdealCustomerProfile,
+) -> None:
+    """First emit succeeds, critic asks for revision, refine emit raises →
+    helper returns the original sequence instead of crashing the prospect."""
+    from sales_team.models import CriticViolation, OutreachCriticReport
+
+    initial = _good_variant_list()
+
+    # Side effect: first call returns initial, second raises.
+    call_count = {"n": 0}
+
+    def _outreach_side_effect(*a, **kw):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return initial
+        raise RuntimeError("refine boom")
+
+    stub_orch.outreach.generate_sequence.side_effect = _outreach_side_effect
+    stub_orch.outreach_critic.review.return_value = OutreachCriticReport(
+        status="FAIL",
+        approved=False,
+        violations=[
+            CriticViolation(
+                rule_id="outreach.day1.cta",
+                severity="must_fix",
+                description="no CTA",
+                suggested_fix="add one",
+            )
+        ],
+    )
+    sequence = stub_orch._generate_outreach_with_critic(
+        sample_prospect, sample_dossier, "p", "v", "", "", None, sample_icp
+    )
+    # Two outreach calls attempted (initial + refine), but the refine raised
+    # and the helper returned the original sequence.
+    assert call_count["n"] == 2
+    assert sequence.variants  # original wrapping survived
+
+
+# ---------------------------------------------------------------------------
+# load_dossiers_for_prospects
+# ---------------------------------------------------------------------------
+
+
+def test_load_dossiers_for_prospects_empty_when_no_ids(stub_orch) -> None:
+    p = Prospect(id="", company_name="Acme")
+    assert stub_orch.load_dossiers_for_prospects([p]) == {}
+
+
+def test_load_dossiers_for_prospects_returns_store_result(
+    monkeypatch: pytest.MonkeyPatch, stub_orch, sample_prospect, sample_dossier
+) -> None:
+    from sales_team import dossier_store as ds_mod
+
+    class _Store:
+        def get_dossiers_by_prospect_ids(self, ids):
+            return {sample_prospect.id: sample_dossier}
+
+    monkeypatch.setattr(ds_mod, "DossierStore", _Store)
+    out = stub_orch.load_dossiers_for_prospects([sample_prospect])
+    assert out[sample_prospect.id].dossier_id == sample_dossier.dossier_id
+
+
+def test_load_dossiers_for_prospects_returns_empty_on_store_failure(
+    monkeypatch: pytest.MonkeyPatch, stub_orch, sample_prospect
+) -> None:
+    from sales_team import dossier_store as ds_mod
+
+    class _BrokenStore:
+        def __init__(self):
+            raise RuntimeError("pg down")
+
+    monkeypatch.setattr(ds_mod, "DossierStore", _BrokenStore)
+    assert stub_orch.load_dossiers_for_prospects([sample_prospect]) == {}
+
+
+# ---------------------------------------------------------------------------
+# Full pipeline `run` — exhaustive shake-down with stubs
+# ---------------------------------------------------------------------------
+
+
+def _qualifier_body(action: str = "advance") -> QualificationScoreBody:
+    return QualificationScoreBody(
+        bant=BANTScore(budget=8, authority=9, need=7, timeline=8),
+        meddic=MEDDICScore(
+            metrics_identified=True,
+            economic_buyer_known=True,
+            decision_criteria_understood=True,
+            decision_process_mapped=True,
+            identify_pain=True,
+            champion_found=True,
+        ),
+        overall_score=0.8,
+        value_creation_level=3,
+        recommended_action=action,
+    )
+
+
+def _proposal_body() -> SalesProposalBody:
+    return SalesProposalBody(
+        executive_summary="...",
+        situation_analysis="...",
+        proposed_solution="...",
+        roi_model=ROIModel(
+            annual_cost_usd=25000.0,
+            estimated_annual_benefit_usd=70000.0,
+            payback_months=6.0,
+            roi_percentage=180.0,
+        ),
+    )
+
+
+def _closer_body() -> ClosingStrategyBody:
+    return ClosingStrategyBody(
+        recommended_close_technique=CloseType.SUMMARY, close_script="Shall we sign?"
+    )
+
+
+def _discovery_body() -> DiscoveryPlanBody:
+    return DiscoveryPlanBody(spin_questions=SPINQuestions(situation=["s"]))
+
+
+def _nurture_body() -> NurtureSequenceBody:
+    return NurtureSequenceBody(duration_days=30)
+
+
+def _coaching_report() -> PipelineCoachingReport:
+    return PipelineCoachingReport(prospects_reviewed=1, coaching_summary="OK")
+
+
+def _pass_outreach_report():
+    from sales_team.models import OutreachCriticReport
+
+    return OutreachCriticReport(status="PASS", approved=True, violations=[])
+
+
+def _pass_proposal_report():
+    from sales_team.models import ProposalCriticReport
+
+    return ProposalCriticReport(status="PASS", approved=True, violations=[])
+
+
+def test_run_full_pipeline_happy_path(
+    monkeypatch: pytest.MonkeyPatch, stub_orch, sample_icp, sample_prospect, sample_dossier
+) -> None:
+    # Stub out all I/O.
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    monkeypatch.setattr(orch_mod, "record_stage_outcome", lambda outcome: outcome)
+
+    # Provide a stub dossier store via load_dossiers_for_prospects override.
+    stub_orch.load_dossiers_for_prospects = MagicMock(
+        return_value={sample_prospect.id: sample_dossier}
+    )
+
+    # Prospector returns the same prospect.
+    stub_orch.prospector.prospect.return_value = ProspectList(prospects=[sample_prospect])
+    # Outreach: returns a good variant list and the critic approves.
+    stub_orch.outreach.generate_sequence.return_value = _good_variant_list()
+    stub_orch.outreach_critic.review.return_value = _pass_outreach_report()
+    # Qualifier: advance.
+    stub_orch.qualifier.qualify.return_value = _qualifier_body("advance")
+    # Discovery + Proposal + Closer + Coach.
+    stub_orch.discovery.prepare.return_value = _discovery_body()
+    stub_orch.proposal.write.return_value = _proposal_body()
+    stub_orch.proposal_critic.review.return_value = _pass_proposal_report()
+    stub_orch.closer.develop_strategy.return_value = _closer_body()
+    stub_orch.coach.review.return_value = _coaching_report()
+
+    request = SalesPipelineRequest(
+        product_name="ProductX",
+        value_proposition="Save 20% on outbound time",
+        icp=sample_icp,
+        entry_stage=PipelineStage.PROSPECTING,
+    )
+    progress: List[tuple[str, int]] = []
+    result = stub_orch.run(
+        request, job_id="job-happy", update_cb=lambda s, p: progress.append((s, p))
+    )
+    assert result.prospects[0].company_name == "Acme Corp"
+    assert len(result.outreach_sequences) == 1
+    assert len(result.qualified_leads) == 1
+    assert len(result.discovery_plans) == 1
+    assert len(result.proposals) == 1
+    assert len(result.closing_strategies) == 1
+    assert result.coaching_report is not None
+    # update_cb fires at every phase boundary.
+    assert any(stage == "completed" for stage, _ in progress)
+
+
+def test_run_uses_existing_prospects_when_provided(
+    monkeypatch: pytest.MonkeyPatch, stub_orch, sample_icp, sample_prospect
+) -> None:
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    monkeypatch.setattr(orch_mod, "record_stage_outcome", lambda outcome: outcome)
+    stub_orch.load_dossiers_for_prospects = MagicMock(return_value={})
+    stub_orch.qualifier.qualify.return_value = _qualifier_body("disqualify")
+    stub_orch.coach.review.return_value = _coaching_report()
+
+    request = SalesPipelineRequest(
+        product_name="P",
+        value_proposition="A long enough value prop string",
+        icp=sample_icp,
+        entry_stage=PipelineStage.PROSPECTING,
+        existing_prospects=[sample_prospect],
+    )
+    result = stub_orch.run(request, job_id="j-exist")
+    # Prospector never called because existing_prospects was supplied.
+    stub_orch.prospector.prospect.assert_not_called()
+    assert result.prospects == [sample_prospect]
+
+
+def test_run_returns_early_when_no_prospects(
+    monkeypatch: pytest.MonkeyPatch, stub_orch, sample_icp
+) -> None:
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    stub_orch.prospector.prospect.return_value = ProspectList(prospects=[])
+    request = SalesPipelineRequest(
+        product_name="P",
+        value_proposition="A valid 10-char value proposition",
+        icp=sample_icp,
+        entry_stage=PipelineStage.PROSPECTING,
+    )
+    result = stub_orch.run(request, job_id="j-empty")
+    assert "No prospects" in result.summary
+    # Downstream stages were not touched.
+    stub_orch.outreach.generate_sequence.assert_not_called()
+
+
+def test_run_uses_existing_prospects_when_entry_after_prospecting(
+    monkeypatch: pytest.MonkeyPatch, stub_orch, sample_icp, sample_prospect
+) -> None:
+    """entry_stage != PROSPECTING goes into the else branch that uses
+    request.existing_prospects directly."""
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    monkeypatch.setattr(orch_mod, "record_stage_outcome", lambda outcome: outcome)
+    stub_orch.load_dossiers_for_prospects = MagicMock(return_value={})
+    stub_orch.qualifier.qualify.return_value = _qualifier_body("disqualify")
+    stub_orch.coach.review.return_value = _coaching_report()
+
+    request = SalesPipelineRequest(
+        product_name="P",
+        value_proposition="A valid 10-char value proposition",
+        icp=sample_icp,
+        entry_stage=PipelineStage.QUALIFICATION,
+        existing_prospects=[sample_prospect],
+    )
+    result = stub_orch.run(request, job_id="j-qual-entry")
+    assert result.prospects == [sample_prospect]
+
+
+def test_run_outreach_failure_caught_per_prospect(
+    monkeypatch: pytest.MonkeyPatch, stub_orch, sample_icp, sample_prospect, sample_dossier
+) -> None:
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    monkeypatch.setattr(orch_mod, "record_stage_outcome", lambda outcome: outcome)
+    stub_orch.load_dossiers_for_prospects = MagicMock(
+        return_value={sample_prospect.id: sample_dossier}
+    )
+    stub_orch.prospector.prospect.return_value = ProspectList(prospects=[sample_prospect])
+    stub_orch.outreach.generate_sequence.side_effect = RuntimeError("boom")
+    stub_orch.qualifier.qualify.return_value = _qualifier_body("disqualify")
+    stub_orch.coach.review.return_value = _coaching_report()
+
+    request = SalesPipelineRequest(
+        product_name="P",
+        value_proposition="A valid long value proposition",
+        icp=sample_icp,
+        entry_stage=PipelineStage.PROSPECTING,
+    )
+    result = stub_orch.run(request, job_id="j-outreach-fail")
+    # No sequence emitted, but pipeline continued past outreach.
+    assert result.outreach_sequences == []
+
+
+def test_run_skips_outreach_when_dossier_missing(
+    monkeypatch: pytest.MonkeyPatch, stub_orch, sample_icp, sample_prospect
+) -> None:
+    """When the dossier map doesn't contain the prospect, the outreach loop
+    skips it via the dossier_missing branch."""
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    monkeypatch.setattr(orch_mod, "record_stage_outcome", lambda outcome: outcome)
+    stub_orch.load_dossiers_for_prospects = MagicMock(return_value={})  # missing
+    stub_orch.prospector.prospect.return_value = ProspectList(prospects=[sample_prospect])
+    stub_orch.qualifier.qualify.return_value = _qualifier_body("disqualify")
+    stub_orch.coach.review.return_value = _coaching_report()
+
+    request = SalesPipelineRequest(
+        product_name="P",
+        value_proposition="A valid long value proposition",
+        icp=sample_icp,
+        entry_stage=PipelineStage.PROSPECTING,
+    )
+    result = stub_orch.run(request, job_id="j-skip-dossier")
+    assert result.outreach_sequences == []
+
+
+def test_run_qualifier_routes_nurture_and_advance(
+    monkeypatch: pytest.MonkeyPatch, stub_orch, sample_icp
+) -> None:
+    """When qualification produces mixed actions, advance leads go to
+    discovery/proposal/close while nurture leads land in nurture_sequences."""
+    p_advance = Prospect(id="prs_a", company_name="Acme")
+    p_nurture = Prospect(id="prs_b", company_name="Beta")
+    p_disq = Prospect(id="prs_c", company_name="Gamma")
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    monkeypatch.setattr(orch_mod, "record_stage_outcome", lambda outcome: outcome)
+    stub_orch.load_dossiers_for_prospects = MagicMock(return_value={})
+    stub_orch.prospector.prospect.return_value = ProspectList(
+        prospects=[p_advance, p_nurture, p_disq]
+    )
+
+    # Return one body per prospect, in order.
+    bodies = iter(
+        [_qualifier_body("advance"), _qualifier_body("nurture"), _qualifier_body("disqualify")]
+    )
+    stub_orch.qualifier.qualify.side_effect = lambda *a, **kw: next(bodies)
+    stub_orch.nurture.build_sequence.return_value = _nurture_body()
+    stub_orch.discovery.prepare.return_value = _discovery_body()
+    stub_orch.proposal.write.return_value = _proposal_body()
+    stub_orch.proposal_critic.review.return_value = _pass_proposal_report()
+    stub_orch.closer.develop_strategy.return_value = _closer_body()
+    stub_orch.coach.review.return_value = _coaching_report()
+
+    request = SalesPipelineRequest(
+        product_name="P",
+        value_proposition="A valid long value proposition",
+        icp=sample_icp,
+        entry_stage=PipelineStage.PROSPECTING,
+    )
+    result = stub_orch.run(request, job_id="j-routes")
+    # Discovery and proposal got the advance-only prospect.
+    assert len(result.discovery_plans) == 1
+    assert result.discovery_plans[0].prospect.company_name == "Acme"
+    # Nurture path picks up the nurture lead (not the disqualified one).
+    assert len(result.nurture_sequences) == 1
+    assert result.nurture_sequences[0].prospect.company_name == "Beta"
+
+
+def test_run_qualifier_failure_branch(
+    monkeypatch: pytest.MonkeyPatch, stub_orch, sample_icp, sample_prospect
+) -> None:
+    """Qualifier raises → per-prospect except branch fires and continues."""
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    monkeypatch.setattr(orch_mod, "record_stage_outcome", lambda outcome: outcome)
+    stub_orch.load_dossiers_for_prospects = MagicMock(return_value={})
+    stub_orch.prospector.prospect.return_value = ProspectList(prospects=[sample_prospect])
+    stub_orch.qualifier.qualify.side_effect = RuntimeError("qual fail")
+    # When qualifier fails, qualified is empty and all prospects advance, so
+    # discovery / proposal / close run. Make them all raise so the pipeline
+    # cleanly drops into the coach stage with empty downstream collections.
+    stub_orch.discovery.prepare.side_effect = RuntimeError("d fail")
+    stub_orch.proposal.write.side_effect = RuntimeError("p fail")
+    stub_orch.closer.develop_strategy.side_effect = RuntimeError("c fail")
+    stub_orch.coach.review.return_value = _coaching_report()
+
+    request = SalesPipelineRequest(
+        product_name="P",
+        value_proposition="A valid long value proposition",
+        icp=sample_icp,
+        entry_stage=PipelineStage.PROSPECTING,
+    )
+    result = stub_orch.run(request, job_id="j-qual-fail")
+    assert result.qualified_leads == []
+
+
+def test_run_propagates_insights_block_when_present(
+    monkeypatch: pytest.MonkeyPatch, stub_orch, sample_icp, sample_prospect
+) -> None:
+    insights = LearningInsights(
+        total_outcomes_analyzed=5,
+        win_rate=0.4,
+        insights_version=7,
+        generated_at="2026-05-21T00:00:00+00:00",
+    )
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: insights)
+    monkeypatch.setattr(orch_mod, "record_stage_outcome", lambda outcome: outcome)
+    stub_orch.load_dossiers_for_prospects = MagicMock(return_value={})
+    stub_orch.prospector.prospect.return_value = ProspectList(prospects=[sample_prospect])
+    stub_orch.qualifier.qualify.return_value = _qualifier_body("disqualify")
+    stub_orch.coach.review.return_value = _coaching_report()
+
+    request = SalesPipelineRequest(
+        product_name="P",
+        value_proposition="A valid long value proposition",
+        icp=sample_icp,
+        entry_stage=PipelineStage.PROSPECTING,
+    )
+    result = stub_orch.run(request, job_id="j-insights")
+    assert "learning insights v7 applied" in result.summary
+
+
+def test_run_nurture_failure_branch(monkeypatch: pytest.MonkeyPatch, stub_orch, sample_icp) -> None:
+    """Inside the nurture stage, build_sequence raising must be swallowed."""
+    p_nurture = Prospect(id="prs_n", company_name="N")
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    monkeypatch.setattr(orch_mod, "record_stage_outcome", lambda outcome: outcome)
+    stub_orch.load_dossiers_for_prospects = MagicMock(return_value={})
+    stub_orch.prospector.prospect.return_value = ProspectList(prospects=[p_nurture])
+    stub_orch.qualifier.qualify.return_value = _qualifier_body("nurture")
+    stub_orch.nurture.build_sequence.side_effect = RuntimeError("nurture boom")
+    stub_orch.coach.review.return_value = _coaching_report()
+
+    request = SalesPipelineRequest(
+        product_name="P",
+        value_proposition="A valid long value proposition",
+        icp=sample_icp,
+        entry_stage=PipelineStage.PROSPECTING,
+    )
+    result = stub_orch.run(request, job_id="j-nurture-fail")
+    assert result.nurture_sequences == []
+
+
+def test_run_discovery_and_proposal_and_close_failure_branches(
+    monkeypatch: pytest.MonkeyPatch, stub_orch, sample_icp, sample_prospect, sample_dossier
+) -> None:
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    monkeypatch.setattr(orch_mod, "record_stage_outcome", lambda outcome: outcome)
+    stub_orch.load_dossiers_for_prospects = MagicMock(
+        return_value={sample_prospect.id: sample_dossier}
+    )
+    stub_orch.prospector.prospect.return_value = ProspectList(prospects=[sample_prospect])
+    stub_orch.outreach.generate_sequence.return_value = _good_variant_list()
+    stub_orch.outreach_critic.review.return_value = _pass_outreach_report()
+    stub_orch.qualifier.qualify.return_value = _qualifier_body("advance")
+    stub_orch.discovery.prepare.side_effect = RuntimeError("discovery boom")
+    stub_orch.proposal.write.side_effect = RuntimeError("proposal boom")
+    stub_orch.closer.develop_strategy.side_effect = RuntimeError("close boom")
+    stub_orch.coach.review.side_effect = RuntimeError("coach boom")
+
+    request = SalesPipelineRequest(
+        product_name="P",
+        value_proposition="A valid long value proposition",
+        icp=sample_icp,
+        entry_stage=PipelineStage.PROSPECTING,
+    )
+    result = stub_orch.run(request, job_id="j-failures")
+    assert result.discovery_plans == []
+    assert result.proposals == []
+    assert result.closing_strategies == []
+    assert result.coaching_report is None
+
+
+def test_record_prospecting_outcomes_swallows_per_prospect_errors(
+    monkeypatch: pytest.MonkeyPatch, stub_orch, sample_prospect
+) -> None:
+    """If record_stage_outcome raises, the loop must continue not crash."""
+
+    def _explode(outcome):
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(orch_mod, "record_stage_outcome", _explode)
+    # Just call the helper directly — no assertion needed beyond "doesn't raise".
+    stub_orch._record_prospecting_outcomes([sample_prospect], "j-err")
+
+
+# ---------------------------------------------------------------------------
+# Single-stage convenience methods
+# ---------------------------------------------------------------------------
+
+
+def test_prospect_only_returns_list(stub_orch, sample_icp, sample_prospect) -> None:
+    stub_orch.prospector.prospect.return_value = ProspectList(prospects=[sample_prospect])
+    out = stub_orch.prospect_only(sample_icp, "P", "V", 5, "")
+    assert out == [sample_prospect]
+
+
+def test_prospect_only_returns_empty_on_failure(stub_orch, sample_icp) -> None:
+    stub_orch.prospector.prospect.side_effect = RuntimeError("down")
+    assert stub_orch.prospect_only(sample_icp, "P", "V", 5, "") == []
+
+
+def test_outreach_only_skips_prospects_without_dossier(
+    monkeypatch: pytest.MonkeyPatch, stub_orch, sample_prospect, sample_dossier
+) -> None:
+    p_missing = Prospect(id="prs_m", company_name="X")
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    stub_orch.outreach.generate_sequence.return_value = _good_variant_list()
+    seqs = stub_orch.outreach_only(
+        [sample_prospect, p_missing],
+        {sample_prospect.id: sample_dossier},
+        "P",
+        "V",
+        [],
+        "",
+    )
+    assert len(seqs) == 1
+
+
+def test_outreach_only_catches_outreach_exception(
+    monkeypatch: pytest.MonkeyPatch, stub_orch, sample_prospect, sample_dossier
+) -> None:
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    stub_orch.outreach.generate_sequence.side_effect = RuntimeError("boom")
+    seqs = stub_orch.outreach_only(
+        [sample_prospect], {sample_prospect.id: sample_dossier}, "P", "V", ["case"], ""
+    )
+    assert seqs == []
+
+
+def test_qualify_only_returns_score_or_none(stub_orch, sample_prospect, monkeypatch) -> None:
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    stub_orch.qualifier.qualify.return_value = _qualifier_body("advance")
+    score = stub_orch.qualify_only(sample_prospect, "P", "V", "")
+    assert score is not None
+    assert score.recommended_action == "advance"
+
+
+def test_qualify_only_returns_none_on_exception(stub_orch, sample_prospect, monkeypatch) -> None:
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    stub_orch.qualifier.qualify.side_effect = RuntimeError("down")
+    assert stub_orch.qualify_only(sample_prospect, "P", "V", "") is None
+
+
+def test_nurture_only_catches_per_prospect_exception(
+    monkeypatch: pytest.MonkeyPatch, stub_orch, sample_prospect
+) -> None:
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    # First call works, second raises.
+    bodies = iter([_nurture_body()])
+
+    def _side(*a, **kw):
+        try:
+            return next(bodies)
+        except StopIteration as exc:
+            raise RuntimeError("boom") from exc
+
+    stub_orch.nurture.build_sequence.side_effect = _side
+    other = Prospect(id="prs_other", company_name="B")
+    out = stub_orch.nurture_only([sample_prospect, other], "P", "V", 30)
+    assert len(out) == 1
+
+
+def test_propose_only_returns_none_on_exception(
+    monkeypatch: pytest.MonkeyPatch, stub_orch, sample_prospect
+) -> None:
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    stub_orch.load_dossiers_for_prospects = MagicMock(return_value={})
+    stub_orch.proposal.write.side_effect = RuntimeError("boom")
+    req = ProposalRequest(
+        prospect=sample_prospect,
+        product_name="P",
+        value_proposition="V",
+        annual_cost_usd=25000.0,
+    )
+    assert stub_orch.propose_only(req) is None
+
+
+def test_propose_only_returns_proposal_on_success(
+    monkeypatch: pytest.MonkeyPatch, stub_orch, sample_prospect
+) -> None:
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    stub_orch.load_dossiers_for_prospects = MagicMock(return_value={})
+    stub_orch.proposal.write.return_value = _proposal_body()
+    stub_orch.proposal_critic.review.return_value = _pass_proposal_report()
+    req = ProposalRequest(
+        prospect=sample_prospect,
+        product_name="P",
+        value_proposition="V",
+        annual_cost_usd=25000.0,
+    )
+    proposal = stub_orch.propose_only(req)
+    assert proposal is not None
+    assert proposal.roi_model.payback_months == 6.0
+
+
+def test_coach_only_returns_report_or_none(
+    monkeypatch: pytest.MonkeyPatch, stub_orch, sample_prospect
+) -> None:
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    stub_orch.coach.review.return_value = _coaching_report()
+    out = stub_orch.coach_only([sample_prospect], "P", "")
+    assert out is not None and out.prospects_reviewed == 1
+
+
+def test_coach_only_returns_none_on_exception(
+    monkeypatch: pytest.MonkeyPatch, stub_orch, sample_prospect
+) -> None:
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    stub_orch.coach.review.side_effect = RuntimeError("down")
+    assert stub_orch.coach_only([sample_prospect], "P", "") is None
+
+
+# ---------------------------------------------------------------------------
+# deep_research_only — the largest method
+# ---------------------------------------------------------------------------
+
+
+def _deep_request(target: int = 10) -> DeepResearchRequest:
+    return DeepResearchRequest(
+        product_name="ProductX",
+        value_proposition="Save 20% on outbound time",
+        icp=IdealCustomerProfile(industry=["SaaS"]),
+        target_prospects=target,
+        max_per_company=2,
+        company_context="",
+    )
+
+
+def test_deep_research_returns_empty_when_prospector_fails(
+    monkeypatch: pytest.MonkeyPatch, stub_orch
+) -> None:
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    stub_orch.prospector.prospect_companies.side_effect = RuntimeError("down")
+    result = stub_orch.deep_research_only(_deep_request(), persist=False)
+    assert result.total_prospects == 0
+    assert "No companies returned" in result.notes
+
+
+def test_deep_research_returns_empty_when_no_companies(
+    monkeypatch: pytest.MonkeyPatch, stub_orch
+) -> None:
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    stub_orch.prospector.prospect_companies.return_value = ProspectList(prospects=[])
+    result = stub_orch.deep_research_only(_deep_request(), persist=False)
+    assert result.total_prospects == 0
+    assert "No companies returned" in result.notes
+
+
+def test_deep_research_returns_empty_when_no_decision_makers(
+    monkeypatch: pytest.MonkeyPatch, stub_orch
+) -> None:
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    stub_orch.prospector.prospect_companies.return_value = ProspectList(
+        prospects=[Prospect(company_name="Acme")]
+    )
+    # Mapper returns an empty contact list for every company.
+    stub_orch.decision_maker_mapper.map_contacts.return_value = DecisionMakerList(contacts=[])
+    result = stub_orch.deep_research_only(_deep_request(), persist=False)
+    assert result.total_prospects == 0
+    assert "No decision-makers" in result.notes
+
+
+def test_deep_research_swallows_mapper_exceptions(
+    monkeypatch: pytest.MonkeyPatch, stub_orch
+) -> None:
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    stub_orch.prospector.prospect_companies.return_value = ProspectList(
+        prospects=[Prospect(company_name="Acme"), Prospect(company_name="Beta")]
+    )
+
+    def _mixed_mapper(company_json, *a, **kw):
+        if "Acme" in company_json:
+            return DecisionMakerList(
+                contacts=[DecisionMakerEntry(contact_name="J", confidence=0.9)]
+            )
+        raise RuntimeError("mapper down")
+
+    stub_orch.decision_maker_mapper.map_contacts.side_effect = _mixed_mapper
+    stub_orch.dossier_builder.build.return_value = ProspectDossier(
+        prospect_id="ignored",
+        full_name="J",
+        current_title="VP",
+        current_company="Acme",
+        sources=["https://x"],
+    )
+    result = stub_orch.deep_research_only(_deep_request(target=10), persist=False)
+    assert result.total_prospects >= 1
+
+
+def test_deep_research_swallows_dossier_builder_exceptions(
+    monkeypatch: pytest.MonkeyPatch, stub_orch
+) -> None:
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    stub_orch.prospector.prospect_companies.return_value = ProspectList(
+        prospects=[Prospect(company_name="Acme")]
+    )
+    stub_orch.decision_maker_mapper.map_contacts.return_value = DecisionMakerList(
+        contacts=[DecisionMakerEntry(contact_name="J", confidence=0.9)]
+    )
+    stub_orch.dossier_builder.build.side_effect = RuntimeError("builder boom")
+    result = stub_orch.deep_research_only(_deep_request(target=10), persist=False)
+    # No dossier produced → no entries.
+    assert result.total_prospects == 0
+    assert "No dossier produced" in result.notes
+
+
+def test_deep_research_persists_via_store(monkeypatch: pytest.MonkeyPatch, stub_orch) -> None:
+    """With persist=True, the store's save_dossier and save_prospect_list are called."""
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    stub_orch.prospector.prospect_companies.return_value = ProspectList(
+        prospects=[Prospect(company_name="Acme")]
+    )
+    stub_orch.decision_maker_mapper.map_contacts.return_value = DecisionMakerList(
+        contacts=[DecisionMakerEntry(contact_name="J", confidence=0.9)]
+    )
+    stub_orch.dossier_builder.build.return_value = ProspectDossier(
+        prospect_id="ignored",
+        full_name="J",
+        current_title="VP",
+        current_company="Acme",
+    )
+
+    saved_dossiers: list[Any] = []
+    saved_lists: list[Any] = []
+    from sales_team import dossier_store as ds_mod
+
+    class _Store:
+        def save_dossier(self, dossier):
+            saved_dossiers.append(dossier)
+            if not dossier.dossier_id:
+                dossier.dossier_id = "dsr_persisted"
+            return dossier
+
+        def save_prospect_list(self, result):
+            saved_lists.append(result)
+            if not result.list_id:
+                result.list_id = "plst_persisted"
+            return result
+
+    monkeypatch.setattr(ds_mod, "DossierStore", _Store)
+    result = stub_orch.deep_research_only(_deep_request(target=10), persist=True)
+    assert saved_dossiers
+    assert saved_lists
+    assert result.list_id == "plst_persisted"
+
+
+def test_deep_research_store_unavailable_branch(monkeypatch: pytest.MonkeyPatch, stub_orch) -> None:
+    """If DossierStore construction raises, persist=True still returns a result."""
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    stub_orch.prospector.prospect_companies.return_value = ProspectList(
+        prospects=[Prospect(company_name="Acme")]
+    )
+    stub_orch.decision_maker_mapper.map_contacts.return_value = DecisionMakerList(
+        contacts=[DecisionMakerEntry(contact_name="J", confidence=0.9)]
+    )
+    stub_orch.dossier_builder.build.return_value = ProspectDossier(
+        prospect_id="ignored",
+        full_name="J",
+        current_title="VP",
+        current_company="Acme",
+    )
+    from sales_team import dossier_store as ds_mod
+
+    class _Broken:
+        def __init__(self):
+            raise RuntimeError("no pg")
+
+    monkeypatch.setattr(ds_mod, "DossierStore", _Broken)
+    result = stub_orch.deep_research_only(_deep_request(target=10), persist=True)
+    # We still get entries — just not persisted.
+    assert result.total_prospects >= 1
+
+
+def test_deep_research_store_save_dossier_failure_continues(
+    monkeypatch: pytest.MonkeyPatch, stub_orch
+) -> None:
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    stub_orch.prospector.prospect_companies.return_value = ProspectList(
+        prospects=[Prospect(company_name="Acme")]
+    )
+    stub_orch.decision_maker_mapper.map_contacts.return_value = DecisionMakerList(
+        contacts=[DecisionMakerEntry(contact_name="J", confidence=0.9)]
+    )
+    stub_orch.dossier_builder.build.return_value = ProspectDossier(
+        prospect_id="ignored",
+        full_name="J",
+        current_title="VP",
+        current_company="Acme",
+    )
+    from sales_team import dossier_store as ds_mod
+
+    class _PartialBroken:
+        def save_dossier(self, d):
+            raise RuntimeError("save fail")
+
+        def save_prospect_list(self, r):
+            raise RuntimeError("list save fail")
+
+    monkeypatch.setattr(ds_mod, "DossierStore", _PartialBroken)
+    result = stub_orch.deep_research_only(_deep_request(target=10), persist=True)
+    # Even though saves fail, we still get entries with auto-assigned dossier_ids.
+    assert result.total_prospects >= 1
+
+
+def test_deep_research_logs_shortfall_when_fewer_than_target(
+    monkeypatch: pytest.MonkeyPatch, stub_orch
+) -> None:
+    """If the per-company cap leaves fewer prospects than target, notes flags it."""
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    stub_orch.prospector.prospect_companies.return_value = ProspectList(
+        prospects=[Prospect(company_name="Acme")]
+    )
+    stub_orch.decision_maker_mapper.map_contacts.return_value = DecisionMakerList(
+        contacts=[DecisionMakerEntry(contact_name="J", confidence=0.9)]
+    )
+    stub_orch.dossier_builder.build.return_value = ProspectDossier(
+        prospect_id="ignored",
+        full_name="J",
+        current_title="VP",
+        current_company="Acme",
+    )
+    # Target 10 but only one company → only one prospect possible.
+    result = stub_orch.deep_research_only(_deep_request(target=10), persist=False)
+    assert "Only" in result.notes and "qualifying" in result.notes
+
+
+def test_deep_research_uses_custom_url_builder(monkeypatch: pytest.MonkeyPatch, stub_orch) -> None:
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    stub_orch.prospector.prospect_companies.return_value = ProspectList(
+        prospects=[Prospect(company_name="Acme")]
+    )
+    stub_orch.decision_maker_mapper.map_contacts.return_value = DecisionMakerList(
+        contacts=[DecisionMakerEntry(contact_name="J", confidence=0.9)]
+    )
+    stub_orch.dossier_builder.build.return_value = ProspectDossier(
+        prospect_id="ignored",
+        full_name="J",
+        current_title="VP",
+        current_company="Acme",
+    )
+
+    def _custom_url(dossier_id: str) -> str:
+        return f"https://example.com/d/{dossier_id}"
+
+    result = stub_orch.deep_research_only(
+        _deep_request(target=10), persist=False, dossier_url_builder=_custom_url
+    )
+    if result.entries:
+        assert result.entries[0].dossier_url.startswith("https://example.com/d/")
+
+
+def test_deep_research_default_url_builder_used_when_none_provided(
+    monkeypatch: pytest.MonkeyPatch, stub_orch
+) -> None:
+    """The else branch that defines the default url builder must execute."""
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    stub_orch.prospector.prospect_companies.return_value = ProspectList(
+        prospects=[Prospect(company_name="Acme")]
+    )
+    stub_orch.decision_maker_mapper.map_contacts.return_value = DecisionMakerList(
+        contacts=[DecisionMakerEntry(contact_name="J", confidence=0.9)]
+    )
+    stub_orch.dossier_builder.build.return_value = ProspectDossier(
+        prospect_id="ignored",
+        full_name="J",
+        current_title="VP",
+        current_company="Acme",
+    )
+    result = stub_orch.deep_research_only(_deep_request(target=10), persist=False)
+    if result.entries:
+        assert result.entries[0].dossier_url.startswith("/api/sales/dossiers/")
+
+
+def test_deep_research_propagates_dossier_field_backfill(
+    monkeypatch: pytest.MonkeyPatch, stub_orch
+) -> None:
+    """The orchestrator backfills full_name, current_title, current_company,
+    and linkedin_url on the dossier from the prospect when the dossier model
+    left them blank-ish. We exercise this branch by returning a sparse dossier.
+    """
+    monkeypatch.setattr(orch_mod, "load_current_insights", lambda: None)
+    company = Prospect(company_name="Acme", website="https://acme")
+    stub_orch.prospector.prospect_companies.return_value = ProspectList(prospects=[company])
+    stub_orch.decision_maker_mapper.map_contacts.return_value = DecisionMakerList(
+        contacts=[
+            DecisionMakerEntry(
+                contact_name="Jane Smith",
+                contact_title="VP Sales",
+                linkedin_url="https://linkedin.com/in/jane",
+                confidence=0.9,
+            )
+        ]
+    )
+    # Build returns a dossier whose backfill-eligible fields are empty.
+    stub_orch.dossier_builder.build.return_value = ProspectDossier(
+        prospect_id="overwrite-me",
+        full_name="",
+        current_title="",
+        current_company="",
+    )
+    result = stub_orch.deep_research_only(_deep_request(target=10), persist=False)
+    # The orchestrator must have populated those fields when building entries.
+    assert result.total_prospects >= 1

--- a/backend/agents/sales_team/tests/test_outcome_store.py
+++ b/backend/agents/sales_team/tests/test_outcome_store.py
@@ -1,0 +1,271 @@
+"""Tests for ``sales_team.outcome_store``.
+
+The store persists ``StageOutcome`` and ``DealOutcome`` records as JSON
+files plus a single ``LearningInsights`` snapshot. The module reads the
+cache root at import time from ``AGENT_CACHE_DIR``, so each test reaches
+into the module-level path constants and points them at a tmpdir.
+
+These tests cover:
+
+  * write/read round-trip for both outcome types,
+  * id + timestamp assignment when caller leaves them empty,
+  * outcome_counts before/after writes,
+  * insights save/load round-trip,
+  * defensive branches: corrupt JSON, missing directory, missing file.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sales_team import outcome_store
+from sales_team.models import (
+    DealOutcome,
+    DealResult,
+    LearningInsights,
+    OutcomeResult,
+    PipelineStage,
+    StageOutcome,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """Point the module-level paths at an empty per-test tmpdir."""
+    cache_root = tmp_path / "sales_team" / "outcomes"
+    insights = tmp_path / "sales_team" / "insights" / "current.json"
+    monkeypatch.setattr(outcome_store, "_CACHE_ROOT", cache_root)
+    monkeypatch.setattr(outcome_store, "_INSIGHTS_PATH", insights)
+    return cache_root, insights
+
+
+# ---------------------------------------------------------------------------
+# Stage outcomes
+# ---------------------------------------------------------------------------
+
+
+def test_record_stage_outcome_assigns_id_and_timestamp_and_persists(
+    _isolate_store,
+) -> None:
+    cache_root, _ = _isolate_store
+    stage = StageOutcome(
+        company_name="Acme Corp",
+        stage=PipelineStage.OUTREACH,
+        outcome=OutcomeResult.CONVERTED,
+    )
+    saved = outcome_store.record_stage_outcome(stage)
+
+    assert saved.outcome_id, "outcome_id should be assigned by the store"
+    assert saved.recorded_at, "recorded_at should be set by the store"
+    expected_file = cache_root / "stage" / f"{saved.outcome_id}.json"
+    assert expected_file.exists()
+
+
+def test_record_stage_outcome_keeps_caller_provided_id_and_timestamp() -> None:
+    stage = StageOutcome(
+        outcome_id="stage-explicit-1",
+        recorded_at="2026-05-21T00:00:00+00:00",
+        company_name="Acme Corp",
+        stage=PipelineStage.OUTREACH,
+        outcome=OutcomeResult.CONVERTED,
+    )
+    saved = outcome_store.record_stage_outcome(stage)
+    assert saved.outcome_id == "stage-explicit-1"
+    assert saved.recorded_at == "2026-05-21T00:00:00+00:00"
+
+
+def test_load_stage_outcomes_returns_empty_when_dir_missing(_isolate_store) -> None:
+    # Nothing has been written yet — the stage subdir doesn't exist.
+    assert outcome_store.load_stage_outcomes() == []
+
+
+def test_load_stage_outcomes_returns_recorded_entries() -> None:
+    a = outcome_store.record_stage_outcome(
+        StageOutcome(
+            company_name="Acme",
+            stage=PipelineStage.OUTREACH,
+            outcome=OutcomeResult.CONVERTED,
+        )
+    )
+    b = outcome_store.record_stage_outcome(
+        StageOutcome(
+            company_name="Beta",
+            stage=PipelineStage.QUALIFICATION,
+            outcome=OutcomeResult.STALLED,
+        )
+    )
+    loaded = outcome_store.load_stage_outcomes()
+    ids = {o.outcome_id for o in loaded}
+    assert {a.outcome_id, b.outcome_id} <= ids
+
+
+def test_load_stage_outcomes_respects_limit() -> None:
+    for i in range(5):
+        outcome_store.record_stage_outcome(
+            StageOutcome(
+                company_name=f"Acme {i}",
+                stage=PipelineStage.OUTREACH,
+                outcome=OutcomeResult.CONVERTED,
+            )
+        )
+    loaded = outcome_store.load_stage_outcomes(limit=2)
+    assert len(loaded) == 2
+
+
+def test_load_stage_outcomes_skips_corrupt_files(_isolate_store) -> None:
+    cache_root, _ = _isolate_store
+    # Persist a real outcome to set up the directory.
+    saved = outcome_store.record_stage_outcome(
+        StageOutcome(
+            company_name="Acme",
+            stage=PipelineStage.OUTREACH,
+            outcome=OutcomeResult.CONVERTED,
+        )
+    )
+    # Drop a malformed JSON file alongside it.
+    (cache_root / "stage" / "bad.json").write_text("{ NOT JSON", encoding="utf-8")
+    # And a JSON file that doesn't match the StageOutcome schema.
+    (cache_root / "stage" / "schema-bad.json").write_text('{"foo": "bar"}', encoding="utf-8")
+
+    loaded = outcome_store.load_stage_outcomes()
+    # Real entry survives; corrupt ones are dropped with a warning, not raised.
+    assert any(o.outcome_id == saved.outcome_id for o in loaded)
+
+
+# ---------------------------------------------------------------------------
+# Deal outcomes
+# ---------------------------------------------------------------------------
+
+
+def test_record_deal_outcome_round_trip(_isolate_store) -> None:
+    cache_root, _ = _isolate_store
+    deal = DealOutcome(
+        company_name="Acme",
+        final_stage_reached=PipelineStage.CLOSED_WON,
+        result=DealResult.WON,
+    )
+    saved = outcome_store.record_deal_outcome(deal)
+    assert saved.outcome_id
+    assert (cache_root / "deal" / f"{saved.outcome_id}.json").exists()
+
+    loaded = outcome_store.load_deal_outcomes()
+    assert any(o.outcome_id == saved.outcome_id for o in loaded)
+
+
+def test_load_deal_outcomes_returns_empty_when_dir_missing(_isolate_store) -> None:
+    assert outcome_store.load_deal_outcomes() == []
+
+
+def test_load_deal_outcomes_skips_corrupt_files(_isolate_store) -> None:
+    cache_root, _ = _isolate_store
+    saved = outcome_store.record_deal_outcome(
+        DealOutcome(
+            company_name="Acme",
+            final_stage_reached=PipelineStage.CLOSED_WON,
+            result=DealResult.WON,
+        )
+    )
+    (cache_root / "deal" / "bad.json").write_text("not-json", encoding="utf-8")
+    (cache_root / "deal" / "schema-bad.json").write_text('{"foo": 1}', encoding="utf-8")
+    loaded = outcome_store.load_deal_outcomes()
+    assert any(o.outcome_id == saved.outcome_id for o in loaded)
+
+
+def test_load_deal_outcomes_respects_limit() -> None:
+    for i in range(3):
+        outcome_store.record_deal_outcome(
+            DealOutcome(
+                company_name=f"C{i}",
+                final_stage_reached=PipelineStage.CLOSED_WON,
+                result=DealResult.WON,
+            )
+        )
+    assert len(outcome_store.load_deal_outcomes(limit=1)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Insights round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_save_and_load_insights_round_trip(_isolate_store) -> None:
+    _, insights_path = _isolate_store
+    assert outcome_store.load_current_insights() is None  # not yet generated
+
+    insights = LearningInsights(
+        total_outcomes_analyzed=3,
+        win_rate=0.5,
+        winning_patterns=["multi-thread"],
+        insights_version=1,
+        generated_at="2026-05-21T00:00:00+00:00",
+    )
+    outcome_store.save_insights(insights)
+    assert insights_path.exists()
+
+    loaded = outcome_store.load_current_insights()
+    assert loaded is not None
+    assert loaded.total_outcomes_analyzed == 3
+    assert loaded.win_rate == 0.5
+    assert loaded.winning_patterns == ["multi-thread"]
+
+
+def test_load_current_insights_returns_none_on_unparseable_file(_isolate_store) -> None:
+    _, insights_path = _isolate_store
+    insights_path.parent.mkdir(parents=True, exist_ok=True)
+    insights_path.write_text("garbage{", encoding="utf-8")
+    assert outcome_store.load_current_insights() is None
+
+
+def test_load_current_insights_returns_none_on_schema_mismatch(_isolate_store) -> None:
+    _, insights_path = _isolate_store
+    insights_path.parent.mkdir(parents=True, exist_ok=True)
+    # Valid JSON but wrong shape — win_rate range violation.
+    insights_path.write_text('{"win_rate": 2.0}', encoding="utf-8")
+    assert outcome_store.load_current_insights() is None
+
+
+# ---------------------------------------------------------------------------
+# outcome_counts
+# ---------------------------------------------------------------------------
+
+
+def test_outcome_counts_when_nothing_written(_isolate_store) -> None:
+    counts = outcome_store.outcome_counts()
+    assert counts == {"stage_outcomes": 0, "deal_outcomes": 0, "has_insights": False}
+
+
+def test_outcome_counts_after_writes(_isolate_store) -> None:
+    outcome_store.record_stage_outcome(
+        StageOutcome(
+            company_name="A",
+            stage=PipelineStage.OUTREACH,
+            outcome=OutcomeResult.CONVERTED,
+        )
+    )
+    outcome_store.record_deal_outcome(
+        DealOutcome(
+            company_name="A",
+            final_stage_reached=PipelineStage.CLOSED_WON,
+            result=DealResult.WON,
+        )
+    )
+    outcome_store.save_insights(LearningInsights(insights_version=1))
+    counts = outcome_store.outcome_counts()
+    assert counts == {"stage_outcomes": 1, "deal_outcomes": 1, "has_insights": True}
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def test_now_returns_iso_with_offset() -> None:
+    now = outcome_store._now()
+    assert "T" in now
+    assert now.endswith("+00:00") or now.endswith("Z")
+
+
+def test_read_json_returns_none_for_missing_path(tmp_path: Path) -> None:
+    assert outcome_store._read_json(tmp_path / "does-not-exist.json") is None

--- a/backend/agents/sales_team/tests/test_pipeline_graph.py
+++ b/backend/agents/sales_team/tests/test_pipeline_graph.py
@@ -1,0 +1,98 @@
+"""Tests for ``sales_team.graphs.pipeline_graph.build_pipeline_graph``.
+
+The graph builder wraps Strands ``GraphBuilder`` to wire seven sales-stage
+agents (prospector → outreach → qualifier → discovery → proposal → negotiator)
+with an optional nurture branch. The tests below verify:
+
+  * the graph builds when ``include_nurture`` defaults to True (the production
+    case),
+  * the optional ``include_nurture=False`` branch builds a graph with no
+    ``nurturer`` node,
+  * the ``learning_insights`` argument actually flows into agent prompts,
+  * the graph carries the timeouts and graph-id the function configures.
+
+Each test imports ``build_pipeline_graph`` lazily to keep failures in
+Strands import scoped to a single test rather than the module collection.
+"""
+
+from __future__ import annotations
+
+
+def _build_graph(**kwargs):
+    """Helper to import + build inside each test (keeps import errors local)."""
+    from sales_team.graphs.pipeline_graph import build_pipeline_graph
+
+    return build_pipeline_graph(**kwargs)
+
+
+def test_default_build_returns_graph_with_seven_nodes() -> None:
+    graph = _build_graph()
+    # Strands Graph exposes nodes via attribute access; we cover both shapes
+    # (newer versions use ``nodes`` dict; older versions store under
+    # ``_node_lookup``).
+    nodes = getattr(graph, "nodes", None) or getattr(graph, "_node_lookup", {})
+    node_ids = set(nodes.keys()) if isinstance(nodes, dict) else {n.node_id for n in nodes}
+    assert {
+        "prospector",
+        "outreach",
+        "qualifier",
+        "discovery",
+        "proposal",
+        "negotiator",
+        "nurturer",
+    }.issubset(node_ids)
+
+
+def test_build_without_nurture_excludes_nurturer_node() -> None:
+    graph = _build_graph(include_nurture=False)
+    nodes = getattr(graph, "nodes", None) or getattr(graph, "_node_lookup", {})
+    node_ids = set(nodes.keys()) if isinstance(nodes, dict) else {n.node_id for n in nodes}
+    assert "nurturer" not in node_ids
+    # The other six nodes are still present.
+    assert {"prospector", "outreach", "qualifier", "discovery", "proposal", "negotiator"}.issubset(
+        node_ids
+    )
+
+
+def test_learning_insights_are_injected_into_agent_prompts() -> None:
+    """The insights string passed in must appear in each agent's system prompt."""
+    sentinel = "INSIGHTSXYZ-1234"
+    graph = _build_graph(learning_insights=sentinel)
+    nodes = getattr(graph, "nodes", None) or getattr(graph, "_node_lookup", {})
+    node_iter = nodes.values() if isinstance(nodes, dict) else list(nodes)
+    found_in_any = False
+    for node in node_iter:
+        # The Strands ``GraphNode`` keeps the executor; the Agent's system
+        # prompt is on ``.executor.system_prompt`` for our build_agent helper.
+        executor = getattr(node, "executor", None)
+        sp = getattr(executor, "system_prompt", "") or ""
+        if sentinel in sp:
+            found_in_any = True
+            break
+    assert found_in_any, "learning_insights string should appear in at least one agent prompt"
+
+
+def test_no_insights_means_no_insights_block() -> None:
+    """When ``learning_insights`` is empty the prompts must NOT contain the prefix."""
+    graph = _build_graph(learning_insights="")
+    nodes = getattr(graph, "nodes", None) or getattr(graph, "_node_lookup", {})
+    node_iter = nodes.values() if isinstance(nodes, dict) else list(nodes)
+    for node in node_iter:
+        executor = getattr(node, "executor", None)
+        sp = getattr(executor, "system_prompt", "") or ""
+        assert "Learning insights from prior campaigns" not in sp
+
+
+def test_entry_point_is_prospector() -> None:
+    graph = _build_graph()
+    # Strands Graph exposes the entry point via ``.entry_points`` (set/list)
+    # or, on older versions, via a single ``.entry_point`` attribute.
+    if hasattr(graph, "entry_points"):
+        ep = graph.entry_points
+        if isinstance(ep, (list, set, tuple)):
+            ids = {getattr(e, "node_id", e) for e in ep}
+        else:
+            ids = {getattr(ep, "node_id", ep)}
+        assert "prospector" in ids
+    else:
+        assert getattr(graph, "entry_point", None) is not None


### PR DESCRIPTION
## Summary

Brings `sales_team` line coverage from **55% to 100%** by adding eight new test modules under `backend/agents/sales_team/tests/`. All 250 tests run as pure unit tests (no Postgres, no Temporal, no real LLM) by mocking at the natural seams (LLM client, dossier store, job manager, Postgres `get_conn`).

No production code was modified. No `# pragma: no cover` markers were added.

## Per-file before / after

| File | Stmts | Before | After |
|---|---:|---:|---:|
| `agents.py` | 121 | 99% | **100%** |
| `api/main.py` | 256 | **0%** | **100%** |
| `critics/outreach_critic.py` | 54 | 93% | **100%** |
| `critics/proposal_critic.py` | 42 | 95% | **100%** |
| `dossier_store.py` | 78 | **0%** | **100%** |
| `graphs/pipeline_graph.py` | 25 | **0%** | **100%** |
| `learning_engine.py` | 94 | 62% | **100%** |
| `llm.py` | 12 | 100% | 100% |
| `models.py` | 496 | 99% | **100%** |
| `orchestrator.py` | 435 | 23% | **100%** |
| `outcome_store.py` | 92 | 26% | **100%** |
| `prompts/_dossier_render.py` | 61 | 64% | **100%** |
| (other prompts modules) | ~80 | 100% | 100% |
| **TOTAL** | **1846** | **55%** | **100%** |

## What each new test module covers

- **`test_api_main.py`** — every FastAPI route (`/sales/pipeline/*`, `/sales/prospect`, `/sales/outreach`, `/sales/qualify`, `/sales/nurture`, `/sales/proposal`, `/sales/coaching`, `/sales/prospect/deep-research`, `/sales/dossiers/{id}`, `/sales/prospect-lists/*`, `/sales/outcomes/*`, `/sales/insights*`, `/health`); the background `_run_pipeline_job` runner with both success and failure branches (threading overridden with an inline stand-in); the 404/409/503 error paths for the dossier store routes; and both the success and failure branches of the FastAPI lifespan including the `close_pool` failure.
- **`test_orchestrator.py`** — `_decision_makers_to_entries` (blank-name skip, empty rationale), `_should_run` (in-order, reversed, off-list), `_generate_outreach_with_critic` (initial-emit raise + keep-original on refine raise), `load_dossiers_for_prospects` (success, empty-ids, store-construction failure), the full `run()` pipeline against stub agents (happy path, no-prospects early return, existing-prospects branch, mixed advance/nurture/disqualify routing, every per-stage failure branch including discovery/proposal/close/coach/nurture), `_record_prospecting_outcomes` swallow-on-error, every single-stage helper (`prospect_only`, `outreach_only`, `qualify_only`, `nurture_only`, `propose_only`, `coach_only`), and the full `deep_research_only` flow with prospector-failure, no-companies, no-decision-makers, mapper-exception, dossier-builder-exception, persist=True success, store-construction failure, partial save failures, shortfall notes, custom `dossier_url_builder`, default URL builder, and dossier field backfill branches.
- **`test_dossier_store.py`** — `DossierStore` wired against a dict-backed fake cursor that routes the SQL statements the store issues; round-trip for save/get of dossiers and prospect lists; id and timestamp assignment when caller leaves them empty; `get_dossiers_by_prospect_ids` early-return + newest-wins for duplicate prospect ids; `list_prospect_lists` summary shape, limit, ordering, and the `isinstance(..., datetime)` fallback path; and the `_now_iso` / `_parse_ts` helpers including empty + invalid inputs.
- **`test_outcome_store.py`** — write/read round-trip for both `StageOutcome` and `DealOutcome`; id + `recorded_at` assignment when caller leaves them empty; `outcome_counts` before and after writes; insights save/load round-trip; corrupt-JSON and schema-mismatch handling that returns `None` without raising; missing-directory empty-list short-circuits; `_now` and `_read_json` helpers.
- **`test_dossier_render.py`** — every section of the markdown renderer (Identity, Executive Summary, Trigger Events, Publications with all metadata fields, Recent Activity, Conversation Hooks, Mutual Connection Angles, Stated Beliefs, Topics of Interest with the top-10 truncation, Sources rendered unbounded); the `_truncate` helper short-circuit; deterministic output verification; identity rendering when title/company are blank.
- **`test_pipeline_graph.py`** — `build_pipeline_graph` topology with all seven nodes; `include_nurture=False` exclusion; `learning_insights` injection into agent prompts; empty-insights branch; entry-point set to `prospector`.
- **`test_learning_engine.py`** — `format_insights_for_prompt` with every optional section populated and again with a minimal `LearningInsights` (only header), plus the version-increment branch off an existing snapshot, the defensive `total_outcomes_analyzed` backfill when the LLM under-reports, and the default-load-on-None branch for stage/deal outcomes.
- **`test_misc_branches.py`** — small validator/critic branches not naturally reached by the larger tests: `EmailTouch` citation validator when context exists but `dossier_source_urls` is missing; `agents._with_insights` whitespace-only branch; outreach + proposal critic prompt builders with oversized dossiers (truncation marker appears); outreach critic with `dossier=None` ("(no dossier supplied)" marker); the proposal critic invariant override when the LLM lies about `approved`; `format_critic_feedback` with a `notes=` string.

## Test plan

- [x] `LLM_PROVIDER=dummy .venv/bin/pytest agents/sales_team/tests/ -m "not integration" --cov=agents/sales_team --cov-report=term-missing -n auto` → **250 passed**, **100.00%** line coverage
- [x] `.venv/bin/ruff check agents/sales_team/` → clean
- [x] `.venv/bin/ruff format --check agents/sales_team/` → clean
- [x] No production code modified
- [x] No `# pragma: no cover` markers added

https://claude.ai/code/session_01V5u4zW36taPZEx99n69c4n

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5u4zW36taPZEx99n69c4n)_