### PR TITLE
investment_team: convert paper-trade API fixture tests to in-memory unit tests

### DIFF
--- a/backend/agents/investment_team/tests/test_paper_trade_api_fixes.py
+++ b/backend/agents/investment_team/tests/test_paper_trade_api_fixes.py
@@ -8,8 +8,9 @@ Covers:
   legacy RUNNING state, so SIGKILL orphans cannot block the new
   per-strategy concurrency guard.
 
-Calls real ``investment_team.shared.job_store``.  Marked integration
-pending follow-up to use the in-memory fake.
+The recovery tests run against an in-memory ``FakeJobServiceClient`` swapped
+into the module-level ``_paper_trading_sessions`` ``_PersistentDict`` so the
+suite no longer requires Postgres or a live job-service.
 """
 
 from __future__ import annotations
@@ -28,7 +29,21 @@ from investment_team.models import (
     StrategySpec,
 )
 
-pytestmark = [pytest.mark.integration]
+
+@pytest.fixture(autouse=True)
+def _patched_paper_trading_client(monkeypatch, fake_job_client):
+    """Redirect the paper-trading ``_PersistentDict`` at the in-memory fake.
+
+    Preconditions: ``_paper_trading_sessions`` exposes a ``_client`` attribute
+    matching the ``JobServiceClient`` interface (``get_job``, ``create_job``,
+    ``update_job``, ``delete_job``, ``list_jobs``).
+    Postconditions: every ``_paper_trading_sessions`` read/write inside this
+    test routes through ``fake_job_client``; the original client is restored
+    after the test by ``monkeypatch``.
+    """
+    monkeypatch.setattr(_paper_trading_sessions, "_client", fake_job_client)
+    return fake_job_client
+
 
 # ---------------------------------------------------------------------------
 # Fee-override resolution


### PR DESCRIPTION
## Summary

- Convert `backend/agents/investment_team/tests/test_paper_trade_api_fixes.py` from a `@pytest.mark.integration` suite to a pure unit-test suite by swapping the module-level `_paper_trading_sessions` `_PersistentDict`'s `_client` attribute for the shared `FakeJobServiceClient` via an autouse fixture.
- All 9 tests now run in ~1s without Postgres or a live job-service, and the file is collected in the default (non-integration) CI lane.

## Why patch the instance attribute, not `job_store._client()`

The original task description suggested patching `investment_team.shared.job_store._client`. That target is wrong for this file — none of the tests touch `shared.job_store`. The recovery code reads/writes `_paper_trading_sessions`, a `_PersistentDict` defined in `backend/agents/investment_team/api/main.py` that constructs its own `JobServiceClient(team="investment_paper_trading_sessions")` directly in `__init__`, bypassing the factory. The minimal correct patch is therefore on the live `_paper_trading_sessions` instance.

The `FakeJobServiceClient` already implements every method `_PersistentDict` calls (`get_job`, `create_job`, `update_job`, `delete_job`, `list_jobs`), so no extra shim is needed.

## Test plan

- [x] `python3 -m pytest backend/agents/investment_team/tests/test_paper_trade_api_fixes.py -v` — **9 passed in 0.95s**
- [x] `pytest -m integration --collect-only` — file no longer collected (9 deselected)
- [x] `pytest -m "not integration" --collect-only` — 9 tests collected
- [x] `ruff check` + `ruff format --check` clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01RX27D7CtSqmyUQJfHpmptf)_