### PR TITLE
investment_team: count SpecImplementabilityError phase-backs as DSR trials

### DIFF
--- a/backend/agents/investment_team/models.py
+++ b/backend/agents/investment_team/models.py
@@ -867,6 +867,16 @@ class StrategyLabRecord(BaseModel):
             "rounds)."
         ),
     )
+    spec_implementability_phase_backs: int = Field(
+        default=0,
+        description=(
+            "Number of times this cycle phased back to the design step "
+            "because a downstream phase raised SpecImplementabilityError. "
+            "Each phase-back also contributes one trial to the convergence "
+            "tracker so DSR deflation reflects the multiple-testing cost "
+            "of the failed attempts. 0 on the happy path and on legacy rows."
+        ),
+    )
     critiques: List[Dict[str, Any]] = Field(
         default_factory=list,
         description=(

--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -572,6 +572,15 @@ class StrategyLabOrchestrator:
         last_spec: Optional[StrategySpec] = None
         last_code: str = ""
         last_failure_phase: Optional[str] = None
+        # Counts every ``SpecImplementabilityError`` raised within this
+        # ``run_cycle``, including the final raise that exhausts the
+        # re-entry budget. Threaded into ``_run_design_attempt`` so the
+        # persisted record (success or short-circuit) reflects the
+        # phase-back history, and used to advance the DSR trial counter
+        # by one per phase-back: each failed attempt consumed real LLM
+        # work on the same evaluation window and so contributes to the
+        # multiple-testing burden that DSR deflation corrects for.
+        phase_back_count: int = 0
         for design_attempt in range(MAX_DESIGN_REENTRIES + 1):
             try:
                 return self._run_design_attempt(
@@ -582,12 +591,15 @@ class StrategyLabOrchestrator:
                     exclude_asset_classes=exclude_asset_classes,
                     directives=directives,
                     design_attempt=design_attempt,
+                    phase_back_count=phase_back_count,
                 )
             except SpecImplementabilityError as exc:
                 last_evidence = exc.evidence
                 last_spec = exc.last_spec
                 last_code = exc.last_code
                 last_failure_phase = exc.failure_phase
+                phase_back_count += 1
+                self.convergence_tracker.increment_trials(1)
                 if design_attempt >= MAX_DESIGN_REENTRIES:
                     break
                 emit(
@@ -595,6 +607,7 @@ class StrategyLabOrchestrator:
                     {
                         "sub_phase": "loopback",
                         "design_attempt": design_attempt + 1,
+                        "phase_back_count": phase_back_count,
                         "evidence": exc.evidence,
                         "failure_phase": exc.failure_phase,
                     },
@@ -629,6 +642,7 @@ class StrategyLabOrchestrator:
                 f"(last failure_phase={last_failure_phase}): {last_evidence}"
             ),
             emit=emit,
+            phase_back_count=phase_back_count,
         )
 
     def _run_design_loop(
@@ -826,6 +840,7 @@ class StrategyLabOrchestrator:
         rationale: str,
         refinement_attempts: List[Dict[str, Any]],
         emit: PhaseCallback,
+        phase_back_count: int = 0,
     ) -> Optional[StrategyLabRecord]:
         """Run spec validation before the refinement loop.
 
@@ -887,6 +902,7 @@ class StrategyLabOrchestrator:
                 + "; ".join(g.details for g in criticals)
             ),
             emit=emit,
+            phase_back_count=phase_back_count,
         )
 
     def _run_synthesis_loop(
@@ -1984,6 +2000,7 @@ class StrategyLabOrchestrator:
         emit: PhaseCallback,
         design_context: Optional[_DesignPersistContext] = None,
         alignment_findings: Optional[List[AlignmentFinding]] = None,
+        phase_back_count: int = 0,
     ) -> StrategyLabRecord:
         """Build the final ``StrategyLabRecord`` from a settled cycle.
 
@@ -2064,6 +2081,7 @@ class StrategyLabOrchestrator:
             strategy_code=code,
             original_spec=original_spec,
             original_code=original_code,
+            spec_implementability_phase_backs=phase_back_count,
         )
 
         self.convergence_tracker.record(spec, all_gate_results)
@@ -2077,6 +2095,7 @@ class StrategyLabOrchestrator:
                 "refinement_rounds": refinement_rounds,
                 "alignment_rounds": alignment_rounds,
                 "trades_aligned": trades_aligned,
+                "phase_back_count": phase_back_count,
             },
         )
 
@@ -2092,6 +2111,7 @@ class StrategyLabOrchestrator:
         exclude_asset_classes: Optional[List[str]],
         directives: List[str],
         design_attempt: int = 0,
+        phase_back_count: int = 0,
     ) -> StrategyLabRecord:
         """One design + refinement attempt. May raise
         ``SpecImplementabilityError`` to signal a need to re-enter the
@@ -2101,6 +2121,11 @@ class StrategyLabOrchestrator:
         gate → DesignReviewAgent → DesignAgent.revise) until either the
         reviewer marks the spec ready or the round budget is exhausted.
         Exhaustion short-circuits the cycle without ever running code.
+
+        ``phase_back_count`` is the number of prior phase-backs in the
+        enclosing ``run_cycle`` and is stamped onto the persisted record
+        so the breakdown (success after N phase-backs, short-circuit
+        after N phase-backs) is observable post hoc.
         """
         # Reset per-attempt counters so a re-entry starts fresh.
         self._consecutive_spec_mutation_rounds = {}
@@ -2151,6 +2176,7 @@ class StrategyLabOrchestrator:
                 short_circuit_reason=abort_reason,
                 emit=emit,
                 design_context=design_context,
+                phase_back_count=phase_back_count,
             )
 
         # ═══ Phase 2 → 3 transition: DESIGN_REVIEW → CODE_SYNTHESIS ═══
@@ -2212,6 +2238,7 @@ class StrategyLabOrchestrator:
                     short_circuit_reason=abort_reason,
                     emit=emit,
                     design_context=design_context,
+                    phase_back_count=phase_back_count,
                 )
 
         spec.strategy_code = code
@@ -2268,6 +2295,7 @@ class StrategyLabOrchestrator:
             rationale=rationale,
             refinement_attempts=refinement_attempts,
             emit=emit,
+            phase_back_count=phase_back_count,
         )
         if pre_synthesis is not None:
             return pre_synthesis
@@ -2439,6 +2467,7 @@ class StrategyLabOrchestrator:
             emit=emit,
             design_context=design_context,
             alignment_findings=alignment_findings,
+            phase_back_count=phase_back_count,
         )
 
     # ------------------------------------------------------------------
@@ -2749,6 +2778,7 @@ class StrategyLabOrchestrator:
         short_circuit_reason: str,
         emit: PhaseCallback,
         design_context: Optional[_DesignPersistContext] = None,
+        phase_back_count: int = 0,
     ) -> StrategyLabRecord:
         """Persist a failed cycle that exited before code execution.
 
@@ -2804,6 +2834,7 @@ class StrategyLabOrchestrator:
             strategy_code=code,
             original_spec=original_spec,
             original_code=original_code,
+            spec_implementability_phase_backs=phase_back_count,
         )
 
         self.convergence_tracker.record(spec, all_gate_results)
@@ -2816,6 +2847,7 @@ class StrategyLabOrchestrator:
                 "metrics": backtest_record.result.model_dump(),
                 "refinement_rounds": len(refinement_attempts),
                 "short_circuit": short_circuit_status,
+                "phase_back_count": phase_back_count,
             },
         )
 

--- a/backend/agents/investment_team/tests/test_strategy_compiler.py
+++ b/backend/agents/investment_team/tests/test_strategy_compiler.py
@@ -937,6 +937,7 @@ def test_compiled_code_flows_into_orchestrator_local_variable() -> None:
         rationale,
         refinement_attempts,
         emit,
+        phase_back_count=0,
     ):
         captured["code"] = code
         captured["original_code"] = original_code

--- a/backend/agents/investment_team/tests/test_strategy_lab_refinement_freeze.py
+++ b/backend/agents/investment_team/tests/test_strategy_lab_refinement_freeze.py
@@ -559,3 +559,102 @@ def test_run_cycle_reroutes_on_stray_key_threshold(
     assert "publication_disabled" in ar and "spec_unimplementable" in ar, (
         f"expected publication_disabled / spec_unimplementable in {ar!r}"
     )
+
+
+# ---------------------------------------------------------------------------
+# Phase-back trial accounting (DSR n_trials)
+# ---------------------------------------------------------------------------
+
+
+def test_phase_backs_count_as_dsr_trials_and_surface_on_record(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Each ``SpecImplementabilityError`` phase-back contributes one trial
+    to the convergence tracker (so DSR deflation reflects the failed
+    attempts) and the count surfaces on the persisted short-circuit
+    record.
+
+    Preconditions:
+      - Every design attempt's refinement loop loosens risk-limits, so
+        ``_apply_updates`` raises ``SpecImplementabilityError`` and
+        ``run_cycle`` exhausts ``MAX_DESIGN_REENTRIES`` re-entries.
+
+    Postconditions:
+      - The persisted record's ``spec_implementability_phase_backs`` is
+        exactly ``MAX_DESIGN_REENTRIES + 1`` (every attempt phase-backed).
+      - The convergence tracker's ``trial_count`` advanced by at least
+        ``MAX_DESIGN_REENTRIES + 1`` (one per phase-back; the failed
+        attempts never reach the synthesis-loop trial-count site, so
+        the new accounting is the only contributor).
+      - Every loopback event carries ``phase_back_count`` matching the
+        running counter so dashboards can render the breakdown.
+    """
+    from investment_team.strategy_lab.agents.design_review import SpecCritique
+
+    spec = _spec()
+    orch = StrategyLabOrchestrator()
+    orch.design_agent = _FakeDesignAgent(spec)  # type: ignore[assignment]
+    orch.refinement_agent = _LoosenOnceRefinementAgent()  # type: ignore[assignment]
+
+    monkeypatch.setattr(orch.design_review_agent, "run", lambda *a, **kw: SpecCritique(ready=True))
+    monkeypatch.setattr(orchestrator_module, "compile_strategy", lambda _spec: "# design code")
+    monkeypatch.setattr(orch.code_synthesis_agent, "run", lambda _spec: "# design code")
+    monkeypatch.setattr(orch.code_safety_checker, "check", lambda code, spec=None: [])
+    monkeypatch.setattr(orch.strategy_validator, "validate", lambda s: [])
+    monkeypatch.setattr(orch.spec_readiness_gate, "validate", lambda *a, **kw: [])
+
+    def _failed_run(
+        code: str, market_data: Any, config: Any, strategy: Any = None
+    ) -> StrategyRunResult:
+        return StrategyRunResult(
+            success=False,
+            error_type="runtime_error",
+            stderr="forced failure for test",
+            stdout="",
+        )
+
+    monkeypatch.setattr(orchestrator_module, "run_strategy_code", _failed_run)
+    monkeypatch.setattr(
+        orch,
+        "_fetch_market_data",
+        lambda spec_arg, config_arg: orchestrator_module._MarketDataFetch(
+            data={
+                "SPY": [
+                    OHLCVBar(
+                        symbol="SPY", date="2023-01-01", open=1, high=1, low=1, close=1, volume=1
+                    )
+                ]
+            },
+            requested_symbols=["SPY"],
+            fetched_symbols=["SPY"],
+        ),
+    )
+
+    trial_count_before = orch.convergence_tracker.trial_count
+    emitted: List[Tuple[str, Dict[str, Any]]] = []
+    record = orch.run_cycle(
+        prior_records=[],
+        config=_config(),
+        on_phase=lambda phase, data: emitted.append((phase, data)),
+    )
+
+    expected_phase_backs = MAX_DESIGN_REENTRIES + 1
+    assert record.spec_implementability_phase_backs == expected_phase_backs, (
+        f"expected {expected_phase_backs} phase-backs on the short-circuit record, "
+        f"got {record.spec_implementability_phase_backs}"
+    )
+
+    trial_delta = orch.convergence_tracker.trial_count - trial_count_before
+    assert trial_delta == expected_phase_backs, (
+        f"expected convergence tracker to advance by {expected_phase_backs} trials "
+        f"(one per phase-back), got delta={trial_delta}"
+    )
+
+    loopback_events = [
+        d for phase, d in emitted if phase == "designing" and d.get("sub_phase") == "loopback"
+    ]
+    assert len(loopback_events) == MAX_DESIGN_REENTRIES
+    for idx, ev in enumerate(loopback_events, start=1):
+        assert ev["phase_back_count"] == idx, (
+            f"loopback #{idx} should report phase_back_count={idx}, got {ev['phase_back_count']}"
+        )


### PR DESCRIPTION
## Summary

Phase-backs from a downstream phase (synthesis or refinement) raising `SpecImplementabilityError` consumed real LLM work on the same evaluation window but were invisible to the convergence tracker's trial counter, so DSR deflation under-reported the multiple-testing burden.

- `run_cycle` now calls `convergence_tracker.increment_trials(1)` inside its `except SpecImplementabilityError` block — every phase-back, including the one that exhausts `MAX_DESIGN_REENTRIES`, contributes one trial to the counter DSR reads as `n_trials`.
- A running `phase_back_count` is threaded into `_run_design_attempt` and onward into every persisted-record build site (`_assemble_record`, `_build_short_circuit_record`, and the `_run_pre_synthesis_phase` short-circuit) so the breakdown survives on the record.
- New persisted field `StrategyLabRecord.spec_implementability_phase_backs` (default `0`, legacy-safe).
- `loopback` and `complete` event payloads grow a `phase_back_count` key for dashboard observability.

## Test plan

- [x] New test `test_phase_backs_count_as_dsr_trials_and_surface_on_record` in `agents/investment_team/tests/test_strategy_lab_refinement_freeze.py`: forces `MAX_DESIGN_REENTRIES + 1` failed attempts via persistent risk-limits loosening; asserts `record.spec_implementability_phase_backs == MAX_DESIGN_REENTRIES + 1`, the convergence tracker delta equals the phase-back count, and each loopback event carries the running counter.
- [x] Pre-existing freeze suite (`test_run_cycle_reroutes_then_short_circuits_on_persistent_loosening`, `test_run_cycle_reroutes_on_stray_key_threshold`) still passes — no regression on routing, cap, or short-circuit status.
- [x] Phase-transition suite (`test_strategy_lab_phase_transitions.py`) still passes — the four-phase contract and PhaseTransition events are unaffected.
- [x] Full investment_team suite (`pytest agents/investment_team/tests/`) — 2385 passed, 5 skipped.
- [x] `ruff check` and `ruff format --check` clean on touched files.

Closes #544


---
_Generated by [Claude Code](https://claude.ai/code/session_01JVFk28LNnP4mLRDhp3UgyE)_