### PR TITLE
nutrition_meal_planning_team: surface guardrail outcome fields on meal-plan response

### DIFF
--- a/backend/agents/nutrition_meal_planning_team/models.py
+++ b/backend/agents/nutrition_meal_planning_team/models.py
@@ -426,6 +426,21 @@ class MealRecommendationWithId(MealRecommendation):
     """Meal recommendation plus storage id for feedback."""
 
     recommendation_id: str = ""
+    clinical_flags: List[str] = Field(default_factory=list)
+    parsed_ingredients_present: bool = True
+
+
+class DroppedSuggestion(BaseModel):
+    """A suggestion the guardrail rejected after retries.
+
+    ``reasons`` carries machine tags (e.g. ``"allergen:tree_nut"``,
+    ``"dietary_forbid:gluten"``); ``detail`` carries the human-readable
+    strings surfaced in the UI.
+    """
+
+    name: str = ""
+    reasons: List[str] = Field(default_factory=list)
+    detail: List[str] = Field(default_factory=list)
 
 
 # --- Feedback ---
@@ -636,6 +651,10 @@ class MealPlanResponse(BaseModel):
 
     client_id: str
     suggestions: List[MealRecommendationWithId] = Field(default_factory=list)
+    dropped: List[DroppedSuggestion] = Field(default_factory=list)
+    flags_by_recommendation: Dict[str, List[str]] = Field(default_factory=dict)
+    guardrail_version: str = ""
+    restrictions_best_effort: bool = False
 
 
 class FeedbackRequest(BaseModel):

--- a/backend/agents/nutrition_meal_planning_team/tests/test_models_validators.py
+++ b/backend/agents/nutrition_meal_planning_team/tests/test_models_validators.py
@@ -388,3 +388,117 @@ def test_applicable_dietary_forbid_ambiguous_default_strict_ignores_exemptions()
         ]
     )
     assert rr.applicable_dietary_forbid({AllergenTag.fish}) == {DietaryTag.animal}
+
+
+# --- SPEC-007 W8: guardrail response fields ------------------------------
+
+
+def test_dropped_suggestion_defaults():
+    from nutrition_meal_planning_team.models import DroppedSuggestion
+
+    d = DroppedSuggestion()
+    assert d.name == ""
+    assert d.reasons == []
+    assert d.detail == []
+
+
+def test_dropped_suggestion_round_trip():
+    from nutrition_meal_planning_team.models import DroppedSuggestion
+
+    d = DroppedSuggestion(
+        name="Pesto Pasta",
+        reasons=["allergen:tree_nut", "dietary_forbid:gluten"],
+        detail=["Contains pine nuts (tree_nut allergen).", "Uses wheat pasta."],
+    )
+    restored = DroppedSuggestion.model_validate(d.model_dump())
+    assert restored.name == "Pesto Pasta"
+    assert restored.reasons == ["allergen:tree_nut", "dietary_forbid:gluten"]
+    assert restored.detail == [
+        "Contains pine nuts (tree_nut allergen).",
+        "Uses wheat pasta.",
+    ]
+
+
+def test_meal_recommendation_with_id_new_fields_defaults():
+    from nutrition_meal_planning_team.models import MealRecommendationWithId
+
+    r = MealRecommendationWithId()
+    assert r.clinical_flags == []
+    assert r.parsed_ingredients_present is True
+
+
+def test_meal_recommendation_with_id_round_trip():
+    from nutrition_meal_planning_team.models import MealRecommendationWithId
+
+    r = MealRecommendationWithId(
+        recommendation_id="r1",
+        clinical_flags=["interaction:warfarin"],
+        parsed_ingredients_present=False,
+    )
+    restored = MealRecommendationWithId.model_validate(r.model_dump())
+    assert restored.recommendation_id == "r1"
+    assert restored.clinical_flags == ["interaction:warfarin"]
+    assert restored.parsed_ingredients_present is False
+
+
+def test_meal_plan_response_new_fields_defaults():
+    from nutrition_meal_planning_team.models import MealPlanResponse
+
+    resp = MealPlanResponse(client_id="c1")
+    assert resp.dropped == []
+    assert resp.flags_by_recommendation == {}
+    assert resp.guardrail_version == ""
+    assert resp.restrictions_best_effort is False
+
+
+def test_meal_plan_response_round_trip():
+    from nutrition_meal_planning_team.models import (
+        DroppedSuggestion,
+        MealPlanResponse,
+        MealRecommendationWithId,
+    )
+
+    resp = MealPlanResponse(
+        client_id="c1",
+        suggestions=[
+            MealRecommendationWithId(
+                recommendation_id="r1",
+                clinical_flags=["interaction:warfarin"],
+                parsed_ingredients_present=False,
+            )
+        ],
+        dropped=[
+            DroppedSuggestion(
+                name="Pesto Pasta",
+                reasons=["allergen:tree_nut"],
+                detail=["Contains pine nuts (tree_nut allergen)."],
+            )
+        ],
+        flags_by_recommendation={"r1": ["advisory:vitamin_k"]},
+        guardrail_version="2026.05.0",
+        restrictions_best_effort=True,
+    )
+    payload = resp.model_dump()
+    restored = MealPlanResponse.model_validate(payload)
+    assert restored.model_dump() == payload
+    assert restored.suggestions[0].clinical_flags == ["interaction:warfarin"]
+    assert restored.suggestions[0].parsed_ingredients_present is False
+    assert restored.dropped[0].name == "Pesto Pasta"
+    assert restored.dropped[0].reasons == ["allergen:tree_nut"]
+    assert restored.flags_by_recommendation == {"r1": ["advisory:vitamin_k"]}
+    assert restored.guardrail_version == "2026.05.0"
+    assert restored.restrictions_best_effort is True
+
+
+def test_meal_plan_response_backwards_compat():
+    """Pre-W8 payloads (missing new fields) deserialize with safe defaults."""
+    from nutrition_meal_planning_team.models import MealPlanResponse
+
+    legacy_payload = {"client_id": "c1", "suggestions": []}
+    resp = MealPlanResponse.model_validate(legacy_payload)
+    assert resp.client_id == "c1"
+    assert resp.suggestions == []
+    assert resp.dropped == []
+    assert resp.flags_by_recommendation == {}
+    assert resp.guardrail_version == ""
+    assert resp.restrictions_best_effort is False


### PR DESCRIPTION
## Summary

Additive Pydantic schema changes on the nutrition meal-plan response so downstream orchestrator and UI work (SPEC-007 W7 and W10) can surface guardrail outcomes without further schema churn. Existing clients keep working — every new field has a safe default.

### `MealPlanResponse` gains four fields
- `dropped: List[DroppedSuggestion]` — suggestions the guardrail rejected after retries, with machine-tag `reasons` (e.g. `"allergen:tree_nut"`) and human-readable `detail` strings.
- `flags_by_recommendation: Dict[str, List[str]]` — recommendation-id → advisory flags (non-blocking).
- `guardrail_version: str` — version stamp on the policy that approved the response (enables replay/re-eval on policy bumps — SPEC-007 §4.10).
- `restrictions_best_effort: bool` — `True` when the profile pre-dates `restriction_resolution` and the response used on-the-fly resolution (SPEC-007 §4.11).

### `MealRecommendationWithId` gains two fields
- `clinical_flags: List[str]` — per-recommendation flags from the guardrail check.
- `parsed_ingredients_present: bool` — `False` signals the parser hit a KB gap on this item.

### New model
- `DroppedSuggestion(name, reasons, detail)`.

All defaults match the SPEC-007 §4.7 contract (empty list / empty dict / empty string / `False` / `True` for `parsed_ingredients_present`).

## Notes

- Used `Field(default_factory=list/dict)` rather than the spec's literal `= []` / `= {}` to stay consistent with the rest of `models.py` and avoid shared-mutable-default footguns.
- Schema-only change. Orchestrator population, UI consumption, and the `guardrail_version` constant land in follow-up work items (W7, W10).

## Test plan
- [x] `ruff check` + `ruff format --check` clean on both touched files.
- [x] `pytest agents/nutrition_meal_planning_team/tests/test_models_validators.py -v` — all 62 tests pass (55 pre-existing + 7 new).
- [x] Seven new tests cover: defaults for `DroppedSuggestion`, `MealRecommendationWithId`, and `MealPlanResponse`; full round-trip (`model_dump()` → `model_validate()`) with every new field populated; and a backwards-compat case that deserializes a pre-change `{"client_id": "c1", "suggestions": []}` payload and confirms defaults populate.
- [ ] Smoke `make run` against a Postgres-backed stack to confirm the FastAPI route still serializes `MealPlanResponse` (no orchestrator changes, expected to be a no-op).


---
_Generated by [Claude Code](https://claude.ai/code/session_0155jBPWaVTViDALK6ZZFW69)_