### PR TITLE
investment-team: per-rule synthetic-bar behavioural probes for synthesis

### DIFF
--- a/backend/agents/investment_team/strategy_lab/executor/indicators.py
+++ b/backend/agents/investment_team/strategy_lab/executor/indicators.py
@@ -37,8 +37,13 @@ def rsi(series: pd.Series, period: int = 14) -> pd.Series:
     avg_loss = loss.ewm(alpha=1 / period, min_periods=period, adjust=False).mean()
     rs = avg_gain / avg_loss.replace(0, np.nan)
     result = 100 - (100 / (1 + rs))
-    # When avg_loss is zero (sustained uptrend) RS is infinite → RSI = 100
-    result = result.fillna(np.where(avg_loss == 0, 100.0, np.nan))
+    # When avg_loss is zero (sustained uptrend) RS is infinite → RSI = 100.
+    # pandas 3.x requires a Series here (rejects raw ndarray), so wrap the
+    # np.where result with the same index as ``result``.
+    fill_values = pd.Series(
+        np.where(avg_loss == 0, 100.0, np.nan), index=result.index
+    )
+    result = result.fillna(fill_values)
     return result
 
 

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -70,6 +70,7 @@ from .quality_gates.code_safety import CodeSafetyChecker
 from .quality_gates.convergence_tracker import ConvergenceTracker
 from .quality_gates.exit_rule_conformance import ExitRuleConformanceGate
 from .quality_gates.models import QualityGateResult, StrategyLabPhase
+from .quality_gates.rule_probes import RuleProbesGate
 from .quality_gates.spec_readiness import SpecReadinessGate
 from .quality_gates.strategy_validator import StrategySpecValidator
 from .quality_gates.target_symbol_coverage import TargetSymbolCoverageGate
@@ -152,6 +153,16 @@ def _design_review_rounds() -> int:
         return max(int(raw), 1)
     except ValueError:
         return 5
+
+
+def _orchestrator_runner(code, market_data, config, *, strategy=None, **kwargs):
+    """Late-binding adapter so ``RuleProbesGate`` resolves
+    ``run_strategy_code`` through this module's namespace at call time —
+    test monkey-patches of ``investment_team.strategy_lab.orchestrator.
+    run_strategy_code`` therefore apply to probe execution as well as
+    the main pipeline.
+    """
+    return run_strategy_code(code, market_data, config, strategy=strategy, **kwargs)
 
 
 MAX_CODE_REFINEMENT_ROUNDS = 50
@@ -319,6 +330,14 @@ class StrategyLabOrchestrator:
         self.strategy_validator = StrategySpecValidator()
         self.code_safety_checker = CodeSafetyChecker()
         self.code_conformance_gate = CodeConformanceGate()
+        # Behavioural complement to CodeConformanceGate: runs the compiled
+        # strategy against per-rule synthetic-bar sequences and asserts
+        # each rule actually fires. Critical failures route back to
+        # refinement with the failing rule_id (see line ~836). The gate's
+        # runner is wired through this module so test monkey-patches of
+        # ``investment_team.strategy_lab.orchestrator.run_strategy_code``
+        # apply to probe execution as well as the main pipeline.
+        self.rule_probes_gate = RuleProbesGate(runner=_orchestrator_runner)
         self.anomaly_detector = BacktestAnomalyDetector()
         self.acceptance_gate = AcceptanceGate()
         self.target_symbol_coverage_gate = TargetSymbolCoverageGate()
@@ -834,6 +853,14 @@ class StrategyLabOrchestrator:
             round_gate_results.extend(code_gates)
             conformance_gates = self.code_conformance_gate.check(code, spec)
             round_gate_results.extend(conformance_gates)
+            # Behavioural rule probes only run when conformance is clean.
+            # Probing code that already failed structural checks adds noisy
+            # rule_id criticals on top of the cleaner conformance critical.
+            if not any(
+                not g.passed and g.severity == "critical" for g in conformance_gates
+            ):
+                probe_gates = self.rule_probes_gate.check(code, spec)
+                round_gate_results.extend(probe_gates)
             self.record_gates(round_gate_results, all_gate_results, refinement_round=round_num)
 
             checks_total = len(round_gate_results)
@@ -853,7 +880,8 @@ class StrategyLabOrchestrator:
                     },
                 )
                 failure_details = "\n".join(
-                    f"- [{g.gate_name}] {g.details}" for g in critical_failures
+                    f"- [{g.gate_name}{(':' + g.rule_id) if g.rule_id else ''}] {g.details}"
+                    for g in critical_failures
                 )
                 spec, code, exhausted = self._refine_or_exhaust(
                     spec=spec,

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -853,11 +853,13 @@ class StrategyLabOrchestrator:
             round_gate_results.extend(code_gates)
             conformance_gates = self.code_conformance_gate.check(code, spec)
             round_gate_results.extend(conformance_gates)
-            # Behavioural rule probes only run when conformance is clean.
-            # Probing code that already failed structural checks adds noisy
-            # rule_id criticals on top of the cleaner conformance critical.
+            # Behavioural rule probes only run when every prior validation
+            # gate (spec readiness, code safety, code conformance) is clean.
+            # Probing code that an earlier gate already flagged as critical
+            # wastes sandbox subprocess time and adds noisy rule_id criticals
+            # on top of the cleaner upstream critical.
             if not any(
-                not g.passed and g.severity == "critical" for g in conformance_gates
+                not g.passed and g.severity == "critical" for g in round_gate_results
             ):
                 probe_gates = self.rule_probes_gate.check(code, spec)
                 round_gate_results.extend(probe_gates)

--- a/backend/agents/investment_team/strategy_lab/quality_gates/__init__.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/__init__.py
@@ -5,6 +5,7 @@ from .backtest_anomaly import BacktestAnomalyDetector
 from .code_safety import CodeSafetyChecker
 from .convergence_tracker import ConvergenceTracker
 from .models import QualityGateResult, StrategyLabPhase
+from .rule_probes import RuleProbesGate
 from .spec_readiness import SpecReadinessGate
 from .strategy_validator import StrategySpecValidator
 from .target_symbol_coverage import TargetSymbolCoverageGate
@@ -15,6 +16,7 @@ __all__ = [
     "CodeSafetyChecker",
     "ConvergenceTracker",
     "QualityGateResult",
+    "RuleProbesGate",
     "SpecReadinessGate",
     "StrategyLabPhase",
     "StrategySpecValidator",

--- a/backend/agents/investment_team/strategy_lab/quality_gates/models.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/models.py
@@ -13,7 +13,13 @@ _VALID_PHASES: frozenset[str] = frozenset(StrategyLabPhase.__args__)  # type: ig
 
 
 class QualityGateResult(BaseModel):
-    """Result of a single quality gate check."""
+    """Result of a single quality gate check.
+
+    ``rule_id`` is an optional human-readable handle for gates whose checks
+    map 1:1 onto spec rules (e.g. ``"entry[0]"``, ``"exit[1]:stop_loss"``).
+    The orchestrator includes it in the aggregated failure-details string
+    so refinement prompts can target the specific branch that failed.
+    """
 
     gate_name: str
     passed: bool
@@ -21,6 +27,7 @@ class QualityGateResult(BaseModel):
     severity: Literal["info", "warning", "critical"]
     phase: StrategyLabPhase
     refinement_round: int = 0
+    rule_id: Optional[str] = None
 
 
 class GateResultsMixin:
@@ -63,17 +70,22 @@ class GateResultsMixin:
             # that throws never leaves stale state visible to the next caller.
             self._phase = prev
 
-    def _critical(self, details: str) -> QualityGateResult:
-        return self._emit(passed=False, severity="critical", details=details)
+    def _critical(self, details: str, *, rule_id: Optional[str] = None) -> QualityGateResult:
+        return self._emit(passed=False, severity="critical", details=details, rule_id=rule_id)
 
-    def _warning(self, details: str) -> QualityGateResult:
-        return self._emit(passed=False, severity="warning", details=details)
+    def _warning(self, details: str, *, rule_id: Optional[str] = None) -> QualityGateResult:
+        return self._emit(passed=False, severity="warning", details=details, rule_id=rule_id)
 
-    def _info(self, details: str = "") -> QualityGateResult:
-        return self._emit(passed=True, severity="info", details=details)
+    def _info(self, details: str = "", *, rule_id: Optional[str] = None) -> QualityGateResult:
+        return self._emit(passed=True, severity="info", details=details, rule_id=rule_id)
 
     def _emit(
-        self, *, passed: bool, severity: Literal["info", "warning", "critical"], details: str
+        self,
+        *,
+        passed: bool,
+        severity: Literal["info", "warning", "critical"],
+        details: str,
+        rule_id: Optional[str] = None,
     ) -> QualityGateResult:
         # Pre: ``_using_phase`` is active.
         assert self._phase is not None, (
@@ -86,4 +98,5 @@ class GateResultsMixin:
             passed=passed,
             severity=severity,
             details=details,
+            rule_id=rule_id,
         )

--- a/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/__init__.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/__init__.py
@@ -1,0 +1,41 @@
+"""Per-rule synthetic-bar behavioural probes.
+
+The structural :class:`CodeConformanceGate` checks that the compiled
+strategy code *looks* like it implements the spec (right indicators,
+right exit branches, right sizing math). It can still be fooled by code
+that's shaped right but wired wrong — a swapped comparator, a negated
+exit predicate, an entry branch whose order submission is silently
+unreachable.
+
+This package adds the behavioural complement: for every rule in the
+spec we synthesise a deterministic bar sequence designed to force that
+rule's predicates to evaluate ``True``, run the compiled code through
+the existing :func:`run_strategy_code` sandbox, and assert the resulting
+``TradeRecord`` envelope matches the expected order / exit. Probe
+failures route back to synthesis with the failing ``rule_id`` so the
+refinement agent can target the right code branch.
+
+The gate slots in after :class:`CodeConformanceGate` in the synthesis
+loop, before the real backtest — failing fast on rules that don't fire,
+without paying for a full backtest cycle to find out.
+
+Public surface:
+
+- :class:`RuleProbesGate` — the quality gate the orchestrator invokes.
+- :class:`ProbeRun` — one probe's synthetic input + expected outcome.
+- :class:`ExpectedOutcome` — what the assertion layer looks for.
+"""
+
+from __future__ import annotations
+
+from .asserter import assess_probe
+from .gate import RuleProbesGate
+from .synthesizer import ExpectedOutcome, ProbeRun, generate_rule_probe_runs
+
+__all__ = [
+    "ExpectedOutcome",
+    "ProbeRun",
+    "RuleProbesGate",
+    "assess_probe",
+    "generate_rule_probe_runs",
+]

--- a/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/asserter.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/asserter.py
@@ -101,18 +101,28 @@ def _check_entry(
             f"expected at least one {expected_side} trade to open on/after "
             f"trigger bar {trigger_date}, but no trades were recorded"
         )
+    early_trades_seen = 0
     for trade in trades:
         side = getattr(trade, "side", None)
         entry_date = getattr(trade, "entry_date", None)
         if expected_side is not None and side != expected_side:
             continue
         if trigger_date is not None and entry_date is not None and str(entry_date) < trigger_date:
-            # The opening trade happened *before* the trigger bar — that
-            # might still be the rule under test (entry bars often satisfy
-            # the predicate earlier than the planned trigger when the
-            # binary search lands a touch high). Accept it.
-            return True, f"trade opened {side} on {entry_date}"
+            # The opening trade happened *before* the synthesised trigger bar.
+            # The recipe verified the predicate becomes True at trigger_date,
+            # so a trade opened earlier is unrelated activity (e.g. an
+            # always-on entry on bar 0) and is not evidence the rule under
+            # test actually fires. Skip and keep scanning for a later
+            # correctly-sided trade.
+            early_trades_seen += 1
+            continue
         return True, f"trade opened {side} on {entry_date}"
+    if early_trades_seen:
+        return False, (
+            f"found {early_trades_seen} {expected_side} trade(s) but all opened "
+            f"before trigger bar {trigger_date}; rule predicate likely not the "
+            "actual entry signal"
+        )
     return False, f"no trade with side={expected_side} found"
 
 

--- a/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/asserter.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/asserter.py
@@ -135,12 +135,30 @@ def _check_exit(
     if not trades:
         return False, (
             f"expected one trade closed with exit_reason containing "
-            f"'{expected_substr}' but no trades were recorded"
+            f"'{expected_substr}' on/after trigger bar {trigger_date} "
+            "but no trades were recorded"
         )
+    early_matches_seen = 0
     for trade in trades:
         exit_reason = getattr(trade, "exit_reason", None) or ""
-        if expected_substr in str(exit_reason):
-            return True, f"trade closed with exit_reason='{exit_reason}'"
+        if expected_substr not in str(exit_reason):
+            continue
+        exit_date = getattr(trade, "exit_date", None)
+        if trigger_date is not None and exit_date is not None and str(exit_date) < trigger_date:
+            # The trade closed *before* the synthesised exit-trigger bar.
+            # An exit_reason substring match alone isn't evidence the
+            # targeted rule fired — a strategy that always exits at bar 2
+            # for unrelated reasons can collide with the substring. Skip
+            # and keep scanning.
+            early_matches_seen += 1
+            continue
+        return True, f"trade closed with exit_reason='{exit_reason}' on {exit_date}"
+    if early_matches_seen:
+        return False, (
+            f"found {early_matches_seen} trade(s) with exit_reason matching "
+            f"'{expected_substr}' but all closed before trigger bar {trigger_date}; "
+            "targeted rule likely not the actual exit cause"
+        )
     return False, (
         f"no trade closed with exit_reason containing '{expected_substr}'"
     )

--- a/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/asserter.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/asserter.py
@@ -1,0 +1,164 @@
+"""Map a :class:`StrategyRunResult` to a :class:`QualityGateResult` per probe.
+
+The gate calls :func:`assess_probe` once per :class:`ProbeRun`. Outcomes:
+
+- Unprobeable run → ``severity="warning"`` with the unprobeable reason in
+  ``details``. Surfaces the limitation in refinement prompts without
+  blocking the synthesis loop.
+- Sandbox-level failure (``result.success=False``) → ``severity="critical"``;
+  refinement will see the engine error and re-author the code.
+- Probeable but no matching trade → ``severity="critical"`` with a compact
+  trade summary so the refinement agent can target the right code branch.
+- Match found → ``severity="info"``, ``passed=True``.
+
+The asserter does not own the :class:`GateResultsMixin` helpers — it
+returns plain :class:`QualityGateResult` values that the gate layer
+constructs through the mixin so the gate name / phase are stamped
+consistently.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Tuple
+
+from ..models import GateResultsMixin, QualityGateResult
+from .synthesizer import ProbeRun
+
+# Max number of trade entries we render into ``details`` on a failure.
+_MAX_TRADES_IN_DETAILS = 5
+# Max stderr characters we propagate from a failed sandbox run.
+_MAX_STDERR_CHARS = 400
+
+
+def assess_probe(
+    probe: ProbeRun,
+    result: object,
+    *,
+    emitter: GateResultsMixin,
+) -> QualityGateResult:
+    """Translate one probe's outcome into a :class:`QualityGateResult`.
+
+    Pre:
+      - ``probe`` carries ``rule_id`` and ``expected`` (or is unprobeable).
+      - ``emitter`` is inside a ``with self._using_phase(...)`` block.
+      - ``result`` exposes ``success: bool``, ``trades: list[TradeRecord]``,
+        ``error_type: Optional[str]``, ``stderr: str``. The asserter accepts
+        any duck-typed object so tests can pass a lightweight stand-in.
+    """
+    if not probe.synthesizable:
+        return emitter._warning(
+            _format_unprobeable(probe),
+            rule_id=probe.rule_id,
+        )
+
+    success = bool(getattr(result, "success", False))
+    if not success:
+        return emitter._critical(
+            _format_sandbox_failure(probe, result),
+            rule_id=probe.rule_id,
+        )
+
+    trades = list(getattr(result, "trades", []) or [])
+    trigger_date = _trigger_date(probe)
+
+    if probe.expected is None:
+        return emitter._critical(
+            f"rule_id={probe.rule_id}: probe has no expected outcome configured.",
+            rule_id=probe.rule_id,
+        )
+
+    if probe.expected.kind == "entry":
+        ok, why = _check_entry(probe, trades, trigger_date)
+    else:
+        ok, why = _check_exit(probe, trades, trigger_date)
+
+    if ok:
+        return emitter._info(
+            f"rule_id={probe.rule_id}: probe passed ({why}).",
+            rule_id=probe.rule_id,
+        )
+    return emitter._critical(
+        f"rule_id={probe.rule_id}: {why}. trades={_summarise_trades(trades)}",
+        rule_id=probe.rule_id,
+    )
+
+
+def _trigger_date(probe: ProbeRun) -> Optional[str]:
+    if not probe.market_data:
+        return None
+    idx = probe.trigger_bar_index
+    if idx < 0 or idx >= len(probe.market_data):
+        return None
+    return probe.market_data[idx].date
+
+
+def _check_entry(
+    probe: ProbeRun, trades: List[object], trigger_date: Optional[str]
+) -> Tuple[bool, str]:
+    expected_side = probe.expected.side if probe.expected else None
+    if not trades:
+        return False, (
+            f"expected at least one {expected_side} trade to open on/after "
+            f"trigger bar {trigger_date}, but no trades were recorded"
+        )
+    for trade in trades:
+        side = getattr(trade, "side", None)
+        entry_date = getattr(trade, "entry_date", None)
+        if expected_side is not None and side != expected_side:
+            continue
+        if trigger_date is not None and entry_date is not None and str(entry_date) < trigger_date:
+            # The opening trade happened *before* the trigger bar — that
+            # might still be the rule under test (entry bars often satisfy
+            # the predicate earlier than the planned trigger when the
+            # binary search lands a touch high). Accept it.
+            return True, f"trade opened {side} on {entry_date}"
+        return True, f"trade opened {side} on {entry_date}"
+    return False, f"no trade with side={expected_side} found"
+
+
+def _check_exit(
+    probe: ProbeRun, trades: List[object], trigger_date: Optional[str]
+) -> Tuple[bool, str]:
+    expected_substr = probe.expected.exit_reason_contains if probe.expected else None
+    if expected_substr is None:
+        return False, "exit probe missing exit_reason_contains expectation"
+    if not trades:
+        return False, (
+            f"expected one trade closed with exit_reason containing "
+            f"'{expected_substr}' but no trades were recorded"
+        )
+    for trade in trades:
+        exit_reason = getattr(trade, "exit_reason", None) or ""
+        if expected_substr in str(exit_reason):
+            return True, f"trade closed with exit_reason='{exit_reason}'"
+    return False, (
+        f"no trade closed with exit_reason containing '{expected_substr}'"
+    )
+
+
+def _format_unprobeable(probe: ProbeRun) -> str:
+    return (
+        f"rule_id={probe.rule_id}: unprobeable ({probe.unprobeable_reason or 'unknown'}). "
+        "The synthesiser could not engineer a bar sequence to fire this rule's predicate; "
+        "the probe was skipped."
+    )
+
+
+def _format_sandbox_failure(probe: ProbeRun, result: object) -> str:
+    error_type = getattr(result, "error_type", None) or "unknown"
+    stderr = (getattr(result, "stderr", "") or "")[:_MAX_STDERR_CHARS]
+    return (
+        f"rule_id={probe.rule_id}: sandbox failed (error_type={error_type}). stderr={stderr!r}"
+    )
+
+
+def _summarise_trades(trades: List[object]) -> str:
+    rendered: List[str] = []
+    for trade in trades[:_MAX_TRADES_IN_DETAILS]:
+        side = getattr(trade, "side", "?")
+        entry_date = getattr(trade, "entry_date", "?")
+        exit_date = getattr(trade, "exit_date", "?")
+        exit_reason = getattr(trade, "exit_reason", None)
+        rendered.append(f"(side={side}, entry={entry_date}, exit={exit_date}, reason={exit_reason!r})")
+    extra = "" if len(trades) <= _MAX_TRADES_IN_DETAILS else f" ...+{len(trades) - _MAX_TRADES_IN_DETAILS} more"
+    return "[" + ", ".join(rendered) + "]" + extra

--- a/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/gate.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/gate.py
@@ -1,0 +1,169 @@
+"""The :class:`RuleProbesGate` quality-gate facade.
+
+For every entry/exit rule in the spec the gate:
+
+1. Asks :func:`generate_rule_probe_runs` to build a deterministic OHLCV
+   sequence designed to fire that rule's predicate.
+2. Runs the compiled ``strategy_code`` through :func:`run_strategy_code`
+   against the synthetic bars with a tiny ``initial_capital`` and zero
+   transaction costs so sizing/order behaviour is deterministic.
+3. Asks :func:`assess_probe` to compare the resulting ``TradeRecord``
+   envelope against the rule's :class:`ExpectedOutcome`.
+
+The gate is purely deterministic — every probe uses the same fixed bar
+geometry, no randomness, no LLM calls. Per-probe runtime is bounded by
+the sandbox's subprocess spawn (~0.2-1.0 s per probe on local hardware),
+satisfying the ``< 5 s per probe`` budget in the gate's contract.
+
+Routing on failure: critical probe results join the synthesis loop's
+existing ``critical_failures`` collection in :mod:`orchestrator` and
+route through ``_refine_or_exhaust(failure_phase="validation", ...)``.
+The probe's ``rule_id`` is surfaced inside the aggregated
+``failure_details`` string so the refinement agent can target the right
+branch.
+
+Limitations:
+
+- ``SignalExitRule`` probes assert the closing trade carries an
+  ``exit_reason`` substring of ``"signal_exit"``. The deterministic
+  compiler emits ``reason="compiled_signal_exit"`` which matches.
+  Strategies that close via strategy-emitted orders with a different
+  reason string (legacy LLM-authored code) will fail this probe even
+  when correct; the asserter renders a clear diagnostic so the
+  refinement loop can adjust.
+- Synthesis is heuristic for ATR/ADX/Stochastic thresholds; recipes
+  that can't satisfy the predicate within the binary-search budget
+  return ``synthesizable=False`` and surface as warnings.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, ClassVar, List, Optional
+
+from ....models import BacktestConfig
+from ...spec_dsl import StopLossRule, TakeProfitRule
+from ..models import GateResultsMixin, QualityGateResult, StrategyLabPhase
+from .asserter import assess_probe
+from .synthesizer import ProbeRun, generate_rule_probe_runs
+
+logger = logging.getLogger(__name__)
+
+GATE: str = "rule_probes"
+
+# Probe-specific BacktestConfig knobs. Tiny capital makes sizing math
+# deterministic regardless of the strategy's chosen sizing rule.
+_PROBE_INITIAL_CAPITAL = 1_000.0
+_PROBE_TRANSACTION_COST_BPS = 0.0
+_PROBE_SLIPPAGE_BPS = 0.0
+
+
+class RuleProbesGate(GateResultsMixin):
+    """Behavioural complement to :class:`CodeConformanceGate`.
+
+    Run **after** ``CodeConformanceGate`` in the synthesis loop. The
+    orchestrator should gate this call on conformance passing — probing
+    code that already failed structural checks adds noisy ``rule_id``
+    criticals on top of the cleaner conformance critical.
+
+    Contract:
+      Pre: ``code`` is non-empty Python source; ``spec`` is a
+      ``StrategySpec`` whose ``entry_rules`` and ``exit_rules`` describe
+      the expected rule set.
+      Post: returned list has one :class:`QualityGateResult` per spec
+      rule. ``rule_id`` is set on every result so the orchestrator can
+      thread the failing rule into ``failure_details``.
+    """
+
+    GATE: ClassVar[str] = GATE
+
+    def __init__(self, runner: Optional[Any] = None) -> None:
+        """``runner`` is the sandbox entry point — defaults to the real
+        :func:`run_strategy_code`. Tests inject a stub to assert against
+        recorded calls without spawning subprocesses.
+        """
+        if runner is None:
+            from ....trading_service.modes.sandbox_compat import run_strategy_code as _rsc
+
+            runner = _rsc
+        self._runner = runner
+
+    def check(
+        self,
+        code: str,
+        spec: Any,
+        *,
+        phase: StrategyLabPhase = "synthesis",
+    ) -> List[QualityGateResult]:
+        with self._using_phase(phase):
+            if not code or not code.strip():
+                return [self._critical("Rule probes gate received empty strategy_code.")]
+            probes = generate_rule_probe_runs(spec, compiled_code=code)
+            if not probes:
+                return [
+                    self._info(
+                        "No entry/exit rules to probe — gate has no work to do."
+                    )
+                ]
+            results: List[QualityGateResult] = []
+            for probe in probes:
+                result = self._run_probe(probe, code, spec)
+                results.append(assess_probe(probe, result, emitter=self))
+            return results
+
+    def _run_probe(self, probe: ProbeRun, code: str, spec: Any) -> Any:
+        """Invoke the sandbox for one probe.
+
+        Skips the sandbox entirely when the probe is unprobeable — the
+        asserter handles that path without needing a result.
+        """
+        if not probe.synthesizable:
+            return _SkippedResult()
+        config = self._make_probe_config(probe)
+        market_data = {probe.symbol: probe.market_data}
+        try:
+            return self._runner(code, market_data, config, strategy=spec)
+        except Exception as exc:
+            logger.warning(
+                "RuleProbesGate sandbox raised for rule_id=%s: %s", probe.rule_id, exc
+            )
+            return _FailedResult(error_type="probe_runner_exception", stderr=str(exc))
+
+    def _make_probe_config(self, probe: ProbeRun) -> BacktestConfig:
+        bars = probe.market_data
+        # Pre: synthesizable probes always carry at least 2 bars.
+        assert bars, "synthesizable probe must carry at least one bar"
+        return BacktestConfig(
+            start_date=bars[0].date,
+            end_date=bars[-1].date,
+            initial_capital=_PROBE_INITIAL_CAPITAL,
+            transaction_cost_bps=_PROBE_TRANSACTION_COST_BPS,
+            slippage_bps=_PROBE_SLIPPAGE_BPS,
+            min_signals_per_bar=0.0,
+        )
+
+
+class _SkippedResult:
+    """Stand-in for ``StrategyRunResult`` when a probe was not run."""
+
+    success = True
+    trades: List[Any] = []
+    error_type = None
+    stderr = ""
+
+
+class _FailedResult:
+    """Stand-in for ``StrategyRunResult`` when the sandbox raised."""
+
+    success = False
+    trades: List[Any] = []
+
+    def __init__(self, *, error_type: str, stderr: str) -> None:
+        self.error_type = error_type
+        self.stderr = stderr
+
+
+# ``StopLossRule`` and ``TakeProfitRule`` are imported so the package's
+# re-export surface stays minimal but the module can be inspected from
+# the gate's call site (e.g. for type-narrowing in tests).
+__all__ = ["GATE", "RuleProbesGate", "StopLossRule", "TakeProfitRule"]

--- a/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/synthesizer.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/synthesizer.py
@@ -581,29 +581,43 @@ def _synthesise_for_predicate(
 def _synth_priceref_vs_number(
     lhs: str, op: str, rhs: float, base_close: float, min_bars: int
 ) -> Tuple[Optional[List[OHLCVBar]], int, Optional[str]]:
-    """Generate bars where the bar's price field satisfies ``lhs op rhs``."""
+    """Generate bars where the bar's price field satisfies ``lhs op rhs``.
+
+    Bails out (unprobeable) when the synthesised values would be clamped
+    by :func:`_normalise_ohlc` (every OHLC value floored to ``_MIN_PRICE``).
+    Verifying on raw bars and shipping clamped bars to the sandbox would
+    produce a false probe failure (e.g. ``bar.close < 0.005`` synthesised
+    as ``-0.995`` but seen as ``0.01`` post-clamp).
+    """
     n = max(min_bars, 30)
     trigger_idx = n - _BARS_AFTER_TRIGGER - 1
     bars: List[OHLCVBar] = []
     field_name = lhs.split(".", 1)[1]  # "bar.close" -> "close"
     # Baseline closes that don't satisfy the predicate.
     baseline = rhs - 5.0 if op in (">", ">=") else rhs + 5.0
+    if op == ">":
+        trigger_value = rhs + 1.0
+    elif op == ">=":
+        trigger_value = rhs + 0.5
+    elif op == "<":
+        trigger_value = rhs - 1.0
+    elif op == "<=":
+        trigger_value = rhs - 0.5
+    elif op == "==":
+        trigger_value = rhs
+    else:
+        return None, 0, f"unsupported_priceref_op:{op}"
+    # ``_normalise_ohlc`` floors every OHLC value to ``_MIN_PRICE`` and may
+    # round high/low up/down around the field's adjacent values; the
+    # critical case is the trigger value itself becoming ``_MIN_PRICE`` and
+    # no longer satisfying the predicate. Refuse the probe in that case.
+    if trigger_value < _MIN_PRICE and not _compare(_MIN_PRICE, op, rhs):
+        return None, 0, "priceref_value_below_clamp_floor"
+    if baseline < _MIN_PRICE and field_name != "volume":
+        return None, 0, "priceref_baseline_below_clamp_floor"
     for i in range(n):
         if i == trigger_idx:
-            # Move the relevant field across the threshold.
-            if op == ">":
-                value = rhs + 1.0
-            elif op == ">=":
-                value = rhs + 0.5
-            elif op == "<":
-                value = rhs - 1.0
-            elif op == "<=":
-                value = rhs - 0.5
-            elif op == "==":
-                value = rhs
-            else:
-                return None, 0, f"unsupported_priceref_op:{op}"
-            bars.append(_bar_with_field(field_name, value))
+            bars.append(_bar_with_field(field_name, trigger_value))
         else:
             bars.append(_bar_with_field(field_name, baseline))
     if not _verify_priceref_vs_number(bars, field_name, op, rhs, trigger_idx):
@@ -768,6 +782,13 @@ def _synth_indicator_vs_number(
 
     if not _verify_indicator_vs_number(bars, ref, op, rhs, trigger_idx):
         return None, 0, f"indicator_predicate_verification_failed:{ref.name}_{op}"
+    # Refine trigger_idx to the earliest bar the predicate actually holds at —
+    # the asserter requires entry_date >= trigger_date, and a correctly-built
+    # strategy opens at the rule's first-fire bar, not at the recipe's
+    # constructed end-of-window bar.
+    earliest = _earliest_indicator_satisfying_index(ref, bars, op, rhs)
+    if earliest is not None:
+        trigger_idx = earliest
     return bars, trigger_idx, None
 
 
@@ -917,6 +938,25 @@ def _verify_indicator_vs_number(
     if value is None or (isinstance(value, float) and not math.isfinite(value)):
         return False
     return _compare(value, op, rhs)
+
+
+def _earliest_indicator_satisfying_index(
+    ref: IndicatorRef, bars: List[OHLCVBar], op: str, rhs: float
+) -> Optional[int]:
+    """Scan the bar series for the first index where ``indicator(bars) op rhs``
+    holds. Used to align the probe's ``trigger_bar_index`` with the bar a
+    correctly-built strategy would actually open on (the rule's first-fire
+    bar). Returns ``None`` if no bar satisfies the predicate.
+    """
+    for i in range(len(bars)):
+        value = _compute_indicator_at(ref, bars, i)
+        if value is None:
+            continue
+        if not math.isfinite(value):
+            continue
+        if _compare(value, op, rhs):
+            return i
+    return None
 
 
 def _compute_indicator_at(ref: IndicatorRef, bars: List[OHLCVBar], idx: int) -> Optional[float]:

--- a/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/synthesizer.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/synthesizer.py
@@ -672,6 +672,13 @@ def _synth_priceref_vs_priceref(
 ) -> Tuple[Optional[List[OHLCVBar]], int, Optional[str]]:
     if lhs == rhs:
         return None, 0, "priceref_vs_self_unsatisfiable"
+    # ``bar.volume`` is a valid PriceRef per the DSL but doesn't fit the
+    # synthesiser's OHLC default model (volume is on a different scale and
+    # rarely comparable against prices). Treat volume-mixed predicates as
+    # unprobeable rather than risking a KeyError or producing meaningless
+    # synthetic bars.
+    if "bar.volume" in (lhs, rhs):
+        return None, 0, "priceref_volume_comparison_unprobeable"
     n = max(min_bars, 30)
     trigger_idx = n - _BARS_AFTER_TRIGGER - 1
     bars: List[OHLCVBar] = []

--- a/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/synthesizer.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/synthesizer.py
@@ -1,0 +1,1283 @@
+"""Synthetic-bar recipes that force each spec rule's predicate to fire.
+
+The compiler's ``on_bar`` is the contract the probes test against. Each
+recipe produces a deterministic OHLCV sequence designed so that the
+target rule's predicate evaluates ``True`` on a specific *trigger* bar,
+verified up-front using the same indicator helpers the compiler emits
+calls to (:mod:`investment_team.strategy_lab.executor.indicators`).
+
+Recipes are organised by rule shape rather than rule kind:
+
+- Entry rules dispatch on the ``Predicate`` shape (price-vs-number,
+  indicator-vs-number, indicator-vs-indicator, cross-above/below).
+- Exit rules reuse the entry recipes to build a position-opening prefix,
+  then append a tail that satisfies the exit predicate (``StopLoss`` /
+  ``TakeProfit`` / ``SignalExit``).
+
+TimeStopRule is out of scope here — ``spec_dsl.py`` deliberately omits
+it from the ``ExitRule`` union ("real traders close on price, P&L, or
+signal reversal, not on an arbitrary Nth bar"). If the DSL grows a
+time-based exit kind later, add a recipe here.
+
+Unprobeable rules (e.g. predicates whose synthetic series cannot be
+made to satisfy the predicate within bounded binary-search iterations,
+or specs whose ``target_symbols`` mismatch the compiled ``UNIVERSE``
+literal) return ``ProbeRun(synthesizable=False, unprobeable_reason=...)``
+— the gate emits a warning rather than blocking the synthesis loop on a
+limitation of this module.
+"""
+
+from __future__ import annotations
+
+import ast
+import math
+from dataclasses import dataclass, field
+from typing import Any, List, Literal, Optional, Tuple
+
+import pandas as pd
+
+from ....market_data_service import OHLCVBar
+from ...executor.indicators import (
+    adx,
+    atr,
+    bollinger_bands,
+    ema,
+    macd,
+    rsi,
+    sma,
+    stochastic,
+    vwap,
+)
+from ...spec_dsl import (
+    EntryRule,
+    IndicatorRef,
+    Predicate,
+    SignalExitRule,
+    StopLossRule,
+    TakeProfitRule,
+)
+
+# Bars/recipe knobs. Indicators with the largest lookback need the most
+# bars; ``min_total_bars`` keeps short-lookback recipes well above the
+# compiler's ``history_depth`` so warm-up never starves them.
+_MIN_TOTAL_BARS = 80
+_BARS_AFTER_TRIGGER = 5
+_DECAY_SEARCH_ITERS = 12
+_PROBE_SYMBOL_FALLBACK = "PROBE"
+
+
+@dataclass(frozen=True)
+class ExpectedOutcome:
+    """What the assertion layer expects to find in ``StrategyRunResult.trades``.
+
+    Preconditions:
+      - ``kind == "entry"`` → ``side`` is set to ``"long"`` / ``"short"``.
+      - ``kind == "exit"`` → ``exit_reason_contains`` is set to a
+        non-empty substring the engine writes into ``TradeRecord.exit_reason``
+        for the rule kind under test (``"stop_loss"``, ``"take_profit"``,
+        ``"signal_exit"``).
+    """
+
+    kind: Literal["entry", "exit"]
+    side: Optional[Literal["long", "short"]] = None
+    exit_reason_contains: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ProbeRun:
+    """One probe's input + expected outcome.
+
+    ``synthesizable=False`` runs skip the sandbox; the asserter emits a
+    warning with ``unprobeable_reason``. ``trigger_bar_index`` is the
+    index in ``market_data[symbol]`` of the bar where the predicate is
+    expected to evaluate True (i.e. where a trade should appear at or
+    after).
+    """
+
+    rule_id: str
+    rule_kind: Literal["entry", "stop_loss", "take_profit", "signal_exit"]
+    symbol: str
+    market_data: List[OHLCVBar] = field(default_factory=list)
+    expected: Optional[ExpectedOutcome] = None
+    trigger_bar_index: int = 0
+    synthesizable: bool = True
+    unprobeable_reason: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+
+def generate_rule_probe_runs(spec: Any, *, compiled_code: str = "") -> List[ProbeRun]:
+    """Build one :class:`ProbeRun` per entry/exit rule in ``spec``.
+
+    Pre:
+      - ``spec`` is a ``StrategySpec`` carrying ``entry_rules`` and
+        ``exit_rules`` lists.
+      - ``compiled_code`` is optional. When supplied, the synthesiser
+        parses any top-level ``UNIVERSE = frozenset({...})`` literal so
+        the probe's synthetic symbol matches the compiled code's symbol
+        filter (otherwise the sandbox's universe-guard returns at the
+        top of ``on_bar`` and the probe sees zero trades).
+
+    Post:
+      - Returns exactly ``len(spec.entry_rules) + len(spec.exit_rules)``
+        :class:`ProbeRun` objects, ordered entries-first.
+      - Every probeable run's ``market_data`` carries unique, ascending
+        ``date`` strings (sandbox callers require parseable dates).
+      - Unprobeable rules carry ``synthesizable=False`` with a non-empty
+        ``unprobeable_reason``; the asserter renders them as warnings.
+    """
+    symbol = _resolve_probe_symbol(spec, compiled_code)
+    runs: List[ProbeRun] = []
+    for idx, rule in enumerate(getattr(spec, "entry_rules", []) or []):
+        runs.append(_build_entry_probe(rule, idx, symbol))
+    for idx, rule in enumerate(getattr(spec, "exit_rules", []) or []):
+        runs.append(_build_exit_probe(rule, idx, symbol, getattr(spec, "entry_rules", []) or []))
+    return [_stamp_dates(run) for run in runs]
+
+
+def _stamp_dates(probe: ProbeRun, start_date: str = "2024-01-01") -> ProbeRun:
+    """Rebuild a probe's bars with ascending calendar dates and validate
+    OHLC integrity.
+
+    Recipe authors emit bars with placeholder ``date`` values for clarity —
+    the actual dates are not meaningful, only their ordering. This pass
+    assigns ``start_date + i days`` so downstream consumers (``BacktestConfig``,
+    sandbox harness) get real, parseable date strings. It also clamps each
+    bar's OHLC values so the downstream market-data preflight (which
+    rejects nan_or_negative_prices and ohlc_violations) accepts the run.
+    """
+    if not probe.synthesizable or not probe.market_data:
+        return probe
+    dates = pd.date_range(start_date, periods=len(probe.market_data), freq="D")
+    new_bars = [
+        _normalise_ohlc(
+            OHLCVBar(
+                date=str(dates[i].strftime("%Y-%m-%d")),
+                open=b.open,
+                high=b.high,
+                low=b.low,
+                close=b.close,
+                volume=b.volume,
+            )
+        )
+        for i, b in enumerate(probe.market_data)
+    ]
+    return ProbeRun(
+        rule_id=probe.rule_id,
+        rule_kind=probe.rule_kind,
+        symbol=probe.symbol,
+        market_data=new_bars,
+        expected=probe.expected,
+        trigger_bar_index=probe.trigger_bar_index,
+        synthesizable=probe.synthesizable,
+        unprobeable_reason=probe.unprobeable_reason,
+    )
+
+
+# Floor for synthesised prices. The market-data preflight rejects any
+# bar with an OHLC value <= 0 (``_has_nan_or_negative_price``), so we
+# clamp here to keep recipes simple — none of the probe assertions
+# care about absolute price levels, only relative motion.
+_MIN_PRICE = 0.01
+
+
+def _normalise_ohlc(bar: OHLCVBar) -> OHLCVBar:
+    """Clamp OHLC values to satisfy the market-data preflight.
+
+    Post:
+      - every OHLC value is finite and > 0.
+      - ``high >= max(open, close, low)``; ``low <= min(open, close, high)``.
+      - ``volume`` is non-negative; NaN is replaced with 1.0.
+    """
+
+    def _safe(value: float) -> float:
+        if value is None or not math.isfinite(value):
+            return _MIN_PRICE
+        return max(_MIN_PRICE, float(value))
+
+    o = _safe(bar.open)
+    c = _safe(bar.close)
+    h = _safe(bar.high)
+    low = _safe(bar.low)
+    # Enforce the OHLC invariants the preflight checks.
+    h = max(h, o, c, low)
+    low = min(low, o, c, h)
+    vol = bar.volume if bar.volume is not None and math.isfinite(bar.volume) and bar.volume >= 0 else 1.0
+    return OHLCVBar(
+        date=bar.date,
+        open=o,
+        high=h,
+        low=low,
+        close=c,
+        volume=vol,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Symbol resolution
+# ---------------------------------------------------------------------------
+
+
+def _resolve_probe_symbol(spec: Any, compiled_code: str) -> str:
+    """Pick a synthetic-bar symbol that matches the compiled code's universe.
+
+    Order of preference:
+      1. ``spec.target_symbols[0]`` if non-empty.
+      2. An element of the top-level ``UNIVERSE = frozenset({...})`` literal
+         parsed out of ``compiled_code`` (if present and non-empty).
+      3. The sentinel ``"PROBE"`` — only safe when the compiled code's
+         universe filter is empty (i.e. no ``UNIVERSE`` reference in
+         ``on_bar``); recipes that emit this sentinel and find a non-empty
+         ``UNIVERSE`` literal mark themselves unprobeable downstream.
+    """
+    target_symbols = list(getattr(spec, "target_symbols", []) or [])
+    if target_symbols:
+        return str(target_symbols[0])
+    parsed = _extract_universe_literal(compiled_code)
+    if parsed:
+        return next(iter(sorted(parsed)))
+    return _PROBE_SYMBOL_FALLBACK
+
+
+def _extract_universe_literal(code: str) -> frozenset:
+    """Parse ``UNIVERSE = frozenset({...})`` (or assignment to ``self.UNIVERSE``)
+    from compiled-strategy source. Returns an empty frozenset on any failure.
+    """
+    if not code:
+        return frozenset()
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return frozenset()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        if len(node.targets) != 1:
+            continue
+        target = node.targets[0]
+        target_name = None
+        if isinstance(target, ast.Name):
+            target_name = target.id
+        elif isinstance(target, ast.Attribute):
+            target_name = target.attr
+        if target_name != "UNIVERSE":
+            continue
+        value = node.value
+        if isinstance(value, ast.Call) and isinstance(value.func, ast.Name) and value.func.id == "frozenset":
+            if not value.args:
+                return frozenset()
+            arg = value.args[0]
+            try:
+                literal = ast.literal_eval(arg)
+            except (ValueError, SyntaxError):
+                return frozenset()
+            if isinstance(literal, (set, frozenset, list, tuple)):
+                return frozenset(str(s) for s in literal)
+    return frozenset()
+
+
+# ---------------------------------------------------------------------------
+# Entry probes
+# ---------------------------------------------------------------------------
+
+
+def _build_entry_probe(rule: EntryRule, idx: int, symbol: str) -> ProbeRun:
+    rule_id = f"entry[{idx}]"
+    bars, trigger_idx, reason = _synthesise_for_predicate(rule.when)
+    if bars is None:
+        return ProbeRun(
+            rule_id=rule_id,
+            rule_kind="entry",
+            symbol=symbol,
+            synthesizable=False,
+            unprobeable_reason=reason or "predicate_not_synthesizable",
+        )
+    return ProbeRun(
+        rule_id=rule_id,
+        rule_kind="entry",
+        symbol=symbol,
+        market_data=bars,
+        expected=ExpectedOutcome(kind="entry", side=rule.side),
+        trigger_bar_index=trigger_idx,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Exit probes — entry-prefix + exit-tail composition
+# ---------------------------------------------------------------------------
+
+
+def _build_exit_probe(
+    rule: Any,
+    idx: int,
+    symbol: str,
+    entry_rules: List[EntryRule],
+) -> ProbeRun:
+    kind = getattr(rule, "kind", None)
+    rule_id = f"exit[{idx}]:{kind}"
+    if not entry_rules:
+        return ProbeRun(
+            rule_id=rule_id,
+            rule_kind=kind or "signal_exit",
+            symbol=symbol,
+            synthesizable=False,
+            unprobeable_reason="no_entry_rules_to_open_position",
+        )
+    # Reuse entry[0]'s recipe to open the position, then append an exit
+    # tail. The opening trigger bar becomes our entry reference for the
+    # exit recipe.
+    entry_bars, entry_trigger_idx, entry_reason = _synthesise_for_predicate(entry_rules[0].when)
+    if entry_bars is None:
+        return ProbeRun(
+            rule_id=rule_id,
+            rule_kind=kind or "signal_exit",
+            symbol=symbol,
+            synthesizable=False,
+            unprobeable_reason=f"entry_prefix_not_synthesizable: {entry_reason}",
+        )
+    entry_close = entry_bars[entry_trigger_idx].close
+    entry_side = entry_rules[0].side
+
+    if isinstance(rule, StopLossRule):
+        tail, tail_trigger_offset = _synthesise_stop_loss_tail(rule, entry_close, entry_side)
+        if tail is None:
+            return ProbeRun(
+                rule_id=rule_id,
+                rule_kind="stop_loss",
+                symbol=symbol,
+                synthesizable=False,
+                unprobeable_reason="stop_loss_tail_not_synthesizable",
+            )
+        full_bars = _stitch(entry_bars, tail)
+        return ProbeRun(
+            rule_id=rule_id,
+            rule_kind="stop_loss",
+            symbol=symbol,
+            market_data=full_bars,
+            expected=ExpectedOutcome(kind="exit", exit_reason_contains="stop_loss"),
+            trigger_bar_index=len(entry_bars) + tail_trigger_offset,
+        )
+    if isinstance(rule, TakeProfitRule):
+        tail, tail_trigger_offset = _synthesise_take_profit_tail(rule, entry_close, entry_side)
+        if tail is None:
+            return ProbeRun(
+                rule_id=rule_id,
+                rule_kind="take_profit",
+                symbol=symbol,
+                synthesizable=False,
+                unprobeable_reason="take_profit_tail_not_synthesizable",
+            )
+        full_bars = _stitch(entry_bars, tail)
+        return ProbeRun(
+            rule_id=rule_id,
+            rule_kind="take_profit",
+            symbol=symbol,
+            market_data=full_bars,
+            expected=ExpectedOutcome(kind="exit", exit_reason_contains="take_profit"),
+            trigger_bar_index=len(entry_bars) + tail_trigger_offset,
+        )
+    if isinstance(rule, SignalExitRule):
+        tail_bars, tail_trigger_idx, tail_reason = _synthesise_for_predicate(
+            rule.when,
+            base_close=entry_close,
+            min_bars=20,
+        )
+        if tail_bars is None:
+            return ProbeRun(
+                rule_id=rule_id,
+                rule_kind="signal_exit",
+                symbol=symbol,
+                synthesizable=False,
+                unprobeable_reason=f"signal_exit_tail_not_synthesizable: {tail_reason}",
+            )
+        full_bars = _stitch(entry_bars, tail_bars)
+        return ProbeRun(
+            rule_id=rule_id,
+            rule_kind="signal_exit",
+            symbol=symbol,
+            market_data=full_bars,
+            # Signal exits in compiler-generated code emit
+            # ``reason="compiled_signal_exit"``; substring "signal_exit"
+            # catches both that and any future "engine_exit:signal_exit"
+            # prefix the engine might adopt later.
+            expected=ExpectedOutcome(kind="exit", exit_reason_contains="signal_exit"),
+            trigger_bar_index=len(entry_bars) + tail_trigger_idx,
+        )
+    return ProbeRun(
+        rule_id=rule_id,
+        rule_kind="signal_exit",
+        symbol=symbol,
+        synthesizable=False,
+        unprobeable_reason=f"unknown_exit_rule_type:{type(rule).__name__}",
+    )
+
+
+def _stitch(prefix: List[OHLCVBar], suffix: List[OHLCVBar]) -> List[OHLCVBar]:
+    """Concatenate two bar lists. Dates are re-stamped at the top level
+    by :func:`_stamp_dates` so this helper does not touch ``date``."""
+    return list(prefix) + list(suffix)
+
+
+# ---------------------------------------------------------------------------
+# Stop-loss / take-profit tails
+# ---------------------------------------------------------------------------
+
+
+def _synthesise_stop_loss_tail(
+    rule: StopLossRule, entry_close: float, entry_side: str
+) -> Tuple[Optional[List[OHLCVBar]], int]:
+    """Return a few quiet bars followed by one adversarial bar that pierces
+    the stop. ``basis="trailing_*"`` reuses the entry_price floor as a
+    conservative approximation — the rule still fires because price moves
+    far enough.
+    """
+    if rule.basis == "trailing_low" and entry_side == "long":
+        return None, 0  # Engine treats this as a no-op for longs.
+    if rule.basis == "trailing_high" and entry_side == "short":
+        return None, 0
+    epsilon = 0.005
+    if entry_side == "long":
+        # Long stop fires when bar.low <= entry_price * (1 - pct).
+        adversarial_close = entry_close * (1.0 - rule.pct - epsilon)
+        adversarial_low = adversarial_close - 0.01
+        adversarial_high = entry_close * (1.0 - rule.pct / 2.0)
+    else:
+        # Short stop fires when bar.high >= entry_price * (1 + pct).
+        adversarial_close = entry_close * (1.0 + rule.pct + epsilon)
+        adversarial_high = adversarial_close + 0.01
+        adversarial_low = entry_close * (1.0 + rule.pct / 2.0)
+    quiet_bars = [
+        OHLCVBar(
+            date="placeholder",
+            open=entry_close,
+            high=entry_close + 0.01,
+            low=entry_close - 0.01,
+            close=entry_close,
+            volume=1_000_000.0,
+        )
+        for _ in range(3)
+    ]
+    trigger_bar = OHLCVBar(
+        date="placeholder",
+        open=entry_close,
+        high=adversarial_high,
+        low=adversarial_low,
+        close=adversarial_close,
+        volume=1_000_000.0,
+    )
+    trail = [
+        OHLCVBar(
+            date="placeholder",
+            open=adversarial_close,
+            high=adversarial_close + 0.01,
+            low=adversarial_close - 0.01,
+            close=adversarial_close,
+            volume=1_000_000.0,
+        )
+        for _ in range(_BARS_AFTER_TRIGGER)
+    ]
+    return quiet_bars + [trigger_bar] + trail, len(quiet_bars)
+
+
+def _synthesise_take_profit_tail(
+    rule: TakeProfitRule, entry_close: float, entry_side: str
+) -> Tuple[Optional[List[OHLCVBar]], int]:
+    epsilon = 0.005
+    if entry_side == "long":
+        adversarial_close = entry_close * (1.0 + rule.pct + epsilon)
+        adversarial_high = adversarial_close + 0.01
+        adversarial_low = entry_close * (1.0 + rule.pct / 2.0)
+    else:
+        adversarial_close = entry_close * (1.0 - rule.pct - epsilon)
+        adversarial_low = adversarial_close - 0.01
+        adversarial_high = entry_close * (1.0 - rule.pct / 2.0)
+    quiet_bars = [
+        OHLCVBar(
+            date="placeholder",
+            open=entry_close,
+            high=entry_close + 0.01,
+            low=entry_close - 0.01,
+            close=entry_close,
+            volume=1_000_000.0,
+        )
+        for _ in range(3)
+    ]
+    trigger_bar = OHLCVBar(
+        date="placeholder",
+        open=entry_close,
+        high=adversarial_high,
+        low=adversarial_low,
+        close=adversarial_close,
+        volume=1_000_000.0,
+    )
+    trail = [
+        OHLCVBar(
+            date="placeholder",
+            open=adversarial_close,
+            high=adversarial_close + 0.01,
+            low=adversarial_close - 0.01,
+            close=adversarial_close,
+            volume=1_000_000.0,
+        )
+        for _ in range(_BARS_AFTER_TRIGGER)
+    ]
+    return quiet_bars + [trigger_bar] + trail, len(quiet_bars)
+
+
+# ---------------------------------------------------------------------------
+# Entry predicate dispatch
+# ---------------------------------------------------------------------------
+
+
+def _synthesise_for_predicate(
+    pred: Predicate,
+    *,
+    base_close: float = 100.0,
+    min_bars: int = _MIN_TOTAL_BARS,
+) -> Tuple[Optional[List[OHLCVBar]], int, Optional[str]]:
+    """Dispatch on the predicate's lhs/rhs/op shape.
+
+    Returns ``(bars, trigger_index, unprobeable_reason)``. ``bars=None``
+    signals "cannot synthesise"; ``unprobeable_reason`` is the diagnostic
+    the gate surfaces to the operator.
+    """
+    lhs, op, rhs = pred.lhs, pred.op, pred.rhs
+
+    # Cross ops route through the cross dispatcher regardless of side shapes —
+    # the (prev, curr)-pair semantics of cross-above/below differ from a
+    # plain inequality, so the recipe must be the cross-specific one.
+    if op in ("cross_above", "cross_below"):
+        return _synth_cross(lhs, op, rhs, base_close, min_bars)
+
+    # Trivial: PriceRef vs float / PriceRef.
+    if isinstance(lhs, str) and isinstance(rhs, (int, float)) and not isinstance(rhs, bool):
+        return _synth_priceref_vs_number(lhs, op, float(rhs), base_close, min_bars)
+    if isinstance(lhs, str) and isinstance(rhs, str):
+        return _synth_priceref_vs_priceref(lhs, op, rhs, base_close, min_bars)
+
+    # Indicator on the lhs against a number.
+    if isinstance(lhs, IndicatorRef) and isinstance(rhs, (int, float)) and not isinstance(rhs, bool):
+        return _synth_indicator_vs_number(lhs, op, float(rhs), base_close, min_bars)
+
+    # Indicator vs Indicator (e.g. SMA(10) > SMA(50)).
+    if isinstance(lhs, IndicatorRef) and isinstance(rhs, IndicatorRef):
+        return _synth_indicator_vs_indicator(lhs, op, rhs, base_close, min_bars)
+
+    # Indicator vs PriceRef (e.g. SMA(50) > bar.close).
+    if isinstance(lhs, IndicatorRef) and isinstance(rhs, str):
+        return _synth_indicator_vs_priceref(lhs, op, rhs, base_close, min_bars)
+
+    return None, 0, f"unsupported_predicate_shape:{type(lhs).__name__}_{op}_{type(rhs).__name__}"
+
+
+# ---------------------------------------------------------------------------
+# Recipe: PriceRef vs number
+# ---------------------------------------------------------------------------
+
+
+def _synth_priceref_vs_number(
+    lhs: str, op: str, rhs: float, base_close: float, min_bars: int
+) -> Tuple[Optional[List[OHLCVBar]], int, Optional[str]]:
+    """Generate bars where the bar's price field satisfies ``lhs op rhs``."""
+    n = max(min_bars, 30)
+    trigger_idx = n - _BARS_AFTER_TRIGGER - 1
+    bars: List[OHLCVBar] = []
+    field_name = lhs.split(".", 1)[1]  # "bar.close" -> "close"
+    # Baseline closes that don't satisfy the predicate.
+    baseline = rhs - 5.0 if op in (">", ">=") else rhs + 5.0
+    for i in range(n):
+        if i == trigger_idx:
+            # Move the relevant field across the threshold.
+            if op == ">":
+                value = rhs + 1.0
+            elif op == ">=":
+                value = rhs + 0.5
+            elif op == "<":
+                value = rhs - 1.0
+            elif op == "<=":
+                value = rhs - 0.5
+            elif op == "==":
+                value = rhs
+            else:
+                return None, 0, f"unsupported_priceref_op:{op}"
+            bars.append(_bar_with_field(field_name, value))
+        else:
+            bars.append(_bar_with_field(field_name, baseline))
+    if not _verify_priceref_vs_number(bars, field_name, op, rhs, trigger_idx):
+        return None, 0, "priceref_vs_number_verification_failed"
+    return bars, trigger_idx, None
+
+
+def _bar_with_field(field_name: str, value: float) -> OHLCVBar:
+    """Build a bar where ``field_name`` is set to ``value`` and the other
+    OHLC fields are consistent (high >= max(open, close), low <= min(...))."""
+    open_ = close = high = low = value
+    if field_name == "close":
+        open_ = value
+        high = value + 0.5
+        low = value - 0.5
+    elif field_name == "high":
+        close = value - 0.5
+        open_ = close
+        low = close - 0.5
+    elif field_name == "low":
+        close = value + 0.5
+        open_ = close
+        high = close + 0.5
+    elif field_name == "volume":
+        open_ = close = high = low = 100.0
+        return OHLCVBar(date="placeholder", open=100.0, high=100.5, low=99.5, close=100.0, volume=value)
+    return OHLCVBar(
+        date="placeholder",
+        open=open_,
+        high=max(high, open_, close),
+        low=min(low, open_, close),
+        close=close,
+        volume=1_000_000.0,
+    )
+
+
+def _verify_priceref_vs_number(
+    bars: List[OHLCVBar], field_name: str, op: str, rhs: float, idx: int
+) -> bool:
+    bar = bars[idx]
+    value = getattr(bar, field_name)
+    return _compare(value, op, rhs)
+
+
+# ---------------------------------------------------------------------------
+# Recipe: PriceRef vs PriceRef (e.g. bar.close > bar.open)
+# ---------------------------------------------------------------------------
+
+
+def _synth_priceref_vs_priceref(
+    lhs: str, op: str, rhs: str, base_close: float, min_bars: int
+) -> Tuple[Optional[List[OHLCVBar]], int, Optional[str]]:
+    if lhs == rhs:
+        return None, 0, "priceref_vs_self_unsatisfiable"
+    n = max(min_bars, 30)
+    trigger_idx = n - _BARS_AFTER_TRIGGER - 1
+    bars: List[OHLCVBar] = []
+    lhs_field = lhs.split(".", 1)[1]
+    rhs_field = rhs.split(".", 1)[1]
+    # Baseline bar where lhs == rhs (predicate inert).
+    for i in range(n):
+        if i == trigger_idx:
+            bars.append(_bar_with_priceref_relation(lhs_field, rhs_field, op))
+        else:
+            bars.append(
+                OHLCVBar(
+                    date="placeholder",
+                    open=base_close,
+                    high=base_close + 1.0,
+                    low=base_close - 1.0,
+                    close=base_close,
+                    volume=1_000_000.0,
+                )
+            )
+    return bars, trigger_idx, None
+
+
+def _bar_with_priceref_relation(lhs_field: str, rhs_field: str, op: str) -> OHLCVBar:
+    """Build a bar where the bar's ``lhs_field`` and ``rhs_field`` satisfy ``op``."""
+    # Default OHLC: open=100, low=99, high=101, close=100.5.
+    open_ = 100.0
+    low = 99.0
+    high = 101.0
+    close = 100.5
+    fields = {"open": open_, "low": low, "high": high, "close": close}
+    lhs_val = fields[lhs_field]
+    rhs_val = fields[rhs_field]
+    if _compare(lhs_val, op, rhs_val):
+        return OHLCVBar(
+            date="placeholder",
+            open=open_,
+            high=high,
+            low=low,
+            close=close,
+            volume=1_000_000.0,
+        )
+    # Adjust the lhs field to satisfy the predicate.
+    if op in (">", ">="):
+        target = rhs_val + 1.0
+    elif op in ("<", "<="):
+        target = rhs_val - 1.0
+    else:
+        target = rhs_val
+    fields[lhs_field] = target
+    new_high = max(fields["open"], fields["close"], fields["high"], target)
+    new_low = min(fields["open"], fields["close"], fields["low"], target)
+    return OHLCVBar(
+        date="placeholder",
+        open=fields["open"],
+        high=new_high,
+        low=new_low,
+        close=fields["close"],
+        volume=1_000_000.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Recipe: Indicator vs number
+# ---------------------------------------------------------------------------
+
+
+def _synth_indicator_vs_number(
+    ref: IndicatorRef, op: str, rhs: float, base_close: float, min_bars: int
+) -> Tuple[Optional[List[OHLCVBar]], int, Optional[str]]:
+    """Drive ``indicator(closes) op rhs`` at the trigger bar by shaping the closes.
+
+    Strategy per indicator:
+      - ``rsi``: geometric decline (op in <, <=) or incline (>, >=); binary-search the rate.
+      - ``sma`` / ``ema``: drive the moving average above/below ``rhs`` by setting closes accordingly.
+      - ``macd`` (output=macd): trending series; pre-flight verification picks the right slope.
+      - ``bollinger``: combination of high-vol then breakout; verification confirms.
+      - ``atr`` / ``adx`` / ``stochastic`` / ``vwap``: synth series, then verify; bail if the
+        requested threshold isn't reachable.
+    """
+    n = max(min_bars, _required_bars_for_indicator(ref))
+    trigger_idx = n - _BARS_AFTER_TRIGGER - 1
+    if ref.name in ("sma", "ema"):
+        # SMA/EMA flat-line at ``rhs`` ± delta hits the predicate trivially.
+        if op in (">", ">="):
+            level = rhs + 1.0
+        elif op in ("<", "<="):
+            level = rhs - 1.0
+        else:
+            level = rhs
+        bars = _flat_bars(level, n)
+    elif ref.name == "rsi":
+        bars = _rsi_search_bars(ref, op, rhs, n, base_close, trigger_idx)
+        if bars is None:
+            return None, 0, "rsi_threshold_unreachable"
+    elif ref.name == "macd":
+        bars = _macd_bars(ref, op, rhs, n, base_close, trigger_idx)
+        if bars is None:
+            return None, 0, "macd_threshold_unreachable"
+    elif ref.name == "bollinger":
+        bars = _bollinger_bars(ref, op, rhs, n, base_close, trigger_idx)
+        if bars is None:
+            return None, 0, "bollinger_threshold_unreachable"
+    elif ref.name in ("atr", "adx", "stochastic", "vwap"):
+        bars = _high_volatility_bars(n, base_close, trigger_idx)
+    else:
+        return None, 0, f"unsupported_indicator:{ref.name}"
+
+    if not _verify_indicator_vs_number(bars, ref, op, rhs, trigger_idx):
+        return None, 0, f"indicator_predicate_verification_failed:{ref.name}_{op}"
+    return bars, trigger_idx, None
+
+
+def _flat_bars(close: float, n: int) -> List[OHLCVBar]:
+    return [
+        OHLCVBar(
+            date="placeholder",
+            open=close,
+            high=close + 0.5,
+            low=close - 0.5,
+            close=close,
+            volume=1_000_000.0,
+        )
+        for _ in range(n)
+    ]
+
+
+def _rsi_search_bars(
+    ref: IndicatorRef, op: str, rhs: float, n: int, base_close: float, trigger_idx: int
+) -> Optional[List[OHLCVBar]]:
+    """Binary-search a per-step return so RSI at ``trigger_idx`` satisfies the predicate.
+
+    For ``rsi < t`` we want sustained losses (negative returns); for ``rsi > t`` sustained gains.
+    """
+    if op in ("<", "<="):
+        # Negative returns drive RSI down.
+        lo, hi = 0.001, 0.05
+        target_below = True
+    elif op in (">", ">="):
+        lo, hi = 0.001, 0.05
+        target_below = False
+    else:
+        return None
+
+    def closes_for(step: float) -> List[float]:
+        if target_below:
+            return [base_close * ((1.0 - step) ** i) for i in range(n)]
+        return [base_close * ((1.0 + step) ** i) for i in range(n)]
+
+    def rsi_at_trigger(step: float) -> float:
+        series = pd.Series(closes_for(step))
+        period = int(ref.param("period"))
+        value = rsi(series, period=period).iloc[trigger_idx]
+        if isinstance(value, float) and not math.isfinite(value):
+            return 100.0 if not target_below else 0.0
+        return float(value)
+
+    for _ in range(_DECAY_SEARCH_ITERS):
+        mid = (lo + hi) / 2.0
+        v = rsi_at_trigger(mid)
+        if _compare(v, op, rhs):
+            closes = closes_for(mid)
+            return [
+                OHLCVBar(
+                    date="placeholder",
+                    open=c,
+                    high=c + 0.01,
+                    low=c - 0.01,
+                    close=c,
+                    volume=1_000_000.0,
+                )
+                for c in closes
+            ]
+        if target_below:
+            lo = mid  # Need stronger decline.
+        else:
+            hi = mid  # Already above; try gentler step.
+    # Last-chance: use the steepest step and check anyway.
+    closes = closes_for(hi if target_below else lo)
+    series = pd.Series(closes)
+    if _compare(rsi(series, period=int(ref.param("period"))).iloc[trigger_idx], op, rhs):
+        return [
+            OHLCVBar(
+                date="placeholder",
+                open=c,
+                high=c + 0.01,
+                low=c - 0.01,
+                close=c,
+                volume=1_000_000.0,
+            )
+            for c in closes
+        ]
+    return None
+
+
+def _macd_bars(
+    ref: IndicatorRef, op: str, rhs: float, n: int, base_close: float, trigger_idx: int
+) -> Optional[List[OHLCVBar]]:
+    """A simple monotonically-trending series produces a non-zero MACD."""
+    slope = 0.5 if op in (">", ">=") else -0.5
+    closes = [base_close + slope * i for i in range(n)]
+    closes = [max(c, 1.0) for c in closes]  # Prevent zero/negative prices.
+    return [
+        OHLCVBar(
+            date="placeholder",
+            open=c,
+            high=c + 0.01,
+            low=c - 0.01,
+            close=c,
+            volume=1_000_000.0,
+        )
+        for c in closes
+    ]
+
+
+def _bollinger_bars(
+    ref: IndicatorRef, op: str, rhs: float, n: int, base_close: float, trigger_idx: int
+) -> Optional[List[OHLCVBar]]:
+    """Quiet history then a breakout bar — moves the requested band relative to ``rhs``."""
+    closes = [base_close] * (n - 5) + [base_close + 10.0 * i for i in range(1, 6)]
+    return [
+        OHLCVBar(
+            date="placeholder",
+            open=c,
+            high=c + 0.5,
+            low=c - 0.5,
+            close=c,
+            volume=1_000_000.0,
+        )
+        for c in closes
+    ]
+
+
+def _high_volatility_bars(n: int, base_close: float, trigger_idx: int) -> List[OHLCVBar]:
+    """Alternating up/down bars produce non-trivial ATR/ADX/Stochastic/VWAP values."""
+    bars: List[OHLCVBar] = []
+    for i in range(n):
+        sign = 1 if i % 2 == 0 else -1
+        close = base_close + sign * 3.0 + i * 0.1
+        bars.append(
+            OHLCVBar(
+                date="placeholder",
+                open=close,
+                high=close + 2.0,
+                low=close - 2.0,
+                close=close,
+                volume=1_000_000.0,
+            )
+        )
+    return bars
+
+
+def _verify_indicator_vs_number(
+    bars: List[OHLCVBar], ref: IndicatorRef, op: str, rhs: float, idx: int
+) -> bool:
+    value = _compute_indicator_at(ref, bars, idx)
+    if value is None or (isinstance(value, float) and not math.isfinite(value)):
+        return False
+    return _compare(value, op, rhs)
+
+
+def _compute_indicator_at(ref: IndicatorRef, bars: List[OHLCVBar], idx: int) -> Optional[float]:
+    """Compute ``ref`` over the synthetic bar series and return the value at ``idx``."""
+    df = _bars_to_df(bars)
+    series = _series_for_source(df, ref.source)
+    if ref.name == "sma":
+        v = sma(series, int(ref.param("period"))).iloc[idx]
+    elif ref.name == "ema":
+        v = ema(series, int(ref.param("period"))).iloc[idx]
+    elif ref.name == "rsi":
+        v = rsi(series, int(ref.param("period"))).iloc[idx]
+    elif ref.name == "macd":
+        line, signal_, hist = macd(
+            series,
+            int(ref.param("fast")),
+            int(ref.param("slow")),
+            int(ref.param("signal")),
+        )
+        output = ref.param("output")
+        v = {"macd": line, "signal": signal_, "histogram": hist}[output].iloc[idx]
+    elif ref.name == "bollinger":
+        upper, middle, lower = bollinger_bands(
+            series, int(ref.param("period")), float(ref.param("num_std"))
+        )
+        band = ref.param("band")
+        v = {"upper": upper, "middle": middle, "lower": lower}[band].iloc[idx]
+    elif ref.name == "atr":
+        v = atr(df["high"], df["low"], df["close"], int(ref.param("period"))).iloc[idx]
+    elif ref.name == "adx":
+        v = adx(df["high"], df["low"], df["close"], int(ref.param("period"))).iloc[idx]
+    elif ref.name == "stochastic":
+        k, d = stochastic(
+            df["high"], df["low"], df["close"], int(ref.param("k_period")), int(ref.param("d_period"))
+        )
+        output = ref.param("output")
+        v = {"k": k, "d": d}[output].iloc[idx]
+    elif ref.name == "vwap":
+        v = vwap(df["high"], df["low"], df["close"], df["volume"]).iloc[idx]
+    else:
+        return None
+    if isinstance(v, float) and not math.isfinite(v):
+        return None
+    return float(v)
+
+
+def _series_for_source(df: pd.DataFrame, source: str) -> pd.Series:
+    if source == "close":
+        return df["close"]
+    if source == "open":
+        return df["open"]
+    if source == "high":
+        return df["high"]
+    if source == "low":
+        return df["low"]
+    if source == "volume":
+        return df["volume"]
+    if source == "hl2":
+        return (df["high"] + df["low"]) / 2.0
+    if source == "ohlc4":
+        return (df["open"] + df["high"] + df["low"] + df["close"]) / 4.0
+    return df["close"]
+
+
+def _bars_to_df(bars: List[OHLCVBar]) -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "open": [b.open for b in bars],
+            "high": [b.high for b in bars],
+            "low": [b.low for b in bars],
+            "close": [b.close for b in bars],
+            "volume": [b.volume for b in bars],
+        }
+    )
+
+
+def _required_bars_for_indicator(ref: IndicatorRef) -> int:
+    if ref.name in ("sma", "ema", "rsi", "atr", "adx"):
+        period = int(ref.param("period")) if "period" in ref.params or ref.name in ("rsi", "atr", "adx") else 20
+        return max(_MIN_TOTAL_BARS, period + 30)
+    if ref.name == "macd":
+        slow = int(ref.param("slow"))
+        signal_ = int(ref.param("signal"))
+        return max(_MIN_TOTAL_BARS, slow + signal_ + 30)
+    if ref.name == "bollinger":
+        period = int(ref.param("period"))
+        return max(_MIN_TOTAL_BARS, period + 30)
+    if ref.name == "stochastic":
+        k = int(ref.param("k_period"))
+        d = int(ref.param("d_period"))
+        return max(_MIN_TOTAL_BARS, k + d + 30)
+    return _MIN_TOTAL_BARS
+
+
+# ---------------------------------------------------------------------------
+# Recipe: cross_above / cross_below
+# ---------------------------------------------------------------------------
+
+
+def _synth_cross(
+    lhs: Any, op: str, rhs: Any, base_close: float, min_bars: int
+) -> Tuple[Optional[List[OHLCVBar]], int, Optional[str]]:
+    """``cross_above(lhs, rhs)`` requires prev: lhs <= rhs, curr: lhs > rhs."""
+    # PriceRef cross IndicatorRef — the common case (close cross_above SMA(50)).
+    if isinstance(lhs, str) and isinstance(rhs, IndicatorRef):
+        return _synth_cross_priceref_indicator(lhs, op, rhs, base_close, min_bars)
+    # IndicatorRef cross IndicatorRef (e.g. fast SMA cross slow SMA).
+    if isinstance(lhs, IndicatorRef) and isinstance(rhs, IndicatorRef):
+        return _synth_cross_indicator_indicator(lhs, op, rhs, base_close, min_bars)
+    # IndicatorRef cross PriceRef (rare; symmetric to above).
+    if isinstance(lhs, IndicatorRef) and isinstance(rhs, str):
+        return _synth_cross_indicator_priceref(lhs, op, rhs, base_close, min_bars)
+    # IndicatorRef cross float.
+    if isinstance(lhs, IndicatorRef) and isinstance(rhs, (int, float)) and not isinstance(rhs, bool):
+        return _synth_cross_indicator_number(lhs, op, float(rhs), base_close, min_bars)
+    return None, 0, f"unsupported_cross_shape:{type(lhs).__name__}_{type(rhs).__name__}"
+
+
+def _synth_cross_priceref_indicator(
+    lhs: str, op: str, rhs: IndicatorRef, base_close: float, min_bars: int
+) -> Tuple[Optional[List[OHLCVBar]], int, Optional[str]]:
+    """Long flat history at ``base_close`` (so MA == base_close), then a single
+    bar with close above/below that level."""
+    if rhs.name not in ("sma", "ema"):
+        return None, 0, f"cross_against_unsupported_indicator:{rhs.name}"
+    if lhs != "bar.close":
+        return None, 0, f"cross_against_unsupported_priceref:{lhs}"
+    n = max(min_bars, int(rhs.param("period")) + 30)
+    trigger_idx = n - _BARS_AFTER_TRIGGER - 1
+    bars = _flat_bars(base_close, n)
+    delta = 5.0 if op == "cross_above" else -5.0
+    triggered_close = base_close + delta
+    bars[trigger_idx] = OHLCVBar(
+        date="placeholder",
+        open=base_close,
+        high=max(base_close, triggered_close) + 0.5,
+        low=min(base_close, triggered_close) - 0.5,
+        close=triggered_close,
+        volume=1_000_000.0,
+    )
+    # Verify the cross actually evaluates true with the (prev, curr) pair.
+    df = _bars_to_df(bars)
+    ma_series = (sma if rhs.name == "sma" else ema)(df["close"], int(rhs.param("period")))
+    prev_close = df["close"].iloc[trigger_idx - 1]
+    cur_close = df["close"].iloc[trigger_idx]
+    prev_ma = ma_series.iloc[trigger_idx - 1]
+    cur_ma = ma_series.iloc[trigger_idx]
+    if not _verify_cross(prev_close, cur_close, prev_ma, cur_ma, op):
+        return None, 0, "cross_priceref_indicator_verification_failed"
+    return bars, trigger_idx, None
+
+
+def _synth_cross_indicator_indicator(
+    lhs: IndicatorRef, op: str, rhs: IndicatorRef, base_close: float, min_bars: int
+) -> Tuple[Optional[List[OHLCVBar]], int, Optional[str]]:
+    """Two SMAs / EMAs cross when the underlying series changes regime."""
+    if lhs.name not in ("sma", "ema") or rhs.name not in ("sma", "ema"):
+        return None, 0, f"indicator_cross_unsupported:{lhs.name}_{rhs.name}"
+    lhs_period = int(lhs.param("period"))
+    rhs_period = int(rhs.param("period"))
+    longest = max(lhs_period, rhs_period)
+    n = max(min_bars, longest * 2 + 30)
+    # Regime 1: declining; regime 2: rising. Fast MA crosses slow MA at the
+    # regime change.
+    midpoint = n // 2
+    closes: List[float] = []
+    for i in range(n):
+        if i < midpoint:
+            closes.append(base_close * (0.98 ** (i)))
+        else:
+            closes.append(closes[-1] * 1.03)
+    closes = [max(c, 1.0) for c in closes]
+    bars = [
+        OHLCVBar(
+            date="placeholder",
+            open=c,
+            high=c + 0.5,
+            low=c - 0.5,
+            close=c,
+            volume=1_000_000.0,
+        )
+        for c in closes
+    ]
+    df = _bars_to_df(bars)
+    lhs_series = (sma if lhs.name == "sma" else ema)(df["close"], lhs_period)
+    rhs_series = (sma if rhs.name == "sma" else ema)(df["close"], rhs_period)
+    # Scan for a bar where the cross occurs.
+    for idx in range(longest + 1, n):
+        if _verify_cross(
+            lhs_series.iloc[idx - 1],
+            lhs_series.iloc[idx],
+            rhs_series.iloc[idx - 1],
+            rhs_series.iloc[idx],
+            op,
+        ):
+            return bars, idx, None
+    return None, 0, "indicator_indicator_cross_not_found_in_window"
+
+
+def _synth_cross_indicator_priceref(
+    lhs: IndicatorRef, op: str, rhs: str, base_close: float, min_bars: int
+) -> Tuple[Optional[List[OHLCVBar]], int, Optional[str]]:
+    # Symmetric to priceref-vs-indicator with sides swapped — flip the op.
+    flipped = "cross_above" if op == "cross_below" else "cross_below"
+    return _synth_cross_priceref_indicator(rhs, flipped, lhs, base_close, min_bars)
+
+
+def _synth_cross_indicator_number(
+    lhs: IndicatorRef, op: str, rhs: float, base_close: float, min_bars: int
+) -> Tuple[Optional[List[OHLCVBar]], int, Optional[str]]:
+    """Build a series where the indicator crosses the threshold ``rhs``.
+
+    Strategy: flat regime far below (or above) ``rhs`` long enough for the
+    indicator to settle, then a sustained burst at a wider distance so
+    the moving average pulls past ``rhs`` over several bars.
+    """
+    if lhs.name in ("sma", "ema"):
+        period = int(lhs.param("period"))
+        n = max(min_bars, period * 3 + 30)
+        # Quiet regime + spike regime; spike magnitude needs to be large
+        # enough that the moving average over the second half clears rhs.
+        if op == "cross_above":
+            below_level = rhs - 10.0
+            spike_level = rhs + max(20.0, rhs)
+            closes = [below_level] * (n // 2) + [spike_level] * (n - n // 2)
+        else:
+            above_level = rhs + 10.0
+            crash_level = max(_MIN_PRICE, rhs - max(20.0, rhs))
+            closes = [above_level] * (n // 2) + [crash_level] * (n - n // 2)
+        bars = [
+            OHLCVBar(
+                date="placeholder",
+                open=c,
+                high=c + 0.5,
+                low=c - 0.5,
+                close=c,
+                volume=1_000_000.0,
+            )
+            for c in closes
+        ]
+        df = _bars_to_df(bars)
+        ma_series = (sma if lhs.name == "sma" else ema)(df["close"], int(lhs.param("period")))
+        for idx in range(int(lhs.param("period")) + 1, n):
+            if _verify_cross(
+                ma_series.iloc[idx - 1], ma_series.iloc[idx], rhs, rhs, op
+            ):
+                return bars, idx, None
+        return None, 0, "indicator_number_cross_not_found"
+    return None, 0, f"cross_indicator_number_unsupported:{lhs.name}"
+
+
+def _verify_cross(prev_l: Any, cur_l: Any, prev_r: Any, cur_r: Any, op: str) -> bool:
+    """Mirror the (prev, curr)-pair semantics the compiled code uses."""
+    try:
+        prev_l_f = float(prev_l)
+        cur_l_f = float(cur_l)
+        prev_r_f = float(prev_r)
+        cur_r_f = float(cur_r)
+    except (TypeError, ValueError):
+        return False
+    if not all(math.isfinite(x) for x in (prev_l_f, cur_l_f, prev_r_f, cur_r_f)):
+        return False
+    if op == "cross_above":
+        return prev_l_f <= prev_r_f and cur_l_f > cur_r_f
+    if op == "cross_below":
+        return prev_l_f >= prev_r_f and cur_l_f < cur_r_f
+    return False
+
+
+# ---------------------------------------------------------------------------
+# Recipe: Indicator vs Indicator (non-cross)
+# ---------------------------------------------------------------------------
+
+
+def _synth_indicator_vs_indicator(
+    lhs: IndicatorRef, op: str, rhs: IndicatorRef, base_close: float, min_bars: int
+) -> Tuple[Optional[List[OHLCVBar]], int, Optional[str]]:
+    """For non-cross comparisons: build a series where both indicators are
+    computable and the inequality holds at the trigger bar."""
+    if {lhs.name, rhs.name} - {"sma", "ema"}:
+        return None, 0, f"indicator_vs_indicator_unsupported:{lhs.name}_{rhs.name}"
+    lhs_period = int(lhs.param("period"))
+    rhs_period = int(rhs.param("period"))
+    longest = max(lhs_period, rhs_period)
+    n = max(min_bars, longest + 30)
+    # Trending series produces lhs-fast > rhs-slow at the right edge.
+    closes = [base_close + i * 0.5 for i in range(n)]
+    if op in ("<", "<="):
+        closes = list(reversed(closes))
+    bars = [
+        OHLCVBar(
+            date="placeholder",
+            open=c,
+            high=c + 0.5,
+            low=c - 0.5,
+            close=c,
+            volume=1_000_000.0,
+        )
+        for c in closes
+    ]
+    df = _bars_to_df(bars)
+    lhs_series = (sma if lhs.name == "sma" else ema)(df["close"], lhs_period)
+    rhs_series = (sma if rhs.name == "sma" else ema)(df["close"], rhs_period)
+    for idx in range(longest, n):
+        lv = lhs_series.iloc[idx]
+        rv = rhs_series.iloc[idx]
+        if isinstance(lv, float) and not math.isfinite(lv):
+            continue
+        if isinstance(rv, float) and not math.isfinite(rv):
+            continue
+        if _compare(float(lv), op, float(rv)):
+            return bars, idx, None
+    return None, 0, "indicator_vs_indicator_no_satisfying_bar"
+
+
+def _synth_indicator_vs_priceref(
+    lhs: IndicatorRef, op: str, rhs: str, base_close: float, min_bars: int
+) -> Tuple[Optional[List[OHLCVBar]], int, Optional[str]]:
+    """Indicator-vs-PriceRef: drive the indicator value relative to the bar's price field."""
+    n = max(min_bars, _required_bars_for_indicator(lhs))
+    if lhs.name in ("sma", "ema"):
+        # Make the MA equal to ``rhs_field`` level minus/plus a delta.
+        ma_level = base_close
+        bars = _flat_bars(ma_level, n)
+        # Adjust the last bar's price field to satisfy the predicate.
+        rhs_field = rhs.split(".", 1)[1]
+        trigger_idx = n - _BARS_AFTER_TRIGGER - 1
+        target_field_value = ma_level - 2.0 if op in (">", ">=") else ma_level + 2.0
+        bar = bars[trigger_idx]
+        bars[trigger_idx] = OHLCVBar(
+            date="placeholder",
+            open=bar.open,
+            high=max(bar.high, target_field_value) if rhs_field == "high" else bar.high,
+            low=min(bar.low, target_field_value) if rhs_field == "low" else bar.low,
+            close=target_field_value if rhs_field == "close" else bar.close,
+            volume=target_field_value if rhs_field == "volume" else bar.volume,
+        )
+        # Verify.
+        df = _bars_to_df(bars)
+        ma_series = (sma if lhs.name == "sma" else ema)(df["close"], int(lhs.param("period")))
+        lv = ma_series.iloc[trigger_idx]
+        rv = getattr(bars[trigger_idx], rhs_field)
+        if isinstance(lv, float) and math.isfinite(lv) and _compare(float(lv), op, float(rv)):
+            return bars, trigger_idx, None
+    return None, 0, f"indicator_vs_priceref_unsupported:{lhs.name}_{rhs}"
+
+
+# ---------------------------------------------------------------------------
+# Comparison helper (mirrors the compiler's predicate eval semantics)
+# ---------------------------------------------------------------------------
+
+
+def _compare(lhs: float, op: str, rhs: float) -> bool:
+    if op == "<":
+        return lhs < rhs
+    if op == "<=":
+        return lhs <= rhs
+    if op == ">":
+        return lhs > rhs
+    if op == ">=":
+        return lhs >= rhs
+    if op == "==":
+        return math.isclose(lhs, rhs, rel_tol=1e-6, abs_tol=1e-6)
+    return False

--- a/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/synthesizer.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/synthesizer.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 import ast
 import math
 from dataclasses import dataclass, field
-from typing import Any, List, Literal, Optional, Tuple
+from typing import Any, Callable, List, Literal, Optional, Tuple
 
 import pandas as pd
 
@@ -92,6 +92,14 @@ class ProbeRun:
     index in ``market_data[symbol]`` of the bar where the predicate is
     expected to evaluate True (i.e. where a trade should appear at or
     after).
+
+    ``post_clamp_verifier`` (when set) is a closure over the recipe's
+    target predicate/condition that ``_stamp_dates`` invokes after
+    ``_normalise_ohlc`` runs. Recipes that synthesise values close to the
+    clamp floor (or that build OHLC arrangements OHLC normalisation may
+    reshape) attach a verifier so a probe whose final post-clamp bars no
+    longer satisfy the rule is marked unprobeable rather than emitted as
+    a false critical against otherwise-correct strategy code.
     """
 
     rule_id: str
@@ -102,6 +110,9 @@ class ProbeRun:
     trigger_bar_index: int = 0
     synthesizable: bool = True
     unprobeable_reason: Optional[str] = None
+    post_clamp_verifier: Optional[Callable[[List[OHLCVBar], int], bool]] = field(
+        default=None, repr=False, compare=False
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -139,8 +150,8 @@ def generate_rule_probe_runs(spec: Any, *, compiled_code: str = "") -> List[Prob
 
 
 def _stamp_dates(probe: ProbeRun, start_date: str = "2024-01-01") -> ProbeRun:
-    """Rebuild a probe's bars with ascending calendar dates and validate
-    OHLC integrity.
+    """Rebuild a probe's bars with ascending calendar dates, clamp OHLC,
+    and re-verify the recipe's predicate post-clamp.
 
     Recipe authors emit bars with placeholder ``date`` values for clarity —
     the actual dates are not meaningful, only their ordering. This pass
@@ -148,6 +159,13 @@ def _stamp_dates(probe: ProbeRun, start_date: str = "2024-01-01") -> ProbeRun:
     sandbox harness) get real, parseable date strings. It also clamps each
     bar's OHLC values so the downstream market-data preflight (which
     rejects nan_or_negative_prices and ohlc_violations) accepts the run.
+
+    Normalisation can reshape values (close clamped to the floor;
+    high/low re-derived to preserve invariants), which may invalidate a
+    predicate the recipe verified against the pre-clamp series. If the
+    probe attached a ``post_clamp_verifier``, this pass calls it and
+    marks the probe unprobeable when the predicate no longer holds —
+    surfacing as a warning rather than a false critical.
     """
     if not probe.synthesizable or not probe.market_data:
         return probe
@@ -165,6 +183,19 @@ def _stamp_dates(probe: ProbeRun, start_date: str = "2024-01-01") -> ProbeRun:
         )
         for i, b in enumerate(probe.market_data)
     ]
+    if probe.post_clamp_verifier is not None:
+        try:
+            verified = probe.post_clamp_verifier(new_bars, probe.trigger_bar_index)
+        except Exception:
+            verified = False
+        if not verified:
+            return ProbeRun(
+                rule_id=probe.rule_id,
+                rule_kind=probe.rule_kind,
+                symbol=probe.symbol,
+                synthesizable=False,
+                unprobeable_reason="post_clamp_predicate_violation",
+            )
     return ProbeRun(
         rule_id=probe.rule_id,
         rule_kind=probe.rule_kind,
@@ -174,6 +205,7 @@ def _stamp_dates(probe: ProbeRun, start_date: str = "2024-01-01") -> ProbeRun:
         trigger_bar_index=probe.trigger_bar_index,
         synthesizable=probe.synthesizable,
         unprobeable_reason=probe.unprobeable_reason,
+        post_clamp_verifier=probe.post_clamp_verifier,
     )
 
 
@@ -284,6 +316,73 @@ def _extract_universe_literal(code: str) -> frozenset:
 # ---------------------------------------------------------------------------
 
 
+def _predicate_verifier(
+    pred: Predicate,
+) -> Callable[[List[OHLCVBar], int], bool]:
+    """Return a closure that evaluates ``pred`` on a list of bars at index.
+
+    Used as ``ProbeRun.post_clamp_verifier``: after :func:`_stamp_dates`
+    normalises OHLC, we re-evaluate the predicate to catch cases where
+    clamping invalidates a recipe that verified pre-clamp. ``cross_*``
+    predicates evaluate over the (prev, curr) pair at ``index``;
+    everything else evaluates at ``index`` directly.
+
+    The closure returns ``False`` on any exception (malformed bars,
+    unsupported predicate shape) so a verifier bug surfaces as
+    "unprobeable" rather than a hard crash inside the synthesis loop.
+    """
+
+    def _verify(bars: List[OHLCVBar], idx: int) -> bool:
+        if not bars or idx < 0 or idx >= len(bars):
+            return False
+        try:
+            return _eval_predicate_at(pred, bars, idx)
+        except Exception:
+            return False
+
+    return _verify
+
+
+def _eval_predicate_at(pred: Predicate, bars: List[OHLCVBar], idx: int) -> bool:
+    """Evaluate ``pred`` on ``bars`` at ``idx`` — mirror of the compiler's
+    runtime predicate semantics, used only for post-clamp verification."""
+    lhs, op, rhs = pred.lhs, pred.op, pred.rhs
+    if op in ("cross_above", "cross_below"):
+        if idx == 0:
+            return False
+        prev_l = _resolve_side(lhs, bars, idx - 1)
+        cur_l = _resolve_side(lhs, bars, idx)
+        prev_r = _resolve_side(rhs, bars, idx - 1)
+        cur_r = _resolve_side(rhs, bars, idx)
+        return _verify_cross(prev_l, cur_l, prev_r, cur_r, op)
+    lhs_val = _resolve_side(lhs, bars, idx)
+    rhs_val = _resolve_side(rhs, bars, idx)
+    if lhs_val is None or rhs_val is None:
+        return False
+    if not math.isfinite(lhs_val) or not math.isfinite(rhs_val):
+        return False
+    return _compare(lhs_val, op, rhs_val)
+
+
+def _resolve_side(side: Any, bars: List[OHLCVBar], idx: int) -> Optional[float]:
+    """Resolve a Predicate side (PriceRef string, IndicatorRef, or number)
+    to a float value at the given bar index. Returns None on indicator
+    failure or unsupported side shape."""
+    if isinstance(side, str):
+        field_name = side.split(".", 1)[1] if side.startswith("bar.") else None
+        if field_name is None:
+            return None
+        return float(getattr(bars[idx], field_name))
+    if isinstance(side, IndicatorRef):
+        value = _compute_indicator_at(side, bars, idx)
+        return None if value is None else float(value)
+    if isinstance(side, bool):
+        return None
+    if isinstance(side, (int, float)):
+        return float(side)
+    return None
+
+
 def _build_entry_probe(rule: EntryRule, idx: int, symbol: str) -> ProbeRun:
     rule_id = f"entry[{idx}]"
     bars, trigger_idx, reason = _synthesise_for_predicate(rule.when)
@@ -302,6 +401,7 @@ def _build_entry_probe(rule: EntryRule, idx: int, symbol: str) -> ProbeRun:
         market_data=bars,
         expected=ExpectedOutcome(kind="entry", side=rule.side),
         trigger_bar_index=trigger_idx,
+        post_clamp_verifier=_predicate_verifier(rule.when),
     )
 
 
@@ -359,6 +459,7 @@ def _build_exit_probe(
             market_data=full_bars,
             expected=ExpectedOutcome(kind="exit", exit_reason_contains="stop_loss"),
             trigger_bar_index=len(entry_bars) + tail_trigger_offset,
+            post_clamp_verifier=_stop_loss_verifier(rule, entry_close, entry_side),
         )
     if isinstance(rule, TakeProfitRule):
         tail, tail_trigger_offset = _synthesise_take_profit_tail(rule, entry_close, entry_side)
@@ -378,6 +479,7 @@ def _build_exit_probe(
             market_data=full_bars,
             expected=ExpectedOutcome(kind="exit", exit_reason_contains="take_profit"),
             trigger_bar_index=len(entry_bars) + tail_trigger_offset,
+            post_clamp_verifier=_take_profit_verifier(rule, entry_close, entry_side),
         )
     if isinstance(rule, SignalExitRule):
         tail_bars, tail_trigger_idx, tail_reason = _synthesise_for_predicate(
@@ -405,6 +507,7 @@ def _build_exit_probe(
             # prefix the engine might adopt later.
             expected=ExpectedOutcome(kind="exit", exit_reason_contains="signal_exit"),
             trigger_bar_index=len(entry_bars) + tail_trigger_idx,
+            post_clamp_verifier=_predicate_verifier(rule.when),
         )
     return ProbeRun(
         rule_id=rule_id,
@@ -419,6 +522,48 @@ def _stitch(prefix: List[OHLCVBar], suffix: List[OHLCVBar]) -> List[OHLCVBar]:
     """Concatenate two bar lists. Dates are re-stamped at the top level
     by :func:`_stamp_dates` so this helper does not touch ``date``."""
     return list(prefix) + list(suffix)
+
+
+def _stop_loss_verifier(
+    rule: StopLossRule, entry_close: float, entry_side: str
+) -> Callable[[List[OHLCVBar], int], bool]:
+    """Closure that re-checks the engine's stop-loss trigger condition on
+    the post-clamp trigger bar. Used by :func:`_stamp_dates` so a probe
+    whose adversarial low/high was clipped by ``_normalise_ohlc`` doesn't
+    ship a non-triggering bar to the sandbox."""
+    pct = rule.pct
+
+    def _verify(bars: List[OHLCVBar], idx: int) -> bool:
+        if not bars or idx < 0 or idx >= len(bars):
+            return False
+        bar = bars[idx]
+        if entry_side == "long":
+            floor = entry_close * (1.0 - pct)
+            return bar.low <= floor
+        ceiling = entry_close * (1.0 + pct)
+        return bar.high >= ceiling
+
+    return _verify
+
+
+def _take_profit_verifier(
+    rule: TakeProfitRule, entry_close: float, entry_side: str
+) -> Callable[[List[OHLCVBar], int], bool]:
+    """Closure that re-checks the engine's take-profit trigger condition
+    on the post-clamp trigger bar."""
+    pct = rule.pct
+
+    def _verify(bars: List[OHLCVBar], idx: int) -> bool:
+        if not bars or idx < 0 or idx >= len(bars):
+            return False
+        bar = bars[idx]
+        if entry_side == "long":
+            target = entry_close * (1.0 + pct)
+            return bar.high >= target
+        target = entry_close * (1.0 - pct)
+        return bar.low <= target
+
+    return _verify
 
 
 # ---------------------------------------------------------------------------
@@ -699,6 +844,16 @@ def _synth_priceref_vs_priceref(
                     volume=1_000_000.0,
                 )
             )
+    # Some PriceRef relations are structurally unsatisfiable under OHLC
+    # invariants (e.g. ``bar.high < bar.low``); :func:`_bar_with_priceref_relation`
+    # tries to adjust the lhs field but ``_normalise_ohlc`` then restores
+    # the invariant, leaving the predicate false. Verify here so the recipe
+    # marks the probe unprobeable instead of shipping a non-triggering bar.
+    trigger_bar = _normalise_ohlc(bars[trigger_idx])
+    lhs_val = getattr(trigger_bar, lhs_field)
+    rhs_val = getattr(trigger_bar, rhs_field)
+    if not _compare(float(lhs_val), op, float(rhs_val)):
+        return None, 0, "priceref_vs_priceref_invariant_conflict"
     return bars, trigger_idx, None
 
 

--- a/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/synthesizer.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/synthesizer.py
@@ -275,8 +275,15 @@ def _resolve_probe_symbol(spec: Any, compiled_code: str) -> str:
 
 
 def _extract_universe_literal(code: str) -> frozenset:
-    """Parse ``UNIVERSE = frozenset({...})`` (or assignment to ``self.UNIVERSE``)
+    """Parse ``UNIVERSE = frozenset({...})`` (or assignment to ``self.UNIVERSE``,
+    or an annotated assignment ``UNIVERSE: frozenset[str] = frozenset({...})``)
     from compiled-strategy source. Returns an empty frozenset on any failure.
+
+    Plain ``Assign`` and annotated ``AnnAssign`` are both accepted because
+    the deterministic compiler emits the bare form but hand-written or
+    LLM-authored strategies often use the typed form, and a mismatched
+    fallback to the ``"PROBE"`` sentinel would hit the strategy's
+    universe-guard at the top of ``on_bar`` and produce a false critical.
     """
     if not code:
         return frozenset()
@@ -285,11 +292,22 @@ def _extract_universe_literal(code: str) -> frozenset:
     except SyntaxError:
         return frozenset()
     for node in ast.walk(tree):
-        if not isinstance(node, ast.Assign):
+        target = None
+        value = None
+        if isinstance(node, ast.Assign):
+            if len(node.targets) != 1:
+                continue
+            target = node.targets[0]
+            value = node.value
+        elif isinstance(node, ast.AnnAssign):
+            # Bare annotations like ``UNIVERSE: frozenset[str]`` (no
+            # ``value``) carry no literal to parse — skip.
+            if node.value is None:
+                continue
+            target = node.target
+            value = node.value
+        else:
             continue
-        if len(node.targets) != 1:
-            continue
-        target = node.targets[0]
         target_name = None
         if isinstance(target, ast.Name):
             target_name = target.id
@@ -297,7 +315,6 @@ def _extract_universe_literal(code: str) -> frozenset:
             target_name = target.attr
         if target_name != "UNIVERSE":
             continue
-        value = node.value
         if isinstance(value, ast.Call) and isinstance(value.func, ast.Name) and value.func.id == "frozenset":
             if not value.args:
                 return frozenset()

--- a/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/synthesizer.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/synthesizer.py
@@ -443,21 +443,62 @@ def _build_exit_probe(
             synthesizable=False,
             unprobeable_reason="no_entry_rules_to_open_position",
         )
-    # Reuse entry[0]'s recipe to open the position, then append an exit
-    # tail. The opening trigger bar becomes our entry reference for the
-    # exit recipe.
-    entry_bars, entry_trigger_idx, entry_reason = _synthesise_for_predicate(entry_rules[0].when)
-    if entry_bars is None:
-        return ProbeRun(
-            rule_id=rule_id,
-            rule_kind=kind or "signal_exit",
-            symbol=symbol,
-            synthesizable=False,
-            unprobeable_reason=f"entry_prefix_not_synthesizable: {entry_reason}",
+    # Walk every entry rule and pick the first whose entry-prefix synthesises
+    # *and* whose side is compatible with the exit rule under test. Hard-coding
+    # ``entry_rules[0]`` would downgrade exit probes to unprobeable whenever
+    # the first rule's predicate isn't synthesisable, or use the wrong side
+    # (e.g. a long ``entry_rules[0]`` paired with a ``StopLossRule(basis=
+    # "trailing_low")`` that the engine treats as a no-op for longs) — both
+    # cases would hide real exit-rule regressions.
+    last_failure = "no_compatible_entry_rule"
+    for entry_rule in entry_rules:
+        entry_bars, entry_trigger_idx, entry_reason = _synthesise_for_predicate(
+            entry_rule.when
         )
-    entry_close = entry_bars[entry_trigger_idx].close
-    entry_side = entry_rules[0].side
+        if entry_bars is None:
+            last_failure = f"entry_prefix_not_synthesizable: {entry_reason}"
+            continue
+        entry_close = entry_bars[entry_trigger_idx].close
+        entry_side = entry_rule.side
+        probe = _build_exit_probe_with_prefix(
+            rule=rule,
+            rule_id=rule_id,
+            kind=kind,
+            symbol=symbol,
+            entry_bars=entry_bars,
+            entry_close=entry_close,
+            entry_side=entry_side,
+        )
+        if probe.synthesizable:
+            return probe
+        last_failure = probe.unprobeable_reason or last_failure
+    return ProbeRun(
+        rule_id=rule_id,
+        rule_kind=kind or "signal_exit",
+        symbol=symbol,
+        synthesizable=False,
+        unprobeable_reason=last_failure,
+    )
 
+
+def _build_exit_probe_with_prefix(
+    *,
+    rule: Any,
+    rule_id: str,
+    kind: Optional[str],
+    symbol: str,
+    entry_bars: List[OHLCVBar],
+    entry_close: float,
+    entry_side: str,
+) -> ProbeRun:
+    """Build the exit probe given a successfully-synthesised entry prefix.
+
+    Returns ``synthesizable=False`` with a descriptive reason when the
+    chosen ``(rule, entry_side)`` pair has no valid tail (e.g. a
+    ``trailing_low`` stop on a long entry — the engine's no-op case).
+    Callers iterate across entry rules and pick the first probe that
+    comes back ``synthesizable=True``.
+    """
     if isinstance(rule, StopLossRule):
         tail, tail_trigger_offset = _synthesise_stop_loss_tail(rule, entry_close, entry_side)
         if tail is None:
@@ -466,7 +507,7 @@ def _build_exit_probe(
                 rule_kind="stop_loss",
                 symbol=symbol,
                 synthesizable=False,
-                unprobeable_reason="stop_loss_tail_not_synthesizable",
+                unprobeable_reason=f"stop_loss_tail_not_synthesizable_for_side={entry_side}",
             )
         full_bars = _stitch(entry_bars, tail)
         return ProbeRun(
@@ -486,7 +527,7 @@ def _build_exit_probe(
                 rule_kind="take_profit",
                 symbol=symbol,
                 synthesizable=False,
-                unprobeable_reason="take_profit_tail_not_synthesizable",
+                unprobeable_reason=f"take_profit_tail_not_synthesizable_for_side={entry_side}",
             )
         full_bars = _stitch(entry_bars, tail)
         return ProbeRun(
@@ -1498,5 +1539,10 @@ def _compare(lhs: float, op: str, rhs: float) -> bool:
     if op == ">=":
         return lhs >= rhs
     if op == "==":
-        return math.isclose(lhs, rhs, rel_tol=1e-6, abs_tol=1e-6)
+        # Exact equality mirrors the compiler's raw ``lhs == rhs`` emission
+        # (see ``strategy_lab/synthesis/compiler.py``). Using ``math.isclose``
+        # here would make the probe accept near-equal floats that the
+        # compiled strategy wouldn't — a recipe-vs-runtime mismatch that
+        # surfaces as a false critical for any ``op == "=="`` predicate.
+        return lhs == rhs
     return False

--- a/backend/agents/investment_team/tests/conftest.py
+++ b/backend/agents/investment_team/tests/conftest.py
@@ -209,6 +209,15 @@ def stub_design_loop(
     # code_synthesis_agent. Stub that too so the test does not depend
     # on the real LLM path.
     monkeypatch.setattr(orch.code_synthesis_agent, "run", code_synthesis_returning(code))
+    # The rule-probes gate runs after CodeConformanceGate in the synthesis
+    # loop. It executes the compiled strategy against synthetic bars and
+    # asserts each rule fires. Pre-existing integration tests that script
+    # a fake strategy code (rather than a compiler-produced one) don't
+    # carry the order-side semantics or exit-reason strings the probe
+    # gate expects, so stub it here to keep the gate's behaviour out of
+    # the synthesis-loop pipeline tests. Tests that explicitly exercise
+    # the probe gate construct their own ``RuleProbesGate`` instance.
+    monkeypatch.setattr(orch.rule_probes_gate, "check", lambda *a, **kw: [])
 
 
 def empty_market_data(

--- a/backend/agents/investment_team/tests/test_rule_probes_extended.py
+++ b/backend/agents/investment_team/tests/test_rule_probes_extended.py
@@ -885,6 +885,80 @@ def test_priceref_vs_priceref_eq_falls_through_to_else_branch():
     assert bar.close == bar.high
 
 
+def test_volume_priceref_comparison_marks_unprobeable_without_crashing():
+    """``bar.volume`` is a valid PriceRef in the DSL but doesn't fit the
+    OHLC default-fields model. The synthesiser must mark the probe
+    unprobeable instead of raising a KeyError."""
+    pred = Predicate(lhs="bar.volume", op=">", rhs="bar.close")
+    bars, _trigger, reason = _synthesise_for_predicate(pred)
+    assert bars is None
+    assert reason == "priceref_volume_comparison_unprobeable"
+
+
+def test_volume_priceref_on_either_side_marks_unprobeable():
+    pred = Predicate(lhs="bar.close", op=">", rhs="bar.volume")
+    bars, _trigger, reason = _synthesise_for_predicate(pred)
+    assert bars is None
+    assert reason == "priceref_volume_comparison_unprobeable"
+
+
+def test_volume_priceref_in_spec_does_not_abort_synthesis_loop():
+    """End-to-end: a spec with a volume-PriceRef rule generates a probe
+    run with synthesizable=False rather than crashing the synthesis loop."""
+    entry = EntryRule(
+        side="long",
+        when=Predicate(lhs="bar.volume", op=">", rhs="bar.close"),
+    )
+    spec = _spec_with(entry_rules=[entry])
+    [probe] = generate_rule_probe_runs(spec)
+    assert probe.synthesizable is False
+    assert "volume" in (probe.unprobeable_reason or "")
+
+
+def test_assess_probe_exit_rejects_trade_closed_before_trigger():
+    """An exit-substring match alone isn't evidence the targeted rule fired —
+    a strategy that always exits at bar 2 for unrelated reasons can collide
+    with the substring. Reject trades whose exit_date precedes the
+    synthesised trigger bar."""
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        ExpectedOutcome,
+    )
+
+    probe = ProbeRun(
+        rule_id="exit[0]:stop_loss",
+        rule_kind="stop_loss",
+        symbol="PROBE",
+        market_data=[
+            OHLCVBar(date="2024-06-01", open=1, high=1.1, low=0.9, close=1, volume=1)
+        ],
+        expected=ExpectedOutcome(kind="exit", exit_reason_contains="stop_loss"),
+        trigger_bar_index=0,
+    )
+    early_trade = TradeRecord(
+        trade_num=1,
+        entry_date="2024-01-01",
+        exit_date="2024-01-02",  # before trigger
+        symbol="PROBE",
+        side="long",
+        entry_price=100.0,
+        exit_price=90.0,
+        shares=1.0,
+        position_value=100.0,
+        gross_pnl=-10.0,
+        net_pnl=-10.0,
+        return_pct=-0.10,
+        hold_days=1,
+        outcome="loss",
+        cumulative_pnl=-10.0,
+        exit_reason="engine_exit:stop_loss",
+    )
+    g = RuleProbesGate(runner=lambda *a, **k: _Stub())
+    with g._using_phase("synthesis"):
+        result = assess_probe(probe, _Stub(success=True, trades=[early_trade]), emitter=g)
+    assert result.passed is False
+    assert "before trigger bar" in result.details
+
+
 def test_priceref_below_clamp_floor_marks_unprobeable():
     """``bar.close < 0.005`` would synthesise a trigger value below
     ``_MIN_PRICE``; the recipe must refuse rather than ship a probe whose

--- a/backend/agents/investment_team/tests/test_rule_probes_extended.py
+++ b/backend/agents/investment_team/tests/test_rule_probes_extended.py
@@ -1,0 +1,928 @@
+"""Extended coverage for :mod:`rule_probes` — every indicator recipe,
+unprobeable-shape branch, and edge case the basic suite doesn't reach.
+
+These tests verify recipes produce series satisfying their predicate (or
+mark the probe unprobeable when they can't). Most cases also exercise
+the corresponding code paths in the asserter when invoked end-to-end
+through :class:`RuleProbesGate` with a stubbed runner.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from investment_team.market_data_service import OHLCVBar
+from investment_team.models import StrategySpec, TradeRecord
+from investment_team.strategy_lab.executor.indicators import (
+    rsi,
+    sma,
+)
+from investment_team.strategy_lab.quality_gates.rule_probes import (
+    RuleProbesGate,
+    generate_rule_probe_runs,
+)
+from investment_team.strategy_lab.quality_gates.rule_probes.asserter import (
+    _summarise_trades,
+    assess_probe,
+)
+from investment_team.strategy_lab.quality_gates.rule_probes.gate import _SkippedResult
+from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+    ProbeRun,
+    _bars_to_df,
+    _compute_indicator_at,
+    _extract_universe_literal,
+    _normalise_ohlc,
+    _resolve_probe_symbol,
+    _series_for_source,
+    _synthesise_for_predicate,
+)
+from investment_team.strategy_lab.spec_dsl import (
+    EntryRule,
+    IndicatorRef,
+    Predicate,
+    StopLossRule,
+    TakeProfitRule,
+)
+
+# ===========================================================================
+# Indicator-vs-number recipes — one test per remaining indicator family
+# ===========================================================================
+
+
+def test_ema_lt_threshold_recipe():
+    ref = IndicatorRef(name="ema", params={"period": 10})
+    pred = Predicate(lhs=ref, op="<", rhs=50.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    value = _compute_indicator_at(ref, bars, trigger)
+    assert value is not None and value < 50.0
+
+
+def test_macd_gt_zero_recipe_uses_trending_series():
+    ref = IndicatorRef(name="macd")
+    pred = Predicate(lhs=ref, op=">", rhs=0.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    value = _compute_indicator_at(ref, bars, trigger)
+    assert value is not None and value > 0.0
+
+
+def test_bollinger_upper_gt_threshold_recipe():
+    ref = IndicatorRef(name="bollinger", params={"band": "upper", "period": 20, "num_std": 2.0})
+    pred = Predicate(lhs=ref, op=">", rhs=100.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    # Bollinger recipe may not always reach an arbitrary upper threshold,
+    # but it should either succeed or be marked unprobeable cleanly.
+    assert (bars is not None) != (reason is not None)
+
+
+def test_atr_gt_threshold_high_volatility_recipe():
+    ref = IndicatorRef(name="atr", params={"period": 14})
+    pred = Predicate(lhs=ref, op=">", rhs=1.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    value = _compute_indicator_at(ref, bars, trigger)
+    assert value is not None and value > 1.0
+
+
+def test_stochastic_recipe_yields_finite_value():
+    ref = IndicatorRef(name="stochastic", params={"k_period": 14, "d_period": 3, "output": "k"})
+    pred = Predicate(lhs=ref, op=">", rhs=0.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    value = _compute_indicator_at(ref, bars, trigger)
+    assert value is not None
+
+
+def test_vwap_recipe_yields_positive_value():
+    ref = IndicatorRef(name="vwap")
+    pred = Predicate(lhs=ref, op=">", rhs=0.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    value = _compute_indicator_at(ref, bars, trigger)
+    assert value is not None and value > 0.0
+
+
+def test_adx_recipe_yields_finite_value():
+    ref = IndicatorRef(name="adx", params={"period": 14})
+    pred = Predicate(lhs=ref, op=">", rhs=0.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    value = _compute_indicator_at(ref, bars, trigger)
+    assert value is not None
+
+
+# ===========================================================================
+# Recipes that should mark themselves unprobeable
+# ===========================================================================
+
+
+def test_rsi_lt_zero_is_unreachable_or_unprobeable():
+    """RSI is bounded in [0, 100]; ``< 0`` is impossible. The recipe must
+    surface that as an unprobeable predicate rather than producing garbage."""
+    ref = IndicatorRef(name="rsi", params={"period": 14})
+    pred = Predicate(lhs=ref, op="<", rhs=-5.0)
+    bars, _trigger, reason = _synthesise_for_predicate(pred)
+    assert bars is None and reason is not None
+
+
+def test_unsupported_indicator_vs_indicator_marks_unprobeable():
+    """``rsi vs sma`` is supported only through specific helpers; mixed
+    indicators without a supporting recipe must return unprobeable."""
+    lhs = IndicatorRef(name="rsi", params={"period": 14})
+    rhs = IndicatorRef(name="sma", params={"period": 20})
+    pred = Predicate(lhs=lhs, op=">", rhs=rhs)
+    bars, _trigger, reason = _synthesise_for_predicate(pred)
+    assert bars is None and reason is not None
+    assert "indicator_vs_indicator_unsupported" in reason
+
+
+def test_priceref_vs_self_marks_unsatisfiable():
+    pred = Predicate(lhs="bar.close", op=">", rhs="bar.close")
+    bars, _trigger, reason = _synthesise_for_predicate(pred)
+    assert bars is None and "priceref_vs_self_unsatisfiable" in (reason or "")
+
+
+# ===========================================================================
+# Cross-recipe variants
+# ===========================================================================
+
+
+def test_indicator_cross_above_priceref_uses_close_flip():
+    """``SMA cross_above bar.close`` is supported via the symmetric flip."""
+    lhs = IndicatorRef(name="sma", params={"period": 20})
+    pred = Predicate(lhs=lhs, op="cross_above", rhs="bar.close")
+    bars, _trigger, reason = _synthesise_for_predicate(pred)
+    # The flip dispatches to the priceref-vs-indicator recipe. Either it
+    # succeeds or marks an explicit unprobeable reason.
+    assert (bars is not None) or reason is not None
+
+
+def test_indicator_cross_above_number_recipe():
+    ref = IndicatorRef(name="sma", params={"period": 20})
+    pred = Predicate(lhs=ref, op="cross_above", rhs=100.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    assert trigger > 0
+
+
+def test_indicator_cross_below_number_recipe():
+    ref = IndicatorRef(name="sma", params={"period": 20})
+    pred = Predicate(lhs=ref, op="cross_below", rhs=100.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+
+
+def test_cross_with_unsupported_indicator_pair_marks_unprobeable():
+    lhs = IndicatorRef(name="rsi", params={"period": 14})
+    rhs = IndicatorRef(name="rsi", params={"period": 21})
+    pred = Predicate(lhs=lhs, op="cross_above", rhs=rhs)
+    bars, _trigger, reason = _synthesise_for_predicate(pred)
+    assert bars is None and reason is not None
+
+
+# ===========================================================================
+# UNIVERSE literal extraction edge cases
+# ===========================================================================
+
+
+def test_extract_universe_literal_from_self_universe_assignment():
+    code = "class S:\n    def __init__(self):\n        self.UNIVERSE = frozenset({'AAA'})\n"
+    parsed = _extract_universe_literal(code)
+    assert "AAA" in parsed
+
+
+def test_extract_universe_literal_empty_frozenset():
+    code = "UNIVERSE = frozenset()\n"
+    parsed = _extract_universe_literal(code)
+    assert parsed == frozenset()
+
+
+def test_extract_universe_literal_returns_empty_on_syntax_error():
+    parsed = _extract_universe_literal("def broken(:\n")
+    assert parsed == frozenset()
+
+
+def test_extract_universe_literal_returns_empty_on_non_call_assignment():
+    code = "UNIVERSE = {'foo'}\n"
+    parsed = _extract_universe_literal(code)
+    assert parsed == frozenset()
+
+
+def test_extract_universe_literal_returns_empty_when_no_assignment():
+    code = "x = 1\n"
+    parsed = _extract_universe_literal(code)
+    assert parsed == frozenset()
+
+
+def test_resolve_probe_symbol_prefers_target_symbols_over_universe():
+    class _S:
+        target_symbols = ["AAPL"]
+
+    code = "UNIVERSE = frozenset({'TEST'})\n"
+    assert _resolve_probe_symbol(_S(), code) == "AAPL"
+
+
+# ===========================================================================
+# Stop-loss / take-profit variant coverage
+# ===========================================================================
+
+
+def test_stop_loss_short_position_targets_ceiling():
+    entry = EntryRule(
+        side="short",
+        when=Predicate(lhs="bar.close", op="<", rhs=200.0),
+    )
+    stop = StopLossRule(pct=0.05)
+    [_e, exit_probe] = generate_rule_probe_runs(
+        _spec_with(entry_rules=[entry], exit_rules=[stop])
+    )
+    assert exit_probe.synthesizable
+    # For shorts the recipe sets a high above entry_close * (1 + pct).
+    trigger_bar = exit_probe.market_data[exit_probe.trigger_bar_index]
+    assert trigger_bar.high > trigger_bar.low
+
+
+def test_take_profit_short_position_targets_floor():
+    entry = EntryRule(
+        side="short",
+        when=Predicate(lhs="bar.close", op="<", rhs=200.0),
+    )
+    tp = TakeProfitRule(pct=0.05)
+    [_e, exit_probe] = generate_rule_probe_runs(
+        _spec_with(entry_rules=[entry], exit_rules=[tp])
+    )
+    assert exit_probe.synthesizable
+    trigger_bar = exit_probe.market_data[exit_probe.trigger_bar_index]
+    assert trigger_bar.low < trigger_bar.high
+
+
+def test_stop_loss_trailing_low_on_long_is_unprobeable():
+    """``trailing_low`` basis applies to shorts; longs are unprobeable
+    because the engine treats this combo as a no-op."""
+    entry = EntryRule(
+        side="long",
+        when=Predicate(lhs="bar.close", op=">", rhs=50.0),
+    )
+    stop = StopLossRule(pct=0.05, basis="trailing_low")
+    [_e, exit_probe] = generate_rule_probe_runs(
+        _spec_with(entry_rules=[entry], exit_rules=[stop])
+    )
+    assert not exit_probe.synthesizable
+
+
+def test_stop_loss_trailing_high_on_short_is_unprobeable():
+    entry = EntryRule(
+        side="short",
+        when=Predicate(lhs="bar.close", op="<", rhs=200.0),
+    )
+    stop = StopLossRule(pct=0.05, basis="trailing_high")
+    [_e, exit_probe] = generate_rule_probe_runs(
+        _spec_with(entry_rules=[entry], exit_rules=[stop])
+    )
+    assert not exit_probe.synthesizable
+
+
+# ===========================================================================
+# OHLC normalisation
+# ===========================================================================
+
+
+def test_normalise_ohlc_clamps_negative_values():
+    bar = OHLCVBar(date="d", open=-1.0, high=5.0, low=-3.0, close=2.0, volume=100.0)
+    out = _normalise_ohlc(bar)
+    assert out.open > 0 and out.low > 0
+    assert out.high >= max(out.open, out.close, out.low)
+    assert out.low <= min(out.open, out.close, out.high)
+
+
+def test_normalise_ohlc_replaces_nan_volume_with_one():
+    bar = OHLCVBar(date="d", open=10.0, high=11.0, low=9.0, close=10.5, volume=float("nan"))
+    out = _normalise_ohlc(bar)
+    assert out.volume == 1.0
+
+
+def test_normalise_ohlc_preserves_clean_bars():
+    bar = OHLCVBar(date="d", open=10.0, high=11.0, low=9.0, close=10.5, volume=100.0)
+    out = _normalise_ohlc(bar)
+    assert (out.open, out.high, out.low, out.close, out.volume) == (10.0, 11.0, 9.0, 10.5, 100.0)
+
+
+# ===========================================================================
+# Source-series helper
+# ===========================================================================
+
+
+def test_series_for_source_hl2_and_ohlc4_are_averages():
+    import pandas as pd
+
+    df = pd.DataFrame(
+        {"open": [10.0], "high": [12.0], "low": [8.0], "close": [11.0], "volume": [100.0]}
+    )
+    hl2 = _series_for_source(df, "hl2").iloc[0]
+    ohlc4 = _series_for_source(df, "ohlc4").iloc[0]
+    assert hl2 == 10.0  # (12+8)/2
+    assert ohlc4 == 10.25  # (10+12+8+11)/4
+
+
+def test_series_for_source_falls_back_to_close_on_unknown():
+    import pandas as pd
+
+    df = pd.DataFrame({"open": [1.0], "high": [2.0], "low": [0.5], "close": [1.5], "volume": [1.0]})
+    fallback = _series_for_source(df, "unknown_source_xyz").iloc[0]
+    assert fallback == 1.5
+
+
+def test_series_for_source_volume_returns_volume_column():
+    import pandas as pd
+
+    df = pd.DataFrame({"open": [1.0], "high": [2.0], "low": [0.5], "close": [1.5], "volume": [7.0]})
+    assert _series_for_source(df, "volume").iloc[0] == 7.0
+
+
+# ===========================================================================
+# Asserter edge paths
+# ===========================================================================
+
+
+@dataclass
+class _Stub:
+    success: bool = True
+    trades: List[TradeRecord] = field(default_factory=list)
+    error_type: Optional[str] = None
+    stderr: str = ""
+
+
+def test_assess_probe_unprobeable_emits_warning():
+    probe = ProbeRun(
+        rule_id="entry[0]",
+        rule_kind="entry",
+        symbol="PROBE",
+        synthesizable=False,
+        unprobeable_reason="some_reason",
+    )
+    g = RuleProbesGate(runner=lambda *a, **k: _Stub())
+    with g._using_phase("synthesis"):
+        result = assess_probe(probe, _Stub(), emitter=g)
+    assert result.severity == "warning"
+    assert "some_reason" in result.details
+
+
+def test_assess_probe_with_no_expected_is_critical():
+    probe = ProbeRun(
+        rule_id="entry[0]",
+        rule_kind="entry",
+        symbol="PROBE",
+        market_data=[
+            OHLCVBar(date="2024-01-01", open=1, high=1.1, low=0.9, close=1, volume=1)
+        ],
+        expected=None,
+    )
+    g = RuleProbesGate(runner=lambda *a, **k: _Stub())
+    with g._using_phase("synthesis"):
+        result = assess_probe(probe, _Stub(success=True), emitter=g)
+    assert result.severity == "critical"
+    assert "no expected outcome" in result.details
+
+
+def test_assess_probe_exit_without_exit_reason_substring_is_critical():
+    """Exit probe whose ``expected.exit_reason_contains`` is None."""
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        ExpectedOutcome,
+    )
+
+    probe = ProbeRun(
+        rule_id="exit[0]:stop_loss",
+        rule_kind="stop_loss",
+        symbol="PROBE",
+        market_data=[
+            OHLCVBar(date="2024-01-01", open=1, high=1.1, low=0.9, close=1, volume=1)
+        ],
+        expected=ExpectedOutcome(kind="exit", exit_reason_contains=None),
+    )
+    g = RuleProbesGate(runner=lambda *a, **k: _Stub())
+    with g._using_phase("synthesis"):
+        result = assess_probe(probe, _Stub(), emitter=g)
+    assert result.severity == "critical"
+    assert "missing exit_reason_contains" in result.details
+
+
+def test_assess_probe_exit_with_no_trades_is_critical():
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        ExpectedOutcome,
+    )
+
+    probe = ProbeRun(
+        rule_id="exit[0]:stop_loss",
+        rule_kind="stop_loss",
+        symbol="PROBE",
+        market_data=[
+            OHLCVBar(date="2024-01-01", open=1, high=1.1, low=0.9, close=1, volume=1)
+        ],
+        expected=ExpectedOutcome(kind="exit", exit_reason_contains="stop_loss"),
+    )
+    g = RuleProbesGate(runner=lambda *a, **k: _Stub())
+    with g._using_phase("synthesis"):
+        result = assess_probe(probe, _Stub(success=True, trades=[]), emitter=g)
+    assert result.severity == "critical"
+    assert "no trades were recorded" in result.details
+
+
+def test_summarise_trades_truncates_long_lists():
+    trades = [
+        TradeRecord(
+            trade_num=i,
+            entry_date=f"2024-01-{i:02d}",
+            exit_date=f"2024-02-{i:02d}",
+            symbol="X",
+            side="long",
+            entry_price=100.0,
+            exit_price=110.0,
+            shares=1.0,
+            position_value=100.0,
+            gross_pnl=10.0,
+            net_pnl=10.0,
+            return_pct=0.10,
+            hold_days=1,
+            outcome="win",
+            cumulative_pnl=10.0,
+        )
+        for i in range(1, 9)
+    ]
+    text = _summarise_trades(trades)
+    assert "+3 more" in text
+
+
+# ===========================================================================
+# Gate-level: SkippedResult path + runner exception handling
+# ===========================================================================
+
+
+def test_skipped_result_has_empty_trades_and_success_true():
+    r = _SkippedResult()
+    assert r.success is True
+    assert r.trades == []
+    assert r.error_type is None
+
+
+def test_unsynthesizable_entry_rule_becomes_unprobeable_probe_run():
+    """An entry rule with an unreachable predicate produces an unprobeable
+    :class:`ProbeRun`, not a crash."""
+    spec = _spec_with(
+        entry_rules=[
+            EntryRule(
+                side="long",
+                when=Predicate(
+                    lhs=IndicatorRef(name="rsi", params={"period": 14}),
+                    op="<",
+                    rhs=-5.0,
+                ),
+            )
+        ]
+    )
+    [probe] = generate_rule_probe_runs(spec)
+    assert probe.synthesizable is False
+    assert probe.unprobeable_reason is not None
+
+
+def test_unsupported_exit_rule_subclass_becomes_unprobeable():
+    """Defensive: an exit rule of an unrecognised type marks the probe
+    unprobeable without raising."""
+    entry = EntryRule(
+        side="long",
+        when=Predicate(lhs="bar.close", op=">", rhs=50.0),
+    )
+
+    class _UnknownExit:
+        kind = "unknown_exit_kind_xyz"
+        note = ""
+
+    spec = _spec_with(entry_rules=[entry])
+    # Bypass the discriminated-union validator by appending after
+    # construction; the synthesiser shouldn't trust ``kind`` blindly.
+    spec.exit_rules = [_UnknownExit()]  # type: ignore[list-item]
+    runs = generate_rule_probe_runs(spec)
+    exit_probe = runs[-1]
+    assert exit_probe.synthesizable is False
+    assert "unknown_exit_rule_type" in (exit_probe.unprobeable_reason or "")
+
+
+def test_normalise_ohlc_handles_none_field():
+    """``_safe`` falls back to the floor for None inputs."""
+    # Pydantic OHLCVBar forbids None, but the helper is exercised on
+    # arbitrary float-like values; test by passing NaN (the equivalent
+    # of the None branch).
+    bar = OHLCVBar(date="d", open=float("nan"), high=10.0, low=5.0, close=8.0, volume=100.0)
+    out = _normalise_ohlc(bar)
+    assert out.open > 0
+
+
+def test_default_runner_resolves_to_sandbox_run_strategy_code():
+    """When constructed without an explicit ``runner``, the gate falls back
+    to ``trading_service.modes.sandbox_compat.run_strategy_code``."""
+    from investment_team.trading_service.modes.sandbox_compat import (
+        run_strategy_code as _real,
+    )
+
+    gate = RuleProbesGate()
+    assert gate._runner is _real
+
+
+def test_runner_exception_is_caught_and_renders_critical():
+    """A buggy/throwing runner is caught by the gate; the probe surfaces as a
+    critical with a stable error type."""
+
+    def boom(code, market_data, config, *, strategy=None):
+        raise RuntimeError("kaboom")
+
+    gate = RuleProbesGate(runner=boom)
+    spec = _spec_with(
+        entry_rules=[
+            EntryRule(
+                side="long",
+                when=Predicate(lhs="bar.close", op=">", rhs=50.0),
+            )
+        ],
+        target_symbols=["PROBE"],
+    )
+    [r] = gate.check(spec.strategy_code, spec)
+    assert r.severity == "critical"
+    assert "probe_runner_exception" in r.details
+
+
+# ===========================================================================
+# Bars-to-DF round trip + check helpers
+# ===========================================================================
+
+
+def test_bars_to_df_preserves_ordering_and_indicator_values():
+    pred = Predicate(
+        lhs=IndicatorRef(name="rsi", params={"period": 14}),
+        op="<",
+        rhs=30.0,
+    )
+    bars, trigger, _reason = _synthesise_for_predicate(pred)
+
+    df = _bars_to_df(bars)
+    assert len(df) == len(bars)
+    # The RSI computed off the dataframe matches the value the synthesiser
+    # computed for verification.
+    assert rsi(df["close"], 14).iloc[trigger] < 30.0
+
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+
+def _spec_with(*, entry_rules=None, exit_rules=None, target_symbols=None):
+    return StrategySpec(
+        strategy_id="probe-ext",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="h",
+        signal_definition="s",
+        timeframe="1d",
+        entry_rules=entry_rules or [],
+        exit_rules=exit_rules or [],
+        target_symbols=target_symbols or [],
+        strategy_code="class S:\n    pass\n",
+    )
+
+
+# ===========================================================================
+# PriceRef-vs-PriceRef recipes
+# ===========================================================================
+
+
+def test_priceref_close_gt_low_recipe():
+    pred = Predicate(lhs="bar.close", op=">", rhs="bar.low")
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    assert bars[trigger].close > bars[trigger].low
+
+
+def test_priceref_high_gt_low_recipe_already_satisfied():
+    """``bar.high > bar.low`` is satisfied on the default OHLC values
+    (high=101, low=99) — the recipe should not need adjustment."""
+    pred = Predicate(lhs="bar.high", op=">", rhs="bar.low")
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    assert bars[trigger].high > bars[trigger].low
+
+
+def test_priceref_low_lt_high_recipe():
+    pred = Predicate(lhs="bar.low", op="<", rhs="bar.high")
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    assert bars[trigger].low < bars[trigger].high
+
+
+# ===========================================================================
+# PriceRef ops the basic suite skipped: <=, >=, ==
+# ===========================================================================
+
+
+def test_priceref_close_le_number_recipe():
+    pred = Predicate(lhs="bar.close", op="<=", rhs=50.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    assert bars[trigger].close <= 50.0
+
+
+def test_priceref_close_ge_number_recipe():
+    pred = Predicate(lhs="bar.close", op=">=", rhs=120.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    assert bars[trigger].close >= 120.0
+
+
+def test_priceref_close_eq_number_recipe():
+    pred = Predicate(lhs="bar.close", op="==", rhs=100.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    assert bars[trigger].close == 100.0
+
+
+# ===========================================================================
+# Bar-field setters: high / low / volume
+# ===========================================================================
+
+
+def test_priceref_high_gt_number_recipe_drives_high_field():
+    pred = Predicate(lhs="bar.high", op=">", rhs=150.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    assert bars[trigger].high > 150.0
+
+
+def test_priceref_low_lt_number_recipe_drives_low_field():
+    pred = Predicate(lhs="bar.low", op="<", rhs=50.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    assert bars[trigger].low < 50.0
+
+
+def test_priceref_volume_gt_number_recipe_drives_volume_field():
+    pred = Predicate(lhs="bar.volume", op=">", rhs=500_000.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    assert bars[trigger].volume > 500_000.0
+
+
+# ===========================================================================
+# Indicator-vs-PriceRef
+# ===========================================================================
+
+
+def test_sma_gt_bar_low_recipe():
+    pred = Predicate(
+        lhs=IndicatorRef(name="sma", params={"period": 5}),
+        op=">",
+        rhs="bar.low",
+    )
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    # SMA at trigger should be > the bar's low.
+    series = _bars_to_df(bars)["close"]
+    assert sma(series, 5).iloc[trigger] > bars[trigger].low
+
+
+def test_unsupported_indicator_vs_priceref_marks_unprobeable():
+    pred = Predicate(
+        lhs=IndicatorRef(name="rsi", params={"period": 14}),
+        op=">",
+        rhs="bar.close",
+    )
+    bars, _trigger, reason = _synthesise_for_predicate(pred)
+    assert bars is None and reason is not None
+    assert "indicator_vs_priceref_unsupported" in reason
+
+
+# ===========================================================================
+# Cross recipe edge cases
+# ===========================================================================
+
+
+def test_cross_with_priceref_against_non_sma_indicator_unprobeable():
+    """``bar.close cross_above RSI(14)`` isn't supported — only SMA/EMA crosses."""
+    pred = Predicate(
+        lhs="bar.close",
+        op="cross_above",
+        rhs=IndicatorRef(name="rsi", params={"period": 14}),
+    )
+    bars, _trigger, reason = _synthesise_for_predicate(pred)
+    assert bars is None and reason is not None
+
+
+def test_cross_against_non_close_priceref_unprobeable():
+    """``bar.high cross_above SMA(20)`` — the supported lhs is bar.close."""
+    pred = Predicate(
+        lhs="bar.high",
+        op="cross_above",
+        rhs=IndicatorRef(name="sma", params={"period": 20}),
+    )
+    bars, _trigger, reason = _synthesise_for_predicate(pred)
+    assert bars is None and reason is not None
+
+
+def test_cross_indicator_number_with_unsupported_indicator_unprobeable():
+    pred = Predicate(
+        lhs=IndicatorRef(name="rsi", params={"period": 14}),
+        op="cross_above",
+        rhs=50.0,
+    )
+    bars, _trigger, reason = _synthesise_for_predicate(pred)
+    # rsi cross above number isn't supported by the SMA/EMA-only recipe.
+    assert bars is None and reason is not None
+
+
+# ===========================================================================
+# Compute-indicator-at safety
+# ===========================================================================
+
+
+def test_compute_indicator_at_returns_none_for_unsupported_name():
+    """Defensive: a malformed IndicatorRef.name should return None."""
+    # IndicatorRef enforces ``name`` is one of the known literals, so we
+    # construct a mock-shaped object that bypasses validation.
+    class _FakeRef:
+        name = "unsupported_xyz"
+        source = "close"
+        params: dict = {}
+
+        def param(self, key, default=None):  # pragma: no cover - defensive
+            return default
+
+
+    bars = [
+        OHLCVBar(date=f"2024-01-{i:02d}", open=1, high=1.1, low=0.9, close=1, volume=1)
+        for i in range(1, 31)
+    ]
+    assert _compute_indicator_at(_FakeRef(), bars, 10) is None
+
+
+# ===========================================================================
+# Probe entry without market_data (defensive trigger_date path)
+# ===========================================================================
+
+
+def test_assess_probe_entry_with_correct_side_but_early_date_passes():
+    """A trade opened before the probe's trigger date is still accepted —
+    binary-search recipes can over-shoot, and an early but correctly-sided
+    fill is still evidence the rule fires."""
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        ExpectedOutcome,
+    )
+
+    probe = ProbeRun(
+        rule_id="entry[0]",
+        rule_kind="entry",
+        symbol="PROBE",
+        market_data=[
+            OHLCVBar(date="2024-06-01", open=1, high=1.1, low=0.9, close=1, volume=1)
+        ],
+        expected=ExpectedOutcome(kind="entry", side="long"),
+        trigger_bar_index=0,
+    )
+    early_trade = TradeRecord(
+        trade_num=1,
+        entry_date="2024-01-01",  # before trigger
+        exit_date="2024-06-15",
+        symbol="PROBE",
+        side="long",
+        entry_price=100.0,
+        exit_price=110.0,
+        shares=1.0,
+        position_value=100.0,
+        gross_pnl=10.0,
+        net_pnl=10.0,
+        return_pct=0.10,
+        hold_days=180,
+        outcome="win",
+        cumulative_pnl=10.0,
+    )
+    g = RuleProbesGate(runner=lambda *a, **k: _Stub())
+    with g._using_phase("synthesis"):
+        result = assess_probe(probe, _Stub(success=True, trades=[early_trade]), emitter=g)
+    assert result.passed is True
+
+
+def test_series_for_source_open_high_low_columns():
+    import pandas as pd
+
+    df = pd.DataFrame(
+        {"open": [11.0], "high": [12.0], "low": [9.0], "close": [10.5], "volume": [100.0]}
+    )
+    assert _series_for_source(df, "open").iloc[0] == 11.0
+    assert _series_for_source(df, "high").iloc[0] == 12.0
+    assert _series_for_source(df, "low").iloc[0] == 9.0
+
+
+def test_indicator_vs_indicator_lt_descending_series():
+    """Inverse-trending series: ``SMA(5) < SMA(20)`` requires a falling regime
+    at the right edge."""
+    fast = IndicatorRef(name="sma", params={"period": 5})
+    slow = IndicatorRef(name="sma", params={"period": 20})
+    pred = Predicate(lhs=fast, op="<", rhs=slow)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    series = _bars_to_df(bars)["close"]
+    assert sma(series, 5).iloc[trigger] < sma(series, 20).iloc[trigger]
+
+
+def test_sma_eq_threshold_recipe():
+    """``sma(5) == X`` flat-lines closes at X."""
+    ref = IndicatorRef(name="sma", params={"period": 5})
+    pred = Predicate(lhs=ref, op="==", rhs=100.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    series = _bars_to_df(bars)["close"]
+    # SMA(5) at trigger should equal the flat-level (100.0).
+    assert abs(sma(series, 5).iloc[trigger] - 100.0) < 1e-6
+
+
+def test_verify_cross_with_unknown_op_returns_false():
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        _verify_cross,
+    )
+
+    # Defensive: an op not in {cross_above, cross_below} returns False.
+    assert _verify_cross(1.0, 2.0, 1.5, 1.5, "not_a_cross_op") is False
+
+
+def test_verify_cross_with_non_numeric_values_returns_false():
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        _verify_cross,
+    )
+
+    assert _verify_cross("a", "b", "c", "d", "cross_above") is False
+
+
+def test_priceref_vs_priceref_already_satisfied_path():
+    """Default OHLC (open=100, low=99, high=101, close=100.5) already
+    satisfies ``close > low``; exercises the early-return branch."""
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        _bar_with_priceref_relation,
+    )
+
+    bar = _bar_with_priceref_relation("close", "low", ">")
+    assert bar.close > bar.low
+
+
+def test_priceref_vs_priceref_eq_falls_through_to_else_branch():
+    """``==`` on default OHLC (close != open) requires adjusting close → open
+    via the else-branch path."""
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        _bar_with_priceref_relation,
+    )
+
+    bar = _bar_with_priceref_relation("close", "high", "==")
+    # The adjustment makes close == high (the rhs value).
+    assert bar.close == bar.high
+
+
+def test_assess_probe_entry_with_wrong_side_then_right_side_still_passes():
+    """Multi-trade result: the first trade has the wrong side, the second
+    has the right side. The asserter must scan all trades, not just the
+    first."""
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        ExpectedOutcome,
+    )
+
+    probe = ProbeRun(
+        rule_id="entry[0]",
+        rule_kind="entry",
+        symbol="PROBE",
+        market_data=[
+            OHLCVBar(date="2024-01-01", open=1, high=1.1, low=0.9, close=1, volume=1)
+        ],
+        expected=ExpectedOutcome(kind="entry", side="long"),
+        trigger_bar_index=0,
+    )
+
+    def _t(side, date):
+        return TradeRecord(
+            trade_num=1,
+            entry_date=date,
+            exit_date=date,
+            symbol="PROBE",
+            side=side,
+            entry_price=100.0,
+            exit_price=100.0,
+            shares=1.0,
+            position_value=100.0,
+            gross_pnl=0.0,
+            net_pnl=0.0,
+            return_pct=0.0,
+            hold_days=0,
+            outcome="loss",
+            cumulative_pnl=0.0,
+        )
+
+    trades = [_t("short", "2024-01-02"), _t("long", "2024-01-03")]
+    g = RuleProbesGate(runner=lambda *a, **k: _Stub())
+    with g._using_phase("synthesis"):
+        result = assess_probe(probe, _Stub(success=True, trades=trades), emitter=g)
+    assert result.passed is True

--- a/backend/agents/investment_team/tests/test_rule_probes_extended.py
+++ b/backend/agents/investment_team/tests/test_rule_probes_extended.py
@@ -1091,6 +1091,101 @@ def test_exit_verifiers_return_false_on_out_of_range_index():
     assert sl([OHLCVBar(date="d", open=1, high=1, low=1, close=1, volume=1)], 5) is False
 
 
+def test_compare_eq_uses_exact_equality_not_isclose():
+    """``op == "=="`` mirrors the compiler's raw ``lhs == rhs``. Near-equal
+    floats must NOT pass; using ``math.isclose`` would let the probe accept
+    values the compiled strategy doesn't, producing false criticals."""
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        _compare,
+    )
+
+    assert _compare(5.0, "==", 5.0) is True
+    # Near-equal but not exactly equal — must be False to match runtime.
+    assert _compare(0.1 + 0.2, "==", 0.3) is False
+    assert _compare(1.0 - 1e-9, "==", 1.0) is False
+
+
+def test_exit_probe_skips_unsynthesizable_entry_rule_and_uses_next():
+    """When ``entry_rules[0]`` can't be synthesised but ``entry_rules[1]``
+    can, the exit probe must use the second rule rather than reporting
+    ``entry_prefix_not_synthesizable`` and hiding the real exit-rule
+    behaviour."""
+    # First rule: rsi < -5 (unreachable; RSI bounded in [0,100]).
+    bad_entry = EntryRule(
+        side="long",
+        when=Predicate(
+            lhs=IndicatorRef(name="rsi", params={"period": 14}),
+            op="<",
+            rhs=-5.0,
+        ),
+    )
+    # Second rule: synthesisable price-ref predicate.
+    good_entry = EntryRule(
+        side="long",
+        when=Predicate(lhs="bar.close", op=">", rhs=50.0),
+    )
+    spec = _spec_with(
+        entry_rules=[bad_entry, good_entry],
+        exit_rules=[TakeProfitRule(pct=0.05)],
+    )
+    runs = generate_rule_probe_runs(spec)
+    # 2 entry probes + 1 exit probe.
+    assert len(runs) == 3
+    exit_probe = runs[-1]
+    assert exit_probe.synthesizable is True
+    assert exit_probe.rule_id == "exit[0]:take_profit"
+
+
+def test_exit_probe_picks_entry_rule_whose_side_is_compatible_with_exit():
+    """Multi-entry spec: rule[0] is long but ``StopLossRule(basis=
+    "trailing_low")`` is a no-op for longs. The exit probe must pick
+    ``entry_rules[1]`` (short) rather than mark itself unprobeable."""
+    long_entry = EntryRule(
+        side="long",
+        when=Predicate(lhs="bar.close", op=">", rhs=50.0),
+    )
+    short_entry = EntryRule(
+        side="short",
+        when=Predicate(lhs="bar.close", op="<", rhs=200.0),
+    )
+    spec = _spec_with(
+        entry_rules=[long_entry, short_entry],
+        exit_rules=[StopLossRule(pct=0.05, basis="trailing_low")],
+    )
+    runs = generate_rule_probe_runs(spec)
+    exit_probe = next(r for r in runs if r.rule_id.startswith("exit["))
+    assert exit_probe.synthesizable is True
+
+
+def test_exit_probe_reports_last_failure_when_no_entry_rule_works():
+    """When every entry rule is unsynthesisable, the exit probe surfaces
+    the most recent failure reason rather than a generic message."""
+    bad1 = EntryRule(
+        side="long",
+        when=Predicate(
+            lhs=IndicatorRef(name="rsi", params={"period": 14}),
+            op="<",
+            rhs=-5.0,
+        ),
+    )
+    bad2 = EntryRule(
+        side="long",
+        when=Predicate(
+            lhs=IndicatorRef(name="rsi", params={"period": 14}),
+            op=">",
+            rhs=200.0,  # > 100 also unreachable
+        ),
+    )
+    spec = _spec_with(
+        entry_rules=[bad1, bad2],
+        exit_rules=[TakeProfitRule(pct=0.05)],
+    )
+    runs = generate_rule_probe_runs(spec)
+    exit_probe = next(r for r in runs if r.rule_id.startswith("exit["))
+    assert exit_probe.synthesizable is False
+    assert "entry_prefix_not_synthesizable" in (exit_probe.unprobeable_reason or "")
+
+
 def test_priceref_high_lt_low_is_unprobeable():
     """``bar.high < bar.low`` is structurally impossible under OHLC
     invariants. The recipe builds a bar with adjusted lhs, but

--- a/backend/agents/investment_team/tests/test_rule_probes_extended.py
+++ b/backend/agents/investment_team/tests/test_rule_probes_extended.py
@@ -768,10 +768,11 @@ def test_compute_indicator_at_returns_none_for_unsupported_name():
 # ===========================================================================
 
 
-def test_assess_probe_entry_with_correct_side_but_early_date_passes():
-    """A trade opened before the probe's trigger date is still accepted —
-    binary-search recipes can over-shoot, and an early but correctly-sided
-    fill is still evidence the rule fires."""
+def test_assess_probe_entry_rejects_trade_opened_before_trigger():
+    """A correctly-sided trade opened *before* the probe's trigger bar is
+    not evidence the rule under test fires — it's more likely an unrelated
+    always-on entry. The asserter must reject it so swapped/negated
+    predicates can't slip past the gate."""
     from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
         ExpectedOutcome,
     )
@@ -806,7 +807,8 @@ def test_assess_probe_entry_with_correct_side_but_early_date_passes():
     g = RuleProbesGate(runner=lambda *a, **k: _Stub())
     with g._using_phase("synthesis"):
         result = assess_probe(probe, _Stub(success=True, trades=[early_trade]), emitter=g)
-    assert result.passed is True
+    assert result.passed is False
+    assert "before trigger bar" in result.details
 
 
 def test_series_for_source_open_high_low_columns():
@@ -881,6 +883,59 @@ def test_priceref_vs_priceref_eq_falls_through_to_else_branch():
     bar = _bar_with_priceref_relation("close", "high", "==")
     # The adjustment makes close == high (the rhs value).
     assert bar.close == bar.high
+
+
+def test_priceref_below_clamp_floor_marks_unprobeable():
+    """``bar.close < 0.005`` would synthesise a trigger value below
+    ``_MIN_PRICE``; the recipe must refuse rather than ship a probe whose
+    post-clamp bars no longer satisfy the predicate."""
+    pred = Predicate(lhs="bar.close", op="<", rhs=0.005)
+    bars, _trigger, reason = _synthesise_for_predicate(pred)
+    assert bars is None
+    assert reason is not None
+    assert "clamp_floor" in reason
+
+
+def test_priceref_above_clamp_floor_still_probeable():
+    """``bar.close > 50`` is safe — trigger value rhs+1=51 and baseline
+    rhs-5=45 both clear the clamp floor, so the post-clamp bars still
+    satisfy the predicate."""
+    pred = Predicate(lhs="bar.close", op=">", rhs=50.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    # Critical: the post-clamp trigger bar must still satisfy the predicate.
+    assert bars[trigger].close > 50.0
+
+
+def test_priceref_baseline_below_clamp_floor_marks_unprobeable():
+    """``bar.close > -10`` would set baseline to ``rhs - 5 = -15``, below
+    the clamp floor. Refuse the probe."""
+    pred = Predicate(lhs="bar.close", op=">", rhs=-10.0)
+    bars, _trigger, reason = _synthesise_for_predicate(pred)
+    assert bars is None
+    assert reason is not None
+
+
+def test_indicator_trigger_idx_points_at_first_satisfying_bar():
+    """For an SMA flat-line recipe, the predicate is satisfied at every
+    post-warmup bar. The recipe must set ``trigger_bar_index`` to the
+    earliest such bar so the asserter's stricter timing check still
+    accepts a strategy that opens at the rule's first-fire bar."""
+    pred = Predicate(
+        lhs=IndicatorRef(name="sma", params={"period": 5}),
+        op=">",
+        rhs=50.0,
+    )
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    series = _bars_to_df(bars)["close"]
+    # The earliest SMA-finite bar that satisfies the predicate.
+    sma_series = sma(series, 5)
+    earliest = next(
+        i for i, v in enumerate(sma_series.tolist())
+        if isinstance(v, float) and v == v and v > 50.0  # not-NaN, satisfies
+    )
+    assert trigger == earliest
 
 
 def test_assess_probe_entry_with_wrong_side_then_right_side_still_passes():

--- a/backend/agents/investment_team/tests/test_rule_probes_extended.py
+++ b/backend/agents/investment_team/tests/test_rule_probes_extended.py
@@ -915,6 +915,252 @@ def test_volume_priceref_in_spec_does_not_abort_synthesis_loop():
     assert "volume" in (probe.unprobeable_reason or "")
 
 
+def test_predicate_verifier_returns_false_on_out_of_range_index():
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        _predicate_verifier,
+    )
+
+    pred = Predicate(lhs="bar.close", op=">", rhs=50.0)
+    verifier = _predicate_verifier(pred)
+    bars = [OHLCVBar(date="d", open=100, high=101, low=99, close=100, volume=1)]
+    assert verifier(bars, -1) is False
+    assert verifier(bars, 5) is False
+    assert verifier([], 0) is False
+
+
+def test_predicate_verifier_returns_false_on_eval_exception():
+    """If ``_eval_predicate_at`` raises (malformed predicate, etc.) the
+    verifier swallows the exception and returns False so a bug surfaces
+    as 'unprobeable' rather than crashing the synthesis loop."""
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        _predicate_verifier,
+    )
+
+    # Construct an in-memory predicate with a side that bypasses DSL
+    # validation but breaks ``_resolve_side``.
+    class _BrokenSide:
+        pass
+
+    class _BrokenPredicate:
+        lhs = _BrokenSide()
+        op = ">"
+        rhs = 0.0
+
+    verifier = _predicate_verifier(_BrokenPredicate())
+    bars = [OHLCVBar(date="d", open=1, high=1.1, low=0.9, close=1, volume=1)]
+    assert verifier(bars, 0) is False
+
+
+def test_eval_predicate_at_cross_above_returns_false_at_index_zero():
+    """``cross_*`` requires a (prev, curr) pair — at index 0 there's no
+    prev, so the predicate is False."""
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        _eval_predicate_at,
+    )
+
+    bars = [OHLCVBar(date="d", open=10, high=11, low=9, close=10, volume=1)]
+    pred = Predicate(
+        lhs="bar.close",
+        op="cross_above",
+        rhs=IndicatorRef(name="sma", params={"period": 5}),
+    )
+    assert _eval_predicate_at(pred, bars, 0) is False
+
+
+def test_resolve_side_numeric_float_path():
+    """Numeric (int/float) sides resolve to their float value at any bar."""
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        _resolve_side,
+    )
+
+    bars = [OHLCVBar(date="d", open=1, high=1.1, low=0.9, close=1, volume=1)]
+    assert _resolve_side(42.5, bars, 0) == 42.5
+    assert _resolve_side(7, bars, 0) == 7.0
+
+
+def test_resolve_side_unsupported_string_returns_none():
+    """Non-``bar.`` string sides aren't a known PriceRef shape."""
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        _resolve_side,
+    )
+
+    bars = [OHLCVBar(date="d", open=1, high=1.1, low=0.9, close=1, volume=1)]
+    assert _resolve_side("not_a_bar_ref", bars, 0) is None
+
+
+def test_resolve_side_bool_returns_none():
+    """Booleans are technically int subclasses; reject them explicitly."""
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        _resolve_side,
+    )
+
+    bars = [OHLCVBar(date="d", open=1, high=1.1, low=0.9, close=1, volume=1)]
+    assert _resolve_side(True, bars, 0) is None
+    assert _resolve_side(False, bars, 0) is None
+
+
+def test_resolve_side_unsupported_type_returns_none():
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        _resolve_side,
+    )
+
+    bars = [OHLCVBar(date="d", open=1, high=1.1, low=0.9, close=1, volume=1)]
+    assert _resolve_side(object(), bars, 0) is None
+
+
+def test_stop_loss_verifier_long_position_triggers_on_floor_breach():
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        _stop_loss_verifier,
+    )
+
+    rule = StopLossRule(pct=0.05)
+    verify = _stop_loss_verifier(rule, entry_close=100.0, entry_side="long")
+    # Trigger: low <= 100 * 0.95 = 95
+    bars_trigger = [OHLCVBar(date="d", open=96, high=97, low=94.5, close=96, volume=1)]
+    assert verify(bars_trigger, 0) is True
+    # No trigger: low above floor
+    bars_safe = [OHLCVBar(date="d", open=96, high=97, low=96, close=96, volume=1)]
+    assert verify(bars_safe, 0) is False
+
+
+def test_stop_loss_verifier_short_position_triggers_on_ceiling_breach():
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        _stop_loss_verifier,
+    )
+
+    rule = StopLossRule(pct=0.05)
+    verify = _stop_loss_verifier(rule, entry_close=100.0, entry_side="short")
+    bars_trigger = [OHLCVBar(date="d", open=104, high=106, low=103, close=104, volume=1)]
+    assert verify(bars_trigger, 0) is True
+    bars_safe = [OHLCVBar(date="d", open=104, high=104.5, low=103, close=104, volume=1)]
+    assert verify(bars_safe, 0) is False
+
+
+def test_take_profit_verifier_long_and_short():
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        _take_profit_verifier,
+    )
+
+    rule = TakeProfitRule(pct=0.05)
+    verify_long = _take_profit_verifier(rule, entry_close=100.0, entry_side="long")
+    assert verify_long([OHLCVBar(date="d", open=104, high=106, low=103, close=105, volume=1)], 0) is True
+    assert verify_long([OHLCVBar(date="d", open=104, high=104.5, low=103, close=104, volume=1)], 0) is False
+    verify_short = _take_profit_verifier(rule, entry_close=100.0, entry_side="short")
+    assert verify_short([OHLCVBar(date="d", open=96, high=97, low=94, close=95, volume=1)], 0) is True
+    assert verify_short([OHLCVBar(date="d", open=96, high=97, low=96, close=96, volume=1)], 0) is False
+
+
+def test_exit_verifiers_return_false_on_out_of_range_index():
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        _stop_loss_verifier,
+        _take_profit_verifier,
+    )
+
+    sl = _stop_loss_verifier(StopLossRule(pct=0.05), entry_close=100.0, entry_side="long")
+    tp = _take_profit_verifier(TakeProfitRule(pct=0.05), entry_close=100.0, entry_side="long")
+    assert sl([], 0) is False
+    assert tp([], 0) is False
+    assert sl([OHLCVBar(date="d", open=1, high=1, low=1, close=1, volume=1)], 5) is False
+
+
+def test_priceref_high_lt_low_is_unprobeable():
+    """``bar.high < bar.low`` is structurally impossible under OHLC
+    invariants. The recipe builds a bar with adjusted lhs, but
+    ``_normalise_ohlc`` restores ``high >= low``, leaving the predicate
+    false. The recipe must detect this and mark the probe unprobeable
+    rather than ship a non-triggering bar."""
+    pred = Predicate(lhs="bar.high", op="<", rhs="bar.low")
+    bars, _trigger, reason = _synthesise_for_predicate(pred)
+    assert bars is None
+    assert reason == "priceref_vs_priceref_invariant_conflict"
+
+
+def test_priceref_low_gt_high_is_unprobeable():
+    """Symmetric case to ``bar.high < bar.low``: ``bar.low > bar.high``
+    can't satisfy the OHLC invariant."""
+    pred = Predicate(lhs="bar.low", op=">", rhs="bar.high")
+    bars, _trigger, reason = _synthesise_for_predicate(pred)
+    assert bars is None
+    assert reason == "priceref_vs_priceref_invariant_conflict"
+
+
+def test_post_clamp_verifier_marks_probe_unprobeable_when_clamping_breaks_predicate():
+    """``sma < 0.5`` synthesises a sub-zero flat-line; ``_normalise_ohlc``
+    clamps closes to the floor, so SMA == ``_MIN_PRICE`` (0.01) >= 0.5 is
+    false and 0.01 < 0.5 is true. With ``rhs`` chosen so the floor sits
+    *above* the predicate's truth region, the clamped bars no longer
+    satisfy the predicate, and the probe must be marked unprobeable."""
+    # Pick rhs s.t. recipe synthesises a level at rhs-1.0 = -0.99 (clamped
+    # to _MIN_PRICE=0.01). SMA computed on clamped closes == 0.01.
+    # Predicate "0.01 < 0.01" is False -> unprobeable.
+    pred = Predicate(
+        lhs=IndicatorRef(name="sma", params={"period": 5}),
+        op="<",
+        rhs=0.01,
+    )
+    # The probe goes through `_build_entry_probe` + `_stamp_dates`; with
+    # the verifier wired we expect the final `ProbeRun` to be marked
+    # unprobeable rather than emitted with bars that won't trigger.
+    rule = EntryRule(side="long", when=pred)
+    spec = _spec_with(entry_rules=[rule])
+    [probe] = generate_rule_probe_runs(spec)
+    assert probe.synthesizable is False
+    assert (
+        probe.unprobeable_reason == "post_clamp_predicate_violation"
+        # Recipe may also bail earlier with its own pre-clamp signal.
+        or "below_clamp_floor" in (probe.unprobeable_reason or "")
+        or "verification_failed" in (probe.unprobeable_reason or "")
+        or "unreachable" in (probe.unprobeable_reason or "")
+    )
+
+
+def test_post_clamp_verifier_passes_for_well_formed_recipe():
+    """A normal predicate (well above clamp floor) survives normalisation:
+    the post-clamp verifier confirms the predicate still holds and the
+    probe ships its bars."""
+    rule = EntryRule(
+        side="long",
+        when=Predicate(
+            lhs=IndicatorRef(name="sma", params={"period": 5}),
+            op=">",
+            rhs=100.0,
+        ),
+    )
+    spec = _spec_with(entry_rules=[rule])
+    [probe] = generate_rule_probe_runs(spec)
+    assert probe.synthesizable is True
+    assert probe.unprobeable_reason is None
+    assert probe.post_clamp_verifier is not None
+    # The stored verifier evaluates the post-clamp bars at the trigger:
+    assert probe.post_clamp_verifier(probe.market_data, probe.trigger_bar_index) is True
+
+
+def test_post_clamp_verifier_raising_marks_unprobeable_not_crash():
+    """A buggy verifier must not propagate exceptions out of the
+    synthesis loop. ``_stamp_dates`` catches and marks unprobeable."""
+    from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+        _stamp_dates,
+    )
+
+    def _explode(_bars, _idx):
+        raise RuntimeError("verifier bug")
+
+    probe = ProbeRun(
+        rule_id="entry[0]",
+        rule_kind="entry",
+        symbol="PROBE",
+        market_data=[
+            OHLCVBar(date="placeholder", open=1, high=1.1, low=0.9, close=1, volume=1)
+        ],
+        trigger_bar_index=0,
+        synthesizable=True,
+        post_clamp_verifier=_explode,
+    )
+    stamped = _stamp_dates(probe)
+    assert stamped.synthesizable is False
+    assert stamped.unprobeable_reason == "post_clamp_predicate_violation"
+
+
 def test_assess_probe_exit_rejects_trade_closed_before_trigger():
     """An exit-substring match alone isn't evidence the targeted rule fired —
     a strategy that always exits at bar 2 for unrelated reasons can collide

--- a/backend/agents/investment_team/tests/test_rule_probes_extended.py
+++ b/backend/agents/investment_team/tests/test_rule_probes_extended.py
@@ -187,6 +187,34 @@ def test_cross_with_unsupported_indicator_pair_marks_unprobeable():
 # ===========================================================================
 
 
+def test_extract_universe_literal_handles_annotated_assignment():
+    """LLM-authored or hand-written strategies often use the typed form
+    ``UNIVERSE: frozenset[str] = frozenset({...})`` (AnnAssign), not the
+    bare ``Assign`` the deterministic compiler emits. Missing this path
+    causes a fallback to the ``"PROBE"`` sentinel that hits the strategy's
+    universe-guard and produces a false critical."""
+    code = "UNIVERSE: frozenset[str] = frozenset({'AAPL', 'MSFT'})\n"
+    parsed = _extract_universe_literal(code)
+    assert parsed == frozenset({"AAPL", "MSFT"})
+
+
+def test_extract_universe_literal_handles_class_level_annotated_assignment():
+    code = (
+        "class S:\n"
+        "    UNIVERSE: frozenset[str] = frozenset({'NVDA'})\n"
+    )
+    parsed = _extract_universe_literal(code)
+    assert parsed == frozenset({"NVDA"})
+
+
+def test_extract_universe_literal_skips_bare_annotation_without_value():
+    """``UNIVERSE: frozenset[str]`` (no assignment) carries no literal —
+    treat as unset rather than erroring."""
+    code = "UNIVERSE: frozenset[str]\nUNIVERSE = frozenset({'FOO'})\n"
+    parsed = _extract_universe_literal(code)
+    assert parsed == frozenset({"FOO"})
+
+
 def test_extract_universe_literal_from_self_universe_assignment():
     code = "class S:\n    def __init__(self):\n        self.UNIVERSE = frozenset({'AAA'})\n"
     parsed = _extract_universe_literal(code)

--- a/backend/agents/investment_team/tests/test_rule_probes_gate.py
+++ b/backend/agents/investment_team/tests/test_rule_probes_gate.py
@@ -1,0 +1,312 @@
+"""End-to-end tests for :class:`RuleProbesGate` with a stubbed sandbox runner.
+
+These tests do **not** spawn subprocesses — they inject a fake runner
+that inspects the ``market_data`` it receives and returns a hand-crafted
+``StrategyRunResult``. That keeps tests fast (<100ms total) and isolates
+the gate's own behaviour from the broader trading-service plumbing.
+
+A separate sandbox-driven test exists for end-to-end confidence (see
+``test_rule_probes_orchestrator.py``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from investment_team.models import StrategySpec, TradeRecord
+from investment_team.strategy_lab.quality_gates.rule_probes import RuleProbesGate
+from investment_team.strategy_lab.spec_dsl import (
+    EntryRule,
+    IndicatorRef,
+    Predicate,
+    SignalExitRule,
+    StopLossRule,
+    TakeProfitRule,
+)
+
+
+@dataclass
+class _FakeResult:
+    """Minimal stand-in for :class:`StrategyRunResult`."""
+
+    success: bool = True
+    trades: List[TradeRecord] = field(default_factory=list)
+    error_type: Optional[str] = None
+    stderr: str = ""
+
+
+def _trade(
+    *,
+    side: str = "long",
+    entry_date: str = "2024-01-50",
+    exit_date: str = "2024-02-01",
+    exit_reason: Optional[str] = None,
+    shares: float = 10.0,
+    symbol: str = "PROBE",
+) -> TradeRecord:
+    return TradeRecord(
+        trade_num=1,
+        entry_date=entry_date,
+        exit_date=exit_date,
+        symbol=symbol,
+        side=side,
+        entry_price=100.0,
+        exit_price=110.0,
+        shares=shares,
+        position_value=1000.0,
+        gross_pnl=100.0,
+        net_pnl=100.0,
+        return_pct=0.10,
+        hold_days=10,
+        outcome="win",
+        cumulative_pnl=100.0,
+        exit_reason=exit_reason,
+    )
+
+
+def _spec(*, entry_rules=None, exit_rules=None, code: str = "x = 1\n") -> StrategySpec:
+    return StrategySpec(
+        strategy_id="probe-test",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="h",
+        signal_definition="s",
+        timeframe="1d",
+        entry_rules=entry_rules or [],
+        exit_rules=exit_rules or [],
+        target_symbols=["PROBE"],
+        strategy_code=code,
+    )
+
+
+def _entry_rsi_lt(side: str = "long") -> EntryRule:
+    return EntryRule(
+        side=side,
+        when=Predicate(
+            lhs=IndicatorRef(name="rsi", params={"period": 14}),
+            op="<",
+            rhs=30.0,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Acceptance scenarios named in the issue
+# ---------------------------------------------------------------------------
+
+
+def test_happy_path_rsi_entry_probe_passes():
+    """Stub runner pretends the strategy opened a long position at the trigger
+    bar. The probe should pass with severity=info, passed=True."""
+
+    def runner(code, market_data, config, *, strategy=None):
+        return _FakeResult(success=True, trades=[_trade(side="long")])
+
+    gate = RuleProbesGate(runner=runner)
+    spec = _spec(entry_rules=[_entry_rsi_lt()])
+    results = gate.check(spec.strategy_code, spec)
+    assert len(results) == 1
+    r = results[0]
+    assert r.passed is True
+    assert r.severity == "info"
+    assert r.rule_id == "entry[0]"
+
+
+def test_swapped_comparator_fails_rsi_entry_probe():
+    """Acceptance: a strategy implementing ``rsi > 30`` against a spec asking
+    for ``rsi < 30`` will not produce any long trade on a falling-RSI series.
+    The stub mimics that by returning no trades."""
+
+    def runner(code, market_data, config, *, strategy=None):
+        return _FakeResult(success=True, trades=[])
+
+    gate = RuleProbesGate(runner=runner)
+    spec = _spec(entry_rules=[_entry_rsi_lt()])
+    results = gate.check(spec.strategy_code, spec)
+    [r] = results
+    assert r.passed is False
+    assert r.severity == "critical"
+    assert r.rule_id == "entry[0]"
+    assert "long" in r.details
+
+
+def test_missing_stop_loss_branch_fails_stop_loss_probe():
+    """Acceptance: a strategy that forgets the stop-loss branch produces no
+    closing trade with ``exit_reason`` matching ``stop_loss``."""
+
+    # The stub opens a long position on the entry trigger but never emits a
+    # stop-loss close. Mirrors a strategy whose engine_exit handling is
+    # missing the stop_loss case.
+    def runner(code, market_data, config, *, strategy=None):
+        return _FakeResult(
+            success=True,
+            trades=[_trade(side="long", exit_reason="manual_close")],
+        )
+
+    gate = RuleProbesGate(runner=runner)
+    spec = _spec(
+        entry_rules=[_entry_rsi_lt()],
+        exit_rules=[StopLossRule(pct=0.03)],
+    )
+    results = gate.check(spec.strategy_code, spec)
+    entry_result, exit_result = results
+    assert exit_result.passed is False
+    assert exit_result.severity == "critical"
+    assert exit_result.rule_id == "exit[0]:stop_loss"
+    assert "stop_loss" in exit_result.details
+
+
+# ---------------------------------------------------------------------------
+# Per-exit-kind happy and negative paths
+# ---------------------------------------------------------------------------
+
+
+def test_take_profit_probe_passes_when_engine_emits_take_profit_reason():
+    def runner(code, market_data, config, *, strategy=None):
+        return _FakeResult(
+            success=True,
+            trades=[
+                _trade(side="long", exit_reason="engine_exit:take_profit"),
+            ],
+        )
+
+    gate = RuleProbesGate(runner=runner)
+    spec = _spec(
+        entry_rules=[_entry_rsi_lt()],
+        exit_rules=[TakeProfitRule(pct=0.05)],
+    )
+    results = gate.check(spec.strategy_code, spec)
+    [_entry, tp] = results
+    assert tp.passed is True
+    assert tp.rule_id == "exit[0]:take_profit"
+
+
+def test_signal_exit_probe_passes_when_compiled_signal_exit_reason_present():
+    def runner(code, market_data, config, *, strategy=None):
+        return _FakeResult(
+            success=True,
+            trades=[
+                _trade(side="long", exit_reason="compiled_signal_exit"),
+            ],
+        )
+
+    gate = RuleProbesGate(runner=runner)
+    signal = SignalExitRule(
+        when=Predicate(lhs="bar.close", op="<", rhs=10.0),
+    )
+    spec = _spec(entry_rules=[_entry_rsi_lt()], exit_rules=[signal])
+    results = gate.check(spec.strategy_code, spec)
+    [_entry, sig] = results
+    assert sig.passed is True
+    assert sig.rule_id == "exit[0]:signal_exit"
+
+
+def test_sandbox_failure_is_critical():
+    def runner(code, market_data, config, *, strategy=None):
+        return _FakeResult(success=False, error_type="runtime_error", stderr="boom")
+
+    gate = RuleProbesGate(runner=runner)
+    spec = _spec(entry_rules=[_entry_rsi_lt()])
+    [r] = gate.check(spec.strategy_code, spec)
+    assert r.passed is False
+    assert r.severity == "critical"
+    assert "runtime_error" in r.details
+    assert "boom" in r.details
+
+
+# ---------------------------------------------------------------------------
+# Unprobeable predicates surface as warnings
+# ---------------------------------------------------------------------------
+
+
+def test_unprobeable_rule_emits_warning():
+    """An exit-only spec (no entry rule to open a position) is unprobeable.
+    The gate emits a warning rather than a critical."""
+
+    def runner(code, market_data, config, *, strategy=None):
+        # The gate should never invoke the runner for unprobeable rules.
+        raise AssertionError("runner must not be called for unprobeable rules")
+
+    gate = RuleProbesGate(runner=runner)
+    spec = _spec(entry_rules=[], exit_rules=[StopLossRule(pct=0.05)])
+    [r] = gate.check(spec.strategy_code, spec)
+    assert r.severity == "warning"
+    assert r.rule_id == "exit[0]:stop_loss"
+    assert "unprobeable" in r.details.lower()
+
+
+# ---------------------------------------------------------------------------
+# Misc: empty-rule spec, every-result-carries-rule_id invariant
+# ---------------------------------------------------------------------------
+
+
+def test_spec_with_no_rules_returns_info():
+    def runner(code, market_data, config, *, strategy=None):
+        raise AssertionError("runner must not be called when there are no rules")
+
+    gate = RuleProbesGate(runner=runner)
+    spec = _spec(entry_rules=[], exit_rules=[])
+    [r] = gate.check(spec.strategy_code, spec)
+    assert r.severity == "info"
+    assert r.passed is True
+
+
+def test_empty_strategy_code_returns_critical_without_invoking_runner():
+    def runner(code, market_data, config, *, strategy=None):
+        raise AssertionError("runner must not be called when code is empty")
+
+    gate = RuleProbesGate(runner=runner)
+    spec = _spec(entry_rules=[_entry_rsi_lt()], code="")
+    [r] = gate.check("", spec)
+    assert r.severity == "critical"
+
+
+def test_every_result_carries_a_rule_id_or_no_rule():
+    """Invariant: every result from RuleProbesGate either carries a rule_id
+    (a per-rule probe outcome) or is a meta-result with no rule_id."""
+
+    def runner(code, market_data, config, *, strategy=None):
+        return _FakeResult(success=True, trades=[_trade(side="long")])
+
+    gate = RuleProbesGate(runner=runner)
+    spec = _spec(
+        entry_rules=[_entry_rsi_lt()],
+        exit_rules=[StopLossRule(pct=0.05), TakeProfitRule(pct=0.05)],
+    )
+    results = gate.check(spec.strategy_code, spec)
+    # 1 entry + 2 exits = 3 probe results, all with rule_id set.
+    assert len(results) == 3
+    for r in results:
+        assert r.rule_id is not None and r.rule_id.startswith(("entry[", "exit["))
+
+
+def test_runner_is_called_with_tiny_initial_capital_and_zero_costs():
+    seen_configs = []
+
+    def runner(code, market_data, config, *, strategy=None):
+        seen_configs.append(config)
+        return _FakeResult(success=True, trades=[_trade(side="long")])
+
+    gate = RuleProbesGate(runner=runner)
+    spec = _spec(entry_rules=[_entry_rsi_lt()])
+    gate.check(spec.strategy_code, spec)
+    assert seen_configs, "runner was never invoked"
+    cfg = seen_configs[0]
+    assert cfg.initial_capital == 1_000.0
+    assert cfg.transaction_cost_bps == 0.0
+    assert cfg.slippage_bps == 0.0
+
+
+def test_runner_receives_synthesised_market_data_keyed_by_target_symbol():
+    seen_md = []
+
+    def runner(code, market_data, config, *, strategy=None):
+        seen_md.append(market_data)
+        return _FakeResult(success=True, trades=[_trade(side="long")])
+
+    gate = RuleProbesGate(runner=runner)
+    spec = _spec(entry_rules=[_entry_rsi_lt()])  # target_symbols=["PROBE"]
+    gate.check(spec.strategy_code, spec)
+    assert seen_md and "PROBE" in seen_md[0]
+    assert len(seen_md[0]["PROBE"]) > 0

--- a/backend/agents/investment_team/tests/test_rule_probes_gate.py
+++ b/backend/agents/investment_team/tests/test_rule_probes_gate.py
@@ -39,12 +39,16 @@ class _FakeResult:
 def _trade(
     *,
     side: str = "long",
-    entry_date: str = "2024-01-50",
-    exit_date: str = "2024-02-01",
+    entry_date: str = "9999-01-01",
+    exit_date: str = "9999-12-31",
     exit_reason: Optional[str] = None,
     shares: float = 10.0,
     symbol: str = "PROBE",
 ) -> TradeRecord:
+    """Build a fake TradeRecord. Default dates are deliberately well after
+    any plausible probe trigger so the asserter's trigger-timing checks
+    accept the trade — tests that need to exercise the early-trade
+    rejection paths pass explicit early dates."""
     return TradeRecord(
         trade_num=1,
         entry_date=entry_date,

--- a/backend/agents/investment_team/tests/test_rule_probes_orchestrator.py
+++ b/backend/agents/investment_team/tests/test_rule_probes_orchestrator.py
@@ -1,0 +1,242 @@
+"""Orchestrator-level wiring tests for the rule-probes gate.
+
+The synthesis loop runs validate → fetch → execute → evaluate. These
+tests stub the gates so the loop short-circuits inside the validate
+phase, which is where the rule-probes wiring lives. We then assert:
+
+1. ``rule_probes_gate.check`` is invoked when ``CodeConformanceGate`` has
+   no critical failures.
+2. ``rule_probes_gate.check`` is **not** invoked when conformance returns
+   a critical (probing already-broken code yields noisy diagnostics on
+   top of the cleaner conformance critical).
+3. Probe-critical results are routed through ``_refine_or_exhaust`` with
+   ``failure_phase="validation"`` and the failing ``rule_id`` surfaced in
+   ``failure_details``.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from investment_team.models import BacktestConfig, StrategySpec
+from investment_team.strategy_lab.orchestrator import StrategyLabOrchestrator
+from investment_team.strategy_lab.quality_gates.models import QualityGateResult
+from investment_team.strategy_lab.spec_dsl import (
+    EntryRule,
+    IndicatorRef,
+    Predicate,
+)
+
+
+def _info_result(gate_name: str, *, phase: str = "synthesis") -> QualityGateResult:
+    return QualityGateResult(
+        gate_name=gate_name,
+        passed=True,
+        details="ok",
+        severity="info",
+        phase=phase,
+    )
+
+
+def _critical_result(gate_name: str, *, rule_id=None) -> QualityGateResult:
+    return QualityGateResult(
+        gate_name=gate_name,
+        passed=False,
+        details=f"forced critical from {gate_name}",
+        severity="critical",
+        phase="synthesis",
+        rule_id=rule_id,
+    )
+
+
+def _minimal_spec() -> StrategySpec:
+    return StrategySpec(
+        strategy_id="orch-test",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="h",
+        signal_definition="s",
+        timeframe="1d",
+        entry_rules=[
+            EntryRule(
+                side="long",
+                when=Predicate(
+                    lhs=IndicatorRef(name="rsi", params={"period": 14}),
+                    op="<",
+                    rhs=30.0,
+                ),
+            )
+        ],
+        target_symbols=["PROBE"],
+        strategy_code="class S:\n    pass\n",
+    )
+
+
+def _minimal_config() -> BacktestConfig:
+    return BacktestConfig(
+        start_date="2024-01-01",
+        end_date="2024-03-01",
+        initial_capital=1_000.0,
+        transaction_cost_bps=0.0,
+        slippage_bps=0.0,
+    )
+
+
+def _stub_clean_gates(orch: StrategyLabOrchestrator) -> None:
+    """Force every gate that runs before rule_probes to return clean."""
+    orch.spec_readiness_gate.validate = lambda spec, **kw: [_info_result("spec_readiness")]
+    orch.code_safety_checker.check = lambda code, spec: [_info_result("code_safety")]
+    orch.code_conformance_gate.check = lambda code, spec: [_info_result("code_conformance")]
+
+
+# ---------------------------------------------------------------------------
+# Wiring test 1: probe gate runs when conformance is clean
+# ---------------------------------------------------------------------------
+
+
+def test_probe_gate_runs_when_conformance_is_clean(monkeypatch):
+    orch = StrategyLabOrchestrator()
+    _stub_clean_gates(orch)
+
+    invocations: List[tuple] = []
+
+    def fake_probe_check(code, spec, *, phase="synthesis"):
+        invocations.append((code, spec))
+        return [_critical_result("rule_probes", rule_id="entry[0]")]
+
+    orch.rule_probes_gate.check = fake_probe_check
+
+    # Capture _refine_or_exhaust calls and immediately exhaust so the loop
+    # terminates after round 1.
+    captured: List[dict] = []
+
+    def fake_refine(*, spec, code, failure_phase, failure_details, **kw):
+        captured.append(
+            {"failure_phase": failure_phase, "failure_details": failure_details}
+        )
+        return spec, code, True  # exhausted
+
+    orch._refine_or_exhaust = fake_refine
+
+    spec = _minimal_spec()
+    outcome = orch._run_synthesis_loop(
+        spec=spec,
+        code=spec.strategy_code,
+        config=_minimal_config(),
+        all_gate_results=[],
+        refinement_attempts=[],
+        zero_trade_attempts=[],
+        emit=lambda *args, **kwargs: None,
+    )
+
+    assert invocations, "rule_probes_gate.check should run when conformance is clean"
+    assert captured, "_refine_or_exhaust should be invoked on probe-critical failure"
+    assert captured[0]["failure_phase"] == "validation"
+    # rule_id must be surfaced in the aggregated failure details so the
+    # refinement agent can target the failing branch.
+    assert "rule_probes:entry[0]" in captured[0]["failure_details"]
+    assert outcome.max_rounds_exhausted is True
+
+
+# ---------------------------------------------------------------------------
+# Wiring test 2: probe gate is skipped when conformance is dirty
+# ---------------------------------------------------------------------------
+
+
+def test_probe_gate_skipped_when_conformance_emits_critical():
+    orch = StrategyLabOrchestrator()
+    orch.spec_readiness_gate.validate = lambda spec, **kw: [_info_result("spec_readiness")]
+    orch.code_safety_checker.check = lambda code, spec: [_info_result("code_safety")]
+    # Conformance returns a critical — probe gate must NOT be invoked.
+    orch.code_conformance_gate.check = lambda code, spec: [_critical_result("code_conformance")]
+
+    probe_called = []
+
+    def fake_probe_check(code, spec, *, phase="synthesis"):
+        probe_called.append(True)
+        return [_info_result("rule_probes")]
+
+    orch.rule_probes_gate.check = fake_probe_check
+    orch._refine_or_exhaust = lambda **kw: (kw["spec"], kw["code"], True)
+
+    spec = _minimal_spec()
+    orch._run_synthesis_loop(
+        spec=spec,
+        code=spec.strategy_code,
+        config=_minimal_config(),
+        all_gate_results=[],
+        refinement_attempts=[],
+        zero_trade_attempts=[],
+        emit=lambda *args, **kwargs: None,
+    )
+
+    assert probe_called == [], (
+        "rule_probes_gate.check must not run when CodeConformanceGate emits a critical"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Wiring test 3: rule_id flows through to failure_details verbatim
+# ---------------------------------------------------------------------------
+
+
+def test_failure_details_format_includes_rule_id():
+    orch = StrategyLabOrchestrator()
+    _stub_clean_gates(orch)
+    orch.rule_probes_gate.check = lambda code, spec, **kw: [
+        _critical_result("rule_probes", rule_id="exit[2]:stop_loss"),
+        _critical_result("rule_probes", rule_id="entry[0]"),
+    ]
+
+    captured: List[dict] = []
+    orch._refine_or_exhaust = lambda **kw: (
+        captured.append({"details": kw["failure_details"]}) or (kw["spec"], kw["code"], True)
+    )
+
+    spec = _minimal_spec()
+    orch._run_synthesis_loop(
+        spec=spec,
+        code=spec.strategy_code,
+        config=_minimal_config(),
+        all_gate_results=[],
+        refinement_attempts=[],
+        zero_trade_attempts=[],
+        emit=lambda *args, **kwargs: None,
+    )
+
+    assert captured, "_refine_or_exhaust must be invoked"
+    details = captured[0]["details"]
+    # Both rule_ids appear in their bracketed prefix form.
+    assert "[rule_probes:exit[2]:stop_loss]" in details
+    assert "[rule_probes:entry[0]]" in details
+
+
+# ---------------------------------------------------------------------------
+# Wiring test 4: record_gates captures probe entries (with rule_id) in
+# the orchestrator's running gate-results list
+# ---------------------------------------------------------------------------
+
+
+def test_record_gates_captures_probe_results_with_rule_id():
+    orch = StrategyLabOrchestrator()
+    _stub_clean_gates(orch)
+    orch.rule_probes_gate.check = lambda code, spec, **kw: [
+        _critical_result("rule_probes", rule_id="entry[0]"),
+    ]
+    orch._refine_or_exhaust = lambda **kw: (kw["spec"], kw["code"], True)
+
+    all_results: List[QualityGateResult] = []
+    spec = _minimal_spec()
+    orch._run_synthesis_loop(
+        spec=spec,
+        code=spec.strategy_code,
+        config=_minimal_config(),
+        all_gate_results=all_results,
+        refinement_attempts=[],
+        zero_trade_attempts=[],
+        emit=lambda *args, **kwargs: None,
+    )
+
+    probe_results = [r for r in all_results if r.gate_name == "rule_probes"]
+    assert probe_results, "rule_probes results must be recorded in all_gate_results"
+    assert probe_results[0].rule_id == "entry[0]"

--- a/backend/agents/investment_team/tests/test_rule_probes_orchestrator.py
+++ b/backend/agents/investment_team/tests/test_rule_probes_orchestrator.py
@@ -143,6 +143,70 @@ def test_probe_gate_runs_when_conformance_is_clean(monkeypatch):
 # ---------------------------------------------------------------------------
 
 
+def test_probe_gate_skipped_when_any_prior_validation_gate_emits_critical():
+    """Probe execution is bounded behind *every* prior validation gate,
+    not just conformance. A critical from code_safety, spec_readiness, or
+    any earlier emitter must short-circuit the probe to avoid sandbox
+    cost on code we already know is rejected."""
+    orch = StrategyLabOrchestrator()
+    # spec_readiness emits a critical — code_safety/conformance happen to
+    # be clean. Probe must not run.
+    orch.spec_readiness_gate.validate = lambda spec, **kw: [
+        _critical_result("spec_readiness")
+    ]
+    orch.code_safety_checker.check = lambda code, spec: [_info_result("code_safety")]
+    orch.code_conformance_gate.check = lambda code, spec: [_info_result("code_conformance")]
+
+    probe_called = []
+    orch.rule_probes_gate.check = lambda code, spec, **kw: (
+        probe_called.append(True) or [_info_result("rule_probes")]
+    )
+    orch._refine_or_exhaust = lambda **kw: (kw["spec"], kw["code"], True)
+
+    spec = _minimal_spec()
+    orch._run_synthesis_loop(
+        spec=spec,
+        code=spec.strategy_code,
+        config=_minimal_config(),
+        all_gate_results=[],
+        refinement_attempts=[],
+        zero_trade_attempts=[],
+        emit=lambda *args, **kwargs: None,
+    )
+    assert probe_called == [], (
+        "rule_probes_gate.check must not run when an earlier validation gate "
+        "(spec_readiness, code_safety) emitted a critical"
+    )
+
+
+def test_probe_gate_skipped_when_code_safety_emits_critical():
+    """Same invariant for code_safety: probe must not pay sandbox cost
+    when code_safety has already produced a critical that drives the
+    refinement loop."""
+    orch = StrategyLabOrchestrator()
+    orch.spec_readiness_gate.validate = lambda spec, **kw: [_info_result("spec_readiness")]
+    orch.code_safety_checker.check = lambda code, spec: [_critical_result("code_safety")]
+    orch.code_conformance_gate.check = lambda code, spec: [_info_result("code_conformance")]
+
+    probe_called = []
+    orch.rule_probes_gate.check = lambda code, spec, **kw: (
+        probe_called.append(True) or [_info_result("rule_probes")]
+    )
+    orch._refine_or_exhaust = lambda **kw: (kw["spec"], kw["code"], True)
+
+    spec = _minimal_spec()
+    orch._run_synthesis_loop(
+        spec=spec,
+        code=spec.strategy_code,
+        config=_minimal_config(),
+        all_gate_results=[],
+        refinement_attempts=[],
+        zero_trade_attempts=[],
+        emit=lambda *args, **kwargs: None,
+    )
+    assert probe_called == []
+
+
 def test_probe_gate_skipped_when_conformance_emits_critical():
     orch = StrategyLabOrchestrator()
     orch.spec_readiness_gate.validate = lambda spec, **kw: [_info_result("spec_readiness")]

--- a/backend/agents/investment_team/tests/test_rule_probes_synthesis.py
+++ b/backend/agents/investment_team/tests/test_rule_probes_synthesis.py
@@ -1,0 +1,354 @@
+"""Per-recipe correctness tests for the bar-synthesiser.
+
+These tests do not invoke the sandbox — they only check that each
+recipe produces a series in which the target predicate evaluates True
+on the recorded trigger bar, using the same indicator helpers the
+compiler emits calls to.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pandas as pd
+import pytest
+
+from investment_team.strategy_lab.executor.indicators import ema, rsi, sma
+from investment_team.strategy_lab.quality_gates.rule_probes.synthesizer import (
+    ProbeRun,
+    _bars_to_df,
+    _compare,
+    _compute_indicator_at,
+    _synthesise_for_predicate,
+    _verify_cross,
+    generate_rule_probe_runs,
+)
+from investment_team.strategy_lab.spec_dsl import (
+    EntryRule,
+    IndicatorRef,
+    Predicate,
+    SignalExitRule,
+    StopLossRule,
+    TakeProfitRule,
+)
+
+
+def _spec_with(entry_rules=None, exit_rules=None, target_symbols=None):
+    """Build the minimal spec shape ``generate_rule_probe_runs`` needs."""
+
+    class _MiniSpec:
+        pass
+
+    s = _MiniSpec()
+    s.entry_rules = entry_rules or []
+    s.exit_rules = exit_rules or []
+    s.target_symbols = target_symbols or []
+    return s
+
+
+# ---------------------------------------------------------------------------
+# Trivial: PriceRef vs number
+# ---------------------------------------------------------------------------
+
+
+def test_priceref_close_lt_number_satisfies_at_trigger():
+    pred = Predicate(lhs="bar.close", op="<", rhs=50.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    assert bars[trigger].close < 50.0
+
+
+def test_priceref_close_gt_number_satisfies_at_trigger():
+    pred = Predicate(lhs="bar.close", op=">", rhs=120.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    assert bars[trigger].close > 120.0
+
+
+# ---------------------------------------------------------------------------
+# RSI threshold recipes
+# ---------------------------------------------------------------------------
+
+
+def test_rsi_lt_recipe_satisfies_predicate():
+    ref = IndicatorRef(name="rsi", params={"period": 14})
+    pred = Predicate(lhs=ref, op="<", rhs=30.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    series = pd.Series([b.close for b in bars])
+    value = rsi(series, period=14).iloc[trigger]
+    assert math.isfinite(value)
+    assert value < 30.0
+
+
+def test_rsi_gt_recipe_satisfies_predicate():
+    ref = IndicatorRef(name="rsi", params={"period": 14})
+    pred = Predicate(lhs=ref, op=">", rhs=70.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    series = pd.Series([b.close for b in bars])
+    value = rsi(series, period=14).iloc[trigger]
+    assert math.isfinite(value)
+    assert value > 70.0
+
+
+# ---------------------------------------------------------------------------
+# SMA threshold recipe (sanity — flat line at level)
+# ---------------------------------------------------------------------------
+
+
+def test_sma_gt_recipe_satisfies_predicate():
+    ref = IndicatorRef(name="sma", params={"period": 20})
+    pred = Predicate(lhs=ref, op=">", rhs=100.0)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    series = pd.Series([b.close for b in bars])
+    value = sma(series, 20).iloc[trigger]
+    assert math.isfinite(value) and value > 100.0
+
+
+# ---------------------------------------------------------------------------
+# Cross_above / cross_below recipes — must satisfy the (prev, curr) pair
+# semantics the compiler's predicate emitter uses.
+# ---------------------------------------------------------------------------
+
+
+def test_close_cross_above_sma_uses_prev_curr_pair_semantics():
+    ref = IndicatorRef(name="sma", params={"period": 20})
+    pred = Predicate(lhs="bar.close", op="cross_above", rhs=ref)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    series = pd.Series([b.close for b in bars])
+    ma = sma(series, 20)
+    assert _verify_cross(
+        series.iloc[trigger - 1],
+        series.iloc[trigger],
+        ma.iloc[trigger - 1],
+        ma.iloc[trigger],
+        "cross_above",
+    )
+
+
+def test_close_cross_below_sma_uses_prev_curr_pair_semantics():
+    ref = IndicatorRef(name="sma", params={"period": 20})
+    pred = Predicate(lhs="bar.close", op="cross_below", rhs=ref)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    series = pd.Series([b.close for b in bars])
+    ma = sma(series, 20)
+    assert _verify_cross(
+        series.iloc[trigger - 1],
+        series.iloc[trigger],
+        ma.iloc[trigger - 1],
+        ma.iloc[trigger],
+        "cross_below",
+    )
+
+
+def test_close_cross_above_ema_uses_prev_curr_pair_semantics():
+    ref = IndicatorRef(name="ema", params={"period": 10})
+    pred = Predicate(lhs="bar.close", op="cross_above", rhs=ref)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    series = pd.Series([b.close for b in bars])
+    ma = ema(series, 10)
+    assert _verify_cross(
+        series.iloc[trigger - 1],
+        series.iloc[trigger],
+        ma.iloc[trigger - 1],
+        ma.iloc[trigger],
+        "cross_above",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Indicator-vs-indicator: SMA-fast crosses SMA-slow at the regime change
+# ---------------------------------------------------------------------------
+
+
+def test_sma_fast_gt_sma_slow_two_regime():
+    fast = IndicatorRef(name="sma", params={"period": 5})
+    slow = IndicatorRef(name="sma", params={"period": 20})
+    pred = Predicate(lhs=fast, op=">", rhs=slow)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    series = pd.Series([b.close for b in bars])
+    assert sma(series, 5).iloc[trigger] > sma(series, 20).iloc[trigger]
+
+
+def test_sma_fast_cross_above_sma_slow():
+    fast = IndicatorRef(name="sma", params={"period": 5})
+    slow = IndicatorRef(name="sma", params={"period": 30})
+    pred = Predicate(lhs=fast, op="cross_above", rhs=slow)
+    bars, trigger, reason = _synthesise_for_predicate(pred)
+    assert reason is None and bars is not None
+    series = pd.Series([b.close for b in bars])
+    fast_s = sma(series, 5)
+    slow_s = sma(series, 30)
+    assert _verify_cross(
+        fast_s.iloc[trigger - 1],
+        fast_s.iloc[trigger],
+        slow_s.iloc[trigger - 1],
+        slow_s.iloc[trigger],
+        "cross_above",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stop-loss and take-profit tail recipes
+# ---------------------------------------------------------------------------
+
+
+def test_stop_loss_long_tail_last_bar_violates_floor():
+    entry_rule = EntryRule(
+        side="long",
+        when=Predicate(lhs="bar.close", op=">", rhs=50.0),
+    )
+    stop = StopLossRule(pct=0.03)
+    runs = generate_rule_probe_runs(
+        _spec_with(entry_rules=[entry_rule], exit_rules=[stop])
+    )
+    [_entry, exit_probe] = runs
+    assert exit_probe.synthesizable
+    entry_bars = exit_probe.market_data[: exit_probe.trigger_bar_index]
+    trigger_bar = exit_probe.market_data[exit_probe.trigger_bar_index]
+    # The opening trade fires at the entry recipe's trigger bar; use that
+    # bar's close as the reference entry price.
+    entry_close = entry_bars[-1].close if entry_bars else trigger_bar.close
+    assert trigger_bar.low <= entry_close * (1.0 - stop.pct)
+
+
+def test_take_profit_long_tail_last_bar_breaches_target():
+    entry_rule = EntryRule(
+        side="long",
+        when=Predicate(lhs="bar.close", op=">", rhs=50.0),
+    )
+    tp = TakeProfitRule(pct=0.05)
+    runs = generate_rule_probe_runs(
+        _spec_with(entry_rules=[entry_rule], exit_rules=[tp])
+    )
+    [_entry, exit_probe] = runs
+    assert exit_probe.synthesizable
+    entry_bars = exit_probe.market_data[: exit_probe.trigger_bar_index]
+    trigger_bar = exit_probe.market_data[exit_probe.trigger_bar_index]
+    entry_close = entry_bars[-1].close if entry_bars else trigger_bar.close
+    assert trigger_bar.high >= entry_close * (1.0 + tp.pct)
+
+
+def test_signal_exit_tail_satisfies_predicate_after_entry_prefix():
+    entry_rule = EntryRule(
+        side="long",
+        when=Predicate(lhs="bar.close", op=">", rhs=50.0),
+    )
+    signal = SignalExitRule(when=Predicate(lhs="bar.close", op="<", rhs=10.0))
+    runs = generate_rule_probe_runs(
+        _spec_with(entry_rules=[entry_rule], exit_rules=[signal])
+    )
+    [_entry, exit_probe] = runs
+    assert exit_probe.synthesizable
+    trigger_bar = exit_probe.market_data[exit_probe.trigger_bar_index]
+    assert trigger_bar.close < 10.0
+
+
+# ---------------------------------------------------------------------------
+# Unprobeable: exit rule with no entry rule cannot open a position
+# ---------------------------------------------------------------------------
+
+
+def test_exit_probe_without_entry_rule_marks_unprobeable():
+    stop = StopLossRule(pct=0.05)
+    runs = generate_rule_probe_runs(_spec_with(entry_rules=[], exit_rules=[stop]))
+    assert len(runs) == 1
+    probe: ProbeRun = runs[0]
+    assert not probe.synthesizable
+    assert "no_entry_rules" in (probe.unprobeable_reason or "")
+
+
+# ---------------------------------------------------------------------------
+# Symbol resolution
+# ---------------------------------------------------------------------------
+
+
+def test_target_symbols_first_used_as_probe_symbol():
+    entry_rule = EntryRule(
+        side="long",
+        when=Predicate(lhs="bar.close", op=">", rhs=50.0),
+    )
+    runs = generate_rule_probe_runs(
+        _spec_with(entry_rules=[entry_rule], target_symbols=["AAPL", "MSFT"])
+    )
+    assert runs[0].symbol == "AAPL"
+
+
+def test_empty_target_symbols_falls_back_to_universe_then_sentinel():
+    entry_rule = EntryRule(
+        side="long",
+        when=Predicate(lhs="bar.close", op=">", rhs=50.0),
+    )
+    # No compiled code → no UNIVERSE → sentinel.
+    runs = generate_rule_probe_runs(_spec_with(entry_rules=[entry_rule]))
+    assert runs[0].symbol == "PROBE"
+    # Compiled code with UNIVERSE — sentinel becomes the first member.
+    code = "UNIVERSE = frozenset({'TEST1', 'TEST2'})\n"
+    runs = generate_rule_probe_runs(
+        _spec_with(entry_rules=[entry_rule]), compiled_code=code
+    )
+    assert runs[0].symbol in ("TEST1", "TEST2")
+
+
+# ---------------------------------------------------------------------------
+# Cross-semantics helper unit
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "prev_l, cur_l, prev_r, cur_r, op, expected",
+    [
+        (10.0, 12.0, 11.0, 11.0, "cross_above", True),
+        (10.0, 12.0, 11.0, 13.0, "cross_above", False),
+        (12.0, 10.0, 11.0, 11.0, "cross_below", True),
+        (12.0, 10.0, 11.0, 9.0, "cross_below", False),
+        (float("nan"), 12.0, 11.0, 11.0, "cross_above", False),
+    ],
+)
+def test_verify_cross_semantics(prev_l, cur_l, prev_r, cur_r, op, expected):
+    assert _verify_cross(prev_l, cur_l, prev_r, cur_r, op) is expected
+
+
+# ---------------------------------------------------------------------------
+# Indicator helper integration — _compute_indicator_at returns floats
+# ---------------------------------------------------------------------------
+
+
+def test_compute_indicator_at_for_sma_returns_finite_float():
+    ref = IndicatorRef(name="sma", params={"period": 5})
+    bars, trigger, reason = _synthesise_for_predicate(
+        Predicate(lhs=ref, op=">", rhs=100.0)
+    )
+    assert reason is None and bars is not None
+    value = _compute_indicator_at(ref, bars, trigger)
+    assert value is not None and math.isfinite(value)
+
+
+def test_compare_semantics_match_compiler_predicate_emitter():
+    # Spot-check operator semantics so future refactors don't drift.
+    assert _compare(1.0, "<", 2.0) is True
+    assert _compare(2.0, "<", 1.0) is False
+    assert _compare(2.0, "==", 2.0) is True
+    assert _compare(2.0, ">=", 2.0) is True
+    assert _compare(1.0, "cross_above", 2.0) is False  # cross_* never matches at the helper level
+
+
+# ---------------------------------------------------------------------------
+# _bars_to_df helper round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_bars_to_df_columns_match_ohlcv():
+    entry_rule = EntryRule(
+        side="long",
+        when=Predicate(lhs="bar.close", op=">", rhs=50.0),
+    )
+    runs = generate_rule_probe_runs(_spec_with(entry_rules=[entry_rule]))
+    df = _bars_to_df(runs[0].market_data)
+    assert set(df.columns) == {"open", "high", "low", "close", "volume"}

--- a/backend/agents/investment_team/tests/test_strategy_lab_refinement_freeze.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_refinement_freeze.py
@@ -498,6 +498,11 @@ def test_run_cycle_reroutes_on_stray_key_threshold(
     monkeypatch.setattr(orch.spec_readiness_gate, "validate", lambda *a, **kw: [])
     monkeypatch.setattr(orch.code_safety_checker, "check", lambda code, spec=None: [])
     monkeypatch.setattr(orch.strategy_validator, "validate", lambda s: [])
+    # Probe gate runs after CodeConformanceGate; this test asserts on
+    # ``failure_phase="execution"``, but the probe would route the
+    # ``# design code`` stub into validation. Stub the gate out so the
+    # synthesis loop reaches the execute phase the test exercises.
+    monkeypatch.setattr(orch.rule_probes_gate, "check", lambda *a, **kw: [])
 
     # Force every execution to fail so the loop stays in the "execution"
     # failure_phase and accumulates stray-key rounds against a single


### PR DESCRIPTION
## Summary

`CodeConformanceGate` proves the compiled strategy code *looks* right (correct indicators present, exit branches wired, sizing math sane). It can be fooled by code that's shaped right and wired wrong — a swapped comparator, a negated exit predicate, an entry branch whose order submission is silently unreachable.

This PR adds the **behavioural** complement: for every rule in the spec, the new `RuleProbesGate` generates a deterministic OHLCV sequence designed to make that rule's predicate evaluate `True`, runs the compiled code through the existing `run_strategy_code` sandbox with tiny initial capital and zero costs, and asserts the resulting `TradeRecord` envelope matches the expected order or exit. Probe-criticals route back to synthesis with the failing `rule_id` in `failure_details` so the refinement agent can target the specific branch.

- New package `backend/agents/investment_team/strategy_lab/quality_gates/rule_probes/` (`synthesizer.py`, `asserter.py`, `gate.py`).
- `QualityGateResult` gains an optional `rule_id`; the orchestrator's failure-details join surfaces it as `[rule_probes:entry[0]]` / `[rule_probes:exit[1]:stop_loss]`.
- The gate runs **after** `CodeConformanceGate` in the synthesis loop and only when conformance is clean — probing already-broken code adds noisy `rule_id` criticals on top of the cleaner conformance critical.
- Recipes cover `EntryRule` (price/indicator/indicator-cross predicates over RSI, SMA/EMA, MACD, Bollinger, ATR, ADX, Stochastic, VWAP), `StopLossRule`, `TakeProfitRule`, `SignalExitRule`. Predicate-verification uses the same `executor/indicators.py` helpers the compiler emits.
- Bar synthesis is heuristic; unprobeable predicates surface as `severity="warning"` (passed=True) rather than blocking the synthesis loop. Documented limitation: `SignalExitRule` asserts an `exit_reason` substring of `"signal_exit"`, which matches the compiler-emitted `"compiled_signal_exit"`; legacy LLM-authored close orders with other reason strings will fail this probe.
- Pure / deterministic; no LLM calls. Per-probe runtime is bounded by the sandbox subprocess (~0.2–1.0 s) — well within the 5 s/probe budget.
- TimeStopRule is deliberately out of scope (the DSL omits it; `spec_dsl.py` documents the omission as "real traders close on price, P&L, or signal reversal").

Incidental fix: the `rsi()` helper in `strategy_lab/executor/indicators.py` was incompatible with pandas 3.x (`Series.fillna()` rejects ndarray). The new tests are the first callers to exercise it directly; wrapped the `np.where` result in a `pd.Series` so the helper works on the pinned pandas version.

## Test plan

- [ ] `cd backend && make lint` — ruff clean.
- [ ] `pytest agents/investment_team/tests/test_rule_probes_synthesis.py agents/investment_team/tests/test_rule_probes_gate.py agents/investment_team/tests/test_rule_probes_orchestrator.py agents/investment_team/tests/test_rule_probes_extended.py -v` — 106 tests green.
- [ ] `pytest agents/investment_team/tests/test_rule_probes_*.py --cov=agents/investment_team/strategy_lab/quality_gates/rule_probes --cov-report=term-missing` — confirm ≥95 % line coverage on the new package (currently 95.54 %).
- [ ] `pytest agents/investment_team/tests/ -q` — full investment-team suite green (1717 passed, 14 skipped).
- [ ] Spot-check the two acceptance scenarios named in the source issue:
  - `test_swapped_comparator_fails_rsi_entry_probe` (RSI`>` strategy fails the `RSI<30` probe).
  - `test_missing_stop_loss_branch_fails_stop_loss_probe` (strategy lacking the engine-exit handling fails the `StopLossRule` probe).

https://claude.ai/code/session_01PexXyLcschd2ZAhhYce44N

---
_Generated by [Claude Code](https://claude.ai/code/session_01PexXyLcschd2ZAhhYce44N)_