### PR TITLE
jobs-dashboard: add elevation shadow to table container

### DIFF
--- a/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
+++ b/user-interface/src/app/components/jobs-dashboard/jobs-dashboard.component.scss
@@ -271,6 +271,7 @@
   background: var(--kh-surface-2);
   border-radius: var(--kh-radius-lg);
   border: 1px solid var(--kh-border);
+  box-shadow: var(--kh-shadow-md);
   overflow: hidden;
 }
 


### PR DESCRIPTION
## Summary

- Add `box-shadow: var(--kh-shadow-md)` to `.jobs-table-container` so the table reads as an elevated card rather than a flat wireframe border
- Uses the existing `--kh-shadow-md` design token (`0 4px 12px rgba(0, 0, 0, 0.5)`), matching the elevation pattern used by integrations-dashboard expanded cards and strategy-lab record cards
- Existing `border: 1px solid var(--kh-border)` preserved for edge definition at rounded corners

## Test plan

- [x] All 83 jobs-dashboard tests pass (2 test files, including a11y)
- [ ] Visually verify the table container has subtle elevation on the dark background
- [ ] Cross-check against Agent Console and integrations dashboard for visual consistency
- [ ] Confirm no layout shift — shadow is outset, no content displacement

Closes #487

https://claude.ai/code/session_01NfGShLnojEhBVxZGfx4a5e

---
_Generated by [Claude Code](https://claude.ai/code/session_01NfGShLnojEhBVxZGfx4a5e)_