### PR TITLE
investment_team: realism-cycle gates and verification veto wiring (1/4)

### DIFF
--- a/backend/agents/investment_team/strategy_lab/orchestrator.py
+++ b/backend/agents/investment_team/strategy_lab/orchestrator.py
@@ -1133,6 +1133,10 @@ class StrategyLabOrchestrator:
                 dsr_aware=config.walk_forward_enabled,
                 diagnostics=exec_result.execution_diagnostics,
                 coverage_report=metrics.coverage_report,
+                start_date=config.start_date,
+                end_date=config.end_date,
+                timeframe=spec.timeframe,
+                market_data=market_data,
             )
             self.record_gates(anomaly_gates, all_gate_results, refinement_round=round_num)
 
@@ -1627,6 +1631,10 @@ class StrategyLabOrchestrator:
             diagnostics=align_exec.execution_diagnostics,
             coverage_report=new_metrics.coverage_report,
             phase="verification",
+            start_date=config.start_date,
+            end_date=config.end_date,
+            timeframe=proposed_spec.timeframe,
+            market_data=market_data,
         )
         self.record_gates(
             anomaly_gates,
@@ -1775,6 +1783,19 @@ class StrategyLabOrchestrator:
                 (not r.passed) and r.severity == "critical" for r in conformance_results
             )
 
+        # Realism cycle — verification-phase checks that the trade ledger
+        # resembles a real-world trading outcome (symbol breadth today;
+        # liquidity / cost-stress / regime / clustering / rule-firing are
+        # additive). Critical failures veto ``is_winning`` below.
+        realism_results = self._run_realism_gates(
+            spec=spec,
+            trades=trades,
+            execution_succeeded=execution_succeeded,
+        )
+        all_gate_results.extend(realism_results)
+        realism_critical = [r for r in realism_results if not r.passed and r.severity == "critical"]
+        realism_passed = not realism_critical
+
         # Resolve is_winning across the three publication-decision paths.
         # ``upstream_admitted`` records whether the upstream gate (walk-
         # forward or fallback) said admit. It feeds the veto-augmentation
@@ -1789,6 +1810,7 @@ class StrategyLabOrchestrator:
                 and acceptance_passed
                 and trades_aligned
                 and exit_rule_conformance_passed
+                and realism_passed
             )
             upstream_admitted = acceptance_passed
         elif walk_forward_failed and execution_succeeded:
@@ -1805,6 +1827,10 @@ class StrategyLabOrchestrator:
                 dsr_aware=False,
                 coverage_report=metrics.coverage_report,
                 phase="verification",
+                start_date=config.start_date,
+                end_date=config.end_date,
+                timeframe=spec.timeframe,
+                market_data=market_data,
             )
             fallback_criticals = [
                 g for g in fallback_anomalies if not g.passed and g.severity == "critical"
@@ -1815,6 +1841,7 @@ class StrategyLabOrchestrator:
                 and not fallback_criticals
                 and trades_aligned
                 and exit_rule_conformance_passed
+                and realism_passed
             )
             upstream_admitted = return_ok and not fallback_criticals
             if fallback_criticals:
@@ -1887,6 +1914,17 @@ class StrategyLabOrchestrator:
                 metrics, suffix, upstream_admitted=upstream_admitted
             )
 
+        if execution_succeeded and trades and not realism_passed:
+            detail = "; ".join(r.details for r in realism_critical)
+            suffix = (
+                f"realism_failed: {detail}"
+                if detail
+                else "realism_failed: realism gates produced a critical finding"
+            )
+            metrics, upstream_admitted = _apply_veto_to_acceptance_reason(
+                metrics, suffix, upstream_admitted=upstream_admitted
+            )
+
         if execution_succeeded and trades and alignment_reports and not trades_aligned:
             last_report = alignment_reports[-1]
             # NOTE: do NOT name this ``rationale`` — the strategy-rationale
@@ -1910,6 +1948,38 @@ class StrategyLabOrchestrator:
             walk_forward_failed=walk_forward_failed,
             exit_rule_conformance_passed=exit_rule_conformance_passed,
         )
+
+    def _run_realism_gates(
+        self,
+        *,
+        spec: StrategySpec,
+        trades: List[TradeRecord],
+        execution_succeeded: bool,
+    ) -> List[QualityGateResult]:
+        """Run verification-phase realism gates and return their results.
+
+        Preconditions:
+          - Called from :meth:`_run_verification_phase` between walk-forward
+            evaluation and the publication-veto block.
+        Postconditions:
+          - Returns ``[]`` when execution didn't succeed or the ledger is
+            empty — the gates' contracts are only meaningful for a strategy
+            that actually traded.
+          - Otherwise returns one or more :class:`QualityGateResult`s; the
+            caller treats any ``critical`` entry as a publication veto and
+            appends every entry to the persisted gate timeline.
+        Invariants:
+          - Pure orchestration: never mutates ``spec`` or ``trades``.
+          - Gates are run in a fixed order so the persisted timeline is
+            deterministic across re-runs of the same record.
+        """
+        if not execution_succeeded or not trades:
+            return []
+        results: List[QualityGateResult] = []
+        results.extend(
+            self.target_symbol_coverage_gate.check_breadth(spec, trades, phase="verification")
+        )
+        return results
 
     def _run_analysis_phase(
         self,

--- a/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
@@ -344,9 +344,9 @@ class BacktestAnomalyDetector(GateResultsMixin):
     def _check_lookahead_bar_predictability(
         self, ctx: BacktestAnomalyCtx
     ) -> Iterable[QualityGateResult]:
-        """Flag trades whose sign agrees suspiciously well with the entry bar's
-        intrabar direction — a heuristic for look-ahead bias that AST checks
-        miss.
+        """Flag trades whose outcome agrees suspiciously well with the entry
+        bar's intrabar direction — a heuristic for look-ahead bias that AST
+        checks miss.
 
         Preconditions:
           - ``ctx.trades`` is non-empty.
@@ -359,6 +359,15 @@ class BacktestAnomalyDetector(GateResultsMixin):
             least 5 trades (smaller-sample backstop).
           - Warning when ``n_eligible >= 20`` and ``80% <= agreement < 95%``.
         Invariants:
+          - Trade side is folded into the comparison: profitable shorts in
+            this codebase carry ``return_pct > 0`` on DOWN bars, so a naive
+            ``bar_dir == sign(return_pct)`` would systematically miss short-
+            side look-ahead. The comparison uses ``effective_bar_dir =
+            bar_dir * side_sign`` (``side_sign = +1`` for long, ``-1`` for
+            short), which models "did the strategy's directional bet on
+            the bar pay off". Look-ahead-biased trades — long on up bars
+            or short on down bars, both winners — produce agreement; the
+            heuristic catches both directions.
           - Entry-bar lookup prefers an exact ``bar.date == trade.entry_date``
             match — calendar-prefix matching would pick the wrong bar on
             intraday timeframes and make the agreement statistic arbitrary.
@@ -370,17 +379,18 @@ class BacktestAnomalyDetector(GateResultsMixin):
             close). Silent skipping in that asymmetry would let look-ahead
             slip through the realism veto, which is the failure mode this
             gate exists to catch.
-          - Trades whose entry bar has ``close == open`` or whose return
-            is exactly zero contribute no sign signal and are skipped.
-          - Degenerate samples (all eligible bars move one direction, or
-            all eligible trades return one sign) are skipped — the rate
+          - Trades whose entry bar has ``close == open``, whose return is
+            exactly zero, or whose ``side`` isn't ``long``/``short`` are
+            skipped — they contribute no sign signal.
+          - Degenerate samples (all effective bar directions move one way,
+            or all eligible trades return one sign) are skipped — the rate
             would be uninformative.
         """
         if ctx.market_data is None or ctx.mode == "paper":
             return ()
         agreements = 0
         eligible = 0
-        bar_dirs: set[int] = set()
+        effective_bar_dirs: set[int] = set()
         ret_dirs: set[int] = set()
         for trade in ctx.trades:
             bars = ctx.market_data.get(trade.symbol)
@@ -389,23 +399,27 @@ class BacktestAnomalyDetector(GateResultsMixin):
             bar_dir = _resolve_entry_bar_direction(bars, trade.entry_date)
             if bar_dir is None:
                 continue
+            side_sign = _side_sign(trade.side)
+            if side_sign is None:
+                continue
             ret_dir = _sign(trade.return_pct)
             if ret_dir == 0:
                 continue
+            effective_bar_dir = bar_dir * side_sign
             eligible += 1
-            bar_dirs.add(bar_dir)
+            effective_bar_dirs.add(effective_bar_dir)
             ret_dirs.add(ret_dir)
-            if bar_dir == ret_dir:
+            if effective_bar_dir == ret_dir:
                 agreements += 1
         if eligible == 0:
             return ()
-        # Degenerate samples (every eligible bar moves the same direction, or
+        # Degenerate samples (every effective bar direction is one way, or
         # every eligible trade returns the same sign) make the agreement
-        # statistic uninformative — a fixture where every bar is positive
-        # and every trade is a winner trivially scores 100% without any
-        # look-ahead. Require both sides of the sign distribution before
-        # promoting agreement to a finding.
-        if len(bar_dirs) < 2 or len(ret_dirs) < 2:
+        # statistic uninformative — a fixture where every long trade wins on
+        # an up bar trivially scores 100% without any look-ahead. Require
+        # both sides of the sign distribution before promoting agreement to
+        # a finding.
+        if len(effective_bar_dirs) < 2 or len(ret_dirs) < 2:
             return ()
         rate = agreements / eligible
         if eligible >= 20 and rate >= 0.95:
@@ -552,6 +566,24 @@ def _sign(value: float) -> int:
     if value < 0:
         return -1
     return 0
+
+
+def _side_sign(side: str) -> Optional[int]:
+    """Map ``"long"``/``"short"`` to ``+1``/``-1`` for look-ahead direction math.
+
+    Postconditions:
+      - Case-insensitive match on the canonical labels.
+      - Returns ``None`` for any other value (skip the trade) — silently
+        defaulting to long would hide short-side look-ahead bias.
+    """
+    if not isinstance(side, str):
+        return None
+    lowered = side.strip().lower()
+    if lowered == "long":
+        return 1
+    if lowered == "short":
+        return -1
+    return None
 
 
 def _resolve_entry_bar_direction(bars: List[OHLCVBar], target: str) -> Optional[int]:

--- a/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import ClassVar, Iterable, List, Optional
+from datetime import date, datetime
+from typing import ClassVar, Dict, Iterable, List, Optional
 
+from ...market_data_service import OHLCVBar
 from ...models import BacktestExecutionDiagnostics, BacktestResult, CoverageReport, TradeRecord
 from .models import GateResultsMixin, QualityGateResult, StrategyLabPhase
 
@@ -25,6 +27,11 @@ class BacktestAnomalyCtx:
     dsr_aware: bool
     diagnostics: Optional[BacktestExecutionDiagnostics]
     coverage_report: Optional[CoverageReport]
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+    timeframe: Optional[str] = None
+    market_data: Optional[Dict[str, List[OHLCVBar]]] = None
+
 
 GATE = "backtest_anomaly"
 
@@ -113,6 +120,10 @@ class BacktestAnomalyDetector(GateResultsMixin):
         diagnostics: Optional[BacktestExecutionDiagnostics] = None,
         coverage_report: Optional[CoverageReport] = None,
         phase: StrategyLabPhase = "synthesis",
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        timeframe: Optional[str] = None,
+        market_data: Optional[Dict[str, List[OHLCVBar]]] = None,
     ) -> List[QualityGateResult]:
         """Run anomaly checks and tag every result with ``phase``.
 
@@ -132,14 +143,20 @@ class BacktestAnomalyDetector(GateResultsMixin):
         ``diagnostics`` and ``coverage_report`` enrich the zero-trade gate
         result with a deterministic failure category and order counters.
         Other rules ignore them.
+
+        ``start_date`` / ``end_date`` / ``timeframe`` are required by the
+        frequency-aware trade-count gate. When omitted the gate falls back
+        to the legacy ``< 5 trades`` floor so callers that don't yet wire
+        them through keep their previous behaviour.
+
+        ``market_data`` is required by the look-ahead pattern gate (needs
+        entry-bar OHLC). When omitted the gate emits no result.
         """
         with self._using_phase(phase):
             # Zero trades is a hard short-circuit — every downstream statistic
             # is meaningless without trades, so we return immediately.
             if not trades:
-                return [
-                    self._critical(_format_zero_trade_details(diagnostics, coverage_report))
-                ]
+                return [self._critical(_format_zero_trade_details(diagnostics, coverage_report))]
             ctx = BacktestAnomalyCtx(
                 metrics=metrics,
                 trades=trades,
@@ -147,6 +164,10 @@ class BacktestAnomalyDetector(GateResultsMixin):
                 dsr_aware=dsr_aware,
                 diagnostics=diagnostics,
                 coverage_report=coverage_report,
+                start_date=start_date,
+                end_date=end_date,
+                timeframe=timeframe,
+                market_data=market_data,
             )
             results = [r for rule in self._RULES for r in rule(self, ctx)]
             return results or [self._info("Backtest results passed all anomaly checks.")]
@@ -156,19 +177,68 @@ class BacktestAnomalyDetector(GateResultsMixin):
     # or more results. Listed in ``_RULES`` below.
     # ------------------------------------------------------------------
     def _check_trade_count_floor(self, ctx: BacktestAnomalyCtx) -> Iterable[QualityGateResult]:
-        # Paper sessions run over short windows (a few weeks at most) so a
-        # <5-trade minimum is inappropriate; the signals_per_bar floor is the
-        # paper-mode equivalent.
-        if ctx.mode != "paper" and len(ctx.trades) < 5:
+        """Frequency-aware trade-count adequacy gate.
+
+        Preconditions:
+          - ``ctx.trades`` is non-empty (the ``check`` zero-trade short-circuit
+            handles the empty case before this rule fires).
+        Postconditions:
+          - Returns an empty tuple in ``paper`` mode (legacy behaviour).
+          - When ``start_date`` / ``end_date`` / ``timeframe`` are missing,
+            falls back to the legacy ``< 5 trades → critical`` floor so
+            callers that haven't yet wired the new kwargs keep their prior
+            verdicts.
+          - When all three are supplied, the expected trade count is
+            ``window_days / expected_hold_days``: realised count below
+            ``25 %`` of expected → critical, ``25–50 %`` → warning, above
+            50 % → pass.
+        Invariants:
+          - Never returns more than one result.
+        """
+        if ctx.mode == "paper":
+            return ()
+
+        observed = len(ctx.trades)
+        expected = _expected_trade_count(
+            start_date=ctx.start_date,
+            end_date=ctx.end_date,
+            timeframe=ctx.timeframe,
+            trades=ctx.trades,
+        )
+        if expected is None:
+            # Legacy fallback: callers that don't yet pass dates/timeframe
+            # still get the original floor so behaviour is unchanged.
+            if observed < 5:
+                return (
+                    self._critical(
+                        f"Only {observed} trades — "
+                        "statistically meaningless for a multi-year backtest."
+                    ),
+                )
+            return ()
+
+        ratio = observed / expected if expected > 0 else 0.0
+        if ratio < 0.25:
             return (
                 self._critical(
-                    f"Only {len(ctx.trades)} trades — "
-                    "statistically meaningless for a multi-year backtest."
+                    f"Observed {observed} trades vs ~{expected} expected "
+                    f"({ratio:.0%} of expected) given window and holding period — "
+                    "well below the 25% floor for a meaningful sample."
+                ),
+            )
+        if ratio < 0.50:
+            return (
+                self._warning(
+                    f"Observed {observed} trades vs ~{expected} expected "
+                    f"({ratio:.0%} of expected) — review whether the signal "
+                    "is firing as designed."
                 ),
             )
         return ()
 
-    def _check_annualized_return_ceiling(self, ctx: BacktestAnomalyCtx) -> Iterable[QualityGateResult]:
+    def _check_annualized_return_ceiling(
+        self, ctx: BacktestAnomalyCtx
+    ) -> Iterable[QualityGateResult]:
         if ctx.metrics.annualized_return_pct > 200:
             return (
                 self._critical(
@@ -189,9 +259,7 @@ class BacktestAnomalyDetector(GateResultsMixin):
             )
         if wr > 90:
             return (
-                self._warning(
-                    f"Win rate {wr:.1f}% exceeds 90% — review for possible overfitting."
-                ),
+                self._warning(f"Win rate {wr:.1f}% exceeds 90% — review for possible overfitting."),
             )
         return ()
 
@@ -228,8 +296,7 @@ class BacktestAnomalyDetector(GateResultsMixin):
         if sr > 3.0:
             return (
                 self._warning(
-                    f"Sharpe ratio {sr:.2f} exceeds 3.0 — review for overfitting "
-                    "or data snooping."
+                    f"Sharpe ratio {sr:.2f} exceeds 3.0 — review for overfitting or data snooping."
                 ),
             )
         return ()
@@ -274,6 +341,89 @@ class BacktestAnomalyDetector(GateResultsMixin):
             )
         return ()
 
+    def _check_lookahead_bar_predictability(
+        self, ctx: BacktestAnomalyCtx
+    ) -> Iterable[QualityGateResult]:
+        """Flag trades whose sign agrees suspiciously well with the entry bar's
+        intrabar direction — a heuristic for look-ahead bias that AST checks
+        miss.
+
+        Preconditions:
+          - ``ctx.trades`` is non-empty.
+          - ``ctx.market_data`` is provided; otherwise the rule emits nothing
+            (the synthesis-loop call site doesn't always have it in scope).
+        Postconditions:
+          - Returns at most one result.
+          - Critical when ``n_eligible >= 20`` and agreement rate ``>= 95%``,
+            OR when ``n_eligible < 20`` and agreement is perfect across at
+            least 5 trades (smaller-sample backstop).
+          - Warning when ``n_eligible >= 20`` and ``80% <= agreement < 95%``.
+        Invariants:
+          - Trades whose entry bar can't be located in ``market_data`` (or
+            whose entry-bar ``close == open``) are skipped — they contribute
+            no agreement signal.
+        """
+        if ctx.market_data is None or ctx.mode == "paper":
+            return ()
+        agreements = 0
+        eligible = 0
+        bar_dirs: set[int] = set()
+        ret_dirs: set[int] = set()
+        for trade in ctx.trades:
+            bars = ctx.market_data.get(trade.symbol)
+            if not bars:
+                continue
+            entry_bar = _find_bar_by_date(bars, trade.entry_date)
+            if entry_bar is None:
+                continue
+            bar_dir = _sign(entry_bar.close - entry_bar.open)
+            ret_dir = _sign(trade.return_pct)
+            if bar_dir == 0 or ret_dir == 0:
+                continue
+            eligible += 1
+            bar_dirs.add(bar_dir)
+            ret_dirs.add(ret_dir)
+            if bar_dir == ret_dir:
+                agreements += 1
+        if eligible == 0:
+            return ()
+        # Degenerate samples (every eligible bar moves the same direction, or
+        # every eligible trade returns the same sign) make the agreement
+        # statistic uninformative — a fixture where every bar is positive
+        # and every trade is a winner trivially scores 100% without any
+        # look-ahead. Require both sides of the sign distribution before
+        # promoting agreement to a finding.
+        if len(bar_dirs) < 2 or len(ret_dirs) < 2:
+            return ()
+        rate = agreements / eligible
+        if eligible >= 20 and rate >= 0.95:
+            return (
+                self._critical(
+                    f"Entry-bar direction agrees with trade return on "
+                    f"{agreements}/{eligible} trades ({rate:.0%}) — perfectly "
+                    "predictable from the entry bar's close-minus-open indicates "
+                    "intrabar look-ahead bias."
+                ),
+            )
+        if eligible < 20 and eligible >= 5 and rate >= 0.999:
+            return (
+                self._critical(
+                    f"Entry-bar direction matches trade return on every "
+                    f"eligible trade ({agreements}/{eligible}) — perfect "
+                    "agreement at small sample is consistent with intrabar "
+                    "look-ahead bias; collect more trades to disambiguate."
+                ),
+            )
+        if eligible >= 20 and rate >= 0.80:
+            return (
+                self._warning(
+                    f"Entry-bar direction agrees with trade return on "
+                    f"{agreements}/{eligible} trades ({rate:.0%}) — review the "
+                    "entry-signal computation for subtle look-ahead."
+                ),
+            )
+        return ()
+
     def _check_cost_sensitivity(self, ctx: BacktestAnomalyCtx) -> Iterable[QualityGateResult]:
         gross_wins = sum(t.gross_pnl for t in ctx.trades if t.gross_pnl > 0)
         gross_losses = abs(sum(t.gross_pnl for t in ctx.trades if t.gross_pnl <= 0))
@@ -298,5 +448,110 @@ class BacktestAnomalyDetector(GateResultsMixin):
         _check_avg_hold_time,
         _check_trade_concentration,
         _check_trade_diversification,
+        _check_lookahead_bar_predictability,
         _check_cost_sensitivity,
     )
+
+
+# ──────────────────────────────────────────────────────────────────────────
+# Module-level helpers used by the rules above.
+# ──────────────────────────────────────────────────────────────────────────
+
+
+# Default expected holding period in CALENDAR DAYS per spec timeframe.
+# Daily-bar swing strategies hold roughly two weeks; intraday holds collapse
+# to fractions of a day. These defaults are the fallback when neither the
+# average observed hold nor a structured TimeStopRule supplies a value.
+_DEFAULT_EXPECTED_HOLD_DAYS: Dict[str, float] = {
+    "1d": 10.0,
+    "1h": 0.5,
+    "15m": 0.1,
+    "5m": 0.04,
+    "1m": 0.01,
+}
+
+
+def _expected_trade_count(
+    *,
+    start_date: Optional[str],
+    end_date: Optional[str],
+    timeframe: Optional[str],
+    trades: List[TradeRecord],
+) -> Optional[int]:
+    """Estimate the expected number of trades over the backtest window.
+
+    Preconditions:
+      - ``trades`` is non-empty (callers skip the empty-ledger case before
+        invoking this helper).
+    Postconditions:
+      - Returns ``None`` whenever any required input is missing or unparseable
+        — the gate then falls back to its legacy floor.
+      - Returns ``max(1, round(window_days / expected_hold_days))`` when the
+        inputs are usable. ``expected_hold_days`` is the average observed
+        hold when at least one trade reports ``hold_days > 0``, otherwise the
+        per-timeframe default.
+    Invariants:
+      - Never returns a value ``<= 0``.
+    """
+    if not start_date or not end_date or not timeframe:
+        return None
+    window_days = _window_days(start_date, end_date)
+    if window_days is None or window_days <= 0:
+        return None
+
+    observed_holds = [t.hold_days for t in trades if t.hold_days and t.hold_days > 0]
+    if observed_holds:
+        expected_hold = sum(observed_holds) / len(observed_holds)
+    else:
+        expected_hold = _DEFAULT_EXPECTED_HOLD_DAYS.get(timeframe)
+    if not expected_hold or expected_hold <= 0:
+        return None
+
+    expected = round(window_days / expected_hold)
+    return max(1, expected)
+
+
+def _window_days(start_date: str, end_date: str) -> Optional[int]:
+    start = _parse_iso_date(start_date)
+    end = _parse_iso_date(end_date)
+    if start is None or end is None:
+        return None
+    return (end - start).days
+
+
+def _parse_iso_date(value: str) -> Optional[date]:
+    """Parse ``YYYY-MM-DD`` or full ISO datetime strings; returns ``None`` on
+    malformed input rather than raising so the gate can fall back gracefully.
+    """
+    if not value:
+        return None
+    try:
+        return date.fromisoformat(value[:10])
+    except (TypeError, ValueError):
+        try:
+            return datetime.fromisoformat(value).date()
+        except (TypeError, ValueError):
+            return None
+
+
+def _sign(value: float) -> int:
+    if value > 0:
+        return 1
+    if value < 0:
+        return -1
+    return 0
+
+
+def _find_bar_by_date(bars: List[OHLCVBar], target: str) -> Optional[OHLCVBar]:
+    """Return the bar whose ``date`` matches ``target`` (date-prefix match).
+
+    Postconditions:
+      - Returns ``None`` when ``target`` is empty or no bar matches.
+    """
+    if not target:
+        return None
+    head = target[:10]
+    for bar in bars:
+        if bar.date.startswith(head):
+            return bar
+    return None

--- a/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
@@ -359,9 +359,16 @@ class BacktestAnomalyDetector(GateResultsMixin):
             least 5 trades (smaller-sample backstop).
           - Warning when ``n_eligible >= 20`` and ``80% <= agreement < 95%``.
         Invariants:
-          - Trades whose entry bar can't be located in ``market_data`` (or
-            whose entry-bar ``close == open``) are skipped — they contribute
-            no agreement signal.
+          - Entry-bar lookup is an EXACT timestamp match against
+            ``OHLCVBar.date`` — calendar-prefix matching would pick the
+            first bar of the day on intraday timeframes and make the
+            agreement statistic arbitrary. Trades whose entry timestamp
+            doesn't exact-match any bar are skipped (ineligible).
+          - Trades whose entry bar has ``close == open`` or whose return
+            is exactly zero contribute no sign signal and are skipped.
+          - Degenerate samples (all eligible bars move one direction, or
+            all eligible trades return one sign) are skipped — the rate
+            would be uninformative.
         """
         if ctx.market_data is None or ctx.mode == "paper":
             return ()
@@ -373,7 +380,7 @@ class BacktestAnomalyDetector(GateResultsMixin):
             bars = ctx.market_data.get(trade.symbol)
             if not bars:
                 continue
-            entry_bar = _find_bar_by_date(bars, trade.entry_date)
+            entry_bar = _find_bar_by_timestamp(bars, trade.entry_date)
             if entry_bar is None:
                 continue
             bar_dir = _sign(entry_bar.close - entry_bar.open)
@@ -542,16 +549,26 @@ def _sign(value: float) -> int:
     return 0
 
 
-def _find_bar_by_date(bars: List[OHLCVBar], target: str) -> Optional[OHLCVBar]:
-    """Return the bar whose ``date`` matches ``target`` (date-prefix match).
+def _find_bar_by_timestamp(bars: List[OHLCVBar], target: str) -> Optional[OHLCVBar]:
+    """Return the bar whose ``date`` equals ``target`` exactly.
 
+    Preconditions:
+      - ``bars`` is iterable; ``target`` is a string.
     Postconditions:
-      - Returns ``None`` when ``target`` is empty or no bar matches.
+      - Returns ``None`` when ``target`` is empty or no bar's ``date``
+        field equals ``target`` exactly.
+      - Never falls back to date-prefix matching: on intraday timeframes
+        (1m/5m/15m/1h) many bars share a calendar day, so a prefix match
+        would pick the first bar of the day rather than the actual entry
+        bar and make the look-ahead agreement statistic arbitrary.
+        Trades whose entry timestamp can't be resolved this way are
+        skipped by the caller (counted as ineligible).
+    Invariants:
+      - Pure function; no side effects.
     """
     if not target:
         return None
-    head = target[:10]
     for bar in bars:
-        if bar.date.startswith(head):
+        if bar.date == target:
             return bar
     return None

--- a/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/backtest_anomaly.py
@@ -359,11 +359,17 @@ class BacktestAnomalyDetector(GateResultsMixin):
             least 5 trades (smaller-sample backstop).
           - Warning when ``n_eligible >= 20`` and ``80% <= agreement < 95%``.
         Invariants:
-          - Entry-bar lookup is an EXACT timestamp match against
-            ``OHLCVBar.date`` — calendar-prefix matching would pick the
-            first bar of the day on intraday timeframes and make the
-            agreement statistic arbitrary. Trades whose entry timestamp
-            doesn't exact-match any bar are skipped (ineligible).
+          - Entry-bar lookup prefers an exact ``bar.date == trade.entry_date``
+            match — calendar-prefix matching would pick the wrong bar on
+            intraday timeframes and make the agreement statistic arbitrary.
+            When exact match fails but at least one bar shares the trade's
+            calendar date (the production case where the simulator
+            truncates entry timestamps to ``YYYY-MM-DD`` while intraday
+            bars carry full ISO timestamps), the rule falls back to the
+            day's net intrabar direction (first bar's open → last bar's
+            close). Silent skipping in that asymmetry would let look-ahead
+            slip through the realism veto, which is the failure mode this
+            gate exists to catch.
           - Trades whose entry bar has ``close == open`` or whose return
             is exactly zero contribute no sign signal and are skipped.
           - Degenerate samples (all eligible bars move one direction, or
@@ -380,12 +386,11 @@ class BacktestAnomalyDetector(GateResultsMixin):
             bars = ctx.market_data.get(trade.symbol)
             if not bars:
                 continue
-            entry_bar = _find_bar_by_timestamp(bars, trade.entry_date)
-            if entry_bar is None:
+            bar_dir = _resolve_entry_bar_direction(bars, trade.entry_date)
+            if bar_dir is None:
                 continue
-            bar_dir = _sign(entry_bar.close - entry_bar.open)
             ret_dir = _sign(trade.return_pct)
-            if bar_dir == 0 or ret_dir == 0:
+            if ret_dir == 0:
                 continue
             eligible += 1
             bar_dirs.add(bar_dir)
@@ -549,26 +554,49 @@ def _sign(value: float) -> int:
     return 0
 
 
-def _find_bar_by_timestamp(bars: List[OHLCVBar], target: str) -> Optional[OHLCVBar]:
-    """Return the bar whose ``date`` equals ``target`` exactly.
+def _resolve_entry_bar_direction(bars: List[OHLCVBar], target: str) -> Optional[int]:
+    """Return the sign of the entry-bar's ``close - open`` for look-ahead
+    detection, accommodating the date-only / timestamped asymmetry.
 
     Preconditions:
-      - ``bars`` is iterable; ``target`` is a string.
+      - ``bars`` is iterable over :class:`OHLCVBar`.
+      - ``target`` is a non-empty string. Production callers pass
+        ``trade.entry_date``, which the trade simulator truncates to
+        ``YYYY-MM-DD``; bars may carry either ``YYYY-MM-DD`` (daily
+        fetchers today) or ``YYYY-MM-DDTHH:MM:SS`` (any future intraday
+        fetcher).
     Postconditions:
-      - Returns ``None`` when ``target`` is empty or no bar's ``date``
-        field equals ``target`` exactly.
-      - Never falls back to date-prefix matching: on intraday timeframes
-        (1m/5m/15m/1h) many bars share a calendar day, so a prefix match
-        would pick the first bar of the day rather than the actual entry
-        bar and make the look-ahead agreement statistic arbitrary.
-        Trades whose entry timestamp can't be resolved this way are
-        skipped by the caller (counted as ineligible).
+      - Returns ``None`` when ``target`` is empty, no bar matches the
+        target's calendar date, or the resolved direction is exactly
+        zero (uninformative for sign-agreement).
+      - Otherwise returns ``+1`` or ``-1`` representing the direction
+        of the entry "bar":
+          * **Exact match path** — when at least one bar's ``date`` equals
+            ``target`` exactly, the direction is ``sign(bar.close - bar.open)``
+            of that bar. Daily backtests resolve here.
+          * **Day-aggregate fallback** — when no bar exact-matches but at
+            least one bar's calendar-date prefix matches ``target[:10]``,
+            the direction is ``sign(last_bar.close - first_bar.open)``
+            across all same-day bars in chronological order. This is the
+            day's net intrabar direction and is a legitimate look-ahead
+            probe even when the trade ledger has truncated an intraday
+            entry timestamp to a date — silent skipping would otherwise
+            let look-ahead slip through the realism veto.
     Invariants:
-      - Pure function; no side effects.
+      - Pure function; never mutates ``bars``.
+      - Day-aggregate path only fires when exact match fails — the
+        precise-bar signal is preferred whenever it's available.
     """
     if not target:
         return None
+    target_date = target[:10]
+    same_day: List[OHLCVBar] = []
     for bar in bars:
         if bar.date == target:
-            return bar
-    return None
+            return _sign(bar.close - bar.open) or None
+        if bar.date[:10] == target_date:
+            same_day.append(bar)
+    if not same_day:
+        return None
+    direction = _sign(same_day[-1].close - same_day[0].open)
+    return direction or None

--- a/backend/agents/investment_team/strategy_lab/quality_gates/target_symbol_coverage.py
+++ b/backend/agents/investment_team/strategy_lab/quality_gates/target_symbol_coverage.py
@@ -82,26 +82,34 @@ class TargetSymbolCoverageGate(GateResultsMixin):
                 missing = sorted(target_upper - fetched_upper)
                 if missing:
                     results.append(
-                        self._critical("target_symbols missing from fetched market data: "
-                                f"{missing}. Requested={sorted({s.upper() for s in requested_symbols})}, "
-                                f"fetched={sorted(fetched_upper)}.")
+                        self._critical(
+                            "target_symbols missing from fetched market data: "
+                            f"{missing}. Requested={sorted({s.upper() for s in requested_symbols})}, "
+                            f"fetched={sorted(fetched_upper)}."
+                        )
                     )
                 else:
                     results.append(
-                        self._info(f"All {len(target_upper)} target_symbols present in fetched data.")
+                        self._info(
+                            f"All {len(target_upper)} target_symbols present in fetched data."
+                        )
                     )
             else:
                 mentioned = sorted(self._tickers_in_hypothesis(spec.hypothesis or ""))
                 if mentioned:
                     results.append(
-                        self._warning(f"Hypothesis mentions known ticker(s) {mentioned} but "
-                                "spec.target_symbols is empty; the backtest is using the "
-                                "asset-class default universe. Set spec.target_symbols "
-                                "explicitly to guarantee the run trades the intended tickers.")
+                        self._warning(
+                            f"Hypothesis mentions known ticker(s) {mentioned} but "
+                            "spec.target_symbols is empty; the backtest is using the "
+                            "asset-class default universe. Set spec.target_symbols "
+                            "explicitly to guarantee the run trades the intended tickers."
+                        )
                     )
                 else:
                     results.append(
-                        self._info("spec.target_symbols empty; no specific tickers referenced in hypothesis.")
+                        self._info(
+                            "spec.target_symbols empty; no specific tickers referenced in hypothesis."
+                        )
                     )
 
             return results
@@ -120,15 +128,71 @@ class TargetSymbolCoverageGate(GateResultsMixin):
                 ]
 
             target_upper = {s.strip().upper() for s in spec.target_symbols if s and s.strip()}
-            offending = sorted({t.symbol.strip().upper() for t in trades if t.symbol} - target_upper)
+            offending = sorted(
+                {t.symbol.strip().upper() for t in trades if t.symbol} - target_upper
+            )
             if offending:
                 return [
-                    self._critical("Trade ledger contains symbols outside spec.target_symbols: "
-                            f"{offending}. target_symbols={sorted(target_upper)}.")
+                    self._critical(
+                        "Trade ledger contains symbols outside spec.target_symbols: "
+                        f"{offending}. target_symbols={sorted(target_upper)}."
+                    )
                 ]
 
+            return [self._info(f"All {len(trades)} trades within target_symbols.")]
+
+    def check_breadth(
+        self,
+        spec: StrategySpec,
+        trades: List[TradeRecord],
+        *,
+        phase: StrategyLabPhase = "verification",
+    ) -> List[QualityGateResult]:
+        """Flag strategies that touch only one of their intended symbols.
+
+        Preconditions:
+          - ``spec`` is a :class:`StrategySpec`.
+          - ``trades`` is a list (possibly empty) of :class:`TradeRecord`.
+        Postconditions:
+          - Returns exactly one :class:`QualityGateResult`.
+          - Severity is ``warning`` when ``len(spec.target_symbols) > 1`` AND
+            the realised ledger uses a single symbol; ``info`` otherwise
+            (single-target spec, empty target list, no trades, or breadth
+            already achieved).
+          - Never emits ``critical`` — true universe leakage is the job of
+            :meth:`check_trades`; breadth is a softer signal.
+        Invariants:
+          - Comparison is case-insensitive: symbols are upper-cased before
+            set construction so ``"qqq"`` and ``"QQQ"`` are treated as one.
+        """
+        with self._using_phase(phase):
+            target_upper = {s.strip().upper() for s in spec.target_symbols if s and s.strip()}
+            if len(target_upper) <= 1:
+                return [
+                    self._info(
+                        "Symbol-breadth check skipped: spec.target_symbols has "
+                        f"{len(target_upper)} entries."
+                    )
+                ]
+            if not trades:
+                return [self._info("Symbol-breadth check skipped: trade ledger is empty.")]
+            traded_upper = {
+                t.symbol.strip().upper() for t in trades if t.symbol and t.symbol.strip()
+            }
+            if len(traded_upper) == 1:
+                only = next(iter(traded_upper))
+                return [
+                    self._warning(
+                        f"spec.target_symbols={sorted(target_upper)} but the "
+                        f"realised ledger traded only {only!r} across "
+                        f"{len(trades)} trades — strategy is not exploiting the "
+                        "intended universe."
+                    )
+                ]
             return [
-                self._info(f"All {len(trades)} trades within target_symbols.")
+                self._info(
+                    f"Trade ledger uses {len(traded_upper)} of {len(target_upper)} target symbols."
+                )
             ]
 
     @staticmethod

--- a/backend/agents/investment_team/tests/test_backtest_anomaly_realism.py
+++ b/backend/agents/investment_team/tests/test_backtest_anomaly_realism.py
@@ -491,3 +491,217 @@ def test_lookahead_returns_no_result_when_no_same_day_bars_exist():
     )
     look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
     assert look == []
+
+
+def test_lookahead_critical_for_short_only_strategy_picking_down_bars():
+    """A look-ahead-biased SHORT strategy enters when the bar moves DOWN.
+    In this codebase profitable shorts carry ``return_pct > 0`` on down
+    bars, so a naive ``bar_dir == sign(return_pct)`` would systematically
+    DISAGREE and the rule would miss the bias. The side-aware comparison
+    must catch it.
+
+    Fixture: 20 short trades, alternating winners and losers. Winners
+    enter on down bars and earn positive return_pct; losers enter on up
+    bars and earn negative return_pct. Both arrangements agree under the
+    side-aware comparison ``effective_bar_dir = bar_dir * side_sign``.
+    """
+    trades = [
+        _trade(
+            trade_num=i + 1,
+            entry_date=f"2024-{((i % 12) + 1):02d}-{((i % 27) + 1):02d}",
+            exit_date=f"2024-{((i % 12) + 1):02d}-{((i % 27) + 2):02d}",
+            return_pct=1.5 if i % 2 == 0 else -1.0,
+            side="short",
+            hold_days=14,
+        )
+        for i in range(20)
+    ]
+    # Winning shorts (return_pct > 0) → down bar; losing shorts → up bar.
+    market: dict = {}
+    for t in trades:
+        bars = market.setdefault(t.symbol, [])
+        if t.return_pct >= 0:
+            bars.append(_bar(t.entry_date, open_=101.5, close=100.0))
+        else:
+            bars.append(_bar(t.entry_date, open_=100.0, close=101.5))
+
+    detector = BacktestAnomalyDetector()
+    results = detector.check(
+        _baseline_metrics(),
+        trades,
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+        timeframe="1d",
+        market_data=market,
+    )
+    look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
+    assert len(look) == 1
+    assert "20/20" in look[0].details
+    assert look[0].severity == "critical"
+
+
+def test_lookahead_critical_on_mixed_long_short_ledger_with_aligned_bets():
+    """Mixed long+short ledger where every trade's directional bet aligned
+    with the entry bar's move (longs on up bars, shorts on down bars), and
+    every trade won. The side-aware comparison sees both subsets as
+    agreeing and fires critical against the union."""
+    trades: List[TradeRecord] = []
+    for i in range(20):
+        side = "long" if i % 2 == 0 else "short"
+        trades.append(
+            _trade(
+                trade_num=i + 1,
+                entry_date=f"2024-{((i % 12) + 1):02d}-{((i % 27) + 1):02d}",
+                exit_date=f"2024-{((i % 12) + 1):02d}-{((i % 27) + 2):02d}",
+                return_pct=1.5,  # every trade wins
+                side=side,
+                hold_days=14,
+            )
+        )
+    market: dict = {}
+    for t in trades:
+        bars = market.setdefault(t.symbol, [])
+        if t.side == "long":
+            bars.append(_bar(t.entry_date, open_=100.0, close=101.5))
+        else:
+            bars.append(_bar(t.entry_date, open_=101.5, close=100.0))
+
+    detector = BacktestAnomalyDetector()
+    results = detector.check(
+        _baseline_metrics(),
+        trades,
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+        timeframe="1d",
+        market_data=market,
+    )
+    look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
+    # The fixture sets ret_dir = +1 for every trade, which collapses the
+    # ret-sign distribution to a single value → degenerate-sample guard
+    # short-circuits. Make some trades losers to satisfy the guard while
+    # keeping the side/bar alignment intact for the agreement count.
+    assert look == [], (
+        "all-winners fixture is degenerate by design — guard should skip; "
+        "see following non-degenerate test for the positive case"
+    )
+
+
+def test_lookahead_critical_on_mixed_long_short_with_winners_and_losers():
+    """Non-degenerate mixed ledger: longs on up bars + shorts on down bars
+    when winning; longs on down bars + shorts on up bars when losing. The
+    side-aware comparison treats both winning subsets as agreeing and
+    both losing subsets as disagreeing → high but not 100% agreement."""
+    trades: List[TradeRecord] = []
+    for i in range(20):
+        side = "long" if i % 2 == 0 else "short"
+        is_winner = i % 5 != 0  # 16 winners, 4 losers → distribution spans both signs
+        trades.append(
+            _trade(
+                trade_num=i + 1,
+                entry_date=f"2024-{((i % 12) + 1):02d}-{((i % 27) + 1):02d}",
+                exit_date=f"2024-{((i % 12) + 1):02d}-{((i % 27) + 2):02d}",
+                return_pct=1.5 if is_winner else -1.0,
+                side=side,
+                hold_days=14,
+            )
+        )
+    market: dict = {}
+    for t in trades:
+        bars = market.setdefault(t.symbol, [])
+        winning = t.return_pct > 0
+        # Long+winning → up bar; long+losing → down bar.
+        # Short+winning → down bar; short+losing → up bar.
+        if (t.side == "long") == winning:
+            bars.append(_bar(t.entry_date, open_=100.0, close=101.5))
+        else:
+            bars.append(_bar(t.entry_date, open_=101.5, close=100.0))
+
+    detector = BacktestAnomalyDetector()
+    results = detector.check(
+        _baseline_metrics(),
+        trades,
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+        timeframe="1d",
+        market_data=market,
+    )
+    look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
+    # 20 eligible trades, all agree under the side-aware comparison
+    # (winners' bets aligned with bar, losers' bets opposed bar — both
+    # consistent with the heuristic's hypothesis), and ret_dir spans both
+    # signs → degenerate guard passes → critical.
+    assert len(look) == 1
+    assert "20/20" in look[0].details
+    assert look[0].severity == "critical"
+
+
+def test_lookahead_passes_when_short_strategy_is_genuinely_signal_driven():
+    """A genuinely signal-driven short strategy enters on some down bars
+    (winners) and some up bars (losers, due to noise/whipsaws), with no
+    systematic alignment. Agreement around chance → no finding.
+
+    Outcomes are keyed on ``i % 2`` so the ret_dir distribution spans both
+    signs; bar directions are keyed on ``i % 3`` so the two axes are
+    uncorrelated. Across 20 trades the agreement rate is well below the
+    80% warning threshold.
+    """
+    trades = [
+        _trade(
+            trade_num=i + 1,
+            entry_date=f"2024-{((i % 12) + 1):02d}-{((i % 27) + 1):02d}",
+            exit_date=f"2024-{((i % 12) + 1):02d}-{((i % 27) + 2):02d}",
+            return_pct=1.5 if i % 2 == 0 else -1.0,
+            side="short",
+            hold_days=14,
+        )
+        for i in range(20)
+    ]
+    market: dict = {}
+    for i, t in enumerate(trades):
+        bars = market.setdefault(t.symbol, [])
+        # i % 3 != i % 2, so bar direction is uncorrelated with outcome.
+        if i % 3 == 0:
+            bars.append(_bar(t.entry_date, open_=101.5, close=100.0))  # down bar
+        else:
+            bars.append(_bar(t.entry_date, open_=100.0, close=101.5))  # up bar
+
+    detector = BacktestAnomalyDetector()
+    results = detector.check(
+        _baseline_metrics(),
+        trades,
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+        timeframe="1d",
+        market_data=market,
+    )
+    look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
+    assert look == []
+
+
+def test_lookahead_skips_trades_with_unrecognised_side():
+    """A malformed ledger row with a non-canonical ``side`` value must be
+    skipped rather than silently defaulted to long — defaulting would hide
+    short-side look-ahead in legacy/typo data."""
+    trades = [
+        _trade(
+            trade_num=i + 1,
+            entry_date=f"2024-{((i % 12) + 1):02d}-{((i % 27) + 1):02d}",
+            exit_date=f"2024-{((i % 12) + 1):02d}-{((i % 27) + 2):02d}",
+            return_pct=1.5 if i % 2 == 0 else -1.0,
+            side="SELL",  # non-canonical
+            hold_days=14,
+        )
+        for i in range(20)
+    ]
+    market = _market_data_perfectly_matching(trades)
+    detector = BacktestAnomalyDetector()
+    results = detector.check(
+        _baseline_metrics(),
+        trades,
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+        timeframe="1d",
+        market_data=market,
+    )
+    look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
+    assert look == []

--- a/backend/agents/investment_team/tests/test_backtest_anomaly_realism.py
+++ b/backend/agents/investment_team/tests/test_backtest_anomaly_realism.py
@@ -1,0 +1,375 @@
+"""Realism extensions of ``BacktestAnomalyDetector``.
+
+Covers two additions:
+
+* Frequency-aware trade-count adequacy — scales the floor by
+  ``window_days / expected_hold_days`` instead of the legacy hard
+  ``< 5 trades`` minimum.
+* Look-ahead pattern in returns — flags trades whose return sign agrees
+  suspiciously well with the entry bar's intrabar direction, a heuristic
+  for look-ahead bias that AST checks miss.
+
+The legacy gates (Sharpe, win-rate, profit factor, hold time, ...) are
+covered by ``test_backtest_anomaly_dsr_aware.py`` and
+``test_backtest_anomaly_zero_trade_diagnostics.py``; this file only
+exercises the realism additions.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+from investment_team.market_data_service import OHLCVBar
+from investment_team.models import BacktestResult, TradeRecord
+from investment_team.strategy_lab.quality_gates.backtest_anomaly import (
+    BacktestAnomalyDetector,
+)
+
+
+def _baseline_metrics() -> BacktestResult:
+    """Realistic, anomaly-clean metrics so only the gate under test fires."""
+    return BacktestResult(
+        total_return_pct=18.0,
+        annualized_return_pct=8.0,
+        volatility_pct=12.0,
+        sharpe_ratio=0.8,
+        max_drawdown_pct=9.0,
+        win_rate_pct=58.0,
+        profit_factor=1.6,
+        calmar_ratio=0.0,
+        deflated_sharpe=0.0,
+        sortino_ratio=0.0,
+    )
+
+
+def _trade(
+    *,
+    trade_num: int,
+    entry_date: str,
+    exit_date: str,
+    symbol: str = "QQQ",
+    return_pct: float = 1.2,
+    hold_days: int = 10,
+    side: str = "long",
+) -> TradeRecord:
+    net = 12.0 if return_pct > 0 else -8.0
+    return TradeRecord(
+        trade_num=trade_num,
+        entry_date=entry_date,
+        exit_date=exit_date,
+        symbol=symbol,
+        side=side,
+        entry_price=100.0,
+        exit_price=100.0 + net / 10.0,
+        shares=10.0,
+        position_value=1000.0,
+        gross_pnl=net,
+        net_pnl=net,
+        return_pct=return_pct,
+        hold_days=hold_days,
+        outcome="win" if return_pct > 0 else "loss",
+        cumulative_pnl=net,
+    )
+
+
+def _trade_count_results(results):
+    return [
+        r
+        for r in results
+        if "expected" in r.details and ("trades" in r.details or "Observed" in r.details)
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Trade-count adequacy
+# ---------------------------------------------------------------------------
+
+
+def test_trade_count_adequacy_critical_when_under_25_pct_of_expected():
+    """5-year daily window with 2-week observed holds expects ~130 trades; 8
+    realised trades is ~6% of expected → critical."""
+    trades = [
+        _trade(
+            trade_num=i + 1,
+            entry_date=f"2020-{(i % 12) + 1:02d}-15",
+            exit_date=f"2020-{(i % 12) + 1:02d}-28",
+            hold_days=14,
+        )
+        for i in range(8)
+    ]
+    detector = BacktestAnomalyDetector()
+    results = detector.check(
+        _baseline_metrics(),
+        trades,
+        start_date="2020-01-01",
+        end_date="2025-01-01",
+        timeframe="1d",
+    )
+    tc = _trade_count_results(results)
+    assert len(tc) == 1
+    assert tc[0].severity == "critical"
+    assert "below the 25%" in tc[0].details or "25%" in tc[0].details
+
+
+def test_trade_count_adequacy_warning_between_25_and_50_pct():
+    """About 40 trades against ~130 expected is ~30% → warning, not critical."""
+    trades = [
+        _trade(
+            trade_num=i + 1,
+            entry_date=f"2021-{((i % 12) + 1):02d}-10",
+            exit_date=f"2021-{((i % 12) + 1):02d}-24",
+            hold_days=14,
+        )
+        for i in range(40)
+    ]
+    detector = BacktestAnomalyDetector()
+    results = detector.check(
+        _baseline_metrics(),
+        trades,
+        start_date="2020-01-01",
+        end_date="2025-01-01",
+        timeframe="1d",
+    )
+    tc = _trade_count_results(results)
+    assert len(tc) == 1
+    assert tc[0].severity == "warning"
+
+
+def test_trade_count_adequacy_passes_above_50_pct():
+    """About 100 trades vs ~130 expected (~77%) → no result emitted."""
+    trades = [
+        _trade(
+            trade_num=i + 1,
+            entry_date=f"202{((i // 24) % 5)}-{((i % 12) + 1):02d}-05",
+            exit_date=f"202{((i // 24) % 5)}-{((i % 12) + 1):02d}-19",
+            hold_days=14,
+        )
+        for i in range(100)
+    ]
+    detector = BacktestAnomalyDetector()
+    results = detector.check(
+        _baseline_metrics(),
+        trades,
+        start_date="2020-01-01",
+        end_date="2025-01-01",
+        timeframe="1d",
+    )
+    assert _trade_count_results(results) == []
+
+
+def test_trade_count_adequacy_falls_back_to_legacy_floor_when_kwargs_missing():
+    """Without dates/timeframe the gate must keep the legacy ``< 5`` floor so
+    older call sites that haven't been updated still produce the prior
+    verdict."""
+    trades = [
+        _trade(trade_num=i + 1, entry_date="2024-01-02", exit_date="2024-01-09") for i in range(3)
+    ]
+    detector = BacktestAnomalyDetector()
+    results = detector.check(_baseline_metrics(), trades)
+    legacy = [r for r in results if "statistically meaningless" in r.details]
+    assert len(legacy) == 1
+    assert legacy[0].severity == "critical"
+
+
+def test_trade_count_adequacy_skipped_in_paper_mode():
+    """Paper sessions run over short windows; the trade-count gate is skipped
+    entirely regardless of which kwargs were threaded in."""
+    trades = [_trade(trade_num=1, entry_date="2024-05-01", exit_date="2024-05-08")]
+    detector = BacktestAnomalyDetector()
+    results = detector.check(
+        _baseline_metrics(),
+        trades,
+        mode="paper",
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+        timeframe="1d",
+    )
+    assert _trade_count_results(results) == []
+    legacy = [r for r in results if "statistically meaningless" in r.details]
+    assert legacy == []
+
+
+# ---------------------------------------------------------------------------
+# Look-ahead in returns
+# ---------------------------------------------------------------------------
+
+
+def _bar(date_str: str, *, open_: float, close: float) -> OHLCVBar:
+    return OHLCVBar(
+        date=date_str,
+        open=open_,
+        high=max(open_, close) + 0.5,
+        low=min(open_, close) - 0.5,
+        close=close,
+        volume=1_000_000.0,
+    )
+
+
+def _market_data_perfectly_matching(trades: List[TradeRecord]) -> dict:
+    """Build per-symbol bars whose intrabar direction matches each trade's
+    return sign — the look-ahead failure mode."""
+    bars_by_symbol: dict = {}
+    for t in trades:
+        bars = bars_by_symbol.setdefault(t.symbol, [])
+        # Same-sign open→close as the trade's return.
+        if t.return_pct >= 0:
+            bars.append(_bar(t.entry_date, open_=100.0, close=101.5))
+        else:
+            bars.append(_bar(t.entry_date, open_=101.5, close=100.0))
+    return bars_by_symbol
+
+
+def _market_data_uncorrelated(trades: List[TradeRecord]) -> dict:
+    """Bars whose intrabar direction is independent of the trade outcome —
+    50/50 by trade_num parity."""
+    bars_by_symbol: dict = {}
+    for t in trades:
+        bars = bars_by_symbol.setdefault(t.symbol, [])
+        if t.trade_num % 2 == 0:
+            bars.append(_bar(t.entry_date, open_=100.0, close=101.0))
+        else:
+            bars.append(_bar(t.entry_date, open_=101.0, close=100.0))
+    return bars_by_symbol
+
+
+def _twenty_trades() -> List[TradeRecord]:
+    return [
+        _trade(
+            trade_num=i + 1,
+            entry_date=f"2024-{((i % 12) + 1):02d}-{((i % 27) + 1):02d}",
+            exit_date=f"2024-{((i % 12) + 1):02d}-{((i % 27) + 2):02d}",
+            return_pct=1.5 if i % 2 == 0 else -1.0,
+            hold_days=14,
+        )
+        for i in range(20)
+    ]
+
+
+def test_lookahead_critical_when_perfect_intrabar_sign_match():
+    """≥ 20 trades and every entry-bar direction matches the trade outcome →
+    critical look-ahead-bias finding."""
+    trades = _twenty_trades()
+    market = _market_data_perfectly_matching(trades)
+    detector = BacktestAnomalyDetector()
+    results = detector.check(
+        _baseline_metrics(),
+        trades,
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+        timeframe="1d",
+        market_data=market,
+    )
+    look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
+    assert len(look) == 1
+    assert look[0].severity == "critical"
+
+
+def test_lookahead_passes_when_agreement_under_threshold():
+    """≥ 20 trades and ~50% agreement → no look-ahead finding."""
+    trades = _twenty_trades()
+    market = _market_data_uncorrelated(trades)
+    detector = BacktestAnomalyDetector()
+    results = detector.check(
+        _baseline_metrics(),
+        trades,
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+        timeframe="1d",
+        market_data=market,
+    )
+    look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
+    assert look == []
+
+
+def test_lookahead_skipped_when_market_data_missing():
+    """Without market_data the rule can't look at entry bars — it must
+    emit no result rather than guessing."""
+    trades = _twenty_trades()
+    detector = BacktestAnomalyDetector()
+    results = detector.check(
+        _baseline_metrics(),
+        trades,
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+        timeframe="1d",
+        market_data=None,
+    )
+    look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
+    assert look == []
+
+
+def test_lookahead_skipped_when_no_entry_bars_resolve():
+    """Market data is present but no symbol matches the trade ledger →
+    eligible count is zero and the rule emits nothing."""
+    trades = _twenty_trades()
+    detector = BacktestAnomalyDetector()
+    results = detector.check(
+        _baseline_metrics(),
+        trades,
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+        timeframe="1d",
+        market_data={"NOT_IN_LEDGER": [_bar("2024-01-02", open_=100.0, close=101.0)]},
+    )
+    look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
+    assert look == []
+
+
+def test_lookahead_smallsample_perfect_match_is_critical():
+    """Under 20 trades the bar-vs-return sign-match is noisier, but perfect
+    agreement across at least 5 trades still flips critical so trivial
+    intrabar leaks don't slip through."""
+    trades = [
+        _trade(
+            trade_num=i + 1,
+            entry_date=f"2024-03-{(i % 27) + 1:02d}",
+            exit_date=f"2024-03-{(i % 27) + 2:02d}",
+            return_pct=1.5 if i % 2 == 0 else -1.0,
+            hold_days=14,
+        )
+        for i in range(8)
+    ]
+    market = _market_data_perfectly_matching(trades)
+    detector = BacktestAnomalyDetector()
+    results = detector.check(
+        _baseline_metrics(),
+        trades,
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+        timeframe="1d",
+        market_data=market,
+    )
+    look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
+    assert len(look) == 1
+    assert look[0].severity == "critical"
+
+
+def test_lookahead_warning_between_80_and_95_pct():
+    """Agreement in the 80–95% band on ≥ 20 trades is a warning, not critical."""
+    trades = _twenty_trades()
+    # Make 17/20 = 85% of trades match by flipping the last three bars to
+    # disagree with their trade direction.
+    market = _market_data_perfectly_matching(trades)
+    for t in trades[-3:]:
+        bars = market[t.symbol]
+        # Replace the bar at this trade's entry date with the opposite
+        # direction. Same date list, last three in trade order.
+        for i, b in enumerate(bars):
+            if b.date == t.entry_date:
+                if t.return_pct >= 0:
+                    bars[i] = _bar(t.entry_date, open_=101.5, close=100.0)
+                else:
+                    bars[i] = _bar(t.entry_date, open_=100.0, close=101.5)
+                break
+    detector = BacktestAnomalyDetector()
+    results = detector.check(
+        _baseline_metrics(),
+        trades,
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+        timeframe="1d",
+        market_data=market,
+    )
+    look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
+    assert len(look) == 1
+    assert look[0].severity == "warning"

--- a/backend/agents/investment_team/tests/test_backtest_anomaly_realism.py
+++ b/backend/agents/investment_team/tests/test_backtest_anomaly_realism.py
@@ -373,3 +373,74 @@ def test_lookahead_warning_between_80_and_95_pct():
     look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
     assert len(look) == 1
     assert look[0].severity == "warning"
+
+
+def test_lookahead_skips_trades_whose_intraday_timestamp_does_not_exact_match():
+    """On intraday timeframes many bars share a calendar day; the rule must
+    require an exact ``bar.date == trade.entry_date`` match and skip trades
+    whose entry timestamp can't be resolved, so the agreement statistic
+    isn't computed against the wrong bar."""
+    # Twenty trades, 1h timeframe. Half carry the bar's exact intraday
+    # timestamp; the other half carry the calendar date only. The latter
+    # must be skipped, leaving only the former in the eligible set.
+    trades: List[TradeRecord] = []
+    for i in range(20):
+        entry_ts = (
+            f"2024-03-{((i % 27) + 1):02d}T10:30:00"
+            if i % 2 == 0
+            else f"2024-03-{((i % 27) + 1):02d}"
+        )
+        exit_ts = (
+            f"2024-03-{((i % 27) + 2):02d}T15:30:00"
+            if i % 2 == 0
+            else f"2024-03-{((i % 27) + 2):02d}"
+        )
+        trades.append(
+            _trade(
+                trade_num=i + 1,
+                entry_date=entry_ts,
+                exit_date=exit_ts,
+                return_pct=1.5 if i % 4 < 2 else -1.0,
+                hold_days=1,
+            )
+        )
+
+    # Build bars whose intrabar direction PERFECTLY matches the exact-match
+    # trades' return signs. For the calendar-date trades we deliberately
+    # publish only an intraday timestamp ("...T09:30:00") so the exact-match
+    # lookup misses them. If the rule fell back to date-prefix matching, it
+    # would pick the 09:30 bar and the agreement stat would be wrong; the
+    # correct behaviour is to skip those trades entirely.
+    bars_by_symbol: dict = {}
+    for t in trades:
+        bars = bars_by_symbol.setdefault(t.symbol, [])
+        # Always publish the day's open bar at 09:30 with one direction so
+        # date-prefix fallback would see homogeneous bars.
+        day_prefix = t.entry_date[:10]
+        bars.append(_bar(f"{day_prefix}T09:30:00", open_=100.0, close=101.0))
+        if "T" in t.entry_date:
+            # Add the bar that exact-matches the intraday trade's entry,
+            # with direction aligned to the trade's return sign.
+            if t.return_pct >= 0:
+                bars.append(_bar(t.entry_date, open_=100.0, close=101.5))
+            else:
+                bars.append(_bar(t.entry_date, open_=101.5, close=100.0))
+
+    detector = BacktestAnomalyDetector()
+    results = detector.check(
+        _baseline_metrics(),
+        trades,
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+        timeframe="1h",
+        market_data=bars_by_symbol,
+    )
+
+    look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
+    # 10 eligible trades (the intraday-timestamped half), all in perfect
+    # agreement with their exact-match bar → small-sample critical fires.
+    # The other 10 trades were correctly skipped because their calendar-date
+    # entry_date didn't exact-match any bar.
+    assert len(look) == 1
+    assert "10/10" in look[0].details
+    assert look[0].severity == "critical"

--- a/backend/agents/investment_team/tests/test_backtest_anomaly_realism.py
+++ b/backend/agents/investment_team/tests/test_backtest_anomaly_realism.py
@@ -375,56 +375,37 @@ def test_lookahead_warning_between_80_and_95_pct():
     assert look[0].severity == "warning"
 
 
-def test_lookahead_skips_trades_whose_intraday_timestamp_does_not_exact_match():
-    """On intraday timeframes many bars share a calendar day; the rule must
-    require an exact ``bar.date == trade.entry_date`` match and skip trades
-    whose entry timestamp can't be resolved, so the agreement statistic
-    isn't computed against the wrong bar."""
-    # Twenty trades, 1h timeframe. Half carry the bar's exact intraday
-    # timestamp; the other half carry the calendar date only. The latter
-    # must be skipped, leaving only the former in the eligible set.
-    trades: List[TradeRecord] = []
-    for i in range(20):
-        entry_ts = (
-            f"2024-03-{((i % 27) + 1):02d}T10:30:00"
-            if i % 2 == 0
-            else f"2024-03-{((i % 27) + 1):02d}"
-        )
-        exit_ts = (
-            f"2024-03-{((i % 27) + 2):02d}T15:30:00"
-            if i % 2 == 0
-            else f"2024-03-{((i % 27) + 2):02d}"
-        )
-        trades.append(
-            _trade(
-                trade_num=i + 1,
-                entry_date=entry_ts,
-                exit_date=exit_ts,
-                return_pct=1.5 if i % 4 < 2 else -1.0,
-                hold_days=1,
-            )
-        )
+def test_lookahead_intraday_exact_match_uses_specific_bar_not_prefix():
+    """When a trade carries a full ISO timestamp that exact-matches one
+    specific intraday bar, the rule must use THAT bar's direction even when
+    other bars on the same calendar day disagree.
 
-    # Build bars whose intrabar direction PERFECTLY matches the exact-match
-    # trades' return signs. For the calendar-date trades we deliberately
-    # publish only an intraday timestamp ("...T09:30:00") so the exact-match
-    # lookup misses them. If the rule fell back to date-prefix matching, it
-    # would pick the 09:30 bar and the agreement stat would be wrong; the
-    # correct behaviour is to skip those trades entirely.
+    The day publishes a 09:30 bar with bearish direction and a 10:30 bar
+    with bullish direction; each trade's exact ``entry_date`` resolves to
+    the 10:30 bar, which agrees with the trade return. Were the rule to
+    accidentally fall back to a calendar-prefix lookup it would see the
+    09:30 bar and the agreement statistic would invert.
+    """
+    trades = [
+        _trade(
+            trade_num=i + 1,
+            entry_date=f"2024-03-{((i % 27) + 1):02d}T10:30:00",
+            exit_date=f"2024-03-{((i % 27) + 2):02d}T15:30:00",
+            return_pct=1.5 if i % 2 == 0 else -1.0,
+            hold_days=1,
+        )
+        for i in range(20)
+    ]
     bars_by_symbol: dict = {}
     for t in trades:
         bars = bars_by_symbol.setdefault(t.symbol, [])
-        # Always publish the day's open bar at 09:30 with one direction so
-        # date-prefix fallback would see homogeneous bars.
         day_prefix = t.entry_date[:10]
-        bars.append(_bar(f"{day_prefix}T09:30:00", open_=100.0, close=101.0))
-        if "T" in t.entry_date:
-            # Add the bar that exact-matches the intraday trade's entry,
-            # with direction aligned to the trade's return sign.
-            if t.return_pct >= 0:
-                bars.append(_bar(t.entry_date, open_=100.0, close=101.5))
-            else:
-                bars.append(_bar(t.entry_date, open_=101.5, close=100.0))
+        # Counter-direction 09:30 bar so prefix-fallback would miscount.
+        bars.append(_bar(f"{day_prefix}T09:30:00", open_=101.5, close=100.0))
+        if t.return_pct >= 0:
+            bars.append(_bar(t.entry_date, open_=100.0, close=101.5))
+        else:
+            bars.append(_bar(t.entry_date, open_=101.5, close=100.0))
 
     detector = BacktestAnomalyDetector()
     results = detector.check(
@@ -435,12 +416,78 @@ def test_lookahead_skips_trades_whose_intraday_timestamp_does_not_exact_match():
         timeframe="1h",
         market_data=bars_by_symbol,
     )
-
     look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
-    # 10 eligible trades (the intraday-timestamped half), all in perfect
-    # agreement with their exact-match bar → small-sample critical fires.
-    # The other 10 trades were correctly skipped because their calendar-date
-    # entry_date didn't exact-match any bar.
     assert len(look) == 1
-    assert "10/10" in look[0].details
+    assert "20/20" in look[0].details
     assert look[0].severity == "critical"
+
+
+def test_lookahead_falls_back_to_day_aggregate_when_trade_date_is_date_only():
+    """Production trade ledgers truncate ``entry_date`` to ``YYYY-MM-DD``
+    (``trade_builder.py:55`` and ``fill_simulator.py:1049``). When the
+    market data is intraday, exact-match would silently fail on every
+    trade and the rule would never fire — defeating the realism veto.
+
+    The rule must fall back to a day-aggregate direction (first same-day
+    bar's open → last same-day bar's close) so look-ahead at day
+    granularity still gets caught.
+    """
+    # 20 date-only trades whose returns track the day's NET intraday move
+    # (09:30 open → 16:00 close). Returns alternate sign across days.
+    trades = [
+        _trade(
+            trade_num=i + 1,
+            entry_date=f"2024-03-{((i % 27) + 1):02d}",
+            exit_date=f"2024-03-{((i % 27) + 2):02d}",
+            return_pct=1.5 if i % 2 == 0 else -1.0,
+            hold_days=1,
+        )
+        for i in range(20)
+    ]
+    # Each day has TWO intraday bars (09:30 open + 16:00 close) whose
+    # combined direction (first.open → last.close) matches the trade's
+    # return sign. Exact-match against the date-only ``entry_date`` fails
+    # for every trade — only the day-aggregate fallback can resolve them.
+    bars_by_symbol: dict = {}
+    for t in trades:
+        bars = bars_by_symbol.setdefault(t.symbol, [])
+        day = t.entry_date  # already date-only
+        if t.return_pct >= 0:
+            bars.append(_bar(f"{day}T09:30:00", open_=100.0, close=100.2))
+            bars.append(_bar(f"{day}T16:00:00", open_=100.2, close=102.0))
+        else:
+            bars.append(_bar(f"{day}T09:30:00", open_=101.5, close=101.3))
+            bars.append(_bar(f"{day}T16:00:00", open_=101.3, close=100.0))
+
+    detector = BacktestAnomalyDetector()
+    results = detector.check(
+        _baseline_metrics(),
+        trades,
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+        timeframe="1h",
+        market_data=bars_by_symbol,
+    )
+    look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
+    # All 20 trades resolve via day-aggregate; perfect agreement → critical.
+    assert len(look) == 1
+    assert "20/20" in look[0].details
+    assert look[0].severity == "critical"
+
+
+def test_lookahead_returns_no_result_when_no_same_day_bars_exist():
+    """When neither the exact-match path nor the day-aggregate path can
+    resolve any trade (no bars share the calendar date), the rule emits
+    nothing — there's genuinely no signal to evaluate."""
+    trades = _twenty_trades()
+    detector = BacktestAnomalyDetector()
+    results = detector.check(
+        _baseline_metrics(),
+        trades,
+        start_date="2024-01-01",
+        end_date="2024-12-31",
+        timeframe="1d",
+        market_data={"QQQ": [_bar("2099-12-31", open_=100.0, close=101.0)]},
+    )
+    look = [r for r in results if "look-ahead" in r.details or "look_ahead" in r.details]
+    assert look == []

--- a/backend/agents/investment_team/tests/test_realism_orchestrator_wiring.py
+++ b/backend/agents/investment_team/tests/test_realism_orchestrator_wiring.py
@@ -1,0 +1,297 @@
+"""Realism-gate wiring inside :class:`StrategyLabOrchestrator`.
+
+Exercises two seams:
+
+* :meth:`_run_realism_gates` — pure helper that runs the verification-phase
+  realism gates against the final spec + trade ledger. Empty inputs short-
+  circuit; a multi-target spec with a single-symbol ledger emits the
+  ``target_symbol_coverage`` breadth warning.
+* :meth:`_run_verification_phase` — when realism produces a ``critical``
+  result, ``is_winning`` flips to ``False`` and ``acceptance_reason`` gains
+  a ``realism_failed: ...`` suffix following the same veto convention as
+  ``exit_rule_conformance_failed`` and ``alignment_failed``.
+
+Lower-level gate behaviour is covered by
+``test_backtest_anomaly_realism.py`` and the breadth extensions in
+``test_target_symbol_coverage.py``. This file only proves the orchestrator
+threads them through to the publication decision.
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from investment_team.models import (
+    BacktestConfig,
+    BacktestResult,
+    StrategySpec,
+    TradeRecord,
+)
+from investment_team.strategy_lab.orchestrator import StrategyLabOrchestrator
+from investment_team.strategy_lab.quality_gates.convergence_tracker import ConvergenceTracker
+from investment_team.strategy_lab.quality_gates.models import QualityGateResult
+from investment_team.strategy_lab.spec_dsl import EntryRule, Predicate, SignalExitRule
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _spec(target_symbols: Optional[List[str]] = None) -> StrategySpec:
+    return StrategySpec(
+        strategy_id="realism-test",
+        authored_by="test",
+        asset_class="stocks",
+        hypothesis="hyp",
+        signal_definition="sig",
+        timeframe="1d",
+        entry_rules=[EntryRule(side="long", when=Predicate(lhs="bar.close", op=">", rhs=0))],
+        exit_rules=[SignalExitRule(when=Predicate(lhs="bar.close", op="<", rhs=0))],
+        risk_limits={},
+        speculative=False,
+        target_symbols=target_symbols or [],
+        strategy_code="from contract import Strategy\nclass S(Strategy):\n    def on_bar(self, ctx, bar):\n        pass\n",
+    )
+
+
+def _config() -> BacktestConfig:
+    return BacktestConfig(
+        start_date="2020-01-01",
+        end_date="2025-01-01",
+        initial_capital=100_000.0,
+        walk_forward_enabled=True,
+    )
+
+
+def _metrics() -> BacktestResult:
+    return BacktestResult(
+        total_return_pct=20.0,
+        annualized_return_pct=10.0,
+        volatility_pct=12.0,
+        sharpe_ratio=0.8,
+        max_drawdown_pct=10.0,
+        win_rate_pct=58.0,
+        profit_factor=1.6,
+        calmar_ratio=0.0,
+        deflated_sharpe=0.0,
+        sortino_ratio=0.0,
+        acceptance_reason="walk_forward_passed: all four criteria met",
+    )
+
+
+def _trade(symbol: str, trade_num: int) -> TradeRecord:
+    return TradeRecord(
+        trade_num=trade_num,
+        entry_date=f"2024-{((trade_num % 12) + 1):02d}-{((trade_num % 27) + 1):02d}",
+        exit_date=f"2024-{((trade_num % 12) + 1):02d}-{((trade_num % 27) + 2):02d}",
+        symbol=symbol,
+        side="long",
+        entry_price=100.0,
+        exit_price=101.0,
+        shares=10.0,
+        position_value=1000.0,
+        gross_pnl=10.0,
+        net_pnl=10.0,
+        return_pct=1.0,
+        hold_days=14,
+        outcome="win",
+        cumulative_pnl=10.0 * trade_num,
+    )
+
+
+def _orch() -> StrategyLabOrchestrator:
+    """Minimal orchestrator instance for testing pure helpers.
+
+    The constructor walks through agent and gate initialisation; nothing
+    here hits the network or LLM provider, so the bare instance is safe to
+    construct in tests.
+    """
+    return StrategyLabOrchestrator(convergence_tracker=ConvergenceTracker())
+
+
+# ---------------------------------------------------------------------------
+# _run_realism_gates
+# ---------------------------------------------------------------------------
+
+
+def test_run_realism_gates_returns_empty_when_no_trades():
+    orch = _orch()
+    results = orch._run_realism_gates(
+        spec=_spec(target_symbols=["QQQ", "SPY"]),
+        trades=[],
+        execution_succeeded=True,
+    )
+    assert results == []
+
+
+def test_run_realism_gates_returns_empty_when_execution_failed():
+    orch = _orch()
+    results = orch._run_realism_gates(
+        spec=_spec(target_symbols=["QQQ", "SPY"]),
+        trades=[_trade("QQQ", 1)],
+        execution_succeeded=False,
+    )
+    assert results == []
+
+
+def test_run_realism_gates_emits_breadth_warning_for_multi_target_single_symbol_ledger():
+    orch = _orch()
+    spec = _spec(target_symbols=["QQQ", "SPY", "IWM"])
+    trades = [_trade("QQQ", i + 1) for i in range(5)]
+
+    results = orch._run_realism_gates(spec=spec, trades=trades, execution_succeeded=True)
+
+    warnings = [r for r in results if not r.passed and r.severity == "warning"]
+    assert len(warnings) == 1
+    assert warnings[0].gate_name == "target_symbol_coverage"
+    assert warnings[0].phase == "verification"
+    assert "QQQ" in warnings[0].details
+
+
+def test_run_realism_gates_passes_when_ledger_uses_full_universe():
+    orch = _orch()
+    spec = _spec(target_symbols=["QQQ", "SPY"])
+    trades = [_trade("QQQ", 1), _trade("SPY", 2)]
+
+    results = orch._run_realism_gates(spec=spec, trades=trades, execution_succeeded=True)
+
+    assert all(r.passed for r in results)
+
+
+# ---------------------------------------------------------------------------
+# _run_verification_phase: realism critical → veto
+# ---------------------------------------------------------------------------
+
+
+def test_verification_phase_vetoes_is_winning_on_realism_critical(monkeypatch):
+    """A synthetic realism critical must flip ``is_winning`` to False and
+    rewrite ``acceptance_reason`` with the ``realism_failed:`` suffix.
+
+    The acceptance gate is stubbed to pass cleanly so realism is the only
+    veto in play; walk-forward evaluation is a no-op pass-through.
+    """
+    orch = _orch()
+
+    # Walk-forward returns metrics unchanged so the acceptance branch fires.
+    monkeypatch.setattr(
+        orch, "_evaluate_walk_forward", lambda spec, md, cfg, trades, metrics: metrics
+    )
+    monkeypatch.setattr(
+        orch.acceptance_gate,
+        "check",
+        lambda metrics, config, n_trials: [
+            QualityGateResult(
+                gate_name="oos_deflated_sharpe",
+                passed=True,
+                severity="info",
+                phase="verification",
+                details="ok",
+            ),
+        ],
+    )
+
+    # Realism returns a critical finding (synthetic stand-in for any of the
+    # eight realism rules — exercising the veto wiring, not the gate's
+    # internal logic).
+    monkeypatch.setattr(
+        orch,
+        "_run_realism_gates",
+        lambda *, spec, trades, execution_succeeded: [
+            QualityGateResult(
+                gate_name="liquidity_realism",
+                passed=False,
+                severity="critical",
+                phase="verification",
+                details="adjusted profit factor 0.7 < 1.0 after slippage haircut",
+            ),
+        ],
+    )
+
+    spec = _spec(target_symbols=["QQQ"])
+    trades = [_trade("QQQ", i + 1) for i in range(20)]
+    metrics = _metrics()
+    config = _config()
+    market_data: dict = {"QQQ": []}
+    all_gate_results: List[QualityGateResult] = []
+
+    outcome = orch._run_verification_phase(
+        spec=spec,
+        trades=trades,
+        metrics=metrics,
+        market_data=market_data,
+        config=config,
+        execution_succeeded=True,
+        trades_aligned=True,
+        alignment_reports=[],
+        all_gate_results=all_gate_results,
+        emit=lambda *_a, **_k: None,
+    )
+
+    assert outcome.is_winning is False
+    reason = outcome.metrics.acceptance_reason or ""
+    assert "realism_failed:" in reason
+    assert "liquidity_realism" not in reason  # detail string, not gate name
+    assert "profit factor" in reason
+    # The stale ``walk_forward_passed`` success summary must be REPLACED by
+    # the veto cause (matches the conformance + alignment veto convention).
+    assert "all four criteria met" not in reason
+
+
+def test_verification_phase_does_not_veto_on_realism_warning(monkeypatch):
+    """Warning-severity realism findings must NOT flip ``is_winning`` — only
+    ``critical`` veto. The persisted gate list still records the warning."""
+    orch = _orch()
+
+    monkeypatch.setattr(
+        orch, "_evaluate_walk_forward", lambda spec, md, cfg, trades, metrics: metrics
+    )
+    monkeypatch.setattr(
+        orch.acceptance_gate,
+        "check",
+        lambda metrics, config, n_trials: [
+            QualityGateResult(
+                gate_name="oos_deflated_sharpe",
+                passed=True,
+                severity="info",
+                phase="verification",
+                details="ok",
+            ),
+        ],
+    )
+    monkeypatch.setattr(
+        orch,
+        "_run_realism_gates",
+        lambda *, spec, trades, execution_succeeded: [
+            QualityGateResult(
+                gate_name="target_symbol_coverage",
+                passed=False,
+                severity="warning",
+                phase="verification",
+                details="single_symbol_breadth",
+            ),
+        ],
+    )
+
+    spec = _spec(target_symbols=["QQQ", "SPY"])
+    trades = [_trade("QQQ", i + 1) for i in range(20)]
+    all_gate_results: List[QualityGateResult] = []
+
+    outcome = orch._run_verification_phase(
+        spec=spec,
+        trades=trades,
+        metrics=_metrics(),
+        market_data={"QQQ": []},
+        config=_config(),
+        execution_succeeded=True,
+        trades_aligned=True,
+        alignment_reports=[],
+        all_gate_results=all_gate_results,
+        emit=lambda *_a, **_k: None,
+    )
+
+    assert outcome.is_winning is True
+    breadth_gates = [g for g in all_gate_results if g.gate_name == "target_symbol_coverage"]
+    assert len(breadth_gates) == 1
+    assert breadth_gates[0].severity == "warning"
+    reason = outcome.metrics.acceptance_reason or ""
+    assert "realism_failed:" not in reason

--- a/backend/agents/investment_team/tests/test_target_symbol_coverage.py
+++ b/backend/agents/investment_team/tests/test_target_symbol_coverage.py
@@ -207,3 +207,85 @@ def test_check_trades_empty_ledger_passes() -> None:
 
     assert _criticals(results) == []
     assert any(r.passed for r in results)
+
+
+# ── check_breadth ───────────────────────────────────────────────────────
+
+
+def test_check_breadth_warns_when_multi_target_but_single_traded_symbol() -> None:
+    """Spec asks for QQQ + SPY + IWM but the ledger only touches QQQ — the
+    strategy isn't exploiting its intended universe, so emit a warning."""
+    gate = TargetSymbolCoverageGate()
+    spec = _spec(target_symbols=["QQQ", "SPY", "IWM"])
+
+    results = gate.check_breadth(
+        spec, trades=[_trade("QQQ"), _trade("QQQ", trade_num=2), _trade("QQQ", trade_num=3)]
+    )
+
+    warnings = _warnings(results)
+    assert len(warnings) == 1
+    assert "QQQ" in warnings[0].details
+    assert "SPY" in warnings[0].details
+    assert warnings[0].gate_name == GATE
+    assert warnings[0].phase == "verification"
+
+
+def test_check_breadth_passes_when_multi_target_and_multi_traded_symbols() -> None:
+    gate = TargetSymbolCoverageGate()
+    spec = _spec(target_symbols=["QQQ", "SPY"])
+
+    results = gate.check_breadth(
+        spec, trades=[_trade("QQQ"), _trade("SPY", trade_num=2)]
+    )
+
+    assert _criticals(results) == []
+    assert _warnings(results) == []
+    assert any(r.passed for r in results)
+
+
+def test_check_breadth_skipped_when_single_target_symbol() -> None:
+    """One target ticker → breadth is irrelevant; emit a benign info."""
+    gate = TargetSymbolCoverageGate()
+    spec = _spec(target_symbols=["QQQ"])
+
+    results = gate.check_breadth(spec, trades=[_trade("QQQ")])
+
+    assert _criticals(results) == []
+    assert _warnings(results) == []
+    assert all(r.passed and r.severity == "info" for r in results)
+
+
+def test_check_breadth_skipped_when_target_symbols_empty() -> None:
+    gate = TargetSymbolCoverageGate()
+    spec = _spec(target_symbols=[])
+
+    results = gate.check_breadth(spec, trades=[_trade("AAPL")])
+
+    assert _criticals(results) == []
+    assert _warnings(results) == []
+    assert all(r.passed and r.severity == "info" for r in results)
+
+
+def test_check_breadth_skipped_when_ledger_empty() -> None:
+    gate = TargetSymbolCoverageGate()
+    spec = _spec(target_symbols=["QQQ", "SPY"])
+
+    results = gate.check_breadth(spec, trades=[])
+
+    assert _criticals(results) == []
+    assert _warnings(results) == []
+    assert all(r.passed and r.severity == "info" for r in results)
+
+
+def test_check_breadth_case_insensitive() -> None:
+    """Mixed-case symbols on either side must collapse to one entry."""
+    gate = TargetSymbolCoverageGate()
+    spec = _spec(target_symbols=["QQQ", "SPY"])
+
+    results = gate.check_breadth(
+        spec, trades=[_trade("qqq"), _trade("QQQ", trade_num=2)]
+    )
+
+    warnings = _warnings(results)
+    assert len(warnings) == 1
+    assert "QQQ" in warnings[0].details


### PR DESCRIPTION
## Summary

First slice of the realism-cycle work in #546. Adds three of the eight planned checks, plus the orchestrator wiring that lets the realism cycle veto `is_winning`. The remaining five checks (liquidity, cost-stress, regime coverage, trade clustering, rule-firing rate) land in subsequent PRs to keep each diff reviewable.

### Checks landed in this PR
- **Trade-count adequacy by frequency** (`BacktestAnomalyDetector._check_trade_count_floor`) — scales by `window_days / observed_hold_days`. Under 25% of expected → critical, 25–50% → warning. Falls back to the legacy `<5 trades` floor when callers don't yet thread `start_date` / `end_date` / `timeframe` through.
- **Look-ahead pattern in returns** (`BacktestAnomalyDetector._check_lookahead_bar_predictability`) — flags trades whose return sign agrees suspiciously well with the entry bar's intrabar `close - open` direction. Requires both bar-direction and return-sign distributions to span both signs before promoting agreement to a finding so degenerate fixtures don't trip it.
- **Symbol breadth** (`TargetSymbolCoverageGate.check_breadth`) — warning when `len(target_symbols) > 1` but the realised ledger uses a single symbol. Universe leakage (trade outside `target_symbols`) is still the job of `check_trades`.

### Wiring
- `StrategyLabOrchestrator._run_verification_phase` invokes a new `_run_realism_gates` between walk-forward evaluation and acceptance-gate resolution. Critical realism findings flip `is_winning=False` and stamp a `realism_failed: …` suffix onto `acceptance_reason` via the same `_apply_veto_to_acceptance_reason` path used by exit-rule conformance and alignment.
- All three anomaly-detector call sites (synthesis loop, alignment recheck, walk-forward fallback) now pass `start_date` / `end_date` / `timeframe` / `market_data` so the frequency-aware trade-count and look-ahead rules fire in those contexts too.

### Out of scope (future PRs in this series)
- Liquidity-adjusted P&L, mandatory cost-stress, regime coverage, trade clustering, rule-firing rate (PRs 2–4).
- The 10-record historical-replay reclassification fixtures called for in the issue acceptance criteria — deferred to the final PR so the replay exercises the full realism gate set.

## Test plan

- [x] `pytest agents/investment_team/tests/test_backtest_anomaly_realism.py` (11 new tests covering trade-count + look-ahead, including degenerate-fixture skip, paper-mode skip, legacy fallback)
- [x] `pytest agents/investment_team/tests/test_target_symbol_coverage.py` (6 new `check_breadth` tests)
- [x] `pytest agents/investment_team/tests/test_realism_orchestrator_wiring.py` (6 tests: `_run_realism_gates` direct + `_run_verification_phase` veto chain for critical vs warning)
- [x] Full `investment_team` suite green (2408 passed, 5 skipped) — no regressions.
- [x] `ruff check` + `ruff format --check` clean on all touched files.

Partially addresses #546 (3 of 8 checks; PRs 2–4 to follow).

https://claude.ai/code/session_01N7agQuAddo73h1RZeC8cAn

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7agQuAddo73h1RZeC8cAn)_