### PR TITLE
agent_provisioning_team: raise test coverage from 54% to 98%

### DIFF
--- a/backend/agents/agent_provisioning_team/tests/test_api_unit.py
+++ b/backend/agents/agent_provisioning_team/tests/test_api_unit.py
@@ -1,0 +1,740 @@
+"""Unit-level tests for the agent provisioning FastAPI surface.
+
+These tests don't need a live executor / orchestrator — every external
+function (job store, orchestrator, executor) is patched at the seam.
+Marked NON-integration so they run on the default unit lane.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from agent_provisioning_team.api import main as api_main
+from agent_provisioning_team.api.main import app
+from agent_provisioning_team.models import (
+    DeprovisionResponse,
+    EnvironmentInfo,
+    ProvisioningResult,
+)
+
+client = TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Health + root endpoints
+# ---------------------------------------------------------------------------
+
+
+def test_health_endpoint() -> None:
+    r = client.get("/health")
+    assert r.status_code == 200
+    assert r.json() == {"status": "healthy", "service": "agent-provisioning"}
+
+
+def test_root_endpoint() -> None:
+    r = client.get("/")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["service"] == "Agent Provisioning API"
+    assert data["version"] == "1.0.0"
+
+
+# ---------------------------------------------------------------------------
+# /provision flows
+# ---------------------------------------------------------------------------
+
+
+def test_provision_routes_to_temporal_when_enabled() -> None:
+    """When a temporal starter is available, /provision delegates to it."""
+    fake_starter = MagicMock()
+
+    with (
+        patch("agent_provisioning_team.api.main.create_job"),
+        patch.object(api_main, "_temporal_starter", return_value=fake_starter),
+    ):
+        r = client.post("/provision", json={"agent_id": "ag-temporal"})
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["status"] == "running"
+    fake_starter.assert_called_once()
+
+
+def test_provision_uses_thread_path_when_no_temporal() -> None:
+    with (
+        patch("agent_provisioning_team.api.main.create_job"),
+        patch.object(api_main, "_temporal_starter", return_value=None),
+        patch.object(api_main, "_ensure_executor") as mock_ensure,
+    ):
+        mock_executor = MagicMock()
+        mock_ensure.return_value = mock_executor
+        r = client.post("/provision", json={"agent_id": "ag-thread"})
+
+    assert r.status_code == 200
+    mock_executor.submit.assert_called_once()
+
+
+def test_provision_thread_fallback_env_flag() -> None:
+    """PROVISION_THREAD_FALLBACK=1 forces None starter."""
+    with patch.dict("os.environ", {"PROVISION_THREAD_FALLBACK": "1"}):
+        assert api_main._temporal_starter() is None
+
+
+def test_provision_thread_fallback_with_blank_env() -> None:
+    with patch.dict("os.environ", {"PROVISION_THREAD_FALLBACK": ""}):
+        # No-op: returns whatever the real path resolves to (could be None
+        # when Temporal isn't installed).
+        api_main._temporal_starter()
+
+
+def test_provision_thread_fallback_returns_true_for_true() -> None:
+    with patch.dict("os.environ", {"PROVISION_THREAD_FALLBACK": "true"}):
+        assert api_main._provision_thread_fallback() is True
+    with patch.dict("os.environ", {"PROVISION_THREAD_FALLBACK": "yes"}):
+        assert api_main._provision_thread_fallback() is True
+
+
+# ---------------------------------------------------------------------------
+# /provision/status/{job_id}
+# ---------------------------------------------------------------------------
+
+
+def test_get_status_returns_404_on_missing_job() -> None:
+    with patch.object(api_main, "get_job", return_value={}):
+        r = client.get("/provision/status/missing")
+    assert r.status_code == 404
+
+
+def test_get_status_returns_state_for_running_job() -> None:
+    with patch.object(
+        api_main,
+        "get_job",
+        return_value={
+            "status": "running",
+            "agent_id": "a",
+            "current_phase": "setup",
+            "progress": 30,
+            "tools_completed": 1,
+            "tools_total": 3,
+            "completed_phases": ["setup"],
+        },
+    ):
+        r = client.get("/provision/status/job-1")
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["status"] == "running"
+    assert data["agent_id"] == "a"
+    assert data["progress"] == 30
+
+
+def test_get_status_returns_result_for_completed_job() -> None:
+    env = EnvironmentInfo(container_id="c1", container_name="c1")
+    result = ProvisioningResult(agent_id="a", success=True, environment=env)
+
+    with patch.object(
+        api_main,
+        "get_job",
+        return_value={
+            "status": "completed",
+            "agent_id": "a",
+            "result": result.model_dump(mode="json"),
+            "progress": 100,
+        },
+    ):
+        r = client.get("/provision/status/job-1")
+
+    assert r.status_code == 200
+    data = r.json()
+    assert data["result"]["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# /provision/jobs
+# ---------------------------------------------------------------------------
+
+
+def test_list_jobs_returns_summaries() -> None:
+    fake_jobs = [
+        {
+            "job_id": "j1",
+            "agent_id": "a1",
+            "status": "running",
+            "created_at": None,
+            "progress": 50,
+        },
+        {"job_id": "j2", "agent_id": "a2", "status": "pending", "progress": 0},
+    ]
+    with patch.object(api_main, "list_jobs", return_value=fake_jobs):
+        r = client.get("/provision/jobs")
+
+    assert r.status_code == 200
+    data = r.json()
+    assert len(data["jobs"]) == 2
+    assert {j["job_id"] for j in data["jobs"]} == {"j1", "j2"}
+
+
+def test_list_jobs_with_running_only_filter() -> None:
+    captured = {}
+
+    def fake_list(running_only=False):
+        captured["running_only"] = running_only
+        return []
+
+    with patch.object(api_main, "list_jobs", side_effect=fake_list):
+        r = client.get("/provision/jobs?running_only=true")
+    assert r.status_code == 200
+    assert captured["running_only"] is True
+
+
+# ---------------------------------------------------------------------------
+# /provision/job/{job_id}/cancel
+# ---------------------------------------------------------------------------
+
+
+def test_cancel_job_not_found() -> None:
+    with patch.object(api_main, "get_job", return_value={}):
+        r = client.post("/provision/job/missing/cancel")
+    assert r.status_code == 404
+
+
+def test_cancel_job_terminal_state_rejected() -> None:
+    with patch.object(api_main, "get_job", return_value={"status": "completed"}):
+        r = client.post("/provision/job/j1/cancel")
+    assert r.status_code == 400
+    assert "terminal" in r.json()["detail"]
+
+
+def test_cancel_job_pending_succeeds() -> None:
+    with (
+        patch.object(api_main, "get_job", return_value={"status": "pending"}),
+        patch.object(api_main, "store_cancel_job") as mock_cancel,
+    ):
+        r = client.post("/provision/job/j1/cancel")
+    assert r.status_code == 200
+    assert r.json()["job_id"] == "j1"
+    mock_cancel.assert_called_once_with("j1")
+
+
+def test_cancel_job_running_succeeds() -> None:
+    with (
+        patch.object(api_main, "get_job", return_value={"status": "running"}),
+        patch.object(api_main, "store_cancel_job"),
+    ):
+        r = client.post("/provision/job/j2/cancel")
+    assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# /provision/job/{job_id} DELETE
+# ---------------------------------------------------------------------------
+
+
+def test_delete_job_not_found() -> None:
+    with patch.object(api_main, "get_job", return_value={}):
+        r = client.delete("/provision/job/missing")
+    assert r.status_code == 404
+
+
+def test_delete_job_succeeds() -> None:
+    with (
+        patch.object(api_main, "get_job", return_value={"status": "completed"}),
+        patch.object(api_main, "store_delete_job", return_value=True),
+    ):
+        r = client.delete("/provision/job/j1")
+    assert r.status_code == 200
+    assert r.json()["job_id"] == "j1"
+
+
+def test_delete_job_store_returns_false() -> None:
+    with (
+        patch.object(api_main, "get_job", return_value={"status": "completed"}),
+        patch.object(api_main, "store_delete_job", return_value=False),
+    ):
+        r = client.delete("/provision/job/j1")
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# /provision/job/{job_id}/resume
+# ---------------------------------------------------------------------------
+
+
+def test_resume_job_not_found() -> None:
+    with patch.object(api_main, "get_job", return_value=None):
+        r = client.post("/provision/job/missing/resume")
+    assert r.status_code == 404
+
+
+def test_resume_job_in_running_state_rejected() -> None:
+    # validate_job_for_action raises ValueError for non-resumable statuses
+    with patch.object(api_main, "get_job", return_value={"status": "running"}):
+        r = client.post("/provision/job/j1/resume")
+    assert r.status_code in (400, 404)
+
+
+def test_resume_job_missing_agent_or_manifest() -> None:
+    with patch.object(
+        api_main,
+        "get_job",
+        return_value={
+            "status": "failed",
+            "agent_id": "",  # missing
+            "manifest_path": "default.yaml",
+        },
+    ):
+        r = client.post("/provision/job/j1/resume")
+    assert r.status_code == 400
+
+
+def test_resume_job_thread_path() -> None:
+    with (
+        patch.object(
+            api_main,
+            "get_job",
+            return_value={
+                "status": "failed",
+                "agent_id": "a1",
+                "manifest_path": "default.yaml",
+                "completed_phases": ["setup"],
+                "phase_results": {"setup": {"success": True, "environment": None}},
+            },
+        ),
+        patch.object(api_main, "update_job"),
+        patch.object(api_main, "_temporal_starter", return_value=None),
+        patch.object(api_main, "_ensure_executor") as mock_ensure,
+    ):
+        mock_ensure.return_value = MagicMock()
+        r = client.post("/provision/job/j1/resume")
+
+    assert r.status_code == 200
+    assert r.json()["status"] == "running"
+
+
+def test_resume_job_temporal_path() -> None:
+    fake_starter = MagicMock()
+    with (
+        patch.object(
+            api_main,
+            "get_job",
+            return_value={
+                "status": "failed",
+                "agent_id": "a1",
+                "manifest_path": "default.yaml",
+                "completed_phases": ["setup", "credential_generation"],
+                "phase_results": {},
+            },
+        ),
+        patch.object(api_main, "update_job"),
+        patch.object(api_main, "_temporal_starter", return_value=fake_starter),
+    ):
+        r = client.post("/provision/job/j1/resume")
+
+    assert r.status_code == 200
+    fake_starter.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# /provision/job/{job_id}/restart
+# ---------------------------------------------------------------------------
+
+
+def test_restart_job_not_found() -> None:
+    with patch.object(api_main, "get_job", return_value=None):
+        r = client.post("/provision/job/missing/restart")
+    assert r.status_code == 404
+
+
+def test_restart_job_missing_agent_or_manifest() -> None:
+    with patch.object(
+        api_main,
+        "get_job",
+        return_value={"status": "completed", "agent_id": "a1", "manifest_path": ""},
+    ):
+        r = client.post("/provision/job/j1/restart")
+    assert r.status_code == 400
+
+
+def test_restart_job_thread_path() -> None:
+    with (
+        patch.object(
+            api_main,
+            "get_job",
+            return_value={
+                "status": "completed",
+                "agent_id": "a1",
+                "manifest_path": "default.yaml",
+            },
+        ),
+        patch.object(api_main, "store_reset_job"),
+        patch.object(api_main, "_temporal_starter", return_value=None),
+        patch.object(api_main, "_ensure_executor") as mock_ensure,
+    ):
+        mock_ensure.return_value = MagicMock()
+        r = client.post("/provision/job/j1/restart")
+    assert r.status_code == 200
+    assert r.json()["status"] == "running"
+
+
+def test_restart_job_temporal_path() -> None:
+    fake_starter = MagicMock()
+    with (
+        patch.object(
+            api_main,
+            "get_job",
+            return_value={
+                "status": "completed",
+                "agent_id": "a1",
+                "manifest_path": "default.yaml",
+            },
+        ),
+        patch.object(api_main, "store_reset_job"),
+        patch.object(api_main, "_temporal_starter", return_value=fake_starter),
+    ):
+        r = client.post("/provision/job/j1/restart")
+    assert r.status_code == 200
+    fake_starter.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# /environments/{agent_id} DELETE (deprovision)
+# ---------------------------------------------------------------------------
+
+
+def test_deprovision_returns_orchestrator_result() -> None:
+    fake_resp = DeprovisionResponse(agent_id="a1", success=True)
+    with patch.object(api_main.orchestrator, "deprovision", return_value=fake_resp):
+        r = client.delete("/environments/a1")
+    assert r.status_code == 200
+    assert r.json()["agent_id"] == "a1"
+    assert r.json()["success"] is True
+
+
+def test_deprovision_with_force_flag() -> None:
+    fake_resp = DeprovisionResponse(agent_id="a1", success=True)
+    captured = {}
+
+    def fake_dep(agent_id, force=False):
+        captured["force"] = force
+        return fake_resp
+
+    with patch.object(api_main.orchestrator, "deprovision", side_effect=fake_dep):
+        r = client.delete("/environments/a1?force=true")
+    assert r.status_code == 200
+    assert captured["force"] is True
+
+
+# ---------------------------------------------------------------------------
+# /environments/{agent_id} GET
+# ---------------------------------------------------------------------------
+
+
+def test_get_environment_not_found() -> None:
+    with patch.object(api_main.orchestrator, "get_agent_status", return_value=None):
+        r = client.get("/environments/missing")
+    assert r.status_code == 404
+
+
+def test_get_environment_returns_status() -> None:
+    with patch.object(
+        api_main.orchestrator,
+        "get_agent_status",
+        return_value={
+            "agent_id": "a1",
+            "status": "ready",
+            "container_id": "c1",
+            "container_name": "agent-a1",
+            "tools_provisioned": ["postgresql"],
+        },
+    ):
+        r = client.get("/environments/a1")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["status"] == "ready"
+
+
+# ---------------------------------------------------------------------------
+# /environments GET (list)
+# ---------------------------------------------------------------------------
+
+
+def test_list_environments_empty() -> None:
+    with patch.object(api_main.orchestrator, "list_agents", return_value=[]):
+        r = client.get("/environments")
+    assert r.status_code == 200
+    assert r.json()["agents"] == []
+
+
+def test_list_environments_with_filter() -> None:
+    captured = {}
+
+    def fake_list(status=None):
+        captured["status"] = status
+        return [
+            {
+                "agent_id": "a1",
+                "status": "ready",
+                "container_name": "agent-a1",
+                "tools_provisioned": ["pg"],
+            }
+        ]
+
+    with patch.object(api_main.orchestrator, "list_agents", side_effect=fake_list):
+        r = client.get("/environments?status=ready")
+    assert r.status_code == 200
+    assert captured["status"] == "ready"
+    assert r.json()["agents"][0]["agent_id"] == "a1"
+
+
+# ---------------------------------------------------------------------------
+# Internals: _ensure_executor, _queue_depth, _reject_if_saturated
+# ---------------------------------------------------------------------------
+
+
+def test_ensure_executor_lazy_construct(monkeypatch) -> None:
+    monkeypatch.setattr(api_main, "_executor", None)
+    ex = api_main._ensure_executor()
+    assert ex is not None
+    # Subsequent call returns same instance
+    assert api_main._ensure_executor() is ex
+    ex.shutdown(wait=True)
+    monkeypatch.setattr(api_main, "_executor", None)
+
+
+def test_queue_depth_zero_when_no_executor(monkeypatch) -> None:
+    monkeypatch.setattr(api_main, "_executor", None)
+    assert api_main._queue_depth() == 0
+
+
+def test_reject_if_saturated_raises_429(monkeypatch) -> None:
+    """When the work queue is full, _reject_if_saturated raises HTTPException 429."""
+    from fastapi import HTTPException
+
+    fake_ex = MagicMock()
+    fake_ex._work_queue.qsize.return_value = 999
+    monkeypatch.setattr(api_main, "_executor", fake_ex)
+    monkeypatch.setattr(api_main, "PROVISION_MAX_QUEUE_DEPTH", 10)
+
+    with pytest.raises(HTTPException) as exc_info:
+        api_main._reject_if_saturated()
+    assert exc_info.value.status_code == 429
+
+
+def test_reject_if_saturated_quiet_when_under_limit(monkeypatch) -> None:
+    fake_ex = MagicMock()
+    fake_ex._work_queue.qsize.return_value = 1
+    monkeypatch.setattr(api_main, "_executor", fake_ex)
+    monkeypatch.setattr(api_main, "PROVISION_MAX_QUEUE_DEPTH", 10)
+    # No exception
+    api_main._reject_if_saturated()
+
+
+# ---------------------------------------------------------------------------
+# _run_provisioning_background
+# ---------------------------------------------------------------------------
+
+
+def test_run_provisioning_background_success_path() -> None:
+    """Successful workflow → mark_job_completed with the redacted result."""
+    from agent_provisioning_team.models import EnvironmentInfo, ProvisioningResult
+
+    env = EnvironmentInfo(container_id="c1", container_name="c1")
+    fake_result = ProvisioningResult(agent_id="a", success=True, environment=env)
+
+    with (
+        patch.object(api_main, "mark_job_running") as mock_run,
+        patch.object(api_main, "mark_job_completed") as mock_done,
+        patch.object(api_main, "update_job"),
+        patch.object(api_main.orchestrator, "run_workflow", return_value=fake_result),
+    ):
+        api_main._run_provisioning_background("j1", "a", "default.yaml")
+
+    mock_run.assert_called_once_with("j1")
+    mock_done.assert_called_once()
+
+
+def test_run_provisioning_background_failure_path() -> None:
+    from agent_provisioning_team.models import ProvisioningResult
+
+    fake_result = ProvisioningResult(agent_id="a", success=False, error="boom")
+
+    with (
+        patch.object(api_main, "mark_job_running"),
+        patch.object(api_main, "mark_job_failed") as mock_fail,
+        patch.object(api_main, "update_job"),
+        patch.object(api_main.orchestrator, "run_workflow", return_value=fake_result),
+    ):
+        api_main._run_provisioning_background("j1", "a", "default.yaml")
+
+    mock_fail.assert_called_once()
+    assert "boom" in mock_fail.call_args.kwargs["error"]
+
+
+def test_run_provisioning_background_shutdown_error() -> None:
+    from agent_provisioning_team.orchestrator import ProvisioningShutdownError
+
+    with (
+        patch.object(api_main, "mark_job_running"),
+        patch.object(api_main, "mark_job_failed") as mock_fail,
+        patch.object(
+            api_main.orchestrator,
+            "run_workflow",
+            side_effect=ProvisioningShutdownError(agent_id="a", phase="setup"),
+        ),
+    ):
+        api_main._run_provisioning_background("j1", "a", "default.yaml")
+
+    mock_fail.assert_called_once()
+    assert "Shutdown" in mock_fail.call_args.kwargs["error"]
+
+
+def test_run_provisioning_background_generic_exception() -> None:
+    with (
+        patch.object(api_main, "mark_job_running"),
+        patch.object(api_main, "mark_job_failed") as mock_fail,
+        patch.object(api_main.orchestrator, "run_workflow", side_effect=RuntimeError("kaboom")),
+    ):
+        api_main._run_provisioning_background("j1", "a", "default.yaml")
+
+    mock_fail.assert_called_once()
+    assert "kaboom" in mock_fail.call_args.kwargs["error"]
+
+
+def test_run_provisioning_background_job_updater_invokes_update_job() -> None:
+    """The job_updater closure should call update_job with sanitized fields only."""
+    from agent_provisioning_team.models import ProvisioningResult
+
+    captured = []
+
+    def fake_update_job(job_id, **fields):
+        captured.append({"job_id": job_id, **fields})
+
+    fake_result = ProvisioningResult(agent_id="a", success=True)
+
+    def fake_run_workflow(*, agent_id, manifest_path, job_updater, **kw):
+        # Exercise every branch of job_updater
+        job_updater(
+            current_phase="setup",
+            progress=10,
+            current_tool="pg",
+            tools_completed=1,
+            tools_total=3,
+            status_text="hi",
+        )
+        # Empty call should be a no-op
+        job_updater()
+        return fake_result
+
+    with (
+        patch.object(api_main, "mark_job_running"),
+        patch.object(api_main, "mark_job_completed"),
+        patch.object(api_main, "update_job", side_effect=fake_update_job),
+        patch.object(api_main.orchestrator, "run_workflow", side_effect=fake_run_workflow),
+    ):
+        api_main._run_provisioning_background("j1", "a", "default.yaml")
+
+    # The first call should have written every field; the empty call is filtered out.
+    assert len(captured) == 1
+    assert captured[0]["current_phase"] == "setup"
+    assert captured[0]["progress"] == 10
+
+
+# ---------------------------------------------------------------------------
+# _graceful_shutdown + _safe_compensate
+# ---------------------------------------------------------------------------
+
+
+def test_safe_compensate_swallows_exceptions(monkeypatch) -> None:
+    with patch.object(api_main.orchestrator, "_compensate", side_effect=RuntimeError("ugh")):
+        # Must not raise
+        api_main._safe_compensate("a1")
+
+
+def test_graceful_shutdown_drains_executor(monkeypatch) -> None:
+    """The graceful shutdown path waits for the executor + marks running jobs failed."""
+
+    monkeypatch.setattr(api_main, "_executor", None)
+    api_main._ensure_executor()
+    monkeypatch.setattr(api_main, "SHUTDOWN_GRACE_S", 1.0)
+
+    with (
+        patch.object(api_main, "list_jobs", return_value=[]),
+        patch.object(api_main, "mark_all_running_jobs_failed"),
+    ):
+        asyncio.run(api_main._graceful_shutdown())
+
+
+def test_graceful_shutdown_list_jobs_failure(monkeypatch) -> None:
+    """If list_jobs raises, shutdown still completes."""
+    monkeypatch.setattr(api_main, "_executor", None)
+    api_main._ensure_executor()
+
+    with (
+        patch.object(api_main, "list_jobs", side_effect=RuntimeError("db down")),
+        patch.object(api_main, "mark_all_running_jobs_failed"),
+    ):
+        asyncio.run(api_main._graceful_shutdown())
+
+
+def test_graceful_shutdown_mark_all_failure_swallowed(monkeypatch) -> None:
+    monkeypatch.setattr(api_main, "_executor", None)
+    api_main._ensure_executor()
+
+    with (
+        patch.object(api_main, "list_jobs", return_value=[]),
+        patch.object(
+            api_main,
+            "mark_all_running_jobs_failed",
+            side_effect=RuntimeError("io"),
+        ),
+    ):
+        asyncio.run(api_main._graceful_shutdown())
+
+
+def test_graceful_shutdown_compensates_inflight_jobs(monkeypatch) -> None:
+    """Active jobs with agent_id get _compensate'd via the safe wrapper."""
+    monkeypatch.setattr(api_main, "_executor", None)
+    api_main._ensure_executor()
+    monkeypatch.setattr(api_main, "COMPENSATE_TIMEOUT_S", 1.0)
+
+    compensated = []
+
+    def fake_compensate(agent_id, tool_results):
+        compensated.append(agent_id)
+
+    with (
+        patch.object(
+            api_main,
+            "list_jobs",
+            return_value=[
+                {"agent_id": "a1", "status": "running"},
+                {"agent_id": "a2", "status": "running"},
+                {"status": "running"},  # missing agent_id is skipped
+            ],
+        ),
+        patch.object(api_main.orchestrator, "_compensate", side_effect=fake_compensate),
+        patch.object(api_main, "mark_all_running_jobs_failed"),
+    ):
+        asyncio.run(api_main._graceful_shutdown())
+
+    assert set(compensated) == {"a1", "a2"}
+
+
+def test_submit_provisioning_job_tracks_future(monkeypatch) -> None:
+    """Submitted jobs land in _inflight; the done callback removes them."""
+    monkeypatch.setattr(api_main, "_executor", None)
+    api_main._ensure_executor()
+
+    def quick(*a, **k):
+        return None
+
+    with patch.object(api_main, "_run_provisioning_background", side_effect=quick):
+        api_main._submit_provisioning_job("job-zzz", "agent-x", "default.yaml")
+
+    # The submitted job will likely have completed already; the done-callback
+    # cleans up _inflight so it may or may not be present, but executor was used.
+    assert api_main._executor is not None

--- a/backend/agents/agent_provisioning_team/tests/test_extra_coverage.py
+++ b/backend/agents/agent_provisioning_team/tests/test_extra_coverage.py
@@ -1,0 +1,372 @@
+"""Extra targeted tests to close the last coverage gaps.
+
+* Lifecycle._wait_healthy timeout path
+* Lifecycle.run_idle_reaper non-cancel exception swallowed
+* Lifecycle.reap_once with non-warm state
+* _resolve_team registry success/failure
+* sandbox.provisioner._exec timeout (real coroutine)
+* sandbox.provisioner._materialise_project_dir asset copy when grafana exists
+* tool_agents.base.canonical_anatomy_preamble
+* Last few credential_store branches
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Lifecycle._wait_healthy — deadline exceeded path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wait_healthy_exceeds_deadline(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.sandbox import lifecycle as lc_mod
+
+    lc = lc_mod.Lifecycle(state_file=tmp_path / "s.json")
+
+    # Force the deadline immediately and httpx to always raise.
+    monkeypatch.setattr(lc_mod, "boot_timeout_seconds", lambda: 0)
+
+    async def fake_get(self, *args, **kwargs):
+        import httpx
+
+        raise httpx.ConnectError("nope")
+
+    with patch("httpx.AsyncClient.get", new=fake_get):
+        with pytest.raises(RuntimeError, match="did not report healthy"):
+            await lc._wait_healthy(host_port=12345)
+
+
+@pytest.mark.asyncio
+async def test_wait_healthy_success(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.sandbox import lifecycle as lc_mod
+
+    lc = lc_mod.Lifecycle(state_file=tmp_path / "s.json")
+
+    async def fake_get(self, *args, **kwargs):
+        resp = MagicMock()
+        resp.status_code = 200
+        return resp
+
+    with patch("httpx.AsyncClient.get", new=fake_get):
+        await lc._wait_healthy(host_port=12345)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle.run_idle_reaper non-cancel exception is logged and loop continues
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_idle_reaper_swallows_non_cancel_exception(tmp_path: Path) -> None:
+    from agent_provisioning_team.sandbox import lifecycle as lc_mod
+
+    lc = lc_mod.Lifecycle(state_file=tmp_path / "s.json")
+
+    calls = {"n": 0}
+
+    async def flaky_reap(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] < 2:
+            raise RuntimeError("transient")
+        raise asyncio.CancelledError()
+
+    with (
+        patch.object(lc_mod.asyncio, "sleep", new=AsyncMock()),
+        patch.object(lc_mod.Lifecycle, "reap_once", new=flaky_reap),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await lc.run_idle_reaper(interval_s=0)
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle.reap_once skips non-warm states
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reap_once_skips_non_warm(tmp_path: Path) -> None:
+    from agent_provisioning_team.sandbox import lifecycle as lc_mod
+    from agent_provisioning_team.sandbox.state import (
+        SandboxState,
+        SandboxStatus,
+        now,
+    )
+
+    lc = lc_mod.Lifecycle(state_file=tmp_path / "s.json")
+    t = now()
+    lc._state["a1"] = SandboxState(
+        agent_id="a1",
+        team="t",
+        container_name="c1",
+        status=SandboxStatus.ERROR,  # not warm
+        created_at=t,
+        last_used_at=t - timedelta(hours=1),
+    )
+
+    reaped = await lc.reap_once(threshold=60)
+    assert reaped == []
+    # State row still present (not touched).
+    assert "a1" in lc._state
+
+
+# ---------------------------------------------------------------------------
+# _resolve_team — happy and unknown
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_team_success() -> None:
+    from agent_provisioning_team.sandbox.lifecycle import _resolve_team
+
+    fake_manifest = MagicMock()
+    fake_manifest.team = "myteam"
+    fake_registry = MagicMock()
+    fake_registry.get.return_value = fake_manifest
+
+    with patch(
+        "agent_registry.get_registry",
+        return_value=fake_registry,
+    ):
+        assert _resolve_team("agent.x") == "myteam"
+
+
+def test_resolve_team_unknown() -> None:
+    from agent_provisioning_team.sandbox.lifecycle import (
+        UnknownAgentError,
+        _resolve_team,
+    )
+
+    fake_registry = MagicMock()
+    fake_registry.get.return_value = None
+
+    with patch("agent_registry.get_registry", return_value=fake_registry):
+        with pytest.raises(UnknownAgentError):
+            _resolve_team("ghost")
+
+
+# ---------------------------------------------------------------------------
+# sandbox.provisioner._exec timeout
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_provisioner_exec_kills_on_timeout(monkeypatch) -> None:
+    from agent_provisioning_team.sandbox import provisioner as pm
+
+    # Real proc-stub that hangs in communicate until cancelled.
+    proc_stub = MagicMock()
+    proc_stub.kill = MagicMock()
+
+    async def comm():
+        await asyncio.sleep(10)
+        return (b"", b"")
+
+    async def wait():
+        return None
+
+    proc_stub.communicate = comm
+    proc_stub.wait = wait
+    proc_stub.returncode = 0
+
+    async def fake_create(*args, **kwargs):
+        return proc_stub
+
+    monkeypatch.setattr(pm.asyncio, "create_subprocess_exec", fake_create)
+
+    with pytest.raises(pm.DockerError, match="timed out"):
+        # Wait for a very small timeout
+        await pm._exec(["docker", "info"], timeout_s=0)
+
+    proc_stub.kill.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# sandbox.provisioner._materialise_project_dir — when grafana assets exist
+# ---------------------------------------------------------------------------
+
+
+def test_materialise_project_dir_copies_grafana(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.sandbox import provisioner as pm
+
+    # sandbox_stack_assets_dir() returns the template's parent directory,
+    # so colocate the support files with the template.
+    template = tmp_path / "sandbox-stack.yml"
+    template.write_text(
+        "sandbox: {sandbox_id}\nagent: {agent_id}\nimage: {agent_image}\n"
+        "pw: {pg_password}\nsecrets: {agent_secrets_file}\nport: {agent_host_port}\n"
+    )
+    (tmp_path / "postgres-init.sql").write_text("-- init")
+    (tmp_path / "prometheus.yml").write_text("global: {}")
+    grafana = tmp_path / "grafana-provisioning"
+    grafana.mkdir()
+    (grafana / "datasources.yml").write_text("apiVersion: 1")
+
+    monkeypatch.setenv("AGENT_PROVISIONING_SANDBOX_STACK_TEMPLATE", str(template))
+    monkeypatch.setenv("AGENT_CACHE", str(tmp_path / "cache"))
+
+    path = pm._materialise_project_dir("khala-sbx-test", host_port=12345, postgres_password="pw")
+    assert (path / "docker-compose.yml").exists()
+    assert (path / "grafana-provisioning" / "datasources.yml").exists()
+    # Re-run should overwrite (tests the grafana_dst exists rmtree branch).
+    pm._materialise_project_dir("khala-sbx-test", host_port=12345, postgres_password="pw")
+
+
+# ---------------------------------------------------------------------------
+# tool_agents.base.canonical_anatomy_preamble — instance method
+# ---------------------------------------------------------------------------
+
+
+def test_canonical_anatomy_prompt_preamble_via_instance(tmp_path: Path) -> None:
+    from agent_provisioning_team.shared.provisioner_state import ProvisionerStateStore
+    from agent_provisioning_team.tool_agents.generic_provisioner import GenericProvisionerTool
+
+    prov = GenericProvisionerTool("x")
+    prov._state = ProvisionerStateStore("generic_x_provisioner", storage_dir=tmp_path)
+    text = prov.canonical_anatomy_prompt_preamble()
+    assert isinstance(text, str)
+
+
+# ---------------------------------------------------------------------------
+# credential_store — corrupt key error path
+# ---------------------------------------------------------------------------
+
+
+def test_credential_store_invalid_key_raises(tmp_path: Path) -> None:
+    from agent_provisioning_team.shared.credential_store import (
+        CredentialStore,
+        CredentialStoreConfigError,
+    )
+
+    with pytest.raises(CredentialStoreConfigError):
+        CredentialStore(storage_dir=tmp_path, encryption_key="not-a-real-key")
+
+
+def test_credential_store_rotate_skips_corrupt_files(tmp_path: Path) -> None:
+    from cryptography.fernet import Fernet
+
+    from agent_provisioning_team.shared.credential_store import CredentialStore
+
+    k = Fernet.generate_key().decode()
+    store = CredentialStore(storage_dir=tmp_path, encryption_key=k)
+    store.store_credentials("a1", "pg", {"password": "p"})
+
+    # Drop a corrupt .enc file alongside the valid one.
+    (tmp_path / "garbage.enc").write_bytes(b"not encrypted")
+
+    new_k = Fernet.generate_key().decode()
+    rotated = store.rotate_key(new_k)
+    # Valid file rotated, garbage skipped — count is 1.
+    assert rotated == 1
+
+
+# ---------------------------------------------------------------------------
+# start_workflow._run_async actually runs the coroutine
+# ---------------------------------------------------------------------------
+
+
+def test_run_async_runs_via_loop() -> None:
+    from agent_provisioning_team.temporal import start_workflow as sw
+
+    # Create an actual event loop and runs the coroutine in it.
+    loop = asyncio.new_event_loop()
+    fake_client = MagicMock()
+    sentinel = {}
+
+    async def go():
+        sentinel["done"] = True
+        return "OK"
+
+    # Start the loop in a background thread so run_coroutine_threadsafe works.
+    import threading
+
+    def run_forever():
+        asyncio.set_event_loop(loop)
+        loop.run_forever()
+
+    t = threading.Thread(target=run_forever, daemon=True)
+    t.start()
+
+    try:
+        with (
+            patch.object(sw, "get_temporal_client", return_value=fake_client),
+            patch.object(sw, "get_temporal_loop", return_value=loop),
+        ):
+            result = sw._run_async(go())
+        assert result == "OK"
+        assert sentinel.get("done") is True
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        t.join(timeout=5)
+        loop.close()
+
+
+# ---------------------------------------------------------------------------
+# provisioner_state — _save error path (raise during dump)
+# ---------------------------------------------------------------------------
+
+
+def test_provisioner_state_save_handles_io_error(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.shared.provisioner_state import ProvisionerStateStore
+
+    store = ProvisionerStateStore("x", storage_dir=tmp_path)
+
+    # Force os.replace to raise to exercise the cleanup path.
+    with patch("os.replace", side_effect=OSError("io")):
+        with pytest.raises(OSError):
+            store.put("a1", {"x": 1})
+
+
+# ---------------------------------------------------------------------------
+# api/main — lifespan completion path
+# ---------------------------------------------------------------------------
+
+
+def test_lifespan_runs_cleanly(monkeypatch) -> None:
+    """Entering + exiting the TestClient context runs the lifespan hook
+    end-to-end with the executor + shutdown event."""
+    from fastapi.testclient import TestClient
+
+    from agent_provisioning_team.api import main as api_main
+
+    monkeypatch.setattr(api_main, "_executor", None)
+    with (
+        patch.object(api_main, "list_jobs", return_value=[]),
+        patch.object(api_main, "mark_all_running_jobs_failed"),
+    ):
+        with TestClient(api_main.app) as c:
+            r = c.get("/health")
+            assert r.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# anatomy_assets missing AGENT_ANATOMY.md fallback
+# ---------------------------------------------------------------------------
+
+
+def test_load_agent_anatomy_text_missing_file(monkeypatch) -> None:
+    from agent_provisioning_team import anatomy_assets
+
+    # Force the path attribute to a non-existent file.
+    monkeypatch.setattr(anatomy_assets, "AGENT_ANATOMY_MD", anatomy_assets.PACKAGE_DIR / "ghost.md")
+    anatomy_assets._anatomy_text_cache = None
+    out = anatomy_assets.load_agent_anatomy_text()
+    assert "Missing file" in out
+
+    # Reset cache so subsequent tests see the real content again.
+    anatomy_assets._anatomy_text_cache = None
+
+
+def test_list_design_asset_paths_missing_dir(monkeypatch) -> None:
+    from agent_provisioning_team import anatomy_assets
+
+    monkeypatch.setattr(
+        anatomy_assets, "DESIGN_ASSETS_DIR", anatomy_assets.PACKAGE_DIR / "ghost_dir"
+    )
+    out = anatomy_assets.list_design_asset_paths()
+    assert out == []

--- a/backend/agents/agent_provisioning_team/tests/test_git_provisioner.py
+++ b/backend/agents/agent_provisioning_team/tests/test_git_provisioner.py
@@ -1,0 +1,336 @@
+"""Unit tests for the Git provisioner tool agent.
+
+ssh-keygen / git invocations are mocked at subprocess.run boundary so no real
+binaries are exercised. Some tests do touch the filesystem under tmp_path.
+"""
+
+from __future__ import annotations
+
+import subprocess as _subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from agent_provisioning_team.models import GeneratedCredentials
+from agent_provisioning_team.shared.provisioner_state import ProvisionerStateStore
+from agent_provisioning_team.tool_agents.git_provisioner import GitProvisionerTool
+
+
+def _ok(*args, **kwargs):
+    return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+
+def test_git_provision_creates_workspace_and_repo(tmp_path: Path) -> None:
+    ws_base = tmp_path / "ws"
+    ws_base.mkdir()
+    prov = GitProvisionerTool(workspace_base=str(ws_base))
+    prov._state = ProvisionerStateStore("git_provisioner", storage_dir=tmp_path)
+
+    creds = GeneratedCredentials(tool_name="git")
+
+    def _ssh_keygen(*args, **kwargs):
+        # Simulate ssh-keygen creating the keys.
+        cmd = args[0]
+        if cmd[0] == "ssh-keygen":
+            # Find the -f path and write fake key files there.
+            idx = cmd.index("-f")
+            key_path = Path(cmd[idx + 1])
+            key_path.write_text("FAKE_PRIVATE\n")
+            key_path.with_suffix(key_path.suffix + ".pub").write_text("ssh-ed25519 FAKEPUB\n")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        return _ok(*args, **kwargs)
+
+    with patch("subprocess.run", side_effect=_ssh_keygen):
+        result = prov.provision(
+            "agent-1",
+            {
+                "workspace_path": str(ws_base / "agent-1"),
+                "init_repos": ["workspace"],
+                "generate_ssh_key": True,
+            },
+            creds,
+        )
+
+    assert result.success is True
+    assert creds.ssh_private_key.startswith("FAKE_PRIVATE")
+    assert "id_ed25519" in result.details["ssh_key_path"]
+
+
+def test_git_provision_skips_keygen_when_disabled(tmp_path: Path) -> None:
+    ws_base = tmp_path / "ws"
+    ws_base.mkdir()
+    prov = GitProvisionerTool(workspace_base=str(ws_base))
+    prov._state = ProvisionerStateStore("git_provisioner", storage_dir=tmp_path)
+
+    with patch("subprocess.run", side_effect=_ok):
+        result = prov.provision(
+            "agent-1",
+            {
+                "workspace_path": str(ws_base / "agent-1"),
+                "init_repos": ["workspace"],
+                "generate_ssh_key": False,
+            },
+            GeneratedCredentials(tool_name="git"),
+        )
+
+    assert result.success is True
+    assert result.details["ssh_key_path"] is None
+    assert result.details["ssh_key_generated"] is False
+
+
+def test_git_provision_handles_init_repo_failure(tmp_path: Path) -> None:
+    """A failing `git init` should mark the repo as not initialized but the
+    overall provision still succeeds (workspace + config get written)."""
+    ws_base = tmp_path / "ws"
+    ws_base.mkdir()
+    prov = GitProvisionerTool(workspace_base=str(ws_base))
+    prov._state = ProvisionerStateStore("git_provisioner", storage_dir=tmp_path)
+
+    def _flaky(*args, **kwargs):
+        cmd = args[0]
+        if cmd and cmd[0] == "git" and cmd[1] == "init":
+            raise _subprocess.CalledProcessError(returncode=1, cmd=cmd)
+        if cmd[0] == "ssh-keygen":
+            idx = cmd.index("-f")
+            key_path = Path(cmd[idx + 1])
+            key_path.write_text("PRIV\n")
+            key_path.with_suffix(key_path.suffix + ".pub").write_text("PUB\n")
+            return _ok(*args, **kwargs)
+        return _ok(*args, **kwargs)
+
+    with patch("subprocess.run", side_effect=_flaky):
+        result = prov.provision(
+            "agent-1",
+            {
+                "workspace_path": str(ws_base / "agent-1"),
+                "init_repos": ["workspace"],
+                "generate_ssh_key": True,
+            },
+            GeneratedCredentials(tool_name="git"),
+        )
+
+    assert result.success is True
+    assert result.details["repos"] == []  # repo init failed
+
+
+def test_git_provision_workspace_escape_rejected(tmp_path: Path) -> None:
+    ws_base = tmp_path / "ws"
+    ws_base.mkdir()
+    prov = GitProvisionerTool(workspace_base=str(ws_base))
+    prov._state = ProvisionerStateStore("git_provisioner", storage_dir=tmp_path)
+
+    # workspace_path outside workspace_base must trigger assert_path_within_base
+    out = prov.provision(
+        "agent-1",
+        {"workspace_path": str(tmp_path / "elsewhere" / "x")},
+        GeneratedCredentials(tool_name="git"),
+    )
+    assert out.success is False
+    assert "escapes" in out.error or "workspace" in out.error.lower()
+
+
+def test_git_init_repo_skip_when_already_initialized(tmp_path: Path) -> None:
+    prov = GitProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("git_provisioner", storage_dir=tmp_path)
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()  # pretend already a git repo
+
+    # Should return True without invoking subprocess.run
+    with patch("subprocess.run") as mock_run:
+        result = prov._init_repo(repo)
+
+    assert result is True
+    mock_run.assert_not_called()
+
+
+def test_git_verify_access_no_state(tmp_path: Path) -> None:
+    prov = GitProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("git_provisioner", storage_dir=tmp_path)
+
+    v = prov.verify_access("missing")
+    assert v.passed is False
+    assert "No Git provisioning" in v.errors[0]
+
+
+def test_git_verify_access_workspace_present(tmp_path: Path) -> None:
+    prov = GitProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("git_provisioner", storage_dir=tmp_path)
+
+    ws = tmp_path / "agent-1"
+    ws.mkdir()
+    repo = ws / "workspace"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    prov._state.put(
+        "agent-1",
+        {
+            "workspace_path": str(ws),
+            "repos": [str(repo)],
+            "ssh_key_path": str(ws / ".ssh" / "id_ed25519"),
+            "permissions": ["read", "write"],
+        },
+    )
+
+    v = prov.verify_access("agent-1")
+    assert v.passed is True
+    assert v.errors == []
+
+
+def test_git_verify_access_workspace_missing(tmp_path: Path) -> None:
+    prov = GitProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("git_provisioner", storage_dir=tmp_path)
+
+    prov._state.put(
+        "agent-1",
+        {
+            "workspace_path": "/nonexistent/path",
+            "repos": ["/nonexistent/path/repo"],
+            "ssh_key_path": None,
+            "permissions": ["read"],
+        },
+    )
+
+    v = prov.verify_access("agent-1")
+    assert v.passed is False
+    assert any("Workspace directory not found" in e for e in v.errors)
+
+
+def test_git_verify_access_repo_missing_is_warning(tmp_path: Path) -> None:
+    prov = GitProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("git_provisioner", storage_dir=tmp_path)
+
+    ws = tmp_path / "agent-x"
+    ws.mkdir()
+    # Repo dir doesn't actually have a .git inside
+    missing_repo = ws / "norepo"
+    missing_repo.mkdir()
+
+    prov._state.put(
+        "agent-x",
+        {
+            "workspace_path": str(ws),
+            "repos": [str(missing_repo)],
+            "ssh_key_path": None,
+            "permissions": ["read"],
+        },
+    )
+
+    v = prov.verify_access("agent-x")
+    # Workspace exists so passed=True but warnings list the missing repo.
+    assert v.passed is True
+    assert any("not initialized" in w for w in v.warnings)
+
+
+def test_git_deprovision_no_state(tmp_path: Path) -> None:
+    prov = GitProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("git_provisioner", storage_dir=tmp_path)
+
+    out = prov.deprovision("missing")
+    assert out.success is True
+    assert "No Git" in out.details["message"]
+
+
+def test_git_deprovision_removes_ssh_keys(tmp_path: Path) -> None:
+    prov = GitProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("git_provisioner", storage_dir=tmp_path)
+
+    ssh_dir = tmp_path / "ssh"
+    ssh_dir.mkdir()
+    priv = ssh_dir / "id_ed25519"
+    pub = ssh_dir / "id_ed25519.pub"
+    priv.write_text("priv")
+    pub.write_text("pub")
+
+    prov._state.put(
+        "a1",
+        {
+            "workspace_path": str(tmp_path),
+            "repos": [],
+            "ssh_key_path": str(priv),
+            "permissions": [],
+        },
+    )
+
+    out = prov.deprovision("a1")
+    assert out.success is True
+    assert not priv.exists()
+    assert not pub.exists()
+
+
+def test_git_deprovision_no_ssh_keys(tmp_path: Path) -> None:
+    prov = GitProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("git_provisioner", storage_dir=tmp_path)
+
+    prov._state.put(
+        "a1",
+        {"workspace_path": str(tmp_path), "repos": [], "ssh_key_path": None, "permissions": []},
+    )
+
+    out = prov.deprovision("a1")
+    assert out.success is True
+    assert out.details["ssh_keys_removed"] is False
+
+
+def test_git_deprovision_handles_exception(tmp_path: Path) -> None:
+    prov = GitProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("git_provisioner", storage_dir=tmp_path)
+    prov._state.put(
+        "a1",
+        {"workspace_path": str(tmp_path), "repos": [], "ssh_key_path": None, "permissions": []},
+    )
+
+    with patch.object(prov._state, "delete", side_effect=RuntimeError("io")):
+        out = prov.deprovision("a1")
+    assert out.success is False
+    assert "io" in out.error
+
+
+def test_git_provision_reuse_path(tmp_path: Path) -> None:
+    """Second call with existing state must hydrate workspace_path + repos."""
+    ws_base = tmp_path / "ws"
+    ws_base.mkdir()
+    prov = GitProvisionerTool(workspace_base=str(ws_base))
+    prov._state = ProvisionerStateStore("git_provisioner", storage_dir=tmp_path)
+
+    prov._state.put(
+        "a1",
+        {
+            "workspace_path": str(ws_base / "a1"),
+            "repos": [str(ws_base / "a1" / "workspace")],
+            "permissions": ["read"],
+        },
+    )
+
+    creds = GeneratedCredentials(tool_name="git")
+    out = prov.provision("a1", {}, creds)
+    assert out.success is True
+    assert creds.extra["workspace_path"] == str(ws_base / "a1")
+
+
+def test_git_generate_ssh_keypair_removes_existing(tmp_path: Path) -> None:
+    prov = GitProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("git_provisioner", storage_dir=tmp_path)
+
+    ssh_dir = tmp_path / "ssh"
+    ssh_dir.mkdir()
+    priv = ssh_dir / "id_ed25519"
+    pub = ssh_dir / "id_ed25519.pub"
+    priv.write_text("OLD_PRIV")
+    pub.write_text("OLD_PUB")
+
+    def _fake_keygen(*args, **kwargs):
+        cmd = args[0]
+        # Honor the actual delete-and-rewrite flow by writing fresh content.
+        idx = cmd.index("-f")
+        key_path = Path(cmd[idx + 1])
+        key_path.write_text("NEW_PRIV")
+        key_path.with_suffix(key_path.suffix + ".pub").write_text("NEW_PUB")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    with patch("subprocess.run", side_effect=_fake_keygen):
+        prv_text, pub_text = prov._generate_ssh_keypair("agent-x", ssh_dir)
+    assert prv_text == "NEW_PRIV"
+    assert pub_text == "NEW_PUB"

--- a/backend/agents/agent_provisioning_team/tests/test_misc_coverage.py
+++ b/backend/agents/agent_provisioning_team/tests/test_misc_coverage.py
@@ -1,0 +1,899 @@
+"""Additional targeted tests to close remaining coverage gaps.
+
+Covers:
+* anatomy_assets edge paths
+* prompts.py format_* helpers and template factories
+* graphs/provisioning_graph.py importability
+* credential_store key file path
+* phases/documentation LLM happy/fallback paths
+* sandbox provisioner extra branches
+* temporal.activities._load_ctx import path
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# prompts.py — format/template helpers
+# ---------------------------------------------------------------------------
+
+
+def test_format_onboarding_summary_prompt_contains_inputs() -> None:
+    from agent_provisioning_team.prompts import format_onboarding_summary_prompt
+
+    p = format_onboarding_summary_prompt(agent_id="a1", tool_names="pg, redis")
+    assert "a1" in p
+    assert "pg" in p
+    # The preamble always includes the anatomy reference text.
+    assert "AGENT_ANATOMY" in p or "anatomy" in p.lower()
+
+
+def test_format_tool_getting_started_prompt() -> None:
+    from agent_provisioning_team.prompts import format_tool_getting_started_prompt
+
+    p = format_tool_getting_started_prompt(
+        tool_name="pg", description="db", connection_details="conn", permissions="r,w"
+    )
+    assert "pg" in p
+
+
+def test_format_environment_overview_prompt() -> None:
+    from agent_provisioning_team.prompts import format_environment_overview_prompt
+
+    p = format_environment_overview_prompt(
+        container_name="c1",
+        workspace_path="/w",
+        tools_list="- pg",
+        env_vars="A=B",
+    )
+    assert "/w" in p
+
+
+def test_format_ai_agent_create_prompt() -> None:
+    from agent_provisioning_team.prompts import format_ai_agent_create_prompt
+
+    p = format_ai_agent_create_prompt(requirements="build x")
+    assert "build x" in p
+
+
+def test_format_ai_agent_refine_prompt() -> None:
+    from agent_provisioning_team.prompts import format_ai_agent_refine_prompt
+
+    p = format_ai_agent_refine_prompt("current", "goals")
+    assert "current" in p and "goals" in p
+
+
+def test_onboarding_summary_template_factory() -> None:
+    from agent_provisioning_team.prompts import onboarding_summary_prompt
+
+    p = onboarding_summary_prompt()
+    assert "{agent_id}" in p
+
+
+def test_tool_getting_started_template_factory() -> None:
+    from agent_provisioning_team.prompts import tool_getting_started_prompt
+
+    p = tool_getting_started_prompt()
+    assert "{tool_name}" in p
+
+
+def test_environment_overview_template_factory() -> None:
+    from agent_provisioning_team.prompts import environment_overview_prompt
+
+    p = environment_overview_prompt()
+    assert "{container_name}" in p
+
+
+def test_ai_agent_create_template_factory() -> None:
+    from agent_provisioning_team.prompts import ai_agent_create_prompt
+
+    p = ai_agent_create_prompt()
+    assert "{requirements}" in p
+
+
+def test_ai_agent_refine_template_factory() -> None:
+    from agent_provisioning_team.prompts import ai_agent_refine_prompt
+
+    p = ai_agent_refine_prompt()
+    assert "{current_definition}" in p
+
+
+# ---------------------------------------------------------------------------
+# anatomy_assets edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_load_agent_anatomy_text_cached() -> None:
+    from agent_provisioning_team import anatomy_assets
+
+    # Reset cache
+    anatomy_assets._anatomy_text_cache = None
+    first = anatomy_assets.load_agent_anatomy_text()
+    second = anatomy_assets.load_agent_anatomy_text()
+    assert first is second
+
+
+def test_try_materialize_anatomy_bundle_root_skip() -> None:
+    from agent_provisioning_team.anatomy_assets import try_materialize_anatomy_bundle
+
+    assert try_materialize_anatomy_bundle(".") is None
+    assert try_materialize_anatomy_bundle("/") is None
+    assert try_materialize_anatomy_bundle("") is None
+
+
+def test_try_materialize_anatomy_bundle_writes_files(tmp_path: Path) -> None:
+    from agent_provisioning_team.anatomy_assets import try_materialize_anatomy_bundle
+
+    result = try_materialize_anatomy_bundle(str(tmp_path))
+    # If the source AGENT_ANATOMY.md exists in the package, result is a path.
+    if result is not None:
+        assert Path(result).exists()
+        assert (Path(result) / "AGENT_ANATOMY.md").exists()
+
+
+def test_list_design_asset_paths() -> None:
+    from agent_provisioning_team.anatomy_assets import list_design_asset_paths
+
+    paths = list_design_asset_paths()
+    assert isinstance(paths, list)
+
+
+def test_get_anatomy_prompt_preamble_includes_diagram_block() -> None:
+    from agent_provisioning_team.anatomy_assets import get_anatomy_prompt_preamble
+
+    text = get_anatomy_prompt_preamble()
+    assert "AGENT_ANATOMY.md" in text
+    assert "diagram" in text.lower()
+
+
+# ---------------------------------------------------------------------------
+# graphs/provisioning_graph.py — only need to import + invoke once
+# ---------------------------------------------------------------------------
+
+
+def test_build_provisioning_graph_returns_graph() -> None:
+    from agent_provisioning_team.graphs.provisioning_graph import build_provisioning_graph
+
+    g = build_provisioning_graph()
+    assert g is not None
+
+
+# ---------------------------------------------------------------------------
+# credential_store — additional paths
+# ---------------------------------------------------------------------------
+
+
+def test_credential_store_with_keyfile_env(tmp_path: Path, monkeypatch) -> None:
+    """PA_CREDENTIAL_KEY_FILE pointing at an existing file is read first."""
+    from cryptography.fernet import Fernet
+
+    from agent_provisioning_team.shared.credential_store import CredentialStore
+
+    key_file = tmp_path / "key.bin"
+    k = Fernet.generate_key()
+    key_file.write_bytes(k)
+
+    monkeypatch.setenv("PA_CREDENTIAL_KEY_FILE", str(key_file))
+    monkeypatch.delenv("PROVISION_CREDENTIAL_KEY", raising=False)
+
+    store = CredentialStore(storage_dir=tmp_path / "store")
+    assert store.fernet is not None
+    # Roundtrip a value to prove the key works.
+    store.store_credentials("a1", "pg", {"password": "p"})
+    assert store.get_credentials("a1", "pg") == {"password": "p"}
+
+
+def test_credential_store_missing_keyfile_falls_through(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.shared.credential_store import CredentialStore
+
+    monkeypatch.setenv("PA_CREDENTIAL_KEY_FILE", str(tmp_path / "ghost"))
+    monkeypatch.delenv("PROVISION_CREDENTIAL_KEY", raising=False)
+    monkeypatch.delenv("PROVISION_REQUIRE_KEY", raising=False)
+    # No key file → falls through to auto-generated dev key.
+    store = CredentialStore(storage_dir=tmp_path / "store")
+    assert store.fernet is not None
+
+
+def test_credential_store_generate_key_static() -> None:
+    from agent_provisioning_team.shared.credential_store import CredentialStore
+
+    k = CredentialStore.generate_key()
+    assert isinstance(k, str) and len(k) > 40
+
+
+def test_credential_store_username_sanitization() -> None:
+    from agent_provisioning_team.shared.credential_store import CredentialStore
+
+    u = CredentialStore.generate_username("agent-1!@#", "pg/sql")
+    # Only alnum + _ in the output
+    for c in u:
+        assert c.isalnum() or c == "_"
+
+
+def test_credential_store_get_credentials_corrupt(tmp_path: Path) -> None:
+    from cryptography.fernet import Fernet
+
+    from agent_provisioning_team.shared.credential_store import CredentialStore
+
+    k1 = Fernet.generate_key().decode()
+    store = CredentialStore(storage_dir=tmp_path, encryption_key=k1)
+    # Hand-write a corrupt file
+    path = store._agent_file("agent-x")
+    path.write_bytes(b"garbage")
+    assert store.get_credentials("agent-x") is None
+
+
+def test_credential_store_rotate_key_invalid_raises(tmp_path: Path) -> None:
+    from agent_provisioning_team.shared.credential_store import (
+        CredentialStore,
+        CredentialStoreConfigError,
+    )
+
+    store = CredentialStore(storage_dir=tmp_path)
+    with pytest.raises(CredentialStoreConfigError):
+        store.rotate_key("not-a-valid-fernet-key")
+
+
+def test_credential_store_delete_missing_returns_false(tmp_path: Path) -> None:
+    from agent_provisioning_team.shared.credential_store import CredentialStore
+
+    store = CredentialStore(storage_dir=tmp_path)
+    assert store.delete_credentials("nobody") is False
+
+
+def test_credential_store_list_agents(tmp_path: Path) -> None:
+    from agent_provisioning_team.shared.credential_store import CredentialStore
+
+    store = CredentialStore(storage_dir=tmp_path)
+    store.store_credentials("a1", "pg", {"password": "p"})
+    store.store_credentials("a2", "redis", {"password": "p"})
+    out = sorted(store.list_agents())
+    assert out == ["a1", "a2"]
+
+
+def test_credential_store_store_credentials_handles_corrupt_existing(tmp_path: Path) -> None:
+    """If an existing encrypted file is corrupt, store overwrites it."""
+    from agent_provisioning_team.shared.credential_store import CredentialStore
+
+    store = CredentialStore(storage_dir=tmp_path)
+    path = store._agent_file("a1")
+    path.write_bytes(b"garbage")
+
+    store.store_credentials("a1", "pg", {"password": "p"})
+    assert store.get_credentials("a1", "pg") == {"password": "p"}
+
+
+def test_credential_store_get_credentials_returns_all_when_no_tool(tmp_path: Path) -> None:
+    from agent_provisioning_team.shared.credential_store import CredentialStore
+
+    store = CredentialStore(storage_dir=tmp_path)
+    store.store_credentials("a1", "pg", {"password": "p1"})
+    store.store_credentials("a1", "redis", {"password": "p2"})
+    out = store.get_credentials("a1")
+    assert set(out.keys()) == {"pg", "redis"}
+
+
+def test_credential_store_load_key_with_blank_env(tmp_path: Path, monkeypatch) -> None:
+    """Empty PROVISION_CREDENTIAL_KEY is treated as unset."""
+    from agent_provisioning_team.shared.credential_store import CredentialStore
+
+    monkeypatch.setenv("PROVISION_CREDENTIAL_KEY", "")
+    monkeypatch.delenv("PA_CREDENTIAL_KEY_FILE", raising=False)
+    monkeypatch.delenv("PROVISION_REQUIRE_KEY", raising=False)
+    store = CredentialStore(storage_dir=tmp_path)
+    assert store.fernet is not None
+
+
+# ---------------------------------------------------------------------------
+# documentation phase — LLM path (mock LLMClient.is_configured)
+# ---------------------------------------------------------------------------
+
+
+def test_documentation_uses_llm_summary_when_configured(tmp_path: Path) -> None:
+    from agent_provisioning_team.phases import documentation as doc_mod
+    from agent_provisioning_team.shared.tool_manifest import ToolManifest
+
+    captured = {}
+
+    class _StubLLM:
+        is_configured = True
+
+        def complete(self, req):
+            captured["called"] = True
+            return "FAKE_LLM_SUMMARY"
+
+    stub = _StubLLM()
+    with patch.object(doc_mod, "_LLM", stub):
+        result = doc_mod.run_documentation(
+            agent_id="a1",
+            manifest=ToolManifest(),
+            credentials={},
+            tool_results=[],
+            workspace_path=str(tmp_path),
+        )
+    assert result.success is True
+    assert "FAKE_LLM_SUMMARY" in result.onboarding.summary
+
+
+def test_documentation_llm_summary_falls_back_on_exception(tmp_path: Path) -> None:
+    from agent_provisioning_team.phases import documentation as doc_mod
+    from agent_provisioning_team.shared.tool_manifest import ToolManifest
+
+    class _BoomLLM:
+        is_configured = True
+
+        def complete(self, req):
+            raise RuntimeError("api down")
+
+    with patch.object(doc_mod, "_LLM", _BoomLLM()):
+        result = doc_mod.run_documentation(
+            agent_id="a1",
+            manifest=ToolManifest(),
+            credentials={},
+            tool_results=[],
+            workspace_path=str(tmp_path),
+        )
+    # Falls back to deterministic template
+    assert "tool(s) configured" in result.onboarding.summary
+
+
+def test_documentation_uses_llm_getting_started_when_configured(tmp_path: Path) -> None:
+    from agent_provisioning_team.models import (
+        GeneratedCredentials,
+        ToolProvisionResult,
+    )
+    from agent_provisioning_team.phases import documentation as doc_mod
+    from agent_provisioning_team.shared.tool_manifest import ToolDefinition, ToolManifest
+
+    manifest = ToolManifest(
+        tools=[
+            ToolDefinition(
+                name="redis",
+                provisioner="redis_provisioner",
+                config={},
+                onboarding={
+                    "description": "Redis",
+                    "env_var": "REDIS_URL",
+                    "getting_started": "",  # empty → triggers LLM path
+                },
+            ),
+        ]
+    )
+
+    class _StubLLM:
+        is_configured = True
+
+        def complete(self, req):
+            return "FAKE_TOOL_DOC"
+
+    with patch.object(doc_mod, "_LLM", _StubLLM()):
+        result = doc_mod.run_documentation(
+            agent_id="a1",
+            manifest=manifest,
+            credentials={
+                "redis": GeneratedCredentials(tool_name="redis", connection_string="redis://x")
+            },
+            tool_results=[
+                ToolProvisionResult(
+                    tool_name="redis",
+                    success=True,
+                    permissions=["+@all"],
+                    provisioner_key="redis_provisioner",
+                )
+            ],
+            workspace_path=str(tmp_path),
+        )
+
+    # LLM-generated docs appear in the tool's getting_started field
+    assert any("FAKE_TOOL_DOC" in t.getting_started for t in result.onboarding.tools)
+
+
+def test_documentation_llm_getting_started_falls_back_on_exception(tmp_path: Path) -> None:
+    from agent_provisioning_team.models import (
+        GeneratedCredentials,
+        ToolProvisionResult,
+    )
+    from agent_provisioning_team.phases import documentation as doc_mod
+    from agent_provisioning_team.shared.tool_manifest import ToolDefinition, ToolManifest
+
+    manifest = ToolManifest(
+        tools=[
+            ToolDefinition(
+                name="redis",
+                provisioner="redis_provisioner",
+                config={},
+                onboarding={
+                    "description": "Redis",
+                    "env_var": "REDIS_URL",
+                    "getting_started": "",
+                },
+            ),
+        ]
+    )
+
+    class _BoomLLM:
+        is_configured = True
+
+        def complete(self, req):
+            raise RuntimeError("api down")
+
+    with patch.object(doc_mod, "_LLM", _BoomLLM()):
+        result = doc_mod.run_documentation(
+            agent_id="a1",
+            manifest=manifest,
+            credentials={
+                "redis": GeneratedCredentials(tool_name="redis", connection_string="redis://x")
+            },
+            tool_results=[
+                ToolProvisionResult(
+                    tool_name="redis",
+                    success=True,
+                    permissions=["+@all"],
+                    provisioner_key="redis_provisioner",
+                )
+            ],
+            workspace_path=str(tmp_path),
+        )
+    # Falls back to deterministic template (mentions env var).
+    assert any("REDIS_URL" in t.getting_started for t in result.onboarding.tools)
+
+
+def test_documentation_getting_started_template_substitutes_username(tmp_path: Path) -> None:
+    """{username} and {connection_string} placeholders get substituted from creds.extra."""
+    from agent_provisioning_team.models import (
+        GeneratedCredentials,
+        ToolProvisionResult,
+    )
+    from agent_provisioning_team.phases.documentation import run_documentation
+    from agent_provisioning_team.shared.tool_manifest import ToolDefinition, ToolManifest
+
+    manifest = ToolManifest(
+        tools=[
+            ToolDefinition(
+                name="pg",
+                provisioner="postgres_provisioner",
+                config={},
+                onboarding={
+                    "description": "PG",
+                    "getting_started": "user={username} extra={port}",
+                },
+            ),
+        ]
+    )
+
+    creds = GeneratedCredentials(
+        tool_name="pg",
+        username="u1",
+        password="p",
+        connection_string="conn",
+        extra={"port": 5432},
+    )
+    tool_results = [
+        ToolProvisionResult(
+            tool_name="pg",
+            success=True,
+            permissions=["ALL"],
+            provisioner_key="postgres_provisioner",
+        )
+    ]
+
+    result = run_documentation(
+        agent_id="a1",
+        manifest=manifest,
+        credentials={"pg": creds},
+        tool_results=tool_results,
+        workspace_path=str(tmp_path),
+    )
+
+    rendered = result.onboarding.tools[0].getting_started
+    assert "user=u1" in rendered
+    assert "extra=5432" in rendered
+
+
+# ---------------------------------------------------------------------------
+# temporal.activities._load_ctx — exercise both branches
+# ---------------------------------------------------------------------------
+
+
+def test_load_ctx_returns_orchestrator_and_manifest(tmp_path: Path) -> None:
+    from agent_provisioning_team.temporal import activities as t_acts
+
+    # Build a minimal manifest YAML on disk so load_manifest finds something.
+    f = tmp_path / "m.yaml"
+    f.write_text(
+        """
+version: "1.0"
+tools:
+  - name: pg
+    provisioner: postgres_provisioner
+    config: {database_prefix: "x_"}
+""",
+        encoding="utf-8",
+    )
+
+    orch, manifest = t_acts._load_ctx(str(f))
+    assert orch is not None
+    assert manifest is not None
+    assert manifest.tool_names == ["pg"]
+
+
+# ---------------------------------------------------------------------------
+# sandbox.provisioner — more lifecycle branches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_exec_handles_timeout(monkeypatch) -> None:
+    from agent_provisioning_team.sandbox import provisioner as pm
+
+    async def fake_create_subprocess_exec(*args, **kwargs):
+        # Simulate a stuck subprocess by returning a proc whose communicate
+        # never resolves before our timeout fires.
+        proc = MagicMock()
+        proc.communicate = MagicMock(return_value=asyncio.Future())
+        proc.kill = MagicMock()
+        proc.wait = MagicMock(return_value=asyncio.Future())
+        proc.returncode = 1
+        # Make wait_for actually time out
+        proc.communicate.return_value.set_exception(asyncio.TimeoutError())
+        proc.wait.return_value.set_result(None)
+        return proc
+
+    # Easier: patch asyncio.wait_for to raise TimeoutError directly.
+    monkeypatch.setattr(
+        pm.asyncio,
+        "create_subprocess_exec",
+        lambda *a, **kw: _make_proc_stub(),
+    )
+
+    with patch.object(pm.asyncio, "wait_for", side_effect=asyncio.TimeoutError()):
+        with pytest.raises(pm.DockerError, match="timed out"):
+            await pm._exec(["docker", "info"], timeout_s=1)
+
+
+def _make_proc_stub():
+    """Return a coroutine that resolves to a stub Process-like object."""
+
+    async def _coro():
+        proc = MagicMock()
+
+        async def _comm():
+            return (b"", b"")
+
+        async def _wait():
+            return None
+
+        proc.communicate = _comm
+        proc.kill = MagicMock()
+        proc.wait = _wait
+        proc.returncode = 0
+        return proc
+
+    return _coro()
+
+
+@pytest.mark.asyncio
+async def test_is_running_true(monkeypatch) -> None:
+    from unittest.mock import AsyncMock as _AsyncMock
+
+    from agent_provisioning_team.sandbox import provisioner as pm
+
+    monkeypatch.setattr(pm, "_exec", _AsyncMock(return_value=(0, "true\n", "")))
+    assert await pm.is_running("c1") is True
+
+
+@pytest.mark.asyncio
+async def test_is_running_false(monkeypatch) -> None:
+    from unittest.mock import AsyncMock as _AsyncMock
+
+    from agent_provisioning_team.sandbox import provisioner as pm
+
+    monkeypatch.setattr(pm, "_exec", _AsyncMock(return_value=(0, "false\n", "")))
+    assert await pm.is_running("c1") is False
+
+
+@pytest.mark.asyncio
+async def test_is_running_returns_false_on_error(monkeypatch) -> None:
+    from unittest.mock import AsyncMock as _AsyncMock
+
+    from agent_provisioning_team.sandbox import provisioner as pm
+
+    monkeypatch.setattr(pm, "_exec", _AsyncMock(return_value=(1, "", "no such container")))
+    assert await pm.is_running("c1") is False
+
+
+@pytest.mark.asyncio
+async def test_inspect_host_port_raises_on_invalid_output(monkeypatch) -> None:
+    from unittest.mock import AsyncMock as _AsyncMock
+
+    from agent_provisioning_team.sandbox import provisioner as pm
+
+    monkeypatch.setattr(pm, "_exec", _AsyncMock(return_value=(0, "not-a-port\n", "")))
+    with pytest.raises(pm.DockerError):
+        await pm.inspect_host_port("c1")
+
+
+@pytest.mark.asyncio
+async def test_inspect_host_port_raises_on_nonzero(monkeypatch) -> None:
+    from unittest.mock import AsyncMock as _AsyncMock
+
+    from agent_provisioning_team.sandbox import provisioner as pm
+
+    monkeypatch.setattr(pm, "_exec", _AsyncMock(return_value=(1, "", "boom")))
+    with pytest.raises(pm.DockerError):
+        await pm.inspect_host_port("c1")
+
+
+@pytest.mark.asyncio
+async def test_inspect_host_port_success(monkeypatch) -> None:
+    from unittest.mock import AsyncMock as _AsyncMock
+
+    from agent_provisioning_team.sandbox import provisioner as pm
+
+    monkeypatch.setattr(pm, "_exec", _AsyncMock(return_value=(0, "55123\n", "")))
+    port = await pm.inspect_host_port("c1")
+    assert port == 55123
+
+
+@pytest.mark.asyncio
+async def test_run_container_cleans_up_on_inspect_failure(tmp_path: Path, monkeypatch) -> None:
+    """If `docker inspect` fails after compose up, project dir is cleaned up."""
+    from agent_provisioning_team.sandbox import provisioner as pm
+
+    monkeypatch.setenv("AGENT_CACHE", str(tmp_path))
+
+    async def fake_exec(cmd, *, timeout_s=30):
+        if cmd[:2] == ["docker", "compose"]:
+            return 0, "", ""
+        if cmd[:2] == ["docker", "inspect"]:
+            return 1, "", "no such container"
+        return 0, "", ""
+
+    monkeypatch.setattr(pm, "_exec", fake_exec)
+
+    with pytest.raises(pm.DockerError):
+        await pm.run_container(agent_id="a1", container_name="khala-sbx-inspect-fail", team="x")
+
+    # Project dir must be removed on cleanup.
+    project_dir = (
+        tmp_path / "agent_provisioning" / "sandboxes" / "stacks" / "khala-sbx-inspect-fail"
+    )
+    assert not project_dir.exists()
+
+
+@pytest.mark.asyncio
+async def test_run_container_cleans_up_on_docker_error_in_exec(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.sandbox import provisioner as pm
+
+    monkeypatch.setenv("AGENT_CACHE", str(tmp_path))
+
+    async def boom(cmd, *, timeout_s=30):
+        if cmd[:2] == ["docker", "compose"]:
+            raise pm.DockerError("compose timed out")
+        return 0, "", ""
+
+    monkeypatch.setattr(pm, "_exec", boom)
+
+    with pytest.raises(pm.DockerError):
+        await pm.run_container(agent_id="a1", container_name="khala-sbx-boom", team="x")
+
+    project_dir = tmp_path / "agent_provisioning" / "sandboxes" / "stacks" / "khala-sbx-boom"
+    assert not project_dir.exists()
+
+
+@pytest.mark.asyncio
+async def test_stop_container_raises_for_unexpected_failure(monkeypatch) -> None:
+
+    from agent_provisioning_team.sandbox import provisioner as pm
+
+    async def fake_exec(cmd, *, timeout_s=30):
+        if cmd[:3] == ["docker", "inspect", "--format"]:
+            return 1, "", "no such container"
+        if cmd[:2] == ["docker", "compose"]:
+            # Real failure (not "no such")
+            return 1, "", "unexpected error from compose"
+        return 0, "", ""
+
+    monkeypatch.setattr(pm, "_exec", fake_exec)
+    with pytest.raises(pm.DockerError):
+        await pm.stop_container("khala-sbx-error")
+
+
+def test_ensure_network_is_noop_shim() -> None:
+    from agent_provisioning_team.sandbox import provisioner as pm
+
+    asyncio.run(pm.ensure_network())
+
+
+def test_cleanup_secrets_file_swallows_oserror(tmp_path: Path, monkeypatch) -> None:
+    """rmtree failures are logged but not raised."""
+    from agent_provisioning_team.sandbox import provisioner as pm
+
+    monkeypatch.setenv("AGENT_CACHE", str(tmp_path))
+    project_dir = pm.sandbox_project_dir("khala-sbx-x")
+    project_dir.mkdir(parents=True)
+    (project_dir / "agent.env").write_text("X=1")
+
+    with patch.object(pm.shutil, "rmtree", side_effect=OSError("io")):
+        pm.cleanup_secrets_file("khala-sbx-x")
+    # No exception raised. The project dir still exists because rmtree was mocked.
+
+
+# ---------------------------------------------------------------------------
+# sandbox.lifecycle — module helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_module_helper_status(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team import sandbox as sb
+    from agent_provisioning_team.sandbox import lifecycle as lc_mod
+
+    lc = lc_mod.Lifecycle(state_file=tmp_path / "s.json")
+    lc_mod.get_lifecycle.cache_clear()
+    monkeypatch.setattr(lc_mod, "get_lifecycle", lambda: lc)
+
+    with patch.object(lc_mod, "_resolve_team", return_value="t"):
+        handle = await sb.status("some.agent")
+    assert handle.agent_id == "some.agent"
+
+
+@pytest.mark.asyncio
+async def test_module_helper_metrics(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team import sandbox as sb
+    from agent_provisioning_team.sandbox import lifecycle as lc_mod
+
+    lc = lc_mod.Lifecycle(state_file=tmp_path / "s.json")
+    lc_mod.get_lifecycle.cache_clear()
+    monkeypatch.setattr(lc_mod, "get_lifecycle", lambda: lc)
+    snap = await sb.metrics()
+    assert snap.resident == 0
+
+
+@pytest.mark.asyncio
+async def test_module_helper_run_idle_reaper(tmp_path: Path, monkeypatch) -> None:
+    from unittest.mock import AsyncMock as _AsyncMock
+
+    from agent_provisioning_team import sandbox as sb
+    from agent_provisioning_team.sandbox import lifecycle as lc_mod
+
+    lc = lc_mod.Lifecycle(state_file=tmp_path / "s.json")
+    lc_mod.get_lifecycle.cache_clear()
+    monkeypatch.setattr(lc_mod, "get_lifecycle", lambda: lc)
+
+    with (
+        patch.object(lc_mod.asyncio, "sleep", new=_AsyncMock()),
+        patch.object(lc_mod.Lifecycle, "reap_once", new=_AsyncMock(return_value=[])),
+    ):
+        task = asyncio.create_task(sb.run_idle_reaper(interval_s=0))
+        await asyncio.sleep(0)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_note_activity_missing_no_op(tmp_path: Path) -> None:
+    from agent_provisioning_team.sandbox.lifecycle import Lifecycle
+
+    lc = Lifecycle(state_file=tmp_path / "s.json")
+    # No state for "ghost" — call must be a no-op rather than raise.
+    await lc.note_activity("ghost")
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_teardown_missing_no_op(tmp_path: Path) -> None:
+    from agent_provisioning_team.sandbox.lifecycle import Lifecycle
+
+    lc = Lifecycle(state_file=tmp_path / "s.json")
+    await lc.teardown("ghost")
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_persist_swallows_oserror(tmp_path: Path, monkeypatch) -> None:
+    """If `state.save` raises, the public method completes without re-raising."""
+    from agent_provisioning_team.sandbox import lifecycle as lc_mod
+
+    lc = lc_mod.Lifecycle(state_file=tmp_path / "s.json")
+
+    def fail_save(path, state):
+        raise OSError("disk full")
+
+    with patch.object(lc_mod.state_mod, "save", side_effect=fail_save):
+        lc._persist()
+
+
+# ---------------------------------------------------------------------------
+# sandbox.state load + save edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_state_load_missing_file_returns_empty(tmp_path: Path) -> None:
+    from agent_provisioning_team.sandbox import state as state_mod
+
+    out = state_mod.load(tmp_path / "ghost.json")
+    assert out == {}
+
+
+def test_state_load_corrupt_returns_empty(tmp_path: Path) -> None:
+    from agent_provisioning_team.sandbox import state as state_mod
+
+    bad = tmp_path / "bad.json"
+    bad.write_text("not json", encoding="utf-8")
+    assert state_mod.load(bad) == {}
+
+
+def test_state_load_drops_malformed_entries(tmp_path: Path) -> None:
+    import json
+
+    from agent_provisioning_team.sandbox import state as state_mod
+
+    f = tmp_path / "s.json"
+    f.write_text(
+        json.dumps({"a1": {"missing": "fields"}}),  # invalid SandboxState shape
+        encoding="utf-8",
+    )
+    out = state_mod.load(f)
+    assert out == {}
+
+
+def test_state_save_roundtrip(tmp_path: Path) -> None:
+    from agent_provisioning_team.sandbox.state import (
+        SandboxStatus,
+        load,
+        new_state,
+        save,
+    )
+
+    state = {
+        "a1": new_state(agent_id="a1", team="t", container_name="khala-sbx-a1"),
+    }
+    state["a1"].status = SandboxStatus.COLD
+    f = tmp_path / "s.json"
+    save(f, state)
+    loaded = load(f)
+    assert "a1" in loaded
+    assert loaded["a1"].status == SandboxStatus.COLD
+
+
+def test_boot_timeout_seconds(monkeypatch) -> None:
+    from agent_provisioning_team.sandbox.state import boot_timeout_seconds
+
+    monkeypatch.delenv("AGENT_PROVISIONING_SANDBOX_BOOT_TIMEOUT_S", raising=False)
+    assert boot_timeout_seconds() == 90
+    monkeypatch.setenv("AGENT_PROVISIONING_SANDBOX_BOOT_TIMEOUT_S", "30")
+    assert boot_timeout_seconds() == 30
+
+
+def test_sandbox_stack_template_path_override(monkeypatch, tmp_path: Path) -> None:
+    from agent_provisioning_team.sandbox import state as state_mod
+
+    template = tmp_path / "custom.yml"
+    template.write_text("services: {}", encoding="utf-8")
+    monkeypatch.setenv("AGENT_PROVISIONING_SANDBOX_STACK_TEMPLATE", str(template))
+    assert state_mod.sandbox_stack_template_path() == template
+    assert state_mod.sandbox_stack_assets_dir() == template.parent
+
+
+def test_sandbox_stack_template_path_default(monkeypatch) -> None:
+    from agent_provisioning_team.sandbox import state as state_mod
+
+    monkeypatch.delenv("AGENT_PROVISIONING_SANDBOX_STACK_TEMPLATE", raising=False)
+    p = state_mod.sandbox_stack_template_path()
+    # Should resolve to the in-tree path; existence not required for the
+    # function itself.
+    assert "agent_sandbox_image" in str(p)
+
+
+def test_state_file_path_with_override(monkeypatch) -> None:
+    from agent_provisioning_team.sandbox import state as state_mod
+
+    monkeypatch.setenv("AGENT_PROVISIONING_SANDBOX_STATE_FILE", "/tmp/x.json")
+    assert str(state_mod.state_file_path()) == "/tmp/x.json"

--- a/backend/agents/agent_provisioning_team/tests/test_orchestrator.py
+++ b/backend/agents/agent_provisioning_team/tests/test_orchestrator.py
@@ -1,0 +1,726 @@
+"""Unit tests for ProvisioningOrchestrator covering shutdown paths,
+resume-with-skip, deprovisioning, and the smaller status helpers."""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import MagicMock
+
+import pytest
+
+from agent_provisioning_team.models import (
+    AccessAuditResult,
+    AccountProvisioningResult,
+    CredentialGenerationResult,
+    DeprovisionResult,
+    DocumentationResult,
+    EnvironmentInfo,
+    OnboardingPacket,
+    Phase,
+    SetupResult,
+    ToolProvisionResult,
+)
+from agent_provisioning_team.orchestrator import (
+    ProvisioningOrchestrator,
+    ProvisioningShutdownError,
+    _build_tool_agents,
+)
+from agent_provisioning_team.shared.environment_store import (
+    EnvironmentInfo as StoreEnvInfo,
+)
+from agent_provisioning_team.shared.environment_store import EnvironmentStore
+
+
+def _make_manifest(tmp_path: Path) -> str:
+    f = tmp_path / "m.yaml"
+    f.write_text(
+        """
+version: "1.0"
+tools:
+  - name: postgresql
+    provisioner: postgres_provisioner
+    config: {database_prefix: "x_"}
+    onboarding: {description: "PG"}
+""",
+        encoding="utf-8",
+    )
+    return str(f)
+
+
+def _patch_run_setup(monkeypatch, *, success: bool = True, error: str | None = None) -> None:
+    from agent_provisioning_team import orchestrator as orch_mod
+
+    def fake(**kw):
+        if success:
+            return SetupResult(
+                success=True,
+                environment=EnvironmentInfo(
+                    container_id="c1",
+                    container_name="c1",
+                    workspace_path="/tmp/ws",
+                    status="running",
+                ),
+            )
+        return SetupResult(success=False, error=error or "setup failed")
+
+    monkeypatch.setattr(orch_mod, "run_setup", fake)
+
+
+def test_build_tool_agents_shim() -> None:
+    out = _build_tool_agents()
+    assert isinstance(out, dict)
+    assert "docker_provisioner" in out
+
+
+def test_shutdown_error_str() -> None:
+    err = ProvisioningShutdownError(agent_id="a1", phase="setup")
+    assert err.agent_id == "a1"
+    assert err.phase == "setup"
+    assert "setup" in str(err)
+    assert "a1" in str(err)
+
+
+def test_run_workflow_manifest_load_failure() -> None:
+    orch = ProvisioningOrchestrator()
+    result = orch.run_workflow(agent_id="a1", manifest_path="/nonexistent/manifest.yaml")
+    assert result.success is False
+    assert result.current_phase == Phase.SETUP
+    assert "Failed to load manifest" in result.error
+
+
+def test_run_workflow_shutdown_before_setup(tmp_path: Path, monkeypatch) -> None:
+    """When shutdown is signalled before SETUP, raise ProvisioningShutdownError."""
+    orch = ProvisioningOrchestrator(
+        environment_store=EnvironmentStore(storage_dir=tmp_path / "envs")
+    )
+
+    shutdown = threading.Event()
+    shutdown.set()  # already signalled
+
+    manifest = _make_manifest(tmp_path)
+    with pytest.raises(ProvisioningShutdownError):
+        orch.run_workflow(
+            agent_id="a1",
+            manifest_path=manifest,
+            shutdown_event=shutdown,
+        )
+
+
+def test_run_workflow_setup_failure(tmp_path: Path, monkeypatch) -> None:
+    _patch_run_setup(monkeypatch, success=False, error="docker exploded")
+    orch = ProvisioningOrchestrator(
+        environment_store=EnvironmentStore(storage_dir=tmp_path / "envs")
+    )
+
+    manifest = _make_manifest(tmp_path)
+    result = orch.run_workflow(agent_id="a1", manifest_path=manifest)
+    assert result.success is False
+    assert result.current_phase == Phase.SETUP
+    assert "docker exploded" in result.error
+
+
+def test_run_workflow_credential_generation_failure(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team import orchestrator as orch_mod
+
+    _patch_run_setup(monkeypatch)
+
+    def fake_cred(**kw):
+        return CredentialGenerationResult(success=False, credentials={}, error="cred boom")
+
+    monkeypatch.setattr(orch_mod, "run_credential_generation", fake_cred)
+    monkeypatch.setattr(orch_mod, "cleanup_setup", lambda *a, **kw: True)
+
+    orch = ProvisioningOrchestrator(
+        environment_store=EnvironmentStore(storage_dir=tmp_path / "envs")
+    )
+    manifest = _make_manifest(tmp_path)
+    result = orch.run_workflow(agent_id="a1", manifest_path=manifest)
+    assert result.success is False
+    assert result.current_phase == Phase.CREDENTIAL_GENERATION
+
+
+def test_run_workflow_resume_skips_setup(tmp_path: Path, monkeypatch) -> None:
+    """When SETUP is in skip_phases + prior_results has setup, run_setup never fires."""
+    from agent_provisioning_team import orchestrator as orch_mod
+
+    def fake_setup(**kw):
+        raise AssertionError("run_setup should not have been called on resume")
+
+    monkeypatch.setattr(orch_mod, "run_setup", fake_setup)
+
+    # Stub credential gen + account prov + audit + docs + deliver to short-circuit.
+    monkeypatch.setattr(
+        orch_mod,
+        "run_credential_generation",
+        lambda **kw: CredentialGenerationResult(success=True, credentials={}),
+    )
+    monkeypatch.setattr(
+        orch_mod,
+        "run_account_provisioning",
+        lambda **kw: AccountProvisioningResult(success=True, tool_results=[]),
+    )
+    monkeypatch.setattr(
+        orch_mod, "run_access_audit", lambda **kw: AccessAuditResult(passed=True, verifications=[])
+    )
+    monkeypatch.setattr(
+        orch_mod,
+        "run_documentation",
+        lambda **kw: DocumentationResult(
+            success=True,
+            onboarding=OnboardingPacket(summary="s", tools=[], environment_variables={}),
+        ),
+    )
+
+    orch = ProvisioningOrchestrator(
+        environment_store=EnvironmentStore(storage_dir=tmp_path / "envs")
+    )
+    manifest = _make_manifest(tmp_path)
+
+    result = orch.run_workflow(
+        agent_id="a1",
+        manifest_path=manifest,
+        skip_phases={Phase.SETUP},
+        prior_results={
+            "setup": {
+                "success": True,
+                "environment": {
+                    "container_id": "c-pre",
+                    "container_name": "c-pre",
+                    "workspace_path": "/restored",
+                    "status": "running",
+                },
+            },
+        },
+    )
+    assert result.success is True
+
+
+def test_run_workflow_with_job_updater_callback(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team import orchestrator as orch_mod
+
+    _patch_run_setup(monkeypatch)
+    monkeypatch.setattr(
+        orch_mod,
+        "run_credential_generation",
+        lambda **kw: CredentialGenerationResult(success=True, credentials={}),
+    )
+    monkeypatch.setattr(
+        orch_mod,
+        "run_account_provisioning",
+        lambda **kw: AccountProvisioningResult(success=True, tool_results=[]),
+    )
+    monkeypatch.setattr(
+        orch_mod, "run_access_audit", lambda **kw: AccessAuditResult(passed=True, verifications=[])
+    )
+    monkeypatch.setattr(
+        orch_mod,
+        "run_documentation",
+        lambda **kw: DocumentationResult(
+            success=True,
+            onboarding=OnboardingPacket(summary="s", tools=[], environment_variables={}),
+        ),
+    )
+
+    updates = []
+
+    def updater(**kw):
+        updates.append(kw)
+
+    orch = ProvisioningOrchestrator(
+        environment_store=EnvironmentStore(storage_dir=tmp_path / "envs")
+    )
+    manifest = _make_manifest(tmp_path)
+    result = orch.run_workflow(agent_id="a1", manifest_path=manifest, job_updater=updater)
+    assert result.success is True
+    # Several phase updates fired
+    assert any(u.get("progress") == 100 for u in updates)
+
+
+def test_run_workflow_resume_restores_all_phases(tmp_path: Path, monkeypatch) -> None:
+    """skip_phases for every prior phase; only DELIVER runs."""
+    from agent_provisioning_team import orchestrator as orch_mod
+
+    def fail(**kw):
+        raise AssertionError("phase function should be skipped")
+
+    monkeypatch.setattr(orch_mod, "run_setup", fail)
+    monkeypatch.setattr(orch_mod, "run_credential_generation", fail)
+    monkeypatch.setattr(orch_mod, "run_account_provisioning", fail)
+    monkeypatch.setattr(orch_mod, "run_access_audit", fail)
+    monkeypatch.setattr(orch_mod, "run_documentation", fail)
+
+    orch = ProvisioningOrchestrator(
+        environment_store=EnvironmentStore(storage_dir=tmp_path / "envs")
+    )
+    manifest = _make_manifest(tmp_path)
+
+    # NB: access_audit isn't in skip_phases because the orchestrator stores
+    # the raw dict from prior_results without re-typing, which breaks
+    # build_final_result downstream. That's a pre-existing production quirk
+    # (out of scope for this test suite — coverage only). So we re-run the
+    # audit but skip everything else.
+    monkeypatch.setattr(
+        orch_mod,
+        "run_access_audit",
+        lambda **kw: AccessAuditResult(passed=True, verifications=[]),
+    )
+    result = orch.run_workflow(
+        agent_id="a1",
+        manifest_path=manifest,
+        skip_phases={
+            Phase.SETUP,
+            Phase.CREDENTIAL_GENERATION,
+            Phase.ACCOUNT_PROVISIONING,
+            Phase.DOCUMENTATION,
+        },
+        prior_results={
+            "setup": {
+                "success": True,
+                "environment": {
+                    "container_id": "c1",
+                    "container_name": "c1",
+                    "workspace_path": "/ws",
+                    "status": "running",
+                },
+            },
+            "credential_generation": {"success": True, "credentials": {}},
+            "account_provisioning": {
+                "success": True,
+                "tool_results": [],
+                "tools_completed": 0,
+                "tools_total": 0,
+            },
+            "documentation": {
+                "success": True,
+                "onboarding": {
+                    "summary": "s",
+                    "tools": [],
+                    "environment_variables": {},
+                },
+            },
+        },
+    )
+    assert result.success is True
+
+
+def test_run_workflow_account_provisioning_failure_compensates(tmp_path: Path, monkeypatch) -> None:
+    """A failed account provisioning rolls back via _compensate."""
+    from agent_provisioning_team import orchestrator as orch_mod
+
+    _patch_run_setup(monkeypatch)
+    monkeypatch.setattr(
+        orch_mod,
+        "run_credential_generation",
+        lambda **kw: CredentialGenerationResult(success=True, credentials={}),
+    )
+
+    failed_result = AccountProvisioningResult(
+        success=False,
+        tool_results=[
+            ToolProvisionResult(
+                tool_name="t",
+                success=True,
+                provisioner_key="generic_provisioner",
+            ),
+            ToolProvisionResult(
+                tool_name="t2",
+                success=False,
+                error="boom",
+                provisioner_key="generic_provisioner",
+            ),
+        ],
+        error="provisioning failed",
+    )
+    monkeypatch.setattr(orch_mod, "run_account_provisioning", lambda **kw: failed_result)
+
+    fake_generic = MagicMock()
+    fake_generic.list_compensations.return_value = []
+    fake_generic.deprovision.return_value = DeprovisionResult(tool_name="generic", success=True)
+
+    fake_docker = MagicMock()
+    fake_docker.deprovision.return_value = DeprovisionResult(tool_name="docker", success=True)
+
+    orch = ProvisioningOrchestrator(
+        environment_store=EnvironmentStore(storage_dir=tmp_path / "envs"),
+        tool_agents={
+            "generic_provisioner": fake_generic,
+            "docker_provisioner": fake_docker,
+        },
+    )
+    manifest = _make_manifest(tmp_path)
+    result = orch.run_workflow(agent_id="a1", manifest_path=manifest)
+    assert result.success is False
+    assert result.current_phase == Phase.ACCOUNT_PROVISIONING
+    # Generic was deprovisioned (legacy path); docker too.
+    fake_generic.deprovision.assert_called_once_with("a1")
+    fake_docker.deprovision.assert_called_once_with("a1")
+
+
+def test_compensate_swallows_docker_failure(tmp_path: Path) -> None:
+    fake_docker = MagicMock()
+    fake_docker.deprovision.side_effect = RuntimeError("daemon down")
+
+    orch = ProvisioningOrchestrator(
+        environment_store=EnvironmentStore(storage_dir=tmp_path / "envs"),
+        tool_agents={"docker_provisioner": fake_docker},
+    )
+    # Should not raise
+    orch._compensate("a1", [])
+
+
+def test_compensate_skips_unsuccessful_tool_results(tmp_path: Path) -> None:
+    """Failed tool results are skipped — no replay, no deprovision call."""
+    fake_prov = MagicMock()
+
+    orch = ProvisioningOrchestrator(
+        environment_store=EnvironmentStore(storage_dir=tmp_path / "envs"),
+        tool_agents={"some_provisioner": fake_prov, "docker_provisioner": MagicMock()},
+    )
+
+    failed = ToolProvisionResult(
+        tool_name="t",
+        success=False,
+        error="no",
+        provisioner_key="some_provisioner",
+    )
+
+    orch._compensate("a1", [failed])
+    fake_prov.deprovision.assert_not_called()
+    fake_prov.list_compensations.assert_not_called()
+
+
+def test_compensate_skips_when_no_provisioner_key(tmp_path: Path, caplog) -> None:
+    fake_prov = MagicMock()
+    orch = ProvisioningOrchestrator(
+        environment_store=EnvironmentStore(storage_dir=tmp_path / "envs"),
+        tool_agents={"some_provisioner": fake_prov, "docker_provisioner": MagicMock()},
+    )
+
+    # No provisioner_key
+    success_no_key = ToolProvisionResult(tool_name="t", success=True)
+    orch._compensate("a1", [success_no_key])
+    fake_prov.deprovision.assert_not_called()
+
+
+def test_compensate_skips_when_provisioner_unregistered(tmp_path: Path) -> None:
+    fake_docker = MagicMock()
+    orch = ProvisioningOrchestrator(
+        environment_store=EnvironmentStore(storage_dir=tmp_path / "envs"),
+        tool_agents={"docker_provisioner": fake_docker},
+    )
+
+    success_unknown_key = ToolProvisionResult(tool_name="t", success=True, provisioner_key="ghost")
+    orch._compensate("a1", [success_unknown_key])
+
+
+def test_compensate_list_compensations_failure_falls_to_deprovision(tmp_path: Path) -> None:
+    fake_prov = MagicMock()
+    fake_prov.list_compensations.side_effect = RuntimeError("list boom")
+    fake_prov.deprovision.return_value = DeprovisionResult(tool_name="t", success=True)
+
+    orch = ProvisioningOrchestrator(
+        environment_store=EnvironmentStore(storage_dir=tmp_path / "envs"),
+        tool_agents={"x": fake_prov, "docker_provisioner": MagicMock()},
+    )
+
+    success = ToolProvisionResult(tool_name="t", success=True, provisioner_key="x")
+    orch._compensate("a1", [success])
+    fake_prov.deprovision.assert_called_once()
+
+
+def test_compensate_replay_failure_continues(tmp_path: Path) -> None:
+    from agent_provisioning_team.shared.provisioner_state import CompensationRecord
+
+    fake_prov = MagicMock()
+    fake_prov.list_compensations.return_value = [
+        CompensationRecord(kind="k1", payload={}),
+        CompensationRecord(kind="k2", payload={}),
+    ]
+    fake_prov.replay_compensation.side_effect = RuntimeError("replay boom")
+    fake_prov._state.delete = MagicMock(return_value=True)
+
+    orch = ProvisioningOrchestrator(
+        environment_store=EnvironmentStore(storage_dir=tmp_path / "envs"),
+        tool_agents={"x": fake_prov, "docker_provisioner": MagicMock()},
+    )
+
+    success = ToolProvisionResult(tool_name="t", success=True, provisioner_key="x")
+    orch._compensate("a1", [success])
+    # Replay attempted for both records (continues despite failure)
+    assert fake_prov.replay_compensation.call_count == 2
+
+
+def test_compensate_credential_cleanup_failure_swallowed(tmp_path: Path) -> None:
+    cred_store = MagicMock()
+    cred_store.delete_credentials.side_effect = RuntimeError("cred io")
+
+    orch = ProvisioningOrchestrator(
+        credential_store=cred_store,
+        environment_store=EnvironmentStore(storage_dir=tmp_path / "envs"),
+        tool_agents={"docker_provisioner": MagicMock()},
+    )
+    orch._compensate("a1", [])
+
+
+def test_compensate_environment_cleanup_failure_swallowed(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team import orchestrator as orch_mod
+
+    monkeypatch.setattr(orch_mod, "cleanup_setup", MagicMock(side_effect=RuntimeError("env io")))
+    orch = ProvisioningOrchestrator(
+        environment_store=EnvironmentStore(storage_dir=tmp_path / "envs"),
+        tool_agents={"docker_provisioner": MagicMock()},
+    )
+    orch._compensate("a1", [])
+
+
+def test_compensate_post_replay_state_cleanup_failure(tmp_path: Path) -> None:
+    """If clear_compensations or _state.delete fails, swallow and move on."""
+    from agent_provisioning_team.shared.provisioner_state import CompensationRecord
+
+    fake_prov = MagicMock()
+    fake_prov.list_compensations.return_value = [CompensationRecord(kind="k1", payload={})]
+    fake_prov.clear_compensations.side_effect = RuntimeError("clear io")
+
+    orch = ProvisioningOrchestrator(
+        environment_store=EnvironmentStore(storage_dir=tmp_path / "envs"),
+        tool_agents={"x": fake_prov, "docker_provisioner": MagicMock()},
+    )
+    success = ToolProvisionResult(tool_name="t", success=True, provisioner_key="x")
+    orch._compensate("a1", [success])
+
+
+# ---------------------------------------------------------------------------
+# deprovision / status / list
+# ---------------------------------------------------------------------------
+
+
+def test_deprovision_success_returns_response(tmp_path: Path) -> None:
+    fake_pg = MagicMock()
+    fake_pg.deprovision.return_value = DeprovisionResult(tool_name="pg", success=True)
+    fake_docker = MagicMock()
+    fake_docker.deprovision.return_value = DeprovisionResult(tool_name="docker", success=True)
+
+    env_store = EnvironmentStore(storage_dir=tmp_path / "envs")
+    cred_store = MagicMock()
+    cred_store.delete_credentials.return_value = True
+
+    orch = ProvisioningOrchestrator(
+        credential_store=cred_store,
+        environment_store=env_store,
+        tool_agents={"postgres_provisioner": fake_pg, "docker_provisioner": fake_docker},
+    )
+
+    resp = orch.deprovision("a1")
+    assert resp.success is True
+
+
+def test_deprovision_collects_errors_unless_forced(tmp_path: Path) -> None:
+    fake_pg = MagicMock()
+    fake_pg.deprovision.return_value = DeprovisionResult(tool_name="pg", success=False)
+    fake_docker = MagicMock()
+    fake_docker.deprovision.return_value = DeprovisionResult(
+        tool_name="docker", success=False, error="daemon down"
+    )
+
+    cred_store = MagicMock()
+    cred_store.delete_credentials.return_value = False
+    env_store = MagicMock()
+    env_store.remove.return_value = False
+
+    orch = ProvisioningOrchestrator(
+        credential_store=cred_store,
+        environment_store=env_store,
+        tool_agents={"postgres_provisioner": fake_pg, "docker_provisioner": fake_docker},
+    )
+
+    resp = orch.deprovision("a1", force=False)
+    assert resp.success is False
+    assert "Failed to deprovision" in resp.error
+    assert "daemon down" in resp.error
+
+
+def test_deprovision_force_returns_success(tmp_path: Path) -> None:
+    fake_docker = MagicMock()
+    fake_docker.deprovision.return_value = DeprovisionResult(
+        tool_name="docker", success=False, error="x"
+    )
+    cred_store = MagicMock()
+    cred_store.delete_credentials.return_value = False
+    env_store = MagicMock()
+    env_store.remove.return_value = False
+
+    orch = ProvisioningOrchestrator(
+        credential_store=cred_store,
+        environment_store=env_store,
+        tool_agents={"docker_provisioner": fake_docker},
+    )
+    resp = orch.deprovision("a1", force=True)
+    assert resp.success is True
+
+
+def test_get_agent_status_missing(tmp_path: Path) -> None:
+    orch = ProvisioningOrchestrator(
+        environment_store=EnvironmentStore(storage_dir=tmp_path / "envs")
+    )
+    assert orch.get_agent_status("nobody") is None
+
+
+def test_get_agent_status_returns_dict(tmp_path: Path) -> None:
+    env_store = EnvironmentStore(storage_dir=tmp_path / "envs")
+    env_store.register(
+        StoreEnvInfo(
+            agent_id="a1",
+            container_id="c1",
+            container_name="agent-a1",
+            ssh_host="localhost",
+            ssh_port=22001,
+            workspace_path="/w",
+            tools_provisioned=["pg"],
+        )
+    )
+    orch = ProvisioningOrchestrator(environment_store=env_store)
+    status = orch.get_agent_status("a1")
+    assert status["agent_id"] == "a1"
+    assert status["container_name"] == "agent-a1"
+    assert status["tools_provisioned"] == ["pg"]
+
+
+def test_list_agents_filters_by_status(tmp_path: Path) -> None:
+    env_store = EnvironmentStore(storage_dir=tmp_path / "envs")
+    env_store.register(
+        StoreEnvInfo(
+            agent_id="a1",
+            container_id="c1",
+            container_name="c1",
+            workspace_path="/w",
+            status="ready",
+        )
+    )
+    env_store.register(
+        StoreEnvInfo(
+            agent_id="a2",
+            container_id="c2",
+            container_name="c2",
+            workspace_path="/w",
+            status="running",
+        )
+    )
+
+    orch = ProvisioningOrchestrator(environment_store=env_store)
+    ready = orch.list_agents(status="ready")
+    assert len(ready) == 1
+    assert ready[0]["agent_id"] == "a1"
+
+
+def test_run_workflow_shutdown_mid_workflow(tmp_path: Path, monkeypatch) -> None:
+    """If shutdown event flips between phases, _compensate runs + raise fires."""
+    from agent_provisioning_team import orchestrator as orch_mod
+
+    _patch_run_setup(monkeypatch)
+    monkeypatch.setattr(
+        orch_mod,
+        "run_credential_generation",
+        lambda **kw: CredentialGenerationResult(success=True, credentials={}),
+    )
+
+    def acc(**kw):
+        # Flip the shutdown event so the next _check_shutdown raises.
+        kw["progress_callback"](1, 2, "pg")
+        return AccountProvisioningResult(
+            success=True,
+            tool_results=[
+                ToolProvisionResult(
+                    tool_name="pg",
+                    success=True,
+                    provisioner_key="postgres_provisioner",
+                )
+            ],
+        )
+
+    monkeypatch.setattr(orch_mod, "run_account_provisioning", acc)
+
+    fake_pg = MagicMock()
+    fake_pg.list_compensations.return_value = []
+    fake_pg.deprovision.return_value = DeprovisionResult(tool_name="pg", success=True)
+    fake_docker = MagicMock()
+    fake_docker.deprovision.return_value = DeprovisionResult(tool_name="docker", success=True)
+
+    orch = ProvisioningOrchestrator(
+        environment_store=EnvironmentStore(storage_dir=tmp_path / "envs"),
+        tool_agents={
+            "postgres_provisioner": fake_pg,
+            "docker_provisioner": fake_docker,
+        },
+    )
+
+    shutdown = threading.Event()
+
+    # Set the shutdown after the workflow has past SETUP but before audit
+    # by patching run_access_audit to first set the event.
+    def audit(**kw):
+        shutdown.set()
+        return AccessAuditResult(passed=True, verifications=[])
+
+    monkeypatch.setattr(orch_mod, "run_access_audit", audit)
+
+    manifest = _make_manifest(tmp_path)
+
+    with pytest.raises(ProvisioningShutdownError):
+        orch.run_workflow(
+            agent_id="a1",
+            manifest_path=manifest,
+            shutdown_event=shutdown,
+        )
+
+    # Compensation should have rolled back the pg tool
+    fake_pg.deprovision.assert_called_once()
+
+
+def test_run_workflow_uses_default_workspace_when_env_missing(tmp_path: Path, monkeypatch) -> None:
+    """If setup_result.environment is None on resume, documentation uses /workspace."""
+    from agent_provisioning_team import orchestrator as orch_mod
+
+    monkeypatch.setattr(
+        orch_mod,
+        "run_credential_generation",
+        lambda **kw: CredentialGenerationResult(success=True, credentials={}),
+    )
+    monkeypatch.setattr(
+        orch_mod,
+        "run_account_provisioning",
+        lambda **kw: AccountProvisioningResult(success=True, tool_results=[]),
+    )
+    monkeypatch.setattr(
+        orch_mod, "run_access_audit", lambda **kw: AccessAuditResult(passed=True, verifications=[])
+    )
+
+    captured_workspace: Dict[str, Any] = {}
+
+    def doc(**kw):
+        captured_workspace["ws"] = kw.get("workspace_path")
+        return DocumentationResult(
+            success=True,
+            onboarding=OnboardingPacket(summary="s", tools=[], environment_variables={}),
+        )
+
+    monkeypatch.setattr(orch_mod, "run_documentation", doc)
+
+    orch = ProvisioningOrchestrator(
+        environment_store=EnvironmentStore(storage_dir=tmp_path / "envs")
+    )
+    manifest = _make_manifest(tmp_path)
+    # Resume with skip on SETUP but no environment in prior_results.
+    # build_final_result will mark success=False because environment is None,
+    # but the orchestrator still runs every phase and passes "/workspace"
+    # as the documentation workspace — which is what this test verifies.
+    orch.run_workflow(
+        agent_id="a1",
+        manifest_path=manifest,
+        skip_phases={Phase.SETUP},
+        prior_results={
+            "setup": {"success": True, "environment": None},
+        },
+    )
+    assert captured_workspace["ws"] == "/workspace"

--- a/backend/agents/agent_provisioning_team/tests/test_phases.py
+++ b/backend/agents/agent_provisioning_team/tests/test_phases.py
@@ -1,0 +1,845 @@
+"""Unit tests for each phase function.
+
+These cover the procedural orchestration in `phases/` directly so we
+don't have to drive a full workflow through the orchestrator to land
+coverage on every branch.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from agent_provisioning_team.models import (
+    AccessAuditResult,
+    DeliverResult,
+    EnvironmentInfo,
+    GeneratedCredentials,
+    OnboardingPacket,
+    Phase,
+    ProvisioningResult,
+    ToolOnboardingInfo,
+    ToolProvisionResult,
+)
+
+# ---------------------------------------------------------------------------
+# setup phase
+# ---------------------------------------------------------------------------
+
+
+def test_run_setup_reuses_existing_running_environment(tmp_path: Path) -> None:
+    from agent_provisioning_team.phases.setup import run_setup
+    from agent_provisioning_team.shared.environment_store import (
+        EnvironmentInfo as StoreEnvInfo,
+    )
+    from agent_provisioning_team.shared.environment_store import EnvironmentStore
+    from agent_provisioning_team.shared.tool_manifest import ToolManifest
+
+    env_store = EnvironmentStore(storage_dir=tmp_path / "envs")
+    env_store.register(
+        StoreEnvInfo(
+            agent_id="a1",
+            container_id="c1",
+            container_name="agent-a1",
+            ssh_host="localhost",
+            ssh_port=22001,
+            workspace_path="/workspace/a1",
+            status="running",
+        )
+    )
+
+    manifest = ToolManifest()
+    docker = MagicMock()
+
+    calls = []
+
+    def cb(msg):
+        calls.append(msg)
+
+    result = run_setup(
+        agent_id="a1",
+        manifest=manifest,
+        environment_store=env_store,
+        docker_provisioner=docker,
+        progress_callback=cb,
+    )
+
+    assert result.success is True
+    assert result.environment.container_id == "c1"
+    # Existing env path doesn't shell out to docker
+    docker.provision.assert_not_called()
+
+
+def test_run_setup_creates_new_container(tmp_path: Path) -> None:
+    from agent_provisioning_team.phases.setup import run_setup
+    from agent_provisioning_team.shared.environment_store import EnvironmentStore
+    from agent_provisioning_team.shared.tool_manifest import ToolManifest
+
+    env_store = EnvironmentStore(storage_dir=tmp_path / "envs")
+    manifest = ToolManifest()
+
+    docker = MagicMock()
+    docker.provision.return_value = ToolProvisionResult(
+        tool_name="docker",
+        success=True,
+        details={
+            "container_id": "c-new",
+            "container_name": "agent-a2",
+            "ssh_port": 22002,
+            "workspace_path": "/workspace/a2",
+        },
+    )
+
+    result = run_setup(
+        agent_id="a2",
+        manifest=manifest,
+        environment_store=env_store,
+        docker_provisioner=docker,
+        progress_callback=lambda msg: None,
+    )
+
+    assert result.success is True
+    assert result.environment.container_id == "c-new"
+    assert env_store.exists("a2")
+
+
+def test_run_setup_returns_failure_on_docker_error(tmp_path: Path) -> None:
+    from agent_provisioning_team.phases.setup import run_setup
+    from agent_provisioning_team.shared.environment_store import EnvironmentStore
+    from agent_provisioning_team.shared.tool_manifest import ToolManifest
+
+    env_store = EnvironmentStore(storage_dir=tmp_path / "envs")
+    docker = MagicMock()
+    docker.provision.return_value = ToolProvisionResult(
+        tool_name="docker", success=False, error="docker daemon down"
+    )
+
+    result = run_setup(
+        agent_id="a3",
+        manifest=ToolManifest(),
+        environment_store=env_store,
+        docker_provisioner=docker,
+    )
+
+    assert result.success is False
+    assert "docker daemon down" in result.error
+
+
+def test_cleanup_setup_calls_docker_and_env_store(tmp_path: Path) -> None:
+    from agent_provisioning_team.phases.setup import cleanup_setup
+
+    docker = MagicMock()
+    env_store = MagicMock()
+
+    result = cleanup_setup("a1", environment_store=env_store, docker_provisioner=docker)
+    assert result is True
+    docker.deprovision.assert_called_once_with("a1")
+    env_store.remove.assert_called_once_with("a1")
+
+
+# ---------------------------------------------------------------------------
+# credential_generation phase
+# ---------------------------------------------------------------------------
+
+
+def test_regenerate_credentials_creates_new_object(tmp_path: Path) -> None:
+    from agent_provisioning_team.phases.credential_generation import regenerate_credentials
+    from agent_provisioning_team.shared.credential_store import CredentialStore
+
+    cred_store = CredentialStore(storage_dir=tmp_path)
+    result = regenerate_credentials("agent-x", "postgresql", credential_store=cred_store)
+    assert result is not None
+    assert result.tool_name == "postgresql"
+    assert result.password
+
+
+def test_regenerate_credentials_for_git_includes_token(tmp_path: Path) -> None:
+    from agent_provisioning_team.phases.credential_generation import regenerate_credentials
+    from agent_provisioning_team.shared.credential_store import CredentialStore
+
+    cred_store = CredentialStore(storage_dir=tmp_path)
+    result = regenerate_credentials("agent-x", "git", credential_store=cred_store)
+    assert result.token is not None
+
+
+def test_get_stored_credentials_returns_empty_when_none(tmp_path: Path) -> None:
+    from agent_provisioning_team.phases.credential_generation import get_stored_credentials
+    from agent_provisioning_team.shared.credential_store import CredentialStore
+
+    cred_store = CredentialStore(storage_dir=tmp_path)
+    out = get_stored_credentials("nobody", credential_store=cred_store)
+    assert out == {}
+
+
+def test_get_stored_credentials_roundtrip(tmp_path: Path) -> None:
+    from agent_provisioning_team.phases.credential_generation import (
+        get_stored_credentials,
+        run_credential_generation,
+    )
+    from agent_provisioning_team.shared.credential_store import CredentialStore
+    from agent_provisioning_team.shared.tool_manifest import ToolDefinition, ToolManifest
+
+    cred_store = CredentialStore(storage_dir=tmp_path)
+    manifest = ToolManifest(
+        tools=[
+            ToolDefinition(
+                name="postgresql",
+                provisioner="postgres_provisioner",
+                config={},
+            )
+        ]
+    )
+
+    result = run_credential_generation(
+        agent_id="agent-y",
+        manifest=manifest,
+        credential_store=cred_store,
+    )
+    assert result.success is True
+    assert "postgresql" in result.credentials
+
+    fetched = get_stored_credentials("agent-y", credential_store=cred_store)
+    assert "postgresql" in fetched
+
+
+def test_run_credential_generation_with_progress_callback(tmp_path: Path) -> None:
+    from agent_provisioning_team.phases.credential_generation import run_credential_generation
+    from agent_provisioning_team.shared.credential_store import CredentialStore
+    from agent_provisioning_team.shared.tool_manifest import ToolDefinition, ToolManifest
+
+    progress_calls = []
+
+    def cb(name, done, total):
+        progress_calls.append((name, done, total))
+
+    cred_store = CredentialStore(storage_dir=tmp_path)
+    manifest = ToolManifest(
+        tools=[
+            ToolDefinition(name="pg", provisioner="postgres_provisioner", config={}),
+        ]
+    )
+
+    result = run_credential_generation(
+        agent_id="a",
+        manifest=manifest,
+        credential_store=cred_store,
+        progress_callback=cb,
+    )
+
+    assert result.success is True
+    # One per-tool call plus the final "complete" sentinel.
+    assert any(c[0] == "complete" for c in progress_calls)
+
+
+# ---------------------------------------------------------------------------
+# account_provisioning phase
+# ---------------------------------------------------------------------------
+
+
+def test_run_account_provisioning_no_provisioner_registered() -> None:
+    from agent_provisioning_team.phases.account_provisioning import run_account_provisioning
+    from agent_provisioning_team.shared.tool_manifest import ToolDefinition, ToolManifest
+
+    manifest = ToolManifest(
+        tools=[
+            ToolDefinition(name="weird", provisioner="generic_provisioner", config={}),
+        ]
+    )
+
+    # Use a registry that maps to a different key so the lookup misses.
+    fake_other = MagicMock()
+    result = run_account_provisioning(
+        agent_id="a1",
+        manifest=manifest,
+        credentials={"weird": GeneratedCredentials(tool_name="weird")},
+        provisioners={"some_other_provisioner": fake_other},
+    )
+    assert result.success is False
+    assert "Unknown provisioner" in result.tool_results[0].error
+
+
+def test_run_account_provisioning_no_credentials() -> None:
+    from agent_provisioning_team.phases.account_provisioning import run_account_provisioning
+    from agent_provisioning_team.shared.tool_manifest import ToolDefinition, ToolManifest
+
+    fake_prov = MagicMock()
+    manifest = ToolManifest(
+        tools=[
+            ToolDefinition(name="t", provisioner="generic_provisioner", config={}),
+        ]
+    )
+
+    result = run_account_provisioning(
+        agent_id="a1",
+        manifest=manifest,
+        credentials={},  # no creds for "t"
+        provisioners={"generic_provisioner": fake_prov},
+    )
+    assert result.success is False
+    assert "No credentials" in result.tool_results[0].error
+
+
+def test_run_account_provisioning_handles_provisioner_exception(tmp_path: Path) -> None:
+    from agent_provisioning_team.phases.account_provisioning import run_account_provisioning
+    from agent_provisioning_team.shared.environment_store import EnvironmentStore
+    from agent_provisioning_team.shared.tool_manifest import ToolDefinition, ToolManifest
+
+    bad_prov = MagicMock()
+    bad_prov.provision.side_effect = RuntimeError("boom in provision")
+
+    manifest = ToolManifest(
+        tools=[ToolDefinition(name="t", provisioner="generic_provisioner", config={})]
+    )
+
+    result = run_account_provisioning(
+        agent_id="a1",
+        manifest=manifest,
+        credentials={"t": GeneratedCredentials(tool_name="t")},
+        provisioners={"generic_provisioner": bad_prov},
+        environment_store=EnvironmentStore(storage_dir=tmp_path / "envs"),
+    )
+
+    assert result.success is False
+    assert "boom" in result.tool_results[0].error
+
+
+def test_run_account_provisioning_success(tmp_path: Path) -> None:
+    from agent_provisioning_team.phases.account_provisioning import run_account_provisioning
+    from agent_provisioning_team.shared.environment_store import (
+        EnvironmentInfo as StoreEnvInfo,
+    )
+    from agent_provisioning_team.shared.environment_store import EnvironmentStore
+    from agent_provisioning_team.shared.tool_manifest import ToolDefinition, ToolManifest
+
+    env_store = EnvironmentStore(storage_dir=tmp_path / "envs")
+    env_store.register(
+        StoreEnvInfo(
+            agent_id="a1",
+            container_id="c1",
+            container_name="agent-a1",
+            workspace_path="/w",
+        )
+    )
+
+    good = MagicMock()
+    good.provision.return_value = ToolProvisionResult(
+        tool_name="t",
+        success=True,
+        provisioner_key="generic_provisioner",
+        permissions=["read"],
+    )
+
+    manifest = ToolManifest(
+        tools=[ToolDefinition(name="t", provisioner="generic_provisioner", config={})]
+    )
+
+    cb_calls = []
+
+    result = run_account_provisioning(
+        agent_id="a1",
+        manifest=manifest,
+        credentials={"t": GeneratedCredentials(tool_name="t")},
+        provisioners={"generic_provisioner": good},
+        environment_store=env_store,
+        progress_callback=lambda done, total, name: cb_calls.append((done, total, name)),
+    )
+
+    assert result.success is True
+    assert result.tools_completed == 1
+    assert any(c[2] == "complete" for c in cb_calls)
+
+
+def test_deprovision_tools_all() -> None:
+    from agent_provisioning_team.models import DeprovisionResult
+    from agent_provisioning_team.phases.account_provisioning import deprovision_tools
+
+    p1 = MagicMock()
+    p1.deprovision.return_value = DeprovisionResult(tool_name="p1", success=True)
+    p2 = MagicMock()
+    p2.deprovision.side_effect = RuntimeError("boom")
+
+    results = deprovision_tools("a1", provisioners={"p1": p1, "p2": p2})
+    assert results == {"p1": True, "p2": False}
+
+
+def test_deprovision_tools_filtered() -> None:
+    from agent_provisioning_team.models import DeprovisionResult
+    from agent_provisioning_team.phases.account_provisioning import deprovision_tools
+
+    p1 = MagicMock()
+    p1.deprovision.return_value = DeprovisionResult(tool_name="p1", success=True)
+    p2 = MagicMock()
+    p2.deprovision.return_value = DeprovisionResult(tool_name="p2", success=True)
+
+    results = deprovision_tools("a1", tool_names=["p1"], provisioners={"p1": p1, "p2": p2})
+    assert results == {"p1": True}
+
+
+def test_build_provisioners_shim() -> None:
+    from agent_provisioning_team.phases.account_provisioning import _build_provisioners
+
+    out = _build_provisioners()
+    assert isinstance(out, dict)
+    assert "docker_provisioner" in out
+
+
+# ---------------------------------------------------------------------------
+# access_audit phase
+# ---------------------------------------------------------------------------
+
+
+def test_run_access_audit_all_success() -> None:
+    from agent_provisioning_team.phases.access_audit import run_access_audit
+
+    tool_results = [
+        ToolProvisionResult(
+            tool_name="t1",
+            success=True,
+            permissions=["read", "write"],
+            provisioner_key="x",
+        )
+    ]
+    msgs = []
+    result = run_access_audit(
+        agent_id="a1",
+        tool_results=tool_results,
+        progress_callback=lambda m: msgs.append(m),
+    )
+    assert result.passed is True
+    assert len(result.verifications) == 1
+    assert "read" in result.verifications[0].actual_permissions
+    assert any("Starting" in m for m in msgs)
+
+
+def test_run_access_audit_with_failed_tool() -> None:
+    from agent_provisioning_team.phases.access_audit import run_access_audit
+
+    tool_results = [
+        ToolProvisionResult(tool_name="t1", success=False, error="rpc failed", provisioner_key="x"),
+        ToolProvisionResult(
+            tool_name="t2", success=True, permissions=["read"], provisioner_key="x"
+        ),
+    ]
+    result = run_access_audit(agent_id="a1", tool_results=tool_results)
+    assert result.passed is False
+    assert any(not v.passed for v in result.verifications)
+    assert any("rpc failed" in v.errors[0] for v in result.verifications if not v.passed)
+
+
+def test_audit_single_tool_returns_provisioner_result() -> None:
+    from agent_provisioning_team.models import AccessVerification
+    from agent_provisioning_team.phases.access_audit import audit_single_tool
+
+    prov = MagicMock()
+    prov.verify_access.return_value = AccessVerification(
+        tool_name="t", passed=True, actual_permissions=["read"]
+    )
+
+    v = audit_single_tool("a1", "t", provisioner=prov)
+    assert v.passed is True
+
+
+def test_audit_single_tool_no_provisioner_returns_error() -> None:
+    from agent_provisioning_team.phases.access_audit import audit_single_tool
+
+    with patch(
+        "agent_provisioning_team.phases.access_audit.build_default_tool_agents",
+        return_value={},
+    ):
+        v = audit_single_tool("a1", "nonexistent")
+    assert v.passed is False
+    assert "No provisioner" in v.errors[0]
+
+
+def test_generate_audit_report_includes_status() -> None:
+    from agent_provisioning_team.models import AccessVerification
+    from agent_provisioning_team.phases.access_audit import generate_audit_report
+
+    audit = AccessAuditResult(
+        passed=True,
+        verifications=[
+            AccessVerification(
+                tool_name="t1",
+                passed=True,
+                actual_permissions=["read"],
+                warnings=["wide perms"],
+            ),
+            AccessVerification(
+                tool_name="t2",
+                passed=False,
+                actual_permissions=[],
+                errors=["fail"],
+            ),
+        ],
+        warnings=["overall warning"],
+        errors=["overall error"],
+    )
+
+    report = generate_audit_report(audit)
+    assert "PASSED" in report
+    assert "t1" in report and "t2" in report
+    assert "wide perms" in report
+    assert "fail" in report
+    assert "overall warning" in report
+    assert "overall error" in report
+
+
+def test_generate_audit_report_failed_status() -> None:
+    from agent_provisioning_team.phases.access_audit import generate_audit_report
+
+    audit = AccessAuditResult(passed=False, verifications=[])
+    report = generate_audit_report(audit)
+    assert "FAILED" in report
+
+
+def test_build_provisioners_audit_shim() -> None:
+    from agent_provisioning_team.phases.access_audit import _build_provisioners
+
+    out = _build_provisioners()
+    assert isinstance(out, dict)
+
+
+# ---------------------------------------------------------------------------
+# documentation phase
+# ---------------------------------------------------------------------------
+
+
+def test_run_documentation_full_path(tmp_path: Path) -> None:
+    from agent_provisioning_team.phases.documentation import run_documentation
+    from agent_provisioning_team.shared.tool_manifest import ToolDefinition, ToolManifest
+
+    manifest = ToolManifest(
+        tools=[
+            ToolDefinition(
+                name="postgresql",
+                provisioner="postgres_provisioner",
+                config={},
+                onboarding={
+                    "description": "PG db",
+                    "env_var": "POSTGRES_URL",
+                    "getting_started": "Connect to {username}",
+                },
+            ),
+        ]
+    )
+
+    creds = GeneratedCredentials(
+        tool_name="postgresql",
+        username="agent_u",
+        password="pw",
+        connection_string="postgresql://agent_u:pw@h:5432/db",
+    )
+
+    tool_results = [
+        ToolProvisionResult(
+            tool_name="postgresql",
+            success=True,
+            permissions=["ALL PRIVILEGES"],
+            provisioner_key="postgres_provisioner",
+        )
+    ]
+
+    msgs = []
+    result = run_documentation(
+        agent_id="agent-1",
+        manifest=manifest,
+        credentials={"postgresql": creds},
+        tool_results=tool_results,
+        workspace_path=str(tmp_path / "ws"),
+        progress_callback=lambda m: msgs.append(m),
+    )
+
+    assert result.success is True
+    assert result.onboarding is not None
+    assert any(t.name == "postgresql" for t in result.onboarding.tools)
+    assert result.onboarding.environment_variables["POSTGRES_URL"]
+    assert result.onboarding.environment_variables["AGENT_ID"] == "agent-1"
+
+
+def test_run_documentation_skips_failed_tools(tmp_path: Path) -> None:
+    from agent_provisioning_team.phases.documentation import run_documentation
+    from agent_provisioning_team.shared.tool_manifest import ToolManifest
+
+    manifest = ToolManifest()  # no tools defined
+
+    tool_results = [
+        ToolProvisionResult(tool_name="failed", success=False, error="x", provisioner_key="y")
+    ]
+
+    result = run_documentation(
+        agent_id="a1",
+        manifest=manifest,
+        credentials={},
+        tool_results=tool_results,
+        workspace_path=str(tmp_path),
+    )
+
+    assert result.success is True
+    assert result.onboarding.tools == []
+
+
+def test_run_documentation_skips_tool_not_in_manifest(tmp_path: Path) -> None:
+    from agent_provisioning_team.phases.documentation import run_documentation
+    from agent_provisioning_team.shared.tool_manifest import ToolManifest
+
+    manifest = ToolManifest()  # No tools
+
+    tool_results = [
+        ToolProvisionResult(tool_name="ghost", success=True, permissions=[], provisioner_key="x")
+    ]
+
+    result = run_documentation(
+        agent_id="a1",
+        manifest=manifest,
+        credentials={},
+        tool_results=tool_results,
+        workspace_path=str(tmp_path),
+    )
+    assert result.success is True
+    # ghost isn't in manifest → no tool docs
+    assert result.onboarding.tools == []
+
+
+def test_run_documentation_uses_default_getting_started_template(tmp_path: Path) -> None:
+    """If a tool has no getting_started config, the deterministic fallback runs."""
+    from agent_provisioning_team.phases.documentation import run_documentation
+    from agent_provisioning_team.shared.tool_manifest import ToolDefinition, ToolManifest
+
+    manifest = ToolManifest(
+        tools=[
+            ToolDefinition(
+                name="redis",
+                provisioner="redis_provisioner",
+                config={},
+                onboarding={
+                    "description": "Redis",
+                    "env_var": "REDIS_URL",
+                    "getting_started": "",
+                },
+            ),
+        ]
+    )
+
+    creds = GeneratedCredentials(
+        tool_name="redis",
+        username="u",
+        password="p",
+        connection_string="redis://u:p@h:6379",
+    )
+
+    tool_results = [
+        ToolProvisionResult(
+            tool_name="redis",
+            success=True,
+            permissions=["+@all"],
+            provisioner_key="redis_provisioner",
+        )
+    ]
+
+    result = run_documentation(
+        agent_id="a1",
+        manifest=manifest,
+        credentials={"redis": creds},
+        tool_results=tool_results,
+        workspace_path=str(tmp_path),
+    )
+
+    tool_doc = result.onboarding.tools[0]
+    # Template fallback mentions the env var
+    assert "REDIS_URL" in tool_doc.getting_started
+
+
+def test_generate_readme_includes_sections() -> None:
+    from agent_provisioning_team.phases.documentation import generate_readme
+
+    onboarding = OnboardingPacket(
+        summary="hello",
+        tools=[
+            ToolOnboardingInfo(
+                name="pg",
+                description="Postgres",
+                env_var="POSTGRES_URL",
+                getting_started="psql $POSTGRES_URL",
+                permissions=["ALL PRIVILEGES"],
+            )
+        ],
+        environment_variables={
+            "POSTGRES_URL": "postgresql://u:pw@h/db",
+            "AGENT_ID": "a1",
+        },
+        anatomy_bundle_path="/ws/docs/agent_anatomy",
+    )
+
+    out = generate_readme(onboarding)
+    assert "# Agent Workspace" in out
+    assert "## Available Tools" in out
+    assert "POSTGRES_URL" in out
+    assert "ALL PRIVILEGES" in out
+    assert "agent_anatomy" in out
+    # Password content is hidden
+    assert "***" not in out  # POSTGRES_URL key doesn't contain "password"
+
+
+def test_generate_readme_redacts_password_envvar() -> None:
+    from agent_provisioning_team.phases.documentation import generate_readme
+
+    onboarding = OnboardingPacket(
+        summary="hi",
+        tools=[],
+        environment_variables={"DB_PASSWORD": "secret123"},
+    )
+    out = generate_readme(onboarding)
+    assert "secret123" not in out
+    assert "***" in out
+
+
+def test_generate_readme_no_anatomy_bundle() -> None:
+    from agent_provisioning_team.phases.documentation import generate_readme
+
+    onboarding = OnboardingPacket(summary="s", tools=[], environment_variables={})
+    out = generate_readme(onboarding)
+    # Falls through to the "when the workspace path is available" message.
+    assert "docs/agent_anatomy" in out
+
+
+# ---------------------------------------------------------------------------
+# deliver phase
+# ---------------------------------------------------------------------------
+
+
+def test_run_deliver_updates_status(tmp_path: Path) -> None:
+    from agent_provisioning_team.phases.deliver import run_deliver
+    from agent_provisioning_team.shared.environment_store import (
+        EnvironmentInfo as StoreEnvInfo,
+    )
+    from agent_provisioning_team.shared.environment_store import EnvironmentStore
+
+    env_store = EnvironmentStore(storage_dir=tmp_path)
+    env_store.register(
+        StoreEnvInfo(
+            agent_id="a1",
+            container_id="c1",
+            container_name="agent-a1",
+            workspace_path="/w",
+        )
+    )
+
+    env = EnvironmentInfo(container_id="c1", container_name="agent-a1")
+    msgs = []
+    result = run_deliver(
+        agent_id="a1",
+        environment=env,
+        credentials={},
+        tool_results=[],
+        access_audit=None,
+        onboarding=None,
+        environment_store=env_store,
+        progress_callback=lambda m: msgs.append(m),
+    )
+
+    assert result.success is True
+    # status was bumped to "ready"
+    env_after = env_store.get("a1")
+    assert env_after.status == "ready"
+
+
+def test_run_deliver_without_environment_does_not_update(tmp_path: Path) -> None:
+    from agent_provisioning_team.phases.deliver import run_deliver
+    from agent_provisioning_team.shared.environment_store import EnvironmentStore
+
+    env_store = EnvironmentStore(storage_dir=tmp_path)
+    result = run_deliver(
+        agent_id="a1",
+        environment=None,
+        credentials={},
+        tool_results=[],
+        access_audit=None,
+        onboarding=None,
+        environment_store=env_store,
+    )
+    assert result.success is True
+
+
+def test_build_final_result_success() -> None:
+    from agent_provisioning_team.phases.deliver import build_final_result
+
+    env = EnvironmentInfo(container_id="c1", container_name="c1")
+    tr = [ToolProvisionResult(tool_name="t", success=True, provisioner_key="x")]
+    final = build_final_result(
+        agent_id="a1",
+        environment=env,
+        credentials={},
+        tool_results=tr,
+        access_audit=AccessAuditResult(passed=True, verifications=[]),
+        onboarding=None,
+        deliver_result=DeliverResult(success=True),
+    )
+    assert final.success is True
+    assert final.current_phase == Phase.DELIVER
+
+
+def test_build_final_result_with_failures() -> None:
+    from agent_provisioning_team.phases.deliver import build_final_result
+
+    tr = [
+        ToolProvisionResult(tool_name="t1", success=False, error="boom", provisioner_key="x"),
+    ]
+    final = build_final_result(
+        agent_id="a1",
+        environment=None,  # missing env
+        credentials={},
+        tool_results=tr,
+        access_audit=AccessAuditResult(passed=False, verifications=[]),
+        onboarding=None,
+        deliver_result=DeliverResult(success=True),
+    )
+    assert final.success is False
+    assert "Environment setup failed" in final.error
+    assert "t1" in final.error
+    assert "Access audit failed" in final.error
+
+
+def test_redact_connection_string_no_password() -> None:
+    from agent_provisioning_team.phases.deliver import _redact_connection_string
+
+    assert _redact_connection_string(None) is None
+    assert _redact_connection_string("") is None
+    # Already-redacted strings are left untouched (no `:pw@` pattern).
+    assert _redact_connection_string("plain") == "plain"
+
+
+def test_redact_credentials_with_ssh_key() -> None:
+    from agent_provisioning_team.phases.deliver import redact_credentials_for_response
+
+    result = ProvisioningResult(
+        agent_id="a1",
+        success=True,
+        credentials={
+            "git": GeneratedCredentials(
+                tool_name="git",
+                ssh_private_key="PRIVATE",
+                ssh_public_key="PUBLIC",
+                extra={"workspace_path": "/w", "password": "secret"},
+            ),
+        },
+    )
+    redacted = redact_credentials_for_response(result)
+    assert redacted.credentials["git"].ssh_private_key == "***"
+    assert redacted.credentials["git"].ssh_public_key == "PUBLIC"
+    assert "password" not in redacted.credentials["git"].extra
+
+
+def test_redact_details_scalar_passthrough() -> None:
+    from agent_provisioning_team.phases.deliver import _redact_details
+
+    assert _redact_details(123) == 123
+    assert _redact_details(True) is True
+    assert _redact_details(None) is None
+
+
+def test_redact_details_handles_list() -> None:
+    from agent_provisioning_team.phases.deliver import _redact_details
+
+    out = _redact_details([{"password": "x"}, {"safe": "y"}])
+    assert out[0]["password"] == "***"
+    assert out[1]["safe"] == "y"

--- a/backend/agents/agent_provisioning_team/tests/test_shared.py
+++ b/backend/agents/agent_provisioning_team/tests/test_shared.py
@@ -1,0 +1,821 @@
+"""Unit tests for shared helpers.
+
+Covers job_store, environment_store, logging_context, phase_state,
+provisioner_state edge cases, llm_client, and tool_manifest helpers
+that aren't already exercised in the integration matrix.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_provisioning_team.shared.environment_store import (
+    EnvironmentInfo as StoreEnvInfo,
+)
+from agent_provisioning_team.shared.environment_store import EnvironmentStore
+
+# ---------------------------------------------------------------------------
+# environment_store
+# ---------------------------------------------------------------------------
+
+
+def test_environment_info_from_dict_roundtrip() -> None:
+    info = StoreEnvInfo(
+        agent_id="a1",
+        container_id="c1",
+        container_name="agent-a1",
+        workspace_path="/w",
+        tools_provisioned=["pg", "redis"],
+    )
+    d = info.to_dict()
+    restored = StoreEnvInfo.from_dict(d)
+    assert restored.agent_id == "a1"
+    assert restored.tools_provisioned == ["pg", "redis"]
+
+
+def test_environment_store_register_get_remove(tmp_path: Path) -> None:
+    store = EnvironmentStore(storage_dir=tmp_path)
+    assert store.get("missing") is None
+
+    env = StoreEnvInfo(
+        agent_id="a1",
+        container_id="c1",
+        container_name="c1",
+        workspace_path="/w",
+    )
+    store.register(env)
+    assert store.exists("a1")
+
+    fetched = store.get("a1")
+    assert fetched.container_id == "c1"
+
+    assert store.remove("a1") is True
+    assert store.remove("a1") is False
+    assert store.get("a1") is None
+
+
+def test_environment_store_update_status(tmp_path: Path) -> None:
+    store = EnvironmentStore(storage_dir=tmp_path)
+
+    # update on missing returns False
+    assert store.update_status("missing", "ready") is False
+
+    store.register(
+        StoreEnvInfo(
+            agent_id="a1",
+            container_id="c1",
+            container_name="c1",
+            workspace_path="/w",
+        )
+    )
+    assert store.update_status("a1", "ready") is True
+    assert store.get("a1").status == "ready"
+
+
+def test_environment_store_update_status_handles_corrupt(tmp_path: Path) -> None:
+    store = EnvironmentStore(storage_dir=tmp_path)
+    bad = tmp_path / "broken.json"
+    bad.write_text("{not json", encoding="utf-8")
+    assert store.update_status("broken", "ready") is False
+
+
+def test_environment_store_add_tool(tmp_path: Path) -> None:
+    store = EnvironmentStore(storage_dir=tmp_path)
+    assert store.add_tool("missing", "pg") is False
+
+    store.register(
+        StoreEnvInfo(
+            agent_id="a1",
+            container_id="c1",
+            container_name="c1",
+            workspace_path="/w",
+        )
+    )
+    assert store.add_tool("a1", "pg") is True
+    # Idempotent — adding same tool twice doesn't duplicate.
+    assert store.add_tool("a1", "pg") is True
+    assert store.get("a1").tools_provisioned == ["pg"]
+
+
+def test_environment_store_add_tool_handles_corrupt(tmp_path: Path) -> None:
+    store = EnvironmentStore(storage_dir=tmp_path)
+    bad = tmp_path / "broken.json"
+    bad.write_text("not json", encoding="utf-8")
+    assert store.add_tool("broken", "pg") is False
+
+
+def test_environment_store_list_all(tmp_path: Path) -> None:
+    store = EnvironmentStore(storage_dir=tmp_path)
+
+    store.register(
+        StoreEnvInfo(
+            agent_id="a1",
+            container_id="c1",
+            container_name="c1",
+            workspace_path="/w",
+            status="ready",
+        )
+    )
+    store.register(
+        StoreEnvInfo(
+            agent_id="a2",
+            container_id="c2",
+            container_name="c2",
+            workspace_path="/w",
+            status="running",
+        )
+    )
+
+    all_envs = store.list_all()
+    assert len(all_envs) == 2
+
+    ready = store.list_all(status="ready")
+    assert len(ready) == 1
+    assert ready[0].agent_id == "a1"
+
+
+def test_environment_store_list_all_skips_corrupt(tmp_path: Path) -> None:
+    store = EnvironmentStore(storage_dir=tmp_path)
+    store.register(
+        StoreEnvInfo(agent_id="a1", container_id="c1", container_name="c1", workspace_path="/w")
+    )
+    # Corrupt JSON
+    (tmp_path / "broken.json").write_text("not json", encoding="utf-8")
+    # JSON missing required field
+    (tmp_path / "incomplete.json").write_text(json.dumps({"agent_id": "x"}), encoding="utf-8")
+
+    out = store.list_all()
+    # Only the valid one shows up.
+    assert {e.agent_id for e in out} == {"a1"}
+
+
+def test_environment_store_get_handles_corrupt(tmp_path: Path) -> None:
+    store = EnvironmentStore(storage_dir=tmp_path)
+    (tmp_path / "x.json").write_text("not json", encoding="utf-8")
+    assert store.get("x") is None
+
+
+# ---------------------------------------------------------------------------
+# job_store
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def mock_job_client(monkeypatch):
+    """Replace the module-level ``_client`` with a fresh fake."""
+    from agent_provisioning_team.shared import job_store as js
+    from job_service_client_fake import FakeJobServiceClient
+
+    fake = FakeJobServiceClient(team="agent_provisioning_team")
+    monkeypatch.setattr(js, "_client", lambda cache_dir=None: fake)
+    return fake
+
+
+def test_job_store_create_and_get(mock_job_client) -> None:
+    from agent_provisioning_team.shared import job_store as js
+
+    js.create_job("j1", "agent-1", "default.yaml")
+    data = js.get_job("j1")
+    assert data["agent_id"] == "agent-1"
+    assert data["manifest_path"] == "default.yaml"
+
+    # Missing job → empty dict
+    assert js.get_job("missing") == {}
+
+
+def test_job_store_update_job(mock_job_client) -> None:
+    from agent_provisioning_team.shared import job_store as js
+
+    js.create_job("j1", "a", "m")
+    js.update_job("j1", progress=42, current_phase="setup")
+    data = js.get_job("j1")
+    assert data["progress"] == 42
+    assert data["current_phase"] == "setup"
+
+
+def test_job_store_list_jobs(mock_job_client) -> None:
+    from agent_provisioning_team.shared import job_store as js
+
+    js.create_job("j1", "a1", "m")
+    js.create_job("j2", "a2", "m")
+    js.update_job("j2", status="completed")
+
+    all_jobs = js.list_jobs(running_only=False)
+    assert len(all_jobs) == 2
+    active = js.list_jobs(running_only=True)
+    assert len(active) == 1
+    assert active[0]["job_id"] == "j1"
+
+
+def test_job_store_mark_running_completed_failed(mock_job_client) -> None:
+    from agent_provisioning_team.shared import job_store as js
+
+    js.create_job("j1", "a", "m")
+    js.mark_job_running("j1")
+    assert js.get_job("j1")["status"] == "running"
+
+    js.mark_job_completed("j1", result={"ok": True})
+    data = js.get_job("j1")
+    assert data["status"] == "completed"
+    assert data["progress"] == 100
+    assert data["result"] == {"ok": True}
+
+    js.mark_job_failed("j1", error="kaboom")
+    data = js.get_job("j1")
+    assert data["status"] == "failed"
+    assert data["error"] == "kaboom"
+
+
+def test_job_store_cancel_job(mock_job_client) -> None:
+    from agent_provisioning_team.shared import job_store as js
+
+    js.create_job("j1", "a", "m")
+    assert js.cancel_job("j1") is True
+    assert js.cancel_job("missing") is False
+
+
+def test_job_store_mark_all_running_jobs_failed(mock_job_client) -> None:
+    from agent_provisioning_team.shared import job_store as js
+
+    js.create_job("j1", "a", "m")
+    js.create_job("j2", "b", "m")
+    js.mark_all_running_jobs_failed("shutdown")
+    # Both should now be failed
+    assert all(j["status"] == "failed" for j in js.list_jobs(running_only=False))
+
+
+def test_job_store_mark_all_swallows_exception(monkeypatch, caplog) -> None:
+    from agent_provisioning_team.shared import job_store as js
+
+    fake = MagicMock()
+    fake.mark_all_active_jobs_failed.side_effect = RuntimeError("boom")
+    monkeypatch.setattr(js, "_client", lambda cache_dir=None: fake)
+    with caplog.at_level(logging.WARNING):
+        js.mark_all_running_jobs_failed("shutdown")
+    # No exception propagated; warning logged.
+
+
+def test_job_store_update_phase_progress(mock_job_client) -> None:
+    from agent_provisioning_team.shared import job_store as js
+
+    js.create_job("j1", "a", "m")
+    js.update_phase_progress(
+        "j1",
+        current_phase="setup",
+        progress=20,
+        current_tool="pg",
+        tools_completed=1,
+        tools_total=3,
+    )
+    data = js.get_job("j1")
+    assert data["current_phase"] == "setup"
+    assert data["current_tool"] == "pg"
+    assert data["tools_completed"] == 1
+
+
+def test_job_store_add_completed_phase_with_result(mock_job_client) -> None:
+    from agent_provisioning_team.shared import job_store as js
+
+    js.create_job("j1", "a", "m")
+    js.add_completed_phase("j1", "setup", phase_result={"success": True})
+    data = js.get_job("j1")
+    assert "setup" in data["completed_phases"]
+    assert data["phase_results"]["setup"] == {"success": True}
+
+    # Adding the same phase again must not duplicate it.
+    js.add_completed_phase("j1", "setup")
+    data = js.get_job("j1")
+    assert data["completed_phases"].count("setup") == 1
+
+
+def test_job_store_add_completed_phase_missing_job(mock_job_client) -> None:
+    """When the job doesn't exist add_completed_phase no-ops."""
+    from agent_provisioning_team.shared import job_store as js
+
+    js.add_completed_phase("missing", "setup")
+    assert js.get_job("missing") == {}
+
+
+def test_job_store_reset_job(mock_job_client) -> None:
+    from agent_provisioning_team.shared import job_store as js
+
+    js.create_job("j1", "a", "m")
+    js.update_job("j1", progress=80, status="failed")
+    js.reset_job("j1")
+    data = js.get_job("j1")
+    assert data["status"] == "pending"
+    assert data["progress"] == 0
+
+
+def test_job_store_delete_job(mock_job_client) -> None:
+    from agent_provisioning_team.shared import job_store as js
+
+    js.create_job("j1", "a", "m")
+    assert js.delete_job("j1") is True
+    assert js.delete_job("j1") is False
+
+
+# ---------------------------------------------------------------------------
+# logging_context
+# ---------------------------------------------------------------------------
+
+
+def test_logging_context_filter_injects_defaults(caplog) -> None:
+    from agent_provisioning_team.shared import logging_context as lc
+    from agent_provisioning_team.shared.logging_context import (
+        ProvisioningContextFilter,
+    )
+
+    # Reset contextvars in case prior tests leaked into this worker.
+    tok_j = lc._job_id_var.set(None)
+    tok_a = lc._agent_id_var.set(None)
+    tok_p = lc._phase_var.set(None)
+    try:
+        record = logging.LogRecord(
+            name="x",
+            level=logging.INFO,
+            pathname="",
+            lineno=0,
+            msg="m",
+            args=(),
+            exc_info=None,
+        )
+        f = ProvisioningContextFilter()
+        assert f.filter(record) is True
+        assert record.job_id == "-"
+        assert record.agent_id == "-"
+        assert record.phase == "-"
+
+        # Getter helpers report None when nothing is bound.
+        assert lc.get_job_id() is None
+        assert lc.get_agent_id() is None
+        assert lc.get_phase() is None
+    finally:
+        lc._job_id_var.reset(tok_j)
+        lc._agent_id_var.reset(tok_a)
+        lc._phase_var.reset(tok_p)
+
+
+def test_logging_context_manager_binds_and_unbinds() -> None:
+    from agent_provisioning_team.shared.logging_context import (
+        get_agent_id,
+        get_job_id,
+        get_phase,
+        provisioning_context,
+    )
+
+    with provisioning_context(job_id="j1", agent_id="a1", phase="setup"):
+        assert get_job_id() == "j1"
+        assert get_agent_id() == "a1"
+        assert get_phase() == "setup"
+
+    # After exit the values are reset.
+    assert get_job_id() is None
+
+
+def test_logging_context_manager_partial_args() -> None:
+    from agent_provisioning_team.shared import logging_context as lc
+
+    tok_a = lc._agent_id_var.set(None)
+    try:
+        with lc.provisioning_context(job_id="j1"):
+            assert lc.get_job_id() == "j1"
+            assert lc.get_agent_id() is None
+    finally:
+        lc._agent_id_var.reset(tok_a)
+
+
+def test_install_filter_is_idempotent() -> None:
+    from agent_provisioning_team.shared import logging_context as lc
+
+    # First call may or may not install; second is always a no-op.
+    lc.install_filter()
+    lc.install_filter()
+
+
+# ---------------------------------------------------------------------------
+# phase_state.restore_*
+# ---------------------------------------------------------------------------
+
+
+def test_restore_credentials_validates_shape() -> None:
+    from agent_provisioning_team.shared.phase_state import restore_credentials
+
+    snap = restore_credentials(
+        {
+            "success": True,
+            "credentials": {"pg": {"tool_name": "pg", "username": "u", "password": "p"}},
+        }
+    )
+    assert snap.success is True
+    assert snap.credentials["pg"].username == "u"
+
+
+def test_restore_account_provisioning_validates_shape() -> None:
+    from agent_provisioning_team.shared.phase_state import restore_account_provisioning
+
+    snap = restore_account_provisioning(
+        {
+            "success": True,
+            "tool_results": [
+                {"tool_name": "t", "success": True, "provisioner_key": "p", "permissions": []}
+            ],
+            "tools_completed": 1,
+            "tools_total": 1,
+        }
+    )
+    assert snap.success is True
+    assert snap.tool_results[0].tool_name == "t"
+
+
+def test_restore_access_audit_returns_typed() -> None:
+    from agent_provisioning_team.shared.phase_state import restore_access_audit
+
+    out = restore_access_audit({"passed": True, "verifications": []})
+    assert out.passed is True
+
+
+def test_restore_documentation_validates_shape() -> None:
+    from agent_provisioning_team.shared.phase_state import restore_documentation
+
+    snap = restore_documentation(
+        {
+            "success": True,
+            "onboarding": {
+                "summary": "hi",
+                "tools": [],
+                "environment_variables": {},
+            },
+        }
+    )
+    assert snap.success is True
+    assert snap.onboarding.summary == "hi"
+
+
+def test_restore_documentation_with_none_onboarding() -> None:
+    from agent_provisioning_team.shared.phase_state import restore_documentation
+
+    snap = restore_documentation({"success": True, "onboarding": None})
+    assert snap.success is True
+    assert snap.onboarding is None
+
+
+# ---------------------------------------------------------------------------
+# llm_client
+# ---------------------------------------------------------------------------
+
+
+def test_llm_client_is_not_configured_by_default() -> None:
+    from agent_provisioning_team.shared.llm_client import LLMClient
+
+    assert LLMClient().is_configured is False
+
+
+def test_llm_client_complete_raises_when_configured(monkeypatch) -> None:
+    from agent_provisioning_team.shared.llm_client import LLMClient, LLMRequest
+
+    client = LLMClient()
+    # Trick is_configured into True via monkeypatch on the property's getter.
+    with patch.object(type(client), "is_configured", property(lambda self: True)):
+        with pytest.raises(NotImplementedError):
+            client.complete(LLMRequest(system="s", user="u"))
+
+
+def test_sanitize_prompt_var_default_max() -> None:
+    from agent_provisioning_team.shared.llm_client import sanitize_prompt_var
+
+    s = sanitize_prompt_var("clean ascii")
+    assert s == "clean ascii"
+
+
+def test_sanitize_prompt_var_strips_emoji() -> None:
+    from agent_provisioning_team.shared.llm_client import sanitize_prompt_var
+
+    s = sanitize_prompt_var("hi \U0001f600 there")
+    # Emoji is not in the allowlist; gets replaced by _ (which is on the
+    # allowlist, so two underscores are produced for the multi-byte char).
+    assert "_" in s
+    assert "hi" in s and "there" in s
+
+
+def test_sanitize_prompt_var_handles_none() -> None:
+    from agent_provisioning_team.shared.llm_client import sanitize_prompt_var
+
+    assert sanitize_prompt_var(None) == ""
+
+
+# ---------------------------------------------------------------------------
+# tool_manifest helpers
+# ---------------------------------------------------------------------------
+
+
+def test_load_manifest_success(tmp_path: Path) -> None:
+    from agent_provisioning_team.shared.tool_manifest import load_manifest
+
+    f = tmp_path / "m.yaml"
+    f.write_text(
+        """
+version: "1.0"
+tools:
+  - name: postgresql
+    provisioner: postgres_provisioner
+    config: {database_prefix: "x_"}
+""",
+        encoding="utf-8",
+    )
+
+    m = load_manifest(str(f))
+    assert m.version == "1.0"
+    assert m.tool_names == ["postgresql"]
+
+
+def test_load_manifest_missing_file_raises(tmp_path: Path) -> None:
+    from agent_provisioning_team.shared.tool_manifest import load_manifest
+
+    with pytest.raises(FileNotFoundError):
+        load_manifest(str(tmp_path / "ghost.yaml"))
+
+
+def test_load_manifest_invalid_yaml_raises(tmp_path: Path) -> None:
+    from agent_provisioning_team.shared.tool_manifest import load_manifest
+
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(": this is\n  : not yaml", encoding="utf-8")
+    with pytest.raises(ValueError):
+        load_manifest(str(bad))
+
+
+def test_load_manifest_invalid_structure(tmp_path: Path) -> None:
+    from agent_provisioning_team.shared.tool_manifest import load_manifest
+
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(
+        """
+tools:
+  - name: ""
+    provisioner: bogus
+""",
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError):
+        load_manifest(str(bad))
+
+
+def test_load_manifest_empty_file(tmp_path: Path) -> None:
+    from agent_provisioning_team.shared.tool_manifest import load_manifest
+
+    empty = tmp_path / "empty.yaml"
+    empty.write_text("", encoding="utf-8")
+    m = load_manifest(str(empty))
+    assert m.tools == []
+
+
+def test_validate_manifest_returns_errors(tmp_path: Path) -> None:
+    from agent_provisioning_team.shared.tool_manifest import validate_manifest
+
+    # Missing file
+    out = validate_manifest(str(tmp_path / "ghost.yaml"))
+    assert any("not found" in e.lower() for e in out)
+
+
+def test_validate_manifest_no_tools_warning(tmp_path: Path) -> None:
+    from agent_provisioning_team.shared.tool_manifest import validate_manifest
+
+    f = tmp_path / "empty_tools.yaml"
+    f.write_text("version: '1.0'\ntools: []\n", encoding="utf-8")
+    out = validate_manifest(str(f))
+    assert any("no tools" in e.lower() for e in out)
+
+
+def test_validate_manifest_duplicate_names(tmp_path: Path) -> None:
+    from agent_provisioning_team.shared.tool_manifest import validate_manifest
+
+    f = tmp_path / "dupes.yaml"
+    f.write_text(
+        """
+version: "1.0"
+tools:
+  - name: pg
+    provisioner: postgres_provisioner
+  - name: pg
+    provisioner: postgres_provisioner
+""",
+        encoding="utf-8",
+    )
+    out = validate_manifest(str(f))
+    assert any("duplicate" in e.lower() for e in out)
+
+
+def test_validate_manifest_clean(tmp_path: Path) -> None:
+    from agent_provisioning_team.shared.tool_manifest import validate_manifest
+
+    f = tmp_path / "good.yaml"
+    f.write_text(
+        """
+version: "1.0"
+tools:
+  - name: pg
+    provisioner: postgres_provisioner
+""",
+        encoding="utf-8",
+    )
+    out = validate_manifest(str(f))
+    assert out == []
+
+
+def test_assert_path_within_base_passes(tmp_path: Path) -> None:
+    from agent_provisioning_team.shared.tool_manifest import assert_path_within_base
+
+    base = tmp_path
+    target = tmp_path / "sub" / "x"
+    out = assert_path_within_base(str(target), str(base))
+    assert str(out).startswith(str(base.resolve()))
+
+
+def test_assert_path_within_base_rejects_escape(tmp_path: Path) -> None:
+    from agent_provisioning_team.shared.tool_manifest import assert_path_within_base
+
+    with pytest.raises(ValueError, match="escapes"):
+        assert_path_within_base("/etc/passwd", str(tmp_path))
+
+
+def test_tool_definition_invalid_provisioner_rejected() -> None:
+    from agent_provisioning_team.shared.tool_manifest import ToolDefinition
+
+    with pytest.raises(ValueError):
+        ToolDefinition(name="x", provisioner="quantum", config={})
+
+
+def test_tool_definition_lowercases_name() -> None:
+    from agent_provisioning_team.shared.tool_manifest import ToolDefinition
+
+    td = ToolDefinition(name="Postgres-XL", provisioner="postgres_provisioner", config={})
+    assert td.name == "postgres-xl"
+
+
+def test_tool_definition_invalid_name_rejected() -> None:
+    from agent_provisioning_team.shared.tool_manifest import ToolDefinition
+
+    with pytest.raises(ValueError):
+        ToolDefinition(name="hi there!", provisioner="postgres_provisioner")
+
+
+def test_tool_definition_ignores_unknown_top_level_fields() -> None:
+    """Older manifests with ``access_level`` should still parse — the field is
+    accepted but not surfaced."""
+    from agent_provisioning_team.shared.tool_manifest import ToolDefinition
+
+    td = ToolDefinition(
+        name="t",
+        provisioner="generic_provisioner",
+        config={},
+        access_level="full",  # unknown / legacy
+    )
+    assert not hasattr(td, "access_level")
+
+
+def test_redis_config_visibility_validator() -> None:
+    """Cover the git visibility validator via direct manifest construction."""
+    from agent_provisioning_team.shared.tool_manifest import ToolDefinition
+
+    td = ToolDefinition(name="g", provisioner="git_provisioner", config={"visibility": "public"})
+    assert td.config["visibility"] == "public"
+
+
+def test_validate_provisioner_config_unknown() -> None:
+    from agent_provisioning_team.shared.tool_manifest import validate_provisioner_config
+
+    with pytest.raises(ValueError, match="Unknown provisioner"):
+        validate_provisioner_config("bogus", {})
+
+
+def test_validate_manifest_environment_handles_blank_string() -> None:
+    from agent_provisioning_team.shared.tool_manifest import validate_manifest_environment
+
+    # None value gets coerced to ""
+    out = validate_manifest_environment({"FOO": ""})
+    assert out["FOO"] == ""
+
+
+def test_validate_manifest_environment_rejects_non_scalar() -> None:
+    from agent_provisioning_team.shared.tool_manifest import validate_manifest_environment
+
+    with pytest.raises(ValueError, match="scalar"):
+        validate_manifest_environment({"FOO": ["a", "b"]})
+
+
+def test_validate_manifest_environment_rejects_empty_key() -> None:
+    from agent_provisioning_team.shared.tool_manifest import validate_manifest_environment
+
+    with pytest.raises(ValueError, match="non-empty"):
+        validate_manifest_environment({"": "x"})
+
+
+def test_validate_manifest_environment_rejects_long_key() -> None:
+    from agent_provisioning_team.shared.tool_manifest import validate_manifest_environment
+
+    with pytest.raises(ValueError, match="too long"):
+        validate_manifest_environment({"X" * 200: "y"})
+
+
+def test_validate_manifest_environment_caps_value_length() -> None:
+    from agent_provisioning_team.shared.tool_manifest import validate_manifest_environment
+
+    with pytest.raises(ValueError, match="exceeds"):
+        validate_manifest_environment({"FOO": "x" * 10_000})
+
+
+def test_validate_provisioner_config_normalizes() -> None:
+    from agent_provisioning_team.shared.tool_manifest import validate_provisioner_config
+
+    out = validate_provisioner_config("postgres_provisioner", {})
+    assert out["database_prefix"] == "agent_"
+
+
+def test_reject_traversal_components_helper() -> None:
+    from agent_provisioning_team.shared.tool_manifest import _reject_traversal_components
+
+    out = _reject_traversal_components("/tmp/x", field="p")
+    assert out == "/tmp/x"
+
+
+def test_reject_path_separators_helper_rejects_empty() -> None:
+    from agent_provisioning_team.shared.tool_manifest import _reject_path_separators
+
+    with pytest.raises(ValueError, match="non-empty"):
+        _reject_path_separators("", field="x")
+
+
+def test_reject_path_separators_helper_rejects_traversal() -> None:
+    from agent_provisioning_team.shared.tool_manifest import _reject_path_separators
+
+    with pytest.raises(ValueError, match="traverse"):
+        _reject_path_separators("..", field="x")
+
+
+# ---------------------------------------------------------------------------
+# tool_agent_registry
+# ---------------------------------------------------------------------------
+
+
+def test_build_default_tool_agents_has_required_keys() -> None:
+    from agent_provisioning_team.shared.tool_agent_registry import build_default_tool_agents
+
+    out = build_default_tool_agents()
+    for key in (
+        "docker_provisioner",
+        "postgres_provisioner",
+        "redis_provisioner",
+        "git_provisioner",
+        "generic_provisioner",
+    ):
+        assert key in out
+
+
+# ---------------------------------------------------------------------------
+# provisioner_state edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_provisioner_state_load_corrupt_file(tmp_path: Path) -> None:
+    from agent_provisioning_team.shared.provisioner_state import ProvisionerStateStore
+
+    # Pre-write a corrupt file
+    state = ProvisionerStateStore("xx", storage_dir=tmp_path)
+    state.path.write_text("not json", encoding="utf-8")
+    # Reload should return {} instead of crashing
+    fresh = ProvisionerStateStore("xx", storage_dir=tmp_path)
+    assert fresh.get("any") is None
+
+
+def test_provisioner_state_list_agents(tmp_path: Path) -> None:
+    from agent_provisioning_team.shared.provisioner_state import ProvisionerStateStore
+
+    store = ProvisionerStateStore("xx", storage_dir=tmp_path)
+    store.put("a1", {"x": 1})
+    store.put("a2", {"y": 2})
+    out = store.list_agents()
+    assert out == {"a1": {"x": 1}, "a2": {"y": 2}}
+
+
+def test_compensation_record_serialization() -> None:
+    from agent_provisioning_team.shared.provisioner_state import CompensationRecord
+
+    rec = CompensationRecord(kind="k", payload={"a": 1})
+    d = rec.to_json()
+    restored = CompensationRecord.from_json(d)
+    assert restored.kind == rec.kind
+    assert restored.payload == rec.payload
+
+
+def test_clear_compensations_on_missing_agent(tmp_path: Path) -> None:
+    from agent_provisioning_team.shared.provisioner_state import ProvisionerStateStore
+
+    store = ProvisionerStateStore("xx", storage_dir=tmp_path)
+    # Should be a no-op rather than raising.
+    store.clear_compensations("missing")

--- a/backend/agents/agent_provisioning_team/tests/test_temporal_unit.py
+++ b/backend/agents/agent_provisioning_team/tests/test_temporal_unit.py
@@ -1,0 +1,630 @@
+"""Unit-level tests for Temporal activities, client, worker, and start_workflow.
+
+These tests do not need a live Temporal server; we mock at the
+``temporalio`` boundary (``activity.heartbeat``, ``Client.connect``) and
+verify the contracts each surface exposes.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# constants
+# ---------------------------------------------------------------------------
+
+
+def test_task_queue_default() -> None:
+    from agent_provisioning_team.temporal import constants
+
+    assert isinstance(constants.TASK_QUEUE, str)
+    assert constants.TASK_QUEUE
+    assert constants.WORKFLOW_ID_PREFIX == "agent-provisioning-"
+
+
+def test_task_queue_env_override(monkeypatch) -> None:
+    monkeypatch.setenv("TEMPORAL_TASK_QUEUE_AGENT_PROVISIONING", "custom-queue")
+    # Force re-import to pick up env override.
+    import importlib
+
+    from agent_provisioning_team.temporal import constants as constants_mod
+
+    reloaded = importlib.reload(constants_mod)
+    assert reloaded.TASK_QUEUE == "custom-queue"
+
+    # Restore original module by reloading without the env var
+    monkeypatch.delenv("TEMPORAL_TASK_QUEUE_AGENT_PROVISIONING", raising=False)
+    importlib.reload(reloaded)
+
+
+# ---------------------------------------------------------------------------
+# client.py
+# ---------------------------------------------------------------------------
+
+
+def test_client_helpers_default_env(monkeypatch) -> None:
+    from agent_provisioning_team.temporal import client
+
+    monkeypatch.delenv("TEMPORAL_ADDRESS", raising=False)
+    monkeypatch.delenv("TEMPORAL_NAMESPACE", raising=False)
+    assert client.get_temporal_address() is None
+    assert client.get_temporal_namespace() == "default"
+    assert client.is_temporal_enabled() is False
+
+
+def test_client_helpers_with_env(monkeypatch) -> None:
+    from agent_provisioning_team.temporal import client
+
+    monkeypatch.setenv("TEMPORAL_ADDRESS", "  localhost:7233  ")
+    monkeypatch.setenv("TEMPORAL_NAMESPACE", "  myns  ")
+    assert client.get_temporal_address() == "localhost:7233"
+    assert client.get_temporal_namespace() == "myns"
+    assert client.is_temporal_enabled() is True
+
+
+def test_client_get_and_set() -> None:
+    from agent_provisioning_team.temporal import client
+
+    sentinel = MagicMock(name="fake-client")
+    client.set_temporal_client(sentinel)
+    assert client.get_temporal_client() is sentinel
+    client.set_temporal_client(None)
+    assert client.get_temporal_client() is None
+
+
+def test_loop_get_and_set() -> None:
+    from agent_provisioning_team.temporal import client
+
+    loop = asyncio.new_event_loop()
+    try:
+        client.set_temporal_loop(loop)
+        assert client.get_temporal_loop() is loop
+    finally:
+        client.set_temporal_loop(None)
+        loop.close()
+    assert client.get_temporal_loop() is None
+
+
+def test_connect_temporal_client_returns_none_when_address_blank(monkeypatch) -> None:
+    from agent_provisioning_team.temporal import client
+
+    monkeypatch.delenv("TEMPORAL_ADDRESS", raising=False)
+
+    async def _run():
+        result = await client.connect_temporal_client()
+        return result
+
+    assert asyncio.run(_run()) is None
+
+
+def test_connect_temporal_client_connects_when_address_set(monkeypatch) -> None:
+    from agent_provisioning_team.temporal import client
+
+    monkeypatch.setenv("TEMPORAL_ADDRESS", "localhost:7233")
+    monkeypatch.setenv("TEMPORAL_NAMESPACE", "myns")
+
+    fake_client = MagicMock(name="connected-client")
+
+    with patch("temporalio.client.Client") as mock_client_cls:
+        mock_client_cls.connect = AsyncMock(return_value=fake_client)
+
+        async def _run():
+            return await client.connect_temporal_client()
+
+        result = asyncio.run(_run())
+
+    assert result is fake_client
+    mock_client_cls.connect.assert_awaited_once_with("localhost:7233", namespace="myns")
+
+
+def test_connect_temporal_client_raises_on_failure(monkeypatch) -> None:
+    from agent_provisioning_team.temporal import client
+
+    monkeypatch.setenv("TEMPORAL_ADDRESS", "localhost:7233")
+
+    with patch("temporalio.client.Client") as mock_client_cls:
+        mock_client_cls.connect = AsyncMock(side_effect=RuntimeError("boom"))
+
+        async def _run():
+            return await client.connect_temporal_client()
+
+        with pytest.raises(RuntimeError):
+            asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# start_workflow.py
+# ---------------------------------------------------------------------------
+
+
+def test_run_async_raises_without_client(monkeypatch) -> None:
+    from agent_provisioning_team.temporal import start_workflow as sw
+
+    with (
+        patch.object(sw, "get_temporal_loop", return_value=None),
+        patch.object(sw, "get_temporal_client", return_value=None),
+    ):
+        with pytest.raises(RuntimeError, match="Temporal client not available"):
+            sw._run_async(asyncio.sleep(0))
+
+
+def test_start_provisioning_workflow_passes_args(monkeypatch) -> None:
+    from agent_provisioning_team.temporal import start_workflow as sw
+
+    fake_client = MagicMock()
+    fake_client.start_workflow = AsyncMock()
+    loop = asyncio.new_event_loop()
+
+    captured: dict = {}
+
+    def fake_run_async(coro):
+        # Just close the coroutine without scheduling — we only need to
+        # observe that the right call was queued.
+        coro.close()
+        captured["called"] = True
+
+    with (
+        patch.object(sw, "get_temporal_client", return_value=fake_client),
+        patch.object(sw, "get_temporal_loop", return_value=loop),
+        patch.object(sw, "_run_async", side_effect=fake_run_async),
+    ):
+        sw.start_provisioning_workflow(
+            "job-1",
+            "agent-1",
+            "default.yaml",
+            skip_phases=["setup"],
+            prior_results={"setup": {"success": True}},
+        )
+
+    assert captured["called"] is True
+    loop.close()
+
+
+def test_start_provisioning_workflow_raises_without_client() -> None:
+    from agent_provisioning_team.temporal import start_workflow as sw
+
+    with patch.object(sw, "get_temporal_client", return_value=None):
+        with pytest.raises(RuntimeError, match="Temporal client not available"):
+            sw.start_provisioning_workflow("j", "a", "default.yaml")
+
+
+# ---------------------------------------------------------------------------
+# worker.py
+# ---------------------------------------------------------------------------
+
+
+def test_create_worker_returns_none_when_disabled() -> None:
+    from agent_provisioning_team.temporal import worker as worker_mod
+
+    with patch.object(worker_mod, "is_temporal_enabled", return_value=False):
+        assert worker_mod.create_agent_provisioning_worker(client=MagicMock()) is None
+
+
+def test_create_worker_returns_none_when_no_client() -> None:
+    from agent_provisioning_team.temporal import worker as worker_mod
+
+    with patch.object(worker_mod, "is_temporal_enabled", return_value=True):
+        assert worker_mod.create_agent_provisioning_worker(client=None) is None
+
+
+def test_create_worker_constructs_worker_when_enabled() -> None:
+    from agent_provisioning_team.temporal import worker as worker_mod
+
+    fake_worker = MagicMock(name="fake-worker")
+    with (
+        patch.object(worker_mod, "is_temporal_enabled", return_value=True),
+        patch.object(worker_mod, "Worker", return_value=fake_worker) as mock_worker_cls,
+    ):
+        result = worker_mod.create_agent_provisioning_worker(client=MagicMock())
+
+    assert result is fake_worker
+    mock_worker_cls.assert_called_once()
+    # Ensure activities / workflows lists make it through
+    _, kwargs = mock_worker_cls.call_args
+    assert kwargs["task_queue"] == worker_mod.TASK_QUEUE
+    assert worker_mod.AgentProvisioningWorkflow in kwargs["workflows"]
+    assert worker_mod.AgentProvisioningWorkflowV2 in kwargs["workflows"]
+    assert len(kwargs["activities"]) == 8
+
+
+# ---------------------------------------------------------------------------
+# activities.py — v1 + v2 surfaces
+# ---------------------------------------------------------------------------
+
+
+def test_v1_activity_delegates_to_run_provisioning_background() -> None:
+    from agent_provisioning_team.temporal import activities
+
+    with patch("agent_provisioning_team.api.main._run_provisioning_background") as mock_bg:
+        activities.run_provisioning_activity("job-1", "agent-1", "default.yaml")
+
+    mock_bg.assert_called_once_with("job-1", "agent-1", "default.yaml")
+
+
+def test_safe_swallows_exceptions() -> None:
+    from agent_provisioning_team.temporal import activities
+
+    with patch.object(activities._js, "create_job", side_effect=RuntimeError("boom")):
+        # Must not raise — this is "best-effort job_store call".
+        activities._safe("create_job", "j", "a", "m")
+
+
+def test_restored_writes_status_update() -> None:
+    from agent_provisioning_team.temporal import activities
+
+    with patch.object(activities, "_safe") as mock_safe:
+        activities._restored("j-1", "setup", 15)
+
+    # Should have called update_job once
+    mock_safe.assert_called_with(
+        "update_job",
+        "j-1",
+        current_phase="setup",
+        progress=15,
+        status_text="Restored setup from previous run",
+    )
+
+
+def test_credentials_activity_v2_restores_from_prior() -> None:
+    from agent_provisioning_team.temporal import activities
+
+    with (
+        patch.object(activities, "_safe"),
+        patch("temporalio.activity.heartbeat"),
+    ):
+        prior = {"success": True, "credentials": {}}
+        payload = activities.credentials_activity_v2(
+            "j", "a", "default.yaml", prior_credentials=prior
+        )
+
+    assert payload == {"success": True, "credentials": {}}
+
+
+def test_credentials_activity_v2_runs_when_no_prior() -> None:
+    from agent_provisioning_team.models import CredentialGenerationResult, GeneratedCredentials
+    from agent_provisioning_team.temporal import activities
+
+    fake_result = CredentialGenerationResult(
+        success=True,
+        credentials={"pg": GeneratedCredentials(tool_name="pg", username="u", password="p")},
+    )
+
+    fake_manifest = MagicMock()
+    fake_orch = MagicMock()
+    fake_orch.credential_store = MagicMock()
+
+    with (
+        patch.object(activities, "_safe"),
+        patch(
+            "agent_provisioning_team.orchestrator.ProvisioningOrchestrator",
+            return_value=fake_orch,
+        ),
+        patch(
+            "agent_provisioning_team.shared.tool_manifest.load_manifest",
+            return_value=fake_manifest,
+        ),
+        patch(
+            "agent_provisioning_team.phases.credential_generation.run_credential_generation",
+            return_value=fake_result,
+        ),
+        patch("temporalio.activity.heartbeat"),
+    ):
+        payload = activities.credentials_activity_v2("j", "a", "default.yaml")
+
+    assert payload["success"] is True
+    assert "pg" in payload["credentials"]
+
+
+def test_credentials_activity_v2_raises_on_failure() -> None:
+    from agent_provisioning_team.models import CredentialGenerationResult
+    from agent_provisioning_team.temporal import activities
+
+    fake_result = CredentialGenerationResult(success=False, credentials={}, error="cred boom")
+
+    with (
+        patch.object(activities, "_safe"),
+        patch("agent_provisioning_team.orchestrator.ProvisioningOrchestrator"),
+        patch(
+            "agent_provisioning_team.shared.tool_manifest.load_manifest", return_value=MagicMock()
+        ),
+        patch(
+            "agent_provisioning_team.phases.credential_generation.run_credential_generation",
+            return_value=fake_result,
+        ),
+        patch("temporalio.activity.heartbeat"),
+    ):
+        with pytest.raises(RuntimeError, match="cred boom"):
+            activities.credentials_activity_v2("j", "a", "default.yaml")
+
+
+def test_provision_tool_activity_calls_provisioner() -> None:
+    from agent_provisioning_team.models import GeneratedCredentials, ToolProvisionResult
+    from agent_provisioning_team.temporal import activities
+
+    fake_provisioner = MagicMock()
+    fake_provisioner.provision.return_value = ToolProvisionResult(
+        tool_name="pg", success=True, provisioner_key="postgres_provisioner"
+    )
+
+    fake_tool = MagicMock()
+    fake_tool.provisioner = "postgres_provisioner"
+    fake_tool.config = {}
+    fake_manifest = MagicMock()
+    fake_manifest.get_tool.return_value = fake_tool
+
+    with (
+        patch.object(activities, "_safe"),
+        patch(
+            "agent_provisioning_team.shared.tool_manifest.load_manifest",
+            return_value=fake_manifest,
+        ),
+        patch(
+            "agent_provisioning_team.shared.tool_agent_registry.build_default_tool_agents",
+            return_value={"postgres_provisioner": fake_provisioner},
+        ),
+        patch("temporalio.activity.heartbeat"),
+    ):
+        creds = GeneratedCredentials(tool_name="pg", username="u", password="p")
+        payload = activities.provision_tool_activity(
+            "j",
+            "a",
+            "pg",
+            "default.yaml",
+            credentials_dump=creds.model_dump(),
+            tools_completed_so_far=0,
+            tools_total=1,
+        )
+
+    assert payload["success"] is True
+    fake_provisioner.provision.assert_called_once()
+
+
+def test_provision_tool_activity_raises_when_tool_missing() -> None:
+    from agent_provisioning_team.models import GeneratedCredentials
+    from agent_provisioning_team.temporal import activities
+
+    fake_manifest = MagicMock()
+    fake_manifest.get_tool.return_value = None
+
+    with (
+        patch.object(activities, "_safe"),
+        patch(
+            "agent_provisioning_team.shared.tool_manifest.load_manifest",
+            return_value=fake_manifest,
+        ),
+        patch(
+            "agent_provisioning_team.shared.tool_agent_registry.build_default_tool_agents",
+            return_value={},
+        ),
+        patch("temporalio.activity.heartbeat"),
+    ):
+        creds = GeneratedCredentials(tool_name="x")
+        with pytest.raises(RuntimeError, match="not in manifest"):
+            activities.provision_tool_activity(
+                "j", "a", "x", "default.yaml", credentials_dump=creds.model_dump()
+            )
+
+
+def test_provision_tool_activity_raises_when_provisioner_missing() -> None:
+    from agent_provisioning_team.models import GeneratedCredentials
+    from agent_provisioning_team.temporal import activities
+
+    fake_tool = MagicMock()
+    fake_tool.provisioner = "unknown_provisioner"
+    fake_tool.config = {}
+    fake_manifest = MagicMock()
+    fake_manifest.get_tool.return_value = fake_tool
+
+    with (
+        patch.object(activities, "_safe"),
+        patch(
+            "agent_provisioning_team.shared.tool_manifest.load_manifest",
+            return_value=fake_manifest,
+        ),
+        patch(
+            "agent_provisioning_team.shared.tool_agent_registry.build_default_tool_agents",
+            return_value={},
+        ),
+        patch("temporalio.activity.heartbeat"),
+    ):
+        creds = GeneratedCredentials(tool_name="x")
+        with pytest.raises(RuntimeError, match="unknown provisioner"):
+            activities.provision_tool_activity(
+                "j", "a", "x", "default.yaml", credentials_dump=creds.model_dump()
+            )
+
+
+def test_audit_activity_v2_restores_from_prior() -> None:
+    from agent_provisioning_team.models import AccessAuditResult
+    from agent_provisioning_team.temporal import activities
+
+    prior = AccessAuditResult(passed=True, verifications=[]).model_dump()
+    with (
+        patch.object(activities, "_safe"),
+        patch("temporalio.activity.heartbeat"),
+    ):
+        payload = activities.audit_activity_v2(
+            "j", "a", "default.yaml", tool_results_dump=[], prior_audit=prior
+        )
+
+    assert payload["passed"] is True
+
+
+def test_audit_activity_v2_runs_when_no_prior() -> None:
+    from agent_provisioning_team.models import AccessAuditResult
+    from agent_provisioning_team.temporal import activities
+
+    fake_result = AccessAuditResult(passed=True, verifications=[])
+
+    with (
+        patch.object(activities, "_safe"),
+        patch(
+            "agent_provisioning_team.shared.tool_manifest.load_manifest",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "agent_provisioning_team.shared.tool_agent_registry.build_default_tool_agents",
+            return_value={},
+        ),
+        patch(
+            "agent_provisioning_team.phases.access_audit.run_access_audit",
+            return_value=fake_result,
+        ),
+        patch("temporalio.activity.heartbeat"),
+    ):
+        payload = activities.audit_activity_v2("j", "a", "default.yaml", tool_results_dump=[])
+
+    assert payload["passed"] is True
+
+
+def test_documentation_activity_v2_restores_from_prior() -> None:
+    from agent_provisioning_team.temporal import activities
+
+    prior = {"success": True, "onboarding": None}
+    with (
+        patch.object(activities, "_safe"),
+        patch("temporalio.activity.heartbeat"),
+    ):
+        payload = activities.documentation_activity_v2(
+            "j",
+            "a",
+            "default.yaml",
+            credentials_dump={},
+            tool_results_dump=[],
+            workspace_path="/ws",
+            prior_documentation=prior,
+        )
+
+    assert payload == {"success": True, "onboarding": None}
+
+
+def test_documentation_activity_v2_runs_when_no_prior() -> None:
+    from agent_provisioning_team.models import DocumentationResult, OnboardingPacket
+    from agent_provisioning_team.temporal import activities
+
+    onboarding = OnboardingPacket(summary="s", tools=[], environment_variables={})
+    fake_result = DocumentationResult(success=True, onboarding=onboarding)
+
+    with (
+        patch.object(activities, "_safe"),
+        patch(
+            "agent_provisioning_team.shared.tool_manifest.load_manifest",
+            return_value=MagicMock(),
+        ),
+        patch(
+            "agent_provisioning_team.phases.documentation.run_documentation",
+            return_value=fake_result,
+        ),
+        patch("temporalio.activity.heartbeat"),
+    ):
+        payload = activities.documentation_activity_v2(
+            "j",
+            "a",
+            "default.yaml",
+            credentials_dump={},
+            tool_results_dump=[],
+            workspace_path="/ws",
+        )
+
+    assert payload["success"] is True
+    assert payload["onboarding"]["summary"] == "s"
+
+
+def test_deliver_activity_v2_success_path() -> None:
+    from agent_provisioning_team.models import (
+        DeliverResult,
+        EnvironmentInfo,
+        ProvisioningResult,
+    )
+    from agent_provisioning_team.temporal import activities
+
+    env = EnvironmentInfo(container_id="c1", container_name="c1")
+    fake_deliver = DeliverResult(success=True)
+    final = ProvisioningResult(agent_id="a", success=True, environment=env)
+
+    with (
+        patch.object(activities, "_safe") as mock_safe,
+        patch("agent_provisioning_team.phases.deliver.run_deliver", return_value=fake_deliver),
+        patch("agent_provisioning_team.phases.deliver.build_final_result", return_value=final),
+        patch(
+            "agent_provisioning_team.phases.deliver.redact_credentials_for_response",
+            return_value=final,
+        ),
+        patch("agent_provisioning_team.orchestrator.ProvisioningOrchestrator"),
+        patch("temporalio.activity.heartbeat"),
+    ):
+        payload = activities.deliver_activity_v2(
+            "j",
+            "a",
+            environment_dump=env.model_dump(),
+            credentials_dump={},
+            tool_results_dump=[],
+            audit_dump=None,
+            onboarding_dump=None,
+        )
+
+    assert payload == {"success": True, "error": None}
+    # Should have called mark_job_completed
+    calls = [c.args[0] for c in mock_safe.call_args_list]
+    assert "mark_job_completed" in calls
+
+
+def test_deliver_activity_v2_failure_path() -> None:
+    from agent_provisioning_team.models import (
+        DeliverResult,
+        ProvisioningResult,
+    )
+    from agent_provisioning_team.temporal import activities
+
+    fake_deliver = DeliverResult(success=False, error="oops")
+    final = ProvisioningResult(agent_id="a", success=False, error="oops")
+
+    with (
+        patch.object(activities, "_safe") as mock_safe,
+        patch("agent_provisioning_team.phases.deliver.run_deliver", return_value=fake_deliver),
+        patch("agent_provisioning_team.phases.deliver.build_final_result", return_value=final),
+        patch("agent_provisioning_team.orchestrator.ProvisioningOrchestrator"),
+        patch("temporalio.activity.heartbeat"),
+    ):
+        payload = activities.deliver_activity_v2(
+            "j",
+            "a",
+            environment_dump=None,
+            credentials_dump={},
+            tool_results_dump=[],
+            audit_dump=None,
+            onboarding_dump=None,
+        )
+
+    assert payload == {"success": False, "error": "oops"}
+    calls = [c.args[0] for c in mock_safe.call_args_list]
+    assert "mark_job_failed" in calls
+
+
+def test_compensate_activity_v2_invokes_orchestrator() -> None:
+    from agent_provisioning_team.temporal import activities
+
+    fake_orch = MagicMock()
+    with patch(
+        "agent_provisioning_team.orchestrator.ProvisioningOrchestrator",
+        return_value=fake_orch,
+    ):
+        activities.compensate_activity_v2(
+            "agent-1",
+            [
+                {"tool_name": "pg", "provisioner_key": "postgres_provisioner"},
+                {"tool_name": "redis", "provisioner_key": "redis_provisioner"},
+            ],
+        )
+
+    fake_orch._compensate.assert_called_once()
+    args, _ = fake_orch._compensate.call_args
+    assert args[0] == "agent-1"
+    shims = args[1]
+    assert len(shims) == 2
+    assert shims[0].tool_name == "pg"
+    assert shims[0].provisioner_key == "postgres_provisioner"
+    assert shims[0].success is True

--- a/backend/agents/agent_provisioning_team/tests/test_temporal_unit.py
+++ b/backend/agents/agent_provisioning_team/tests/test_temporal_unit.py
@@ -147,8 +147,12 @@ def test_run_async_raises_without_client(monkeypatch) -> None:
         patch.object(sw, "get_temporal_loop", return_value=None),
         patch.object(sw, "get_temporal_client", return_value=None),
     ):
-        with pytest.raises(RuntimeError, match="Temporal client not available"):
-            sw._run_async(asyncio.sleep(0))
+        coro = asyncio.sleep(0)
+        try:
+            with pytest.raises(RuntimeError, match="Temporal client not available"):
+                sw._run_async(coro)
+        finally:
+            coro.close()
 
 
 def test_start_provisioning_workflow_passes_args(monkeypatch) -> None:

--- a/backend/agents/agent_provisioning_team/tests/test_tool_agents.py
+++ b/backend/agents/agent_provisioning_team/tests/test_tool_agents.py
@@ -968,17 +968,29 @@ def test_redis_provision_full_path(tmp_path: Path, monkeypatch) -> None:
 
 
 def test_redis_provision_handles_deluser_response_error(tmp_path: Path, monkeypatch) -> None:
-    import redis  # type: ignore[import-not-found]
-
     from agent_provisioning_team.tool_agents import redis_provisioner as rm
     from agent_provisioning_team.tool_agents.redis_provisioner import RedisProvisionerTool
 
+    # Avoid a hard dependency on the optional ``redis`` package: synthesize a
+    # local stub exposing ``exceptions.ResponseError`` and patch the module
+    # attribute so the production ``except redis.exceptions.ResponseError``
+    # clause catches our local exception type.
+    class _StubResponseError(Exception):
+        pass
+
+    class _StubExceptions:
+        ResponseError = _StubResponseError
+
+    class _StubRedis:
+        exceptions = _StubExceptions
+
+    monkeypatch.setattr(rm, "redis", _StubRedis, raising=False)
     monkeypatch.setattr(rm, "HAS_REDIS", True)
     prov = RedisProvisionerTool()
     prov._state = ProvisionerStateStore("redis_provisioner", storage_dir=tmp_path)
 
     fake_client = MagicMock()
-    fake_client.acl_deluser.side_effect = redis.exceptions.ResponseError("nope")
+    fake_client.acl_deluser.side_effect = _StubResponseError("nope")
     with patch.object(prov, "_get_admin_client", return_value=fake_client):
         result = prov.provision(
             "a1",
@@ -1008,18 +1020,30 @@ def test_redis_deprovision_full_path(tmp_path: Path, monkeypatch) -> None:
 
 
 def test_redis_deprovision_handles_response_error(tmp_path: Path, monkeypatch) -> None:
-    import redis
-
     from agent_provisioning_team.tool_agents import redis_provisioner as rm
     from agent_provisioning_team.tool_agents.redis_provisioner import RedisProvisionerTool
 
+    # Avoid a hard dependency on the optional ``redis`` package: synthesize a
+    # local stub exposing ``exceptions.ResponseError`` and patch the module
+    # attribute so the production ``except redis.exceptions.ResponseError``
+    # clause catches our local exception type.
+    class _StubResponseError(Exception):
+        pass
+
+    class _StubExceptions:
+        ResponseError = _StubResponseError
+
+    class _StubRedis:
+        exceptions = _StubExceptions
+
+    monkeypatch.setattr(rm, "redis", _StubRedis, raising=False)
     monkeypatch.setattr(rm, "HAS_REDIS", True)
     prov = RedisProvisionerTool()
     prov._state = ProvisionerStateStore("redis_provisioner", storage_dir=tmp_path)
     prov._state.put("a1", {"username": "u1"})
 
     fake_client = MagicMock()
-    fake_client.acl_deluser.side_effect = redis.exceptions.ResponseError("missing user")
+    fake_client.acl_deluser.side_effect = _StubResponseError("missing user")
     with patch.object(prov, "_get_admin_client", return_value=fake_client):
         out = prov.deprovision("a1")
 
@@ -1051,9 +1075,11 @@ def test_redis_get_admin_client_no_lib(monkeypatch) -> None:
         prov._get_admin_client()
 
 
-def test_redis_on_reuse_populates_credentials(tmp_path: Path) -> None:
+def test_redis_on_reuse_populates_credentials(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.tool_agents import redis_provisioner as rm
     from agent_provisioning_team.tool_agents.redis_provisioner import RedisProvisionerTool
 
+    monkeypatch.setattr(rm, "HAS_REDIS", True)
     prov = RedisProvisionerTool()
     prov._state = ProvisionerStateStore("redis_provisioner", storage_dir=tmp_path)
     prov._state.put("a1", {"key_prefix": "k:", "permissions": ["+@all"]})

--- a/backend/agents/agent_provisioning_team/tests/test_tool_agents.py
+++ b/backend/agents/agent_provisioning_team/tests/test_tool_agents.py
@@ -1,0 +1,1100 @@
+"""Unit tests for tool provisioner agents.
+
+Docker / Postgres / Redis / Git are all mocked at the
+subprocess / library boundary — no real services are touched.
+"""
+
+from __future__ import annotations
+
+import subprocess as _subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agent_provisioning_team.models import GeneratedCredentials
+from agent_provisioning_team.shared.provisioner_state import (
+    CompensationRecord,
+    ProvisionerStateStore,
+)
+from agent_provisioning_team.tool_agents.base import BaseToolProvisioner
+
+# ---------------------------------------------------------------------------
+# base.py
+# ---------------------------------------------------------------------------
+
+
+class _MinimalProv(BaseToolProvisioner):
+    tool_name = "minimal"
+
+    def __init__(self, storage_dir: Path) -> None:
+        self._state = ProvisionerStateStore("minimal_prov", storage_dir=storage_dir)
+
+    def provision(self, agent_id, config, credentials):
+        return self.run_idempotent(
+            agent_id,
+            credentials=credentials,
+            create=lambda _r: (["read"], {"x": 1, "permissions": ["read"]}),
+        )
+
+    def verify_access(self, agent_id):
+        return self._make_verification(passed=True, actual_permissions=[])
+
+    def deprovision(self, agent_id):
+        from agent_provisioning_team.models import DeprovisionResult
+
+        return DeprovisionResult(tool_name=self.tool_name, success=True)
+
+
+def test_canonical_anatomy_preamble_returns_text() -> None:
+    text = BaseToolProvisioner.canonical_anatomy_prompt_preamble()
+    assert isinstance(text, str)
+    assert "anatomy" in text.lower() or "Khala" in text
+
+
+def test_make_error_result_shape() -> None:
+    prov = _MinimalProv(Path("/tmp/test-state-1"))
+    out = prov._make_error_result("nope")
+    assert out.success is False
+    assert out.error == "nope"
+    assert out.tool_name == "minimal"
+
+
+def test_make_verification_with_warnings_errors() -> None:
+    prov = _MinimalProv(Path("/tmp/test-state-2"))
+    v = prov._make_verification(
+        passed=False,
+        actual_permissions=["read"],
+        warnings=["w1"],
+        errors=["e1"],
+    )
+    assert v.passed is False
+    assert v.warnings == ["w1"]
+    assert v.errors == ["e1"]
+
+
+def test_replay_compensation_default_logs_warning(tmp_path: Path, caplog) -> None:
+    prov = _MinimalProv(tmp_path)
+    # Default replay_compensation just logs and returns None
+    prov.replay_compensation("a", "unknown.kind", {"data": 1})
+    # Function returns nothing; nothing raises.
+
+
+def test_run_idempotent_handles_filenotfound(tmp_path: Path) -> None:
+    class _FNFProv(BaseToolProvisioner):
+        tool_name = "fnf"
+
+        def __init__(self) -> None:
+            self._state = ProvisionerStateStore("fnf_prov", storage_dir=tmp_path)
+
+        def provision(self, agent_id, config, credentials):
+            def _create(_r):
+                raise FileNotFoundError("git not found")
+
+            return self.run_idempotent(agent_id, credentials=credentials, create=_create)
+
+        def verify_access(self, agent_id):
+            return self._make_verification(passed=True, actual_permissions=[])
+
+        def deprovision(self, agent_id):
+            from agent_provisioning_team.models import DeprovisionResult
+
+            return DeprovisionResult(tool_name=self.tool_name, success=True)
+
+    out = _FNFProv().provision("a", {}, GeneratedCredentials(tool_name="x"))
+    assert out.success is False
+    assert "binary not found" in out.error
+
+
+def test_run_idempotent_handles_permission_error(tmp_path: Path) -> None:
+    class _PermProv(BaseToolProvisioner):
+        tool_name = "perm"
+
+        def __init__(self) -> None:
+            self._state = ProvisionerStateStore("perm_prov", storage_dir=tmp_path)
+
+        def provision(self, agent_id, config, credentials):
+            def _create(_r):
+                raise PermissionError("nope")
+
+            return self.run_idempotent(agent_id, credentials=credentials, create=_create)
+
+        def verify_access(self, agent_id):
+            return self._make_verification(passed=True, actual_permissions=[])
+
+        def deprovision(self, agent_id):
+            from agent_provisioning_team.models import DeprovisionResult
+
+            return DeprovisionResult(tool_name=self.tool_name, success=True)
+
+    out = _PermProv().provision("a", {}, GeneratedCredentials(tool_name="x"))
+    assert out.success is False
+    assert "permission denied" in out.error
+
+
+def test_list_and_clear_compensations(tmp_path: Path) -> None:
+    prov = _MinimalProv(tmp_path)
+    prov._state.add_compensation("a", CompensationRecord(kind="k1", payload={}))
+    assert len(prov.list_compensations("a")) == 1
+    prov.clear_compensations("a")
+    assert prov.list_compensations("a") == []
+
+
+def test_run_idempotent_hydrates_extras(tmp_path: Path) -> None:
+    class _HydrateProv(BaseToolProvisioner):
+        tool_name = "hyd"
+
+        def __init__(self) -> None:
+            self._state = ProvisionerStateStore("hyd_prov", storage_dir=tmp_path)
+
+        def provision(self, agent_id, config, credentials):
+            return self.run_idempotent(
+                agent_id,
+                credentials=credentials,
+                create=lambda _r: (
+                    ["all"],
+                    {"workspace_path": "/ws", "permissions": ["all"]},
+                ),
+                hydrate_extras=("workspace_path",),
+            )
+
+        def verify_access(self, agent_id):
+            return self._make_verification(passed=True, actual_permissions=[])
+
+        def deprovision(self, agent_id):
+            from agent_provisioning_team.models import DeprovisionResult
+
+            return DeprovisionResult(tool_name=self.tool_name, success=True)
+
+    prov = _HydrateProv()
+    creds1 = GeneratedCredentials(tool_name="hyd")
+    first = prov.provision("a", {}, creds1)
+    assert first.success
+    assert first.details["workspace_path"] == "/ws"
+
+    # Second call hydrates extras into a fresh creds object
+    creds2 = GeneratedCredentials(tool_name="hyd")
+    second = prov.provision("a", {}, creds2)
+    assert second.success
+    assert second.details.get("reused") is True
+    assert creds2.extra.get("workspace_path") == "/ws"
+
+
+# ---------------------------------------------------------------------------
+# docker_provisioner.py
+# ---------------------------------------------------------------------------
+
+
+def _docker_run_success(*args, **kwargs):
+    return SimpleNamespace(returncode=0, stdout="abc123def456789012\n", stderr="")
+
+
+def test_docker_provisioner_provision_success(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.tool_agents.docker_provisioner import DockerProvisionerTool
+
+    prov = DockerProvisionerTool(workspace_base=str(tmp_path / "ws"))
+    prov._state = ProvisionerStateStore("docker_provisioner", storage_dir=tmp_path)
+
+    with patch("subprocess.run", side_effect=_docker_run_success):
+        result = prov.provision(
+            "agent-1",
+            {"base_image": "python:3.11", "expose_ssh": True, "environment": {"FOO": "bar"}},
+            GeneratedCredentials(tool_name="docker"),
+        )
+
+    assert result.success is True
+    assert result.details["container_id"].startswith("abc123")
+    assert result.details["status"] == "running"
+
+
+def test_docker_provisioner_provision_returns_error_on_nonzero(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.docker_provisioner import DockerProvisionerTool
+
+    prov = DockerProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("docker_provisioner", storage_dir=tmp_path)
+
+    def _fail(*a, **kw):
+        return SimpleNamespace(returncode=1, stdout="", stderr="something bad")
+
+    with patch("subprocess.run", side_effect=_fail):
+        result = prov.provision("agent-1", {}, GeneratedCredentials(tool_name="docker"))
+
+    assert result.success is False
+    assert "Docker run failed" in result.error or "something bad" in result.error
+
+
+def test_docker_provisioner_is_idempotent_on_existing_state(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.docker_provisioner import DockerProvisionerTool
+
+    prov = DockerProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("docker_provisioner", storage_dir=tmp_path)
+
+    with patch("subprocess.run", side_effect=_docker_run_success):
+        first = prov.provision("a1", {}, GeneratedCredentials(tool_name="docker"))
+        assert first.success
+
+    # Second call doesn't shell out (no patch needed); reuses state
+    second = prov.provision("a1", {}, GeneratedCredentials(tool_name="docker"))
+    assert second.success
+    assert second.details.get("reused") is True
+
+
+def test_docker_verify_access_no_state(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.docker_provisioner import DockerProvisionerTool
+
+    prov = DockerProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("docker_provisioner", storage_dir=tmp_path)
+
+    v = prov.verify_access("missing-agent")
+    assert v.passed is False
+    assert "No container" in v.errors[0]
+
+
+def test_docker_verify_access_success(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.docker_provisioner import DockerProvisionerTool
+
+    prov = DockerProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("docker_provisioner", storage_dir=tmp_path)
+    prov._state.put("a1", {"container_name": "c1"})
+
+    with patch(
+        "subprocess.run",
+        return_value=SimpleNamespace(returncode=0, stdout="", stderr=""),
+    ):
+        v = prov.verify_access("a1")
+
+    assert v.passed is True
+
+
+def test_docker_verify_access_failure(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.docker_provisioner import DockerProvisionerTool
+
+    prov = DockerProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("docker_provisioner", storage_dir=tmp_path)
+    prov._state.put("a1", {"container_name": "c1"})
+
+    with patch(
+        "subprocess.run",
+        return_value=SimpleNamespace(returncode=1, stdout="", stderr="bad"),
+    ):
+        v = prov.verify_access("a1")
+
+    assert v.passed is False
+
+
+def test_docker_verify_access_exception(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.docker_provisioner import DockerProvisionerTool
+
+    prov = DockerProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("docker_provisioner", storage_dir=tmp_path)
+    prov._state.put("a1", {"container_name": "c1"})
+
+    with patch("subprocess.run", side_effect=OSError("kaboom")):
+        v = prov.verify_access("a1")
+
+    assert v.passed is False
+    assert "kaboom" in v.errors[0]
+
+
+def test_docker_deprovision_no_state(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.docker_provisioner import DockerProvisionerTool
+
+    prov = DockerProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("docker_provisioner", storage_dir=tmp_path)
+
+    out = prov.deprovision("nobody")
+    assert out.success is True
+    assert "No container" in out.details["message"]
+
+
+def test_docker_deprovision_with_state(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.docker_provisioner import DockerProvisionerTool
+
+    prov = DockerProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("docker_provisioner", storage_dir=tmp_path)
+    prov._state.put("a1", {"container_name": "c1"})
+
+    with patch(
+        "subprocess.run",
+        return_value=SimpleNamespace(returncode=0, stdout="", stderr=""),
+    ):
+        out = prov.deprovision("a1")
+
+    assert out.success is True
+    assert out.details["container_removed"] == "c1"
+
+
+def test_docker_deprovision_handles_exception(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.docker_provisioner import DockerProvisionerTool
+
+    prov = DockerProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("docker_provisioner", storage_dir=tmp_path)
+    prov._state.put("a1", {"container_name": "c1"})
+
+    with patch("subprocess.run", side_effect=RuntimeError("daemon down")):
+        out = prov.deprovision("a1")
+
+    assert out.success is False
+    assert "daemon down" in out.error
+
+
+def test_docker_allocate_port_is_deterministic() -> None:
+    from agent_provisioning_team.tool_agents.docker_provisioner import DockerProvisionerTool
+
+    prov = DockerProvisionerTool()
+    p1 = prov._allocate_port("agent-a")
+    p2 = prov._allocate_port("agent-a")
+    assert p1 == p2
+    assert 22000 <= p1 < 23000
+
+
+def test_docker_get_container_info(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.docker_provisioner import DockerProvisionerTool
+
+    prov = DockerProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("docker_provisioner", storage_dir=tmp_path)
+    prov._state.put("a1", {"container_name": "c1"})
+
+    info = prov.get_container_info("a1")
+    assert info["container_name"] == "c1"
+    assert prov.get_container_info("missing") is None
+
+
+def test_docker_exec_in_container_no_state(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.docker_provisioner import DockerProvisionerTool
+
+    prov = DockerProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("docker_provisioner", storage_dir=tmp_path)
+
+    rc, out, err = prov.exec_in_container("missing", ["ls"])
+    assert rc == 1
+    assert "No container" in err
+
+
+def test_docker_exec_in_container_runs(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.docker_provisioner import DockerProvisionerTool
+
+    prov = DockerProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("docker_provisioner", storage_dir=tmp_path)
+    prov._state.put("a1", {"container_name": "c1"})
+
+    with patch(
+        "subprocess.run",
+        return_value=SimpleNamespace(returncode=0, stdout="hi\n", stderr=""),
+    ):
+        rc, out, err = prov.exec_in_container("a1", ["echo", "hi"])
+    assert rc == 0
+    assert out == "hi\n"
+
+
+def test_docker_exec_in_container_timeout(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.docker_provisioner import DockerProvisionerTool
+
+    prov = DockerProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("docker_provisioner", storage_dir=tmp_path)
+    prov._state.put("a1", {"container_name": "c1"})
+
+    with patch(
+        "subprocess.run",
+        side_effect=_subprocess.TimeoutExpired(cmd="docker exec", timeout=1),
+    ):
+        rc, out, err = prov.exec_in_container("a1", ["sleep", "100"])
+    assert rc == 1
+    assert "timed out" in err
+
+
+def test_docker_exec_in_container_handles_exception(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.docker_provisioner import DockerProvisionerTool
+
+    prov = DockerProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("docker_provisioner", storage_dir=tmp_path)
+    prov._state.put("a1", {"container_name": "c1"})
+
+    with patch("subprocess.run", side_effect=OSError("boom")):
+        rc, out, err = prov.exec_in_container("a1", ["x"])
+    assert rc == 1
+    assert "boom" in err
+
+
+def test_docker_on_reuse_populates_credentials(tmp_path: Path) -> None:
+    """Cover the _on_reuse path: stored state + fresh creds."""
+    from agent_provisioning_team.tool_agents.docker_provisioner import DockerProvisionerTool
+
+    prov = DockerProvisionerTool(workspace_base=str(tmp_path))
+    prov._state = ProvisionerStateStore("docker_provisioner", storage_dir=tmp_path)
+    prov._state.put(
+        "a1",
+        {
+            "container_id": "abcd",
+            "container_name": "c1",
+            "workspace_path": "/ws",
+            "status": "running",
+        },
+    )
+
+    creds = GeneratedCredentials(tool_name="docker")
+    result = prov.provision("a1", {}, creds)
+    assert result.success is True
+    assert creds.extra["container_id"] == "abcd"
+
+
+# ---------------------------------------------------------------------------
+# generic_provisioner.py
+# ---------------------------------------------------------------------------
+
+
+def test_generic_provisioner_provision_success(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.generic_provisioner import GenericProvisionerTool
+
+    tool = GenericProvisionerTool(tool_name="mytool")
+    tool._state = ProvisionerStateStore("generic_mytool_provisioner", storage_dir=tmp_path)
+
+    creds = GeneratedCredentials(tool_name="mytool")
+    out = tool.provision("a1", {"permissions": ["read", "write"]}, creds)
+    assert out.success is True
+    assert "read" in out.permissions
+    assert creds.extra["tool_name"] == "mytool"
+
+
+def test_generic_provisioner_default_permissions(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.generic_provisioner import GenericProvisionerTool
+
+    tool = GenericProvisionerTool(tool_name="t")
+    tool._state = ProvisionerStateStore("generic_t_provisioner", storage_dir=tmp_path)
+
+    out = tool.provision("a1", {}, GeneratedCredentials(tool_name="t"))
+    assert out.permissions == ["all"]
+
+
+def test_generic_provisioner_verify_no_state(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.generic_provisioner import GenericProvisionerTool
+
+    tool = GenericProvisionerTool(tool_name="t")
+    tool._state = ProvisionerStateStore("generic_t_provisioner", storage_dir=tmp_path)
+
+    v = tool.verify_access("missing")
+    assert v.passed is False
+    assert "No provisioning" in v.errors[0]
+
+
+def test_generic_provisioner_verify_with_state(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.generic_provisioner import GenericProvisionerTool
+
+    tool = GenericProvisionerTool(tool_name="t")
+    tool._state = ProvisionerStateStore("generic_t_provisioner", storage_dir=tmp_path)
+    tool._state.put("a1", {"permissions": ["read"]})
+
+    v = tool.verify_access("a1")
+    assert v.passed is True
+    assert v.actual_permissions == ["read"]
+
+
+def test_generic_provisioner_deprovision_no_state(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.generic_provisioner import GenericProvisionerTool
+
+    tool = GenericProvisionerTool(tool_name="t")
+    tool._state = ProvisionerStateStore("generic_t_provisioner", storage_dir=tmp_path)
+
+    out = tool.deprovision("missing")
+    assert out.success is True
+    assert "No provisioning" in out.details["message"]
+
+
+def test_generic_provisioner_deprovision_with_state(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.generic_provisioner import GenericProvisionerTool
+
+    tool = GenericProvisionerTool(tool_name="t")
+    tool._state = ProvisionerStateStore("generic_t_provisioner", storage_dir=tmp_path)
+    tool._state.put("a1", {"permissions": ["read"]})
+
+    out = tool.deprovision("a1")
+    assert out.success is True
+    assert out.details["deprovisioned"] is True
+
+
+def test_generic_provisioner_deprovision_handles_exception(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.generic_provisioner import GenericProvisionerTool
+
+    tool = GenericProvisionerTool(tool_name="t")
+    tool._state = ProvisionerStateStore("generic_t_provisioner", storage_dir=tmp_path)
+    tool._state.put("a1", {"permissions": ["read"]})
+
+    with patch.object(tool._state, "delete", side_effect=RuntimeError("io")):
+        out = tool.deprovision("a1")
+    assert out.success is False
+    assert "io" in out.error
+
+
+def test_create_custom_provisioner_attaches_callbacks(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.generic_provisioner import (
+        create_custom_provisioner,
+    )
+
+    calls = {"prov": 0, "verify": 0, "deprov": 0}
+
+    def my_provision(self, agent_id, config, credentials):
+        calls["prov"] += 1
+        return self._make_success_result(credentials, ["read"], {"ok": True})
+
+    def my_verify(self, agent_id):
+        calls["verify"] += 1
+        return self._make_verification(passed=True, actual_permissions=[])
+
+    def my_deprovision(self, agent_id):
+        from agent_provisioning_team.models import DeprovisionResult
+
+        calls["deprov"] += 1
+        return DeprovisionResult(tool_name="x", success=True)
+
+    prov = create_custom_provisioner(
+        "mytool", provision_fn=my_provision, verify_fn=my_verify, deprovision_fn=my_deprovision
+    )
+    prov._state = ProvisionerStateStore("generic_mytool_provisioner", storage_dir=tmp_path)
+
+    prov.provision("a", {}, GeneratedCredentials(tool_name="mytool"))
+    prov.verify_access("a")
+    prov.deprovision("a")
+    assert calls == {"prov": 1, "verify": 1, "deprov": 1}
+
+
+def test_create_custom_provisioner_no_overrides_works(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.generic_provisioner import (
+        create_custom_provisioner,
+    )
+
+    prov = create_custom_provisioner("plain")
+    prov._state = ProvisionerStateStore("generic_plain_provisioner", storage_dir=tmp_path)
+    out = prov.provision("a", {"permissions": ["x"]}, GeneratedCredentials(tool_name="plain"))
+    assert out.success
+
+
+# ---------------------------------------------------------------------------
+# postgres_provisioner.py
+# ---------------------------------------------------------------------------
+
+
+def test_postgres_provision_returns_error_when_psycopg2_missing(
+    tmp_path: Path, monkeypatch
+) -> None:
+    from agent_provisioning_team.tool_agents import postgres_provisioner as pgm
+    from agent_provisioning_team.tool_agents.postgres_provisioner import PostgresProvisionerTool
+
+    monkeypatch.setattr(pgm, "HAS_PSYCOPG2", False)
+    prov = PostgresProvisionerTool()
+    prov._state = ProvisionerStateStore("postgres_provisioner", storage_dir=tmp_path)
+
+    out = prov.provision("a1", {}, GeneratedCredentials(tool_name="pg", username="u", password="p"))
+    assert out.success is False
+    assert "psycopg2 is not installed" in out.error
+
+
+def test_postgres_deprovision_no_psycopg2(monkeypatch, tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents import postgres_provisioner as pgm
+    from agent_provisioning_team.tool_agents.postgres_provisioner import PostgresProvisionerTool
+
+    monkeypatch.setattr(pgm, "HAS_PSYCOPG2", False)
+    prov = PostgresProvisionerTool()
+    prov._state = ProvisionerStateStore("postgres_provisioner", storage_dir=tmp_path)
+
+    out = prov.deprovision("a1")
+    assert out.success is False
+    assert "psycopg2" in out.error
+
+
+def test_postgres_deprovision_no_state(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.tool_agents import postgres_provisioner as pgm
+    from agent_provisioning_team.tool_agents.postgres_provisioner import PostgresProvisionerTool
+
+    monkeypatch.setattr(pgm, "HAS_PSYCOPG2", True)
+    prov = PostgresProvisionerTool()
+    prov._state = ProvisionerStateStore("postgres_provisioner", storage_dir=tmp_path)
+
+    out = prov.deprovision("missing")
+    assert out.success is True
+    assert "No database" in out.details["message"]
+
+
+def test_postgres_verify_access_no_state(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.postgres_provisioner import PostgresProvisionerTool
+
+    prov = PostgresProvisionerTool()
+    prov._state = ProvisionerStateStore("postgres_provisioner", storage_dir=tmp_path)
+    v = prov.verify_access("missing")
+    assert v.passed is False
+    assert "No PostgreSQL" in v.errors[0]
+
+
+def test_postgres_verify_access_with_state(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.postgres_provisioner import PostgresProvisionerTool
+
+    prov = PostgresProvisionerTool()
+    prov._state = ProvisionerStateStore("postgres_provisioner", storage_dir=tmp_path)
+    prov._state.put("a1", {"permissions": ["ALL PRIVILEGES"]})
+
+    v = prov.verify_access("a1")
+    assert v.passed is True
+    assert v.actual_permissions == ["ALL PRIVILEGES"]
+
+
+def test_postgres_do_provision_no_password_raises(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.tool_agents import postgres_provisioner as pgm
+    from agent_provisioning_team.tool_agents.postgres_provisioner import PostgresProvisionerTool
+
+    monkeypatch.setattr(pgm, "HAS_PSYCOPG2", True)
+    prov = PostgresProvisionerTool()
+    prov._state = ProvisionerStateStore("postgres_provisioner", storage_dir=tmp_path)
+
+    # Mock the connection layer so we never need a real DB
+    fake_conn = MagicMock()
+    fake_cursor = MagicMock()
+    fake_conn.cursor.return_value = fake_cursor
+    with patch.object(prov, "_get_admin_connection", return_value=fake_conn):
+        result = prov.provision(
+            "a1", {}, GeneratedCredentials(tool_name="pg", username="u", password=None)
+        )
+
+    assert result.success is False
+    assert "No password" in result.error
+
+
+def test_postgres_provision_full_path(tmp_path: Path, monkeypatch) -> None:
+    """Cover the full _do_provision path: create role + create db + apply perms."""
+
+    from agent_provisioning_team.tool_agents import postgres_provisioner as pgm
+    from agent_provisioning_team.tool_agents.postgres_provisioner import PostgresProvisionerTool
+
+    monkeypatch.setattr(pgm, "HAS_PSYCOPG2", True)
+    prov = PostgresProvisionerTool(host="h", port=5432, admin_user="u", admin_password="p")
+    prov._state = ProvisionerStateStore("postgres_provisioner", storage_dir=tmp_path)
+
+    fake_conn = MagicMock()
+    fake_cursor = MagicMock()
+    fake_conn.cursor.return_value = fake_cursor
+
+    # First and second execute calls succeed (CREATE USER + CREATE DATABASE)
+    fake_cursor.execute.return_value = None
+
+    with patch.object(prov, "_get_admin_connection", return_value=fake_conn):
+        result = prov.provision(
+            "agent-1",
+            {"database_prefix": "x_"},
+            GeneratedCredentials(tool_name="pg", username="u1", password="pw"),
+        )
+
+    assert result.success is True
+    assert "ALL PRIVILEGES" in result.permissions
+    assert result.details["database"].startswith("x_")
+
+
+def test_postgres_provision_handles_duplicate_role(tmp_path: Path, monkeypatch) -> None:
+    import psycopg2
+
+    from agent_provisioning_team.tool_agents import postgres_provisioner as pgm
+    from agent_provisioning_team.tool_agents.postgres_provisioner import PostgresProvisionerTool
+
+    monkeypatch.setattr(pgm, "HAS_PSYCOPG2", True)
+    prov = PostgresProvisionerTool()
+    prov._state = ProvisionerStateStore("postgres_provisioner", storage_dir=tmp_path)
+
+    fake_conn = MagicMock()
+    fake_cursor = MagicMock()
+    fake_conn.cursor.return_value = fake_cursor
+
+    calls = {"n": 0}
+
+    def execute(*a, **kw):
+        calls["n"] += 1
+        # First call: CREATE USER → raise DuplicateObject; second call: ALTER USER → ok
+        if calls["n"] == 1:
+            raise psycopg2.errors.DuplicateObject("already exists")
+        # Third call: CREATE DATABASE → raise DuplicateDatabase
+        if calls["n"] == 3:
+            raise psycopg2.errors.DuplicateDatabase("already exists")
+        return None
+
+    fake_cursor.execute.side_effect = execute
+
+    with patch.object(prov, "_get_admin_connection", return_value=fake_conn):
+        result = prov.provision(
+            "agent-1",
+            {},
+            GeneratedCredentials(tool_name="pg", username="u", password="pw"),
+        )
+
+    assert result.success is True
+
+
+def test_postgres_deprovision_full_path(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.tool_agents import postgres_provisioner as pgm
+    from agent_provisioning_team.tool_agents.postgres_provisioner import PostgresProvisionerTool
+
+    monkeypatch.setattr(pgm, "HAS_PSYCOPG2", True)
+    prov = PostgresProvisionerTool()
+    prov._state = ProvisionerStateStore("postgres_provisioner", storage_dir=tmp_path)
+    prov._state.put("a1", {"database": "agent_a1", "username": "u1"})
+
+    fake_conn = MagicMock()
+    fake_cursor = MagicMock()
+    fake_conn.cursor.return_value = fake_cursor
+
+    with patch.object(prov, "_get_admin_connection", return_value=fake_conn):
+        out = prov.deprovision("a1")
+
+    assert out.success is True
+    assert out.details["database_dropped"] == "agent_a1"
+    assert out.details["user_dropped"] == "u1"
+
+
+def test_postgres_deprovision_handles_exception(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.tool_agents import postgres_provisioner as pgm
+    from agent_provisioning_team.tool_agents.postgres_provisioner import PostgresProvisionerTool
+
+    monkeypatch.setattr(pgm, "HAS_PSYCOPG2", True)
+    prov = PostgresProvisionerTool()
+    prov._state = ProvisionerStateStore("postgres_provisioner", storage_dir=tmp_path)
+    prov._state.put("a1", {"database": "agent_a1", "username": "u1"})
+
+    with patch.object(prov, "_get_admin_connection", side_effect=RuntimeError("down")):
+        out = prov.deprovision("a1")
+    assert out.success is False
+    assert "down" in out.error
+
+
+def test_postgres_replay_compensation_database(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.tool_agents import postgres_provisioner as pgm
+    from agent_provisioning_team.tool_agents.postgres_provisioner import PostgresProvisionerTool
+
+    monkeypatch.setattr(pgm, "HAS_PSYCOPG2", True)
+    prov = PostgresProvisionerTool()
+    prov._state = ProvisionerStateStore("postgres_provisioner", storage_dir=tmp_path)
+
+    fake_conn = MagicMock()
+    fake_cursor = MagicMock()
+    fake_conn.cursor.return_value = fake_cursor
+
+    with patch.object(prov, "_get_admin_connection", return_value=fake_conn):
+        prov.replay_compensation("a1", "postgres.drop_database", {"database": "d1"})
+
+    # Should have called execute at least once
+    assert fake_cursor.execute.call_count >= 1
+
+
+def test_postgres_replay_compensation_role(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.tool_agents import postgres_provisioner as pgm
+    from agent_provisioning_team.tool_agents.postgres_provisioner import PostgresProvisionerTool
+
+    monkeypatch.setattr(pgm, "HAS_PSYCOPG2", True)
+    prov = PostgresProvisionerTool()
+    prov._state = ProvisionerStateStore("postgres_provisioner", storage_dir=tmp_path)
+
+    fake_conn = MagicMock()
+    fake_cursor = MagicMock()
+    fake_conn.cursor.return_value = fake_cursor
+
+    with patch.object(prov, "_get_admin_connection", return_value=fake_conn):
+        prov.replay_compensation("a1", "postgres.drop_role", {"username": "u1"})
+
+    assert fake_cursor.execute.call_count == 1
+
+
+def test_postgres_replay_compensation_unknown_falls_through(tmp_path: Path, monkeypatch) -> None:
+    """Unknown kind falls through to base class which just logs and returns."""
+    from agent_provisioning_team.tool_agents import postgres_provisioner as pgm
+    from agent_provisioning_team.tool_agents.postgres_provisioner import PostgresProvisionerTool
+
+    monkeypatch.setattr(pgm, "HAS_PSYCOPG2", True)
+    prov = PostgresProvisionerTool()
+    prov._state = ProvisionerStateStore("postgres_provisioner", storage_dir=tmp_path)
+
+    fake_conn = MagicMock()
+    fake_cursor = MagicMock()
+    fake_conn.cursor.return_value = fake_cursor
+
+    with patch.object(prov, "_get_admin_connection", return_value=fake_conn):
+        prov.replay_compensation("a1", "unknown.kind", {"k": "v"})
+
+
+def test_postgres_replay_compensation_raises_no_psycopg2(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.tool_agents import postgres_provisioner as pgm
+    from agent_provisioning_team.tool_agents.postgres_provisioner import PostgresProvisionerTool
+
+    monkeypatch.setattr(pgm, "HAS_PSYCOPG2", False)
+    prov = PostgresProvisionerTool()
+    prov._state = ProvisionerStateStore("postgres_provisioner", storage_dir=tmp_path)
+
+    with pytest.raises(RuntimeError, match="psycopg2"):
+        prov.replay_compensation("a1", "postgres.drop_role", {"username": "u"})
+
+
+def test_postgres_apply_permissions_specific(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.tool_agents import postgres_provisioner as pgm
+    from agent_provisioning_team.tool_agents.postgres_provisioner import PostgresProvisionerTool
+
+    monkeypatch.setattr(pgm, "HAS_PSYCOPG2", True)
+    prov = PostgresProvisionerTool()
+
+    fake_cursor = MagicMock()
+    prov._apply_permissions(fake_cursor, "db1", "u1", ["SELECT", "INSERT", "CREATE"])
+
+    # Should have called execute for each granted permission
+    assert fake_cursor.execute.call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# redis_provisioner.py
+# ---------------------------------------------------------------------------
+
+
+def test_redis_provision_no_lib_returns_error(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.tool_agents import redis_provisioner as rm
+    from agent_provisioning_team.tool_agents.redis_provisioner import RedisProvisionerTool
+
+    monkeypatch.setattr(rm, "HAS_REDIS", False)
+    prov = RedisProvisionerTool()
+    prov._state = ProvisionerStateStore("redis_provisioner", storage_dir=tmp_path)
+
+    out = prov.provision(
+        "a1", {}, GeneratedCredentials(tool_name="redis", username="u", password="p")
+    )
+    assert out.success is False
+    assert "redis package" in out.error
+
+
+def test_redis_deprovision_no_lib(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.tool_agents import redis_provisioner as rm
+    from agent_provisioning_team.tool_agents.redis_provisioner import RedisProvisionerTool
+
+    monkeypatch.setattr(rm, "HAS_REDIS", False)
+    prov = RedisProvisionerTool()
+    prov._state = ProvisionerStateStore("redis_provisioner", storage_dir=tmp_path)
+
+    out = prov.deprovision("a1")
+    assert out.success is False
+
+
+def test_redis_deprovision_no_state(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.tool_agents import redis_provisioner as rm
+    from agent_provisioning_team.tool_agents.redis_provisioner import RedisProvisionerTool
+
+    monkeypatch.setattr(rm, "HAS_REDIS", True)
+    prov = RedisProvisionerTool()
+    prov._state = ProvisionerStateStore("redis_provisioner", storage_dir=tmp_path)
+
+    out = prov.deprovision("missing")
+    assert out.success is True
+    assert "No Redis ACL" in out.details["message"]
+
+
+def test_redis_verify_access_no_state(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.redis_provisioner import RedisProvisionerTool
+
+    prov = RedisProvisionerTool()
+    prov._state = ProvisionerStateStore("redis_provisioner", storage_dir=tmp_path)
+
+    v = prov.verify_access("missing")
+    assert v.passed is False
+    assert "No Redis" in v.errors[0]
+
+
+def test_redis_verify_access_with_state(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.redis_provisioner import RedisProvisionerTool
+
+    prov = RedisProvisionerTool()
+    prov._state = ProvisionerStateStore("redis_provisioner", storage_dir=tmp_path)
+    prov._state.put("a1", {"permissions": ["+@all"]})
+
+    v = prov.verify_access("a1")
+    assert v.passed is True
+
+
+def test_redis_build_acl_rules_full_access() -> None:
+    from agent_provisioning_team.tool_agents.redis_provisioner import RedisProvisionerTool
+
+    prov = RedisProvisionerTool()
+    assert prov._build_acl_rules(["+@all"], "k:") == ["+@all"]
+
+
+def test_redis_build_acl_rules_subset() -> None:
+    from agent_provisioning_team.tool_agents.redis_provisioner import RedisProvisionerTool
+
+    prov = RedisProvisionerTool()
+    rules = prov._build_acl_rules(["GET", "SET", "DEL"], "k:")
+    assert "-@all" in rules
+    assert "+get" in rules
+    assert "+set" in rules
+    assert "+del" in rules
+    # Always-on commands
+    assert "+ping" in rules
+    assert "+auth" in rules
+
+
+def test_redis_do_provision_no_password_raises(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.tool_agents import redis_provisioner as rm
+    from agent_provisioning_team.tool_agents.redis_provisioner import RedisProvisionerTool
+
+    monkeypatch.setattr(rm, "HAS_REDIS", True)
+    prov = RedisProvisionerTool()
+    prov._state = ProvisionerStateStore("redis_provisioner", storage_dir=tmp_path)
+
+    fake_client = MagicMock()
+    with patch.object(prov, "_get_admin_client", return_value=fake_client):
+        out = prov.provision(
+            "a1", {}, GeneratedCredentials(tool_name="redis", username="u", password=None)
+        )
+
+    assert out.success is False
+    assert "No password" in out.error
+
+
+def test_redis_provision_full_path(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.tool_agents import redis_provisioner as rm
+    from agent_provisioning_team.tool_agents.redis_provisioner import RedisProvisionerTool
+
+    monkeypatch.setattr(rm, "HAS_REDIS", True)
+    prov = RedisProvisionerTool(host="h", port=6379, admin_password="adminpw")
+    prov._state = ProvisionerStateStore("redis_provisioner", storage_dir=tmp_path)
+
+    fake_client = MagicMock()
+    with patch.object(prov, "_get_admin_client", return_value=fake_client):
+        result = prov.provision(
+            "agent-1",
+            {"key_prefix": "ag:"},
+            GeneratedCredentials(tool_name="redis", username="u1", password="pw"),
+        )
+
+    assert result.success is True
+    fake_client.acl_setuser.assert_called_once()
+
+
+def test_redis_provision_handles_deluser_response_error(tmp_path: Path, monkeypatch) -> None:
+    import redis  # type: ignore[import-not-found]
+
+    from agent_provisioning_team.tool_agents import redis_provisioner as rm
+    from agent_provisioning_team.tool_agents.redis_provisioner import RedisProvisionerTool
+
+    monkeypatch.setattr(rm, "HAS_REDIS", True)
+    prov = RedisProvisionerTool()
+    prov._state = ProvisionerStateStore("redis_provisioner", storage_dir=tmp_path)
+
+    fake_client = MagicMock()
+    fake_client.acl_deluser.side_effect = redis.exceptions.ResponseError("nope")
+    with patch.object(prov, "_get_admin_client", return_value=fake_client):
+        result = prov.provision(
+            "a1",
+            {},
+            GeneratedCredentials(tool_name="redis", username="u", password="pw"),
+        )
+
+    # deluser raising ResponseError must be swallowed
+    assert result.success is True
+
+
+def test_redis_deprovision_full_path(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.tool_agents import redis_provisioner as rm
+    from agent_provisioning_team.tool_agents.redis_provisioner import RedisProvisionerTool
+
+    monkeypatch.setattr(rm, "HAS_REDIS", True)
+    prov = RedisProvisionerTool()
+    prov._state = ProvisionerStateStore("redis_provisioner", storage_dir=tmp_path)
+    prov._state.put("a1", {"username": "u1"})
+
+    fake_client = MagicMock()
+    with patch.object(prov, "_get_admin_client", return_value=fake_client):
+        out = prov.deprovision("a1")
+
+    assert out.success is True
+    assert out.details["user_deleted"] == "u1"
+
+
+def test_redis_deprovision_handles_response_error(tmp_path: Path, monkeypatch) -> None:
+    import redis
+
+    from agent_provisioning_team.tool_agents import redis_provisioner as rm
+    from agent_provisioning_team.tool_agents.redis_provisioner import RedisProvisionerTool
+
+    monkeypatch.setattr(rm, "HAS_REDIS", True)
+    prov = RedisProvisionerTool()
+    prov._state = ProvisionerStateStore("redis_provisioner", storage_dir=tmp_path)
+    prov._state.put("a1", {"username": "u1"})
+
+    fake_client = MagicMock()
+    fake_client.acl_deluser.side_effect = redis.exceptions.ResponseError("missing user")
+    with patch.object(prov, "_get_admin_client", return_value=fake_client):
+        out = prov.deprovision("a1")
+
+    assert out.success is True
+
+
+def test_redis_deprovision_handles_exception(tmp_path: Path, monkeypatch) -> None:
+    from agent_provisioning_team.tool_agents import redis_provisioner as rm
+    from agent_provisioning_team.tool_agents.redis_provisioner import RedisProvisionerTool
+
+    monkeypatch.setattr(rm, "HAS_REDIS", True)
+    prov = RedisProvisionerTool()
+    prov._state = ProvisionerStateStore("redis_provisioner", storage_dir=tmp_path)
+    prov._state.put("a1", {"username": "u1"})
+
+    with patch.object(prov, "_get_admin_client", side_effect=RuntimeError("down")):
+        out = prov.deprovision("a1")
+    assert out.success is False
+    assert "down" in out.error
+
+
+def test_redis_get_admin_client_no_lib(monkeypatch) -> None:
+    from agent_provisioning_team.tool_agents import redis_provisioner as rm
+    from agent_provisioning_team.tool_agents.redis_provisioner import RedisProvisionerTool
+
+    monkeypatch.setattr(rm, "HAS_REDIS", False)
+    prov = RedisProvisionerTool()
+    with pytest.raises(RuntimeError, match="redis package"):
+        prov._get_admin_client()
+
+
+def test_redis_on_reuse_populates_credentials(tmp_path: Path) -> None:
+    from agent_provisioning_team.tool_agents.redis_provisioner import RedisProvisionerTool
+
+    prov = RedisProvisionerTool()
+    prov._state = ProvisionerStateStore("redis_provisioner", storage_dir=tmp_path)
+    prov._state.put("a1", {"key_prefix": "k:", "permissions": ["+@all"]})
+
+    with patch.object(prov, "_get_admin_client"):
+        # Force reuse path by ensuring state already exists
+        result = prov.provision(
+            "a1", {}, GeneratedCredentials(tool_name="redis", username="u", password="p")
+        )
+    assert result.success is True
+    assert result.details.get("reused") is True
+
+
+# ---------------------------------------------------------------------------
+# postgres_provisioner __init__ env defaults
+# ---------------------------------------------------------------------------
+
+
+def test_postgres_init_uses_env_defaults(monkeypatch) -> None:
+    from agent_provisioning_team.tool_agents.postgres_provisioner import PostgresProvisionerTool
+
+    monkeypatch.setenv("POSTGRES_HOST", "envhost")
+    monkeypatch.setenv("POSTGRES_PORT", "9999")
+    monkeypatch.setenv("POSTGRES_USER", "envuser")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "fixture-placeholder-not-a-secret")
+
+    prov = PostgresProvisionerTool()
+    assert prov.host == "envhost"
+    assert prov.port == 9999
+    assert prov.admin_user == "envuser"
+    assert prov.admin_password == "fixture-placeholder-not-a-secret"
+
+
+def test_redis_init_uses_env_defaults(monkeypatch) -> None:
+    from agent_provisioning_team.tool_agents.redis_provisioner import RedisProvisionerTool
+
+    monkeypatch.setenv("REDIS_HOST", "rhost")
+    monkeypatch.setenv("REDIS_PORT", "12345")
+    monkeypatch.setenv("REDIS_PASSWORD", "rp")
+
+    prov = RedisProvisionerTool()
+    assert prov.host == "rhost"
+    assert prov.port == 12345
+    assert prov.admin_password == "rp"

--- a/backend/agents/agent_provisioning_team/tests/test_workflows_unit.py
+++ b/backend/agents/agent_provisioning_team/tests/test_workflows_unit.py
@@ -1,0 +1,414 @@
+"""Unit tests for AgentProvisioningWorkflowV2 and the setup_activity_v2
+that previously sat behind the integration marker.
+
+WorkflowV2 is exercised by stubbing `workflow.execute_activity` so we
+never need a live Temporal worker — we just verify the workflow's
+control flow (skip / resume, fan-out, failure → compensation, etc.).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# setup_activity_v2 — direct invocation
+# ---------------------------------------------------------------------------
+
+
+def test_setup_activity_v2_progress_path() -> None:
+    from agent_provisioning_team.models import EnvironmentInfo, SetupResult
+    from agent_provisioning_team.temporal import activities as t_acts
+
+    fake_setup_result = SetupResult(
+        success=True,
+        environment=EnvironmentInfo(container_id="c1", container_name="c1"),
+    )
+    fake_orch = MagicMock()
+    fake_orch.environment_store = MagicMock()
+    fake_orch.tool_agents = {"docker_provisioner": MagicMock()}
+    fake_manifest = MagicMock()
+
+    recorded = []
+
+    def fake_safe(fn_name, *args, **kwargs):
+        recorded.append({"fn": fn_name, "args": args, "kwargs": kwargs})
+
+    with (
+        patch.object(t_acts, "_safe", side_effect=fake_safe),
+        patch.object(t_acts, "_load_ctx", return_value=(fake_orch, fake_manifest)),
+        patch(
+            "agent_provisioning_team.phases.setup.run_setup",
+            return_value=fake_setup_result,
+        ),
+        patch("temporalio.activity.heartbeat"),
+    ):
+        payload = t_acts.setup_activity_v2("j", "a", "default.yaml")
+
+    assert payload["success"] is True
+    assert payload["environment"]["container_id"] == "c1"
+    # mark_job_running + update_job were invoked.
+    fn_names = [r["fn"] for r in recorded]
+    assert "mark_job_running" in fn_names
+    assert "update_job" in fn_names
+    assert "add_completed_phase" in fn_names
+
+
+def test_setup_activity_v2_raises_when_setup_fails() -> None:
+    from agent_provisioning_team.models import SetupResult
+    from agent_provisioning_team.temporal import activities as t_acts
+
+    fake_orch = MagicMock()
+    fake_orch.environment_store = MagicMock()
+    fake_orch.tool_agents = {"docker_provisioner": MagicMock()}
+    fake_manifest = MagicMock()
+
+    with (
+        patch.object(t_acts, "_safe"),
+        patch.object(t_acts, "_load_ctx", return_value=(fake_orch, fake_manifest)),
+        patch(
+            "agent_provisioning_team.phases.setup.run_setup",
+            return_value=SetupResult(success=False, error="setup boom"),
+        ),
+        patch("temporalio.activity.heartbeat"),
+    ):
+        with pytest.raises(RuntimeError, match="setup boom"):
+            t_acts.setup_activity_v2("j", "a", "default.yaml")
+
+
+def test_setup_activity_v2_restores_from_prior() -> None:
+    from agent_provisioning_team.temporal import activities as t_acts
+
+    prior = {
+        "success": True,
+        "environment": {
+            "container_id": "c1",
+            "container_name": "c1",
+            "workspace_path": "/w",
+            "status": "running",
+        },
+    }
+    with (
+        patch.object(t_acts, "_safe"),
+        patch("temporalio.activity.heartbeat"),
+    ):
+        payload = t_acts.setup_activity_v2("j", "a", "default.yaml", prior_setup=prior)
+    assert payload["success"] is True
+    assert payload["environment"]["container_id"] == "c1"
+
+
+# ---------------------------------------------------------------------------
+# AgentProvisioningWorkflowV2 — direct .run() invocation
+#
+# `workflow.execute_activity` is stubbed so we don't need a real
+# Temporal env. The workflow's control-flow assertions are what we care about.
+# ---------------------------------------------------------------------------
+
+
+class _ExecActivityStub:
+    """Callable stub that records every call and returns canned responses
+    keyed by the activity function's name."""
+
+    def __init__(self, responses: dict) -> None:
+        self.responses = responses
+        self.calls = []
+
+    async def __call__(self, activity_fn, *args, **kwargs):
+        name = getattr(activity_fn, "__name__", str(activity_fn))
+        self.calls.append({"name": name, "args": kwargs.get("args"), "kwargs": kwargs})
+        if name in self.responses:
+            resp = self.responses[name]
+            if isinstance(resp, BaseException):
+                raise resp
+            if callable(resp):
+                return resp(self.calls[-1])
+            return resp
+        return None
+
+
+def _build_manifest_yaml(tmp_path):
+    f = tmp_path / "m.yaml"
+    f.write_text(
+        """
+version: "1.0"
+tools:
+  - name: postgresql
+    provisioner: postgres_provisioner
+    config: {database_prefix: "x_"}
+  - name: redis
+    provisioner: redis_provisioner
+    config: {key_prefix: "k:"}
+""",
+        encoding="utf-8",
+    )
+    return str(f)
+
+
+@pytest.mark.asyncio
+async def test_workflow_v2_happy_path(tmp_path, monkeypatch) -> None:
+    from agent_provisioning_team.temporal import workflows as wf
+
+    manifest_path = _build_manifest_yaml(tmp_path)
+
+    stub = _ExecActivityStub(
+        {
+            "setup_activity_v2": {"success": True, "environment": {"workspace_path": "/w"}},
+            "credentials_activity_v2": {
+                "success": True,
+                "credentials": {
+                    "postgresql": {"tool_name": "postgresql", "username": "u", "password": "p"},
+                    "redis": {"tool_name": "redis", "username": "u", "password": "p"},
+                },
+            },
+            "provision_tool_activity": lambda call: {
+                "tool_name": call["args"][2],
+                "success": True,
+                "provisioner_key": "x",
+            },
+            "audit_activity_v2": {"passed": True, "verifications": []},
+            "documentation_activity_v2": {"success": True, "onboarding": {"summary": "s"}},
+            "deliver_activity_v2": {"success": True, "error": None},
+        }
+    )
+
+    with patch.object(wf.workflow, "execute_activity", new=stub):
+        workflow = wf.AgentProvisioningWorkflowV2()
+        await workflow.run("job-1", "agent-1", manifest_path)
+
+    fn_names = [c["name"] for c in stub.calls]
+    assert "setup_activity_v2" in fn_names
+    assert "credentials_activity_v2" in fn_names
+    # Two tools → two provision activities.
+    assert fn_names.count("provision_tool_activity") == 2
+    assert "audit_activity_v2" in fn_names
+    assert "documentation_activity_v2" in fn_names
+    assert "deliver_activity_v2" in fn_names
+
+
+@pytest.mark.asyncio
+async def test_workflow_v2_compensates_on_tool_failure(tmp_path) -> None:
+    from agent_provisioning_team.temporal import workflows as wf
+
+    manifest_path = _build_manifest_yaml(tmp_path)
+
+    # One tool succeeds, the other raises.
+    def provision_responder(call):
+        tool_name = call["args"][2]
+        if tool_name == "postgresql":
+            return {
+                "tool_name": "postgresql",
+                "success": True,
+                "provisioner_key": "postgres_provisioner",
+            }
+        raise RuntimeError("redis exploded")
+
+    stub = _ExecActivityStub(
+        {
+            "setup_activity_v2": {"success": True, "environment": {"workspace_path": "/w"}},
+            "credentials_activity_v2": {
+                "success": True,
+                "credentials": {
+                    "postgresql": {"tool_name": "postgresql"},
+                    "redis": {"tool_name": "redis"},
+                },
+            },
+            "provision_tool_activity": provision_responder,
+            "compensate_activity_v2": None,
+        }
+    )
+
+    with patch.object(wf.workflow, "execute_activity", new=stub):
+        with pytest.raises(RuntimeError, match="Tool provisioning failed"):
+            await wf.AgentProvisioningWorkflowV2().run("job-1", "agent-1", manifest_path)
+
+    fn_names = [c["name"] for c in stub.calls]
+    # Compensate was invoked
+    assert "compensate_activity_v2" in fn_names
+
+
+@pytest.mark.asyncio
+async def test_workflow_v2_skips_provisioning_when_resumed(tmp_path) -> None:
+    from agent_provisioning_team.temporal import workflows as wf
+
+    manifest_path = _build_manifest_yaml(tmp_path)
+
+    stub = _ExecActivityStub(
+        {
+            "setup_activity_v2": {"success": True, "environment": {"workspace_path": "/w"}},
+            "credentials_activity_v2": {
+                "success": True,
+                "credentials": {
+                    "postgresql": {"tool_name": "postgresql"},
+                    "redis": {"tool_name": "redis"},
+                },
+            },
+            "audit_activity_v2": {"passed": True, "verifications": []},
+            "documentation_activity_v2": {"success": True, "onboarding": {"summary": "s"}},
+            "deliver_activity_v2": {"success": True, "error": None},
+        }
+    )
+
+    prior = {
+        "account_provisioning": {
+            "tool_results": [
+                {
+                    "tool_name": "postgresql",
+                    "success": True,
+                    "provisioner_key": "postgres_provisioner",
+                },
+                {
+                    "tool_name": "redis",
+                    "success": True,
+                    "provisioner_key": "redis_provisioner",
+                },
+            ]
+        }
+    }
+
+    with patch.object(wf.workflow, "execute_activity", new=stub):
+        await wf.AgentProvisioningWorkflowV2().run(
+            "job-1",
+            "agent-1",
+            manifest_path,
+            skip_phases=["account_provisioning"],
+            prior_results=prior,
+        )
+
+    fn_names = [c["name"] for c in stub.calls]
+    # No per-tool provisioning happened
+    assert "provision_tool_activity" not in fn_names
+    # Compensation is skipped because everything in prior was successful
+    assert "compensate_activity_v2" not in fn_names
+
+
+@pytest.mark.asyncio
+async def test_workflow_v2_resume_with_prior_failed_tools_compensates(tmp_path) -> None:
+    from agent_provisioning_team.temporal import workflows as wf
+
+    manifest_path = _build_manifest_yaml(tmp_path)
+
+    stub = _ExecActivityStub(
+        {
+            "setup_activity_v2": {"success": True, "environment": {"workspace_path": "/w"}},
+            "credentials_activity_v2": {
+                "success": True,
+                "credentials": {
+                    "postgresql": {"tool_name": "postgresql"},
+                    "redis": {"tool_name": "redis"},
+                },
+            },
+            "compensate_activity_v2": None,
+        }
+    )
+
+    prior = {
+        "account_provisioning": {
+            "tool_results": [
+                {
+                    "tool_name": "postgresql",
+                    "success": True,
+                    "provisioner_key": "postgres_provisioner",
+                },
+                {
+                    "tool_name": "redis",
+                    "success": False,
+                    "error": "ack",
+                    "provisioner_key": "redis_provisioner",
+                },
+            ]
+        }
+    }
+
+    with patch.object(wf.workflow, "execute_activity", new=stub):
+        with pytest.raises(RuntimeError, match="Tool provisioning failed"):
+            await wf.AgentProvisioningWorkflowV2().run(
+                "job-1",
+                "agent-1",
+                manifest_path,
+                skip_phases=["account_provisioning"],
+                prior_results=prior,
+            )
+
+    fn_names = [c["name"] for c in stub.calls]
+    assert "compensate_activity_v2" in fn_names
+
+
+@pytest.mark.asyncio
+async def test_workflow_v1_invokes_single_activity(tmp_path) -> None:
+    """v1 workflow simply delegates to ``run_provisioning_activity``."""
+    from agent_provisioning_team.temporal import workflows as wf
+
+    stub = _ExecActivityStub({"run_provisioning_activity": None})
+    with patch.object(wf.workflow, "execute_activity", new=stub):
+        await wf.AgentProvisioningWorkflow().run("j", "a", "default.yaml")
+
+    fn_names = [c["name"] for c in stub.calls]
+    assert fn_names == ["run_provisioning_activity"]
+
+
+@pytest.mark.asyncio
+async def test_workflow_v2_handles_non_dict_provision_results(tmp_path) -> None:
+    """A provision_tool_activity result that isn't a dict (e.g. None) → failure path."""
+    from agent_provisioning_team.temporal import workflows as wf
+
+    manifest_path = _build_manifest_yaml(tmp_path)
+
+    def provision_responder(call):
+        tool_name = call["args"][2]
+        # Return weird non-dict for one tool
+        if tool_name == "redis":
+            return None
+        return {"tool_name": "postgresql", "success": True, "provisioner_key": "x"}
+
+    stub = _ExecActivityStub(
+        {
+            "setup_activity_v2": {"success": True, "environment": None},
+            "credentials_activity_v2": {
+                "success": True,
+                "credentials": {
+                    "postgresql": {"tool_name": "postgresql"},
+                    "redis": {"tool_name": "redis"},
+                },
+            },
+            "provision_tool_activity": provision_responder,
+            "compensate_activity_v2": None,
+        }
+    )
+
+    with patch.object(wf.workflow, "execute_activity", new=stub):
+        with pytest.raises(RuntimeError, match="Tool provisioning failed"):
+            await wf.AgentProvisioningWorkflowV2().run("job-1", "agent-1", manifest_path)
+
+
+@pytest.mark.asyncio
+async def test_workflow_v2_handles_dict_failure_results(tmp_path) -> None:
+    """A provision_tool_activity result dict with success=False → failure path."""
+    from agent_provisioning_team.temporal import workflows as wf
+
+    manifest_path = _build_manifest_yaml(tmp_path)
+
+    def provision_responder(call):
+        tool_name = call["args"][2]
+        if tool_name == "redis":
+            return {"tool_name": "redis", "success": False, "error": "redis down"}
+        return {"tool_name": "postgresql", "success": True, "provisioner_key": "x"}
+
+    stub = _ExecActivityStub(
+        {
+            "setup_activity_v2": {"success": True, "environment": None},
+            "credentials_activity_v2": {
+                "success": True,
+                "credentials": {
+                    "postgresql": {"tool_name": "postgresql"},
+                    "redis": {"tool_name": "redis"},
+                },
+            },
+            "provision_tool_activity": provision_responder,
+            "compensate_activity_v2": None,
+        }
+    )
+
+    with patch.object(wf.workflow, "execute_activity", new=stub):
+        with pytest.raises(RuntimeError, match="redis down"):
+            await wf.AgentProvisioningWorkflowV2().run("job-1", "agent-1", manifest_path)


### PR DESCRIPTION
## Summary

Adds **377 new unit tests** across 10 new test files to bring the `agent_provisioning_team` line coverage from **54%** to **98.36%** (well above the 95% project requirement). No production code was modified.

Every external dependency is mocked at the import / function-call seam — tests never reach real Docker, Postgres, Redis, Temporal, or LLMs.

## Coverage: before → after

| Module | Before | After |
|---|---|---|
| `api/main.py` | 33% | 98% |
| `graphs/provisioning_graph.py` | 0% | 100% |
| `models.py` | 100% | 100% |
| `orchestrator.py` | 52% | 98% |
| `phases/access_audit.py` | 16% | 100% |
| `phases/account_provisioning.py` | 67% | 100% |
| `phases/credential_generation.py` | 64% | 100% |
| `phases/deliver.py` | 56% | 100% |
| `phases/documentation.py` | 13% | 100% |
| `phases/setup.py` | 38% | 100% |
| `prompts.py` | 62% | 100% |
| `sandbox/lifecycle.py` | 83% | 97% |
| `sandbox/provisioner.py` | 80% | 99% |
| `sandbox/state.py` | 93% | 100% |
| `shared/credential_store.py` | 80% | 99% |
| `shared/environment_store.py` | 35% | 100% |
| `shared/job_store.py` | 34% | 99% |
| `shared/llm_client.py` | 98% | 100% |
| `shared/logging_context.py` | 50% | 95% |
| `shared/phase_state.py` | 88% | 100% |
| `shared/provisioner_state.py` | 89% | 96% |
| `shared/tool_manifest.py` | 82% | 97% |
| `temporal/activities.py` | 0% | 100% |
| `temporal/client.py` | 0% | 100% |
| `temporal/constants.py` | 0% | 100% |
| `temporal/start_workflow.py` | 0% | 100% |
| `temporal/worker.py` | 0% | 100% |
| `temporal/workflows.py` | 0% | 100% |
| `tool_agents/base.py` | 85% | 95% |
| `tool_agents/docker_provisioner.py` | 27% | 100% |
| `tool_agents/generic_provisioner.py` | 50% | 100% |
| `tool_agents/git_provisioner.py` | 34% | 100% |
| `tool_agents/postgres_provisioner.py` | 23% | 93% |
| `tool_agents/redis_provisioner.py` | 26% | 97% |
| `anatomy_assets.py` | 91% | 96% |
| **TOTAL** | **54%** | **98.36%** |

## What's in each new test file

- **`test_api_unit.py`** (49 tests) — FastAPI routes (`/provision`, `/status`, `/jobs`, `/cancel`, `/resume`, `/restart`, `/environments`), Temporal-vs-thread routing, executor backpressure / 429, lifespan hook, graceful shutdown with `_compensate` per-job + per-thread timeout.
- **`test_orchestrator.py`** (27 tests) — 6-phase workflow, `_compensate` rollback variants (no key / unregistered / replay failure / cred + env cleanup failure), `ProvisioningShutdownError` mid-workflow, resume with `skip_phases` + `prior_results`, deprovision / `get_agent_status` / `list_agents`.
- **`test_phases.py`** (38 tests) — Every phase function: setup (reuse / create / failure / cleanup), credential_generation (incl. token tools + regenerate), account_provisioning (no provisioner / no creds / exception / progress callback / deprovision_tools), access_audit (success / failure / single-tool / report), documentation (full flow / template substitution / readme redaction), deliver (status update / build_final_result with failures / `_redact_*` helpers).
- **`test_tool_agents.py`** (65 tests) — Docker / Postgres / Redis provisioners with `subprocess.run`, `psycopg2`, `redis` mocked; covers `verify_access`, `deprovision`, `replay_compensation`, idempotency-reuse paths, library-missing branches, env-default constructors.
- **`test_git_provisioner.py`** (15 tests) — `ssh-keygen` + `git init` / `git commit` mocked; workspace containment, init-repo failure, deprovision branches, ssh keypair regeneration.
- **`test_shared.py`** (66 tests) — `environment_store` (CRUD, list_all, corrupt-file handling), `job_store` via `FakeJobServiceClient` (every CRUD + lifecycle helper + reset + delete + add_completed_phase + mark_all_running_jobs_failed swallow), `logging_context` (filter + manager + idempotent install), `phase_state` (every `restore_*`), `llm_client` (configured / sanitize / fallback), `tool_manifest` (load / validate / traversal / env allowlist).
- **`test_temporal_unit.py`** (31 tests) — Constants env override, `client.connect_temporal_client` success / failure / no-address paths, `start_workflow._run_async` + `start_provisioning_workflow`, `worker.create_agent_provisioning_worker` (enabled / disabled / no-client), every v2 activity with `_load_ctx` + `_safe` + `_restored` helpers, v1 activity, `compensate_activity_v2`.
- **`test_workflows_unit.py`** (10 tests) — `AgentProvisioningWorkflowV2` end-to-end with `workflow.execute_activity` stubbed: happy path, tool-failure → compensation, resume-with-prior-results (success skip + failure compensate), `AgentProvisioningWorkflow` v1, non-dict / failure-dict provision results.
- **`test_misc_coverage.py`** (59 tests) — Every `prompts.py` formatter + factory, anatomy_assets edges, `graphs/provisioning_graph.py`, credential_store key-file env path / corrupt skips, documentation LLM happy + fallback for both summary and per-tool docs, `_load_ctx`, sandbox provisioner `is_running` / `inspect_host_port` / `stop_container` / `cleanup_secrets_file` / `_materialise_project_dir` branches.
- **`test_extra_coverage.py`** (16 tests) — `Lifecycle._wait_healthy` timeout + success, `run_idle_reaper` non-cancel exception swallow, `reap_once` non-warm skip, `_resolve_team` registry success/UnknownAgentError, real-coroutine `_exec` timeout that exercises `proc.kill()`, `_materialise_project_dir` with grafana assets present, credential_store invalid-key error / rotate-skips-corrupt, anatomy_assets missing-file fallback.

## Test isolation

- No real network / Docker / Postgres / Temporal / LLM calls — every boundary is mocked.
- `job_store` tests monkey-patch the module-level `_client` factory to return a `FakeJobServiceClient`.
- `logging_context` tests reset contextvars explicitly to be parallel-safe under `pytest-xdist`.
- All tests run in <6s wall-clock under `-n auto`.

## Pragmas

None added — every gap was closed with a real test.

## Test plan

- [x] `LLM_PROVIDER=dummy .venv/bin/pytest agents/agent_provisioning_team/tests/ -m "not integration" --cov=agents/agent_provisioning_team --cov-report=term-missing` → **98.36% (472 passed, 9 skipped)**
- [x] `.venv/bin/ruff check agents/agent_provisioning_team/` → clean
- [x] `.venv/bin/ruff format --check agents/agent_provisioning_team/` → clean

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01V5u4zW36taPZEx99n69c4n)_