### PR TITLE
social_media_marketing_team: convert integration tests to unit tests

### DIFF
--- a/backend/agents/social_media_marketing_team/tests/conftest.py
+++ b/backend/agents/social_media_marketing_team/tests/conftest.py
@@ -29,9 +29,14 @@ def _patched_job_manager(monkeypatch, fake_job_client):
     return fake_job_client
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture()
 def _inline_threading(monkeypatch):
     """Run dispatched jobs synchronously so tests don't need polling.
+
+    Not autouse — only test modules that exercise the ``/run`` endpoint
+    should opt in via ``pytest.mark.usefixtures("_inline_threading")``.
+    Patching ``api_main.threading.Thread`` globally would break OTel's
+    ``ThreadingInstrumentor`` in tests that create Strands agents.
 
     Postconditions: ``threading.Thread`` in ``api_main`` is replaced with
         an inline variant that calls ``target(*args)`` on ``start()``.
@@ -41,8 +46,11 @@ def _inline_threading(monkeypatch):
         def __init__(self, target, args=(), daemon=False, **kw):
             self._target, self._args = target, args
 
-        def start(self):
+        def run(self):
             self._target(*self._args)
+
+        def start(self):
+            self.run()
 
     monkeypatch.setattr(api_main.threading, "Thread", _InlineThread)
 

--- a/backend/agents/social_media_marketing_team/tests/conftest.py
+++ b/backend/agents/social_media_marketing_team/tests/conftest.py
@@ -12,7 +12,39 @@ BLOGGING_DIR = ROOT / "blogging"
 if str(BLOGGING_DIR) not in sys.path:
     sys.path.insert(0, str(BLOGGING_DIR))
 
+from social_media_marketing_team.api import main as api_main  # noqa: E402
 from social_media_marketing_team.models import BrandGoals  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _patched_job_manager(monkeypatch, fake_job_client):
+    """Route the SMM ``_job_manager`` through the in-memory fake.
+
+    Preconditions: ``fake_job_client`` resolves to the function-scoped
+        ``FakeJobServiceClient`` defined in ``backend/conftest.py``.
+    Postconditions: every call to ``api_main._job_manager.*`` within a test
+        hits the in-memory fake; the real ``JobServiceClient`` is never used.
+    """
+    monkeypatch.setattr(api_main, "_job_manager", fake_job_client)
+    return fake_job_client
+
+
+@pytest.fixture(autouse=True)
+def _inline_threading(monkeypatch):
+    """Run dispatched jobs synchronously so tests don't need polling.
+
+    Postconditions: ``threading.Thread`` in ``api_main`` is replaced with
+        an inline variant that calls ``target(*args)`` on ``start()``.
+    """
+
+    class _InlineThread:
+        def __init__(self, target, args=(), daemon=False, **kw):
+            self._target, self._args = target, args
+
+        def start(self):
+            self._target(*self._args)
+
+    monkeypatch.setattr(api_main.threading, "Thread", _InlineThread)
 
 
 def make_goals(

--- a/backend/agents/social_media_marketing_team/tests/test_api.py
+++ b/backend/agents/social_media_marketing_team/tests/test_api.py
@@ -1,13 +1,15 @@
 """Tests for social_media_marketing_team API endpoints (HTTP layer).
 
-The autouse fixtures in ``conftest.py`` swap ``_job_manager`` for an
-in-memory ``FakeJobServiceClient`` and replace ``threading.Thread`` with
-a synchronous inline variant, so these tests run without a live job
-service or Postgres.
+The autouse ``_patched_job_manager`` fixture in ``conftest.py`` swaps
+``_job_manager`` for an in-memory ``FakeJobServiceClient``.  The
+``_inline_threading`` fixture (opted in below) replaces
+``threading.Thread`` with a synchronous variant so jobs complete during
+the POST handler and no polling is needed.
 """
 
 from unittest.mock import patch
 
+import pytest
 from fastapi.testclient import TestClient
 
 from social_media_marketing_team.adapters.branding import (
@@ -16,6 +18,8 @@ from social_media_marketing_team.adapters.branding import (
 )
 from social_media_marketing_team.api.main import app
 from social_media_marketing_team.models import Platform
+
+pytestmark = [pytest.mark.usefixtures("_inline_threading")]
 
 _MOCK_BRAND_CTX = BrandContext(
     brand_name="Acme",

--- a/backend/agents/social_media_marketing_team/tests/test_api.py
+++ b/backend/agents/social_media_marketing_team/tests/test_api.py
@@ -1,7 +1,13 @@
-import time
+"""Tests for social_media_marketing_team API endpoints (HTTP layer).
+
+The autouse fixtures in ``conftest.py`` swap ``_job_manager`` for an
+in-memory ``FakeJobServiceClient`` and replace ``threading.Thread`` with
+a synchronous inline variant, so these tests run without a live job
+service or Postgres.
+"""
+
 from unittest.mock import patch
 
-import pytest
 from fastapi.testclient import TestClient
 
 from social_media_marketing_team.adapters.branding import (
@@ -10,10 +16,6 @@ from social_media_marketing_team.adapters.branding import (
 )
 from social_media_marketing_team.api.main import app
 from social_media_marketing_team.models import Platform
-
-# Hits the team API which calls the real job service.  See
-# ``test_api_internal.py`` for the converted unit-style equivalent.
-pytestmark = [pytest.mark.integration]
 
 _MOCK_BRAND_CTX = BrandContext(
     brand_name="Acme",
@@ -27,19 +29,6 @@ _MOCK_BRAND_CTX = BrandContext(
 )
 
 _BRAND_ADAPTER = "social_media_marketing_team.api.main"
-
-
-def _wait_for_done(client: TestClient, job_id: str):
-    deadline = time.time() + 5
-    status_payload = None
-    while time.time() < deadline:
-        status_resp = client.get(f"/social-marketing/status/{job_id}")
-        assert status_resp.status_code == 200
-        status_payload = status_resp.json()
-        if status_payload["status"] in {"completed", "failed"}:
-            break
-        time.sleep(0.05)
-    return status_payload
 
 
 @patch(f"{_BRAND_ADAPTER}._fetch_and_validate_brand", return_value=_MOCK_BRAND_CTX)
@@ -60,8 +49,9 @@ def test_run_endpoint_and_status_success(_mock_brand) -> None:
     assert body["brand_summary"] is not None
     assert "Acme" in body["brand_summary"]
 
-    status_payload = _wait_for_done(client, job_id)
-    assert status_payload is not None
+    status_resp = client.get(f"/social-marketing/status/{job_id}")
+    assert status_resp.status_code == 200
+    status_payload = status_resp.json()
     assert status_payload["status"] == "completed"
     assert status_payload["progress"] == 100
     assert status_payload["llm_model_name"] == "llama3.1"
@@ -108,9 +98,9 @@ def test_performance_ingest_and_revision_endpoints(_mock_brand) -> None:
     assert revise.status_code == 200
     assert revise.json()["status"] == "running"
 
-    status = _wait_for_done(client, job_id)
-    assert status is not None
-    assert status["status"] == "completed"
+    status_resp = client.get(f"/social-marketing/status/{job_id}")
+    assert status_resp.status_code == 200
+    assert status_resp.json()["status"] == "completed"
 
 
 @patch(

--- a/backend/agents/social_media_marketing_team/tests/test_winning_posts_api.py
+++ b/backend/agents/social_media_marketing_team/tests/test_winning_posts_api.py
@@ -2,8 +2,9 @@
 
 Swaps the bank module's ``get_conn`` for an in-process fake so the
 routes exercise their full happy-path without Postgres.  The autouse
-fixtures in ``conftest.py`` route ``_job_manager`` through an in-memory
-fake and run dispatched jobs synchronously.
+``_patched_job_manager`` fixture in ``conftest.py`` routes
+``_job_manager`` through an in-memory fake; the ``_inline_threading``
+fixture (opted in below) runs dispatched jobs synchronously.
 """
 
 from __future__ import annotations
@@ -18,6 +19,8 @@ from fastapi.testclient import TestClient
 from social_media_marketing_team.adapters.branding import BrandContext
 from social_media_marketing_team.api.main import app
 from social_media_marketing_team.tests.test_winning_posts_bank import _FakeConn
+
+pytestmark = [pytest.mark.usefixtures("_inline_threading")]
 
 _BRAND_ADAPTER = "social_media_marketing_team.api.main"
 

--- a/backend/agents/social_media_marketing_team/tests/test_winning_posts_api.py
+++ b/backend/agents/social_media_marketing_team/tests/test_winning_posts_api.py
@@ -1,11 +1,9 @@
 """API-level tests for Winning Posts Bank CRUD routes + auto-ingest hook.
 
 Swaps the bank module's ``get_conn`` for an in-process fake so the
-routes exercise their full happy-path without Postgres.
-
-Marked integration: the auto-ingest hook calls into ``_job_manager``
-which currently routes to the real job service.  Follow-up to mock that
-boundary.
+routes exercise their full happy-path without Postgres.  The autouse
+fixtures in ``conftest.py`` route ``_job_manager`` through an in-memory
+fake and run dispatched jobs synchronously.
 """
 
 from __future__ import annotations
@@ -20,8 +18,6 @@ from fastapi.testclient import TestClient
 from social_media_marketing_team.adapters.branding import BrandContext
 from social_media_marketing_team.api.main import app
 from social_media_marketing_team.tests.test_winning_posts_bank import _FakeConn
-
-pytestmark = [pytest.mark.integration]
 
 _BRAND_ADAPTER = "social_media_marketing_team.api.main"
 


### PR DESCRIPTION
## Summary

- Add autouse fixtures to `conftest.py` that patch `_job_manager` with the in-memory `FakeJobServiceClient` and replace `threading.Thread` with a synchronous `InlineThread`
- Remove `pytestmark = [pytest.mark.integration]` from `test_api.py` and `test_winning_posts_api.py` so they run in every CI build
- Replace the polling `_wait_for_done` helper with direct status checks now that jobs complete synchronously

## Test plan

- [x] All 5 tests in `test_api.py` pass (previously skipped as integration)
- [x] All 6 tests in `test_winning_posts_api.py` pass (previously skipped as integration)
- [x] All 7 tests in `test_api_internal.py` still pass (existing exemplar, unmodified)
- [x] No `pytest.mark.integration` markers remain in the SMM test directory
- [x] `ruff check` and `ruff format --check` pass

Closes #367

https://claude.ai/code/session_01AyiMUoMiPFCPLRjTpYXZtk

---
_Generated by [Claude Code](https://claude.ai/code/session_01AyiMUoMiPFCPLRjTpYXZtk)_